### PR TITLE
Fix the placement of arrows in the zoom box

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -755,8 +755,6 @@ html[dir='rtl'] .dropdownToolbarButton {
 }
 
 .dropdownToolbarButton > select {
-  -webkit-appearance: none;
-  -moz-appearance: none; /* in the future this might matter, see bugzilla bug #649849 */
   min-width: 140px;
   font-size: 12px;
   color: hsl(0,0%,95%);


### PR DESCRIPTION
Now that [bug 649849](https://bugzilla.mozilla.org/show_bug.cgi?id=649849) has been fixed, adding support for `-moz-appearance: none`, the arrow is now too close to the text in the zoom box. This is currently only an issue in Nightly, but assuming the patch doesn't get backed out, this will soon affect all versions of Firefox.

This is an illustration of the issue:
![zoom-arrow](https://cloud.githubusercontent.com/assets/2692120/4515904/e8880e90-4bd7-11e4-9395-b44d3cb73401.png)

**Edit:** Should also fix https://bugzilla.mozilla.org/show_bug.cgi?id=1102063.
