### PR TITLE
Zero the height and width of the PageView canvas before deleting.

### DIFF
--- a/web/page_view.js
+++ b/web/page_view.js
@@ -99,7 +99,13 @@ var PageView = function pageView(container, id, scale,
       this.annotationLayer = null;
     }
 
-    delete this.canvas;
+    if (this.canvas) {
+      // Zeroing the width and height causes Firefox to release graphics
+      // resources immediately, which can greatly reduce memory consumption.
+      this.canvas.width = 0;
+      this.canvas.height = 0;
+      delete this.canvas;
+    }
 
     this.loadingIconDiv = document.createElement('div');
     this.loadingIconDiv.className = 'loadingIcon';


### PR DESCRIPTION
I've been measuring a 122 page document. Scrolling through it fairly quickly (i.e. at a speed where every page just has time to render) on my Mac, Firefox's memory usage jumps up to about 2,300 MiB, and most of it is canvas pixels.

PageView.destroy() actually deletes canvases for pages that fall out of the cache, but GC doesn't necessarily happen immediately, which means the pixel data can be held on to for a while. Robert O'Callahan told me that if you zero the |width| and |height| of a canvas, in Firefox the graphics resources are freed immediately.

This patch does this, and for the scenario described above it reduces peak memory usage from ~2,300 MiB to between ~1,000 and ~1,400 MiB. Not bad.

(If I scroll through the document _really_ fast, then PageView.destroy() doesn't get called on most of the pages, and so this patch doesn't help much. Working out why destroy() isn't being called in that scenario can be done in a follow-up.)
