### PR TITLE
Bug 1156287 - Do not extract unreachable code after return

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1684,9 +1684,7 @@ function webViewerInitialized() {
     }
     return;
   }
-//#endif
 
-//#if !B2G && !CHROME
   if (file) {
     PDFViewerApplication.open(file, 0);
   }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1156287

I'm going to add warning for unreachable code after return statement in https://bugzilla.mozilla.org/show_bug.cgi?id=1151931 , and it hits following code.

http://mxr.mozilla.org/mozilla-central/source/browser/extensions/pdfjs/content/web/viewer.js#6818

```
  PDFViewerApplication.setTitleUsingUrl(file);
  PDFViewerApplication.initPassiveLoading();
  return;


  if (file) {
    PDFViewerApplication.open(file, 0);
  }
}
```

Those are extracted from following code in upstream.

https://github.com/mozilla/pdf.js/blob/master/web/viewer.js#L1661

```
//#if (FIREFOX || MOZCENTRAL)
//PDFViewerApplication.setTitleUsingUrl(file);
//PDFViewerApplication.initPassiveLoading();
//return;
//#endif
```

https://github.com/mozilla/pdf.js/blob/master/web/viewer.js#L1689

```
//#if !B2G && !CHROME
  if (file) {
    PDFViewerApplication.open(file, 0);
  }
//#endif
```

if former code is extracted, latter one won't be reachable, so it shouldn't be extracted if (FIREFOX || MOZCENTRAL) is true.
