### PR TITLE
Miscellaneous B2G viewer fixes [WIP]

### DIFF
--- a/web/hand_tool.js
+++ b/web/hand_tool.js
@@ -22,6 +22,9 @@
 var HandTool = {
   initialize: function handToolInitialize(options) {
     var toggleHandTool = options.toggleHandTool;
+    if (!toggleHandTool) {
+      return;
+    }
     this.handTool = new GrabToPan({
       element: options.container,
       onActiveChanged: function(isActive) {
@@ -43,6 +46,9 @@ var HandTool = {
   },
 
   toggle: function handToolToggle() {
+    if (!this.handTool) {
+      return;
+    }
     this.handTool.toggle();
   },
 


### PR DESCRIPTION
After merging some PRs, the B2G viewer had some issues displaying documents properly. This PR fixes the following B2G viewer problems:
1. Stop initializing the hand tool in the B2G viewer: the B2G viewer stopped rendering pages because `toggleHandTool` was `null`. We now disable the hand tool if the toggle button is not available.

To do:
- [ ] B2G viewer is only rendering when scrolling down a little bit. It should render immediately. This seems to have regressed in #3978. /cc @brendandahl 
