### PR TITLE
Avoid unnecessary re-reading of streams

### DIFF
--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -187,6 +187,8 @@ var ChunkedStream = (function ChunkedStreamClosure() {
     },
 
     makeSubStream: function ChunkedStream_makeSubStream(start, length, dict) {
+      this.ensureRange(start, start + length);
+
       function ChunkedStreamSubstream() {}
       ChunkedStreamSubstream.prototype = Object.create(this);
       ChunkedStreamSubstream.prototype.getMissingChunks = function() {

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -300,12 +300,10 @@ var Parser = (function ParserClosure() {
         return new LZWStream(stream, earlyChange);
       }
       if (name == 'DCTDecode' || name == 'DCT') {
-        var bytes = stream.getBytes(length);
-        return new JpegStream(bytes, stream.dict, this.xref);
+        return new JpegStream(stream, length, stream.dict, this.xref);
       }
       if (name == 'JPXDecode' || name == 'JPX') {
-        var bytes = stream.getBytes(length);
-        return new JpxStream(bytes, stream.dict);
+        return new JpxStream(stream, length, stream.dict);
       }
       if (name == 'ASCII85Decode' || name == 'A85') {
         return new Ascii85Stream(stream);
@@ -320,8 +318,7 @@ var Parser = (function ParserClosure() {
         return new RunLengthStream(stream);
       }
       if (name == 'JBIG2Decode') {
-        var bytes = stream.getBytes(length);
-        return new Jbig2Stream(bytes, stream.dict);
+        return new Jbig2Stream(stream, length, stream.dict);
       }
       warn('filter "' + name + '" not supported yet');
       return stream;

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals bytesToString, ColorSpace, Dict, EOF, error, info, Jbig2Image,
-           JpegImage, JpxImage, Lexer, Util, PDFJS, isArray, warn */
+/* globals bytesToString, ColorSpace, Dict, EOF, error, info, isArray,
+           Jbig2Image, JpegImage, JpxImage, Lexer, PDFJS, shadow, Util, warn */
 
 'use strict';
 
@@ -777,16 +777,24 @@ var PredictorStream = (function PredictorStreamClosure() {
  * DecodeStreams.
  */
 var JpegStream = (function JpegStreamClosure() {
-  function JpegStream(bytes, dict, xref) {
+  function JpegStream(stream, length, dict, xref) {
     // TODO: per poppler, some images may have 'junk' before that
     // need to be removed
+    this.stream = stream;
+    this.length = length;
     this.dict = dict;
-    this.bytes = bytes;
 
     DecodeStream.call(this);
   }
 
   JpegStream.prototype = Object.create(DecodeStream.prototype);
+
+  Object.defineProperty(JpegStream.prototype, 'bytes', {
+    get: function JpegStream_bytes() {
+      return shadow(this, 'bytes', this.stream.getBytes(this.length));
+    },
+    configurable: true
+  });
 
   JpegStream.prototype.ensureBuffer = function JpegStream_ensureBuffer(req) {
     if (this.bufferLength)
@@ -836,14 +844,22 @@ var JpegStream = (function JpegStreamClosure() {
  * the stream behaves like all the other DecodeStreams.
  */
 var JpxStream = (function JpxStreamClosure() {
-  function JpxStream(bytes, dict) {
+  function JpxStream(stream, length, dict) {
+    this.stream = stream;
+    this.length = length;
     this.dict = dict;
-    this.bytes = bytes;
 
     DecodeStream.call(this);
   }
 
   JpxStream.prototype = Object.create(DecodeStream.prototype);
+
+  Object.defineProperty(JpxStream.prototype, 'bytes', {
+    get: function JpxStream_bytes() {
+      return shadow(this, 'bytes', this.stream.getBytes(this.length));
+    },
+    configurable: true
+  });
 
   JpxStream.prototype.ensureBuffer = function JpxStream_ensureBuffer(req) {
     if (this.bufferLength)
@@ -935,14 +951,22 @@ var JpxStream = (function JpxStreamClosure() {
  * the stream behaves like all the other DecodeStreams.
  */
 var Jbig2Stream = (function Jbig2StreamClosure() {
-  function Jbig2Stream(bytes, dict) {
+  function Jbig2Stream(stream, length, dict) {
+    this.stream = stream;
+    this.length = length;
     this.dict = dict;
-    this.bytes = bytes;
 
     DecodeStream.call(this);
   }
 
   Jbig2Stream.prototype = Object.create(DecodeStream.prototype);
+
+  Object.defineProperty(Jbig2Stream.prototype, 'bytes', {
+    get: function Jbig2Stream_bytes() {
+      return shadow(this, 'bytes', this.stream.getBytes(this.length));
+    },
+    configurable: true
+  });
 
   Jbig2Stream.prototype.ensureBuffer = function Jbig2Stream_ensureBuffer(req) {
     if (this.bufferLength)


### PR DESCRIPTION
The first two patches in this pull request reduce the load time of http://www.minotnd.org/pdf/engineering/sanitary%20sewer/24x36_ntrunk.pdf (when loaded through a local web server rather than directly from file), from ~28 seconds to ~6 seconds, and reduce peak memory consumption from ~405 MiB to ~355 MiB.

The third patch doesn't have any effect on the load time/memory consumption of the files I tested, but it's certainly conceivable that there are files for which it would help. Getting all of a stream's bytes up-front is an anti-pattern that's worth avoiding in general.
