### PR TITLE
Propagate network errors through promise (issue 6139)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "underscore": "~1.4.0",
     "shelljs": "0.4.0",
     "typogr": "~0.5.0",
-    "yargs": "~1.2.1"
+    "yargs": "~1.2.1",
+    "stream-throttle": "~0.1.3"
   },
   "scripts": {
     "test": "node ./node_modules/.bin/jshint --extra-ext .jsm ."

--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -301,7 +301,8 @@ var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
       this.sendRequest = function ChunkedStreamManager_sendRequest(begin, end) {
         this.networkManager.requestRange(begin, end, {
           onDone: this.onReceiveData.bind(this),
-          onProgress: this.onProgress.bind(this)
+          onProgress: this.onProgress.bind(this),
+          onError: this.onError.bind(this, begin, end)
         });
       };
     }
@@ -311,6 +312,7 @@ var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
     this.chunksNeededByRequest = {};
     this.requestsByChunk = {};
     this.callbacksByRequest = {};
+    this.errorHandlersByRequest = {};
     this.progressiveDataLength = 0;
 
     this._loadedStreamCapability = createPromiseCapability();
@@ -329,12 +331,16 @@ var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
     // contiguous ranges to load in as few requests as possible
     requestAllChunks: function ChunkedStreamManager_requestAllChunks() {
       var missingChunks = this.stream.getMissingChunks();
-      this.requestChunks(missingChunks);
-      return this._loadedStreamCapability.promise;
+      return new Promise(function(resolve, reject) {
+        this.requestChunks(missingChunks, function() {
+          resolve(this.stream);
+        }.bind(this), reject);
+      }.bind(this));
     },
 
     requestChunks: function ChunkedStreamManager_requestChunks(chunks,
-                                                               callback) {
+                                                               callback,
+                                                               errorHandler) {
       var requestId = this.currRequestId++;
 
       var chunksNeeded;
@@ -354,6 +360,7 @@ var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
       }
 
       this.callbacksByRequest[requestId] = callback;
