### PR TITLE
Simple heuristics for choosing document title

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -310,8 +310,9 @@ var PDFView = {
 
   open: function pdfViewOpen(url, scale) {
     this.url = url;
+    var filename = decodeURIComponent(getFileName(url)) || url;
 
-    document.title = decodeURIComponent(getFileName(url)) || url;
+    document.title = filename;
 
     if (!PDFView.loadingBar) {
       PDFView.loadingBar = new ProgressBar('#loadingBar', {});
@@ -571,11 +572,12 @@ var PDFView = {
         pdfTitle = metadata.get('dc:title');
     }
 
-    if (!pdfTitle && info && info['Title'])
+    if ((!pdfTitle || pdfTitle === '()') && info && info['Title'])
       pdfTitle = info['Title'];
 
-    if (pdfTitle)
-      document.title = pdfTitle;
+    if (pdfTitle) {
+      document.title = (pdfTitle === '()') ? filename : pdfTitle;
+    }
   },
 
   setHash: function pdfViewSetHash(hash) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -572,11 +572,11 @@ var PDFView = {
         pdfTitle = metadata.get('dc:title');
     }
 
-    if ((!pdfTitle || pdfTitle === '()') && info && info['Title'])
+    if (!pdfTitle && info && info['Title'])
       pdfTitle = info['Title'];
 
     if (pdfTitle) {
-      document.title = (pdfTitle === '()') ? filename : pdfTitle;
+      document.title = pdfTitle + ' - ' + document.title;
     }
   },
 


### PR DESCRIPTION
As the title states this is simple heuristics for choosing the document title. @aleth says that he's quite frequently seeing PDF documents with a "()" title. This is probably because of some "bad" PDF generator/encoder, but it would nonetheless be better to display the filename in such cases - which is what this pull request does.

"Fixes" #1476
