### PR TITLE
Prevent the error callback from being called twice when getPdf fails because of a cross domain request.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -60,6 +60,7 @@ function getPdf(arg, callback) {
         calledErrorBack = true;
         params.error();
       }
+    }
   }
 
   xhr.onreadystatechange = function getPdfOnreadystatechange(e) {

--- a/src/core.js
+++ b/src/core.js
@@ -52,8 +52,12 @@ function getPdf(arg, callback) {
   if ('progress' in params)
     xhr.onprogress = params.progress || undefined;
 
-  if ('error' in params)
+  var calledErrorBack = false;
+
+  if ('error' in params && !calledErrorBack) {
+    calledErrorBack = true;
     xhr.onerror = params.error || undefined;
+  }
 
   xhr.onreadystatechange = function getPdfOnreadystatechange(e) {
     if (xhr.readyState === 4) {
@@ -61,7 +65,8 @@ function getPdf(arg, callback) {
         var data = (xhr.mozResponseArrayBuffer || xhr.mozResponse ||
                     xhr.responseArrayBuffer || xhr.response);
         callback(data);
-      } else if (params.error) {
+      } else if (params.error && !calledErrorBack) {
+        calledErrorBack = true;
         params.error(e);
       }
     }

--- a/src/core.js
+++ b/src/core.js
@@ -54,9 +54,12 @@ function getPdf(arg, callback) {
 
   var calledErrorBack = false;
 
-  if ('error' in params && !calledErrorBack) {
-    calledErrorBack = true;
-    xhr.onerror = params.error || undefined;
+  if ('error' in params) {
+    xhr.onerror = function errorBack() {
+      if (!calledErrorBack) {
+        calledErrorBack = true;
+        params.error();
+      }
   }
 
   xhr.onreadystatechange = function getPdfOnreadystatechange(e) {


### PR DESCRIPTION
When the server returns 404 because of a missing pdf doc, getPdf calls the error callback twice which leads to two rejection of the promise which throws an error.

To reproduce this issue I changed helloworld.pdf to helloworld2.pdf
http://jsbin.com/ofisex/edit#javascript,html,live

Thanks
