### PR TITLE
Another fix to my last CIDFont patch

### DIFF
--- a/fonts.js
+++ b/fonts.js
@@ -789,7 +789,7 @@ var Font = (function Font() {
     encoding: null,
 
     checkAndRepair: function font_checkAndRepair(name, font, properties) {
-      var kCmapGlyphOffset = 0xFF;
+      var kCmapGlyphOffset = 0xE000; //offset glpyhs to the Unicode Private Use Area
 
       function readTableEntry(file) {
         // tag


### PR DESCRIPTION
This is an improvement to may last CIDFont patch. 

Basically, CIDFonts draw glyphs but the canvas fillText() draws characters. Drawing characters used for other languages is causing random errors for some of my other PDF files and there are more characters that could be transformed by fillText - e.g. characters in the Arabic Unicode range may be drawn right to left. So I have changed the glyph offset to the Unicode Private Use Area (U+E000 to U+F8FF). This will work as long as the font has less than 6,400 glyphs. In the future, if we do find fonts with more than 6,400 glyphs, then we could split those fonts into multiple smaller with up to 6,400 glyphs each.
