### PR TITLE
Fixes B2G file open sequence.

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -2301,11 +2301,14 @@ window.addEventListener('afterprint', function afterPrint(evt) {
 //  var fileURL = activity.source.data.url;
 //
 //  var url = URL.createObjectURL(blob);
-//  PDFViewerApplication.open({url : url, originalUrl: fileURL});
+//  // We need to delay opening until all HTML is loaded.
+//  PDFViewerApplication.animationStartedPromise.then(function () {
+//    PDFViewerApplication.open({url : url, originalUrl: fileURL});
 //
-//  var header = document.getElementById('header');
-//  header.addEventListener('action', function() {
-//    activity.postResult('close');
+//    var header = document.getElementById('header');
+//    header.addEventListener('action', function() {
+//      activity.postResult('close');
+//    });
 //  });
 //});
 //#endif


### PR DESCRIPTION
Sometimes during viewer opening, we can get `errorWrapper is undefined` error. Right now it's only with our testing stubs, but could potentially happen on real device.
