### PR TITLE
Prevent the loadingBar from overlaying the errorWrapper

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1225,6 +1225,9 @@ canvas {
   padding: 3px;
   font-size: 0.8em;
 }
+.loadingInProgress #errorWrapper {
+  top: 39px;
+}
 
 #errorMessageLeft {
   float: left;


### PR DESCRIPTION
After #3332 was merged, the loadingBar will now overlay the top of the errorWrapper during load. This was an oversight on my part, which this PR fixes.
