### PR TITLE
Fix loadingBar hiding when disableAutoFetch is enabled (issue 3590)

### DIFF
--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -329,7 +329,7 @@ var ProgressBar = (function ProgressBarClosure() {
 
     hide: function ProgressBar_hide() {
       this.bar.classList.add('hidden');
-      this.bar.removeAttribute('style');
+      document.body.classList.remove('loadingInProgress');
     }
   };
 

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -275,6 +275,7 @@ var ProgressBar = (function ProgressBarClosure() {
   }
 
   function ProgressBar(id, opts) {
+    this.visible = true;
 
     // Fetch the sub-elements for later.
     this.div = document.querySelector(id + ' .progress');
@@ -328,8 +329,21 @@ var ProgressBar = (function ProgressBarClosure() {
     },
 
     hide: function ProgressBar_hide() {
+      if (!this.visible) {
+        return;
+      }
+      this.visible = false;
       this.bar.classList.add('hidden');
       document.body.classList.remove('loadingInProgress');
+    },
+
+    show: function ProgressBar_show() {
+      if (this.visible) {
+        return;
+      }
+      this.visible = true;
+      document.body.classList.add('loadingInProgress');
+      this.bar.classList.remove('hidden');
     }
   };
 

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -96,8 +96,8 @@ http://sourceforge.net/adobe/cmap/wiki/License/
 
   </head>
 
-  <body tabindex="1">
-    <div id="outerContainer" class="loadingInProgress">
+  <body tabindex="1" class="loadingInProgress">
+    <div id="outerContainer">
 
       <div id="sidebarContainer">
         <div id="toolbarSidebar">

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -35,6 +35,7 @@ var VIEW_HISTORY_MEMORY = 20;
 var SCALE_SELECT_CONTAINER_PADDING = 8;
 var SCALE_SELECT_PADDING = 22;
 var PAGE_NUMBER_LOADING_INDICATOR = 'visiblePageIsLoading';
+var DISABLE_AUTO_FETCH_LOADING_BAR_TIMEOUT = 5000;
 //#if B2G
 //PDFJS.useOnlyCssZoom = true;
 //PDFJS.disableTextLayer = true;
@@ -855,6 +856,24 @@ var PDFViewerApplication = {
     // increases.
     if (percent > this.loadingBar.percent || isNaN(percent)) {
       this.loadingBar.percent = percent;
+
+      // When disableAutoFetch is enabled, it's not uncommon for the entire file
+      // to never be fetched (depends on e.g. the file structure). In this case
+      // the loading bar will not be completely filled, nor will it be hidden.
+      // To prevent displaying a partially filled loading bar permanently, we
+      // hide it when no data has been loaded during a certain amount of time.
+      if (PDFJS.disableAutoFetch && percent) {
+        if (this.disableAutoFetchLoadingBarTimeout) {
+          clearTimeout(this.disableAutoFetchLoadingBarTimeout);
+          this.disableAutoFetchLoadingBarTimeout = null;
+        }
+        this.loadingBar.show();
+
+        this.disableAutoFetchLoadingBarTimeout = setTimeout(function () {
+          this.loadingBar.hide();
+          this.disableAutoFetchLoadingBarTimeout = null;
+        }.bind(this), DISABLE_AUTO_FETCH_LOADING_BAR_TIMEOUT);
+      }
     }
   },
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -873,8 +873,6 @@ var PDFViewerApplication = {
     var downloadedPromise = pdfDocument.getDownloadInfo().then(function() {
       self.downloadComplete = true;
       self.loadingBar.hide();
-      var outerContainer = document.getElementById('outerContainer');
-      outerContainer.classList.remove('loadingInProgress');
     });
 
     var pagesCount = pdfDocument.numPages;


### PR DESCRIPTION
This is an attempt to fix #3590.

**Edit:** Test with http://107.21.233.14:8877/52cea2c73cecaf5/web/viewer.html#disableAutoFetch=true.
