### PR TITLE
[issue 5440] fix rtl direction bug for full language codes

### DIFF
--- a/extensions/firefox/tools/l10n.js
+++ b/extensions/firefox/tools/l10n.js
@@ -123,7 +123,11 @@
       // http://www.w3.org/International/questions/qa-scripts
       // Arabic, Hebrew, Farsi, Pashto, Urdu
       var rtlList = ['ar', 'he', 'fa', 'ps', 'ur'];
-      return (rtlList.indexOf(gLanguage) >= 0 ? 'rtl' : 'ltr');
+
+      // use the short language code for "full" codes like 'ar-sa' (issue 5440) 
+      var shortCode = gLanguage.split('-')[0];
+
+      return (rtlList.indexOf(shortCode) >= 0) ? 'rtl' : 'ltr';
     },
 
     // translate an element or document fragment

--- a/external/webL10n/l10n.js
+++ b/external/webL10n/l10n.js
@@ -977,7 +977,11 @@ document.webL10n = (function(window, document, undefined) {
       // http://www.w3.org/International/questions/qa-scripts
       // Arabic, Hebrew, Farsi, Pashto, Urdu
       var rtlList = ['ar', 'he', 'fa', 'ps', 'ur'];
-      return (rtlList.indexOf(gLanguage) >= 0) ? 'rtl' : 'ltr';
+     
+      // use the short language code for "full" codes like 'ar-sa' (issue 5440) 
+      var shortCode = gLanguage.split('-')[0];
+
+      return (rtlList.indexOf(shortCode) >= 0) ? 'rtl' : 'ltr';
     },
 
     // translate an element or document fragment


### PR DESCRIPTION
- fixes issue #5440 
- full language codes are represented as "ab-cd", whereas short ones are "ab"
- this code change only uses "ab" to determine the RTL/LTR direction
