### PR TITLE
Zero the height and width of the WebGL canvases on cleanup

### DIFF
--- a/src/display/webgl.js
+++ b/src/display/webgl.js
@@ -406,6 +406,14 @@ var WebGLUtils = (function WebGLUtilsClosure() {
   }
 
   function cleanup() {
+    if (smaskCache && smaskCache.canvas) {
+      smaskCache.canvas.width = 0;
+      smaskCache.canvas.height = 0;
+    }
+    if (figuresCache && figuresCache.canvas) {
+      figuresCache.canvas.width = 0;
+      figuresCache.canvas.height = 0;
+    }
     smaskCache = null;
     figuresCache = null;
   }


### PR DESCRIPTION
The same idea as PRs #4920 and #4959, but for the temporary canvases used in WebGL assisted rendering.
