### PR TITLE
Fix for bind compatibility implementation (polyfill)

### DIFF
--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -306,7 +306,7 @@ if (typeof PDFJS === 'undefined') {
   Function.prototype.bind = function functionPrototypeBind(obj) {
     var fn = this, headArgs = Array.prototype.slice.call(arguments, 1);
     var bound = function functionPrototypeBindBound() {
-      var args = Array.prototype.concat.apply(headArgs, arguments);
+      var args = headArgs.concat(Array.prototype.slice.call(arguments));
       return fn.apply(obj, args);
     };
     return bound;


### PR DESCRIPTION
Previously, reconstruction of arguments was incorrect if arguments contained arrays. Arrays were added to arguments as their elements and not as a whole array. It is enough to simply pass whole array to concat and it will be (only one level deep) added to arguments.

In addition, we call slice on arguments for maximum compatibility (it is used in Underscore.js library, with which I was comparing implementations while debugging).
