### PR TITLE
Added fallback to fake worker if serialization of typed array fails.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -598,7 +598,7 @@ var PDFDoc = (function PDFDocClosure() {
         }.bind(this));
 
         var testObj = new Uint8Array(1);
-        // Some versions of Opera throw a DATA_CLONE_ERR on 
+        // Some versions of Opera throw a DATA_CLONE_ERR on
         // serializing the typed array.
         messageHandler.send('test', testObj);
         return;

--- a/src/core.js
+++ b/src/core.js
@@ -579,42 +579,34 @@ var PDFDoc = (function PDFDocClosure() {
         throw 'No PDFJS.workerSrc specified';
       }
 
-      var worker;
       try {
-        worker = new Worker(workerSrc);
-      } catch (e) {
         // Some versions of FF can't create a worker on localhost, see:
         // https://bugzilla.mozilla.org/show_bug.cgi?id=683280
-        globalScope.PDFJS.disableWorker = true;
-        this.setupFakeWorker();
-        return;
-      }
+        var worker = new Worker(workerSrc);
+        
+        var messageHandler = new MessageHandler('main', worker);
+        // Tell the worker the file it was created from.
+        messageHandler.send('workerSrc', workerSrc);
+        messageHandler.on('test', function pdfDocTest(supportTypedArray) {
+          if (supportTypedArray) {
+            this.worker = worker;
+            this.setupMessageHandler(messageHandler);
+          } else {
+            globalScope.PDFJS.disableWorker = true;
+            this.setupFakeWorker();
+          }
+        }.bind(this));
 
-      var messageHandler = new MessageHandler('main', worker);
-
-      // Tell the worker the file it was created from.
-      messageHandler.send('workerSrc', workerSrc);
-
-      messageHandler.on('test', function pdfDocTest(supportTypedArray) {
-        if (supportTypedArray) {
-          this.worker = worker;
-          this.setupMessageHandler(messageHandler);
-        } else {
-          this.setupFakeWorker();
-        }
-      }.bind(this));
-
-      var testObj = new Uint8Array(1);
-      // Some versions of Opera throw a DATA_CLONE_ERR on serializing the typed array.
-      // If such an error occurs, we fallback to a faked worker.
-      try {
+        var testObj = new Uint8Array(1);
+        // Some versions of Opera throw a DATA_CLONE_ERR on serializing the typed array.
         messageHandler.send('test', testObj);
-      } catch (e) {
-        this.setupFakeWorker();
-      }
-    } else {
-      this.setupFakeWorker();
+        return;
+      } catch (e) {}
     }
+    // Either workers are disabled, not suppored or have thrown an exception.
+    // Thus, we fallback to a faked worker.
+    globalScope.PDFJS.disableWorker = true;
+    this.setupFakeWorker();
   }
 
   PDFDoc.prototype = {

--- a/src/core.js
+++ b/src/core.js
@@ -605,7 +605,13 @@ var PDFDoc = (function PDFDocClosure() {
       }.bind(this));
 
       var testObj = new Uint8Array(1);
-      messageHandler.send('test', testObj);
+      // Some versions of Opera throw a DATA_CLONE_ERR on serializing the typed array.
+      // If such an error occurs, we fallback to a faked worker.
+      try {
+        messageHandler.send('test', testObj);
+      } catch (e) {
+        this.setupFakeWorker();
+      }
     } else {
       this.setupFakeWorker();
     }

--- a/src/core.js
+++ b/src/core.js
@@ -583,7 +583,7 @@ var PDFDoc = (function PDFDocClosure() {
         // Some versions of FF can't create a worker on localhost, see:
         // https://bugzilla.mozilla.org/show_bug.cgi?id=683280
         var worker = new Worker(workerSrc);
-        
+
         var messageHandler = new MessageHandler('main', worker);
         // Tell the worker the file it was created from.
         messageHandler.send('workerSrc', workerSrc);
@@ -598,7 +598,8 @@ var PDFDoc = (function PDFDocClosure() {
         }.bind(this));
 
         var testObj = new Uint8Array(1);
-        // Some versions of Opera throw a DATA_CLONE_ERR on serializing the typed array.
+        // Some versions of Opera throw a DATA_CLONE_ERR on 
+        // serializing the typed array.
         messageHandler.send('test', testObj);
         return;
       } catch (e) {}

--- a/src/core.js
+++ b/src/core.js
@@ -603,7 +603,7 @@ var PDFDoc = (function PDFDocClosure() {
         return;
       } catch (e) {}
     }
-    // Either workers are disabled, not suppored or have thrown an exception.
+    // Either workers are disabled, not supported or have thrown an exception.
     // Thus, we fallback to a faked worker.
     globalScope.PDFJS.disableWorker = true;
     this.setupFakeWorker();


### PR DESCRIPTION
This happens e.g. in Opera 11.60. Now PDF.js works again in Opera.
