### PR TITLE
Prevent font error when no preferred cmap table is found (workaround for issue 4800)

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -2971,7 +2971,12 @@ var Font = (function FontClosure() {
 
         if (!potentialTable) {
           warn('Could not find a preferred cmap table.');
-          return [];
+          return {
+            platformId: -1,
+            encodingId: -1,
+            mappings: [],
+            hasShortCmap: false
+          };
         }
 
         font.pos = start + potentialTable.offset;


### PR DESCRIPTION
Workaround for the error in #4800.
