### PR TITLE
Use full screen width in presentation mode

### DIFF
--- a/web/presentation_mode.js
+++ b/web/presentation_mode.js
@@ -149,11 +149,9 @@ var PresentationMode = {
     // Presentation Mode, by waiting until fullscreen mode is disabled.
     // Note: This is only necessary in non-Mozilla browsers.
     setTimeout(function exitPresentationModeTimeout() {
+      this.active = false;
       PDFView.setScale(this.args.previousScale);
       PDFView.page = page;
-      // Keep Presentation Mode active until the page is scrolled into view,
-      // to prevent issues in non-Mozilla browsers.
-      this.active = false;
       this.args = null;
     }.bind(this), 0);
 

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -90,18 +90,22 @@ select {
 
 :-webkit-full-screen .page {
   margin-bottom: 100%;
+  border: 0;
 }
 
 :-moz-full-screen .page {
   margin-bottom: 100%;
+  border: 0;
 }
 
 :-ms-fullscreen .page {
   margin-bottom: 100% !important;
+  border: 0;
 }
 
 :fullscreen .page {
   margin-bottom: 100%;
+  border: 0;
 }
 
 :-webkit-full-screen a:not(.internalLink) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -283,9 +283,11 @@ var PDFView = {
       if (!currentPage) {
         return;
       }
-      var pageWidthScale = (this.container.clientWidth - SCROLLBAR_PADDING) /
+      var hPadding = PresentationMode.active ? 0 : SCROLLBAR_PADDING;
+      var vPadding = PresentationMode.active ? 0 : VERTICAL_PADDING;
+      var pageWidthScale = (this.container.clientWidth - hPadding) /
                             currentPage.width * currentPage.scale;
-      var pageHeightScale = (this.container.clientHeight - VERTICAL_PADDING) /
+      var pageHeightScale = (this.container.clientHeight - vPadding) /
                              currentPage.height * currentPage.scale;
       switch (value) {
         case 'page-actual':


### PR DESCRIPTION
Fixes #4439 by removing all horizontal borders and reducing the vertical ones when in presentation mode.
This improves reading on small devices.

It still looks a little bit awkward that the document is tied to the top of the screen on portrait mode displays, but I didn't figure out how to correctly center it.
