### PR TITLE
Temporarily increase the size of the page cache to prevent an infinite drawing/destroying loop when the total number of visible pages exceeds CACHE_SIZE

### DIFF
--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* globals PDFView */
 
 'use strict';
 
@@ -251,7 +252,15 @@ var Cache = function cacheCache(size) {
       data.splice(i, 1);
     }
     data.push(view);
-    if (data.length > size) {
+
+    // If the number of visible pages is greater than the cache size,
+    // we will get stuck in an infinite loop of drawing and destroying pages.
+    // Prevent this by temporarily increasing the size of the cache to the
+    // number of visible pages plus one. (Allowing cache space for one extra
+    // page is needed to account for pre-rendering of the previous/next page.)
+    var currentMaxSize = (PDFView.currentNumberOfVisiblePages >= size ?
+                          PDFView.currentNumberOfVisiblePages + 1 : size);
+    if (data.length > currentMaxSize) {
       data.shift().destroy();
     }
   };

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -127,6 +127,7 @@ var PDFView = {
   isViewerEmbedded: (window.parent !== window),
   idleTimeout: null,
   currentPosition: null,
+  currentNumberOfVisiblePages: null,
 
   // called once when the document is loaded
   initialize: function pdfViewInitialize() {
@@ -1238,6 +1239,7 @@ var PDFView = {
 
     // Pages have a higher priority than thumbnails, so check them first.
     var visiblePages = currentlyVisiblePages || this.getVisiblePages();
+    this.currentNumberOfVisiblePages = visiblePages.views.length;
     var pageView = this.getHighestPriority(visiblePages, this.pages,
                                            this.pageViewScroll.down);
     if (pageView) {


### PR DESCRIPTION
It is possible to get stuck in a infinite loop where pages are continuously rendered/destroyed, if certain circumstances are met:
- The screen resolution is sufficiently large (a large height is especially relevant).
- The height of the pages in the PDF file are short (e.g. pages rotated to landscape orientation).
- The zoom level is sufficiently small.

When all of the above criteria are met at the same time, the number of pages simultaneously visible in the viewer can easily exceed `CACHE_SIZE`. This will cause the rendering to constantly cycle through the visible pages.<sup>1</sup>
Provided that the screen resolution is large enough, this can be tested using e.g. https://www.cosic.esat.kuleuven.be/ecrypt/AESday/slides/Use_of_the_AES_Instruction_Set.pdf#page=1&zoom=25. For me, this looks as in the screen-shot below.<sup>2</sup>

This issue has always existed, since `CACHE_SIZE` is a set number while the number of simultaneously visible pages will obviously vary. However with the recent PR #4937, the risk that people will actually come across this is now, in my opinion, large enough that we should try and do something to address this.

This PR is my suggestion of a solution to the problem. Obviously this will increase the memory usage in the edge-cases where the number of visible pages exceeds `CACHE_SIZE`, but I think that this is definitely preferred to an infinite rendering loop.

__
[1] This issue has actually been described previously in https://github.com/mozilla/pdf.js/pull/4524#issuecomment-38802625.

[2] ![infinite_render_loop](https://cloud.githubusercontent.com/assets/2692120/3278721/473a2f92-f3cf-11e3-99bd-1638af1d5f82.png)
