### PR TITLE
Rewrite 'Preferences' to make it async

### DIFF
--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -452,7 +452,7 @@ ChromeActions.prototype = {
     getChromeWindow(this.domWindow).gFindBar
                                    .updateControlState(result, findPrevious);
   },
-  setPreferences: function(prefs) {
+  setPreferences: function(prefs, sendResponse) {
     var defaultBranch = Services.prefs.getDefaultBranch(PREF_PREFIX + '.');
     var numberOfPrefs = 0;
     var prefValue, prefName;
@@ -483,8 +483,11 @@ ChromeActions.prototype = {
           break;
       }
     }
+    if (sendResponse) {
+      sendResponse(true);
+    }
   },
-  getPreferences: function(prefs) {
+  getPreferences: function(prefs, sendResponse) {
     var defaultBranch = Services.prefs.getDefaultBranch(PREF_PREFIX + '.');
     var currentPrefs = {}, numberOfPrefs = 0;
     var prefValue, prefName;
@@ -510,7 +513,11 @@ ChromeActions.prototype = {
           break;
       }
     }
-    return JSON.stringify(currentPrefs);
+    if (sendResponse) {
+      sendResponse(JSON.stringify(currentPrefs));
+    } else {
+      return JSON.stringify(currentPrefs);
+    }
   }
 };
 

--- a/web/default_preferences.js
+++ b/web/default_preferences.js
@@ -21,5 +21,6 @@
 var DEFAULT_PREFERENCES = {
   showPreviousViewOnLoad: true,
   defaultZoomValue: '',
-  ifAvailableShowOutlineOnLoad: false
+  ifAvailableShowOutlineOnLoad: false,
+  enableHandToolOnLoad: false
 };

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -104,15 +104,17 @@ var DownloadManager = (function DownloadManagerClosure() {
   return DownloadManager;
 })();
 
