### PR TITLE
[Firefox] Use getTabForBrowser instead of _getTabForBrowser if possible

### DIFF
--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -77,7 +77,18 @@ function getFindBar(domWindow) {
   var browser = getContainingBrowser(domWindow);
   try {
     var tabbrowser = browser.getTabBrowser();
-    var tab = tabbrowser._getTabForBrowser(browser);
+    var tab;
+//#if MOZCENTRAL
+    tab = tabbrowser.getTabForBrowser(browser);
+//#else
+    if (tabbrowser.getTabForBrowser) {
+      tab = tabbrowser.getTabForBrowser(browser);
+    } else {
+      // _getTabForBrowser is depreciated in Firefox 35, see
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1039500.
+      tab = tabbrowser._getTabForBrowser(browser);
+    }
+//#endif
     return tabbrowser.getFindBar(tab);
   } catch (e) {
     // FF22 has no _getTabForBrowser, and FF24 has no getFindBar

--- a/extensions/firefox/content/PdfjsChromeUtils.jsm
+++ b/extensions/firefox/content/PdfjsChromeUtils.jsm
@@ -272,7 +272,18 @@ let PdfjsChromeUtils = {
  */
 function PdfjsFindbarWrapper(aBrowser) {
   let tabbrowser = aBrowser.getTabBrowser();
-  let tab = tabbrowser._getTabForBrowser(aBrowser);
+  let tab;
+//#if MOZCENTRAL
+  tab = tabbrowser.getTabForBrowser(aBrowser);
+//#else
+  if (tabbrowser.getTabForBrowser) {
+    tab = tabbrowser.getTabForBrowser(aBrowser);
+  } else {
+    // _getTabForBrowser is depreciated in Firefox 35, see
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1039500.
+    tab = tabbrowser._getTabForBrowser(aBrowser);
+  }
+//#endif
   this._findbar = tabbrowser.getFindBar(tab);
 };
 


### PR DESCRIPTION
`_getTabForBrowser` was depreciated in https://bugzilla.mozilla.org/show_bug.cgi?id=1039500, so this patch adds support for `getTabForBrowser` in a way that doesn't break backwards compatibility. (This is in contrast to [this already landed patch](https://bugzilla.mozilla.org/attachment.cgi?id=8502864&action=diff), which if up-streamed would break the findbar in older versions of Firefox.)
