### PR TITLE
Fix handling of [page /XYZ null null null] destinations.

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1523,8 +1523,10 @@ var PDFView = {
           if (zoomArgNumber)
             zoomArg = zoomArgNumber / 100;
 
-          var dest = [null, {name: 'XYZ'}, (zoomArgs[1] | 0),
-            (zoomArgs[2] | 0), zoomArg];
+          var dest = [null, {name: 'XYZ'},
+                      zoomArgs.length > 1 ? (zoomArgs[1] | 0) : null,
+                      zoomArgs.length > 2 ? (zoomArgs[2] | 0) : null,
+                      zoomArg];
           var currentPage = this.pages[pageNumber - 1];
           currentPage.scrollIntoView(dest);
         } else {
@@ -2036,6 +2038,12 @@ var PageView = function pageView(container, pdfPage, id, scale,
           x = dest[2];
           y = dest[3];
           scale = dest[4];
+          // If x and/or y coordinates are not supplied, default to
+          // _top_ left of the page (not the obvious bottom left,
+          // since aligning the bottom of the intended page with the
+          // top of the window is rarely helpful).
+          x = x !== null ? x : 0;
+          y = y !== null ? y : this.height / this.scale;
           break;
         case 'Fit':
         case 'FitB':


### PR DESCRIPTION
The PDF I linked to in issue #2835,
http://www.chiark.greenend.org.uk/%7Esgtatham/halibut/doc-1.0/halibut.pdf
uses the format [page /XYZ null null null] for all the destinations of its internal links (both hyperlinks between pages and links in the contents list), with the intention being to simply encode "go to that page" without specifying any particular position on the page or any change to the viewer's zoom setting.

pdf.js currently responds to this type of link by aligning the _bottom_ of the target page with the top of the window, so that you can't see any of the actual target page and instead you see a gutter followed by the page after the one targeted.

The patch in this pull request adjusts the default so that a null y-coordinate in an XYZ destination causes the top of the page rather than the bottom to be aligned with the top of the window, which seems more useful to me. x-coordinate handling is unchanged, so it should still default to the left (which seems as good a policy as any).
