### PR TITLE
[PDFHistory] Fix "Warning: Unhandled rejection: [Exception... "The operation is insecure."" in Firefox 25

### DIFF
--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -132,16 +132,18 @@ var PDFHistory = {
 
   _pushOrReplaceState: function pdfHistory_pushOrReplaceState(stateObj,
                                                               replace) {
-    // In Firefox, 'urlParam' needs to be undefined in order to prevent issues
-    // when local files are opened.
-    var urlParam;
-//#if (GENERIC || CHROME)
-    urlParam = document.URL;
-//#endif
     if (replace) {
-      window.history.replaceState(stateObj, '', urlParam);
+//#if (GENERIC || CHROME)
+      window.history.replaceState(stateObj, '', document.URL);
+//#else
+//    window.history.replaceState(stateObj, '');
+//#endif
     } else {
-      window.history.pushState(stateObj, '', urlParam);
+//#if (GENERIC || CHROME)
+      window.history.pushState(stateObj, '', document.URL);
+//#else
+//    window.history.pushState(stateObj, '');
+//#endif
     }
   },
 


### PR DESCRIPTION
Apparently PR #3934 causes issues in **Firefox 25** (the current release version), which I missed since I didn't test using that version. Note that Firefox version 26 (and above) already works as they should.

This patch should solve the issue. Unfortunately this means that the code becomes slightly more difficult to read, but I don't think that can be avoided.

Fixes #3959.
