### PR TITLE
Prevent searching during load from breaking the find functionality

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -64,6 +64,8 @@ var PDFFindController = {
 
   integratedFind: false,
 
+  firstPagePromise: new PDFJS.Promise(),
+
   initialize: function(options) {
     if(typeof PDFFindBar === 'undefined' || PDFFindBar === null) {
         throw 'PDFFindController cannot be initialized ' +
@@ -172,15 +174,17 @@ var PDFFindController = {
     this.state = e.detail;
     this.updateUIState(FindStates.FIND_PENDING);
 
-    this.extractText();
+    this.firstPagePromise.then(function() {
+      this.extractText();
 
-    clearTimeout(this.findTimeout);
-    if (e.type === 'find') {
-      // Only trigger the find action after 250ms of silence.
-      this.findTimeout = setTimeout(this.nextMatch.bind(this), 250);
-    } else {
-      this.nextMatch();
-    }
+      clearTimeout(this.findTimeout);
+      if (e.type === 'find') {
+        // Only trigger the find action after 250ms of silence.
+        this.findTimeout = setTimeout(this.nextMatch.bind(this), 250);
+      } else {
+        this.nextMatch();
+      }
+    }.bind(this));
   },
 
   updatePage: function(idx) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -162,8 +162,6 @@ var Settings = (function SettingsClosure() {
 var cache = new Cache(CACHE_SIZE);
 var currentPageNumber = 1;
 
-// TODO: Enable the FindBar *AFTER* the pagesPromise in the load function
-// got resolved
 //#include pdf_find_bar.js
 //#include pdf_find_controller.js
 //#include pdf_history.js
@@ -940,6 +938,8 @@ var PDFView = {
         });
         pagePromises.push(pagePromise);
       }
+
+      PDFFindController.firstPagePromise.resolve();
 
       PDFJS.Promise.all(pagePromises).then(function(pages) {
         pagesPromise.resolve(pages);


### PR DESCRIPTION
This patch fixes #3604. It does this by adding a promise that is resolved when enough of the file is loaded, to avoid issues with properties of `PDFView` not being defined when the user tries to search.

Initially I tried just moving `PDFFindController.initialize(...)` in viewer.js, but this didn't really seem to help. Furthermore that also doesn't seem like a good solution since that would delay the registering of the find event listeners, which might not be ideal considering that we use that built-in findbar in Firefox. 

~~Finally, this patch also fixes a few coding style nits in pdf_find_controller.js and removes some old dead code from viewer.js.~~

I hope that the approach in this patch is sound!
