### PR TITLE
Remove unused hasOperatorList code

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -538,11 +538,7 @@ var LinkAnnotation = (function LinkAnnotationClosure() {
     return url;
   }
 
-  Util.inherit(LinkAnnotation, InteractiveAnnotation, {
-    hasOperatorList: function LinkAnnotation_hasOperatorList() {
-      return false;
-    }
-  });
+  Util.inherit(LinkAnnotation, InteractiveAnnotation, { });
 
   return LinkAnnotation;
 })();


### PR DESCRIPTION
Originated from https://github.com/mozilla/pdf.js/commit/f8f4b3f45dc6ff5f5b2572b5387389db33616be3#diff-c18ac71361bc452920c40076a5937b3dR485 but has been unused since then.
