### PR TITLE
Update thumbnails only when they are visible (to improve scrolling through large documents)

### DIFF
--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -76,7 +76,9 @@ var PDFThumbnailViewer = (function PDFThumbnailViewerClosure() {
         selected.classList.remove('selected');
       }
       var thumbnail = document.getElementById('thumbnailContainer' + page);
-      thumbnail.classList.add('selected');
+      if (thumbnail) {
+        thumbnail.classList.add('selected');
+      }
       var visibleThumbs = this._getVisibleThumbs();
       var numVisibleThumbs = visibleThumbs.views.length;
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1177,6 +1177,23 @@ var PDFViewerApplication = {
     }
   },
 
+  refreshThumbnailViewer: function pdfViewRefreshThumbnailViewer() {
+    var pdfViewer = this.pdfViewer;
+    var thumbnailViewer = this.pdfThumbnailViewer;
+
+    // set thumbnail images of rendered pages
+    var pagesCount = pdfViewer.pagesCount;
+    for (var pageIndex = 0; pageIndex < pagesCount; pageIndex++) {
+      var pageView = pdfViewer.getPageView(pageIndex);
+      if (pageView && pageView.renderingState === RenderingStates.FINISHED) {
+        var thumbnailView = thumbnailViewer.getThumbnail(pageIndex);
+        thumbnailView.setImage(pageView);
+      }
+    }
+
+    thumbnailViewer.scrollThumbnailIntoView(this.page);
+  },
+
   switchSidebarView: function pdfViewSwitchSidebarView(view, openSidebar) {
     if (openSidebar && !this.sidebarOpen) {
       document.getElementById('sidebarToggle').click();
@@ -1575,8 +1592,7 @@ function webViewerInitialized() {
       PDFViewerApplication.sidebarOpen =
         outerContainer.classList.contains('sidebarOpen');
       if (PDFViewerApplication.sidebarOpen) {
-        PDFViewerApplication.pdfThumbnailViewer.
-          scrollThumbnailIntoView(PDFViewerApplication.page);
+        PDFViewerApplication.refreshThumbnailViewer();
       }
       PDFViewerApplication.forceRendering();
     });
@@ -1692,9 +1708,12 @@ document.addEventListener('pagerendered', function (e) {
   var pageNumber = e.detail.pageNumber;
   var pageIndex = pageNumber - 1;
   var pageView = PDFViewerApplication.pdfViewer.getPageView(pageIndex);
-  var thumbnailView = PDFViewerApplication.pdfThumbnailViewer.
-                      getThumbnail(pageIndex);
-  thumbnailView.setImage(pageView);
+
+  if (PDFViewerApplication.sidebarOpen) {
+    var thumbnailView = PDFViewerApplication.pdfThumbnailViewer.
+                        getThumbnail(pageIndex);
+    thumbnailView.setImage(pageView);
+  }
 
   if (PDFJS.pdfBug && Stats.enabled && pageView.stats) {
     Stats.add(pageNumber, pageView.stats);

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1574,6 +1574,10 @@ function webViewerInitialized() {
       outerContainer.classList.toggle('sidebarOpen');
       PDFViewerApplication.sidebarOpen =
         outerContainer.classList.contains('sidebarOpen');
+      if (PDFViewerApplication.sidebarOpen) {
+        PDFViewerApplication.pdfThumbnailViewer.
+          scrollThumbnailIntoView(PDFViewerApplication.page);
+      }
       PDFViewerApplication.forceRendering();
     });
 
@@ -1920,7 +1924,9 @@ window.addEventListener('pagechange', function pagechange(evt) {
   var page = evt.pageNumber;
   if (evt.previousPageNumber !== page) {
     document.getElementById('pageNumber').value = page;
-    PDFViewerApplication.pdfThumbnailViewer.scrollThumbnailIntoView(page);
+    if (PDFViewerApplication.sidebarOpen) {
+      PDFViewerApplication.pdfThumbnailViewer.scrollThumbnailIntoView(page);
+    }
   }
   var numPages = PDFViewerApplication.pagesCount;
 


### PR DESCRIPTION
This PR postpones highlighting the current page thumbnail in `PDFThumbnailViewer.scrollThumbnailIntoView()` until the thumbnail view is opened. Setting the style of thumbnails can take long and become a bottleneck if the document (and thus, the DOM tree) is very large. Scrolling through very large documents is now smoother with this PR.

Good tests: 
[1] [pdf](https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=282159) (2000+ pages) from #5207 and
[2] [pdf](http://www.etsi.org/deliver/etsi_ts/151000_151099/15101001/04.03.00_60/ts_15101001v040300p.pdf) (3000+ pages) from https://bugzilla.mozilla.org/show_bug.cgi?id=885287#c6. 
[3] [pdf](http://www.etsi.org/deliver/etsi_ts/151000_151099/15101001/10.03.00_60/ts_15101001v100300p.pdf) (5000+ pages)

_A benchmark_: Scrolling through the first 50 pages of [3] with the `↓` key:

| Browser | w/o patch | w/ patch |
| --- | --- | --- |
| FF 34 | 1:01 | 0:49 |
| FF Nightly 37.0a1 | 1:50 | 1:07 |

_Another benchmark_: While scrolling through the first 10 pages of [1] with the `↓` key, the frame rates are now much more often at the 60 fps mark (FF Nightly 37.0a1):
![zwischenablage03](https://cloud.githubusercontent.com/assets/4624768/5558516/fba44b8a-8d2a-11e4-8601-e1fa7ab618c4.png)
![zwischenablage04](https://cloud.githubusercontent.com/assets/4624768/5558519/1000545c-8d2b-11e4-8021-22581803bea7.png)

EDIT: Added correct link to [3] which I had used for benchmarking, added Firefox 34 results (which shows performance regression of Nightly)
