### PR TITLE
Use the Alternate entry, if it exists, in ICCBased Colour Space dictionaries (issue 5836, issue 5939, issue 6055)

### DIFF
--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -262,7 +262,7 @@ var ColorSpace = (function ColorSpaceClosure() {
     } else if (isArray(cs)) {
       mode = xref.fetchIfRef(cs[0]).name;
       this.mode = mode;
-      var numComps, params;
+      var numComps, params, alt;
 
       switch (mode) {
         case 'DeviceGray':
@@ -284,6 +284,17 @@ var ColorSpace = (function ColorSpaceClosure() {
           var stream = xref.fetchIfRef(cs[1]);
           var dict = stream.dict;
           numComps = dict.get('N');
+          alt = dict.get('Alternate');
+          if (alt) {
+            var altIR = ColorSpace.parseToIR(alt, xref, res);
+            // Parse the /Alternate CS to ensure that the number of components
+            // are correct, and also (indirectly) that it is not a PatternCS.
+            var altCS = ColorSpace.fromIR(altIR);
+            if (altCS.numComps === numComps) {
+              return altIR;
+            }
+            warn('ICCBased color space: Ignoring incorrect /Alternate entry.');
+          }
           if (numComps === 1) {
             return 'DeviceGrayCS';
           } else if (numComps === 3) {
@@ -316,11 +327,11 @@ var ColorSpace = (function ColorSpaceClosure() {
           } else if (isArray(name)) {
             numComps = name.length;
           }
-          var alt = ColorSpace.parseToIR(cs[2], xref, res);
+          alt = ColorSpace.parseToIR(cs[2], xref, res);
           var tintFnIR = PDFFunction.getIR(xref, xref.fetchIfRef(cs[3]));
           return ['AlternateCS', numComps, alt, tintFnIR];
         case 'Lab':
-          params = cs[1].getAll();
+          params = xref.fetchIfRef(cs[1]).getAll();
           return ['LabCS', params];
         default:
           error('unimplemented color space object "' + mode + '"');

--- a/test/pdfs/issue5939.pdf.link
+++ b/test/pdfs/issue5939.pdf.link
@@ -1,0 +1,1 @@
+http://web.archive.org/web/20150613184455/https://www.usenix.org/system/files/login/articles/login_apr15_02_grosvenor_041315.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -728,6 +728,15 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "issue5939",
+       "file": "pdfs/issue5939.pdf",
+       "md5": "43c61e06ad407c158763f0860c99bb04",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 1,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "cmykjpeg",
        "file": "pdfs/cmykjpeg.pdf",
        "md5": "85d162b48ce98503a382d96f574f70a2",


### PR DESCRIPTION
Fixes #5836.
Fixes #5939.
Fixes #6055.

_The relevant part of the specification:_ http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#G7.3804856.
