### PR TITLE
Only handle scroll events when PDFView.pdfDocument is defined (issue 4642)

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -242,6 +242,9 @@ var PDFView = {
     state.down = true;
     state.lastY = viewAreaElement.scrollTop;
     viewAreaElement.addEventListener('scroll', function webViewerScroll(evt) {
+      if (!PDFView.pdfDocument) {
+        return;
+      }
       var currentY = viewAreaElement.scrollTop;
       var lastY = state.lastY;
       if (currentY > lastY) {


### PR DESCRIPTION
Attempted workaround to fix #4642. This should work, and it's a very easy solution, but I'm not completely convinced that this is the best way to handle the issue.

**Edit:** The reason for my apprehension about it, is that the patch adds code that is unnecessary most of the time to a function that is called _a lot_.

@dferer Does this fix the issue?
