### PR TITLE
Fix pageNumber input field in Firefox Nightly

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -195,7 +195,7 @@ limitations under the License.
                   </button>
                 </div>
                 <label id="pageNumberLabel" class="toolbarLabel" for="pageNumber" data-l10n-id="page_label">Page: </label>
-                <input type="number" id="pageNumber" class="toolbarField pageNumber" value="1" size="4" min="1" tabindex="8">
+                <input id="pageNumber" class="toolbarField pageNumber" value="1" size="4" min="1" tabindex="8">
                 <span id="numPages" class="toolbarLabel"></span>
               </div>
               <div id="toolbarViewerRight">


### PR DESCRIPTION
With recent changes in Firefox, the pageNumber input field no longer looks right, see below.
- **This is how it _should_ look:**
  Screenshot taken in the latest Aurora (Mozilla/5.0 (Windows NT 6.1; WOW64; rv:27.0) Gecko/20100101 Firefox/27.0 ID:20131209004003 CSet: 0ff7a838c4be).
  ![aurora](https://f.cloud.github.com/assets/2692120/1708594/2d84e52a-6111-11e3-8623-2cfb5d25b95c.png)
- **This is how it looks now:**
  Screenshot taken in the latest Holly, i.e. Firefox Nightly without Australis (Mozilla/5.0 (Windows NT 6.1; WOW64; rv:28.0) Gecko/20100101 Firefox/28.0 ID:20131209081648 CSet: 894b56f8bbf5).
  ![holly](https://f.cloud.github.com/assets/2692120/1708602/577027fa-6111-11e3-88f0-48404e81a983.png)

It appears that with the improvements of HTML5 input elements, `<input type="number>"` isn't what we want to use for the pageNumber field. This patch fixes the issues by changing it to a standard `<input>` element.
