### PR TITLE
parser: dereference stream 'Length' field

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -513,7 +513,7 @@ var Parser = (function ParserClosure() {
       return stream;
     },
     makeFilter: function Parser_makeFilter(stream, name, maybeLength, params) {
-      if (stream.dict.get('Length') === 0) {
+      if (this.fetchIfRef(stream.dict.get('Length')) === 0) {
         return new NullStream(stream);
       }
       try {


### PR DESCRIPTION
Check indirect values as we do elsewhere in the parser for internal
consistency.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/pdf.js/6045)

<!-- Reviewable:end -->
