### PR TITLE
Refactors history and how the database is stored

### DIFF
--- a/extensions/firefox/bootstrap.js
+++ b/extensions/firefox/bootstrap.js
@@ -43,13 +43,6 @@ function getBoolPref(pref, def) {
   }
 }
 
-function setStringPref(pref, value) {
-  var str = Cc['@mozilla.org/supports-string;1']
-              .createInstance(Ci.nsISupportsString);
-  str.data = value;
-  Services.prefs.setComplexValue(pref, Ci.nsISupportsString, str);
-}
-
 function log(str) {
   if (!getBoolPref(EXT_PREFIX + '.pdfBugEnabled', false)) {
     return;
@@ -176,9 +169,10 @@ function shutdown(aData, aReason) {
 }
 
 function install(aData, aReason) {
+  // TODO remove after some time -- cleanup of unused preferences
+  Services.prefs.clearUserPref(EXT_PREFIX + '.database');
 }
 
 function uninstall(aData, aReason) {
-  setStringPref(EXT_PREFIX + '.database', '{}');
 }
 

--- a/extensions/firefox/content/PdfJs.jsm
+++ b/extensions/firefox/content/PdfJs.jsm
@@ -128,14 +128,18 @@ let PdfJs = {
   },
 
   _migrate: function migrate() {
-    const VERSION = 1;
+    const VERSION = 2;
     var currentVersion = getIntPref(PREF_MIGRATION_VERSION, 0);
     if (currentVersion >= VERSION) {
       return;
     }
     // Make pdf.js the default pdf viewer on the first migration.
-    if (currentVersion < 2) {
+    if (currentVersion < 1) {
       this._becomeHandler();
+    }
+    if (currentVersion < 2) {
+      // cleaning up of unused database preference (see #3994)
+      Services.prefs.clearUserPref(PREF_PREFIX + '.database');
     }
     Services.prefs.setIntPref(PREF_MIGRATION_VERSION, VERSION);
   },

--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -32,7 +32,6 @@ const PDFJS_EVENT_ID = 'pdf.js.message';
 const PDF_CONTENT_TYPE = 'application/pdf';
 const PREF_PREFIX = 'PDFJSSCRIPT_PREF_PREFIX';
 const PDF_VIEWER_WEB_PAGE = 'resource://pdf.js/web/viewer.html';
-const MAX_DATABASE_LENGTH = 4096;
 const MAX_NUMBER_OF_PREFS = 50;
 const MAX_STRING_PREF_LENGTH = 128;
 
@@ -294,19 +293,6 @@ ChromeActions.prototype = {
 
       channel.asyncOpen(listener, null);
     });
-  },
-  setDatabase: function(data) {
-    if (this.isInPrivateBrowsing())
-      return;
-    // Protect against something sending tons of data to setDatabase.
-    if (data.length > MAX_DATABASE_LENGTH)
-      return;
-    setStringPref(PREF_PREFIX + '.database', data);
-  },
-  getDatabase: function() {
-    if (this.isInPrivateBrowsing())
-      return '{}';
-    return getStringPref(PREF_PREFIX + '.database', '{}');
   },
   getLocale: function() {
     return getStringPref('general.useragent.locale', 'en-US');

--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -537,3 +537,23 @@ if (typeof PDFJS === 'undefined') {
     }
   }
 })();
+
+(function checkStorages() {
+  // Feature test as per http://diveintohtml5.info/storage.html
+  // The additional localStorage call is to get around a FF quirk, see
+  // bug #495747 in bugzilla
+  try {
+    if ('localStorage' in window && window['localStorage'] !== null) {
+      return;
+    }
+  } catch (e) { }
+  window.localStorage = {
+    data: Object.create(null),
+    getItem: function (key) {
+      return this.data[key];
+    },
+    setItem: function (key, value) {
+      this.data[key] = value;
+    }
+  };
+})();

