### PR TITLE
Reduce warning spam caused by BX/EX

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -1420,10 +1420,10 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     // Compatibility
 
     beginCompat: function CanvasGraphics_beginCompat() {
-      TODO('ignore undefined operators (should we do that anyway?)');
+      // TODO ignore undefined operators (should we do that anyway?)
     },
     endCompat: function CanvasGraphics_endCompat() {
-      TODO('stop ignoring undefined operators');
+      // TODO stop ignoring undefined operators
     },
 
     // Helper functions


### PR DESCRIPTION
Partially fixes https://bugzilla.mozilla.org/show_bug.cgi?id=767455 .
We should warn only if we actually encountered an undefined operator. If the PDF doesn't contain an undefined operator, The PDF will be displayed correctly and we don't have to kick the fallback. If the PDF contains an undefined operator, we already warns about the undefined operator. So the extra two warnings ("ignore undefined operators" / "stop ignoring undefined operators") are redundant.
