### PR TITLE
Check if the browser supports manipulation of the history

### DIFF
--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -391,7 +391,7 @@ if (typeof PDFJS === 'undefined') {
   });
 })();
 
-// Check console compatability
+// Check console compatibility
 (function checkConsoleCompatibility() {
   if (!('console' in window)) {
     window.console = {
@@ -453,5 +453,12 @@ if (typeof PDFJS === 'undefined') {
                   window.HTMLElement).indexOf('Constructor') > 0;
   if (isSafari) {
     PDFJS.disableRange = true;
+  }
+})();
+
+// Check if the browser supports manipulation of the history.
+(function checkHistoryManipulation() {
+  if (!window.history.pushState) {
+    PDFJS.disableHistory = true;
   }
 })();

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -31,7 +31,6 @@ var VERTICAL_PADDING = 5;
 var MIN_SCALE = 0.25;
 var MAX_SCALE = 4.0;
 var SETTINGS_MEMORY = 20;
-var HISTORY_DISABLED = false;
 var SCALE_SELECT_CONTAINER_PADDING = 8;
 var SCALE_SELECT_PADDING = 22;
 var RenderingStates = {
@@ -190,7 +189,7 @@ var PDFHistory = {
   initialDestination: null,
 
   initialize: function pdfHistoryInitialize(fingerprint) {
-    if (HISTORY_DISABLED || window.parent !== window) {
+    if (PDFJS.disableHistory || window.parent !== window) {
       // The browsing history is only enabled when the viewer is standalone,
       // i.e. not when it is embedded in a page.
       return;
@@ -2562,6 +2561,10 @@ document.addEventListener('DOMContentLoaded', function webViewerLoad(evt) {
 
   if ('disableFontFace' in hashParams) {
     PDFJS.disableFontFace = (hashParams['disableFontFace'] === 'true');
+  }
+
+  if ('disableHistory' in hashParams) {
+    PDFJS.disableHistory = (hashParams['disableHistory'] === 'true');
   }
 
 //#if !(FIREFOX || MOZCENTRAL)


### PR DESCRIPTION
This PR adds a check in `compatibility.js`, to determine if the browser supports history manipulations. If this isn't the case, `PDFHistory` will be disabled.
This PR also adds the `disableHistory` hash parameter, which enables the user to manually disable the browsing history.

In my testing, this fixes issue #3380.
~~It's also possible that this will fix issue #3381, but I cannot confirm this since I don't have access to an Android device.~~
