### PR TITLE
Cleared some unused code

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -849,10 +849,6 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
 
           x += charWidth;
 
-          var glyphUnicode = glyph.unicode === ' ' ? '\u00A0' : glyph.unicode;
-          if (glyphUnicode in NormalizedUnicodes)
-            glyphUnicode = NormalizedUnicodes[glyphUnicode];
-
           canvasWidth += charWidth;
         }
         current.x += x * textHScale2;


### PR DESCRIPTION
These 4 line do nothing more than consume CPU cycles. I think they were left over when functionality was moved into fontCharsToUnicode()
