### PR TITLE
Fix issue with resizing the zoom box width - follow-up of #2816

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -30,6 +30,8 @@ var MIN_SCALE = 0.25;
 var MAX_SCALE = 4.0;
 var SETTINGS_MEMORY = 20;
 var HISTORY_DISABLED = false;
+var SCALE_SELECT_CONTAINER_PADDING = 8;
+var SCALE_SELECT_PADDING = 22;
 var RenderingStates = {
   INITIAL: 0,
   RUNNING: 1,
@@ -3729,15 +3731,19 @@ window.addEventListener('localized', function localized(evt) {
   document.getElementsByTagName('html')[0].dir = mozL10n.getDirection();
 
   // Adjust the width of the zoom box to fit the content.
-  PDFView.animationStartedPromise.then(
-    function() {
-      var container = document.getElementById('scaleSelectContainer');
+  // Note: This is only done if the zoom box is actually visible,
+  // since otherwise element.clientWidth will return 0.
+  PDFView.animationStartedPromise.then(function() {
+    var container = document.getElementById('scaleSelectContainer');
+    if (container.clientWidth > 0) {
       var select = document.getElementById('scaleSelect');
       select.setAttribute('style', 'min-width: inherit;');
-      var width = select.clientWidth + 8;
-      select.setAttribute('style', 'min-width: ' + (width + 20) + 'px;');
+      var width = select.clientWidth + SCALE_SELECT_CONTAINER_PADDING;
+      select.setAttribute('style', 'min-width: ' +
+                                   (width + SCALE_SELECT_PADDING) + 'px;');
       container.setAttribute('style', 'min-width: ' + width + 'px; ' +
                                       'max-width: ' + width + 'px;');
+    }
   });
 }, true);
 


### PR DESCRIPTION
This fixes an issue with the automatic resizing of the zoom box width.
Currently, if the viewer is small enough that the zoom box isn't visible on load, the zoom box resizing doesn't work. This means that if the viewer is then enlarged, it will look like this:
![zoom-box-issue](https://f.cloud.github.com/assets/2692120/508060/32e8285c-bd7d-11e2-9fbf-37eb2bc35868.png)

This PR fixes this, so that the zoom box will only be resized on load when it's actually visible.
