### PR TITLE
Move hand tool initialization to secondary toolbar

### DIFF
--- a/web/hand_tool.js
+++ b/web/hand_tool.js
@@ -36,9 +36,8 @@ var HandTool = {
           toggleHandTool.firstElementChild.textContent =
             mozL10n.get('hand_tool_enable_label', null, 'Enable hand tool');
         }
-    }
+      }
     });
-    toggleHandTool.addEventListener('click', this.handTool.toggle, false);
     // TODO: Read global prefs and call this.handTool.activate() if needed.
   },
 

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFView, SCROLLBAR_PADDING */
+/* globals PDFView, SCROLLBAR_PADDING, HandTool */
 
 'use strict';
 
@@ -38,6 +38,7 @@ var SecondaryToolbar = {
     this.lastPage = options.lastPage;
     this.pageRotateCw = options.pageRotateCw;
     this.pageRotateCcw = options.pageRotateCcw;
+    this.handToolButton = options.handToolButton;
 
     // Attach the event listeners.
     var elements = [
@@ -50,7 +51,8 @@ var SecondaryToolbar = {
       { element: this.firstPage, handler: this.firstPageClick },
       { element: this.lastPage, handler: this.lastPageClick },
       { element: this.pageRotateCw, handler: this.pageRotateCwClick },
-      { element: this.pageRotateCcw, handler: this.pageRotateCcwClick }
+      { element: this.pageRotateCcw, handler: this.pageRotateCcwClick },
+      { element: this.handToolButton, handler: this.handToolClick }
     ];
 
     for (var item in elements) {
@@ -96,6 +98,10 @@ var SecondaryToolbar = {
 
   pageRotateCcwClick: function secondaryToolbarPageRotateCcwClick(evt) {
     PDFView.rotatePages(-90);
+  },
+
+  handToolClick: function secondaryToolbarHandToolClick(evt) {
+    HandTool.toggle();
   },
 
   // Misc. functions for interacting with the toolbar.

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -159,7 +159,8 @@ var PDFView = {
       firstPage: document.getElementById('firstPage'),
       lastPage: document.getElementById('lastPage'),
       pageRotateCw: document.getElementById('pageRotateCw'),
-      pageRotateCcw: document.getElementById('pageRotateCcw')
+      pageRotateCcw: document.getElementById('pageRotateCcw'),
+      handToolButton: document.getElementById('toggleHandTool')
     });
 
     PasswordPrompt.initialize({


### PR DESCRIPTION
Supersedes #4076 and fixes the B2G viewer (currently it's broken because it would attempt to initialize the hand tool).
