### PR TITLE
Attempt to display the File size quicker in the Document Properties dialog

### DIFF
--- a/web/document_properties.js
+++ b/web/document_properties.js
@@ -22,6 +22,7 @@ var DocumentProperties = {
   overlayName: null,
   fileName: '',
   fileSize: '',
+  rawFileSize: 0,
 
   // Document property fields (in the viewer).
   fileNameField: null,
@@ -77,6 +78,9 @@ var DocumentProperties = {
 
     // Get the file size.
     PDFView.pdfDocument.getDownloadInfo().then(function(data) {
+      if (data.length === this.rawFileSize) {
+        return;
+      }
       this.setFileSize(data.length);
       this.updateUI(this.fileSizeField, this.fileSize);
     }.bind(this));
@@ -85,7 +89,7 @@ var DocumentProperties = {
     PDFView.pdfDocument.getMetadata().then(function(data) {
       var fields = [
         { field: this.fileNameField, content: this.fileName },
-        // The fileSize field is updated once getDownloadInfo is resolved.
+        { field: this.fileSizeField, content: this.fileSize },
         { field: this.titleField, content: data.info.Title },
         { field: this.authorField, content: data.info.Author },
         { field: this.subjectField, content: data.info.Subject },
@@ -115,7 +119,7 @@ var DocumentProperties = {
   },
 
   setFileSize: function documentPropertiesSetFileSize(fileSize) {
-    var kb = fileSize / 1024;
+    var kb = (this.rawFileSize = fileSize) / 1024;
     if (kb < 1024) {
       this.fileSize = mozL10n.get('document_properties_kb', {
         size_kb: (+kb.toPrecision(3)).toLocaleString(),

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -696,6 +696,10 @@ var PDFView = {
         self.loading = false;
       }
     );
+
+    if (args && args.length) {
+      DocumentProperties.setFileSize(args.length);
+    }
   },
 
   download: function pdfViewDownload() {


### PR DESCRIPTION
Currently the File size field in the Document Properties dialog isn't set until `PDFView.pdfDocument.getDownloadInfo()` is resolved. If the Document Properties dialog is opened while a PDF file is loading with range requests, this leads to the less desirable situation where all fields _except_ File size are available.

In cases where `PDFView.open()` is called with the `args` parameter defined, and `args` contains the property `length`, we actually know the File size when the PDF file begins to load. (This is usually the case when ranged loading is used in the Firefox addon/built-in version.)
Hence we can use `args.length` to set the File size immediately when `PDFView.open()` is called, resulting in a better user experience.
