### PR TITLE
Patch for the Evaluator.js:splitCombinedOperations

### DIFF
--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -112,14 +112,33 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
   };
 
   function splitCombinedOperations(operations) {
-    // Two operations can be combined together, trying to find which two
+    // Two or more operations can be combined together, trying to find which
     // operations were concatenated.
-    for (var i = operations.length - 1; i > 0; i--) {
-      var op1 = operations.substring(0, i), op2 = operations.substring(i);
-      if (op1 in OP_MAP && op2 in OP_MAP)
-        return [op1, op2]; // operations found
+    var result = [];
+    var opIndex = 0;
+
+    if (!operations) {
+      return null;
     }
-    return null;
+
+    while (opIndex < operations.length) {
+      var currentOp = '';
+      for (var op in OP_MAP) {
+        if (op == operations.substr(opIndex, op.length) &&
+            op.length > currentOp.length) {
+          currentOp = op;
+        }
+      }
+
+      if (currentOp.length > 0) {
+        result.push(operations.substr(opIndex, currentOp.length));
+        opIndex += currentOp.length;
+      } else {
+        return null;
+      }
+    }
+
+    return result;
   }
 
   PartialEvaluator.prototype = {
@@ -267,14 +286,14 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       var patterns = resources.get('Pattern') || new Dict();
       var parser = new Parser(new Lexer(stream), false, xref);
       var res = resources;
-      var hasNextObj = false, nextObj;
+      var hasNextObj = false, nextObjs;
       var args = [], obj;
       var TILING_PATTERN = 1, SHADING_PATTERN = 2;
 
       while (true) {
         if (hasNextObj) {
-          obj = nextObj;
-          hasNextObj = false;
+          obj = nextObjs.pop();
+          hasNextObj = (nextObjs.length > 0);
         } else {
           obj = parser.getObj();
           if (isEOF(obj))
@@ -290,9 +309,12 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
             if (cmds) {
               cmd = cmds[0];
               fn = OP_MAP[cmd];
-              // feeding other command on the next interation
+              // feeding other command on the next iteration
               hasNextObj = true;
-              nextObj = Cmd.get(cmds[1]);
+              nextObjs = [];
+              for (var idx = 1; idx < cmds.length; idx++) {
+                 nextObjs.push(Cmd.get(cmds[idx]));
+              }
             }
           }
           assertWellFormed(fn, 'Unknown command "' + cmd + '"');


### PR DESCRIPTION
Some forms contain combined operations like 'qqq' and 'qqBT' that should be parsed correctly. See 
US I-9 https://skydrive.live.com/?cid=ff4296d34444d85d#cid=FF4296D34444D85D&id=FF4296D34444D85D%211137
US W-4 https://skydrive.live.com/?cid=ff4296d34444d85d#cid=FF4296D34444D85D&id=FF4296D34444D85D%211138
