### PR TITLE
Fixes #1186 - Race condition due to fast zooming

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -37,10 +37,6 @@ var RenderingQueue = (function RenderingQueueClosure() {
       if (!item.drawingRequired())
         return; // as no redraw required, no need for queueing.
 
-      if ('rendering' in item)
-        return; // is already in the queue
-
-      item.rendering = true;
       this.items.push(item);
       if (this.items.length > 1)
         return; // not first item
@@ -49,7 +45,6 @@ var RenderingQueue = (function RenderingQueueClosure() {
     },
     continueExecution: function RenderingQueueContinueExecution() {
       var item = this.items.shift();
-      delete item.rendering;
 
       if (this.items.length == 0)
         return; // queue is empty
@@ -869,7 +864,10 @@ var PageView = function pageView(container, content, id, pageWidth, pageHeight,
     var self = this;
     stats.begin = Date.now();
     this.content.startRendering(ctx, function pageViewDrawCallback(error) {
-      div.removeChild(self.loadingIconDiv);
+      if (self.loadingIconDiv) {
+        div.removeChild(self.loadingIconDiv);
+        delete self.loadingIconDiv;
+      }
 
       if (error)
         PDFView.error('An error occurred while rendering the page.', error);
@@ -969,7 +967,7 @@ var ThumbnailView = function thumbnailView(container, page, id, pageRatio) {
   };
 
   this.setImage = function thumbnailViewSetImage(img) {
-    if (this.hasImage)
+    if (this.hasImage || !img)
       return;
 
     var ctx = getPageDrawContext();
@@ -1206,7 +1204,6 @@ function updateViewarea() {
 window.addEventListener('scroll', function webViewerScroll(evt) {
   updateViewarea();
 }, true);
-
 
 var thumbnailTimer;
 


### PR DESCRIPTION
As reported in #1186, zooming in/out too fast raises some exceptions, and makes some pages not render unless the user scrolls. These two issues are fixed here.

Basically I'm removing the `item.rendering` check and a bug with my recently introduced `loadingIconDiv` element. Removing that check from the queue doesn't seem to be a problem for most PDFs I've tried -- no duplicate drawing/rendering ensues.

PS: I really wish we were using a more organized MVC structure in `viewer.js`... debugging this was an exercise in following a web of window events and function calls. Perhaps when we have a new UI we can revisit the overall code structure? :)
