### PR TITLE
Extract more accurate glyph heights from type3 fonts

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -956,6 +956,17 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           var tsm = [textState.fontSize * textState.textHScale, 0,
                      0, textState.fontSize,
                      0, textState.textRise];
+
+          if (font.isType3Font &&
+              textState.fontMatrix !== FONT_IDENTITY_MATRIX &&
+              textState.fontSize === 1) {
+            var glyphHeight = font.bbox[3] - font.bbox[1];
+            if (glyphHeight > 0) {
+              glyphHeight = glyphHeight * textState.fontMatrix[3];
+              tsm[3] *= glyphHeight;
+            }
+          }
+
           var trm = textChunk.transform = Util.transform(textState.ctm,
                                     Util.transform(textState.textMatrix, tsm));
           if (!font.vertical) {
@@ -1615,6 +1626,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           // is a tagged pdf. Create a barbebones one to get by.
           descriptor = new Dict(null);
           descriptor.set('FontName', Name.get(type));
+          descriptor.set('FontBBox', dict.get('FontBBox'));
         } else {
           // Before PDF 1.5 if the font was one of the base 14 fonts, having a
           // FontDescriptor was not required.

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -2438,6 +2438,7 @@ var Font = (function FontClosure() {
     this.ascent = properties.ascent / PDF_GLYPH_SPACE_UNITS;
     this.descent = properties.descent / PDF_GLYPH_SPACE_UNITS;
     this.fontMatrix = properties.fontMatrix;
+    this.bbox = properties.bbox;
 
     this.toUnicode = properties.toUnicode = this.buildToUnicode(properties);
 


### PR DESCRIPTION
Unlike other font-types, type-3 fonts define a custom transformation from glyph-space to text-space, via the `FontMatrix`. As such, we cannot assume the glyph's to have a height of `1 unit` (as is done currently). By utilizing the `FontBBox` (which is a required property of type-3 fonts), we can get a good estimate of the glyph height.

From the spec:

> The glyph coordinate system is the space in which an individual character’s glyph is defined. All path coordinates and metrics shall be interpreted in glyph space. For all font types except Type 3, the units of glyph space are one-thousandth of a unit of text space; for a Type 3 font, the transformation from glyph space to text space shall be defined by a font matrix specified in an explicit FontMatrix entry in the font.

And

> A font defines the glyphs at one standard size. This standard is arranged so that the nominal height of tightly spaced lines of text is 1 unit

Improvements can be verified by text-selection in these PDF's:

http://www.dfki.uni-kl.de/~kieni/publications/spie98.pdf

http://neo.lcc.uma.es/Articles/WRH98.pdf

Fixes #5896.
