### PR TITLE
Fix text highlighting in the Font Inspector in the debugger

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1590,11 +1590,9 @@ html[dir='rtl'] #documentPropertiesOverlay .row > * {
 .debuggerShowText {
   background: none repeat scroll 0 0 yellow;
   color: blue;
-  opacity: 0.3;
 }
 .debuggerHideText:hover {
   background: none repeat scroll 0 0 yellow;
-  opacity: 0.3;
 }
 #PDFBug .stats {
   font-family: courier;


### PR DESCRIPTION
After PR #5282, the text highlighting in the Font Inspector is very hard to see against a white background. That seems to be an oversight from the mentioned PR, hence this patch fixes that.
