### PR TITLE
Revert commit fc73e2e (PR 5005) for breaking certain PDF files

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals assert, bytesToString, calculateMD5, Catalog, Dict, error, info,
-           isArray, isArrayBuffer, isName, isStream, isString,
+/* globals assert, calculateMD5, Catalog, Dict, error, info, isArray,
+           isArrayBuffer, isName, isStream, isString, createPromiseCapability,
            Linearization, NullStream, PartialEvaluator, shadow, Stream, Lexer,
            StreamsSequenceStream, stringToPDFString, stringToBytes, Util, XRef,
            MissingDataException, Promise, Annotation, ObjectLoader, OperatorList
@@ -301,10 +301,14 @@ var PDFDocument = (function PDFDocumentClosure() {
   function find(stream, needle, limit, backwards) {
     var pos = stream.pos;
     var end = stream.end;
+    var strBuf = [];
     if (pos + limit > end) {
       limit = end - pos;
     }
-    var str = bytesToString(stream.getBytes(limit));
+    for (var n = 0; n < limit; ++n) {
+      strBuf.push(String.fromCharCode(stream.getByte()));
+    }
+    var str = strBuf.join('');
     stream.pos = pos;
     var index = backwards ? str.lastIndexOf(needle) : str.indexOf(needle);
     if (index == -1) {

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -531,10 +531,12 @@ var FlateStream = (function FlateStreamClosure() {
           this.eof = true;
         }
       } else {
-        var block = str.getBytes(blockLen);
-        buffer.set(block, bufferLength);
-        if (block.length < blockLen) {
-          this.eof = true;
+        for (var n = bufferLength; n < end; ++n) {
+          if ((b = str.getByte()) === -1) {
+            this.eof = true;
+            break;
+          }
+          buffer[n] = b;
         }
       }
       return;


### PR DESCRIPTION
After fc73e2e (i.e. the second commit of PR #5005), the first page of http://arxiv.org/pdf/1112.0542v1.pdf no longer renders. This is only reproducible in the addon _with_ range requests active.

/cc @fkaelberer
