### PR TITLE
Toolbar configuration

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -122,6 +122,65 @@ PDFJS.disableCreateObjectURL = (PDFJS.disableCreateObjectURL === undefined ?
 PDFJS.disableWebGL = (PDFJS.disableWebGL === undefined ?
                       true : PDFJS.disableWebGL);
 
+
+/**                  
+ * Disable the download function.
+ * @var {boolean}
+ */
+PDFJS.disableDownload = (PDFJS.disableDownload === undefined ?
+                        false : PDFJS.disableDownload);
+
+/**
+ * Disable the print function.
+ * @var {boolean}
+ */
+PDFJS.disablePrinting = (PDFJS.disablePrinting === undefined ?
+                        false : PDFJS.disablePrinting);
+
+
+/**
+ * Disable the open function.
+ * @var {boolean}
+ */
+PDFJS.disableOpenFile = (PDFJS.disableOpenFile === undefined ?
+                        false : PDFJS.disableOpenFile);
+
+/**
+ * Disable the showProperties function.
+ * @var {boolean}
+ */
+PDFJS.disableShowProperties = (PDFJS.disableShowProperties === undefined ?
+                              false : PDFJS.disableShowProperties);
+
+/**
+ * Disables the textSelection function.
+ * @var {boolean}
+ */
+PDFJS.disableSearch = (PDFJS.disableSearch === undefined ?
+                      false : PDFJS.disableSearch);
+
+/**
+ * Disables the presentationMode function.
+ * @var {boolean}
+ */
+PDFJS.disablePresentationMode = (PDFJS.disablePresentationMode === undefined ?
+                                false : PDFJS.disabelPresentationMode);
+
+/**
+ * Forces the HandTool to be active.
+ * @var {boolean}
+ */
+PDFJS.forceHandTool = (PDFJS.forceHandTool === undefined ?
+                      false : PDFJS.forceHandTool);
+
+/**
+ * Disables the viewBookmark function.
+ * @var {boolean}
+ */
+PDFJS.disableViewBookmark = (PDFJS.disableViewBookmark === undefined ?
+                            false : PDFJS.disableViewBookmark);
+
+
 /**
  * Enables CSS only zooming.
  * @var {boolean}

--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -78,6 +78,10 @@ var DownloadManager = (function DownloadManagerClosure() {
     },
 
     download: function DownloadManager_download(blob, url, filename) {
+      if (PDFJS.disableDownload) {
+        return;
+      }
+
       if (!URL) {
         // URL.createObjectURL is not supported
         this.downloadUrl(url, filename);

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -99,6 +99,10 @@ var DownloadManager = (function DownloadManagerClosure() {
     },
 
     download: function DownloadManager_download(blob, url, filename) {
+      if (PDFJS.disableDownload) {
+        return;
+      }
+
       var blobUrl = window.URL.createObjectURL(blob);
 
       FirefoxCom.request('download', {

--- a/web/hand_tool.js
+++ b/web/hand_tool.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals mozL10n, GrabToPan, PDFView, Preferences, SecondaryToolbar */
+/* globals mozL10n, GrabToPan, PDFJS, PDFView, Preferences, SecondaryToolbar */
 
 'use strict';
 
@@ -55,7 +55,9 @@ var HandTool = {
   },
 
   toggle: function handToolToggle() {
-    this.handTool.toggle();
+    if (!PDFJS.forceHandTool) {
+      this.handTool.toggle();
+    }
     SecondaryToolbar.close();
   },
 

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFView, SCROLLBAR_PADDING */
+/* globals PDFJS, PDFView, SCROLLBAR_PADDING */
 
 'use strict';
 
@@ -72,22 +72,30 @@ var SecondaryToolbar = {
 
   // Event handling functions.
   presentationModeClick: function secondaryToolbarPresentationModeClick(evt) {
-    this.presentationMode.request();
+    if (!PDFJS.disablePresentationMode) {
+      this.presentationMode.request();
+    }
     this.close();
   },
 
   openFileClick: function secondaryToolbarOpenFileClick(evt) {
-    document.getElementById('fileInput').click();
+    if (!PDFJS.disableOpenFile) {
+      document.getElementById('fileInput').click();
+    }
     this.close();
   },
 
   printClick: function secondaryToolbarPrintClick(evt) {
-    window.print();
+    if (!PDFJS.disablePrinting) {
+      window.print();
+    }
     this.close();
   },
 
   downloadClick: function secondaryToolbarDownloadClick(evt) {
-    PDFView.download();
+    if (!PDFJS.disableDownload) {
+      PDFView.download();
+    }
     this.close();
   },
 
@@ -114,7 +122,9 @@ var SecondaryToolbar = {
   },
 
   documentPropertiesClick: function secondaryToolbarDocumentPropsClick(evt) {
-    this.documentProperties.open();
+    if (!PDFJS.disableShowProperties) {
+      this.documentProperties.open();
+    }
     this.close();
   },
 

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1839,6 +1839,11 @@ html[dir='rtl'] #documentPropertiesOverlay .row > * {
     top: 0;
     left: 0;
   }
+  
+  /*Rule for printing an empty page if printing is disabled*/
+  .noprint {
+    display:none;
+  }
 }
 
 .visibleLargeView,

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -698,6 +698,9 @@ var PDFView = {
   },
 
   download: function pdfViewDownload() {
+    if (PDFJS.disableDownload) {
+      return;
+    }
     function downloadByUrl() {
       downloadManager.downloadUrl(url, filename);
     }
@@ -1757,6 +1760,40 @@ function webViewerInitialized() {
     PDFJS.disableWebGL = (hashParams['webgl'] !== 'true');
   }
 
+  if ('disableDownload' in hashParams) {
+    PDFJS.disableDownload = (hashParams['disableDownload'] === 'true');
+  }
+  
+  if ('disablePrinting' in hashParams) {
+    PDFJS.disablePrinting = (hashParams['disablePrinting'] === 'true');
+  }
+  
+  if ('disableOpenFile'in hashParams) {
+    PDFJS.disableOpenFile = (hashParams['disableOpenFile'] === 'true');
+  }
+  
+  if ('disableSearch' in hashParams) {
+    PDFJS.disableSearch = (hashParams['disableSearch'] === 'true');
+  }
+  
+  if ('disableShowProperties' in hashParams) {
+    PDFJS.disableShowProperties =
+                  (hashParams['disableShowProperties'] === 'true');
+  }
+  
+  if ('disablePresentationMode' in hashParams) {
+    PDFJS.disablePresentationMode =
+                (hashParams['disablePresentationMode'] === 'true');
+  }
+  
+  if ('forceHandTool' in hashParams) {
+    PDFJS.forceHandTool = (hashParams['forceHandTool'] === 'true');
+  }
+  
+  if ('disableViewBookmark' in hashParams) {
+    PDFJS.disableViewBookmark = (hashParams['disableViewBookmark'] === 'true');
+  }
+  
   if ('useOnlyCssZoom' in hashParams) {
     PDFJS.useOnlyCssZoom = (hashParams['useOnlyCssZoom'] === 'true');
   }
@@ -1819,18 +1856,49 @@ function webViewerInitialized() {
     PDFBug.init();
   }
 
-  if (!PDFView.supportsPrinting) {
+  if (!PDFView.supportsPrinting || PDFJS.disablePrinting) {
     document.getElementById('print').classList.add('hidden');
     document.getElementById('secondaryPrint').classList.add('hidden');
+  
+    if (PDFJS.disablePrinting) {
+      document.getElementsByTagName('body')[0].classList.add('noprint');
+    }
+  }
+  
+  if (PDFJS.disableOpenFile) {
+    document.getElementById('openFile').classList.add('hidden');
+    document.getElementById('secondaryOpenFile').classList.add('hidden');
+  }
+  
+  if (PDFJS.disableDownload) {
+    document.getElementById('download').classList.add('hidden');
+    document.getElementById('secondaryDownload').classList.add('hidden');
+  }
+  
+  if (PDFJS.disableShowProperties) {
+    document.getElementById('documentProperties').classList.add('hidden');
   }
 
-  if (!PDFView.supportsFullscreen) {
+  if (PDFJS.forceHandTool) {
+    // hide the handTool button and the following separator
+    var handToolElement = document.getElementById('toggleHandTool');
+    handToolElement.classList.add('hidden');
+    handToolElement.nextElementSibling.classList.add('hidden');
+    HandTool.handTool.activate();
+  }
+
+  if (PDFJS.disableViewBookmark) {
+    document.getElementById('viewBookmark').classList.add('hidden');
+    document.getElementById('secondaryViewBookmark').classList.add('hidden');
+  }
+
+  if (!PDFView.supportsFullscreen || PDFJS.disablePresentationMode) {
     document.getElementById('presentationMode').classList.add('hidden');
     document.getElementById('secondaryPresentationMode').
       classList.add('hidden');
   }
 
-  if (PDFView.supportsIntegratedFind) {
+  if (PDFView.supportsIntegratedFind || PDFJS.disableSearch) {
     document.getElementById('viewFind').classList.add('hidden');
   }
 
@@ -2213,13 +2281,13 @@ window.addEventListener('keydown', function keydown(evt) {
     // either CTRL or META key with optional SHIFT.
     switch (evt.keyCode) {
       case 70: // f
-        if (!PDFView.supportsIntegratedFind) {
+        if (!PDFView.supportsIntegratedFind && !PDFJS.disableSearch) {
           PDFFindBar.open();
           handled = true;
         }
         break;
       case 71: // g
-        if (!PDFView.supportsIntegratedFind) {
+        if (!PDFView.supportsIntegratedFind && !PDFJS.disableSearch) {
           PDFFindBar.dispatchEvent('again', cmd === 5 || cmd === 12);
           handled = true;
         }


### PR DESCRIPTION
Added several new configuration options for the toolbar via hashParams:
disableDownload=true: Hides the download button and disables the download functionality
disablePrinting=true: Hides the print button and disables printing functionality.
disableOpenFile=true: Hides the open file button.
disableSearch=true: Hides the search field and disables the search functionality. 
disableShowProperties=true: Hides the show properties button
disablePresentationMode=true: Hides the fullscreen button
disableViewBookmark=true: Hides the bookmark button.
forceHandTool=true: forces the handtool to be active and hides the handtool button.
