### PR TITLE
Add a preference to set the sidebarView on load

### DIFF
--- a/web/default_preferences.js
+++ b/web/default_preferences.js
@@ -21,7 +21,7 @@
 var DEFAULT_PREFERENCES = {
   showPreviousViewOnLoad: true,
   defaultZoomValue: '',
-  ifAvailableShowOutlineOnLoad: false,
+  sidebarViewOnLoad: 0,
   enableHandToolOnLoad: false,
   enableWebGL: false
 };

--- a/web/preferences.js
+++ b/web/preferences.js
@@ -20,6 +20,13 @@
 
 //#include default_preferences.js
 
+var SidebarView = {
+  NONE: 0,
+  THUMBS: 1,
+  OUTLINE: 2,
+  ATTACHMENTS: 3
+};
+
 /**
  * Preferences - Utility for storing persistent settings.
  *   Used for settings that should be applied to all opened documents,


### PR DESCRIPTION
As promised in https://github.com/mozilla/pdf.js/pull/4329#discussion-diff-11768622, this PR adds a preference (`sidebarViewOnLoad`) that enables the user to choose if (and with what view) the sidebar should be opened when the viewer loads.

This PR thus removes one of the current prefs (`ifAvailableShowOutlineOnLoad`) in favour of the new one. Furthermore it also re-factors the way that the sidebar is opened, to avoid duplicating code in multiple places (hence the multiple commits).

As a follow-up to this PR, I'm thinking that it could be a good idea to add a Wiki page describing the available preferences. The reason that I didn't do so after support for preferences initially landed, is that I didn't want to advertise this feature too much until:
a) The actual preference implementation had stabilized.
b) We had more preferences available, and the names had stabilized.
c) Until the preferences made their way into Firefox.
