### PR TITLE
Increase wait timeout for api unit tests.

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -10,7 +10,7 @@ describe('api', function() {
   function waitsForPromise(promise) {
     waitsFor(function() {
       return promise.isResolved || promise.isRejected;
-    }, 1000);
+    }, 4000);
   }
   function expectAfterPromise(promise, successCallback) {
     waitsForPromise(promise);


### PR DESCRIPTION
Hopefully fixes all the TEST-UNEXPECTED-FAIL | creates pdf doc from URL | in chrome | timeout: timed out after 1000 msec waiting for something to happen in  https://etherpad.mozilla.org/pdfjs-war-on-orange .
