### PR TITLE
Only use data-font-name attributes when necessary.

### DIFF
--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -157,7 +157,12 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
       textDiv.style.fontFamily = style.fontFamily;
 
       textDiv.textContent = geom.str;
-      textDiv.dataset.fontName = geom.fontName;
+      // |fontName| is only used by the Font Inspector. This test will succeed
+      // when e.g. the Font Inspector is off but the Stepper is on, but it's
+      // not worth the effort to do a more accurate test.
+      if (PDFJS.pdfBug) {
+        textDiv.dataset.fontName = geom.fontName;
+      }
       // Storing into dataset will convert number into string.
       if (angle !== 0) {
         textDiv.dataset.angle = angle * (180 / Math.PI);


### PR DESCRIPTION
The data-font-name attribute of textLayer divs are only used by the Font
Inspector. This change omits them when Font Inspector is disabled.
