### PR TITLE
Add feature detection for using Uint8Array as imageData

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -5,6 +5,8 @@
 
 var globalScope = (typeof window === 'undefined') ? this : window;
 
+var isWorker = (typeof window == 'undefined');
+
 var ERRORS = 0, WARNINGS = 1, TODOS = 5;
 var verbosity = WARNINGS;
 

--- a/src/fonts.js
+++ b/src/fonts.js
@@ -3,8 +3,6 @@
 
 'use strict';
 
-var isWorker = (typeof window == 'undefined');
-
 /**
  * Maximum time to wait for a font to be loaded by font-face rules.
  */


### PR DESCRIPTION
Some browsers (like Firefox) can use Uint8Array directly as imageData in `ctx.putImageData`. This patch adds feature detection for this as well as enables it for supported browsers.
