### PR TITLE
Tweak the :focus/:hover CSS rules of the .toolbarField class used in Overlay dialogs

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1358,10 +1358,6 @@ html[dir='rtl'] .attachmentsItem > button {
 .dialog .toolbarField {
   margin: 5px 0;
 }
-.dialog .toolbarField:hover,
-.dialog .toolbarField:focus {
-  border-color: hsla(0,0%,0%,.32) hsla(0,0%,0%,.38) hsla(0,0%,0%,.42);
-}
 
 .dialog .separator {
   display: block;


### PR DESCRIPTION
Having recently spent some time staring at the PasswordPrompt, while fixing issue #6010, I felt that the current border style does not really give a good visual  indication that the input field actually has focus.

The current appearance was first introduced in PR #3527; but I don't know if having a different border style in Overlay dialogs was intentional, or if it just "happened".
However, given the colour palette used in the viewer UI, I think that using the same border style for all .toolbarFields makes sense.

/cc @timvandermeij What's your opinion on this? 
