### PR TITLE
Enable OPS.setHScale in the SVG backend

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -518,6 +518,9 @@ var SVGGraphics = (function SVGGraphicsClosure() {
           case OPS.setWordSpacing:
             this.setWordSpacing(args[0]);
             break;
+          case OPS.setHScale:
+            this.setHScale(args[0]);
+            break;
           case OPS.setTextMatrix:
             this.setTextMatrix(args[0], args[1], args[2],
                                args[3], args[4], args[5]);


### PR DESCRIPTION
The necessary code had already been implemented, but the operation had not yet been added to the `switch` statement. This resulted in a console message about an unimplemented operator. This patch makes http://kennemerlyceum.nl/attachments/article/4/Lessentabel%202014-2015.pdf render better since we now respect the horizontal text scale.

To verify:
- Open the `svgviewer` example without the patch applied and set it to load http://kennemerlyceum.nl/attachments/article/4/Lessentabel%202014-2015.pdf (download the file first).
- Open a second tab with the same `svgviewer` example, but now apply the patch. Notice subtle differences in spacing between the glyphs when switching between tabs.

This patch is the result of an effort to find out what we are missing in the SVG backend. I have tested many different PDF files and observed the console output to determine essential missing operations. This was one of them. From what I have found shading/gradients/SMask are the biggest missing features. We will benefit from running the tests with the SVG backend to catch differences with the canvas rendering.
