### PR TITLE
Separate the page action functionality

### DIFF
--- a/extensions/chromium/extension-pageAction.js
+++ b/extensions/chromium/extension-pageAction.js
@@ -1,0 +1,65 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/*
+Copyright 2014 Mozilla Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/* globals chrome */
+
+'use strict';
+
+(function ExtensionPageActionClosure() {
+  var VIEWER_URL = chrome.extension.getURL('content/web/viewer.html');
+
+  /**
+   * @param {string} url URL of PDF Viewer.
+   * @return {string|undefined} The percent-encoded URL of the (PDF) file.
+   */
+  function parseViewerURL(url) {
+    if (url.lastIndexOf(VIEWER_URL, 0) !== 0) {
+      // Does not even start with the correct URL. Bye!
+      return;
+    }
+    url = url.match(/[&?]file=([^&#]+)/);
+    if (url) {
+      url = url[1];
+      return url;
+    }
+  }
+
+  /**
+   * @param {number} tabId ID of tab where the page action will be shown
+   * @param {string} url URL to be displayed in page action
+   */
+  function showPageAction(tabId, displayUrl) {
+    var url = parsePDFjsExtensionURL(displayUrl) || parseViewerURL(displayUrl);
+    if (url) {
+      chrome.pageAction.setPopup({
+        tabId: tabId,
+        popup: 'pageActionPopup.html?file=' + url
+      });
+      chrome.pageAction.show(tabId);
+    } else {
+      console.log('Unable to get PDF url from ' + displayUrl);
+    }
+  }
+
+  chrome.runtime.onMessage.addListener(function(message, sender) {
+    if (message === 'showPageAction' && sender.tab) {
+      showPageAction(sender.tab.id, sender.tab.url);
+    }
+  });
+
+  console.log('Set up page action.');
+})();

--- a/extensions/chromium/extension-router.js
+++ b/extensions/chromium/extension-router.js
@@ -23,72 +23,6 @@ limitations under the License.
   var VIEWER_URL = chrome.extension.getURL('content/web/viewer.html');
   var CRX_BASE_URL = chrome.extension.getURL('/');
 
-  var schemes = [
-    'http',
-    'https',
-    'ftp',
-    'file',
-    'chrome-extension',
-    // Chromium OS
-    'filesystem',
-    // Chromium OS, shorthand for filesystem:<origin>/external/
-    'drive'
-  ];
-
-  /**
-   * @param {string} url The URL prefixed with chrome-extension://.../
-   * @return {string|undefined} The percent-encoded URL of the (PDF) file.
-   */
-  function parseExtensionURL(url) {
-    url = url.substring(CRX_BASE_URL.length);
-    // Find the (url-encoded) colon and verify that the scheme is whitelisted.
-    var schemeIndex = url.search(/:|%3A/i);
-    if (schemeIndex === -1) {
-      return;
-    }
-    var scheme = url.slice(0, schemeIndex).toLowerCase();
-    if (schemes.indexOf(scheme) >= 0) {
-      url = url.split('#')[0];
-      if (url.charAt(schemeIndex) === ':') {
-        url = encodeURIComponent(url);
-      }
-      return url;
-    }
-  }
-
-  /**
-   * @param {string} url URL of PDF Viewer.
-   * @return {string|undefined} The percent-encoded URL of the (PDF) file.
-   */
-  function parseViewerURL(url) {
-    if (url.lastIndexOf(VIEWER_URL, 0) !== 0) {
-      // Does not even start with the correct URL. Bye!
-      return;
-    }
-    url = url.match(/[&?]file=([^&#]+)/);
-    if (url) {
-      url = url[1];
-      return url;
-    }
-  }
-
-  /**
-   * @param {number} tabId ID of tab where the page action will be shown
-   * @param {string} url URL to be displayed in page action
-   */
-  function showPageAction(tabId, displayUrl) {
-    var url = parseExtensionURL(displayUrl) || parseViewerURL(displayUrl);
-    if (url) {
-      chrome.pageAction.setPopup({
-        tabId: tabId,
-        popup: 'pageActionPopup.html?file=' + url
-      });
-      chrome.pageAction.show(tabId);
-    } else {
-      console.log('Unable to get PDF url from ' + displayUrl);
-    }
-  }
-
   // TODO(rob): Use declarativeWebRequest once declared URL-encoding is
   //            supported, see http://crbug.com/273589
   //            (or rewrite the query string parser in viewer.js to get it to
@@ -96,7 +30,7 @@ limitations under the License.
   chrome.webRequest.onBeforeRequest.addListener(function(details) {
     // This listener converts chrome-extension://.../http://...pdf to
     // chrome-extension://.../content/web/viewer.html?file=http%3A%2F%2F...pdf
-    var url = parseExtensionURL(details.url);
+    var url = parsePDFjsExtensionURL(details.url);
     if (url) {
       url = VIEWER_URL + '?file=' + url;
       var i = details.url.indexOf('#');
@@ -108,17 +42,11 @@ limitations under the License.
     }
   }, {
     types: ['main_frame', 'sub_frame'],
-    urls: schemes.map(function(scheme) {
+    urls: pdfSchemes.map(function(scheme) {
       // Format: "chrome-extension://[EXTENSIONID]/<scheme>*"
       return CRX_BASE_URL + scheme + '*';
     })
   }, ['blocking']);
-
-  chrome.runtime.onMessage.addListener(function(message, sender) {
-    if (message === 'showPageAction' && sender.tab) {
-      showPageAction(sender.tab.id, sender.tab.url);
-    }
-  });
 
   // When session restore is used, viewer pages may be loaded before the
   // webRequest event listener is attached (= page not found).

--- a/extensions/chromium/extension-urls.js
+++ b/extensions/chromium/extension-urls.js
@@ -1,0 +1,62 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/*
+Copyright 2014 Mozilla Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/* globals chrome */
+
+'use strict';
+
+(function ExtensionUrlClosure() {
+  var CRX_BASE_URL = chrome.extension.getURL('/');
+
+  var schemes = [
+    'http',
+    'https',
+    'ftp',
+    'file',
+    'chrome-extension',
+    // Chromium OS
+    'filesystem',
+    // Chromium OS, shorthand for filesystem:<origin>/external/
+    'drive'
+  ];
+
+  /**
+   * @param {string} url The URL prefixed with chrome-extension://.../
+   * @return {string|undefined} The percent-encoded URL of the (PDF) file.
+   */
+  function parseExtensionURL(url) {
+    url = url.substring(CRX_BASE_URL.length);
+    // Find the (url-encoded) colon and verify that the scheme is whitelisted.
+    var schemeIndex = url.search(/:|%3A/i);
+    if (schemeIndex === -1) {
+      return;
+    }
+    var scheme = url.slice(0, schemeIndex).toLowerCase();
+    if (schemes.indexOf(scheme) >= 0) {
+      url = url.split('#')[0];
+      if (url.charAt(schemeIndex) === ':') {
+        url = encodeURIComponent(url);
+      }
+      return url;
+    }
+  }
+
+  // Export this symbols globally
+  window.parsePDFjsExtensionURL = parseExtensionURL
+  window.pdfSchemes = schemes
+
+})();

--- a/extensions/chromium/pdfHandler.html
+++ b/extensions/chromium/pdfHandler.html
@@ -17,6 +17,8 @@ limitations under the License.
 <script src="chrome.tabs.executeScriptInFrame.js"></script>
 <script src="feature-detect.js"></script>
 <script src="pdfHandler.js"></script>
+<script src="extension-urls.js"></script>
 <script src="extension-router.js"></script>
+<script src="extension-pageAction.js"></script>
 <script src="pdfHandler-v2.js"></script>
 <script src="pdfHandler-vcros.js"></script>


### PR DESCRIPTION
Until now, the extension URL router and the page action code
lived in the same file.

However, some applications consuming PDF.js might want to use
one of these functionalities, but not both.

So I separated the functionalities into 3 files:
- extension-urls.js contains the common base
- extension-router.js sets up the extension URL router
- extension-pageAction sets up the page action.

All three files are now included in pdfHandler.html,

---

There is no new code added in this PR; it's just existing code being
separated into separate files.

The out-of-the-box functionality of the extension doesn't change;
this change only gives consuming applications
a finer grained control about which parts of functionality to
include.

---

There is one thing I am not sure about: what is the preferred method
of sharing symbols between these JS files?
They are all encapsulated in separate closures, so for now, I explicitly
exported two symbols into the window scope.

(If you would prefer something else, we can change that.)
