### PR TITLE
Fallback to unescape() if decodeURIComponent fails, before giving up [Follow-up to #2031]

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -385,7 +385,12 @@ var PDFView = {
 
   setTitleUsingUrl: function pdfViewSetTitleUsingUrl(url) {
     this.url = url;
-    document.title = decodeURIComponent(getFileName(url)) || url;
+    try {
+      document.title = decodeURIComponent(getFileName(url)) || url;
+    } catch (Exception) {
+      console.log('WARNING: Unable to decode: ' + getFileName(url));
+      document.title = url;
+    }
   },
 
   open: function pdfViewOpen(url, scale, password) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -385,9 +385,9 @@ var PDFView = {
 
   setTitleUsingUrl: function pdfViewSetTitleUsingUrl(url) {
     this.url = url;
-    
+
     var filename = getFileName(url);
-    if(filename) {
+    if (filename) {
       try {
         document.title = decodeURIComponent(filename);
       } catch (e) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -385,11 +385,22 @@ var PDFView = {
 
   setTitleUsingUrl: function pdfViewSetTitleUsingUrl(url) {
     this.url = url;
-    try {
-      document.title = decodeURIComponent(getFileName(url)) || url;
-    } catch (e) {
-      // decodeURIComponent may throw URIError,
-      // fall back to using the unprocessed url in that case
+    
+    var filename = getFileName(url);
+    if(filename) {
+      try {
+        document.title = decodeURIComponent(filename);
+      } catch (e) {
+        // decodeURIComponent() may throw URIError, try unescape() first,
+        // before giving up completely
+        try {
+          document.title = unescape(filename);
+        } catch (e) {
+          // fall back to using the unprocessed url if nothing works
+          document.title = filename;
+        }
+      }
+    } else {
       document.title = url;
     }
   },

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -387,8 +387,9 @@ var PDFView = {
     this.url = url;
     try {
       document.title = decodeURIComponent(getFileName(url)) || url;
-    } catch (Exception) {
-      console.log('WARNING: Unable to decode: ' + getFileName(url));
+    } catch (e) {
+      // decodeURIComponent may throw URIError,
+      // fall back to using the unprocessed url in that case
       document.title = url;
     }
   },


### PR DESCRIPTION
Improves upon #2031, see title.
