### PR TITLE
Prefer Microsoft encodings to Mac encodings

### DIFF
--- a/src/fonts.js
+++ b/src/fonts.js
@@ -2962,6 +2962,7 @@ var Font = (function FontClosure() {
             cmap.data[i] = data.charCodeAt(i);
         }
 
+        var cmapTable;
         for (var i = 0; i < numRecords; i++) {
           var table = tables[i];
           font.pos = start + table.offset;
@@ -2984,7 +2985,7 @@ var Font = (function FontClosure() {
                 ids.push(index);
               }
             }
-            return {
+            cmapTable = {
               glyphs: glyphs,
               ids: ids,
               hasShortCmap: true
@@ -3071,11 +3072,14 @@ var Font = (function FontClosure() {
               ids.push(glyphCode);
             }
 
-            return {
+            cmapTable = {
               glyphs: glyphs,
               ids: ids
             };
           }
+        }
+        if (cmapTable) {
+          return cmapTable;
         }
         error('Unsupported cmap table format');
       };

--- a/test/pdfs/jre_memory.pdf.link
+++ b/test/pdfs/jre_memory.pdf.link
@@ -1,0 +1,1 @@
+http://www.cals.pref.mie.jp/info/jre_memory.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -817,6 +817,12 @@
       "rounds": 1,
       "type": "eq"
     },
+    {  "id": "jre_memory.pdf",
+      "file": "pdfs/jre_memory.pdf",
+      "md5": "d277ad5c9e93fcdc3d93c0b5f1454c0a",
+      "rounds": 1,
+      "type": "eq"
+    },
     {  "id": "noembed-identity",
       "file": "pdfs/noembed-identity.pdf",
       "md5": "05d3803b6c22451e18cb60d8d8c75c0c",


### PR DESCRIPTION
Fixes <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=833676">bug 833676</a>.
According to PDF Reference 9.6.6.4, Microsoft encodings should have higher precedence than Mac encodings. And Mac encodings actually tend to have bogus values because format 0 subtable can't represent glyphID larger than 255.
