### PR TITLE
Remove commented out code about |disableWorker| in the test suite

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -23,10 +23,6 @@
  */
 (function DriverClosure() {
 
-// Disable worker support for running test as
-//   https://github.com/mozilla/pdf.js/pull/764#issuecomment-2638944
-//   "firefox-bin: Fatal IO error 12 (Cannot allocate memory) on X server :1."
-// PDFJS.disableWorker = true;
 PDFJS.enableStats = true;
 PDFJS.cMapUrl = '../external/bcmaps/';
 PDFJS.cMapPacked = true;

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -6,7 +6,6 @@
 'use strict';
 
 describe('api', function() {
-  // TODO run with worker enabled
   var basicApiUrl = combineUrl(window.location.href, '../pdfs/basicapi.pdf');
   var basicApiFileLength = 105779; // bytes
   function waitsForPromiseResolved(promise, successCallback) {


### PR DESCRIPTION
Since the tests have run with workers enabled for a long time, these comments are no longer relevant.
