### PR TITLE
Ensure that entries in the Differences array of Type1 fonts are either numbers or names

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1284,8 +1284,13 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
               var data = diffEncoding[j];
               if (isNum(data)) {
                 index = data;
-              } else {
+              } else if (isName(data)) {
                 differences[index++] = data.name;
+              } else if (isRef(data)) {
+                diffEncoding[j--] = xref.fetch(data);
+                continue;
+              } else {
+                error('Invalid entry in \'Differences\' array: ' + data);
               }
             }
           }

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -2,6 +2,7 @@
 *.error
 
 !tracemonkey.pdf
+!franz.pdf
 !issue2391-1.pdf
 !issue2391-2.pdf
 !filled-background.pdf

--- a/test/pdfs/franz.pdf
+++ b/test/pdfs/franz.pdf
@@ -1,0 +1,81 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 128
+endobj 
+2 0 obj 157
+endobj 
+3 0 obj 
+<<
+/Type /Encoding
+/Differences [0 /.notdef 1 /dotaccent /fi /fl /fraction /hungarumlaut /Lslash /lslash /ogonek /ring 10 /.notdef 11 /breve /minus 13 /.notdef 14 /Zcaron /zcaron /caron /dotlessi /dotlessj /ff /ffi /ffl 22 /.notdef 30 /grave /quotesingle /space /exclam /quotedbl /numbersign /dollar /percent /ampersand /quoteright /parenleft /parenright /asterisk /plus /comma /hyphen /period /slash /zero /one /two /three /four /five /six /seven /eight /nine /colon /semicolon /less /equal /greater /question /at /A /B /C /D /E /F /G /H /I /J /K /L /M /N /O /P /Q /R /S /T /U /V /W /X /Y /Z /bracketleft /backslash /bracketright /asciicircum /underscore /quoteleft /a /b /c /d /e /f /g /h /i /j /k /l /m /n /o /p /q /r /s /t /u /v /w /x /y /z /braceleft /bar /braceright /asciitilde 127 /.notdef 1 0 R /Euro 129 /.notdef 130 /quotesinglbase /florin /quotedblbase /ellipsis /dagger /daggerdbl /circumflex /perthousand /Scaron /guilsinglleft /OE 141 /.notdef 147 /quotedblleft /quotedblright /bullet /endash /emdash /tilde /trademark /scaron /guilsinglright /oe 2 0 R /.notdef 159 /Ydieresis 160 /.notdef 161 /exclamdown /cent /sterling /currency /yen /brokenbar /section /dieresis /copyright /ordfeminine /guillemotleft /logicalnot /hyphen /registered /macron /degree /plusminus /twosuperior /threesuperior /acute /mu /paragraph /periodcentered /cedilla /onesuperior /ordmasculine /guillemotright /onequarter /onehalf /threequarters /questiondown /Agrave /Aacute /Acircumflex /Atilde /Adieresis /Aring /AE /Ccedilla /Egrave /Eacute /Ecircumflex /Edieresis /Igrave /Iacute /Icircumflex /Idieresis /Eth /Ntilde /Ograve /Oacute /Ocircumflex /Otilde /Odieresis /multiply /Oslash /Ugrave /Uacute /Ucircumflex /Udieresis /Yacute /Thorn /germandbls /agrave /aacute /acircumflex /atilde /adieresis /aring /ae /ccedilla /egrave /eacute /ecircumflex /edieresis /igrave /iacute /icircumflex /idieresis /eth /ntilde /ograve /oacute /ocircumflex /otilde /odieresis /divide /oslash /ugrave /uacute /ucircumflex /udieresis /yacute /thorn /ydieresis]
+>>
+endobj 
+4 0 obj 
+<<
+/Pages 5 0 R
+/Type /Catalog
+>>
+endobj 
+5 0 obj 
+<<
+/MediaBox [0 0 200 50]
+/Kids [6 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+6 0 obj 
+<<
+/Parent 5 0 R
+/MediaBox [0 0 200 50]
+/Resources 
+<<
+/Font 
+<<
+/F1 7 0 R
+>>
+>>
+/Contents 8 0 R
+/Type /Page
+>>
+endobj 
+7 0 obj 
+<<
+/BaseFont /Helvetica-Bold
+/Subtype /Type1
+/Type /Font
+/Encoding 3 0 R
+>>
+endobj 
+8 0 obj 
+<<
+/Length 42
+>>
+stream
+BT
+10 20 TD
+/F1 20 Tf
+(Hello World) Tj
+ET
+
+endstream 
+endobj xref
+0 9
+0000000000 65535 f 
+0000000015 00000 n 
+0000000035 00000 n 
+0000000055 00000 n 
+0000002111 00000 n 
+0000002162 00000 n 
+0000002244 00000 n 
+0000002373 00000 n 
+0000002466 00000 n 
+trailer
+
+<<
+/Root 4 0 R
+/Size 9
+>>
+startxref
+2560
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -490,6 +490,14 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "franz",
+       "file": "pdfs/franz.pdf",
+       "md5": "12f0bbdec09900cbdd86e1737ed5f992",
+       "link": false,
+       "rounds": 1,
+       "type": "eq",
+       "about": "Type1 font with |Ref|s in the Differences array of the Encoding dictionary."
+    },
     {  "id": "issue4934",
        "file": "pdfs/issue4934.pdf",
        "md5": "6099da44f677702ae65a648b51a2226d",


### PR DESCRIPTION
This patch is yet another installment in the (never ending) series of bugs in PDF files with non-embedded fonts.

Fixes http://www.int.washington.edu/talks/WorkShops/int_08_37W/People/Franz_M/Franz.pdf.
