### PR TITLE
Jump over PLT

### DIFF
--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -357,6 +357,9 @@ var JpxImage = (function JpxImageClosure() {
                 context.currentTile.COC = [];
               }
               break;
+            case 0xFF58: // PLT, jump over it (We jump from box to box)
+              length = readUint16(data, position);
+              break;
             case 0xFF90: // Start of tile-part (SOT)
               length = readUint16(data, position);
               tile = {};


### PR DESCRIPTION
Jump over PLT markers if they are present. PLT markers contain the positions of the starting points of the packet in the codestream.
