### PR TITLE
Update canvas.js

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1391,11 +1391,19 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
           // rescale per character
           var measuredWidth = ctx.measureText(character).width * 1000 /
             fontSize * fontSizeScale;
-          var characterScaleX = width / measuredWidth;
-          restoreNeeded = true;
-          ctx.save();
-          ctx.scale(characterScaleX, 1);
-          scaledX /= characterScaleX;
+          if (width < measuredWidth) {
+            var characterScaleX = width / measuredWidth;
+            restoreNeeded = true;
+            ctx.save();
+            ctx.scale(characterScaleX, 1);
+            scaledX /= characterScaleX;
+          } else if (width > measuredWidth) {
+            var d = (width - measuredWidth)*500;
+            scaledX += d;
+            if (accent) {
+              scaledAccentX += d;
+            }
+          }
         }
 
         if (simpleFillText && !accent) {


### PR DESCRIPTION
The chars with measuredWidth less then width look terrible after scaling. Let to move it in center instead of scaling.
