### PR TITLE
[GENERIC viewer] Fix the background color of the findInput when the search term is not found

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -472,8 +472,8 @@ html[dir='ltr'] .doorHangerRight:before {
   color: #A6B7D0;
 }
 
-.notFound {
-  background-color: rgb(255, 137, 153);
+#findInput.notFound {
+  background-color: rgb(255, 102, 102);
 }
 
 html[dir='ltr'] #toolbarViewerLeft {


### PR DESCRIPTION
When a search term isn't found, the background color of the findInput is supposed to change (to red). This is currently not working as intended, because the CSS rule is not being applied correctly. (It seems that this broke in PR #2208.)

This patch also changes the background color to match the one used in the native Firefox findbar, since the old color seemed a bit too pink.
