### PR TITLE
[CRX] Get pdf name from URL instead of query string

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2199,12 +2199,12 @@ var DocumentOutlineView = function documentOutlineView(outline) {
 
 document.addEventListener('DOMContentLoaded', function webViewerLoad(evt) {
   PDFView.initialize();
-  var params = PDFView.parseQueryString(document.location.search.substring(1));
 
-//#if !(FIREFOX || MOZCENTRAL)
+//#if !(FIREFOX || MOZCENTRAL || CHROME)
+  var params = PDFView.parseQueryString(document.location.search.substring(1));
   var file = params.file || DEFAULT_URL;
 //#else
-//var file = window.location.toString()
+//var file = window.location.href.split('#')[0];
 //#endif
 
 //#if !(FIREFOX || MOZCENTRAL)


### PR DESCRIPTION
Fixes https://github.com/operasoftware/pdf.js/issues/6.

Before this fix, http://www.berlin.de/imperia/md/content/lb-patienten/patientenforum/martus_gute_studie.pdf?start&ts=1309357143&file=martus_gute_studie.pdf was incorrectly treated as http://www.berlin.de/imperia/md/content/lb-patienten/patientenforum/martus_gute_studie.pdf, causing the viewer to break in the Chrome/Opera extension.
