### PR TITLE
Incrementally render by sending the operator list by chunks as they're ready.

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -670,7 +670,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
             this.setFlatness(value);
             break;
           case 'Font':
-            this.setFont(state[1], state[2]);
+            this.setFont(value[0], value[1]);
             break;
           case 'CA':
             this.current.strokeAlpha = state[1];

--- a/src/core.js
+++ b/src/core.js
@@ -18,7 +18,8 @@
            isArrayBuffer, isDict, isName, isStream, isString, Lexer,
            Linearization, NullStream, PartialEvaluator, shadow, Stream,
            StreamsSequenceStream, stringToPDFString, TODO, Util, warn, XRef,
-           MissingDataException, Promise, Annotation, ObjectLoader */
+           MissingDataException, Promise, Annotation, ObjectLoader, OperatorList
+           */
 
 'use strict';
 
@@ -183,33 +184,35 @@ var Page = (function PageClosure() {
       dataPromises.then(function(data) {
         var contentStream = data[0];
 
-        partialEvaluator.getOperatorList(contentStream, self.resources).then(
-          function(data) {
-            pageListPromise.resolve(data);
-          },
-          reject
-        );
+
+        var opList = new OperatorList(handler, self.pageIndex);
+
+        handler.send('StartRenderPage', {
+          transparency: partialEvaluator.hasBlendModes(self.resources),
+          pageIndex: self.pageIndex
+        });
+        partialEvaluator.getOperatorList(contentStream, self.resources, opList);
+        pageListPromise.resolve(opList);
       });
 
       var annotationsPromise = pdfManager.ensure(this, 'annotations');
       Promise.all([pageListPromise, annotationsPromise]).then(function(datas) {
-        var pageData = datas[0];
-        var pageQueue = pageData.queue;
+        var pageOpList = datas[0];
         var annotations = datas[1];
 
         if (annotations.length === 0) {
-          PartialEvaluator.optimizeQueue(pageQueue);
-          promise.resolve(pageData);
+          PartialEvaluator.optimizeQueue(pageOpList);
+          pageOpList.flush(true);
+          promise.resolve(pageOpList);
           return;
         }
 
-        var dependencies = pageData.dependencies;
         var annotationsReadyPromise = Annotation.appendToOperatorList(
-          annotations, pageQueue, pdfManager, dependencies, partialEvaluator);
+          annotations, pageOpList, pdfManager, partialEvaluator);
         annotationsReadyPromise.then(function () {
-          PartialEvaluator.optimizeQueue(pageQueue);
-
-          promise.resolve(pageData);
+          PartialEvaluator.optimizeQueue(pageOpList);
+          pageOpList.flush(true);
+          promise.resolve(pageOpList);
         }, reject);
       }, reject);
 
@@ -244,12 +247,9 @@ var Page = (function PageClosure() {
               self.pageIndex, 'p' + self.pageIndex + '_',
               self.idCounters);
 
-        partialEvaluator.getTextContent(
-            contentStream, self.resources).then(function(bidiTexts) {
-          textContentPromise.resolve({
-            bidiTexts: bidiTexts
-          });
-        });
+        var bidiTexts = partialEvaluator.getTextContent(contentStream,
+                                                        self.resources);
+        textContentPromise.resolve(bidiTexts);
       });
 
       return textContentPromise;

