### PR TITLE
Reduce the number of calls to PDFView.getVisiblePages from updateViewarea

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1205,14 +1205,15 @@ var PDFView = {
     }
   },
 
-  renderHighestPriority: function pdfViewRenderHighestPriority() {
+  renderHighestPriority:
+      function pdfViewRenderHighestPriority(currentlyVisiblePages) {
     if (PDFView.idleTimeout) {
       clearTimeout(PDFView.idleTimeout);
       PDFView.idleTimeout = null;
     }
 
     // Pages have a higher priority than thumbnails, so check them first.
-    var visiblePages = this.getVisiblePages();
+    var visiblePages = currentlyVisiblePages || this.getVisiblePages();
     var pageView = this.getHighestPriority(visiblePages, this.pages,
                                            this.pageViewScroll.down);
     if (pageView) {
@@ -1925,7 +1926,7 @@ function updateViewarea() {
     return;
   }
 
-  PDFView.renderHighestPriority();
+  PDFView.renderHighestPriority(visible);
 
   var currentId = PDFView.page;
   var firstPage = visible.first;


### PR DESCRIPTION
Currently for every call to `updateViewarea` we call `PDFView.getVisiblePages` (at [viewer.js#L1922](https://github.com/mozilla/pdf.js/blob/master/web/viewer.js#L1922)) before calling `PDFView.renderHighestPriority` (at [viewer.js#L1928](https://github.com/mozilla/pdf.js/blob/master/web/viewer.js#L1928)); in that function we again call `getVisiblePages` (at [viewer.js#L1215](https://github.com/mozilla/pdf.js/blob/master/web/viewer.js#L1215)).

This means that every time when the user scrolls, we will essentially do two back-to-back calls to `getVisiblePages`. Given that this requires traversing the DOM to check which pages are actually visible on screen, this seem like the kind of thing you really want to avoid doing if possible (especially in long documents).

~~To avoid the above, I've refactored `renderHighestPriority` to always return the result of `getVisiblePages`.~~
