### PR TITLE
Fixing driver.js for Windows bot

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -266,6 +266,9 @@ function sendTaskResult(snapshot, task, failure) {
   r.onreadystatechange = function sendTaskResultOnreadystatechange(e) {
     if (r.readyState == 4) {
       inFlightRequests--;
+      // Retry until successful
+      if (r.status !== 200)
+        sendTaskResult(snapshot, task, failure);
     }
   };
   document.getElementById('inFlightCount').innerHTML = inFlightRequests++;


### PR DESCRIPTION
Retries POST request if status !== 200. This should enable Chrome + Firefox on our Windows bot.

(It seems like on Windows the Python web server in `test.py` sometimes gets overwhelmed when both FF and Chrome are firing POST requests at it).
#### Ready to be merged after makeref is complete
