### PR TITLE
grunt-bump (proposal to resolve #5047)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,23 @@
+module.exports = function(grunt){
+
+    grunt.loadNpmTasks('grunt-bump');
+
+    grunt.initConfig({
+      bump: {
+        options: {
+          files: ['bower.json','package.json'],
+          updateConfigs: [],
+          commit: true,
+          commitMessage: 'Version %VERSION%',
+          commitFiles: ['bower.json','package.json'],
+          createTag: true,
+          tagName: 'v%VERSION%',
+          tagMessage: 'Version %VERSION%',
+          push: true,
+          pushTo: 'origin',
+          gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d'
+        }
+      },
+    })
+
+};

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "pdf.js",
+  "version": "0.8.0",
+  "main": "src/pdf.js",
+  "ignore": [
+    ".gitattributes",
+    ".gitignore",
+    ".gitmodules",
+    ".jshintignore",
+    ".jshintrc",
+    ".travis.yml"
+  ],
+  "scripts": {
+    "test": "node ./node_modules/.bin/jshint ."
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mozilla/pdf.js.git"
+  },
+  "licenses": [
+    {
+      "type": "Apache v2",
+      "url": "https://github.com/mozilla/pdf.js/blob/master/LICENSE"
+    }
+  ]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "moment": "2.3.x",
     "underscore": "1.4.x",
     "typogr": "0.5.x",
-    "yargs": "~1.2.1"
+    "yargs": "~1.2.1",
+    "grunt-bump": "~0.0.15"
   },
   "scripts": {
     "test": "node ./node_modules/.bin/jshint ."


### PR DESCRIPTION
I've added a `Gruntfile.js` that could handle the versioning on Github, npm and Bower. See the grunt-bump [usage examples](https://github.com/vojtajina/grunt-bump#usage-examples) on how to make use of this.

I also created a basic `bower.json` resembling the existing `package.json`. Is there a specific reason why the version in `package.json` lags behind the git tag?
