### PR TITLE
Some parsing tweaks to reduce memory consumption

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -291,11 +291,12 @@ var PDFDocument = (function PDFDocumentClosure() {
   function find(stream, needle, limit, backwards) {
     var pos = stream.pos;
     var end = stream.end;
-    var str = '';
+    var strBuf = [];
     if (pos + limit > end)
       limit = end - pos;
     for (var n = 0; n < limit; ++n)
-      str += String.fromCharCode(stream.getByte());
+      strBuf.push(String.fromCharCode(stream.getByte()));
+    var str = strBuf.join('');
     stream.pos = pos;
     var index = backwards ? str.lastIndexOf(needle) : str.indexOf(needle);
     if (index == -1)

--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -548,7 +548,7 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
     return userPassword;
   }
 
-  var identityName = new Name('Identity');
+  var identityName = Name.get('Identity');
 
   function CipherTransformFactory(dict, fileId, password) {
     var filter = dict.get('Filter');

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1104,7 +1104,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           // FontDescriptor is only required for Type3 fonts when the document
           // is a tagged pdf. Create a barbebones one to get by.
           descriptor = new Dict();
-          descriptor.set('FontName', new Name(type.name));
+          descriptor.set('FontName', Name.get(type.name));
         } else {
           // Before PDF 1.5 if the font was one of the base 14 fonts, having a
           // FontDescriptor was not required.
@@ -1152,10 +1152,10 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       var baseFont = dict.get('BaseFont');
       // Some bad pdf's have a string as the font name.
       if (isString(fontName)) {
-        fontName = new Name(fontName);
+        fontName = Name.get(fontName);
       }
       if (isString(baseFont)) {
-        baseFont = new Name(baseFont);
+        baseFont = Name.get(baseFont);
       }
 
       if (type.name !== 'Type3') {

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -2382,11 +2382,11 @@ var Font = (function FontClosure() {
   }
 
   function arrayToString(arr) {
-    var str = '';
+    var strBuf = [];
     for (var i = 0, ii = arr.length; i < ii; ++i)
-      str += String.fromCharCode(arr[i]);
+      strBuf.push(String.fromCharCode(arr[i]));
 
-    return str;
+    return strBuf.join('');
   }
 
   function int16(bytes) {
@@ -2801,10 +2801,10 @@ var Font = (function FontClosure() {
     for (var i = 0, ii = strings.length; i < ii; i++) {
       var str = proto[1][i] || strings[i];
 
-      var strUnicode = '';
+      var strBufUnicode = [];
       for (var j = 0, jj = str.length; j < jj; j++)
-        strUnicode += string16(str.charCodeAt(j));
-      stringsUnicode.push(strUnicode);
+        strBufUnicode.push(string16(str.charCodeAt(j)));
+      stringsUnicode.push(strBufUnicode.join(''));
     }
 
     var names = [strings, stringsUnicode];

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -88,7 +88,7 @@ var PDFImage = (function PDFImageClosure() {
       var colorSpace = dict.get('ColorSpace', 'CS');
       if (!colorSpace) {
         warn('JPX images (which don"t require color spaces');
-        colorSpace = new Name('DeviceRGB');
+        colorSpace = Name.get('DeviceRGB');
       }
       this.colorSpace = ColorSpace.parse(colorSpace, xref, res);
       this.numComps = this.colorSpace.numComps;

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -30,6 +30,13 @@ var Name = (function NameClosure() {
 
   Name.prototype = {};
 
+  var nameCache = {};
+
+  Name.get = function Name_get(name) {
+    var nameValue = nameCache[name];
+    return nameValue ? nameValue : (nameCache[name] = new Name(name));
+  };
+
   return Name;
 })();
 
@@ -44,10 +51,7 @@ var Cmd = (function CmdClosure() {
 
   Cmd.get = function Cmd_get(cmd) {
     var cmdValue = cmdCache[cmd];
-    if (cmdValue)
-      return cmdValue;
-
-    return cmdCache[cmd] = new Cmd(cmd);
+    return cmdValue ? cmdValue : (cmdCache[cmd] = new Cmd(cmd));
   };
 
   return Cmd;

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -586,7 +586,7 @@ var Lexer = (function LexerClosure() {
         error('Warning: name token is longer than allowed by the spec: ' +
               strBuf.length);
       }
-      return new Name(strBuf.join(''));
+      return Name.get(strBuf.join(''));
     },
     getHexString: function Lexer_getHexString() {
       var strBuf = this.strBuf;

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -389,6 +389,10 @@ var Lexer = (function LexerClosure() {
     return -1;
   }
 
+  function join(strBuf) {
+    return strBuf.length === 1 ? strBuf[0] : strBuf.join('');
+  }
+
   Lexer.prototype = {
     nextChar: function Lexer_nextChar() {
       return (this.currentChar = this.stream.getByte());
@@ -560,7 +564,7 @@ var Lexer = (function LexerClosure() {
           ch = this.nextChar();
         }
       }
-      return strBuf.join('');
+      return join(strBuf);
     },
     getName: function Lexer_getName() {
       var ch;
@@ -586,7 +590,7 @@ var Lexer = (function LexerClosure() {
         error('Warning: name token is longer than allowed by the spec: ' +
               strBuf.length);
       }
-      return Name.get(strBuf.join(''));
+      return Name.get(join(strBuf));
     },
     getHexString: function Lexer_getHexString() {
       var strBuf = this.strBuf;
@@ -626,7 +630,7 @@ var Lexer = (function LexerClosure() {
           ch = this.nextChar();
         }
       }
-      return strBuf.join('');
+      return join(strBuf);
     },
     getObj: function Lexer_getObj() {
       // skip whitespace and comments

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -376,11 +376,11 @@ var XRefParseException = (function XRefParseExceptionClosure() {
 
 
 function bytesToString(bytes) {
-  var str = '';
+  var strBuf = [];
   var length = bytes.length;
   for (var n = 0; n < length; ++n)
-    str += String.fromCharCode(bytes[n]);
-  return str;
+    strBuf.push(String.fromCharCode(bytes[n]));
+  return strBuf.join('');
 }
 
 function stringToBytes(str) {
@@ -705,19 +705,19 @@ var PDFStringTranslateTable = [
 ];
 
 function stringToPDFString(str) {
-  var i, n = str.length, str2 = '';
+  var i, n = str.length, strBuf = [];
   if (str[0] === '\xFE' && str[1] === '\xFF') {
     // UTF16BE BOM
     for (i = 2; i < n; i += 2)
-      str2 += String.fromCharCode(
-        (str.charCodeAt(i) << 8) | str.charCodeAt(i + 1));
+      strBuf.push(String.fromCharCode(
+        (str.charCodeAt(i) << 8) | str.charCodeAt(i + 1)));
   } else {
     for (i = 0; i < n; ++i) {
       var code = PDFStringTranslateTable[str.charCodeAt(i)];
-      str2 += code ? String.fromCharCode(code) : str.charAt(i);
+      strBuf.push(code ? String.fromCharCode(code) : str.charAt(i));
     }
   }
-  return str2;
+  return strBuf.join('');
 }
 
 function stringToUTF8String(str) {

--- a/test/unit/crypto_spec.js
+++ b/test/unit/crypto_spec.js
@@ -198,7 +198,7 @@ describe('CipherTransformFactory', function() {
   };
 
   var map1 = {
-    Filter: new Name('Standard'),
+    Filter: Name.get('Standard'),
     V: 2,
     Length: 128,
     O: unescape('%80%C3%04%96%91o%20sl%3A%E6%1B%13T%91%F2%0DV%12%E3%FF%5E%BB%' +
@@ -211,7 +211,7 @@ describe('CipherTransformFactory', function() {
   var fileID1 = unescape('%F6%C6%AF%17%F3rR%8DRM%9A%80%D1%EF%DF%18');
 
   var map2 = {
-    Filter: new Name('Standard'),
+    Filter: Name.get('Standard'),
     V: 4,
     Length: 128,
     O: unescape('sF%14v.y5%27%DB%97%0A5%22%B3%E1%D4%AD%BD%9B%3C%B4%A5%89u%15%' +

--- a/test/unit/obj_spec.js
+++ b/test/unit/obj_spec.js
@@ -10,7 +10,7 @@ describe('obj', function() {
   describe('Name', function() {
     it('should retain the given name', function() {
       var givenName = 'Font';
-      var name = new Name(givenName);
+      var name = Name.get(givenName);
       expect(name.name).toEqual(givenName);
     });
   });

--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -72,7 +72,7 @@ describe('util', function() {
 
     it('handles dictionaries with type check', function() {
       var dict = new Dict();
-      dict.set('Type', new Name('Page'));
+      dict.set('Type', Name.get('Page'));
       expect(isDict(dict, 'Page')).toEqual(true);
     });
   });


### PR DESCRIPTION
The first patch, which introduces the Name cache, is the most effective. On a 4,125 page PDF it reduces peak memory consumption during parsing from ~800 MiB to ~750 MiB.

The other two patches provide smaller improvements.
