### PR TITLE
Fix the positioning of the progressive loadingBar

### DIFF
--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -155,15 +155,18 @@ var ProgressBar = (function ProgressBarClosure() {
 
   function ProgressBar(id, opts) {
 
-    // Fetch the sub-elements for later
+    // Fetch the sub-elements for later.
     this.div = document.querySelector(id + ' .progress');
 
-    // Get options, with sensible defaults
+    // Get the loading bar element, so it can be resized to fit the viewer.
+    this.bar = this.div.parentNode;
+
+    // Get options, with sensible defaults.
     this.height = opts.height || 100;
     this.width = opts.width || 100;
     this.units = opts.units || '%';
 
-    // Initialize heights
+    // Initialize heights.
     this.div.style.height = this.height + this.units;
     this.percent = 0;
   }
@@ -190,6 +193,22 @@ var ProgressBar = (function ProgressBarClosure() {
       this._indeterminate = isNaN(val);
       this._percent = clamp(val, 0, 100);
       this.updateBar();
+    },
+
+    setWidth: function ProgressBar_setWidth(viewer) {
+      if (viewer) {
+        var container = viewer.parentNode;
+        var scrollbarWidth = container.offsetWidth - viewer.offsetWidth;
+        if (scrollbarWidth > 0) {
+          this.bar.setAttribute('style', 'width: calc(100% - ' +
+                                         scrollbarWidth + 'px);');
+        }
+      }
+    },
+
+    hide: function ProgressBar_hide() {
+      this.bar.classList.add('hidden');
+      this.bar.removeAttribute('style');
     }
   };
 

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -231,9 +231,6 @@ html[dir='rtl'] #sidebarContent {
   left: 0;
   outline: none;
 }
-.loadingInProgress #viewerContainer {
-  top: 39px;
-}
 
 .toolbar {
   position: relative;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -746,16 +746,21 @@ var PDFView = {
     return support;
   },
 
+  get loadingBar() {
+    var bar = new ProgressBar('#loadingBar', {});
+    Object.defineProperty(this, 'loadingBar', { value: bar,
+                                                enumerable: true,
+                                                configurable: true,
+                                                writable: false });
+    return bar;
+  },
+
   get isHorizontalScrollbarEnabled() {
     var div = document.getElementById('viewerContainer');
     return div.scrollWidth > div.clientWidth;
   },
 
   initPassiveLoading: function pdfViewInitPassiveLoading() {
-    if (!PDFView.loadingBar) {
-      PDFView.loadingBar = new ProgressBar('#loadingBar', {});
-    }
-
     var pdfDataRangeTransport = {
       rangeListeners: [],
       progressListeners: [],
@@ -855,10 +860,6 @@ var PDFView = {
       for (var prop in args) {
         parameters[prop] = args[prop];
       }
-    }
-
-    if (!PDFView.loadingBar) {
-      PDFView.loadingBar = new ProgressBar('#loadingBar', {});
     }
 
     this.pdfDocument = null;
@@ -1150,8 +1151,7 @@ var PDFView = {
     errorWrapper.setAttribute('hidden', 'true');
 
     pdfDocument.dataLoaded().then(function() {
-      var loadingBar = document.getElementById('loadingBar');
-      loadingBar.classList.add('hidden');
+      PDFView.loadingBar.hide();
       var outerContainer = document.getElementById('outerContainer');
       outerContainer.classList.remove('loadingInProgress');
     });
@@ -1212,6 +1212,8 @@ var PDFView = {
       var event = document.createEvent('CustomEvent');
       event.initCustomEvent('documentload', true, true, {});
       window.dispatchEvent(event);
+
+      PDFView.loadingBar.setWidth(container);
 
       for (var pageNum = 1; pageNum <= pagesCount; ++pageNum) {
         var pagePromise = pdfDocument.getPage(pageNum);


### PR DESCRIPTION
This PR changes the positioning of the progressive loadingBar to address the following issue:

> When the PDF document is loaded with zoom set to 'page-fit', once the progressive loading bar is removed, the pages will be slightly shorter than the viewer height. To see this issue, try opening: http://mozilla.github.io/pdf.js/web/viewer.html#page=2&zoom=page-fit.

This PR replaces the sub-optimal approach suggested in #3224.

@yurydelendik Is this a better approach?
