### PR TITLE
Optimize JPG.js receiveAndExtend for 1 bit case.

### DIFF
--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -159,6 +159,9 @@ var JpegImage = (function jpegImage() {
     }
 
     function receiveAndExtend(length) {
+      if (length === 1) {
+        return readBit() === 1 ? 1 : -1;
+      }
       var n = receive(length);
       if (n >= 1 << (length - 1)) {
         return n;


### PR DESCRIPTION
Profiling showed that receiveAndExtend is frequently called with the length of
one bit. This happens for example in decodeBaseline.
For a single bit, the loop and shift in receive, as well as the shifts in
receiveAndExtend are overhead.
This shortcut manually calculates the shifts by either returning 1 or -1 from
receiveAndExtend by reading the bit and deciding on the return value.
While it comes with an overhead for each non-one length, the speedup is at about
10% in the hot parse/decode path.
