### PR TITLE
Implements HTTP range request support

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -163,13 +163,6 @@ var PDFPageProxy = (function PDFPageProxyClosure() {
       return this.pageInfo.rotate;
     },
     /**
-     * @return {object} The reference that points to this page. It has 'num' and
-     * 'gen' properties.
-     */
-    get ref() {
-      return this.pageInfo.ref;
-    },
-    /**
      * @return {array} An array of the visible portion of the PDF page in the
      * user space units - [x1, y1, x2, y2].
      */

--- a/src/core.js
+++ b/src/core.js
@@ -93,8 +93,13 @@ function getPdf(arg, callback) {
     return buffer.buffer;
   };
 
-  if (rangeState !== 2 && 'progress' in params)
-      xhr.onprogress = params.progress || undefined;
+  if (rangeState !== 2 && params.progress) {
+    xhr.onprogress = function xhrProgress(e) {
+      if (xhr.status == xhr.altExpected)
+        return;
+      params.progress(e);
+    };
+  }
 
   xhr.onreadystatechange = function getPdfOnreadystatechange(e) {
     if (xhr.readyState === 4) {

--- a/src/core.js
+++ b/src/core.js
@@ -55,8 +55,8 @@ function getPdf(arg, callback) {
   var protocol = params.url.substring(0, params.url.indexOf(':') + 1);
   var isHttpProtocol = (protocol === 'http:' || protocol === 'https:');
   xhr.expected = isHttpProtocol ? 200 : 0;
-  var isRangeEnabled = isHttpProtocol && !globalScope.PDFJS.disableRange;
-
+  var isRangeEnabled = isHttpProtocol && isWorker &&
+                       !globalScope.PDFJS.disableRange;
 
   var rangeState = 0;
   if ('range' in params) {

--- a/src/core.js
+++ b/src/core.js
@@ -10,8 +10,8 @@ var isWorker = (typeof window == 'undefined');
 var ERRORS = 0, WARNINGS = 1, INFOS = 5;
 var verbosity = WARNINGS;
 
-var REQUEST_BLOCK_SIZE = 1000;
-var INITIAL_REQUEST_SIZE = REQUEST_BLOCK_SIZE * 3;
+var REQUEST_BLOCK_SIZE = 2000;
+var INITIAL_REQUEST_SIZE = REQUEST_BLOCK_SIZE;
 
 // The global PDFJS object exposes the API
 // In production, it will be declared outside a global wrapper
@@ -93,6 +93,9 @@ function getPdf(arg, callback) {
     return buffer.buffer;
   };
 
+  if (rangeState !== 2 && 'progress' in params)
+      xhr.onprogress = params.progress || undefined;
+
   xhr.onreadystatechange = function getPdfOnreadystatechange(e) {
     if (xhr.readyState === 4) {
       if ((xhr.status === xhr.expected && rangeState !== 2) ||
@@ -107,11 +110,6 @@ function getPdf(arg, callback) {
       } else if (params.error && !calledErrorBack) {
         calledErrorBack = true;
         params.error(e);
-      }
-    } else if (xhr.readyState === 2) {
-      if (xhr.status === xhr.expected && rangeState !== 2) {
-        if ('progress' in params)
-          xhr.onprogress = params.progress || undefined;
       }
     }
   };

--- a/src/core.js
+++ b/src/core.js
@@ -104,7 +104,7 @@ function getPdf(arg, callback) {
         var data = xhr.getArrayBuffer();
         var rangeHeader = xhr.getResponseHeader('Content-Range');
         var totalLength = parseInt(rangeHeader.split('/')[1], 10);
-        callback({chunk: data, request: arg, length: totalLength});
+        callback({chunk: data, context: arg, length: totalLength});
       } else if (params.error && !calledErrorBack) {
         calledErrorBack = true;
         params.error(e);

--- a/src/core.js
+++ b/src/core.js
@@ -10,7 +10,7 @@ var isWorker = (typeof window == 'undefined');
 var ERRORS = 0, WARNINGS = 1, INFOS = 5;
 var verbosity = WARNINGS;
 
-var REQUEST_BLOCK_SIZE = 2000;
+var REQUEST_BLOCK_SIZE = 4000;
 var INITIAL_REQUEST_SIZE = REQUEST_BLOCK_SIZE;
 
 // The global PDFJS object exposes the API

--- a/src/core.js
+++ b/src/core.js
@@ -117,10 +117,11 @@ globalScope.PDFJS.getPdf = getPdf;
 globalScope.PDFJS.pdfBug = false;
 
 var Page = (function PageClosure() {
-  function Page(xref, pageNumber, pageDict, ref) {
+  function Page(catalog, pageNumber, pageDict, ref) {
     this.pageNumber = pageNumber;
     this.pageDict = pageDict;
-    this.xref = xref;
+    this.catalog = catalog;
+    this.xref = catalog.xref;
     this.ref = ref;
 
     this.displayReadyPromise = null;
@@ -324,7 +325,7 @@ var Page = (function PageClosure() {
                   item.url = url;
                   break;
                 case 'GoTo':
-                  item.dest = a.get('D');
+                  item.dest = this.resolveDestination(a.get('D'));
                   break;
                 default:
                   TODO('other link types');
@@ -332,7 +333,7 @@ var Page = (function PageClosure() {
             } else if (annotation.has('Dest')) {
               // simple destination link
               var dest = annotation.get('Dest');
-              item.dest = isName(dest) ? dest.name : dest;
+              item.dest = this.resolveDestination(dest);
             }
             break;
           case 'Widget':
@@ -393,6 +394,9 @@ var Page = (function PageClosure() {
         items.push(item);
       }
       return items;
+    },
+    resolveDestination: function Page_resolveDestination(dest) {
+      return this.catalog.resolveDestination(dest);
     }
   };
 

--- a/src/stream.js
+++ b/src/stream.js
@@ -70,6 +70,119 @@ var Stream = (function StreamClosure() {
   return Stream;
 })();
 
+var ChunkedStream = (function ChunkedStreamClosure() {
+  function ChunkedStream(length, blockSize, moreDataCallback) {
+    this.bytes = new Uint8Array(length);
+    this.blockSize = blockSize;
+    this.start = 0;
+    this.pos = 0;
+    this.end = length;
+    this.blocksFilled = [];
+    this.moreData = moreDataCallback;
+  }
+
+  // required methods for a stream. if a particular stream does not
+  // implement these, an error should be thrown
+  ChunkedStream.prototype = {
+    get length() {
+      return this.end - this.start;
+    },
+    getByte: function ChunkedStream_getByte() {
+      var pos = this.pos;
+      if (pos >= this.end)
+        return null;
+      this.ensureRange(pos, pos + 1);
+      return this.bytes[this.pos++];
+    },
+    // returns subarray of original buffer
+    // should only be read
+    getBytes: function ChunkedStream_getBytes(length) {
+      var bytes = this.bytes;
+      var pos = this.pos;
+      var strEnd = this.end;
+
+      if (!length) {
+        this.ensureRange(pos, strEnd);
+        return bytes.subarray(pos, strEnd);
+      }
+
+      var end = pos + length;
+      if (end > strEnd)
+        end = strEnd;
+      this.ensureRange(pos, end);
+
+      this.pos = end;
+      return bytes.subarray(pos, end);
+    },
+    lookChar: function ChunkedStream_lookChar() {
+      var pos = this.pos;
+      if (pos >= this.end)
+        return null;
+      this.ensureRange(pos, pos + 1);
+      return String.fromCharCode(this.bytes[pos]);
+    },
+    getChar: function ChunkedStream_getChar() {
+      var pos = this.pos;
+      if (pos >= this.end)
+        return null;
+      this.ensureRange(pos, pos + 1);
+      return String.fromCharCode(this.bytes[this.pos++]);
+    },
+    skip: function ChunkedStream_skip(n) {
+      if (!n)
+        n = 1;
+      this.pos += n;
+    },
+    reset: function ChunkedStream_reset() {
+      this.pos = this.start;
+    },
+    moveStart: function ChunkedStream_moveStart() {
+      this.start = this.pos;
+    },
+    makeSubStream: function ChunkedStream_makeSubStream(start, length, dict) {
+      function ChunkedStreamSubstream() {}
+      ChunkedStreamSubstream.prototype = Object.create(this);
+      var subStream = new ChunkedStreamSubstream();
+      subStream.pos = subStream.start = start;
+      subStream.end = start + length || this.end;
+      subStream.dict = dict;
+      return subStream;
+    },
+    ensureRange: function ChunkedStream_ensureRange(start, end) {
+      var blockSize = this.blockSize;
+      var startBlock = Math.floor(start / blockSize);
+      var endBlock = Math.ceil(end / blockSize);
+      var filled = this.blocksFilled;
+      var i = startBlock;
+      do {
+        while (i < endBlock && filled[i])
+          i++;
+        if (i >= endBlock)
+          break;
+        var j = i + 1;
+        while (j < endBlock && !filled[j])
+          j++;
+        this.moreData(i * blockSize, Math.min(j * blockSize, this.end));
+        i = j;
+      } while (true);
+    },
+    set: function ChunkedStream_set(offset, buffer) {
+      this.bytes.set(new Uint8Array(buffer), offset);
+      var blockSize = this.blockSize;
+      var end = offset + buffer.byteLength;
+      var startBlock = Math.floor(offset / blockSize);
+      var endBlock = end < this.end ? Math.floor(end / blockSize) :
+                                      Math.ceil(this.end / blockSize);
+      var filled = this.blocksFilled;
+      for (var i = startBlock; i < endBlock; i++)
+        filled[i] = true;
+    },
+    isStream: true
+  };
+
+  return ChunkedStream;
+})();
+
 var StringStream = (function StringStreamClosure() {
   function StringStream(str) {
     var length = str.length;

--- a/src/stream.js
+++ b/src/stream.js
@@ -140,6 +140,10 @@ var ChunkedStream = (function ChunkedStreamClosure() {
       this.start = this.pos;
     },
     makeSubStream: function ChunkedStream_makeSubStream(start, length, dict) {
+      if (length) {
+        this.ensureRange(start, start + length);
+        return new Stream(this.bytes.buffer, start, length, dict);
+      }
       function ChunkedStreamSubstream() {}
       ChunkedStreamSubstream.prototype = Object.create(this);
       var subStream = new ChunkedStreamSubstream();

--- a/src/worker.js
+++ b/src/worker.js
@@ -83,6 +83,7 @@ MessageHandler.prototype = {
 var WorkerMessageHandler = {
   setup: function wphSetup(handler) {
     var pdfModel = null;
+    var usingRangeRequest = false;
 
     function loadDocument(pdfData, pdfModelSource) {
       // Create only the model of the PDFDoc, which is enough for
@@ -92,15 +93,32 @@ var WorkerMessageHandler = {
         var stream;
         if ('chunk' in pdfData) {
           var context = pdfData.context;
+          var reportProgress =
+            (function reportProgressClosure(total, progressCallback) {
+            var loaded = 0;
+            return (function reportProgress(delta) {
+              loaded += delta;
+              if (!progressCallback)
+                return;
+              progressCallback({
+                lengthComputable: true,
+                total: total,
+                loaded: loaded
+              });
+            });
+          })(pdfData.length, context.progress);
           stream = new ChunkedStream(pdfData.length, REQUEST_BLOCK_SIZE,
                                      function moreDataCallback(start, end) {
             context.sync = true;
             context.range = [start, end];
             getPdf(context, function(data) {
               stream.set(start, data);
+              reportProgress(data.byteLength);
             });
           });
           stream.set(0, pdfData.chunk);
+          reportProgress(pdfData.chunk.byteLength);
+          usingRangeRequest = true;
         } else
           stream = new Stream(pdfData);
         pdfModel = new PDFDocument(stream, pdfPassword);
@@ -128,7 +146,8 @@ var WorkerMessageHandler = {
         outline: pdfModel.catalog.documentOutline,
         info: pdfModel.getDocumentInfo(),
         metadata: pdfModel.catalog.metadata,
-        encrypted: !!pdfModel.xref.encrypt
+        encrypted: !!pdfModel.xref.encrypt,
+        usingRangeRequest: usingRangeRequest
       };
       handler.send('GetDoc', {pdfInfo: doc});
     }

--- a/src/worker.js
+++ b/src/worker.js
@@ -173,7 +173,6 @@ var WorkerMessageHandler = {
       var page = {
         pageIndex: data.pageIndex,
         rotate: pdfPage.rotate,
-        ref: pdfPage.ref,
         view: pdfPage.view
       };
       handler.send('GetPage', {pageInfo: page});

--- a/src/worker.js
+++ b/src/worker.js
@@ -89,7 +89,10 @@ var WorkerMessageHandler = {
       // processing the content of the pdf.
       var pdfPassword = pdfModelSource.password;
       try {
-        pdfModel = new PDFDocument(new Stream(pdfData), pdfPassword);
+        if ('chunk' in pdfData)
+          throw 'Chunked loading is not supported yet';
+        var stream = new Stream(pdfData);
+        pdfModel = new PDFDocument(stream, pdfPassword);
       } catch (e) {
         if (e instanceof PasswordException) {
           if (e.code === 'needpassword') {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -626,6 +626,13 @@ var PDFView = {
       };
     }
 
+    function EstimatedViewport(baseViewport) {
+      this.width = baseViewport.width;
+      this.height = baseViewport.height;
+      this.convertToPdfPoint = function() { return [0, 0]; };
+      this.convertToViewportPoint = function() { return [0, 0]; };
+    }
+
     this.pdfDocument = pdfDocument;
 
     var errorWrapper = document.getElementById('errorWrapper');
@@ -667,15 +674,18 @@ var PDFView = {
 
     var thumbnails = this.thumbnails = [];
     var pagePromises = [];
-    for (var i = 1; i <= pagesCount; i++)
+    for (var i = 1; i <= Math.min(pagesCount, 2); i++)
       pagePromises.push(pdfDocument.getPage(i));
     var self = this;
     var pagesPromise = PDFJS.Promise.all(pagePromises);
     pagesPromise.then(function(promisedPages) {
+      var previousViewport = null;
       for (var i = 1; i <= pagesCount; i++) {
-        var page = promisedPages[i - 1];
+        var page = promisedPages[i - 1] || null;
         var pageView = new PageView(container, page, i, scale,
-                                    page.stats, self.navigateTo.bind(self));
+                                    self.navigateTo.bind(self),
+                                    previousViewport);
+        previousViewport = new EstimatedViewport(pageView.viewport);
         var thumbnailView = new ThumbnailView(thumbsView, page, i);
         bindOnAfterDraw(pageView, thumbnailView);
 
@@ -720,6 +730,10 @@ var PDFView = {
       if (pdfTitle)
         document.title = pdfTitle + ' - ' + document.title;
     });
+  },
+
+  getPage: function pdfViewGetPage(n) {
+    return this.pdfDocument.getPage(n);
   },
 
   setInitialView: function pdfViewSetInitialView(storedHash, scale) {
@@ -1070,12 +1084,13 @@ var PDFView = {
 };
 
 var PageView = function pageView(container, pdfPage, id, scale,
-                                 stats, navigateTo) {
+                                 navigateTo, defaultViewport) {
   this.id = id;
   this.pdfPage = pdfPage;
 
   this.scale = scale || 1.0;
-  this.viewport = this.pdfPage.getViewport(this.scale);
+  this.viewport = pdfPage ? this.pdfPage.getViewport(this.scale) :
+                            defaultViewport;
 
   this.renderingState = RenderingStates.INITIAL;
   this.resume = null;
@@ -1092,17 +1107,29 @@ var PageView = function pageView(container, pdfPage, id, scale,
 
   this.destroy = function pageViewDestroy() {
     this.update();
-    this.pdfPage.destroy();
+    if (this.pdfPage)
+      this.pdfPage.destroy();
   };
 
   this.update = function pageViewUpdate(scale) {
     this.renderingState = RenderingStates.INITIAL;
     this.resume = null;
 
-    this.scale = scale || this.scale;
-    var viewport = this.pdfPage.getViewport(this.scale);
+    var viewport;
+    if (!this.pdfPage) {
+      viewport = this.viewport;
+      if (scale && this.scale != scale) {
+        var k = scale / this.scale;
+        this.scale = scale;
+        viewport.width *= k;
+        viewport.height *= k;
+      }
+    } else {
+      this.scale = scale || this.scale;
+      viewport = this.pdfPage.getViewport(this.scale);
+      this.viewport = viewport;
+    }
 
-    this.viewport = viewport;
     div.style.width = viewport.width + 'px';
     div.style.height = viewport.height + 'px';
 
@@ -1301,7 +1328,21 @@ var PageView = function pageView(container, pdfPage, id, scale,
       }, 0);
   };
 
+  this.setPdfPage = function pdfViewSetPdfPage(aPdfPage) {
+    this.pdfPage = pdfPage = aPdfPage;
+    this.update(this.scale);
+  };
+
   this.draw = function pageviewDraw(callback) {
+    if (!pdfPage) {
+      var promise = PDFView.getPage(this.id);
+      promise.then((function(pdfPage) {
+        this.setPdfPage(pdfPage);
+        this.draw(callback);
+      }).bind(this));
+      return;
+    }
+
     if (this.renderingState !== RenderingStates.INITIAL)
       error('Must be in new state before drawing');
 
@@ -1386,6 +1427,7 @@ var PageView = function pageView(container, pdfPage, id, scale,
   };
 
   this.beforePrint = function pageViewBeforePrint() {
+    // TODO what is pdfPage is not loaded???
     var pdfPage = this.pdfPage;
     var viewport = pdfPage.getViewport(1);
 
@@ -1440,16 +1482,7 @@ var ThumbnailView = function thumbnailView(container, pdfPage, id) {
     return false;
   };
 
-  var viewport = pdfPage.getViewport(1);
-  var pageWidth = this.width = viewport.width;
-  var pageHeight = this.height = viewport.height;
-  var pageRatio = pageWidth / pageHeight;
   this.id = id;
-
-  var canvasWidth = 98;
-  var canvasHeight = canvasWidth / this.width * this.height;
-  var scaleX = this.scaleX = (canvasWidth / pageWidth);
-  var scaleY = this.scaleY = (canvasHeight / pageHeight);
 
   var div = this.el = document.createElement('div');
   div.id = 'thumbnailContainer' + id;
@@ -1461,7 +1494,10 @@ var ThumbnailView = function thumbnailView(container, pdfPage, id) {
   this.hasImage = false;
   this.renderingState = RenderingStates.INITIAL;
 
-  function getPageDrawContext() {
+  function getPageDrawContext(pageWidth, pageHeight) {
+    var canvasWidth = 98;
+    var canvasHeight = canvasWidth / pageWidth * pageHeight;
+
     var canvas = document.createElement('canvas');
     canvas.id = 'thumbnail' + id;
     canvas.mozOpaque = true;
@@ -1491,7 +1527,20 @@ var ThumbnailView = function thumbnailView(container, pdfPage, id) {
     return !this.hasImage;
   };
 
+  this.setPdfPage = function thumbnailViewSetPdfPage(aPdfPage) {
+    this.pdfPage = pdfPage = aPdfPage;
+  };
+
   this.draw = function thumbnailViewDraw(callback) {
+    if (!pdfPage) {
+      var promise = PDFView.getPage(this.id);
+      promise.then((function(pdfPage) {
+        this.setPdfPage(pdfPage);
+        this.draw(callback);
+      }).bind(this));
+      return;
+    }
+
     if (this.renderingState !== RenderingStates.INITIAL)
       error('Must be in new state before drawing');
 
@@ -1501,8 +1550,13 @@ var ThumbnailView = function thumbnailView(container, pdfPage, id) {
       return;
     }
 
+    var viewport = pdfPage.getViewport(1);
+    var pageWidth = this.width = viewport.width;
+    var pageHeight = this.height = viewport.height;
+
     var self = this;
-    var ctx = getPageDrawContext();
+    var ctx = getPageDrawContext(pageWidth, pageHeight);
+    var scaleX = ctx.canvas.width / pageWidth;
     var drawViewport = pdfPage.getViewport(scaleX);
     var renderContext = {
       canvasContext: ctx,
@@ -1536,7 +1590,7 @@ var ThumbnailView = function thumbnailView(container, pdfPage, id) {
     if (this.hasImage || !img)
       return;
     this.renderingState = RenderingStates.FINISHED;
-    var ctx = getPageDrawContext();
+    var ctx = getPageDrawContext(img.width, img.height);
     ctx.drawImage(img, 0, 0, img.width, img.height,
                   0, 0, ctx.canvas.width, ctx.canvas.height);
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -631,11 +631,6 @@ var PDFView = {
     var errorWrapper = document.getElementById('errorWrapper');
     errorWrapper.setAttribute('hidden', 'true');
 
-    var loadingBox = document.getElementById('loadingBox');
-    loadingBox.setAttribute('hidden', 'true');
-    var loadingIndicator = document.getElementById('loading');
-    loadingIndicator.textContent = '';
-
     var thumbsView = document.getElementById('thumbnailView');
     thumbsView.parentNode.scrollTop = 0;
 
@@ -696,6 +691,11 @@ var PDFView = {
 
     // outline and initial view depends on destinations and pagesRefMap
     PDFJS.Promise.all([pagesPromise, destinationsPromise]).then(function() {
+      var loadingBox = document.getElementById('loadingBox');
+      loadingBox.setAttribute('hidden', 'true');
+      var loadingIndicator = document.getElementById('loading');
+      loadingIndicator.textContent = '';
+
       pdfDocument.getOutline().then(function(outline) {
         self.outline = new DocumentOutlineView(outline);
       });
@@ -1750,6 +1750,8 @@ window.addEventListener('load', function webViewerLoad(evt) {
 
   if ('disableWorker' in hashParams)
     PDFJS.disableWorker = (hashParams['disableWorker'] === 'true');
+  if ('disableRange' in hashParams)
+    PDFJS.disableWorker = (hashParams['disableRange'] === 'true');
 
   if (!PDFJS.isFirefoxExtension) {
     var locale = navigator.language;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -499,10 +499,8 @@ var PDFView = {
       dest = this.destinations[dest];
     if (!(dest instanceof Array))
       return; // invalid destination
-    // dest array looks like that: <page-ref> </XYZ|FitXXX> <args..>
-    var destRef = dest[0];
-    var pageNumber = destRef instanceof Object ?
-      this.pagesRefMap[destRef.num + ' ' + destRef.gen + ' R'] : (destRef + 1);
+    // dest array looks like that: <page-index> </XYZ|FitXXX> <args..>
+    var pageNumber = (dest[0] + 1);
     if (pageNumber > this.pages.length)
       pageNumber = this.pages.length;
     if (pageNumber) {
@@ -671,7 +669,7 @@ var PDFView = {
     var pages = this.pages = [];
     this.pageText = [];
     this.startedTextExtraction = false;
-    var pagesRefMap = {};
+
     var thumbnails = this.thumbnails = [];
     var pagePromises = [];
     for (var i = 1; i <= pagesCount; i++)
@@ -688,11 +686,7 @@ var PDFView = {
 
         pages.push(pageView);
         thumbnails.push(thumbnailView);
-        var pageRef = page.ref;
-        pagesRefMap[pageRef.num + ' ' + pageRef.gen + ' R'] = i;
       }
-
-      self.pagesRefMap = pagesRefMap;
     });
 
     var destinationsPromise = pdfDocument.getDestinations();


### PR DESCRIPTION
It shall cut some initial downloading time. We still scanning all pages at random file locations. If we adjust our viewer to request only few pages initially, our initial download time will be even less.

Use `#disableRange=true` to disable the feature. I was surprised to find lots of servers on the web that supports range requests.
