### PR TITLE
Move the call to |PDFFindController.resolveFirstPage| into PDFViewer

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -306,6 +306,10 @@ var PDFViewer = (function pdfViewer() {
         if (this.defaultRenderingQueue) {
           this.update();
         }
+
+        if (this.findController) {
+          this.findController.resolveFirstPage();
+        }
       }.bind(this));
     },
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -863,8 +863,6 @@ var PDFViewerApplication = {
 
       self.loadingBar.setWidth(document.getElementById('viewer'));
 
-      self.findController.resolveFirstPage();
-
       if (!PDFJS.disableHistory && !self.isViewerEmbedded) {
         // The browsing history is only enabled when the viewer is standalone,
         // i.e. not when it is embedded in a web page.


### PR DESCRIPTION
From reading IRC scrollback, it became clear that having to manually call `PDFFindController.resolveFirstPage` in order for the find functionality to work isn't particulary good. Hence this PR, which moves that code into `PDFViewer.setDocument` to make life easier for third-party implementations.
