### PR TITLE
Moves Subrs to Private tail in CFF top dict

### DIFF
--- a/src/fonts.js
+++ b/src/fonts.js
@@ -4221,9 +4221,9 @@ var CFFPrivateDict = (function CFFPrivateDictClosure() {
     [[12, 17], 'LanguageGroup', 'num', 0],
     [[12, 18], 'ExpansionFactor', 'num', 0.06],
     [[12, 19], 'initialRandomSeed', 'num', 0],
-    [19, 'Subrs', 'offset', null],
     [20, 'defaultWidthX', 'num', 0],
-    [21, 'nominalWidthX', 'num', 0]
+    [21, 'nominalWidthX', 'num', 0],
+    [19, 'Subrs', 'offset', null]
   ];
   var tables = null;
   function CFFPrivateDict(strings) {

--- a/test/pdfs/issue1629.pdf.link
+++ b/test/pdfs/issue1629.pdf.link
@@ -1,0 +1,1 @@
+http://is.muni.cz/www/20544/noty/sbm/Taize/Adoramus_te_Christe.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -451,6 +451,13 @@
       "link": true,
       "type": "eq"
     },
+    {  "id": "issue1629",
+      "file": "pdfs/issue1629.pdf",
+      "md5": "0f2cbbf268383a377e95e6bbe36c6a9a",
+      "rounds": 1,
+      "link": true,
+      "type": "eq"
+    },
     {  "id": "issue1169",
       "file": "pdfs/issue1169.pdf",
       "md5": "3df3ed21fd43ac7fdb21e2015c8a7809",


### PR DESCRIPTION
Fixes #1629

The Firefox on Windows with hardware acceleration on does not like Subrs entry be defined before other entries. <del> I also notices that Private and CharStrings entries are swapped as well.</del>
