### PR TITLE
Fix disabling of zoom buttons and add camel case button names

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -166,11 +166,11 @@ limitations under the License.
               <div class="outerCenter">
                 <div class="innerCenter" id="toolbarViewerMiddle">
                   <div class="splitToolbarButton">
-                    <button class="toolbarButton zoomOut" id="zoom_out" title="Zoom Out" tabindex="9" data-l10n-id="zoom_out">
+                    <button id="zoomOut" class="toolbarButton zoomOut" title="Zoom Out" tabindex="9" data-l10n-id="zoom_out">
                       <span data-l10n-id="zoom_out_label">Zoom Out</span>
                     </button>
                     <div class="splitToolbarButtonSeparator"></div>
-                    <button class="toolbarButton zoomIn" id="zoom_in" title="Zoom In" tabindex="10" data-l10n-id="zoom_in">
+                    <button id="zoomIn" class="toolbarButton zoomIn" title="Zoom In" tabindex="10" data-l10n-id="zoom_in">
                       <span data-l10n-id="zoom_in_label">Zoom In</span>
                      </button>
                   </div>
@@ -202,13 +202,13 @@ limitations under the License.
         </div>
 
         <menu type="context" id="viewerContextMenu">
-          <menuitem label="First Page" id="first_page"
+          <menuitem id="firstPage" label="First Page"
                     data-l10n-id="first_page" ></menuitem>
-          <menuitem label="Last Page" id="last_page"
+          <menuitem id="lastPage" label="Last Page"
                     data-l10n-id="last_page" ></menuitem>
-          <menuitem label="Rotate Counter-Clockwise" id="page_rotate_ccw"
+          <menuitem id="pageRotateCcw" label="Rotate Counter-Clockwise"
                     data-l10n-id="page_rotate_ccw" ></menuitem>
-          <menuitem label="Rotate Clockwise" id="page_rotate_cw"
+          <menuitem id="pageRotateCw" label="Rotate Clockwise"
                     data-l10n-id="page_rotate_cw" ></menuitem>
         </menu>
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -3159,7 +3159,7 @@ document.addEventListener('DOMContentLoaded', function webViewerLoad(evt) {
   }
 
   if (PDFView.supportsIntegratedFind) {
-    document.querySelector('#viewFind').classList.add('hidden');
+    document.getElementById('viewFind').classList.add('hidden');
   }
 
   // Listen for warnings to trigger the fallback UI.  Errors should be caught
@@ -3210,12 +3210,12 @@ document.addEventListener('DOMContentLoaded', function webViewerLoad(evt) {
       PDFView.page++;
     });
 
-  document.querySelector('.zoomIn').addEventListener('click',
+  document.getElementById('zoomIn').addEventListener('click',
     function() {
       PDFView.zoomIn();
     });
 
-  document.querySelector('.zoomOut').addEventListener('click',
+  document.getElementById('zoomOut').addEventListener('click',
     function() {
       PDFView.zoomOut();
     });
@@ -3260,22 +3260,22 @@ document.addEventListener('DOMContentLoaded', function webViewerLoad(evt) {
       PDFView.parseScale(this.value);
     });
 
-  document.getElementById('first_page').addEventListener('click',
+  document.getElementById('firstPage').addEventListener('click',
     function() {
       PDFView.page = 1;
     });
 
-  document.getElementById('last_page').addEventListener('click',
+  document.getElementById('lastPage').addEventListener('click',
     function() {
       PDFView.page = PDFView.pdfDocument.numPages;
     });
 
-  document.getElementById('page_rotate_ccw').addEventListener('click',
+  document.getElementById('pageRotateCcw').addEventListener('click',
     function() {
       PDFView.rotatePages(-90);
     });
 
-  document.getElementById('page_rotate_cw').addEventListener('click',
+  document.getElementById('pageRotateCw').addEventListener('click',
     function() {
       PDFView.rotatePages(90);
     });
@@ -3421,6 +3421,9 @@ window.addEventListener('localized', function localized(evt) {
 }, true);
 
 window.addEventListener('scalechange', function scalechange(evt) {
+  document.getElementById('zoomOut').disabled = (evt.scale === MIN_SCALE);
+  document.getElementById('zoomIn').disabled = (evt.scale === MAX_SCALE);
+
   var customScaleOption = document.getElementById('customScaleOption');
   customScaleOption.selected = false;
 
@@ -3437,10 +3440,6 @@ window.addEventListener('scalechange', function scalechange(evt) {
     customScaleOption.textContent = Math.round(evt.scale * 10000) / 100 + '%';
     customScaleOption.selected = true;
   }
-  
-  document.getElementById('zoom_out').disabled = (evt.scale === MIN_SCALE);
-  document.getElementById('zoom_in').disabled = (evt.scale === MAX_SCALE);
-
   updateViewarea();
 }, true);
 


### PR DESCRIPTION
If the user zooms in (or out) until the maximum (minimum) zoom level is reached, the corresponding zoom button will be disabled. If the user now chooses a predefined zoom level in the drop down box, for example "Page Fit", the disabled zoom button won't be re-enabled.
This PR fixes the above, and also changes a couple of related button names to camel case. Lastly, this PR also replaces a couple instances of `querySelector` with `getElementById`.
