### PR TITLE
Re-enable ‘open file’ button.

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1433,6 +1433,11 @@ canvas {
   background: white;
   color: black;
   margin-top: 5px;
+
+  visibility: hidden;
+  position: fixed;
+  right: 0;
+  top: 0;
 }
 
 #PDFBug {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1548,13 +1548,12 @@ document.addEventListener('DOMContentLoaded', function webViewerLoad(evt) {
 //}
 //#endif
 
-//#if !(FIREFOX || MOZCENTRAL || CHROME)
+//#if !(FIREFOX || MOZCENTRAL)
   var fileInput = document.createElement('input');
   fileInput.id = 'fileInput';
   fileInput.className = 'fileInput';
   fileInput.setAttribute('type', 'file');
-  fileInput.setAttribute('style',
-    'visibility: hidden; position: fixed; right: 0; top: 0');
+  fileInput.setAttribute('accept', 'application/pdf');
   fileInput.oncontextmenu = noContextMenuHandler;
   document.body.appendChild(fileInput);
 


### PR DESCRIPTION
Re-enable ‘open file’ button.

Originally disabled as a way to not violate the ‘inline script/style’ not allowed permission. We resolve the inline styling issues by moving styling to CSS. 

Also only accept PDF documents in the file dialog (yes it’s a weak form of filtering since not every OS/browser enforces it, but when it works it'll help improve the UX). As far as I know, this doesn't work on Windows but works on OSX.
