### PR TITLE
Optimize Ref_toString().

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -220,7 +220,13 @@ var Ref = (function RefClosure() {
 
   Ref.prototype = {
     toString: function Ref_toString() {
-      return 'R' + this.num + '.' + this.gen;
+      // This function is hot, so we make the string as compact as possible.
+      // |this.gen| is almost always zero, so we treat that case specially.
+      var str = this.num + 'R';
+      if (this.gen !== 0) {
+        str += this.gen;
+      }
+      return str;
     }
   };
 


### PR DESCRIPTION
I have a large PDF where this function is called 1.6 million times
during loading. Minimizing the string concatenations reduces the
cumulative allocations done by Firefox within this function from 113 MB
to 48 MB.
