### PR TITLE
Disable Google Translate on viewer in Chrome.

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -18,6 +18,9 @@ limitations under the License.
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<!--#if GENERIC || CHROME-->
+    <meta name="google" content="notranslate">
+<!--#endif-->
     <title>PDF.js viewer</title>
 
 <!--#if FIREFOX || MOZCENTRAL-->


### PR DESCRIPTION
test/pdfs/yo01.pdf triggered "This page is in Japanese. Would you like to translate it?" info bar in Chrome. This commit adds an extra [meta tag](https://support.google.com/webmasters/answer/79812?hl=en) to the viewer for GENERIC and CHROME to disable this "feature"..

![pdfjs-google-translate](https://f.cloud.github.com/assets/1365071/801292/54fd194e-ed9c-11e2-8003-e7a5be51d90a.png)
