### PR TITLE
correct word spacing

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -4562,8 +4562,10 @@ var Font = (function FontClosure() {
           var glyph = this.charToGlyph(charcode);
           glyphs.push(glyph);
           // placing null after each word break charcode (ASCII SPACE)
-          if (charcode == 0x20)
+          // Ignore occurences of 0x20 in multiple-byte codes.
+          if (length === 1 && chars.charCodeAt(i - 1) === 0x20) {
             glyphs.push(null);
+          }
         }
       }
       else {

--- a/test/pdfs/issue3205.pdf.link
+++ b/test/pdfs/issue3205.pdf.link
@@ -1,0 +1,2 @@
+http://teach.beaverton.k12.or.us/~shannon_schilling/FOV1-00015633/FOV1-0007B939/FOV1-000B0E58/Physics%20HL%20paper%202%20TZ1%20markscheme.pdf
+

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1417,5 +1417,14 @@
        "firstPage": 1,
        "lastPage": 2,
        "type": "eq"
+    },
+    {  "id": "issue3205",
+       "file": "pdfs/issue3205.pdf",
+       "md5": "e833326f69f2fdf7c1c8438fe1d3b622",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 4,
+       "lastPage": 4,
+       "type": "eq"
     }
 ]


### PR DESCRIPTION
Certain char streams may contain 0x20 which can be mapped to non space character. Word spacing in those cases are ignored. Fix for #3205
