### PR TITLE
Fix regression that prevents resetting the zoom level to "Automatic" when using the |Ctrl + 0| keys

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -335,12 +335,27 @@ var PDFViewer = (function pdfViewer() {
       }
     },
 
+    _setScaleDispatchEvent: function pdfViewer_setScaleDispatchEvent(
+        newScale, newValue, preset) {
+      var event = document.createEvent('UIEvents');
+      event.initUIEvent('scalechange', true, true, window, 0);
+      event.scale = newScale;
+      if (preset) {
+        event.presetValue = newValue;
+      }
+      this.container.dispatchEvent(event);
+    },
+
     _setScaleUpdatePages: function pdfViewer_setScaleUpdatePages(
         newScale, newValue, noScroll, preset) {
       this._currentScaleValue = newValue;
       if (newScale === this._currentScale) {
+        if (preset) {
+          this._setScaleDispatchEvent(newScale, newValue, true);
+        }
         return;
       }
+
       for (var i = 0, ii = this.pages.length; i < ii; i++) {
         this.pages[i].update(newScale);
       }
@@ -360,13 +375,7 @@ var PDFViewer = (function pdfViewer() {
         this.scrollPageIntoView(page, dest);
       }
 
-      var event = document.createEvent('UIEvents');
-      event.initUIEvent('scalechange', true, true, window, 0);
-      event.scale = newScale;
-      if (preset) {
-        event.presetValue = newValue;
-      }
-      this.container.dispatchEvent(event);
+      this._setScaleDispatchEvent(newScale, newValue, preset);
     },
 
     _setScale: function pdfViewer_setScale(value, noScroll) {


### PR DESCRIPTION
**Steps to reproduce:**
1. Open http://mozilla.github.io/pdf.js/web/viewer.html#zoom=125.<br>
   _Please note:_ the bug also exists if the user have manually set the zoom level to 125% (by selecting that value in the dropdown box), I just wanted to provide as simple as possible STR.
2. Press <kbd>Ctrl</kbd> + <kbd>0</kbd>.

**Expected result:**
The zoom level (in the dropdown box) is set to "Automatic".
_Edit:_ Compare with http://107.22.172.223:8877/458bfe79a031b38/web/viewer.html#zoom=125.

**Actual result:**
Nothing happens.

---

This is a regression from commit https://github.com/mozilla/pdf.js/commit/7af8748151b174fc2206a6ed543b5474a589fb25, and it is caused by the removal of [this code](https://github.com/mozilla/pdf.js/commit/7af8748151b174fc2206a6ed543b5474a589fb25#diff-dd42e9b2d2a652b8e312efa567698aa6L345).
In the current code we instead rely on the `scalechange` event to update the zoom box (in `viewer.js`), but since we return early in [pdf_viewer.js#L341-L343](https://github.com/mozilla/pdf.js/blob/master/web/pdf_viewer.js#L341-L343) for this case (given "Automatic" zoom == 125%) we aren't dispatching the event.
