### PR TITLE
Fix a typo causing a TypeError when attempting to call pdfHistory_clearHistoryState (issue 6121)

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -796,7 +796,7 @@ var PDFViewerApplication = {
         // The browsing history is only enabled when the viewer is standalone,
         // i.e. not when it is embedded in a web page.
         if (!self.preferenceShowPreviousViewOnLoad) {
-          PDFHistory.clearHistoryState();
+          self.pdfHistory.clearHistoryState();
         }
         self.pdfHistory.initialize(self.documentFingerprint);
 


### PR DESCRIPTION
Fixes #6121.

Note: This "regressed" in PR #5823.
