### PR TITLE
Refactor the Presentation Mode code

### DIFF
--- a/web/hand_tool.js
+++ b/web/hand_tool.js
@@ -51,6 +51,17 @@ var HandTool = {
           }
         }.bind(this), function rejected(reason) {});
       }.bind(this));
+
+      window.addEventListener('presentationmodechanged', function (evt) {
+        if (evt.detail.switchInProgress) {
+          return;
+        }
+        if (evt.detail.active) {
+          this.enterPresentationMode();
+        } else {
+          this.exitPresentationMode();
+        }
+      }.bind(this));
     }
   },
 

--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS, PresentationMode */
 
 'use strict';
 
@@ -31,6 +30,7 @@ var PDFHistory = {
     this.reInitialized = false;
     this.allowHashChange = true;
     this.historyUnlocked = true;
+    this.isViewerInPresentationMode = false;
 
     this.previousHash = window.location.hash.substring(1);
     this.currentBookmark = '';
@@ -122,6 +122,10 @@ var PDFHistory = {
       // the 'DOMContentLoaded' event is not fired on 'pageshow'.
       window.addEventListener('beforeunload', pdfHistoryBeforeUnload, false);
     }, false);
+
+    window.addEventListener('presentationmodechanged', function(e) {
+      self.isViewerInPresentationMode = !!e.detail.active;
+    });
   },
 
   _isStateObjectDefined: function pdfHistory_isStateObjectDefined(state) {
@@ -286,7 +290,7 @@ var PDFHistory = {
       return null;
     }
     var params = { hash: this.currentBookmark, page: this.currentPage };
-    if (PresentationMode.active) {
+    if (this.isViewerInPresentationMode) {
       params.hash = null;
     }
     return params;

--- a/web/pdf_presentation_mode.js
+++ b/web/pdf_presentation_mode.js
@@ -18,9 +18,9 @@
 
 'use strict';
 
+var DELAY_BEFORE_RESETTING_SWITCH_IN_PROGRESS = 1500; // in ms
 var DELAY_BEFORE_HIDING_CONTROLS = 3000; // in ms
 var SELECTOR = 'presentationControls';
-var DELAY_BEFORE_RESETTING_SWITCH_IN_PROGRESS = 1000; // in ms
 
 /**
  * @typedef {Object} PDFPresentationModeOptions
@@ -32,30 +32,25 @@ var DELAY_BEFORE_RESETTING_SWITCH_IN_PROGRESS = 1000; // in ms
  *   to the context menu in Presentation Mode.
  */
 
-var PDFPresentationMode = {
-  initialized: false,
-  active: false,
-  args: null,
-  contextMenuOpen: false,
-  mouseScrollTimeStamp: 0,
-  mouseScrollDelta: 0,
-
+/**
+ * @class
+ */
+var PDFPresentationMode = (function PDFPresentationModeClosure() {
   /**
+   * @constructs PDFPresentationMode
    * @param {PDFPresentationModeOptions} options
    */
-  initialize: function pdfPresentationModeInitialize(options) {
-    this.initialized = true;
+  function PDFPresentationMode(options) {
     this.container = options.container;
     this.viewer = options.viewer || options.container.firstElementChild;
     this.pdfThumbnailViewer = options.pdfThumbnailViewer || null;
     var contextMenuItems = options.contextMenuItems || null;
 
-    window.addEventListener('fullscreenchange', this._fullscreenChange);
-    window.addEventListener('mozfullscreenchange', this._fullscreenChange);
-//#if !(FIREFOX || MOZCENTRAL)
-    window.addEventListener('webkitfullscreenchange', this._fullscreenChange);
-    window.addEventListener('MSFullscreenChange', this._fullscreenChange);
-//#endif
+    this.active = false;
+    this.args = null;
+    this.contextMenuOpen = false;
+    this.mouseScrollTimeStamp = 0;
+    this.mouseScrollDelta = 0;
 
     if (contextMenuItems) {
       for (var i = 0, ii = contextMenuItems.length; i < ii; i++) {
@@ -66,276 +61,336 @@ var PDFPresentationMode = {
         }.bind(this, item.handler));
       }
     }
-  },
+  }
 
-  /**
-   * Request the browser to enter fullscreen mode.
-   * @returns {boolean} Indicating if the request was successful.
-   */
-  request: function pdfPresentationModeRequest() {
-    if (!this.initialized || this.switchInProgress || this.active ||
-        !this.viewer.hasChildNodes()) {
-      return false;
-    }
-    this._setSwitchInProgress();
-    this._notifyStateChange();
+  PDFPresentationMode.prototype = {
+    /**
+     * Request the browser to enter fullscreen mode.
+     * @returns {boolean} Indicating if the request was successful.
+     */
+    request: function PDFPresentationMode_request() {
+      if (this.switchInProgress || this.active ||
+          !this.viewer.hasChildNodes()) {
+        return false;
+      }
+      this._addFullscreenChangeListeners();
+      this._setSwitchInProgress();
+      this._notifyStateChange();
 
-    if (this.container.requestFullscreen) {
-      this.container.requestFullscreen();
-    } else if (this.container.mozRequestFullScreen) {
-      this.container.mozRequestFullScreen();
-    } else if (this.container.webkitRequestFullscreen) {
-      this.container.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
-    } else if (this.container.msRequestFullscreen) {
-      this.container.msRequestFullscreen();
-    } else {
-      return false;
-    }
+      if (this.container.requestFullscreen) {
+        this.container.requestFullscreen();
+      } else if (this.container.mozRequestFullScreen) {
+        this.container.mozRequestFullScreen();
+      } else if (this.container.webkitRequestFullscreen) {
+        this.container.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
+      } else if (this.container.msRequestFullscreen) {
+        this.container.msRequestFullscreen();
+      } else {
+        return false;
+      }
 
-    this.args = {
-      page: PDFViewerApplication.page,
-      previousScale: PDFViewerApplication.currentScaleValue
-    };
+      this.args = {
+        page: PDFViewerApplication.page,
+        previousScale: PDFViewerApplication.currentScaleValue
+      };
 
-    return true;
-  },
+      return true;
+    },
 
-  /**
-   * Switches page when the user scrolls (using a scroll wheel or a touchpad)
-   * with large enough motion, to prevent accidental page switches.
-   * @param {number} delta - The delta value from the mouse event.
-   */
-  mouseScroll: function pdfPresentationModeMouseScroll(delta) {
-    if (!this.initialized && !this.active) {
-      return;
-    }
-    var MOUSE_SCROLL_COOLDOWN_TIME = 50;
-    var PAGE_SWITCH_THRESHOLD = 120;
-    var PageSwitchDirection = {
-      UP: -1,
-      DOWN: 1
-    };
-
-    var currentTime = (new Date()).getTime();
-    var storedTime = this.mouseScrollTimeStamp;
-
-    // If we've already switched page, avoid accidentally switching page again.
-    if (currentTime > storedTime &&
-        currentTime - storedTime < MOUSE_SCROLL_COOLDOWN_TIME) {
-      return;
-    }
-    // If the user changes scroll direction, reset the accumulated scroll delta.
-    if ((this.mouseScrollDelta > 0 && delta < 0) ||
-        (this.mouseScrollDelta < 0 && delta > 0)) {
-      this._resetMouseScrollState();
-    }
-    this.mouseScrollDelta += delta;
-
-    if (Math.abs(this.mouseScrollDelta) >= PAGE_SWITCH_THRESHOLD) {
-      var pageSwitchDirection = (this.mouseScrollDelta > 0) ?
-        PageSwitchDirection.UP : PageSwitchDirection.DOWN;
-      var page = PDFViewerApplication.page;
-      this._resetMouseScrollState();
-
-      // If we're already on the first/last page, we don't need to do anything.
-      if ((page === 1 && pageSwitchDirection === PageSwitchDirection.UP) ||
-          (page === PDFViewerApplication.pagesCount &&
-           pageSwitchDirection === PageSwitchDirection.DOWN)) {
+    /**
+     * Switches page when the user scrolls (using a scroll wheel or a touchpad)
+     * with large enough motion, to prevent accidental page switches.
+     * @param {number} delta - The delta value from the mouse event.
+     */
+    mouseScroll: function PDFPresentationMode_mouseScroll(delta) {
+      if (!this.active) {
         return;
       }
-      PDFViewerApplication.page = (page + pageSwitchDirection);
-      this.mouseScrollTimeStamp = currentTime;
-    }
-  },
+      var MOUSE_SCROLL_COOLDOWN_TIME = 50;
+      var PAGE_SWITCH_THRESHOLD = 120;
+      var PageSwitchDirection = {
+        UP: -1,
+        DOWN: 1
+      };
 
-  get isFullscreen() {
-    return !!(document.fullscreenElement ||
-              document.mozFullScreen ||
-              document.webkitIsFullScreen ||
-              document.msFullscreenElement);
-  },
+      var currentTime = (new Date()).getTime();
+      var storedTime = this.mouseScrollTimeStamp;
 
-  /**
-   * @private
-   */
-  _fullscreenChange: function pdfPresentationModeFullscreenChange() {
-    var self = PDFPresentationMode;
-    if (self.isFullscreen) {
-      self._enter();
-    } else {
-      self._exit();
-    }
-  },
-
-  /**
-   * @private
-   */
-  _notifyStateChange: function pdfPresentationModeNotifyStateChange() {
-    var self = PDFPresentationMode;
-    var event = document.createEvent('CustomEvent');
-    event.initCustomEvent('presentationmodechanged', true, true, {
-      active: self.active,
-      switchInProgress: !!self.switchInProgress
-    });
-    window.dispatchEvent(event);
-  },
-
-  /**
-   * Used to initialize a timeout when requesting Presentation Mode,
-   * i.e. when the browser is requested to enter fullscreen mode.
-   * This timeout is used to prevent the current page from being scrolled
-   * partially, or completely, out of view when entering Presentation Mode.
-   * NOTE: This issue seems limited to certain zoom levels (e.g. 'page-width').
-   * @private
-   */
-  _setSwitchInProgress: function pdfPresentationMode_setSwitchInProgress() {
-    if (this.switchInProgress) {
-      clearTimeout(this.switchInProgress);
-    }
-    this.switchInProgress = setTimeout(function switchInProgressTimeout() {
-      delete this.switchInProgress;
-      this._notifyStateChange();
-    }.bind(this), DELAY_BEFORE_RESETTING_SWITCH_IN_PROGRESS);
-  },
-
-  /**
-   * @private
-   */
-  _resetSwitchInProgress: function pdfPresentationMode_resetSwitchInProgress() {
-    if (this.switchInProgress) {
-      clearTimeout(this.switchInProgress);
-      delete this.switchInProgress;
-    }
-  },
-
-  /**
-   * @private
-   */
-  _enter: function pdfPresentationModeEnter() {
-    this.active = true;
-    this._resetSwitchInProgress();
-    this._notifyStateChange();
-
-    // Ensure that the correct page is scrolled into view when entering
-    // Presentation Mode, by waiting until fullscreen mode in enabled.
-    setTimeout(function enterPresentationModeTimeout() {
-      PDFViewerApplication.page = this.args.page;
-      PDFViewerApplication.setScale('page-fit', true);
-    }.bind(this), 0);
-
-    window.addEventListener('mousemove', this._showControls, false);
-    window.addEventListener('mousedown', this._mouseDown, false);
-    window.addEventListener('keydown', this._resetMouseScrollState, false);
-    window.addEventListener('contextmenu', this._contextMenu, false);
-
-    this._showControls();
-    this.contextMenuOpen = false;
-    this.container.setAttribute('contextmenu', 'viewerContextMenu');
-
-    // Text selection is disabled in Presentation Mode, thus it's not possible
-    // for the user to deselect text that is selected (e.g. with "Select all")
-    // when entering Presentation Mode, hence we remove any active selection.
-    window.getSelection().removeAllRanges();
-  },
-
-  /**
-   * @private
-   */
-  _exit: function pdfPresentationModeExit() {
-    var page = PDFViewerApplication.page;
-
-    // Ensure that the correct page is scrolled into view when exiting
-    // Presentation Mode, by waiting until fullscreen mode is disabled.
-    setTimeout(function exitPresentationModeTimeout() {
-      this.active = false;
-      this._notifyStateChange();
-
-      PDFViewerApplication.setScale(this.args.previousScale, true);
-      PDFViewerApplication.page = page;
-      this.args = null;
-    }.bind(this), 0);
-
-    window.removeEventListener('mousemove', this._showControls, false);
-    window.removeEventListener('mousedown', this._mouseDown, false);
-    window.removeEventListener('keydown', this._resetMouseScrollState, false);
-    window.removeEventListener('contextmenu', this._contextMenu, false);
-
-    this._hideControls();
-    this._resetMouseScrollState();
-    this.container.removeAttribute('contextmenu');
-    this.contextMenuOpen = false;
-
-    if (this.pdfThumbnailViewer) {
-      this.pdfThumbnailViewer.ensureThumbnailVisible(page);
-    }
-  },
-
-  /**
-   * @private
-   */
-  _mouseDown: function pdfPresentationModeMouseDown(evt) {
-    var self = PDFPresentationMode;
-    if (self.contextMenuOpen) {
-      self.contextMenuOpen = false;
-      evt.preventDefault();
-      return;
-    }
-    if (evt.button === 0) {
-      // Enable clicking of links in presentation mode. Please note:
-      // Only links pointing to destinations in the current PDF document work.
-      var isInternalLink = (evt.target.href &&
-                            evt.target.classList.contains('internalLink'));
-      if (!isInternalLink) {
-        // Unless an internal link was clicked, advance one page.
-        evt.preventDefault();
-        PDFViewerApplication.page += (evt.shiftKey ? -1 : 1);
+      // If we've already switched page, avoid accidentally switching again.
+      if (currentTime > storedTime &&
+          currentTime - storedTime < MOUSE_SCROLL_COOLDOWN_TIME) {
+        return;
       }
+      // If the scroll direction changed, reset the accumulated scroll delta.
+      if ((this.mouseScrollDelta > 0 && delta < 0) ||
+          (this.mouseScrollDelta < 0 && delta > 0)) {
+        this._resetMouseScrollState();
+      }
+      this.mouseScrollDelta += delta;
+
+      if (Math.abs(this.mouseScrollDelta) >= PAGE_SWITCH_THRESHOLD) {
+        var pageSwitchDirection = (this.mouseScrollDelta > 0) ?
+          PageSwitchDirection.UP : PageSwitchDirection.DOWN;
+        var page = PDFViewerApplication.page;
+        this._resetMouseScrollState();
+
+        // If we're at the first/last page, we don't need to do anything.
+        if ((page === 1 && pageSwitchDirection === PageSwitchDirection.UP) ||
+            (page === PDFViewerApplication.pagesCount &&
+             pageSwitchDirection === PageSwitchDirection.DOWN)) {
+          return;
+        }
+        PDFViewerApplication.page = (page + pageSwitchDirection);
+        this.mouseScrollTimeStamp = currentTime;
+      }
+    },
+
+    get isFullscreen() {
+      return !!(document.fullscreenElement ||
+                document.mozFullScreen ||
+                document.webkitIsFullScreen ||
+                document.msFullscreenElement);
+    },
+
+    /**
+     * @private
+     */
+    _notifyStateChange: function PDFPresentationMode_notifyStateChange() {
+      var event = document.createEvent('CustomEvent');
+      event.initCustomEvent('presentationmodechanged', true, true, {
+        active: this.active,
+        switchInProgress: !!this.switchInProgress
+      });
+      window.dispatchEvent(event);
+    },
+
+    /**
+     * Used to initialize a timeout when requesting Presentation Mode,
+     * i.e. when the browser is requested to enter fullscreen mode.
+     * This timeout is used to prevent the current page from being scrolled
+     * partially, or completely, out of view when entering Presentation Mode.
+     * NOTE: This issue seems limited to certain zoom levels (e.g. page-width).
+     * @private
+     */
+    _setSwitchInProgress: function PDFPresentationMode_setSwitchInProgress() {
+      if (this.switchInProgress) {
+        clearTimeout(this.switchInProgress);
+      }
+      this.switchInProgress = setTimeout(function switchInProgressTimeout() {
+        this._removeFullscreenChangeListeners();
+        delete this.switchInProgress;
+        this._notifyStateChange();
+      }.bind(this), DELAY_BEFORE_RESETTING_SWITCH_IN_PROGRESS);
+    },
+
+    /**
+     * @private
+     */
+    _resetSwitchInProgress:
+        function PDFPresentationMode_resetSwitchInProgress() {
+      if (this.switchInProgress) {
+        clearTimeout(this.switchInProgress);
+        delete this.switchInProgress;
+      }
+    },
+
+    /**
+     * @private
+     */
+    _enter: function PDFPresentationMode_enter() {
+      this.active = true;
+      this._resetSwitchInProgress();
+      this._notifyStateChange();
+
+      // Ensure that the correct page is scrolled into view when entering
+      // Presentation Mode, by waiting until fullscreen mode in enabled.
+      setTimeout(function enterPresentationModeTimeout() {
+        PDFViewerApplication.page = this.args.page;
+        PDFViewerApplication.setScale('page-fit', true);
+      }.bind(this), 0);
+
+      this._addWindowListeners();
+      this._showControls();
+      this.contextMenuOpen = false;
+      this.container.setAttribute('contextmenu', 'viewerContextMenu');
+
+      // Text selection is disabled in Presentation Mode, thus it's not possible
+      // for the user to deselect text that is selected (e.g. with "Select all")
+      // when entering Presentation Mode, hence we remove any active selection.
+      window.getSelection().removeAllRanges();
+    },
+
+    /**
+     * @private
+     */
+    _exit: function PDFPresentationMode_exit() {
+      var page = PDFViewerApplication.page;
+
+      // Ensure that the correct page is scrolled into view when exiting
+      // Presentation Mode, by waiting until fullscreen mode is disabled.
+      setTimeout(function exitPresentationModeTimeout() {
+        this.active = false;
+        this._removeFullscreenChangeListeners();
+        this._notifyStateChange();
+
+        PDFViewerApplication.setScale(this.args.previousScale, true);
+        PDFViewerApplication.page = page;
+        this.args = null;
+      }.bind(this), 0);
+
+      this._removeWindowListeners();
+      this._hideControls();
+      this._resetMouseScrollState();
+      this.container.removeAttribute('contextmenu');
+      this.contextMenuOpen = false;
+
+      if (this.pdfThumbnailViewer) {
+        this.pdfThumbnailViewer.ensureThumbnailVisible(page);
+      }
+    },
+
+    /**
+     * @private
+     */
+    _mouseDown: function PDFPresentationMode_mouseDown(evt) {
+      if (this.contextMenuOpen) {
+        this.contextMenuOpen = false;
+        evt.preventDefault();
+        return;
+      }
+      if (evt.button === 0) {
+        // Enable clicking of links in presentation mode. Please note:
+        // Only links pointing to destinations in the current PDF document work.
+        var isInternalLink = (evt.target.href &&
+                              evt.target.classList.contains('internalLink'));
+        if (!isInternalLink) {
+          // Unless an internal link was clicked, advance one page.
+          evt.preventDefault();
+          PDFViewerApplication.page += (evt.shiftKey ? -1 : 1);
+        }
+      }
+    },
+
+    /**
+     * @private
+     */
+    _contextMenu: function PDFPresentationMode_contextMenu() {
+      this.contextMenuOpen = true;
+    },
+
+    /**
+     * @private
+     */
+    _showControls: function PDFPresentationMode_showControls() {
+      if (this.controlsTimeout) {
+        clearTimeout(this.controlsTimeout);
+      } else {
+        this.container.classList.add(SELECTOR);
+      }
+      this.controlsTimeout = setTimeout(function showControlsTimeout() {
+        this.container.classList.remove(SELECTOR);
+        delete this.controlsTimeout;
+      }.bind(this), DELAY_BEFORE_HIDING_CONTROLS);
+    },
+
+    /**
+     * @private
+     */
+    _hideControls: function PDFPresentationMode_hideControls() {
+      if (!this.controlsTimeout) {
+        return;
+      }
+      clearTimeout(this.controlsTimeout);
+      this.container.classList.remove(SELECTOR);
+      delete this.controlsTimeout;
+    },
+
+    /**
+     * Resets the properties used for tracking mouse scrolling events.
+     * @private
+     */
+    _resetMouseScrollState:
+        function PDFPresentationMode_resetMouseScrollState() {
+      this.mouseScrollTimeStamp = 0;
+      this.mouseScrollDelta = 0;
+    },
+
+    /**
+     * @private
+     */
+    _addWindowListeners: function PDFPresentationMode_addWindowListeners() {
+      this.showControlsBind = this._showControls.bind(this);
+      this.mouseDownBind = this._mouseDown.bind(this);
+      this.resetMouseScrollStateBind = this._resetMouseScrollState.bind(this);
+      this.contextMenuBind = this._contextMenu.bind(this);
+
+      window.addEventListener('mousemove', this.showControlsBind);
+      window.addEventListener('mousedown', this.mouseDownBind);
+      window.addEventListener('keydown', this.resetMouseScrollStateBind);
+      window.addEventListener('contextmenu', this.contextMenuBind);
+    },
+
+    /**
+     * @private
+     */
+    _removeWindowListeners:
+        function PDFPresentationMode_removeWindowListeners() {
+      window.removeEventListener('mousemove', this.showControlsBind);
+      window.removeEventListener('mousedown', this.mouseDownBind);
+      window.removeEventListener('keydown', this.resetMouseScrollStateBind);
+      window.removeEventListener('contextmenu', this.contextMenuBind);
+
+      delete this.showControlsBind;
+      delete this.mouseDownBind;
+      delete this.resetMouseScrollStateBind;
+      delete this.contextMenuBind;
+    },
+
+    /**
+     * @private
+     */
+    _fullscreenChange: function PDFPresentationMode_fullscreenChange() {
+      if (this.isFullscreen) {
+        this._enter();
+      } else {
+        this._exit();
+      }
+    },
+
+    /**
+     * @private
+     */
+    _addFullscreenChangeListeners:
+        function PDFPresentationMode_addFullscreenChangeListeners() {
+      this.fullscreenChangeBind = this._fullscreenChange.bind(this);
+
+      window.addEventListener('fullscreenchange', this.fullscreenChangeBind);
+      window.addEventListener('mozfullscreenchange', this.fullscreenChangeBind);
+//#if !(FIREFOX || MOZCENTRAL)
+      window.addEventListener('webkitfullscreenchange',
+                              this.fullscreenChangeBind);
+      window.addEventListener('MSFullscreenChange', this.fullscreenChangeBind);
+//#endif
+    },
+
+    /**
+     * @private
+     */
+    _removeFullscreenChangeListeners:
+        function PDFPresentationMode_removeFullscreenChangeListeners() {
+      window.removeEventListener('fullscreenchange', this.fullscreenChangeBind);
+      window.removeEventListener('mozfullscreenchange',
+                                 this.fullscreenChangeBind);
+//#if !(FIREFOX || MOZCENTRAL)
+      window.removeEventListener('webkitfullscreenchange',
+                              this.fullscreenChangeBind);
+      window.removeEventListener('MSFullscreenChange',
+                                 this.fullscreenChangeBind);
+//#endif
+
+      delete this.fullscreenChangeBind;
     }
-  },
+  };
 
-  /**
-   * @private
-   */
-  _contextMenu: function pdfPresentationModeContextMenu(evt) {
-    PDFPresentationMode.contextMenuOpen = true;
-  },
-
-  /**
-   * @private
-   */
-  _showControls: function pdfPresentationModeShowControls() {
-    var self = PDFPresentationMode;
-    if (self.controlsTimeout) {
-      clearTimeout(self.controlsTimeout);
-    } else {
-      self.container.classList.add(SELECTOR);
-    }
-    self.controlsTimeout = setTimeout(function showControlsTimeout() {
-      self.container.classList.remove(SELECTOR);
-      delete self.controlsTimeout;
-    }, DELAY_BEFORE_HIDING_CONTROLS);
-  },
-
-  /**
-   * @private
-   */
-  _hideControls: function pdfPresentationModeHideControls() {
-    var self = PDFPresentationMode;
-    if (!self.controlsTimeout) {
-      return;
-    }
-    clearTimeout(self.controlsTimeout);
-    self.container.classList.remove(SELECTOR);
-    delete self.controlsTimeout;
-  },
-
-  /**
-   * Resets the properties used for tracking mouse scrolling events.
-   * @private
-   */
-  _resetMouseScrollState: function pdfPresentationModeResetMouseScrollState() {
-    var self = PDFPresentationMode;
-    self.mouseScrollTimeStamp = 0;
-    self.mouseScrollDelta = 0;
-  }
-};
+  return PDFPresentationMode;
+})();

--- a/web/pdf_presentation_mode.js
+++ b/web/pdf_presentation_mode.js
@@ -20,7 +20,8 @@
 
 var DELAY_BEFORE_RESETTING_SWITCH_IN_PROGRESS = 1500; // in ms
 var DELAY_BEFORE_HIDING_CONTROLS = 3000; // in ms
-var SELECTOR = 'presentationControls';
+var ACTIVE_SELECTOR = 'pdfPresentationMode';
+var CONTROLS_SELECTOR = 'pdfPresentationModeControls';
 
 /**
  * @typedef {Object} PDFPresentationModeOptions
@@ -201,6 +202,7 @@ var PDFPresentationMode = (function PDFPresentationModeClosure() {
       this.active = true;
       this._resetSwitchInProgress();
       this._notifyStateChange();
+      this.container.classList.add(ACTIVE_SELECTOR);
 
       // Ensure that the correct page is scrolled into view when entering
       // Presentation Mode, by waiting until fullscreen mode in enabled.
@@ -225,6 +227,7 @@ var PDFPresentationMode = (function PDFPresentationModeClosure() {
      */
     _exit: function PDFPresentationMode_exit() {
       var page = PDFViewerApplication.page;
+      this.container.classList.remove(ACTIVE_SELECTOR);
 
       // Ensure that the correct page is scrolled into view when exiting
       // Presentation Mode, by waiting until fullscreen mode is disabled.
@@ -285,10 +288,10 @@ var PDFPresentationMode = (function PDFPresentationModeClosure() {
       if (this.controlsTimeout) {
         clearTimeout(this.controlsTimeout);
       } else {
-        this.container.classList.add(SELECTOR);
+        this.container.classList.add(CONTROLS_SELECTOR);
       }
       this.controlsTimeout = setTimeout(function showControlsTimeout() {
-        this.container.classList.remove(SELECTOR);
+        this.container.classList.remove(CONTROLS_SELECTOR);
         delete this.controlsTimeout;
       }.bind(this), DELAY_BEFORE_HIDING_CONTROLS);
     },
@@ -301,7 +304,7 @@ var PDFPresentationMode = (function PDFPresentationModeClosure() {
         return;
       }
       clearTimeout(this.controlsTimeout);
-      this.container.classList.remove(SELECTOR);
+      this.container.classList.remove(CONTROLS_SELECTOR);
       delete this.controlsTimeout;
     },
 

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -57,22 +57,22 @@
   box-shadow: 0px 2px 10px #ff0;
 }
 
-:-webkit-full-screen .pdfViewer .page {
+.pdfPresentationMode:-webkit-full-screen .pdfViewer .page {
   margin-bottom: 100%;
   border: 0;
 }
 
-:-moz-full-screen .pdfViewer .page {
+.pdfPresentationMode:-moz-full-screen .pdfViewer .page {
   margin-bottom: 100%;
   border: 0;
 }
 
-:-ms-fullscreen .pdfViewer .page {
+.pdfPresentationMode:-ms-fullscreen .pdfViewer .page {
   margin-bottom: 100% !important;
   border: 0;
 }
 
-:fullscreen .pdfViewer .page {
+.pdfPresentationMode:fullscreen .pdfViewer .page {
   margin-bottom: 100%;
   border: 0;
 }

--- a/web/presentation_mode.js
+++ b/web/presentation_mode.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals scrollIntoView, HandTool, PDFViewerApplication */
+/* globals scrollIntoView, PDFViewerApplication */
 
 'use strict';
 
@@ -23,6 +23,7 @@ var SELECTOR = 'presentationControls';
 var DELAY_BEFORE_RESETTING_SWITCH_IN_PROGRESS = 1000; // in ms
 
 var PresentationMode = {
+  initialized: false,
   active: false,
   args: null,
   contextMenuOpen: false,
@@ -31,6 +32,7 @@ var PresentationMode = {
 //#endif
 
   initialize: function presentationModeInitialize(options) {
+    this.initialized = true;
     this.container = options.container;
     this.secondaryToolbar = options.secondaryToolbar;
 
@@ -93,7 +95,7 @@ var PresentationMode = {
   },
 
   request: function presentationModeRequest() {
-    if (!PDFViewerApplication.supportsFullscreen || this.isFullscreen ||
+    if (!this.initialized || this.isFullscreen ||
         !this.viewer.hasChildNodes()) {
       return false;
     }
@@ -147,7 +149,6 @@ var PresentationMode = {
     window.addEventListener('contextmenu', this.contextMenu, false);
 
     this.showControls();
-    HandTool.enterPresentationMode();
     this.contextMenuOpen = false;
     this.container.setAttribute('contextmenu', 'viewerContextMenu');
 
@@ -178,7 +179,6 @@ var PresentationMode = {
 
     this.hideControls();
     PDFViewerApplication.clearMouseScrollState();
-    HandTool.exitPresentationMode();
     this.container.removeAttribute('contextmenu');
     this.contextMenuOpen = false;
 

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -25,7 +25,6 @@ var SecondaryToolbar = {
 
   initialize: function secondaryToolbarInitialize(options) {
     this.toolbar = options.toolbar;
-    this.presentationMode = options.presentationMode;
     this.documentProperties = options.documentProperties;
     this.buttonContainer = this.toolbar.firstElementChild;
 
@@ -72,7 +71,7 @@ var SecondaryToolbar = {
 
   // Event handling functions.
   presentationModeClick: function secondaryToolbarPresentationModeClick(evt) {
-    this.presentationMode.request();
+    PDFViewerApplication.requestPresentationMode();
     this.close();
   },
 

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -47,7 +47,7 @@ select {
   display: none !important;
 }
 
-#viewerContainer:-webkit-full-screen {
+#viewerContainer.pdfPresentationMode:-webkit-full-screen {
   top: 0px;
   border-top: 2px solid transparent;
   background-color: #000;
@@ -58,7 +58,7 @@ select {
   -webkit-user-select: none;
 }
 
-#viewerContainer:-moz-full-screen {
+#viewerContainer.pdfPresentationMode:-moz-full-screen {
   top: 0px;
   border-top: 2px solid transparent;
   background-color: #000;
@@ -69,7 +69,7 @@ select {
   -moz-user-select: none;
 }
 
-#viewerContainer:-ms-fullscreen {
+#viewerContainer.pdfPresentationMode:-ms-fullscreen {
   top: 0px !important;
   border-top: 2px solid transparent;
   width: 100%;
@@ -79,11 +79,11 @@ select {
   -ms-user-select: none;
 }
 
-#viewerContainer:-ms-fullscreen::-ms-backdrop {
+#viewerContainer.pdfPresentationMode:-ms-fullscreen::-ms-backdrop {
   background-color: #000;
 }
 
-#viewerContainer:fullscreen {
+#viewerContainer.pdfPresentationMode:fullscreen {
   top: 0px;
   border-top: 2px solid transparent;
   background-color: #000;
@@ -96,36 +96,40 @@ select {
   -ms-user-select: none;
 }
 
-:-webkit-full-screen a:not(.internalLink) {
+.pdfPresentationMode:-webkit-full-screen a:not(.internalLink) {
   display: none;
 }
 
-:-moz-full-screen a:not(.internalLink) {
+.pdfPresentationMode:-moz-full-screen a:not(.internalLink) {
   display: none;
 }
 
-:-ms-fullscreen a:not(.internalLink) {
+.pdfPresentationMode:-ms-fullscreen a:not(.internalLink) {
   display: none !important;
 }
 
-:fullscreen a:not(.internalLink) {
+.pdfPresentationMode:fullscreen a:not(.internalLink) {
   display: none;
 }
 
-:-webkit-full-screen .textLayer > div {
+.pdfPresentationMode:-webkit-full-screen .textLayer > div {
   cursor: none;
 }
 
-:-moz-full-screen .textLayer > div {
+.pdfPresentationMode:-moz-full-screen .textLayer > div {
   cursor: none;
 }
 
-:fullscreen .textLayer > div {
+.pdfPresentationMode:-ms-fullscreen .textLayer > div {
   cursor: none;
 }
 
-#viewerContainer.presentationControls,
-#viewerContainer.presentationControls .textLayer > div {
+.pdfPresentationMode:fullscreen .textLayer > div {
+  cursor: none;
+}
+
+.pdfPresentationMode.pdfPresentationModeControls > *,
+.pdfPresentationMode.pdfPresentationModeControls .textLayer > div {
   cursor: default;
 }
 

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -81,7 +81,7 @@ http://sourceforge.net/adobe/cmap/wiki/License/
     <script src="pdf_find_controller.js"></script>
     <script src="pdf_history.js"></script>
     <script src="secondary_toolbar.js"></script>
-    <script src="presentation_mode.js"></script>
+    <script src="pdf_presentation_mode.js"></script>
     <script src="grab_to_pan.js"></script>
     <script src="hand_tool.js"></script>
     <script src="overlay_manager.js"></script>

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -191,6 +191,7 @@ var PDFViewerApplication = {
       var toolbar = SecondaryToolbar;
       PDFPresentationMode.initialize({
         container: container,
+        viewer: viewer,
         pdfThumbnailViewer: this.pdfThumbnailViewer,
         contextMenuItems: [
           { element: document.getElementById('contextFirstPage'),
@@ -1347,6 +1348,9 @@ var PDFViewerApplication = {
     PDFPresentationMode.request();
   },
 
+  /**
+   * @param {number} delta - The delta value from the mouse event.
+   */
   scrollPresentationMode: function pdfViewScrollPresentationMode(delta) {
     if (!this.supportsFullscreen) {
       return;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 /* globals PDFJS, PDFBug, FirefoxCom, Stats, Cache, ProgressBar,
-           DownloadManager, getFileName, scrollIntoView, getPDFFileNameFromURL,
+           DownloadManager, getFileName, getPDFFileNameFromURL,
            PDFHistory, Preferences, SidebarView, ViewHistory, Stats,
            PDFThumbnailViewer, URL, noContextMenuHandler, SecondaryToolbar,
            PasswordPrompt, PresentationMode, HandTool, Promise,
@@ -188,13 +188,20 @@ var PDFViewerApplication = {
     });
 
     if (this.supportsFullscreen) {
+      var toolbar = SecondaryToolbar;
       PresentationMode.initialize({
         container: container,
-        secondaryToolbar: SecondaryToolbar,
-        firstPage: document.getElementById('contextFirstPage'),
-        lastPage: document.getElementById('contextLastPage'),
-        pageRotateCw: document.getElementById('contextPageRotateCw'),
-        pageRotateCcw: document.getElementById('contextPageRotateCcw')
+        pdfThumbnailViewer: this.pdfThumbnailViewer,
+        contextMenuItems: [
+          { element: document.getElementById('contextFirstPage'),
+            handler: toolbar.firstPageClick.bind(toolbar) },
+          { element: document.getElementById('contextLastPage'),
+            handler: toolbar.lastPageClick.bind(toolbar) },
+          { element: document.getElementById('contextPageRotateCw'),
+            handler: toolbar.pageRotateCwClick.bind(toolbar) },
+          { element: document.getElementById('contextPageRotateCcw'),
+            handler: toolbar.pageRotateCcwClick.bind(toolbar) }
+        ]
       });
     }
 
@@ -317,8 +324,8 @@ var PDFViewerApplication = {
 
   get supportsFullscreen() {
     var doc = document.documentElement;
-    var support = doc.requestFullscreen || doc.mozRequestFullScreen ||
-                  doc.webkitRequestFullScreen || doc.msRequestFullscreen;
+    var support = !!(doc.requestFullscreen || doc.mozRequestFullScreen ||
+                     doc.webkitRequestFullScreen || doc.msRequestFullscreen);
 
     if (document.fullscreenEnabled === false ||
         document.mozFullScreenEnabled === false ||
@@ -1936,15 +1943,9 @@ window.addEventListener('DOMMouseScroll', handleMouseWheel);
 window.addEventListener('mousewheel', handleMouseWheel);
 
 window.addEventListener('click', function click(evt) {
-  if (!PDFViewerApplication.pdfViewer.isInPresentationMode) {
-    if (SecondaryToolbar.opened &&
-        PDFViewerApplication.pdfViewer.containsElement(evt.target)) {
-      SecondaryToolbar.close();
-    }
-  } else if (evt.button === 0) {
-    // Necessary since preventDefault() in 'mousedown' won't stop
-    // the event propagation in all circumstances in presentation mode.
-    evt.preventDefault();
+  if (SecondaryToolbar.opened &&
+      PDFViewerApplication.pdfViewer.containsElement(evt.target)) {
+    SecondaryToolbar.close();
   }
 }, false);
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -107,6 +107,8 @@ var PDFViewerApplication = {
   pdfThumbnailViewer: null,
   /** @type {PDFRenderingQueue} */
   pdfRenderingQueue: null,
+  /** @type {PDFPresentationMode} */
+  pdfPresentationMode: null,
   pageRotation: 0,
   updateScaleControls: true,
   isInitialViewSet: false,
@@ -189,7 +191,7 @@ var PDFViewerApplication = {
 
     if (this.supportsFullscreen) {
       var toolbar = SecondaryToolbar;
-      PDFPresentationMode.initialize({
+      this.pdfPresentationMode = new PDFPresentationMode({
         container: container,
         viewer: viewer,
         pdfThumbnailViewer: this.pdfThumbnailViewer,
@@ -1342,20 +1344,20 @@ var PDFViewerApplication = {
   },
 
   requestPresentationMode: function pdfViewRequestPresentationMode() {
-    if (!this.supportsFullscreen) {
+    if (!this.pdfPresentationMode) {
       return;
     }
-    PDFPresentationMode.request();
+    this.pdfPresentationMode.request();
   },
 
   /**
    * @param {number} delta - The delta value from the mouse event.
    */
   scrollPresentationMode: function pdfViewScrollPresentationMode(delta) {
-    if (!this.supportsFullscreen) {
+    if (!this.pdfPresentationMode) {
       return;
     }
-    PDFPresentationMode.mouseScroll(delta);
+    this.pdfPresentationMode.mouseScroll(delta);
   }
 };
 //#if GENERIC

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -18,7 +18,7 @@
            DownloadManager, getFileName, getPDFFileNameFromURL,
            PDFHistory, Preferences, SidebarView, ViewHistory, Stats,
            PDFThumbnailViewer, URL, noContextMenuHandler, SecondaryToolbar,
-           PasswordPrompt, PresentationMode, HandTool, Promise,
+           PasswordPrompt, PDFPresentationMode, HandTool, Promise,
            DocumentProperties, PDFOutlineView, PDFAttachmentView,
            OverlayManager, PDFFindController, PDFFindBar, getVisibleElements,
            watchScroll, PDFViewer, PDFRenderingQueue, PresentationModeState,
@@ -84,7 +84,7 @@ var mozL10n = document.mozL10n || document.webL10n;
 //#include pdf_find_controller.js
 //#include pdf_history.js
 //#include secondary_toolbar.js
-//#include presentation_mode.js
+//#include pdf_presentation_mode.js
 //#include hand_tool.js
 //#include overlay_manager.js
 //#include password_prompt.js
@@ -189,7 +189,7 @@ var PDFViewerApplication = {
 
     if (this.supportsFullscreen) {
       var toolbar = SecondaryToolbar;
-      PresentationMode.initialize({
+      PDFPresentationMode.initialize({
         container: container,
         pdfThumbnailViewer: this.pdfThumbnailViewer,
         contextMenuItems: [
@@ -1344,14 +1344,14 @@ var PDFViewerApplication = {
     if (!this.supportsFullscreen) {
       return;
     }
-    PresentationMode.request();
+    PDFPresentationMode.request();
   },
 
   scrollPresentationMode: function pdfViewScrollPresentationMode(delta) {
     if (!this.supportsFullscreen) {
       return;
     }
-    PresentationMode.mouseScroll(delta);
+    PDFPresentationMode.mouseScroll(delta);
   }
 };
 //#if GENERIC


### PR DESCRIPTION
This PR follows a similar pattern to PR #5673. The main goal of this refactoring has been to break the existing dependencies between Presentation Mode code, and other parts of the code base.

Since I know, from own past experiences with PDF.js, that when working with the fullscreen API it's sometimes very easy to introduce subtle bugs that only show up for certain browsers/OSes/platforms, I've tried to avoid making any significant functional changes in these patches.
To make both development and reviewing simpler, I've split the PR into a (perhaps too large) number of patches to make it easier to ascertain that nothing breaks.

As it currently stands, the Presentation Mode code still depends on `PDFViewerApplication`. I looked into replacing that with e.g. an instance of [`IPDFLinkService`](https://github.com/mozilla/pdf.js/blob/master/web/interfaces.js#L19-L54)/[`SimpleLinkService`](https://github.com/mozilla/pdf.js/blob/master/web/pdf_viewer.js#L718-L763), but in their current state they don't implement all the necessary methods.
With these patches, `PDFPresentationMode` depends on the `PDFViewerApplication.{page, currentScaleValue, setScale, pagesCount}` methods, and currently only `page` is present in the interface.
@yurydelendik Could/should we extend the interfaces with the necessary methods, i.e. `{getScale, setScale, pagesCount}`, or is another solution preferred? (In a way the interfaces actually already support setting the scale, through the `setHash` method.)

PS. For some of the larger patches, using the `?w=1` URL flag should help considerably when reviewing the code.
