### PR TITLE
Update the annotationLayer when using CSS only zoom

### DIFF
--- a/web/page_view.js
+++ b/web/page_view.js
@@ -184,6 +184,10 @@ var PageView = function pageView(container, id, scale,
                             'translate(' + transX + ', ' + transY + ')');
       CustomStyle.setProp('transformOrigin', textLayerDiv, '0% 0%');
     }
+
+    if (USE_ONLY_CSS_ZOOM && this.annotationLayer) {
+      setupAnnotations(div, this.pdfPage, this.viewport);
+    }
   };
 
   Object.defineProperty(this, 'width', {


### PR DESCRIPTION
Currently when using CSS only zoom, the annotationLayer will not be updated. This causes links, and other annotations, to be placed in the wrong positions when the document is zoomed.

To see this issue in action, open: http://arxiv.org/pdf/1112.0542v1.pdf#useOnlyCssZoom=true; and then zoom the document. Note how the position of the links isn't updated.

This patch thus fixes an issue that regressed in #3727.
