### PR TITLE
Use 512 as a max pattern size

### DIFF
--- a/src/pattern.js
+++ b/src/pattern.js
@@ -268,7 +268,8 @@ var TilingPattern = (function TilingPatternClosure() {
     COLORED: 1,
     UNCOLORED: 2
   };
-  var MAX_PATTERN_SIZE = 4096;
+
+  var MAX_PATTERN_SIZE = 512;
 
   function TilingPattern(IR, color, ctx, objs, commonObjs) {
     var operatorList = IR[2];


### PR DESCRIPTION
This fixes a regression #3153 which was introduced by #2177.
Having too large MAX_PATTERN_SIZE causes huge pixmaps to be created
that will lead to OOM.
