### PR TITLE
Avoid browser-test stoppage when task.pdfDoc is undefined.

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -79,7 +79,7 @@ function nextTask() {
 }
 
 function isLastPage(task) {
-    return (task.pdfDoc && (task.pageNum > task.pdfDoc.numPages));
+    return (!task.pdfDoc || (task.pageNum > task.pdfDoc.numPages));
 }
 
 function nextPage(task, loadError) {


### PR DESCRIPTION
If nextTask leaves task.pdfDoc as undefined then sendTaskResult will fail on
that. SendTaskResult tries to access task.pdfDoc.numPages which cannot
succeed. This leads to a complete stop in the browser-test.
