### PR TITLE
Add PDFJS.abortGetDocument function to enable cancelling of calls to PDFJS.getDocument

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -144,7 +144,7 @@ var WorkerMessageHandler = PDFJS.WorkerMessageHandler = {
           if (status === 404) {
             var exception = new MissingPDFException('Missing PDF "' +
                                                     source.url + '".');
-            handler.send('MissingPDF', { exception: exception });
+            handler.send('MissingPDF', exception);
           } else {
             handler.send('DocError', 'Unexpected server response (' +
                          status + ') while retrieving PDF "' +
@@ -200,26 +200,17 @@ var WorkerMessageHandler = PDFJS.WorkerMessageHandler = {
       var onFailure = function(e) {
         if (e instanceof PasswordException) {
           if (e.code === PasswordResponses.NEED_PASSWORD) {
-            handler.send('NeedPassword', {
-              exception: e
-            });
+            handler.send('NeedPassword', e);
           } else if (e.code === PasswordResponses.INCORRECT_PASSWORD) {
-            handler.send('IncorrectPassword', {
-              exception: e
-            });
+            handler.send('IncorrectPassword', e);
           }
         } else if (e instanceof InvalidPDFException) {
-          handler.send('InvalidPDF', {
-            exception: e
-          });
+          handler.send('InvalidPDF', e);
         } else if (e instanceof MissingPDFException) {
-          handler.send('MissingPDF', {
-            exception: e
-          });
+          handler.send('MissingPDF', e);
         } else {
-          handler.send('UnknownError', {
-            exception: new UnknownErrorException(e.message, e.toString())
-          });
+          handler.send('UnknownError',
+                       new UnknownErrorException(e.message, e.toString()));
         }
       };
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -865,36 +865,35 @@ var WorkerTransport = (function WorkerTransportClosure() {
         this.workerReadyCapability.resolve(pdfDocument);
       }, this);
 
-      messageHandler.on('NeedPassword', function transportPassword(data) {
+      messageHandler.on('NeedPassword',
+                        function transportNeedPassword(exception) {
         if (this.passwordCallback) {
           return this.passwordCallback(updatePassword,
                                        PasswordResponses.NEED_PASSWORD);
         }
-        this.workerReadyCapability.reject(data.exception.message,
-                                          data.exception);
+        this.workerReadyCapability.reject(exception);
       }, this);
 
-      messageHandler.on('IncorrectPassword', function transportBadPass(data) {
+      messageHandler.on('IncorrectPassword',
+                        function transportIncorrectPassword(exception) {
         if (this.passwordCallback) {
           return this.passwordCallback(updatePassword,
                                        PasswordResponses.INCORRECT_PASSWORD);
         }
-        this.workerReadyCapability.reject(data.exception.message,
-                                          data.exception);
+        this.workerReadyCapability.reject(exception);
       }, this);
 
-      messageHandler.on('InvalidPDF', function transportInvalidPDF(data) {
-        this.workerReadyCapability.reject(data.exception.name, data.exception);
+      messageHandler.on('InvalidPDF', function transportInvalidPDF(exception) {
+        this.workerReadyCapability.reject(exception);
       }, this);
 
-      messageHandler.on('MissingPDF', function transportMissingPDF(data) {
-        this.workerReadyCapability.reject(data.exception.message,
-                                          data.exception);
+      messageHandler.on('MissingPDF', function transportMissingPDF(exception) {
+        this.workerReadyCapability.reject(exception);
       }, this);
 
-      messageHandler.on('UnknownError', function transportUnknownError(data) {
-        this.workerReadyCapability.reject(data.exception.message,
-                                          data.exception);
+      messageHandler.on('UnknownError',
+                        function transportUnknownError(exception) {
+        this.workerReadyCapability.reject(exception);
       }, this);
 
       messageHandler.on('DataLoaded', function transportPage(data) {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -380,6 +380,18 @@ var MissingPDFException = (function MissingPDFExceptionClosure() {
   return MissingPDFException;
 })();
 
+var AbortGetDocumentException = (function AbortGetDocumentExceptionClosure() {
+  function AbortGetDocumentException(msg) {
+    this.name = 'AbortGetDocumentException';
+    this.message = msg;
+  }
+
+  AbortGetDocumentException.prototype = new Error();
+  AbortGetDocumentException.constructor = AbortGetDocumentException;
+
+  return AbortGetDocumentException;
+})();
+
 var NotImplementedException = (function NotImplementedExceptionClosure() {
   function NotImplementedException(msg) {
     this.message = msg;
@@ -417,7 +429,6 @@ var XRefParseException = (function XRefParseExceptionClosure() {
 
   return XRefParseException;
 })();
-
 
 function bytesToString(bytes) {
   var length = bytes.length;

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -8,7 +8,7 @@
 describe('api', function() {
   // TODO run with worker enabled
   var basicApiUrl = combineUrl(window.location.href, '../pdfs/basicapi.pdf');
-  function waitsForPromise(promise, successCallback) {
+  function waitsForPromiseResolved(promise, successCallback) {
     var data;
     promise.then(function(val) {
       data = val;
@@ -22,11 +22,25 @@ describe('api', function() {
       return data !== undefined;
     }, 20000);
   }
+  function waitsForPromiseRejected(promise, failureCallback) {
+    var data;
+    promise.then(function(val) {
+      // Shouldn't get here.
+      expect(false).toEqual(true);
+    },
+    function(error) {
+      data = error;
+      failureCallback(data);
+    });
+    waitsFor(function() {
+      return data !== undefined;
+    }, 20000);
+  }
   describe('PDFJS', function() {
     describe('getDocument', function() {
       it('creates pdf doc from URL', function() {
         var promise = PDFJS.getDocument(basicApiUrl);
-        waitsForPromise(promise, function(data) {
+        waitsForPromiseResolved(promise, function(data) {
           expect(true).toEqual(true);
         });
       });
@@ -61,7 +75,7 @@ describe('api', function() {
         expect(typedArrayPdf.length).toEqual(105779);
 
         var promise = PDFJS.getDocument(typedArrayPdf);
-        waitsForPromise(promise, function(data) {
+        waitsForPromiseResolved(promise, function(data) {
           expect(true).toEqual(true);
         });
       });
@@ -70,7 +84,7 @@ describe('api', function() {
   describe('PDFDocument', function() {
     var promise = PDFJS.getDocument(basicApiUrl);
     var doc;
-    waitsForPromise(promise, function(data) {
+    waitsForPromiseResolved(promise, function(data) {
       doc = data;
     });
     it('gets number of pages', function() {
@@ -81,7 +95,7 @@ describe('api', function() {
     });
     it('gets page', function() {
       var promise = doc.getPage(1);
-      waitsForPromise(promise, function(data) {
+      waitsForPromiseResolved(promise, function(data) {
         expect(true).toEqual(true);
       });
     });
@@ -89,32 +103,32 @@ describe('api', function() {
       // reference to second page
       var ref = {num: 17, gen: 0};
       var promise = doc.getPageIndex(ref);
-      waitsForPromise(promise, function(pageIndex) {
+      waitsForPromiseResolved(promise, function(pageIndex) {
         expect(pageIndex).toEqual(1);
       });
     });
     it('gets destinations', function() {
       var promise = doc.getDestinations();
-      waitsForPromise(promise, function(data) {
+      waitsForPromiseResolved(promise, function(data) {
         expect(data).toEqual({ chapter1: [{ gen: 0, num: 17 }, { name: 'XYZ' },
                                           0, 841.89, null] });
       });
     });
     it('gets attachments', function() {
       var promise = doc.getAttachments();
-      waitsForPromise(promise, function (data) {
+      waitsForPromiseResolved(promise, function (data) {
         expect(data).toEqual(null);
       });
     });
     it('gets javascript', function() {
       var promise = doc.getJavaScript();
-      waitsForPromise(promise, function (data) {
+      waitsForPromiseResolved(promise, function (data) {
         expect(data).toEqual([]);
       });
     });
     it('gets outline', function() {
       var promise = doc.getOutline();
-      waitsForPromise(promise, function(outline) {
+      waitsForPromiseResolved(promise, function(outline) {
         // Two top level entries.
         expect(outline.length).toEqual(2);
         // Make sure some basic attributes are set.
@@ -125,26 +139,26 @@ describe('api', function() {
     });
     it('gets metadata', function() {
       var promise = doc.getMetadata();
-      waitsForPromise(promise, function(metadata) {
+      waitsForPromiseResolved(promise, function(metadata) {
         expect(metadata.info['Title']).toEqual('Basic API Test');
         expect(metadata.metadata.get('dc:title')).toEqual('Basic API Test');
       });
     });
     it('gets data', function() {
       var promise = doc.getData();
-      waitsForPromise(promise, function (data) {
+      waitsForPromiseResolved(promise, function (data) {
         expect(true).toEqual(true);
       });
     });
     it('gets filesize in bytes', function() {
       var promise = doc.getDownloadInfo();
-      waitsForPromise(promise, function (data) {
+      waitsForPromiseResolved(promise, function (data) {
         expect(data.length).toEqual(105779);
       });
     });
     it('gets stats', function() {
       var promise = doc.getStats();
-      waitsForPromise(promise, function (stats) {
+      waitsForPromiseResolved(promise, function (stats) {
         expect(isArray(stats.streamTypes)).toEqual(true);
         expect(isArray(stats.fontTypes)).toEqual(true);
       });
@@ -161,7 +175,7 @@ describe('api', function() {
       });
     });
     var page;
-    waitsForPromise(promise, function(data) {
+    waitsForPromiseResolved(promise, function(data) {
       page = data;
     });
     it('gets page number', function () {
@@ -187,13 +201,13 @@ describe('api', function() {
     });
     it('gets annotations', function () {
       var promise = page.getAnnotations();
-      waitsForPromise(promise, function (data) {
+      waitsForPromiseResolved(promise, function (data) {
         expect(data.length).toEqual(4);
       });
     });
     it('gets text content', function () {
       var promise = page.getTextContent();
-      waitsForPromise(promise, function (data) {
+      waitsForPromiseResolved(promise, function (data) {
         expect(!!data.items).toEqual(true);
         expect(data.items.length).toEqual(7);
         expect(!!data.styles).toEqual(true);
@@ -201,7 +215,7 @@ describe('api', function() {
     });
     it('gets operator list', function() {
       var promise = page.getOperatorList();
-      waitsForPromise(promise, function (oplist) {
+      waitsForPromiseResolved(promise, function (oplist) {
         expect(!!oplist.fnArray).toEqual(true);
         expect(!!oplist.argsArray).toEqual(true);
         expect(oplist.lastChunk).toEqual(true);

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1,7 +1,7 @@
 /* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 /* globals PDFJS, expect, it, describe, Promise, combineUrl, waitsFor,
-           isArray */
+           isArray, AbortGetDocumentException */
 
 'use strict';
 
@@ -77,6 +77,13 @@ describe('api', function() {
         var promise = PDFJS.getDocument(typedArrayPdf);
         waitsForPromiseResolved(promise, function(data) {
           expect(true).toEqual(true);
+        });
+      });
+      it('aborts creation of pdf doc from URL', function() {
+        var promise = PDFJS.getDocument(basicApiUrl);
+        PDFJS.abortGetDocument();
+        waitsForPromiseRejected(promise, function(error) {
+          expect(error instanceof AbortGetDocumentException).toEqual(true);
         });
       });
     });

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -672,24 +672,29 @@ var PDFView = {
         self.load(pdfDocument, scale);
         self.loading = false;
       },
-      function getDocumentError(message, exception) {
+      function getDocumentError(exception) {
+        var name, message;
+        if (exception) {
+          name = exception.name;
+          message = exception.message;
+        }
         var loadingErrorMessage = mozL10n.get('loading_error', null,
           'An error occurred while loading the PDF.');
 
-        if (exception && exception.name === 'InvalidPDFException') {
+        if (name === 'InvalidPDFException') {
           // change error message also for other builds
           loadingErrorMessage = mozL10n.get('invalid_file_error', null,
-                                        'Invalid or corrupted PDF file.');
+                                            'Invalid or corrupted PDF file.');
 //#if B2G
 //        window.alert(loadingErrorMessage);
 //        return window.close();
 //#endif
         }
 
-        if (exception && exception.name === 'MissingPDFException') {
+        if (name === 'MissingPDFException') {
           // special message for missing PDF's
           loadingErrorMessage = mozL10n.get('missing_file_error', null,
-                                        'Missing PDF file.');
+                                            'Missing PDF file.');
 
 //#if B2G
 //        window.alert(loadingErrorMessage);

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -605,6 +605,10 @@ var PDFView = {
   },
 
   close: function pdfViewClose() {
+    if (this.loading) {
+      PDFJS.abortGetDocument();
+    }
+
     var errorWrapper = document.getElementById('errorWrapper');
     errorWrapper.setAttribute('hidden', 'true');
 
@@ -678,6 +682,15 @@ var PDFView = {
           name = exception.name;
           message = exception.message;
         }
+
+        if (name === 'AbortGetDocumentException') {
+          console.log(message);
+          self.loading = false;
+          // No need to display the fallback bar (or errorWrapper) when
+          // PDFJS.getDocument was aborted during document load.
+          return;
+        }
+
         var loadingErrorMessage = mozL10n.get('loading_error', null,
           'An error occurred while loading the PDF.');
 


### PR DESCRIPTION
This PR contains a tentative patch to fix #3485 (and should also fix #5228, #4774).

I was slightly unsure of the best way to handle the rejection of `workerReadyCapability`, since it's not easily available outside of `getDocument` and I didn't just want to expose it in `PDFJS`.
A caveat with this patch is that it's only possible to abort the current `getDocument`, so if you have multiple ones active simultaneously this isn't going to work. Since this implementation should work fine when used in the generic viewer (e.g. for #5228), I don't know if it's really worth complicating the solution too much.

One other thing to note here: `abortGetDocument` really only makes sense when `getDocument` isn't resolved/rejected yet, since otherwise just calling `destroy` is enough.

~~When I started looking at this, I realized that our current exception handling code wasn't really working as intended (rejection with multiple arguments). The first commit fixes this, and I'd be happy to extract that into a separate PR if that's preferred.~~ Submitted as a separate PR.

@yurydelendik Please let me know if this PR heading in the right direction, or if you'd prefer a different/modified solution!
