### PR TITLE
Get progress bar for PDF streams in Chromium by passing the expected content length to the page

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -160,7 +160,7 @@ var WorkerMessageHandler = PDFJS.WorkerMessageHandler = {
         onProgress: function onProgress(evt) {
           handler.send('DocProgress', {
             loaded: evt.loaded,
-            total: evt.lengthComputable ? evt.total : void(0)
+            total: evt.lengthComputable ? evt.total : source.length
           });
         }
       });

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1821,7 +1821,9 @@ document.addEventListener('DOMContentLoaded', function webViewerLoad(evt) {
 //    var streamUrl = response.streamUrl;
 //    if (streamUrl) {
 //      console.log('Found data stream for ' + file);
-//      PDFView.open(streamUrl, 0);
+//      PDFView.open(streamUrl, 0, undefined, undefined, {
+//        length: response.contentLength
+//      });
 //      PDFView.setTitleUsingUrl(file);
 //      return;
 //    }


### PR DESCRIPTION
An Opera user reported that nothing happened for 10 seconds, then all of a sudden a PDF appeared. With this PR,  users will see a progress bar while the FTP/POST stream is coming in.

(this patch is only relevant for Chromium / Opera extension users)  

To test in Chromium / Google Chrome:
1. `node make chromium`
2. `sed -i 's/"mime_/"key":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC4zyYTii0VTKI7W2U6fDeAvs3YCVZeAt7C62IC64IDCMHvWy7SKMpOPjfg5v1PgYkFm+fGsCsVLN8NaF7fzYMVtjLc5bqhqPAi56Qidrqh1HxPAAYhwFQd5BVGhZmh1fySHXFPE8VI2tIHwRrASOtx67jbSEk4nBAcJz6n+eGq8QIDAQAB",\n"mime_/' build/chromium/manifest.json`
3. `chromium --user-data-dir=/tmp/tempdir --load-extension=build/chromium --no-first-run`
4. Google for "ftp pdf" and pick the first result (e.g. ftp://ftp.ipswitch.com/ipswitch/manuals/ftpserv.pdf).
5. Observe that a progress bar is displayed while loading.

To compare with the previous version, just `git checkout master`, repeat steps 1-4 and observe that no progress is shown.
