### PR TITLE
Fix two memory leaks in testing framework.

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -56,23 +56,31 @@ function load() {
 }
 
 function cleanup() {
-  var styleSheet = document.styleSheets[0];
-  if (styleSheet) {
-    while (styleSheet.cssRules.length > 0)
-      styleSheet.deleteRule(0);
+  // Clear out all the stylesheets since a new one is created for each font.
+  while (document.styleSheets.length > 0) {
+    var styleSheet = document.styleSheets[0];
+    if (styleSheet) {
+      while (styleSheet.cssRules.length > 0)
+        styleSheet.deleteRule(0);
+    }
+    var parent = styleSheet.ownerNode.parentNode;
+    parent.removeChild(styleSheet.ownerNode);
   }
   var guard = document.getElementById('content-end');
   var body = document.body;
   while (body.lastChild !== guard)
     body.removeChild(body.lastChild);
+
+  // Wipe out the link to the pdfdoc so it can be GC'ed.
+  for (var i = 0; i < manifest.length; i++) {
+    if (manifest[i].pdfDoc) {
+      manifest[i].pdfDoc.destroy();
+      delete manifest[i].pdfDoc
+    }
+  }
 }
 
 function nextTask() {
-  // If there is a pdfDoc on the last task executed, destroy it to free memory.
-  if (task && task.pdfDoc) {
-    task.pdfDoc.destroy();
-    delete task.pdfDoc;
-  }
   cleanup();
 
   if (currentTaskIdx == manifest.length) {

--- a/test/driver.js
+++ b/test/driver.js
@@ -59,12 +59,10 @@ function cleanup() {
   // Clear out all the stylesheets since a new one is created for each font.
   while (document.styleSheets.length > 0) {
     var styleSheet = document.styleSheets[0];
-    if (styleSheet) {
-      while (styleSheet.cssRules.length > 0)
-        styleSheet.deleteRule(0);
-    }
-    var parent = styleSheet.ownerNode.parentNode;
-    parent.removeChild(styleSheet.ownerNode);
+    while (styleSheet.cssRules.length > 0)
+      styleSheet.deleteRule(0);
+    var ownerNode = styleSheet.ownerNode;
+    ownerNode.parentNode.removeChild(ownerNode);
   }
   var guard = document.getElementById('content-end');
   var body = document.body;
@@ -75,7 +73,7 @@ function cleanup() {
   for (var i = 0; i < manifest.length; i++) {
     if (manifest[i].pdfDoc) {
       manifest[i].pdfDoc.destroy();
-      delete manifest[i].pdfDoc
+      delete manifest[i].pdfDoc;
     }
   }
 }


### PR DESCRIPTION
1) A new style tag is created for each font so we can no longer just wipe out the first one.
2) There was some code to unlink the pdfdoc from the manifest task but it was referring to a global that no longer exists.
