### PR TITLE
Apply the current zoom level value to each page in Presentation Mode

### DIFF
--- a/web/page_view.js
+++ b/web/page_view.js
@@ -327,6 +327,7 @@ var PageView = function pageView(container, id, scale,
   this.scrollIntoView = function pageViewScrollIntoView(dest) {
     if (PresentationMode.active) { // Avoid breaking presentation mode.
       dest = null;
+      PDFView.setScale(PDFView.currentScaleValue, true, true);
     }
     if (!dest) {
       scrollIntoView(div);

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -397,8 +397,8 @@ var PDFView = {
   },
 
   get isHorizontalScrollbarEnabled() {
-    var div = document.getElementById('viewerContainer');
-    return div.scrollWidth > div.clientWidth;
+    return (PresentationMode.active ? false :
+            (this.container.scrollWidth > this.container.clientWidth));
   },
 
   initPassiveLoading: function pdfViewInitPassiveLoading() {


### PR DESCRIPTION
This patch makes sure that each page fits properly in Presentation Mode, even for documents with different sized pages.

Fixes #3827 and probably [bug 804074](https://bugzilla.mozilla.org/show_bug.cgi?id=804074) (_the testcase is no longer available, but it appears to be the same issue_).
