### PR TITLE
Added URL parameter to auto show and hide toolbar

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -262,6 +262,33 @@ html[dir='rtl'] #sidebarContent {
   cursor: default;
 }
 
+#outerContainer.toolbarToogle #viewerContainer {
+  -webkit-transition-property: top;
+  -webkit-transition-duration: 200ms;
+  -webkit-transition-timing-function: ease;
+  transition-property: top;
+  transition-duration: 200ms;
+  transition-timing-function: ease;
+}
+
+#outerContainer.toolbarToogle #toolbar {
+  -webkit-transition-property: top;
+  -webkit-transition-duration: 200ms;
+  -webkit-transition-timing-function: ease;
+  transition-property: top;
+  transition-duration: 200ms;
+  transition-timing-function: ease;
+  visibility: visible;
+}
+
+#outerContainer.toolbarClosed #toolbar {
+  top: -32px;
+}
+
+#outerContainer.toolbarClosed #viewerContainer {
+  top: 0;
+}
+
 #toolbarContainer {
   width: 100%;
 }
@@ -1621,6 +1648,13 @@ canvas {
   #outerContainer .visibleLargeView,
   #outerContainer .visibleMediumView {
     display: none;
+  }
+  #outerContainer.toolbarToogle #sidebarContainer {
+    -webkit-transition-property: top, left;
+    transition-property: top, left;
+  }
+  #outerContainer.toolbarClosed #sidebarContainer {
+    top: 0;
   }
 }
 

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -161,7 +161,7 @@ limitations under the License.
           </div>
         </div>  <!-- secondaryToolbar -->
 
-        <div class="toolbar">
+        <div id="toolbar" class="toolbar">
           <div id="toolbarContainer">
             <div id="toolbarViewer">
               <div id="toolbarViewerLeft">


### PR DESCRIPTION
Implemented hiding the toolbar when the url parameter `toolbar=0` is passed per issue https://github.com/mozilla/pdf.js/issues/2784
- Built on the toolbar hiding in https://github.com/mozilla/pdf.js/pull/2885
- Toolbar slides down when mouse is moved to the top of the window where the toolbar would be.
- Uses CSS transitions similar to the sidebar to hide and show the toolbar
