### PR TITLE
Prevent undefined error when calling .destroy on a document when LocalPdfManager is used

### DIFF
--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -63,6 +63,10 @@ var BasePdfManager = (function BasePdfManagerClosure() {
       if (this.passwordChangedPromise) {
         this.passwordChangedPromise.resolve();
       }
+    },
+
+    terminate: function BasePdfManager_terminate() {
+      return new NotImplementedException();
     }
   };
 
@@ -113,6 +117,11 @@ var LocalPdfManager = (function LocalPdfManagerClosure() {
   LocalPdfManager.prototype.onLoadedStream =
       function LocalPdfManager_getLoadedStream() {
     return this.loadedStream;
+  };
+
+  LocalPdfManager.prototype.terminate =
+      function LocalPdfManager_terminate() {
+    return;
   };
 
   return LocalPdfManager;
@@ -190,6 +199,11 @@ var NetworkPdfManager = (function NetworkPdfManagerClosure() {
   NetworkPdfManager.prototype.onLoadedStream =
       function NetworkPdfManager_getLoadedStream() {
     return this.streamManager.onLoadedStream();
+  };
+
+  NetworkPdfManager.prototype.terminate =
+      function NetworkPdfManager_terminate() {
+    this.streamManager.networkManager.abortAllRequests();
   };
 
   return NetworkPdfManager;

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -368,7 +368,7 @@ var WorkerMessageHandler = PDFJS.WorkerMessageHandler = {
     });
 
     handler.on('Terminate', function wphTerminate(data, promise) {
-      pdfManager.streamManager.networkManager.abortAllRequests();
+      pdfManager.terminate();
       promise.resolve();
     });
   }


### PR DESCRIPTION
Per assistance with @brendandahl this addresses an undefined error that is shown when the LocalPdfManager is used when getDocument is called and .destroy is later called on that document because LocalPdfManager does not have a streamManager.
