### PR TITLE
Update README.md with shorter clone command and improved instruction order

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,21 +51,26 @@ The version of the extension for the Opera browser can be found at the [Opera ad
 
 To get a local copy of the current code, clone it using git:
 
-    $ git clone git://github.com/mozilla/pdf.js.git pdfjs
-    $ cd pdfjs
+    $ git clone git://github.com/mozilla/pdf.js.git
+    $ cd pdf.js
 
-Next, you need to start a local web server as some browsers don't allow opening
-PDF files for a file:// url:
+Next, install Node.js via the [official package](http://nodejs.org) or via
+[nvm](https://github.com/creationix/nvm). If everything worked out, run
+
+    $ npm install
+
+to install all dependencies for PDF.js.
+
+Finally you need to start a local web server as some browsers do not allow opening
+PDF files using a file:// URL. Run
 
     $ node make server
 
-You can install Node via [nvm](https://github.com/creationix/nvm) or the
-[official package](http://nodejs.org). If everything worked out, you can now
-serve
+and then you can open
 
 + http://localhost:8888/web/viewer.html
 
-You can also view all the test pdf files on the right side serving
+It is also possible to view all test PDF files on the right side by opening
 
 + http://localhost:8888/test/pdfs/?frame
 

--- a/docs/contents/getting_started/index.md
+++ b/docs/contents/getting_started/index.md
@@ -51,8 +51,8 @@ Before downloading PDF.js please take a moment to understand the different layer
   <div class="col-md-6">
     <h3>Source</h3>
     To get a local copy of the current code, clone it using git:
-    <pre><code>$ git clone git://github.com/mozilla/pdf.js.git pdfjs
-$ cd pdfjs
+    <pre><code>$ git clone git://github.com/mozilla/pdf.js.git
+$ cd pdf.js
 </code></pre>
   </div>
 </div>


### PR DESCRIPTION
Supersedes #5978 and improves the order of instructions such that Node.js must be installed first (with dependencies) before telling the user to start a web server.
