### PR TITLE
Fix scrolling using Shift+Spacebar in Firefox

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2270,29 +2270,6 @@ window.addEventListener('keydown', function keydown(evt) {
         PDFView.rotatePages(90);
         break;
     }
-    if (!handled && !PresentationMode.active) {
-      // 33=Page Up  34=Page Down  35=End    36=Home
-      // 37=Left     38=Up         39=Right  40=Down
-      if (evt.keyCode >= 33 && evt.keyCode <= 40 &&
-          !PDFView.container.contains(curElement)) {
-        // The page container is not focused, but a page navigation key has been
-        // pressed. Change the focus to the viewer container to make sure that
-        // navigation by keyboard works as expected.
-        PDFView.container.focus();
-      }
-      // 32=Spacebar
-      if (evt.keyCode === 32 && curElementTagName !== 'BUTTON') {
-//#if (FIREFOX || MOZCENTRAL)
-//// Workaround for issue in Firefox, that prevents scroll keys from working
-//// when elements with 'tabindex' are focused. (#3499)
-//      PDFView.container.blur();
-//#else
-        if (!PDFView.container.contains(curElement)) {
-          PDFView.container.focus();
-        }
-//#endif
-      }
-    }
   }
 
   if (cmd === 4) { // shift-key
@@ -2309,6 +2286,30 @@ window.addEventListener('keydown', function keydown(evt) {
       case 82: // 'r'
         PDFView.rotatePages(-90);
         break;
+    }
+  }
+
+  if (!handled && !PresentationMode.active) {
+    // 33=Page Up  34=Page Down  35=End    36=Home
+    // 37=Left     38=Up         39=Right  40=Down
+    if (evt.keyCode >= 33 && evt.keyCode <= 40 &&
+        !PDFView.container.contains(curElement)) {
+      // The page container is not focused, but a page navigation key has been
+      // pressed. Change the focus to the viewer container to make sure that
+      // navigation by keyboard works as expected.
+      PDFView.container.focus();
+    }
+    // 32=Spacebar
+    if (evt.keyCode === 32 && curElementTagName !== 'BUTTON') {
+//#if (FIREFOX || MOZCENTRAL)
+//    // Workaround for issue in Firefox, that prevents scroll keys from
+//    // working when elements with 'tabindex' are focused. (#3498)
+//    PDFView.container.blur();
+//#else
+      if (!PDFView.container.contains(curElement)) {
+        PDFView.container.focus();
+      }
+//#endif
     }
   }
 


### PR DESCRIPTION
After #4224, scrolling using <kbd>Shift</kbd> + <kbd>Spacebar</kbd> doesn't work in Firefox, unless another navigation key was pressed before it.
