### PR TITLE
Managed preferences for Chrome administrators

### DIFF
--- a/extensions/chromium/manifest.json
+++ b/extensions/chromium/manifest.json
@@ -40,6 +40,9 @@
   "mime_types": [
     "application/pdf"
   ],
+  "storage": {
+    "managed_schema": "preferences_schema.json"
+  },
   "background": {
     "page": "pdfHandler.html"
   },

--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -1,0 +1,68 @@
+{
+  "type": "object",
+  "properties": {
+    "showPreviousViewOnLoad": {
+      "title": "Resume view on load",
+      "description": "Whether to view PDF documents in the last page and position upon opening the viewer.",
+      "type": "boolean",
+      "default": true
+    },
+    "defaultZoomValue": {
+      "title": "Default zoom level",
+      "description": "Default zoom level of the viewer. Accepted values: 'auto', 'page-actual', 'page-width', 'page-height', 'page-fit', or a zoom level in percents.",
+      "type": "string",
+      "pattern": "|auto|page-actual|page-width|page-height|page-fit|[0-9]+\\.?[0-9]*(,[0-9]+\\.?[0-9]*){0,2}",
+      "default": ""
+    },
+    "sidebarViewOnLoad": {
+      "title": "Sidebar state on load",
+      "description": "Controls the state of the sidebar upon load.\n 0 = do not show sidebar.\n 1 = show thumbnails in sidebar.\n 2 = show document outline in sidebar.\n 3 = Show attachments in sidebar.",
+      "type": "integer",
+      "enum": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "default": 0
+    },
+    "enableHandToolOnLoad": {
+      "title": "Activate Hand tool by default",
+      "description": "Whether to activate the hand tool by default.",
+      "type": "boolean",
+      "default": false
+    },
+    "enableWebGL": {
+      "title": "Enable WebGL",
+      "description": "Whether to enable WebGL.",
+      "type": "boolean",
+      "default": false
+    },
+    "disableRange": {
+      "title": "Disable range requests",
+      "description": "Whether to disable range requests (not recommended).",
+      "type": "boolean",
+      "default": false
+    },
+    "disableAutoFetch": {
+      "type": "boolean",
+      "default": false
+    },
+    "disableFontFace": {
+      "title": "Disable @font-face",
+      "description": "Whether to disable @font-face and fall back to canvas rendering (this is more resource-intensive).",
+      "type": "boolean",
+      "default": false
+    },
+    "disableTextLayer": {
+      "title": "Disable text selection layer",
+      "description": "Whether to disable the text selection layer.",
+      "type": "boolean",
+      "default": false
+    },
+    "useOnlyCssZoom": {
+      "type": "boolean",
+      "default": false
+    }
+  }
+}

--- a/web/default_preferences.js
+++ b/web/default_preferences.js
@@ -18,6 +18,9 @@
 
 'use strict';
 
+//#if CHROME
+////Note: Keep in sync with extensions/chromium/preferences_schema.json !
+//#endif
 var DEFAULT_PREFERENCES = {
   showPreviousViewOnLoad: true,
   defaultZoomValue: '',

--- a/web/preferences.js
+++ b/web/preferences.js
@@ -178,7 +178,46 @@ var Preferences = {
 //};
 //#endif
 
-//#if !(FIREFOX || MOZCENTRAL || B2G)
+//#if CHROME
+//Preferences._writeToStorage = function (prefObj) {
+//  return new Promise(function (resolve) {
+//    if (prefObj == DEFAULT_PREFERENCES) {
+//      var keysToRemove = Object.keys(DEFAULT_PREFERENCES);
+//      // If the storage is reset, remove the keys so that the values from
+//      // managed storage are applied again.
+//      chrome.storage.local.remove(keysToRemove, function() {
+//        resolve();
+//      });
+//    } else {
+//      chrome.storage.local.set(prefObj, function() {
+//        resolve();
+//      });
+//    }
+//  });
+//};
+//
+//Preferences._readFromStorage = function (prefObj) {
+//  return new Promise(function (resolve) {
+//    if (chrome.storage.managed) {
+//      // Get preferences as set by the system administrator.
+//      // See extensions/chromium/preferences_schema.json for more information.
+//      // These preferences can be overridden by the user.
+//      chrome.storage.managed.get(DEFAULT_PREFERENCES, getPreferences);
+//    } else {
+//      // Managed storage not supported, e.g. in Opera.
+//      getPreferences(DEFAULT_PREFERENCES);
+//    }
+//
+//    function getPreferences(defaultPrefs) {
+//      chrome.storage.local.get(defaultPrefs, function(readPrefs) {
+//        resolve(readPrefs);
+//      });
+//    }
+//  });
+//};
+//#endif
+
+//#if !(FIREFOX || MOZCENTRAL || B2G || CHROME)
 Preferences._writeToStorage = function (prefObj) {
   return new Promise(function (resolve) {
     localStorage.setItem('pdfjs.preferences', JSON.stringify(prefObj));


### PR DESCRIPTION
Implement support for managed preferences. This feature allows users (administrators) to easily change the default settings of the PDF Viewer for all Chrome or Chromium browsers within their organization.

External resources for end users (administrators)
- http://www.chromium.org/administrators/
- http://www.chromium.org/administrators/configuring-policy-for-extensions
- http://www.chromium.org/administrators/windows-quick-start
- http://www.chromium.org/administrators/mac-quick-start
- http://www.chromium.org/administrators/linux-quick-start
- http://www.chromium.org/administrators/policy-templates

Administrators can read one of the previous links to learn more about creating policies. We want to auto-generate these templates, but there are no public tools for doing that. It will be added in the future, see https://code.google.com/p/chromium/issues/detail?id=389061.

Resources for PDF.js/extension developers
- http://cs.chromium.org/file:policy_templates.json
- https://developer.chrome.com/extensions/manifest/storage
