### PR TITLE
Fix corrupted images #4649

### DIFF
--- a/src/core/image.js
+++ b/src/core/image.js
@@ -107,8 +107,10 @@ var PDFImage = (function PDFImageClosure() {
           case 3:
             colorSpace = Name.get('DeviceRGB');
             break;
+          case 4:
+            colorSpace = Name.get('DeviceCMYK');
+            break;
           default:
-            // TODO: Find out how four color channels are handled. CMYK? Alpha?
             error('JPX images with ' + this.numComps +
                   ' color components not supported.');
         }

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -1077,11 +1077,13 @@ var JpxImage = (function JpxImageClosure() {
 
       // Section G.2.2 Inverse multi component transform
       var shift, offset, max, min;
-      var pos = 0, j, jj, y0, y1, y2, r, g, b, val;
+      var pos = 0, j, jj, y0, y1, y2, r, g, b, k, val;
       if (tile.codingStyleDefaultParameters.multipleComponentTransform) {
-        var y2items = transformedTiles[2].items;
-        var y1items = transformedTiles[1].items;
+        var fourComponents = componentsCount === 4;
         var y0items = transformedTiles[0].items;
+        var y1items = transformedTiles[1].items;
+        var y2items = transformedTiles[2].items;
+        var y3items = fourComponents ? transformedTiles[3].items : null;
 
         // HACK: The multiple component transform formulas below assume that
         // all components have the same precision. With this in mind, we
@@ -1104,6 +1106,11 @@ var JpxImage = (function JpxImageClosure() {
             out[pos++] = r <= min ? 0 : r >= max ? 255 : (r + offset) >> shift;
             out[pos++] = g <= min ? 0 : g >= max ? 255 : (g + offset) >> shift;
             out[pos++] = b <= min ? 0 : b >= max ? 255 : (b + offset) >> shift;
+            if (fourComponents) {
+              k = y3items[j];
+              out[pos++] =
+                k <= min ? 0 : k >= max ? 255 : (k + offset) >> shift;
+            }
           }
         } else {
           // inverse reversible multiple component transform
@@ -1117,6 +1124,11 @@ var JpxImage = (function JpxImageClosure() {
             out[pos++] = r <= min ? 0 : r >= max ? 255 : (r + offset) >> shift;
             out[pos++] = g <= min ? 0 : g >= max ? 255 : (g + offset) >> shift;
             out[pos++] = b <= min ? 0 : b >= max ? 255 : (b + offset) >> shift;
+            if (fourComponents) {
+              k = y3items[j];
+              out[pos++] =
+                k <= min ? 0 : k >= max ? 255 : (k + offset) >> shift;
+            }
           }
         }
       } else { // no multi-component transform


### PR DESCRIPTION
Adds support for CMYK multiple component transform and so fixes #4649.

Sorry for that bug. I thought I had read in the JPEG2000 draft that multiple component transform only applies to 3 component images, but I got that wrong.
Additionally, according to the PDF 1.7 spec, page 89, 4 color images should be interpreted as CMYK unless specified otherwise.
