### PR TITLE
Really call unregister for _pdfRedirectorFactory (fixing issue #3598)

### DIFF
--- a/extensions/firefox/content/PdfJs.jsm
+++ b/extensions/firefox/content/PdfJs.jsm
@@ -254,7 +254,7 @@ let PdfJs = {
     this._pdfStreamConverterFactory.unregister();
     delete this._pdfStreamConverterFactory;
 
-    this._pdfRedirectorFactory.unregister;
+    this._pdfRedirectorFactory.unregister();
     delete this._pdfRedirectorFactory;
     Svc.pluginHost.unregisterPlayPreviewMimeType(PDF_CONTENT_TYPE);
 


### PR DESCRIPTION
Due to the missing brackets the unregister function for _pdfRedirectorFactory is not call resulting in the error messages described in issue #3598 if the pdf.js is (temporarily) disabled by a addon. This fix was tested by using the javascript debugger in firefox and calling the unregister function manually in the interactive session box.
