### PR TITLE
Hooks SVG stuff into the viewer

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -139,6 +139,13 @@ PDFJS.useOnlyCssZoom = (PDFJS.useOnlyCssZoom === undefined ?
                         false : PDFJS.useOnlyCssZoom);
 
 /**
+ * Enables SVG rendering.
+ * @var {boolean}
+ */
+PDFJS.svgRendering = (PDFJS.svgRendering === undefined ?
+                      true : PDFJS.svgRendering);
+
+/**
  * Controls the logging level.
  * The constants from PDFJS.VERBOSITY_LEVELS should be used:
  * - errors
@@ -1164,7 +1171,9 @@ var WorkerTransport = (function WorkerTransportClosure() {
           }
         }
         this.commonObjs.clear();
-        FontLoader.clear();
+        if (!PDFJS.svgRendering) { // HACK we might have SVGs using fonts
+          FontLoader.clear();
+        }
       }.bind(this));
     }
   };

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -19,7 +19,7 @@
 
 'use strict';
 
-//#if (GENERIC || SINGLE_FILE)
+//#if (GENERIC || SINGLE_FILE || CHROME || FIREFOX)
 var SVG_DEFAULTS = {
   fontStyle: 'normal',
   fontWeight: 'normal',

--- a/web/default_preferences.js
+++ b/web/default_preferences.js
@@ -31,6 +31,7 @@ var DEFAULT_PREFERENCES = {
   disableStream: false,
   disableAutoFetch: false,
   disableFontFace: false,
+  svgRendering: false,
 //#if B2G
 //disableTextLayer: true,
 //useOnlyCssZoom: true

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1252,6 +1252,9 @@ html[dir='rtl'] .attachmentsItem > button {
   cursor: default;
 }
 
+svg text {
+  cursor: text;
+}
 
 /* TODO: file FF bug to support ::-moz-selection:window-inactive
    so we can override the opaque grey background when the window is inactive;
@@ -1678,7 +1681,7 @@ html[dir='rtl'] #documentPropertiesOverlay .row > * {
     overflow: visible;
   }
 
-  #mainContainer, #viewerContainer, .page, .page canvas {
+  #mainContainer, #viewerContainer, .page, .page canvas, .page svg {
     position: static;
     padding: 0;
     margin: 0;

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -55,6 +55,7 @@ http://sourceforge.net/adobe/cmap/wiki/License/
     <script src="../src/display/pattern_helper.js"></script>
     <script src="../src/display/font_loader.js"></script>
     <script src="../src/display/annotation_helper.js"></script>
+    <script src="../src/display/svg.js"></script>
     <script>PDFJS.workerSrc = '../src/worker_loader.js';</script>
 <!--#endif-->
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -247,6 +247,9 @@ var PDFViewerApplication = {
       }),
       Preferences.get('useOnlyCssZoom').then(function resolved(value) {
         PDFJS.useOnlyCssZoom = value;
+      }),
+      Preferences.get('svgRendering').then(function resolved(value) {
+        PDFJS.svgRendering = value;
       })
       // TODO move more preferences and other async stuff here
     ]).catch(function (reason) { });
@@ -1515,6 +1518,9 @@ function webViewerInitialized() {
     if ('useonlycsszoom' in hashParams) {
       PDFJS.useOnlyCssZoom = (hashParams['useonlycsszoom'] === 'true');
     }
+    if ('svg' in hashParams) {
+      PDFJS.svgRendering = (hashParams['svg'] === 'true');
+    }
     if ('verbosity' in hashParams) {
       PDFJS.verbosity = hashParams['verbosity'] | 0;
     }
@@ -1528,6 +1534,12 @@ function webViewerInitialized() {
       PDFJS.cMapPacked = false;
     }
 //#endif
+
+  if (PDFJS.svgRendering) {
+    PDFJS.useOnlyCssZoom = true;
+    PDFJS.disableTextLayer = true;
+  }
+
 //#if !(FIREFOX || MOZCENTRAL)
     if ('locale' in hashParams) {
       locale = hashParams['locale'];
@@ -1721,7 +1733,9 @@ document.addEventListener('pagerendered', function (e) {
   var pageView = PDFViewerApplication.pdfViewer.getPageView(pageIndex);
   var thumbnailView = PDFViewerApplication.pdfThumbnailViewer.
                       getThumbnail(pageIndex);
-  thumbnailView.setImage(pageView.canvas);
+  if (!PDFJS.svgRendering) {
+    thumbnailView.setImage(pageView.canvas);
+  }
 
 //#if (FIREFOX || MOZCENTRAL)
 //if (pageView.textLayer && pageView.textLayer.textDivs &&


### PR DESCRIPTION
Don't merge -- just for reference.

This is pilot of connecting SVG stuff into the generic viewer. We have to slowly refactor to make this pretty.

Generate preview to build the extension with current master. There are "#svg=true" flag and `extensions.uriloader@pdf.js.svgRendering` preference, to enable the SVG rendering.
