### PR TITLE
Disable Chrome extension for non-GET requests

### DIFF
--- a/extensions/chrome/pdfHandler.js
+++ b/extensions/chrome/pdfHandler.js
@@ -147,6 +147,10 @@ function getHeadersWithContentDispositionAttachment(details) {
 
 chrome.webRequest.onHeadersReceived.addListener(
   function(details) {
+    if (details.method !== 'GET') {
+      // Don't intercept POST requests until http://crbug.com/104058 is fixed.
+      return;
+    }
     if (!isPdfFile(details))
       return;
 


### PR DESCRIPTION
Disable the Chrome extension for non-GET methods, because it's technically not possible to intercept the response body of POST requests in a Chromium extension.

Fixes https://github.com/operasoftware/pdf.js/issues/3
Fixes #3510
