### PR TITLE
Small cleanup in 'set page'

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -295,7 +295,6 @@ var PDFView = {
 
   set page(val) {
     var pages = this.pages;
-    var input = document.getElementById('pageNumber');
     var event = document.createEvent('UIEvents');
     event.initUIEvent('pagechange', false, false, window, 0);
 
@@ -314,13 +313,13 @@ var PDFView = {
 
     // checking if the this.page was called from the updateViewarea function:
     // avoiding the creation of two "set page" method (internal and public)
-    if (updateViewarea.inProgress)
+    if (updateViewarea.inProgress) {
       return;
-
+    }
     // Avoid scrolling the first page during loading
-    if (this.loading && val == 1)
+    if (this.loading && val === 1) {
       return;
-
+    }
     pages[val - 1].scrollIntoView();
   },
 


### PR DESCRIPTION
Currently on every call to [`set page`](https://github.com/mozilla/pdf.js/blob/master/web/viewer.js#L298) a reference to the pageNumber input element is fetched from the DOM, even though this not used anywhere in the function after that. From using git blame, it appears that this hasn't been used since the custom `pagechange` event was introduced.

This PR simply removes what is now a meaningless piece of code. Since this patch is so small, I also took the liberty of fixing a few small coding style issues (braces for single line statements and strict equalities) in `set page`.
