### PR TITLE
Remove type="text/javascript" from script tags.

### DIFF
--- a/examples/acroforms/index.html
+++ b/examples/acroforms/index.html
@@ -4,18 +4,18 @@
 <head>
   <!-- In production, only one script (pdf.js) is necessary -->
   <!-- In production, change the content of PDFJS.workerSrc below -->
-  <script type="text/javascript" src="../../src/shared/util.js"></script>
-  <script type="text/javascript" src="../../src/shared/colorspace.js"></script>
-  <script type="text/javascript" src="../../src/shared/function.js"></script>
-  <script type="text/javascript" src="../../src/shared/annotation.js"></script>
-  <script type="text/javascript" src="../../src/display/api.js"></script>
-  <script type="text/javascript" src="../../src/display/metadata.js"></script>
-  <script type="text/javascript" src="../../src/display/canvas.js"></script>
-  <script type="text/javascript" src="../../src/display/webgl.js"></script>
-  <script type="text/javascript" src="../../src/display/pattern_helper.js"></script>
-  <script type="text/javascript" src="../../src/display/font_loader.js"></script>
+  <script src="../../src/shared/util.js"></script>
+  <script src="../../src/shared/colorspace.js"></script>
+  <script src="../../src/shared/function.js"></script>
+  <script src="../../src/shared/annotation.js"></script>
+  <script src="../../src/display/api.js"></script>
+  <script src="../../src/display/metadata.js"></script>
+  <script src="../../src/display/canvas.js"></script>
+  <script src="../../src/display/webgl.js"></script>
+  <script src="../../src/display/pattern_helper.js"></script>
+  <script src="../../src/display/font_loader.js"></script>
 
-  <script type="text/javascript">
+  <script>
     // Specify the main script used to create a new PDF.JS web worker.
     // In production, change this to point to the combined `pdf.js` file.
     PDFJS.workerSrc = '../../src/worker_loader.js';
