### PR TITLE
Update findbar to wrap on initial search

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -44,6 +44,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
       pageIdx: null,
       matchIdx: null
     };
+    this.pagesToSearch = null;
     this.resumePageIdx = null;
     this.state = null;
     this.dirtyMatch = false;
@@ -255,6 +256,8 @@ var PDFFindController = (function PDFFindControllerClosure() {
       }
 
       var offset = this.offset;
+      // Keep track of how many pages we should maximally iterate through.
+      this.pagesToSearch = this.pdfViewer.pagesCount;
       // If there's already a matchIdx that means we are iterating through a
       // page's matches.
       if (offset.matchIdx !== null) {
@@ -293,8 +296,8 @@ var PDFFindController = (function PDFFindControllerClosure() {
         this.advanceOffsetPage(previous);
         if (offset.wrapped) {
           offset.matchIdx = null;
-          if (!this.hadMatch) {
-            // No point in wrapping, there were no matches.
+          if (this.pagesToSearch < 0) {
+            // No point in wrapping again, there were no matches.
             this.updateMatch(false);
             // while matches were not found, searching for a page 
             // with matches should nevertheless halt.
@@ -327,11 +330,12 @@ var PDFFindController = (function PDFFindControllerClosure() {
       var numPages = this.extractTextPromises.length;
       offset.pageIdx = (previous ? offset.pageIdx - 1 : offset.pageIdx + 1);
       offset.matchIdx = null;
+
+      this.pagesToSearch--;
       
       if (offset.pageIdx >= numPages || offset.pageIdx < 0) {
         offset.pageIdx = (previous ? numPages - 1 : 0);
         offset.wrapped = true;
-        return;
       }
     },
 

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -257,7 +257,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
 
       var offset = this.offset;
       // Keep track of how many pages we should maximally iterate through.
-      this.pagesToSearch = this.pdfViewer.pagesCount;
+      this.pagesToSearch = numPages;
       // If there's already a matchIdx that means we are iterating through a
       // page's matches.
       if (offset.matchIdx !== null) {


### PR DESCRIPTION
Fixes #5324

Updated pdf_find_controller to keep track of the original page index
on which the search begins. This allows us to wrap a search without looping
infinitely through the document: if we've wrapped and advanced beyond
the original page index, we know there are no more results to be found.
