### PR TITLE
Adds stub of the PdfJs.jsm

### DIFF
--- a/extensions/firefox/content/PdfJs-stub.jsm
+++ b/extensions/firefox/content/PdfJs-stub.jsm
@@ -1,0 +1,7 @@
+// Don't remove this file. FF15+ expects PdfJs module to be present at resource://pdf.js/PdfJs.jsm
+// See https://mxr.mozilla.org/mozilla-central/source/browser/components/nsBrowserGlue.js
+var EXPORTED_SYMBOLS = ["PdfJs"];
+
+let PdfJs = {
+  init: function PdfJs_init() {}
+};

--- a/make.js
+++ b/make.js
@@ -339,6 +339,8 @@ target.firefox = function() {
   mkdir('-p', FIREFOX_BUILD_CONTENT_DIR + BUILD_DIR);
   mkdir('-p', FIREFOX_BUILD_CONTENT_DIR + '/web');
 
+  cp(FIREFOX_CONTENT_DIR + 'PdfJs-stub.jsm', FIREFOX_BUILD_CONTENT_DIR + 'PdfJs.jsm');
+
   // Copy extension files
   cd('extensions/firefox');
   cp('-R', FIREFOX_EXTENSION_FILES_TO_COPY, ROOT_DIR + FIREFOX_BUILD_DIR);


### PR DESCRIPTION
The firefox expects "resource://pdf.js/PdfJs.jsm" to be found. Otherwise `PdfJs.init();` fails at http://mxr.mozilla.org/mozilla-central/source/browser/components/nsBrowserGlue.js#344 and that stops "browser-ui-startup-complete" notification.

Fixes #2000 and #1838
