### PR TITLE
In the reftest analyzer, make it possible to toggle "Circle differences" with the D key

### DIFF
--- a/test/resources/reftest-analyzer.js
+++ b/test/resources/reftest-analyzer.js
@@ -464,6 +464,9 @@ window.onload = function() {
         val = 1;
       }
       document.querySelector('input[name="which"][value="' + val + '"]').click();
+    } else if (event.which === 68) {
+      // 'd' toggle differences
+      document.getElementById("differences").click();
     } else if (event.which === 78 || event.which === 80) {
       // 'n' next image, 'p' previous image
       var select = gSelected;


### PR DESCRIPTION
It's currently possible to step through the test results using the <kbd>N</kbd> and <kbd>P</kbd> keys, and you can also switch between test and reference images with the <kbd>T</kbd> key.
However if you want to highlight the differences, that can only be done by clicking. This has always annoyed me somewhat, so this patch adds support for toggling the differences view with the <kbd>D</kbd> key.
