### PR TITLE
Detect and add fallback if document colors are disabled in Firefox

### DIFF
--- a/extensions/firefox/components/PdfStreamConverter.js
+++ b/extensions/firefox/components/PdfStreamConverter.js
@@ -383,6 +383,9 @@ ChromeActions.prototype = {
     var prefGfx = getBoolPref('gfx.downloadable_fonts.enabled', true);
     return (!!prefBrowser && prefGfx);
   },
+  supportsDocumentColors: function() {
+    return getBoolPref('browser.display.use_document_colors', true);
+  },
   fallback: function(url, sendResponse) {
     var self = this;
     var domWindow = this.domWindow;

--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -123,3 +123,4 @@ request_password=PDF is protected by a password:
 printing_not_supported=Warning: Printing is not fully supported by this browser.
 printing_not_ready=Warning: The PDF is not fully loaded for printing.
 web_fonts_disabled=Web fonts are disabled: unable to use embedded PDF fonts.
+web_colors_disabled=Web colors are disabled.

--- a/l10n/sv/viewer.properties
+++ b/l10n/sv/viewer.properties
@@ -122,4 +122,5 @@ request_password=PDF-filen är lösenordsskyddad:
 
 printing_not_supported=Varning: Utskrifter stöds inte fullt ut av denna webbläsare.
 printing_not_ready=Varning: Hela PDF-filen måste laddas innan utskrift kan ske.
-web_fonts_disabled=Webbtypsnitt är inaktiverade: Typsnitt inkluderade i PDF-filer kan ej användas.
+web_fonts_disabled=Webbtypsnitt är inaktiverade: Typsnitt inbäddade i PDF-filer kan ej användas.
+web_colors_disabled=Webbfärger är inaktiverade.

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -922,6 +922,19 @@ var PDFView = {
     return support;
   },
 
+  get supportsDocumentColors() {
+    var support = true;
+//#if !(FIREFOX || MOZCENTRAL)
+//#else
+//  support = FirefoxCom.requestSync('supportsDocumentColors');
+//#endif
+    Object.defineProperty(this, 'supportsDocumentColors', { value: support,
+                                                            enumerable: true,
+                                                            configurable: true,
+                                                            writable: false });
+    return support;
+  },
+
   get isHorizontalScrollbarEnabled() {
     var div = document.getElementById('viewerContainer');
     return div.scrollWidth > div.clientWidth;
@@ -2261,6 +2274,12 @@ var PageView = function pageView(container, id, scale,
 //        !PDFView.supportsDocumentFonts) {
 //      console.error(mozL10n.get('web_fonts_disabled', null,
 //        'Web fonts are disabled: unable to use embedded PDF fonts.'));
+//      PDFView.fallback();
+//    }
+//    if (self.textLayer && self.textLayer.textDivs.length &&
+//        !PDFView.supportsDocumentColors) {
+//      console.error(mozL10n.get('web_colors_disabled', null,
+//        'Web colors are disabled.'));
 //      PDFView.fallback();
 //    }
 //#endif


### PR DESCRIPTION
This PR adds a check of the Firefox preference `browser.display.use_document_colors`, and triggers the fallback if appropriate.

Related issue: https://bugzilla.mozilla.org/show_bug.cgi?id=843473
