### PR TITLE
Add toolbar URL parameter

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -114,7 +114,7 @@ limitations under the License.
           <label for="findMatchCase" class="toolbarLabel" tabindex="25" data-l10n-id="find_match_case_label">Match case</label>
           <span id="findMsg" class="toolbarLabel"></span>
         </div>
-        <div class="toolbar">
+        <div id="toolbar" class="toolbar">
           <div id="toolbarContainer">
             <div id="toolbarViewer">
               <div id="toolbarViewerLeft">

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1546,6 +1546,16 @@ var PDFView = {
           toggle.click();
         }
       }
+      if ('toolbar' in params) {
+        var toolbar = document.getElementById('toolbar');
+        if (params.toolbar === '0') {
+          toolbar.classList.add('hidden');
+          this.container.setAttribute('style', 'top: 0px;');
+        } else {
+          toolbar.classList.remove('hidden');
+          this.container.removeAttribute('style');
+        }
+      }
     } else if (/^\d+$/.test(hash)) // page number
       this.page = hash;
     else // named destination


### PR DESCRIPTION
This PR adds the `toolbar` URL parameter to pdf.js, see the specification: http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/pdf_open_parameters_v9.pdf#page=7.

Fixes #2784 and [bug 844350](https://bugzilla.mozilla.org/show_bug.cgi?id=844350).

**Work in progress, do not merge!**
