### PR TITLE
Disable default browser check in FF testing

### DIFF
--- a/test/resources/firefox/prefs.js
+++ b/test/resources/firefox/prefs.js
@@ -1,0 +1,1 @@
+user_pref("browser.shell.checkDefaultBrowser", false);


### PR DESCRIPTION
Hopefully this disables the "default browser" dialog when running `make test`.
