### PR TITLE
Enable changing page using Shift+Spacebar in presentation mode

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -3117,6 +3117,15 @@ window.addEventListener('keydown', function keydown(evt) {
 
   if (cmd === 4) { // shift-key
     switch (evt.keyCode) {
+      case 32: // spacebar
+        if (!PDFView.isPresentationMode &&
+            PDFView.currentScaleValue !== 'page-fit') {
+          break;
+        }
+        PDFView.page--;
+        handled = true;
+        break;
+
       case 82: // 'r'
         PDFView.rotatePages(-90);
         break;


### PR DESCRIPTION
This PR enables the user to go to the previous page using `Shift+Spacebar` whilst in presentation mode.

This fixes [bug 886902](https://bugzilla.mozilla.org/show_bug.cgi?id=886902).
