### PR TITLE
Refactor 'cmap' generation

### DIFF
--- a/test/pdfs/gesamt.pdf.link
+++ b/test/pdfs/gesamt.pdf.link
@@ -1,0 +1,1 @@
+http://www.gesetze-im-internet.de/bundesrecht/bgb/gesamt.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -933,6 +933,14 @@
       "link": true,
       "type": "eq"
     },
+    {  "id": "gesamt",
+      "file": "pdfs/gesamt.pdf",
+      "md5": "f9148b71aad9a7856f70f303d7e78703",
+      "rounds": 1,
+      "link": true,
+      "lastPage": 1,
+      "type": "eq"
+    },
     {  "id": "javauninstall-7",
       "file": "pdfs/javauninstall-7.pdf",
       "md5": "c9eb59503923c9125b9660e348618675",


### PR DESCRIPTION
Broken example: http://www.numark.jp/products/ns6/data/ns6_product_overview_JP_web.pdf

The current code is too inefficient to make the table size smaller than 64K.
Also fixes a potential problem in case the final startCode is already 0xFFFF.
