### PR TITLE
Fix Uncaught TypeError: Cannot read property 'cleanup' of null

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1097,7 +1097,9 @@ var PDFViewerApplication = {
   cleanup: function pdfViewCleanup() {
     this.pdfViewer.cleanup();
     this.pdfThumbnailViewer.cleanup();
-    this.pdfDocument.cleanup();
+    if (this.pdfDocument) {
+      this.pdfDocument.cleanup();
+    }
   },
 
   forceRendering: function pdfViewForceRendering() {


### PR DESCRIPTION
There's actually another case in viewer.js:

```
  get pagesCount() {
    return this.pdfDocument.numPages;
  },
```

But `this.pdfDocument` is used everywhere, and for some rare cases it's null, and I have no idea why. This is just a simple patch, but I'd like to figure out what the source of the problem is.
