### PR TITLE
Fix disableAutoFetch regression in the generic viewer

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -138,7 +138,7 @@ var WorkerMessageHandler = PDFJS.WorkerMessageHandler = {
           }
         },
 
-        onProgressiveData: PDFJS.disableStream ? null :
+        onProgressiveData: source.disableStream ? null :
             function onProgressiveData(chunk) {
           if (!pdfManager) {
             cachedChunks.push(chunk);

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1076,6 +1076,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
 
     fetchDocument: function WorkerTransport_fetchDocument(source) {
       source.disableAutoFetch = PDFJS.disableAutoFetch;
+      source.disableStream = PDFJS.disableStream;
       source.chunkedViewerLoading = !!this.pdfDataRangeTransport;
       this.messageHandler.send('GetDocRequest', {
         source: source,


### PR DESCRIPTION
After PR #5263, setting `disableAutoFetch = true` no longer works correctly (the entire file loads). This is a tentative patch that attempts to address that.
