### PR TITLE
Skip loading worker src when PDFJS.workerSrc = 'none'

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -617,9 +617,13 @@ var WorkerTransport = (function WorkerTransportClosure() {
 //#if !PRODUCTION
         Util.loadScript(PDFJS.workerSrc);
 //#else
-//      Util.loadScript(PDFJS.workerSrc, function() {
+//      if (PDFJS.workerSrc != 'none') {
+//        Util.loadScript(PDFJS.workerSrc, function() {
+//          PDFJS.fakeWorkerFilesLoadedPromise.resolve();
+//        });
+//      } else {
 //        PDFJS.fakeWorkerFilesLoadedPromise.resolve();
-//      });
+//      }
 //#endif
       }
       return PDFJS.fakeWorkerFilesLoadedPromise;


### PR DESCRIPTION
We're using pdf.js in a build environment where we're pre-concatenating all of our sources before loading into a webpage. We set PDFJS.disableWorker = true, but even then the worker loading logic would always attempt to load a separate pdf.worker.js Javascript file.

Our solution was to add some logic to specifically recognize a PDFJS.workerSrc = 'none' value, in which case the loading is skipped and the promise is returned.

Maybe this would be helpful for other integrators who wish to avoid relying on a predictable path for the associated JS file?
