### PR TITLE
Set transformOrigin for text layer in css.

### DIFF
--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -91,7 +91,6 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
             transform = 'rotate(' + rotation + 'deg) ' + transform;
           }
           CustomStyle.setProp('transform' , textDiv, transform);
-          CustomStyle.setProp('transformOrigin' , textDiv, '0% 0%');
         }
       }
 

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1305,8 +1305,6 @@ canvas {
   top: 0;
   right: 0;
   bottom: 0;
-  color: #000;
-  font-family: sans-serif;
   overflow: hidden;
 }
 
@@ -1677,7 +1675,7 @@ html[dir='rtl'] #documentPropertiesOverlay .row > * {
     background: url(images/toolbarButton-menuArrows@2x.png) no-repeat;
     background-size: 7px 16px;
   }
-  
+
   html[dir='ltr'] .toolbarButton#sidebarToggle::before {
     content: url(images/toolbarButton-sidebarToggle@2x.png);
   }
@@ -1967,4 +1965,3 @@ html[dir='rtl'] #documentPropertiesOverlay .row > * {
     display: none;
   }
 }
-

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1027,7 +1027,7 @@ html[dir='rtl'] .verticalToolbarSeparator {
 }
 
 .horizontalToolbarSeparator {
-  display: block; 
+  display: block;
   margin: 0 0 4px 0;
   height: 1px;
   width: 100%;
@@ -1315,6 +1315,11 @@ canvas {
   position: absolute;
   white-space: pre;
   cursor: text;
+  -webkit-transform-origin: 0% 0%;
+  -moz-transform-origin: 0% 0%;
+  -o-transform-origin: 0% 0%;
+  -ms-transform-origin: 0% 0%;
+  transform-origin: 0% 0%;
 }
 
 .textLayer .highlight {
@@ -1489,7 +1494,7 @@ canvas {
 }
 
 .dialog .separator {
-  display: block; 
+  display: block;
   margin: 4px 0 4px 0;
   height: 1px;
   width: 100%;


### PR DESCRIPTION
transformOrigin is set to 0% 0% in all cases. This adds extra memory
impact into the dom tree. It also involves the CustomStyles workaround
to determine the correct css rule for the browser.
By setting all vendor and standard variants in css, the rule is applied
without the dom memory overhead and without the minor computation
overhead to set the value.
