### PR TITLE
Refactoring thumbnail scroll code to fix jumps

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1078,6 +1078,11 @@ html[dir='rtl'] .verticalToolbarSeparator {
 
 .thumbnail {
   float: left;
+  margin-bottom: 5px;
+}
+
+#thumbnailView > a:last-of-type > .thumbnail {
+  margin-bottom: 10px;
 }
 
 .thumbnail:not([data-loaded]) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -35,6 +35,7 @@ var MAX_SCALE = 4.0;
 var SETTINGS_MEMORY = 20;
 var SCALE_SELECT_CONTAINER_PADDING = 8;
 var SCALE_SELECT_PADDING = 22;
+var THUMBNAIL_SCROLL_MARGIN = -19;
 var USE_ONLY_CSS_ZOOM = false;
 //#if B2G
 //USE_ONLY_CSS_ZOOM = true;
@@ -1854,22 +1855,23 @@ window.addEventListener('pagechange', function pagechange(evt) {
   if (PDFView.previousPageNumber !== page) {
     document.getElementById('pageNumber').value = page;
     var selected = document.querySelector('.thumbnail.selected');
-    if (selected)
+    if (selected) {
       selected.classList.remove('selected');
+    }
     var thumbnail = document.getElementById('thumbnailContainer' + page);
     thumbnail.classList.add('selected');
     var visibleThumbs = PDFView.getVisibleThumbs();
     var numVisibleThumbs = visibleThumbs.views.length;
-    // If the thumbnail isn't currently visible scroll it into view.
+
+    // If the thumbnail isn't currently visible, scroll it into view.
     if (numVisibleThumbs > 0) {
       var first = visibleThumbs.first.id;
       // Account for only one thumbnail being visible.
-      var last = numVisibleThumbs > 1 ?
-                  visibleThumbs.last.id : first;
-      if (page <= first || page >= last)
-        scrollIntoView(thumbnail);
+      var last = (numVisibleThumbs > 1 ? visibleThumbs.last.id : first);
+      if (page <= first || page >= last) {
+        scrollIntoView(thumbnail, { top: THUMBNAIL_SCROLL_MARGIN });
+      }
     }
-
   }
   document.getElementById('previous').disabled = (page <= 1);
   document.getElementById('next').disabled = (page >= PDFView.pages.length);


### PR DESCRIPTION
Fixes #3230 and supersedes #3243.

This PR does a couple of things:
- Fixes thumbnail jumps as described in #3230 in a cleaner way than the previous PR, that is with almost no JavaScript.
- Improves the thumbnail view by adding a bit more margin between the thumbnails. Also, the last thumbnail is given a larger bottom margin to make it look the same as the top of the thumbnail view.
- The code style for the piece of code this PR touches has been updated to adhere to the coding standards.

_The thumbnail value is explained as follows: each thumbnail has a 7px wide border. Therefore, the top and bottom border both take up 7px + 7px = 14px. The margin between the thumbnails is 5px, which gives a total margin of 14px + 5px = 19px to move to make the thumbnails show up properly._
