### PR TITLE
Error on jbig2.  Add 'RL' abbreviation for run length decode.

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -249,7 +249,7 @@ var Parser = (function ParserClosure() {
       if (name == 'CCITTFaxDecode' || name == 'CCF') {
         return new CCITTFaxStream(stream, params);
       }
-      if (name == 'RunLengthDecode') {
+      if (name == 'RunLengthDecode' || name == 'RL') {
         return new RunLengthStream(stream);
       }
       if (name == 'JBIG2Decode') {

--- a/src/parser.js
+++ b/src/parser.js
@@ -252,6 +252,9 @@ var Parser = (function ParserClosure() {
       if (name == 'RunLengthDecode') {
         return new RunLengthStream(stream);
       }
+      if (name == 'JBIG2Decode') {
+        error('JBIG2 image format is not currently supprted.');
+      }
       warn('filter "' + name + '" not supported yet');
       return stream;
     }


### PR DESCRIPTION
All the JBIG2 images have been a full page so it should be okay to error out on the page.  This gives more feedback so hopefully future JBIG2 bugs will not need triage.

While doing this I noticed we don't have the abbreviation for Run length decode filters.  See "Table 94 – Additional Abbreviations in an Inline Image" in the pdf spec.
