### PR TITLE
(Yet another) browsing history bug

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -707,6 +707,7 @@ var PDFHistory = {
     this.currentPage = 0;
     this.updatePreviousBookmark = false;
     this.previousBookmark = '';
+    this.previousPage = 0;
     this.nextHashParam = '';
 
     this.fingerprint = fingerprint;
@@ -814,6 +815,7 @@ var PDFHistory = {
       this.currentPage = pageNum | 0;
       if (this.updatePreviousBookmark) {
         this.previousBookmark = this.currentBookmark;
+        this.previousPage = this.currentPage;
         this.updatePreviousBookmark = false;
       }
     }
@@ -875,8 +877,8 @@ var PDFHistory = {
       if (this.previousBookmark === this.currentBookmark) {
         return null;
       }
-    } else if (this.current.page) {
-      if (this.current.page === this.currentPage) {
+    } else if (this.current.page || onlyCheckPage) {
+      if (this.previousPage === this.currentPage) {
         return null;
       }
     } else {


### PR DESCRIPTION
This PR fixes a bug in the browsing history, that prevents the user from going back in the history. When this happens, the history gets "stuck" in the current state, effectively breaking the navigation.
This bug can happen when multiple pages are visible simultaneously in the viewer, i.e. at lower zoom levels and/or when the destination is on the last page of a document.

This is the first bug I've found that really causes the browser history to break, so I think that it might be a good idea to include this fix in the pending uplift to mozcentral ([bug 878897](https://bugzilla.mozilla.org/show_bug.cgi?id=878897)).

/cc @brendandahl
