### PR TITLE
More even way of zooming

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -808,12 +808,14 @@ var PDFView = {
 
   zoomIn: function pdfViewZoomIn() {
     var newScale = (this.currentScale * DEFAULT_SCALE_DELTA).toFixed(2);
+    newScale = Math.ceil(newScale * 10) / 10;
     newScale = Math.min(MAX_SCALE, newScale);
     this.parseScale(newScale, true);
   },
 
   zoomOut: function pdfViewZoomOut() {
     var newScale = (this.currentScale / DEFAULT_SCALE_DELTA).toFixed(2);
+    newScale = Math.floor(newScale * 10) / 10;
     newScale = Math.max(MIN_SCALE, newScale);
     this.parseScale(newScale, true);
   },


### PR DESCRIPTION
Fixes the extra comment in #570. This is something that I have also found strange. Adobe Acrobat X and other PDF viewers also zoom with steps of at least 10%. With this setting, one can always reach 100% and zooming in and out is more even (100 - 110 - 120 % etc. instead of 100 - 106 - 113 etc.). In the higher ranges, the zooming percentages will grow faster, just like in Adobe Acrobat X for example.
