### PR TITLE
Decode JPEGs using browser when possible

### DIFF
--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -211,7 +211,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         args = [objId, w, h];
 
         var softMask = dict.get('SMask', 'IM') || false;
-        if (!softMask && image instanceof JpegStream && image.isNative) {
+        if (!softMask && image instanceof JpegStream &&
+            image.isNativelySupported(xref, resources)) {
           // These JPEGs don't need any more processing so we can just send it.
           fn = 'paintJpegXObject';
           handler.send('obj', [objId, 'JpegStream', image.getIR()]);

--- a/src/image.js
+++ b/src/image.js
@@ -9,7 +9,7 @@ var PDFImage = (function PDFImageClosure() {
    * when the image data is ready.
    */
   function handleImageData(handler, xref, res, image, promise) {
-    if (image instanceof JpegStream && image.isNative) {
+    if (image instanceof JpegStream && image.isNativelyDecodable(xref, res)) {
       // For natively supported jpegs send them to the main thread for decoding.
       var dict = image.dict;
       var colorSpace = dict.get('ColorSpace', 'CS');

--- a/src/stream.js
+++ b/src/stream.js
@@ -819,7 +819,6 @@ var JpegStream = (function JpegStreamClosure() {
   JpegStream.prototype = Object.create(DecodeStream.prototype);
 
   JpegStream.prototype.ensureBuffer = function jpegStreamEnsureBuffer(req) {
-    // todo make sure this isn't called on natively supported jpegs
     if (this.bufferLength)
       return;
     var jpegImage = new JpegImage();
@@ -844,6 +843,8 @@ var JpegStream = (function JpegStreamClosure() {
   JpegStream.prototype.isNativelySupported = function isNativelySupported(xref,
                                                                           res) {
     var cs = ColorSpace.parse(this.dict.get('ColorSpace'), xref, res);
+    // when bug 674619 lands, let's check if browser can do
+    // normal cmyk and then we won't need to decode in JS
     if (cs.name === 'DeviceGray' || cs.name === 'DeviceRGB')
       return true;
     if (cs.name === 'DeviceCMYK' && !this.isAdobeImage &&

--- a/src/stream.js
+++ b/src/stream.js
@@ -803,8 +803,8 @@ var JpegStream = (function JpegStreamClosure() {
     // need to be removed
     this.dict = dict;
 
-    this.colorTransform = dict.get('ColorTransform') || -1;
     this.isAdobeImage = false;
+    this.colorTransform = dict.get('ColorTransform') || -1;
 
     if (isAdobeImage(bytes)) {
       this.isAdobeImage = true;
@@ -822,7 +822,8 @@ var JpegStream = (function JpegStreamClosure() {
     if (this.bufferLength)
       return;
     var jpegImage = new JpegImage();
-    jpegImage.colorTransform = this.colorTransform;
+    if (this.colorTransform != -1)
+      jpegImage.colorTransform = this.colorTransform;
     jpegImage.parse(this.bytes);
     var width = jpegImage.width;
     var height = jpegImage.height;
@@ -858,7 +859,8 @@ var JpegStream = (function JpegStreamClosure() {
   JpegStream.prototype.isNativelyDecodable = function isNativelyDecodable(xref,
                                                                           res) {
     var cs = ColorSpace.parse(this.dict.get('ColorSpace'), xref, res);
-    if (cs.numComps == 1 || cs.numComps == 3)
+    var numComps = cs.numComps;
+    if (numComps == 1 || numComps == 3)
       return true;
 
     return false;


### PR DESCRIPTION
Previously some images were using jpg.js that could actually be decoded by the browser. They're now decoded using the browser then sent back to apply the needed color conversions.
