### PR TITLE
Implement default preferences in Firefox

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -240,6 +240,75 @@ var Settings = (function SettingsClosure() {
   return Settings;
 })();
 
+// Preferences Manager - utility for storing persistant settings.
+// The preferences are stored in about:config,
+// hence only Firefox is currently supported.
+var Preferences = (function PreferencesClosure() {
+  function Preferences() {
+    this.initializedPromise = new PDFJS.Promise();
+
+    var resolvePromise = (function preferencesResolvePromise(prefString) {
+      this.initialize(prefString || '{}');
+      this.initializedPromise.resolve();
+    }).bind(this);
+
+//#if (FIREFOX || MOZCENTRAL)
+//  resolvePromise(FirefoxCom.requestSync('getUserPrefs'));
+//#else
+    resolvePromise();
+//#endif
+  }
+
+  Preferences.prototype = {
+    initialize: function preferencesInitialize(prefString) {
+      this.prefObj = JSON.parse(prefString);
+    },
+
+    reload: function preferencesReload() {
+      if (!this.initializedPromise.isResolved) {
+        return;
+      }
+
+//#if (FIREFOX || MOZCENTRAL)
+//    this.initialize(FirefoxCom.requestSync('getUserPrefs'));
+//#endif
+    },
+
+    reset: function preferencesReset() {
+      if (!this.initializedPromise.isResolved) {
+        return;
+      }
+      this.prefObj = {};
+
+//#if (FIREFOX || MOZCENTRAL)
+//    this.initialize(FirefoxCom.requestSync('resetUserPrefs'));
+//#endif
+    },
+
+    set: function preferencesSet(name, value) {
+      if (!this.initializedPromise.isResolved) {
+        return;
+      }
+      var pref = {};
+      pref[name] = value;
+      var prefString = JSON.stringify(pref);
+
+//#if (FIREFOX || MOZCENTRAL)
+//    this.initialize(FirefoxCom.requestSync('setUserPrefs', prefString));
+//#endif
+    },
+
+    get: function preferencesGet(name) {
+      if (!this.initializedPromise.isResolved) {
+        return null;
+      }
+      return this.prefObj[name];
+    }
+  };
+
+  return Preferences;
+})();
+
 var cache = new Cache(CACHE_SIZE);
 var currentPageNumber = 1;
 
@@ -1690,6 +1759,7 @@ var PDFView = {
 
     PDFView.documentFingerprint = id;
     var store = PDFView.store = new Settings(id);
+    var prefs = PDFView.prefs = new Preferences();
 
     this.pageRotation = 0;
 
@@ -1753,16 +1823,21 @@ var PDFView = {
     });
 
     var storePromise = store.initializedPromise;
-    PDFJS.Promise.all([firstPagePromise, storePromise]).then(function() {
+    var prefsPromise = prefs.initializedPromise;
+    PDFJS.Promise.all([firstPagePromise, storePromise, prefsPromise]).
+        then(function() {
+      var defaultZoomValue = prefs.get('defaultZoomValue');
       var storedHash = null;
       if (store.get('exists', false)) {
         var pageNum = store.get('page', '1');
-        var zoom = store.get('zoom', PDFView.currentScale);
+        var zoom = defaultZoomValue || store.get('zoom', PDFView.currentScale);
         var left = store.get('scrollLeft', '0');
         var top = store.get('scrollTop', '0');
 
         storedHash = 'page=' + pageNum + '&zoom=' + zoom + ',' +
                      left + ',' + top;
+      } else if (defaultZoomValue) {
+        storedHash = 'page=1&zoom=' + defaultZoomValue;
       }
       // Initialize the browsing history.
       PDFHistory.initialize(self.documentFingerprint);
@@ -1812,6 +1887,13 @@ var PDFView = {
       pdfDocument.getOutline().then(function(outline) {
         self.outline = new DocumentOutlineView(outline);
         document.getElementById('viewOutline').disabled = !outline;
+
+        if (outline && prefs.get('ifAvailableShowOutlineOnLoad')) {
+          if (!self.sidebarOpen) {
+            document.getElementById('sidebarToggle').click();
+          }
+          self.switchSidebarView('outline');
+        }
       });
     });
 


### PR DESCRIPTION
This PR contains a suggested approach for implementing default preferences in the Firefox version of pdf.js. This uses `about:config` to store the preferences, hence this will only work in the Firefox add-on and should also work in the version of pdf.js that is included in Firefox.

This PR implements a framework for reading/writing of default preferences, so it should be easy to add more preferences if needed. (Since most preferences that I can think of only matters when a document is loaded, I haven't bothered adding any preference observers.)
Currently this PR adds the following three preferences (default values in bold):

`PREF_PREFIX.showPreviousViewOnLoad` = **true** | false.
Setting this preference to false will always load the document at the first page.
Related issue: #2568.

`PREF_PREFIX.defaultZoomValue` = **{empty string}**
Setting this preference to either a numerical value, or one of the predefined zoom values, will load all documents at the user defined zoom level. To avoid issues if the user sets this to an non-existent value, part of PR #2970 is needed. 
Related issue: #1624.

`PREF_PREFIX.ifAvailableShowOutlineOnLoad`  = **false** | true
Setting this to true will automatically display the outline when the document, but _only if_ the document actually contains an outline. Setting this to true would save the user opening the sidebar just to see if an outline is available. This is a much improved version of #2691.

As a follow-up to this PR, I've got a prototype UI for displaying and changing these preferences in the viewer.

/cc @brendandahl, @yurydelendik: What are your opinions about this approach?
