### PR TITLE
Emulate spacebar to fix scrolling in the web viewer in Firefox

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2726,6 +2726,20 @@ window.addEventListener('keydown', function keydown(evt) {
     curElement = curElement.parentNode;
   }
 
+//#if GENERIC
+  var EMULATED_SPACEBAR_SCROLL_OFFSET = 35;
+
+  // Hack to make scrolling using the spacebar completely browser agnostic.
+  // (Needed for spacebar scrolling to work in the web viewer in Firefox.)
+  var emulateSpacebar = function(scrollDown) {
+    var viewerContainer = PDFView.container;
+    var top = (viewerContainer.scrollTop - EMULATED_SPACEBAR_SCROLL_OFFSET +
+               (scrollDown ? 1 : -1) * viewerContainer.clientHeight);
+    scrollIntoView(viewerContainer.firstElementChild, { top: top });
+    handled = true;
+  };
+//#endif
+
   if (cmd === 0) { // no control key pressed at all.
     switch (evt.keyCode) {
       case 38: // up arrow
@@ -2759,6 +2773,11 @@ window.addEventListener('keydown', function keydown(evt) {
       case 32: // spacebar
         if (!PDFView.isPresentationMode &&
             PDFView.currentScaleValue !== 'page-fit') {
+//#if GENERIC
+          if (evt.keyCode === 32) {
+            emulateSpacebar(true);
+          }
+//#endif
           break;
         }
         /* falls through */
@@ -2798,6 +2817,9 @@ window.addEventListener('keydown', function keydown(evt) {
       case 32: // spacebar
         if (!PDFView.isPresentationMode &&
             PDFView.currentScaleValue !== 'page-fit') {
+//#if GENERIC
+          emulateSpacebar(false);
+//#endif
           break;
         }
         PDFView.page--;


### PR DESCRIPTION
This is a continuation of PR #3497, and it implements a workaround to make sure that scrolling using the `spacebar` key works in a predictable way in all browsers. This patch tries to, as closely as possible, emulate the behaviour in Firefox, since that is where scrolling using the `spacebar` key currently doesn't work in the web viewer.

To make sure that this patch doesn't unnecessarily interfere with already working cases, it only applies to the web viewer _and_ builds created with `node make generic`.
This means that for the Firefox addon and the Mozcentral version (and also the Chromium addon), this workaround won't be used since it's not needed in those cases. 

Fixes #3498.

PS. I initially tried solving this by creating a `keydown` event to simulate `Page Down`/`Page Up` being pressed, since those keys already works. Unfortunately this didn't make any difference, hence the reason for the current workaround.
