### PR TITLE
Add "cursor: text;" to textLayer div CSS.

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1189,6 +1189,7 @@ canvas {
   position: absolute;
   line-height:1;
   white-space:pre;
+  cursor: text;
 }
 
 .textLayer .highlight {


### PR DESCRIPTION
Fixes problem caused by e4e4b1ab4ea4a6e44b84efa5a67237e2ad044b.

This is a workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=389283.
