### PR TITLE
Update canvas.js to display QR codes correctly

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -769,7 +769,14 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         fnId = fnArray[i];
 
         if (fnId !== OPS.dependency) {
-          this[fnId].apply(this, argsArray[i]);
+          var tempArgsArray = argsArray[i];
+          if(fnId === 59) {
+            this[58].apply(this, tempArgsArray);
+          }
+          if(fnId === 22 || fnId === 23) {
+            fnId = 24;
+          }
+          this[fnId].apply(this, tempArgsArray);
         } else {
           var deps = argsArray[i];
           for (var n = 0, nn = deps.length; n < nn; n++) {


### PR DESCRIPTION
I would like to resolve #3331 by changing a few lines in 'canvas.js'. The changes I have made is described:
Determine stroke RGB color with the fill RGB color in the array. And use 'fillStroke' instead of 'fill' and  'eoFill' in order not to display white lines in rectangles such as QR codes.
