### PR TITLE
If the top level Pages dictionary has a |Resources| entry, use its content to amend Page |Resources| dictionaries if necessary (issue 5954)

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -589,7 +589,7 @@ var Catalog = (function CatalogClosure() {
             var dict = a[0];
             var ref = a[1];
             return new Page(this.pdfManager, this.xref, pageIndex, dict, ref,
-                            this.fontCache);
+                            this.fontCache, this.toplevelPagesDict);
           }.bind(this)
         );
       }

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -22,6 +22,7 @@
 !issue4630.pdf
 !issue5202.pdf
 !issue5280.pdf
+!issue5954.pdf
 !alphatrans.pdf
 !devicen.pdf
 !cmykjpeg.pdf

--- a/test/pdfs/issue5954.pdf
+++ b/test/pdfs/issue5954.pdf
@@ -1,0 +1,78 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj 
+<<
+/Pages 2 0 R
+/Type /Catalog
+>>
+endobj 
+3 0 obj 
+<<
+/Parent 2 0 R
+/Resources 
+<<
+/XObject 
+<<
+>>
+>>
+/MediaBox [0 0 200 50]
+/Type /Page
+/Contents 4 0 R
+>>
+endobj 
+4 0 obj 
+<<
+/Length 41
+>>
+stream
+BT
+10 20 TD
+/F1 20 Tf
+(Issue 5954) Tj
+ET
+
+endstream 
+endobj 
+2 0 obj 
+<<
+/MediaBox [0 0 200 50]
+/Resources 5 0 R
+/Kids [3 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+5 0 obj 
+<<
+/Font 
+<<
+/F1 6 0 R
+>>
+>>
+endobj 
+6 0 obj 
+<<
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Name /F1
+/Type /Font
+/Encoding /WinAnsiEncoding
+>>
+endobj xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000282 00000 n 
+0000000066 00000 n 
+0000000188 00000 n 
+0000000381 00000 n 
+0000000427 00000 n 
+trailer
+
+<<
+/Root 1 0 R
+/Size 7
+>>
+startxref
+537
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -558,6 +558,13 @@
        "link": false,
        "type": "load"
     },
+    {  "id": "issue5954",
+       "file": "pdfs/issue5954.pdf",
+       "md5": "4f60ec0d9bbeec845b681242b8982361",
+       "rounds": 1,
+       "link": false,
+       "type": "eq"
+    },
     {  "id": "txt2pdf",
        "file": "pdfs/txt2pdf.pdf",
        "md5": "02cefa0f5e8d96313bb05163b2f88c8c",


### PR DESCRIPTION
The PDF file has all of its `Font` resources placed in the `Pages` dictonary, instead of in each `Page` resources dictionary. To work around that, this patch tries to amend the `Page` resources with entries taken from the top level `Pages` resources.

Fixes #5954.

_An added bonus:_ With this patch PDF.js actually renders the file better than Adobe Reader.
