### PR TITLE
Additional heuristics to recognize unknown glyphs for toUnicode (bug 1027533)

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -4295,6 +4295,12 @@ var Font = (function FontClosure() {
                 (code = parseInt(glyphName.substr(1), 16))) {
               toUnicode[charcode] = String.fromCharCode(code);
             }
+            // g00xx glyph
+            if (glyphName.length === 5 &&
+                glyphName[0] === 'g' &&
+                (code = parseInt(glyphName.substr(1), 16))) {
+              toUnicode[charcode] = String.fromCharCode(code);
+            }
             // Cddd glyph
             if (glyphName.length >= 3 &&
                 glyphName[0] === 'C' &&


### PR DESCRIPTION
With the introduction of `adjustMapping` in PR #4259, for certain fonts we are now a lot more dependent on the existence (and correctness) of `toUnicode`; see e.g. [fonts.js#L2479](https://github.com/mozilla/pdf.js/blob/master/src/core/fonts.js#L2479).

For [the PDF file referenced in the bug](http://studioforcreativeinquiry.org/public/warhol_amiga_report_v10.pdf), the `toUnicode` entries are of the form `g00xx`, so I've simply extended the heuristics to deal with that particular case of bad Unicode data.

_Note:_ This patch still doesn't really fix copying. It's now possible to select the text, but you only get junk when copying (however this is also the case in Adobe Reader).

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1027533.
