### PR TITLE
Fix horizontal scroll issue when zooming

### DIFF
--- a/web/page_view.js
+++ b/web/page_view.js
@@ -328,6 +328,14 @@ var PageView = function pageView(container, id, scale,
     return this.viewport.convertToPdfPoint(x, y);
   };
 
+  function getLeftScrollPosition(pos) {
+    if (pos !== undefined && ((self.width | 0) >
+                         (PDFView.container.clientWidth - SCROLLBAR_PADDING))) {
+      return pos;
+    }
+    return (PDFView.isViewerRtl ? 1 : -1) * PDFView.container.scrollWidth;
+  }
+
   this.scrollIntoView = function pageViewScrollIntoView(dest) {
     if (PresentationMode.active) { // Avoid breaking presentation mode.
       dest = null;
@@ -404,7 +412,8 @@ var PageView = function pageView(container, id, scale,
       this.viewport.convertToViewportPoint(x, y),
       this.viewport.convertToViewportPoint(x + width, y + height)
     ];
-    var left = Math.min(boundingRect[0][0], boundingRect[1][0]);
+    var left = getLeftScrollPosition(Math.min(boundingRect[0][0],
+                                              boundingRect[1][0]));
     var top = Math.min(boundingRect[0][1], boundingRect[1][1]);
 
     scrollIntoView(div, { left: left, top: top });

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* globals SKIP_HORIZONTAL_SCROLLING */
 
 'use strict';
 
@@ -130,7 +131,7 @@ function scrollIntoView(element, spot) {
     if (spot.top !== undefined) {
       offsetY += spot.top;
     }
-    if (spot.left !== undefined) {
+    if (spot.left !== undefined && !SKIP_HORIZONTAL_SCROLLING) {
       offsetX += spot.left;
       parent.scrollLeft = offsetX;
     }

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -118,6 +118,7 @@ var PDFView = {
   isViewerEmbedded: (window.parent !== window),
   idleTimeout: null,
   currentPosition: null,
+  isViewerRtl: false,
 
   // called once when the document is loaded
   initialize: function pdfViewInitialize() {
@@ -1983,7 +1984,9 @@ function selectScaleOption(value) {
 }
 
 window.addEventListener('localized', function localized(evt) {
-  document.getElementsByTagName('html')[0].dir = mozL10n.getDirection();
+  var textDirection = mozL10n.getDirection();
+  document.getElementsByTagName('html')[0].dir = textDirection;
+  PDFView.isViewerRtl = (textDirection === 'rtl');
 
   PDFView.animationStartedPromise.then(function() {
     // Adjust the width of the zoom box to fit the content.

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -41,6 +41,7 @@ var THUMBNAIL_SCROLL_MARGIN = -19;
 var USE_ONLY_CSS_ZOOM = false;
 var CLEANUP_TIMEOUT = 30000;
 var IGNORE_CURRENT_POSITION_ON_ZOOM = false;
+var SKIP_HORIZONTAL_SCROLLING = false;
 //#if B2G
 //USE_ONLY_CSS_ZOOM = true;
 //#endif
@@ -1987,6 +1988,14 @@ window.addEventListener('localized', function localized(evt) {
   var textDirection = mozL10n.getDirection();
   document.getElementsByTagName('html')[0].dir = textDirection;
   PDFView.isViewerRtl = (textDirection === 'rtl');
+
+//#if !(FIREFOX || MOZCENTRAL || B2G)
+  // Horizontal scrolling doesn't work in RTL mode in non-Mozilla browsers.
+  if (PDFView.isViewerRtl && (window.chrome || window.opera ||
+                              navigator.userAgent.indexOf('Trident') >= 0)) {
+    SKIP_HORIZONTAL_SCROLLING = true;
+  }
+//#endif
 
   PDFView.animationStartedPromise.then(function() {
     // Adjust the width of the zoom box to fit the content.


### PR DESCRIPTION
I've updated this PR to avoid the issues that @yurydelendik pointed out previously.

When testing this I also found that horizontal scrolling isn't really working in RTL locales in non-Mozilla browsers, hence I've disabled this feature to avoid issues. (This means that in RTL mode in other browsers, scrolling will work just like it did prior to #3967.)

Fixes #4186.
