### PR TITLE
Workaround for TrueType fonts with exotic cmap tables (bug 1057544)

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -4034,7 +4034,15 @@ var Font = (function FontClosure() {
         // where the the font is symbolic and it has an encoding.
         if (hasEncoding &&
             (cmapPlatformId === 3 && cmapEncodingId === 1 ||
-             cmapPlatformId === 1 && cmapEncodingId === 0)) {
+             cmapPlatformId === 1 && cmapEncodingId === 0) ||
+            (cmapPlatformId === -1 && cmapEncodingId === -1 && // Temporary hack
+             !!Encodings[properties.baseEncodingName])) {      // Temporary hack
+          // When no preferred cmap table was found and |baseEncodingName| is
+          // one of the predefined encodings, we seem to obtain a better
+          // |charCodeToGlyphId| map from the code below (fixes bug 1057544).
+          // TODO: Note that this is a hack which should be removed as soon as
+          //       we have proper support for more exotic cmap tables.
+
           var baseEncoding = [];
           if (properties.baseEncodingName === 'MacRomanEncoding' ||
               properties.baseEncodingName === 'WinAnsiEncoding') {


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1057544.

The TrueType font used in the file has a (0, 1) cmap table, which we currently don't support. Adding support for more kinds of cmap tables is tracked in #5231, which I'll happily leave for @brendandahl when he gets back :-)

In the meantime, I'm submitting this patch to workaround the bug. Prior to #4259, we used to default to a (3, 1) cmap table when no standard one was found, which is why I hope this patch will be OK as a temporary fix.

**Note:** I'm expecting some movement, for the better, on issue4800.pdf since it has a (0, 1) cmap.
