### PR TITLE
Remove obselete file from .gitignore

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,4 +1,3 @@
-viewer-production.html
 locale.properties
 locale/
 cmaps/


### PR DESCRIPTION
Has been introduced almost 3.5 years ago in https://github.com/mozilla/pdf.js/commit/0075007d49cd2fcc6e24fe38d58ec525d6a675af, but since the production process has changed a lot since then this file has been obsolete for a very long time.
