### PR TITLE
Ensure that the viewer loads even if there are errors when the preferences are read

### DIFF
--- a/web/hand_tool.js
+++ b/web/hand_tool.js
@@ -45,11 +45,11 @@ var HandTool = {
       toggleHandTool.addEventListener('click', this.toggle.bind(this), false);
 
       window.addEventListener('localized', function (evt) {
-        Preferences.get('enableHandToolOnLoad').then(function (prefValue) {
-          if (prefValue) {
+        Preferences.get('enableHandToolOnLoad').then(function resolved(value) {
+          if (value) {
             this.handTool.activate();
           }
-        }.bind(this));
+        }.bind(this), function rejected(reason) {});
       }.bind(this));
     }
   },

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -222,9 +222,9 @@ var PDFView = {
     }, false);
 
     var initializedPromise = Promise.all([
-      Preferences.get('enableWebGL').then(function (value) {
+      Preferences.get('enableWebGL').then(function resolved(value) {
         PDFJS.disableWebGL = !value;
-      })
+      }, function rejected(reason) {})
       // TODO move more preferences and other async stuff here
     ]);
 
@@ -1042,8 +1042,8 @@ var PDFView = {
 //      self.container.blur();
 //#endif
       }
-    }, function rejected(errorMsg) {
-      console.error(errorMsg);
+    }, function rejected(reason) {
+      console.error(reason);
 
       firstPagePromise.then(function () {
         self.setInitialView(null, scale);


### PR DESCRIPTION
While trying to debug #4690, I stumbled on another issue.
Currently if e.g. `Preferences._readFromStorage` fails, the PDF document will fail to load. This PR adds missing rejection handler functions, to avoid this issue. (I assumed that it was best to handle this on the caller side, rather than in `Preferences`.)
