### PR TITLE
Stop the viewBookmark button from displaying nonsensical link during document load

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -826,6 +826,11 @@ html[dir='rtl'] .toolbarButton.pageDown::before {
   padding-top: 4px;
 }
 
+#viewBookmark[href='#'] {
+  opacity: .5;
+  pointer-events: none;
+}
+
 .toolbarButton.bookmark::before {
   content: url(images/toolbarButton-bookmark.png);
 }


### PR DESCRIPTION
This PR fixes [bug 795225](https://bugzilla.mozilla.org/show_bug.cgi?id=795225).

According to MDN, [pointer-events](https://developer.mozilla.org/en-US/docs/CSS/pointer-events) is not supported in all browsers. This is probably not a big issue, since the problem described in the bug seems to only affect the Firefox add-on.
