### PR TITLE
Remove </input> tag

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -188,7 +188,6 @@ limitations under the License.
                 </div>
                 <label id="pageNumberLabel" class="toolbarLabel" for="pageNumber" data-l10n-id="page_label">Page: </label>
                 <input type="number" id="pageNumber" class="toolbarField pageNumber" value="1" size="4" min="1" tabindex="8">
-                </input>
                 <span id="numPages" class="toolbarLabel"></span>
               </div>
               <div id="toolbarViewerRight">


### PR DESCRIPTION
Since the `<input>` element shouldn't have an end tag (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#Summary), let's just remove it. Also, this should fix #3847.
