### PR TITLE
Fixes intermittent rendering stop

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2075,7 +2075,12 @@ var PageView = function pageView(container, pdfPage, id, scale,
     // Rendering area
 
     var self = this;
+    var renderingWasReset = false;
     function pageViewDrawCallback(error) {
+      if (renderingWasReset) {
+        return;
+      }
+
       self.renderingState = RenderingStates.FINISHED;
 
       if (self.loadingIconDiv) {
@@ -2110,6 +2115,12 @@ var PageView = function pageView(container, pdfPage, id, scale,
       viewport: this.viewport,
       textLayer: textLayer,
       continueCallback: function pdfViewcContinueCallback(cont) {
+        if (self.renderingState === RenderingStates.INITIAL) {
+          // The page update() was called, we just need to abort any rendering.
+          renderingWasReset = true;
+          return;
+        }
+
         if (PDFView.highestPriorityPage !== 'page' + self.id) {
           self.renderingState = RenderingStates.PAUSED;
           self.resume = function resumeCallback() {


### PR DESCRIPTION
To replicate the issue:
1) open http://people.mozilla.com/~ydelendik/pdfjs-ttf-2012.pdf;
2) if not on first page, goto first page, and refresh;
3) click presentation mode;
4) hit right key and mouse click.

Empty/white page is shown.

May also fix other intermittent failures during rendering connected with fast zooming.
