### PR TITLE
Fix JPX "Out of Packets" Error (issues 4358, 4659, 4814)

### DIFF
--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -540,6 +540,11 @@ var JpxImage = (function JpxImageClosure() {
         codeblock.precinctNumber = precinctNumber;
         codeblock.subbandType = subband.type;
         codeblock.Lblock = 3;
+
+        if (codeblock.tbx1_ <= codeblock.tbx0_ ||
+            codeblock.tby1_ <= codeblock.tby0_) {
+          continue;
+        }
         codeblocks.push(codeblock);
         // building precinct for the sub-band
         var precinct = precincts[precinctNumber];

--- a/test/pdfs/bug865858.pdf.link
+++ b/test/pdfs/bug865858.pdf.link
@@ -1,0 +1,1 @@
+https://bug865858.bugzilla.mozilla.org/attachment.cgi?id=742273

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1675,6 +1675,14 @@
       "type": "eq",
       "about": "JPX with 0xFF55 marker"
     },
+    {  "id": "bug865858",
+      "file": "pdfs/bug865858.pdf",
+      "md5": "7a81bd987dc1d95e9a0be46b7c3f2e18",
+      "link": true,
+      "rounds": 1,
+      "type": "eq",
+      "about": "JPX packets"
+    },
     {  "id": "bug766138",
       "file": "pdfs/bug766138.pdf",
       "md5": "b171f5cf8d9834348112fba60ee54f8c",


### PR DESCRIPTION
This PR fixes the handling of JPX packets which caused blurriness in JPEG2000 images (#4814, #4659 page 3) and random blocks at the bottom or right border of the images (#4358).

This PR does not fix #5349, so it does not make #5350 obsolete.

The `if` condition in this fix should be equivalent to [jj2000/PktDecoder.java#L483](https://github.com/Unidata/jj2000/blob/185fc9b6ae39ffbe57506b88b6845116efac48b6/src/main/java/jj2000/j2k/codestream/reader/PktDecoder.java#L483)
