### PR TITLE
Update font name matching for Type 0 CIDFont

### DIFF
--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -1213,6 +1213,13 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       }
 
       var fontNameStr = fontName && fontName.name;
+      // 9.7.6.1
+      if (type.name == 'CIDFontType0') {
+        var cidEncoding = baseDict.get('Encoding');
+        if (isName(cidEncoding)) {
+          fontNameStr = fontNameStr + '-' + cidEncoding.name;
+        }
+      }
       var baseFontStr = baseFont && baseFont.name;
       if (fontNameStr !== baseFontStr) {
         warn('The FontDescriptor\'s FontName is "' + fontNameStr +


### PR DESCRIPTION
Fixes #2598.
This patch will not affect the rendering, only removes the warning spam.
