### PR TITLE
IE9 SVG control images need viewport defined

### DIFF
--- a/web/images/bookmark.svg
+++ b/web/images/bookmark.svg
@@ -20,7 +20,8 @@
    height="48.000000px"
    width="48.000000px"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   version="1.1">
+   version="1.1"
+   viewbox="0 0 48 48">
   <defs
      id="defs3">
     <inkscape:perspective

--- a/web/images/document-print.svg
+++ b/web/images/document-print.svg
@@ -16,7 +16,8 @@
    id="svg2994"
    height="48px"
    width="48px"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewbox="0 0 48 48">
   <defs
      id="defs3">
     <inkscape:perspective

--- a/web/images/download.svg
+++ b/web/images/download.svg
@@ -16,7 +16,8 @@
    id="svg2913"
    height="48px"
    width="48px"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewbox="0 0 48 48">
   <defs
      id="defs3">
     <inkscape:perspective

--- a/web/images/go-down.svg
+++ b/web/images/go-down.svg
@@ -19,7 +19,8 @@
    inkscape:export-filename="/home/jimmac/Desktop/wi-fi.png"
    inkscape:export-xdpi="90.000000"
    inkscape:export-ydpi="90.000000"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewbox="0 0 48 48">
   <defs
      id="defs3">
     <inkscape:perspective

--- a/web/images/go-up.svg
+++ b/web/images/go-up.svg
@@ -19,7 +19,8 @@
    inkscape:export-filename="/home/jimmac/Desktop/wi-fi.png"
    inkscape:export-xdpi="90.000000"
    inkscape:export-ydpi="90.000000"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewbox="0 0 48 48">
   <defs
      id="defs3">
     <inkscape:perspective

--- a/web/images/zoom-in.svg
+++ b/web/images/zoom-in.svg
@@ -16,7 +16,8 @@
    inkscape:version="0.46"
    sodipodi:docbase="/home/jimmac/src/cvs/tango-icon-theme/scalable/actions"
    sodipodi:docname="list-add.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewbox="0 0 48 48">
   <defs
      id="defs6433">
     <inkscape:perspective

--- a/web/images/zoom-out.svg
+++ b/web/images/zoom-out.svg
@@ -16,7 +16,8 @@
    inkscape:version="0.46"
    sodipodi:docbase="/home/jimmac/src/cvs/tango-icon-theme/scalable/actions"
    sodipodi:docname="list-remove.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewbox="0 0 48 48">
   <defs
      id="defs6433">
     <inkscape:perspective


### PR DESCRIPTION
In IE9 the previous, next, zoom in, zoom out, download, bookmark, print images do not display on the controls toolbar.  This is due to the viewport not being defined in the SVG image.  This pull request is to fix the SVG images to define viewport.
