### PR TITLE
Skip FontName vs. BaseFont check for Type 3 fonts

### DIFF
--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -1235,12 +1235,14 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         baseFont = new Name(baseFont);
       }
 
-      var fontNameStr = fontName && fontName.name;
-      var baseFontStr = baseFont && baseFont.name;
-      if (fontNameStr !== baseFontStr) {
-        warn('The FontDescriptor\'s FontName is "' + fontNameStr +
-            '" but should be the same as the Font\'s BaseFont "' +
-            baseFontStr + '"');
+      if (type.name !== 'Type3') {
+        var fontNameStr = fontName && fontName.name;
+        var baseFontStr = baseFont && baseFont.name;
+        if (fontNameStr !== baseFontStr) {
+          warn('The FontDescriptor\'s FontName is "' + fontNameStr +
+               '" but should be the same as the Font\'s BaseFont "' +
+               baseFontStr + '"');
+        }
       }
       fontName = fontName || baseFont;
 


### PR DESCRIPTION
Type 3 font dict does not have a BaseFont entry (see PDF Reference 9.6.5 Table 112). This check is actually causing false positives:
http://math.berkeley.edu/~daisuke/Bonn2013.pdf
http://math.berkeley.edu/~daisuke/BVSOL.pdf
http://www.ieice-hbkb.org/files/06/06gun_02hen_04.pdf
http://www.asahi-net.or.jp/~td6i-st/fuku-cathedral/new/gat.pdf
