### PR TITLE
Use the |shadow| function from src/shared/util.js in viewer.js

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -325,6 +325,7 @@ function shadow(obj, prop, value) {
                                      writable: false });
   return value;
 }
+PDFJS.shadow = shadow;
 
 var PasswordResponses = PDFJS.PasswordResponses = {
   NEED_PASSWORD: 1,

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -320,8 +320,7 @@ var PDFViewerApplication = {
 
   get supportsIntegratedFind() {
     var support = false;
-//#if !(FIREFOX || MOZCENTRAL)
-//#else
+//#if (FIREFOX || MOZCENTRAL)
 //  support = FirefoxCom.requestSync('supportsIntegratedFind');
 //#endif
 
@@ -330,8 +329,7 @@ var PDFViewerApplication = {
 
   get supportsDocumentFonts() {
     var support = true;
-//#if !(FIREFOX || MOZCENTRAL)
-//#else
+//#if (FIREFOX || MOZCENTRAL)
 //  support = FirefoxCom.requestSync('supportsDocumentFonts');
 //#endif
 
@@ -340,8 +338,7 @@ var PDFViewerApplication = {
 
   get supportsDocumentColors() {
     var support = true;
-//#if !(FIREFOX || MOZCENTRAL)
-//#else
+//#if (FIREFOX || MOZCENTRAL)
 //  support = FirefoxCom.requestSync('supportsDocumentColors');
 //#endif
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -299,12 +299,8 @@ var PDFViewerApplication = {
   get supportsPrinting() {
     var canvas = document.createElement('canvas');
     var value = 'mozPrintCallback' in canvas;
-    // shadow
-    Object.defineProperty(this, 'supportsPrinting', { value: value,
-                                                      enumerable: true,
-                                                      configurable: true,
-                                                      writable: false });
-    return value;
+
+    return PDFJS.shadow(this, 'supportsPrinting', value);
   },
 
   get supportsFullscreen() {
@@ -319,11 +315,7 @@ var PDFViewerApplication = {
       support = false;
     }
 
-    Object.defineProperty(this, 'supportsFullscreen', { value: support,
-                                                        enumerable: true,
-                                                        configurable: true,
-                                                        writable: false });
-    return support;
+    return PDFJS.shadow(this, 'supportsFullscreen', support);
   },
 
   get supportsIntegratedFind() {
@@ -332,11 +324,8 @@ var PDFViewerApplication = {
 //#else
 //  support = FirefoxCom.requestSync('supportsIntegratedFind');
 //#endif
-    Object.defineProperty(this, 'supportsIntegratedFind', { value: support,
-                                                            enumerable: true,
-                                                            configurable: true,
-                                                            writable: false });
-    return support;
+
+    return PDFJS.shadow(this, 'supportsIntegratedFind', support);
   },
 
   get supportsDocumentFonts() {
@@ -345,11 +334,8 @@ var PDFViewerApplication = {
 //#else
 //  support = FirefoxCom.requestSync('supportsDocumentFonts');
 //#endif
-    Object.defineProperty(this, 'supportsDocumentFonts', { value: support,
-                                                           enumerable: true,
-                                                           configurable: true,
-                                                           writable: false });
-    return support;
+
+    return PDFJS.shadow(this, 'supportsDocumentFonts', support);
   },
 
   get supportsDocumentColors() {
@@ -358,20 +344,14 @@ var PDFViewerApplication = {
 //#else
 //  support = FirefoxCom.requestSync('supportsDocumentColors');
 //#endif
-    Object.defineProperty(this, 'supportsDocumentColors', { value: support,
-                                                            enumerable: true,
-                                                            configurable: true,
-                                                            writable: false });
-    return support;
+
+    return PDFJS.shadow(this, 'supportsDocumentColors', support);
   },
 
   get loadingBar() {
     var bar = new ProgressBar('#loadingBar', {});
-    Object.defineProperty(this, 'loadingBar', { value: bar,
-                                                enumerable: true,
-                                                configurable: true,
-                                                writable: false });
-    return bar;
+
+    return PDFJS.shadow(this, 'loadingBar', bar);
   },
 
 //#if (FIREFOX || MOZCENTRAL)


### PR DESCRIPTION
While working on refactoring the `PresentationMode` code, I noticed that in viewer.js we currently repeat the same "shadowing" code six times. Since this is a _verbatim_ copy of https://github.com/mozilla/pdf.js/blob/master/src/shared/util.js#L321, I think it makes sense to just use that function instead.
