### PR TITLE
Fix issue with space offsets in TJs

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1136,38 +1136,15 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
                   var prevChar = j > 0 ? items[j - 1] : null;
                   offset = isNum(prevChar) ? items[j - 1] / 1000 : 0;
                   buildTextGeometry(items[j], textChunk, offset);
-                } else {
-                  // PDF Specification 5.3.2 states:
-                  // The number is expressed in thousandths of a unit of text
-                  // space.
-                  // This amount is subtracted from the current horizontal or
-                  // vertical coordinate, depending on the writing mode.
-                  // In the default coordinate system, a positive adjustment
-                  // has the effect of moving the next glyph painted either to
-                  // the left or down by the given amount.
-                  var val = items[j] * textState.fontSize / 1000;
-                  if (textState.font.vertical) {
-                    offset = val * textState.textMatrix[3];
-                    textState.translateTextMatrix(0, offset);
-                    // Value needs to be added to height to paint down.
-                    textChunk.height += offset;
-                  } else {
-                    offset = val * textState.textHScale *
-                                   textState.textMatrix[0];
-                    textState.translateTextMatrix(offset, 0);
-                    // Value needs to be subtracted from width to paint left.
-                    textChunk.width -= offset;
-                  }
-                  if (items[j] < 0 && textState.font.spaceWidth > 0) {
-                    var fakeSpaces = -items[j] / textState.font.spaceWidth;
-                    if (fakeSpaces > MULTI_SPACE_FACTOR) {
-                      fakeSpaces = Math.round(fakeSpaces);
-                      while (fakeSpaces--) {
-                        textChunk.str.push(' ');
-                      }
-                    } else if (fakeSpaces > SPACE_FACTOR) {
+                } else if (items[j] < 0 && textState.font.spaceWidth > 0) {
+                  var fakeSpaces = -items[j] / textState.font.spaceWidth;
+                  if (fakeSpaces > MULTI_SPACE_FACTOR) {
+                    fakeSpaces = Math.round(fakeSpaces);
+                    while (fakeSpaces--) {
                       textChunk.str.push(' ');
                     }
+                  } else if (fakeSpaces > SPACE_FACTOR) {
+                    textChunk.str.push(' ');
                   }
                 }
               }

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -953,8 +953,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           });
       }
 
