### PR TITLE
Always declare window.URL even if undefined

### DIFF
--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -94,7 +94,7 @@ if (typeof PDFJS === 'undefined') {
 
 // URL = URL || webkitURL
 (function normalizeURLObject() {
-  if (!window.URL && window.webkitURL) {
+  if (!window.URL) {
     window.URL = window.webkitURL;
   }
 })();


### PR DESCRIPTION
Otherwise it breaks feature detection in https://github.com/mozilla/pdf.js/blob/e583070deb73113f13e7a5244138582b7a86140a/web/viewer.js#L1011
"ReferenceError: Can't find variable: URL" in Safari 5.1
