### PR TITLE
Resize the zoom box width to fit the content - fix embedding

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -667,6 +667,7 @@ html[dir='rtl'] .dropdownToolbarButton {
 }
 
 .dropdownToolbarButton {
+  width: 120px;
   max-width: 120px;
   padding: 3px 2px 2px;
   overflow: hidden;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -3153,14 +3153,16 @@ window.addEventListener('localized', function localized(evt) {
   document.getElementsByTagName('html')[0].dir = mozL10n.getDirection();
 
   // Adjust the width of the zoom box to fit the content.
-  var container = document.getElementById('scaleSelectContainer');
-  var select = document.getElementById('scaleSelect');
-
-  select.setAttribute('style', 'min-width: inherit;');
-  var width = select.clientWidth + 8;
-  container.setAttribute('style', 'min-width: ' + width + 'px; ' +
-                                  'max-width: ' + width + 'px;');
-  select.setAttribute('style', 'min-width: ' + (width + 20) + 'px;');
+  PDFView.animationStartedPromise.then(
+    function() {
+      var container = document.getElementById('scaleSelectContainer');
+      var select = document.getElementById('scaleSelect');
+      select.setAttribute('style', 'min-width: inherit;');
+      var width = select.clientWidth + 8;
+      select.setAttribute('style', 'min-width: ' + (width + 20) + 'px;');
+      container.setAttribute('style', 'min-width: ' + width + 'px; ' +
+                                      'max-width: ' + width + 'px;');
+  });
 }, true);
 
 window.addEventListener('scalechange', function scalechange(evt) {


### PR DESCRIPTION
This PR is a follow-up of #2612, since that one break the zoom box if the viewer is embedded.
This patch fixes #2793, thanks @timvandermeij for reporting this issue.

Thanks to @yurydelendik for pointing out a simpler solution!
