### PR TITLE
Remove redundant getOperatorList()

### DIFF
--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -281,10 +281,6 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
             xobj.dict.get('Resources') || resources,
             dependencyArray, queue);
 
-        self.getOperatorList(xobj,
-                             xobj.dict.get('Resources') || resources,
-                             dependencyArray, queue);
-
         // Add the dependencies that are required to execute the
         // operatorList.
         insertDependency(dependencyArray.slice(depIdx));


### PR DESCRIPTION
There are two `getOperatorList()` calls in a row. Pretty sure this is a typo.
