### PR TITLE
Remove reference to GNUpdf from comment in |DocumentProperties.parseDate|

### DIFF
--- a/web/document_properties.js
+++ b/web/document_properties.js
@@ -151,8 +151,7 @@ var DocumentProperties = {
   },
 
   parseDate: function documentPropertiesParseDate(inputDate) {
-    // This is implemented according to the PDF specification (see
-    // http://www.gnupdf.org/Date for an overview), but note that
+    // This is implemented according to the PDF specification, but note that
     // Adobe Reader doesn't handle changing the date to universal time
     // and doesn't use the user's time zone (they're effectively ignoring
     // the HH' and mm' parts of the date string).


### PR DESCRIPTION
Since the link is no longer valid, we should remove it from the comment.

(Using the Internet Archive, it seems that the contents of that page was basically identical to the PDF specification.)
