### PR TITLE
Allow Skinned Viewers to Change Find Bar without Changing Javascript

### DIFF
--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -42,17 +42,23 @@ var PDFFindBar = (function PDFFindBarClosure() {
                       'PDFFindController instance.');
     }
 
+    function addListenerSafely(object, event, func) {
+      if (object) {
+        return object.addEventListener(event, func);
+      }
+    }
+    
     // Add event listeners to the DOM elements.
     var self = this;
-    this.toggleButton.addEventListener('click', function() {
+    addListenerSafely(this.toggleButton, 'click', function() {
       self.toggle();
     });
 
-    this.findField.addEventListener('input', function() {
+    addListenerSafely(this.findField, 'input', function() {
       self.dispatchEvent('');
     });
 
-    this.bar.addEventListener('keydown', function(evt) {
+    addListenerSafely(this.bar, 'keydown', function(evt) {
       switch (evt.keyCode) {
         case 13: // Enter
           if (evt.target === self.findField) {
@@ -65,19 +71,19 @@ var PDFFindBar = (function PDFFindBarClosure() {
       }
     });
 
-    this.findPreviousButton.addEventListener('click', function() {
+    addListenerSafely(this.findPreviousButton, 'click', function() {
       self.dispatchEvent('again', true);
     });
 
-    this.findNextButton.addEventListener('click', function() {
+    addListenerSafely(this.findNextButton, 'click', function() {
       self.dispatchEvent('again', false);
     });
 
-    this.highlightAll.addEventListener('click', function() {
+    addListenerSafely(this.highlightAll, 'click', function() {
       self.dispatchEvent('highlightallchange');
     });
 
-    this.caseSensitive.addEventListener('click', function() {
+    addListenerSafely(this.caseSensitive, 'click', function() {
       self.dispatchEvent('casesensitivitychange');
     });
   }
@@ -87,8 +93,8 @@ var PDFFindBar = (function PDFFindBarClosure() {
       var event = document.createEvent('CustomEvent');
       event.initCustomEvent('find' + type, true, true, {
         query: this.findField.value,
-        caseSensitive: this.caseSensitive.checked,
-        highlightAll: this.highlightAll.checked,
+        caseSensitive: this.caseSensitive ? this.caseSensitive.checked : false,
+        highlightAll: this.highlightAll ? this.highlightAll.checked : false,
         findPrevious: findPrev
       });
       return window.dispatchEvent(event);


### PR DESCRIPTION
## The Problem

For those of use who write our own viewers, we often change or remove certain functionality from the stock viewer.  In those situations, it's nice for the javascript to not be so tightly tied to the DOM layout. That way, we can remove/change objects without crashing the viewer or modifying any javascript.
## The Solution

In this PR, we remove all javascript dependencies in the find bar's DOM. That is, anyone who skins pdf.js and removes or changes the DOM layout of the find bar will now no longer have to change their javascript too. We do this simply by adding null checks to make sure an element exists before acting on it.
## Going Forward

There are many other places in pdf.js where the javascript is tightly tied to the DOM, not just the find bar. If this PR is acceptable, I can try to do the same for other areas as well. I thought I'd start small here though.
