### PR TITLE
Render all pages before printing across all browsers (not feasable)

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -3095,13 +3095,30 @@ window.addEventListener('keydown', function keydown(evt) {
   }
 });
 
-window.addEventListener('beforeprint', function beforePrint(evt) {
-  PDFView.beforePrint();
-});
+if (PDFView.supportsPrinting) {
+  // Firefox 18+
+  window.addEventListener('beforeprint', function beforePrint(evt) {
+    PDFView.beforePrint();
+  });
 
-window.addEventListener('afterprint', function afterPrint(evt) {
-  PDFView.afterPrint();
-});
+  window.addEventListener('afterprint', function afterPrint(evt) {
+    PDFView.afterPrint();
+  });
+} else if ('onbeforeprint' in window) {
+  // Internet Explorer, Firefox 5-17
+  window.addEventListener('beforeprint', function beforePrint() {
+    window.removeEventListener('beforeprint', beforePrint);
+    // TODO: PDFView.renderAllPages();
+  });
+} else if (window.matchMedia) {
+  // Chrome 9+, Opera 15+, Safari 5.1+
+  window.matchMedia('print').addListener(function beforePrint(mql) {
+    if (mql.matches) {
+      mql.removeListener(beforePrint);
+      // TODO: PDFView.renderAllPages();
+    }
+  });
+}
 
 (function presentationModeClosure() {
   function presentationModeChange(e) {


### PR DESCRIPTION
To properly solve issue #3445, PDF.js has to render all pages when the user wants to print something.

I have [figured out](http://tjvantoll.com/2012/06/15/detecting-print-requests-with-javascript/) how to detect print requests, and implemented it in the first commit. This commit introduces the possibility to fix the printing behaviour for the following browsers:
- Firefox 5 - 17 (not needed in 18+ because of mozPrintCallback)
- Chrome 9+
- Safari 5.1+
- Internet Explorer (9+)
- Opera 15+

**I have only implemented the print detection, what remains is to implement "TODO: PDFView.renderAllPages();".**
As a response to my question "What's the least expensive way to render all pages at once?", yury responded "remove image decoding and text layer generation". This answer seems reasonable, but I have yet to figure out how to convert the concept to code.
- [x] Detect print requests
- [ ] Render all pages on print (EDIT: synchronously. Is that possible? If not, see [this comment](https://github.com/mozilla/pdf.js/pull/3475#issuecomment-21004565))
