### PR TITLE
Ignore previously parsed xref streams

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -3094,10 +3094,11 @@ var XRef = (function() {
       // check for 'XRefStm' key
       if (IsInt(obj = dict.get('XRefStm'))) {
         var pos = obj;
-        if (pos in this.xrefstms)
-          error('Invalid XRef table');
-        this.xrefstms[pos] = 1; // avoid infinite recursion
-        this.readXRef(pos);
+        // ignore previously loaded xref streams (possible infinite recursion)
+        if (!(pos in this.xrefstms)) {
+          this.xrefstms[pos] = 1;
+          this.readXRef(pos);
+        }
       }
 
       return dict;

--- a/test/pdfs/f1040.pdf.link
+++ b/test/pdfs/f1040.pdf.link
@@ -1,0 +1,1 @@
+http://www.irs.gov/pub/irs-pdf/f1040.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -139,5 +139,11 @@
        "link": true,
        "rounds": 1,
        "type": "load"
+    },
+    {  "id": "f1040",
+       "file": "pdfs/f1040.pdf",
+       "link": true,
+       "rounds": 1,
+       "type": "load"
     }
 ]


### PR DESCRIPTION
Some pdf's have duplicate xref streams referenced which aren't actually infinite recursion.  Instead of erroring out on duplicates and infinite recursion it will now just ignore it.
