### PR TITLE
Disable the developer hash parameters by default in PRODUCTION builds of PDF.js

### DIFF
--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -348,9 +348,6 @@ ChromeActions.prototype = {
       return 'null';
     }
   },
-  pdfBugEnabled: function() {
-    return getBoolPref(PREF_PREFIX + '.pdfBugEnabled', false);
-  },
   supportsIntegratedFind: function() {
     // Integrated find is only supported when we're not in a frame
     if (this.domWindow.frameElement !== null) {

--- a/web/default_preferences.js
+++ b/web/default_preferences.js
@@ -24,6 +24,7 @@ var DEFAULT_PREFERENCES = {
   sidebarViewOnLoad: 0,
   enableHandToolOnLoad: false,
   enableWebGL: false,
+  pdfBugEnabled: false,
   disableRange: false,
   disableAutoFetch: false,
   disableFontFace: false,

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -228,6 +228,9 @@ var PDFView = {
       Preferences.get('sidebarViewOnLoad').then(function resolved(value) {
         self.preferenceSidebarViewOnLoad = value;
       }),
+      Preferences.get('pdfBugEnabled').then(function resolved(value) {
+        self.preferencesPdfBugEnabled = value;
+      }),
       Preferences.get('disableTextLayer').then(function resolved(value) {
         if (PDFJS.disableTextLayer === true) {
           return;
@@ -1810,7 +1813,7 @@ function webViewerInitialized() {
 //#if !(FIREFOX || MOZCENTRAL)
   if ('pdfBug' in hashParams) {
 //#else
-//if ('pdfBug' in hashParams && FirefoxCom.requestSync('pdfBugEnabled')) {
+//if ('pdfBug' in hashParams && PDFView.preferencesPdfBugEnabled) {
 //#endif
     PDFJS.pdfBug = true;
     var pdfBug = hashParams['pdfBug'];

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1732,60 +1732,81 @@ function webViewerInitialized() {
 //document.getElementById('secondaryOpenFile').setAttribute('hidden', 'true');
 //#endif
 
-  // Special debugging flags in the hash section of the URL.
-  var hash = document.location.hash.substring(1);
-  var hashParams = PDFView.parseQueryString(hash);
-
-  if ('disableWorker' in hashParams) {
-    PDFJS.disableWorker = (hashParams['disableWorker'] === 'true');
-  }
-
-  if ('disableRange' in hashParams) {
-    PDFJS.disableRange = (hashParams['disableRange'] === 'true');
-  }
-
-  if ('disableAutoFetch' in hashParams) {
-    PDFJS.disableAutoFetch = (hashParams['disableAutoFetch'] === 'true');
-  }
-
-  if ('disableFontFace' in hashParams) {
-    PDFJS.disableFontFace = (hashParams['disableFontFace'] === 'true');
-  }
-
-  if ('disableHistory' in hashParams) {
-    PDFJS.disableHistory = (hashParams['disableHistory'] === 'true');
-  }
-
-  if ('webgl' in hashParams) {
-    PDFJS.disableWebGL = (hashParams['webgl'] !== 'true');
-  }
-
-  if ('useOnlyCssZoom' in hashParams) {
-    PDFJS.useOnlyCssZoom = (hashParams['useOnlyCssZoom'] === 'true');
-  }
-
-  if ('verbosity' in hashParams) {
-    PDFJS.verbosity = hashParams['verbosity'] | 0;
-  }
-
-  if ('ignoreCurrentPositionOnZoom' in hashParams) {
-    IGNORE_CURRENT_POSITION_ON_ZOOM =
-      (hashParams['ignoreCurrentPositionOnZoom'] === 'true');
-  }
-
-//#if !PRODUCTION
-  if ('disableBcmaps' in hashParams && hashParams['disableBcmaps']) {
-    PDFJS.cMapUrl = '../external/cmaps/';
-    PDFJS.cMapPacked = false;
-  }
-//#endif
-
-
 //#if !(FIREFOX || MOZCENTRAL)
   var locale = PDFJS.locale || navigator.language;
-  if ('locale' in hashParams) {
-    locale = hashParams['locale'];
+//#endif
+
+//#if !PRODUCTION
+  if (true) {
+//#else
+//if (PDFView.preferencesPdfBugEnabled) {
+//#endif
+    // Special debugging flags in the hash section of the URL.
+    var hash = document.location.hash.substring(1);
+    var hashParams = PDFView.parseQueryString(hash);
+
+    if ('disableWorker' in hashParams) {
+      PDFJS.disableWorker = (hashParams['disableWorker'] === 'true');
+    }
+    if ('disableRange' in hashParams) {
+      PDFJS.disableRange = (hashParams['disableRange'] === 'true');
+    }
+    if ('disableAutoFetch' in hashParams) {
+      PDFJS.disableAutoFetch = (hashParams['disableAutoFetch'] === 'true');
+    }
+    if ('disableFontFace' in hashParams) {
+      PDFJS.disableFontFace = (hashParams['disableFontFace'] === 'true');
+    }
+    if ('disableHistory' in hashParams) {
+      PDFJS.disableHistory = (hashParams['disableHistory'] === 'true');
+    }
+    if ('webgl' in hashParams) {
+      PDFJS.disableWebGL = (hashParams['webgl'] !== 'true');
+    }
+    if ('useOnlyCssZoom' in hashParams) {
+      PDFJS.useOnlyCssZoom = (hashParams['useOnlyCssZoom'] === 'true');
+    }
+    if ('verbosity' in hashParams) {
+      PDFJS.verbosity = hashParams['verbosity'] | 0;
+    }
+    if ('ignoreCurrentPositionOnZoom' in hashParams) {
+      IGNORE_CURRENT_POSITION_ON_ZOOM =
+        (hashParams['ignoreCurrentPositionOnZoom'] === 'true');
+    }
+//#if !PRODUCTION
+    if ('disableBcmaps' in hashParams && hashParams['disableBcmaps']) {
+      PDFJS.cMapUrl = '../external/cmaps/';
+      PDFJS.cMapPacked = false;
+    }
+//#endif
+//#if !(FIREFOX || MOZCENTRAL)
+    if ('locale' in hashParams) {
+      locale = hashParams['locale'];
+    }
+//#endif
+    if ('textLayer' in hashParams) {
+      switch (hashParams['textLayer']) {
+        case 'off':
+          PDFJS.disableTextLayer = true;
+          break;
+        case 'visible':
+        case 'shadow':
+        case 'hover':
+          var viewer = document.getElementById('viewer');
+          viewer.classList.add('textLayer-' + hashParams['textLayer']);
+          break;
+      }
+    }
+    if ('pdfBug' in hashParams) {
+      PDFJS.pdfBug = true;
+      var pdfBug = hashParams['pdfBug'];
+      var enabled = pdfBug.split(',');
+      PDFBug.enable(enabled);
+      PDFBug.init();
+    }
   }
+
+//#if !(FIREFOX || MOZCENTRAL)
   mozL10n.setLanguage(locale);
 //#endif
 //#if (FIREFOX || MOZCENTRAL)
@@ -1795,32 +1816,6 @@ function webViewerInitialized() {
 //    'Web fonts are disabled: unable to use embedded PDF fonts.'));
 //}
 //#endif
-
-  if ('textLayer' in hashParams) {
-    switch (hashParams['textLayer']) {
-      case 'off':
-        PDFJS.disableTextLayer = true;
-        break;
-      case 'visible':
-      case 'shadow':
-      case 'hover':
-        var viewer = document.getElementById('viewer');
-        viewer.classList.add('textLayer-' + hashParams['textLayer']);
-        break;
-    }
-  }
-
-//#if !(FIREFOX || MOZCENTRAL)
-  if ('pdfBug' in hashParams) {
-//#else
-//if ('pdfBug' in hashParams && PDFView.preferencesPdfBugEnabled) {
-//#endif
-    PDFJS.pdfBug = true;
-    var pdfBug = hashParams['pdfBug'];
-    var enabled = pdfBug.split(',');
-    PDFBug.enable(enabled);
-    PDFBug.init();
-  }
 
   if (!PDFView.supportsPrinting) {
     document.getElementById('print').classList.add('hidden');


### PR DESCRIPTION
This PR adds a `pdfBugEnabled` preference, which in `PRODUCTION` builds must be set in order to enable the developer hash parameters.

Fixes #4954.

_Note:_ To simplify development/debugging, I purposely left the hash parameters enabled by default when the viewer is used in non-production mode, e.g. with `node make server`.

**Edit:** Simpler reviewing with https://github.com/mozilla/pdf.js/pull/4956/files?w=1
