### PR TITLE
Add preprocessor tags in Presentation Mode code

### DIFF
--- a/web/presentation_mode.js
+++ b/web/presentation_mode.js
@@ -56,9 +56,13 @@ var PresentationMode = {
 
   get isFullscreen() {
     return (document.fullscreenElement ||
+//#if (FIREFOX || MOZCENTRAL || B2G)
+//          document.mozFullScreen);
+//#else
             document.mozFullScreen ||
             document.webkitIsFullScreen ||
             document.msFullscreenElement);
+//#endif
   },
 
   request: function presentationModeRequest() {
@@ -70,10 +74,12 @@ var PresentationMode = {
       this.container.requestFullscreen();
     } else if (this.container.mozRequestFullScreen) {
       this.container.mozRequestFullScreen();
+//#if !(FIREFOX || MOZCENTRAL || B2G)
     } else if (this.container.webkitRequestFullScreen) {
       this.container.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);
     } else if (this.container.msRequestFullscreen) {
       this.container.msRequestFullscreen();
+//#endif
     } else {
       return false;
     }
@@ -185,7 +191,9 @@ var PresentationMode = {
 
   window.addEventListener('fullscreenchange', presentationModeChange, false);
   window.addEventListener('mozfullscreenchange', presentationModeChange, false);
+//#if !(FIREFOX || MOZCENTRAL || B2G)
   window.addEventListener('webkitfullscreenchange', presentationModeChange,
                           false);
   window.addEventListener('MSFullscreenChange', presentationModeChange, false);
+//#endif
 })();

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -323,13 +323,23 @@ var PDFView = {
 
   get supportsFullscreen() {
     var doc = document.documentElement;
-    var support = doc.requestFullscreen || doc.mozRequestFullScreen ||
-                  doc.webkitRequestFullScreen || doc.msRequestFullscreen;
+    var support = (doc.requestFullscreen ||
+//#if (FIREFOX || MOZCENTRAL || B2G)
+//                 doc.mozRequestFullScreen);
+//#else
+                   doc.mozRequestFullScreen ||
+                   doc.webkitRequestFullScreen ||
+                   doc.msRequestFullscreen);
+//#endif
 
     if (document.fullscreenEnabled === false ||
+//#if (FIREFOX || MOZCENTRAL || B2G)
+//      document.mozFullScreenEnabled === false) {
+//#else
         document.mozFullScreenEnabled === false ||
         document.webkitFullscreenEnabled === false ||
         document.msFullscreenEnabled === false) {
+//#endif
       support = false;
     } else if (this.isViewerEmbedded) {
       // Need to check if the viewer is embedded as well, to prevent issues with


### PR DESCRIPTION
This PR is the fifth in a series of patches that will improve the presentation mode implementation. (The previous ones were #3752, #3763, #3774 and #3777.)

This patch adds preprocessor tags in the Presentation Mode code, so that we stop including WebKit and Microsoft specific code in the Mozilla versions (builds created with `node make {firefox, mozcentral, b2g}`) of PDF.js.
