### PR TITLE
Remove old -moz prefixed rules from viewer.css

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -139,8 +139,6 @@ html[dir='rtl'] .innerCenter {
   visibility: hidden;
   -webkit-transition-duration: 200ms;
   -webkit-transition-timing-function: ease;
-  -moz-transition-duration: 200ms;
-  -moz-transition-timing-function: ease;
   -ms-transition-duration: 200ms;
   -ms-transition-timing-function: ease;
   -o-transition-duration: 200ms;
@@ -151,7 +149,6 @@ html[dir='rtl'] .innerCenter {
 }
 html[dir='ltr'] #sidebarContainer {
   -webkit-transition-property: left;
-  -moz-transition-property: left;
   -ms-transition-property: left;
   -o-transition-property: left;
   transition-property: left;
@@ -185,8 +182,6 @@ html[dir='rtl'] #outerContainer.sidebarOpen > #sidebarContainer {
   min-width: 320px;
   -webkit-transition-duration: 200ms;
   -webkit-transition-timing-function: ease;
-  -moz-transition-duration: 200ms;
-  -moz-transition-timing-function: ease;
   -ms-transition-duration: 200ms;
   -ms-transition-timing-function: ease;
   -o-transition-duration: 200ms;
@@ -196,7 +191,6 @@ html[dir='rtl'] #outerContainer.sidebarOpen > #sidebarContainer {
 }
 html[dir='ltr'] #outerContainer.sidebarOpen > #mainContainer {
   -webkit-transition-property: left;
-  -moz-transition-property: left;
   -ms-transition-property: left;
   -o-transition-property: left;
   transition-property: left;
@@ -204,7 +198,6 @@ html[dir='ltr'] #outerContainer.sidebarOpen > #mainContainer {
 }
 html[dir='rtl'] #outerContainer.sidebarOpen > #mainContainer {
   -webkit-transition-property: right;
-  -moz-transition-property: right;
   -ms-transition-property: right;
   -o-transition-property: right;
   transition-property: right;
@@ -299,16 +292,9 @@ html[dir='rtl'] #sidebarContent {
   height: 100%;
   background-color: #ddd;
   overflow: hidden;
-  -moz-transition: width 200ms;
   -ms-transition: width 200ms;
   -webkit-transition: width 200ms;
   transition: width 200ms;
