### PR TITLE
Ensure transport is destroyed if the document fails to load

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -246,6 +246,9 @@ PDFJS.getDocument = function getDocument(source,
     transport.passwordCallback = passwordCallback;
     transport.fetchDocument(params);
   });
+  workerReadyCapability.promise.then(null, function(){
+    transport.destroy();
+  });
   return workerReadyCapability.promise;
 };
 


### PR DESCRIPTION
Currently if a document fails to load, the transport created is never cleaned up. This abandons a webworker which no longer needs to exist. The following document can be used to recreate this on the pdf.js demo viewer (and is re-producable on master)

https://drive.google.com/file/d/0B-t46RM6nE09cXpEb3QtVDVocUU/view?usp=sharing

![issue](https://cloud.githubusercontent.com/assets/320654/5522080/65c10bee-8a05-11e4-97a0-4288e7ac7f50.png)

Video of issue: https://www.youtube.com/watch?v=PC81V7_4q0M
