### PR TITLE
Fetch info that is stored in Refs for DocumentInfo

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -647,9 +647,17 @@ var PDFDoc = (function PDFDocClosure() {
 
     this.data = data;
     this.stream = stream;
-    this.pdfModel = new PDFDocModel(stream);
+    var model = this.pdfModel = new PDFDocModel(stream);
     this.fingerprint = this.pdfModel.getFingerprint();
-    this.info = this.pdfModel.getDocumentInfo();
+    var info = this.info = this.pdfModel.getDocumentInfo();
+    if (isDict(info)) {
+      // Iterate values so that values, which are references
+      // will be translated to the real value
+      info.forEach(function(key, val) {
+        if (isRef(val))
+          info.set(key, model.xref.fetch(val));
+      });
+    }
     this.catalog = this.pdfModel.catalog;
     this.objs = new PDFObjects();
 


### PR DESCRIPTION
This is a fix for #1447 - The `PDFDoc.info` now contains not the "raw" info dictionary, but a dictionary where every `Ref` has been fetched and therefore easier to work with. The raw dictionary can still be fetched from `PDFDocModel.getDocumentInfo()`
