### PR TITLE
Adds Promises to getOperatorList

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -507,11 +507,17 @@ var Catalog = (function CatalogClosure() {
     },
 
     cleanup: function Catalog_cleanup() {
-      this.fontCache.forEach(function (font) {
-        delete font.sent;
-        delete font.translated;
+      var promises = [];
+      this.fontCache.forEach(function (promise) {
+        promises.push(promise);
       });
-      this.fontCache.clear();
+      return Promise.all(promises).then(function (fonts) {
+        for (var i = 0, ii = fonts.length; i < ii; i++) {
+          delete fonts[i].sent;
+          delete fonts[i].translated;
+        }
+        this.fontCache.clear();
+      }.bind(this));
     },
 
     getPage: function Catalog_getPage(pageIndex) {

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -387,8 +387,7 @@ var WorkerMessageHandler = PDFJS.WorkerMessageHandler = {
     });
 
     handler.on('Cleanup', function wphCleanup(data) {
-      pdfManager.cleanup();
-      return true;
+      return pdfManager.cleanup();
     });
 
     handler.on('Terminate', function wphTerminate(data) {


### PR DESCRIPTION
During active scrolling only one page can be parsed. This PR:
- For future, allows suspend parsing at any moment of getOperatorList or getTextContent;
- Gives 20ms time slot for those operations.

This allows parsing and display several pages at once (see https://gist.github.com/yurydelendik/513e6d9592fc4fd3a520)

This might help change people's perception of the performance when they actively scrolling.
