### PR TITLE
Increases chunk size in SMask composition to 1M pixels

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -661,7 +661,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     }
 
     // processing image in chunks to save memory
-    var PIXELS_TO_PROCESS = 65536;
+    var PIXELS_TO_PROCESS = 1048576;
     var chunkSize = Math.min(height, Math.ceil(PIXELS_TO_PROCESS / width));
     for (var row = 0; row < height; row += chunkSize) {
       var chunkHeight = Math.min(chunkSize, height - row);


### PR DESCRIPTION
This PR increases the chunk size for SMask composition from 64k to 1M pixels to speed up #5515.
Chunking avoids the duplication of _large_ buffers when `ctx.getImageData()` is called in favor for the duplication of many small buffers. But since calling `ctx.[get|put]ImageData()` is soo slow, too small chunks slow down SMask processing significantly.
The 1M chunk size makes decoding #5515 several times faster (unless the zoom level is very small). Issue #2648 renders also noticeably quicker.

I was surprised so see that this PR also reduces peak memory consumption:

| Chunk Size | Peak Mem |
| --- | --- |
| 64k | >2000M |
| 1M | ~820M |
| 8M | ~920M |

(using win7 x64, pdf from issue 5515 at zoom=200, http://www.partnerplast.com/images/seismikk/2844_PPMSG_Seismic_REV_012014_PREVEIW.pdf#zoom=200&page=10)
