### PR TITLE
Test with opera

### DIFF
--- a/test/webbrowser.js
+++ b/test/webbrowser.js
@@ -149,7 +149,7 @@ WebBrowser.create = function (desc) {
   if (/firefox/i.test(name)) {
     return new FirefoxBrowser(desc.name, desc.path);
   }
-  if (/(chrome|chromium)/i.test(name)) {
+  if (/(chrome|chromium|opera)/i.test(name)) {
     return new ChromiumBrowser(desc.name, desc.path);
   }
   return new WebBrowser(desc.name, desc.path);

--- a/test/webserver.js
+++ b/test/webserver.js
@@ -161,7 +161,6 @@ WebServer.prototype = {
       res.setHeader('Content-Type', 'text/html');
       res.writeHead(200);
 
-      var content = '';
       if (queryPart === 'frame') {
         res.end('<html><frameset cols=*,200><frame name=pdf>' +
           '<frame src=\"' + encodeURI(pathPart) +


### PR DESCRIPTION
This makes it possible to run the reftests in opera.

E.g. by using such a manifest file

```
   {
    "name": "opera20",
    "path": "/Applications/Opera.app"
   },
```

(`test/resources/browser_manifests/browser_manifest.jsgon`) for the mac.
