### PR TITLE
Look for startxref further in from end if not found #828

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -382,11 +382,15 @@ var PDFDocModel = (function pdfDoc() {
           startXRef = stream.pos + 6;
       } else {
         // Find startxref at the end of the file.
-        var start = stream.end - 1024;
-        if (start < 0)
-          start = 0;
-        stream.pos = start;
-        if (find(stream, 'startxref', 1024, true)) {
+        var found = false, pos = stream.end;
+        while(!found && pos > 0) {
+          pos -= 1024;
+          if (pos < 0)
+            pos = 0;
+          stream.pos = pos;
+          found = find(stream, 'startxref', 1024, true);
+        }
+        if (found) {
           stream.skip(9);
           var ch;
           do {

--- a/src/core.js
+++ b/src/core.js
@@ -384,7 +384,7 @@ var PDFDocModel = (function pdfDoc() {
         // Find startxref at the end of the file.
         var found = false, pos = stream.end;
         while(!found && pos > 0) {
-          pos -= 1024;
+          pos -= 1024 - 9;
           if (pos < 0)
             pos = 0;
           stream.pos = pos;

--- a/src/core.js
+++ b/src/core.js
@@ -381,14 +381,15 @@ var PDFDocModel = (function pdfDoc() {
         if (find(stream, 'endobj', 1024))
           startXRef = stream.pos + 6;
       } else {
-        // Find startxref at the end of the file.
+        // Find startxref by jumping backward from the end of the file.
+        var step = 1024;
         var found = false, pos = stream.end;
-        while(!found && pos > 0) {
-          pos -= 1024 - 9;
+        while (!found && pos > 0) {
+          pos -= step - 'startxref'.length;
           if (pos < 0)
             pos = 0;
           stream.pos = pos;
-          found = find(stream, 'startxref', 1024, true);
+          found = find(stream, 'startxref', step, true);
         }
         if (found) {
           stream.skip(9);


### PR DESCRIPTION
PDFs provided in title issue have ~10k trailing characters before which comes a normal xref table.

(updated @arturadib): Link to issue #828
