### PR TITLE
Fix zoom parameter regression

### DIFF
--- a/web/page_view.js
+++ b/web/page_view.js
@@ -347,7 +347,7 @@ var PageView = function pageView(container, id, scale,
         // since aligning the bottom of the intended page with the
         // top of the window is rarely helpful).
         x = x !== null ? x : 0;
-        y = y !== null ? y : this.height / this.scale;
+        y = y !== null ? y : (this.height / this.scale) / CSS_UNITS;
         break;
       case 'Fit':
       case 'FitB':


### PR DESCRIPTION
This patch fixes a regression caused by PR #3727.

**Steps to reproduce:**
Open http://mozilla.github.io/pdf.js/web/viewer.html#page=2&zoom=110.

**Expected result:**
The document should be scrolled such that the _top_ of the second page is aligned with the top of the `viewerContainer`.

**Actual result:**
![zoom-parameter-regression](https://f.cloud.github.com/assets/2692120/1437136/1a8c6100-4168-11e3-93e4-bb5be6a7fa52.png)
