### PR TITLE
Add a console warning when JavaScript/AcroForm/XFA was found

### DIFF
--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -390,7 +390,8 @@
   if (!('console' in window)) {
     window.console = {
       log: function() {},
-      error: function() {}
+      error: function() {},
+      warn: function() {}
     };
   } else if (!('bind' in console.log)) {
     // native functions in IE9 might not have bind
@@ -400,6 +401,9 @@
     console.error = (function(fn) {
       return function(msg) { return fn(msg); };
     })(console.error);
+    console.warn = (function(fn) {
+      return function(msg) { return fn(msg); };
+    })(console.warn);
   }
 })();
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1316,6 +1316,7 @@ var PDFView = {
       if (PDFView.supportsPrinting) {
         pdfDocument.getJavaScript().then(function(javaScript) {
           if (javaScript.length) {
+            console.warn('Warning: JavaScript is not supported');
             PDFView.fallback();
           }
           // Hack to support auto printing.
@@ -1389,7 +1390,7 @@ var PDFView = {
         self.setTitle(pdfTitle + ' - ' + document.title);
 
       if (info.IsAcroFormPresent) {
-        // AcroForm/XFA was found
+        console.warn('Warning: AcroForm/XFA is not supported');
         PDFView.fallback();
       }
     });


### PR DESCRIPTION
Currently I don't see any reasons in the console why the infobar is displayed.
