### PR TITLE
Group 'rectangle' operator into constructPath

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -852,6 +852,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
             case OPS.closePath:
               self.buildPath(operatorList, fn, args);
               continue;
+            case OPS.rectangle:
+              self.buildPath(operatorList, fn, args);
+              continue;
           }
           operatorList.addOp(fn, args);
         }

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -977,6 +977,26 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       var x = current.x, y = current.y;
       for (var i = 0, j = 0, ii = ops.length; i < ii; i++) {
         switch (ops[i] | 0) {
+          case OPS.rectangle:
+            x = args[j++];
+            y = args[j++];
+            var width = args[j++];
+            var height = args[j++];
+            if (width === 0) {
+              width = this.getSinglePixelWidth();
+            }
+            if (height === 0) {
+              height = this.getSinglePixelWidth();
+            }
+            var xw = x + width;
+            var yh = y + height;
+            this.ctx.moveTo(x, y);
+            this.ctx.lineTo(xw, y);
+            this.ctx.lineTo(xw, yh);
+            this.ctx.lineTo(x, yh);
+            this.ctx.lineTo(x, y);
+            this.ctx.closePath();
+            break;
           case OPS.moveTo:
             x = args[j++];
             y = args[j++];
@@ -1016,16 +1036,6 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     },
     closePath: function CanvasGraphics_closePath() {
       this.ctx.closePath();
-    },
-    rectangle: function CanvasGraphics_rectangle(x, y, width, height) {
-      if (width === 0) {
-        width = this.getSinglePixelWidth();
-      }
-      if (height === 0) {
-        height = this.getSinglePixelWidth();
-      }
-
-      this.ctx.rect(x, y, width, height);
     },
     stroke: function CanvasGraphics_stroke(consumePath) {
       consumePath = typeof consumePath !== 'undefined' ? consumePath : true;
@@ -1510,7 +1520,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
                                                                         ury) {
       // TODO According to the spec we're also suppose to ignore any operators
       // that set color or include images while processing this type3 font.
-      this.rectangle(llx, lly, urx - llx, ury - lly);
+      this.ctx.rect(llx, lly, urx - llx, ury - lly);
       this.clip();
       this.endPath();
     },
@@ -1603,7 +1613,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       if (isArray(bbox) && 4 === bbox.length) {
         var width = bbox[2] - bbox[0];
         var height = bbox[3] - bbox[1];
-        this.rectangle(bbox[0], bbox[1], width, height);
+        this.ctx.rect(bbox[0], bbox[1], width, height);
         this.clip();
         this.endPath();
       }
@@ -1755,7 +1765,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       if (isArray(rect) && 4 === rect.length) {
         var width = rect[2] - rect[0];
         var height = rect[3] - rect[1];
-        this.rectangle(rect[0], rect[1], width, height);
+        this.ctx.rect(rect[0], rect[1], width, height);
         this.clip();
         this.endPath();
       }

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -385,7 +385,7 @@ var TilingPattern = (function TilingPatternClosure() {
       if (bbox && isArray(bbox) && 4 == bbox.length) {
         var bboxWidth = x1 - x0;
         var bboxHeight = y1 - y0;
-        graphics.rectangle(x0, y0, bboxWidth, bboxHeight);
+        graphics.ctx.rect(x0, y0, bboxWidth, bboxHeight);
         graphics.clip();
         graphics.endPath();
       }

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -321,9 +321,6 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
           case OPS.constructPath:
             this.constructPath(args[0], args[1]);
             break;
-          case OPS.rectangle:
-            this.rectangle(args[0], args[1], args[2], args[3]);
-            break;
           case 92:
             this.group(opTree[x].items);
             break;
@@ -524,6 +521,17 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
 
       for (var i = 0, j = 0; i < opLength; i++) {
         switch (ops[i] | 0) {
+          case OPS.rectangle:
+            x = args[j++];
+            y = args[j++];
+            var width = args[j++];
+            var height = args[j++];
+            var xw = x + width;
+            var yh = y + height;
+            d += 'M' + x + ' ' + y + 'L' + xw + ' ' + y +
+                 'L' + xw + ' ' + yh + 'L' + xw + ' ' + yh +
+                 'L' + x + ' ' + yh + ' ' + 'Z';
+            break;
           case OPS.moveTo:
             x = args[j++];
             y = args[j++];
@@ -567,6 +575,7 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
       current.path.setAttributeNS(null, 'stroke-width', current.lineWidth);
       current.path.setAttributeNS(null, 'stroke-dasharray', current.dashArray);
       current.path.setAttributeNS(null, 'stroke-dashoffset', current.dashPhase);
+      current.path.setAttributeNS(null, 'fill', 'none');
       this.tgrp.appendChild(current.path);
       // Saving a reference in current.element so that it can be addressed
       // in 'fill' and 'stroke'
@@ -672,28 +681,6 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
     closeFillStroke: function SVGGraphics_closeFillStroke() {
       this.closePath();
       this.fillStroke();
-    },
-
-    rectangle: function SVGGraphics_rectangle(x, y, width, height) {
-      var current = this.current;
-      if (width < 0) {
-        x = x + width;
-        width = -width;
-      }
-      if (height < 0) {
-        y = y + height;
-        height = -height;
-      }
-      current.rect = document.createElementNS(NS, 'svg:rect');
-      current.rect.setAttributeNS(null, 'x', x);
-      current.rect.setAttributeNS(null, 'y', y);
-      current.rect.setAttributeNS(null, 'fill', 'none');
-      current.rect.setAttributeNS(null, 'width', width);
-      current.rect.setAttributeNS(null, 'height', height);
-      current.rect.setAttributeNS(null, 'stroke-width', current.lineWidth);
-      // Saving a reference in current.element so that it can be addressed
-      // in 'fill' or 'stroke'
-      current.element = current.rect;
     },
   };
   return SVGGraphics;


### PR DESCRIPTION
This groups the 'rectangle' operator into the constructPath operations (moveto, lineto, etc.), eliminating the same. 
