### PR TITLE
[CRX] Strip location fragment from URL in the UrlFilter of the webNavigation API

### DIFF
--- a/extensions/chrome/pdfHandler.js
+++ b/extensions/chrome/pdfHandler.js
@@ -74,7 +74,7 @@ function activatePDFJSForTab(tabId, url) {
     }
   };
   var urlFilter = {
-    url: [{ urlEquals: url }]
+    url: [{ urlEquals: url.split('#', 1)[0] }]
   };
   chrome.webNavigation.onCommitted.addListener(listener, urlFilter);
 }


### PR DESCRIPTION
Otherwise the PDF Viewer is not rendered for URLs that contain a #-character, e.g. for `http://localhost:8888/test.pdf#disableWorker=true`.
