### PR TITLE
Ensure that |get fingerprint| doesn't fail if the ID is not an array (issue 5599)

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -281,9 +281,9 @@ var Page = (function PageClosure() {
  */
 var PDFDocument = (function PDFDocumentClosure() {
   var FINGERPRINT_FIRST_BYTES = 1024;
-
   var EMPTY_FINGERPRINT = '\x00\x00\x00\x00\x00\x00\x00' +
     '\x00\x00\x00\x00\x00\x00\x00\x00\x00';
+
   function PDFDocument(pdfManager, arg, password) {
     if (isStream(arg)) {
       init.call(this, pdfManager, arg, password);
@@ -495,11 +495,13 @@ var PDFDocument = (function PDFDocumentClosure() {
       return shadow(this, 'documentInfo', docInfo);
     },
     get fingerprint() {
-      var xref = this.xref, hash, fileID = '';
+      var xref = this.xref, idArray, hash, fileID = '';
 
-      if (xref.trailer.has('ID') &&
-          xref.trailer.get('ID')[0] !== EMPTY_FINGERPRINT) {
-        hash = stringToBytes(xref.trailer.get('ID')[0]);
+      if (xref.trailer.has('ID')) {
+        idArray = xref.trailer.get('ID');
+      }
+      if (idArray && isArray(idArray) && idArray[0] !== EMPTY_FINGERPRINT) {
+        hash = stringToBytes(idArray[0]);
       } else {
         if (this.stream.ensureRange) {
           this.stream.ensureRange(0,

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -70,6 +70,7 @@
 !issue5291.pdf
 !issue5421.pdf
 !issue5470.pdf
+!issue5599.pdf
 !gradientfill.pdf
 !bug903856.pdf
 !bug850854.pdf

--- a/test/pdfs/issue5599.pdf
+++ b/test/pdfs/issue5599.pdf
@@ -1,0 +1,76 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/Type /Encoding
+/BaseEncoding /WinAnsiEncoding
+>>
+endobj 
+2 0 obj 
+<<
+/Pages 3 0 R
+/Type /Catalog
+>>
+endobj 
+3 0 obj 
+<<
+/MediaBox [0 0 200 50]
+/Kids [4 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+4 0 obj 
+<<
+/Parent 3 0 R
+/MediaBox [0 0 200 50]
+/Resources 
+<<
+/Font 
+<<
+/F1 5 0 R
+>>
+>>
+/Contents 6 0 R
+/Type /Page
+>>
+endobj 
+5 0 obj 
+<<
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Encoding 1 0 R
+/Type /Font
+>>
+endobj 
+6 0 obj 
+<<
+/Length 41
+>>
+stream
+BT
+10 20 TD
+/F1 20 Tf
+(Issue 5599) Tj
+ET
+
+endstream 
+endobj xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000085 00000 n 
+0000000136 00000 n 
+0000000218 00000 n 
+0000000347 00000 n 
+0000000437 00000 n 
+trailer
+
+<<
+/Root 2 0 R
+/Size 7
+/ID 77777777777777777
+>>
+startxref
+530
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -508,6 +508,13 @@
        "lastPage": 1,
        "type": "load"
     },
+    {  "id": "issue5599",
+       "file": "pdfs/issue5599.pdf",
+       "md5": "529a4a9409ac024aeb57a047210280fe",
+       "rounds": 1,
+       "link": false,
+       "type": "load"
+    },
     {  "id": "txt2pdf",
        "file": "pdfs/txt2pdf.pdf",
        "md5": "02cefa0f5e8d96313bb05163b2f88c8c",


### PR DESCRIPTION
According to the [PDF specification](http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#page=51) the `ID` should be an array. To prevent errors if the PDF file violates that part of the spec, check that the `ID` is actually an array.

Fixes #5599.
