### PR TITLE
Fixes unhandled XObject subtype PS error

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -635,7 +635,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
                 assert(isName(type),
                   'XObject should have a Name subtype');
 
-                if ('Form' == type.name) {
+                if (type.name === 'Form') {
                   stateManager.save();
                   return self.buildFormXObject(resources, xobj, null,
                                                operatorList,
@@ -644,10 +644,15 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
                       stateManager.restore();
                       next(resolve, reject);
                     }, reject);
-                } else if ('Image' == type.name) {
+                } else if (type.name === 'Image') {
                   self.buildPaintImageXObject(resources, xobj, false,
                     operatorList, name, imageCache);
                   args = [];
+                  continue;
+                } else if (type.name === 'PS') {
+                  // PostScript XObjects are unused when viewing documents.
+                  // See section 4.7.1 of Adobe's PDF reference.
+                  info('Ignored XObject subtype PS');
                   continue;
                 } else {
                   error('Unhandled XObject subtype ' + type.name);


### PR DESCRIPTION
Fixes #4278.

From Adobe's PDF reference section 4.7.1:

"Beginning with PDF 1.1, a content stream can include PostScript language fragments. These fragments are used only when printing to a PostScript output device; they have no effect either when viewing the document on-screen or when printing it to a non-PostScript device. In addition, applications that understand PDF are unlikely to be able to interpret the PostScript fragments. Hence, this capability should be used with extreme caution and only if there is no other way to achieve the same result."

This tells us that we can safely ignore this XObject subtype.

Note that this PR also addresses the use of strict equalities in the changed portion of the code.
