### PR TITLE
Rename 'Settings' to 'ViewHistory'

### DIFF
--- a/web/view_history.js
+++ b/web/view_history.js
@@ -14,39 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS, SETTINGS_MEMORY */
+/* globals PDFJS, VIEW_HISTORY_MEMORY, isLocalStorageEnabled */
 
 'use strict';
 
 /**
- * Settings Manager - This is a utility for saving settings.
+ * View History - This is a utility for saving various view parameters for
+ *                recently opened files.
  *
- * The way that settings are stored depends on how PDF.js is built,
+ * The way that the view parameters are stored depends on how PDF.js is built,
  * for 'node make <flag>' the following cases exist:
  *  - FIREFOX or MOZCENTRAL - uses about:config.
  *  - B2G                   - uses asyncStorage.
  *  - GENERIC or CHROME     - uses localStorage, if it is available.
  */
-var Settings = (function SettingsClosure() {
-//#if !(FIREFOX || MOZCENTRAL || B2G)
-  var isLocalStorageEnabled = (function localStorageEnabledTest() {
-    // Feature test as per http://diveintohtml5.info/storage.html
-    // The additional localStorage call is to get around a FF quirk, see
-    // bug #495747 in bugzilla
-    try {
-      return ('localStorage' in window && window['localStorage'] !== null &&
-              localStorage);
-    } catch (e) {
-      return false;
-    }
-  })();
-//#endif
-
-  function Settings(fingerprint) {
+var ViewHistory = (function ViewHistoryClosure() {
+  function ViewHistory(fingerprint) {
     this.fingerprint = fingerprint;
     this.initializedPromise = new PDFJS.Promise();
 
-    var resolvePromise = (function settingsResolvePromise(db) {
+    var resolvePromise = (function ViewHistoryResolvePromise(db) {
       this.initialize(db || '{}');
       this.initializedPromise.resolve();
     }).bind(this);
@@ -66,13 +53,13 @@ var Settings = (function SettingsClosure() {
 //#endif
   }
 
-  Settings.prototype = {
-    initialize: function settingsInitialize(database) {
+  ViewHistory.prototype = {
+    initialize: function ViewHistory_initialize(database) {
       database = JSON.parse(database);
       if (!('files' in database)) {
         database.files = [];
       }
-      if (database.files.length >= SETTINGS_MEMORY) {
+      if (database.files.length >= VIEW_HISTORY_MEMORY) {
         database.files.shift();
       }
       var index;
@@ -90,7 +77,7 @@ var Settings = (function SettingsClosure() {
       this.database = database;
     },
 
-    set: function settingsSet(name, val) {
+    set: function ViewHistory_set(name, val) {
       if (!this.initializedPromise.isResolved) {
         return;
       }
@@ -113,7 +100,7 @@ var Settings = (function SettingsClosure() {
 //#endif
     },
 
-    get: function settingsGet(name, defaultValue) {
+    get: function ViewHistory_get(name, defaultValue) {
       if (!this.initializedPromise.isResolved) {
         return defaultValue;
       }
@@ -121,5 +108,5 @@ var Settings = (function SettingsClosure() {
     }
   };
 
-  return Settings;
+  return ViewHistory;
 })();

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -65,7 +65,7 @@ limitations under the License.
     <script type="text/javascript" src="default_preferences.js"></script>
     <script type="text/javascript" src="preferences.js"></script>
     <script type="text/javascript" src="download_manager.js"></script>
-    <script type="text/javascript" src="settings.js"></script>
+    <script type="text/javascript" src="view_history.js"></script>
     <script type="text/javascript" src="page_view.js"></script>
     <script type="text/javascript" src="thumbnail_view.js"></script>
     <script type="text/javascript" src="text_layer_builder.js"></script>

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -17,8 +17,9 @@
 /* globals PDFJS, PDFBug, FirefoxCom, Stats, Cache, PDFFindBar, CustomStyle,
            PDFFindController, ProgressBar, TextLayerBuilder, DownloadManager,
            getFileName, scrollIntoView, getPDFFileNameFromURL, PDFHistory,
-           Preferences, Settings, PageView, ThumbnailView, noContextMenuHandler,
-           SecondaryToolbar, PasswordPrompt, PresentationMode, HandTool */
+           Preferences, ViewHistory, PageView, ThumbnailView,
+           noContextMenuHandler, SecondaryToolbar, PasswordPrompt,
+           PresentationMode, HandTool */
 
 'use strict';
 
@@ -33,7 +34,7 @@ var VERTICAL_PADDING = 5;
 var MAX_AUTO_SCALE = 1.25;
 var MIN_SCALE = 0.25;
 var MAX_SCALE = 4.0;
-var SETTINGS_MEMORY = 20;
+var VIEW_HISTORY_MEMORY = 20;
 var SCALE_SELECT_CONTAINER_PADDING = 8;
 var SCALE_SELECT_PADDING = 22;
 var THUMBNAIL_SCROLL_MARGIN = -19;
@@ -80,7 +81,7 @@ var mozL10n = document.mozL10n || document.webL10n;
 var cache = new Cache(CACHE_SIZE);
 var currentPageNumber = 1;
 
-//#include settings.js
+//#include view_history.js
 //#include pdf_find_bar.js
 //#include pdf_find_controller.js
 //#include pdf_history.js
@@ -832,7 +833,7 @@ var PDFView = {
 
     var prefs = PDFView.prefs = new Preferences();
     PDFView.documentFingerprint = id;
-    var store = PDFView.store = new Settings(id);
+    var store = PDFView.store = new ViewHistory(id);
 
     this.pageRotation = 0;
 


### PR DESCRIPTION
This PR renames `Settings` to `ViewHistory`, as was suggested by @brendandahl [previously](https://github.com/mozilla/pdf.js/pull/3255#issuecomment-26374851).

Beside the renaming, this patch also removes `isLocalStorageEnabled` to reduce unnecessary code duplication, since this function is available in [ui_utils.js](https://github.com/mozilla/pdf.js/blob/master/web/ui_utils.js#L259).
