### PR TITLE
FIxed Ascent and Descent in OS/2 table

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -8,6 +8,7 @@
                   Justin D'Arcangelo <justindarc@gmail.com>
                   Yury Delendik
                   Kalervo Kujala
+                  Adil Allawi <@ironymark>
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
When PDF.js generates an OS/2 table for a font it would get the value from the PDF Font Descriptor. Not only was this to the wrong scale, causing clipping of the font on Windows, but if there was no ascent value in the Font Descriptor it would cause the font to fail on Windows.

This patch fixes OS/2 generation to use the yMax and yMin values from the head table. It also sets the 'use cleartype' flag in the font 'head' table in a vain attempt to improve font rendering.

Test file is already in the tests  - /test/pdfs/ArabicCIDTrueType.pdf

Adil
