### PR TITLE
Improve image mask handling again

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -14,10 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals assert, assertWellFormed, ColorSpace, Dict, Encodings, error,
-           ErrorFont, Font, FONT_IDENTITY_MATRIX, fontCharsToUnicode, FontFlags,
-           ImageKind, info, isArray, isCmd, isDict, isEOF, isName, isNum,
-           isStream, isString, JpegStream, Lexer, Metrics, Name, Parser,
+/* globals assert, assertWellFormed, ColorSpace, DecodeStream, Dict, Encodings,
+           error, ErrorFont, Font, FONT_IDENTITY_MATRIX, fontCharsToUnicode,
+           FontFlags, ImageKind, info, isArray, isCmd, isDict, isEOF, isName,
+           isNum, isStream, isString, JpegStream, Lexer, Metrics, Name, Parser,
            Pattern, PDFImage, PDFJS, serifFonts, stdFontMap, symbolsFonts,
            getTilingPatternIR, warn, Util, Promise, LegacyPromise,
            RefSetCache, isRef, TextRenderingMode, CMapFactory, OPS,
@@ -146,10 +146,12 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         var bitStrideLength = (width + 7) >> 3;
         var imgArray = image.getBytes(bitStrideLength * height);
         var decode = dict.get('Decode', 'D');
+        var canTransfer = image instanceof DecodeStream;
         var inverseDecode = !!decode && decode[0] > 0;
 
         operatorList.addOp(OPS.paintImageMaskXObject,
-          [PDFImage.createMask(imgArray, width, height, inverseDecode)]
+          [PDFImage.createMask(imgArray, width, height, canTransfer,
+                               inverseDecode)]
         );
         return;
       }

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -209,19 +209,25 @@ var PDFImage = (function PDFImageClosure() {
     return temp;
   };
 
-  PDFImage.createMask = function PDFImage_createMask(imgArray, width, height,
-                                                     inverseDecode) {
-    // Copy imgArray into a typed array (inverting if necessary) so it can be
-    // transferred to the main thread.
+  PDFImage.createMask =
+      function PDFImage_createMask(imgArray, width, height, canTransfer,
+                                   inverseDecode) {
+    // If imgArray came from a DecodeStream, we're safe to transfer it.
+    // Otherwise, copy it.
     var actualLength = imgArray.byteLength;
-    var data = new Uint8Array(actualLength);
+    var data;
+    if (canTransfer) {
+      data = imgArray;
+    } else {
+      data = new Uint8Array(actualLength);
+      data.set(imgArray);
+    }
+    // Invert if necessary. It's safe to modify the array -- whether it's the
+    // original or a copy, we're about to transfer it anyway, so nothing else
+    // in this thread can be relying on its contents.
     if (inverseDecode) {
       for (var i = 0; i < actualLength; i++) {
-        data[i] = ~imgArray[i];
-      }
-    } else {
-      for (var i = 0; i < actualLength; i++) {
-        data[i] = imgArray[i];
+        data[i] = ~data[i];
       }
     }
 

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -213,14 +213,14 @@ var PDFImage = (function PDFImageClosure() {
                                                      inverseDecode) {
     // Copy imgArray into a typed array (inverting if necessary) so it can be
     // transferred to the main thread.
-    var length = ((width + 7) >> 3) * height;
-    var data = new Uint8Array(length);
+    var actualLength = imgArray.byteLength;
+    var data = new Uint8Array(actualLength);
     if (inverseDecode) {
-      for (var i = 0; i < length; i++) {
+      for (var i = 0; i < actualLength; i++) {
         data[i] = ~imgArray[i];
       }
     } else {
-      for (var i = 0; i < length; i++) {
+      for (var i = 0; i < actualLength; i++) {
         data[i] = imgArray[i];
       }
     }


### PR DESCRIPTION
The first patch fixes a what I believe is a bug in the handling of image masks when the amount of data falls short of height*width. This causes the test for issue2984.pdf to fail, but that's because the previous rendering was incorrect, featuring lots of thin horizontal lines at the tops of many letters. This patch causes those lines to disappear, which is the same result given by evince and Mac Preview.

The second patch optimizates mask handling by transferring image mask arrays where possible, instead of copying. I have two test files involving image masks, and the reduction in peak RSS was as follows:
- bach:  ~310 MiB to ~280 MiB
- 37335: ~255 MiB to ~230 MiB
