### PR TITLE
Enable loading of PDFs with undefined or missing stream lengths

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -208,8 +208,10 @@ var Parser = (function ParserClosure() {
 
       // get length
       var length = this.fetchIfRef(dict.get('Length'));
-      if (!isInt(length))
-        error('Bad ' + length + ' attribute in stream');
+      if (!isInt(length)) {
+        info('Bad ' + length + ' attribute in stream');
+        length = 0;
+      }
 
       // skip over the stream data
       stream.pos = pos + length;

--- a/test/pdfs/issue1293.pdf.link
+++ b/test/pdfs/issue1293.pdf.link
@@ -1,0 +1,1 @@
+http://dl.dropbox.com/u/22242495/pdfjs/pdfkit_uncompressed.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -23,6 +23,16 @@
        "rounds": 1,
        "type": "text"
     },
+    {  "id": "issue1293",
+       "file": "pdfs/issue1293.pdf",
+       "md5": "0a744b3bbf2fd8da0131fd3c01dd1e30",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 1,
+       "lastPage": 1,
+       "type": "load",
+       "about": "PDF with undefined stream length."
+    },
     {  "id": "issue2881",
        "file": "pdfs/issue2881.pdf",
        "md5": "ea6ade27d2cb146676d23dcd6605d5ee",


### PR DESCRIPTION
After #3376 landed, there is support for loading of PDFs with incorrect stream lengths (commit https://github.com/yurydelendik/pdf.js/commit/4d9ee7b53002cc34e42b503db31530deea50c62c). This code works equally well when a stream length is undefined, so this PR enables loading of PDFs with undefined stream lengths.

Fixes #1293.

/cc @yurydelendik
