### PR TITLE
Refactor searching for end of inline (EI) JPEG image streams

### DIFF
--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -170,6 +170,9 @@ var ChunkedStream = (function ChunkedStreamClosure() {
     getUint16: function ChunkedStream_getUint16() {
       var b0 = this.getByte();
       var b1 = this.getByte();
+      if (b0 === -1 || b1 === -1) {
+        return -1;
+      }
       return (b0 << 8) + b1;
     },
 

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -47,6 +47,9 @@ var Stream = (function StreamClosure() {
     getUint16: function Stream_getUint16() {
       var b0 = this.getByte();
       var b1 = this.getByte();
+      if (b0 === -1 || b1 === -1) {
+        return -1;
+      }
       return (b0 << 8) + b1;
     },
     getInt32: function Stream_getInt32() {
@@ -174,6 +177,9 @@ var DecodeStream = (function DecodeStreamClosure() {
     getUint16: function DecodeStream_getUint16() {
       var b0 = this.getByte();
       var b1 = this.getByte();
+      if (b0 === -1 || b1 === -1) {
+        return -1;
+      }
       return (b0 << 8) + b1;
     },
     getInt32: function DecodeStream_getInt32() {


### PR DESCRIPTION
This patch changes searching for EI image streams to rely on the EOI (end-of-image) marker for DCTDecode filters (i.e. JPEG images).

_Note:_ This code was initially included in PR #5383, but removed from it based on this comment from @yurydelendik: https://github.com/mozilla/pdf.js/pull/5383#discussion_r21834325.
It should be quite easy to, if necessary, ignore that particular marker sequence, but unfortunately I've been unable to find any information about it.
