### PR TITLE
Remove the test of experimental properties in workers

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -168,8 +168,14 @@ var WorkerMessageHandler = {
       }
       // check if the response property is supported by xhr
       var xhr = new XMLHttpRequest();
-      if (!('response' in xhr || 'mozResponse' in xhr ||
-          'responseArrayBuffer' in xhr || 'mozResponseArrayBuffer' in xhr)) {
+      var responseExists = 'response' in xhr;
+      // check if the property is actually implemented
+      try {
+        var dummy = xhr.responseType;
+      } catch (e) {
+        responseExists = false;
+      }
+      if (!responseExists) {
         handler.send('test', false);
         return;
       }

--- a/test/features/tests.js
+++ b/test/features/tests.js
@@ -514,7 +514,7 @@ var tests = [
             promise.resolve({ output: 'Success', emulated: '' });
           else
             promise.resolve({ output: 'Failed', emulated: 'Yes' });
-        });
+        }, false);
         worker.postMessage({action: 'test',
                             data: new Uint8Array(60000000)}); // 60MB
         return promise;
@@ -546,7 +546,7 @@ var tests = [
             promise.resolve({ output: 'Success', emulated: '' });
           else
             promise.resolve({ output: 'Failed', emulated: 'Yes' });
-        });
+        }, false);
         worker.postMessage({action: 'xhr'});
         return promise;
       } catch (e) {
@@ -586,7 +586,7 @@ var tests = [
             promise.resolve({ output: 'Failed',
                               emulated: emulatable ? 'Yes' : 'No' });
           }
-        });
+        }, false);
         worker.postMessage({action: 'TextDecoder'});
         return promise;
       } catch (e) {

--- a/test/features/worker-stub.js
+++ b/test/features/worker-stub.js
@@ -23,8 +23,13 @@ onmessage = function (e) {
     break;
   case 'xhr':
     var xhr = new XMLHttpRequest();
-    var responseExists = 'response' in xhr || 'mozResponse' in xhr ||
-        'responseArrayBuffer' in xhr || 'mozResponseArrayBuffer' in xhr;
+    var responseExists = 'response' in xhr;
+    // check if the property is actually implemented
+    try {
+      var dummy = xhr.responseType;
+    } catch (e) {
+      responseExists = false;
+    }
     postMessage({action: 'xhr', result: responseExists});
     break;
   case 'TextDecoder':


### PR DESCRIPTION
Partially fixes #2728.
Actually this change made pdf.js work with Firefox 6 & 7 because arraybuffer response in worker was fairly broken on older versions.
