### PR TITLE
Remove Math.log in LZW calculation of next code size.

### DIFF
--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -2301,9 +2301,8 @@ var LZWStream = (function LZWStreamClosure() {
         dictionaryLengths[nextCode] = dictionaryLengths[prevCode] + 1;
         dictionaryValues[nextCode] = currentSequence[0];
         nextCode++;
-        codeLength = (nextCode + earlyChange) & (nextCode + earlyChange - 1) ?
-          codeLength : Math.min(Math.log(nextCode + earlyChange) /
-          0.6931471805599453 + 1, 12) | 0;
+        if (nextCode + earlyChange >= (1 << codeLength) && codeLength < 12)
+          codeLength++;
       }
       prevCode = code;
 


### PR DESCRIPTION
Remove Math.log in LZW calculation of next code size. The LZW codes always increase one bit at a time.

This code was added in 03c5fa3d19bac01a16245ee727b07477b8cabb2f.  I don't really see a natural log call as a good optimization over a switch statement, but this code can be made much simpler anyway.

I'm not sure if there are any good test cases covering this, I reckon it's okay though : )
