### PR TITLE
Removing unused code and enforcing additional JSHint options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -10,6 +10,8 @@
   "trailing": true,
   "curly": true,
   "undef": true,
+  "noarg": true,
+  "nonbsp": true,
 
   // Relaxing
   "boss": true,

--- a/.jshintrc
+++ b/.jshintrc
@@ -9,6 +9,7 @@
   "quotmark": "single",
   "trailing": true,
   "curly": true,
+  "undef": true,
 
   // Relaxing
   "boss": true,

--- a/src/display/annotation_helper.js
+++ b/src/display/annotation_helper.js
@@ -100,7 +100,7 @@ var AnnotationUtils = (function AnnotationUtilsClosure() {
     return element;
   }
 
-  function getHtmlElementForTextAnnotation(item, commonObjs) {
+  function getHtmlElementForTextAnnotation(item) {
     var rect = item.rect;
 
     // sanity check because of OOo-generated PDFs
@@ -217,8 +217,7 @@ var AnnotationUtils = (function AnnotationUtilsClosure() {
     return container;
   }
 
-  function getHtmlElementForLinkAnnotation(item, commonObjs) {
-
+  function getHtmlElementForLinkAnnotation(item) {
     var container = initContainer(item);
     container.className = 'annotLink';
 
@@ -238,9 +237,9 @@ var AnnotationUtils = (function AnnotationUtilsClosure() {
       case AnnotationType.WIDGET:
         return getHtmlElementForTextWidgetAnnotation(data, objs);
       case AnnotationType.TEXT:
-        return getHtmlElementForTextAnnotation(data, objs);
+        return getHtmlElementForTextAnnotation(data);
       case AnnotationType.LINK:
-        return getHtmlElementForLinkAnnotation(data, objs);
+        return getHtmlElementForLinkAnnotation(data);
       default:
         throw new Error('Unsupported annotationType: ' + data.annotationType);
     }

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -16,7 +16,7 @@
  */
 /* globals error, PDFJS, assert, info, shadow, TextRenderingMode,
            FONT_IDENTITY_MATRIX, Uint32ArrayView, IDENTITY_MATRIX, ImageData,
-           ImageKind, isArray, isNum, TilingPattern, OPS, Promise, Util, warn,
+           ImageKind, isArray, isNum, TilingPattern, OPS, Util, warn,
            getShadingPatternFromIR, WebGLUtils */
 
 'use strict';

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 /*jshint globalstrict: false */
+/* globals PDFJS */
 
 // Initializing PDFJS global object (if still undefined)
 if (typeof PDFJS === 'undefined') {

--- a/src/shared/fonts_utils.js
+++ b/src/shared/fonts_utils.js
@@ -384,7 +384,7 @@ var Type2Parser = function type2Parser(aFilePath) {
       error('Need to support CFFExpertSubsetCharset');
     } else {
       aStream.pos = charsetEntry;
-      var charset = readCharset(aStream, charStrings);
+      readCharset(aStream, charStrings);
     }
   };
 };

--- a/test/driver.js
+++ b/test/driver.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS, getPdf, combineUrl, StatTimer, SpecialPowers, Promise */
+/* globals PDFJS, combineUrl, StatTimer, SpecialPowers, Promise */
 
 'use strict';
 
@@ -273,8 +273,6 @@ function nextPage(task, loadError) {
     snapshotCurrentPage(task, '');
     return;
   }
-
-  var page = null;
 
   if (!failure) {
     try {

--- a/test/test.js
+++ b/test/test.js
@@ -25,7 +25,6 @@ var path = require('path');
 var fs = require('fs');
 var os = require('os');
 var url = require('url');
-var spawn = require('child_process').spawn;
 var testUtils = require('./testutils.js');
 
 function parseOptions() {
@@ -630,22 +629,6 @@ function startBrowsers(url, initSessionCallback) {
   });
 }
 
-function stopBrowsers(callback) {
-  var count = sessions.length;
-  sessions.forEach(function (session) {
-    if (session.closed) {
-      return;
-    }
-    session.browser.stop(function () {
-      session.closed = true;
-      count--;
-      if (count === 0 && callback) {
-        callback();
-      }
-    });
-  });
-}
-
 function getServerBaseAddress() {
   return 'http://' + host + ':' + server.port;
 }
@@ -690,7 +673,6 @@ function closeSession(browser) {
 
 function ensurePDFsDownloaded(callback) {
   var downloadUtils = require('./downloadutils.js');
-  var downloadManifestFiles = downloadUtils.downloadManifestFiles;
   var manifest = JSON.parse(fs.readFileSync(options.manifestFile));
   downloadUtils.downloadManifestFiles(manifest, function () {
     downloadUtils.verifyManifestFiles(manifest, function (hasErrors) {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1,6 +1,6 @@
 /* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
-/* globals PDFJS, expect, it, describe, Promise, combineUrl, waitsFor, runs */
+/* globals PDFJS, expect, it, describe, Promise, combineUrl, waitsFor */
 
 'use strict';
 

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -1,6 +1,6 @@
 /* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
-/* globals expect, it, describe, StringStream, Lexer, CMapFactory, Name */
+/* globals expect, it, describe, StringStream, CMapFactory, Name */
 
 'use strict';
 
@@ -95,9 +95,8 @@ describe('cmap', function() {
     expect(cmap.vertical).toEqual(true);
   });
   it('loads built in cmap', function() {
-    var cmap = CMapFactory.create(new Name('Adobe-Japan1-1'),
-                                  '../../external/cmaps/',
-                                  null);
+    CMapFactory.create(new Name('Adobe-Japan1-1'), '../../external/cmaps/',
+                       null);
   });
 });
 

--- a/test/unit/crypto_spec.js
+++ b/test/unit/crypto_spec.js
@@ -601,74 +601,61 @@ describe('CipherTransformFactory', function() {
   describe('#ctor', function() {
     describe('AES256 Revision 5', function () {
       it('should accept user password', function () {
-        var factory = new CipherTransformFactory(new DictMock(aes256Map),
-                                                 fileID1,
-                                                 'user');
+        new CipherTransformFactory(new DictMock(aes256Map), fileID1, 'user');
       });
       it('should accept owner password', function () {
-        var factory = new CipherTransformFactory(new DictMock(aes256Map),
-                                                 fileID1,
-                                                 'owner');
+        new CipherTransformFactory(new DictMock(aes256Map), fileID1, 'owner');
       });
       it('should not accept wrong password', function () {
         var thrown = false;
         try {
-          var factory = new CipherTransformFactory(new DictMock(aes256Map),
-                                                   fileID1,
-                                                   'wrong');
+          new CipherTransformFactory(new DictMock(aes256Map), fileID1,
+                                     'wrong');
         } catch (e) {
           thrown = true;
         }
         expect(thrown).toEqual(true);
       });
       it('should accept blank password', function () {
-        var factory = new CipherTransformFactory(new DictMock(aes256BlankMap),
-                                                 fileID1);
+        new CipherTransformFactory(new DictMock(aes256BlankMap), fileID1);
       });
     });
 
     describe('AES256 Revision 6', function () {
       it('should accept user password', function () {
-        var factory = new CipherTransformFactory(new DictMock(aes256IsoMap),
-                                                 fileID1,
-                                                 'user');
+        new CipherTransformFactory(new DictMock(aes256IsoMap), fileID1,
+                                   'user');
       });
       it('should accept owner password', function () {
-        var factory = new CipherTransformFactory(new DictMock(aes256IsoMap),
-                                                 fileID1,
-                                                 'owner');
+        new CipherTransformFactory(new DictMock(aes256IsoMap), fileID1,
+                                   'owner');
       });
       it('should not accept wrong password', function () {
         var thrown = false;
         try {
-          var factory = new CipherTransformFactory(new DictMock(aes256IsoMap),
-                                                   fileID1,
-                                                   'wrong');
+          new CipherTransformFactory(new DictMock(aes256IsoMap), fileID1,
+                                     'wrong');
         } catch (e) {
           thrown = true;
         }
         expect(thrown).toEqual(true);
       });
       it('should accept blank password', function () {
-        var factory = new CipherTransformFactory(new DictMock(aes256IBlankMap),
-                                                 fileID1);
+        new CipherTransformFactory(new DictMock(aes256IBlankMap), fileID1);
       });
     });
     it('should accept user password', function() {
-      var factory = new CipherTransformFactory(new DictMock(map1), fileID1,
-                                               '123456');
+      new CipherTransformFactory(new DictMock(map1), fileID1, '123456');
     });
 
     it('should accept owner password', function() {
-      var factory = new CipherTransformFactory(new DictMock(map1), fileID1,
-                                               '654321');
+      new CipherTransformFactory(new DictMock(map1), fileID1, '654321');
     });
 
     it('should not accept wrong password', function() {
       var thrown = false;
       try {
-        var factory = new CipherTransformFactory(new DictMock(map1), fileID1,
-                                                 'wrong');
+        new CipherTransformFactory(new DictMock(map1), fileID1, 'wrong');
       } catch (e) {
         thrown = true;
       }
@@ -676,7 +663,7 @@ describe('CipherTransformFactory', function() {
     });
 
     it('should accept no password', function() {
-      var factory = new CipherTransformFactory(new DictMock(map2), fileID2);
+      new CipherTransformFactory(new DictMock(map2), fileID2);
     });
   });
 });

--- a/test/unit/font_spec.js
+++ b/test/unit/font_spec.js
@@ -6,17 +6,6 @@
 'use strict';
 
 describe('font', function() {
-  function hexDump(bytes) {
-    var line = '';
-    for (var i = 0, ii = bytes.length; i < ii; ++i) {
-      var b = bytes[i].toString(16);
-      if (b.length < 2) {
-        b = '0' + b;
-      }
-      line += b.toString(16);
-    }
-    return line;
-  }
   // This example font comes from the CFF spec:
   // http://www.adobe.com/content/dam/Adobe/en/devnet/font/pdfs/5176.CFF.pdf
   var exampleFont = '0100040100010101134142434445462b' +
@@ -40,14 +29,6 @@ describe('font', function() {
       return bytes;
     }
   };
-
-  function bytesToString(bytesArray) {
-    var str = '';
-    for (var i = 0, ii = bytesArray.length; i < ii; i++) {
-      str += String.fromCharCode(bytesArray[i]);
-    }
-    return str;
-  }
 
   describe('CFFParser', function() {
     var parser = new CFFParser(fontData, {});
@@ -381,7 +362,7 @@ describe('font', function() {
         '/FontMatrix [0.001 0 0 0.001 0 0 ]readonly def\n');
       var parser = new Type1Parser(stream);
       var props = {};
-      var program = parser.extractFontHeader(props);
+      parser.extractFontHeader(props);
       expect(props.fontMatrix).toEqual([0.001, 0, 0, 0.001, 0, 0]);
     });
     it('parses font header encoding', function() {
@@ -392,7 +373,7 @@ describe('font', function() {
         'readonly def\n');
       var parser = new Type1Parser(stream);
       var props = { overridableEncoding: true };
-      var program = parser.extractFontHeader(props);
+      parser.extractFontHeader(props);
       expect(props.builtInEncoding[33]).toEqual('arrowright');
     });
   });

--- a/test/unit/testreporter.js
+++ b/test/unit/testreporter.js
@@ -1,10 +1,10 @@
 /* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
-/*jshint globalstrict: false */
+/* globals SpecialPowers */
+
+'use strict';
 
 var TestReporter = function(browser, appPath) {
-  'use strict';
-
   function send(action, json, cb) {
     var r = new XMLHttpRequest();
     // (The POST URI is ignored atm.)

--- a/test/webserver.js
+++ b/test/webserver.js
@@ -66,7 +66,6 @@ WebServer.prototype = {
     this.server = null;
   },
   _handler: function (req, res) {
-    var agent = req.headers['user-agent'];
     var url = req.url;
     var urlParts = /([^?]*)((?:\?(.*))?)/.exec(url);
     var pathPart = decodeURI(urlParts[1]), queryPart = urlParts[3];

--- a/web/default_preferences.js
+++ b/web/default_preferences.js
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals */
 
 'use strict';
 

--- a/web/hand_tool.js
+++ b/web/hand_tool.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals mozL10n, GrabToPan, PDFView, Preferences, SecondaryToolbar */
+/* globals mozL10n, GrabToPan, Preferences, SecondaryToolbar */
 
 'use strict';
 


### PR DESCRIPTION
This PR consists of three commits.
- The first commit removes unused code (and fixes small code style issues).
- The second commit enforces JSHint's `undef` option and makes the necessary changes to make lint succeed.
- The third commit enforces JSHint's `noarg` and `nonbsp` options. No code changes were necessary for this, but it's good to enforce them to avoid having them appear in the codebase in the future.
