### PR TITLE
Properly disable presentation mode when the viewer is embedded

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -400,6 +400,10 @@ var PDFView = {
         document.mozFullScreenEnabled === false ||
         document.webkitFullscreenEnabled === false ) {
       support = false;
+    } else if (this.isViewerEmbedded) {
+      // Need to check if the viewer is embedded as well, to prevent issues with
+      // presentation mode when the viewer is embedded in '<object>' tags.
+      support = false;
     }
 
     Object.defineProperty(this, 'supportsFullscreen', { value: support,
@@ -1392,6 +1396,9 @@ var PDFView = {
   },
 
   presentationMode: function pdfViewPresentationMode() {
+    if (!this.supportsFullscreen) {
+      return false;
+    }
     var isPresentationMode = document.fullscreenElement ||
                              document.mozFullScreen ||
                              document.webkitIsFullScreen;


### PR DESCRIPTION
Currently presentation mode isn't properly disabled when the viewer is embedded in a web page.
**Steps to reproduce:**
1. Open http://people.mozilla.com/~ydelendik/presentations/ecma5.html#/2.
2. Click anywhere within the PDF.js user interface.
3. Enter presentation mode, by using the keyboard shortcut `Ctrl+Alt+P`. ~~(Note that the toolbar button isn't visible, but that's only because the PDF.js UI is too small.)~~ _EDIT: Now that the secondary toolbar has landed, the presentation mode button will be available from it, thus making it a lot easier for the user to enter a non-working presentation mode._

**Expected result:** Presentation mode should either work, or be disabled.

**Actual result:** (A picture is worth a thousand words...)
![presentationmode_embedded](https://f.cloud.github.com/assets/2692120/1079656/688d892a-154d-11e3-945a-20d598c6fb73.png)

This PR adds a check in `PDFView.supportsFullscreen` to disable presentation mode when the viewer is embedded, to avoid the above issue.
