### PR TITLE
Fix border sizes around thumbnails

### DIFF
--- a/web/thumbnail_view.js
+++ b/web/thumbnail_view.js
@@ -20,6 +20,7 @@
 'use strict';
 
 var THUMBNAIL_SCROLL_MARGIN = -19;
+var THUMBNAIL_CANVAS_BORDER_WIDTH = 1;
 
 /**
  * @constructor
@@ -55,8 +56,8 @@ var ThumbnailView = function thumbnailView(container, id, defaultViewport,
   this.renderingId = 'thumbnail' + id;
 
   this.canvasWidth = 98;
-  this.canvasHeight = this.canvasWidth / this.pageWidth * this.pageHeight;
-  this.scale = (this.canvasWidth / this.pageWidth);
+  this.canvasHeight = (this.canvasWidth / this.pageRatio) | 0;
+  this.scale = this.canvasWidth / this.pageWidth;
 
   var div = this.el = document.createElement('div');
   div.id = 'thumbnailContainer' + id;
@@ -70,8 +71,10 @@ var ThumbnailView = function thumbnailView(container, id, defaultViewport,
 
   var ring = document.createElement('div');
   ring.className = 'thumbnailSelectionRing';
-  ring.style.width = this.canvasWidth + 'px';
-  ring.style.height = this.canvasHeight + 'px';
+  ring.style.width = this.canvasWidth + 2 * THUMBNAIL_CANVAS_BORDER_WIDTH +
+                     'px';
+  ring.style.height = this.canvasHeight + 2 * THUMBNAIL_CANVAS_BORDER_WIDTH +
+                      'px';
 
   div.appendChild(ring);
   anchor.appendChild(div);
@@ -103,13 +106,15 @@ var ThumbnailView = function thumbnailView(container, id, defaultViewport,
     this.pageHeight = this.viewport.height;
     this.pageRatio = this.pageWidth / this.pageHeight;
 
-    this.canvasHeight = this.canvasWidth / this.pageWidth * this.pageHeight;
+    this.canvasHeight = (this.canvasWidth / this.pageRatio) | 0;
     this.scale = (this.canvasWidth / this.pageWidth);
 
     div.removeAttribute('data-loaded');
     ring.textContent = '';
-    ring.style.width = this.canvasWidth + 'px';
-    ring.style.height = this.canvasHeight + 'px';
+    ring.style.width = this.canvasWidth + 2 * THUMBNAIL_CANVAS_BORDER_WIDTH +
+                       'px';
+    ring.style.height = this.canvasHeight + 2 * THUMBNAIL_CANVAS_BORDER_WIDTH +
+                        'px';
 
     this.hasImage = false;
     this.renderingState = RenderingStates.INITIAL;

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1115,9 +1115,13 @@ html[dir='rtl'] .verticalToolbarSeparator {
   margin-bottom: 10px;
 }
 
+#thumbnailView > a:last-of-type > .thumbnail:not([data-loaded]) {
+  margin-bottom: 9px;
+}
+
 .thumbnail:not([data-loaded]) {
   border: 1px dashed rgba(255, 255, 255, 0.5);
-  margin-bottom: 10px;
+  margin: -1px -1px 4px -1px;
 }
 
 .thumbnailImage {


### PR DESCRIPTION
This PR fixes two issues: 

**1. Thumbnail borders do not have the same width in all directions**
Currently, the thumbnail border width is [7, 5, 6, 7]px in [top, right, bottom, left] direction. This is because the thumbnail canvas has a 1px border which is not accounted for in the size of the div element around it (which would explain a border size of [7, 5, 5, 7]px). The remaining pixel difference is because the size of the thumbnail canvas and its surrounding div is set as a fractional number, whose fractional part is ignored by the canvas element but respected by the div element. This PR ensures a 7px border width by taking the canvas border into account and setting an integer height to canvas and its surrounding div element.

**2. Thumbnails jump up and down by a few pixels whenever a new thumbnail is loaded.**
Thumbnails currently have a different size, depending on whether or not the "data-loaded" tag is set.
This PR adjust the CSS style of the not([data-loaded]) elements so that its size matches the other ones.
(The not([data-loaded]) elements have a 1px dashed border, whose size must be subtracted).

The second fix works perfectly for the tracemonkey paper, but images still move if pages have different aspect ratio. Nevertheless, there is much less movement than before.
