### PR TITLE
Evaluate type 1 charstrings for conversion to type 2.

### DIFF
--- a/test/pdfs/issue1936.pdf.link
+++ b/test/pdfs/issue1936.pdf.link
@@ -1,0 +1,2 @@
+http://sci2s.ugr.es/keel/pdf/specific/articulo/alp99.pdf
+

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -776,6 +776,14 @@
       "link": true,
       "type": "eq"
     },
+    {  "id": "issue1936",
+      "file": "pdfs/issue1936.pdf",
+      "md5": "7302eb9b6a626308e2a933aaed9e1756",
+      "rounds": 1,
+      "pageLimit": 1,
+      "link": true,
+      "type": "eq"
+    },
     {  "id": "issue2337",
       "file": "pdfs/issue2337.pdf",
       "md5": "ea10f4131202b9b8f2a6cb7770d3f185",


### PR DESCRIPTION
Fixes #1936 and #2536

Locally on OSX the following changed:
TEST-UNEXPECTED-FAIL | eq fit11-talk | in firefoxaurora | rendering of page 8 != reference rendering
TEST-UNEXPECTED-FAIL | eq fit11-talk | in firefoxaurora | rendering of page 10 != reference rendering
TEST-UNEXPECTED-FAIL | eq fit11-talk | in firefoxaurora | rendering of page 11 != reference rendering
