### PR TITLE
Add larger zoom values to zoom dropdown box

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -270,6 +270,8 @@ http://sourceforge.net/adobe/cmap/wiki/License/
                       <option title="" value="1.25">125%</option>
                       <option title="" value="1.5">150%</option>
                       <option title="" value="2">200%</option>
+                      <option title="" value="3">300%</option>
+                      <option title="" value="4">400%</option>
                     </select>
                   </span>
                 </div>


### PR DESCRIPTION
After PR #4834 has landed, we now have support for larger zoom levels (up to 1000%) in a way that should keep the memory usage at reasonable levels.
I therefore suggest that we add a few larger zoom values to this list, for the following reasons:
1. This will help improve discoverability of the newly added support for larger zoom levels. Useful in the context of e.g. [bug 827496](https://bugzilla.mozilla.org/show_bug.cgi?id=827496).
2. Simplify setting a larger zoom level quickly, instead of having to press the "zoom in"-button (or using <kbd>Ctrl</kbd>&nbsp;+&nbsp;<kbd>+</kbd>) many times in quick succession.
