### PR TITLE
For |make firefox/mozcentral| builds, add cleanupJSSource to remove duplicate file headers in extensions/firefox/content/PdfjsChromeUtils.jsm

### DIFF
--- a/make.js
+++ b/make.js
@@ -660,6 +660,7 @@ target.firefox = function() {
 
   cleanupJSSource(FIREFOX_BUILD_CONTENT_DIR + '/web/viewer.js');
   cleanupJSSource(FIREFOX_BUILD_DIR + 'bootstrap.js');
+  cleanupJSSource(FIREFOX_BUILD_CONTENT_DIR + 'PdfjsChromeUtils.jsm');
 
   // Remove '.DS_Store' and other hidden files
   find(FIREFOX_BUILD_DIR).forEach(function(file) {
@@ -780,6 +781,7 @@ target.mozcentral = function() {
 
   cleanupJSSource(MOZCENTRAL_CONTENT_DIR + '/web/viewer.js');
   cleanupJSSource(MOZCENTRAL_CONTENT_DIR + '/PdfJs.jsm');
+  cleanupJSSource(MOZCENTRAL_CONTENT_DIR + '/PdfjsChromeUtils.jsm');
 
   // Remove '.DS_Store' and other hidden files
   find(MOZCENTRAL_DIR).forEach(function(file) {


### PR DESCRIPTION
While looking at the attached patch in https://bugzilla.mozilla.org/show_bug.cgi?id=1064496, I'm seeing that my https://github.com/mozilla/pdf.js/pull/5115#issuecomment-54976863 was never addressed. This leads to a file header being present in the middle of the code, which doesn't look too good, hence this patch.

I should have checked this while working on PR #5305, but it unfortunately slipped my mind. Sorry about that!
