### PR TITLE
Fixes shortcuts steals from browser - Issue #979

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -937,6 +937,8 @@ window.addEventListener('pagechange', function pagechange(evt) {
 }, true);
 
 window.addEventListener('keydown', function keydown(evt) {
+  if (evt.ctrlKey || evt.altKey || evt.shiftKey || evt.metaKey)
+    return;
   var curElement = document.activeElement;
   if (curElement && curElement.tagName == 'INPUT')
     return;


### PR DESCRIPTION
As the title says, this simple pull request resolves issue #979, which is about the fact that our shortcut keys as they're implemented now steals the browser shortcut combinations like Ctrl+k to get to the search field and Ctrl+j to get downloads.

Maybe we should think of making a lightweight API for creating keyboard shortcuts. I've done something similar before and it's not really any problem. This would our way of settings shortcuts more "specific" instead of the switch statement we use now.
