### PR TITLE
[OverlayManager] Add preventDefault to the keydown event handler

### DIFF
--- a/web/overlay_manager.js
+++ b/web/overlay_manager.js
@@ -128,6 +128,7 @@ var OverlayManager = {
     var self = OverlayManager;
     if (self.active && evt.keyCode === 27) { // Esc key.
       self._closeThroughCaller();
+      evt.preventDefault();
     }
   },
 


### PR DESCRIPTION
If we don't do this, pressing <kbd>Esc</kbd> while an overlay is open could abort loading of files for which the server doesn't specify the `contentLength`.

/cc @timvandermeij
