### PR TITLE
viewer.properties - Polish lang : English file -> Polish and translated new values

### DIFF
--- a/l10n/pl/viewer.properties
+++ b/l10n/pl/viewer.properties
@@ -12,46 +12,113 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-bookmark.title=Aktualny widok (kopiuj lub otwórz w nowym oknie)
+# Main toolbar buttons (tooltips and alt text for images)
 previous.title=Poprzednia strona
+previous_label=Wstecz
 next.title=Następna strona
-print.title=Drukuj
-download.title=Pobierz
+next_label=Dalej
+
+# LOCALIZATION NOTE (page_label, page_of):
+# These strings are concatenated to form the "Page: X of Y" string.
+# Do not translate "{{pageCount}}", it will be substituted with a number
+# representing the total number of pages.
+page_label=Strona:
+page_of=z {{pageCount}}
+
 zoom_out.title=Pomniejsz
+zoom_out_label=Pomniejsz
 zoom_in.title=Powiększ
+zoom_in_label=Powiększ
+zoom.title=Powiększenie
+print.title=Drukuj
+print_label=Drukuj
+presentation_mode.title=Przełącz do trybu prezentacji
+presentation_mode_label=Tryb prezentacji
+open_file.title=Otwórz plik
+open_file_label=Otwórz
+download.title=Pobierz
+download_label=Pobierz
+bookmark.title=Aktualny widok (kopiuj lub otwórz w nowym oknie)
+bookmark_label=Aktualny widok
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Pokaż/Ukryj panel boczny
+toggle_sidebar_label=Pokaż/Ukryj panel
+outline.title=Wyświetl konspekt dokumentu
+outline_label=Konspekt dokumentu
+thumbs.title=Wyświetl miniatury
+thumbs_label=Miniatury
+findbar.title=Szukaj w tekście
+findbar_label=Znajdź
+
+# Document outline messages
+no_outline=Konspekt nie jest dostępny
+
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Strona {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Miniatura strony {{page}}
+
+# Context menu
+first_page.label=Idź do pierwszej strony
+last_page.label=Idź do ostatniej strony
+page_rotate_cw.label=Obróć w prawo
+page_rotate_ccw.label=Obróć w lewo
+
+# Find panel button title and messages
+find_label=Znajdź:
+find_previous.title=Znajdź poprzednie wystąpienie ostatnio szukanej frazy
+find_previous_label=Poprzednie
+find_next.title=Znajdź następne wystąpienie ostatnio szukanej frazy
+find_next_label=Następne
+find_highlight=Podświetl
+find_match_case_label=Rozróżniaj wielkość liter
+find_reached_top=Początek strony. Wyszukiwanie od końca.
+find_reached_bottom=Koniec strony. Wyszukiwanie od początku.
+find_not_found=Szukany tekst nie został odnaleziony.
+
+# Error panel labels
 error_more_info=Więcej informacji
 error_less_info=Mniej informacji
 error_close=Zamknij
-error_build=Wersja PDF.JS: {{build}}
+# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
+# replaced by the PDF.JS version and build ID.
+error_version_info=Wersja PDF.js: {{version}} (kompilacja: {{build}})
+# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
+# english string describing the error.
 error_message=Wiadomość: {{message}}
+# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
+# trace.
 error_stack=Stos: {{stack}}
+# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
 error_file=Plik: {{file}}
+# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
 error_line=Linia: {{line}}
+rendering_error=Wystąpił błąd podczas wyświetlania strony.
+
+# Predefined zoom values
 page_scale_width=Szerokość strony
 page_scale_fit=Cała strona
 page_scale_auto=Automatyczne dopasowanie
 page_scale_actual=Rzeczywisty rozmiar
-toggle_slider.title=Włącz/wyłącz suwak
-thumbs.title=Wyświetl miniatury
-outline.title=Wyświetl konspekt dokumentu
-loading=Wczytywanie... {{percent}}%
+
+# Loading indicator messages
 loading_error_indicator=Błąd
 loading_error=Wystąpił błąd podczas wczytywania pliku PDF.
-invalid_file_error=Błędny lub zepsuty plik PDF.
-rendering_error=Wystąpił błąd podczas wyświetlania strony.
-page_label=Strona:
-page_of=z {{pageCount}}
-no_outline=Konspekt nie jest dostępny
-open_file.title=Otwórz plik
+invalid_file_error=Błędny lub uszkodzony plik PDF.
+missing_file_error=Nie znaleziono pliku PDF.
+
+# LOCALIZATION NOTE (text_annotation_type): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 - Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
 text_annotation_type=[Komentarz {{type}}]
-toggle_slider_label=Przełącz suwak
-thumbs_label=Miniatury
-outline_label=Konspekt dokumentu
-bookmark_label=Aktualny widok
-previous_label=Wstecz
-next_label=Dalej
-print_label=Drukuj
-download_label=Pobierz
-zoom_out_label=Pomniejsz
-zoom_in_label=Powiększ
-zoom.title=Powiększenie
+request_password=Plik PDF jest chroniony przez hasło:
+
+printing_not_supported=Ostrzeżenie: Drukowanie nie jest w pełni obsługiwane przez tę przeglądarkę.
+web_fonts_disabled=Web fonty są nieaktywne. Nie można korzystać z osadzonych czcionek w plikach PDF.


### PR DESCRIPTION
I merged Polish viewer.properties into English file (only these lines that have equivalents in English file) and in this file I translated lines wasn't earlier in Polish file.

I only wasn't sure if "Web fonts"="Web fonty" in Polish and if I translated properly "web_fonts_disabled" .

removed values:
error_build
loading
toggle_slider.title
toggle_slider_label

added values:
toggle_sidebar.title
toggle_sidebar_label
presentation_mode.title
presentation_mode_label
open_file_label
findbar.title
findbar_label
thumb_page_title
thumb_page_canvas
first_page.label
last_page.label
page_rotate_cw.label
page_rotate_ccw.label
find_label
find_previous.title
find_previous_label
find_next.title
find_next_label
find_highlight
find_match_case_label
find_reached_top
find_reached_bottom
find_not_found
invalid_file_error
missing_file_error
request_password
printing_not_supported
web_fonts_disabled
