### PR TITLE
Fixes issue 3076 (viewer off by one page)

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2236,10 +2236,16 @@ var PageView = function pageView(container, id, scale,
           return;
       }
 
-      if (scale && scale !== PDFView.currentScale)
+      if (scale && scale !== PDFView.currentScale) {
         PDFView.parseScale(scale, true, true);
-      else if (PDFView.currentScale === UNKNOWN_SCALE)
+      } else if (PDFView.currentScale === UNKNOWN_SCALE) {
         PDFView.parseScale(DEFAULT_SCALE, true, true);
+      }
+
+      if (scale === 'page-fit' && !dest[4]) {
+        scrollIntoView(div);
+        return;
+      }
 
       var boundingRect = [
         this.viewport.convertToViewportPoint(x, y),


### PR DESCRIPTION
As the title says, this fixes #3076.

Edit: This PR only fixes the second issue described in the attached PDF file in #3076.
The third issue behaves the same way in pdf.js and Adobe Reader, so this must be an error in the PDF file.
