### PR TITLE
Faster chunkedStream_getByte()

### DIFF
--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -155,8 +155,15 @@ var ChunkedStream = (function ChunkedStreamClosure() {
       if (pos >= this.end) {
         return -1;
       }
-      this.ensureByte(pos);
-      return this.bytes[this.pos++];
+      var byte = this.bytes[pos];
+      if (byte === 0) {
+        // |byte| might be zero, because the corresponding chunk has not been
+        // loaded yet. In this case, this.ensureByte(pos) will throw an
+        // exception and nothing is returned.
+        this.ensureByte(pos);
+      }
+      this.pos++;
+      return byte;
     },
 
     getUint16: function ChunkedStream_getUint16() {

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals assert, calculateMD5, Catalog, Dict, error, info, isArray,
-           isArrayBuffer, isName, isStream, isString, createPromiseCapability,
+/* globals assert, bytesToString, calculateMD5, Catalog, Dict, error, info,
+           isArray, isArrayBuffer, isName, isStream, isString,
            Linearization, NullStream, PartialEvaluator, shadow, Stream, Lexer,
            StreamsSequenceStream, stringToPDFString, stringToBytes, Util, XRef,
            MissingDataException, Promise, Annotation, ObjectLoader, OperatorList
@@ -301,14 +301,10 @@ var PDFDocument = (function PDFDocumentClosure() {
   function find(stream, needle, limit, backwards) {
     var pos = stream.pos;
     var end = stream.end;
-    var strBuf = [];
     if (pos + limit > end) {
       limit = end - pos;
     }
-    for (var n = 0; n < limit; ++n) {
-      strBuf.push(String.fromCharCode(stream.getByte()));
-    }
-    var str = strBuf.join('');
+    var str = bytesToString(stream.getBytes(limit));
     stream.pos = pos;
     var index = backwards ? str.lastIndexOf(needle) : str.indexOf(needle);
     if (index == -1) {

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -539,12 +539,10 @@ var FlateStream = (function FlateStreamClosure() {
           this.eof = true;
         }
       } else {
-        for (var n = bufferLength; n < end; ++n) {
-          if ((b = str.getByte()) === -1) {
-            this.eof = true;
-            break;
-          }
-          buffer[n] = b;
+        var block = str.getBytes(blockLen);
+        buffer.set(block, bufferLength);
+        if (block.length < blockLen) {
+          this.eof = true;
         }
       }
       return;


### PR DESCRIPTION
Even though #4966 accelerated `ensureRange()` a lot, it is faster to avoid the check altogether. If the byte array is non-zero at the requested position, the data must have been loaded already, so we can skip the range check.

This speeds up some PDFs considerably, for example, page 11 of the [tracemonkey](http://cdn.mozilla.net/pdfjs/tracemonkey.pdf#pdfBug=Stats&page=11&zoom=50) paper now loads 20-30% faster.
