### PR TITLE
[Firefox] Workaround for sessionStorage error when the preference network.cookie.lifetimePolicy is set to 1 (bug 1000777)

### DIFF
--- a/web/view_history.js
+++ b/web/view_history.js
@@ -48,7 +48,13 @@ var ViewHistory = (function ViewHistoryClosure() {
 //#endif
 
 //#if FIREFOX || MOZCENTRAL
-//  resolvePromise(sessionStorage.getItem('pdfjsHistory'));
+//  var sessionHistory;
+//  try {
+//    // Workaround for security error when the preference
+//    // network.cookie.lifetimePolicy is set to 1, see Mozilla Bug 365772.
+//    sessionHistory = sessionStorage.getItem('pdfjsHistory');
+//  } catch (ex) {}
+//  resolvePromise(sessionHistory);
 //#endif
 
 //#if !(FIREFOX || MOZCENTRAL || B2G)
@@ -93,7 +99,10 @@ var ViewHistory = (function ViewHistoryClosure() {
 //#endif
 
 //#if FIREFOX || MOZCENTRAL
-//    sessionStorage.setItem('pdfjsHistory',database);
+//    try {
+//      // See comment in try-catch block above.
+//      sessionStorage.setItem('pdfjsHistory', database);
+//    } catch (ex) {}
 //#endif
 
 //#if !(FIREFOX || MOZCENTRAL || B2G)


### PR DESCRIPTION
The error is described in [bug 365772](https://bugzilla.mozilla.org/show_bug.cgi?id=365772), which is a seven (!) year old bug :-(

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1000777.
