### PR TITLE
Fix hiding of the cursor in Presentation Mode in WebKit browsers

### DIFF
--- a/web/presentation_mode.js
+++ b/web/presentation_mode.js
@@ -25,6 +25,9 @@ var PresentationMode = {
   active: false,
   args: null,
   contextMenuOpen: false,
+//#if (GENERIC || CHROME)
+  prevCoords: { x: null, y: null },
+//#endif
 
   initialize: function presentationModeInitialize(options) {
     this.container = options.container;
@@ -145,6 +148,19 @@ var PresentationMode = {
   },
 
   mouseMove: function presentationModeMouseMove(evt) {
+//#if (GENERIC || CHROME)
+    // Workaround for a bug in WebKit browsers that causes the 'mousemove' event
+    // to be fired when the cursor is changed. For details, see:
+    // http://code.google.com/p/chromium/issues/detail?id=103041.
+
+    var currCoords = { x: evt.clientX, y: evt.clientY };
+    var prevCoords = PresentationMode.prevCoords;
+    PresentationMode.prevCoords = currCoords;
+
+    if (currCoords.x === prevCoords.x && currCoords.y === prevCoords.y) {
+      return;
+    }
+//#endif
     PresentationMode.showControls();
   },
 


### PR DESCRIPTION
This PR is the fourth in a series of patches that will improve the presentation mode implementation. (The previous ones were #3752, #3763 and #3774.)

This patch makes sure that the cursor is hidden in Presentation Mode in WebKit browsers. For a description of the issue, see: http://code.google.com/p/chromium/issues/detail?id=103041.
_Note that this has been fixed upstream, but the fix hasn't yet made it into the current release version of Google Chrome._
