### PR TITLE
Annotation selection

### DIFF
--- a/src/shared/annotation.js
+++ b/src/shared/annotation.js
@@ -571,15 +571,23 @@ var TextAnnotation = (function TextAnnotationClosure() {
             e.appendChild(document.createElement('br'));
         }
         text.appendChild(e);
-        image.addEventListener('mouseover', function annotationImageOver() {
+
+        var showAnnotation = function showAnnotation() {
           container.style.zIndex += 1;
           content.removeAttribute('hidden');
-        }, false);
+        };
 
-        image.addEventListener('mouseout', function annotationImageOut() {
-          container.style.zIndex -= 1;
-          content.setAttribute('hidden', true);
-        }, false);
+        var hideAnnotation = function hideAnnotation(e) {
+          if (e.toElement || e.relatedTarget) { // No context menu is used
+            container.style.zIndex -= 1;
+            content.setAttribute('hidden', true);
+          }
+        };
+
+        content.addEventListener('mouseover', showAnnotation, false);
+        content.addEventListener('mouseout', hideAnnotation, false);
+        image.addEventListener('mouseover', showAnnotation, false);
+        image.addEventListener('mouseout', hideAnnotation, false);
       }
 
       content.appendChild(title);

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1259,7 +1259,6 @@ canvas {
 }
 
 .annotText > img:hover {
-  cursor: pointer;
   opacity: 1;
 }
 


### PR DESCRIPTION
Fixes #2964. Also removes the cursor pointer from the annotation symbols as it implies you can click on them, but really nothing happens.
