### PR TITLE
fixed toolbar position for ios safari

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -258,7 +258,7 @@ html[dir='rtl'] #sidebarContent {
 }
 
 .toolbar {
-  position: relative;
+  position: fixed;
   left: 0;
   right: 0;
   z-index: 9999;


### PR DESCRIPTION
When triggering an orientation change (portrait to landscape) the value of window.scrollY is 20, resulting in the toolbar to be partially hidden. This issue observed on ios 7.0.4 safari.
