### PR TITLE
Re-factor and clean-up some preference related code in viewer.js

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -232,9 +232,6 @@ var PDFViewerApplication = {
       }),
       Preferences.get('showPreviousViewOnLoad').then(function resolved(value) {
         self.preferenceShowPreviousViewOnLoad = value;
-        if (!value && window.history.state) {
-          window.history.replaceState(null, '');
-        }
       }),
       Preferences.get('defaultZoomValue').then(function resolved(value) {
         self.preferenceDefaultZoomValue = value;
@@ -884,6 +881,9 @@ var PDFViewerApplication = {
       if (!PDFJS.disableHistory && !self.isViewerEmbedded) {
         // The browsing history is only enabled when the viewer is standalone,
         // i.e. not when it is embedded in a web page.
+        if (!self.preferenceShowPreviousViewOnLoad && window.history.state) {
+          window.history.replaceState(null, '');
+        }
         PDFHistory.initialize(self.documentFingerprint, self);
       }
     });
@@ -891,7 +891,7 @@ var PDFViewerApplication = {
     var storePromise = store.initializedPromise;
     Promise.all([firstPagePromise, storePromise]).then(function resolved() {
       var storedHash = null;
-      if (PDFViewerApplication.preferenceShowPreviousViewOnLoad &&
+      if (self.preferenceShowPreviousViewOnLoad &&
           store.get('exists', false)) {
         var pageNum = store.get('page', '1');
         var zoom = self.preferenceDefaultZoomValue ||

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -886,38 +886,34 @@ var PDFViewerApplication = {
         }
         PDFHistory.initialize(self.documentFingerprint, self);
       }
-    });
 
-    var storePromise = store.initializedPromise;
-    Promise.all([firstPagePromise, storePromise]).then(function resolved() {
-      var storedHash = null;
-      if (self.preferenceShowPreviousViewOnLoad &&
-          store.get('exists', false)) {
-        var pageNum = store.get('page', '1');
-        var zoom = self.preferenceDefaultZoomValue ||
-                   store.get('zoom', self.pdfViewer.currentScale);
-        var left = store.get('scrollLeft', '0');
-        var top = store.get('scrollTop', '0');
+      store.initializedPromise.then(function resolved() {
+        var storedHash = null;
+        if (self.preferenceShowPreviousViewOnLoad &&
+            store.get('exists', false)) {
+          var pageNum = store.get('page', '1');
+          var zoom = self.preferenceDefaultZoomValue ||
+                     store.get('zoom', self.pdfViewer.currentScale);
+          var left = store.get('scrollLeft', '0');
+          var top = store.get('scrollTop', '0');
 
-        storedHash = 'page=' + pageNum + '&zoom=' + zoom + ',' +
-                     left + ',' + top;
-      } else if (self.preferenceDefaultZoomValue) {
-        storedHash = 'page=1&zoom=' + self.preferenceDefaultZoomValue;
-      }
-      self.setInitialView(storedHash, scale);
+          storedHash = 'page=' + pageNum + '&zoom=' + zoom + ',' +
+                       left + ',' + top;
+        } else if (self.preferenceDefaultZoomValue) {
+          storedHash = 'page=1&zoom=' + self.preferenceDefaultZoomValue;
+        }
+        self.setInitialView(storedHash, scale);
 
-      // Make all navigation keys work on document load,
-      // unless the viewer is embedded in a web page.
-      if (!self.isViewerEmbedded) {
-        self.pdfViewer.focus();
+        // Make all navigation keys work on document load,
+        // unless the viewer is embedded in a web page.
+        if (!self.isViewerEmbedded) {
+          self.pdfViewer.focus();
 //#if (FIREFOX || MOZCENTRAL)
-//      self.pdfViewer.blur();
+//        self.pdfViewer.blur();
 //#endif
-      }
-    }, function rejected(reason) {
-      console.error(reason);
-
-      firstPagePromise.then(function () {
+        }
+      }, function rejected(reason) {
+        console.error(reason);
         self.setInitialView(null, scale);
       });
     });


### PR DESCRIPTION
_For details, please refer to the individual commit messages._

These patches slightly re-factors the handling of a couple of preferences in viewer.js, and also simplifies the code that sets the initial document position on load.

**Edit:** Also, the `?w=1` URL flag should simplify things when reviewing the last patch!