-      function buildTextGeometry(chars, textChunk) {
+      function buildTextGeometry(chars, textChunk, previousChars) {
         var font = textState.font;
+        var offset = (isNum(previousChars) ? previousChars / 1000 : 0);
         textChunk = textChunk || newTextChunk();
         if (!textChunk.transform) {
           // 9.4.4 Text Space Details
@@ -1036,17 +1037,19 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           var ty = 0;
           if (!font.vertical) {
             var w0 = glyphWidth * textState.fontMatrix[0];
-            tx = (w0 * textState.fontSize + charSpacing) *
+            tx = ((w0 - offset) * textState.fontSize + charSpacing) *
                  textState.textHScale;
             width += tx;
           } else {
             var w1 = glyphWidth * textState.fontMatrix[0];
-            ty = w1 * textState.fontSize + charSpacing;
+            ty = (w1 - offset) * textState.fontSize + charSpacing;
             height += ty;
           }
           textState.translateTextMatrix(tx, ty);
 
           textChunk.str.push(glyphUnicode);
+
+          offset = 0;
         }
 
         var a = textState.textLineMatrix[0];
@@ -1130,7 +1133,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
               var offset;
               for (var j = 0, jj = items.length; j < jj; j++) {
                 if (typeof items[j] === 'string') {
-                  buildTextGeometry(items[j], textChunk);
+                  buildTextGeometry(items[j], textChunk,
+                                   (j > 0 ? items[j - 1] : 0));
                 } else {
                   // PDF Specification 5.3.2 states:
                   // The number is expressed in thousandths of a unit of text

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1134,7 +1134,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
               for (var j = 0, jj = items.length; j < jj; j++) {
                 if (typeof items[j] === 'string') {
                   buildTextGeometry(items[j], textChunk,
-                                   (j > 0 ? items[j - 1] : 0));
+                                    (j > 0 ? items[j - 1] : null));
                 } else {
                   // PDF Specification 5.3.2 states:
                   // The number is expressed in thousandths of a unit of text

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -953,10 +953,10 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           });
       }
 
-      function buildTextGeometry(chars, textChunk, previousChars) {
+      function buildTextGeometry(chars, textChunk, offset) {
         var font = textState.font;
-        var offset = (isNum(previousChars) ? previousChars / 1000 : 0);
         textChunk = textChunk || newTextChunk();
+        offset = offset || 0;
         if (!textChunk.transform) {
           // 9.4.4 Text Space Details
           var tsm = [textState.fontSize * textState.textHScale, 0,
@@ -1133,8 +1133,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
               var offset;
               for (var j = 0, jj = items.length; j < jj; j++) {
                 if (typeof items[j] === 'string') {
-                  buildTextGeometry(items[j], textChunk,
-                                    (j > 0 ? items[j - 1] : null));
+                  var prevChar = j > 0 ? items[j - 1] : null;
+                  offset = isNum(prevChar) ? items[j - 1] / 1000 : 0;
+                  buildTextGeometry(items[j], textChunk, offset);
                 } else {
                   // PDF Specification 5.3.2 states:
                   // The number is expressed in thousandths of a unit of text

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -74,6 +74,7 @@
 !issue1171.pdf
 !smaskdim.pdf
 !endchar.pdf
+!pr6019.pdf
 !type4psfunc.pdf
 !issue1350.pdf
 !S2.pdf

--- a/test/pdfs/pr6019.pdf
+++ b/test/pdfs/pr6019.pdf
@@ -1,0 +1,80 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/Type /Encoding
+/BaseEncoding /WinAnsiEncoding
+>>
+endobj 
+2 0 obj 
+<<
+/Pages 3 0 R
+/Type /Catalog
+>>
+endobj 
+3 0 obj 
+<<
+/Kids [4 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+4 0 obj 
+<<
+/Rotate 90
+/Parent 3 0 R
+/MediaBox [0 0 50 400]
+/Resources 
+<<
+/Font 
+<<
+/F1 5 0 R
+>>
+>>
+/Contents 6 0 R
+/Type /Page
+>>
+endobj 
+5 0 obj 
+<<
+/BaseFont /Times-Italic
+/Subtype /Type1
+/Encoding 1 0 R
+/Type /Font
+>>
+endobj 
+6 0 obj 
+<<
+/Length 108
+>>
+stream
+BT
+/F1 1 Tf
+0 24 -24 0 30 30 Tm
+0 Tw
+(–)Tj
+0.94 0 TD
+-0.0002 Tc
+0.0002 Tw
+[(Medicine Bow)-3653(  936)]TJ
+ET
+
+endstream 
+endobj xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000085 00000 n 
+0000000136 00000 n 
+0000000195 00000 n 
+0000000335 00000 n 
+0000000426 00000 n 
+trailer
+
+<<
+/Root 2 0 R
+/Size 7
+>>
+startxref
+587
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -922,6 +922,13 @@
       "rounds": 1,
       "type": "eq"
     },
+    {  "id": "pr6019",
+      "file": "pdfs/pr6019.pdf",
+      "md5": "7a2e5dda3b0fc5c2e9060e378a8cdc4e",
+      "rounds": 1,
+      "type": "text",
+      "link": false
+    },
     {  "id": "type4psfunc",
       "file": "pdfs/type4psfunc.pdf",
       "md5": "7e6027a02ff78577f74dccdf84e37189",


### PR DESCRIPTION
We were having issues in multiple documents with spaces in a table-like text block that used TJs when selecting text.

master:
![image](https://cloud.githubusercontent.com/assets/289053/7647461/c72ed676-fa9a-11e4-9f69-d461699d96b2.png)

this branch:
![image](https://cloud.githubusercontent.com/assets/289053/7647463/da6b0b60-fa9a-11e4-8464-83e497e611b3.png)

because of the math involved in calculating the offsets in spaced text (TJ), you can't really separate out that logic into two separate operations.

Reference equation from the [spec](http://wwwimages.adobe.com/content/dam/Adobe/en/devnet/pdf/pdfs/PDF32000_2008.pdf) is on page 252.

I wasn't sure if just adding the pdf to the test_manifest was enough, so let me know if you need more than that.
