### PR TITLE
Disable range requests in old Android versions

### DIFF
--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -458,7 +458,15 @@ if (typeof PDFJS === 'undefined') {
   // Last tested with version 6.0.4.
   var isSafari = Object.prototype.toString.call(
                   window.HTMLElement).indexOf('Constructor') > 0;
-  if (isSafari) {
+
+  // Older versions of Android (pre 3.0) has issues with range requests, see:
+  // https://github.com/mozilla/pdf.js/issues/3381.
+  // Make sure that we only match webkit-based Android browsers,
+  // since Firefox/Fennec works as expected.
+  var regex = /Android\s[0-2][^\d]/;
+  var isOldAndroid = regex.test(navigator.userAgent);
+
+  if (isSafari || isOldAndroid) {
     PDFJS.disableRange = true;
   }
 })();


### PR DESCRIPTION
This PR attempts to fix #3381. _(Disclaimer: I don't have access to an Android device with the right OS version, so I've tested this by changing the user agent in a standard desktop browser.)_

I've been unable to find any proper information regarding which Android versions that doesn't support range requests, so based on the information given in the issue I simply assumed that this effects `Android versions < 3`.

@DanielRuf Can you confirm if this fixes the issues you reported in #3381.
