### PR TITLE
UI for viewing and setting default preferences

### DIFF
--- a/web/password_prompt.js
+++ b/web/password_prompt.js
@@ -62,6 +62,7 @@ var PasswordPrompt = {
     }
     this.visible = true;
     this.overlayContainer.classList.remove('hidden');
+    this.overlayContainer.firstElementChild.classList.remove('hidden');
     this.passwordField.focus();
 
     var promptString = mozL10n.get('password_label', null,
@@ -82,6 +83,7 @@ var PasswordPrompt = {
     this.visible = false;
     this.passwordField.value = '';
     this.overlayContainer.classList.add('hidden');
+    this.overlayContainer.firstElementChild.classList.add('hidden');
   },
 
   verifyPassword: function passwordPromptVerifyPassword() {

--- a/web/preferences_ui.js
+++ b/web/preferences_ui.js
@@ -1,0 +1,124 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/* Copyright 2013 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* globals Preferences */
+
+'use strict';
+
+var PreferencesUI = {
+  opened: false,
+
+  initialize: function() {
+    this.container = document.getElementById('preferencesContainer'),
+    this.overlayContainer = this.container.parentNode;
+
+    this.preferenceNames = [
+      { name: 'showPreviousViewOnLoad', type: 'checkbox' },
+      { name: 'ifAvailableShowOutlineOnLoad', type: 'checkbox' },
+      { name: 'defaultZoomValue', type: 'text' }
+    ];
+
+    this.resetButton = document.getElementById('preferencesReset');
+    this.closeButton = document.getElementById('preferencesClose');
+
+    this.resetButton.addEventListener('click', function(evt) {
+      this._resetPreferences();
+    }.bind(this));
+
+    this.closeButton.addEventListener('click', function(evt) {
+      this.close();
+    }.bind(this));
+  },
+
+  _update: function() {
+    var entry, prefName, prefValue, element;
+
+    for (var item in this.preferenceNames) {
+      entry = this.preferenceNames[item];
+      prefName = entry.name;
+      prefValue = this.prefs.get(prefName);
+      element = document.getElementById(prefName);
+
+      switch (entry.type) {
+        case 'checkbox':
+          element.checked = prefValue;
+          break;
+        case 'text':
+          element.value = prefValue;
+          break;
+        default:
+          break;
+      }
+    }
+  },
+
+  _resetPreferences: function() {
+    this.prefs.reset();
+    this._update();
+  },
+
+  _savePreferences: function() {
+    var entry, prefName, newPrefValue, element;
+
+    for (var item in this.preferenceNames) {
+      entry = this.preferenceNames[item];
+      prefName = entry.name;
+      element = document.getElementById(prefName);
+
+      switch (entry.type) {
+        case 'checkbox':
+          newPrefValue = element.checked;
+          break;
+        case 'text':
+          newPrefValue = element.value;
+          break;
+        default:
+          break;
+      }
+      this.prefs.set(prefName, newPrefValue);
+    }
+  },
+
+  open: function() {
+    if (this.opened) {
+      return;
+    }
+    // Since the preferences might have been changed manually by the user
+    // (by editing about:config in Firefox) after the file was loaded,
+    // fetch the current preferences from storage by creating a new instance.
+    this.prefs = new Preferences();
+
+    this.prefs.initializedPromise.then(function() {
+      this.opened = true;
+      this.container.classList.remove('hidden');
+      this.overlayContainer.classList.remove('hidden');
+
+      this._update();
+    }.bind(this));
+  },
+
+  close: function() {
+    if (!this.opened) {
+      return;
+    }
+    this._savePreferences();
+    delete this.prefs;
+
+    this.container.classList.add('hidden');
+    this.overlayContainer.classList.add('hidden');
+    this.opened = false;
+  }
+};

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFView, SCROLLBAR_PADDING */
+/* globals PDFView, SCROLLBAR_PADDING, PreferencesUI */
 
 'use strict';
 
@@ -38,6 +38,7 @@ var SecondaryToolbar = {
     this.lastPage = options.lastPage;
     this.pageRotateCw = options.pageRotateCw;
     this.pageRotateCcw = options.pageRotateCcw;
+    this.openPreferencesUI = document.getElementById('openPreferencesUI');
 
     // Attach the event listeners.
     var elements = [
@@ -50,13 +51,17 @@ var SecondaryToolbar = {
       { element: this.firstPage, handler: this.firstPageClick },
       { element: this.lastPage, handler: this.lastPageClick },
       { element: this.pageRotateCw, handler: this.pageRotateCwClick },
-      { element: this.pageRotateCcw, handler: this.pageRotateCcwClick }
+      { element: this.pageRotateCcw, handler: this.pageRotateCcwClick },
+      { element: this.openPreferencesUI, handler: this.openPreferencesUIClick }
     ];
 
+    var element, handler, scope;
     for (var item in elements) {
-      var element = elements[item].element;
+      element = elements[item].element;
       if (element) {
-        element.addEventListener('click', elements[item].handler.bind(this));
+        handler = elements[item].handler;
+        scope = (elements[item].scope || this);
+        element.addEventListener('click', handler.bind(scope));
       }
     }
   },
@@ -96,6 +101,11 @@ var SecondaryToolbar = {
 
   pageRotateCcwClick: function secondaryToolbarPageRotateCcwClick(evt) {
     PDFView.rotatePages(-90);
+  },
+
+  openPreferencesUIClick: function secondaryToolbarOpenPreferencesUIClick(evt) {
+    this.close();
+    PreferencesUI.open();
   },
 
   // Misc. functions for interacting with the toolbar.

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1377,7 +1377,49 @@ canvas {
   width: 100%;
   height: 100%;
   background-color: hsla(0,0%,0%,.2);
-  z-index: 10000;
+  z-index: 1000000;
+}
+
+#preferencesContainer {
+  display: table-cell;
+  vertical-align: middle;
+  text-align: center;
+}
+#preferencesContainer > * {
+  display: inline-block;
+  display: inline-block;
+  padding: 6px;
+  border-spacing: 4px;
+  max-width: 350px;
+  max-height: 350px;
+  color: hsl(0,0%,85%);
+  font-size: 12px;
+  line-height: 14px;
+  text-align: left;
+  cursor: default;
+  background-color: #474747; /* fallback */
+  background-image: url(images/texture.png),
+                    linear-gradient(hsla(0,0%,32%,.99), hsla(0,0%,27%,.95));
+  box-shadow: inset 1px 0 0 hsla(0,0%,100%,.08),
+              inset 0 1px 1px hsla(0,0%,0%,.15),
+              inset 0 -1px 0 hsla(0,0%,100%,.05),
+              0 1px 0 hsla(0,0%,0%,.15),
+              0 1px 1px hsla(0,0%,0%,.1);
+}
+#preferencesContainer .caption {
+  font-weight: bold;
+}
+#preferencesContainer .row {
+  display: table-row;
+}
+#preferencesContainer .row > * {
+  display: table-cell;
+}
+#preferencesReset {
+  float: left;
+}
+#preferencesClose {
+  float: right;
 }
 
 #promptContainer {

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -75,6 +75,7 @@ limitations under the License.
     <script type="text/javascript" src="secondary_toolbar.js"></script>
     <script type="text/javascript" src="password_prompt.js"></script>
     <script type="text/javascript" src="presentation_mode.js"></script>
