### PR TITLE
Add keyboard shortcuts to navigate pages forward and back

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -914,11 +914,13 @@ window.addEventListener('keydown', function keydown(evt) {
       break;
     case 37: // left arrow
     case 75: // 'k'
+    case 80: // 'p'
       PDFView.page--;
       handle = true;
       break;
     case 39: // right arrow
     case 74: // 'j'
+    case 78: // 'n'
       PDFView.page++;
       handle = true;
       break;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -912,6 +912,14 @@ window.addEventListener('keydown', function keydown(evt) {
       PDFView.setScale(kDefaultScale, true);
       handled = true;
       break;
+    case 37: // left arrow
+      PDFView.page--;
+      handle = true;
+      break;
+    case 39: // right arrow
+      PDFView.page++;
+      handle = true;
+      break;
   }
 
   if (handled) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -913,10 +913,12 @@ window.addEventListener('keydown', function keydown(evt) {
       handled = true;
       break;
     case 37: // left arrow
+    case 75: // 'k'
       PDFView.page--;
       handle = true;
       break;
     case 39: // right arrow
+    case 74: // 'j'
       PDFView.page++;
       handle = true;
       break;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -916,13 +916,13 @@ window.addEventListener('keydown', function keydown(evt) {
     case 75: // 'k'
     case 80: // 'p'
       PDFView.page--;
-      handle = true;
+      handled = true;
       break;
     case 39: // right arrow
     case 74: // 'j'
     case 78: // 'n'
       PDFView.page++;
-      handle = true;
+      handled = true;
       break;
   }
 


### PR DESCRIPTION
This branch adds keyboard shortcuts to navigate pages using:
- left and right arrow keys (like Adobe Reader.app and Apple's Preview.app)
- 'j' and 'k' keys like vi
- or 'n' and 'p' keys (Next/Previous mnemonic for our non-vi using friends)

I implemented these changes as separate commits so you could pull just the keyboard shortcuts you like. :)
