### PR TITLE
 Fix margin on toolbar button separator

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -521,7 +521,7 @@ html[dir='rtl'] .splitToolbarButtonSeparator {
 .splitToolbarButton:hover > .splitToolbarButtonSeparator,
 .splitToolbarButton.toggled > .splitToolbarButtonSeparator {
   padding: 12px 0;
-  margin: 0;
+  margin: 1px 0;
   box-shadow: 0 0 0 1px hsla(0,0%,100%,.03);
   -webkit-transition-property: padding;
   -webkit-transition-duration: 10ms;


### PR DESCRIPTION
 Fix margin on toolbar button separator to avoid changing height on hover, causing jittering.

See https://bugzilla.mozilla.org/show_bug.cgi?id=816697
