### PR TITLE
Removed duplicate md5 entry

### DIFF
--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -20,7 +20,6 @@
     {  "id": "intelisa-load",
        "file": "pdfs/intelisa.pdf",
        "md5": "f5712097d29287a97f1278839814f682",
-       "md5": "f3ed5487d1afa34d8b77c0c734a95c79",
        "link": true,
        "rounds": 1,
        "type": "load"


### PR DESCRIPTION
@brendandahl Not sure how this happened, but we seem to have two md5 lines here.

Our bot tests keep giving warnings as it seems to ignore the first (see https://github.com/mozilla/pdf.js/pull/846#issuecomment-3020774).
