### PR TITLE
Fix thumbnail rotation regression

### DIFF
--- a/web/thumbnail_view.js
+++ b/web/thumbnail_view.js
@@ -29,7 +29,7 @@ var ThumbnailView = function thumbnailView(container, id, defaultViewport) {
 
   this.pdfPage = undefined;
   this.viewport = defaultViewport;
-  this.pdfPageRotate = defaultViewport.rotate;
+  this.pdfPageRotate = defaultViewport.rotation;
 
   this.rotation = 0;
   this.pageWidth = this.viewport.width;
@@ -66,20 +66,16 @@ var ThumbnailView = function thumbnailView(container, id, defaultViewport) {
   this.setPdfPage = function thumbnailViewSetPdfPage(pdfPage) {
     this.pdfPage = pdfPage;
     this.pdfPageRotate = pdfPage.rotate;
-    this.viewport = pdfPage.getViewport(1);
+    var totalRotation = (this.rotation + this.pdfPageRotate) % 360;
+    this.viewport = pdfPage.getViewport(1, totalRotation);
     this.update();
   };
 
-  this.update = function thumbnailViewUpdate(rot) {
-    if (!this.pdfPage) {
-      return;
+  this.update = function thumbnailViewUpdate(rotation) {
+    if (rotation !== undefined) {
+      this.rotation = rotation;
     }
-
-    if (rot !== undefined) {
-      this.rotation = rot;
-    }
-
-    var totalRotation = (this.rotation + this.pdfPage.rotate) % 360;
+    var totalRotation = (this.rotation + this.pdfPageRotate) % 360;
     this.viewport = this.viewport.clone({
       scale: 1,
       rotation: totalRotation
@@ -179,8 +175,17 @@ var ThumbnailView = function thumbnailView(container, id, defaultViewport) {
   };
 
   this.setImage = function thumbnailViewSetImage(img) {
-    if (this.hasImage || !img)
+    if (!this.pdfPage) {
+      var promise = PDFView.getPage(this.id);
+      promise.then(function(pdfPage) {
+        this.setPdfPage(pdfPage);
+        this.setImage(img);
+      }.bind(this));
       return;
+    }
+    if (this.hasImage || !img) {
+      return;
+    }
     this.renderingState = RenderingStates.FINISHED;
     var ctx = this.getPageDrawContext();
     ctx.drawImage(img, 0, 0, img.width, img.height,

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1370,7 +1370,7 @@ var PDFView = {
       div.removeChild(div.lastChild);
   },
 
-  rotatePages: function pdfViewPageRotation(delta) {
+  rotatePages: function pdfViewRotatePages(delta) {
 
     this.pageRotation = (this.pageRotation + 360 + delta) % 360;
 


### PR DESCRIPTION
This PR fixes a fairly recent regression that causes the thumbnails to not be rotated properly. The PRs responsible for the regression should be #3848, and to some extent #3978. The rotation issue might, for example, look like this:
![thumbs_rotation](https://f.cloud.github.com/assets/2692120/1809117/2bdddfec-6daf-11e3-81be-b10eb1590def.png)

In this patch, besides fixing the regression, I've also made sure that thumbnail rotations are handled the same way as page rotations. (Basically PR #3971, but for thumbnails.)

Note that the reason that I didn't add the thumbnail equivalent of this code: https://github.com/mozilla/pdf.js/blob/master/web/viewer.js#L871-L874, is that it isn't necessary and it also wouldn't help when `disableAutoFetch = true`.
