### PR TITLE
IE9 subarray method not defined

### DIFF
--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -14,7 +14,7 @@
   }
 
   function subarray(start, end) {
-    return this.slice(start, end);
+    return new TypedArray(this.slice(start, end));
   }
 
   function setArrayOffset(array, offset) {


### PR DESCRIPTION
fix for issue #1027 (https://github.com/mozilla/pdf.js/issues/1027)
