### PR TITLE
Remove unused annotation highlight div

### DIFF
--- a/src/display/annotation_helper.js
+++ b/src/display/annotation_helper.js
@@ -18,7 +18,6 @@
 
 'use strict';
 
-var HIGHLIGHT_OFFSET = 4; // px
 var ANNOT_MIN_SIZE = 10; // px
 
 var AnnotationUtils = (function AnnotationUtilsClosure() {
@@ -66,16 +65,6 @@ var AnnotationUtils = (function AnnotationUtilsClosure() {
     }
     cstyle.width = width + 'px';
     cstyle.height = height + 'px';
-
-    var highlight = document.createElement('div');
-    highlight.className = 'annotationHighlight';
-    highlight.style.left = highlight.style.top = -HIGHLIGHT_OFFSET + 'px';
-    highlight.style.right = highlight.style.bottom = -HIGHLIGHT_OFFSET + 'px';
-    highlight.setAttribute('hidden', true);
-
-    item.highlightElement = highlight;
-    container.appendChild(item.highlightElement);
-
     return container;
   }
 

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -72,11 +72,6 @@
   border: 0;
 }
 
-.pdfViewer .page .annotationHighlight {
-  position: absolute;
-  border: 2px #FFFF99 solid;
-}
-
 .pdfViewer .page .annotText > img {
   position: absolute;
   cursor: pointer;


### PR DESCRIPTION
This is now done using CSS. For annotation-heavy documents this change makes the DOM much lighter.
