### PR TITLE
Multiline text blocks

### DIFF
--- a/examples/text-selection/js/minimal.js
+++ b/examples/text-selection/js/minimal.js
@@ -21,6 +21,7 @@ window.onload = function () {
 
   var scale = 1.5; //Set this to whatever you want. This is basically the "zoom" factor for the PDF.
   PDFJS.workerSrc = '../../build/generic/build/pdf.worker.js';
+  var fontMetrics = new FontMetrics();
 
   function loadPdf(pdfPath) {
     var pdf = PDFJS.getDocument(pdfPath);
@@ -74,7 +75,8 @@ window.onload = function () {
       var textLayer = new TextLayerBuilder({
         textLayerDiv: $textLayerDiv.get(0),
         viewport: viewport,
-        pageIndex: 0
+        pageIndex: 0,
+        fontMetrics: fontMetrics
       });
       textLayer.setTextContent(textContent);
 

--- a/make.js
+++ b/make.js
@@ -456,7 +456,8 @@ function cleanupJSSource(file) {
   var content = cat(file);
 
   // Strip out all the vim/license headers.
-  var reg = /\n\/\* -\*- Mode(.|\n)*?Mozilla Foundation(.|\n)*?'use strict';/g;
+  var reg = new RegExp('\\n\\/\\* -\\*- Mode(.|\\n)*?' +
+    '(Mozilla Foundation|Opera Software ASA)(.|\\n)*?\'use strict\';', 'g');
   content = content.replace(reg, '');
 
   content.to(file);

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -134,6 +134,16 @@ PDFJS.verbosity = (PDFJS.verbosity === undefined ?
                    PDFJS.VERBOSITY_LEVELS.warnings : PDFJS.verbosity);
 
 /**
+ * Disables creation of multi-line text blocks in the text layer.
+ * Currently disabled by default.
+ * @var {boolean}
+ */
+
+PDFJS.disableMultilineTextLayer =
+  (PDFJS.disableMultilineTextLayer === undefined ?
+   true : PDFJS.disableMultilineTextLayer);
+
+/**
  * Document initialization / loading parameters object.
  *
  * @typedef {Object} DocumentInitParameters

--- a/web/font_metrics.js
+++ b/web/font_metrics.js
@@ -1,0 +1,82 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+
+/* Copyright 2014 Opera Software ASA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+var FontMetrics = (function FontMetricsClosure () {
+
+  function FontMetrics () {
+    this.canvas = document.createElement('canvas');
+    this.ctx = this.canvas.getContext('2d');
+    this.canvas.width = 100;
+    this.canvas.height = 100;
+    this.cache = Object.create(null);
+  }
+
+  FontMetrics.prototype = {
+    getFirstNoneWhitePixelTop: function FontMetricsGetFirstNoneWhitePixelTop() {
+      var x = 0;
+      var y = 0;
+      var width = this.canvas.width;
+      var height = this.canvas.height;
+      var pixels = null;
+      while (y < height) {
+        pixels = this.ctx.getImageData(0, y, width, 1).data;
+        for (x = 0; x < width * 4; x += 4) {
+          if (pixels[x] === 0) {
+            break;
+          }
+        }
+
+        if (x < width) {
+          break;
+        }
+        y++;
+      }
+      return y;
+    },
+
+    getFontAscent: function FontMetricsDetFontAscent(font, str) {
+      if (this.cache[font]) {
+        return this.cache[font];
+      }
+
+      if (!str) {
+        str = 'The quick brown fox jumps over the lazy dog';
+      }
+      var height = parseFloat(font);
+      var textBaselines = ['alphabetic', 'top'];
+      var results = [];
+      for (var i = 0; i < 2; i++) {
+        this.ctx.fillStyle = '#fff';
+        this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+        this.ctx.textBaseline = textBaselines[i];
+        this.ctx.fillStyle = '#000';
+        this.ctx.font = font;
+        this.ctx.fillText(str, 0, height);
+        results[i] = this.getFirstNoneWhitePixelTop();
+      }
+      var ascent = results[1] - results[0];
+      this.cache[font] = ascent;
+      return ascent;
+    }
+  };
+
+  return FontMetrics;
+
+})();

--- a/web/page_view.js
+++ b/web/page_view.js
@@ -494,7 +494,8 @@ var PageView = function pageView(container, id, scale,
         pageIndex: this.id - 1,
         lastScrollSource: PDFView,
         viewport: this.viewport,
-        isViewerInPresentationMode: PresentationMode.active
+        isViewerInPresentationMode: PresentationMode.active,
+        fontMetrics: PDFView.fontMetrics
       }) : null;
     // TODO(mack): use data attributes to store these
     ctx._scaleX = outputScale.sx;

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -54,6 +54,7 @@ var TextLayerBuilder = function textLayerBuilder(options) {
   this.currentRowCount = 0;
   this.currentLastElement = null;
   this.isBlockBuilding = false;
+  this.fontMetrics = options.fontMetrics;
 
   if (typeof PDFFindController === 'undefined') {
     window.PDFFindController = null;
@@ -189,9 +190,9 @@ var TextLayerBuilder = function textLayerBuilder(options) {
       CustomStyle.setProp('transform' , this.currentDiv, transform);
       CustomStyle.setProp('transformOrigin' , this.currentDiv, '0% 0%');
       this.currentRowCount = 0;
-      var delta = Math.round((this.currentFontHeight - setLineHeight) / 2);
+      var delta = (this.currentFontHeight - setLineHeight) / 2;
       if (delta) {
-        this.currentDiv.style.marginTop = delta + 'px';
+        this.currentDiv.style.marginTop = delta.toFixed(3) + 'px';
       }
     }
   };
@@ -311,9 +312,8 @@ var TextLayerBuilder = function textLayerBuilder(options) {
       angle += Math.PI / 2;
     }
     var fontHeight = Math.sqrt((tx[2] * tx[2]) + (tx[3] * tx[3]));
-    var fontAscent = (style.ascent ? style.ascent * fontHeight :
-      (style.descent ? (1 + style.descent) * fontHeight : fontHeight));
-
+    var font = fontHeight.toFixed(3) + 'px ' + style.fontFamily;
+    var fontAscent = this.fontMetrics.getFontAscent(font);
     var x = tx[4];
     var y = tx[5];
     var width = geom.width * this.viewport.scale;
@@ -360,10 +360,11 @@ var TextLayerBuilder = function textLayerBuilder(options) {
         this.currentLineHeight = 0;
         this.currentXEnd = x + width;
       }
-      var textDiv = this.createTextElement('div', geom, angle, fontHeight,
-                                           style, true);
-      textDiv.style.left = (x + (fontAscent * Math.sin(angle))).toFixed(3) + 'px';
-      textDiv.style.top = (y - (fontAscent * Math.cos(angle))).toFixed(3) + 'px';
+      textDiv = this.createTextElement('div', geom, angle, fontHeight, style);
+      var left = x + (fontAscent * Math.sin(angle));
+      textDiv.style.left = left.toFixed(3) + 'px';
+      var top = y - (fontAscent * Math.cos(angle));
+      textDiv.style.top = top.toFixed(3) + 'px';
       this.textDivs.push(textDiv);
       this.currentDiv = textDiv;
       this.currentLastElement = textDiv;

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1024,7 +1024,7 @@ html[dir='rtl'] .verticalToolbarSeparator {
 }
 
 .horizontalToolbarSeparator {
-  display: block; 
+  display: block;
   margin: 0 0 4px 0;
   height: 1px;
   width: 100%;
@@ -1281,6 +1281,7 @@ canvas {
   color: #000;
   font-family: sans-serif;
   overflow: hidden;
+  opacity: .35;
 }
 
 .textLayer > div {
@@ -1288,6 +1289,13 @@ canvas {
   position: absolute;
   white-space: pre;
   cursor: text;
+  line-height: 1;
+}
+
+.textLayer > div > span.inline-block {
+  display: inline-block;
+  margin-top: -1em;
+  margin-bottom: -1em;
 }
 
 .textLayer .highlight {
@@ -1317,8 +1325,8 @@ canvas {
 /* TODO: file FF bug to support ::-moz-selection:window-inactive
    so we can override the opaque grey background when the window is inactive;
    see https://bugzilla.mozilla.org/show_bug.cgi?id=706209 */
-::selection { background:rgba(0,0,255,0.3); }
-::-moz-selection { background:rgba(0,0,255,0.3); }
+::selection { background-color: Highlight; }
+::-moz-selection { background-color: Highlight; }
 
 .annotationHighlight {
   position: absolute;
@@ -1481,7 +1489,7 @@ canvas {
 }
 
 #documentPropertiesContainer .separator {
-  display: block; 
+  display: block;
   margin: 4px 0 4px 0;
   height: 1px;
   width: 100%;
@@ -1594,6 +1602,24 @@ html[dir='rtl'] #documentPropertiesContainer .row > * {
   color: black;
 }
 
+#viewer.textLayer-debug .textLayer > div {
+  color: red;
+  outline: 3px solid red;
+}
+
+#viewer.textLayer-debug .textLayer > div > span {
+  background-color: rgba(0, 255, 0, .5);
+  outline: 1px solid green;
+}
+
+#viewer.textLayer-debug .textLayer > div > span.inline-block {
+  display: inline-block;
+  margin-top: -1em;
+  margin-bottom: -1em;
+  background-color: rgba(0, 255, 255, .5);
+  outline: 1px solid blue;
+}
+
 .grab-to-pan-grab {
   cursor: url("images/grab.cur"), move !important;
   cursor: -webkit-grab !important;
@@ -1659,7 +1685,7 @@ html[dir='rtl'] #documentPropertiesContainer .row > * {
     background: url(images/toolbarButton-menuArrows@2x.png) no-repeat;
     background-size: 7px 16px;
   }
-  
+
   html[dir='ltr'] .toolbarButton#sidebarToggle::before {
     content: url(images/toolbarButton-sidebarToggle@2x.png);
   }

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -72,6 +72,7 @@ http://sourceforge.net/adobe/cmap/wiki/License/
     <script type="text/javascript" src="view_history.js"></script>
     <script type="text/javascript" src="page_view.js"></script>
     <script type="text/javascript" src="thumbnail_view.js"></script>
