### PR TITLE
Add viewport metatag for mobile

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -985,3 +985,10 @@ canvas {
     display: none;
   }
 }
+
+@media all and (max-width: 500px) {
+  #scaleSelectContainer, #pageNumberLabel {
+    display: none;
+  }
+}
+

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -2,6 +2,7 @@
 <html dir="ltr">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <title>PDF.js viewer</title>
     <!-- PDFJSSCRIPT_INCLUDE_FIREFOX_EXTENSION -->
 


### PR DESCRIPTION
IRC chat:

```
<wesj> yury: right now you don't have a metaviewport tag, so we give you a window that 800 or 900px wide: https://developer.mozilla.org/en/Mobile/Viewport_meta_tag
..
<wesj> yury: if you add one, you can control the size... kinda
```
