### PR TITLE
Removes button outline as visible in Chrome

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -35,6 +35,7 @@ input,
 button,
 select {
   font: message-box;
+  outline: none;
 }
 
 .hidden {
@@ -920,6 +921,7 @@ html[dir="rtl"] .secondaryToolbarButton.print::before {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
+  outline: none;
   padding-top: 4px;
   text-decoration: none;
 }


### PR DESCRIPTION
Chrome adds an annoying blue outline whenever you click a button or a select field, which is not visible in Firefox/IE.
