### PR TITLE
Fix issues with /FitR destinations

### DIFF
--- a/web/page_view.js
+++ b/web/page_view.js
@@ -371,7 +371,7 @@ var PageView = function pageView(container, id, scale,
           width / CSS_UNITS;
         heightScale = (PDFView.container.clientHeight - SCROLLBAR_PADDING) /
           height / CSS_UNITS;
-        scale = Math.min(widthScale, heightScale);
+        scale = Math.min(Math.abs(widthScale), Math.abs(heightScale));
         break;
       default:
         return;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -209,7 +209,7 @@ var PDFView = {
     var number = parseFloat(value);
     var scale;
 
-    if (number) {
+    if (number > 0) {
       scale = number;
       resetAutoSettings = true;
     } else {


### PR DESCRIPTION
This patch forces `widthScale`and `heightScale` to be positive numbers for `/FitR` destinations, to prevent trying to set the zoom level to a value below 0 %.

Also, to prevent similar issues in the future, `PDFView.setScale` is changed to refuse a scale value smaller than zero.

Fixes #3953.
