### PR TITLE
Fix scroll keys in Firefox

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -265,11 +265,7 @@ limitations under the License.
                     data-l10n-id="page_rotate_ccw"></menuitem>
         </menu>
 
-<!--#if (FIREFOX || MOZCENTRAL) -->
-<!--    <div id="viewerContainer"> -->
-<!--#else -->
         <div id="viewerContainer" tabindex="0">
-<!--#endif -->
           <div id="viewer"></div>
         </div>
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2015,6 +2015,11 @@ window.addEventListener('keydown', function keydown(evt) {
       return; // ignoring if the 'toolbar' element is focused
     curElement = curElement.parentNode;
   }
+//#if (FIREFOX || MOZCENTRAL)
+//// Workaround for issue in Firefox, that prevents scroll keys from working
+//// when elements with 'tabindex' are focused.
+//PDFView.container.blur();
+//#endif
 
   if (cmd === 0) { // no control key pressed at all.
     switch (evt.keyCode) {


### PR DESCRIPTION
When I fixed the broken <kbd>spacebar</kbd> key in Firefox (PR #3497), I apparently caused one serious usability issue as well.
_I'm amazed that neither I, nor anybody else, have noticed this until now. I only realized that this bug existed when trying to reproduce #3830._

**Steps to reproduce:**
1. Load any PDF file, using either the _Firefox addon_ or the _built-in version in Firefox Nighlty/Aurora_, for example: http://www.nada.kth.se/kurser/kth/2D1339/linser2005.pdf.
2. Click anywhere within the `viewerContainer`.
3. Attempt to scroll the document with either the: Up/Down arrow keys, Page Up/Down, Home/End or Spacebar.

**Expected result:**
The document should scroll.

**Actual result:**
Nothing happens.

**_EDIT:_** Fixes #3832.
