### PR TITLE
Fix Blob creation in Safari 7.0

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1092,7 +1092,7 @@ var StatTimer = (function StatTimerClosure() {
 })();
 
 PDFJS.createBlob = function createBlob(data, contentType) {
-  if (typeof Blob === 'function')
+  if (typeof Blob !== 'undefined')
     return new Blob([data], { type: contentType });
   // Blob builder is deprecated in FF14 and removed in FF18.
   var bb = new MozBlobBuilder();


### PR DESCRIPTION
This fixes `createBlob` in Safari 7.0.
