### PR TITLE
Stop building the AMO extension

### DIFF
--- a/make.js
+++ b/make.js
@@ -764,8 +764,7 @@ target.firefox = function() {
          'chrome',
          'locale',
          'LICENSE'],
-      FIREFOX_EXTENSION_NAME = 'pdf.js.xpi',
-      FIREFOX_AMO_EXTENSION_NAME = 'pdf.js.amo.xpi';
+      FIREFOX_EXTENSION_NAME = 'pdf.js.xpi';
 
   target.locale();
   target.bundle({ excludes: ['core/network.js'], defines: defines });
@@ -852,14 +851,6 @@ target.firefox = function() {
   exec('zip -r ' + FIREFOX_EXTENSION_NAME + ' ' +
        FIREFOX_EXTENSION_FILES.join(' '));
   echo('extension created: ' + FIREFOX_EXTENSION_NAME);
-  cd(ROOT_DIR);
-
-  // Build the amo extension too (remove the updateUrl)
-  cd(FIREFOX_BUILD_DIR);
-  sed('-i', /.*updateURL.*\n/, '', 'install.rdf');
-  exec('zip -r ' + FIREFOX_AMO_EXTENSION_NAME + ' ' +
-       FIREFOX_EXTENSION_FILES.join(' '));
-  echo('AMO extension created: ' + FIREFOX_AMO_EXTENSION_NAME);
   cd(ROOT_DIR);
 };
 


### PR DESCRIPTION
A long time ago it has already been removed from the bot's preview messages, but the extension was still generated (and left unused) in the background. This patch stops building the AMO extension altogether as we do not use and provide it anymore as an add-on. Users that do want to use the extension for highly exceptional cases (such as Android where we have no proper viewer yet) could use the development extension.
