### PR TITLE
Make worker load the right files after file split

### DIFF
--- a/examples/helloworld/hello.js
+++ b/examples/helloworld/hello.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-PDFJS.getPdf('helloworld.pdf', function getPdfHelloWorld(data) {
+getPdf('helloworld.pdf', function getPdfHelloWorld(data) {
   //
   // Instantiate PDFDoc with PDF data
   //

--- a/examples/helloworld/index.html
+++ b/examples/helloworld/index.html
@@ -3,27 +3,32 @@
 
 <head>
   <!-- In production, only one script (pdf.js) is necessary -->
-  <script type="text/javascript" src="../../src/core.js"></script> 
-  <script type="text/javascript" src="../../src/util.js"></script>  
-  <script type="text/javascript" src="../../src/canvas.js"></script>  
-  <script type="text/javascript" src="../../src/obj.js"></script>  
-  <script type="text/javascript" src="../../src/function.js"></script> 
-  <script type="text/javascript" src="../../src/charsets.js"></script>  
-  <script type="text/javascript" src="../../src/cidmaps.js"></script>  
-  <script type="text/javascript" src="../../src/colorspace.js"></script>  
-  <script type="text/javascript" src="../../src/crypto.js"></script>  
-  <script type="text/javascript" src="../../src/evaluator.js"></script>  
-  <script type="text/javascript" src="../../src/fonts.js"></script>  
-  <script type="text/javascript" src="../../src/glyphlist.js"></script>  
-  <script type="text/javascript" src="../../src/image.js"></script>  
-  <script type="text/javascript" src="../../src/metrics.js"></script>  
-  <script type="text/javascript" src="../../src/parser.js"></script>  
-  <script type="text/javascript" src="../../src/pattern.js"></script>  
-  <script type="text/javascript" src="../../src/stream.js"></script>  
-  <script type="text/javascript" src="../../src/worker.js"></script>  
+  <script type="text/javascript" src="../../src/core.js"></script>
+  <script type="text/javascript" src="../../src/util.js"></script>
+  <script type="text/javascript" src="../../src/canvas.js"></script>
+  <script type="text/javascript" src="../../src/obj.js"></script>
+  <script type="text/javascript" src="../../src/function.js"></script>
+  <script type="text/javascript" src="../../src/charsets.js"></script>
+  <script type="text/javascript" src="../../src/cidmaps.js"></script>
+  <script type="text/javascript" src="../../src/colorspace.js"></script>
+  <script type="text/javascript" src="../../src/crypto.js"></script>
+  <script type="text/javascript" src="../../src/evaluator.js"></script>
+  <script type="text/javascript" src="../../src/fonts.js"></script>
+  <script type="text/javascript" src="../../src/glyphlist.js"></script>
+  <script type="text/javascript" src="../../src/image.js"></script>
+  <script type="text/javascript" src="../../src/metrics.js"></script>
+  <script type="text/javascript" src="../../src/parser.js"></script>
+  <script type="text/javascript" src="../../src/pattern.js"></script>
+  <script type="text/javascript" src="../../src/stream.js"></script>
+  <script type="text/javascript" src="../../src/worker.js"></script>
 
+  <script type="text/javascript">
+    // Specify the directory of the source files, such that the web worker
+    // knows where to load them.
+    var PDFJS_WORKER_DIR = '../../src/';
+  </script>
   <script type="text/javascript" src="hello.js"></script>
-</head>  
+</head>
 
 <body>
   <canvas id="the-canvas" style="border:1px solid black;"/>

--- a/src/core.js
+++ b/src/core.js
@@ -471,7 +471,26 @@ var PDFDoc = (function() {
     this.pageCache = [];
 
     if (useWorker) {
-      var worker = new Worker('../src/worker_loader.js');
+      var worker;
+      if (typeof PDFJS_WORKER_DIR !== 'undefined') {
+        // If `PDFJS_WORKER_DIR` is specified, we assume the pdf.js files
+        // located all in that directory. Create a new worker and tell him
+        // the directory, such that he can load the scripts from there.
+        worker = new Worker(PDFJS_WORKER_DIR + 'worker_loader.js');
+        console.log('main: post dir');
+
+        worker.postMessage(PDFJS_WORKER_DIR);
+      } else if (typeof PDFJS_WORKER_FILE !== 'undefined') {
+        // If we build the worker using a worker file, then we assume, that
+        // everything the worker needs is already included in that file.
+        // Therefore the worker doesn't have to call `importScripts` to load
+        // all the single files and therefore it's not necessary to tell the
+        // worker a directory to laod the js files from.
+        // (Which is different from the PDFJS_WORKER_DIR case above.)
+        worker = new Worker(PDFJS_WORKER_FILE);
+      } else {
+        throw 'No worker file or directory specified.';
+      }
     } else {
       // If we don't use a worker, just post/sendMessage to the main thread.
       var worker = {

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -4,7 +4,6 @@
 var PDFJS = {};
 
 (function pdfjsWrapper() {
-
   // Use strict in our context only - users might not want it
   'use strict';
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -174,10 +174,9 @@ var workerConsole = {
 
 // Worker thread?
 if (typeof window === 'undefined') {
-  globalScope.console = workerConsole;
+  this.console = workerConsole;
 
-  // Listen for messages from the main thread.
-  var handler = new MessageHandler('worker_processor', globalScope);
+  var handler = new MessageHandler('worker_processor', this);
   WorkerProcessorHandler.setup(handler);
 }
 

--- a/src/worker_loader.js
+++ b/src/worker_loader.js
@@ -3,22 +3,40 @@
 
 'use strict';
 
-importScripts('../src/core.js');
-importScripts('../src/util.js');
-importScripts('../src/canvas.js');
-importScripts('../src/obj.js');
-importScripts('../src/function.js');
-importScripts('../src/charsets.js');
-importScripts('../src/cidmaps.js');
-importScripts('../src/colorspace.js');
-importScripts('../src/crypto.js');
-importScripts('../src/evaluator.js');
-importScripts('../src/fonts.js');
-importScripts('../src/glyphlist.js');
-importScripts('../src/image.js');
-importScripts('../src/metrics.js');
-importScripts('../src/parser.js');
-importScripts('../src/pattern.js');
-importScripts('../src/stream.js');
-importScripts('../src/worker.js');
+this.onmessage = function(evt) {
+  // Reset the `onmessage` function as it was only set to call
+  // this function the first time a message is passed to the worker
+  // but shouldn't get called anytime afterwards.
+  delete this.onmessage;
 
+  // Directory the include files are contained is send as the
+  // first message to the worker.
+  var dir = evt.data;
+
+  // List of files to include;
+  var files = [
+    'core.js',
+    'util.js',
+    'canvas.js',
+    'obj.js',
+    'function.js',
+    'charsets.js',
+    'cidmaps.js',
+    'colorspace.js',
+    'crypto.js',
+    'evaluator.js',
+    'fonts.js',
+    'glyphlist.js',
+    'image.js',
+    'metrics.js',
+    'parser.js',
+    'pattern.js',
+    'stream.js',
+    'worker.js'
+  ];
+
+  // Load all the files.
+  for (var i = 0; i < files.length; i++) {
+    importScripts(dir + files[i]);
+  }
+}.bind(this);

--- a/web/viewer-snippet.html
+++ b/web/viewer-snippet.html
@@ -1,2 +1,7 @@
 <!-- This snippet is used in production, see Makefile -->
 <script type="text/javascript" src="../build/pdf.js"></script>
+<script type="text/javascript">
+  // This specifies the location of the pdf.js file. This is necessary to
+  // spawn the web worker.
+  var PDFJS_WORKER_FILE = "../build/pdf.js";
+</script>

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -3,9 +3,9 @@
     <head>
         <title>Simple pdf.js page viewer</title>
         <link rel="stylesheet" href="viewer.css"/>
-        
+
         <!-- PDFJSSCRIPT_INCLUDE_BUILD -->
-        
+        <script type="text/javascript">var PDFJS_WORKER_DIR = "../src/"</script> <!-- PDFJSSCRIPT_REMOVE -->
         <script type="text/javascript" src="../src/core.js"></script> <!-- PDFJSSCRIPT_REMOVE -->
         <script type="text/javascript" src="../src/util.js"></script>  <!-- PDFJSSCRIPT_REMOVE -->
         <script type="text/javascript" src="../src/canvas.js"></script>  <!-- PDFJSSCRIPT_REMOVE -->
@@ -114,7 +114,7 @@
         </div>
      </div>
     </div>
-    
+
     <div id="loading">Loading... 0%</div>
     <div id="viewer"></div>
   </body>


### PR DESCRIPTION
Right now, turning on `useWorker` enables the worker in the production and debug build. But within the production build, the worker is constructed from the individual source files still.

This patch fixes this. It's now required to define the global variables `PDFJS_WORKER_FILE` and `PDFJS_WORKER_DIR` which determ how the web worker is created.
