### PR TITLE
Convert UTF8 encoded passwords to ISO-8859-1 for |R = 6| encryption (issue 6010)

### DIFF
--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 /* globals bytesToString, DecryptStream, error, isInt, isName, Name,
-           PasswordException, PasswordResponses, stringToBytes */
+           PasswordException, PasswordResponses, stringToBytes, warn,
+           utf8StringToString */
 
 'use strict';
 
@@ -1918,6 +1919,14 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
     var fileIdBytes = stringToBytes(fileId);
     var passwordBytes;
     if (password) {
+      if (revision === 6) {
+        try {
+          password = utf8StringToString(password);
+        } catch (ex) {
+          warn('CipherTransformFactory: ' +
+               'Unable to convert UTF8 encoded password.');
+        }
+      }
       passwordBytes = stringToBytes(password);
     }
 
@@ -2022,7 +2031,7 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
 
   CipherTransformFactory.prototype = {
     createCipherTransform:
-      function CipherTransformFactory_createCipherTransform(num, gen) {
+        function CipherTransformFactory_createCipherTransform(num, gen) {
       if (this.algorithm === 4 || this.algorithm === 5) {
         return new CipherTransform(
           buildCipherConstructor(this.cf, this.stmf,

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -946,6 +946,10 @@ function stringToUTF8String(str) {
   return decodeURIComponent(escape(str));
 }
 
+function utf8StringToString(str) {
+  return unescape(encodeURIComponent(str));
+}
+
 function isEmptyObj(obj) {
   for (var key in obj) {
     return false;

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -130,3 +130,5 @@
 !issue5701.pdf
 !issue5896.pdf
 !issue5909.pdf
+!issue6010_1.pdf
+!issue6010_2.pdf

--- a/test/pdfs/issue6010_1.pdf
+++ b/test/pdfs/issue6010_1.pdf
@@ -1,0 +1,37 @@
+%PDF-1.7
+%€‚ƒ
+1 0 obj
+<</Pages 6 0 R/Type/Catalog>>
+endobj
+2 0 obj
+<</Type/Encoding/BaseEncoding/WinAnsiEncoding>>
+endobj
+3 0 obj
+<</Parent 6 0 R/Resources<</Font<</F1 5 0 R>>>>/MediaBox[0 0 200 50]/Type/Page/Contents 4 0 R>>
+endobj
+4 0 obj
+<</Filter/FlateDecode/Length 64>>
+stream
+‚Õ62ˆÖõ|Q$j¾•ƒ¯^‚BHJC<wß²ÆM%X33uì°º;½*¡¬‚iÍ»ÄŞöKöÏ9³¦­IRñ
+endstream
+endobj
+5 0 obj
+<</BaseFont/Times-Roman/Subtype/Type1/Type/Font/Encoding 2 0 R>>
+endobj
+6 0 obj
+<</MediaBox[0 0 200 50]/Kids[3 0 R]/Type/Pages/Count 1>>
+endobj
+xref
+0 7 
+0000000000 65535 f 
+0000000015 00000 n 
+0000000060 00000 n 
+0000000123 00000 n 
+0000000234 00000 n 
+0000000365 00000 n 
+0000000445 00000 n 
+trailer
+<</Size 7/ID[(gUe>/j¿_ƒ8:‚;Û)(gUe>/j¿_ƒ8:‚;Û)]/Encrypt<</Filter/Standard/V 5/CF<</StdCF<</Length 32/AuthEvent/DocOpen/CFM/AESV3>>>>/EncryptMetadata true/Length 256/R 6/O(éô6âÖ\(«T#¸óƒ‰k6PQé’\nšèã`@”µ$ï¾KşëeÀù F„â)/U(ïéË 4É4õš~>W…nT-û:„Æø}|XSvf2,8ß›^—,ê}w£‡3\fÜİı)/P -4/StrF/StdCF/StmF/StdCF/Perms(×ìÀï§\r1Öéo‹u)/OE(Å?ÑOƒëæ\(Q¸5FıéRV‚ÆJÒÿ,VYö)/UE(Ebîlp·KÃ5±PL­ÜúÉFqIöD<€>ø<ô)>>/Root 1 0 R>>
+startxref
+517
+%%EOF

--- a/test/pdfs/issue6010_2.pdf
+++ b/test/pdfs/issue6010_2.pdf
@@ -1,0 +1,38 @@
+%PDF-1.7
+%ÄÅÇÉ
+1 0 obj
+<</Pages 6 0 R/Type/Catalog>>
+endobj
+2 0 obj
+<</Type/Encoding/BaseEncoding/WinAnsiEncoding>>
+endobj
+3 0 obj
+<</Parent 6 0 R/Resources<</Font<</F1 5 0 R>>>>/MediaBox[0 0 200 50]/Type/Page/Contents 4 0 R>>
+endobj
+4 0 obj
+<</Filter/FlateDecode/Length 64>>
+stream
+Ÿ‰±h∫Rô$£ç„÷Ø’kèÒo®ŒoElg,†éçQhw$Yv√É=›;^Íu÷Ís√_Ô
+##%Ñ'ß
+endstream
+endobj
+5 0 obj
+<</BaseFont/Times-Roman/Subtype/Type1/Type/Font/Encoding 2 0 R>>
+endobj
+6 0 obj
+<</MediaBox[0 0 200 50]/Kids[3 0 R]/Type/Pages/Count 1>>
+endobj
+xref
+0 7 
+0000000000 65535 f 
+0000000015 00000 n 
+0000000060 00000 n 
+0000000123 00000 n 
+0000000234 00000 n 
+0000000365 00000 n 
+0000000445 00000 n 
+trailer
+<</Size 7/ID[(IÜ$"E6?T”ônﬂè\b)(IÜ$"E6?T”ônﬂè\b)]/Encrypt<</Filter/Standard/V 5/CF<</StdCF<</Length 32/AuthEvent/DocOpen/CFM/AESV3>>>>/EncryptMetadata true/Length 256/R 6/O(Îì∑XXB\fñ¢Ùﬁp ÒG&ß¬ßq0“<ºü„æPxÅa∏U∑˝ë§Å¿ΩY)/U(WPk˛D£π_√ëåL^ó∑√D\f.C›s∑rÃ√ˆF\\NUø±L∏®µ4ãF…¶–9‹)/P -4/StrF/StdCF/StmF/StdCF/Perms(G^¥oØ¢‹ˆFâGQO)/OE(h7È•∑Û‚¥ÅCnòÁÛx§∑à¶æÂ–'7+éÅn53ÄE)/UE(ûWÄ[âZ—™=Q©•®«0yÖ#‹#Ù‘≠˝&⁄π£ŸPv)>>/Root 1 0 R>>
+startxref
+517
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1493,6 +1493,23 @@
       "type": "eq",
       "about": "Rotated transparency group with blend mode."
     },
+    {  "id": "issue6010_1",
+       "file": "pdfs/issue6010_1.pdf",
+       "md5": "b58adce5dbb08936ddb0d904f0da8716",
+       "rounds": 1,
+       "link": false,
+       "type": "load",
+       "password": "abc"
+    },
+    {  "id": "issue6010_2",
+       "file": "pdfs/issue6010_2.pdf",
+       "md5": "73a8091d0ab2a47af5ca45047f04da99",
+       "rounds": 1,
+       "link": false,
+       "type": "load",
+       "password": "\u00E6\u00F8\u00E5",
+       "about": "The password (זרו) is UTF8 encoded."
+    },
     { "id": "issue3458.pdf",
       "file": "pdfs/issue3458.pdf",
       "md5": "dab8bd3ad1acfc8dc82a8381a3c8ff94",


### PR DESCRIPTION
For passwords where the encoding already is correct, the conversion is a no-op.
Also, since `encodeURIComponent` might throw, we need to make sure that we handle that case too.

Fixes #6010.
