### PR TITLE
Find bar

### DIFF
--- a/extensions/firefox/components/PdfStreamConverter.js
+++ b/extensions/firefox/components/PdfStreamConverter.js
@@ -317,8 +317,8 @@ ChromeActions.prototype = {
   pdfBugEnabled: function() {
     return getBoolPref(PREF_PREFIX + '.pdfBugEnabled', false);
   },
-  searchEnabled: function() {
-    return getBoolPref(PREF_PREFIX + '.searchEnabled', false);
+  findEnabled: function() {
+    return getBoolPref(PREF_PREFIX + '.findEnabled', false);
   },
   fallback: function(url, sendResponse) {
     var self = this;

--- a/l10n/ar/viewer.properties
+++ b/l10n/ar/viewer.properties
@@ -36,8 +36,8 @@ outline.title=إظهار ملخص المستند
 outline_label=ملخص المستند
 thumbs.title=إظهار الصور المصغرة
 thumbs_label=الصور المصغرة
-search_panel.title=البحث في المستند
-search_panel_label=بحث
+find_panel.title=البحث في المستند
+find_panel_label=بحث
 
 # Document outline messages
 no_outline=لا يوجد ملخص
@@ -54,9 +54,9 @@ thumb_page_canvas=صورة مصغرة من الصفحة {{page}}
 page_rotate_cw.label=تدوير مع عقارب الساعة
 page_rotate_ccw.label=تدوير عكس عقارب الساعة
 
-# Search panel button title and messages
-search=بحث
-search_terms_not_found=(لا يوجد)
+# Find panel button title and messages
+find=بحث
+find_terms_not_found=(لا يوجد)
 
 # Error panel labels
 error_more_info=مزيد من المعلومات

--- a/l10n/da/viewer.properties
+++ b/l10n/da/viewer.properties
@@ -36,8 +36,8 @@ outline.title=Vis dokumentoversigt
 outline_label=Dokumentoversigt
 thumbs.title=Vis thumbnails
 thumbs_label=Thumbnails
-search_panel.title=Søg i dokumentet
-search_panel_label=Søg
+find_panel.title=Søg i dokumentet
+find_panel_label=Søg
 
 # Dokumentoversigtsbeskeder
 no_outline=Ingen dokumentoversigt tilgængelig
@@ -51,8 +51,8 @@ thumb_page_title=Side {{page}}
 thumb_page_canvas=Thumbnail af side {{page}}
 
 # Søgepanelet
-search=Søg
-search_terms_not_found=(Ikke fundet)
+find=Søg
+find_terms_not_found=(Ikke fundet)
 
 # Fejlpanel
 error_more_info=Mere information

--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -36,8 +36,6 @@ outline.title=Show Document Outline
 outline_label=Document Outline
 thumbs.title=Show Thumbnails
 thumbs_label=Thumbnails
-find_panel.title=Find in Document
-find_panel_label=Find
 
 # Document outline messages
 no_outline=No Outline Available
@@ -55,8 +53,14 @@ page_rotate_cw.label=Rotate Clockwise
 page_rotate_ccw.label=Rotate Counter-Clockwise
 
 # Find panel button title and messages
-find=Find
-find_terms_not_found=(Not found)
+find.title=Find in Document
+find_label=Find
+find_previous.title=Find the previous occurrence of the phrase
+find_next.title=Find the next occurrence of the phrase
+find_highlight=Highlight all
+find_match_case_label=Match case
+find_wrapped_to_bottom=Reached end of page, continued from bottom
+find_wrapped_to_top=Reached end of page, continued from top
 
 # Error panel labels
 error_more_info=More Information

--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -36,8 +36,8 @@ outline.title=Show Document Outline
 outline_label=Document Outline
 thumbs.title=Show Thumbnails
 thumbs_label=Thumbnails
-search_panel.title=Search Document
-search_panel_label=Search
+find_panel.title=Find in Document
+find_panel_label=Find
 
 # Document outline messages
 no_outline=No Outline Available
@@ -54,9 +54,9 @@ thumb_page_canvas=Thumbnail of Page {{page}}
 page_rotate_cw.label=Rotate Clockwise
 page_rotate_ccw.label=Rotate Counter-Clockwise
 
-# Search panel button title and messages
-search=Find
-search_terms_not_found=(Not found)
+# Find panel button title and messages
+find=Find
+find_terms_not_found=(Not found)
 
 # Error panel labels
 error_more_info=More Information

--- a/l10n/es/viewer.properties
+++ b/l10n/es/viewer.properties
@@ -36,8 +36,8 @@ outline.title=Mostrar esquema del documento
 outline_label=Esquema del documento
 thumbs.title=Mostrar miniaturas
 thumbs_label=Miniaturas
-search_panel.title=Buscar en el documento
-search_panel_label=Buscar
+find_panel.title=Buscar en el documento
+find_panel_label=Buscar
 
 # Document outline messages
 no_outline=No hay un esquema disponible
@@ -50,9 +50,9 @@ thumb_page_title=Página {{page}}
 # number.
 thumb_page_canvas=Miniatura de la página {{page}}
 
-# Search panel button title and messages
-search=Buscar
-search_terms_not_found=(No encontrado)
+# Find panel button title and messages
+find=Buscar
+find_terms_not_found=(No encontrado)
 
 # Error panel labels
 error_more_info=Más información

--- a/l10n/fi/viewer.properties
+++ b/l10n/fi/viewer.properties
@@ -36,8 +36,8 @@ outline.title=Näytä asiakirjan jäsennys
 outline_label=Asiakirjan jäsennys
 thumbs.title=Näytä esikatselukuvat
 thumbs_label=Esikatselukuvat
-search_panel.title=Etsi asiakirjasta
-search_panel_label=Etsi
+find_panel.title=Etsi asiakirjasta
+find_panel_label=Etsi
 
 # Document outline messages
 no_outline=Jäsennystä ei ole tarjolla
@@ -50,9 +50,9 @@ thumb_page_title=Sivu {{page}}
 # number.
 thumb_page_canvas=Sivun {{page}} esikatselukuva
 
-# Search panel button title and messages
-search=Etsi
-search_terms_not_found=(Ei löytynyt)
+# Find panel button title and messages
+find=Etsi
+find_terms_not_found=(Ei löytynyt)
 
 # Error panel labels
 error_more_info=Enemmän tietoa

--- a/l10n/ja/viewer.properties
+++ b/l10n/ja/viewer.properties
@@ -36,8 +36,8 @@ outline.title=文書の目次
 outline_label=文書の目次
 thumbs.title=縮小版
 thumbs_label=縮小版
-search_panel.title=検索
-search_panel_label=検索
+find_panel.title=検索
+find_panel_label=検索
 
 # Document outline messages
 no_outline=利用可能な目次はありません
@@ -54,9 +54,9 @@ thumb_page_canvas=ページの縮小版 {{page}}
 page_rotate_cw.label=右回転
 page_rotate_ccw.label=左回転
 
-# Search panel button title and messages
-search=検索
-search_terms_not_found=(見つかりませんでした)
+# Find panel button title and messages
+find=検索
+find_terms_not_found=(見つかりませんでした)
 
 # Error panel labels
 error_more_info=詳細情報

--- a/l10n/nl/viewer.properties
+++ b/l10n/nl/viewer.properties
@@ -34,8 +34,8 @@ outline.title=Toon document structuur
 outline_label=Document structuur
 thumbs.title=Toon miniaturen
 thumbs_label=Miniaturen
-search_panel.title=Doorzoek document
-search_panel_label=Zoek
+find_panel.title=Doorzoek document
+find_panel_label=Zoek
 
 # Document outline messages
 no_outline=Geen structuur beschikbaar
@@ -48,9 +48,9 @@ thumb_page_title=Pagina {{page}}
 # number.
 thumb_page_canvas=Miniatuur van pagina {{page}}
 
-# Search panel button title and messages
-search=Zoek
-search_terms_not_found=(Niet gevonden)
+# Find panel button title and messages
+find=Zoek
+find_terms_not_found=(Niet gevonden)
 
 # Error panel labels
 error_more_info=Meer informatie

--- a/l10n/sv/viewer.properties
+++ b/l10n/sv/viewer.properties
@@ -34,8 +34,8 @@ outline.title=Visa dokumentdisposition
 outline_label=Dokumentdisposition
 thumbs.title=Visa miniatyrer
 thumbs_label=Miniatyrer
-search_panel.title=Sök i dokumentet
-search_panel_label=Sök
+find_panel.title=Sök i dokumentet
+find_panel_label=Sök
 
 # Document outline messages
 no_outline=Ingen dokumentdisposition tillgänglig
@@ -48,9 +48,9 @@ thumb_page_title=Sida {{page}}
 # number.
 thumb_page_canvas=Miniatyr av sida {{page}}
 
-# Search panel button title and messages
-search=Hitta
-search_terms_not_found=(hittades inte)
+# Find panel button title and messages
+find=Hitta
+find_terms_not_found=(hittades inte)
 
 # Error panel labels
 error_more_info=Mer information

--- a/l10n/zh-TW/viewer.properties
+++ b/l10n/zh-TW/viewer.properties
@@ -34,8 +34,8 @@ outline.title=顯示文件綱要
 outline_label=文件綱要
 thumbs.title=顯示縮圖
 thumbs_label=縮圖
-search_panel.title=搜索文件
-search_panel_label=搜索
+find_panel.title=搜索文件
+find_panel_label=搜索
 
 # 文件綱要相關訊息
 no_outline=無可用的綱要
@@ -51,8 +51,8 @@ page_rotate_cw.label=順時針旋轉
 page_rotate_ccw.label=逆時針旋轉
 
 # 搜尋面板按鍵文字及訊息
-search=搜索
-search_terms_not_found=（沒有找到）
+find=搜索
+find_terms_not_found=（沒有找到）
 
 # 錯誤面板標籤
 error_more_info=更多資訊

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -870,8 +870,7 @@ a:focus > .thumbnail > .thumbnailSelectionRing,
   margin-left: 20px;
 }
 
-.outlineItem > a,
-#findResults > a {
+.outlineItem > a {
   text-decoration: none;
   display: inline-block;
   min-width: 95%;
@@ -887,8 +886,7 @@ a:focus > .thumbnail > .thumbnailSelectionRing,
   white-space: nowrap;
 }
 
-.outlineItem > a:hover,
-#findResults > a:hover {
+.outlineItem > a:hover {
   background-color: hsla(0,0%,100%,.02);
   background-image: -moz-linear-gradient(hsla(0,0%,100%,.05), hsla(0,0%,100%,0));
   background-clip: padding-box;
@@ -921,36 +919,6 @@ a:focus > .thumbnail > .thumbnailSelectionRing,
   bottom: 10px;
   left: 10px;
   width: 280px;
-}
-
-#findToolbar {
-  padding-left: 0px;
-  right: 0px;
-  padding-top: 0px;
-  padding-bottom: 5px;
-}
-
-#findToolbar > input {
-  margin-left: 4px;
-  width: 124px;
-}
-
-#findToolbar button {
-  width: auto;
-  margin: 0;
-  padding: 0 6px;
-  height: 22px;
-}
-
-#findResults {
-  overflow: auto;
-  position: absolute;
-  top: 30px;
-  bottom: 0px;
-  left: 0px;
-  right: 0;
-  padding: 4px 4px 0;
-  font-size: smaller;
 }
 
 #sidebarControls {

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -728,7 +728,7 @@ html[dir='rtl'] .toolbarButton.pageDown::before {
   content: url(images/toolbarButton-viewOutline.png);
 }
 
