### PR TITLE
Fix the calculation of default vertical metrics

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -989,7 +989,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
           var character = glyph.fontChar;
           var vmetric = glyph.vmetric || defaultVMetrics;
           if (vertical) {
-            var vx = vmetric[1] * fontSize * current.fontMatrix[0];
+            var vx = glyph.vmetric ? vmetric[1] : glyph.width * 0.5;
+            vx = -vx * fontSize * current.fontMatrix[0];
             var vy = vmetric[2] * fontSize * current.fontMatrix[0];
           }
           var width = vmetric ? -vmetric[0] : glyph.width;
@@ -1064,7 +1065,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         geom.canvasWidth = canvasWidth;
         if (vertical) {
           var vmetric = font.defaultVMetrics;
-          geom.x -= vmetric[1] * fontSize * current.fontMatrix[0] /
+          geom.x += vmetric[1] * fontSize * current.fontMatrix[0] /
                     fontSizeScale * geom.hScale;
           geom.y += vmetric[2] * fontSize * current.fontMatrix[0] /
                     fontSizeScale * geom.vScale;
@@ -1125,7 +1126,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         if (vertical) {
           var fontSizeScale = current.fontSizeScale;
           var vmetric = font.defaultVMetrics;
-          geom.x -= vmetric[1] * fontSize * current.fontMatrix[0] /
+          geom.x += vmetric[1] * fontSize * current.fontMatrix[0] /
                     fontSizeScale * geom.hScale;
           geom.y += vmetric[2] * fontSize * current.fontMatrix[0] /
                     fontSizeScale * geom.vScale;

--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -1047,7 +1047,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
         if (properties.vertical) {
           var vmetrics = dict.get('DW2') || [880, -1000];
-          defaultVMetrics = [vmetrics[1], vmetrics[1] / 2, vmetrics[0]];
+          defaultVMetrics = [vmetrics[1], defaultWidth * 0.5, vmetrics[0]];
           vmetrics = dict.get('W2');
           if (vmetrics) {
             for (var i = 0, ii = vmetrics.length; i < ii; i++) {


### PR DESCRIPTION
Fixes <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=849627">bug 849627</a> and <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=849628">849628</a>.
The current code was obviously wrong per the spec 9.7.4.3.
