### PR TITLE
Take BaseFont entry from CIDFont dict instead of Type 0 Font dict

### DIFF
--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -1205,7 +1205,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       var lastChar = dict.get('LastChar') || maxCharIndex;
 
       var fontName = descriptor.get('FontName');
-      var baseFont = baseDict.get('BaseFont');
+      var baseFont = dict.get('BaseFont');
       // Some bad pdf's have a string as the font name.
       if (isString(fontName)) {
         fontName = new Name(fontName);
@@ -1215,13 +1215,6 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       }
 
       var fontNameStr = fontName && fontName.name;
-      // 9.7.6.1
-      if (type.name == 'CIDFontType0') {
-        var cidEncoding = baseDict.get('Encoding');
-        if (isName(cidEncoding)) {
-          fontNameStr = fontNameStr + '-' + cidEncoding.name;
-        }
-      }
       var baseFontStr = baseFont && baseFont.name;
       if (fontNameStr !== baseFontStr) {
         warn('The FontDescriptor\'s FontName is "' + fontNameStr +


### PR DESCRIPTION
Partially fixes https://bugzilla.mozilla.org/show_bug.cgi?id=767455 .
We shouldn't compare against BaseFont entry from Type 0 Font dict because it can contain arbitrary names as 9.7.6.1 is saying. And pdf.js spams warnings for those PDFs.
