### PR TITLE
Implement support for Highlight annotations

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -21,7 +21,7 @@
 'use strict';
 
 var DEFAULT_ICON_SIZE = 22; // px
-var SUPPORTED_TYPES = ['Link', 'Text', 'Widget'];
+var SUPPORTED_TYPES = ['Link', 'Text', 'Widget', 'Highlight'];
 
 var Annotation = (function AnnotationClosure() {
   // 12.5.5: Algorithm: Appearance streams
@@ -232,7 +232,7 @@ var Annotation = (function AnnotationClosure() {
     // TODO(mack): Implement FreeText annotations
     if (subtype === 'Link') {
       return LinkAnnotation;
-    } else if (subtype === 'Text') {
+    } else if (subtype === 'Text' || subtype === 'Highlight') {
       return TextAnnotation;
     } else if (subtype === 'Widget') {
       if (!fieldType) {


### PR DESCRIPTION
Fixes #5018.

Highlight annotations are basically nothing more than the already implemented Text annotations. Therefore a Highlight annotation can be represented as a Text annotation according to the PDF specification at https://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/pdf_reference_1-7.pdf#page=633&zoom=auto,-306,268.

Note that for the issue mentioned in this PR the annotations itself are fixed with this PR, but the annotation content is rotated. This is a separate issue (due to the transform on `annotText` that also affects child elements such as the annotation content) and I think it also related to #3826. This should be filed as a follow-up issue.
