### PR TITLE
Removes "too many inline images" limit

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -330,7 +330,10 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       'setFillCMYKColor': true,
       'paintJpegXObject': true,
       'paintImageXObject': true,
+      'paintInlineImageXObject': true,
+      'paintInlineImageXObjectGroup': true,
       'paintImageMaskXObject': true,
+      'paintImageMaskXObjectGroup': true,
       'shadingFill': true
     },
 

--- a/src/core.js
+++ b/src/core.js
@@ -193,7 +193,9 @@ var Page = (function PageClosure() {
                                 xref, handler, this.pageIndex,
                                 'p' + this.pageIndex + '_');
 
-      return pe.getOperatorList(contentStream, resources, dependency);
+      var list = pe.getOperatorList(contentStream, resources, dependency);
+      pe.optimizeQueue(list);
+      return list;
     },
     extractTextContent: function Page_extractTextContent() {
       var handler = {

--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -298,116 +298,6 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           }, handler, xref, resources, image, inline);
       }
 
-      function optimizeQueue() {
-        // grouping paintInlineImageXObject's into paintInlineImageXObjectGroup
-        // searching for (save, transform, paintInlineImageXObject, restore)+
-        var MIN_IMAGES_COUNT = 10;
-        var MAX_WIDTH = 1000;
-        var IMAGE_PADDING = 1;
-        for (var i = 0, ii = fnArray.length; i < ii; i++) {
-          if (fnArray[i] === 'paintInlineImageXObject' &&
-              fnArray[i - 2] === 'save' && fnArray[i - 1] === 'transform' &&
-              fnArray[i + 1] === 'restore') {
-            var j = i - 2;
-            for (i += 2; i < ii && fnArray[i - 4] === fnArray[i]; i++) {
-            }
-            var count = (i - j) >> 2;
-            if (count < MIN_IMAGES_COUNT) {
-              continue;
-            }
-            // assuming that heights of those image is too small (~1 pixel)
-            // packing as much as possible by lines
-            var maxX = 0;
-            var map = [], maxLineHeight = 0;
-            var currentX = IMAGE_PADDING, currentY = IMAGE_PADDING;
-            for (var q = 0; q < count; q++) {
-              var transform = argsArray[j + (q << 2) + 1];
-              var img = argsArray[j + (q << 2) + 2][0];
-              if (currentX + img.width > MAX_WIDTH) {
-                // starting new line
-                maxX = Math.max(maxX, currentX);
-                currentY += maxLineHeight + 2 * IMAGE_PADDING;
-                currentX = 0;
-                maxLineHeight = 0;
-              }
-              map.push({
-                transform: transform,
-                x: currentX, y: currentY,
-                w: img.width, h: img.height
-              });
-              currentX += img.width + 2 * IMAGE_PADDING;
-              maxLineHeight = Math.max(maxLineHeight, img.height);
-            }
-            var imgWidth = Math.max(maxX, currentX) + IMAGE_PADDING;
-            var imgHeight = currentY + maxLineHeight + IMAGE_PADDING;
-            var imgData = new Uint8Array(imgWidth * imgHeight * 4);
-            var imgRowSize = imgWidth << 2;
-            for (var q = 0; q < count; q++) {
-              var data = argsArray[j + (q << 2) + 2][0].data;
-              // copy image by lines and extends pixels into padding
-              var rowSize = map[q].w << 2;
-              var dataOffset = 0;
-              var offset = (map[q].x + map[q].y * imgWidth) << 2;
-              imgData.set(
-                data.subarray(0, rowSize), offset - imgRowSize);
-              for (var k = 0, kk = map[q].h; k < kk; k++) {
-                imgData.set(
-                  data.subarray(dataOffset, dataOffset + rowSize), offset);
-                dataOffset += rowSize;
-                offset += imgRowSize;
-              }
-              imgData.set(
-                data.subarray(dataOffset - rowSize, dataOffset), offset);
-              while (offset >= 0) {
-                data[offset - 4] = data[offset];
-                data[offset - 3] = data[offset + 1];
-                data[offset - 2] = data[offset + 2];
-                data[offset - 1] = data[offset + 3];
-                data[offset + rowSize] = data[offset + rowSize - 4];
-                data[offset + rowSize + 1] = data[offset + rowSize - 3];
-                data[offset + rowSize + 2] = data[offset + rowSize - 2];
-                data[offset + rowSize + 3] = data[offset + rowSize - 1];
-                offset -= imgRowSize;
-              }
-            }
-            // replacing queue items
-            fnArray.splice(j, count * 4, ['paintInlineImageXObjectGroup']);
-            argsArray.splice(j, count * 4,
-              [{width: imgWidth, height: imgHeight, data: imgData}, map]);
-            i = j;
-            ii = fnArray.length;
-          }
-        }
-        // grouping paintImageMaskXObject's into paintImageMaskXObjectGroup
-        // searching for (save, transform, paintImageMaskXObject, restore)+
-        for (var i = 0, ii = fnArray.length; i < ii; i++) {
-          if (fnArray[i] === 'paintImageMaskXObject' &&
-              fnArray[i - 2] === 'save' && fnArray[i - 1] === 'transform' &&
-              fnArray[i + 1] === 'restore') {
-            var j = i - 2;
-            for (i += 2; i < ii && fnArray[i - 4] === fnArray[i]; i++) {
-            }
-            var count = (i - j) >> 2;
-            if (count < MIN_IMAGES_COUNT) {
-              continue;
-            }
-            var images = [];
-            for (var q = 0; q < count; q++) {
-              var transform = argsArray[j + (q << 2) + 1];
-              var maskParams = argsArray[j + (q << 2) + 2];
-              images.push({data: maskParams[0], width: maskParams[2],
-                height: maskParams[3], transform: transform,
-                inverseDecode: maskParams[1]});
-            }
-            // replacing queue items
-            fnArray.splice(j, count * 4, ['paintImageMaskXObjectGroup']);
-            argsArray.splice(j, count * 4, [images]);
-            i = j;
-            ii = fnArray.length;
-          }
-        }
-      }
-
       if (!queue)
         queue = {};
 
