### PR TITLE
Fix sidebar display issue #2062

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1936,6 +1936,12 @@ document.addEventListener('DOMContentLoaded', function webViewerLoad(evt) {
       outerContainer.classList.toggle('sidebarOpen');
       PDFView.sidebarOpen = outerContainer.classList.contains('sidebarOpen');
       PDFView.renderHighestPriority();
+
+	  if (PDFView.sidebarOpen) {
+		document.getElementById('sidebarContainer').classList.remove('hidden');
+	  } else {
+		document.getElementById('sidebarContainer').classList.add('hidden');
+	  }
     });
 
 //#if (FIREFOX || MOZCENTRAL)


### PR DESCRIPTION
Fix sidebar display issue #2062, the issues is thumbnail / outline won't disappear after toggle the sidebar off. Only happen in Chrome / Safari.

[Test Steps]
1. Toggle the sidebar on in Chrome browser.
2. When the thumbnails has been rendered, toggle the sidebar off.
3. The thumbnails still exist there.
