### PR TITLE
Don't use transform-origin on every text layer div.

### DIFF
--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -91,7 +91,6 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
             transform = 'rotate(' + rotation + 'deg) ' + transform;
           }
           CustomStyle.setProp('transform' , textDiv, transform);
-          CustomStyle.setProp('transformOrigin' , textDiv, '0% 0%');
         }
       }
 

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1315,6 +1315,11 @@ canvas {
   position: absolute;
   white-space: pre;
   cursor: text;
+  -ms-transform-origin: 0% 0% 0px;
+  -moz-transform-origin: 0% 0% 0px;
+  -webkit-transform-origin: 0% 0% 0px;
+  -o-transform-origin: 0% 0% 0px;
+  transform-origin: 0% 0% 0px;
 }
 
 .textLayer .highlight {


### PR DESCRIPTION
This change makes the transform-origin style be applied via viewer.css,
rather than annotating every node individually. It makes the scrolling
of the document from #1045 substantially smoother in Firefox.
