### PR TITLE
Support password protected PDF files - With user input

### DIFF
--- a/l10n/da/viewer.properties
+++ b/l10n/da/viewer.properties
@@ -29,3 +29,4 @@ page_of=af {{pageCount}}
 no_outline=Ingen dokumentoversigt tilgængelig
 open_file.title=Åbn fil
 text_annotation_type=[{{type}} Kommentar]
+password_request=Filen er beskyttet med et kodeord:

--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -42,3 +42,4 @@ zoom_in_label=Zoom In
 zoom.title=Zoom
 thumb_page_title=Page {{page}}
 thumb_page_canvas=Thumbnail of Page {{page}}
+password_request=PDF is protected by a password:

--- a/src/api.js
+++ b/src/api.js
@@ -122,6 +122,7 @@ var PDFDocumentProxy = (function PDFDocumentProxyClosure() {
     },
     isEncrypted: function PDFDocumentProxy_isEncrypted() {
       var promise = new PDFJS.Promise();
+      promise.resolve(this.pdfInfo.encrypted);
       return promise;
     },
     destroy: function PDFDocumentProxy_destroy() {

--- a/src/core.js
+++ b/src/core.js
@@ -308,19 +308,19 @@ var Page = (function PageClosure() {
  * `PDFDocument` objects on the main thread created.
  */
 var PDFDocument = (function PDFDocumentClosure() {
-  function PDFDocument(arg, callback) {
+  function PDFDocument(arg, password) {
     if (isStream(arg))
-      init.call(this, arg);
+      init.call(this, arg, password);
     else if (isArrayBuffer(arg))
-      init.call(this, new Stream(arg));
+      init.call(this, new Stream(arg), password);
     else
       error('PDFDocument: Unknown argument type');
   }
 
-  function init(stream) {
+  function init(stream, password) {
     assertWellFormed(stream.length > 0, 'stream must have data');
     this.stream = stream;
-    this.setup();
+    this.setup(password);
     this.acroForm = this.catalog.catDict.get('AcroForm');
   }
 
@@ -411,11 +411,12 @@ var PDFDocument = (function PDFDocumentClosure() {
       }
       // May not be a PDF file, continue anyway.
     },
-    setup: function PDFDocument_setup(ownerPassword, userPassword) {
+    setup: function PDFDocument_setup(password) {
       this.checkHeader();
       var xref = new XRef(this.stream,
                           this.startXRef,
-                          this.mainXRefEntriesOffset);
+                          this.mainXRefEntriesOffset,
+                          password);
       this.xref = xref;
       this.catalog = new Catalog(xref);
     },

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -419,13 +419,14 @@ var CipherTransform = (function CipherTransformClosure() {
 })();
 
 var CipherTransformFactory = (function CipherTransformFactoryClosure() {
+  var defaultPasswordBytes = new Uint8Array([
+    0x28, 0xBF, 0x4E, 0x5E, 0x4E, 0x75, 0x8A, 0x41,
+    0x64, 0x00, 0x4E, 0x56, 0xFF, 0xFA, 0x01, 0x08,
+    0x2E, 0x2E, 0x00, 0xB6, 0xD0, 0x68, 0x3E, 0x80,
+    0x2F, 0x0C, 0xA9, 0xFE, 0x64, 0x53, 0x69, 0x7A]);
+
   function prepareKeyData(fileId, password, ownerPassword, userPassword,
                           flags, revision, keyLength, encryptMetadata) {
-    var defaultPasswordBytes = new Uint8Array([
-      0x28, 0xBF, 0x4E, 0x5E, 0x4E, 0x75, 0x8A, 0x41,
-      0x64, 0x00, 0x4E, 0x56, 0xFF, 0xFA, 0x01, 0x08,
-      0x2E, 0x2E, 0x00, 0xB6, 0xD0, 0x68, 0x3E, 0x80,
-      0x2F, 0x0C, 0xA9, 0xFE, 0x64, 0x53, 0x69, 0x7A]);
     var hashData = new Uint8Array(100), i = 0, j, n;
     if (password) {
       n = Math.min(32, password.length);
@@ -462,9 +463,8 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
     var cipher, checkData;
 
     if (revision >= 3) {
-      // padded password in hashData, we can use this array for user
-      // password check
-      i = 32;
+      for (i = 0; i < 32; ++i)
+        hashData[i] = defaultPasswordBytes[i];
       for (j = 0, n = fileId.length; j < n; ++j)
         hashData[i++] = fileId[j];
       cipher = new ARCFourCipher(encryptionKey);
@@ -477,15 +477,52 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
         cipher = new ARCFourCipher(derivedKey);
         checkData = cipher.encryptBlock(checkData);
       }
+      for (j = 0, n = checkData.length; j < n; ++j) {
+        if (userPassword[j] != checkData[j])
+          return null;
+      }
     } else {
       cipher = new ARCFourCipher(encryptionKey);
-      checkData = cipher.encryptBlock(hashData.subarray(0, 32));
-    }
-    for (j = 0, n = checkData.length; j < n; ++j) {
-      if (userPassword[j] != checkData[j])
-        error('incorrect password');
+      checkData = cipher.encryptBlock(defaultPasswordBytes);
+      for (j = 0, n = checkData.length; j < n; ++j) {
+        if (userPassword[j] != checkData[j])
+          return null;
+      }
     }
     return encryptionKey;
+  }
+  function decodeUserPassword(password, ownerPassword, revision, keyLength) {
+    var hashData = new Uint8Array(32), i = 0, j, n;
+    n = Math.min(32, password.length);
+    for (; i < n; ++i)
+      hashData[i] = password[i];
+    j = 0;
+    while (i < 32) {
+      hashData[i++] = defaultPasswordBytes[j++];
+    }
+    var hash = calculateMD5(hashData, 0, i);
+    var keyLengthInBytes = keyLength >> 3;
+    if (revision >= 3) {
+      for (j = 0; j < 50; ++j) {
+         hash = calculateMD5(hash, 0, hash.length);
+      }
+    }
+
+    var cipher, userPassword;
+    if (revision >= 3) {
+      userPassword = ownerPassword;
+      var derivedKey = new Uint8Array(keyLengthInBytes), k;
+      for (j = 19; j >= 0; j--) {
+        for (k = 0; k < keyLengthInBytes; ++k)
+          derivedKey[k] = hash[k] ^ j;
+        cipher = new ARCFourCipher(derivedKey);
+        userPassword = cipher.encryptBlock(userPassword);
+      }
+    } else {
+      cipher = new ARCFourCipher(hash.subarray(0, keyLengthInBytes));
+      userPassword = cipher.encryptBlock(ownerPassword);
+    }
+    return userPassword;
   }
 
   var identityName = new Name('Identity');
@@ -516,10 +553,23 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
     if (password)
       passwordBytes = stringToBytes(password);
 
-    this.encryptionKey = prepareKeyData(fileIdBytes, passwordBytes,
-                                        ownerPassword, userPassword,
-                                        flags, revision,
-                                        keyLength, encryptMetadata);
+    var encryptionKey = prepareKeyData(fileIdBytes, passwordBytes,
+                                       ownerPassword, userPassword, flags,
+                                       revision, keyLength, encryptMetadata);
+    if (!encryptionKey && password) {
+      // Attempting use the password as an owner password
+      var decodedPassword = decodeUserPassword(passwordBytes, ownerPassword,
+                                               revision, keyLength);
+      encryptionKey = prepareKeyData(fileIdBytes, decodedPassword,
+                                     ownerPassword, userPassword, flags,
+                                     revision, keyLength, encryptMetadata);
+    }
+
+    if (!encryptionKey)
+      error('incorrect password or encryption data');
+
+    this.encryptionKey = encryptionKey;
+
     if (algorithm == 4) {
       this.cf = dict.get('CF');
       this.stmf = dict.get('StmF') || identityName;

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -556,7 +556,9 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
     var encryptionKey = prepareKeyData(fileIdBytes, passwordBytes,
                                        ownerPassword, userPassword, flags,
                                        revision, keyLength, encryptMetadata);
-    if (!encryptionKey && password) {
+    if (!encryptionKey && !password) {
+      throw new PasswordException('No password given', 'needpassword');
+    } else if (!encryptionKey && password) {
       // Attempting use the password as an owner password
       var decodedPassword = decodeUserPassword(passwordBytes, ownerPassword,
                                                revision, keyLength);

--- a/src/obj.js
+++ b/src/obj.js
@@ -298,7 +298,7 @@ var Catalog = (function CatalogClosure() {
 })();
 
 var XRef = (function XRefClosure() {
-  function XRef(stream, startXRef, mainXRefEntriesOffset) {
+  function XRef(stream, startXRef, mainXRefEntriesOffset, password) {
     this.stream = stream;
     this.entries = [];
     this.xrefstms = {};
@@ -312,7 +312,7 @@ var XRef = (function XRefClosure() {
     if (encrypt) {
       var fileId = trailerDict.get('ID');
       this.encrypt = new CipherTransformFactory(encrypt,
-                                                fileId[0] /*, password */);
+                                                fileId[0], password);
     }
 
     // get the root dictionary (catalog) object

--- a/src/util.js
+++ b/src/util.js
@@ -58,6 +58,14 @@ function shadow(obj, prop, value) {
   return value;
 }
 
+function PasswordException(message, code) {
+  this.name = "PasswordException";
+  this.message = message;
+  this.code = code;
+}
+PasswordException.prototype = new Error();
+PasswordException.constructor = PasswordException;
+
 function bytesToString(bytes) {
   var str = '';
   var length = bytes.length;
@@ -471,7 +479,7 @@ var Promise = PDFJS.Promise = (function PromiseClosure() {
       }
     },
 
-    reject: function Promise_reject(reason) {
+    reject: function Promise_reject(reason, exception) {
       if (this.isRejected) {
         error('A Promise can be rejected only once ' + this.name);
       }
@@ -484,7 +492,7 @@ var Promise = PDFJS.Promise = (function PromiseClosure() {
       var errbacks = this.errbacks;
 
       for (var i = 0, ii = errbacks.length; i < ii; i++) {
-        errbacks[i].call(null, reason);
+        errbacks[i].call(null, reason, exception);
       }
     },
 

--- a/src/util.js
+++ b/src/util.js
@@ -464,7 +464,7 @@ var Promise = PDFJS.Promise = (function PromiseClosure() {
       }
 
       this.isResolved = true;
-      this.data = data || null;
+      this.data = (typeof data !== 'undefined') ? data : null;
       var callbacks = this.callbacks;
 
       for (var i = 0, ii = callbacks.length; i < ii; i++) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -88,7 +88,22 @@ var WorkerMessageHandler = {
     handler.on('GetDocRequest', function wphSetupDoc(data) {
       // Create only the model of the PDFDoc, which is enough for
       // processing the content of the pdf.
-      pdfModel = new PDFDocument(new Stream(data));
+      var pdfData = data.data;
+      var password = data.params.password;
+      try {
+        pdfModel = new PDFDocument(new Stream(pdfData), password);
+      } catch(e) {
+        if (e instanceof PasswordException) {
+          handler.send('NeedPassword', {
+            exception: e,
+            reason: 'needPassword'
+          });
+
+          return;
+        } else {
+          throw e;
+        }
+      }
       var doc = {
         numPages: pdfModel.numPages,
         fingerprint: pdfModel.getFingerprint(),

--- a/src/worker.js
+++ b/src/worker.js
@@ -110,7 +110,8 @@ var WorkerMessageHandler = {
         destinations: pdfModel.catalog.destinations,
         outline: pdfModel.catalog.documentOutline,
         info: pdfModel.getDocumentInfo(),
-        metadata: pdfModel.catalog.metadata
+        metadata: pdfModel.catalog.metadata,
+        encrypted: !!pdfModel.xref.encrypt
       };
       handler.send('GetDoc', {pdfInfo: doc});
     });

--- a/test/unit/crypto_spec.js
+++ b/test/unit/crypto_spec.js
@@ -185,3 +185,66 @@ describe('crypto', function() {
   });
 });
 
+describe('CipherTransformFactory', function() {
+  function DictMock(map) {
+    this.map = map;
+  }
+  DictMock.prototype = {
+    get: function(key) {
+      return this.map[key];
+    }
+  };
+
+  var map1 = {
+    Filter: new Name('Standard'),
+    V: 2,
+    Length: 128,
+    O: unescape('%80%C3%04%96%91o%20sl%3A%E6%1B%13T%91%F2%0DV%12%E3%FF%5E%BB%' +
+                'E9VO%D8k%9A%CA%7C%5D'),
+    U: unescape('j%0C%8D%3EY%19%00%BCjd%7D%91%BD%AA%00%18%00%00%00%00%00%00%0' +
+                '0%00%00%00%00%00%00%00%00%00'),
+    P: -1028,
+    R: 3
+  };
+  var fileID1 = unescape('%F6%C6%AF%17%F3rR%8DRM%9A%80%D1%EF%DF%18');
+
+  var map2 = {
+    Filter: new Name('Standard'),
+    V: 4,
+    Length: 128,
+    O: unescape('sF%14v.y5%27%DB%97%0A5%22%B3%E1%D4%AD%BD%9B%3C%B4%A5%89u%15%' +
+                'B2Y%F1h%D9%E9%F4'),
+    U: unescape('%93%04%89%A9%BF%8AE%A6%88%A2%DB%C2%A0%A8gn%00%00%00%00%00%00' +
+                '%00%00%00%00%00%00%00%00%00%00'),
+    P: -1084,
+    R: 4
+  };
+  var fileID2 = unescape('%3CL_%3AD%96%AF@%9A%9D%B3%3Cx%1Cv%AC');
+
+  describe('#ctor', function() {
+    it('should accept user password', function() {
+      var factory = new CipherTransformFactory(new DictMock(map1), fileID1,
+        '123456');
+    });
+
+    it('should accept owner password', function() {
+      var factory = new CipherTransformFactory(new DictMock(map1), fileID1,
+        '654321');
+    });
+
+    it('should not accept wrong password', function() {
+      var thrown = false;
+      try {
+        var factory = new CipherTransformFactory(new DictMock(map1), fileID1,
+          'wrong');
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).toEqual(true);
+    });
+
+    it('should accept no password', function() {
+      var factory = new CipherTransformFactory(new DictMock(map2), fileID2);
+    });
+  });
+});

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -351,11 +351,12 @@ var PDFView = {
       },
       function getDocumentError(message, exception) {
         if (exception && exception.name === 'PasswordException') {
-          password = prompt("PDF Protected by password:");
+          password = prompt(mozL10n.get('password_request', null, 'PDF is protected by a password:'));
           if (password && password.length > 0) {
             return PDFView.open(url, scale, password);
           }
         }
+
         var loadingIndicator = document.getElementById('loading');
         loadingIndicator.textContent = mozL10n.get('loading_error_indicator',
           null, 'Error');


### PR DESCRIPTION
This PR (tries to) solve(s) the problem we've had with password protected PDF files. Right now the process is as follows:
- getDocument() tries to open the PDF file
- Since the PDF is encrypted, the `CipherTransformFactory` gets instantiated and tries to decode the PDF
- Since no password has been supplied, it throws a `PasswordException`, which is catched by the Worker
- The Worker requests a password from client (API -> Viewer)
- The viewer _prompt_s (yes I know it's ugly), the user for a password
- The getDocument method is now supplied with a password, which is hopefully the correct one.

This PR implements `PasswordException` located in `src/util.js` and an `isEncrypted` method to the API (`src/api.s`)

We've had a wrong password/encryption algorithm implementation, but this has just been solved by @yurydelendik #1694

This PR solves/closes #1228 and #1621
