### PR TITLE
Renaming export to exportData

### DIFF
--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -210,7 +210,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           }
 
           if (data instanceof Font)
-            data = data.export();
+            data = data.exportData();
 
           handler.send('obj', [
               loadedName,

--- a/src/fonts.js
+++ b/src/fonts.js
@@ -2040,7 +2040,7 @@ var Font = (function FontClosure() {
     mimetype: null,
     encoding: null,
 
-    export: function Font_export() {
+    exportData: function Font_exportData() {
       var data = {};
       for (var i in this) {
         if (this.hasOwnProperty(i))


### PR DESCRIPTION
Some browsers don't like export as a property name, e.g. android browser on ICS. 

logcat:

```
E/browser ( 2977): Console: Uncaught SyntaxError: Unexpected strict mode reserved word http://mozilla.github.com/pdf.js/build/pdf.js:16106
E/browser ( 2977): Console: Uncaught ReferenceError: PDFJS is not defined http://mozilla.github.com/pdf.js/web/viewer.js:38
```

Renaming to exportData
