### PR TITLE
Added support for JBIG2 extension segment

### DIFF
--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -912,6 +912,9 @@ var Jbig2Image = (function Jbig2ImageClosure() {
         break;
       case 51: // EndOfFile
         break;
+      case 62: // 7.4.15 defines 2 extension types which
+               // are comments and can be ignored.
+        break;
       default:
         error('JBIG2 error: segment type ' + header.typeName + '(' +
               header.type + ') is not implemented');


### PR DESCRIPTION
This addresses an issue #3616, https://github.com/mozilla/pdf.js/issues/3616. The extension segment (62) was not being handled in the switch/case so the default case threw an exception. Per the JBIG2 spec (7.4.14-7.4.15) this information is simply a metadata comment and per the PDF32000 spec (7.4.7) can be safely ignored.

JBIG2 spec - http://www.jpeg.org/public/fcd14492.pdf
PDF32000 spec - http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf
