### PR TITLE
Use a cache to minimize the number of Name objects.

### DIFF
--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -548,7 +548,7 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
     return userPassword;
   }
 
-  var identityName = new Name('Identity');
+  var identityName = Name.get('Identity');
 
   function CipherTransformFactory(dict, fileId, password) {
     var filter = dict.get('Filter');

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1102,7 +1102,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           // FontDescriptor is only required for Type3 fonts when the document
           // is a tagged pdf. Create a barbebones one to get by.
           descriptor = new Dict();
-          descriptor.set('FontName', new Name(type.name));
+          descriptor.set('FontName', Name.get(type.name));
         } else {
           // Before PDF 1.5 if the font was one of the base 14 fonts, having a
           // FontDescriptor was not required.
@@ -1150,10 +1150,10 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       var baseFont = dict.get('BaseFont');
       // Some bad pdf's have a string as the font name.
       if (isString(fontName)) {
-        fontName = new Name(fontName);
+        fontName = Name.get(fontName);
       }
       if (isString(baseFont)) {
-        baseFont = new Name(baseFont);
+        baseFont = Name.get(baseFont);
       }
 
       if (type.name !== 'Type3') {

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -88,7 +88,7 @@ var PDFImage = (function PDFImageClosure() {
       var colorSpace = dict.get('ColorSpace', 'CS');
       if (!colorSpace) {
         warn('JPX images (which don"t require color spaces');
-        colorSpace = new Name('DeviceRGB');
+        colorSpace = Name.get('DeviceRGB');
       }
       this.colorSpace = ColorSpace.parse(colorSpace, xref, res);
       this.numComps = this.colorSpace.numComps;

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -30,6 +30,13 @@ var Name = (function NameClosure() {
 
   Name.prototype = {};
 
+  var nameCache = {};
+
+  Name.get = function Name_get(name) {
+    var nameValue = nameCache[name];
+    return nameValue ? nameValue : (nameCache[name] = new Name(name));
+  };
+
   return Name;
 })();
 
@@ -44,10 +51,7 @@ var Cmd = (function CmdClosure() {
 
   Cmd.get = function Cmd_get(cmd) {
     var cmdValue = cmdCache[cmd];
-    if (cmdValue)
-      return cmdValue;
-
-    return cmdCache[cmd] = new Cmd(cmd);
+    return cmdValue ? cmdValue : (cmdCache[cmd] = new Cmd(cmd));
   };
 
   return Cmd;

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -586,7 +586,7 @@ var Lexer = (function LexerClosure() {
         error('Warning: name token is longer than allowed by the spec: ' +
               strBuf.length);
       }
-      return new Name(strBuf.join(''));
+      return Name.get(strBuf.join(''));
     },
     getHexString: function Lexer_getHexString() {
       var strBuf = this.strBuf;

--- a/test/unit/crypto_spec.js
+++ b/test/unit/crypto_spec.js
@@ -198,7 +198,7 @@ describe('CipherTransformFactory', function() {
   };
 
   var map1 = {
-    Filter: new Name('Standard'),
+    Filter: Name.get('Standard'),
     V: 2,
     Length: 128,
     O: unescape('%80%C3%04%96%91o%20sl%3A%E6%1B%13T%91%F2%0DV%12%E3%FF%5E%BB%' +
@@ -211,7 +211,7 @@ describe('CipherTransformFactory', function() {
   var fileID1 = unescape('%F6%C6%AF%17%F3rR%8DRM%9A%80%D1%EF%DF%18');
 
   var map2 = {
-    Filter: new Name('Standard'),
+    Filter: Name.get('Standard'),
     V: 4,
     Length: 128,
     O: unescape('sF%14v.y5%27%DB%97%0A5%22%B3%E1%D4%AD%BD%9B%3C%B4%A5%89u%15%' +

--- a/test/unit/obj_spec.js
+++ b/test/unit/obj_spec.js
@@ -10,7 +10,7 @@ describe('obj', function() {
   describe('Name', function() {
     it('should retain the given name', function() {
       var givenName = 'Font';
-      var name = new Name(givenName);
+      var name = Name.get(givenName);
       expect(name.name).toEqual(givenName);
     });
   });

--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -72,7 +72,7 @@ describe('util', function() {
 
     it('handles dictionaries with type check', function() {
       var dict = new Dict();
-      dict.set('Type', new Name('Page'));
+      dict.set('Type', Name.get('Page'));
       expect(isDict(dict, 'Page')).toEqual(true);
     });
   });


### PR DESCRIPTION
This reduces peak RSS on large PDFs.
