### PR TITLE
Speed up JPX decoding on Firefox

### DIFF
--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -1692,6 +1692,19 @@ var JpxImage = (function JpxImageClosure() {
       }
       return ll;
     };
+    Transform.prototype.expand = function expand(buffer, bufferPadding, step) {
+        // Section F.3.7 extending... using max extension of 4
+        var i1 = bufferPadding - 1, j1 = bufferPadding + 1;
+        var i2 = bufferPadding + step - 2, j2 = bufferPadding + step;
+        buffer[i1--] = buffer[j1++];
+        buffer[j2++] = buffer[i2--];
+        buffer[i1--] = buffer[j1++];
+        buffer[j2++] = buffer[i2--];
+        buffer[i1--] = buffer[j1++];
+        buffer[j2++] = buffer[i2--];
+        buffer[i1--] = buffer[j1++];
+        buffer[j2++] = buffer[i2--];
+    };
     Transform.prototype.iterate = function Transform_iterate(ll, hl, lh, hh,
                                                             u0, v0) {
       var llWidth = ll.width, llHeight = ll.height, llItems = ll.items;
@@ -1745,18 +1758,7 @@ var JpxImage = (function JpxImageClosure() {
         for (var u = 0; u < width; u++, k++, l++)
           buffer[l] = items[k];
 
-        // Section F.3.7 extending... using max extension of 4
-        var i1 = bufferPadding - 1, j1 = bufferPadding + 1;
-        var i2 = bufferPadding + width - 2, j2 = bufferPadding + width;
-        buffer[i1--] = buffer[j1++];
-        buffer[j2++] = buffer[i2--];
-        buffer[i1--] = buffer[j1++];
-        buffer[j2++] = buffer[i2--];
-        buffer[i1--] = buffer[j1++];
-        buffer[j2++] = buffer[i2--];
-        buffer[i1--] = buffer[j1++];
-        buffer[j2++] = buffer[i2--];
-
+        this.expand(buffer, bufferPadding, width);
         this.filter(buffer, bufferPadding, width, u0, bufferOut);
 
         k = v * width;
@@ -1780,18 +1782,7 @@ var JpxImage = (function JpxImageClosure() {
         for (var v = 0; v < height; v++, k += width, l++)
           buffer[l] = items[k];
 
-        // Section F.3.7 extending... using max extension of 4
-        var i1 = bufferPadding - 1, j1 = bufferPadding + 1;
-        var i2 = bufferPadding + height - 2, j2 = bufferPadding + height;
-        buffer[i1--] = buffer[j1++];
-        buffer[j2++] = buffer[i2--];
-        buffer[i1--] = buffer[j1++];
-        buffer[j2++] = buffer[i2--];
-        buffer[i1--] = buffer[j1++];
-        buffer[j2++] = buffer[i2--];
-        buffer[i1--] = buffer[j1++];
-        buffer[j2++] = buffer[i2--];
-
+        this.expand(buffer, bufferPadding, height);
         this.filter(buffer, bufferPadding, height, v0, bufferOut);
 
         k = u;


### PR DESCRIPTION
This PR extracts ten lines of code to an own method, and thereby speeds up JPX image decoding on Firefox significantly (for whatever reason). 

Chrome Nightly:

```
User Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/30.0.1588.0 Safari/537.36
-- Grouped By stat, browser, pdf -- 
stat         | browser  | pdf       | Baseline(ms) | Current(ms) | +/- | %     | Result(P<.05)
----------------------------------------------------------------------------------------------
Overall      | chrome | S2-eq     | 843          | 896         | -53 | -6.29 |              
Overall      | chrome | issue2790 | 6035         | 5877        | 158 | 2.62  |              
Overall      | chrome | issue3181 | 4670         | 4558        | 112 | 2.4   |              
Page Request | chrome | S2-eq     | 164          | 159         | 5   | 3.05  |              
Page Request | chrome | issue2790 | 7            | 7           | 0   | 0.0   |              
Page Request | chrome | issue3181 | 209          | 219         | -10 | -4.78 |              
Rendering    | chrome | S2-eq     | 677          | 736         | -59 | -8.71 |              
Rendering    | chrome | issue2790 | 6027         | 5869        | 158 | 2.62  |              
Rendering    | chrome | issue3181 | 4459         | 4338        | 121 | 2.71  |              
```

Firefox 24:

```
User Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:24.0) Gecko/20130804 Firefox/24.0
-- Grouped By stat, browser, pdf -- 
stat         | browser | pdf       | Baseline(ms) | Current(ms) | +/-   | %     | Result(P<.05)
-----------------------------------------------------------------------------------------------
Overall      | firefox | S2-eq     | 2098         | 852         | 1246  | 59.39 |              
Overall      | firefox | issue2790 | 25487        | 10949       | 14538 | 57.04 |              
Overall      | firefox | issue3181 | 21759        | 12411       | 9348  | 42.96 |              
Page Request | firefox | S2-eq     | 173          | 189         | -16   | -9.25 |              
Page Request | firefox | issue2790 | 18           | 14          | 4     | 22.22 |              
Page Request | firefox | issue3181 | 158          | 159         | -1    | -0.63 |              
Rendering    | firefox | S2-eq     | 1924         | 661         | 1263  | 65.64 |              
Rendering    | firefox | issue2790 | 25468        | 10935       | 14533 | 57.06 |              
Rendering    | firefox | issue3181 | 21600        | 12252       | 9348  | 43.28 |              
```

Firefox Nightly:

```
User Agent: Mozilla/5.0 (X11; Linux x86_64; rv:26.0) Gecko/20100101 Firefox/26.0
-- Grouped By stat, browser, pdf -- 
stat         | browser        | pdf       | Baseline(ms) | Current(ms) | +/-   | %     | Result(P<.05)
------------------------------------------------------------------------------------------------------
Overall      | firefoxNightly | S2-eq     | 2230         | 887         | 1343  | 60.22 |              
Overall      | firefoxNightly | issue2790 | 22007        | 6544        | 15463 | 70.26 |              
Overall      | firefoxNightly | issue3181 | 14886        | 5283        | 9603  | 64.51 |              
Page Request | firefoxNightly | S2-eq     | 195          | 190         | 5     | 2.56  |              
Page Request | firefoxNightly | issue2790 | 12           | 15          | -3    | -25.0 |              
Page Request | firefoxNightly | issue3181 | 158          | 159         | -1    | -0.63 |              
Rendering    | firefoxNightly | S2-eq     | 2034         | 697         | 1337  | 65.73 |              
Rendering    | firefoxNightly | issue2790 | 21995        | 6529        | 15466 | 70.32 |              
Rendering    | firefoxNightly | issue3181 | 14727        | 5123        | 9604  | 65.21 |              
```