-}
-
-@-moz-keyframes progressIndeterminate {
-  0% { left: 0%; }
-  50% { left: 100%; }
-  100% { left: 100%; }
 }
 
 @-ms-keyframes progressIndeterminate {
@@ -331,7 +317,6 @@ html[dir='rtl'] #sidebarContent {
 
 #loadingBar .progress.indeterminate {
   background-color: #999;
-  -moz-transition: none;
   -ms-transition: none;
   -webkit-transition: none;
   transition: none;
@@ -345,9 +330,9 @@ html[dir='rtl'] #sidebarContent {
   width: 50px;
 
   background-image: linear-gradient(to right, #999 0%, #fff 50%, #999 100%);
-  background-size: 100% 100% no-repeat;
+  background-size: 100% 100%;
+  background-repeat: no-repeat;
 
-  -moz-animation: progressIndeterminate 2s linear infinite;
   -ms-animation: progressIndeterminate 2s linear infinite;
   -webkit-animation: progressIndeterminate 2s linear infinite;
   animation: progressIndeterminate 2s linear infinite;
@@ -533,9 +518,6 @@ html[dir='rtl'] .splitToolbarButton > .toolbarButton {
   -webkit-transition-property: background-color, border-color, box-shadow;
   -webkit-transition-duration: 150ms;
   -webkit-transition-timing-function: ease;
-  -moz-transition-property: background-color, border-color, box-shadow;
-  -moz-transition-duration: 150ms;
-  -moz-transition-timing-function: ease;
   -ms-transition-property: background-color, border-color, box-shadow;
   -ms-transition-duration: 150ms;
   -ms-transition-timing-function: ease;
@@ -599,9 +581,6 @@ html[dir='rtl'] .splitToolbarButtonSeparator {
   -webkit-transition-property: padding;
   -webkit-transition-duration: 10ms;
   -webkit-transition-timing-function: ease;
-  -moz-transition-property: padding;
-  -moz-transition-duration: 10ms;
-  -moz-transition-timing-function: ease;
   -ms-transition-property: padding;
   -ms-transition-duration: 10ms;
   -ms-transition-timing-function: ease;
@@ -630,9 +609,6 @@ html[dir='rtl'] .splitToolbarButtonSeparator {
   -webkit-transition-property: background-color, border-color, box-shadow;
   -webkit-transition-duration: 150ms;
   -webkit-transition-timing-function: ease;
-  -moz-transition-property: background-color, border-color, box-shadow;
-  -moz-transition-duration: 150ms;
-  -moz-transition-timing-function: ease;
   -ms-transition-property: background-color, border-color, box-shadow;
   -ms-transition-duration: 150ms;
   -ms-transition-timing-function: ease;
@@ -677,9 +653,6 @@ html[dir='rtl'] .dropdownToolbarButton {
   -webkit-transition-property: background-color, border-color, box-shadow;
   -webkit-transition-duration: 10ms;
   -webkit-transition-timing-function: linear;
-  -moz-transition-property: background-color, border-color, box-shadow;
-  -moz-transition-duration: 10ms;
-  -moz-transition-timing-function: linear;
   -ms-transition-property: background-color, border-color, box-shadow;
   -ms-transition-duration: 10ms;
   -ms-transition-timing-function: linear;
@@ -702,9 +675,6 @@ html[dir='rtl'] .dropdownToolbarButton {
   -webkit-transition-property: background-color, border-color, box-shadow;
   -webkit-transition-duration: 10ms;
   -webkit-transition-timing-function: linear;
-  -moz-transition-property: background-color, border-color, box-shadow;
-  -moz-transition-duration: 10ms;
-  -moz-transition-timing-function: linear;
   -ms-transition-property: background-color, border-color, box-shadow;
   -ms-transition-duration: 10ms;
   -ms-transition-timing-function: linear;
@@ -935,9 +905,9 @@ html[dir='rtl'] .toolbarButton.pageDown::before {
   font-size: 12px;
   line-height: 14px;
   outline-style: none;
-  -moz-transition-property: background-color, border-color, box-shadow;
-  -moz-transition-duration: 150ms;
-  -moz-transition-timing-function: ease;
+  transition-property: background-color, border-color, box-shadow;
+  transition-duration: 150ms;
+  transition-timing-function: ease;
 }
 
 .toolbarField[type=checkbox] {
@@ -1001,7 +971,7 @@ html[dir='rtl'] .toolbarButton.pageDown::before {
 }
 
 .thumbnailImage {
-  -moz-transition-duration: 150ms;
+  transition-duration: 150ms;
   border: 1px solid transparent;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5), 0 2px 8px rgba(0, 0, 0, 0.3);
   opacity: 0.8;
@@ -1011,7 +981,7 @@ html[dir='rtl'] .toolbarButton.pageDown::before {
 .thumbnailSelectionRing {
   border-radius: 2px;
   padding: 7px;
-  -moz-transition-duration: 150ms;
+  transition-duration: 150ms;
 }
 
 a:focus > .thumbnail > .thumbnailSelectionRing > .thumbnailImage,


### PR DESCRIPTION
This PR removes a number of old `-moz` prefixed CSS rules that have been supported in their non prefixed versions since Firefox 16.0, [released 2012-10-09](https://wiki.mozilla.org/RapidRelease/Calendar). The following prefixed rules are removed/changed:
- transition, https://developer.mozilla.org/en-US/docs/Web/CSS/transition.
- transition-property, https://developer.mozilla.org/en-US/docs/Web/CSS/transition-property.
- transition-duration, https://developer.mozilla.org/en-US/docs/Web/CSS/transition-duration.
- transition-timing-function, https://developer.mozilla.org/en-US/docs/Web/CSS/transition-timing-function.
- @keyframes, https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes.
- animation, https://developer.mozilla.org/en-US/docs/Web/CSS/animation.

For those worried about the file size of `viewer.css`, this should be a welcome change since these changes corresponds to a reduction of 1188 bytes (or approx. 3.5%).
