### PR TITLE
Rejects invalid fpgm table when too many functions

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -3707,6 +3707,11 @@ var Font = (function FontClosure() {
         if (ttContext.tooComplexToFollowFunctions) {
           return;
         }
+        if (ttContext.functionsDefined.length > maxFunctionDefs) {
+          warn('TT: more functions defined than expected');
+          ttContext.hintsValid = false;
+          return;
+        }
         for (var j = 0, jj = ttContext.functionsUsed.length; j < jj; j++) {
           if (j > maxFunctionDefs) {
             warn('TT: invalid function id: ' + j);


### PR DESCRIPTION
Fixes bug 950316 and 978276

Microsoft Font Validator fails with messages for those documents:

```
E6016 FDEF out of range Size 4, FDEF, Pre-Program, At ByteOffset 374,  
A6000 An exception occurred during rasterization testing Secure Rasterizer error: Function out of range 
```
