### PR TITLE
Ensure that the result of |constructStichedFromIRResult| is a number (issue 6113)

### DIFF
--- a/src/core/function.js
+++ b/src/core/function.js
@@ -364,7 +364,10 @@ var PDFFunction = (function PDFFunctionClosure() {
         var rmin = encode[2 * i];
         var rmax = encode[2 * i + 1];
 
-        tmpBuf[0] = rmin + (v - dmin) * (rmax - rmin) / (dmax - dmin);
+        // Prevent the value from becoming NaN as a result
+        // of division by zero (fixes issue6113.pdf).
+        tmpBuf[0] = dmin === dmax ? rmin :
+                    rmin + (v - dmin) * (rmax - rmin) / (dmax - dmin);
 
         // call the appropriate function
         fns[i](tmpBuf, 0, dest, destOffset);

--- a/test/pdfs/issue6113.pdf.link
+++ b/test/pdfs/issue6113.pdf.link
@@ -1,0 +1,1 @@
+http://web.archive.org/web/20150319000257/http://www.niseko.ne.jp/en/map/pdf/FPmap_en.pdf?1413937768

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1538,6 +1538,15 @@
       "rounds": 1,
       "type": "eq"
     },
+    {  "id": "issue6113",
+       "file": "pdfs/issue6113.pdf",
+       "md5": "7919dbdcd1da04914d7e8dfb05aeb86a",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 1,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "blendmode",
       "file": "pdfs/blendmode.pdf",
       "md5": "5a86e7e9333e93c58abc3f382e1e6ea2",


### PR DESCRIPTION
Fixes #6113.

It appears that when we switched to using `Float32Array` (in PR #5134), we may now occasionally encounter rounding errors, which cause the result to become `NaN` thus leading to incorrect rendering.
