### PR TITLE
Fix a bug and speed up graycs_getRgbBuffer.

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -5469,8 +5469,9 @@ var DeviceGrayCS = (function() {
     },
     getRgbBuffer: function graycs_getRgbBuffer(input, bits) {
       var scale = 255 / ((1 << bits) - 1);
-      var rgbBuf = new Uint8Array(input.length * 3);
-      for (var i = 0, j = 0; i < input.length; ++i) {
+      var length = input.length;
+      var rgbBuf = new Uint8Array(length * 3);
+      for (var i = 0, j = 0; i < length; ++i) {
         var c = (scale * input[i]) | 0;
         rgbBuf[j++] = c;
         rgbBuf[j++] = c;

--- a/pdf.js
+++ b/pdf.js
@@ -5469,9 +5469,8 @@ var DeviceGrayCS = (function() {
     },
     getRgbBuffer: function graycs_getRgbBuffer(input, bits) {
       var scale = 255 / ((1 << bits) - 1);
-      var length = input.length * 3;
-      var rgbBuf = new Uint8Array(length);
-      for (var i = 0, j = 0; i < length; ++i) {
+      var rgbBuf = new Uint8Array(input.length * 3);
+      for (var i = 0, j = 0; i < input.length; ++i) {
         var c = (scale * input[i]) | 0;
         rgbBuf[j++] = c;
         rgbBuf[j++] = c;


### PR DESCRIPTION
An rgbBuffer was created which was three times as big as intended. It also
caused that the function was very slow when rendering cable.pdf. Which led
to a slow script warning dialog.

With this fix the function speeds up ten-fold in the firebug profile.

Firebug profile before the fix:
graycs_getRgbBuffer 8   39.11%  53341.245ms 53343.357ms 6667.92ms   6607.754ms  6768.796ms  pdf.js (line 5471)
anonymous   8   11.43%  15592.314ms 48348.452ms 6043.557ms  4805.474ms  6636.21ms   pdf.js (line 1553)
anonymous   11765608    8.84%   12060.094ms 24200.705ms 0.002ms 0ms 2.927ms pdf.js (line 1609)
decodestream_ensureBuffer   11768257    6.31%   8600.948ms  8600.948ms  0.001ms 0ms 6.64ms  pdf.js (line 178)
anonymous   2677438 3.75%   5109.491ms  8999.525ms  0.003ms 0.002ms 0.228ms pdf.js (line 1902)
fillRgbaBuffer  418 3.6%    4909.592ms  110375.71ms 264.057ms   1.657ms 14258.955ms pdf.js (line 6063)
snapshotCurrentPage 40  3.19%   4355.991ms  4488.668ms  112.217ms   87.253ms    145.143ms   driver.js (line 143)

Firebug profile after the fix:
anonymous   8   19.35%  15517.712ms 47805.081ms 5975.635ms  4782.444ms  6640.163ms  pdf.js (line 1553)
anonymous   11765608    14.56%  11677.139ms 23669.988ms 0.002ms 0ms 4.966ms pdf.js (line 1609)
decodestream_ensureBuffer   11766815    10.78%  8644.553ms  8644.553ms  0.001ms 0ms 6.533ms pdf.js (line 178)
graycs_getRgbBuffer 8   7.28%   5837.802ms  5837.802ms  729.725ms   707.46ms    747.449ms   pdf.js (line 5471)
anonymous   2677438 6.29%   5043.433ms  8912.495ms  0.003ms 0.002ms 3.372ms pdf.js (line 1902)
fillRgbaBuffer  278 6.23%   4997.227ms  62026.713ms 223.118ms   1.673ms 8303.603ms  pdf.js (line 6063)
snapshotCurrentPage 30  4.11%   3298.892ms  3398.715ms  113.291ms   87.805ms    147.789ms   driver.js (line 143)
