### PR TITLE
Fix regression preventing the setting of breakpoints in the Stepper (PDFBug)

### DIFF
--- a/web/debugger.js
+++ b/web/debugger.js
@@ -326,6 +326,8 @@ var Stepper = (function StepperClosure() {
       }
     },
     updateOperatorList: function updateOperatorList(operatorList) {
+      var self = this;
+
       function cboxOnClick() {
         var x = +this.dataset.idx;
         if (this.checked) {


### PR DESCRIPTION
Fixes a regression from PR #4607, which makes it impossible to set breakpoints (`TypeError: self.breakPoints is undefined`).
