### PR TITLE
[WIP] Render all pages on clicking "Print" or "Ctrl + P" [needs-feedback]

### DIFF
--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -69,7 +69,7 @@ var SecondaryToolbar = {
   },
 
   printClick: function secondaryToolbarPrintClick(evt) {
-    window.print();
+    PDFView.print();
     this.close(evt.target);
   },
 


### PR DESCRIPTION
Adds proper printing support for non-Firefox browsers and Firefox 17- (layout is fixed by #3473).

There's only one problem: I've noticed that for large documents (e.g. TAMReview.pdf from tests/), the pdf page [Cache manager](https://github.com/mozilla/pdf.js/blob/e5cd027dce073209505e57d36b6045c8856ec713/web/ui_utils.js#L225-L235) disposes pages, causing the callback loop to loop forever. Should this problem be solved by temporarily changing the cache size to Infinity, or by changing the render method?

Another thing I'm unsure about is the `window.print()` call in [`pdfDocument.getJavaScript().then(function(javaScript) {`](https://github.com/mozilla/pdf.js/blob/330f6212ba411fbb6e346b7150c67a3aa0d19cf9/web/viewer.js#L1240-L1258). Should I replace this call with the `PDFView.print()` (and remove the `if (PDFview.supportsPrinting)` check at line 1240)?
- [x] Add Printer button
- [x] Intercept Ctrl + P
- [ ] Solve cache issue (see above)
- [ ] `window.print()` call for "PDFs with javaScript" (see above)
- [ ] Optimization: Skip text layers? ...?
