### PR TITLE
Default to a built-in font if an invalid non-embedded font is encountered

### DIFF
--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -1089,9 +1089,30 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       properties.widths = glyphsWidths;
     },
 
+    isSerifFont: function PartialEvaluator_isSerifFont(baseFontName) {
+
+      // Simulating descriptor flags attribute
+      var fontNameWoStyle = baseFontName.split('-')[0];
+      return (fontNameWoStyle in serifFonts) ||
+          (fontNameWoStyle.search(/serif/gi) !== -1);
+    },
+
     getBaseFontMetrics: function PartialEvaluator_getBaseFontMetrics(name) {
       var defaultWidth = 0, widths = [], monospace = false;
-      var glyphWidths = Metrics[stdFontMap[name] || name];
+
+      var lookupName = stdFontMap[name] || name;
+
+      if (!(lookupName in Metrics)) {
+        // Use default fonts for looking up font metrics if the passed
+        // font is not a base font
+        if (this.isSerifFont(name)) {
+          lookupName = 'Times-Roman';
+        } else {
+          lookupName = 'Helvetica';
+        }
+      }
+      var glyphWidths = Metrics[lookupName];
+
       if (isNum(glyphWidths)) {
         defaultWidth = glyphWidths;
         monospace = true;
@@ -1153,8 +1174,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
           // Simulating descriptor flags attribute
           var fontNameWoStyle = baseFontName.split('-')[0];
-          var flags = (serifFonts[fontNameWoStyle] ||
-            (fontNameWoStyle.search(/serif/gi) != -1) ? FontFlags.Serif : 0) |
+          var flags = (
+            this.isSerifFont(fontNameWoStyle) ? FontFlags.Serif : 0) |
             (metrics.monospace ? FontFlags.FixedPitch : 0) |
             (symbolsFonts[fontNameWoStyle] ? FontFlags.Symbolic :
             FontFlags.Nonsymbolic);

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -2,6 +2,7 @@
 
 !tracemonkey.pdf
 !issue2391-1.pdf
+!issue2391-2.pdf
 !ArabicCIDTrueType.pdf
 !ThuluthFeatures.pdf
 !arial_unicode_ab_cidfont.pdf

--- a/test/pdfs/issue2391-2.pdf
+++ b/test/pdfs/issue2391-2.pdf
@@ -1,0 +1,130 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj 
+<<
+/Pages 2 0 R
+/Metadata 3 0 R
+/Type /Catalog
+>>
+endobj 
+2 0 obj 
+<<
+/Kids [4 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+4 0 obj 
+<<
+/Rotate 0
+/Parent 2 0 R
+/Resources 
+<<
+/ExtGState 5 0 R
+/Font 6 0 R
+/ProcSet [/PDF /Text]
+>>
+/MediaBox [0 0 595 842]
+/Contents 7 0 R
+/Type /Page
+>>
+endobj 
+7 0 obj 
+<<
+/Length 121
+>>
+stream
+q 0.1 0 0 0.1 0 0 cm
+/R7 gs
+0 g
+q
+10 0 0 10 0 0 cm BT
+/R8 10 Tf
+1 0 0 1 29 805 Tm
+(test non-existant base font)Tj
+ET
+Q
+Q
+
+endstream 
+endobj 
+8 0 obj 
+<<
+/Type /ExtGState
+/OPM 1
+>>
+endobj 
+9 0 obj 
+<<
+/BaseFont /Monaco
+/Subtype /Type1
+/Type /Font
+>>
+endobj 
+5 0 obj 
+<<
+/R7 8 0 R
+>>
+endobj 
+6 0 obj 
+<<
+/R8 9 0 R
+>>
+endobj 
+3 0 obj 
+<<
+/Subtype /XML
+/Length 1421
+/Type /Metadata
+>>
+stream
+<?xpacket begin='Ôªø' id='W5M0MpCehiHzreSzNTczkc9d'?>
+<?adobe-xap-filters esc="CRLF"?>
+<x:xmpmeta xmlns:x='adobe:ns:meta/' x:xmptk='XMP toolkit 2.9.1-13, framework 1.6'>
+<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:iX='http://ns.adobe.com/iX/1.0/'>
+<rdf:Description rdf:about='uuid:5da849aa-943d-11ed-0000-29e0e127fe1e' xmlns:pdf='http://ns.adobe.com/pdf/1.3/' pdf:Producer='GPL Ghostscript 9.05'/>
+<rdf:Description rdf:about='uuid:5da849aa-943d-11ed-0000-29e0e127fe1e' xmlns:xmp='http://ns.adobe.com/xap/1.0/'><xmp:ModifyDate>2013-01-11T10:57:59-08:00</xmp:ModifyDate>
+<xmp:CreateDate>2013-01-11T10:57:59-08:00</xmp:CreateDate>
+<xmp:CreatorTool>GNU Enscript 1.6.6</xmp:CreatorTool></rdf:Description>
+<rdf:Description rdf:about='uuid:5da849aa-943d-11ed-0000-29e0e127fe1e' xmlns:xapMM='http://ns.adobe.com/xap/1.0/mm/' xapMM:DocumentID='uuid:5da849aa-943d-11ed-0000-29e0e127fe1e'/>
+<rdf:Description rdf:about='uuid:5da849aa-943d-11ed-0000-29e0e127fe1e' xmlns:dc='http://purl.org/dc/elements/1.1/' dc:format='application/pdf'><dc:title><rdf:Alt><rdf:li xml:lang='x-default'>Enscript Output</rdf:li></rdf:Alt></dc:title><dc:creator><rdf:Seq><rdf:li>Mack Duan</rdf:li></rdf:Seq></dc:creator></rdf:Description>
+</rdf:RDF>
+</x:xmpmeta>
+                                                                        
+                                                                        
+<?xpacket end='w'?>
+endstream 
+endobj 
+10 0 obj 
+<<
+/Creator (GNU Enscript 1.6.6)
+/Title (Enscript Output)
+/Producer (GPL Ghostscript 9.05)
+/Author (Mack Duan)
+/ModDate (D:20130111105759-08'00')
+/CreationDate (D:20130111105759-08'00')
+>>
+endobj xref
+0 11
+0000000000 65535 f 
+0000000015 00000 n 
+0000000082 00000 n 
+0000000666 00000 n 
+0000000141 00000 n 
+0000000600 00000 n 
+0000000633 00000 n 
+0000000309 00000 n 
+0000000484 00000 n 
+0000000531 00000 n 
+0000002172 00000 n 
+trailer
+
+<<
+/Info 10 0 R
+/Root 1 0 R
+/Size 11
+/ID [<2eee0bd94f14c7014ff602c9df19ad9a> <2eee0bd94f14c7014ff602c9df19ad9a>]
+>>
+startxref
+2378
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -24,6 +24,12 @@
       "pageLimit": 1,
       "type": "load"
     },
+    {  "id": "issue2391-2",
+      "file": "pdfs/issue2391-2.pdf",
+      "md5": "7e68756d11021a087383eaac95ba45dd",
+      "rounds": 1,
+      "type": "eq"
+    },
     {  "id": "html5-canvas-cheat-sheet-load",
        "file": "pdfs/canvas.pdf",
        "md5": "59510028561daf62e00bf9f6f066b033",


### PR DESCRIPTION
Partially fixed #2391 by defaulting to a built-in font is an invalid non-embedded font is encountered.
