### PR TITLE
[PDFHistory] Prevent updating the current position when zooming the document without scrolling the destination into view

### DIFF
--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -36,6 +36,7 @@ var PDFHistory = {
     this.previousHash = window.location.hash.substring(1);
     this.currentBookmark = '';
     this.currentPage = 0;
+    this.skipUpdateBookmark = false;
     this.updatePreviousBookmark = false;
     this.previousBookmark = '';
     this.previousPage = 0;
@@ -159,9 +160,20 @@ var PDFHistory = {
     }
   },
 
+  skipNextUpdateCurrentBookmark:
+      function pdfHistorySkipNextUpdateCurrentBookmark() {
+    if (this.initialized) {
+      this.skipUpdateBookmark = true;
+    }
+  },
+
   updateCurrentBookmark: function pdfHistoryUpdateCurrentBookmark(bookmark,
                                                                   pageNum) {
     if (this.initialized) {
+      if (this.skipUpdateBookmark) {
+        this.skipUpdateBookmark = false;
+        return;
+      }
       this.currentBookmark = bookmark.substring(1);
       this.currentPage = pageNum | 0;
       this._updatePreviousBookmark();

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -246,6 +246,8 @@ var PDFView = {
 
     if (!noScroll) {
       currentPage.scrollIntoView();
+    } else {
+      PDFHistory.skipNextUpdateCurrentBookmark();
     }
 
     var event = document.createEvent('UIEvents');


### PR DESCRIPTION
**Steps to reproduce:**
1. Open: https://www.eff.org/sites/default/files/filenode/DMCA/NTIA%20DMCA%20White%20Paper.pdf.
2. Take note of the current zoom value.
3. Click on any item in the outline.
4. Click the back button in the browser.

**Expected result:**
The document should go back to the previous position, with the same zoom value as before.

**Actual result:**
The zoom value is wrong.
