### PR TITLE
Added multiple term search functionality (with default phrase search)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1251,6 +1251,7 @@ var PDFViewerApplication = {
     eventBus.on('rotateccw', webViewerRotateCcw);
     eventBus.on('documentproperties', webViewerDocumentProperties);
     eventBus.on('find', webViewerFind);
+    eventBus.on('findfromurlhash', webViewerFindFromUrlHash);
 //#if GENERIC
     eventBus.on('fileinputchange', webViewerFileInputChange);
 //#endif
@@ -1906,9 +1907,20 @@ function webViewerDocumentProperties() {
 function webViewerFind(e) {
   PDFViewerApplication.findController.executeCommand('find' + e.type, {
     query: e.query,
+    phraseSearch: e.phraseSearch,
     caseSensitive: e.caseSensitive,
     highlightAll: e.highlightAll,
     findPrevious: e.findPrevious
+  });
+}
+
+function webViewerFindFromUrlHash(e) {
+  PDFViewerApplication.findController.executeCommand('find', {
+    query: e.query,
+    phraseSearch: e.phraseSearch,
+    caseSensitive: false,
+    highlightAll: true,
+    findPrevious: false
   });
 }
 
@@ -2055,6 +2067,7 @@ window.addEventListener('keydown', function keydown(evt) {
           if (findState) {
             PDFViewerApplication.findController.executeCommand('findagain', {
               query: findState.query,
+              phraseSearch: findState.phraseSearch,
               caseSensitive: findState.caseSensitive,
               highlightAll: findState.highlightAll,
               findPrevious: cmd === 5 || cmd === 12

--- a/web/dom_events.js
+++ b/web/dom_events.js
@@ -88,6 +88,7 @@
       var event = document.createEvent('CustomEvent');
       event.initCustomEvent('find' + e.type, true, true, {
         query: e.query,
+        phraseSearch: e.phraseSearch,
         caseSensitive: e.caseSensitive,
         highlightAll: e.highlightAll,
         findPrevious: e.findPrevious

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -163,6 +163,7 @@ Preferences._readFromStorage = function (prefObj) {
       source: window,
       type: evt.type.substring('find'.length),
       query: evt.detail.query,
+      phraseSearch: true,
       caseSensitive: !!evt.detail.caseSensitive,
       highlightAll: !!evt.detail.highlightAll,
       findPrevious: !!evt.detail.findPrevious

--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -109,6 +109,7 @@ var PDFFindBar = (function PDFFindBarClosure() {
         type: type,
         query: this.findField.value,
         caseSensitive: this.caseSensitive.checked,
+        phraseSearch: true,
         highlightAll: this.highlightAll.checked,
         findPrevious: findPrev
       });

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -194,6 +194,13 @@ var PDFLinkService = (function () {
     setHash: function PDFLinkService_setHash(hash) {
       if (hash.indexOf('=') >= 0) {
         var params = parseQueryString(hash);
+        if ('search' in params) {
+          this.eventBus.dispatch('findfromurlhash', {
+            source: this,
+            query: params['search'].replace(/"/g, ''),
+            phraseSearch: (params['phrase'] === 'true')
+          });
+        }
         // borrowing syntax from "Parameters for Opening PDF Files"
         if ('nameddest' in params) {
           if (this.pdfHistory) {

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -116,7 +116,8 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
       this.divContentDone = true;
     },
 
-    convertMatches: function TextLayerBuilder_convertMatches(matches) {
+    convertMatches: function TextLayerBuilder_convertMatches(matches,
+                                                             matchesLength) {
       var i = 0;
       var iIndex = 0;
       var bidiTexts = this.textContent.items;
@@ -124,7 +125,9 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
       var queryLen = (this.findController === null ?
                       0 : this.findController.state.query.length);
       var ret = [];
-
+      if (!matches) {
+        return ret;
+      }
       for (var m = 0, len = matches.length; m < len; m++) {
         // Calculate the start position.
         var matchIdx = matches[m];
@@ -147,7 +150,11 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
         };
 
         // Calculate the end position.
-        matchIdx += queryLen;
+        if (matchesLength) { // multiterm search
+          matchIdx += matchesLength[m];
+        } else { // phrase search
+          matchIdx += queryLen;
+        }
 
         // Somewhat the same array as above, but use > instead of >= to get
         // the end position right.
@@ -289,8 +296,14 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
 
       // Convert the matches on the page controller into the match format
       // used for the textLayer.
-      this.matches = this.convertMatches(this.findController === null ?
-        [] : (this.findController.pageMatches[this.pageIdx] || []));
+      var pageMatches, pageMatchesLength;
+      if (this.findController !== null) {
+        pageMatches = this.findController.pageMatches[this.pageIdx] || null;
+        pageMatchesLength = (this.findController.pageMatchesLength) ?
+          this.findController.pageMatchesLength[this.pageIdx] || null : null;
+      }
+
+      this.matches = this.convertMatches(pageMatches, pageMatchesLength);
       this.renderMatches(this.matches);
     },
 


### PR DESCRIPTION
This pull-request is very similar to #5496
Change allows:
- in addition to the standard (phrase) search adds functionality to search multiple words separated by a space (multiple terms search)
- define the word (or word list) to search in the url hash tag #search. When page has been loaded, document is scrolling to the search results.
- specify the type of search (phrase or multiple term search) in the url hash tag #phrase (true or absent hash tag - default phrase search, false - multiple term search)
- specify the type of search (phrase or multiple term search) in UI (checkbox 'Phrase', by default this is checked).

![pdfjspull](https://cloud.githubusercontent.com/assets/10258064/5538374/73ff2626-8ad4-11e4-843e-870d821cf76c.png)

Examples:
find phrase 'Locking tames tamed tame':
# search=Locking%20tames%20tamed%20tame&phrase=true

or 
# search=Locking%20tames%20tamed%20tame

find multiple term search 'Locking tames tamed tame':
# search=Locking%20tames%20tamed%20tame&phrase=false

Screenshots:
![pdfjspull-phrase](https://cloud.githubusercontent.com/assets/10258064/5538444/051c58e4-8ad6-11e4-95a5-42c01f9fbd24.png)

![pdfjspull-multiple](https://cloud.githubusercontent.com/assets/10258064/5538446/0c22a3c8-8ad6-11e4-9e99-59ee68e4482c.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/pdf.js/5579)

<!-- Reviewable:end -->
