### PR TITLE
Amend the docs for |disableAutoFetch| to mention that streaming must also be disabled

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -99,6 +99,9 @@ PDFJS.disableStream = (PDFJS.disableStream === undefined ?
  * Disable pre-fetching of PDF file data. When range requests are enabled PDF.js
  * will automatically keep fetching more data even if it isn't needed to display
  * the current page. This default behavior can be disabled.
+ *
+ * NOTE: It is also necessary to disable streaming, see above,
+ *       in order for disabling of pre-fetching to work correctly.
  * @var {boolean}
  */
 PDFJS.disableAutoFetch = (PDFJS.disableAutoFetch === undefined ?


### PR DESCRIPTION
The fact that `disableStream = true` is necessary for `disableAutoFetch = true` to work, is something that I initially overlooked myself (see #5371).

It now appears that users of PDF.js are beginning to facing the same issue, see e.g. https://github.com/mozilla/pdf.js/issues/3811#issuecomment-69908211 and [IRC log](http://logs.glob.uno/?c=mozilla%23pdfjs&s=4+Dec+2014&e=4+Dec+2014&h=disableautofetch#c27695).

We should perhaps look into if we need to make any code changes to make the current situation clearer, e.g. https://github.com/mozilla/pdf.js/pull/5371#issuecomment-57490530, but in the meantime lets at least add a note about it in the docs.
