### PR TITLE
Introducing pageLimit to manifest

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -86,7 +86,7 @@ function nextTask() {
 }
 
 function isLastPage(task) {
-  return (task.pageNum > task.pdfDoc.numPages);
+  return task.pageNum > task.pdfDoc.numPages || task.pageNum > task.pageLimit;
 }
 
 function canvasToDataURL() {
@@ -205,7 +205,7 @@ function done() {
 function sendTaskResult(snapshot, task, failure) {
   var result = { browser: browser,
                  id: task.id,
-                 numPages: task.pdfDoc ? task.pdfDoc.numPages : 0,
+                 numPages: task.pdfDoc ? (task.pageLimit || task.pdfDoc.numPages) : 0,
                  failure: failure,
                  file: task.file,
                  round: task.round,

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -18,13 +18,15 @@
        "file": "pdfs/intelisa.pdf",
        "link": true,
        "rounds": 1,
-       "type": "load"
+       "type": "load",
+       "pageLimit": 100       
     },
     {  "id": "pdfspec-load",
        "file": "pdfs/pdf.pdf",
        "link": true,
        "rounds": 1,
-       "type": "load"
+       "type": "load",
+       "pageLimit": 100       
     },
     {  "id": "shavian-load",
        "file": "pdfs/shavian.pdf",
@@ -102,7 +104,8 @@
        "file": "pdfs/jai.pdf",
        "link": true,
        "rounds": 1,
-       "type": "load"
+       "type": "load",
+       "pageLimit": 100
     },
     {  "id": "cable",
        "file": "pdfs/cable.pdf",


### PR DESCRIPTION
The motivation is that (a) tests are taking too long both for users (see #333) and for bots :), and (b) our longest PDFs don't seem to introduce a whole lot of new features per page.

I went ahead and limited to 100 pages the tests of three of our PDFs. If you know of a particularly important feature this will miss please speak up :)

Note that all of these are simply "load" tests, not "eq".
