### PR TITLE
FIX: Removed unnecessary .bind in worker_loader.js that broke Safari

### DIFF
--- a/src/worker_loader.js
+++ b/src/worker_loader.js
@@ -49,4 +49,4 @@ function onMessageLoader(evt) {
   }
 }
 
-this.onmessage = onMessageLoader.bind(this);
+this.onmessage = onMessageLoader;


### PR DESCRIPTION
bind wasn't required, code works as expected without it as `this` is the event callback scope.
