### PR TITLE
Add unit test for getData

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -86,6 +86,12 @@ describe('api', function() {
         expect(metadata.metadata.get('dc:title')).toEqual('Basic API Test');
       });
     });
+    it('gets data', function() {
+      var promise = doc.getData();
+      waitsForPromise(promise, function (data) {
+        expect(true).toEqual(true);
+      });
+    });
   });
   describe('Page', function() {
     var resolvePromise;


### PR DESCRIPTION
Having a unit test for `getData` would have caught the regression fixed in #4793, so this PR adds a basic test that just checks if `getData` succeeds.

As a follow-up we might also want to either modify, or add another test, to check that `getData` returns the correct data. In that case we should probably use a smaller PDF file to test with.
