### PR TITLE
Fix CMap unit tests

### DIFF
--- a/test/font/font_test.html
+++ b/test/font/font_test.html
@@ -24,7 +24,6 @@
   <script src="../../src/core/annotation.js"></script>
   <script src="../../src/core/function.js"></script>
   <script src="../../src/core/charsets.js"></script>
-  <script src="../../src/core/cidmaps.js"></script>
   <script src="../../src/core/colorspace.js"></script>
   <script src="../../src/core/crypto.js"></script>
   <script src="../../src/core/pattern.js"></script>

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -4,6 +4,9 @@
 
 'use strict';
 
+var cMapUrl = '../../external/bcmaps/';
+var cMapPacked = true;
+
 describe('cmap', function() {
   it('parses beginbfchar', function() {
     var str = '2 beginbfchar\n' +
@@ -87,8 +90,10 @@ describe('cmap', function() {
   it('read usecmap', function() {
     var str = '/Adobe-Japan1-1 usecmap\n';
     var stream = new StringStream(str);
-    var cmap = CMapFactory.create(stream, null, '../../external/cmaps/');
-    expect(cmap.useCMap).toBeDefined();
+    var cmap = CMapFactory.create(stream,
+                                  { url: cMapUrl, packed: cMapPacked }, null);
+    expect(cmap.useCMap).not.toBeNull();
+    expect(cmap.builtInCMap).toBeUndefined();
   });
   it('parses wmode', function() {
     var str = '/WMode 1 def\n';
@@ -97,8 +102,10 @@ describe('cmap', function() {
     expect(cmap.vertical).toEqual(true);
   });
   it('loads built in cmap', function() {
-    CMapFactory.create(new Name('Adobe-Japan1-1'), '../../external/cmaps/',
-                       null);
+    var cmap = CMapFactory.create(new Name('Adobe-Japan1-1'),
+                                  { url: cMapUrl, packed: cMapPacked }, null);
+    expect(cmap.useCMap).toBeNull();
+    expect(cmap.builtInCMap).toBeTruthy();
   });
 });
 

--- a/test/unit/unit_test.html
+++ b/test/unit/unit_test.html
@@ -23,7 +23,6 @@
   <script src="../../src/core/annotation.js"></script>
   <script src="../../src/core/function.js"></script>
   <script src="../../src/core/charsets.js"></script>
-  <script src="../../src/core/cidmaps.js"></script>
   <script src="../../src/core/colorspace.js"></script>
   <script src="../../src/core/crypto.js"></script>
   <script src="../../src/core/pattern.js"></script>


### PR DESCRIPTION
When the binary CMaps were added, some of the relevant unit tests were not changed. This patch updates them, so that we actually test the current implementation.
What's somewhat troubling here is that we currently have CMap unit tests that passes, _despite_ not working as intended (the CMap files doesn't load).

**Edit:** When failing to `GET` a CMap we should `error`, see [cmap.js#L390-L392](https://github.com/mozilla/pdf.js/blob/master/src/core/cmap.js#L390-L392) and [cmap.js#L930-L932](https://github.com/mozilla/pdf.js/blob/master/src/core/cmap.js#L930-L932), but the condition isn't true, even when the CMap fails to load.
I found a [review comment for PR #4259](https://github.com/brendandahl/pdf.js/commit/b5b94a4af389ef387570cf22662d9fc6bd41417a#commitcomment-5434455) that was never addressed, which (in my testing) would fix the current situation where we fail to throw an error when the CMap is unavailable.
@yurydelendik If you think it's a good idea, I'd be happy to follow-up this PR with that fix!

In this PR I'm also removing the remaining references to cidmaps.js, which I missed in #5088.