@@ -624,9 +514,123 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         }
       }
 
-      optimizeQueue();
-
       return queue;
+    },
+
+    optimizeQueue: function PartialEvaluator_optimizeQueue(queue) {
+      var fnArray = queue.fnArray, argsArray = queue.argsArray;
+      // grouping paintInlineImageXObject's into paintInlineImageXObjectGroup
+      // searching for (save, transform, paintInlineImageXObject, restore)+
+      var MIN_IMAGES_IN_INLINE_IMAGES_BLOCK = 10;
+      var MAX_IMAGES_IN_INLINE_IMAGES_BLOCK = 200;
+      var MAX_WIDTH = 1000;
+      var IMAGE_PADDING = 1;
+      for (var i = 0, ii = fnArray.length; i < ii; i++) {
+        if (fnArray[i] === 'paintInlineImageXObject' &&
+            fnArray[i - 2] === 'save' && fnArray[i - 1] === 'transform' &&
+            fnArray[i + 1] === 'restore') {
+          var j = i - 2;
+          for (i += 2; i < ii && fnArray[i - 4] === fnArray[i]; i++) {
+          }
+          var count = Math.min((i - j) >> 2,
+                               MAX_IMAGES_IN_INLINE_IMAGES_BLOCK);
+          if (count < MIN_IMAGES_IN_INLINE_IMAGES_BLOCK) {
+            continue;
+          }
+          // assuming that heights of those image is too small (~1 pixel)
+          // packing as much as possible by lines
+          var maxX = 0;
+          var map = [], maxLineHeight = 0;
+          var currentX = IMAGE_PADDING, currentY = IMAGE_PADDING;
+          for (var q = 0; q < count; q++) {
+            var transform = argsArray[j + (q << 2) + 1];
+            var img = argsArray[j + (q << 2) + 2][0];
+            if (currentX + img.width > MAX_WIDTH) {
+              // starting new line
+              maxX = Math.max(maxX, currentX);
+              currentY += maxLineHeight + 2 * IMAGE_PADDING;
+              currentX = 0;
+              maxLineHeight = 0;
+            }
+            map.push({
+              transform: transform,
+              x: currentX, y: currentY,
+              w: img.width, h: img.height
+            });
+            currentX += img.width + 2 * IMAGE_PADDING;
+            maxLineHeight = Math.max(maxLineHeight, img.height);
+          }
+          var imgWidth = Math.max(maxX, currentX) + IMAGE_PADDING;
+          var imgHeight = currentY + maxLineHeight + IMAGE_PADDING;
+          var imgData = new Uint8Array(imgWidth * imgHeight * 4);
+          var imgRowSize = imgWidth << 2;
+          for (var q = 0; q < count; q++) {
+            var data = argsArray[j + (q << 2) + 2][0].data;
+            // copy image by lines and extends pixels into padding
+            var rowSize = map[q].w << 2;
+            var dataOffset = 0;
+            var offset = (map[q].x + map[q].y * imgWidth) << 2;
+            imgData.set(
+              data.subarray(0, rowSize), offset - imgRowSize);
+            for (var k = 0, kk = map[q].h; k < kk; k++) {
+              imgData.set(
+                data.subarray(dataOffset, dataOffset + rowSize), offset);
+              dataOffset += rowSize;
+              offset += imgRowSize;
+            }
+            imgData.set(
+              data.subarray(dataOffset - rowSize, dataOffset), offset);
+            while (offset >= 0) {
+              data[offset - 4] = data[offset];
+              data[offset - 3] = data[offset + 1];
+              data[offset - 2] = data[offset + 2];
+              data[offset - 1] = data[offset + 3];
+              data[offset + rowSize] = data[offset + rowSize - 4];
+              data[offset + rowSize + 1] = data[offset + rowSize - 3];
+              data[offset + rowSize + 2] = data[offset + rowSize - 2];
+              data[offset + rowSize + 3] = data[offset + rowSize - 1];
+              offset -= imgRowSize;
+            }
+          }
+          // replacing queue items
+          fnArray.splice(j, count * 4, ['paintInlineImageXObjectGroup']);
+          argsArray.splice(j, count * 4,
+            [{width: imgWidth, height: imgHeight, data: imgData}, map]);
+          i = j;
+          ii = fnArray.length;
+        }
+      }
+      // grouping paintImageMaskXObject's into paintImageMaskXObjectGroup
+      // searching for (save, transform, paintImageMaskXObject, restore)+
+      var MIN_IMAGES_IN_MASKS_BLOCK = 10;
+      var MAX_IMAGES_IN_MASKS_BLOCK = 100;
+      for (var i = 0, ii = fnArray.length; i < ii; i++) {
+        if (fnArray[i] === 'paintImageMaskXObject' &&
+            fnArray[i - 2] === 'save' && fnArray[i - 1] === 'transform' &&
+            fnArray[i + 1] === 'restore') {
+          var j = i - 2;
+          for (i += 2; i < ii && fnArray[i - 4] === fnArray[i]; i++) {
+          }
+          var count = Math.min((i - j) >> 2,
+                               MAX_IMAGES_IN_MASKS_BLOCK);
+          if (count < MIN_IMAGES_IN_MASKS_BLOCK) {
+            continue;
+          }
+          var images = [];
+          for (var q = 0; q < count; q++) {
+            var transform = argsArray[j + (q << 2) + 1];
+            var maskParams = argsArray[j + (q << 2) + 2];
+            images.push({data: maskParams[0], width: maskParams[2],
+              height: maskParams[3], transform: transform,
+              inverseDecode: maskParams[1]});
+          }
+          // replacing queue items
+          fnArray.splice(j, count * 4, ['paintImageMaskXObjectGroup']);
+          argsArray.splice(j, count * 4, [images]);
+          i = j;
+          ii = fnArray.length;
+        }
+      }
     },
 
     getTextContent: function PartialEvaluator_getTextContent(

--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -260,14 +260,27 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           return;
         }
 
