### PR TITLE
Fix JBIG2 decoding issue #5026

### DIFF
--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -140,11 +140,12 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     }
   ];
 
+  // See 6.2.5.7 Decoding the bitmap.
   var ReusedContexts = [
-    0x1CD3, // '00111001101' (template) + '0011' (at),
-    0x079A, // '001111001101' + '0',
-    0x00E3, // '001110001' + '1',
-    0x018B  // '011000101' + '1'
+    0x9B25, // 10011 0110010 0101
+    0x0795, // 0011 110010 101
+    0x00E5, // 001 11001 01
+    0x0195  // 011001 0101
   ];
 
   var RefinementReusedContexts = [


### PR DESCRIPTION
This PR fixes two issues that caused #5026:
1. A `0` was missing in the old template (I think Figure 8 in the [draft](http://www.jpeg.org/public/fcd14492.pdf#page=44) is slightly wrong, the leftmost zero should be in thick borders). Up to the missing zero, the old constants (almost) matched those in xpdf.
2. We are sorting the template since abcc72a173d6c88f01938ef8326b63b6e12cdafb, and so the template bits must be reordered as well. The new constants match those in [jbig2dec](https://github.com/rillian/jbig2dec/blob/master/jbig2_generic.c).

EDIT: Fixed wrong link to the sorting commit.
