### PR TITLE
Fixes typo/regression of #5295 for presentation mode

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -99,7 +99,7 @@ var PDFViewer = (function pdfViewer() {
       event.updateInProgress = this.updateInProgress;
 
       if (!(0 < val && val <= this.pagesCount)) {
-        event.pageNumber = this.page;
+        event.pageNumber = this._currentPageNumber;
         event.previousPageNumber = val;
         this.container.dispatchEvent(event);
         return;


### PR DESCRIPTION
Per http://logs.glob.uno/?c=mozilla%23pdfjs&s=29+Sep+2014&e=29+Sep+2014#c25981

```
Snuffleupagus   Hm, entering/exiting presentation mode is sluggish and "too much recursion" is printed in the console.
```
