### PR TITLE
Support filespec dictionary in annotations

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -286,6 +286,12 @@ var Page = (function PageClosure() {
                   break;
                 case 'GoToR':
                   var url = a.get('F');
+                  if (isDict(url)) {
+                    // We assume that the 'url' is a Filspec dictionary
+                    // and fetch the url without checking any further
+                    url = url.get('F') || '';
+                  }
+
                   // TODO: pdf reference says that GoToR
                   // can also have 'NewWindow' attribute
                   if (!isValidUrl(url))


### PR DESCRIPTION
Until now we haven't supported full Filespec dictionaries in different links. We assumed they were the URL string.

In a sample document send by a user Sudcheer in the mailing list, a full Filespec dictionary was used. This simply adds support for it in GoToR annotations.