-#viewSearch.toolbarButton::before {
+#viewFind.toolbarButton::before {
   display: inline-block;
   content: url(images/toolbarButton-search.png);
 }
@@ -871,7 +871,7 @@ a:focus > .thumbnail > .thumbnailSelectionRing,
 }
 
 .outlineItem > a,
-#searchResults > a {
+#findResults > a {
   text-decoration: none;
   display: inline-block;
   min-width: 95%;
@@ -888,7 +888,7 @@ a:focus > .thumbnail > .thumbnailSelectionRing,
 }
 
 .outlineItem > a:hover,
-#searchResults > a:hover {
+#findResults > a:hover {
   background-color: hsla(0,0%,100%,.02);
   background-image: -moz-linear-gradient(hsla(0,0%,100%,.05), hsla(0,0%,100%,0));
   background-clip: padding-box;
@@ -915,7 +915,7 @@ a:focus > .thumbnail > .thumbnailSelectionRing,
   font-style: italic;
 }
 
-#searchScrollView {
+#findScrollView {
   position: absolute;
   top: 10px;
   bottom: 10px;
@@ -923,26 +923,26 @@ a:focus > .thumbnail > .thumbnailSelectionRing,
   width: 280px;
 }
 
-#searchToolbar {
+#findToolbar {
   padding-left: 0px;
   right: 0px;
   padding-top: 0px;
   padding-bottom: 5px;
 }
 
