### PR TITLE
Extension chrome

### DIFF
--- a/extensions/chrome/manifest.json
+++ b/extensions/chrome/manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "uriloader@pdf.js",
+  "version": "0.1",
+  "description": "Read PDF Document",
+  "permissions": [
+    "experimental",
+    "http://*/*.pdf",
+    "file:///*/*.pdf"
+  ],
+  "background_page": "pdfHandler.html"
+}

--- a/extensions/chrome/manifest.json
+++ b/extensions/chrome/manifest.json
@@ -5,7 +5,7 @@
   "permissions": [
     "experimental",
     "http://*/*.pdf",
-    "file:///*/*.pdf"
+    "file://*/*.pdf"
   ],
   "background_page": "pdfHandler.html"
 }

--- a/extensions/chrome/pdfHandler.html
+++ b/extensions/chrome/pdfHandler.html
@@ -2,7 +2,8 @@
 <script>
 chrome.experimental.webRequest.onBeforeRequest.addListener(
   function(details) {
-    var url = chrome.extension.getURL('') + 'web/viewer.html?file=' + details.url;
+    var params = '?file=' + details.url;
+    var url = chrome.extension.getURL('web/viewer.html') + params;
     return { redirectUrl: url };
   },
   {

--- a/extensions/chrome/pdfHandler.html
+++ b/extensions/chrome/pdfHandler.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<script>
+chrome.experimental.webRequest.onBeforeRequest.addListener(
+  function(details) {
+    var url = chrome.extension.getURL('') + 'web/viewer.html?file=' + details.url;
+    return { redirectUrl: url };
+  },
+  {
+    urls: [
+      "http://*/*.pdf",
+      "file://*/*.pdf",
+    ],
+    types: [ "main_frame" ]
+  },
+  ["blocking"]);
+</script>
+


### PR DESCRIPTION
This is an extension on top of the current experimental chrome API that handle every *.pdf files (not based on mimetype - there is no such API for that yet) and redirect it to pdf.js.