--- a/web/preferences.js
+++ b/web/preferences.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals DEFAULT_PREFERENCES, isLocalStorageEnabled, Promise */
+/* globals DEFAULT_PREFERENCES, Promise */
 
 'use strict';
 
@@ -174,19 +174,14 @@ var Preferences = {
 //#if !(FIREFOX || MOZCENTRAL || B2G)
 Preferences._writeToStorage = function (prefObj) {
   return new Promise(function (resolve) {
-    if (isLocalStorageEnabled) {
-      localStorage.setItem('pdfjs.preferences', JSON.stringify(prefObj));
-    }
+    localStorage.setItem('pdfjs.preferences', JSON.stringify(prefObj));
     resolve();
   });
 };
 
 Preferences._readFromStorage = function (prefObj) {
   return new Promise(function (resolve) {
-    var readPrefs;
-    if (isLocalStorageEnabled) {
-      readPrefs = JSON.parse(localStorage.getItem('pdfjs.preferences'));
-    }
+    var readPrefs = JSON.parse(localStorage.getItem('pdfjs.preferences'));
     resolve(readPrefs);
   });
 };

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -257,16 +257,3 @@ var Cache = function cacheCache(size) {
   };
 };
 
-//#if !(FIREFOX || MOZCENTRAL || B2G)
-var isLocalStorageEnabled = (function isLocalStorageEnabledClosure() {
-  // Feature test as per http://diveintohtml5.info/storage.html
-  // The additional localStorage call is to get around a FF quirk, see
-  // bug #495747 in bugzilla
-  try {
-    return ('localStorage' in window && window['localStorage'] !== null &&
-            localStorage);
-  } catch (e) {
-    return false;
-  }
-})();
-//#endif

--- a/web/view_history.js
+++ b/web/view_history.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS, VIEW_HISTORY_MEMORY, isLocalStorageEnabled, Promise */
+/* globals PDFJS, VIEW_HISTORY_MEMORY, Promise */
 
 'use strict';
 
@@ -24,7 +24,7 @@
  *
  * The way that the view parameters are stored depends on how PDF.js is built,
  * for 'node make <flag>' the following cases exist:
- *  - FIREFOX or MOZCENTRAL - uses about:config.
+ *  - FIREFOX or MOZCENTRAL - uses sessionStorage.
  *  - B2G                   - uses asyncStorage.
  *  - GENERIC or CHROME     - uses localStorage, if it is available.
  */
@@ -48,13 +48,11 @@ var ViewHistory = (function ViewHistoryClosure() {
 //#endif
 
 //#if FIREFOX || MOZCENTRAL
-//  resolvePromise(FirefoxCom.requestSync('getDatabase', null));
+//  resolvePromise(sessionStorage.getItem('pdfjsHistory'));
 //#endif
 
 //#if !(FIREFOX || MOZCENTRAL || B2G)
-    if (isLocalStorageEnabled) {
-      resolvePromise(localStorage.getItem('database'));
-    }
+    resolvePromise(localStorage.getItem('database'));
 //#endif
   }
 
@@ -95,13 +93,11 @@ var ViewHistory = (function ViewHistoryClosure() {
 //#endif
 
 //#if FIREFOX || MOZCENTRAL
-//    FirefoxCom.requestSync('setDatabase', database);
+//    sessionStorage.setItem('pdfjsHistory',database);
 //#endif
 
 //#if !(FIREFOX || MOZCENTRAL || B2G)
-      if (isLocalStorageEnabled) {
-        localStorage.setItem('database', database);
-      }
+      localStorage.setItem('database', database);
 //#endif
     },
 


### PR DESCRIPTION
- Alternative for https://bugzilla.mozilla.org/show_bug.cgi?id=986966 and https://bugzilla.mozilla.org/show_bug.cgi?id=865893
- Moves localStorage checks to the compatibility.js

Pros:
- Firefox will not store any history of the browsed files permanently, so no keeping of the trail

Cons:
- Firefox will not store any history of the browsed files permanently, so no restore of the current PDF position after browser is closed
