### PR TITLE
Tweak the PDFLinkService a bit

### DIFF
--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -89,12 +89,14 @@ var PDFLinkService = (function () {
           }
           self.pdfViewer.scrollPageIntoView(pageNumber, dest);
 
-          // Update the browsing history.
-          self.pdfHistory.push({
-            dest: dest,
-            hash: destString,
-            page: pageNumber
-          });
+          if (self.pdfHistory) {
+            // Update the browsing history.
+            self.pdfHistory.push({
+              dest: dest,
+              hash: destString,
+              page: pageNumber
+            });
+          }
         } else {
           self.pdfDocument.getPageIndex(destRef).then(function (pageIndex) {
             var pageNum = pageIndex + 1;
@@ -173,7 +175,9 @@ var PDFLinkService = (function () {
         var params = parseQueryString(hash);
         // borrowing syntax from "Parameters for Opening PDF Files"
         if ('nameddest' in params) {
-          this.pdfHistory.updateNextHashParam(params.nameddest);
+          if (this.pdfHistory) {
+            this.pdfHistory.updateNextHashParam(params.nameddest);
+          }
           this.navigateTo(params.nameddest);
           return;
         }
@@ -233,7 +237,9 @@ var PDFLinkService = (function () {
       } else if (/^\d+$/.test(hash)) { // page number
         this.page = hash;
       } else { // named destination
-        this.pdfHistory.updateNextHashParam(unescape(hash));
+        if (this.pdfHistory) {
+          this.pdfHistory.updateNextHashParam(unescape(hash));
+        }
         this.navigateTo(unescape(hash));
       }
     },
@@ -245,11 +251,15 @@ var PDFLinkService = (function () {
       // See PDF reference, table 8.45 - Named action
       switch (action) {
         case 'GoBack':
-          this.pdfHistory.back();
+          if (this.pdfHistory) {
+            this.pdfHistory.back();
+          }
           break;
 
         case 'GoForward':
-          this.pdfHistory.forward();
+          if (this.pdfHistory) {
+            this.pdfHistory.forward();
+          }
           break;
 
         case 'NextPage':

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -65,12 +65,14 @@ var PDFLinkService = (function () {
     get page() {
       return this.pdfViewer.currentPageNumber;
     },
+
     /**
      * @param {number} value
      */
     set page(value) {
       this.pdfViewer.currentPageNumber = value;
     },
+
     /**
      * @param dest - The PDF destination object.
      */
@@ -207,7 +209,7 @@ var PDFLinkService = (function () {
                       zoomArgs.length > 1 ? (zoomArgs[1] | 0) : null];
             } else if (zoomArg === 'FitR') {
               if (zoomArgs.length !== 5) {
-                console.error('pdfViewSetHash: ' +
+                console.error('PDFLinkService_setHash: ' +
                               'Not enough parameters for \'FitR\'.');
               } else {
                 dest = [null, { name: zoomArg },
@@ -215,7 +217,7 @@ var PDFLinkService = (function () {
                         (zoomArgs[3] | 0), (zoomArgs[4] | 0)];
               }
             } else {
-              console.error('pdfViewSetHash: \'' + zoomArg +
+              console.error('PDFLinkService_setHash: \'' + zoomArg +
                             '\' is not a valid zoom value.');
             }
           }


### PR DESCRIPTION
_This PR contains a couple of small follow-ups to PR #5971._
- **Make PDFHistory optional in PDFLinkService**
  Currently `PDFLinkService` requires access to a `PDFHistory` instance in order for it to work correctly (and to avoid errors). If we want `PDFLinkService` to be more useful in custom viewers, I don't think that we actually want to force it to have a `PDFHistory` instance.
  Hence this patch, which contains a very simply approach to make `PDFHistory` optional.
- **Fix a couple of function names in error messages in PDFLinkService**

**Edit**: Even simpler reviewing with https://github.com/mozilla/pdf.js/pull/6063/files?w=1.
