### PR TITLE
Throw error on # of pixels mismatch

### DIFF
--- a/src/image.js
+++ b/src/image.js
@@ -198,10 +198,6 @@ var PDFImage = (function pdfImage() {
       var opacityPos = 0;
       var length = width * height * 4;
 
-      // Is there a one-to-one correspondence between pixels in the loop below?
-      if (length !== 4 * comps.length / 3)
-        error('Number of image pixels mismatch (RGB)');
-
       for (var i = 0; i < length; i += 4) {
         buffer[i] = comps[compsPos++];
         buffer[i + 1] = comps[compsPos++];
@@ -225,10 +221,6 @@ var PDFImage = (function pdfImage() {
 
       var comps = this.getComponents(imgArray);
       var length = width * height;
-
-      // Is there a one-to-one correspondence between pixels in the loop below?
-      if (length !== comps.length)
-        error('Number of image pixels mismatch (Gray)');
 
       for (var i = 0; i < length; ++i)
         buffer[i] = comps[i];

--- a/src/image.js
+++ b/src/image.js
@@ -199,7 +199,7 @@ var PDFImage = (function pdfImage() {
       var length = width * height * 4;
 
       // Is there a one-to-one correspondence between pixels in the loop below?
-      if (length !== 4*comps.length/3)
+      if (length !== 4 * comps.length / 3)
         error('Number of image pixels mismatch (RGB)');
 
       for (var i = 0; i < length; i += 4) {

--- a/src/image.js
+++ b/src/image.js
@@ -200,7 +200,7 @@ var PDFImage = (function pdfImage() {
 
       // Is there a one-to-one correspondence between pixels in the loop below?
       if (length !== 4*comps.length/3)
-        error('Number of image pixels mismatch');
+        error('Number of image pixels mismatch (RGB)');
 
       for (var i = 0; i < length; i += 4) {
         buffer[i] = comps[compsPos++];
@@ -225,6 +225,10 @@ var PDFImage = (function pdfImage() {
 
       var comps = this.getComponents(imgArray);
       var length = width * height;
+
+      // Is there a one-to-one correspondence between pixels in the loop below?
+      if (length !== comps.length)
+        error('Number of image pixels mismatch (Gray)');
 
       for (var i = 0; i < length; ++i)
         buffer[i] = comps[i];

--- a/src/image.js
+++ b/src/image.js
@@ -198,6 +198,10 @@ var PDFImage = (function pdfImage() {
       var opacityPos = 0;
       var length = width * height * 4;
 
+      // Is there a one-to-one correspondence between pixels in the loop below?
+      if (length !== 4*comps.length/3)
+        error('Number of image pixels mismatch');
+
       for (var i = 0; i < length; i += 4) {
         buffer[i] = comps[compsPos++];
         buffer[i + 1] = comps[compsPos++];

--- a/src/parser.js
+++ b/src/parser.js
@@ -249,7 +249,7 @@ var Parser = (function parserParser() {
       if (name == 'CCITTFaxDecode' || name == 'CCF') {
         return new CCITTFaxStream(stream, params);
       }
-      TODO('filter "' + name + '" not supported yet');
+      warn('filter "' + name + '" not supported yet');
       return stream;
     }
   };


### PR DESCRIPTION
Following practice in `image.js` to throw `error()` on failed sanity checks.

Comes up in 2011-Horizon-Report (see #912).
