### PR TITLE
Implement page rotation controls using context menu.

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -50,6 +50,10 @@ thumb_page_title=Page {{page}}
 # number.
 thumb_page_canvas=Thumbnail of Page {{page}}
 
+# Context menu
+page_rotate_cw=Rotate Clockwise
+page_rotate_ccw=Rotate Counter-Clockwise
+
 # Search panel button title and messages
 search=Find
 search_terms_not_found=(Not found)

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -778,8 +778,6 @@ html[dir='rtl'] .toolbarButton.pageDown::before {
 .thumbnail {
   margin-bottom: 15px;
   float: left;
-  width: 114px;
-  height: 142px;
 }
 
 .thumbnail:not([data-loaded]) {

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -185,8 +185,15 @@ limitations under the License.
           </div>
         </div>
 
+        <menu type="context" id="viewerContextMenu">
+          <menuitem label="Rotate Counter-Clockwise" id="page_rotate_ccw"
+                    data-l10n-id="page_rotate_ccw" ></menuitem>
+          <menuitem label="Rotate Clockwise" id="page_rotate_cw"
+                    data-l10n-id="page_rotate_cw" ></menuitem>
+        </menu>
+
         <div id="viewerContainer">
-          <div id="viewer"></div>
+          <div id="viewer" contextmenu="viewerContextMenu"></div>
         </div>
 
         <div id="loadingBox">


### PR DESCRIPTION
Derives from #2038 (same code, compacted into one commit, excluding the toolbar changes).

Adds a context menu to the viewer with the rotation menuitems.

Fixes #2036.
