### PR TITLE
[WIP] Enforce minimum line widths and rectangle sizes

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -978,6 +978,9 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       this.ctx.closePath();
     },
     rectangle: function CanvasGraphics_rectangle(x, y, width, height) {
+      width = this.getMinimumLineWidth(width);
+      height = this.getMinimumLineWidth(height);
+
       this.ctx.rect(x, y, width, height);
     },
     stroke: function CanvasGraphics_stroke(consumePath) {

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -27,6 +27,9 @@
 // Minimal font size that would be used during canvas fillText operations.
 var MIN_FONT_SIZE = 16;
 
+// Heuristic value used when enforcing a minimum line width.
+var MIN_LINE_WIDTH_FACTOR = 0.75;
+
 var COMPILE_TYPE3_GLYPHS = true;
 
 function createScratchCanvas(width, height) {
@@ -981,9 +984,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       consumePath = typeof consumePath !== 'undefined' ? consumePath : true;
       var ctx = this.ctx;
       var strokeColor = this.current.strokeColor;
-      if (this.current.lineWidth === 0) {
-        ctx.lineWidth = this.getSinglePixelWidth();
-      }
+      ctx.lineWidth = this.getMinimumLineWidth(this.current.lineWidth);
       // For stroke we want to temporarily change the global alpha to the
       // stroking alpha.
       ctx.globalAlpha = this.current.strokeAlpha;
@@ -2201,6 +2202,23 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
           transform[0] * x + transform[2] * y + transform[4],
           transform[1] * x + transform[3] * y + transform[5]
         ];
+    },
+    getMinimumLineWidth:
+        function CanvasGraphics_getMinimumLineWidth(currentLineWidth) {
+      var minAbsoluteLineWidth = (this.getSinglePixelWidth() *
+                                  MIN_LINE_WIDTH_FACTOR);
+      if (currentLineWidth === undefined) {
+        return minAbsoluteLineWidth;
+      } else if (currentLineWidth >= 0) {
+        if (currentLineWidth < minAbsoluteLineWidth) {
+          return minAbsoluteLineWidth;
+        }
+      } else { // currentLineWidth < 0
+        if (currentLineWidth > minAbsoluteLineWidth) {
+          return -minAbsoluteLineWidth;
+        }
+      }
+      return currentLineWidth;
     }
   };
 


### PR DESCRIPTION
This PR contains experimental patches that enforce lower bounds on both line widths and rectangle sizes. I don't think this should be merged as is, but I wanted to submit the PR to get feedback. My apologies for the very long post!

Given that PDF.js currently renders some files with lines that are way too thin, in some cases becoming almost invisible, I think that we should replace too narrow line widths with more reasonable ones.
Comparing PDF.js with Adobe Reader, it seems that they enforce minimum line widths. This would explain why there are a number of bugs filed about missing lines PDF.js. (See below for an incomplete list.)

The obvious candidate to use when establishing a minimum line width should be [`getSinglePixelWidth`](https://github.com/mozilla/pdf.js/blob/master/src/display/canvas.js#L2191). Unfortunately, in my testing, using that value causes many lines to become _way_ too thick.
Through some trial and error, I found that reducing the value returned by `getSinglePixelWidth` to `0.75 * getSinglePixelWidth` seemed to yield _much_ better results. Obviously, this seems like an ugly hack, but I don't really understand why `getSinglePixelWidth` isn't returning more reasonable values.
It then occurred to me that `0.75 = 1 / CSS_UNITS`, where `CSS_UNITS = 96.0 /72.0` (see [viewer.js#L31](https://github.com/mozilla/pdf.js/blob/master/web/viewer.js#L31)). Is this just a coincidence, or could it explain the issues I had with the values returned by `getSinglePixelWidth`?

As this PR currently stands, it would fix issues like: #4314, #3316 and #2722, and it would also prevent any future issues with lines getting drawn too thin.

Please note that if we, as suggested in this PR, start to enforce minimum line widths (and rectangle sizes) this obviously means that a fair number of the test PDFs would change. These changes would fall in two general categories:
- Changes that are so small that they are virtually indistinguishable to the naked eye.
- Changes that are easily noticeable. In most of these cases, the slightly thicker lines looks a lot better (to me, at least) and the rendering in PDF.js is now very close to the one in Adobe Reader.
  In a number of the test files, it's also possible to see details (in figures) that currently are almost invisible.
