### PR TITLE
Tweak external links in fullscreen mode - follow up on #2712

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -88,6 +88,18 @@ select {
   margin-bottom: 100%;
 }
 
+:-webkit-full-screen a:not(.internalLink) {
+  display: none;
+}
+
+:-moz-full-screen a:not(.internalLink) {
+  display: none;
+}
+
+:fullscreen a:not(.internalLink) {
+  display: none;
+}
+
 #viewerContainer.presentationControls {
   cursor: default;
 }

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1932,6 +1932,7 @@ var PageView = function pageView(container, pdfPage, id, scale,
           PDFView.navigateTo(dest);
         return false;
       };
+      link.className = 'internalLink';
     }
     function createElementWithStyle(tagName, item, rect) {
       if (!rect) {


### PR DESCRIPTION
This PR is a follow up on #2712.
This patch changes external links so they don't appear to be click-able in fullscreen mode, since this most likely will confuse users.
