### PR TITLE
Prevent searching from breaking when opening a new file in the web viewer

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -87,6 +87,12 @@ var PDFFindController = {
     }
   },
 
+  reset: function pdfFindControllerReset() {
+    this.startedTextExtraction = false;
+    this.extractTextPromises = [];
+    this.active = false;
+  },
+
   calcFindMatch: function(pageIndex) {
     var pageContent = this.pageContents[pageIndex];
     var query = this.state.query;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -827,6 +827,8 @@ var PDFView = {
       };
     }
 
+    PDFFindController.reset();
+
     this.pdfDocument = pdfDocument;
 
     var errorWrapper = document.getElementById('errorWrapper');


### PR DESCRIPTION
When testing #3607, I stumbled upon another search related bug. Steps to reproduce:
1. Open: http://mozilla.github.io/pdf.js/web/viewer.html.
2. Search for any word.
3. Click on the "Open File" button and load a new file.
4. Do a new search.

**Expected result:** Searching should work in the new document.

**Actual result:** Searching fails, with the following console message:
`[12:38:33.353] TypeError: this.extractTextPromises[i] is undefined @ http://mozilla.github.io/pdf.js/web/viewer.js:794`

This PR fixes the above by resetting a couple of parameters in `PDFFindController` whenever a file is loaded, thus preventing find from using data from a previously loaded file when the user searches.
