### PR TITLE
Follow JMPR op only if outside of FDEF and IF

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -3675,9 +3675,11 @@ var Font = (function FontClosure() {
             }
             --ifLevel;
           } else if (op === 0x1C) { // JMPR
-            var offset = stack[stack.length - 1];
-            // only jumping forward to prevent infinite loop
-            if (offset > 0) { i += offset - 1; }
+            if (!inFDEF && !inELSE) {
+              var offset = stack[stack.length - 1];
+              // only jumping forward to prevent infinite loop
+              if (offset > 0) { i += offset - 1; }
+            }
           }
           // Adjusting stack not extactly, but just enough to get function id
           if (!inFDEF && !inELSE) {


### PR DESCRIPTION
JMPR usually comes after a push op.
Push ops only change the stack if outside of FDEF and IF so JMPR need to do the same.

This PR fixes the following issues:
https://github.com/mozilla/pdf.js/issues/4002
https://github.com/mozilla/pdf.js/issues/4091
https://github.com/mozilla/pdf.js/issues/4411
https://github.com/mozilla/pdf.js/issues/3482
https://github.com/mozilla/pdf.js/issues/3851
https://github.com/mozilla/pdf.js/issues/4280
https://github.com/mozilla/pdf.js/issues/4115 (not sure, don't speak Russian)
https://bugzilla.mozilla.org/show_bug.cgi?id=926462
https://bugzilla.mozilla.org/show_bug.cgi?id=982861
