### PR TITLE
Make presentation mode work again in Safari

### DIFF
--- a/web/presentation_mode.js
+++ b/web/presentation_mode.js
@@ -104,8 +104,8 @@ var PresentationMode = {
       this.container.requestFullscreen();
     } else if (this.container.mozRequestFullScreen) {
       this.container.mozRequestFullScreen();
-    } else if (this.container.webkitRequestFullScreen) {
-      this.container.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);
+    } else if (this.container.webkitRequestFullscreen) {
+      this.container.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
     } else if (this.container.msRequestFullscreen) {
       this.container.msRequestFullscreen();
     } else {


### PR DESCRIPTION
Fixes #4561.

Thanks to @CodingFabian and the video.js people (see https://github.com/mozilla/pdf.js/issues/4561#issuecomment-65773682).
