### PR TITLE
Bug 1122280 - Handle UTF-8 encoding in URI

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -16,7 +16,8 @@
  */
 /* globals PDFJS, Util, isDict, isName, stringToPDFString, warn, Dict, Stream,
            stringToBytes, assert, Promise, isArray, ObjectLoader, OperatorList,
-           isValidUrl, OPS, createPromiseCapability, AnnotationType */
+           isValidUrl, OPS, createPromiseCapability, AnnotationType, 
+           stringToUTF8String */
 
 'use strict';
 
@@ -500,7 +501,15 @@ var LinkAnnotation = (function LinkAnnotationClosure() {
         if (!isValidUrl(url, false)) {
           url = '';
         }
-        data.url = url;
+        // According to ISO 32000-1:2008, section 12.6.4.7, 
+        // URI should to be encoded in 7-bit ASCII.
+        // Some bad PDFs may have URIs in UTF-8 encoding, see Bugzilla 1122280.
+        try {
+          data.url = stringToUTF8String(url);
+        } catch (e) {
+          // Fall back to a simple copy.
+          data.url = url;
+        }
       } else if (linkType === 'GoTo') {
         data.dest = action.get('D');
       } else if (linkType === 'GoToR') {


### PR DESCRIPTION
URL annotations handled as UTF-8 to accommodate some bad PDFs. For proper 7-bit ASCII this makes no difference. Fixes Bug 1122280.

Reasoning:
According to ISO 32000-1:2008, section 12.6.4.7, URI should be encoded in 7-bit ASCII, i.e. not handling UTF-8 in URI is, strictly speaking, not a bug.
However some bad PDFs may have URIs in UTF-8 encoding and other PDF viewers are able to produce the intended result.
