### PR TITLE
Fix and simplify composeSMask()

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -540,15 +540,11 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         for (var i = 3; i < length; i += 4) {
           var alpha = layerDataBytes[i];
           if (alpha !== 0 && alpha !== 255) {
-            var r = ((layerDataBytes[i - 3] * 255 -
-              r0 * (255 - alpha)) / alpha) | 0;
-            layerDataBytes[i - 3] = r < 0 ? 0 : r > 255 ? 255 : r;
-            var g = ((layerDataBytes[i - 2] * 255 -
-              g0 * (255 - alpha)) / alpha) | 0;
-            layerDataBytes[i - 2] = g < 0 ? 0 : g > 255 ? 255 : g;
-            var b = ((layerDataBytes[i - 1] * 255 -
-              b0 * (255 - alpha)) / alpha) | 0;
-            layerDataBytes[i - 1] = b < 0 ? 0 : b > 255 ? 255 : b;
+            var a0 = alpha / 255;
+            var a1 = 1 - a0;
+            layerDataBytes[i - 3] = (a0 * layerDataBytes[i - 3] - a1 * r0) | 0;
+            layerDataBytes[i - 2] = (a0 * layerDataBytes[i - 2] - a1 * g0) | 0;
+            layerDataBytes[i - 1] = (a0 * layerDataBytes[i - 1] - a1 * b0) | 0;
           }
         }
       }.bind(null, backdrop[0], backdrop[1], backdrop[2]);


### PR DESCRIPTION
Fixes #4198.

The old code is equivalent to setting   a0 = 255/alpha   in the new code, so numerator and denomitator were accidentally swapped before (since we are blending two colors, a0 is supposed to be within 0...1).

I also skipped the range checks of the colors. Assuming that the input is proper (integers in 0...255), the output can NEVER be out of range, which can easily be checked by the skript below.

```
var e = 0;
for (var a = 1; a < 255; a++) {
    var a0 = a / 255;
    var a1 = 1 - a0;
    for (var ldb = 0; ldb < 256; ldb++) {
        for (var r0 = 0; r0 < 256; r0++) {
            var c = (a0* ldb + a1 * r0) | 0;
            if (c > 255 || c < 0) {
                e++;
            }
        }
    }
}
console.log("errors: " + e);
```
