### PR TITLE
Support 'GoToR'-type links

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -306,6 +306,15 @@ var Page = (function PageClosure() {
                 case 'GoTo':
                   item.dest = a.get('D');
                   break;
+                case 'GoToR':
+                  var url = a.get('F');
+                  // TODO: pdf reference says that GoToR
+                  // can also have 'NewWindow' attribute
+                  if (!isValidUrl(url))
+                    url = '';
+                  item.url = url;
+                  item.dest = a.get('D');
+                  break;
                 default:
                   TODO('unrecognized link type: ' + a.get('S').name);
               }


### PR DESCRIPTION
Note the `item.target = target;` code. I was not sure where to go to handle this on the other end, so give me a pointer and I'll implement it.
(Should output as the `target` attribute on an `a` tag).

Don't waste time linting/testing this before I implement that.
