### PR TITLE
Bug 1072164 - Fixes decoding for CMYK jpegs.

### DIFF
--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -884,7 +884,7 @@ var JpegStream = (function JpegStreamClosure() {
       var jpegImage = new JpegImage();
 
       // checking if values needs to be transformed before conversion
-      if (this.dict && isArray(this.dict.get('Decode'))) {
+      if (this.forceRGB && this.dict && isArray(this.dict.get('Decode'))) {
         var decodeArr = this.dict.get('Decode');
         var bitsPerComponent = this.dict.get('BitsPerComponent') || 8;
         var decodeArrLength = decodeArr.length;

--- a/test/pdfs/bug1072164.pdf.link
+++ b/test/pdfs/bug1072164.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=8494369

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1602,6 +1602,14 @@
       "rounds": 1,
       "type": "eq"
     },
+    {  "id": "bug1072164",
+      "file": "pdfs/bug1072164.pdf",
+      "md5": "cfee3c51e8464aa44218f4eaf27e084b",
+      "rounds": 1,
+      "link": true,
+      "type": "eq",
+      "about": "CMYK jpeg with mask"
+    },
     {  "id": "bug886717",
       "file": "pdfs/bug886717.pdf",
       "md5": "8ba614192797a1324765610231a1bc9d",


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1072164
