### PR TITLE
Ignore xmp header.

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -2601,6 +2601,11 @@ var Lexer = (function() {
         stream.skip();
         return new Cmd('<<');
       }
+      if (ch == '?') {
+        // xmp header
+        stream.skip();
+        return new Cmd('<?');
+      }
       return this.getHexString(ch);
       // dict punctuation
       case '>':
@@ -2608,6 +2613,12 @@ var Lexer = (function() {
       if (ch == '>') {
         stream.skip();
         return new Cmd('>>');
+      }
+      case '?':
+      ch = stream.lookChar();
+      if (ch == '>') {
+        stream.skip();
+        return new Cmd('?>');
       }
       case '{':
       case '}':


### PR DESCRIPTION
Ignore XMP specification for now in order to render the pdf containing such headers.
See http://partners.adobe.com/public/developer/en/xmp/sdk/XMPspecification.pdf

I don't know if this totally correct thing to do but the intelisa.pdf renders ok with this fix. I would have liked to insert some TODO's but the correct place is unknown to me.

Before the fix I get this when running 'make test':
error("Illegal character in hex string: ?")@http://localhost:8080/pdf.js:22
("?")@http://localhost:8080/pdf.js:2550
()@http://localhost:8080/pdf.js:2604
()@http://localhost:8080/pdf.js:2682
()@http://localhost:8080/pdf.js:2720
constructor([object Object])@http://localhost:8080/pdf.js:2881
()@http://localhost:8080/pdf.js:3628
()@http://localhost:8080/pdf.js:3638
()@http://localhost:8080/pdf.js:3691
constructor([object Object])@http://localhost:8080/pdf.js:3604
([object Event])@http://localhost:8080/test/driver.js:71
done (failed !: load PDF doc : Error: Illegal character in hex string: ?)

I also don't fully understand why getObj chooses to ignore unknown Cmd's. Perhaps that is intended.

Safe to say is that feedback is appreciated.

Is XMP specification something that is applicable for pdf.js some time in the future? If so maybe this specification pdf could be part of the test pdfs.
