### PR TITLE
Force Unix line endings for text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,18 @@
+# Force Unix line endings for most file formats (except binary files)
+*.js         text eol=lf
+*.jsm        text eol=lf
+*.css        text eol=lf
+*.html       text eol=lf
+*.md         text eol=lf
+*.properties text eol=lf
+*.yml        text eol=lf
+*.json       text eol=lf
+*.config     text eol=lf
+*.inc        text eol=lf
+*.manifest   text eol=lf
+*.rdf        text eol=lf
+*.jade       text eol=lf
+*.coffee     text eol=lf
+
+# PDF files shall not modify CRLF line endings
 *.pdf -crlf


### PR DESCRIPTION
This overrides the user's `autocrlf` setting for all text files because we really only want Unix line endings for them.
