### PR TITLE
Close findbar also when focus is away from it

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -3296,6 +3296,12 @@ window.addEventListener('keydown', function keydown(evt) {
         PDFView.page--;
         handled = true;
         break;
+      case 27: // esc key
+        if (!PDFView.supportsIntegratedFind && PDFFindBar.opened) {
+          PDFFindBar.close();
+          handled = true;
+        }
+        break;
       case 40: // down arrow
       case 34: // pg down
       case 32: // spacebar


### PR DESCRIPTION
This has been bothering me for a while now. A lot of times, if one searches a word or sentence in a document and one finds it, one tends to read and scroll a bit, but then the focus is away from the findbar. One would have to click on the findbar input field and press Esc to close it, but with this patch, it is possible to push Esc anywhere and close the findbar.

Note that the findbar is only closed if it is already open. It will not toggle the sidebar: that's what Ctrl-F is for :)
