### PR TITLE
Type3 smoothing: pre-scale image in the paintImageMaskXObject

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -1150,17 +1150,17 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
 
       applyStencilMask(pixels, inverseDecode);
 
-      tmpCtx.putImageData(imgData, 0, 0);
       var currentTransform = ctx.mozCurrentTransformInverse;
       var widthScale = Math.max(Math.abs(currentTransform[0]), 1);
       var heightScale = Math.max(Math.abs(currentTransform[3]), 1);
       if (widthScale >= 2 || heightScale >= 2) {
-        // canvas does not resize large images to small -- using simple
+        // canvas does not resize well large images to small -- using simple
         // algorithm to perform pre-scaling
         tmpCanvas = rescaleImage(imgData.data, widthScale, heightScale);
         ctx.scale(widthScale, heightScale);
         ctx.drawImage(tmpCanvas, 0, -h / heightScale);
       } else
+        tmpCtx.putImageData(imgData, 0, 0);
         ctx.drawImage(tmpCanvas, 0, -h);
       this.restore();
     },

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -1159,9 +1159,10 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         tmpCanvas = rescaleImage(imgData.data, widthScale, heightScale);
         ctx.scale(widthScale, heightScale);
         ctx.drawImage(tmpCanvas, 0, -h / heightScale);
-      } else
+      } else {
         tmpCtx.putImageData(imgData, 0, 0);
         ctx.drawImage(tmpCanvas, 0, -h);
+      }
       this.restore();
     },
 


### PR DESCRIPTION
Per MDN ( https://developer.mozilla.org/en/Canvas_tutorial/Using_images#drawImage_example_2 ):

"Images can become blurry when scaling up or grainy if they're scaled down too much. Scaling is probably best not done if you've got some text in it which needs to remain legible."

Using the simple algorithm to pre-scale the image.
