### PR TITLE
Fix invalid arguments for certain fonts.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -558,20 +558,9 @@ var PDFDoc = (function pdfDoc() {
             var properties = data[4];
 
             if (file) {
+              // Rewrap the ArrayBuffer in a stream.
               var fontFileDict = new Dict();
-              fontFileDict.map = file.dict.map;
-
-              var fontFile = new Stream(file.bytes, file.start,
-                                        file.end - file.start, fontFileDict);
-
-              // Check if this is a FlateStream. Otherwise just use the created
-              // Stream one. This makes complex_ttf_font.pdf work.
-              var cmf = file.bytes[0];
-              if ((cmf & 0x0f) == 0x08) {
-                file = new FlateStream(fontFile);
-              } else {
-                file = fontFile;
-              }
+              file = new Stream(file, 0, file.length, fontFileDict);
             }
 
             // For now, resolve the font object here direclty. The real font

--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -155,6 +155,11 @@ var PartialEvaluator = (function partialEvaluator() {
             font.loadedName = loadedName;
 
             var translated = font.translated;
+            // Convert the file to an ArrayBuffer which will be turned back into
+            // a Stream in the main thread.
+            if (translated.file)
+              translated.file = translated.file.getBytes();
+
             handler.send('obj', [
                 loadedName,
                 'Font',

--- a/test/pdfs/protectip.pdf.link
+++ b/test/pdfs/protectip.pdf.link
@@ -1,0 +1,1 @@
+http://leahy.senate.gov/imo/media/doc/BillText-PROTECTIPAct.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -276,5 +276,12 @@
        "link": false,
        "rounds": 1,
        "type": "eq"
+    },
+    {  "id": "protectip",
+       "file": "pdfs/protectip.pdf",
+       "md5": "676e7a7b8f96d04825361832b1838a93",
+       "link": true,
+       "rounds": 1,
+       "type": "eq"
     }
 ]


### PR DESCRIPTION
Two pdf's in the corpus report were throwing an error of "invalid arguments".  This happened when a font had a stream that didn't have a bytes property.

I couldn't figure out how to build a test file without putting a lot of time into it, but I've linked to one that is small and hopefully won't change much.
