### PR TITLE
Prevent external links from "replacing" the viewer when it's embedded (bug 976541)

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -263,6 +263,12 @@ var PDFViewerApplication = {
       // TODO move more preferences and other async stuff here
     ]).catch(function (reason) { });
 
+    if (this.isViewerEmbedded) {
+      // Prevent external links from "replacing" the viewer when it's embedded
+      // in e.g. an iframe or an object.
+      PDFJS.openExternalLinksInNewWindow = true;
+    }
+
     return initializedPromise.then(function () {
       PDFViewerApplication.initialized = true;
     });


### PR DESCRIPTION
A tentative patch, that fixes https://bugzilla.mozilla.org/show_bug.cgi?id=976541.

To test this, install the Firefox extension, and visit e.g. http://www.cs.tut.fi/~jkorpela/html/iframe-pdf.html.
