### PR TITLE
Avoid drawing text when the font size is zero (issue 4484)

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1322,6 +1322,19 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       var vertical = font.vertical;
       var defaultVMetrics = font.defaultVMetrics;
 
+      if (fontSize === 0) {
+        if (textSelection) {
+          geom = this.createTextGeometry();
+          geom.canvasWidth = canvasWidth;
+          if (vertical) {
+            var VERTICAL_TEXT_ROTATION = Math.PI / 2;
+            geom.angle += VERTICAL_TEXT_ROTATION;
+          }
+          this.textLayer.appendText(geom);
+        }
+        return canvasWidth;
+      }
+
       // Type3 fonts - each glyph is a "mini-PDF"
       if (font.coded) {
         ctx.save();


### PR DESCRIPTION
Fixes #4484.

Note that the code to update the `textLayer` is needed to prevent errors from `TextLayerBuilder`. It might be better to re-factor `TextLayerBuilder` to avoid this, but that seemed out of scope for this particular issue.
