### PR TITLE
Implemented getPdf(). Closes #516

### DIFF
--- a/examples/helloworld/hello.js
+++ b/examples/helloworld/hello.js
@@ -7,30 +7,7 @@
 
 'use strict';
 
-//
-// Ajax GET request, for binary files
-// (like jQuery's $.get(), but supports the binary type ArrayBuffer)
-//
-var ajaxGet = function(url, callback) {
-  var xhr = new XMLHttpRequest();
-  xhr.open('GET', url);
-  xhr.mozResponseType = xhr.responseType = 'arraybuffer';
-  xhr.expected = (document.URL.indexOf('file:') === 0) ? 0 : 200;
-  xhr.onreadystatechange = function() {
-    if (xhr.readyState === 4 && xhr.status === xhr.expected) {
-      var data = (xhr.mozResponseArrayBuffer || xhr.mozResponse ||
-                  xhr.responseArrayBuffer || xhr.response);
-
-      callback(data);
-    }
-  };
-  xhr.send(null);
-};
-
-//
-// This is where the fun happens
-//
-ajaxGet('helloworld.pdf', function ajaxGetHelloWorld(data) {
+getPdf('helloworld.pdf', function(data){  
   //
   // Instantiate PDFDoc with PDF data
   //

--- a/pdf.js
+++ b/pdf.js
@@ -112,6 +112,35 @@ function stringToPDFString(str) {
   return str2;
 }
 
+//
+// getPdf()
+// Convenience function to perform binary Ajax GET
+// Usage: getPdf('http://...', callback)
+//        getPdf({url:String [,progress:Function]}, callback)
+//
+function getPdf(arg, callback) {
+  var params = arg;
+  if (typeof arg === 'string') {
+    params = {url: arg};
+  }
+
+  var xhr = new XMLHttpRequest();
+  xhr.open('GET', params.url);
+  xhr.mozResponseType = xhr.responseType = 'arraybuffer';
+  xhr.expected = (document.URL.indexOf('file:') === 0) ? 0 : 200;
+  xhr.onprogress = params.progress || undefined;
+  
+  xhr.onreadystatechange = function() {
+    var data;
+    if (xhr.readyState === 4 && xhr.status === xhr.expected) {
+      data = (xhr.mozResponseArrayBuffer || xhr.mozResponse ||
+                  xhr.responseArrayBuffer || xhr.response);
+      callback(data);
+    }
+  };
+  xhr.send(null);  
+}
+
 var Stream = (function streamStream() {
   function constructor(arrayBuffer, start, length, dict) {
     this.bytes = new Uint8Array(arrayBuffer);

--- a/test/driver.js
+++ b/test/driver.js
@@ -73,26 +73,16 @@ function nextTask() {
 
   log('Loading file "' + task.file + '"\n');
 
-  var r = new XMLHttpRequest();
-  r.open('GET', task.file);
-  r.mozResponseType = r.responseType = 'arraybuffer';
-  r.onreadystatechange = function nextTaskOnreadystatechange() {
+  getPdf(task.file, function(data){
     var failure;
-    if (r.readyState == 4) {
-      var data = r.mozResponseArrayBuffer || r.mozResponse ||
-        r.responseArrayBuffer || r.response;
-
-      try {
-        task.pdfDoc = new PDFDoc(data);
-      } catch (e) {
-        failure = 'load PDF doc : ' + e.toString();
-      }
-
-      task.pageNum = 1;
-      nextPage(task, failure);
+    try {
+      task.pdfDoc = new PDFDoc(data);
+    } catch (e) {
+      failure = 'load PDF doc : ' + e.toString();
     }
-  };
-  r.send(null);
+    task.pageNum = 1;
+    nextPage(task, failure);
+  });
 }
 
 function isLastPage(task) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -107,23 +107,10 @@ var PDFView = {
 
     document.title = url;
 
-    var xhr = new XMLHttpRequest();
-    xhr.open('GET', url);
-    xhr.mozResponseType = xhr.responseType = 'arraybuffer';
-    xhr.expected = (document.URL.indexOf('file:') === 0) ? 0 : 200;
-    xhr.onprogress = PDFView.progressLevel;
-
-    xhr.onreadystatechange = function() {
-      if (xhr.readyState === 4 && xhr.status === xhr.expected) {
-        var data = (xhr.mozResponseArrayBuffer || xhr.mozResponse ||
-                    xhr.responseArrayBuffer || xhr.response);
-
-        document.getElementById('loading').style.display = 'none';
-        PDFView.load(data, scale);
-      }
-    };
-
-    xhr.send(null);
+    getPdf({url:url, progress:PDFView.progressLevel}, function(data) {
+      document.getElementById('loading').style.display = 'none';
+      PDFView.load(data, scale);
+    });
   },
 
   progressLevel: function(evt) {


### PR DESCRIPTION
Main function `getPdf()` is implemented in `pdf.js`. Examples and viewers are also updated to make use of it.

In the near future this function, as part of our global namespace cleaning efforts, this function will/should be wrapped in a global namespace.

This is also where most of the work re: XHR's "chunked" support will probably take place, cf. #485.
