### PR TITLE
Prototype: Canvas-based text selection backend

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -188,7 +188,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
   // before it stops and shedules a continue of execution.
   var kExecutionTime = 50;
 
-  function CanvasGraphics(canvasCtx, objs, textLayer) {
+  function CanvasGraphics(canvasCtx, objs, selectionLayer) {
     this.ctx = canvasCtx;
     this.current = new CanvasExtraState();
     this.stateStack = [];
@@ -197,7 +197,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     this.xobjs = null;
     this.ScratchCanvas = ScratchCanvas;
     this.objs = objs;
-    this.textLayer = textLayer;
+    this.selectionLayer = selectionLayer;
     if (canvasCtx) {
       addContextCurrentTransform(canvasCtx);
     }
@@ -260,8 +260,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       // Move the media left-top corner to the (0,0) canvas position
       this.ctx.translate(-mediaBox.x, -mediaBox.y);
 
-      if (this.textLayer)
-        this.textLayer.beginLayout();
+      if (this.selectionLayer)
+        this.selectionLayer.beginLayout();
     },
 
     executeIRQueue: function canvasGraphicsExecuteIRQueue(codeIR,
@@ -325,8 +325,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     endDrawing: function canvasGraphicsEndDrawing() {
       this.ctx.restore();
 
-      if (this.textLayer)
-        this.textLayer.endLayout();
+      if (this.selectionLayer)
+        this.selectionLayer.endLayout();
     },
 
     // Graphics state
@@ -654,10 +654,10 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       var textHScale2 = textHScale * fontMatrix[0];
       var glyphsLength = glyphs.length;
       var textRenderingMode = current.textRenderingMode;
-      var textLayer = this.textLayer;
+      var selectionLayer = this.selectionLayer;
       var textData = [];
       // var text = {str: '', length: 0, canvasWidth: 0, geom: {}};
-      // var textSelection = textLayer && !skipTextSelection ? true : false;
+      // var textSelection = selectionLayer && !skipTextSelection ? true : false;
 
       // Type3 fonts - each glyph is a "mini-PDF"
       if (font.coded) {
@@ -713,7 +713,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
 
         ctx.lineWidth = lineWidth;
 
-        if (textLayer)
+        if (selectionLayer)
           var geom = this.getTextGeometry();
 
         var x = 0;
@@ -765,8 +765,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         ctx.restore();
       }
 
-      if (textLayer)
-        textLayer.appendTextData(textData);
+      if (selectionLayer)
+        selectionLayer.appendTextData(textData);
     },
     showSpacedText: function canvasGraphicsShowSpacedText(arr) {
       var ctx = this.ctx;
@@ -777,7 +777,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       if (!font.coded)
         textHScale *= (current.fontMatrix || IDENTITY_MATRIX)[0];
       var arrLength = arr.length;
-      var textLayer = this.textLayer;
+      var selectionLayer = this.selectionLayer;
 
       for (var i = 0; i < arrLength; ++i) {
         var e = arr[i];
@@ -785,13 +785,13 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
           // Space
           var spacingLength = -e * 0.001 * fontSize * textHScale;
   
-          if (textLayer && spacingLength > 0) {
+          if (selectionLayer && spacingLength > 0) {
             ctx.save();
             this.applyTextTransforms();
             var geom = this.getTextGeometry();
             ctx.restore();
 
-            textLayer.appendTextData([{
+            selectionLayer.appendTextData([{
               char: ' ',
               x: geom.x,
               y: geom.y,

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -261,7 +261,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       this.ctx.translate(-mediaBox.x, -mediaBox.y);
 
       if (this.selectionHandler)
-        this.selectionHandler.beginLayout();
+        this.selectionHandler.begin();
     },
 
     executeIRQueue: function canvasGraphicsExecuteIRQueue(codeIR,
@@ -326,7 +326,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       this.ctx.restore();
 
       if (this.selectionHandler)
-        this.selectionHandler.endLayout();
+        this.selectionHandler.end();
     },
 
     // Graphics state
@@ -744,12 +744,12 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
             textData.push({
               char: char, 
               x: geom.x + x * geom.hScale,
-              y: geom.y,
+              y: geom.y - fontSize * geom.vScale,
               width: charWidth * geom.hScale,
               height: fontSize * geom.vScale
             });
           }
-          
+
           x += charWidth;
 
           // text.str += glyph.unicode === ' ' ? '\u00A0' : glyph.unicode;
@@ -789,7 +789,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
             selectionHandler.appendTextData([{
               char: ' ',
               x: geom.x,
-              y: geom.y,
+              y: geom.y - fontSize * geom.vScale,
               width: spacingLength * geom.hScale,
               height: fontSize * geom.vScale
             }]);

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -251,6 +251,15 @@ canvas {
   top: 0;
 }
 
+.selectionTextLayer {
+  position: absolute;
+  opacity: 0;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+}
+
 .annotComment > div {
   position: absolute;
 }
@@ -279,12 +288,6 @@ canvas {
   border-bottom: 1px solid #000000;
   margin: 0px;
 }
-
-/* TODO: file FF bug to support ::-moz-selection:window-inactive
-   so we can override the opaque grey background when the window is inactive;
-   see https://bugzilla.mozilla.org/show_bug.cgi?id=706209 */
-::selection { background:rgba(0,0,255,0.3); }
-::-moz-selection { background:rgba(0,0,255,0.3); }
 
 #viewer {
   margin: 44px 0px 0px;

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -249,6 +249,7 @@ canvas {
   position: absolute;
   left: 0;
   top: 0;
+  cursor: text;
 }
 
 .selectionDiv {

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -245,7 +245,7 @@ canvas {
   background: url('images/loading-icon.gif') center no-repeat;
 }
 
-.textLayer {
+.selectionLayer {
   position: absolute;
   left: 0;
   top: 0;

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -245,13 +245,13 @@ canvas {
   background: url('images/loading-icon.gif') center no-repeat;
 }
 
-.selectionLayer {
+.selectionCanvas {
   position: absolute;
   left: 0;
   top: 0;
 }
 
-.selectionTextLayer {
+.selectionDiv {
   position: absolute;
   opacity: 0;
   left: 0;

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -249,15 +249,6 @@ canvas {
   position: absolute;
   left: 0;
   top: 0;
-  right: 0;
-  bottom: 0;
-  color: #000;
-}
-
-.textLayer > div {
-  color: transparent;
-  position: absolute;
-  line-height:1.3;
 }
 
 .annotComment > div {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1185,9 +1185,9 @@ var SelectionHandler =
         self.selectionArr = [];
         ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-        // Find range of user-selected letters
-        // At this point firstLetter, lastLetter are the first and last letters
-        // that fall inside the selection rectangle
+        // Compute firstLetter, lastLetter:
+        // These are the first and last letters that fall inside the 
+        // selection rectangle
         var rect = { x0: pos0.x, y0: pos0.y, 
                      x1: pos1.x, y1: pos1.y },
             textData = self.textData,
@@ -1210,22 +1210,29 @@ var SelectionHandler =
         if (lastLetter === null)
           return;
 
-        // Fix firstLetter/lastLetter by adding adjacent letters that belong 
-        // to the same line (if cursor is above the letters)
-
+        // If firstLetter is below pos0, move firstLetter backwards (in the
+        // PDF order) until it crosses pos0.y or is no longer going up
         if (pos0.y < textData[firstLetter].y) {
           var i = firstLetter;
-          while (i > 0 && textData[i - 1].y === textData[i].y)
+          while (i > 0 && textData[i - 1].y <= textData[i].y &&
+                 textData[i - 1].y > pos0.y)
             i--;
           firstLetter = i;
         }
 
+        // Selection is from top to bottom
+        if (pos1.y > pos0.y) {
+          // Replace selection pos0 to that of firstLetter
+          self.pos0 = { x: textData[firstLetter].x, 
+                        y: textData[firstLetter].y };
+        }
+        
         // Draw selection box
-        // ctx.save();
-        // ctx.fillStyle = 'rgba(0, 0, 255, 0.2)';
-        // ctx.fillRect(pos0.x, pos0.y, 
-        //              pos1.x - pos0.x, pos1.y - pos0.y);
-        // ctx.restore();
+        ctx.save();
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.2)';
+        ctx.fillRect(pos0.x, pos0.y, 
+                     pos1.x - pos0.x, pos1.y - pos0.y);
+        ctx.restore();
 
         // Highlight and push letters from firstLetter-lastLatter
         ctx.save();

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -852,16 +852,16 @@ var PageView = function pageView(container, content, id, pageWidth, pageHeight,
     ctx.restore();
     ctx.translate(-this.x * scale, -this.y * scale);
 
-    var textLayerCanvas = null;
-    if (!PDFJS.disableTextLayer) {
-      textLayerCanvas = document.createElement('canvas');
-      textLayerCanvas.className = 'textLayer';
-      textLayerCanvas.width = pageWidth * scale;
-      textLayerCanvas.height = pageHeight * scale;
-      div.appendChild(textLayerCanvas);
+    var selectionLayerCanvas = null;
+    if (!PDFJS.disableSelectionLayer) {
+      selectionLayerCanvas = document.createElement('canvas');
+      selectionLayerCanvas.className = 'selectionLayer';
+      selectionLayerCanvas.width = pageWidth * scale;
+      selectionLayerCanvas.height = pageHeight * scale;
+      div.appendChild(selectionLayerCanvas);
     }
-    var textLayer = textLayerCanvas ? 
-        new TextLayerBuilder(textLayerCanvas) : null;
+    var selectionLayer = selectionLayerCanvas ? 
+        new SelectionLayerBuilder(selectionLayerCanvas) : null;
 
     // Rendering area
 
@@ -879,7 +879,7 @@ var PageView = function pageView(container, content, id, pageWidth, pageHeight,
 
       cache.push(self);
       callback();
-    }, textLayer);
+    }, selectionLayer);
 
     setupAnnotations(this.content, this.scale);
     div.setAttribute('data-loaded', true);
@@ -1015,9 +1015,9 @@ var DocumentOutlineView = function documentOutlineView(outline) {
   }
 };
 
-var TextLayerBuilder = function textLayerBuilder(textLayerCanvas) {  
-  var canvas = textLayerCanvas,
-      ctx = textLayerCanvas.getContext('2d'),      
+var SelectionLayerBuilder = function selectionLayerBuilder(selectionLayerCanvas) {  
+  var canvas = selectionLayerCanvas,
+      ctx = selectionLayerCanvas.getContext('2d'),      
       textData = [],
       holdingButton = false,
       pos0 = {
@@ -1069,9 +1069,9 @@ var TextLayerBuilder = function textLayerBuilder(textLayerCanvas) {
   }
 
   // Methods
-  this.beginLayout = function textLayerBuilderBeginLayout() {};
+  this.beginLayout = function selectionLayerBuilderBeginLayout() {};
 
-  this.endLayout = function textLayerBuilderEndLayout() {
+  this.endLayout = function selectionLayerBuilderEndLayout() {
     canvas.addEventListener('mousedown', function(e) {
       if (e.button === 0) {
         holdingButton = true;
@@ -1129,7 +1129,7 @@ var TextLayerBuilder = function textLayerBuilder(textLayerCanvas) {
     });
   };
 
-  this.appendTextData = function textLayerBuilderAppendText(aTextData) {
+  this.appendTextData = function selectionLayerBuilderAppendText(aTextData) {
     textData.push.apply(textData, aTextData);
   };
 };
@@ -1158,8 +1158,8 @@ window.addEventListener('load', function webViewerLoad(evt) {
   if ('disableWorker' in params)
     PDFJS.disableWorker = (params['disableWorker'] === 'true');
 
-  if ('disableTextLayer' in params)
-    PDFJS.disableTextLayer = (params['disableTextLayer'] === 'true');
+  if ('disableSelectionLayer' in params)
+    PDFJS.disableSelectionLayer = (params['disableSelectionLayer'] === 'true');
 
   var sidebarScrollView = document.getElementById('sidebarScrollView');
   sidebarScrollView.addEventListener('scroll', updateThumbViewArea, true);

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1109,19 +1109,27 @@ var SelectionHandler =
           return;
         
         self.holdingButton = false;
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-        if (self.selectionArr.length === 0) {
-          ctx.clearRect(0, 0, canvas.width, canvas.height);
+        // No text at all under box?
+        if (self.selectionArr.length === 0)
           return;
-        }
 
+        // Extract text from selectionArr, highlight it
         var selectionText = '';
+        ctx.fillStyle = 'rgba(0, 0, 255, 0.4)';
         for (var i = 0; i < self.selectionArr.length; i++) {
+          // Introduce space if previous letter comes from a different line
           if (i > 0 && self.selectionArr[i - 1].y < self.selectionArr[i].y)
             selectionText += ' ';
           selectionText += self.selectionArr[i].char;
+
+          // Leaves the text highlighted
+          var text = self.selectionArr[i];
+          ctx.fillRect(text.x, text.y - text.height, text.width, text.height);
         };
         
+        // Copy and select text to selectionDiv
         self.selectionDiv.textContent = selectionText;
         var range = document.createRange();
         range.selectNode(self.selectionDiv);

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1085,8 +1085,10 @@ var TextLayerBuilder = function textLayerBuilder(textLayerCanvas) {
       if (e.button === 0) {
         holdingButton = false;
 
-        if (selectionArr.length === 0)
+        if (selectionArr.length === 0) {
+          ctx.clearRect(0, 0, canvas.width, canvas.height);
           return;
+        }
 
         var selectionText = '';
         for (var i = 0; i < selectionArr.length; i++) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1084,6 +1084,10 @@ var TextLayerBuilder = function textLayerBuilder(textLayerCanvas) {
     canvas.addEventListener('mouseup', function(e) {
       if (e.button === 0) {
         holdingButton = false;
+
+        if (selectionArr.length === 0)
+          return;
+
         var selectionText = '';
         for (var i = 0; i < selectionArr.length; i++) {
           if (i > 0 && selectionArr[i - 1].y < selectionArr[i].y)
@@ -1110,7 +1114,7 @@ var TextLayerBuilder = function textLayerBuilder(textLayerCanvas) {
 
       // Highlight letters
       ctx.save();
-      ctx.fillStyle = 'rgba(0, 0, 255, 0.5)';
+      ctx.fillStyle = 'rgba(0, 0, 255, 0.4)';
       var rect = { x0: pos0.x, y0: pos0.y, x1: pos1.x, y1: pos1.y };
       textData.forEach(function(text) {
         if (isInsideRect(text, rect)) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1095,6 +1095,7 @@ var TextLayerBuilder = function textLayerBuilder(textLayerCanvas) {
           selectionText += selectionArr[i].char;
         };
         window.prompt("Copy to clipboard: Ctrl+C, Enter", selectionText);
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
       }
     });
 


### PR DESCRIPTION
This prototype was implemented during our workweek, inspired by conversations with @ironymark. I wanted to get more feedback about the overall direction I'm heading before spending more time on it.

Our current text selection algorithm (based on textual divs) suffers from the following problems:
- **What-You-Select-Is-Not-What-You-Get (WYSINWYG)**: This is an issue particularly for international documents (e.g. Chinese, Arabic, etc). Because the algo lumps characters into a single div, we can't reproduce the subtle character spacings that come with the `showSpacedText()` command. Consequently the selected characters do not necessarily match the ones we see in the underlying canvas.
- **Impractical for "letter-by-letter" docs** (i.e. docs that use one `showText()` command per character): The algorithm was designed assuming that all documents use one `showSpacedText()` per line, and makes some expensive calculations/adjustments after each div. Some generators do not obey this rule (e.g. https://github.com/mozilla/pdf.js/issues/1045), and hence lead to impractically large CPU usage.
- **Selection jerkiness**: Because the divs have to be absolutely positioned, the layout engine resets the selection region every time the mouse falls outside the immediate vicinity of text. So the user needs to be precise in where they place the mouse, which is unusual.

Because of the above, I've started prototyping a new selection backend using pure Canvas -- there is no text in the DOM. This gives us much more flexibility in terms of how the selection should behave, leads to a much faster overhead, and lets us select exactly the text one sees in the canvas.

However, there are challenges:
- **LTR, RTL**: We'll still need to think about how to support both LTR and RTL, perhaps reuse some of @ironymark's #1202.
- **Scrolling**: When the user tries to select text beyond the allowed region (e.g. beyond the bottom) the browser does _not_ scroll automatically. I've prototyped the desired behavior somewhat in the current algorithm. (Should this be a platform feature?)
- **Accessibility**. This is actually a challenge for both implementations, as it isn't working in our current implementation. I understand the HTML5 spec for canvas allows the use of a "caret" to help with keyboard navigation and text selection (http://www.w3.org/TR/2dcontext/#caret-selection). I'm not saying this is the best solution; we'd have to research what our options are.
- **Won't work with docs that don't have letter ordering**: This is also a problem with the current algorithm. In the new one, I too make the assumption that the letters have a specific ordering associated with them (whether it's LTR or RTL). Without this we'd have to either perform a layout analysis, or fallback to simple rectangular selection.
