### PR TITLE
Add a unit-test that attempts to fetch a non-existent named destination

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -485,7 +485,7 @@ var Catalog = (function CatalogClosure() {
       }
 
       var xref = this.xref;
-      var dest, nameTreeRef, nameDictionaryRef;
+      var dest = null, nameTreeRef, nameDictionaryRef;
       var obj = this.catDict.get('Names');
       if (obj && obj.has('Dests')) {
         nameTreeRef = obj.getRaw('Dests');

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -129,6 +129,12 @@ describe('api', function() {
                               0, 841.89, null]);
       });
     });
+    it('gets a non-existent destination', function() {
+      var promise = doc.getDestination('non-existent-named-destination');
+      waitsForPromiseResolved(promise, function(data) {
+        expect(data).toEqual(null);
+      });
+    });
     it('gets attachments', function() {
       var promise = doc.getAttachments();
       waitsForPromiseResolved(promise, function (data) {


### PR DESCRIPTION
Doing this helped uncover an issue with the `getDestination` implementation.
Currently if a named destination doesn't exist, the method (in `obj.js`) may return `undefined` which leads to the promise being stuck in a pending state.
_Note:_ returning `null` for this case is consistent with other methods, e.g. `getOutline` and `getAttachments`.
