### PR TITLE
Fix missing urlencoding of pdf urls in the extension

### DIFF
--- a/extensions/firefox/components/pdfContentHandler.js
+++ b/extensions/firefox/components/pdfContentHandler.js
@@ -56,7 +56,8 @@ pdfContentHandler.prototype = {
       throw NS_ERROR_WONT_HANDLE_CONTENT;
 
     aRequest.cancel(Cr.NS_BINDING_ABORTED);
-    window.location = url.replace('%s', targetUrl);
+    aRequest.cancel(Cr.NS_BINDING_ABORTED);
+    window.location = url.replace('%s', encodeURIComponent(targetUrl));
   },
 
   classID: Components.ID('{2278dfd0-b75c-11e0-8257-1ba3d93c9f1a}'),

--- a/extensions/firefox/components/pdfContentHandler.js
+++ b/extensions/firefox/components/pdfContentHandler.js
@@ -56,7 +56,6 @@ pdfContentHandler.prototype = {
       throw NS_ERROR_WONT_HANDLE_CONTENT;
 
     aRequest.cancel(Cr.NS_BINDING_ABORTED);
-    aRequest.cancel(Cr.NS_BINDING_ABORTED);
     window.location = url.replace('%s', encodeURIComponent(targetUrl));
   },
 


### PR DESCRIPTION
as I explained in issue #723 of andreasgal/pdf.js, the extension didn't urlencode the pdf url before passing it to the viewer, so any URL containing international characters or special url characters would prevent the viewer from loading the pdf.

You may prefer to fix this yourselves instead of using my clumsy commits, though.
