### PR TITLE
Unreliable link to demo

### DIFF
--- a/web/index.html.template
+++ b/web/index.html.template
@@ -51,7 +51,7 @@
     </div>
 
     <h2>Try it out!</h2>
-    <p>Live <a href="web/viewer.html">demo</a> or firefox <a href="https://addons.mozilla.org/firefox/addon/pdfjs/">extension</a>.</p>
+    <p>Live <a href="http://mozilla.github.io/pdf.js/web/viewer.html">demo</a> or firefox <a href="https://addons.mozilla.org/firefox/addon/pdfjs/">extension</a>.</p>
 
     <h2>Authors</h2>
     Andreas Gal (gal@mozilla.com)<br/>


### PR DESCRIPTION
The first result on google for pdf.js is http://people.mozilla.com/~bdahl/sandbox/path_fonts/web/index.html.template and not http://mozilla.github.io/pdf.js/ so clicking on the relative link brings me to http://people.mozilla.com/~bdahl/sandbox/path_fonts/web/web/viewer.html which doesn't exist.

mozilla.github.io isn't even on Google's results, so might be worth getting that fixed instead.
