### PR TITLE
Only enable pdfDebug for the extension if a pref is set.

### DIFF
--- a/extensions/firefox/components/PdfStreamConverter.js
+++ b/extensions/firefox/components/PdfStreamConverter.js
@@ -66,6 +66,9 @@ ChromeActions.prototype = {
     if (this.inPrivateBrowswing)
       return '{}';
     return application.prefs.getValue(EXT_PREFIX + '.database', '{}');
+  },
+  pdfBugEnabled: function() {
+    return application.prefs.getValue(EXT_PREFIX + '.pdfBugEnabled', false);
   }
 };
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1182,7 +1182,8 @@ window.addEventListener('load', function webViewerLoad(evt) {
   if ('disableTextLayer' in hashParams)
     PDFJS.disableTextLayer = (hashParams['disableTextLayer'] === 'true');
 
-  if ('pdfBug' in hashParams) {
+  if ('pdfBug' in hashParams &&
+      (!PDFJS.isFirefoxExtension || FirefoxCom.request('pdfBugEnabled'))) {
     PDFJS.pdfBug = true;
     var pdfBug = hashParams['pdfBug'];
     var enabled = pdfBug.split(',');


### PR DESCRIPTION
As a further safety precaution the debugger stuff for the extension will now require the user to set a pref in about:config.

Setting in about:config (boolean true)
extensions.uriloader@pdf.js.pdfBug
