### PR TITLE
Misc SVG Viewer example fixes

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -132,6 +132,12 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
     restore: function SVGGraphics_restore() {
       this.transformMatrix = this.transformStack.pop();
       this.current = this.extraStack.pop();
+
+      this.tgrp = document.createElementNS(NS, 'svg:g');
+      this.tgrp.setAttributeNS(null, 'id', 'transform');
+      this.tgrp.setAttributeNS(null, 'transform',
+          'matrix(' + this.transformMatrix + ')');
+      this.pgrp.appendChild(this.tgrp);
     },
 
     group: function SVGGraphics_group(items) {
@@ -669,7 +675,6 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
     },
 
     rectangle: function SVGGraphics_rectangle(x, y, width, height) {
-      this.save();
       var current = this.current;
       if (width < 0) {
         x = x + width;


### PR DESCRIPTION
Adds query parameters: `file` to specify different file and `scale` change the scale. Hash can be used to navigate to the page. Example: `http://localhost:8888/examples/svgviewer/index.html?scale=1.5&file=/web/compressed.tracemonkey-pldi-09.pdf#page=3`.

Also, fixed mistake in the rectange and restore.
