### PR TITLE
Improved Text Selection By Padding Text Elements

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -18,7 +18,8 @@
            isArrayBuffer, isName, isStream, isString, createPromiseCapability,
            Linearization, NullStream, PartialEvaluator, shadow, Stream, Lexer,
            StreamsSequenceStream, stringToPDFString, stringToBytes, Util, XRef,
-           MissingDataException, Promise, Annotation, ObjectLoader, OperatorList
+           MissingDataException, Promise, Annotation, ObjectLoader, 
+           OperatorList, TextLayoutEvaluator
            */
 
 'use strict';
@@ -242,7 +243,15 @@ var Page = (function PageClosure() {
                                                     self.fontCache);
 
         return partialEvaluator.getTextContent(contentStream,
-                                               self.resources);
+                                              self.resources).then(
+            function (data) {
+          var bounds = { y: self.mediaBox[0], x: self.mediaBox[1],
+                        width: self.mediaBox[2], height: self.mediaBox[3] };
+          var layout = new TextLayoutEvaluator();
+          // The following will mutate data.items adding supplemental info.
+          layout.calculateTextFlow(bounds, data.items, data.styles);
+          return data;
+        });
       });
     },
 

--- a/src/core/quadtree.js
+++ b/src/core/quadtree.js
@@ -1,0 +1,469 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/* Copyright 2015 Mozilla Foundation
+ * Copyright 2015 Michael Sander (speedplane)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required bY applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+/****************** QuadTree ****************
+*
+* A QuadTree implementation in JavaScript that stores rectangular regions.
+* @module QuadTree
+**/
+var QuadTree = (function QuadTreeClosure() {
+  /**
+  * QuadTree data structure.
+  * @class QuadTree
+  * @constructor
+  * @param {Object} An object representing the top level QuadTree's bounds. The
+  *                 object should contain: x, y, width, height and id that 
+  *                 uniquely identifies it.
+  * @param {Number} maxDepth Max number of levels that the quadtree will create.
+  * @param {Number} maxChildren Max children in a node before being split.
+  **/
+  function QuadTree(bounds, maxDepth, maxChildren) {
+    this.root = new QNode(bounds, 0, maxDepth, maxChildren);
+    this.length = 0;
+  }
+  
+  // The root node of the QuadTree covers the entire area being segmented.
+  QuadTree.prototype.root = null;
+  QuadTree.prototype.length = 0;
+  
+  /**
+  * Inserts an item into the QuadTree.
+  * Each element must have an id to uniquely identify it. We don't check to 
+  * make ensure that the element has already been added.
+  **/
+  QuadTree.prototype.insert = function QuadTree_insert(item) {
+    if (item instanceof Array) {
+      for (var i = 0, len = item.length; i < len; i++) {
+        this.insert(item[i]);
+      }
+    } else {
+      var b = this.root.bounds;
+      if (item.x >= b.x + b.width || item.x + item.width <= b.x ||
+          item.y >= b.y + b.height || item.y + item.height <= b.y) {
+        // Can extend past the bounds, but must be at least partially in it.
+        return false;
+      }
+      this.root.insert(item);
+      this.length++;
+      return true;
+    }
+  };
+  QuadTree.prototype.print = function QuadTree_print() {
+    var leafs = this.root.print();
+    console.log('QuadTree: ' + this.length + ' objects. ' + leafs + ' leafs.');
+  };
+
+  /**
+  * Retrieve all items in the same node as the specified item. If it overlaps 
+  * multiple nodes, then all children in will be returned.
+  * @method retrieve
+  * @param {Object} item A rect with x, y, width, height properties.
+  **/
+  QuadTree.prototype.retrieve = function QuadTree_retrieve(item) {
+    // Get a copy of the array of items
+    return this.root.retrieve(item, [], { });
+  };
+  
+  /**
+   * Iterate through the items from the left to the right as specified bY the 
+   * bounding box given bY item: x, y, and height.
+   */
+  QuadTree.prototype.retrieveXInc =
+      function QuadTree_retrieveXInc(x, y, height) {
+    var it = { x: x, y: y,
+            height: height, width: this.root.bounds.width - x };
+    var sorter = function (a, b) {
+      return a.x < b.x ? -1 : (a.x > b.x ? 1 : 0);
+    };
+    var side1 = [QNode.TOP_LEFT, QNode.BOTTOM_LEFT];
+    var side2 = [QNode.TOP_RIGHT, QNode.BOTTOM_RIGHT];
+    return this.root.retrieveIterate(it, sorter, side1, side2, { });
+  };
+  QuadTree.prototype.retrieveXDec =
+      function QuadTree_retrieveXDec(x, y, height) {
+    var x0 = this.root.bounds.x;
+    var it = { x: x0, y: y, height: height, width: x - x0 };
+    var sorter = function (a, b) {
+      var aX = a.x + a.width, bX = b.x + b.width;
+      return aX < bX ? 1 : (aX > bX ? -1 : 0);
+    };
+    var side1 = [QNode.TOP_RIGHT, QNode.BOTTOM_RIGHT];
+    var side2 = [QNode.TOP_LEFT, QNode.BOTTOM_LEFT];
+    return this.root.retrieveIterate(it, sorter, side1, side2, { });
+  };
+  
+  /**
+   * Iterate through the items with increasing y that intersect the box bY: x, 
+   * y, and width.
+   */
+  QuadTree.prototype.retrieveYInc =
+      function QuadTree_retrieveYInc(x, y, width) {
+    var it = { x: x, y: y,
+            width: width, height: this.root.bounds.height - y };
+    var sorter = function (a, b) {
+      return a.y < b.y ? -1 : (a.y > b.y ? 1 : 0);
+    };
+    var side1 = [QNode.TOP_LEFT, QNode.TOP_RIGHT];
+    var side2 = [QNode.BOTTOM_LEFT, QNode.BOTTOM_RIGHT];
+    return this.root.retrieveIterate(it, sorter, side1, side2, { });
+  };
+  /**
+   * Iterate through the items from the down to up as specified bY the 
+   * lower left corner of the bounding box given bY item: x, y, and width.
+   */
+  QuadTree.prototype.retrieveYDec =
+      function QuadTree_retrieveYDec(x, y, width) {
+    // When decreasing, we're given bottom left corner, convert to top right.
+    var y0 = this.root.bounds.y;  // Calculate the top-left corner
+    var it = { x: x, y: y0, width: width, height: y - y0 };
+    var sorter = function (a, b) {
+      var aY = a.y + a.height, bY = b.y + b.height;
+      return aY < bY ? 1 : (aY > bY ? -1 : 0);
+    };
+    var side1 = [QNode.BOTTOM_LEFT, QNode.BOTTOM_RIGHT];
+    var side2 = [QNode.TOP_LEFT, QNode.TOP_RIGHT];
+    return this.root.retrieveIterate(it, sorter, side1, side2, { });
+  };
+  
+  function QNode(bounds, depth, maxDepth, maxChildren) {
+    this.bounds = bounds; //  bounds
+    this.children = []; // children contained directly in the node
+    this.nodes = null; // subnodes
+    this.maxChildren = maxChildren || 4;
+    this.maxDepth = maxDepth || 4;
+    this.depth = depth || 0;
+  }
+  
+  // We consider "top" to be lower y values (screen coords), but if you're 
+  // using a different coord system, everything works. If these constants 
+  // change, the array in subdivide must too.
+  QNode.TOP_LEFT = 0;
+  QNode.TOP_RIGHT = 1;
+  QNode.BOTTOM_LEFT = 2;
+  QNode.BOTTOM_RIGHT = 3;
+  
+  ///////////
+  // Debugging
+  QNode.prototype.print = function QNode_print() {
+    var tabs = '';
+    for (var d = 0; d < this.depth; d++) {
+      tabs += ' ';
+    }
+    if (this.nodes !== null) {
+      var txt = { };
+      var totalElements = 0;
+      txt[QNode.TOP_LEFT] = 'TOP_LEFT';
+      txt[QNode.TOP_RIGHT] = 'TOP_RIGHT';
+      txt[QNode.BOTTOM_LEFT] = 'BOTTOM_LEFT';
+      txt[QNode.BOTTOM_RIGHT] = 'BOTTOM_RIGHT';
+      
+      for (var i = 0; i < this.nodes.length; i++) {
+          console.log(tabs + 'Depth ' + this.depth + ' ' + txt[i]);
+          totalElements += this.nodes[i].print();
+      }
+      return totalElements;
+    }
+    console.log(tabs + 'Leaf with ' + this.children.length + ' elements.');
+    return this.children.length;
+  };
+  
+  ///////////
+  // Insertion
+  QNode.prototype.insert = function QNode_insert(item) {
+    if (this.nodes !== null) {
+      // This is a node, insert into subnodes
+      // We may need to insert into more than one if it straddles borders.
+      for (var i in this.findIndices(item)) {
+        this.nodes[i].insert(item);
+      }
+      return;
+    }
+    
+    // We're a leaf node
+    this.children.push(item);
+    if (this.children.length >= this.maxChildren &&
+                                this.depth < this.maxDepth) {
+      // This will turn this from a leaf node into a node.
+      this.subdivide();
+      // Do inserts now that this is a subdivided node.
+      var childrenLen = this.children.length;
+      for (var j = 0; j < childrenLen; j++) {
+          this.insert(this.children[j]);
+      }
+      this.children = null; // Don't need it anymore.
+    }
+  };
+
+  QNode.prototype.findIndices = function QNode_findIndices(item) {
+    // Given the item, return which of the four quadrents the item intersects.
+    // Can intersect up to four quadrants. Returns an assoc set.
+    var b = this.bounds;
+    var bX = b.x + ((b.width / 2) | 0);
+    var bY = b.y + ((b.height / 2) | 0);
+    
+    var out = { };
+    var below = false;
+    if (item.y < bY) {
+      var right;
+      if (item.x < bX) {
+        out[QNode.TOP_LEFT] = true;
+        if (item.x + item.width >= bX) {
+          out[QNode.TOP_RIGHT] = true;
+        }
+      } else {
+        out[QNode.TOP_RIGHT] = true;
+      }
+    } else {
+      below = true;
+    }
+    
+    if (below || item.y + item.height >= bY) {
+      if (item.x < bX) {
+        out[QNode.BOTTOM_LEFT] = true;
+        if (item.x + item.width >= bX) {
+          out[QNode.BOTTOM_RIGHT] = true;
+        }
+      } else {
+        out[QNode.BOTTOM_RIGHT] = true;
+      }
+    }
+    return out;
+  };
+  
+  QNode.prototype.subdivide = function Qnode_subdivide() {
+    // Subdivides this node into four others.
+    // Does not redistribute the children.
+    var depth = this.depth + 1;
+
+    var bX = this.bounds.x;
+    var bY = this.bounds.y;
+
+    // Floor the values
+    var bHalfWidth = (this.bounds.width / 2) | 0;
+    var bHalfHeight = (this.bounds.height / 2) | 0;
+    var bXMid = bX + bHalfWidth;
+    var bYMid = bY + bHalfHeight;
+    
+    this.nodes = [
+      // TOP_LEFT
+      new QNode({
+        x: bX,
+        y: bY,
+        width: bHalfWidth, height: bHalfHeight
+      }, depth, this.maxDepth, this.maxChildren),
+      // TOP_RIGHT
+      new QNode({
+        x: bXMid,
+        y: bY,
+        width: bHalfWidth, height: bHalfHeight
+      }, depth, this.maxDepth, this.maxChildren),
+      // BOTTOM_LEFT
+      new QNode({
+        x: bX,
+        y: bYMid,
+        width: bHalfWidth, height: bHalfHeight
+      }, depth, this.maxDepth, this.maxChildren),
+      // BOTTOM_RIGHT
+      new QNode({
+        x: bXMid,
+        y: bYMid,
+        width: bHalfWidth, height: bHalfHeight
+      }, depth, this.maxDepth, this.maxChildren)
+    ];
+  };
+  
+  ///////////////////////////////
+  // Retrieval
+  /**
+   * Internal retrieval function. Retrieves all elements that intersect item.
+   * ar       where we store the output.
+   * deduper  a dictionary so we can keep track of duplicates.
+   */
+  QNode.prototype.retrieve = function QNode_retrieve(item, ar, deduper) {
+    if (this.nodes) {
+      // Everything should be deduped, that takes place in the leaf node.
+      for (var i in this.findIndices(item)) {
+        this.nodes[i].retrieve(item, ar, deduper);
+      }
+      return ar;
+    }
+    
+    // Go through children.
+    var childrenLen = this.children.length;
+    var itX2 = item.x + item.width;
+    var itY2 = item.y + item.height;
+    for (var ci = 0; ci < childrenLen; ci++) {
+      var c = this.children[ci];
+      if (item.x < c.x + c.width &&
+          item.y < c.y + c.height &&
+          itX2 > c.x && itY2 > c.y &&
+          !(c.id in deduper)) {
+        deduper[c.id] = true;
+        ar.push(c);
+      }
+    }
+    return ar;
+  };
+  /**
+   * A function that iterates through the items in any direction with 
+   * complexity O(logN) for each iteration. Should not be called directly, 
+   * instead use the QuadTree iteration function.
+   */
+  QNode.prototype.retrieveIterate =
+      function QNode_retrieveIterate(item, sorter, side1, side2, deduper) {
+    if (this.nodes) {
+      return new NodeIterator(this, item, sorter, side1, side2, deduper);
+    }
+    
+    this.children.sort(sorter);
+    // Iterate through children.
+    return new LeafIterator(item, this.children, deduper);
+  };
+  
+  ///////////////////////////////
+  // Iteration
+  // No matter which way you iterate, for a given node, you know that two of
+  // the quadrants will be iterated before the other two.
+  function NodeIterator(quad, item, sorter, side1, side2, deduper) {
+    this.indices = quad.findIndices(item);
+    this.quad = quad;
+    
+    // If only one iterator type is being used at once, these can be shared.
+    this.side1 = side1;
+    this.side2 = side2;
+    this.item = item;
+    this.sorter = sorter;
+    this.deduper = deduper;
+    
+    // Start with the first side, then move to the second
+    this.didSide2 = false;
+    // Build sub-iterators for the first side's two quandrants.
+    this.buildIterators(this.side1);
+    // Initialize the iterators to null
+    this.lastIt0 = null;
+    this.lastIt1 = null;
+  }
+  NodeIterator.prototype.buildIterators =
+      function NodeIterator_buildIterators(side) {
+    // Build sub-iterators for two of the four quandrants. s indicates which 2.
+    this.it0 = this.indices[side[0]] ?
+      this.quad.nodes[side[0]].retrieveIterate(this.item, this.sorter,
+        this.side1, this.side2, this.deduper) : null;
+    this.it1 = this.indices[side[1]] ?
+      this.quad.nodes[side[1]].retrieveIterate(this.item, this.sorter,
+        this.side1, this.side2, this.deduper) : null;
+  };
+  NodeIterator.prototype.next = function NodeIterator_next() {
+    // Get the first item of the two iterators.
+    if (this.it0 && !this.lastIt0) {
+      this.lastIt0 = this.it0.next();
+    }
+    if (this.it1 && !this.lastIt1) {
+      this.lastIt1 = this.it1.next();
+    }
+    
+    var out;
+    if (this.lastIt0 && this.lastIt1) {
+      // There are elements in both iterators, return the first.
+      if (this.sorter(this.lastIt0, this.lastIt1) <= 0) {
+        out = this.lastIt0;
+        this.lastIt0 = null;
+      } else {
+        out = this.lastIt1;
+        this.lastIt1 = null;
+      }
+      return out;
+    } else if (this.lastIt0) {
+      out = this.lastIt0;
+      this.lastIt0 = null;
+      return out;
+    } else if (this.lastIt1) {
+      out = this.lastIt1;
+      this.lastIt1 = null;
+      return out;
+    }
+    // There are no more items left for the two iterators.
+    // Get the iterator for the other side if we have another side.
+    if (!this.didSide2) {
+      // Build sub-iterators for the second side's two quandrants.
+      this.buildIterators(this.side2);
+      this.didSide2 = true;
+      return this.next();
+    }
+    
+    // Nothing else to iterate.
+    return null;
+  };
+  NodeIterator.prototype.debugPrint =
+      function NodeIterator_debugPrint(depth) {
+    if (depth === undefined) {
+      depth = 0;
+    }
+    var spaces = new Array(depth + 2).join(' ');
+    console.log(spaces + 'Node Iterator depth ' + depth + ': ' +
+                (this.it0 ? 'with it0 ' : '') +
+                (this.it1 ? 'with it1 ' : ''));
+    console.log(spaces + '-> ' + this.side1 + ' | ' + this.side2);
+    if (this.it0) {
+      this.it0.debugPrint(depth + 1);
+    }
+    if (this.it1) {
+      this.it1.debugPrint(depth + 1);
+    }
+  };
+  function LeafIterator(item, children, deduper) {
+    this.children = children;
+    this.childrenLen = children.length;
+    this.itX1 = item.x;
+    this.itY1 = item.y;
+    this.itX2 = item.x + item.width;
+    this.itY2 = item.y + item.height;
+    this.ci = 0;
+    this.deduper = deduper;
+    return this;
+  }
+  LeafIterator.prototype.next = function LeafIterator_next() {
+    // Return the iterator that goes through all children.
+    while (this.ci < this.childrenLen) {
+      var c = this.children[this.ci];
+      this.ci++;
+      if (this.itX1 < c.x + c.width &&
+          this.itY1 < c.y + c.height &&
+          this.itX2 > c.x && this.itY2 > c.y &&
+          !(c.id in this.deduper)) {
+        this.deduper[c.id] = true;
+        return c;
+      }
+    }
+    return null;
+  };
+  
+  LeafIterator.prototype.debugPrint =
+      function LeafIterator_debugPrint(depth) {
+    if (depth === undefined) {
+      depth = 0;
+    }
+    var spaces = new Array(depth).join(' ');
+    console.log(spaces + 'LeafIterator depth ' + depth + ': ' +
+                this.children.length + ' items');
+  };
+  
+  return QuadTree;
+})();

