### PR TITLE
Add fallback for non-embedded "Century Gothic" CIDFontType2 font (issue 4722 and bug 879561)

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -320,9 +320,12 @@ var stdFontMap = {
   'CourierNewPS-BoldMT': 'Courier-Bold',
   'CourierNewPS-ItalicMT': 'Courier-Oblique',
   'CourierNewPSMT': 'Courier',
+  'Helvetica': 'Helvetica',
   'Helvetica-Bold': 'Helvetica-Bold',
   'Helvetica-BoldItalic': 'Helvetica-BoldOblique',
+  'Helvetica-BoldOblique': 'Helvetica-BoldOblique',
   'Helvetica-Italic': 'Helvetica-Oblique',
+  'Helvetica-Oblique':'Helvetica-Oblique',
   'Symbol-Bold': 'Symbol',
   'Symbol-BoldItalic': 'Symbol',
   'Symbol-Italic': 'Symbol',
@@ -348,6 +351,10 @@ var stdFontMap = {
  * fonts without glyph data.
  */
 var nonStdFontMap = {
+  'CenturyGothic': 'Helvetica',
+  'CenturyGothic-Bold': 'Helvetica-Bold',
+  'CenturyGothic-BoldItalic': 'Helvetica-BoldOblique',
+  'CenturyGothic-Italic': 'Helvetica-Oblique',
   'ComicSansMS': 'Comic Sans MS',
   'ComicSansMS-Bold': 'Comic Sans MS-Bold',
   'ComicSansMS-BoldItalic': 'Comic Sans MS-BoldItalic',
@@ -2455,7 +2462,8 @@ var Font = (function FontClosure() {
       // The file data is not specified. Trying to fix the font name
       // to be used with the canvas.font.
       var fontName = name.replace(/[,_]/g, '-');
-      var isStandardFont = fontName in stdFontMap;
+      var isStandardFont = !!stdFontMap[fontName] ||
+        (nonStdFontMap[fontName] && !!stdFontMap[nonStdFontMap[fontName]]);
       fontName = stdFontMap[fontName] || nonStdFontMap[fontName] || fontName;
 
       this.bold = (fontName.search(/bold/gi) !== -1);

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -101,6 +101,7 @@
 !issue4246.pdf
 !issue4461.pdf
 !issue4573.pdf
+!issue4722.pdf
 !issue4800.pdf
 !issue4801.pdf
 !issue5549.pdf

--- a/test/pdfs/issue4722.pdf
+++ b/test/pdfs/issue4722.pdf
@@ -1,0 +1,110 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/Supplement 0
+/Registry (Adobe)
+/Ordering (Identity)
+>>
+endobj 
+2 0 obj 
+<<
+/FontName /CenturyGothic,Bold
+/StemV 132
+/Ascent 1122
+/Flags 4
+/FontWeight 700
+/XHeight 531
+/FontFamily (Century Gothic)
+/FontStretch /Normal
+/Descent -307
+/ItalicAngle 0
+/FontBBox [-115 -307 1260 1122]
+/Type /FontDescriptor
+/CapHeight 718
+>>
+endobj 
+3 0 obj 
+<<
+/BaseFont /CenturyGothic,Bold
+/Subtype /CIDFontType2
+/DW 1000
+/CIDSystemInfo 1 0 R
+/FontDescriptor 2 0 R
+/W [3 [280] 17 [280] 36 [740 580 780 700 520] 44 [280] 48 [900 740 840 560 840 580 520 420 640] 60 [620]]
+/Type /Font
+>>
+endobj 
+4 0 obj [3 0 R]
+endobj 
+5 0 obj 
+<<
+/Pages 6 0 R
+/Type /Catalog
+>>
+endobj 
+6 0 obj 
+<<
+/MediaBox [0 0 200 50]
+/Kids [7 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+7 0 obj 
+<<
+/Parent 6 0 R
+/MediaBox [0 0 200 50]
+/Resources 
+<<
+/Font 
+<<
+/F1 8 0 R
+>>
+>>
+/Contents 9 0 R
+/Type /Page
+>>
+endobj 
+8 0 obj 
+<<
+/DescendantFonts 4 0 R
+/BaseFont /CenturyGothic,Bold
+/Subtype /Type0
+/Type /Font
+/Encoding /Identity-H
+>>
+endobj 
+9 0 obj 
+<<
+/Length 74
+>>
+stream
+BT
+10 20 TD
+/F1 20 Tf
+<00270028003600260035002C00330037002C00320031>Tj
+ET
+
+endstream 
+endobj xref
+0 10
+0000000000 65535 f 
+0000000015 00000 n 
+0000000091 00000 n 
+0000000354 00000 n 
+0000000600 00000 n 
+0000000624 00000 n 
+0000000675 00000 n 
+0000000757 00000 n 
+0000000886 00000 n 
+0000001012 00000 n 
+trailer
+
+<<
+/Root 5 0 R
+/Size 10
+>>
+startxref
+1138
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -944,6 +944,13 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "issue4722",
+       "file": "pdfs/issue4722.pdf",
+       "md5": "a42ca858af7d179358f92f47e57c0fed",
+       "link": false,
+       "rounds": 1,
+       "type": "eq"
+    },
     {  "id": "issue4875",
        "file": "pdfs/issue4875.pdf",
        "md5": "9a558e18029a42c0ef4e9a8755e24733",


### PR DESCRIPTION
According to practical experiments, falling back to "Helvetica" when we encounter a non-embedded "[Century Gothic](http://en.wikipedia.org/wiki/Century_Gothic)" `CIDFontType2` font seems to work well.
(Also, the section on Wikipedia about "Printer ink usage" _might_ provide some anecdotal evidence that Century Gothic is a fairly standard sans-serif font.)

Obviously this patch doesn't make "Century Gothic" fonts render perfectly, as is often the case with non-embedded fonts, but all the text is now legible in the referenced issues.

Fixes #4722.
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=879561.

**Edit:** Both the issues referenced contains files that were exported from SolidWorks.
