### PR TITLE
Fix text selection for oddly-spaced TJ commands (Issue #2808)

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -1053,6 +1053,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       var canvasWidth = 0.0;
       var textSelection = textLayer ? true : false;
       var vertical = font.vertical;
+      var spacingAccumulator = 0;
 
       if (textSelection) {
         ctx.save();
@@ -1072,12 +1073,14 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
           }
 
           if (textSelection)
-            canvasWidth += spacingLength;
+            spacingAccumulator += spacingLength;
         } else if (isString(e)) {
           var shownCanvasWidth = this.showText(e, true);
 
-          if (textSelection)
-            canvasWidth += shownCanvasWidth;
+          if (textSelection) {
+            canvasWidth += spacingAccumulator + shownCanvasWidth;
+            spacingAccumulator = 0;
+          }
         } else {
           error('TJ array element ' + e + ' is not string or num');
         }


### PR DESCRIPTION
Proposed fix for issue #2808

This change will discard trailing space adjustments in TJ/showSpacedText()
for the purposes of calculating the text width for text selection. In
pathological cases, a PDF may write one character and then move the text
matrix back to the beginning of the character within one TJ invocation.
This would add up to a canvasWidth of 0, so the text selection <div> would
be scaled to zero pixels wide, even though the character was drawn
normally.

With this change, canvasWidth will not include any adjustments made after
the last character was written. Normal use of TJ will result in the same
text selection behavior, whereas pathological use of TJ will result in the
text selection layer matching the actual width of the characters
displayed.

For an example of such pathological behavior, see http://www.tycovalves-usa.com/ld/CROMC-0297-US.pdf#page=48
