### PR TITLE
Move the |pagerendered| event to pdf_page_view.js

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -413,12 +413,20 @@ var PDFPageView = (function PDFPageViewClosure() {
         if (self.onAfterDraw) {
           self.onAfterDraw();
         }
-
         var event = document.createEvent('CustomEvent');
-        event.initCustomEvent('pagerender', true, true, {
-          pageNumber: pdfPage.pageNumber
+        event.initCustomEvent('pagerendered', true, true, {
+          pageNumber: self.id
         });
         div.dispatchEvent(event);
+//#if GENERIC
+        // This custom event is deprecated, and will be removed in the future,
+        // please use the |pagerendered| event instead.
+        var deprecatedEvent = document.createEvent('CustomEvent');
+        deprecatedEvent.initCustomEvent('pagerender', true, true, {
+          pageNumber: pdfPage.pageNumber
+        });
+        div.dispatchEvent(deprecatedEvent);
+//#endif
 
         if (!error) {
           resolveRenderPromise(undefined);

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -244,11 +244,6 @@ var PDFViewer = (function pdfViewer() {
             isOnePageRenderedResolved = true;
             resolveOnePageRendered();
           }
-          var event = document.createEvent('CustomEvent');
-          event.initCustomEvent('pagerendered', true, true, {
-            pageNumber: pageView.id
-          });
-          self.container.dispatchEvent(event);
         };
       };
 


### PR DESCRIPTION
Also deprecates the |pagerender| event, except for GENERIC builds.

This patch implements https://github.com/mozilla/pdf.js/pull/5606#discussion_r22527144, and supersedes #5441.
