### PR TITLE
Avoid allocating return object in EvaluatorPreprocessor_read().

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -638,9 +638,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
       return new Promise(function next(resolve, reject) {
         timeSlotManager.reset();
-        var stop, operation, i, ii, cs;
+        var stop, operation = {}, i, ii, cs;
         while (!(stop = timeSlotManager.check()) &&
-               (operation = preprocessor.read())) {
+               preprocessor.read(operation)) {
           var args = operation.args;
           var fn = operation.fn;
 
@@ -894,7 +894,6 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
       var preprocessor = new EvaluatorPreprocessor(stream, xref, stateManager);
 
-      var operation;
       var textState;
 
       function newTextChunk() {
@@ -1029,9 +1028,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
       return new Promise(function next(resolve, reject) {
         timeSlotManager.reset();
-        var stop;
+        var stop, operation = {};
         while (!(stop = timeSlotManager.check()) &&
-               (operation = preprocessor.read())) {
+               (preprocessor.read(operation))) {
           textState = stateManager.state;
           var fn = operation.fn;
           var args = operation.args;
@@ -2096,12 +2095,12 @@ var EvaluatorPreprocessor = (function EvaluatorPreprocessorClosure() {
       return this.stateManager.stateStack.length;
     },
 
-    read: function EvaluatorPreprocessor_read() {
+    read: function EvaluatorPreprocessor_read(operation) {
       var args = [];
       while (true) {
         var obj = this.parser.getObj();
         if (isEOF(obj)) {
-          return null; // no more commands
+          return false; // no more commands
         }
         if (!isCmd(obj)) {
           // argument
@@ -2152,7 +2151,9 @@ var EvaluatorPreprocessor = (function EvaluatorPreprocessorClosure() {
         // TODO figure out how to type-check vararg functions
         this.preprocessCommand(fn, args);
 
-        return { fn: fn, args: args };
+        operation.fn = fn;
+        operation.args = args;
+        return true;
       }
     },
 


### PR DESCRIPTION
This function can be called 100s of 1000s or even millions of times, and the
allocated return object accounts for 10% of all GC thing allocations for some
documents. It's easy to avoid, which reduces stress on the garbage collector,
and this patch does that.
