### PR TITLE
Remove caching of stream data and fix object loader for streams.

### DIFF
--- a/src/chunked_stream.js
+++ b/src/chunked_stream.js
@@ -46,6 +46,10 @@ var ChunkedStream = (function ChunkedStreamClosure() {
       return chunks;
     },
 
+    getBaseStreams: function ChunkedStream_getBaseStreams() {
+      return [this];
+    },
+
     allChunksLoaded: function ChunkedStream_allChunksLoaded() {
       return this.numChunksLoaded === this.numChunks;
     },


### PR DESCRIPTION
Should help with memory usage.  Since I removed `e = e.makeSubStream(0, e.bufferLength, e.dict);` I had to change the object loader to check the base streams for missing data since it was no longer trying to fetch it all when the object was requested.
