### PR TITLE
Fix TypedArrays on IE9

### DIFF
--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -55,8 +55,14 @@
       result = [];
       for (var i = 0; i < arg1; ++i)
         result[i] = 0;
-    } else
+    } else if ('slice' in arg1) {
       result = arg1.slice(0);
+    } else {
+      result = [];
+      for (var i = 0, n = arg1.length; i < n; ++i) {
+        result[i] = arg1[i];
+      }
+    }
 
     result.subarray = subarray;
     result.buffer = result;


### PR DESCRIPTION
Uint8Array(imgData.data) fails because imgData.data doesn't have the slice method which the compatibility tries to use.

Fixes #2824
