### PR TITLE
[CRX] Ignore PDFs from responses to POST requests

### DIFF
--- a/extensions/chromium/contentscript.js
+++ b/extensions/chromium/contentscript.js
@@ -75,6 +75,19 @@ function watchObjectOrEmbed(elem) {
     return;
   }
 
+  if (elem.tagName === 'EMBED' && elem.name === 'plugin' &&
+      elem.parentNode === document.body &&
+      elem.parentNode.childElementCount === 1 && elem.src === location.href) {
+    // This page is most likely Chrome's default page that embeds a PDF file.
+    // The fact that the extension's background page did not intercept and
+    // redirect this PDF request means that this PDF cannot be opened by PDF.js,
+    // e.g. because it is a response to a POST request (as in #6174).
+    // A reduced test case to test PDF response to POST requests is available at
+    // https://robwu.nl/pdfjs/issue6174/.
+    // Until #4483 is fixed, POST requests should be ignored.
+    return;
+  }
+
   if (elem[shadowRoot]) {
     // If the element already has a shadow root, assume that we've already
     // seen this element.


### PR DESCRIPTION
As explained in https://github.com/mozilla/pdf.js/issues/6174#issuecomment-118502802.

To verify that this patch works:
1. Build the Chrome extension (node make chromium)
2. Load the Chrome extension (at chrome://extensions)
3. Visit https://robwu.nl/pdfjs/issue6174/.
4. Verify that PDF.js is not used to load the PDF. Either Chrome's default PDF Viewer is used (and you will see the secret message in my hand-crafted PDF file ;) ), or the PDF is offered as a file download.

(verified with Chromium 43.0.2357.81 and 45.0.2445.0 on Linux)
