### PR TITLE
Fixes off-by-one error when finding missing endstream

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -215,7 +215,7 @@ var Parser = (function ParserClosure() {
         while (stream.pos < stream.end) {
           var scanBytes = stream.peekBytes(SCAN_BLOCK_SIZE);
           var scanLength = scanBytes.length - ENDSTREAM_SIGNATURE_LENGTH;
-          var found = false, i, ii, j;
+          var found = false, i, j;
           for (i = 0, j = 0; i < scanLength; i++) {
             var b = scanBytes[i];
             if (b !== ENDSTREAM_SIGNATURE[j]) {
@@ -224,6 +224,7 @@ var Parser = (function ParserClosure() {
             } else {
               j++;
               if (j >= ENDSTREAM_SIGNATURE_LENGTH) {
+                i++;
                 found = true;
                 break;
               }


### PR DESCRIPTION
Fixes #4387. Also removed unused variable `ii`.

Short explanation: we start with `i=0` and `j=0`. Assume we find the `e` of `endstream` immediately. Then `j` becomes 1, but `i` is still 0. `i` will be `1` in the next iteration, but when the `n` from `endstream` is then found `j` becomes 2, et cetera. In the end we will make `j` equal `9` and then stop, but `i` will then be `8`. Therefore this patch increases `i` by 1 to make them equal.
