### PR TITLE
Add singlefile build target

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -545,6 +545,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
     // all requirements to run parts of pdf.js in a web worker.
     // Right now, the requirement is, that an Uint8Array is still an Uint8Array
     // as it arrives on the worker. Chrome added this with version 15.
+//#if !SINGLE_FILE
     if (!globalScope.PDFJS.disableWorker && typeof Worker !== 'undefined') {
       var workerSrc = PDFJS.workerSrc;
       if (!workerSrc) {
@@ -591,6 +592,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
         info('The worker has been disabled.');
       }
     }
+//#endif    
     // Either workers are disabled, not supported or have thrown an exception.
     // Thus, we fallback to a faked worker.
     globalScope.PDFJS.disableWorker = true;
@@ -619,7 +621,11 @@ var WorkerTransport = (function WorkerTransportClosure() {
         // pdf.worker.js file is needed.
 //#if !PRODUCTION
         Util.loadScript(PDFJS.workerSrc);
-//#else
+//#endif
+//#if PRODUCTION && SINGLE_FILE
+//      PDFJS.fakeWorkerFilesLoadedPromise.resolve();
+//#endif
+//#if PRODUCTION && !SINGLE_FILE
 //      Util.loadScript(PDFJS.workerSrc, function() {
 //        PDFJS.fakeWorkerFilesLoadedPromise.resolve();
 //      });


### PR DESCRIPTION
Adds a 'singlefile' target in make.js, which concatenates pdf.js and pdf.worker.js into a single pdf.combined.js file within the singlefile build directory.

A SINGLE_FILE preprocessor define is also set, which adjusts the workerSrc loading code to not attempt to load an external pdf.worker.js file and instead immediately resolve the promise.

Note: this is a second attempt at implementing the use case described in https://github.com/mozilla/pdf.js/pull/3947 . I'm not sure if I used the right #if / #else preprocessor syntax, but the builder doesn't seem to support #elsif, which would have led to more natural code there. Happy to take other advice / feedback into account here.
