### PR TITLE
Remove two instances of leftover console.log debug statements

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -835,8 +835,6 @@ var XRef = (function XRefClosure() {
           // Validate entry obj
           if (!isInt(entry.offset) || !isInt(entry.gen) ||
               !(entry.free || entry.uncompressed)) {
-            console.log(entry.offset, entry.gen, entry.free,
-                        entry.uncompressed);
             error('Invalid entry in XRef subsection: ' + first + ', ' + count);
           }
 

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -165,7 +165,6 @@ describe('evaluator', function() {
                                            new XrefMock(), new HandlerMock(),
                                            'prefix');
       var stream = new StringStream('5 1 d0');
-      console.log('here!');
       runOperatorListCheck(evaluator, stream, new ResourcesMock(),
           function (result) {
         expect(result.argsArray[0][0]).toEqual(5);


### PR DESCRIPTION
The `console.log` statement in evaluator_spec.js is obviously not needed. In obj.js it could have been replaced by `info`, but that seemed unnecessary given the already existing `error`.
