### PR TITLE
Use data directly in PDFDoc.

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -3800,7 +3800,8 @@ var Catalog = (function catalogCatalog() {
 })();
 
 var PDFDoc = (function pdfDoc() {
-  function constructor(stream) {
+  function constructor(data) {
+    var stream = new Stream(data);
     assertWellFormed(stream.length > 0, 'stream must have data');
     this.stream = stream;
     this.setup();

--- a/test/driver.js
+++ b/test/driver.js
@@ -83,7 +83,7 @@ function nextTask() {
         r.responseArrayBuffer || r.response;
 
       try {
-        task.pdfDoc = new PDFDoc(new Stream(data));
+        task.pdfDoc = new PDFDoc(data);
       } catch (e) {
         failure = 'load PDF doc : ' + e.toString();
       }

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -159,7 +159,7 @@ var PDFView = {
     while (container.hasChildNodes())
       container.removeChild(container.lastChild);
 
-    var pdf = new PDFDoc(new Stream(data));
+    var pdf = new PDFDoc(data);
     var pagesCount = pdf.numPages;
     document.getElementById('numPages').innerHTML = pagesCount;
 

--- a/worker/pdf.js
+++ b/worker/pdf.js
@@ -48,7 +48,7 @@ addEventListener('message', function(event) {
   var data = event.data;
   // If there is no pdfDocument yet, then the sent data is the PDFDocument.
   if (!pdfDocument) {
-    pdfDocument = new PDFDoc(new Stream(data));
+    pdfDocument = new PDFDoc(data);
     postMessage({
       action: 'pdf_num_pages',
       data: pdfDocument.numPages


### PR DESCRIPTION
And create the Stream inside the PDFDoc constructor for a cleaner interface.
Also encapsulate unnecessary details from the user.

This is also a feature request #480
