### PR TITLE
Remove the |el| property in PDFPageView and PDFThumbnailView

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -80,7 +80,6 @@ var PDFPageView = (function PDFPageViewClosure() {
     div.className = 'page';
     div.style.width = Math.floor(this.viewport.width) + 'px';
     div.style.height = Math.floor(this.viewport.height) + 'px';
-    this.el = div; // TODO replace 'el' property usage
     this.div = div;
 
     container.appendChild(div);

--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -99,7 +99,6 @@ var PDFThumbnailView = (function PDFThumbnailViewClosure() {
     var div = document.createElement('div');
     div.id = 'thumbnailContainer' + id;
     div.className = 'thumbnail';
-    this.el = div; // TODO: replace 'el' property usage.
     this.div = div;
 
     if (id === 1) {

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -194,16 +194,16 @@ function getVisibleElements(scrollEl, views, sortByVisibility) {
   var currentWidth, viewWidth;
   for (var i = 0, ii = views.length; i < ii; ++i) {
     view = views[i];
-    currentHeight = view.el.offsetTop + view.el.clientTop;
-    viewHeight = view.el.clientHeight;
+    currentHeight = view.div.offsetTop + view.div.clientTop;
+    viewHeight = view.div.clientHeight;
     if ((currentHeight + viewHeight) < top) {
       continue;
     }
     if (currentHeight > bottom) {
       break;
     }
-    currentWidth = view.el.offsetLeft + view.el.clientLeft;
-    viewWidth = view.el.clientWidth;
+    currentWidth = view.div.offsetLeft + view.div.clientLeft;
+    viewWidth = view.div.clientWidth;
     if ((currentWidth + viewWidth) < left || currentWidth > right) {
       continue;
     }


### PR DESCRIPTION
~~Obviously it would have been nicer to just remove it all together, but in the event that some third-party implementation depends on it, I figured that we might want to keep it around for `GENERIC` builds for now.~~
