### PR TITLE
[Prototype] PDF browsing history

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -198,6 +198,10 @@ limitations under the License.
                     data-l10n-id="first_page" ></menuitem>
           <menuitem label="Last Page" id="last_page"
                     data-l10n-id="last_page" ></menuitem>
+          <menuitem label="Previous View" id="previous_view"
+                    data-l10n-id="previous_view" ></menuitem>
+          <menuitem label="Next View" id="next_view"
+                    data-l10n-id="next_view" ></menuitem>
           <menuitem label="Rotate Counter-Clockwise" id="page_rotate_ccw"
                     data-l10n-id="page_rotate_ccw" ></menuitem>
           <menuitem label="Rotate Clockwise" id="page_rotate_cw"


### PR DESCRIPTION
This PR implements a browsing history prototype for PDF files.
The back/forward functionality is currently accessed either from the context menu, or even simpler by using `Alt + left arrow`/`Alt + right arrow`.
With this PR it is possible to click on a link within a PDF file, and then return to the previous page.

Related issues: #900, #750 and [bug 842670](https://bugzilla.mozilla.org/show_bug.cgi?id=842670)
