### PR TITLE
Fix |cleanup| regression in the viewer

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -609,8 +609,9 @@ var PDFViewer = (function pdfViewer() {
                                                             this.scroll.down);
       if (pageView) {
         this.renderingQueue.renderView(pageView);
-        return;
+        return true;
       }
+      return false;
     },
 
     getPageTextContent: function (pageIndex) {


### PR DESCRIPTION
Addresses https://github.com/mozilla/pdf.js/issues/2813#issuecomment-57545936 by mimicking the pattern used in https://github.com/mozilla/pdf.js/blob/master/web/thumbnail_view.js#L370.

/cc @timvandermeij
