### PR TITLE
refactor src/core/pdf_manager.js: rename pdfModel to pdfDocument

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -294,7 +294,8 @@ var WorkerMessageHandler = PDFJS.WorkerMessageHandler = {
 
     handler.on('GetPageIndex', function wphSetupGetPageIndex(data, deferred) {
       var ref = new Ref(data.ref.num, data.ref.gen);
-      pdfManager.pdfModel.catalog.getPageIndex(ref).then(function (pageIndex) {
+      var catalog = pdfManager.pdfDocument.catalog;
+      catalog.getPageIndex(ref).then(function (pageIndex) {
         deferred.resolve(pageIndex);
       }, deferred.reject);
     });

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -54,6 +54,14 @@ describe('api', function() {
         expect(true).toEqual(true);
       });
     });
+    it('gets page index', function() {
+      // reference to second page
+      var ref = {num: 17, gen: 0};
+      var promise = doc.getPageIndex(ref);
+      waitsForPromise(promise, function(pageIndex) {
+        expect(pageIndex).toEqual(1);
+      });
+    });
     it('gets destinations', function() {
       var promise = doc.getDestinations();
       waitsForPromise(promise, function(data) {


### PR DESCRIPTION
Fix #4480, only changes in src/core/worker.js below line 296 are new. It's amazing that all tests didn't find this error?!
