### PR TITLE
Add support for setting multiple values at once in ViewHistory

### DIFF
--- a/web/view_history.js
+++ b/web/view_history.js
@@ -86,28 +86,31 @@ var ViewHistory = (function ViewHistoryClosure() {
       this.database = database;
     },
 
-    set: function ViewHistory_set(name, val) {
-      if (!this.isInitializedPromiseResolved) {
-        return;
-      }
-      var file = this.file;
-      file[name] = val;
-      var database = JSON.stringify(this.database);
+    _writeToStorage: function ViewHistory_writeToStorage() {
+      var databaseStr = JSON.stringify(this.database);
 
 //#if B2G
-//    asyncStorage.setItem('database', database);
+//    asyncStorage.setItem('database', databaseStr);
 //#endif
 
 //#if FIREFOX || MOZCENTRAL
 //    try {
 //      // See comment in try-catch block above.
-//      sessionStorage.setItem('pdfjsHistory', database);
+//      sessionStorage.setItem('pdfjsHistory', databaseStr);
 //    } catch (ex) {}
 //#endif
 
 //#if !(FIREFOX || MOZCENTRAL || B2G)
-      localStorage.setItem('database', database);
+      localStorage.setItem('database', databaseStr);
 //#endif
+    },
+
+    set: function ViewHistory_set(name, val) {
+      if (!this.isInitializedPromiseResolved) {
+        return;
+      }
+      this.file[name] = val;
+      this._writeToStorage();
     },
 
     get: function ViewHistory_get(name, defaultValue) {

--- a/web/view_history.js
+++ b/web/view_history.js
@@ -113,6 +113,16 @@ var ViewHistory = (function ViewHistoryClosure() {
       this._writeToStorage();
     },
 
+    setMultiple: function ViewHistory_setMultiple(properties) {
+      if (!this.isInitializedPromiseResolved) {
+        return;
+      }
+      for (var name in properties) {
+        this.file[name] = properties[name];
+      }
+      this._writeToStorage();
+    },
+
     get: function ViewHistory_get(name, defaultValue) {
       if (!this.isInitializedPromiseResolved) {
         return defaultValue;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1970,13 +1970,14 @@ function updateViewarea() {
     PDFView.currentPosition = { page: pageNumber, left: intLeft, top: intTop };
   }
 
-  var store = PDFView.store;
-  store.initializedPromise.then(function() {
-    store.set('exists', true);
-    store.set('page', pageNumber);
-    store.set('zoom', normalizedScaleValue);
-    store.set('scrollLeft', intLeft);
-    store.set('scrollTop', intTop);
+  PDFView.store.initializedPromise.then(function() {
+    PDFView.store.setMultiple({
+      'exists': true,
+      'page': pageNumber,
+      'zoom': normalizedScaleValue,
+      'scrollLeft': intLeft,
+      'scrollTop': intTop
+    });
   });
   var href = PDFView.getAnchorUrl(pdfOpenParams);
   document.getElementById('viewBookmark').href = href;


### PR DESCRIPTION
Currently for every call to `updateViewarea`, `ViewHistory.set` is called five times, which means that the `database` is converted to a string and written to storage five times in succession.

This PR adds a method, `setMultiple`, that sets all values before the `database` is written to storage.

Generally the value of micro-benchmarks can be questioned, but to get at least some confirmation that this PR is meaningful I've tried comparing the current code with this patch: http://jsperf.com/viewhistory.
Based on the consistency of the results across various browsers, it seems probable that this PR does reduce the time taken to update the history.
