### PR TITLE
Disable outline button when unavailable

### DIFF
--- a/l10n/ar/viewer.properties
+++ b/l10n/ar/viewer.properties
@@ -53,9 +53,6 @@ thumbs_label=الصور المصغرة
 findbar.title=البحث في المستند
 findbar_label=بحث
 
-# Document outline messages
-no_outline=لا يوجد ملخص
-
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
 # number.

--- a/l10n/ca/viewer.properties
+++ b/l10n/ca/viewer.properties
@@ -55,9 +55,6 @@ thumbs_label=Miniatures
 findbar.title=Cercar en el document
 findbar_label=Cercar
 
-# Document outline messages
-no_outline=No hi ha cap esquema disponible
-
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
 # number.

--- a/l10n/cs/viewer.properties
+++ b/l10n/cs/viewer.properties
@@ -40,7 +40,6 @@ loading_error=Došlo k chybě při načítání PDF.
 rendering_error=Došlo k chybě při vykreslování stránky.
 page_label=Stránka:
 page_of=z{{pageCount}}
-no_outline=Žádné osnovy k dispozici
 open_file.title=Otevřít soubor
 text_annotation_type=[{{type}}Anotace]
 toggle_slider_label=Přepnout posuvník

--- a/l10n/da/viewer.properties
+++ b/l10n/da/viewer.properties
@@ -53,9 +53,6 @@ thumbs_label=Thumbnails
 findbar.title=Søg i dokumentet
 findbar_label=Søg
 
-# Dokumentoversigtsbeskeder
-no_outline=Ingen dokumentoversigt tilgængelig
-
 # Thumbnails panelet (tooltips og alt. billedtekst)
 # Oversættelsesnote: "{{page}}" vil blive erstattet af det
 # egentlige sidetal

--- a/l10n/de/viewer.properties
+++ b/l10n/de/viewer.properties
@@ -53,9 +53,6 @@ thumbs_label=Vorschaubilder
 findbar.title=Im Dokument suchen
 findbar_label=Suchen
 
-# Document outline messages
-no_outline=Kein Inhaltsverzeichnis verfügbar
-
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
 # number.

--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -53,9 +53,6 @@ thumbs_label=Thumbnails
 findbar.title=Find in Document
 findbar_label=Find
 
-# Document outline messages
-no_outline=No Outline Available
-
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
 # number.

--- a/l10n/es-MX/viewer.properties
+++ b/l10n/es-MX/viewer.properties
@@ -53,9 +53,6 @@ thumbs_label=Miniaturas
 findbar.title=Buscar en el documento
 findbar_label=Buscar
 
-# Document outline messages
-no_outline=No hay esquema disponible
-
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
 # number.

--- a/l10n/es/viewer.properties
+++ b/l10n/es/viewer.properties
@@ -53,9 +53,6 @@ thumbs_label=Miniaturas
 findbar.title=Buscar en el documento
 findbar_label=Buscar
 
-# Document outline messages
-no_outline=No hay un esquema disponible
-
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
 # number.

--- a/l10n/fi/viewer.properties
+++ b/l10n/fi/viewer.properties
@@ -53,9 +53,6 @@ thumbs_label=Esikatselukuvat
 findbar.title=Etsi asiakirjasta
 findbar_label=Etsi
 
-# Document outline messages
-no_outline=Jäsennystä ei ole tarjolla
-
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
 # number.

--- a/l10n/fr/viewer.properties
+++ b/l10n/fr/viewer.properties
@@ -53,9 +53,6 @@ thumbs_label=Vignettes
 findbar.title=Rechercher dans le document
 findbar_label=Rechercher
 
-# Document outline messages
-no_outline=Aucun signet disponible
-
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
 # number.

--- a/l10n/he/viewer.properties
+++ b/l10n/he/viewer.properties
@@ -40,7 +40,6 @@ loading_error=אירעה שגיאה בעת טעינת קובץ PDF.
 rendering_error=אירעה שגיאה בעת עיבוד הדף.
 page_label=דף:
 page_of=מתוך {{pageCount}}
-no_outline=אין מתאר זמין
 open_file.title=פתיחת קובץ
 text_annotation_type=[{{type}} Annotation]
 toggle_slider_label=מתג החלקה

--- a/l10n/it/viewer.properties
+++ b/l10n/it/viewer.properties
@@ -40,6 +40,5 @@ loading_error=È accaduto un errore durante il caricamento del PDF.
 rendering_error=È accaduto un errore durante il rendering della pagina.
 page_label=Pagina:
 page_of=di {{pageCount}}
-no_outline=Nessun Indice Disponibile
 open_file.title=Apri File
 text_annotation_type=[{{type}} Annotazione]

--- a/l10n/ja/viewer.properties
+++ b/l10n/ja/viewer.properties
@@ -53,9 +53,6 @@ thumbs_label=縮小版
 findbar.title=検索
 findbar_label=検索
 
-# Document outline messages
-no_outline=利用可能な目次はありません
-
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
 # number.

--- a/l10n/lt/viewer.properties
+++ b/l10n/lt/viewer.properties
@@ -53,9 +53,6 @@ thumbs_label=Miniatiūros
 findbar.title=Paieška dokumente
 findbar_label=Paieška
 
-# Document outline messages
-no_outline=Turinys nėra galimas
-
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
 # number.

--- a/l10n/nl/viewer.properties
+++ b/l10n/nl/viewer.properties
@@ -53,9 +53,6 @@ thumbs_label=Miniaturen
 findbar.title=Zoeken in document
 findbar_label=Zoeken
 
-# Document outline messages
-no_outline=Geen documentstructuur beschikbaar
-
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
 # number.

