### PR TITLE
BugFix: Missing var (context) in function call getOutputScale of text-se...

### DIFF
--- a/examples/text-selection/js/minimal.js
+++ b/examples/text-selection/js/minimal.js
@@ -54,7 +54,7 @@ window.onload = function () {
             });
 
         //The following few lines of code set up scaling on the context if we are on a HiDPI display
-        var outputScale = getOutputScale();
+        var outputScale = getOutputScale(context);
         if (outputScale.scaled) {
             var cssScale = 'scale(' + (1 / outputScale.sx) + ', ' +
                 (1 / outputScale.sy) + ')';


### PR DESCRIPTION
...lection example