-Preferences.prototype.writeToStorage = function(prefObj) {
-  FirefoxCom.requestSync('setPreferences', prefObj);
+Preferences._writeToStorage = function (prefObj) {
+  return new Promise(function (resolve) {
+    FirefoxCom.requestSync('setPreferences', prefObj);
+    resolve();
+  });
 };
 
-Preferences.prototype.readFromStorage = function(prefObj) {
-  var readFromStoragePromise = new Promise(function (resolve) {
+Preferences._readFromStorage = function (prefObj) {
+  return new Promise(function (resolve) {
     var readPrefs = JSON.parse(FirefoxCom.requestSync('getPreferences',
                                                       prefObj));
     resolve(readPrefs);
   });
-  return readFromStoragePromise;
 };

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -106,15 +106,15 @@ var DownloadManager = (function DownloadManagerClosure() {
 
 Preferences._writeToStorage = function (prefObj) {
   return new Promise(function (resolve) {
-    FirefoxCom.requestSync('setPreferences', prefObj);
-    resolve();
+    FirefoxCom.request('setPreferences', prefObj, resolve);
   });
 };
 
 Preferences._readFromStorage = function (prefObj) {
   return new Promise(function (resolve) {
-    var readPrefs = JSON.parse(FirefoxCom.requestSync('getPreferences',
-                                                      prefObj));
-    resolve(readPrefs);
+    FirefoxCom.request('getPreferences', prefObj, function (prefStr) {
+      var readPrefs = JSON.parse(prefStr);
+      resolve(readPrefs);
+    });
   });
 };

--- a/web/hand_tool.js
+++ b/web/hand_tool.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals mozL10n, GrabToPan, PDFView, SecondaryToolbar */
+/* globals mozL10n, GrabToPan, PDFView, Preferences, SecondaryToolbar */
 
 'use strict';
 
@@ -43,8 +43,15 @@ var HandTool = {
     });
     if (toggleHandTool) {
       toggleHandTool.addEventListener('click', this.toggle.bind(this), false);
+
+      window.addEventListener('localized', function (evt) {
+        Preferences.get('enableHandToolOnLoad').then(function (prefValue) {
+          if (prefValue) {
+            this.handTool.activate();
+          }
+        }.bind(this));
+      }.bind(this));
     }
-    // TODO: Read global prefs and call this.handTool.activate() if needed.
   },
 
   toggle: function handToolToggle() {

--- a/web/preferences.js
+++ b/web/preferences.js
@@ -14,51 +14,99 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals DEFAULT_PREFERENCES, PDFJS, isLocalStorageEnabled, Promise */
+/* globals DEFAULT_PREFERENCES, isLocalStorageEnabled, Promise */
 
 'use strict';
 
 //#include default_preferences.js
 
-var Preferences = (function PreferencesClosure() {
-  function Preferences() {
-    this.prefs = {};
-    this.isInitializedPromiseResolved = false;
-    this.initializedPromise = this.readFromStorage(DEFAULT_PREFERENCES).then(
-      function(prefObj) {
-        this.isInitializedPromiseResolved = true;
+/**
+ * Preferences - Utility for storing persistent settings.
+ *   Used for settings that should be applied to all opened documents,
+ *   or every time the viewer is loaded.
+ */
+var Preferences = {
+  prefs: Object.create(DEFAULT_PREFERENCES),
+  isInitializedPromiseResolved: false,
+  initializedPromise: null,
+
+  /**
+   * Initialize and fetch the current preference values from storage.
+   * @return {Promise} A promise that is resolved when the preferences
+   *                   have been initialized.
+   */
+  initialize: function preferencesInitialize() {
+    return this.initializedPromise =
+        this._readFromStorage(DEFAULT_PREFERENCES).then(function(prefObj) {
+      this.isInitializedPromiseResolved = true;
+      if (prefObj) {
+        this.prefs = prefObj;
+      }
+    }.bind(this));
+  },
+
+  /**
+   * Stub function for writing preferences to storage.
+   * NOTE: This should be overridden by a build-specific function defined below.
+   * @param {Object} prefObj The preferences that should be written to storage.
+   * @return {Promise} A promise that is resolved when the preference values
+   *                   have been written.
+   */
+  _writeToStorage: function preferences_writeToStorage(prefObj) {
+    return Promise.resolve();
+  },
+
+  /**
+   * Stub function for reading preferences from storage.
+   * NOTE: This should be overridden by a build-specific function defined below.
+   * @param {Object} prefObj The preferences that should be read from storage.
+   * @return {Promise} A promise that is resolved with an {Object} containing
+   *                   the preferences that have been read.
+   */
+  _readFromStorage: function preferences_readFromStorage(prefObj) {
+    return Promise.resolve();
+  },
+
+  /**
+   * Reset the preferences to their default values and update storage.
+   * @return {Promise} A promise that is resolved when the preference values
+   *                   have been reset.
+   */
+  reset: function preferencesReset() {
+    return this.initializedPromise.then(function() {
+      this.prefs = Object.create(DEFAULT_PREFERENCES);
+      return this._writeToStorage(DEFAULT_PREFERENCES);
+    }.bind(this));
+  },
+
+  /**
+   * Replace the current preference values with the ones from storage.
+   * @return {Promise} A promise that is resolved when the preference values
+   *                   have been updated.
+   */
+  reload: function preferencesReload() {
+    return this.initializedPromise.then(function () {
+      this._readFromStorage(DEFAULT_PREFERENCES).then(function(prefObj) {
         if (prefObj) {
           this.prefs = prefObj;
         }
       }.bind(this));
-  }
+    }.bind(this));
+  },
 
-  Preferences.prototype = {
-    writeToStorage: function Preferences_writeToStorage(prefObj) {
-      return;
-    },
-
-    readFromStorage: function Preferences_readFromStorage(prefObj) {
-      var readFromStoragePromise = Promise.resolve();
-      return readFromStoragePromise;
-    },
-
-    reset: function Preferences_reset() {
-      if (this.isInitializedPromiseResolved) {
-        this.prefs = {};
-        this.writeToStorage(DEFAULT_PREFERENCES);
-      }
-    },
-
-    set: function Preferences_set(name, value) {
-      if (!this.isInitializedPromiseResolved) {
-        return;
-      } else if (DEFAULT_PREFERENCES[name] === undefined) {
-        console.error('Preferences_set: \'' + name + '\' is undefined.');
-        return;
+  /**
+   * Set the value of a preference.
+   * @param {string} name The name of the preference that should be changed.
+   * @param {boolean|number|string} value The new value of the preference.
+   * @return {Promise} A promise that is resolved when the value has been set,
+   *                   provided that the preference exists and the types match.
+   */
+  set: function preferencesSet(name, value) {
+    return this.initializedPromise.then(function () {
+      if (DEFAULT_PREFERENCES[name] === undefined) {
+        throw new Error('preferencesSet: \'' + name + '\' is undefined.');
       } else if (value === undefined) {
-        console.error('Preferences_set: no value is specified.');
-        return;
+        throw new Error('preferencesSet: no value is specified.');
       }
       var valueType = typeof value;
       var defaultType = typeof DEFAULT_PREFERENCES[name];
@@ -67,71 +115,79 @@ var Preferences = (function PreferencesClosure() {
         if (valueType === 'number' && defaultType === 'string') {
           value = value.toString();
         } else {
-          console.error('Preferences_set: \'' + value + '\' is a \"' +
-                        valueType + '\", expected a \"' + defaultType + '\".');
-          return;
+          throw new Error('Preferences_set: \'' + value + '\' is a \"' +
+                          valueType + '\", expected \"' + defaultType + '\".');
         }
       } else {
         if (valueType === 'number' && (value | 0) !== value) {
-          console.error('Preferences_set: \'' + value +
-                        '\' must be an \"integer\".');
-          return;
+          throw new Error('Preferences_set: \'' + value +
+                          '\' must be an \"integer\".');
         }
       }
       this.prefs[name] = value;
-      this.writeToStorage(this.prefs);
-    },
+      return this._writeToStorage(this.prefs);
+    }.bind(this));
+  },
 
-    get: function Preferences_get(name) {
-      var defaultPref = DEFAULT_PREFERENCES[name];
+  /**
+   * Get the value of a preference.
+   * @param {string} name The name of the preference whose value is requested.
+   * @return {Promise} A promise that is resolved with a {boolean|number|string}
+   *                   containing the value of the preference.
+   */
+  get: function preferencesGet(name) {
+    return this.initializedPromise.then(function () {
+      var defaultValue = DEFAULT_PREFERENCES[name];
 
-      if (defaultPref === undefined) {
-        console.error('Preferences_get: \'' + name + '\' is undefined.');
-        return;
-      } else if (this.isInitializedPromiseResolved) {
-        var pref = this.prefs[name];
+      if (defaultValue === undefined) {
+        throw new Error('preferencesGet: \'' + name + '\' is undefined.');
+      } else {
+        var prefValue = this.prefs[name];
 
-        if (pref !== undefined) {
-          return pref;
+        if (prefValue !== undefined) {
+          return prefValue;
         }
       }
-      return defaultPref;
-    }
-  };
-
-  return Preferences;
-})();
+      return defaultValue;
+    }.bind(this));
+  }
+};
 
 //#if B2G
-//Preferences.prototype.writeToStorage = function(prefObj) {
-//  asyncStorage.setItem('pdfjs.preferences', JSON.stringify(prefObj));
+//Preferences._writeToStorage = function (prefObj) {
+//  return new Promise(function (resolve) {
+//    asyncStorage.setItem('pdfjs.preferences', JSON.stringify(prefObj),
+//                         resolve);
+//  });
 //};
 //
-//Preferences.prototype.readFromStorage = function(prefObj) {
-//  var readFromStoragePromise = new Promise(function (resolve) {
-//    asyncStorage.getItem('pdfjs.preferences', function(prefStr) {
+//Preferences._readFromStorage = function (prefObj) {
+//  return new Promise(function (resolve) {
+//    asyncStorage.getItem('pdfjs.preferences', function (prefStr) {
 //      var readPrefs = JSON.parse(prefStr);
 //      resolve(readPrefs);
 //    });
 //  });
-//  return readFromStoragePromise;
 //};
 //#endif
 
 //#if !(FIREFOX || MOZCENTRAL || B2G)
-Preferences.prototype.writeToStorage = function(prefObj) {
-  if (isLocalStorageEnabled) {
-    localStorage.setItem('pdfjs.preferences', JSON.stringify(prefObj));
-  }
+Preferences._writeToStorage = function (prefObj) {
+  return new Promise(function (resolve) {
+    if (isLocalStorageEnabled) {
+      localStorage.setItem('pdfjs.preferences', JSON.stringify(prefObj));
+    }
+    resolve();
+  });
 };
 
-Preferences.prototype.readFromStorage = function(prefObj) {
-  var readFromStoragePromise = new Promise(function (resolve) {
+Preferences._readFromStorage = function (prefObj) {
+  return new Promise(function (resolve) {
+    var readPrefs;
     if (isLocalStorageEnabled) {
-      var readPrefs = JSON.parse(localStorage.getItem('pdfjs.preferences'));
-      resolve(readPrefs);
+      readPrefs = JSON.parse(localStorage.getItem('pdfjs.preferences'));
     }
+    resolve(readPrefs);
   });
-  return readFromStoragePromise;
 };
 //#endif


### PR DESCRIPTION
/cc @brendandahl Please look at this, and see if I'm on the right track with the rewrite.

This PR makes a number of changes to `Preferences`:
- Remove the class-like implementation, so that it's instead invoked once when the viewer loads.<br>
  This change is necessary if we want to support preferences for the viewer itself, and not just when opening documents. (The second commit makes use of this to add a pref that enables the hand tool by default.)
- Changes all functions to be asynchronous.
- Adds docs. Some of it might be unnecessary or too verbose, so feedback is welcome on this.

Fixes #4459.
