### PR TITLE
Increase the font weight used for non-embedded ArialBlack fonts

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1225,7 +1225,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       }
 
       var name = fontObj.loadedName || 'sans-serif';
-      var bold = fontObj.black ? (fontObj.bold ? 'bolder' : 'bold') :
+      var bold = fontObj.black ? (fontObj.bold ? '900' : 'bold') :
                                  (fontObj.bold ? 'bold' : 'normal');
 
       var italic = fontObj.italic ? 'italic' : 'normal';


### PR DESCRIPTION
Currently non-embedded ArialBlack fonts are not rendered bold enough, compared to e.g. Adobe Reader.
The issue is that we set the font weight to `bolder`, but since that is actually relative to the font weight of the parent, the result is that there's no practical difference from just using `bold`.

This patch attempts to address that, by explicitly setting the font weight to the maximum value instead (see https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight).

_Note:_ I expect one test "failure" in `issue5801`, which in this case is an improvement, since that PDF file uses ArialBlack.

**Edit:** Apparently this made no difference on the bots. But it does improve things locally for me, when testing on Windows with HWA _on_. However, with HWA switched _off_, the patch doesn't seem to help.
Hence it seems that whether or not this patch improves things, is connected with the HWA setting.
