### PR TITLE
Add preference to show outline automatically on document load

### DIFF
--- a/extensions/firefox/components/PdfStreamConverter.js
+++ b/extensions/firefox/components/PdfStreamConverter.js
@@ -367,6 +367,15 @@ ChromeActions.prototype = {
   pdfBugEnabled: function() {
     return getBoolPref(PREF_PREFIX + '.pdfBugEnabled', false);
   },
+  ifAvailableShowOutlineOnLoad: function() {
+    var prefName = PREF_PREFIX + '.ifAvailableShowOutlineOnLoad';
+    try {
+      return Services.prefs.getBoolPref(prefName);
+    } catch (ex) {
+      Services.prefs.setBoolPref(prefName, false);
+      return false;
+    }
+  },
   supportsIntegratedFind: function() {
     // Integrated find is only supported when we're not in a frame and when the
     // new find events code exists.

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -703,6 +703,7 @@ var PDFView = {
   mouseScrollDelta: 0,
   lastScroll: 0,
   previousPageNumber: 1,
+  containsOutline: false,
 
   // called once when the document is loaded
   initialize: function pdfViewInitialize() {
@@ -1323,6 +1324,18 @@ var PDFView = {
       }
 
       self.setInitialView(storedHash, scale);
+
+//#if (FIREFOX || MOZCENTRAL)
+//    // If the document contains an outline, and the preference is set to true,
+//    // display the outline automatically on document load.
+//    if (PDFView.containsOutline &&
+//        FirefoxCom.requestSync('ifAvailableShowOutlineOnLoad')) {
+//      if (!PDFView.sidebarOpen) {
+//        document.getElementById('sidebarToggle').click();
+//      }
+//      PDFView.switchSidebarView('outline');
+//    }
+//#endif
     });
 
     pdfDocument.getMetadata().then(function(data) {
@@ -2430,6 +2443,7 @@ var DocumentOutlineView = function documentOutlineView(outline) {
       levelData.parent.appendChild(div);
     }
   }
+  PDFView.containsOutline = true;
 };
 
 // optimised CSS custom property getter/setter


### PR DESCRIPTION
This is a feature that I have missed ever since I started using pdf.js. I've lost count of how many times that I've opened the sidebar and clicked on "Show Outline", just to see that the PDF didn't provide an outline.

This PR implements a, currently hidden, boolean preference in about:config 
`PREF_PREFIX.ifAvailableShowOutlineOnLoad`. When this is set to `true` by the user, the outline will be automatically shown on load, but **_only if_** it exists.
