### PR TITLE
Fix document loading with zoom set to 'page-fit', regression from #2719

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -754,6 +754,11 @@ var PDFView = {
     }, true);
   },
 
+  getPageTop: function pdfViewGetPageTop(currentId) {
+    var currentPage = this.pages[(currentId || this.page) - 1];
+    return (currentPage.el.offsetTop + currentPage.el.clientTop);
+  },
+
   setScale: function pdfViewSetScale(val, resetAutoSettings, noScroll) {
     if (val == this.currentScale)
       return;
@@ -1360,6 +1365,7 @@ var PDFView = {
       };
     }
 
+    var self = this;
     this.pdfDocument = pdfDocument;
 
     var errorWrapper = document.getElementById('errorWrapper');
@@ -1370,6 +1376,11 @@ var PDFView = {
       loadingBar.classList.add('hidden');
       var outerContainer = document.getElementById('outerContainer');
       outerContainer.classList.remove('loadingInProgress');
+
+      if (self.currentScaleValue === 'page-fit') {
+        var noScroll = (self.pageViewScroll.lastY !== self.getPageTop());
+        self.parseScale(self.currentScaleValue, true, noScroll);
+      }
     });
 
     var thumbsView = document.getElementById('thumbnailView');
@@ -1403,7 +1414,6 @@ var PDFView = {
     var thumbnails = this.thumbnails = [];
 
     var pagesPromise = this.pagesPromise = new PDFJS.Promise();
-    var self = this;
 
     var firstPagePromise = pdfDocument.getPage(1);
 


### PR DESCRIPTION
This PR fixes an issue when the PDF document is loaded with zoom set to 'page-fit'.
Currently, once the progressive loading bar is removed, the pages will be slightly shorter than the viewer height. To see this issue, try opening: http://mozilla.github.io/pdf.js/web/viewer.html#page=2&zoom=page-fit.
