### PR TITLE
Zero the height and width of cached canvases before deleting them.

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -179,7 +179,14 @@ var CachedCanvases = (function CachedCanvasesClosure() {
       return canvasEntry;
     },
     clear: function () {
-      cache = {};
+      for (var id in cache) {
+        var canvasEntry = cache[id];
+        // Zeroing the width and height causes Firefox to release graphics
+        // resources immediately, which can greatly reduce memory consumption.
+        canvasEntry.canvas.width = 0;
+        canvasEntry.canvas.height = 0;
+        delete cache[id];
+      }
     }
   };
 })();


### PR DESCRIPTION
This is exactly the same idea as #4920, but for CachedCanvases.

This reduces peak RSS from ~1400 MiB to ~1100 MiB on my Mac when scrolling slowly through
the first 30 pages of a scanned black and white document.
