### PR TITLE
Disable Presentation Mode until the document has started rendering

### DIFF
--- a/web/presentation_mode.js
+++ b/web/presentation_mode.js
@@ -33,6 +33,8 @@ var PresentationMode = {
     this.container = options.container;
     this.secondaryToolbar = options.secondaryToolbar;
 
+    this.viewer = this.container.firstElementChild;
+
     this.firstPage = options.firstPage;
     this.lastPage = options.lastPage;
     this.pageRotateCw = options.pageRotateCw;
@@ -65,7 +67,8 @@ var PresentationMode = {
   },
 
   request: function presentationModeRequest() {
-    if (!PDFView.supportsFullscreen || this.isFullscreen) {
+    if (!PDFView.supportsFullscreen || this.isFullscreen ||
+        !this.viewer.hasChildNodes()) {
       return false;
     }
 


### PR DESCRIPTION
Currently if the user enters Presentation Mode when the document is loading, **and before** it has begun to render, things will not work properly.
First of all, the "page-fit" zoom setting will not be applied. Secondly, when exiting Presentation Mode the zoom level will not be set correctly, since `PresentationMode.args.previousScale` will be undefined.

This patch simply avoids these issues, by disabling Presentation Mode until the document has actually begun to render.

_Note that I considered adding a promise, to enter Presentation Mode once the document has become available. I decided against that approach, because it would add unnecessary complexity to the code. Since trying to enter Presentation Mode before the document is available should be an edge case anyway, a simple workaround should suffice._
