### PR TITLE
Round the scale value displayed by the viewBookmark button to two decimal places

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1745,8 +1745,8 @@ function updateViewarea() {
 
   var currentScale = PDFView.currentScale;
   var currentScaleValue = PDFView.currentScaleValue;
-  var normalizedScaleValue = currentScaleValue == currentScale ?
-    currentScale * 100 : currentScaleValue;
+  var normalizedScaleValue = currentScaleValue === currentScale ?
+    Math.round(currentScale * 10000) / 100 : currentScaleValue;
 
   var pageNumber = firstPage.id;
   var pdfOpenParams = '#page=' + pageNumber;


### PR DESCRIPTION
This prevents issues at certain scale values, e.g. 110%.

**Edit:** This is analogous to the scale select drop-down menu, see https://github.com/mozilla/pdf.js/blob/master/web/viewer.js#L1874.
