### PR TITLE
Print WebGL status in the console

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1104,7 +1104,8 @@ var PDFView = {
       console.log('PDF ' + pdfDocument.fingerprint + ' [' +
                   info.PDFFormatVersion + ' ' + (info.Producer || '-').trim() +
                   ' / ' + (info.Creator || '-').trim() + ']' +
-                  (PDFJS.version ? ' (PDF.js: ' + PDFJS.version + ')' : ''));
+                  ' (PDF.js: ' + (PDFJS.version || '-') +
+                  (!PDFJS.disableWebGL ? ' [WebGL]' : '') + ')');
 
       var pdfTitle;
       if (metadata && metadata.has('dc:title')) {


### PR DESCRIPTION
Since it's possible to enable WebGL through a preference, I think it makes sense to indicate if WebGL is active when printing debug info in the console.
This will not only be be useful when debugging, but should also help when people are reporting rendering bugs. (Since asking a bug reporter to open the console and copy-paste the messages should be a lot easier, and less error prone, compared to asking them to also run e.g. `PDFJS.disableWebGL` and copy-paste the result of that.)

**Edit:** Can easily tested with
http://107.22.172.223:8877/f79df450bcdd0fe/web/viewer.html#webgl=true
http://107.22.172.223:8877/f79df450bcdd0fe/web/viewer.html#webgl=false
