### PR TITLE
Avoid extra allocations in ensureBuffer() caused by an off-by-one error.

### DIFF
--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -108,9 +108,15 @@ var DecodeStream = (function DecodeStreamClosure() {
   DecodeStream.prototype = {
     ensureBuffer: function DecodeStream_ensureBuffer(requested) {
       var buffer = this.buffer;
-      var current = buffer ? buffer.byteLength : 0;
-      if (requested < current)
-        return buffer;
+      var current;
+      if (buffer) {
+        current = buffer.byteLength;
+        if (requested <= current) {
+          return buffer;
+        }
+      } else {
+        current = 0;
+      }
       var size = 512;
       while (size < requested)
         size <<= 1;


### PR DESCRIPTION
If you call ensureBuffer() with a |requested| value equal to the current |buffer.byteLength|, it'll allocate a new buffer that's the same size as the current one, due to a simple off-by-one error.

And this actually does manifest in practice -- there are a non-trivial number of redundant reallocations of this kind. In one large document, this change saves 3.4 MiB of unnecessary re-allocations. This wasn't enough to noticeably change the peak RSS requirements, but still! :)
