### PR TITLE
Fix setScale regression that affects exiting Presentation Mode on narrow window widths

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -206,19 +206,37 @@ var PDFView = {
     }, true);
   },
 
+  _setScaleUpdatePages: function pdfView_setScaleUpdatePages(
+      newScale, newValue, resetAutoSettings, noScroll) {
+    this.currentScaleValue = newValue;
+    if (newScale === this.currentScale) {
+      return;
+    }
+    for (var i = 0, ii = this.pages.length; i < ii; i++) {
+      this.pages[i].update(newScale);
+    }
+    this.currentScale = newScale;
+
+    if (!noScroll) {
+      this.pages[this.page - 1].scrollIntoView();
+    }
+    var event = document.createEvent('UIEvents');
+    event.initUIEvent('scalechange', false, false, window, 0);
+    event.scale = newScale;
+    event.resetAutoSettings = resetAutoSettings;
+    window.dispatchEvent(event);
+  },
+
   setScale: function pdfViewSetScale(value, resetAutoSettings, noScroll) {
     if (value === 'custom') {
       return;
     }
-    var pages = this.pages;
-    var currentPage = pages[this.page - 1];
-    var number = parseFloat(value);
-    var scale;
+    var scale = parseFloat(value);
 
-    if (number > 0) {
-      scale = number;
-      resetAutoSettings = true;
+    if (scale > 0) {
+      this._setScaleUpdatePages(scale, value, true, noScroll);
     } else {
+      var currentPage = this.pages[this.page - 1];
       if (!currentPage) {
         return;
       }
@@ -247,28 +265,8 @@ var PDFView = {
                         '\' is an unknown zoom value.');
           return;
       }
-    }
-    this.currentScaleValue = value;
+      this._setScaleUpdatePages(scale, value, resetAutoSettings, noScroll);
 
-    if (scale === this.currentScale) {
-      return;
-    }
-    for (var i = 0, ii = pages.length; i < ii; i++) {
-      pages[i].update(scale);
-    }
-    this.currentScale = scale;
-
-    if (!noScroll) {
-      currentPage.scrollIntoView();
-    }
-
-    var event = document.createEvent('UIEvents');
-    event.initUIEvent('scalechange', false, false, window, 0);
-    event.scale = scale;
-    event.resetAutoSettings = resetAutoSettings;
-    window.dispatchEvent(event);
-
-    if (!number) {
       selectScaleOption(value);
     }
   },


### PR DESCRIPTION
On narrow window widths, the zoom value will not be reset properly when exiting Presentation Mode.
- **Before** entering Presentation Mode:
  ![before](https://f.cloud.github.com/assets/2692120/1749369/40c7c092-650f-11e3-9c9c-f3f39e9f8231.png)
- **After** entering and then exiting Presentation Mode:
  ![after](https://f.cloud.github.com/assets/2692120/1749371/5316dcec-650f-11e3-8a5a-e9aaec810e83.png)

I have bisected this, and found that this regressed in #3787 (meaning it's my fault).
After looking into this, the only working solution unfortunately seems to be to revert the changes made in #3787. Given that other PRs have touched the `setScale` code in the meantime, just backing out the offending commit isn't possible. Hence I've manually extracted the necessary code into a new function.
