### PR TITLE
Add IE 11 to the text/html data URI shim

### DIFF
--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -276,10 +276,9 @@ if (typeof PDFJS === 'undefined') {
   };
 })();
 
-// IE9/10 text/html data URI
+// IE9-11 text/html data URI
 (function checkDataURICompatibility() {
-  if (!('documentMode' in document) ||
-      document.documentMode !== 9 && document.documentMode !== 10)
+  if (!('documentMode' in document) || document.documentMode > 11)
     return;
   // overriding the src property
   var originalSrcDescriptor = Object.getOwnPropertyDescriptor(


### PR DESCRIPTION
IE 11 preview is out as part of Windows 8.1 preview and it needs the same shim like IE 9 and IE 10.
