### PR TITLE
[Firefox] Enable linting of *.jsm files and update the code style in extensions/firefox/content

### DIFF
--- a/extensions/firefox/content/PdfJs-stub.jsm
+++ b/extensions/firefox/content/PdfJs-stub.jsm
@@ -1,3 +1,5 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 /* Copyright 2012 Mozilla Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,10 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* jshint esnext:true, maxlen:100 */
+
+'use strict';
 
 // Don't remove this file. FF15+ expects PdfJs module to be present at resource://pdf.js/PdfJs.jsm
 // See https://mxr.mozilla.org/mozilla-central/source/browser/components/nsBrowserGlue.js
-var EXPORTED_SYMBOLS = ["PdfJs"];
+var EXPORTED_SYMBOLS = ['PdfJs'];
 
 let PdfJs = {
   init: function PdfJs_init() {}

--- a/extensions/firefox/content/PdfJs.jsm
+++ b/extensions/firefox/content/PdfJs.jsm
@@ -1,3 +1,5 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 /* Copyright 2012 Mozilla Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* jshint esnext:true */
+/* globals Components, Services, XPCOMUtils, PdfjsChromeUtils, PdfRedirector,
+           PdfjsContentUtils, DEFAULT_PREFERENCES, PdfStreamConverter */
 
-var EXPORTED_SYMBOLS = ["PdfJs"];
+'use strict';
+
+var EXPORTED_SYMBOLS = ['PdfJs'];
 
 const Cc = Components.classes;
 const Ci = Components.interfaces;
@@ -25,11 +32,12 @@ const PREF_PREFIX = 'pdfjs';
 const PREF_DISABLED = PREF_PREFIX + '.disabled';
 const PREF_MIGRATION_VERSION = PREF_PREFIX + '.migrationVersion';
 const PREF_PREVIOUS_ACTION = PREF_PREFIX + '.previousHandler.preferredAction';
-const PREF_PREVIOUS_ASK = PREF_PREFIX + '.previousHandler.alwaysAskBeforeHandling';
+const PREF_PREVIOUS_ASK = PREF_PREFIX +
+                          '.previousHandler.alwaysAskBeforeHandling';
 const PREF_DISABLED_PLUGIN_TYPES = 'plugin.disable_full_page_plugin_for_types';
 const TOPIC_PDFJS_HANDLER_CHANGED = 'pdfjs:handlerChanged';
-const TOPIC_PLUGINS_LIST_UPDATED = "plugins-list-updated";
-const TOPIC_PLUGIN_INFO_UPDATED = "plugin-info-updated";
+const TOPIC_PLUGINS_LIST_UPDATED = 'plugins-list-updated';
+const TOPIC_PLUGIN_INFO_UPDATED = 'plugin-info-updated';
 const PDF_CONTENT_TYPE = 'application/pdf';
 
 Cu.import('resource://gre/modules/XPCOMUtils.jsm');
@@ -42,10 +50,10 @@ XPCOMUtils.defineLazyServiceGetter(Svc, 'mime',
 XPCOMUtils.defineLazyServiceGetter(Svc, 'pluginHost',
                                    '@mozilla.org/plugin/host;1',
                                    'nsIPluginHost');
-XPCOMUtils.defineLazyModuleGetter(this, "PdfjsChromeUtils",
-                                  "resource://pdf.js/PdfjsChromeUtils.jsm");
-XPCOMUtils.defineLazyModuleGetter(this, "PdfjsContentUtils",
-                                  "resource://pdf.js/PdfjsContentUtils.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, 'PdfjsChromeUtils',
+                                  'resource://pdf.js/PdfjsChromeUtils.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'PdfjsContentUtils',
+                                  'resource://pdf.js/PdfjsContentUtils.jsm');
 
 function getBoolPref(aPref, aDefaultValue) {
   try {
@@ -64,7 +72,7 @@ function getIntPref(aPref, aDefaultValue) {
 }
 
 function isDefaultHandler() {
- if (Services.appinfo.processType == Services.appinfo.PROCESS_TYPE_CONTENT) {
+ if (Services.appinfo.processType === Services.appinfo.PROCESS_TYPE_CONTENT) {
    return PdfjsContentUtils.isDefaultHandlerApp();
  }
  return PdfjsChromeUtils.isDefaultHandlerApp();
@@ -119,8 +127,10 @@ let PdfJs = {
   _initialized: false,
 
   init: function init(remote) {
-    if (Services.appinfo.processType != Services.appinfo.PROCESS_TYPE_DEFAULT) {
-      throw new Error("PdfJs.init should only get called in the parent process.");
+    if (Services.appinfo.processType !==
+        Services.appinfo.PROCESS_TYPE_DEFAULT) {
+      throw new Error('PdfJs.init should only get called ' +
+                      'in the parent process.');
     }
     PdfjsChromeUtils.init();
     if (!remote) {
@@ -224,9 +234,9 @@ let PdfJs = {
     prefs.setCharPref(PREF_DISABLED_PLUGIN_TYPES, types.join(','));
 
     // Update the category manager in case the plugins are already loaded.
-    let categoryManager = Cc["@mozilla.org/categorymanager;1"];
+    let categoryManager = Cc['@mozilla.org/categorymanager;1'];
     categoryManager.getService(Ci.nsICategoryManager).
-                    deleteCategoryEntry("Gecko-Content-Viewers",
+                    deleteCategoryEntry('Gecko-Content-Viewers',
                                         PDF_CONTENT_TYPE,
                                         false);
   },
@@ -234,8 +244,9 @@ let PdfJs = {
   // nsIObserver
   observe: function observe(aSubject, aTopic, aData) {
     this.updateRegistration();
-    if (Services.appinfo.processType == Services.appinfo.PROCESS_TYPE_DEFAULT) {
-      let jsm = "resource://pdf.js/PdfjsChromeUtils.jsm";
+    if (Services.appinfo.processType ===
+        Services.appinfo.PROCESS_TYPE_DEFAULT) {
+      let jsm = 'resource://pdf.js/PdfjsChromeUtils.jsm';
       let PdfjsChromeUtils = Components.utils.import(jsm, {}).PdfjsChromeUtils;
       PdfjsChromeUtils.notifyChildOfSettingsChange();
     }
@@ -267,9 +278,9 @@ let PdfJs = {
     }
 
     // Check if there is an enabled pdf plugin.
-    // Note: this check is performed last because getPluginTags() triggers costly
-    // plugin list initialization (bug 881575)
-    let tags = Cc["@mozilla.org/plugin/host;1"].
+    // Note: this check is performed last because getPluginTags() triggers
+    // costly plugin list initialization (bug 881575)
+    let tags = Cc['@mozilla.org/plugin/host;1'].
                   getService(Ci.nsIPluginHost).
                   getPluginTags();
     let enabledPluginFound = tags.some(function(tag) {
@@ -287,9 +298,9 @@ let PdfJs = {
   },
 
   _ensureRegistered: function _ensureRegistered() {
-    if (this._registered)
+    if (this._registered) {
       return;
-
+    }
     this._pdfStreamConverterFactory = new Factory();
     Cu.import('resource://pdf.js/PdfStreamConverter.jsm');
     this._pdfStreamConverterFactory.register(PdfStreamConverter);
@@ -305,9 +316,9 @@ let PdfJs = {
   },
 
   _ensureUnregistered: function _ensureUnregistered() {
-    if (!this._registered)
+    if (!this._registered) {
       return;
-
+    }
     this._pdfStreamConverterFactory.unregister();
     Cu.unload('resource://pdf.js/PdfStreamConverter.jsm');
     delete this._pdfStreamConverterFactory;

--- a/extensions/firefox/content/PdfJsTelemetry-addon.jsm
+++ b/extensions/firefox/content/PdfJsTelemetry-addon.jsm
@@ -14,7 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* jshint esnext:true */
+/* jshint esnext:true, maxlen:120 */
+/* globals Components, Services */
 
 'use strict';
 
@@ -23,7 +24,7 @@ this.EXPORTED_SYMBOLS = ['PdfJsTelemetry'];
 const Cu = Components.utils;
 Cu.import('resource://gre/modules/Services.jsm');
 
-const ADDON_ID = "uriloader@pdf.js";
+const ADDON_ID = 'uriloader@pdf.js';
 
 var Telemetry = Services.telemetry;
 
@@ -36,9 +37,9 @@ try {
   if (ffVersion === 36) {
     // Probing FF36 to check if it has new API.
     try {
-      Telemetry.registerAddonHistogram(ADDON_ID, "PDF_36",
+      Telemetry.registerAddonHistogram(ADDON_ID, 'PDF_36',
         Telemetry.HISTOGRAM_LINEAR, 1, 40, 41);
-      var histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_36");
+      var histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_36');
       histogram.add(36);
     } catch (e) {
       oldTelemetryAPI = true;
@@ -66,47 +67,47 @@ registerAddonHistogram(ADDON_ID, 'PDF_VIEWER_TIME_TO_VIEW_MS', Telemetry.HISTOGR
 
 this.PdfJsTelemetry = {
   onViewerIsUsed: function () {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_USED");
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_USED');
     histogram.add(true);
   },
   onFallback: function () {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_FALLBACK_SHOWN");
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_FALLBACK_SHOWN');
     histogram.add(true);
   },
   onDocumentSize: function (size) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_DOCUMENT_SIZE_KB");
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_DOCUMENT_SIZE_KB');
     histogram.add(size / 1024);
   },
   onDocumentVersion: function (versionId) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_DOCUMENT_VERSION");
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_DOCUMENT_VERSION');
     histogram.add(versionId);
   },
   onDocumentGenerator: function (generatorId) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_DOCUMENT_GENERATOR");
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_DOCUMENT_GENERATOR');
     histogram.add(generatorId);
   },
   onEmbed: function (isObject) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_EMBED");
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_EMBED');
     histogram.add(isObject);
   },
   onFontType: function (fontTypeId) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_FONT_TYPES");
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_FONT_TYPES');
     histogram.add(fontTypeId);
   },
   onForm: function (isAcroform) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_FORM");
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_FORM');
     histogram.add(isAcroform);
   },
   onPrint: function () {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_PRINT");
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_PRINT');
     histogram.add(true);
   },
   onStreamType: function (streamTypeId) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_STREAM_TYPES");
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_STREAM_TYPES');
     histogram.add(streamTypeId);
   },
   onTimeToView: function (ms) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_TIME_TO_VIEW_MS");
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_TIME_TO_VIEW_MS');
     histogram.add(ms);
   }
 };

--- a/extensions/firefox/content/PdfJsTelemetry.jsm
+++ b/extensions/firefox/content/PdfJsTelemetry.jsm
@@ -14,7 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* jshint esnext:true */
+/* jshint esnext:true, maxlen: 100 */
+/* globals Components, Services */
 
 'use strict';
 
@@ -25,47 +26,47 @@ Cu.import('resource://gre/modules/Services.jsm');
 
 this.PdfJsTelemetry = {
   onViewerIsUsed: function () {
-    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_USED");
+    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_USED');
     histogram.add(true);
   },
   onFallback: function () {
-    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_FALLBACK_SHOWN");
+    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_FALLBACK_SHOWN');
     histogram.add(true);
   },
   onDocumentSize: function (size) {
-    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_DOCUMENT_SIZE_KB");
+    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_DOCUMENT_SIZE_KB');
     histogram.add(size / 1024);
   },
   onDocumentVersion: function (versionId) {
-    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_DOCUMENT_VERSION");
+    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_DOCUMENT_VERSION');
     histogram.add(versionId);
   },
   onDocumentGenerator: function (generatorId) {
-    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_DOCUMENT_GENERATOR");
+    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_DOCUMENT_GENERATOR');
     histogram.add(generatorId);
   },
   onEmbed: function (isObject) {
-    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_EMBED");
+    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_EMBED');
     histogram.add(isObject);
   },
   onFontType: function (fontTypeId) {
-    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_FONT_TYPES");
+    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_FONT_TYPES');
     histogram.add(fontTypeId);
   },
   onForm: function (isAcroform) {
-    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_FORM");
+    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_FORM');
     histogram.add(isAcroform);
   },
   onPrint: function () {
-    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_PRINT");
+    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_PRINT');
     histogram.add(true);
   },
   onStreamType: function (streamTypeId) {
-    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_STREAM_TYPES");
+    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_STREAM_TYPES');
     histogram.add(streamTypeId);
   },
   onTimeToView: function (ms) {
-    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_TIME_TO_VIEW_MS");
+    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_TIME_TO_VIEW_MS');
     histogram.add(ms);
   }
 };

--- a/extensions/firefox/content/PdfjsChromeUtils.jsm
+++ b/extensions/firefox/content/PdfjsChromeUtils.jsm
@@ -14,7 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- /*globals DEFAULT_PREFERENCES */
+/* jshint esnext:true */
+/* globals Components, Services, XPCOMUtils, DEFAULT_PREFERENCES */
 
 'use strict';
 
@@ -52,39 +53,42 @@ let PdfjsChromeUtils = {
   init: function () {
     if (!this._ppmm) {
       // global parent process message manager (PPMM)
-      this._ppmm = Cc["@mozilla.org/parentprocessmessagemanager;1"].getService(Ci.nsIMessageBroadcaster);
-      this._ppmm.addMessageListener("PDFJS:Parent:clearUserPref", this);
-      this._ppmm.addMessageListener("PDFJS:Parent:setIntPref", this);
-      this._ppmm.addMessageListener("PDFJS:Parent:setBoolPref", this);
-      this._ppmm.addMessageListener("PDFJS:Parent:setCharPref", this);
-      this._ppmm.addMessageListener("PDFJS:Parent:setStringPref", this);
-      this._ppmm.addMessageListener("PDFJS:Parent:isDefaultHandlerApp", this);
+      this._ppmm = Cc['@mozilla.org/parentprocessmessagemanager;1'].
+        getService(Ci.nsIMessageBroadcaster);
+      this._ppmm.addMessageListener('PDFJS:Parent:clearUserPref', this);
+      this._ppmm.addMessageListener('PDFJS:Parent:setIntPref', this);
+      this._ppmm.addMessageListener('PDFJS:Parent:setBoolPref', this);
+      this._ppmm.addMessageListener('PDFJS:Parent:setCharPref', this);
+      this._ppmm.addMessageListener('PDFJS:Parent:setStringPref', this);
+      this._ppmm.addMessageListener('PDFJS:Parent:isDefaultHandlerApp', this);
 
       // global dom message manager (MMg)
-      this._mmg = Cc["@mozilla.org/globalmessagemanager;1"].getService(Ci.nsIMessageListenerManager);
-      this._mmg.addMessageListener("PDFJS:Parent:getChromeWindow", this);
-      this._mmg.addMessageListener("PDFJS:Parent:getFindBar", this);
-      this._mmg.addMessageListener("PDFJS:Parent:displayWarning", this);
+      this._mmg = Cc['@mozilla.org/globalmessagemanager;1'].
+        getService(Ci.nsIMessageListenerManager);
+      this._mmg.addMessageListener('PDFJS:Parent:getChromeWindow', this);
+      this._mmg.addMessageListener('PDFJS:Parent:getFindBar', this);
+      this._mmg.addMessageListener('PDFJS:Parent:displayWarning', this);
 
       // observer to handle shutdown
-      Services.obs.addObserver(this, "quit-application", false);
+      Services.obs.addObserver(this, 'quit-application', false);
     }
   },
 
   uninit: function () {
     if (this._ppmm) {
-      this._ppmm.removeMessageListener("PDFJS:Parent:clearUserPref", this);
-      this._ppmm.removeMessageListener("PDFJS:Parent:setIntPref", this);
-      this._ppmm.removeMessageListener("PDFJS:Parent:setBoolPref", this);
-      this._ppmm.removeMessageListener("PDFJS:Parent:setCharPref", this);
-      this._ppmm.removeMessageListener("PDFJS:Parent:setStringPref", this);
-      this._ppmm.removeMessageListener("PDFJS:Parent:isDefaultHandlerApp", this);
+      this._ppmm.removeMessageListener('PDFJS:Parent:clearUserPref', this);
+      this._ppmm.removeMessageListener('PDFJS:Parent:setIntPref', this);
+      this._ppmm.removeMessageListener('PDFJS:Parent:setBoolPref', this);
+      this._ppmm.removeMessageListener('PDFJS:Parent:setCharPref', this);
+      this._ppmm.removeMessageListener('PDFJS:Parent:setStringPref', this);
+      this._ppmm.removeMessageListener('PDFJS:Parent:isDefaultHandlerApp',
+                                       this);
 
-      this._mmg.removeMessageListener("PDFJS:Parent:getChromeWindow", this);
-      this._mmg.removeMessageListener("PDFJS:Parent:getFindBar", this);
-      this._mmg.removeMessageListener("PDFJS:Parent:displayWarning", this);
+      this._mmg.removeMessageListener('PDFJS:Parent:getChromeWindow', this);
+      this._mmg.removeMessageListener('PDFJS:Parent:getFindBar', this);
+      this._mmg.removeMessageListener('PDFJS:Parent:displayWarning', this);
 
-      Services.obs.removeObserver(this, "quit-application", false);
+      Services.obs.removeObserver(this, 'quit-application', false);
 
       this._mmg = null;
       this._ppmm = null;
@@ -98,14 +102,14 @@ let PdfjsChromeUtils = {
    * the module's registration.
    */
   notifyChildOfSettingsChange: function () {
-    if (Services.appinfo.processType == Services.appinfo.PROCESS_TYPE_DEFAULT &&
-        this._ppmm) {
+    if (Services.appinfo.processType ===
+        Services.appinfo.PROCESS_TYPE_DEFAULT && this._ppmm) {
       // XXX kinda bad, we want to get the parent process mm associated
       // with the content process. _ppmm is currently the global process
       // manager, which means this is going to fire to every child process
       // we have open. Unfortunately I can't find a way to get at that
       // process specific mm from js.
-      this._ppmm.broadcastAsyncMessage("PDFJS:Child:refreshSettings", {});
+      this._ppmm.broadcastAsyncMessage('PDFJS:Child:refreshSettings', {});
     }
   },
 
@@ -114,38 +118,38 @@ let PdfjsChromeUtils = {
    */
 
   observe: function(aSubject, aTopic, aData) {
-    if (aTopic == "quit-application") {
+    if (aTopic === 'quit-application') {
       this.uninit();
     }
   },
 
   receiveMessage: function (aMsg) {
     switch (aMsg.name) {
-      case "PDFJS:Parent:clearUserPref":
+      case 'PDFJS:Parent:clearUserPref':
         this._clearUserPref(aMsg.data.name);
         break;
-      case "PDFJS:Parent:setIntPref":
+      case 'PDFJS:Parent:setIntPref':
         this._setIntPref(aMsg.data.name, aMsg.data.value);
         break;
-      case "PDFJS:Parent:setBoolPref":
+      case 'PDFJS:Parent:setBoolPref':
         this._setBoolPref(aMsg.data.name, aMsg.data.value);
         break;
-      case "PDFJS:Parent:setCharPref":
+      case 'PDFJS:Parent:setCharPref':
         this._setCharPref(aMsg.data.name, aMsg.data.value);
         break;
-      case "PDFJS:Parent:setStringPref":
+      case 'PDFJS:Parent:setStringPref':
         this._setStringPref(aMsg.data.name, aMsg.data.value);
         break;
-      case "PDFJS:Parent:isDefaultHandlerApp":
+      case 'PDFJS:Parent:isDefaultHandlerApp':
         return this.isDefaultHandlerApp();
-      case "PDFJS:Parent:displayWarning":
+      case 'PDFJS:Parent:displayWarning':
         this._displayWarning(aMsg);
         break;
 
       // CPOW getters
-      case "PDFJS:Parent:getChromeWindow":
+      case 'PDFJS:Parent:getChromeWindow':
         return this._getChromeWindow(aMsg);
-      case "PDFJS:Parent:getFindBar":
+      case 'PDFJS:Parent:getFindBar':
         return this._getFindBar(aMsg);
     }
   },
@@ -178,8 +182,8 @@ let PdfjsChromeUtils = {
     let unPrefixedName = aPrefName.split(PREF_PREFIX + '.');
     if (unPrefixedName[0] !== '' ||
         this._allowedPrefNames.indexOf(unPrefixedName[1]) === -1) {
-      let msg = "'" + aPrefName + "' ";
-      msg += "can't be accessed from content. See PdfjsChromeUtils." 
+      let msg = '"' + aPrefName + '" ' +
+                'can\'t be accessed from content. See PdfjsChromeUtils.';
       throw new Error(msg);
     }
   },
@@ -219,8 +223,8 @@ let PdfjsChromeUtils = {
    */
   isDefaultHandlerApp: function () {
     var handlerInfo = Svc.mime.getFromTypeAndExtension(PDF_CONTENT_TYPE, 'pdf');
-    return !handlerInfo.alwaysAskBeforeHandling &&
-           handlerInfo.preferredAction == Ci.nsIHandlerInfo.handleInternally;
+    return (!handlerInfo.alwaysAskBeforeHandling &&
+            handlerInfo.preferredAction === Ci.nsIHandlerInfo.handleInternally);
   },
 
   /*
@@ -285,13 +289,13 @@ function PdfjsFindbarWrapper(aBrowser) {
   }
 //#endif
   this._findbar = tabbrowser.getFindBar(tab);
-};
+}
 
 PdfjsFindbarWrapper.prototype = {
   __exposedProps__: {
-    addEventListener: "r",
-    removeEventListener: "r",
-    updateControlState: "r",
+    addEventListener: 'r',
+    removeEventListener: 'r',
+    updateControlState: 'r',
   },
   _findbar: null,
 
@@ -300,7 +304,8 @@ PdfjsFindbarWrapper.prototype = {
   },
 
   addEventListener: function (aType, aListener, aUseCapture, aWantsUntrusted) {
-    this._findbar.addEventListener(aType, aListener, aUseCapture, aWantsUntrusted);
+    this._findbar.addEventListener(aType, aListener, aUseCapture,
+                                   aWantsUntrusted);
   },
 
   removeEventListener: function (aType, aListener, aUseCapture) {
@@ -310,11 +315,11 @@ PdfjsFindbarWrapper.prototype = {
 
 function PdfjsWindowWrapper(aBrowser) {
   this._window = aBrowser.ownerDocument.defaultView;
-};
+}
 
 PdfjsWindowWrapper.prototype = {
   __exposedProps__: {
-    valueOf: "r",
+    valueOf: 'r',
   },
   _window: null,
 
@@ -322,4 +327,3 @@ PdfjsWindowWrapper.prototype = {
     return this._window.valueOf();
   }
 };
-

--- a/extensions/firefox/content/PdfjsContentUtils.jsm
+++ b/extensions/firefox/content/PdfjsContentUtils.jsm
@@ -1,3 +1,5 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 /* Copyright 2012 Mozilla Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* jshint esnext:true */
+/* globals Components, Services, XPCOMUtils */
 
 'use strict';
 
@@ -33,23 +37,25 @@ let PdfjsContentUtils = {
    */
 
   get isRemote() {
-    return Services.appinfo.processType == Services.appinfo.PROCESS_TYPE_CONTENT;
+    return (Services.appinfo.processType ===
+            Services.appinfo.PROCESS_TYPE_CONTENT);
   },
 
   init: function () {
     // child *process* mm, or when loaded into the parent for in-content
     // support the psuedo child process mm 'child PPMM'.
     if (!this._mm) {
-      this._mm = Cc["@mozilla.org/childprocessmessagemanager;1"].getService(Ci.nsISyncMessageSender);
-      this._mm.addMessageListener("PDFJS:Child:refreshSettings", this);
-      Services.obs.addObserver(this, "quit-application", false);
+      this._mm = Cc['@mozilla.org/childprocessmessagemanager;1'].
+        getService(Ci.nsISyncMessageSender);
+      this._mm.addMessageListener('PDFJS:Child:refreshSettings', this);
+      Services.obs.addObserver(this, 'quit-application', false);
     }
   },
 
   uninit: function () {
     if (this._mm) {
-      this._mm.removeMessageListener("PDFJS:Child:refreshSettings", this);
-      Services.obs.removeObserver(this, "quit-application");
+      this._mm.removeMessageListener('PDFJS:Child:refreshSettings', this);
+      Services.obs.removeObserver(this, 'quit-application');
     }
     this._mm = null;
   },
@@ -61,34 +67,34 @@ let PdfjsContentUtils = {
    */
 
   clearUserPref: function (aPrefName) {
-    this._mm.sendSyncMessage("PDFJS:Parent:clearUserPref", {
+    this._mm.sendSyncMessage('PDFJS:Parent:clearUserPref', {
       name: aPrefName
     });
   },
 
   setIntPref: function (aPrefName, aPrefValue) {
-    this._mm.sendSyncMessage("PDFJS:Parent:setIntPref", {
+    this._mm.sendSyncMessage('PDFJS:Parent:setIntPref', {
       name: aPrefName,
       value: aPrefValue
     });
   },
 
   setBoolPref: function (aPrefName, aPrefValue) {
-    this._mm.sendSyncMessage("PDFJS:Parent:setBoolPref", {
+    this._mm.sendSyncMessage('PDFJS:Parent:setBoolPref', {
       name: aPrefName,
       value: aPrefValue
     });
   },
 
   setCharPref: function (aPrefName, aPrefValue) {
-    this._mm.sendSyncMessage("PDFJS:Parent:setCharPref", {
+    this._mm.sendSyncMessage('PDFJS:Parent:setCharPref', {
       name: aPrefName,
       value: aPrefValue
     });
   },
 
   setStringPref: function (aPrefName, aPrefValue) {
-    this._mm.sendSyncMessage("PDFJS:Parent:setStringPref", {
+    this._mm.sendSyncMessage('PDFJS:Parent:setStringPref', {
       name: aPrefName,
       value: aPrefValue
     });
@@ -99,7 +105,7 @@ let PdfjsContentUtils = {
    * handler app settings only available in the parent process.
    */
   isDefaultHandlerApp: function () {
-    return this._mm.sendSyncMessage("PDFJS:Parent:isDefaultHandlerApp")[0];
+    return this._mm.sendSyncMessage('PDFJS:Parent:isDefaultHandlerApp')[0];
   },
 
   /*
@@ -112,7 +118,7 @@ let PdfjsContentUtils = {
                        .getInterface(Ci.nsIDocShell)
                        .QueryInterface(Ci.nsIInterfaceRequestor)
                        .getInterface(Ci.nsIContentFrameMessageManager);
-    winmm.sendAsyncMessage("PDFJS:Parent:displayWarning", {
+    winmm.sendAsyncMessage('PDFJS:Parent:displayWarning', {
       message: aMessage,
       label: aLabel,
       accessKey: accessKey
@@ -126,17 +132,18 @@ let PdfjsContentUtils = {
    */
 
   observe: function(aSubject, aTopic, aData) {
-    if (aTopic == "quit-application") {
+    if (aTopic === 'quit-application') {
       this.uninit();
     }
   },
 
   receiveMessage: function (aMsg) {
     switch (aMsg.name) {
-      case "PDFJS:Child:refreshSettings":
+      case 'PDFJS:Child:refreshSettings':
         // Only react to this if we are remote.
-        if (Services.appinfo.processType == Services.appinfo.PROCESS_TYPE_CONTENT) {
-          let jsm = "resource://pdf.js/PdfJs.jsm";
+        if (Services.appinfo.processType ===
+            Services.appinfo.PROCESS_TYPE_CONTENT) {
+          let jsm = 'resource://pdf.js/PdfJs.jsm';
           let pdfjs = Components.utils.import(jsm, {}).PdfJs;
           pdfjs.updateRegistration();
         }
@@ -159,12 +166,14 @@ let PdfjsContentUtils = {
     // send over a small container for the object we want.
     let suitcase = {
       _window: null,
-      setChromeWindow: function (aObj) { this._window = aObj; }
-    }
-    if (!winmm.sendSyncMessage("PDFJS:Parent:getChromeWindow", {},
+      setChromeWindow: function (aObj) {
+        this._window = aObj;
+      }
+    };
+    if (!winmm.sendSyncMessage('PDFJS:Parent:getChromeWindow', {},
                                { suitcase: suitcase })[0]) {
-      Cu.reportError("A request for a CPOW wrapped chrome window " +
-                     "failed for unknown reasons.");
+      Cu.reportError('A request for a CPOW wrapped chrome window ' +
+                     'failed for unknown reasons.');
       return null;
     }
     return suitcase._window;
@@ -179,12 +188,14 @@ let PdfjsContentUtils = {
                         .getInterface(Ci.nsIContentFrameMessageManager);
     let suitcase = {
       _findbar: null,
-      setFindBar: function (aObj) { this._findbar = aObj; }
-    }
-    if (!winmm.sendSyncMessage("PDFJS:Parent:getFindBar", {},
+      setFindBar: function (aObj) {
+        this._findbar = aObj;
+      }
+    };
+    if (!winmm.sendSyncMessage('PDFJS:Parent:getFindBar', {},
                                { suitcase: suitcase })[0]) {
-      Cu.reportError("A request for a CPOW wrapped findbar " +
-                     "failed for unknown reasons.");
+      Cu.reportError('A request for a CPOW wrapped findbar ' +
+                     'failed for unknown reasons.');
       return null;
     }
     return suitcase._findbar;

--- a/make.js
+++ b/make.js
@@ -1460,8 +1460,10 @@ target.lint = function() {
     echo('jshint is not installed -- installing...');
     exec('npm install jshint@2.4.x'); // TODO read version from package.json
   }
+  // Lint the Firefox specific *.jsm files.
+  var options = '--extra-ext .jsm';
 
-  var exitCode = exec('"' + jshintPath + '" .').code;
+  var exitCode = exec('"' + jshintPath + '" ' + options + ' .').code;
   if (exitCode === 0) {
     echo('files checked, no errors found');
   }


### PR DESCRIPTION
By default JSHint will only lint `*.js` files, however it is possible specify that other file types should be covered as well. To ensure a consistent code style, and to help catch errors, I think that it's a good idea to also include `*.jsm` files when running lint.
Besides updating the `node make lint` command, this PR also makes the necessary adjustments to make linting pass.

Besides, obviously, testing this using the built addon, I've also made extensive use of the addon debugger to make sure that changing to strict equalities doesn't change the behaviour.

_Note:_ In a couple of the files I've relaxed the maximum line length requirement, because enforcing 80 characters would have meant adding a, in my opinion, disproportionally large number of new lines. I tried to keep the total diff as small as possible, but I would be happy to change this is if that is preferred.
