### PR TITLE
Metadata Parsing - Setting proper document title

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ PDF_JS_FILES = \
   ../external/jpgjs/jpg.js \
   jpx.js \
   bidi.js \
+  metadata.js \
 	$(NULL)
 
 # make server

--- a/make.js
+++ b/make.js
@@ -97,7 +97,8 @@ target.bundle = function() {
         'worker.js',
         '../external/jpgjs/jpg.js',
         'jpx.js',
-        'bidi.js'];
+        'bidi.js',
+        'metadata-js'];
 
   if (!exists(BUILD_DIR))
     mkdir(BUILD_DIR);

--- a/make.js
+++ b/make.js
@@ -98,7 +98,7 @@ target.bundle = function() {
         '../external/jpgjs/jpg.js',
         'jpx.js',
         'bidi.js',
-        'metadata-js'];
+        'metadata.js'];
 
   if (!exists(BUILD_DIR))
     mkdir(BUILD_DIR);

--- a/src/core.js
+++ b/src/core.js
@@ -587,13 +587,15 @@ var PDFDocModel = (function PDFDocModelClosure() {
                           this.mainXRefEntriesOffset);
       this.xref = xref;
       this.catalog = new Catalog(xref);
-      if (xref.trailer && xref.trailer.has('ID')) {
-        var fileID = '';
-        var id = xref.fetchIfRef(xref.trailer.get('ID'))[0];
-        id.split('').forEach(function(el) {
-          fileID += Number(el.charCodeAt(0)).toString(16);
-        });
-        this.fileID = fileID;
+      if (xref.trailer) {
+        if (xref.trailer.has('ID')) {
+          var fileID = '';
+          var id = xref.fetchIfRef(xref.trailer.get('ID'))[0];
+          id.split('').forEach(function(el) {
+            fileID += Number(el.charCodeAt(0)).toString(16);
+          });
+          this.fileID = fileID;
+        }
       }
     },
     get numPages() {
@@ -601,6 +603,11 @@ var PDFDocModel = (function PDFDocModelClosure() {
       var num = linearization ? linearization.numPages : this.catalog.numPages;
       // shadow the prototype getter
       return shadow(this, 'numPages', num);
+    },
+    getDocumentInfo: function pdfDocGetDocumentInfo() {
+      if (this.xref.trailer.has('Info')) {
+        return this.xref.fetch(this.xref.trailer.get('Info'));
+      }
     },
     getFingerprint: function pdfDocGetFingerprint() {
       if (this.fileID) {
@@ -645,6 +652,7 @@ var PDFDoc = (function PDFDocClosure() {
     this.stream = stream;
     this.pdfModel = new PDFDocModel(stream);
     this.fingerprint = this.pdfModel.getFingerprint();
+    this.info = this.pdfModel.getDocumentInfo();
     this.catalog = this.pdfModel.catalog;
     this.objs = new PDFObjects();
 

--- a/src/core.js
+++ b/src/core.js
@@ -596,9 +596,8 @@ var PDFDocModel = (function PDFDocModelClosure() {
     },
     getDocumentInfo: function pdfDocGetDocumentInfo() {
       var info;
-      if (this.xref.trailer.has('Info')) {
+      if (this.xref.trailer.has('Info'))
         info = this.xref.fetch(this.xref.trailer.get('Info'));
-      }
 
       return shadow(this, 'getDocumentInfo', info);
     },

--- a/src/core.js
+++ b/src/core.js
@@ -587,16 +587,6 @@ var PDFDocModel = (function PDFDocModelClosure() {
                           this.mainXRefEntriesOffset);
       this.xref = xref;
       this.catalog = new Catalog(xref);
-      if (xref.trailer) {
-        if (xref.trailer.has('ID')) {
-          var fileID = '';
-          var id = xref.fetchIfRef(xref.trailer.get('ID'))[0];
-          id.split('').forEach(function(el) {
-            fileID += Number(el.charCodeAt(0)).toString(16);
-          });
-          this.fileID = fileID;
-        }
-      }
     },
     get numPages() {
       var linearization = this.linearization;
@@ -610,20 +600,25 @@ var PDFDocModel = (function PDFDocModelClosure() {
       }
     },
     getFingerprint: function pdfDocGetFingerprint() {
-      if (this.fileID) {
-        return this.fileID;
+      var xref = this.xref, fileID;
+      if (xref.trailer.has('ID')) {
+        fileID = '';
+        var id = xref.fetchIfRef(xref.trailer.get('ID'))[0];
+        id.split('').forEach(function(el) {
+          fileID += Number(el.charCodeAt(0)).toString(16);
+        });
       } else {
         // If we got no fileID, then we generate one,
         // from the first 100 bytes of PDF
         var data = this.stream.bytes.subarray(0, 100);
         var hash = calculateMD5(data, 0, data.length);
-        var strHash = '';
+        fileID = '';
         for (var i = 0, length = hash.length; i < length; i++) {
-          strHash += Number(hash[i]).toString(16);
+          fileID += Number(hash[i]).toString(16);
         }
-
-        return strHash;
       }
+
+      return shadow(this, 'getFingerprint', fileID);
     },
     getPage: function pdfDocGetPage(n) {
       return this.catalog.getPage(n);

--- a/src/core.js
+++ b/src/core.js
@@ -595,9 +595,12 @@ var PDFDocModel = (function PDFDocModelClosure() {
       return shadow(this, 'numPages', num);
     },
     getDocumentInfo: function pdfDocGetDocumentInfo() {
+      var info;
       if (this.xref.trailer.has('Info')) {
-        return this.xref.fetch(this.xref.trailer.get('Info'));
+        info = this.xref.fetch(this.xref.trailer.get('Info'));
       }
+
+      return shadow(this, 'getDocumentInfo', info);
     },
     getFingerprint: function pdfDocGetFingerprint() {
       var xref = this.xref, fileID;

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -1,3 +1,6 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+
 'use strict';
 
 var Metadata = PDFJS.Metadata = (function MetadataClosure() {

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -1,4 +1,6 @@
-var Metadata = (function MetadataClosure() {
+'use strict';
+
+var Metadata = PDFJS.Metadata = (function MetadataClosure() {
   function Metadata(meta) {
     if (typeof meta === 'string') {
       var parser = new DOMParser();

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -16,13 +16,15 @@ var Metadata = (function MetadataClosure() {
     parse: function() {
       var doc = this.metaDocument;
       var rdf = doc.documentElement;
-      if (rdf.tagName.toLowerCase() !== 'rdf:rdf') { // Wrapped in <xmpmeta>
+
+      if (rdf.nodeName.toLowerCase() !== 'rdf:rdf') { // Wrapped in <xmpmeta>
         rdf = rdf.firstChild;
-        while (rdf.nodeName && rdf.nodeName.toLowerCase() !== 'rdf:rdf')
+        while (rdf && rdf.nodeName.toLowerCase() !== 'rdf:rdf')
           rdf = rdf.nextSibling;
       }
 
-      if (rdf.nodeName.toLowerCase() !== 'rdf:rdf' || !rdf.hasChildNodes())
+      var nodeName = (rdf) ? rdf.nodeName.toLowerCase() : null;
+      if (!rdf || nodeName !== 'rdf:rdf' || !rdf.hasChildNodes())
         return;
 
       var childNodes = rdf.childNodes, desc, namespace, entries, entry;

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -1,0 +1,80 @@
+var Metadata = (function MetadataClosure() {
+  function Metadata(meta) {
+    if (typeof meta === 'string') {
+      var parser = new DOMParser();
+      meta = parser.parseFromString(meta, 'application/xml');
+    } else if (!(meta instanceof Document)) {
+      error('Metadata: Invalid metadata object');
+    }
+
+    this.metaDocument = meta;
+    this.metadata = {};
+    this.parse();
+  }
+
+  Metadata.prototype = {
+    parse: function() {
+      var doc = this.metaDocument;
+      var rdf = doc.documentElement;
+      if (rdf.tagName.toLowerCase() !== 'rdf:rdf') { // Wrapped in <xmpmeta>
+        rdf = rdf.firstChild;
+        while (rdf.nodeName && rdf.nodeName.toLowerCase() !== 'rdf:rdf') {
+          rdf = rdf.nextSibling;
+        }
+      }
+      if (rdf.nodeName.toLowerCase() !== 'rdf:rdf' || !rdf.hasChildNodes()) {
+        return;
+      }
+
+      var childNodes = rdf.childNodes, desc, namespace, entries, entry;
+
+      for (var i = 0, length = childNodes.length; i < length; i++) {
+        desc = childNodes[i];
+        if (desc.nodeName.toLowerCase() !== 'rdf:description') {
+          continue;
+        }
+
+        entries = [];
+        for (var ii = 0, iLength = desc.childNodes.length; ii < iLength; ii++) {
+          if (desc.childNodes[ii].nodeName.toLowerCase() !== '#text') {
+            entries.push(desc.childNodes[ii]);
+          }
+        }
+
+        for (ii = 0, iLength = entries.length; ii < iLength; ii++) {
+          var entry = entries[ii];
+          var name = entry.nodeName.toLowerCase();
+          var entryName = name.split(':');
+          entryName = (entryName.length > 1) ? entryName[1] : entryName[0];
+          switch (name) {
+            case 'pdf:moddate':
+            case 'xap:createdate':
+            case 'xap:metadatadate':
+            case 'xap:modifydate':
+              this.metadata[entryName] = new Date(entry.textContent.trim());
+              break;
+
+            default:
+              // For almost all entries we just add them to the metadata object
+              if (this.metadata[entryName]) {
+                this.metadata[name] = entry.textContent.trim();
+              } else {
+                this.metadata[entryName] = entry.textContent.trim();
+              }
+              break;
+          }
+        }
+      }
+    },
+
+    get: function(name) {
+      return this.metadata[name] || null;
+    },
+
+    has: function(name) {
+      return typeof this.metadata[name] !== 'undefined';
+    }
+  };
+
+  return Metadata;
+})();

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -18,27 +18,24 @@ var Metadata = (function MetadataClosure() {
       var rdf = doc.documentElement;
       if (rdf.tagName.toLowerCase() !== 'rdf:rdf') { // Wrapped in <xmpmeta>
         rdf = rdf.firstChild;
-        while (rdf.nodeName && rdf.nodeName.toLowerCase() !== 'rdf:rdf') {
+        while (rdf.nodeName && rdf.nodeName.toLowerCase() !== 'rdf:rdf')
           rdf = rdf.nextSibling;
-        }
       }
-      if (rdf.nodeName.toLowerCase() !== 'rdf:rdf' || !rdf.hasChildNodes()) {
+
+      if (rdf.nodeName.toLowerCase() !== 'rdf:rdf' || !rdf.hasChildNodes())
         return;
-      }
 
       var childNodes = rdf.childNodes, desc, namespace, entries, entry;
 
       for (var i = 0, length = childNodes.length; i < length; i++) {
         desc = childNodes[i];
-        if (desc.nodeName.toLowerCase() !== 'rdf:description') {
+        if (desc.nodeName.toLowerCase() !== 'rdf:description')
           continue;
-        }
 
         entries = [];
         for (var ii = 0, iLength = desc.childNodes.length; ii < iLength; ii++) {
-          if (desc.childNodes[ii].nodeName.toLowerCase() !== '#text') {
+          if (desc.childNodes[ii].nodeName.toLowerCase() !== '#text')
             entries.push(desc.childNodes[ii]);
-          }
         }
 
         for (ii = 0, iLength = entries.length; ii < iLength; ii++) {

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -44,25 +44,7 @@ var Metadata = (function MetadataClosure() {
         for (ii = 0, iLength = entries.length; ii < iLength; ii++) {
           var entry = entries[ii];
           var name = entry.nodeName.toLowerCase();
-          var entryName = name.split(':');
-          entryName = (entryName.length > 1) ? entryName[1] : entryName[0];
-          switch (name) {
-            case 'pdf:moddate':
-            case 'xap:createdate':
-            case 'xap:metadatadate':
-            case 'xap:modifydate':
-              this.metadata[entryName] = new Date(entry.textContent.trim());
-              break;
-
-            default:
-              // For almost all entries we just add them to the metadata object
-              if (this.metadata[entryName]) {
-                this.metadata[name] = entry.textContent.trim();
-              } else {
-                this.metadata[entryName] = entry.textContent.trim();
-              }
-              break;
-          }
+          this.metadata[name] = entry.textContent.trim();
         }
       }
     },

--- a/src/obj.js
+++ b/src/obj.js
@@ -113,24 +113,19 @@ var Catalog = (function CatalogClosure() {
   Catalog.prototype = {
     get metadata() {
       var ref = this.catDict.get('Metadata');
-      if (!ref) {
-        return null;
-      }
-
-      var stream = this.xref.fetch(ref);
-      var dict = stream.dict;
-      if (isDict(dict)) {
-        var type = dict.get('Type');
-        var subtype = dict.get('Subtype');
+      var stream = this.xref.fetchIfRef(ref);
+      var metadata;
+      if (stream && isDict(stream.dict)) {
+        var type = stream.dict.get('Type');
+        var subtype = stream.dict.get('Subtype');
 
         if (isName(type) && isName(subtype) &&
             type.name === 'Metadata' && subtype.name === 'XML') {
-          var metadata = stringToPDFString(bytesToString(stream.getBytes()));
-          return metadata;
+          metadata = stringToPDFString(bytesToString(stream.getBytes()));
         }
       }
 
-      return null;
+      return shadow(this, 'metadata', metadata);
     },
     get toplevelPagesDict() {
       var pagesObj = this.catDict.get('Pages');

--- a/src/obj.js
+++ b/src/obj.js
@@ -125,7 +125,7 @@ var Catalog = (function CatalogClosure() {
 
         if (isName(type) && isName(subtype) &&
             type.name === 'Metadata' && subtype.name === 'XML') {
-          var metadata = stringToPDFString(bytesToString(stream.getbytes()));
+          var metadata = stringToPDFString(bytesToString(stream.getBytes()));
           return metadata;
         }
       }

--- a/src/obj.js
+++ b/src/obj.js
@@ -123,7 +123,7 @@ var Catalog = (function CatalogClosure() {
         var type = dict.get('Type');
         var subtype = dict.get('Subtype');
 
-        if(isName(type) && isName(subtype) &&
+        if (isName(type) && isName(subtype) &&
             type.name === 'Metadata' && subtype.name === 'XML') {
           var metadata = stringToPDFString(bytesToString(stream.getbytes()));
           return metadata;

--- a/src/obj.js
+++ b/src/obj.js
@@ -111,6 +111,27 @@ var Catalog = (function CatalogClosure() {
   }
 
   Catalog.prototype = {
+    get metadata() {
+      var ref = this.catDict.get('Metadata');
+      if (!ref) {
+        return null;
+      }
+
+      var stream = this.xref.fetch(ref);
+      var dict = stream.dict;
+      if (isDict(dict)) {
+        var type = dict.get('Type');
+        var subtype = dict.get('Subtype');
+
+        if(isName(type) && isName(subtype) &&
+            type.name === 'Metadata' && subtype.name === 'XML') {
+          var metadata = stringToPDFString(bytesToString(stream.getbytes()));
+          return metadata;
+        }
+      }
+
+      return null;
+    },
     get toplevelPagesDict() {
       var pagesObj = this.catDict.get('Pages');
       assertWellFormed(isRef(pagesObj), 'invalid top-level pages reference');

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -11,6 +11,7 @@
         <!-- PDFJSSCRIPT_INCLUDE_BUILD -->
         <script type="text/javascript" src="../src/core.js"></script> <!-- PDFJSSCRIPT_REMOVE_CORE -->
         <script type="text/javascript" src="../src/util.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
+        <script type="text/javascript" src="../src/metadata.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
         <script type="text/javascript" src="../src/canvas.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
         <script type="text/javascript" src="../src/obj.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
         <script type="text/javascript" src="../src/function.js"></script> <!-- PDFJSSCRIPT_REMOVE_CORE -->

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -511,7 +511,7 @@ var PDFView = {
       }
     }
 
-    if (info && info.has('Title') && !pdfTitle) {
+    if (!pdfTitle && info && info.has('Title')) {
       pdfTitle = info.get('Title');
     }
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -501,11 +501,22 @@ var PDFView = {
     }
 
     var metadata = pdf.catalog.metadata;
+    var info = pdf.info;
+    var pdfTitle;
+
     if (metadata) {
       this.metadata = metadata = new Metadata(metadata);
-      if (metadata.has('title')) {
-        document.title = metadata.get('title');
+      if (metadata.has('dc:title')) {
+        pdfTitle = metadata.get('dc:title');
       }
+    }
+
+    if (info && info.has('Title') && !pdfTitle) {
+      pdfTitle = info.get('Title');
+    }
+
+    if (pdfTitle) {
+      document.title = pdfTitle;
     }
   },
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -502,7 +502,7 @@ var PDFView = {
 
     this.metadata = null;
     var metadata = pdf.catalog.metadata;
-    var info = pdf.info;
+    var info = this.documentInfo = pdf.info;
     var pdfTitle;
 
     if (metadata) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -506,18 +506,16 @@ var PDFView = {
 
     if (metadata) {
       this.metadata = metadata = new Metadata(metadata);
-      if (metadata.has('dc:title')) {
+
+      if (metadata.has('dc:title'))
         pdfTitle = metadata.get('dc:title');
-      }
     }
 
-    if (!pdfTitle && info && info.has('Title')) {
+    if (!pdfTitle && info && info.has('Title'))
       pdfTitle = info.get('Title');
-    }
 
-    if (pdfTitle) {
+    if (pdfTitle)
       document.title = pdfTitle;
-    }
   },
 
   setHash: function pdfViewSetHash(hash) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -506,7 +506,7 @@ var PDFView = {
     var pdfTitle;
 
     if (metadata) {
-      this.metadata = metadata = new Metadata(metadata);
+      this.metadata = metadata = new PDFJS.Metadata(metadata);
 
       if (metadata.has('dc:title'))
         pdfTitle = metadata.get('dc:title');

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -500,6 +500,7 @@ var PDFView = {
       this.parseScale(kDefaultScale, true);
     }
 
+    this.metadata = null;
     var metadata = pdf.catalog.metadata;
     var info = pdf.info;
     var pdfTitle;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -499,6 +499,14 @@ var PDFView = {
       // Setting the default one.
       this.parseScale(kDefaultScale, true);
     }
+
+    var metadata = pdf.catalog.metadata;
+    if (metadata) {
+      this.metadata = metadata = new Metadata(metadata);
+      if (metadata.has('title')) {
+        document.title = metadata.get('title');
+      }
+    }
   },
 
   setHash: function pdfViewSetHash(hash) {


### PR DESCRIPTION
This pull request implements a metadata parser for pdf.js - It looks for Metadata objects in the PDF file, and parses the metadata "understanding" it to some extent. Furthermore the viewer now has a access to the pdf file's metadata through `PDFViewer.metadata`.

I've added the parser to a new file called `metadata.js`

On thing that is open to discussion is how the parser handles the metadata entries. Right now most metadata information is just mapped directly into a metadata object, but maybe there's a problem with this. The metadata format for PDF files (XMP) makes it possible to use many different XML namespaces which have different meaning. It makes no sense to try to "understand" them all, but maybe the most used should be "properly" parsed and not just mapped like any other entry?
