### PR TITLE
Do not process shortcuts when active element is a Textarea

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2692,6 +2692,7 @@ window.addEventListener('keydown', function keydown(evt) {
   // is selected.
   var curElement = document.activeElement || document.querySelector(':focus');
   if (curElement && (curElement.tagName.toUpperCase() === 'INPUT' ||
+                      curElement.tagName.toUpperCase() === 'TEXTAREA' ||
                      curElement.tagName.toUpperCase() === 'SELECT')) {
     // Make sure that the secondary toolbar is closed when Escape is pressed.
     if (evt.keyCode !== 27) { // 'Esc'

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2692,7 +2692,7 @@ window.addEventListener('keydown', function keydown(evt) {
   // is selected.
   var curElement = document.activeElement || document.querySelector(':focus');
   if (curElement && (curElement.tagName.toUpperCase() === 'INPUT' ||
-                      curElement.tagName.toUpperCase() === 'TEXTAREA' ||
+                     curElement.tagName.toUpperCase() === 'TEXTAREA' ||
                      curElement.tagName.toUpperCase() === 'SELECT')) {
     // Make sure that the secondary toolbar is closed when Escape is pressed.
     if (evt.keyCode !== 27) { // 'Esc'


### PR DESCRIPTION
With this patch, if the active control is a textarea keyboard shortcuts won't be processed
