### PR TITLE
Use a reusable style sheet instead of creating a new tag for each rule.

### DIFF
--- a/src/fonts.js
+++ b/src/fonts.js
@@ -2377,6 +2377,7 @@ var Font = (function FontClosure() {
       var styleElement = document.getElementById('PDFJS_FONT_STYLE_TAG');
       if (!styleElement) {
           styleElement = document.createElement('style');
+          styleElement.id = 'PDFJS_FONT_STYLE_TAG';
           document.documentElement.getElementsByTagName('head')[0].appendChild(
             styleElement);   
       }

--- a/src/fonts.js
+++ b/src/fonts.js
@@ -20,6 +20,9 @@ var kPDFGlyphSpaceUnits = 1000;
 // Until hinting is fully supported this constant can be used
 var kHintingEnabled = false;
 
+// A reference to a reusable style sheet.
+var styleSheet;
+
 var FontFlags = {
   FixedPitch: 1,
   Serif: 2,
@@ -2374,11 +2377,14 @@ var Font = (function FontClosure() {
                  window.btoa(data) + ');');
       var rule = "@font-face { font-family:'" + fontName + "';src:" + url + '}';
 
-      var styleElement = document.createElement('style');
-      document.documentElement.getElementsByTagName('head')[0].appendChild(
-        styleElement);
 
-      var styleSheet = styleElement.sheet;
+      if(!styleSheet) {
+        var styleElement = document.createElement('style');
+        document.documentElement.getElementsByTagName('head')[0].appendChild(
+          styleElement);
+
+        styleSheet = styleElement.sheet;
+      }
       styleSheet.insertRule(rule, styleSheet.cssRules.length);
 
       if (PDFJS.pdfBug && FontInspector.enabled)

--- a/src/fonts.js
+++ b/src/fonts.js
@@ -20,9 +20,6 @@ var kPDFGlyphSpaceUnits = 1000;
 // Until hinting is fully supported this constant can be used
 var kHintingEnabled = false;
 
-// A reference to a reusable style sheet.
-var styleSheet;
-
 var FontFlags = {
   FixedPitch: 1,
   Serif: 2,
@@ -2377,14 +2374,14 @@ var Font = (function FontClosure() {
                  window.btoa(data) + ');');
       var rule = "@font-face { font-family:'" + fontName + "';src:" + url + '}';
 
-
-      if(!styleSheet) {
-        var styleElement = document.createElement('style');
-        document.documentElement.getElementsByTagName('head')[0].appendChild(
-          styleElement);
-
-        styleSheet = styleElement.sheet;
+      var styleElement = document.getElementById('PDFJS_FONT_STYLE_TAG');
+      if (!styleElement) {
+          styleElement = document.createElement('style');
+          document.documentElement.getElementsByTagName('head')[0].appendChild(
+            styleElement);   
       }
+
+      var styleSheet = styleElement.sheet;
       styleSheet.insertRule(rule, styleSheet.cssRules.length);
 
       if (PDFJS.pdfBug && FontInspector.enabled)

--- a/src/fonts.js
+++ b/src/fonts.js
@@ -2379,7 +2379,7 @@ var Font = (function FontClosure() {
           styleElement = document.createElement('style');
           styleElement.id = 'PDFJS_FONT_STYLE_TAG';
           document.documentElement.getElementsByTagName('head')[0].appendChild(
-            styleElement);   
+            styleElement);
       }
 
       var styleSheet = styleElement.sheet;


### PR DESCRIPTION
IE9 breaks when creating too many style tags in one page:
http://support.microsoft.com/kb/262161

In any case, on all browsers it's better to reuse a single style sheet than creating a new one for each new rule.
