### PR TITLE
Fix font rendering problem in QtWebkit 4.8

### DIFF
--- a/src/fonts.js
+++ b/src/fonts.js
@@ -1206,13 +1206,10 @@ var Font = (function FontClosure() {
       'Original licence',  // 0.Copyright
       name,                // 1.Font family
       'Unknown',           // 2.Font subfamily (font weight)
-      'uniqueID',          // 3.Unique ID
+      name,                // 3.Unique ID
       name,                // 4.Full font name
       'Version 0.11',      // 5.Version
-      '',                  // 6.Postscript name
-      'Unknown',           // 7.Trademark
-      'Unknown',           // 8.Manufacturer
-      'Unknown'            // 9.Designer
+      name                 // 6.Postscript name
     ];
 
     // Mac want 1-byte per character strings while Windows want


### PR DESCRIPTION
The lack of two fields in the generated font files' name tables seem to cause problems for QtWebkit.

This is what the tracemonkey paper looks like in QtWebkit 4.8 (Mac OS X 10.7.3) without this fix:
http://cl.ly/2B330e410e0r0s3v1f2z

Here's what it looks like with the fix:
http://cl.ly/071j1p0g0N3W3B1e3n0W
