### PR TITLE
Add B2G build and new preprocessor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ You can also view all the test pdf files on the right side serving
 
 + http://localhost:8888/test/pdfs/?frame
 
-### Building pdf.js
+### Building pdf.js.
 
-In order to bundle all `src/` files into a final `pdf.js`, issue:
+In order to bundle all `src/` files into a final `pdf.js` and build the generic viewer, issue:
 
-    $ node make bundle
+    $ node make generic
 
-This will generate the file `build/pdf.js` that can be included in your final project. (WARNING: That's a large file! Consider minifying it).
+This will generate the file `build/generic/build/pdf.js` that can be included in your final project. The pdf.js file is large and should be minified for production. Also, if you would like to support more browsers than firefox you'll also need to include `compatibility.js` from `build/generic/web/`.
 
 
 # Learning

--- a/external/builder/builder.js
+++ b/external/builder/builder.js
@@ -1,0 +1,142 @@
+require('../shelljs/make');
+var fs = require('fs'),
+    path = require('path'),
+    vm = require('vm');
+
+/**
+ * A simple preprocessor that is based on the firefox preprocessor
+ * see (https://developer.mozilla.org/en/Build/Text_Preprocessor).  The main
+ * difference is that this supports a subset of the commands and it supports
+ * preproccesor commands in html style comments.
+ * Currently Supported commands:
+ * - if
+ * - else
+ * - endif
+ * - include
+ * - expand
+ */
+function preprocess(inFilename, outFilename, defines) {
+  // TODO make this really read line by line.
+  var lines = fs.readFileSync(inFilename).toString().split('\n');
+  var totalLines = lines.length;
+  var out = '';
+  var i = 0;
+  function readLine() {
+    if (i < totalLines) {
+      return lines[i++];
+    }
+    return null;
+  }
+  var writeLine = typeof outFilename === 'function' ? outFilename : function(line) {
+    out += line + '\n';
+  }
+  function include(file) {
+    var realPath = fs.realpathSync(inFilename);
+    var dir = path.dirname(realPath);
+    preprocess(path.join(dir, file), writeLine, defines);
+  }
+  function expand(line) {
+    line = line.replace(/__[\w]+__/g, function(variable) {
+      variable = variable.substring(2, variable.length - 2);
+      if (variable in defines) {
+        return defines[variable];
+      }
+      return '';
+    });
+    writeLine(line);
+  }
+
+  var s, state = 0, stack = [];
+  var control = /^(?:\/\/|<!--)\s*#(if|else|endif|expand|include)(?:\s+(.*?)(?:-->)?$)?/;
+  var lineNumber = 0;
+  while ((s = readLine()) !== null) {
+    ++lineNumber;
+    var m = control.exec(s);
+    if (m) {
+      switch (m[1]) {
+        case 'if':
+          stack.push(state);
+          try {
+            state = vm.runInNewContext(m[2], defines) ? 3 : 1;
+          } catch (e) {
+            console.error('Could not evalute line \'' + m[2] + '\' at ' +
+                          fs.realpathSync(inFilename) + ':' + lineNumber);
+            throw e;
+          }
+          break;
+        case 'else':
+          state = state === 1 ? 3 : 2;
+          break;
+        case 'endif':
+          state = stack.pop();
+          break;
+        case 'expand':
+          if (state === 0 || state === 3)
+            expand(m[2]);
+          break;
+        case 'include':
+          if (state === 0 || state === 3)
+            include(m[2]);
+          break;
+      }
+    } else {
+      if (state === 0) {
+        writeLine(s);
+      } else if(state === 3) {
+        writeLine(s.replace(/^\/\/|^<!--|-->/g, "  "));
+      }
+    }
+  }
+  if (state !== 0 || stack.length !== 0)
+    throw new Error('Missing endif in preprocessor.');
+  if (typeof outFilename !== 'function')
+    fs.writeFileSync(outFilename, out);
+}
+exports.preprocess = preprocess;
+
+/**
+ * Simplifies common build steps.
+ * @param setup
+ *        .defines defines for preprocessors
+ *        .copy array of arrays of source and destination pairs of files to copy
+ *        .preprocess array of arrays of source and destination pairs of files
+ *                    run through preprocessor
+ */
+function build(setup) {
+  var defines = setup.defines;
+
+  setup.copy.forEach(function(option) {
+    var source = option[0];
+    var destination = option[1];
+    cp('-R', source, destination);
+  });
+
+  setup.preprocess.forEach(function(option) {
+    var sources = option[0];
+    var destination = option[1];
+
+    sources = ls('-R', sources);
+    sources.forEach(function(source) {
+      // ??? Warn if the source is wildcard and dest is file?
+      var destWithFolder = destination;
+      if (test('-d', destination))
+        destWithFolder += '/' + path.basename(source);
+      preprocess(source, destWithFolder, defines);
+    });
+  });
+}
+exports.build = build;
+
+/**
+ * Merge two defines arrays. Values in the second param will override values in
+ * the first.
+ */
+function merge(defaults, defines) {
+  var ret = {};
+  for (var key in defaults)
+    ret[key] = defaults[key];
+  for (key in defines)
+    ret[key] = defines[key];
+  return ret;
+}
+exports.merge = merge;

--- a/make.js
+++ b/make.js
@@ -178,7 +178,7 @@ target.all = function() {
 //
 
 // Files that need to be included in every build.
-var COMMON_WEB_FILES = 
+var COMMON_WEB_FILES =
       ['web/viewer.css',
        'web/images',
        'web/debugger.js'],

--- a/src/api.js
+++ b/src/api.js
@@ -430,19 +430,18 @@ var WorkerTransport = (function WorkerTransportClosure() {
 
       try {
         var worker;
-        if (PDFJS.isFirefoxExtension) {
-          // The firefox extension can't load the worker from the resource://
-          // url so we have to inline the script and then use the blob loader.
-          var bb = new MozBlobBuilder();
-          bb.append(document.querySelector('#PDFJS_SCRIPT_TAG').textContent);
-          var blobUrl = window.URL.createObjectURL(bb.getBlob());
-          worker = new Worker(blobUrl);
-        } else {
-          // Some versions of FF can't create a worker on localhost, see:
-          // https://bugzilla.mozilla.org/show_bug.cgi?id=683280
-          worker = new Worker(workerSrc);
-        }
-
+//#if !(FIREFOX || MOZCENTRAL)
+        // Some versions of FF can't create a worker on localhost, see:
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=683280
+        worker = new Worker(workerSrc);
+//#else
+//      // The firefox extension can't load the worker from the resource://
+//      // url so we have to inline the script and then use the blob loader.
+//      var bb = new MozBlobBuilder();
+//      bb.append(document.querySelector('#PDFJS_SCRIPT_TAG').textContent);
+//      var blobUrl = window.URL.createObjectURL(bb.getBlob());
+//      worker = new Worker(blobUrl);
+//#endif
         var messageHandler = new MessageHandler('main', worker);
         this.messageHandler = messageHandler;
 

--- a/src/core.js
+++ b/src/core.js
@@ -29,9 +29,11 @@ function getPdf(arg, callback) {
   var params = arg;
   if (typeof arg === 'string')
     params = { url: arg };
-
+//#if !B2G
   var xhr = new XMLHttpRequest();
-
+//#else
+//var xhr = new XMLHttpRequest({mozSystem: true});
+//#endif
   xhr.open('GET', params.url);
 
   var headers = params.headers;

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -7,9 +7,13 @@ var PDFJS = {};
   // Use strict in our context only - users might not want it
   'use strict';
 
-  PDFJS.build = 'PDFJSSCRIPT_BUNDLE_VER';
+  PDFJS.build =
+//#if !BUNDLE_VERSION
+  'PDFJSSCRIPT_BUNDLE_VER';
+//#else
+//#expand '__BUNDLE_VERSION__';
+//#endif
 
-  // Files are inserted below - see Makefile
-  /* PDFJSSCRIPT_INCLUDE_ALL */
+//#expand __BUNDLE__
 
 }).call((typeof window === 'undefined') ? this : window);

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -1,0 +1,60 @@
+var FirefoxCom = (function FirefoxComClosure() {
+  return {
+    /**
+     * Creates an event that the extension is listening for and will
+     * synchronously respond to.
+     * NOTE: It is reccomended to use request() instead since one day we may not
+     * be able to synchronously reply.
+     * @param {String} action The action to trigger.
+     * @param {String} data Optional data to send.
+     * @return {*} The response.
+     */
+    requestSync: function(action, data) {
+      var request = document.createTextNode('');
+      request.setUserData('action', action, null);
+      request.setUserData('data', data, null);
+      request.setUserData('sync', true, null);
+      document.documentElement.appendChild(request);
+
+      var sender = document.createEvent('Events');
+      sender.initEvent('pdf.js.message', true, false);
+      request.dispatchEvent(sender);
+      var response = request.getUserData('response');
+      document.documentElement.removeChild(request);
+      return response;
+    },
+    /**
+     * Creates an event that the extension is listening for and will
+     * asynchronously respond by calling the callback.
+     * @param {String} action The action to trigger.
+     * @param {String} data Optional data to send.
+     * @param {Function} callback Optional response callback that will be called
+     * with one data argument.
+     */
+    request: function(action, data, callback) {
+      var request = document.createTextNode('');
+      request.setUserData('action', action, null);
+      request.setUserData('data', data, null);
+      request.setUserData('sync', false, null);
+      if (callback) {
+        request.setUserData('callback', callback, null);
+
+        document.addEventListener('pdf.js.response', function listener(event) {
+          var node = event.target,
+              callback = node.getUserData('callback'),
+              response = node.getUserData('response');
+
+          document.documentElement.removeChild(node);
+
+          document.removeEventListener('pdf.js.response', listener, false);
+          return callback(response);
+        }, false);
+      }
+      document.documentElement.appendChild(request);
+
+      var sender = document.createEvent('HTMLEvents');
+      sender.initEvent('pdf.js.message', true, false);
+      return request.dispatchEvent(sender);
+    }
+  };
+})();

--- a/web/viewer-snippet-b2g.html
+++ b/web/viewer-snippet-b2g.html
@@ -1,0 +1,9 @@
+<!-- This snippet is used in b2g, see Makefile -->
+<link rel="resource" type="application/l10n" href="locale.properties"/>
+<script type="text/javascript" src="l10n.js"></script>
+<script type="text/javascript" src="../build/pdf.js"></script>
+<script type="text/javascript">
+  // This specifies the location of the pdf.js file.
+  PDFJS.workerSrc = "../build/pdf.js";
+  PDFJS.disableTextLayer = true;
+</script>

--- a/web/viewer-snippet-firefox-extension.html
+++ b/web/viewer-snippet-firefox-extension.html
@@ -1,14 +1,11 @@
 <!-- This snippet is used in firefox extension, see Makefile -->
 <base href="resource://pdf.js/web/" />
-<script type="application/l10n">
-<!-- PDFJSSCRIPT_LOCALE_DATA -->
-</script>
 <script type="text/javascript" src="l10n.js"></script>
 <script type="text/javascript" id="PDFJS_SCRIPT_TAG">
 <!--
 // pdf.js is inlined here because resource:// urls won't work
 // for loading workers.
-/* PDFJSSCRIPT_INCLUDE_BUNDLE */
+//#include ../build/pdf.js
 -->
 </script>
 <script type="text/javascript">

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -4,41 +4,60 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <title>PDF.js viewer</title>
-    <!-- PDFJSSCRIPT_INCLUDE_FIREFOX_EXTENSION -->
+
+<!--#if FIREFOX-->
+<!--#include viewer-snippet-firefox-extension.html-->
+<!--#endif-->
 
     <link rel="stylesheet" href="viewer.css"/>
-    <link rel="resource" type="application/l10n" href="locale.properties"/><!-- PDFJSSCRIPT_REMOVE_CORE -->
+<!--#if !PRODUCTION-->
+    <link rel="resource" type="application/l10n" href="locale.properties"/>
+<!--#endif-->
 
-    <script type="text/javascript" src="compatibility.js"></script> <!-- PDFJSSCRIPT_REMOVE_FIREFOX_EXTENSION -->
-    <script type="text/javascript" src="../external/webL10n/l10n.js"></script><!-- PDFJSSCRIPT_REMOVE_CORE -->
+<!--#if !FIREFOX -->
+    <script type="text/javascript" src="compatibility.js"></script>
+<!--#endif-->
 
-    <!-- PDFJSSCRIPT_INCLUDE_BUILD -->
-    <script type="text/javascript" src="../src/core.js"></script> <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/util.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/api.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/metadata.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/canvas.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/obj.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/function.js"></script> <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/charsets.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/cidmaps.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/colorspace.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/crypto.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/evaluator.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/fonts.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/glyphlist.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/image.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/metrics.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/parser.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/pattern.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/stream.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/worker.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../external/jpgjs/jpg.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/jpx.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/jbig2.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript" src="../src/bidi.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <script type="text/javascript">PDFJS.workerSrc = '../src/worker_loader.js';</script> <!-- PDFJSSCRIPT_REMOVE_CORE -->
-    <!-- PDFJSSCRIPT_INCLUDE_B2G -->
+<!--#if !PRODUCTION-->
+    <script type="text/javascript" src="../external/webL10n/l10n.js"></script>
+<!--#endif-->
+
+<!--#if !PRODUCTION-->
+    <script type="text/javascript" src="../src/core.js"></script>
+    <script type="text/javascript" src="../src/util.js"></script>
+    <script type="text/javascript" src="../src/api.js"></script>
+    <script type="text/javascript" src="../src/metadata.js"></script>
+    <script type="text/javascript" src="../src/canvas.js"></script>
+    <script type="text/javascript" src="../src/obj.js"></script>
+    <script type="text/javascript" src="../src/function.js"></script>
+    <script type="text/javascript" src="../src/charsets.js"></script>
+    <script type="text/javascript" src="../src/cidmaps.js"></script>
+    <script type="text/javascript" src="../src/colorspace.js"></script>
+    <script type="text/javascript" src="../src/crypto.js"></script>
+    <script type="text/javascript" src="../src/evaluator.js"></script>
+    <script type="text/javascript" src="../src/fonts.js"></script>
+    <script type="text/javascript" src="../src/glyphlist.js"></script>
+    <script type="text/javascript" src="../src/image.js"></script>
+    <script type="text/javascript" src="../src/metrics.js"></script>
+    <script type="text/javascript" src="../src/parser.js"></script>
+    <script type="text/javascript" src="../src/pattern.js"></script>
+    <script type="text/javascript" src="../src/stream.js"></script>
+    <script type="text/javascript" src="../src/worker.js"></script>
+    <script type="text/javascript" src="../external/jpgjs/jpg.js"></script>
+    <script type="text/javascript" src="../src/jpx.js"></script>
+    <script type="text/javascript" src="../src/jbig2.js"></script>
+    <script type="text/javascript" src="../src/bidi.js"></script>
+    <script type="text/javascript">PDFJS.workerSrc = '../src/worker_loader.js';</script>
+<!--#endif-->
+
+<!--#if GENERIC || CHROME-->
+<!--#include viewer-snippet.html-->
+<!--#endif-->
+
+<!--#if B2G-->
+<!--#include viewer-snippet-b2g.html-->
+<!--#endif-->
+
     <script type="text/javascript" src="debugger.js"></script>
     <script type="text/javascript" src="viewer.js"></script>
   </head>

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <title>PDF.js viewer</title>
 
-<!--#if FIREFOX-->
+<!--#if FIREFOX || MOZCENTRAL-->
 <!--#include viewer-snippet-firefox-extension.html-->
 <!--#endif-->
 
@@ -14,7 +14,7 @@
     <link rel="resource" type="application/l10n" href="locale.properties"/>
 <!--#endif-->
 
-<!--#if !FIREFOX -->
+<!--#if !(FIREFOX || MOZCENTRAL)-->
     <script type="text/javascript" src="compatibility.js"></script>
 <!--#endif-->
 

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -38,6 +38,7 @@
     <script type="text/javascript" src="../src/jbig2.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
     <script type="text/javascript" src="../src/bidi.js"></script>  <!-- PDFJSSCRIPT_REMOVE_CORE -->
     <script type="text/javascript">PDFJS.workerSrc = '../src/worker_loader.js';</script> <!-- PDFJSSCRIPT_REMOVE_CORE -->
+    <!-- PDFJSSCRIPT_INCLUDE_B2G -->
     <script type="text/javascript" src="debugger.js"></script>
     <script type="text/javascript" src="viewer.js"></script>
   </head>

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1880,8 +1880,9 @@ window.addEventListener('load', function webViewerLoad(evt) {
       PDFView.sidebarOpen = outerContainer.classList.contains('sidebarOpen');
       PDFView.renderHighestPriority();
     });
-
+//#if !B2G
   PDFView.open(file, 0);
+//#endif
 }, true);
 
 function updateViewarea() {
@@ -2140,3 +2141,21 @@ window.addEventListener('afterprint', function afterPrint(evt) {
   window.addEventListener('mozfullscreenchange', fullscreenChange, false);
   window.addEventListener('webkitfullscreenchange', fullscreenChange, false);
 })();
+
+//#if B2G
+// window.navigator.mozSetMessageHandler('activity', function(activity) {
+//   var url = activity.source.data.url;
+//   // Temporarily get the data here since the cross domain xhr is broken in
+//   // the worker currently, see bug 761227.
+//   var params = {
+//     url: url,
+//     error: function(e) {
+//       PDFView.error(mozL10n.get('loading_error', null,
+//                     'An error occurred while loading the PDF.'), e);
+//     }
+//   };
+//   PDFJS.getPdf(params, function successCallback(data) {
+//     PDFView.open(data, 0);
+//   });
+// });
+//#endif

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -91,66 +91,7 @@ var ProgressBar = (function ProgressBarClosure() {
 })();
 
 //#if FIREFOX || MOZCENTRAL
-var FirefoxCom = (function FirefoxComClosure() {
-  return {
-    /**
-     * Creates an event that the extension is listening for and will
-     * synchronously respond to.
-     * NOTE: It is reccomended to use request() instead since one day we may not
-     * be able to synchronously reply.
-     * @param {String} action The action to trigger.
-     * @param {String} data Optional data to send.
-     * @return {*} The response.
-     */
-    requestSync: function(action, data) {
-      var request = document.createTextNode('');
-      request.setUserData('action', action, null);
-      request.setUserData('data', data, null);
-      request.setUserData('sync', true, null);
-      document.documentElement.appendChild(request);
-
-      var sender = document.createEvent('Events');
-      sender.initEvent('pdf.js.message', true, false);
-      request.dispatchEvent(sender);
-      var response = request.getUserData('response');
-      document.documentElement.removeChild(request);
-      return response;
-    },
-    /**
-     * Creates an event that the extension is listening for and will
-     * asynchronously respond by calling the callback.
-     * @param {String} action The action to trigger.
-     * @param {String} data Optional data to send.
-     * @param {Function} callback Optional response callback that will be called
-     * with one data argument.
-     */
-    request: function(action, data, callback) {
-      var request = document.createTextNode('');
-      request.setUserData('action', action, null);
-      request.setUserData('data', data, null);
-      request.setUserData('sync', false, null);
-      if (callback) {
-        request.setUserData('callback', callback, null);
-
-        document.addEventListener('pdf.js.response', function listener(event) {
-          var node = event.target,
-              callback = node.getUserData('callback'),
-              response = node.getUserData('response');
-
-          document.documentElement.removeChild(node);
-
-          document.removeEventListener('pdf.js.response', listener, false);
-          return callback(response);
-        }, false);
-      }
-      document.documentElement.appendChild(request);
-
-      var sender = document.createEvent('HTMLEvents');
-      sender.initEvent('pdf.js.message', true, false);
-      return request.dispatchEvent(sender);
-    }
-  };
-})();
+//#include firefoxcom.js
 //#endif
 
 // Settings Manager - This is a utility for saving settings


### PR DESCRIPTION
Since we're adding another target that I believe will require more customization in the future and I think our strategy of just using SED was getting too messy, I've added a new preprocessor which tries to follow the ff preprocessor(https://developer.mozilla.org/en/Build/Text_Preprocessor).  I also added another little build helper function to help with common steps we were taking in the main build targets(firefox,chrome,mozcentral,b2g,web).  We could probably simplify things even further if we added an initial layout step to this, but the PR was already getting too big so I'll wait to do that.

Also, I added a new build target `generic` which builds the generic production version of pdf.js.  This is basically the contents of our old `web` build target.  I mainly did this because now the file `build/pdf.js` is not preprocessed since it needs to be preprocessed differently by each main build target.

For testing, I built all the targets and compared them to the current build output.  Everything still needs verification though.
