### PR TITLE
Adjust the speed of the indeterminate loading bar according to the viewer width (issue 4718)

### DIFF
--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -22,6 +22,11 @@ var UNKNOWN_SCALE = 0;
 var MAX_AUTO_SCALE = 1.25;
 var SCROLLBAR_PADDING = 40;
 var VERTICAL_PADDING = 5;
+var INDETERMINATE_LOADING_BAR = {
+  hiddenPercentage: 50,
+  speed: 500, // pixels / second
+  minimumDuration: 1.5 // seconds
+};
 
 // optimised CSS custom property getter/setter
 var CustomStyle = (function CustomStyleClosure() {
@@ -343,6 +348,22 @@ var ProgressBar = (function ProgressBarClosure() {
       this.visible = true;
       document.body.classList.add('loadingInProgress');
       this.bar.classList.remove('hidden');
+    },
+
+    indeterminateSpeed: function ProgressBar_indeterminateSpeed(container) {
+      if (!this._indeterminate || !this.visible || !container) {
+        return;
+      }
+      var totalWidth = Math.ceil(container.clientWidth *
+        (1 + INDETERMINATE_LOADING_BAR.hiddenPercentage / 100));
+      if (totalWidth === this._previousIndeterminateWidth) {
+        return;
+      }
+      this._previousIndeterminateWidth = totalWidth;
+      var duration = Math.max(INDETERMINATE_LOADING_BAR.minimumDuration,
+        Math.ceil(10 * totalWidth / INDETERMINATE_LOADING_BAR.speed) / 10);
+      var glimmer = this.div.firstElementChild;
+      glimmer.setAttribute('style', 'animation-duration: ' + duration + 's;');
     }
   };
 

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -332,14 +332,12 @@ html[dir='rtl'] #toolbarContainer, .findbar, .secondaryToolbar {
 }
 
 @-webkit-keyframes progressIndeterminate {
-  0% { left: 0%; }
-  50% { left: 100%; }
+  0% { left: -50%; }
   100% { left: 100%; }
 }
 
 @keyframes progressIndeterminate {
-  0% { left: 0%; }
-  50% { left: 100%; }
+  0% { left: -50%; }
   100% { left: 100%; }
 }
 
@@ -360,8 +358,8 @@ html[dir='rtl'] #toolbarContainer, .findbar, .secondaryToolbar {
   background-size: 100% 100%;
   background-repeat: no-repeat;
 
-  -webkit-animation: progressIndeterminate 2s linear infinite;
-  animation: progressIndeterminate 2s linear infinite;
+  -webkit-animation: progressIndeterminate 3s linear infinite;
+  animation: progressIndeterminate 3s linear infinite;
 }
 
 .findbar, .secondaryToolbar {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -877,6 +877,11 @@ var PDFViewerApplication = {
           this.loadingBar.hide();
           this.disableAutoFetchLoadingBarTimeout = null;
         }.bind(this), DISABLE_AUTO_FETCH_LOADING_BAR_TIMEOUT);
+      } else if (!percent) {
+        // The loaded percentage in `undefined`, which is caused by the server
+        // failing to provide the contentLength.
+        this.loadingBar.indeterminateSpeed(
+          document.getElementById('viewerContainer'));
       }
     }
   },
@@ -1841,8 +1846,11 @@ window.addEventListener('resize', function webViewerResize(evt) {
   }
   updateViewarea();
 
+  var viewerContainer = document.getElementById('viewerContainer');
   // Set the 'max-height' CSS property of the secondary toolbar.
-  SecondaryToolbar.setMaxHeight(document.getElementById('viewerContainer'));
+  SecondaryToolbar.setMaxHeight(viewerContainer);
+  // Adjust the speed of the indeterminate loading bar, if necessary.
+  PDFViewerApplication.loadingBar.indeterminateSpeed(viewerContainer);
 });
 
 window.addEventListener('hashchange', function webViewerHashchange(evt) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -853,7 +853,7 @@ var PDFViewerApplication = {
   },
 
   progress: function pdfViewProgress(level) {
-    var percent = Math.round(level * 100);
+    var percent;// = Math.round(level * 100);
     // When we transition from full request to range requests, it's possible
     // that we discard some of the loaded data. This can cause the loading
     // bar to move backwards. So prevent this by only updating the bar if it
@@ -895,7 +895,7 @@ var PDFViewerApplication = {
 
     var downloadedPromise = pdfDocument.getDownloadInfo().then(function() {
       self.downloadComplete = true;
-      self.loadingBar.hide();
+      //self.loadingBar.hide();
     });
 
     var pagesCount = pdfDocument.numPages;


### PR DESCRIPTION
This PR changes the `animation-duration` of the indeterminate loading bar to depend on the viewer width, instead of being constant. 
I settled on 500 pixels / second as a reasonable value for the animation speed, but this can easily be changed.
Compared to a previous attempt to solve this (see PR #4741), this should work for _any_ viewer width without the need for a large number of added CSS rules.

_Note:_ The first commit is only included to simplify testing, and should _not_ be merged.

Fixes #4718.
