### PR TITLE
Fix priority of which font encoding is used.

### DIFF
--- a/src/fonts.js
+++ b/src/fonts.js
@@ -3104,7 +3104,7 @@ var Font = (function FontClosure() {
           encoding[code] = glyphName;
         }
         properties.glyphNameMap = glyphNameMap;
-        if (!properties.hasEncoding)
+        if (properties.overridableEncoding)
           properties.baseEncoding = encoding;
       }
 
@@ -5345,7 +5345,7 @@ var Type1Parser = (function Type1ParserClosure() {
                 }
               }
             }
-            if (!properties.hasEncoding && encoding) {
+            if (properties.overridableEncoding && encoding) {
               properties.baseEncoding = encoding;
               break;
             }

--- a/test/pdfs/issue3064.pdf.link
+++ b/test/pdfs/issue3064.pdf.link
@@ -1,0 +1,2 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=733257
+

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1013,6 +1013,14 @@
       "type": "eq",
       "about": "Has a 4 bit per component image with mask and decode."
     },
+    {  "id": "issue3064",
+      "file": "pdfs/issue3064.pdf",
+      "md5": "0307415b7d69b13acaf8bd4285d9544b",
+      "rounds": 1,
+      "link": true,
+      "type": "eq",
+      "about": "True type font with encoding dict with no base encoding but with differences."
+    },
     {  "id": "p020121130574743273239",
       "file": "pdfs/P020121130574743273239.pdf",
       "md5": "271b65885d42d174cbc597ca89becb1a",

--- a/test/unit/font_spec.js
+++ b/test/unit/font_spec.js
@@ -383,7 +383,7 @@ describe('font', function() {
         'dup 33 /arrowright put\n' +
         'readonly def\n');
       var parser = new Type1Parser(stream);
-      var props = {};
+      var props = { overridableEncoding: true };
       var program = parser.extractFontHeader(props);
       expect(props.baseEncoding[33]).toEqual('arrowright');
     });


### PR DESCRIPTION
The true type file in this font had an encoding dictionary that didn't have a baseEncoding but it did have a differences array (the spec says this shouldn't happen).  Following some of poppler's logic on encoding handling we should still mark the font as having an encoding in this case though.

I'm still a bit iffy on our encoding handling code and thinking we should maybe revisit and more closely follow popplers lead since they've dealt with all of this already.

Fixes #3064
I expect issue1936 to fail.  It's currently wrong and still wrong after.
