### PR TITLE
Making extensions/chromium/*.js adhere to the style guide

### DIFF
--- a/extensions/chromium/chrome.tabs.executeScriptInFrame.js
+++ b/extensions/chromium/chrome.tabs.executeScriptInFrame.js
@@ -5,7 +5,7 @@
  *
  * Implements the chrome.tabs.executeScriptInFrame API.
  * This API is similar to the chrome.tabs.executeScript method, except
- *  that it also recognizes the "frameId" property.
+ * that it also recognizes the "frameId" property.
  * This frameId can be obtained through the webNavigation or webRequest API.
  *
  * When an error occurs, chrome.runtime.lastError is set.
@@ -18,32 +18,36 @@
  * In addition, the following field must also be set in manifest.json:
  * "web_accessible_resources": ["getFrameId"]
  */
+/* globals chrome, console */
 
 (function() {
-/* jshint browser:true, maxlen:100 */
-/* globals chrome, console */
-'use strict';
-chrome.tabs.executeScriptInFrame = executeScript;
+  /* jshint browser:true, maxlen:100 */
+  'use strict';
 
-// This URL is used to communicate the frameId. The resource is never visited, so it should
-// be a non-existent location. Do not use *, ", ' or line breaks in the file name.
-var URL_WHAT_IS_MY_FRAME_ID = chrome.extension.getURL('getFrameId');
-// The callback will be called within ... ms:
-// Don't set a too low value.
-var MAXIMUM_RESPONSE_TIME_MS = 1000;
+  chrome.tabs.executeScriptInFrame = executeScript;
 
-// Callbacks are stored here until they're invoked.
-// Key = dummyUrl, value = callback function
-var callbacks = {};
+  // This URL is used to communicate the frameId. The resource is never
+  // visited, so it should be a non-existent location. Do not use *, ", '
+  // or line breaks in the file name.
+  var URL_WHAT_IS_MY_FRAME_ID = chrome.extension.getURL('getFrameId');
+  // The callback will be called within ... ms:
+  // Don't set a too low value.
+  var MAXIMUM_RESPONSE_TIME_MS = 1000;
 
-chrome.webRequest.onBeforeRequest.addListener(function showFrameId(details) {
+  // Callbacks are stored here until they're invoked.
+  // Key = dummyUrl, value = callback function
+  var callbacks = {};
+
+  chrome.webRequest.onBeforeRequest.addListener(function showFrameId(details) {
     // Positive integer frameId >= 0
-    // Since an image is used as a data transport, we add 1 to get a non-zero width.
+    // Since an image is used as a data transport, we add 1 to get a
+    // non-zero width.
     var frameId = details.frameId + 1;
-    // Assume that the frameId fits in three bytes - which is a very reasonable assumption.
+    // Assume that the frameId fits in three bytes - which is a very
+    // reasonable assumption.
     var width = String.fromCharCode(frameId & 0xFF, (frameId >> 8) & 0xFF);
-    // When frameId > 0xFFFF, use the height to convey the additional information.
-    // Again, add 1 to make sure that the height is non-zero.
+    // When frameId > 0xFFFF, use the height to convey the additional
+    // information. Again, add 1 to make sure that the height is non-zero.
     var height = String.fromCharCode((frameId >> 16) + 1, 0);
     // Convert data to base64 to avoid loss of bytes
     var image = 'data:image/gif;base64,' + btoa(
@@ -76,184 +80,204 @@ chrome.webRequest.onBeforeRequest.addListener(function showFrameId(details) {
                 // GIF trailer
                 '\x3b'
                 );
-        return {redirectUrl: image};
-}, {
+    return {redirectUrl: image};
+  }, {
     urls: [URL_WHAT_IS_MY_FRAME_ID + '*'],
     types: ['image']
-}, ['blocking']);
+  }, ['blocking']);
 
-chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
+  chrome.runtime.onMessage.addListener(function(message, sender,
+                                                sendResponse) {
     if (message && message.executeScriptCallback) {
-        var callback = callbacks[message.identifier];
-        if (callback) {
-            if (message.hello) {
-                clearTimeout(callback.timer);
-                return;
-            }
-            delete callbacks[message.identifier];
-            // Result within an array to be consistent with the chrome.tabs.executeScript API.
-            callback([message.evalResult]);
-        } else {
-            console.warn('Callback not found for response in tab ' + sender.tab.id);
+      var callback = callbacks[message.identifier];
+      if (callback) {
+        if (message.hello) {
+          clearTimeout(callback.timer);
+          return;
         }
+        delete callbacks[message.identifier];
+        // Result within an array to be consistent with the
+        // chrome.tabs.executeScript API.
+        callback([message.evalResult]);
+      } else {
+        console.warn('Callback not found for response in tab ' +
+                     sender.tab.id);
+      }
     }
-});
+  });
 
-/**
- * Execute content script in a specific frame.
- *
- * @param tabId {integer} required
- * @param details.frameId {integer} required
- * @param details.code {string} Code or file is required (not both)
- * @param details.file {string} Code or file is required (not both)
- * @param details.runAt {optional string} One of "document_start", "document_end", "document_idle"
- * @param callback {optional function(optional array of any result)} When an error occurs, result
- *                                                                   is not set.
- */
-function executeScript(tabId, details, callback) {
-    console.assert(typeof details === 'object', 'details must be an object (argument 0)');
+  /**
+   * Execute content script in a specific frame.
+   *
+   * @param tabId {integer} required
+   * @param details.frameId {integer} required
+   * @param details.code {string} Code or file is required (not both)
+   * @param details.file {string} Code or file is required (not both)
+   * @param details.runAt {optional string} One of "document_start",
+   *                                        "document_end", "document_idle"
+   * @param callback {optional function(optional result array)} When an error
+   *                                                            occurs, result
+   *                                                            is not set.
+   */
+  function executeScript(tabId, details, callback) {
+    console.assert(typeof details === 'object',
+                  'details must be an object (argument 0)');
     var frameId = details.frameId;
-    console.assert(typeof tabId === 'number', 'details.tabId must be a number');
-    console.assert(typeof frameId === 'number', 'details.frameId must be a number');
-    var sourceType = 'code' in details ? 'code' : 'file';
+    console.assert(typeof tabId === 'number',
+                  'details.tabId must be a number');
+    console.assert(typeof frameId === 'number',
+                  'details.frameId must be a number');
+    var sourceType = ('code' in details ? 'code' : 'file');
     console.assert(sourceType in details, 'No source code or file specified');
     var sourceValue = details[sourceType];
-    console.assert(typeof sourceValue === 'string', 'details.' + sourceType + ' must be a string');
+    console.assert(typeof sourceValue === 'string',
+                  'details.' + sourceType + ' must be a string');
     var runAt = details.runAt;
-    if (!callback) callback = function() {/* no-op*/};
-    console.assert(typeof callback === 'function', 'callback must be a function');
+    if (!callback) {
+      callback = function() {/* no-op*/};
+    }
+    console.assert(typeof callback === 'function',
+                  'callback must be a function');
 
     if (frameId === 0) {
-        // No need for heavy lifting if we want to inject the script in the main frame
-        var injectDetails = {
-            allFrames: false,
-            runAt: runAt
-        };
-        injectDetails[sourceType] = sourceValue;
-        chrome.tabs.executeScript(tabId, injectDetails, callback);
-        return;
+      // No need for heavy lifting if we want to inject the script
+      // in the main frame
+      var injectDetails = {
+        allFrames: false,
+        runAt: runAt
+      };
+      injectDetails[sourceType] = sourceValue;
+      chrome.tabs.executeScript(tabId, injectDetails, callback);
+      return;
     }
 
     var identifier = Math.random().toString(36);
 
     if (sourceType === 'code') {
-        executeScriptInFrame();
+      executeScriptInFrame();
     } else { // sourceType === 'file'
-        (function() {
-            var x = new XMLHttpRequest();
-            x.open('GET', chrome.extension.getURL(sourceValue), true);
-            x.onload = function() {
-                sourceValue = x.responseText;
-                executeScriptInFrame();
-            };
-            x.onerror = function executeScriptResourceFetchError() {
-                var message = 'Failed to load file: "' + sourceValue + '".';
-                console.error('executeScript: ' + message);
-                chrome.runtime.lastError = chrome.extension.lastError = { message: message };
-                try {
-                    callback();
-                } finally {
-                    chrome.runtime.lastError = chrome.extension.lastError = undefined;
-                }
-            };
-            x.send();
-        })();
+      (function() {
+        var x = new XMLHttpRequest();
+        x.open('GET', chrome.extension.getURL(sourceValue), true);
+        x.onload = function() {
+          sourceValue = x.responseText;
+          executeScriptInFrame();
+        };
+        x.onerror = function executeScriptResourceFetchError() {
+          var message = 'Failed to load file: "' + sourceValue + '".';
+          console.error('executeScript: ' + message);
+          chrome.runtime.lastError = chrome.extension.lastError =
+            { message: message };
+          try {
+            callback();
+          } finally {
+            chrome.runtime.lastError = chrome.extension.lastError = undefined;
+          }
+        };
+        x.send();
+      })();
     }
-
 
     function executeScriptInFrame() {
-        callbacks[identifier] = callback;
-        chrome.tabs.executeScript(tabId, {
-            code: '(' + DETECT_FRAME + ')(' +
-                  'window,' +
-                  JSON.stringify(identifier) + ',' +
-                  frameId + ',' +
-                  JSON.stringify(sourceValue) + ')',
-            allFrames: true,
-            runAt: 'document_start'
-        }, function(results) {
-            if (results) {
-                callback.timer = setTimeout(executeScriptTimedOut, MAXIMUM_RESPONSE_TIME_MS);
-            } else {
-                // Failed :(
-                delete callbacks[identifier];
-                callback();
-            }
-        });
-    }
-    function executeScriptTimedOut() {
-        var callback = callbacks[identifier];
-        if (!callback) {
-            return;
+      callbacks[identifier] = callback;
+      chrome.tabs.executeScript(tabId, {
+        code: '(' + DETECT_FRAME + ')(' +
+              'window,' +
+               JSON.stringify(identifier) + ',' +
+               frameId + ',' +
+               JSON.stringify(sourceValue) + ')',
+        allFrames: true,
+        runAt: 'document_start'
+      }, function(results) {
+        if (results) {
+          callback.timer = setTimeout(executeScriptTimedOut,
+                                      MAXIMUM_RESPONSE_TIME_MS);
+        } else {
+          // Failed :(
+          delete callbacks[identifier];
+          callback();
         }
-        delete callbacks[identifier];
-        var message = 'Failed to execute script: Frame ' + frameId + ' not found in tab ' + tabId;
-        console.error('executeScript: ' + message);
-        chrome.runtime.lastError = chrome.extension.lastError = { message: message };
-        try {
-            callback();
-        } finally {
-            chrome.runtime.lastError = chrome.extension.lastError = undefined;
-        }
+      });
     }
-}
 
-/**
- * Code executed as a content script.
- */
-var DETECT_FRAME = '' + function checkFrame(window, identifier, frameId, code) {
+    function executeScriptTimedOut() {
+      var callback = callbacks[identifier];
+      if (!callback) {
+        return;
+      }
+      delete callbacks[identifier];
+      var message = 'Failed to execute script: Frame ' + frameId +
+                    ' not found in tab ' + tabId;
+      console.error('executeScript: ' + message);
+      chrome.runtime.lastError = chrome.extension.lastError =
+        { message: message };
+      try {
+          callback();
+      } finally {
+          chrome.runtime.lastError = chrome.extension.lastError = undefined;
+      }
+    }
+  }
+
+  /**
+   * Code executed as a content script.
+   */
+  var DETECT_FRAME = '' + function checkFrame(window, identifier, frameId,
+                                              code) {
     var i;
     if ('__executeScript_frameId__' in window) {
-        evalAsContentScript();
+      evalAsContentScript();
     } else {
-        // Do NOT use new Image(), because of http://crbug.com/245296 in Chrome 27-29
-        i = window.document.createElement('img');
-        i.onload = function() {
-            window.__executeScript_frameId__ = (this.naturalWidth - 1) +
-                                               (this.naturalHeight - 1 << 16);
-            evalAsContentScript();
-        };
-        // Trigger webRequest event to get frameId
-        // (append extra characters to bust the cache)
-        i.src = 'URL_WHAT_IS_MY_FRAME_ID?' + Math.random().toString(36).slice(-6);
+      // Do NOT use new Image() because of http://crbug.com/245296
+      // in Chrome 27-29
+      i = window.document.createElement('img');
+      i.onload = function() {
+        window.__executeScript_frameId__ = (this.naturalWidth - 1) +
+                                           (this.naturalHeight - 1 << 16);
+        evalAsContentScript();
+      };
+      // Trigger webRequest event to get frameId
+      // (append extra characters to bust the cache)
+      i.src = 'URL_WHAT_IS_MY_FRAME_ID?' +
+               Math.random().toString(36).slice(-6);
     }
 
     for (i = 0 ; i < window.frames.length; ++i) {
-        try {
-            var frame = window.frames[i];
-            var scheme = frame.location.protocol;
-            if (scheme !== 'https:' && scheme !== 'http:' && scheme !== 'file:') {
-                checkFrame(frame, identifier, frameId, code);
-            }
-        } catch (e) {
-            // blocked by same origin policy, so it's not a javascript: / about:blank
-            // URL. chrome.tabs.executeScript will run the script for the frame.
+      try {
+        var frame = window.frames[i];
+        var scheme = frame.location.protocol;
+        if (scheme !== 'https:' && scheme !== 'http:' && scheme !== 'file:') {
+          checkFrame(frame, identifier, frameId, code);
         }
+      } catch (e) {
+        // blocked by same origin policy, so it's not a javascript:/about:blank
+        // URL. chrome.tabs.executeScript will run the script for the frame.
+      }
     }
-    function evalAsContentScript() {
-        if (window.__executeScript_frameId__ !== frameId) {
-            return;
-        }
-        // Send an early message to make sure that any blocking code
-        // in the evaluated code does not cause the time-out in the background page
-        // to be triggered
-        chrome.runtime.sendMessage({
-            executeScriptCallback: true,
-            hello: true,
-            identifier: identifier
-        });
-        var result = null;
-        try {
-            // jshint evil:true
-            result = window.eval(code);
-        } finally {
-            chrome.runtime.sendMessage({
-                executeScriptCallback: true,
-                evalResult: result,
-                identifier: identifier
-            });
-        }
-    }
-}.toString().replace('URL_WHAT_IS_MY_FRAME_ID', URL_WHAT_IS_MY_FRAME_ID);
 
+    function evalAsContentScript() {
+      if (window.__executeScript_frameId__ !== frameId) {
+        return;
+      }
+      // Send an early message to make sure that any blocking code
+      // in the evaluated code does not cause the time-out in the background
+      // page to be triggered
+      chrome.runtime.sendMessage({
+        executeScriptCallback: true,
+        hello: true,
+        identifier: identifier
+      });
+      var result = null;
+      try {
+        // jshint evil:true
+        result = window.eval(code);
+      } finally {
+        chrome.runtime.sendMessage({
+          executeScriptCallback: true,
+          evalResult: result,
+          identifier: identifier
+        });
+      }
+    }
+  }.toString().replace('URL_WHAT_IS_MY_FRAME_ID', URL_WHAT_IS_MY_FRAME_ID);
 })();

--- a/extensions/chromium/extension-router.js
+++ b/extensions/chromium/extension-router.js
@@ -18,6 +18,7 @@ limitations under the License.
 /* globals chrome */
 
 'use strict';
+
 (function ExtensionRouterClosure() {
   var VIEWER_URL = chrome.extension.getURL('content/web/viewer.html');
   var CRX_BASE_URL = chrome.extension.getURL('/');
@@ -102,11 +103,11 @@ limitations under the License.
       return { redirectUrl: url };
     }
   }, {
-      types: ['main_frame', 'sub_frame'],
-      urls: schemes.map(function(scheme) {
-        // Format: "chrome-extension://[EXTENSIONID]/<scheme>*"
-        return CRX_BASE_URL + scheme + '*';
-      })
+    types: ['main_frame', 'sub_frame'],
+    urls: schemes.map(function(scheme) {
+      // Format: "chrome-extension://[EXTENSIONID]/<scheme>*"
+      return CRX_BASE_URL + scheme + '*';
+    })
   }, ['blocking']);
 
   chrome.runtime.onMessage.addListener(function(message, sender) {

--- a/extensions/chromium/pdfHandler-v2.js
+++ b/extensions/chromium/pdfHandler-v2.js
@@ -18,244 +18,259 @@ limitations under the License.
 /* globals chrome, URL, getViewerURL */
 
 (function() {
-'use strict';
+  'use strict';
 
-if (!chrome.streamsPrivate) {
-  // Aww, PDF.js is still not whitelisted... See http://crbug.com/326949
-  console.warn('streamsPrivate not available, PDF from FTP or POST ' +
-               'requests will not be displayed using this extension! ' +
-               'See http://crbug.com/326949');
-  chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
-    if (message && message.action === 'getPDFStream') {
-      sendResponse();
-    }
-  });
-  return;
-}
-
-//
-// Stream URL storage manager
-//
-
-// Hash map of "<tab id>": { "<pdf url>": ["<stream url>", ...], ... }
-var urlToStream = {};
-
-chrome.streamsPrivate.onExecuteMimeTypeHandler.addListener(handleStream);
-
-// Chrome before 27 does not support tabIds on stream events.
-var streamSupportsTabId = true;
-// "tabId" used for Chrome before 27.
-var STREAM_NO_TABID = 0;
-
-function hasStream(tabId, pdfUrl) {
-  var streams = urlToStream[streamSupportsTabId ? tabId : STREAM_NO_TABID];
-  return streams && streams[pdfUrl] && streams[pdfUrl].length > 0;
-}
-
-/**
-* Get stream URL for a given tabId and PDF url. The retrieved stream URL
-* will be removed from the list.
-* @return {object} An object with property url (= blob:-URL) and
-*                                 property contentLength (= expected size)
-*/
-function getStream(tabId, pdfUrl) {
-  if (!streamSupportsTabId) tabId = STREAM_NO_TABID;
-  if (hasStream(tabId, pdfUrl)) {
-    var streamInfo = urlToStream[tabId][pdfUrl].shift();
-    if (urlToStream[tabId][pdfUrl].length === 0) {
-      delete urlToStream[tabId][pdfUrl];
-      if (Object.keys(urlToStream[tabId]).length === 0) {
-        delete urlToStream[tabId];
-      }
-    }
-    return streamInfo;
-  }
-}
-
-function setStream(tabId, pdfUrl, streamUrl, expectedSize) {
-  tabId = tabId || STREAM_NO_TABID;
-  if (!urlToStream[tabId]) urlToStream[tabId] = {};
-  if (!urlToStream[tabId][pdfUrl]) urlToStream[tabId][pdfUrl] = [];
-  urlToStream[tabId][pdfUrl].push({
-    streamUrl: streamUrl,
-    contentLength: expectedSize
-  });
-}
-
-// http://crbug.com/276898 - the onExecuteMimeTypeHandler event is sometimes
-// dispatched in the wrong incognito profile. To work around the bug, transfer
-// the stream information from the incognito session when the bug is detected.
-function transferStreamToIncognitoProfile(tabId, pdfUrl) {
-  if (chrome.extension.inIncognitoContext) {
-    console.log('Already within incognito profile. Aborted stream transfer.');
-    return;
-  }
-  var streamInfo = getStream(tabId, pdfUrl);
-  if (!streamInfo) {
-    return;
-  }
-  console.log('Attempting to transfer stream info to a different profile...');
-  var itemId = 'streamInfo:' + window.performance.now();
-  var items = {};
-  items[itemId] = {
-    tabId: tabId,
-    pdfUrl: pdfUrl,
-    streamUrl: streamInfo.streamUrl,
-    contentLength: streamInfo.contentLength
-  };
-  // The key will be removed whenever an incognito session is started,
-  // or when an incognito session is active.
-  chrome.storage.local.set(items, function() {
-    chrome.extension.isAllowedIncognitoAccess(function(isAllowedAccess) {
-      if (!isAllowedAccess) {
-        // If incognito is disabled, forget about the stream.
-        console.warn('Incognito is disabled, unexpected unknown stream.');
-        chrome.storage.local.remove(items);
+  if (!chrome.streamsPrivate) {
+    // Aww, PDF.js is still not whitelisted... See http://crbug.com/326949
+    console.warn('streamsPrivate not available, PDF from FTP or POST ' +
+                 'requests will not be displayed using this extension! ' +
+                 'See http://crbug.com/326949');
+    chrome.runtime.onMessage.addListener(function(message, sender,
+                                                  sendResponse) {
+      if (message && message.action === 'getPDFStream') {
+        sendResponse();
       }
     });
-  });
-}
-if (chrome.extension.inIncognitoContext) {
-  var importStream = function(itemId, streamInfo) {
-    if (itemId.lastIndexOf('streamInfo:', 0) !== 0) return;
-    console.log('Importing stream info from non-incognito profile', streamInfo);
-    handleStream('', streamInfo.pdfUrl, streamInfo.streamUrl, streamInfo.tabId,
-        streamInfo.contentLength);
-    chrome.storage.local.remove(itemId);
-  };
-  var handleStorageItems = function(items) {
-    Object.keys(items).forEach(function(itemId) {
-      var item = items[itemId];
-      if (item.oldValue && !item.newValue) return; // storage remove event
-      if (item.newValue) item = item.newValue;     // storage setter event
-      importStream(itemId, item);
-    });
-  };
-  // Parse information that was set before the event pages were ready.
-  chrome.storage.local.get(null, handleStorageItems);
-  chrome.storage.onChanged.addListener(handleStorageItems);
-}
-// End of work-around for crbug 276898
+    return;
+  }
 
-chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
-  if (message && message.action === 'getPDFStream') {
-    var pdfUrl = message.data;
-    var streamInfo = getStream(sender.tab.id, pdfUrl) || {};
-    sendResponse({
+  //
+  // Stream URL storage manager
+  //
+
+  // Hash map of "<tab id>": { "<pdf url>": ["<stream url>", ...], ... }
+  var urlToStream = {};
+
+  chrome.streamsPrivate.onExecuteMimeTypeHandler.addListener(handleStream);
+
+  // Chrome before 27 does not support tabIds on stream events.
+  var streamSupportsTabId = true;
+  // "tabId" used for Chrome before 27.
+  var STREAM_NO_TABID = 0;
+
+  function hasStream(tabId, pdfUrl) {
+    var streams = urlToStream[streamSupportsTabId ? tabId : STREAM_NO_TABID];
+    return (streams && streams[pdfUrl] && streams[pdfUrl].length > 0);
+  }
+
+  /**
+   * Get stream URL for a given tabId and PDF url. The retrieved stream URL
+   * will be removed from the list.
+   * @return {object} An object with property url (= blob:-URL) and
+   *                                 property contentLength (= expected size)
+   */
+  function getStream(tabId, pdfUrl) {
+    if (!streamSupportsTabId) {
+      tabId = STREAM_NO_TABID;
+    }
+    if (hasStream(tabId, pdfUrl)) {
+      var streamInfo = urlToStream[tabId][pdfUrl].shift();
+      if (urlToStream[tabId][pdfUrl].length === 0) {
+        delete urlToStream[tabId][pdfUrl];
+        if (Object.keys(urlToStream[tabId]).length === 0) {
+          delete urlToStream[tabId];
+        }
+      }
+      return streamInfo;
+    }
+  }
+
+  function setStream(tabId, pdfUrl, streamUrl, expectedSize) {
+    tabId = tabId || STREAM_NO_TABID;
+    if (!urlToStream[tabId]) {
+      urlToStream[tabId] = {};
+    }
+    if (!urlToStream[tabId][pdfUrl]) {
+      urlToStream[tabId][pdfUrl] = [];
+    }
+    urlToStream[tabId][pdfUrl].push({
+      streamUrl: streamUrl,
+      contentLength: expectedSize
+    });
+  }
+
+  // http://crbug.com/276898 - the onExecuteMimeTypeHandler event is sometimes
+  // dispatched in the wrong incognito profile. To work around the bug, transfer
+  // the stream information from the incognito session when the bug is detected.
+  function transferStreamToIncognitoProfile(tabId, pdfUrl) {
+    if (chrome.extension.inIncognitoContext) {
+      console.log('Already within incognito profile. Aborted stream transfer.');
+      return;
+    }
+    var streamInfo = getStream(tabId, pdfUrl);
+    if (!streamInfo) {
+      return;
+    }
+    console.log('Attempting to transfer stream info to a different profile...');
+    var itemId = 'streamInfo:' + window.performance.now();
+    var items = {};
+    items[itemId] = {
+      tabId: tabId,
+      pdfUrl: pdfUrl,
       streamUrl: streamInfo.streamUrl,
       contentLength: streamInfo.contentLength
+    };
+    // The key will be removed whenever an incognito session is started,
+    // or when an incognito session is active.
+    chrome.storage.local.set(items, function() {
+      chrome.extension.isAllowedIncognitoAccess(function(isAllowedAccess) {
+        if (!isAllowedAccess) {
+          // If incognito is disabled, forget about the stream.
+          console.warn('Incognito is disabled, unexpected unknown stream.');
+          chrome.storage.local.remove(items);
+        }
+      });
     });
   }
-});
 
-//
-// PDF detection and activation of PDF viewer.
-//
-
-/**
- * Callback for when we receive a stream
- *
- * @param mimeType {string} The mime type of the incoming stream
- * @param pdfUrl {string} The full URL to the file
- * @param streamUrl {string} The url pointing to the open stream
- * @param tabId {number} The ID of the tab in which the stream has been opened
- *                       (undefined before Chrome 27, http://crbug.com/225605)
- * @param expectedSize {number} The expected content length of the stream.
- *                       (added in Chrome 29, http://crbug.com/230346)
- */
-function handleStream(mimeType, pdfUrl, streamUrl, tabId, expectedSize) {
-  console.log('Intercepted ' + mimeType + ' in tab ' + tabId + ' with URL ' +
-              pdfUrl + '\nAvailable as: ' + streamUrl);
-  streamSupportsTabId = typeof tabId === 'number';
-
-  setStream(tabId, pdfUrl, streamUrl, expectedSize);
-
-  if (!tabId) { // Chrome doesn't set the tabId before v27
-    // PDF.js targets Chrome 28+ because of fatal bugs in incognito mode
-    // for older versions of Chrome. So, don't bother implementing a fallback.
-    // For those who are interested, either loop through all tabs, or use the
-    // webNavigation.onBeforeNavigate event to map pdfUrls to tab + frame IDs.
-    return;
-  }
-
-  // Check if the frame has already been rendered.
-  chrome.webNavigation.getAllFrames({
-    tabId: tabId
-  }, function(details) {
-    if (details) {
-      details = details.filter(function(frame) {
-        return frame.url === pdfUrl;
-      });
-      if (details.length > 0) {
-        if (details.length !== 1) {
-          // (Rare case) Multiple frames with same URL.
-          // TODO(rob): Find a better way to handle this case
-          //            (e.g. open in new tab).
-          console.warn('More than one frame found for tabId ' + tabId +
-            ' with URL ' + pdfUrl + '. Using first frame.');
-        }
-        details = details[0];
-        details = {
-          tabId: tabId,
-          frameId: details.frameId,
-          url: details.url
-        };
-        handleWebNavigation(details);
-      } else {
-        console.warn('No webNavigation frames found for tabId ' + tabId);
+  if (chrome.extension.inIncognitoContext) {
+    var importStream = function(itemId, streamInfo) {
+      if (itemId.lastIndexOf('streamInfo:', 0) !== 0) {
+        return;
       }
-    } else {
-      console.warn('Unable to get frame information for tabId ' + tabId);
-      // This branch may occur when a new incognito session is launched.
-      // The event is dispatched in the non-incognito session while it should
-      // be dispatched in the incognito session. See http://crbug.com/276898
-      transferStreamToIncognitoProfile(tabId, pdfUrl);
+      console.log('Importing stream info from non-incognito profile',
+                  streamInfo);
+      handleStream('', streamInfo.pdfUrl, streamInfo.streamUrl,
+        streamInfo.tabId, streamInfo.contentLength);
+      chrome.storage.local.remove(itemId);
+    };
+    var handleStorageItems = function(items) {
+      Object.keys(items).forEach(function(itemId) {
+        var item = items[itemId];
+        if (item.oldValue && !item.newValue) {
+          return; // storage remove event
+        }
+        if (item.newValue) {
+          item = item.newValue; // storage setter event
+        }
+        importStream(itemId, item);
+      });
+    };
+    // Parse information that was set before the event pages were ready.
+    chrome.storage.local.get(null, handleStorageItems);
+    chrome.storage.onChanged.addListener(handleStorageItems);
+  }
+  // End of work-around for crbug 276898
+
+  chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
+    if (message && message.action === 'getPDFStream') {
+      var pdfUrl = message.data;
+      var streamInfo = getStream(sender.tab.id, pdfUrl) || {};
+      sendResponse({
+        streamUrl: streamInfo.streamUrl,
+        contentLength: streamInfo.contentLength
+      });
     }
   });
-}
 
-/**
- * This method is called when the chrome.streamsPrivate API has intercepted
- *  the PDF stream. This method detects such streams, finds the frame where
- *  the request was made, and loads the viewer in that frame.
- *
- * @param details {object}
- * @param details.tabId {number} The ID of the tab
- * @param details.url {string} The URL being navigated when the error occurred.
- * @param details.frameId {number} 0 indicates the navigation happens in the tab
- *                                 content window; a positive value indicates
- *                                 navigation in a subframe.
- */
-function handleWebNavigation(details) {
-  var tabId = details.tabId;
-  var frameId = details.frameId;
-  var pdfUrl = details.url;
+  //
+  // PDF detection and activation of PDF viewer.
+  //
 
-  if (!hasStream(tabId, pdfUrl)) {
-    console.log('No PDF stream found in tab ' + tabId + ' for ' + pdfUrl);
-    return;
-  }
+  /**
+   * Callback for when we receive a stream
+   *
+   * @param mimeType {string} The mime type of the incoming stream
+   * @param pdfUrl {string} The full URL to the file
+   * @param streamUrl {string} The url pointing to the open stream
+   * @param tabId {number} The ID of the tab in which the stream has been opened
+   *                       (undefined before Chrome 27, http://crbug.com/225605)
+   * @param expectedSize {number} The expected content length of the stream.
+   *                       (added in Chrome 29, http://crbug.com/230346)
+   */
+  function handleStream(mimeType, pdfUrl, streamUrl, tabId, expectedSize) {
+    console.log('Intercepted ' + mimeType + ' in tab ' + tabId + ' with URL ' +
+                pdfUrl + '\nAvailable as: ' + streamUrl);
+    streamSupportsTabId = typeof tabId === 'number';
 
-  var viewerUrl = getViewerURL(pdfUrl);
+    setStream(tabId, pdfUrl, streamUrl, expectedSize);
 
-  if (frameId === 0) { // Main frame
-    console.log('Going to render PDF Viewer in main frame for ' + pdfUrl);
-    chrome.tabs.update(tabId, {
-      url: viewerUrl
-    });
-  } else {
-    console.log('Going to render PDF Viewer in sub frame for ' + pdfUrl);
-    // Non-standard Chrome API. chrome.tabs.executeScriptInFrame and docs
-    // is available at https://github.com/Rob--W/chrome-api
-    chrome.tabs.executeScriptInFrame(tabId, {
-      frameId: frameId,
-      code: 'location.href = ' + JSON.stringify(viewerUrl) + ';'
-    }, function(result) {
-      if (!result) { // Did the tab disappear? Is the frame inaccessible?
-        console.warn('Frame not found, viewer not rendered in tab ' + tabId);
+    if (!tabId) { // Chrome doesn't set the tabId before v27
+      // PDF.js targets Chrome 28+ because of fatal bugs in incognito mode
+      // for older versions of Chrome. So, don't bother implementing a fallback.
+      // For those who are interested, either loop through all tabs, or use the
+      // webNavigation.onBeforeNavigate event to map pdfUrls to tab + frame IDs.
+      return;
+    }
+
+    // Check if the frame has already been rendered.
+    chrome.webNavigation.getAllFrames({
+      tabId: tabId
+    }, function(details) {
+      if (details) {
+        details = details.filter(function(frame) {
+          return (frame.url === pdfUrl);
+        });
+        if (details.length > 0) {
+          if (details.length !== 1) {
+            // (Rare case) Multiple frames with same URL.
+            // TODO(rob): Find a better way to handle this case
+            //            (e.g. open in new tab).
+            console.warn('More than one frame found for tabId ' + tabId +
+                         ' with URL ' + pdfUrl + '. Using first frame.');
+          }
+          details = details[0];
+          details = {
+            tabId: tabId,
+            frameId: details.frameId,
+            url: details.url
+          };
+          handleWebNavigation(details);
+        } else {
+          console.warn('No webNavigation frames found for tabId ' + tabId);
+        }
+      } else {
+        console.warn('Unable to get frame information for tabId ' + tabId);
+        // This branch may occur when a new incognito session is launched.
+        // The event is dispatched in the non-incognito session while it should
+        // be dispatched in the incognito session. See http://crbug.com/276898
+        transferStreamToIncognitoProfile(tabId, pdfUrl);
       }
     });
   }
-}
 
+  /**
+   * This method is called when the chrome.streamsPrivate API has intercepted
+   *  the PDF stream. This method detects such streams, finds the frame where
+   *  the request was made, and loads the viewer in that frame.
+   *
+   * @param details {object}
+   * @param details.tabId {number} The ID of the tab
+   * @param details.url {string} The URL being navigated when the error
+   *                             occurred.
+   * @param details.frameId {number} 0 indicates the navigation happens in
+   *                                 the tab content window; a positive value
+   *                                 indicates navigation in a subframe.
+   */
+  function handleWebNavigation(details) {
+    var tabId = details.tabId;
+    var frameId = details.frameId;
+    var pdfUrl = details.url;
+
+    if (!hasStream(tabId, pdfUrl)) {
+      console.log('No PDF stream found in tab ' + tabId + ' for ' + pdfUrl);
+      return;
+    }
+
+    var viewerUrl = getViewerURL(pdfUrl);
+
+    if (frameId === 0) { // Main frame
+      console.log('Going to render PDF Viewer in main frame for ' + pdfUrl);
+      chrome.tabs.update(tabId, {
+        url: viewerUrl
+      });
+    } else {
+      console.log('Going to render PDF Viewer in sub frame for ' + pdfUrl);
+      // Non-standard Chrome API. chrome.tabs.executeScriptInFrame and docs
+      // is available at https://github.com/Rob--W/chrome-api
+      chrome.tabs.executeScriptInFrame(tabId, {
+        frameId: frameId,
+        code: 'location.href = ' + JSON.stringify(viewerUrl) + ';'
+      }, function(result) {
+        if (!result) { // Did the tab disappear? Is the frame inaccessible?
+          console.warn('Frame not found, viewer not rendered in tab ' + tabId);
+        }
+      });
+    }
+  }
 })();

--- a/extensions/chromium/pdfHandler-vcros.js
+++ b/extensions/chromium/pdfHandler-vcros.js
@@ -29,7 +29,8 @@ limitations under the License.
   /**
    * Invoked when "Open with PDF Viewer" is chosen in the File browser.
    *
-   * @param {String} id      File browser action ID as specified in manifest.json
+   * @param {String} id      File browser action ID as specified in
+   *                         manifest.json
    * @param {Object} details Object of type FileHandlerExecuteEventDetails
    */
   function onExecuteFileBrowserHandler(id, details) {

--- a/extensions/chromium/pdfHandler-vcros.js
+++ b/extensions/chromium/pdfHandler-vcros.js
@@ -18,78 +18,77 @@ limitations under the License.
 /* globals chrome, getViewerURL */
 
 (function() {
-'use strict';
+  'use strict';
 
-if (!chrome.fileBrowserHandler) {
-  // Not on Chromium OS, bail out
-  return;
-}
-chrome.fileBrowserHandler.onExecute.addListener(onExecuteFileBrowserHandler);
-
-/**
- * Invoked when "Open with PDF Viewer" is chosen in the File browser.
- *
- * @param {String} id      File browser action ID as specified in manifest.json
- * @param {Object} details Object of type FileHandlerExecuteEventDetails
- */
-function onExecuteFileBrowserHandler(id, details) {
-  if (id !== 'open-as-pdf') {
+  if (!chrome.fileBrowserHandler) {
+    // Not on Chromium OS, bail out
     return;
   }
-  var fileEntries = details.entries;
-  // "tab_id" is the currently documented format, but it is inconsistent with
-  // the other Chrome APIs that use "tabId" (http://crbug.com/179767)
-  var tabId = details.tab_id || details.tabId;
-  if (tabId > 0) {
-    chrome.tabs.get(tabId, function(tab) {
-      openViewer(tab && tab.windowId, fileEntries);
-    });
-  } else {
-    // Re-use existing window, if available.
-    chrome.windows.getLastFocused(function(chromeWindow) {
-      var windowId = chromeWindow && chromeWindow.id;
-      if (windowId) {
-        chrome.windows.update(windowId, { focused: true });
-      }
-      openViewer(windowId, fileEntries);
-    });
-  }
-}
+  chrome.fileBrowserHandler.onExecute.addListener(onExecuteFileBrowserHandler);
 
-/**
- * Open the PDF Viewer for the given list of PDF files.
- *
- * @param {number} windowId
- * @param {Array} fileEntries List of Entry objects (HTML5 FileSystem API)
- */
-function openViewer(windowId, fileEntries) {
-  if (!fileEntries.length) {
-    return;
+  /**
+   * Invoked when "Open with PDF Viewer" is chosen in the File browser.
+   *
+   * @param {String} id      File browser action ID as specified in manifest.json
+   * @param {Object} details Object of type FileHandlerExecuteEventDetails
+   */
+  function onExecuteFileBrowserHandler(id, details) {
+    if (id !== 'open-as-pdf') {
+      return;
+    }
+    var fileEntries = details.entries;
+    // "tab_id" is the currently documented format, but it is inconsistent with
+    // the other Chrome APIs that use "tabId" (http://crbug.com/179767)
+    var tabId = details.tab_id || details.tabId;
+    if (tabId > 0) {
+      chrome.tabs.get(tabId, function(tab) {
+        openViewer(tab && tab.windowId, fileEntries);
+      });
+    } else {
+      // Re-use existing window, if available.
+      chrome.windows.getLastFocused(function(chromeWindow) {
+        var windowId = chromeWindow && chromeWindow.id;
+        if (windowId) {
+          chrome.windows.update(windowId, { focused: true });
+        }
+        openViewer(windowId, fileEntries);
+      });
+    }
   }
-  var fileEntry = fileEntries.shift();
-  var url = fileEntry.toURL();
-  // Use drive: alias to get shorter (more human-readable) URLs.
-  url = url.replace(/^filesystem:chrome-extension:\/\/[a-p]{32}\/external\//,
-      'drive:');
-  url = getViewerURL(url);
 
-  if (windowId) {
-    chrome.tabs.create({
-      windowId: windowId,
-      active: true,
-      url: url
-    }, function() {
-      openViewer(windowId, fileEntries);
-    });
-  } else {
-    chrome.windows.create({
-      type: 'normal',
-      focused: true,
-      url: url
-    }, function(chromeWindow) {
-      openViewer(chromeWindow.id, fileEntries);
-    });
+  /**
+   * Open the PDF Viewer for the given list of PDF files.
+   *
+   * @param {number} windowId
+   * @param {Array} fileEntries List of Entry objects (HTML5 FileSystem API)
+   */
+  function openViewer(windowId, fileEntries) {
+    if (!fileEntries.length) {
+      return;
+    }
+    var fileEntry = fileEntries.shift();
+    var url = fileEntry.toURL();
+    // Use drive: alias to get shorter (more human-readable) URLs.
+    url = url.replace(/^filesystem:chrome-extension:\/\/[a-p]{32}\/external\//,
+                      'drive:');
+    url = getViewerURL(url);
+
+    if (windowId) {
+      chrome.tabs.create({
+        windowId: windowId,
+        active: true,
+        url: url
+      }, function() {
+        openViewer(windowId, fileEntries);
+      });
+    } else {
+      chrome.windows.create({
+        type: 'normal',
+        focused: true,
+        url: url
+      }, function(chromeWindow) {
+        openViewer(chromeWindow.id, fileEntries);
+      });
+    }
   }
-}
-
 })();

--- a/extensions/chromium/pdfHandler.js
+++ b/extensions/chromium/pdfHandler.js
@@ -31,15 +31,17 @@ function getViewerURL(pdf_url) {
  * @return {boolean} True if the PDF file should be downloaded.
  */
 function isPdfDownloadable(details) {
-  if (details.url.indexOf('pdfjs.action=download') >= 0)
+  if (details.url.indexOf('pdfjs.action=download') >= 0) {
     return true;
+  }
   // Display the PDF viewer regardless of the Content-Disposition header
   // if the file is displayed in the main frame.
-  if (details.type == 'main_frame')
+  if (details.type == 'main_frame') {
     return false;
-  var cdHeader = details.responseHeaders &&
-    getHeaderFromHeaders(details.responseHeaders, 'content-disposition');
-  return cdHeader && /^attachment/i.test(cdHeader.value);
+  }
+  var cdHeader = (details.responseHeaders &&
+    getHeaderFromHeaders(details.responseHeaders, 'content-disposition'));
+  return (cdHeader && /^attachment/i.test(cdHeader.value));
 }
 
 /**
@@ -67,9 +69,9 @@ function isPdfFile(details) {
   var header = getHeaderFromHeaders(details.responseHeaders, 'content-type');
   if (header) {
     var headerValue = header.value.toLowerCase().split(';',1)[0].trim();
-    return headerValue === 'application/pdf' ||
-      headerValue === 'application/octet-stream' &&
-      details.url.toLowerCase().indexOf('.pdf') > 0;
+    return (headerValue === 'application/pdf' ||
+            headerValue === 'application/octet-stream' &&
+            details.url.toLowerCase().indexOf('.pdf') > 0);
   }
 }
 
@@ -83,16 +85,16 @@ function isPdfFile(details) {
  *                            have been modified, undefined otherwise.
  */
 function getHeadersWithContentDispositionAttachment(details) {
-    var headers = details.responseHeaders;
-    var cdHeader = getHeaderFromHeaders(headers, 'content-disposition');
-    if (!cdHeader) {
-      cdHeader = {name: 'Content-Disposition'};
-      headers.push(cdHeader);
-    }
-    if (!/^attachment/i.test(cdHeader.value)) {
-      cdHeader.value = 'attachment' + cdHeader.value.replace(/^[^;]+/i, '');
-      return { responseHeaders: headers };
-    }
+  var headers = details.responseHeaders;
+  var cdHeader = getHeaderFromHeaders(headers, 'content-disposition');
+  if (!cdHeader) {
+    cdHeader = {name: 'Content-Disposition'};
+    headers.push(cdHeader);
+  }
+  if (!/^attachment/i.test(cdHeader.value)) {
+    cdHeader.value = 'attachment' + cdHeader.value.replace(/^[^;]+/i, '');
+    return { responseHeaders: headers };
+  }
 }
 
 chrome.webRequest.onHeadersReceived.addListener(
@@ -101,9 +103,9 @@ chrome.webRequest.onHeadersReceived.addListener(
       // Don't intercept POST requests until http://crbug.com/104058 is fixed.
       return;
     }
-    if (!isPdfFile(details))
+    if (!isPdfFile(details)) {
       return;
-
+    }
     if (isPdfDownloadable(details)) {
       // Force download by ensuring that Content-Disposition: attachment is set
       return getHeadersWithContentDispositionAttachment(details);
@@ -172,8 +174,9 @@ chrome.webRequest.onHeadersReceived.addListener(
 
 chrome.webRequest.onBeforeRequest.addListener(
   function(details) {
-    if (isPdfDownloadable(details))
+    if (isPdfDownloadable(details)) {
       return;
+    }
 
     // NOTE: The manifest file has declared an empty content script
     // at file://*/* to make sure that the viewer can load the PDF file


### PR DESCRIPTION
@Snuffleupagus I apologize in advance because this might be hard to review. Most files (especially `chrome.tabs.executeScriptInFrame.js`) were indented in a different way than in the style guide, so fixing that causes the diff here to be hard to parse. It might be easier to just use the `View` button for some files and go through the files to see if all is correct.

It would be nice if you could compile the Chrome extension and test it to make sure nothing is broken.
