### PR TITLE
Inline setScale in parseScale

### DIFF
--- a/web/page_view.js
+++ b/web/page_view.js
@@ -330,9 +330,9 @@ var PageView = function pageView(container, id, scale,
     }
 
     if (scale && scale !== PDFView.currentScale) {
-      PDFView.parseScale(scale, true, true);
+      PDFView.setScale(scale, true, true);
     } else if (PDFView.currentScale === UNKNOWN_SCALE) {
-      PDFView.parseScale(DEFAULT_SCALE, true, true);
+      PDFView.setScale(DEFAULT_SCALE, true, true);
     }
 
     if (scale === 'page-fit' && !dest[4]) {

--- a/web/presentation_mode.js
+++ b/web/presentation_mode.js
@@ -93,7 +93,7 @@ var PresentationMode = {
     this.active = true;
 
     PDFView.page = this.args.page;
-    PDFView.parseScale('page-fit', true);
+    PDFView.setScale('page-fit', true);
 
     window.addEventListener('mousemove', this.mouseMove, false);
     window.addEventListener('mousedown', this.mouseDown, false);
@@ -108,7 +108,7 @@ var PresentationMode = {
     this.active = false;
 
     var page = PDFView.page;
-    PDFView.parseScale(this.args.previousScale);
+    PDFView.setScale(this.args.previousScale);
     PDFView.page = page;
 
     window.removeEventListener('mousemove', this.mouseMove, false);


### PR DESCRIPTION
This PR combines the `setScale` and `parseScale` functions into one function. I decided to call this "new" function `setScale`, since that seems like the best name considering what it actually does.

This patch should remove any questions regarding why there is currently two different functions involved in changing the scale, and which one should/shouldn't be used.

Fixes #1130.

_PS. My apologies to the reviewer. I know it will be difficult to make sense of the changes without a good side-by-side diff tool._
