### PR TITLE
Implement default preferences

### DIFF
--- a/extensions/firefox/components/PdfStreamConverter.js
+++ b/extensions/firefox/components/PdfStreamConverter.js
@@ -16,7 +16,7 @@
  */
 /* jshint esnext:true */
 /* globals Components, Services, XPCOMUtils, NetUtil, PrivateBrowsingUtils,
-           dump, NetworkManager, PdfJsTelemetry */
+           dump, NetworkManager, PdfJsTelemetry, DEFAULT_PREFERENCES */
 
 'use strict';
 
@@ -33,11 +33,15 @@ const PDF_CONTENT_TYPE = 'application/pdf';
 const PREF_PREFIX = 'PDFJSSCRIPT_PREF_PREFIX';
 const PDF_VIEWER_WEB_PAGE = 'resource://pdf.js/web/viewer.html';
 const MAX_DATABASE_LENGTH = 4096;
+const MAX_STRING_PREF_LENGTH = 4096;
 
 Cu.import('resource://gre/modules/XPCOMUtils.jsm');
 Cu.import('resource://gre/modules/Services.jsm');
 Cu.import('resource://gre/modules/NetUtil.jsm');
 Cu.import('resource://pdf.js/network.js');
+
+// Load the default preferences.
+Cu.import('resource://pdf.js/default_preferences.js');
 
 XPCOMUtils.defineLazyModuleGetter(this, 'PrivateBrowsingUtils',
   'resource://gre/modules/PrivateBrowsingUtils.jsm');
@@ -58,12 +62,20 @@ function getChromeWindow(domWindow) {
   return containingBrowser.ownerDocument.defaultView;
 }
 
+function setBoolPref(pref, value) {
+  Services.prefs.setBoolPref(pref, value);
+}
+
 function getBoolPref(pref, def) {
   try {
     return Services.prefs.getBoolPref(pref);
   } catch (ex) {
     return def;
   }
+}
+
+function setIntPref(pref, value) {
+  Services.prefs.setIntPref(pref, value);
 }
 
 function getIntPref(pref, def) {
@@ -431,6 +443,62 @@ ChromeActions.prototype = {
     }
     getChromeWindow(this.domWindow).gFindBar
                                    .updateControlState(result, findPrevious);
+  },
+  setPreferences: function(prefs) {
+    var prefValue, defaultValue, prefName, prefType, defaultType;
+
+    for (var key in DEFAULT_PREFERENCES) {
+      prefValue = prefs[key];
+      defaultValue = DEFAULT_PREFERENCES[key];
+      prefName = (PREF_PREFIX + '.' + key);
+
+      if (!prefValue || prefValue === defaultValue) {
+        Services.prefs.clearUserPref(prefName);
+      } else {
+        prefType = typeof prefValue;
+        defaultType = typeof defaultValue;
+
+        if (prefType !== defaultType) {
+          continue;
+        }
+        switch (defaultType) {
+          case 'boolean':
+            setBoolPref(prefName, prefValue);
+            break;
+          case 'number':
+            setIntPref(prefName, prefValue);
+            break;
+          case 'string':
+            // Protect against adding arbitrarily long strings in about:config.
+            if (prefValue.length <= MAX_STRING_PREF_LENGTH) {
+              setStringPref(prefName, prefValue);
+            }
+            break;
+        }
+      }
+    }
+  },
+  getPreferences: function() {
+    var currentPrefs = {};
+    var defaultValue, prefName;
+
+    for (var key in DEFAULT_PREFERENCES) {
+      defaultValue = DEFAULT_PREFERENCES[key];
+      prefName = (PREF_PREFIX + '.' + key);
+
+      switch (typeof defaultValue) {
+        case 'boolean':
+          currentPrefs[key] = getBoolPref(prefName, defaultValue);
+          break;
+        case 'number':
+          currentPrefs[key] = getIntPref(prefName, defaultValue);
+          break;
+        case 'string':
+          currentPrefs[key] = getStringPref(prefName, defaultValue);
+          break;
+      }
+    }
+    return JSON.stringify(currentPrefs);
   }
 };
 

