### PR TITLE
Use jQuery 2 in examples

### DIFF
--- a/examples/text-selection/index.html
+++ b/examples/text-selection/index.html
@@ -2,7 +2,7 @@
     <head>
         <title>Minimal pdf.js text-selection demo</title>
         <link href="css/minimal.css" rel="stylesheet" media="screen" />
-        <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
+        <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
 
         <!-- you will need to run "node make generic" first before you can use this -->
         <script src="../../build/generic/build/pdf.js" type="text/javascript"></script>


### PR DESCRIPTION
Since pdf.js doesn't work in IE8 anyway, it doesn't make sense to use
jQuery 1 with it. jQuery 2 should be used in every example that needs
jQuery.
