### PR TITLE
Removes browser decoding optimization for JPEG CMYK

### DIFF
--- a/external/jpgjs/jpg.js
+++ b/external/jpgjs/jpg.js
@@ -847,8 +847,6 @@ var JpegImage = (function jpegImage() {
           }
           break;
         case 4:
-          if (!this.adobe)
-            throw 'Unsupported color mode (4 components)';
           // The default transform for four components is false
           colorTransform = false;
           // The adobe transform marker overrides any previous setting

--- a/test/pdfs/bug887152.pdf.link
+++ b/test/pdfs/bug887152.pdf.link
@@ -1,0 +1,1 @@
+http://www.nature.com/news/2010/100721/pdf/466432a.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1071,6 +1071,14 @@
       "rounds": 1,
       "type": "eq"
     },
+    {  "id": "bug887152",
+      "file": "pdfs/bug887152.pdf",
+      "md5": "783a3e7b1de2cf40a47ffe1f36a41d4f",
+      "rounds": 1,
+      "lastPage": 1,
+      "link": true,
+      "type": "eq"
+    },
     {  "id": "bug816075",
       "file": "pdfs/bug816075.pdf",
       "md5": "7ec87c115c1f9ec41234cc7002555e82",


### PR DESCRIPTION
Fixes #3395
and https://bugzilla.mozilla.org/show_bug.cgi?id=887152
