### PR TITLE
[Firefox] Lazy load network.js in PdfStreamConverter.js

### DIFF
--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -39,7 +39,9 @@ const MAX_STRING_PREF_LENGTH = 128;
 Cu.import('resource://gre/modules/XPCOMUtils.jsm');
 Cu.import('resource://gre/modules/Services.jsm');
 Cu.import('resource://gre/modules/NetUtil.jsm');
-Cu.import('resource://pdf.js/network.js');
+
+XPCOMUtils.defineLazyModuleGetter(this, 'NetworkManager',
+  'resource://pdf.js/network.js');
 
 XPCOMUtils.defineLazyModuleGetter(this, 'PrivateBrowsingUtils',
   'resource://gre/modules/PrivateBrowsingUtils.jsm');


### PR DESCRIPTION
_Inspired by this thread, started by @nnethercote on dev.platform: https://groups.google.com/forum/#!topic/mozilla.dev.platform/sAuhWQOAWic._

This PR changes `network.js` to be lazily loaded instead, to delay loading it until it's needed and to avoid affecting the browser start-up.

I my testing this works fine, and given that we already lazy load other modules (e.g. `PdfJsTelemetry.jsm`) I don't think that there should be any issues with this change.