+        var softMask = dict.get('SMask', 'SM') || false;
+        var mask = dict.get('Mask') || false;
+
+        var SMALL_IMAGE_DIMENSIONS = 200;
+        // Inlining small images into the queue as RGB data
+        if (inline && !softMask && !mask &&
+            !(image instanceof JpegStream) &&
+            (w + h) < SMALL_IMAGE_DIMENSIONS) {
+          var imageObj = new PDFImage(xref, resources, image,
+                                      inline, null, null);
+          var imgData = imageObj.getImageData();
+          fn = 'paintInlineImageXObject';
+          args = [imgData];
+          return;
+        }
+
         // If there is no imageMask, create the PDFImage and a lot
         // of image processing can be done here.
         var objId = 'img_' + uniquePrefix + (++self.objIdCounter);
         insertDependency([objId]);
         args = [objId, w, h];
-
-        var softMask = dict.get('SMask', 'SM') || false;
-        var mask = dict.get('Mask') || false;
 
         if (!softMask && !mask && image instanceof JpegStream &&
             image.isNativelySupported(xref, resources)) {
@@ -280,17 +293,119 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         fn = 'paintImageXObject';
 
         PDFImage.buildImage(function(imageObj) {
-            var drawWidth = imageObj.drawWidth;
-            var drawHeight = imageObj.drawHeight;
-            var imgData = {
-              width: drawWidth,
-              height: drawHeight,
-              data: new Uint8Array(drawWidth * drawHeight * 4)
-            };
-            var pixels = imgData.data;
-            imageObj.fillRgbaBuffer(pixels, drawWidth, drawHeight);
+            var imgData = imageObj.getImageData();
             handler.send('obj', [objId, pageIndex, 'Image', imgData]);
           }, handler, xref, resources, image, inline);
+      }
+
+      function optimizeQueue() {
+        // grouping paintInlineImageXObject's into paintInlineImageXObjectGroup
+        // searching for (save, transform, paintInlineImageXObject, restore)+
+        var MIN_IMAGES_COUNT = 10;
+        var MAX_WIDTH = 1000;
+        var IMAGE_PADDING = 1;
+        for (var i = 0, ii = fnArray.length; i < ii; i++) {
+          if (fnArray[i] === 'paintInlineImageXObject' &&
+              fnArray[i - 2] === 'save' && fnArray[i - 1] === 'transform' &&
+              fnArray[i + 1] === 'restore') {
+            var j = i - 2;
+            for (i += 2; i < ii && fnArray[i - 4] === fnArray[i]; i++) {
+            }
+            var count = (i - j) >> 2;
+            if (count < MIN_IMAGES_COUNT) {
+              continue;
+            }
+            // assuming that heights of those image is too small (~1 pixel)
+            // packing as much as possible by lines
+            var maxX = 0;
+            var map = [], maxLineHeight = 0;
+            var currentX = IMAGE_PADDING, currentY = IMAGE_PADDING;
+            for (var q = 0; q < count; q++) {
+              var transform = argsArray[j + (q << 2) + 1];
+              var img = argsArray[j + (q << 2) + 2][0];
+              if (currentX + img.width > MAX_WIDTH) {
+                // starting new line
+                maxX = Math.max(maxX, currentX);
+                currentY += maxLineHeight + 2 * IMAGE_PADDING;
+                currentX = 0;
+                maxLineHeight = 0;
+              }
+              map.push({
+                transform: transform,
+                x: currentX, y: currentY,
+                w: img.width, h: img.height
+              });
+              currentX += img.width + 2 * IMAGE_PADDING;
+              maxLineHeight = Math.max(maxLineHeight, img.height);
+            }
+            var imgWidth = Math.max(maxX, currentX) + IMAGE_PADDING;
+            var imgHeight = currentY + maxLineHeight + IMAGE_PADDING;
+            var imgData = new Uint8Array(imgWidth * imgHeight * 4);
+            var imgRowSize = imgWidth << 2;
+            for (var q = 0; q < count; q++) {
+              var data = argsArray[j + (q << 2) + 2][0].data;
+              // copy image by lines and extends pixels into padding
+              var rowSize = map[q].w << 2;
+              var dataOffset = 0;
+              var offset = (map[q].x + map[q].y * imgWidth) << 2;
+              imgData.set(
+                data.subarray(0, rowSize), offset - imgRowSize);
+              for (var k = 0, kk = map[q].h; k < kk; k++) {
+                imgData.set(
+                  data.subarray(dataOffset, dataOffset + rowSize), offset);
+                dataOffset += rowSize;
+                offset += imgRowSize;
+              }
+              imgData.set(
+                data.subarray(dataOffset - rowSize, dataOffset), offset);
+              while (offset >= 0) {
+                data[offset - 4] = data[offset];
+                data[offset - 3] = data[offset + 1];
+                data[offset - 2] = data[offset + 2];
+                data[offset - 1] = data[offset + 3];
+                data[offset + rowSize] = data[offset + rowSize - 4];
+                data[offset + rowSize + 1] = data[offset + rowSize - 3];
+                data[offset + rowSize + 2] = data[offset + rowSize - 2];
+                data[offset + rowSize + 3] = data[offset + rowSize - 1];
+                offset -= imgRowSize;
+              }
+            }
+            // replacing queue items
+            fnArray.splice(j, count * 4, ['paintInlineImageXObjectGroup']);
+            argsArray.splice(j, count * 4,
+              [{width: imgWidth, height: imgHeight, data: imgData}, map]);
+            i = j;
+            ii = fnArray.length;
+          }
+        }
+        // grouping paintImageMaskXObject's into paintImageMaskXObjectGroup
+        // searching for (save, transform, paintImageMaskXObject, restore)+
+        for (var i = 0, ii = fnArray.length; i < ii; i++) {
+          if (fnArray[i] === 'paintImageMaskXObject' &&
+              fnArray[i - 2] === 'save' && fnArray[i - 1] === 'transform' &&
+              fnArray[i + 1] === 'restore') {
+            var j = i - 2;
+            for (i += 2; i < ii && fnArray[i - 4] === fnArray[i]; i++) {
+            }
+            var count = (i - j) >> 2;
+            if (count < MIN_IMAGES_COUNT) {
+              continue;
+            }
+            var images = [];
+            for (var q = 0; q < count; q++) {
+              var transform = argsArray[j + (q << 2) + 1];
+              var maskParams = argsArray[j + (q << 2) + 2];
+              images.push({data: maskParams[0], width: maskParams[2],
+                height: maskParams[3], transform: transform,
+                inverseDecode: maskParams[1]});
+            }
+            // replacing queue items
+            fnArray.splice(j, count * 4, ['paintImageMaskXObjectGroup']);
+            argsArray.splice(j, count * 4, [images]);
+            i = j;
+            ii = fnArray.length;
+          }
+        }
       }
 
       if (!queue)
