### PR TITLE
Fix strict js warnings.

### DIFF
--- a/fonts.js
+++ b/fonts.js
@@ -2631,7 +2631,8 @@ var Type2CFF = (function type2CFF() {
         if (unicode <= 0x1f || (unicode >= 127 && unicode <= 255))
           unicode += kCmapGlyphOffset;
 
-        var width = isNum(mapping.width) ? mapping.width : defaultWidth;
+        var width = (mapping.hasOwnProperty('width') && isNum(mapping.width)) ?
+                    mapping.width : defaultWidth;
         properties.encoding[code] = {
           unicode: unicode,
           width: width


### PR DESCRIPTION
Warning: variable dependency redeclares argument

Source File: http://localhost:8080/pdf.js

Line: 4668, Column: 10

Source Code:
      var dependency = dependency || []; 

Warning: variable queue redeclares argument

Source File: http://localhost:8080/pdf.js

Line: 5297, Column: 14

Source Code:
          var queue = {}; 

Warning: anonymous function does not always return a value

Source File: http://localhost:8080/pdf.js

Line: 7131

Warning: anonymous function does not always return a value

Source File: http://localhost:8080/pdf.js

Line: 7432, Column: 8

Source Code:
        return obj.data; 
