### PR TITLE
Ignore malformed dictionary entries.

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -17,7 +17,7 @@
 /* globals Ascii85Stream, AsciiHexStream, CCITTFaxStream, Cmd, Dict, error,
            FlateStream, isArray, isCmd, isDict, isInt, isName, isNum, isRef,
            isString, Jbig2Stream, JpegStream, JpxStream, LZWStream, Name,
-           NullStream, PredictorStream, Ref, RunLengthStream, warn */
+           NullStream, PredictorStream, Ref, RunLengthStream, warn, info */
 
 'use strict';
 
@@ -85,8 +85,11 @@ var Parser = (function ParserClosure() {
         this.shift();
         var dict = new Dict(this.xref);
         while (!isCmd(this.buf1, '>>') && !isEOF(this.buf1)) {
-          if (!isName(this.buf1))
-            error('Dictionary key must be a name object');
+          if (!isName(this.buf1)) {
+            info('Malformed dictionary, key must be a name object');
+            this.shift();
+            continue;
+          }
 
           var key = this.buf1.name;
           this.shift();

--- a/test/pdfs/bug808084.pdf.link
+++ b/test/pdfs/bug808084.pdf.link
@@ -1,0 +1,2 @@
+http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n1984.pdf
+

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1051,6 +1051,14 @@
       "type": "eq",
       "about": "Has a 4 bit per component image with mask and decode."
     },
+    {  "id": "bug808084",
+      "file": "pdfs/bug808084.pdf",
+      "md5": "b1c400de699af29ea3f1983bb26870ab",
+      "link": true,
+      "rounds": 1,
+      "lastPage": 1,
+      "type": "load"
+    },
     {  "id": "issue3064",
       "file": "pdfs/issue3064.pdf",
       "md5": "0307415b7d69b13acaf8bd4285d9544b",


### PR DESCRIPTION
A dictionary in a pdf has a string that has missing parens so it screws up everything else, but we can ignore and it works fine.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=808084
