### PR TITLE
Enable browser cache when running test server

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -655,6 +655,7 @@ function startServer() {
   server.host = host;
   server.port = options.port;
   server.root = '..';
+  server.cacheExpirationTime = 3600;
   server.start();
 }
 

--- a/test/webserver.js
+++ b/test/webserver.js
@@ -47,6 +47,7 @@ function WebServer() {
   this.port = 8000;
   this.server = null;
   this.verbose = false;
+  this.cacheExpirationTime = 0;
   this.disableRangeRequests = false;
   this.hooks = {
     'GET': [],
@@ -91,6 +92,7 @@ WebServer.prototype = {
     }
 
     var disableRangeRequests = this.disableRangeRequests;
+    var cacheExpirationTime = this.cacheExpirationTime;
 
     var filePath;
     fs.realpath(path.join(this.root, pathPart), checkFile);
@@ -222,6 +224,11 @@ WebServer.prototype = {
       }
       res.setHeader('Content-Type', contentType);
       res.setHeader('Content-Length', fileSize);
+      if (cacheExpirationTime > 0) {
+        var expireTime = new Date();
+        expireTime.setSeconds(expireTime.getSeconds() + cacheExpirationTime);
+        res.setHeader('Expires', expireTime.toUTCString());
+      }
       res.writeHead(200);
 
       stream.pipe(res);


### PR DESCRIPTION
This PR sets an expiration time of 1 hour for all files that are requested from the test web server, so that javascript sources are not downloaded by the browsers for each pdf file. This reduces the duration of the test significantly, from 

```
All regression tests passed.
Runtime was 881.5 seconds
```

to

```
All regression tests passed.
Runtime was 578.2 seconds
```

The cache expiration time defaults to 0, so that nothing changes unless the expiration time is explicitly set.

I assumed that each browser uses a fresh profile, so that a newly started test doesn't run on old, cached code. Is that always correct?
