### PR TITLE
Crypt filter EFF key should have StmF value as default, not StrF

### DIFF
--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -1967,7 +1967,7 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
       this.cf = dict.get('CF');
       this.stmf = dict.get('StmF') || identityName;
       this.strf = dict.get('StrF') || identityName;
-      this.eff = dict.get('EFF') || this.strf;
+      this.eff = dict.get('EFF') || this.stmf;
     }
   }
 


### PR DESCRIPTION
This fixes #5935.
