### PR TITLE
Simplify getVisiblePages() and fix searching in presentation mode

### DIFF
--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -36,6 +36,7 @@ var TextLayerBuilder = function textLayerBuilder(options) {
   this.pageIdx = options.pageIndex;
   this.matches = [];
   this.lastScrollSource = options.lastScrollSource;
+  this.isViewerInPresentationMode = options.isViewerInPresentationMode;
 
   if(typeof PDFFindController === 'undefined') {
       window.PDFFindController = null;
@@ -304,8 +305,9 @@ var TextLayerBuilder = function textLayerBuilder(options) {
 
       var isSelected = isSelectedPage && i === selectedMatchIdx;
       var highlightSuffix = (isSelected ? ' selected' : '');
-      if (isSelected)
-        scrollIntoView(textDivs[begin.divIdx], {top: -50});
+      if (isSelected && !this.isViewerInPresentationMode) {
+        scrollIntoView(textDivs[begin.divIdx], { top: -50 });
+      }
 
       // Match inside new div.
       if (!prevEnd || begin.divIdx !== prevEnd.divIdx) {

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -75,7 +75,6 @@ select {
   cursor: none;
 }
 
-
 :-webkit-full-screen .page {
   margin-bottom: 100%;
 }
@@ -100,7 +99,20 @@ select {
   display: none;
 }
 
-#viewerContainer.presentationControls {
+:-webkit-full-screen .textLayer > div {
+  cursor: none;
+}
+
+:-moz-full-screen .textLayer > div {
+  cursor: none;
+}
+
+:fullscreen .textLayer > div {
+  cursor: none;
+}
+
+#viewerContainer.presentationControls,
+#viewerContainer.presentationControls .textLayer > div {
   cursor: default;
 }
 


### PR DESCRIPTION
This PR makes a couple of improvements of the presentation mode implementation:
- First of all, this patch removes the presentation mode specific code from `getVisiblePages()`, since it isn't actually needed any more. (It appears that this code was made redundant by https://github.com/mozilla/pdf.js/pull/2916, but I apparently missed it in that PR.)
  This change is also necessary for the next part of this patch.
- Secondly, this patch also fixes issues related to searching in presentation mode. (Please note that searching is still _only_ possible in the Firefox versions of PDF.js.)
  ~~This was done by adding a variable to the `PDFJS` object, since that was the easiest way I could think of that shouldn't break any third-party implementations of PDF.js with text selection enabled.~~
- Finally, since text selection isn't possible in presentation mode, the cursor is changed to properly reflect that.
  Fixes #3423.
