### PR TITLE
Remove hmm.pdf in test

### DIFF
--- a/test/pdfs/hmm.pdf.link
+++ b/test/pdfs/hmm.pdf.link
@@ -1,1 +1,1 @@
-http://speech.tifr.res.in/tutorials/hmmTutExamplesAlgo.pdf
+http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.145.4773&rep=rep1&type=pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -193,9 +193,11 @@
     },
     {  "id": "hmm-pdf",
        "file": "pdfs/hmm.pdf",
-       "md5": "e08467e60101ee5f4a59716e86db6dc9",
+       "md5": "ea163ef2b6b69039e0c2c1364f280f67",
        "link": true,
        "rounds": 1,
+       "firstPage": 1,
+       "lastPage": 2,
        "type": "load"
     },
     {  "id": "rotation",


### PR DESCRIPTION
The link in test/pds/hmm.pdf.link http://speech.tifr.res.in/tutorials/hmmTutExamplesAlgo.pdf is gone
