### PR TITLE
Improve the behaviour of the pageNumber input field

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2912,9 +2912,19 @@ document.addEventListener('DOMContentLoaded', function webViewerLoad(evt) {
       PDFView.download();
     });
 
+  document.getElementById('pageNumber').addEventListener('click',
+    function() {
+      this.select();
+    });
+
   document.getElementById('pageNumber').addEventListener('change',
     function() {
-      PDFView.page = this.value;
+      // Handle the user inputting a floating point number.
+      PDFView.page = (this.value | 0);
+
+      if (this.value !== (this.value | 0).toString()) {
+        this.value = PDFView.page;
+      }
     });
 
   document.getElementById('scaleSelect').addEventListener('change',


### PR DESCRIPTION
This PR adds the following two improvements to the pageNumber input element:
- When the user clicks on the pageNumber input element, the content is selected.
- If a floating point number is entered, it's handled similarly to other pdf viewers. In this case, pdf.js will no longer fail @[web/viewer.js#L826](https://github.com/mozilla/pdf.js/blob/master/web/viewer.js#L826) because `val` is a float.
