### PR TITLE
Add option to open external links in new window

### DIFF
--- a/src/display/annotation_helper.js
+++ b/src/display/annotation_helper.js
@@ -217,6 +217,9 @@ var AnnotationUtils = (function AnnotationUtilsClosure() {
 
     var link = document.createElement('a');
     link.href = link.title = item.url || '';
+    if (item.url && PDFJS.openExternalLinksInNewWindow) {
+      link.target = '_blank';
+    }
 
     container.appendChild(link);
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -161,6 +161,15 @@ PDFJS.maxCanvasPixels = (PDFJS.maxCanvasPixels === undefined ?
                          16777216 : PDFJS.maxCanvasPixels);
 
 /**
+ * Opens external links in a new window if enabled. The default behavior opens
+ * external links in the PDF.js window.
+ * @var {boolean}
+ */
+PDFJS.openExternalLinksInNewWindow = (
+  PDFJS.openExternalLinksInNewWindow === undefined ?
+    false : PDFJS.openExternalLinksInNewWindow);
+
+/**
  * Document initialization / loading parameters object.
  *
  * @typedef {Object} DocumentInitParameters


### PR DESCRIPTION
This change adds a PDFJS.openExternalLinkInNewWindow boolean, which opens links in a new window when enabled. The default now and previous to this change, clicking on an external link will open the link the same window (and navigate away from PDF.js). 
