### PR TITLE
Make sure downloaded files have a ".pdf" extension

### DIFF
--- a/extensions/firefox/components/PdfStreamConverter.js
+++ b/extensions/firefox/components/PdfStreamConverter.js
@@ -232,10 +232,26 @@ ChromeActions.prototype = {
     return docIsPrivate;
   },
   download: function(data, sendResponse) {
-    var originalUrl = data.originalUrl;
+    var url = data.originalUrl;
+    var ios = Services.io;
+    var ch = ios.newChannel(data.originalUrl, null, null);
+    var header = ch.getResponseHeader('Content-Disposition').split(';');
+    var fileName = null;
+    for (var i = 0; i < header.length; i++) {
+      if (header[i].trim().indexOf('filename') === 0) {
+        fileName = header[i].substr(header[i].indexOf('=') + 1);
+      }
+    }
+    if (fileName != null) {
+      url = fileName;
+    } else {
+      // Append .pdf to the filename if it isn't already there
+      url += (url.toLowerCase().indexOf('.pdf', url.length - 4) !== -1) ?
+        '.pdf' : '';
+    }
     // The data may not be downloaded so we need just retry getting the pdf with
     // the original url.
-    var originalUri = NetUtil.newURI(data.originalUrl);
+    var originalUri = NetUtil.newURI(url);
     var blobUri = data.blobUrl ? NetUtil.newURI(data.blobUrl) : originalUri;
     var extHelperAppSvc =
           Cc['@mozilla.org/uriloader/external-helper-app-service;1'].

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1024,6 +1024,9 @@ var PDFView = {
 //    function getDataSuccess(data) {
 //      var blob = PDFJS.createBlob(data.buffer, 'application/pdf');
 //      var blobUrl = window.URL.createObjectURL(blob);
+//      // Append .pdf to the filename if it isn't already there
+//      url += (url.toLowerCase().indexOf('.pdf', url.length - 4) !== -1)
+//        ? '.pdf' : '';
 //
 //      FirefoxCom.request('download', { blobUrl: blobUrl, originalUrl: url },
 //        function response(err) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1024,9 +1024,6 @@ var PDFView = {
 //    function getDataSuccess(data) {
 //      var blob = PDFJS.createBlob(data.buffer, 'application/pdf');
 //      var blobUrl = window.URL.createObjectURL(blob);
-//      // Append .pdf to the filename if it isn't already there
-//      url += (url.toLowerCase().indexOf('.pdf', url.length - 4) !== -1)
-//        ? '.pdf' : '';
 //
 //      FirefoxCom.request('download', { blobUrl: blobUrl, originalUrl: url },
 //        function response(err) {


### PR DESCRIPTION
Partially addresses #2407. I couldn't find a way to get the HTTP headers without sending an `XMLHttpRequest` and reading the headers sent back, but there are plenty of reasons to NOT do that.

This patch simply ensures there is a `.pdf` extension on the file (e.g if you are at a URL that ends in .php because a PHP script generated the PDF, this adds a .pdf to the file, so it is .php.pdf)
