### PR TITLE
Reduce the speed of the indeterminate progress bar and make it work at different window widths

### DIFF
--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -218,7 +218,7 @@ var ProgressBar = (function ProgressBarClosure() {
     },
 
     set percent(val) {
-      this._indeterminate = isNaN(val);
+      this._indeterminate = true; // isNaN(val);
       this._percent = clamp(val, 0, 100);
       this.updateBar();
     },
@@ -235,8 +235,8 @@ var ProgressBar = (function ProgressBarClosure() {
     },
 
     hide: function ProgressBar_hide() {
-      this.bar.classList.add('hidden');
-      this.bar.removeAttribute('style');
+      // this.bar.classList.add('hidden');
+      // this.bar.removeAttribute('style');
     }
   };
 

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -345,13 +345,13 @@ html[dir='rtl'] #toolbarContainer, .findbar, .secondaryToolbar {
 
 @-webkit-keyframes progressIndeterminate {
   0% { left: 0%; }
-  50% { left: 100%; }
+  84% { left: 100%; }
   100% { left: 100%; }
 }
 
 @keyframes progressIndeterminate {
   0% { left: 0%; }
-  50% { left: 100%; }
+  84% { left: 100%; }
   100% { left: 100%; }
 }
 
@@ -372,8 +372,8 @@ html[dir='rtl'] #toolbarContainer, .findbar, .secondaryToolbar {
   background-size: 100% 100%;
   background-repeat: no-repeat;
 
-  -webkit-animation: progressIndeterminate 2s linear infinite;
-  animation: progressIndeterminate 2s linear infinite;
+  -webkit-animation: progressIndeterminate 6s linear infinite;
+  animation: progressIndeterminate 6s linear infinite;
 }
 
 .findbar, .secondaryToolbar {
@@ -1865,6 +1865,108 @@ html[dir='rtl'] #documentPropertiesContainer .row > * {
   display: none;
 }
 
