### PR TITLE
Fix flaw in mozCurrentTransform polyfill

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -46,11 +46,8 @@ function createScratchCanvas(width, height) {
 }
 
 function addContextCurrentTransform(ctx) {
-  // If the context doesn't expose a `mozCurrentTransform`, add a JS based on.
+  // If the context doesn't expose a `mozCurrentTransform`, add a JS based one.
   if (!ctx.mozCurrentTransform) {
-    // Store the original context
-    ctx._scaleX = ctx._scaleX || 1.0;
-    ctx._scaleY = ctx._scaleY || 1.0;
     ctx._originalSave = ctx.save;
     ctx._originalRestore = ctx.restore;
     ctx._originalRotate = ctx.rotate;
@@ -59,7 +56,7 @@ function addContextCurrentTransform(ctx) {
     ctx._originalTransform = ctx.transform;
     ctx._originalSetTransform = ctx.setTransform;
 
-    ctx._transformMatrix = [ctx._scaleX, 0, 0, ctx._scaleY, 0, 0];
+    ctx._transformMatrix = ctx._transformMatrix || [1, 0, 0, 1, 0, 0];
     ctx._transformStack = [];
 
     Object.defineProperty(ctx, 'mozCurrentTransform', {
@@ -435,6 +432,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     this.smaskCounter = 0;
     this.tempSMask = null;
     if (canvasCtx) {
+      // NOTE: if mozCurrentTransform is polyfilled, then the current state of
+      // the transformation must already be set in canvasCtx._transformMatrix.
       addContextCurrentTransform(canvasCtx);
     }
     this.cachedGetSinglePixelWidth = null;

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -362,10 +362,11 @@ var PDFPageView = (function PDFPageViewClosure() {
       }
       this.textLayer = textLayer;
 
-      // TODO(mack): use data attributes to store these
-      ctx._scaleX = outputScale.sx;
-      ctx._scaleY = outputScale.sy;
       if (outputScale.scaled) {
+//#if !(MOZCENTRAL || FIREFOX)
+        // Used by the mozCurrentTransform polyfill in src/display/canvas.js.
+        ctx._transformMatrix = [outputScale.sx, 0, 0, outputScale.sy, 0, 0];
+//#endif
         ctx.scale(outputScale.sx, outputScale.sy);
       }
 
@@ -516,6 +517,11 @@ var PDFPageView = (function PDFPageViewClosure() {
         ctx.fillStyle = 'rgb(255, 255, 255)';
         ctx.fillRect(0, 0, canvas.width, canvas.height);
         ctx.restore();
+//#if !(MOZCENTRAL || FIREFOX)
+        // Used by the mozCurrentTransform polyfill in src/display/canvas.js.
+        ctx._transformMatrix =
+          [PRINT_OUTPUT_SCALE, 0, 0, PRINT_OUTPUT_SCALE, 0, 0];
+//#endif
         ctx.scale(PRINT_OUTPUT_SCALE, PRINT_OUTPUT_SCALE);
 
         var renderContext = {


### PR DESCRIPTION
Set transformation matrix in (polyfilled) mozPrintCallback when a scale is applied, and removed `ctx._scaleX` and `ctx._scaleY` in favor of `ctx._transformMatrix` to emphasize that the caller MUST ensure that the state of the matrix is correct before `addContextCurrentTransform` is called.

To verify that the bug is fixed:
1. Start the PDF.js server (`node make server`)
2. Download https://github.com/mumble-voip/mumble/blob/d73a2bb6962e5659c881ba789b40190bb04274a6/doc/mumble-protocol.pdf?raw=true
3. Visit http://localhost:8888/web/viewer.html, click on Open file and select the PDF from step 2.
4. Press the print button in the viewer to get a print preview.
5. Scroll to page 4 (of the PDF, possibly page 7 if there is a blank page between each page (this is a different bug)) and check whether the images are aligned correctly (see screenshots in #5827).

Fixes #5505
Fixes #5827

(note: these bugs have been marked as Chrome-specific, but the bug is actually more general, it applies to every non-Firefox browser).
