### PR TITLE
Fix type3 font loading regression.

### DIFF
--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -467,6 +467,13 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "issue3188",
+      "file": "pdfs/issue3188.pdf",
+      "md5": "161b72604d86f40ab2f765ddd3b61227",
+      "rounds": 1,
+      "lastPage": 1,
+      "type": "eq"
+    },
     {  "id": "issue1586",
       "file": "pdfs/pdfjsbad1586.pdf",
       "md5": "793d0870f0b0c613799b0677d64daca4",


### PR DESCRIPTION
Type3 fonts were showing as loaded even though the operator lists for them hadn't finished loading.  I moved some the code around and hopefully made it more explicit when the font is loaded by adding a .loaded flag.  

Fixes #3188 and #3196
