### PR TITLE
Change the channel owner to the resource url.

### DIFF
--- a/extensions/firefox/components/PdfStreamConverter.js
+++ b/extensions/firefox/components/PdfStreamConverter.js
@@ -653,7 +653,7 @@ PdfStreamConverter.prototype = {
       var resourcePrincipal = 'getNoAppCodebasePrincipal' in securityManager ?
                               securityManager.getNoAppCodebasePrincipal(uri) :
                               securityManager.getCodebasePrincipal(uri);
-      channel.owner = resourcePrincipal;
+      aRequest.owner = resourcePrincipal;
     }
     channel.asyncOpen(proxy, aContext);
   },


### PR DESCRIPTION
Restores the previous behavior of the viewer running in the context of the resource url instead of the pdf url.
