### PR TITLE
Avoid triggering rendering multiple times when zooming using the mouse wheel

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1119,12 +1119,14 @@ canvas {
   background-color: white;
 }
 
-.page > a {
+.page > a,
+.annotationLayer > a {
   display: block;
   position: absolute;
 }
 
-.page > a:hover {
+.page > a:hover,
+.annotationLayer > a:hover {
   opacity: 0.2;
   background: #ff0;
   box-shadow: 0px 2px 10px #ff0;


### PR DESCRIPTION
Currently when zooming using `Ctrl+Mouse wheel` in Firefox, the document is re-rendered multiple times in quick succession. Apart from causing the rendering of the document to become slower than necessary, this has the more serious side effect that hyperlinks are not removed from the pages.

This issue effects all documents containing hyperlinks, but it's most easily seem when the links are enclosed in boxes. A file demonstrating the issue is: http://arxiv.org/pdf/1112.0542v1.pdf, and this is what it looks like when zooming using `Ctrl+Mouse wheel` in Firefox:

![wheel_zoom](https://f.cloud.github.com/assets/2692120/727817/86f40476-e1c1-11e2-8860-2c0bf12312a3.png)

This PR fixes this issue by calculating the new scale value completely before the rendering begins.
