### PR TITLE
Fix regression that prevents downloading of font files in the debugger

### DIFF
--- a/web/debugger.js
+++ b/web/debugger.js
@@ -124,8 +124,8 @@ var FontInspector = (function FontInspectorClosure() {
         url = URL.createObjectURL(new Blob([fontObj.data], {
           type: fontObj.mimeType
         }));
+        download.href = url;
       }
-      download.href = url;
       download.textContent = 'Download';
       var logIt = document.createElement('a');
       logIt.href = '';


### PR DESCRIPTION
This is a regression from PR #5366.
