### PR TITLE
Ability to Highlight Multiple Search Terms #5220

### DIFF
--- a/web/page_view.js
+++ b/web/page_view.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 /* globals RenderingStates, PDFJS, mozL10n, CustomStyle, getOutputScale, Stats,
-           CSS_UNITS, myMatcher */
+           CSS_UNITS, searchMatcher */
 
 'use strict';
 
@@ -525,7 +525,7 @@ var PageView = function pageView(container, id, scale, defaultViewport,
           self.pdfPage.getTextContent().then(
             function textContentResolved(textContent) {
                 textLayer.setTextContent(textContent);
-                myMatcher(self);
+                searchMatcher(self);
             }
           );
         }

--- a/web/page_view.js
+++ b/web/page_view.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 /* globals RenderingStates, PDFJS, mozL10n, CustomStyle, getOutputScale, Stats,
-           CSS_UNITS */
+           CSS_UNITS, myMatcher */
 
 'use strict';
 

--- a/web/page_view.js
+++ b/web/page_view.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 /* globals RenderingStates, PDFJS, mozL10n, CustomStyle, getOutputScale, Stats,
-           CSS_UNITS, searchMatcher */
+           CSS_UNITS, PDFURLFinder */
 
 'use strict';
 
@@ -525,7 +525,7 @@ var PageView = function pageView(container, id, scale, defaultViewport,
           self.pdfPage.getTextContent().then(
             function textContentResolved(textContent) {
                 textLayer.setTextContent(textContent);
-                searchMatcher(self);
+                var match = new PDFURLFinder(self);
             }
           );
         }

