### PR TITLE
Allow unsafe-eval to fix font renderer in Chromium extension

### DIFF
--- a/extensions/chromium/manifest.json
+++ b/extensions/chromium/manifest.json
@@ -27,6 +27,7 @@
     "run_at": "document_start",
     "js": ["contentscript.js"]
   }],
+  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "file_browser_handlers": [{
     "id": "open-as-pdf",
     "default_title": "Open with PDF Viewer",


### PR DESCRIPTION
Fixes #4660
