### PR TITLE
Prevent named actions from displaying a 'resource://' URL in Firefox

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1643,6 +1643,7 @@ var PageView = function pageView(container, id, scale,
     }
 
     function bindNamedAction(link, action) {
+      link.href = PDFView.getAnchorUrl('');
       link.onclick = function pageViewSetupNamedActionOnClick() {
         // See PDF reference, table 8.45 - Named action
         switch (action) {


### PR DESCRIPTION
After #3557 was merged, there is support for named actions. One small visual issue with that PR is that in the _Firefox addon_, when hovering over a named action link, a `resource://` URL will be displayed. This is fixed by the current PR.

An example of a file containing named actions: http://homepages.cwi.nl/~frb/PC13slides.pdf.
