### PR TITLE
Enable links beginning with 'www.' even if no protocol is specified

### DIFF
--- a/src/shared/annotation.js
+++ b/src/shared/annotation.js
@@ -616,7 +616,7 @@ var LinkAnnotation = (function LinkAnnotationClosure() {
     if (action) {
       var linkType = action.get('S').name;
       if (linkType === 'URI') {
-        var url = action.get('URI');
+        var url = addDefaultProtocolToUrl(action.get('URI'));
         // TODO: pdf spec mentions urls can be relative to a Base
         // entry in the dictionary.
         if (!isValidUrl(url, false)) {
@@ -650,6 +650,14 @@ var LinkAnnotation = (function LinkAnnotationClosure() {
       var dest = dict.get('Dest');
       data.dest = isName(dest) ? dest.name : dest;
     }
+  }
+
+  // Lets URLs beginning with 'www.' default to using the 'http://' protocol.
+  function addDefaultProtocolToUrl(url) {
+    if (url.indexOf('www.') === 0) {
+      return ('http://' + url);
+    }
+    return url;
   }
 
   Util.inherit(LinkAnnotation, Annotation, {


### PR DESCRIPTION
This PR adds a function that fixes standard hyperlinks, which are specified without a protocol (this is a problem in some PDF files). Currently, these kind of links all point to `resource://pdf.js/web/` in Firefox.

I understand that there are security considerations when enabling links, but I do not believe that there should be any real issues if we simply add `http://` only to those links that begin with `www.`.
_If this assessment of the security situation is wrong, please feel free to close this PR._

Fixes #3741 (and possibly #3284, but I can't check since the file is no longer available).
