### PR TITLE
Right-size the array in getSampleArray().

### DIFF
--- a/src/core/function.js
+++ b/src/core/function.js
@@ -35,7 +35,7 @@ var PDFFunction = (function PDFFunctionClosure() {
       }
       length *= outputSize;
 
-      var array = [];
+      var array = new Array(length);
       var codeSize = 0;
       var codeBuf = 0;
       // 32 is a valid bps so shifting won't work
@@ -50,7 +50,7 @@ var PDFFunction = (function PDFFunctionClosure() {
           codeSize += 8;
         }
         codeSize -= bps;
-        array.push((codeBuf >> codeSize) * sampleMul);
+        array[i] = (codeBuf >> codeSize) * sampleMul;
         codeBuf &= (1 << codeSize) - 1;
       }
       return array;


### PR DESCRIPTION
This allows the JS engine to do a better job of allocating the right
number of elements for the array, avoiding some resizings. For the PDF
in #2504, this avoids 100s of MiBs of allocations in Firefox.
