### PR TITLE
Fix instanceof Typed Arrays in IE9

### DIFF
--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -74,6 +74,7 @@
 
     return result;
   }
+  TypedArray.prototype = Array.prototype;
 
   window.Uint8Array = TypedArray;
 


### PR DESCRIPTION
Fix #2687 and #2617
