### PR TITLE
Refresh the zoom settings after rotating the pages

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1201,9 +1201,7 @@ var PDFView = {
 
     var currentPage = this.pages[this.page - 1];
 
-    if (this.isFullscreen) {
-      this.parseScale('page-fit', true);
-    }
+    this.parseScale(this.currentScaleValue, true);
 
     this.renderHighestPriority();
 


### PR DESCRIPTION
Use the known current scale setting to refresh the pages, so that it works also for non-fullscreen viewing mode.
