### PR TITLE
Refactor the test driver

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -54,7 +54,7 @@ window.load = function load() {
   var delay = params.delay || 0;
 
   canvas = document.createElement('canvas');
-  stdout = document.getElementById('stdout');
+  stdout = document.getElementById('output');
 
   info('User Agent: ' + navigator.userAgent);
   log('load...\n');
@@ -93,7 +93,7 @@ function cleanup(callback) {
     var ownerNode = styleSheet.ownerNode;
     ownerNode.parentNode.removeChild(ownerNode);
   }
-  var guard = document.getElementById('content-end');
+  var guard = document.getElementById('end');
   var body = document.body;
   while (body.lastChild !== guard) {
     body.removeChild(body.lastChild);
@@ -369,7 +369,7 @@ function quitApp() {
 
 function done() {
   if (inFlightRequests > 0) {
-    document.getElementById('inFlightCount').innerHTML = inFlightRequests;
+    document.getElementById('inflight').innerHTML = inFlightRequests;
     setTimeout(done, 100);
   } else {
     setTimeout(quitApp, 100);
@@ -417,7 +417,7 @@ function send(url, message, callback) {
       }
     }
   };
-  document.getElementById('inFlightCount').innerHTML = inFlightRequests++;
+  document.getElementById('inflight').innerHTML = inFlightRequests++;
   r.send(message);
 }
 
@@ -433,11 +433,8 @@ function clear(ctx) {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
 }
 
-/* Auto-scroll if the scrollbar is near the bottom, otherwise do nothing. */
-function checkScrolling() {
-  if ((stdout.scrollHeight - stdout.scrollTop) <= stdout.offsetHeight) {
-    stdout.scrollTop = stdout.scrollHeight;
-  }
+function scroll() {
+  window.scrollTo(0, document.body.scrollHeight);
 }
 
 function log(str) {
@@ -448,7 +445,7 @@ function log(str) {
   }
 
   if (str.lastIndexOf('\n') >= 0) {
-    checkScrolling();
+    scroll();
   }
 }
 

--- a/test/driver.js
+++ b/test/driver.js
@@ -96,9 +96,11 @@ var SimpleTextLayerBuilder = (function SimpleTextLayerBuilderClosure() {
 
 /**
  * @typedef {Object} DriverOptions
- * @property {HTMLPreElement} output - Container for all output messages.
  * @property {HTMLSpanElement} inflight - Field displaying the number of
  *   inflight requests.
+ * @property {HTMLInputElement} disableScrolling - Checkbox to disable
+ *   automatic scrolling of the output container.
+ * @property {HTMLPreElement} output - Container for all output messages.
  * @property {HTMLDivElement} end - Container for a completion message.
  */
 
@@ -118,8 +120,9 @@ var Driver = (function DriverClosure() {
     PDFJS.enableStats = true;
 
     // Set the passed options
-    this.output = options.output;
     this.inflight = options.inflight;
+    this.disableScrolling = options.disableScrolling;
+    this.output = options.output;
     this.end = options.end;
 
     // Set parameters from the query string
@@ -410,9 +413,9 @@ var Driver = (function DriverClosure() {
         this.output.textContent += message;
       }
 
-      if (message.lastIndexOf('\n') >= 0) {
+      if (message.lastIndexOf('\n') >= 0 && !this.disableScrolling.checked) {
         // Scroll to the bottom of the page
-        window.scrollTo(0, document.body.scrollHeight);
+        this.output.scrollTop = this.output.scrollHeight;
       }
     },
 

--- a/test/test_slave.html
+++ b/test/test_slave.html
@@ -34,7 +34,11 @@ limitations under the License.
     <div id="end"></div>
   </body>
   <script>
-    PDFJS.workerSrc = '../src/worker_loader.js';
-    load();
+    var driver = new Driver({
+      output: document.getElementById('output'),
+      inflight: document.getElementById('inflight'),
+      end: document.getElementById('end')
+    });
+    driver.run();
   </script>
 </html>

--- a/test/test_slave.html
+++ b/test/test_slave.html
@@ -29,14 +29,19 @@ limitations under the License.
     <script src="driver.js"></script>
   </head>
   <body>
-    <pre id="output"></pre>
     <p>Inflight requests: <span id="inflight"></span></p>
+    <p>
+      <input type="checkbox" id="disableScrolling">
+      <label for="disableScrolling">Disable automatic scrolling</label>
+    </p>
+    <pre id="output" style="max-height: 800px; overflow-y: scroll;"></pre>
     <div id="end"></div>
   </body>
   <script>
     var driver = new Driver({
-      output: document.getElementById('output'),
+      disableScrolling: document.getElementById('disableScrolling'),
       inflight: document.getElementById('inflight'),
+      output: document.getElementById('output'),
       end: document.getElementById('end')
     });
     driver.run();

--- a/test/test_slave.html
+++ b/test/test_slave.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-Copyright 2012 Mozilla Foundation
+Copyright 2015 Mozilla Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,34 +14,27 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-
 <html>
   <head>
-    <title>pdf.js test slave</title>
-    <style type="text/css"></style>
-    <script src="/src/shared/util.js"></script>
-    <script src="/src/display/api.js"></script>
-    <script src="/src/display/metadata.js"></script>
-    <script src="/src/display/canvas.js"></script>
-    <script src="/src/display/webgl.js"></script>
-    <script src="/src/display/pattern_helper.js"></script>
-    <script src="/src/display/font_loader.js"></script>
-    <script src="/src/display/annotation_helper.js"></script>
+    <title>PDF.js test slave</title>
+    <meta charset="utf-8">
+    <script src="../src/shared/util.js"></script>
+    <script src="../src/display/api.js"></script>
+    <script src="../src/display/metadata.js"></script>
+    <script src="../src/display/canvas.js"></script>
+    <script src="../src/display/webgl.js"></script>
+    <script src="../src/display/pattern_helper.js"></script>
+    <script src="../src/display/font_loader.js"></script>
+    <script src="../src/display/annotation_helper.js"></script>
     <script src="driver.js"></script>
-
-    <script>
-      PDFJS.workerSrc = '/src/worker_loader.js';
-    </script>
   </head>
-
   <body>
-    <pre style="width:800px; height:800px; overflow:scroll;" id="stdout"></pre>
-    <p>Inflight requests: <span id="inFlightCount"></span></p>
-    <div id="content-end"></div>
-
-    <script>
-      'use strict';
-      load();
-    </script>
+    <pre id="output"></pre>
+    <p>Inflight requests: <span id="inflight"></span></p>
+    <div id="end"></div>
   </body>
+  <script>
+    PDFJS.workerSrc = '../src/worker_loader.js';
+    load();
+  </script>
 </html>


### PR DESCRIPTION
Some time ago I attempted to make the test suite work with the SVG back-end. I then found that the current testing code is really unmaintainable at some points and figured that it had to be corrected before we have a chance of adding new functionality (such as a back-end or WebGL switch).

This patch refactors the test driver by making it more class-like and removing quite some complexity from hacks and unneeded functions. Not only does this make the code much more readable, it also allows us to extend the code in a cleaner way because we got rid of the `window.load` dependency, `innerHTML` usages and many callbacks. Not all callbacks have been removed because the remaining ones are not too invasive and this patch can be seen as a major first step in cleaning up the test driver.

@Snuffleupagus Would you be up for reviewing this? It is not as daunting as it might look at first sight because a lot of it is just moving code around. The other changes are largely the same as the other refactoring PRs we have done. Reviewing with `?w=1` helps a bit, especially for the third commit.
