### PR TITLE
Fix issue with 'this' binding in PdfStreamConverter

### DIFF
--- a/extensions/firefox/components/PdfStreamConverter.js
+++ b/extensions/firefox/components/PdfStreamConverter.js
@@ -337,6 +337,7 @@ ChromeActions.prototype = {
       }, '*');
     };
 
+    var self = this;
     this.dataListener.oncomplete =
       function ChromeActions_dataListenerComplete(data, errorCode) {
 
@@ -346,7 +347,7 @@ ChromeActions.prototype = {
         errorCode: errorCode
       }, '*');
 
-      delete this.dataListener;
+      delete self.dataListener;
     };
 
     return true;


### PR DESCRIPTION
`this` is incorrectly bound when it is called in PdfStreamConverter.
