### PR TITLE
Correctly detect the presence of the Adobe specific APP14 JPEG marker (bug 1140761)

### DIFF
--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -669,9 +669,9 @@ var JpegImage = (function jpegImage() {
             if (fileMarker === 0xFFEE) {
               if (appData[0] === 0x41 && appData[1] === 0x64 &&
                   appData[2] === 0x6F && appData[3] === 0x62 &&
-                  appData[4] === 0x65 && appData[5] === 0) { // 'Adobe\x00'
+                  appData[4] === 0x65) { // 'Adobe'
                 adobe = {
-                  version: appData[6],
+                  version: (appData[5] << 8) | appData[6],
                   flags0: (appData[7] << 8) | appData[8],
                   flags1: (appData[9] << 8) | appData[10],
                   transformCode: appData[11]

--- a/test/pdfs/bug1140761.pdf.link
+++ b/test/pdfs/bug1140761.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=8574416

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1608,6 +1608,15 @@
       "link": true,
       "type": "eq"
     },
+    {  "id": "bug1140761",
+       "file": "pdfs/bug1140761.pdf",
+       "md5": "b74eced7634d4f248dc6265f8225d432",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 1,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "bug1011159",
       "file": "pdfs/bug1011159.pdf",
       "md5": "4532e22deb92d4cd2992d0cfe255582a",


### PR DESCRIPTION
According to the specification, http://partners.adobe.com/public/developer/en/ps/sdk/5116.DCT_Filter.pdf#G3.851943, the content of the marker segment should begin with `Adobe`, and not `Adobe\x00` as the code currently look for.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1140761.
Fixes the colour conversion part of issues #4090 and #5623.

_Note:_ Thus far I've been unable to find anything other than a hacky work-around for the remaining issue, `"Error: JPEG error: marker was not found"`, but I figured I would submit this PR anyway since it at least solves one part of the problem.
