### PR TITLE
Handle 'space' character correctly in WinAnsiEncoding (bug 850854)

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -210,7 +210,7 @@ var Encodings = {
     'guilsinglleft', 'OE', 'bullet', 'Zcaron', 'bullet', 'bullet', 'quoteleft',
     'quoteright', 'quotedblleft', 'quotedblright', 'bullet', 'endash',
     'emdash', 'tilde', 'trademark', 'scaron', 'guilsinglright', 'oe', 'bullet',
-    'zcaron', 'Ydieresis', '', 'exclamdown', 'cent', 'sterling',
+    'zcaron', 'Ydieresis', 'space', 'exclamdown', 'cent', 'sterling',
     'currency', 'yen', 'brokenbar', 'section', 'dieresis', 'copyright',
     'ordfeminine', 'guillemotleft', 'logicalnot', 'hyphen', 'registered',
     'macron', 'degree', 'plusminus', 'twosuperior', 'threesuperior', 'acute',

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -50,6 +50,7 @@
 !issue925.pdf
 !gradientfill.pdf
 !bug903856.pdf
+!bug850854.pdf
 !basicapi.pdf
 !mixedfonts.pdf
 !shading_extend.pdf

--- a/test/pdfs/bug850854.pdf
+++ b/test/pdfs/bug850854.pdf
@@ -1,0 +1,70 @@
+%PDF-1.7
+11 0 obj
+<<
+/Type /Catalog
+/Pages 12 0 R
+>>
+endobj
+12 0 obj
+<<
+/Type /Pages
+/MediaBox [ 0 0 200 50 ]
+/Count 1
+/Kids [ 13 0 R ]
+>>
+endobj
+13 0 obj
+<<
+/Type /Page
+/Parent 12 0 R
+/Resources <<
+/Font <<
+/F1 14 0 R
+>>
+
+>>
+
+/Contents 15 0 R
+>>
+endobj
+14 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+>>
+endobj
+15 0 obj
+<<
+/Length 52
+>>
+stream
+BT
+10 20 TD
+/F1 20 Tf
+(Bug\240\240\240850854) Tj
+ET
+endstream
+endobj
+xref
+0 1
+0000000000 65535 f
+11 1
+0000000009 00000 n
+12 1
+0000000060 00000 n
+13 1
+0000000146 00000 n
+14 1
+0000000254 00000 n
+15 1
+0000000352 00000 n
+trailer
+<<
+/Size 5
+/Root 11 0 R
+>>
+startxref
+454
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -378,6 +378,15 @@
        "rounds": 1,
        "type": "load"
     },
+    {  "id": "bug850854",
+       "file": "pdfs/bug850854.pdf",
+       "md5": "346a034a80120d123b9fefc42bcb11da",
+       "rounds": 1,
+       "link": false,
+       "firstPage": 1,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "wdsg_fitc",
        "file": "pdfs/wdsg_fitc.pdf",
        "md5": "5bb1c2b83705d4cdfc43197ee74f07f9",


### PR DESCRIPTION
(Basically identical to PR #4569, but for WinAnsiEncoding.)

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=850854.
