### PR TITLE
Remove issue6113.pdf from the test-suite for failing intermittently in Firefox on the Linux bot

### DIFF
--- a/test/pdfs/issue6113.pdf.link
+++ b/test/pdfs/issue6113.pdf.link
@@ -1,1 +1,0 @@
-http://web.archive.org/web/20150319000257/http://www.niseko.ne.jp/en/map/pdf/FPmap_en.pdf?1413937768

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1538,15 +1538,6 @@
       "rounds": 1,
       "type": "eq"
     },
-    {  "id": "issue6113",
-       "file": "pdfs/issue6113.pdf",
-       "md5": "7919dbdcd1da04914d7e8dfb05aeb86a",
-       "rounds": 1,
-       "link": true,
-       "firstPage": 1,
-       "lastPage": 1,
-       "type": "eq"
-    },
     {  "id": "blendmode",
       "file": "pdfs/blendmode.pdf",
       "md5": "5a86e7e9333e93c58abc3f382e1e6ea2",


### PR DESCRIPTION
As can be seen in https://github.com/mozilla/pdf.js/pull/3891#issuecomment-112467962 and below, `makeref` didn't help since the test is still failing mysteriously in Firefox on Linux.
Hence I think that we should just remove the test for now, since I'd like to be able to get PR #6120 landed before the pending `mozilla-central` uplift is done.

_If I've got time later, I'll look into replacing the test with a unit-test or perhaps a reduced test-case instead._
