### PR TITLE
Implement JBig2Decode using jbig2dec (emscripten)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ PDF_JS_FILES = \
   stream.js \
   worker.js \
   ../external/jpgjs/jpg.js \
+  ../external/jbig2dec/jbig2dec.js \
   jpx.js \
   bidi.js \
   metadata.js \

--- a/external/jbig2dec/COPYING
+++ b/external/jbig2dec/COPYING
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/external/jbig2dec/LICENSE
+++ b/external/jbig2dec/LICENSE
@@ -1,0 +1,23 @@
+  The files in this directory (folder) and any subdirectories 
+  (sub-folders) thereof are part of jbig2dec, with the exception
+  of certain source files included to support portability which are
+  marked otherwise in their copyright headers.
+
+  jbig2dec is free software; you can redistribute it and/or modify
+  it under the terms the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or 
+  (at your option) any later version.
+
+  This software is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program in the file named COPYING. If not, write 
+  to the Free Software Foundation, Inc., 59 Temple Place Suite 330,
+  Boston, MA 02111-1307, USA.
+
+  In addition, specific permission is given to link jbig2dec to or 
+  compile jbig2dec into AFPL Ghostscript and to distribute same
+  under the Aladdin Free Public License (AFPL) version 9.

--- a/external/jbig2dec/jbig2dec.js
+++ b/external/jbig2dec/jbig2dec.js
@@ -1,0 +1,8303 @@
+function N(oa) {
+  throw oa
+}
+var ua = void 0, V = !0, Sc = null, Y = !1, Yg = (function () {
+  function oa() {
+    var Nb, Ia, Ub, Ba, Cb, Vb;
+
+    function oa(a) {
+      eval.call(Sc, a)
+    }
+
+    function mb(a) {
+      x.print(a + ":\n" + Error().stack);
+      N("Assertion: " + a)
+    }
+
+    function cb(a, b) {
+      a || mb("Assertion failed: " + b)
+    }
+
+    function Ue(a, b, f, l) {
+      var c = 0;
+      try {
+        var s = eval("_" + a)
+      } catch (k) {
+        try {
+          s = Kg.Module["_" + a]
+        } catch (i) {
+        }
+      }
+      cb(s, "Cannot call unknown function " + a + " (perhaps LLVM optimizations or closure removed it?)");
+      var G = 0, a = l ? l.map((function (a) {
+        var h = f[G++];
+        "string" == h ? (c || (c = M.I()), h = M.H(a.length + 1), Ve(a, h), a = h) : "array" == h && (c || (c = M.I()), h = M.H(a.length), We(a, h), a = h);
+        return a
+      })) : [], b = (function (a, h) {
+        if ("string" == h) {
+          return Xe(a)
+        }
+        cb("array" != h);
+        return a
+      })(s.apply(Sc, a), b);
+      c && M.ga(c);
+      return b
+    }
+
+    function vb(a, b, f) {
+      return(function () {
+        return Ue(a, b, f, Array.prototype.slice.call(arguments))
+      })
+    }
+
+    function Ye(h, b, f) {
+      f = f || "i8";
+      "*" === f[f.length - 1] && (f = "i32");
+      switch (f) {
+        case"i1":
+          q[h] = b;
+          break;
+        case"i8":
+          q[h] = b;
+          break;
+        case"i16":
+          ja[h >> 1] = b;
+          break;
+        case"i32":
+          a[h >> 2] = b;
+          break;
+        case"i64":
+          a[h >> 2] = b;
+          break;
+        case"float":
+          nb[h >> 2] = b;
+          break;
+        case"double":
+          Ob[0] = b;
+          a[h >> 2] = cc[0];
+          a[h + 4 >> 2] = cc[1];
+          break;
+        default:
+          mb("invalid type for setValue: " + f)
+      }
+    }
+
+    function d(a, b, f) {
+      var l, c;
+      "number" === typeof a ? (l = V, c = a) : (l = Y, c = a.length);
+      var s = "string" === typeof b ? b : Sc, f = [Wb, M.H, M.ha][f === ua ? e : f](Math.max(c, s ? 1 : b.length));
+      if (l) {
+        return ea(f, 0, c), f
+      }
+      l = 0;
+      for (var k; l < c;) {
+        var i = a[l];
+        "function" === typeof i && (i = M.wf(i));
+        k = s || b[l];
+        0 === k ? l++ : ("i64" == k && (k = "i32"), Ye(f + l, i, k), l += M.B(k))
+      }
+      return f
+    }
+
+    function Xe(a, b) {
+      for (var f = "undefined" == typeof b, l = "", c = 0, s, k = String.fromCharCode(0); ;) {
+        s = String.fromCharCode(F[a + c]);
+        if (f && s == k) {
+          break
+        }
+        l += s;
+        c += 1;
+        if (!f && c == b) {
+          break
+        }
+      }
+      return l
+    }
+
+    function wb(a) {
+      for (; 0 < a.length;) {
+        var b = a.shift(), f = b.A;
+        "number" === typeof f && (f = Q[f]);
+        f(b.Be === ua ? Sc : b.Be)
+      }
+    }
+
+    function Ze(a, b) {
+      return Array.prototype.slice.call(q.subarray(a, a + b))
+    }
+
+    function oc(a) {
+      for (var b = 0; q[a + b];) {
+        b++
+      }
+      return b
+    }
+
+    function $e(a, b) {
+      var f = oc(a);
+      b && f++;
+      var l = Ze(a, f);
+      b && (l[f - 1] = 0);
+      return l
+    }
+
+    function db(a, b, f) {
+      var l = [], c = 0;
+      f === ua && (f = a.length);
+      for (; c < f;) {
+        var s = a.charCodeAt(c);
+        255 < s && (s &= 255);
+        l.push(s);
+        c += 1
+      }
+      b || l.push(0);
+      return l
+    }
+
+    function Ve(a, b, f) {
+      for (var l = 0; l < a.length;) {
+        var c = a.charCodeAt(l);
+        255 < c && (c &= 255);
+        q[b + l] = c;
+        l += 1
+      }
+      f || (q[b + l] = 0)
+    }
+
+    function We(a, b) {
+      for (var f = 0; f < a.length; f++) {
+        q[b + f] = a[f]
+      }
+    }
+
+    function ce(a, b) {
+      return 0 <= a ? a : 32 >= b ? 2 * Math.abs(1 << b - 1) + a : Math.pow(2, b) + a
+    }
+
+    function af(a, b) {
+      if (0 >= a) {
+        return a
+      }
+      var f = 32 >= b ? Math.abs(1 << b - 1) : Math.pow(2, b - 1);
+      if (a >= f && (32 >= b || a > f)) {
+        a = -2 * f + a
+      }
+      return a
+    }
+
+    function Ac(a) {
+      return(F[a] & 255) << 8 | F[a + 1 | 0] & 255
+    }
+
+    function Pa(a) {
+      return F[a + 3 | 0] & 255 | ((F[a] & 255) << 8 | F[a + 1 | 0] & 255) << 16 | (F[a + 2 | 0] & 255) << 8
+    }
+
+    function ia(a) {
+      return F[a + 3 | 0] & 255 | ((F[a] & 255) << 8 | F[a + 1 | 0] & 255) << 16 | (F[a + 2 | 0] & 255) << 8
+    }
+
+    function bf(a, b) {
+      var f = p[a + 4 >> 2], l = p[a + 8 >> 2], c = (b + 4 | 0) >>> 0 < l >>> 0;
+      a:do {
+        if (c) {
+          var s = (F[b + (f + 1) | 0] & 255) << 16 | (F[f + b | 0] & 255) << 24 | F[b + (f + 3) | 0] & 255 | (F[b + (f + 2) | 0] & 255) << 8
+        } else {
+          if (l >>> 0 > b >>> 0) {
+            for (var k = l - b | 0, i = 0, G = 0; ;) {
+              if (i |= (F[f + G + b | 0] & 255) << (3 - G << 3), G = G + 1 | 0, G >>> 0 >= k >>> 0) {
+                s = i;
+                break a
+              }
+            }
+          } else {
+            s = 0
+          }
+        }
+      } while (0);
+      return s
+    }
+
+    function O(h, b) {
+      return Q[a[h >> 2]](h, b)
+    }
+
+    function K(h, b) {
+      Q[a[h + 4 >> 2]](h, b)
+    }
+
+    function pc(h, b, f) {
+      return Q[a[h + 8 >> 2]](h, b, f)
+    }
+
+    function m(h, z, f, l) {
+      var c = b;
+      b += 1028;
+      var s = c + 1024;
+      a[s >> 2] = arguments[m.length];
+      for (var k = c | 0, s = cf(l, a[s >> 2]), i = Math.min(s.length, 1023), G = 0; G < i; G++) {
+        q[k + G] = s[G]
+      }
+      q[k + G] = 0;
+      s = s.length;
+      if (0 > (s | 0) | 1024 == (s | 0)) {
+        for (var s = g.Xa | 0, i = Y, va = 0; 1024 > va; va++) {
+          G = i ? 0 : q[s + va], q[k + va] = G, i = i || 0 == q[s + va]
+        }
+      }
+      k = Q[a[h + 12 >> 2]](a[h + 16 >> 2], k, z, f);
+      b = c;
+      return 3 == (z | 0) ? -1 : k
+    }
+
+    function df(h, b, f, l, c) {
+      var s, k, h = 0 == (h | 0) ? ef : h, i = 0 == (l | 0) ? 4 : l, G = O(h, 76), l = G >> 2, va = 0 == (G | 0);
+      a:do {
+        if (va) {
+          Q[i](c, g.Ca | 0, 3, -1)
+        } else {
+          s = G;
+          a[s >> 2] = h;
+          a[l + 1] = b;
+          a[l + 2] = f;
+          a[l + 3] = i;
+          a[l + 4] = c;
+          a[l + 9] = b & 1;
+          a[l + 5] = 0;
+          a[l + 14] = 0;
+          a[l + 12] = 16;
+          k = O(h, 64);
+          var L = G + 52 | 0;
+          a[L >> 2] = k;
+          if (0 == (k | 0)) {
+            Q[i](c, g.Rb | 0, 3, -1), K(h, G)
+          } else {
+            a[l + 15] = 0;
+            a[l + 16] = 0;
+            k = (G + 68 | 0) >> 2;
+            a[k] = 4;
+            var Ca = O(a[s >> 2], 176), r = Ca;
+            s = (G + 72 | 0) >> 2;
+            a[s] = r;
+            if (0 == (Ca | 0)) {
+              Q[i](c, g.zc | 0, 3, -1), K(h, a[L >> 2]), K(h, G)
+            } else {
+              if (0 < (a[k] | 0)) {
+                for (L = 0; ;) {
+                  a[(r >> 2) + (11 * L | 0)] = 0;
+                  a[(a[s] + 44 * L + 4 | 0) >> 2] = 0;
+                  a[(a[s] + 44 * L + 40 | 0) >> 2] = 0;
+                  L = L + 1 | 0;
+                  if ((L | 0) >= (a[k] | 0)) {
+                    break a
+                  }
+                  r = a[s]
+                }
+              }
+            }
+          }
+        }
+      } while (0);
+      return G
+    }
+
+    function ff(h, z, f) {
+      var l, n, s, k, i, G, va, L, Ca = b;
+      b += 4;
+      var r;
+      L = (h + 20 | 0) >> 2;
+      l = p[L];
+      n = 0 == (l | 0);
+      do {
+        if (n) {
+          for (r = 1024; ;) {
+            s = r << 1;
+            if (s >>> 0 >= f >>> 0) {
+              break
+            }
+            r = s
+          }
+          r = O(a[h >> 2], s);
+          a[L] = r;
+          0 == (r | 0) ? (j = m(h, 3, -1, g.ed | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), r = 51) : (a[h + 24 >> 2] = s, G = h + 28 | 0, a[G >> 2] = 0, a[h + 32 >> 2] = 0, H = r, C = 0, G >>= 2, r = 16)
+        } else {
+          va = (h + 32 | 0) >> 2;
+          r = p[va];
+          var o = r + f | 0, d = h + 24 | 0, t = p[d >> 2], u = h + 28 | 0;
+          i = u >> 2;
+          if (o >>> 0 > t >>> 0) {
+            var e = p[i];
+            if (e >>> 0 > t >>> 1 >>> 0) {
+              r = 8
+            } else {
+              if (r = r - e | 0, (r + f | 0) >>> 0 > t >>> 0) {
+                r = 8
+              } else {
+                var v = l, t = l + e | 0;
+                if (t < v && v < t + r) {
+                  t += r;
+                  for (v += r; r--;) {
+                    v--, t--, q[v] = q[t]
+                  }
+                } else {
+                  eb(v, t, r)
+                }
+                v = a[L];
+                r = 15
+              }
+            }
+            if (8 == r) {
+              r = o - e | 0;
+              for (v = 1024; ;) {
+                k = v << 1;
+                if (k >>> 0 >= r >>> 0) {
+                  break
+                }
+                v = k
+              }
+              r = h | 0;
+              v = O(a[r >> 2], k);
+              if (0 == (v | 0)) {
+                var j = m(h, 3, -1, g.Cd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                r = 51;
+                break
+              }
+              H = a[i];
+              eb(v, a[L] + H | 0, a[va] - H | 0);
+              K(a[r >> 2], a[L]);
+              a[L] = v;
+              a[d >> 2] = k
+            }
+            C = a[va] - a[i] | 0;
+            a[va] = C;
+            a[i] = 0;
+            H = v
+          } else {
+            var H = l, C = r
+          }
+          G = u;
+          G >>= 2;
+          r = 16
+        }
+      } while (0);
+      a:do {
+        if (16 == r) {
+          i = (h + 32 | 0) >> 2;
+          eb(H + C | 0, z, f);
+          a[i] = a[i] + f | 0;
+          k = (h + 36 | 0) >> 2;
+          va = h + 40 | 0;
+          u = h + 44 | 0;
+          d = h;
+          s = (h + 56 | 0) >> 2;
+          v = h + 48 | 0;
+          o = h | 0;
+          n = (h + 52 | 0) >> 2;
+          l = (h + 60 | 0) >> 2;
+          b:for (; ;) {
+            e = a[k];
+            c:for (; ;) {
+              for (; ;) {
+                if (0 == (e | 0)) {
+                  e = p[G];
+                  if (9 > (a[i] - e | 0) >>> 0) {
+                    j = 0;
+                    break a
+                  }
+                  var t = p[L], D;
+                  d:{
+                    for (D = 0; 8 > D; D++) {
+                      var B = q[(t + e | 0) + D], I = q[(g.xe | 0) + D];
+                      if (B != I) {
+                        D = B > I ? 1 : -1;
+                        break d
+                      }
+                    }
+                    D = 0
+                  }
+                  if (0 != (D | 0)) {
+                    j = m(h, 3, -1, g.Pd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                    break a
+                  }
+                  e = F[e + (t + 8) | 0];
+                  q[va] = e;
+                  t = e & 255;
+                  0 != (t & 252 | 0) && (m(h, 2, -1, g.Zd | 0, (c = b, b += 4, a[c >> 2] = t, c)), e = q[va]);
+                  if (0 == (e & 2) << 24 >> 24) {
+                    e = p[G];
+                    if (13 > (a[i] - e | 0) >>> 0) {
+                      j = 0;
+                      break a
+                    }
+                    t = Pa(a[L] + e + 9 | 0);
+                    a[u >> 2] = t;
+                    a[G] = e + 13 | 0;
+                    1 == (t | 0) ? m(h, 1, -1, g.ie | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)) : m(h, 1, -1, g.se | 0, (c = b, b += 4, a[c >> 2] = t, c))
+                  } else {
+                    a[u >> 2] = 0, a[G] = a[G] + 9 | 0
+                  }
+                  if (0 == (q[va] & 1) << 24 >> 24) {
+                    a[k] = 3;
+                    m(h, 0, -1, g.Aa | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                    continue b
+                  }
+                  a[k] = 1;
+                  m(h, 0, -1, g.ra | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                  continue b
+                } else {
+                  if (1 == (e | 0) || 3 == (e | 0)) {
+                    e = a[G];
+                    t = e = gf(d, a[L] + e | 0, a[i] - e | 0, Ca);
+                    if (0 == (e | 0)) {
+                      j = 0;
+                      break a
+                    }
+                    a[G] = a[G] + a[Ca >> 2] | 0;
+                    B = a[s];
+                    D = a[v >> 2];
+                    (B | 0) == (D | 0) ? (B = a[o >> 2], I = a[n], a[v >> 2] = D << 2, B = pc(B, I, D << 4), a[n] = B, D = a[s]) : (D = B, B = a[n]);
+                    a[s] = D + 1 | 0;
+                    a[B + (D << 2) >> 2] = t;
+                    if (3 == (a[k] | 0)) {
+                      if (51 != (q[e + 4 | 0] & 63) << 24 >> 24) {
+                        continue b
+                      }
+                      e = 4
+                    } else {
+                      e = 2
+                    }
+                    a[k] = e;
+                    continue c
+                  } else {
+                    if (2 == (e | 0) || 4 == (e | 0)) {
+                      t = p[a[n] + (a[l] << 2) >> 2];
+                      e = t + 12 | 0;
+                      D = p[G];
+                      if (p[e >> 2] >>> 0 > (a[i] - D | 0) >>> 0) {
+                        hf(g.ze | 0);
+                        j = 0;
+                        break a
+                      }
+                      t = Nc(d, t, a[L] + D | 0);
+                      a[G] = a[G] + a[e >> 2] | 0;
+                      e = a[l] + 1 | 0;
+                      a[l] = e;
+                      4 == (a[k] | 0) ? (e | 0) == (a[s] | 0) && (a[k] = 5) : a[k] = 1;
+                      if (0 <= (t | 0)) {
+                        continue b
+                      }
+                      a[k] = 5;
+                      j = t;
+                      break a
+                    } else {
+                      if (5 == (e | 0)) {
+                        if ((a[G] | 0) == (a[i] | 0)) {
+                          j = 0;
+                          break a
+                        }
+                        j = m(h, 2, -1, g.Ta | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                        break a
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      } while (0);
+      b = Ca;
+      return j
+    }
+
+    function jf(h) {
+      var b = a[h >> 2];
+      K(b, a[h + 20 >> 2]);
+      var f = h + 52 | 0, c = a[f >> 2];
+      if (0 != (c | 0)) {
+        var n = h + 56 | 0, s = 0 < (a[n >> 2] | 0);
+        a:do {
+          if (s) {
+            for (var k = h, i = 0, G = c; ;) {
+              if (kf(k, a[G + (i << 2) >> 2]), i = i + 1 | 0, G = a[f >> 2], (i | 0) >= (a[n >> 2] | 0)) {
+                var g = G;
+                break a
+              }
+            }
+          } else {
+            g = c
+          }
+        } while (0);
+        K(b, g)
+      }
+      f = h + 72 | 0;
+      c = a[f >> 2];
+      if (0 != (c | 0)) {
+        n = h + 64 | 0;
+        s = a[n >> 2];
+        k = 0 > (s | 0);
+        a:do {
+          if (k) {
+            var L = c
+          } else {
+            for (var g = h, i = 0, G = c, e = s; ;) {
+              var r = a[(G + 40 >> 2) + (11 * i | 0)];
+              0 != (r | 0) && (Qa(g, r), e = a[n >> 2], G = a[f >> 2]);
+              i = i + 1 | 0;
+              if ((i | 0) > (e | 0)) {
+                L = G;
+                break a
+              }
+            }
+          }
+        } while (0);
+        K(b, L)
+      }
+      K(b, h)
+    }
+
+    function Gd(h, z, f) {
+      var l = O(a[h >> 2], 12);
+      0 == (l | 0) ? (m(h, 3, -1, g.bb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), h = 0) : (a[l >> 2] = 2, a[(l + 4 | 0) >> 2] = z, a[(l + 8 | 0) >> 2] = f, h = l);
+      return h
+    }
+
+    function Tc(h, b) {
+      K(a[h >> 2], b)
+    }
+
+    function Hd(h, z) {
+      var f, l = O(a[h >> 2], 28);
+      if (0 == (l | 0)) {
+        m(h, 3, -1, g.pc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c))
+      } else {
+        a[(l + 20 | 0) >> 2] = z;
+        var n = Q[a[z >> 2]](z, 0);
+        a[(l + 12 | 0) >> 2] = n;
+        a[(l + 16 | 0) >> 2] = 4;
+        a[(l + 24 | 0) >> 2] = 4;
+        f = l >> 2;
+        a[f] = n >>> 8 & 16711680;
+        qc(l);
+        a[f] <<= 7;
+        f = l + 8 | 0;
+        a[f >> 2] = a[f >> 2] - 7 | 0;
+        a[(l + 4 | 0) >> 2] = 32768
+      }
+      return l
+    }
+
+    function qc(h) {
+      var b, f, c, n;
+      b = h >> 2;
+      n = (h + 12 | 0) >> 2;
+      var s = p[n];
+      if (-16777216 == (s & -16777216 | 0)) {
+        f = (h + 16 | 0) >> 2;
+        var k = p[f];
+        1 == (k | 0) ? (s = a[b + 5], k = a[s >> 2], c = (h + 24 | 0) >> 2, s = Q[k](s, a[c]), a[n] = s, a[c] = a[c] + 4 | 0, 2415919103 < s >>> 0 ? (h |= 0, a[h >> 2] = a[h >> 2] + 65280 | 0, a[b + 2] = 8, a[n] = s >>> 8 & 16711680 | -16777216, a[f] = 2) : (h |= 0, a[h >> 2] = a[h >> 2] + (s >>> 15 & 130560) | 0, a[b + 2] = 7, a[f] = 4)) : (c = s >>> 16 & 255, 143 < c >>> 0 ? (h |= 0, a[h >> 2] = a[h >> 2] + 65280 | 0, a[b + 2] = 8) : (a[f] = k - 1 | 0, a[n] = s << 8, h |= 0, a[h >> 2] = (c << 9) + a[h >> 2] | 0, a[b + 2] = 7))
+      } else {
+        a[b + 2] = 8, c = s << 8, a[n] = c, f = (h + 16 | 0) >> 2, s = a[f] - 1 | 0, a[f] = s, 0 == (s | 0) && (c = a[b + 5], s = a[c >> 2], b = (h + 24 | 0) >> 2, c = Q[s](c, a[b]), a[n] = c, a[b] = a[b] + 4 | 0, a[f] = 4), n = c, h |= 0, a[h >> 2] = (n >>> 16 & 65280) + a[h >> 2] | 0
+      }
+    }
+
+    function T(h, b) {
+      var f, c = F[b] & 255, n = c & 127, s = Da[ob + (n << 2) >> 1] & 65535;
+      f = (h + 4 | 0) >> 2;
+      var k = a[f] - s | 0;
+      a[f] = k;
+      var i = h | 0, G = p[i >> 2];
+      G >>> 16 >>> 0 < s >>> 0 ? (a[f] = s, f = c >>> 7, (k | 0) < (s | 0) ? (s = f, n = q[b] ^ q[(n << 2) + ob + 2 | 0]) : (s = 1 - f | 0, n = q[b] ^ q[(n << 2) + ob + 3 | 0]), q[b] = n, lf(h), n = s) : (a[i >> 2] = G - (s << 16) | 0, 0 == (k & 32768 | 0) ? (f = c >>> 7, (k | 0) < (s | 0) ? (s = 1 - f | 0, n = q[b] ^ q[(n << 2) + ob + 3 | 0]) : (s = f, n = q[b] ^ q[(n << 2) + ob + 2 | 0]), q[b] = n, lf(h), n = s) : n = c >>> 7);
+      return n
+    }
+
+    function lf(h) {
+      var b;
+      b = (h + 8 | 0) >> 2;
+      for (var f = h + 4 | 0, c = h | 0, n = a[b]; ;) {
+        if (0 == (n | 0)) {
+          qc(h);
+          var s = a[b]
+        } else {
+          s = n
+        }
+        n = a[f >> 2] << 1;
+        a[f >> 2] = n;
+        a[c >> 2] <<= 1;
+        s = s - 1 | 0;
+        a[b] = s;
+        if (0 != (n & 32768 | 0)) {
+          break
+        }
+        n = s
+      }
+    }
+
+    function Ce(h, z) {
+      var f = h | 0, l = O(a[f >> 2], 8), n = 1 << z;
+      0 == (l | 0) ? m(h, 3, -1, g.tc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)) : (a[l >> 2] = z, f = O(a[f >> 2], n), a[(l + 4 | 0) >> 2] = f, 0 == (f | 0) ? m(h, 3, -1, g.Pa | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)) : ea(f, 0, n));
+      return l
+    }
+
+    function mf(h, b, f) {
+      var c = a[h + 4 >> 2], h = a[h >> 2], n = 0 < (h | 0);
+      a:do {
+        if (n) {
+          for (var s = 1, k = 0; ;) {
+            if (s = T(b, c + s | 0) | s << 1, k = k + 1 | 0, (k | 0) == (h | 0)) {
+              var i = s;
+              break a
+            }
+          }
+        } else {
+          i = 1
+        }
+      } while (0);
+      a[f >> 2] = i - (1 << h) | 0
+    }
+
+    function De(h, b) {
+      if (0 != (b | 0)) {
+        var f = h | 0;
+        K(a[f >> 2], a[b + 4 >> 2]);
+        K(a[f >> 2], b)
+      }
+    }
+
+    function fa(h) {
+      var z = O(a[h >> 2], 512);
+      0 == (z | 0) ? m(h, 3, -1, g.Bc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)) : ea(z, 0, 512);
+      return z
+    }
+
+    function Ja(h, b, f) {
+      var c = T(b, h + 1 | 0), n = c | 2, s = T(b, h + n | 0), k = n << 1 | s;
+      if (0 == (s | 0)) {
+        var s = 0, n = 2, i = k
+      } else {
+        s = T(b, h + k | 0), k = s | k << 1, 0 == (s | 0) ? (n = s = 4, i = k) : (s = T(b, h + k | 0), k = s | k << 1, 0 == (s | 0) ? (s = 20, n = 6, i = k) : (s = T(b, h + k | 0), k = s | k << 1, 0 == (s | 0) ? (s = 84, n = 8, i = k) : (i = T(b, h + k | 0), s = (n = 0 == (i | 0)) ? 340 : 4436, n = n ? 12 : 32, i |= k << 1)))
+      }
+      for (var G = k = 0; ;) {
+        var g = T(b, h + i | 0), L = g | k << 1, G = G + 1 | 0;
+        if ((G | 0) >= (n | 0)) {
+          break
+        }
+        k = L;
+        i = i << 1 & 510 | i & 256 | g
+      }
+      h = L + s | 0;
+      h = (c = 0 != (c | 0)) ? -h | 0 : h;
+      a[f >> 2] = h;
+      return c & 0 == (h | 0) & 1
+    }
+
+    function ga(h, b) {
+      K(a[h >> 2], b | 0)
+    }
+
+    function nf(h, z) {
+      var f = O(a[h >> 2], 20);
+      if (0 == (f | 0)) {
+        m(h, 3, -1, g.Hc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c))
+      } else {
+        a[(f + 12 | 0) >> 2] = 0;
+        a[(f + 8 | 0) >> 2] = 0;
+        var l = z | 0, n = Q[a[l >> 2]](z, 0);
+        a[f >> 2] = n;
+        l = Q[a[l >> 2]](z, 4);
+        a[(f + 4 | 0) >> 2] = l;
+        a[(f + 16 | 0) >> 2] = z
+      }
+      return f
+    }
+
+    function ue(h) {
+      var b, f;
+      f = (h + 8 | 0) >> 2;
+      var c = p[f];
+      b = c & 7;
+      if (0 != (b | 0)) {
+        b = 8 - b | 0;
+        c = b + c | 0;
+        a[f] = c;
+        var n = h | 0;
+        a[n >> 2] = p[h + 4 >> 2] >>> ((32 - c | 0) >>> 0) | a[n >> 2] << b
+      }
+      b = c;
+      if (31 < (b | 0)) {
+        var n = a[h + 16 >> 2], c = h + 4 | 0, s = a[c >> 2];
+        b = (h | 0) >> 2;
+        a[b] = s;
+        h = h + 12 | 0;
+        s = a[h >> 2];
+        a[h >> 2] = s + 4 | 0;
+        h = Q[a[n >> 2]](n, s + 8 | 0);
+        a[c >> 2] = h;
+        c = a[f];
+        n = c - 32 | 0;
+        a[f] = n;
+        0 != (n | 0) && (a[b] = h >>> ((64 - c | 0) >>> 0) | a[b] << n)
+      }
+    }
+
+    function Ee(h, b) {
+      var f, c, n, s = a[h + 16 >> 2];
+      n = (h + 12 | 0) >> 2;
+      var k = a[n] + (b & -4) | 0;
+      a[n] = k;
+      c = (h + 8 | 0) >> 2;
+      f = a[c] + (b << 3 & 24) | 0;
+      a[c] = f;
+      31 < (f | 0) && (k = k + 4 | 0, a[n] = k, a[c] = f - 32 | 0);
+      f = k;
+      var k = s | 0, i = Q[a[k >> 2]](s, f);
+      f = (h | 0) >> 2;
+      a[f] = i;
+      n = Q[a[k >> 2]](s, a[n] + 4 | 0);
+      a[h + 4 >> 2] = n;
+      c = a[c];
+      0 < (c | 0) && (a[f] = a[f] << c | n >>> ((32 - c | 0) >>> 0))
+    }
+
+    function Oc(h, b) {
+      var f, c;
+      c = (h | 0) >> 2;
+      var n = p[c], s = n >>> ((32 - b | 0) >>> 0);
+      f = (h + 8 | 0) >> 2;
+      var k = a[f] + b | 0;
+      a[f] = k;
+      if (31 < (k | 0)) {
+        var i = h + 12 | 0, n = p[i >> 2];
+        a[i >> 2] = n + 4 | 0;
+        a[f] = k - 32 | 0;
+        k = h + 4 | 0;
+        a[c] = a[k >> 2];
+        i = a[h + 16 >> 2];
+        n = Q[a[i >> 2]](i, n + 8 | 0);
+        a[k >> 2] = n;
+        f = a[f];
+        k = a[c] << f;
+        a[c] = 0 == (f | 0) ? k : k | n >>> ((32 - f | 0) >>> 0)
+      } else {
+        a[c] = p[h + 4 >> 2] >>> ((32 - k | 0) >>> 0) | n << b
+      }
+      return s
+    }
+
+    function pa(h, b, f) {
+      var c, n = h + 8 | 0, s = h | 0;
+      c = (h + 4 | 0) >> 2;
+      for (var k = h + 16 | 0, h = (h + 12 | 0) >> 2, i = b, G = a[n >> 2], g = a[s >> 2], b = a[c]; ;) {
+        var L = g >>> ((32 - a[i >> 2] | 0) >>> 0), e = p[i + 4 >> 2], r = (L << 3) + e | 0, o = F[(L << 3) + e + 6 | 0], d = F[(L << 3) + e + 4 | 0] & 255, t = d + G | 0;
+        if (31 < (t | 0)) {
+          var d = a[k >> 2], u = p[h];
+          a[h] = u + 4 | 0;
+          d = Q[a[d >> 2]](d, u + 8 | 0);
+          t = t - 32 | 0;
+          a[c] = d;
+          u = G = t;
+          t = b
+        } else {
+          G = d, d = b, u = t, t = g
+        }
+        t = 0 == (G | 0) ? t : t << G | d >>> ((32 - u | 0) >>> 0);
+        o &= 255;
+        if (0 == (o & 4 | 0)) {
+          break
+        }
+        i = a[r >> 2];
+        G = u;
+        g = t;
+        b = d
+      }
+      r = p[r >> 2];
+      L = F[(L << 3) + e + 5 | 0];
+      b = L & 255;
+      0 == L << 24 >> 24 ? (d = r, L = u, c = t) : (L = t >>> ((32 - b | 0) >>> 0), L = (0 == (o & 2 | 0) ? L : -L | 0) + r | 0, e = b + u | 0, 31 < (e | 0) ? (k = a[k >> 2], t = a[h], a[h] = t + 4 | 0, h = Q[a[k >> 2]](k, t + 8 | 0), k = e - 32 | 0, a[c] = h, c = k, t = d) : (c = b, h = d, k = e), 0 == (c | 0)) ? (d = L, L = k, c = t) : (d = L, L = k, c = t << c | h >>> ((32 - k | 0) >>> 0));
+      a[s >> 2] = c;
+      a[n >> 2] = L;
+      0 != (f | 0) && (a[f >> 2] = o & 1);
+      return d
+    }
+
+    function Bc(a) {
+      return 0 == (a | 0) ? 65536 : 1 == (a | 0) ? 16384 : 1024
+    }
+
+    function xb(h, b, f) {
+      var c = p[b >> 2], n = (c & 7) + f | 0, s = (n + 7 | 0) / 8 & -1, k = 0 < (n | 0);
+      a:do {
+        if (k) {
+          for (var i = n - (s << 3) | 0, G = 0, g = c >>> 3, L = s; ;) {
+            var L = L - 1 | 0, e = g + 1 | 0, g = F[h + g | 0] & 255, r = (L << 3) + i | 0, G = (0 < (r | 0) ? g << r : 0 > (r | 0) ? g >>> ((-r | 0) >>> 0) : g) | G;
+            if (0 >= (L | 0)) {
+              var o = G;
+              break a
+            }
+            g = e
+          }
+        } else {
+          o = 0
+        }
+      } while (0);
+      a[b >> 2] = c + f | 0;
+      return o & (-1 << f ^ -1)
+    }
+
+    function J(h, z) {
+      var f, l, n, s = p[z + 8 >> 2];
+      n = s >> 2;
+      l = (z + 4 | 0) >> 2;
+      var k = p[l];
+      f = (h | 0) >> 2;
+      var i = O(a[f], 1024), G = 0 == (i | 0);
+      a:do {
+        if (G) {
+          m(h, 3, -1, g.Ua | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+          var va = 0
+        } else {
+          ea(i, 0, 1024);
+          var L = 0 < (a[l] | 0);
+          b:do {
+            if (L) {
+              for (var e = 0, r = 0, o = -1; ;) {
+                var d = a[n + (3 * r | 0)];
+                (d | 0) > (o | 0) && ((o | 0) < (d | 0) && ea((o << 2) + i + 4 | 0, 0, d - o << 2), o = d);
+                var t = (d << 2) + i | 0;
+                a[t >> 2] = a[t >> 2] + 1 | 0;
+                t = a[n + (3 * r | 0) + 1] + d | 0;
+                d = 16 < (t | 0) ? d : t;
+                e = 17 > (d | 0) & (e | 0) < (d | 0) ? d : e;
+                r = r + 1 | 0;
+                if ((r | 0) >= (a[l] | 0)) {
+                  var u = e, y = o;
+                  break b
+                }
+              }
+            } else {
+              u = 0, y = -1
+            }
+          } while (0);
+          L = h;
+          m(L, 0, -1, g.cc | 0, (c = b, b += 4, a[c >> 2] = u, c));
+          e = 1 << u;
+          o = r = O(a[f], 8);
+          if (0 == (r | 0)) {
+            m(L, 3, -1, g.Kc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), va = 0
+          } else {
+            if (a[r >> 2] = u, d = t = O(a[f], e << 3), 0 == (t | 0)) {
+              m(L, 3, -1, g.ld | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), va = 0
+            } else {
+              t = r + 4 | 0;
+              a[t >> 2] = d;
+              a[i >> 2] = 0;
+              var v = z | 0, j = k - 1 | 0, H = 0, C = 1;
+              b:for (; ;) {
+                if ((C | 0) > (y | 0)) {
+                  K(a[f], i);
+                  va = o;
+                  break a
+                }
+                for (var D = u - C | 0, B = a[i + (C - 1 << 2) >> 2] + H << 1, I = 0, P = B; ;) {
+                  if ((I | 0) >= (k | 0)) {
+                    H = B;
+                    C = C + 1 | 0;
+                    continue b
+                  }
+                  var Fe = p[n + (3 * I | 0)], w = (Fe | 0) == (C | 0);
+                  c:do {
+                    if (w) {
+                      var F = a[n + (3 * I | 0) + 1], x = P << D, A = P + 1 | 0, E = A << D;
+                      if ((E | 0) > (e | 0)) {
+                        m(L, 3, -1, g.Gd | 0, (c = b, b += 8, a[c >> 2] = E, a[c + 4 >> 2] = e, c));
+                        K(a[f], a[t >> 2]);
+                        K(a[f], r);
+                        K(a[f], i);
+                        va = 0;
+                        break a
+                      }
+                      var J = 0 != (a[v >> 2] | 0), U = J & (I | 0) == (j | 0) & 1, J = (I | 0) == (k - (J ? 3 : 2) | 0) ? U | 2 : U, Ua = F + Fe | 0, U = (x | 0) < (E | 0);
+                      if (16 < (Ua | 0)) {
+                        if (U) {
+                          for (var U = s + 12 * I + 8 | 0, M = Fe & 255, F = F & 255; ;) {
+                            if (a[((x << 3) + d | 0) >> 2] = a[U >> 2], q[(x << 3) + d + 4 | 0] = M, q[(x << 3) + d + 5 | 0] = F, q[(x << 3) + d + 6 | 0] = J, x = x + 1 | 0, (x | 0) == (E | 0)) {
+                              wa = A;
+                              break c
+                            }
+                          }
+                        } else {
+                          var wa = A
+                        }
+                      } else {
+                        if (U) {
+                          if (U = D - F | 0, F = (1 << F) - 1 | 0, M = s + 12 * I + 8 | 0, Ua &= 255, 0 == (J & 2) << 24 >> 24) {
+                            for (; ;) {
+                              if (a[((x << 3) + d | 0) >> 2] = a[M >> 2] + (x >> U & F) | 0, q[(x << 3) + d + 4 | 0] = Ua, q[(x << 3) + d + 5 | 0] = 0, q[(x << 3) + d + 6 | 0] = J, x = x + 1 | 0, (x | 0) == (E | 0)) {
+                                wa = A;
+                                break c
+                              }
+                            }
+                          } else {
+                            for (; ;) {
+                              if (a[((x << 3) + d | 0) >> 2] = a[M >> 2] - (x >> U & F) | 0, q[(x << 3) + d + 4 | 0] = Ua, q[(x << 3) + d + 5 | 0] = 0, q[(x << 3) + d + 6 | 0] = J, x = x + 1 | 0, (x | 0) == (E | 0)) {
+                                wa = A;
+                                break c
+                              }
+                            }
+                          }
+                        } else {
+                          wa = A
+                        }
+                      }
+                    } else {
+                      wa = P
+                    }
+                  } while (0);
+                  I = I + 1 | 0;
+                  P = wa
+                }
+              }
+            }
+          }
+        }
+      } while (0);
+      return va
+    }
+
+    function ma(h, b) {
+      if (0 != (b | 0)) {
+        var f = h | 0;
+        K(a[f >> 2], a[b + 4 >> 2]);
+        K(a[f >> 2], b)
+      }
+    }
+
+    function of(h, z, f) {
+      var l, n, s = z >> 2, k = b;
+      b += 4;
+      var i;
+      n = k >> 2;
+      z = z + 24 | 0;
+      a[z >> 2] = 0;
+      var G = p[s + 3], va = 10 > G >>> 0;
+      a:do {
+        if (va) {
+          var L = 0, e = 0;
+          i = 20
+        } else {
+          var r = F[f] & 255;
+          i = r & 1;
+          var o = (r >>> 1 & 7) + 1 | 0, d = (r >>> 4 & 7) + 1 | 0, t = Pa(f + 1 | 0), u = Pa(f + 5 | 0), r = G << 3, y = 0 == (i | 0), v = i | 2, v = Math.floor(((r - o * v | 0) >>> 0) / ((o + d | 0) >>> 0)) + v | 0, j = f + 9 | 0, q = r - 72 | 0;
+          a[n] = 0;
+          l = (h | 0) >> 2;
+          var C = r = O(a[l], 12);
+          if (0 == (r | 0)) {
+            m(h, 3, a[s], g.Sd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+            var D = C;
+            i = 23
+          } else {
+            var B = O(a[l], 12 * v | 0), I = B;
+            if (0 == (B | 0)) {
+              m(h, 3, a[s], g.ce | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+              var P = I, x = C;
+              i = 21
+            } else {
+              for (var w = 0, A = t, E = 0; ;) {
+                var J = (E + o | 0) >>> 0 >= q >>> 0;
+                if ((A | 0) >= (u | 0)) {
+                  break
+                }
+                if (J) {
+                  L = I;
+                  e = C;
+                  i = 20;
+                  break a
+                }
+                E = xb(j, k, o);
+                a[(I + 12 * w | 0) >> 2] = E;
+                if ((a[n] + d | 0) >>> 0 >= q >>> 0) {
+                  L = I;
+                  e = C;
+                  i = 20;
+                  break a
+                }
+                E = xb(j, k, d);
+                a[(I + 12 * w + 4 | 0) >> 2] = E;
+                a[(I + 12 * w + 8 | 0) >> 2] = A;
+                w = w + 1 | 0;
+                A = (1 << E) + A | 0;
+                E = a[n]
+              }
+              if (J) {
+                L = I, e = C, i = 20
+              } else {
+                if (d = xb(j, k, o), a[(I + 12 * w | 0) >> 2] = d, a[(I + 12 * w + 4 | 0) >> 2] = 32, a[(I + 12 * w + 8 | 0) >> 2] = t - 1 | 0, t = w + 1 | 0, (a[n] + o | 0) >>> 0 < q >>> 0) {
+                  d = xb(j, k, o);
+                  a[(I + 12 * t | 0) >> 2] = d;
+                  a[(I + 12 * t + 4 | 0) >> 2] = 32;
+                  a[(I + 12 * t + 8 | 0) >> 2] = u;
+                  u = w + 2 | 0;
+                  if (y) {
+                    o = u
+                  } else {
+                    if ((a[n] + o | 0) >>> 0 >= q >>> 0) {
+                      L = I;
+                      e = C;
+                      i = 20;
+                      break
+                    }
+                    o = xb(j, k, o);
+                    a[(I + 12 * u | 0) >> 2] = o;
+                    a[(I + 12 * u + 4 | 0) >> 2] = 0;
+                    a[(I + 12 * u + 8 | 0) >> 2] = 0;
+                    o = w + 3 | 0
+                  }
+                  if ((o | 0) == (v | 0)) {
+                    var Ea = I
+                  } else {
+                    v = pc(a[l], B, 12 * o | 0);
+                    if (0 == (v | 0)) {
+                      m(h, 3, a[s], g.le | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                      P = I;
+                      x = C;
+                      i = 21;
+                      break
+                    }
+                    Ea = v
+                  }
+                  a[r >> 2] = i;
+                  a[(r + 4 | 0) >> 2] = o;
+                  a[(r + 8 | 0) >> 2] = Ea;
+                  a[z >> 2] = r;
+                  Ea = 0;
+                  i = 25
+                } else {
+                  L = I, e = C, i = 20
+                }
+              }
+            }
+          }
+        }
+      } while (0);
+      20 == i && (m(h, 3, a[s], g.c | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), P = L, x = e, i = 21);
+      21 == i && (0 != (P | 0) && K(a[h >> 2], P), D = x, i = 23);
+      23 == i && (0 != (D | 0) && K(a[h >> 2], D), Ea = -1);
+      b = k;
+      return Ea
+    }
+
+    function xa(h, b, f) {
+      var c = a[b + 16 >> 2], b = b + 20 | 0, n = 0, s = 0;
+      a:for (; ;) {
+        if ((s | 0) >= (c | 0)) {
+          var k = 0;
+          break
+        }
+        var i = rc(h, a[a[b >> 2] + (s << 2) >> 2]), G = 0 == (i | 0);
+        do {
+          if (G) {
+            var g = n
+          } else {
+            if (53 != (q[i + 4 | 0] & 63) << 24 >> 24) {
+              g = n
+            } else {
+              if ((n | 0) == (f | 0)) {
+                k = a[i + 24 >> 2];
+                break a
+              }
+              g = n + 1 | 0
+            }
+          }
+        } while (0);
+        n = g;
+        s = s + 1 | 0
+      }
+      return k
+    }
+
+    function hd(h, z, f, l, n, s) {
+      var k, i = f + 16 | 0, G = f | 0, va = 0 == (a[G >> 2] | 0);
+      a:do {
+        if (va) {
+          if (0 != (a[f + 8 >> 2] | 0)) {
+            var L;
+            L = f;
+            k = l;
+            var e = n, r = s, o = a[L + 4 >> 2];
+            0 == (o | 0) ? (pf(L, k, e, r), L = 0) : 1 == (o | 0) ? (qf(L, k, e, r), L = 0) : 2 == (o | 0) ? (rf(L, k, e, r), L = 0) : 3 == (o | 0) ? (sf(L, k, e, r), L = 0) : L = -1;
+            k = 26
+          } else {
+            if (k = f + 4 | 0, e = a[k >> 2], 0 == (e | 0)) {
+              L = 3 == q[i] << 24 >> 24;
+              do {
+                if (L && -1 == q[f + 17 | 0] << 24 >> 24 && -3 == q[f + 18 | 0] << 24 >> 24 && -1 == q[f + 19 | 0] << 24 >> 24 && 2 == q[f + 20 | 0] << 24 >> 24 && -2 == q[f + 21 | 0] << 24 >> 24 && -2 == q[f + 22 | 0] << 24 >> 24 && -2 == q[f + 23 | 0] << 24 >> 24) {
+                  tf(l, n, s);
+                  L = 0;
+                  k = 26;
+                  break a
+                }
+              } while (0);
+              uf(f, l, n, s);
+              L = 0;
+              k = 26
+            } else {
+              if (1 == (e | 0)) {
+                vf(l, n, s), L = 0, k = 26
+              } else {
+                if (2 == (e | 0)) {
+                  L = 3 == q[i] << 24 >> 24;
+                  do {
+                    if (L && -1 == q[f + 17 | 0] << 24 >> 24) {
+                      wf(l, n, s);
+                      L = 0;
+                      k = 26;
+                      break a
+                    }
+                  } while (0);
+                  xf(l, n, s);
+                  L = 0;
+                  k = 26
+                } else {
+                  if (3 == (e | 0)) {
+                    L = 2 == q[i] << 24 >> 24;
+                    do {
+                      if (L && -1 == q[f + 17 | 0] << 24 >> 24) {
+                        id(f, l, n, s);
+                        L = 0;
+                        k = 26;
+                        break a
+                      }
+                    } while (0);
+                    id(f, l, n, s);
+                    L = 0;
+                    k = 26
+                  } else {
+                    d = k, k = 3
+                  }
+                }
+              }
+            }
+          }
+        } else {
+          var d = f + 4 | 0;
+          k = 3
+        }
+      } while (0);
+      3 == k && (z = (z | 0) >> 2, i = q[i] << 24 >> 24, m(h, 0, a[z], g.d | 0, (c = b, b += 8, a[c >> 2] = 0, a[c + 4 >> 2] = i, c)), i = q[f + 17 | 0] << 24 >> 24, m(h, 0, a[z], g.d | 0, (c = b, b += 8, a[c >> 2] = 1, a[c + 4 >> 2] = i, c)), i = q[f + 18 | 0] << 24 >> 24, m(h, 0, a[z], g.d | 0, (c = b, b += 8, a[c >> 2] = 2, a[c + 4 >> 2] = i, c)), i = q[f + 19 | 0] << 24 >> 24, m(h, 0, a[z], g.d | 0, (c = b, b += 8, a[c >> 2] = 3, a[c + 4 >> 2] = i, c)), i = q[f + 20 | 0] << 24 >> 24, m(h, 0, a[z], g.d | 0, (c = b, b += 8, a[c >> 2] = 4, a[c + 4 >> 2] = i, c)), i = q[f + 21 | 0] << 24 >> 24, m(h, 0, a[z], g.d | 0, (c = b, b += 8, a[c >> 2] = 5, a[c + 4 >> 2] = i, c)), i = q[f + 22 | 0] << 24 >> 24, m(h, 0, a[z], g.d | 0, (c = b, b += 8, a[c >> 2] = 6, a[c + 4 >> 2] = i, c)), f = q[f + 23 | 0] << 24 >> 24, m(h, 0, a[z], g.d | 0, (c = b, b += 8, a[c >> 2] = 7, a[c + 4 >> 2] = f, c)), G = a[G >> 2], d = a[d >> 2], m(h, 2, a[z], g.cb | 0, (c = b, b += 8, a[c >> 2] = G, a[c + 4 >> 2] = d, c)), L = -1);
+      return L
+    }
+
+    function tf(h, b, f) {
+      var c, n = p[b >> 2], s = p[b + 4 >> 2], k = p[b + 8 >> 2], i = -k | 0, G = 0 < (s | 0);
+      a:do {
+        if (G) {
+          for (var g = n + 7 & -8, e = -(k << 1) | 0, d = 0 < (g | 0), r = 1 - k | 0, o = e | 1, j = n ^ -1, t = 0, u = a[b + 12 >> 2]; ;) {
+            var y = 0 < (t | 0);
+            if (y) {
+              var v = F[u + i | 0] & 255;
+              if (1 < (t | 0)) {
+                m = (F[u + e | 0] & 255) << 6, H = 1
+              } else {
+                var m = 0, H = 0
+              }
+            } else {
+              H = v = m = 0
+            }
+            b:do {
+              if (d) {
+                var C = 0;
+                c = C >> 3;
+                for (var D = m & 63488 | v & 240, B = v, I = m, P = j; ;) {
+                  var x = -9 < (P | 0) ? P ^ -1 : 8, B = y ? ((C + 8 | 0) < (n | 0) ? F[u + r + c | 0] & 255 : 0) | B << 8 : B, I = H ? ((C + 8 | 0) < (n | 0) ? (F[u + o + c | 0] & 255) << 6 : 0) | I << 8 : I, w = 0 < (n - C | 0);
+                  c:do {
+                    if (w) {
+                      for (var A = D, E = 0, K = 0; ;) {
+                        var J = T(h, f + A | 0), O = 7 - K | 0, E = (J << O | E & 255) & 255, A = I >>> (O >>> 0) & 2048 | A << 1 & 63470 | B >>> (O >>> 0) & 16 | J, K = K + 1 | 0;
+                        if ((K | 0) == (x | 0)) {
+                          var U = A, M = E;
+                          break c
+                        }
+                      }
+                    } else {
+                      U = D, M = 0
+                    }
+                  } while (0);
+                  q[u + c | 0] = M;
+                  c = C + 8 | 0;
+                  if ((c | 0) >= (g | 0)) {
+                    break b
+                  }
+                  C = c;
+                  c = C >> 3;
+                  D = U;
+                  P = P + 8 | 0
+                }
+              }
+            } while (0);
+            t = t + 1 | 0;
+            if ((t | 0) == (s | 0)) {
+              break a
+            }
+            u = u + k | 0
+          }
+        }
+      } while (0)
+    }
+
+    function uf(b, c, f, l) {
+      var n = a[f >> 2], s = a[f + 4 >> 2], k = 0 < (s | 0);
+      a:do {
+        if (k) {
+          for (var i = 0 < (n | 0), g = b + 16 | 0, e = b + 17 | 0, L = b + 18 | 0, d = b + 19 | 0, r = b + 20 | 0, o = b + 21 | 0, j = b + 22 | 0, t = b + 23 | 0, u = 0; ;) {
+            b:do {
+              if (i) {
+                for (var y = u - 1 | 0, v = u - 2 | 0, m = 0; ;) {
+                  var p = m - 1 | 0, C = m - 2 | 0, D = m + 1 | 0, p = T(c, l + (w(f, C, u) << 1 | w(f, p, u) | w(f, m - 3 | 0, u) << 2 | w(f, m - 4 | 0, u) << 3 | w(f, (q[g] << 24 >> 24) + m | 0, (q[e] << 24 >> 24) + u | 0) << 4 | w(f, m + 2 | 0, y) << 5 | w(f, D, y) << 6 | w(f, m, y) << 7 | w(f, p, y) << 8 | w(f, C, y) << 9 | w(f, (q[L] << 24 >> 24) + m | 0, (q[d] << 24 >> 24) + u | 0) << 10 | w(f, (q[r] << 24 >> 24) + m | 0, (q[o] << 24 >> 24) + u | 0) << 11 | w(f, D, v) << 12 | w(f, m, v) << 13 | w(f, p, v) << 14 | w(f, (q[j] << 24 >> 24) + m | 0, (q[t] << 24 >> 24) + u | 0) << 15) | 0);
+                  qa(f, m, u, p);
+                  if ((D | 0) == (n | 0)) {
+                    break b
+                  }
+                  m = D
+                }
+              }
+            } while (0);
+            u = u + 1 | 0;
+            if ((u | 0) == (s | 0)) {
+              break a
+            }
+          }
+        }
+      } while (0)
+    }
+
+    function vf(b, c, f) {
+      var l, n = p[c >> 2], s = p[c + 4 >> 2], k = p[c + 8 >> 2], i = -k | 0, g = 0 < (s | 0);
+      a:do {
+        if (g) {
+          for (var e = n + 7 & -8, L = -(k << 1) | 0, d = 0 < (e | 0), r = 1 - k | 0, o = L | 1, m = n ^ -1, t = 0, u = a[c + 12 >> 2]; ;) {
+            var y = 0 < (t | 0);
+            if (y) {
+              var v = F[u + i | 0] & 255;
+              if (1 < (t | 0)) {
+                j = (F[u + L | 0] & 255) << 5, H = 1
+              } else {
+                var j = 0, H = 0
+              }
+            } else {
+              H = v = j = 0
+            }
+            b:do {
+              if (d) {
+                var C = 0;
+                l = C >> 3;
+                for (var D = j >>> 1 & 7680 | v >>> 1 & 120, B = v, I = j, P = m; ;) {
+                  var x = -9 < (P | 0) ? P ^ -1 : 8, B = y ? ((C + 8 | 0) < (n | 0) ? F[u + r + l | 0] & 255 : 0) | B << 8 : B, I = H ? ((C + 8 | 0) < (n | 0) ? (F[u + o + l | 0] & 255) << 5 : 0) | I << 8 : I, w = 0 < (n - C | 0);
+                  c:do {
+                    if (w) {
+                      for (var A = D, E = 0, K = 0; ;) {
+                        var J = T(b, f + A | 0), E = (J << 7 - K | E & 255) & 255, O = 8 - K | 0, A = I >>> (O >>> 0) & 512 | A << 1 & 7670 | B >>> (O >>> 0) & 8 | J, K = K + 1 | 0;
+                        if ((K | 0) == (x | 0)) {
+                          var U = A, M = E;
+                          break c
+                        }
+                      }
+                    } else {
+                      U = D, M = 0
+                    }
+                  } while (0);
+                  q[u + l | 0] = M;
+                  l = C + 8 | 0;
+                  if ((l | 0) >= (e | 0)) {
+                    break b
+                  }
+                  C = l;
+                  l = C >> 3;
+                  D = U;
+                  P = P + 8 | 0
+                }
+              }
+            } while (0);
+            t = t + 1 | 0;
+            if ((t | 0) == (s | 0)) {
+              break a
+            }
+            u = u + k | 0
+          }
+        }
+      } while (0)
+    }
+
+    function wf(b, c, f) {
+      var l, n = p[c >> 2], s = p[c + 4 >> 2], k = p[c + 8 >> 2], i = -k | 0, g = 0 < (s | 0);
+      a:do {
+        if (g) {
+          for (var e = n + 7 & -8, d = -(k << 1) | 0, Ca = 0 < (e | 0), r = 1 - k | 0, o = d | 1, m = n ^ -1, t = 0, u = a[c + 12 >> 2]; ;) {
+            var y = 0 < (t | 0);
+            if (y) {
+              var v = F[u + i | 0] & 255;
+              if (1 < (t | 0)) {
+                j = (F[u + d | 0] & 255) << 4, H = 1
+              } else {
+                var j = 0, H = 0
+              }
+            } else {
+              H = v = j = 0
+            }
+            b:do {
+              if (Ca) {
+                var C = 0;
+                l = C >> 3;
+                for (var D = v >>> 3 & 24 | v >>> 2 & 4 | j >>> 3 & 896, B = v, I = j, P = m; ;) {
+                  var x = -9 < (P | 0) ? P ^ -1 : 8, B = y ? ((C + 8 | 0) < (n | 0) ? F[u + r + l | 0] & 255 : 0) | B << 8 : B, I = H ? ((C + 8 | 0) < (n | 0) ? (F[u + o + l | 0] & 255) << 4 : 0) | I << 8 : I, w = 0 < (n - C | 0);
+                  c:do {
+                    if (w) {
+                      for (var A = D, E = 0, K = 0; ;) {
+                        var J = T(b, f + A | 0), E = (J << 7 - K | E & 255) & 255, O = 10 - K | 0, A = I >>> (O >>> 0) & 128 | A << 1 & 882 | B >>> ((9 - K | 0) >>> 0) & 4 | B >>> (O >>> 0) & 8 | J, K = K + 1 | 0;
+                        if ((K | 0) == (x | 0)) {
+                          var U = A, M = E;
+                          break c
+                        }
+                      }
+                    } else {
+                      U = D, M = 0
+                    }
+                  } while (0);
+                  q[u + l | 0] = M;
+                  l = C + 8 | 0;
+                  if ((l | 0) >= (e | 0)) {
+                    break b
+                  }
+                  C = l;
+                  l = C >> 3;
+                  D = U;
+                  P = P + 8 | 0
+                }
+              }
+            } while (0);
+            t = t + 1 | 0;
+            if ((t | 0) == (s | 0)) {
+              break a
+            }
+            u = u + k | 0
+          }
+        }
+      } while (0)
+    }
+
+    function xf(b, c, f) {
+      var l, n = p[c >> 2], s = p[c + 4 >> 2], k = p[c + 8 >> 2], i = -k | 0, g = 0 < (s | 0);
+      a:do {
+        if (g) {
+          for (var e = n + 7 & -8, d = -(k << 1) | 0, Ca = 0 < (e | 0), r = 1 - k | 0, o = d | 1, m = n ^ -1, t = 0, u = a[c + 12 >> 2]; ;) {
+            var y = 0 < (t | 0);
+            if (y) {
+              var v = F[u + i | 0] & 255;
+              if (1 < (t | 0)) {
+                j = (F[u + d | 0] & 255) << 4, H = 1
+              } else {
+                var j = 0, H = 0
+              }
+            } else {
+              H = v = j = 0
+            }
+            b:do {
+              if (Ca) {
+                var C = 0;
+                l = C >> 3;
+                for (var D = j >>> 3 & 896 | v >>> 3 & 28, B = v, I = j, P = m; ;) {
+                  var x = -9 < (P | 0) ? P ^ -1 : 8, B = y ? ((C + 8 | 0) < (n | 0) ? F[u + r + l | 0] & 255 : 0) | B << 8 : B, I = H ? ((C + 8 | 0) < (n | 0) ? (F[u + o + l | 0] & 255) << 4 : 0) | I << 8 : I, w = 0 < (n - C | 0);
+                  c:do {
+                    if (w) {
+                      for (var A = D, K = 0, E = 0; ;) {
+                        var J = T(b, f + A | 0), K = (J << 7 - E | K & 255) & 255, O = 10 - E | 0, A = I >>> (O >>> 0) & 128 | A << 1 & 890 | B >>> (O >>> 0) & 4 | J, E = E + 1 | 0;
+                        if ((E | 0) == (x | 0)) {
+                          var M = A, Ua = K;
+                          break c
+                        }
+                      }
+                    } else {
+                      M = D, Ua = 0
+                    }
+                  } while (0);
+                  q[u + l | 0] = Ua;
+                  l = C + 8 | 0;
+                  if ((l | 0) >= (e | 0)) {
+                    break b
+                  }
+                  C = l;
+                  l = C >> 3;
+                  D = M;
+                  P = P + 8 | 0
+                }
+              }
+            } while (0);
+            t = t + 1 | 0;
+            if ((t | 0) == (s | 0)) {
+              break a
+            }
+            u = u + k | 0
+          }
+        }
+      } while (0)
+    }
+
+    function id(b, c, f, l) {
+      var n = a[f >> 2], s = a[f + 4 >> 2], k = 0 < (s | 0);
+      a:do {
+        if (k) {
+          for (var i = 0 < (n | 0), g = b + 16 | 0, e = b + 17 | 0, d = 0; ;) {
+            b:do {
+              if (i) {
+                for (var Ca = d - 1 | 0, r = 0; ;) {
+                  var o = r - 1 | 0, m = r - 2 | 0, t = r - 3 | 0, u = r + 1 | 0, o = T(c, l + (w(f, m, d) << 1 | w(f, o, d) | w(f, t, d) << 2 | w(f, r - 4 | 0, d) << 3 | w(f, (q[g] << 24 >> 24) + r | 0, (q[e] << 24 >> 24) + d | 0) << 4 | w(f, u, Ca) << 5 | w(f, r, Ca) << 6 | w(f, o, Ca) << 7 | w(f, m, Ca) << 8 | w(f, t, Ca) << 9) | 0);
+                  qa(f, r, d, o);
+                  if ((u | 0) == (n | 0)) {
+                    break b
+                  }
+                  r = u
+                }
+              }
+            } while (0);
+            d = d + 1 | 0;
+            if ((d | 0) == (s | 0)) {
+              break a
+            }
+          }
+        }
+      } while (0)
+    }
+
+    function yf(h, z, f) {
+      var l, n, s, k = b;
+      b += 56;
+      s = k >> 2;
+      var i = k + 24, G = k + 32;
+      n = (z + 12 | 0) >> 2;
+      var e = 18 > p[n] >>> 0;
+      do {
+        if (e) {
+          var d = m(h, 3, a[z >> 2], g.c | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c))
+        } else {
+          Cc(k, f);
+          l = (z | 0) >> 2;
+          var Ca = p[s], r = p[s + 1], d = p[s + 2], o = p[s + 3], j = F[k + 20 | 0] & 255, t = h;
+          m(t, 1, a[l], g.O | 0, (c = b, b += 20, a[c >> 2] = Ca, a[c + 4 >> 2] = r, a[c + 8 >> 2] = d, a[c + 12 >> 2] = o, a[c + 16 >> 2] = j, c));
+          j = F[f + 17 | 0] & 255;
+          m(t, 1, a[l], g.nd | 0, (c = b, b += 4, a[c >> 2] = j, c));
+          var u = j & 1, y = 0 != (u | 0), v = j & 6;
+          0 == (v | 0) | y ^ 1 || m(t, 2, a[l], g.Id | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+          if (y) {
+            var R = 0, H = i | 0
+          } else {
+            v = 0 != (v | 0) ? 2 : 8;
+            if ((v + 18 | 0) >>> 0 > p[n] >>> 0) {
+              d = m(t, 3, a[l], g.c | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+              break
+            }
+            y = i | 0;
+            eb(y, f + 18 | 0, v);
+            R = q[y] << 24 >> 24;
+            H = q[i + 1 | 0] << 24 >> 24;
+            m(t, 1, a[l], g.Td | 0, (c = b, b += 8, a[c >> 2] = R, a[c + 4 >> 2] = H, c));
+            R = v;
+            H = y
+          }
+          y = R + 18 | 0;
+          v = G | 0;
+          a[v >> 2] = u;
+          u = G + 4 | 0;
+          a[u >> 2] = j >>> 1 & 3;
+          a[G + 8 >> 2] = j >>> 3 & 1;
+          a[G + 12 >> 2] = 0;
+          eb(G + 16 | 0, H, R);
+          j = pb(h, Ca, r);
+          R = a[l];
+          if (0 == (j | 0)) {
+            d = m(t, 2, R, g.de | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c))
+          } else {
+            m(t, 0, R, g.M | 0, (c = b, b += 8, a[c >> 2] = Ca, a[c + 4 >> 2] = r, c));
+            if (0 == (a[v >> 2] | 0)) {
+              if (u = Bc(a[u >> 2]), Ca = h | 0, r = O(a[Ca >> 2], u), 0 == (r | 0)) {
+                var C = 0, D = 0, B = 0, I = m(t, 3, a[l], g.ue | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), P = Ca;
+                l = 22
+              } else {
+                if (ea(r, 0, u), u = y = Gd(t, f + y | 0, a[n] - y | 0), 0 == (y | 0)) {
+                  I = m(t, 3, a[l], g.sa | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), C = r, D = 0, B = u, P = Ca, l = 22
+                } else {
+                  if (y = Hd(h, u), 0 == (y | 0)) {
+                    I = m(t, 3, a[l], g.Da | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), C = r, D = 0, B = u, P = Ca, l = 22
+                  } else {
+                    var x = hd(h, z, G, y, j, r), w = r, A = y, E = u, J = Ca;
+                    l = 21
+                  }
+                }
+              }
+            } else {
+              Ge(f + y | 0, a[n] - y | 0, j);
+              var w = 0, A = 0, E = 0, x = 0, J = h | 0;
+              l = 21
+            }
+            21 == l && (Id(h, a[h + 72 >> 2] + 44 * a[h + 64 >> 2] | 0, j, d, o), C = w, D = A, B = E, I = x, P = J);
+            K(a[P >> 2], D);
+            Tc(t, B);
+            K(a[P >> 2], C);
+            Qa(h, j);
+            d = I
+          }
+        }
+      } while (0);
+      b = k;
+      return d
+    }
+
+    function pf(b, c, f, l) {
+      var n = a[f >> 2], s = a[f + 4 >> 2], k = 0 < (s | 0);
+      a:do {
+        if (k) {
+          for (var i = l + 39717 | 0, g = 0 < (n | 0), e = b + 16 | 0, d = b + 17 | 0, j = b + 18 | 0, r = b + 19 | 0, o = b + 20 | 0, m = b + 21 | 0, t = b + 22 | 0, u = b + 23 | 0, y = 0, v = 0; ;) {
+            var p = T(c, i), H = p ^ v, v = (v | 0) == (p | 0);
+            b:do {
+              if (v) {
+                if (g) {
+                  for (var p = y - 1 | 0, C = y - 2 | 0, D = 0; ;) {
+                    var B = D - 1 | 0, I = D - 2 | 0, P = D + 1 | 0, B = T(c, l + (w(f, I, y) << 1 | w(f, B, y) | w(f, D - 3 | 0, y) << 2 | w(f, D - 4 | 0, y) << 3 | w(f, (q[e] << 24 >> 24) + D | 0, (q[d] << 24 >> 24) + y | 0) << 4 | w(f, D + 2 | 0, p) << 5 | w(f, P, p) << 6 | w(f, D, p) << 7 | w(f, B, p) << 8 | w(f, I, p) << 9 | w(f, (q[j] << 24 >> 24) + D | 0, (q[r] << 24 >> 24) + y | 0) << 10 | w(f, (q[o] << 24 >> 24) + D | 0, (q[m] << 24 >> 24) + y | 0) << 11 | w(f, P, C) << 12 | w(f, D, C) << 13 | w(f, B, C) << 14 | w(f, (q[t] << 24 >> 24) + D | 0, (q[u] << 24 >> 24) + y | 0) << 15) | 0);
+                    qa(f, D, y, B);
+                    if ((P | 0) == (n | 0)) {
+                      break b
+                    }
+                    D = P
+                  }
+                }
+              } else {
+                Uc(f, y)
+              }
+            } while (0);
+            y = y + 1 | 0;
+            if ((y | 0) == (s | 0)) {
+              break a
+            }
+            v = H
+          }
+        }
+      } while (0)
+    }
+
+    function qf(b, c, f, l) {
+      var n = a[f >> 2], s = a[f + 4 >> 2], k = 0 < (s | 0);
+      a:do {
+        if (k) {
+          for (var i = l + 1941 | 0, g = 0 < (n | 0), e = b + 16 | 0, d = b + 17 | 0, j = 0, r = 0; ;) {
+            var o = T(c, i), m = o ^ r, r = (r | 0) == (o | 0);
+            b:do {
+              if (r) {
+                if (g) {
+                  for (var o = j - 1 | 0, t = j - 2 | 0, u = 0; ;) {
+                    var y = u - 1 | 0, v = u - 2 | 0, p = u + 2 | 0, H = u + 1 | 0, y = T(c, l + (w(f, v, j) << 1 | w(f, y, j) | w(f, u - 3 | 0, j) << 2 | w(f, (q[e] << 24 >> 24) + u | 0, (q[d] << 24 >> 24) + j | 0) << 3 | w(f, p, o) << 4 | w(f, H, o) << 5 | w(f, u, o) << 6 | w(f, y, o) << 7 | w(f, v, o) << 8 | w(f, p, t) << 9 | w(f, H, t) << 10 | w(f, u, t) << 11 | w(f, y, t) << 12) | 0);
+                    qa(f, u, j, y);
+                    if ((H | 0) == (n | 0)) {
+                      break b
+                    }
+                    u = H
+                  }
+                }
+              } else {
+                Uc(f, j)
+              }
+            } while (0);
+            j = j + 1 | 0;
+            if ((j | 0) == (s | 0)) {
+              break a
+            }
+            r = m
+          }
+        }
+      } while (0)
+    }
+
+    function rf(b, c, f, l) {
+      var n = a[f >> 2], s = a[f + 4 >> 2], k = 0 < (s | 0);
+      a:do {
+        if (k) {
+          for (var i = l + 229 | 0, g = 0 < (n | 0), e = b + 16 | 0, d = b + 17 | 0, j = 0, r = 0; ;) {
+            var o = T(c, i), m = o ^ r, r = (r | 0) == (o | 0);
+            b:do {
+              if (r) {
+                if (g) {
+                  for (var o = j - 1 | 0, t = j - 2 | 0, u = 0; ;) {
+                    var p = u - 1 | 0, v = u - 2 | 0, R = u + 1 | 0, p = T(c, l + (w(f, v, j) << 1 | w(f, p, j) | w(f, (q[e] << 24 >> 24) + u | 0, (q[d] << 24 >> 24) + j | 0) << 2 | w(f, R, o) << 3 | w(f, u, o) << 4 | w(f, p, o) << 5 | w(f, v, o) << 6 | w(f, R, t) << 7 | w(f, u, t) << 8 | w(f, p, t) << 9) | 0);
+                    qa(f, u, j, p);
+                    if ((R | 0) == (n | 0)) {
+                      break b
+                    }
+                    u = R
+                  }
+                }
+              } else {
+                Uc(f, j)
+              }
+            } while (0);
+            j = j + 1 | 0;
+            if ((j | 0) == (s | 0)) {
+              break a
+            }
+            r = m
+          }
+        }
+      } while (0)
+    }
+
+    function sf(b, c, f, l) {
+      var n = a[f >> 2], s = a[f + 4 >> 2], k = 0 < (s | 0);
+      a:do {
+        if (k) {
+          for (var i = l + 405 | 0, g = 0 < (n | 0), e = b + 16 | 0, d = b + 17 | 0, j = 0, r = 0; ;) {
+            var o = T(c, i), m = o ^ r, r = (r | 0) == (o | 0);
+            b:do {
+              if (r) {
+                if (g) {
+                  for (var o = j - 1 | 0, t = 0; ;) {
+                    var u = t - 1 | 0, p = t - 2 | 0, v = t - 3 | 0, R = t + 1 | 0, u = T(c, l + (w(f, p, j) << 1 | w(f, u, j) | w(f, v, j) << 2 | w(f, t - 4 | 0, j) << 3 | w(f, (q[e] << 24 >> 24) + t | 0, (q[d] << 24 >> 24) + j | 0) << 4 | w(f, R, o) << 5 | w(f, t, o) << 6 | w(f, u, o) << 7 | w(f, p, o) << 8 | w(f, v, o) << 9) | 0);
+                    qa(f, t, j, u);
+                    if ((R | 0) == (n | 0)) {
+                      break b
+                    }
+                    t = R
+                  }
+                }
+              } else {
+                Uc(f, j)
+              }
+            } while (0);
+            j = j + 1 | 0;
+            if ((j | 0) == (s | 0)) {
+              break a
+            }
+            r = m
+          }
+        }
+      } while (0)
+    }
+
+    function Uc(b, c) {
+      var f = a[b + 12 >> 2];
+      if (0 == (c | 0)) {
+        ea(f, 0, a[b + 8 >> 2])
+      } else {
+        var l = a[b + 8 >> 2], n = l * (c - 1) | 0;
+        eb(f + n + l | 0, f + n | 0, l)
+      }
+    }
+
+    function He(h, z, f, l, n, s) {
+      var k = b, z = z | 0, i = f + 8 | 0, G = a[i >> 2], e = f + 12 | 0, d = a[e >> 2], j = f | 0, r = a[j >> 2], o = f + 16 | 0, p = a[o >> 2], t = q[f + 20 | 0] << 24 >> 24, u = q[f + 21 | 0] << 24 >> 24, y = q[f + 22 | 0] << 24 >> 24, v = q[f + 23 | 0] << 24 >> 24;
+      m(h, 0, a[z >> 2], g.Jd | 0, (c = b, b += 32, a[c >> 2] = G, a[c + 4 >> 2] = d, a[c + 8 >> 2] = r, a[c + 12 >> 2] = p, a[c + 16 >> 2] = t, a[c + 20 >> 2] = u, a[c + 24 >> 2] = y, a[c + 28 >> 2] = v, c));
+      0 == (a[o >> 2] | 0) ? 0 == (a[j >> 2] | 0) ? zf(f, l, n, s) : Af(a[f + 4 >> 2], a[i >> 2], a[e >> 2], l, n, s) : m(h, 2, a[z >> 2], g.jb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+      b = k
+    }
+
+    function Af(b, c, f, l, n, s) {
+      var k = a[n >> 2], i = a[n + 4 >> 2], g = 0 < (i | 0);
+      a:do {
+        if (g) {
+          for (var e = 0 < (k | 0), d = n, j = b, r = 0; ;) {
+            b:do {
+              if (e) {
+                for (var o = r - 1 | 0, m = r - f | 0, t = m + 1 | 0, u = m - 1 | 0, p = 0; ;) {
+                  var v = p - 1 | 0, q = p + 1 | 0, H = p - c | 0, C = H + 1 | 0, v = T(l, s + (w(d, q, o) << 1 | w(d, v, r) | w(d, p, o) << 2 | w(d, v, o) << 3 | w(j, C, t) << 4 | w(j, H, t) << 5 | w(j, C, m) << 6 | w(j, H, m) << 7 | w(j, H - 1 | 0, m) << 8 | w(j, H, u) << 9) | 0);
+                  qa(d, p, r, v);
+                  if ((q | 0) == (k | 0)) {
+                    break b
+                  }
+                  p = q
+                }
+              }
+            } while (0);
+            r = r + 1 | 0;
+            if ((r | 0) == (i | 0)) {
+              break a
+            }
+          }
+        }
+      } while (0)
+    }
+
+    function zf(b, c, f, l) {
+      var n = a[f >> 2], s = a[f + 4 >> 2], k = a[b + 8 >> 2], i = a[b + 12 >> 2], g = 0 < (s | 0);
+      a:do {
+        if (g) {
+          for (var e = 0 < (n | 0), d = f, j = b + 20 | 0, r = b + 21 | 0, o = a[b + 4 >> 2], m = b + 22 | 0, t = b + 23 | 0, u = 0; ;) {
+            b:do {
+              if (e) {
+                for (var p = u - 1 | 0, v = u - i | 0, R = v + 1 | 0, H = v - 1 | 0, C = 0; ;) {
+                  var D = C + 1 | 0, B = C - k | 0, I = B + 1 | 0, P = B - 1 | 0, B = T(c, l + (w(d, D, p) << 1 | w(d, C - 1 | 0, u) | w(d, C, p) << 2 | w(d, (q[j] << 24 >> 24) + C | 0, (q[r] << 24 >> 24) + u | 0) << 3 | w(o, I, R) << 4 | w(o, B, R) << 5 | w(o, P, R) << 6 | w(o, I, v) << 7 | w(o, B, v) << 8 | w(o, P, v) << 9 | w(o, I, H) << 10 | w(o, B, H) << 11 | w(o, (q[m] << 24 >> 24) + B | 0, (q[t] << 24 >> 24) + v | 0) << 12) | 0);
+                  qa(d, C, u, B);
+                  if ((D | 0) == (n | 0)) {
+                    break b
+                  }
+                  C = D
+                }
+              }
+            } while (0);
+            u = u + 1 | 0;
+            if ((u | 0) == (s | 0)) {
+              break a
+            }
+          }
+        }
+      } while (0)
+    }
+
+    function Bf(h, z, f) {
+      var l, n, s, k, i, G, d = b;
+      b += 48;
+      G = d >> 2;
+      var e = d + 24;
+      i = e >> 2;
+      k = (z + 12 | 0) >> 2;
+      var j = 18 > p[k] >>> 0;
+      do {
+        if (j) {
+          var r = m(h, 3, a[z >> 2], g.c | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c))
+        } else {
+          Cc(e, f);
+          s = (z | 0) >> 2;
+          var o = p[i], Pb = p[i + 1], t = p[i + 2], u = p[i + 3];
+          l = F[e + 20 | 0] & 255;
+          r = h;
+          m(r, 1, a[s], g.O | 0, (c = b, b += 20, a[c >> 2] = o, a[c + 4 >> 2] = Pb, a[c + 8 >> 2] = t, a[c + 12 >> 2] = u, a[c + 16 >> 2] = l, c));
+          var y = F[f + 17 | 0] & 255, v = y & 1;
+          a[G] = v;
+          l = y & 2;
+          n = 0 != (l | 0);
+          a[G + 4] = l >>> 1;
+          var R = (l = 0 != (v | 0)) ? g.Ud | 0 : sc | 0;
+          n = n ? g.me | 0 : sc | 0;
+          m(r, 1, a[s], g.Ld | 0, (c = b, b += 12, a[c >> 2] = y, a[c + 4 >> 2] = R, a[c + 8 >> 2] = n, c));
+          0 != (y & 252 | 0) && m(r, 2, a[s], g.ve | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+          if (0 == (v | 0)) {
+            if (22 > p[k] >>> 0) {
+              r = m(r, 3, a[s], g.c | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+              break
+            }
+            v = F[f + 18 | 0];
+            q[d + 20 | 0] = v;
+            R = F[f + 19 | 0];
+            q[d + 21 | 0] = R;
+            n = q[f + 20 | 0];
+            q[d + 22 | 0] = n;
+            y = q[f + 21 | 0];
+            q[d + 23 | 0] = y;
+            v = v << 24 >> 24;
+            R = R << 24 >> 24;
+            n = n << 24 >> 24;
+            y = y << 24 >> 24;
+            m(r, 1, a[s], g.ta | 0, (c = b, b += 16, a[c >> 2] = v, a[c + 4 >> 2] = R, a[c + 8 >> 2] = n, a[c + 12 >> 2] = y, c));
+            y = 22
+          } else {
+            y = 18
+          }
+          if (0 == (a[z + 16 >> 2] | 0)) {
+            v = Dc(a[(a[h + 72 >> 2] + 40 >> 2) + (11 * a[h + 64 >> 2] | 0)]), a[G + 1] = v, v = h
+          } else {
+            v = h;
+            n = a[z + 16 >> 2];
+            var R = z + 20 | 0, H = z | 0, C = 0;
+            a:for (; ;) {
+              if ((C | 0) >= (n | 0)) {
+                var D = 0;
+                break
+              }
+              var B = a[a[R >> 2] + (C << 2) >> 2], I = rc(v, B), P = I, x = 0 == (I | 0);
+              do {
+                if (x) {
+                  m(v, 2, a[H >> 2], g.ic | 0, (c = b, b += 4, a[c >> 2] = B, c))
+                } else {
+                  var w = F[I + 4 | 0] & 63;
+                  if ((4 == (w | 0) || 20 == (w | 0) || 36 == (w | 0) || 40 == (w | 0)) && 0 != (a[I + 24 >> 2] | 0)) {
+                    D = P;
+                    break a
+                  }
+                }
+              } while (0);
+              C = C + 1 | 0
+            }
+            R = D;
+            if (0 == (R | 0)) {
+              r = m(r, 3, a[s], g.Ea | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+              break
+            }
+            n = (R + 24 | 0) >> 2;
+            v = h;
+            H = Dc(a[n]);
+            a[G + 1] = H;
+            Qa(v, a[n]);
+            a[n] = 0;
+            n = a[R >> 2];
+            m(r, 0, a[s], g.Ma | 0, (c = b, b += 4, a[c >> 2] = n, c))
+          }
+          a[G + 2] = 0;
+          a[G + 3] = 0;
+          R = n = pb(v, o, Pb);
+          H = a[s];
+          0 == (n | 0) ? r = m(r, 3, H, g.Va | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)) : (m(r, 0, H, g.M | 0, (c = b, b += 8, a[c >> 2] = o, a[c + 4 >> 2] = Pb, c)), C = l ? 1024 : 8192, l = (h | 0) >> 2, H = O(a[l], C), 0 == (H | 0) ? (m(r, 3, -1, g.kb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), o = s = 0) : (ea(H, 0, C), y = C = Gd(r, f + y | 0, a[k] - y | 0), 0 == (C | 0) ? (m(r, 3, -1, g.rb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), s = 0) : (C = Hd(v, C), 0 == (C | 0) ? (m(r, 3, -1, g.xb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), s = 0) : (He(h, z, d, C, R, H), 40 == (q[z + 4 | 0] & 63) << 24 >> 24 ? a[z + 24 >> 2] = n : (m(r, 0, a[s], g.zb | 0, (c = b, b += 16, a[c >> 2] = o, a[c + 4 >> 2] = Pb, a[c + 8 >> 2] = t, a[c + 12 >> 2] = u, c)), Id(v, a[h + 72 >> 2] + 44 * a[h + 64 >> 2] | 0, n, t, u), Qa(v, n)), s = C)), o = y), K(a[l], s), Tc(r, o), K(a[l], H), r = 0)
+        }
+      } while (0);
+      b = d;
+      return r
+    }
+
+    function Cf(h, z, f) {
+      var l, n = a[z + 12 >> 2] + 1 | 0, s = a[z + 4 >> 2], k = a[z + 8 >> 2], z = (h | 0) >> 2, i = O(a[z], 16), G = 0 == (i | 0);
+      a:do {
+        if (G) {
+          m(h, 3, -1, g.mc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), l = i
+        } else {
+          var d = O(a[z], n << 2), e = d;
+          l = (i + 4 | 0) >> 2;
+          a[l] = e;
+          if (0 == (d | 0)) {
+            m(h, 3, -1, g.be | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), K(a[z], i)
+          } else {
+            a[i >> 2] = n;
+            a[(i + 8 | 0) >> 2] = s;
+            a[(i + 12 | 0) >> 2] = k;
+            e = -s | 0;
+            for (d = 0; ;) {
+              if ((d | 0) >= (n | 0)) {
+                l = i;
+                break a
+              }
+              var j = pb(h, s, k);
+              a[((d << 2) + a[l] | 0) >> 2] = j;
+              j = a[a[l] + (d << 2) >> 2];
+              if (0 == (j | 0)) {
+                break
+              }
+              Vc(0, j, f, d * e | 0, 0, 4);
+              d = d + 1 | 0
+            }
+            m(h, 2, -1, g.wb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+            e = 0 < (d | 0);
+            j = a[z];
+            b:do {
+              if (e) {
+                for (var r = 0, o = j; ;) {
+                  if (K(o, a[a[l] + (r << 2) >> 2]), r = r + 1 | 0, o = a[z], (r | 0) == (d | 0)) {
+                    var p = o;
+                    break b
+                  }
+                }
+              } else {
+                p = j
+              }
+            } while (0);
+            K(p, i)
+          }
+          l = 0
+        }
+      } while (0);
+      return l
+    }
+
+    function Df(h, z, f) {
+      var l, n, s = b;
+      b += 20;
+      n = s >> 2;
+      var k = z + 12 | 0, i = 7 > p[k >> 2] >>> 0;
+      do {
+        if (i) {
+          var G = m(h, 3, a[z >> 2], g.c | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c))
+        } else {
+          var d = F[f] & 255, e = d & 1, G = s | 0;
+          a[G >> 2] = e;
+          var j = d >>> 1 & 3;
+          a[n + 4] = j;
+          var r = F[f + 1 | 0] & 255;
+          a[n + 1] = r;
+          var o = F[f + 2 | 0] & 255;
+          a[n + 2] = o;
+          var q = ia(f + 3 | 0);
+          a[n + 3] = q;
+          l = (z | 0) >> 2;
+          var t = q + 1 | 0, q = h;
+          m(q, 1, a[l], g.sd | 0, (c = b, b += 16, a[c >> 2] = d, a[c + 4 >> 2] = t, a[c + 8 >> 2] = r, a[c + 12 >> 2] = o, c));
+          r = 0 == (e | 0);
+          r | 0 == (j | 0) || m(q, 2, a[l], g.Md | 0, (c = b, b += 8, a[c >> 2] = j, a[c + 4 >> 2] = e, c));
+          0 != (d & 248 | 0) && m(q, 2, a[l], g.Vd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+          if (r) {
+            d = Bc(j);
+            e = O(a[h >> 2], d);
+            if (0 == (e | 0)) {
+              m(q, 3, a[l], g.ee | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+              G = 0;
+              break
+            }
+            ea(e, 0, d);
+            l = e
+          } else {
+            l = 0
+          }
+          q = Ef(h, z, s, f + 7 | 0, a[k >> 2] - 7 | 0, l);
+          d = z + 24 | 0;
+          a[d >> 2] = q;
+          0 == (a[G >> 2] | 0) ? (K(a[h >> 2], l), G = a[d >> 2]) : G = q;
+          G = 0 == (G | 0) & 1
+        }
+      } while (0);
+      b = s;
+      return G
+    }
+
+    function Ef(h, z, f, l, n, s) {
+      var k, i = b;
+      b += 24;
+      k = i >> 2;
+      var G = f + 4 | 0, d = pb(h, (a[f + 12 >> 2] + 1) * a[G >> 2] | 0, a[f + 8 >> 2]);
+      if (0 == (d | 0)) {
+        m(h, 2, a[z >> 2], g.Tb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), h = 0
+      } else {
+        var e = a[f >> 2];
+        a[k] = e;
+        a[k + 1] = a[f + 16 >> 2];
+        a[k + 2] = 0;
+        a[k + 3] = 0;
+        q[i + 16 | 0] = -a[G >> 2] & 255;
+        q[i + 17 | 0] = 0;
+        q[i + 18 | 0] = -3;
+        q[i + 19 | 0] = -1;
+        q[i + 20 | 0] = 2;
+        q[i + 21 | 0] = -2;
+        q[i + 22 | 0] = -2;
+        q[i + 23 | 0] = -2;
+        0 == (e | 0) ? (l = Gd(h, l, n), 0 == (l | 0) ? m(h, 2, a[z >> 2], g.dc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)) : (n = Hd(h, l), 0 == (n | 0) ? m(h, 2, a[z >> 2], g.$b | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)) : hd(h, z, i, n, d, s), K(a[h >> 2], n), Tc(h, l))) : Ge(l, n, d);
+        z = Cf(h, f, d);
+        Qa(h, d);
+        h = z
+      }
+      b = i;
+      return h
+    }
+
+    function Ff(h, z, f, l, n, s, k, i, G, d, e, j) {
+      var r, o, p, t, d = b;
+      b += 28;
+      var u, y = d + 4;
+      t = y >> 2;
+      a[d >> 2] = 0;
+      p = (h | 0) >> 2;
+      var v = O(a[p], i << 2);
+      o = v >> 2;
+      var R = 0 == (v | 0);
+      a:do {
+        if (R) {
+          m(h, 3, -1, g.ne | 0, (c = b, b += 4, a[c >> 2] = i, c));
+          var H = 0
+        } else {
+          for (var C = 0; ;) {
+            if (C >>> 0 >= i >>> 0) {
+              u = 9;
+              break
+            }
+            var D = pb(h, s, k);
+            a[((C << 2) + v | 0) >> 2] = D;
+            if (0 == (D | 0)) {
+              u = 5;
+              break
+            }
+            C = C + 1 | 0
+          }
+          if (5 == u) {
+            m(h, 3, -1, g.we | 0, (c = b, b += 8, a[c >> 2] = s, a[c + 4 >> 2] = k, c));
+            H = 0 < (C | 0);
+            b:do {
+              if (H) {
+                for (D = C; ;) {
+                  if (D = D - 1 | 0, Qa(h, a[(D << 2 >> 2) + o]), 0 >= (D | 0)) {
+                    break b
+                  }
+                }
+              }
+            } while (0);
+            K(a[p], v);
+            H = 0
+          } else {
+            if (9 == u) {
+              a[t] = n;
+              a[t + 1] = e;
+              a[t + 2] = 0;
+              a[t + 3] = G;
+              q[y + 16 | 0] = 2 > (e | 0) ? 3 : 2;
+              q[y + 17 | 0] = -1;
+              q[y + 18 | 0] = -3;
+              q[y + 19 | 0] = -1;
+              q[y + 20 | 0] = 2;
+              q[y + 21 | 0] = -2;
+              q[y + 22 | 0] = -2;
+              q[y + 23 | 0] = -2;
+              if (C = 0 != (n | 0)) {
+                Gf(f, l, a[(i - 1 << 2 >> 2) + o], d), D = H = 0
+              } else {
+                var H = h, B = Gd(H, f, l), D = Hd(h, B);
+                0 != (hd(h, z, y, D, a[(i - 1 << 2 >> 2) + o], j) | 0) && m(H, 2, a[z >> 2], g.J | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                H = B
+              }
+              var B = i - 2 | 0, I = -1 < (B | 0);
+              b:do {
+                if (I) {
+                  var x = z | 0, A = h;
+                  for (r = B; ;) {
+                    if (C) {
+                      var E = a[d >> 2];
+                      Gf(f + E | 0, l - E | 0, a[(r << 2 >> 2) + o], d)
+                    } else {
+                      0 != (hd(h, z, y, D, a[(r << 2 >> 2) + o], j) | 0) && m(A, 2, a[x >> 2], g.J | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c))
+                    }
+                    var E = a[a[o] + 8 >> 2] * k | 0, J = 0 == (E | 0);
+                    c:do {
+                      if (!J) {
+                        for (var M = (r + 1 << 2) + v | 0, T = (r << 2) + v | 0, Ea = 0; ;) {
+                          var Q = a[a[T >> 2] + 12 >> 2] + Ea | 0;
+                          q[Q] ^= q[a[a[M >> 2] + 12 >> 2] + Ea | 0];
+                          Ea = Ea + 1 | 0;
+                          if ((Ea | 0) == (E | 0)) {
+                            break c
+                          }
+                        }
+                      }
+                    } while (0);
+                    if (0 >= (r | 0)) {
+                      break b
+                    }
+                    r = r - 1 | 0
+                  }
+                }
+              } while (0);
+              B = I = O(a[p], s << 2);
+              if (0 == (I | 0)) {
+                m(h, 3, -1, g.K | 0, (c = b, b += 4, a[c >> 2] = s, c)), H = 0
+              } else {
+                for (I = 0; I >>> 0 < s >>> 0;) {
+                  x = O(a[p], k);
+                  a[((I << 2) + B | 0) >> 2] = x;
+                  if (0 == (x | 0)) {
+                    z = k * s | 0;
+                    m(h, 3, -1, g.K | 0, (c = b, b += 4, a[c >> 2] = z, c));
+                    H = 0;
+                    break a
+                  }
+                  I = I + 1 | 0
+                }
+                I = 0 == (s | 0);
+                b:do {
+                  if (I) {
+                    u = 38
+                  } else {
+                    x = 0 == (k | 0);
+                    A = 0 == (i | 0);
+                    for (E = 0; ;) {
+                      c:do {
+                        if (!x) {
+                          if (r = ((E << 2) + B | 0) >> 2, A) {
+                            for (J = 0; ;) {
+                              if (q[a[r] + J | 0] = 0, J = J + 1 | 0, (J | 0) == (k | 0)) {
+                                break c
+                              }
+                            }
+                          } else {
+                            for (J = 0; ;) {
+                              for (M = q[a[r] + J | 0] = 0; !(T = a[r] + J | 0, q[T] = (w(a[(M << 2 >> 2) + o], E, J) << M) + (F[T] & 255) & 255, M = M + 1 | 0, (M | 0) == (i | 0));) {
+                              }
+                              J = J + 1 | 0;
+                              if ((J | 0) == (k | 0)) {
+                                break c
+                              }
+                            }
+                          }
+                        }
+                      } while (0);
+                      r = E + 1 | 0;
+                      if ((r | 0) == (s | 0)) {
+                        break b
+                      }
+                      E = r
+                    }
+                  }
+                } while (0);
+                C || (K(a[p], D), Tc(h, H));
+                C = 0 == (i | 0);
+                b:do {
+                  if (!C) {
+                    for (H = 0; ;) {
+                      if (Qa(h, a[(H << 2 >> 2) + o]), H = H + 1 | 0, (H | 0) == (i | 0)) {
+                        break b
+                      }
+                    }
+                  }
+                } while (0);
+                K(a[p], v);
+                H = B
+              }
+            }
+          }
+        }
+      } while (0);
+      b = d;
+      return H
+    }
+
+    function Dc(b) {
+      if (0 != (b | 0)) {
+        var c = b + 16 | 0;
+        a[c >> 2] = a[c >> 2] + 1 | 0
+      }
+      return b
+    }
+
+    function qa(b, c, f, l) {
+      var n = a[b + 4 >> 2];
+      0 <= (c | 0) && (a[b >> 2] | 0) > (c | 0) && -1 < (f | 0) & (n | 0) > (f | 0) && (n = c & 7 ^ 7, b = (c >> 3) + a[b + 12 >> 2] + a[b + 8 >> 2] * f | 0, q[b] = (F[b] & 255 & (1 << n ^ 255) | l << n) & 255)
+    }
+
+    function w(b, c, f) {
+      var l = a[b + 4 >> 2], n = (c >> 3) + a[b + 8 >> 2] * f | 0;
+      return 0 > (c | 0) ? 0 : (a[b >> 2] | 0) > (c | 0) ? -1 < (f | 0) & (l | 0) > (f | 0) ? (F[a[b + 12 >> 2] + n | 0] & 255) >>> ((c & 7 ^ 7) >>> 0) & 1 : 0 : 0
+    }
+
+    function Hf(h, z, f, l, n, s, k) {
+      var i, G;
+      ea(a[s + 12 >> 2], a[f + 40 >> 2] & 255, a[s + 4 >> 2] * a[s + 8 >> 2] | 0);
+      var d = f + 32 | 0;
+      1 == (a[d >> 2] | 0) && m(h, 2, a[z >> 2], g.Oa | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+      var e;
+      G = a[z + 16 >> 2];
+      e = z + 20 | 0;
+      var j = 0;
+      a:for (; ;) {
+        if ((G | 0) <= (j | 0)) {
+          i = 0;
+          break
+        }
+        var r = rc(h, a[a[e >> 2] + (j << 2) >> 2]), o = 0 == (r | 0);
+        do {
+          if (!o && 16 == (q[r + 4 | 0] & 63) << 24 >> 24) {
+            var Pb = a[r + 24 >> 2];
+            if (0 != (Pb | 0)) {
+              i = Pb;
+              break a
+            }
+          }
+        } while (0);
+        j = j + 1 | 0
+      }
+      e = i;
+      if (0 == (e | 0)) {
+        m(h, 2, a[z >> 2], g.Wa | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+        var t = -1
+      } else {
+        j = p[e >> 2];
+        for (G = 0; ;) {
+          var u = G + 1 | 0;
+          if (j >>> 0 <= 1 << u >>> 0) {
+            break
+          }
+          G = u
+        }
+        r = a[f + 24 >> 2];
+        G = (f + 4 | 0) >> 2;
+        o = a[G];
+        i = (f + 8 | 0) >> 2;
+        l = Ff(h, z, l, n, r, o, a[i], u, a[d >> 2], 0, a[f + 28 >> 2], k);
+        if (0 == (l | 0)) {
+          m(h, 2, a[z >> 2], g.eb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), t = -1
+        } else {
+          n = p[i];
+          k = 0 == (n | 0);
+          a:do {
+            if (k) {
+              var y = a[G]
+            } else {
+              for (var d = f + 12 | 0, u = f + 22 | 0, r = f + 20 | 0, o = f + 16 | 0, Pb = e + 4 | 0, v = f + 36 | 0, R = z | 0, H = h, C = j + 255 & 255, D = 0, B = a[G], I = n; ;) {
+                if (0 == (B | 0)) {
+                  B = 0
+                } else {
+                  for (B = 0; ;) {
+                    var I = Da[u >> 1] & 65535, x = Da[r >> 1] & 65535, w = (I * D + a[d >> 2] + x * B | 0) >>> 8, I = (a[o >> 2] - I * B + x * D | 0) >>> 8, x = F[a[l + (B << 2) >> 2] + D | 0], A = x & 255;
+                    A >>> 0 < j >>> 0 || (m(H, 2, a[R >> 2], g.lb | 0, (c = b, b += 4, a[c >> 2] = A, c)), x = C);
+                    Vc(0, s, a[a[Pb >> 2] + ((x & 255) << 2) >> 2], w, I, a[v >> 2]);
+                    B = B + 1 | 0;
+                    w = p[G];
+                    if (B >>> 0 >= w >>> 0) {
+                      break
+                    }
+                  }
+                  B = w;
+                  I = a[i]
+                }
+                D = D + 1 | 0;
+                if (D >>> 0 >= I >>> 0) {
+                  y = B;
+                  break a
+                }
+              }
+            }
+          } while (0);
+          z = 0 == (y | 0);
+          h |= 0;
+          f = p[h >> 2];
+          a:do {
+            if (z) {
+              t = f
+            } else {
+              s = 0;
+              for (y = f; ;) {
+                if (K(y, a[l + (s << 2) >> 2]), s = s + 1 | 0, y = a[h >> 2], s >>> 0 >= p[G] >>> 0) {
+                  t = y;
+                  break a
+                }
+              }
+            }
+          } while (0);
+          K(t, l);
+          t = 0
+        }
+      }
+      return t
+    }
+
+    function If(h, z, f) {
+      var l, n, s, k = h >> 2, i = b;
+      b += 68;
+      var G;
+      s = i >> 2;
+      var d = i + 24;
+      n = (z + 12 | 0) >> 2;
+      var e = 17 > p[n] >>> 0;
+      do {
+        if (e) {
+          G = 19
+        } else {
+          if (Cc(i, f), 18 > p[n] >>> 0) {
+            G = 19
+          } else {
+            G = F[f + 17 | 0];
+            q[d | 0] = G;
+            var j = G & 255, r = j & 1;
+            G = d + 24 | 0;
+            a[G >> 2] = r;
+            var o = j >>> 1 & 3;
+            a[d + 28 >> 2] = o;
+            var Pb = j >>> 3 & 1;
+            a[d + 32 >> 2] = Pb;
+            a[d + 36 >> 2] = j >>> 4 & 7;
+            a[d + 40 >> 2] = j >>> 7;
+            l = (z | 0) >> 2;
+            var t = p[s], u = p[s + 1], y = p[s + 2], v = p[s + 3], R = h;
+            m(R, 1, a[l], g.sb | 0, (c = b, b += 20, a[c >> 2] = t, a[c + 4 >> 2] = u, a[c + 8 >> 2] = y, a[c + 12 >> 2] = v, a[c + 16 >> 2] = j, c));
+            j = 0 == (r | 0);
+            j || (0 != (o | 0) && m(R, 2, a[l], g.yb | 0, (c = b, b += 8, a[c >> 2] = o, a[c + 4 >> 2] = r, c)), 0 != (Pb | 0) && m(R, 2, a[l], g.Db | 0, (c = b, b += 8, a[c >> 2] = Pb, a[c + 4 >> 2] = r, c)));
+            var H = p[n];
+            if (16 > (H - 18 | 0) >>> 0) {
+              G = 19
+            } else {
+              r = ia(f + 18 | 0);
+              a[d + 4 >> 2] = r;
+              Pb = ia(f + 22 | 0);
+              a[d + 8 >> 2] = Pb;
+              var C = Pa(f + 26 | 0);
+              a[d + 12 >> 2] = C;
+              var D = Pa(f + 30 | 0);
+              a[d + 16 >> 2] = D;
+              if (4 > (H - 34 | 0) >>> 0) {
+                G = 19
+              } else {
+                var B = Ac(f + 34 | 0);
+                ja[d + 20 >> 1] = B;
+                var x = Ac(f + 36 | 0);
+                ja[d + 22 >> 1] = x;
+                var w = C >> 8, C = C & 255, H = D >> 8, D = D & 255, A = B & 65535, B = A >>> 8, A = A & 255, E = x & 65535, x = E >>> 8, E = E & 255;
+                m(R, 1, a[l], g.Eb | 0, (c = b, b += 40, a[c >> 2] = r, a[c + 4 >> 2] = Pb, a[c + 8 >> 2] = w, a[c + 12 >> 2] = C, a[c + 16 >> 2] = H, a[c + 20 >> 2] = D, a[c + 24 >> 2] = B, a[c + 28 >> 2] = A, a[c + 32 >> 2] = x, a[c + 36 >> 2] = E, c));
+                if (j) {
+                  o = Bc(o);
+                  j = O(a[k], o);
+                  if (0 == (j | 0)) {
+                    w = m(R, 3, a[l], g.Jb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                    G = 20;
+                    break
+                  }
+                  ea(j, 0, o);
+                  o = j
+                } else {
+                  o = 0
+                }
+                t = pb(h, t, u);
+                0 == (t | 0) ? (K(a[k], o), w = m(R, 2, a[l], g.Mb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c))) : (l = Hf(h, z, d, f + 38 | 0, a[n] - 38 | 0, t, o), 0 == (a[G >> 2] | 0) && K(a[k], o), Id(h, a[k + 18] + 44 * a[k + 16] | 0, t, y, v), Qa(h, t), w = l);
+                G = 20
+              }
+            }
+          }
+        }
+      } while (0);
+      19 == G && (w = m(h, 3, a[z >> 2], g.c | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)));
+      b = i;
+      return w
+    }
+
+    function pb(h, z, f) {
+      var l;
+      l = (h | 0) >> 2;
+      var n = O(a[l], 20);
+      if (0 == (n | 0)) {
+        m(h, 3, -1, g.re | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), h = 0
+      } else {
+        var s = z - 1 + 8 >> 3 | 0, k = s * f | 0, i = O(a[l], k);
+        a[(n + 12 | 0) >> 2] = i;
+        0 == (i | 0) ? (m(h, 3, -1, g.Ib | 0, (c = b, b += 4, a[c >> 2] = k, c)), K(a[l], n), h = 0) : (a[n >> 2] = z, a[(n + 4 | 0) >> 2] = f, a[(n + 8 | 0) >> 2] = s, a[(n + 16 | 0) >> 2] = 1, h = n)
+      }
+      return h
+    }
+
+    function Qa(b, c) {
+      if (0 != (c | 0)) {
+        var f = c + 16 | 0, l = a[f >> 2] - 1 | 0;
+        a[f >> 2] = l;
+        0 == (l | 0) && (f = b | 0, 0 != (c | 0) && K(a[f >> 2], a[c + 12 >> 2]), K(a[f >> 2], c))
+      }
+    }
+
+    function Jf(b, c, f, l, n, s) {
+      var k = a[f >> 2], i = a[f + 4 >> 2];
+      if (0 > (l | 0)) {
+        var b = -l | 0, g = 0, d = k + l | 0
+      } else {
+        b = 0, g = l, d = k
+      }
+      if (0 > (n | 0)) {
+        var l = -n | 0, e = i + n | 0, n = 0
+      } else {
+        l = 0, e = i
+      }
+      var i = g + d | 0, k = a[c >> 2], d = (i | 0) < (k | 0) ? d : k - g | 0, j = e + n | 0, r = a[c + 4 >> 2], e = (j | 0) < (r | 0) ? e : r - n | 0;
+      a:do {
+        if (0 == (s | 0)) {
+          if (0 < (e | 0) & 0 < (d | 0)) {
+            for (var o = k ^ -1, p = i ^ -1, o = (g ^ -1) - ((o | 0) > (p | 0) ? o : p) | 0, p = r ^ -1, t = j ^ -1, p = (n ^ -1) - ((p | 0) > (t | 0) ? p : t) | 0, t = 0; ;) {
+              for (var u = t + n | 0, m = t + l | 0, v = 0; ;) {
+                var q = v + g | 0;
+                qa(c, q, u, w(c, q, u) | w(f, v + b | 0, m));
+                v = v + 1 | 0;
+                if ((v | 0) == (o | 0)) {
+                  break
+                }
+              }
+              t = t + 1 | 0;
+              if ((t | 0) == (p | 0)) {
+                break a
+              }
+            }
+          }
+        } else {
+          if (1 == (s | 0)) {
+            if (0 < (e | 0) & 0 < (d | 0)) {
+              o = k ^ -1;
+              p = i ^ -1;
+              o = (g ^ -1) - ((o | 0) > (p | 0) ? o : p) | 0;
+              p = r ^ -1;
+              t = j ^ -1;
+              p = (n ^ -1) - ((p | 0) > (t | 0) ? p : t) | 0;
+              for (t = 0; ;) {
+                u = t + n | 0;
+                m = t + l | 0;
+                for (v = 0; !(q = v + g | 0, qa(c, q, u, w(c, q, u) & w(f, v + b | 0, m)), v = v + 1 | 0, (v | 0) == (o | 0));) {
+                }
+                t = t + 1 | 0;
+                if ((t | 0) == (p | 0)) {
+                  break a
+                }
+              }
+            }
+          } else {
+            if (2 == (s | 0)) {
+              if (0 < (e | 0) & 0 < (d | 0)) {
+                o = k ^ -1;
+                p = i ^ -1;
+                o = (g ^ -1) - ((o | 0) > (p | 0) ? o : p) | 0;
+                p = r ^ -1;
+                t = j ^ -1;
+                p = (n ^ -1) - ((p | 0) > (t | 0) ? p : t) | 0;
+                for (t = 0; ;) {
+                  u = t + n | 0;
+                  m = t + l | 0;
+                  for (v = 0; !(q = v + g | 0, qa(c, q, u, w(c, q, u) ^ w(f, v + b | 0, m)), v = v + 1 | 0, (v | 0) == (o | 0));) {
+                  }
+                  t = t + 1 | 0;
+                  if ((t | 0) == (p | 0)) {
+                    break a
+                  }
+                }
+              }
+            } else {
+              if (3 == (s | 0)) {
+                if (0 < (e | 0) & 0 < (d | 0)) {
+                  o = k ^ -1;
+                  p = i ^ -1;
+                  o = (g ^ -1) - ((o | 0) > (p | 0) ? o : p) | 0;
+                  p = r ^ -1;
+                  t = j ^ -1;
+                  p = (n ^ -1) - ((p | 0) > (t | 0) ? p : t) | 0;
+                  for (t = 0; ;) {
+                    u = t + n | 0;
+                    m = t + l | 0;
+                    for (v = 0; !(q = v + g | 0, qa(c, q, u, w(c, q, u) ^ w(f, v + b | 0, m) ^ -1), v = v + 1 | 0, (v | 0) == (o | 0));) {
+                    }
+                    t = t + 1 | 0;
+                    if ((t | 0) == (p | 0)) {
+                      break a
+                    }
+                  }
+                }
+              } else {
+                if (4 == (s | 0) && 0 < (e | 0) & 0 < (d | 0)) {
+                  o = k ^ -1;
+                  p = i ^ -1;
+                  o = (g ^ -1) - ((o | 0) > (p | 0) ? o : p) | 0;
+                  p = r ^ -1;
+                  t = j ^ -1;
+                  p = (n ^ -1) - ((p | 0) > (t | 0) ? p : t) | 0;
+                  for (t = 0; ;) {
+                    u = t + n | 0;
+                    m = t + l | 0;
+                    for (v = 0; !(qa(c, v + g | 0, u, w(f, v + b | 0, m)), v = v + 1 | 0, (v | 0) == (o | 0));) {
+                    }
+                    t = t + 1 | 0;
+                    if ((t | 0) == (p | 0)) {
+                      break a
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      } while (0);
+      return 0
+    }
+
+    function rc(b, c) {
+      for (var f, l = a[b + 8 >> 2], n = b + 52 | 0, s = a[b + 60 >> 2]; ;) {
+        var k = s - 1 | 0;
+        if (0 >= (s | 0)) {
+          f = 4;
+          break
+        }
+        s = a[a[n >> 2] + (k << 2) >> 2];
+        if ((a[s >> 2] | 0) == (c | 0)) {
+          var i = s;
+          f = 8;
+          break
+        }
+        s = k
+      }
+      a:do {
+        if (4 == f) {
+          if (0 == (l | 0)) {
+            i = 0
+          } else {
+            n = l + 52 | 0;
+            for (s = a[l + 60 >> 2]; ;) {
+              k = s - 1 | 0;
+              if (0 >= (s | 0)) {
+                i = 0;
+                break a
+              }
+              s = a[a[n >> 2] + (k << 2) >> 2];
+              if ((a[s >> 2] | 0) == (c | 0)) {
+                i = s;
+                break a
+              }
+              s = k
+            }
+          }
+        }
+      } while (0);
+      return i
+    }
+
+    function Vc(b, c, f, l, n, s) {
+      var k, b = 0 == (s | 0);
+      a:do {
+        if (b) {
+          var i = p[f + 4 >> 2], g = p[f + 12 >> 2];
+          k = 0 > (l | 0);
+          var d = a[f >> 2] + (k ? l : 0) | 0;
+          k = k ? 0 : l;
+          var e = 0 > (n | 0), j = i + (e ? n : 0) | 0, e = e ? 0 : n, r = a[c >> 2], o = (d + k | 0) < (r | 0) ? d : r - k | 0, d = p[c + 4 >> 2], m = (j + e | 0) < (d | 0) ? j : d - e | 0, t = k >> 3, u = o + k | 0, y = u - 1 >> 3, j = k & 7;
+          k = (c + 8 | 0) >> 2;
+          e = a[c + 12 >> 2] + a[k] * e + t | 0;
+          if ((t | 0) == (y | 0)) {
+            if (0 < (m | 0)) {
+              r = -(256 >>> (o >>> 0)) | 0;
+              o = f + 8 | 0;
+              u = n ^ -1;
+              m = 0 < (n | 0) ? n : 0;
+              i = (-1 < (u | 0) ? u : -1) - i - m | 0;
+              d ^= -1;
+              i = (((i | 0) > (d | 0) ? i : d) ^ -1) - m | 0;
+              for (d = 0; ;) {
+                q[e] = ((F[g] & 255 & r) >>> (j >>> 0) | F[e] & 255) & 255;
+                d = d + 1 | 0;
+                if ((d | 0) == (i | 0)) {
+                  break a
+                }
+                g = g + a[o >> 2] | 0;
+                e = e + a[k] | 0
+              }
+            }
+          } else {
+            if (0 == (j | 0)) {
+              if (j = o & 7, j = 0 == (j | 0) ? 255 : -1 << 8 - j & 255, 0 < (m | 0)) {
+                if (r = f + 8 | 0, (t | 0) < (y | 0)) {
+                  o = y - t | 0;
+                  u = n ^ -1;
+                  m = 0 < (n | 0) ? n : 0;
+                  i = (-1 < (u | 0) ? u : -1) - i - m | 0;
+                  d ^= -1;
+                  i = (((i | 0) > (d | 0) ? i : d) ^ -1) - m | 0;
+                  for (d = 0; ;) {
+                    for (var m = e + o | 0, u = g, v = e; ;) {
+                      var x = v + 1 | 0;
+                      q[v] |= q[u];
+                      if ((x | 0) == (m | 0)) {
+                        break
+                      }
+                      u = u + 1 | 0;
+                      v = x
+                    }
+                    q[m] = (F[m] & 255 | F[g + o | 0] & 255 & j) & 255;
+                    d = d + 1 | 0;
+                    if ((d | 0) == (i | 0)) {
+                      break a
+                    }
+                    g = g + a[r >> 2] | 0;
+                    e = e + a[k] | 0
+                  }
+                } else {
+                  m = n ^ -1;
+                  o = 0 < (n | 0) ? n : 0;
+                  i = (-1 < (m | 0) ? m : -1) - i - o | 0;
+                  d ^= -1;
+                  i = (((i | 0) > (d | 0) ? i : d) ^ -1) - o | 0;
+                  for (d = 0; ;) {
+                    q[e] = (F[e] & 255 | F[g] & 255 & j) & 255;
+                    d = d + 1 | 0;
+                    if ((d | 0) == (i | 0)) {
+                      break a
+                    }
+                    g = g + a[r >> 2] | 0;
+                    e = e + a[k] | 0
+                  }
+                }
+              }
+            } else {
+              if (o = (r = (o + 7 >> 3 | 0) < ((u + 7 >> 3) - t | 0)) ? 256 - (256 >>> ((u & 7) >>> 0)) >> 8 - j : 256 - (256 >>> ((o & 7) >>> 0)) | 0, 0 < (m | 0)) {
+                for (var H = -1 << j, m = H & 255, C = y - 1 | 0, u = (t | 0) < (C | 0), v = 8 - j | 0, x = f + 8 | 0, H = (H | -256) ^ 255, y = y - t | 0, t = C - t | 0, D = n ^ -1, C = 0 < (n | 0) ? n : 0, i = (-1 < (D | 0) ? D : -1) - i - C | 0, d = d ^ -1, i = (((i | 0) > (d | 0) ? i : d) ^ -1) - C | 0, d = t + 1 | 0, C = 0; ;) {
+                  q[e] = ((F[g] & 255 & m) >>> (j >>> 0) | F[e] & 255) & 255;
+                  var B = e + 1 | 0;
+                  if (u) {
+                    for (var D = e + y | 0, w = e + d | 0, P = g, A = B; ;) {
+                      B = P + 1 | 0;
+                      P = (F[P] & 255 & H) << v | F[A] & 255;
+                      q[A] = P & 255;
+                      q[A] = ((F[B] & 255 & m) >>> (j >>> 0) | P) & 255;
+                      A = A + 1 | 0;
+                      if ((A | 0) == (w | 0)) {
+                        break
+                      }
+                      P = B
+                    }
+                    w = g + t | 0
+                  } else {
+                    w = g, D = B
+                  }
+                  P = F[w] & 255;
+                  q[D] = (r ? F[D] & 255 | (o & P) << v : F[D] & 255 | (P & H) << v | (o & F[w + 1 | 0] & 255) >>> (j >>> 0)) & 255;
+                  C = C + 1 | 0;
+                  if ((C | 0) == (i | 0)) {
+                    break a
+                  }
+                  g = g + a[x >> 2] | 0;
+                  e = e + a[k] | 0
+                }
+              }
+            }
+          }
+        } else {
+          Jf(0, c, f, l, n, s)
+        }
+      } while (0);
+      return 0
+    }
+
+    function Kf(b, c) {
+      ea(a[b + 12 >> 2], (0 != (c | 0)) << 31 >> 31, a[b + 4 >> 2] * a[b + 8 >> 2] | 0)
+    }
+
+    function gf(h, z, f, l) {
+      var n, s, k = 11 > f >>> 0;
+      do {
+        if (k) {
+          var i = 0
+        } else {
+          s = (h | 0) >> 2;
+          var d = i = O(a[s], 28);
+          if (0 == (i | 0)) {
+            m(h, 3, -1, g.ua | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), i = d
+          } else {
+            var e = ia(z);
+            n = i >> 2;
+            a[n] = e;
+            var j = F[z + 4 | 0], p = i + 4 | 0;
+            q[p] = j;
+            var r = z + 5 | 0, o = F[r] & 255;
+            224 == (o & 224 | 0) ? (o = ia(r) & 536870911, r = ((o + 1 | 0) >>> 3) + 9 | 0) : (r = 6, o >>>= 5);
+            a[(i + 16 | 0) >> 2] = o;
+            var x = 257 > e >>> 0 ? 1 : 65537 > e >>> 0 ? 2 : 4, t = x * o | 0;
+            if (((0 != (j & 64) << 24 >> 24 ? 4 : 1) + (t + (r + 4)) | 0) >>> 0 > f >>> 0) {
+              m(h, 0, e, g.va | 0, (c = b, b += 4, a[c >> 2] = -1, c)), K(a[s], i), i = 0
+            } else {
+              if (0 == (o | 0)) {
+                a[(i + 20 | 0) >> 2] = 0, p = j
+              } else {
+                j = e = O(a[s], t << 2);
+                s = h;
+                if (0 == (e | 0)) {
+                  m(s, 3, -1, g.Nb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                  i = 0;
+                  break
+                }
+                a:do {
+                  if (1 == (x | 0)) {
+                    for (var e = 1 < o >>> 0 ? o : 1, u = r, t = 0; ;) {
+                      var y = F[z + u | 0] & 255;
+                      a[((t << 2) + j | 0) >> 2] = y;
+                      var u = u + 1 | 0, v = a[n];
+                      m(s, 0, v, g.t | 0, (c = b, b += 8, a[c >> 2] = v, a[c + 4 >> 2] = y, c));
+                      t = t + 1 | 0;
+                      if ((t | 0) >= (o | 0)) {
+                        var w = e;
+                        break a
+                      }
+                    }
+                  } else {
+                    if (2 == (x | 0)) {
+                      e = 1 < o >>> 0 ? o << 1 : 2;
+                      u = r;
+                      for (t = 0; ;) {
+                        if (y = Ac(z + u | 0) & 65535, a[((t << 2) + j | 0) >> 2] = y, u = u + 2 | 0, v = a[n], m(s, 0, v, g.t | 0, (c = b, b += 8, a[c >> 2] = v, a[c + 4 >> 2] = y, c)), t = t + 1 | 0, (t | 0) >= (o | 0)) {
+                          w = e;
+                          break a
+                        }
+                      }
+                    } else {
+                      e = x * (1 < o >>> 0 ? o : 1) | 0;
+                      u = r;
+                      for (t = 0; ;) {
+                        if (y = ia(z + u | 0), a[((t << 2) + j | 0) >> 2] = y, u = u + x | 0, v = a[n], m(s, 0, v, g.t | 0, (c = b, b += 8, a[c >> 2] = v, a[c + 4 >> 2] = y, c)), t = t + 1 | 0, (t | 0) >= (o | 0)) {
+                          w = e;
+                          break a
+                        }
+                      }
+                    }
+                  }
+                } while (0);
+                a[(i + 20 | 0) >> 2] = j;
+                r = r + w | 0;
+                p = q[p]
+              }
+              0 == (p & 64) << 24 >> 24 ? (o = F[z + r | 0] & 255, a[(i + 8 | 0) >> 2] = o, p = r + 1 | 0) : (o = ia(z + r | 0), a[(i + 8 | 0) >> 2] = o, p = r + 4 | 0);
+              r = o;
+              n = a[n];
+              m(h, 0, n, g.ad | 0, (c = b, b += 8, a[c >> 2] = n, a[c + 4 >> 2] = r, c));
+              a[(i + 12 | 0) >> 2] = ia(z + p | 0);
+              a[l >> 2] = p + 4 | 0;
+              a[(i + 24 | 0) >> 2] = 0;
+              i = d
+            }
+          }
+        }
+      } while (0);
+      return i
+    }
+
+    function kf(b, c) {
+      var f = c >> 2, l = a[f + 5];
+      0 != (l | 0) && K(a[b >> 2], l);
+      l = F[c + 4 | 0] & 63;
+      if (0 == (l | 0)) {
+        f = a[f + 6], 0 != (f | 0) && de(b, f)
+      } else {
+        if (4 == (l | 0) || 40 == (l | 0)) {
+          f = a[f + 6], 0 != (f | 0) && Qa(b, f)
+        } else {
+          if (53 == (l | 0)) {
+            if (f = a[f + 6], 0 != (f | 0) && 0 != (f | 0)) {
+              var l = a[f + 8 >> 2], n = b | 0;
+              0 != (l | 0) && K(a[n >> 2], l);
+              K(a[n >> 2], f)
+            }
+          } else {
+            62 == (l | 0) && (f = a[f + 6], 0 != (f | 0) && Wc(b, f))
+          }
+        }
+      }
+      K(a[b >> 2], c)
+    }
+
+    function Cc(b, c) {
+      var f = b >> 2;
+      a[f] = Pa(c);
+      a[f + 1] = Pa(c + 4 | 0);
+      a[f + 2] = Pa(c + 8 | 0);
+      a[f + 3] = Pa(c + 12 | 0);
+      var l = F[c + 16 | 0];
+      q[b + 20 | 0] = l;
+      a[f + 4] = l & 7
+    }
+
+    function Nc(h, z, f) {
+      var l, n = b;
+      l = (z | 0) >> 2;
+      var s = a[l], k = z + 4 | 0, i = F[k] & 255, d = a[z + 12 >> 2];
+      m(h, 1, s, g.fe | 0, (c = b, b += 16, a[c >> 2] = s, a[c + 4 >> 2] = i, a[c + 8 >> 2] = i & 63, a[c + 12 >> 2] = d, c));
+      s = F[k] & 63;
+      if (0 == (s | 0)) {
+        h = Lf(h, z, f)
+      } else {
+        if (4 == (s | 0) || 6 == (s | 0) || 7 == (s | 0)) {
+          h = Mf(h, z, f)
+        } else {
+          if (16 == (s | 0)) {
+            h = Df(h, z, f)
+          } else {
+            if (20 == (s | 0) || 22 == (s | 0) || 23 == (s | 0)) {
+              h = If(h, z, f)
+            } else {
+              if (36 == (s | 0)) {
+                h = m(h, 2, a[l], g.oe | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c))
+              } else {
+                if (38 == (s | 0) || 39 == (s | 0)) {
+                  h = yf(h, z, f)
+                } else {
+                  if (40 == (s | 0) || 42 == (s | 0) || 43 == (s | 0)) {
+                    h = Bf(h, z, f)
+                  } else {
+                    if (48 == (s | 0)) {
+                      h = Nf(h, z, f)
+                    } else {
+                      if (49 == (s | 0)) {
+                        var f = a[(a[h + 72 >> 2] + 4 >> 2) + (11 * a[h + 64 >> 2] | 0)], e = a[z + 8 >> 2], z = z | 0;
+                        (e | 0) != (f | 0) && m(h, 2, a[z >> 2], g.te | 0, (c = b, b += 8, a[c >> 2] = e, a[c + 4 >> 2] = f, c));
+                        e = h;
+                        m(e, 1, a[z >> 2], g.qa | 0, (c = b, b += 4, a[c >> 2] = f, c));
+                        ee(h);
+                        h = 0
+                      } else {
+                        if (50 == (s | 0)) {
+                          e = a[(a[h + 72 >> 2] + 32 >> 2) + (11 * a[h + 64 >> 2] | 0)], f = Pa(f), z = a[z >> 2], (f | 0) < (e | 0) ? m(h, 2, z, g.Qd | 0, (c = b, b += 8, a[c >> 2] = f, a[c + 4 >> 2] = e, c)) : m(h, 1, z, g.$d | 0, (c = b, b += 4, a[c >> 2] = f, c)), h = 0
+                        } else {
+                          if (51 == (s | 0)) {
+                            a[h + 36 >> 2] = 5, h = m(h, 1, a[l], g.oa | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c))
+                          } else {
+                            if (52 == (s | 0)) {
+                              h = m(h, 2, a[l], g.wa | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c))
+                            } else {
+                              if (53 == (s | 0)) {
+                                h = of(h, z, f)
+                              } else {
+                                if (62 == (s | 0)) {
+                                  if (l = ia(f), s = 0 > (l | 0), s & 0 == (l & 536870912 | 0) && m(h, 2, a[z >> 2], g.zd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), 536870912 == (l | 0)) {
+                                    s = b;
+                                    k = f + a[z + 12 >> 2] | 0;
+                                    l = (z | 0) >> 2;
+                                    m(h, 1, a[l], g.Fc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                                    var j;
+                                    j = (h | 0) >> 2;
+                                    i = O(a[j], 20);
+                                    if (0 == (i | 0)) {
+                                      m(h, 3, -1, g.La | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c))
+                                    } else {
+                                      a[i >> 2] = 0;
+                                      a[(i + 12 | 0) >> 2] = 0;
+                                      var p = i + 16 | 0;
+                                      a[p >> 2] = 4;
+                                      var r = O(a[j], 16), d = i + 4 | 0;
+                                      a[d >> 2] = r;
+                                      j = O(a[j], a[p >> 2] << 2);
+                                      a[(i + 8 | 0) >> 2] = j;
+                                      0 == (a[d >> 2] | 0) | 0 == (j | 0) && (m(h, 3, -1, g.hc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), Wc(h, i), i = 0)
+                                    }
+                                    d = 0 == (i | 0);
+                                    a:do {
+                                      if (d) {
+                                        m(h, 2, a[l], g.jd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), e = -1
+                                      } else {
+                                        j = f + 4 | 0;
+                                        b:for (; ;) {
+                                          if (0 != q[j] << 24 >> 24 & j >>> 0 < k >>> 0) {
+                                            var p = oc(j) + 1 | 0, r = j + p | 0, o = r >>> 0 < k >>> 0;
+                                            do {
+                                              if (o) {
+                                                var x = oc(r) + 1 | 0, t = j + x + p | 0;
+                                                if (t >>> 0 < k >>> 0) {
+                                                  Of(h, i, j, p, r, x);
+                                                  m(h, 1, a[l], g.Ed | 0, (c = b, b += 8, a[c >> 2] = j, a[c + 4 >> 2] = r, c));
+                                                  j = t;
+                                                  continue b
+                                                }
+                                              }
+                                            } while (0);
+                                            Wc(h, i);
+                                            e = m(h, 2, a[l], g.Rd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                                            break a
+                                          }
+                                          a[z + 24 >> 2] = i;
+                                          e = 0;
+                                          break a
+                                        }
+                                      }
+                                    } while (0);
+                                    b = s;
+                                    h = e
+                                  } else {
+                                    536870914 == (l | 0) ? (f = b, h = m(h, 2, a[z >> 2], g.ae | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), b = f) : (z = a[z >> 2], h = s ? m(h, 3, z, g.Nd | 0, (c = b, b += 4, a[c >> 2] = l, c)) : m(h, 2, z, g.Wd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)))
+                                  }
+                                } else {
+                                  m(h, 2, a[l], g.Ga | 0, (c = b, b += 4, a[c >> 2] = s, c)), h = 0
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      b = n;
+      return h
+    }
+
+    function ve(h, z) {
+      var f;
+      f = (h | 0) >> 2;
+      var l = O(a[f], 8);
+      if (0 == (l | 0)) {
+        m(h, 3, -1, g.Ra | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), f = 0
+      } else {
+        var n = z << 2, s = O(a[f], n);
+        a[(l + 4 | 0) >> 2] = s;
+        a[l >> 2] = z;
+        0 == (s | 0) ? (m(h, 3, -1, g.Ba | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), K(a[f], l), f = 0) : (ea(s, 0, n), f = l)
+      }
+      return f
+    }
+
+    function de(b, c) {
+      if (0 != (c | 0)) {
+        var f = c | 0, l = a[f >> 2], n = 0 < (l | 0), s = c + 4 | 0;
+        a:do {
+          if (n) {
+            for (var k = 0, i = l; ;) {
+              var g = a[a[s >> 2] + (k << 2) >> 2];
+              0 != (g | 0) && (Qa(b, g), i = a[f >> 2]);
+              k = k + 1 | 0;
+              if ((k | 0) >= (i | 0)) {
+                break a
+              }
+            }
+          }
+        } while (0);
+        f = b | 0;
+        K(a[f >> 2], a[s >> 2]);
+        K(a[f >> 2], c)
+      }
+    }
+
+    function fe(b, c) {
+      var f = p[c + 16 >> 2], l = 0 < (f | 0);
+      a:do {
+        if (l) {
+          for (var n = a[c + 20 >> 2], s = 0, k = 0; ;) {
+            var i = rc(b, a[n + (s << 2) >> 2]), k = 0 == (i | 0) ? k : (0 == (q[i + 4 | 0] & 63) << 24 >> 24 & 1) + k | 0, s = s + 1 | 0;
+            if ((s | 0) >= (f | 0)) {
+              var g = k;
+              break a
+            }
+          }
+        } else {
+          g = 0
+        }
+      } while (0);
+      return g
+    }
+
+    function Xc(h, z) {
+      var f = fe(h, z), l = O(a[h >> 2], f << 2), n = 0 == (l | 0);
+      do {
+        if (n) {
+          m(h, 3, a[z >> 2], g.Qb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+          var s = 0
+        } else {
+          var s = z + 16 | 0, k = a[s >> 2], i = 0 < (k | 0);
+          a:do {
+            if (i) {
+              for (var d = z + 20 | 0, e = 0, j = 0, p = k; ;) {
+                var r = rc(h, a[a[d >> 2] + (e << 2) >> 2]);
+                0 != (r | 0) && 0 == (q[r + 4 | 0] & 63) << 24 >> 24 && (a[((j << 2) + l | 0) >> 2] = a[r + 24 >> 2], j = j + 1 | 0, p = a[s >> 2]);
+                e = e + 1 | 0;
+                if ((e | 0) >= (p | 0)) {
+                  var o = j;
+                  break a
+                }
+              }
+            } else {
+              o = 0
+            }
+          } while (0);
+          (o | 0) != (f | 0) && m(h, 3, a[z >> 2], g.yc | 0, (c = b, b += 8, a[c >> 2] = f, a[c + 4 >> 2] = o, c));
+          s = l
+        }
+      } while (0);
+      return s
+    }
+
+    function Pf(h, z, f) {
+      var l = 0 < (z | 0);
+      a:do {
+        if (l) {
+          for (var n = 0, s = 0; ;) {
+            if (s = a[a[f + (n << 2) >> 2] >> 2] + s | 0, n = n + 1 | 0, (n | 0) == (z | 0)) {
+              var k = s;
+              break a
+            }
+          }
+        } else {
+          k = 0
+        }
+      } while (0);
+      k = ve(h, k);
+      n = 0 == (k | 0);
+      a:do {
+        if (n) {
+          m(h, 2, -1, g.cd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c))
+        } else {
+          if (l) {
+            for (var s = k + 4 | 0, i = 0, d = 0; ;) {
+              var e = (i << 2) + f | 0, j = a[e >> 2], p = 0 < (a[j >> 2] | 0);
+              b:do {
+                if (p) {
+                  for (var r = 0, o = d, q = j; ;) {
+                    var t = Dc(a[a[q + 4 >> 2] + (r << 2) >> 2]), q = o + 1 | 0;
+                    a[((o << 2) + a[s >> 2] | 0) >> 2] = t;
+                    r = r + 1 | 0;
+                    t = a[e >> 2];
+                    if ((r | 0) >= (a[t >> 2] | 0)) {
+                      var u = q;
+                      break b
+                    }
+                    o = q;
+                    q = t
+                  }
+                } else {
+                  u = d
+                }
+              } while (0);
+              i = i + 1 | 0;
+              if ((i | 0) == (z | 0)) {
+                break a
+              }
+              d = u
+            }
+          }
+        }
+      } while (0);
+      return k
+    }
+
+    function Lf(h, z, f) {
+      var l, n, s, k, i, d, e, j, q = z >> 2, r = b;
+      b += 60;
+      var o;
+      j = r >> 2;
+      e = (z + 12 | 0) >> 2;
+      var x = 10 > p[e] >>> 0;
+      a:do {
+        if (x) {
+          o = 71
+        } else {
+          s = Ac(f);
+          k = r >> 2;
+          for (i = k + 15; k < i; k++) {
+            a[k] = 0
+          }
+          var t = s & 65535;
+          n = t & 1;
+          d = (r | 0) >> 2;
+          a[d] = n;
+          i = (r + 4 | 0) >> 2;
+          a[i] = t >>> 1 & 1;
+          k = (r + 40 | 0) >> 2;
+          a[k] = t >>> 10 & 3;
+          s = (r + 52 | 0) >> 2;
+          a[s] = t >>> 12 & 1;
+          n = 0 == (n | 0);
+          do {
+            if (n) {
+              o = 36
+            } else {
+              var u = t >>> 2 & 3;
+              if (0 == (u | 0)) {
+                var y = J(h, Yc);
+                a[j + 6] = y;
+                u = 0
+              } else {
+                if (1 == (u | 0)) {
+                  y = J(h, Ec), a[j + 6] = y, u = 0
+                } else {
+                  if (3 == (u | 0)) {
+                    u = h;
+                    y = xa(u, z, 0);
+                    if (0 == (y | 0)) {
+                      var v = m(h, 3, a[q], g.Ad | 0, (c = b, b += 4, a[c >> 2] = 0, c));
+                      o = 72;
+                      break a
+                    }
+                    y = J(u, y);
+                    a[j + 6] = y;
+                    u = 1
+                  } else {
+                    v = m(h, 3, a[q], g.R | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                    o = 72;
+                    break a
+                  }
+                }
+              }
+              if (0 == (y | 0)) {
+                m(h, 3, a[q], g.Xd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), o = 68
+              } else {
+                y = t >>> 4 & 3;
+                if (0 == (y | 0)) {
+                  y = J(h, ge), a[j + 7] = y
+                } else {
+                  if (1 == (y | 0)) {
+                    y = J(h, Zc), a[j + 7] = y
+                  } else {
+                    if (3 == (y | 0)) {
+                      y = h, o = xa(y, z, u), 0 == (o | 0) ? (m(h, 3, a[q], g.ge | 0, (c = b, b += 4, a[c >> 2] = u, c)), y = a[j + 7]) : (y = J(y, o), a[j + 7] = y, u = u + 1 | 0)
+                    } else {
+                      v = m(h, 3, a[q], g.R | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                      o = 72;
+                      break a
+                    }
+                  }
+                }
+                0 == (y | 0) ? (m(h, 3, a[q], g.pe | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), o = 68) : (y = h, 0 == (t & 64 | 0) ? (o = J(y, Jd), a[j + 8] = o) : (o = xa(y, z, u), 0 == (o | 0) ? (m(h, 3, a[q], g.pa | 0, (c = b, b += 4, a[c >> 2] = u, c)), o = a[j + 8]) : (o = J(y, o), a[j + 8] = o, u = u + 1 | 0)), 0 == (o | 0)) ? (m(h, 3, a[q], g.xa | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), o = 68) : (0 == (t & 128 | 0) ? (u = J(y, Jd), a[j + 9] = u) : (o = xa(y, z, u), 0 == (o | 0) ? (m(h, 3, a[q], g.Ha | 0, (c = b, b += 4, a[c >> 2] = u, c)), u = a[j + 9]) : (u = J(y, o), a[j + 9] = u)), 0 == (u | 0)) ? (m(h, 3, a[q], g.Qa | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), o = 68) : o = 0 == (a[d] | 0) ? 36 : 40
+              }
+            }
+          } while (0);
+          36 == o && (0 != (t & 12 | 0) && m(h, 2, a[q], g.Ya | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), 0 != (t & 48 | 0) && m(h, 2, a[q], g.gb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), o = 40);
+          b:do {
+            if (40 == o) {
+              0 != (t & 128 | 0) && m(h, 2, a[q], g.nb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+              n = 0 == (a[d] | 0) ? 0 == (a[k] | 0) ? 8 : 2 : 0;
+              eb(r + 44 | 0, f + 2 | 0, n);
+              u = n + 2 | 0;
+              y = 0 == (a[i] | 0);
+              do {
+                if (y) {
+                  o = u
+                } else {
+                  if (0 != (a[s] | 0)) {
+                    o = u
+                  } else {
+                    o = n + 6 | 0;
+                    if (o >>> 0 > p[e] >>> 0) {
+                      o = 71;
+                      break a
+                    }
+                    var w = f + u | 0;
+                    a[j + 14] = F[w] | F[w + 1] << 8 | F[w + 2] << 16 | F[w + 3] << 24 | 0
+                  }
+                }
+              } while (0);
+              u = o + 8 | 0;
+              if (u >>> 0 > p[e] >>> 0) {
+                o = 71;
+                break a
+              }
+              w = ia(f + o | 0);
+              a[j + 5] = w;
+              o = ia(o + (f + 4) | 0);
+              a[j + 4] = o;
+              n = (z | 0) >> 2;
+              y = h;
+              m(y, 1, a[n], g.tb | 0, (c = b, b += 12, a[c >> 2] = t, a[c + 4 >> 2] = w, a[c + 8 >> 2] = o, c));
+              var w = fe(h, z), H = 0 < (w | 0);
+              do {
+                if (H) {
+                  o = Xc(h, z);
+                  if (0 == (o | 0)) {
+                    m(y, 2, a[n], g.Ab | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                    break b
+                  }
+                  l = Pf(h, w, o);
+                  a[j + 3] = l;
+                  if (0 != (l | 0)) {
+                    var C = l;
+                    o = 55
+                  } else {
+                    m(y, 2, a[n], g.Fb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                    de(h, a[o >> 2]);
+                    break b
+                  }
+                } else {
+                  o = a[j + 3], 0 == (o | 0) ? o = 56 : (C = o, o = 55)
+                }
+              } while (0);
+              55 == o && (a[j + 2] = a[C >> 2]);
+              w = 0 == (t & 256 | 0);
+              do {
+                if (w) {
+                  var H = a[k], D = 0 == (H | 0) ? 65536 : 1 == (H | 0) ? 8192 : 1024;
+                  l = (h | 0) >> 2;
+                  H = O(a[l], D);
+                  if (0 == (H | 0)) {
+                    m(y, 3, -1, g.Ob | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                    break b
+                  }
+                  ea(H, 0, D);
+                  if (0 == (a[i] | 0)) {
+                    l = 0
+                  } else {
+                    var D = 0 != (a[s] | 0) ? 1024 : 8192, B = O(a[l], D);
+                    if (0 == (B | 0)) {
+                      m(y, 3, -1, g.Ub | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                      K(a[l], H);
+                      break b
+                    }
+                    ea(B, 0, D);
+                    l = B
+                  }
+                } else {
+                  m(y, 2, a[n], g.Kb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), H = l = 0
+                }
+              } while (0);
+              u = Qf(h, z, r, f + u | 0, a[e] - u | 0, H, l);
+              a[q + 6] = u;
+              0 != (t & 512 | 0) && m(y, 2, a[n], g.ac | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c))
+            }
+          } while (0);
+          0 != (a[d] | 0) && (v = h, ma(v, a[j + 6]), ma(v, a[j + 7]), ma(v, a[j + 8]), ma(v, a[j + 9]));
+          v = (0 == (a[q + 6] | 0)) << 31 >> 31;
+          o = 72
+        }
+      } while (0);
+      71 == o && (v = m(h, 3, a[q], g.c | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)));
+      b = r;
+      return v
+    }
+
+    function Qf(h, z, f, l, n, s, k) {
+      var i, d, e, j, q, r, o, x, t, u, y, v, w, H, C, D, B, I = f >> 2, A = b;
+      b += 92;
+      var E;
+      B = A >> 2;
+      var M = A + 4, T = A + 8, Q = A + 12, W = A + 36, Ea = A + 40, ea = A + 64, U = A + 68, Ua = A + 72, aa = A + 76;
+      D = aa >> 2;
+      var wa = A + 80;
+      C = wa >> 2;
+      var ia = A + 84;
+      H = ia >> 2;
+      var ja = A + 88;
+      a[B] = 0;
+      var ra = Gd(h, l, n);
+      if (0 == (ra | 0)) {
+        m(h, 2, a[z >> 2], g.fc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+        var dc = 0
+      } else {
+        var S = Hd(h, ra);
+        if (0 == (S | 0)) {
+          m(h, 2, a[z >> 2], g.jc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), Tc(h, ra), dc = 0
+        } else {
+          w = (f | 0) >> 2;
+          var Z = 0 == (a[w] | 0);
+          do {
+            if (Z) {
+              var Kd = h, he = fa(Kd), ie = fa(Kd), ic = fa(Kd), Fc = fa(Kd);
+              if (0 == (he | 0) | 0 == (ie | 0) | 0 == (ic | 0) | 0 == (Fc | 0)) {
+                m(h, 2, a[z >> 2], g.s | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                var ba = 0, ya = he, zd = ie, La = ic, $c = Fc, jd = h | 0;
+                E = 137;
+                break
+              }
+              if (0 == (a[I + 1] | 0)) {
+                var tc = 0, qb = 0, ka = 0, rb = 0, fb = 0, X = he, sb = ie, Va = ic, na = Fc, Wa = 0, Ra = 0, Gc = 0;
+                E = 18;
+                break
+              }
+              var ec = a[I + 4] + a[a[I + 3] >> 2] | 0, Ad = 1 < (ec | 0);
+              a:do {
+                if (Ad) {
+                  for (var ta = 0; ;) {
+                    var Xb = ta + 1 | 0;
+                    if ((1 << Xb | 0) >= (ec | 0)) {
+                      var Sa = Xb;
+                      break a
+                    }
+                    ta = Xb
+                  }
+                } else {
+                  Sa = 0
+                }
+              } while (0);
+              var Qb = Ce(h, Sa), Yb = fa(Kd), da = fa(Kd);
+              if (!(0 == (Qb | 0) | 0 == (Yb | 0) | 0 == (da | 0))) {
+                tc = 0;
+                qb = Sa;
+                fb = rb = ka = 0;
+                X = he;
+                sb = ie;
+                Va = ic;
+                na = Fc;
+                Wa = Qb;
+                Ra = Yb;
+                Gc = da;
+                E = 18;
+                break
+              }
+              m(h, 2, a[z >> 2], g.s | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+              var la = 0, Ma = 0, Na = 0, Pc = 0, je = 0, Hc = 0, fc = he, tb = ie, Ic = ic, ub = Fc, Jc = Qb, jc = Yb, Xa = da
+            } else {
+              v = (z | 0) >> 2;
+              m(h, 0, a[v], g.nc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+              var Fa = h, ad = nf(Fa, ra), bd = J(Fa, Ib), Zb = J(Fa, Jd);
+              if (0 == (ad | 0) | 0 == (bd | 0) | 0 == (Zb | 0)) {
+                m(h, 2, a[v], g.s | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                Na = Ma = la = 0;
+                Pc = ad;
+                je = bd;
+                Hc = Zb;
+                Xa = jc = Jc = ub = Ic = tb = fc = 0;
+                E = 136;
+                break
+              }
+              if (0 != (a[I + 1] | 0)) {
+                qb = tc = 0;
+                ka = ad;
+                rb = bd;
+                fb = Zb;
+                Gc = Ra = Wa = na = Va = sb = X = 0;
+                E = 18;
+                break
+              }
+              var Db = O(a[h >> 2], a[I + 4] << 2), yb = Db;
+              if (0 != (Db | 0)) {
+                tc = yb;
+                qb = 0;
+                ka = ad;
+                rb = bd;
+                fb = Zb;
+                Gc = Ra = Wa = na = Va = sb = X = 0;
+                E = 18;
+                break
+              }
+              m(h, 3, a[v], g.qc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+              Ma = la = 0;
+              Na = yb;
+              Pc = ad;
+              je = bd;
+              Hc = Zb;
+              Xa = jc = Jc = ub = Ic = tb = fc = 0
+            }
+            E = 136
+          } while (0);
+          a:do {
+            if (18 == E) {
+              y = (f + 16 | 0) >> 2;
+              var zb = ve(h, a[y]);
+              u = (z | 0) >> 2;
+              if (0 == (zb | 0)) {
+                m(h, 2, a[u], g.uc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), Ma = la = 0
+              } else {
+                t = (f + 4 | 0) >> 2;
+                var Lg = Q | 0, qa = f + 40 | 0, Bd = Q + 4 | 0, Aa = Q + 8 | 0, Qc = Q + 12 | 0, Fb = Q + 16 | 0, we = f + 44 | 0;
+                x = (zb + 4 | 0) >> 2;
+                o = (h | 0) >> 2;
+                r = (f + 8 | 0) >> 2;
+                var ca = h, kd = h, cd = f + 52 | 0, za = h;
+                q = (f + 12 | 0) >> 2;
+                var Ie = 0 != (S | 0) ? 0 : ra, xa = Ea | 0, Mg = Ea + 4 | 0, ib = Ea + 8 | 0, Je = Ea + 12 | 0, Jb = Ea + 16 | 0, $b = f + 56 | 0, Ld = Ea + 20 | 0, Rb = z, Ke = Ea, Md = f + 36 | 0, Le = f + 28 | 0, Pa = f + 32 | 0, Me = f + 24 | 0, ld = 0, Gb = 0, kc = qb, md = 0, nd = 0;
+                b:for (; ;) {
+                  if (Gb >>> 0 >= p[y] >>> 0) {
+                    E = 108;
+                    break
+                  }
+                  if (0 == (a[w] | 0)) {
+                    var Za = Ja(X, S, M), Ne = a[B] = Za
+                  } else {
+                    var Nb = pa(ka, a[Me >> 2], A);
+                    a[M >> 2] = Nb;
+                    Ne = a[B]
+                  }
+                  0 != (Ne | 0) && m(h, 2, a[u], g.wc | 0, (c = b, b += 4, a[c >> 2] = Ne, c));
+                  var Ta = a[M >> 2] + ld | 0, Ia = a[u];
+                  if (0 > (Ta | 0)) {
+                    var Ba = m(h, 3, Ia, g.Cc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                    a[B] = Ba;
+                    la = zb;
+                    Ma = 0;
+                    Na = tc;
+                    Pc = ka;
+                    je = rb;
+                    Hc = fb;
+                    fc = X;
+                    tb = sb;
+                    Ic = Va;
+                    ub = na;
+                    Jc = Wa;
+                    jc = Ra;
+                    Xa = Gc;
+                    E = 136;
+                    break a
+                  }
+                  m(h, 0, Ia, g.Ic | 0, (c = b, b += 8, a[c >> 2] = Ta, a[c + 4 >> 2] = Gb, c));
+                  for (var gb = Gb, Rf = 0, cb = 0, Hb = kc, Ga = md, sa = nd; ;) {
+                    if (gb >>> 0 > p[y] >>> 0) {
+                      m(h, 2, a[u], g.Lc | 0, (c = b, b += 4, a[c >> 2] = Ta, c));
+                      var Ab = 0, Ya = Ga, $ = sa;
+                      j = $ >> 2;
+                      E = 128;
+                      break b
+                    }
+                    if (0 == (a[w] | 0)) {
+                      var Oe = Ja(sb, S, T);
+                      a[B] = Oe;
+                      if (0 > (Oe | 0)) {
+                        Ab = 0;
+                        Ya = Ga;
+                        $ = sa;
+                        j = $ >> 2;
+                        E = 128;
+                        break b
+                      }
+                      var Da = Oe
+                    } else {
+                      var uc = pa(ka, a[Le >> 2], A);
+                      a[T >> 2] = uc;
+                      Da = a[B]
+                    }
+                    if (1 == (Da | 0)) {
+                      break
+                    }
+                    var gc = a[T >> 2] + Rf | 0, Oa = gc + cb | 0;
+                    if (0 > (gc | 0)) {
+                      var Eb = m(h, 3, a[u], g.Pc | 0, (c = b, b += 8, a[c >> 2] = gc, a[c + 4 >> 2] = gb + 1 | 0, c));
+                      a[B] = Eb;
+                      Ab = 0;
+                      Ya = Ga;
+                      $ = sa;
+                      j = $ >> 2;
+                      E = 128;
+                      break b
+                    }
+                    var $a = 0 == (a[w] | 0), Sf = 0 == (a[t] | 0);
+                    do {
+                      if ($a) {
+                        if (Sf) {
+                          a[Lg >> 2] = 0;
+                          var Ha = a[qa >> 2];
+                          a[Bd >> 2] = Ha;
+                          a[Aa >> 2] = 0;
+                          a[Qc >> 2] = 0;
+                          eb(Fb, we, 0 == (Ha | 0) ? 8 : 2);
+                          var od = pb(h, gc, Ta);
+                          if (0 == (od | 0)) {
+                            var Ng = m(h, 3, a[u], g.Rc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                            a[B] = Ng;
+                            Ab = 0;
+                            Ya = Ga;
+                            $ = sa;
+                            j = $ >> 2;
+                            E = 128;
+                            break b
+                          }
+                          var Tf = hd(h, z, Q, S, od, s);
+                          a[B] = Tf;
+                          if (0 > (Tf | 0)) {
+                            Ab = 0;
+                            Ya = Ga;
+                            $ = sa;
+                            j = $ >> 2;
+                            E = 128;
+                            break b
+                          }
+                          a[((gb << 2) + a[x] | 0) >> 2] = od;
+                          Kc = Hb;
+                          Lc = Ga;
+                          Kb = sa;
+                          E = 88
+                        } else {
+                          var Nd = Ja(na, S, W), Cd = a[B] = Nd;
+                          E = 48
+                        }
+                      } else {
+                        if (Sf) {
+                          var Kc = Hb, Lc = Ga, Kb = sa;
+                          E = 88
+                        } else {
+                          var oa = pa(ka, a[Md >> 2], A);
+                          a[W >> 2] = oa;
+                          var Cd = a[B];
+                          E = 48
+                        }
+                      }
+                    } while (0);
+                    c:do {
+                      if (48 == E) {
+                        var Cb = 0 == (Cd | 0);
+                        do {
+                          if (Cb) {
+                            var vc = p[W >> 2];
+                            if (1 <= (vc | 0)) {
+                              m(h, 0, a[u], g.Vc | 0, (c = b, b += 4, a[c >> 2] = vc, c));
+                              if (1 >= vc >>> 0) {
+                                var Od = p[a[q] >> 2];
+                                a[D] = 0;
+                                a[C] = 0;
+                                a[H] = 0;
+                                if (0 == (a[w] | 0)) {
+                                  mf(Wa, S, ea);
+                                  a[D] = 0;
+                                  var Wb = Ja(Ra, S, U);
+                                  a[C] = Wb;
+                                  var db = Ja(Gc, S, Ua);
+                                  a[H] = db;
+                                  var Pd = 0
+                                } else {
+                                  var kb = Oc(ka, Hb);
+                                  a[ea >> 2] = kb;
+                                  var bb = pa(ka, rb, aa);
+                                  a[U >> 2] = bb;
+                                  var Og = pa(ka, rb, wa);
+                                  a[Ua >> 2] = Og;
+                                  var Pg = pa(ka, fb, ia);
+                                  ue(ka);
+                                  Pd = Pg
+                                }
+                                var lc = 0 > (a[D] | 0);
+                                do {
+                                  if (!lc && 0 <= (a[C] | 0) && 0 <= (a[H] | 0)) {
+                                    var ac = p[ea >> 2], Uf = a[u];
+                                    if (ac >>> 0 >= (Od + gb | 0) >>> 0) {
+                                      var vb = m(h, 3, Uf, g.od | 0, (c = b, b += 4, a[c >> 2] = ac, c));
+                                      a[B] = vb;
+                                      Ab = 0;
+                                      Ya = Ga;
+                                      $ = sa;
+                                      j = $ >> 2;
+                                      E = 128;
+                                      break b
+                                    }
+                                    var Vf = p[U >> 2], nb = p[Ua >> 2];
+                                    m(h, 0, Uf, g.qd | 0, (c = b, b += 12, a[c >> 2] = ac, a[c + 4 >> 2] = Vf, a[c + 8 >> 2] = nb, c));
+                                    var Mc = pb(h, gc, Ta);
+                                    if (0 == (Mc | 0)) {
+                                      var cc = m(h, 3, a[u], g.N | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                                      a[B] = cc;
+                                      Ab = 0;
+                                      Ya = Ga;
+                                      $ = sa;
+                                      j = $ >> 2;
+                                      E = 128;
+                                      break b
+                                    }
+                                    a[xa >> 2] = a[cd >> 2];
+                                    a[Mg >> 2] = a[(ac >>> 0 < Od >>> 0 ? (ac << 2) + a[a[q] + 4 >> 2] | 0 : (ac - Od << 2) + a[x] | 0) >> 2];
+                                    a[ib >> 2] = Vf;
+                                    a[Je >> 2] = nb;
+                                    a[Jb >> 2] = 0;
+                                    a[Ld >> 2] = F[$b] | F[$b + 1] << 8 | F[$b + 2] << 16 | F[$b + 3] << 24 | 0;
+                                    He(za, Rb, Ke, S, Mc, k);
+                                    a[((gb << 2) + a[x] | 0) >> 2] = Mc;
+                                    if (0 == (a[w] | 0)) {
+                                      var pd = sa, Wf = Ga, qd = Hb;
+                                      E = 91;
+                                      break c
+                                    }
+                                    Ee(ka, 0 == (Pd | 0) ? a[Mc + 8 >> 2] * a[Mc + 4 >> 2] | 0 : Pd);
+                                    Kc = Hb;
+                                    Lc = Ga;
+                                    Kb = sa;
+                                    E = 88;
+                                    break c
+                                  }
+                                } while (0);
+                                var Qg = m(h, 3, a[u], g.L | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                                a[B] = Qg;
+                                Ab = 0;
+                                Ya = Ga;
+                                $ = sa;
+                                j = $ >> 2;
+                                E = 128;
+                                break b
+                              }
+                              if (0 == (sa | 0)) {
+                                var dd = O(a[o], 4), hc = dd;
+                                if (0 == (dd | 0)) {
+                                  var rd = m(h, 3, a[u], g.Yc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                                  a[B] = rd;
+                                  var Sb = hc, sd = 0;
+                                  E = 133;
+                                  break b
+                                }
+                                var td = ve(h, a[y] + a[r] | 0);
+                                a[hc >> 2] = td;
+                                if (0 == (td | 0)) {
+                                  var Rg = m(h, 3, a[u], g.$c | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                                  a[B] = Rg;
+                                  K(a[o], dd);
+                                  Sb = hc;
+                                  sd = 0;
+                                  E = 133;
+                                  break b
+                                }
+                                var Ac = 0 < (a[r] | 0);
+                                d:do {
+                                  if (Ac) {
+                                    for (var Bb = 0; ;) {
+                                      var ud = Dc(a[a[a[q] + 4 >> 2] + (Bb << 2) >> 2]);
+                                      a[((Bb << 2) + a[a[hc >> 2] + 4 >> 2] | 0) >> 2] = ud;
+                                      var Xf = Bb + 1 | 0;
+                                      if ((Xf | 0) >= (a[r] | 0)) {
+                                        break d
+                                      }
+                                      Bb = Xf
+                                    }
+                                  }
+                                } while (0);
+                                var ha = O(a[o], 120), Yf = ha;
+                                if (0 == (ha | 0)) {
+                                  var Sg = m(h, 3, a[u], g.fd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                                  a[B] = Sg;
+                                  Ab = 0;
+                                  Ya = hc;
+                                  $ = Yf;
+                                  j = $ >> 2;
+                                  E = 128;
+                                  break b
+                                }
+                                if (0 == (a[w] | 0)) {
+                                  var pc = fa(ca);
+                                  a[(ha + 72 | 0) >> 2] = pc;
+                                  var ob = fa(ca);
+                                  a[(ha + 76 | 0) >> 2] = ob;
+                                  var Rc = fa(ca);
+                                  a[(ha + 80 | 0) >> 2] = Rc;
+                                  var ab = fa(ca);
+                                  a[(ha + 84 | 0) >> 2] = ab;
+                                  var lb = a[y] + a[r] | 0, Ub = 1 < (lb | 0);
+                                  d:do {
+                                    if (Ub) {
+                                      for (var Vb = 0; ;) {
+                                        var Pe = Vb + 1 | 0;
+                                        if ((1 << Pe | 0) >= (lb | 0)) {
+                                          var vd = Pe;
+                                          break d
+                                        }
+                                        Vb = Pe
+                                      }
+                                    } else {
+                                      vd = 0
+                                    }
+                                  } while (0);
+                                  var mb = Ce(kd, vd);
+                                  a[(ha + 88 | 0) >> 2] = mb;
+                                  var wc = fa(ca);
+                                  a[(ha + 92 | 0) >> 2] = wc;
+                                  var wd = fa(ca);
+                                  a[(ha + 96 | 0) >> 2] = wd;
+                                  var mc = fa(ca);
+                                  a[(ha + 100 | 0) >> 2] = mc;
+                                  var nc = fa(ca);
+                                  a[(ha + 104 | 0) >> 2] = nc;
+                                  var xd = fa(ca);
+                                  a[(ha + 108 | 0) >> 2] = xd;
+                                  var yd = vd
+                                } else {
+                                  var oc = J(za, xe);
+                                  a[(ha + 40 | 0) >> 2] = oc;
+                                  var xb = J(za, ye);
+                                  a[(ha + 44 | 0) >> 2] = xb;
+                                  var rc = J(za, ze);
+                                  a[(ha + 48 | 0) >> 2] = rc;
+                                  var ed = J(za, Ib);
+                                  a[(ha + 52 | 0) >> 2] = ed;
+                                  var Mb = J(za, Ib);
+                                  a[(ha + 56 | 0) >> 2] = Mb;
+                                  var yc = J(za, Ib);
+                                  a[(ha + 60 | 0) >> 2] = yc;
+                                  var zc = J(za, Ib);
+                                  a[(ha + 64 | 0) >> 2] = zc;
+                                  yd = Hb
+                                }
+                                a[ha >> 2] = a[w];
+                                a[(ha + 4 | 0) >> 2] = 1;
+                                a[(ha + 36 | 0) >> 2] = 1;
+                                a[(ha + 8 | 0) >> 2] = 0;
+                                a[(ha + 12 | 0) >> 2] = 0;
+                                a[(ha + 16 | 0) >> 2] = 0;
+                                a[(ha + 20 | 0) >> 2] = 1;
+                                a[(ha + 24 | 0) >> 2] = 0;
+                                a[(ha + 112 | 0) >> 2] = a[cd >> 2];
+                                var wb = yd, ke = hc, le = Yf
+                              } else {
+                                wb = Hb, ke = Ga, le = sa
+                              }
+                              a[le + 28 >> 2] = vc;
+                              var Cc = pb(h, gc, Ta);
+                              if (0 == (Cc | 0)) {
+                                var Id = m(h, 3, a[u], g.N | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                                a[B] = Id;
+                                Ab = 0;
+                                Ya = ke;
+                                $ = le;
+                                j = $ >> 2;
+                                E = 128;
+                                break b
+                              }
+                              Qe(h, z, le, ke, 1, Cc, 0, 0, k, S, Ie);
+                              a[((gb << 2) + a[x] | 0) >> 2] = Cc;
+                              var Uc = Dc(a[a[x] + (gb << 2) >> 2]);
+                              a[((a[r] + gb << 2) + a[a[ke >> 2] + 4 >> 2] | 0) >> 2] = Uc;
+                              Kc = wb;
+                              Lc = ke;
+                              Kb = le;
+                              E = 88;
+                              break c
+                            }
+                          }
+                        } while (0);
+                        var Wc = m(h, 3, a[u], g.Tc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                        a[B] = Wc;
+                        Ab = 0;
+                        Ya = Ga;
+                        $ = sa;
+                        j = $ >> 2;
+                        E = 128;
+                        break b
+                      }
+                    } while (0);
+                    88 == E && (0 != (a[w] | 0) && 0 == (a[t] | 0) && (a[tc + (gb << 2) >> 2] = gc), pd = Kb, Wf = Lc, qd = Kc);
+                    var gd = a[y];
+                    m(h, 0, a[u], g.rd | 0, (c = b, b += 16, a[c >> 2] = gb, a[c + 4 >> 2] = gd, a[c + 8 >> 2] = gc, a[c + 12 >> 2] = Ta, c));
+                    gb = gb + 1 | 0;
+                    Rf = gc;
+                    cb = Oa;
+                    Hb = qd;
+                    Ga = Wf;
+                    sa = pd
+                  }
+                  m(h, 0, a[u], g.Nc | 0, (c = b, b += 4, a[c >> 2] = Ta, c));
+                  if (0 == (a[w] | 0)) {
+                    ld = Ta, Gb = gb, kc = Hb, md = Ga, nd = sa
+                  } else {
+                    if (0 != (a[t] | 0)) {
+                      ld = Ta, Gb = gb, kc = Hb, md = Ga, nd = sa
+                    } else {
+                      var me = pa(ka, a[Pa >> 2], A);
+                      if (0 != (a[B] | 0) | 0 > (me | 0)) {
+                        m(h, 3, a[u], g.td | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                        Ab = 0;
+                        Ya = Ga;
+                        $ = sa;
+                        j = $ >> 2;
+                        E = 128;
+                        break
+                      }
+                      ue(ka);
+                      var Dd = pb(h, cb, Ta);
+                      e = Dd >> 2;
+                      if (0 == (Dd | 0)) {
+                        m(h, 3, a[u], g.vd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                        Ab = 0;
+                        Ya = Ga;
+                        $ = sa;
+                        j = $ >> 2;
+                        E = 128;
+                        break
+                      }
+                      var Td = 0 == (me | 0);
+                      c:do {
+                        if (Td) {
+                          var Wd = (a[ka + 8 >> 2] >> 3) + a[ka + 12 >> 2] | 0, bc = p[e], jb = (bc >> 3) + (0 != (bc & 7 | 0) & 1) | 0, Zd = a[e + 3];
+                          d = (Dd + 4 | 0) >> 2;
+                          var Tb = a[d], Ob = jb * Tb | 0;
+                          m(h, 0, a[u], g.xd | 0, (c = b, b += 16, a[c >> 2] = bc, a[c + 4 >> 2] = Tb, a[c + 8 >> 2] = gb - Gb | 0, a[c + 12 >> 2] = Ob, c));
+                          if (0 < (a[d] | 0)) {
+                            for (var ce = Dd + 8 | 0, Nc = 0, qc = l + Wd | 0, Bc = Zd; ;) {
+                              eb(Bc, qc, jb);
+                              var id = Nc + 1 | 0;
+                              if ((id | 0) >= (a[d] | 0)) {
+                                sc = Ob;
+                                break c
+                              }
+                              Nc = id;
+                              qc = qc + jb | 0;
+                              Bc = Bc + a[ce >> 2] | 0
+                            }
+                          } else {
+                            var sc = Ob
+                          }
+                        } else {
+                          var ee = a[e], fe = a[e + 1];
+                          m(h, 0, a[u], g.yd | 0, (c = b, b += 16, a[c >> 2] = ee, a[c + 4 >> 2] = fe, a[c + 8 >> 2] = gb - Gb | 0, a[c + 12 >> 2] = me, c));
+                          Ge(l + ((a[ka + 8 >> 2] >> 3) + a[ka + 12 >> 2] | 0) | 0, me, Dd);
+                          a[B] = 0;
+                          sc = me
+                        }
+                      } while (0);
+                      Ee(ka, sc);
+                      for (var Xc = 0, ne = Gb; ;) {
+                        if (ne >>> 0 >= gb >>> 0) {
+                          Qa(h, Dd);
+                          ld = Ta;
+                          Gb = gb;
+                          kc = Hb;
+                          md = Ga;
+                          nd = sa;
+                          continue b
+                        }
+                        var Yc = (ne << 2) + tc | 0, Ec = pb(h, a[Yc >> 2], Ta);
+                        if (0 == (Ec | 0)) {
+                          m(h, 3, a[u], g.Fd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                          Ab = 0;
+                          Ya = Ga;
+                          $ = sa;
+                          j = $ >> 2;
+                          E = 128;
+                          break b
+                        }
+                        Vc(0, Ec, Dd, -Xc | 0, 0, 4);
+                        var ge = a[Yc >> 2] + Xc | 0;
+                        a[((ne << 2) + a[x] | 0) >> 2] = Ec;
+                        Xc = ge;
+                        ne = ne + 1 | 0
+                      }
+                    }
+                  }
+                }
+                b:do {
+                  if (108 == E) {
+                    i = (f + 20 | 0) >> 2;
+                    var Ae = ve(h, a[i]);
+                    if (0 == (Ae | 0)) {
+                      m(h, 3, a[u], g.Hd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c))
+                    } else {
+                      for (var Zc = a[q], Qd = 0 == (Zc | 0) ? 0 : a[Zc >> 2], pe = Ae + 4 | 0, fd = 0, Ed = 0, Be = 0; ;) {
+                        var Rd = p[i];
+                        if (Ed >>> 0 >= Rd >>> 0) {
+                          Ab = Ae;
+                          Ya = md;
+                          $ = nd;
+                          j = $ >> 2;
+                          E = 128;
+                          break b
+                        }
+                        if (0 == (a[w] | 0)) {
+                          var qe = Ja(Va, S, ja);
+                          a[B] = qe;
+                          var Fd = a[ja >> 2]
+                        } else {
+                          var re = 0 == (fd | 0) ? 0 : Rd, Fd = a[ja >> 2] = re
+                        }
+                        var xc = 0 != (fd | 0);
+                        if (xc) {
+                          var Sd = p[i];
+                          if (Fd >>> 0 > (Sd - Ed | 0) >>> 0) {
+                            break
+                          }
+                        }
+                        if (0 < (Fd | 0)) {
+                          var se = 1 < (Fd | 0) ? Fd : 1;
+                          c:do {
+                            if (xc) {
+                              for (var oe = Be, Lb = Ed, Ud = 0; ;) {
+                                var te = (oe | 0) < (Qd | 0) ? Dc(a[a[a[q] + 4 >> 2] + (oe << 2) >> 2]) : Dc(a[a[x] + (oe - Qd << 2) >> 2]), Vd = Lb + 1 | 0;
+                                a[((Lb << 2) + a[pe >> 2] | 0) >> 2] = te;
+                                var Xd = Ud + 1 | 0;
+                                if ((Xd | 0) >= (Fd | 0)) {
+                                  var Yd = Vd;
+                                  break c
+                                }
+                                oe = oe + 1 | 0;
+                                Lb = Vd;
+                                Ud = Xd
+                              }
+                            } else {
+                              Yd = Ed
+                            }
+                          } while (0);
+                          var $d = Be + se | 0, ae = Yd
+                        } else {
+                          $d = Be, ae = Ed
+                        }
+                        fd = xc & 1 ^ 1;
+                        Ed = ae;
+                        Be = $d
+                      }
+                      m(h, 3, a[u], g.Kd | 0, (c = b, b += 12, a[c >> 2] = Fd, a[c + 4 >> 2] = Sd, a[c + 8 >> 2] = Ed, c));
+                      de(h, Ae)
+                    }
+                    Ab = 0;
+                    Ya = md;
+                    $ = nd;
+                    j = $ >> 2;
+                    E = 128
+                  }
+                } while (0);
+                128 == E && (0 != ($ | 0) && (0 == (a[w] | 0) ? (ga(ca, a[j + 18]), ga(ca, a[j + 19]), ga(ca, a[j + 20]), ga(ca, a[j + 21]), De(kd, a[j + 22]), ga(ca, a[j + 23]), ga(ca, a[j + 24]), ga(ca, a[j + 25]), ga(ca, a[j + 26]), ga(ca, a[j + 27])) : (ma(za, a[j + 10]), ma(za, a[j + 11]), ma(za, a[j + 12]), ma(za, a[j + 15]), ma(za, a[j + 16]), ma(za, a[j + 13]), ma(za, a[j + 14])), K(a[o], $)), Sb = Ya, sd = Ab);
+                0 != (Sb | 0) && (de(h, a[Sb >> 2]), K(a[o], Sb));
+                K(a[o], s);
+                la = zb;
+                Ma = sd
+              }
+              Na = tc;
+              Pc = ka;
+              je = rb;
+              Hc = fb;
+              fc = X;
+              tb = sb;
+              Ic = Va;
+              ub = na;
+              Jc = Wa;
+              jc = Ra;
+              Xa = Gc;
+              E = 136
+            }
+          } while (0);
+          if (136 == E) {
+            de(h, la);
+            var be = h | 0;
+            K(a[be >> 2], Na);
+            ma(h, je);
+            ma(h, Hc);
+            0 != (Pc | 0) && hb(Pc);
+            De(h, Jc);
+            ga(h, jc);
+            ga(h, Xa);
+            ba = Ma;
+            ya = fc;
+            zd = tb;
+            La = Ic;
+            $c = ub;
+            jd = be
+          }
+          Tc(h, ra);
+          K(a[jd >> 2], S);
+          ga(h, ya);
+          ga(h, zd);
+          ga(h, La);
+          ga(h, $c);
+          dc = ba
+        }
+      }
+      b = A;
+      return dc
+    }
+
+    function Qe(h, z, f, l, n, s, k, i, d, e, j) {
+      var q, r, o, w, t, u, y, v, x, H, C, D, B, E, A, M, Ka = b;
+      b += 540;
+      var Q, T = Ka + 4;
+      M = T >> 2;
+      var W = Ka + 8;
+      A = W >> 2;
+      var Ea = Ka + 12, ea = Ka + 16, U = Ka + 20;
+      E = U >> 2;
+      var Ua = Ka + 24;
+      B = Ua >> 2;
+      var fa = Ka + 28;
+      D = fa >> 2;
+      var wa = Ka + 32;
+      C = wa >> 2;
+      var ga = Ka + 44;
+      H = ga >> 2;
+      var aa = Ka + 464;
+      x = aa >> 2;
+      var ra = Ka + 476, dc = Ka + 480, S = Ka + 504, Z = Ka + 508, ja = Ka + 512, ia = Ka + 516, ta = Ka + 520;
+      v = ta >> 2;
+      var ic = Ka + 524;
+      y = ic >> 2;
+      var Fc = Ka + 528;
+      u = Fc >> 2;
+      var ba = Ka + 532;
+      t = ba >> 2;
+      var ya = Ka + 536;
+      a[B] = 0;
+      var zd = 0 == (n | 0);
+      a:do {
+        if (zd) {
+          var La = 0
+        } else {
+          for (var $c = 0, jd = 0; ;) {
+            var tc = a[a[l + ($c << 2) >> 2] >> 2] + jd | 0, qb = $c + 1 | 0;
+            if ((qb | 0) == (n | 0)) {
+              La = tc;
+              break a
+            }
+            $c = qb;
+            jd = tc
+          }
+        }
+      } while (0);
+      w = (z | 0) >> 2;
+      m(h, 0, a[w], g.qb | 0, (c = b, b += 8, a[c >> 2] = La, a[c + 4 >> 2] = n, c));
+      o = (f | 0) >> 2;
+      var ka = p[o], rb = 0 == (ka | 0);
+      do {
+        if (rb) {
+          var fb = 0, X = 0, sb = ka;
+          Q = 31
+        } else {
+          m(h, 0, a[w], g.Fa | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+          var Va = h, na = nf(Va, j);
+          if (0 == (na | 0)) {
+            m(h, 2, a[w], g.Sb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+            var Wa = -1;
+            Q = 112
+          } else {
+            for (var Ra = 0; ;) {
+              var Gc = Oc(na, 4);
+              a[H + (3 * Ra | 0)] = Gc;
+              a[H + (3 * Ra | 0) + 1] = 0;
+              a[H + (3 * Ra | 0) + 2] = Ra;
+              m(h, 0, a[w], g.Ac | 0, (c = b, b += 8, a[c >> 2] = Ra, a[c + 4 >> 2] = Gc, c));
+              var ec = Ra + 1 | 0;
+              if (35 == (ec | 0)) {
+                break
+              }
+              Ra = ec
+            }
+            a[C] = 0;
+            a[C + 2] = ga | 0;
+            a[C + 1] = 35;
+            var Ad = J(Va, wa), qa = 0 == (Ad | 0);
+            a:do {
+              if (qa) {
+                m(h, 3, a[w], g.dd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                a[B] = -1;
+                var Xb = 0, Sa = 0, Qb = h | 0
+              } else {
+                var Yb = h | 0, da = O(a[Yb >> 2], 12 * La | 0), la = da;
+                if (0 == (da | 0)) {
+                  m(h, 3, a[w], g.Bd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), a[B] = -1, Xb = la, Sa = 0, Qb = Yb
+                } else {
+                  for (var Ma = ed, Na = 0; ;) {
+                    for (var Pc = Na >>> 0 < La >>> 0, Aa = La - Na | 0, Hc = 0 == (Na | 0), fc = la + 12 * (Na - 1) | 0, tb = Ma; ;) {
+                      if (!Pc) {
+                        a[x] = 0;
+                        a[x + 2] = la;
+                        a[x + 1] = La;
+                        ue(na);
+                        var Ic = J(Va, aa), Xb = la, Sa = Ic, Qb = Yb;
+                        break a
+                      }
+                      var ub = pa(na, Ad, ra);
+                      a[B] = ub;
+                      if (0 != (a[ra >> 2] | 0) | 34 < ub >>> 0) {
+                        m(h, 3, a[w], g.Od | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                        var Jc = a[ra >> 2];
+                        a[B] = 0 != (Jc | 0) ? Jc : -1;
+                        Xb = la;
+                        Sa = 0;
+                        Qb = Yb;
+                        break a
+                      }
+                      var jc = 32 > (ub | 0);
+                      do {
+                        if (jc) {
+                          var Xa = 1, Fa = ub
+                        } else {
+                          if (32 == (ub | 0)) {
+                            if (Hc) {
+                              m(h, 3, a[w], g.Yd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                              a[B] = -1;
+                              Xb = la;
+                              Sa = 0;
+                              Qb = Yb;
+                              break a
+                            }
+                            var ad = a[fc >> 2], Xa = Oc(na, 2) + 3 | 0, Fa = ad
+                          } else {
+                            Xa = 34 == (ub | 0) ? Oc(na, 7) + 11 | 0 : 33 == (ub | 0) ? Oc(na, 3) + 3 | 0 : tb, Fa = 0
+                          }
+                        }
+                      } while (0);
+                      var bd = a[B];
+                      m(h, 0, a[w], g.he | 0, (c = b, b += 16, a[c >> 2] = bd, a[c + 4 >> 2] = Na, a[c + 8 >> 2] = Fa, a[c + 12 >> 2] = Xa, c));
+                      var Zb = Xa + Na | 0;
+                      if (Zb >>> 0 > La >>> 0) {
+                        m(h, 2, a[w], g.qe | 0, (c = b, b += 4, a[c >> 2] = Zb - La | 0, c));
+                        var Db = Aa
+                      } else {
+                        Db = Xa
+                      }
+                      if (0 < (Db | 0)) {
+                        var yb = 0, zb = Na;
+                        break
+                      }
+                      tb = Db
+                    }
+                    for (; ;) {
+                      a[(la + 12 * zb | 0) >> 2] = Fa;
+                      a[(la + 12 * zb + 4 | 0) >> 2] = 0;
+                      a[(la + 12 * zb + 8 | 0) >> 2] = zb;
+                      var xa = yb + 1 | 0, ib = xa + Na | 0;
+                      if ((xa | 0) == (Db | 0)) {
+                        break
+                      }
+                      yb = xa;
+                      zb = ib
+                    }
+                    Ma = Db;
+                    Na = Db + Na | 0
+                  }
+                }
+              }
+            } while (0);
+            K(a[Qb >> 2], Xb);
+            ma(Va, Ad);
+            if (0 == (Sa | 0)) {
+              m(h, 3, a[w], g.ya | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+              0 != (na | 0) && hb(na);
+              var Bd = a[B], Wa = 0 != (Bd | 0) ? Bd : -1;
+              Q = 112
+            } else {
+              fb = Sa, X = na, sb = a[o], Q = 31
+            }
+          }
+        }
+      } while (0);
+      a:do {
+        if (31 == Q) {
+          Kf(s, a[f + 8 >> 2]);
+          if (0 == (sb | 0)) {
+            var Ia = f + 72 | 0, Qc = Ja(a[Ia >> 2], e, T);
+            a[B] = Qc;
+            if (0 > (Qc | 0)) {
+              Q = 109
+            } else {
+              var Fb = a[M], we = Ia, ca = f + 48 | 0;
+              Q = 35
+            }
+          } else {
+            var kd = f + 48 | 0, cd = pa(X, a[kd >> 2], Ua), Fb = a[M] = cd, we = f + 72 | 0, ca = kd;
+            Q = 35
+          }
+          b:do {
+            if (35 == Q) {
+              r = (f + 36 | 0) >> 2;
+              a[M] = Fb * -a[r] | 0;
+              var za = f + 28 | 0, Ie = f + 44 | 0, cb = f + 24 | 0, Pa = f + 80 | 0, Za = f + 88 | 0, Je = f + 4 | 0, Jb = f + 16 | 0, $b = f + 20 | 0, Ld = f + 12 | 0, Rb = f + 92 | 0, Ke = f + 96 | 0, Md = f + 100 | 0, Le = f + 104 | 0, Nb = f + 108 | 0, Me = f + 112 | 0, ld = dc | 0, Gb = dc + 4 | 0, kc = dc + 8 | 0, md = dc + 12 | 0, nd = dc + 16 | 0, Ba = f + 116 | 0, eb = dc + 20 | 0, Da = h, Ta = z, Ib = dc, Ha = f + 52 | 0, gb = f + 56 | 0, Oa = f + 60 | 0, Eb = f + 64 | 0, Hb = f + 68 | 0, Ga = f + 84 | 0, sa = f + 32 | 0, Ab = f + 40 | 0, Ya = f + 76 | 0, $ = 0, $a = 0, oa = ed, uc = ed, gc = ed;
+              c:for (; ;) {
+                if ($ >>> 0 >= p[za >> 2] >>> 0) {
+                  break b
+                }
+                if (0 == (a[o] | 0)) {
+                  var Cb = Ja(a[we >> 2], e, W);
+                  a[B] = Cb;
+                  if (0 > (Cb | 0)) {
+                    break b
+                  }
+                  var nb = a[A]
+                } else {
+                  var Wb = pa(X, a[ca >> 2], Ua), nb = a[A] = Wb
+                }
+                var db = nb * a[r] | 0;
+                a[A] = db;
+                a[M] = a[M] + db | 0;
+                for (var kb = $, od = $a, bb = oa, lb = 1, Nd = uc, Cd = gc; ;) {
+                  var Kc = 0 != (a[o] | 0);
+                  if (0 == (lb | 0)) {
+                    if (Kc) {
+                      var Lc = pa(X, a[Ie >> 2], Ua);
+                      a[ea >> 2] = Lc;
+                      var Kb = a[B]
+                    } else {
+                      var Vb = Ja(a[Pa >> 2], e, ea), Kb = a[B] = Vb
+                    }
+                    if (0 != (Kb | 0)) {
+                      $ = kb;
+                      $a = od;
+                      oa = bb;
+                      uc = Nd;
+                      gc = Cd;
+                      continue c
+                    }
+                    var vb = od, vc = a[ea >> 2] + bb + a[cb >> 2] | 0, Od = lb
+                  } else {
+                    if (Kc) {
+                      var cc = pa(X, a[Ab >> 2], Ua), Ac = a[Ea >> 2] = cc
+                    } else {
+                      var Pd = Ja(a[Ya >> 2], e, Ea);
+                      a[B] = Pd;
+                      if (0 > (Pd | 0)) {
+                        break b
+                      }
+                      Ac = a[Ea >> 2]
+                    }
+                    var pc = Ac + od | 0, vc = vb = pc, Od = 0
+                  }
+                  if (1 == (a[r] | 0)) {
+                    var ob = a[E] = 0
+                  } else {
+                    if (0 == (a[o] | 0)) {
+                      var Cc = Ja(a[Ga >> 2], e, U);
+                      a[B] = Cc;
+                      if (0 > (Cc | 0)) {
+                        break b
+                      }
+                      ob = a[E]
+                    } else {
+                      var Rc = Oc(X, a[sa >> 2]), ob = a[E] = Rc
+                    }
+                  }
+                  var lc = ob + a[M] | 0;
+                  if (0 == (a[o] | 0)) {
+                    mf(a[Za >> 2], e, Ka);
+                    a[B] = 0;
+                    var ac = a[Ka >> 2]
+                  } else {
+                    var bc = pa(X, fb, Ua), ac = a[Ka >> 2] = bc
+                  }
+                  if (ac >>> 0 >= La >>> 0) {
+                    Wa = m(h, 3, a[w], g.Ia | 0, (c = b, b += 8, a[c >> 2] = ac, a[c + 4 >> 2] = La, c));
+                    break a
+                  }
+                  var ab = p[l >> 2], jb = p[ab >> 2], Ub = ac >>> 0 < jb >>> 0;
+                  d:do {
+                    if (Ub) {
+                      var Mc = ac, mb = ab
+                    } else {
+                      for (var pd = 0, Ob = ac, qd = jb; ;) {
+                        var wb = pd + 1 | 0, dd = Ob - qd | 0, hc = p[l + (wb << 2) >> 2], rd = p[hc >> 2];
+                        if (dd >>> 0 < rd >>> 0) {
+                          Mc = dd;
+                          mb = hc;
+                          break d
+                        }
+                        pd = wb;
+                        Ob = dd;
+                        qd = rd
+                      }
+                    }
+                  } while (0);
+                  var Sb = Dc(a[a[mb + 4 >> 2] + (Mc << 2) >> 2]), sd = 0 == (a[Je >> 2] | 0);
+                  d:do {
+                    if (!sd) {
+                      if (0 == (a[o] | 0)) {
+                        var td = Ja(a[Rb >> 2], e, fa);
+                        a[B] = td;
+                        if (0 > (td | 0)) {
+                          break b
+                        }
+                        var oc = a[D]
+                      } else {
+                        var Tc = Oc(X, 1), oc = a[D] = Tc
+                      }
+                      if (0 == (oc | 0)) {
+                        var Bb = Sb;
+                        q = Bb >> 2;
+                        break
+                      }
+                      a[v] = 0;
+                      a[y] = 0;
+                      a[u] = 0;
+                      a[t] = 0;
+                      a[ya >> 2] = 0;
+                      if (0 == (a[o] | 0)) {
+                        var ud = Ja(a[Ke >> 2], e, S);
+                        a[v] = ud;
+                        var qc = Ja(a[Md >> 2], e, Z);
+                        a[y] = qc;
+                        var ha = Ja(a[Le >> 2], e, ja);
+                        a[u] = ha;
+                        var Bc = Ja(a[Nb >> 2], e, ia);
+                        a[t] = Bc;
+                        var xb = 0
+                      } else {
+                        var rc = pa(X, a[Ha >> 2], ta);
+                        a[S >> 2] = rc;
+                        var sc = pa(X, a[gb >> 2], ic);
+                        a[Z >> 2] = sc;
+                        var Xc = pa(X, a[Oa >> 2], Fc);
+                        a[ja >> 2] = Xc;
+                        var Ec = pa(X, a[Eb >> 2], ba);
+                        a[ia >> 2] = Ec;
+                        var fd = pa(X, a[Hb >> 2], ya);
+                        ue(X);
+                        xb = fd
+                      }
+                      var xc = 0 > (a[v] | 0);
+                      do {
+                        if (!xc && 0 <= (a[y] | 0) && 0 <= (a[u] | 0) && 0 <= (a[t] | 0) && 0 <= (a[ya >> 2] | 0)) {
+                          var Lb = a[S >> 2], Mb = a[Z >> 2], vd = pb(h, Lb + a[Sb >> 2] | 0, Mb + a[Sb + 4 >> 2] | 0);
+                          if (0 == (vd | 0)) {
+                            Qa(h, Sb);
+                            0 != (a[o] | 0) && ma(Da, fb);
+                            Wa = m(h, 3, a[w], g.Za | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                            break a
+                          }
+                          a[ld >> 2] = a[Me >> 2];
+                          a[Gb >> 2] = Sb;
+                          a[kc >> 2] = (Lb >> 1) + a[ja >> 2] | 0;
+                          a[md >> 2] = (Mb >> 1) + a[ia >> 2] | 0;
+                          a[nd >> 2] = 0;
+                          a[eb >> 2] = F[Ba] | F[Ba + 1] << 8 | F[Ba + 2] << 16 | F[Ba + 3] << 24 | 0;
+                          He(Da, Ta, Ib, e, vd, d);
+                          Qa(h, Sb);
+                          if (0 == (a[o] | 0)) {
+                            Bb = vd;
+                            q = Bb >> 2;
+                            break d
+                          }
+                          Ee(X, xb);
+                          Bb = vd;
+                          q = Bb >> 2;
+                          break d
+                        }
+                      } while (0);
+                      var Tb = m(h, 3, a[w], g.L | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                      a[B] = Tb;
+                      break b
+                    }
+                    a[D] = 0;
+                    Bb = Sb;
+                    q = Bb >> 2
+                  } while (0);
+                  var wc = a[$b >> 2];
+                  if (0 == (a[Jb >> 2] | 0)) {
+                    var wd = 1 < (wc | 0) ? vc - 1 + a[q] | 0 : vc;
+                    if (1 == (wc | 0)) {
+                      var mc = wd, nc = lc, xd = wd
+                    } else {
+                      3 == (wc | 0) ? (mc = wd + 1 - a[q] | 0, nc = lc) : 0 == (wc | 0) ? (mc = wd, nc = lc + 1 - a[q + 1] | 0) : 2 == (wc | 0) ? (mc = wd + 1 - a[q] | 0, nc = lc + 1 - a[q + 1] | 0) : (mc = Nd, nc = Cd), xd = wd
+                    }
+                  } else {
+                    var yd = 0 == (wc & 1 | 0) ? vc - 1 + a[q + 1] | 0 : vc;
+                    1 == (wc | 0) ? (mc = lc, nc = yd) : 3 == (wc | 0) ? (mc = lc + 1 - a[q] | 0, nc = yd) : 0 == (wc | 0) ? (mc = lc, nc = yd + 1 - a[q + 1] | 0) : 2 == (wc | 0) ? (mc = lc + 1 - a[q] | 0, nc = yd + 1 - a[q + 1] | 0) : (mc = Nd, nc = Cd);
+                    xd = yd
+                  }
+                  Vc(0, s, Bb, mc, nc, a[Ld >> 2]);
+                  var yc = a[$b >> 2], zc = 0 == (a[Jb >> 2] | 0) ? 2 > (yc | 0) ? xd - 1 + a[q] | 0 : xd : 0 == (yc & 1 | 0) ? xd : xd - 1 + a[q + 1] | 0, Nc = kb + 1 | 0;
+                  Qa(h, Bb);
+                  kb = Nc;
+                  od = vb;
+                  bb = zc;
+                  lb = Od;
+                  Nd = mc;
+                  Cd = nc
+                }
+              }
+            }
+          } while (0);
+          0 != (a[o] | 0) && ma(h, fb);
+          0 != (X | 0) && hb(X);
+          Wa = a[B]
+        }
+      } while (0);
+      b = Ka;
+      return Wa
+    }
+
+    function Mf(h, z, f) {
+      var l, n, s, k, i, d, e, j = h >> 2, w = b;
+      b += 144;
+      var r;
+      e = w >> 2;
+      var o = w + 24;
+      d = o >> 2;
+      var x = z + 12 | 0;
+      if (17 > p[x >> 2] >>> 0) {
+        var t = m(h, 3, a[z >> 2], g.c | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c))
+      } else {
+        Cc(w, f);
+        var u = Ac(f + 17 | 0);
+        i = (z | 0) >> 2;
+        var y = u & 65535;
+        m(h, 0, a[i], g.hb | 0, (c = b, b += 4, a[c >> 2] = y, c));
+        for (var v = o >> 2, E = v + 30; v < E; v++) {
+          a[v] = 0
+        }
+        var H = y & 1;
+        k = (o | 0) >> 2;
+        a[k] = H;
+        s = (o + 4 | 0) >> 2;
+        a[s] = y & 2;
+        var C = y >>> 2 & 3;
+        a[d + 8] = C;
+        a[d + 9] = 1 << C;
+        a[d + 5] = y >>> 4 & 3;
+        a[d + 4] = y & 64;
+        a[d + 3] = y >>> 7 & 3;
+        a[d + 2] = y & 512;
+        var D = y >>> 10, B = D & 31, A = 15 < B >>> 0 ? D | -32 : B;
+        a[d + 6] = A;
+        n = (o + 112 | 0) >> 2;
+        a[n] = y & 32768;
+        if (0 == (A | 0)) {
+          var F = H
+        } else {
+          m(h, 0, a[i], g.ob | 0, (c = b, b += 4, a[c >> 2] = A, c)), F = a[k]
+        }
+        if (0 == (F | 0)) {
+          if (0 == (a[s] | 0)) {
+            var M = 19, Q = 0, T = 0
+          } else {
+            0 != (a[n] | 0) ? M = 19 : (q[o + 116 | 0] = q[f + 19 | 0], q[o + 117 | 0] = q[f + 20 | 0], q[o + 118 | 0] = q[f + 21 | 0], q[o + 119 | 0] = q[f + 22 | 0], M = 23), Q = 0, T = F
+          }
+        } else {
+          var W = Ac(f + 19 | 0);
+          0 > W << 16 >> 16 ? (m(h, 2, a[i], g.ub | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), M = 21, Q = W, T = a[k]) : (M = 21, Q = W, T = F)
+        }
+        var aa = o + 28 | 0;
+        a[aa >> 2] = ia(f + M | 0);
+        var Ea = M + 4 | 0, ja = 0 == (T | 0);
+        do {
+          if (ja) {
+            r = 86
+          } else {
+            var U = Q & 65535, Ua = U & 3;
+            if (0 == (Ua | 0)) {
+              var ta = J(h, xe);
+              a[d + 10] = ta;
+              var wa = 0, pa = ta
+            } else {
+              if (1 == (Ua | 0)) {
+                var Ja = J(h, Qd);
+                a[d + 10] = Ja;
+                wa = 0;
+                pa = Ja
+              } else {
+                if (3 == (Ua | 0)) {
+                  var ra = h, dc = xa(ra, z, 0);
+                  if (0 == (dc | 0)) {
+                    var S = 0, Z = m(h, 3, a[i], g.Bb | 0, (c = b, b += 4, a[c >> 2] = 0, c));
+                    r = 134;
+                    break
+                  }
+                  var qa = J(ra, dc);
+                  a[d + 10] = qa;
+                  wa = 1;
+                  pa = qa
+                } else {
+                  var Aa = m(h, 3, a[i], g.Gb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), S = 0, Z = Aa;
+                  r = 134;
+                  break
+                }
+              }
+            }
+            if (0 == (pa | 0)) {
+              var Ba = m(h, 3, a[i], g.Lb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), S = 0, Z = Ba;
+              r = 134
+            } else {
+              var ic = U >>> 2 & 3;
+              if (0 == (ic | 0)) {
+                var Fc = J(h, ye);
+                a[d + 11] = Fc;
+                var ba = wa, ya = Fc
+              } else {
+                if (1 == (ic | 0)) {
+                  var zd = J(h, pe);
+                  a[d + 11] = zd;
+                  ba = wa;
+                  ya = zd
+                } else {
+                  if (2 == (ic | 0)) {
+                    var La = J(h, fd);
+                    a[d + 11] = La;
+                    ba = wa;
+                    ya = La
+                  } else {
+                    if (3 == (ic | 0)) {
+                      var $c = h, jd = xa($c, z, wa);
+                      if (0 == (jd | 0)) {
+                        var tc = m(h, 3, a[i], g.Pb | 0, (c = b, b += 4, a[c >> 2] = wa, c)), S = 0, Z = tc;
+                        r = 134;
+                        break
+                      }
+                      var qb = J($c, jd);
+                      a[d + 11] = qb;
+                      ba = wa + 1 | 0;
+                      ya = qb
+                    } else {
+                      ba = wa, ya = a[d + 11]
+                    }
+                  }
+                }
+              }
+              if (0 == (ya | 0)) {
+                var ka = m(h, 3, a[i], g.Vb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), S = 0, Z = ka;
+                r = 134
+              } else {
+                var rb = U >>> 4 & 3;
+                if (0 == (rb | 0)) {
+                  var fb = J(h, ze);
+                  a[d + 12] = fb;
+                  var X = ba, sb = fb
+                } else {
+                  if (1 == (rb | 0)) {
+                    var Va = J(h, Rd);
+                    a[d + 12] = Va;
+                    X = ba;
+                    sb = Va
+                  } else {
+                    if (2 == (rb | 0)) {
+                      var na = J(h, qe);
+                      a[d + 12] = na;
+                      X = ba;
+                      sb = na
+                    } else {
+                      if (3 == (rb | 0)) {
+                        var Wa = h, Ra = xa(Wa, z, ba);
+                        if (0 == (Ra | 0)) {
+                          var Gc = m(h, 3, a[i], g.bc | 0, (c = b, b += 4, a[c >> 2] = ba, c)), S = 0, Z = Gc;
+                          r = 134;
+                          break
+                        }
+                        var ec = J(Wa, Ra);
+                        a[d + 12] = ec;
+                        X = ba + 1 | 0;
+                        sb = ec
+                      } else {
+                        X = ba, sb = a[d + 12]
+                      }
+                    }
+                  }
+                }
+                if (0 == (sb | 0)) {
+                  var Ad = m(h, 3, a[i], g.ec | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), S = 0, Z = Ad;
+                  r = 134
+                } else {
+                  var Ia = U >>> 6 & 3;
+                  if (0 == (Ia | 0)) {
+                    var Xb = J(h, Rc);
+                    a[d + 13] = Xb;
+                    var Sa = X, Qb = Xb
+                  } else {
+                    if (1 == (Ia | 0)) {
+                      var Yb = J(h, Ib);
+                      a[d + 13] = Yb;
+                      Sa = X;
+                      Qb = Yb
+                    } else {
+                      if (3 == (Ia | 0)) {
+                        var da = h, la = xa(da, z, X);
+                        if (0 == (la | 0)) {
+                          var Ma = m(h, 3, a[i], g.gc | 0, (c = b, b += 4, a[c >> 2] = X, c)), S = 0, Z = Ma;
+                          r = 134;
+                          break
+                        }
+                        var Na = J(da, la);
+                        a[d + 13] = Na;
+                        Sa = X + 1 | 0;
+                        Qb = Na
+                      } else {
+                        var Pc = m(h, 3, a[i], g.kc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), S = 0, Z = Pc;
+                        r = 134;
+                        break
+                      }
+                    }
+                  }
+                  if (0 == (Qb | 0)) {
+                    var ib = m(h, 3, a[i], g.lc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), S = 0, Z = ib;
+                    r = 134
+                  } else {
+                    var Hc = U >>> 8 & 3;
+                    if (0 == (Hc | 0)) {
+                      var fc = J(h, Rc);
+                      a[d + 14] = fc;
+                      var tb = Sa, Ic = fc
+                    } else {
+                      if (1 == (Hc | 0)) {
+                        var ub = J(h, Ib);
+                        a[d + 14] = ub;
+                        tb = Sa;
+                        Ic = ub
+                      } else {
+                        if (3 == (Hc | 0)) {
+                          var Jc = h, jc = xa(Jc, z, Sa);
+                          if (0 == (jc | 0)) {
+                            var Xa = m(h, 3, a[i], g.oc | 0, (c = b, b += 4, a[c >> 2] = Sa, c)), S = 0, Z = Xa;
+                            r = 134;
+                            break
+                          }
+                          var Fa = J(Jc, jc);
+                          a[d + 14] = Fa;
+                          tb = Sa + 1 | 0;
+                          Ic = Fa
+                        } else {
+                          var ad = m(h, 3, a[i], g.rc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), S = 0, Z = ad;
+                          r = 134;
+                          break
+                        }
+                      }
+                    }
+                    if (0 == (Ic | 0)) {
+                      var bd = m(h, 3, a[i], g.vc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), S = 0, Z = bd;
+                      r = 134
+                    } else {
+                      var Zb = U >>> 10 & 3;
+                      if (0 == (Zb | 0)) {
+                        var Db = J(h, Rc);
+                        a[d + 15] = Db;
+                        var yb = tb, zb = Db
+                      } else {
+                        if (1 == (Zb | 0)) {
+                          var cb = J(h, Ib);
+                          a[d + 15] = cb;
+                          yb = tb;
+                          zb = cb
+                        } else {
+                          if (3 == (Zb | 0)) {
+                            var Pa = h, Bd = xa(Pa, z, tb);
+                            if (0 == (Bd | 0)) {
+                              var Da = m(h, 3, a[i], g.xc | 0, (c = b, b += 4, a[c >> 2] = tb, c)), S = 0, Z = Da;
+                              r = 134;
+                              break
+                            }
+                            var Qc = J(Pa, Bd);
+                            a[d + 15] = Qc;
+                            yb = tb + 1 | 0;
+                            zb = Qc
+                          } else {
+                            var Fb = m(h, 3, a[i], g.Dc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), S = 0, Z = Fb;
+                            r = 134;
+                            break
+                          }
+                        }
+                      }
+                      if (0 == (zb | 0)) {
+                        var Za = m(h, 3, a[i], g.Jc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), S = 0, Z = Za;
+                        r = 134
+                      } else {
+                        var ca = U >>> 12 & 3;
+                        if (0 == (ca | 0)) {
+                          var kd = J(h, Rc);
+                          a[d + 16] = kd;
+                          var cd = yb, za = kd
+                        } else {
+                          if (1 == (ca | 0)) {
+                            var Nb = J(h, Ib);
+                            a[d + 16] = Nb;
+                            cd = yb;
+                            za = Nb
+                          } else {
+                            if (3 == (ca | 0)) {
+                              var eb = h, $a = xa(eb, z, yb);
+                              if (0 == ($a | 0)) {
+                                var Ha = m(h, 3, a[i], g.Mc | 0, (c = b, b += 4, a[c >> 2] = yb, c)), S = 0, Z = Ha;
+                                r = 134;
+                                break
+                              }
+                              var kb = J(eb, $a);
+                              a[d + 16] = kb;
+                              cd = yb + 1 | 0;
+                              za = kb
+                            } else {
+                              var Jb = m(h, 3, a[i], g.Oc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), S = 0, Z = Jb;
+                              r = 134;
+                              break
+                            }
+                          }
+                        }
+                        if (0 == (za | 0)) {
+                          var $b = m(h, 3, a[i], g.Qc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), S = 0, Z = $b;
+                          r = 134
+                        } else {
+                          var Ld = U >>> 14 & 1;
+                          if (0 == (Ld | 0)) {
+                            var Rb = J(h, Jd), bb = a[d + 17] = Rb
+                          } else {
+                            if (1 == (Ld | 0)) {
+                              var Md = h, lb = xa(Md, z, cd);
+                              if (0 == (lb | 0)) {
+                                var oa = m(h, 3, a[i], g.Sc | 0, (c = b, b += 4, a[c >> 2] = cd, c)), S = 0, Z = oa;
+                                r = 134;
+                                break
+                              }
+                              var Cb = J(Md, lb), bb = a[d + 17] = Cb
+                            } else {
+                              bb = a[d + 17]
+                            }
+                          }
+                          if (0 == (bb | 0)) {
+                            var ld = m(h, 3, a[i], g.Uc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), S = 0, Z = ld;
+                            r = 134
+                          } else {
+                            0 != (U & 32768 | 0) && m(h, 2, a[i], g.Wc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), r = 86
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        } while (0);
+        a:do {
+          if (86 == r) {
+            var Gb = p[e], kc = p[e + 1], nb = p[e + 2], db = p[e + 3], ob = a[aa >> 2];
+            m(h, 1, a[i], g.Zc | 0, (c = b, b += 20, a[c >> 2] = Gb, a[c + 4 >> 2] = kc, a[c + 8 >> 2] = nb, a[c + 12 >> 2] = db, a[c + 16 >> 2] = ob, c));
+            var Oa = fe(h, z);
+            if (0 == (Oa | 0)) {
+              var Eb = m(h, 3, a[i], g.bd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), S = 0, Z = Eb;
+              r = 134
+            } else {
+              var Ta = Xc(h, z);
+              l = Ta >> 2;
+              if (0 == (Ta | 0)) {
+                var vb = m(h, 3, a[i], g.gd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), S = 0, Z = vb;
+                r = 134
+              } else {
+                if (0 == (a[l] | 0)) {
+                  var Wb = m(h, 2, a[i], g.kd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), S = Ta, Z = Wb;
+                  r = 134
+                } else {
+                  var gb = 1 < (Oa | 0);
+                  b:do {
+                    if (gb) {
+                      for (var hb = 1, ab = Oa; ;) {
+                        if (0 == (a[(hb << 2 >> 2) + l] | 0)) {
+                          m(h, 2, a[i], g.md | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                          var Hb = hb
+                        } else {
+                          Hb = ab
+                        }
+                        var Ga = hb + 1 | 0;
+                        if ((Ga | 0) >= (Hb | 0)) {
+                          var sa = Hb;
+                          break b
+                        }
+                        hb = Ga;
+                        ab = Hb
+                      }
+                    } else {
+                      sa = Oa
+                    }
+                  } while (0);
+                  var Ab = 0 == (a[k] | 0);
+                  do {
+                    if (Ab) {
+                      if (0 == (a[s] | 0)) {
+                        var Ya = 0
+                      } else {
+                        var $ = 0 != (a[n] | 0) ? 1024 : 8192, jb = O(a[j], $);
+                        if (0 == (jb | 0)) {
+                          var Vb = m(h, 3, a[i], g.pd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), S = Ta, Z = Vb;
+                          r = 134;
+                          break a
+                        }
+                        ea(jb, 0, $);
+                        Ya = jb
+                      }
+                    } else {
+                      Ya = 0
+                    }
+                  } while (0);
+                  var uc = pb(h, Gb, kc);
+                  if (0 == (uc | 0)) {
+                    var gc = m(h, 3, a[i], g.P | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), S = Ta, Z = gc;
+                    r = 134
+                  } else {
+                    var mb = Gd(h, f + Ea | 0, a[x >> 2] - Ea | 0), Ob = mb;
+                    if (0 == (mb | 0)) {
+                      var cc = m(h, 3, a[i], g.P | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+                      Qa(h, uc);
+                      var wb = cc
+                    } else {
+                      var oc = 0 == (a[k] | 0);
+                      b:do {
+                        if (oc) {
+                          var pc = 0 < (sa | 0);
+                          c:do {
+                            if (pc) {
+                              for (var xb = 0, Lb = 0; ;) {
+                                var bc = a[a[(xb << 2 >> 2) + l] >> 2] + Lb | 0, Mb = xb + 1 | 0;
+                                if ((Mb | 0) == (sa | 0)) {
+                                  var Kc = bc;
+                                  break c
+                                }
+                                xb = Mb;
+                                Lb = bc
+                              }
+                            } else {
+                              Kc = 0
+                            }
+                          } while (0);
+                          var Lc = Hd(h, Ob), Kb = h, yc = fa(Kb), Ub = o + 72 | 0;
+                          a[Ub >> 2] = yc;
+                          var vc = fa(Kb), qc = o + 76 | 0;
+                          a[qc >> 2] = vc;
+                          var Bc = fa(Kb), rc = o + 80 | 0;
+                          a[rc >> 2] = Bc;
+                          var sc = fa(Kb);
+                          a[d + 21] = sc;
+                          var Dc = 0 == (Lc | 0);
+                          do {
+                            if (!Dc && 0 != (a[Ub >> 2] | 0) && 0 != (a[qc >> 2] | 0) && !(0 == (a[rc >> 2] | 0) | 0 == (sc | 0))) {
+                              var Ec = 1 < (Kc | 0);
+                              c:do {
+                                if (Ec) {
+                                  for (var xc = 0; ;) {
+                                    var Tb = xc + 1 | 0;
+                                    if ((1 << Tb | 0) >= (Kc | 0)) {
+                                      var lc = Tb;
+                                      break c
+                                    }
+                                    xc = Tb
+                                  }
+                                } else {
+                                  lc = 0
+                                }
+                              } while (0);
+                              var ac = Ce(h, lc), zc = o + 88 | 0;
+                              a[zc >> 2] = ac;
+                              var Nc = fa(Kb), Oc = o + 92 | 0;
+                              a[Oc >> 2] = Nc;
+                              var ed = fa(Kb), Mc = o + 96 | 0;
+                              a[Mc >> 2] = ed;
+                              var hd = fa(Kb), pd = o + 100 | 0;
+                              a[pd >> 2] = hd;
+                              var id = fa(Kb), qd = o + 104 | 0;
+                              a[qd >> 2] = id;
+                              var Uc = fa(Kb);
+                              a[d + 27] = Uc;
+                              var dd = 0 == (a[zc >> 2] | 0);
+                              do {
+                                if (!dd && 0 != (a[Oc >> 2] | 0) && 0 != (a[Mc >> 2] | 0) && 0 != (a[pd >> 2] | 0) && !(0 == (a[qd >> 2] | 0) | 0 == (Uc | 0))) {
+                                  var hc = Lc;
+                                  r = 121;
+                                  break b
+                                }
+                              } while (0);
+                              var rd = m(h, 3, a[i], g.Q | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), Sb = Lc;
+                              r = 126;
+                              break b
+                            }
+                          } while (0);
+                          var sd = m(h, 3, a[i], g.Q | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), td = Lc;
+                          r = 128
+                        } else {
+                          hc = 0, r = 121
+                        }
+                      } while (0);
+                      if (121 == r) {
+                        var Vc = Qe(h, z, o, Ta, sa, uc, 0, 0, Ya, hc, 0 != (hc | 0) ? 0 : Ob);
+                        0 > (Vc | 0) ? (m(h, 3, a[i], g.ud | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), Qa(h, uc)) : 4 == (q[z + 4 | 0] & 63) << 24 >> 24 ? a[z + 24 >> 2] = uc : (m(h, 0, a[i], g.wd | 0, (c = b, b += 16, a[c >> 2] = Gb, a[c + 4 >> 2] = kc, a[c + 8 >> 2] = nb, a[c + 12 >> 2] = db, c)), Id(h, a[j + 18] + 44 * a[j + 16] | 0, uc, nb, db), Qa(h, uc));
+                        rd = Vc;
+                        Sb = hc;
+                        r = 126
+                      }
+                      if (126 == r) {
+                        if (0 != (a[k] | 0)) {
+                          var Wc = rd;
+                          r = 130
+                        } else {
+                          De(h, a[d + 22]);
+                          var Bb = h;
+                          ga(Bb, a[d + 23]);
+                          ga(Bb, a[d + 24]);
+                          ga(Bb, a[d + 25]);
+                          ga(Bb, a[d + 26]);
+                          ga(Bb, a[d + 27]);
+                          sd = rd;
+                          td = Sb;
+                          r = 128
+                        }
+                      }
+                      if (128 == r) {
+                        if (0 == (a[k] | 0)) {
+                          var ud = h;
+                          ga(ud, a[d + 18]);
+                          ga(ud, a[d + 19]);
+                          ga(ud, a[d + 20]);
+                          ga(ud, a[d + 21]);
+                          K(a[j], td)
+                        }
+                        Wc = sd
+                      }
+                      Tc(h, mb);
+                      wb = Wc
+                    }
+                    if (0 != (a[k] | 0)) {
+                      var Yc = wb, ha = Ta;
+                      r = 135
+                    } else {
+                      0 != (a[s] | 0) && K(a[j], Ya), S = Ta, Z = wb, r = 134
+                    }
+                  }
+                }
+              }
+            }
+          }
+        } while (0);
+        if (134 == r) {
+          if (0 == (a[k] | 0)) {
+            var Zc = Z, gd = S;
+            r = 136
+          } else {
+            Yc = Z, ha = S, r = 135
+          }
+        }
+        135 == r && (ma(h, a[d + 10]), ma(h, a[d + 11]), ma(h, a[d + 12]), ma(h, a[d + 15]), ma(h, a[d + 16]), ma(h, a[d + 13]), ma(h, a[d + 14]), ma(h, a[d + 17]), Zc = Yc, gd = ha);
+        K(a[j], gd);
+        t = Zc
+      }
+      b = w;
+      return t
+    }
+
+    function Zf(b, c, f, l, n) {
+      b >>= 2;
+      a[b] = c;
+      a[b + 1] = f;
+      a[b + 2] = l;
+      a[b + 3] = n;
+      a[b + 4] = 0;
+      a[b + 5] = 0;
+      c = 0 == (n | 0);
+      a:do {
+        if (c) {
+          var d = 0
+        } else {
+          for (var f = 4294967292 < (-n | 0) >>> 0 ? n : 4, k = 0, i = 0; ;) {
+            if (i |= (F[l + k | 0] & 255) << (3 - k << 3), k = k + 1 | 0, (k | 0) == (f | 0)) {
+              d = i;
+              break a
+            }
+          }
+        }
+      } while (0);
+      a[b + 6] = d
+    }
+
+    function Za(b, c) {
+      var f, l;
+      l = (b + 24 | 0) >> 2;
+      var n = a[l] << c;
+      a[l] = n;
+      f = (b + 20 | 0) >> 2;
+      var d = a[f] + c | 0;
+      a[f] = d;
+      var k = 7 < (d | 0);
+      a:do {
+        if (k) {
+          for (var i = b + 16 | 0, g = b + 8 | 0, e = p[b + 12 >> 2], j = d, m = a[i >> 2], r = n; ;) {
+            j = j - 8 | 0;
+            a[f] = j;
+            var o = m + 4 | 0;
+            o >>> 0 < e >>> 0 && (r |= (F[a[g >> 2] + o | 0] & 255) << j, a[l] = r);
+            m = m + 1 | 0;
+            a[i >> 2] = m;
+            if (7 >= (j | 0)) {
+              break a
+            }
+          }
+        }
+      } while (0)
+    }
+
+    function re(a, b, c) {
+      var l = 0 == (a | 0);
+      a:do {
+        if (l) {
+          var n = c
+        } else {
+          if (-1 == (b | 0)) {
+            var d = 0, k = 0
+          } else {
+            d = (F[(b >> 3) + a | 0] & 255) >>> ((b & 7 ^ 7) >>> 0) & 1, k = b + 1 | 0
+          }
+          for (; ;) {
+            if ((k | 0) >= (c | 0)) {
+              n = k;
+              break a
+            }
+            if ((d | 0) != ((F[(k >> 3) + a | 0] & 255) >>> ((k & 7 ^ 7) >>> 0) & 1 | 0)) {
+              n = k;
+              break a
+            }
+            k = k + 1 | 0
+          }
+        }
+      } while (0);
+      return n
+    }
+
+    function Ge(h, c, f) {
+      var l = b;
+      b += 28;
+      var n = a[f + 8 >> 2], d = a[f + 12 >> 2], k = a[f >> 2], f = (f + 4 | 0) >> 2;
+      Zf(l, k, a[f], h, c);
+      h = 0 < (a[f] | 0);
+      a:do {
+        if (h) {
+          for (var c = d, i = k = 0; ;) {
+            ea(c, 0, n);
+            xc(l, k, c);
+            i = i + 1 | 0;
+            if ((i | 0) >= (a[f] | 0)) {
+              break a
+            }
+            k = c;
+            c = c + n | 0
+          }
+        }
+      } while (0);
+      b = l
+    }
+
+    function xc(b, c, f) {
+      var l, n = b + 24 | 0;
+      l = (b | 0) >> 2;
+      for (var d = 0, k = -1; ;) {
+        var i = p[n >> 2];
+        if ((k | 0) >= (a[l] | 0)) {
+          break
+        }
+        var g = i >>> 29;
+        if (1 == (g | 0)) {
+          if (Za(b, 3), k = -1 == (k | 0) ? 0 : k, 0 == (d | 0)) {
+            g = gd(b, Sd | 0, 8), d = gd(b, se | 0, 7), k = g + k | 0, g = k + d | 0, d = a[l], g = (g | 0) > (d | 0) ? d : g, Oa(f, (k | 0) > (d | 0) ? d : k, g), d = 0, k = g
+          } else {
+            var g = gd(b, se | 0, 7), e = gd(b, Sd | 0, 8), g = g + k | 0, i = g + e | 0, e = a[l], i = (i | 0) > (e | 0) ? e : i;
+            Oa(f, k, (g | 0) > (e | 0) ? e : g);
+            k = i
+          }
+        } else {
+          if (268435456 == (i & -268435456 | 0)) {
+            Za(b, 4), e = a[l], g = 0 != (d | 0), e = re(c, Eb(c, k, e, g & 1 ^ 1), e), g ? Oa(f, k, e) : d = 0, k = e
+          } else {
+            if (0 > (i | 0)) {
+              Za(b, 1), d = 0 != (d | 0), e = d & 1 ^ 1, g = Eb(c, k, a[l], e), d && Oa(f, k, g), d = e, k = g
+            } else {
+              if (3 == (g | 0)) {
+                Za(b, 3);
+                g = a[l];
+                d = 0 != (d | 0);
+                i = d & 1 ^ 1;
+                e = Eb(c, k, g, i) + 1 | 0;
+                if ((e | 0) > (g | 0)) {
+                  break
+                }
+                d && Oa(f, k, e);
+                d = i;
+                k = e
+              } else {
+                if (e = i >>> 26, 3 == (e | 0)) {
+                  Za(b, 6);
+                  g = a[l];
+                  d = 0 != (d | 0);
+                  i = d & 1 ^ 1;
+                  e = Eb(c, k, g, i) + 2 | 0;
+                  if ((e | 0) > (g | 0)) {
+                    break
+                  }
+                  d && Oa(f, k, e);
+                  d = i;
+                  k = e
+                } else {
+                  if (i >>>= 25, 3 == (i | 0)) {
+                    Za(b, 7);
+                    g = a[l];
+                    d = 0 != (d | 0);
+                    i = d & 1 ^ 1;
+                    e = Eb(c, k, g, i) + 3 | 0;
+                    if ((e | 0) > (g | 0)) {
+                      break
+                    }
+                    d && Oa(f, k, e);
+                    d = i;
+                    k = e
+                  } else {
+                    if (2 == (g | 0)) {
+                      Za(b, 3), d = 0 != (d | 0), e = d & 1 ^ 1, g = Eb(c, k, a[l], e) - 1 | 0
+                    } else {
+                      if (2 == (e | 0)) {
+                        Za(b, 6), d = 0 != (d | 0), e = d & 1 ^ 1, g = Eb(c, k, a[l], e) - 2 | 0
+                      } else {
+                        if (2 != (i | 0)) {
+                          break
+                        }
+                        Za(b, 7);
+                        d = 0 != (d | 0);
+                        e = d & 1 ^ 1;
+                        g = Eb(c, k, a[l], e) - 3 | 0
+                      }
+                    }
+                    if (0 > (g | 0)) {
+                      break
+                    }
+                    d && Oa(f, k, g);
+                    d = e;
+                    k = g
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    function Gf(h, c, f, l) {
+      var d = b;
+      b += 28;
+      var g = a[f + 8 >> 2], k = a[f + 12 >> 2], i = a[f >> 2], f = (f + 4 | 0) >> 2;
+      Zf(d, i, a[f], h, c);
+      h = 0 < (a[f] | 0);
+      a:do {
+        if (h) {
+          for (var c = k, e = i = 0; ;) {
+            ea(c, 0, g);
+            xc(d, i, c);
+            e = e + 1 | 0;
+            if ((e | 0) >= (a[f] | 0)) {
+              break a
+            }
+            i = c;
+            c = c + g | 0
+          }
+        }
+      } while (0);
+      g = d + 16 | 0;
+      k = a[g >> 2];
+      1048832 == (a[d + 24 >> 2] & -256 | 0) && (k = k + 3 | 0, a[g >> 2] = k);
+      g = k;
+      k = a[d + 20 >> 2];
+      a[l >> 2] = (k >> 3) + a[l >> 2] + g + (0 < (k | 0) & 1) | 0;
+      b = d
+    }
+
+    function gd(a, b, c) {
+      for (var l = 0; ;) {
+        var d, g = p[a + 24 >> 2], e = 32 - c | 0, i = g >>> (e >>> 0);
+        d = ja[b + (i << 2) >> 1] << 16 >> 16;
+        i = ja[b + (i << 2) + 2 >> 1] << 16 >> 16;
+        (i | 0) > (c | 0) ? (d = ((g & (1 << e) - 1) >>> ((32 - i | 0) >>> 0)) + d | 0, g = (ja[b + (d << 2) + 2 >> 1] << 16 >> 16) + c | 0, d = ja[b + (d << 2) >> 1] << 16 >> 16) : g = i;
+        Za(a, g);
+        g = d + l | 0;
+        if (63 >= (d | 0)) {
+          break
+        }
+        l = g
+      }
+      return g
+    }
+
+    function Oa(a, b, c) {
+      var l = b >> 3, d = c >> 3, c = c & 7, b = q[g.ye + (b & 7) | 0];
+      if ((l | 0) == (d | 0)) {
+        a = a + l | 0, q[a] |= q[g.S + c | 0] & b
+      } else {
+        var e = a + l | 0;
+        q[e] |= b;
+        b = l + 1 | 0;
+        (b | 0) < (d | 0) && ea(a + b | 0, -1, d - 1 - l | 0);
+        a = a + d | 0;
+        q[a] |= q[g.S + c | 0]
+      }
+    }
+
+    function Eb(a, b, c, l) {
+      0 == (a | 0) ? a = c : (b = re(a, b, c), a = (b | 0) < (c | 0) ? ((F[(b >> 3) + a | 0] & 255) >>> ((b & 7 ^ 7) >>> 0) & 1 | 0) == (l | 0) ? b : re(a, b, c) : b);
+      return a
+    }
+
+    function Nf(h, d, f) {
+      var l, n, e, k, i = d >> 2;
+      k = (h + 64 | 0) >> 2;
+      var j = p[k];
+      e = (h + 72 | 0) >> 2;
+      n = p[e];
+      if (0 == (a[(n + 4 >> 2) + (11 * j | 0)] | 0)) {
+        var w = n
+      } else {
+        w = n + 44 * j | 0, 2 > p[w >> 2] >>> 0 ? (a[w >> 2] = 2, m(h, 2, a[i], g.Yb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), j = a[k], w = a[e]) : w = n
+      }
+      var x = w + 44 * j | 0, E = x | 0, r = 0 == (a[E >> 2] | 0);
+      a:do {
+        if (r) {
+          l = j;
+          var o = w, A = x, t = E
+        } else {
+          n = (h + 68 | 0) >> 2;
+          for (var u = h | 0, y = j, v = w, R = a[n]; ;) {
+            var y = y + 1 | 0, H = (y | 0) < (R | 0);
+            b:do {
+              if (H) {
+                var C = R, D = v
+              } else {
+                var B = a[u >> 2];
+                a[n] = R << 2;
+                var I = pc(B, v, 176 * R | 0);
+                a[e] = I;
+                B = a[n];
+                if ((y | 0) < (B | 0)) {
+                  for (B = y; ;) {
+                    a[(I >> 2) + (11 * B | 0)] = 0;
+                    a[(a[e] + 44 * B + 4 | 0) >> 2] = 0;
+                    a[(a[e] + 44 * B + 40 | 0) >> 2] = 0;
+                    var B = B + 1 | 0, P = p[n], I = p[e];
+                    if ((B | 0) >= (P | 0)) {
+                      C = P;
+                      D = I;
+                      break b
+                    }
+                  }
+                } else {
+                  C = B, D = I
+                }
+              }
+            } while (0);
+            v = D + 44 * y | 0;
+            R = v | 0;
+            if (0 == (a[R >> 2] | 0)) {
+              l = y;
+              o = D;
+              A = v;
+              t = R;
+              break a
+            }
+            v = D;
+            R = C
+          }
+        }
+      } while (0);
+      a[k] = l;
+      a[t >> 2] = 1;
+      a[(o + 4 >> 2) + (11 * l | 0)] = a[i + 2];
+      C = d + 12 | 0;
+      19 > p[C >> 2] >>> 0 ? h = m(h, 3, a[i], g.Ka | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)) : (k = o + 44 * l + 12 | 0, a[k >> 2] = ia(f), D = ia(f + 4 | 0), t = o + 44 * l + 8 | 0, a[t >> 2] = D, a[(o + 16 >> 2) + (11 * l | 0)] = ia(f + 8 | 0), a[(o + 20 >> 2) + (11 * l | 0)] = ia(f + 12 | 0), e = o + 44 * l + 36 | 0, q[e] = q[f + 16 | 0], j = (F[f + 17 | 0] & 255) << 8 | F[(f + 17 | 0) + 1 | 0] & 255, f = (o + 44 * l + 28 | 0) >> 2, -1 < j << 16 >> 16 ? (a[f] = 0, ja[(o + 24 >> 1) + (22 * l | 0)] = 0, -1 == (D | 0) && (m(h, 2, a[i], g.Wb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), a[f] = 1)) : (a[f] = 1, ja[(o + 24 >> 1) + (22 * l | 0)] = j & 32767), a[(o + 32 >> 2) + (11 * l | 0)] = 0, 19 < p[C >> 2] >>> 0 && m(h, 2, a[i], g.Ec | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), f = a[A + 16 >> 2], 0 == (f | 0) ? (f = a[A + 4 >> 2], C = a[A + 12 >> 2], D = a[A + 8 >> 2], m(h, 1, a[d >> 2], g.pb | 0, (c = b, b += 12, a[c >> 2] = f, a[c + 4 >> 2] = C, a[c + 8 >> 2] = D, c))) : (C = a[A + 20 >> 2], D = a[d >> 2], j = a[A + 4 >> 2], n = a[A + 12 >> 2], w = a[A + 8 >> 2], (f | 0) == (C | 0) ? m(h, 1, D, g.vb | 0, (c = b, b += 16, a[c >> 2] = j, a[c + 4 >> 2] = n, a[c + 8 >> 2] = w, a[c + 12 >> 2] = f, c)) : m(h, 1, D, g.Cb | 0, (c = b, b += 20, a[c >> 2] = j, a[c + 4 >> 2] = n, a[c + 8 >> 2] = w, a[c + 12 >> 2] = f, a[c + 16 >> 2] = C, c))), 0 != (a[A + 28 >> 2] | 0) && (A = Da[A + 24 >> 1] & 65535, m(h, 1, a[d >> 2], g.Hb | 0, (c = b, b += 4, a[c >> 2] = A, c))), d = p[t >> 2], A = a[k >> 2], d = -1 == (d | 0) ? pb(h, A, Da[(o + 24 >> 1) + (22 * l | 0)] & 65535) : pb(h, A, d), o = a[(o + 40 >> 2) + (11 * l | 0)] = d, l = o >> 2, 0 == (o | 0)) ? h = m(h, 2, a[i], g.hd | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)) : (Kf(o, F[e] & 4), o = a[l], d = a[l + 1], l = a[l + 2] * d | 0, m(h, 0, a[i], g.Dd | 0, (c = b, b += 12, a[c >> 2] = o, a[c + 4 >> 2] = d, a[c + 8 >> 2] = l, c)), h = 0);
+      return h
+    }
+
+    function ee(h) {
+      var d, f, l, n = h >> 2;
+      l = (h + 60 | 0) >> 2;
+      d = a[l];
+      if ((d | 0) == (a[n + 14] | 0)) {
+        l = 0
+      } else {
+        var e = a[a[n + 13] + (d << 2) >> 2];
+        f = (e + 12 | 0) >> 2;
+        -1 != (a[f] | 0) ? l = 0 : (m(h, 2, a[e >> 2], g.je | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)), d = (h + 28 | 0) >> 2, a[f] = a[n + 8] - a[d] | 0, h = Nc(h, e, a[n + 5] + a[d] | 0), a[d] = a[d] + a[f] | 0, a[l] = a[l] + 1 | 0, l = h)
+      }
+      h = a[n + 16];
+      n = a[n + 18];
+      0 != (a[(n + 40 >> 2) + (11 * h | 0)] | 0) && (a[(n + 44 * h | 0) >> 2] = 2);
+      return l
+    }
+
+    function Id(h, d, f, l, n) {
+      if (0 == (a[d + 28 >> 2] | 0)) {
+        var e = d + 40 | 0, k = d + 32 | 0
+      } else {
+        k = d + 32 | 0;
+        e = a[f + 4 >> 2] + n + a[k >> 2] | 0;
+        d = d + 40 | 0;
+        if ((a[a[d >> 2] + 4 >> 2] | 0) < (e | 0)) {
+          m(h, 0, -1, g.za | 0, (c = b, b += 4, a[c >> 2] = e, c));
+          var i = a[d >> 2];
+          if ((a[i >> 2] | 0) == (a[i >> 2] | 0)) {
+            var j = i + 12 | 0, p = i + 8 | 0, q = pc(a[h >> 2], a[j >> 2], a[p >> 2] * e | 0);
+            a[j >> 2] = q;
+            0 == (q | 0) ? m(h, 3, -1, g.sc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)) : (h = i + 4 | 0, i = a[h >> 2], (i | 0) < (e | 0) && (p = a[p >> 2], ea(q + p * i | 0, 0, p * (e - i) | 0)), a[h >> 2] = e)
+          } else {
+            m(h, 2, -1, g.Xc | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c))
+          }
+        }
+        e = d
+      }
+      Vc(0, a[e >> 2], f, l, a[k >> 2] + n | 0, 0)
+    }
+
+    function $f(h) {
+      for (var d = h + 68 | 0, f = h + 72 | 0, l = 0; ;) {
+        if ((l | 0) >= (a[d >> 2] | 0)) {
+          var n = 0;
+          break
+        }
+        var e = a[f >> 2], k = e + 44 * l | 0;
+        if (2 == (a[k >> 2] | 0)) {
+          var i = a[(e + 40 >> 2) + (11 * l | 0)], e = a[(e + 4 >> 2) + (11 * l | 0)];
+          a[k >> 2] = 3;
+          if (0 != (i | 0)) {
+            m(h, 0, -1, g.Ja | 0, (c = b, b += 4, a[c >> 2] = e, c));
+            n = Dc(i);
+            break
+          }
+          m(h, 2, -1, g.Sa | 0, (c = b, b += 4, a[c >> 2] = e, c))
+        }
+        l = l + 1 | 0
+      }
+      return n
+    }
+
+    function Wc(b, c) {
+      var f = c + 4 | 0, l = a[f >> 2];
+      if (0 != (l | 0)) {
+        var d = c + 12 | 0, g = 0 < (a[d >> 2] | 0), e = b | 0, i = a[e >> 2];
+        a:do {
+          if (g) {
+            for (var j = 0, p = i, m = l; ;) {
+              if (K(p, a[m + (j << 2) >> 2]), j = j + 1 | 0, p = a[e >> 2], m = a[f >> 2], (j | 0) >= (a[d >> 2] | 0)) {
+                var q = p, r = m;
+                break a
+              }
+            }
+          } else {
+            q = i, r = l
+          }
+        } while (0);
+        K(q, r)
+      }
+      f = c + 8 | 0;
+      l = a[f >> 2];
+      if (0 == (l | 0)) {
+        var o = b | 0
+      } else {
+        d = c + 12 | 0;
+        g = 0 < (a[d >> 2] | 0);
+        e = b | 0;
+        i = a[e >> 2];
+        a:do {
+          if (g) {
+            q = 0;
+            j = i;
+            for (r = l; ;) {
+              if (K(j, a[r + (q << 2) >> 2]), q = q + 1 | 0, j = a[e >> 2], r = a[f >> 2], (q | 0) >= (a[d >> 2] | 0)) {
+                var o = j, w = r;
+                break a
+              }
+            }
+          } else {
+            o = i, w = l
+          }
+        } while (0);
+        K(o, w);
+        o = e
+      }
+      K(a[o >> 2], c)
+    }
+
+    function Of(h, d, f, l, e, j) {
+      var k, i, p;
+      i = (d + 12 | 0) >> 2;
+      k = (d + 16 | 0) >> 2;
+      var q = a[k];
+      if ((a[i] | 0) == (q | 0)) {
+        a[k] = q >> 2;
+        var w = h | 0;
+        p = d + 4 | 0;
+        q = pc(a[w >> 2], a[p >> 2], q & -4);
+        d = d + 8 | 0;
+        k = pc(a[w >> 2], a[d >> 2], a[k] << 2);
+        if (0 == (q | 0) | 0 == (k | 0)) {
+          m(h, 3, -1, g.Xb | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+          var x = -1;
+          p = 7
+        } else {
+          a[p >> 2] = q, a[d >> 2] = k, r = p, o = d, p = 6
+        }
+      } else {
+        var r = d + 4 | 0, o = d + 8 | 0;
+        p = 6
+      }
+      6 == p && (f = ag(h, f, l), a[((a[i] << 2) + a[r >> 2] | 0) >> 2] = f, h = ag(h, e, j), a[((a[i] << 2) + a[o >> 2] | 0) >> 2] = h, a[i] = a[i] + 1 | 0, x = 0);
+      return x
+    }
+
+    function ag(h, d, f) {
+      var l = O(a[h >> 2], f);
+      0 == (l | 0) ? m(h, 3, -1, g.ke | 0, (c = b, b += 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c)) : eb(l, d, f);
+      return l
+    }
+
+    function Wb(b) {
+      var c, f = 245 > b >>> 0;
+      do {
+        if (f) {
+          var l = 11 > b >>> 0 ? 16 : b + 11 & -8, d = l >>> 3;
+          c = p[j >> 2];
+          var g = c >>> (d >>> 0);
+          if (0 != (g & 3 | 0)) {
+            var b = (g & 1 ^ 1) + d | 0, l = b << 1, f = (l << 2) + j + 40 | 0, d = (l + 2 << 2) + j + 40 | 0, e = p[d >> 2], l = e + 8 | 0, g = p[l >> 2];
+            (f | 0) == (g | 0) ? a[j >> 2] = c & (1 << b ^ -1) : (g >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!")), a[d >> 2] = g, a[g + 12 >> 2] = f);
+            c = b << 3;
+            a[e + 4 >> 2] = c | 3;
+            c = e + (c | 4) | 0;
+            a[c >> 2] |= 1;
+            e = l;
+            c = 38;
+            break
+          }
+          if (l >>> 0 <= p[j + 8 >> 2] >>> 0) {
+            var i = l;
+            c = 30;
+            break
+          }
+          if (0 != (g | 0)) {
+            var b = 2 << d, b = g << d & (b | -b), f = (b & -b) - 1 | 0, b = f >>> 12 & 16, e = f >>> (b >>> 0), f = e >>> 5 & 8, d = e >>> (f >>> 0), e = d >>> 2 & 4, g = d >>> (e >>> 0), d = g >>> 1 & 2, g = g >>> (d >>> 0), m = g >>> 1 & 1, e = (f | b | e | d | m) + (g >>> (m >>> 0)) | 0, b = e << 1, d = (b << 2) + j + 40 | 0, g = (b + 2 << 2) + j + 40 | 0, f = p[g >> 2], b = f + 8 | 0, m = p[b >> 2];
+            (d | 0) == (m | 0) ? a[j >> 2] = c & (1 << e ^ -1) : (m >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!")), a[g >> 2] = m, a[m + 12 >> 2] = d);
+            e <<= 3;
+            c = e - l | 0;
+            a[f + 4 >> 2] = l | 3;
+            d = f;
+            f = d + l | 0;
+            a[d + (l | 4) >> 2] = c | 1;
+            a[d + e >> 2] = c;
+            m = p[j + 8 >> 2];
+            0 != (m | 0) && (l = a[j + 20 >> 2], d = m >>> 2 & 1073741822, e = (d << 2) + j + 40 | 0, g = p[j >> 2], m = 1 << (m >>> 3), 0 == (g & m | 0) ? (a[j >> 2] = g | m, g = e, d = (d + 2 << 2) + j + 40 | 0) : (d = (d + 2 << 2) + j + 40 | 0, g = p[d >> 2], g >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!"))), a[d >> 2] = l, a[g + 12 >> 2] = l, a[(l + 8 | 0) >> 2] = g, a[(l + 12 | 0) >> 2] = e);
+            a[j + 8 >> 2] = c;
+            a[j + 20 >> 2] = f;
+            e = b;
+            c = 38;
+            break
+          }
+          if (0 == (a[j + 4 >> 2] | 0)) {
+            i = l;
+            c = 30;
+            break
+          }
+          c = bg(l);
+          if (0 == (c | 0)) {
+            i = l;
+            c = 30;
+            break
+          }
+          e = c
+        } else {
+          if (4294967231 < b >>> 0) {
+            i = -1;
+            c = 30;
+            break
+          }
+          c = b + 11 & -8;
+          if (0 == (a[j + 4 >> 2] | 0)) {
+            i = c;
+            c = 30;
+            break
+          }
+          l = cg(c);
+          if (0 == (l | 0)) {
+            i = c;
+            c = 30;
+            break
+          }
+          e = l
+        }
+        c = 38
+      } while (0);
+      30 == c && (l = p[j + 8 >> 2], i >>> 0 > l >>> 0 ? (c = p[j + 12 >> 2], i >>> 0 < c >>> 0 ? (c = c - i | 0, a[j + 12 >> 2] = c, l = p[j + 24 >> 2], a[j + 24 >> 2] = l + i | 0, a[i + (l + 4) >> 2] = c | 1, a[l + 4 >> 2] = i | 3, e = l + 8 | 0) : e = dg(i)) : (b = l - i | 0, c = p[j + 20 >> 2], 15 < b >>> 0 ? (a[j + 20 >> 2] = c + i | 0, a[j + 8 >> 2] = b, a[i + (c + 4) >> 2] = b | 1, a[c + l >> 2] = b, a[c + 4 >> 2] = i | 3) : (a[j + 8 >> 2] = 0, a[j + 20 >> 2] = 0, a[c + 4 >> 2] = l | 3, i = l + (c + 4) | 0, a[i >> 2] |= 1), e = c + 8 | 0));
+      return e
+    }
+
+    function bg(b) {
+      var c, f, l = a[j + 4 >> 2], d = (l & -l) - 1 | 0, l = d >>> 12 & 16, g = d >>> (l >>> 0), d = g >>> 5 & 8;
+      f = g >>> (d >>> 0);
+      var g = f >>> 2 & 4, e = f >>> (g >>> 0);
+      f = e >>> 1 & 2;
+      var e = e >>> (f >>> 0), i = e >>> 1 & 1, l = d = p[j + ((d | l | g | f | i) + (e >>> (i >>> 0)) << 2) + 304 >> 2];
+      f = l >> 2;
+      d = (a[d + 4 >> 2] & -8) - b | 0;
+      a:for (; ;) {
+        for (g = l; ;) {
+          e = a[g + 16 >> 2];
+          if (0 == (e | 0)) {
+            if (g = a[g + 20 >> 2], 0 == (g | 0)) {
+              break a
+            }
+          } else {
+            g = e
+          }
+          e = (a[g + 4 >> 2] & -8) - b | 0;
+          if (e >>> 0 < d >>> 0) {
+            l = g;
+            f = l >> 2;
+            d = e;
+            continue a
+          }
+        }
+      }
+      var e = l, m = p[j + 16 >> 2], i = e >>> 0 < m >>> 0;
+      do {
+        if (!i) {
+          var q = e + b | 0, g = q;
+          if (e >>> 0 < q >>> 0) {
+            var i = p[f + 6], q = p[f + 3], w = (q | 0) == (l | 0);
+            do {
+              if (w) {
+                c = l + 20 | 0;
+                var x = a[c >> 2];
+                if (0 == (x | 0) && (c = l + 16 | 0, x = a[c >> 2], 0 == (x | 0))) {
+                  x = 0;
+                  c = x >> 2;
+                  break
+                }
+                for (; ;) {
+                  var r = x + 20 | 0, o = a[r >> 2];
+                  if (0 == (o | 0) && (r = x + 16 | 0, o = p[r >> 2], 0 == (o | 0))) {
+                    break
+                  }
+                  c = r;
+                  x = o
+                }
+                c >>> 0 < m >>> 0 && (E(), N("Reached an unreachable!"));
+                a[c >> 2] = 0
+              } else {
+                c = p[f + 2], c >>> 0 < m >>> 0 && (E(), N("Reached an unreachable!")), a[c + 12 >> 2] = q, a[q + 8 >> 2] = c, x = q
+              }
+              c = x >> 2
+            } while (0);
+            m = 0 == (i | 0);
+            a:do {
+              if (!m) {
+                q = l + 28 | 0;
+                w = (a[q >> 2] << 2) + j + 304 | 0;
+                r = (l | 0) == (a[w >> 2] | 0);
+                do {
+                  if (r) {
+                    a[w >> 2] = x;
+                    if (0 != (x | 0)) {
+                      break
+                    }
+                    a[j + 4 >> 2] &= 1 << a[q >> 2] ^ -1;
+                    break a
+                  }
+                  i >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!"));
+                  o = i + 16 | 0;
+                  (a[o >> 2] | 0) == (l | 0) ? a[o >> 2] = x : a[i + 20 >> 2] = x;
+                  if (0 == (x | 0)) {
+                    break a
+                  }
+                } while (0);
+                x >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!"));
+                a[c + 6] = i;
+                q = p[f + 4];
+                0 != (q | 0) && (q >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!")), a[c + 4] = q, a[q + 24 >> 2] = x);
+                q = p[f + 5];
+                0 != (q | 0) && (q >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!")), a[c + 5] = q, a[q + 24 >> 2] = x)
+              }
+            } while (0);
+            16 > d >>> 0 ? (b = d + b | 0, a[f + 1] = b | 3, b = b + (e + 4) | 0, a[b >> 2] |= 1) : (a[f + 1] = b | 3, a[b + (e + 4) >> 2] = d | 1, a[e + d + b >> 2] = d, m = p[j + 8 >> 2], 0 != (m | 0) && (b = p[j + 20 >> 2], e = m >>> 2 & 1073741822, f = (e << 2) + j + 40 | 0, i = p[j >> 2], m = 1 << (m >>> 3), 0 == (i & m | 0) ? (a[j >> 2] = i | m, i = f, e = (e + 2 << 2) + j + 40 | 0) : (e = (e + 2 << 2) + j + 40 | 0, i = p[e >> 2], i >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!"))), a[e >> 2] = b, a[i + 12 >> 2] = b, a[b + 8 >> 2] = i, a[b + 12 >> 2] = f), a[j + 8 >> 2] = d, a[j + 20 >> 2] = g);
+            return l + 8 | 0
+          }
+        }
+      } while (0);
+      E();
+      N("Reached an unreachable!")
+    }
+
+    function dg(b) {
+      var c, f;
+      0 == (a[aa >> 2] | 0) && eg();
+      var d = 0 == (a[j + 440 >> 2] & 4 | 0);
+      do {
+        if (d) {
+          f = a[j + 24 >> 2];
+          if (0 == (f | 0)) {
+            f = 6
+          } else {
+            if (f = Lb(f), 0 == (f | 0)) {
+              f = 6
+            } else {
+              var e = a[aa + 8 >> 2], e = b + 47 - a[j + 12 >> 2] + e & -e;
+              if (2147483647 > e >>> 0) {
+                var g = ib(e);
+                if ((g | 0) == (a[f >> 2] + a[f + 4 >> 2] | 0)) {
+                  var k = g, i = e;
+                  c = g;
+                  f = 13
+                } else {
+                  var m = g, q = e;
+                  f = 15
+                }
+              } else {
+                f = 14
+              }
+            }
+          }
+          if (6 == f) {
+            if (f = ib(0), -1 == (f | 0)) {
+              f = 14
+            } else {
+              var e = a[aa + 8 >> 2], e = e + (b + 47) & -e, g = f, w = a[aa + 4 >> 2], x = w - 1 | 0, e = 0 == (x & g | 0) ? e : e - g + (x + g & -w) | 0;
+              2147483647 > e >>> 0 ? (g = ib(e), (g | 0) == (f | 0) ? (k = f, i = e, c = g, f = 13) : (m = g, q = e, f = 15)) : f = 14
+            }
+          }
+          if (13 == f) {
+            if (-1 != (k | 0)) {
+              var r = i, o = k;
+              f = 26;
+              break
+            }
+            m = c;
+            q = i
+          } else {
+            if (14 == f) {
+              a[j + 440 >> 2] |= 4;
+              f = 23;
+              break
+            }
+          }
+          f = -q | 0;
+          if (-1 != (m | 0) & 2147483647 > q >>> 0) {
+            if (q >>> 0 < (b + 48 | 0) >>> 0) {
+              e = a[aa + 8 >> 2], e = b + 47 - q + e & -e, 2147483647 > e >>> 0 ? -1 == (ib(e) | 0) ? (ib(f), f = 22) : (A = e + q | 0, f = 21) : (A = q, f = 21)
+            } else {
+              var A = q;
+              f = 21
+            }
+          } else {
+            A = q, f = 21
+          }
+          21 == f && -1 != (m | 0) ? (r = A, o = m, f = 26) : (a[j + 440 >> 2] |= 4, f = 23)
+        } else {
+          f = 23
+        }
+      } while (0);
+      23 == f && (d = a[aa + 8 >> 2], d = d + (b + 47) & -d, 2147483647 > d >>> 0 ? (d = ib(d), k = ib(0), -1 != (k | 0) & -1 != (d | 0) & d >>> 0 < k >>> 0 ? (k = k - d | 0, k >>> 0 <= (b + 40 | 0) >>> 0 | -1 == (d | 0) ? f = 49 : (r = k, o = d, f = 26)) : f = 49) : f = 49);
+      a:do {
+        if (26 == f) {
+          d = a[j + 432 >> 2] + r | 0;
+          a[j + 432 >> 2] = d;
+          d >>> 0 > p[j + 436 >> 2] >>> 0 && (a[j + 436 >> 2] = d);
+          d = p[j + 24 >> 2];
+          k = 0 == (d | 0);
+          b:do {
+            if (k) {
+              i = p[j + 16 >> 2];
+              0 == (i | 0) | o >>> 0 < i >>> 0 && (a[j + 16 >> 2] = o);
+              a[j + 444 >> 2] = o;
+              a[j + 448 >> 2] = r;
+              a[j + 456 >> 2] = 0;
+              a[j + 36 >> 2] = a[aa >> 2];
+              a[j + 32 >> 2] = -1;
+              for (i = 0; !(c = i << 1, m = (c << 2) + j + 40 | 0, a[j + (c + 3 << 2) + 40 >> 2] = m, a[j + (c + 2 << 2) + 40 >> 2] = m, i = i + 1 | 0, 32 == (i | 0));) {
+              }
+              Td(o, r - 40 | 0)
+            } else {
+              m = j + 444 | 0;
+              for (c = m >> 2; 0 != (m | 0);) {
+                i = p[c];
+                m = m + 4 | 0;
+                q = p[m >> 2];
+                A = i + q | 0;
+                if ((o | 0) == (A | 0)) {
+                  if (0 != (a[c + 3] & 8 | 0)) {
+                    break
+                  }
+                  c = d;
+                  if (!(c >>> 0 >= i >>> 0 & c >>> 0 < A >>> 0)) {
+                    break
+                  }
+                  a[m >> 2] = q + r | 0;
+                  Td(a[j + 24 >> 2], a[j + 12 >> 2] + r | 0);
+                  break b
+                }
+                m = a[c + 2];
+                c = m >> 2
+              }
+              o >>> 0 < p[j + 16 >> 2] >>> 0 && (a[j + 16 >> 2] = o);
+              c = o + r | 0;
+              for (m = j + 444 | 0; 0 != (m | 0);) {
+                q = m | 0;
+                i = p[q >> 2];
+                if ((i | 0) == (c | 0)) {
+                  if (0 != (a[m + 12 >> 2] & 8 | 0)) {
+                    break
+                  }
+                  a[q >> 2] = o;
+                  var t = m + 4 | 0;
+                  a[t >> 2] = a[t >> 2] + r | 0;
+                  t = fg(o, i, b);
+                  f = 50;
+                  break a
+                }
+                m = a[m + 8 >> 2]
+              }
+              gg(o, r)
+            }
+          } while (0);
+          d = p[j + 12 >> 2];
+          d >>> 0 > b >>> 0 ? (t = d - b | 0, a[j + 12 >> 2] = t, k = d = p[j + 24 >> 2], a[j + 24 >> 2] = k + b | 0, a[b + (k + 4) >> 2] = t | 1, a[d + 4 >> 2] = b | 3, t = d + 8 | 0, f = 50) : f = 49
+        }
+      } while (0);
+      49 == f && (a[W.i >> 2] = 12, t = 0);
+      return t
+    }
+
+    function cg(b) {
+      var c, f, d, e, g, k = b >> 2, i = -b | 0, m = b >>> 8;
+      if (0 == (m | 0)) {
+        var q = 0
+      } else {
+        if (16777215 < b >>> 0) {
+          q = 31
+        } else {
+          var w = (m + 1048320 | 0) >>> 16 & 8, x = m << w, r = (x + 520192 | 0) >>> 16 & 4, o = x << r, A = (o + 245760 | 0) >>> 16 & 2, t = 14 - (r | w | A) + (o << A >>> 15) | 0, q = b >>> ((t + 7 | 0) >>> 0) & 1 | t << 1
+        }
+      }
+      var u = p[j + (q << 2) + 304 >> 2], y = 0 == (u | 0);
+      a:do {
+        if (y) {
+          var v = 0, F = i, H = 0
+        } else {
+          var C = 31 == (q | 0) ? 0 : 25 - (q >>> 1) | 0, D = 0, B = i, I = u;
+          g = I >> 2;
+          for (var P = b << C, J = 0; ;) {
+            var K = a[g + 1] & -8, M = K - b | 0;
+            if (M >>> 0 < B >>> 0) {
+              if ((K | 0) == (b | 0)) {
+                v = I;
+                F = M;
+                H = I;
+                break a
+              }
+              var O = I, Q = M
+            } else {
+              O = D, Q = B
+            }
+            var T = p[g + 5], W = p[((P >>> 31 << 2) + 16 >> 2) + g], U = 0 == (T | 0) | (T | 0) == (W | 0) ? J : T;
+            if (0 == (W | 0)) {
+              v = O;
+              F = Q;
+              H = U;
+              break a
+            }
+            D = O;
+            B = Q;
+            I = W;
+            g = I >> 2;
+            P <<= 1;
+            J = U
+          }
+        }
+      } while (0);
+      if (0 == (H | 0) & 0 == (v | 0)) {
+        var ea = 2 << q, aa = a[j + 4 >> 2] & (ea | -ea);
+        if (0 == (aa | 0)) {
+          var wa = H
+        } else {
+          var fa = (aa & -aa) - 1 | 0, ga = fa >>> 12 & 16, ra = fa >>> (ga >>> 0), ja = ra >>> 5 & 8, S = ra >>> (ja >>> 0), Z = S >>> 2 & 4, ma = S >>> (Z >>> 0), ia = ma >>> 1 & 2, pa = ma >>> (ia >>> 0), ta = pa >>> 1 & 1, wa = a[j + ((ja | ga | Z | ia | ta) + (pa >>> (ta >>> 0)) << 2) + 304 >> 2]
+        }
+      } else {
+        wa = H
+      }
+      var Ja = 0 == (wa | 0);
+      a:do {
+        if (Ja) {
+          var ba = F, ya = v;
+          e = ya >> 2
+        } else {
+          var qa = wa;
+          d = qa >> 2;
+          for (var La = F, Ia = v; ;) {
+            var Aa = (a[d + 1] & -8) - b | 0, Ba = Aa >>> 0 < La >>> 0, qb = Ba ? Aa : La, ka = Ba ? qa : Ia, rb = p[d + 4];
+            if (0 != (rb | 0)) {
+              qa = rb
+            } else {
+              var fb = p[d + 5];
+              if (0 == (fb | 0)) {
+                ba = qb;
+                ya = ka;
+                e = ya >> 2;
+                break a
+              }
+              qa = fb
+            }
+            d = qa >> 2;
+            La = qb;
+            Ia = ka
+          }
+        }
+      } while (0);
+      var X = 0 == (ya | 0);
+      a:do {
+        if (X) {
+          var sb = 0
+        } else {
+          if (ba >>> 0 < (a[j + 8 >> 2] - b | 0) >>> 0) {
+            var Va = ya;
+            f = Va >> 2;
+            var na = p[j + 16 >> 2], Wa = Va >>> 0 < na >>> 0;
+            do {
+              if (!Wa) {
+                var Ra = Va + b | 0, Qa = Ra;
+                if (Va >>> 0 < Ra >>> 0) {
+                  var ec = p[e + 6], xa = p[e + 3], cb = (xa | 0) == (ya | 0);
+                  do {
+                    if (cb) {
+                      var Xb = ya + 20 | 0, Sa = a[Xb >> 2];
+                      if (0 == (Sa | 0)) {
+                        var Qb = ya + 16 | 0, Yb = a[Qb >> 2];
+                        if (0 == (Yb | 0)) {
+                          var da = 0;
+                          c = da >> 2;
+                          break
+                        }
+                        var la = Qb, Ma = Yb
+                      } else {
+                        la = Xb, Ma = Sa
+                      }
+                      for (; ;) {
+                        var Na = Ma + 20 | 0, Pa = a[Na >> 2];
+                        if (0 != (Pa | 0)) {
+                          la = Na, Ma = Pa
+                        } else {
+                          var Oa = Ma + 16 | 0, ib = p[Oa >> 2];
+                          if (0 == (ib | 0)) {
+                            break
+                          }
+                          la = Oa;
+                          Ma = ib
+                        }
+                      }
+                      la >>> 0 < na >>> 0 && (E(), N("Reached an unreachable!"));
+                      a[la >> 2] = 0;
+                      da = Ma
+                    } else {
+                      var fc = p[e + 2];
+                      fc >>> 0 < na >>> 0 && (E(), N("Reached an unreachable!"));
+                      a[fc + 12 >> 2] = xa;
+                      a[xa + 8 >> 2] = fc;
+                      da = xa
+                    }
+                    c = da >> 2
+                  } while (0);
+                  var tb = 0 == (ec | 0);
+                  b:do {
+                    if (!tb) {
+                      var bb = ya + 28 | 0, ub = (a[bb >> 2] << 2) + j + 304 | 0, Nb = (ya | 0) == (a[ub >> 2] | 0);
+                      do {
+                        if (Nb) {
+                          a[ub >> 2] = da;
+                          if (0 != (da | 0)) {
+                            break
+                          }
+                          a[j + 4 >> 2] &= 1 << a[bb >> 2] ^ -1;
+                          break b
+                        }
+                        ec >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!"));
+                        var jc = ec + 16 | 0;
+                        (a[jc >> 2] | 0) == (ya | 0) ? a[jc >> 2] = da : a[ec + 20 >> 2] = da;
+                        if (0 == (da | 0)) {
+                          break b
+                        }
+                      } while (0);
+                      da >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!"));
+                      a[c + 6] = ec;
+                      var Xa = p[e + 4];
+                      0 != (Xa | 0) && (Xa >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!")), a[c + 4] = Xa, a[Xa + 24 >> 2] = da);
+                      var Fa = p[e + 5];
+                      0 != (Fa | 0) && (Fa >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!")), a[c + 5] = Fa, a[Fa + 24 >> 2] = da)
+                    }
+                  } while (0);
+                  var nb = 16 > ba >>> 0;
+                  b:do {
+                    if (nb) {
+                      var db = ba + b | 0;
+                      a[e + 1] = db | 3;
+                      var Zb = db + (Va + 4) | 0;
+                      a[Zb >> 2] |= 1
+                    } else {
+                      if (a[e + 1] = b | 3, a[k + (f + 1)] = ba | 1, a[(ba >> 2) + f + k] = ba, 256 > ba >>> 0) {
+                        var Db = ba >>> 2 & 1073741822, yb = (Db << 2) + j + 40 | 0, zb = p[j >> 2], eb = 1 << (ba >>> 3);
+                        if (0 == (zb & eb | 0)) {
+                          a[j >> 2] = zb | eb;
+                          var Da = yb, hb = (Db + 2 << 2) + j + 40 | 0
+                        } else {
+                          var Za = (Db + 2 << 2) + j + 40 | 0, Qc = p[Za >> 2];
+                          Qc >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!"));
+                          Da = Qc;
+                          hb = Za
+                        }
+                        a[hb >> 2] = Qa;
+                        a[Da + 12 >> 2] = Qa;
+                        a[k + (f + 2)] = Da;
+                        a[k + (f + 3)] = yb
+                      } else {
+                        var Fb = Ra, $a = ba >>> 8;
+                        if (0 == ($a | 0)) {
+                          var ca = 0
+                        } else {
+                          if (16777215 < ba >>> 0) {
+                            ca = 31
+                          } else {
+                            var kb = ($a + 1048320 | 0) >>> 16 & 8, lb = $a << kb, za = (lb + 520192 | 0) >>> 16 & 4, pb = lb << za, jb = (pb + 245760 | 0) >>> 16 & 2, Ha = 14 - (za | kb | jb) + (pb << jb >>> 15) | 0, ca = ba >>> ((Ha + 7 | 0) >>> 0) & 1 | Ha << 1
+                          }
+                        }
+                        var oa = (ca << 2) + j + 304 | 0;
+                        a[k + (f + 7)] = ca;
+                        var Cb = b + (Va + 16) | 0;
+                        a[k + (f + 5)] = 0;
+                        a[Cb >> 2] = 0;
+                        var Jb = a[j + 4 >> 2], $b = 1 << ca;
+                        if (0 == (Jb & $b | 0)) {
+                          a[j + 4 >> 2] = Jb | $b, a[oa >> 2] = Fb, a[k + (f + 6)] = oa, a[k + (f + 3)] = Fb, a[k + (f + 2)] = Fb
+                        } else {
+                          for (var mb = ba << (31 == (ca | 0) ? 0 : 25 - (ca >>> 1) | 0), Rb = a[oa >> 2]; ;) {
+                            if ((a[Rb + 4 >> 2] & -8 | 0) == (ba | 0)) {
+                              var wb = Rb + 8 | 0, ob = p[wb >> 2], xb = p[j + 16 >> 2], Eb = Rb >>> 0 < xb >>> 0;
+                              do {
+                                if (!Eb && ob >>> 0 >= xb >>> 0) {
+                                  a[ob + 12 >> 2] = Fb;
+                                  a[wb >> 2] = Fb;
+                                  a[k + (f + 2)] = ob;
+                                  a[k + (f + 3)] = Rb;
+                                  a[k + (f + 6)] = 0;
+                                  break b
+                                }
+                              } while (0);
+                              E();
+                              N("Reached an unreachable!")
+                            }
+                            var ab = (mb >>> 31 << 2) + Rb + 16 | 0, vb = p[ab >> 2];
+                            if (0 == (vb | 0)) {
+                              if (ab >>> 0 >= p[j + 16 >> 2] >>> 0) {
+                                a[ab >> 2] = Fb;
+                                a[k + (f + 6)] = Rb;
+                                a[k + (f + 3)] = Fb;
+                                a[k + (f + 2)] = Fb;
+                                break b
+                              }
+                              E();
+                              N("Reached an unreachable!")
+                            }
+                            mb <<= 1;
+                            Rb = vb
+                          }
+                        }
+                      }
+                    }
+                  } while (0);
+                  sb = ya + 8 | 0;
+                  break a
+                }
+              }
+            } while (0);
+            E();
+            N("Reached an unreachable!")
+          }
+          sb = 0
+        }
+      } while (0);
+      return sb
+    }
+
+    function hg(b) {
+      var c;
+      0 == (a[aa >> 2] | 0) && eg();
+      var f = 4294967232 > b >>> 0;
+      a:do {
+        if (f) {
+          var d = p[j + 24 >> 2];
+          if (0 == (d | 0)) {
+            c = 0;
+            break
+          }
+          var e = p[j + 12 >> 2], g = e >>> 0 > (b + 40 | 0) >>> 0;
+          do {
+            if (g) {
+              var k = p[aa + 8 >> 2], i = (Math.floor(((-40 - b - 1 + e + k | 0) >>> 0) / (k >>> 0)) - 1) * k | 0, m = Lb(d);
+              if (0 == (a[m + 12 >> 2] & 8 | 0)) {
+                var q = ib(0);
+                c = (m + 4 | 0) >> 2;
+                if ((q | 0) == (a[m >> 2] + a[c] | 0) && (i = ib(-(2147483646 < i >>> 0 ? -2147483648 - k | 0 : i) | 0), k = ib(0), -1 != (i | 0) & k >>> 0 < q >>> 0 && (i = q - k | 0, (q | 0) != (k | 0)))) {
+                  a[c] = a[c] - i | 0;
+                  a[j + 432 >> 2] = a[j + 432 >> 2] - i | 0;
+                  Td(a[j + 24 >> 2], a[j + 12 >> 2] - i | 0);
+                  c = (q | 0) != (k | 0);
+                  break a
+                }
+              }
+            }
+          } while (0);
+          if (p[j + 12 >> 2] >>> 0 <= p[j + 28 >> 2] >>> 0) {
+            c = 0;
+            break
+          }
+          a[j + 28 >> 2] = -1
+        }
+        c = 0
+      } while (0);
+      return c & 1
+    }
+
+    function hb(b) {
+      var c, f, d, e, g, k, i = b >> 2, m, q = 0 == (b | 0);
+      a:do {
+        if (!q) {
+          var w = b - 8 | 0, x = w, r = p[j + 16 >> 2], o = w >>> 0 < r >>> 0;
+          b:do {
+            if (!o) {
+              var A = p[b - 4 >> 2], t = A & 3;
+              if (1 != (t | 0)) {
+                var u = A & -8;
+                k = u >> 2;
+                var y = b + (u - 8) | 0, v = y, F = 0 == (A & 1 | 0);
+                c:do {
+                  if (F) {
+                    var H = p[w >> 2];
+                    if (0 == (t | 0)) {
+                      break a
+                    }
+                    var C = -8 - H | 0;
+                    g = C >> 2;
+                    var D = b + C | 0, B = D, I = H + u | 0;
+                    if (D >>> 0 < r >>> 0) {
+                      break b
+                    }
+                    if ((B | 0) == (a[j + 20 >> 2] | 0)) {
+                      e = (b + (u - 4) | 0) >> 2;
+                      if (3 != (a[e] & 3 | 0)) {
+                        var J = B;
+                        d = J >> 2;
+                        var K = I;
+                        break
+                      }
+                      a[j + 8 >> 2] = I;
+                      a[e] &= -2;
+                      a[g + (i + 1)] = I | 1;
+                      a[y >> 2] = I;
+                      break a
+                    }
+                    if (256 > H >>> 0) {
+                      var M = p[g + (i + 2)], O = p[g + (i + 3)];
+                      if ((M | 0) == (O | 0)) {
+                        a[j >> 2] &= 1 << (H >>> 3) ^ -1, J = B, d = J >> 2, K = I
+                      } else {
+                        var Q = ((H >>> 2 & 1073741822) << 2) + j + 40 | 0, T = (M | 0) != (Q | 0) & M >>> 0 < r >>> 0;
+                        do {
+                          if (!T && (O | 0) == (Q | 0) | O >>> 0 >= r >>> 0) {
+                            a[M + 12 >> 2] = O;
+                            a[O + 8 >> 2] = M;
+                            J = B;
+                            d = J >> 2;
+                            K = I;
+                            break c
+                          }
+                        } while (0);
+                        E();
+                        N("Reached an unreachable!")
+                      }
+                    } else {
+                      var W = D, aa = p[g + (i + 6)], U = p[g + (i + 3)], ea = (U | 0) == (W | 0);
+                      do {
+                        if (ea) {
+                          var fa = C + (b + 20) | 0, ga = a[fa >> 2];
+                          if (0 == (ga | 0)) {
+                            var ja = C + (b + 16) | 0, ma = a[ja >> 2];
+                            if (0 == (ma | 0)) {
+                              var ra = 0;
+                              f = ra >> 2;
+                              break
+                            }
+                            var ia = ja, S = ma
+                          } else {
+                            ia = fa, S = ga, m = 21
+                          }
+                          for (; ;) {
+                            var Z = S + 20 | 0, pa = a[Z >> 2];
+                            if (0 != (pa | 0)) {
+                              ia = Z, S = pa
+                            } else {
+                              var qa = S + 16 | 0, ta = p[qa >> 2];
+                              if (0 == (ta | 0)) {
+                                break
+                              }
+                              ia = qa;
+                              S = ta
+                            }
+                          }
+                          ia >>> 0 < r >>> 0 && (E(), N("Reached an unreachable!"));
+                          a[ia >> 2] = 0;
+                          ra = S
+                        } else {
+                          var xa = p[g + (i + 2)];
+                          xa >>> 0 < r >>> 0 && (E(), N("Reached an unreachable!"));
+                          a[xa + 12 >> 2] = U;
+                          a[U + 8 >> 2] = xa;
+                          ra = U
+                        }
+                        f = ra >> 2
+                      } while (0);
+                      if (0 != (aa | 0)) {
+                        var Ia = C + (b + 28) | 0, ba = (a[Ia >> 2] << 2) + j + 304 | 0, ya = (W | 0) == (a[ba >> 2] | 0);
+                        do {
+                          if (ya) {
+                            a[ba >> 2] = ra;
+                            if (0 != (ra | 0)) {
+                              break
+                            }
+                            a[j + 4 >> 2] &= 1 << a[Ia >> 2] ^ -1;
+                            J = B;
+                            d = J >> 2;
+                            K = I;
+                            break c
+                          }
+                          aa >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!"));
+                          var Ja = aa + 16 | 0;
+                          (a[Ja >> 2] | 0) == (W | 0) ? a[Ja >> 2] = ra : a[aa + 20 >> 2] = ra;
+                          if (0 == (ra | 0)) {
+                            J = B;
+                            d = J >> 2;
+                            K = I;
+                            break c
+                          }
+                        } while (0);
+                        ra >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!"));
+                        a[f + 6] = aa;
+                        var La = p[g + (i + 4)];
+                        0 != (La | 0) && (La >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!")), a[f + 4] = La, a[La + 24 >> 2] = ra);
+                        var Aa = p[g + (i + 5)];
+                        0 != (Aa | 0) && (Aa >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!")), a[f + 5] = Aa, a[Aa + 24 >> 2] = ra)
+                      }
+                      J = B;
+                      d = J >> 2;
+                      K = I
+                    }
+                  } else {
+                    J = x, d = J >> 2, K = u
+                  }
+                } while (0);
+                var Ba = J;
+                if (Ba >>> 0 < y >>> 0) {
+                  var Qa = b + (u - 4) | 0, qb = p[Qa >> 2];
+                  if (0 != (qb & 1 | 0)) {
+                    var ka = 0 == (qb & 2 | 0);
+                    do {
+                      if (ka) {
+                        if ((v | 0) == (a[j + 24 >> 2] | 0)) {
+                          var rb = a[j + 12 >> 2] + K | 0;
+                          a[j + 12 >> 2] = rb;
+                          a[j + 24 >> 2] = J;
+                          a[d + 1] = rb | 1;
+                          (J | 0) == (a[j + 20 >> 2] | 0) && (a[j + 20 >> 2] = 0, a[j + 8 >> 2] = 0);
+                          if (rb >>> 0 <= p[j + 28 >> 2] >>> 0) {
+                            break a
+                          }
+                          hg(0);
+                          break a
+                        }
+                        if ((v | 0) == (a[j + 20 >> 2] | 0)) {
+                          var fb = a[j + 8 >> 2] + K | 0;
+                          a[j + 8 >> 2] = fb;
+                          a[j + 20 >> 2] = J;
+                          a[d + 1] = fb | 1;
+                          a[(Ba + fb | 0) >> 2] = fb;
+                          break a
+                        }
+                        var X = (qb & -8) + K | 0, sb = qb >>> 3, Va = 256 > qb >>> 0;
+                        c:do {
+                          if (Va) {
+                            var na = p[i + k], Wa = p[((u | 4) >> 2) + i];
+                            if ((na | 0) == (Wa | 0)) {
+                              a[j >> 2] &= 1 << sb ^ -1
+                            } else {
+                              var Ra = ((qb >>> 2 & 1073741822) << 2) + j + 40 | 0;
+                              m = (na | 0) == (Ra | 0) ? 63 : na >>> 0 < p[j + 16 >> 2] >>> 0 ? 66 : 63;
+                              do {
+                                if (63 == m && !((Wa | 0) != (Ra | 0) && Wa >>> 0 < p[j + 16 >> 2] >>> 0)) {
+                                  a[na + 12 >> 2] = Wa;
+                                  a[Wa + 8 >> 2] = na;
+                                  break c
+                                }
+                              } while (0);
+                              E();
+                              N("Reached an unreachable!")
+                            }
+                          } else {
+                            var Pa = y, Da = p[k + (i + 4)], Oa = p[((u | 4) >> 2) + i], ib = (Oa | 0) == (Pa | 0);
+                            do {
+                              if (ib) {
+                                var $a = u + (b + 12) | 0, Sa = a[$a >> 2];
+                                if (0 == (Sa | 0)) {
+                                  var bb = u + (b + 8) | 0, cb = a[bb >> 2];
+                                  if (0 == (cb | 0)) {
+                                    var da = 0;
+                                    c = da >> 2;
+                                    break
+                                  }
+                                  var la = bb, Ma = cb
+                                } else {
+                                  la = $a, Ma = Sa, m = 73
+                                }
+                                for (; ;) {
+                                  var Na = Ma + 20 | 0, db = a[Na >> 2];
+                                  if (0 != (db | 0)) {
+                                    la = Na, Ma = db
+                                  } else {
+                                    var eb = Ma + 16 | 0, hb = p[eb >> 2];
+                                    if (0 == (hb | 0)) {
+                                      break
+                                    }
+                                    la = eb;
+                                    Ma = hb
+                                  }
+                                }
+                                la >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!"));
+                                a[la >> 2] = 0;
+                                da = Ma
+                              } else {
+                                var Za = p[i + k];
+                                Za >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!"));
+                                a[Za + 12 >> 2] = Oa;
+                                a[Oa + 8 >> 2] = Za;
+                                da = Oa
+                              }
+                              c = da >> 2
+                            } while (0);
+                            if (0 != (Da | 0)) {
+                              var tb = u + (b + 20) | 0, kb = (a[tb >> 2] << 2) + j + 304 | 0, ub = (Pa | 0) == (a[kb >> 2] | 0);
+                              do {
+                                if (ub) {
+                                  a[kb >> 2] = da;
+                                  if (0 != (da | 0)) {
+                                    break
+                                  }
+                                  a[j + 4 >> 2] &= 1 << a[tb >> 2] ^ -1;
+                                  break c
+                                }
+                                Da >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!"));
+                                var lb = Da + 16 | 0;
+                                (a[lb >> 2] | 0) == (Pa | 0) ? a[lb >> 2] = da : a[Da + 20 >> 2] = da;
+                                if (0 == (da | 0)) {
+                                  break c
+                                }
+                              } while (0);
+                              da >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!"));
+                              a[c + 6] = Da;
+                              var oa = p[k + (i + 2)];
+                              0 != (oa | 0) && (oa >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!")), a[c + 4] = oa, a[oa + 24 >> 2] = da);
+                              var Xa = p[k + (i + 3)];
+                              0 != (Xa | 0) && (Xa >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!")), a[c + 5] = Xa, a[Xa + 24 >> 2] = da)
+                            }
+                          }
+                        } while (0);
+                        a[d + 1] = X | 1;
+                        a[Ba + X >> 2] = X;
+                        if ((J | 0) != (a[j + 20 >> 2] | 0)) {
+                          var Fa = X
+                        } else {
+                          a[j + 8 >> 2] = X;
+                          break a
+                        }
+                      } else {
+                        a[Qa >> 2] = qb & -2, a[d + 1] = K | 1, Fa = a[Ba + K >> 2] = K
+                      }
+                    } while (0);
+                    if (256 > Fa >>> 0) {
+                      var Nb = Fa >>> 2 & 1073741822, mb = (Nb << 2) + j + 40 | 0, nb = p[j >> 2], Db = 1 << (Fa >>> 3);
+                      if (0 == (nb & Db | 0)) {
+                        a[j >> 2] = nb | Db;
+                        var yb = mb, zb = (Nb + 2 << 2) + j + 40 | 0
+                      } else {
+                        var ob = (Nb + 2 << 2) + j + 40 | 0, pb = p[ob >> 2];
+                        pb >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!"));
+                        yb = pb;
+                        zb = ob
+                      }
+                      a[zb >> 2] = J;
+                      a[yb + 12 >> 2] = J;
+                      a[d + 2] = yb;
+                      a[d + 3] = mb;
+                      break a
+                    }
+                    var ab = J, jb = Fa >>> 8;
+                    if (0 == (jb | 0)) {
+                      var Ha = 0
+                    } else {
+                      if (16777215 < Fa >>> 0) {
+                        Ha = 31
+                      } else {
+                        var Fb = (jb + 1048320 | 0) >>> 16 & 8, wb = jb << Fb, ca = (wb + 520192 | 0) >>> 16 & 4, xb = wb << ca, Cb = (xb + 245760 | 0) >>> 16 & 2, za = 14 - (ca | Fb | Cb) + (xb << Cb >>> 15) | 0, Ha = Fa >>> ((za + 7 | 0) >>> 0) & 1 | za << 1
+                      }
+                    }
+                    var vb = (Ha << 2) + j + 304 | 0;
+                    a[d + 7] = Ha;
+                    a[d + 5] = 0;
+                    a[d + 4] = 0;
+                    var Eb = a[j + 4 >> 2], Ob = 1 << Ha, Wb = 0 == (Eb & Ob | 0);
+                    c:do {
+                      if (Wb) {
+                        a[j + 4 >> 2] = Eb | Ob, a[vb >> 2] = ab, a[d + 6] = vb, a[d + 3] = J, a[d + 2] = J
+                      } else {
+                        for (var Ib = Fa << (31 == (Ha | 0) ? 0 : 25 - (Ha >>> 1) | 0), Jb = a[vb >> 2]; ;) {
+                          if ((a[Jb + 4 >> 2] & -8 | 0) == (Fa | 0)) {
+                            var $b = Jb + 8 | 0, Lb = p[$b >> 2], Rb = p[j + 16 >> 2], bc = Jb >>> 0 < Rb >>> 0;
+                            do {
+                              if (!bc && Lb >>> 0 >= Rb >>> 0) {
+                                a[Lb + 12 >> 2] = ab;
+                                a[$b >> 2] = ab;
+                                a[d + 2] = Lb;
+                                a[d + 3] = Jb;
+                                a[d + 6] = 0;
+                                break c
+                              }
+                            } while (0);
+                            E();
+                            N("Reached an unreachable!")
+                          }
+                          var Mb = (Ib >>> 31 << 2) + Jb + 16 | 0, Tb = p[Mb >> 2];
+                          if (0 == (Tb | 0)) {
+                            if (Mb >>> 0 >= p[j + 16 >> 2] >>> 0) {
+                              a[Mb >> 2] = ab;
+                              a[d + 6] = Jb;
+                              a[d + 3] = J;
+                              a[d + 2] = J;
+                              break c
+                            }
+                            E();
+                            N("Reached an unreachable!")
+                          }
+                          Ib <<= 1;
+                          Jb = Tb
+                        }
+                      }
+                    } while (0);
+                    var Ub = a[j + 32 >> 2] - 1 | 0;
+                    a[j + 32 >> 2] = Ub;
+                    if (0 != (Ub | 0)) {
+                      break a
+                    }
+                    var Vb = a[j + 452 >> 2], cc = 0 == (Vb | 0);
+                    c:do {
+                      if (!cc) {
+                        for (var Gb = Vb; ;) {
+                          var kc = a[Gb + 8 >> 2];
+                          if (0 == (kc | 0)) {
+                            break c
+                          }
+                          Gb = kc
+                        }
+                      }
+                    } while (0);
+                    a[j + 32 >> 2] = -1;
+                    break a
+                  }
+                }
+              }
+            }
+          } while (0);
+          E();
+          N("Reached an unreachable!")
+        }
+      } while (0)
+    }
+
+    function ig(b, c) {
+      var f, d, e, g = 4294967231 < c >>> 0;
+      a:do {
+        if (g) {
+          a[W.i >> 2] = 12;
+          var k = 0
+        } else {
+          e = f = b - 8 | 0;
+          d = (b - 4 | 0) >> 2;
+          var i = p[d], m = i & -8, q = m - 8 | 0, w = b + q | 0, x = f >>> 0 < p[j + 16 >> 2] >>> 0;
+          do {
+            if (!x) {
+              var r = i & 3;
+              if (1 != (r | 0) & -8 < (q | 0) && (f = (b + (m - 4) | 0) >> 2, 0 != (a[f] & 1 | 0))) {
+                g = 11 > c >>> 0 ? 16 : c + 11 & -8;
+                if (0 == (r | 0)) {
+                  var o = 0, A, i = a[e + 4 >> 2] & -8;
+                  A = 256 > g >>> 0 ? 0 : i >>> 0 >= (g + 4 | 0) >>> 0 && (i - g | 0) >>> 0 <= a[aa + 8 >> 2] << 1 >>> 0 ? e : 0;
+                  e = 17
+                } else {
+                  m >>> 0 < g >>> 0 ? (w | 0) != (a[j + 24 >> 2] | 0) ? e = 21 : (f = a[j + 12 >> 2] + m | 0, f >>> 0 > g >>> 0 ? (o = f - g | 0, A = b + (g - 8) | 0, a[d] = g | i & 1 | 2, a[b + (g - 4) >> 2] = o | 1, a[j + 24 >> 2] = A, a[j + 12 >> 2] = o, o = 0, A = e, e = 17) : e = 21) : (o = m - g | 0, 15 < o >>> 0 ? (a[d] = g | i & 1 | 2, a[b + (g - 4) >> 2] = o | 3, a[f] |= 1, o = b + g | 0) : o = 0, A = e, e = 17)
+                }
+                do {
+                  if (17 == e && 0 != (A | 0)) {
+                    0 != (o | 0) && hb(o);
+                    k = A + 8 | 0;
+                    break a
+                  }
+                } while (0);
+                e = Wb(c);
+                if (0 == (e | 0)) {
+                  k = 0;
+                  break a
+                }
+                d = m - (0 == (a[d] & 3 | 0) ? 8 : 4) | 0;
+                eb(e, b, d >>> 0 < c >>> 0 ? d : c);
+                hb(b);
+                k = e;
+                break a
+              }
+            }
+          } while (0);
+          E();
+          N("Reached an unreachable!")
+        }
+      } while (0);
+      return k
+    }
+
+    function eg() {
+      if (0 == (a[aa >> 2] | 0)) {
+        var b = Tg();
+        0 == (b - 1 & b | 0) ? (a[aa + 8 >> 2] = b, a[aa + 4 >> 2] = b, a[aa + 12 >> 2] = -1, a[aa + 16 >> 2] = 2097152, a[aa + 20 >> 2] = 0, a[j + 440 >> 2] = 0, a[aa >> 2] = Math.floor(Date.now() / 1e3) & -16 ^ 1431655768) : (E(), N("Reached an unreachable!"))
+      }
+    }
+
+    function Lb(b) {
+      var c, f = j + 444 | 0;
+      for (c = f >> 2; ;) {
+        var d = p[c];
+        if (d >>> 0 <= b >>> 0 && (d + a[c + 1] | 0) >>> 0 > b >>> 0) {
+          var e = f;
+          break
+        }
+        c = p[c + 2];
+        if (0 == (c | 0)) {
+          e = 0;
+          break
+        }
+        f = c;
+        c = f >> 2
+      }
+      return e
+    }
+
+    function Td(b, c) {
+      var f = b + 8 | 0, f = 0 == (f & 7 | 0) ? 0 : -f & 7, d = c - f | 0;
+      a[j + 24 >> 2] = b + f | 0;
+      a[j + 12 >> 2] = d;
+      a[f + (b + 4) >> 2] = d | 1;
+      a[c + (b + 4) >> 2] = 40;
+      a[j + 28 >> 2] = a[aa + 16 >> 2]
+    }
+
+    function fg(b, c, f) {
+      var d, e, g, k = c >> 2, i = b >> 2, m, q = b + 8 | 0, q = 0 == (q & 7 | 0) ? 0 : -q & 7;
+      e = c + 8 | 0;
+      var w = 0 == (e & 7 | 0) ? 0 : -e & 7;
+      g = w >> 2;
+      var x = c + w | 0, r = q + f | 0;
+      e = r >> 2;
+      var o = b + r | 0, A = x - (b + q) - f | 0;
+      a[(q + 4 >> 2) + i] = f | 3;
+      f = (x | 0) == (a[j + 24 >> 2] | 0);
+      a:do {
+        if (f) {
+          var t = a[j + 12 >> 2] + A | 0;
+          a[j + 12 >> 2] = t;
+          a[j + 24 >> 2] = o;
+          a[e + (i + 1)] = t | 1
+        } else {
+          if ((x | 0) == (a[j + 20 >> 2] | 0)) {
+            t = a[j + 8 >> 2] + A | 0, a[j + 8 >> 2] = t, a[j + 20 >> 2] = o, a[e + (i + 1)] = t | 1, a[(b + t + r | 0) >> 2] = t
+          } else {
+            var u = p[g + (k + 1)];
+            if (1 == (u & 3 | 0)) {
+              var t = u & -8, y = u >>> 3, v = 256 > u >>> 0;
+              b:do {
+                if (v) {
+                  var F = p[((w | 8) >> 2) + k], H = p[g + (k + 3)];
+                  if ((F | 0) == (H | 0)) {
+                    a[j >> 2] &= 1 << y ^ -1
+                  } else {
+                    var C = ((u >>> 2 & 1073741822) << 2) + j + 40 | 0;
+                    m = (F | 0) == (C | 0) ? 15 : F >>> 0 < p[j + 16 >> 2] >>> 0 ? 18 : 15;
+                    do {
+                      if (15 == m && !((H | 0) != (C | 0) && H >>> 0 < p[j + 16 >> 2] >>> 0)) {
+                        a[F + 12 >> 2] = H;
+                        a[H + 8 >> 2] = F;
+                        break b
+                      }
+                    } while (0);
+                    E();
+                    N("Reached an unreachable!")
+                  }
+                } else {
+                  m = x;
+                  F = p[((w | 24) >> 2) + k];
+                  H = p[g + (k + 3)];
+                  C = (H | 0) == (m | 0);
+                  do {
+                    if (C) {
+                      d = w | 16;
+                      var D = d + (c + 4) | 0, B = a[D >> 2];
+                      if (0 == (B | 0)) {
+                        if (d = c + d | 0, B = a[d >> 2], 0 == (B | 0)) {
+                          B = 0;
+                          d = B >> 2;
+                          break
+                        }
+                      } else {
+                        d = D
+                      }
+                      for (; ;) {
+                        var D = B + 20 | 0, I = a[D >> 2];
+                        if (0 == (I | 0) && (D = B + 16 | 0, I = p[D >> 2], 0 == (I | 0))) {
+                          break
+                        }
+                        d = D;
+                        B = I
+                      }
+                      d >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!"));
+                      a[d >> 2] = 0
+                    } else {
+                      d = p[((w | 8) >> 2) + k], d >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!")), a[d + 12 >> 2] = H, a[H + 8 >> 2] = d, B = H
+                    }
+                    d = B >> 2
+                  } while (0);
+                  if (0 != (F | 0)) {
+                    H = w + (c + 28) | 0;
+                    C = (a[H >> 2] << 2) + j + 304 | 0;
+                    D = (m | 0) == (a[C >> 2] | 0);
+                    do {
+                      if (D) {
+                        a[C >> 2] = B;
+                        if (0 != (B | 0)) {
+                          break
+                        }
+                        a[j + 4 >> 2] &= 1 << a[H >> 2] ^ -1;
+                        break b
+                      }
+                      F >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!"));
+                      I = F + 16 | 0;
+                      (a[I >> 2] | 0) == (m | 0) ? a[I >> 2] = B : a[F + 20 >> 2] = B;
+                      if (0 == (B | 0)) {
+                        break b
+                      }
+                    } while (0);
+                    B >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!"));
+                    a[d + 6] = F;
+                    m = w | 16;
+                    F = p[(m >> 2) + k];
+                    0 != (F | 0) && (F >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!")), a[d + 4] = F, a[F + 24 >> 2] = B);
+                    m = p[(m + 4 >> 2) + k];
+                    0 != (m | 0) && (m >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!")), a[d + 5] = m, a[m + 24 >> 2] = B)
+                  }
+                }
+              } while (0);
+              u = c + (t | w) | 0;
+              t = t + A | 0
+            } else {
+              u = x, t = A
+            }
+            u = u + 4 | 0;
+            a[u >> 2] &= -2;
+            a[e + (i + 1)] = t | 1;
+            a[(t >> 2) + i + e] = t;
+            if (256 > t >>> 0) {
+              y = t >>> 2 & 1073741822, u = (y << 2) + j + 40 | 0, v = p[j >> 2], t = 1 << (t >>> 3), 0 == (v & t | 0) ? (a[j >> 2] = v | t, t = u, y = (y + 2 << 2) + j + 40 | 0) : (y = (y + 2 << 2) + j + 40 | 0, t = p[y >> 2], t >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!"))), a[y >> 2] = o, a[t + 12 >> 2] = o, a[e + (i + 2)] = t, a[e + (i + 3)] = u
+            } else {
+              if (u = o, v = t >>> 8, 0 == (v | 0) ? y = 0 : 16777215 < t >>> 0 ? y = 31 : (y = (v + 1048320 | 0) >>> 16 & 8, m = v << y, v = (m + 520192 | 0) >>> 16 & 4, m <<= v, F = (m + 245760 | 0) >>> 16 & 2, y = 14 - (v | y | F) + (m << F >>> 15) | 0, y = t >>> ((y + 7 | 0) >>> 0) & 1 | y << 1), v = (y << 2) + j + 304 | 0, a[e + (i + 7)] = y, m = r + (b + 16) | 0, a[e + (i + 5)] = 0, a[m >> 2] = 0, m = a[j + 4 >> 2], F = 1 << y, 0 == (m & F | 0)) {
+                a[j + 4 >> 2] = m | F, a[v >> 2] = u, a[e + (i + 6)] = v, a[e + (i + 3)] = u, a[e + (i + 2)] = u
+              } else {
+                y = t << (31 == (y | 0) ? 0 : 25 - (y >>> 1) | 0);
+                for (v = a[v >> 2]; ;) {
+                  if ((a[v + 4 >> 2] & -8 | 0) == (t | 0)) {
+                    m = v + 8 | 0;
+                    F = p[m >> 2];
+                    H = p[j + 16 >> 2];
+                    C = v >>> 0 < H >>> 0;
+                    do {
+                      if (!C && F >>> 0 >= H >>> 0) {
+                        a[F + 12 >> 2] = u;
+                        a[m >> 2] = u;
+                        a[e + (i + 2)] = F;
+                        a[e + (i + 3)] = v;
+                        a[e + (i + 6)] = 0;
+                        break a
+                      }
+                    } while (0);
+                    E();
+                    N("Reached an unreachable!")
+                  }
+                  m = (y >>> 31 << 2) + v + 16 | 0;
+                  F = p[m >> 2];
+                  if (0 == (F | 0)) {
+                    if (m >>> 0 >= p[j + 16 >> 2] >>> 0) {
+                      a[m >> 2] = u;
+                      a[e + (i + 6)] = v;
+                      a[e + (i + 3)] = u;
+                      a[e + (i + 2)] = u;
+                      break a
+                    }
+                    E();
+                    N("Reached an unreachable!")
+                  }
+                  y <<= 1;
+                  v = F
+                }
+              }
+            }
+          }
+        }
+      } while (0);
+      return b + (q | 8) | 0
+    }
+
+    function jg(b) {
+      a[b >> 2] = Ud + 8 | 0
+    }
+
+    function te(a) {
+      Ug(a | 0)
+    }
+
+    function gg(b, c) {
+      var f, d, e = p[j + 24 >> 2];
+      d = e >> 2;
+      var g = Lb(e), k = a[g >> 2];
+      f = a[g + 4 >> 2];
+      var g = k + f | 0, i = k + (f - 39) | 0, k = k + (f - 47) + (0 == (i & 7 | 0) ? 0 : -i & 7) | 0, k = k >>> 0 < (e + 16 | 0) >>> 0 ? e : k, i = k + 8 | 0;
+      f = i >> 2;
+      Td(b, c - 40 | 0);
+      a[(k + 4 | 0) >> 2] = 27;
+      a[f] = a[j + 444 >> 2];
+      a[f + 1] = a[j + 448 >> 2];
+      a[f + 2] = a[j + 452 >> 2];
+      a[f + 3] = a[j + 456 >> 2];
+      a[j + 444 >> 2] = b;
+      a[j + 448 >> 2] = c;
+      a[j + 456 >> 2] = 0;
+      a[j + 452 >> 2] = i;
+      f = k + 28 | 0;
+      a[f >> 2] = 7;
+      i = (k + 32 | 0) >>> 0 < g >>> 0;
+      a:do {
+        if (i) {
+          for (var m = f; ;) {
+            var q = m + 4 | 0;
+            a[q >> 2] = 7;
+            if ((m + 8 | 0) >>> 0 >= g >>> 0) {
+              break a
+            }
+            m = q
+          }
+        }
+      } while (0);
+      g = (k | 0) == (e | 0);
+      a:do {
+        if (!g) {
+          if (f = k - e | 0, i = e + f | 0, m = f + (e + 4) | 0, a[m >> 2] &= -2, a[d + 1] = f | 1, a[i >> 2] = f, 256 > f >>> 0) {
+            m = f >>> 2 & 1073741822, i = (m << 2) + j + 40 | 0, q = p[j >> 2], f = 1 << (f >>> 3), 0 == (q & f | 0) ? (a[j >> 2] = q | f, f = i, m = (m + 2 << 2) + j + 40 | 0) : (m = (m + 2 << 2) + j + 40 | 0, f = p[m >> 2], f >>> 0 < p[j + 16 >> 2] >>> 0 && (E(), N("Reached an unreachable!"))), a[m >> 2] = e, a[f + 12 >> 2] = e, a[d + 2] = f, a[d + 3] = i
+          } else {
+            i = e;
+            q = f >>> 8;
+            if (0 == (q | 0)) {
+              m = 0
+            } else {
+              if (16777215 < f >>> 0) {
+                m = 31
+              } else {
+                var m = (q + 1048320 | 0) >>> 16 & 8, w = q << m, q = (w + 520192 | 0) >>> 16 & 4, w = w << q, x = (w + 245760 | 0) >>> 16 & 2, m = 14 - (q | m | x) + (w << x >>> 15) | 0, m = f >>> ((m + 7 | 0) >>> 0) & 1 | m << 1
+              }
+            }
+            q = (m << 2) + j + 304 | 0;
+            a[d + 7] = m;
+            a[d + 5] = 0;
+            a[d + 4] = 0;
+            w = a[j + 4 >> 2];
+            x = 1 << m;
+            if (0 == (w & x | 0)) {
+              a[j + 4 >> 2] = w | x, a[q >> 2] = i, a[d + 6] = q, a[d + 3] = e, a[d + 2] = e
+            } else {
+              m = f << (31 == (m | 0) ? 0 : 25 - (m >>> 1) | 0);
+              for (q = a[q >> 2]; ;) {
+                if ((a[q + 4 >> 2] & -8 | 0) == (f | 0)) {
+                  var w = q + 8 | 0, x = p[w >> 2], r = p[j + 16 >> 2], o = q >>> 0 < r >>> 0;
+                  do {
+                    if (!o && x >>> 0 >= r >>> 0) {
+                      a[x + 12 >> 2] = i;
+                      a[w >> 2] = i;
+                      a[d + 2] = x;
+                      a[d + 3] = q;
+                      a[d + 6] = 0;
+                      break a
+                    }
+                  } while (0);
+                  E();
+                  N("Reached an unreachable!")
+                }
+                w = (m >>> 31 << 2) + q + 16 | 0;
+                x = p[w >> 2];
+                if (0 == (x | 0)) {
+                  if (w >>> 0 >= p[j + 16 >> 2] >>> 0) {
+                    a[w >> 2] = i;
+                    a[d + 6] = q;
+                    a[d + 3] = e;
+                    a[d + 2] = e;
+                    break a
+                  }
+                  E();
+                  N("Reached an unreachable!")
+                }
+                m <<= 1;
+                q = x
+              }
+            }
+          }
+        }
+      } while (0)
+    }
+
+    function W(b) {
+      W.i || (W.i = d([0], "i32", e));
+      return a[W.i >> 2] = b
+    }
+
+    function Vd(a, b, c) {
+      var d = A.a[a];
+      if (d) {
+        if (d.q) {
+          if (0 > c) {
+            return W(Ba), -1
+          }
+          if (d.object.e) {
+            if (d.object.f) {
+              for (var e = 0; e < c; e++) {
+                try {
+                  d.object.f(q[b + e])
+                } catch (g) {
+                  return W(Cb), -1
+                }
+              }
+              d.object.timestamp = Date.now();
+              return e
+            }
+            W(Vb);
+            return-1
+          }
+          e = d.position;
+          a = A.a[a];
+          if (!a || a.object.e) {
+            W(Nb), b = -1
+          } else {
+            if (a.q) {
+              if (a.object.h) {
+                W(Ub), b = -1
+              } else {
+                if (0 > c || 0 > e) {
+                  W(Ba), b = -1
+                } else {
+                  for (var k = a.object.b; k.length < e;) {
+                    k.push(0)
+                  }
+                  for (var i = 0; i < c; i++) {
+                    k[e + i] = F[b + i]
+                  }
+                  a.object.timestamp = Date.now();
+                  b = i
+                }
+              }
+            } else {
+              W(Ia), b = -1
+            }
+          }
+          -1 != b && (d.position += b);
+          return b
+        }
+        W(Ia);
+        return-1
+      }
+      W(Nb);
+      return-1
+    }
+
+    function cf(b, c) {
+      function f(b) {
+        var f;
+        "double" === b ? f = (cc[0] = a[c + e >> 2], cc[1] = a[c + e + 4 >> 2], Ob[0]) : "i64" == b ? f = [a[c + e >> 2], a[c + e + 4 >> 2]] : (b = "i32", f = a[c + e >> 2]);
+        e += M.Ke(b);
+        return f
+      }
+
+      for (var d = b, e = 0, g = [], k, i; ;) {
+        var j = d;
+        k = q[d];
+        if (0 === k) {
+          break
+        }
+        i = q[d + 1];
+        if (37 == k) {
+          var m = Y, p = Y, w = Y, r = Y;
+          a:for (; ;) {
+            switch (i) {
+              case 43:
+                m = V;
+                break;
+              case 45:
+                p = V;
+                break;
+              case 35:
+                w = V;
+                break;
+              case 48:
+                if (r) {
+                  break a
+                } else {
+                  r = V;
+                  break
+                }
+                ;
+              default:
+                break a
+            }
+            d++;
+            i = q[d + 1]
+          }
+          var o = 0;
+          if (42 == i) {
+            o = f("i32"), d++, i = q[d + 1]
+          } else {
+            for (; 48 <= i && 57 >= i;) {
+              o = 10 * o + (i - 48), d++, i = q[d + 1]
+            }
+          }
+          var x = Y;
+          if (46 == i) {
+            var t = 0, x = V;
+            d++;
+            i = q[d + 1];
+            if (42 == i) {
+              t = f("i32"), d++
+            } else {
+              for (; ;) {
+                i = q[d + 1];
+                if (48 > i || 57 < i) {
+                  break
+                }
+                t = 10 * t + (i - 48);
+                d++
+              }
+            }
+            i = q[d + 1]
+          } else {
+            t = 6
+          }
+          var u;
+          switch (String.fromCharCode(i)) {
+            case"h":
+              i = q[d + 2];
+              104 == i ? (d++, u = 1) : u = 2;
+              break;
+            case"l":
+              i = q[d + 2];
+              108 == i ? (d++, u = 8) : u = 4;
+              break;
+            case"L":
+            case"q":
+            case"j":
+              u = 8;
+              break;
+            case"z":
+            case"t":
+            case"I":
+              u = 4;
+              break;
+            default:
+              u = Sc
+          }
+          u && d++;
+          i = q[d + 1];
+          if (-1 != "d,i,u,o,x,X,p".split(",").indexOf(String.fromCharCode(i))) {
+            j = 100 == i || 105 == i;
+            u = u || 4;
+            var y = k = f("i" + 8 * u), v;
+            8 == u && (k = M.Qe(k[0], k[1], 117 == i));
+            4 >= u && (k = (j ? af : ce)(k & Math.pow(256, u) - 1, 8 * u));
+            var A = Math.abs(k), j = "";
+            if (100 == i || 105 == i) {
+              v = 8 == u && Wd ? Wd.stringify(y[0], y[1]) : af(k, 8 * u).toString(10)
+            } else {
+              if (117 == i) {
+                v = 8 == u && Wd ? Wd.stringify(y[0], y[1], V) : ce(k, 8 * u).toString(10), k = Math.abs(k)
+              } else {
+                if (111 == i) {
+                  v = (w ? "0" : "") + A.toString(8)
+                } else {
+                  if (120 == i || 88 == i) {
+                    j = w ? "0x" : "";
+                    if (0 > k) {
+                      k = -k;
+                      v = (A - 1).toString(16);
+                      w = [];
+                      for (y = 0; y < v.length; y++) {
+                        w.push((15 - parseInt(v[y], 16)).toString(16))
+                      }
+                      for (v = w.join(""); v.length < 2 * u;) {
+                        v = "f" + v
+                      }
+                    } else {
+                      v = A.toString(16)
+                    }
+                    88 == i && (j = j.toUpperCase(), v = v.toUpperCase())
+                  } else {
+                    112 == i && (0 === A ? v = "(nil)" : (j = "0x", v = A.toString(16)))
+                  }
+                }
+              }
+            }
+            if (x) {
+              for (; v.length < t;) {
+                v = "0" + v
+              }
+            }
+            for (m && (j = 0 > k ? "-" + j : "+" + j); j.length + v.length < o;) {
+              p ? v += " " : r ? v = "0" + v : j = " " + j
+            }
+            v = j + v;
+            v.split("").forEach((function (a) {
+              g.push(a.charCodeAt(0))
+            }))
+          } else {
+            if (-1 != "f,F,e,E,g,G".split(",").indexOf(String.fromCharCode(i))) {
+              k = f("double");
+              if (isNaN(k)) {
+                v = "nan", r = Y
+              } else {
+                if (isFinite(k)) {
+                  x = Y;
+                  u = Math.min(t, 20);
+                  if (103 == i || 71 == i) {
+                    x = V, t = t || 1, u = parseInt(k.toExponential(u).split("e")[1], 10), t > u && -4 <= u ? (i = (103 == i ? "f" : "F").charCodeAt(0), t -= u + 1) : (i = (103 == i ? "e" : "E").charCodeAt(0), t--), u = Math.min(t, 20)
+                  }
+                  if (101 == i || 69 == i) {
+                    v = k.toExponential(u), /[eE][-+]\d$/.test(v) && (v = v.slice(0, -1) + "0" + v.slice(-1))
+                  } else {
+                    if (102 == i || 70 == i) {
+                      v = k.toFixed(u)
+                    }
+                  }
+                  j = v.split("e");
+                  if (x && !w) {
+                    for (; 1 < j[0].length && -1 != j[0].indexOf(".") && ("0" == j[0].slice(-1) || "." == j[0].slice(-1));) {
+                      j[0] = j[0].slice(0, -1)
+                    }
+                  } else {
+                    for (w && -1 == v.indexOf(".") && (j[0] += "."); t > u++;) {
+                      j[0] += "0"
+                    }
+                  }
+                  v = j[0] + (1 < j.length ? "e" + j[1] : "");
+                  69 == i && (v = v.toUpperCase());
+                  m && 0 <= k && (v = "+" + v)
+                } else {
+                  v = (0 > k ? "-" : "") + "inf", r = Y
+                }
+              }
+              for (; v.length < o;) {
+                v = p ? v + " " : r && ("-" == v[0] || "+" == v[0]) ? v[0] + "0" + v.slice(1) : (r ? "0" : " ") + v
+              }
+              97 > i && (v = v.toUpperCase());
+              v.split("").forEach((function (a) {
+                g.push(a.charCodeAt(0))
+              }))
+            } else {
+              if (115 == i) {
+                (m = f("i8*")) ? (m = $e(m), x && m.length > t && (m = m.slice(0, t))) : m = db("(null)", V);
+                if (!p) {
+                  for (; m.length < o--;) {
+                    g.push(32)
+                  }
+                }
+                g = g.concat(m);
+                if (p) {
+                  for (; m.length < o--;) {
+                    g.push(32)
+                  }
+                }
+              } else {
+                if (99 == i) {
+                  for (p && g.push(f("i8")); 0 < --o;) {
+                    g.push(32)
+                  }
+                  p || g.push(f("i8"))
+                } else {
+                  if (110 == i) {
+                    p = f("i32*"), a[p >> 2] = g.length
+                  } else {
+                    if (37 == i) {
+                      g.push(k)
+                    } else {
+                      for (y = j; y < d + 2; y++) {
+                        g.push(q[y])
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          d += 2
+        } else {
+          g.push(k), d += 1
+        }
+      }
+      return g
+    }
+
+    function bc(a, b, c) {
+      var e = cf(b, c), b = M.I();
+      c = d(e, "i8", kg);
+      e = 1 * e.length;
+      0 != e && -1 == Vd(a, c, e) && A.a[a] && (A.a[a].error = V);
+      M.ga(b)
+    }
+
+    function eb(b, c, f) {
+      if (20 <= f && c % 2 == b % 2) {
+        if (c % 4 == b % 4) {
+          for (f = c + f; c % 4;) {
+            q[b++] = q[c++]
+          }
+          for (var c = c >> 2, b = b >> 2, d = f >> 2; c < d;) {
+            a[b++] = a[c++]
+          }
+          c <<= 2;
+          for (b <<= 2; c < f;) {
+            q[b++] = q[c++]
+          }
+        } else {
+          f = c + f;
+          c % 2 && (q[b++] = q[c++]);
+          c >>= 1;
+          b >>= 1;
+          for (d = f >> 1; c < d;) {
+            ja[b++] = ja[c++]
+          }
+          c <<= 1;
+          b <<= 1;
+          c < f && (q[b++] = q[c++])
+        }
+      } else {
+        for (; f--;) {
+          q[b++] = q[c++]
+        }
+      }
+    }
+
+    function Xd(a) {
+      function b(a) {
+        a in A.a && A.a[a].object.f && (A.a[a].D || A.a[a].object.f(Sc))
+      }
+
+      try {
+        if (0 === a) {
+          for (var c in A.a) {
+            b(c)
+          }
+        } else {
+          b(a)
+        }
+      } catch (d) {
+        W(Cb)
+      }
+    }
+
+    function ea(b, c, f) {
+      if (20 <= f) {
+        for (f = b + f; b % 4;) {
+          q[b++] = c
+        }
+        0 > c && (c += 256);
+        for (var b = b >> 2, d = f >> 2, e = c | c << 8 | c << 16 | c << 24; b < d;) {
+          a[b++] = e
+        }
+        for (b <<= 2; b < f;) {
+          q[b++] = c
+        }
+      } else {
+        for (; f--;) {
+          q[b++] = c
+        }
+      }
+    }
+
+    function E() {
+      N("abort() at " + Error().stack)
+    }
+
+    function Tg() {
+      switch (8) {
+        case 8:
+          return Vg;
+        case 54:
+        case 56:
+        case 21:
+        case 61:
+        case 63:
+        case 22:
+        case 67:
+        case 23:
+        case 24:
+        case 25:
+        case 26:
+        case 27:
+        case 69:
+        case 28:
+        case 101:
+        case 70:
+        case 71:
+        case 29:
+        case 30:
+        case 199:
+        case 75:
+        case 76:
+        case 32:
+        case 43:
+        case 44:
+        case 80:
+        case 46:
+        case 47:
+        case 45:
+        case 48:
+        case 49:
+        case 42:
+        case 82:
+        case 33:
+        case 7:
+        case 108:
+        case 109:
+        case 107:
+        case 112:
+        case 119:
+        case 121:
+          return 200809;
+        case 13:
+        case 104:
+        case 94:
+        case 95:
+        case 34:
+        case 35:
+        case 77:
+        case 81:
+        case 83:
+        case 84:
+        case 85:
+        case 86:
+        case 87:
+        case 88:
+        case 89:
+        case 90:
+        case 91:
+        case 94:
+        case 95:
+        case 110:
+        case 111:
+        case 113:
+        case 114:
+        case 115:
+        case 116:
+        case 117:
+        case 118:
+        case 120:
+        case 40:
+        case 16:
+        case 79:
+        case 19:
+          return-1;
+        case 92:
+        case 93:
+        case 5:
+        case 72:
+        case 6:
+        case 74:
+        case 92:
+        case 93:
+        case 96:
+        case 97:
+        case 98:
+        case 99:
+        case 102:
+        case 103:
+        case 105:
+          return 1;
+        case 38:
+        case 66:
+        case 50:
+        case 51:
+        case 4:
+          return 1024;
+        case 15:
+        case 64:
+        case 41:
+          return 32;
+        case 55:
+        case 37:
+        case 17:
+          return 2147483647;
+        case 18:
+        case 1:
+          return 47839;
+        case 59:
+        case 57:
+          return 99;
+        case 68:
+        case 58:
+          return 2048;
+        case 0:
+          return 2097152;
+        case 3:
+          return 65536;
+        case 14:
+          return 32768;
+        case 73:
+          return 32767;
+        case 39:
+          return 16384;
+        case 60:
+          return 1e3;
+        case 106:
+          return 700;
+        case 52:
+          return 256;
+        case 62:
+          return 255;
+        case 2:
+          return 100;
+        case 65:
+          return 64;
+        case 36:
+          return 20;
+        case 100:
+          return 16;
+        case 20:
+          return 6;
+        case 53:
+          return 4
+      }
+      W(Ba);
+      return-1
+    }
+
+    function ib(a) {
+      var b = ib;
+      b.Fe || (Aa = Aa + 4095 >> 12 << 12, b.Fe = V);
+      b = Aa;
+      0 != a && M.ha(a);
+      return b
+    }
+
+    function lg() {
+      return a[lg.Ce >> 2]
+    }
+
+    function Mb(a, b) {
+      var c = ce(a & 255);
+      q[Mb.i] = c;
+      return-1 == Vd(b, Mb.i, 1) ? (b in A.a && (A.a[b].error = V), -1) : c
+    }
+
+    function hf(b) {
+      var c = a[$a >> 2];
+      0 > Vd(c, b, oc(b)) || Mb(10, c)
+    }
+
+    function mg(a) {
+      a = a || x.arguments;
+      x.setStatus && x.setStatus("");
+      x.preRun && x.preRun();
+      var b = Sc;
+      x._main && (wb(ng), b = x.Ee(a), x.noExitRuntime || (wb(Yd), og.print()));
+      x.postRun && x.postRun();
+      return b
+    }
+
+    try {
+      this.Module = x
+    } catch (Zg) {
+      this.Module = x = {}
+    }
+    var pg = "object" === typeof process, qg = "object" === typeof window, rg = "function" === typeof importScripts, Wg = !qg && !pg && !rg;
+    if (pg) {
+      x.print = (function (a) {
+        process.stdout.write(a + "\n")
+      });
+      x.printErr = (function (a) {
+        process.stderr.write(a + "\n")
+      });
+      var sg = require("fs"), tg = require("path");
+      x.read = (function (a) {
+        var a = tg.normalize(a), b = sg.readFileSync(a).toString();
+        !b && a != tg.resolve(a) && (a = path.join(__dirname, "..", "src", a), b = sg.readFileSync(a).toString());
+        return b
+      });
+      x.load = (function (a) {
+        oa(read(a))
+      });
+      x.arguments || (x.arguments = process.argv.slice(2))
+    } else {
+      Wg ? (x.print = print, x.printErr = printErr, x.read = "undefined" != typeof read ? read : (function (a) {
+        snarf(a)
+      }), x.arguments || ("undefined" != typeof scriptArgs ? x.arguments = scriptArgs : "undefined" != typeof arguments && (x.arguments = arguments))) : qg ? (x.print || (x.print = (function (a) {
+        console.log(a)
+      })), x.printErr || (x.printErr = (function (a) {
+        console.log(a)
+      })), x.read = (function (a) {
+        var b = new XMLHttpRequest;
+        b.open("GET", a, Y);
+        b.send(Sc);
+        return b.responseText
+      }), x.arguments || "undefined" != typeof arguments && (x.arguments = arguments)) : rg ? x.load = importScripts : N("Unknown runtime environment. Where are we?")
+    }
+    "undefined" == !x.load && x.read && (x.load = (function (a) {
+      oa(x.read(a))
+    }));
+    x.printErr || (x.printErr = (function () {
+    }));
+    x.print || (x.print = x.printErr);
+    x.arguments || (x.arguments = []);
+    var M = {I:(function () {
+      return b
+    }), ga:(function (a) {
+      b = a
+    }), uf:(function (a, b) {
+      b = b || 4;
+      if (1 == b) {
+        return a
+      }
+      if (isNumber(a) && isNumber(b)) {
+        return Math.ceil(a / b) * b
+      }
+      if (isNumber(b) && isPowerOfTwo(b)) {
+        var c = log2(b);
+        return"((((" + a + ")+" + (b - 1) + ")>>" + c + ")<<" + c + ")"
+      }
+      return"Math.ceil((" + a + ")/" + b + ")*" + b
+    }), Me:(function (a) {
+      return a in M.ka || a in M.ja
+    }), Ne:(function (a) {
+      return"*" == a[a.length - 1]
+    }), Pe:(function (a) {
+      return isPointerType(a) ? Y : /^\[\d+\ x\ (.*)\]/.test(a) || /<?{ ?[^}]* ?}>?/.test(a) ? V : "%" == a[0]
+    }), ka:{i1:0, i8:0, i16:0, i32:0, i64:0}, ja:{"float":0, "double":0}, pf:(function (a, b, c, d) {
+      var e = Math.pow(2, d) - 1;
+      if (32 > d) {
+        switch (c) {
+          case"shl":
+            return[a << d, b << d | (a & e << 32 - d) >>> 32 - d];
+          case"ashr":
+            return[(a >>> d | (b & e) << 32 - d) >> 0 >>> 0, b >> d >>> 0];
+          case"lshr":
+            return[(a >>> d | (b & e) << 32 - d) >>> 0, b >>> d]
+        }
+      } else {
+        if (32 == d) {
+          switch (c) {
+            case"shl":
+              return[0, a];
+            case"ashr":
+              return[b, 0 > (b | 0) ? e : 0];
+            case"lshr":
+              return[b, 0]
+          }
+        } else {
+          switch (c) {
+            case"shl":
+              return[0, a << d - 32];
+            case"ashr":
+              return[b >> d - 32 >>> 0, 0 > (b | 0) ? e : 0];
+            case"lshr":
+              return[b >>> d - 32, 0]
+          }
+        }
+      }
+      mb("unknown bitshift64 op: " + [value, c, d])
+    }), zf:(function (a, b) {
+      return(a | 0 | b | 0) + 4294967296 * (Math.round(a / 4294967296) | Math.round(b / 4294967296))
+    }), of:(function (a, b) {
+      return((a | 0) & (b | 0)) + 4294967296 * (Math.round(a / 4294967296) & Math.round(b / 4294967296))
+    }), Gf:(function (a, b) {
+      return((a | 0) ^ (b | 0)) + 4294967296 * (Math.round(a / 4294967296) ^ Math.round(b / 4294967296))
+    }), B:(function (a) {
+      if (1 == M.k) {
+        return 1
+      }
+      var b = {"%i1":1, "%i8":1, "%i16":2, "%i32":4, "%i64":8, "%float":4, "%double":8}["%" + a];
+      b || ("*" == a[a.length - 1] ? b = M.k : "i" == a[0] && (a = parseInt(a.substr(1)), cb(0 == a % 8), b = a / 8));
+      return b
+    }), Ke:(function (a) {
+      return Math.max(M.B(a), M.k)
+    }), Ie:(function (a, b) {
+      var c = {};
+      return b ? a.filter((function (a) {
+        return c[a[b]] ? Y : c[a[b]] = V
+      })) : a.filter((function (a) {
+        return c[a] ? Y : c[a] = V
+      }))
+    }), set:(function () {
+      for (var a = "object" === typeof arguments[0] ? arguments[0] : arguments, b = {}, c = 0; c < a.length; c++) {
+        b[a[c]] = 0
+      }
+      return b
+    }), De:(function (a) {
+      a.g = 0;
+      a.m = 0;
+      var b = [], c = -1;
+      a.aa = a.z.map((function (d) {
+        var e, g;
+        M.Me(d) || M.Ne(d) ? g = e = M.B(d) : M.Pe(d) ? (e = Types.types[d].g, g = Types.types[d].m) : N("Unclear type in struct: " + d + ", in " + a.Re + " :: " + dump(Types.types[a.Re]));
+        g = a.Af ? 1 : Math.min(g, M.k);
+        a.m = Math.max(a.m, g);
+        d = M.l(a.g, g);
+        a.g = d + e;
+        0 <= c && b.push(d - c);
+        return c = d
+      }));
+      a.g = M.l(a.g, a.m);
+      0 == b.length ? a.$ = a.g : 1 == M.Ie(b).length && (a.$ = b[0]);
+      a.xf = 1 != a.$;
+      return a.aa
+    }), Je:(function (a, b, c) {
+      var d, e;
+      if (b) {
+        c = c || 0;
+        d = ("undefined" === typeof Types ? M.Ff : Types.types)[b];
+        if (!d) {
+          return Sc
+        }
+        cb(d.z.length === a.length, "Number of named fields must match the type for " + b);
+        e = d.aa
+      } else {
+        d = {z:a.map((function (a) {
+          return a[0]
+        }))}, e = M.De(d)
+      }
+      var g = {Ve:d.g};
+      b ? a.forEach((function (a, b) {
+        if ("string" === typeof a) {
+          g[a] = e[b] + c
+        } else {
+          var h, j;
+          for (j in a) {
+            h = j
+          }
+          g[h] = M.Je(a[h], d.z[b], e[b])
+        }
+      })) : a.forEach((function (a, b) {
+        g[a[1]] = e[b]
+      }));
+      return g
+    }), nf:(function (a) {
+      var b = Q.length;
+      Q.push(a);
+      Q.push(0);
+      return b
+    }), H:(function (a) {
+      var c = b;
+      b += a;
+      b = b + 3 >> 2 << 2;
+      return c
+    }), ha:(function (b) {
+      var c = Aa;
+      Aa += b;
+      Aa = Aa + 3 >> 2 << 2;
+      if (Aa >= ab) {
+        for (; ab <= Aa;) {
+          ab = 2 * ab + 4095 >> 12 << 12
+        }
+        var b = q, d = new ArrayBuffer(ab);
+        q = new Int8Array(d);
+        ja = new Int16Array(d);
+        a = new Int32Array(d);
+        F = new Uint8Array(d);
+        Da = new Uint16Array(d);
+        p = new Uint32Array(d);
+        nb = new Float32Array(d);
+        jb = new Float64Array(d);
+        q.set(b)
+      }
+      return c
+    }), l:(function (a, b) {
+      return Math.ceil(a / (b ? b : 4)) * (b ? b : 4)
+    }), Qe:(function (a, b, c) {
+      return c ? (a >>> 0) + 4294967296 * (b >>> 0) : (a >>> 0) + 4294967296 * (b | 0)
+    }), k:4, Ue:0}, og = {la:0, U:0, Cf:{}, yf:(function (a, b) {
+      b || (this.U++, this.U >= this.la && mb("\n\nToo many corrections!"))
+    }), print:(function () {
+    })}, ed = 0, c, Kg = this;
+    x.ccall = Ue;
+    x.cwrap = vb;
+    x.setValue = Ye;
+    x.getValue = (function (b, c) {
+      c = c || "i8";
+      "*" === c[c.length - 1] && (c = "i32");
+      switch (c) {
+        case"i1":
+          return q[b];
+        case"i8":
+          return q[b];
+        case"i16":
+          return ja[b >> 1];
+        case"i32":
+          return a[b >> 2];
+        case"i64":
+          return a[b >> 2];
+        case"float":
+          return nb[b >> 2];
+        case"double":
+          return cc[0] = a[b >> 2], cc[1] = a[b + 4 >> 2], Ob[0];
+        default:
+          mb("invalid type for setValue: " + c)
+      }
+      return Sc
+    });
+    var kg = 1, e = 2;
+    x.ALLOC_NORMAL = 0;
+    x.ALLOC_STACK = kg;
+    x.ALLOC_STATIC = e;
+    x.allocate = d;
+    x.Pointer_stringify = Xe;
+    x.Array_stringify = (function (a) {
+      for (var b = "", c = 0; c < a.length; c++) {
+        b += String.fromCharCode(a[c])
+      }
+      return b
+    });
+    var Q, Vg = 4096, q, F, ja, Da, a, p, nb, jb, b, Zd, Aa, Xg = x.TOTAL_STACK || 5242880, ab = x.TOTAL_MEMORY || 10485760;
+    cb(!!Int32Array && !!Float64Array && !!(new Int32Array(1)).subarray && !!(new Int32Array(1)).set, "Cannot fallback to non-typed array case: Code is too specialized");
+    var Ha = new ArrayBuffer(ab);
+    q = new Int8Array(Ha);
+    ja = new Int16Array(Ha);
+    a = new Int32Array(Ha);
+    F = new Uint8Array(Ha);
+    Da = new Uint16Array(Ha);
+    p = new Uint32Array(Ha);
+    nb = new Float32Array(Ha);
+    jb = new Float64Array(Ha);
+    a[0] = 255;
+    cb(255 === F[0] && 0 === F[3], "Typed arrays 2 must be run on a little-endian system");
+    var $d = db("(null)");
+    Aa = $d.length;
+    for (var Tb = 0; Tb < $d.length; Tb++) {
+      q[Tb] = $d[Tb]
+    }
+    x.HEAP = ua;
+    x.HEAP8 = q;
+    x.HEAP16 = ja;
+    x.HEAP32 = a;
+    x.HEAPU8 = F;
+    x.HEAPU16 = Da;
+    x.HEAPU32 = p;
+    x.HEAPF32 = nb;
+    x.HEAPF64 = jb;
+    Zd = (b = M.l(Aa)) + Xg;
+    var yc = M.l(Zd, 8);
+    q.subarray(yc);
+    var cc = a.subarray(yc >> 2);
+    nb.subarray(yc >> 2);
+    var Ob = jb.subarray(yc >> 3);
+    Zd = yc + 8;
+    Aa = Zd + 4095 >> 12 << 12;
+    var ug = [], ng = [], Yd = [];
+    x.Array_copy = Ze;
+    x.TypedArray_copy = (function (a, b, c) {
+      c === ua && (c = 0);
+      for (var d = new Uint8Array(b - c), e = c; e < b; ++e) {
+        d[e - c] = q[a + e]
+      }
+      return d.buffer
+    });
+    x.String_len = oc;
+    x.String_copy = $e;
+    x.intArrayFromString = db;
+    x.intArrayToString = (function (a) {
+      for (var b = [], c = 0; c < a.length; c++) {
+        var d = a[c];
+        255 < d && (d &= 255);
+        b.push(String.fromCharCode(d))
+      }
+      return b.join("")
+    });
+    x.writeStringToMemory = Ve;
+    x.writeArrayToMemory = We;
+    var g = [], ae = 0;
+    bf.X = 1;
+    df.X = 1;
+    ff.X = 1;
+    jf.X = 1;
+    qc.X = 1;
+    T.X = 1;
+    Ja.X = 1;
+    pa.X = 1;
+    J.X = 1;
+    of.X = 1;
+    hd.X = 1;
+    tf.X = 1;
+    uf.X = 1;
+    vf.X = 1;
+    wf.X = 1;
+    xf.X = 1;
+    id.X = 1;
+    yf.X = 1;
+    pf.X = 1;
+    qf.X = 1;
+    rf.X = 1;
+    sf.X = 1;
+    Af.X = 1;
+    zf.X = 1;
+    Bf.X = 1;
+    Cf.X = 1;
+    Df.X = 1;
+    Ef.X = 1;
+    Ff.X = 1;
+    Hf.X = 1;
+    If.X = 1;
+    Jf.X = 1;
+    Vc.X = 1;
+    gf.X = 1;
+    kf.X = 1;
+    Nc.X = 1;
+    Xc.X = 1;
+    Pf.X = 1;
+    Lf.X = 1;
+    Qf.X = 1;
+    Qe.X = 1;
+    Mf.X = 1;
+    xc.X = 1;
+    Nf.X = 1;
+    ee.X = 1;
+    Wc.X = 1;
+    Of.X = 1;
+    x._malloc = Wb;
+    Wb.X = 1;
+    bg.X = 1;
+    dg.X = 1;
+    cg.X = 1;
+    hg.X = 1;
+    x._free = hb;
+    hb.X = 1;
+    ig.X = 1;
+    fg.X = 1;
+    gg.X = 1;
+    var Wd = Sc;
+    Ia = 13;
+    Nb = 9;
+    Ba = 22;
+    Cb = 5;
+    Ub = 21;
+    Vb = 6;
+    var be = 0, $a = 0, kb = 0, A = {He:"/", Se:2, a:[Sc], ba:V, T:(function (a, b) {
+      if ("string" !== typeof a) {
+        return Sc
+      }
+      b === ua && (b = A.He);
+      a && "/" == a[0] && (b = "");
+      for (var c = (b + "/" + a).split("/").reverse(), d = [""]; c.length;) {
+        var e = c.pop();
+        "" == e || "." == e || (".." == e ? 1 < d.length && d.pop() : d.push(e))
+      }
+      return 1 == d.length ? "/" : d.join("/")
+    }), u:(function (a, b, c) {
+      var d = {Oe:Y, p:Y, error:0, name:Sc, path:Sc, object:Sc, F:Y, ea:Sc, G:Sc}, a = A.T(a);
+      if ("/" == a) {
+        d.Oe = V, d.p = d.F = V, d.name = "/", d.path = d.ea = "/", d.object = d.G = A.root
+      } else {
+        if (a !== Sc) {
+          for (var c = c || 0, a = a.slice(1).split("/"), e = A.root, g = [""]; a.length;) {
+            1 == a.length && e.h && (d.F = V, d.ea = 1 == g.length ? "/" : g.join("/"), d.G = e, d.name = a[0]);
+            var j = a.shift();
+            if (e.h) {
+              if (e.fa) {
+                if (!e.b.hasOwnProperty(j)) {
+                  d.error = 2;
+                  break
+                }
+              } else {
+                d.error = Ia;
+                break
+              }
+            } else {
+              d.error = 20;
+              break
+            }
+            e = e.b[j];
+            if (e.link && !(b && 0 == a.length)) {
+              if (40 < c) {
+                d.error = 40;
+                break
+              }
+              d = A.T(e.link, g.join("/"));
+              d = A.u([d].concat(a).join("/"), b, c + 1);
+              break
+            }
+            g.push(j);
+            0 == a.length && (d.p = V, d.path = g.join("/"), d.object = e)
+          }
+        }
+      }
+      return d
+    }), Z:(function (a, b) {
+      A.W();
+      var c = A.u(a, b);
+      if (c.p) {
+        return c.object
+      }
+      W(c.error);
+      return Sc
+    }), V:(function (a, b, c, d, e) {
+      a || (a = "/");
+      "string" === typeof a && (a = A.Z(a));
+      a || (W(Ia), N(Error("Parent path must exist.")));
+      a.h || (W(20), N(Error("Parent must be a folder.")));
+      !a.write && !A.ba && (W(Ia), N(Error("Parent folder must be writeable.")));
+      if (!b || "." == b || ".." == b) {
+        W(2), N(Error("Name must not be empty."))
+      }
+      a.b.hasOwnProperty(b) && (W(17), N(Error("Can't overwrite object.")));
+      a.b[b] = {fa:d === ua ? V : d, write:e === ua ? Y : e, timestamp:Date.now(), Le:A.Se++};
+      for (var g in c) {
+        c.hasOwnProperty(g) && (a.b[b][g] = c[g])
+      }
+      return a.b[b]
+    }), w:(function (a, b, c, d) {
+      return A.V(a, b, {h:V, e:Y, b:{}}, c, d)
+    }), Ge:(function (a, b, c, d) {
+      a = A.Z(a);
+      a === Sc && N(Error("Invalid parent."));
+      for (b = b.split("/").reverse(); b.length;) {
+        var e = b.pop();
+        e && (a.b.hasOwnProperty(e) || A.w(a, e, c, d), a = a.b[e])
+      }
+      return a
+    }), o:(function (a, b, c, d, e) {
+      c.h = Y;
+      return A.V(a, b, c, d, e)
+    }), qf:(function (a, b, c, d, e) {
+      if ("string" === typeof c) {
+        for (var g = Array(c.length), j = 0, i = c.length; j < i; ++j) {
+          g[j] = c.charCodeAt(j)
+        }
+        c = g
+      }
+      return A.o(a, b, {e:Y, b:c}, d, e)
+    }), rf:(function (a, b, c, d, e) {
+      return A.o(a, b, {e:Y, url:c}, d, e)
+    }), sf:(function (a, b, c, d, e) {
+      return A.o(a, b, {e:Y, link:c}, d, e)
+    }), n:(function (a, b, c, d) {
+      !c && !d && N(Error("A device must have at least one callback defined."));
+      return A.o(a, b, {e:V, input:c, f:d}, Boolean(c), Boolean(d))
+    }), vf:(function (a) {
+      if (a.e || a.h || a.link || a.b) {
+        return V
+      }
+      var b = V;
+      if ("undefined" !== typeof XMLHttpRequest) {
+        cb("Cannot do synchronous binary XHRs in modern browsers. Use --embed-file or --preload-file in emcc")
+      } else {
+        if (x.read) {
+          try {
+            a.b = db(x.read(a.url), V)
+          } catch (c) {
+            b = Y
+          }
+        } else {
+          N(Error("Cannot load without read() or XMLHttpRequest."))
+        }
+      }
+      b || W(Cb);
+      return b
+    }), W:(function () {
+      A.root || (A.root = {fa:V, write:V, h:V, e:Y, timestamp:Date.now(), Le:1, b:{}})
+    }), j:(function (a, b, c) {
+      function g(a) {
+        a === Sc || 10 === a ? (b.r(b.buffer.join("")), b.buffer = []) : b.buffer.push(String.fromCharCode(a))
+      }
+
+      cb(!A.j.C, "FS.init was previously called. If you want to initialize later with custom parameters, remove any earlier calls (note that one is automatically added to the generated code)");
+      A.j.C = V;
+      A.W();
+      var a = a || x.stdin, b = b || x.stdout, c = c || x.stderr, j = V, m = V, k = V;
+      a || (j = Y, a = (function () {
+        if (!a.v || !a.v.length) {
+          var b;
+          "undefined" != typeof window && "function" == typeof window.prompt ? b = window.prompt("Input: ") : "function" == typeof readline && (b = readline());
+          b || (b = "");
+          a.v = db(b + "\n", V)
+        }
+        return a.v.shift()
+      }));
+      b || (m = Y, b = g);
+      b.r || (b.r = x.print);
+      b.buffer || (b.buffer = []);
+      c || (k = Y, c = g);
+      c.r || (c.r = x.print);
+      c.buffer || (c.buffer = []);
+      A.w("/", "tmp", V, V);
+      var i = A.w("/", "dev", V, V), q = A.n(i, "stdin", a), p = A.n(i, "stdout", Sc, b), c = A.n(i, "stderr", Sc, c);
+      A.n(i, "tty", a, b);
+      A.a[1] = {path:"/dev/stdin", object:q, position:0, da:V, q:Y, ca:Y, D:!j, error:Y, Y:Y, ia:[]};
+      A.a[2] = {path:"/dev/stdout", object:p, position:0, da:Y, q:V, ca:Y, D:!m, error:Y, Y:Y, ia:[]};
+      A.a[3] = {path:"/dev/stderr", object:c, position:0, da:Y, q:V, ca:Y, D:!k, error:Y, Y:Y, ia:[]};
+      be = d([1], "void*", e);
+      $a = d([2], "void*", e);
+      kb = d([3], "void*", e);
+      A.Ge("/", "dev/shm/tmp", V, V);
+      A.a[be] = A.a[1];
+      A.a[$a] = A.a[2];
+      A.a[kb] = A.a[3];
+      d([d([0, 0, 0, 0, be, 0, 0, 0, $a, 0, 0, 0, kb, 0, 0, 0], "void*", e)], "void*", e)
+    }), Te:(function () {
+      A.j.C && (A.a[2] && 0 < A.a[2].object.f.buffer.length && A.a[2].object.f(10), A.a[3] && 0 < A.a[3].object.f.buffer.length && A.a[3].object.f(10))
+    }), Df:(function (a) {
+      "./" == a.substr(0, 2) && (a = a.substr(2));
+      return a
+    }), tf:(function (a) {
+      a = A.u(a);
+      (!a.F || !a.p) && N("Invalid path " + a);
+      delete a.G.b[a.name]
+    })}, Re = Sc, bb = {}, Ug;
+    ug.unshift({A:(function () {
+      !x.noFSInit && !A.j.C && A.j()
+    })});
+    ng.push({A:(function () {
+      A.ba = Y
+    })});
+    Yd.push({A:(function () {
+      A.Te()
+    })});
+    W(0);
+    ((function (b) {
+      var c, f;
+      Re === Sc ? (bb.USER = "root", bb.PATH = "/", bb.PWD = "/", bb.HOME = "/home/emscripten", bb.LANG = "en_US.UTF-8", bb._ = "./this.program", c = d(1024, "i8", e), f = d(256, "i8*", e), a[f >> 2] = c, Re = d([f], "i8**", e)) : (f = a[Re >> 2], c = a[f >> 2]);
+      var g = [], j = 0, m;
+      for (m in b) {
+        if ("string" === typeof b[m]) {
+          var k = m + "=" + b[m];
+          g.push(k);
+          j += k.length
+        }
+      }
+      1024 < j && N(Error("Environment size exceeded TOTAL_ENV_SIZE!"));
+      for (b = 0; b < g.length; b++) {
+        k = g[b];
+        for (j = 0; j < k.length; j++) {
+          q[c + j] = k.charCodeAt(j)
+        }
+        q[c + j] = 0;
+        a[f + 4 * b >> 2] = c;
+        c += k.length + 1
+      }
+      a[f + 4 * g.length >> 2] = 0
+    }))(bb);
+    lg.Ce = d(12, "void*", e);
+    Mb.i = d([0], "i8", e);
+    x.Ee = (function (a) {
+      function b() {
+        for (var a = 0; 3 > a; a++) {
+          g.push(0)
+        }
+      }
+
+      var c = a.length + 1, g = [d(db("/bin/this.program"), "i8", e)];
+      b();
+      for (var j = 0; j < c - 1; j += 1) {
+        g.push(d(db(a[j]), "i8", e)), b()
+      }
+      g.push(0);
+      g = d(g, "i32", e);
+      return _main(c, g, 0)
+    });
+    var ef, ob, vg, Jd, wg, ge, xg, Zc, yg, Yc, zg, Ec, Ag, xe, Bg, Qd, Cg, ye, Dg, pe, Eg, fd, Fg, ze, Gg, Rd, Hg, qe, Ig, Rc, Jg, Ib, sc, Sd, se, ta, j, aa, Ud, Se, Te, lb, zc;
+    d([1], ["i32", 0, 0, 0, 0], e);
+    d([1], ["i32", 0, 0, 0, 0], e);
+    d([63], ["i32", 0, 0, 0, 0], e);
+    d(1, "i8*", e);
+    d(1, "i32", e);
+    d(1, "i8*", e);
+    d(1, "i32", e);
+    d(1, "i32", e);
+    d(1, "i32", e);
+    g.We = d([45, 45, 0], "i8", e);
+    g.Xe = d([37, 115, 58, 32, 111, 112, 116, 105, 111, 110, 32, 96, 37, 115, 39, 32, 105, 115, 32, 97, 109, 98, 105, 103, 117, 111, 117, 115, 10, 0], "i8", e);
+    g.cf = d([37, 115, 58, 32, 111, 112, 116, 105, 111, 110, 32, 96, 45, 45, 37, 115, 39, 32, 100, 111, 101, 115, 110, 39, 116, 32, 97, 108, 108, 111, 119, 32, 97, 110, 32, 97, 114, 103, 117, 109, 101, 110, 116, 10, 0], "i8", e);
+    g.gf = d([37, 115, 58, 32, 111, 112, 116, 105, 111, 110, 32, 96, 37, 99, 37, 115, 39, 32, 100, 111, 101, 115, 110, 39, 116, 32, 97, 108, 108, 111, 119, 32, 97, 110, 32, 97, 114, 103, 117, 109, 101, 110, 116, 10, 0], "i8", e);
+    g.hf = d([37, 115, 58, 32, 111, 112, 116, 105, 111, 110, 32, 96, 37, 115, 39, 32, 114, 101, 113, 117, 105, 114, 101, 115, 32, 97, 110, 32, 97, 114, 103, 117, 109, 101, 110, 116, 10, 0], "i8", e);
+    g.jf = d([37, 115, 58, 32, 117, 110, 114, 101, 99, 111, 103, 110, 105, 122, 101, 100, 32, 111, 112, 116, 105, 111, 110, 32, 96, 45, 45, 37, 115, 39, 10, 0], "i8", e);
+    g.kf = d([37, 115, 58, 32, 117, 110, 114, 101, 99, 111, 103, 110, 105, 122, 101, 100, 32, 111, 112, 116, 105, 111, 110, 32, 96, 37, 99, 37, 115, 39, 10, 0], "i8", e);
+    d(1, "i8*", e);
+    g.lf = d([37, 115, 58, 32, 105, 108, 108, 101, 103, 97, 108, 32, 111, 112, 116, 105, 111, 110, 32, 45, 45, 32, 37, 99, 10, 0], "i8", e);
+    g.mf = d([37, 115, 58, 32, 105, 110, 118, 97, 108, 105, 100, 32, 111, 112, 116, 105, 111, 110, 32, 45, 45, 32, 37, 99, 10, 0], "i8", e);
+    g.Ye = d([37, 115, 58, 32, 111, 112, 116, 105, 111, 110, 32, 114, 101, 113, 117, 105, 114, 101, 115, 32, 97, 110, 32, 97, 114, 103, 117, 109, 101, 110, 116, 32, 45, 45, 32, 37, 99, 10, 0], "i8", e);
+    g.Ze = d([37, 115, 58, 32, 111, 112, 116, 105, 111, 110, 32, 96, 45, 87, 32, 37, 115, 39, 32, 105, 115, 32, 97, 109, 98, 105, 103, 117, 111, 117, 115, 10, 0], "i8", e);
+    g.$e = d([37, 115, 58, 32, 111, 112, 116, 105, 111, 110, 32, 96, 45, 87, 32, 37, 115, 39, 32, 100, 111, 101, 115, 110, 39, 116, 32, 97, 108, 108, 111, 119, 32, 97, 110, 32, 97, 114, 103, 117, 109, 101, 110, 116, 10, 0], "i8", e);
+    g.bf = d([80, 79, 83, 73, 88, 76, 89, 95, 67, 79, 82, 82, 69, 67, 84, 0], "i8", e);
+    g.Xa = d([106, 98, 105, 103, 50, 95, 101, 114, 114, 111, 114, 58, 32, 101, 114, 114, 111, 114, 32, 105, 110, 32, 103, 101, 110, 101, 114, 97, 116, 105, 110, 103, 32, 101, 114, 114, 111, 114, 32, 115, 116, 114, 105, 110, 103, 0], "i8", e);
+    g.Ca = d([105, 110, 105, 116, 105, 97, 108, 32, 99, 111, 110, 116, 101, 120, 116, 32, 97, 108, 108, 111, 99, 97, 116, 105, 111, 110, 32, 102, 97, 105, 108, 101, 100, 33, 0], "i8", e);
+    g.Rb = d([105, 110, 105, 116, 105, 97, 108, 32, 115, 101, 103, 109, 101, 110, 116, 115, 32, 97, 108, 108, 111, 99, 97, 116, 105, 111, 110, 32, 102, 97, 105, 108, 101, 100, 33, 0], "i8", e);
+    g.zc = d([105, 110, 105, 116, 105, 97, 108, 32, 112, 97, 103, 101, 115, 32, 97, 108, 108, 111, 99, 97, 116, 105, 111, 110, 32, 102, 97, 105, 108, 101, 100, 33, 0], "i8", e);
+    g.ed = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 99, 116, 120, 45, 62, 98, 117, 102, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 100, 97, 116, 97, 95, 105, 110, 0], "i8", e);
+    g.Cd = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 98, 117, 102, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 100, 97, 116, 97, 95, 105, 110, 0], "i8", e);
+    g.xe = d([151, 74, 66, 50, 13, 10, 26, 10], "i8", e);
+    g.Pd = d([78, 111, 116, 32, 97, 32, 74, 66, 73, 71, 50, 32, 102, 105, 108, 101, 32, 104, 101, 97, 100, 101, 114, 0], "i8", e);
+    g.Zd = d([114, 101, 115, 101, 114, 118, 101, 100, 32, 98, 105, 116, 115, 32, 40, 50, 45, 55, 41, 32, 111, 102, 32, 102, 105, 108, 101, 32, 104, 101, 97, 100, 101, 114, 32, 102, 108, 97, 103, 115, 32, 97, 114, 101, 32, 110, 111, 116, 32, 122, 101, 114, 111, 32, 40, 48, 120, 37, 48, 50, 120, 41, 0], "i8", e);
+    g.ie = d([102, 105, 108, 101, 32, 104, 101, 97, 100, 101, 114, 32, 105, 110, 100, 105, 99, 97, 116, 101, 115, 32, 97, 32, 115, 105, 110, 103, 108, 101, 32, 112, 97, 103, 101, 32, 100, 111, 99, 117, 109, 101, 110, 116, 0], "i8", e);
+    g.se = d([102, 105, 108, 101, 32, 104, 101, 97, 100, 101, 114, 32, 105, 110, 100, 105, 99, 97, 116, 101, 115, 32, 97, 32, 37, 100, 32, 112, 97, 103, 101, 32, 100, 111, 99, 117, 109, 101, 110, 116, 0], "i8", e);
+    g.ra = d([102, 105, 108, 101, 32, 104, 101, 97, 100, 101, 114, 32, 105, 110, 100, 105, 99, 97, 116, 101, 115, 32, 115, 101, 113, 117, 101, 110, 116, 105, 97, 108, 32, 111, 114, 103, 97, 110, 105, 122, 97, 116, 105, 111, 110, 0], "i8", e);
+    g.Aa = d([102, 105, 108, 101, 32, 104, 101, 97, 100, 101, 114, 32, 105, 110, 100, 105, 99, 97, 116, 101, 115, 32, 114, 97, 110, 100, 111, 109, 45, 97, 99, 99, 101, 115, 115, 32, 111, 114, 103, 97, 110, 105, 122, 97, 116, 105, 111, 110, 0], "i8", e);
+    g.Ta = d([71, 97, 114, 98, 97, 103, 101, 32, 98, 101, 121, 111, 110, 100, 32, 101, 110, 100, 32, 111, 102, 32, 102, 105, 108, 101, 0], "i8", e);
+    g.bb = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 74, 98, 105, 103, 50, 87, 111, 114, 100, 83, 116, 114, 101, 97, 109, 66, 117, 102, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 119, 111, 114, 100, 95, 115, 116, 114, 101, 97, 109, 95, 98, 117, 102, 95, 110, 101, 119, 0], "i8", e);
+    g.fb = d([106, 98, 105, 103, 50, 32, 100, 101, 99, 111, 100, 101, 114, 32, 70, 65, 84, 65, 76, 32, 69, 82, 82, 79, 82, 58, 32, 37, 115, 0], "i8", e);
+    g.mb = d([32, 40, 115, 101, 103, 109, 101, 110, 116, 32, 48, 120, 37, 48, 50, 120, 41, 0], "i8", e);
+    ef = d([10, 0, 0, 0, 12, 0, 0, 0, 14, 0, 0, 0], ["*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0], e);
+    g.pc = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 74, 98, 105, 103, 50, 65, 114, 105, 116, 104, 83, 116, 97, 116, 101, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 97, 114, 105, 116, 104, 95, 110, 101, 119, 0], "i8", e);
+    ob = d([22017, 0, 1, -127, 13313, 0, 3, 7, 6145, 0, 1, 11, 2753, 0, 7, 15, 1313, 0, 1, 25, 545, 0, 35, 36, 22017, 0, 1, -128, 21505, 0, 15, 9, 18433, 0, 1, 6, 14337, 0, 3, 7, 12289, 0, 1, 27, 9217, 0, 7, 25, 7169, 0, 1, 24, 5633, 0, 16, 24, 22017, 0, 1, -128, 21505, 0, 31, 1, 20737, 0, 1, 31, 18433, 0, 3, 1, 14337, 0, 1, 3, 13313, 0, 7, 1, 12289, 0, 1, 7, 10241, 0, 3, 6, 9217, 0, 1, 2, 8705, 0, 15, 2, 7169, 0, 1, 14, 6145, 0, 3, 14, 5633, 0, 1, 2, 5121, 0, 7, 2, 4609, 0, 1, 6, 4353, 0, 3, 6, 2753, 0, 1, 2, 2497, 0, 63, 2, 2209, 0, 1, 62, 1313, 0, 3, 62, 1089, 0, 1, 2, 673, 0, 7, 2, 545, 0, 1, 6, 321, 0, 3, 6, 273, 0, 1, 2, 133, 0, 15, 2, 73, 0, 1, 14, 37, 0, 3, 14, 21, 0, 1, 2, 9, 0, 7, 2, 5, 0, 1, 6, 1, 0, 0, 6, 22017, 0, 0, 0], ["i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8", "i16", 0, "i8", "i8"], e);
+    g.tc = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 115, 116, 111, 114, 97, 103, 101, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 97, 114, 105, 116, 104, 95, 105, 97, 105, 100, 95, 99, 116, 120, 95, 110, 101, 119, 0], "i8", e);
+    g.Pa = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 115, 121, 109, 98, 111, 108, 32, 73, 68, 32, 115, 116, 111, 114, 97, 103, 101, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 97, 114, 105, 116, 104, 95, 105, 97, 105, 100, 95, 99, 116, 120, 95, 110, 101, 119, 0], "i8", e);
+    g.Bc = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 74, 98, 105, 103, 50, 65, 114, 105, 116, 104, 73, 110, 116, 67, 116, 120, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 97, 114, 105, 116, 104, 95, 105, 110, 116, 95, 99, 116, 120, 95, 110, 101, 119, 0], "i8", e);
+    vg = d([1, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 8, 0, 0, 0, 16, 0, 0, 0, 3, 0, 0, 0, 16, 0, 0, 0, 272, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, -1, 0, 0, 0, 3, 0, 0, 0, 32, 0, 0, 0, 65808, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0], e);
+    Jd = d([0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0], e);
+    wg = d([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 4, 0, 0, 0, 3, 0, 0, 0, 3, 0, 0, 0, 5, 0, 0, 0, 6, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, -1, 0, 0, 0, 6, 0, 0, 0, 32, 0, 0, 0, 75, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0], e);
+    ge = d([1, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0], e);
+    xg = d([8, 0, 0, 0, 8, 0, 0, 0, -256, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 4, 0, 0, 0, 3, 0, 0, 0, 3, 0, 0, 0, 5, 0, 0, 0, 6, 0, 0, 0, 11, 0, 0, 0, 8, 0, 0, 0, 32, 0, 0, 0, -257, 0, 0, 0, 7, 0, 0, 0, 32, 0, 0, 0, 75, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0], e);
+    Zc = d([1, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0], e);
+    yg = d([1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0, 6, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, -1, 0, 0, 0, 5, 0, 0, 0, 32, 0, 0, 0, 76, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0], e);
+    Yc = d([0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0], e);
+    zg = d([7, 0, 0, 0, 8, 0, 0, 0, -255, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0, 6, 0, 0, 0, 12, 0, 0, 0, 7, 0, 0, 0, 32, 0, 0, 0, -256, 0, 0, 0, 6, 0, 0, 0, 32, 0, 0, 0, 76, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0], e);
+    Ec = d([0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0], e);
+    Ag = d([5, 0, 0, 0, 10, 0, 0, 0, -2048, 0, 0, 0, 4, 0, 0, 0, 9, 0, 0, 0, -1024, 0, 0, 0, 4, 0, 0, 0, 8, 0, 0, 0, -512, 0, 0, 0, 4, 0, 0, 0, 7, 0, 0, 0, -256, 0, 0, 0, 5, 0, 0, 0, 6, 0, 0, 0, -128, 0, 0, 0, 5, 0, 0, 0, 5, 0, 0, 0, -64, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0, -32, 0, 0, 0, 2, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 7, 0, 0, 0, 128, 0, 0, 0, 3, 0, 0, 0, 8, 0, 0, 0, 256, 0, 0, 0, 4, 0, 0, 0, 9, 0, 0, 0, 512, 0, 0, 0, 4, 0, 0, 0, 10, 0, 0, 0, 1024, 0, 0, 0, 6, 0, 0, 0, 32, 0, 0, 0, -2049, 0, 0, 0, 6, 0, 0, 0, 32, 0, 0, 0, 2048, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0], e);
+    xe = d([0, 0, 0, 0, 14, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0], e);
+    Bg = d([4, 0, 0, 0, 9, 0, 0, 0, -1024, 0, 0, 0, 3, 0, 0, 0, 8, 0, 0, 0, -512, 0, 0, 0, 4, 0, 0, 0, 7, 0, 0, 0, -256, 0, 0, 0, 5, 0, 0, 0, 6, 0, 0, 0, -128, 0, 0, 0, 5, 0, 0, 0, 5, 0, 0, 0, -64, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0, -32, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 5, 0, 0, 0, 32, 0, 0, 0, 5, 0, 0, 0, 6, 0, 0, 0, 64, 0, 0, 0, 4, 0, 0, 0, 7, 0, 0, 0, 128, 0, 0, 0, 3, 0, 0, 0, 8, 0, 0, 0, 256, 0, 0, 0, 3, 0, 0, 0, 9, 0, 0, 0, 512, 0, 0, 0, 3, 0, 0, 0, 10, 0, 0, 0, 1024, 0, 0, 0, 5, 0, 0, 0, 32, 0, 0, 0, -1025, 0, 0, 0, 5, 0, 0, 0, 32, 0, 0, 0, 2048, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0], e);
+    Qd = d([0, 0, 0, 0, 15, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0], e);
+    Cg = d([8, 0, 0, 0, 3, 0, 0, 0, -15, 0, 0, 0, 9, 0, 0, 0, 1, 0, 0, 0, -7, 0, 0, 0, 8, 0, 0, 0, 1, 0, 0, 0, -5, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, -3, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, -2, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 4, 0, 0, 0, 6, 0, 0, 0, 1, 0, 0, 0, 20, 0, 0, 0, 4, 0, 0, 0, 4, 0, 0, 0, 22, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0, 38, 0, 0, 0, 5, 0, 0, 0, 6, 0, 0, 0, 70, 0, 0, 0, 5, 0, 0, 0, 7, 0, 0, 0, 134, 0, 0, 0, 6, 0, 0, 0, 7, 0, 0, 0, 262, 0, 0, 0, 7, 0, 0, 0, 8, 0, 0, 0, 390, 0, 0, 0, 6, 0, 0, 0, 10, 0, 0, 0, 646, 0, 0, 0, 9, 0, 0, 0, 32, 0, 0, 0, -16, 0, 0, 0, 9, 0, 0, 0, 32, 0, 0, 0, 1670, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0], e);
+    ye = d([1, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0], e);
+    Dg = d([8, 0, 0, 0, 4, 0, 0, 0, -31, 0, 0, 0, 9, 0, 0, 0, 2, 0, 0, 0, -15, 0, 0, 0, 8, 0, 0, 0, 2, 0, 0, 0, -11, 0, 0, 0, 9, 0, 0, 0, 1, 0, 0, 0, -7, 0, 0, 0, 7, 0, 0, 0, 1, 0, 0, 0, -5, 0, 0, 0, 4, 0, 0, 0, 1, 0, 0, 0, -3, 0, 0, 0, 3, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0, 0, 3, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 5, 0, 0, 0, 1, 0, 0, 0, 3, 0, 0, 0, 6, 0, 0, 0, 1, 0, 0, 0, 5, 0, 0, 0, 3, 0, 0, 0, 5, 0, 0, 0, 7, 0, 0, 0, 6, 0, 0, 0, 2, 0, 0, 0, 39, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0, 43, 0, 0, 0, 4, 0, 0, 0, 6, 0, 0, 0, 75, 0, 0, 0, 5, 0, 0, 0, 7, 0, 0, 0, 139, 0, 0, 0, 5, 0, 0, 0, 8, 0, 0, 0, 267, 0, 0, 0, 6, 0, 0, 0, 8, 0, 0, 0, 523, 0, 0, 0, 7, 0, 0, 0, 9, 0, 0, 0, 779, 0, 0, 0, 6, 0, 0, 0, 11, 0, 0, 0, 1291, 0, 0, 0, 9, 0, 0, 0, 32, 0, 0, 0, -32, 0, 0, 0, 9, 0, 0, 0, 32, 0, 0, 0, 3339, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0], e);
+    pe = d([1, 0, 0, 0, 22, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0], e);
+    Eg = d([7, 0, 0, 0, 4, 0, 0, 0, -21, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, -5, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, -4, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, -3, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, -2, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 2, 0, 0, 0, 6, 0, 0, 0, 6, 0, 0, 0, 5, 0, 0, 0, 5, 0, 0, 0, 70, 0, 0, 0, 6, 0, 0, 0, 5, 0, 0, 0, 102, 0, 0, 0, 6, 0, 0, 0, 6, 0, 0, 0, 134, 0, 0, 0, 6, 0, 0, 0, 7, 0, 0, 0, 198, 0, 0, 0, 6, 0, 0, 0, 8, 0, 0, 0, 326, 0, 0, 0, 6, 0, 0, 0, 9, 0, 0, 0, 582, 0, 0, 0, 6, 0, 0, 0, 10, 0, 0, 0, 1094, 0, 0, 0, 7, 0, 0, 0, 11, 0, 0, 0, 2118, 0, 0, 0, 8, 0, 0, 0, 32, 0, 0, 0, -22, 0, 0, 0, 8, 0, 0, 0, 32, 0, 0, 0, 4166, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0], e);
+    fd = d([1, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0], e);
+    Fg = d([1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 4, 0, 0, 0, 1, 0, 0, 0, 5, 0, 0, 0, 5, 0, 0, 0, 1, 0, 0, 0, 7, 0, 0, 0, 5, 0, 0, 0, 2, 0, 0, 0, 9, 0, 0, 0, 6, 0, 0, 0, 2, 0, 0, 0, 13, 0, 0, 0, 7, 0, 0, 0, 2, 0, 0, 0, 17, 0, 0, 0, 7, 0, 0, 0, 3, 0, 0, 0, 21, 0, 0, 0, 7, 0, 0, 0, 4, 0, 0, 0, 29, 0, 0, 0, 7, 0, 0, 0, 5, 0, 0, 0, 45, 0, 0, 0, 7, 0, 0, 0, 6, 0, 0, 0, 77, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, -1, 0, 0, 0, 7, 0, 0, 0, 32, 0, 0, 0, 141, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0], e);
+    ze = d([0, 0, 0, 0, 14, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0], e);
+    Gg = d([1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 1, 0, 0, 0, 3, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 5, 0, 0, 0, 1, 0, 0, 0, 6, 0, 0, 0, 6, 0, 0, 0, 1, 0, 0, 0, 8, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 7, 0, 0, 0, 1, 0, 0, 0, 11, 0, 0, 0, 7, 0, 0, 0, 2, 0, 0, 0, 13, 0, 0, 0, 7, 0, 0, 0, 3, 0, 0, 0, 17, 0, 0, 0, 7, 0, 0, 0, 4, 0, 0, 0, 25, 0, 0, 0, 8, 0, 0, 0, 5, 0, 0, 0, 41, 0, 0, 0, 8, 0, 0, 0, 32, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0], e);
+    Rd = d([0, 0, 0, 0, 15, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0], e);
+    Hg = d([1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 4, 0, 0, 0, 1, 0, 0, 0, 5, 0, 0, 0, 3, 0, 0, 0, 3, 0, 0, 0, 7, 0, 0, 0, 6, 0, 0, 0, 1, 0, 0, 0, 15, 0, 0, 0, 6, 0, 0, 0, 2, 0, 0, 0, 17, 0, 0, 0, 6, 0, 0, 0, 3, 0, 0, 0, 21, 0, 0, 0, 6, 0, 0, 0, 4, 0, 0, 0, 29, 0, 0, 0, 6, 0, 0, 0, 5, 0, 0, 0, 45, 0, 0, 0, 7, 0, 0, 0, 6, 0, 0, 0, 77, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, -1, 0, 0, 0, 7, 0, 0, 0, 32, 0, 0, 0, 141, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0], e);
+    qe = d([0, 0, 0, 0, 14, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0], e);
+    Ig = d([3, 0, 0, 0, 0, 0, 0, 0, -2, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 3, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0], e);
+    Rc = d([0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0], e);
+    Jg = d([7, 0, 0, 0, 4, 0, 0, 0, -24, 0, 0, 0, 6, 0, 0, 0, 2, 0, 0, 0, -8, 0, 0, 0, 5, 0, 0, 0, 1, 0, 0, 0, -4, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, -2, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 5, 0, 0, 0, 1, 0, 0, 0, 3, 0, 0, 0, 6, 0, 0, 0, 2, 0, 0, 0, 5, 0, 0, 0, 7, 0, 0, 0, 4, 0, 0, 0, 9, 0, 0, 0, 7, 0, 0, 0, 32, 0, 0, 0, -25, 0, 0, 0, 7, 0, 0, 0, 32, 0, 0, 0, 25, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0], e);
+    Ib = d([0, 0, 0, 0, 13, 0, 0, 0, 0, 0, 0, 0], ["i32", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0], e);
+    g.Hc = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 110, 101, 119, 32, 104, 117, 102, 102, 109, 97, 110, 32, 99, 111, 100, 105, 110, 103, 32, 115, 116, 97, 116, 101, 0], "i8", e);
+    g.Ua = d([99, 111, 117, 108, 100, 110, 39, 116, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 115, 116, 111, 114, 97, 103, 101, 32, 102, 111, 114, 32, 104, 117, 102, 102, 109, 97, 110, 32, 104, 105, 115, 116, 111, 103, 114, 97, 109, 0], "i8", e);
+    g.cc = d([99, 111, 110, 115, 116, 114, 117, 99, 116, 105, 110, 103, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 32, 108, 111, 103, 32, 115, 105, 122, 101, 32, 37, 100, 0], "i8", e);
+    g.Kc = d([99, 111, 117, 108, 100, 110, 39, 116, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 114, 101, 115, 117, 108, 116, 32, 115, 116, 111, 114, 97, 103, 101, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 98, 117, 105, 108, 100, 95, 104, 117, 102, 102, 109, 97, 110, 95, 116, 97, 98, 108, 101, 0], "i8", e);
+    g.ld = d([99, 111, 117, 108, 100, 110, 39, 116, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 101, 110, 116, 114, 105, 101, 115, 32, 115, 116, 111, 114, 97, 103, 101, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 98, 117, 105, 108, 100, 95, 104, 117, 102, 102, 109, 97, 110, 95, 116, 97, 98, 108, 101, 0], "i8", e);
+    g.Gd = d([114, 97, 110, 32, 111, 102, 102, 32, 116, 104, 101, 32, 101, 110, 100, 32, 111, 102, 32, 116, 104, 101, 32, 101, 110, 116, 114, 105, 101, 115, 32, 116, 97, 98, 108, 101, 33, 32, 40, 37, 100, 32, 62, 61, 32, 37, 100, 41, 0], "i8", e);
+    g.Sd = d([67, 111, 117, 108, 100, 32, 110, 111, 116, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 72, 117, 102, 102, 109, 97, 110, 32, 84, 97, 98, 108, 101, 32, 80, 97, 114, 97, 109, 101, 116, 101, 114, 0], "i8", e);
+    g.ce = d([67, 111, 117, 108, 100, 32, 110, 111, 116, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 72, 117, 102, 102, 109, 97, 110, 32, 84, 97, 98, 108, 101, 32, 76, 105, 110, 101, 115, 0], "i8", e);
+    g.le = d([67, 111, 117, 108, 100, 32, 110, 111, 116, 32, 114, 101, 97, 108, 108, 111, 99, 97, 116, 101, 32, 72, 117, 102, 102, 109, 97, 110, 32, 84, 97, 98, 108, 101, 32, 76, 105, 110, 101, 115, 0], "i8", e);
+    g.d = d([103, 98, 97, 116, 91, 37, 100, 93, 32, 61, 32, 37, 100, 0], "i8", e);
+    g.cb = d([100, 101, 99, 111, 100, 101, 95, 103, 101, 110, 101, 114, 105, 99, 95, 114, 101, 103, 105, 111, 110, 58, 32, 77, 77, 82, 61, 37, 100, 44, 32, 71, 66, 84, 69, 77, 80, 76, 65, 84, 69, 61, 37, 100, 32, 78, 89, 73, 0], "i8", e);
+    g.nd = d([115, 101, 103, 109, 101, 110, 116, 32, 102, 108, 97, 103, 115, 32, 61, 32, 37, 48, 50, 120, 0], "i8", e);
+    g.Id = d([77, 77, 82, 32, 105, 115, 32, 49, 44, 32, 98, 117, 116, 32, 71, 66, 84, 69, 77, 80, 76, 65, 84, 69, 32, 105, 115, 32, 110, 111, 116, 32, 48, 0], "i8", e);
+    g.Td = d([103, 98, 97, 116, 58, 32, 37, 100, 44, 32, 37, 100, 0], "i8", e);
+    g.de = d([117, 110, 97, 98, 108, 101, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 103, 101, 110, 101, 114, 105, 99, 32, 105, 109, 97, 103, 101, 0], "i8", e);
+    g.ue = d([117, 110, 97, 98, 108, 101, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 71, 66, 95, 115, 116, 97, 116, 115, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 105, 109, 109, 101, 100, 105, 97, 116, 101, 95, 103, 101, 110, 101, 114, 105, 99, 95, 114, 101, 103, 105, 111, 110, 0], "i8", e);
+    g.sa = d([117, 110, 97, 98, 108, 101, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 119, 115, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 105, 109, 109, 101, 100, 105, 97, 116, 101, 95, 103, 101, 110, 101, 114, 105, 99, 95, 114, 101, 103, 105, 111, 110, 0], "i8", e);
+    g.Da = d([117, 110, 97, 98, 108, 101, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 97, 115, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 105, 109, 109, 101, 100, 105, 97, 116, 101, 95, 103, 101, 110, 101, 114, 105, 99, 95, 114, 101, 103, 105, 111, 110, 0], "i8", e);
+    g.Jd = d([100, 101, 99, 111, 100, 105, 110, 103, 32, 103, 101, 110, 101, 114, 105, 99, 32, 114, 101, 102, 105, 110, 101, 109, 101, 110, 116, 32, 114, 101, 103, 105, 111, 110, 32, 119, 105, 116, 104, 32, 111, 102, 102, 115, 101, 116, 32, 37, 100, 44, 37, 120, 44, 10, 32, 32, 71, 82, 84, 69, 77, 80, 76, 65, 84, 69, 61, 37, 100, 44, 32, 84, 80, 71, 82, 79, 78, 61, 37, 100, 44, 32, 82, 65, 49, 61, 40, 37, 100, 44, 37, 100, 41, 32, 82, 65, 50, 61, 40, 37, 100, 44, 37, 100, 41, 10, 0], "i8", e);
+    g.jb = d([100, 101, 99, 111, 100, 101, 95, 114, 101, 102, 105, 110, 101, 109, 101, 110, 116, 95, 114, 101, 103, 105, 111, 110, 58, 32, 116, 121, 112, 105, 99, 97, 108, 32, 112, 114, 101, 100, 105, 99, 116, 105, 111, 110, 32, 99, 111, 100, 105, 110, 103, 32, 78, 89, 73, 0], "i8", e);
+    g.ic = d([99, 111, 117, 108, 100, 32, 110, 111, 116, 32, 102, 105, 110, 100, 32, 114, 101, 102, 101, 114, 114, 101, 100, 32, 116, 111, 32, 115, 101, 103, 109, 101, 110, 116, 32, 37, 100, 0], "i8", e);
+    g.O = d([103, 101, 110, 101, 114, 105, 99, 32, 114, 101, 103, 105, 111, 110, 58, 32, 37, 100, 32, 120, 32, 37, 100, 32, 64, 32, 40, 37, 100, 44, 32, 37, 100, 41, 44, 32, 102, 108, 97, 103, 115, 32, 61, 32, 37, 48, 50, 120, 0], "i8", e);
+    g.Ld = d([115, 101, 103, 109, 101, 110, 116, 32, 102, 108, 97, 103, 115, 32, 61, 32, 37, 48, 50, 120, 32, 37, 115, 37, 115, 0], "i8", e);
+    g.Ud = d([32, 71, 82, 84, 69, 77, 80, 76, 65, 84, 69, 0], "i8", e);
+    sc = d(1, "i8", e);
+    g.me = d([32, 84, 80, 71, 82, 79, 78, 0], "i8", e);
+    g.ve = d([114, 101, 115, 101, 114, 118, 101, 100, 32, 115, 101, 103, 109, 101, 110, 116, 32, 102, 108, 97, 103, 32, 98, 105, 116, 115, 32, 97, 114, 101, 32, 110, 111, 110, 45, 122, 101, 114, 111, 0], "i8", e);
+    g.ta = d([103, 114, 97, 116, 49, 58, 32, 40, 37, 100, 44, 32, 37, 100, 41, 32, 103, 114, 97, 116, 50, 58, 32, 40, 37, 100, 44, 32, 37, 100, 41, 0], "i8", e);
+    g.Ea = d([99, 111, 117, 108, 100, 32, 110, 111, 116, 32, 102, 105, 110, 100, 32, 114, 101, 102, 101, 114, 101, 110, 99, 101, 32, 98, 105, 116, 109, 97, 112, 33, 0], "i8", e);
+    g.Ma = d([102, 111, 117, 110, 100, 32, 114, 101, 102, 101, 114, 101, 110, 99, 101, 32, 98, 105, 116, 109, 97, 112, 32, 105, 110, 32, 115, 101, 103, 109, 101, 110, 116, 32, 37, 100, 0], "i8", e);
+    g.Va = d([117, 110, 97, 98, 108, 101, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 114, 101, 102, 105, 110, 101, 109, 101, 110, 116, 32, 105, 109, 97, 103, 101, 0], "i8", e);
+    g.M = d([97, 108, 108, 111, 99, 97, 116, 101, 100, 32, 37, 100, 32, 120, 32, 37, 100, 32, 105, 109, 97, 103, 101, 32, 98, 117, 102, 102, 101, 114, 32, 102, 111, 114, 32, 114, 101, 103, 105, 111, 110, 32, 100, 101, 99, 111, 100, 101, 32, 114, 101, 115, 117, 108, 116, 115, 0], "i8", e);
+    g.kb = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 71, 82, 45, 115, 116, 97, 116, 115, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 114, 101, 102, 105, 110, 101, 109, 101, 110, 116, 95, 114, 101, 103, 105, 111, 110, 0], "i8", e);
+    g.rb = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 119, 115, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 114, 101, 102, 105, 110, 101, 109, 101, 110, 116, 95, 114, 101, 103, 105, 111, 110, 0], "i8", e);
+    g.xb = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 97, 115, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 114, 101, 102, 105, 110, 101, 109, 101, 110, 116, 95, 114, 101, 103, 105, 111, 110, 0], "i8", e);
+    g.zb = d([99, 111, 109, 112, 111, 115, 105, 110, 103, 32, 37, 100, 120, 37, 100, 32, 100, 101, 99, 111, 100, 101, 100, 32, 114, 101, 102, 105, 110, 101, 109, 101, 110, 116, 32, 114, 101, 103, 105, 111, 110, 32, 111, 110, 116, 111, 32, 112, 97, 103, 101, 32, 97, 116, 32, 40, 37, 100, 44, 32, 37, 100, 41, 0], "i8", e);
+    g.be = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 112, 97, 116, 116, 101, 114, 110, 32, 105, 110, 32, 99, 111, 108, 108, 101, 99, 116, 105, 118, 101, 32, 98, 105, 116, 109, 97, 112, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 121, 0], "i8", e);
+    g.wb = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 112, 97, 116, 116, 101, 114, 110, 32, 101, 108, 101, 109, 101, 110, 116, 32, 105, 109, 97, 103, 101, 0], "i8", e);
+    g.mc = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 99, 111, 108, 108, 101, 99, 116, 105, 118, 101, 32, 98, 105, 116, 109, 97, 112, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 121, 0], "i8", e);
+    g.sd = d([112, 97, 116, 116, 101, 114, 110, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 121, 44, 32, 102, 108, 97, 103, 115, 61, 37, 48, 50, 120, 44, 32, 37, 100, 32, 103, 114, 97, 121, 115, 32, 40, 37, 100, 120, 37, 100, 32, 99, 101, 108, 108, 41, 0], "i8", e);
+    g.Md = d([72, 68, 84, 69, 77, 80, 76, 65, 84, 69, 32, 105, 115, 32, 37, 100, 32, 119, 104, 101, 110, 32, 72, 68, 77, 77, 82, 32, 105, 115, 32, 37, 100, 44, 32, 99, 111, 110, 116, 114, 97, 114, 121, 32, 116, 111, 32, 115, 112, 101, 99, 0], "i8", e);
+    g.Vd = d([82, 101, 115, 101, 114, 118, 101, 100, 32, 102, 108, 97, 103, 32, 98, 105, 116, 115, 32, 110, 111, 110, 45, 122, 101, 114, 111, 0], "i8", e);
+    g.ee = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 71, 66, 95, 115, 116, 97, 116, 115, 32, 105, 110, 32, 112, 97, 116, 116, 101, 114, 110, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 121, 0], "i8", e);
+    g.ne = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 37, 100, 32, 98, 121, 116, 101, 115, 32, 102, 111, 114, 32, 71, 83, 80, 76, 65, 78, 69, 83, 0], "i8", e);
+    g.we = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 37, 100, 120, 37, 100, 32, 105, 109, 97, 103, 101, 32, 102, 111, 114, 32, 71, 83, 80, 76, 65, 78, 69, 83, 0], "i8", e);
+    g.J = d([101, 114, 114, 111, 114, 32, 100, 101, 99, 111, 100, 105, 110, 103, 32, 71, 83, 80, 76, 65, 78, 69, 83, 32, 102, 111, 114, 32, 104, 97, 108, 102, 116, 111, 110, 101, 32, 105, 109, 97, 103, 101, 0], "i8", e);
+    g.K = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 71, 83, 86, 65, 76, 83, 58, 32, 37, 100, 32, 98, 121, 116, 101, 115, 0], "i8", e);
+    g.Oa = d([117, 110, 104, 97, 110, 100, 108, 101, 100, 32, 111, 112, 116, 105, 111, 110, 32, 72, 69, 78, 65, 66, 76, 69, 83, 75, 73, 80, 0], "i8", e);
+    g.Wa = d([110, 111, 32, 112, 97, 116, 116, 101, 114, 110, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 121, 32, 102, 111, 117, 110, 100, 44, 32, 115, 107, 105, 112, 112, 105, 110, 103, 32, 104, 97, 108, 102, 116, 111, 110, 101, 32, 105, 109, 97, 103, 101, 0], "i8", e);
+    g.eb = d([117, 110, 97, 98, 108, 101, 32, 116, 111, 32, 97, 99, 113, 117, 105, 114, 101, 32, 103, 114, 97, 121, 45, 115, 99, 97, 108, 101, 32, 105, 109, 97, 103, 101, 44, 32, 115, 107, 105, 112, 112, 105, 110, 103, 32, 104, 97, 108, 102, 116, 111, 110, 101, 32, 105, 109, 97, 103, 101, 0], "i8", e);
+    g.lb = d([103, 114, 97, 121, 45, 115, 99, 97, 108, 101, 32, 105, 109, 97, 103, 101, 32, 117, 115, 101, 115, 32, 118, 97, 108, 117, 101, 32, 37, 100, 32, 119, 104, 105, 99, 104, 32, 108, 97, 114, 103, 101, 114, 32, 116, 104, 97, 110, 32, 112, 97, 116, 116, 101, 114, 110, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 121, 0], "i8", e);
+    g.sb = d([104, 97, 108, 102, 116, 111, 110, 101, 32, 114, 101, 103, 105, 111, 110, 58, 32, 37, 100, 32, 120, 32, 37, 100, 32, 64, 32, 40, 37, 120, 44, 37, 100, 41, 32, 102, 108, 97, 103, 115, 61, 37, 48, 50, 120, 0], "i8", e);
+    g.yb = d([72, 84, 69, 77, 80, 76, 65, 84, 69, 32, 105, 115, 32, 37, 100, 32, 119, 104, 101, 110, 32, 72, 77, 77, 82, 32, 105, 115, 32, 37, 100, 44, 32, 99, 111, 110, 116, 114, 97, 114, 121, 32, 116, 111, 32, 115, 112, 101, 99, 0], "i8", e);
+    g.Db = d([72, 69, 78, 65, 66, 76, 69, 83, 75, 73, 80, 32, 105, 115, 32, 37, 100, 32, 119, 104, 101, 110, 32, 72, 77, 77, 82, 32, 105, 115, 32, 37, 100, 44, 32, 99, 111, 110, 116, 114, 97, 114, 121, 32, 116, 111, 32, 115, 112, 101, 99, 0], "i8", e);
+    g.Eb = d([32, 103, 114, 105, 100, 32, 37, 100, 32, 120, 32, 37, 100, 32, 64, 32, 40, 37, 100, 46, 37, 100, 44, 37, 100, 46, 37, 100, 41, 32, 118, 101, 99, 116, 111, 114, 32, 40, 37, 100, 46, 37, 100, 44, 37, 100, 46, 37, 100, 41, 0], "i8", e);
+    g.Jb = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 71, 66, 95, 115, 116, 97, 116, 115, 32, 105, 110, 32, 104, 97, 108, 102, 116, 111, 110, 101, 32, 114, 101, 103, 105, 111, 110, 0], "i8", e);
+    g.Mb = d([117, 110, 97, 98, 108, 101, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 104, 97, 108, 102, 116, 111, 110, 101, 32, 105, 109, 97, 103, 101, 0], "i8", e);
+    g.Tb = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 99, 111, 108, 108, 101, 99, 116, 105, 118, 101, 32, 98, 105, 116, 109, 97, 112, 32, 102, 111, 114, 32, 104, 97, 108, 102, 116, 111, 110, 101, 32, 100, 105, 99, 116, 33, 0], "i8", e);
+    g.$b = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 115, 116, 111, 114, 97, 103, 101, 32, 102, 111, 114, 32, 97, 115, 32, 105, 110, 32, 104, 97, 108, 102, 116, 111, 110, 101, 32, 100, 105, 99, 116, 33, 0], "i8", e);
+    g.dc = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 115, 116, 111, 114, 97, 103, 101, 32, 102, 111, 114, 32, 119, 115, 32, 105, 110, 32, 104, 97, 108, 102, 116, 111, 110, 101, 32, 100, 105, 99, 116, 33, 0], "i8", e);
+    g.re = d([99, 111, 117, 108, 100, 32, 110, 111, 116, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 105, 109, 97, 103, 101, 32, 115, 116, 114, 117, 99, 116, 117, 114, 101, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 105, 109, 97, 103, 101, 95, 110, 101, 119, 0], "i8", e);
+    g.Ib = d([99, 111, 117, 108, 100, 32, 110, 111, 116, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 105, 109, 97, 103, 101, 32, 100, 97, 116, 97, 32, 98, 117, 102, 102, 101, 114, 33, 32, 91, 37, 100, 32, 98, 121, 116, 101, 115, 93, 10, 0], "i8", e);
+    g.sc = d([99, 111, 117, 108, 100, 32, 110, 111, 116, 32, 114, 101, 115, 105, 122, 101, 32, 105, 109, 97, 103, 101, 32, 98, 117, 102, 102, 101, 114, 33, 0], "i8", e);
+    g.Xc = d([106, 98, 105, 103, 50, 95, 105, 109, 97, 103, 101, 95, 114, 101, 115, 105, 122, 101, 32, 99, 97, 108, 108, 101, 100, 32, 119, 105, 116, 104, 32, 97, 32, 100, 105, 102, 102, 101, 114, 101, 110, 116, 32, 119, 105, 100, 116, 104, 32, 40, 78, 89, 73, 41, 0], "i8", e);
+    g.ua = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 115, 101, 103, 109, 101, 110, 116, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 112, 97, 114, 115, 101, 95, 115, 101, 103, 109, 101, 110, 116, 95, 104, 101, 97, 100, 101, 114, 0], "i8", e);
+    g.va = d([106, 98, 105, 103, 50, 95, 112, 97, 114, 115, 101, 95, 115, 101, 103, 109, 101, 110, 116, 95, 104, 101, 97, 100, 101, 114, 40, 41, 32, 99, 97, 108, 108, 101, 100, 32, 119, 105, 116, 104, 32, 105, 110, 115, 117, 102, 102, 105, 99, 105, 101, 110, 116, 32, 100, 97, 116, 97, 0], "i8", e);
+    g.Nb = d([99, 111, 117, 108, 100, 32, 110, 111, 116, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 114, 101, 102, 101, 114, 114, 101, 100, 95, 116, 111, 95, 115, 101, 103, 109, 101, 110, 116, 115, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 112, 97, 114, 115, 101, 95, 115, 101, 103, 109, 101, 110, 116, 95, 104, 101, 97, 100, 101, 114, 0], "i8", e);
+    g.t = d([115, 101, 103, 109, 101, 110, 116, 32, 37, 100, 32, 114, 101, 102, 101, 114, 115, 32, 116, 111, 32, 115, 101, 103, 109, 101, 110, 116, 32, 37, 100, 0], "i8", e);
+    g.ad = d([115, 101, 103, 109, 101, 110, 116, 32, 37, 100, 32, 105, 115, 32, 97, 115, 115, 111, 99, 105, 97, 116, 101, 100, 32, 119, 105, 116, 104, 32, 112, 97, 103, 101, 32, 37, 100, 0], "i8", e);
+    g.zd = d([101, 120, 116, 101, 110, 115, 105, 111, 110, 32, 115, 101, 103, 109, 101, 110, 116, 32, 105, 115, 32, 109, 97, 114, 107, 101, 100, 32, 39, 110, 101, 99, 101, 115, 115, 97, 114, 121, 39, 32, 98, 117, 116, 32, 110, 111, 116, 32, 39, 114, 101, 115, 101, 114, 118, 101, 114, 101, 100, 39, 32, 99, 111, 110, 116, 114, 97, 114, 121, 32, 116, 111, 32, 115, 112, 101, 99, 0], "i8", e);
+    g.Nd = d([117, 110, 104, 97, 110, 100, 108, 101, 100, 32, 110, 101, 99, 101, 115, 115, 97, 114, 121, 32, 101, 120, 116, 101, 110, 115, 105, 111, 110, 32, 115, 101, 103, 109, 101, 110, 116, 32, 116, 121, 112, 101, 32, 48, 120, 37, 48, 56, 120, 0], "i8", e);
+    g.Wd = d([117, 110, 104, 97, 110, 100, 108, 101, 100, 32, 101, 120, 116, 101, 110, 115, 105, 111, 110, 32, 115, 101, 103, 109, 101, 110, 116, 0], "i8", e);
+    g.fe = d([83, 101, 103, 109, 101, 110, 116, 32, 37, 100, 44, 32, 102, 108, 97, 103, 115, 61, 37, 120, 44, 32, 116, 121, 112, 101, 61, 37, 100, 44, 32, 100, 97, 116, 97, 95, 108, 101, 110, 103, 116, 104, 61, 37, 100, 0], "i8", e);
+    g.oe = d([117, 110, 104, 97, 110, 100, 108, 101, 100, 32, 115, 101, 103, 109, 101, 110, 116, 32, 116, 121, 112, 101, 32, 39, 105, 110, 116, 101, 114, 109, 101, 100, 105, 97, 116, 101, 32, 103, 101, 110, 101, 114, 105, 99, 32, 114, 101, 103, 105, 111, 110, 39, 0], "i8", e);
+    g.oa = d([101, 110, 100, 32, 111, 102, 32, 102, 105, 108, 101, 0], "i8", e);
+    g.wa = d([117, 110, 104, 97, 110, 100, 108, 101, 100, 32, 115, 101, 103, 109, 101, 110, 116, 32, 116, 121, 112, 101, 32, 39, 112, 114, 111, 102, 105, 108, 101, 39, 0], "i8", e);
+    g.Ga = d([117, 110, 107, 110, 111, 119, 110, 32, 115, 101, 103, 109, 101, 110, 116, 32, 116, 121, 112, 101, 32, 37, 100, 0], "i8", e);
+    g.Ra = d([117, 110, 97, 98, 108, 101, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 110, 101, 119, 32, 101, 109, 112, 116, 121, 32, 115, 121, 109, 98, 111, 108, 32, 100, 105, 99, 116, 0], "i8", e);
+    g.Ba = d([117, 110, 97, 98, 108, 101, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 103, 108, 121, 112, 104, 115, 32, 102, 111, 114, 32, 110, 101, 119, 32, 101, 109, 112, 116, 121, 32, 115, 121, 109, 98, 111, 108, 32, 100, 105, 99, 116, 0], "i8", e);
+    g.Qb = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 114, 101, 102, 101, 114, 114, 101, 100, 32, 108, 105, 115, 116, 32, 111, 102, 32, 115, 121, 109, 98, 111, 108, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 105, 101, 115, 0], "i8", e);
+    g.yc = d([99, 111, 117, 110, 116, 101, 100, 32, 37, 100, 32, 115, 121, 109, 98, 111, 108, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 105, 101, 115, 32, 98, 117, 116, 32, 98, 117, 105, 108, 100, 32, 97, 32, 108, 105, 115, 116, 32, 119, 105, 116, 104, 32, 37, 100, 46, 10, 0], "i8", e);
+    g.cd = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 110, 101, 119, 32, 115, 121, 109, 98, 111, 108, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 121, 0], "i8", e);
+    g.Ad = d([67, 117, 115, 116, 111, 109, 32, 68, 72, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 32, 110, 111, 116, 32, 102, 111, 117, 110, 100, 32, 40, 37, 100, 41, 0], "i8", e);
+    g.R = d([115, 121, 109, 98, 111, 108, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 121, 32, 115, 112, 101, 99, 105, 102, 105, 101, 100, 32, 105, 110, 118, 97, 108, 105, 100, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 0], "i8", e);
+    g.Xd = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 68, 72, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 0], "i8", e);
+    g.ge = d([67, 117, 115, 116, 111, 109, 32, 68, 87, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 32, 110, 111, 116, 32, 102, 111, 117, 110, 100, 32, 40, 37, 100, 41, 0], "i8", e);
+    g.pe = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 68, 87, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 0], "i8", e);
+    g.pa = d([67, 117, 115, 116, 111, 109, 32, 66, 77, 83, 73, 90, 69, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 32, 110, 111, 116, 32, 102, 111, 117, 110, 100, 32, 40, 37, 100, 41, 0], "i8", e);
+    g.xa = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 66, 77, 83, 73, 90, 69, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 0], "i8", e);
+    g.Ha = d([67, 117, 115, 116, 111, 109, 32, 82, 69, 70, 65, 71, 71, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 32, 110, 111, 116, 32, 102, 111, 117, 110, 100, 32, 40, 37, 100, 41, 0], "i8", e);
+    g.Qa = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 82, 69, 70, 65, 71, 71, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 0], "i8", e);
+    g.Ya = d([83, 68, 72, 85, 70, 70, 32, 105, 115, 32, 122, 101, 114, 111, 44, 32, 98, 117, 116, 32, 99, 111, 110, 116, 114, 97, 114, 121, 32, 116, 111, 32, 115, 112, 101, 99, 32, 83, 68, 72, 85, 70, 70, 68, 72, 32, 105, 115, 32, 110, 111, 116, 46, 0], "i8", e);
+    g.gb = d([83, 68, 72, 85, 70, 70, 32, 105, 115, 32, 122, 101, 114, 111, 44, 32, 98, 117, 116, 32, 99, 111, 110, 116, 114, 97, 114, 121, 32, 116, 111, 32, 115, 112, 101, 99, 32, 83, 68, 72, 85, 70, 70, 68, 87, 32, 105, 115, 32, 110, 111, 116, 46, 0], "i8", e);
+    g.nb = d([98, 105, 116, 109, 97, 112, 32, 99, 111, 100, 105, 110, 103, 32, 99, 111, 110, 116, 101, 120, 116, 32, 105, 115, 32, 117, 115, 101, 100, 32, 40, 78, 89, 73, 41, 32, 115, 121, 109, 98, 111, 108, 32, 100, 97, 116, 97, 32, 108, 105, 107, 101, 108, 121, 32, 116, 111, 32, 98, 101, 32, 103, 97, 114, 98, 97, 103, 101, 33, 0], "i8", e);
+    g.tb = d([115, 121, 109, 98, 111, 108, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 121, 44, 32, 102, 108, 97, 103, 115, 61, 37, 48, 52, 120, 44, 32, 37, 100, 32, 101, 120, 112, 111, 114, 116, 101, 100, 32, 115, 121, 109, 115, 44, 32, 37, 100, 32, 110, 101, 119, 32, 115, 121, 109, 115, 0], "i8", e);
+    g.Ab = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 100, 105, 99, 116, 115, 32, 105, 110, 32, 115, 121, 109, 98, 111, 108, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 121, 0], "i8", e);
+    g.Fb = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 115, 121, 109, 98, 111, 108, 32, 97, 114, 114, 97, 121, 32, 105, 110, 32, 115, 121, 109, 98, 111, 108, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 121, 0], "i8", e);
+    g.Kb = d([115, 101, 103, 109, 101, 110, 116, 32, 109, 97, 114, 107, 115, 32, 98, 105, 116, 109, 97, 112, 32, 99, 111, 100, 105, 110, 103, 32, 99, 111, 110, 116, 101, 120, 116, 32, 97, 115, 32, 117, 115, 101, 100, 32, 40, 78, 89, 73, 41, 0], "i8", e);
+    g.Ob = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 71, 66, 95, 115, 116, 97, 116, 115, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 115, 121, 109, 98, 111, 108, 95, 100, 105, 99, 116, 105, 111, 110, 97, 114, 121, 0], "i8", e);
+    g.Ub = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 71, 82, 95, 115, 116, 97, 116, 115, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 115, 121, 109, 98, 111, 108, 95, 100, 105, 99, 116, 105, 111, 110, 97, 114, 121, 0], "i8", e);
+    g.ac = d([115, 101, 103, 109, 101, 110, 116, 32, 109, 97, 114, 107, 115, 32, 98, 105, 116, 109, 97, 112, 32, 99, 111, 100, 105, 110, 103, 32, 99, 111, 110, 116, 101, 120, 116, 32, 97, 115, 32, 114, 101, 116, 97, 105, 110, 101, 100, 32, 40, 78, 89, 73, 41, 0], "i8", e);
+    g.fc = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 119, 115, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 100, 101, 99, 111, 100, 101, 95, 115, 121, 109, 98, 111, 108, 95, 100, 105, 99, 116, 0], "i8", e);
+    g.jc = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 97, 115, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 100, 101, 99, 111, 100, 101, 95, 115, 121, 109, 98, 111, 108, 95, 100, 105, 99, 116, 0], "i8", e);
+    g.s = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 115, 116, 111, 114, 97, 103, 101, 32, 102, 111, 114, 32, 115, 121, 109, 98, 111, 108, 32, 98, 105, 116, 109, 97, 112, 0], "i8", e);
+    g.nc = d([104, 117, 102, 102, 109, 97, 110, 32, 99, 111, 100, 101, 100, 32, 115, 121, 109, 98, 111, 108, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 121, 0], "i8", e);
+    g.qc = d([99, 111, 117, 108, 100, 32, 110, 111, 116, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 115, 116, 111, 114, 97, 103, 101, 32, 102, 111, 114, 32, 115, 121, 109, 98, 111, 108, 32, 119, 105, 100, 116, 104, 115, 0], "i8", e);
+    g.uc = d([99, 111, 117, 108, 100, 32, 110, 111, 116, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 115, 116, 111, 114, 97, 103, 101, 32, 102, 111, 114, 32, 115, 121, 109, 98, 111, 108, 115, 0], "i8", e);
+    g.wc = d([101, 114, 114, 111, 114, 32, 111, 114, 32, 79, 79, 66, 32, 100, 101, 99, 111, 100, 105, 110, 103, 32, 104, 101, 105, 103, 104, 116, 32, 99, 108, 97, 115, 115, 32, 100, 101, 108, 116, 97, 32, 40, 37, 100, 41, 10, 0], "i8", e);
+    g.Cc = d([73, 110, 118, 97, 108, 105, 100, 32, 72, 67, 72, 69, 73, 71, 72, 84, 32, 118, 97, 108, 117, 101, 0], "i8", e);
+    g.Ic = d([100, 101, 99, 111, 100, 105, 110, 103, 32, 104, 101, 105, 103, 104, 116, 32, 99, 108, 97, 115, 115, 32, 37, 100, 32, 119, 105, 116, 104, 32, 37, 100, 32, 115, 121, 109, 115, 32, 100, 101, 99, 111, 100, 101, 100, 0], "i8", e);
+    g.Lc = d([78, 111, 32, 79, 79, 66, 32, 115, 105, 103, 110, 97, 108, 108, 105, 110, 103, 32, 101, 110, 100, 32, 111, 102, 32, 104, 101, 105, 103, 104, 116, 32, 99, 108, 97, 115, 115, 32, 37, 100, 0], "i8", e);
+    g.Nc = d([32, 79, 79, 66, 32, 115, 105, 103, 110, 97, 108, 115, 32, 101, 110, 100, 32, 111, 102, 32, 104, 101, 105, 103, 104, 116, 32, 99, 108, 97, 115, 115, 32, 37, 100, 0], "i8", e);
+    g.Pc = d([73, 110, 118, 97, 108, 105, 100, 32, 83, 89, 77, 87, 73, 68, 84, 72, 32, 118, 97, 108, 117, 101, 32, 40, 37, 100, 41, 32, 97, 116, 32, 115, 121, 109, 98, 111, 108, 32, 37, 100, 0], "i8", e);
+    g.Rc = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 105, 109, 97, 103, 101, 32, 105, 110, 32, 106, 98, 105, 103, 50, 95, 100, 101, 99, 111, 100, 101, 95, 115, 121, 109, 98, 111, 108, 95, 100, 105, 99, 116, 0], "i8", e);
+    g.Tc = d([105, 110, 118, 97, 108, 105, 100, 32, 110, 117, 109, 98, 101, 114, 32, 111, 102, 32, 115, 121, 109, 98, 111, 108, 115, 32, 111, 114, 32, 79, 79, 66, 32, 105, 110, 32, 97, 103, 103, 114, 101, 103, 97, 116, 101, 32, 103, 108, 121, 112, 104, 0], "i8", e);
+    g.Vc = d([97, 103, 103, 114, 101, 103, 97, 116, 101, 32, 115, 121, 109, 98, 111, 108, 32, 99, 111, 100, 105, 110, 103, 32, 40, 37, 100, 32, 105, 110, 115, 116, 97, 110, 99, 101, 115, 41, 0], "i8", e);
+    g.Yc = d([79, 117, 116, 32, 111, 102, 32, 109, 101, 109, 111, 114, 121, 32, 97, 108, 108, 111, 99, 97, 116, 105, 110, 103, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 121, 32, 97, 114, 114, 97, 121, 0], "i8", e);
+    g.$c = d([79, 117, 116, 32, 111, 102, 32, 109, 101, 109, 111, 114, 121, 32, 97, 108, 108, 111, 99, 97, 116, 105, 110, 103, 32, 115, 121, 109, 98, 111, 108, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 121, 0], "i8", e);
+    g.fd = d([79, 117, 116, 32, 111, 102, 32, 109, 101, 109, 111, 114, 121, 32, 99, 114, 101, 97, 116, 105, 110, 103, 32, 116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 112, 97, 114, 97, 109, 115, 0], "i8", e);
+    g.N = d([79, 117, 116, 32, 111, 102, 32, 109, 101, 109, 111, 114, 121, 32, 99, 114, 101, 97, 116, 105, 110, 103, 32, 115, 121, 109, 98, 111, 108, 32, 105, 109, 97, 103, 101, 0], "i8", e);
+    g.od = d([114, 101, 102, 105, 110, 101, 109, 101, 110, 116, 32, 114, 101, 102, 101, 114, 101, 110, 99, 101, 115, 32, 117, 110, 107, 110, 111, 119, 110, 32, 115, 121, 109, 98, 111, 108, 32, 37, 100, 0], "i8", e);
+    g.qd = d([115, 121, 109, 98, 111, 108, 32, 105, 115, 32, 97, 32, 114, 101, 102, 105, 110, 101, 109, 101, 110, 116, 32, 111, 102, 32, 105, 100, 32, 37, 100, 32, 119, 105, 116, 104, 32, 116, 104, 101, 32, 114, 101, 102, 105, 110, 101, 109, 101, 110, 116, 32, 97, 112, 112, 108, 105, 101, 100, 32, 97, 116, 32, 40, 37, 100, 44, 37, 100, 41, 0], "i8", e);
+    g.rd = d([100, 101, 99, 111, 100, 101, 100, 32, 115, 121, 109, 98, 111, 108, 32, 37, 100, 32, 111, 102, 32, 37, 100, 32, 40, 37, 100, 120, 37, 100, 41, 0], "i8", e);
+    g.td = d([101, 114, 114, 111, 114, 32, 100, 101, 99, 111, 100, 105, 110, 103, 32, 115, 105, 122, 101, 32, 111, 102, 32, 99, 111, 108, 108, 101, 99, 116, 105, 118, 101, 32, 98, 105, 116, 109, 97, 112, 33, 0], "i8", e);
+    g.vd = d([99, 111, 117, 108, 100, 32, 110, 111, 116, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 99, 111, 108, 108, 101, 99, 116, 105, 118, 101, 32, 98, 105, 116, 109, 97, 112, 32, 105, 109, 97, 103, 101, 33, 0], "i8", e);
+    g.xd = d([114, 101, 97, 100, 105, 110, 103, 32, 37, 100, 120, 37, 100, 32, 117, 110, 99, 111, 109, 112, 114, 101, 115, 115, 101, 100, 32, 98, 105, 116, 109, 97, 112, 32, 102, 111, 114, 32, 37, 100, 32, 115, 121, 109, 98, 111, 108, 115, 32, 40, 37, 100, 32, 98, 121, 116, 101, 115, 41, 0], "i8", e);
+    g.yd = d([114, 101, 97, 100, 105, 110, 103, 32, 37, 100, 120, 37, 100, 32, 99, 111, 108, 108, 101, 99, 116, 105, 118, 101, 32, 98, 105, 116, 109, 97, 112, 32, 102, 111, 114, 32, 37, 100, 32, 115, 121, 109, 98, 111, 108, 115, 32, 40, 37, 100, 32, 98, 121, 116, 101, 115, 41, 0], "i8", e);
+    g.Fd = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 99, 111, 112, 121, 32, 116, 104, 101, 32, 99, 111, 108, 108, 101, 99, 116, 105, 118, 101, 32, 98, 105, 116, 109, 97, 112, 32, 105, 110, 116, 111, 32, 115, 121, 109, 98, 111, 108, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 121, 0], "i8", e);
+    g.Hd = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 115, 121, 109, 98, 111, 108, 115, 32, 101, 120, 112, 111, 114, 116, 101, 100, 32, 102, 114, 111, 109, 32, 115, 121, 109, 98, 111, 108, 115, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 121, 0], "i8", e);
+    g.Kd = d([114, 117, 110, 108, 101, 110, 103, 116, 104, 32, 116, 111, 111, 32, 108, 97, 114, 103, 101, 32, 105, 110, 32, 101, 120, 112, 111, 114, 116, 32, 115, 121, 109, 98, 111, 108, 32, 116, 97, 98, 108, 101, 32, 40, 37, 100, 32, 62, 32, 37, 100, 32, 45, 32, 37, 100, 41, 10, 0], "i8", e);
+    g.qb = d([115, 121, 109, 98, 111, 108, 32, 108, 105, 115, 116, 32, 99, 111, 110, 116, 97, 105, 110, 115, 32, 37, 100, 32, 103, 108, 121, 112, 104, 115, 32, 105, 110, 32, 37, 100, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 105, 101, 115, 0], "i8", e);
+    g.Fa = d([104, 117, 102, 102, 109, 97, 110, 32, 99, 111, 100, 101, 100, 32, 116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 0], "i8", e);
+    g.Sb = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 115, 116, 111, 114, 97, 103, 101, 32, 102, 111, 114, 32, 116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 0], "i8", e);
+    g.Ac = d([32, 32, 114, 101, 97, 100, 32, 114, 117, 110, 99, 111, 100, 101, 37, 100, 32, 108, 101, 110, 103, 116, 104, 32, 37, 100, 0], "i8", e);
+    g.dd = d([101, 114, 114, 111, 114, 32, 99, 111, 110, 115, 116, 114, 117, 99, 116, 105, 110, 103, 32, 115, 121, 109, 98, 111, 108, 32, 105, 100, 32, 114, 117, 110, 99, 111, 100, 101, 32, 116, 97, 98, 108, 101, 33, 0], "i8", e);
+    g.Bd = d([109, 101, 109, 111, 114, 121, 32, 97, 108, 108, 111, 99, 97, 116, 105, 111, 110, 32, 102, 97, 105, 108, 117, 114, 101, 32, 114, 101, 97, 100, 105, 110, 103, 32, 115, 121, 109, 98, 111, 108, 32, 73, 68, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 33, 0], "i8", e);
+    g.Od = d([101, 114, 114, 111, 114, 32, 114, 101, 97, 100, 105, 110, 103, 32, 115, 121, 109, 98, 111, 108, 32, 73, 68, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 33, 0], "i8", e);
+    g.Yd = d([101, 114, 114, 111, 114, 32, 100, 101, 99, 111, 100, 105, 110, 103, 32, 115, 121, 109, 98, 111, 108, 32, 105, 100, 32, 116, 97, 98, 108, 101, 58, 32, 114, 117, 110, 32, 108, 101, 110, 103, 116, 104, 32, 119, 105, 116, 104, 32, 110, 111, 32, 97, 110, 116, 101, 99, 101, 100, 101, 110, 116, 33, 0], "i8", e);
+    g.he = d([32, 32, 114, 101, 97, 100, 32, 114, 117, 110, 99, 111, 100, 101, 37, 100, 32, 97, 116, 32, 105, 110, 100, 101, 120, 32, 37, 100, 32, 40, 108, 101, 110, 103, 116, 104, 32, 37, 100, 32, 114, 97, 110, 103, 101, 32, 37, 100, 41, 0], "i8", e);
+    g.qe = d([114, 117, 110, 108, 101, 110, 103, 116, 104, 32, 101, 120, 116, 101, 110, 100, 115, 32, 37, 100, 32, 101, 110, 116, 114, 105, 101, 115, 32, 98, 101, 121, 111, 110, 100, 32, 116, 104, 101, 32, 101, 110, 100, 32, 111, 102, 32, 115, 121, 109, 98, 111, 108, 32, 105, 100, 32, 116, 97, 98, 108, 101, 33, 0], "i8", e);
+    g.ya = d([99, 111, 117, 108, 100, 32, 110, 111, 116, 32, 99, 111, 110, 115, 116, 114, 117, 99, 116, 32, 83, 121, 109, 98, 111, 108, 32, 73, 68, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 33, 0], "i8", e);
+    g.Ia = d([115, 121, 109, 98, 111, 108, 32, 105, 100, 32, 111, 117, 116, 32, 111, 102, 32, 114, 97, 110, 103, 101, 33, 32, 40, 37, 100, 47, 37, 100, 41, 0], "i8", e);
+    g.L = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 100, 101, 99, 111, 100, 101, 32, 100, 97, 116, 97, 0], "i8", e);
+    g.Za = d([99, 111, 117, 108, 100, 110, 39, 116, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 114, 101, 102, 101, 114, 101, 110, 99, 101, 32, 105, 109, 97, 103, 101, 0], "i8", e);
+    g.hb = d([116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 104, 101, 97, 100, 101, 114, 32, 102, 108, 97, 103, 115, 32, 48, 120, 37, 48, 52, 120, 0], "i8", e);
+    g.ob = d([116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 104, 97, 115, 32, 83, 66, 68, 83, 79, 70, 70, 83, 69, 84, 32, 37, 100, 0], "i8", e);
+    g.ub = d([114, 101, 115, 101, 114, 118, 101, 100, 32, 98, 105, 116, 32, 49, 53, 32, 111, 102, 32, 116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 104, 117, 102, 102, 109, 97, 110, 32, 102, 108, 97, 103, 115, 32, 105, 115, 32, 110, 111, 116, 32, 122, 101, 114, 111, 0], "i8", e);
+    g.Bb = d([67, 117, 115, 116, 111, 109, 32, 70, 83, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 32, 110, 111, 116, 32, 102, 111, 117, 110, 100, 32, 40, 37, 100, 41, 0], "i8", e);
+    g.Gb = d([116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 115, 112, 101, 99, 105, 102, 105, 101, 100, 32, 105, 110, 118, 97, 108, 105, 100, 32, 70, 83, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 0], "i8", e);
+    g.Lb = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 115, 112, 101, 99, 105, 102, 105, 101, 100, 32, 70, 83, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 0], "i8", e);
+    g.Pb = d([67, 117, 115, 116, 111, 109, 32, 68, 83, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 32, 110, 111, 116, 32, 102, 111, 117, 110, 100, 32, 40, 37, 100, 41, 0], "i8", e);
+    g.Vb = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 115, 112, 101, 99, 105, 102, 105, 101, 100, 32, 68, 83, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 0], "i8", e);
+    g.bc = d([67, 117, 115, 116, 111, 109, 32, 68, 84, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 32, 110, 111, 116, 32, 102, 111, 117, 110, 100, 32, 40, 37, 100, 41, 0], "i8", e);
+    g.ec = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 115, 112, 101, 99, 105, 102, 105, 101, 100, 32, 68, 84, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 0], "i8", e);
+    g.gc = d([67, 117, 115, 116, 111, 109, 32, 82, 68, 87, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 32, 110, 111, 116, 32, 102, 111, 117, 110, 100, 32, 40, 37, 100, 41, 0], "i8", e);
+    g.kc = d([116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 115, 112, 101, 99, 105, 102, 105, 101, 100, 32, 105, 110, 118, 97, 108, 105, 100, 32, 82, 68, 87, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 0], "i8", e);
+    g.lc = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 115, 112, 101, 99, 105, 102, 105, 101, 100, 32, 82, 68, 87, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 0], "i8", e);
+    g.oc = d([67, 117, 115, 116, 111, 109, 32, 82, 68, 72, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 32, 110, 111, 116, 32, 102, 111, 117, 110, 100, 32, 40, 37, 100, 41, 0], "i8", e);
+    g.rc = d([116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 115, 112, 101, 99, 105, 102, 105, 101, 100, 32, 105, 110, 118, 97, 108, 105, 100, 32, 82, 68, 72, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 0], "i8", e);
+    g.vc = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 115, 112, 101, 99, 105, 102, 105, 101, 100, 32, 82, 68, 72, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 0], "i8", e);
+    g.xc = d([67, 117, 115, 116, 111, 109, 32, 82, 68, 88, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 32, 110, 111, 116, 32, 102, 111, 117, 110, 100, 32, 40, 37, 100, 41, 0], "i8", e);
+    g.Dc = d([116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 115, 112, 101, 99, 105, 102, 105, 101, 100, 32, 105, 110, 118, 97, 108, 105, 100, 32, 82, 68, 88, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 0], "i8", e);
+    g.Jc = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 115, 112, 101, 99, 105, 102, 105, 101, 100, 32, 82, 68, 88, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 0], "i8", e);
+    g.Mc = d([67, 117, 115, 116, 111, 109, 32, 82, 68, 89, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 32, 110, 111, 116, 32, 102, 111, 117, 110, 100, 32, 40, 37, 100, 41, 0], "i8", e);
+    g.Oc = d([116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 115, 112, 101, 99, 105, 102, 105, 101, 100, 32, 105, 110, 118, 97, 108, 105, 100, 32, 82, 68, 89, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 0], "i8", e);
+    g.Qc = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 115, 112, 101, 99, 105, 102, 105, 101, 100, 32, 82, 68, 89, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 0], "i8", e);
+    g.Sc = d([67, 117, 115, 116, 111, 109, 32, 82, 83, 73, 90, 69, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 32, 110, 111, 116, 32, 102, 111, 117, 110, 100, 32, 40, 37, 100, 41, 0], "i8", e);
+    g.Uc = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 115, 112, 101, 99, 105, 102, 105, 101, 100, 32, 82, 83, 73, 90, 69, 32, 104, 117, 102, 102, 109, 97, 110, 32, 116, 97, 98, 108, 101, 0], "i8", e);
+    g.Wc = d([116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 104, 117, 102, 102, 109, 97, 110, 32, 102, 108, 97, 103, 115, 32, 98, 105, 116, 32, 49, 53, 32, 105, 115, 32, 115, 101, 116, 44, 32, 99, 111, 110, 116, 114, 97, 114, 121, 32, 116, 111, 32, 115, 112, 101, 99, 0], "i8", e);
+    g.Zc = d([116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 58, 32, 37, 100, 32, 120, 32, 37, 100, 32, 64, 32, 40, 37, 100, 44, 37, 100, 41, 32, 37, 100, 32, 115, 121, 109, 98, 111, 108, 115, 0], "i8", e);
+    g.bd = d([116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 114, 101, 102, 101, 114, 115, 32, 116, 111, 32, 110, 111, 32, 115, 121, 109, 98, 111, 108, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 105, 101, 115, 33, 0], "i8", e);
+    g.gd = d([117, 110, 97, 98, 108, 101, 32, 116, 111, 32, 114, 101, 116, 114, 105, 118, 101, 32, 115, 121, 109, 98, 111, 108, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 105, 101, 115, 33, 32, 112, 114, 101, 118, 105, 111, 117, 115, 32, 112, 97, 114, 115, 105, 110, 103, 32, 101, 114, 114, 111, 114, 63, 0], "i8", e);
+    g.kd = d([117, 110, 97, 98, 108, 101, 32, 116, 111, 32, 102, 105, 110, 100, 32, 102, 105, 114, 115, 116, 32, 114, 101, 102, 101, 114, 101, 110, 99, 101, 100, 32, 115, 121, 109, 98, 111, 108, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 121, 33, 0], "i8", e);
+    g.md = d([117, 110, 97, 98, 108, 101, 32, 116, 111, 32, 102, 105, 110, 100, 32, 97, 108, 108, 32, 114, 101, 102, 101, 114, 101, 110, 99, 101, 100, 32, 115, 121, 109, 98, 111, 108, 32, 100, 105, 99, 116, 105, 111, 110, 97, 114, 105, 101, 115, 33, 0], "i8", e);
+    g.pd = d([99, 111, 117, 108, 100, 32, 110, 111, 116, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 71, 82, 95, 115, 116, 97, 116, 115, 0], "i8", e);
+    g.P = d([99, 111, 117, 108, 100, 110, 39, 116, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 105, 109, 97, 103, 101, 0], "i8", e);
+    g.Q = d([99, 111, 117, 108, 100, 110, 39, 116, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 105, 109, 97, 103, 101, 32, 100, 97, 116, 97, 0], "i8", e);
+    g.ud = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 100, 101, 99, 111, 100, 101, 32, 116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 105, 109, 97, 103, 101, 32, 100, 97, 116, 97, 0], "i8", e);
+    g.wd = d([99, 111, 109, 112, 111, 115, 105, 110, 103, 32, 37, 100, 120, 37, 100, 32, 100, 101, 99, 111, 100, 101, 100, 32, 116, 101, 120, 116, 32, 114, 101, 103, 105, 111, 110, 32, 111, 110, 116, 111, 32, 112, 97, 103, 101, 32, 97, 116, 32, 40, 37, 100, 44, 32, 37, 100, 41, 0], "i8", e);
+    g.c = d([83, 101, 103, 109, 101, 110, 116, 32, 116, 111, 111, 32, 115, 104, 111, 114, 116, 0], "i8", e);
+    Sd = d([256, 0, 12, 0, 272, 0, 12, 0, 29, 0, 8, 0, 30, 0, 8, 0, 45, 0, 8, 0, 46, 0, 8, 0, 22, 0, 7, 0, 22, 0, 7, 0, 23, 0, 7, 0, 23, 0, 7, 0, 47, 0, 8, 0, 48, 0, 8, 0, 13, 0, 6, 0, 13, 0, 6, 0, 13, 0, 6, 0, 13, 0, 6, 0, 20, 0, 7, 0, 20, 0, 7, 0, 33, 0, 8, 0, 34, 0, 8, 0, 35, 0, 8, 0, 36, 0, 8, 0, 37, 0, 8, 0, 38, 0, 8, 0, 19, 0, 7, 0, 19, 0, 7, 0, 31, 0, 8, 0, 32, 0, 8, 0, 1, 0, 6, 0, 1, 0, 6, 0, 1, 0, 6, 0, 1, 0, 6, 0, 12, 0, 6, 0, 12, 0, 6, 0, 12, 0, 6, 0, 12, 0, 6, 0, 53, 0, 8, 0, 54, 0, 8, 0, 26, 0, 7, 0, 26, 0, 7, 0, 39, 0, 8, 0, 40, 0, 8, 0, 41, 0, 8, 0, 42, 0, 8, 0, 43, 0, 8, 0, 44, 0, 8, 0, 21, 0, 7, 0, 21, 0, 7, 0, 28, 0, 7, 0, 28, 0, 7, 0, 61, 0, 8, 0, 62, 0, 8, 0, 63, 0, 8, 0, 0, 0, 8, 0, 320, 0, 8, 0, 384, 0, 8, 0, 10, 0, 5, 0, 10, 0, 5, 0, 10, 0, 5, 0, 10, 0, 5, 0, 10, 0, 5, 0, 10, 0, 5, 0, 10, 0, 5, 0, 10, 0, 5, 0, 11, 0, 5, 0, 11, 0, 5, 0, 11, 0, 5, 0, 11, 0, 5, 0, 11, 0, 5, 0, 11, 0, 5, 0, 11, 0, 5, 0, 11, 0, 5, 0, 27, 0, 7, 0, 27, 0, 7, 0, 59, 0, 8, 0, 60, 0, 8, 0, 288, 0, 9, 0, 290, 0, 9, 0, 18, 0, 7, 0, 18, 0, 7, 0, 24, 0, 7, 0, 24, 0, 7, 0, 49, 0, 8, 0, 50, 0, 8, 0, 51, 0, 8, 0, 52, 0, 8, 0, 25, 0, 7, 0, 25, 0, 7, 0, 55, 0, 8, 0, 56, 0, 8, 0, 57, 0, 8, 0, 58, 0, 8, 0, 192, 0, 6, 0, 192, 0, 6, 0, 192, 0, 6, 0, 192, 0, 6, 0, 1664, 0, 6, 0, 1664, 0, 6, 0, 1664, 0, 6, 0, 1664, 0, 6, 0, 448, 0, 8, 0, 512, 0, 8, 0, 292, 0, 9, 0, 640, 0, 8, 0, 576, 0, 8, 0, 294, 0, 9, 0, 296, 0, 9, 0, 298, 0, 9, 0, 300, 0, 9, 0, 302, 0, 9, 0, 256, 0, 7, 0, 256, 0, 7, 0, 2, 0, 4, 0, 2, 0, 4, 0, 2, 0, 4, 0, 2, 0, 4, 0, 2, 0, 4, 0, 2, 0, 4, 0, 2, 0, 4, 0, 2, 0, 4, 0, 2, 0, 4, 0, 2, 0, 4, 0, 2, 0, 4, 0, 2, 0, 4, 0, 2, 0, 4, 0, 2, 0, 4, 0, 2, 0, 4, 0, 2, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 128, 0, 5, 0, 128, 0, 5, 0, 128, 0, 5, 0, 128, 0, 5, 0, 128, 0, 5, 0, 128, 0, 5, 0, 128, 0, 5, 0, 128, 0, 5, 0, 8, 0, 5, 0, 8, 0, 5, 0, 8, 0, 5, 0, 8, 0, 5, 0, 8, 0, 5, 0, 8, 0, 5, 0, 8, 0, 5, 0, 8, 0, 5, 0, 9, 0, 5, 0, 9, 0, 5, 0, 9, 0, 5, 0, 9, 0, 5, 0, 9, 0, 5, 0, 9, 0, 5, 0, 9, 0, 5, 0, 9, 0, 5, 0, 16, 0, 6, 0, 16, 0, 6, 0, 16, 0, 6, 0, 16, 0, 6, 0, 17, 0, 6, 0, 17, 0, 6, 0, 17, 0, 6, 0, 17, 0, 6, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 14, 0, 6, 0, 14, 0, 6, 0, 14, 0, 6, 0, 14, 0, 6, 0, 15, 0, 6, 0, 15, 0, 6, 0, 15, 0, 6, 0, 15, 0, 6, 0, 64, 0, 5, 0, 64, 0, 5, 0, 64, 0, 5, 0, 64, 0, 5, 0, 64, 0, 5, 0, 64, 0, 5, 0, 64, 0, 5, 0, 64, 0, 5, 0, 6, 0, 4, 0, 6, 0, 4, 0, 6, 0, 4, 0, 6, 0, 4, 0, 6, 0, 4, 0, 6, 0, 4, 0, 6, 0, 4, 0, 6, 0, 4, 0, 6, 0, 4, 0, 6, 0, 4, 0, 6, 0, 4, 0, 6, 0, 4, 0, 6, 0, 4, 0, 6, 0, 4, 0, 6, 0, 4, 0, 6, 0, 4, 0, 7, 0, 4, 0, 7, 0, 4, 0, 7, 0, 4, 0, 7, 0, 4, 0, 7, 0, 4, 0, 7, 0, 4, 0, 7, 0, 4, 0, 7, 0, 4, 0, 7, 0, 4, 0, 7, 0, 4, 0, 7, 0, 4, 0, 7, 0, 4, 0, 7, 0, 4, 0, 7, 0, 4, 0, 7, 0, 4, 0, 7, 0, 4, 0, -2, 0, 3, 0, -2, 0, 3, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -3, 0, 4, 0, 1792, 0, 3, 0, 1792, 0, 3, 0, 1984, 0, 4, 0, 2048, 0, 4, 0, 2112, 0, 4, 0, 2176, 0, 4, 0, 2240, 0, 4, 0, 2304, 0, 4, 0, 1856, 0, 3, 0, 1856, 0, 3, 0, 1920, 0, 3, 0, 1920, 0, 3, 0, 2368, 0, 4, 0, 2432, 0, 4, 0, 2496, 0, 4, 0, 2560, 0, 4, 0, 1472, 0, 1, 0, 1536, 0, 1, 0, 1600, 0, 1, 0, 1728, 0, 1, 0, 704, 0, 1, 0, 768, 0, 1, 0, 832, 0, 1, 0, 896, 0, 1, 0, 960, 0, 1, 0, 1024, 0, 1, 0, 1088, 0, 1, 0, 1152, 0, 1, 0, 1216, 0, 1, 0, 1280, 0, 1, 0, 1344, 0, 1, 0, 1408, 0, 1, 0], ["i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0], e);
+    se = d([128, 0, 12, 0, 160, 0, 13, 0, 224, 0, 12, 0, 256, 0, 12, 0, 10, 0, 7, 0, 11, 0, 7, 0, 288, 0, 12, 0, 12, 0, 7, 0, 9, 0, 6, 0, 9, 0, 6, 0, 8, 0, 6, 0, 8, 0, 6, 0, 7, 0, 5, 0, 7, 0, 5, 0, 7, 0, 5, 0, 7, 0, 5, 0, 6, 0, 4, 0, 6, 0, 4, 0, 6, 0, 4, 0, 6, 0, 4, 0, 6, 0, 4, 0, 6, 0, 4, 0, 6, 0, 4, 0, 6, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 5, 0, 4, 0, 1, 0, 3, 0, 1, 0, 3, 0, 1, 0, 3, 0, 1, 0, 3, 0, 1, 0, 3, 0, 1, 0, 3, 0, 1, 0, 3, 0, 1, 0, 3, 0, 1, 0, 3, 0, 1, 0, 3, 0, 1, 0, 3, 0, 1, 0, 3, 0, 1, 0, 3, 0, 1, 0, 3, 0, 1, 0, 3, 0, 1, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 4, 0, 3, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 3, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, -2, 0, 4, 0, -2, 0, 4, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, 0, -3, 0, 5, 0, 1792, 0, 4, 0, 1792, 0, 4, 0, 1984, 0, 5, 0, 2048, 0, 5, 0, 2112, 0, 5, 0, 2176, 0, 5, 0, 2240, 0, 5, 0, 2304, 0, 5, 0, 1856, 0, 4, 0, 1856, 0, 4, 0, 1920, 0, 4, 0, 1920, 0, 4, 0, 2368, 0, 5, 0, 2432, 0, 5, 0, 2496, 0, 5, 0, 2560, 0, 5, 0, 18, 0, 3, 0, 18, 0, 3, 0, 18, 0, 3, 0, 18, 0, 3, 0, 18, 0, 3, 0, 18, 0, 3, 0, 18, 0, 3, 0, 18, 0, 3, 0, 52, 0, 5, 0, 52, 0, 5, 0, 640, 0, 6, 0, 704, 0, 6, 0, 768, 0, 6, 0, 832, 0, 6, 0, 55, 0, 5, 0, 55, 0, 5, 0, 56, 0, 5, 0, 56, 0, 5, 0, 1280, 0, 6, 0, 1344, 0, 6, 0, 1408, 0, 6, 0, 1472, 0, 6, 0, 59, 0, 5, 0, 59, 0, 5, 0, 60, 0, 5, 0, 60, 0, 5, 0, 1536, 0, 6, 0, 1600, 0, 6, 0, 24, 0, 4, 0, 24, 0, 4, 0, 24, 0, 4, 0, 24, 0, 4, 0, 25, 0, 4, 0, 25, 0, 4, 0, 25, 0, 4, 0, 25, 0, 4, 0, 1664, 0, 6, 0, 1728, 0, 6, 0, 320, 0, 5, 0, 320, 0, 5, 0, 384, 0, 5, 0, 384, 0, 5, 0, 448, 0, 5, 0, 448, 0, 5, 0, 512, 0, 6, 0, 576, 0, 6, 0, 53, 0, 5, 0, 53, 0, 5, 0, 54, 0, 5, 0, 54, 0, 5, 0, 896, 0, 6, 0, 960, 0, 6, 0, 1024, 0, 6, 0, 1088, 0, 6, 0, 1152, 0, 6, 0, 1216, 0, 6, 0, 64, 0, 3, 0, 64, 0, 3, 0, 64, 0, 3, 0, 64, 0, 3, 0, 64, 0, 3, 0, 64, 0, 3, 0, 64, 0, 3, 0, 64, 0, 3, 0, 13, 0, 1, 0, 13, 0, 1, 0, 13, 0, 1, 0, 13, 0, 1, 0, 13, 0, 1, 0, 13, 0, 1, 0, 13, 0, 1, 0, 13, 0, 1, 0, 13, 0, 1, 0, 13, 0, 1, 0, 13, 0, 1, 0, 13, 0, 1, 0, 13, 0, 1, 0, 13, 0, 1, 0, 13, 0, 1, 0, 13, 0, 1, 0, 23, 0, 4, 0, 23, 0, 4, 0, 50, 0, 5, 0, 51, 0, 5, 0, 44, 0, 5, 0, 45, 0, 5, 0, 46, 0, 5, 0, 47, 0, 5, 0, 57, 0, 5, 0, 58, 0, 5, 0, 61, 0, 5, 0, 256, 0, 5, 0, 16, 0, 3, 0, 16, 0, 3, 0, 16, 0, 3, 0, 16, 0, 3, 0, 17, 0, 3, 0, 17, 0, 3, 0, 17, 0, 3, 0, 17, 0, 3, 0, 48, 0, 5, 0, 49, 0, 5, 0, 62, 0, 5, 0, 63, 0, 5, 0, 30, 0, 5, 0, 31, 0, 5, 0, 32, 0, 5, 0, 33, 0, 5, 0, 40, 0, 5, 0, 41, 0, 5, 0, 22, 0, 4, 0, 22, 0, 4, 0, 14, 0, 1, 0, 14, 0, 1, 0, 14, 0, 1, 0, 14, 0, 1, 0, 14, 0, 1, 0, 14, 0, 1, 0, 14, 0, 1, 0, 14, 0, 1, 0, 14, 0, 1, 0, 14, 0, 1, 0, 14, 0, 1, 0, 14, 0, 1, 0, 14, 0, 1, 0, 14, 0, 1, 0, 14, 0, 1, 0, 14, 0, 1, 0, 15, 0, 2, 0, 15, 0, 2, 0, 15, 0, 2, 0, 15, 0, 2, 0, 15, 0, 2, 0, 15, 0, 2, 0, 15, 0, 2, 0, 15, 0, 2, 0, 128, 0, 5, 0, 192, 0, 5, 0, 26, 0, 5, 0, 27, 0, 5, 0, 28, 0, 5, 0, 29, 0, 5, 0, 19, 0, 4, 0, 19, 0, 4, 0, 20, 0, 4, 0, 20, 0, 4, 0, 34, 0, 5, 0, 35, 0, 5, 0, 36, 0, 5, 0, 37, 0, 5, 0, 38, 0, 5, 0, 39, 0, 5, 0, 21, 0, 4, 0, 21, 0, 4, 0, 42, 0, 5, 0, 43, 0, 5, 0, 0, 0, 3, 0, 0, 0, 3, 0, 0, 0, 3, 0, 0, 0, 3, 0], ["i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0, "i16", 0], e);
+    g.ye = d([255, 127, 63, 31, 15, 7, 3, 1], "i8", e);
+    g.S = d([0, 128, 192, 224, 240, 248, 252, 254], "i8", e);
+    g.Yb = d([117, 110, 101, 120, 112, 101, 99, 116, 101, 100, 32, 112, 97, 103, 101, 32, 105, 110, 102, 111, 32, 115, 101, 103, 109, 101, 110, 116, 44, 32, 109, 97, 114, 107, 105, 110, 103, 32, 112, 114, 101, 118, 105, 111, 117, 115, 32, 112, 97, 103, 101, 32, 102, 105, 110, 105, 115, 104, 101, 100, 0], "i8", e);
+    g.Ka = d([115, 101, 103, 109, 101, 110, 116, 32, 116, 111, 111, 32, 115, 104, 111, 114, 116, 0], "i8", e);
+    g.Wb = d([104, 101, 105, 103, 104, 116, 32, 105, 115, 32, 117, 110, 115, 112, 101, 99, 105, 102, 105, 101, 100, 32, 98, 117, 116, 32, 112, 97, 103, 101, 32, 105, 115, 32, 110, 111, 116, 32, 109, 97, 114, 107, 101, 115, 32, 97, 115, 32, 115, 116, 114, 105, 112, 101, 100, 0], "i8", e);
+    g.Ec = d([101, 120, 116, 114, 97, 32, 100, 97, 116, 97, 32, 105, 110, 32, 115, 101, 103, 109, 101, 110, 116, 0], "i8", e);
+    g.hd = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 98, 117, 102, 102, 101, 114, 32, 102, 111, 114, 32, 112, 97, 103, 101, 32, 105, 109, 97, 103, 101, 0], "i8", e);
+    g.Dd = d([97, 108, 108, 111, 99, 97, 116, 101, 100, 32, 37, 100, 120, 37, 100, 32, 112, 97, 103, 101, 32, 105, 109, 97, 103, 101, 32, 40, 37, 100, 32, 98, 121, 116, 101, 115, 41, 0], "i8", e);
+    g.Qd = d([101, 110, 100, 32, 111, 102, 32, 115, 116, 114, 105, 112, 101, 32, 115, 101, 103, 109, 101, 110, 116, 32, 119, 105, 116, 104, 32, 110, 111, 110, 45, 112, 111, 115, 105, 116, 105, 118, 101, 32, 101, 110, 100, 32, 114, 111, 119, 32, 97, 100, 118, 97, 110, 99, 101, 32, 40, 110, 101, 119, 32, 101, 110, 100, 32, 114, 111, 119, 32, 37, 100, 32, 118, 115, 32, 99, 117, 114, 114, 101, 110, 116, 32, 101, 110, 100, 32, 114, 111, 119, 32, 37, 100, 41, 0], "i8", e);
+    g.$d = d([101, 110, 100, 32, 111, 102, 32, 115, 116, 114, 105, 112, 101, 58, 32, 97, 100, 118, 97, 110, 99, 105, 110, 103, 32, 101, 110, 100, 32, 114, 111, 119, 32, 116, 111, 32, 37, 100, 0], "i8", e);
+    g.je = d([70, 105, 108, 101, 32, 104, 97, 115, 32, 97, 110, 32, 105, 110, 118, 97, 108, 105, 100, 32, 115, 101, 103, 109, 101, 110, 116, 32, 100, 97, 116, 97, 32, 108, 101, 110, 103, 116, 104, 33, 32, 84, 114, 121, 105, 110, 103, 32, 116, 111, 32, 100, 101, 99, 111, 100, 101, 32, 117, 115, 105, 110, 103, 32, 116, 104, 101, 32, 97, 118, 97, 105, 108, 97, 98, 108, 101, 32, 100, 97, 116, 97, 46, 0], "i8", e);
+    g.te = d([101, 110, 100, 32, 111, 102, 32, 112, 97, 103, 101, 32, 109, 97, 114, 107, 101, 114, 32, 102, 111, 114, 32, 112, 97, 103, 101, 32, 37, 100, 32, 100, 111, 101, 115, 110, 39, 116, 32, 109, 97, 116, 99, 104, 32, 99, 117, 114, 114, 101, 110, 116, 32, 112, 97, 103, 101, 32, 110, 117, 109, 98, 101, 114, 32, 37, 100, 0], "i8", e);
+    g.qa = d([101, 110, 100, 32, 111, 102, 32, 112, 97, 103, 101, 32, 37, 100, 0], "i8", e);
+    g.za = d([103, 114, 111, 119, 105, 110, 103, 32, 112, 97, 103, 101, 32, 98, 117, 102, 102, 101, 114, 32, 116, 111, 32, 37, 100, 32, 114, 111, 119, 115, 32, 116, 111, 32, 97, 99, 99, 111, 109, 111, 100, 97, 116, 101, 32, 110, 101, 119, 32, 115, 116, 114, 105, 112, 101, 0], "i8", e);
+    g.Ja = d([112, 97, 103, 101, 32, 37, 100, 32, 114, 101, 116, 117, 114, 110, 101, 100, 32, 116, 111, 32, 116, 104, 101, 32, 99, 108, 105, 101, 110, 116, 0], "i8", e);
+    g.Sa = d([112, 97, 103, 101, 32, 37, 100, 32, 114, 101, 116, 117, 114, 110, 101, 100, 32, 119, 105, 116, 104, 32, 110, 111, 32, 97, 115, 115, 111, 99, 105, 97, 116, 101, 100, 32, 105, 109, 97, 103, 101, 0], "i8", e);
+    g.$a = d([112, 97, 103, 101, 32, 37, 100, 32, 114, 101, 108, 101, 97, 115, 101, 100, 32, 98, 121, 32, 116, 104, 101, 32, 99, 108, 105, 101, 110, 116, 0], "i8", e);
+    g.ib = d([106, 98, 105, 103, 50, 95, 114, 101, 108, 101, 97, 115, 101, 95, 112, 97, 103, 101, 32, 99, 97, 108, 108, 101, 100, 32, 111, 110, 32, 117, 110, 107, 110, 111, 119, 110, 32, 112, 97, 103, 101, 0], "i8", e);
+    g.pb = d([112, 97, 103, 101, 32, 37, 100, 32, 105, 109, 97, 103, 101, 32, 105, 115, 32, 37, 100, 120, 37, 100, 32, 40, 117, 110, 107, 110, 111, 119, 110, 32, 114, 101, 115, 41, 0], "i8", e);
+    g.vb = d([112, 97, 103, 101, 32, 37, 100, 32, 105, 109, 97, 103, 101, 32, 105, 115, 32, 37, 100, 120, 37, 100, 32, 40, 37, 100, 32, 112, 112, 109, 41, 0], "i8", e);
+    g.Cb = d([112, 97, 103, 101, 32, 37, 100, 32, 105, 109, 97, 103, 101, 32, 105, 115, 32, 37, 100, 120, 37, 100, 32, 40, 37, 100, 120, 37, 100, 32, 112, 112, 109, 41, 0], "i8", e);
+    g.Hb = d([9, 109, 97, 120, 105, 109, 117, 109, 32, 115, 116, 114, 105, 112, 101, 32, 115, 105, 122, 101, 58, 32, 37, 100, 0], "i8", e);
+    g.hc = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 115, 116, 111, 114, 97, 103, 101, 32, 102, 111, 114, 32, 109, 101, 116, 97, 100, 97, 116, 97, 32, 107, 101, 121, 115, 47, 118, 97, 108, 117, 101, 115, 0], "i8", e);
+    g.La = d([102, 97, 105, 108, 101, 100, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 115, 116, 111, 114, 97, 103, 101, 32, 102, 111, 114, 32, 109, 101, 116, 97, 100, 97, 116, 97, 0], "i8", e);
+    g.Xb = d([117, 110, 97, 98, 108, 101, 32, 116, 111, 32, 114, 101, 115, 105, 122, 101, 32, 109, 101, 116, 97, 100, 97, 116, 97, 32, 115, 116, 114, 117, 99, 116, 117, 114, 101, 0], "i8", e);
+    g.Fc = d([65, 83, 67, 73, 73, 32, 99, 111, 109, 109, 101, 110, 116, 32, 100, 97, 116, 97, 0], "i8", e);
+    g.jd = d([117, 110, 97, 98, 108, 101, 32, 116, 111, 32, 97, 108, 108, 111, 99, 97, 116, 101, 32, 99, 111, 109, 109, 101, 110, 116, 32, 115, 116, 114, 117, 99, 116, 117, 114, 101, 0], "i8", e);
+    g.Ed = d([39, 37, 115, 39, 9, 39, 37, 115, 39, 0], "i8", e);
+    g.Rd = d([117, 110, 101, 120, 112, 101, 99, 116, 101, 100, 32, 101, 110, 100, 32, 111, 102, 32, 99, 111, 109, 109, 101, 110, 116, 32, 115, 101, 103, 109, 101, 110, 116, 0], "i8", e);
+    g.ae = d([117, 110, 104, 97, 110, 100, 108, 101, 100, 32, 117, 110, 105, 99, 111, 100, 101, 32, 99, 111, 109, 109, 101, 110, 116, 32, 115, 101, 103, 109, 101, 110, 116, 0], "i8", e);
+    g.ke = d([117, 110, 97, 98, 108, 101, 32, 116, 111, 32, 100, 117, 112, 108, 105, 99, 97, 116, 101, 32, 99, 111, 109, 109, 101, 110, 116, 32, 115, 116, 114, 105, 110, 103, 0], "i8", e);
+    ta = d(20, ["i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0, "i32", 0, 0, 0], e);
+    g.Na = d([87, 65, 82, 78, 73, 78, 71, 58, 32, 37, 115, 10, 0], "i8", e);
+    g.Zb = d([70, 65, 84, 65, 76, 32, 69, 82, 82, 79, 82, 58, 32, 37, 115, 10, 0], "i8", e);
+    g.ef = d([128, 0], "i8", e);
+    d(2, "i8", e);
+    j = d(468, ["i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0, "i32", 0, 0, 0, "*", 0, 0, 0, "i32", 0, 0, 0], e);
+    aa = d(24, "i32", e);
+    g.ff = d([109, 97, 120, 32, 115, 121, 115, 116, 101, 109, 32, 98, 121, 116, 101, 115, 32, 61, 32, 37, 49, 48, 108, 117, 10, 0], "i8", e);
+    g.af = d([115, 121, 115, 116, 101, 109, 32, 98, 121, 116, 101, 115, 32, 32, 32, 32, 32, 61, 32, 37, 49, 48, 108, 117, 10, 0], "i8", e);
+    g.df = d([105, 110, 32, 117, 115, 101, 32, 98, 121, 116, 101, 115, 32, 32, 32, 32, 32, 61, 32, 37, 49, 48, 108, 117, 10, 0], "i8", e);
+    d([ed], "i8", e);
+    d(1, "void ()*", e);
+    Ud = d([0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 16, 0, 0, 0, 18, 0, 0, 0], ["*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0], e);
+    d(1, "void*", e);
+    g.Gc = d([115, 116, 100, 58, 58, 98, 97, 100, 95, 97, 108, 108, 111, 99, 0], "i8", e);
+    Se = d([0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 20, 0, 0, 0, 22, 0, 0, 0], ["*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0, "*", 0, 0, 0], e);
+    d(1, "void*", e);
+    g.ab = d([98, 97, 100, 95, 97, 114, 114, 97, 121, 95, 110, 101, 119, 95, 108, 101, 110, 103, 116, 104, 0], "i8", e);
+    g.na = d([83, 116, 57, 98, 97, 100, 95, 97, 108, 108, 111, 99, 0], "i8", e);
+    lb = d(12, "*", e);
+    g.ma = d([83, 116, 50, 48, 98, 97, 100, 95, 97, 114, 114, 97, 121, 95, 110, 101, 119, 95, 108, 101, 110, 103, 116, 104, 0], "i8", e);
+    zc = d(12, "*", e);
+    g.ze = d([78, 101, 101, 100, 32, 109, 111, 114, 101, 32, 100, 97, 116, 97, 46, 0], "i8", e);
+    g.Ae = d([78, 111, 32, 112, 97, 103, 101, 115, 33, 32, 73, 110, 99, 111, 109, 112, 108, 101, 116, 101, 32, 115, 116, 114, 101, 97, 109, 63, 33, 0], "i8", e);
+    a[Jd + 8 >> 2] = vg | 0;
+    a[ge + 8 >> 2] = wg | 0;
+    a[Zc + 8 >> 2] = xg | 0;
+    a[Yc + 8 >> 2] = yg | 0;
+    a[Ec + 8 >> 2] = zg | 0;
+    a[xe + 8 >> 2] = Ag | 0;
+    a[Qd + 8 >> 2] = Bg | 0;
+    a[ye + 8 >> 2] = Cg | 0;
+    a[pe + 8 >> 2] = Dg | 0;
+    a[fd + 8 >> 2] = Eg | 0;
+    a[ze + 8 >> 2] = Fg | 0;
+    a[Rd + 8 >> 2] = Gg | 0;
+    a[qe + 8 >> 2] = Hg | 0;
+    a[Rc + 8 >> 2] = Ig | 0;
+    a[Ib + 8 >> 2] = Jg | 0;
+    a[Ud + 4 >> 2] = lb;
+    a[Se + 4 >> 2] = zc;
+    Te = d([2, 0, 0, 0, 0], ["i8*", 0, 0, 0, 0], e);
+    a[lb >> 2] = Te + 8 | 0;
+    a[lb + 4 >> 2] = g.na | 0;
+    a[lb + 8 >> 2] = ua;
+    a[zc >> 2] = Te + 8 | 0;
+    a[zc + 4 >> 2] = g.ma | 0;
+    a[zc + 8 >> 2] = lb;
+    Q = [0, 0, bf, 0, (function (d, e, f, j) {
+      3 == (f | 0) && (bc(a[kb >> 2], g.fb | 0, (c = b, b += 4, a[c >> 2] = e, c)), -1 != (j | 0) && bc(a[kb >> 2], g.mb | 0, (c = b, b += 4, a[c >> 2] = j, c)), Mb(10, a[kb >> 2]), Xd(a[kb >> 2]));
+      return 0
+    }), 0, (function (d, e, f) {
+      0 < (f | 0) && (d = (c = b, b += 4, a[c >> 2] = e, c),
+          bc(a[$a >> 2], g.Na | 0, d), Xd(a[$a >> 2]),
+          2 < (f | 0) && (e = (c = b, b += 4, a[c >> 2] = e, c),
+              bc(a[$a >> 2], g.Zb | 0, e), Xd(a[$a >> 2]), wb(Yd),
+              og.print()));
+      return 0
+    }), 0, te, 0, (function (a, b) {
+      return Wb(b)
+    }), 0, (function (a, b) {
+      hb(b)
+    }), 0, (function (a, b, c) {
+      return 0 == (b | 0) ? Wb(c) : ig(b, c)
+    }), 0, (function (a) {
+      te(a);
+      0 != (a | 0) && hb(a)
+    }), 0, (function () {
+      return g.Gc | 0
+    }), 0, (function (a) {
+      te(a | 0);
+      0 != (a | 0) && hb(a)
+    }), 0, (function () {
+      return g.ab | 0
+    }), 0, jg, 0, (function (b) {
+      jg(b | 0);
+      a[b >> 2] = Se + 8 | 0
+    }), 0];
+    x.FUNCTION_TABLE = Q;
+    x.run = mg;
+    wb(ug);
+    x.noInitialRun && (ae++, x.monitorRunDependencies && x.monitorRunDependencies(ae));
+    0 == ae && mg();
+    x.readArrayFromMemory = (function (a, b) {
+      for (var c = 0; c < a.length; c++) {
+        a[c] = q[b + c]
+      }
+    });
+    x._process = (function (d, e) {
+      var f, j, n = a[ta + 12 >> 2];
+      if ((n | 0) != 0) {
+        hb(n);
+        a[ta + 12 >> 2] = 0
+      }
+      n = df(0, 1, 0, 6, 0);
+      ff(n, d, e);
+      j = $f(n);
+      if ((j | 0) == 0) {
+        ee(n);
+        j = $f(n);
+        if ((j | 0) != 0) {
+          var p = j;
+          j = 5
+        } else {
+          hf(g.Ae | 0);
+          j = 11
+        }
+      } else {
+        p = j;
+        j = 5
+      }
+      if (j == 5) {
+        j = a[p + 4 >> 2] * a[p + 8 >> 2] | 0;
+        f = p >> 2;
+        a[ta >> 2] = a[f];
+        a[ta + 4 >> 2] = a[f + 1];
+        a[ta + 8 >> 2] = a[f + 2];
+        a[ta + 12 >> 2] = a[f + 3];
+        a[ta + 16 >> 2] = a[f + 4];
+        f = Wb(j);
+        a[ta + 12 >> 2] = f;
+        var k = (j | 0) > 0;
+        a:do {
+          if (k) {
+            for (var i = p + 12 | 0, w = 0, x = f; ;) {
+              q[x + w | 0] = q[a[i >> 2] + w | 0] ^ -1;
+              w = w + 1 | 0;
+              if ((w | 0) == (j | 0)) {
+                break a
+              }
+              x = a[ta + 12 >> 2]
+            }
+          }
+        } while (0);
+        f = a[n + 68 >> 2];
+        j = (n + 72 | 0) >> 2;
+        for (k = 0; ;) {
+          if ((k | 0) >= (f | 0)) {
+            m(n, 2, -1, g.ib | 0, (c = b, b = b + 1, b = b + 3 >> 2 << 2, a[c >> 2] = 0, c));
+            break
+          }
+          if ((a[(a[j] + 40 >> 2) + (k * 11 | 0)] | 0) == (p | 0)) {
+            Qa(n, p);
+            a[(a[j] + k * 44 | 0) >> 2] = 4;
+            p = a[(a[j] + 4 >> 2) + (k * 11 | 0)];
+            m(n, 0, -1, g.$a | 0, (c = b, b = b + 4, a[c >> 2] = p, c));
+            break
+          }
+          k = k + 1 | 0
+        }
+      }
+      jf(n);
+      return 0
+    });
+    x._getWidth = (function () {
+      return a[ta >> 2]
+    });
+    x._getHeight = (function () {
+      return a[ta + 4 >> 2]
+    });
+    x._getStride = (function () {
+      return a[ta + 8 >> 2]
+    });
+    x._getPixels = (function () {
+      return a[ta + 12 >> 2]
+    });
+    this.__process = vb("process", "number", ["array", "number"]);
+    this.__getWidth = vb("getWidth", "number");
+    this.__getHeight = vb("getHeight", "number");
+    this.__getStride = vb("getStride", "number");
+    this.__getPixels = vb("getPixels", "pointer")
+  }
+
+  var x = {};
+  oa.prototype.process = (function (oa) {
+    console.log("process " + oa.length + " bytes");
+    this.__process(oa, oa.length);
+    var oa = this.__getWidth(), Ia = this.__getHeight(), Ub = this.__getStride(), Ba = Ub * Ia, Cb = this.__getPixels();
+    if (0 == Cb) {
+      return Sc
+    }
+    var Ba = new ArrayBuffer(Ba), Vb = new Uint8Array(Ba);
+    x.readArrayFromMemory(Vb, Cb);
+    return{width:oa, height:Ia, stride:Ub, pixels:Vb, buffer:Ba}
+  });
+  return oa
+})();
+var JBig2Decode = new Yg;

--- a/external/jbig2dec/jbig2dec.js
+++ b/external/jbig2dec/jbig2dec.js
@@ -1,3 +1,18 @@
+/*
+    jbig2dec
+
+    Copyright (C) 2002-2008 Artifex Software, Inc.
+
+    This software is distributed under license and may not
+    be copied, modified or distributed except as expressly
+    authorized under the terms of the license contained in
+    the file LICENSE in this distribution.
+
+    For further licensing information refer to http://artifex.com/ or
+    contact Artifex Software, Inc., 7 Mt. Lassen Drive - Suite A-134,
+    San Rafael, CA  94903, U.S.A., +1(415)492-9861.
+*/
+
 function N(oa) {
   throw oa
 }

--- a/src/parser.js
+++ b/src/parser.js
@@ -253,7 +253,7 @@ var Parser = (function ParserClosure() {
         return new RunLengthStream(stream);
       }
       if (name == 'JBIG2Decode') {
-        error('JBIG2 image format is not currently supprted.');
+        return new JBig2Stream(stream);
       }
       warn('filter "' + name + '" not supported yet');
       return stream;

--- a/src/stream.js
+++ b/src/stream.js
@@ -1151,6 +1151,34 @@ var AsciiHexStream = (function AsciiHexStreamClosure() {
   return AsciiHexStream;
 })();
 
+var JBig2Stream = (function JBig2StreamClosure() {
+  function JBig2Stream(str) {
+    this.str = str;
+    this.dict = str.dict;
+    DecodeStream.call(this);
+  }
+
+  JBig2Stream.prototype = Object.create(DecodeStream.prototype);
+
+  JBig2Stream.prototype.readBlock = function JBig2Stream_readBlock() {
+    var bytes = this.str.getBytes();
+
+    warn('About to process ' + bytes.length + ' bytes of data...');
+
+    var image = JBig2Decode.process(bytes);
+
+    assert(image, 'JBig2Decode failed to decode the stream.');
+
+    var buffer = this.ensureBuffer(image.pixels.length);
+
+    this.buffer = image.pixels;
+    this.bufferLength = image.pixels.length;
+
+  };
+
+  return JBig2Stream;
+})();
+
 var RunLengthStream = (function RunLengthStreamClosure() {
   function RunLengthStream(str) {
     this.str = str;

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -30,6 +30,7 @@
         <script type="text/javascript" src="../src/stream.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
         <script type="text/javascript" src="../src/worker.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
         <script type="text/javascript" src="../external/jpgjs/jpg.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
+        <script type="text/javascript" src="../external/jbig2dec/jbig2dec.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
         <script type="text/javascript" src="../src/jpx.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
         <script type="text/javascript" src="../src/bidi.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
         <script type="text/javascript">PDFJS.workerSrc = '../src/worker_loader.js';</script> <!-- PDFJSSCRIPT_REMOVE_CORE -->


### PR DESCRIPTION
I converted jbig2dec from C to javascript using emscripten, and custom glue code.
Most JBig2Decode images are now displayed.

Related issues: #806, #1089, #1147, #1303, #1308, #1467, #1472, #1480, #1509, #1606

Still broken:
- #1509 -- http://iranembassy.ca/forms/Aber_Gheiremojaz.pdf
- #806 -- http://pdfstore.patentorder.com/pdf/us/140/us2005100140.pdf

Apparently unrelated issue: Message: Bits per component missing in image: false
- #1303 -- http://dspace.mit.edu/bitstream/handle/1721.1/48833/planningsystemsc00rama.pdf

Requires unimplemented feature:
- #1606 -- http://articles.adsabs.harvard.edu/cgi-bin/nph-iarticle_query?1984ApJ...277..470P&defaultprint=YES&filetype=.pdf

The JBig2 support in PDF allows for a separate JBIG2Globals stream, which should contain all the data not specific to any of the images. This global stream is currently not handled, so the decoder doesn't have enough data to process the decoding.

I'm not yet sure how this relates to the problems in #1509 and #806.

[EDIT: Fixed a few typos and added the new issue]
[UPDATE: Mode details on #1606]
