### PR TITLE
Make 'make test' factors faster.

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -221,6 +221,8 @@ function checkScrolling() {
 }
 
 function log(str) {
-  stdout.innerHTML += str;
-  checkScrolling();
+  stdout.insertAdjacentHTML("BeforeEnd", str);
+
+  if (str.charAt(str.length - 1) == '\n')
+    checkScrolling();
 }

--- a/test/driver.js
+++ b/test/driver.js
@@ -221,8 +221,8 @@ function checkScrolling() {
 }
 
 function log(str) {
-  stdout.insertAdjacentHTML("BeforeEnd", str);
+  stdout.insertAdjacentHTML('BeforeEnd', str);
 
-  if (str.charAt(str.length - 1) == '\n')
+  if (str.lastIndexOf('\n') >= 0)
     checkScrolling();
 }


### PR DESCRIPTION
Profiling with firebug reveals that log and checkScrolling functions slow down
the 'make test' by factors.

Use insertAdjacentHtml in the log fucntion insteand of appending to
innerHTML. Also call checkScrolling function only when it is prudent to do
instead of unnecessarily in every log function call.
