### PR TITLE
Use Blob constructor when available instead of deprecated MozBlobBuilder.

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -460,9 +460,9 @@ var WorkerTransport = (function WorkerTransportClosure() {
 //#else
 //      // The firefox extension can't load the worker from the resource://
 //      // url so we have to inline the script and then use the blob loader.
-//      var bb = new MozBlobBuilder();
-//      bb.append(document.querySelector('#PDFJS_SCRIPT_TAG').textContent);
-//      var blobUrl = window.URL.createObjectURL(bb.getBlob());
+//      var script = document.querySelector('#PDFJS_SCRIPT_TAG');
+//      var blob = PDFJS.createBlob(script.textContent, script.type);
+//      var blobUrl = window.URL.createObjectURL(blob);
 //      worker = new Worker(blobUrl);
 //#endif
         var messageHandler = new MessageHandler('main', worker);
@@ -503,6 +503,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
       this.pagePromises = [];
     },
     setupFakeWorker: function WorkerTransport_setupFakeWorker() {
+      warn('Setting up fake worker.');
       // If we don't use a worker, just post/sendMessage to the main thread.
       var fakeWorker = {
         postMessage: function WorkerTransport_postMessage(obj) {

--- a/src/util.js
+++ b/src/util.js
@@ -662,3 +662,12 @@ var StatTimer = (function StatTimerClosure() {
   };
   return StatTimer;
 })();
+
+PDFJS.createBlob = function createBlob(data, contentType) {
+  if (typeof Blob === 'function')
+    return new Blob([data], { type: contentType });
+  // Blob builder is deprecated in FF14 and removed in FF18.
+  var bb = new MozBlobBuilder();
+  bb.append(data);
+  return bb.getBlob(contentType);
+};

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -483,7 +483,6 @@ var PDFView = {
     function noData() {
       FirefoxCom.request('download', { originalUrl: url });
     }
-
     var url = this.url.split('#')[0];
 //#if !(FIREFOX || MOZCENTRAL)
     url += '#pdfjs.action=download';
@@ -496,10 +495,8 @@ var PDFView = {
 //  }
 //  this.pdfDocument.getData().then(
 //    function getDataSuccess(data) {
-//      var bb = new MozBlobBuilder();
-//      bb.append(data.buffer);
-//      var blobUrl = window.URL.createObjectURL(
-//                      bb.getBlob('application/pdf'));
+//      var blob = PDFJS.createBlob(data.buffer, 'application/pdf');
+//      var blobUrl = window.URL.createObjectURL(blob);
 //
 //      FirefoxCom.request('download', { blobUrl: blobUrl, originalUrl: url },
 //        function response(err) {


### PR DESCRIPTION
Was tired of seeing this warning in the console.