+@media all and (max-width: 2000px) {
+  @-webkit-keyframes progressIndeterminate {
+    0% { left: 0%; }
+    80% { left: 100%; }
+    100% { left: 100%; }
+  }
+  @keyframes progressIndeterminate {
+    0% { left: 0%; }
+    80% { left: 100%; }
+    100% { left: 100%; }
+  }
+  #loadingBar .indeterminate .glimmer {
+    -webkit-animation-duration: 4.8s;
+    animation-duration: 4.8s;
+  }
+}
+
+@media all and (max-width: 1800px) {
+  @-webkit-keyframes progressIndeterminate {
+    0% { left: 0%; }
+    78% { left: 100%; }
+    100% { left: 100%; }
+  }
+  @keyframes progressIndeterminate {
+    0% { left: 0%; }
+    78% { left: 100%; }
+    100% { left: 100%; }
+  }
+  #loadingBar .indeterminate .glimmer {
+    -webkit-animation-duration: 4.4s;
+    animation-duration: 4.4s;
+  }
+}
+
+@media all and (max-width: 1600px) {
+  @-webkit-keyframes progressIndeterminate {
+    0% { left: 0%; }
+    75% { left: 100%; }
+    100% { left: 100%; }
+  }
+  @keyframes progressIndeterminate {
+    0% { left: 0%; }
+    75% { left: 100%; }
+    100% { left: 100%; }
+  }
+  #loadingBar .indeterminate .glimmer {
+    -webkit-animation-duration: 4s;
+    animation-duration: 4s;
+  }
+}
+
+@media all and (max-width: 1400px) {
+  @-webkit-keyframes progressIndeterminate {
+    0% { left: 0%; }
+    73% { left: 100%; }
+    100% { left: 100%; }
+  }
+  @keyframes progressIndeterminate {
+    0% { left: 0%; }
+    73% { left: 100%; }
+    100% { left: 100%; }
+  }
+  #loadingBar .indeterminate .glimmer {
+    -webkit-animation-duration: 3.6s;
+    animation-duration: 3.6s;
+  }
+}
+
+@media all and (max-width: 1200px) {
+  @-webkit-keyframes progressIndeterminate {
+    0% { left: 0%; }
+    69% { left: 100%; }
+    100% { left: 100%; }
+  }
+  @keyframes progressIndeterminate {
+    0% { left: 0%; }
+    69% { left: 100%; }
+    100% { left: 100%; }
+  }
+  #loadingBar .indeterminate .glimmer {
+    -webkit-animation-duration: 3.2s;
+    animation-duration: 3.2s;
+  }
+}
+
+@media all and (max-width: 1000px) {
+  @-webkit-keyframes progressIndeterminate {
+    0% { left: 0%; }
+    65% { left: 100%; }
+    100% { left: 100%; }
+  }
+  @keyframes progressIndeterminate {
+    0% { left: 0%; }
+    65% { left: 100%; }
+    100% { left: 100%; }
+  }
+  #loadingBar .indeterminate .glimmer {
+    -webkit-animation-duration: 2.8s;
+    animation-duration: 2.8s;
+  }
+}
+
 @media all and (max-width: 960px) {
   html[dir='ltr'] #outerContainer.sidebarMoving .outerCenter,
   html[dir='ltr'] #outerContainer.sidebarOpen .outerCenter {
@@ -1893,6 +1995,23 @@ html[dir='rtl'] #documentPropertiesContainer .row > * {
   }
   .sidebarOpen .visibleMediumView {
     display: inherit;
+  }
+}
+
+@media all and (max-width: 800px) {
+  @-webkit-keyframes progressIndeterminate {
+    0% { left: 0%; }
+    59% { left: 100%; }
+    100% { left: 100%; }
+  }
+  @keyframes progressIndeterminate {
+    0% { left: 0%; }
+    59% { left: 100%; }
+    100% { left: 100%; }
+  }
+  #loadingBar .indeterminate .glimmer {
+    -webkit-animation-duration: 2.4s;
+    animation-duration: 2.4s;
   }
 }
 
@@ -1973,6 +2092,21 @@ html[dir='rtl'] #documentPropertiesContainer .row > * {
   .toolbarButtonSpacer {
     width: 0;
   }
+
+  @-webkit-keyframes progressIndeterminate {
+    0% { left: 0%; }
+    50% { left: 100%; }
+    100% { left: 100%; }
+  }
+  @keyframes progressIndeterminate {
+    0% { left: 0%; }
+    50% { left: 100%; }
+    100% { left: 100%; }
+  }
+  #loadingBar .indeterminate .glimmer {
+    -webkit-animation-duration: 2s;
+    animation-duration: 2s;
+  }
 }
 
 @media all and (max-width: 510px) {
@@ -1981,3 +2115,19 @@ html[dir='rtl'] #documentPropertiesContainer .row > * {
   }
 }
 
+@media all and (max-width: 400px) {
+  @-webkit-keyframes progressIndeterminate {
+    0% { left: 0%; }
+    38% { left: 100%; }
+    100% { left: 100%; }
+  }
+  @keyframes progressIndeterminate {
+    0% { left: 0%; }
+    38% { left: 100%; }
+    100% { left: 100%; }
+  }
+  #loadingBar .indeterminate .glimmer {
+    -webkit-animation-duration: 1.6s;
+    animation-duration: 1.6s;
+  }
+}


### PR DESCRIPTION
This PR aims to not only reduce the speed of the indeterminate progress bar to a more reasonable one (I aimed for ~500 pixels/second), but also to keep it fairly constant for different viewer widths.
Unfortunately since there's no way to set the speed of a CSS animation directly, but only the time it should take to complete, I couldn't find a better way to handle varying viewer widths except with media queries.

Things left to do before merging:
- [ ] Ask @shorlander for feedback on the proposed changes.
- [ ] Remove the first commit (it's only included to simplify testing).

Fixes #4718.
