### PR TITLE
Add carriage return checks to make.js.

### DIFF
--- a/external/crlfchecker/crlfchecker.js
+++ b/external/crlfchecker/crlfchecker.js
@@ -1,0 +1,25 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+
+function checkIfCrlfIsPresent(files) {
+  var failed = [];
+
+  (ls(files)).forEach(function checkCrlf(file) {
+    if ((cat(file)).match(/.*\r.*/)) {
+      failed.push(file);
+    }
+  });
+
+  if (failed.length) {
+    var errorMessage =
+      'Please remove carriage return\'s from\n' + failed.join('\n') + '\n' +
+      'Also check your setting for: git config core.autocrlf.';
+
+    echo();
+    echo(errorMessage);
+    exit(1);
+  }
+}
+
+exports.checkIfCrlfIsPresent = checkIfCrlfIsPresent;
+

--- a/make.js
+++ b/make.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 require('./external/shelljs/make');
 var builder = require('./external/builder/builder.js');
+var crlfchecker = require('./external/crlfchecker/crlfchecker.js');
 
 var ROOT_DIR = __dirname + '/', // absolute path to project's root
     BUILD_DIR = 'build/',
@@ -26,32 +27,6 @@ var DEFINES = {
   B2G: false,
   CHROME: false
 };
-
-//
-// Helper functions
-//
-function checkIfCarriageReturnsArePresent(string, throwOnError) {
-  if (string.match(/.*\r.*/)) {
-    var errorMessage =
-      'Carriage Return\'s should not be present. Please remove them.\n' +
-      'Also check your setting for: git config core.autocrlf.';
-
-    if (throwOnError) {
-      throw(errorMessage);
-    } else {
-      echo();
-      echo(errorMessage);
-    }
-  }
-}
-
-function throwIfCarriageReturnsArePresent(string) {
-  checkIfCarriageReturnsArePresent(string, true);
-}
-
-function warnIfCarriageReturnsArePresent(string) {
-  checkIfCarriageReturnsArePresent(string, false);
-}
 
 //
 // make all
@@ -245,7 +220,7 @@ target.bundle = function() {
         {silent: true}).output.replace('\n', '');
 
   // Handle only src/*.js for now.
-  throwIfCarriageReturnsArePresent(cat('*.js'));
+  crlfchecker.checkIfCrlfIsPresent(['*.js']);
 
   // This just preprocesses the empty pdf.js file, we don't actually want to
   // preprocess everything yet since other build targets use this file.
@@ -711,7 +686,7 @@ target.lint = function() {
   exec('gjslint --nojsdoc ' + LINT_FILES.join(' '));
 
   // Handle only src/*.js for now.
-  warnIfCarriageReturnsArePresent(cat('src/*.js'));
+  crlfchecker.checkIfCrlfIsPresent(['src/*.js']);
 };
 
 //

