### PR TITLE
Revert PR 5510, except in WebKit browsers, for breaking print preview in Firefox

### DIFF
--- a/web/viewer-snippet-mozPrintCallback-polyfill.html
+++ b/web/viewer-snippet-mozPrintCallback-polyfill.html
@@ -1,4 +1,12 @@
 <div id="mozPrintCallback-shim" hidden>
+  <style>
+@media print {
+  #printContainer div {
+    page-break-after: always;
+    page-break-inside: avoid;
+  }
+}
+  </style>
   <style scoped>
 #mozPrintCallback-shim {
   position: fixed;

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1717,10 +1717,6 @@ html[dir='rtl'] #documentPropertiesOverlay .row > * {
     left: 0;
     display: block;
   }
-  #printContainer div {
-    page-break-after: always;
-    page-break-inside: avoid;
-  }
 }
 
 .visibleLargeView,


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1138993.
