### PR TITLE
Lexer_getNumber faster number parsing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Jonas Jenwald <jonas.jenwald@gmail.com>
 Julian Viereck
 Justin D'Arcangelo <justindarc@gmail.com>
 Kalervo Kujala
+Ophir Lojkine <@lovasoa>
 Rob Wu <gwnRob@gmail.com>
 Shaon Barman <shaon.barman@gmail.com>
 Tim van der Meij <info@timvandermeij.nl>

--- a/test/unit/parser_spec.js
+++ b/test/unit/parser_spec.js
@@ -14,6 +14,30 @@ describe('parser', function() {
       expect(result).toEqual(11.234);
     });
 
+    it('should parse PostScript numbers', function() {
+      var numbers = ['-.002', '34.5', '-3.62', '123.6e10', '1E-5', '-1.', '0.0',
+                    '123', '-98', '43445', '0', '+17'];
+      for (var i=0, ii=numbers.length; i<ii; i++) {
+        var num = numbers[i];
+        var input = new StringStream(num);
+        var lexer = new Lexer(input);
+        var result = lexer.getNumber();
+
+        expect(result).toEqual(parseFloat(num));
+      }
+    });
+
+
+    it('should handle glued numbers and operators', function() {
+      var input = new StringStream('123ET');
+      var lexer = new Lexer(input);
+      var value = lexer.getNumber();
+
+      expect(value).toEqual(123);
+      // The lexer must not have consumed the 'E'
+      expect(lexer.currentChar).toEqual(0x45); // 'E'
+    });
+
     it('should stop parsing strings at the end of stream', function() {
       var input = new StringStream('(1$4)');
       input.getByte = function(super_getByte) {


### PR DESCRIPTION
In Lexer_getNumber, numbers were calculated by getting each of their numbers as charcodes (integers), converting them to one character strings, putting all the strings in an array, eventually merging the strings, an finally converting the strings back to a number.

In this newer version, there is no type conversion, the number is calculated from the char codes of its digits, with only basic arithmetic operations. (+ \* / and Math.pow for numbers in scientific notation).
