### PR TITLE
Fix a couple of closure names.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -785,7 +785,7 @@ var PDFDoc = (function PDFDocClosure() {
           error('Only 3 component or 1 component can be returned');
 
         var img = new Image();
-        img.onload = (function jpegImageLoaderOnload() {
+        img.onload = (function messageHandler_onloadClosure() {
           var width = img.width;
           var height = img.height;
           var size = width * height;

--- a/src/fonts.js
+++ b/src/fonts.js
@@ -4247,7 +4247,7 @@ var CFFFDSelect = (function CFFFDSelectClosure() {
 
 // Helper class to keep track of where an offset is within the data and helps
 // filling in that offset once it's known.
-var CFFOffsetTracker = (function CFFOffsetTracker() {
+var CFFOffsetTracker = (function CFFOffsetTrackerClosure() {
   function CFFOffsetTracker() {
     this.offsets = {};
   }

--- a/src/image.js
+++ b/src/image.js
@@ -365,7 +365,7 @@ var PDFImage = (function PDFImageClosure() {
 
 function loadJpegStream(id, imageData, objs) {
   var img = new Image();
-  img.onload = (function jpegImageLoaderOnload() {
+  img.onload = (function loadJpegStream_onloadClosure() {
     objs.resolve(id, img);
   });
   img.src = 'data:image/jpeg;base64,' + window.btoa(imageData);

--- a/src/jpx.js
+++ b/src/jpx.js
@@ -159,7 +159,7 @@ var JpxImage = (function JpxImageClosure() {
   })();
 
   // Implements C.3. Arithmetic decoding procedures
-  var ArithmeticDecoder = (function arithmeticDecoderClosure() {
+  var ArithmeticDecoder = (function ArithmeticDecoderClosure() {
     var QeTable = [
       {qe: 0x5601, nmps: 1, nlps: 1, switchFlag: 1},
       {qe: 0x3401, nmps: 2, nlps: 6, switchFlag: 0},


### PR DESCRIPTION
Few trivial changes for closure names.

In case somebody is interested. This is the script I used for making these fixes. Some manual changes on top of that too.

```
#!/bin/sh

for file in *.js ; do
  CLASSES=`grep "= (function" ${file} | sed 's/.*var //;s/.*\.//;s/ =.*//'`
  echo ${CLASSES}

  for class in ${CLASSES} ; do
    echo ${class}
    sed 's/\(var \)\(.*\)\( = (function \)\(.*\)\((.*\)/\1\2\3\2Closure\5/' ${file} | \
    sed 's/\(.*\.\)\(.*\)\( = (function \)\(.*\)\((.*\)/\1\2\3\2Closure\5/' > _temp
    mv -f _temp ${file}
  done
done
```
