### PR TITLE
Use Different Approach to add Event Listener

### DIFF
--- a/extensions/firefox/components/PdfStreamConverter.js
+++ b/extensions/firefox/components/PdfStreamConverter.js
@@ -30,23 +30,11 @@ function log(aMsg) {
   Services.console.logStringMessage(msg);
   dump(msg + '\n');
 }
-function getWindow(top, id) {
-  return top.QueryInterface(Ci.nsIInterfaceRequestor)
-            .getInterface(Ci.nsIDOMWindowUtils)
-            .getOuterWindowWithId(id);
-}
-function windowID(win) {
-  return win.QueryInterface(Ci.nsIInterfaceRequestor)
-            .getInterface(Ci.nsIDOMWindowUtils)
-            .outerWindowID;
-}
-function topWindow(win) {
-  return win.QueryInterface(Ci.nsIInterfaceRequestor)
-            .getInterface(Ci.nsIWebNavigation)
-            .QueryInterface(Ci.nsIDocShellTreeItem)
-            .rootTreeItem
-            .QueryInterface(Ci.nsIInterfaceRequestor)
-            .getInterface(Ci.nsIDOMWindow);
+
+function getDOMWindow(aChannel) {
+  var requestor = aChannel.notificationCallbacks;
+  var win = requestor.getInterface(Components.interfaces.nsIDOMWindow);
+  return win;
 }
 
 // All the priviledged actions.
@@ -74,6 +62,12 @@ ChromeActions.prototype = {
     return application.prefs.getValue(EXT_PREFIX + '.pdfBugEnabled', false);
   }
 };
+
+function getDOMWindow(aChannel) {
+  var requestor = aChannel.notificationCallbacks;
+  var win = requestor.getInterface(Components.interfaces.nsIDOMWindow);
+  return win;
+}
 
 // Event listener to trigger chrome privedged code.
 function RequestListener(actions) {
@@ -163,38 +157,29 @@ PdfStreamConverter.prototype = {
     var channel = ioService.newChannel(
                     'resource://pdf.js/web/viewer.html', null, null);
 
-    // Keep the URL the same so the browser sees it as the same.
-    channel.originalURI = aRequest.URI;
-    channel.asyncOpen(this.listener, aContext);
-
-    // Setup a global listener waiting for the next DOM to be created and verfiy
-    // that its the one we want by its URL. When the correct DOM is found create
-    // an event listener on that window for the pdf.js events that require
-    // chrome priviledges. Code snippet from John Galt.
-    let window = aRequest.loadGroup.groupObserver
-                         .QueryInterface(Ci.nsIWebProgress)
-                         .DOMWindow;
-    let top = topWindow(window);
-    let id = windowID(window);
-    window = null;
-
-    top.addEventListener('DOMWindowCreated', function onDOMWinCreated(event) {
-      let doc = event.originalTarget;
-      let win = doc.defaultView;
-
-      if (id == windowID(win)) {
-        top.removeEventListener('DOMWindowCreated', onDOMWinCreated, true);
-        if (!doc.documentURIObject.equals(aRequest.URI))
-          return;
-
+    var listener = this.listener;
+    // Proxy all the requst observer calls, when it gets to onStopRequst
+    // we can get the dom window.
+    var proxy = {
+      onStartRequest: function() {
+        listener.onStartRequest.apply(listener, arguments);
+      },
+      onDataAvailable: function() {
+        listener.onDataAvailable.apply(listener, arguments);
+      },
+      onStopRequest: function() {
+        var domWindow = getDOMWindow(channel);
         let requestListener = new RequestListener(new ChromeActions);
-        win.addEventListener(PDFJS_EVENT_ID, function(event) {
+        domWindow.addEventListener(PDFJS_EVENT_ID, function(event) {
           requestListener.receive(event);
         }, false, true);
-      } else if (!getWindow(top, id)) {
-        top.removeEventListener('DOMWindowCreated', onDOMWinCreated, true);
+        listener.onStopRequest.apply(listener, arguments);
       }
-    }, true);
+    };
+
+    // Keep the URL the same so the browser sees it as the same.
+    channel.originalURI = aRequest.URI;
+    channel.asyncOpen(proxy, aContext);
   },
 
   // nsIRequestObserver::onStopRequest

--- a/extensions/firefox/components/PdfStreamConverter.js
+++ b/extensions/firefox/components/PdfStreamConverter.js
@@ -63,11 +63,6 @@ ChromeActions.prototype = {
   }
 };
 
-function getDOMWindow(aChannel) {
-  var requestor = aChannel.notificationCallbacks;
-  var win = requestor.getInterface(Components.interfaces.nsIDOMWindow);
-  return win;
-}
 
 // Event listener to trigger chrome privedged code.
 function RequestListener(actions) {

--- a/extensions/firefox/components/PdfStreamConverter.js
+++ b/extensions/firefox/components/PdfStreamConverter.js
@@ -164,10 +164,13 @@ PdfStreamConverter.prototype = {
       },
       onStopRequest: function() {
         var domWindow = getDOMWindow(channel);
-        let requestListener = new RequestListener(new ChromeActions);
-        domWindow.addEventListener(PDFJS_EVENT_ID, function(event) {
-          requestListener.receive(event);
-        }, false, true);
+        // Double check the url is still the correct one.
+        if (domWindow.document.documentURIObject.equals(aRequest.URI)) {
+          let requestListener = new RequestListener(new ChromeActions);
+          domWindow.addEventListener(PDFJS_EVENT_ID, function(event) {
+            requestListener.receive(event);
+          }, false, true);
+        }
         listener.onStopRequest.apply(listener, arguments);
       }
     };


### PR DESCRIPTION
Previously the event listener wasn't getting added for pdfs in iframes and pdfs that opened in new windows since the window id of where the request started didn't match the id where the pdf ended up.
Fixes:
#1327
#1310

Test with an iframe pointing to a pdf

```
<iframe width="600px" height="600px" src="http://www.irs.gov/pub/irs-pdf/f1040.pdf"/>
```

or any pdf links on http://www.gesis.org/publikationen/zeitschriften/isi/ except the first one.
