### PR TITLE
Implement proper utf-8 decoding in stringToPDFString

### DIFF
--- a/src/obj.js
+++ b/src/obj.js
@@ -140,7 +140,12 @@ var Catalog = (function CatalogClosure() {
 
         if (isName(type) && isName(subtype) &&
             type.name === 'Metadata' && subtype.name === 'XML') {
-          metadata = stringToPDFString(bytesToString(stream.getBytes()));
+          // XXX: This should examine the charset the XML document defines,
+          // however since there are currently no real means to decode
+          // arbitrary charsets, let's just hope that the author of the PDF
+          // was reasonable enough to stick with the XML default charset,
+          // which is UTF-8.
+          metadata = stringToUTF8String(bytesToString(stream.getBytes()));
         }
       }
 

--- a/src/util.js
+++ b/src/util.js
@@ -302,6 +302,10 @@ function stringToPDFString(str) {
   return str2;
 }
 
+function stringToUTF8String(str) {
+  return decodeURIComponent(escape(str));
+}
+
 function isBool(v) {
   return typeof v == 'boolean';
 }


### PR DESCRIPTION
Before, stringToPDFString tried to find an UTF-16 BOM, and if not
present, instread tried to decode the stream using some ad-hoc
translation table. This will not work if the string is real UTF-8
Unicode.  Hence a proper UTF-8 decoder was added, and the old, ad-hoc
translation was left in as a fallback should the new decoder reject
the string.

Fixes GH-1692, and maybe others
