### PR TITLE
Open Find bar instead of toggling it on Ctrl + F

### DIFF
--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -144,11 +144,12 @@ var PDFFindBar = {
   },
 
   open: function() {
-    if (this.opened) return;
+    if (!this.opened) {
+      this.opened = true;
+      this.toggleButton.classList.add('toggled');
+      this.bar.classList.remove('hidden');
+    }
 
-    this.opened = true;
-    this.toggleButton.classList.add('toggled');
-    this.bar.classList.remove('hidden');
     this.findField.select();
     this.findField.focus();
   },

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1926,7 +1926,7 @@ window.addEventListener('keydown', function keydown(evt) {
     switch (evt.keyCode) {
       case 70: // f
         if (!PDFView.supportsIntegratedFind) {
-          PDFFindBar.toggle();
+          PDFFindBar.open();
           handled = true;
         }
         break;


### PR DESCRIPTION
<kbd>Ctrl</kbd>+<kbd>F</kbd> currently toggles the Find bar. I.e. when the Find bar is already activated, pressing Ctrl + F hides it again. This behaviour is inconsistent with what most if not all other applications do: Ctrl + F should focus the find field when it's used while the find bar is open.

This PR corrects the behaviour. If the user wants to close the find bar, s/he has to use <kbd>Esc</kbd> instead.
