### PR TITLE
Workaround for missing 'Rect' entry in annotation dictionaries (issue 4537)

### DIFF
--- a/src/shared/annotation.js
+++ b/src/shared/annotation.js
@@ -80,7 +80,7 @@ var Annotation = (function AnnotationClosure() {
     var data = this.data = {};
 
     data.subtype = dict.get('Subtype').name;
-    var rect = dict.get('Rect');
+    var rect = dict.get('Rect') || [0, 0, 0, 0];
     data.rect = Util.normalizeRect(rect);
     data.annotationFlags = dict.get('F');
 


### PR DESCRIPTION
Fixes #4537.
