### PR TITLE
Don't layout sidebar when hidden

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -166,7 +166,6 @@ html[dir='rtl'] .innerCenter {
   top: 0;
   bottom: 0;
   width: 200px;
-  visibility: hidden;
   -webkit-transition-duration: 200ms;
   -webkit-transition-timing-function: ease;
   transition-duration: 200ms;
@@ -184,10 +183,6 @@ html[dir='rtl'] #sidebarContainer {
   right: -200px;
 }
 
-#outerContainer.sidebarMoving > #sidebarContainer,
-#outerContainer.sidebarOpen > #sidebarContainer {
-  visibility: visible;
-}
 html[dir='ltr'] #outerContainer.sidebarOpen > #sidebarContainer {
   left: 0px;
 }

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -101,7 +101,7 @@ http://sourceforge.net/adobe/cmap/wiki/License/
   <body tabindex="1" class="loadingInProgress">
     <div id="outerContainer">
 
-      <div id="sidebarContainer">
+      <div id="sidebarContainer" class="hidden">
         <div id="toolbarSidebar">
           <div class="splitToolbarButton toggled">
             <button id="viewThumbnail" class="toolbarButton group toggled" title="Show Thumbnails" tabindex="2" data-l10n-id="thumbs">

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1575,8 +1575,13 @@ function webViewerInitialized() {
 
   var mainContainer = document.getElementById('mainContainer');
   var outerContainer = document.getElementById('outerContainer');
+  var sidebarContainer = document.getElementById('sidebarContainer');
+
   mainContainer.addEventListener('transitionend', function(e) {
     if (e.target === mainContainer) {
+      if (!PDFViewerApplication.sidebarOpen) {
+        sidebarContainer.classList.add('hidden');
+      }
       var event = document.createEvent('UIEvents');
       event.initUIEvent('resize', false, false, window, 0);
       window.dispatchEvent(event);
@@ -1587,14 +1592,20 @@ function webViewerInitialized() {
   document.getElementById('sidebarToggle').addEventListener('click',
     function() {
       this.classList.toggle('toggled');
-      outerContainer.classList.add('sidebarMoving');
-      outerContainer.classList.toggle('sidebarOpen');
-      PDFViewerApplication.sidebarOpen =
-        outerContainer.classList.contains('sidebarOpen');
+      var wasSidebarOpen = outerContainer.classList.contains('sidebarOpen');
+      PDFViewerApplication.sidebarOpen = !wasSidebarOpen;
       if (PDFViewerApplication.sidebarOpen) {
+        sidebarContainer.classList.remove('hidden');
         PDFViewerApplication.refreshThumbnailViewer();
       }
+      // The sidebar opening transition does not work if the 'hidden' class is
+      // still active for the sidebar container. The forceRendering() call
+      // between remove('hidden') and toogle('sidebarOpen') seems to provide
+      // enough time for the remove('hidden') statement to complete before
+      // opening the sidebar.
       PDFViewerApplication.forceRendering();
+      outerContainer.classList.add('sidebarMoving');
+      outerContainer.classList.toggle('sidebarOpen');
     });
 
   document.getElementById('viewThumbnail').addEventListener('click',


### PR DESCRIPTION
This PR removes the `visibility: hidden` property from the `sidebarContainer`, and sets the 

```
.hidden { display: none !important }
```

class instead.

The `.hidden` class is added at launch and after the closing transition (at the `transitionend` event) and it is removed before opening the sidebar again. Since the `display: none` property removes the burden of layouting the elements, it is much faster than `visibility: hidden`.

This PR carries the [WIP] label in its title because the `scrollThumbnailIntoView` functionality does not work for `.hidden` elements, but it should work once #5586 is merged (because #5586 calls `scrollThumbnailsIntoView` when the sidebar is opened).

See also the discussion in https://github.com/mozilla/pdf.js/pull/5586#issuecomment-68638537
(Btw, setting the max-size properties did not work).
