### PR TITLE
Faster JBIG2 decoding for Firefox

### DIFF
--- a/src/jbig2.js
+++ b/src/jbig2.js
@@ -114,26 +114,50 @@ var Jbig2Image = (function Jbig2ImageClosure() {
           this.clow &= 0xFFFF;
         }
       },
-      readBit: function ArithmeticDecoder_readBit(cx) {
-        var qeIcx = QeTable[cx.index].qe;
+      readBit: function ArithmeticDecoder_readBit(contexts, pos) {
+        // contexts are packed into 1 byte: 
+        // highest 7 bits carry cx.index, lowest bit carries cx.mps
+        var cx_index = contexts[pos] >> 1, cx_mps = contexts[pos] & 1;
+        var qeTableIcx = QeTable[cx_index];
+        var qeIcx = qeTableIcx.qe;
+        var nmpsIcx = qeTableIcx.nmps;
+        var nlpsIcx = qeTableIcx.nlps;
+        var switchIcx = qeTableIcx.switchFlag;
+        var d;
         this.a -= qeIcx;
 
         if (this.chigh < qeIcx) {
-          var d = this.exchangeLps(cx);
-          this.renormD();
-          return d;
+          // exchangeLps
+          if (this.a < qeIcx) {
+            this.a = qeIcx;
+            d = cx_mps;
+            cx_index = nmpsIcx;
+          } else {
+            this.a = qeIcx;
+            d = 1 - cx_mps;
+            if (switchIcx) {
+              cx_mps = d;
+            }
+            cx_index = nlpsIcx;
+          }
         } else {
           this.chigh -= qeIcx;
-          if ((this.a & 0x8000) === 0) {
-            var d = this.exchangeMps(cx);
-            this.renormD();
-            return d;
+          if ((this.a & 0x8000) !== 0) {
+            return cx_mps;
+          }
+          // exchangeMps
+          if (this.a < qeIcx) {
+            d = 1 - cx_mps;
+            if (switchIcx) {
+              cx_mps = d;
+            }
+            cx_index = nlpsIcx;
           } else {
-            return cx.mps;
+            d = cx_mps;
+            cx_index = nmpsIcx;
           }
         }
-      },
-      renormD: function ArithmeticDecoder_renormD() {
+        // renormD;
         do {
           if (this.ct === 0)
             this.byteIn();
@@ -143,39 +167,8 @@ var Jbig2Image = (function Jbig2ImageClosure() {
           this.clow = (this.clow << 1) & 0xFFFF;
           this.ct--;
         } while ((this.a & 0x8000) === 0);
-      },
-      exchangeMps: function ArithmeticDecoder_exchangeMps(cx) {
-        var d;
-        var qeTableIcx = QeTable[cx.index];
-        if (this.a < qeTableIcx.qe) {
-          d = 1 - cx.mps;
 
-          if (qeTableIcx.switchFlag == 1) {
-            cx.mps = 1 - cx.mps;
-          }
-          cx.index = qeTableIcx.nlps;
-        } else {
-          d = cx.mps;
-          cx.index = qeTableIcx.nmps;
-        }
-        return d;
-      },
-      exchangeLps: function ArithmeticDecoder_exchangeLps(cx) {
-        var d;
-        var qeTableIcx = QeTable[cx.index];
-        if (this.a < qeTableIcx.qe) {
-          this.a = qeTableIcx.qe;
-          d = cx.mps;
-          cx.index = qeTableIcx.nmps;
-        } else {
-          this.a = qeTableIcx.qe;
-          d = 1 - cx.mps;
-
-          if (qeTableIcx.switchFlag == 1) {
-            cx.mps = 1 - cx.mps;
-          }
-          cx.index = qeTableIcx.nlps;
-        }
+        contexts[pos] = cx_index << 1 | cx_mps;
         return d;
       }
     };
@@ -190,7 +183,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     getContexts: function(id) {
       if (id in this)
         return this[id];
-      return (this[id] = []);
+      return (this[id] = new Int8Array(1<<16));
     }
   };
 
@@ -220,10 +213,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     var state = 1, v = 0, s;
     var toRead = 32, offset = 4436; // defaults for state 7
     while (state) {
-      var cx = contexts[prev];
-      if (!cx)
-        contexts[prev] = cx = {index: 0, mps: 0};
-      var bit = decoder.readBit(cx);
+      var bit = decoder.readBit(contexts, prev);
       prev = prev < 256 ? (prev << 1) | bit :
         (((prev << 1) | bit) & 511) | 256;
       switch (state) {
@@ -278,10 +268,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
 
     var prev = 1;
     for (var i = 0; i < codeLength; i++) {
-      var cx = contexts[prev];
-      if (!cx)
-        contexts[prev] = cx = {index: 0, mps: 0};
-      var bit = decoder.readBit(cx);
+      var bit = decoder.readBit(contexts, prev);
       prev = (prev * 2) + bit;
     }
     if (codeLength < 31)
@@ -398,10 +385,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     var ltp = 0;
     for (var i = 0; i < height; i++) {
       if (prediction) {
-        var cx = contexts[pseudoPixelContext];
-        if (!cx)
-          contexts[pseudoPixelContext] = cx = {index: 0, mps: 0};
-        var sltp = decoder.readBit(cx);
+        var sltp = decoder.readBit(contexts, pseudoPixelContext);
         ltp ^= sltp;
       }
       if (ltp) {
@@ -423,10 +407,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
           else
             contextLabel = (contextLabel << 1) | bitmap[i0][j0];
         }
-        var cx = contexts[contextLabel];
-        if (!cx)
-          contexts[contextLabel] = cx = {index: 0, mps: 0};
-        var pixel = decoder.readBit(cx);
+        var pixel = decoder.readBit(contexts, contextLabel);
         row[j] = pixel;
       }
     }
@@ -469,10 +450,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     var ltp = 0;
     for (var i = 0; i < height; i++) {
       if (prediction) {
-        var cx = contexts[pseudoPixelContext];
-        if (!cx)
-          contexts[pseudoPixelContext] = cx = {index: 0, mps: 0};
-        var sltp = decoder.readBit(cx);
+        var sltp = decoder.readBit(contexts, pseudoPixelContext);
         ltp ^= sltp;
       }
       var row = new Uint8Array(width);
@@ -497,10 +475,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
           else
             contextLabel = (contextLabel << 1) | referenceBitmap[i0][j0];
         }
-        var cx = contexts[contextLabel];
-        if (!cx)
-          contexts[contextLabel] = cx = {index: 0, mps: 0};
-        var pixel = decoder.readBit(cx);
+        var pixel = decoder.readBit(contexts, contextLabel);
         row[j] = pixel;
       }
     }


### PR DESCRIPTION
This PR improves decoding speed of JBIG2 (scanned black & white) images on Firefox, and so improves #2909 and #3448.

Speed was increased via
- inlining two of the most-called functions, and
- converting a sparse array of context objects into a typed array for faster access.

The rendering speed on Firefox 24a2 is increased by factor 1.5x-5x, and by 1.5x in FF25. Chrome28 speed is unaffected.

The timings seem to be a little inconsistent though (maybe because they are measured in a VirtualBox VM?). On Windows, decoding times decreased by factor 1.25 on FF22, and by factor 2 on FF25 nightly.

Can somebody confirm the speedup?

Firefox 24a2:

```
User Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:24.0) Gecko/20130803 Firefox/24.0
-- Grouped By stat, browser, pdf -- 
stat         | browser | pdf       | Baseline(ms) | Current(ms) | +/-   | %      | Result(P<.05)
------------------------------------------------------------------------------------------------
Overall      | firefox | issue1810 | 6123         | 2213        | 3910  | 63.86  | faster       
Overall      | firefox | issue2909 | 20840        | 4297        | 16543 | 79.38  | faster       
Overall      | firefox | issue3448 | 1811         | 1167        | 643   | 35.54  |              
Page Request | firefox | issue1810 | 3            | 3           | 0     | 3.12   |              
Page Request | firefox | issue2909 | 42           | 42          | 0     | 0.79   |              
Page Request | firefox | issue3448 | 1            | 2           | -0    | -28.57 |              
Rendering    | firefox | issue1810 | 6120         | 2210        | 3910  | 63.89  | faster       
Rendering    | firefox | issue2909 | 20797        | 4255        | 16543 | 79.54  | faster       
Rendering    | firefox | issue3448 | 1809         | 1165        | 644   | 35.59  |              
```

Firefox nightly 25a1:

```
User Agent: Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0
-- Grouped By stat, browser, pdf -- 
stat         | browser        | pdf       | Baseline(ms) | Current(ms) | +/-  | %     | Result(P<.05)
-----------------------------------------------------------------------------------------------------
Overall      | ffNightly | issue1810 | 1944         | 1269        | 676  | 34.74 | faster       
Overall      | ffNightly | issue2909 | 6738         | 4523        | 2215 | 32.87 | faster       
Overall      | ffNightly | issue3448 | 681          | 466         | 215  | 31.57 | faster       
Page Request | ffNightly | issue1810 | 2            | 3           | -0   | -6.67 |              
Page Request | ffNightly | issue2909 | 42           | 42          | -0   | -0.13 |              
Page Request | ffNightly | issue3448 | 2            | 2           | -0   | -10.0 |              
Rendering    | ffNightly | issue1810 | 1941         | 1266        | 676  | 34.8  | faster       
Rendering    | ffNightly | issue2909 | 6695         | 4480        | 2215 | 33.08 | faster       
Rendering    | ffNightly | issue3448 | 679          | 464         | 215  | 31.67 | faster       
```

Chrome 28:

```
User Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.95 Safari/537.36
-- Grouped By stat, browser, pdf -- 
stat         | browser  | pdf       | Baseline(ms) | Current(ms) | +/- | %     | Result(P<.05)
----------------------------------------------------------------------------------------------
Overall      | chrome28 | issue1810 | 1499         | 1502        | -4  | -0.24 |              
Overall      | chrome28 | issue2909 | 5313         | 5327        | -13 | -0.25 |              
Overall      | chrome28 | issue3448 | 501          | 490         | 11  | 2.15  |              
Page Request | chrome28 | issue1810 | 3            | 3           | 0   | 0.0   |              
Page Request | chrome28 | issue2909 | 47           | 44          | 3   | 6.82  |              
Page Request | chrome28 | issue3448 | 4            | 3           | 1   | 33.33 |              
Rendering    | chrome28 | issue1810 | 1494         | 1497        | -4  | -0.25 |              
Rendering    | chrome28 | issue2909 | 5260         | 5281        | -20 | -0.39 |              
Rendering    | chrome28 | issue3448 | 496          | 486         | 10  | 1.98  |              
```
