### PR TITLE
Download PDF from cache for non-Firefox add-on

### DIFF
--- a/extensions/firefox/components/PdfStreamConverter.js
+++ b/extensions/firefox/components/PdfStreamConverter.js
@@ -206,6 +206,10 @@ ChromeActions.prototype = {
     // The data may not be downloaded so we need just retry getting the pdf with
     // the original url.
     var originalUri = NetUtil.newURI(data.originalUrl);
+    var filename = data.filename;
+    if (typeof filename !== 'string' || !/\.pdf$/i.test(filename)) {
+      filename = 'document.pdf';
+    }
     var blobUri = data.blobUrl ? NetUtil.newURI(data.blobUrl) : originalUri;
     var extHelperAppSvc =
           Cc['@mozilla.org/uriloader/external-helper-app-service;1'].
@@ -234,7 +238,9 @@ ChromeActions.prototype = {
         // contentDisposition/contentDispositionFilename is readonly before FF18
         channel.contentDisposition = Ci.nsIChannel.DISPOSITION_ATTACHMENT;
         if (self.contentDispositionFilename) {
-           channel.contentDispositionFilename = self.contentDispositionFilename;
+          channel.contentDispositionFilename = self.contentDispositionFilename;
+        } else {
+          channel.contentDispositionFilename = filename;
         }
       } catch (e) {}
       channel.setURI(originalUri);

--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -92,6 +92,13 @@ if (typeof PDFJS === 'undefined') {
   window.Float64Array = TypedArray;
 })();
 
+// URL = URL || webkitURL
+(function normalizeURLObject() {
+  if (!window.URL && window.webkitURL) {
+    window.URL = window.webkitURL;
+  }
+})();
+
 // Object.create() ?
 (function checkObjectCreateCompatibility() {
   if (typeof Object.create !== 'undefined')

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* globals URL*/
 /* globals PDFJS, PDFBug, FirefoxCom, Stats, Cache, PDFFindBar */
 /* globals PDFFindController, ProgressBar, getFileName, CustomStyle */
 /* globals getOutputScale, TextLayerBuilder */
@@ -975,8 +976,7 @@ var PDFView = {
 //      );
 //  }
 //#endif
-    var URL = window.URL || window.webkitURL;
-    // If the PDF is not ready yet, or if createObjectURL is not supported,
+    // If the PDF is not ready yet, or if URL.createObjectURL is not supported,
     // just try to download with the url.
     if (!this.pdfDocument || !URL) {
         noData();

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1015,11 +1015,20 @@ var PDFView = {
     this.pdfDocument.getData().then(
       function getDataSuccess(data) {
         var blob = PDFJS.createBlob(data.buffer, 'application/pdf');
+//#if GENERIC
+        if (navigator.msSaveBlob) {
+          // IE10 / IE11
+          if (!navigator.msSaveBlob(blob, getPDFFileNameFromURL(url))) {
+            noData();
+          }
+          return;
+        }
+//#endif
         var blobUrl = URL.createObjectURL(blob);
         triggerSaveAs(url, blobUrl);
       },
       noData // Error occurred try downloading with just the url.
-    );
+    ).then(null, noData);
   },
 
   fallback: function pdfViewFallback() {


### PR DESCRIPTION
This feature relies on URL.createObjectURL, which is supported by
- Firefox 4
- Chrome 8
- Opera 15
- Internet Explorer 10
- Safari 6

If the feature is missing, it falls back to downloading the file directly from the server.

The environment-specific code are put in ifdef's. Two methods are defined:
- `noData`  
  This function is used as a fallback in case of failure, it triggers a download directly from the server.
- `triggerSaveAs(String url, optional String blob)`  
  This function attempts to show a Save As dialog for a given URL.
  It attempts to use the [a.download](http://caniuse.com/download) attribute, if available, and falls back to `window.open(<url>, '_parent')` if unavailable.

---

Side note: If I'm not mistaken, we're generating the blob-URL by first passing the data over the Web Worker, followed by createObjectURL. This can be implemented more efficiently by directly calling `URL.createObjectURL` inside the Web Worker. This feature is supported by most major browsers:
- Firefox 21 - https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/21#Worker
- Chrome / Safari - https://bugs.webkit.org/show_bug.cgi?id=74386 (closed in October 2012)
- Opera 15

(`URL.createObjectURL` is supported in Internet Explorer 10, but not inside Web Workers (`<a download>` isn't supported either...))
