### PR TITLE
Miscellaneous improvements for the document properties dialog

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -63,12 +63,12 @@ hand_tool_disable.title=Disable hand tool
 hand_tool_disable_label=Disable hand tool
 
 # Document properties dialog box
-document_properties.title=Document Properties
-document_properties_label=Document Properties
+document_properties.title=Document Properties…
+document_properties_label=Document Properties…
 document_properties_file_name=File name:
 document_properties_file_size=File size:
-document_properties_kb={{size_kb}} KB
-document_properties_mb={{size_mb}} MB
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
 document_properties_title=Title:
 document_properties_author=Author:
 document_properties_subject=Subject:

--- a/l10n/nl/viewer.properties
+++ b/l10n/nl/viewer.properties
@@ -63,12 +63,12 @@ hand_tool_disable.title=Handcursor uitschakelen
 hand_tool_disable_label=Handcursor uitschakelen
 
 # Document properties dialog box
-document_properties.title=Documenteigenschappen
-document_properties_label=Documenteigenschappen
+document_properties.title=Documenteigenschappen…
+document_properties_label=Documenteigenschappen…
 document_properties_file_name=Bestandsnaam:
 document_properties_file_size=Bestandsgrootte:
-document_properties_kb={{size_kb}} KB
-document_properties_mb={{size_mb}} MB
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
 document_properties_title=Titel:
 document_properties_author=Auteur:
 document_properties_subject=Onderwerp:

--- a/web/password_prompt.js
+++ b/web/password_prompt.js
@@ -48,7 +48,7 @@ var PasswordPrompt = {
         }
       }.bind(this));
 
-    this.overlayContainer.addEventListener('keydown',
+    window.addEventListener('keydown',
       function (e) {
         if (e.keyCode === 27) { // Esc key
           this.hide();

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1486,6 +1486,16 @@ html[dir='rtl'] #documentPropertiesContainer .row > * {
   text-align: right;
 }
 
+#documentPropertiesContainer .row span {
+  width: 125px;
+  word-wrap: break-word;
+}
+
+#documentPropertiesContainer .row p {
+  max-width: 225px;
+  word-wrap: break-word;
+}
+
 #documentPropertiesContainer .buttonRow {
   margin-top: 10px;
   text-align: center;

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -175,8 +175,8 @@ limitations under the License.
             
             <div class="horizontalToolbarSeparator"></div>
 
-            <button id="documentProperties" class="secondaryToolbarButton documentProperties" title="Document Properties" tabindex="28" data-l10n-id="document_properties">
-              <span data-l10n-id="document_properties_label">Document Properties</span>
+            <button id="documentProperties" class="secondaryToolbarButton documentProperties" title="Document Properties…" tabindex="28" data-l10n-id="document_properties">
+              <span data-l10n-id="document_properties_label">Document Properties…</span>
             </button>
           </div>
         </div>  <!-- secondaryToolbar -->


### PR DESCRIPTION
This PR finetunes the document properties implemention from #4149. The following changes have been made:
- Implements closing the document properties dialog with the Esc key. It also fixes a bug in the password 
  prompt where it would only be closed if focus was in the text field (which is important to have consistent behaviour).
- Adds an ellipsis to the document properties menu item in the l10n files.
- Adds the improved `setFileSize` function as provided by @Rob--W including the required localization.
- Adds wrapping for property fields to fix an issue where a very long file name would exceed the dialog
  width (you can use http://www.kennemerlyceum.nl/attachments/article/4/Toelatingsbeleid%202014-2015%20%28laatst%20gewijzigd%20op%206%20november%202013%29.pdf to verify this fix).
- Fixes a small issue when the property text was too long, causing the view to be misaligned (as reported
  by @Rob--W).
- Fixes number formatting as discussed with @yurydelendik.
- Fixes an issue where the add-on version would show the entire URL instead of only the file name in the
  document properties dialog (you can use http://www.kennemerlyceum.nl/attachments/article/4/Toelatingsbeleid%202014-2015%20%28laatst%20gewijzigd%20op%206%20november%202013%29.pdf to verify the fix).
