### PR TITLE
Prevent updating the current transformation matrix when the stateStack is empty

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1580,8 +1580,11 @@ var TextState = (function TextStateClosure() {
     push: function TextState_push() {
       this.stateStack.push(this.ctm.slice());
     },
-    pop: function TextStae_pop() {
-      this.ctm = this.stateStack.pop();
+    pop: function TextState_pop() {
+      var prev = this.stateStack.pop();
+      if (prev) {
+        this.ctm = prev;
+      }
     },
     initialiseTextObj: function TextState_initialiseTextObj() {
       var m = this.textMatrix;

--- a/test/pdfs/issue3925.pdf.link
+++ b/test/pdfs/issue3925.pdf.link
@@ -1,0 +1,1 @@
+http://patentimages.storage.googleapis.com/pdfs/US4441207.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -23,6 +23,15 @@
        "rounds": 1,
        "type": "text"
     },
+    {  "id": "issue3925",
+       "file": "pdfs/issue3925.pdf",
+       "md5": "c5c895deecf7a7565393587e0d61be2b",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 1,
+       "lastPage": 1,
+       "type": "text"
+    },
     {  "id": "issue1293",
        "file": "pdfs/issue1293.pdf",
        "md5": "0a744b3bbf2fd8da0131fd3c01dd1e30",


### PR DESCRIPTION
Fixes #3925.
