### PR TITLE
Remove MozTT reference

### DIFF
--- a/extensions/b2g/viewer.css
+++ b/extensions/b2g/viewer.css
@@ -30,7 +30,7 @@ html {
 body {
   background: url(images/document_bg.png);
   color: #fff;
-  font-family: "MozTT", sans-serif;
+  font-family: sans-serif;
   font-size: 10px;
   height: 100%;
   width: 100%;


### PR DESCRIPTION
Hi PDFjs team,
The font name `MozTT` is going to be depreated. See https://groups.google.com/forum/#!topic/mozilla.dev.gaia/gZcJ1S-U6fw
The bug to remove all reference is bug 900420

Thanks!
