### PR TITLE
Add unprefixed "grab" / "grabbing" values for cursor

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1503,12 +1503,14 @@ canvas {
   cursor: url("images/grab.cur"), move !important;
   cursor: -webkit-grab !important;
   cursor: -moz-grab !important;
+  cursor: grab !important;
 }
 .grab-to-pan-grabbing,
 .grab-to-pan-grabbing * {
   cursor: url("images/grabbing.cur"), move !important;
   cursor: -webkit-grabbing !important;
   cursor: -moz-grabbing !important;
+  cursor: grabbing !important;
 }
 .grab-to-pan-grab input,
 .grab-to-pan-grab textarea,


### PR DESCRIPTION
Unprefixed "grab" / "grabbing" values of cursor will land in Firefox 27.
 (https://bugzilla.mozilla.org/show_bug.cgi?id=880672)
 (https://github.com/Rob--W/grab-to-pan.js/commit/fda961a3)
