### PR TITLE
Fix the initialization of the first page for multiple testing rounds.

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -206,7 +206,7 @@ function nextPage(task, loadError) {
   if (isLastPage(task)) {
     if (++task.round < task.rounds) {
       log(' Round ' + (1 + task.round) + '\n');
-      task.pageNum = 1;
+      task.pageNum = task.firstPage || 1;
     } else {
       ++currentTaskIdx;
       nextTask();


### PR DESCRIPTION
Doesn't affect any current tests, but was annoying issue when trying to run a certain page multiple times.
