### PR TITLE
Improve font loading check by using onload in subdocument

### DIFF
--- a/multi_page_viewer.js
+++ b/multi_page_viewer.js
@@ -125,14 +125,7 @@ var PDFViewer = {
       var fonts = [];
       page.compile(gfx, fonts);
 
-      var loadFont = function() {
-        if (!FontLoader.bind(fonts)) {
-          pageTimeout = window.setTimeout(loadFont, 10);
-          return;
-        }
-        page.display(gfx);
-      }
-      loadFont();
+      FontLoader.bind(fonts, function() { page.display(gfx); });
     }
   },
   
@@ -194,17 +187,10 @@ var PDFViewer = {
       var fonts = [];
       page.compile(gfx, fonts);
 
-      var loadFont = function() {
-        if (!FontLoader.bind(fonts)) {
-          pageTimeout = window.setTimeout(loadFont, 10);
-          return;
-        }
-        page.display(gfx);
-      }
-      loadFont();
+      FontLoader.bind(fonts, function() { page.display(gfx); });
     }
   },
-  
+
   changeScale: function(num) {
     while (PDFViewer.element.hasChildNodes()) {
       PDFViewer.element.removeChild(PDFViewer.element.firstChild);

--- a/test/test_slave.html
+++ b/test/test_slave.html
@@ -113,25 +113,18 @@ function nextPage() {
     failure = 'page setup: '+ e.toString();
   }
 
-  var fontLoaderTimer = null;
-  function checkFontsLoaded() {
+  if (!failure) {
     try {
-      if (!FontLoader.bind(fonts)) {
-        fontLoaderTimer = window.setTimeout(checkFontsLoaded, 10);
-        return;
-      }
+      FontLoader.bind(fonts, function() { snapshotCurrentPage(gfx); });
     } catch(e) {
       failure = 'fonts: '+ e.toString();
     }
-    snapshotCurrentPage(gfx);
   }
 
   if (failure) {
-    // Skip font loading if there was a failure, since the fonts might
-    // be in an inconsistent state.
+    // Skip right to snapshotting if there was a failure, since the
+    // fonts might be in an inconsistent state.
     snapshotCurrentPage(gfx);
-  } else {
-    checkFontsLoaded();
   }
 }
 

--- a/viewer.js
+++ b/viewer.js
@@ -3,7 +3,7 @@
 
 "use strict";
 
-var pdfDocument, canvas, pageScale, pageDisplay, pageNum, numPages, pageTimeout;
+var pdfDocument, canvas, pageScale, pageDisplay, pageNum, numPages;
 function load(userInput) {
     canvas = document.getElementById("canvas");
     canvas.mozOpaque = true;
@@ -53,8 +53,6 @@ function gotoPage(num) {
 }
 
 function displayPage(num) {
-    window.clearTimeout(pageTimeout);
-
     document.getElementById("pageNumber").value = num;
 
     var t0 = Date.now();
@@ -82,22 +80,18 @@ function displayPage(num) {
     page.compile(gfx, fonts);
     var t2 = Date.now();
 
-    function loadFont() {
-      if (!FontLoader.bind(fonts)) {
-        pageTimeout = window.setTimeout(loadFont, 10);
-        return;
-      }
+    function displayPage() {
+        var t3 = Date.now();
 
-      var t3 = Date.now();
+        page.display(gfx);
 
-      page.display(gfx);
+        var t4 = Date.now();
 
-      var t4 = Date.now();
+        var infoDisplay = document.getElementById("info");
+        infoDisplay.innerHTML = "Time to load/compile/fonts/render: "+ (t1 - t0) + "/" + (t2 - t1) + "/" + (t3 - t2) + "/" + (t4 - t3) + " ms";
+    }
 
-      var infoDisplay = document.getElementById("info");
-      infoDisplay.innerHTML = "Time to load/compile/fonts/render: "+ (t1 - t0) + "/" + (t2 - t1) + "/" + (t3 - t2) + "/" + (t4 - t3) + " ms";
-    };
-    loadFont();
+    FontLoader.bind(fonts, displayPage);
 }
 
 function nextPage() {


### PR DESCRIPTION
issue 68 and issue 56

This is a pretty horrible hack, but on the whole is certainly more reliable, and arguably a bit cleaner.  This has allowed me to turn the firefox5 tests back on.

It appears to be a perf regression (unsurprisingly since we create one subdocument per font and have to load the fonts twice).  There's room for optimization, I think.
