### PR TITLE
Dereference dictionary for colorspace linked by name

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -5431,7 +5431,7 @@ var ColorSpace = (function colorSpaceColorSpace() {
 
   constructor.parse = function colorspace_parse(cs, xref, res) {
     if (IsName(cs)) {
-      var colorSpaces = res.get('ColorSpace');
+      var colorSpaces = xref.fetchIfRef(res.get('ColorSpace'));
       if (IsDict(colorSpaces)) {
         var refcs = colorSpaces.get(cs.name);
         if (refcs)

--- a/test/pdfs/hudsonsurvey.pdf.link
+++ b/test/pdfs/hudsonsurvey.pdf.link
@@ -1,0 +1,1 @@
+https://issues.apache.org/jira/secure/attachment/12421789/survey.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -145,5 +145,11 @@
        "link": true,
        "rounds": 1,
        "type": "load"
+    },
+    {  "id": "hudsonsurvey",
+       "file": "pdfs/hudsonsurvey.pdf",
+       "link": true,
+       "rounds": 1,
+       "type": "load"
     }
 ]


### PR DESCRIPTION
The dictionary linked by name wasn't being dereferenced. I'm starting to think we should add a function to the Dict object that's something like get() but you'd also pass the xref and it would fetch if it needed to.  Seems like an easy mistake to make to not use the xref.fetchIfRef() after dict.get().

On a side note: 32 of my 37 test pdfs are now working.
