### PR TITLE
Pass in a `PDFViewer` instance to `PDFPresentationMode` and use it to eliminate all references to `PDFViewerApplication`

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -220,6 +220,7 @@ var PDFViewerApplication = {
       this.pdfPresentationMode = new PDFPresentationMode({
         container: container,
         viewer: viewer,
+        pdfViewer: this.pdfViewer,
         pdfThumbnailViewer: this.pdfThumbnailViewer,
         contextMenuItems: [
           { element: document.getElementById('contextFirstPage'),


### PR DESCRIPTION
This patch is the the first step towards to addressing issue #6158, which will be done by refactoring the code for setting/getting the current scale in `viewer.js`.
