### PR TITLE
Small re-factoring of DocumentProperties

### DIFF
--- a/web/document_properties.js
+++ b/web/document_properties.js
@@ -20,8 +20,6 @@
 
 var DocumentProperties = {
   overlayName: null,
-  fileName: '',
-  fileSize: '',
   rawFileSize: 0,
 
   // Document property fields (in the viewer).
@@ -73,23 +71,21 @@ var DocumentProperties = {
       // don't bother updating the properties.
       return;
     }
-    // Get the file name.
-    this.fileName = getPDFFileNameFromURL(PDFView.url);
-
-    // Get the file size.
+    // Get the file size (if it hasn't already been set).
     PDFView.pdfDocument.getDownloadInfo().then(function(data) {
       if (data.length === this.rawFileSize) {
         return;
       }
       this.setFileSize(data.length);
-      this.updateUI(this.fileSizeField, this.fileSize);
+      this.updateUI(this.fileSizeField, this.parseFileSize());
     }.bind(this));
 
-    // Get the other document properties.
+    // Get the document properties.
     PDFView.pdfDocument.getMetadata().then(function(data) {
       var fields = [
-        { field: this.fileNameField, content: this.fileName },
-        { field: this.fileSizeField, content: this.fileSize },
+        { field: this.fileNameField,
+          content: getPDFFileNameFromURL(PDFView.url) },
+        { field: this.fileSizeField, content: this.parseFileSize() },
         { field: this.titleField, content: data.info.Title },
         { field: this.authorField, content: data.info.Author },
         { field: this.subjectField, content: data.info.Subject },
@@ -119,14 +115,22 @@ var DocumentProperties = {
   },
 
   setFileSize: function documentPropertiesSetFileSize(fileSize) {
-    var kb = (this.rawFileSize = fileSize) / 1024;
-    if (kb < 1024) {
-      this.fileSize = mozL10n.get('document_properties_kb', {
+    if (fileSize > 0) {
+      this.rawFileSize = fileSize;
+    }
+  },
+
+  parseFileSize: function documentPropertiesParseFileSize() {
+    var fileSize = this.rawFileSize, kb = fileSize / 1024;
+    if (!kb) {
+      return;
+    } else if (kb < 1024) {
+      return mozL10n.get('document_properties_kb', {
         size_kb: (+kb.toPrecision(3)).toLocaleString(),
         size_b: fileSize.toLocaleString()
       }, '{{size_kb}} KB ({{size_b}} bytes)');
     } else {
-      this.fileSize = mozL10n.get('document_properties_mb', {
+      return mozL10n.get('document_properties_mb', {
         size_mb: (+(kb / 1024).toPrecision(3)).toLocaleString(),
         size_b: fileSize.toLocaleString()
       }, '{{size_mb}} MB ({{size_b}} bytes)');


### PR DESCRIPTION
With the changes made in PR #5169 to enable quicker display of the File size, `setFileSize()` can now be called during file loading. This function parses _and_ localizes the file size, where the l10n is a synchronous operation.
This patch:
- Re-factors `setFileSize()` to _only_ update `rawFileSize`, and moves parsing and fetching of the l10n string to a separate method that isn't called until the Document Properties dialog is actually opened.
- Adds a couple of checks to make sure that `rawFileSize` is set to a positive number.
- Removes the `fileName` and `fileSize` properties. Since they are parsed every time the Document Properties dialog is opened, it doesn't seem necessary to cache them.

/cc @timvandermeij Can you please review this?
