### PR TITLE
Prevent text selection divs from overflowing page boundries

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1165,6 +1165,7 @@ canvas {
   bottom: 0;
   color: #000;
   font-family: sans-serif;
+  overflow: hidden;
 }
 
 .textLayer > div {


### PR DESCRIPTION
This fixes [bug 837462](https://bugzilla.mozilla.org/show_bug.cgi?id=837462).
