### PR TITLE
simplify conversion to UInt8 in JPX decoder

### DIFF
--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -1062,30 +1062,15 @@ var JpxImage = (function JpxImageClosure() {
       }
 
       // Section G.1 DC level shifting to unsigned component values
-      for (var c = 0; c < componentsCount; c++) {
-        var component = components[c];
-        if (component.isSigned) {
-          continue;
-        }
-
-        var offset = 1 << (component.precision - 1);
-        var tileImage = result[c];
-        var items = tileImage.items;
-        for (var j = 0, jj = items.length; j < jj; j++) {
-          items[j] += offset;
-        }
-      }
-
       // To simplify things: shift and clamp output to 8 bit unsigned
       for (var c = 0; c < componentsCount; c++) {
         var component = components[c];
-        var offset = component.isSigned ? 128 : 0;
         var shift = component.precision - 8;
         var tileImage = result[c];
         var items = tileImage.items;
         var data = new Uint8Array(items.length);
         for (var j = 0, jj = items.length; j < jj; j++) {
-          var value = (items[j] >> shift) + offset;
+          var value = (items[j] >> shift) + 128;
           data[j] = value < 0 ? 0 : value > 255 ? 255 : value;
         }
         result[c].items = data;


### PR DESCRIPTION
The existing code unnecessarily differentiates between signed component values and unsigned ones.

If `component.isSigned`, then the first loop is skipped, and the second loop adds offset == 128 to the component values. 

If `!component.isSigned`, then the first loop adds `1 << (precision - 1)` and the second loop right-shifts that value by `precision - 8`, so `1 << ((precision - 1) - (precision - 8)) == 128` is added effectively.

Since the `items` are Float32s, no overflow is to be expected, so it doesn't matter if we add the offset before or after the shift.
