### PR TITLE
(firefox extension) Slimmed down toolbar height, from 40 to 24px.

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -18,11 +18,11 @@ body {
   background: -moz-linear-gradient(center bottom, #eee 0%, #fff 100%);
   background: -webkit-gradient(linear, left bottom, left top, color-stop(0.0, #ddd), color-stop(1.0, #fff));
   border-bottom: 1px solid #666;
-  padding: 4px;
+  padding: 3px;
   position: fixed;
   left: 0px;
   top: 0px;
-  height: 40px;
+  height: 24px;
   width: 100%;
   z-index: 1;
   white-space:nowrap;
@@ -33,22 +33,23 @@ body {
   display: inline;
   border-left: 1px solid #d3d3d3;
   border-right: 1px solid #fff;
-  height: 32px;
+  height: 16px;
   width:0px;
   margin: 4px;
 }
 
 #controls > a > img {
-  margin: 2px;
+    margin: 4px;
+    height: 16px;
 }
 
 #controls > button {
-  line-height: 32px;
+  line-height: 16px;
 }
 
 #controls > button > img {
-  width: 32px;
-  height: 32px;
+  width: 16px;
+  height: 16px;
 }
 
 #controls > button[disabled] > img {
@@ -60,7 +61,7 @@ body {
 }
 
 #fileInput {
-  line-height: 32px;
+  line-height: 16px;
 }
 
 span#info {

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -32,12 +32,12 @@
   <body>
     <div id="controls">
       <button id="previous" onclick="PDFView.page--;" oncontextmenu="return false;">
-        <img src="images/go-up.svg" align="top" height="32"/>
+        <img src="images/go-up.svg" align="top" height="16"/>
         Previous
       </button>
 
       <button id="next" onclick="PDFView.page++;" oncontextmenu="return false;">
-        <img src="images/go-down.svg" align="top" height="32"/>
+        <img src="images/go-down.svg" align="top" height="16"/>
         Next
       </button>
 
@@ -51,10 +51,10 @@
       <div class="separator"></div>
 
       <button id="zoomOut" title="Zoom Out" onclick="PDFView.zoomOut();" oncontextmenu="return false;">
-        <img src="images/zoom-out.svg" align="top" height="32"/>
+        <img src="images/zoom-out.svg" align="top" height="16"/>
       </button>
       <button id="zoomIn" title="Zoom In" onclick="PDFView.zoomIn();" oncontextmenu="return false;">
-        <img src="images/zoom-in.svg" align="top" height="32"/>
+        <img src="images/zoom-in.svg" align="top" height="16"/>
       </button>
 
       <div class="separator"></div>
@@ -74,12 +74,12 @@
       <div class="separator"></div>
 
       <button id="print" onclick="window.print();" oncontextmenu="return false;">
-        <img src="images/document-print.svg" align="top" height="32"/>
+        <img src="images/document-print.svg" align="top" height="16"/>
         Print
       </button>
 
       <button id="download" title="Download" onclick="PDFView.download();" oncontextmenu="return false;">
-        <img src="images/download.svg" align="top" height="32"/>
+        <img src="images/download.svg" align="top" height="16"/>
         Download
       </button>
 
@@ -89,8 +89,8 @@
 
       <div class="separator"></div>
 
-      <a href="#" id="viewBookmark" title="Current View (bookmark or copy the location)">
-        <img src="images/bookmark.svg" alt="Bookmark" align="top" height="32"/>
+      <a href="#" id="viewBookmark" title="Bookmark (or copy) current location">
+        <img src="images/bookmark.svg" alt="Bookmark" align="top" height="16"/>
       </a>
 
       <span id="info">--</span>
@@ -106,10 +106,10 @@
         </div>
         <div id="sidebarControls">
           <button id="thumbsSwitch" title="Show Thumbnails" onclick="PDFView.switchSidebarView('thumbs')" data-selected>
-            <img src="images/nav-thumbs.svg" align="top" height="32" alt="Thumbs" />
+            <img src="images/nav-thumbs.svg" align="top" height="16" alt="Thumbs" />
           </button>
           <button id="outlineSwitch" title="Show Document Outline" onclick="PDFView.switchSidebarView('outline')" disabled>
-            <img src="images/nav-outline.svg" align="top" height="32" alt="Document Outline" />
+            <img src="images/nav-outline.svg" align="top" height="16" alt="Document Outline" />
           </button>
         </div>
      </div>


### PR DESCRIPTION
This matches the height of the regular Firefox toolbars, 40px takes too
much screen space, and (in my opinion) unnecessarily so, since the fonts
are not even larger.

Great work btw, I can finally ditch chrome for firefox again.
