### PR TITLE
Handtool: Remove focus from previous node on click

### DIFF
--- a/web/grab_to_pan.js
+++ b/web/grab_to_pan.js
@@ -135,6 +135,11 @@ var GrabToPan = (function GrabToPanClosure() {
       event.preventDefault();
       event.stopPropagation();
       this.document.documentElement.classList.add(this.CSS_CLASS_GRABBING);
+
+      var focusedElement = document.activeElement;
+      if (focusedElement && !focusedElement.contains(event.target)) {
+        focusedElement.blur();
+      }
     },
 
     /**


### PR DESCRIPTION
"This commit fixes the issue that a focused element cannot lose
focus when the draggable element is clicked."
https://github.com/Rob--W/grab-to-pan.js/commit/dae91a92ee47bf2

Steps to reproduce/verify:
1. Enable the hand tool (e.g. by using the <kbd>H</kbd> shortcut)
2. Click on the Page number input.
3. Click or drag the PDF canvas.
4. Observe that the page number input is still focused. Consequently, the hand tool cannot be disabled using the <kbd>H</kbd> shortcut.

After applying this patch, the input field will lose focus at step 3, and at step 4 the hand tool can successfully be toggled using the <kbd>H</kbd> shortcut.
