### PR TITLE
Fix the display of the indeterminate progress bar when the loaded percentage is NaN (issue 4696)

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -887,7 +887,7 @@ var PDFView = {
     // that we discard some of the loaded data. This can cause the loading
     // bar to move backwards. So prevent this by only updating the bar if it
     // increases.
-    if (percent > PDFView.loadingBar.percent) {
+    if (percent > PDFView.loadingBar.percent || isNaN(percent)) {
       PDFView.loadingBar.percent = percent;
     }
   },


### PR DESCRIPTION
Should (hopefully) fix #4696.

@joepie91 Does this patch fix the issue?
