### PR TITLE
Corrected word spelling and made translation be right

### DIFF
--- a/l10n/vi/metadata.inc
+++ b/l10n/vi/metadata.inc
@@ -2,7 +2,7 @@
       <Description>
         <em:locale>vi-VN</em:locale>
         <em:name>Trình Xem PDF</em:name>
-        <em:description>Dùng HTML5 để hiện trị PDF trực giao trên FireFox.</em:description>
+        <em:description>Dùng HTML5 để hiện thị PDF trực tiếp trên FireFox.</em:description>
       </Description>
     </em:localized>
 


### PR DESCRIPTION
"directly"
Original: "trực giao"
Corrected: "trực tiếp"
