### PR TITLE
Add back cid cff font test.

### DIFF
--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -684,6 +684,12 @@
       "link": true,
       "type": "eq"
     },
+    {  "id": "cid_cff",
+      "file": "pdfs/cid_cff.pdf",
+      "md5": "a19a18eaa626262cc45e0760004d6de9",
+      "rounds": 1,
+      "type": "eq"
+    },
     {  "id": "issue1155",
       "file": "pdfs/issue1155.pdf",
       "md5": "b732ef25c16c9c20a77e40edef5aa6fe",


### PR DESCRIPTION
FF19 is stable now. Undoes #2522 and we can mark #2045 as resolved.
