### PR TITLE
Generates proxy Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ local.mk
 build/
 tags
 .DS_Store
+Makefile

--- a/make.js
+++ b/make.js
@@ -789,3 +789,13 @@ target.clean = function() {
   rm('-rf', BUILD_DIR);
 };
 
+//
+// make makefile
+//
+target.makefile = function() {
+  var makefileContent = 'help:\n\tnode make\n\n';
+  for (var i in target) {
+    makefileContent += i + ':\n\tnode make ' + i + '\n\n';
+  }
+  makefileContent.to('Makefile');
+};


### PR DESCRIPTION
`make <target>` cli commands can be used -- replaces removed ability to do `./make.js <target>`
