### PR TITLE
[PDFHistory] Fix "Warning: Unhandled rejection: [Exception... "The operation is insecure."" when opening local file

### DIFF
--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -65,8 +65,7 @@ var PDFHistory = {
         // is opened in the web viewer.
         this.reInitialized = true;
       }
-      window.history.replaceState({ fingerprint: this.fingerprint }, '',
-          document.URL);
+      this._pushOrReplaceState({ fingerprint: this.fingerprint }, true);
     }
 
     var self = this;
@@ -129,6 +128,21 @@ var PDFHistory = {
     return (state && state.uid >= 0 &&
             state.fingerprint && this.fingerprint === state.fingerprint &&
             state.target && state.target.hash) ? true : false;
+  },
+
+  _pushOrReplaceState: function pdfHistory_pushOrReplaceState(stateObj,
+                                                              replace) {
+    // In Firefox, 'urlParam' needs to be undefined in order to prevent issues
+    // when local files are opened.
+    var urlParam;
+//#if (GENERIC || CHROME)
+    urlParam = document.URL;
+//#endif
+    if (replace) {
+      window.history.replaceState(stateObj, '', urlParam);
+    } else {
+      window.history.pushState(stateObj, '', urlParam);
+    }
   },
 
   get isHashChangeUnlocked() {
@@ -291,11 +305,8 @@ var PDFHistory = {
         this._pushToHistory(previousParams, false, replacePrevious);
       }
     }
-    if (overwrite || this.uid === 0) {
-      window.history.replaceState(this._stateObj(params), '', document.URL);
-    } else {
-      window.history.pushState(this._stateObj(params), '', document.URL);
-    }
+    this._pushOrReplaceState(this._stateObj(params),
+                             (overwrite || this.uid === 0));
     this.currentUid = this.uid++;
     this.current = params;
     this.updatePreviousBookmark = true;


### PR DESCRIPTION
Using Firefox to open a **local PDF file** (e.g. by drag and drop, or using the "Open File" menu entry), the fallback bar is displayed and the console contains the following message:
`"Warning: Unhandled rejection: [Exception... "The operation is insecure."  code: "18" nsresult: "0x80530012 (SecurityError)"  location: "<unknown>"]"`

Apparently, providing the third optional parameter to `window.history.pushState/replaceState` fails when opening a **local PDF file** in Firefox.

This regressed in PR #3582. Since providing the third parameter isn't necessary in Firefox, the simplest solution seemed to be to add preprocessor tags to work around this bug.
