### PR TITLE
only convert in IE9 if the requested responseType is actually an arraybu...

### DIFF
--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -171,7 +171,11 @@ if (typeof PDFJS === 'undefined') {
   if (typeof VBArray !== 'undefined') {
     Object.defineProperty(xhrPrototype, 'response', {
       get: function xmlHttpRequestResponseGet() {
-        return new Uint8Array(new VBArray(this.responseBody).toArray());
+        if (this.responseType === 'arraybuffer') {
+          return new Uint8Array(new VBArray(this.responseBody).toArray());
+        } else {
+          return this.responseText;
+        }
       }
     });
     return;


### PR DESCRIPTION
only convert in IE9 if the requested responseType is actually an arrabuffer, otherwise just return the responseText. That way the compatibility.js does not break other frameworks like angular that not always want an array from xhr requests.

Fixes https://github.com/mozilla/pdf.js/issues/4672
