### PR TITLE
Implement NullStream, fixes #1832

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -230,6 +230,9 @@ var Parser = (function ParserClosure() {
       return stream;
     },
     makeFilter: function Parser_makeFilter(stream, name, length, params) {
+      if (stream.dict.get('Length') === 0) {
+        return new NullStream(stream);
+      }
       if (name == 'FlateDecode' || name == 'Fl') {
         if (params) {
           return new PredictorStream(new FlateStream(stream), params);

--- a/src/stream.js
+++ b/src/stream.js
@@ -2350,3 +2350,12 @@ var LZWStream = (function LZWStreamClosure() {
   return LZWStream;
 })();
 
+var NullStream = (function NullStreamClosure() {
+  function NullStream() {
+    Stream.call(this, new Uint8Array(0));
+  }
+
+  NullStream.prototype = Stream.prototype;
+
+  return NullStream;
+})();


### PR DESCRIPTION
As title says, this PR fixes #1832.

The file had a stream, which tried to apply FlateDecode on an empty stream (`/Length 0`):

```
60 0 obj
<<
/Length 0
/LC /iSQP
/Filter /FlateDecode
>>
stream

endstream
endobj
```

This PR just implements a Stream that does nothing - NullStream, which is returned from the `makeFilter` method if the length of the stream is zero.
