### PR TITLE
Use text widget annotation appearance stream if it is available.

### DIFF
--- a/src/shared/annotation.js
+++ b/src/shared/annotation.js
@@ -100,6 +100,7 @@ var Annotation = (function AnnotationClosure() {
     }
 
     this.appearance = getDefaultAppearance(dict);
+    data.hasAppearance = !!this.appearance;
   }
 
   Annotation.prototype = {
@@ -406,7 +407,7 @@ var TextWidgetAnnotation = (function TextWidgetAnnotationClosure() {
   var parent = WidgetAnnotation.prototype;
   Util.inherit(TextWidgetAnnotation, WidgetAnnotation, {
     hasHtml: function TextWidgetAnnotation_hasHtml() {
-      return !!this.data.fieldValue;
+      return !this.data.hasAppearance && !!this.data.fieldValue;
     },
 
     getHtmlElement: function TextWidgetAnnotation_getHtmlElement(commonObjs) {
@@ -434,6 +435,9 @@ var TextWidgetAnnotation = (function TextWidgetAnnotationClosure() {
     },
 
     getOperatorList: function TextWidgetAnnotation_getOperatorList(evaluator) {
+      if (this.appearance) {
+        return Annotation.prototype.getOperatorList.call(this, evaluator);
+      }
 
       var promise = new Promise();
       var opList = new OperatorList();


### PR DESCRIPTION
Fixes #3419

I also have some code to build more html for these annotations, but to get it to a state where it fully matches the appearance stream is going to be a lot more work.  For now let's just use the appearance stream if it's available.
