### PR TITLE
Dismiss native browser zoom, and use PDF.JS zoom instead

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1846,12 +1846,12 @@ window.addEventListener('pagechange', function pagechange(evt) {
 
 // Firefox specific event, so that we can prevent browser from zooming
 window.addEventListener('DOMMouseScroll', function(evt) {
-  if(evt.ctrlKey) {
+  if (evt.ctrlKey) {
     evt.preventDefault();
 
     var ticks = evt.detail;
     var direction = (ticks > 0) ? 'zoomOut' : 'zoomIn';
-    for(var i = 0, length = Math.abs(ticks); i < length; i++)
+    for (var i = 0, length = Math.abs(ticks); i < length; i++)
       PDFView[direction]();
   }
 }, false);

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1844,6 +1844,18 @@ window.addEventListener('pagechange', function pagechange(evt) {
   document.getElementById('next').disabled = (page >= PDFView.pages.length);
 }, true);
 
+// Firefox specific event, so that we can prevent browser from zooming
+window.addEventListener('DOMMouseScroll', function(evt) {
+  if(evt.ctrlKey) {
+    evt.preventDefault();
+
+    var ticks = evt.detail;
+    var direction = (ticks > 0) ? 'zoomOut' : 'zoomIn';
+    for(var i = 0, length = Math.abs(ticks); i < length; i++)
+      PDFView[direction]();
+  }
+}, false);
+
 window.addEventListener('keydown', function keydown(evt) {
   var handled = false;
   var cmd = (evt.ctrlKey ? 1 : 0) |


### PR DESCRIPTION
Fixes #902 - Works beautifully, but only in Firefox, since DOMMouseScroll is Firefox specific.
