### PR TITLE
Display print icon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,10 @@
 # PDF.js
 
-PDF.js is Portable Document Format (PDF) viewer that is built with HTML5.
-
-PDF.js is community-driven and supported by Mozilla Labs. Our goal is to
-create a general-purpose, web standards-based platform for parsing and
-rendering PDFs.
-
-## Contributing
-
-PDF.js is an open source project and always looking for more contributors. To
-get involved checkout:
-
-+ [Workflow](https://github.com/mozilla/pdf.js/wiki/Contributing)
-+ [Style Guide](https://github.com/mozilla/pdf.js/wiki/Style-Guide)
-+ [Good Beginner Bugs](https://github.com/mozilla/pdf.js/issues?direction=desc&labels=5-good-beginner-bug&page=1&sort=created&state=open)
-+ [Priorities](https://github.com/mozilla/pdf.js/issues/milestones)
-+ [Attend a Public Meeting](https://github.com/mozilla/pdf.js/wiki/Weekly-Public-Meetings)
-
-For further questions or guidance feel free to stop by #pdfjs on
-irc.mozilla.org.
-
-## Getting Started
-
-### Online demo
-
-+ http://mozilla.github.io/pdf.js/web/viewer.html
-
-### Browser Extensions
-
-#### Firefox
-
-PDF.js is built into version 19+ of Firefox, however two extensions are still
-available that are updated at a different rate:
-
-+ [Development Version](http://mozilla.github.io/pdf.js/extensions/firefox/pdf.js.xpi) - This version is updated every time new code is merged into the PDF.js codebase. This should be quite stable but still might break from time to time.
-+ [Stable Version](https://addons.mozilla.org/firefox/addon/pdfjs) - After version 24 of Firefox is released we no longer plan to support the stable extension. The stable version will then be considered whatever is built into Firefox.
-
-#### Chrome and Opera
-
-The Chromium extension is still somewhat experimental but it can be installed two
-ways:
-
-+ [Unofficial Version](https://chrome.google.com/webstore/detail/pdf-viewer/oemmndcbldboiebfnladdacbdfmadadm) - *This extension is maintained by a PDF.js contributor.*
-+ Build Your Own - Get the code as explained below and issue `node make chromium`. Then open
-Chrome, go to `Tools > Extension` and load the (unpackaged) extension from the
-directory `build/chromium`.
-
-The version of the extension for the Opera browser can be found at the [Opera add-ons catalog](https://addons.opera.com/en/extensions/details/pdf-viewer/).
-
-## Getting the Code
-
-To get a local copy of the current code, clone it using git:
-
-    $ git clone git://github.com/mozilla/pdf.js.git pdfjs
-    $ cd pdfjs
-
 Next, you need to start a local web server as some browsers don't allow opening
 PDF files for a file:// url:
 
     $ node make server
 
-You can install Node via [nvm](https://github.com/creationix/nvm) or the
-[official package](http://nodejs.org). If everything worked out, you can now
-serve
 
 + http://localhost:8888/web/viewer.html
 
@@ -70,7 +12,23 @@ You can also view all the test pdf files on the right side serving
 
 + http://localhost:8888/test/pdfs/?frame
 
-## Building PDF.js
+
+## Building Kaybus specific PDF.js viewer
+
+In order to bundle all `src/` files into two productions scripts and build the Kaybus Viewer, issue:
+
+    $ node make kb_viewer
+
+This will generate `pdf.js` and `pdf.worker.js` in the `build/kaybus/pdfjs` directory.
+Both scripts are needed but only `pdf.js` needs to be included since `pdf.worker.js` will
+be loaded by `pdf.js`. 
+
+## Deploying Kaybus specific PDF.js viewer to the Kaybus repository
+
+Manually copy pdfjs/build/kaybus/pdfjs folder content into the kaybus/vendor/assets/javascripts/pdfjs folder
+
+
+## Building generic PDF.js
 
 In order to bundle all `src/` files into two productions scripts and build the generic
 viewer, issue:
@@ -82,6 +40,15 @@ Both scripts are needed but only `pdf.js` needs to be included since `pdf.worker
 be loaded by `pdf.js`. If you want to support more browsers than Firefox you'll also need
 to include `compatibility.js` from `build/generic/web/`. The PDF.js files are large and
 should be minified for production.
+
+
+## Cleaning PDF.js
+
+In order to clean a build prior to a new build, please issue:
+
+    $ node make clean
+
+
 
 ## Learning
 
@@ -109,25 +76,3 @@ Even more learning resources can be found at:
 
 + https://github.com/mozilla/pdf.js/wiki/Additional-Learning-Resources
 
-## Questions
-
-Talk to us on IRC:
-
-+ #pdfjs on irc.mozilla.org
-
-Join our mailing list:
-
-+ dev-pdf-js@lists.mozilla.org
-
-Subscribe either using lists.mozilla.org or Google Groups:
-
-+ https://lists.mozilla.org/listinfo/dev-pdf-js
-+ https://groups.google.com/group/mozilla.dev.pdf-js/topics
-
-Follow us on twitter: @pdfjs
-
-+ http://twitter.com/#!/pdfjs
-
-Weekly Public Meetings
-
-+ https://github.com/mozilla/pdf.js/wiki/Weekly-Public-Meetings

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ In order to bundle all `src/` files into two productions scripts and build the K
 
     $ node make kb_viewer
 
-This will generate `pdf.js` and `pdf.worker.js` in the `build/kaybus/pdfjs` directory.
+This will generate `pdf.js` and `pdf.worker.js` in the `build/kb/pdfjs` directory.
 Both scripts are needed but only `pdf.js` needs to be included since `pdf.worker.js` will
 be loaded by `pdf.js`. 
 
 ## Deploying Kaybus specific PDF.js viewer to the Kaybus repository
 
-Manually copy pdfjs/build/kaybus/pdfjs folder content into the kaybus/vendor/assets/javascripts/pdfjs folder
+Manually copy pdfjs/build/kb/pdfjs folder content into the kaybus/vendor/assets/javascripts/pdfjs folder
 
 
 ## Building generic PDF.js

--- a/make.js
+++ b/make.js
@@ -38,6 +38,10 @@ var ROOT_DIR = __dirname + '/', // absolute path to project's root
     LOCALE_SRC_DIR = 'l10n/',
     GH_PAGES_DIR = BUILD_DIR + 'gh-pages/',
     GENERIC_DIR = BUILD_DIR + 'generic/',
+    KB_DIR = BUILD_DIR + 'kb/pdfjs/',
+    KB_BUILD_TARGET = KB_DIR + 'pdf.js',
+    KB_BUILD_WORKER_TARGET = KB_DIR + 'pdf.worker.js',
+    KB_BUILD_TARGETS = [KB_BUILD_TARGET, KB_BUILD_WORKER_TARGET],
     REPO = 'git@github.com:mozilla/pdf.js.git',
     PYTHON_BIN = 'python2.7',
     MOZCENTRAL_PREF_PREFIX = 'pdfjs',
@@ -119,6 +123,49 @@ target.generic = function() {
 
   cleanupJSSource(GENERIC_DIR + '/web/viewer.js');
 };
+
+
+
+//
+// make viewer
+// Builds the generic production viewer that should be compatible with most
+// modern HTML5 browsers.
+//
+target.kb_viewer = function() {
+  target.bundle({});
+  target.locale();
+
+  cd(ROOT_DIR);
+  echo();
+  echo('### Creating custom kb viewer');
+
+  rm('-rf', KB_DIR);
+  mkdir('-p', KB_DIR);
+
+  var defines = builder.merge(DEFINES, {GENERIC: true});
+
+  var setup = {
+    defines: defines,
+    copy: [
+      [COMMON_WEB_FILES, KB_DIR],
+      ['external/webL10n/l10n.js', KB_DIR],
+      ['web/viewer.css', KB_DIR],
+      ['web/compatibility.js', KB_DIR],
+      ['web/locale', KB_DIR]
+    ],
+    preprocess: [
+      [BUILD_TARGETS, KB_DIR],
+      [COMMON_WEB_FILES_PREPROCESS, KB_DIR]
+    ]
+  };
+  builder.build(setup);
+
+  cleanupJSSource(KB_DIR + '/viewer.js');
+  rm('-rf', BUILD_DIR + '/pdf.js');
+  rm('-rf', BUILD_DIR + '/pdf.worker.js');
+
+};
+
 
 //
 // make web

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -2721,6 +2721,7 @@ var Font = (function FontClosure() {
     }
     var winAscent = override.yMax || typoAscent;
     var winDescent = -override.yMin || -typoDescent;
+    var x31 = '\x31';
 
     return '\x00\x03' + // version
            '\x02\x24' + // xAvgCharWidth
@@ -2735,7 +2736,7 @@ var Font = (function FontClosure() {
            '\x02\xBB' + // ySuperScriptYSize
            '\x00\x00' + // ySuperScriptXOffset
            '\x01\xDF' + // ySuperScriptYOffset
-           '\x00\x31' + // yStrikeOutSize
+           '\x00'+x31 + // yStrikeOutSize
            '\x01\x02' + // yStrikeOutPosition
            '\x00\x00' + // sFamilyClass
            '\x00\x00\x06' +

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -47,3 +47,13 @@ if (!PDFJS.workerSrc && typeof document !== 'undefined') {
   })();
 }
 //#endif
+
+function search(searchQuery){
+    if (!searchQuery || searchQuery.length == 0){
+      return;
+    }
+    PDFFindBar.open(); 
+    PDFFindBar.findField.value = searchQuery;
+    PDFFindBar.highlightAll= true;
+    PDFFindBar.findNextButton.click();
+}

--- a/src/shared/annotation.js
+++ b/src/shared/annotation.js
@@ -713,6 +713,8 @@ var LinkAnnotation = (function LinkAnnotationClosure() {
       element.style.height = height + 'px';
 
       element.href = this.data.url || '';
+      element.target = '_blank';
+
       return element;
     }
   });

--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -39,6 +39,7 @@ var PDFFindBar = {
   findNextButton: null,
 
   initialize: function(options) {
+    options.highlightAllCheckbox.checked=true;
     if(typeof PDFFindController === 'undefined' || PDFFindController === null) {
         throw 'PDFFindBar cannot be initialized ' +
             'without a PDFFindController instance.';

--- a/web/presentation_mode.js
+++ b/web/presentation_mode.js
@@ -25,7 +25,7 @@ var DELAY_BEFORE_RESETTING_SWITCH_IN_PROGRESS = 1000; // in ms
 var PresentationMode = {
   active: false,
   args: null,
-  contextMenuOpen: false,
+  contextMenuOpen: true,
 //#if (GENERIC || CHROME)
   prevCoords: { x: null, y: null },
 //#endif
@@ -161,7 +161,7 @@ var PresentationMode = {
     window.removeEventListener('mousedown', this.mouseDown, false);
     window.removeEventListener('contextmenu', this.contextMenu, false);
 
-    this.hideControls();
+    this.showControls();
     PDFView.clearMouseScrollState();
     HandTool.exitPresentationMode();
     this.container.removeAttribute('contextmenu');

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -23,8 +23,7 @@
 
 'use strict';
 
-var DEFAULT_URL = 'compressed.tracemonkey-pldi-09.pdf';
-var DEFAULT_SCALE = 'auto';
+var DEFAULT_SCALE = '1'; // 1 = set default zoom to 100%
 var DEFAULT_SCALE_DELTA = 1.1;
 var UNKNOWN_SCALE = 0;
 var CACHE_SIZE = 20;
@@ -39,8 +38,11 @@ var SCALE_SELECT_CONTAINER_PADDING = 8;
 var SCALE_SELECT_PADDING = 22;
 var THUMBNAIL_SCROLL_MARGIN = -19;
 var USE_ONLY_CSS_ZOOM = false;
+var PDFJS_APP_PATH = '/assets/pdfjs/';
+var DEFAULT_URL = PDFJS_APP_PATH + 'compressed.tracemonkey-pldi-09.pdf';
 var CLEANUP_TIMEOUT = 30000;
 var IGNORE_CURRENT_POSITION_ON_ZOOM = false;
+
 //#if B2G
 //USE_ONLY_CSS_ZOOM = true;
 //#endif
@@ -57,9 +59,9 @@ var FindStates = {
   FIND_PENDING: 3
 };
 
-PDFJS.imageResourcesPath = './images/';
+PDFJS.imageResourcesPath = PDFJS_APP_PATH + '/images/';
 //#if (FIREFOX || MOZCENTRAL || B2G || GENERIC || CHROME)
-//PDFJS.workerSrc = '../build/pdf.worker.js';
+//PDFJS.workerSrc = PDFJS_APP_PATH + '/pdf.worker.js';
 //#endif
 
 var mozL10n = document.mozL10n || document.webL10n;
@@ -110,7 +112,7 @@ var PDFView = {
   mouseScrollDelta: 0,
   lastScroll: 0,
   previousPageNumber: 1,
-  isViewerEmbedded: (window.parent !== window),
+  isViewerEmbedded: false,
   idleTimeout: null,
   currentPosition: null,
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -339,6 +339,12 @@ var PDFView = {
   get supportsPrinting() {
     var canvas = document.createElement('canvas');
     var value = 'mozPrintCallback' in canvas;
+
+    // This hides the print icon if printing is not natively supported.
+    // However, the shim does provide the ability to print.
+    // So we DO want to show the icon.
+    value = true;
+
     // shadow
     Object.defineProperty(this, 'supportsPrinting', { value: value,
                                                       enumerable: true,


### PR DESCRIPTION
The `supportsPrinting` property was being set based on the presence of the `mozPrintCallback` property on the `canvas` element. Even though that is polyfilled on other browsers, this caused the print icon to not be displayed. Set it to `true` in all cases.
