### PR TITLE
Log how long it takes for the getDocument() to complete

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -132,8 +132,21 @@ function nextTask() {
       nextPage(task, failure);
     }
     try {
+      var docStats = new StatTimer();
+      docStats.time('GetDoc Request');
+
       var promise = PDFJS.getDocument(data);
       promise.then(function(doc) {
+
+        docStats.timeEnd('GetDoc Request');
+        var message = JSON.stringify({
+          browser: browser,
+          id: task.id,
+          round: task.round,
+          stats: docStats.times
+        });
+        send('/sendDocStats', message);
+
         task.pdfDoc = doc;
         continuation();
       }, function(e) {

--- a/test/test.py
+++ b/test/test.py
@@ -335,8 +335,25 @@ class PDFTestHandler(TestHandlerBase):
                 return
 
             id = result['id']
-            failure = result['failure']
             round = result['round']
+
+            if url.path == '/sendDocStats':
+                if not State.saveStats:
+                    return
+
+                stat = {
+                    'browser': browser,
+                    'pdf': id,
+                    # Use special page '0' to denote stats about full doc
+                    'page': 0,
+                    'round': round,
+                    'stats': result['stats'],
+                }
+
+                State.stats.append(stat)
+                return
+
+            failure = result['failure']
             page = result['page']
             snapshot = result['snapshot']
 


### PR DESCRIPTION
Was trying something to see if I could make `Lexer.getNumber()` faster. That didn't work out, but coded up this as a consequence.
