### PR TITLE
Moves loading of the binary PDF data to the worker

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -20,6 +20,15 @@
 PDFJS.getDocument = function getDocument(source) {
   var workerInitializedPromise, workerReadyPromise, transport;
 
+  if (typeof source === 'string') {
+    source = { url: source };
+  } else if (isArrayBuffer(source)) {
+    source = { data: source };
+  } else if (typeof source !== 'object') {
+    error('Invalid parameter in getDocument, need either Uint8Array, ' +
+          'string or a parameter object');
+  }
+
   if (!source.url && !source.data)
     error('Invalid parameter array, need either .data or .url');
 

--- a/src/api.js
+++ b/src/api.js
@@ -572,7 +572,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
       }, this);
 
       messageHandler.on('DocError', function transportDocError(data) {
-        this.workerReadyPromise.reject(data.message);
+        this.workerReadyPromise.reject(data);
       }, this);
 
       messageHandler.on('PageError', function transportError(data) {

--- a/src/api.js
+++ b/src/api.js
@@ -480,34 +480,6 @@ var WorkerTransport = (function WorkerTransportClosure() {
         this.workerReadyPromise.resolve(pdfDocument);
       }, this);
 
-      messageHandler.on('FetchDoc', function transportFetchDoc(data) {
-        var url = data.url;
-        var headers = data.httpHeaders;
-        var password = data.password;
-
-        var promise = this.workerReadyPromise;
-        var transport = this;
-        PDFJS.getPdf(
-          {
-            url: url,
-            progress: function getPDFProgress(evt) {
-              if (evt.lengthComputable)
-                promise.progress({
-                  loaded: evt.loaded,
-                  total: evt.total
-                });
-            },
-            error: function getPDFError(e) {
-              promise.reject('Unexpected server response of ' +
-                e.target.status + '.');
-            },
-            headers: headers
-          },
-          function getPDFLoad(data) {
-            transport.sendData(data);
-          });
-      }, this);
-
       messageHandler.on('NeedPassword', function transportPassword(data) {
         this.workerReadyPromise.reject(data.exception.message, data.exception);
       }, this);
@@ -629,12 +601,8 @@ var WorkerTransport = (function WorkerTransportClosure() {
       });
     },
 
-    sendData: function WorkerTransport_sendData(data) {
-      this.messageHandler.send('GetDocRequest', {data: data});
-    },
-
     fetchDocument: function WorkerTransport_fetchDocument(source) {
-      this.messageHandler.send('FetchDocRequest', {source: source});
+      this.messageHandler.send('GetDocRequest', {source: source});
     },
 
     getData: function WorkerTransport_getData(promise) {

--- a/src/core.js
+++ b/src/core.js
@@ -45,8 +45,8 @@ function getPdf(arg, callback) {
   }
 
   xhr.mozResponseType = xhr.responseType = 'arraybuffer';
-  var protocol = params.url.indexOf(':') < 0 ? window.location.protocol :
-    params.url.substring(0, params.url.indexOf(':') + 1);
+
+  var protocol = params.url.substring(0, params.url.indexOf(':') + 1);
   xhr.expected = (protocol === 'http:' || protocol === 'https:') ? 200 : 0;
 
   if ('progress' in params)

--- a/src/util.js
+++ b/src/util.js
@@ -57,6 +57,8 @@ function assert(cond, msg) {
     error(msg);
 }
 
+// Combines two URLs. The baseUrl shall be absolute URL. If the url is an
+// absolute URL, it will be returned as is.
 function combineUrl(baseUrl, url) {
   if (url.indexOf(':') >= 0)
     return url;
@@ -67,10 +69,13 @@ function combineUrl(baseUrl, url) {
     return baseUrl.substring(0, i) + url;
   } else {
     // relative path
-    var i = baseUrl.lastIndexOf('#');
-    i = baseUrl.lastIndexOf('?', i < 0 ? baseUrl.length : i);
-    i = baseUrl.lastIndexOf('/', i < 0 ? baseUrl.length : i);
-    return baseUrl.substring(0, i + 1) + url;
+    var pathLength = baseUrl.length, i;
+    i = baseUrl.lastIndexOf('#');
+    pathLength = i >= 0 ? i : pathLength;
+    i = baseUrl.lastIndexOf('?', pathLength);
+    pathLength = i >= 0 ? i : pathLength;
+    var prefixLength = baseUrl.lastIndexOf('/', pathLength);
+    return baseUrl.substring(0, prefixLength + 1) + url;
   }
 }
 PDFJS.combineUrl = combineUrl;

--- a/src/util.js
+++ b/src/util.js
@@ -57,6 +57,24 @@ function assert(cond, msg) {
     error(msg);
 }
 
+function combineUrl(baseUrl, url) {
+  if (url.indexOf(':') >= 0)
+    return url;
+  if (url.charAt(0) == '/') {
+    // absolute path
+    var i = baseUrl.indexOf('://');
+    i = baseUrl.indexOf('/', i + 3);
+    return baseUrl.substring(0, i) + url;
+  } else {
+    // relative path
+    var i = baseUrl.lastIndexOf('#');
+    i = baseUrl.lastIndexOf('?', i < 0 ? baseUrl.length : i);
+    i = baseUrl.lastIndexOf('/', i < 0 ? baseUrl.length : i);
+    return baseUrl.substring(0, i + 1) + url;
+  }
+}
+PDFJS.combineUrl = combineUrl;
+
 // In a well-formed PDF, |cond| holds.  If it doesn't, subsequent
 // behavior is undefined.
 function assertWellFormed(cond, msg) {

--- a/test/driver.js
+++ b/test/driver.js
@@ -86,10 +86,6 @@ function exceptionToString(e) {
   return e.message + ('stack' in e ? ' at ' + e.stack.split('\n')[0] : '');
 }
 
-function expandUrl(url) {
-  return combineUrl(window.location.href, url);
-}
-
 function nextTask() {
   cleanup();
 
@@ -102,7 +98,8 @@ function nextTask() {
 
   log('Loading file "' + task.file + '"\n');
 
-  getPdf(expandUrl(task.file), function nextTaskGetPdf(data) {
+  var absoluteUrl = combineUrl(window.location.href, task.file);
+  getPdf(absoluteUrl, function nextTaskGetPdf(data) {
     var failure;
     function continuation() {
       task.pageNum = task.firstPage || 1;

--- a/test/driver.js
+++ b/test/driver.js
@@ -86,6 +86,10 @@ function exceptionToString(e) {
   return e.message + ('stack' in e ? ' at ' + e.stack.split('\n')[0] : '');
 }
 
+function expandUrl(url) {
+  return combineUrl(window.location.href, url);
+}
+
 function nextTask() {
   cleanup();
 
@@ -98,7 +102,7 @@ function nextTask() {
 
   log('Loading file "' + task.file + '"\n');
 
-  getPdf(task.file, function nextTaskGetPdf(data) {
+  getPdf(expandUrl(task.file), function nextTaskGetPdf(data) {
     var failure;
     function continuation() {
       task.pageNum = task.firstPage || 1;

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -6,7 +6,7 @@
 describe('api', function() {
   // TODO run with worker enabled
   PDFJS.disableWorker = true;
-  var basicApiUrl = '../pdfs/basicapi.pdf';
+  var basicApiUrl = combineUrl(window.location.href, '../pdfs/basicapi.pdf');
   function waitsForPromise(promise) {
     waitsFor(function() {
       return promise.isResolved || promise.isRejected;

--- a/test/unit/unit_test.html
+++ b/test/unit/unit_test.html
@@ -43,6 +43,7 @@
   <script type="text/javascript" src="stream_spec.js"></script>
   <script type="text/javascript" src="api_spec.js"></script>
   <script type="text/javascript" src="metadata_spec.js"></script>
+  <script type="text/javascript" src="util_spec.js"></script>
   <script type="text/javascript">
     'use strict';
 

--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -1,0 +1,51 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+
+'use strict';
+
+describe('util', function() {
+
+  describe('combineUrl', function() {
+    it('absolute url with protocol stays as is', function() {
+      var baseUrl = 'http://server/index.html';
+      var url = 'http://server2/test2.html';
+      var result = combineUrl(baseUrl, url);
+      var expected = 'http://server2/test2.html';
+      expect(result).toEqual(expected);
+    });
+
+    it('absolute url without protocol uses prefix from base', function() {
+      var baseUrl = 'http://server/index.html';
+      var url = '/test2.html';
+      var result = combineUrl(baseUrl, url);
+      var expected = 'http://server/test2.html';
+      expect(result).toEqual(expected);
+    });
+
+    it('combines relative url with base', function() {
+      var baseUrl = 'http://server/index.html';
+      var url = 'test2.html';
+      var result = combineUrl(baseUrl, url);
+      var expected = 'http://server/test2.html';
+      expect(result).toEqual(expected);
+    });
+
+    it('combines relative url (w/hash) with base', function() {
+      var baseUrl = 'http://server/index.html#!/test';
+      var url = 'test2.html';
+      var result = combineUrl(baseUrl, url);
+      var expected = 'http://server/test2.html';
+      expect(result).toEqual(expected);
+    });
+
+    it('combines relative url (w/query) with base', function() {
+      var baseUrl = 'http://server/index.html?search=/test';
+      var url = 'test2.html';
+      var result = combineUrl(baseUrl, url);
+      var expected = 'http://server/test2.html';
+      expect(result).toEqual(expected);
+    });
+  });
+
+});
+

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -33,10 +33,6 @@ function getFileName(url) {
   return url.substring(url.lastIndexOf('/', end) + 1, end);
 }
 
-function expandUrl(url) {
-  return PDFJS.combineUrl(window.location.href, url);
-}
-
 var Cache = function cacheCache(size) {
   var data = [];
   this.push = function cachePush(view) {
@@ -388,7 +384,7 @@ var PDFView = {
     if (typeof url === 'string') { // URL
       this.url = url;
       document.title = decodeURIComponent(getFileName(url)) || url;
-      parameters.url = expandUrl(url);
+      parameters.url = PDFJS.combineUrl(window.location.href, url);
     } else if (url && 'byteLength' in url) { // ArrayBuffer
       parameters.data = url;
     }

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -26,6 +26,10 @@ function getFileName(url) {
   return url.substring(url.lastIndexOf('/', end) + 1, end);
 }
 
+function expandUrl(url) {
+  return PDFJS.combineUrl(window.location.href, url);
+}
+
 var Cache = function cacheCache(size) {
   var data = [];
   this.push = function cachePush(view) {
@@ -376,7 +380,7 @@ var PDFView = {
     if (typeof url === 'string') { // URL
       this.url = url;
       document.title = decodeURIComponent(getFileName(url)) || url;
-      parameters.url = url;
+      parameters.url = expandUrl(url);
     } else if (url && 'byteLength' in url) { // ArrayBuffer
       parameters.data = url;
     }


### PR DESCRIPTION
This will avoid unnecessary serialization of the binary data between main and worker threads.

According to https://bugzilla.mozilla.org/show_bug.cgi?id=675504, the FF9 and below does not support typed array with XMLHttpRequest  . It's recommended to apply PR #1697 
