### PR TITLE
Fixed german translation for sidebar

### DIFF
--- a/l10n/de/viewer.properties
+++ b/l10n/de/viewer.properties
@@ -44,8 +44,8 @@ bookmark_label=Aktuelle Ansicht
 # Tooltips and alt text for side panel toolbar buttons
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
-toggle_slider.title=Seitenleiste anzeigen
-toggle_slider_label=Seitenleiste
+toggle_sidebar.title=Seitenleiste anzeigen
+toggle_sidebar_label=Seitenleiste
 outline.title=Zeige Inhaltsverzeichnis
 outline_label=Inhaltsverzeichnis
 thumbs.title=Zeige Vorschaubilder


### PR DESCRIPTION
viewer.html is using "toggle_sidebar" - German localization file only defines "toggle_slider" which is not used
