### PR TITLE
Tests presence of the xhr-response in the worker

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -152,7 +152,19 @@ var WorkerMessageHandler = {
     }
 
     handler.on('test', function wphSetupTest(data) {
-      handler.send('test', data instanceof Uint8Array);
+      // check if Uint8Array can be sent to worker
+      if (!(data instanceof Uint8Array)) {
+        handler.send('test', false);
+        return;
+      }
+      // check if the response property is supported by xhr
+      var xhr = new XMLHttpRequest();
+      if (!('response' in xhr || 'mozResponse' in xhr ||
+          'responseArrayBuffer' in xhr || 'mozResponseArrayBuffer' in xhr)) {
+        handler.send('test', false);
+        return;
+      }
+      handler.send('test', true);
     });
 
     handler.on('GetDocRequest', function wphSetupDoc(data) {

--- a/test/features/tests.js
+++ b/test/features/tests.js
@@ -512,6 +512,37 @@ var tests = [
     },
     impact: 'Important',
     area: 'Core'
+  },
+  {
+    id: 'Worker-xhr-response',
+    name: 'XMLHttpRequest supports the reponse property in web workers',
+    run: function () {
+      if (typeof Worker == 'undefined')
+        return { output: 'Skipped', emulated: '' };
+
+     try {
+        var worker = new Worker('worker-stub.js');
+
+        var promise = new Promise();
+        var timeout = setTimeout(function () {
+          promise.resolve({ output: 'Failed', emulated: '?' });
+        }, 5000);
+
+        worker.addEventListener('message', function (e) {
+          var data = e.data;
+          if (data.action == 'xhr' && data.result)
+            promise.resolve({ output: 'Success', emulated: '' });
+          else
+            promise.resolve({ output: 'Failed', emulated: 'Yes' });
+        });
+        worker.postMessage({action: 'xhr'});
+        return promise;
+      } catch (e) {
+        return { output: 'Failed', emulated: 'Yes' };
+      }
+    },
+    impact: 'Important',
+    area: 'Core'
   }
 ];
 

--- a/test/features/worker-stub.js
+++ b/test/features/worker-stub.js
@@ -17,7 +17,16 @@
 
 onmessage = function (e) {
   var data = e.data;
-  postMessage({action: 'test', result: data.action == 'test' &&
-                                       data.data instanceof Uint8Array});
+  switch (data.action) {
+  case 'test':
+    postMessage({action: 'test', result: data.data instanceof Uint8Array});
+    break;
+  case 'xhr':
+    var xhr = new XMLHttpRequest();
+    var responseExists = 'response' in xhr || 'mozResponse' in xhr ||
+        'responseArrayBuffer' in xhr || 'mozResponseArrayBuffer' in xhr;
+    postMessage({action: 'xhr', result: responseExists});
+    break;
+  }
 };
 


### PR DESCRIPTION
makes firefox 9 work again (at least for web viewer)
