### PR TITLE
Replace curly quotes by regular quotes for searching

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -109,6 +109,12 @@ var PDFFindController = {
       query = query.toLowerCase();
     }
 
+    // Replace curly quotes by regular quotes
+    pageContent = pageContent.replace(/[\u2018\u2019]/g, '\'')
+                             .replace(/[\u201C\u201D]/g, '"');
+    query = query.replace(/[\u2018\u2019]/g, '\'')
+                 .replace(/[\u201C\u201D]/g, '"');
+
     var matches = [];
 
     var matchIdx = -queryLen;


### PR DESCRIPTION
Fixes #1399.

Note that this fixes searching not only for the document referenced in the issue, but also for many other documents that I have encountered on the internet. Lots of documents use curly quotes, but almost no one uses those when searching.
