### PR TITLE
<object> / <embed> support in Chrome / Opera

### DIFF
--- a/extensions/chromium/contentscript.js
+++ b/extensions/chromium/contentscript.js
@@ -25,15 +25,108 @@ function getViewerURL(pdf_url) {
   return VIEWER_URL + '?file=' + encodeURIComponent(pdf_url);
 }
 
-document.addEventListener('beforeload', function(event) {
-  var elem = event.target;
-  if (elem.nodeName.toUpperCase() !== 'EMBED') {
+// (un)prefixed property names
+var createShadowRoot, shadowRoot;
+if (typeof Element.prototype.createShadowRoot !== 'undefined') {
+  // Chrome 35+
+  createShadowRoot = 'createShadowRoot';
+  shadowRoot = 'shadowRoot';
+} else if (typeof Element.prototype.webkitCreateShadowRoot !== 'undefined') {
+  // Chrome 25 - 34
+  createShadowRoot = 'webkitCreateShadowRoot';
+  shadowRoot = 'webkitShadowRoot';
+  try {
+    document.createElement('embed').webkitCreateShadowRoot();
+  } catch (e) {
+    // Only supported since Chrome 33.
+    createShadowRoot = shadowRoot = '';
+  }
+}
+
+// Only observe the document if we can make use of Shadow DOM.
+if (createShadowRoot) {
+  if ('animation' in document.documentElement.style) {
+    document.addEventListener('animationstart', onAnimationStart, true);
+  } else {
+    document.addEventListener('webkitAnimationStart', onAnimationStart, true);
+  }
+}
+
+function onAnimationStart(event) {
+  if (event.animationName === 'pdfjs-detected-object-or-embed') {
+    watchObjectOrEmbed(event.target);
+  }
+}
+
+// Called for every <object> or <embed> element in the page.
+// It does not trigger any Mutation observers, but it may modify the
+// shadow DOM rooted under the given element.
+// Calling this function multiple times for the same element is safe, i.e.
+// it has no side effects.
+function watchObjectOrEmbed(elem) {
+  var mimeType = elem.type;
+  if (mimeType && 'application/pdf' !== mimeType.toLowerCase()) {
     return;
   }
-  if (!/^application\/pdf$/i.test(elem.type)) {
+  // <embed src> <object data>
+  var srcAttribute = 'src' in elem ? 'src' : 'data';
+  var path = elem[srcAttribute];
+  if (!mimeType && !/\.pdf($|[?#])/i.test(path)) {
     return;
   }
-  event.preventDefault();
-  elem.type = 'text/html';
-  elem.src = getViewerURL(elem.src);
-}, true);
+
+  if (elem[shadowRoot]) {
+    // If the element already has a shadow root, assume that we've already
+    // seen this element.
+    return;
+  }
+  elem[createShadowRoot]();
+
+  function updateViewerFrame() {
+    var path = elem[srcAttribute];
+    if (!path) {
+      elem[shadowRoot].textContent = '';
+    } else {
+      elem[shadowRoot].innerHTML =
+        // Set display: inline-block; to the host element (<embed>/<object>) to
+        // ensure that the dimensions defined on the host element are applied to
+        // the iframe (http://crbug.com/358648).
+        // The styles are declared in the shadow DOM to allow page authors to
+        // override these styles (e.g. .style.display = 'none';).
+        '<style>\n' +
+        // Chrome 35+
+        ':host { display: inline-block; }\n' +
+        // Chrome 33 and 34 (not 35+ because of http://crbug.com/351248)
+        '*:not(style):not(iframe) { display: inline-block; }\n' +
+        'iframe { width: 100%; height: 100%; border: 0; }\n' +
+        '</style>' +
+        '<iframe allowfullscreen></iframe>';
+      elem[shadowRoot].lastChild.src = getEmbeddedViewerURL(path);
+    }
+  }
+
+  updateViewerFrame();
+
+  // Watch for page-initiated changes of the src/data attribute.
+  var srcObserver = new MutationObserver(updateViewerFrame);
+  srcObserver.observe(elem, {
+    attributes: true,
+    childList: false,
+    characterData: false,
+    attributeFilter: [srcAttribute]
+  });
+}
+
+// Get the viewer URL, provided that the path is a valid URL.
+function getEmbeddedViewerURL(path) {
+  var fragment = /^([^#]*)(#.*)?$/.exec(path);
+  path = fragment[1];
+  fragment = fragment[2] || '';
+
+  // Resolve relative path to document.
+  var a = document.createElement('a');
+  a.href = document.baseURI;
+  a.href = path;
+  path = a.href;
+  return getViewerURL(path) + fragment;
+}

--- a/extensions/chromium/contentstyle.css
+++ b/extensions/chromium/contentstyle.css
@@ -1,0 +1,13 @@
+/**
+ * Detect creation of <embed> and <object> tags.
+ */
+@-webkit-keyframes pdfjs-detected-object-or-embed { from {} }
+@keyframes         pdfjs-detected-object-or-embed { from {} }
+object, embed {
+  -webkit-animation-delay: 0s !important;
+  -webkit-animation-name: pdfjs-detected-object-or-embed !important;
+  -webkit-animation-play-state: running !important;
+  animation-delay: 0s !important;
+  animation-name: pdfjs-detected-object-or-embed !important;
+  animation-play-state: running !important;
+}

--- a/extensions/chromium/manifest.json
+++ b/extensions/chromium/manifest.json
@@ -25,6 +25,8 @@
       "file://*/*"
     ],
     "run_at": "document_start",
+    "all_frames": true,
+    "css": ["contentstyle.css"],
     "js": ["contentscript.js"]
   }],
   "file_browser_handlers": [{


### PR DESCRIPTION
This PR brings support for embedded PDFs of the following forms:

```
<object type="application/pdf" data="...">
<embed type="application/pdf" src="...">
<object data="....pdf"> <!-- note: no type specified -->
<embed src="....pdf"> <!-- note: no type specified -->
```

Fixes https://github.com/operasoftware/pdf.js/issues/19
Fixes #3736
Supersedes #4194
##### Tests

To check whether the feature works as intended, visit the following pages, and check whether the PDF viewer is rendered:
- http://plugindoc.mozdev.org/testpages/pdf.html
- http://acroeng.adobe.com/wp/?page_id=161 (all 9 examples)
- http://pdfpiw.uspto.gov/.piw?Docid=08000431&homeurl=http%3A%2F%2Fpatft.uspto.gov%2Fnetacgi%2Fnph-Parser%3FSect1%3DPTO2%2526Sect2%3DHITOFF%2526p%3D1%2526u%3D%25252Fnetahtml%25252FPTO%25252Fsearch-bool.html%2526r%3D1%2526f%3DG%2526l%3D50%2526co1%3DAND%2526d%3DPTXT%2526s1%3D3,257,285%2526OS%3D3,257,285%2526RS%3D3,257,285&PageNum=&Rtype=&SectionNum=&idkey=NONE&Input=View+first+page
