### PR TITLE
[JBIG2] Fix getting decodeParms when it's an array

### DIFF
--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 /* globals bytesToString, ColorSpace, Dict, EOF, error, info, Jbig2Image,
-           JpegImage, JpxImage, Lexer, Util, PDFJS */
+           JpegImage, JpxImage, Lexer, Util, PDFJS, isArray, warn */
 
 'use strict';
 
@@ -976,6 +976,16 @@ var Jbig2Stream = (function Jbig2StreamClosure() {
     var jbig2Image = new Jbig2Image();
 
     var chunks = [], decodeParams = this.dict.get('DecodeParms');
+
+    // According to the PDF specification, DecodeParms can be either
+    // a dictionary, or an array whose elements are dictionaries.
+    if (isArray(decodeParams)) {
+      if (decodeParams.length > 1) {
+        warn('JBIG2 - \'DecodeParms\' array with multiple elements ' +
+             'not supported.');
+      }
+      decodeParams = decodeParams[0];
+    }
     if (decodeParams && decodeParams.has('JBIG2Globals')) {
       var globalsStream = decodeParams.get('JBIG2Globals');
       var globals = globalsStream.getBytes();

--- a/test/pdfs/issue3999.pdf.link
+++ b/test/pdfs/issue3999.pdf.link
@@ -1,0 +1,1 @@
+http://www.nber.org/papers/w4332.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -98,6 +98,15 @@
       "lastPage": 4,
       "type": "eq"
     },
+    {  "id": "issue3999",
+       "file": "pdfs/issue3999.pdf",
+       "md5": "0a59cd612e93758aa9f104470f45574b",
+       "link": true,
+       "rounds": 1,
+       "firstPage": 1,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue2537",
       "file": "pdfs/issue2537.pdf",
       "md5": "f56805a70ed3aa52aae5c16dd335f827",


### PR DESCRIPTION
According to the specification, `DecodeParms` can be either a dictionary or an array of dictionaries: http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#G6.1919337.

This patch handles the case where `DecodeParms` is an array with only one element. Obviously this will not work perfectly when there are multiple dictionaries present, but without a general testcase it seemed best to just address this special case and trigger the fallback bar otherwise.  

Fixes #3999.
