### PR TITLE
Set Gecko 10 as min version for the extension

### DIFF
--- a/extensions/firefox/install.rdf
+++ b/extensions/firefox/install.rdf
@@ -13,7 +13,7 @@
     <em:targetApplication>
       <Description>
        <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
-       <em:minVersion>6.0</em:minVersion>
+       <em:minVersion>10.0</em:minVersion>
        <em:maxVersion>15.0a1</em:maxVersion>
      </Description>
     </em:targetApplication>
@@ -22,7 +22,7 @@
     <em:targetApplication>
       <Description>
        <em:id>{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}</em:id>
-       <em:minVersion>2.1.*</em:minVersion>
+       <em:minVersion>2.7</em:minVersion>
        <em:maxVersion>2.12a1</em:maxVersion>
      </Description>
     </em:targetApplication>


### PR DESCRIPTION
Set min supported version to Firefox 10 and SeaMonkey 2.7
