### PR TITLE
Remove no longer needed hacks that enable spacebar scrolling in Firefox (issue 3498)

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -622,10 +622,6 @@ var PDFViewer = (function pdfViewer() {
       this.container.focus();
     },
 
-    blur: function () {
-      this.container.blur();
-    },
-
     get isInPresentationMode() {
       return this.presentationModeState === PresentationModeState.FULLSCREEN;
     },

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -922,9 +922,6 @@ var PDFViewerApplication = {
         // unless the viewer is embedded in a web page.
         if (!self.isViewerEmbedded) {
           self.pdfViewer.focus();
-//#if (FIREFOX || MOZCENTRAL)
-//        self.pdfViewer.blur();
-//#endif
         }
       }, function rejected(reason) {
         console.error(reason);
@@ -2169,16 +2166,9 @@ window.addEventListener('keydown', function keydown(evt) {
       pdfViewer.focus();
     }
     // 32=Spacebar
-    if (evt.keyCode === 32 && curElementTagName !== 'BUTTON') {
-//#if (FIREFOX || MOZCENTRAL)
-//    // Workaround for issue in Firefox, that prevents scroll keys from
-//    // working when elements with 'tabindex' are focused. (#3498)
-//    pdfViewer.blur();
-//#else
-      if (!pdfViewer.containsElement(curElement)) {
-        pdfViewer.focus();
-      }
-//#endif
+    if (evt.keyCode === 32 && curElementTagName !== 'BUTTON' &&
+        !pdfViewer.containsElement(curElement)) {
+      pdfViewer.focus();
     }
   }
 


### PR DESCRIPTION
**Note:** _We probably want to hold off merging this a few days (or maybe a week), to ensure that the upstream patch sticks._ ~~**Edit:** https://bugzilla.mozilla.org/show_bug.cgi?id=915962#c14.~~

Now that [bug 915962](https://bugzilla.mozilla.org/show_bug.cgi?id=915962) has landed, we no longer need any hacks to enable <kbd>spacebar</kbd> scrolling in Firefox.

Fixes #3498.
