### PR TITLE
Lower space factor threshold

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -893,7 +893,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         styles: Object.create(null)
       };
       var bidiTexts = textContent.items;
-      var SPACE_FACTOR = 0.35;
+      var SPACE_FACTOR = 0.3;
       var MULTI_SPACE_FACTOR = 1.5;
 
       var self = this;


### PR DESCRIPTION
Fixes text selection formatting with https://github.com/vortext/vortext/blob/master/resources/public/examples/TestDocument3.pdf

For example, "Two years after a hip" on second page used to read as "Twoyearsafterahip"
