### PR TITLE
Disable Range Support for Chrome 39+40 (#5512)

### DIFF
--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -479,7 +479,10 @@ if (typeof PDFJS === 'undefined') {
   var regex = /Android\s[0-2][^\d]/;
   var isOldAndroid = regex.test(navigator.userAgent);
 
-  if (isSafari || isOldAndroid) {
+  // Range requests are broken in Chrome 39 and 40, https://crbug.com/442318
+  var isChromeWithRangeBug = /Chrome\/(39|40)\./.test(navigator.userAgent);
+
+  if (isSafari || isOldAndroid || isChromeWithRangeBug) {
     PDFJS.disableRange = true;
     PDFJS.disableStream = true;
   }


### PR DESCRIPTION
Disabling Range Support for Chrome 39 and above, due to regression in
Chromium. Will be enabled once a fix version is confirmed.
- https://code.google.com/p/chromium/issues/detail?id=444659
- https://code.google.com/p/chromium/issues/detail?id=442318
