### PR TITLE
Fixes concurrent pages loading (#974 and #626) 

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -527,8 +527,7 @@ var PDFDocModel = (function PDFDocModelClosure() {
                            this.startXRef,
                            this.mainXRefEntriesOffset);
       this.catalog = new Catalog(this.xref);
-      
-      if(this.xref.trailer && this.xref.trailer.has('ID')) {
+      if (this.xref.trailer && this.xref.trailer.has('ID')) {
         var fileID = '';
         this.xref.trailer.get('ID')[0].split('').forEach(function(el) {
           fileID += Number(el.charCodeAt(0)).toString(16);
@@ -543,14 +542,15 @@ var PDFDocModel = (function PDFDocModelClosure() {
       return shadow(this, 'numPages', num);
     },
     getFingerprint: function pdfDocGetFingerprint() {
-      if(this.fileID) {
+      if (this.fileID) {
         return this.fileID;
       } else {
-        // If we got no fileID, then we generate one, from the first 100 bytes of PDF
+        // If we got no fileID, then we generate one,
+        // from the first 100 bytes of PDF
         var data = this.stream.bytes.subarray(0, 100);
         var hash = calculateMD5(data, 0, data.length);
         var strHash = '';
-        for(var i = 0, length = hash.length; i < length; i++) {
+        for (var i = 0, length = hash.length; i < length; i++) {
           strHash += Number(hash[i]).toString(16);
         }
 

--- a/src/core.js
+++ b/src/core.js
@@ -542,6 +542,21 @@ var PDFDocModel = (function PDFDocModelClosure() {
       // shadow the prototype getter
       return shadow(this, 'numPages', num);
     },
+    getFingerprint: function pdfDocGetFingerprint() {
+      if(this.fileID) {
+        return this.fileID;
+      } else {
+        // If we got no fileID, then we generate one, from the first 100 bytes of PDF
+        var data = this.stream.bytes.subarray(0, 100);
+        var hash = calculateMD5(data, 0, data.length);
+        var strHash = '';
+        for(var i = 0, length = hash.length; i < length; i++) {
+          strHash += Number(hash[i]).toString(16);
+        }
+
+        return strHash;
+      }
+    },
     getPage: function pdfDocGetPage(n) {
       return this.catalog.getPage(n);
     }
@@ -568,7 +583,7 @@ var PDFDoc = (function PDFDocClosure() {
     this.data = data;
     this.stream = stream;
     this.pdf = new PDFDocModel(stream);
-    this.fileID = this.pdf.fileID;
+    this.fingerprint = this.pdf.getFingerprint();
     this.catalog = this.pdf.catalog;
     this.objs = new PDFObjects();
 

--- a/src/core.js
+++ b/src/core.js
@@ -527,6 +527,14 @@ var PDFDocModel = (function PDFDocModelClosure() {
                            this.startXRef,
                            this.mainXRefEntriesOffset);
       this.catalog = new Catalog(this.xref);
+      
+      if(this.xref.trailer && this.xref.trailer.has('ID')) {
+        var fileID = '';
+        this.xref.trailer.get('ID')[0].split('').forEach(function(el) {
+          fileID += Number(el.charCodeAt(0)).toString(16);
+        });
+        this.fileID = fileID;
+      }
     },
     get numPages() {
       var linearization = this.linearization;
@@ -560,7 +568,7 @@ var PDFDoc = (function PDFDocClosure() {
     this.data = data;
     this.stream = stream;
     this.pdf = new PDFDocModel(stream);
-
+    this.fileID = this.pdf.fileID;
     this.catalog = this.pdf.catalog;
     this.objs = new PDFObjects();
 

--- a/src/obj.js
+++ b/src/obj.js
@@ -273,7 +273,7 @@ var XRef = (function XRefClosure() {
     this.entries = [];
     this.xrefstms = {};
     var trailerDict = this.readXRef(startXRef);
-
+    this.trailer = trailerDict;
     // prepare the XRef cache
     this.cache = [];
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -26,7 +26,7 @@ var Cache = function cacheCache(size) {
 };
 
 // Settings Manager - This is a utility for saving settings
-// First we see if localStorage is available, which isn't pt. in FF due to bug #495747
+// First we see if localStorage is available, FF bug #495747
 // If not, we use FUEL in FF and fallback to Cookies for other browsers.
 var Settings = (function settingsClosure() {
   var isCookiesEnabled = (function() {
@@ -37,7 +37,7 @@ var Settings = (function settingsClosure() {
   var isLocalStorageEnabled = (function localStorageEnabledTest() {
     try {
       localStorage;
-    } catch(e) {
+    } catch (e) {
       return false;
     }
     return true;
@@ -47,25 +47,27 @@ var Settings = (function settingsClosure() {
 
   return {
     set: function settingsSet(name, val) {
-      if(location.protocol == 'chrome:' && !isLocalStorageEnabled) {
-        Application.prefs.setValue(extPrefix + '.' + name, val); 
-      } else if(isLocalStorageEnabled) {
+      if (location.protocol == 'chrome:' && !isLocalStorageEnabled) {
+        Application.prefs.setValue(extPrefix + '.' + name, val);
+      } else if (isLocalStorageEnabled) {
         localStorage.setItem(name, val);
-      } else if(isCookiesEnabled) {
+      } else if (isCookiesEnabled) {
         var cookieString = name + '=' + escape(val);
-        var expire = (new Date((new Date().getTime())+1000*60*60*24*365)).toGMTString();
-        cookieString += '; expires='+expire;
-        document.cookie = cookieString; 
-      } 
+        var expire = new Date();
+        expire.setTime(expire.getTime() + 1000 * 60 * 60 * 24 * 365);
+        cookieString += '; expires=' + expire.toGMTString();
+        document.cookie = cookieString;
+      }
     },
 
     get: function settingsGet(name, defaultValue) {
-      if(location.protocol == 'chrome:' && !isLocalStorageEnabled) {
-        return Application.prefs.getValue(extPrefix + '.' + name, defaultValue); 
-      } else if(isLocalStorageEnabled) {
+      if (location.protocol == 'chrome:' && !isLocalStorageEnabled) {
+        var preferenceName = extPrefix + '.' + name;
+        return Application.prefs.getValue(preferenceName, defaultValue);
+      } else if (isLocalStorageEnabled) {
         return localStorage.getItem(name) || defaultValue;
-      } else if(isCookiesEnabled) {
-        var res = document.cookie.match ( '(^|;) ?' + name + '=([^;]*)(;|$)' );
+      } else if (isCookiesEnabled) {
+        var res = document.cookie.match('(^|;) ?' + name + '=([^;]*)(;|$)');
         return res ? unescape(res[2]) : defaultValue;
       }
     }
@@ -360,7 +362,7 @@ var PDFView = {
         setTimeout(function scrollWindow() {
           window.scrollTo(0, scroll);
         }, 0);
-      } else 
+      } else
         this.page = 1;
     }
   },
@@ -885,10 +887,8 @@ function updateViewarea() {
 
 window.addEventListener('scroll', function webViewerScroll(evt) {
   updateViewarea();
-  var id;
-  if((id = PDFView.pages[0].content.pdf.fingerprint)) {
-    Settings.set(id+'.scroll', window.pageYOffset);
-  }
+  var fingerprint = PDFView.pages[0].content.pdf.fingerprint;
+  Settings.set(fingerprint + '.scroll', window.pageYOffset);
 }, true);
 
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -29,7 +29,7 @@ var Cache = function cacheCache(size) {
 // First we see if localStorage is available, FF bug #495747
 // If not, we use FUEL in FF and fallback to Cookies for other browsers.
 var Settings = (function settingsClosure() {
-  var isCookiesEnabled = (function() {
+  var isCookiesEnabled = (function cookiesEnabledTest() {
     document.cookie = 'they=work';
     return document.cookie.length > 0;
   })();

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -27,7 +27,7 @@ var Cache = function cacheCache(size) {
 
 // Settings Manager - This is a utility for saving settings
 // First we see if localStorage is available, FF bug #495747
-// If not, we use FUEL in FF and fallback to Cookies for other browsers.
+// If not, we use FUEL in FF
 var Settings = (function SettingsClosure() {
   var isLocalStorageEnabled = (function localStorageEnabledTest() {
     try {
@@ -390,7 +390,7 @@ var PDFView = {
     else if (storedHash) {
      this.setHash(storedHash);
     } else
-      window.scrollTo(0, 0); // Scroll to top is default.
+      this.page = 1;
   },
 
   setHash: function pdfViewSetHash(hash) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -28,7 +28,6 @@ var Cache = function cacheCache(size) {
 
 var RenderingQueue = (function RenderingQueueClosure() {
   function RenderingQueue() {
-    this.busy = false;
     this.items = [];
   }
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -347,7 +347,7 @@ var PDFView = {
       pagesRefMap[pageRef.num + ' ' + pageRef.gen + ' R'] = i;
     }
 
-    var id = pdf.fileID;
+    var id = pdf.fingerprint;
     if (id) {
       var scroll = Settings.get(id + '.scroll', -1);
       if (scroll != -1) {
@@ -895,9 +895,9 @@ function updateViewarea() {
 
 window.addEventListener('scroll', function webViewerScroll(evt) {
   updateViewarea();
-  var fileID;
-  if((fileID = PDFView.pages[0].content.pdf.fileID)) {
-    Settings.set(fileID+'.scroll', window.pageYOffset);
+  var id;
+  if((id = PDFView.pages[0].content.pdf.fingerprint)) {
+    Settings.set(id+'.scroll', window.pageYOffset);
   }
 }, true);
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -12,6 +12,7 @@ var kScrollbarPadding = 40;
 var kMinScale = 0.25;
 var kMaxScale = 4.0;
 var kImageDirectory = './images/';
+var kSettingsMemory = 20;
 
 var Cache = function cacheCache(size) {
   var data = [];
@@ -53,7 +54,7 @@ var Settings = (function SettingsClosure() {
     database = JSON.parse(database);
     if (!('files' in database))
       database.files = [];
-    if (database.files.length >= 20)
+    if (database.files.length >= kSettingsMemory)
       database.files.shift();
     for (var i = 0, length = database.files.length; i < length; i++) {
       var branch = database.files[i];
@@ -77,10 +78,9 @@ var Settings = (function SettingsClosure() {
     set: function settingsSet(name, val) {
       var file = this.file;
       file[name] = val;
-      if (isExtension) {
+      if (isExtension)
         Application.prefs.setValue(extPrefix + '.database',
             JSON.stringify(this.database));
-      }
       else if (isLocalStorageEnabled)
         localStorage.setItem('database', JSON.stringify(this.database));
     },
@@ -387,9 +387,9 @@ var PDFView = {
       this.setHash(this.initialBookmark);
       this.initialBookmark = null;
     }
-    else if (storedHash) {
+    else if (storedHash)
      this.setHash(storedHash);
-    } else
+    else
       this.page = 1;
   },
 


### PR DESCRIPTION
Continuation/extension of the #974. Adds the queue to render pages in sequence. Loading multiple pages at once generate undesirable results (see second page of the fit11-talk of #626) .

@jviereck, if you have time, could you review this one?
