### PR TITLE
Fix to how cmap is created

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -3879,6 +3879,9 @@ function ScratchCanvas(width, height) {
 }
 
 var CanvasGraphics = (function() {
+  var kScalePrecision = 50;
+  var kRasterizerMin = 14;
+
   function constructor(canvasCtx, imageCanvas) {
     this.ctx = canvasCtx;
     this.current = new CanvasExtraState();
@@ -4094,8 +4097,10 @@ var CanvasGraphics = (function() {
       if (this.ctx.$setFont) {
         this.ctx.$setFont(fontName, size);
       } else {
-        this.ctx.font = size + 'px "' + fontName + '"';
         FontMeasure.setActive(fontObj, size);
+
+        size = (size <= kRasterizerMin) ? size * kScalePrecision : size;
+        this.ctx.font = size + 'px"' + fontName + '"';
       }
     },
     setTextRenderingMode: function(mode) {
@@ -4143,6 +4148,8 @@ var CanvasGraphics = (function() {
         ctx.translate(current.x, -1 * current.y);
         var font = this.current.font;
         if (font) {
+          if (this.current.fontSize < kRasterizerMin)
+            ctx.transform(1 / kScalePrecision, 0, 0, 1 / kScalePrecision, 0, 0);
           ctx.transform.apply(ctx, font.textMatrix);
           text = font.charsToUnicode(text);
         }


### PR DESCRIPTION
This patch isn't meant to be pulled in, but I don't really understand how how the current createCMapTable is being used and wanted @vingtetun to look at this patch. This patch does fix the encoding issues I was having with type1c fonts.

Basically, for format 4 subtables, the previous getRanges sorted the unicode values. But this meant glyph whose glyphIds are not sequential could be in the same range

Example
GID Unicode
1       1000
2       500
3       999

=>
Unicode          GID
[500]                2
[999 - 1000]      3,1

With this patch, ranges are divided up by both unicode value and glyph id value. Furthermore, the format 4 subtables now use idDelta to map to glyph id.
