### PR TITLE
Use binary search in getVisibleElements()

### DIFF
--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -1,0 +1,37 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/* globals expect, it, describe, binarySearchFirstItem */
+
+'use strict';
+
+describe('ui_utils', function() {
+
+  describe('binary search', function() {
+    function isTrue(boolean) {
+      return boolean;
+    }
+    function isGreater3(number) {
+      return number > 3;
+    }
+
+    it('empty array', function() {
+      expect(binarySearchFirstItem([], isTrue)).toEqual(0);
+    });
+    it('single boolean entry', function() {
+      expect(binarySearchFirstItem([false], isTrue)).toEqual(1);
+      expect(binarySearchFirstItem([true], isTrue)).toEqual(0);
+    });
+    it('three boolean entries', function() {
+      expect(binarySearchFirstItem([true, true, true], isTrue)).toEqual(0);
+      expect(binarySearchFirstItem([false, true, true], isTrue)).toEqual(1);
+      expect(binarySearchFirstItem([false, false, true], isTrue)).toEqual(2);
+      expect(binarySearchFirstItem([false, false, false], isTrue)).toEqual(3);
+    });
+    it('three numeric entries', function() {
+      expect(binarySearchFirstItem([0, 1, 2], isGreater3)).toEqual(3);
+      expect(binarySearchFirstItem([2, 3, 4], isGreater3)).toEqual(2);
+      expect(binarySearchFirstItem([4, 5, 6], isGreater3)).toEqual(0);
+    });
+  });
+});
+

--- a/test/unit/unit_test.html
+++ b/test/unit/unit_test.html
@@ -40,6 +40,7 @@
   <script src="../../src/core/worker.js"></script>
   <script src="../../src/display/metadata.js"></script>
   <script src="../../src/core/jpg.js"></script>
+  <script src="../../web/ui_utils.js"></script>
   <script>PDFJS.workerSrc = '../../src/worker_loader.js';</script>
 
   <!-- include spec files here... -->
@@ -52,6 +53,7 @@
   <script src="parser_spec.js"></script>
   <script src="api_spec.js"></script>
   <script src="metadata_spec.js"></script>
+  <script src="ui_utils_spec.js"></script>
   <script src="util_spec.js"></script>
   <script src="cmap_spec.js"></script>
   <script>


### PR DESCRIPTION
The method `getVisibleElements()` uses a linear search to find the first page and thumbnail in the visible range. It is called on every scroll event, so it can take a noticeable amount of time for the bottom pages of a very large document.
This PR replaces the linear search with a binary one (which needs O(log n) time).

A good test:
[3] [pdf](http://www.etsi.org/deliver/etsi_ts/151000_151099/15101001/10.03.00_60/ts_15101001v100300p.pdf) (5000+ pages)

A benchmark:
Scrolling through pages 5500 to 5515 of [3], using the `↓` key, Linux, Firefox Nightly 37.0a1, `textLayer=off`
Before:
![linearsearch2](https://cloud.githubusercontent.com/assets/4624768/5571239/c6a01f66-8f8e-11e4-91af-b79fc2b00df2.png)
After:
![binarysearch2](https://cloud.githubusercontent.com/assets/4624768/5571240/ca4d0b74-8f8e-11e4-9493-b2de8375a63b.png)

(Admittedly, the document has to be very large to notice a difference, but it should be more pronounced on slow devices).
