### PR TITLE
Whitelists 'tel' schema.

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -310,6 +310,7 @@ function isValidUrl(url, allowRelative) {
     case 'https':
     case 'ftp':
     case 'mailto':
+    case 'tel':
       return true;
     default:
       return false;


### PR DESCRIPTION
Per  http://blogs.adobe.com/acrolaw/2015/01/dial-a-phone-from-a-pdf-link-on-mobile-devices/

http://www.ietf.org/rfc/rfc2806.txt
