### PR TITLE
Fixes bug 863591

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -120,4 +120,4 @@ request_password=PDF is protected by a password:
 printing_not_supported=Warning: Printing is not fully supported by this browser.
 printing_not_ready=Warning: The PDF is not fully loaded for printing.
 web_fonts_disabled=Web fonts are disabled: unable to use embedded PDF fonts.
-web_colors_disabled=Web colors are disabled.
+document_colors_disabled=PDF documents are not allowed to use their own colors: \'Allow pages to choose their own colors\' is deactivated in the browser.

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2377,8 +2377,10 @@ var PageView = function pageView(container, id, scale,
 //    if (self.textLayer && self.textLayer.textDivs &&
 //        self.textLayer.textDivs.length > 0 &&
 //        !PDFView.supportsDocumentColors) {
-//      console.error(mozL10n.get('web_colors_disabled', null,
-//        'Web colors are disabled.'));
+//      console.error(mozL10n.get('document_colors_disabled', null,
+//        'PDF documents are not allowed to use their own colors: ' +
+//        '\'Allow pages to choose their own colors\' ' +
+//        'is deactivated in the browser.'));
 //      PDFView.fallback();
 //    }
 //#endif


### PR DESCRIPTION
This should resolve the ambiguity of the error message when document colors are disabled in Firefox. The error message is now somewhat verbose, but should be a lot clearer.
