### PR TITLE
Github pages are now located at github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pdf.js.
 
 For an online demo, visit:
 
-+ http://mozilla.github.com/pdf.js/web/viewer.html
++ http://mozilla.github.io/pdf.js/web/viewer.html
 
 This demo provides an interactive interface for displaying and browsing PDFs
 using the pdf.js API.
@@ -27,7 +27,7 @@ using the pdf.js API.
 A Firefox extension is availble in two places:
 
 + Stable Version: https://addons.mozilla.org/firefox/addon/pdfjs
-+ Development Version: http://mozilla.github.com/pdf.js/extensions/firefox/pdf.js.xpi
++ Development Version: http://mozilla.github.io/pdf.js/extensions/firefox/pdf.js.xpi
 
 The development extension should be quite stable but still might break from time to time.
 Also, note that the development extension is updated on every merge and by default Firefox will
@@ -107,7 +107,7 @@ More information about the contributor process can be found on the
 
 If you don't want to hack on the project or have little spare time, __you still
 can help!__ Just open PDFs in the 
-[online demo](http://mozilla.github.com/pdf.js/web/viewer.html) and report 
+[online demo](http://mozilla.github.io/pdf.js/web/viewer.html) and report 
 any breakage in rendering.
 
 Our Github contributors so far:


### PR DESCRIPTION
This saves the network communication a HTTP 301 Moved Permanently, so that we all can live in a CO2 neutral world.
