### PR TITLE
Reset scale value on opening new file

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -437,6 +437,10 @@ var PDFView = {
       this.switchSidebarView('outline');
     }
 
+    // Reset the current scale, as otherwise the page's scale might not get
+    // updated if the zoom level stayed the same.
+    this.currentScale = 0;
+    this.currentScaleValue = null;
     if (this.initialBookmark) {
       this.setHash(this.initialBookmark);
       this.initialBookmark = null;


### PR DESCRIPTION
Assume one opens the viewer with PDF file A and later on opens file B in the same viewer instance. If the zoom level stays the same for file A and file B (where zoom level means the "real", parsed percentage scale value), https://github.com/mozilla/pdf.js/blob/master/web/viewer.js#L153 will be true still. But then the `page.scale` value is not set, as the `pages[i].update(...)` function is not called (see https://github.com/mozilla/pdf.js/blob/master/web/viewer.js#L158).

This patch resets the `PDFView.currentScale` value such that https://github.com/mozilla/pdf.js/blob/master/web/viewer.js#L153 won't eval to true whenever a new page is opened and therefore the `page.scale` value is set.
