### PR TITLE
Cache Cmd object to reduce number of created objects

### DIFF
--- a/src/obj.js
+++ b/src/obj.js
@@ -25,13 +25,13 @@ var Cmd = (function CmdClosure() {
 
   var cmdCache = {};
 
-  Cmd.get = function(cmd) {
-    if (cmdCache[cmd]) {
-      return cmdCache[cmd];
-    } else {
-      return cmdCache[cmd] = new Cmd(cmd);
-    }
-  }
+  Cmd.get = function cmdGet(cmd) {
+    var cmdValue = cmdCache[cmd];
+    if (cmdValue)
+      return cmdValue;
+
+    return cmdCache[cmd] = new Cmd(cmd);
+  };
 
   return Cmd;
 })();

--- a/src/obj.js
+++ b/src/obj.js
@@ -22,6 +22,17 @@ var Cmd = (function CmdClosure() {
   Cmd.prototype = {
   };
 
+
+  var cmdCache = {};
+
+  Cmd.get = function(cmd) {
+    if (cmdCache[cmd]) {
+      return cmdCache[cmd];
+    } else {
+      return cmdCache[cmd] = new Cmd(cmd);
+    }
+  }
+
   return Cmd;
 })();
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -157,7 +157,7 @@ var Parser = (function ParserClosure() {
       imageStream = this.filter(imageStream, dict, length);
       imageStream.parameters = dict;
 
-      this.buf2 = new Cmd('EI');
+      this.buf2 = Cmd.get('EI');
       this.shift();
 
       return imageStream;
@@ -496,14 +496,14 @@ var Lexer = (function LexerClosure() {
         // array punctuation
         case '[':
         case ']':
-          return new Cmd(ch);
+          return Cmd.get(ch);
         // hex string or dict punctuation
         case '<':
           ch = stream.lookChar();
           if (ch == '<') {
             // dict punctuation
             stream.skip();
-            return new Cmd('<<');
+            return Cmd.get('<<');
           }
           return this.getHexString(ch);
         // dict punctuation
@@ -511,11 +511,11 @@ var Lexer = (function LexerClosure() {
           ch = stream.lookChar();
           if (ch == '>') {
             stream.skip();
-            return new Cmd('>>');
+            return Cmd.get('>>');
           }
         case '{':
         case '}':
-          return new Cmd(ch);
+          return Cmd.get(ch);
         // fall through
         case ')':
           error('Illegal character: ' + ch);
@@ -538,7 +538,7 @@ var Lexer = (function LexerClosure() {
         return false;
       if (str == 'null')
         return null;
-      return new Cmd(str);
+      return Cmd.get(str);
     },
     skipToNextLine: function lexerSkipToNextLine() {
       var stream = this.stream;


### PR DESCRIPTION
Every `Cmd` in PDF.JS is a object with a `cmd` string property. The number of different `cmd` strings used is somewhat in the region around 50 if rendering the first few pages of the `pdf.pdf` document. However, for each command, a new `Cmd` object is created, although the `Cmd` object with the same `cmd` value can get reused. E.g. in the case of the `pdf.pdf` document, if we render the first page, already 334.140 (!!!) `Cmd` objects are created.

This patch makes sure we create each `Cmd` object only once and reuse them.
