### PR TITLE
Use unprefixed box-sizing

### DIFF
--- a/extensions/b2g/viewer.css
+++ b/extensions/b2g/viewer.css
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-* { -moz-box-sizing: border-box; }
+* { box-sizing: border-box; }
 
 * {
   padding: 0;

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -918,8 +918,6 @@ html[dir="rtl"] .secondaryToolbarButton.print::before {
 
 .toolbarButton.bookmark,
 .secondaryToolbarButton.bookmark {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
   outline: none;
   padding-top: 4px;


### PR DESCRIPTION
Firefox 29 and later do not require the -moz- prefix.

Safari 5 and later do not require the -webkit- prefix.
