### PR TITLE
Close the secondary toolbar when an action is performed once

### DIFF
--- a/web/hand_tool.js
+++ b/web/hand_tool.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals mozL10n, GrabToPan, PDFView */
+/* globals mozL10n, GrabToPan, PDFView, SecondaryToolbar */
 
 'use strict';
 
@@ -42,13 +42,14 @@ var HandTool = {
       }
     });
     if (toggleHandTool) {
-      toggleHandTool.addEventListener('click', this.handTool.toggle, false);
+      toggleHandTool.addEventListener('click', this.toggle.bind(this), false);
     }
     // TODO: Read global prefs and call this.handTool.activate() if needed.
   },
 
   toggle: function handToolToggle() {
     this.handTool.toggle();
+    SecondaryToolbar.close();
   },
 
   enterPresentationMode: function handToolEnterPresentationMode() {

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -34,6 +34,7 @@ var SecondaryToolbar = {
     this.openFile = options.openFile;
     this.print = options.print;
     this.download = options.download;
+    this.viewBookmark = options.viewBookmark;
     this.firstPage = options.firstPage;
     this.lastPage = options.lastPage;
     this.pageRotateCw = options.pageRotateCw;
@@ -50,6 +51,7 @@ var SecondaryToolbar = {
       { element: this.openFile, handler: this.openFileClick },
       { element: this.print, handler: this.printClick },
       { element: this.download, handler: this.downloadClick },
+      { element: this.viewBookmark, handler: this.viewBookmarkClick },
       { element: this.firstPage, handler: this.firstPageClick },
       { element: this.lastPage, handler: this.lastPageClick },
       { element: this.pageRotateCw, handler: this.pageRotateCwClick },
@@ -85,12 +87,18 @@ var SecondaryToolbar = {
     this.close(evt.target);
   },
 
+  viewBookmarkClick: function secondaryToolbarViewBookmarkClick(evt) {
+    this.close();
+  },
+
   firstPageClick: function secondaryToolbarFirstPageClick(evt) {
     PDFView.page = 1;
+    this.close();
   },
 
   lastPageClick: function secondaryToolbarLastPageClick(evt) {
     PDFView.page = PDFView.pdfDocument.numPages;
+    this.close();
   },
 
   pageRotateCwClick: function secondaryToolbarPageRotateCwClick(evt) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -158,6 +158,7 @@ var PDFView = {
       openFile: document.getElementById('secondaryOpenFile'),
       print: document.getElementById('secondaryPrint'),
       download: document.getElementById('secondaryDownload'),
+      viewBookmark: document.getElementById('secondaryViewBookmark'),
       firstPage: document.getElementById('firstPage'),
       lastPage: document.getElementById('lastPage'),
       pageRotateCw: document.getElementById('pageRotateCw'),


### PR DESCRIPTION
Fixes #4009.
- Makes sure the secondary toolbar closes when using the first page/last page/hand tool toggle buttons, as they are usually only used once (not used in succession).
- Fixes a bug in the hand tool implementation where the `this.toggle()` function of the object was never called.
- Adds the `viewBookmark` button to the secondary toolbar because it was missing and so we can close the secondary toolbar after clicking the button (also usually used once to quickly get a bookmark link).
