### PR TITLE
Refactor Presentation Mode code

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -147,6 +147,10 @@ var PDFView = {
       passwordCancel: document.getElementById('passwordCancel')
     });
 
+    PresentationMode.initialize({
+      container: container
+    });
+
     this.initialized = true;
     container.addEventListener('scroll', function() {
       self.lastScroll = Date.now();


### PR DESCRIPTION
This PR is the second part in a series of patches that will improve the presentation mode implementation. (The first part was #3752.)
This patch refactors the code, and makes a couple of changes. Noteworthy changes made in this PR:
- Create a `isFullscreen` function to check if the browser is in fullscreen mode, instead of duplicating the same exact code in multiple places.
- Add/remove the `mousemove` and `mousedown` event listeners when entering/exiting presentation mode, since they are not used in the regular viewer.
- Two small tweaks of the `mousedown` event handling function:
  - Remove the regular expression, since it has been unnecessary ever since PR #2919 landed.
  - Make it possible to go back one page by using `Shift` + `Click`.
- Keep a reference to the `#viewerContainer`, instead of creating a lot of temporary `wrapper` variables.
