### PR TITLE
Auto updatable github extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ DEFAULT_BROWSERS := resources/browser_manifests/browser_manifest.json
 DEFAULT_TESTS := test_manifest.json
 
 EXTENSION_SRC := ./extensions/
+EXTENSION_BASE_VERSION := 4bb289ec499013de66eb421737a4dbb4a9273eda
 FIREFOX_EXTENSION_NAME := pdf.js.xpi
+FIREFOX_AMO_EXTENSION_NAME := pdf.js.amo.xpi
 CHROME_EXTENSION_NAME := pdf.js.crx
 
 all: bundle
@@ -147,7 +149,7 @@ web: | production extension compiler pages-repo
 	@cp $(BUILD_TARGET) $(GH_PAGES)/$(BUILD_TARGET)
 	@cp -R web/* $(GH_PAGES)/web
 	@cp web/images/* $(GH_PAGES)/web/images
-	@cp $(EXTENSION_SRC)/firefox/*.xpi $(GH_PAGES)/$(EXTENSION_SRC)/firefox/
+	@cp $(FIREFOX_BUILD_DIR)/$(FIREFOX_EXTENSION_NAME) $(FIREFOX_BUILD_DIR)/update.rdf $(GH_PAGES)/$(EXTENSION_SRC)/firefox/
 	@cp $(GH_PAGES)/web/index.html.template $(GH_PAGES)/index.html;
 	@mv -f $(GH_PAGES)/web/viewer-production.html $(GH_PAGES)/web/viewer.html;
 	@cd $(GH_PAGES); git add -A;
@@ -190,8 +192,7 @@ pages-repo: | $(BUILD_DIR)
 # This target produce a restartless firefox extension containing a
 # copy of the pdf.js source.
 CONTENT_DIR := content
-FIREFOX_CONTENT_DIR := $(EXTENSION_SRC)/firefox/$(CONTENT_DIR)/
-CHROME_CONTENT_DIR := $(EXTENSION_SRC)/chrome/$(CONTENT_DIR)/
+BUILD_NUMBER := `git log --format=oneline $(EXTENSION_BASE_VERSION).. | wc -l | awk '{print $$1}'`
 PDF_WEB_FILES = \
 	web/images \
 	web/compatibility.js \
@@ -199,26 +200,66 @@ PDF_WEB_FILES = \
 	web/viewer.js \
 	web/viewer-production.html \
 	$(NULL)
+
+FIREFOX_BUILD_DIR := $(BUILD_DIR)/firefox
+FIREFOX_BUILD_CONTENT := $(FIREFOX_BUILD_DIR)/$(CONTENT_DIR)/
+FIREFOX_CONTENT_DIR := $(EXTENSION_SRC)/firefox/$(CONTENT_DIR)/
+FIREFOX_EXTENSION_FILES_TO_COPY = \
+	*.js \
+	*.rdf \
+	chrome.manifest \
+	components \
+	$(NULL)
+FIREFOX_EXTENSION_FILES = \
+	content \
+	*.js \
+	install.rdf \
+	chrome.manifest \
+	components \
+	content \
+	$(NULL)
+
+CHROME_BUILD_DIR := $(BUILD_DIR)/chrome
+CHROME_CONTENT_DIR := $(EXTENSION_SRC)/chrome/$(CONTENT_DIR)/
+CHROME_BUILD_CONTENT := $(CHROME_BUILD_DIR)/$(CONTENT_DIR)/
+CHROME_EXTENSION_FILES = \
+	extensions/chrome/*.json \
+	extensions/chrome/*.html \
+	$(NULL)
 extension: | production
+	# Clear out everything in the firefox extension build directory
+	@rm -Rf $(FIREFOX_BUILD_DIR)
+	@mkdir -p $(FIREFOX_BUILD_CONTENT)
+	@mkdir -p $(FIREFOX_BUILD_CONTENT)/$(BUILD_DIR)
+	@mkdir -p $(FIREFOX_BUILD_CONTENT)/web
+	@cd extensions/firefox; cp -r $(FIREFOX_EXTENSION_FILES_TO_COPY) ../../$(FIREFOX_BUILD_DIR)/
 	# Copy a standalone version of pdf.js inside the content directory
-	@rm -Rf $(FIREFOX_CONTENT_DIR)
-	@mkdir -p $(FIREFOX_CONTENT_DIR)/$(BUILD_DIR)
-	@mkdir -p $(FIREFOX_CONTENT_DIR)/web
-	@cp $(BUILD_TARGET) $(FIREFOX_CONTENT_DIR)/$(BUILD_DIR)
-	@cp -r $(PDF_WEB_FILES) $(FIREFOX_CONTENT_DIR)/web/
-	@mv -f $(FIREFOX_CONTENT_DIR)/web/viewer-production.html $(FIREFOX_CONTENT_DIR)/web/viewer.html
-
+	@cp $(BUILD_TARGET) $(FIREFOX_BUILD_CONTENT)/$(BUILD_DIR)/
+	@cp -r $(PDF_WEB_FILES) $(FIREFOX_BUILD_CONTENT)/web/
+	@mv -f $(FIREFOX_BUILD_CONTENT)/web/viewer-production.html $(FIREFOX_BUILD_CONTENT)/web/viewer.html
+	# Update the build version number
+	@sed -i.bak "s/PDFJSSCRIPT_BUILD/$(BUILD_NUMBER)/" $(FIREFOX_BUILD_DIR)/install.rdf
+	@sed -i.bak "s/PDFJSSCRIPT_BUILD/$(BUILD_NUMBER)/" $(FIREFOX_BUILD_DIR)/update.rdf
+	@rm -f $(FIREFOX_BUILD_DIR)/*.bak
 	# Create the xpi
-	@cd $(EXTENSION_SRC)/firefox; zip -r $(FIREFOX_EXTENSION_NAME) *
+	@cd $(FIREFOX_BUILD_DIR); zip -r $(FIREFOX_EXTENSION_NAME) $(FIREFOX_EXTENSION_FILES)
 	@echo "extension created: " $(FIREFOX_EXTENSION_NAME)
+	# Build the amo extension too (remove the updateUrl)
+	@sed -i.bak "/updateURL/d" $(FIREFOX_BUILD_DIR)/install.rdf
+	@rm -f $(FIREFOX_BUILD_DIR)/*.bak
+	@cd $(FIREFOX_BUILD_DIR); zip -r $(FIREFOX_AMO_EXTENSION_NAME) $(FIREFOX_EXTENSION_FILES)
+	@echo "AMO extension created: " $(FIREFOX_AMO_EXTENSION_NAME)
 
-  # Copy a standalone version of pdf.js inside the extension directory
-	@rm -Rf $(CHROME_CONTENT_DIR)
-	@mkdir -p $(CHROME_CONTENT_DIR)/$(BUILD_DIR)
-	@mkdir -p $(CHROME_CONTENT_DIR)/web
-	@cp $(BUILD_TARGET) $(CHROME_CONTENT_DIR)/$(BUILD_DIR)
-	@cp -r $(PDF_WEB_FILES) $(CHROME_CONTENT_DIR)/web/
-	@mv -f $(CHROME_CONTENT_DIR)/web/viewer-production.html $(CHROME_CONTENT_DIR)/web/viewer.html
+	# Clear out everything in the chrome extension build directory
+	@rm -Rf $(CHROME_BUILD_DIR)
+	@mkdir -p $(CHROME_BUILD_CONTENT)
+	@mkdir -p $(CHROME_BUILD_CONTENT)/$(BUILD_DIR)
+	@mkdir -p $(CHROME_BUILD_CONTENT)/web
+	@cp -R $(CHROME_EXTENSION_FILES) $(CHROME_BUILD_DIR)/
+	# Copy a standalone version of pdf.js inside the content directory
+	@cp $(BUILD_TARGET) $(CHROME_BUILD_CONTENT)/$(BUILD_DIR)/
+	@cp -r $(PDF_WEB_FILES) $(CHROME_BUILD_CONTENT)/web/
+	@mv -f $(CHROME_BUILD_CONTENT)/web/viewer-production.html $(CHROME_BUILD_CONTENT)/web/viewer.html
 
   # Create the crx
   #TODO

--- a/extensions/firefox/install.rdf
+++ b/extensions/firefox/install.rdf
@@ -6,7 +6,7 @@
   <Description about="urn:mozilla:install-manifest">
     <em:id>uriloader@pdf.js</em:id>
     <em:name>pdf.js</em:name>
-    <em:version>0.1.0</em:version>
+    <em:version>0.2.PDFJSSCRIPT_BUILD</em:version>
 	  <em:iconURL>chrome://pdf.js/skin/logo.png</em:iconURL>
     <em:targetApplication>
       <Description>
@@ -17,9 +17,10 @@
     </em:targetApplication>
     <em:bootstrap>true</em:bootstrap>
     <em:unpack>true</em:unpack>
-    <em:creator>Vivien Nicolas</em:creator>
+    <em:creator>Mozilla Labs</em:creator>
     <em:description>pdf.js uri loader</em:description>
     <em:homepageURL>https://github.com/mozilla/pdf.js/</em:homepageURL>
     <em:type>2</em:type>
+    <em:updateURL>https://github.com/mozilla/pdf.js/raw/gh-pages/extensions/firefox/update.rdf</em:updateURL>
   </Description>
 </RDF>

--- a/extensions/firefox/install.rdf
+++ b/extensions/firefox/install.rdf
@@ -21,6 +21,7 @@
     <em:description>pdf.js uri loader</em:description>
     <em:homepageURL>https://github.com/mozilla/pdf.js/</em:homepageURL>
     <em:type>2</em:type>
+    <!-- Use the raw link for updates so we we can use SSL. -->
     <em:updateURL>https://github.com/mozilla/pdf.js/raw/gh-pages/extensions/firefox/update.rdf</em:updateURL>
   </Description>
 </RDF>

--- a/extensions/firefox/update.rdf
+++ b/extensions/firefox/update.rdf
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<RDF:RDF xmlns:RDF="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:em="http://www.mozilla.org/2004/em-rdf#">
+
+  <RDF:Description about="urn:mozilla:extension:uriloader@pdf.js">
+    <em:updates>
+      <RDF:Seq>
+        <RDF:li>
+          <RDF:Description>
+            <em:version>0.2.PDFJSSCRIPT_BUILD</em:version>
+            <em:targetApplication>
+              <RDF:Description>
+                <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
+                <em:minVersion>6.0</em:minVersion>
+                <em:maxVersion>11.*</em:maxVersion>
+                <em:updateLink>https://github.com/mozilla/pdf.js/raw/gh-pages/extensions/firefox/pdf.js.xpi</em:updateLink>
+              </RDF:Description>
+            </em:targetApplication>
+          </RDF:Description>
+        </RDF:li>
+      </RDF:Seq>
+    </em:updates>
+  </RDF:Description>
+</RDF:RDF>

--- a/extensions/firefox/update.rdf
+++ b/extensions/firefox/update.rdf
@@ -14,6 +14,7 @@
                 <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
                 <em:minVersion>6.0</em:minVersion>
                 <em:maxVersion>11.*</em:maxVersion>
+                <!-- Use the raw link so we we can use SSL. -->
                 <em:updateLink>https://github.com/mozilla/pdf.js/raw/gh-pages/extensions/firefox/pdf.js.xpi</em:updateLink>
               </RDF:Description>
             </em:targetApplication>

--- a/extensions/firefox/update.rdf
+++ b/extensions/firefox/update.rdf
@@ -14,7 +14,7 @@
                 <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
                 <em:minVersion>6.0</em:minVersion>
                 <em:maxVersion>11.*</em:maxVersion>
-                <!-- Use the raw link so we we can use SSL. -->
+                <!-- Use the raw link for updates so we we can use SSL. -->
                 <em:updateLink>https://github.com/mozilla/pdf.js/raw/gh-pages/extensions/firefox/pdf.js.xpi</em:updateLink>
               </RDF:Description>
             </em:targetApplication>


### PR DESCRIPTION
Makes the extension on our github site support automatic updating.  The github version could be considered our nightly build.

If you missed the IRC conversation the plan is the last version number will get incremented every time we merge, but it will be how many merges from a certain commit.  So each time we want to bump the middle version number we'll update the EXTENSION_BASE_VERSION variable to reset the third version number.

To support AMO we now build two extensions, one with the updateUrl and one without.

I also did some cleaning and moved all the extension building into the "build" folder, so build clean actually wipes out stuff.

PS My Makefile knowledge isn't comprehensive so if I violated some known best practices let me know.
