### PR TITLE
Extension specific fullscreen requesting

### DIFF
--- a/extensions/firefox/components/PdfStreamConverter.js
+++ b/extensions/firefox/components/PdfStreamConverter.js
@@ -248,6 +248,24 @@ ChromeActions.prototype = {
       if (!sentResponse)
         sendResponse(false);
     });
+  },
+
+  fullscreen: function(element) {
+    var domWin = this.domWindow,
+        url = this.domWindow.document.location.toString();
+
+    // Add permission so there's no need to ask the user
+    Services.perms.add(Services.io.newURI(url, null, null), 'fullscreen',
+      Services.perms.ALLOW_ACTION, Services.perms.EXPIRE_SESSION);
+
+    element.mozRequestFullScreen();
+
+    // Remove the permission again, when there isn't any use for it
+    domWin.addEventListener('mozfullscreenchange', function() {
+      if(!domWin.document.mozFullScreen) {
+        Services.perms.remove(domWin.document.location.host, 'fullscreen');
+      }
+    }, false);
   }
 };
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1109,14 +1109,20 @@ var PDFView = {
     }
 
     var wrapper = document.getElementById('viewerContainer');
-    if (document.documentElement.requestFullScreen) {
-      wrapper.requestFullScreen();
-    } else if (document.documentElement.mozRequestFullScreen) {
-      wrapper.mozRequestFullScreen();
-    } else if (document.documentElement.webkitRequestFullScreen) {
-      wrapper.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);
+    if (PDFJS.isFirefoxExtension) {
+      // Extension specific method provided to let the users
+      // be let of granting fullscreen privileges to every site they visit
+      FirefoxCom.requestSync('fullscreen', wrapper);
     } else {
-      return false;
+      if (document.documentElement.requestFullScreen) {
+        wrapper.requestFullScreen();
+      } else if (document.documentElement.mozRequestFullScreen) {
+        wrapper.mozRequestFullScreen();
+      } else if (document.documentElement.webkitRequestFullScreen) {
+        wrapper.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);
+      } else {
+        return false;
+      }
     }
 
     this.isFullscreen = true;


### PR DESCRIPTION
This PR changes the Firefox extension to use some Chrome Privileged code to let the user be let of granting access to each of the documents' host when watching them fullscreen.

Solves #1951

PS: I'm not particularly fond of the way this is being done:
- First the viewer requests the chrome code.
- chrome code, grants fullscreen access to the host
- chrome code makes the view fullscreen
- When the user exits fullscreen, the chrome code removes the granted access.

If there's any better solution I'll be glad to accept it.
