### PR TITLE
Fix intermittent blank page on fast zoom.

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -852,7 +852,7 @@ var InternalRenderTask = (function InternalRenderTaskClosure() {
     cancel: function InternalRenderTask_cancel() {
       this.running = false;
       this.cancelled = true;
-      this.callback();
+      this.callback('cancelled');
     },
 
     operatorListChanged: function InternalRenderTask_operatorListChanged() {


### PR DESCRIPTION
Fixes #3545. The current render task was being replaced but the old one still updated the state.
