### PR TITLE
Firefox addon: Use isContentWindowPrivate instead of isWindowPrivate if available

### DIFF
--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -255,7 +255,14 @@ function ChromeActions(domWindow, contentDispositionFilename) {
 
 ChromeActions.prototype = {
   isInPrivateBrowsing: function() {
-    return PrivateBrowsingUtils.isWindowPrivate(this.domWindow);
+//#if !MOZCENTRAL
+    if (!PrivateBrowsingUtils.isContentWindowPrivate) {
+      // pbu.isContentWindowPrivate was not supported prior Firefox 35.
+      // (https://bugzilla.mozilla.org/show_bug.cgi?id=1069059)
+      return PrivateBrowsingUtils.isWindowPrivate(this.domWindow);
+    }
+//#endif
+    return PrivateBrowsingUtils.isContentWindowPrivate(this.domWindow);
   },
   download: function(data, sendResponse) {
     var self = this;


### PR DESCRIPTION
As of Firefox 35, `PrivateBrowsingUtilsisContentWindowPrivate` should be used for DOM windows instead of `PrivateBrowsingUtils.isWindowPrivate`. See https://bugzilla.mozilla.org/show_bug.cgi?id=1069059 and http://hg.mozilla.org/mozilla-central/diff/324798b60ba3/toolkit/modules/PrivateBrowsingUtils.jsm

Without this fix, you will get the following error message when Firefox+PDF.js is started:

> WARNING: content window passed to PrivateBrowsingUtils.isWindowPrivate. Use isContentWindowPrivate instead (but only for frame scripts).
> pbu_isWindowPrivate@resource://gre/modules/PrivateBrowsingUtils.jsm:25:14
> ChromeActions.prototype.isInPrivateBrowsing@resource://pdf.js/PdfStreamConverter.jsm:237:12
> xhr_onreadystatechange@resource://pdf.js/PdfStreamConverter.jsm:545:30
> NetworkManager_requestRange@resource://pdf.js/network.js:95:7
> NetworkManager_requestRange@resource://pdf.js/network.js:81:14
> RangedChromeActions_requestDataRange@resource://pdf.js/PdfStreamConverter.jsm:596:1
> RequestListener.prototype.receive@resource://pdf.js/PdfStreamConverter.jsm:705:5
> PdfStreamConverter.prototype.onStartRequest/proxy.onStopRequest/<@<b></b>resource://pdf.js/PdfStreamConverter.jsm:909:11
> FirefoxComClosure/<.request@resource://pdf.js/web/viewer.js:529:14
> PdfDataRangeTransport_requestDataRange@resource://pdf.js/web/viewer.js:2977:9
> transportDataRange@resource://pdf.js/build/pdf.js:2122:13
> messageHandlerComObjOnMessage@resource://pdf.js/build/pdf.js:1219:9
