### PR TITLE
Remove unused require() directive

### DIFF
--- a/external/builder/builder.js
+++ b/external/builder/builder.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-require('shelljs/make');
 var fs = require('fs'),
     path = require('path'),
     vm = require('vm');


### PR DESCRIPTION
This had the undesirable side-effect of invoking make's command-line argument
parser upon inclusion.
