### PR TITLE
Remove leading and trailing spaces from info.Producer and info.Creator when printing debug info in the console (bug 872827)

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1102,8 +1102,8 @@ var PDFView = {
 
       // Provides some basic debug information
       console.log('PDF ' + pdfDocument.fingerprint + ' [' +
-                  info.PDFFormatVersion + ' ' + (info.Producer || '-') +
-                  ' / ' + (info.Creator || '-') + ']' +
+                  info.PDFFormatVersion + ' ' + (info.Producer || '-').trim() +
+                  ' / ' + (info.Creator || '-').trim() + ']' +
                   (PDFJS.version ? ' (PDF.js: ' + PDFJS.version + ')' : ''));
 
       var pdfTitle;


### PR DESCRIPTION
Using `trim` instead of a regexp seemed less clunky, and it should be fine given https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim#Browser_compatibility.
(If this assumption is incorrect, I'll be happy to either replacing it with a regexp or adding a polyfill in web/compatibility.js.)

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=872827.
