### PR TITLE
Avoid infinite loop in readXRef.

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -982,6 +982,9 @@ var XRef = (function XRefClosure() {
           // Recursively get previous dictionary, if any
           obj = dict.get('Prev');
           if (isInt(obj)) {
+            if (obj == startXRef) {
+              error('Invalid XRef prev');
+            }
             this.startXRefQueue.push(obj);
           } else if (isRef(obj)) {
             // The spec says Prev must not be a reference, i.e. "/Prev NNN"


### PR DESCRIPTION
Our application (Paperpile, http://paperpile.com/) uses pdf.js within a Chrome extension to parse out metadata and text from journal article PDFs. One of our users recently noticed a reproducible crash occurring when attempting to parse Frontiers in Neuroscience PDFs. Processor usage would run to 100% and the extension would eventually crash.

Here's an example PDF: http://www.its.caltech.edu/~dray/Papers/RayBossaerts_FIN11.pdf

We were able to confirm this issue still exists on the latest code from mozilla/pdf.js master running both Chrome and Firefox.

I tracked this down to an infinite loop occurring within the readXRef method. I'm not 100% sure what's going on in that loop, but this appeared to be a reasonable way to exit.

I wasn't able to get all the pdf.js tests passing before making this change, so I'm not sure if this breaks any other PDFs. If this PR isn't useful, I'd be happy to create a new issue instead.
