### PR TITLE
Disable web worker on firefox 8-9 localhost using feature detection

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -15,10 +15,6 @@ if (!globalScope.PDFJS) {
   globalScope.PDFJS = {};
 }
 
-// Temporarily disabling workers until 'localhost' FF bugfix lands:
-// https://bugzilla.mozilla.org/show_bug.cgi?id=683280
-globalScope.PDFJS.disableWorker = true;
-
 // getPdf()
 // Convenience function to perform binary Ajax GET
 // Usage: getPdf('http://...', callback)
@@ -471,6 +467,7 @@ var PDFDoc = (function pdfDoc() {
     this.objs = new PDFObjects();
 
     this.pageCache = [];
+    this.fontsLoading = {};
     this.workerReadyPromise = new Promise('workerReady');
 
     // If worker support isn't disabled explicit and the browser has worker
@@ -484,7 +481,16 @@ var PDFDoc = (function pdfDoc() {
         throw 'No PDFJS.workerSrc specified';
       }
 
-      var worker = new Worker(workerSrc);
+      var worker
+      try {
+        worker = new Worker(workerSrc);
+      } catch (e) {
+        // Some versions of FF can't create a worker on localhost, see:
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=683280
+        globalScope.PDFJS.disableWorker = true;
+        this.setupFakeWorker();
+        return;
+      }
 
       var messageHandler = new MessageHandler('main', worker);
 
@@ -505,8 +511,6 @@ var PDFDoc = (function pdfDoc() {
     } else {
       this.setupFakeWorker();
     }
-
-    this.fontsLoading = {};
   }
 
   constructor.prototype = {

--- a/test/driver.js
+++ b/test/driver.js
@@ -7,6 +7,11 @@
 
 'use strict';
 
+// Disable worker support for running test as
+//   https://github.com/mozilla/pdf.js/pull/764#issuecomment-2638944
+//   "firefox-bin: Fatal IO error 12 (Cannot allocate memory) on X server :1."
+PDFJS.disableWorker = true;
+
 var appPath, browser, canvas, currentTaskIdx, manifest, stdout;
 var inFlightRequests = 0;
 


### PR DESCRIPTION
This turns on worker support by default, but turns it off again if there is an exception while creating the worker. This is necessary, as on Firefox 8-9 creating a worker from a `localhost://` url throws an error.

This does **not** turn on worker support for the tests. It's turned off explicit.

See meta issue #782.
