### PR TITLE
Handle 'space' character correctly in MacRomanEncoding (bug 878026)

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -158,7 +158,7 @@ var Encodings = {
     'summation', 'product', 'pi', 'integral', 'ordfeminine', 'ordmasculine',
     'Omega', 'ae', 'oslash', 'questiondown', 'exclamdown', 'logicalnot',
     'radical', 'florin', 'approxequal', 'Delta', 'guillemotleft',
-    'guillemotright', 'ellipsis', '', 'Agrave', 'Atilde', 'Otilde', 'OE',
+    'guillemotright', 'ellipsis', 'space', 'Agrave', 'Atilde', 'Otilde', 'OE',
     'oe', 'endash', 'emdash', 'quotedblleft', 'quotedblright', 'quoteleft',
     'quoteright', 'divide', 'lozenge', 'ydieresis', 'Ydieresis', 'fraction',
     'currency', 'guilsinglleft', 'guilsinglright', 'fi', 'fl', 'daggerdbl',

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -59,6 +59,7 @@
 !noembed-eucjp.pdf
 !noembed-sjis.pdf
 !vertical.pdf
+!bug878026.pdf
 !issue3025.pdf
 !issue2099-1.pdf
 !issue3371.pdf

--- a/test/pdfs/bug878026.pdf
+++ b/test/pdfs/bug878026.pdf
@@ -1,0 +1,71 @@
+%PDF-1.7
+43 0 obj
+<<
+/Type /Catalog
+/Pages 44 0 R
+>>
+endobj
+44 0 obj
+<<
+/Type /Pages
+/MediaBox [ 0 0 200 50 ]
+/Count 1
+/Kids [ 45 0 R ]
+>>
+endobj
+45 0 obj
+<<
+/Type /Page
+/Parent 44 0 R
+/Resources <<
+/Font <<
+/F1 46 0 R
+>>
+
+>>
+
+/Contents 47 0 R
+>>
+endobj
+46 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/Name /Fcpdf1
+/BaseFont /Times-Roman
+/Encoding /MacRomanEncoding
+>>
+endobj
+47 0 obj
+<<
+/Length 44
+>>
+stream
+BT
+10 20 TD
+/F1 20 Tf
+(Bug\312878026) Tj
+ET
+endstream
+endobj
+xref
+0 1
+0000000000 65535 f
+43 1
+0000000009 00000 n
+44 1
+0000000060 00000 n
+45 1
+0000000146 00000 n
+46 1
+0000000254 00000 n
+47 1
+0000000369 00000 n
+trailer
+<<
+/Size 5
+/Root 43 0 R
+>>
+startxref
+463
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -343,6 +343,15 @@
        "rounds": 1,
        "type": "load"
     },
+    {  "id": "bug878026",
+       "file": "pdfs/bug878026.pdf",
+       "md5": "13072db0586f2b4e96de189e23fc7395",
+       "rounds": 1,
+       "link": false,
+       "firstPage": 1,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "jai-pdf",
        "file": "pdfs/jai.pdf",
        "md5": "1f5dd128c3757420a881a155f2f8ace3",


### PR DESCRIPTION
According to the specification, using MacRomanEncoding the "space" character could also be encoded as 312 (= 202 decimal), see **Note 6** here: http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#page=664.

Currently `MacRomanEncoding[202] = ''` ([fonts.js#L161](https://github.com/mozilla/pdf.js/blob/master/src/core/fonts.js#L161)), and given [fonts.js#L4210](https://github.com/mozilla/pdf.js/blob/master/src/core/fonts.js#L4210) this explains why the "Ecircumflex" character is rendered.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=878026.
