### PR TITLE
Change the kExecutionTime value to 15.

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -190,7 +190,7 @@ function addContextCurrentTransform(ctx) {
 var CanvasGraphics = (function CanvasGraphicsClosure() {
   // Defines the time the executeIRQueue is going to be executing
   // before it stops and shedules a continue of execution.
-  var kExecutionTime = 50;
+  var kExecutionTime = 15;
 
   function CanvasGraphics(canvasCtx, objs, textLayer) {
     this.ctx = canvasCtx;


### PR DESCRIPTION
This should get us close to 60FPS while rendering to the canvas. In reality the setTimout has some "overhead" and due to other facts the rendering might still take longer than 15ms.

With this applied the TM feel less choppy.
