### PR TITLE
Add error backs for promises.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -398,17 +398,25 @@ var Page = (function PageClosure() {
       }
 
       // Once the IRQueue and fonts are loaded, perform the actual rendering.
-      this.displayReadyPromise.then(function pageDisplayReadyPromise() {
-        var gfx = new CanvasGraphics(ctx, this.objs, textLayer);
-        try {
-          this.display(gfx, callback);
-        } catch (e) {
-          if (self.callback)
-            self.callback(e);
+      this.displayReadyPromise.then(
+        function pageDisplayReadyPromise() {
+          var gfx = new CanvasGraphics(ctx, this.objs, textLayer);
+          try {
+            this.display(gfx, callback);
+          } catch (e) {
+            if (callback)
+              callback(e);
+            else
+              throw e;
+          }
+        }.bind(this),
+        function pageDisplayReadPromiseError(reason) {
+          if (callback)
+            callback(reason);
           else
-            throw e;
+            throw reason;
         }
-      }.bind(this));
+      );
     }
   };
 
@@ -722,8 +730,8 @@ var PDFDoc = (function PDFDocClosure() {
 
       messageHandler.on('page_error', function pdfDocError(data) {
         var page = this.pageCache[data.pageNum];
-        if (page.callback)
-          page.callback(data.error);
+        if (page.displayReadyPromise) {
+          page.displayReadyPromise.reject(data.error);}
         else
           throw data.error;
       }, this);

--- a/src/core.js
+++ b/src/core.js
@@ -730,8 +730,8 @@ var PDFDoc = (function PDFDocClosure() {
 
       messageHandler.on('page_error', function pdfDocError(data) {
         var page = this.pageCache[data.pageNum];
-        if (page.displayReadyPromise) {
-          page.displayReadyPromise.reject(data.error);}
+        if (page.displayReadyPromise)
+          page.displayReadyPromise.reject(data.error);
         else
           throw data.error;
       }, this);

--- a/src/util.js
+++ b/src/util.js
@@ -206,6 +206,8 @@ var Promise = (function PromiseClosure() {
    */
   function Promise(name, data) {
     this.name = name;
+    this.isRejected = false;
+    this.error = null;
     // If you build a promise and pass in some data it's already resolved.
     if (data != null) {
       this.isResolved = true;
@@ -216,6 +218,7 @@ var Promise = (function PromiseClosure() {
       this._data = EMPTY_PROMISE;
     }
     this.callbacks = [];
+    this.errbacks = [];
   };
   /**
    * Builds a promise that is resolved when all the passed in promises are
@@ -282,6 +285,9 @@ var Promise = (function PromiseClosure() {
       if (this.isResolved) {
         throw 'A Promise can be resolved only once ' + this.name;
       }
+      if (this.isRejected) {
+        throw 'The Promise was already rejected ' + this.name;
+      }
 
       this.isResolved = true;
       this.data = data || null;
@@ -292,7 +298,24 @@ var Promise = (function PromiseClosure() {
       }
     },
 
-    then: function promiseThen(callback) {
+    reject: function proimseReject(reason) {
+      if (this.isRejected) {
+        throw 'A Promise can be rejected only once ' + this.name;
+      }
+      if (this.isResolved) {
+        throw 'The Promise was already resolved ' + this.name;
+      }
+
+      this.isRejected = true;
+      this.error = reason || null;
+      var errbacks = this.errbacks;
+
+      for (var i = 0, ii = errbacks.length; i < ii; i++) {
+        errbacks[i].call(null, reason);
+      }
+    },
+
+    then: function promiseThen(callback, errback) {
       if (!callback) {
         throw 'Requiring callback' + this.name;
       }
@@ -301,8 +324,13 @@ var Promise = (function PromiseClosure() {
       if (this.isResolved) {
         var data = this.data;
         callback.call(null, data);
+      } else if (this.isRejected && errorback) {
+        var error = this.error;
+        errback.call(null, error);
       } else {
         this.callbacks.push(callback);
+        if (errback)
+          this.errbacks.push(errback);
       }
     }
   };


### PR DESCRIPTION
#957 made it so the start rendering call back was never called on errors.  To support this I've added an errrback to promise.then.  This follows the commonjs promise/a spec.

At this point I'm tempted to just switch to use a full blown promise library such as https://github.com/briancavalier/when.js which is well tested and very light.  If anyone else thinks this would be worthwhile I'd be happy to implement such a thing.
