### PR TITLE
Support PDF generated by OpenOffice

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -3803,7 +3803,7 @@ var CanvasGraphics = (function() {
             this.current.leading = leading;
         },
         setFont: function(fontRef, size) {
-            var font = this.res.get("Font");
+            var font = this.xref.fetchIfRef(this.res.get("Font"));
             if (!IsDict(font))
               return;
 

--- a/test/pdfs/DiwanProfile.pdf.link
+++ b/test/pdfs/DiwanProfile.pdf.link
@@ -1,0 +1,1 @@
+http://oannis.com/DiwanProfile.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -42,5 +42,11 @@
        "link": true,
        "rounds": 1,
        "type": "eq"
+    },
+    {  "id": "openoffice-pdf",
+       "file": "pdfs/DiwanProfile.pdf",
+       "link": true,
+       "rounds": 1,
+       "type": "load"
     }
 ]


### PR DESCRIPTION
OpenOffice includes the optional reference to a Font dictionary in the Resources dictionary. This breaks SetFont in pdf.js as the Font in this.res is not a dictionary but an xref. Sample file at http://oannis.com/DiwanProfile.pdf
