### PR TITLE
Recover from bad URI values

### DIFF
--- a/src/shared/annotation.js
+++ b/src/shared/annotation.js
@@ -640,7 +640,13 @@ var LinkAnnotation = (function LinkAnnotationClosure() {
     if (action) {
       var linkType = action.get('S').name;
       if (linkType === 'URI') {
-        var url = addDefaultProtocolToUrl(action.get('URI'));
+        var url = action.get('URI');
+        if (isName(url)) {
+          // Some bad PDFs do not put parentheses around relative URLs.
+          url = '/' + url.name;
+        } else {
+          url = addDefaultProtocolToUrl(url);
+        }
         // TODO: pdf spec mentions urls can be relative to a Base
         // entry in the dictionary.
         if (!isValidUrl(url, false)) {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -223,7 +223,7 @@ var UnsupportedManager = PDFJS.UnsupportedManager =
 function combineUrl(baseUrl, url) {
   if (!url)
     return baseUrl;
-  if (url.indexOf(':') >= 0)
+  if (/^[a-z][a-z0-9+\-.]*:/i.test(url))
     return url;
   if (url.charAt(0) == '/') {
     // absolute path
@@ -247,11 +247,13 @@ function isValidUrl(url, allowRelative) {
   if (!url) {
     return false;
   }
-  var colon = url.indexOf(':');
-  if (colon < 0) {
+  // RFC 3986 (http://tools.ietf.org/html/rfc3986#section-3.1)
+  // scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+  var protocol = /^[a-z][a-z0-9+\-.]*(?=:)/i.exec(url);
+  if (!protocol) {
     return allowRelative;
   }
-  var protocol = url.substr(0, colon);
+  protocol = protocol[0].toLowerCase();
   switch (protocol) {
     case 'http':
     case 'https':


### PR DESCRIPTION
This PR fixes issue #4159.

The PDF file in #4159 is malformed:

```
BAD (testo.pdf):
<< /S /URI /URI /v#2findex.php#2fFile:Logo.png >>
GOOD (practice.pdf):
<< /S /URI /URI (http://127.0.0.1/v/index.php/File:Logo.png >>
```

The URL should be wrapped in parentheses, but it isn't. Consequently, the blob is interpreted as a Name (because of the leading "/"), and the resulting object is `{name: "v/index.php/File:Logo.png" }`. Obviously, this is not a string, so `url.indexOf` throws an error here.

I have also adjusted the URL parsing code to make it RFC 3986-compliant, to avoid mis-interpreting "/v/index.php/File:Logo.png" as an invalid URL. Now the validation function returns true if relative URLs are accepted.
