### PR TITLE
Fix passing null as onFullfilled (which is broken in Chrome(-ium) 32)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -253,7 +253,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           var imgData = imageObj.createImageData(/* forceRGBA = */ false);
           self.handler.send('obj', [objId, self.pageIndex, 'Image', imgData],
             [imgData.data.buffer]);
-        }).then(null, function (reason) {
+        }).then(undefined, function (reason) {
           warn('Unable to decode image: ' + reason);
           self.handler.send('obj', [objId, self.pageIndex, 'Image', null]);
         });


### PR DESCRIPTION
Chromium v32 Promises implementation is rather old and supports only functions and `undefined` as `onRejected` and `onFullfilled` callbacks (otherwise it throws TypeError).

Some _local_ browsers are built on the top of Chromium 32 (e.g. http://s1.amigo.mail.ru/) and have not been updated yet. 

[JSFiddle](http://jsfiddle.net/palkan/4hptzyuw/) (Open in Chromium 32 to see a blank page)