--- a/src/core/text_layout_evaluator.js
+++ b/src/core/text_layout_evaluator.js
@@ -1,0 +1,196 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/* Copyright 2015 Mozilla Foundation
+ * Copyright 2015 Michael Sander (speedplane)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* globals QuadTree */
+ 
+'use strict';
+ 
+var TextLayoutEvaluator = (function TextLayoutEvaluatorClosure() {
+  function TextLayoutEvaluator() {
+  }
+ 
+  TextLayoutEvaluator.prototype = {
+    addToQuadTree:
+        function TextLayoutEvaluator_addToQuadTree(quadtree, obj, id, styles) {
+      var style = styles[obj.fontName];
+      var tx = obj.transform;
+      
+      var angle = Math.atan2(tx[1], tx[0]);
+      if (style.vertical) {
+        angle += Math.PI / 2;
+      }
+      var fontHeight = Math.sqrt((tx[2] * tx[2]) + (tx[3] * tx[3]));
+      var fontAscent = fontHeight;
+      if (style.ascent) {
+        fontAscent = style.ascent * fontAscent;
+      } else if (style.descent) {
+        fontAscent = (1 + style.descent) * fontAscent;
+      }
+      
+      function getCoords(x, y) {
+        var x0 = tx[4], y0 = tx[5];
+        return {
+          x: x0 + (x - x0) * Math.cos(angle) + (y - y0) * Math.sin(angle),
+          y: y0 - (x - x0) * Math.sin(angle) + (y - y0) * Math.cos(angle)
+        };
+      }
+
+      // Set y,x to the bottom.
+      obj.x = tx[4];
+      obj.y = tx[5];
+      var EPSILON = 1e-5;
+      if (Math.abs(angle) < EPSILON) {
+        obj.x1 = obj.x;
+        obj.x2 = obj.x + obj.width;
+        obj.y1 = obj.y;
+        obj.y2 = obj.y + obj.height;
+      } else {
+        // Need to calculate how the three points will be transformed.      
+        var topRight = getCoords(obj.x + obj.width, obj.y + obj.height);
+        var botRight = getCoords(obj.x + obj.width, obj.y);
+        var topLeft = getCoords(obj.x, obj.y + obj.height);
+          
+        obj.x1 = Math.min(obj.x, topRight.x, botRight.x, topLeft.x);
+        obj.x2 = Math.max(obj.x, topRight.x, botRight.x, topLeft.x);
+        obj.y1 = Math.min(obj.y, topRight.y, botRight.y, topLeft.y);
+        obj.y2 = Math.max(obj.y, topRight.y, botRight.y, topLeft.y);
+      }
+      
+      obj.vertical = style.vertical;
+      
+      obj.id = id;         // Used to uniquely identify object.
+      obj.right = null;   // The nearest object to the right.
+      obj.bottom = null;  // The nearest object to the bottom.
+      obj.left = null;
+      obj.top = null;
+
+      // This insert may will fail if inserting an item outside of bounds. 
+      // That's okay, because it will not be displayed.
+      quadtree.insert({
+        x: obj.x1,
+        y: obj.y1,
+        width: obj.x2 - obj.x1,
+        height: obj.y2 - obj.y1,
+        id: id,
+      });
+    },
+    
+    calculateTextFlow:
+        function TextLayoutEvaluator_calculateTextFlow(bounds, objs, styles) {
+      var it; // Use iterators to move over the quadtree
+      var obj; // Current item
+      var objN; // Temp storage for the "next" object.
+      
+      // Use a quadtree to quickly lookup neighbors.
+      var quadtree_vert = new QuadTree(bounds, 4, 16);
+      // Populate the first
+      for (var i = 0, len = objs.length; i < len; i++) {
+        this.addToQuadTree(quadtree_vert, objs[i], i, styles);
+      }
+      
+      for (i = 0; i < len; i++) {
+        obj = objs[i];
+        var top = obj.y2;
+        
+        // Bottom
+        it = quadtree_vert.retrieveYDec(obj.x1, top, obj.x2 - obj.x1);
+        while (objN = it.next()) {
+          if (objN.id !== obj.id && objN.y < obj.y1) {
+            obj.bottom = objN.id;
+            break;
+          }
+        }
+        // Top
+        // We're looking for items above this item, so start from the bottom.
+        it = quadtree_vert.retrieveYInc(obj.x1, obj.y1, obj.x2 - obj.x1);
+        while (objN = it.next()) {
+          if (objN.id !== obj.id && objN.y + objN.width > top) {
+            obj.top = objN.id;
+            break;
+          }
+        }
+      }
+      quadtree_vert = undefined; // Done with this structure, help the GC.
+      
+      // Build a second quadtree taking into account the fact that we will
+      // extend the objects height to reach the nearest neighbors.
+      var quadtree_horiz = new QuadTree(bounds, 4, 16);
+      // Populate the first
+      for (i = 0; i < len; i++) {
+        obj = objs[i];
+        
+        obj.fullHeight = obj.y2 - obj.y1;
+        if (obj.bottom === null) {
+          // There is nothing underneath, it starts on the bottom
+          obj.fullY1 = bounds.y;
+          obj.fullHeight += obj.y1 - bounds.y;
+        } else if(objs[obj.bottom].y2 <= obj.y1) {
+          // There is an item underneath, extend our bottom to its top.
+          obj.fullY1 = objs[obj.bottom].y2;
+          obj.fullHeight += obj.y1 - obj.fullY1;
+        } else {
+          // This item overlaps another beneath it. We won't pad it.
+          obj.fullY1 = obj.y1;
+          obj.fullHeight = obj.y2 - obj.y1;
+        }
+        
+        // Objects do not get extended upwards unless there is nothing above.
+        if (obj.top === undefined) {
+          // Extend to the top
+          obj.fullHeight = bounds.height - obj.fullY1;
+        }
+        
+        quadtree_horiz.insert({
+          x: obj.x1,
+          y: obj.fullY1,
+          width: obj.x2 - obj.x1,
+          height: obj.fullHeight,
+          id: obj.id
+        });
+      }
+      
+      // Iterate over the items in the second quadtree to find right/left objs.
+      for (i = 0; i < len; i++) {
+        obj = objs[i];
+        var right = obj.x2;
+        
+        // Find the first object to the right. Start looking from the left 
+        // edge so we catch any overlapping items.
+        it = quadtree_horiz.retrieveXInc(obj.x , obj.fullY1, obj.fullHeight);
+        while (objN = it.next()) {
+          if (objN.id !== obj.id && objN.x + objN.width > right) {
+            obj.right = objN.id;
+            break;
+          }
+        }
+        // Find the left item. Start from the right edge to find overlaps.
+        it = quadtree_horiz.retrieveXDec(right, obj.fullY1, obj.fullHeight);
+        while (objN = it.next()) {
+          if (objN.id !== obj.id && objN.x < obj.x) {
+            obj.left = objN.id;
+            break;
+          }
+        }
+        
+        // Remove these variables that are no longer needed.
+        obj.fullY1 = undefined;
+        obj.fullHeight = undefined;
+      }
+    }
+  };
+  return TextLayoutEvaluator;
+})();

