### PR TITLE
Explicitly define layout of toolbar buttons

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -391,12 +391,14 @@ html[dir='ltr'] #toolbarViewerLeft > *,
 html[dir='ltr'] #toolbarViewerMiddle > *,
 html[dir='ltr'] #toolbarViewerRight > *,
 html[dir='ltr'] .findbar > * {
+  position: relative;
   float: left;
 }
 html[dir='rtl'] #toolbarViewerLeft > *,
 html[dir='rtl'] #toolbarViewerMiddle > *,
 html[dir='rtl'] #toolbarViewerRight > *,
 html[dir='rtl'] .findbar > * {
+  position: relative;
   float: right;
 }
 
@@ -747,6 +749,14 @@ html[dir='rtl'] #findPrevious {
 html[dir='rtl'] #findNext {
   margin-left: 3px;
 }
+.toolbarButton::before {
+  /* All matching images have a size of 16x16
+   * (except for the print button: 18x16)
+   * All relevant containers have a size of 32x25 */
+  position: absolute;
+  top: 4px;
+  left: 7px;
+}
 
 html[dir='ltr'] .toolbarButton.findPrevious::before {
   display: inline-block;
@@ -806,6 +816,7 @@ html[dir='rtl'] .toolbarButton.pageDown::before {
 .toolbarButton.print::before {
   display: inline-block;
   content: url(images/toolbarButton-print.png);
+  left: 6px;
 }
 
 .toolbarButton.openFile::before {


### PR DESCRIPTION
Before:
- Firefox's buttons looks OK
- Chrome (quirks mode): Buttons were aligned to the bottom (too much)
- Chrome (standards mode): Buttons were aligned to the top (too much)
- Opera/IE/Safari: Like Chrome (standards): Buttons too high

(Too high = Compare the other buttons to the rightmost button)

After:
- Firefox's button positions didn't change at all
- All buttons are aligned at the same level, across all browsers

Screenshots for comparisons:
https://rob.lekensteyn.nl/pdfjs/
https://rob.lekensteyn.nl/pdfjs/buttons-firefox-before.png
https://rob.lekensteyn.nl/pdfjs/buttons-firefox-after.png
https://rob.lekensteyn.nl/pdfjs/buttons-chrome-before.png
https://rob.lekensteyn.nl/pdfjs/buttons-chrome-after.png
https://rob.lekensteyn.nl/pdfjs/buttons-opera-before.png
https://rob.lekensteyn.nl/pdfjs/buttons-opera-after.png
https://rob.lekensteyn.nl/pdfjs/buttons-safari-before.png
https://rob.lekensteyn.nl/pdfjs/buttons-safari-after.png
https://rob.lekensteyn.nl/pdfjs/buttons-ie-before.png
https://rob.lekensteyn.nl/pdfjs/buttons-ie-after.png
