### PR TITLE
Prevent the open file button from appearing in the B2G viewer/preview

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1567,7 +1567,7 @@ document.addEventListener('DOMContentLoaded', function webViewerLoad(evt) {
 //}
 //#endif
 
-//#if !(FIREFOX || MOZCENTRAL || CHROME)
+//#if !(FIREFOX || MOZCENTRAL || CHROME || B2G)
   var fileInput = document.createElement('input');
   fileInput.id = 'fileInput';
   fileInput.className = 'fileInput';


### PR DESCRIPTION
Fixes a small regression caused by #4120. We do not want the open file button to appear in the B2G viewer at all.
