### PR TITLE
Switch to Node.js 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 0.8
+  - 0.10


### PR DESCRIPTION
Node.js 0.12 is soon going to be released and Node 0.8 might be
deprecated soon. It's best to stay on the current version.
