### PR TITLE
Avoid creating intermediate strings in sanitizeMetrics

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -3297,16 +3297,12 @@ var Font = (function FontClosure() {
         var numMissing = numOfSidebearings -
           ((metrics.length - numOfMetrics * 4) >> 1);
 
-        var i, ii;
         if (numMissing > 0) {
-          font.pos = (font.start ? font.start : 0) + metrics.offset;
-          var entries = '';
-          for (i = 0, ii = metrics.length; i < ii; i++) {
-            entries += String.fromCharCode(font.getByte());
-          }
-          for (i = 0; i < numMissing; i++) {
-            entries += '\x00\x00';
-          }
+          // For each missing glyph, we set both the width and lsb to 0 (zero).
+          // Since we need to add two properties for each glyph, this explains
+          // the use of |numMissing * 2| when initializing the typed array.
+          var entries = new Uint8Array(metrics.length + numMissing * 2);
+          entries.set(metrics.data);
           metrics.data = entries;
         }
       }


### PR DESCRIPTION
This patch avoids creating many intermediate strings, by instead writing directly to a Uint8Array, when writing dummy width/lsb entries for glyphs where those are missing.
For the relevant PDF files in our test suite (see https://gist.github.com/Snuffleupagus/27f6586ceac79dadacbe), the average number of intermediate strings are well over 1000.
