### PR TITLE
Tune whitespace insertion

### DIFF
--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -510,6 +510,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     getTextContent: function partialEvaluatorGetIRQueue(
                                                     stream, resources, state) {
       var bidiTexts;
+      var kSpaceFactor = 0.35;
+      var kMultipleSpaceFactor = 1.5;
 
       if (!state) {
         bidiTexts = [];
@@ -552,12 +554,12 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
                   chunk += fontCharsToUnicode(items[j], font);
                 } else if (items[j] < 0 && font.spaceWidth > 0) {
                   var fakeSpaces = -items[j] / font.spaceWidth;
-                  if (fakeSpaces > 1.5) {
+                  if (fakeSpaces > kMultipleSpaceFactor) {
                     fakeSpaces = Math.round(fakeSpaces);
                     while (fakeSpaces--) {
                       chunk += ' ';
                     }
-                  } else if (-items[j] / font.spaceWidth > 0.35) {
+                  } else if (fakeSpaces > kSpaceFactor) {
                     chunk += ' ';
                   }
                 }

--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -551,8 +551,13 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
                 if (typeof items[j] === 'string') {
                   chunk += fontCharsToUnicode(items[j], font);
                 } else if (items[j] < 0 && font.spaceWidth > 0) {
-                  var numFakeSpaces = Math.round(-items[j] / font.spaceWidth);
-                  if (numFakeSpaces > 0) {
+                  var fakeSpaces = -items[j] / font.spaceWidth;
+                  if (fakeSpaces > 1.5) {
+                    fakeSpaces = Math.round(fakeSpaces);
+                    while (fakeSpaces--) {
+                      chunk += ' ';
+                    }
+                  } else if (-items[j] / font.spaceWidth > 0.35) {
                     chunk += ' ';
                   }
                 }


### PR DESCRIPTION
Adds more then one whitespace if the space is huge and start adding a whitespace if the space > 0.35*whitespace-width. This improves the traceMonkey paper, where

1) There were spaces missing in some lines. This caused the text to get selected as one chunk if double-clicked a word and caused the find-highlighting to be off
2) The code listing/headlines missed spaces after the numbers. This caused the text in the textLayer to get scratched way too much.
