### PR TITLE
[B2G] Remove the spinner from the pageNumber field

### DIFF
--- a/extensions/b2g/viewer.css
+++ b/extensions/b2g/viewer.css
@@ -91,6 +91,7 @@ footer {
 }
 
 #pageNumber {
+  -moz-appearance: textfield; /* hides the spinner in moz */
   position: absolute;
   width: 28%;
   height: 100%;


### PR DESCRIPTION
I'm assuming that we don't want a spinner in the pageNumber field in the B2G viewer, so this patch just copies PR #4020 to the B2G viewer.
