### PR TITLE
Sanitize pdf link urls.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -338,7 +338,13 @@ var Page = (function PageClosure() {
             if (a) {
               switch (a.get('S').name) {
                 case 'URI':
-                  item.url = a.get('URI');
+                  var url = a.get('URI');
+                  // TODO: pdf spec mentions urls can be relative to a Base
+                  // entry in the dictionary.
+                  // For now only allow http and https schemes.
+                  if (url.search(/^https?\:/) !== 0)
+                    url = '';
+                  item.url = url;
                   break;
                 case 'GoTo':
                   item.dest = a.get('D');

--- a/src/core.js
+++ b/src/core.js
@@ -310,6 +310,22 @@ var Page = (function PageClosure() {
           return null;
         return item.get(name);
       }
+      function isValidUrl(url) {
+        if (!url)
+          return false;
+        var colon = url.indexOf(':');
+        if (colon < 0)
+          return false;
+        var protocol = url.substr(0, colon);
+        switch (protocol) {
+          case 'http':
+          case 'https':
+          case 'ftp':
+            return true;
+          default:
+            return false;
+        }
+      }
 
       var annotations = xref.fetchIfRef(this.annotations) || [];
       var i, n = annotations.length;
@@ -341,8 +357,7 @@ var Page = (function PageClosure() {
                   var url = a.get('URI');
                   // TODO: pdf spec mentions urls can be relative to a Base
                   // entry in the dictionary.
-                  // For now only allow http and https schemes.
-                  if (url.search(/^https?\:/) !== 0)
+                  if (!isValidUrl(url))
                     url = '';
                   item.url = url;
                   break;


### PR DESCRIPTION
Only allow http and https urls.
Addresses https://bugzilla.mozilla.org/show_bug.cgi?id=734794
