### PR TITLE
Fix spacebar scrolling in Firefox (4224 follow-up)

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2254,7 +2254,7 @@ window.addEventListener('keydown', function keydown(evt) {
       }
       // 32=Spacebar
       if (evt.keyCode === 32 && curElementTagName !== 'BUTTON') {
-//#if !(FIREFOX || MOZCENTRAL)
+//#if (FIREFOX || MOZCENTRAL)
 //// Workaround for issue in Firefox, that prevents scroll keys from working
 //// when elements with 'tabindex' are focused. (#3499)
 //      PDFView.container.blur();


### PR DESCRIPTION
The preprocessor tag was apparently included the wrong way around in PR #4224, which causes scrolling with <kbd>spacebar</kbd> to break again in `FIREFOX` and `MOZCENTRAL` builds.
