### PR TITLE
Allow raw PDF objects to be retrieved in display layer.

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -325,6 +325,25 @@ var PDFDocumentProxy = (function PDFDocumentProxyClosure() {
       return this.transport.getMetadata();
     },
     /**
+    * @param {{num: number, gen: number}} ref The PDF-object reference. Must
+     *   have the 'num' and 'gen' properties.
+     * @return {Promise} A promise that is resolved with the PDF object with
+     *   the object identifier ref.
+     */
+    getRawObject: function PDFDocumentProxy_getRawObject(ref) {
+      return this.transport.getRawObject(ref);
+    },
+    /**
+    * @param {{num: number, gen: number}} ref The stream reference. Must have
+     *   the 'num' and 'gen' properties.
+     * @return {Promise} A promise that is resolved with a TypedArray
+     *   containing the bytes of the decoded stream object with the object
+     *   identifier ref.
+     */
+    getStreamBytes: function PDFDocumentProxy_getStreamBytes(ref) {
+      return this.transport.getStreamBytes(ref);
+    },
+    /**
      * @return {Promise} A promise that is resolved with a TypedArray that has
      * the raw data from the PDF.
      */
@@ -1120,6 +1139,16 @@ var WorkerTransport = (function WorkerTransportClosure() {
 
     getStats: function WorkerTransport_getStats() {
       return this.messageHandler.sendWithPromise('GetStats', null);
+    },
+
+    getRawObject: function WorkerTransport_getRawObject(ref) {
+      return this.messageHandler.
+        sendWithPromise('GetRawObject', { ref: ref });
+    },
+
+    getStreamBytes: function WorkerTransport_getStreamBytes(ref) {
+      return this.messageHandler.
+        sendWithPromise('GetStreamBytes', { ref: ref });
     },
 
     startCleanup: function WorkerTransport_startCleanup() {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -111,6 +111,27 @@ describe('api', function() {
         expect(data.length).toEqual(105779);
       });
     });
+    it('gets a raw PDF object', function() {
+      var promise = doc.getRawObject({ num: 20, gen: 0 });
+      waitsForPromise(promise, function (data) {
+        expect(data.dict.map.Length).toEqual(281);
+        expect(data.start).toEqual(1956);
+        expect(data.end).toEqual(1956+281);
+      });
+    });
+    it('gets PDF trailer object', function() {
+      var promise = doc.getRawObject('trailer');
+      waitsForPromise(promise, function (data) {
+        expect(data.map.Root.num).toEqual(38);
+      });
+    });
+    it('gets stream bytes', function() {
+      var promise = doc.getStreamBytes({ num: 20, gen: 0 });
+      waitsForPromise(promise, function (data) {
+        expect(data.byteLength).toEqual(916);
+        expect(data[0]).toEqual(48);
+      });
+    });
   });
   describe('Page', function() {
     var resolvePromise;


### PR DESCRIPTION
There should be a way to retrieve the raw PDF objects in a PDF file using PDF.js. This is both useful for inspecting PDF as well as being able to edit PDF files using incremental updates outside of PDF.js (see an example below; my further goal is to be able to add annotations to PDF files).

In previous versions of PDF.js, this was possible by using PDFDocument.xref.fetch() directly as done by pdf.js.utils. PDF.js versions using a Web Worker no longer exposed an API for this.

A demo demonstrating the new API can be found at:

http://ebenda.org/2014/pdf.js.utils/browser/ (updated pdf.js.utils including the possibility to extract raw PDF streams (e. g. click downloadRaw on a DCTDecode/JPEG image) and generate PNG files out of some FlateDecode images (only results in a valid PNG file if a Predictor is present), source at https://github.com/rgieschke/pdf.js.utils ).

http://ebenda.org/2014/pdf-update/build/generic/web/viewer.html (viewer including the possibility to delete the first page of a PDF file, source at https://github.com/rgieschke/pdf.js/blob/pdf-update/web/update.coffee ).