--- a/src/worker_loader.js
+++ b/src/worker_loader.js
@@ -36,6 +36,8 @@ var otherFiles = [
   'core/colorspace.js',
   'core/crypto.js',
   'core/pattern.js',
+  'core/quadtree.js',
+  'core/text_layout_evaluator.js',
   'core/evaluator.js',
   'core/cmap.js',
   'core/fonts.js',

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -228,6 +228,10 @@ describe('api', function() {
         expect(!!data.items).toEqual(true);
         expect(data.items.length).toEqual(7);
         expect(!!data.styles).toEqual(true);
+        
+        // Make sure the text is ordered properly.
+        expect(data.items[1].str).toEqual('Table Of Content');
+        expect(data.items[6].str.replace(/^\s+/,'')).toEqual('page 1 / 3');
       });
     });
     it('gets operator list', function() {

--- a/test/unit/quadtree_spec.js
+++ b/test/unit/quadtree_spec.js
@@ -1,0 +1,410 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/* Copyright 2015 Mozilla Foundation
+ * Copyright 2015 Michael Sander (speedplane)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required bY applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* globals expect, it, describe, QuadTree */
+
+'use strict';
+
+describe('quadtree', function() {
+  var bounds = { x: 0, y: 0, width: 100, height: 100 };
+  describe('Quadtree Basics', function() {
+    it('empty quadtree', function() {
+      var quad = new QuadTree(bounds);
+      expect(quad.length).toEqual(0);
+      expect(quad.retrieve({ x: 5, y: 5, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 55, y: 5, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 5, y: 55, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 55, y: 55, width: 1, height: 1 }))
+        .toEqual([]);
+    });
+    it('quadtree len of one', function() {
+      var quad = new QuadTree(bounds);
+      var items = [{ x: 2, y: 2, width: 96, height: 96, id: 0 }];
+      quad.insert(items[0]);
+      expect(quad.length).toEqual(1);
+      
+      // Check all quadrants that it's there
+      expect(quad.retrieve({ x: 5, y: 5, width: 1, height: 1 }))
+        .toEqual(items);
+      expect(quad.retrieve({ x: 55, y: 5, width: 1, height: 1 }))
+        .toEqual(items);
+      expect(quad.retrieve({ x: 5, y: 55, width: 1, height: 1 }))
+        .toEqual(items);
+      expect(quad.retrieve({ x: 55, y: 55, width: 1, height: 1 }))
+        .toEqual(items);
+      
+      // Check all quadrants that it's not
+      expect(quad.retrieve({ x: 1, y: 1, width: 0.5, height: 0.5 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 1, y: 99, width: 0.5, height: 0.5 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 99, y: 1, width: 0.5, height: 0.5 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 99, y: 99, width: 0.5, height: 0.5 }))
+        .toEqual([]);
+      // Check on the sides
+      expect(quad.retrieve({ x: 50, y: 1, width: 0.5, height: 0.5 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 50, y: 99, width: 0.5, height: 0.5 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 1, y: 50, width: 0.5, height: 0.5 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 99, y: 50, width: 0.5, height: 0.5 }))
+        .toEqual([]);
+      
+      // Check the boundaries - Just in boundaries
+      expect(quad.retrieve({ x: 2, y: 2, width: 5, height: 5 }))
+        .toEqual(items);
+      expect(quad.retrieve({ x: 2, y: 94, width: 5, height: 5 }))
+        .toEqual(items);
+      expect(quad.retrieve({ x: 94, y: 2, width: 5, height: 5 }))
+        .toEqual(items);
+      expect(quad.retrieve({ x: 94, y: 94, width: 5, height: 5 }))
+        .toEqual(items);
+      // Check the boundaries - Just outside corners
+      expect(quad.retrieve({ x: 98, y: 1, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 1, y: 98, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 98, y: 50, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 98, y: 98, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 50, y: 98, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 1, y: 1, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 1, y: 50, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 50, y: 1, width: 1, height: 1 }))
+        .toEqual([]);
+      // Check the boundaries - sides
+      expect(quad.retrieve({ x: 50, y: 98, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 98, y: 50, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 98, y: 98, width: 1, height: 1 }))
+        .toEqual([]);
+      
+      // Just over the boundaries
+      expect(quad.retrieve({ x: 1.01, y: 1.01, width: 1, height: 1 }))
+        .toEqual(items);
+    });
+    
+    it('repeated elements in quadtree', function() {
+      var quad = new QuadTree(bounds);
+      var items = [
+        { x: 2, y: 2, width: 96, height: 96, id: 0 },
+        { x: 2, y: 2, width: 96, height: 96, id: 1 },
+        { x: 2, y: 2, width: 96, height: 96, id: 2 },
+        { x: 2, y: 2, width: 96, height: 96, id: 3 },
+        { x: 2, y: 2, width: 96, height: 96, id: 4 },
+        { x: 2, y: 2, width: 96, height: 96, id: 5 },
+        { x: 2, y: 2, width: 96, height: 96, id: 6 },
+        { x: 2, y: 2, width: 96, height: 96, id: 7 },
+        { x: 2, y: 2, width: 96, height: 96, id: 8 }
+      ];
+      quad.insert(items);
+      expect(quad.length).toEqual(items.length);
+      // Check all quadrants that it's there
+      expect(quad.retrieve({ x: 5, y: 5, width: 1, height: 1 }))
+        .toEqual(items);
+      expect(quad.retrieve({ x: 55, y: 5, width: 1, height: 1 }))
+        .toEqual(items);
+      expect(quad.retrieve({ x: 5, y: 55, width: 1, height: 1 }))
+        .toEqual(items);
+      expect(quad.retrieve({ x: 55, y: 55, width: 1, height: 1 }))
+        .toEqual(items);
+      
+      // Check all quadrants that it's not
+      expect(quad.retrieve({ x: 1, y: 1, width: 0.5, height: 0.5 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 1, y: 99, width: 0.5, height: 0.5 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 99, y: 1, width: 0.5, height: 0.5 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 99, y: 99, width: 0.5, height: 0.5 }))
+        .toEqual([]);
+      // Check on the sides
+      expect(quad.retrieve({ x: 50, y: 1, width: 0.5, height: 0.5 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 50, y: 99, width: 0.5, height: 0.5 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 1, y: 50, width: 0.5, height: 0.5 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 99, y: 50, width: 0.5, height: 0.5 }))
+        .toEqual([]);
+      
+      // Check the boundaries - Just in boundaries
+      expect(quad.retrieve({ x: 2, y: 2, width: 5, height: 5 }))
+        .toEqual(items);
+      expect(quad.retrieve({ x: 2, y: 94, width: 5, height: 5 }))
+        .toEqual(items);
+      expect(quad.retrieve({ x: 94, y: 2, width: 5, height: 5 }))
+        .toEqual(items);
+      expect(quad.retrieve({ x: 94, y: 94, width: 5, height: 5 }))
+        .toEqual(items);
+      // Check the boundaries - Just outside corners
+      expect(quad.retrieve({ x: 98, y: 1, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 1, y: 98, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 98, y: 50, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 98, y: 98, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 50, y: 98, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 1, y: 1, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 1, y: 50, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 50, y: 1, width: 1, height: 1 }))
+        .toEqual([]);
+      // Check the boundaries - sides
+      expect(quad.retrieve({ x: 50, y: 98, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 98, y: 50, width: 1, height: 1 }))
+        .toEqual([]);
+      expect(quad.retrieve({ x: 98, y: 98, width: 1, height: 1 }))
+        .toEqual([]);
+      
+      // Just over the boundaries
+      expect(quad.retrieve({ x: 1.01, y: 1.01, width: 1, height: 1 }))
+        .toEqual(items);
+    });
+  });
+  
+  function itToAr(iterator) {
+    // Convert an iterator to an array
+    var out = [];
+    while (true) {
+      var item = iterator.next();
+      if (item === null) {
+        return out;
+      }
+      out.push(item);
+    }
+    return out;
+  }
+  
+  describe('Quadtree X Iteration', function() {
+    var quad = new QuadTree(bounds);
+    var items = [
+      { x: 2, y: 49, width: 2, height: 2, id: 0 },
+      { x: 4, y: 49, width: 2, height: 2, id: 1 },
+      { x: 6, y: 49, width: 2, height: 2, id: 2 },
+      { x: 8, y: 49, width: 2, height: 2, id: 3 },
+      { x: 10, y: 49, width: 2, height: 2, id: 4 },
+      { x: 12, y: 49, width: 2, height: 2, id: 5 },
+    ];
+    quad.insert(items);
+    
+    function testIterateXTests() {
+      // Runs tests on a quad in the x direction. 
+      var out = [];
+      out = itToAr(quad.retrieveXInc(0, 49, 1));
+      expect(out).toEqual(items);
+      
+      out = itToAr(quad.retrieveXInc(0, 49, 5));
+      expect(out).toEqual(items);
+      
+      // Skip the first
+      out = itToAr(quad.retrieveXInc(4, 49, 1));
+      expect(out).toEqual(items.slice(1));
+      // Skip all
+      out = itToAr(quad.retrieveXInc(14, 49, 1));
+      expect(out).toEqual([]);
+      // Get the edges
+      out = itToAr(quad.retrieveXInc(0, 48, 1));
+      expect(out).toEqual([]);
+      out = itToAr(quad.retrieveXInc(0, 51, 1));
+      expect(out).toEqual([]);
+      
+      // Now test the same in reverse
+      items.reverse();
+      
+      out = itToAr(quad.retrieveXDec(50, 49, 1));
+      expect(out).toEqual(items);
+      out = itToAr(quad.retrieveXDec(13, 49, 1));
+      expect(out).toEqual(items);
+      // Skip the first
+      out = itToAr(quad.retrieveXDec(12, 49, 1));
+      expect(out).toEqual(items.slice(1));
+      out = itToAr(quad.retrieveXDec(9, 49, 1));
+      expect(out).toEqual(items.slice(2));
+      // Get the edges
+      out = itToAr(quad.retrieveXDec(8, 49, 1));
+      expect(out).toEqual(items.slice(3));
+      out = itToAr(quad.retrieveXDec(6, 49, 1));
+      expect(out).toEqual(items.slice(4));
+      out = itToAr(quad.retrieveXDec(4, 49, 1));
+      expect(out).toEqual(items.slice(5));
+      out = itToAr(quad.retrieveXDec(2, 49, 1));
+      expect(out).toEqual([]);
+      
+      // Put items back into forward order
+      items.reverse();
+    }
+    
+    
+    it('iterate x alone', testIterateXTests);
+    // Add a number of objects
+    for (var i=0; i<100; i += 5) {
+      quad.insert({ x: i, y: i/20, width: 1, height: 1 });
+    }
+    // Adding the objects above should not have changed the test
+    it('iterate x with objs', testIterateXTests);
+    for (i=0; i<100; i += 5) {
+      quad.insert({ x: 99-i, y: 98-i/20, width: 1, height: 1 });
+    }
+    it('iterate x with more objs', testIterateXTests);
+  });
+  
+  
+  
+  describe('Quadtree Y Iteration', function() {
+    var quad = new QuadTree(bounds);
+    var items = [
+      { y: 2, x: 49, width: 2, height: 2, id: 0 },
+      { y: 4, x: 49, width: 2, height: 2, id: 1 },
+      { y: 6, x: 49, width: 2, height: 2, id: 2 },
+      { y: 8, x: 49, width: 2, height: 2, id: 3 },
+      { y: 10, x: 49, width: 2, height: 2, id: 4 },
+      { y: 12, x: 49, width: 2, height: 2, id: 5 },
+    ];
+    quad.insert(items);
+    
+    function testIterateYTests() {
+      // Runs tests on a quad in the x direction. 
+      var out = [];
+      out = itToAr(quad.retrieveYInc(49, 0, 1));
+      expect(out).toEqual(items);
+      out = itToAr(quad.retrieveYInc(49, 0, 5));
+      expect(out).toEqual(items);
+      
+      // Skip the first
+      out = itToAr(quad.retrieveYInc(49, 4, 1));
+      expect(out).toEqual(items.slice(1));
+      // Skip all
+      out = itToAr(quad.retrieveYInc(49, 14, 1));
+      expect(out).toEqual([]);
+      // Get the edges
+      out = itToAr(quad.retrieveYInc(48, 0, 1));
+      expect(out).toEqual([]);
+      out = itToAr(quad.retrieveYInc(51, 0, 1));
+      expect(out).toEqual([]);
+      
+      // Now test the same in reverse
+      items.reverse();
+      
+      out = itToAr(quad.retrieveYDec(49, 50, 1));
+      expect(out).toEqual(items);
+      out = itToAr(quad.retrieveYDec(49, 13, 1));
+      expect(out).toEqual(items);
+      // Skip the first
+      out = itToAr(quad.retrieveYDec(49, 12, 1));
+      expect(out).toEqual(items.slice(1));
+      out = itToAr(quad.retrieveYDec(49, 9, 1));
+      expect(out).toEqual(items.slice(2));
+      // Get the edges
+      out = itToAr(quad.retrieveYDec(49, 8, 1));
+      expect(out).toEqual(items.slice(3));
+      out = itToAr(quad.retrieveYDec(49, 6, 1));
+      expect(out).toEqual(items.slice(4));
+      out = itToAr(quad.retrieveYDec(49, 4, 1));
+      expect(out).toEqual(items.slice(5));
+      out = itToAr(quad.retrieveYDec(49, 2, 1));
+      expect(out).toEqual([]);
+      
+      // Put items back into forward order
+      items.reverse();
+    }
+    
+    
+    it('iterate x alone', testIterateYTests);
+    // Add a number of objects
+    for (var i=0; i<100; i += 5) {
+      quad.insert({ x: i/20, y: i, width: 1, height: 1 });
+    }
+    // Adding the objects above should not have changed the test
+    it('iterate x with objs', testIterateYTests);
+    for (i=0; i<100; i += 5) {
+      quad.insert({ x: 99-i/20, y: 99-i, width: 1, height: 1 });
+    }
+    it('iterate x with more objs', testIterateYTests);
+    
+  });
+  describe('Quadtree Var Size Iteration', function () {
+    it('X Direc', function () {
+      var quad = new QuadTree(bounds);
+      var items = [
+        { y: 1, x: 10, width: 30, height: 2, id: 0 },
+        { y: 1, x: 2, width: 80, height: 2, id: 1 },
+      ];
+      quad.insert(items);
+      var c;
+      c = quad.retrieveXInc(0, 0, 50).next();
+      expect(c && c.id).toEqual(1);
+      c = quad.retrieveXDec(100, 0, 50).next();
+      expect(c && c.id).toEqual(1);
+    });
+    it('X Direc - Multiquads', function () {
+      var quad = new QuadTree(bounds);
+      var items = [
+        { y: 1, x: 10, width: 30, height: 2, id: 0 },
+        { y: 1, x: 2, width: 80, height: 2, id: 1 },
+        { y: 3, x: 10, width: 30, height: 2, id: 2 },
+        { y: 4, x: 10, width: 30, height: 2, id: 3 },
+      ];
+      quad.insert(items);
+      var c;
+      c = quad.retrieveXInc(0, 0, 50).next();
+      expect(c && c.id).toEqual(1);
+      c = quad.retrieveXDec(100, 0, 50).next();
+      expect(c && c.id).toEqual(1);
+    });
+    it('Y Direc', function () {
+      var quad = new QuadTree(bounds);
+      var items = [
+        { x: 1, y: 10, width: 2, height: 30, id: 0 },
+        { x: 1, y: 2, width: 2, height: 80, id: 1 },
+      ];
+      quad.insert(items);
+      var c;
+      c = quad.retrieveYInc(0, 0, 50).next();
+      expect(c && c.id).toEqual(1);
+      c = quad.retrieveYDec(0, 100, 50).next();
+      expect(c && c.id).toEqual(1);
+    });
+  });
+  describe('Other Exmaples', function () {
+    var quad = new QuadTree({ x: 0, y: 0, width: 350, height: 500 });
+    var items = [
+      { x: 327.50, y: 226.06, width: 3.74, height: 14.96, id: 0 },
+      { x: 321.85, y: 243.27, width: 14.98, height: 14.96, id: 1 },
+    ];
+    quad.insert(items);
+    
+    var out = itToAr(quad.retrieveYInc(327.50, 226.06, 3.74));
+    out = out.map(function (c) { return c.id; });
+    expect(out).toEqual([0, 1]);
+  });
+});

--- a/test/unit/unit_test.html
+++ b/test/unit/unit_test.html
@@ -27,6 +27,7 @@
   <script src="../../src/core/crypto.js"></script>
   <script src="../../src/core/pattern.js"></script>
   <script src="../../src/core/evaluator.js"></script>
+  <script src="../../src/core/quadtree.js"></script>
   <script src="../../src/core/cmap.js"></script>
   <script src="../../src/core/fonts.js"></script>
   <script src="../../src/core/glyphlist.js"></script>
@@ -43,6 +44,7 @@
   <script>PDFJS.workerSrc = '../../src/worker_loader.js';</script>
 
   <!-- include spec files here... -->
+  <script src="quadtree_spec.js"></script>
   <script src="obj_spec.js"></script>
   <script src="font_spec.js"></script>
   <script src="function_spec.js"></script>

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1268,6 +1268,20 @@ html[dir='rtl'] .attachmentsItem > button {
 ::selection { background: rgba(0,0,255,0.3); }
 ::-moz-selection { background: rgba(0,0,255,0.3); }
 
+.textLayer ::selection { background: rgb(0,0,255); }
+.textLayer ::-moz-selection { background: rgb(0,0,255); }
+.textLayer .whitespace::selection { background: none; }
+.textLayer .whitespace::-moz-selection { background: none; }
+.textLayer {
+  opacity: 0.2;
+}
+/* We need to calculate font height before rendering. Setting line-height to
+   normal is inconsistent across browsers.  Instead, set it to a common
+   value. */
+.textLayer div {
+  line-height: 1.14;
+}
+
 #errorWrapper {
   background: none repeat scroll 0 0 #FF5555;
   color: white;


### PR DESCRIPTION
## The Problem

Text selection in pdf.js does not work so well. If while dragging, your cursor is not directly on top of a text element, then you get unexpected results. This occurs with nearly all examples, including [the tracemonkey example](http://mozilla.github.io/pdf.js/web/viewer.html).  Try starting a selection, then dragging the mouse to a blank whitespace area beneath the initial selection. You'll see the selection gets reversed. If you keep moving your mouse, it flickers and is generally a horrible experience. I'm not the first to report this, it is the subject of at least #4629 and #4843. 
## The Solution

The reason why selection doesn't work is because most browsers rely on padding between text to detect text flow.  The solution, therefore, is to increase padding of each text element so that each element runs right up next to the next element. 
### Other Solutions

Adding padding to each text element was recognized as a possible solution by @mitar in #4843.  However, in #4843, the suggested solution was relatively complex, which included modifying the padding dynamically whenever a mouse moves. It was also written in CoffeeScript for a completely separate viewer and porting it seemed difficult.
### This Solution

In this solution, the padding is calculated when the text elements are added. For each added text element, we find the nearest neighbor to the right that is on the same line. We then set the `padding-right` of the text element to that distance.  Similarly, for `padding-bottom` we find the next line that is underneath the text element, and set the padding to the difference between lines.  Setting `padding-bottom` is especially helpful for PDFs that are double spaced (lots of space between lines).

The solution isn't all milk and honey though. The computation is `O(N^2)`, which could be bad for complex PDFs.  There are [fancier algorithms to find the nearest neighbor](http://en.wikipedia.org/wiki/Nearest_neighbor_search), but for now, for each text element, we look at every other text element to see if it's nearest.

_UPDATE_: As discussed below, the `O(N^2)` issue in this pull request has been resolved by using a quadtree datastructure.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/pdf.js/5545)

<!-- Reviewable:end -->
