### PR TITLE
Re-run feature detection after downgrading the Chromium browser.

### DIFF
--- a/extensions/chromium/feature-detect.js
+++ b/extensions/chromium/feature-detect.js
@@ -33,13 +33,20 @@ chrome.storage.local.get(Features, function(features) {
     // Browser not upgraded, so the features did probably not change.
     return;
   }
+
+  // In case of a downgrade, the features must be tested again.
+  var lastVersion = /Chrome\/\d+\.0\.(\d+)/.exec(features.featureDetectLastUA);
+  lastVersion = lastVersion ? parseInt(lastVersion[1], 10) : 0;
+  var newVersion = /Chrome\/\d+\.0\.(\d+)/.exec(navigator.userAgent);
+  var isDowngrade = newVersion && parseInt(newVersion[1], 10) < lastVersion;
+
   var inconclusiveTestCount = 0;
 
-  if (!features.extensionSupportsFTP) {
+  if (isDowngrade || !features.extensionSupportsFTP) {
     features.extensionSupportsFTP = featureTestFTP();
   }
 
-  if (!features.webRequestRedirectUrl) {
+  if (isDowngrade || !features.webRequestRedirectUrl) {
     ++inconclusiveTestCount;
     // Relatively expensive (and asynchronous) test:
     featureTestRedirectOnHeadersReceived(function(result) {


### PR DESCRIPTION
If a user downgrades from Chromium 35+ to 34, then the PDF Viewer extension will not work any more because the extension assumes that certain features were available based on the cached feature detection results.

To resolve this problem, all feature detection tests run again if the browser was downgraded.
