### PR TITLE
Fix keyboardbindings

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1456,16 +1456,6 @@ window.addEventListener('pagechange', function pagechange(evt) {
 }, true);
 
 window.addEventListener('keydown', function keydown(evt) {
-  var curElement = document.activeElement;
-  if (curElement && curElement.tagName == 'INPUT')
-    return;
-  var controlsElement = document.getElementById('controls');
-  while (curElement) {
-    if (curElement === controlsElement)
-      return; // ignoring if the 'controls' element is focused
-    curElement = curElement.parentNode;
-  }
-
   var cmd = 0;
   if (evt.ctrlKey)  cmd |= 1;
   if (evt.altKey)   cmd |= 2;
@@ -1473,23 +1463,10 @@ window.addEventListener('keydown', function keydown(evt) {
   if (evt.metaKey)  cmd |= 8; 
 
   var handled = false;
-  if (cmd == 0) { // no control key pressed at all.
-    switch (evt.keyCode) {
-      case 37: // left arrow
-      case 75: // 'k'
-      case 80: // 'p'
-        PDFView.page--;
-        handled = true;
-        break;
-      case 39: // right arrow
-      case 74: // 'j'
-      case 78: // 'n'
-        PDFView.page++;
-        handled = true;
-        break;
-    }
-  }
-  else if (cmd == 1 || cmd == 8) { // either CTRL or META key.
+
+  // First, handle the key bindings that are independent whether an input
+  // control is selected or not.
+  if (cmd == 1 || cmd == 8) { // either CTRL or META key.
     switch (evt.keyCode) {
       case 61: // FF/Mac '='
       case 107: // FF '+' and '='
@@ -1504,6 +1481,40 @@ window.addEventListener('keydown', function keydown(evt) {
         break;
       case 48: // '0'
         PDFView.parseScale(kDefaultScale, true);
+        handled = true;
+        break;
+    }
+  }
+
+  if (handled) {
+    evt.preventDefault();
+    return;
+  }
+
+  // Some shortcuts should not get handled if a control/input element
+  // is selected.
+  var curElement = document.activeElement;
+  if (curElement && curElement.tagName == 'INPUT')
+    return;
+  var controlsElement = document.getElementById('controls');
+  while (curElement) {
+    if (curElement === controlsElement)
+      return; // ignoring if the 'controls' element is focused
+    curElement = curElement.parentNode;
+  }
+
+  if (cmd == 0) { // no control key pressed at all.
+    switch (evt.keyCode) {
+      case 37: // left arrow
+      case 75: // 'k'
+      case 80: // 'p'
+        PDFView.page--;
+        handled = true;
+        break;
+      case 39: // right arrow
+      case 74: // 'j'
+      case 78: // 'n'
+        PDFView.page++;
         handled = true;
         break;
     }

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1456,8 +1456,6 @@ window.addEventListener('pagechange', function pagechange(evt) {
 }, true);
 
 window.addEventListener('keydown', function keydown(evt) {
-  if (evt.ctrlKey || evt.altKey || evt.shiftKey || evt.metaKey)
-    return;
   var curElement = document.activeElement;
   if (curElement && curElement.tagName == 'INPUT')
     return;
@@ -1467,35 +1465,48 @@ window.addEventListener('keydown', function keydown(evt) {
       return; // ignoring if the 'controls' element is focused
     curElement = curElement.parentNode;
   }
+
+  var cmd = 0;
+  if (evt.ctrlKey)  cmd |= 1;
+  if (evt.altKey)   cmd |= 2;
+  if (evt.shiftKey) cmd |= 4;
+  if (evt.metaKey)  cmd |= 8; 
+
   var handled = false;
-  switch (evt.keyCode) {
-    case 61: // FF/Mac '='
-    case 107: // FF '+' and '='
-    case 187: // Chrome '+'
-      PDFView.zoomIn();
-      handled = true;
-      break;
-    case 109: // FF '-'
-    case 189: // Chrome '-'
-      PDFView.zoomOut();
-      handled = true;
-      break;
-    case 48: // '0'
-      PDFView.parseScale(kDefaultScale, true);
-      handled = true;
-      break;
-    case 37: // left arrow
-    case 75: // 'k'
-    case 80: // 'p'
-      PDFView.page--;
-      handled = true;
-      break;
-    case 39: // right arrow
-    case 74: // 'j'
-    case 78: // 'n'
-      PDFView.page++;
-      handled = true;
-      break;
+  if (cmd == 0) { // no control key pressed at all.
+    switch (evt.keyCode) {
+      case 37: // left arrow
+      case 75: // 'k'
+      case 80: // 'p'
+        PDFView.page--;
+        handled = true;
+        break;
+      case 39: // right arrow
+      case 74: // 'j'
+      case 78: // 'n'
+        PDFView.page++;
+        handled = true;
+        break;
+    }
+  }
+  else if (cmd == 1 || cmd == 8) { // either CTRL or META key.
+    switch (evt.keyCode) {
+      case 61: // FF/Mac '='
+      case 107: // FF '+' and '='
+      case 187: // Chrome '+'
+        PDFView.zoomIn();
+        handled = true;
+        break;
+      case 109: // FF '-'
+      case 189: // Chrome '-'
+        PDFView.zoomOut();
+        handled = true;
+        break;
+      case 48: // '0'
+        PDFView.parseScale(kDefaultScale, true);
+        handled = true;
+        break;
+    }
   }
 
   if (handled) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1456,13 +1456,11 @@ window.addEventListener('pagechange', function pagechange(evt) {
 }, true);
 
 window.addEventListener('keydown', function keydown(evt) {
-  var cmd = 0;
-  if (evt.ctrlKey)  cmd |= 1;
-  if (evt.altKey)   cmd |= 2;
-  if (evt.shiftKey) cmd |= 4;
-  if (evt.metaKey)  cmd |= 8; 
-
   var handled = false;
+  var cmd = (evt.ctrlKey ? 1 : 0) |
+            (evt.altKey ? 2 : 0) |
+            (evt.shiftKey ? 4 : 0) |
+            (evt.metaKey ? 8 : 0);
 
   // First, handle the key bindings that are independent whether an input
   // control is selected or not.


### PR DESCRIPTION
The keyboard bindings for <CTRL|Cmd>+<Some key> (e.g. CMD + <plus> to zoom) are broken right now in the codebase. In the case of the zoom short cut, if someone presses the zoom key combo, the entire page gets resized and not only the page view.

Note: Listening for zoom changes by listening to the keydown event is not the optimal solution. There needs to be an API to hock into it. This pull request is only about fixing the code that is in the viewer right now, which doesn't do what it should do.