--- a/l10n/pl/viewer.properties
+++ b/l10n/pl/viewer.properties
@@ -53,9 +53,6 @@ thumbs_label=Miniatury
 findbar.title=Szukaj w tekście
 findbar_label=Znajdź
 
-# Document outline messages
-no_outline=Konspekt nie jest dostępny
-
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
 # number.

--- a/l10n/pt-BR/viewer.properties
+++ b/l10n/pt-BR/viewer.properties
@@ -40,6 +40,5 @@ loading_error=Um erro ocorreu ao carregar o arquivo.
 rendering_error=Um erro ocorreu ao apresentar a página.
 page_label=Página:
 page_of=de {{pageCount}}
-no_outline=Índice não disponível
 open_file.title=Abrir arquivo
 text_annotation_type=[{{type}} Anotações]

--- a/l10n/ro/viewer.properties
+++ b/l10n/ro/viewer.properties
@@ -40,7 +40,6 @@ loading_error=S-a produs o eroare în timpul încărcării documentului.
 rendering_error=S-a produs o eroare în timpul procesării paginii.
 page_label=Pagina:
 page_of=din {{pageCount}}
-no_outline=Cuprins indisponibil
 open_file.title=Deschide fișier
 text_annotation_type=[Adnotare {{type}}]
 toggle_slider_label=Vedere de ansamblu

--- a/l10n/ru/viewer.properties
+++ b/l10n/ru/viewer.properties
@@ -40,7 +40,6 @@ loading_error=Произошла ошибка во время загрузки P
 rendering_error=Произошла ошибка во время создания страницы.
 page_label=Страница:
 page_of=из {{pageCount}}
-no_outline=Содержание не доступно
 open_file.title=Открыть файл
 text_annotation_type=[Аннотация {{type}}]
 toggle_slider_label=Вспомогательная панель

--- a/l10n/sr/viewer.properties
+++ b/l10n/sr/viewer.properties
@@ -40,7 +40,6 @@ loading_error=Дошло је до грешке током учитавања П
 rendering_error=Дошло је до грешке приликом приказивања стране.
 page_label=Страна:
 page_of=од {{pageCount}}
-no_outline=Нема линија
 open_file.title=Отвори датотеку
 text_annotation_type=[{{type}} Annotation]
 toggle_slider_label=Клизач

--- a/l10n/sv/viewer.properties
+++ b/l10n/sv/viewer.properties
@@ -53,9 +53,6 @@ thumbs_label=Sidminiatyrer
 findbar.title=Sök i dokumentet
 findbar_label=Sök
 
-# Document outline messages
-no_outline=Inga bokmärken tillgängliga
-
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
 # number.

--- a/l10n/tr/viewer.properties
+++ b/l10n/tr/viewer.properties
@@ -53,9 +53,6 @@ thumbs_label=Önizleme
 findbar.title=Döküman içerisinde bul
 findbar_label=Bul
 
-# Document outline messages
-no_outline=Kenarlık Mevcut Değil
-
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
 # number.

--- a/l10n/zh-CN/viewer.properties
+++ b/l10n/zh-CN/viewer.properties
@@ -53,9 +53,6 @@ thumbs_label=缩略图
 findbar.title=在该文档内查找
 findbar_label=查找
 
-# Document outline messages
-no_outline=没有可用的大纲
-
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
 # number.

--- a/l10n/zh-TW/viewer.properties
+++ b/l10n/zh-TW/viewer.properties
@@ -51,9 +51,6 @@ thumbs_label=縮圖
 findbar.title=在文件中搜尋
 findbar_label=搜索
 
-# 文件綱要相關訊息
-no_outline=無可用的綱要
-
 # 縮圖面板項目 (工具提示和圖像的替代文字)
 # 本地化提示 (thumb_page_title): "{{page}}" 會被頁數取代。
 thumb_page_title=第 {{page}} 頁

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1061,7 +1061,6 @@ html[dir='rtl'] .outlineItem > a {
   color: hsla(0,0%,100%,1);
 }
 
-.noOutline,
 .noResults {
   font-size: 12px;
   color: hsla(0,0%,100%,.8);

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1444,6 +1444,7 @@ var PDFView = {
     PDFJS.Promise.all(promises).then(function() {
       pdfDocument.getOutline().then(function(outline) {
         self.outline = new DocumentOutlineView(outline);
+        document.getElementById('viewOutline').disabled = !outline;
       });
 
       // Make all navigation keys work on document load,
@@ -2622,8 +2623,16 @@ var ThumbnailView = function thumbnailView(container, id, defaultViewport) {
 
 var DocumentOutlineView = function documentOutlineView(outline) {
   var outlineView = document.getElementById('outlineView');
+  var outlineButton = document.getElementById('viewOutline');
   while (outlineView.firstChild)
     outlineView.removeChild(outlineView.firstChild);
+
+  if (!outline) {
+    if (!outlineView.classList.contains('hidden'))
+      PDFView.switchSidebarView('thumbs');
+
+    return;
+  }
 
   function bindItemLink(domObj, item) {
     domObj.href = PDFView.getDestinationHash(item.dest);
@@ -2633,14 +2642,6 @@ var DocumentOutlineView = function documentOutlineView(outline) {
     };
   }
 
-  if (!outline) {
-    var noOutline = document.createElement('div');
-    noOutline.classList.add('noOutline');
-    noOutline.textContent = mozL10n.get('no_outline', null,
-      'No Outline Available');
-    outlineView.appendChild(noOutline);
-    return;
-  }
 
   var queue = [{parent: outlineView, items: outline}];
   while (queue.length > 0) {


### PR DESCRIPTION
This is a little accessibility that bugs me, the outline button is clickable although there's no outline available. This PR disables the button (but still creates the `DocumentOutlineView`).

Thoughts on this? If you like this, maybe I should just prevent the creation of a `DocumentOutlineView` in cases where there's no outline?
