### PR TITLE
Prevent the Document Properties from being empty when the dialog is opened before the file has started loading

### DIFF
--- a/web/document_properties.js
+++ b/web/document_properties.js
@@ -74,8 +74,6 @@ var DocumentProperties = {
   },
 
   getProperties: function documentPropertiesGetProperties() {
-    var self = this;
-
     // Get the file name.
     this.fileName = getPDFFileNameFromURL(PDFView.url);
 
@@ -88,20 +86,20 @@ var DocumentProperties = {
     // Get the other document properties.
     PDFView.pdfDocument.getMetadata().then(function(data) {
       var fields = [
-        { field: self.fileNameField, content: self.fileName },
+        { field: this.fileNameField, content: this.fileName },
         // The fileSize field is updated once getDownloadInfo is resolved.
-        { field: self.titleField, content: data.info.Title },
-        { field: self.authorField, content: data.info.Author },
-        { field: self.subjectField, content: data.info.Subject },
-        { field: self.keywordsField, content: data.info.Keywords },
-        { field: self.creationDateField,
-          content: self.parseDate(data.info.CreationDate) },
-        { field: self.modificationDateField,
-          content: self.parseDate(data.info.ModDate) },
-        { field: self.creatorField, content: data.info.Creator },
-        { field: self.producerField, content: data.info.Producer },
-        { field: self.versionField, content: data.info.PDFFormatVersion },
-        { field: self.pageCountField, content: PDFView.pdfDocument.numPages }
+        { field: this.titleField, content: data.info.Title },
+        { field: this.authorField, content: data.info.Author },
+        { field: this.subjectField, content: data.info.Subject },
+        { field: this.keywordsField, content: data.info.Keywords },
+        { field: this.creationDateField,
+          content: this.parseDate(data.info.CreationDate) },
+        { field: this.modificationDateField,
+          content: this.parseDate(data.info.ModDate) },
+        { field: this.creatorField, content: data.info.Creator },
+        { field: this.producerField, content: data.info.Producer },
+        { field: this.versionField, content: data.info.PDFFormatVersion },
+        { field: this.pageCountField, content: PDFView.pdfDocument.numPages }
       ];
 
       // Show the properties in the dialog.

--- a/web/document_properties.js
+++ b/web/document_properties.js
@@ -74,6 +74,11 @@ var DocumentProperties = {
   },
 
   getProperties: function documentPropertiesGetProperties() {
+    if (!this.visible) {
+      // If the dialog was closed before dataAvailablePromise was resolved,
+      // don't bother updating the properties.
+      return;
+    }
     // Get the file name.
     this.fileName = getPDFFileNameFromURL(PDFView.url);
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -887,6 +887,8 @@ var PDFView = {
 
     this.pdfDocument = pdfDocument;
 
+    DocumentProperties.resolveDataAvailable();
+
     pdfDocument.getDownloadInfo().then(function() {
       PDFView.loadingBar.hide();
       var outerContainer = document.getElementById('outerContainer');


### PR DESCRIPTION
Currently when opening the Document Properties during file load, all fields will remain blank, with the following message printed in the console: `TypeError: PDFView.pdfDocument is null`.

This PR adds a promise that is resolved when the data is available, and also re-factors the code slightly to add a `updateUI` function so that the file size is updated once it's available.

/cc @timvandermeij 
