### PR TITLE
Removed en-US from link to stable version in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ using the pdf.js API.
 
 A Firefox extension is availble in two places:
 
-+ Stable Version: https://addons.mozilla.org/en-US/firefox/addon/pdfjs
++ Stable Version: https://addons.mozilla.org/firefox/addon/pdfjs
 + Development Version: http://mozilla.github.com/pdf.js/extensions/firefox/pdf.js.xpi
 
 The development extension should be quite stable but still might break from time to time.


### PR DESCRIPTION
Because English is not everybody's native language, some people (like me) may prefer to view a localized version of AMO.
