### PR TITLE
Enable presentationMode in Internet Explorer 11

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1542,3 +1542,23 @@ canvas {
   }
 }
 
+#viewerContainer:-ms-fullscreen {
+  /* Presentation mode doesn't work properly in Internet Explorer 11,
+     unless these rules are placed *after* the ones that are being overridden. */
+  top: 0px;
+  border-top: 2px solid transparent;
+  background-color: #404040;
+  background-image: url(images/texture.png);
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  cursor: none;
+}
+
+:-ms-fullscreen .page {
+  margin-bottom: 100%;
+}
+
+:-ms-fullscreen a:not(.internalLink) {
+  display: none;
+}

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -391,12 +391,15 @@ var PDFView = {
 
   get supportsFullscreen() {
     var doc = document.documentElement;
-    var support = doc.requestFullscreen || doc.mozRequestFullScreen ||
-                  doc.webkitRequestFullScreen;
+    var support = doc.requestFullscreen ||
+                  doc.mozRequestFullScreen ||
+                  doc.webkitRequestFullScreen ||
+                  doc.msRequestFullscreen;
 
     if (document.fullscreenEnabled === false ||
         document.mozFullScreenEnabled === false ||
-        document.webkitFullscreenEnabled === false ) {
+        document.webkitFullscreenEnabled === false ||
+        document.msFullscreenEnabled === false) {
       support = false;
     }
 
@@ -1386,8 +1389,8 @@ var PDFView = {
   presentationMode: function pdfViewPresentationMode() {
     var isPresentationMode = document.fullscreenElement ||
                              document.mozFullScreen ||
-                             document.webkitIsFullScreen;
-
+                             document.webkitIsFullScreen ||
+                             document.msFullscreenElement;
     if (isPresentationMode) {
       return false;
     }
@@ -1399,6 +1402,8 @@ var PDFView = {
       wrapper.mozRequestFullScreen();
     } else if (document.documentElement.webkitRequestFullScreen) {
       wrapper.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);
+    } else if (document.documentElement.msRequestFullscreen) {
+      wrapper.msRequestFullscreen();
     } else {
       return false;
     }
@@ -2830,7 +2835,8 @@ window.addEventListener('afterprint', function afterPrint(evt) {
   function presentationModeChange(e) {
     var isPresentationMode = document.fullscreenElement ||
                              document.mozFullScreen ||
-                             document.webkitIsFullScreen;
+                             document.webkitIsFullScreen ||
+                             document.msFullscreenElement;
 
     if (isPresentationMode) {
       PDFView.enterPresentationMode();
@@ -2843,6 +2849,7 @@ window.addEventListener('afterprint', function afterPrint(evt) {
   window.addEventListener('mozfullscreenchange', presentationModeChange, false);
   window.addEventListener('webkitfullscreenchange', presentationModeChange,
                           false);
+  window.addEventListener('MSFullscreenChange', presentationModeChange, false);
 })();
 
 (function animationStartedClosure() {


### PR DESCRIPTION
_(I just realized that I had forgotten about this patch, after finishing it a couple of weeks ago.)_

This PR enables presentation mode in Internet Explorer. Note that it will only work in version 11, since that is the first version of IE that supports the Fullscreen API: http://msdn.microsoft.com/en-us/library/ie/dn265028%28v=vs.85%29.aspx.

_**Just a note for anyone wanting to test this:** IE11 does not include the compatibility mode which allows you to test pages in previous versions of the browser (such as IE10, IE9, ...). By installing IE11, you are no longer able to easily run older version of IE._
