### PR TITLE
Disable the "Go to First/Last Page" buttons when the first/last page is currently active

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2211,8 +2211,13 @@ window.addEventListener('pagechange', function pagechange(evt) {
       }
     }
   }
+  var numPages = PDFView.pages.length;
+
   document.getElementById('previous').disabled = (page <= 1);
-  document.getElementById('next').disabled = (page >= PDFView.pages.length);
+  document.getElementById('next').disabled = (page >= numPages);
+
+  document.getElementById('firstPage').disabled = (page <= 1);
+  document.getElementById('lastPage').disabled = (page >= numPages);
 }, true);
 
 function handleMouseWheel(evt) {


### PR DESCRIPTION
Since the "Previous/Next Page" buttons are disabled when the first/last page is active, I think that for the sake of consistency the "Go to First/Last Page" should behave the same way.
