### PR TITLE
Bug 639134 - update check for document colors

### DIFF
--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -375,7 +375,11 @@ ChromeActions.prototype = {
     return (!!prefBrowser && prefGfx);
   },
   supportsDocumentColors: function() {
-    return getBoolPref('browser.display.use_document_colors', true);
+    if (getIntPref('browser.display.document_color_use', 0) == 2 ||
+        !getBoolPref('browser.display.use_document_colors', true)) {
+      return false;
+    }
+    return true;
   },
   reportTelemetry: function (data) {
     var probeInfo = JSON.parse(data);


### PR DESCRIPTION
This checks for both prefs on the understanding that we need to work on older versions of Firefox. If that isn't the case, the first part of the if isn't necessary. This should only land if bug 639134 is resolved - I'd make the patch part of that bug, but AIUI pdfjs's canonical repo is on github, so...
