### PR TITLE
Fix error message typo

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -64,7 +64,7 @@ var PDFFindController = {
   initialize: function(options) {
     if(typeof PDFFindBar === 'undefined' || PDFFindBar === null) {
       throw 'PDFFindController cannot be initialized ' +
-            'without a PDFFindController instance';
+            'without a PDFFindBar instance';
     }
 
     this.pdfPageSource = options.pdfPageSource;


### PR DESCRIPTION
It should read 'PDFFindController cannot be initialized without a PDFFindBar instance'.
