### PR TITLE
try/catch fallback fails to disable linearization

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -458,6 +458,7 @@ var PDFDocument = (function PDFDocumentClosure() {
         } catch (err) {
           warn('The linearization data is not available ' +
                'or unreadable pdf data is found');
+          linearization = false;
         }
       }
       // shadow the prototype getter with a data property


### PR DESCRIPTION
I've got a bank statement pdf that can't be opened with pdf.js nor the viewer. It gives the warning: "Warning: The linearization data is not available or unreadable pdf data is found", and fails to load.

There is a bug in the linearization getter try/catch, in src/core.js.
Inside the try block for get linearization(), linearization.length could throw an error, but the linearization variable is not reset to false in the catch. Only the warning is emitted.

This is a fix on top of https://github.com/mozilla/pdf.js/pull/1899

Adding the missing line in the catch block fixes rendering for that pdf, for both getDocument, and the web viewer.
