### PR TITLE
Remove TryCatch in canvas for EvenOdd winding rule.

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1096,12 +1096,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
           ctx.fill();
           ctx.mozFillRule = 'nonzero';
         } else {
-          try {
-            ctx.fill('evenodd');
-          } catch (ex) {
-            // shouldn't really happen, but browsers might think differently
-            ctx.fill();
-          }
+          ctx.fill('evenodd');
         }
         this.pendingEOFill = false;
       } else {
@@ -2110,12 +2105,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
             ctx.clip();
             ctx.mozFillRule = 'nonzero';
           } else {
-            try {
-              ctx.clip('evenodd');
-            } catch (ex) {
-              // shouldn't really happen, but browsers might think differently
-              ctx.clip();
-            }
+            ctx.clip('evenodd');
           }
         } else {
           ctx.clip();

--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -522,9 +522,9 @@ if (typeof PDFJS === 'undefined') {
 
     if (polyfill) {
       var contextPrototype = window.CanvasRenderingContext2D.prototype;
-      contextPrototype._createImageData = contextPrototype.createImageData;
+      var createImageData = contextPrototype.createImageData;
       contextPrototype.createImageData = function(w, h) {
-        var imageData = this._createImageData(w, h);
+        var imageData = createImageData.call(this, w, h);
         imageData.data.set = function(arr) {
           for (var i = 0, ii = this.length; i < ii; i++) {
             this[i] = arr[i];
@@ -532,6 +532,8 @@ if (typeof PDFJS === 'undefined') {
         };
         return imageData;
       };
+      // this closure will be kept referenced, so clear its vars
+      contextPrototype = null;
     }
   }
 })();


### PR DESCRIPTION
There are browsers which do not support a winding rule param to fill,
clip and isPointInPath. This polyfill tests for it, and replaces the
methods so that they ignore the param in case of exceptions.

This allows not to catch the exception in canvas.js which would prevent
optimization by JS engines.

This fixes #5458
