### PR TITLE
instanceof HTMLElement does not work in jsdom node.js module.

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1709,7 +1709,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       var heightScale = Math.max(Math.sqrt(c * c + d * d), 1);
 
       var imgToPaint;
-      if (imgData instanceof HTMLElement) {
+      // instanceof HTMLElement does not work in jsdom node.js module
+      if (imgData instanceof HTMLElement || !imgData.data) {
         imgToPaint = imgData;
       } else {
         var tmpCanvas = CachedCanvases.getCanvas('inlineImage', width, height);


### PR DESCRIPTION
instanceof HTMLElement does not work in jsdom node.js module:

https://github.com/tmpvar/jsdom/issues/649

I am using pdf.js inside node.js and by this simple change it works perfectly.
