### PR TITLE
dont display file input when printing

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1434,6 +1434,10 @@ canvas {
     display: block;
   }
 
+  .fileInput {
+    display: none;
+  }
+
   /* Rules for browsers that support mozPrintCallback */
   body[data-mozPrintCallback] #outerContainer {
     display: none;


### PR DESCRIPTION
the file input was previously part of the page layout, causing an extra blank page to be printed

closes #2464
