### PR TITLE
Fix a regression preventing page change in the Stepper in the debugger

### DIFF
--- a/web/debugger.js
+++ b/web/debugger.js
@@ -211,6 +211,7 @@ var StepperManager = (function StepperManagerClosure() {
     },
     selectStepper: function selectStepper(pageIndex, selectPanel) {
       var i;
+      pageIndex = pageIndex | 0;
       if (selectPanel) {
         this.manager.selectPanel(this);
       }
@@ -419,7 +420,7 @@ var Stepper = (function StepperClosure() {
       var allRows = this.panel.getElementsByClassName('line');
       for (var x = 0, xx = allRows.length; x < xx; ++x) {
         var row = allRows[x];
-        if (parseInt(row.dataset.idx, 10) === idx) {
+        if ((row.dataset.idx | 0) === idx) {
           row.style.backgroundColor = 'rgb(251,250,207)';
           row.scrollIntoView();
         } else {


### PR DESCRIPTION
This is a regression from https://github.com/mozilla/pdf.js/commit/ddd3c8fc2fe7b8715bed6d6f146c206d133b5dd6, which prevents changing pages in the Stepper.

(Apart from fixing the bug, for the sake of consistency, I also removed one instance of `parseInt`.)

@timvandermeij Can you please review this?
