### PR TITLE
Update l10n for de: hand_tool_*, password_*, fixes

### DIFF
--- a/l10n/de/viewer.properties
+++ b/l10n/de/viewer.properties
@@ -98,9 +98,9 @@ find_not_found=Ausdruck nicht gefunden
 error_more_info=Mehr Info
 error_less_info=Weniger Info
 error_close=Schließen
-# LOCALIZATION NOTE (error_build): "{{build}}" will be replaced by the PDF.JS
-# build ID.
-error_build=PDF.JS Build: {{build}}
+# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
+# replaced by the PDF.JS version and build ID.
+error_version_info=PDF.js v{{version}} (build: {{build}})
 # LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
 # english string describing the error.
 error_message=Nachricht: {{message}}
@@ -130,7 +130,6 @@ missing_file_error=Fehlende PDF-Datei.
 # the PDF spec (32000-1:2008 Table 169 – Annotation types).
 # Some common types are e.g.: "Check", "Text", "Comment", "Note"
 text_annotation_type.alt=[{{type}} Annotation]
-request_password=Die PDF-Datei ist passwortgeschützt:
 password_label=Geben Sie das Passwort ein, um diese Datei zu öffnen.
 password_invalid=Ungültiges Passwort. Versuchen Sie es erneut.
 password_ok=OK
@@ -139,3 +138,4 @@ password_cancel=Abbrechen
 printing_not_supported=Warnung: Drucken wird durch diesen Browser nicht vollständig unterstützt.
 printing_not_ready=Warnung: Die PDF-Datei ist zum Drucken noch nicht vollständig geladen.
 web_fonts_disabled=Webfonts sind deaktiviert: Eingebundene PDF-Schriftarten können nicht verwendet werden.
+# TODO: document_colors_disabled

--- a/l10n/de/viewer.properties
+++ b/l10n/de/viewer.properties
@@ -42,6 +42,8 @@ bookmark.title=Aktuelle Ansicht (Kopieren oder in einem neuen Fenster öffnen)
 bookmark_label=Aktuelle Ansicht
 
 # Secondary toolbar and context menu
+tools.title=Werkzeuge
+tools_label=Werkzeuge
 first_page.title=Erste Seite
 first_page.label=Erste Seite
 first_page_label=Erste Seite
@@ -51,9 +53,14 @@ last_page_label=Letzte Seite
 page_rotate_cw.title=Im Uhrzeigersinn drehen
 page_rotate_cw.label=Im Uhrzeigersinn drehen
 page_rotate_cw_label=Im Uhrzeigersinn drehen
-page_rotate_ccw.title=Entgegen dem Uhrzeigersinn drehen
-page_rotate_ccw.label=Entgegen dem Uhrzeigersinn drehen
-page_rotate_ccw_label=Entgegen dem Uhrzeigersinn drehen
+page_rotate_ccw.title=Gegen den Uhrzeigersinn drehen
+page_rotate_ccw.label=Gegen den Uhrzeigersinn drehen
+page_rotate_ccw_label=Gegen den Uhrzeigersinn drehen
+
+hand_tool_enable.title=Hand-Werkzeug aktivieren
+hand_tool_enable_label=Hand-Werkzeug aktivieren
+hand_tool_disable.title=Hand-Werkzeug deaktivieren
+hand_tool_disable_label=Hand-Werkzeug deaktivieren
 
 # Tooltips and alt text for side panel toolbar buttons
 # (the _label strings are alt text for the buttons, the .title strings are
@@ -104,7 +111,7 @@ error_stack=Stack: {{stack}}
 error_file=Datei: {{file}}
 # LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
 error_line=Zeile: {{line}}
-rendering_error=Das PDF konnte nicht angezeigt werden.
+rendering_error=Die PDF-Datei konnte nicht angezeigt werden.
 
 # Predefined zoom values
 page_scale_width=Seitenbreite
@@ -114,15 +121,21 @@ page_scale_actual=Originalgröße
 
 # Loading indicator messages
 loading_error_indicator=Fehler
-loading_error=Das PDF konnte nicht geladen werden.
+loading_error=Die PDF-Datei konnte nicht geladen werden.
 invalid_file_error=Ungültige oder beschädigte PDF-Datei.
+missing_file_error=Fehlende PDF-Datei.
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in
 # the PDF spec (32000-1:2008 Table 169 – Annotation types).
 # Some common types are e.g.: "Check", "Text", "Comment", "Note"
 text_annotation_type.alt=[{{type}} Annotation]
-request_password=Das PDF ist passwortgeschützt:
+request_password=Die PDF-Datei ist passwortgeschützt:
+password_label=Geben Sie das Passwort ein, um diese Datei zu öffnen.
+password_invalid=Ungültiges Passwort. Versuchen Sie es erneut.
+password_ok=OK
+password_cancel=Abbrechen
 
 printing_not_supported=Warnung: Drucken wird durch diesen Browser nicht vollständig unterstützt.
+printing_not_ready=Warnung: Die PDF-Datei ist zum Drucken noch nicht vollständig geladen.
 web_fonts_disabled=Webfonts sind deaktiviert: Eingebundene PDF-Schriftarten können nicht verwendet werden.


### PR DESCRIPTION
Comments:
Line 56-58: "Gegen den Uhrzeigersinn" is shorter and more common than "Entgegen dem Uhrzeigersinn" (http://de.wikipedia.org/wiki/Drehrichtung)

Line 60-63: "Hand-Werkzeug" is also used in Acrobat

Line 124,133,..: "PDF" is not a noun. Acrobat, Wikipedia use "PDF-Datei" (="PDF file") instead of "PDF". 
The English translation sounds just as bad: "An error occurred while loading the PDF.", "The PDF is not fully loaded for printing."

Questions:
133: "request_password" is not present in en-US. Is it necessary in DE?

Why the difference in Line 103:
en-US: error_version_info=PDF.js v{{version}} (build: {{build}})
de-DE: error_build=PDF.JS Build: {{build}}
