### PR TITLE
Recovering from RGBT-command (ref #577)

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -4366,6 +4366,20 @@ var PartialEvaluator = (function partialEvaluator() {
         if (isCmd(obj)) {
           var cmd = obj.cmd;
           var fn = OP_MAP[cmd];
+          if (!fn) {
+            // invalid content command, trying to recover
+            if (cmd.substr(-2) == 'BT') {
+              fn = OP_MAP[cmd.substr(0, cmd.length - 2)];
+              // feeding 'BT' on next interation
+              parser = {
+                getObj: function() {
+                  parser = this.oldParser;
+                  return { name: 'BT' };
+                },
+                oldParser: parser
+              };
+            }
+          }
           assertWellFormed(fn, "Unknown command '" + cmd + "'");
           // TODO figure out how to type-check vararg functions
 

--- a/test/pdfs/vesta.pdf.link
+++ b/test/pdfs/vesta.pdf.link
@@ -1,0 +1,1 @@
+http://www-csag.ucsd.edu/~jburke/Vesta/Vesta_Overview.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -158,6 +158,12 @@
        "rounds": 1,
        "type": "load"
     },
+    {  "id": "vesta-bad",
+       "file": "pdfs/vesta.pdf",
+       "link": true,
+       "rounds": 1,
+       "type": "load"
+    },
     {  "id": "ibwa-bad",
        "file": "pdfs/ibwa-bad.pdf",
        "link": true,


### PR DESCRIPTION
The RGBT is invalid content command -- replaced to RG and BT
