### PR TITLE
Allow scrolling by keyboard in Chrome/Opera

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -236,6 +236,7 @@ html[dir='rtl'] #sidebarContent {
   right: 0;
   bottom: 0;
   left: 0;
+  outline: none;
 }
 .loadingInProgress #viewerContainer {
   top: 39px;

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -222,7 +222,7 @@ limitations under the License.
                     data-l10n-id="page_rotate_cw" ></menuitem>
         </menu>
 
-        <div id="viewerContainer">
+        <div id="viewerContainer" tabindex="0">
           <div id="viewer" contextmenu="viewerContextMenu"></div>
         </div>
 


### PR DESCRIPTION
Set "tabindex" attribute to allow focus;
Added "outline: none" to prevent focus ring from appearing.

Fixes #3443
