### PR TITLE
Always add style element to the head

### DIFF
--- a/src/fonts.js
+++ b/src/fonts.js
@@ -2092,7 +2092,7 @@ var Font = (function FontClosure() {
                  window.btoa(data) + ');');
       var rule = "@font-face { font-family:'" + fontName + "';src:" + url + '}';
 
-      document.documentElement.firstChild.appendChild(
+      document.documentElement.getElementsByTagName('head')[0].appendChild(
         document.createElement('style'));
 
       var styleSheet = document.styleSheets[document.styleSheets.length - 1];


### PR DESCRIPTION
My first element was a comment and was throwing on this line. I think it's safer to explicitly look for the head tag and add it there, not sure if there are performance implications tough.
