### PR TITLE
Changing cubic spline interpolation error to TODO

### DIFF
--- a/src/function.js
+++ b/src/function.js
@@ -103,11 +103,12 @@ var PDFFunction = (function PDFFunctionClosure() {
 
       var size = dict.get('Size');
       var bps = dict.get('BitsPerSample');
-      var order = dict.get('Order');
-      if (!order)
-        order = 1;
-      if (order !== 1)
-        error('No support for cubic spline interpolation: ' + order);
+      var order = dict.get('Order') || 1;
+      if (order !== 1) {
+        // No description how cubic spline interpolation works in PDF32000:2008
+        // As in poppler, ignoring order, linear interpolation may work as good
+        TODO('No support for cubic spline interpolation: ' + order);
+      }
 
       var encode = dict.get('Encode');
       if (!encode) {


### PR DESCRIPTION
Following up on issue #1152.

Reading the PDF32000 spec it's not really clear how the cubic spline interpolation is used/applied. By reading a multiple articles onthe subject, there are multiple ways to perform the interpolation when some coefficients must be calculated (e.g. derivatives from the sampled values), and there are minimal knowledge about spatial interpolation.

As I understand, the poppler decided to ignore the order and use only linear interpolation: http://cgit.freedesktop.org/poppler/poppler/tree/poppler/Function.cc#n213 . This fix will do the same.

Let's close #1591, #1771, #1806 and #1848, and keep #1152 opened with the '2-image-quality' tag.
