### PR TITLE
Fix the log scrolling in the test harness.

### DIFF
--- a/test/test_slave.html
+++ b/test/test_slave.html
@@ -200,8 +200,7 @@ function clear(ctx) {
   ctx.restore();
 }
 
-/* Auto-scroll if the scrollbar is near the bottom, otherwise do
-nothing. */
+/* Auto-scroll if the scrollbar is near the bottom, otherwise do nothing. */
 function checkScrolling() {
   if ((stdout.scrollHeight - stdout.scrollTop) <= stdout.offsetHeight) {
      stdout.scrollTop = stdout.scrollHeight;

--- a/test/test_slave.html
+++ b/test/test_slave.html
@@ -194,9 +194,17 @@ function clear(ctx) {
   ctx.restore();
 }
 
+/* Auto-scroll if the scrollbar is near the bottom, otherwise do
+nothing. */
+function checkScrolling() {
+  if ((stdout.scrollHeight - stdout.scrollTop) <= stdout.offsetHeight) {
+     stdout.scrollTop = stdout.scrollHeight;
+  }
+}
+
 function log(str) {
   stdout.innerHTML += str;
-  window.scrollTo(0, stdout.getBoundingClientRect().bottom);
+  checkScrolling();
 }
   </script>
 </head>

--- a/test/test_slave.html
+++ b/test/test_slave.html
@@ -203,7 +203,7 @@ function clear(ctx) {
 /* Auto-scroll if the scrollbar is near the bottom, otherwise do nothing. */
 function checkScrolling() {
   if ((stdout.scrollHeight - stdout.scrollTop) <= stdout.offsetHeight) {
-     stdout.scrollTop = stdout.scrollHeight;
+    stdout.scrollTop = stdout.scrollHeight;
   }
 }
 


### PR DESCRIPTION
Make the log auto-scroll if the scrollbar is near the bottom, but maintain position if it isn't.
