### PR TITLE
viewer: display sharp Retina icons in Safari

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1509,7 +1509,8 @@ html[dir='rtl'] #documentPropertiesOverlay .row > * {
   display: none;
 }
 
-@media screen and (min-resolution: 2dppx) {
+@media screen and (min-resolution: 2dppx),
+       screen and (-webkit-min-device-pixel-ratio: 2) {
   /* Rules for Retina screens */
   .toolbarButton::before {
     -webkit-transform: scale(0.5);


### PR DESCRIPTION
The blurry 1x iconset was getting displayed on WebKit browsers that do not
support dppx media queries, including current Safari versions.
