### PR TITLE
Show browser-test results in pageNum/numPages format.

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -99,7 +99,7 @@ function nextPage(task, loadError) {
     var page = null;
     if (!failure) {
         try {
-            log("    loading page "+ task.pageNum +"... ");
+            log("    loading page "+ task.pageNum +"/"+ task.pdfDoc.numPages +"... ");
             ctx = canvas.getContext("2d");
             page = task.pdfDoc.getPage(task.pageNum);
 


### PR DESCRIPTION
This is only for convenience in order to see how far in the pdf the test
currently is.
