### PR TITLE
Fixes CSS for webkit

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1607,6 +1607,7 @@ html[dir='rtl'] #documentPropertiesContainer .row > * {
   /* Rules for Retina screens */
   .toolbarButton::before {
     transform: scale(0.5);
+    -webkit-transform: scale(0.5);
     top: -5px;
   }
 


### PR DESCRIPTION
HiDPI icons looked bad/big:

![screen shot 2014-03-05 at 8 50 42 am](https://f.cloud.github.com/assets/1523410/2334170/bc2d3730-a475-11e3-8245-2f70f5a50030.png)
