### PR TITLE
Add progression order

### DIFF
--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -617,6 +617,44 @@ var JpxImage = (function JpxImageClosure() {
       codeblocks: precinctCodeblocks
     };
   }
+  function ResolutionPositionComponentLayer(context) {
+    var siz = context.SIZ;
+    var tileIndex = context.currentTile.index;
+    var tile = context.tiles[tileIndex];
+    var layersCount = tile.codingStyleDefaultParameters.layersCount;
+    var componentsCount = siz.Csiz;
+    var maxDecompositionLevelsCount = 0;
+    for (var q = 0; q < componentsCount; q++) {
+      maxDecompositionLevelsCount = Math.max(maxDecompositionLevelsCount,
+        tile.components[q].codingStyleParameters.decompositionLevelsCount);
+    }
+    var r = 0, l = 0, i = 0, k = 0;
+    this.nextPacket = function JpxImage_nextPacket() {
+      // Section B.12.1.2 Resolution-layer-component-position
+      for (; r <= maxDecompositionLevelsCount; r++) {
+        var component = tile.components[0];
+        var resolution = component.resolutions[r];
+        var numprecincts = resolution.precinctParameters.numprecincts;
+        for (; k < numprecincts;k++) {
+          for (; i < componentsCount; i++) {
+            var component = tile.components[i];
+            if (r > component.codingStyleParameters.decompositionLevelsCount) {
+              continue;
+            }
+            for (; l < layersCount;) {
+              var packet = createPacket(resolution, k, l);
+              l++;
+              return packet;
+            }
+            l = 0;
+          }
+          i = 0;
+        }
+        k = 0;
+      }
+      throw 'Out of packets';
+    };
+  }
   function LayerResolutionComponentPositionIterator(context) {
     var siz = context.SIZ;
     var tileIndex = context.currentTile.index;
@@ -788,6 +826,20 @@ var JpxImage = (function JpxImageClosure() {
       case 1:
         tile.packetsIterator =
           new ResolutionLayerComponentPositionIterator(context);
+        break;
+      case 2:
+        closestPowerOfTwo = function(inputValue) { 
+            var resultValue = Math.round(Math.pow(2,Math.round(Math.log(inputValue)/ Math.log(2)))); 
+            return resultValue;
+            };
+        if( tile.width == closestPowerOfTwo(tile.width) &&  tile.height == closestPowerOfTwo(tile.height)){
+          tile.packetsIterator =
+            new ResolutionPositionComponentLayer(context);
+        }
+        else {
+            throw new Error('JPX Error: Progression order ' +
+                            progressionOrder + " only supported for powers of two.");
+        }
         break;
       default:
         throw new Error('JPX Error: Unsupported progression order ' +


### PR DESCRIPTION
The progression order ResolutionPositionComponentLayer is added for tiles that have width and height that have a power of 2.
