### PR TITLE
Bug 815475 - Fix pdfjs when there is no integrated findbar (pdfjs 0.6.39 ...

### DIFF
--- a/extensions/firefox/components/PdfStreamConverter.js
+++ b/extensions/firefox/components/PdfStreamConverter.js
@@ -348,6 +348,7 @@ ChromeActions.prototype = {
     // Integrated find is only supported when we're not in a frame and when the
     // new find events code exists.
     return this.domWindow.frameElement === null &&
+           getChromeWindow(this.domWindow).gFindBar &&
            'updateControlState' in getChromeWindow(this.domWindow).gFindBar;
   },
   fallback: function(url, sendResponse) {


### PR DESCRIPTION
...broke Firefox metro)
