### PR TITLE
Fix regression that disabled the "Open With Different Viewer" button on the fallback bar

### DIFF
--- a/extensions/firefox/components/PdfStreamConverter.js
+++ b/extensions/firefox/components/PdfStreamConverter.js
@@ -377,7 +377,10 @@ ChromeActions.prototype = {
         break;
     }
   },
-  fallback: function(featureId, url, sendResponse) {
+  fallback: function(args, sendResponse) {
+    var featureId = args.featureId;
+    var url = args.url;
+
     var self = this;
     var domWindow = this.domWindow;
     var strings = getLocalizedStrings('chrome.properties');

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -615,11 +615,13 @@ var PDFView = {
 //    return;
 //  this.fellback = true;
 //  var url = this.url.split('#')[0];
-//  FirefoxCom.request('fallback', featureId, url, function response(download) {
-//    if (!download)
-//      return;
-//    PDFView.download();
-//  });
+//  FirefoxCom.request('fallback', { featureId: featureId, url: url },
+//    function response(download) {
+//      if (!download) {
+//        return;
+//      }
+//      PDFView.download();
+//    });
 //#endif
   },
 


### PR DESCRIPTION
Clicking the "Open With Different Viewer" button on the fallback bar fails, because we no longer provide a callback to `FirefoxCom.request` (see: https://github.com/mozilla/pdf.js/blob/master/web/firefoxcom.js#L51).

Note that this could equally well be solved by just removing the `url` parameter, since it doesn't appear to be used anywhere in the code, but I wasn't sure if there was a reason for including this parameter. _I'll be happy to update the PR with this change instead!_

This regressed in PR #4077.
