### PR TITLE
Prevent infinite loop when scanning for endstream (bug 1020226)

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -266,6 +266,9 @@ var Parser = (function ParserClosure() {
         while (stream.pos < stream.end) {
           var scanBytes = stream.peekBytes(SCAN_BLOCK_SIZE);
           var scanLength = scanBytes.length - ENDSTREAM_SIGNATURE_LENGTH;
+          if (scanLength <= 0) {
+            break;
+          }
           found = false;
           for (i = 0, j = 0; i < scanLength; i++) {
             var b = scanBytes[i];


### PR DESCRIPTION
_Note:_ even with this patch, the file referenced in the bug still doesn't load in PDF.js. However I think this is OK, since even Adobe Reader won't open the file (it just displays a message saying that the file is damaged).
