### PR TITLE
[Chrome extension] Improved navigation detection by using webNavigation instead of tabs API.

### DIFF
--- a/extensions/chrome/insertviewer.js
+++ b/extensions/chrome/insertviewer.js
@@ -27,6 +27,12 @@ function getViewerURL(pdf_url) {
 }
 
 function showViewer(url) {
+  if (document.documentElement === null) {
+    // If the root element hasn't been rendered yet, delay the next operation.
+    // Otherwise, document.readyState will get stuck in "interactive".
+    setTimeout(showViewer, 0, url);
+    return;
+  }
   // Cancel page load and empty document.
   window.stop();
   document.body.textContent = '';

--- a/extensions/chrome/manifest.json
+++ b/extensions/chrome/manifest.json
@@ -11,7 +11,8 @@
   "permissions": [
     "webRequest", "webRequestBlocking",
     "<all_urls>",
-    "tabs"
+    "tabs",
+    "webNavigation"
   ],
   "content_scripts": [{
       "matches": [

--- a/extensions/chrome/pdfHandler.js
+++ b/extensions/chrome/pdfHandler.js
@@ -62,6 +62,28 @@ function insertPDFJSForTab(tabId, url) {
  * @param {string} url The URL of the pdf file.
  */
 function activatePDFJSForTab(tabId, url) {
+  if (!chrome.webNavigation) {
+    // Opera... does not support the webNavigation API.
+    activatePDFJSForTabFallbackForOpera(tabId, url);
+    return;
+  }
+  var listener = function webNavigationEventListener(details) {
+    if (details.tabId === tabId) {
+      insertPDFJSForTab(tabId, url);
+      chrome.webNavigation.onCommitted.removeListener(listener);
+    }
+  };
+  var urlFilter = {
+    url: [{ urlEquals: url }]
+  };
+  chrome.webNavigation.onCommitted.addListener(listener, urlFilter);
+}
+
+/**
+ * Fallback for Opera.
+ * @see activatePDFJSForTab
+ **/
+function activatePDFJSForTabFallbackForOpera(tabId, url) {
   chrome.tabs.onUpdated.addListener(function listener(_tabId) {
     if (tabId === _tabId) {
       insertPDFJSForTab(tabId, url);


### PR DESCRIPTION
A user reported that the PDF Viewer is not rendered on Dropbox,
(Chrome on Mac OS X). This is apparently caused by the fact that the
PDF file is loaded in an iframe in such a way that the tabs.onUpdated
event is not triggered.

This patch switches to the webNavigation event API, which improves the
reliability of the navigation detection.

Unfortunately Opera 15 does not support the webNavigation API, so the
old (tabs.onUpdated) method is used (feature-detection is used, so
whenever Opera decides to implement this API, it will profit from it).
