### PR TITLE
Using fast pixels copy in putBinaryImageData

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -1279,7 +1279,8 @@ function checkPutBinaryImageDataCompatibility() {
   } catch (e) {
     CanvasGraphics.prototype.putBinaryImageData =
       function CanvasGraphicsPutBinaryImageDataShim(ctx, imgData, w, h) {
-        var tmpImgData = ctx.getImageData(0, 0, w, h);
+        var tmpImgData = 'createImageData' in ctx ? ctx.createImageData(w, h) :
+          ctx.getImageData(0, 0, w, h);
 
         var tmpImgDataPixels = tmpImgData.data;
         var data = imgData.data;

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -1281,12 +1281,14 @@ function checkPutBinaryImageDataCompatibility() {
       function CanvasGraphicsPutBinaryImageDataShim(ctx, imgData, w, h) {
         var tmpImgData = ctx.getImageData(0, 0, w, h);
 
-        // Copy over the imageData pixel by pixel.
         var tmpImgDataPixels = tmpImgData.data;
-        var len = tmpImgDataPixels.length;
-
-        while (len--) {
-          tmpImgDataPixels[len] = imgData.data[len];
+        var data = imgData.data;
+        if ('set' in tmpImgDataPixels)
+          tmpImgDataPixels.set(data);
+        else {
+          // Copy over the imageData pixel by pixel.
+          for (var i = 0, ii = tmpImgDataPixels.length; i < ii; i++)
+            tmpImgDataPixels[i] = data[i];
         }
 
         ctx.putImageData(tmpImgData, 0, 0);


### PR DESCRIPTION
Attempt to resolve #1970: some browsers are using typed array as data in the ImageData, so the set() method is available. (Also, fixes not copy of the first pixel red data at index 0).
