### PR TITLE
Fixes text clipping

### DIFF
--- a/test/pdfs/issue1687.pdf.link
+++ b/test/pdfs/issue1687.pdf.link
@@ -1,0 +1,1 @@
+http://www.karynellis.com/charts/bird/KarynEllisChordChart-BIRD.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -557,6 +557,13 @@
       "link": true,
       "type": "eq"
     },
+    {  "id": "issue1687",
+      "file": "pdfs/issue1687.pdf",
+      "md5": "ea79d83821d1dd0663414b037080add5",
+      "rounds": 1,
+      "link": true,
+      "type": "eq"
+    },
     {  "id": "issue1133",
       "file": "pdfs/issue1133.pdf",
       "md5": "d1b61580cb100e3df93d33703af1773a",


### PR DESCRIPTION
Create text mask layer, temporary replaces current image with the empty canvas, let it draw stuff. And upon restore() applies mask, restores saved image and paints the result. Fixes #1125, #1227, #1687, #1931, #2165, #2201.

@brendandahl, can we use the similar technique for smask/blend?
