### PR TITLE
Avoid hard-coding the "node" command in shell.js

### DIFF
--- a/external/shelljs/shell.js
+++ b/external/shelljs/shell.js
@@ -1312,7 +1312,7 @@ function execSync(cmd, opts) {
   if (fs.existsSync(codeFile)) _unlinkSync(codeFile);
 
   fs.writeFileSync(scriptFile, script);
-  child.exec('node '+scriptFile, { 
+  child.exec(process.argv[0] + " " + scriptFile, { 
     env: process.env,
     cwd: exports.pwd()
   });


### PR DESCRIPTION
In Ubuntu, the "node" command is actually a throwback program (node(8) -  Node front end for AX.25, NET/ROM, Rose and TCP)

This breaks the build of pdf.js on Ubuntu for now, but more importantly the patch ensures that the same node version is used to run every child in the exec() if there are multiple versions installed.
