### PR TITLE
Fix spacing calculation of TJ operator

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -1044,9 +1044,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       var current = this.current;
       var font = current.font;
       var fontSize = current.fontSize;
-      var textHScale = current.textHScale * (current.fontMatrix && !font.coded ?
-        current.fontMatrix[0] : FONT_IDENTITY_MATRIX[0]) *
-        current.fontDirection;
+      // TJ array's number is independent from fontMatrix
+      var textHScale = current.textHScale * 0.001 * current.fontDirection;
       var arrLength = arr.length;
       var textLayer = this.textLayer;
       var geom;


### PR DESCRIPTION
Fixes the first point of issue #2842.
TJ array's number is always divided by thousand, not by unitsPerEm.
(See PDF reference 9.4.3 Table 109 and 9.4.4.)
