### PR TITLE
Fix thumbnail rendering regression, when using |draw|, for PDF files with blend modes (issue 5637)

### DIFF
--- a/web/thumbnail_view.js
+++ b/web/thumbnail_view.js
@@ -127,12 +127,7 @@ var ThumbnailView = function thumbnailView(container, id, defaultViewport,
 
     ring.appendChild(canvas);
 
-    var ctx = canvas.getContext('2d');
-    ctx.save();
-    ctx.fillStyle = 'rgb(255, 255, 255)';
-    ctx.fillRect(0, 0, this.canvasWidth, this.canvasHeight);
-    ctx.restore();
-    return ctx;
+    return canvas.getContext('2d');
   };
 
   this.drawingRequired = function thumbnailViewDrawingRequired() {

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1124,6 +1124,8 @@ html[dir='rtl'] .verticalToolbarSeparator {
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5), 0 2px 8px rgba(0, 0, 0, 0.3);
   opacity: 0.8;
   z-index: 99;
+  background-color: white;
+  background-clip: content-box;
 }
 
 .thumbnailSelectionRing {


### PR DESCRIPTION
Tentative patch that fixes the _second_ part of #5637; thorough testing is needed!
This patch basically changes the `thumbnail` code to be more in line with the corresponding `page` code.
