### PR TITLE
Initialize PDFView.url = ''

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -128,6 +128,7 @@ var PDFView = {
   isViewerEmbedded: (window.parent !== window),
   idleTimeout: null,
   currentPosition: null,
+  url: '',
 
   // called once when the document is loaded
   initialize: function pdfViewInitialize() {


### PR DESCRIPTION
The absence of the `PDFView.url` property caused the following error in `PDFView.download`:

> Cannot read property 'split' of undefined

This property is unset when the PDF was loaded through a typed array instead of a URL. With the fix, the file name will default to "document.pdf", as defined by `getPDFFileNameFromURL` in web/ui_utils.js
