### PR TITLE
[l10n] Treat language as case-insensitive

### DIFF
--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -447,20 +447,10 @@ if (typeof PDFJS === 'undefined') {
 
 // Checks if navigator.language is supported
 (function checkNavigatorLanguage() {
-  if ('language' in navigator &&
-      /^[a-z]+(-[A-Z]+)?$/.test(navigator.language)) {
+  if ('language' in navigator) {
     return;
   }
-  function formatLocale(locale) {
-    var split = locale.split(/[-_]/);
-    split[0] = split[0].toLowerCase();
-    if (split.length > 1) {
-      split[1] = split[1].toUpperCase();
-    }
-    return split.join('-');
-  }
-  var language = navigator.language || navigator.userLanguage || 'en-US';
-  PDFJS.locale = formatLocale(language);
+  PDFJS.locale = navigator.userLanguage || 'en-US';
 })();
 
 (function checkRangeRequests() {


### PR DESCRIPTION
RFC 4646 specifies that language tags should be treated case-insensitively, so the previous work-around to #4335 is insufficient: The patch should not be added to compatibility.js, but become a part of the l10n library.

See "Case-insensitive language comparisons per RFC 4646" @ https://github.com/fabi1cazenave/webL10n/pull/51

(I've created this patch because I've noticed that `navigator.language` is lowercase in Chrome 40: https://code.google.com/p/chromium/issues/detail?id=454331)
