### PR TITLE
Convert all indexed colorspace values at once.

### DIFF
--- a/src/colorspace.js
+++ b/src/colorspace.js
@@ -385,12 +385,16 @@ var IndexedCS = (function IndexedCSClosure() {
       var numComps = base.numComps;
       var outputDelta = base.getOutputLength(numComps);
       var lookup = this.lookup;
-
+      // Copy all the values into a temporary array so we can convert the whole
+      // thing at once.
+      var temp = new Uint8Array(numComps * count);
       for (var i = 0; i < count; ++i) {
         var lookupPos = src[srcOffset++] * numComps;
-        base.getRgbBuffer(lookup, lookupPos, 1, dest, destOffset, 8);
-        destOffset += outputDelta;
+        for (var j = 0; j < numComps; ++j) {
+          temp[i * numComps + j] = lookup[lookupPos + j];
+        }
       }
+      base.getRgbBuffer(temp, 0, count, dest, destOffset, 8);
     },
     getOutputLength: function IndexedCS_getOutputLength(inputLength) {
       return this.base.getOutputLength(inputLength * this.base.numComps);


### PR DESCRIPTION
Use a temporary array to convert indexed color space buffers.  This avoids calling the base.getRGBBuffer functions a gazillion times.  Uses more memory but is much faster.

For example in issue1133.pdf I see the color space conversion go from 100ms to 8ms.
