### PR TITLE
Fix bug in api.js whereby fake workers didn't load the worker code

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -135,7 +135,7 @@ var PDFDocumentProxy = (function PDFDocumentProxyClosure() {
     },
     /**
      * @param {number} The page number to get. The first page is 1.
-     * @return {Promise} A promise that is resolved with a {PDFPageProxy}
+     * @return {Promise} A promise that is resolved with a {PDFPmageProxy}
      * object.
      */
     getPage: function PDFDocumentProxy_getPage(number) {
@@ -494,11 +494,14 @@ var WorkerTransport = (function WorkerTransportClosure() {
           if (supportTypedArray) {
             this.worker = worker;
             this.setupMessageHandler(messageHandler);
+            workerInitializedPromise.resolve();
           } else {
             globalScope.PDFJS.disableWorker = true;
-            this.setupFakeWorker();
+            this.loadFakeWorkerFiles().then(function() {
+              this.setupFakeWorker();
+              workerInitializedPromise.resolve();
+            }.bind(this));
           }
-          workerInitializedPromise.resolve();
         }.bind(this));
 
         var testObj = new Uint8Array(1);


### PR DESCRIPTION
PDFJS does not work on Windows Safari, due to the lack of support for workers passing typed arrays. At some point, the code to set up the fake worker so that things work on Safari seems to have become broken and nobody noticed - it was just calling setupFakeWorker() without actually calling loadFakeWorkerFiles(). With this patch, the PDFJS works again on Windows Safari.