--- a/web/page_view.js
+++ b/web/page_view.js
@@ -524,7 +524,8 @@ var PageView = function pageView(container, id, scale, defaultViewport,
         if (textLayer) {
           self.pdfPage.getTextContent().then(
             function textContentResolved(textContent) {
-              textLayer.setTextContent(textContent);
+                textLayer.setTextContent(textContent);
+                myMatcher(self);
             }
           );
         }

--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals FindStates, mozL10n */
+/* globals FindStates, mozL10n, PDFJS */
 
 'use strict';
 

--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -49,7 +49,7 @@ var PDFFindBar = (function PDFFindBarClosure() {
     });
 
     this.findField.addEventListener('input', function() {
-        delete window.multiple;
+        delete PDFJS.multiple;
         var spans = document.body.getElementsByClassName('highlight');
         for (var i = spans.length - 1; i >= 0; i--) {
             spans[i].className = '';

--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -49,7 +49,13 @@ var PDFFindBar = (function PDFFindBarClosure() {
     });
 
     this.findField.addEventListener('input', function() {
-      self.dispatchEvent('');
+        delete window.multiple;
+        var spans = document.body.getElementsByClassName('highlight');
+        for (var i = spans.length - 1; i >= 0; i--) {
+            spans[i].className = '';
+        }
+
+        self.dispatchEvent('');
     });
 
     this.bar.addEventListener('keydown', function(evt) {

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS, FirefoxCom, Promise, scrollIntoView */
+/* globals PDFJS, FirefoxCom, Promise, scrollIntoView, PDFView */
 
 'use strict';
 
@@ -430,7 +430,8 @@ var PDFURLFinder = (function PDFFindBarClosure() {
             }
 
             if (params[paramname] !== undefined) {
-                PDFJS.multiple = params[paramname].replace(/\"/ig, '').split(/\s+/);
+                var parambase = params[paramname].replace(/\"/ig, '');
+                PDFJS.multiple = parambase.split(/\s+/);
             }
 
             //sample highlighted words

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -228,7 +228,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
 
     },
 
-    nextMatch: function PDFFindController_nextMatch() {
+    nextMatch: function PDFFindController_nextMatch(page) {
       var previous = this.state.findPrevious;
       var currentPageIndex = this.pdfViewer.currentPageNumber - 1;
       var numPages = this.pdfViewer.pagesCount;
@@ -260,13 +260,14 @@ var PDFFindController = (function PDFFindControllerClosure() {
               if (PDFJS.multiple === undefined) {
                   self.calcFindMatch(pageIdx);
               } else {
-                  for (var i = 0; i < PDFJS.multiple.length; i++) {
-                      qwy = PDFJS.multiple[i].replace(/\=/ig, ' ');
+                  if(page === pageIdx) {
+                    for (var j = 0; j < PDFJS.multiple.length; j++) {
+                      qwy = PDFJS.multiple[j].replace(/\=/ig, ' ');
                       self.state.query = qwy;
                       self.calcFindMatch(pageIdx);
+                    }
                   }
               }
-
 
             });
           }
@@ -453,7 +454,7 @@ var PDFURLFinder = (function PDFFindBarClosure() {
             window.setTimeout(function () {
                 fc.dirtyMatch = true;
                 fc.extractText();
-                fc.nextMatch();
+                fc.nextMatch(parseInt(page.textLayer.pageIdx));
             }, 250);
 
         } catch (e) {

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS, FirefoxCom, Promise */
+/* globals PDFJS, FirefoxCom, Promise, scrollIntoView */
 
 'use strict';
 
@@ -203,7 +203,9 @@ var PDFFindController = (function PDFFindControllerClosure() {
         // If the page is selected, scroll the page into view, which triggers
         // rendering the page, which adds the textLayer. Once the textLayer is
         // build, it will scroll onto the selected match.
-          if (window.multiple == null) { this.pdfViewer.scrollPageIntoView(index + 1); }
+          if (window.multiple === undefined) {
+              this.pdfViewer.scrollPageIntoView(index + 1);
+          }
       }
 
       if (page.textLayer) {
@@ -211,7 +213,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
       }
 
       //scroll match into view
-      if (window.multiple != null) {
+      if (window.multiple !== undefined) {
           try {
               var d = document.getElementsByClassName('highlight');
               if (d.length > 0) {
@@ -243,6 +245,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
         this.resumePageIdx = null;
         this.pageMatches = [];
         var self = this;
+        var qwy = '';
 
         for (var i = 0; i < numPages; i++) {
           // Wipe out any previous highlighted matches.
@@ -254,11 +257,12 @@ var PDFFindController = (function PDFFindControllerClosure() {
             this.extractTextPromises[i].then(function(pageIdx) {
               delete self.pendingFindMatches[pageIdx];
 
-              if (window.multiple == null) {
+              if (window.multiple === undefined) {
                   self.calcFindMatch(pageIdx);
               } else {
                   for (var i = 0; i < window.multiple.length; i++) {
-                      self.state.query = window.multiple[i].replace(/\=/ig, ' ');
+                      qwy = window.multiple[i].replace(/\=/ig, ' ');
+                      self.state.query = qwy;
                       self.calcFindMatch(pageIdx);
                   }
               }

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -203,12 +203,27 @@ var PDFFindController = (function PDFFindControllerClosure() {
         // If the page is selected, scroll the page into view, which triggers
         // rendering the page, which adds the textLayer. Once the textLayer is
         // build, it will scroll onto the selected match.
-        this.pdfViewer.scrollPageIntoView(index + 1);
+          if (window.multiple == null) { this.pdfViewer.scrollPageIntoView(index + 1); }
       }
 
       if (page.textLayer) {
         page.textLayer.updateMatches();
       }
+
+      //scroll match into view
+      if (window.multiple != null) {
+          try {
+              var d = document.getElementsByClassName('highlight');
+              if (d.length > 0) {
+                  var vc = document.getElementById('viewerContainer');
+                  if (vc.scrollTop < 40) {
+                      scrollIntoView(d[0].parentNode);
+                  }
+              }
+          } catch (e) {
+          }
+      }
+
     },
 
     nextMatch: function PDFFindController_nextMatch() {
@@ -238,7 +253,17 @@ var PDFFindController = (function PDFFindControllerClosure() {
             this.pendingFindMatches[i] = true;
             this.extractTextPromises[i].then(function(pageIdx) {
               delete self.pendingFindMatches[pageIdx];
-              self.calcFindMatch(pageIdx);
+
+              if (window.multiple == null) {
+                  self.calcFindMatch(pageIdx);
+              } else {
+                  for (var i = 0; i < window.multiple.length; i++) {
+                      self.state.query = window.multiple[i].replace(/\=/ig, ' ');
+                      self.calcFindMatch(pageIdx);
+                  }
+              }
+
+
             });
           }
         }

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -313,10 +313,16 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
         var isSelected = (isSelectedPage && i === selectedMatchIdx);
         var highlightSuffix = (isSelected ? ' selected' : '');
 
-        if (isSelected && !this.isViewerInPresentationMode) {
-          scrollIntoView(textDivs[begin.divIdx],
-                         { top: FIND_SCROLL_OFFSET_TOP,
-                           left: FIND_SCROLL_OFFSET_LEFT });
+        if (window.multiple == null) {
+            if (isSelected && !this.isViewerInPresentationMode) {
+                scrollIntoView(textDivs[begin.divIdx],
+                               {
+                                   top: FIND_SCROLL_OFFSET_TOP,
+                                   left: FIND_SCROLL_OFFSET_LEFT
+                               });
+            }
+        } else {
+            highlightSuffix = '';
         }
 
         // Match inside new div.
@@ -363,19 +369,21 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
       var clearedUntilDivIdx = -1;
 
       // Clear all current matches.
-      for (var i = 0, len = matches.length; i < len; i++) {
-        var match = matches[i];
-        var begin = Math.max(clearedUntilDivIdx, match.begin.divIdx);
-        for (var n = begin, end = match.end.divIdx; n <= end; n++) {
-          var div = textDivs[n];
-          div.textContent = bidiTexts[n].str;
-          div.className = '';
-        }
-        clearedUntilDivIdx = match.end.divIdx + 1;
-      }
+      if (window.multiple == null) {
+          for (var i = 0, len = matches.length; i < len; i++) {
+              var match = matches[i];
+              var begin = Math.max(clearedUntilDivIdx, match.begin.divIdx);
+              for (var n = begin, end = match.end.divIdx; n <= end; n++) {
+                  var div = textDivs[n];
+                  div.textContent = bidiTexts[n].str;
+                  div.className = '';
+              }
+              clearedUntilDivIdx = match.end.divIdx + 1;
+          }
 
-      if (this.findController === null || !this.findController.active) {
-        return;
+          if (this.findController === null || !this.findController.active) {
+              return;
+          }
       }
 
       // Convert the matches on the page controller into the match format

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -313,7 +313,7 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
         var isSelected = (isSelectedPage && i === selectedMatchIdx);
         var highlightSuffix = (isSelected ? ' selected' : '');
 
-        if (window.multiple == null) {
+        if (window.multiple === undefined) {
             if (isSelected && !this.isViewerInPresentationMode) {
                 scrollIntoView(textDivs[begin.divIdx],
                                {
@@ -369,7 +369,7 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
       var clearedUntilDivIdx = -1;
 
       // Clear all current matches.
-      if (window.multiple == null) {
+      if (window.multiple === undefined) {
           for (var i = 0, len = matches.length; i < len; i++) {
               var match = matches[i];
               var begin = Math.max(clearedUntilDivIdx, match.begin.divIdx);

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -313,7 +313,7 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
         var isSelected = (isSelectedPage && i === selectedMatchIdx);
         var highlightSuffix = (isSelected ? ' selected' : '');
 
-        if (window.multiple === undefined) {
+        if (PDFJS.multiple === undefined) {
             if (isSelected && !this.isViewerInPresentationMode) {
                 scrollIntoView(textDivs[begin.divIdx],
                                {
@@ -369,7 +369,7 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
       var clearedUntilDivIdx = -1;
 
       // Clear all current matches.
-      if (window.multiple === undefined) {
+      if (PDFJS.multiple === undefined) {
           for (var i = 0, len = matches.length; i < len; i++) {
               var match = matches[i];
               var begin = Math.max(clearedUntilDivIdx, match.begin.divIdx);

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -23,7 +23,7 @@
            OverlayManager, PDFFindController, PDFFindBar, getVisibleElements,
            watchScroll, PDFViewer, PDFRenderingQueue, PresentationModeState,
            RenderingStates, DEFAULT_SCALE, UNKNOWN_SCALE,
-           IGNORE_CURRENT_POSITION_ON_ZOOM: true, PDFView */
+           IGNORE_CURRENT_POSITION_ON_ZOOM: true */
 
 'use strict';
 
@@ -1200,9 +1200,11 @@ var PDFViewerApplication = {
                 zoomArg];
       }
       if (dest) {
-          if (window.multiple !== undefined) {
-              this.pdfViewer.scrollPageIntoView(pageNumber || this.page, dest);
-          }
+        this.pdfViewer.scrollPageIntoView(pageNumber || this.page, dest);
+         if (PDFJS.multiple !== undefined) {
+	   this.pdfViewer.scrollPageIntoView(pageNumber || this.page, dest);
+         }
+        
       } else if (pageNumber) {
         this.page = pageNumber; // simple page
       }
@@ -2294,53 +2296,3 @@ window.addEventListener('afterprint', function afterPrint(evt) {
 //  });
 //});
 //#endif
-
-function searchMatcher(self) {
-    try {
-        //wl parameter contains search terms- 
-        //multiple space (%20) separated words or phrases
-        //search term syntax: a b c single words,
-        //a=b c=d e=f=g phrases
-
-        //check local window for search terms
-        //make sure to check for pound symbol
-        var loc = document.location.href.replace('#', '&');
-        loc = loc.replace(/\+/ig, '%20');
-        var params = PDFView.parseQueryString(loc);
-
-        //also check parent window for any search terms
-        if (params['search'] === undefined) {
-            loc = parent.document.location.href.replace('#', '&');
-            loc = loc.replace(/\+/ig, '%20');
-            params = PDFView.parseQueryString(loc);
-        }
-
-        if (params['search'] !== undefined) {
-            window.multiple = params['search'].split(/\s+/);
-        }
-
-        //sample highlighted words
-        //window.multiple = ['of','the', 'is', 'or', 'and', 'this']
-
-        if (window.multiple === undefined) {
-            return;
-        }
-
-        var fc = self.textLayer.findController;
-        fc.state = {
-            query: '',
-            caseSensitive: false,
-            highlightAll: true,
-            findPrevious: false
-        };
-
-        //small delay to avoid screen jumps
-        window.setTimeout(function () {
-            fc.dirtyMatch = true;
-            fc.extractText();
-            fc.nextMatch();
-        }, 250);
-
-    } catch (e) {
-    }
-}

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2311,7 +2311,7 @@ function myMatcher(self) {
         if (params['wl'] === undefined) {
             loc = parent.document.location.href.replace(/\+/ig, '%20');
             params = PDFView.parseQueryString(loc);
-            if (params['wl'] != null) {
+            if (params['wl'] !== undefined) {
                 window.multiple = params['wl'].split(/\s+/);
             }
         }
@@ -2324,7 +2324,14 @@ function myMatcher(self) {
         }
 
         var fc = self.textLayer.findController;
-        fc.state = { query: '', caseSensitive: false, highlightAll: true, findPrevious: false };
+
+        fc.state = {
+            query: '',
+            caseSensitive: false,
+            highlightAll: true,
+            findPrevious: false
+        };
+
         window.setTimeout(function () {
             fc.dirtyMatch = true;
             fc.extractText();

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1202,7 +1202,7 @@ var PDFViewerApplication = {
       if (dest) {
         this.pdfViewer.scrollPageIntoView(pageNumber || this.page, dest);
          if (PDFJS.multiple !== undefined) {
-	   this.pdfViewer.scrollPageIntoView(pageNumber || this.page, dest);
+           this.pdfViewer.scrollPageIntoView(pageNumber || this.page, dest);
          }
         
       } else if (pageNumber) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2024,9 +2024,9 @@ window.addEventListener('keydown', function keydown(evt) {
   if (cmd === 1 || cmd === 8 || cmd === 5 || cmd === 12) {
     // either CTRL or META key with optional SHIFT.
     var pdfViewer = PDFViewerApplication.pdfViewer;
-    var inPresentationMode =
-      pdfViewer.presentationModeState === PresentationModeState.CHANGING ||
-      pdfViewer.presentationModeState === PresentationModeState.FULLSCREEN;
+    var inPresentationMode = pdfViewer &&
+      (pdfViewer.presentationModeState === PresentationModeState.CHANGING ||
+       pdfViewer.presentationModeState === PresentationModeState.FULLSCREEN);
 
     switch (evt.keyCode) {
       case 70: // f
@@ -2292,3 +2292,33 @@ window.addEventListener('afterprint', function afterPrint(evt) {
 //  });
 //});
 //#endif
+
+function myMatcher(self) {
+    try {
+        //wl parameter contains search terms- multiple space (%20) separated words or phrases
+        //search term syntax: a b c single words, a=b c=d e=f=g phrases
+
+        //check local window for search terms
+        var params = PDFView.parseQueryString(document.location.href.replace(/\+/ig, '%20'));
+        if (params['wl'] != null) { window.multiple = params['wl'].split(/\s+/); }
+
+        //fallback check parent window (iframe implementation)
+        if (params['wl'] == null) {
+            var params = PDFView.parseQueryString(parent.document.location.href.replace(/\+/ig, '%20'));
+            if (params['wl'] != null) { window.multiple = params['wl'].split(/\s+/); }
+        }
+
+        //sample highlighted words
+        //window.multiple = ['of','the', 'is', 'or', 'and', 'this']
+
+        if (window.multiple == null) { return }
+
+        var fc = self.textLayer.findController;
+        fc.state = { query: '', caseSensitive: false, highlightAll: true, findPrevious: false }
+        window.setTimeout(function () { fc.dirtyMatch = true; fc.extractText(); fc.nextMatch(); }, 250);
+
+
+    } catch (e) {
+    }
+}
+

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1200,7 +1200,9 @@ var PDFViewerApplication = {
                 zoomArg];
       }
       if (dest) {
-        this.pdfViewer.scrollPageIntoView(pageNumber || this.page, dest);
+          if (window.multiple !== undefined) {
+              this.pdfViewer.scrollPageIntoView(pageNumber || this.page, dest);
+          }
       } else if (pageNumber) {
         this.page = pageNumber; // simple page
       }

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2295,7 +2295,7 @@ window.addEventListener('afterprint', function afterPrint(evt) {
 //});
 //#endif
 
-function myMatcher(self) {
+function searchMatcher(self) {
     try {
         //wl parameter contains search terms- 
         //multiple space (%20) separated words or phrases

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2303,19 +2303,20 @@ function myMatcher(self) {
         //a=b c=d e=f=g phrases
 
         //check local window for search terms
-        var loc = document.location.href.replace(/\+/ig, '%20');
+        //make sure to check for pound symbol
+        var loc = document.location.href.replace('#', '&');
+        loc = loc.replace(/\+/ig, '%20');
         var params = PDFView.parseQueryString(loc);
-        if (params['wl'] !== undefined) {
-            window.multiple = params['wl'].split(/\s+/);
+
+        //also check parent window for any search terms
+        if (params['search'] === undefined) {
+            loc = parent.document.location.href.replace('#', '&');
+            loc = loc.replace(/\+/ig, '%20');
+            params = PDFView.parseQueryString(loc);
         }
 
-        //fallback check parent window (iframe implementation)
-        if (params['wl'] === undefined) {
-            loc = parent.document.location.href.replace(/\+/ig, '%20');
-            params = PDFView.parseQueryString(loc);
-            if (params['wl'] !== undefined) {
-                window.multiple = params['wl'].split(/\s+/);
-            }
+        if (params['search'] !== undefined) {
+            window.multiple = params['search'].split(/\s+/);
         }
 
         //sample highlighted words
@@ -2326,7 +2327,6 @@ function myMatcher(self) {
         }
 
         var fc = self.textLayer.findController;
-
         fc.state = {
             query: '',
             caseSensitive: false,
@@ -2334,14 +2334,13 @@ function myMatcher(self) {
             findPrevious: false
         };
 
+        //small delay to avoid screen jumps
         window.setTimeout(function () {
             fc.dirtyMatch = true;
             fc.extractText();
             fc.nextMatch();
         }, 250);
 
-
     } catch (e) {
     }
 }
-

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -23,7 +23,7 @@
            OverlayManager, PDFFindController, PDFFindBar, getVisibleElements,
            watchScroll, PDFViewer, PDFRenderingQueue, PresentationModeState,
            RenderingStates, DEFAULT_SCALE, UNKNOWN_SCALE,
-           IGNORE_CURRENT_POSITION_ON_ZOOM: true */
+           IGNORE_CURRENT_POSITION_ON_ZOOM: true, PDFView */
 
 'use strict';
 
@@ -2295,27 +2295,41 @@ window.addEventListener('afterprint', function afterPrint(evt) {
 
 function myMatcher(self) {
     try {
-        //wl parameter contains search terms- multiple space (%20) separated words or phrases
-        //search term syntax: a b c single words, a=b c=d e=f=g phrases
+        //wl parameter contains search terms- 
+        //multiple space (%20) separated words or phrases
+        //search term syntax: a b c single words,
+        //a=b c=d e=f=g phrases
 
         //check local window for search terms
-        var params = PDFView.parseQueryString(document.location.href.replace(/\+/ig, '%20'));
-        if (params['wl'] != null) { window.multiple = params['wl'].split(/\s+/); }
+        var loc = document.location.href.replace(/\+/ig, '%20');
+        var params = PDFView.parseQueryString(loc);
+        if (params['wl'] !== undefined) {
+            window.multiple = params['wl'].split(/\s+/);
+        }
 
         //fallback check parent window (iframe implementation)
-        if (params['wl'] == null) {
-            var params = PDFView.parseQueryString(parent.document.location.href.replace(/\+/ig, '%20'));
-            if (params['wl'] != null) { window.multiple = params['wl'].split(/\s+/); }
+        if (params['wl'] === undefined) {
+            loc = parent.document.location.href.replace(/\+/ig, '%20');
+            params = PDFView.parseQueryString(loc);
+            if (params['wl'] != null) {
+                window.multiple = params['wl'].split(/\s+/);
+            }
         }
 
         //sample highlighted words
         //window.multiple = ['of','the', 'is', 'or', 'and', 'this']
 
-        if (window.multiple == null) { return }
+        if (window.multiple === undefined) {
+            return;
+        }
 
         var fc = self.textLayer.findController;
-        fc.state = { query: '', caseSensitive: false, highlightAll: true, findPrevious: false }
-        window.setTimeout(function () { fc.dirtyMatch = true; fc.extractText(); fc.nextMatch(); }, 250);
+        fc.state = { query: '', caseSensitive: false, highlightAll: true, findPrevious: false };
+        window.setTimeout(function () {
+            fc.dirtyMatch = true;
+            fc.extractText();
+            fc.nextMatch();
+        }, 250);
 
 
     } catch (e) {


### PR DESCRIPTION
If PDF document was part of a document search would like the ability to highlight multiple simultaneous terms and/or phrases that were returned as a search result. Currently there is no way to do this.

Change allows search terms to be passed in via URL parameter (search = terms list). The terms will all be highlighted with the same classes used in the findbar. All instances of all terms will be highlighted. Each term must be separated by a space (%20) and each phrase must be separated with an equals (%3d). The document will scroll to the match nearest to the top of the page after loading. Would like the scroll to be animated, but too much effort without another library or jquery at this time.

Examples:

unix dos windows =>  &search=unix%20dos%20windows
"sales manager" McDonalds => &search=sales%3dmanager%20McDonalds 

Also allows terms to be sent in via parent URL if using iframes and/or multiple pdf viewers on  same search result. This allows the iframes to load different documents without having to append the search terms each time.
