### PR TITLE
Prevent adding undefined array entries to CMap.map in mapRangeToArray (issue 4875)

### DIFF
--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -222,8 +222,8 @@ var CMap = (function CMapClosure() {
     },
 
     mapRangeToArray: function(low, high, array) {
-      var i = 0;
-      while (low <= high) {
+      var i = 0, ii = array.length;
+      while (low <= high && i < ii) {
         this.map[low] = array[i++];
         ++low;
       }


### PR DESCRIPTION
Tentative patch to fix #4875.

I'm not sure if this is the correct/optimal way to fix the issue, which is the reason that I didn't bother including a test file yet. Also I didn't want to waste time running the botio tests until I knew if this patch is any good (note however that it _does_ pass all tests locally).
