### PR TITLE
Fixed browser shutdown bug in Mac tests

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -157,7 +157,7 @@ function snapshotCurrentPage(page, task, failure) {
 
 function sendQuitRequest() {
   var r = new XMLHttpRequest();
-  r.open('POST', '/tellMeToQuit?path = ' + escape(appPath), false);
+  r.open('POST', '/tellMeToQuit?path=' + escape(appPath), false);
   r.send('');
 }
 


### PR DESCRIPTION
The unnecessary spaces in the URL query were causing `tellAppToQuit()` to fail to detect the query `path`, so the browser was being killed via timeout instead of intended script.
