### PR TITLE
When the viewer is embedded, change the viewBookmark buttons to open the current view in a new window by default

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -40,6 +40,8 @@ download.title=Download
 download_label=Download
 bookmark.title=Current view (copy or open in new window)
 bookmark_label=Current View
+bookmark_embedded.title=Open Current View in new Window
+bookmark_embedded_label=Open Current View in new Window
 
 # Secondary toolbar and context menu
 tools.title=Tools

--- a/l10n/sv/viewer.properties
+++ b/l10n/sv/viewer.properties
@@ -40,6 +40,8 @@ download.title=Ladda ner
 download_label=Ladda ner
 bookmark.title=Aktuell vy (kopiera eller öppna i nytt fönster)
 bookmark_label=Aktuell vy
+bookmark_embedded.title=Öppna aktuell vy i nytt fönster
+bookmark_embedded_label=Öppna aktuell vy i nytt fönster
 
 # Secondary toolbar and context menu
 tools.title=Verktyg

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1557,6 +1557,14 @@ document.addEventListener('DOMContentLoaded', function webViewerLoad(evt) {
     document.getElementById('viewFind').classList.add('hidden');
   }
 
+  if (PDFView.isViewerEmbedded) {
+    // If the viewer is embedded, let the viewBookmark buttons default to
+    // opening the current view in a new window.
+    var TARGET = '_blank';
+    document.getElementById('viewBookmark').target = TARGET;
+    document.getElementById('secondaryViewBookmark').target = TARGET;
+ }
+
   // Listen for warnings to trigger the fallback UI.  Errors should be caught
   // and call PDFView.error() so we don't need to listen for those.
   PDFJS.LogManager.addLogger({
@@ -1818,6 +1826,21 @@ window.addEventListener('localized', function localized(evt) {
     // Set the 'max-height' CSS property of the secondary toolbar.
     SecondaryToolbar.setMaxHeight(PDFView.container);
   });
+
+  if (PDFView.isViewerEmbedded) {
+    var FALLBACK_STRING = 'Open Current View in new Window';
+    var title = mozL10n.get('bookmark_embedded.title', null, FALLBACK_STRING);
+    var label = mozL10n.get('bookmark_embedded_label', null, FALLBACK_STRING);
+
+    var viewBookmark = document.getElementById('viewBookmark');
+    var secondaryViewBookmark =
+      document.getElementById('secondaryViewBookmark');
+
+    viewBookmark.title = title;
+    viewBookmark.firstElementChild.textContent = label;
+    secondaryViewBookmark.title = title;
+    secondaryViewBookmark.firstElementChild.textContent = label;
+  }
 }, true);
 
 window.addEventListener('scalechange', function scalechange(evt) {


### PR DESCRIPTION
Currently in the viewer, clicking the viewBookmark "buttons" (they are actually links, styled to look like the other buttons) updates the hash corresponding to the current document position.
By either middle-clicking or right-clicking (and choosing open in new tab/window) the user is able to open the current document position in a new tab/window. This behaviour is probably not very discoverable, but this is most likely a non-issue when the viewer is used "standalone". However, when the viewer is _embedded_ in a page, the viewBookmark "buttons" will appear to do nothing when clicked.

This PR changes the behaviour of the viewBookmark "buttons" slightly when the viewer is _embedded_. With this patch, the "buttons" will instead, by default, open the current document position in a new window. To let the user know that this feature exists when the viewer is _embedded_, the strings are also changed slightly to reflect this behaviour.

This PR (together with #3739) should thus fix [bug 921162](https://bugzilla.mozilla.org/show_bug.cgi?id=921162).

/cc @timvandermeij - Since we discussed this issue on IRC.
