### PR TITLE
Move Presentation Mode related code from viewer.js to its own file

### DIFF
--- a/web/page_view.js
+++ b/web/page_view.js
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 /* globals RenderingStates, PDFView, PDFHistory, PDFFindBar, PDFJS, mozL10n,
-           CustomStyle, scrollIntoView, SCROLLBAR_PADDING, CSS_UNITS,
-           UNKNOWN_SCALE, DEFAULT_SCALE, getOutputScale, TextLayerBuilder,
-           cache, Stats */
+           CustomStyle, PresentationMode, scrollIntoView, SCROLLBAR_PADDING,
+           CSS_UNITS, UNKNOWN_SCALE, DEFAULT_SCALE, getOutputScale,
+           TextLayerBuilder, cache, Stats */
 
 'use strict';
 
@@ -238,7 +238,7 @@ var PageView = function pageView(container, id, scale,
   };
 
   this.scrollIntoView = function pageViewScrollIntoView(dest) {
-    if (PDFView.isPresentationMode) { // Avoid breaking presentation mode.
+    if (PresentationMode.active) { // Avoid breaking presentation mode.
       dest = null;
     }
     if (!dest) {
@@ -379,7 +379,7 @@ var PageView = function pageView(container, id, scale,
         pageIndex: this.id - 1,
         lastScrollSource: PDFView,
         viewport: this.viewport,
-        isViewerInPresentationMode: PDFView.isPresentationMode
+        isViewerInPresentationMode: PresentationMode.active
       }) : null;
     // TODO(mack): use data attributes to store these
     ctx._scaleX = outputScale.sx;

--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS, PDFView */
+/* globals PDFJS, PDFView, PresentationMode */
 
 'use strict';
 
@@ -264,7 +264,7 @@ var PDFHistory = {
       return null;
     }
     var params = { hash: this.currentBookmark, page: this.currentPage };
-    if (PDFView.isPresentationMode) {
+    if (PresentationMode.active) {
       params.hash = null;
     }
     return params;

--- a/web/presentation_mode.js
+++ b/web/presentation_mode.js
@@ -1,0 +1,157 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/* Copyright 2012 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* globals PDFView, scrollIntoView */
+
+'use strict';
+
+var PresentationMode = {
+  active: false,
+  args: null,
+
+  request: function presentationModeRequest() {
+    if (!PDFView.supportsFullscreen) {
+      return false;
+    }
+    var isPresentationMode = document.fullscreenElement ||
+                             document.mozFullScreen ||
+                             document.webkitIsFullScreen ||
+                             document.msFullscreenElement;
+
+    if (isPresentationMode) {
+      return false;
+    }
+
+    var wrapper = document.getElementById('viewerContainer');
+    if (document.documentElement.requestFullscreen) {
+      wrapper.requestFullscreen();
+    } else if (document.documentElement.mozRequestFullScreen) {
+      wrapper.mozRequestFullScreen();
+    } else if (document.documentElement.webkitRequestFullScreen) {
+      wrapper.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);
+    } else if (document.documentElement.msRequestFullscreen) {
+      wrapper.msRequestFullscreen();
+    } else {
+      return false;
+    }
+
+    this.args = {
+      page: PDFView.page,
+      previousScale: PDFView.currentScaleValue
+    };
+
+    return true;
+  },
+
+  enter: function presentationModeEnter() {
+    this.active = true;
+
+    PDFView.page = this.args.page;
+    PDFView.parseScale('page-fit', true);
+
+    this.showControls();
+
+    var viewer = document.getElementById('viewer');
+    viewer.setAttribute('contextmenu', 'viewerContextMenu');
+  },
+
+  exit: function presentationModeExit() {
+    this.active = false;
+
+    var page = PDFView.page;
+    PDFView.parseScale(this.args.previousScale);
+    PDFView.page = page;
+
+    this.hideControls();
+    this.args = null;
+    PDFView.clearMouseScrollState();
+
+    var viewer = document.getElementById('viewer');
+    viewer.removeAttribute('contextmenu');
+
+    // Ensure that the thumbnail of the current page is visible
+    // when exiting presentation mode.
+    scrollIntoView(document.getElementById('thumbnailContainer' + page));
+  },
+
+  showControls: function presentationModeShowControls() {
+    var DELAY_BEFORE_HIDING_CONTROLS = 3000;
+    var wrapper = document.getElementById('viewerContainer');
+    if (this.controlsTimeout) {
+      clearTimeout(this.controlsTimeout);
+    } else {
+      wrapper.classList.add('presentationControls');
+    }
+    this.controlsTimeout = setTimeout(function hideControlsTimeout() {
+      wrapper.classList.remove('presentationControls');
+      delete this.controlsTimeout;
+    }.bind(this), DELAY_BEFORE_HIDING_CONTROLS);
+  },
+
+  hideControls: function presentationModeHideControls() {
+    if (!this.controlsTimeout) {
+      return;
+    }
+    clearTimeout(this.controlsTimeout);
+    delete this.controlsTimeout;
+
+    var wrapper = document.getElementById('viewerContainer');
+    wrapper.classList.remove('presentationControls');
+  }
+};
+
+window.addEventListener('mousemove', function mousemove(evt) {
+  if (PresentationMode.active) {
+    PresentationMode.showControls();
+  }
+}, false);
+
+window.addEventListener('mousedown', function mousedown(evt) {
+  if (PresentationMode.active && evt.button === 0) {
+    // Enable clicking of links in presentation mode.
+    // Note: Only links that point to the currently loaded PDF document works.
+    var targetHref = evt.target.href;
+    var internalLink = targetHref && (targetHref.replace(/#.*$/, '') ===
+                                      window.location.href.replace(/#.*$/, ''));
+    if (!internalLink) {
+      // Unless an internal link was clicked, advance a page in presentation
+      // mode.
+      evt.preventDefault();
+      PDFView.page++;
+    }
+  }
+}, false);
+
+(function presentationModeClosure() {
+  function presentationModeChange(e) {
+    var isPresentationMode = document.fullscreenElement ||
+                             document.mozFullScreen ||
+                             document.webkitIsFullScreen ||
+                             document.msFullscreenElement;
+
+    if (isPresentationMode) {
+      PresentationMode.enter();
+    } else {
+      PresentationMode.exit();
+    }
+  }
+
+  window.addEventListener('fullscreenchange', presentationModeChange, false);
+  window.addEventListener('mozfullscreenchange', presentationModeChange, false);
+  window.addEventListener('webkitfullscreenchange', presentationModeChange,
+                          false);
+  window.addEventListener('MSFullscreenChange', presentationModeChange, false);
+})();

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFView, SCROLLBAR_PADDING */
+/* globals PDFView, PresentationMode, SCROLLBAR_PADDING */
 
 'use strict';
 
@@ -59,7 +59,7 @@ var SecondaryToolbar = {
 
   // Event handling functions.
   presentationModeClick: function secondaryToolbarPresentationModeClick(evt) {
-    PDFView.presentationMode();
+    PresentationMode.request();
     this.close();
   },
 

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -68,6 +68,7 @@ limitations under the License.
     <script type="text/javascript" src="pdf_history.js"></script>
     <script type="text/javascript" src="secondary_toolbar.js"></script>
     <script type="text/javascript" src="password_prompt.js"></script>
+    <script type="text/javascript" src="presentation_mode.js"></script>
 <!--#endif-->
 
     <script type="text/javascript" src="debugger.js"></script>


### PR DESCRIPTION
This PR is the first of in a series of patches that aims to make a couple of improvements (and simplifications) in the presentation mode code.
The current PR is just the first step, hence this patch only moves the presentation mode code to its own file.
