### PR TITLE
Add PDF.js license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,5 +10,11 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/mozilla/pdf.js.git"
-  }
+  },
+  "licenses": [
+    {
+      "type": "Apache v2",
+      "url": "https://github.com/mozilla/pdf.js/blob/master/LICENSE"
+    }
+  ]
 }


### PR DESCRIPTION
NPM spec allows for the PDF.js license in the package.json. For completeness, I added it in :)

https://npmjs.org/doc/json.html
