### PR TITLE
Maintain the current position in the document when zooming

### DIFF
--- a/web/page_view.js
+++ b/web/page_view.js
@@ -400,16 +400,10 @@ var PageView = function pageView(container, id, scale,
       this.viewport.convertToViewportPoint(x, y),
       this.viewport.convertToViewportPoint(x + width, y + height)
     ];
-    setTimeout(function pageViewScrollIntoViewRelayout() {
-      // letting page to re-layout before scrolling
-      var scale = PDFView.currentScale;
-      var x = Math.min(boundingRect[0][0], boundingRect[1][0]);
-      var y = Math.min(boundingRect[0][1], boundingRect[1][1]);
-      var width = Math.abs(boundingRect[0][0] - boundingRect[1][0]);
-      var height = Math.abs(boundingRect[0][1] - boundingRect[1][1]);
+    var left = Math.min(boundingRect[0][0], boundingRect[1][0]);
+    var top = Math.min(boundingRect[0][1], boundingRect[1][1]);
 
-      scrollIntoView(div, {left: x, top: y, width: width, height: height});
-    }, 0);
+    scrollIntoView(div, { left: left, top: top });
   };
 
   this.getTextContent = function pageviewGetTextContent() {


### PR DESCRIPTION
This is my third, and hopefully final, attempt to fix #1521 (previous failed attempts were PRs #3446 and #3513).

This PR is slightly more complicated than the previous versions, but I don't think that can be avoided in order to handle all edge cases correctly in different browsers.

I've tested this patch successfully in Firefox, Chrome and IE. Since the previous PRs seemed to cause different issues on different systems, this needs to be tested **_thoroughly_** before we even consider merging it!

/cc @brendandahl

_Note that this PR depends on #4034, since it includes the code contained in that patch._
