### PR TITLE
Print shortcut: Ctrl + (Shift +) P only

### DIFF
--- a/web/mozPrintCallback_polyfill.js
+++ b/web/mozPrintCallback_polyfill.js
@@ -98,7 +98,10 @@
   var hasAttachEvent = !!document.attachEvent;
 
   window.addEventListener('keydown', function(event) {
-    if (event.keyCode === 80/*P*/ && (event.ctrlKey || event.metaKey)) {
+    // Intercept Cmd/Ctrl + P in all browsers.
+    // Also intercept Cmd/Ctrl + Shift + P in Chrome and Opera
+    if (event.keyCode === 80/*P*/ && (event.ctrlKey || event.metaKey) &&
+        !event.altKey && (!event.shiftKey || window.chrome || window.opera)) {
       window.print();
       if (hasAttachEvent) {
         // Only attachEvent can cancel Ctrl + P dialog in IE <=10


### PR DESCRIPTION
The previous version interfered with the full screen shortcut (Ctrl + Alt + P).

The new version only intercepts Cmd/Ctrl + P (all browsers),
and Cmd/Ctrl + Shift + P in Chrome / Opera (Presto and Chromium).
