### PR TITLE
Adds textlayer debug modes

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1162,6 +1162,17 @@ canvas {
   font-size: 10px;
 }
 
+#viewer.textLayer-visible .textLayer > div,
+#viewer.textLayer-hover .textLayer > div:hover {
+  background-color: white;
+  color: black;
+}
+
+#viewer.textLayer-shadow .textLayer > div {
+  background-color: rgba(255,255,255, .6);
+  color: black;
+}
+
 @page {
   margin: 0;
 } 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1802,8 +1802,19 @@ window.addEventListener('load', function webViewerLoad(evt) {
   mozL10n.language.code = locale;
 //#endif
 
-  if ('disableTextLayer' in hashParams)
-    PDFJS.disableTextLayer = (hashParams['disableTextLayer'] === 'true');
+  if ('textLayer' in hashParams) {
+    switch (hashParams['textLayer']) {
+      case 'off':
+        PDFJS.disableTextLayer = true;
+        break;
+      case 'visible':
+      case 'shadow':
+      case 'hover':
+        var viewer = document.getElementById('viewer');
+        viewer.classList.add('textLayer-' + hashParams['textLayer']);
+        break;
+    }
+  }
 
 //#if !(FIREFOX || MOZCENTRAL)
   if ('pdfBug' in hashParams) {


### PR DESCRIPTION
(instead of `#disableTextLayer=true`) the following options can be used:
  `#textLayer=off` - turns of the textLayer;
  `#textLayer=visible` - makes text layer visible;
  `#textLayer=shadow` - makes text layer visible (original text semi-visible);
  `#textLayer=hover` - text layer portion/div visible on hover.
