### PR TITLE
Set URL in history.replaceState/pushState

### DIFF
--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -65,7 +65,8 @@ var PDFHistory = {
         // is opened in the web viewer.
         this.reInitialized = true;
       }
-      window.history.replaceState({ fingerprint: this.fingerprint }, '');
+      window.history.replaceState({ fingerprint: this.fingerprint }, '',
+          document.URL);
     }
 
     var self = this;
@@ -270,9 +271,9 @@ var PDFHistory = {
       }
     }
     if (overwrite || this.uid === 0) {
-      window.history.replaceState(this._stateObj(params), '');
+      window.history.replaceState(this._stateObj(params), '', document.URL);
     } else {
-      window.history.pushState(this._stateObj(params), '');
+      window.history.pushState(this._stateObj(params), '', document.URL);
     }
     this.currentUid = this.uid++;
     this.current = params;


### PR DESCRIPTION
When `<base href>` is present, `history.replaceState` and `history.pushState` behave inconsistent with relative URLs - see https://code.google.com/p/chromium/issues/detail?id=274024

Contrary to what one expect, omitting the third argument, or using '' as the URL parameter for `replaceState`/`pushState` does not associate the currently active URL with the history entry, but a path relative to `<base href>`.

To fix the issue, explicitly associate the current active URL with the history's state.

Note: Chrome does currently not use `<base href>`, but I'm working on an improved version of the Chrome extension that uses this tag. Among the features of the new Chrome extension is the support for POST requests. I'm tracking the progress separately at https://github.com/Rob--W/pdf.js/issues/1, because I haven't submit a PR yet (use of the private API requires feedback from the Chromium project).
