### PR TITLE
Append whitespace divs so matches still line up.

### DIFF
--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -112,6 +112,7 @@ var TextLayerBuilder = function textLayerBuilder(options) {
   this.appendText = function textLayerBuilderAppendText(geom, styles) {
     var style = styles[geom.fontName];
     var textDiv = document.createElement('div');
+    this.textDivs.push(textDiv);
     if (!/\S/.test(geom.str)) {
       textDiv.dataset.isWhitespace = true;
       return;
@@ -140,7 +141,6 @@ var TextLayerBuilder = function textLayerBuilder(options) {
       textDiv.dataset.canvasWidth = geom.width * this.viewport.scale;
     }
 
-    this.textDivs.push(textDiv);
   };
 
   this.setTextContent = function textLayerBuilderSetTextContent(textContent) {


### PR DESCRIPTION
Search was broken in this pdf.
STR:
1. Open http://www.adobe.com/products/postscript/pdfs/PLRM.pdf
2. Search for 'dieresis'
