### PR TITLE
[PDFHistory] Prevent the history from skipping entries in certain edge cases, when specifying an initialBookmark in the hash parameters on document load

### DIFF
--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -202,10 +202,14 @@ var PDFHistory = {
       }
       return;
     }
-    if (this.nextHashParam && this.nextHashParam === params.hash) {
-      this.nextHashParam = null;
-      this.updatePreviousBookmark = true;
-      return;
+    if (this.nextHashParam) {
+      if (this.nextHashParam === params.hash) {
+        this.nextHashParam = null;
+        this.updatePreviousBookmark = true;
+        return;
+      } else {
+        this.nextHashParam = null;
+      }
     }
 
     if (params.hash) {


### PR DESCRIPTION
This PR fixes a small regression in the browsing history, which was caused by #3341.
I found this issue while going through the code, and I highly doubt that anyone has actually stumbled across this when using PDF.js, since the issue can be quite tricky to actually reproduce.

**Steps to reproduce:**
1. Open: http://mirrors.ctan.org/info/lshort/english/lshort.pdf#section.6.1.
2. When the file starts to load and the first page is rendered, click _immediately_ on the link on the first page.
(This is the difficult step, since the click needs to happen before the destination specified in the hash is resolved.)
3. Open the Sidebar, switch to the Outline View and scroll down and click on the item: "New Commands, Environments and Packages".

**Expected result:**
The history should contain three states: `section.6.1`, `page.157` and `section.6.1`.

**Actual result:**
The history contains two states: `section.6.1`, `page.157`.

/cc @brendandahl
