### PR TITLE
Return ErrorFont in loadFont when the fontRef is undefined

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -469,6 +469,11 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           return errorFont();
         }
       }
+      if (!fontRef) {
+        warn('fontRef not available');
+        return errorFont();
+      }
+
       if (this.fontCache.has(fontRef)) {
         return this.fontCache.get(fontRef);
       }


### PR DESCRIPTION
This patch enables loading of: http://www.cruiseshipportal.com/fileadmin/Downloads/CostaConcordia_study.pdf; as reported on IRC: http://logs.glob.uno/?c=mozilla%23pdfjs&s=10+Jun+2014&e=10+Jun+2014#c17609.

The following is an overview of the issues with this particular PDF file:
- The first page contains a Type3 font (`R34 (dict) [id: 34, gen: 0]`).
- In the `CharProcs` dictionary, for the `three` character, there is a reference to the font `R98 (dict) [id: 98, gen: 0]`.
  - This particular font isn't available amongst the font resources for the first page.
  - However it does exist in the font resources for the _second_ page.
  - Since the font isn't available, `fontRef` is undefined which causes an error preventing the first two pages from rendering.
- This should thus explain why all pages render when the file is opened on the second page, since in that case the missing font has already been loaded by the time it's accessed from the first page.

This patch changes `loadFont` to return `ErrorFont` when the `fontRef` is undefined, thus preventing errors like those described above.
Obviously this isn't a complete solution, but it does reduce the severity of the issue considerably. I'm not even sure if solving this completely is actually feasible (and this kind of issue should be rare), given that it would require waiting for all font resources (hence all pages) to load before attempting to load e.g. Type3 fonts.
