### PR TITLE
Fix type mismatch causing wrong scale value in the viewBookmark button

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1745,7 +1745,7 @@ function updateViewarea() {
 
   var currentScale = PDFView.currentScale;
   var currentScaleValue = PDFView.currentScaleValue;
-  var normalizedScaleValue = currentScaleValue === currentScale ?
+  var normalizedScaleValue = parseFloat(currentScaleValue) === currentScale ?
     Math.round(currentScale * 10000) / 100 : currentScaleValue;
 
   var pageNumber = firstPage.id;


### PR DESCRIPTION
This fixes an oversight on my part in #3854.
The old code relied on implicit type conversion, which I forgot to account for. 
