### PR TITLE
Move jshint & yargs to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,16 +1,14 @@
 {
   "name": "pdf.js",
   "version": "0.8.0",
-  "dependencies": {
-    "jshint": "2.4.x",
-    "yargs": "~1.2.1"
-  },
   "devDependencies": {
     "jsdoc": "~3.3.0",
+    "jshint": "2.4.x",
     "wintersmith": "2.0.x",
     "moment": "2.3.x",
     "underscore": "1.4.x",
-    "typogr": "0.5.x"
+    "typogr": "0.5.x",
+    "yargs": "~1.2.1"
   },
   "scripts": {
     "test": "node ./node_modules/.bin/jshint ."


### PR DESCRIPTION
`dependencies` are modules that get installed when the current package is added as a dependency or a devDependency to another package that someone installs. Therefore, it shouldn't packages needed only for test purposes should all be specified as devDependencies.