@@ -508,6 +623,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           args.push(obj instanceof Dict ? obj.getAll() : obj);
         }
       }
+
+      optimizeQueue();
 
       return queue;
     },

--- a/src/image.js
+++ b/src/image.js
@@ -433,6 +433,18 @@ var PDFImage = (function PDFImageClosure() {
       for (var i = 0; i < length; ++i)
         buffer[i] = (scale * comps[i]) | 0;
     },
+    getImageData: function PDFImage_getImageData() {
+      var drawWidth = this.drawWidth;
+      var drawHeight = this.drawHeight;
+      var imgData = {
+        width: drawWidth,
+        height: drawHeight,
+        data: new Uint8Array(drawWidth * drawHeight * 4)
+      };
+      var pixels = imgData.data;
+      this.fillRgbaBuffer(pixels, drawWidth, drawHeight);
+      return imgData;
+    },
     getImageBytes: function PDFImage_getImageBytes(length) {
       this.image.reset();
       return this.image.getBytes(length);

--- a/src/parser.js
+++ b/src/parser.js
@@ -28,7 +28,6 @@ var Parser = (function ParserClosure() {
     this.lexer = lexer;
     this.allowStreams = allowStreams;
     this.xref = xref;
-    this.inlineImg = 0;
     this.refill();
   }
 
@@ -151,15 +150,6 @@ var Parser = (function ParserClosure() {
             state = 0;
             break;
         }
-      }
-
-      // TODO improve the small images performance to remove the limit
-      var inlineImgLimit = 500;
-      if (++this.inlineImg >= inlineImgLimit) {
-        if (this.inlineImg === inlineImgLimit)
-          warn('Too many inline images');
-        this.shift();
-        return null;
       }
 
       var length = (stream.pos - 4) - startPos;

--- a/src/stream.js
+++ b/src/stream.js
@@ -19,7 +19,8 @@
 
 var Stream = (function StreamClosure() {
   function Stream(arrayBuffer, start, length, dict) {
-    this.bytes = new Uint8Array(arrayBuffer);
+    this.bytes = arrayBuffer instanceof Uint8Array ? arrayBuffer :
+      new Uint8Array(arrayBuffer);
     this.start = start || 0;
     this.pos = this.start;
     this.end = (start + length) || this.bytes.length;


### PR DESCRIPTION
Shall fix #591, #2108, #2408, and #2416.

The patch:
1. Introduces paintInlineImageXObject to avoid worker->main thread->worker->main thread exchange for small images;
2. Groups the sequence of the following commands:

```
q 4.16667 0 0 4.16667 545.832 3125 cm
BI
/CS/RGB
/W 1
/H 1
/BPC 8
ID <<bindata>>
EI Q
```

into single paintInlineImageXObjectGroup command with big image constructed by packing small inline images into one.
