### PR TITLE
Do not run cleanup while printing is ongoing.

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -117,6 +117,7 @@ var PDFView = {
   fellback: false,
   pdfDocument: null,
   sidebarOpen: false,
+  printing: false,
   pageViewScroll: null,
   thumbnailViewScroll: null,
   pageRotation: 0,
@@ -1256,6 +1257,11 @@ var PDFView = {
       }
     }
 
+    if (this.printing) {
+      // If printing is currently ongoing do not reschedule cleanup.
+      return;
+    }
+
     PDFView.idleTimeout = setTimeout(function () {
       PDFView.cleanup();
     }, CLEANUP_TIMEOUT);
@@ -1565,6 +1571,9 @@ var PDFView = {
       return;
     }
 
+    this.printing = true;
+    this.renderHighestPriority();
+
     var body = document.querySelector('body');
     body.setAttribute('data-mozPrintCallback', true);
     for (i = 0, ii = this.pages.length; i < ii; ++i) {
@@ -1583,6 +1592,9 @@ var PDFView = {
     while (div.hasChildNodes()) {
       div.removeChild(div.lastChild);
     }
+
+    this.printing = false;
+    this.renderHighestPriority();
   },
 
   rotatePages: function pdfViewRotatePages(delta) {


### PR DESCRIPTION
During investigation of #4994 it became clear that one possible problem with fonts in print is that while printing is ongoing a font is removed and reloaded. If cleanup was set to a low number the problem disappeared.

the cleanup was scheduled when no page or thumbnail was rendered. Because printing uses a different mechanism, t could happen that printing occurs at the same time as cleanup. This is consistent with the observation that the error was reproducible after a few tries (most likely just hitting the 30 second mark).

The solution is to not run cleanup while printing is ongoing. Therefor a flag is set and renderHighestPriority() invoked before and after printing.
