### PR TITLE
Fix destination name for 'Fit' zoom levels in hash params

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1328,6 +1328,9 @@ var PDFView = {
   },
 
   setHash: function pdfViewSetHash(hash) {
+    var validFitZoomValues = ['Fit','FitB','FitH','FitBH',
+      'FitV','FitBV','FitR'];
+
     if (!hash) {
       return;
     }
@@ -1352,10 +1355,13 @@ var PDFView = {
         // it should stay as it is.
         var zoomArg = zoomArgs[0];
         var zoomArgNumber = parseFloat(zoomArg);
+        var destName = 'XYZ';
         if (zoomArgNumber) {
           zoomArg = zoomArgNumber / 100;
+        } else if (validFitZoomValues.indexOf(zoomArg) >= 0) {
+          destName = zoomArg;
         }
-        dest = [null, {name: 'XYZ'},
+        dest = [null, { name: destName },
                 zoomArgs.length > 1 ? (zoomArgs[1] | 0) : null,
                 zoomArgs.length > 2 ? (zoomArgs[2] | 0) : null,
                 zoomArg];


### PR DESCRIPTION
Fixes handling of hash parameters like `#page=0&zoom=Fit`

Actual implementation of fitting was already in `page_view.js`, but incorrect parameter `name: XYZ` was always sent instead of correct Fit\* ones.
