### PR TITLE
Sanity checks

### DIFF
--- a/fonts.js
+++ b/fonts.js
@@ -1291,6 +1291,10 @@ var Font = (function Font() {
                  window.btoa(data) + ');');
       var rule = "@font-face { font-family:'" + fontName + "';src:" + url + '}';
       var styleSheet = document.styleSheets[0];
+      if (!styleSheet) {
+        document.documentElement.firstChild.appendChild( document.createElement('style') );
+        styleSheet = document.styleSheets[0];
+      }
       styleSheet.insertRule(rule, styleSheet.cssRules.length);
 
       return rule;

--- a/pdf.js
+++ b/pdf.js
@@ -3379,7 +3379,7 @@ var Page = (function() {
           } catch (e) {
             exc = e.toString();
           }
-          continuation(exc);
+          if (continuation) continuation(exc);
         });
       };
 


### PR DESCRIPTION
`continuation` doesn't necessarily need to be passed.

also, the doc might not have a `styleSheet`, so create one if none exists.

@jviereck
