### PR TITLE
Changes 'documentload' event behavior.

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -913,7 +913,7 @@ var PDFView = {
 
     DocumentProperties.resolveDataAvailable();
 
-    pdfDocument.getDownloadInfo().then(function() {
+    var downloadedPromise = pdfDocument.getDownloadInfo().then(function() {
       self.downloadComplete = true;
       PDFView.loadingBar.hide();
       var outerContainer = document.getElementById('outerContainer');
@@ -988,9 +988,11 @@ var PDFView = {
         }
       });
 
-      var event = document.createEvent('CustomEvent');
-      event.initCustomEvent('documentload', true, true, {});
-      window.dispatchEvent(event);
+      downloadedPromise.then(function () {
+        var event = document.createEvent('CustomEvent');
+        event.initCustomEvent('documentload', true, true, {});
+        window.dispatchEvent(event);
+      });
 
       PDFView.loadingBar.setWidth(container);
 


### PR DESCRIPTION
... to wait until entire PDF document data is loaded

In support of https://bugzilla.mozilla.org/show_bug.cgi?id=995431
