### PR TITLE
Fix cllosure compiler warning for uninitialized variables

### DIFF
--- a/src/function.js
+++ b/src/function.js
@@ -702,8 +702,8 @@ var PostScriptParser = (function PostScriptParserClosure() {
   function PostScriptParser(lexer) {
     this.lexer = lexer;
     this.operators = [];
-    this.token;
-    this.prev;
+    this.token = null;
+    this.prev = null;
   }
   PostScriptParser.prototype = {
     nextToken: function PostScriptParser_nextToken() {


### PR DESCRIPTION
I'm running closure compiler with
--language_in=ECMASCRIPT5
