### PR TITLE
Remove all inline JavaScript from viewer.html to comply with CSP unsafe-inline and correct error textarea's height

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -230,15 +230,15 @@ limitations under the License.
         <div id="errorWrapper" hidden='true'>
           <div id="errorMessageLeft">
             <span id="errorMessage"></span>
-            <button id="errorShowMore" onclick="" oncontextmenu="return false;" data-l10n-id="error_more_info">
+            <button id="errorShowMore" data-l10n-id="error_more_info">
               More Information
             </button>
-            <button id="errorShowLess" onclick="" oncontextmenu="return false;" data-l10n-id="error_less_info" hidden='true'>
+            <button id="errorShowLess" data-l10n-id="error_less_info" hidden='true'>
               Less Information
             </button>
           </div>
           <div id="errorMessageRight">
-            <button id="errorClose" oncontextmenu="return false;" data-l10n-id="error_close">
+            <button id="errorClose" data-l10n-id="error_close">
               Close
             </button>
           </div>

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1075,17 +1075,21 @@ var PDFView = {
       errorMoreInfo.removeAttribute('hidden');
       moreInfoButton.setAttribute('hidden', 'true');
       lessInfoButton.removeAttribute('hidden');
+      errorMoreInfo.style.height = errorMoreInfo.scrollHeight + 'px';
     };
     lessInfoButton.onclick = function() {
       errorMoreInfo.setAttribute('hidden', 'true');
       moreInfoButton.removeAttribute('hidden');
       lessInfoButton.setAttribute('hidden', 'true');
     };
+    moreInfoButton.oncontextmenu =
+    lessInfoButton.oncontextmenu =
+    closeButton.oncontextmenu = function(e) {
+      e.preventDefault();
+    };
     moreInfoButton.removeAttribute('hidden');
     lessInfoButton.setAttribute('hidden', 'true');
     errorMoreInfo.value = moreInfoText;
-
-    errorMoreInfo.rows = moreInfoText.split('\n').length - 1;
 //#else
 //  console.error(message + '\n' + moreInfoText);
 //  this.fallback();


### PR DESCRIPTION
Move inline event handlers to viewer.js to comply with a [Content-Security-Policy](http://www.w3.org/TR/2013/WD-CSP11-20130604/) where directive "unsafe-inline" is not set.

Also changed `textarea.rows = <number of newlines>` to `textarea.style.height = textarea.scrollHeight`.
The previous method was unreliable, because most errors are wrapped. In practice, this meant that the error was alsways put in a textarea with the height of one line.
