### PR TITLE
Fix CCITTStream regression by byte-aligning rows before checking EOL marker

### DIFF
--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -2044,6 +2044,10 @@ var CCITTFaxStream = (function CCITTFaxStreamClosure() {
 
       var gotEOL = false;
 
+      if (this.byteAlign) {
+        this.inputBits &= ~7;
+      }
+
       if (!this.eoblock && this.row === this.rows - 1) {
         this.eof = true;
       } else {
@@ -2065,10 +2069,6 @@ var CCITTFaxStream = (function CCITTFaxStreamClosure() {
         } else if (code1 === EOF) {
           this.eof = true;
         }
-      }
-
-      if (this.byteAlign && !gotEOL) {
-        this.inputBits &= ~7;
       }
 
       if (!this.eof && this.encoding > 0) {

--- a/test/pdfs/issue5726.pdf.link
+++ b/test/pdfs/issue5726.pdf.link
@@ -1,0 +1,1 @@
+http://digipool.bib-bvb.de/bvb/info/OCR_with_TIFFG4.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1606,6 +1606,13 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue5726",
+       "file": "pdfs/issue5726.pdf",
+       "md5": "f52f31ad3da316b599cade875ab049db",
+       "rounds": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "bug816075",
       "file": "pdfs/bug816075.pdf",
       "md5": "7ec87c115c1f9ec41234cc7002555e82",


### PR DESCRIPTION
Fixes #5726.

It turns out that byte-aligning rows needs to happen before checking for an EOL marker. Older versions of the Poppler code did this (https://github.com/davidben/poppler/blob/master/poppler/Stream.cc#L1642), as well as libpdf++ (https://github.com/match41/sumpdf/blob/master/libpdfdoc/src/stream/CCITTFaxStream.cc#L403).
