### PR TITLE
Add getFindBar for Fx extension

### DIFF
--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -53,12 +53,22 @@ XPCOMUtils.defineLazyServiceGetter(Svc, 'mime',
                                    '@mozilla.org/mime;1',
                                    'nsIMIMEService');
 
+function getContainingBrowser(domWindow) {
+  return domWindow.QueryInterface(Ci.nsIInterfaceRequestor)
+                  .getInterface(Ci.nsIWebNavigation)
+                  .QueryInterface(Ci.nsIDocShell)
+                  .chromeEventHandler;
+}
+
 function getChromeWindow(domWindow) {
-  var containingBrowser = domWindow.QueryInterface(Ci.nsIInterfaceRequestor)
-                                   .getInterface(Ci.nsIWebNavigation)
-                                   .QueryInterface(Ci.nsIDocShell)
-                                   .chromeEventHandler;
-  return containingBrowser.ownerDocument.defaultView;
+  return getContainingBrowser(domWindow).ownerDocument.defaultView;
+}
+
+function getFindBar(domWindow) {
+  var browser = getContainingBrowser(domWindow);
+  var tabbrowser = browser.getTabBrowser();
+  var tab = tabbrowser._getTabForBrowser(browser);
+  return tabbrowser.getFindBar(tab);
 }
 
 function setBoolPref(pref, value) {
@@ -320,8 +330,8 @@ ChromeActions.prototype = {
     // Integrated find is only supported when we're not in a frame and when the
     // new find events code exists.
     return this.domWindow.frameElement === null &&
-           getChromeWindow(this.domWindow).gFindBar &&
-           'updateControlState' in getChromeWindow(this.domWindow).gFindBar;
+           getFindBar(this.domWindow) &&
+           'updateControlState' in getFindBar(this.domWindow);
   },
   supportsDocumentFonts: function() {
     var prefBrowser = getIntPref('browser.display.use_document_fonts', 1);
@@ -438,8 +448,7 @@ ChromeActions.prototype = {
         (findPreviousType !== 'undefined' && findPreviousType !== 'boolean')) {
       return;
     }
-    getChromeWindow(this.domWindow).gFindBar
-                                   .updateControlState(result, findPrevious);
+    getFindBar(this.domWindow).updateControlState(result, findPrevious);
   },
   setPreferences: function(prefs, sendResponse) {
     var defaultBranch = Services.prefs.getDefaultBranch(PREF_PREFIX + '.');
@@ -917,7 +926,8 @@ PdfStreamConverter.prototype = {
         }, false, true);
         if (actions.supportsIntegratedFind()) {
           var chromeWindow = getChromeWindow(domWindow);
-          var findEventManager = new FindEventManager(chromeWindow.gFindBar,
+          var findBar = getFindBar(domWindow);
+          var findEventManager = new FindEventManager(findBar,
                                                       domWindow,
                                                       chromeWindow);
           findEventManager.bind();

--- a/test/mozcentral/browser_pdfjs_main.js
+++ b/test/mozcentral/browser_pdfjs_main.js
@@ -47,6 +47,11 @@ function runTests(document, window, callback) {
   ok('PDFJS' in window.wrappedJSObject, "window content has PDFJS object");
 
   //
+  // Browser Find
+  //
+  ok(gBrowser.isFindBarInitialized(tab), "Browser FindBar initialized!");
+
+  //
   // Sidebar: open
   //
   var sidebar = document.querySelector('button#sidebarToggle'),


### PR DESCRIPTION
[BMO: 1006714: _'Find' fails to search whole PDF with pdf.js when opened in a new tab_](https://bugzilla.mozilla.org/show_bug.cgi?id=1006714) was caused by [BMO: 537013: _The find bar should exist on a per-tab basis_](https://bugzilla.mozilla.org/show_bug.cgi?id=537013) which made `gFindBar` point to the _active_ tab's findbar.

This pull request addresses the defect by adding a function to get the correct findbar based on the `domWindow`. It also adds a test that checks if the findbar has been initialized (I verified that the test fails pre-patch and passes post-patch, in addition to testing that the behavior described in the bug is fixed).
