### PR TITLE
Don't scale single-char text divs.

### DIFF
--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -83,14 +83,21 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
         var width = ctx.measureText(textDiv.textContent).width;
         if (width > 0) {
           textLayerFrag.appendChild(textDiv);
-          // Dataset values come of type string.
-          var textScale = textDiv.dataset.canvasWidth / width;
+          var transform;
+          if (textDiv.dataset.canvasWidth !== undefined) {
+            // Dataset values come of type string.
+            var textScale = textDiv.dataset.canvasWidth / width;
+            transform = 'scaleX(' + textScale + ')';
+          } else {
+            transform = '';
+          }
           var rotation = textDiv.dataset.angle;
-          var transform = 'scale(' + textScale + ', 1)';
           if (rotation) {
             transform = 'rotate(' + rotation + 'deg) ' + transform;
           }
-          CustomStyle.setProp('transform' , textDiv, transform);
+          if (transform) {
+            CustomStyle.setProp('transform' , textDiv, transform);
+          }
         }
       }
 
@@ -165,10 +172,15 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
       if (angle !== 0) {
         textDiv.dataset.angle = angle * (180 / Math.PI);
       }
-      if (style.vertical) {
-        textDiv.dataset.canvasWidth = geom.height * this.viewport.scale;
-      } else {
-        textDiv.dataset.canvasWidth = geom.width * this.viewport.scale;
+      // We don't bother scaling single-char text divs, because it has very
+      // little effect on text highlighting. This makes scrolling on docs with
+      // lots of such divs a lot faster.
+      if (textDiv.textContent.length > 1) {
+        if (style.vertical) {
+          textDiv.dataset.canvasWidth = geom.height * this.viewport.scale;
+        } else {
+          textDiv.dataset.canvasWidth = geom.width * this.viewport.scale;
+        }
       }
     },
 


### PR DESCRIPTION
This change makes scrolling noticeably smoother on files with many
single-char text divs, such as the one in #1045. The trade-off is that
the visual appearance of text selection in such documents is slightly
worse, because more text divs overlap.

This change also uses `scaleX(N)` instead of `scale(N, 1)`. This might
be marginally more efficient in terms of JS string concatenation.

Here's a screenshot showing text selection and search selection prior to my change:

![genre-old](https://cloud.githubusercontent.com/assets/1940286/3991352/7d8334b8-28e0-11e4-8468-ea48138581f3.png)

Here's the equivalent screenshot after my change:

![genre-new](https://cloud.githubusercontent.com/assets/1940286/3991358/9364fc44-28e0-11e4-9802-500333a8c359.png)

The old code gave very little overlap, but some gaps. The new code gives more overlap, but no gaps. Neither of them look great!
