### PR TITLE
Fix loading of inline JPEG images

### DIFF
--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -195,6 +195,12 @@ var ChunkedStream = (function ChunkedStreamClosure() {
       return bytes.subarray(pos, end);
     },
 
+    peekByte: function ChunkedStream_peekByte() {
+      var peekedByte = this.getByte();
+      this.pos--;
+      return peekedByte;
+    },
+
     peekBytes: function ChunkedStream_peekBytes(length) {
       var bytes = this.getBytes(length);
       this.pos -= bytes.length;

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -478,7 +478,7 @@ var Lexer = (function LexerClosure() {
       return (this.currentChar = this.stream.getByte());
     },
     peekChar: function Lexer_peekChar() {
-      return this.stream.peekBytes(1)[0];
+      return this.stream.peekByte();
     },
     getNumber: function Lexer_getNumber() {
       var ch = this.currentChar;

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -372,6 +372,22 @@ var Parser = (function ParserClosure() {
           return new LZWStream(stream, maybeLength, earlyChange);
         }
         if (name === 'DCTDecode' || name === 'DCT') {
+          // According to the specification: for inline images, the ID operator
+          // shall be followed by a single whitespace character (unless it uses
+          // ASCII85Decode or ASCIIHexDecode filters).
+          // In practice this only seems to be followed for inline JPEG images,
+          // and generally ignoring the first byte of the stream if it is a
+          // whitespace char can even *cause* issues (e.g. in the CCITTFaxDecode
+          // filters used in issue2984.pdf).
+          // Hence when the first byte of the stream of an inline JPEG image is
+          // a whitespace character, we thus simply skip over it.
+          if (isCmd(this.buf1, 'ID')) {
+            var firstByte = stream.peekByte();
+            if (firstByte === 0x0A /* LF */ || firstByte === 0x0D /* CR */ ||
+                firstByte === 0x20 /* SPACE */) {
+              stream.skip();
+            }
+          }
           xrefStreamStats[StreamType.DCT] = true;
           return new JpegStream(stream, maybeLength, stream.dict, this.xref);
         }

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -73,6 +73,11 @@ var Stream = (function StreamClosure() {
       this.pos = end;
       return bytes.subarray(pos, end);
     },
+    peekByte: function Stream_peekByte() {
+      var peekedByte = this.getByte();
+      this.pos--;
+      return peekedByte;
+    },
     peekBytes: function Stream_peekBytes(length) {
       var bytes = this.getBytes(length);
       this.pos -= bytes.length;
@@ -201,6 +206,11 @@ var DecodeStream = (function DecodeStreamClosure() {
 
       this.pos = end;
       return this.buffer.subarray(pos, end);
+    },
+    peekByte: function DecodeStream_peekByte() {
+      var peekedByte = this.getByte();
+      this.pos--;
+      return peekedByte;
     },
     peekBytes: function DecodeStream_peekBytes(length) {
       var bytes = this.getBytes(length);
@@ -527,7 +537,7 @@ var FlateStream = (function FlateStreamClosure() {
       var end = bufferLength + blockLen;
       this.bufferLength = end;
       if (blockLen === 0) {
-        if (str.peekBytes(1).length === 0) {
+        if (str.peekByte() === -1) {
           this.eof = true;
         }
       } else {


### PR DESCRIPTION
This is a tentative patch to fix loading of inline JPEG images, based on this paragraph: http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#page=223&zoom=auto,0,600.

Fixes #2812.
Fixes #4776.
Fixes [bug 1065245](https://bugzilla.mozilla.org/show_bug.cgi?id=1065245)

Also fixes missing images in (but the text is still incorrect):
#2840.
#4054.
