### PR TITLE
Change bug878194 to an |eq| test

### DIFF
--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1593,7 +1593,7 @@
        "rounds": 1,
        "firstPage": 4,
        "lastPage": 4,
-       "type": "load"
+       "type": "eq"
     },
     {  "id": "p020121130574743273239",
       "file": "pdfs/P020121130574743273239.pdf",


### PR DESCRIPTION
While working on simplifying the approach in PR #5383, I noticed that in some cases it is possible (caused by incorrect code) to truncate an inline image stream in such a way that it still represents a valid image.
To make sure that PR #5383 doesn't cause any regressions, I thus think that it would be good to change `bug878194` to an `eq` test instead.
