### PR TITLE
Fix typo causing destinations using '/FitR' to fail

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2022,9 +2022,9 @@ var PageView = function pageView(container, id, scale,
           y = dest[3];
           width = dest[4] - x;
           height = dest[5] - y;
-          widthScale = (this.container.clientWidth - SCROLLBAR_PADDING) /
+          widthScale = (PDFView.container.clientWidth - SCROLLBAR_PADDING) /
             width / CSS_UNITS;
-          heightScale = (this.container.clientHeight - SCROLLBAR_PADDING) /
+          heightScale = (PDFView.container.clientHeight - SCROLLBAR_PADDING) /
             height / CSS_UNITS;
           scale = Math.min(widthScale, heightScale);
           break;


### PR DESCRIPTION
This PR fixes two typos which prevent destinations using '/FitR' from working, i.e. nothing happens when such a link is clicked.
An example of such a file is: https://www.eff.org/sites/default/files/filenode/DMCA/NTIA%20DMCA%20White%20Paper.pdf.
Using the latest version of pdf.js, notice how nothing happens when clicking on the links in the outline.
