### PR TITLE
Propagate promise rejections so we show the fallback.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -156,6 +156,10 @@ var Page = (function PageClosure() {
       var self = this;
       var promise = new Promise();
 
+      function reject(e) {
+        promise.reject(e);
+      }
+
       var pageListPromise = new Promise();
       var annotationListPromise = new Promise();
 
@@ -170,7 +174,7 @@ var Page = (function PageClosure() {
             this.idCounters);
 
       var dataPromises = Promise.all(
-          [contentStreamPromise, resourcesPromise]);
+          [contentStreamPromise, resourcesPromise], reject);
       dataPromises.then(function(data) {
         var contentStream = data[0];
         var resources = data[1];
@@ -181,7 +185,8 @@ var Page = (function PageClosure() {
             opListPromise.then(function(data) {
               pageListPromise.resolve(data);
             });
-          }
+          },
+          reject
         );
       });
 
@@ -195,7 +200,8 @@ var Page = (function PageClosure() {
               });
             }
           );
-        }
+        },
+        reject
       );
 
       Promise.all([pageListPromise, annotationListPromise]).then(
@@ -211,7 +217,8 @@ var Page = (function PageClosure() {
           Util.extendObj(pageData.dependencies, annotationData.dependencies);
 
           promise.resolve(pageData);
-        }
+        },
+        reject
       );
 
       return promise;

--- a/src/worker.js
+++ b/src/worker.js
@@ -137,7 +137,8 @@ var WorkerMessageHandler = {
             javaScript: results[6]
           };
           loadDocumentPromise.resolve(doc);
-        });
+        },
+        parseFailure);
       };
 
       var parseFailure = function parseFailure(e) {
@@ -261,7 +262,7 @@ var WorkerMessageHandler = {
 
       var onSuccess = function(doc) {
         handler.send('GetDoc', { pdfInfo: doc });
-        pdfManager.ensureModel('traversePages', []);
+        pdfManager.ensureModel('traversePages', []).then(null, onFailure);
       };
 
       var onFailure = function(e) {


### PR DESCRIPTION
-Adds rejection support to Promise.All.
-Makes promise.then() callback optional.

Fixes: #3138

I'm also working on a subsequent PR that will hopefully simplify things with better promises.
