### PR TITLE
[Firefox] Replace the CPOW with asynchronous messages for the Fallback bar

### DIFF
--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -482,9 +482,23 @@ ChromeActions.prototype = {
       message = getLocalizedString(strings, 'unsupported_feature');
     }
     PdfJsTelemetry.onFallback();
-    PdfjsContentUtils.displayWarning(domWindow, message, sendResponse,
+    PdfjsContentUtils.displayWarning(domWindow, message,
       getLocalizedString(strings, 'open_with_different_viewer'),
       getLocalizedString(strings, 'open_with_different_viewer', 'accessKey'));
+
+    let winmm = domWindow.QueryInterface(Ci.nsIInterfaceRequestor)
+                         .getInterface(Ci.nsIDocShell)
+                         .QueryInterface(Ci.nsIInterfaceRequestor)
+                         .getInterface(Ci.nsIContentFrameMessageManager);
+
+    winmm.addMessageListener('PDFJS:Child:fallbackDownload',
+      function fallbackDownload(msg) {
+        let data = msg.data;
+        sendResponse(data.download);
+
+        winmm.removeMessageListener('PDFJS:Child:fallbackDownload',
+                                    fallbackDownload);
+      });
   },
   updateFindControlState: function(data) {
     if (!this.supportsIntegratedFind()) {

--- a/extensions/firefox/content/PdfjsChromeUtils.jsm
+++ b/extensions/firefox/content/PdfjsChromeUtils.jsm
@@ -295,24 +295,30 @@ let PdfjsChromeUtils = {
    * a pdf displayed correctly.
    */
   _displayWarning: function (aMsg) {
-    let json = aMsg.data;
+    let data = aMsg.data;
     let browser = aMsg.target;
-    let cpowCallback = aMsg.objects.callback;
+
     let tabbrowser = browser.getTabBrowser();
     let notificationBox = tabbrowser.getNotificationBox(browser);
-    // Flag so we don't call the response callback twice, since if the user
-    // clicks open with different viewer both the button callback and
+
+    // Flag so we don't send the message twice, since if the user clicks
+    // "open with different viewer" both the button callback and
     // eventCallback will be called.
-    let responseSent = false;
+    let messageSent = false;
+    function sendMessage(download) {
+      let mm = browser.messageManager;
+      mm.sendAsyncMessage('PDFJS:Child:fallbackDownload',
+                          { download: download });
+    }
     let buttons = [{
-      label: json.label,
-      accessKey: json.accessKey,
+      label: data.label,
+      accessKey: data.accessKey,
       callback: function() {
-        responseSent = true;
-        cpowCallback(true);
+        messageSent = true;
+        sendMessage(true);
       }
     }];
-    notificationBox.appendNotification(json.message, 'pdfjs-fallback', null,
+    notificationBox.appendNotification(data.message, 'pdfjs-fallback', null,
                                        notificationBox.PRIORITY_INFO_LOW,
                                        buttons,
                                        function eventsCallback(eventType) {
@@ -323,10 +329,10 @@ let PdfjsChromeUtils = {
       }
       // Don't send a response again if we already responded when the button was
       // clicked.
-      if (responseSent) {
+      if (messageSent) {
         return;
       }
-      cpowCallback(false);
+      sendMessage(false);
     });
   }
 };

--- a/extensions/firefox/content/PdfjsContentUtils.jsm
+++ b/extensions/firefox/content/PdfjsContentUtils.jsm
@@ -112,7 +112,7 @@ let PdfjsContentUtils = {
    * Request the display of a notification warning in the associated window
    * when the renderer isn't sure a pdf displayed correctly.
    */
-  displayWarning: function (aWindow, aMessage, aCallback, aLabel, accessKey) {
+  displayWarning: function (aWindow, aMessage, aLabel, accessKey) {
     // the child's dom frame mm associated with the window.
     let winmm = aWindow.QueryInterface(Ci.nsIInterfaceRequestor)
                        .getInterface(Ci.nsIDocShell)
@@ -122,8 +122,6 @@ let PdfjsContentUtils = {
       message: aMessage,
       label: aLabel,
       accessKey: accessKey
-    }, {
-      callback: aCallback
     });
   },
 


### PR DESCRIPTION
This patch removes the only remaining CPOW usage from the code-base, and should thus fix https://bugzilla.mozilla.org/show_bug.cgi?id=1071082.

_Note:_ This will not fix the "Open With Different Viewer" button in e10s, since clicking it still fails with `frontWindow is null` in the console, but I do believe that that issue is somewhat orthogonal to this patch.
