### PR TITLE
Remove showPreviousViewOnLoad preference

### DIFF
--- a/web/default_preferences.js
+++ b/web/default_preferences.js
@@ -19,7 +19,6 @@
 'use strict';
 
 var DEFAULT_PREFERENCES = {
-  showPreviousViewOnLoad: true,
   defaultZoomValue: '',
   ifAvailableShowOutlineOnLoad: false,
   enableHandToolOnLoad: false,

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1002,11 +1002,6 @@ var PDFView = {
     });
 
     // Fetch the necessary preference values.
-    var showPreviousViewOnLoad;
-    var showPreviousViewOnLoadPromise =
-      Preferences.get('showPreviousViewOnLoad').then(function (prefValue) {
-        showPreviousViewOnLoad = prefValue;
-      });
     var defaultZoomValue;
     var defaultZoomValuePromise =
       Preferences.get('defaultZoomValue').then(function (prefValue) {
@@ -1014,10 +1009,10 @@ var PDFView = {
       });
 
     var storePromise = store.initializedPromise;
-    Promise.all([firstPagePromise, storePromise, showPreviousViewOnLoadPromise,
+    Promise.all([firstPagePromise, storePromise,
                  defaultZoomValuePromise]).then(function resolved() {
       var storedHash = null;
-      if (showPreviousViewOnLoad && store.get('exists', false)) {
+      if (store.get('exists', false)) {
         var pageNum = store.get('page', '1');
         var zoom = defaultZoomValue || store.get('zoom', PDFView.currentScale);
         var left = store.get('scrollLeft', '0');


### PR DESCRIPTION
After #4559, we no longer store the view history permanently in Firefox.
I think that keeping the preference `showPreviousViewOnLoad` around will be confusing, and unnecessary, for the user. Hence I propose that we can remove the preference, since the behaviour that setting `showPreviousViewOnLoad = false` gives is now the default in the main build target (i.e. Firefox).
