### PR TITLE
Ignore paint form XObject when the name is missing (issue 4558)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -658,6 +658,10 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
               }
               // eagerly compile XForm objects
               var name = args[0].name;
+              if (!name) {
+                warn('XObject must be referred to by name.');
+                continue;
+              }
               if (imageCache[name] !== undefined) {
                 operatorList.addOp(imageCache[name].fn, imageCache[name].args);
                 args = null;

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -227,5 +227,16 @@ describe('evaluator', function() {
         expect(result.fnArray[3]).toEqual(OPS.restore);
       });
     });
+    it('should skip paint form XObject if name is missing', function() {
+      var evaluator = new PartialEvaluator(new PdfManagerMock(),
+                                           new XrefMock(), new HandlerMock(),
+                                           'prefix');
+      var stream = new StringStream('/ Do');
+      runOperatorListCheck(evaluator, stream, new ResourcesMock(),
+          function (result) {
+        expect(result.argsArray).toEqual([]);
+        expect(result.fnArray).toEqual([]);
+      });
+    });
   });
 });


### PR DESCRIPTION
Fixes #4558 (since the font issues already appear to be fixed).
