### PR TITLE
Fix PageView cache re-insertions.

### DIFF
--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -248,7 +248,7 @@ var Cache = function cacheCache(size) {
   this.push = function cachePush(view) {
     var i = data.indexOf(view);
     if (i >= 0) {
-      data.splice(i);
+      data.splice(i, 1);
     }
     data.push(view);
     if (data.length > size) {


### PR DESCRIPTION
If a PageView is re-inserted into the cache, there's a splice() call done which I'm pretty sure is supposed to just remove the existing copy. But in Firefox a.splice(n) has a special behaviour -- it causes every element after the nth to be removed. (See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice for details. I don't know what it does in other browsers.) This causes pages to be removed from the cache without having destroy() called on them.

This patch changes it to a.splice(n, 1), which always removes just the single element.

(BTW, there are two splice(i) calls in src/shared/util.js that may also be buggy.)
