### PR TITLE
Removing non-standard __defineGetter__ function

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -55,16 +55,10 @@ function assertWellFormed(cond, msg) {
 }
 
 function shadow(obj, prop, value) {
-  try {
-    Object.defineProperty(obj, prop, { value: value,
-                                       enumerable: true,
-                                       configurable: true,
-                                       writable: false });
-  } catch (e) {
-    obj.__defineGetter__(prop, function shadowDefineGetter() {
-      return value;
-    });
-  }
+  Object.defineProperty(obj, prop, { value: value,
+                                     enumerable: true,
+                                     configurable: true,
+                                     writable: false });
   return value;
 }
 


### PR DESCRIPTION
Partially backing up the https://github.com/vingtetun/pdf.js/commit/c7195a44505443407a22273ff069d704763ec227

Current Chrome/Chromium works fine without **defineGetter**. Looks like a unreachable code now.
