### PR TITLE
Fix linearization error messages

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -698,7 +698,7 @@ var Linearization = (function LinearizationClosure() {
           obj > 0) {
         return obj;
       }
-      error('"' + name + '" field in linearization table is invalid');
+      info('"' + name + '" field in linearization table is invalid');
     },
     getHint: function Linearization_getHint(index) {
       var linDict = this.linDict;
@@ -710,7 +710,7 @@ var Linearization = (function LinearizationClosure() {
           obj2 > 0) {
         return obj2;
       }
-      error('Hints table in linearization table is invalid: ' + index);
+      info('Hints table in linearization table is invalid: ' + index);
     },
     get length() {
       if (!isDict(this.linDict))


### PR DESCRIPTION
Since (valid) linearization data shouldn't be necessary to load and render a PDF file, I've changed two instances of `error` to `info` so that we can avoid displaying unnecessary warnings and triggering the fallback bar.

Given that files with invalid linearization dictionaries (e.g. the PDF in #4143) already displays fine, I don't think that we need to throw errors. _I hope this assumption in correct!_

Fixes #4143.
