### PR TITLE
Fix the placement of the findInput loading indicator in RTL locales

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -410,6 +410,9 @@ html[dir='rtl'] .findbar {
   background-repeat: no-repeat;
   background-position: right;
 }
+html[dir='rtl'] #findInput[data-status="pending"] {
+  background-position: left;
+}
 
 .secondaryToolbar {
   padding: 6px;


### PR DESCRIPTION
Currently in RTL locales, the loading indicator is placed such that it is in the way when entring a search term. Hence this patch moves it to the other side of the input field to fix this.

For an illustration of the issue, please see the following screenshot:
![rtl-loading](https://cloud.githubusercontent.com/assets/2692120/4037647/f2e8d2d4-2ca6-11e4-93fc-fd3b888abe98.png)

**Edit:** Test easily with http://107.22.172.223:8877/d47fe64ad146917/web/viewer.html#locale=he.
