### PR TITLE
Remove commented out code from viewer.html

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -239,7 +239,6 @@ http://sourceforge.net/adobe/cmap/wiki/License/
                 <button id="download" class="toolbarButton download hiddenMediumView" title="Download" tabindex="34" data-l10n-id="download">
                   <span data-l10n-id="download_label">Download</span>
                 </button>
-                <!-- <div class="toolbarButtonSpacer"></div> -->
                 <a href="#" id="viewBookmark" class="toolbarButton bookmark hiddenSmallView" title="Current view (copy or open in new window)" tabindex="35" data-l10n-id="bookmark">
                   <span data-l10n-id="bookmark_label">Current View</span>
                 </a>
@@ -391,6 +390,6 @@ http://sourceforge.net/adobe/cmap/wiki/License/
     <div id="printContainer"></div>
 <!--#if !(FIREFOX || MOZCENTRAL)-->
 <!--#include viewer-snippet-mozPrintCallback-polyfill.html-->
-<!--#endif--->
+<!--#endif-->
   </body>
 </html>


### PR DESCRIPTION
The line that this patch removes has been commented out since 2012 (!), see commit https://github.com/mozilla/pdf.js/commit/c8a6a9ba004eacf095d41942e6431000845c4ea7.

Also, since the patch is trivial, I'm fixing the formatting of a comment to stop [GitHub from marking it with a red color](https://github.com/mozilla/pdf.js/blob/master/web/viewer.html#L394) (and IE from complaining).
