### PR TITLE
Fix printing behaviour in Chrome

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1332,6 +1332,9 @@ canvas {
   #sidebarContainer, .toolbar, #loadingBox, #errorWrapper, .textLayer {
     display: none;
   }
+  #viewerContainer {
+    overflow: visible;
+  }
 
   #mainContainer, #viewerContainer, .page, .page canvas {
     position: static;
@@ -1342,6 +1345,7 @@ canvas {
   .page {
     float: left;
     display: none;
+    border: none;
     box-shadow: none;
   }
 


### PR DESCRIPTION
This small PR fixes a giant bug, reported at #3445
1. The border is removed by adding adding `border:none`.
2. I've added `overflow:visible` to `#viewContainer`, which solves two problems:
   - It prevents scrollbars from appearing.
   - Every "page" is automatically resized to fit on a printed page, just like the Firefox.

Before this fix, "Chrome's print to PDF" feature resulted in: https://robwu.nl/pdfjs/pdfjs-print-with-chromium-28.pdf
After this fix, the Print-to-PDF feature results in a file which looks similar to the original file.

The initial commit fixes only the styling issues. All pages still have to be pre-rendered before printing, this needs to be implemented in a separate commit/PR, and will probably require more discussion and review because rendering all pages at once will probably cause a performance hit. EDIT: See #3475
