### PR TITLE
Use new Chromium APIs for FTP and redirects

### DIFF
--- a/extensions/chromium/feature-detect.js
+++ b/extensions/chromium/feature-detect.js
@@ -1,0 +1,58 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/*
+Copyright 2014 Mozilla Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/* globals chrome */
+
+'use strict';
+
+var Features = {
+  featureDetectLastUA: '',
+  // Whether ftp: in XMLHttpRequest is allowed
+  extensionSupportsFTP: false,
+};
+
+chrome.storage.local.get(Features, function(features) {
+  Features = features;
+  if (features.featureDetectLastUA === navigator.userAgent) {
+    // Browser not upgraded, so the features did probably not change.
+    return;
+  }
+
+  if (!features.extensionSupportsFTP) {
+    features.extensionSupportsFTP = featureTestFTP();
+  }
+
+  Features.featureDetectLastUA = navigator.userAgent;
+  chrome.storage.local.set(Features);
+});
+
+// Tests whether the extension can perform a FTP request.
+// Feature is supported since Chromium 35.0.1888.0 (r256810).
+function featureTestFTP() {
+  var x = new XMLHttpRequest();
+  // The URL does not need to exist, as long as the scheme is ftp:.
+  x.open('GET', 'ftp://ftp.mozilla.org/');
+  try {
+    x.send();
+    // Previous call did not throw error, so the feature is supported!
+    // Immediately abort the request so that the network is not hit at all.
+    x.abort();
+    return true;
+  } catch (e) {
+    return false;
+  }
+}

--- a/extensions/chromium/pdfHandler-v2.js
+++ b/extensions/chromium/pdfHandler-v2.js
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-/* globals chrome, URL, getViewerURL */
+/* globals chrome, URL, getViewerURL, Features */
 
 (function() {
   'use strict';
@@ -158,7 +158,8 @@ limitations under the License.
       var streamInfo = getStream(sender.tab.id, pdfUrl) || {};
       sendResponse({
         streamUrl: streamInfo.streamUrl,
-        contentLength: streamInfo.contentLength
+        contentLength: streamInfo.contentLength,
+        extensionSupportsFTP: Features.extensionSupportsFTP
       });
     }
   });

--- a/extensions/chromium/pdfHandler.html
+++ b/extensions/chromium/pdfHandler.html
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <script src="chrome.tabs.executeScriptInFrame.js"></script>
+<script src="feature-detect.js"></script>
 <script src="pdfHandler.js"></script>
 <script src="extension-router.js"></script>
 <script src="pdfHandler-v2.js"></script>

--- a/extensions/chromium/pdfHandler.js
+++ b/extensions/chromium/pdfHandler.js
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-/* globals chrome */
+/* globals chrome, Features */
 
 'use strict';
 
@@ -171,6 +171,27 @@ chrome.webRequest.onHeadersReceived.addListener(
     types: ['main_frame', 'sub_frame']
   },
   ['blocking','responseHeaders']);
+
+chrome.webRequest.onBeforeRequest.addListener(
+  function onBeforeRequestForFTP(details) {
+    if (!Features.extensionSupportsFTP) {
+      chrome.webRequest.onBeforeRequest.removeListener(onBeforeRequestForFTP);
+      return;
+    }
+    if (isPdfDownloadable(details)) {
+      return;
+    }
+    var viewerUrl = getViewerURL(details.url);
+    return { redirectUrl: viewerUrl };
+  },
+  {
+    urls: [
+      'ftp://*/*.pdf',
+      'ftp://*/*.PDF'
+    ],
+    types: ['main_frame', 'sub_frame']
+  },
+  ['blocking']);
 
 chrome.webRequest.onBeforeRequest.addListener(
   function(details) {

--- a/extensions/chromium/pdfHandler.js
+++ b/extensions/chromium/pdfHandler.js
@@ -114,8 +114,11 @@ chrome.webRequest.onHeadersReceived.addListener(
     var viewerUrl = getViewerURL(details.url);
 
     // Replace frame with viewer
-    // TODO: When http://crbug.com/280464 is fixed, use
-    // return { redirectUrl: viewerUrl };
+    if (Features.webRequestRedirectUrl) {
+      return { redirectUrl: viewerUrl };
+    }
+    // Aww.. redirectUrl is not yet supported, so we have to use a different
+    // method as fallback (Chromium <35).
 
     if (details.frameId === 0) {
       // Main frame. Just replace the tab and be done!

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1876,9 +1876,10 @@ function webViewerLoad(evt) {
 //      PDFView.setTitleUsingUrl(file);
 //      return;
 //    }
-//    if (isFTPFile) {
-//      // Stream not found, and it's loaded from FTP. Reload the page, because
-//      // it is not possible to get resources over ftp using XMLHttpRequest.
+//    if (isFTPFile && !response.extensionSupportsFTP) {
+//      // Stream not found, and it's loaded from FTP.
+//      // When the browser does not support loading ftp resources over
+//      // XMLHttpRequest, just reload the page.
 //      // NOTE: This will not lead to an infinite redirect loop, because
 //      // if the file exists, then the streamsPrivate API will capture the
 //      // stream and send back the response. If the stream does not exist, then


### PR DESCRIPTION
Starting with Chromium 35, extensions can get the content of ftp URLs using XMLHttpRequests.

Starting with Chromium 35, extensions can redirect requests after detecting the (PDF) MIME-type. With this feature, PDFs in frames can reliably be redirected to the viewer URL.

For both features, I've added capability tests to ensure full backwards compatibility.
