### PR TITLE
Hook the SVG backend into the viewer and implement testing

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -75,6 +75,13 @@
     "useOnlyCssZoom": {
       "type": "boolean",
       "default": false
+    },
+    "displayBackend": {
+      "title": "Display backend",
+      "description": "The display backend to use. Accepted values: 'canvas' and 'svg'.",
+      "type": "string",
+      "pattern": "|canvas|svg|",
+      "default": "svg"
     }
   }
 }

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -24,6 +24,13 @@
 'use strict';
 
 /**
+ * Specifies the display backend to use.
+ * @var {string}
+ */
+PDFJS.displayBackend = (PDFJS.displayBackend === undefined ?
+                        'svg' : PDFJS.displayBackend);
+
+/**
  * The maximum allowed image size in total pixels e.g. width * height. Images
  * above this value will not be drawn. Use -1 for no limit.
  * @var {number}
@@ -1372,7 +1379,9 @@ var WorkerTransport = (function WorkerTransportClosure() {
           }
         }
         this.commonObjs.clear();
-        FontLoader.clear();
+        if (PDFJS.displayBackend === 'canvas') {
+          FontLoader.clear();
+        }
       }.bind(this));
     }
   };

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -19,7 +19,6 @@
 
 'use strict';
 
-//#if (GENERIC || SINGLE_FILE)
 var SVG_DEFAULTS = {
   fontStyle: 'normal',
   fontWeight: 'normal',
@@ -1191,4 +1190,3 @@ var SVGGraphics = (function SVGGraphicsClosure() {
 })();
 
 PDFJS.SVGGraphics = SVGGraphics;
-//#endif

--- a/test/svg_todataurl.js
+++ b/test/svg_todataurl.js
@@ -1,0 +1,219 @@
+/**
+	The missing SVG.toDataURL library for your SVG elements.
+	
+	Usage: SVGElement.toDataURL( type, { options } )
+
+	Returns: the data URL, except when using native PNG renderer (needs callback).
+
+	type	MIME type of the exported data.
+			Default: image/svg+xml.
+			Must support: image/png.
+			Additional: image/jpeg.
+
+	options is a map of options: {
+		callback: function(dataURL)
+			Callback function which is called when the data URL is ready.
+			This is only necessary when using native PNG renderer.
+			Default: undefined.
+		
+		[the rest of the options only apply when type="image/png" or type="image/jpeg"]
+
+		renderer: "native"|"canvg"
+			PNG renderer to use. Native renderer¹ might cause a security exception.
+			Default: canvg if available, otherwise native.
+
+		keepNonSafe: true|false
+			Export non-safe (image and foreignObject) elements.
+			This will set the Canvas origin-clean property to false, if this data is transferred to Canvas.
+			Default: false, to keep origin-clean true.
+			NOTE: not currently supported and is just ignored.
+
+		keepOutsideViewport: true|false
+			Export all drawn content, even if not visible.
+			Default: false, export only visible viewport, similar to Canvas toDataURL().
+			NOTE: only supported with canvg renderer.
+	}
+
+	See original paper¹ for more info on SVG to Canvas exporting.
+
+	¹ http://svgopen.org/2010/papers/62-From_SVG_to_Canvas_and_Back/#svg_to_canvas
+*/
+
+SVGElement.prototype.toDataURL = function(type, options) {
+	var _svg = this;
+	
+	function debug(s) {
+		console.log("SVG.toDataURL:", s);
+	}
+
+	function exportSVG() {
+		var svg_xml = XMLSerialize(_svg);
+		var svg_dataurl = base64dataURLencode(svg_xml);
+		debug(type + " length: " + svg_dataurl.length);
+
+		// NOTE double data carrier
+		if (options.callback) options.callback(svg_dataurl);
+		return svg_dataurl;
+	}
+
+	function XMLSerialize(svg) {
+
+		// quick-n-serialize an SVG dom, needed for IE9 where there's no XMLSerializer nor SVG.xml
+		// s: SVG dom, which is the <svg> elemennt
+		function XMLSerializerForIE(s) {
+			var out = "";
+			
+			out += "<" + s.nodeName;
+			for (var n = 0; n < s.attributes.length; n++) {
+				out += " " + s.attributes[n].name + "=" + "'" + s.attributes[n].value + "'";
+			}
+			
+			if (s.hasChildNodes()) {
+				out += ">\n";
+
+				for (var n = 0; n < s.childNodes.length; n++) {
+					out += XMLSerializerForIE(s.childNodes[n]);
+				}
+
+				out += "</" + s.nodeName + ">" + "\n";
+
+			} else out += " />\n";
+
+			return out;
+		}
+
+		
+		if (window.XMLSerializer) {
+			debug("using standard XMLSerializer.serializeToString")
+			return (new XMLSerializer()).serializeToString(svg);
+		} else {
+			debug("using custom XMLSerializerForIE")
+			return XMLSerializerForIE(svg);
+		}
+	
+	}
+
+	function base64dataURLencode(s) {
+		var b64 = "data:image/svg+xml;base64,";
+
+		// https://developer.mozilla.org/en/DOM/window.btoa
+		if (window.btoa) {
+			debug("using window.btoa for base64 encoding");
+			b64 += btoa(unescape(encodeURIComponent(s)));
+		} else {
+			debug("using custom base64 encoder");
+			b64 += Base64.encode(unescape(encodeURIComponent(s)));
+		}
+		
+		return b64;
+	}
+
+	function exportImage(type) {
+		var canvas = document.createElement("canvas");
+		var ctx = canvas.getContext('2d');
+
+		// TODO: if (options.keepOutsideViewport), do some translation magic?
+
+		var svg_img = new Image();
+		var svg_xml = XMLSerialize(_svg);
+		svg_img.src = base64dataURLencode(svg_xml);
+
+		svg_img.onload = function() {
+			debug("exported image size: " + [svg_img.width, svg_img.height])
+			canvas.width = svg_img.width;
+			canvas.height = svg_img.height;
+			ctx.drawImage(svg_img, 0, 0);
+
+			// SECURITY_ERR WILL HAPPEN NOW
+			var png_dataurl = canvas.toDataURL(type);
+			debug(type + " length: " + png_dataurl.length);
+
+			if (options.callback) options.callback( png_dataurl );
+			else debug("WARNING: no callback set, so nothing happens.");
+		}
+		
+		svg_img.onerror = function() {
+			console.log(
+				"Can't export! Maybe your browser doesn't support " +
+				"SVG in img element or SVG input for Canvas drawImage?\n" +
+				"http://en.wikipedia.org/wiki/SVG#Native_support"
+			);
+		}
+
+		// NOTE: will not return anything
+	}
+
+	function exportImageCanvg(type) {
+		var canvas = document.createElement("canvas");
+		var ctx = canvas.getContext('2d');
+		var svg_xml = XMLSerialize(_svg);
+
+		// NOTE: canvg gets the SVG element dimensions incorrectly if not specified as attributes
+		//debug("detected svg dimensions " + [_svg.clientWidth, _svg.clientHeight])
+		//debug("canvas dimensions " + [canvas.width, canvas.height])
+
+		var keepBB = options.keepOutsideViewport;
+		if (keepBB) var bb = _svg.getBBox();
+
+		// NOTE: this canvg call is synchronous and blocks
+		canvg(canvas, svg_xml, { 
+			ignoreMouse: true, ignoreAnimation: true,
+			offsetX: keepBB ? -bb.x : undefined, 
+			offsetY: keepBB ? -bb.y : undefined,
+			scaleWidth: keepBB ? bb.width+bb.x : undefined,
+			scaleHeight: keepBB ? bb.height+bb.y : undefined,
+			renderCallback: function() {
+				debug("exported image dimensions " + [canvas.width, canvas.height]);
+				var png_dataurl = canvas.toDataURL(type);
+				debug(type + " length: " + png_dataurl.length);
+	
+				if (options.callback) options.callback( png_dataurl );
+			}
+		});
+
+		// NOTE: return in addition to callback
+		return canvas.toDataURL(type);
+	}
+
+	// BEGIN MAIN
+
+	if (!type) type = "image/svg+xml";
+	if (!options) options = {};
+
+	if (options.keepNonSafe) debug("NOTE: keepNonSafe is NOT supported and will be ignored!");
+	if (options.keepOutsideViewport) debug("NOTE: keepOutsideViewport is only supported with canvg exporter.");
+	
+	switch (type) {
+		case "image/svg+xml":
+			return exportSVG();
+			break;
+
+		case "image/png":
+		case "image/jpeg":
+
+			if (!options.renderer) {
+				if (window.canvg) options.renderer = "canvg";
+				else options.renderer="native";
+			}
+
+			switch (options.renderer) {
+				case "canvg":
+					debug("using canvg renderer for png export");
+					return exportImageCanvg(type);
+					break;
+
+				case "native":
+					debug("using native renderer for png export. THIS MIGHT FAIL.");
+					return exportImage(type);
+					break;
+
+				default:
+					debug("unknown png renderer given, doing noting (" + options.renderer + ")");
+			}
+
+			break;
+
+		default:
+			debug("Sorry! Exporting as '" + type + "' is not supported!")
+	}
+}

