### PR TITLE
Ignore empty strings for text selection

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2529,6 +2529,9 @@ var TextLayerBuilder = function textLayerBuilder(textLayerDiv, pageIdx) {
 
     for (var i = 0, ii = textDivs.length; i < ii; i++) {
       var textDiv = textDivs[i];
+      if ('isWhitespace' in textDiv.dataset) {
+        continue;
+      }
       textLayerFrag.appendChild(textDiv);
 
       ctx.font = textDiv.style.fontSize + ' ' + textDiv.style.fontFamily;
@@ -2601,6 +2604,10 @@ var TextLayerBuilder = function textLayerBuilder(textLayerDiv, pageIdx) {
     for (var i = 0; i < bidiTexts.length; i++) {
       var bidiText = bidiTexts[i];
       var textDiv = textDivs[i];
+      if (!/\S/.test(bidiText.str)) {
+        textDiv.dataset.isWhitespace = true;
+        continue;
+      }
 
       textDiv.textContent = bidiText.str;
       textDiv.dir = bidiText.ltr ? 'ltr' : 'rtl';


### PR DESCRIPTION
They were causing double selection.

Test PDF: (just change ext. to .pdf and it'll work)
![test.pdf](https://f.cloud.github.com/assets/2175324/186933/969ed37a-7d3e-11e2-9918-e20f04d46c58.png)
