### PR TITLE
Remove embeddedFontsUsed from API.

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -214,13 +214,6 @@ var PDFDocumentProxy = (function PDFDocumentProxyClosure() {
       return this.pdfInfo.fingerprint;
     },
     /**
-     * @return {boolean} true if embedded document fonts are in use. Will be
-     * set during rendering of the pages.
-     */
-    get embeddedFontsUsed() {
-      return this.transport.embeddedFontsUsed;
-    },
-    /**
      * @param {number} pageNumber The page number to get. The first page is 1.
      * @return {Promise} A promise that is resolved with a {@link PDFPageProxy}
      * object.
@@ -578,7 +571,6 @@ var WorkerTransport = (function WorkerTransportClosure() {
 
     this.pageCache = [];
     this.pagePromises = [];
-    this.embeddedFontsUsed = false;
     this.downloadInfoPromise = new PDFJS.LegacyPromise();
     this.passwordCallback = null;
 

--- a/web/page_view.js
+++ b/web/page_view.js
@@ -509,11 +509,6 @@ var PageView = function pageView(container, id, scale,
       textLayerDiv.dataset._scaleY = outputScale.sy;
     }
 
-//#if (FIREFOX || MOZCENTRAL)
-//  // Checking if document fonts are used only once
-//  var checkIfDocumentFontsUsed = !PDFView.pdfDocument.embeddedFontsUsed;
-//#endif
-
     // Rendering area
 
     var self = this;
@@ -542,12 +537,6 @@ var PageView = function pageView(container, id, scale,
       }
 
 //#if (FIREFOX || MOZCENTRAL)
-//    if (checkIfDocumentFontsUsed && PDFView.pdfDocument.embeddedFontsUsed &&
-//        PDFJS.disableFontFace) {
-//      console.error(mozL10n.get('web_fonts_disabled', null,
-//        'Web fonts are disabled: unable to use embedded PDF fonts.'));
-//      PDFView.fallback();
-//    }
 //    if (self.textLayer && self.textLayer.textDivs &&
 //        self.textLayer.textDivs.length > 0 &&
 //        !PDFView.supportsDocumentColors) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1674,6 +1674,8 @@ function webViewerLoad(evt) {
 //#if (FIREFOX || MOZCENTRAL)
 //if (!PDFView.supportsDocumentFonts) {
 //  PDFJS.disableFontFace = true;
+//  console.warn(mozL10n.get('web_fonts_disabled', null,
+//    'Web fonts are disabled: unable to use embedded PDF fonts.'));
 //}
 //#endif
 


### PR DESCRIPTION
This was broken for 7 months and we now auto switch to the internal font renderer if document fonts aren't supported anyways.
