### PR TITLE
Make sure that an A entry in an annotation dictionary is also a dictionary itself

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -485,7 +485,7 @@ var LinkAnnotation = (function LinkAnnotationClosure() {
     data.annotationType = AnnotationType.LINK;
 
     var action = dict.get('A');
-    if (action) {
+    if (action && isDict(action)) {
       var linkType = action.get('S').name;
       if (linkType === 'URI') {
         var url = action.get('URI');


### PR DESCRIPTION
Fixes #5683.

According to https://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/pdf_reference_1-7.pdf#page=647&zoom=auto,-246,56 an `A` entry in an annotation dictionary _must_ also be a dictionary itself. The current code just assumes that, but some (corrupted) PDFs violate that standard. This patch makes sure to check that the `A` entry is actually a dictionary before trying to get properties from it (on https://github.com/mozilla/pdf.js/blob/master/src/core/annotation.js#L489 which assumes we are dealing with a valid dictionary).
