### PR TITLE
Scroll the Thumbnail of the current page into view when exiting fullscreen mode

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1730,6 +1730,10 @@ var PDFView = {
     this.page = this.page;
     this.clearMouseScrollState();
     this.hidePresentationControls();
+
+    // Ensure that the thumbnail of the current page is visible
+    // when exiting fullscreen mode.
+    scrollIntoView(document.getElementById('thumbnailContainer' + this.page));
   },
 
   showPresentationControls: function pdfViewShowPresentationControls() {


### PR DESCRIPTION
This PR fixes an issue with fullscreen mode where in some circumstances, particularly when going to the last page of a document while in fullscreen mode, the Thumbnails won't be scrolled into view properly when exiting fullscreen.

Follow up on #2509.
