### PR TITLE
Adding new find() commands for moz-central

### DIFF
--- a/external/shelljs/README.md
+++ b/external/shelljs/README.md
@@ -1,8 +1,10 @@
 # ShellJS - Unix shell commands for Node.js [![Build Status](https://secure.travis-ci.org/arturadib/shelljs.png)](http://travis-ci.org/arturadib/shelljs)
 
+_This project is young and experimental. Use at your own risk._
+
 ShellJS is a **portable** (Windows included) implementation of Unix shell commands on top of the Node.js API. You can use it to eliminate your shell script's dependency on Unix while still keeping its familiar and powerful commands.
 
-The project is both [unit-tested](http://travis-ci.org/arturadib/shelljs) and battle-tested at Mozilla's [pdf.js](http://github.com/mozilla/pdf.js).
+The project is [unit-tested](http://travis-ci.org/arturadib/shelljs) and is being used at Mozilla's [pdf.js](http://github.com/mozilla/pdf.js).
 
 
 ### Example
@@ -12,7 +14,7 @@ require('shelljs/global');
 
 // Copy files to release dir
 mkdir('-p', 'out/Release');
-cp('-R', 'lib/*.js', 'out/Release');
+cp('-R', 'stuff/*', 'out/Release');
 
 // Replace macros in each .js file
 cd('lib');
@@ -130,6 +132,27 @@ Returns list of files in the given path, or in current directory if no path prov
 For convenient iteration via `for (file in ls())`, the format returned is a hash object:
 `{ 'file1':null, 'dir1/file2':null, ...}`.
 
+#### find(path [,path ...])
+#### find(path_array)
+Examples:
+
+```javascript
+find('src', 'lib');
+find(['src', 'lib']); // same as above
+for (file in find('.')) {
+if (!file.match(/\.js$/))
+continue;
+// all files at this point end in '.js'
+}
+```
+
+Returns list of all files (however deep) in the given paths. For convenient iteration 
+via `for (file in find(...))`, the format returned is a hash object:
+`{ 'file1':null, 'dir1/file2':null, ...}`.
+
+The main difference with respect to `ls('-R', path)` is that the resulting file names 
+include the base directories, e.g. `lib/resources/file1` instead of just `file1`.
+
 #### cp('[options ,] source [,source ...], dest')
 #### cp('[options ,] source_array, dest')
 Available options:
@@ -194,6 +217,21 @@ mkdir('-p', ['/tmp/a/b/c/d', '/tmp/e/f/g']); // same as above
 ```
 
 Creates directories.
+
+#### test(expression)
+Available expression primaries:
+
++ `'-d', 'path'`: true if path is a directory
++ `'-f', 'path'`: true if path is a regular file
+
+Examples:
+
+```javascript
+if (test('-d', path)) { /* do something with dir */ };
+if (!test('-f', path)) continue; // skip if it's a regular file
+```
+
+Evaluates expression using the available primaries and returns corresponding value.
 
 #### cat(file [, file ...])
 #### cat(file_array)

--- a/make.js
+++ b/make.js
@@ -168,7 +168,8 @@ target.pagesrepo = function() {
 //
 
 var EXTENSION_WEB_FILES =
-      ['web/images',
+      ['web/debugger.js',
+       'web/images',
        'web/viewer.css',
        'web/viewer.js',
        'web/viewer.html',
@@ -264,8 +265,11 @@ target.firefox = function() {
 
   // We don't need pdf.js anymore since its inlined
   rm('-Rf', FIREFOX_BUILD_CONTENT_DIR + BUILD_DIR);
-  // TODO remove '.DS_Store' and other hidden files
-  // `find $(FIREFOX_BUILD_DIR) -name ".*" -delete`
+  // Remove '.DS_Store' and other hidden files
+  for (file in find(FIREFOX_BUILD_DIR)) {
+    if (file.match(/^\./))
+      rm('-f', file);
+  }
 
   // Update the build version number
   sed('-i', /PDFJSSCRIPT_VERSION/, EXTENSION_VERSION, FIREFOX_BUILD_DIR + '/install.rdf');
@@ -285,8 +289,14 @@ target.firefox = function() {
   echo('AMO extension created: ' + FIREFOX_AMO_EXTENSION_NAME);
   cd(ROOT_DIR);
 
-  // TODO List all files for mozilla-central
-  // `@cd $(FIREFOX_BUILD_DIR); find $(FIREFOX_EXTENSION_FILES) -type f > extension-files`
+  // List all files for mozilla-central
+  cd(FIREFOX_BUILD_DIR);
+  var extensionFiles = '';
+  for (file in find(FIREFOX_EXTENSION_FILES)) {
+    if (test('-f', file))
+      extensionFiles += file+'\n';
+  }
+  extensionFiles.to('extension-files');
 };
 
 //


### PR DESCRIPTION
Follow-up from #1334.

Note that `find()` does not currently support expressions, so we have to test each file in a loop. For the second loop we use `test()`, another Unix command (http://en.wikipedia.org/wiki/Test_%28Unix%29).

/cc @notmasteryet
