### PR TITLE
Fix Zoom box resizing when it's hidden when the viewer loads (issue 5224)

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2155,9 +2155,12 @@ window.addEventListener('localized', function localized(evt) {
 
   PDFView.animationStartedPromise.then(function() {
     // Adjust the width of the zoom box to fit the content.
-    // Note: This is only done if the zoom box is actually visible,
-    // since otherwise element.clientWidth will return 0.
+    // Note: If the window is narrow enough that the zoom box is not visible,
+    //       we temporarily show it to be able to adjust its width.
     var container = document.getElementById('scaleSelectContainer');
+    if (container.clientWidth === 0) {
+      container.setAttribute('style', 'display: inherit;');
+    }
     if (container.clientWidth > 0) {
       var select = document.getElementById('scaleSelect');
       select.setAttribute('style', 'min-width: inherit;');


### PR DESCRIPTION
Attempting to fix #5224.

@fkaelberer Can you please confirm if this patch fixes the issue?
