### PR TITLE
Lazy textLayer rendering - pauses after scroll event

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -973,14 +973,18 @@ var TextLayerBuilder = function textLayerBuilder(textLayerDiv) {
         return;
       }
       var textDiv = textDivs.shift();
-      if (textDiv.dataset.textLength > 1) { // avoid div by zero
-        // Adjust div width (via letterSpacing) to match canvas text
-        // Due to the .offsetWidth calls, this is slow
-        textDiv.style.letterSpacing =
-          ((textDiv.dataset.canvasWidth - textDiv.offsetWidth) /
-            (textDiv.dataset.textLength - 1)) + 'px';
-      }
-      textLayerDiv.appendChild(textDiv);
+      if (textDiv.dataset.textLength > 0) {
+        textLayerDiv.appendChild(textDiv);
+
+        if (textDiv.dataset.textLength > 1) { // avoid div by zero
+          // Adjust div width (via letterSpacing) to match canvas text
+          // Due to the .offsetWidth calls, this is slow
+          // **This needs to come after appending to the DOM**
+          textDiv.style.letterSpacing =
+            ((textDiv.dataset.canvasWidth - textDiv.offsetWidth) /
+              (textDiv.dataset.textLength - 1)) + 'px';
+        }
+      } // textLength > 0
     }
     renderTimer = setInterval(renderTextLayer, renderInterval);
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -979,7 +979,7 @@ var TextLayerBuilder = function textLayerBuilder(textLayerDiv) {
         if (textDiv.dataset.textLength > 1) { // avoid div by zero
           // Adjust div width (via letterSpacing) to match canvas text
           // Due to the .offsetWidth calls, this is slow
-          // **This needs to come after appending to the DOM**
+          // This needs to come after appending to the DOM
           textDiv.style.letterSpacing =
             ((textDiv.dataset.canvasWidth - textDiv.offsetWidth) /
               (textDiv.dataset.textLength - 1)) + 'px';
@@ -1001,7 +1001,7 @@ var TextLayerBuilder = function textLayerBuilder(textLayerDiv) {
       clearInterval(renderTimer);
 
       clearTimeout(scrollTimer);
-      scrollTimer = setTimeout(function() {
+      scrollTimer = setTimeout(function textLayerScrollTimer() {
         // Resume rendering
         renderTimer = setInterval(renderTextLayer, renderInterval);
       }, resumeInterval);

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -974,13 +974,13 @@ var TextLayerBuilder = function textLayerBuilder(textLayerDiv) {
       }
       var textDiv = textDivs.shift();
       if (textDiv.dataset.textLength > 1) { // avoid div by zero
-        textLayerDiv.appendChild(textDiv);
         // Adjust div width (via letterSpacing) to match canvas text
         // Due to the .offsetWidth calls, this is slow
         textDiv.style.letterSpacing =
           ((textDiv.dataset.canvasWidth - textDiv.offsetWidth) /
             (textDiv.dataset.textLength - 1)) + 'px';
       }
+      textLayerDiv.appendChild(textDiv);
     }
     renderTimer = setInterval(renderTextLayer, renderInterval);
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -973,7 +973,7 @@ var TextLayerBuilder = function textLayerBuilder(textLayerDiv) {
         return;
       }
       var textDiv = textDivs.shift();
-      if (textDiv.dataset.textLength >= 1) { // avoid div by zero
+      if (textDiv.dataset.textLength > 1) { // avoid div by zero
         textLayerDiv.appendChild(textDiv);
         // Adjust div width (via letterSpacing) to match canvas text
         // Due to the .offsetWidth calls, this is slow


### PR DESCRIPTION
This improves upon the previous algorithm in that the rendering completely pauses (no background setInterval calls, etc) until the user has stopped scrolling. 

Any choppiness in the scrolling should now be due to other synchronous calls, like canvas ops, etc. 
