### PR TITLE
Fix searching for end of inline (EI) images with ASCII85Decode filters (bug 1077808)

### DIFF
--- a/test/pdfs/bug1077808.pdf.link
+++ b/test/pdfs/bug1077808.pdf.link
@@ -1,0 +1,1 @@
+https://bug1077808.bugzilla.mozilla.org/attachment.cgi?id=8499998

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1524,6 +1524,15 @@
       "type": "eq",
       "about": "Type3 font with negative HScale and font size"
     },
+    {  "id": "bug1077808",
+       "file": "pdfs/bug1077808.pdf",
+       "md5": "4a4bfc27e3fafe2f74e7a4a4cd04b8dc",
+       "rounds": 1,
+       "lastPage": 1,
+       "link": true,
+       "type": "eq",
+       "about": "Inline image with ASCII85Decode filter."
+    },
     {  "id": "bug1108753",
        "file": "pdfs/bug1108753.pdf",
        "md5": "a7aaf92d55b4602afb0ca3d75198b56b",


### PR DESCRIPTION
Based on http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#page=33, this is a tentative patch to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1077808.
