### PR TITLE
Support corrupted pdfs that are encrypted but lack 'ID' in trailer

### DIFF
--- a/src/obj.js
+++ b/src/obj.js
@@ -342,8 +342,9 @@ var XRef = (function XRefClosure() {
 
     var encrypt = trailerDict.get('Encrypt');
     if (encrypt) {
-      var fileId = trailerDict.get('ID');
-      this.encrypt = new CipherTransformFactory(encrypt, fileId[0], password);
+      var ids = trailerDict.get('ID');
+      var fileId = (ids && ids.length) ? ids[0] : '';
+      this.encrypt = new CipherTransformFactory(encrypt, fileId, password);
     }
 
     // get the root dictionary (catalog) object


### PR DESCRIPTION
Fixes #2085.

Couldn't include the test pdf since the link has some kind of timeout mechanism on it.
