### PR TITLE
Keep the results visible in test_slave.html before quitting.

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -156,7 +156,8 @@ function sendQuitRequest() {
 
 function quitApp() {
   log('Done !');
-  document.body.innerHTML = 'Tests are finished. <h1>CLOSE ME!</h1>';
+  document.body.innerHTML = 'Tests are finished. <h1>CLOSE ME!</h1>' +
+                             document.body.innerHTML;
   if (window.SpecialPowers) {
     SpecialPowers.quitApplication();
   } else {


### PR DESCRIPTION
Currently the innerHTML is replaced with text:
Tests are finished.
CLOSE ME!
Instead of replacing the innerHTML prepend that text to it.
This way the user can still check the results of the test.
