### PR TITLE
Implement streaming using moz-chunk-arraybuffer

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -44,6 +44,12 @@
       "type": "boolean",
       "default": false
     },
+    "disableStream": {
+      "title": "Disable streaming for requests",
+      "description": "Whether to disable streaming for requests (not recommended).",
+      "type": "boolean",
+      "default": false
+    },
     "disableAutoFetch": {
       "type": "boolean",
       "default": false

--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -41,7 +41,7 @@ var ChunkedStream = (function ChunkedStreamClosure() {
     getMissingChunks: function ChunkedStream_getMissingChunks() {
       var chunks = [];
       for (var chunk = 0, n = this.numChunks; chunk < n; ++chunk) {
-        if (!(chunk in this.loadedChunks)) {
+        if (!this.loadedChunks[chunk]) {
           chunks.push(chunk);
         }
       }
@@ -73,7 +73,7 @@ var ChunkedStream = (function ChunkedStreamClosure() {
       var curChunk;
 
       for (curChunk = beginChunk; curChunk < endChunk; ++curChunk) {
-        if (!(curChunk in this.loadedChunks)) {
+        if (!this.loadedChunks[curChunk]) {
           this.loadedChunks[curChunk] = true;
           ++this.numChunksLoaded;
         }
@@ -92,7 +92,7 @@ var ChunkedStream = (function ChunkedStreamClosure() {
                      Math.floor(position / this.chunkSize);
       var curChunk;
       for (curChunk = beginChunk; curChunk < endChunk; ++curChunk) {
-        if (!(curChunk in this.loadedChunks)) {
+        if (!this.loadedChunks[curChunk]) {
           this.loadedChunks[curChunk] = true;
           ++this.numChunksLoaded;
         }
@@ -105,7 +105,7 @@ var ChunkedStream = (function ChunkedStreamClosure() {
         return;
       }
 
-      if (!(chunk in this.loadedChunks)) {
+      if (!this.loadedChunks[chunk]) {
         throw new MissingDataException(pos, pos + 1);
       }
       this.lastSuccessfulEnsureByteChunk = chunk;
@@ -124,7 +124,7 @@ var ChunkedStream = (function ChunkedStreamClosure() {
       var beginChunk = Math.floor(begin / chunkSize);
       var endChunk = Math.floor((end - 1) / chunkSize) + 1;
       for (var chunk = beginChunk; chunk < endChunk; ++chunk) {
-        if (!(chunk in this.loadedChunks)) {
+        if (!this.loadedChunks[chunk]) {
           throw new MissingDataException(begin, end);
         }
       }
@@ -133,13 +133,13 @@ var ChunkedStream = (function ChunkedStreamClosure() {
     nextEmptyChunk: function ChunkedStream_nextEmptyChunk(beginChunk) {
       var chunk, n;
       for (chunk = beginChunk, n = this.numChunks; chunk < n; ++chunk) {
-        if (!(chunk in this.loadedChunks)) {
+        if (!this.loadedChunks[chunk]) {
           return chunk;
         }
       }
       // Wrap around to beginning
       for (chunk = 0; chunk < beginChunk; ++chunk) {
-        if (!(chunk in this.loadedChunks)) {
+        if (!this.loadedChunks[chunk]) {
           return chunk;
         }
       }
@@ -147,7 +147,7 @@ var ChunkedStream = (function ChunkedStreamClosure() {
     },
 
     hasChunk: function ChunkedStream_hasChunk(chunk) {
-      return chunk in this.loadedChunks;
+      return !!this.loadedChunks[chunk];
     },
 
     get length() {
@@ -246,7 +246,7 @@ var ChunkedStream = (function ChunkedStreamClosure() {
         var endChunk = Math.floor((this.end - 1) / chunkSize) + 1;
         var missingChunks = [];
         for (var chunk = beginChunk; chunk < endChunk; ++chunk) {
-          if (!(chunk in this.loadedChunks)) {
+          if (!this.loadedChunks[chunk]) {
             missingChunks.push(chunk);
           }
         }

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -65,6 +65,10 @@ var BasePdfManager = (function BasePdfManagerClosure() {
       return new NotImplementedException();
     },
 
+    sendProgressiveData: function BasePdfManager_sendProgressiveData(chunk) {
+      return new NotImplementedException();
+    },
+
     updatePassword: function BasePdfManager_updatePassword(password) {
       this.pdfDocument.xref.password = this.password = password;
       if (this._passwordChangedCapability) {
@@ -199,6 +203,11 @@ var NetworkPdfManager = (function NetworkPdfManagerClosure() {
   NetworkPdfManager.prototype.requestLoadedStream =
       function NetworkPdfManager_requestLoadedStream() {
     this.streamManager.requestAllChunks();
+  };
+
+  NetworkPdfManager.prototype.sendProgressiveData =
+      function NetworkPdfManager_sendProgressiveData(chunk) {
+    this.streamManager.onReceiveData({ chunk: chunk });
   };
 
   NetworkPdfManager.prototype.onLoadedStream =

--- a/web/default_preferences.js
+++ b/web/default_preferences.js
@@ -28,6 +28,7 @@ var DEFAULT_PREFERENCES = {
   enableWebGL: false,
   pdfBugEnabled: false,
   disableRange: false,
+  disableStream: false,
   disableAutoFetch: false,
   disableFontFace: false,
 //#if B2G


### PR DESCRIPTION
Implements #4739 with `moz-chunk-arraybuffer`. Support of the http://www.w3.org/TR/streams-api/ will be easier to add.

The PDFJS.disableStream option added to disable this functionality. Currently it autodetects presence of moz-chunk-arraybuffer feature, and if enabled turns on the streaming of the PDF (in addition to range requests). The disableAutoFetch is true when streaming in process.
