### PR TITLE
Workaround Opera background style in <select> element.

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -534,7 +534,7 @@ html[dir='rtl'] .dropdownToolbarButton {
   margin:0;
   padding:0;
   border:none;
-  background: transparent;
+  background: rgba(0,0,0,0); /* Opera does not support 'transparent' <select> background */
 }
 
 .dropdownToolbarButton > select > option {


### PR DESCRIPTION
Apparently Opera doesn't support 'transparent' style in <select> background, but rgba(0,0,0,0) works instead so I made the change.

Fixes #1937
