### PR TITLE
Makes PDF files load when xrefEntry is undefined

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -1100,7 +1100,7 @@ var XRef = (function XRefClosure() {
 
     getEntry: function XRef_getEntry(i) {
       var xrefEntry = this.entries[i];
-      if (xrefEntry !== null && !xrefEntry.free && xrefEntry.offset) {
+      if (xrefEntry && !xrefEntry.free && xrefEntry.offset) {
         return xrefEntry;
       }
       return null;


### PR DESCRIPTION
Fixes http://www.prensalibre.com/multimedia/Terremoto-1976-Sismo-terremoto_del_76-guatemala-Teremoto-temblorgt_PREFIL20140203_0001.pdf from http://bthorben.github.io/pdfRepo.

Thanks to @bthorben and the Opera team for listing problematic PDFs at http://bthorben.github.io/pdfRepo!
