### PR TITLE
Check that the progressCallback is defined before calling it

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -699,10 +699,12 @@ var WorkerTransport = (function WorkerTransportClosure() {
       }, this);
 
       messageHandler.on('DocProgress', function transportDocProgress(data) {
-        this.progressCallback({
-          loaded: data.loaded,
-          total: data.total
-        });
+        if (this.progressCallback) {
+          this.progressCallback({
+            loaded: data.loaded,
+            total: data.total
+          });
+        }
       }, this);
 
       messageHandler.on('DocError', function transportDocError(data) {

--- a/src/api.js
+++ b/src/api.js
@@ -698,12 +698,14 @@ var WorkerTransport = (function WorkerTransportClosure() {
         }
       }, this);
 
-      messageHandler.on('DocProgress', function transportDocProgress(data) {
-        this.progressCallback({
-          loaded: data.loaded,
-          total: data.total
-        });
-      }, this);
+      if(this.progressCallback) {
+        messageHandler.on('DocProgress', function transportDocProgress(data) {
+          this.progressCallback({
+            loaded: data.loaded,
+            total: data.total
+          });
+        }, this);
+      }
 
       messageHandler.on('DocError', function transportDocError(data) {
         this.workerReadyPromise.reject(data);

--- a/src/api.js
+++ b/src/api.js
@@ -698,14 +698,14 @@ var WorkerTransport = (function WorkerTransportClosure() {
         }
       }, this);
 
-      if(this.progressCallback) {
-        messageHandler.on('DocProgress', function transportDocProgress(data) {
+      messageHandler.on('DocProgress', function transportDocProgress(data) {
+        if (this.progressCallback) {
           this.progressCallback({
             loaded: data.loaded,
             total: data.total
           });
-        }, this);
-      }
+        }
+      }, this);
 
       messageHandler.on('DocError', function transportDocError(data) {
         this.workerReadyPromise.reject(data);


### PR DESCRIPTION
Fix issue #3367

When calling getDocument without a progressCallback we get an error when trying to call it.
