### PR TITLE
Fixes DownloadManager for IE10 and above

### DIFF
--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -68,6 +68,10 @@ var DownloadManager = (function DownloadManagerClosure() {
 
     downloadData: function DownloadManager_downloadData(data, filename,
                                                         contentType) {
+      if (navigator.msSaveBlob) { // IE10 and above
+        return navigator.msSaveBlob(new Blob([data], { type: contentType }),
+                                    filename);
+      }
 
       var blobUrl = PDFJS.createObjectURL(data, contentType);
       download(blobUrl, filename);


### PR DESCRIPTION
Fixes #4688.

It turns out that it is best to use `navigator.msSaveBlob` for IE10 and above (and possibly older versions, see https://stackoverflow.com/questions/20844644/why-am-i-getting-this-error-in-ie and https://stackoverflow.com/questions/16376161/javascript-set-file-in-download). Because of the feature test, this will only affect IE.
