### PR TITLE
Updated Swedish locale

### DIFF
--- a/l10n/sv/chrome.properties
+++ b/l10n/sv/chrome.properties
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 # Chrome notification bar messages and buttons
-unsupported_feature=Denna PDF kanske inte visas korrekt.
-open_with_different_viewer=Öppna med annan pdf-visare.
+unsupported_feature=Detta PDF-dokument kanske inte visas korrekt.
+open_with_different_viewer=Öppna med ett annat program
 open_with_different_viewer.accessKey=ö

--- a/l10n/sv/metadata.inc
+++ b/l10n/sv/metadata.inc
@@ -1,8 +1,7 @@
     <em:localized>
       <Description>
         <em:locale>sv</em:locale>
-        <em:name>PDF Läsare</em:name>
-        <em:description>Använder HTML5 för att visa PDF filer direkt i Firefox.</em:description>
+        <em:name>PDF-läsare</em:name>
+        <em:description>Använder HTML5 för att visa PDF-filer direkt i Firefox.</em:description>
       </Description>
     </em:localized>
-

--- a/l10n/sv/viewer.properties
+++ b/l10n/sv/viewer.properties
@@ -32,8 +32,8 @@ zoom_in_label=Zooma in
 zoom.title=Zooma
 print.title=Skriv ut
 print_label=Skriv ut
-presentation_mode.title=Växla till presentationsläge
-presentation_mode_label=Presentatationsläge
+presentation_mode.title=Presentationsläge
+presentation_mode_label=Presentationsläge
 open_file.title=Öppna fil
 open_file_label=Öppna
 download.title=Ladda ner
@@ -44,17 +44,17 @@ bookmark_label=Aktuell vy
 # Tooltips and alt text for side panel toolbar buttons
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
-toggle_slider.title=Visa/Dölj panel
-toggle_slider_label=Visa/Dölj panel
-outline.title=Visa dokumentdisposition
-outline_label=Dokumentdisposition
-thumbs.title=Visa miniatyrer
-thumbs_label=Miniatyrer
+toggle_sidebar.title=Visa/Dölj sidopanel
+toggle_sidebar_label=Visa/Dölj sidopanel
+outline.title=Visa bokmärken
+outline_label=Bokmärken
+thumbs.title=Visa sidminiatyrer
+thumbs_label=Sidminiatyrer
 findbar.title=Sök i dokumentet
 findbar_label=Sök
 
 # Document outline messages
-no_outline=Ingen dokumentdisposition tillgänglig
+no_outline=Inga bokmärken tillgängliga
 
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
@@ -77,18 +77,18 @@ find_previous_label=Föregående
 find_next.title=Hitta nästa förekomst av frasen
 find_next_label=Nästa
 find_highlight=Markera alla
-find_match_case_label=Matcha versaler/gemener
-find_wrapped_to_bottom=Nådde toppen av sidan, fortsätter från slutet
-find_wrapped_to_top=Nådde slutet av sidan, fortsätter från toppen
+find_match_case_label=Matcha VERSALER/gemener
+find_reached_top=Kommit till början av dokumentet, börjat om
+find_reached_bottom=Kommit till slutet av dokumentet, börjat om
 find_not_found=Frasen hittades inte
 
 # Error panel labels
 error_more_info=Mer information
 error_less_info=Mindre information
 error_close=Stäng
-# LOCALIZATION NOTE (error_build): "{{build}}" will be replaced by the PDF.JS
-# build ID.
-error_build=PDF.JS Bygge: {{build}}
+# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
+# replaced by the PDF.JS version and build ID.
+error_version_info=PDF.js v{{version}} (bygge: {{build}})
 # LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
 # english string describing the error.
 error_message=Meddelande: {{message}}
@@ -103,20 +103,22 @@ rendering_error=Ett fel inträffade när sidan renderades.
 
 # Predefined zoom values
 page_scale_width=Sidbredd
-page_scale_fit=Passa sida
-page_scale_auto=Automatisk Zoom
+page_scale_fit=Helsida
+page_scale_auto=Automatisk zoom
 page_scale_actual=Faktisk storlek
 
 # Loading indicator messages
 loading_error_indicator=Fel
-loading_error=Ett fel inträffade när PDFen skulle laddas.
+loading_error=Ett fel inträffade när PDF-filen laddades.
 invalid_file_error=Ogiltig eller korrupt PDF-fil.
+missing_file_error=PDF-filen saknas.
 
 # LOCALIZATION NOTE (text_annotation_type): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in
 # the PDF spec (32000-1:2008 Table 169 – Annotation types).
 # Some common types are e.g.: "Check", "Text", "Comment", "Note"
-text_annotation_type=[{{type}} Annotering]
-request_password=PDFen är skyddad av lösenord:
+text_annotation_type=[{{type}}-anteckning]
+request_password=PDF-filen är lösenordsskyddad:
 
 printing_not_supported=Varning: Utskrifter stöds inte fullt ut av denna webbläsare.
+web_fonts_disabled=Webbtypsnitt är inaktiverade: Typsnitt inkluderade i PDF-filer kan ej användas.


### PR DESCRIPTION
It appears that no one is maintaining the Swedish localization of pdf.js any more, since there hasn't been any updates in a couple of months. I'm not the original translator, but I am willing to take over the maintenance of the l10n. (I'm a native Swedish speaker.)

This PR makes a number of changes to the Swedish localization of pdf.js:
- Adds all currently missing fields.
- Fixes the fields who's names have changed since last update.
- A few changes to the `find` strings, so that they correspond to the wording of the Swedish l10n of Firefox.
- A few strings are changed slightly to improve the overall consistence and the grammar of the translation.
- Generally the current translation is good, but are some strings that I find quite confusing. Hence there has been a couple of changes to hopefully improve the overall quality of the translation.
