### PR TITLE
Remove a duplicate PDF file from the test suite

### DIFF
--- a/test/pdfs/issue2337.pdf.link
+++ b/test/pdfs/issue2337.pdf.link
@@ -1,1 +1,0 @@
-http://mirrors.ctan.org/info/lshort/english/lshort.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -305,7 +305,8 @@
       "rounds": 1,
       "type": "eq",
       "link": true,
-      "lastPage": 1
+      "lastPage": 1,
+      "about": "The same file as issue2337."
     },
     {  "id": "thuluthfont-text",
        "file": "pdfs/ThuluthFeatures.pdf",
@@ -1335,14 +1336,6 @@
       "lastPage": 1,
       "link": true,
       "type": "eq"
-    },
-    {  "id": "issue2337",
-      "file": "pdfs/issue2337.pdf",
-      "md5": "ea10f4131202b9b8f2a6cb7770d3f185",
-      "rounds": 1,
-      "lastPage": 1,
-      "link": true,
-      "type": "load"
     },
     {  "id": "issue2074",
       "file": "pdfs/issue2074.pdf",


### PR DESCRIPTION
The files issue3115.pdf and issue2337.pdf are identical, the only difference being that the first one is an `eq` test and the second one a `load` test. Hence there is no reason to keep the `load` test, since it's just a subset of the `eq` test.
