### PR TITLE
PR 5749 followup

### DIFF
--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -63,13 +63,6 @@ function getContainingBrowser(domWindow) {
                   .chromeEventHandler;
 }
 
-function getChromeWindow(domWindow) {
-  if (PdfjsContentUtils.isRemote) {
-    return PdfjsContentUtils.getChromeWindow(domWindow);
-  }
-  return getContainingBrowser(domWindow).ownerDocument.defaultView;
-}
-
 function getFindBar(domWindow) {
   if (PdfjsContentUtils.isRemote) {
     throw new Error('FindBar is not accessible from the content process.');

--- a/extensions/firefox/content/PdfjsContentUtils.jsm
+++ b/extensions/firefox/content/PdfjsContentUtils.jsm
@@ -149,55 +149,5 @@ let PdfjsContentUtils = {
         }
         break;
     }
-  },
-
-  /*
-   * CPOWs
-   */
-
-  getChromeWindow: function (aWindow) {
-    let winmm = aWindow.QueryInterface(Ci.nsIInterfaceRequestor)
-                        .getInterface(Ci.nsIDocShell)
-                        .sameTypeRootTreeItem
-                        .QueryInterface(Ci.nsIDocShell)
-                        .QueryInterface(Ci.nsIInterfaceRequestor)
-                        .getInterface(Ci.nsIContentFrameMessageManager);
-    // Sync calls don't support cpow wrapping of returned results, so we
-    // send over a small container for the object we want.
-    let suitcase = {
-      _window: null,
-      setChromeWindow: function (aObj) {
-        this._window = aObj;
-      }
-    };
-    if (!winmm.sendSyncMessage('PDFJS:Parent:getChromeWindow', {},
-                               { suitcase: suitcase })[0]) {
-      Cu.reportError('A request for a CPOW wrapped chrome window ' +
-                     'failed for unknown reasons.');
-      return null;
-    }
-    return suitcase._window;
-  },
-
-  getFindBar: function (aWindow) {
-    let winmm = aWindow.QueryInterface(Ci.nsIInterfaceRequestor)
-                        .getInterface(Ci.nsIDocShell)
-                        .sameTypeRootTreeItem
-                        .QueryInterface(Ci.nsIDocShell)
-                        .QueryInterface(Ci.nsIInterfaceRequestor)
-                        .getInterface(Ci.nsIContentFrameMessageManager);
-    let suitcase = {
-      _findbar: null,
-      setFindBar: function (aObj) {
-        this._findbar = aObj;
-      }
-    };
-    if (!winmm.sendSyncMessage('PDFJS:Parent:getFindBar', {},
-                               { suitcase: suitcase })[0]) {
-      Cu.reportError('A request for a CPOW wrapped findbar ' +
-                     'failed for unknown reasons.');
-      return null;
-    }
-    return suitcase._findbar;
   }
 };


### PR DESCRIPTION
- Remove obsolete CPOW code from PdfjsContentUtils.jsm (PR 5749 followup)<br/>This code is unused since PR 5749, and according to https://github.com/mozilla/pdf.js/pull/5749#discussion_r25931841 it should be removed.
- Remove unused |getChromeWindow| function from PdfStreamConverter.jsm
