### PR TITLE
Webkit dashed line support

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -361,6 +361,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     setDash: function canvasGraphicsSetDash(dashArray, dashPhase) {
       this.ctx.mozDash = dashArray;
       this.ctx.mozDashOffset = dashPhase;
+      this.ctx.webkitLineDash = dashArray;
+      this.ctx.webkitLineDashOffset = dashPhase;
     },
     setRenderingIntent: function canvasGraphicsSetRenderingIntent(intent) {
       TODO('set rendering intent: ' + intent);


### PR DESCRIPTION
As per #1012.

Notice that Google Canary (as of today) still doesn't support `webkitLineDash*`. We can test this PR when it does.
