### PR TITLE
replace isName in the viewer.js

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -168,7 +168,8 @@ var PDFView = {
         (destRef + 1);
       if (pageNumber) {
         var pdfOpenParams = '#page=' + pageNumber;
-        if (isName(dest[1], 'XYZ')) {
+        var destKind = dest[1];
+        if ('name' in destKind && destKind.name == 'XYZ') {
           var scale = (dest[4] || this.currentScale);
           pdfOpenParams += '&zoom=' + (scale * 100);
           if (dest[2] || dest[3]) {


### PR DESCRIPTION
The function isName is not available in the global namespace anymore
