### PR TITLE
Fix where image component decoding takes place.

### DIFF
--- a/test/pdfs/issue2770.pdf.link
+++ b/test/pdfs/issue2770.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=718826

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -971,6 +971,14 @@
       "link": true,
       "type": "eq"
     },
+    {  "id": "issue2770",
+      "file": "pdfs/issue2770.pdf",
+      "md5": "36070d756d06eaa35c2227efb069fb1b",
+      "rounds": 1,
+      "link": true,
+      "type": "eq",
+      "about": "Has a 4 bit per component image with mask and decode."
+    },
     {  "id": "p020121130574743273239",
       "file": "pdfs/P020121130574743273239.pdf",
       "md5": "271b65885d42d174cbc597ca89becb1a",


### PR DESCRIPTION
Fixes #2770, #2847

The image in the PDF had 4 bits per component and a color mask.  The mask wasn't working correctly because it was being applied to the rgb buffer that was already decoded whereas it should have been applied to the raw components before decoding.
