### PR TITLE
Tweak the behaviour of navigateTo during document load

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1486,19 +1486,12 @@ var PDFView = {
   },
 
   navigateTo: function pdfViewNavigateTo(dest) {
+    var destString = '';
     var self = this;
-    PDFJS.Promise.all([this.pagesPromise,
-                       this.destinationsPromise]).then(function() {
-      var destString = '';
-      if (typeof dest === 'string') {
-        destString = dest;
-        dest = self.destinations[dest];
-      }
-      if (!(dest instanceof Array)) {
-        return; // invalid destination
-      }
+
+    var goToDestination = function(destRef) {
+      self.pendingRefStr = null;
       // dest array looks like that: <page-ref> </XYZ|FitXXX> <args..>
-      var destRef = dest[0];
       var pageNumber = destRef instanceof Object ?
         self.pagesRefMap[destRef.num + ' ' + destRef.gen + ' R'] :
         (destRef + 1);
@@ -1511,7 +1504,24 @@ var PDFView = {
 
         // Update the browsing history.
         PDFHistory.push({ dest: dest, hash: destString, page: pageNumber });
+      } else {
+        self.pendingRefStrLoaded = new PDFJS.Promise();
+        self.pendingRefStr = destRef.num + ' ' + destRef.gen + ' R';
+        self.pendingRefStrLoaded.then(function() {
+          goToDestination(destRef);
+        });
       }
+    };
+
+    this.destinationsPromise.then(function() {
+      if (typeof dest === 'string') {
+        destString = dest;
+        dest = self.destinations[dest];
+      }
+      if (!(dest instanceof Array)) {
+        return; // invalid destination
+      }
+      goToDestination(dest[0]);
     });
   },
 
@@ -1746,6 +1756,10 @@ var PDFView = {
           var pageRef = pdfPage.ref;
           var refStr = pageRef.num + ' ' + pageRef.gen + ' R';
           pagesRefMap[refStr] = pdfPage.pageNumber;
+
+          if (self.pendingRefStr && self.pendingRefStr === refStr) {
+            self.pendingRefStrLoaded.resolve();
+          }
         });
         pagePromises.push(pagePromise);
       }


### PR DESCRIPTION
When I fixed issue #3068 in #3135, it was done by waiting for all pages to be resolved before the `navigateTo` method would be run.
Unfortunately this approach has at least two unwanted side effects. First of all, the loading of a destination from an `initialBookmark` is forced to wait for the entire document to load, even when it's not necessary. Secondly, the more severe issue is that until the document has finished loading, clicking on links within the document will not produce any results until the document is completely loaded. This can thus create the impression that links are broken in pdf.js.
Both these issues are particular noticeable in large and/or slow loading documents.

I've tried to address the above issues by adding a Promise to the `navigateTo` method, that will be resolved as soon as all the necessary info is loaded. In my testing, especially for larger files this cuts down the waiting time when links are clicked considerably.
To prevent dealing with a miniature callback hell, I've implemented this in such a way that if a destination is currently unresolved when a new link is clicked, the previous one will simply be discarded.

Since I don't have a great deal of experience working with promises, I hope that this approach is sound!
