### PR TITLE
Terminates browser processes; if killed waits for termination

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -292,6 +292,8 @@ class BaseBrowserCommand(object):
         self.browserLog = open(BROWSERLOG_FILE, "w")
 
     def teardown(self):
+        self.process.terminate()
+
         # If the browser is still running, wait up to ten seconds for it to quit
         if self.process and self.process.poll() is None:
             checks = 0
@@ -302,6 +304,7 @@ class BaseBrowserCommand(object):
             if self.process.poll() is None:
                 print "Process %s is still running. Killing." % self.name
                 self.process.kill()
+                self.process.wait()
             
         if self.tempDir is not None and os.path.exists(self.tempDir):
             shutil.rmtree(self.tempDir)


### PR DESCRIPTION
Removes the following message:

```
Process firefox is still running. Killing.
Error cleaning up after browser at  C:/Program Files (x86)/Mozilla Firefox/firefox.exe
Temp dir was  c:\users\xxxx\appdata\local\temp\tmp1n6ipf
Error: <type 'exceptions.WindowsError'>
```
