### PR TITLE
Add custom |outlineloaded| and |attachmentsloaded| events to the viewer (bug 1112947)

### DIFF
--- a/web/pdf_attachment_view.js
+++ b/web/pdf_attachment_view.js
@@ -50,6 +50,17 @@ var PDFAttachmentView = (function PDFAttachmentViewClosure() {
     /**
      * @private
      */
+    _dispatchEvent: function PDFAttachmentView_dispatchEvent(attachmentsCount) {
+      var event = document.createEvent('CustomEvent');
+      event.initCustomEvent('attachmentsloaded', true, true, {
+        attachmentsCount: attachmentsCount
+      });
+      this.container.dispatchEvent(event);
+    },
+
+    /**
+     * @private
+     */
     _bindLink: function PDFAttachmentView_bindLink(button, content, filename) {
       button.onclick = function downloadFile(e) {
         this.downloadManager.downloadData(content, filename, '');
@@ -59,17 +70,21 @@ var PDFAttachmentView = (function PDFAttachmentViewClosure() {
 
     render: function PDFAttachmentView_render() {
       var attachments = this.attachments;
+      var attachmentsCount = 0;
 
       this.reset();
 
       if (!attachments) {
+        this._dispatchEvent(attachmentsCount);
         return;
       }
 
       var names = Object.keys(attachments).sort(function(a, b) {
         return a.toLowerCase().localeCompare(b.toLowerCase());
       });
-      for (var i = 0, len = names.length; i < len; i++) {
+      attachmentsCount = names.length;
+
+      for (var i = 0; i < attachmentsCount; i++) {
         var item = attachments[names[i]];
         var filename = getFileName(item.filename);
         var div = document.createElement('div');
@@ -80,6 +95,8 @@ var PDFAttachmentView = (function PDFAttachmentViewClosure() {
         div.appendChild(button);
         this.container.appendChild(div);
       }
+
+      this._dispatchEvent(attachmentsCount);
     }
   };
 

--- a/web/pdf_outline_view.js
+++ b/web/pdf_outline_view.js
@@ -49,6 +49,17 @@ var PDFOutlineView = (function PDFOutlineViewClosure() {
     /**
      * @private
      */
+    _dispatchEvent: function PDFOutlineView_dispatchEvent(outlineCount) {
+      var event = document.createEvent('CustomEvent');
+      event.initCustomEvent('outlineloaded', true, true, {
+        outlineCount: outlineCount
+      });
+      this.container.dispatchEvent(event);
+    },
+
+    /**
+     * @private
+     */
     _bindLink: function PDFOutlineView_bindLink(element, item) {
       var linkService = this.linkService;
       element.href = linkService.getDestinationHash(item.dest);
@@ -60,10 +71,12 @@ var PDFOutlineView = (function PDFOutlineViewClosure() {
 
     render: function PDFOutlineView_render() {
       var outline = this.outline;
+      var outlineCount = 0;
 
       this.reset();
 
       if (!outline) {
+        this._dispatchEvent(outlineCount);
         return;
       }
 
@@ -87,8 +100,11 @@ var PDFOutlineView = (function PDFOutlineViewClosure() {
           }
 
           levelData.parent.appendChild(div);
+          outlineCount++;
         }
       }
+
+      this._dispatchEvent(outlineCount);
     }
   };
 


### PR DESCRIPTION
When looking at the intermittent failure in https://bugzilla.mozilla.org/show_bug.cgi?id=1112947, it seems to me that the only good solution to get rid of [the problematic `setTimeout`](https://bugzilla.mozilla.org/show_bug.cgi?id=1112947#c20), is to provide an event that can be used instead.
Hence this patch (tentatively) adds two new events, `outlineloaded` and `attachmentsloaded`.
