### PR TITLE
Add support for GBK-EUC-H encoding for cid fonts

### DIFF
--- a/src/fonts.js
+++ b/src/fonts.js
@@ -410,11 +410,14 @@ var CMapConverterList = {
   '90ms-RKSJ-H': sjisToUnicode,
   '90ms-RKSJ-V': sjisToUnicode,
   '90msp-RKSJ-H': sjisToUnicode,
-  '90msp-RKSJ-V': sjisToUnicode
+  '90msp-RKSJ-V': sjisToUnicode,
+  'GBK-EUC-H': gbkToUnicode
 };
 
 var decodeBytes;
 if (typeof TextDecoder !== 'undefined') {
+  // The encodings supported by TextDecoder can be found at:
+  // http://encoding.spec.whatwg.org/#concept-encoding-get
   decodeBytes = function(bytes, encoding) {
     return new TextDecoder(encoding).decode(bytes);
   };
@@ -442,6 +445,10 @@ function eucjpToUnicode(str) {
 
 function sjisToUnicode(str) {
   return decodeBytes(stringToBytes(str), 'shift_jis');
+}
+
+function gbkToUnicode(str) {
+  return decodeBytes(stringToBytes(str), 'gbk');
 }
 
 // Some characters, e.g. copyrightserif, mapped to the private use area and

--- a/test/pdfs/issue2128.pdf.link
+++ b/test/pdfs/issue2128.pdf.link
@@ -1,0 +1,1 @@
+http://www.bookcool.com/pdf/6/ts006006.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -44,6 +44,14 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "issue2128",
+       "file": "pdfs/issue2128.pdf",
+       "md5": "b3f4d9ed3c41e1f1768264a3f8b93aad",
+       "link": true,
+       "pageLimit": 2,
+       "rounds": 1,
+       "type": "eq"
+    },
     {  "id": "pdfspec-load",
        "file": "pdfs/pdf.pdf",
        "md5": "dbdb23c939d2be09b43126c3c56060c7",


### PR DESCRIPTION
Fixes issue #2128 on Firefox.
