### PR TITLE
Add shortcut for goto page

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -30,6 +30,7 @@ var CACHE_SIZE = 20;
 var CSS_UNITS = 96.0 / 72.0;
 var SCROLLBAR_PADDING = 40;
 var VERTICAL_PADDING = 5;
+var MAX_AUTO_SCALE = 1.25;
 var MIN_SCALE = 0.25;
 var MAX_SCALE = 4.0;
 var SETTINGS_MEMORY = 20;
@@ -230,7 +231,7 @@ var PDFView = {
           scale = Math.min(pageWidthScale, pageHeightScale);
           break;
         case 'auto':
-          scale = Math.min(1.0, pageWidthScale);
+          scale = Math.min(MAX_AUTO_SCALE, pageWidthScale);
           break;
       }
     }

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1991,6 +1991,11 @@ window.addEventListener('keydown', function keydown(evt) {
         SecondaryToolbar.presentationModeClick();
         handled = true;
         break;
+      case 71: // g
+        //focuses input#pageNumber field  
+        document.getElementById('pageNumber').select();
+        handled = true;
+        break;
     }
   }
 


### PR DESCRIPTION
Press `Alt + G` to focus the page number input field.
I checked [firefox shortcuts](https://support.mozilla.org/en-US/kb/keyboard-shortcuts-perform-firefox-tasks-quickly) to make sure the key combination is appropriate but let me know if there is a better one ;)

Closes #3825
