### PR TITLE
Add another preference check to detect if web fonts are disabled in Firefox

### DIFF
--- a/extensions/firefox/components/PdfStreamConverter.js
+++ b/extensions/firefox/components/PdfStreamConverter.js
@@ -376,8 +376,9 @@ ChromeActions.prototype = {
            'updateControlState' in getChromeWindow(this.domWindow).gFindBar;
   },
   supportsDocumentFonts: function() {
-    var pref = getIntPref('browser.display.use_document_fonts', 1);
-    return !!pref;
+    var prefBrowser = getIntPref('browser.display.use_document_fonts', 1);
+    var prefGfx = getBoolPref('gfx.downloadable_fonts.enabled', true);
+    return (!!prefBrowser && prefGfx);
   },
   fallback: function(url, sendResponse) {
     var self = this;


### PR DESCRIPTION
This PR adds a check of the preference `gfx.downloadable_fonts.enabled`. Setting this to false currently doesn't trigger a warning that the PDF file might be displayed incorrectly, even though most PDF files I've tried fails to display correctly when `gfx.downloadable_fonts.enabled = false`.

This a follow-up of #2425.