+    <script type="text/javascript" src="preferences_ui.js"></script>
 <!--#endif-->
 
     <script type="text/javascript" src="debugger.js"></script>
@@ -162,6 +163,12 @@ limitations under the License.
             </button>
             <button id="pageRotateCcw" class="secondaryToolbarButton rotateCcw" title="Rotate Counterclockwise" tabindex="26" data-l10n-id="page_rotate_ccw">
               <span data-l10n-id="page_rotate_ccw_label">Rotate Counterclockwise</span>
+            </button>
+
+            <div class="horizontalToolbarSeparator"></div>
+
+            <button id="openPreferencesUI" class="secondaryToolbarButton" title="Preferences..." tabindex="27" data-l10n-id="">
+              <span data-l10n-id="">Preferences...</span>
             </button>
           </div>
         </div>  <!-- secondaryToolbar -->
@@ -292,7 +299,7 @@ limitations under the License.
       </div> <!-- mainContainer -->
 
       <div id="overlayContainer" class="hidden">
-        <div id="promptContainer">
+        <div id="promptContainer" class="hidden">
           <div id="passwordContainer" class="prompt doorHanger">
             <div class="row">
               <p id="passwordText" data-l10n-id="password_label">Enter the password to open this PDF file:</p>
@@ -304,6 +311,33 @@ limitations under the License.
               <button id="passwordCancel" class="promptButton"><span data-l10n-id="password_cancel">Cancel</span></button>
               <button id="passwordSubmit" class="promptButton"><span data-l10n-id="password_ok">OK</span></button>
             </div>
