### PR TITLE
Addon fix

### DIFF
--- a/extensions/firefox/install.rdf
+++ b/extensions/firefox/install.rdf
@@ -12,7 +12,7 @@
       <Description>
        <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
        <em:minVersion>6.0</em:minVersion>
-       <em:maxVersion>11.0.*</em:maxVersion>
+       <em:maxVersion>11.0a1</em:maxVersion>
      </Description>
     </em:targetApplication>
     <em:bootstrap>true</em:bootstrap>
@@ -20,5 +20,6 @@
     <em:creator>Vivien Nicolas</em:creator>
     <em:description>pdf.js uri loader</em:description>
     <em:homepageURL>https://github.com/mozilla/pdf.js/</em:homepageURL>
+    <em:type>2</em:type>
   </Description>
 </RDF>

--- a/extensions/firefox/install.rdf
+++ b/extensions/firefox/install.rdf
@@ -6,7 +6,7 @@
   <Description about="urn:mozilla:install-manifest">
     <em:id>uriloader@pdf.js</em:id>
     <em:name>pdf.js</em:name>
-    <em:version>0.1</em:version>
+    <em:version>0.1.0</em:version>
 	  <em:iconURL>chrome://pdf.js/skin/logo.png</em:iconURL>
     <em:targetApplication>
       <Description>


### PR DESCRIPTION
Preparing for AMO. The only real error was that the version "11.0.*" was not acceptable:

https://addons.mozilla.org/en-US/firefox/pages/appversions/

The rest were just cosmetic/warnings.

@vingtetun
