### PR TITLE
Add a list of common serif fonts to not always fallback on sans-serif

### DIFF
--- a/fonts.js
+++ b/fonts.js
@@ -858,6 +858,11 @@ var Font = (function Font() {
         }
 
         // Check that table are sorted by platformID then encodingID,
+        records.sort(function(a, b) {
+          return ((a.platformID << 16) + a.encodingID) -
+                 ((b.platformID << 16) + b.encodingID)
+        });
+
         var tables = [records[0]];
         for (var i = 1; i < numRecords; i++) {
           // The sanitizer will drop the font if 2 tables have the same
@@ -875,7 +880,7 @@ var Font = (function Font() {
         }
 
         var missing = numRecords - tables.length;
-        if (numRecords - tables.length) {
+        if (missing) {
           numRecords = tables.length;
           var data = string16(version) + string16(numRecords);
 

--- a/fonts.js
+++ b/fonts.js
@@ -67,6 +67,53 @@ var stdFontMap = {
   'TimesNewRomanPSMT_Italic': 'Times-Italic'
 };
 
+var serifFonts = {
+  'Adobe Jenson': true, 'Adobe Text': true, 'Albertus': true,
+  'Aldus': true, 'Alexandria': true, 'Algerian': true,
+  'American Typewriter': true, 'Antiqua': true, 'Apex': true,
+  'Arno': true, 'Aster': true, 'Aurora': true,
+  'Baskerville': true, 'Bell': true, 'Bembo': true,
+  'Bembo Schoolbook': true, 'Benguiat': true, 'Berkeley Old Style': true,
+  'Bernhard Modern': true, 'Berthold City': true, 'Bodoni': true,
+  'Bauer Bodoni': true, 'Book Antiqua': true, 'Bookman': true,
+  'Bordeaux Roman': true, 'Californian FB': true, 'Calisto': true,
+  'Calvert': true, 'Capitals': true, 'Cambria': true,
+  'Cartier': true, 'Caslon': true, 'Catull': true,
+  'Centaur': true, 'Century Old Style': true, 'Century Schoolbook': true,
+  'Chaparral': true, 'Charis SIL': true, 'Cheltenham': true,
+  'Cholla Slab': true, 'Clarendon': true, 'Clearface': true,
+  'Cochin': true, 'Colonna': true, 'Computer Modern': true,
+  'Concrete Roman': true, 'Constantia': true, 'Cooper Black': true,
+  'Corona': true, 'Ecotype': true, 'Egyptienne': true,
+  'Elephant': true, 'Excelsior': true, 'Fairfield': true,
+  'FF Scala': true, 'Folkard': true, 'Footlight': true,
+  'FreeSerif': true, 'Friz Quadrata': true, 'Garamond': true,
+  'Gentium': true, 'Georgia': true, 'Gloucester': true,
+  'Goudy Old Style': true, 'Goudy Schoolbook': true, 'Goudy Pro Font': true,
+  'Granjon': true, 'Guardian Egyptian': true, 'Heather': true,
+  'Hercules': true, 'High Tower Text': true, 'Hiroshige': true,
+  'Hoefler Text': true, 'Humana Serif': true, 'Imprint': true,
+  'Ionic No. 5': true, 'Janson': true, 'Joanna': true,
+  'Korinna': true, 'Lexicon': true, 'Liberation Serif': true,
+  'Linux Libertine': true, 'Literaturnaya': true, 'Lucida': true,
+  'Lucida Bright': true, 'Melior': true, 'Memphis': true,
+  'Miller': true, 'Minion': true, 'Modern': true,
+  'Mona Lisa': true, 'Mrs Eaves': true, 'MS Serif': true,
+  'Museo Slab': true, 'New York': true, 'Nimbus Roman': true,
+  'NPS Rawlinson Roadway': true, 'Palatino': true, 'Perpetua': true,
+  'Plantin': true, 'Plantin Schoolbook': true, 'Playbill': true,
+  'Poor Richard': true, 'Rawlinson Roadway': true, 'Renault': true,
+  'Requiem': true, 'Rockwell': true, 'Roman': true,
+  'Rotis Serif': true, 'Sabon': true, 'Scala': true,
+  'Seagull': true, 'Sistina': true, 'Souvenir': true,
+  'STIX': true, 'Stone Informal': true, 'Stone Serif': true,
+  'Sylfaen': true, 'Times': true, 'Trajan': true,
+  'Trinité': true, 'Trump Mediaeval': true, 'Utopia': true,
+  'Vale Type': true, 'Bitstream Vera': true, 'Vera Serif': true,
+  'Versailles': true, 'Wanted': true, 'Weiss': true,
+  'Wide Latin': true, 'Windsor': true, 'XITS': true
+};
+
 var FontMeasure = (function FontMeasure() {
   var kScalePrecision = 30;
   var ctx = document.createElement('canvas').getContext('2d');
@@ -400,10 +447,15 @@ var Font = (function Font() {
     this.glyphs = properties.glyphs;
     this.sizes = [];
 
+    var names = name.split("+");
+    names = names.length > 1 ? names[1] : names[0];
+    names = names.split(/[-,_]/g)[0];
+    this.serif = serifFonts[names] || (name.indexOf("Serif") != -1);
+
     // If the font is to be ignored, register it like an already loaded font
     // to avoid the cost of waiting for it be be loaded by the platform.
     if (properties.ignore) {
-      this.loadedName = 'sans-serif';
+      this.loadedName = this.serif ? 'serif' : 'sans-serif';
       this.loading = false;
       return;
     }

--- a/fonts.js
+++ b/fonts.js
@@ -857,9 +857,42 @@ var Font = (function Font() {
           });
         }
 
+        // Check that table are sorted by platformID then encodingID,
+        var tables = [records[0]];
+        for (var i = 1; i < numRecords; i++) {
+          // The sanitizer will drop the font if 2 tables have the same
+          // platformID and the same encodingID, this will be correct for
+          // most cases but if the font has been made for Mac it could
+          // exist a few platformID: 1, encodingID: 0 but with a different
+          // language field and that's correct. But the sanitizer does not
+          // seem to support this case.
+          var current = records[i];
+          var previous = records[i - 1];
+          if (((current.platformID << 16) + current.encodingID) <=
+             ((previous.platformID << 16) + previous.encodingID))
+                continue;
+          tables.push(current);
+        }
+
+        var missing = numRecords - tables.length;
+        if (numRecords - tables.length) {
+          numRecords = tables.length;
+          var data = string16(version) + string16(numRecords);
+
+          for (var i = 0; i < numRecords; i++) {
+            var table = tables[i];
+            data += string16(table.platformID) +
+                    string16(table.encodingID) +
+                    string32(table.offset);
+          }
+
+          for (var i = 0; i < data.length; i++)
+            cmap.data[i] = data.charCodeAt(i); 
+        }
+
         var encoding = properties.encoding;
         for (var i = 0; i < numRecords; i++) {
-          var table = records[i];
+          var table = tables[i];
           font.pos = start + table.offset;
 
           var format = int16(font.getBytes(2));

--- a/pdf.js
+++ b/pdf.js
@@ -4406,8 +4406,8 @@ var PartialEvaluator = (function() {
           return null;
 
         // Using base font name as a font name.
-        baseFontName = baseFontName.name.replace(/[\+,\-]/g, '_');
-        if (/^Symbol(_?(Bold|Italic))*$/.test(baseFontName)) {
+        baseFontName = baseFontName.name;
+        if (/^Symbol(-?(Bold|Italic))*$/.test(baseFontName)) {
           // special case for symbols
           var encoding = Encodings.symbolsEncoding;
           for (var i = 0, n = encoding.length, j; i < n; i++) {
@@ -4428,7 +4428,7 @@ var PartialEvaluator = (function() {
       var descriptor = xref.fetch(fd);
       var fontName = xref.fetchIfRef(descriptor.get('FontName'));
       assertWellFormed(IsName(fontName), 'invalid font name');
-      fontName = fontName.name.replace(/[\+,\-]/g, '_');
+      fontName = fontName.name;
 
       var fontFile = descriptor.get('FontFile', 'FontFile2', 'FontFile3');
       var length1, length2;
@@ -4803,11 +4803,8 @@ var CanvasGraphics = (function() {
       if (!font)
         return;
 
-      var name = '';
       var fontObj = font.fontObj;
-      if (fontObj)
-        name = fontObj.loadedName;
-
+      var name = fontObj.loadedName;
       if (!name) {
         // TODO: fontDescriptor is not available, fallback to default font
         name = 'sans-serif';
@@ -4827,7 +4824,9 @@ var CanvasGraphics = (function() {
                                    (fontObj.bold ? 'bold' : 'normal');
 
         var italic = fontObj.italic ? 'italic' : 'normal';
-        var rule = italic + ' ' + bold + ' ' + size + 'px "' + name + '", "sans-serif"';
+        var serif = fontObj.serif ? 'serif' : 'sans-serif';
+        var typeface = '"' + name + '", ' + serif
+        var rule = italic + ' ' + bold + ' ' + size + 'px ' + typeface;
         this.ctx.font = rule;
       }
     },

--- a/pdf.js
+++ b/pdf.js
@@ -4824,7 +4824,7 @@ var CanvasGraphics = (function() {
                                    (fontObj.bold ? 'bold' : 'normal');
 
         var italic = fontObj.italic ? 'italic' : 'normal';
-        var rule = italic + ' ' + bold + ' ' + size + 'px "' + name + '"';
+        var rule = italic + ' ' + bold + ' ' + size + 'px "' + name + '", "sans-serif"';
         this.ctx.font = rule;
       }
     },

--- a/pdf.js
+++ b/pdf.js
@@ -4304,6 +4304,9 @@ var PartialEvaluator = (function() {
             var index = GlyphsUnicode[glyph] || i;
             glyphsMap[glyph] = encodingMap[i] = index;
 
+            if (!fontFile)
+              continue;
+
             if (index <= 0x1f || (index >= 127 && index <= 255))
               glyphsMap[glyph] = encodingMap[i] += kCmapGlyphOffset;
           }


### PR DESCRIPTION
The list of fonts came from wikipedia and can probably be enhance but it we precise nothing Firefox always try to take a serif font while this is not always what the author of the document was trying to do.
