### PR TITLE
Fix for Issue 2998 – "Consider using `window.parent !== window` instead of `!!window.frameElement`"

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -886,7 +886,7 @@ var PDFView = {
                   doc.webkitRequestFullScreen;
 
     // Disable fullscreen button if we're in an iframe
-    if (!!window.frameElement)
+    if (window.parent !== window)
       support = false;
 
     Object.defineProperty(this, 'supportsFullScreen', { value: support,


### PR DESCRIPTION
I hope this fixes the issue. This is my first pull request, so I hope I didn't do anything wrong.
