### PR TITLE
Fix annotation border issue (bug 957034)

### DIFF
--- a/src/shared/annotation.js
+++ b/src/shared/annotation.js
@@ -98,6 +98,29 @@ var Annotation = (function AnnotationClosure() {
     } else {
       var borderArray = dict.get('Border') || [0, 0, 1];
       data.borderWidth = borderArray[2] || 0;
+
+      // TODO: implement proper support for annotations with line dash patterns.
+      var dashArray = borderArray[3];
+      if (dashArray && isArray(dashArray)) {
+        var dashArrayLength = dashArray.length;
+        if (dashArrayLength > 0) {
+          // According to the PDF specification: the elements in a dashArray
+          // shall be numbers that are nonnegative and not all equal to zero.
+          var isInvalid = false;
+          var numPositive = 0;
+          for (var i = 0; i < dashArrayLength; i++) {
+            if (!(+dashArray[i] >= 0)) {
+              isInvalid = true;
+              break;
+            } else if (dashArray[i] > 0) {
+              numPositive++;
+            }
+          }
+          if (isInvalid || numPositive === 0) {
+            data.borderWidth = 0;
+          }
+        }
+      }
     }
 
     this.appearance = getDefaultAppearance(dict);


### PR DESCRIPTION
According to the PDF specification, the `Border` entry in an Annotation dictionary may contain a line dash pattern: http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#page=392.
The line dash pattern is outlined here: http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#M7.9.24210.3Heading.Line.Dash.Pattern.

The PDF file in [bug 957034](https://bugzilla.mozilla.org/show_bug.cgi?id=957034) contains link annotations with `Border` entries of the form `[10 10 10 [0]]`, which means that the links should have 10 unit wide borders with a line dash pattern of `[0]`.
According to the PDF specification, the entries in dashArray must obey: "the numbers shall be nonnegative and not all zero". This means that the line dash pattern used in the PDF file isn't valid (i.e. yet another bad PDF generator).

I don't know if assigning the border a width of zero when the line dash pattern is invalid is the right thing to do, but it does solve the issue, and it appears to be what happens in Adobe Reader.

_Since this issue should hopefully be rare, I didn't know if it was really necessary to include a test case._

Fixes [bug 957034](https://bugzilla.mozilla.org/show_bug.cgi?id=957034).