--- a/make.js
+++ b/make.js
@@ -436,7 +436,8 @@ target.firefox = function() {
     copy: [
       [COMMON_WEB_FILES, FIREFOX_BUILD_CONTENT_DIR + '/web'],
       [FIREFOX_EXTENSION_DIR + 'tools/l10n.js',
-       FIREFOX_BUILD_CONTENT_DIR + '/web']
+       FIREFOX_BUILD_CONTENT_DIR + '/web'],
+      ['web/default_preferences.js', FIREFOX_BUILD_CONTENT_DIR]
     ],
     preprocess: [
       [COMMON_WEB_FILES_PREPROCESS, FIREFOX_BUILD_CONTENT_DIR + '/web'],
@@ -551,7 +552,8 @@ target.mozcentral = function() {
     defines: defines,
     copy: [
       [COMMON_WEB_FILES, MOZCENTRAL_CONTENT_DIR + '/web'],
-      ['extensions/firefox/tools/l10n.js', MOZCENTRAL_CONTENT_DIR + '/web']
+      ['extensions/firefox/tools/l10n.js', MOZCENTRAL_CONTENT_DIR + '/web'],
+      ['web/default_preferences.js', MOZCENTRAL_CONTENT_DIR]
     ],
     preprocess: [
       [COMMON_WEB_FILES_PREPROCESS, MOZCENTRAL_CONTENT_DIR + '/web'],

--- a/web/default_preferences.js
+++ b/web/default_preferences.js
@@ -1,0 +1,27 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/* Copyright 2013 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* globals */
+
+'use strict';
+
+var EXPORTED_SYMBOLS = ['DEFAULT_PREFERENCES'];
+
+var DEFAULT_PREFERENCES = {
+  showPreviousViewOnLoad: true,
+  defaultZoomValue: '',
+  ifAvailableShowOutlineOnLoad: false
+};

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* globals Preferences, PDFJS */
 
 'use strict';
 
@@ -102,3 +103,14 @@ var DownloadManager = (function DownloadManagerClosure() {
 
   return DownloadManager;
 })();
+
+Preferences.prototype.writeToStorage = function(prefObj) {
+  FirefoxCom.requestSync('setPreferences', prefObj);
+};
+
+Preferences.prototype.readFromStorage = function() {
+  var readFromStoragePromise = new PDFJS.Promise();
+  var readPrefs = JSON.parse(FirefoxCom.requestSync('getPreferences'));
+  readFromStoragePromise.resolve(readPrefs);
+  return readFromStoragePromise;
+};

--- a/web/preferences.js
+++ b/web/preferences.js
@@ -1,0 +1,126 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/* Copyright 2013 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* globals DEFAULT_PREFERENCES, PDFJS, isLocalStorageEnabled */
+
+'use strict';
+
+//#include default_preferences.js
+
+var Preferences = (function PreferencesClosure() {
+  function Preferences() {
+    this.prefs = {};
+    this.initializedPromise = this.readFromStorage().then(function(prefObj) {
+      if (prefObj) {
+        this.prefs = prefObj;
+      }
+    }.bind(this));
+  }
+
+  Preferences.prototype = {
+    writeToStorage: function Preferences_writeToStorage(prefObj) {
+      return;
+    },
+
+    readFromStorage: function Preferences_readFromStorage() {
+      var readFromStoragePromise = new PDFJS.Promise();
+      return readFromStoragePromise;
+    },
+
+    reset: function Preferences_reset() {
+      if (this.initializedPromise.isResolved) {
+        this.prefs = {};
+        this.writeToStorage(this.prefs);
+      }
+    },
+
+    set: function Preferences_set(name, value) {
+      if (!this.initializedPromise.isResolved) {
+        return;
+      } else if (DEFAULT_PREFERENCES[name] === undefined) {
+        console.error('Preferences_set: \'' + name + '\' is undefined.');
+        return;
+      } else if (value === undefined) {
+        console.error('Preferences_set: no value is specified.');
+        return;
+      }
+      var valueType = typeof value;
+      var defaultType = typeof DEFAULT_PREFERENCES[name];
+
+      if (valueType !== defaultType) {
+        if (valueType === 'number' && defaultType === 'string') {
+          value = value.toString();
+        } else {
+          console.error('Preferences_set: \'' + value + '\' is a \"' +
+                        valueType + '\", expected a \"' + defaultType + '\".');
+          return;
+        }
+      }
+      this.prefs[name] = value;
+      this.writeToStorage(this.prefs);
+    },
+
+    get: function Preferences_get(name) {
+      var defaultPref = DEFAULT_PREFERENCES[name];
+
+      if (defaultPref === undefined) {
+        console.error('Preferences_get: \'' + name + '\' is undefined.');
+        return;
+      } else if (this.initializedPromise.isResolved) {
+        var pref = this.prefs[name];
+
+        if (pref !== undefined) {
+          return pref;
+        }
+      }
+      return defaultPref;
+    }
+  };
+
+  return Preferences;
+})();
+
+//#if B2G
+//Preferences.prototype.writeToStorage = function(prefObj) {
+//  asyncStorage.setItem('preferences', JSON.stringify(prefObj));
+//};
+//
+//Preferences.prototype.readFromStorage = function() {
+//  var readFromStoragePromise = new PDFJS.Promise();
+//  asyncStorage.getItem('preferences', function(prefString) {
+//    var readPrefs = JSON.parse(prefString);
+//    readFromStoragePromise.resolve(readPrefs);
+//  });
+//  return readFromStoragePromise;
+//};
+//#endif
+
+//#if !(FIREFOX || MOZCENTRAL || B2G)
+Preferences.prototype.writeToStorage = function(prefObj) {
+  if (isLocalStorageEnabled) {
+    localStorage.setItem('preferences', JSON.stringify(prefObj));
+  }
+};
+
+Preferences.prototype.readFromStorage = function() {
+  var readFromStoragePromise = new PDFJS.Promise();
+  if (isLocalStorageEnabled) {
+    var readPrefs = JSON.parse(localStorage.getItem('preferences'));
+    readFromStoragePromise.resolve(readPrefs);
+  }
+  return readFromStoragePromise;
+};
+//#endif

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -240,3 +240,16 @@ var Cache = function cacheCache(size) {
   };
 };
 
+//#if !(FIREFOX || MOZCENTRAL || B2G)
+var isLocalStorageEnabled = (function isLocalStorageEnabledClosure() {
+  // Feature test as per http://diveintohtml5.info/storage.html
+  // The additional localStorage call is to get around a FF quirk, see
+  // bug #495747 in bugzilla
+  try {
+    return ('localStorage' in window && window['localStorage'] !== null &&
+            localStorage);
+  } catch (e) {
+    return false;
+  }
+})();
+//#endif

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -62,6 +62,8 @@ limitations under the License.
 
 <!--#if !PRODUCTION-->
     <script type="text/javascript" src="ui_utils.js"></script>
+    <script type="text/javascript" src="default_preferences.js"></script>
+    <script type="text/javascript" src="preferences.js"></script>
     <script type="text/javascript" src="download_manager.js"></script>
     <script type="text/javascript" src="settings.js"></script>
     <script type="text/javascript" src="page_view.js"></script>


### PR DESCRIPTION
This PR implements a framework for default preferences in PDF.js, hence this supersedes #3255.
Compared to the previous patch, this one is written such that is should be completely browser/platform agnostic.

In this PR the functions for reading/writing the preferences are provided as empty stubs, which are then overridden by specific versions for the different builds.
@brendandahl Is that the approach you had in mind with [this comment](https://github.com/mozilla/pdf.js/pull/3255#issuecomment-26373931), or should it be done differently?

In this initial patch, the following default preferences are added (default values in bold):
- `showPreviousViewOnLoad`: **true** | false. <br />
  Setting this to false will always load the document at the first page.
- `defaultZoomValue`: **[empty string]**. <br />
  Setting this to either one of the predefined zoom values (auto, page-actual, page-fit or page-width), or a numerical value, will load all documents with this zoom value _irrespective_ of the saved zoom settings.
- `ifAvailableShowOutlineOnLoad`: **false** | true. <br />
  Setting this to true will automatically display the outline when the document is loaded, but _only if_ the document actually contains an outline.

As a follow-up to this PR, I've got a prototype UI for displaying/changing the preferences in the viewer.

Fixes #1624, #2568 and [bug 845946](https://bugzilla.mozilla.org/show_bug.cgi?id=845946); and contains an improved version of PR #2691.

PS. @brendandahl I really like your suggestion about the current `Settings`: https://github.com/mozilla/pdf.js/pull/3255#issuecomment-26374851, but I decided to implement that in a follow-up PR to keep this patch smaller and easier to test.
