### PR TITLE
Support printing page with different rotation

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -75,6 +75,10 @@
     "useOnlyCssZoom": {
       "type": "boolean",
       "default": false
+    },
+    "disablePrintAutoRotate": {
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/web/default_preferences.js
+++ b/web/default_preferences.js
@@ -32,4 +32,5 @@ var DEFAULT_PREFERENCES = {
   disableTextLayer: false,
   useOnlyCssZoom: false,
   externalLinkTarget: 0,
+  disablePrintAutoRotate: false,
 };

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -517,19 +517,32 @@ var PDFPageView = (function PDFPageViewClosure() {
       return promise;
     },
 
-    beforePrint: function PDFPageView_beforePrint() {
+    beforePrint: function PDFPageView_beforePrint(isFirstPagePortrait) {
       var CustomStyle = PDFJS.CustomStyle;
       var pdfPage = this.pdfPage;
 
       var viewport = pdfPage.getViewport(1);
+
+      var pageWidth = viewport.width;
+      var pageHeight = viewport.height;
+
+      var isPortrait = pageHeight > pageWidth;
+      if (!PDFJS.disablePrintAutoRotate && isFirstPagePortrait !== isPortrait) {
+        // Rotate page by 90deg to make all pages same orientation
+        var rotate = (pdfPage.rotate + 90) % 360;
+        pageWidth = viewport.height;
+        pageHeight = viewport.width;
+        viewport = pdfPage.getViewport(1, rotate);
+      }
+
       // Use the same hack we use for high dpi displays for printing to get
       // better output until bug 811002 is fixed in FF.
       var PRINT_OUTPUT_SCALE = 2;
       var canvas = document.createElement('canvas');
 
       // The logical size of the canvas.
-      canvas.width = Math.floor(viewport.width) * PRINT_OUTPUT_SCALE;
-      canvas.height = Math.floor(viewport.height) * PRINT_OUTPUT_SCALE;
+      canvas.width = Math.floor(pageWidth) * PRINT_OUTPUT_SCALE;
+      canvas.height = Math.floor(pageHeight) * PRINT_OUTPUT_SCALE;
 
       // The rendered size of the canvas, relative to the size of canvasWrapper.
       canvas.style.width = (PRINT_OUTPUT_SCALE * 100) + '%';
@@ -542,8 +555,8 @@ var PDFPageView = (function PDFPageViewClosure() {
 
       var printContainer = document.getElementById('printContainer');
       var canvasWrapper = document.createElement('div');
-      canvasWrapper.style.width = viewport.width + 'pt';
-      canvasWrapper.style.height = viewport.height + 'pt';
+      canvasWrapper.style.width = pageWidth + 'pt';
+      canvasWrapper.style.height = pageHeight + 'pt';
       canvasWrapper.appendChild(canvas);
       printContainer.appendChild(canvasWrapper);
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -297,6 +297,9 @@ var PDFViewerApplication = {
         }
         PDFJS.externalLinkTarget = value;
       }),
+      Preferences.get('disablePrintAutoRotate').then(function resolved(value) {
+        PDFJS.disablePrintAutoRotate = value;
+      }),
       // TODO move more preferences and other async stuff here
     ]).catch(function (reason) { });
 
@@ -1239,8 +1242,10 @@ var PDFViewerApplication = {
       '}';
     body.appendChild(this.pageStyleSheet);
 
+    var isFirstPagePortrait = pageSize.height > pageSize.width;
+
     for (i = 0, ii = this.pagesCount; i < ii; ++i) {
-      this.pdfViewer.getPageView(i).beforePrint();
+      this.pdfViewer.getPageView(i).beforePrint(isFirstPagePortrait);
     }
 
 //#if !PRODUCTION
@@ -1445,6 +1450,10 @@ function webViewerInitialized() {
           viewer.classList.add('textLayer-' + hashParams['textlayer']);
           break;
       }
+    }
+    if ('disableprintautorotate' in hashParams) {
+      PDFJS.disablePrintAutoRotate =
+        (hashParams['disableprintautorotate'] === 'true');
     }
     if ('pdfbug' in hashParams) {
       PDFJS.pdfBug = true;


### PR DESCRIPTION
This PR fixed a printing issue on document that contains page with different orientation.

Some page may print upside down, but rotate a printed paper sheet shouldn't be a problem.

@Rob--W This is the PR you and @Hengjie discussed in #5857 

Some test pdfs:

https://drive.google.com/a/notable.ac/file/d/0B6YhVF9p-y2AbUJlcEI5ZGZ5Z2c/view?usp=sharing
https://drive.google.com/a/notable.ac/file/d/0B6YhVF9p-y2AQTNxMVVOekJYeFE/view?usp=sharing
