### PR TITLE
Fix a jpx inclusion tag tree bug

### DIFF
--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -1125,6 +1125,11 @@ var JpxImage = (function JpxImageClosure() {
             zeroBitPlanesTree = new TagTree(width, height);
             precinct.inclusionTree = inclusionTree;
             precinct.zeroBitPlanesTree = zeroBitPlanesTree;
+            for (var l=0; l < layerNumber; l++) {
+              if (readBits(1) !== 0) {
+                throw new Error('JPX Error: Invalid tag tree');
+              }
+            }
           }
 
           if (inclusionTree.reset(codeblockColumn, codeblockRow, layerNumber)) {


### PR DESCRIPTION
The current code only works when every code-block includes at least some coding pass in layer 0. Otherwise, the tag tree will have x preceding 0, where x is the number of layers before the code-block is first included (See section B.10.2 and B.10.4 of ITU-T Rec. T.800). Such file appears severely corrupted as everything read beyond that point is misaligned.

This commit purge the preceding zeros when the inclusionTree is constructed and throw an error if the number of preceding zeros does not match the current layer (Tag tree is invalid or the code-block was supposed to be included in a earlier packet).
