### PR TITLE
Implements onerror for JpegStreams

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1562,5 +1562,9 @@ function loadJpegStream(id, imageUrl, objs) {
   img.onload = (function loadJpegStream_onloadClosure() {
     objs.resolve(id, img);
   });
+  img.onerror = (function loadJpegStream_onerrorClosure() {
+    objs.resolve(id, null);
+    warn('Error during JPEG image loading');
+  });
   img.src = imageUrl;
 }


### PR DESCRIPTION
Partly addresses #2812. It resolves the infinite loop and renders everything but the images.

Thanks to @yurydelendik for helping with debugging this!
