### PR TITLE
Refactor - remove redundant function and all references

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals assertWellFormed, calculateMD5, Catalog, Dict, error, info, isArray,
+/* globals assert, calculateMD5, Catalog, Dict, error, info, isArray,
            isArrayBuffer, isName, isStream, isString, LegacyPromise,
            Linearization, NullStream, PartialEvaluator, shadow, Stream, Lexer,
            StreamsSequenceStream, stringToPDFString, stringToBytes, Util, XRef,
@@ -303,7 +303,7 @@ var PDFDocument = (function PDFDocumentClosure() {
   }
 
   function init(pdfManager, stream, password) {
-    assertWellFormed(stream.length > 0, 'stream must have data');
+    assert(stream.length > 0, 'stream must have data');
     this.pdfManager = pdfManager;
     this.stream = stream;
     var xref = new XRef(this.stream, password, pdfManager);

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals assert, assertWellFormed, ColorSpace, DecodeStream, Dict, Encodings,
+/* globals assert, ColorSpace, DecodeStream, Dict, Encodings,
            error, ErrorFont, Font, FONT_IDENTITY_MATRIX, fontCharsToUnicode,
            FontFlags, ImageKind, info, isArray, isCmd, isDict, isEOF, isName,
            isNum, isStream, isString, JpegStream, Lexer, Metrics,
@@ -564,10 +564,10 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
             var xobj = xobjs.get(name);
             if (xobj) {
-              assertWellFormed(isStream(xobj), 'XObject should be a stream');
+              assert(isStream(xobj), 'XObject should be a stream');
 
               var type = xobj.dict.get('Subtype');
-              assertWellFormed(isName(type),
+              assert(isName(type),
                 'XObject should have a Name subtype');
 
               if ('Form' == type.name) {
@@ -942,10 +942,10 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
             if (!xobj) {
               break;
             }
-            assertWellFormed(isStream(xobj), 'XObject should be a stream');
+            assert(isStream(xobj), 'XObject should be a stream');
 
             var type = xobj.dict.get('Subtype');
-            assertWellFormed(isName(type),
+            assert(isName(type),
               'XObject should have a Name subtype');
 
             if ('Form' !== type.name) {
@@ -1287,7 +1287,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     preEvaluateFont: function PartialEvaluator_preEvaluateFont(dict, xref) {
       var baseDict = dict;
       var type = dict.get('Subtype');
-      assertWellFormed(isName(type), 'invalid font Subtype');
+      assert(isName(type), 'invalid font Subtype');
 
       var composite = false;
       var uint8array;
@@ -1303,7 +1303,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         dict = (isArray(df) ? xref.fetchIfRef(df[0]) : df);
 
         type = dict.get('Subtype');
-        assertWellFormed(isName(type), 'invalid font Subtype');
+        assert(isName(type), 'invalid font Subtype');
         composite = true;
       }
 
@@ -1434,7 +1434,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       }
       fontName = (fontName || baseFont);
 
-      assertWellFormed(isName(fontName), 'invalid font name');
+      assert(isName(fontName), 'invalid font name');
 
       var fontFile = descriptor.get('FontFile', 'FontFile2', 'FontFile3');
       if (fontFile) {
@@ -1827,7 +1827,7 @@ var EvaluatorPreprocessor = (function EvaluatorPreprocessorClosure() {
           // argument
           if (obj !== null && obj !== undefined) {
             args.push((obj instanceof Dict ? obj.getAll() : obj));
-            assertWellFormed(args.length <= 33, 'Too many arguments');
+            assert(args.length <= 33, 'Too many arguments');
           }
           continue;
         }

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -14,10 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals assertWellFormed, bytesToString, CipherTransformFactory, error, info,
+/* globals assert, bytesToString, CipherTransformFactory, error, info,
            InvalidPDFException, isArray, isCmd, isDict, isInt, isName, isRef,
            isStream, Lexer, Page, Parser, Promise, shadow,
-           stringToPDFString, stringToUTF8String, warn, isString, assert,
+           stringToPDFString, stringToUTF8String, warn, isString,
            Promise, MissingDataException, XRefParseException, Stream,
            ChunkedStream, LegacyPromise */
 
@@ -296,7 +296,7 @@ var Catalog = (function CatalogClosure() {
     this.xref = xref;
     this.catDict = xref.getCatalogObj();
     this.fontCache = new RefSetCache();
-    assertWellFormed(isDict(this.catDict),
+    assert(isDict(this.catDict),
       'catalog object is not a dictionary');
 
     this.pagePromises = [];
@@ -337,7 +337,7 @@ var Catalog = (function CatalogClosure() {
     },
     get toplevelPagesDict() {
       var pagesObj = this.catDict.get('Pages');
-      assertWellFormed(isDict(pagesObj), 'invalid top-level pages dictionary');
+      assert(isDict(pagesObj), 'invalid top-level pages dictionary');
       // shadow the prototype getter
       return shadow(this, 'toplevelPagesDict', pagesObj);
     },
@@ -411,7 +411,7 @@ var Catalog = (function CatalogClosure() {
     },
     get numPages() {
       var obj = this.toplevelPagesDict.get('Count');
-      assertWellFormed(
+      assert(
         isInt(obj),
         'page count in top level pages object is not an integer'
       );
@@ -1114,7 +1114,7 @@ var XRef = (function XRefClosure() {
     },
 
     fetch: function XRef_fetch(ref, suppressEncryption) {
-      assertWellFormed(isRef(ref), 'ref object is not a reference');
+      assert(isRef(ref), 'ref object is not a reference');
       var num = ref.num;
       if (num in this.cache) {
         var cacheEntry = this.cache[num];

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -283,14 +283,6 @@ function isValidUrl(url, allowRelative) {
 }
 PDFJS.isValidUrl = isValidUrl;
 
-// In a well-formed PDF, |cond| holds.  If it doesn't, subsequent
-// behavior is undefined.
-function assertWellFormed(cond, msg) {
-  if (!cond) {
-    error(msg);
-  }
-}
-
 function shadow(obj, prop, value) {
   Object.defineProperty(obj, prop, { value: value,
                                      enumerable: true,


### PR DESCRIPTION
The function `assertWllFormed` was doing nothing different than `assert` which is
available in the same namespace. Removing it will lighten the filesize - albeit
very slightly - and reduce complexity.
