### PR TITLE
Estimate the size of decoded streams in advance.

### DIFF
--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -431,9 +431,9 @@ var CipherTransform = (function CipherTransformClosure() {
     this.streamCipherConstructor = streamCipherConstructor;
   }
   CipherTransform.prototype = {
-    createStream: function CipherTransform_createStream(stream) {
+    createStream: function CipherTransform_createStream(stream, length) {
       var cipher = new this.streamCipherConstructor();
-      return new DecryptStream(stream,
+      return new DecryptStream(stream, length,
         function cipherTransformDecryptStream(data, finalize) {
           return cipher.decryptBlock(data, finalize);
         }

--- a/test/unit/stream_spec.js
+++ b/test/unit/stream_spec.js
@@ -30,7 +30,7 @@ describe('stream', function() {
 
       var input = new Stream(new Uint8Array([2, 100, 3, 2, 1, 255, 2, 1, 255]),
         0, 9, dict);
-      var predictor = new PredictorStream(input, dict);
+      var predictor = new PredictorStream(input, /* length = */ 9, dict);
       var result = predictor.getBytes(6);
 
       expect(result).toMatchTypedArray(


### PR DESCRIPTION
When decoding a stream, the decode buffer is often grown multiple times, its
byte size increasing like so: 512, 1024, 2048, etc. This patch estimates the
minimum size in advance (using the length of the encoded stream), often
allowing the smaller sizes to be skipped. It also renames numerous |length|
variables as |maybeLength| to make it clear that they can be |null|.

I measured this change on eight documents. This change reduces the cumulative
size of decode buffer allocations by 0--32%, with 10--20% being typical. This
reduces peak RSS by 10 or 20 MiB for several of them.

BTW, I think Ascii85 and AsciiHex streams are the only ones for which the decoded data is regularly smaller than the encoded data, and I've accounted for that. Please let me know if any of the other stream kinds have the same behaviour.
