### PR TITLE
Add a (linked) test case for bug 1108753 (PR 5276)

### DIFF
--- a/test/pdfs/bug1108753.pdf.link
+++ b/test/pdfs/bug1108753.pdf.link
@@ -1,0 +1,1 @@
+https://bug1108753.bugzilla.mozilla.org/attachment.cgi?id=8533311

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1524,6 +1524,15 @@
       "type": "eq",
       "about": "Type3 font with negative HScale and font size"
     },
+    {  "id": "bug1108753",
+       "file": "pdfs/bug1108753.pdf",
+       "md5": "a7aaf92d55b4602afb0ca3d75198b56b",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 1,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "bug816075",
       "file": "pdfs/bug816075.pdf",
       "md5": "7ec87c115c1f9ec41234cc7002555e82",


### PR DESCRIPTION
When submitting PR #5276 there wasn't a good PDF file to include in the test suite. However, with https://bugzilla.mozilla.org/show_bug.cgi?id=1108753, we now have a better source for a test file, hence this patch.
