### PR TITLE
Zoom relative to cursor position via mouse wheel

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1811,14 +1811,31 @@ function handleMouseWheel(evt) {
               evt.wheelDelta / MOUSE_WHEEL_DELTA_FACTOR;
   var direction = (ticks < 0) ? 'zoomOut' : 'zoomIn';
 
-  if (PDFViewerApplication.pdfViewer.isInPresentationMode) {
+  var pdfViewer = PDFViewerApplication.pdfViewer;
+  if (pdfViewer.isInPresentationMode) {
     evt.preventDefault();
     PDFViewerApplication.scrollPresentationMode(ticks *
                                                 MOUSE_WHEEL_DELTA_FACTOR);
   } else if (evt.ctrlKey || evt.metaKey) {
     // Only zoom the pages, not the entire viewer.
     evt.preventDefault();
+
+    var previousScale = pdfViewer.currentScale;
+
     PDFViewerApplication[direction](Math.abs(ticks));
+
+    var currentScale = pdfViewer.currentScale;
+    if (previousScale !== currentScale) {
+      // After scaling the page via zoomIn/zoomOut, the position of the upper-
+      // left corner is restored. When the mouse wheel is used, the position
+      // under the cursor should be restored instead.
+      var scaleCorrectionFactor = currentScale / previousScale - 1;
+      var rect = pdfViewer.container.getBoundingClientRect();
+      var dx = evt.clientX - rect.left;
+      var dy = evt.clientY - rect.top;
+      pdfViewer.container.scrollLeft += dx * scaleCorrectionFactor;
+      pdfViewer.container.scrollTop += dy * scaleCorrectionFactor;
+    }
   }
 }
 


### PR DESCRIPTION
Before this patch, zooming in/out via the scroll wheel caused the page to be zoomed relative to the upper-left corner of the page, i.e. the upper-left corner of the page stays at a fixed position.

After this patch, the page is zoomed relative to the cursor position, i.e. after zooming in/out, the part under the cursor 'has not moved'.

This only applies when the page does not fit in the viewport, because pages smaller than the viewpoer are always centered.

To verify that the patch works as intended:
1. Open the viewer.
2. Resize (shrink) the window if you have a huge screen until the PDF does not fully fit in the viewport.
3. Use the mouse wheel to zoom in at a letter.
4. Zoom out while the page is still bigger than the viewport.

During step 3 and 4, the PDF under the page position under the cursor should be fixed.
