### PR TITLE
HTTP Header support

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -10,7 +10,7 @@
  * @param {string|TypedAray} source Either a url to a PDF is located or a
  * typed array (Uint8Array) already populated with data.
  * @param {Object} headers An object containing the http headers like this:
- * { Authorization: "BASIC XXX" }
+ * { Authorization: "BASIC XXX" }.
  * @return {Promise} A promise that is resolved with {PDFDocumentProxy} object.
  */
 PDFJS.getDocument = function getDocument(source, headers) {
@@ -32,7 +32,7 @@ PDFJS.getDocument = function getDocument(source, headers) {
           promise.reject('Unexpected server response of ' +
             e.target.status + '.');
         },
-	headers: headers
+        headers: headers
       },
       function getPDFLoad(data) {
         transport.sendData(data);

--- a/src/api.js
+++ b/src/api.js
@@ -8,10 +8,10 @@
  * e.g. No cross domain requests without CORS.
  *
  * @param {string|TypedAray} source Either a url to a PDF is located or a
- * typed array already populated with data.
+ * typed array (Uint8Array) already populated with data.
  * @return {Promise} A promise that is resolved with {PDFDocumentProxy} object.
  */
-PDFJS.getDocument = function getDocument(source) {
+PDFJS.getDocument = function getDocument(source, headers) {
   var promise = new PDFJS.Promise();
   var transport = new WorkerTransport(promise);
   if (typeof source === 'string') {
@@ -29,7 +29,8 @@ PDFJS.getDocument = function getDocument(source) {
         error: function getPDFError(e) {
           promise.reject('Unexpected server response of ' +
             e.target.status + '.');
-        }
+        },
+	headers: headers
       },
       function getPDFLoad(data) {
         transport.sendData(data);

--- a/src/api.js
+++ b/src/api.js
@@ -9,6 +9,8 @@
  *
  * @param {string|TypedAray} source Either a url to a PDF is located or a
  * typed array (Uint8Array) already populated with data.
+ * @param {Object} headers An object containing the http headers like this:
+ * { Authorization: "BASIC XXX" }
  * @return {Promise} A promise that is resolved with {PDFDocumentProxy} object.
  */
 PDFJS.getDocument = function getDocument(source, headers) {

--- a/src/core.js
+++ b/src/core.js
@@ -32,11 +32,14 @@ function getPdf(arg, callback) {
 
   var xhr = new XMLHttpRequest();
   
-  if(params.headers){
-    //TODO: Code this, use xhr.setRequestHeader(key, value);
-  }
-  
   xhr.open('GET', params.url);
+  if(params.headers){
+    for(var property in params.headers){
+      if(typeof(params.headers[property]) !== undefined){
+	xhr.setRequestHeader(property, params.headers[property]);
+      }
+    }
+  }
   xhr.mozResponseType = xhr.responseType = 'arraybuffer';
   var protocol = params.url.indexOf(':') < 0 ? window.location.protocol :
     params.url.substring(0, params.url.indexOf(':') + 1);

--- a/src/core.js
+++ b/src/core.js
@@ -33,13 +33,17 @@ function getPdf(arg, callback) {
   var xhr = new XMLHttpRequest();
   
   xhr.open('GET', params.url);
-  if(params.headers){
-    for(var property in params.headers){
-      if(typeof(params.headers[property]) !== undefined){
-	xhr.setRequestHeader(property, params.headers[property]);
-      }
+  
+  var headers = params.headers;
+  if (headers) {
+    for (var property in headers) {
+      if (typeof headers[property] === 'undefined')
+        continue;
+      
+      xhr.setRequestHeader(property, params.headers[property]);
     }
   }
+  
   xhr.mozResponseType = xhr.responseType = 'arraybuffer';
   var protocol = params.url.indexOf(':') < 0 ? window.location.protocol :
     params.url.substring(0, params.url.indexOf(':') + 1);

--- a/src/core.js
+++ b/src/core.js
@@ -31,6 +31,11 @@ function getPdf(arg, callback) {
     params = { url: arg };
 
   var xhr = new XMLHttpRequest();
+  
+  if(params.headers){
+    //TODO: Code this, use xhr.setRequestHeader(key, value);
+  }
+  
   xhr.open('GET', params.url);
   xhr.mozResponseType = xhr.responseType = 'arraybuffer';
   var protocol = params.url.indexOf(':') < 0 ? window.location.protocol :

--- a/src/core.js
+++ b/src/core.js
@@ -31,19 +31,19 @@ function getPdf(arg, callback) {
     params = { url: arg };
 
   var xhr = new XMLHttpRequest();
-  
+
   xhr.open('GET', params.url);
-  
+
   var headers = params.headers;
   if (headers) {
     for (var property in headers) {
       if (typeof headers[property] === 'undefined')
         continue;
-      
+
       xhr.setRequestHeader(property, params.headers[property]);
     }
   }
-  
+
   xhr.mozResponseType = xhr.responseType = 'arraybuffer';
   var protocol = params.url.indexOf(':') < 0 ? window.location.protocol :
     params.url.substring(0, params.url.indexOf(':') + 1);


### PR DESCRIPTION
This patch allows to add custom headers to the http request that downloads the PDF from a certain url. For example authentication can be implemented with this.
This closes this issue:
https://github.com/mozilla/pdf.js/issues/1659

Furthermore, any header can be added to the request, making it even more valuable. To do this, an optional parameter headers was added to the PDFJS.getDocument function. It accepts an Object that contains the headers like this:
{ 
 Authorization: "BASIC XXX",
 OtherHeader: "asdfasdf"
}
