### PR TITLE
New test/ features (useful for bot)

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -4888,8 +4888,8 @@ var CanvasExtraState = (function canvasExtraState() {
     this.fillColorObj = null;
     this.strokeColorObj = null;
     // Default fore and background colors
-    this.fillColor = "#000000";
-    this.strokeColor = "#000000";
+    this.fillColor = '#000000';
+    this.strokeColor = '#000000';
 
     this.old = old;
   }

--- a/test/driver.js
+++ b/test/driver.js
@@ -86,7 +86,7 @@ function nextTask() {
 }
 
 function isLastPage(task) {
-  return (task.pageNum > task.pdfDoc.numPages);
+  return task.pageNum > task.pdfDoc.numPages || task.pageNum > task.pageLimit;
 }
 
 function canvasToDataURL() {
@@ -205,7 +205,7 @@ function done() {
 function sendTaskResult(snapshot, task, failure) {
   var result = { browser: browser,
                  id: task.id,
-                 numPages: task.pdfDoc ? task.pdfDoc.numPages : 0,
+                 numPages: task.pdfDoc ? (task.pageLimit || task.pdfDoc.numPages) : 0,
                  failure: failure,
                  file: task.file,
                  round: task.round,

--- a/test/driver.js
+++ b/test/driver.js
@@ -205,7 +205,7 @@ function done() {
 function sendTaskResult(snapshot, task, failure) {
   var result = { browser: browser,
                  id: task.id,
-                 numPages: task.pdfDoc ? 
+                 numPages: task.pdfDoc ?
                            (task.pageLimit || task.pdfDoc.numPages) : 0,
                  failure: failure,
                  file: task.file,

--- a/test/driver.js
+++ b/test/driver.js
@@ -205,7 +205,8 @@ function done() {
 function sendTaskResult(snapshot, task, failure) {
   var result = { browser: browser,
                  id: task.id,
-                 numPages: task.pdfDoc ? (task.pageLimit || task.pdfDoc.numPages) : 0,
+                 numPages: task.pdfDoc ? 
+                           (task.pageLimit || task.pdfDoc.numPages) : 0,
                  failure: failure,
                  file: task.file,
                  round: task.round,

--- a/test/test.py
+++ b/test/test.py
@@ -23,6 +23,8 @@ class TestOptions(OptionParser):
         OptionParser.__init__(self, **kwargs)
         self.add_option("-m", "--masterMode", action="store_true", dest="masterMode",
                         help="Run the script in master mode.", default=False)
+        self.add_option("--noPrompts", action="store_true", dest="noPrompts",
+                        help="Uses default answers (intended for CLOUD TESTS only!).", default=False)
         self.add_option("--manifestFile", action="store", type="string", dest="manifestFile",
                         help="A JSON file in the form of test_manifest.json (the default).")
         self.add_option("-b", "--browser", action="store", type="string", dest="browser",
@@ -321,7 +323,7 @@ def setUp(options):
     if options.masterMode and os.path.isdir(TMPDIR):
         print 'Temporary snapshot dir tmp/ is still around.'
         print 'tmp/ can be removed if it has nothing you need.'
-        if prompt('SHOULD THIS SCRIPT REMOVE tmp/?  THINK CAREFULLY'):
+        if options.noPrompts or prompt('SHOULD THIS SCRIPT REMOVE tmp/?  THINK CAREFULLY'):
             subprocess.call(( 'rm', '-rf', 'tmp' ))
 
     assert not os.path.isdir(TMPDIR)
@@ -414,8 +416,9 @@ def checkEq(task, results, browser, masterMode):
 
         path = os.path.join(pfx, str(page + 1))
         if not os.access(path, os.R_OK):
-            print 'WARNING: no reference snapshot', path
             State.numEqNoSnapshot += 1
+            if not masterMode:
+                print 'WARNING: no reference snapshot', path
         else:
             f = open(path)
             ref = f.read()
@@ -444,8 +447,9 @@ def checkEq(task, results, browser, masterMode):
             try:
                 os.makedirs(tmpTaskDir)
             except OSError, e:
-                print >>sys.stderr, 'Creating', tmpTaskDir, 'failed!'
-
+                if e.errno != 17: # file exists
+                    print >>sys.stderr, 'Creating', tmpTaskDir, 'failed!'
+        
             of = open(os.path.join(tmpTaskDir, str(page + 1)), 'w')
             of.write(snapshot)
             of.close()
@@ -503,10 +507,10 @@ def maybeUpdateRefImages(options, browser):
             print '  Yes!  The references in tmp/ can be synced with ref/.'
             if options.reftest:                                                                                                              
                 startReftest(browser, options)
-            if not prompt('Would you like to update the master copy in ref/?'):
+            if options.noPrompts or not prompt('Would you like to update the master copy in ref/?'):
                 print '  OK, not updating.'
             else:
-                sys.stdout.write('  Updating ... ')
+                sys.stdout.write('  Updating ref/ ... ')
 
                 # XXX unclear what to do on errors here ...
                 # NB: do *NOT* pass --delete to rsync.  That breaks this


### PR DESCRIPTION
**Please wait until I've run a bot test on this before merging**

The bot will always use `test/` from upstream (andreasgal/master), unless the pull request makes changes to files within that dir, in which case it will use `test/` from the PR. 

Thus, merging the changes listed below will ensure the bot can make use of features like `--noPrompts` on existing pull requests (which avoids having to resort to a long timeout).

`test.py:`
- added option --noPrompts, which skips prompts with sensible default answers for bot scenario
- removed unnecessary warnings when in masterMode
- removed unnecessary "Creating tmp failed" message when error is simply b/c it already exists

`driver.js:`
- added per PDF manifest option "pageLimit", e.g. "pageLimit":100 (currently not used)
