### PR TITLE
Avoid creating new shapes due to initialization order of privateData.

### DIFF
--- a/src/fonts.js
+++ b/src/fonts.js
@@ -4836,8 +4836,22 @@ var Type1Parser = function type1Parser() {
       subrs: [],
       charstrings: [],
       properties: {
-        'privateData': {
-          'lenIV': 4
+        privateData: {
+          lenIV: 4,
+          BlueValues: null,
+          OtherBlues: null,
+          FamilyBlues: null,
+          FamilyOtherBlues: null,
+          StemSnapH: null,
+          StemSnapV: null,
+          StdHW: null,
+          StdVW: null,
+          BlueShift: null,
+          BlueFuzz: null,
+          BlueScale: null,
+          LanguageGroup: null,
+          ExpansionFactor: null,
+          ForceBold: null
         }
       }
     };
@@ -5270,7 +5284,7 @@ Type1Font.prototype = {
     ];
     for (var i = 0, ii = fields.length; i < ii; i++) {
       var field = fields[i];
-      if (!properties.privateData.hasOwnProperty(field))
+      if (properties.privateData[field] === null)
         continue;
       privateDict.setByName(field, properties.privateData[field]);
     }


### PR DESCRIPTION
The privateData object got a shape when it is created.  Everytime a command is read out-of the stream a property might be added to the privateData object.  Due to legacy issues, JS engines have to keep the order of initialization of the shapes.  As the order is not defined, any field might appear in any order, thus creating a different shape each time.

This cause a few performance / memory issues because of the allocation of new shapes every time consume a bit of  space, but it also cause the engine to create different inline caches for properties such as lenIV.

The fonttest are not running on my computer.  Checking by hand with “make.js server” highlight to bad result on the “tracemonkey” paper related to the merge pull request #2493.  I guess it would be best to merge this pull request after fixing fonts issues.
