### PR TITLE
Use Title - Filename as document.title

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -575,7 +575,7 @@ var PDFView = {
       pdfTitle = info['Title'];
 
     if (pdfTitle)
-      document.title = pdfTitle;
+      document.title = pdfTitle + ' - ' + document.title;
   },
 
   setHash: function pdfViewSetHash(hash) {


### PR DESCRIPTION
As the title states this just appends the document.title with the PDF title if possible. @aleth says that he's quite frequently seeing PDF documents with a "()" title. This is probably because of some "bad" PDF generator/encoder, but it would nonetheless be better to display the filename in such cases - which is what this pull request does. After a discussion with yury, we decided to do this, so that the title will always contain _some_ relevant information (at least the filename).

"Fixes" #1476
