### PR TITLE
nbsp normalization

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -65,7 +65,8 @@ var PDFFindController = (function PDFFindControllerClosure() {
       '\u201F': '"', // Double high-reversed-9 quotation mark
       '\u00BC': '1/4', // Vulgar fraction one quarter
       '\u00BD': '1/2', // Vulgar fraction one half
-      '\u00BE': '3/4' // Vulgar fraction three quarters
+      '\u00BE': '3/4', // Vulgar fraction three quarters
+      '\u00A0': ' ' // No-break space
     };
     this.findBar = options.findBar || null;
 


### PR DESCRIPTION
Added nbsp (no-break space) normalization into PDFFindController. All pdfs that I came across generated by Google Docs have nbsp instead of regular space, so this comes in handy for searching them.
