### PR TITLE
Remove unused viewer-snippet-b2g-activity-header.html

### DIFF
--- a/web/viewer-snippet-b2g-activity-header.html
+++ b/web/viewer-snippet-b2g-activity-header.html
@@ -1,6 +1,0 @@
-<section role="region" id="activityHeader" class="skin-organic">
-  <header>
-    <button id="activityClose"><span class="icon icon-close"></span></button>
-    <h1 id="activityTitle"></h1>
-  </header>
-</section>


### PR DESCRIPTION
This file has been made obsolete by https://github.com/mozilla/pdf.js/commit/fd4e40c82b3372fcfcbcb33877d8388f3b8c37c6#diff-5dba6a2f9a0235d9e5b2b75ef5a6f774R42 which already included this code in the B2G-specific viewer. On top of that, the code is also old because it has been replaced in https://github.com/mozilla/pdf.js/commit/d8bc16362cc42c7c30fe5874501f51e29a41389f.
