### PR TITLE
zoom not always stored correctly in local storage

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1021,9 +1021,7 @@ function updateViewarea() {
   updateViewarea.inProgress = false;
 
   var currentScale = PDFView.currentScale;
-  var currentScaleValue = PDFView.currentScaleValue;
-  var normalizedScaleValue = currentScaleValue == currentScale != null ?
-    currentScale * 100 : currentScaleValue;
+  var normalizedScaleValue = currentScale * 100;
 
   var kViewerTopMargin = 52;
   var pageNumber = firstPage.id;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1074,7 +1074,7 @@ function updateViewarea() {
   updateViewarea.inProgress = false;
 
   var currentScale = PDFView.currentScale;
-  var normalizedScaleValue = currentScale * 100;
+  var normalizedScaleValue = isStringScaleSelected() ? PDFView.currentScaleValue : currentScale * 100;
 
   var kViewerTopMargin = 52;
   var pageNumber = firstPage.id;
@@ -1123,9 +1123,7 @@ window.addEventListener('transitionend', updateThumbViewArea, true);
 window.addEventListener('webkitTransitionEnd', updateThumbViewArea, true);
 
 window.addEventListener('resize', function webViewerResize(evt) {
-  if (document.getElementById('pageWidthOption').selected ||
-      document.getElementById('pageFitOption').selected ||
-      document.getElementById('pageAutoOption').selected)
+  if (isStringScaleSelected())
       PDFView.parseScale(document.getElementById('scaleSelect').value);
   updateViewarea();
 });
@@ -1177,14 +1175,18 @@ function selectScaleOption(value) {
   return predefinedValueFound;
 }
 
+function isStringScaleSelected() {
+	 return (document.getElementById('pageWidthOption').selected ||
+             document.getElementById('pageFitOption').selected ||
+             document.getElementById('pageAutoOption').selected);
+}
+
 window.addEventListener('scalechange', function scalechange(evt) {
   var customScaleOption = document.getElementById('customScaleOption');
   customScaleOption.selected = false;
 
   if (!evt.resetAutoSettings &&
-       (document.getElementById('pageWidthOption').selected ||
-        document.getElementById('pageFitOption').selected ||
-        document.getElementById('pageAutoOption').selected)) {
+       isStringScaleSelected()) {
       updateViewarea();
       return;
   }

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1022,7 +1022,7 @@ function updateViewarea() {
 
   var currentScale = PDFView.currentScale;
   var currentScaleValue = PDFView.currentScaleValue;
-  var normalizedScaleValue = currentScaleValue == currentScale ?
+  var normalizedScaleValue = currentScaleValue == currentScale != null ?
     currentScale * 100 : currentScaleValue;
 
   var kViewerTopMargin = 52;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1074,9 +1074,7 @@ function updateViewarea() {
   updateViewarea.inProgress = false;
 
   var currentScale = PDFView.currentScale;
-  var currentScaleValue = PDFView.currentScaleValue;
-  var normalizedScaleValue = currentScaleValue == currentScale ?
-    currentScale * 100 : currentScaleValue;
+  var normalizedScaleValue = currentScale * 100;
 
   var kViewerTopMargin = 52;
   var pageNumber = firstPage.id;


### PR DESCRIPTION
I've noticed the viewer does not always store the zoom value correctly.  For example, when zooming out and going below 100% there are times when the value that is stored will be less than 1.  As a result when the zoom value is retrieved by storage and recalculated (e.g. it's divided by 100), the scale will be less than 1%.

Looks like the code is checking currentScaleValue == currentScale ? currentScale \* 100 : currentScaleValue.  

Is the check currentScaleValue == currentScale needed?  

For example, I logged the following situation occurring repeatedly:
currentScaleValue = 0.6830134553650703
currentScale = 0.9090909090909088
normalizedValue = 0.6830134553650703
