### PR TITLE
Adding Persian Translations

### DIFF
--- a/l10n/fa/chrome.properties
+++ b/l10n/fa/chrome.properties
@@ -1,0 +1,18 @@
+# Copyright 2013 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Chrome notification bar messages and buttons
+unsupported_feature=این پروندهٔ پی‌دی‌اف ممکن است به درستی نمایش داده نشود.
+open_with_different_viewer=با نمایش‌دهنده‌ای متفاوت آن را باز کنید
+open_with_different_viewer.accessKey=o

--- a/l10n/fa/metadata.inc
+++ b/l10n/fa/metadata.inc
@@ -1,0 +1,8 @@
+    <em:localized>
+      <Description>
+        <em:locale>fa</em:locale>
+        <em:name>نمایش‌دهندهٔ پی‌دی‌اف</em:name>
+        <em:description>از اچ‌تی‌ام‌ال۵ برای نمایش پرونده‌های پی‌دی‌اف به‌صورت مستقیم در فایرفاکس استفاده می‌کند.</em:description>
+      </Description>
+    </em:localized>
+

--- a/l10n/fa/viewer.properties
+++ b/l10n/fa/viewer.properties
@@ -1,0 +1,134 @@
+# Copyright 2013 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=صفحهٔ قبلی
+previous_label=قبلی
+next.title=صفحهٔ بعدی
+next_label=بعدی
+
+# LOCALIZATION NOTE (page_label, page_of):
+# These strings are concatenated to form the "Page: X of Y" string.
+# Do not translate "{{pageCount}}", it will be substituted with a number
+# representing the total number of pages.
+page_label=صفحه:
+page_of=از {{pageCount}}
+
+zoom_out.title=کوچک‌نمایی
+zoom_out_label=کوچک‌نمایی
+zoom_in.title=بزرگ‌نمایی
+zoom_in_label=بزرگ‌نمایی
+zoom.title=زوم
+presentation_mode.title=تغییر وضع به حالت نمایش
+presentation_mode_label=حالت نمایش
+open_file.title=بازکردن پرونده
+open_file_label=بازکردن پرونده
+print.title=چاپ
+print_label=چاپ
+download.title=بارگیری
+download_label=بارگیری
+bookmark.title=دید فعلی (رونوشت یا بازکردن در پنجرهٔ جدید)
+bookmark_label=دید فعلی
+
+# Secondary toolbar and context menu
+tools.title=ابزارها
+tools_label=ابزارها
+first_page.title=رفتن به صفحهٔ اول
+first_page.label=رفتن به صفحهٔ اول
+first_page_label=رفتن به صفحهٔ اول
+last_page.title=رفتن به صفحهٔ آخر
+last_page.label=رفتن به صفحهٔ آخر
+last_page_label=رفتن به صفحهٔ آخر
+page_rotate_cw.title=چرخش در جهت عقربه‌های ساعت
+page_rotate_cw.label=چرخش در جهت عقربه‌های ساعت
+page_rotate_cw_label=چرخش در جهت عقربه‌های ساعت
+page_rotate_ccw.title=چرخش در خلاف جهت عقربه‌های ساعت
+page_rotate_ccw.label=چرخش در خلاف جهت عقربه‌های ساعت
+page_rotate_ccw_label=چرخش در خلاف جهت عقربه‌های ساعت
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=تغییر وضع نوار کناری
+toggle_sidebar_label=تغییر وضع نوار کناری
+outline.title=نمایش رئوس مطالب سند
+outline_label=رئوس مطالب سند
+thumbs.title=نمایش بندانگشتی‌ها
+thumbs_label=بندانگشتی‌ها
+findbar.title=یافتن در سند
+findbar_label=پیداکردن
+
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=صفحهٔ {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=بندانگشتی صفحهٔ {{page}}
+
+# Find panel button title and messages
+find_label=پیداکردن:
+find_previous.title=یافتن رویداد قبلی عبارت
+find_previous_label=قبلی
+find_next.title=یافتن رویداد بعدی عبارت
+find_next_label=بعدی
+find_highlight=پررنگ‌کردن همه
+find_match_case_label=تطبیق بزرگی/کوچکی حروف
+find_reached_top=به بالای سند رسید، ادامه‌یافته از زیر
+find_reached_bottom=به انتهای سند رسید، ادامه‌یافته از بالا
+find_not_found=عبارت پیدا نشد
+
+# Error panel labels
+error_more_info=اطلاعات بیشتر
+error_less_info=اطلاعات کمتر
+error_close=بستن
+# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
+# replaced by the PDF.JS version and build ID.
+error_version_info=پی‌دی‌اف.جی‌اس نسخهٔ {{version}} (ساخت: {{build}})
+# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
+# english string describing the error.
+error_message=پیغام: {{message}}
+# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
+# trace.
+error_stack=پشته: {{stack}}
+# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
+error_file=پرونده: {{file}}
+# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
+error_line=خط: {{line}}
+rendering_error=خطایی هنگام رندرکردن صفحه روی داد.
+
+# Predefined zoom values
+page_scale_width=اندازهٔ صفحه
+page_scale_fit=متناسب صفحه
+page_scale_auto=زوم خودکار
+page_scale_actual=اندازهٔ حقیقی
+
+# Loading indicator messages
+loading_error_indicator=خطا
+loading_error=خطایی هنگامی بارگیری پی‌دی‌اف روی داد.
+invalid_file_error=پروندهٔ پی‌دی‌اف نامعتیر یا خراب شده.
+missing_file_error=پروندهٔ پی‌دی‌اف مفقودشده.
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[گزارمان {{type}}]
+request_password=پی‌دی‌اف توسط یک گذرواژه محافظت شده‌است:
+invalid_password=گذرواژهٔ نامعتبر.
+
+printing_not_supported=اخطار: چاپ توسط این مرورگر به‌صورت کامل پشتبانی نشده‌است.
+printing_not_ready=اخطار: پی‌دی‌اف برای چاپ به‌طور کامل بار نشده‌است.
+web_fonts_disabled=قلم‌های وبی غیر فعال هستند: از قلم‌های توکار پی‌دی‌اف نتوانست استفاده شود.
+document_colors_disabled=اسناد پی‌دی‌اف اجازه ندارند که رنگ‌های خودشان را استفاده کنند: «اجازهٔ انتخاب صفحه‌ها برای انتخاب رنگ‌های خود» در مرورگر غیرفعال شده‌است.


### PR DESCRIPTION
Persian translations for pdf.js. Word equivalence is based on [Persian Academy](http://www.persianacademy.ir/fa/wordsSearch.aspx) and localization translations of [MediaWiki](http://translatewiki.net/wiki/Portal:Fa) and manual of style of [Persian Wikipedia](http://fa.wikipedia.org/wiki/%D9%88%DB%8C%DA%A9%DB%8C%E2%80%8C%D9%BE%D8%AF%DB%8C%D8%A7:%D8%AF%D8%B3%D8%AA%D9%88%D8%B1_%D8%AE%D8%B7) and [Persian Academy orthography guideline](http://www.persianacademy.ir/fa/das.aspx) is used.