--- a/make.js
+++ b/make.js
@@ -219,8 +219,7 @@ target.bundle = function() {
       bundleVersion = exec('git log --format="%h" -n 1',
         {silent: true}).output.replace('\n', '');
 
-  // Handle only src/*.js for now.
-  crlfchecker.checkIfCrlfIsPresent(['*.js']);
+  crlfchecker.checkIfCrlfIsPresent(SRC_FILES);
 
   // This just preprocesses the empty pdf.js file, we don't actually want to
   // preprocess everything yet since other build targets use this file.
@@ -685,8 +684,7 @@ target.lint = function() {
 
   exec('gjslint --nojsdoc ' + LINT_FILES.join(' '));
 
-  // Handle only src/*.js for now.
-  crlfchecker.checkIfCrlfIsPresent(['src/*.js']);
+  crlfchecker.checkIfCrlfIsPresent(LINT_FILES);
 };
 
 //

--- a/make.js
+++ b/make.js
@@ -30,11 +30,27 @@ var DEFINES = {
 //
 // Helper functions
 //
-function throwIfCarriageReturnIsPresent(string) {
+function checkIfCarriageReturnsArePresent(string, throwOnError) {
   if (string.match(/.*\r.*/)) {
-    throw('Carriage Return\'s should not be present. Please remove them.\n' +
-          'Also check your setting for: git config core.autocrlf');
+    var errorMessage =
+      'Carriage Return\'s should not be present. Please remove them.\n' +
+      'Also check your setting for: git config core.autocrlf.';
+
+    if (throwOnError) {
+      throw(errorMessage);
+    } else {
+      echo();
+      echo(errorMessage);
+    }
   }
+}
+
+function throwIfCarriageReturnsArePresent(string) {
+  checkIfCarriageReturnsArePresent(string, true);
+}
+
+function warnIfCarriageReturnsArePresent(string) {
+  checkIfCarriageReturnsArePresent(string, false);
 }
 
 //
@@ -229,7 +245,7 @@ target.bundle = function() {
         {silent: true}).output.replace('\n', '');
 
   // Handle only src/*.js for now.
-  throwIfCarriageReturnIsPresent(cat('*.js'));
+  throwIfCarriageReturnsArePresent(cat('*.js'));
 
   // This just preprocesses the empty pdf.js file, we don't actually want to
   // preprocess everything yet since other build targets use this file.
@@ -692,10 +708,10 @@ target.lint = function() {
                     'extensions/firefox/components/*.js',
                     'extensions/chrome/*.js'];
 
-  // Handle only src/*.js for now.
-  throwIfCarriageReturnIsPresent(cat('src/*.js'));
-
   exec('gjslint --nojsdoc ' + LINT_FILES.join(' '));
+
+  // Handle only src/*.js for now.
+  warnIfCarriageReturnsArePresent(cat('src/*.js'));
 };
 
 //

--- a/make.js
+++ b/make.js
@@ -28,6 +28,16 @@ var DEFINES = {
 };
 
 //
+// Helper functions
+//
+function throwIfCarriageReturnIsPresent(string) {
+  if (string.match(/.*\r.*/)) {
+    throw('Carriage Return\'s should not be present. Please remove them.\n' +
+          'Also check your setting for: git config core.autocrlf');
+  }
+}
+
+//
 // make all
 //
 target.all = function() {
@@ -217,6 +227,9 @@ target.bundle = function() {
   var bundle = cat(SRC_FILES),
       bundleVersion = exec('git log --format="%h" -n 1',
         {silent: true}).output.replace('\n', '');
+
+  // Handle only src/*.js for now.
+  throwIfCarriageReturnIsPresent(cat('*.js'));
 
   // This just preprocesses the empty pdf.js file, we don't actually want to
   // preprocess everything yet since other build targets use this file.
@@ -671,15 +684,18 @@ target.lint = function() {
   echo();
   echo('### Linting JS files (this can take a while!)');
 
-  var LINT_FILES = 'src/*.js \
-                    web/*.js \
-                    test/*.js \
-                    test/unit/*.js \
-                    extensions/firefox/*.js \
-                    extensions/firefox/components/*.js \
-                    extensions/chrome/*.js';
+  var LINT_FILES = ['src/*.js',
+                    'web/*.js',
+                    'test/*.js',
+                    'test/unit/*.js',
+                    'extensions/firefox/*.js',
+                    'extensions/firefox/components/*.js',
+                    'extensions/chrome/*.js'];
 
-  exec('gjslint --nojsdoc ' + LINT_FILES);
+  // Handle only src/*.js for now.
+  throwIfCarriageReturnIsPresent(cat('src/*.js'));
+
+  exec('gjslint --nojsdoc ' + LINT_FILES.join(' '));
 };
 
 //
@@ -692,3 +708,4 @@ target.clean = function() {
 
   rm('-rf', BUILD_DIR);
 };
+


### PR DESCRIPTION
The target.bundle and target.lint will throw if carriage return's are present
in the files that are being processed.

Currently only src/*.js files are checked.
#1991
