### PR TITLE
Prevent rendering unnecessary pages when the HOME/END keys are pressed

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2347,13 +2347,14 @@ window.addEventListener('keydown', function keydown(evt) {
         break;
 
       case 36: // home
-        if (PresentationMode.active) {
+        if (PresentationMode.active || PDFView.page > 1) {
           PDFView.page = 1;
           handled = true;
         }
         break;
       case 35: // end
-        if (PresentationMode.active) {
+        if (PresentationMode.active ||
+            PDFView.page < PDFView.pdfDocument.numPages) {
           PDFView.page = PDFView.pdfDocument.numPages;
           handled = true;
         }


### PR DESCRIPTION
Currently (at least in Firefox) when the <kbd>HOME</kbd>/<kbd>END</kbd> keys are pressed, this will trigger unnecessary rendering of pages that lay between the current page and the first/last page. Avoid this by going straight to the first/last page instead.
