### PR TITLE
[PROTOTYPE] Implements chunked rendering

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -176,41 +176,42 @@ var Page = (function PageClosure() {
         var resources = data[1];
 
         pdfManager.ensure(partialEvaluator, 'getOperatorList',
-                          [contentStream, resources]).then(
+                          [contentStream, resources, 1000]).then(
           function(opListPromise) {
-            opListPromise.then(function(data) {
-              pageListPromise.resolve(data);
+            opListPromise.then(function() {
+              pageListPromise.resolve();
             });
           }
         );
       });
 
-      pdfManager.ensure(this, 'getAnnotationsForDraw', []).then(
-        function(annotations) {
-          pdfManager.ensure(partialEvaluator, 'getAnnotationsOperatorList',
-                            [annotations]).then(
-            function(opListPromise) {
-              opListPromise.then(function(data) {
-                annotationListPromise.resolve(data);
-              });
-            }
-          );
-        }
-      );
+      //pdfManager.ensure(this, 'getAnnotationsForDraw', []).then(
+      //  function(annotations) {
+      //    pdfManager.ensure(partialEvaluator, 'getAnnotationsOperatorList',
+      //                      [annotations]).then(
+      //      function(opListPromise) {
+      //        opListPromise.then(function(data) {
+      //          annotationListPromise.resolve(data);
+      //        });
+      //      }
+      //    );
+      //  }
+      //);
 
-      Promise.all([pageListPromise, annotationListPromise]).then(
-        function(datas) {
-          var pageData = datas[0];
-          var pageQueue = pageData.queue;
-          var annotationData = datas[1];
-          var annotationQueue = annotationData.queue;
-          Util.concatenateToArray(pageQueue.fnArray, annotationQueue.fnArray);
-          Util.concatenateToArray(pageQueue.argsArray,
-                                  annotationQueue.argsArray);
-          PartialEvaluator.optimizeQueue(pageQueue);
-          Util.extendObj(pageData.dependencies, annotationData.dependencies);
+      Promise.all([pageListPromise/*, annotationListPromise*/]).then(
+        function(/*datas*/) {
+          //var pageData = datas[0];
+          //var pageQueue = pageData.queue;
+          //var annotationData = datas[1];
+          //var annotationQueue = annotationData.queue;
+          //Util.concatenateToArray(pageQueue.fnArray, annotationQueue.fnArray);
+          //Util.concatenateToArray(pageQueue.argsArray,
+          //                        annotationQueue.argsArray);
+          //PartialEvaluator.optimizeQueue(pageQueue);
+          //Util.extendObj(pageData.dependencies, annotationData.dependencies);
 
-          promise.resolve(pageData);
+          //promise.resolve(pageData);
+          promise.resolve();
         }
       );
 

--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -19,7 +19,8 @@
            IDENTITY_MATRIX, info, isArray, isCmd, isDict, isEOF, isName, isNum,
            isStream, isString, JpegStream, Lexer, Metrics, Name, Parser,
            Pattern, PDFImage, PDFJS, serifFonts, stdFontMap, symbolsFonts,
-           TilingPattern, TODO, warn, Util, MissingDataException, Promise */
+           TilingPattern, TODO, warn, Util, MissingDataException, Promise,
+           isInt */
 
 'use strict';
 
@@ -585,8 +586,12 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     },
 
     getOperatorList: function PartialEvaluator_getOperatorList(stream,
-                                                               resources) {
+                                                               resources,
+                                                               chunkSize) {
 
+      if (isInt(chunkSize)) {
+        this.chunkId = 0;
+      }
       var self = this;
       var xref = this.xref;
       var handler = this.handler;
@@ -607,11 +612,51 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       // dictionary
       var parser = new Parser(new Lexer(stream, OP_MAP), false, xref);
 
+      function sendRenderPageChunk(
+          handler, operatorList, dependencies, chunkId, isLastChunk) {
+        // Filter the dependecies for fonts.
+        var fonts = {};
+        for (var dep in dependencies) {
+          if (dep.indexOf('g_font_') === 0) {
+            fonts[dep] = true;
+          }
+        }
+
+        PartialEvaluator.optimizeQueue(operatorList);
+
+        handler.send('RenderPageChunk', {
+          pageIndex: self.pageIndex,
+          operatorList: operatorList,
+          chunkId: chunkId,
+          isLastChunk: isLastChunk,
+          depFonts: Object.keys(fonts)
+        });
+      }
+
       var promise = new Promise();
       function parseCommands() {
+        function afterParseSubOperatorList(data) {
+          // The reason we are only sending chunks at top level is because
+          // nested operator lists might have stuff added before and after
+          // them
+
+          var subQueue = data.queue;
+          Util.concatenateToArray(fnArray, subQueue.fnArray);
+          Util.concatenateToArray(argsArray, subQueue.argsArray);
+          queue.transparency = subQueue.transparency || queue.transparency;
+          Util.extendObj(dependencies, data.dependencies);
+
+          parser.saveState();
+          args = [];
+
+          // Continue parsing at next tick to prevent stack overflow
+          handler.send('nextTick', null, parseCommands);
+        }
+
+        var args = [];
+        parser.restoreState();
+
         try {
-          parser.restoreState();
-          var args = [];
           while (true) {
 
             var obj = parser.getObj();
@@ -668,10 +713,10 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
                   var typeNum = dict.get('PatternType');
 
                   if (typeNum == TILING_PATTERN) {
-                    var patternPromise = self.handleTilingType(
-                        fn, args, resources, pattern, dict);
-                    fn = 'promise';
-                    args = [patternPromise];
+                    //fn = 'promise';
+                    self.handleTilingType(fn, args, resources, pattern,
+                        dict).then(afterParseSubOperatorList);
+                    return;
                   } else if (typeNum == SHADING_PATTERN) {
                     var shading = dict.get('Shading');
                     var matrix = dict.get('Matrix');
@@ -697,8 +742,11 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
                   );
 
                   if ('Form' == type.name) {
-                    fn = 'promise';
-                    args = [self.buildFormXObject(resources, xobj)];
+                    //fn = 'promise';
+                    //args = [self.buildFormXObject(resources, xobj)];
+                    self.buildFormXObject(resources, xobj).then(
+                        afterParseSubOperatorList);
+                    return;
                   } else if ('Image' == type.name) {
                     var data = self.buildPaintImageXObject(
                         resources, xobj, false);
@@ -711,8 +759,10 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
                   }
                 }
               } else if (cmd == 'Tf') { // eagerly collect all fonts
-                fn = 'promise';
-                args = [self.handleSetFont(resources, args)];
+                //fn = 'promise';
+                self.handleSetFont(resources, args).then(
+                    afterParseSubOperatorList);
+                return;
               } else if (cmd == 'EI') {
                 var data = self.buildPaintImageXObject(
                     resources, args[0], true);
@@ -751,13 +801,25 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
                     break;
 
                   var gState = extGState.get(dictName.name);
-                  fn = 'promise';
-                  args = [self.setGState(resources, gState)];
+                  //fn = 'promise';
+                  self.setGState(resources, gState).then(
+                      afterParseSubOperatorList);
+                  return;
               } // switch
 
               fnArray.push(fn);
               argsArray.push(args);
               args = [];
+
+              if (isInt(chunkSize) && fnArray.length >= chunkSize) {
+                sendRenderPageChunk(handler, {
+                  fnArray: fnArray,
+                  argsArray: argsArray
+                }, dependencies, self.chunkId++, false);
+                queue.fnArray = fnArray = [];
+                queue.argsArray = argsArray = [];
+                dependencies = {};
+              }
               parser.saveState();
             } else if (obj !== null && obj !== undefined) {
               args.push(obj instanceof Dict ? obj.getAll() : obj);
@@ -765,54 +827,71 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
             }
           }
 
-          var subQueuePromises = [];
-          for (var i = 0; i < fnArray.length; ++i) {
-            if (fnArray[i] === 'promise') {
-              subQueuePromises.push(argsArray[i][0]);
-            }
-          }
-          Promise.all(subQueuePromises).then(function(datas) {
-            // TODO(mack): Optimize by using repositioning elements
-            // in original queue rather than creating new queue
+          //var subQueuePromises = [];
+          //for (var i = 0; i < fnArray.length; ++i) {
+          //  if (fnArray[i] === 'promise') {
+          //    subQueuePromises.push(argsArray[i][0]);
+          //  }
+          //}
+          //Promise.all(subQueuePromises).then(function(datas) {
+          //  // TODO(mack): Optimize by using repositioning elements
+          //  // in original queue rather than creating new queue
 
-            for (var i = 0, n = datas.length; i < n; ++i) {
-              var data = datas[i];
-              var subQueue = data.queue;
-              queue.transparency = subQueue.transparency || queue.transparency;
-              Util.extendObj(dependencies, data.dependencies);
-            }
+          //  for (var i = 0, n = datas.length; i < n; ++i) {
+          //    var data = datas[i];
+          //    var subQueue = data.queue;
+          //    queue.transparency = subQueue.transparency || queue.transparency;
+          //    Util.extendObj(dependencies, data.dependencies);
+          //  }
 
-            var newFnArray = [];
-            var newArgsArray = [];
-            var currOffset = 0;
-            var subQueueIdx = 0;
-            for (var i = 0, n = fnArray.length; i < n; ++i) {
-              var offset = i + currOffset;
-              if (fnArray[i] === 'promise') {
-                var data = datas[subQueueIdx++];
-                var subQueue = data.queue;
-                var subQueueFnArray = subQueue.fnArray;
-                var subQueueArgsArray = subQueue.argsArray;
-                for (var j = 0, nn = subQueueFnArray.length; j < nn; ++j) {
-                  newFnArray[offset + j] = subQueueFnArray[j];
-                  newArgsArray[offset + j] = subQueueArgsArray[j];
-                }
-                currOffset += subQueueFnArray.length - 1;
-              } else {
-                newFnArray[offset] = fnArray[i];
-                newArgsArray[offset] = argsArray[i];
-              }
-            }
+          //  var newFnArray = [];
+          //  var newArgsArray = [];
+          //  var currOffset = 0;
+          //  var subQueueIdx = 0;
+          //  for (var i = 0, n = fnArray.length; i < n; ++i) {
+          //    var offset = i + currOffset;
+          //    if (fnArray[i] === 'promise') {
+          //      var data = datas[subQueueIdx++];
+          //      var subQueue = data.queue;
+          //      var subQueueFnArray = subQueue.fnArray;
+          //      var subQueueArgsArray = subQueue.argsArray;
+          //      for (var j = 0, nn = subQueueFnArray.length; j < nn; ++j) {
+          //        newFnArray[offset + j] = subQueueFnArray[j];
+          //        newArgsArray[offset + j] = subQueueArgsArray[j];
+          //      }
+          //      currOffset += subQueueFnArray.length - 1;
+          //    } else {
+          //      newFnArray[offset] = fnArray[i];
+          //      newArgsArray[offset] = argsArray[i];
+          //    }
+          //  }
 
+          //  promise.resolve({
+          //    queue: {
+          //      fnArray: newFnArray,
+          //      argsArray: newArgsArray,
+          //      transparency: queue.transparency
+          //    },
+          //    dependencies: dependencies
+          //  });
+          //});
+          if (!isInt(chunkSize)) {
             promise.resolve({
               queue: {
-                fnArray: newFnArray,
-                argsArray: newArgsArray,
+                fnArray: fnArray,
+                argsArray: argsArray,
                 transparency: queue.transparency
               },
               dependencies: dependencies
             });
-          });
+          } else {
+            sendRenderPageChunk(handler, {
+              fnArray: fnArray,
+              argsArray: argsArray
+            }, dependencies, self.chunkId++, true);
+
+            promise.resolve();
+          }
         } catch (e) {
           if (!(e instanceof MissingDataException)) {
             throw e;

--- a/src/worker.js
+++ b/src/worker.js
@@ -367,31 +367,33 @@ var WorkerMessageHandler = {
         var pageNum = data.pageIndex + 1;
         var start = Date.now();
         // Pre compile the pdf page and fetch the fonts/images.
-        page.getOperatorList(handler).then(function(opListData) {
+        page.getOperatorList(handler).then(function() {
 
-          var operatorList = opListData.queue;
-          var dependency = Object.keys(opListData.dependencies);
+          //var operatorList = opListData.queue;
+          //var dependency = Object.keys(opListData.dependencies);
 
           // The following code does quite the same as
           // Page.prototype.startRendering, but stops at one point and sends the
           // result back to the main thread.
 
-          log('page=%d - getOperatorList: time=%dms, len=%d', pageNum,
-              Date.now() - start, operatorList.fnArray.length);
+          console.log('time:' + (Date.now() - start) / 1000);
+          //console.log('opListLen:' + operatorList.fnArray.length + ':time:' + (Date.now() - start)/1000);
+          //log('page=%d - getOperatorList: time=%dms, len=%d', pageNum,
+          //    Date.now() - start, operatorList.fnArray.length);
 
-          // Filter the dependecies for fonts.
-          var fonts = {};
-          for (var i = 0, ii = dependency.length; i < ii; i++) {
-            var dep = dependency[i];
-            if (dep.indexOf('g_font_') === 0) {
-              fonts[dep] = true;
-            }
-          }
-          handler.send('RenderPage', {
-            pageIndex: data.pageIndex,
-            operatorList: operatorList,
-            depFonts: Object.keys(fonts)
-          });
+          //// Filter the dependecies for fonts.
+          //var fonts = {};
+          //for (var i = 0, ii = dependency.length; i < ii; i++) {
+          //  var dep = dependency[i];
+          //  if (dep.indexOf('g_font_') === 0) {
+          //    fonts[dep] = true;
+          //  }
+          //}
+          //handler.send('RenderPage', {
+          //  pageIndex: data.pageIndex,
+          //  operatorList: operatorList,
+          //  depFonts: Object.keys(fonts)
+          //});
         }, function(e) {
 
           var minimumStackMessage =


### PR DESCRIPTION
This PR implements chunked rendering of the operator list of each page. That is, we will render chunks of the operator list as they are parsed, rather than rendering after the  entire operator list has been parsed.

Before #2719, these changes had a significant improvement on the rendering times of PDFs with large operator lists such as the maps in #2541 and #2813. However, rebasing on the progressive loading changes of #2719 seems to have killed most of this improvement. I'll need to investigate if it's possible to gain back the potential improvements from chunked rendering.
