### PR TITLE
Fixes a broken pdf link for kdchart.pdf

### DIFF
--- a/test/pdfs/kdchart.pdf.link
+++ b/test/pdfs/kdchart.pdf.link
@@ -1,1 +1,1 @@
-http://www.ics.com/files/datasheets/kdchart.pdf
+http://manager.ics.com/files/datasheets/kdchart.pdf


### PR DESCRIPTION
It appears that the link for the test PDF file kdchart.pdf was broken.
