### PR TITLE
[Firefox] Re-add _getTabForBrowser compatibility hack for the addon

### DIFF
--- a/extensions/firefox/content/PdfjsChromeUtils.jsm
+++ b/extensions/firefox/content/PdfjsChromeUtils.jsm
@@ -168,7 +168,18 @@ let PdfjsChromeUtils = {
   _findbarFromMessage: function(aMsg) {
     let browser = aMsg.target;
     let tabbrowser = browser.getTabBrowser();
-    let tab = tabbrowser.getTabForBrowser(browser);
+    let tab;
+//#if MOZCENTRAL
+    tab = tabbrowser.getTabForBrowser(browser);
+//#else
+    if (tabbrowser.getTabForBrowser) {
+      tab = tabbrowser.getTabForBrowser(browser);
+    } else {
+      // _getTabForBrowser is deprecated in Firefox 35, see
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1039500.
+      tab = tabbrowser._getTabForBrowser(browser);
+    }
+//#endif
     return tabbrowser.getFindBar(tab);
   },
 


### PR DESCRIPTION
This should enable Find to work again in the current ESR version (31).