@@ -33,7 +33,7 @@
   .inputHint { opacity: 0.2; background: #ccc; position: absolute; }
   </style>
 
-  <script type="text/javascript" src="forms.js"></script>
+  <script src="forms.js"></script>
 </head>
 
 <body>

--- a/examples/helloworld/index.html
+++ b/examples/helloworld/index.html
@@ -4,24 +4,24 @@
 <head>
   <!-- In production, only one script (pdf.js) is necessary -->
   <!-- In production, change the content of PDFJS.workerSrc below -->
-  <script type="text/javascript" src="../../src/shared/util.js"></script>
-  <script type="text/javascript" src="../../src/shared/colorspace.js"></script>
-  <script type="text/javascript" src="../../src/shared/function.js"></script>
-  <script type="text/javascript" src="../../src/shared/annotation.js"></script>
-  <script type="text/javascript" src="../../src/display/api.js"></script>
-  <script type="text/javascript" src="../../src/display/metadata.js"></script>
-  <script type="text/javascript" src="../../src/display/canvas.js"></script>
-  <script type="text/javascript" src="../../src/display/webgl.js"></script>
-  <script type="text/javascript" src="../../src/display/pattern_helper.js"></script>
-  <script type="text/javascript" src="../../src/display/font_loader.js"></script>
+  <script src="../../src/shared/util.js"></script>
+  <script src="../../src/shared/colorspace.js"></script>
+  <script src="../../src/shared/function.js"></script>
+  <script src="../../src/shared/annotation.js"></script>
+  <script src="../../src/display/api.js"></script>
+  <script src="../../src/display/metadata.js"></script>
+  <script src="../../src/display/canvas.js"></script>
+  <script src="../../src/display/webgl.js"></script>
+  <script src="../../src/display/pattern_helper.js"></script>
+  <script src="../../src/display/font_loader.js"></script>
 
-  <script type="text/javascript">
+  <script>
     // Specify the main script used to create a new PDF.JS web worker.
     // In production, leave this undefined or change it to point to the
     // combined `pdf.worker.js` file.
     PDFJS.workerSrc = '../../src/worker_loader.js';
   </script>
-  <script type="text/javascript" src="hello.js"></script>
+  <script src="hello.js"></script>
 </head>
 
 <body>

--- a/examples/text-only/index.html
+++ b/examples/text-only/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>Text-only PDF.js example</title>
-    <script src="../../build/generic/build/pdf.js" type="text/javascript"></script>
+    <script src="../../build/generic/build/pdf.js"></script>
     <script src="pdf2svg.js"></script>
 </head>
 <body>

--- a/examples/text-selection/index.html
+++ b/examples/text-selection/index.html
@@ -5,7 +5,7 @@
         <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
 
         <!-- you will need to run "node make generic" first before you can use this -->
-        <script src="../../build/generic/build/pdf.js" type="text/javascript"></script>
+        <script src="../../build/generic/build/pdf.js"></script>
 
         <!-- These files are viewer components that you will need to get text-selection to work -->
         <script src="../../web/pdf_find_bar.js"></script>
@@ -13,12 +13,12 @@
         <script src="../../web/ui_utils.js"></script>
         <script src="../../web/text_layer_builder.js"></script>
 
-        <script type="text/javascript">
+        <script>
              // Specify the main script used to create a new PDF.JS web worker.
              // In production, change this to point to the combined `pdf.js` file.
          </script>
 
-        <script src="js/minimal.js" type="text/javascript"></script>
+        <script src="js/minimal.js"></script>
     </head>
     <body>
         This is a minimal pdf.js text-selection demo. The existing minimal-example shows you how to render a PDF, but not

--- a/extensions/b2g/viewer.html
+++ b/extensions/b2g/viewer.html
@@ -24,11 +24,11 @@ limitations under the License.
     <link rel="stylesheet" href="viewer.css"/>
     <link rel="resource" type="application/l10n" href="locale/locale.properties"/>
     <link rel="stylesheet" href="/shared/style/headers.css" type="text/css" />
-    <script type="text/javascript" src="l10n.js"></script>
-    <script type="text/javascript" src="../build/pdf.js"></script>
-    <script type="text/javascript" src="/shared/js/async_storage.js"></script>
+    <script src="l10n.js"></script>
+    <script src="../build/pdf.js"></script>
+    <script src="/shared/js/async_storage.js"></script>
 
-    <script type="text/javascript" src="viewer.js"></script>
+    <script src="viewer.js"></script>
   </head>
 
 

--- a/test/font/font_test.html
+++ b/test/font/font_test.html
@@ -6,50 +6,50 @@
   <link rel="shortcut icon" type="image/png" href="../../external/jasmine/jasmine_favicon.png">
   <link rel="stylesheet" type="text/css" href="../../external/jasmine/jasmine.css">
 
-  <script type="text/javascript" src="../../external/jasmine/jasmine.js"></script>
-  <script type="text/javascript" src="../../external/jasmine/jasmine-html.js"></script>
-  <script type="text/javascript" src="../unit/testreporter.js"></script>
-  <script type="text/javascript" src="fontutils.js"></script>
+  <script src="../../external/jasmine/jasmine.js"></script>
+  <script src="../../external/jasmine/jasmine-html.js"></script>
+  <script src="../unit/testreporter.js"></script>
+  <script src="fontutils.js"></script>
 
   <!-- include source files here... -->
-  <script type="text/javascript" src="../../src/core/network.js"></script>
-  <script type="text/javascript" src="../../src/core/chunked_stream.js"></script>
-  <script type="text/javascript" src="../../src/core/pdf_manager.js"></script>
-  <script type="text/javascript" src="../../src/core/core.js"></script>
-  <script type="text/javascript" src="../../src/shared/util.js"></script>
-  <script type="text/javascript" src="../../src/display/api.js"></script>
-  <script type="text/javascript" src="../../src/display/canvas.js"></script>
-  <script type="text/javascript" src="../../src/display/webgl.js"></script>
-  <script type="text/javascript" src="../../src/core/obj.js"></script>
-  <script type="text/javascript" src="../../src/shared/annotation.js"></script>
-  <script type="text/javascript" src="../../src/shared/function.js"></script>
-  <script type="text/javascript" src="../../src/core/charsets.js"></script>
-  <script type="text/javascript" src="../../src/core/cidmaps.js"></script>
-  <script type="text/javascript" src="../../src/shared/colorspace.js"></script>
-  <script type="text/javascript" src="../../src/core/crypto.js"></script>
-  <script type="text/javascript" src="../../src/core/pattern.js"></script>
-  <script type="text/javascript" src="../../src/core/evaluator.js"></script>
-  <script type="text/javascript" src="../../src/core/cmap.js"></script>
-  <script type="text/javascript" src="../../src/core/fonts.js"></script>
-  <script type="text/javascript" src="../../src/core/glyphlist.js"></script>
-  <script type="text/javascript" src="../../src/core/image.js"></script>
-  <script type="text/javascript" src="../../src/core/metrics.js"></script>
-  <script type="text/javascript" src="../../src/core/parser.js"></script>
-  <script type="text/javascript" src="../../src/core/ps_parser.js"></script>
-  <script type="text/javascript" src="../../src/display/pattern_helper.js"></script>
-  <script type="text/javascript" src="../../src/core/stream.js"></script>
-  <script type="text/javascript" src="../../src/core/worker.js"></script>
-  <script type="text/javascript" src="../../src/display/metadata.js"></script>
-  <script type="text/javascript" src="../../src/core/jpg.js"></script>
-  <script type="text/javascript">PDFJS.workerSrc = '../../src/worker_loader.js';</script>
+  <script src="../../src/core/network.js"></script>
+  <script src="../../src/core/chunked_stream.js"></script>
+  <script src="../../src/core/pdf_manager.js"></script>
+  <script src="../../src/core/core.js"></script>
+  <script src="../../src/shared/util.js"></script>
+  <script src="../../src/display/api.js"></script>
+  <script src="../../src/display/canvas.js"></script>
+  <script src="../../src/display/webgl.js"></script>
+  <script src="../../src/core/obj.js"></script>
+  <script src="../../src/shared/annotation.js"></script>
+  <script src="../../src/shared/function.js"></script>
+  <script src="../../src/core/charsets.js"></script>
+  <script src="../../src/core/cidmaps.js"></script>
+  <script src="../../src/shared/colorspace.js"></script>
+  <script src="../../src/core/crypto.js"></script>
+  <script src="../../src/core/pattern.js"></script>
+  <script src="../../src/core/evaluator.js"></script>
+  <script src="../../src/core/cmap.js"></script>
+  <script src="../../src/core/fonts.js"></script>
+  <script src="../../src/core/glyphlist.js"></script>
+  <script src="../../src/core/image.js"></script>
+  <script src="../../src/core/metrics.js"></script>
+  <script src="../../src/core/parser.js"></script>
+  <script src="../../src/core/ps_parser.js"></script>
+  <script src="../../src/display/pattern_helper.js"></script>
+  <script src="../../src/core/stream.js"></script>
+  <script src="../../src/core/worker.js"></script>
+  <script src="../../src/display/metadata.js"></script>
+  <script src="../../src/core/jpg.js"></script>
+  <script>PDFJS.workerSrc = '../../src/worker_loader.js';</script>
 
   <!-- include spec files here... -->
-  <script type="text/javascript" src="font_core_spec.js"></script>
-  <script type="text/javascript" src="font_os2_spec.js"></script>
-  <script type="text/javascript" src="font_post_spec.js"></script>
-  <script type="text/javascript" src="font_fpgm_spec.js"></script>
+  <script src="font_core_spec.js"></script>
+  <script src="font_os2_spec.js"></script>
+  <script src="font_post_spec.js"></script>
+  <script src="font_fpgm_spec.js"></script>
 
-  <script type="text/javascript">
+  <script>
     'use strict';
 
     (function pdfJsUnitTest() {

--- a/test/test_slave.html
+++ b/test/test_slave.html
@@ -19,19 +19,19 @@ limitations under the License.
   <head>
     <title>pdf.js test slave</title>
     <style type="text/css"></style>
-    <script type="text/javascript" src="/src/shared/util.js"></script>
-    <script type="text/javascript" src="/src/shared/colorspace.js"></script>
-    <script type="text/javascript" src="/src/shared/function.js"></script>
-    <script type="text/javascript" src="/src/shared/annotation.js"></script>
-    <script type="text/javascript" src="/src/display/api.js"></script>
-    <script type="text/javascript" src="/src/display/metadata.js"></script>
-    <script type="text/javascript" src="/src/display/canvas.js"></script>
-    <script type="text/javascript" src="/src/display/webgl.js"></script>
-    <script type="text/javascript" src="/src/display/pattern_helper.js"></script>
-    <script type="text/javascript" src="/src/display/font_loader.js"></script>
-    <script type="text/javascript" src="driver.js"></script>
+    <script src="/src/shared/util.js"></script>
+    <script src="/src/shared/colorspace.js"></script>
+    <script src="/src/shared/function.js"></script>
+    <script src="/src/shared/annotation.js"></script>
+    <script src="/src/display/api.js"></script>
+    <script src="/src/display/metadata.js"></script>
+    <script src="/src/display/canvas.js"></script>
+    <script src="/src/display/webgl.js"></script>
+    <script src="/src/display/pattern_helper.js"></script>
+    <script src="/src/display/font_loader.js"></script>
+    <script src="driver.js"></script>
 
-    <script type="text/javascript">
+    <script>
       PDFJS.workerSrc = '/src/worker_loader.js';
     </script>
   </head>
@@ -41,7 +41,7 @@ limitations under the License.
     <p>Inflight requests: <span id="inFlightCount"></span></p>
     <div id="content-end"></div>
 
-    <script type="text/javascript">
+    <script>
       'use strict';
       load();
     </script>

--- a/test/unit/unit_test.html
+++ b/test/unit/unit_test.html
@@ -6,55 +6,55 @@
   <link rel="shortcut icon" type="image/png" href="../../external/jasmine/jasmine_favicon.png">
   <link rel="stylesheet" type="text/css" href="../../external/jasmine/jasmine.css">
 
-  <script type="text/javascript" src="../../external/jasmine/jasmine.js"></script>
-  <script type="text/javascript" src="../../external/jasmine/jasmine-html.js"></script>
-  <script type="text/javascript" src="testreporter.js"></script>
+  <script src="../../external/jasmine/jasmine.js"></script>
+  <script src="../../external/jasmine/jasmine-html.js"></script>
+  <script src="testreporter.js"></script>
 
   <!-- include source files here... -->
-  <script type="text/javascript" src="../../src/core/network.js"></script>
-  <script type="text/javascript" src="../../src/core/chunked_stream.js"></script>
-  <script type="text/javascript" src="../../src/core/pdf_manager.js"></script>
-  <script type="text/javascript" src="../../src/core/core.js"></script>
-  <script type="text/javascript" src="../../src/shared/util.js"></script>
-  <script type="text/javascript" src="../../src/display/api.js"></script>
-  <script type="text/javascript" src="../../src/display/canvas.js"></script>
-  <script type="text/javascript" src="../../src/display/webgl.js"></script>
-  <script type="text/javascript" src="../../src/core/obj.js"></script>
-  <script type="text/javascript" src="../../src/shared/annotation.js"></script>
-  <script type="text/javascript" src="../../src/shared/function.js"></script>
-  <script type="text/javascript" src="../../src/core/charsets.js"></script>
-  <script type="text/javascript" src="../../src/core/cidmaps.js"></script>
-  <script type="text/javascript" src="../../src/shared/colorspace.js"></script>
-  <script type="text/javascript" src="../../src/core/crypto.js"></script>
-  <script type="text/javascript" src="../../src/core/pattern.js"></script>
-  <script type="text/javascript" src="../../src/core/evaluator.js"></script>
-  <script type="text/javascript" src="../../src/core/cmap.js"></script>
-  <script type="text/javascript" src="../../src/core/fonts.js"></script>
-  <script type="text/javascript" src="../../src/core/glyphlist.js"></script>
-  <script type="text/javascript" src="../../src/core/image.js"></script>
-  <script type="text/javascript" src="../../src/core/metrics.js"></script>
-  <script type="text/javascript" src="../../src/core/parser.js"></script>
-  <script type="text/javascript" src="../../src/core/ps_parser.js"></script>
-  <script type="text/javascript" src="../../src/display/pattern_helper.js"></script>
-  <script type="text/javascript" src="../../src/core/stream.js"></script>
-  <script type="text/javascript" src="../../src/core/worker.js"></script>
-  <script type="text/javascript" src="../../src/display/metadata.js"></script>
-  <script type="text/javascript" src="../../src/core/jpg.js"></script>
-  <script type="text/javascript">PDFJS.workerSrc = '../../src/worker_loader.js';</script>
+  <script src="../../src/core/network.js"></script>
+  <script src="../../src/core/chunked_stream.js"></script>
+  <script src="../../src/core/pdf_manager.js"></script>
+  <script src="../../src/core/core.js"></script>
+  <script src="../../src/shared/util.js"></script>
+  <script src="../../src/display/api.js"></script>
+  <script src="../../src/display/canvas.js"></script>
+  <script src="../../src/display/webgl.js"></script>
+  <script src="../../src/core/obj.js"></script>
+  <script src="../../src/shared/annotation.js"></script>
+  <script src="../../src/shared/function.js"></script>
+  <script src="../../src/core/charsets.js"></script>
+  <script src="../../src/core/cidmaps.js"></script>
+  <script src="../../src/shared/colorspace.js"></script>
+  <script src="../../src/core/crypto.js"></script>
+  <script src="../../src/core/pattern.js"></script>
+  <script src="../../src/core/evaluator.js"></script>
+  <script src="../../src/core/cmap.js"></script>
+  <script src="../../src/core/fonts.js"></script>
+  <script src="../../src/core/glyphlist.js"></script>
+  <script src="../../src/core/image.js"></script>
+  <script src="../../src/core/metrics.js"></script>
+  <script src="../../src/core/parser.js"></script>
+  <script src="../../src/core/ps_parser.js"></script>
+  <script src="../../src/display/pattern_helper.js"></script>
+  <script src="../../src/core/stream.js"></script>
+  <script src="../../src/core/worker.js"></script>
+  <script src="../../src/display/metadata.js"></script>
+  <script src="../../src/core/jpg.js"></script>
+  <script>PDFJS.workerSrc = '../../src/worker_loader.js';</script>
 
   <!-- include spec files here... -->
-  <script type="text/javascript" src="obj_spec.js"></script>
-  <script type="text/javascript" src="font_spec.js"></script>
-  <script type="text/javascript" src="function_spec.js"></script>
-  <script type="text/javascript" src="crypto_spec.js"></script>
-  <script type="text/javascript" src="evaluator_spec.js"></script>
-  <script type="text/javascript" src="stream_spec.js"></script>
-  <script type="text/javascript" src="parser_spec.js"></script>
-  <script type="text/javascript" src="api_spec.js"></script>
-  <script type="text/javascript" src="metadata_spec.js"></script>
-  <script type="text/javascript" src="util_spec.js"></script>
-  <script type="text/javascript" src="cmap_spec.js"></script>
-  <script type="text/javascript">
+  <script src="obj_spec.js"></script>
+  <script src="font_spec.js"></script>
+  <script src="function_spec.js"></script>
+  <script src="crypto_spec.js"></script>
+  <script src="evaluator_spec.js"></script>
+  <script src="stream_spec.js"></script>
+  <script src="parser_spec.js"></script>
+  <script src="api_spec.js"></script>
+  <script src="metadata_spec.js"></script>
+  <script src="util_spec.js"></script>
+  <script src="cmap_spec.js"></script>
+  <script>
     'use strict';
 
     (function pdfJsUnitTest() {

--- a/web/viewer-snippet-chrome-extension.html
+++ b/web/viewer-snippet-chrome-extension.html
@@ -1,5 +1,5 @@
 <!-- This snippet is used in the Chromium extension (included from viewer.html) -->
 <base href="/content/web/">
 <link rel="resource" type="application/l10n" href="locale/locale.properties">
-<script type="text/javascript" src="l10n.js"></script>
-<script type="text/javascript" src="../build/pdf.js"></script>
+<script src="l10n.js"></script>
+<script src="../build/pdf.js"></script>

--- a/web/viewer-snippet-firefox-extension.html
+++ b/web/viewer-snippet-firefox-extension.html
@@ -1,4 +1,4 @@
 <!-- This snippet is used in the Firefox extension (included from viewer.html) -->
 <base href="resource://pdf.js/web/" />
-<script type="text/javascript" src="l10n.js"></script>
-<script type="text/javascript" src="../build/pdf.js"></script>
+<script src="l10n.js"></script>
+<script src="../build/pdf.js"></script>

--- a/web/viewer-snippet-minified.html
+++ b/web/viewer-snippet-minified.html
@@ -1,3 +1,3 @@
 <!-- This snippet is used in production (included from viewer.html) -->
 <link rel="resource" type="application/l10n" href="locale/locale.properties"/>
-<script type="text/javascript" src="pdf.viewer.js"></script>
+<script src="pdf.viewer.js"></script>

--- a/web/viewer-snippet.html
+++ b/web/viewer-snippet.html
@@ -1,4 +1,4 @@
 <!-- This snippet is used in production (included from viewer.html) -->
 <link rel="resource" type="application/l10n" href="locale/locale.properties"/>
-<script type="text/javascript" src="l10n.js"></script>
-<script type="text/javascript" src="../build/pdf.js"></script>
+<script src="l10n.js"></script>
+<script src="../build/pdf.js"></script>

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -39,25 +39,25 @@ http://sourceforge.net/adobe/cmap/wiki/License/
 <!--#endif-->
 
 <!--#if !(FIREFOX || MOZCENTRAL || CHROME || MINIFIED)-->
-    <script type="text/javascript" src="compatibility.js"></script>
+    <script src="compatibility.js"></script>
 <!--#endif-->
 
 <!--#if !PRODUCTION-->
-    <script type="text/javascript" src="../external/webL10n/l10n.js"></script>
+    <script src="../external/webL10n/l10n.js"></script>
 <!--#endif-->
 
 <!--#if !PRODUCTION-->
-    <script type="text/javascript" src="../src/shared/util.js"></script>
-    <script type="text/javascript" src="../src/shared/colorspace.js"></script>
-    <script type="text/javascript" src="../src/shared/function.js"></script>
-    <script type="text/javascript" src="../src/shared/annotation.js"></script>
-    <script type="text/javascript" src="../src/display/api.js"></script>
-    <script type="text/javascript" src="../src/display/metadata.js"></script>
-    <script type="text/javascript" src="../src/display/canvas.js"></script>
-    <script type="text/javascript" src="../src/display/webgl.js"></script>
-    <script type="text/javascript" src="../src/display/pattern_helper.js"></script>
-    <script type="text/javascript" src="../src/display/font_loader.js"></script>
-    <script type="text/javascript">PDFJS.workerSrc = '../src/worker_loader.js';</script>
+    <script src="../src/shared/util.js"></script>
+    <script src="../src/shared/colorspace.js"></script>
+    <script src="../src/shared/function.js"></script>
+    <script src="../src/shared/annotation.js"></script>
+    <script src="../src/display/api.js"></script>
+    <script src="../src/display/metadata.js"></script>
+    <script src="../src/display/canvas.js"></script>
+    <script src="../src/display/webgl.js"></script>
+    <script src="../src/display/pattern_helper.js"></script>
+    <script src="../src/display/font_loader.js"></script>
+    <script>PDFJS.workerSrc = '../src/worker_loader.js';</script>
 <!--#endif-->
 
 <!--#if (GENERIC && !MINIFIED) -->
@@ -65,30 +65,30 @@ http://sourceforge.net/adobe/cmap/wiki/License/
 <!--#endif-->
 
 <!--#if !PRODUCTION-->
-    <script type="text/javascript" src="ui_utils.js"></script>
-    <script type="text/javascript" src="default_preferences.js"></script>
-    <script type="text/javascript" src="preferences.js"></script>
-    <script type="text/javascript" src="download_manager.js"></script>
-    <script type="text/javascript" src="view_history.js"></script>
-    <script type="text/javascript" src="page_view.js"></script>
-    <script type="text/javascript" src="thumbnail_view.js"></script>
-    <script type="text/javascript" src="text_layer_builder.js"></script>
-    <script type="text/javascript" src="document_outline_view.js"></script>
-    <script type="text/javascript" src="document_attachments_view.js"></script>
-    <script type="text/javascript" src="pdf_find_bar.js"></script>
-    <script type="text/javascript" src="pdf_find_controller.js"></script>
-    <script type="text/javascript" src="pdf_history.js"></script>
-    <script type="text/javascript" src="secondary_toolbar.js"></script>
-    <script type="text/javascript" src="password_prompt.js"></script>
-    <script type="text/javascript" src="presentation_mode.js"></script>
-    <script type="text/javascript" src="grab_to_pan.js"></script>
-    <script type="text/javascript" src="hand_tool.js"></script>
-    <script type="text/javascript" src="document_properties.js"></script>
+    <script src="ui_utils.js"></script>
+    <script src="default_preferences.js"></script>
+    <script src="preferences.js"></script>
+    <script src="download_manager.js"></script>
+    <script src="view_history.js"></script>
+    <script src="page_view.js"></script>
+    <script src="thumbnail_view.js"></script>
+    <script src="text_layer_builder.js"></script>
+    <script src="document_outline_view.js"></script>
+    <script src="document_attachments_view.js"></script>
+    <script src="pdf_find_bar.js"></script>
+    <script src="pdf_find_controller.js"></script>
+    <script src="pdf_history.js"></script>
+    <script src="secondary_toolbar.js"></script>
+    <script src="password_prompt.js"></script>
+    <script src="presentation_mode.js"></script>
+    <script src="grab_to_pan.js"></script>
+    <script src="hand_tool.js"></script>
+    <script src="document_properties.js"></script>
 <!--#endif-->
 
 <!--#if !MINIFIED -->
-    <script type="text/javascript" src="debugger.js"></script>
-    <script type="text/javascript" src="viewer.js"></script>
+    <script src="debugger.js"></script>
+    <script src="viewer.js"></script>
 <!--#else-->
 <!--#include viewer-snippet-minified.html-->
 <!--#endif-->


### PR DESCRIPTION
"text/javascript" is not a correct MIME type (the correct one is
"application/javascript") but it's not even needed; all browsers default
to the correct type and treat it as executable JS when type is ommited.
Since not all browsers recognize the "application/javascript" MIME type
the only way to both stay compliant and to support all popular browsers
is to omit the type. It's also shorter this way.
