### PR TITLE
Prevent text selection in Presentation Mode (bug 1018882)

### DIFF
--- a/web/presentation_mode.js
+++ b/web/presentation_mode.js
@@ -150,6 +150,11 @@ var PresentationMode = {
     HandTool.enterPresentationMode();
     this.contextMenuOpen = false;
     this.container.setAttribute('contextmenu', 'viewerContextMenu');
+
+    // Text selection is disabled in Presentation Mode, thus it's not possible
+    // for the user to deselect text that is selected (e.g. with "Select all")
+    // when entering Presentation Mode, hence we remove any active selection.
+    window.getSelection().removeAllRanges();
   },
 
   exit: function presentationModeExit() {

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -55,6 +55,7 @@ select {
   height: 100%;
   overflow: hidden;
   cursor: none;
+  -webkit-user-select: none;
 }
 
 #viewerContainer:-moz-full-screen {
@@ -65,6 +66,7 @@ select {
   height: 100%;
   overflow: hidden;
   cursor: none;
+  -moz-user-select: none;
 }
 
 #viewerContainer:-ms-fullscreen {
@@ -74,6 +76,7 @@ select {
   height: 100%;
   overflow: hidden !important;
   cursor: none;
+  -ms-user-select: none;
 }
 
 #viewerContainer:-ms-fullscreen::-ms-backdrop {
@@ -88,6 +91,9 @@ select {
   height: 100%;
   overflow: hidden;
   cursor: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
 }
 
 :-webkit-full-screen a:not(.internalLink) {


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1018882.
(I got tired of receiving lots of bug mail about something that is, in my opinion, a very minor issue. Hence this PR ;-)

Note that no unprefixed version of `user-select` exists, see: https://developer.mozilla.org/en-US/docs/Web/CSS/user-select.

There is also an edge case of all text already being selected when Presentation Mode is entered. This isn't something that the bug covers, so I wasn't sure if we wanted to address that as well, hence a separate commit (to make it easier to revert the code changes if this feature isn't necessary).
