### PR TITLE
Remove custom |pagerender| event from page_view.js, except for |GENERIC| builds

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -414,11 +414,15 @@ var PDFPageView = (function PDFPageViewClosure() {
           self.onAfterDraw();
         }
 
+//#if GENERIC
+        // This custom event is deprecated and will be removed in the future.
+        // Please use the |pagerendered| event instead, see pdf_viewer.js.
         var event = document.createEvent('CustomEvent');
         event.initCustomEvent('pagerender', true, true, {
           pageNumber: pdfPage.pageNumber
         });
         div.dispatchEvent(event);
+//#endif
 
         if (!error) {
           resolveRenderPromise(undefined);


### PR DESCRIPTION
The custom `pagerender` event in page_view.js is not used anywhere in the codebase.
PR #5295 introduced the (in my opinion) better named `pagerendered` event, which is placed in pdf_viewer.js and is actually being used.
Hence this patch removes `pagerender`, since I believe it to be unnecessary code duplication.
