### PR TITLE
Removes unnecessary ctx.mozCurrentTransformInverse transforms

### DIFF
--- a/src/pattern.js
+++ b/src/pattern.js
@@ -112,17 +112,6 @@ Shadings.RadialAxial = (function RadialAxialClosure() {
     return {
       type: 'Pattern',
       getPattern: function RadialAxial_getPattern(ctx) {
-        var curMatrix = ctx.mozCurrentTransform;
-        if (curMatrix) {
-          var userMatrix = ctx.mozCurrentTransformInverse;
-
-          p0 = Util.applyTransform(p0, curMatrix);
-          p0 = Util.applyTransform(p0, userMatrix);
-
-          p1 = Util.applyTransform(p1, curMatrix);
-          p1 = Util.applyTransform(p1, userMatrix);
-        }
-
         var grad;
         if (type == PatternType.AXIAL)
           grad = ctx.createLinearGradient(p0[0], p0[1], p1[0], p1[1]);
@@ -209,7 +198,6 @@ var TilingPattern = (function TilingPatternClosure() {
     TODO('TilingType');
 
     this.curMatrix = ctx.mozCurrentTransform;
-    this.invMatrix = ctx.mozCurrentTransformInverse;
     this.ctx = ctx;
     this.type = 'Pattern';
 


### PR DESCRIPTION
I don't think we need those
