### PR TITLE
Moz print callback

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -88,4 +88,4 @@ loading_error=An error occurred while loading the PDF.
 text_annotation_type=[{{type}} Annotation]
 request_password=PDF is protected by a password:
 
-printing_not_supported=Warning: Printing is not supported by this browser.
+printing_not_supported=Warning: Printing is not fully supported by this browser.

--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -87,3 +87,5 @@ loading_error=An error occurred while loading the PDF.
 # Some common types are e.g.: "Check", "Text", "Comment", "Note"
 text_annotation_type=[{{type}} Annotation]
 request_password=PDF is protected by a password:
+
+printing_not_supported=Warning: Printing is not supported by this browser.

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1122,13 +1122,37 @@ canvas {
 }
 
 @media print {
-  #outerContainer {
+  /* Rules for browsers that don't support mozPrintCallback. */
+  #sidebarContainer, .toolbar, #loadingBox, #errorWrapper, .textLayer {
     display: none;
   }
-  #printContainer {
+
+  #mainContainer, #viewerContainer, .page, .page canvas {
+    position: static;
+    padding: 0;
+    margin: 0;
+  }
+
+  .page {
+    float: left;
+    display: none;
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+    box-shadow: none;
+  }
+
+  .page[data-loaded] {
     display: block;
   }
-  canvas {
+
+  /* Rules for browsers that support mozPrintCallback */
+  body[data-mozPrintCallback] #outerContainer {
+    display: none;
+  }
+  body[data-mozPrintCallback] #printContainer {
+    display: block;
+  }
+  #printContainer canvas {
     position: relative;
     top: 0;
     left: 0;

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1113,27 +1113,25 @@ canvas {
   font-size: 10px;
 }
 
+@page {
+  margin: 0;
+} 
+
+#printContainer {
+  display: none;
+}
+
 @media print {
-  #sidebarContainer, .toolbar, #loadingBox, #errorWrapper, .textLayer {
+  #outerContainer {
     display: none;
   }
-
-  #mainContainer, #viewerContainer, .page, .page canvas {
-    position: static;
-    padding: 0;
-    margin: 0;
-  }
-
-  .page {
-    float: left;
-    display: none;
-    -webkit-box-shadow: none;
-    -moz-box-shadow: none;
-    box-shadow: none;
-  }
-
-  .page[data-loaded] {
+  #printContainer {
     display: block;
+  }
+  canvas {
+    position: relative;
+    top: 0;
+    left: 0;
   }
 }
 

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -176,5 +176,6 @@
       </div> <!-- mainContainer -->
 
     </div> <!-- outerContainer -->
+    <div id="printContainer"></div>
   </body>
 </html>

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -102,11 +102,9 @@
                    <span data-l10n-id="open_file_label">Open</span>
                 </button>
 
-                <!--
                 <button id="print" class="toolbarButton print" title="Print" tabindex="11" data-l10n-id="print" onclick="window.print()">
                   <span data-l10n-id="print_label">Print</span>
                 </button>
-                -->
 
                 <button id="download" class="toolbarButton download" title="Download" onclick="PDFView.download();" tabindex="12" data-l10n-id="download">
                   <span data-l10n-id="download_label">Download</span>

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -381,7 +381,13 @@ var PDFView = {
 
   get supportsPrinting() {
     var canvas = document.createElement('canvas');
-    return 'mozPrintCallback' in canvas;
+    var value = 'mozPrintCallback' in canvas;
+    // shadow
+    Object.defineProperty(this, 'supportsPrinting', { value: value,
+                                                      enumerable: true,
+                                                      configurable: true,
+                                                      writable: false });
+    return value;
   },
 
   open: function pdfViewOpen(url, scale, password) {
@@ -1051,10 +1057,12 @@ var PDFView = {
   beforePrint: function pdfViewSetupBeforePrint() {
     if (!this.supportsPrinting) {
       var printMessage = mozL10n.get('printing_not_supported', null,
-                         'Warning: Printing is not supported by this browser.');
+          'Warning: Printing is not fully supported by this browser.');
       alert(printMessage);
       return;
     }
+    var body = document.querySelector('body');
+    body.setAttribute('data-mozPrintCallback', true);
     for (var i = 0, ii = this.pages.length; i < ii; ++i) {
       this.pages[i].beforePrint();
     }
@@ -1412,7 +1420,11 @@ var PageView = function pageView(container, pdfPage, id, scale,
         console.error(error);
         // Tell the printEngine that rendering this canvas/page has failed.
         // This will make the print proces stop.
-        obj.abort();
+        if ('abort' in object)
+          obj.abort();
+        else
+          obj.done();
+        self.pdfPage.destroy();
       });
     };
   };

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1058,7 +1058,7 @@ var PDFView = {
     if (!this.supportsPrinting) {
       var printMessage = mozL10n.get('printing_not_supported', null,
           'Warning: Printing is not fully supported by this browser.');
-      alert(printMessage);
+      this.error(printMessage);
       return;
     }
     var body = document.querySelector('body');

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1050,7 +1050,9 @@ var PDFView = {
 
   beforePrint: function pdfViewSetupBeforePrint() {
     if (!this.supportsPrinting) {
-      alert('Printing is not supported by this browser.');
+      var printMessage = mozL10n.get('printing_not_supported', null,
+                         'Warning: Printing is not supported by this browser.');
+      alert(printMessage);
       return;
     }
     for (var i = 0, ii = this.pages.length; i < ii; ++i) {
@@ -1759,6 +1761,10 @@ window.addEventListener('load', function webViewerLoad(evt) {
   if (!PDFJS.isFirefoxExtension ||
     (PDFJS.isFirefoxExtension && FirefoxCom.requestSync('searchEnabled'))) {
     document.querySelector('#viewSearch').classList.remove('hidden');
+  }
+
+  if (!PDFView.supportsPrinting) {
+    document.getElementById('print').classList.add('hidden');
   }
 
   // Listen for warnings to trigger the fallback UI.  Errors should be caught


### PR DESCRIPTION
Adds the code on the pdf.js side of things needed for Julian mozPrintCallback api.

You can get the patch for mozprintcallback is at:
http://people.mozilla.com/~bdahl/patches/mozprintcallback.patch

I haven't updated the patch bugzilla yet since it is still leaking memory on the new ref test.

Try run & builds(just restarted):
https://tbpl.mozilla.org/?tree=Try&rev=c15d226623dd
http://ftp.mozilla.org/pub/mozilla.org/firefox/try-builds/bdahl@mozilla.com-c15d226623dd
