### PR TITLE
Opera fixes

### DIFF
--- a/extensions/chromium/pdfHandler-v2.js
+++ b/extensions/chromium/pdfHandler-v2.js
@@ -180,6 +180,16 @@ limitations under the License.
    *                       (added in Chrome 29, http://crbug.com/230346)
    */
   function handleStream(mimeType, pdfUrl, streamUrl, tabId, expectedSize) {
+    if (typeof mimeType === 'object') {
+      // API change: argument list -> object, see crbug.com/345882
+      // documentation: chrome/common/extensions/api/streams_private.idl
+      var streamInfo = mimeType;
+      mimeType = streamInfo.mimeType;
+      pdfUrl = streamInfo.originalUrl;
+      streamUrl = streamInfo.streamUrl;
+      tabId = streamInfo.tabId;
+      expectedSize = streamInfo.expectedContentSize;
+    }
     console.log('Intercepted ' + mimeType + ' in tab ' + tabId + ' with URL ' +
                 pdfUrl + '\nAvailable as: ' + streamUrl);
     streamSupportsTabId = typeof tabId === 'number';

--- a/web/preferences.js
+++ b/web/preferences.js
@@ -204,11 +204,15 @@ var Preferences = {
 //      // These preferences can be overridden by the user.
 //      chrome.storage.managed.get(DEFAULT_PREFERENCES, getPreferences);
 //    } else {
-//      // Managed storage not supported, e.g. in Opera.
+//      // Managed storage not supported, e.g. in old Chromium versions.
 //      getPreferences(DEFAULT_PREFERENCES);
 //    }
 //
 //    function getPreferences(defaultPrefs) {
+//      if (chrome.runtime.lastError) {
+//        // Managed storage not supported, e.g. in Opera.
+//        defaultPrefs = DEFAULT_PREFERENCES;
+//      }
 //      chrome.storage.local.get(defaultPrefs, function(readPrefs) {
 //        resolve(readPrefs);
 //      });


### PR DESCRIPTION
Some miscellaneous bugs that I spotted when @5953lc and I got in a debugging session.

The streamsPrivate API change is an important fix that re-enables POST support for Opera.
