### PR TITLE
Run the browsers in parallel, and try hard to clean up after them

### DIFF
--- a/test/resources/firefox/user.js
+++ b/test/resources/firefox/user.js
@@ -32,3 +32,4 @@ user_pref("app.update.enabled", false);
 user_pref("browser.panorama.experienced_first_run", true); // Assume experienced
 user_pref("dom.w3c_touch_events.enabled", true);
 user_pref("extensions.checkCompatibility", false);
+user_pref("extensions.installDistroAddons", false); // prevent testpilot etc

--- a/test/test.py
+++ b/test/test.py
@@ -1,4 +1,4 @@
-import json, platform, os, shutil, sys, subprocess, tempfile, threading, urllib, urllib2
+import json, platform, os, shutil, sys, subprocess, tempfile, threading, time, urllib, urllib2
 from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 import SocketServer
 from optparse import OptionParser
@@ -138,6 +138,7 @@ class BrowserCommand():
     def __init__(self, browserRecord):
         self.name = browserRecord["name"]
         self.path = browserRecord["path"]
+        self.tempDir = None
 
         if platform.system() == "Darwin" and (self.path.endswith(".app") or self.path.endswith(".app/")):
             self._fixupMacPath()
@@ -151,19 +152,19 @@ class BrowserCommand():
     def setup(self):
         self.tempDir = tempfile.mkdtemp()
         self.profileDir = os.path.join(self.tempDir, "profile")
-        print self.profileDir
         shutil.copytree(os.path.join(DOC_ROOT, "test", "resources", "firefox"),
                         self.profileDir)
 
     def teardown(self):
-        shutil.rmtree(self.tempDir)
+        if self.tempDir is not None and os.path.exists(self.tempDir):
+            shutil.rmtree(self.tempDir)
 
     def start(self, url):
         cmds = [self.path]
         if platform.system() == "Darwin":
             cmds.append("-foreground")
         cmds.extend(["-no-remote", "-profile", self.profileDir, url])
-        subprocess.call(cmds)
+        subprocess.Popen(cmds)
 
 def makeBrowserCommands(browserManifestFile):
     with open(browserManifestFile) as bmf:
@@ -223,15 +224,22 @@ def setUp(options):
 
     State.remaining = len(testBrowsers) * len(manifestList)
 
-    for b in testBrowsers:
-        try:
-            b.setup()
-            print 'Launching', b.name
-            qs = 'browser='+ urllib.quote(b.name) +'&manifestFile='+ urllib.quote(options.manifestFile)
-            b.start('http://localhost:8080/test/test_slave.html?'+ qs)
-        finally:
-            b.teardown()
+    return testBrowsers
 
+def startBrowsers(browsers, options):
+    for b in browsers:
+        b.setup()
+        print 'Launching', b.name
+        qs = 'browser='+ urllib.quote(b.name) +'&manifestFile='+ urllib.quote(options.manifestFile)
+        b.start('http://localhost:8080/test/test_slave.html?'+ qs)
+
+def teardownBrowsers(browsers):
+    for b in browsers:
+        try:
+            b.teardown()
+        except:
+            print "Error cleaning up after browser at ", b.path
+    
 def check(task, results, browser):
     failed = False
     for r in xrange(len(results)):
@@ -385,8 +393,14 @@ def main():
     httpd_thread.setDaemon(True)
     httpd_thread.start()
 
-    setUp(options)
-    processResults()
+    browsers = setUp(options)
+    try:
+        startBrowsers(browsers, options)
+        while not State.done:
+            time.sleep(1)
+        processResults()
+    finally:
+        teardownBrowsers(browsers)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
I ran a couple browsers at once with this code, and it worked ok. I even commented out the call to quitApplication() and let the process.kill() code run, which also worked. I think the shutdown process is slow if there's lots of disk i/o, so some waiting helps if the browsers all try to quit at once.
