### PR TITLE
Removes unused isLocalStorageEnabled

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -153,6 +153,7 @@ var ProgressBar = (function ProgressBarClosure() {
 // If not, we use FUEL in FF
 // Use asyncStorage for B2G
 var Settings = (function SettingsClosure() {
+//#if !(FIREFOX || MOZCENTRAL || B2G)
   var isLocalStorageEnabled = (function localStorageEnabledTest() {
     // Feature test as per http://diveintohtml5.info/storage.html
     // The additional localStorage call is to get around a FF quirk, see
@@ -164,6 +165,7 @@ var Settings = (function SettingsClosure() {
       return false;
     }
   })();
+//#endif
 
   function Settings(fingerprint) {
     this.fingerprint = fingerprint;


### PR DESCRIPTION
The variable isLocalStorageEnabled is now unused in Firefox and B2G.
