### PR TITLE
Allow a url to omit the protocol

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -228,7 +228,11 @@ function combineUrl(baseUrl, url) {
   if (url.charAt(0) == '/') {
     // absolute path
     var i = baseUrl.indexOf('://');
-    i = baseUrl.indexOf('/', i + 3);
+    if (url.charAt(1) === '/') {
+      ++i;
+    } else {
+      i = baseUrl.indexOf('/', i + 3);
+    }
     return baseUrl.substring(0, i) + url;
   } else {
     // relative path


### PR DESCRIPTION
Currently we are working on an application that can be served by either http or https. To do so we are omitting the protocol from the URLs of static files to work in either case.

example:
`//static.example.com/filename.pdf`

instead of:
`http[s]://static.example.com/filename.pdf`

This works for images and other files but the combineUrl function in PDF.js was mistakenly considering such urls as absolute instead which meant that we ended up with stuff like:
`http[s]://app.example.com//static.example.com/filename.pdf`
and the accompanying 404 not found error.

This is a quick fix for this issue.
