### PR TITLE
[SVG] Adds clip operator, fixes setGState, fill, stroke operators

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -61,6 +61,9 @@ var SVGExtraState = (function SVGExtraStateClosure() {
     this.lineJoin = '';
     this.lineCap = '';
     this.miterLimit = 0;
+    
+    this.dashArray = [];
+    this.dashPhase = 0;
 
     // Dependency
     this.dependencies = [];

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -25,8 +25,7 @@ function createScratchSVG(width, height) {
   svg.setAttributeNS(null, 'version', '1.1');
   svg.setAttributeNS(null, 'width', width + 'px');
   svg.setAttributeNS(null, 'height', height + 'px');
-  svg.setAttributeNS(null, 'viewBox', '0 ' + (-height) + ' ' +
-    width + ' ' + height);
+  svg.setAttributeNS(null, 'viewBox', '0 0 ' + width + ' ' + height);
   return svg;
 }
 
@@ -203,8 +202,8 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
       this.viewport = viewport;
       this.transformMatrix = IDENTITY_MATRIX;
       this.pgrp = document.createElementNS(NS, 'svg:g'); // Parent group
-      this.pgrp.setAttributeNS(null, 'transform', 'scale(' + viewport.scale +
-        ',' + -viewport.scale + ')');
+      this.pgrp.setAttributeNS(null, 'transform',
+        'matrix(' + viewport.transform +')');
       this.tgrp = document.createElementNS(NS, 'svg:g'); // Transform group
       this.tgrp.setAttributeNS(null, 'transform',
         'matrix(' + this.transformMatrix +')');
@@ -304,7 +303,7 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
             this.setDash(args[0], args[1]);
             break;
           case OPS.setGState:
-            this.setGState(args);
+            this.setGState(args[0]);
             break;
           case OPS.fill:
             this.fill();
@@ -690,7 +689,7 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
           case 'FL':
             break;
           case 'Font':
-            this.setFont(value[0], value[1]);
+            this.setFont(value);
             break;
           case 'CA':
             break;

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -192,7 +192,6 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
       this.tgrp = document.createElementNS(NS, 'svg:g');
       this.tgrp.setAttributeNS(null, 'transform',
         'matrix(' + this.transformMatrix + ')');
-      this.pgrp.appendChild(this.tgrp);
     },
 
     beginDrawing: function SVGGraphics_beginDrawing(viewport, pageNum,
@@ -266,7 +265,7 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
             this.showText(args[0]);
             break;
           case OPS.endText:
-            this.endText(args);
+            this.endText();
             break;
           case OPS.moveText:
             this.moveText(args[0], args[1]);
@@ -350,6 +349,9 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
             break;
           case OPS.constructPath:
             this.constructPath(args[0], args[1]);
+            break;
+          case OPS.endPath:
+            this.endPath();
             break;
           case 92:
             this.group(opTree[x].items);
@@ -477,7 +479,7 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
       this.tgrp.appendChild(current.txtElement);
 
     },
-    
+
     setLeadingMoveText: function SVGGraphics_setLeadingMoveText(x, y) {
       this.setLeading(-y);
       this.moveText(x, y);
@@ -515,7 +517,14 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
     },
 
     endText: function SVGGraphics_endText(args) {
-      // Empty for now. Not sure how to break showText into this.
+      if (this.current.pendingClip) {
+        this.pgrp.appendChild(this.cgrp);
+      } else {
+        this.pgrp.appendChild(this.tgrp);
+      }
+      this.tgrp = document.createElementNS(NS, 'svg:g');
+      this.tgrp.setAttributeNS(null, 'transform',
+         'matrix(' + this.transformMatrix + ')');
     },
 
     // Path properties
@@ -608,15 +617,31 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
       current.path.setAttributeNS(null, 'stroke-dasharray', current.dashArray);
       current.path.setAttributeNS(null, 'stroke-dashoffset',
         current.dashPhase + 'px');
+      current.path.setAttributeNS(null, 'fill', 'none');
+
+      this.tgrp.appendChild(current.path);
       if (current.pendingClip) {
         this.cgrp.appendChild(this.tgrp);
+        this.pgrp.appendChild(this.cgrp);
+      } else {
+        this.pgrp.appendChild(this.tgrp);
       }
-      current.path.setAttributeNS(null, 'fill', 'none');
-      this.tgrp.appendChild(current.path);
       // Saving a reference in current.element so that it can be addressed
       // in 'fill' and 'stroke'
       current.element = current.path;
       current.setCurrentPoint(x, y);
+    },
+
+    endPath: function SVGGraphics_endPath() {
+      var current = this.current;
+      if (current.pendingClip) {
+        this.pgrp.appendChild(this.cgrp);
+      } else {
+        this.pgrp.appendChild(this.tgrp);
+      }
+      this.tgrp = document.createElementNS(NS, 'svg:g');
+      this.tgrp.setAttributeNS(null, 'transform',
+          'matrix(' + this.transformMatrix + ')');
     },
 
     clip: function SVGGraphics_clip(type) {
@@ -766,10 +791,14 @@ var SVGGraphics = (function SVGGraphicsClosure(ctx) {
        imgEl.setAttributeNS(null, 'y', -h);
        imgEl.setAttributeNS(null, 'transform', 'scale(' + 1 / w +
         ' ' + -1 / h + ')');
+
+       this.tgrp.appendChild(imgEl);
        if (current.pendingClip) {
         this.cgrp.appendChild(this.tgrp);
+        this.pgrp.appendChild(this.cgrp);
+       } else {
+        this.pgrp.appendChild(this.tgrp);
        }
-       this.tgrp.appendChild(imgEl);
     },
   };
   return SVGGraphics;


### PR DESCRIPTION
This PR: 
- Adds support for 'clip' operator (Ref: http://www.jagpdf.org/doc/samples/jagpdf_doc_clipping_path.pdf, http://www.jagpdf.org/samples/imageclip.pdf or PDF 32000 spec document (Page 248) ) 
- Fixes setGState to accept args properly (Ref: /test/pdfs/extgstate.pdf)
- Added some missing properties for text & path element (Ref: /test/pdfs/txt2pdf.pdf)
- Fixed viewport transform to include translate (only scaling was done previously) (Ref: /test/pdfs/jai.pdf)
- Added eoFillStroke method (Ref: /test/pdfs/jai.pdf)
