### PR TITLE
Skip fill bytes (0xFF) when decoding JPEG images (issue 5331)

### DIFF
--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -792,6 +792,13 @@ var JpegImage = (function jpegImage() {
               successiveApproximation >> 4, successiveApproximation & 15);
             offset += processed;
             break;
+
+          case 0xFFFF: // Fill bytes
+            if (data[offset] !== 0xFF) { // Avoid skipping a valid marker.
+              offset--;
+            }
+            break;
+
           default:
             if (data[offset - 3] === 0xFF &&
                 data[offset - 2] >= 0xC0 && data[offset - 2] <= 0xFE) {


### PR DESCRIPTION
Fixes #5331.

_Note:_ The reason that I didn't add a test-case, is that the file is only available through a Dropbox link (hence with very uncertain future availability).
Since the file is an excerpt from a Medical Journal, I've tried to find the original article. Unsurprisingly it's protected with a login, and the version of the article I found through Google Scholar (obviously) didn't exhibit the same issue :-(

However, given that JPEG images with fill bytes seem to be very uncommon in PDF files (I've only found one issue), I'm hoping that in this case we can do without a test-case.
