### PR TITLE
Only apply pageContainer ids in the Firefox extension build

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -76,7 +76,9 @@ var PDFPageView = (function PDFPageViewClosure() {
     this.annotationLayer = null;
 
     var div = document.createElement('div');
-    div.id = 'pageContainer' + this.id;
+//#if (FIREFOX || MOZCENTRAL)
+//  div.id = container.id + '_pageContainer' + this.id;
+//#endif
     div.className = 'page';
     div.style.width = Math.floor(this.viewport.width) + 'px';
     div.style.height = Math.floor(this.viewport.height) + 'px';


### PR DESCRIPTION
They are unnecessary given the availability of data-page-number attributes, and
potentially problematic with efforts to support multiple instances.

This can be removed entirely once remaining dependencies have been fixed in
Mozilla (See #5897)
