### PR TITLE
Add support for type 1 seac charstring command.

### DIFF
--- a/src/fonts.js
+++ b/src/fonts.js
@@ -3429,7 +3429,8 @@ var Type1Parser = function type1Parser() {
     for (var i = 0; i < numArgs; i++) {
       if (index < 0) {
         args.unshift({ arg: [0],
-                       value: 0 });
+                       value: 0,
+                       offset: 0 });
         warn('Malformed charstring stack: not enough values on stack.');
         continue;
       }
@@ -3443,11 +3444,13 @@ var Type1Parser = function type1Parser() {
           b = 1;
         }
         args.unshift({ arg: [a, b, 'div'],
-                       value: a / b });
+                       value: a / b,
+                       offset: index - 2 });
         index -= 3;
       } else if (isInt(token)) {
         args.unshift({ arg: stack.slice(index, index + 1),
-                       value: token });
+                       value: token,
+                       offset: index });
         index--;
       } else {
         warn('Malformed charsting stack: found bad token ' + token + '.');
@@ -3501,7 +3504,9 @@ var Type1Parser = function type1Parser() {
           } else if (escape == 6) {
             // seac is like type 2's special endchar but it doesn't use the
             // first argument asb, so remove it.
-            charstring.splice(charstring.length - 5, 1);
+            var args = breakUpArgs(charstring, 5);
+            var arg0 = args[0];
+            charstring.splice(arg0.offset, arg0.arg.length);
           } else if (!kHintingEnabled && (escape == 1 || escape == 2)) {
             charstring.push('drop', 'drop', 'drop', 'drop', 'drop', 'drop');
             continue;

--- a/src/fonts.js
+++ b/src/fonts.js
@@ -3391,8 +3391,8 @@ var Type1Parser = function type1Parser() {
       '1': 'vstem',
       '2': 'hstem',
 
+      '6': 'endchar', // seac
       // Type1 only command with command not (yet) built-in ,throw an error
-      '6': -1, // seac
       '7': -1, // sbw
 
       '11': 'sub',
@@ -3464,6 +3464,10 @@ var Type1Parser = function type1Parser() {
             // pop or setcurrentpoint commands can be ignored
             // since we are not doing callothersubr
             continue;
+          } else if (escape == 6) {
+            // seac is like type 2's special endchar but it doesn't use the
+            // first argument asb, so remove it.
+            charstring.splice(charstring.length - 5, 1);
           } else if (!kHintingEnabled && (escape == 1 || escape == 2)) {
             charstring.push('drop', 'drop', 'drop', 'drop', 'drop', 'drop');
             continue;

--- a/test/pdfs/issue818.pdf.link
+++ b/test/pdfs/issue818.pdf.link
@@ -1,0 +1,1 @@
+http://www.effi.org/system/files?file=effi-siv-251110.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -624,5 +624,13 @@
       "pageLimit": 2,
       "link": true,
       "type": "eq"
+    },
+    {  "id": "issue818",
+      "file": "pdfs/issue818.pdf",
+      "md5": "dd2f8a5bd65164ad74da2b45a6ca90cc",
+      "rounds": 1,
+      "pageLimit": 1,
+      "link": true,
+      "type": "eq"
     }
 ]


### PR DESCRIPTION
Fixes all fonts in:
#1356 biblatex.pdf
#1581 scalable-joins.pdf
#1515 StopStealingDreamsSCREEN.pdf

Fixes most fonts, but some still broken due to other issues:
#1655 thesis-draft.pdf - fixes most not all(bad fonts down around page 7)
#845 new-pdf(1).pdf - removes seac warnings but font still broken
#818 818.pdf - fixes most not all
