### PR TITLE
[SVG] Optimization of save/restore usage, Addition of paint methods

### DIFF
--- a/examples/svgviewer/viewer.js
+++ b/examples/svgviewer/viewer.js
@@ -53,7 +53,7 @@ PDFJS.getDocument(url).then(function(pdf) {
         };
         // the next page fetch will start only after this page rendering is done
         return page.getOperatorList().then(function (opList) {
-          var svgGfx = new SVGGraphics(page.commonObjs);
+          var svgGfx = new SVGGraphics(page.commonObjs, page.objs);
           return svgGfx.loadDependencies(opList).then(function (values) {
             return svgGfx.beginDrawing(renderContext.viewport,
               renderContext.pageNum, renderContext.container, opList);

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -134,7 +134,6 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
       this.current = this.extraStack.pop();
 
       this.tgrp = document.createElementNS(NS, 'svg:g');
-      this.tgrp.setAttributeNS(null, 'id', 'transform');
       this.tgrp.setAttributeNS(null, 'transform',
           'matrix(' + this.transformMatrix + ')');
       this.pgrp.appendChild(this.tgrp);
@@ -176,7 +175,6 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
         transformMatrix);
 
       this.tgrp = document.createElementNS(NS, 'svg:g');
-      this.tgrp.setAttributeNS(null, 'id', 'transform');
       this.tgrp.setAttributeNS(null, 'transform',
         'matrix(' + this.transformMatrix + ')');
       this.pgrp.appendChild(this.tgrp);
@@ -385,7 +383,6 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
     },
 
     showText: function SVGGraphics_showText(glyphs) {
-      this.save();
       var current = this.current;
       var font = current.font;
       var fontSize = current.fontSize;
@@ -438,13 +435,10 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
         'matrix(' + current.textMatrix + ') scale(1, -1)' );
       current.txtElement.setAttributeNS(XML_NS, 'xml:space', 'preserve');
       current.txtElement.appendChild(current.tspan);
-
-      current.txtgrp.setAttributeNS(null, 'id', 'text');
       current.txtgrp.appendChild(current.txtElement);
 
       this.tgrp.appendChild(current.txtElement);
 
-      this.restore();
     },
     
     setLeadingMoveText: function SVGGraphics_setLeadingMoveText(x, y) {
@@ -644,28 +638,22 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
     },
 
     fill: function SVGGraphics_fill() {
-      this.save();
       var current = this.current;
       current.element.setAttributeNS(null, 'fill', current.fillColor);
       this.tgrp.appendChild(current.element);
-      this.restore();
     },
 
     stroke: function SVGGraphics_stroke() {
-      this.save();
       var current = this.current;
       current.element.setAttributeNS(null, 'stroke', current.strokeColor);
       current.element.setAttributeNS(null, 'fill', 'none');
       this.tgrp.appendChild(current.element);
-      this.restore();
     },
 
     eoFill: function SVGGraphics_eoFill() {
-      this.save();
       var current = this.current;
       current.element.setAttributeNS(null, 'fill', current.fillColor);
       current.element.setAttributeNS(null, 'fill-rule', 'evenodd');
-      this.restore();
     },
 
     fillStroke: function SVGGraphics_fillStroke() {

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -300,6 +300,9 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
           case OPS.fillStroke:
             this.fillStroke();
             break;
+          case OPS.paintSolidColorImageMask:
+            this.paintSolidColorImageMask();
+            break;
           case OPS.closePath:
             this.closePath();
             break;
@@ -669,6 +672,17 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
     closeFillStroke: function SVGGraphics_closeFillStroke() {
       this.closePath();
       this.fillStroke();
+    },
+    paintSolidColorImageMask:
+      function SVGGraphics_paintSolidColorImageMask() {
+        var current = this.current;
+        var rect = document.createElementNS(NS, 'svg:rect');
+        rect.setAttributeNS(null, 'x', 0);
+        rect.setAttributeNS(null, 'y', 0);
+        rect.setAttributeNS(null, 'width', 1);
+        rect.setAttributeNS(null, 'height', 1);
+        rect.setAttributeNS(null, 'fill', current.fillColor);
+        this.tgrp.appendChild(rect);
     },
   };
   return SVGGraphics;


### PR DESCRIPTION
1stt commit: Removed some unwated 'this.save()' and 'this.restore()' commands;
2nd and 3rd commits: Added support for paintSolidColorImageMask & paintJpegXObject

Test pdf: Default pdf (liveprogramming.pdf) - page 25
