### PR TITLE
Jbig2 optimizations

### DIFF
--- a/src/core/arithmetic_decoder.js
+++ b/src/core/arithmetic_decoder.js
@@ -128,41 +128,39 @@ var ArithmeticDecoder = (function ArithmeticDecoderClosure() {
       var cx_index = contexts[pos] >> 1, cx_mps = contexts[pos] & 1;
       var qeTableIcx = QeTable[cx_index];
       var qeIcx = qeTableIcx.qe;
-      var nmpsIcx = qeTableIcx.nmps;
-      var nlpsIcx = qeTableIcx.nlps;
-      var switchIcx = qeTableIcx.switchFlag;
       var d;
-      this.a -= qeIcx;
+      var a = this.a - qeIcx;
 
       if (this.chigh < qeIcx) {
         // exchangeLps
-        if (this.a < qeIcx) {
-          this.a = qeIcx;
+        if (a < qeIcx) {
+          a = qeIcx;
           d = cx_mps;
-          cx_index = nmpsIcx;
+          cx_index = qeTableIcx.nmps;
         } else {
-          this.a = qeIcx;
-          d = 1 - cx_mps;
-          if (switchIcx) {
+          a = qeIcx;
+          d = 1 ^ cx_mps;
+          if (qeTableIcx.switchFlag === 1) {
             cx_mps = d;
           }
-          cx_index = nlpsIcx;
+          cx_index = qeTableIcx.nlps;
         }
       } else {
         this.chigh -= qeIcx;
-        if ((this.a & 0x8000) !== 0) {
+        if ((a & 0x8000) !== 0) {
+          this.a = a;
           return cx_mps;
         }
         // exchangeMps
-        if (this.a < qeIcx) {
-          d = 1 - cx_mps;
-          if (switchIcx) {
+        if (a < qeIcx) {
+          d = 1 ^ cx_mps;
+          if (qeTableIcx.switchFlag === 1) {
             cx_mps = d;
           }
-          cx_index = nlpsIcx;
+          cx_index = qeTableIcx.nlps;
         } else {
           d = cx_mps;
-          cx_index = nmpsIcx;
+          cx_index = qeTableIcx.nmps;
         }
       }
       // C.3.3 renormD;
@@ -171,11 +169,12 @@ var ArithmeticDecoder = (function ArithmeticDecoderClosure() {
           this.byteIn();
         }
 
-        this.a <<= 1;
+        a <<= 1;
         this.chigh = ((this.chigh << 1) & 0xFFFF) | ((this.clow >> 15) & 1);
         this.clow = (this.clow << 1) & 0xFFFF;
         this.ct--;
-      } while ((this.a & 0x8000) === 0);
+      } while ((a & 0x8000) === 0);
+      this.a = a;
 
       contexts[pos] = cx_index << 1 | cx_mps;
       return d;

--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -961,11 +961,13 @@ var Jbig2Image = (function Jbig2ImageClosure() {
       var combinationOperator = pageInfo.combinationOperatorOverride ?
         regionInfo.combinationOperator : pageInfo.combinationOperator;
       var buffer = this.buffer;
+      var mask0 =  128 >> (regionInfo.x & 7);
+      var offset0 = regionInfo.y * rowSize + (regionInfo.x >> 3);
       switch (combinationOperator) {
         case 0: // OR
           for (var i = 0; i < height; i++) {
-            var mask = 128 >> (regionInfo.x & 7);
-            var offset = (i + regionInfo.y) * rowSize + (regionInfo.x >> 3);
+            var mask = mask0;
+            var offset = offset0;
             for (var j = 0; j < width; j++) {
               if (bitmap[i][j]) {
                 buffer[offset] |= mask;
@@ -976,12 +978,13 @@ var Jbig2Image = (function Jbig2ImageClosure() {
                 offset++;
               }
             }
+            offset0 += rowSize;
           }
         break;
         case 2: // XOR
           for (var i = 0; i < height; i++) {
-            var mask = 128 >> (regionInfo.x & 7);
-            var offset = (i + regionInfo.y) * rowSize + (regionInfo.x >> 3);
+            var mask = mask0;
+            var offset = offset0;
             for (var j = 0; j < width; j++) {
               if (bitmap[i][j]) {
                 buffer[offset] ^= mask;
@@ -992,6 +995,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
                 offset++;
               }
             }
+            offset0 += rowSize;
           }
           break;
         default:

--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -273,6 +273,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     var sbb_right = width - maxX;
 
     var pseudoPixelContext = ReusedContexts[templateIndex];
+    var row = new Uint8Array(width);
     var bitmap = [];
 
     var decoder = decodingContext.decoder;
@@ -284,11 +285,11 @@ var Jbig2Image = (function Jbig2ImageClosure() {
         var sltp = decoder.readBit(contexts, pseudoPixelContext);
         ltp ^= sltp;
         if (ltp) {
-          bitmap[i] = row;//bitmap[i - 1]); // duplicate previous row
+          bitmap.push(row); // duplicate previous row
           continue;
         }
       }
-      var row = new Uint8Array(width);
+      row = new Uint8Array(row);
       bitmap.push(row);
       for (j = 0; j < width; j++) {
         if (useskip && skip[i][j]) {

--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -269,10 +269,10 @@ var Jbig2Image = (function Jbig2ImageClosure() {
       if (prediction) {
         var sltp = decoder.readBit(contexts, pseudoPixelContext);
         ltp ^= sltp;
-      }
-      if (ltp) {
-        bitmap.push(bitmap[bitmap.length - 1]); // duplicate previous row
-        continue;
+        if (ltp) {
+          bitmap[i] = row;//bitmap[i - 1]); // duplicate previous row
+          continue;
+        }
       }
       var row = new Uint8Array(width);
       bitmap.push(row);

--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -105,7 +105,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
           offset = 340;
           break;
         default:
-          v = v * 2 + bit;
+          v = ((v << 1) | bit) >>> 0;
           if (--toRead === 0) {
             state = 0;
           }
@@ -124,12 +124,12 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     var prev = 1;
     for (var i = 0; i < codeLength; i++) {
       var bit = decoder.readBit(contexts, prev);
-      prev = (prev * 2) + bit;
+      prev = (prev << 1) | bit;
     }
     if (codeLength < 31) {
       return prev & ((1 << codeLength) - 1);
     }
-    return prev - Math.pow(2, codeLength);
+    return prev & 0x7FFFFFFF;
   }
 
   // 7.3 Segment types

--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -938,34 +938,42 @@ var Jbig2Image = (function Jbig2ImageClosure() {
       var combinationOperator = pageInfo.combinationOperatorOverride ?
         regionInfo.combinationOperator : pageInfo.combinationOperator;
       var buffer = this.buffer;
-      for (var i = 0; i < height; i++) {
-        var mask = 128 >> (regionInfo.x & 7);
-        var offset = (i + regionInfo.y) * rowSize + (regionInfo.x >> 3);
-        switch (combinationOperator) {
-          case 0: // OR
+      switch (combinationOperator) {
+        case 0: // OR
+          for (var i = 0; i < height; i++) {
+            var mask = 128 >> (regionInfo.x & 7);
+            var offset = (i + regionInfo.y) * rowSize + (regionInfo.x >> 3);
             for (var j = 0; j < width; j++) {
-              buffer[offset] |= bitmap[i][j] ? mask : 0;
+              if (bitmap[i][j]) {
+                buffer[offset] |= mask;
+              }
               mask >>= 1;
               if (!mask) {
                 mask = 128;
                 offset++;
               }
             }
-            break;
-          case 2: // XOR
+          }
+        break;
+        case 2: // XOR
+          for (var i = 0; i < height; i++) {
+            var mask = 128 >> (regionInfo.x & 7);
+            var offset = (i + regionInfo.y) * rowSize + (regionInfo.x >> 3);
             for (var j = 0; j < width; j++) {
-              buffer[offset] ^= bitmap[i][j] ? mask : 0;
+              if (bitmap[i][j]) {
+                buffer[offset] ^= mask;
+              }
               mask >>= 1;
               if (!mask) {
                 mask = 128;
                 offset++;
               }
             }
-            break;
-          default:
-            error('JBIG2 error: operator ' + combinationOperator +
-                  ' is not supported');
-        }
+          }
+          break;
+        default:
+          error('JBIG2 error: operator ' + combinationOperator +
+                ' is not supported');
       }
     },
     onImmediateGenericRegion:

--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -376,13 +376,13 @@ var Jbig2Image = (function Jbig2ImageClosure() {
       if (prediction) {
         var sltp = decoder.readBit(contexts, pseudoPixelContext);
         ltp ^= sltp;
+        if (ltp) {
+          error('JBIG2 error: prediction is not supported');
+        }
       }
       var row = new Uint8Array(width);
       bitmap.push(row);
       for (var j = 0; j < width; j++) {
-        if (ltp) {
-          error('JBIG2 error: prediction is not supported');
-        }
 
         var contextLabel = 0;
         for (var k = 0; k < codingTemplateLength; k++) {


### PR DESCRIPTION
~13% speed improvement in JBIG2 decoding.

Measured 10x the decoding time of ten 33M pixels JBIG2 images:
Average decoding time went from ~1440ms to ~1270ms in Opera, and ~1240ms to ~1060ms in Aurora
