### PR TITLE
define console for IE9 when debugging tools is not opened

### DIFF
--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -225,9 +225,9 @@
   });
 })();
 
-//IE9 console
+// Check console compatability
 (function checkConsoleCompatibility() {
-  if (typeof console == "undefined") {
+  if (typeof console == 'undefined') {
     console = {log: function() {}};
   }
 })();

--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -224,3 +224,10 @@
     }
   });
 })();
+
+//IE9 console
+(function checkConsoleCompatibility() {
+  if (typeof console == "undefined") {
+    console = {log: function() {}};
+  }
+})();


### PR DESCRIPTION
When accessing http://mozilla.github.com/pdf.js/web/viewer.html I get a JS error if developer tools is not opened in IE9.
Message: 'console' is undefined
Line: 1
Char: 1
Code: 0
URI: http://mozilla.github.com/pdf.js/web/viewer.html

A proposed fix is to define console.log in compatability.js if console is undefined.
