### PR TITLE
Remove unused anchor links placed before every page

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -75,9 +75,6 @@ var PDFPageView = (function PDFPageViewClosure() {
 
     this.annotationLayer = null;
 
-    var anchor = document.createElement('a');
-    anchor.name = '' + this.id;
-
     var div = document.createElement('div');
     div.id = 'pageContainer' + this.id;
     div.className = 'page';
@@ -86,7 +83,6 @@ var PDFPageView = (function PDFPageViewClosure() {
     this.el = div; // TODO replace 'el' property usage
     this.div = div;
 
-    container.appendChild(anchor);
     container.appendChild(div);
   }
 


### PR DESCRIPTION
In old versions of the viewer, anchor links were used to be able to scroll a page into view. Since we for quite some time have had a `scrollIntoView` function which handles this, the anchor links are no longer necessary and I believe that they can be removed. Doing so will reduce the total number of DOM elements in the viewer.

For most documents this patch will probably not make much of a difference performance wise, but for very long (1000+ pages) documents this could help performance especially on lower powered hardware.