+    <script type="text/javascript" src="font_metrics.js"></script>
     <script type="text/javascript" src="text_layer_builder.js"></script>
     <script type="text/javascript" src="pdf_find_bar.js"></script>
     <script type="text/javascript" src="pdf_find_controller.js"></script>
@@ -180,7 +181,7 @@ http://sourceforge.net/adobe/cmap/wiki/License/
             <button id="toggleHandTool" class="secondaryToolbarButton handTool" title="Enable hand tool" tabindex="27" data-l10n-id="hand_tool_enable">
               <span data-l10n-id="hand_tool_enable_label">Enable hand tool</span>
             </button>
-            
+
             <div class="horizontalToolbarSeparator"></div>
 
             <button id="documentProperties" class="secondaryToolbarButton documentProperties" title="Document Properties…" tabindex="28" data-l10n-id="document_properties">
@@ -235,10 +236,10 @@ http://sourceforge.net/adobe/cmap/wiki/License/
                 </a>
 
                 <div class="verticalToolbarSeparator hiddenSmallView"></div>
-                
+
                 <button id="secondaryToolbarToggle" class="toolbarButton" title="Tools" tabindex="17" data-l10n-id="tools">
                   <span data-l10n-id="tools_label">Tools</span>
-                </button> 
+                </button>
               </div>
               <div class="outerCenter">
                 <div class="innerCenter" id="toolbarViewerMiddle">

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1748,6 +1748,11 @@ function webViewerInitialized() {
       (hashParams['ignoreCurrentPositionOnZoom'] === 'true');
   }
 
