### PR TITLE
Preserve reference fragment in Chromium URL router

### DIFF
--- a/extensions/chromium/extension-router.js
+++ b/extensions/chromium/extension-router.js
@@ -99,6 +99,10 @@ limitations under the License.
     var url = parseExtensionURL(details.url);
     if (url) {
       url = VIEWER_URL + '?file=' + url;
+      var i = details.url.indexOf('#');
+      if (i > 0) {
+        url += details.url.slice(i);
+      }
       console.log('Redirecting ' + details.url + ' to ' + url);
       return { redirectUrl: url };
     }


### PR DESCRIPTION
Because removed reference fragments are no longer automatically copied thanks to https://code.google.com/p/chromium/issues/detail?id=354653
