### PR TITLE
Disable spellcheck in Chromium's URL popup

### DIFF
--- a/extensions/chromium/pageActionPopup.html
+++ b/extensions/chromium/pageActionPopup.html
@@ -38,7 +38,7 @@ body {
 }
 </style>
 </head>
-<body contentEditable="plaintext-only">
+<body contentEditable="plaintext-only" spellcheck="false">
 <script src="pageActionPopup.js"></script>
 </body>
 </html>


### PR DESCRIPTION
These red waves below a URL are quite useless and only distracting.
