### PR TITLE
Bug 1031612 - In PDF Viewer, the buggy XMP title "Untitled" overrides th...

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1164,7 +1164,11 @@ var PDFView = {
 
       var pdfTitle;
       if (metadata && metadata.has('dc:title')) {
-        pdfTitle = metadata.get('dc:title');
+        var title = metadata.get('dc:title');
+        // Ghostscript sometimes return 'Untitled', sets the title to 'Untitled'
+        if (title !== 'Untitled') {
+          pdfTitle = title;
+        }
       }
 
       if (!pdfTitle && info && info['Title']) {


### PR DESCRIPTION
...e document info title

Reordered to make sure if info['Title'] exists, assign pdfTitle to it.