+  if ('disableMultilineTextLayer' in hashParams) {
+    PDFJS.disableMultilineTextLayer =
+      (hashParams['disableMultilineTextLayer'] === 'true');
+  }
+
 //#if !PRODUCTION
   if ('disableBcmaps' in hashParams && hashParams['disableBcmaps']) {
     PDFJS.cMapUrl = '../external/cmaps/';
@@ -1779,6 +1784,7 @@ function webViewerInitialized() {
       case 'visible':
       case 'shadow':
       case 'hover':
+      case 'debug':
         var viewer = document.getElementById('viewer');
         viewer.classList.add('textLayer-' + hashParams['textLayer']);
         break;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -19,7 +19,8 @@
            getFileName, scrollIntoView, getPDFFileNameFromURL, PDFHistory,
            Preferences, ViewHistory, PageView, ThumbnailView, URL,
            noContextMenuHandler, SecondaryToolbar, PasswordPrompt,
-           PresentationMode, HandTool, Promise, DocumentProperties */
+           PresentationMode, HandTool, Promise, DocumentProperties,
+           FontMetrics */
 
 'use strict';
 
@@ -103,6 +104,7 @@ var currentPageNumber = 1;
 //#include presentation_mode.js
 //#include hand_tool.js
 //#include document_properties.js
+//#include font_metrics.js
 
 var PDFView = {
   pages: [],
@@ -126,6 +128,7 @@ var PDFView = {
   isViewerEmbedded: (window.parent !== window),
   idleTimeout: null,
   currentPosition: null,
+  fontMetrics: new FontMetrics(),
 
   // called once when the document is loaded
   initialize: function pdfViewInitialize() {


### PR DESCRIPTION
Support for multi-line text blocks

Adds a feature flag to enable multi-line text blocks (disableMultilineTextLayer=false), disabled by default.
The purpose is to make the DOM lighter and the text selection more natural, e.g. less flickering on text selection. Additionally added a flag to make the text layer visible (debugTextLayer). Mainly checked the code with
- the Trace Monkey document
- the NASA document (#4339)
- the PDF 1.7 spec
- some Russian document (#4626)
- and some French document (#4487)

Especially with the last two documents the scroll performance has improved remarkably, mainly due to concatenating of chars to words.

Also changed the highlight color to system color as a suggestion. 
