### PR TITLE
Hide header/footer by default when printing from Firefox. See Bug 743252

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<html dir="ltr" mozdisallowselectionprint>
+<html dir="ltr" mozdisallowselectionprint moznomarginboxes>
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">


### PR DESCRIPTION
Add **moznomarginboxes** on `<html>` element to hide footer/header when printing from Firefox by default.

See also the corresponding patch on bug 743252:

  https://bug743252.bugzilla.mozilla.org/attachment.cgi?id=714888
