### PR TITLE
Remove LegacyPromise in src/core/worker.js

### DIFF
--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -67,9 +67,14 @@ var BasePdfManager = (function BasePdfManagerClosure() {
 
     updatePassword: function BasePdfManager_updatePassword(password) {
       this.pdfDocument.xref.password = this.password = password;
-      if (this.passwordChangedPromise) {
-        this.passwordChangedPromise.resolve();
+      if (this._passwordChangedCapability) {
+        this._passwordChangedCapability.resolve();
       }
+    },
+
+    passwordChanged: function BasePdfManager_passwordChanged() {
+      this._passwordChangedCapability = createPromiseCapability();
+      return this._passwordChangedCapability.promise;
     },
 
     terminate: function BasePdfManager_terminate() {


### PR DESCRIPTION
Depends on PR #4725.

I wasn't sure what to make of https://github.com/mozilla/pdf.js/issues/4430#issue-29094940, so thus far this PR just replaces the Promises.

Another slight issue that I came across is the way that incorrect passwords are currently handled (see [worker.js#L256-L257](https://github.com/mozilla/pdf.js/blob/master/src/core/worker.js#L256-L257) and [pdf_manager.js#L70-L72](https://github.com/mozilla/pdf.js/blob/master/src/core/pdf_manager.js#L70-L72)). We basically reach into the `pdfManager` object and create a promise there, which seem all kinds of wrong :-)
I've attempted to rectify this situation, and the patch does work, but I'm not sure if this is the best solution. 

_I will squash the commits once this is ready to be merged._
