### PR TITLE
Allow bypassing the sanitizer for Type1C font with encoding supplement

### DIFF
--- a/crypto.js
+++ b/crypto.js
@@ -569,6 +569,7 @@ var CipherTransformFactory = (function() {
       };
     }
     error('Unknown crypto method');
+    return null;
   }
 
   constructor.prototype = {

--- a/fonts.js
+++ b/fonts.js
@@ -57,7 +57,7 @@ var stdFontMap = {
 };
 
 var FontMeasure = (function FontMeasure() {
-  var kScalePrecision = 50;
+  var kScalePrecision = 30;
   var ctx = document.createElement('canvas').getContext('2d');
   ctx.scale(1 / kScalePrecision, 1);
 

--- a/fonts.js
+++ b/fonts.js
@@ -1703,7 +1703,7 @@ var Type1Parser = function() {
                 var index = parseInt(getToken());
                 var glyph = getToken();
               
-                if (!properties.differences[j]) {
+                if (!properties.encoding[index]) {
                   var code = GlyphsUnicode[glyph];
                   properties.glyphs[glyph] = properties.encoding[index] = code;
                 }

--- a/fonts.js
+++ b/fonts.js
@@ -80,6 +80,7 @@ var FontMeasure = (function FontMeasure() {
       size *= kScalePrecision;
       var rule = italic + ' ' + bold + ' ' + size + 'px "' + name + '"';
       ctx.font = rule;
+      current = font;
     },
     measureText: function fonts_measureText(text) {
       var width;

--- a/fonts.js
+++ b/fonts.js
@@ -870,13 +870,15 @@ var Font = (function Font() {
               }
             }
 
-            if (properties.firstChar < 0x20)
+            if (properties.firstChar < 0x20) {
               var code = 0;
               for (var j = 0; j < glyphs.length; j++) {
                 var glyph = glyphs[j];
                 glyphs[j].unicode += 0x1F;
                 properties.glyphs[glyph.glyph] = encoding[++code] = glyph.unicode;
+              }
             }
+            
             return cmap.data = createCMapTable(glyphs, deltas);
           } else if (format == 6) {
             // Format 6 is a 2-bytes dense mapping, which means the font data

--- a/fonts.js
+++ b/fonts.js
@@ -66,7 +66,7 @@ var FontMeasure = (function FontMeasure() {
 
   return {
     setActive: function fonts_setActive(font, size) {
-      if (current = font) {
+      if (current == font) {
         var sizes = current.sizes;
         if (!(measureCache = sizes[size]))
           measureCache = sizes[size] = Object.create(null);
@@ -856,7 +856,7 @@ var Font = (function Font() {
           var language = int16(font.getBytes(2));
 
           if (format == 4) {
-            return;
+            return cmap.data;
           } else if (format == 0) {
             // Characters below 0x20 are controls characters that are hardcoded
             // into the platform so if some characters in the font are assigned
@@ -927,6 +927,7 @@ var Font = (function Font() {
             return cmap.data = createCMapTable(glyphs);
           }
         }
+        return cmap.data;
       };
 
       // Check that required tables are present
@@ -2287,7 +2288,7 @@ var Type2CFF = (function() {
             id = (id << 8) | bytes[pos++];
             charset.push(strings[id]);
           }
-          return charset;
+          break;
         case 1:
           while (charset.length <= length) {
             var first = bytes[pos++];
@@ -2296,7 +2297,7 @@ var Type2CFF = (function() {
             for (var i = 0; i <= numLeft; ++i)
               charset.push(strings[first++]);
           }
-          return charset;
+          break;
         case 2:
           while (charset.length <= length) {
             var first = bytes[pos++];
@@ -2306,11 +2307,11 @@ var Type2CFF = (function() {
             for (var i = 0; i <= numLeft; ++i)
               charset.push(strings[first++]);
           }
-          return charset;
+          break;
         default:
           error('Unknown charset format');
       }
-
+      return charset;
     },
     getPrivDict: function cff_getprivdict(baseDict, strings) {
       var dict = {};
@@ -2440,6 +2441,7 @@ var Type2CFF = (function() {
         } else {
           error('Incorrect byte');
         }
+        return -1;
       };
 
       function parseFloatOperand() {

--- a/fonts.js
+++ b/fonts.js
@@ -415,10 +415,8 @@ var Font = (function Font() {
         this.mimetype = 'font/opentype';
 
         var subtype = properties.subtype;
-        if (subtype === 'Type1C')
-          var cff = new Type2CFF(file, properties);
-        else
-          var cff = new CFF(name, file, properties);
+        var cff = (subtype === 'Type1C') ? new Type2CFF(file, properties)
+                                         : new CFF(name, file, properties);
 
         // Wrap the CFF data inside an OTF font file
         data = this.convert(name, cff, properties);
@@ -2161,16 +2159,16 @@ var Type2CFF = (function() {
 
       var bytes = this.bytes;
 
-      var privateInfo = topDict['Private'];
+      var privateInfo = topDict.Private;
       var privOffset = privateInfo[1], privLength = privateInfo[0];
       var privBytes = bytes.subarray(privOffset, privOffset + privLength);
       baseDict = this.parseDict(privBytes);
       var privDict = this.getPrivDict(baseDict, strings);
 
-      var charStrings = this.parseIndex(topDict['CharStrings']);
-      var charset = this.parseCharsets(topDict['charset'],
+      var charStrings = this.parseIndex(topDict.CharStrings);
+      var charset = this.parseCharsets(topDict.charset,
                                        charStrings.length, strings);
-      var hasSupplement = this.parseEncoding(topDict['Encoding'], properties, 
+      var hasSupplement = this.parseEncoding(topDict.Encoding, properties, 
                                              strings, charset);
 
       // The font sanitizer does not support CFF encoding with a
@@ -2179,7 +2177,7 @@ var Type2CFF = (function() {
       // the top dictionary to let the sanitizer think the font use
       // StandardEncoding, that's a lie but that's ok.
       if (hasSupplement)
-        bytes[topDict['Encoding']] = 0;
+        bytes[topDict.Encoding] = 0;
 
       // charstrings contains info about glyphs (one element per glyph
       // containing mappings for {unicode, width})
@@ -2258,7 +2256,6 @@ var Type2CFF = (function() {
             encoding[index] = gid++;
         }
       } else {
-
         var format = bytes[pos++];
         switch (format & 0x7f) {
           case 0:

--- a/fonts.js
+++ b/fonts.js
@@ -422,7 +422,6 @@ var Font = (function Font() {
 
         // Wrap the CFF data inside an OTF font file
         data = this.convert(name, cff, properties);
-        writeToFile(data, "/tmp/" + name + ".otf");
         break;
 
       case 'TrueType':
@@ -2210,7 +2209,7 @@ var Type2CFF = (function() {
 
       var charstrings = [];
       var differences = properties.differences;
-      var index = 1;
+      var index = 0;
       var kCmapGlyphOffset = 0xE000;
       for (var i = 1; i < charsets.length; i++) {
         var glyph = charsets[i];
@@ -2222,6 +2221,9 @@ var Type2CFF = (function() {
         }
 
         var code = differences.indexOf(glyph);
+        if (code == -1)
+          code = properties.glyphs[glyph] || index;
+
         var width = widths[code] || defaultWidth;
         properties.encoding[index] = index + kCmapGlyphOffset;
         charstrings.push({unicode: code + kCmapGlyphOffset, width: width, gid: i});

--- a/fonts.js
+++ b/fonts.js
@@ -2210,12 +2210,22 @@ var Type2CFF = (function() {
 
       var charstrings = [];
       var differences = properties.differences;
+      var index = 1;
+      var kCmapGlyphOffset = 0xE000;
       for (var i = 1; i < charsets.length; i++) {
         var glyph = charsets[i];
+        for (var j = index; j < differences.length; j++) {
+          if (differences[j]) {
+            index = j;
+            break;
+          }
+        }
+
         var code = differences.indexOf(glyph);
         var width = widths[code] || defaultWidth;
-        properties.encoding[i] = i + 0x1F;
-        charstrings.push({unicode: code + 0x1F, width: width, gid: i});
+        properties.encoding[index] = index + kCmapGlyphOffset;
+        charstrings.push({unicode: code + kCmapGlyphOffset, width: width, gid: i});
+        index++;
       }
 
       // sort the array by the unicode value

--- a/fonts.js
+++ b/fonts.js
@@ -423,6 +423,7 @@ var Font = (function Font() {
 
         // Wrap the CFF data inside an OTF font file
         data = this.convert(name, cff, properties);
+        writeToFile(data, "/tmp/" + name + ".otf");
         break;
 
       case 'TrueType':
@@ -2198,10 +2199,16 @@ var Type2CFF = (function() {
       var nominalWidth = privDict['nominalWidthX'];
 
       var charstrings = [];
-      for (var code in encoding) {
-        var gid = encoding[code];
-        var width = widths[code] || defaultWidth;
-        charstrings.push({unicode: code, width: width, gid: gid});
+      var differences = properties.differences;
+      for (var i = 1; i < charsets.length; i++) {
+        var glyph = charsets[i];
+        var charCode = properties.glyphs[glyph];
+        if (charCode) {
+          var width = widths[charCode] || defaultWidth;
+          charstrings.push({unicode: charCode, width: width, gid: i});
+        } else if (glyph !== '.notdef') {
+          warn('Cannot find unicode for glyph ' + charName);
+        }
       }
 
       // sort the array by the unicode value
@@ -2246,7 +2253,6 @@ var Type2CFF = (function() {
 
           case 1:
             var rangesCount = bytes[pos++];
-            log(rangesCount);
             var gid = 1;
             for (var i = 0; i < rangesCount; i++) {
               var start = bytes[pos++];

--- a/fonts.js
+++ b/fonts.js
@@ -385,6 +385,7 @@ var Font = (function Font() {
   var constructor = function font_constructor(name, file, properties) {
     this.name = name;
     this.encoding = properties.encoding;
+    this.glyphs = properties.glyphs;
     this.sizes = [];
 
     // If the font is to be ignored, register it like an already loaded font
@@ -1271,6 +1272,10 @@ var Font = (function Font() {
             unicode = charcode;
           }
 
+          // Check if the glyph has already been converted
+          if (!IsNum(unicode))
+            unicode = encoding[charcode] = this.glyphs[unicode];
+
           // Handle surrogate pairs
           if (unicode > 0xFFFF) {
             str += String.fromCharCode(unicode & 0xFFFF);
@@ -1703,9 +1708,9 @@ var Type1Parser = function() {
                 var index = parseInt(getToken());
                 var glyph = getToken();
               
-                if (!properties.encoding[index]) {
-                  var code = GlyphsUnicode[glyph];
-                  properties.glyphs[glyph] = properties.encoding[index] = code;
+                if ('undefined' == typeof(properties.differences[index])) {
+                  properties.encoding[index] = glyph;
+                  properties.glyphs[glyph] = GlyphsUnicode[glyph];
                 }
                 getToken(); // read the in 'put'
               }

--- a/pdf.js
+++ b/pdf.js
@@ -4290,7 +4290,7 @@ var PartialEvaluator = (function() {
             glyphsMap[glyph] = encodingMap[i] = GlyphsUnicode[glyph];
         }
 
-        if (fontDict.has('ToUnicode') && differences) {
+        if (fontType == 'TrueType' && fontDict.has('ToUnicode') && differences) {
           var cmapObj = xref.fetchIfRef(fontDict.get('ToUnicode'));
           if (IsName(cmapObj)) {
             error('ToUnicode file cmap translation not implemented');
@@ -4358,6 +4358,7 @@ var PartialEvaluator = (function() {
         var baseFontName = fontDict.get('BaseFont');
         if (!IsName(baseFontName))
           return null;
+
         // Using base font name as a font name.
         baseFontName = baseFontName.name.replace(/[\+,\-]/g, '_');
         if (/^Symbol(_?(Bold|Italic))*$/.test(baseFontName)) {

--- a/pdf.js
+++ b/pdf.js
@@ -4287,7 +4287,7 @@ var PartialEvaluator = (function() {
         for (var i = firstChar; i <= lastChar; i++) {
           var glyph = diffEncoding[i] || baseEncoding[i];
           if (glyph)
-            glyphsMap[glyph] = encodingMap[i] = GlyphsUnicode[glyph];
+            glyphsMap[glyph] = encodingMap[i] = GlyphsUnicode[glyph] || i;
         }
 
         if (fontType == 'TrueType' && fontDict.has('ToUnicode') && differences) {

--- a/pdf.js
+++ b/pdf.js
@@ -2093,7 +2093,7 @@ var LZWStream = (function() {
       var c = this.str.getByte();
       if (c == null) {
         this.eof = true;
-        return;
+        return null;
       }
       cachedData = (cachedData << 8) | c;
       bitsCached += 8;
@@ -5208,7 +5208,7 @@ var Util = (function() {
     return 'rgb(' + ri + ',' + gi + ',' + bi + ')';
   };
   constructor.makeCssCmyk = function makecmyk(c, m, y, k) {
-    var c = (new DeviceCmykCS()).getRgb([c, m, y, k]);
+    c = (new DeviceCmykCS()).getRgb([c, m, y, k]);
     var ri = (255 * c[0]) | 0, gi = (255 * c[1]) | 0, bi = (255 * c[2]) | 0;
     return 'rgb(' + ri + ',' + gi + ',' + bi + ')';
   };
@@ -5335,6 +5335,7 @@ var ColorSpace = (function() {
     } else {
       error('unrecognized color space object: "' + cs + '"');
     }
+    return null;
   };
 
   return constructor;
@@ -5623,6 +5624,7 @@ var Pattern = (function() {
     default:
       error('Unknown type of pattern: ' + typeNum);
     }
+    return null;
   };
 
   constructor.parseShading = function pattern_shading(shading, matrix,

--- a/pdf.js
+++ b/pdf.js
@@ -4284,8 +4284,11 @@ var PartialEvaluator = (function() {
         // firstChar and width are required
         // (except for 14 standard fonts)
         var firstChar = xref.fetchIfRef(fontDict.get('FirstChar')) || 0;
-        var lastChar = xref.fetchIfRef(fontDict.get('LastChar')) || 0;
         var widths = xref.fetchIfRef(fontDict.get('Widths')) || [];
+
+        var lastChar = xref.fetchIfRef(fontDict.get('LastChar'));
+        if (!lastChar)
+          lastChar = diffEncoding.length || baseEncoding.length;
 
         // merge in the differences
         var glyphsMap = {};

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -417,16 +417,18 @@ window.addEventListener('transitionend', function(evt) {
   var pagesCount = PDFView.pages.length;
 
   var container = document.getElementById('sidebarView');
-  container._interval = window.setInterval(function() {
-    if (pageIndex >= pagesCount)
-      return window.clearInterval(container._interval);
+  container._interval = window.setInterval(function interval() {
+    if (pageIndex >= pagesCount) {
+      window.clearInterval(container._interval);
+      return;
+    }
 
     PDFView.thumbnails[pageIndex++].draw();
   }, 500);
 }, true);
 
 
-window.addEventListener('scalechange', function(evt) {
+window.addEventListener('scalechange', function scalechange(evt) {
   var options = document.getElementById('scaleSelect').options;
   for (var i = 0; i < options.length; i++) {
     var option = options[i];
@@ -434,7 +436,7 @@ window.addEventListener('scalechange', function(evt) {
   }
 }, true);
 
-window.addEventListener('pagechange', function(evt) {
+window.addEventListener('pagechange', function pagechange(evt) {
   var page = evt.detail;
   document.location.hash = page;
   document.getElementById('pageNumber').value = page;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -217,11 +217,10 @@ var PageView = function(container, content, id, width, height,
 
   function setupLinks(canvas, content, scale) {
     function bindLink(link, dest) {
-      if (dest) {
-        link.onclick = function() {
+      link.onclick = function() {
+        if (dest)
           PDFView.navigateTo(dest);
-          return false;
-        };
+        return false;
       }
     }
     var links = content.getLinks();
@@ -232,7 +231,7 @@ var PageView = function(container, content, id, width, height,
       link.style.width = Math.ceil(links[i].width * scale) + 'px';
       link.style.height = Math.ceil(links[i].height * scale) + 'px';
       link.href = links[i].url || '';
-      bindLink(link, links[i].dest);
+      bindLink(link, ('dest' in links[i]) ? links[i].dest : null);
       div.appendChild(link);
     }
   }


### PR DESCRIPTION
The patch allow the display of fonts embedded in www.ntg.nl/maps/26/29.pdf

Also changes to crypto.js, viewer.js and the added 'return' are because of a bunch of warnings on the console when you enable the strict checking.

The change of the kScalePrecision variable is to let the arial documents in the test directory to displays to the correct size, otherwise it seems that we hit a maximum width and end up with a wrong size per letters.

The way of mapping encoding and glyphs is also cleaner, at the end I would like to end up with a direct mapping (not using the GlyphsUnicode table and getting rid of the ToUnicode dictionnary) but it seems hard for the moment.
