### PR TITLE
Get rid of weird scrollbar on mouse down

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1598,8 +1598,8 @@ html[dir='rtl'] #documentPropertiesContainer .row > * {
   display: block;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
+  right: 0;
+  bottom: 0;
   overflow: hidden;
   z-index: 50000; /* should be higher than anything else in PDF.js! */
 }


### PR DESCRIPTION
I noticed that on mouse down, a scrollbar appeared in the viewer (just try out the live demo to see what I mean, reproduced in Firefox 26 and Chromium 31). This patch fixes that issue.
