### PR TITLE
Remove some bad code patterns

### DIFF
--- a/src/fonts.js
+++ b/src/fonts.js
@@ -4100,7 +4100,7 @@ Type1Font.prototype = {
     // charstring changes size - can't cache .length in loop
     for (var i = 0; i < charstring.length; i++) {
       var command = charstring[i];
-      if (command.charAt) {
+      if (typeof command === 'string') {
         var cmd = map[command];
         assert(cmd, 'Unknow command: ' + command);
 

--- a/src/stream.js
+++ b/src/stream.js
@@ -395,9 +395,9 @@ var FlateStream = (function FlateStreamClosure() {
     var codeBuf = this.codeBuf;
     var bytes = this.bytes;
     var bytesPos = this.bytesPos;
-  
+
     var b;
-    while (codeSize < maxLen) {    
+    while (codeSize < maxLen) {
       if (typeof (b = bytes[bytesPos++]) == 'undefined')
         error('Bad encoding in flate stream');
       codeBuf |= (b << codeSize);

--- a/src/stream.js
+++ b/src/stream.js
@@ -395,9 +395,9 @@ var FlateStream = (function FlateStreamClosure() {
     var codeBuf = this.codeBuf;
     var bytes = this.bytes;
     var bytesPos = this.bytesPos;
-
-    while (codeSize < maxLen) {
-      var b;
+  
+    var b;
+    while (codeSize < maxLen) {    
       if (typeof (b = bytes[bytesPos++]) == 'undefined')
         error('Bad encoding in flate stream');
       codeBuf |= (b << codeSize);


### PR DESCRIPTION
We started looking into this, because of v8s new Octane benchmark. These are two easy to fix performance faults in Firefox.