+      this.errorHandlersByRequest[requestId] = errorHandler;
 
       var chunksToRequest = [];
       for (var chunk in chunksNeeded) {
@@ -371,7 +378,7 @@ var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
 
       var groupedChunksToRequest = this.groupChunks(chunksToRequest);
 
-      for (i = 0; i < groupedChunksToRequest.length; ++i) {
+      for (i = 0, ii = groupedChunksToRequest.length; i < ii; ++i) {
         var groupedChunk = groupedChunksToRequest[i];
         var begin = groupedChunk.beginChunk * this.chunkSize;
         var end = Math.min(groupedChunk.endChunk * this.chunkSize, this.length);
@@ -385,7 +392,7 @@ var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
 
     // Loads any chunks in the requested range that are not yet loaded
     requestRange: function ChunkedStreamManager_requestRange(
-                      begin, end, callback) {
+                      begin, end, callback, errorHandler) {
 
       end = Math.min(end, this.length);
 
@@ -397,15 +404,16 @@ var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
         chunks.push(chunk);
       }
 
-      this.requestChunks(chunks, callback);
+      this.requestChunks(chunks, callback, errorHandler);
     },
 
     requestRanges: function ChunkedStreamManager_requestRanges(ranges,
-                                                               callback) {
+                                                               callback,
+                                                               errorHandler) {
       ranges = ranges || [];
       var chunksToRequest = [];
 
-      for (var i = 0; i < ranges.length; i++) {
+      for (var i = 0, len = ranges.length; i < len; i++) {
         var beginChunk = this.getBeginChunk(ranges[i].begin);
         var endChunk = this.getEndChunk(ranges[i].end);
         for (var chunk = beginChunk; chunk < endChunk; ++chunk) {
@@ -416,7 +424,7 @@ var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
       }
 
       chunksToRequest.sort(function(a, b) { return a - b; });
-      this.requestChunks(chunksToRequest, callback);
+      this.requestChunks(chunksToRequest, callback, errorHandler);
     },
 
     // Groups a sorted array of chunks into as few continguous larger
@@ -425,7 +433,7 @@ var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
       var groupedChunks = [];
       var beginChunk = -1;
       var prevChunk = -1;
-      for (var i = 0; i < chunks.length; ++i) {
+      for (var i = 0, len = chunks.length; i < len; ++i) {
         var chunk = chunks[i];
 
         if (beginChunk < 0) {
@@ -478,13 +486,13 @@ var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
       }
 
       var loadedRequests = [];
-      var i, requestId;
+      var i, len, requestId;
       for (chunk = beginChunk; chunk < endChunk; ++chunk) {
         // The server might return more chunks than requested
         var requestIds = this.requestsByChunk[chunk] || [];
         delete this.requestsByChunk[chunk];
 
-        for (i = 0; i < requestIds.length; ++i) {
+        for (i = 0, len = requestIds.length; i < len; ++i) {
           requestId = requestIds[i];
           var chunksNeeded = this.chunksNeededByRequest[requestId];
           if (chunk in chunksNeeded) {
@@ -519,10 +527,11 @@ var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
         }
       }
 
-      for (i = 0; i < loadedRequests.length; ++i) {
+      for (i = 0, len = loadedRequests.length; i < len; ++i) {
         requestId = loadedRequests[i];
         var callback = this.callbacksByRequest[requestId];
         delete this.callbacksByRequest[requestId];
+        delete this.errorHandlersByRequest[requestId];
         if (callback) {
           callback();
         }
@@ -534,8 +543,48 @@ var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
       });
     },
 
-    onError: function ChunkedStreamManager_onError(err) {
-      this._loadedStreamCapability.reject(err);
+    onError: function ChunkedStreamManager_onError(begin, end, err) {
+      var beginChunk = Math.floor(begin / this.chunkSize);
+      var endChunk = end < this.length ? Math.floor(end / this.chunkSize) :
+                                         Math.ceil(end / this.chunkSize);
+
+      var failedRequests = [];
+      var i, len, requestId;
+      for (var chunk = beginChunk; chunk < endChunk; ++chunk) {
+        var requestIds = this.requestsByChunk[chunk] || [];
+        delete this.requestsByChunk[chunk];
+
+        for (i = 0; i < requestIds.length; ++i) {
+          requestId = requestIds[i];
+          var chunksNeeded = this.chunksNeededByRequest[requestId] || {};
+          // A single chunk failure in the request fails the whole request
+          var chunkRequestIds;
+          for (var chunkNeeded in chunksNeeded) {
+            chunkRequestIds = this.requestsByChunk[chunkNeeded] || [];
+            this.requestsByChunk[chunkNeeded] = chunkRequestIds.filter(
+              function(reqId) {
+                return reqId !== requestId;
+              }
+            );
+            if (this.requestsByChunk[chunkNeeded].length === 0) {
+              delete this.requestsByChunk[chunkNeeded];
+            }
+          }
+          delete this.chunksNeededByRequest[requestId];
+          
+          failedRequests.push(requestId);
+        }
+      }
+      
+      for (i = 0, len = failedRequests.length; i < len; ++i) {
+        requestId = failedRequests[i];
+        var errorHandler = this.errorHandlersByRequest[requestId];
+        delete this.errorHandlersByRequest[requestId];
+        delete this.callbacksByRequest[requestId];
+        if (errorHandler) {
+          errorHandler(err);
+        }
+      }
     },
 
     getBeginChunk: function ChunkedStreamManager_getBeginChunk(begin) {

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -608,6 +608,10 @@ var Catalog = (function CatalogClosure() {
             var ref = a[1];
             return new Page(this.pdfManager, this.xref, pageIndex, dict, ref,
                             this.fontCache);
+          }.bind(this),
+          function (reason) {
+            delete this.pagePromises[pageIndex];
+            return Promise.reject(reason);
           }.bind(this)
         );
       }
@@ -1355,7 +1359,7 @@ var XRef = (function XRefClosure() {
           if (e instanceof MissingDataException) {
             streamManager.requestRange(e.begin, e.end, function () {
               tryFetch(resolve, reject);
-            });
+            }, reject);
             return;
           }
           reject(e);
@@ -1714,7 +1718,7 @@ var ObjectLoader = (function() {
             }
           }
           this.walk(nodesToVisit);
-        }.bind(this));
+        }.bind(this), this.capability.reject);
         return;
       }
       // Everything is loaded.

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -125,6 +125,7 @@ var LocalPdfManager = (function LocalPdfManagerClosure() {
 
   LocalPdfManager.prototype.requestLoadedStream =
       function LocalPdfManager_requestLoadedStream() {
+    return this._loadedStreamCapability.promise;
   };
 
   LocalPdfManager.prototype.onLoadedStream =
@@ -183,7 +184,8 @@ var NetworkPdfManager = (function NetworkPdfManagerClosure() {
             reject(e);
             return;
           }
-          pdfManager.streamManager.requestRange(e.begin, e.end, ensureHelper);
+          pdfManager.streamManager.requestRange(e.begin, e.end,
+                                                ensureHelper, reject);
         }
       }
 
@@ -193,16 +195,16 @@ var NetworkPdfManager = (function NetworkPdfManagerClosure() {
 
   NetworkPdfManager.prototype.requestRange =
       function NetworkPdfManager_requestRange(begin, end) {
-    return new Promise(function (resolve) {
+    return new Promise(function (resolve, reject) {
       this.streamManager.requestRange(begin, end, function() {
         resolve();
-      });
+      }, reject);
     }.bind(this));
   };
 
   NetworkPdfManager.prototype.requestLoadedStream =
       function NetworkPdfManager_requestLoadedStream() {
-    this.streamManager.requestAllChunks();
+    return this.streamManager.requestAllChunks();
   };
 
   NetworkPdfManager.prototype.sendProgressiveData =

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -764,6 +764,7 @@ var PDFPageProxy = (function PDFPageProxyClosure() {
           internalRenderTask.operatorListChanged();
         },
         function pageDisplayReadPromiseError(reason) {
+          intentState.displayReadyCapability = undefined;
           complete(reason);
         }
       );
@@ -1315,6 +1316,9 @@ var WorkerTransport = (function WorkerTransportClosure() {
         var page = new PDFPageProxy(pageIndex, pageInfo, this);
         this.pageCache[pageIndex] = page;
         return page;
+      }.bind(this), function(reason) {
+        delete this.pagePromises[pageIndex];
+        return Promise.reject(reason);
       }.bind(this));
       this.pagePromises[pageIndex] = promise;
       return promise;


### PR DESCRIPTION
Fixes #6139 

Propagates network errors through API promises so that they can be handled by the requester. Prevents rejected promises from being cached so requests can be retried.

Also adds support for testing connection errors in unit tests by exposing web server instantiation.
