### PR TITLE
Fixes PDF application switch in Firefox.

### DIFF
--- a/extensions/firefox/content/PdfJs.jsm
+++ b/extensions/firefox/content/PdfJs.jsm
@@ -192,6 +192,7 @@ let PdfJs = {
     var handlerInfo = Svc.mime.
                         getFromTypeAndExtension('application/pdf', 'pdf');
     return handlerInfo.alwaysAskBeforeHandling == false &&
+           handlerInfo.plugin == null &&
            handlerInfo.preferredAction == Ci.nsIHandlerInfo.handleInternally;
   },
 


### PR DESCRIPTION
Based on http://mxr.mozilla.org/mozilla-central/source/browser/components/preferences/applications.js#300 , if plugin is specified the preferredAction is irrelevant.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=855666
