### PR TITLE
Check if viewer is embedded only once and cache the result

### DIFF
--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -23,9 +23,9 @@ var PDFHistory = {
   initialDestination: null,
 
   initialize: function pdfHistoryInitialize(fingerprint) {
-    if (PDFJS.disableHistory || window.parent !== window) {
+    if (PDFJS.disableHistory || PDFView.isViewerEmbedded) {
       // The browsing history is only enabled when the viewer is standalone,
-      // i.e. not when it is embedded in a page.
+      // i.e. not when it is embedded in a web page.
       return;
     }
     this.initialized = true;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -191,6 +191,7 @@ var PDFView = {
   mouseScrollDelta: 0,
   lastScroll: 0,
   previousPageNumber: 1,
+  isViewerEmbedded: (window.parent !== window),
 
   // called once when the document is loaded
   initialize: function pdfViewInitialize() {
@@ -947,11 +948,11 @@ var PDFView = {
       self.setInitialView(storedHash, scale);
 
       // Make all navigation keys work on document load,
-      // unless the viewer is embedded in another page.
-      if (window.parent === window) {
-        PDFView.container.focus();
+      // unless the viewer is embedded in a web page.
+      if (!self.isViewerEmbedded) {
+        self.container.focus();
 //#if (FIREFOX || MOZCENTRAL)
-//      PDFView.container.blur();
+//      self.container.blur();
 //#endif
       }
     });


### PR DESCRIPTION
I realized that I've managed to check if the viewer is embedded in two separate places in the code. Since it seems much more logical to only check once, and then cache the result, I decided to fix this. 
