### PR TITLE
Use the wheel event instead of DOMMouseScroll

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1920,16 +1920,27 @@ window.addEventListener('pagechange', function pagechange(evt) {
 }, true);
 
 function handleMouseWheel(evt) {
-  var MOUSE_WHEEL_DELTA_FACTOR = 40;
-  var ticks = (evt.type === 'DOMMouseScroll') ? -evt.detail :
-              evt.wheelDelta / MOUSE_WHEEL_DELTA_FACTOR;
-  var direction = (ticks < 0) ? 'zoomOut' : 'zoomIn';
+  var WHEEL_DELTA_FACTOR = 40;
+
+  var delta = evt.deltaY;
+  if (delta !== undefined) {
+    // evt.deltaMode === 0 means pixels => no change
+    if (evt.deltaMode === 1) {
+      // lines
+      delta /= parseInt(getComputedStyle(evt.target).fontSize, 10);
+    } else if (evt.deltaMode === 2) {
+      // pages
+      delta /= document.documentElement.clientHeight;
+    }
+  } else {
+    delta = -evt.wheelDeltaY / 3;
+  }
+  var direction = (delta > 0) ? 'zoomOut' : 'zoomIn';
 
   var pdfViewer = PDFViewerApplication.pdfViewer;
   if (pdfViewer.isInPresentationMode) {
     evt.preventDefault();
-    PDFViewerApplication.scrollPresentationMode(ticks *
-                                                MOUSE_WHEEL_DELTA_FACTOR);
+    PDFViewerApplication.scrollPresentationMode(-delta);
   } else if (evt.ctrlKey || evt.metaKey) {
     var support = PDFViewerApplication.supportedMouseWheelZoomModifierKeys;
     if ((evt.ctrlKey && !support.ctrlKey) ||
@@ -1941,7 +1952,7 @@ function handleMouseWheel(evt) {
 
     var previousScale = pdfViewer.currentScale;
 
-    PDFViewerApplication[direction](Math.abs(ticks));
+    PDFViewerApplication[direction](Math.abs(delta) / WHEEL_DELTA_FACTOR);
 
     var currentScale = pdfViewer.currentScale;
     if (previousScale !== currentScale) {
@@ -1958,7 +1969,7 @@ function handleMouseWheel(evt) {
   }
 }
 
-window.addEventListener('DOMMouseScroll', handleMouseWheel);
+window.addEventListener('wheel', handleMouseWheel);
 window.addEventListener('mousewheel', handleMouseWheel);
 
 window.addEventListener('click', function click(evt) {


### PR DESCRIPTION
(NOTE: I treat it as work in progress. What's the best way to test how this implementation works?)

DOMMouseScroll is a proprietary Firefox event while wheel is specified
in DOM Level 3 Events:
http://www.w3.org/TR/DOM-Level-3-Events/#event-type-wheel

All major browsers implement the wheel event at least in their latest dev
versions (Fx 17, Chrome 31, IE 9, WebKit Nightly) and all older versions of
these browsers except Firefox implement the non-standard mousewheel event.

IE9+ implements both but it doesn't have wheelDeltaX/wheelDeltaY, only
wheelDelta which makes it impossible to detect the scrolling axis. Its wheel
event implements all 3 axises.

The wheel event specifies the deltaMode parameter; 0 means deltas are given
in pixels; 1 means lines and 2 means pages. All browsers seems to specify 0 but
there's no guarantee it doesn't vary by the input device etc. so it's better
to normalize.

wheelDeltaY is usually larger (after passing through abs) than deltaY, in Chrome
that specifies both on both wheel & mousewheel events wheelDeltaY is 3 times
larger.

In this way, all of the browsers have both horizontal & vertical axis recognized
which may be used in the future (for example on OS X you can scroll in both
directions at the same time using a trackpad, creating an effect of panning
via moving 2 fingers around on the trackpad).
