### PR TITLE
Use Opaque Canvas

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -688,7 +688,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
         info('The worker has been disabled.');
       }
     }
-//#endif    
+//#endif
     // Either workers are disabled, not supported or have thrown an exception.
     // Thus, we fallback to a faked worker.
     globalScope.PDFJS.disableWorker = true;

--- a/web/page_view.js
+++ b/web/page_view.js
@@ -462,7 +462,7 @@ var PageView = function pageView(container, id, scale,
     this.canvas = canvas;
 
     var scale = this.scale;
-    var ctx = canvas.getContext('2d');
+    var ctx = canvas.getContext('2d', {alpha: false});
     var outputScale = getOutputScale(ctx);
 
     if (USE_ONLY_CSS_ZOOM) {

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -53,7 +53,7 @@ var TextLayerBuilder = function textLayerBuilder(options) {
   this.renderLayer = function textLayerBuilderRenderLayer() {
     var textDivs = this.textDivs;
     var canvas = document.createElement('canvas');
-    var ctx = canvas.getContext('2d');
+    var ctx = canvas.getContext('2d', {alpha: false});
 
     // No point in rendering so many divs as it'd make the browser unusable
     // even after the divs are rendered

--- a/web/thumbnail_view.js
+++ b/web/thumbnail_view.js
@@ -111,7 +111,7 @@ var ThumbnailView = function thumbnailView(container, id, defaultViewport) {
 
     ring.appendChild(canvas);
 
-    var ctx = canvas.getContext('2d');
+    var ctx = canvas.getContext('2d', {alpha: false});
     ctx.save();
     ctx.fillStyle = 'rgb(255, 255, 255)';
     ctx.fillRect(0, 0, this.canvasWidth, this.canvasHeight);


### PR DESCRIPTION
This improves painting performance and text rendering quality in some browsers, without any measurable performance impact.

Scrolling through the TraceMonkey PDF, several times, at three different zoom level with and without opaque Canvas, the average time to draw a page was the same in both Firefox Aurora and Opera Developer.
