### PR TITLE
Check if the Names dictionary actually contains a Dests dictionary before attempting to get the destinations

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -419,7 +419,7 @@ var Catalog = (function CatalogClosure() {
       var xref = this.xref;
       var dests = {}, nameTreeRef, nameDictionaryRef;
       var obj = this.catDict.get('Names');
-      if (obj) {
+      if (obj && obj.has('Dests')) {
         nameTreeRef = obj.getRaw('Dests');
       } else if (this.catDict.has('Dests')) {
         nameDictionaryRef = this.catDict.get('Dests');

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -65,7 +65,8 @@ describe('api', function() {
     it('gets destinations', function() {
       var promise = doc.getDestinations();
       waitsForPromise(promise, function(data) {
-        // TODO this seems to be broken for the test pdf
+        expect(data).toEqual({ chapter1: [{ gen: 0, num: 17 }, { name: 'XYZ' },
+                                          0, 841.89, null] });
       });
     });
     it('gets outline', function() {


### PR DESCRIPTION
Currently the unit test for `getDestinations` is partially disabled, see https://github.com/mozilla/pdf.js/blob/master/test/unit/api_spec.js#L68.

The problem with the file [basicapi.pdf](https://github.com/mozilla/pdf.js/blob/master/test/pdfs/basicapi.pdf) is that the `Names` dictionary is empty, so this PR makes sure that we check that before attempting to get the `Dests`.
This PR thus makes it possible to fix a, currently meaningless, unit test.
