### PR TITLE
Concurrent browsers sending results asynchronously

### DIFF
--- a/test/test_slave.html
+++ b/test/test_slave.html
@@ -139,31 +139,41 @@ function snapshotCurrentPage(gfx) {
     }
   }
 
-  currentTask.taskDone = (currentTask.pageNum == pdfDoc.numPages
-                          && (1 + currentTask.round) == currentTask.rounds);
   sendTaskResult(canvas.toDataURL("image/png"));
   log("done"+ (failure ? " (failed!)" : "") +"\n");
 
-  ++currentTask.pageNum, nextPage();
-}
-
-function done() {
-  log("Done!\n");
+  // Set up the next request
+  backoff = (inFlightRequests > 0) ? inFlightRequests * 10 : 0;
   setTimeout(function() {
-      document.body.innerHTML = "Tests are finished.  <h1>CLOSE ME!</h1>";
-      if (window.SpecialPowers)
-        SpecialPowers.quitApplication();
-      else
-        window.close();
+      ++currentTask.pageNum, nextPage();
     },
-    100
+    backoff
   );
 }
 
+function quitApp() {
+  log("Done!");
+  document.body.innerHTML = "Tests are finished.  <h1>CLOSE ME!</h1>";
+  if (window.SpecialPowers)
+    SpecialPowers.quitApplication();
+  else
+    window.close();
+}
+
+function done() {
+  if (inFlightRequests > 0) {
+    document.getElementById("inFlightCount").innerHTML = inFlightRequests;
+    setTimeout(done, 100);
+  } else {
+    setTimeout(quitApp, 100);
+  }
+}
+
+var inFlightRequests = 0;
 function sendTaskResult(snapshot) {
   var result = { browser: browser,
                  id: currentTask.id,
-                 taskDone: currentTask.taskDone,
+                 numPages: pdfDoc.numPages,
                  failure: failure,
                  file: currentTask.file,
                  round: currentTask.round,
@@ -172,9 +182,14 @@ function sendTaskResult(snapshot) {
 
   var r = new XMLHttpRequest();
   // (The POST URI is ignored atm.)
-  r.open("POST", "/submit_task_results", false);
+  r.open("POST", "/submit_task_results", true);
   r.setRequestHeader("Content-Type", "application/json");
-  // XXX async
+  r.onreadystatechange = function(e) {
+    if (r.readyState == 4) {
+      inFlightRequests--;
+    }
+  }
+  document.getElementById("inFlightCount").innerHTML = inFlightRequests++;
   r.send(JSON.stringify(result));
 }
 
@@ -194,7 +209,8 @@ function log(str) {
 </head>
 
 <body onload="load();">
-  <pre id="stdout"></pre>
+  <pre style="width:800; height:800; overflow: scroll;"id="stdout"></pre>
+  <p>Inflight requests: <span id="inFlightCount"></span></p>
 </body>
 
 </html>


### PR DESCRIPTION
This can max out a CPU per-browser on my laptop. The server copes just fine, but things can get stuck if there's a lot of I/O. There's a little throttling included in the HTML so things don't get too backed up (the worst I saw on my machine was about 30 unprocessed requests, but that was before I added the backoff).
