### PR TITLE
Configurable IMAGE_DIR for annotations to get svg images to show up in Chromium extension

### DIFF
--- a/extensions/chrome/insertviewer.js
+++ b/extensions/chrome/insertviewer.js
@@ -108,9 +108,9 @@ function renderPDF(url) {
   var script = document.createElement('script');
   script.textContent =
   '(function(args) {' +
+  '  PDFJS.imageResourcesPath = args.BASE_URL + PDFJS.imageResourcesPath;' +
   '  PDFJS.workerSrc = args.BASE_URL + PDFJS.workerSrc;' +
   '  window.DEFAULT_URL = args.pdf_url;' +
-  '  window.IMAGE_DIR = args.BASE_URL + window.IMAGE_DIR;' +
   '})(' + JSON.stringify(args) + ');';
   document.head.appendChild(script);
 

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -552,7 +552,6 @@ var TextAnnotation = (function TextAnnotationClosure() {
   }
 
   var ANNOT_MIN_SIZE = 10;
-  var IMAGE_DIR = './images/';
 
   Util.inherit(TextAnnotation, Annotation, {
 
@@ -593,7 +592,7 @@ var TextAnnotation = (function TextAnnotationClosure() {
       image.style.width = container.style.width;
       image.style.height = container.style.height;
       var iconName = item.name;
-      image.src = IMAGE_DIR + 'annotation-' +
+      image.src = PDFJS.imageResourcesPath + 'annotation-' +
         iconName.toLowerCase() + '.svg';
       image.alt = '[{{type}} Annotation]';
       image.dataset.l10nId = 'text_annotation_type';

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -46,6 +46,7 @@ var FindStates = {
   FIND_PENDING: 3
 };
 
+PDFJS.imageResourcesPath = './images/';
 //#if (FIREFOX || MOZCENTRAL || B2G || GENERIC || CHROME)
 //PDFJS.workerSrc = '../build/pdf.js';
 //#endif


### PR DESCRIPTION
The Chrome extension activates PDF.js by inserting the script tags
in a document whose URL and location origin is identical to the PDF
file.
Because of this, the path './images/' was resolved relatively to the
location of the PDF file instead of the extension.

To fix this, the IMAGE_DIR constant is moved back to the global scope,
which allows extensions/chrome/insertviewer.js to override the value.

Originally, the IMAGE_DIR variable was a global variable, but commit
f8f4b3f45dc6ff5f5b2572b5387389db33616be3 moved the global variable
to the local scope, causing the extension to malfunction.

Impact: low, the only consequence is that some rarely used images
were not visible.

Trivial test:
At the center of page 2, the annotation icon
(images/annotation-comment.svg) should be visible:
http://linorg.usp.br/CTAN/macros/latex/contrib/pdfcomment/doc/pdfcomment.pdf
