### PR TITLE
Fix error in 'PdfStreamConverter.js' that prevents the user from setting a boolean preference to false

### DIFF
--- a/extensions/firefox/components/PdfStreamConverter.js
+++ b/extensions/firefox/components/PdfStreamConverter.js
@@ -452,7 +452,7 @@ ChromeActions.prototype = {
       defaultValue = DEFAULT_PREFERENCES[key];
       prefName = (PREF_PREFIX + '.' + key);
 
-      if (!prefValue || prefValue === defaultValue) {
+      if (prefValue === undefined || prefValue === defaultValue) {
         Services.prefs.clearUserPref(prefName);
       } else {
         prefType = typeof prefValue;


### PR DESCRIPTION
Without this small change, it's not possible to set a preference to `false` in Firefox.
This patch thus fixes a stupid mistake I made in #3850. Sorry about this, I should have tested it more thoroughly!

/cc @brendandahl
