### PR TITLE
Fix mediaBox check (regr. of #519)

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -3322,7 +3322,7 @@ var Page = (function pagePage() {
     get mediaBox() {
       var obj = this.inheritPageProp('MediaBox');
       // Reset invalid media box to letter size.
-      if (!IsArray(obj) || obj.length === 4)
+      if (!IsArray(obj) || obj.length !== 4)
         obj = [0, 0, 612, 792];
       return shadow(this, 'mediaBox', obj);
     },


### PR DESCRIPTION
Fix for:

TEST-UNEXPECTED-FAIL | eq sizes | in firefox | rendering of page 2 != reference rendering
TEST-UNEXPECTED-FAIL | eq sizes | in firefox | rendering of page 3 != reference rendering
TEST-UNEXPECTED-FAIL | eq openweb-cover | in firefox | rendering of page 1 != reference rendering
