### PR TITLE
Workaround for cases where FontName in the FontDescriptor differs from BaseFont in the Font (bug 847420)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1219,6 +1219,12 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           info('The FontDescriptor\'s FontName is "' + fontNameStr +
                '" but should be the same as the Font\'s BaseFont "' +
                baseFontStr + '"');
+          // Workaround for cases where e.g. fontNameStr = 'Arial' and
+          // baseFontStr = 'Arial,Bold' (needed when no font file is embedded).
+          if (fontNameStr && baseFontStr &&
+              baseFontStr.search(fontNameStr) === 0) {
+            fontName = baseFont;
+          }
         }
       }
       fontName = (fontName || baseFont);


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=847420.
