### PR TITLE
Read color info from JPX stream + fix color problem #4540

### DIFF
--- a/src/core/image.js
+++ b/src/core/image.js
@@ -52,17 +52,19 @@ var PDFImage = (function PDFImageClosure() {
   function PDFImage(xref, res, image, inline, smask, mask, isMask) {
     this.image = image;
     var dict = image.dict;
-    if (dict.get('Filter').name === 'JPXDecode') {
-      info('get image params from JPX stream');
-      var jpxImage = new JpxImage();
-      var data = image.stream.bytes;
-      jpxImage.parseImageProperties(data, 0, data.length);
-      image.bitsPerComponent = jpxImage.bitsPerComponent;
-      image.numComps = jpxImage.componentsCount;
-    }
-    if (dict.get('Filter').name === 'JBIG2Decode') {
-      image.bitsPerComponent = 1;
-      image.numComps = 1;
+    if (dict.has('Filter')) {
+      var filter = dict.get('Filter').name;
+      if (filter === 'JPXDecode') {
+        info('get image params from JPX stream');
+        var jpxImage = new JpxImage();
+        jpxImage.parseImageProperties(image.stream);
+        image.stream.reset();
+        image.bitsPerComponent = jpxImage.bitsPerComponent;
+        image.numComps = jpxImage.componentsCount;
+      } else if (filter === 'JBIG2Decode') {
+        image.bitsPerComponent = 1;
+        image.numComps = 1;
+      }
     }
     // TODO cache rendered images?
 

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -98,19 +98,22 @@ var JpxImage = (function JpxImageClosure() {
         }
       }
     },
-    parseImageProperties: function JpxImage_parseImageProperties(data, start,
-                                                                 end) {
+    parseImageProperties: function JpxImage_parseImageProperties(stream) {
       try {
-        var position = start;
-        while (position + 40 < end) {
-          var code = readUint16(data, position);
+        var newByte = stream.getByte();
+        while (newByte >= 0) {
+          var oldByte = newByte;
+          newByte = stream.getByte();
+          var code = (oldByte << 8) | newByte;
           // Image and tile size (SIZ)
           if (code == 0xFF51) {
-            var Xsiz = readUint32(data, position + 6);
-            var Ysiz = readUint32(data, position + 10);
-            var XOsiz = readUint32(data, position + 14);
-            var YOsiz = readUint32(data, position + 18);
-            var Csiz = readUint16(data, position + 38);
+            stream.skip(4);
+            var Xsiz = stream.getUint32(); // Byte 4 
+            var Ysiz = stream.getUint32(); // Byte 8
+            var XOsiz = stream.getUint32(); // Byte 12
+            var YOsiz = stream.getUint32(); // Byte 16
+            stream.skip(16);
+            var Csiz = stream.getUint16(); // Byte 36
             this.width = Xsiz - XOsiz;
             this.height = Ysiz - YOsiz;
             this.componentsCount = Csiz;
@@ -118,7 +121,6 @@ var JpxImage = (function JpxImageClosure() {
             this.bitsPerComponent = 8;
             return;
           }
-          position += 1;
         }
         throw 'No size marker found in JPX stream';
       } catch (e) {


### PR DESCRIPTION
These are two commits that I accicently squashed into one.

The first one gets color information directly from the JPX stream, to define the color space in `images.js`.
This fixes #1303, #4407 (and all documents that are created with Acrobat 8 from JPX images).
I'm not 100% if this is how it is supposed to be done in `image.js`, so please have a look at that.

The other commit corrects the coefficient magnitudes in `jpx.js` and so fixes #4540.

Everything below Line 1000 in `jpx.js` is just minor cleanup.

I opened another PR concurrently to #4538, because I wanted to fix errors first, and make the performance oriented changes of #4538 optional.
