### PR TITLE
Clear the |getSinglePixelWidth| cache when rendering Type3 fonts (issue 6117)

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1485,6 +1485,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       if (isTextInvisible || fontSize === 0) {
         return;
       }
+      this.cachedGetSinglePixelWidth = null;
 
       ctx.save();
       ctx.transform.apply(ctx, current.textMatrix);

--- a/test/pdfs/issue6117.pdf.link
+++ b/test/pdfs/issue6117.pdf.link
@@ -1,0 +1,1 @@
+http://web.archive.org/web/20150402085611/http://chrishecker.com/images/3/33/Gdmogl.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1315,6 +1315,15 @@
       "link": true,
       "type": "eq"
     },
+    {  "id": "issue6117",
+       "file": "pdfs/issue6117.pdf",
+       "md5": "691f5f8268e07f3831e8293258a68da7",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 6,
+       "lastPage": 6,
+       "type": "eq"
+    },
     {  "id": "cid_cff",
       "file": "pdfs/cid_cff.pdf",
       "md5": "a19a18eaa626262cc45e0760004d6de9",


### PR DESCRIPTION
Fixes #6117.
