### PR TITLE
Refactor how the database is read in ViewHistory

### DIFF
--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -547,13 +547,20 @@ if (typeof PDFJS === 'undefined') {
       return;
     }
   } catch (e) { }
-  window.localStorage = {
-    data: Object.create(null),
-    getItem: function (key) {
-      return this.data[key];
-    },
-    setItem: function (key, value) {
-      this.data[key] = value;
-    }
-  };
+  // When the generic viewer is used in Firefox the following code will fail
+  // when the preference 'network.cookie.lifetimePolicy' is set to 1,
+  // see Mozilla bug 365772.
+  try {
+    window.localStorage = {
+      data: Object.create(null),
+      getItem: function (key) {
+        return this.data[key];
+      },
+      setItem: function (key, value) {
+        this.data[key] = value;
+      }
+    };
+  } catch (e) {
+    console.log('Unable to create polyfill for localStorage');
+  }
 })();


### PR DESCRIPTION
This PR re-factors `ViewHistory` so that reading stored values returns a Promise. It should thus handle any possible errors when either `sessionStorage` or `localStorage` fails (e.g. [bug 1000777](https://bugzilla.mozilla.org/show_bug.cgi?id=1000777) and #4690).

My goal with this PR was to address https://github.com/mozilla/pdf.js/pull/4679#issuecomment-41400533, so the `ViewHistory` will now fail to initialize when the database cannot be read.
As part of the re-factoring I've also taken the opportunity to simplify the, in my opinion, quite clunky initialization code.
I didn't want to touch too much code, so I refrained from rewriting the entire `ViewHistory` to be Promise friendly and just settled for the necessary part.

Also fixes #4690 (by courtesy of the first commit).
