### PR TITLE
CCITTFaxStream: fix regression when EncodedByteAlign is true and EndOfLine is false

### DIFF
--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -2040,7 +2040,7 @@ var CCITTFaxStream = (function CCITTFaxStreamClosure() {
 
       if (!this.eoblock && this.row === this.rows - 1) {
         this.eof = true;
-      } else if (this.eoline || !this.byteAlign) {
+      } else {
         code1 = this.lookBits(12);
         if (this.eoline) {
           while (code1 !== EOF && code1 !== 1) {

--- a/test/pdfs/issue5592.pdf.link
+++ b/test/pdfs/issue5592.pdf.link
@@ -1,0 +1,1 @@
+http://www.pdf-archive.com/2014/12/29/4111112/4111112.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1926,6 +1926,13 @@
        "link": true,
        "type": "eq"
     },
+    {  "id": "issue5592",
+       "file": "pdfs/issue5592.pdf",
+       "md5": "a0750f95afa80c880f7966df7062616c",
+       "rounds": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "issue5549.pdf",
        "file": "pdfs/issue5549.pdf",
        "md5": "6c36df6ebc583c9e18aad0ad00d257b8",


### PR DESCRIPTION
Fixes #5592.

I have manually checked the files from #5136 to be sure that they still render the same as before. This PR makes sure that PDFs where EncodedByteAlign is true and EndOfLine is false also enter the EOL check. See http://logs.glob.uno/?c=mozilla%23pdfjs&s=29+Dec+2014&e=29+Dec+2014#c28841 for more information.
