### PR TITLE
Limits U and O entries size

### DIFF
--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -565,8 +565,8 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
       keyLength < 40 || (keyLength % 8) !== 0)
       error('invalid key length');
     // prepare keys
-    var ownerPassword = stringToBytes(dict.get('O'));
-    var userPassword = stringToBytes(dict.get('U'));
+    var ownerPassword = stringToBytes(dict.get('O')).subarray(0, 32);
+    var userPassword = stringToBytes(dict.get('U')).subarray(0, 32);
     var flags = dict.get('P');
     var revision = dict.get('R');
     var encryptMetadata = algorithm == 4 &&  // meaningful when V is 4


### PR DESCRIPTION
Fixes document received in https://bugzilla.mozilla.org/show_bug.cgi?id=900822 comment 9

abcpdf adds extra character to the "O" entry of the standard encryption dictionary, which makes it incorrect from PDF32000 specification point of view.

(Workaround for patching files generated by abcpdf: open binary PDF data,  look for binary '2F 4F 20' starting from the end if the file, and make this /O entry one character shorter by searching and replacing binary '0A 29' [located somewhere around 100 bytes after /O] to '29 20')
