### PR TITLE
Catch errors when parsing the linearization header.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -398,16 +398,16 @@ var PDFDocument = (function PDFDocumentClosure() {
     get linearization() {
       var length = this.stream.length;
       var linearization = false;
-      try {
-        if (length) {
+      if (length) {
+        try {
           linearization = new Linearization(this.stream);
           if (linearization.length != length)
             linearization = false;
+        } catch (err) {
+          warn('since pdf is broken pdf.js is trying to recover it ' +
+               'by indexing the object; ' +
+               'the error in firebug shall have a different origin');
         }
-      } catch (err) {
-        warn('since pdf is broken pdf.js is trying to recover it ' +
-             'by indexing the object; ' +
-             'the error in firebug shall have a different origin');
       }
       // shadow the prototype getter with a data property
       return shadow(this, 'linearization', linearization);

--- a/src/core.js
+++ b/src/core.js
@@ -404,9 +404,8 @@ var PDFDocument = (function PDFDocumentClosure() {
           if (linearization.length != length)
             linearization = false;
         } catch (err) {
-          warn('since pdf is broken pdf.js is trying to recover it ' +
-               'by indexing the object; ' +
-               'the error in firebug shall have a different origin');
+          warn('The linearization data is not available ' +
+               'or unreadable pdf data is found');
         }
       }
       // shadow the prototype getter with a data property

--- a/src/core.js
+++ b/src/core.js
@@ -398,10 +398,16 @@ var PDFDocument = (function PDFDocumentClosure() {
     get linearization() {
       var length = this.stream.length;
       var linearization = false;
-      if (length) {
-        linearization = new Linearization(this.stream);
-        if (linearization.length != length)
-          linearization = false;
+      try {
+        if (length) {
+          linearization = new Linearization(this.stream);
+          if (linearization.length != length)
+            linearization = false;
+        }
+      } catch (err) {
+        warn('since pdf is broken pdf.js is trying to recover it ' +
+             'by indexing the object; ' +
+             'the error in firebug shall have a different origin');
       }
       // shadow the prototype getter with a data property
       return shadow(this, 'linearization', linearization);


### PR DESCRIPTION
I have a corrupted doc that I can't post here.
I can view the docs in foxitreader and with gs on ubuntu but pdf.js throws an error.
I can view the doc in pdf.js without errors after repairing it with:
gs \
  -o repaired.pdf \
  -sDEVICE=pdfwrite \
  -dPDFSETTINGS=/prepress \
   corrupted.pdf

The error when viewing the corrupted doc:

Error: Illegal character in hex string: 
Lexer_getHexString("\x9C")@http://localhost/pdf.js/build/pdf.js:27526 Lexer_getObj()@http://localhost/pdf.js/build/pdf.js:27573 Parser_refill()@http://localhost/pdf.js/build/pdf.js:27074 Parser([object Object],false,null)@http://localhost/pdf.js/build/pdf.js:27068 Linearization([object Object])@http://localhost/pdf.js/build/pdf.js:27635 ()@http://localhost/pdf.js/build/pdf.js:414 ()@http://localhost/pdf.js/build/pdf.js:424 PDFDocument_setup((void 0))@http://localhost/pdf.js/build/pdf.js:483 init([object Object],(void 0))@http://localhost/pdf.js/build/pdf.js:389 PDFDocument([object Object],(void 0))@http://localhost/pdf.js/build/pdf.js:379 wphSetupDoc([object Object])@http://localhost/pdf.js/build/pdf.js:30448 messageHandlerComObjOnMessage([object Object])@http://localhost/pdf.js/build/pdf.js:30398 WorkerTransport_postMessage([object Object])@http://localhost/pdf.js/build/pdf.js:1668 messageHandlerSend("GetDocRequest",[object Object])@http://localhost/pdf.js/build/pdf.js:30430 WorkerTransport_sendData([object ArrayBuffer],[object Object])@http://localhost/pdf.js/build/pdf.js:1803 workerInitialized(null)@http://localhost/pdf.js/build/pdf.js:1227 Promise_then(workerInitialized)@http://localhost/pdf.js/build/pdf.js:1084 getPDFLoad([object ArrayBuffer])@http://localhost/pdf.js/build/pdf.js:1226 getPdfOnreadystatechange([object Event])@http://localhost/pdf.js/build/pdf.js:75
