### PR TITLE
[PDFHistory] Prevent the history from getting stuck in certain edge cases

### DIFF
--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -231,6 +231,22 @@ var PDFHistory = {
                                                             beforeUnload) {
     if (!(this.currentBookmark && this.currentPage)) {
       return null;
+    } else if (this.updatePreviousBookmark) {
+      this.updatePreviousBookmark = false;
+    }
+    if (this.uid > 0 && !(this.previousBookmark && this.previousPage)) {
+      // Prevent the history from getting stuck in the current state,
+      // effectively preventing the user from going back/forward in the history.
+      //
+      // This happens if the current position in the document didn't change when
+      // the history was previously updated. The reasons for this are either:
+      // 1. The current zoom value is such that the document does not need to,
+      //    or cannot, be scrolled to display the destination.
+      // 2. The previous destination is broken, and doesn't actally point to a
+      //    position within the document.
+      //    (This is either due to a bad PDF generator, or the user making a
+      //     mistake when entering a destination in the hash parameters.)
+      return null;
     }
     if ((!this.current.dest && !onlyCheckPage) || beforeUnload) {
       if (this.previousBookmark === this.currentBookmark) {
@@ -265,7 +281,8 @@ var PDFHistory = {
     if (addPrevious && !overwrite) {
       var previousParams = this._getPreviousParams();
       if (previousParams) {
-        var replacePrevious = (this.current.hash !== this.previousHash);
+        var replacePrevious = (!this.current.dest &&
+                               this.current.hash !== this.previousHash);
         this._pushToHistory(previousParams, false, replacePrevious);
       }
     }


### PR DESCRIPTION
This PR fixes another serious issue (the first one was #3338) where the browsing history can get stuck in the current state, preventing the user from going back/forward in the history. Detailed info about the issue in comments: https://github.com/Snuffleupagus/pdf.js/compare/PDFHistory-fix-multiple-identical-states#L0R237. The comments are perhaps a bit too verbose, but since I missed this edge case previously I thought it might be good to properly document it.

**EDIT:** An example file demonstrating this bug (note how navigation breaks when clicking on the link in the outline): http://www.nordichardware.se/images/labswedish/artiklar/Grafik/Roundup_2013_mainstream/fullimages/Warranty.pdf.

Finally, this PR also fixes a stupid copy-and-paste error (https://github.com/Snuffleupagus/pdf.js/compare/PDFHistory-fix-multiple-identical-states#L0R284) I made in #3449. This is not a particularly serious issue, since the only problem without this change is that when overwriting previous history states the current algorithm will be slightly too greedy in certain circumstances.

/cc @brendandahl
