### PR TITLE
Fix initial scroll direction detection.

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -912,7 +912,6 @@ var PDFView = {
       }
       if ('page' in params) {
         var pageNumber = (params.page | 0) || 1;
-        this.page = pageNumber;
         if ('zoom' in params) {
           var zoomArgs = params.zoom.split(','); // scale,left,top
           // building destination array
@@ -928,8 +927,9 @@ var PDFView = {
             (zoomArgs[2] | 0), zoomArg];
           var currentPage = this.pages[pageNumber - 1];
           currentPage.scrollIntoView(dest);
-        } else
+        } else {
           this.page = params.page; // simple page
+        }
         return;
       }
     } else if (/^\d+$/.test(hash)) // page number

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -928,7 +928,7 @@ var PDFView = {
           var currentPage = this.pages[pageNumber - 1];
           currentPage.scrollIntoView(dest);
         } else {
-          this.page = params.page; // simple page
+          this.page = pageNumber; // simple page
         }
         return;
       }


### PR DESCRIPTION
If you had visited a PDF already and were scrolled two the top(first page was below the top bar) then the scroll direction monitoring would think you had scrolled up causing the viewer not to pre-render the second page.  

This happened because setHash set the page number which then scrolled the page into view, but then it would scroll up further to account for the offset above the top page.  Setting the page isn't needed since that will happen when the offset location is scrolled.
