### PR TITLE
Fullscreen updates to viewer.js for latest (unprefixed) spec.

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -383,7 +383,7 @@ var PDFView = {
 
   get supportsFullscreen() {
     var doc = document.documentElement;
-    var support = doc.requestFullScreen || doc.mozRequestFullScreen ||
+    var support = doc.requestFullscreen || doc.mozRequestFullScreen ||
                   doc.webkitRequestFullScreen;
     Object.defineProperty(this, 'supportsFullScreen', { value: support,
                                                         enumerable: true,
@@ -1155,16 +1155,16 @@ var PDFView = {
   },
 
   fullscreen: function pdfViewFullscreen() {
-    var isFullscreen = document.fullscreen || document.mozFullScreen ||
-        document.webkitIsFullScreen;
+    var isFullscreen = document.fullscreenElement && document.fullscreenElement !== null || 
+        document.mozFullScreen || document.webkitIsFullScreen;
 
     if (isFullscreen) {
       return false;
     }
 
     var wrapper = document.getElementById('viewerContainer');
-    if (document.documentElement.requestFullScreen) {
-      wrapper.requestFullScreen();
+    if (document.documentElement.requestFullscreen) {
+      wrapper.requestFullscreen();
     } else if (document.documentElement.mozRequestFullScreen) {
       wrapper.mozRequestFullScreen();
     } else if (document.documentElement.webkitRequestFullScreen) {
@@ -2368,8 +2368,8 @@ window.addEventListener('afterprint', function afterPrint(evt) {
 
 (function fullscreenClosure() {
   function fullscreenChange(e) {
-    var isFullscreen = document.fullscreen || document.mozFullScreen ||
-        document.webkitIsFullScreen;
+    var isFullscreen = document.fullscreenElement && document.fullscreenElement !== null || 
+        document.mozFullScreen || document.webkitIsFullScreen;
 
     if (!isFullscreen) {
       PDFView.exitFullscreen();

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1155,8 +1155,8 @@ var PDFView = {
   },
 
   fullscreen: function pdfViewFullscreen() {
-    var isFullscreen = document.fullscreenElement && document.fullscreenElement !== null || 
-        document.mozFullScreen || document.webkitIsFullScreen;
+    var isFullscreen = document.fullscreenElement || document.mozFullScreen ||
+    document.webkitIsFullScreen;
 
     if (isFullscreen) {
       return false;
@@ -2368,8 +2368,8 @@ window.addEventListener('afterprint', function afterPrint(evt) {
 
 (function fullscreenClosure() {
   function fullscreenChange(e) {
-    var isFullscreen = document.fullscreenElement && document.fullscreenElement !== null || 
-        document.mozFullScreen || document.webkitIsFullScreen;
+    var isFullscreen = document.fullscreenElement || document.mozFullScreen ||
+    document.webkitIsFullScreen;
 
     if (!isFullscreen) {
       PDFView.exitFullscreen();


### PR DESCRIPTION
Fixes the camelCase error in requestFullscreen (`requestFullScreen` -> `requestFullscreen`). Replaces `document.fullscreen` with a check for a non-null `document.fullscreenElement`.

This allows the fullscreen button to work in Opera Next (what will be Opera 12.10), which implements a newer version of the spec sans prefix.
