### PR TITLE
Exclude B2G stubs from linting

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -9,6 +9,7 @@ external/jpgjs/
 external/jasmine/
 external/cmapscompress/
 external/importL10n/
+shared/
 test/tmp/
 test/features/
 test/resources/


### PR DESCRIPTION
After #4602, you get lint failures if you have added a `shared` folder containing B2G viewer stubs (as outlined in https://github.com/mozilla/pdf.js/pull/3794#issue-20775028). 