-#searchToolbar > input {
+#findToolbar > input {
   margin-left: 4px;
   width: 124px;
 }
 
-#searchToolbar button {
+#findToolbar button {
   width: auto;
   margin: 0;
   padding: 0 6px;
   height: 22px;
 }
 
-#searchResults {
+#findResults {
   overflow: auto;
   position: absolute;
   top: 30px;

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -245,7 +245,7 @@ html[dir='rtl'] #sidebarContent {
               0 1px 1px hsla(0,0%,0%,.1);
 }
 
-#toolbarViewer {
+#toolbarViewer, .findbar {
   position: relative;
   height: 32px;
   background-image: url(images/texture.png),
@@ -265,6 +265,32 @@ html[dir='rtl'] #sidebarContent {
               0 1px 0 hsla(0,0%,0%,.15),
               0 1px 1px hsla(0,0%,0%,.1);
 }
+
+.findbar {
+  top: 40px;
+  left: 40px;
+  position: absolute;
+  z-index: 100;
+  height: 20px;
+
+  min-width: 16px;
+  padding: 3px 6px 3px 6px;
+  margin: 4px 2px 4px 0;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  color: hsl(0,0%,85%);
+  font-size: 12px;
+  line-height: 14px;
+  text-align: left;
+  -webkit-user-select:none;
+  -moz-user-select:none;
+  cursor: default;
+}
+
+.notFound {
+  background-color: rgb(255, 137, 153);
+}
+
 html[dir='ltr'] #toolbarViewerLeft {
   margin-left: -1px;
 }
