### PR TITLE
Remove old unused code from PDFView.close()

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -612,10 +612,6 @@ var PDFView = {
       thumbsView.removeChild(thumbsView.lastChild);
     }
 
-    if ('_loadingInterval' in thumbsView) {
-      clearInterval(thumbsView._loadingInterval);
-    }
-
     var container = document.getElementById('viewer');
     while (container.hasChildNodes()) {
       container.removeChild(container.lastChild);


### PR DESCRIPTION
This patch removes a piece of dead code from `PDFView.close()`.

The code removed here originated in PR #285, but hasn't actually been used for anything in a long time. Furthermore it appears that this code was already obsolete when the current viewer UI was first introduced in PR&nbsp;#1537.

(As an aside: Looking at PR #285 I'm actually wondering if it ever worked as intended, since the property is called `_interval` in one place and `_loadingInterval` in another :-)
