### PR TITLE
Set page size via @page + size

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -493,10 +493,15 @@ var PDFPageView = (function PDFPageViewClosure() {
       // better output until bug 811002 is fixed in FF.
       var PRINT_OUTPUT_SCALE = 2;
       var canvas = document.createElement('canvas');
+
+      // The logical size of the canvas.
       canvas.width = Math.floor(viewport.width) * PRINT_OUTPUT_SCALE;
       canvas.height = Math.floor(viewport.height) * PRINT_OUTPUT_SCALE;
-      canvas.style.width = (PRINT_OUTPUT_SCALE * viewport.width) + 'pt';
-      canvas.style.height = (PRINT_OUTPUT_SCALE * viewport.height) + 'pt';
+
+      // The rendered size of the canvas, relative to the size of canvasWrapper.
+      canvas.style.width = (PRINT_OUTPUT_SCALE * 100) + '%';
+      canvas.style.height = (PRINT_OUTPUT_SCALE * 100) + '%';
+
       var cssScale = 'scale(' + (1 / PRINT_OUTPUT_SCALE) + ', ' +
                                 (1 / PRINT_OUTPUT_SCALE) + ')';
       CustomStyle.setProp('transform' , canvas, cssScale);

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1711,10 +1711,14 @@ html[dir='rtl'] #documentPropertiesOverlay .row > * {
   body[data-mozPrintCallback] #printContainer {
     display: block;
   }
-  #printContainer canvas {
+  /* wrapper around (scaled) print canvas elements */
+  #printContainer > div {
     position: relative;
     top: 0;
     left: 0;
+    overflow: hidden;
+  }
+  #printContainer canvas {
     display: block;
   }
 }


### PR DESCRIPTION
In Blink-based browsers, there is a mismatch between document size and paper size. Even if exactly the same values and unit are used, it is possible that the printed results takes more pages than expected.

To solve the issue, the page size is set via `@page` size, and the canvas and ancestor nodes are assigned a width+height of 100% (=relative to the page). This change resolves bugs such as blank pages and split pages.

To test the result, open a PDF with A4 size, such as the ones in https://github.com/mozilla/pdf.js/issues/5718 and open a print preview. No blanks pages should appear between the pages (in Firefox, a blank page shows up at the end, but this was already present before my patch).

Fixes #5718 (no blank pages, and the correct paper size is automatically selected if needed; only in Chrome, Firefox does not support `@page size yet` - https://bugzilla.mozilla.org/show_bug.cgi?id=851937).
