### PR TITLE
Enabling clicking to close the context menu in Presentation Mode, without going to the next page

### DIFF
--- a/web/presentation_mode.js
+++ b/web/presentation_mode.js
@@ -24,9 +24,34 @@ var SELECTOR = 'presentationControls';
 var PresentationMode = {
   active: false,
   args: null,
+  contextMenuOpen: false,
 
   initialize: function presentationModeInitialize(options) {
     this.container = options.container;
+    this.secondaryToolbar = options.secondaryToolbar;
+
+    this.firstPage = options.firstPage;
+    this.lastPage = options.lastPage;
+    this.pageRotateCw = options.pageRotateCw;
+    this.pageRotateCcw = options.pageRotateCcw;
+
+    this.firstPage.addEventListener('click', function() {
+      this.contextMenuOpen = false;
+      this.secondaryToolbar.firstPageClick();
+    }.bind(this));
+    this.lastPage.addEventListener('click', function() {
+      this.contextMenuOpen = false;
+      this.secondaryToolbar.lastPageClick();
+    }.bind(this));
+
+    this.pageRotateCw.addEventListener('click', function() {
+      this.contextMenuOpen = false;
+      this.secondaryToolbar.pageRotateCwClick();
+    }.bind(this));
+    this.pageRotateCcw.addEventListener('click', function() {
+      this.contextMenuOpen = false;
+      this.secondaryToolbar.pageRotateCcwClick();
+    }.bind(this));
   },
 
   get isFullscreen() {
@@ -69,8 +94,10 @@ var PresentationMode = {
 
     window.addEventListener('mousemove', this.mouseMove, false);
     window.addEventListener('mousedown', this.mouseDown, false);
+    window.addEventListener('contextmenu', this.contextMenu, false);
 
     this.showControls();
+    this.contextMenuOpen = false;
     this.container.setAttribute('contextmenu', 'viewerContextMenu');
   },
 
@@ -83,11 +110,13 @@ var PresentationMode = {
 
     window.removeEventListener('mousemove', this.mouseMove, false);
     window.removeEventListener('mousedown', this.mouseDown, false);
+    window.removeEventListener('contextmenu', this.contextMenu, false);
 
     this.hideControls();
     this.args = null;
     PDFView.clearMouseScrollState();
     this.container.removeAttribute('contextmenu');
+    this.contextMenuOpen = false;
 
     // Ensure that the thumbnail of the current page is visible
     // when exiting presentation mode.
@@ -120,6 +149,13 @@ var PresentationMode = {
   },
 
   mouseDown: function presentationModeMouseDown(evt) {
+    var self = PresentationMode;
+    if (self.contextMenuOpen) {
+      self.contextMenuOpen = false;
+      evt.preventDefault();
+      return;
+    }
+
     if (evt.button === 0) {
       // Enable clicking of links in presentation mode. Please note:
       // Only links pointing to destinations in the current PDF document work.
@@ -131,6 +167,10 @@ var PresentationMode = {
         PDFView.page += (evt.shiftKey ? -1 : 1);
       }
     }
+  },
+
+  contextMenu: function presentationModeContextMenu(evt) {
+    PresentationMode.contextMenuOpen = true;
   }
 };
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -148,7 +148,12 @@ var PDFView = {
     });
 
     PresentationMode.initialize({
-      container: container
+      container: container,
+      secondaryToolbar: SecondaryToolbar,
+      firstPage: document.getElementById('contextFirstPage'),
+      lastPage: document.getElementById('contextLastPage'),
+      pageRotateCw: document.getElementById('contextPageRotateCw'),
+      pageRotateCcw: document.getElementById('contextPageRotateCcw')
     });
 
     this.initialized = true;
@@ -1649,18 +1654,6 @@ document.addEventListener('DOMContentLoaded', function webViewerLoad(evt) {
 
   document.getElementById('download').addEventListener('click',
     SecondaryToolbar.downloadClick.bind(SecondaryToolbar));
-
-  document.getElementById('contextFirstPage').addEventListener('click',
-    SecondaryToolbar.firstPageClick.bind(SecondaryToolbar));
-
-  document.getElementById('contextLastPage').addEventListener('click',
-    SecondaryToolbar.lastPageClick.bind(SecondaryToolbar));
-
-  document.getElementById('contextPageRotateCw').addEventListener('click',
-    SecondaryToolbar.pageRotateCwClick.bind(SecondaryToolbar));
-
-  document.getElementById('contextPageRotateCcw').addEventListener('click',
-    SecondaryToolbar.pageRotateCcwClick.bind(SecondaryToolbar));
 
 //#if (FIREFOX || MOZCENTRAL)
 //PDFView.setTitleUsingUrl(file);


### PR DESCRIPTION
This PR is the third in a series of patches that will improve the presentation mode implementation. (The previous ones were #3752 and #3763.)

This patch enables the user to close the context menu without changing page unintentionally. Fixes #3276.
(The PR also moves the event listeners for the context menu items from `viewer.js` to `presentation_mode.js`.)
