### PR TITLE
Ask for password on failed decryption

### DIFF
--- a/l10n/da/viewer.properties
+++ b/l10n/da/viewer.properties
@@ -103,5 +103,6 @@ loading_error=Der skete en fejl under indlæsningen af PDF-filen
 # Nogle almindelige typer er f.eks.: "Check", "Text", "Comment" og "Note"
 text_annotation_type=[{{type}} Kommentar]
 request_password=PDF filen er beskyttet med et kodeord:
+invalid_password=Ugyldigt kodeord.
 
 printing_not_supported=Advarsel: Denne browser er ikke fuldt understøttet ved udskrift

--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -119,6 +119,7 @@ missing_file_error=Missing PDF file.
 # Some common types are e.g.: "Check", "Text", "Comment", "Note"
 text_annotation_type=[{{type}} Annotation]
 request_password=PDF is protected by a password:
+invalid_password=Invalid Password.
 
 printing_not_supported=Warning: Printing is not fully supported by this browser.
 printing_not_ready=Warning: The PDF is not fully loaded for printing.

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1008,9 +1008,16 @@ var PDFView = {
       },
       function getDocumentError(message, exception) {
         if (exception && exception.name === 'PasswordException') {
-          if (exception.code === 'needpassword') {
+          if (exception.code === 'needpassword' ||
+              exception.code === 'incorrectpassword') {
             var promptString = mozL10n.get('request_password', null,
                                       'PDF is protected by a password:');
+
+            if (exception.code === 'incorrectpassword') {
+              promptString += '\n' + mozL10n.get('invalid_password', null,
+                                      'Invalid Password.');
+            }
+
             password = prompt(promptString);
             if (password && password.length > 0) {
               return PDFView.open(url, scale, password);


### PR DESCRIPTION
Fixes #2556 by asking again.

I think this is normal behaviour. One could also implement a special "you failed, try again" message, but I don't know if that's relevant.