+          </div>
+        </div>
+
+        <div id="preferencesContainer" class="hidden">
+          <div class="doorHanger">
+            <div class="row">
+              <span class="toolbarLabel caption" data-l10n-id="">Preferences</span>
+            </div>
+            <div class="row">
+              <label for="showPreviousViewOnLoad" class="toolbarLabel" data-l10n-id="">showPreviousViewOnLoad</label>
+              <input type="checkbox" id="showPreviousViewOnLoad" class="toolbarField" tabindex="">
+            </div>
+            <div class="row">
+               <label for="ifAvailableShowOutlineOnLoad" class="toolbarLabel" data-l10n-id="">ifAvailableShowOutlineOnLoad</label>
+               <input type="checkbox" id="ifAvailableShowOutlineOnLoad" class="toolbarField" tabindex="">
+            </div>
+            <div class="row">
+              <label for="defaultZoomValue" class="toolbarLabel" data-l10n-id="">defaultZoomValue</label>
+              <input id="defaultZoomValue" class="toolbarField" tabindex="">
+            </div>
+
+            <button id="preferencesReset" class="" title="Reset" tabindex="" data-l10n-id="">
+              <span data-l10n-id="">Reset</span>
+            </button>
+            <button id="preferencesClose" class="" title="Close" tabindex="" data-l10n-id="">
+              <span data-l10n-id="">Close</span>
+            </button>
           </div>
         </div>
       </div> 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -18,7 +18,7 @@
            PDFFindController, ProgressBar, TextLayerBuilder, DownloadManager,
            getFileName, scrollIntoView, getPDFFileNameFromURL, PDFHistory,
            Preferences, Settings, PageView, ThumbnailView, noContextMenuHandler,
-           SecondaryToolbar, PasswordPrompt, PresentationMode */
+           SecondaryToolbar, PasswordPrompt, PresentationMode, PreferencesUI */
 
 'use strict';
 
@@ -87,6 +87,7 @@ var currentPageNumber = 1;
 //#include secondary_toolbar.js
 //#include password_prompt.js
 //#include presentation_mode.js
+//#include preferences_ui.js
 
 var PDFView = {
   pages: [],
@@ -171,6 +172,8 @@ var PDFView = {
       pageRotateCw: document.getElementById('contextPageRotateCw'),
       pageRotateCcw: document.getElementById('contextPageRotateCcw')
     });
+
+    PreferencesUI.initialize();
 
     this.initialized = true;
     container.addEventListener('scroll', function() {


### PR DESCRIPTION
This patch is a follow-up of PR #3850, and it contains a mock-up of a UI for viewing and setting the default preferences from within the viewer. The preferences are accessed through a button placed in the secondary toolbar.

**Please note: This PR is _only_ submitted to gauge the interest in this feature, it is by no means ready to be merged in its current form!**

_If_ this functionality should be added to PDF.js, the following is an incomplete list of things that would need to be fixed before this could be merged:
- [ ] Improve the visual appearance of the UI. (Currently it looks horrible.)
- [ ] Provide more descriptive information about what the different preferences actually does.
- [ ] Localization of the strings (at least for English).
- [ ] General improvements of the code quality. (This is just a quick hack.)

I didn't really want to spend a lot of time on this, before knowing whether this functionality is wanted or not, hence the ugly appearance. Despite this, the basic functionality should be OK, so it should be possible to test this.

/cc @brendandahl
