### PR TITLE
Followup fix for entering/exiting Presentation mode

### DIFF
--- a/web/page_view.js
+++ b/web/page_view.js
@@ -368,7 +368,7 @@ var PageView = function pageView(container, id, scale, defaultViewport,
       }
       dest = null;
       // Fixes the case when PDF has different page sizes.
-      this.viewer.currentScaleValue = this.viewer.currentScaleValue;
+      this.viewer._setScale(this.viewer.currentScaleValue, true);
     }
     if (!dest) {
       scrollIntoView(div);


### PR DESCRIPTION
Even after PR #5359, switching to/from Presentation mode is still sluggish and I'm still seeing `too much recursion` printed in the console.
I've managed to track down the issue to line https://github.com/mozilla/pdf.js/blob/master/web/page_view.js#L371. It appears that for this particular case, we actually _need_ to set `noScroll = true` when calling the `_setScale` function. (Note that it only applies to _this_ line, and not to Presentation mode in general.)
Given the amount of refactoring done to the viewer, I'm not sure what the best way to fix this would be. However I'm submitting this patch as an easy workaround for now, but we should probably refactor this to avoid calling a "private" method directly.

/cc @yurydelendik
