### PR TITLE
Attempt to display the File size quicker in the Document Properties dialog (PR 5554 followup)

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -403,6 +403,10 @@ var PDFViewerApplication = {
 
           PDFViewerApplication.open(args.pdfUrl, 0, undefined,
                                     pdfDataRangeTransport);
+
+          if (args.length) {
+            DocumentProperties.setFileSize(args.length);
+          }
           break;
         case 'range':
           pdfDataRangeTransport.onDataRange(args.begin, args.chunk);


### PR DESCRIPTION
This was initially implemented in PR https://github.com/mozilla/pdf.js/pull/5169#issue-39965479, but due to the refactoring done in PR #5554 it unfortunately stopped working.
