### PR TITLE
Disabling zoom buttons if zooming in or out is not possible anymore.

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -164,11 +164,11 @@ limitations under the License.
               <div class="outerCenter">
                 <div class="innerCenter" id="toolbarViewerMiddle">
                   <div class="splitToolbarButton">
-                    <button class="toolbarButton zoomOut" title="Zoom Out" tabindex="8" data-l10n-id="zoom_out">
+                    <button class="toolbarButton zoomOut" id="zoom_out" title="Zoom Out" tabindex="8" data-l10n-id="zoom_out">
                       <span data-l10n-id="zoom_out_label">Zoom Out</span>
                     </button>
                     <div class="splitToolbarButtonSeparator"></div>
-                    <button class="toolbarButton zoomIn" title="Zoom In" tabindex="9" data-l10n-id="zoom_in">
+                    <button class="toolbarButton zoomIn" id="zoom_in" title="Zoom In" tabindex="9" data-l10n-id="zoom_in">
                       <span data-l10n-id="zoom_in_label">Zoom In</span>
                      </button>
                   </div>

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -3146,6 +3146,9 @@ window.addEventListener('scalechange', function scalechange(evt) {
     customScaleOption.textContent = Math.round(evt.scale * 10000) / 100 + '%';
     customScaleOption.selected = true;
   }
+  
+  document.getElementById('zoom_out').disabled = (evt.scale === MIN_SCALE);
+  document.getElementById('zoom_in').disabled = (evt.scale === MAX_SCALE);
 
   updateViewarea();
 }, true);


### PR DESCRIPTION
This was already the case with page up/down, so why not with zooming, I was wondering.
