### PR TITLE
[Firefox] Stop importing default_preferences.js as a module and include it instead

### DIFF
--- a/extensions/firefox/bootstrap.js
+++ b/extensions/firefox/bootstrap.js
@@ -58,7 +58,7 @@ function log(str) {
 }
 
 function initializeDefaultPreferences() {
-  Cu.import('resource://' + RESOURCE_NAME + '/default_preferences.js');
+//#include ../../web/default_preferences.js
 
   var defaultBranch = Services.prefs.getDefaultBranch(EXT_PREFIX + '.');
   var defaultValue;

--- a/extensions/firefox/content/PdfJs.jsm
+++ b/extensions/firefox/content/PdfJs.jsm
@@ -62,7 +62,7 @@ function getIntPref(aPref, aDefaultValue) {
 }
 
 function initializeDefaultPreferences() {
-  Cu.import('resource://pdf.js/default_preferences.js');
+//#include ../../../web/default_preferences.js
 
   var defaultBranch = Services.prefs.getDefaultBranch(PREF_PREFIX + '.');
   var defaultValue;

--- a/make.js
+++ b/make.js
@@ -612,13 +612,13 @@ target.firefox = function() {
       [COMMON_WEB_FILES, FIREFOX_BUILD_CONTENT_DIR + '/web'],
       ['external/bcmaps/*', FIREFOX_BUILD_CONTENT_DIR + '/web/cmaps'],
       [FIREFOX_EXTENSION_DIR + 'tools/l10n.js',
-       FIREFOX_BUILD_CONTENT_DIR + '/web'],
-      ['web/default_preferences.js', FIREFOX_BUILD_CONTENT_DIR]
+       FIREFOX_BUILD_CONTENT_DIR + '/web']
     ],
     preprocess: [
       [COMMON_WEB_FILES_PREPROCESS, FIREFOX_BUILD_CONTENT_DIR + '/web'],
       [BUILD_TARGETS, FIREFOX_BUILD_CONTENT_DIR + BUILD_DIR],
-      [SRC_DIR + 'core/network.js', FIREFOX_BUILD_CONTENT_DIR]
+      [SRC_DIR + 'core/network.js', FIREFOX_BUILD_CONTENT_DIR],
+      [FIREFOX_EXTENSION_DIR + 'bootstrap.js', FIREFOX_BUILD_DIR]
     ],
     preprocessCSS: [
       ['firefox', 'web/viewer.css',
@@ -628,6 +628,7 @@ target.firefox = function() {
   builder.build(setup);
 
   cleanupJSSource(FIREFOX_BUILD_CONTENT_DIR + '/web/viewer.js');
+  cleanupJSSource(FIREFOX_BUILD_DIR + 'bootstrap.js');
 
   // Remove '.DS_Store' and other hidden files
   find(FIREFOX_BUILD_DIR).forEach(function(file) {
@@ -712,7 +713,8 @@ target.mozcentral = function() {
   mkdir('-p', MOZCENTRAL_CONTENT_DIR + '/web');
   mkdir('-p', MOZCENTRAL_CONTENT_DIR + '/web/cmaps');
 
-  cp(FIREFOX_CONTENT_DIR + 'PdfJs.jsm', MOZCENTRAL_CONTENT_DIR);
+  // Do not copy PdfJs.jsm, since it should be run through the preprocessor.
+
   cp(FIREFOX_CONTENT_DIR + 'PdfJsTelemetry.jsm', MOZCENTRAL_CONTENT_DIR);
   cp(FIREFOX_CONTENT_DIR + 'PdfStreamConverter.jsm', MOZCENTRAL_CONTENT_DIR);
   cp(FIREFOX_CONTENT_DIR + 'PdfRedirector.jsm', MOZCENTRAL_CONTENT_DIR);
@@ -730,13 +732,13 @@ target.mozcentral = function() {
     copy: [
       [COMMON_WEB_FILES, MOZCENTRAL_CONTENT_DIR + '/web'],
       ['external/bcmaps/*', MOZCENTRAL_CONTENT_DIR + '/web/cmaps'],
-      ['extensions/firefox/tools/l10n.js', MOZCENTRAL_CONTENT_DIR + '/web'],
-      ['web/default_preferences.js', MOZCENTRAL_CONTENT_DIR]
+      ['extensions/firefox/tools/l10n.js', MOZCENTRAL_CONTENT_DIR + '/web']
     ],
     preprocess: [
       [COMMON_WEB_FILES_PREPROCESS, MOZCENTRAL_CONTENT_DIR + '/web'],
       [BUILD_TARGETS, MOZCENTRAL_CONTENT_DIR + BUILD_DIR],
-      [SRC_DIR + 'core/network.js', MOZCENTRAL_CONTENT_DIR]
+      [SRC_DIR + 'core/network.js', MOZCENTRAL_CONTENT_DIR],
+      [FIREFOX_CONTENT_DIR + 'PdfJs.jsm', MOZCENTRAL_CONTENT_DIR]
     ],
     preprocessCSS: [
       ['mozcentral',
@@ -747,6 +749,7 @@ target.mozcentral = function() {
   builder.build(setup);
 
   cleanupJSSource(MOZCENTRAL_CONTENT_DIR + '/web/viewer.js');
+  cleanupJSSource(MOZCENTRAL_CONTENT_DIR + '/PdfJs.jsm');
 
   // Remove '.DS_Store' and other hidden files
   find(MOZCENTRAL_DIR).forEach(function(file) {

--- a/web/default_preferences.js
+++ b/web/default_preferences.js
@@ -18,8 +18,6 @@
 
 'use strict';
 
-var EXPORTED_SYMBOLS = ['DEFAULT_PREFERENCES'];
-
 var DEFAULT_PREFERENCES = {
   showPreviousViewOnLoad: true,
   defaultZoomValue: '',


### PR DESCRIPTION
_Inspired by this thread, started by @nnethercote on dev.platform: https://groups.google.com/forum/#!topic/mozilla.dev.platform/sAuhWQOAWic._

This PR makes use of the preprocessor to include the file default_preferences.js, instead of loading it as a module in the `MOZCENTRAL`/`FIREFOX` builds.

The only way to test this is unfortunately to apply the patch, run `node make {mozcentral, firefox}`, and then check that `DEFAULT_PREFERENCES` is included properly in `initializeDefaultPreferences` (i.e. lines https://github.com/mozilla/pdf.js/blob/master/web/default_preferences.js#L23-L27 should appear) in the following files:
- `MOZCENTRAL` - build/mozcentral/browser/extensions/pdfjs/content/PdfJs.jsm.
- `FIREFOX` - build/firefox/bootstrap.js.

Note that the file default_preferences.js should not be present in the build directories, since it's no longer necessary.
