### PR TITLE
Show a loading message instead of a progress bar on browsers without onprogress support.

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -178,6 +178,19 @@
           <div id="loading"></div>
           <div id="loadingBar"><div class="progress"></div></div>
         </div>
+        
+        <script>
+          var byeprogress = new XMLHttpRequest();
+          if (byeprogress.onprogress === undefined)
+          {
+            document.getElementById('loadingBox').innerHTML += '<span style="color: #EEEEEE; font-size: 11px;">Loading file...</span>';
+          }
+          else
+          {
+            document.getElementById('loadingBar').style.display = 'inline-block';
+            document.getElementById('loadingBar').style.visibility = 'visible';
+          }
+        </script>
 
         <div id="errorWrapper" hidden='true'>
           <div id="errorMessageLeft">


### PR DESCRIPTION
Show a "Loading file..." message instead of a progress bar on browsers without support for the progress event (XMLHttpRequest Level 2), such as IE9.

I'd say this is implementation is not as clean as you want (poor separation of concerns at least), but still makes it easy to understand the hack. Please tidy it up as you want, or give me some guideline to do it by myself. Thank you.
