### PR TITLE
Prevent trying to set the 'maxHeight' property of the secondaryToolbar before the viewer is completely loaded

### DIFF
--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -96,6 +96,9 @@ var SecondaryToolbar = {
 
   // Misc. functions for interacting with the toolbar.
   setMaxHeight: function secondaryToolbarSetMaxHeight(container) {
+    if (!container) {
+      return;
+    }
     this.newContainerHeight = container.clientHeight;
     if (this.previousContainerHeight === this.newContainerHeight) {
       return;


### PR DESCRIPTION
Fixes #3690.
