### PR TITLE
Right-size |chars.length| and |type.length| in bidi().

### DIFF
--- a/src/core/bidi.js
+++ b/src/core/bidi.js
@@ -119,8 +119,8 @@ var bidi = PDFJS.bidi = (function bidiClosure() {
     }
 
     // Get types and fill arrays
-    chars.length = 0;
-    types.length = 0;
+    chars.length = strLength;
+    types.length = strLength;
     var numBidi = 0;
 
     var i, ii;


### PR DESCRIPTION
This lets the JS engine resize the array elements buffer immediately,
thus avoiding some intermediate resizings. This can save multiple MiBs
of reallocation in text-heavy files.
