### PR TITLE
Various fixes for Thunderbird compatibility.

### DIFF
--- a/extensions/firefox/install.rdf
+++ b/extensions/firefox/install.rdf
@@ -15,6 +15,13 @@
        <em:maxVersion>13.0a1</em:maxVersion>
      </Description>
     </em:targetApplication>
+    <em:targetApplication>
+      <Description>
+        <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id>
+        <em:minVersion>11.0a1</em:minVersion>
+        <em:maxVersion>14.0a1</em:maxVersion>
+      </Description>
+    </em:targetApplication>
     <em:bootstrap>true</em:bootstrap>
     <em:unpack>true</em:unpack>
     <em:creator>Mozilla Labs</em:creator>


### PR DESCRIPTION
@brendandahl @saebekassebil This is what was needed for me in order for something to happen when I double-click on a PDF attachment. I also needed to fix a fallout from one of the latest merges (I'm running trunk which is maybe why it went unnoticed?).

The viewer UI now loads fine, except I get:

```
An error occured while loading the PDF
PDF.JS Build: 59283bd
Message: Unexpected server response of 0.
```
