### PR TITLE
Fixing "no spaces" issue (ref #577)

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -4585,10 +4585,8 @@ var PartialEvaluator = (function partialEvaluator() {
           width: isNum(width) ? width : properties.defaultWidth
         };
 
-        if (glyph) {
-          if (replaceGlyph || !glyphs[glyph])
+        if (glyph && (replaceGlyph || !glyphs[glyph]))
             glyphs[glyph] = map[i];
-        }
 
         // If there is no file, the character mapping can't be modified
         // but this is unlikely that there is any standard encoding with

--- a/pdf.js
+++ b/pdf.js
@@ -4573,11 +4573,10 @@ var PartialEvaluator = (function partialEvaluator() {
       var glyphs = {};
       for (var i = firstChar; i <= lastChar; i++) {
         var glyph = differences[i];
+        var replaceGlyph = true;
         if (!glyph) {
           glyph = baseEncoding[i];
-          // skipping already specified by difference glyphs
-          if (differences.indexOf(glyph) >= 0)
-            continue;
+          replaceGlyph = false;
         }
         var index = GlyphsUnicode[glyph] || i;
         var width = widths[i] || widths[glyph];
@@ -4586,8 +4585,10 @@ var PartialEvaluator = (function partialEvaluator() {
           width: isNum(width) ? width : properties.defaultWidth
         };
 
-        if (glyph)
-          glyphs[glyph] = map[i];
+        if (glyph) {
+          if (replaceGlyph || !glyphs[glyph])
+            glyphs[glyph] = map[i];
+        }
 
         // If there is no file, the character mapping can't be modified
         // but this is unlikely that there is any standard encoding with

--- a/test/pdfs/unix01.pdf.link
+++ b/test/pdfs/unix01.pdf.link
@@ -1,0 +1,1 @@
+https://docs.rice.edu/confluence/download/attachments/4588376/unix01.pdf?version=1

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -128,6 +128,12 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "unix01",
+       "file": "pdfs/unix01.pdf",
+       "link": true,
+       "rounds": 1,
+       "type": "eq"
+    },
     {  "id": "fips197",
        "file": "pdfs/fips197.pdf",
        "link": true,


### PR DESCRIPTION
Takes care of missing default-encoded characters
- https://docs.rice.edu/confluence/download/attachments/4588376/unix01.pdf?version=1
- http://www.csb.yale.edu/userguides/graphics/rasmol/rasmol.pdf
