### PR TITLE
Only check for line dash pattern when annotation has a visible border (bug 957034 followup)

### DIFF
--- a/src/shared/annotation.js
+++ b/src/shared/annotation.js
@@ -101,7 +101,7 @@ var Annotation = (function AnnotationClosure() {
 
       // TODO: implement proper support for annotations with line dash patterns.
       var dashArray = borderArray[3];
-      if (dashArray && isArray(dashArray)) {
+      if (data.borderWidth > 0 && dashArray && isArray(dashArray)) {
         var dashArrayLength = dashArray.length;
         if (dashArrayLength > 0) {
           // According to the PDF specification: the elements in a dashArray


### PR DESCRIPTION
This fixes a _very_ minor oversight on my part in PR #4080.
We only need to check for the existence of an invalid line dash pattern if there is an actual border width specified, since otherwise there really is no point in doing all of these checks.

Sorry about not catching this initially!
