### PR TITLE
Ensure Type1Parser_extractFontProgram loop counter is not interpreted as a double.

### DIFF
--- a/src/fonts.js
+++ b/src/fonts.js
@@ -4755,7 +4755,9 @@ var Type1Parser = function type1Parser() {
         i += length;
         token = '';
       } else if (isSeparator(c)) {
-        length = parseInt(token, 10);
+        // Use '| 0' to prevent setting a double into length such as the double
+        // does not flow into the loop variable.
+        length = parseInt(token, 10) | 0;
         token = '';
       } else {
         token += c;


### PR DESCRIPTION
This patch improves pure JavaScript performances by 30% by removing double computations from Type1Parser_extractFontProgram. When parseInt is fed with non numerical values, it returns a NaN which flows into the loop counter which cause every operation to be computed as a double and every index to be trunctated as an int before reading a character.  This patch force the NaN value to be coerce as an integer by using a bitwise-or operation with zero.
