### PR TITLE
Add more unit tests for the API

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -449,7 +449,7 @@ var Catalog = (function CatalogClosure() {
     },
     get attachments() {
       var xref = this.xref;
-      var attachments, nameTreeRef;
+      var attachments = null, nameTreeRef;
       var obj = this.catDict.get('Names');
       if (obj) {
         nameTreeRef = obj.getRaw('EmbeddedFiles');

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -69,6 +69,18 @@ describe('api', function() {
                                           0, 841.89, null] });
       });
     });
+    it('gets attachments', function() {
+      var promise = doc.getAttachments();
+      waitsForPromise(promise, function (data) {
+        expect(data).toEqual(null);
+      });
+    });
+    it('gets javascript', function() {
+      var promise = doc.getJavaScript();
+      waitsForPromise(promise, function (data) {
+        expect(data).toEqual([]);
+      });
+    });
     it('gets outline', function() {
       var promise = doc.getOutline();
       waitsForPromise(promise, function(outline) {
@@ -91,6 +103,12 @@ describe('api', function() {
       var promise = doc.getData();
       waitsForPromise(promise, function (data) {
         expect(true).toEqual(true);
+      });
+    });
+    it('gets filesize in bytes', function() {
+      var promise = doc.getDownloadInfo();
+      waitsForPromise(promise, function (data) {
+        expect(data.length).toEqual(105779);
       });
     });
   });


### PR DESCRIPTION
Unit tests can never hurt, so let's add a couple more :-)

While doing this, I also came across a slight issue with `getAttachments`. Currently when no attachments are present in a file, the function will return `undefined` which causes the test to timeout. I've changed the function to instead return `null`, which fixes these issues (and is also consistent with e.g. `getOutline`).
