### PR TITLE
Support for fullscreen presentationMode in Internet Explorer

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -66,11 +66,10 @@ select {
 
 #viewerContainer:-ms-fullscreen {
   top: 0px !important;
-  position: absolute;
   border-top: 2px solid transparent;
   width: 100%;
   height: 100%;
-  overflow: hidden;
+  overflow: hidden !important;
   cursor: none;
 }
 
@@ -99,7 +98,7 @@ select {
 }
 
 :-ms-fullscreen .page {
-  margin-bottom: 100%;
+  margin-bottom: 100% !important;
 }
 
 :fullscreen .page {
@@ -115,7 +114,7 @@ select {
 }
 
 :-ms-fullscreen a:not(.internalLink) {
-  display: none;
+  display: none !important;
 }
 
 :fullscreen a:not(.internalLink) {

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -64,6 +64,21 @@ select {
   cursor: none;
 }
 
+#viewerContainer:-ms-fullscreen {
+  top: 0px !important;
+  position: absolute;
+  border-top: 2px solid transparent;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  cursor: none;
+}
+
+#viewerContainer:-ms-fullscreen::-ms-backdrop {
+  background-color: #404040;
+  background-image: url(images/texture.png);
+}
+
 #viewerContainer:fullscreen {
   top: 0px;
   border-top: 2px solid transparent;
@@ -83,6 +98,10 @@ select {
   margin-bottom: 100%;
 }
 
+:-ms-fullscreen .page {
+  margin-bottom: 100%;
+}
+
 :fullscreen .page {
   margin-bottom: 100%;
 }
@@ -92,6 +111,10 @@ select {
 }
 
 :-moz-full-screen a:not(.internalLink) {
+  display: none;
+}
+
+:-ms-fullscreen a:not(.internalLink) {
   display: none;
 }
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -392,11 +392,12 @@ var PDFView = {
   get supportsFullscreen() {
     var doc = document.documentElement;
     var support = doc.requestFullscreen || doc.mozRequestFullScreen ||
-                  doc.webkitRequestFullScreen;
+                  doc.webkitRequestFullScreen || doc.msRequestFullscreen;
 
     if (document.fullscreenEnabled === false ||
         document.mozFullScreenEnabled === false ||
-        document.webkitFullscreenEnabled === false ) {
+        document.webkitFullscreenEnabled === false ||
+        document.msFullscreenEnabled === false) {
       support = false;
     }
 
@@ -1386,7 +1387,8 @@ var PDFView = {
   presentationMode: function pdfViewPresentationMode() {
     var isPresentationMode = document.fullscreenElement ||
                              document.mozFullScreen ||
-                             document.webkitIsFullScreen;
+                             document.webkitIsFullScreen ||
+                             document.msFullscreenElement;
 
     if (isPresentationMode) {
       return false;
@@ -1399,6 +1401,8 @@ var PDFView = {
       wrapper.mozRequestFullScreen();
     } else if (document.documentElement.webkitRequestFullScreen) {
       wrapper.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);
+    } else if (document.documentElement.msRequestFullscreen) {
+      wrapper.msRequestFullscreen();
     } else {
       return false;
     }
@@ -2830,7 +2834,8 @@ window.addEventListener('afterprint', function afterPrint(evt) {
   function presentationModeChange(e) {
     var isPresentationMode = document.fullscreenElement ||
                              document.mozFullScreen ||
-                             document.webkitIsFullScreen;
+                             document.webkitIsFullScreen ||
+                             document.msFullscreenElement;
 
     if (isPresentationMode) {
       PDFView.enterPresentationMode();
@@ -2843,6 +2848,7 @@ window.addEventListener('afterprint', function afterPrint(evt) {
   window.addEventListener('mozfullscreenchange', presentationModeChange, false);
   window.addEventListener('webkitfullscreenchange', presentationModeChange,
                           false);
+  window.addEventListener('MSFullscreenChange', presentationModeChange, false);
 })();
 
 (function animationStartedClosure() {


### PR DESCRIPTION
This PR enables presentationMode in Internet Explorer 11.

Background color and image is specified separately, as per MSDN.

MSDN reference api: http://msdn.microsoft.com/en-us/library/ie/dn265028(v=vs.85).aspx

Tested on Windows 7 IE11.
