### PR TITLE
Avoid getting stuck in empty nodes in the Pages tree when calling |Catalog_getPageDict| (issue 5644)

### DIFF
--- a/test/pdfs/issue5644.pdf.link
+++ b/test/pdfs/issue5644.pdf.link
@@ -1,0 +1,1 @@
+http://web.archive.org/web/20140703204310/http://repository.readscheme.org/ftp/papers/sw2010/06-barland.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -812,6 +812,15 @@
        "link": false,
        "type": "eq"
     },
+    {  "id": "issue5644",
+       "file": "pdfs/issue5644.pdf",
+       "md5": "6f9313c5043b3ecb0ab2df321d3e1847",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 1,
+       "lastPage": 6,
+       "type": "eq"
+    },
     {  "id": "bug866395",
        "file": "pdfs/bug866395.pdf",
        "md5": "f03bc77e84637241980b09a0a220f575",


### PR DESCRIPTION
This is a tentative patch that fixes #5644.

The issue with the referenced PDF file is that the `Pages` dictionary contains a number of empty `Kids`, and we were getting stuck in those nodes before reaching the actual pages.

~~As far as I can tell [this code is just an optimization](https://github.com/mozilla/pdf.js/blob/master/src/core/obj.js#L636), to avoid what is usually a number of unnecessary iterations, but isn't strictly necessary. The only way I could find to solve the particular issue referenced, and to avoid similar issues in the future, was to remove that code path. This might mean that the lookup becomes a _tiny_ bit slower in very large files, but I unfortunately found no other way to fix the issue (hence why I'm labelling this as a tentative patch).~~

**Edit:** Removing [this optimization](https://github.com/mozilla/pdf.js/blob/master/src/core/obj.js#L636), as the first version of the patch did, would be bad for performance reasons (especially with ranged loading). Hence I've submitted a new, and hopefully better, version of the patch that only checks all `Kids` if we've actually encountered an empty node.

I've checked a large number of the PDF files in the test suite, especially the longer ones (where the performance penalty would be especially bad), and didn't find any file where the special case introduced in this patch was actually hit.

_Note:_ I'm adding an `eq` test, to ensure that we actually find the _correct_ page for each `pageIndex`.
