### PR TITLE
Worker feature detection

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -545,7 +545,7 @@ var PDFDoc = (function pdfDoc() {
           case 'JpegStream':
             var IR = data[2];
             new JpegImage(id, IR, this.objs);
-          break;
+            break;
           case 'Font':
             var name = data[2];
             var file = data[3];
@@ -575,7 +575,7 @@ var PDFDoc = (function pdfDoc() {
               file: file,
               properties: properties
             });
-          break;
+            break;
           default:
             throw 'Got unkown object type ' + type;
         }

--- a/src/worker.js
+++ b/src/worker.js
@@ -47,6 +47,10 @@ var WorkerProcessorHandler = {
   setup: function wphSetup(handler) {
     var pdfDoc = null;
 
+    handler.on('test', function wphSetupTest(data) {
+      handler.send('test', data instanceof Uint8Array);
+    });
+
     handler.on('workerSrc', function wphSetupWorkerSrc(data) {
       // In development, the `workerSrc` message is handled in the
       // `worker_loader.js` file. In production the workerProcessHandler is

--- a/src/worker.js
+++ b/src/worker.js
@@ -43,7 +43,7 @@ MessageHandler.prototype = {
   }
 };
 
-var WorkerProcessorHandler = {
+var WorkerMessageHandler = {
   setup: function wphSetup(handler) {
     var pdfDoc = null;
 
@@ -188,6 +188,6 @@ if (typeof window === 'undefined') {
   globalScope.console = workerConsole;
 
   var handler = new MessageHandler('worker_processor', this);
-  WorkerProcessorHandler.setup(handler);
+  WorkerMessageHandler.setup(handler);
 }
 


### PR DESCRIPTION
This removes the `useWorker` flag and turns on worker support whenever the browser supports this. Adds a flag to the viewer.html (`viewer.html?worker=off`), that turns off worker support explicit.

@brendandahl has given some feedback during the implementation - can you take a look at this PR?
