### PR TITLE
Fixes regression that cause scrolling using spacebar to break in Firefox

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -227,7 +227,11 @@ limitations under the License.
                     data-l10n-id="page_rotate_cw" ></menuitem>
         </menu>
 
+<!--#if (FIREFOX || MOZCENTRAL) -->
+<!--    <div id="viewerContainer"> -->
+<!--#else -->
         <div id="viewerContainer" tabindex="0">
+<!--#endif -->
           <div id="viewer" contextmenu="viewerContextMenu"></div>
         </div>
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -950,7 +950,9 @@ var PDFView = {
       // unless the viewer is embedded in another page.
       if (window.parent === window) {
         PDFView.container.focus();
-        PDFView.container.blur();
+//#if (FIREFOX || MOZCENTRAL)
+//      PDFView.container.blur();
+//#endif
       }
     });
 


### PR DESCRIPTION
After PR #3447 was merged, scrolling using the `spacebar` no longer works as is it should in Firefox. (Note that all the other navigation keys still works as intended). To see the issue:
1. Open http://mozilla.github.io/pdf.js/web/viewer.html in Firefox.
2. Click anywhere in the `viewerContainer`.
3. Now, try to scroll the document by pressing the `spacebar`.

Expected result: The document should scroll down.
Actual result: nothing happens.

It appears that in Firefox you cannot use the spacebar to scroll when a `<div>` is the currently active element, but it works fine if the `<body>` is active. In my testing, this issue is specific to Firefox, since it works as expected in both IE and Chrome.

I've solved this issue by adding code in preprocessor tags, so that scrolling using the spacebar is restored in the Firefox addon and the Mozcentral version. Unfortunately, this solution means that scrolling using the spacebar is still broken in the web viewer whilst using Firefox. Since I'm not sure how to fix this without reintroducing the issue that #3447 fixed, I'm hoping that this will be an acceptable solution.
