### PR TITLE
Fix external links in Presentation Mode (issue 3755)

### DIFF
--- a/web/page_view.js
+++ b/web/page_view.js
@@ -127,7 +127,9 @@ var PageView = function pageView(container, id, scale,
         }
         return false;
       };
-      link.className = 'internalLink';
+      if (dest) {
+        link.className = 'internalLink';
+      }
     }
 
     function bindNamedAction(link, action) {


### PR DESCRIPTION
This fixes the part of #3755 that cause links to remain visible in Presentation Mode.
(This issue is the result of an oversight on my part in PR #2919.)
