### PR TITLE
Removes usage of print as log

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -22,8 +22,6 @@
 var log = (function() {
   if ('console' in globalScope && 'log' in globalScope['console']) {
     return globalScope['console']['log'].bind(globalScope['console']);
-  } else if ('print' in globalScope) {
-    return globalScope['print'].bind(globalScope);
   } else {
     return function nop() {
     };

--- a/src/worker.js
+++ b/src/worker.js
@@ -35,6 +35,7 @@ function MessageHandler(name, comObj) {
     }];
   } else {
     ah['console_error'] = [function ahConsoleError(data) {
+      log.apply(null, data);
     }];
   }
   ah['_warn'] = [function ah_Warn(data) {


### PR DESCRIPTION
Using print does not make any sense instead of log. Removing.

Introduced by 0fbbc5a8
