### PR TITLE
Reduce memory consumption of simple black and white images.

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -165,7 +165,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           (w + h) < SMALL_IMAGE_DIMENSIONS) {
         var imageObj = new PDFImage(this.xref, resources, image,
                                     inline, null, null);
-        var imgData = imageObj.getImageData();
+        var imgData = imageObj.createImageData();
         operatorList.addOp(OPS.paintInlineImageXObject, [imgData]);
         return;
       }
@@ -188,7 +188,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
 
       PDFImage.buildImage(function(imageObj) {
-          var imgData = imageObj.getImageData();
+          var imgData = imageObj.createImageData();
           self.handler.send('obj', [objId, self.pageIndex, 'Image', imgData],
                             null, [imgData.data.buffer]);
         }, self.handler, self.xref, resources, image, inline);
@@ -1296,7 +1296,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         // replacing queue items
         squash(fnArray, j, count * 4, OPS.paintInlineImageXObjectGroup);
         argsArray.splice(j, count * 4,
-          [{width: imgWidth, height: imgHeight, data: imgData}, map]);
+          [{width: imgWidth, height: imgHeight, kind: 'rgba_32bpp',
+            data: imgData}, map]);
         i = j;
         ii = argsArray.length;
       }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=962933#c0 has a description of the
basic idea. The enormous improvements described there still apply.

Things to note about the patch.
- I merged getImageData() and fillRgbaBuffer(). The new function is called
  createImageData().
- In evaluator.js, when replacing queue items, I set |kind| to 'rgba_32bpp'.
  I'm not sure if it would be possible here for the incoming image to be
  'grayscale_1bpp'. (It doesn't happen in any of the tests, though.)
- In canvas.js, I made the chunking code more concise by combining the two
  loops into one. This required a condition within the outer loop, but this
  doesn't hurt performance. I also came up with better names for lots of the
  variables.