--- a/test/test_slave.html
+++ b/test/test_slave.html
@@ -27,6 +27,8 @@ limitations under the License.
     <script src="/src/display/pattern_helper.js"></script>
     <script src="/src/display/font_loader.js"></script>
     <script src="/src/display/annotation_helper.js"></script>
+    <script src="/src/display/svg.js"></script>
+    <script src="svg_todataurl.js"></script>
     <script src="driver.js"></script>
 
     <script>

--- a/web/default_preferences.js
+++ b/web/default_preferences.js
@@ -36,6 +36,7 @@ var DEFAULT_PREFERENCES = {
 //useOnlyCssZoom: true
 //#else
   disableTextLayer: false,
-  useOnlyCssZoom: false
+  useOnlyCssZoom: false,
+  displayBackend: 'svg'
 //#endif
 };

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -141,8 +141,10 @@ var PDFPageView = (function PDFPageViewClosure() {
       if (this.canvas) {
         // Zeroing the width and height causes Firefox to release graphics
         // resources immediately, which can greatly reduce memory consumption.
-        this.canvas.width = 0;
-        this.canvas.height = 0;
+        if (this.canvas.tagName === 'CANVAS') {
+          this.canvas.width = 0;
+          this.canvas.height = 0;
+        }
         delete this.canvas;
       }
 
@@ -165,7 +167,8 @@ var PDFPageView = (function PDFPageViewClosure() {
       });
 
       var isScalingRestricted = false;
-      if (this.canvas && PDFJS.maxCanvasPixels > 0) {
+      if (this.canvas && PDFJS.maxCanvasPixels > 0 &&
+          PDFJS.displayBackend === 'canvas') {
         var ctx = this.canvas.getContext('2d');
         var outputScale = getOutputScale(ctx);
         var pixelsInViewport = this.viewport.width * this.viewport.height;
@@ -299,75 +302,78 @@ var PDFPageView = (function PDFPageViewClosure() {
       canvasWrapper.style.height = div.style.height;
       canvasWrapper.classList.add('canvasWrapper');
 
-      var canvas = document.createElement('canvas');
-      canvas.id = 'page' + this.id;
-      canvasWrapper.appendChild(canvas);
       if (this.annotationLayer) {
         // annotationLayer needs to stay on top
         div.insertBefore(canvasWrapper, this.annotationLayer.div);
       } else {
         div.appendChild(canvasWrapper);
       }
-      this.canvas = canvas;
 
-      var ctx = canvas.getContext('2d');
-      var outputScale = getOutputScale(ctx);
+      var canvas;
+      if (PDFJS.displayBackend === 'canvas') {
+        canvas = document.createElement('canvas');
+        canvas.id = 'page' + this.id;
+        canvasWrapper.appendChild(canvas);
+        this.canvas = canvas;
 
-      if (PDFJS.useOnlyCssZoom) {
-        var actualSizeViewport = viewport.clone({ scale: CSS_UNITS });
-        // Use a scale that will make the canvas be the original intended size
-        // of the page.
-        outputScale.sx *= actualSizeViewport.width / viewport.width;
-        outputScale.sy *= actualSizeViewport.height / viewport.height;
-        outputScale.scaled = true;
-      }
+        var ctx = canvas.getContext('2d');
+        var outputScale = getOutputScale(ctx);
 
-      if (PDFJS.maxCanvasPixels > 0) {
-        var pixelsInViewport = viewport.width * viewport.height;
-        var maxScale = Math.sqrt(PDFJS.maxCanvasPixels / pixelsInViewport);
-        if (outputScale.sx > maxScale || outputScale.sy > maxScale) {
-          outputScale.sx = maxScale;
-          outputScale.sy = maxScale;
+        if (PDFJS.useOnlyCssZoom) {
+          var actualSizeViewport = viewport.clone({ scale: CSS_UNITS });
+          // Use a scale that will make the canvas be the original intended size
+          // of the page.
+          outputScale.sx *= actualSizeViewport.width / viewport.width;
+          outputScale.sy *= actualSizeViewport.height / viewport.height;
           outputScale.scaled = true;
-          this.hasRestrictedScaling = true;
-        } else {
-          this.hasRestrictedScaling = false;
+        }
+
+        if (PDFJS.maxCanvasPixels > 0) {
+          var pixelsInViewport = viewport.width * viewport.height;
+          var maxScale = Math.sqrt(PDFJS.maxCanvasPixels / pixelsInViewport);
+          if (outputScale.sx > maxScale || outputScale.sy > maxScale) {
+            outputScale.sx = maxScale;
+            outputScale.sy = maxScale;
+            outputScale.scaled = true;
+            this.hasRestrictedScaling = true;
+          } else {
+            this.hasRestrictedScaling = false;
+          }
+        }
+
+        canvas.width = (Math.floor(viewport.width) * outputScale.sx) | 0;
+        canvas.height = (Math.floor(viewport.height) * outputScale.sy) | 0;
+        canvas.style.width = Math.floor(viewport.width) + 'px';
+        canvas.style.height = Math.floor(viewport.height) + 'px';
+        // Add the viewport so it's known what it was originally drawn with.
+        canvas._viewport = viewport;
+
+        // TODO(mack): use data attributes to store these
+        ctx._scaleX = outputScale.sx;
+        ctx._scaleY = outputScale.sy;
+        if (outputScale.scaled) {
+          ctx.scale(outputScale.sx, outputScale.sy);
         }
       }
-
-      canvas.width = (Math.floor(viewport.width) * outputScale.sx) | 0;
-      canvas.height = (Math.floor(viewport.height) * outputScale.sy) | 0;
-      canvas.style.width = Math.floor(viewport.width) + 'px';
-      canvas.style.height = Math.floor(viewport.height) + 'px';
-      // Add the viewport so it's known what it was originally drawn with.
-      canvas._viewport = viewport;
 
       var textLayerDiv = null;
       var textLayer = null;
       if (this.textLayerFactory) {
         textLayerDiv = document.createElement('div');
         textLayerDiv.className = 'textLayer';
-        textLayerDiv.style.width = canvas.style.width;
-        textLayerDiv.style.height = canvas.style.height;
+        textLayerDiv.style.width = Math.floor(viewport.width) + 'px';
+        textLayerDiv.style.height = Math.floor(viewport.height) + 'px';
         if (this.annotationLayer) {
           // annotationLayer needs to stay on top
           div.insertBefore(textLayerDiv, this.annotationLayer.div);
         } else {
           div.appendChild(textLayerDiv);
         }
-
         textLayer = this.textLayerFactory.createTextLayerBuilder(textLayerDiv,
                                                                  this.id - 1,
                                                                  this.viewport);
       }
       this.textLayer = textLayer;
-
-      // TODO(mack): use data attributes to store these
-      ctx._scaleX = outputScale.sx;
-      ctx._scaleY = outputScale.sy;
-      if (outputScale.scaled) {
-        ctx.scale(outputScale.sx, outputScale.sy);
-      }
 
       var resolveRenderPromise, rejectRenderPromise;
       var promise = new Promise(function (resolve, reject) {
@@ -428,6 +434,26 @@ var PDFPageView = (function PDFPageViewClosure() {
         } else {
           rejectRenderPromise(error);
         }
+      }
+
+      if (PDFJS.displayBackend === 'svg') {
+        // The next page fetch will start after this page rendering is done
+        this.pdfPage.getOperatorList().then(function (opList) {
+          var page = self.pdfPage;
+          var pageNum = self.id;
+          var svgGfx = new PDFJS.SVGGraphics(page.commonObjs, page.objs);
+          
+          return svgGfx.getSVG(opList, viewport).then(function (svg) {
+            self.canvas = canvas = svg;
+            canvas._viewport = viewport;
+            canvasWrapper.appendChild(canvas);
+            pageViewDrawCallback(null);
+          }, function (reason) {
+            pageViewDrawCallback(reason);
+          });
+        });
+        div.setAttribute('data-loaded', true);
+        return;
       }
 
       var renderContinueCallback = null;

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -40,6 +40,10 @@ select {
   outline: none;
 }
 
+svg text {
+  cursor: text;
+}
+
 .hidden {
   display: none !important;
 }
@@ -1681,7 +1685,7 @@ html[dir='rtl'] #documentPropertiesOverlay .row > * {
     overflow: visible;
   }
 
-  #mainContainer, #viewerContainer, .page, .page canvas {
+  #mainContainer, #viewerContainer, .page, .page canvas, .page svg {
     position: static;
     padding: 0;
     margin: 0;

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -55,6 +55,7 @@ http://sourceforge.net/adobe/cmap/wiki/License/
     <script src="../src/display/pattern_helper.js"></script>
     <script src="../src/display/font_loader.js"></script>
     <script src="../src/display/annotation_helper.js"></script>
+    <script src="../src/display/svg.js"></script>
     <script>PDFJS.workerSrc = '../src/worker_loader.js';</script>
 <!--#endif-->
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -220,6 +220,9 @@ var PDFViewerApplication = {
 
     var self = this;
     var initializedPromise = Promise.all([
+      Preferences.get('displayBackend').then(function resolved(value) {
+        PDFJS.displayBackend = value;
+      }),
       Preferences.get('enableWebGL').then(function resolved(value) {
         PDFJS.disableWebGL = !value;
       }),
@@ -1476,6 +1479,9 @@ function webViewerInitialized() {
     var hash = document.location.hash.substring(1);
     var hashParams = PDFViewerApplication.parseQueryString(hash);
 
+    if ('displayBackend' in hashParams) {
+      PDFJS.displayBackend = hashParams['displaybackend'];
+    }
     if ('disableworker' in hashParams) {
       PDFJS.disableWorker = (hashParams['disableworker'] === 'true');
     }
@@ -1511,6 +1517,10 @@ function webViewerInitialized() {
     if ('disablebcmaps' in hashParams && hashParams['disablebcmaps']) {
       PDFJS.cMapUrl = '../external/cmaps/';
       PDFJS.cMapPacked = false;
+    }
+    if (PDFJS.displayBackend === 'svg') {
+      PDFJS.useOnlyCssZoom = true;
+      PDFJS.disableTextLayer = true;
     }
 //#endif
 //#if !(FIREFOX || MOZCENTRAL)


### PR DESCRIPTION
**Heavily WIP. Do not merge!**

The idea of this patch is to explore working with two backends (canvas and SVG) and to run the tests for the SVG backend. It is based on @yurydelendik's work in #5159. Please feel free to provide suggestions such that we can come up with a solution that can actually be implemented. The goal of this PR is to explore where the difficulties are and to try to overcome them. A follow-up patch can then provide a pretty solution.

Current problems:
- [ ] SVG to PNG does not keep font data. A possible solution is to render the SVG on a canvas and save that.
- [ ] We can do with less code edits (e.g., text test removal), but for now this was the fastest. The test driver needs to be refactored to make certain code paths depend on `PDFJS.displayBackend` to solve this. There are no text tests for the SVG backend as there is no text layer, but SVG text instead.
