### PR TITLE
Adds fill('evenodd') as alternative for mozFillRule

### DIFF
--- a/test/features/tests.js
+++ b/test/features/tests.js
@@ -362,10 +362,13 @@ var tests = [
       var ctx = canvas.getContext('2d');
       ctx.rect(1, 1, 50, 50);
       ctx.rect(5, 5, 41, 41);
-      ['fillRule', 'mozFillRule', 'webkitFillRule'].forEach(function (name) {
-        if (name in ctx) ctx[name] = 'evenodd';
-      });
-      ctx.fill();
+
+      if ('mozFillRule' in ctx) {
+        ctx.mozFillRule = 'evenodd';
+        ctx.fill();
+      } else {
+        ctx.fill('evenodd');
+      }
 
       var data = ctx.getImageData(0, 0, 50, 50).data;
       var isEvenOddFill = data[20 * 4 + 20 * 200 + 3] == 0 &&


### PR DESCRIPTION
Addresses #2351. `ctx.fill('evenodd');` is available in current Chrome and Firefox 21.

Based on https://bugzilla.mozilla.org/show_bug.cgi?id=827053
