### PR TITLE
Add 'registered' and 'trademark' to mapPrivateUseChars (bug 925985)

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -599,6 +599,15 @@ function mapPrivateUseChars(code) {
     case 0xF8E9: // copyrightsans
     case 0xF6D9: // copyrightserif
       return 0x00A9; // copyright
+
+    case 0xF8E8: // registersans
+    case 0xF6DA: // registerserif
+      return 0x00AE; // registered
+
+    case 0xF8EA: // trademarksans
+    case 0xF6DB: // trademarkserif
+      return 0x2122; // trademark
+
     default:
       return code;
   }


### PR DESCRIPTION
Fixes the missing trademark (&#x2122;) in: https://bugzilla.mozilla.org/show_bug.cgi?id=925985.

Note that I originally found this issue while reading: https://partners.adobe.com/public/developer/en/font/5015.Type1_Supp.pdf. In that file there are both trademark and registered (&#x00AE;) characters missing, which is why they are both included in this PR.
