### PR TITLE
Refactoring to move page display code into separate class

### DIFF
--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* globals chrome, PDFJS, PDFView */
+/* globals chrome, PDFJS, PDFViewerApplication */
 'use strict';
 
 var ChromeCom = (function ChromeComClosure() {
@@ -64,10 +64,10 @@ var ChromeCom = (function ChromeComClosure() {
         var streamUrl = response.streamUrl;
         if (streamUrl) {
           console.log('Found data stream for ' + file);
-          PDFView.open(streamUrl, 0, undefined, undefined, {
+          PDFViewerApplication.open(streamUrl, 0, undefined, undefined, {
             length: response.contentLength
           });
-          PDFView.setTitleUsingUrl(file);
+          PDFViewerApplication.setTitleUsingUrl(file);
           return;
         }
         if (isFTPFile && !response.extensionSupportsFTP) {
@@ -91,7 +91,7 @@ var ChromeCom = (function ChromeComClosure() {
         resolveLocalFileSystemURL(file, function onResolvedFSURL(fileEntry) {
           fileEntry.file(function(fileObject) {
             var blobUrl = URL.createObjectURL(fileObject);
-            PDFView.open(blobUrl, 0, undefined, undefined, {
+            PDFViewerApplication.open(blobUrl, 0, undefined, undefined, {
               length: fileObject.size
             });
           });
@@ -100,11 +100,11 @@ var ChromeCom = (function ChromeComClosure() {
           // usual way of getting the File's data (via the Web worker).
           console.warn('Cannot resolve file ' + file + ', ' + error.name + ' ' +
                        error.message);
-          PDFView.open(file, 0);
+          PDFViewerApplication.open(file, 0);
         });
         return;
       }
-      PDFView.open(file, 0);
+      PDFViewerApplication.open(file, 0);
     });
   };
   return ChromeCom;

--- a/web/document_attachments_view.js
+++ b/web/document_attachments_view.js
@@ -14,20 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFView, DownloadManager, getFileName */
+/* globals DownloadManager, getFileName */
 
 'use strict';
 
-var DocumentAttachmentsView = function documentAttachmentsView(attachments) {
-  var attachmentsView = document.getElementById('attachmentsView');
+var DocumentAttachmentsView = function documentAttachmentsView(options) {
+  var attachments = options.attachments;
+  var attachmentsView = options.attachmentsView;
   while (attachmentsView.firstChild) {
     attachmentsView.removeChild(attachmentsView.firstChild);
   }
 
   if (!attachments) {
-    if (!attachmentsView.classList.contains('hidden')) {
-      PDFView.switchSidebarView('thumbs');
-    }
     return;
   }
 

--- a/web/document_outline_view.js
+++ b/web/document_outline_view.js
@@ -14,27 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFView */
 
 'use strict';
 
-var DocumentOutlineView = function documentOutlineView(outline) {
-  var outlineView = document.getElementById('outlineView');
+var DocumentOutlineView = function documentOutlineView(options) {
+  var outline = options.outline;
+  var outlineView = options.outlineView;
   while (outlineView.firstChild) {
     outlineView.removeChild(outlineView.firstChild);
   }
 
   if (!outline) {
-    if (!outlineView.classList.contains('hidden')) {
-      PDFView.switchSidebarView('thumbs');
-    }
     return;
   }
 
+  var linkService = options.linkService;
+
   function bindItemLink(domObj, item) {
-    domObj.href = PDFView.getDestinationHash(item.dest);
+    domObj.href = linkService.getDestinationHash(item.dest);
     domObj.onclick = function documentOutlineViewOnclick(e) {
-      PDFView.navigateTo(item.dest);
+      linkService.navigateTo(item.dest);
       return false;
     };
   }

--- a/web/document_properties.js
+++ b/web/document_properties.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFView, Promise, mozL10n, getPDFFileNameFromURL, OverlayManager */
+/* globals Promise, mozL10n, getPDFFileNameFromURL, OverlayManager */
 
 'use strict';
 
@@ -35,6 +35,8 @@ var DocumentProperties = {
   producerField: null,
   versionField: null,
   pageCountField: null,
+  url: null,
+  pdfDocument: null,
 
   initialize: function documentPropertiesInitialize(options) {
     this.overlayName = options.overlayName;
@@ -72,7 +74,7 @@ var DocumentProperties = {
       return;
     }
     // Get the file size (if it hasn't already been set).
-    PDFView.pdfDocument.getDownloadInfo().then(function(data) {
+    this.pdfDocument.getDownloadInfo().then(function(data) {
       if (data.length === this.rawFileSize) {
         return;
       }
@@ -81,10 +83,10 @@ var DocumentProperties = {
     }.bind(this));
 
     // Get the document properties.
-    PDFView.pdfDocument.getMetadata().then(function(data) {
+    this.pdfDocument.getMetadata().then(function(data) {
       var fields = [
         { field: this.fileNameField,
-          content: getPDFFileNameFromURL(PDFView.url) },
+          content: getPDFFileNameFromURL(this.url) },
         { field: this.fileSizeField, content: this.parseFileSize() },
         { field: this.titleField, content: data.info.Title },
         { field: this.authorField, content: data.info.Author },
@@ -97,7 +99,7 @@ var DocumentProperties = {
         { field: this.creatorField, content: data.info.Creator },
         { field: this.producerField, content: data.info.Producer },
         { field: this.versionField, content: data.info.PDFFormatVersion },
-        { field: this.pageCountField, content: PDFView.pdfDocument.numPages }
+        { field: this.pageCountField, content: this.pdfDocument.numPages }
       ];
 
       // Show the properties in the dialog.

--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -1,0 +1,77 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* Copyright 2012 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+/**
+ * @interface
+ */
+function IPDFLinkService() {}
+IPDFLinkService.prototype = {
+  /**
+   * @returns {number}
+   */
+  get page() {},
+  /**
+   * @param {number} value
+   */
+  set page(value) {},
+  /**
+   * @param dest - The PDF destination object.
+   */
+  navigateTo: function (dest) {},
+  /**
+   * @param dest - The PDF destination object.
+   * @returns {string} The hyperlink to the PDF object.
+   */
+  getDestinationHash: function (dest) {},
+  /**
+   * @param hash - The PDF parameters/hash.
+   * @returns {string} The hyperlink to the PDF object.
+   */
+  getAnchorUrl: function (hash) {},
+};
+
+/**
+ * @interface
+ */
+function IRenderableView() {}
+IRenderableView.prototype = {
+  /**
+   * @returns {string} - Unique ID for rendering queue.
+   */
+  get renderingId() {},
+  /**
+   * @returns {RenderingStates}
+   */
+  get renderingState() {},
+  /**
+   * @param {function} callback - The draw completion callback.
+   */
+  draw: function (callback) {},
+  resume: function () {},
+};
+
+/**
+ * @interface
+ */
+function ILastScrollSource() {}
+ILastScrollSource.prototype = {
+  /**
+   * @returns {number}
+   */
+  get lastScroll() {},
+};

--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -43,6 +43,10 @@ IPDFLinkService.prototype = {
    * @returns {string} The hyperlink to the PDF object.
    */
   getAnchorUrl: function (hash) {},
+  /**
+   * @param {string} hash
+   */
+  setHash: function (hash) {},
 };
 
 /**

--- a/web/page_view.js
+++ b/web/page_view.js
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 /* globals RenderingStates, PDFView, PDFJS, mozL10n, CustomStyle,
-           PresentationMode, scrollIntoView, SCROLLBAR_PADDING, CSS_UNITS,
-           UNKNOWN_SCALE, DEFAULT_SCALE, getOutputScale, TextLayerBuilder,
-           Stats */
+           SCROLLBAR_PADDING, CSS_UNITS, UNKNOWN_SCALE, DEFAULT_SCALE,
+           getOutputScale, TextLayerBuilder, scrollIntoView, Stats,
+           PresentationModeState */
 
 'use strict';
 
@@ -346,7 +346,8 @@ var PageView = function pageView(container, id, scale, defaultViewport,
   };
 
   this.scrollIntoView = function pageViewScrollIntoView(dest) {
-    if (PresentationMode.active) {
+    if (this.viewer.presentationModeState ===
+        PresentationModeState.FULLSCREEN) {
       if (this.linkService.page !== this.id) {
         // Avoid breaking getVisiblePages in presentation mode.
         this.linkService.page = this.id;
@@ -520,13 +521,15 @@ var PageView = function pageView(container, id, scale, defaultViewport,
         div.appendChild(textLayerDiv);
       }
     }
+    var isViewerInPresentationMode =
+      this.viewer.presentationModeState === PresentationModeState.FULLSCREEN;
     var textLayer = this.textLayer =
       textLayerDiv ? new TextLayerBuilder({
         textLayerDiv: textLayerDiv,
         pageIndex: this.id - 1,
         lastScrollSource: this.linkService,
         viewport: this.viewport,
-        isViewerInPresentationMode: PresentationMode.active,
+        isViewerInPresentationMode: isViewerInPresentationMode,
         findController: PDFView.findController
       }) : null;
     // TODO(mack): use data attributes to store these

--- a/web/page_view.js
+++ b/web/page_view.js
@@ -20,6 +20,20 @@
 
 'use strict';
 
+/**
+ * @constructor
+ * @param {HTMLDivElement} container - The viewer element.
+ * @param {number} id - The page unique ID (normally its number).
+ * @param {number} scale - The page scale display.
+ * @param {PageViewport} defaultViewport - The page viewport.
+ * @param {IPDFLinkService} linkService - The navigation/linking service.
+ * @param {PDFRenderingQueue} renderingQueue - The rendering queue object.
+ * @param {Cache} cache - The page cache.
+ * @param {PDFPageSource} pageSource
+ * @param {PDFViewer} viewer
+ *
+ * @implements {IRenderableView}
+ */
 var PageView = function pageView(container, id, scale, defaultViewport,
                                  linkService, renderingQueue, cache,
                                  pageSource, viewer) {

--- a/web/page_view.js
+++ b/web/page_view.js
@@ -353,7 +353,8 @@ var PageView = function pageView(container, id, scale, defaultViewport,
         return;
       }
       dest = null;
-      this.viewer.setScale(this.viewer.currentScaleValue, true, true);
+      // Fixes the case when PDF has different page sizes.
+      this.viewer.currentScaleValue = this.viewer.currentScaleValue;
     }
     if (!dest) {
       scrollIntoView(div);
@@ -413,9 +414,9 @@ var PageView = function pageView(container, id, scale, defaultViewport,
     }
 
     if (scale && scale !== this.viewer.currentScale) {
-      this.viewer.setScale(scale, true, true);
+      this.viewer.currentScaleValue = scale;
     } else if (this.viewer.currentScale === UNKNOWN_SCALE) {
-      this.viewer.setScale(DEFAULT_SCALE, true, true);
+      this.viewer.currentScaleValue = DEFAULT_SCALE;
     }
 
     if (scale === 'page-fit' && !dest[4]) {

--- a/web/page_view.js
+++ b/web/page_view.js
@@ -22,7 +22,8 @@
 'use strict';
 
 var PageView = function pageView(container, id, scale, defaultViewport,
-                                 linkService, renderingQueue, cache, viewer) {
+                                 linkService, renderingQueue, cache,
+                                 pageSource, viewer) {
   this.id = id;
 
   this.rotation = 0;
@@ -34,6 +35,7 @@ var PageView = function pageView(container, id, scale, defaultViewport,
   this.linkService = linkService;
   this.renderingQueue = renderingQueue;
   this.cache = cache;
+  this.pageSource = pageSource;
   this.viewer = viewer;
 
   this.renderingState = RenderingStates.INITIAL;
@@ -430,12 +432,6 @@ var PageView = function pageView(container, id, scale, defaultViewport,
     scrollIntoView(div, { left: left, top: top });
   };
 
-  this.getTextContent = function pageviewGetTextContent() {
-    return this.renderingQueue.getPage(this.id).then(function(pdfPage) {
-      return pdfPage.getTextContent();
-    });
-  };
-
   this.draw = function pageviewDraw(callback) {
     var pdfPage = this.pdfPage;
 
@@ -443,7 +439,7 @@ var PageView = function pageView(container, id, scale, defaultViewport,
       return;
     }
     if (!pdfPage) {
-      var promise = this.renderingQueue.getPage(this.id);
+      var promise = this.pageSource.getPage();
       promise.then(function(pdfPage) {
         delete this.pagePdfPromise;
         this.setPdfPage(pdfPage);
@@ -631,7 +627,7 @@ var PageView = function pageView(container, id, scale, defaultViewport,
       function pdfPageRenderCallback() {
         pageViewDrawCallback(null);
         if (textLayer) {
-          self.getTextContent().then(
+          self.pdfPage.getTextContent().then(
             function textContentResolved(textContent) {
               textLayer.setTextContent(textContent);
             }

--- a/web/page_view.js
+++ b/web/page_view.js
@@ -25,6 +25,7 @@ var PageView = function pageView(container, id, scale, defaultViewport,
                                  linkService, renderingQueue, cache,
                                  pageSource, viewer) {
   this.id = id;
+  this.renderingId = 'page' + id;
 
   this.rotation = 0;
   this.scale = scale || 1.0;
@@ -610,7 +611,7 @@ var PageView = function pageView(container, id, scale, defaultViewport,
       viewport: this.viewport,
       // intent: 'default', // === 'display'
       continueCallback: function pdfViewcContinueCallback(cont) {
-        if (self.renderingQueue.highestPriorityPage !== 'page' + self.id) {
+        if (!self.renderingQueue.isHighestPriority(self)) {
           self.renderingState = RenderingStates.PAUSED;
           self.resume = function resumeCallback() {
             self.renderingState = RenderingStates.RUNNING;

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -137,7 +137,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
 
       this.pageContents = [];
       var extractTextPromisesResolves = [];
-      var numPages = this.pdfPageSource.pdfDocument.numPages;
+      var numPages = this.pdfPageSource.pagesCount;
       for (var i = 0; i < numPages; i++) {
         this.extractTextPromises.push(new Promise(function (resolve) {
           extractTextPromisesResolves.push(resolve);
@@ -146,7 +146,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
 
       var self = this;
       function extractPageText(pageIndex) {
-        self.pdfPageSource.pages[pageIndex].getTextContent().then(
+        self.pdfPageSource.getPageView(pageIndex).getTextContent().then(
           function textContentResolved(textContent) {
             var textItems = textContent.items;
             var str = [];
@@ -159,7 +159,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
             self.pageContents.push(str.join(''));
 
             extractTextPromisesResolves[pageIndex](pageIndex);
-            if ((pageIndex + 1) < self.pdfPageSource.pages.length) {
+            if ((pageIndex + 1) < self.pdfPageSource.pagesCount) {
               extractPageText(pageIndex + 1);
             }
           }
@@ -189,7 +189,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
     },
 
     updatePage: function PDFFindController_updatePage(index) {
-      var page = this.pdfPageSource.pages[index];
+      var page = this.pdfPageSource.getPageView(index);
 
       if (this.selected.pageIdx === index) {
         // If the page is selected, scroll the page into view, which triggers
@@ -206,7 +206,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
     nextMatch: function PDFFindController_nextMatch() {
       var previous = this.state.findPrevious;
       var currentPageIndex = this.pdfPageSource.page - 1;
-      var numPages = this.pdfPageSource.pages.length;
+      var numPages = this.pdfPageSource.pagesCount;
 
       this.active = true;
 

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -13,9 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS, FindStates, FirefoxCom, Promise */
+/* globals PDFJS, FirefoxCom, Promise */
 
 'use strict';
+
+var FindStates = {
+  FIND_FOUND: 0,
+  FIND_NOTFOUND: 1,
+  FIND_WRAPPED: 2,
+  FIND_PENDING: 3
+};
 
 /**
  * Provides "search" or "find" functionality for the PDF.
@@ -41,7 +48,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
     this.state = null;
     this.dirtyMatch = false;
     this.findTimeout = null;
-    this.pdfPageSource = options.pdfPageSource || null;
+    this.pdfViewer = options.pdfViewer || null;
     this.integratedFind = options.integratedFind || false;
     this.charactersToNormalize = {
       '\u2018': '\'', // Left single quotation mark
@@ -137,7 +144,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
 
       this.pageContents = [];
       var extractTextPromisesResolves = [];
-      var numPages = this.pdfPageSource.pagesCount;
+      var numPages = this.pdfViewer.pagesCount;
       for (var i = 0; i < numPages; i++) {
         this.extractTextPromises.push(new Promise(function (resolve) {
           extractTextPromisesResolves.push(resolve);
@@ -146,7 +153,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
 
       var self = this;
       function extractPageText(pageIndex) {
-        self.pdfPageSource.getPageView(pageIndex).getTextContent().then(
+        self.pdfViewer.getPageTextContent(pageIndex).then(
           function textContentResolved(textContent) {
             var textItems = textContent.items;
             var str = [];
@@ -159,7 +166,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
             self.pageContents.push(str.join(''));
 
             extractTextPromisesResolves[pageIndex](pageIndex);
-            if ((pageIndex + 1) < self.pdfPageSource.pagesCount) {
+            if ((pageIndex + 1) < self.pdfViewer.pagesCount) {
               extractPageText(pageIndex + 1);
             }
           }
@@ -189,7 +196,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
     },
 
     updatePage: function PDFFindController_updatePage(index) {
-      var page = this.pdfPageSource.getPageView(index);
+      var page = this.pdfViewer.getPageView(index);
 
       if (this.selected.pageIdx === index) {
         // If the page is selected, scroll the page into view, which triggers
@@ -205,8 +212,8 @@ var PDFFindController = (function PDFFindControllerClosure() {
 
     nextMatch: function PDFFindController_nextMatch() {
       var previous = this.state.findPrevious;
-      var currentPageIndex = this.pdfPageSource.page - 1;
-      var numPages = this.pdfPageSource.pagesCount;
+      var currentPageIndex = this.pdfViewer.currentPageNumber - 1;
+      var numPages = this.pdfViewer.pagesCount;
 
       this.active = true;
 
@@ -346,7 +353,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
     
       this.updateUIState(state, this.state.findPrevious);
       if (this.selected.pageIdx !== -1) {
-        this.updatePage(this.selected.pageIdx, true);
+        this.updatePage(this.selected.pageIdx);
       }
     },
 

--- a/web/pdf_rendering_queue.js
+++ b/web/pdf_rendering_queue.js
@@ -14,9 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*globals CLEANUP_TIMEOUT */
 
 'use strict';
+
+var CLEANUP_TIMEOUT = 30000;
 
 var RenderingStates = {
   INITIAL: 0,

--- a/web/pdf_rendering_queue.js
+++ b/web/pdf_rendering_queue.js
@@ -26,7 +26,14 @@ var RenderingStates = {
   FINISHED: 3
 };
 
+/**
+ * Controls rendering of the views for pages and thumbnails.
+ * @class
+ */
 var PDFRenderingQueue = (function PDFRenderingQueueClosure() {
+  /**
+   * @constructs
+   */
   function PDFRenderingQueue() {
     this.pdfViewer = null;
     this.pdfThumbnailViewer = null;
@@ -38,16 +45,26 @@ var PDFRenderingQueue = (function PDFRenderingQueueClosure() {
     this.isThumbnailViewEnabled = false;
   }
 
-  PDFRenderingQueue.prototype = {
+  PDFRenderingQueue.prototype = /** @lends PDFRenderingQueue.prototype */ {
+    /**
+     * @param {PDFViewer} pdfViewer
+     */
     setViewer: function PDFRenderingQueue_setViewer(pdfViewer) {
       this.pdfViewer = pdfViewer;
     },
 
+    /**
+     * @param {PDFThumbnailViewer} pdfThumbnailViewer
+     */
     setThumbnailViewer:
         function PDFRenderingQueue_setThumbnailViewer(pdfThumbnailViewer) {
       this.pdfThumbnailViewer = pdfThumbnailViewer;
     },
 
+    /**
+     * @param {IRenderableView} view
+     * @returns {boolean}
+     */
     isHighestPriority: function PDFRenderingQueue_isHighestPriority(view) {
       return this.highestPriorityPage === view.renderingId;
     },
@@ -120,13 +137,20 @@ var PDFRenderingQueue = (function PDFRenderingQueueClosure() {
       return null;
     },
 
+    /**
+     * @param {IRenderableView} view
+     * @returns {boolean}
+     */
     isViewFinished: function PDFRenderingQueue_isViewFinished(view) {
       return view.renderingState === RenderingStates.FINISHED;
     },
 
-    // Render a page or thumbnail view. This calls the appropriate function
-    // based on the views state. If the view is already rendered it will return
-    // false.
+    /**
+     * Render a page or thumbnail view. This calls the appropriate function
+     * based on the views state. If the view is already rendered it will return
+     * false.
+     * @param {IRenderableView} view
+     */
     renderView: function PDFRenderingQueue_renderView(view) {
       var state = view.renderingState;
       switch (state) {

--- a/web/pdf_rendering_queue.js
+++ b/web/pdf_rendering_queue.js
@@ -1,0 +1,151 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/* Copyright 2012 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*globals CLEANUP_TIMEOUT */
+
+'use strict';
+
+var RenderingStates = {
+  INITIAL: 0,
+  RUNNING: 1,
+  PAUSED: 2,
+  FINISHED: 3
+};
+
+var PDFRenderingQueue = (function PDFRenderingQueueClosure() {
+  function PDFRenderingQueue() {
+    this.pdfViewer = null;
+    this.pdfThumbnailViewer = null;
+    this.onIdle = null;
+
+    this.highestPriorityPage = null;
+    this.idleTimeout = null;
+    this.printing = false;
+    this.isThumbnailViewEnabled = false;
+  }
+
+  PDFRenderingQueue.prototype = {
+    setViewer: function PDFRenderingQueue_setViewer(pdfViewer) {
+      this.pdfViewer = pdfViewer;
+    },
+
+    setThumbnailViewer:
+        function PDFRenderingQueue_setThumbnailViewer(pdfThumbnailViewer) {
+      this.pdfThumbnailViewer = pdfThumbnailViewer;
+    },
+
+    isHighestPriority: function PDFRenderingQueue_isHighestPriority(view) {
+      return this.highestPriorityPage === view.renderingId;
+    },
+
+    renderHighestPriority: function
+        PDFRenderingQueue_renderHighestPriority(currentlyVisiblePages) {
+      if (this.idleTimeout) {
+        clearTimeout(this.idleTimeout);
+        this.idleTimeout = null;
+      }
+
+      // Pages have a higher priority than thumbnails, so check them first.
+      if (this.pdfViewer.forceRendering(currentlyVisiblePages)) {
+        return;
+      }
+      // No pages needed rendering so check thumbnails.
+      if (this.pdfThumbnailViewer && this.isThumbnailViewEnabled) {
+        if (this.pdfThumbnailViewer.forceRendering()) {
+          return;
+        }
+      }
+
+      if (this.printing) {
+        // If printing is currently ongoing do not reschedule cleanup.
+        return;
+      }
+
+      if (this.onIdle) {
+        this.idleTimeout = setTimeout(this.onIdle.bind(this), CLEANUP_TIMEOUT);
+      }
+    },
+
+    getHighestPriority: function
+        PDFRenderingQueue_getHighestPriority(visible, views, scrolledDown) {
+      // The state has changed figure out which page has the highest priority to
+      // render next (if any).
+      // Priority:
+      // 1 visible pages
+      // 2 if last scrolled down page after the visible pages
+      // 2 if last scrolled up page before the visible pages
+      var visibleViews = visible.views;
+
+      var numVisible = visibleViews.length;
+      if (numVisible === 0) {
+        return false;
+      }
+      for (var i = 0; i < numVisible; ++i) {
+        var view = visibleViews[i].view;
+        if (!this.isViewFinished(view)) {
+          return view;
+        }
+      }
+
+      // All the visible views have rendered, try to render next/previous pages.
+      if (scrolledDown) {
+        var nextPageIndex = visible.last.id;
+        // ID's start at 1 so no need to add 1.
+        if (views[nextPageIndex] &&
+            !this.isViewFinished(views[nextPageIndex])) {
+          return views[nextPageIndex];
+        }
+      } else {
+        var previousPageIndex = visible.first.id - 2;
+        if (views[previousPageIndex] &&
+          !this.isViewFinished(views[previousPageIndex])) {
+          return views[previousPageIndex];
+        }
+      }
+      // Everything that needs to be rendered has been.
+      return null;
+    },
+
+    isViewFinished: function PDFRenderingQueue_isViewFinished(view) {
+      return view.renderingState === RenderingStates.FINISHED;
+    },
+
+    // Render a page or thumbnail view. This calls the appropriate function
+    // based on the views state. If the view is already rendered it will return
+    // false.
+    renderView: function PDFRenderingQueue_renderView(view) {
+      var state = view.renderingState;
+      switch (state) {
+        case RenderingStates.FINISHED:
+          return false;
+        case RenderingStates.PAUSED:
+          this.highestPriorityPage = view.renderingId;
+          view.resume();
+          break;
+        case RenderingStates.RUNNING:
+          this.highestPriorityPage = view.renderingId;
+          break;
+        case RenderingStates.INITIAL:
+          this.highestPriorityPage = view.renderingId;
+          view.draw(this.renderHighestPriority.bind(this));
+          break;
+      }
+      return true;
+    },
+  };
+
+  return PDFRenderingQueue;
+})();

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -17,7 +17,7 @@
  /*globals watchScroll, Cache, DEFAULT_CACHE_SIZE, PageView, UNKNOWN_SCALE,
            IGNORE_CURRENT_POSITION_ON_ZOOM, SCROLLBAR_PADDING, VERTICAL_PADDING,
            MAX_AUTO_SCALE, getVisibleElements, RenderingStates, Promise,
-           CSS_UNITS, PDFJS */
+           CSS_UNITS, PDFJS, TextLayerBuilder */
 
 'use strict';
 
@@ -36,6 +36,7 @@ var PDFViewer = (function pdfViewer() {
     this.linkService = options.linkService;
 
     this.scroll = watchScroll(this.container, this._scrollUpdate.bind(this));
+    this.lastScroll = 0;
     this.updateInProgress = false;
     this.presentationModeState = PresentationModeState.UNKNOWN;
     this.resetView();
@@ -180,6 +181,8 @@ var PDFViewer = (function pdfViewer() {
     },
 
     _scrollUpdate: function () {
+      this.lastScroll = Date.now();
+
       if (this.pagesCount === 0) {
         return;
       }
@@ -410,6 +413,23 @@ var PDFViewer = (function pdfViewer() {
       return this.pdfDocument.getPage(pageIndex + 1).then(function (page) {
         return page.getTextContent();
       });
+    },
+
+    createTextLayerBuilder: function (textLayerDiv, pageIndex, viewport) {
+      var isViewerInPresentationMode =
+        this.presentationModeState === PresentationModeState.FULLSCREEN;
+      return new TextLayerBuilder({
+        textLayerDiv: textLayerDiv,
+        pageIndex: pageIndex,
+        viewport: viewport,
+        lastScrollSource: this,
+        isViewerInPresentationMode: isViewerInPresentationMode,
+        findController: this.findController
+      });
+    },
+
+    setFindController: function (findController) {
+      this.findController = findController;
     },
   };
 

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -392,7 +392,7 @@ var PDFViewer = (function pdfViewer() {
                                                             this.pages,
                                                             this.scroll.down);
       if (pageView) {
-        this.renderingQueue.renderView(pageView, 'page');
+        this.renderingQueue.renderView(pageView);
         return;
       }
     },

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -34,7 +34,26 @@ var IGNORE_CURRENT_POSITION_ON_ZOOM = false;
 //#include page_view.js
 //#include text_layer_builder.js
 
+/**
+ * @typedef {Object} PDFViewerOptions
+ * @property {HTMLDivElement} container - The container for the viewer element.
+ * @property {HTMLDivElement} viewer - (optional) The viewer element.
+ * @property {IPDFLinkService} linkService - The navigation/linking service.
+ * @property {PDFRenderingQueue} renderingQueue - (optional) The rendering
+ *   queue object.
+ */
+
+/**
+ * Simple viewer control to display PDF content/pages.
+ * @class
+ * @implements {ILastScrollSource}
+ * @implements {IRenderableView}
+ */
 var PDFViewer = (function pdfViewer() {
+  /**
+   * @constructs PDFViewer
+   * @param {PDFViewerOptions} options
+   */
   function PDFViewer(options) {
     this.container = options.container;
     this.viewer = options.viewer || options.container.firstElementChild;
@@ -56,7 +75,7 @@ var PDFViewer = (function pdfViewer() {
     this._resetView();
   }
 
-  PDFViewer.prototype = {
+  PDFViewer.prototype = /** @lends PDFViewer.prototype */{
     get pagesCount() {
       return this.pages.length;
     },
@@ -496,6 +515,12 @@ var PDFViewer = (function pdfViewer() {
       });
     },
 
+    /**
+     * @param textLayerDiv {HTMLDivElement}
+     * @param pageIndex {number}
+     * @param viewport {PageViewport}
+     * @returns {TextLayerBuilder}
+     */
     createTextLayerBuilder: function (textLayerDiv, pageIndex, viewport) {
       var isViewerInPresentationMode =
         this.presentationModeState === PresentationModeState.FULLSCREEN;
@@ -517,13 +542,26 @@ var PDFViewer = (function pdfViewer() {
   return PDFViewer;
 })();
 
+/**
+ * PDFPage object source.
+ * @class
+ */
 var PDFPageSource = (function PDFPageSourceClosure() {
+  /**
+   * @constructs
+   * @param {PDFDocument} pdfDocument
+   * @param {number} pageNumber
+   * @constructor
+   */
   function PDFPageSource(pdfDocument, pageNumber) {
     this.pdfDocument = pdfDocument;
     this.pageNumber = pageNumber;
   }
 
-  PDFPageSource.prototype = {
+  PDFPageSource.prototype = /** @lends PDFPageSource.prototype */ {
+    /**
+     * @returns {Promise<PDFPage>}
+     */
     getPage: function () {
       return this.pdfDocument.getPage(this.pageNumber);
     }

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -1,0 +1,314 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/* Copyright 2014 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*globals watchScroll, Cache, DEFAULT_CACHE_SIZE, PageView, UNKNOWN_SCALE,
+           IGNORE_CURRENT_POSITION_ON_ZOOM, SCROLLBAR_PADDING, VERTICAL_PADDING,
+           MAX_AUTO_SCALE, getVisibleElements, PresentationMode,
+           RenderingStates */
+
+'use strict';
+
+var PDFViewer = (function pdfViewer() {
+  function PDFViewer(options) {
+    this.container = options.container;
+    this.viewer = options.viewer;
+    this.renderingQueue = options.renderingQueue;
+    this.linkService = options.linkService;
+
+    this.scroll = watchScroll(this.container, this._scrollUpdate.bind(this));
+    this.pages = [];
+    this.cache = new Cache(DEFAULT_CACHE_SIZE);
+    this.currentPageNumber = 1;
+    this.previousPageNumber = 1;
+    this.updateInProgress = true;
+    this.resetView();
+  }
+
+  PDFViewer.prototype = {
+    get pagesCount() {
+      return this.pages.length;
+    },
+
+    setCurrentPageNumber: function (val) {
+      var event = document.createEvent('UIEvents');
+      event.initUIEvent('pagechange', true, true, window, 0);
+      event.updateInProgress = this.updateInProgress;
+
+      if (!(0 < val && val <= this.pagesCount)) {
+        this.previousPageNumber = val;
+        event.pageNumber = this.page;
+        this.container.dispatchEvent(event);
+        return;
+      }
+
+      this.pages[val - 1].updateStats();
+      this.previousPageNumber = this.currentPageNumber;
+      this.currentPageNumber = val;
+      event.pageNumber = val;
+      this.container.dispatchEvent(event);
+    },
+
+    addPage: function (pageNum, scale, viewport) {
+      var pageView = new PageView(this.viewer, pageNum, scale, viewport,
+                                  this.linkService, this.renderingQueue,
+                                  this.cache, this);
+      this.pages.push(pageView);
+      return pageView;
+    },
+
+    resetView: function () {
+      this.currentScale = UNKNOWN_SCALE;
+      this.currentScaleValue = null;
+      this.location = null;
+    },
+
+    _scrollUpdate: function () {
+      if (this.pagesCount === 0) {
+        return;
+      }
+      this.update();
+    },
+
+    _setScaleUpdatePages: function pdfViewer_setScaleUpdatePages(
+        newScale, newValue, resetAutoSettings, noScroll, preset) {
+      this.currentScaleValue = newValue;
+      if (newScale === this.currentScale) {
+        return;
+      }
+      for (var i = 0, ii = this.pages.length; i < ii; i++) {
+        this.pages[i].update(newScale);
+      }
+      this.currentScale = newScale;
+
+      if (!noScroll) {
+        var page = this.currentPageNumber, dest;
+        if (this.location && !this.inPresentationMode &&
+          !IGNORE_CURRENT_POSITION_ON_ZOOM) {
+          page = this.location.pageNumber;
+          dest = [null, { name: 'XYZ' }, this.location.left,
+            this.location.top, null];
+        }
+        this.pages[page - 1].scrollIntoView(dest);
+      }
+
+      var event = document.createEvent('UIEvents');
+      event.initUIEvent('scalechange', true, true, window, 0);
+      event.scale = newScale;
+      event.resetAutoSettings = resetAutoSettings;
+      if (preset) {
+        event.presetValue = newValue;
+      }
+      this.container.dispatchEvent(event);
+    },
+
+    setScale: function pdfViewer_setScale(value, resetAutoSettings, noScroll) {
+      if (value === 'custom') {
+        return;
+      }
+      var scale = parseFloat(value);
+
+      if (scale > 0) {
+        this._setScaleUpdatePages(scale, value, true, noScroll, false);
+      } else {
+        var currentPage = this.pages[this.currentPageNumber - 1];
+        if (!currentPage) {
+          return;
+        }
+        var hPadding = PresentationMode.active ? 0 : SCROLLBAR_PADDING;
+        var vPadding = PresentationMode.active ? 0 : VERTICAL_PADDING;
+        var pageWidthScale = (this.container.clientWidth - hPadding) /
+                             currentPage.width * currentPage.scale;
+        var pageHeightScale = (this.container.clientHeight - vPadding) /
+                              currentPage.height * currentPage.scale;
+        switch (value) {
+          case 'page-actual':
+            scale = 1;
+            break;
+          case 'page-width':
+            scale = pageWidthScale;
+            break;
+          case 'page-height':
+            scale = pageHeightScale;
+            break;
+          case 'page-fit':
+            scale = Math.min(pageWidthScale, pageHeightScale);
+            break;
+          case 'auto':
+            var isLandscape = (currentPage.width > currentPage.height);
+            var horizontalScale = isLandscape ? pageHeightScale :
+                                                pageWidthScale;
+            scale = Math.min(MAX_AUTO_SCALE, horizontalScale);
+            break;
+          default:
+            console.error('pdfViewSetScale: \'' + value +
+              '\' is an unknown zoom value.');
+            return;
+        }
+        this._setScaleUpdatePages(scale, value, resetAutoSettings, noScroll,
+                                  true);
+      }
+    },
+
+    updateRotation: function pdfViewRotatePages(rotation) {
+      for (var i = 0, l = this.pages.length; i < l; i++) {
+        var page = this.pages[i];
+        page.update(page.scale, rotation);
+      }
+
+      this.setScale(this.currentScaleValue, true, true);
+    },
+
+    removeAllPages: function () {
+      var container = this.viewer;
+      while (container.hasChildNodes()) {
+        container.removeChild(container.lastChild);
+      }
+      this.pages = [];
+    },
+
+    updateLocation: function (firstPage) {
+      var currentScale = this.currentScale;
+      var currentScaleValue = this.currentScaleValue;
+      var normalizedScaleValue =
+        parseFloat(currentScaleValue) === currentScale ?
+        Math.round(currentScale * 10000) / 100 : currentScaleValue;
+
+      var pageNumber = firstPage.id;
+      var pdfOpenParams = '#page=' + pageNumber;
+      pdfOpenParams += '&zoom=' + normalizedScaleValue;
+      var currentPageView = this.pages[pageNumber - 1];
+      var container = this.container;
+      var topLeft = currentPageView.getPagePoint(
+        (container.scrollLeft - firstPage.x),
+        (container.scrollTop - firstPage.y));
+      var intLeft = Math.round(topLeft[0]);
+      var intTop = Math.round(topLeft[1]);
+      pdfOpenParams += ',' + intLeft + ',' + intTop;
+
+      this.location = {
+        pageNumber: pageNumber,
+        scale: normalizedScaleValue,
+        top: intTop,
+        left: intLeft,
+        pdfOpenParams: pdfOpenParams
+      };
+    },
+
+    get inPresentationMode() {
+      return PresentationMode.active || PresentationMode.switchInProgress;
+    },
+
+    update: function () {
+      var visible = this.getVisiblePages();
+      var visiblePages = visible.views;
+      if (visiblePages.length === 0) {
+        return;
+      }
+
+      this.updateInProgress = true;
+
+      var suggestedCacheSize = Math.max(DEFAULT_CACHE_SIZE,
+          2 * visiblePages.length + 1);
+      this.cache.resize(suggestedCacheSize);
+
+      this.renderingQueue.renderHighestPriority(visible);
+
+      var currentId = this.currentPageNumber;
+      var firstPage = visible.first;
+
+      for (var i = 0, ii = visiblePages.length, stillFullyVisible = false;
+           i < ii; ++i) {
+        var page = visiblePages[i];
+
+        if (page.percent < 100) {
+          break;
+        }
+        if (page.id === this.currentPageNumber) {
+          stillFullyVisible = true;
+          break;
+        }
+      }
+
+      if (!stillFullyVisible) {
+        currentId = visiblePages[0].id;
+      }
+
+      if (!PresentationMode.active) {
+        this.setCurrentPageNumber(currentId);
+      }
+
+      this.updateLocation(firstPage);
+
+      this.updateInProgress = false;
+
+      var event = document.createEvent('UIEvents');
+      event.initUIEvent('updateviewarea', true, true, window, 0);
+      this.container.dispatchEvent(event);
+    },
+
+    containsElement: function (element) {
+      return this.container.contains(element);
+    },
+
+    focus: function () {
+      this.container.focus();
+    },
+
+    blur: function () {
+      this.container.blur();
+    },
+
+    get isHorizontalScrollbarEnabled() {
+      return (PresentationMode.active ? false :
+        (this.container.scrollWidth > this.container.clientWidth));
+    },
+
+    getVisiblePages: function () {
+      if (!PresentationMode.active) {
+        return getVisibleElements(this.container, this.pages, true);
+      } else {
+        // The algorithm in getVisibleElements doesn't work in all browsers and
+        // configurations when presentation mode is active.
+        var visible = [];
+        var currentPage = this.pages[this.currentPageNumber - 1];
+        visible.push({ id: currentPage.id, view: currentPage });
+        return { first: currentPage, last: currentPage, views: visible };
+      }
+    },
+
+    cleanup: function () {
+      for (var i = 0, ii = this.pages.length; i < ii; i++) {
+        if (this.pages[i] &&
+          this.pages[i].renderingState !== RenderingStates.FINISHED) {
+          this.pages[i].reset();
+        }
+      }
+    },
+
+    forceRendering: function (currentlyVisiblePages) {
+      var visiblePages = currentlyVisiblePages || this.getVisiblePages();
+      var pageView = this.renderingQueue.getHighestPriority(visiblePages,
+                                                            this.pages,
+                                                            this.scroll.down);
+      if (pageView) {
+        this.renderingQueue.renderView(pageView, 'page');
+        return;
+      }
+    },
+  };
+
+  return PDFViewer;
+})();

--- a/web/presentation_mode.js
+++ b/web/presentation_mode.js
@@ -81,6 +81,7 @@ var PresentationMode = {
     }
     this.switchInProgress = setTimeout(function switchInProgressTimeout() {
       delete this.switchInProgress;
+      this._notifyStateChange();
     }.bind(this), DELAY_BEFORE_RESETTING_SWITCH_IN_PROGRESS);
   },
 
@@ -97,6 +98,7 @@ var PresentationMode = {
       return false;
     }
     this._setSwitchInProgress();
+    this._notifyStateChange();
 
     if (this.container.requestFullscreen) {
       this.container.requestFullscreen();
@@ -118,9 +120,19 @@ var PresentationMode = {
     return true;
   },
 
+  _notifyStateChange: function presentationModeNotifyStateChange() {
+    var event = document.createEvent('CustomEvent');
+    event.initCustomEvent('presentationmodechanged', true, true, {
+      active: PresentationMode.active,
+      switchInProgress: !!PresentationMode.switchInProgress
+    });
+    window.dispatchEvent(event);
+  },
+
   enter: function presentationModeEnter() {
     this.active = true;
     this._resetSwitchInProgress();
+    this._notifyStateChange();
 
     // Ensure that the correct page is scrolled into view when entering
     // Presentation Mode, by waiting until fullscreen mode in enabled.
@@ -148,6 +160,8 @@ var PresentationMode = {
     // Note: This is only necessary in non-Mozilla browsers.
     setTimeout(function exitPresentationModeTimeout() {
       this.active = false;
+      this._notifyStateChange();
+
       PDFView.setScale(this.args.previousScale, true);
       PDFView.page = page;
       this.args = null;

--- a/web/presentation_mode.js
+++ b/web/presentation_mode.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFView, scrollIntoView, HandTool */
+/* globals scrollIntoView, HandTool, PDFViewerApplication */
 
 'use strict';
 
@@ -93,7 +93,7 @@ var PresentationMode = {
   },
 
   request: function presentationModeRequest() {
-    if (!PDFView.supportsFullscreen || this.isFullscreen ||
+    if (!PDFViewerApplication.supportsFullscreen || this.isFullscreen ||
         !this.viewer.hasChildNodes()) {
       return false;
     }
@@ -113,8 +113,8 @@ var PresentationMode = {
     }
 
     this.args = {
-      page: PDFView.page,
-      previousScale: PDFView.currentScaleValue
+      page: PDFViewerApplication.page,
+      previousScale: PDFViewerApplication.currentScaleValue
     };
 
     return true;
@@ -138,8 +138,8 @@ var PresentationMode = {
     // Presentation Mode, by waiting until fullscreen mode in enabled.
     // Note: This is only necessary in non-Mozilla browsers.
     setTimeout(function enterPresentationModeTimeout() {
-      PDFView.page = this.args.page;
-      PDFView.setScale('page-fit', true);
+      PDFViewerApplication.page = this.args.page;
+      PDFViewerApplication.setScale('page-fit', true);
     }.bind(this), 0);
 
     window.addEventListener('mousemove', this.mouseMove, false);
@@ -153,7 +153,7 @@ var PresentationMode = {
   },
 
   exit: function presentationModeExit() {
-    var page = PDFView.page;
+    var page = PDFViewerApplication.page;
 
     // Ensure that the correct page is scrolled into view when exiting
     // Presentation Mode, by waiting until fullscreen mode is disabled.
@@ -162,8 +162,8 @@ var PresentationMode = {
       this.active = false;
       this._notifyStateChange();
 
-      PDFView.setScale(this.args.previousScale, true);
-      PDFView.page = page;
+      PDFViewerApplication.setScale(this.args.previousScale, true);
+      PDFViewerApplication.page = page;
       this.args = null;
     }.bind(this), 0);
 
@@ -172,7 +172,7 @@ var PresentationMode = {
     window.removeEventListener('contextmenu', this.contextMenu, false);
 
     this.hideControls();
-    PDFView.clearMouseScrollState();
+    PDFViewerApplication.clearMouseScrollState();
     HandTool.exitPresentationMode();
     this.container.removeAttribute('contextmenu');
     this.contextMenuOpen = false;
@@ -236,7 +236,7 @@ var PresentationMode = {
       if (!isInternalLink) {
         // Unless an internal link was clicked, advance one page.
         evt.preventDefault();
-        PDFView.page += (evt.shiftKey ? -1 : 1);
+        PDFViewerApplication.page += (evt.shiftKey ? -1 : 1);
       }
     }
   },

--- a/web/presentation_mode.js
+++ b/web/presentation_mode.js
@@ -68,7 +68,7 @@ var PresentationMode = {
   },
 
   /**
-   * Initialize a timeout that is used to reset PDFView.currentPosition when the
+   * Initialize a timeout that is used to specify switchInProgress when the
    * browser transitions to fullscreen mode. Since resize events are triggered
    * multiple times during the switch to fullscreen mode, this is necessary in
    * order to prevent the page from being scrolled partially, or completely,
@@ -82,8 +82,6 @@ var PresentationMode = {
     this.switchInProgress = setTimeout(function switchInProgressTimeout() {
       delete this.switchInProgress;
     }.bind(this), DELAY_BEFORE_RESETTING_SWITCH_IN_PROGRESS);
-
-    PDFView.currentPosition = null;
   },
 
   _resetSwitchInProgress: function presentationMode_resetSwitchInProgress() {
@@ -150,7 +148,7 @@ var PresentationMode = {
     // Note: This is only necessary in non-Mozilla browsers.
     setTimeout(function exitPresentationModeTimeout() {
       this.active = false;
-      PDFView.setScale(this.args.previousScale);
+      PDFView.setScale(this.args.previousScale, true);
       PDFView.page = page;
       this.args = null;
     }.bind(this), 0);

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFView, SCROLLBAR_PADDING */
+/* globals PDFViewerApplication, SCROLLBAR_PADDING */
 
 'use strict';
 
@@ -87,7 +87,7 @@ var SecondaryToolbar = {
   },
 
   downloadClick: function secondaryToolbarDownloadClick(evt) {
-    PDFView.download();
+    PDFViewerApplication.download();
     this.close();
   },
 
@@ -96,23 +96,23 @@ var SecondaryToolbar = {
   },
 
   firstPageClick: function secondaryToolbarFirstPageClick(evt) {
-    PDFView.page = 1;
+    PDFViewerApplication.page = 1;
     this.close();
   },
 
   lastPageClick: function secondaryToolbarLastPageClick(evt) {
-    if (PDFView.pdfDocument) {
-      PDFView.page = PDFView.pdfDocument.numPages;
+    if (PDFViewerApplication.pdfDocument) {
+      PDFViewerApplication.page = PDFViewerApplication.pagesCount;
     }
     this.close();
   },
 
   pageRotateCwClick: function secondaryToolbarPageRotateCwClick(evt) {
-    PDFView.rotatePages(90);
+    PDFViewerApplication.rotatePages(90);
   },
 
   pageRotateCcwClick: function secondaryToolbarPageRotateCcwClick(evt) {
-    PDFView.rotatePages(-90);
+    PDFViewerApplication.rotatePages(-90);
   },
 
   documentPropertiesClick: function secondaryToolbarDocumentPropsClick(evt) {

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -29,10 +29,22 @@ function isAllWhitespace(str) {
 }
 
 /**
+ * @typedef {Object} TextLayerBuilderOptions
+ * @property {HTMLDivElement} textLayerDiv - The text layer container.
+ * @property {number} pageIndex - The page index.
+ * @property {PageViewport} viewport - The viewport of the text layer.
+ * @property {ILastScrollSource} lastScrollSource - The object that records when
+ *   last time scroll happened.
+ * @property {boolean} isViewerInPresentationMode
+ * @property {PDFFindController} findController
+ */
+
+/**
  * TextLayerBuilder provides text-selection functionality for the PDF.
  * It does this by creating overlay divs over the PDF text. These divs
  * contain text that matches the PDF text they are overlaying. This object
  * also provides a way to highlight text that is being searched for.
+ * @class
  */
 var TextLayerBuilder = (function TextLayerBuilderClosure() {
   function TextLayerBuilder(options) {

--- a/web/thumbnail_view.js
+++ b/web/thumbnail_view.js
@@ -39,6 +39,7 @@ var ThumbnailView = function thumbnailView(container, id, defaultViewport,
   this.pageHeight = this.viewport.height;
   this.pageRatio = this.pageWidth / this.pageHeight;
   this.id = id;
+  this.renderingId = 'thumbnail' + id;
 
   this.canvasWidth = 98;
   this.canvasHeight = this.canvasWidth / this.pageWidth * this.pageHeight;
@@ -155,7 +156,7 @@ var ThumbnailView = function thumbnailView(container, id, defaultViewport,
       canvasContext: ctx,
       viewport: drawViewport,
       continueCallback: function(cont) {
-        if (self.renderingQueue.highestPriorityPage !== 'thumbnail' + self.id) {
+        if (!self.renderingQueue.isHighestPriority(self)) {
           self.renderingState = RenderingStates.PAUSED;
           self.resume = function() {
             self.renderingState = RenderingStates.RUNNING;
@@ -336,7 +337,7 @@ var PDFThumbnailViewer = (function pdfThumbnailViewer() {
                                                              this.thumbnails,
                                                              this.scroll.down);
       if (thumbView) {
-        this.renderingQueue.renderView(thumbView, 'thumbnail');
+        this.renderingQueue.renderView(thumbView);
         return true;
       }
       return false;

--- a/web/thumbnail_view.js
+++ b/web/thumbnail_view.js
@@ -14,10 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals mozL10n, RenderingStates, THUMBNAIL_SCROLL_MARGIN, Promise,
-           watchScroll, getVisibleElements, scrollIntoView, PDFPageSource */
+/* globals mozL10n, RenderingStates, Promise, scrollIntoView, PDFPageSource,
+           watchScroll, getVisibleElements */
 
 'use strict';
+
+var THUMBNAIL_SCROLL_MARGIN = -19;
 
 var ThumbnailView = function thumbnailView(container, id, defaultViewport,
                                            linkService, renderingQueue,

--- a/web/thumbnail_view.js
+++ b/web/thumbnail_view.js
@@ -21,6 +21,17 @@
 
 var THUMBNAIL_SCROLL_MARGIN = -19;
 
+/**
+ * @constructor
+ * @param container
+ * @param id
+ * @param defaultViewport
+ * @param linkService
+ * @param renderingQueue
+ * @param pageSource
+ *
+ * @implements {IRenderableView}
+ */
 var ThumbnailView = function thumbnailView(container, id, defaultViewport,
                                            linkService, renderingQueue,
                                            pageSource) {
@@ -241,7 +252,22 @@ var ThumbnailView = function thumbnailView(container, id, defaultViewport,
 
 ThumbnailView.tempImageCache = null;
 
+/**
+ * @typedef {Object} PDFThumbnailViewerOptions
+ * @property {HTMLDivElement} container - The container for the thumbs elements.
+ * @property {IPDFLinkService} linkService - The navigation/linking service.
+ * @property {PDFRenderingQueue} renderingQueue - The rendering queue object.
+ */
+
+/**
+ * Simple viewer control to display thumbs for pages.
+ * @class
+ */
 var PDFThumbnailViewer = (function pdfThumbnailViewer() {
+  /**
+   * @constructs
+   * @param {PDFThumbnailViewerOptions} options
+   */
   function PDFThumbnailViewer(options) {
     this.container = options.container;
     this.renderingQueue = options.renderingQueue;

--- a/web/thumbnail_view.js
+++ b/web/thumbnail_view.js
@@ -247,13 +247,12 @@ var PDFThumbnailViewer = (function pdfThumbnailViewer() {
     this.renderingQueue = options.renderingQueue;
     this.linkService = options.linkService;
 
-    this.scroll = watchScroll(this.container, this.scrollUpdated.bind(this));
-    this.thumbnails = [];
-    this.currentPage = -1;
+    this.scroll = watchScroll(this.container, this._scrollUpdated.bind(this));
+    this._resetView();
   }
 
   PDFThumbnailViewer.prototype = {
-    scrollUpdated: function PDFThumbnailViewer_scrollUpdated() {
+    _scrollUpdated: function PDFThumbnailViewer_scrollUpdated() {
       this.renderingQueue.renderHighestPriority();
     },
 
@@ -261,18 +260,18 @@ var PDFThumbnailViewer = (function pdfThumbnailViewer() {
       return this.thumbnails[index];
     },
 
-    getVisibleThumbs: function PDFThumbnailViewer_getVisibleThumbs() {
+    _getVisibleThumbs: function PDFThumbnailViewer_getVisibleThumbs() {
       return getVisibleElements(this.container, this.thumbnails);
     },
 
-    updatePage: function (page) {
+    scrollThumbnailIntoView: function (page) {
       var selected = document.querySelector('.thumbnail.selected');
       if (selected) {
         selected.classList.remove('selected');
       }
       var thumbnail = document.getElementById('thumbnailContainer' + page);
       thumbnail.classList.add('selected');
-      var visibleThumbs = this.getVisibleThumbs();
+      var visibleThumbs = this._getVisibleThumbs();
       var numVisibleThumbs = visibleThumbs.views.length;
 
       // If the thumbnail isn't currently visible, scroll it into view.
@@ -284,18 +283,27 @@ var PDFThumbnailViewer = (function pdfThumbnailViewer() {
           scrollIntoView(thumbnail, { top: THUMBNAIL_SCROLL_MARGIN });
         }
       }
-      this.currentPage = page;
     },
 
-    updateRotation: function (pageRotation) {
+    get pagesRotation() {
+      return this._pagesRotation;
+    },
+
+    set pagesRotation(rotation) {
+      this._pagesRotation = rotation;
       for (var i = 0, l = this.thumbnails.length; i < l; i++) {
         var thumb = this.thumbnails[i];
-        thumb.update(pageRotation);
+        thumb.update(rotation);
       }
     },
 
     cleanup: function PDFThumbnailViewer_cleanup() {
       ThumbnailView.tempImageCache = null;
+    },
+
+    _resetView: function () {
+      this.thumbnails = [];
+      this._pagesRotation = 0;
     },
 
     setDocument: function (pdfDocument) {
@@ -305,7 +313,7 @@ var PDFThumbnailViewer = (function pdfThumbnailViewer() {
         while (thumbsView.hasChildNodes()) {
           thumbsView.removeChild(thumbsView.lastChild);
         }
-        this.thumbnails = [];
+        this._resetView();
       }
 
       this.pdfDocument = pdfDocument;
@@ -334,7 +342,7 @@ var PDFThumbnailViewer = (function pdfThumbnailViewer() {
     },
 
     forceRendering: function () {
-      var visibleThumbs = this.getVisibleThumbs();
+      var visibleThumbs = this._getVisibleThumbs();
       var thumbView = this.renderingQueue.getHighestPriority(visibleThumbs,
                                                              this.thumbnails,
                                                              this.scroll.down);

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -16,6 +16,14 @@
 
 'use strict';
 
+var CSS_UNITS = 96.0 / 72.0;
+var DEFAULT_SCALE = 'auto';
+var UNKNOWN_SCALE = 0;
+var MAX_AUTO_SCALE = 1.25;
+var SCROLLBAR_PADDING = 40;
+var VERTICAL_PADDING = 5;
+var DEFAULT_CACHE_SIZE = 10;
+
 // optimised CSS custom property getter/setter
 var CustomStyle = (function CustomStyleClosure() {
 

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -139,6 +139,91 @@ function scrollIntoView(element, spot) {
 }
 
 /**
+ * Helper function to start monitoring the scroll event and converting them into
+ * PDF.js friendly one: with scroll debounce and scroll direction.
+ */
+function watchScroll(viewAreaElement, callback) {
+  var debounceScroll = function debounceScroll(evt) {
+    if (rAF) {
+      return;
+    }
+    // schedule an invocation of scroll for next animation frame.
+    rAF = window.requestAnimationFrame(function viewAreaElementScrolled() {
+      rAF = null;
+
+      var currentY = viewAreaElement.scrollTop;
+      var lastY = state.lastY;
+      if (currentY > lastY) {
+        state.down = true;
+      } else if (currentY < lastY) {
+        state.down = false;
+      }
+      state.lastY = currentY;
+      // else do nothing and use previous value
+      callback(state);
+    });
+  };
+
+  var state = {
+    down: true,
+    lastY: viewAreaElement.scrollTop,
+    _eventHandler: debounceScroll
+  };
+
+  var rAF = null;
+  viewAreaElement.addEventListener('scroll', debounceScroll, true);
+  return state;
+}
+
+/**
+ * Generic helper to find out what elements are visible within a scroll pane.
+ */
+function getVisibleElements(scrollEl, views, sortByVisibility) {
+  var top = scrollEl.scrollTop, bottom = top + scrollEl.clientHeight;
+  var left = scrollEl.scrollLeft, right = left + scrollEl.clientWidth;
+
+  var visible = [], view;
+  var currentHeight, viewHeight, hiddenHeight, percentHeight;
+  var currentWidth, viewWidth;
+  for (var i = 0, ii = views.length; i < ii; ++i) {
+    view = views[i];
+    currentHeight = view.el.offsetTop + view.el.clientTop;
+    viewHeight = view.el.clientHeight;
+    if ((currentHeight + viewHeight) < top) {
+      continue;
+    }
+    if (currentHeight > bottom) {
+      break;
+    }
+    currentWidth = view.el.offsetLeft + view.el.clientLeft;
+    viewWidth = view.el.clientWidth;
+    if ((currentWidth + viewWidth) < left || currentWidth > right) {
+      continue;
+    }
+    hiddenHeight = Math.max(0, top - currentHeight) +
+      Math.max(0, currentHeight + viewHeight - bottom);
+    percentHeight = ((viewHeight - hiddenHeight) * 100 / viewHeight) | 0;
+
+    visible.push({ id: view.id, x: currentWidth, y: currentHeight,
+      view: view, percent: percentHeight });
+  }
+
+  var first = visible[0];
+  var last = visible[visible.length - 1];
+
+  if (sortByVisibility) {
+    visible.sort(function(a, b) {
+      var pc = a.percent - b.percent;
+      if (Math.abs(pc) > 0.001) {
+        return -pc;
+      }
+      return a.id - b.id; // ensure stability
+    });
+  }
+  return {first: first, last: last, views: visible};
+}
+
+/**
  * Event handler to suppress context menu.
  */
 function noContextMenuHandler(e) {

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -70,9 +70,9 @@ http://sourceforge.net/adobe/cmap/wiki/License/
     <script src="view_history.js"></script>
     <script src="pdf_rendering_queue.js"></script>
     <script src="page_view.js"></script>
+    <script src="text_layer_builder.js"></script>
     <script src="pdf_viewer.js"></script>
     <script src="thumbnail_view.js"></script>
-    <script src="text_layer_builder.js"></script>
     <script src="document_outline_view.js"></script>
     <script src="document_attachments_view.js"></script>
     <script src="pdf_find_bar.js"></script>

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -68,6 +68,7 @@ http://sourceforge.net/adobe/cmap/wiki/License/
     <script src="preferences.js"></script>
     <script src="download_manager.js"></script>
     <script src="view_history.js"></script>
+    <script src="pdf_rendering_queue.js"></script>
     <script src="page_view.js"></script>
     <script src="pdf_viewer.js"></script>
     <script src="thumbnail_view.js"></script>

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -69,6 +69,7 @@ http://sourceforge.net/adobe/cmap/wiki/License/
     <script src="download_manager.js"></script>
     <script src="view_history.js"></script>
     <script src="page_view.js"></script>
+    <script src="pdf_viewer.js"></script>
     <script src="thumbnail_view.js"></script>
     <script src="text_layer_builder.js"></script>
     <script src="document_outline_view.js"></script>

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -92,8 +92,11 @@ var PDFView = {
   pdfDocument: null,
   sidebarOpen: false,
   printing: false,
+  /** @type {PDFViewer} */
   pdfViewer: null,
+  /** @type {PDFThumbnailViewer} */
   pdfThumbnailViewer: null,
+  /** @type {PDFRenderingQueue} */
   pdfRenderingQueue: null,
   pageRotation: 0,
   updateScaleControls: true,

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -21,7 +21,7 @@
            PasswordPrompt, PresentationMode, HandTool, Promise,
            DocumentProperties, DocumentOutlineView, DocumentAttachmentsView,
            OverlayManager, PDFFindController, PDFFindBar, getVisibleElements,
-           watchScroll, PDFViewer, PDFRenderingQueue */
+           watchScroll, PDFViewer, PDFRenderingQueue, PresentationModeState */
 
 'use strict';
 
@@ -1667,6 +1667,14 @@ document.addEventListener('pagerendered', function (e) {
   var thumbnailView = PDFView.pdfThumbnailViewer.getThumbnail(pageIndex);
   thumbnailView.setImage(pageView.canvas);
 }, true);
+
+window.addEventListener('presentationmodechanged', function (e) {
+  var active = e.detail.active;
+  var switchInProgress = e.detail.switchInProgress;
+  PDFView.pdfViewer.presentationModeState =
+    switchInProgress ? PresentationModeState.CHANGING :
+    active ? PresentationModeState.FULLSCREEN : PresentationModeState.NORMAL;
+});
 
 function updateViewarea() {
   if (!PDFView.initialized) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -21,27 +21,20 @@
            PasswordPrompt, PresentationMode, HandTool, Promise,
            DocumentProperties, DocumentOutlineView, DocumentAttachmentsView,
            OverlayManager, PDFFindController, PDFFindBar, getVisibleElements,
-           watchScroll, PDFViewer, PDFRenderingQueue, PresentationModeState */
+           watchScroll, PDFViewer, PDFRenderingQueue, PresentationModeState,
+           DEFAULT_SCALE, UNKNOWN_SCALE,
+           IGNORE_CURRENT_POSITION_ON_ZOOM: true */
 
 'use strict';
 
 var DEFAULT_URL = 'compressed.tracemonkey-pldi-09.pdf';
-var DEFAULT_SCALE = 'auto';
 var DEFAULT_SCALE_DELTA = 1.1;
-var UNKNOWN_SCALE = 0;
-var DEFAULT_CACHE_SIZE = 10;
-var CSS_UNITS = 96.0 / 72.0;
-var SCROLLBAR_PADDING = 40;
-var VERTICAL_PADDING = 5;
-var MAX_AUTO_SCALE = 1.25;
 var MIN_SCALE = 0.25;
 var MAX_SCALE = 10.0;
 var VIEW_HISTORY_MEMORY = 20;
 var SCALE_SELECT_CONTAINER_PADDING = 8;
 var SCALE_SELECT_PADDING = 22;
-var THUMBNAIL_SCROLL_MARGIN = -19;
-var CLEANUP_TIMEOUT = 30000;
-var IGNORE_CURRENT_POSITION_ON_ZOOM = false;
+
 //#if B2G
 //PDFJS.useOnlyCssZoom = true;
 //PDFJS.disableTextLayer = true;
@@ -90,6 +83,7 @@ var mozL10n = document.mozL10n || document.webL10n;
 //#include overlay_manager.js
 //#include password_prompt.js
 //#include document_properties.js
+//#include pdf_viewer.js
 
 var PDFView = {
   initialBookmark: document.location.hash.substring(1),
@@ -1363,11 +1357,7 @@ var PDFView = {
   }
 };
 
-//#include pdf_rendering_queue.js
-//#include page_view.js
-//#include pdf_viewer.js
 //#include thumbnail_view.js
-//#include text_layer_builder.js
 //#include document_outline_view.js
 //#include document_attachments_view.js
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -104,7 +104,6 @@ var PDFView = {
   pageRotation: 0,
   mouseScrollTimeStamp: 0,
   mouseScrollDelta: 0,
-  lastScroll: 0,
   isViewerEmbedded: (window.parent !== window),
   url: '',
 
@@ -138,6 +137,7 @@ var PDFView = {
       pdfViewer: this.pdfViewer,
       integratedFind: this.supportsIntegratedFind
     });
+    this.pdfViewer.setFindController(this.findController);
 
     this.findBar = new PDFFindBar({
       bar: document.getElementById('findbar'),
@@ -210,10 +210,6 @@ var PDFView = {
       versionField: document.getElementById('versionField'),
       pageCountField: document.getElementById('pageCountField')
     });
-
-    container.addEventListener('scroll', function() {
-      self.lastScroll = Date.now();
-    }, false);
 
     var initializedPromise = Promise.all([
       Preferences.get('enableWebGL').then(function resolved(value) {
@@ -1666,6 +1662,36 @@ document.addEventListener('pagerendered', function (e) {
   var pageView = PDFView.pdfViewer.getPageView(pageIndex);
   var thumbnailView = PDFView.pdfThumbnailViewer.getThumbnail(pageIndex);
   thumbnailView.setImage(pageView.canvas);
+
+//#if (FIREFOX || MOZCENTRAL)
+//if (pageView.textLayer && pageView.textLayer.textDivs &&
+//    pageView.textLayer.textDivs.length > 0 &&
+//    !PDFView.supportsDocumentColors) {
+//  console.error(mozL10n.get('document_colors_disabled', null,
+//    'PDF documents are not allowed to use their own colors: ' +
+//    '\'Allow pages to choose their own colors\' ' +
+//    'is deactivated in the browser.'));
+//  PDFView.fallback();
+//}
+//#endif
+
+  if (pageView.error) {
+    PDFView.error(mozL10n.get('rendering_error', null,
+      'An error occurred while rendering the page.'), pageView.error);
+  }
+
+//#if (FIREFOX || MOZCENTRAL)
+//FirefoxCom.request('reportTelemetry', JSON.stringify({
+//  type: 'pageInfo'
+//}));
+//// It is a good time to report stream and font types
+//PDFView.pdfDocument.getStats().then(function (stats) {
+//  FirefoxCom.request('reportTelemetry', JSON.stringify({
+//    type: 'documentStats',
+//    stats: stats
+//  }));
+//});
+//#endif
 }, true);
 
 window.addEventListener('presentationmodechanged', function (e) {


### PR DESCRIPTION
Idea is to create reusable PDFViewer that will not have dependency on the PDFView (toolbars, find controller, etc).
- [x] Move pages container logic into PDFViewer (?) out of PDFView
- [x] Move thumbs container logic into PDFThumbnailsViewer (?) out of PDFView
- [x] Remove all dependency on PDFView in PDFViewer and classes it's using
- [x] Remove any rendering logic from PDFView
- [x] Isolate PDFPageSource logic and use in PDFViewer, PDFThumbnailsViewer, PDFFindController
- [x] Refactor PresentationMode (minimal, to remove dependency from PDFViewer)

NOTE: The refactoring shall not include any optimization or bug fixes
