### PR TITLE
Fix to replaceCMapTable 

### DIFF
--- a/fonts.js
+++ b/fonts.js
@@ -425,6 +425,7 @@ var Font = (function () {
       };
 
       function replaceCMapTable(cmap, font, properties) {
+        font.pos = cmap.length;
         var version = FontsUtils.bytesToInteger(font.getBytes(2));
         var numTables = FontsUtils.bytesToInteger(font.getBytes(2));
 


### PR DESCRIPTION
Function replaceCMapTable() was not setting the font pos pointer to the correct place to read the cmap. This caused PDFs to fail because the cmap was not correctly rewritten.
