### PR TITLE
Auto zoom landscape documents (like slide presentations) to fit their height

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -359,7 +359,9 @@ var PDFView = {
           scale = Math.min(pageWidthScale, pageHeightScale);
           break;
         case 'auto':
-          scale = Math.min(MAX_AUTO_SCALE, pageWidthScale);
+          var isLandscape = (currentPage.width > currentPage.height);
+          var horizontalScale = isLandscape ? pageHeightScale : pageWidthScale;
+          scale = Math.min(MAX_AUTO_SCALE, horizontalScale);
           break;
         default:
           console.error('pdfViewSetScale: \'' + value +

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1213,7 +1213,7 @@ var PDFView = {
   setInitialView: function pdfViewSetInitialView(storedHash, scale) {
     // Reset the current scale, as otherwise the page's scale might not get
     // updated if the zoom level stayed the same.
-    this.currentScale = 0;
+    this.currentScale = UNKNOWN_SCALE;
     this.currentScaleValue = null;
     // When opening a new file (when one is already loaded in the viewer):
     // Reset 'currentPageNumber', since otherwise the page's scale will be wrong


### PR DESCRIPTION
Landscape documents, like slide presentations, are much easier to read if "Automatic Zoom" fits the slide height so the full slide is visible. Here is an example landscape slide presentation:

https://wiki.mozilla.org/images/5/55/MobileOpportunity.pdf
