### PR TITLE
Make chrome extensions compatible with latest API changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ auto-update extensions on a daily basis (you can change this through the
 `extensions.update.interval` option in `about:config`).
 
 For an experimental Chrome extension, get the code as explained below and issue `make extension`. 
-Then open Chrome with the flag `--enable-experimental-extension-apis`, go to `Tools > Extension`
-and load the (unpackaged) extension from the directory `extensions/chrome`.
+Then open Chrome, go to `Tools > Extension` and load the (unpackaged) extension
+from the directory `build/chrome`.
 
 ### Getting the code
 

--- a/extensions/chrome/manifest.json
+++ b/extensions/chrome/manifest.json
@@ -3,7 +3,7 @@
   "version": "0.1",
   "description": "Read PDF Document",
   "permissions": [
-    "experimental",
+    "webRequest", "webRequestBlocking",
     "http://*/*.pdf",
     "file:///*/*.pdf"
   ],

--- a/extensions/chrome/pdfHandler.html
+++ b/extensions/chrome/pdfHandler.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <script>
-chrome.experimental.webRequest.onBeforeRequest.addListener(
+chrome.webRequest.onBeforeRequest.addListener(
   function(details) {
     var viewerPage = 'content/web/viewer.html';
     var url = chrome.extension.getURL(viewerPage) + '?file=' + details.url;


### PR DESCRIPTION
That is, webRequest is no longer experimental and so it's easier
to start (without --enable-experimental-extension-apis).

This fixes issue #1196.