--- a/src/util.js
+++ b/src/util.js
@@ -903,14 +903,14 @@ var StatTimer = (function StatTimerClosure() {
       if (!this.enabled)
         return;
       if (name in this.started)
-        throw 'Timer is already running for ' + name;
+        warn('Timer is already running for ' + name);
       this.started[name] = Date.now();
     },
     timeEnd: function StatTimer_timeEnd(name) {
       if (!this.enabled)
         return;
       if (!(name in this.started))
-        throw 'Timer has not been started for ' + name;
+        warn('Timer has not been started for ' + name);
       this.times.push({
         'name': name,
         'start': this.started[name],

--- a/src/worker.js
+++ b/src/worker.js
@@ -398,31 +398,11 @@ var WorkerMessageHandler = {
         var pageNum = data.pageIndex + 1;
         var start = Date.now();
         // Pre compile the pdf page and fetch the fonts/images.
-        page.getOperatorList(handler).then(function(opListData) {
-
-          var operatorList = opListData.queue;
-          var dependency = Object.keys(opListData.dependencies);
-
-          // The following code does quite the same as
-          // Page.prototype.startRendering, but stops at one point and sends the
-          // result back to the main thread.
+        page.getOperatorList(handler).then(function(operatorList) {
 
           log('page=%d - getOperatorList: time=%dms, len=%d', pageNum,
               Date.now() - start, operatorList.fnArray.length);
 
-          // Filter the dependecies for fonts.
-          var fonts = {};
-          for (var i = 0, ii = dependency.length; i < ii; i++) {
-            var dep = dependency[i];
-            if (dep.indexOf('g_font_') === 0) {
-              fonts[dep] = true;
-            }
-          }
-          handler.send('RenderPage', {
-            pageIndex: data.pageIndex,
-            operatorList: operatorList,
-            depFonts: Object.keys(fonts)
-          });
         }, function(e) {
 
           var minimumStackMessage =

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -36,14 +36,11 @@ describe('evaluator', function() {
                                            new XrefMock(), new HandlerMock(),
                                            'prefix');
       var stream = new StringStream('qTT');
-      var promise = evaluator.getOperatorList(stream, new ResourcesMock());
-      promise.then(function(data) {
-        var result = data.queue;
-        expect(!!result.fnArray && !!result.argsArray).toEqual(true);
-        expect(result.fnArray.length).toEqual(1);
-        expect(result.fnArray[0]).toEqual('save');
-        expect(result.argsArray[0].length).toEqual(0);
-      });
+      var result = evaluator.getOperatorList(stream, new ResourcesMock());
+      expect(!!result.fnArray && !!result.argsArray).toEqual(true);
+      expect(result.fnArray.length).toEqual(1);
+      expect(result.fnArray[0]).toEqual('save');
+      expect(result.argsArray[0].length).toEqual(0);
     });
 
     it('should handle one operations', function() {
@@ -51,13 +48,10 @@ describe('evaluator', function() {
                                            new XrefMock(), new HandlerMock(),
                                            'prefix');
       var stream = new StringStream('Q');
-      var promise = evaluator.getOperatorList(stream, new ResourcesMock());
-      promise.then(function(data) {
-        var result = data.queue;
-        expect(!!result.fnArray && !!result.argsArray).toEqual(true);
-        expect(result.fnArray.length).toEqual(1);
-        expect(result.fnArray[0]).toEqual('restore');
-      });
+      var result = evaluator.getOperatorList(stream, new ResourcesMock());
+      expect(!!result.fnArray && !!result.argsArray).toEqual(true);
+      expect(result.fnArray.length).toEqual(1);
+      expect(result.fnArray[0]).toEqual('restore');
     });
 
     it('should handle two glued operations', function() {
@@ -67,14 +61,11 @@ describe('evaluator', function() {
       var resources = new ResourcesMock();
       resources.Res1 = {};
       var stream = new StringStream('/Res1 DoQ');
-      var promise = evaluator.getOperatorList(stream, resources);
-      promise.then(function(data) {
-        var result = data.queue;
-        expect(!!result.fnArray && !!result.argsArray).toEqual(true);
-        expect(result.fnArray.length).toEqual(2);
-        expect(result.fnArray[0]).toEqual('paintXObject');
-        expect(result.fnArray[1]).toEqual('restore');
-      });
+      var result = evaluator.getOperatorList(stream, resources);
+      expect(!!result.fnArray && !!result.argsArray).toEqual(true);
+      expect(result.fnArray.length).toEqual(2);
+      expect(result.fnArray[0]).toEqual('paintXObject');
+      expect(result.fnArray[1]).toEqual('restore');
     });
 
     it('should handle tree glued operations', function() {
@@ -82,15 +73,12 @@ describe('evaluator', function() {
                                            new XrefMock(), new HandlerMock(),
                                            'prefix');
       var stream = new StringStream('qqq');
-      var promise = evaluator.getOperatorList(stream, new ResourcesMock());
-      promise.then(function(data) {
-        var result = data.queue;
-        expect(!!result.fnArray && !!result.argsArray).toEqual(true);
-        expect(result.fnArray.length).toEqual(3);
-        expect(result.fnArray[0]).toEqual('save');
-        expect(result.fnArray[1]).toEqual('save');
-        expect(result.fnArray[2]).toEqual('save');
-      });
+      var result = evaluator.getOperatorList(stream, new ResourcesMock());
+      expect(!!result.fnArray && !!result.argsArray).toEqual(true);
+      expect(result.fnArray.length).toEqual(3);
+      expect(result.fnArray[0]).toEqual('save');
+      expect(result.fnArray[1]).toEqual('save');
+      expect(result.fnArray[2]).toEqual('save');
     });
 
     it('should handle three glued operations #2', function() {
@@ -100,15 +88,12 @@ describe('evaluator', function() {
       var resources = new ResourcesMock();
       resources.Res1 = {};
       var stream = new StringStream('B*Bf*');
-      var promise = evaluator.getOperatorList(stream, resources);
-      promise.then(function(data) {
-        var result = data.queue;
-        expect(!!result.fnArray && !!result.argsArray).toEqual(true);
-        expect(result.fnArray.length).toEqual(3);
-        expect(result.fnArray[0]).toEqual('eoFillStroke');
-        expect(result.fnArray[1]).toEqual('fillStroke');
-        expect(result.fnArray[2]).toEqual('eoFill');
-      });
+      var result = evaluator.getOperatorList(stream, resources);
+      expect(!!result.fnArray && !!result.argsArray).toEqual(true);
+      expect(result.fnArray.length).toEqual(3);
+      expect(result.fnArray[0]).toEqual('eoFillStroke');
+      expect(result.fnArray[1]).toEqual('fillStroke');
+      expect(result.fnArray[2]).toEqual('eoFill');
     });
 
     it('should handle glued operations and operands', function() {
@@ -116,17 +101,14 @@ describe('evaluator', function() {
                                            new XrefMock(), new HandlerMock(),
                                            'prefix');
       var stream = new StringStream('q5 Ts');
-      var promise  = evaluator.getOperatorList(stream, new ResourcesMock());
-      promise.then(function(data) {
-        var result = data.queue;
-        expect(!!result.fnArray && !!result.argsArray).toEqual(true);
-        expect(result.fnArray.length).toEqual(2);
-        expect(result.fnArray[0]).toEqual('save');
-        expect(result.fnArray[1]).toEqual('setTextRise');
-        expect(result.argsArray.length).toEqual(2);
-        expect(result.argsArray[1].length).toEqual(1);
-        expect(result.argsArray[1][0]).toEqual(5);
-      });
+      var result  = evaluator.getOperatorList(stream, new ResourcesMock());
+      expect(!!result.fnArray && !!result.argsArray).toEqual(true);
+      expect(result.fnArray.length).toEqual(2);
+      expect(result.fnArray[0]).toEqual('save');
+      expect(result.fnArray[1]).toEqual('setTextRise');
+      expect(result.argsArray.length).toEqual(2);
+      expect(result.argsArray[1].length).toEqual(1);
+      expect(result.argsArray[1][0]).toEqual(5);
     });
 
     it('should handle glued operations and literals', function() {
@@ -134,21 +116,18 @@ describe('evaluator', function() {
                                            new XrefMock(), new HandlerMock(),
                                            'prefix');
       var stream = new StringStream('trueifalserinullq');
-      var promise = evaluator.getOperatorList(stream, new ResourcesMock());
-      promise.then(function(data) {
-        var result = data.queue;
-        expect(!!result.fnArray && !!result.argsArray).toEqual(true);
-        expect(result.fnArray.length).toEqual(3);
-        expect(result.fnArray[0]).toEqual('setFlatness');
-        expect(result.fnArray[1]).toEqual('setRenderingIntent');
-        expect(result.fnArray[2]).toEqual('save');
-        expect(result.argsArray.length).toEqual(3);
-        expect(result.argsArray[0].length).toEqual(1);
-        expect(result.argsArray[0][0]).toEqual(true);
-        expect(result.argsArray[1].length).toEqual(1);
-        expect(result.argsArray[1][0]).toEqual(false);
-        expect(result.argsArray[2].length).toEqual(0);
-      });
+      var result = evaluator.getOperatorList(stream, new ResourcesMock());
+      expect(!!result.fnArray && !!result.argsArray).toEqual(true);
+      expect(result.fnArray.length).toEqual(3);
+      expect(result.fnArray[0]).toEqual('setFlatness');
+      expect(result.fnArray[1]).toEqual('setRenderingIntent');
+      expect(result.fnArray[2]).toEqual('save');
+      expect(result.argsArray.length).toEqual(3);
+      expect(result.argsArray[0].length).toEqual(1);
+      expect(result.argsArray[0][0]).toEqual(true);
+      expect(result.argsArray[1].length).toEqual(1);
+      expect(result.argsArray[1][0]).toEqual(false);
+      expect(result.argsArray[2].length).toEqual(0);
     });
   });
 
@@ -159,39 +138,30 @@ describe('evaluator', function() {
                                            'prefix');
       var stream = new StringStream('5 1 d0');
       console.log('here!');
-      var promise = evaluator.getOperatorList(stream, new ResourcesMock());
-      promise.then(function(data) {
-        var result = data.queue;
-        expect(result.argsArray[0][0]).toEqual(5);
-        expect(result.argsArray[0][1]).toEqual(1);
-        expect(result.fnArray[0]).toEqual('setCharWidth');
-      });
+      var result = evaluator.getOperatorList(stream, new ResourcesMock());
+      expect(result.argsArray[0][0]).toEqual(5);
+      expect(result.argsArray[0][1]).toEqual(1);
+      expect(result.fnArray[0]).toEqual('setCharWidth');
     });
     it('should execute if too many arguments', function() {
       var evaluator = new PartialEvaluator(new PdfManagerMock(),
                                            new XrefMock(), new HandlerMock(),
                                            'prefix');
       var stream = new StringStream('5 1 4 d0');
-      var promise = evaluator.getOperatorList(stream, new ResourcesMock());
-      promise.then(function(data) {
-        var result = data.queue;
-        expect(result.argsArray[0][0]).toEqual(5);
-        expect(result.argsArray[0][1]).toEqual(1);
-        expect(result.argsArray[0][2]).toEqual(4);
-        expect(result.fnArray[0]).toEqual('setCharWidth');
-      });
+      var result = evaluator.getOperatorList(stream, new ResourcesMock());
+      expect(result.argsArray[0][0]).toEqual(5);
+      expect(result.argsArray[0][1]).toEqual(1);
+      expect(result.argsArray[0][2]).toEqual(4);
+      expect(result.fnArray[0]).toEqual('setCharWidth');
     });
     it('should skip if too few arguments', function() {
       var evaluator = new PartialEvaluator(new PdfManagerMock(),
                                            new XrefMock(), new HandlerMock(),
                                            'prefix');
       var stream = new StringStream('5 d0');
-      var promise = evaluator.getOperatorList(stream, new ResourcesMock());
-      promise.then(function(data) {
-        var result = data.queue;
-        expect(result.argsArray).toEqual([]);
-        expect(result.fnArray).toEqual([]);
-      });
+      var result = evaluator.getOperatorList(stream, new ResourcesMock());
+      expect(result.argsArray).toEqual([]);
+      expect(result.fnArray).toEqual([]);
     });
   });
 });

--- a/test/unit/unit_test.html
+++ b/test/unit/unit_test.html
@@ -15,8 +15,8 @@
   <script type="text/javascript" src="../../src/chunked_stream.js"></script>
   <script type="text/javascript" src="../../src/pdf_manager.js"></script>
   <script type="text/javascript" src="../../src/core.js"></script>
-  <script type="text/javascript" src="../../src/api.js"></script>
   <script type="text/javascript" src="../../src/util.js"></script>
+  <script type="text/javascript" src="../../src/api.js"></script>
   <script type="text/javascript" src="../../src/canvas.js"></script>
   <script type="text/javascript" src="../../src/obj.js"></script>
   <script type="text/javascript" src="../../src/annotation.js"></script>

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -220,26 +220,26 @@ var StepperManager = (function StepperManagerClosure() {
 
 // The stepper for each page's IRQueue.
 var Stepper = (function StepperClosure() {
+  // Shorter way to create element and optionally set textContent.
+  function c(tag, textContent) {
+    var d = document.createElement(tag);
+    if (textContent)
+      d.textContent = textContent;
+    return d;
+  }
+
   function Stepper(panel, pageIndex, initialBreakPoints) {
     this.panel = panel;
-    this.len = 0;
     this.breakPoint = 0;
     this.nextBreakPoint = null;
     this.pageIndex = pageIndex;
     this.breakPoints = initialBreakPoints;
     this.currentIdx = -1;
+    this.operatorListIdx = 0;
   }
   Stepper.prototype = {
-    init: function init(IRQueue) {
-      // Shorter way to create element and optionally set textContent.
-      function c(tag, textContent) {
-        var d = document.createElement(tag);
-        if (textContent)
-          d.textContent = textContent;
-        return d;
-      }
+    init: function init() {
       var panel = this.panel;
-      this.len = IRQueue.fnArray.length;
       var content = c('div', 'c=continue, s=step');
       var table = c('table');
       content.appendChild(table);
@@ -250,15 +250,18 @@ var Stepper = (function StepperClosure() {
       headerRow.appendChild(c('th', 'Idx'));
       headerRow.appendChild(c('th', 'fn'));
       headerRow.appendChild(c('th', 'args'));
-
+      panel.appendChild(content);
+      this.table = table;
+    },
+    updateOperatorList: function updateOperatorList(operatorList) {
       var self = this;
-      for (var i = 0; i < IRQueue.fnArray.length; i++) {
+      for (var i = this.operatorListIdx; i < operatorList.fnArray.length; i++) {
         var line = c('tr');
         line.className = 'line';
         line.dataset.idx = i;
-        table.appendChild(line);
+        this.table.appendChild(line);
         var checked = this.breakPoints.indexOf(i) != -1;
-        var args = IRQueue.argsArray[i] ? IRQueue.argsArray[i] : [];
+        var args = operatorList.argsArray[i] ? operatorList.argsArray[i] : [];
 
         var breakCell = c('td');
         var cbox = c('input');
@@ -278,11 +281,9 @@ var Stepper = (function StepperClosure() {
         breakCell.appendChild(cbox);
         line.appendChild(breakCell);
         line.appendChild(c('td', i.toString()));
-        line.appendChild(c('td', IRQueue.fnArray[i]));
+        line.appendChild(c('td', operatorList.fnArray[i]));
         line.appendChild(c('td', args.join(', ')));
       }
-      panel.appendChild(content);
-      var self = this;
     },
     getNextBreakPoint: function getNextBreakPoint() {
       this.breakPoints.sort(function(a, b) { return a - b; });


### PR DESCRIPTION
To make this much easier I stripped out much of uneeded promise code for getting operator lists.  

I've created RenderTask/InternalRenderTask to help with rendering that make it much easier to cancel the rendering and resume when more chunks are ready.  I don't really like extending the Promise for page.render(), but this way we don't break anyone's code. I've also created an OperatorList class so we have one central one that we can flush as it is built.  This also cleans up a lot of code since we had little pseudo operator list objects in a number of places.

Things we should further explore:
- Chunk size - played a bit not sure what's optimal yet.
- Render skipping images if they are ready, then restarting when they are.
- On the main thread empty the operator list as it comes in, instead of appending it.  This would help with memory but complicates things if we have multiple renderTasks going at once.

Should also note for complex pdfs this drops the rendering time quite a bit on my machine. For instance:
http://www.sfbike.org/download/map.pdf
Old code: nothing appears for 15s, 28s to finish rendering
New: appears ~2s, 15s to finish rendering
