### PR TITLE
[B2G] Stub the |DownloadManager| to avoid error

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -65,6 +65,11 @@ var mozL10n = document.mozL10n || document.webL10n;
 //#if GENERIC || CHROME
 //#include download_manager.js
 //#endif
+//#if B2G
+//var DownloadManager = (function DownloadManagerClosure() {
+//  return function DownloadManager() {};
+//})();
+//#endif
 
 //#if FIREFOX || MOZCENTRAL
 //#include firefoxcom.js


### PR DESCRIPTION
After the refactoring in PR #5678, the B2G viewer now prints the following in the console:

```
ReferenceError: DownloadManager is not defined
```

This will obviously not matter once the B2G viewer is replaced with the new components-based one. But until that happens, I think it makes sense to just stub the class to suppress the error.
