### PR TITLE
[CRX] Fixes to view local files again

### DIFF
--- a/extensions/chrome/pdfHandler.js
+++ b/extensions/chrome/pdfHandler.js
@@ -31,8 +31,8 @@ function isPdfDownloadable(details) {
   // if the file is displayed in the main frame.
   if (details.type == 'main_frame')
     return false;
-  var cdHeader = getHeaderFromHeaders(details.responseHeaders,
-                                      'content-disposition');
+  var cdHeader = details.responseHeaders &&
+    getHeaderFromHeaders(details.responseHeaders, 'content-disposition');
   return cdHeader && /^attachment/i.test(cdHeader.value);
 }
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2259,11 +2259,17 @@ var DocumentOutlineView = function documentOutlineView(outline) {
 document.addEventListener('DOMContentLoaded', function webViewerLoad(evt) {
   PDFView.initialize();
 
-//#if !(FIREFOX || MOZCENTRAL || CHROME)
+//#if !(FIREFOX || MOZCENTRAL)
   var params = PDFView.parseQueryString(document.location.search.substring(1));
   var file = params.file || DEFAULT_URL;
 //#else
 //var file = window.location.href.split('#')[0];
+//#endif
+
+//#if CHROME
+//if (location.protocol !== 'chrome-extension:') {
+//  file = location.href.split('#')[0];
+//}
 //#endif
 
 //#if !(FIREFOX || MOZCENTRAL || CHROME)


### PR DESCRIPTION
pdfHandler-local.js references the isPdfDownloadable function from
pdfHandler.js, but the function didn't expect that the responseHeaders
property was absent. Added a check to prevent a runtime error when a
local file is displayed in a frame, and show local PDF files again.

Local files are rendered on the `chrome-extension:`-protocol. The previous
method of getting the PDF URL was incorrect, this has been fixed as well.
