### PR TITLE
Fixes the unicode symbols on the text layer

### DIFF
--- a/src/fonts.js
+++ b/src/fonts.js
@@ -2142,7 +2142,8 @@ var Font = (function Font() {
           break;
       }
 
-      var unicodeChars = this.toUnicode ? this.toUnicode[charcode] : charcode;
+      var unicodeChars = !('toUnicode' in this) ? charcode :
+        this.toUnicode[charcode] || charcode;
       if (typeof unicodeChars === 'number')
         unicodeChars = String.fromCharCode(unicodeChars);
 


### PR DESCRIPTION
To reproduce: when text is copied from the test/pdfs/wdsg_fitc.pdf, "undefined" copied instead
