### PR TITLE
Fix for web worker test in Safari

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -18,7 +18,7 @@
  * @return {Promise} A promise that is resolved with {PDFDocumentProxy} object.
  */
 PDFJS.getDocument = function getDocument(source) {
-  var url, data, headers, password, parameters = {};
+  var url, data, headers, password, parameters = {}, workerInitializedPromise, workerReadyPromise, transport;
   if (typeof source === 'string') {
     url = source;
   } else if (isArrayBuffer(source)) {
@@ -37,8 +37,9 @@ PDFJS.getDocument = function getDocument(source) {
           'string or a parameter object');
   }
 
-  var promise = new PDFJS.Promise();
-  var transport = new WorkerTransport(promise);
+  workerInitializedPromise = new PDFJS.Promise();
+  workerReadyPromise = new PDFJS.Promise();
+  transport = new WorkerTransport(workerInitializedPromise, workerReadyPromise);
   if (data) {
     // assuming the data is array, instantiating directly from it
     transport.sendData(data, parameters);
@@ -49,23 +50,26 @@ PDFJS.getDocument = function getDocument(source) {
         url: url,
         progress: function getPDFProgress(evt) {
           if (evt.lengthComputable)
-            promise.progress({
+			  workerReadyPromise.progress({
               loaded: evt.loaded,
               total: evt.total
             });
         },
         error: function getPDFError(e) {
-          promise.reject('Unexpected server response of ' +
+			workerReadyPromise.reject('Unexpected server response of ' +
             e.target.status + '.');
         },
         headers: headers
       },
       function getPDFLoad(data) {
-        transport.sendData(data, parameters);
+		//we have to wait for the WorkerTransport to finalize worker-support detection! This may take a while...
+		workerInitializedPromise.then(function () {
+        	transport.sendData(data, parameters);
+		});
       });
   }
 
-  return promise;
+  return workerReadyPromise;
 };
 
 /**
@@ -414,8 +418,8 @@ var PDFPageProxy = (function PDFPageProxyClosure() {
  * For internal use only.
  */
 var WorkerTransport = (function WorkerTransportClosure() {
-  function WorkerTransport(promise) {
-    this.workerReadyPromise = promise;
+  function WorkerTransport(workerInitializedPromise, workerReadyPromise) {
+    this.workerReadyPromise = workerReadyPromise;
     this.objs = new PDFObjects();
 
     this.pageCache = [];
@@ -459,6 +463,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
             globalScope.PDFJS.disableWorker = true;
             this.setupFakeWorker();
           }
+          workerInitializedPromise.resolve();
         }.bind(this));
 
         var testObj = new Uint8Array(1);
@@ -474,6 +479,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
     // Thus, we fallback to a faked worker.
     globalScope.PDFJS.disableWorker = true;
     this.setupFakeWorker();
+	workerInitializedPromise.resolve();
   }
   WorkerTransport.prototype = {
     destroy: function WorkerTransport_destroy() {

--- a/src/worker.js
+++ b/src/worker.js
@@ -20,6 +20,10 @@ function MessageHandler(name, comObj) {
     warn(data);
   }];
 
+  comObj.onerror = function(event){
+    throw new Error(event.message + " (" + event.filename + ":" + event.lineno + ")");
+  };
+
   comObj.onmessage = function messageHandlerComObjOnMessage(event) {
     var data = event.data;
     if (data.isReply) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -20,10 +20,6 @@ function MessageHandler(name, comObj) {
     warn(data);
   }];
 
-  comObj.onerror = function(event){
-    throw new Error(event.message + " (" + event.filename + ":" + event.lineno + ")");
-  };
-
   comObj.onmessage = function messageHandlerComObjOnMessage(event) {
     var data = event.data;
     if (data.isReply) {

--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -10,10 +10,10 @@
     if (typeof Uint8Array.prototype.subarray === 'undefined') {
         Uint8Array.prototype.subarray = function subarray(start, end) {
           return new Uint8Array(this.slice(start, end));
-        }
+        };
         Float32Array.prototype.subarray = function subarray(start, end) {
             return new Float32Array(this.slice(start, end));
-        }
+        };
     }
 
     // some mobile version might not support Float64Array
@@ -79,9 +79,17 @@
 
 // Object.defineProperty() ?
 (function checkObjectDefinePropertyCompatibility() {
-  // safari 5 and 6 cannot use this on DOM objects and thus it's unusable,
-  if ((typeof Object.defineProperty !== 'undefined') &&
-    !/Safari/.test(navigator.userAgent)) return;
+  if (typeof Object.defineProperty !== 'undefined') {
+    // some browsers (e.g. safari) cannot use defineProperty() on DOM objects
+    // and thus the native version is not sufficient
+    var definePropertyPossible = true;
+    try {
+      Object.defineProperty(new Image(), 'id', { value: 'test' });
+    } catch (e) {
+      definePropertyPossible = false;
+    }
+    if (definePropertyPossible) return;
+  }
 
   Object.defineProperty = function objectDefineProperty(obj, name, def) {
     delete obj[name];

--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -79,10 +79,9 @@
 
 // Object.defineProperty() ?
 (function checkObjectDefinePropertyCompatibility() {
-  // safari 5 cannot use this on DOM objects and thus is unusable,
-  // see http://kangax.github.com/es5-compat-table/
+  // safari 5 and 6 cannot use this on DOM objects and thus it's unusable,
   if ((typeof Object.defineProperty !== 'undefined') &&
-    /Safari\/5/.test(navigator.userAgent)) return;
+    !/Safari/.test(navigator.userAgent)) return;
 
   Object.defineProperty = function objectDefineProperty(obj, name, def) {
     delete obj[name];

--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -6,7 +6,7 @@
 // Checking if the typed arrays are supported
 (function checkTypedArrayCompatibility() {
   if (typeof Uint8Array !== 'undefined') {
-    // some mobile versions do not support subarray (e.g. safari 5 / iPhone / iPad)
+    // some mobile versions do not support subarray (e.g. safari 5 / iOS)
     if (typeof Uint8Array.prototype.subarray === 'undefined') {
         Uint8Array.prototype.subarray = function subarray(start, end) {
           return new Uint8Array(this.slice(start, end));
@@ -79,9 +79,10 @@
 
 // Object.defineProperty() ?
 (function checkObjectDefinePropertyCompatibility() {
-  // safari 5 cannot use this on DOM objects and thus is unusable, see http://kangax.github.com/es5-compat-table/
-  if ((typeof Object.defineProperty !== 'undefined') && /Safari\/5/.test(navigator.userAgent))
-    return;
+  // safari 5 cannot use this on DOM objects and thus is unusable,
+  // see http://kangax.github.com/es5-compat-table/
+  if ((typeof Object.defineProperty !== 'undefined') &&
+    /Safari\/5/.test(navigator.userAgent)) return;
 
   Object.defineProperty = function objectDefineProperty(obj, name, def) {
     delete obj[name];

--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -6,6 +6,16 @@
 // Checking if the typed arrays are supported
 (function checkTypedArrayCompatibility() {
   if (typeof Uint8Array !== 'undefined') {
+    // some mobile versions do not support subarray (e.g. safari 5 / iPhone / iPad)
+    if (typeof Uint8Array.prototype.subarray === 'undefined') {
+        Uint8Array.prototype.subarray = function subarray(start, end) {
+          return new Uint8Array(this.slice(start, end));
+        }
+        Float32Array.prototype.subarray = function subarray(start, end) {
+            return new Float32Array(this.slice(start, end));
+        }
+    }
+
     // some mobile version might not support Float64Array
     if (typeof Float64Array === 'undefined')
       window.Float64Array = Float32Array;
@@ -69,7 +79,8 @@
 
 // Object.defineProperty() ?
 (function checkObjectDefinePropertyCompatibility() {
-  if (typeof Object.defineProperty !== 'undefined')
+  // safari 5 cannot use this on DOM objects and thus is unusable, see http://kangax.github.com/es5-compat-table/
+  if ((typeof Object.defineProperty !== 'undefined') && /Safari\/5/.test(navigator.userAgent))
     return;
 
   Object.defineProperty = function objectDefineProperty(obj, name, def) {

--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -79,9 +79,16 @@
 
 // Object.defineProperty() ?
 (function checkObjectDefinePropertyCompatibility() {
-  // safari 5 and 6 cannot use this on DOM objects and thus it's unusable,
-  if ((typeof Object.defineProperty !== 'undefined') &&
-    !/Safari/.test(navigator.userAgent)) return;
+  if (typeof Object.defineProperty !== 'undefined') {
+    // Some browsers (e.g. safari) cannot use this on DOM objects
+    var definePropertyPossible = true;
+    try {
+      Object.defineProperty(new Image(), 'id', { value: 'test' });
+    } catch (e) {
+      definePropertyPossible = false;
+    }
+    if (definePropertyPossible) return true;
+  }
 
   Object.defineProperty = function objectDefineProperty(obj, name, def) {
     delete obj[name];


### PR DESCRIPTION
Safari can not read or write typed arrays to 'web workers'. This will cause Safari on the iPhone and iPad to crash. The desktop version of Safari just throws a weird error.

This behaviour is tested by pdf.js while a pdf is being downloaded from a URL. However, sometimes the pdf has finished downloading BEFORE the web worker-test has finished! In that case the rendering of the final pdf would cause errors, because the web workers have not yet been disabled.

This patch fixes this and the issues #1314, #1627, #1643, #1846 and #1805 .
