### PR TITLE
Implement core support for named actions, and some viewer functionality

### DIFF
--- a/src/annotation.js
+++ b/src/annotation.js
@@ -674,6 +674,8 @@ var LinkAnnotation = (function LinkAnnotationClosure() {
         }
         data.url = url;
         data.dest = action.get('D');
+      } else if (linkType === 'Named') {
+        data.action = action.get('N').name;
       } else {
         TODO('unrecognized link type: ' + linkType);
       }

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2427,6 +2427,53 @@ var PageView = function pageView(container, id, scale,
       };
       link.className = 'internalLink';
     }
+    function bindNamedAction(link, action) {
+      link.onclick = function pageViewSetupNamedActionOnClick() {
+        // See PDF reference, table 8.45 - Named action
+        console.log('Click with action', action);
+        switch (action) {
+          case 'GoToPage':
+            document.getElementById('pageNumber').focus();
+            break;
+
+          case 'GoBack':
+            PDFHistory.back();
+            // TODO implement
+            break;
+
+          case 'GoForward':
+            PDFHistory.forward();
+            // TODO implement
+            break;
+
+          case 'Find':
+            PDFFindBar.toggle();
+            break;
+
+          case 'NextPage':
+            PDFView.page++;
+            break;
+
+          case 'PrevPage':
+            PDFView.page--;
+            break;
+
+          case 'LastPage':
+            PDFView.page = PDFView.pages.length;
+            break;
+
+          case 'FirstPage':
+            PDFView.page = 1;
+            break;
+
+          default:
+            // No action according to spec
+        }
+
+        return false;
+      };
+      link.className = 'internalLink';
+    }
 
     pdfPage.getAnnotations().then(function(annotationsData) {
       viewport = viewport.clone({ dontFlip: true });
@@ -2460,7 +2507,11 @@ var PageView = function pageView(container, id, scale,
         CustomStyle.setProp('transformOrigin', element, transformOriginStr);
 
         if (data.subtype === 'Link' && !data.url) {
-          bindLink(element, ('dest' in data) ? data.dest : null);
+          if (data.action) {
+            bindNamedAction(element, data.action);
+          } else {
+            bindLink(element, ('dest' in data) ? data.dest : null);
+          }
         }
 
         annotationsDiv.appendChild(element);


### PR DESCRIPTION
This PR implements core support for Named Actions (just recognizing them, instead of discarding them), described in the PDF reference, section 8.5

Furthermore I've implemented some of the most used Named Actions (non are standardized to my knowledge). Adobe, implements almost all of their menu items, but I've implemented the following:
- `GoToPage`: Focuses the page input element
- `Find`: Toggles the search panel
- `NextPage`, `PrevPage`, `FirstPage` and `LastPage`

This also implements a `FirefoxCom` action called `toggleFindBar` - which toggles the find bar.

Fixes #3030
