### PR TITLE
Chrome extension: uses encodeURIComponent; fixes download button

### DIFF
--- a/extensions/chrome/pdfHandler.html
+++ b/extensions/chrome/pdfHandler.html
@@ -1,18 +1,28 @@
 <!doctype html>
 <script>
+
+function isPdfDownloadable(details) {
+  return details.url.indexOf('pdfjs.action=download') >= 0;
+}
+
 chrome.webRequest.onBeforeRequest.addListener(
   function(details) {
+    if (isPdfDownloadable(details))
+      return;
+
     var viewerPage = 'content/web/viewer.html';
-    var url = chrome.extension.getURL(viewerPage) + '?file=' + details.url;
+    var url = chrome.extension.getURL(viewerPage) +
+      '?file=' + encodeURIComponent(details.url);
     return { redirectUrl: url };
   },
   {
     urls: [
       "http://*/*.pdf",
-      "file://*/*.pdf",
+      "file://*/*.pdf"
     ],
     types: [ "main_frame" ]
   },
   ["blocking"]);
+
 </script>
 


### PR DESCRIPTION
Follow up on #1196 and applies fix from #1297
