### PR TITLE
Opera, Mac: exception on importScript jpg.js locally (clean pull)

### DIFF
--- a/src/worker_loader.js
+++ b/src/worker_loader.js
@@ -23,9 +23,9 @@ var files = [
   'pattern.js',
   'stream.js',
   'worker.js',
-  '../external/jpgjs/jpg.js',
   'jpx.js',
-  'bidi.js'
+  'bidi.js',
+  '../external/jpgjs/jpg.js'
 ];
 
 // Load all the files.


### PR DESCRIPTION
If you open viewer.html on your local computer in Opera, worker_loader.js throws an exception for each script file imported after '../external/jpgjs/jpg.js'.

It does not happen if you access viewer.html on a server or if jpg.js is not placed in a subfolder of the parent folder '..'. Although I do not understand fully what is going on here, the fix is straightforward: importing jpg.js last.

I am interested if someone has an explanation of this behavior. Either we should file a bug report for Opera or there is another issue with our usage of importScripts ...?
