### PR TITLE
Fix a problem about Japanese PDFs without embedded fonts

### DIFF
--- a/l10n/ja/viewer.properties
+++ b/l10n/ja/viewer.properties
@@ -86,9 +86,9 @@ find_not_found=見つかりませんでした。
 error_more_info=詳細情報
 error_less_info=詳細情報の非表示
 error_close=閉じる
-# LOCALIZATION NOTE (error_build): "{{build}}" will be replaced by the PDF.JS
-# build ID.
-error_build=PDF.JS Build: {{build}}
+# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
+# replaced by the PDF.JS version and build ID.
+error_version_info=PDF.js v{{version}} (ビルド: {{build}})
 # LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
 # english string describing the error.
 error_message=メッセージ: {{message}}

--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -791,6 +791,10 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           };
         }
 
+        var cidEncoding = baseDict.get('Encoding');
+        if (isName(cidEncoding))
+          properties.cidEncoding = cidEncoding.name;
+
         var cidToGidMap = dict.get('CIDToGIDMap');
         if (isStream(cidToGidMap))
           properties.cidToGidMap = this.readCidToGidMap(cidToGidMap);

--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -791,6 +791,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           };
         }
 
+        var cidEncoding = baseDict.get('Encoding');
+        properties.cidEncoding = cidEncoding && cidEncoding.name;
+
         var cidToGidMap = dict.get('CIDToGIDMap');
         if (isStream(cidToGidMap))
           properties.cidToGidMap = this.readCidToGidMap(cidToGidMap);

--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -792,7 +792,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         }
 
         var cidEncoding = baseDict.get('Encoding');
-        properties.cidEncoding = cidEncoding && cidEncoding.name;
+        if (isName(cidEncoding))
+          properties.cidEncoding = cidEncoding.name;
 
         var cidToGidMap = dict.get('CIDToGIDMap');
         if (isStream(cidToGidMap))

--- a/src/fonts.js
+++ b/src/fonts.js
@@ -4129,7 +4129,10 @@ var Font = (function FontClosure() {
 
       var cidEncoding = properties.cidEncoding;
       if (cidEncoding && cidEncoding.indexOf('Uni') === 0) {
-        // input is already Unicode for Uni* CMap encodings
+        // input is already Unicode for Uni* CMap encodings.
+        // However, Unicode-to-CID conversion is needed
+        // regardless of the CMap encoding. So we can't reset
+        // unicodeToCID.
         this.cidToUnicode = [];
       }
     },

--- a/src/fonts.js
+++ b/src/fonts.js
@@ -4128,7 +4128,7 @@ var Font = (function FontClosure() {
       }
 
       var cidEncoding = properties.cidEncoding;
-      if (cidEncoding && cidEncoding.substring(0, 3) == 'Uni') {
+      if (cidEncoding && cidEncoding.indexOf('Uni') === 0) {
         // input is already Unicode for Uni* CMap encodings
         this.cidToUnicode = [];
       }

--- a/src/fonts.js
+++ b/src/fonts.js
@@ -4205,16 +4205,12 @@ var Font = (function FontClosure() {
         case 'CIDFontType0':
           if (this.noUnicodeAdaptation) {
             width = this.widths[this.unicodeToCID[charcode] || charcode];
-            fontCharCode = mapPrivateUseChars(charcode);
-            break;
           }
           fontCharCode = this.toFontChar[charcode] || charcode;
           break;
         case 'CIDFontType2':
           if (this.noUnicodeAdaptation) {
             width = this.widths[this.unicodeToCID[charcode] || charcode];
-            fontCharCode = mapPrivateUseChars(charcode);
-            break;
           }
           fontCharCode = this.toFontChar[charcode] || charcode;
           break;

--- a/src/fonts.js
+++ b/src/fonts.js
@@ -4126,6 +4126,12 @@ var Font = (function FontClosure() {
         } else
           cid++;
       }
+
+      var cidEncoding = properties.cidEncoding;
+      if (cidEncoding && cidEncoding.substring(0, 3) == 'Uni') {
+        // input is already Unicode for Uni* CMap encodings
+        this.cidToUnicode = [];
+      }
     },
 
     bindDOM: function Font_bindDOM() {

--- a/src/fonts.js
+++ b/src/fonts.js
@@ -4126,6 +4126,15 @@ var Font = (function FontClosure() {
         } else
           cid++;
       }
+
+      var cidEncoding = properties.cidEncoding;
+      if (cidEncoding && cidEncoding.indexOf('Uni') === 0) {
+        // input is already Unicode for Uni* CMap encodings.
+        // However, Unicode-to-CID conversion is needed
+        // regardless of the CMap encoding. So we can't reset
+        // unicodeToCID.
+        this.cidToUnicode = [];
+      }
     },
 
     bindDOM: function Font_bindDOM() {
@@ -4205,16 +4214,12 @@ var Font = (function FontClosure() {
         case 'CIDFontType0':
           if (this.noUnicodeAdaptation) {
             width = this.widths[this.unicodeToCID[charcode] || charcode];
-            fontCharCode = mapPrivateUseChars(charcode);
-            break;
           }
           fontCharCode = this.toFontChar[charcode] || charcode;
           break;
         case 'CIDFontType2':
           if (this.noUnicodeAdaptation) {
             width = this.widths[this.unicodeToCID[charcode] || charcode];
-            fontCharCode = mapPrivateUseChars(charcode);
-            break;
           }
           fontCharCode = this.toFontChar[charcode] || charcode;
           break;


### PR DESCRIPTION
Fixes #2559. CIDFont need a conversion even if the font is not embedded.
