### PR TITLE
changed the type1font cff wrapping to use offsets 391,392... instead of 0,1... for pointing to strings in the String INDEX

### DIFF
--- a/src/fonts.js
+++ b/src/fonts.js
@@ -5205,11 +5205,13 @@ Type1Font.prototype = {
     cff.names = [name];
 
     var topDict = new CFFTopDict();
-    topDict.setByName('version', 0);
-    topDict.setByName('Notice', 1);
-    topDict.setByName('FullName', 2);
-    topDict.setByName('FamilyName', 3);
-    topDict.setByName('Weight', 4);
+    // CFF strings IDs 0...390 are predefined names, so refering
+    // to entries in our own String INDEX starts at SID 391.
+    topDict.setByName('version', 391);
+    topDict.setByName('Notice', 392);
+    topDict.setByName('FullName', 393);
+    topDict.setByName('FamilyName', 394);
+    topDict.setByName('Weight', 395);
     topDict.setByName('Encoding', null); // placeholder
     topDict.setByName('FontMatrix', properties.fontMatrix);
     topDict.setByName('FontBBox', properties.bbox);


### PR DESCRIPTION
CFF fonts have a predefined string dictionary with 391 strings that don't need to be encoded because they apply to all CFF, so custom strings in a String INDEX after the Top DICT are referenced by SID 391 and up. However, the Type1Font .wrap function sets up the header with name/version/etc SID's pointing to the index positions in the string array (0,1,2,...) rather than the position after offsetting for the 391 predefined strings, as 391,392,393 etc.

This pull request changes the offsets so that cff header.name, .version, etc have the correct strings rather than the first five predefined strings from the Type2 Charstring list (.notdef, space, etc)
