### PR TITLE
Revert commit 9a41659 (PR 5005) for breaking the loading of certain PDF files in the Firefox addon when range requests are active

### DIFF
--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -155,15 +155,8 @@ var ChunkedStream = (function ChunkedStreamClosure() {
       if (pos >= this.end) {
         return -1;
       }
-      var byte = this.bytes[pos];
-      if (byte === 0) {
-        // |byte| might be zero, because the corresponding chunk has not been
-        // loaded yet. In this case, this.ensureByte(pos) will throw an
-        // exception and nothing is returned.
-        this.ensureByte(pos);
-      }
-      this.pos++;
-      return byte;
+      this.ensureByte(pos);
+      return this.bytes[this.pos++];
     },
 
     getUint16: function ChunkedStream_getUint16() {


### PR DESCRIPTION
After https://github.com/mozilla/pdf.js/commit/9a41659ae7eddb92eaa09626db84b672947a6a43 (i.e. the first commit of PR #5005), the first page of http://purasilkthailand.com/static/doc/thai-tc.pdf no longer renders. This is _only_ reproducible in the addon when range requests are active. To reproduce this, make sure that the file is loaded from the server by doing a "skip"-cache reload (e.g. <kbd>Ctrl</kbd> + <kbd>F5</kbd>).

What's somewhat unfortunate with this regression, is that not only has this already landed on Mozilla Central (see [bug 1042307](https://bugzilla.mozilla.org/show_bug.cgi?id=1042307)); but it has also been uplifted to the Aurora channel.

/cc @fkaelberer
