### PR TITLE
stop canvasRenderTextLayer blocking browser UI

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -361,7 +361,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
             textLayerQueue.splice(i, 1);
         }
         if (textLayerQueue.length == 0)
-          clearInterval(this.textLayerTimer);
+          clearInterval(self.textLayerTimer);
       }, 1);
     },
 

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -328,11 +328,12 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         return;
 
       var self = this;
+      var textDivIndex = 0;
       var renderTextLayer = function canvasRenderTextLayer() {
-        var finished = true;
+        var finished = false;
         var textDivs = self.textDivs;
-        if (textDivs.length > 0) {
-          var textDiv = textDivs.shift();
+        if (textDivIndex < textDivs.length) {
+          var textDiv = textDivs[textDivIndex++];
           if (textDiv.dataset.textLength > 1) { // avoid div by zero
             textLayer.appendChild(textDiv);
             // Adjust div width (via letterSpacing) to match canvas text
@@ -341,8 +342,9 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
               ((textDiv.dataset.canvasWidth - textDiv.offsetWidth) /
                (textDiv.dataset.textLength - 1)) + 'px';
           }
-          finished = false;
         }
+        else
+          finished = true;
         return finished;
       }
       var textLayerQueue = this.textLayerQueue;

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -356,7 +356,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         for (var i = textLayerQueue.length - 1; i >= 0; i--) {
           var finished = textLayerQueue[i].call();
           if (finished)
-            textLayerQueue.splice(i,1);
+            textLayerQueue.splice(i, 1);
         }
         if (textLayerQueue.length == 0)
           clearInterval(this.textLayerTimer);


### PR DESCRIPTION
Convert textLayerTimer to use setInterval instead of setTimeout to keep browser responsive while the text selection divs are added to the DOM.

A page with a large amount of text can block the browser for several seconds while the the text selection markup is added to the DOM.

This implementation adds a single div every millisecond so that the browser UI does not block and scrolling remains smooth.
