### PR TITLE
Add partial support for "search=" URL parameter

### DIFF
--- a/extensions/firefox/components/PdfStreamConverter.js
+++ b/extensions/firefox/components/PdfStreamConverter.js
@@ -444,6 +444,18 @@ ChromeActions.prototype = {
     }
     getChromeWindow(this.domWindow).gFindBar
                                    .updateControlState(result, findPrevious);
+  },
+  searchWithIntegratedFindBar: function(phrase, highlightAll) {
+    if (!this.supportsIntegratedFind()) {
+      return;
+    }
+    var fBar = getChromeWindow(this.domWindow).gFindBar;
+    fBar._findField.value = phrase;
+    fBar._setCaseSensitivity(false);
+    if (phrase && highlightAll) {
+      fBar.getElement('highlight').click();
+    }
+    fBar.onFindCommand();
   }
 };
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1492,6 +1492,32 @@ var PDFView = {
           this.page = pageNumber; // simple page
         }
       }
+      if ('search' in params) {
+        // pdf.js currently implements this as a phrase search,
+        // i.e. specifying the URL parameter as: #search="word1 word2"
+        // will perform a search for the whole string "word1 word2".
+
+        var phrase = params.search.replace(/[\"]/g, '');
+        if (!PDFView.supportsIntegratedFind) {
+          var fBar = PDFFindBar;
+          fBar.findField.value = phrase;
+          fBar.caseSensitive.checked = false;
+          if (phrase) {
+            fBar.highlightAll.checked = true;
+            fBar.dispatchEvent('');
+            fBar.findField.blur();
+          } else {
+            fBar.highlightAll.checked = false;
+            fBar.dispatchEvent('highlightallchange');
+          }
+          fBar.open();
+          fBar.findField.select();
+        } else {
+          // searchWithIntegratedFindBar(phrase {String},
+          //                             highlightAll {Boolean})
+          FirefoxCom.request('searchWithIntegratedFindBar', phrase, true);
+        }
+      }
     } else if (/^\d+$/.test(hash)) // page number
       this.page = hash;
     else // named destination


### PR DESCRIPTION
Addresses #1875 according to the discussion in the thread.
This patch adds the URL parameter `#search=phrase`, with the following interpretation:

> Opens the Search UI and performs a search for the specified ~~word list~~ _phrase_ in the document. Matching words are highlighted in the document.
> The ~~words~~ _phrase_ ~~must~~ _may_ be enclosed in quotes ~~and separated by spaces; for example:
> # search=”word1 word2”~~

For reference, see http://partners.adobe.com/public/developer/en/acrobat/PDFOpenParameters.pdf#page=7
