### PR TITLE
Adds a hasOwnProperty check to ToUnicodeMap forEach method

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -2191,6 +2191,9 @@ var ToUnicodeMap = (function ToUnicodeMapClosure() {
 
     forEach: function(callback) {
       for (var charCode in this._map) {
+        if (!this._map.hasOwnProperty(charCode)) {
+          continue;
+        }
         callback(charCode, this._map[charCode].charCodeAt(0));
       }
     },


### PR DESCRIPTION
I encountered the following console output trying to render a PDF:

```
Warning: Unsupported feature "font" pdf.worker.js:240
Warning: Error during font loading: undefined is not a function pdf.js:240
Warning: Unsupported feature "font" pdf.worker.js:240
Warning: Error during font loading: undefined is not a function pdf.js:240
```

Visually, the PDF is rendered without any text.

It turned out that the `this._map` instance member of `ToUnicodeMap` was an array and the error was coming from array prototype methods being treated as character codes.  Adding a `hasOwnProperty` check in this loop fixed the issue and my PDF looks perfect.

The PDF I'm rendering can be found in this gist:  https://gist.github.com/sfishel18/eb187c923b15017f4ee4.  Let me know if there is a better way to attach that file.
