### PR TITLE
add uppercase extension recognition for Chrome

### DIFF
--- a/extensions/chrome/manifest.json
+++ b/extensions/chrome/manifest.json
@@ -7,7 +7,10 @@
     "webRequest", "webRequestBlocking",
     "http://*/*.pdf",
     "https://*/*.pdf",
-    "file:///*/*.pdf"
+    "file:///*/*.pdf",
+    "http://*/*.PDF",
+    "https://*/*.PDF",
+    "file://*/*.PDF"
   ],
   "background": {
     "page": "pdfHandler.html"

--- a/extensions/chrome/pdfHandler.js
+++ b/extensions/chrome/pdfHandler.js
@@ -32,7 +32,10 @@ chrome.webRequest.onBeforeRequest.addListener(
     urls: [
       'http://*/*.pdf',
       'https://*/*.pdf',
-      'file://*/*.pdf'
+      'file://*/*.pdf',
+      'http://*/*.PDF',
+      'https://*/*.PDF',
+      'file://*/*.PDF'
     ],
     types: ['main_frame']
   },


### PR DESCRIPTION
Currently pdf.js works in Chrome only on lowercase *.pdf extensions.  This change will allow for recognition of uppercase *.PDF extensions
