### PR TITLE
Updated to current latest stable version of jshint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,7 +2,6 @@
   // Environments
   "browser": true,
   "devel": true,
-  "es5": true,
   "worker": true,
 
   // Enforcing

--- a/extensions/chromium/pageActionPopup.js
+++ b/extensions/chromium/pageActionPopup.js
@@ -12,11 +12,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+'use strict';
+
 var url = location.search.match(/[&?]file=([^&]+)/i);
 if (url) {
   url = decodeURIComponent(url[1]);
   document.body.textContent = url;
   // Set cursor to end of the content-editable section.
-  getSelection().selectAllChildren(document.body);
-  getSelection().collapseToEnd();
+  window.getSelection().selectAllChildren(document.body);
+  window.getSelection().collapseToEnd();
 }

--- a/external/webL10n/l10n.js
+++ b/external/webL10n/l10n.js
@@ -26,7 +26,7 @@
     - Removes window._ assignment.
 */
 
-/*jshint browser: true, devel: true, es5: true, globalstrict: true */
+/*jshint browser: true, devel: true, globalstrict: true */
 'use strict';
 
 document.webL10n = (function(window, document, undefined) {

--- a/make.js
+++ b/make.js
@@ -1138,7 +1138,7 @@ target.lint = function() {
   var jshintPath = path.normalize('./node_modules/.bin/jshint');
   if (!test('-f', jshintPath)) {
     echo('jshint is not installed -- installing...');
-    exec('npm install jshint@1.1'); // TODO read version from package.json
+    exec('npm install jshint@2.4.x'); // TODO read version from package.json
   }
 
   exit(exec('"' + jshintPath + '" --reporter test/reporter.js ' +

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pdf.js",
   "version": "0.8.0",
   "dependencies": {
-    "jshint": "1.1.x"
+    "jshint": "2.4.x"
   },
   "scripts": {
     "test": "node make lint"

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1384,7 +1384,7 @@ var OperatorList = (function OperatorListClosure() {
       this.fnArray = [];
     }
     this.argsArray = [];
-    this.dependencies = {},
+    this.dependencies = {};
     this.pageIndex = pageIndex;
     this.fnIndex = 0;
   }
@@ -1471,11 +1471,11 @@ var TextState = (function TextStateClosure() {
   TextState.prototype = {
     initialiseTextObj: function TextState_initialiseTextObj() {
       var m = this.textMatrix;
-      m[0] = 1, m[1] = 0, m[2] = 0, m[3] = 1, m[4] = 0, m[5] = 0;
+      m[0] = 1; m[1] = 0; m[2] = 0; m[3] = 1; m[4] = 0; m[5] = 0;
     },
     setTextMatrix: function TextState_setTextMatrix(a, b, c, d, e, f) {
       var m = this.textMatrix;
-      m[0] = a, m[1] = b, m[2] = c, m[3] = d, m[4] = e, m[5] = f;
+      m[0] = a; m[1] = b; m[2] = c; m[3] = d; m[4] = e; m[5] = f;
     },
     translateTextMatrix: function TextState_translateTextMatrix(x, y) {
       var m = this.textMatrix;

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -1725,19 +1725,19 @@ var JpxImage = (function JpxImageClosure() {
         }
       }
       for (i = 0; i < hlHeight; i++) {
-        k = i * hlWidth, l = i * 2 * width + 1;
+        k = i * hlWidth; l = i * 2 * width + 1;
         for (j = 0; j < hlWidth; j++, k++, l += 2) {
           items[l] = hlItems[k];
         }
       }
       for (i = 0; i < lhHeight; i++) {
-        k = i * lhWidth, l = (i * 2 + 1) * width;
+        k = i * lhWidth; l = (i * 2 + 1) * width;
         for (j = 0; j < lhWidth; j++, k++, l += 2) {
           items[l] = lhItems[k];
         }
       }
       for (i = 0; i < hhHeight; i++) {
-        k = i * hhWidth, l = (i * 2 + 1) * width + 1;
+        k = i * hhWidth; l = (i * 2 + 1) * width + 1;
         for (j = 0; j < hhWidth; j++, k++, l += 2) {
           items[l] = hhItems[k];
         }

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*jshint globalstrict: false */
 
 // Initializing PDFJS global object (if still undefined)
 if (typeof PDFJS === 'undefined') {

--- a/src/shared/cffStandardStrings.js
+++ b/src/shared/cffStandardStrings.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+'use strict';
+
 var CFFEncodingMap = {
   '0': '-reserved-',
   '1': 'hstem',

--- a/test/unit/testreporter.js
+++ b/test/unit/testreporter.js
@@ -1,5 +1,6 @@
 /* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/*jshint globalstrict: false */
 
 var TestReporter = function(browser, appPath) {
   'use strict';


### PR DESCRIPTION
I updated jshint to newest stable version. It finally correctly addresses #4175 and finds some additional issues with the code which I addressed. It found some missing "use strict" which I added when I thought they should be, or added an ignore switch otherwise.

ES5 option is now set per default, so I disabled it. [Reference](http://jslinterrors.com/es5-option-is-now-set-per-default/).
