### PR TITLE
Add mailto protocol to whitelist - #1608

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -188,6 +188,7 @@ var Page = (function PageClosure() {
           case 'http':
           case 'https':
           case 'ftp':
+          case 'mailto':
             return true;
           default:
             return false;


### PR DESCRIPTION
There shouldn't be any security issues involved with this implementation, according to @yurydelendik and Google :)

Fixes #1608 by whitelisting the 'mailto' protocol in links.