@@ -1067,6 +1093,30 @@ canvas {
   position: absolute;
   line-height:1.3;
   white-space:pre;
+}
+
+.textLayer .highlight {
+  margin: -1px;
+  padding: 1px;
+
+  background-color: rgba(0, 137, 26, 0.2);
+  border-radius: 4px;
+}
+
+.textLayer .highlight.begin {
+  border-radius: 4px 0px 0px 4px;
+}
+
+.textLayer .highlight.end {
+  border-radius: 0px 4px 4px 0px;
+}
+
+.textLayer .highlight.middle {
+  border-radius: 0px;
+}
+
+.textLayer .highlight.selected {
+  background-color: rgba(255, 0, 0, 0.2);
 }
 
 /* TODO: file FF bug to support ::-moz-selection:window-inactive

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -282,9 +282,17 @@ html[dir='rtl'] #sidebarContent {
   font-size: 12px;
   line-height: 14px;
   text-align: left;
+  cursor: default;
+}
+
+.findbar label {
   -webkit-user-select:none;
   -moz-user-select:none;
-  cursor: default;
+}
+
+#findMsg {
+  font-style: italic;
+  color: #A6B7D0;
 }
 
 .notFound {

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1067,7 +1067,7 @@ canvas {
   margin: -1px;
   padding: 1px;
 
-  background-color: rgba(0, 137, 26, 0.2);
+  background-color: rgba(180, 0, 170, 0.2);
   border-radius: 4px;
 }
 
@@ -1084,7 +1084,7 @@ canvas {
 }
 
 .textLayer .highlight.selected {
-  background-color: rgba(255, 0, 0, 0.2);
+  background-color: rgba(0, 100, 0, 0.2);
 }
 
 /* TODO: file FF bug to support ::-moz-selection:window-inactive

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -267,17 +267,15 @@ html[dir='rtl'] #sidebarContent {
 }
 
 .findbar {
-  top: 40px;
-  left: 40px;
+  top: 32px;
+  left: 68px;
   position: absolute;
-  z-index: 100;
+  z-index: 10000;
   height: 20px;
 
   min-width: 16px;
   padding: 3px 6px 3px 6px;
   margin: 4px 2px 4px 0;
-  border: 1px solid transparent;
-  border-radius: 2px;
   color: hsl(0,0%,85%);
   font-size: 12px;
   line-height: 14px;
@@ -288,6 +286,33 @@ html[dir='rtl'] #sidebarContent {
 .findbar label {
   -webkit-user-select:none;
   -moz-user-select:none;
+}
+
+.doorHanger {
+  border: 1px solid hsla(0,0%,0%,.5);
+  border-radius: 2px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+.doorHanger:after, .doorHanger:before {
+  bottom: 100%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+.doorHanger:after {
+  border-bottom-color: hsla(0,0%,32%,.99);
+  border-width: 8px;
+  left: 16px;
+  margin-left: -8px;
+}
+.doorHanger:before {
+  border-bottom-color: hsla(0,0%,0%,.5);
+  border-width: 9px;
+  left: 16px;
+  margin-left: -9px;
 }
 
 #findMsg {
@@ -1317,7 +1342,7 @@ canvas {
 }
 
 @media all and (max-width: 600px) {
-  #toolbarViewerRight {
+  #toolbarViewerRight, #findbar, #viewFind {
     display: none;
   }
 }

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -108,9 +108,20 @@ limitations under the License.
       </div>  <!-- sidebarContainer -->
 
       <div id="mainContainer">
+        <div class="findbar hidden" id="findbar">
+          <label for="findInput">Find: </label>
+          <input id="findInput" type="search">
+          <button id="findPrevious">&lt;</button>
+          <button id="findNext">&gt;</button>
+          <input type="checkbox" id="findHighlightAll">
+          <label for="findHighlightAll">Highlight all</label>
+          <input type="checkbox" id="findMatchCase">
+          <label for="findMatchCase">Match case</label>
+          <span id="findMsgWrap" class="hidden">Reached end of page, continued from top</span>
+          <span id="findMsgNotFound" class="hidden">Phrase not found</span>
+        </div>
         <div class="toolbar">
           <div id="toolbarContainer">
-
             <div id="toolbarViewer">
               <div id="toolbarViewerLeft">
                 <button id="sidebarToggle" class="toolbarButton" title="Toggle Sidebar" tabindex="4" data-l10n-id="toggle_slider">

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -97,13 +97,6 @@ limitations under the License.
           </div>
           <div id="outlineView" class="hidden">
           </div>
-          <div id="findView" class="hidden">
-            <div id="findToolbar">
-              <input id="findTermsInput" class="toolbarField">
-              <button id="findButton" class="textButton toolbarButton" data-l10n-id="find">Find</button>
-            </div>
-            <div id="findResults"></div>
-          </div>
         </div>
       </div>  <!-- sidebarContainer -->
 

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -88,11 +88,6 @@ limitations under the License.
           <button id="viewOutline" class="toolbarButton group" title="Show Document Outline" tabindex="2" data-l10n-id="outline">
              <span data-l10n-id="outline_label">Document Outline</span>
           </button>
-<!--#if !MOZCENTRAL-->
-          <button id="viewFind" class="toolbarButton group" title="Find in Document" tabindex="3" data-l10n-id="find_panel">
-             <span data-l10n-id="find_panel_label">Find in Document</span>
-          </button>
-<!--#endif-->
         </div>
         <div id="sidebarContent">
           <div id="thumbnailView">
@@ -103,7 +98,7 @@ limitations under the License.
       </div>  <!-- sidebarContainer -->
 
       <div id="mainContainer">
-        <div class="findbar hidden" id="findbar">
+        <div class="findbar hidden doorHanger" id="findbar">
           <label for="findInput">Find: </label>
           <input id="findInput" type="search">
           <button id="findPrevious">&lt;</button>
@@ -118,10 +113,15 @@ limitations under the License.
           <div id="toolbarContainer">
             <div id="toolbarViewer">
               <div id="toolbarViewerLeft">
-                <button id="sidebarToggle" class="toolbarButton" title="Toggle Sidebar" tabindex="4" data-l10n-id="toggle_slider">
+                <button id="sidebarToggle" class="toolbarButton" title="Toggle Sidebar" tabindex="3" data-l10n-id="toggle_slider">
                   <span data-l10n-id="toggle_slider_label">Toggle Sidebar</span>
                 </button>
                 <div class="toolbarButtonSpacer"></div>
+<!--#if !MOZCENTRAL-->
+                <button id="viewFind" class="toolbarButton group" title="Find in Document" tabindex="4" data-l10n-id="find_panel">
+                   <span data-l10n-id="find_panel_label">Find in Document</span>
+                </button>
+<!--#endif-->
                 <div class="splitToolbarButton">
                   <button class="toolbarButton pageUp" title="Previous Page" id="previous" tabindex="5" data-l10n-id="previous">
                     <span data-l10n-id="previous_label">Previous</span>

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -112,8 +112,7 @@ limitations under the License.
           <label for="findHighlightAll">Highlight all</label>
           <input type="checkbox" id="findMatchCase">
           <label for="findMatchCase">Match case</label>
-          <span id="findMsgWrap" class="hidden">Reached end of page, continued from top</span>
-          <span id="findMsgNotFound" class="hidden">Phrase not found</span>
+          <span id="findMsg"></span>
         </div>
         <div class="toolbar">
           <div id="toolbarContainer">

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -99,14 +99,14 @@ limitations under the License.
 
       <div id="mainContainer">
         <div class="findbar hidden doorHanger" id="findbar">
-          <label for="findInput">Find: </label>
+          <label for="findInput" data-l10n-id="find_label">Find</label>:
           <input id="findInput" type="search">
-          <button id="findPrevious">&lt;</button>
-          <button id="findNext">&gt;</button>
+          <button id="findPrevious" data-l10n-id="find_previous" title="">&lt;</button>
+          <button id="findNext" data-l10n-id="find_next">&gt;</button>
           <input type="checkbox" id="findHighlightAll">
-          <label for="findHighlightAll">Highlight all</label>
+          <label for="findHighlightAll" data-l10n-id="find_highlight">Highlight all</label>
           <input type="checkbox" id="findMatchCase">
-          <label for="findMatchCase">Match case</label>
+          <label for="findMatchCase" data-l10n-id="find_match_case_label">Match case</label>
           <span id="findMsg"></span>
         </div>
         <div class="toolbar">
@@ -118,8 +118,8 @@ limitations under the License.
                 </button>
                 <div class="toolbarButtonSpacer"></div>
 <!--#if !MOZCENTRAL-->
-                <button id="viewFind" class="toolbarButton group" title="Find in Document" tabindex="4" data-l10n-id="find_panel">
-                   <span data-l10n-id="find_panel_label">Find in Document</span>
+                <button id="viewFind" class="toolbarButton group" title="Find in Document" tabindex="4" data-l10n-id="find">
+                   <span data-l10n-id="find_label">Find</span>
                 </button>
 <!--#endif-->
                 <div class="splitToolbarButton">

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -88,9 +88,11 @@ limitations under the License.
           <button id="viewOutline" class="toolbarButton group" title="Show Document Outline" tabindex="2" data-l10n-id="outline">
              <span data-l10n-id="outline_label">Document Outline</span>
           </button>
+<!--#if !MOZCENTRAL-->
           <button id="viewFind" class="toolbarButton group" title="Find in Document" tabindex="3" data-l10n-id="find_panel">
              <span data-l10n-id="find_panel_label">Find in Document</span>
           </button>
+<!--#endif-->
         </div>
         <div id="sidebarContent">
           <div id="thumbnailView">

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -88,8 +88,8 @@ limitations under the License.
           <button id="viewOutline" class="toolbarButton group" title="Show Document Outline" tabindex="2" data-l10n-id="outline">
              <span data-l10n-id="outline_label">Document Outline</span>
           </button>
-          <button id="viewSearch" class="toolbarButton group hidden" title="Search Document" tabindex="3" data-l10n-id="search_panel">
-             <span data-l10n-id="search_panel_label">Search Document</span>
+          <button id="viewFind" class="toolbarButton group" title="Find in Document" tabindex="3" data-l10n-id="find_panel">
+             <span data-l10n-id="find_panel_label">Find in Document</span>
           </button>
         </div>
         <div id="sidebarContent">
@@ -97,12 +97,12 @@ limitations under the License.
           </div>
           <div id="outlineView" class="hidden">
           </div>
-          <div id="searchView" class="hidden">
-            <div id="searchToolbar">
-              <input id="searchTermsInput" class="toolbarField">
-              <button id="searchButton" class="textButton toolbarButton" data-l10n-id="search">Find</button>
+          <div id="findView" class="hidden">
+            <div id="findToolbar">
+              <input id="findTermsInput" class="toolbarField">
+              <button id="findButton" class="textButton toolbarButton" data-l10n-id="find">Find</button>
             </div>
-            <div id="searchResults"></div>
+            <div id="findResults"></div>
           </div>
         </div>
       </div>  <!-- sidebarContainer -->

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -247,10 +247,16 @@ var PDFFindController = {
     // TODO: Handle the other find options here as well.
 
     var query = this.state.query;
+    var caseSensitive = this.state.caseSensitive;
     var queryLen = query.length;
 
     if (queryLen === 0)
       return [];
+
+    if (!caseSensitive) {
+      pageContent = pageContent.toLowerCase();
+      query = query.toLowerCase();
+    }
 
     var matches = [];
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -236,10 +236,10 @@ var PDFFindController = {
       'findcasesensitivitychange'
     ];
 
-    this.handelEvent = this.handelEvent.bind(this);
+    this.handleEvent = this.handleEvent.bind(this);
 
     for (var i = 0; i < events.length; i++) {
-      window.addEventListener(events[i], this.handelEvent);
+      window.addEventListener(events[i], this.handleEvent);
     }
   },
 
@@ -295,7 +295,7 @@ var PDFFindController = {
     extractPageText(0);
   },
 
-  handelEvent: function(e) {
+  handleEvent: function(e) {
     this.state = e.detail;
     if (e.detail.findPrevious === undefined) {
       this.dirtyMatch = true;
@@ -358,7 +358,7 @@ var PDFFindController = {
       }
     } else {
       // If there is NO selection, then there is no match at all -> no sense to
-      // handel previous/next action.
+      // handle previous/next action.
       if (this.selected.pageIdx === -1)
         return;
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2365,12 +2365,26 @@ var TextLayerBuilder = function textLayerBuilder(textLayerDiv, pageIdx) {
     return ret;
   };
 
+  this.clearMatches = function textLayerBuilder_clearMatches() {
+    var textDivs = this.textDivs;
+
+    // Clear all previous highlights
+    textDivs.forEach(function(div) {
+      var spans = div.querySelectorAll('span');
+      for (var i = 0, ii = spans.length; i < ii; i++) {
+        spans[i].className = '';
+      }
+    });
+  }
+
   this.renderMatches = function textLayerBuilder_renderMatches(matches) {
     var bidiTexts = this.textContent.bidiTexts;
     var textDivs = this.textDivs;
     var prevEnd = null;
     var isSelectedPage = this.pageIdx === PDFFindController.selected.pageIdx;
     var selectedMatchIdx = PDFFindController.selected.matchIdx;
+
+    this.clearMatches();
 
     var infty = {
       divIdx: -1,

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2254,27 +2254,18 @@ var TextLayerBuilder = function textLayerBuilder(textLayerDiv, pageIdx) {
     return ret;
   };
 
-  this.clearMatches = function textLayerBuilder_clearMatches() {
-    var textDivs = this.textDivs;
-
-    // Clear all previous highlights
-    textDivs.forEach(function(div) {
-      var spans = div.querySelectorAll('span');
-      for (var i = 0, ii = spans.length; i < ii; i++) {
-        spans[i].className = '';
-      }
-    });
-  }
-
   this.renderMatches = function textLayerBuilder_renderMatches(matches) {
+    // Early exit if there is nothing to render.
+    if (matches.length === 0) {
+      return;
+    }
+
     var bidiTexts = this.textContent.bidiTexts;
     var textDivs = this.textDivs;
     var prevEnd = null;
     var isSelectedPage = this.pageIdx === PDFFindController.selected.pageIdx;
     var selectedMatchIdx = PDFFindController.selected.matchIdx;
     var highlightAll = PDFFindController.state.highlightAll;
-
-    this.clearMatches();
 
     var infty = {
       divIdx: -1,
@@ -2377,12 +2368,13 @@ var TextLayerBuilder = function textLayerBuilder(textLayerDiv, pageIdx) {
     var bidiTexts = this.textContent.bidiTexts;
     var clearedUntilDivIdx = -1;
 
+    // Clear out all current matches.
     for (var i = 0; i < matches.length; i++) {
       var match = matches[i];
       var begin = Math.max(clearedUntilDivIdx, match.begin.divIdx);
       for (var n = begin; n <= match.end.divIdx; n++) {
-        var div = bidiTexts[n].str;
-        div.textContent = div.textContent;
+        var div = textDivs[n];
+        div.textContent = bidiTexts[n].str;
         div.className = '';
       }
       clearedUntilDivIdx = match.end.divIdx + 1;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -211,7 +211,7 @@ var currentPageNumber = 1;
 var PDFFindController = {
   startedTextExtraction: false,
 
-  // If active, search resulsts will be highlighted.
+  // If active, find results will be highlighted.
   active: false,
 
   // Stores the text for each page.
@@ -244,7 +244,7 @@ var PDFFindController = {
   },
 
   calcFindMatch: function(pageContent) {
-    // TODO: Handle the other search options here as well.
+    // TODO: Handle the other find options here as well.
 
     var query = this.state.query;
     var queryLen = query.length;
@@ -274,7 +274,7 @@ var PDFFindController = {
     function extractPageText(pageIndex) {
       PDFView.pages[pageIndex].getTextContent().then(
         function textContentResolved(data) {
-          // Bulid the search string.
+          // Build the find string.
           var bidiTexts = data.bidiTexts;
           var str = '';
 
@@ -434,7 +434,7 @@ var PDFFindBar = {
 
   initialize: function() {
     this.bar = document.getElementById('findbar');
-    this.toggleButton = document.getElementById('viewSearch');
+    this.toggleButton = document.getElementById('viewFind');
     this.findField = document.getElementById('findInput');
     this.highlightAll = document.getElementById('findHighlightAll');
     this.caseSensitive = document.getElementById('findMatchCase');
@@ -1224,39 +1224,39 @@ var PDFView = {
     return true;
   },
 
-  search: function pdfViewStartSearch() {
-    // Limit this function to run every <SEARCH_TIMEOUT>ms.
-    var SEARCH_TIMEOUT = 250;
-    var lastSearch = this.lastSearch;
+  find: function pdfViewStartFind() {
+    // Limit this function to run every <FIND_TIMEOUT>ms.
+    var FIND_TIMEOUT = 250;
+    var lastFind = this.lastFind;
     var now = Date.now();
-    if (lastSearch && (now - lastSearch) < SEARCH_TIMEOUT) {
-      if (!this.searchTimer) {
-        this.searchTimer = setTimeout(function resumeSearch() {
-            PDFView.search();
+    if (lastFind && (now - lastFind) < FIND_TIMEOUT) {
+      if (!this.findTimer) {
+        this.findTimer = setTimeout(function resumeFind() {
+            PDFView.find();
           },
-          SEARCH_TIMEOUT - (now - lastSearch)
+          FIND_TIMEOUT - (now - lastFind)
         );
       }
       return;
     }
-    this.searchTimer = null;
-    this.lastSearch = now;
+    this.FindTimer = null;
+    this.lastFind = now;
 
     function bindLink(link, pageNumber) {
       link.href = '#' + pageNumber;
-      link.onclick = function searchBindLink() {
+      link.onclick = function findBindLink() {
         PDFView.page = pageNumber;
         return false;
       };
     }
 
-    var searchResults = document.getElementById('searchResults');
+    var findResults = document.getElementById('findResults');
 
-    var searchTermsInput = document.getElementById('searchTermsInput');
-    searchResults.removeAttribute('hidden');
-    searchResults.textContent = '';
+    var findTermsInput = document.getElementById('findTermsInput');
+    findResults.removeAttribute('hidden');
+    findResults.textContent = '';
 
-    var terms = searchTermsInput.value;
+    var terms = findTermsInput.value;
 
     if (!terms)
       return;
@@ -1276,17 +1276,17 @@ var PDFView = {
       var link = document.createElement('a');
       bindLink(link, pageNumber);
       link.textContent = 'Page ' + pageNumber + ': ' + textSample;
-      searchResults.appendChild(link);
+      findResults.appendChild(link);
 
       pageFound = true;
     }
     if (!pageFound) {
-      searchResults.textContent = '';
+      findResults.textContent = '';
       var noResults = document.createElement('div');
       noResults.classList.add('noResults');
-      noResults.textContent = mozL10n.get('search_terms_not_found', null,
+      noResults.textContent = mozL10n.get('find_terms_not_found', null,
                                               '(Not found)');
-      searchResults.appendChild(noResults);
+      findResults.appendChild(noResults);
     }
   },
 
@@ -1331,20 +1331,20 @@ var PDFView = {
   switchSidebarView: function pdfViewSwitchSidebarView(view) {
     var thumbsView = document.getElementById('thumbnailView');
     var outlineView = document.getElementById('outlineView');
-    var searchView = document.getElementById('searchView');
+    var findView = document.getElementById('findView');
 
     var thumbsButton = document.getElementById('viewThumbnail');
     var outlineButton = document.getElementById('viewOutline');
-    var searchButton = document.getElementById('viewSearch');
+    var findButton = document.getElementById('viewFind');
 
     switch (view) {
       case 'thumbs':
         thumbsButton.classList.add('toggled');
         outlineButton.classList.remove('toggled');
-        searchButton.classList.remove('toggled');
+        findButton.classList.remove('toggled');
         thumbsView.classList.remove('hidden');
         outlineView.classList.add('hidden');
-        searchView.classList.add('hidden');
+        findView.classList.add('hidden');
 
         PDFView.renderHighestPriority();
         break;
@@ -1352,25 +1352,25 @@ var PDFView = {
       case 'outline':
         thumbsButton.classList.remove('toggled');
         outlineButton.classList.add('toggled');
-        searchButton.classList.remove('toggled');
+        findButton.classList.remove('toggled');
         thumbsView.classList.add('hidden');
         outlineView.classList.remove('hidden');
-        searchView.classList.add('hidden');
+        findView.classList.add('hidden');
 
         if (outlineButton.getAttribute('disabled'))
           return;
         break;
 
-      case 'search':
+      case 'find':
         thumbsButton.classList.remove('toggled');
         outlineButton.classList.remove('toggled');
-        searchButton.classList.add('toggled');
+        findButton.classList.add('toggled');
         thumbsView.classList.add('hidden');
         outlineView.classList.add('hidden');
-        searchView.classList.remove('hidden');
+        findView.classList.remove('hidden');
 
-        var searchTermsInput = document.getElementById('searchTermsInput');
-        searchTermsInput.focus();
+        var findTermsInput = document.getElementById('findTermsInput');
+        findTermsInput.focus();
         // Start text extraction as soon as the search gets displayed.
         this.extractText();
         break;
@@ -1386,7 +1386,7 @@ var PDFView = {
       self.pages[pageIndex].pdfPage.getTextContent().then(
         function textContentResolved(textContent) {
           self.pageText[pageIndex] = textContent.join('');
-          self.search();
+          self.find();
           if ((pageIndex + 1) < self.pages.length)
             extractPageText(pageIndex + 1);
         }
@@ -2545,8 +2545,8 @@ document.addEventListener('DOMContentLoaded', function webViewerLoad(evt) {
 
 //#if !(FIREFOX || MOZCENTRAL)
 //#else
-//if (FirefoxCom.requestSync('searchEnabled')) {
-//  document.querySelector('#viewSearch').classList.remove('hidden');
+//if (FirefoxCom.requestSync('findEnabled')) {
+//  document.querySelector('#viewFind').classList.remove('hidden');
 //}
 //#endif
 
@@ -2636,10 +2636,10 @@ document.addEventListener('DOMContentLoaded', function webViewerLoad(evt) {
       PDFView.download();
     });
 
-  document.getElementById('searchTermsInput').addEventListener('keydown',
+  document.getElementById('findTermsInput').addEventListener('keydown',
     function(event) {
       if (event.keyCode == 13) {
-        PDFView.search();
+        PDFView.find();
       }
     });
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -458,22 +458,18 @@ var PDFFindBar = {
     // next match when the findField is selected.
 
     document.getElementById('findPrevious').addEventListener('click',
-    function() {
-      self.dispatchEvent('again', true);
-    });
+      function() { self.dispatchEvent('again', true); }
+    );
 
-    document.getElementById('findNext').addEventListener('click',
-    function() {
+    document.getElementById('findNext').addEventListener('click', function() {
       self.dispatchEvent('again', false);
     });
 
-    this.highlightAll.addEventListener('click',
-    function() {
+    this.highlightAll.addEventListener('click', function() {
       self.dispatchEvent('highlightallchange');
     });
 
-    this.caseSensitive.addEventListener('click',
-    function() {
+    this.caseSensitive.addEventListener('click', function() {
       self.dispatchEvent('casesensitivitychange');
     });
   },
@@ -2276,6 +2272,7 @@ var TextLayerBuilder = function textLayerBuilder(textLayerDiv, pageIdx) {
     var prevEnd = null;
     var isSelectedPage = this.pageIdx === PDFFindController.selected.pageIdx;
     var selectedMatchIdx = PDFFindController.selected.matchIdx;
+    var highlightAll = PDFFindController.state.highlightAll;
 
     this.clearMatches();
 
@@ -2323,7 +2320,14 @@ var TextLayerBuilder = function textLayerBuilder(textLayerDiv, pageIdx) {
       textDivs[divIdx].className = className;
     }
 
-    for (var i = 0; i < matches.length; i++) {
+    var i0 = selectedMatchIdx, i1 = i0 + 1, i;
+
+    if (highlightAll) {
+      i0 = 0;
+      i1 = matches.length;
+    }
+
+    for (i = i0; i < i1; i++) {
       var match = matches[i];
       var begin = match.begin;
       var end = match.end;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2799,7 +2799,7 @@ window.addEventListener('keydown', function keydown(evt) {
   // control is selected or not.
   if (cmd == 1 || cmd == 8) { // either CTRL or META key.
     switch (evt.keyCode) {
-//#if !(FIREFOX || MOZCENTRAL)
+//#if !MOZCENTRAL
       case 70:
         PDFFindBar.toggle();
         handled = true;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -480,8 +480,16 @@ var PDFFindBar = {
       self.dispatchEvent('');
     });
 
-    // TODO: Add keybindings like enter, shift-enter, CMD-G etc. to go to prev/
+    // TODO: Add keybindings CMD-G etc. to go to prev/
     // next match when the findField is selected.
+
+    this.findField.addEventListener('keydown', function(evt) {
+      switch (evt.keyCode) {
+        case 13: // Enter
+          self.dispatchEvent('again', evt.shiftKey);
+          break;
+      }
+    });
 
     document.getElementById('findPrevious').addEventListener('click',
       function() { self.dispatchEvent('again', true); }

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -446,8 +446,7 @@ var PDFFindBar = {
     this.findMsgNotFound = document.getElementById('findMsgNotFound');
 
     var self = this;
-    this.toggleButton.addEventListener('click',
-    function() {
+    this.toggleButton.addEventListener('click', function() {
       self.toggle();
     });
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2316,6 +2316,9 @@ var TextLayerBuilder = function textLayerBuilder(textLayerDiv, pageIdx) {
     if (highlightAll) {
       i0 = 0;
       i1 = matches.length;
+    } else if(!isSelectedPage) {
+      // Not highlighting all and this isn't the selected page, so do nothing.
+      return;
     }
 
     for (i = i0; i < i1; i++) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -323,13 +323,15 @@ var PDFFindController = {
   updatePage: function(idx) {
     var page = PDFView.pages[idx];
 
-    if (page.textLayer) {
-      page.textLayer.updateMatches();
-    } else if (this.selected.pageIdx === idx) {
+    if (this.selected.pageIdx === idx) {
       // If the page is selected, scroll the page into view, which triggers
       // rendering the page, which adds the textLayer. Once the textLayer is
       // build, it will scroll onto the selected match.
       page.scrollIntoView();
+    }
+
+    if (page.textLayer) {
+      page.textLayer.updateMatches();
     }
   },
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -343,10 +343,6 @@ var PDFFindController = {
 
     this.active = true;
 
-    if (!this.state.query) {
-      this.updateUIState(FindStates.FIND_FOUND);
-      return;
-    }
     this.updateUIState(FindStates.FIND_PENDING);
 
     if (this.dirtyMatch) {
@@ -372,7 +368,7 @@ var PDFFindController = {
         }
         this.updatePage(i, true);
       }
-      if (!firstMatch) {
+      if (!firstMatch || !this.state.query) {
         this.updateUIState(FindStates.FIND_FOUND);
       } else {
         this.updateUIState(FindStates.FIND_NOTFOUND);


### PR DESCRIPTION
Supersedes #2138
# To-Do (prior to merging)
- ~~Highlight all~~
- ~~Case insensitive (right now it's Match All by default)~~
- ~~Update find status (found, not found, wrapped, ..)~~
- ~~UI: When in MOZCENTRAL don't show find icon - otherwise show it~~
- ~~Bug: highlight does not clear after searching for new word~~
- ~~Bug: if current page is not first, the viewer doesn't scroll back to the page with match (e.g. search for "dynamic" starting on p.7 of Tracemonkey)~~
- ~~Bug: viewer.js/html/css still have the old `findView`, `findToolbar`, `extractText()`, etc, even though the new find bar doesn't use them~~
- ~~Bug: Searching for "Trace" without "Highlight ALL" enabled shows the first match on every page. However, it should only highlight the current selected search result over all pages of the PDF /by jviereck~~
