### PR TITLE
Update Swedish locale with 'printing_not_ready' string

### DIFF
--- a/l10n/sv/viewer.properties
+++ b/l10n/sv/viewer.properties
@@ -121,4 +121,5 @@ text_annotation_type=[{{type}}-anteckning]
 request_password=PDF-filen är lösenordsskyddad:
 
 printing_not_supported=Varning: Utskrifter stöds inte fullt ut av denna webbläsare.
+printing_not_ready=Varning: Hela PDF-filen måste laddas innan utskrift kan ske.
 web_fonts_disabled=Webbtypsnitt är inaktiverade: Typsnitt inkluderade i PDF-filer kan ej användas.


### PR DESCRIPTION
Adds missing string to `viewer.properties`.
