### PR TITLE
Fixed empty packet parsing bug

### DIFF
--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -1097,10 +1097,10 @@ var JpxImage = (function JpxImageClosure() {
         // Skip also marker segment length and packet sequence ID
         skipBytes(4);
       }
+      var packet = packetsIterator.nextPacket();
       if (!readBits(1)) {
         continue;
       }
-      var packet = packetsIterator.nextPacket();
       var layerNumber = packet.layerNumber;
       var queue = [], codeblock;
       for (var i = 0, ii = packet.codeblocks.length; i < ii; i++) {


### PR DESCRIPTION
Packet iterator was not advanced for empty packets.

Here is a fictively-generated image for testing (was generated by simply replacing the last quality layer's packets in empty ones):
https://www.dropbox.com/s/wdem5s87pp3zowf/cabs_small_bw_with_plt_reconstructed_9layers.j2k?dl=0
