### PR TITLE
Embedded Viewer Should Not Override Page Title

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -434,6 +434,10 @@ var PDFViewerApplication = {
   },
 
   setTitle: function pdfViewSetTitle(title) {
+    if (this.isViewerEmbedded) {
+      // Embedded PDF viewers should not be changing their parent page's title.
+      return;
+    }
     document.title = title;
 //#if B2G
 //  document.getElementById('activityTitle').textContent = title;


### PR DESCRIPTION
This simple pull request simply stops embedded viewers from overriding their parent window's page title. 

There is often other stuff going on in the page when there is an embedded viewer (including possibly, other embedded viewers) and it seems that the PDF viewer should not override that.
