### PR TITLE
Handle missing 'FontName' entry in FontDescriptor object

### DIFF
--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -1146,10 +1146,26 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       // a variant.
       var firstChar = dict.get('FirstChar') || 0;
       var lastChar = dict.get('LastChar') || maxCharIndex;
+
       var fontName = descriptor.get('FontName');
+      var baseFont = baseDict.get('BaseFont');
       // Some bad pdf's have a string as the font name.
-      if (isString(fontName))
+      if (isString(fontName)) {
         fontName = new Name(fontName);
+      }
+      if (isString(baseFont)) {
+        baseFont = new Name(baseFont);
+      }
+
+      var fontNameStr = fontName && fontName.name;
+      var baseFontStr = baseFont && baseFont.name;
+      if (fontNameStr !== baseFontStr) {
+        warn('The FontDescriptor\'s FontName is "' + fontNameStr +
+            '" but should be the same as the Font\'s BaseFont "' +
+            baseFontStr + '"');
+      }
+      fontName = fontName || baseFont;
+
       assertWellFormed(isName(fontName), 'invalid font name');
 
       var fontFile = descriptor.get('FontFile', 'FontFile2', 'FontFile3');

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -38,3 +38,4 @@
 !mixedfonts.pdf
 !shading_extend.pdf
 !noembed-identity.pdf
+!issue2099-1.pdf

--- a/test/pdfs/issue2099-1.pdf
+++ b/test/pdfs/issue2099-1.pdf
@@ -1,0 +1,137 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj 
+<<
+/Pages 2 0 R
+/Metadata 3 0 R
+/Type /Catalog
+>>
+endobj 
+2 0 obj 
+<<
+/Kids [4 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+3 0 obj 
+<<
+/Subtype /XML
+/Length 1421
+/Type /Metadata
+>>
+stream
+<?xpacket begin='Ôªø' id='W5M0MpCehiHzreSzNTczkc9d'?>
+<?adobe-xap-filters esc="CRLF"?>
+<x:xmpmeta xmlns:x='adobe:ns:meta/' x:xmptk='XMP toolkit 2.9.1-13, framework 1.6'>
+<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:iX='http://ns.adobe.com/iX/1.0/'>
+<rdf:Description rdf:about='uuid:5da849aa-943d-11ed-0000-29e0e127fe1e' xmlns:pdf='http://ns.adobe.com/pdf/1.3/' pdf:Producer='GPL Ghostscript 9.05'/>
+<rdf:Description rdf:about='uuid:5da849aa-943d-11ed-0000-29e0e127fe1e' xmlns:xmp='http://ns.adobe.com/xap/1.0/'><xmp:ModifyDate>2013-01-11T10:57:59-08:00</xmp:ModifyDate>
+<xmp:CreateDate>2013-01-11T10:57:59-08:00</xmp:CreateDate>
+<xmp:CreatorTool>GNU Enscript 1.6.6</xmp:CreatorTool></rdf:Description>
+<rdf:Description rdf:about='uuid:5da849aa-943d-11ed-0000-29e0e127fe1e' xmlns:xapMM='http://ns.adobe.com/xap/1.0/mm/' xapMM:DocumentID='uuid:5da849aa-943d-11ed-0000-29e0e127fe1e'/>
+<rdf:Description rdf:about='uuid:5da849aa-943d-11ed-0000-29e0e127fe1e' xmlns:dc='http://purl.org/dc/elements/1.1/' dc:format='application/pdf'><dc:title><rdf:Alt><rdf:li xml:lang='x-default'>Enscript Output</rdf:li></rdf:Alt></dc:title><dc:creator><rdf:Seq><rdf:li>Mack Duan</rdf:li></rdf:Seq></dc:creator></rdf:Description>
+</rdf:RDF>
+</x:xmpmeta>
+                                                                        
+                                                                        
+<?xpacket end='w'?>
+endstream 
+endobj 
+4 0 obj 
+<<
+/Rotate 0
+/Parent 2 0 R
+/Resources 
+<<
+/ExtGState 5 0 R
+/Font 6 0 R
+/ProcSet [/PDF /Text]
+>>
+/MediaBox [0 0 595 842]
+/Contents 7 0 R
+/Type /Page
+>>
+endobj 
+5 0 obj 
+<<
+/R7 8 0 R
+>>
+endobj 
+6 0 obj 
+<<
+/R8 9 0 R
+>>
+endobj 
+7 0 obj 
+<<
+/Length 138
+>>
+stream
+q 0.1 0 0 0.1 0 0 cm
+/R7 gs
+0 g
+q
+10 0 0 10 0 0 cm BT
+/R8 10 Tf
+1 0 0 1 29 805 Tm
+(test missing FontName in FontDescriptor dict)Tj
+ET
+Q
+Q
+
+endstream 
+endobj 
+8 0 obj 
+<<
+/Type /ExtGState
+/OPM 1
+>>
+endobj 
+9 0 obj 
+<<
+/BaseFont /Courier
+/Subtype /Type1
+/FontDescriptor 10 0 R
+/Type /Font
+>>
+endobj 
+10 0 obj 
+<<
+/Type /FontDescriptor
+>>
+endobj 
+11 0 obj 
+<<
+/Creator (GNU Enscript 1.6.6)
+/Title (Enscript Output)
+/Producer (GPL Ghostscript 9.05)
+/Author (Mack Duan)
+/ModDate (D:20130111105759-08'00')
+/CreationDate (D:20130111105759-08'00')
+>>
+endobj xref
+0 12
+0000000000 65535 f 
+0000000015 00000 n 
+0000000082 00000 n 
+0000000141 00000 n 
+0000001647 00000 n 
+0000001815 00000 n 
+0000001848 00000 n 
+0000001881 00000 n 
+0000002073 00000 n 
+0000002120 00000 n 
+0000002213 00000 n 
+0000002259 00000 n 
+trailer
+
+<<
+/Info 11 0 R
+/Root 1 0 R
+/Size 12
+/ID [<2eee0bd94f14c7014ff602c9df19ad9a> <2eee0bd94f14c7014ff602c9df19ad9a>]
+>>
+startxref
+2465
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -801,5 +801,11 @@
       "md5": "05d3803b6c22451e18cb60d8d8c75c0c",
       "rounds": 1,
       "type": "eq"
+    },
+    {  "id": "issue2099-1",
+      "file": "pdfs/issue2099-1.pdf",
+      "md5": "c7eca682d70a976dfc4b7e64d3e9f1ce",
+      "rounds": 1,
+      "type": "eq"
     }
 ]


### PR DESCRIPTION
If the 'FontName' entry in the FontDescriptor dict is missing, use the 'BaseFont' entry in the corresponding Font dict.

This partially fixes #2099.
