### PR TITLE
Directly print PDFs in Chromium (+PDF editing functionality)

### DIFF
--- a/make.js
+++ b/make.js
@@ -75,7 +75,8 @@ var DEFINES = {
   CHROME: false,
   MINIFIED: false,
   SINGLE_FILE: false,
-  COMPONENTS: false
+  COMPONENTS: false,
+  WITH_EDITING: false,
 };
 
 //
@@ -115,7 +116,8 @@ var COMMON_WEB_FILES =
 // modern HTML5 browsers.
 //
 target.generic = function() {
-  target.bundle({});
+  var defines = builder.merge(DEFINES, {GENERIC: true, WITH_EDITING: true});
+  target.bundle({defines: defines});
   target.locale();
 
   cd(ROOT_DIR);
@@ -127,8 +129,6 @@ target.generic = function() {
   mkdir('-p', GENERIC_DIR + BUILD_DIR);
   mkdir('-p', GENERIC_DIR + '/web');
   mkdir('-p', GENERIC_DIR + '/web/cmaps');
-
-  var defines = builder.merge(DEFINES, {GENERIC: true});
 
   var setup = {
     defines: defines,
@@ -536,6 +536,12 @@ target.bundle = function(args) {
 
   var srcFiles = builder.getWorkerSrcFiles('src/worker_loader.js');
   var WORKER_SRC_FILES = srcFiles.srcFiles;
+
+  if (!defines.WITH_EDITING) {
+    WORKER_SRC_FILES = WORKER_SRC_FILES.filter(function(file) {
+      return file.lastIndexOf('editing/', 0) === -1;
+    });
+  }
 
   if (!defines.SINGLE_FILE) {
     // We want shared_src_files in both pdf.js and pdf.worker.js
@@ -1049,7 +1055,7 @@ target.chromium = function() {
   cd(ROOT_DIR);
   echo();
   echo('### Building Chromium extension');
-  var defines = builder.merge(DEFINES, {CHROME: true});
+  var defines = builder.merge(DEFINES, {CHROME: true, WITH_EDITING: true});
 
   var CHROME_BUILD_DIR = BUILD_DIR + '/chromium/',
       CHROME_BUILD_CONTENT_DIR = CHROME_BUILD_DIR + '/content/';

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -287,7 +287,7 @@ var WorkerMessageHandler = PDFJS.WorkerMessageHandler = {
           pdfManager.onLoadedStream().then(function() {
             loadDocument(true).then(onSuccess, onFailure);
           });
-        }, onFailure);
+        });
       }, onFailure);
     });
 

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -49,12 +49,7 @@ var WorkerMessageHandler = PDFJS.WorkerMessageHandler = {
         loadDocumentCapability.reject(e);
       };
 
-      pdfManager.ensureDoc('checkHeader', []).then(function() {
-        pdfManager.ensureDoc('parseStartXRef', []).then(function() {
-          pdfManager.ensureDoc('parse', [recoveryMode]).then(
-            parseSuccess, parseFailure);
-        }, parseFailure);
-      }, parseFailure);
+      pdfManager.parseDoc(recoveryMode).then(parseSuccess, parseFailure);
 
       return loadDocumentCapability.promise;
     }

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -18,7 +18,8 @@
            NetworkManager, isInt, RANGE_CHUNK_SIZE, MissingPDFException,
            UnexpectedResponseException, PasswordException, Promise, warn,
            PasswordResponses, InvalidPDFException, UnknownErrorException,
-           XRefParseException, Ref, info, globalScope, error, MessageHandler */
+           XRefParseException, Ref, info, globalScope, error, MessageHandler,
+           getDataForPrintingImplementation */
 
 'use strict';
 
@@ -357,6 +358,12 @@ var WorkerMessageHandler = PDFJS.WorkerMessageHandler = {
         return stream.bytes;
       });
     });
+
+//#if WITH_EDITING
+    handler.on('GetDataForPrinting', function wphSetupGetDataForPrinting(data) {
+      return getDataForPrintingImplementation(pdfManager);
+    });
+//#endif
 
     handler.on('GetStats',
       function wphSetupGetStats(data) {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -538,6 +538,17 @@ var PDFDocumentProxy = (function PDFDocumentProxyClosure() {
     getData: function PDFDocumentProxy_getData() {
       return this.transport.getData();
     },
+//#if WITH_EDITING
+    /**
+     * @return {Promise} A promise that is resolved with an {Object} that has
+     * the pdfBlobUrl property. pdfBlobUrl is a blob:-URL that represents the
+     * current PDF file with automatic printing enabled. The caller should
+     * revoke the URL when the data is no longer needed.
+     */
+    getDataForPrinting: function PDFDocumentProxy_getDataForPrinting() {
+      return this.transport.getDataForPrinting();
+    },
+//#endif
     /**
      * @return {Promise} A promise that is resolved when the document's data
      * is loaded. It is resolved with an {Object} that contains the length
@@ -1295,6 +1306,11 @@ var WorkerTransport = (function WorkerTransportClosure() {
     getData: function WorkerTransport_getData() {
       return this.messageHandler.sendWithPromise('GetData', null);
     },
+//#if WITH_EDITING
+    getDataForPrinting: function WorkerTransport_getDataForPrinting() {
+      return this.messageHandler.sendWithPromise('GetDataForPrinting', null);
+    },
+//#endif
 
     getPage: function WorkerTransport_getPage(pageNumber, capability) {
       if (pageNumber <= 0 || pageNumber > this.numPages ||

--- a/src/editing/pdf_data_writer.js
+++ b/src/editing/pdf_data_writer.js
@@ -1,0 +1,701 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/* Copyright 2015 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* globals assert, error, Dict, Name, isArray, isArrayBuffer, isBool, isDict,
+           isInt, isName, isNum, isString, isRef, Ref, stringToBytes */
+
+'use strict';
+
+/**
+ * The PDFDataWriter enables one to serialize PDF.js objects to raw PDF data.
+ *
+ * See the inline comments and unit tests to learn how to use this class.
+ *
+ * PDF32000 is mentioned several times in the inline documentation in this file.
+ * This refers to the PDF 1.7 specification, which can be downloaded from
+ * https://adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf
+ */
+var PDFDataWriter = (function PDFDataWriterClosure() {
+  // Char codes for 0...9A...F
+  var NUM_TO_HEX_ORD = new Uint8Array([48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+      65, 66, 67, 68, 69, 70]);
+  var PDF_FALSE = new Uint8Array([102, 97, 108, 115, 101]);
+  var PDF_TRUE = new Uint8Array([116, 114, 117, 101]);
+  var PDF_NULL = new Uint8Array([110, 117, 108, 108]);
+  var PDF_ARRAY_START = new Uint8Array([91]);
+  var PDF_ARRAY_SEPARATOR = new Uint8Array([32]);
+  var PDF_ARRAY_END = new Uint8Array([93]);
+  var PDF_DICT_START = new Uint8Array([60, 60]);
+  var PDF_DICT_SEPARATOR = new Uint8Array([32]);
+  var PDF_DICT_END = new Uint8Array([62, 62]);
+  var PDF_REF_SEPARATOR = new Uint8Array([32]);
+  var PDF_REF_END = new Uint8Array([32, 82]);
+
+  var PDF_STREAM_HEAD = new Uint8Array([10, 115, 116, 114, 101, 97, 109,
+      10]);
+  var PDF_STREAM_TAIL = new Uint8Array([10, 101, 110, 100, 115, 116, 114, 101,
+      97, 109, 10]);
+
+  var PDF_OBJ_HEAD_START = new Uint8Array([10]);
+  var PDF_OBJ_HEAD_SEPARATOR = new Uint8Array([32]);
+  var PDF_OBJ_HEAD_END = new Uint8Array([32, 111, 98, 106, 10]);
+  var PDF_OBJ_TAIL = new Uint8Array([10, 101, 110, 100, 111, 98, 106, 10]);
+
+  var PDF_TRAILER_START = new Uint8Array([10, 116, 114, 97, 105, 108, 101, 114,
+      10]);
+  var PDF_TRAILER_STARTXREF = new Uint8Array([10, 115, 116, 97, 114, 116, 120,
+      114, 101, 102, 10]);
+  var PDF_TRAILER_EOF = new Uint8Array([10, 37, 37, 69, 79, 70, 10]);
+
+  var PDF_XREF_START = new Uint8Array([10, 120, 114, 101, 102, 10]);
+  var PDF_XREF_SUBSECTION_SEPARATOR = new Uint8Array([32]);
+  var PDF_XREF_SUBSECTION_END = new Uint8Array([10]);
+  var PDF_XREF_ENTRY = new Uint8Array([48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+      32, 48, 48, 48, 48, 48, 32, 102, 32, 10]);
+
+  /**
+   * Insert the decimal representation of an integer in the typed array
+   * (aligned at the end of the array).
+   *
+   * @param {Uint8Array} array - The destination array.
+   * @param {integer} n - A signed 32-bit integer to be inserted in the array.
+   */
+  function insertIntAsDigitsAtEnd(array, n) {
+    var isNegative = n < 0;
+    if (isNegative) {
+      n = -n;
+    }
+    var i = array.length;
+    do {
+      array[--i] = (n % 10) + 48 | 0;
+    } while ((n = n / 10 | 0) > 0);
+
+    if (isNegative) {
+      array[i - 1] = 45; // '-'
+    }
+  }
+
+  /**
+   * Inserts the hexadecimal representation of an integer in the typed array
+   * (aligned at the end of the array).
+   *
+   * @param {Uint8Array} array - The destination array.
+   * @param {integer} n - A signed 32-bit integer to be inserted in the array.
+   */
+  function insertIntAsHexAtEnd(array, n) {
+    var i = array.length;
+    while (n > 0 && i >= 0) {
+      array[--i] = NUM_TO_HEX_ORD[n & 0xF];
+      n >>= 4;
+    }
+    while (--i >= 0) {
+      array[i] = NUM_TO_HEX_ORD[0];
+    }
+  }
+
+  /**
+   * @param {integer} n - A positive 32-bit integer.
+   *
+   * @returns number of bytes needed to fit the integer in hexadecimal form.
+   */
+  function getHexByteWidth(n) {
+    return n < 0x100 ? 2 : n < 0x10000 ? 4 : n < 0x1000000 ? 6 : 8;
+  }
+
+  /**
+   * Construct a new PDFDataWriter instance. This can be used to append data to
+   * an existing PDF file, or to create a partial PDF file.
+   *
+   * To extend an existing PDF file for which all data is known, use:
+   *
+   *     new PDFDataWriter(new Uint8Array([ ... PDF data ... ]));
+   *
+   * To create an incremental update for a PDF file whose content is known, but
+   * its byte size is not. For example, if the PDF file has a size of 123 bytes:
+   *
+   *     new PDFDataWriter(null, 123);
+   *
+   * @param {Uint8Array=} pdfData - Raw data of a valid PDF file.
+   * @param {integer=} byteLengthBeforeData - Number of bytes before the data.
+   */
+  function PDFDataWriter(pdfData, byteLengthBeforeData) {
+    assert(!pdfData || pdfData instanceof Uint8Array,
+        'pdfData must be a Uint8Array if set');
+
+    // List of Uint8Array objects. The content of each Uint8Array will not be
+    // modified by this PDFDataWriter instance.
+    this.data = pdfData ? [pdfData] : [];
+
+    // The byte size of the data held by this writer.
+    this.dataByteLength = pdfData ? pdfData.byteLength : 0;
+
+    // Whether the writer has started an indirect object.
+    this.inObject = false;
+
+    // Whether the writer has started a stream object.
+    this.inStream = false;
+
+    // Map of xref object number to generation number and offset.
+    this.newXRefInfo = {
+      // The first entry in the XRef table, per PDF32000, 7.5.4.
+      0: {
+        offset: 0,
+        gen: 65535,
+        free: true,
+      }
+    };
+
+    // Byte offset of start of last XRef table/stream in the PDF data.
+    this.startXRef = 0;
+
+    this.trailerDict = null;
+
+    // Whether the PDF ends with a cross-reference stream. When such PDF data is
+    // extended, we also have to write a stream. Otherwise (if the PDF uses a
+    // plain XRef table, or a hybrid cross-reference stream) a normal XRef table
+    // should be written.
+    this.shouldWriteXRefStream = false;
+
+    this.byteLengthBeforeData = byteLengthBeforeData || 0;
+  }
+
+  PDFDataWriter.prototype = {
+    /**
+     * The byte size of the PDF file represented by this PDFDataWriter instance.
+     */
+    get length() {
+      return this.byteLengthBeforeData + this.dataByteLength;
+    },
+
+    /**
+     * Set the byte offset of the last XRef table. This results in the Prev key
+     * being written to the trailer. If not set, the Prev key is not written and
+     * PDF readers will only find items that are defined by this class.
+     */
+    setStartXRef: function PDFDataWriter_setStartXRef(startXRef) {
+      assert(isInt(startXRef), 'startXRef must be an integer');
+      this.startXRef = startXRef;
+      return this;
+    },
+
+    /**
+     * Set the current trailer dictionary (PDF32000, 7.5.5). The keys and values
+     * are shallowly copied to an internal dictionary that will be inserted when
+     * the trailer is appended. This method must be called before the trailer
+     *
+     * @param {Dict} trailerDict
+     */
+    setTrailer: function PDFDataWriter_setTrailer(trailer) {
+      assert(isDict(trailer) && trailer.has('Size') && trailer.has('Root'),
+          'trailer must be a dict containing Size and Root');
+
+      var keys = ['Size', 'Root', 'Encrypt', 'Info', 'ID'];
+      this.shouldWriteXRefStream = isDict(trailer, 'XRef');
+      if (!this.shouldWriteXRefStream) {
+        keys.push('XRefStm');
+      }
+      this.trailerDict = new Dict();
+      for (var i = 0; i < keys.length; ++i) {
+        var key = keys[i];
+        if (trailer.has(key)) {
+          this.trailerDict.set(key, trailer.getRaw(key));
+        }
+      }
+      return this;
+    },
+
+    /**
+     * Append a value to the PDFDataWriter. This method supports all datatypes
+     * from the PDF 1.7 specification (PDF32000, 7.3). Typed arrays are appended
+     * as-is, which can be used to store streams (PDF32000, 7.3.8).
+     *
+     * This method accepts all JavaScript primitive values (boolean, number,
+     * string, null), Name, Ref, Dict, ArrayBuffer, Uint8Array and
+     * arrays/objects consisting of these types. Typed arrays are stored by
+     * reference in an internal buffer, other types are copied by value.
+     * Do not modify the value of a typed array after passing it to append!
+     */
+    append: function PDFDataWriter_append(v) {
+      if (isBool(v)) {
+        this.appendBool(v);
+      } else if (isNum(v)) {
+        this.appendNum(v);
+      } else if (isString(v)) {
+        this.appendString(v);
+      } else if (isName(v)) {
+        this.appendName(v);
+      } else if (isArray(v)) {
+        this.appendArray(v);
+      } else if (isRef(v)) {
+        this.appendRef(v);
+      } else if (isDict(v)) {
+        this.appendDict(v);
+      } else if (isArrayBuffer(v)) {
+        this.appendUint8Array(v.buffer ? v : new Uint8Array(v));
+      } else if (v) {
+        error('Cannot append object of unknown type: ' + v);
+      } else {
+        this.appendNull();
+      }
+      return this;
+    },
+
+    /**
+     * Append as a boolean object (PDF32000, 7.3.2).
+     *
+     * @param {boolean} v
+     */
+    appendBool: function PDFDataWriter_appendBool(v) {
+      if (v) {
+        this.appendUint8Array(PDF_TRUE);
+      } else {
+        this.appendUint8Array(PDF_FALSE);
+      }
+      return this;
+    },
+
+    /**
+     * Append as a numeric object (PDF32000, 7.3.3).
+     *
+     * @param {number} v
+     */
+    appendNum: function PDFDataWriter_appendNum(v) {
+      if (isInt(v)) {
+        var length;
+        if (v) {
+          length = (v < 0 ? 1 : 0) +
+            Math.ceil(Math.log(Math.abs(v) + 1) / Math.LN10);
+        } else {
+          length = 1;
+        }
+        var buf = new Uint8Array(length);
+        insertIntAsDigitsAtEnd(buf, v);
+        this.appendUint8Array(buf);
+      } else {
+        this.appendUint8Array(stringToBytes(v.toString()));
+      }
+      return this;
+    },
+
+    /**
+     * Append as a hex-encoded string (PDF32000, 7.3.4.3).
+     *
+     * @param {string} v - A string of 8-bit characters (UTF8 is not supported).
+     */
+    appendString: function PDFDataWriter_appendString(v) {
+      var buf = new Uint8Array(v.length * 2 + 2);
+      buf[0] = 60; // '<'
+
+      var offset = 0;
+      for (var i = 0, ii = v.length; i < ii; ++i) {
+        var c = v.charCodeAt(i);
+        buf[++offset] = NUM_TO_HEX_ORD[(c >> 4) & 15];
+        buf[++offset] = NUM_TO_HEX_ORD[c & 15];
+      }
+
+      buf[++offset] = 62; // '>'
+      this.appendUint8Array(buf);
+      return this;
+    },
+
+    /**
+     * Append as a Name object (PDF32000, 7.3.5).
+     *
+     * @param {Name|string} v
+     */
+    appendName: function PDFDataWriter_appendName(v) {
+      // This method accepts a string to avoid the need for the conversion of a
+      // string to a Name in appendDict.
+      if (typeof v !== 'string') {
+        v = v.name;
+      }
+
+      // In the worst case, all characters in the name needs to be escaped.
+      var buf = new Uint8Array(v.length * 3 + 1);
+
+      buf[0] = 47; // '/'
+
+      var offset = 0;
+      for (var i = 0, ii = v.length; i < ii; ++i) {
+        var c = v.charCodeAt(i) & 0xFF;
+        // Regular characters are all characters except for whitespace and
+        // delimiters (7.2.2). These must be escaped with a #. It is recommended
+        // to escape characters outside the [33, 126] range (PDF32000, 7.3.5).
+        if (c >= 33 && c <= 126 && c !== 35 && c !== 40 && c !== 41 &&
+            c !== 60 && c !== 62 && c !== 91 && c !== 93 && c !== 123 &&
+            c !== 125 && c !== 47 && c !== 37) {
+          buf[++offset] = c;
+        } else {
+          // Escape character, '#xx'
+          buf[++offset] = 35; // '#'
+          buf[++offset] = NUM_TO_HEX_ORD[(c >> 4) & 15];
+          buf[++offset] = NUM_TO_HEX_ORD[c & 15];
+        }
+      }
+      this.appendUint8Array(buf.subarray(0, offset + 1));
+      return this;
+    },
+
+    /**
+     * Append as an Array object (PDF32000, 7.3.6).
+     *
+     * @param {Array} v - a list of objects consisting of objects that is
+     *   accepted by the {@code append} method.
+     */
+    appendArray: function PDFDataWriter_appendArray(v) {
+      this.appendUint8Array(PDF_ARRAY_START);
+      if (v.length) {
+        this.append(v[0]);
+      }
+      for (var i = 1, ii = v.length; i < ii; ++i) {
+        this.appendUint8Array(PDF_ARRAY_SEPARATOR);
+        this.append(v[i]);
+      }
+      this.appendUint8Array(PDF_ARRAY_END);
+      return this;
+    },
+
+    /**
+     * Append as a Dictionary object (PDF32000, 7.3.7).
+     *
+     * @param {Dict} v - a dictionary consisting of objects that is accepted by
+     *   the {@code append} method.
+     */
+    appendDict: function PDFDataWriter_appendDict(v) {
+      this.appendUint8Array(PDF_DICT_START);
+      var map = v.map;
+      for (var k in map) {
+        this.appendName(k);
+        this.appendUint8Array(PDF_DICT_SEPARATOR);
+        this.append(map[k]);
+      }
+      this.appendUint8Array(PDF_DICT_END);
+      return this;
+    },
+
+    /**
+     * Append a null value (PDF32000, 7.3.9)
+     */
+    appendNull: function PDFDataWriter_appendNull() {
+      this.appendUint8Array(PDF_NULL);
+      return this;
+    },
+
+    /**
+     * Append as an indirect reference (PDF32000, 7.3.10)
+     *
+     * @param {Ref} v
+     */
+    appendRef: function PDFDataWriter_appendRef(v) {
+      this.appendNum(v.num);
+      this.appendUint8Array(PDF_REF_SEPARATOR);
+      this.appendNum(v.gen);
+      this.appendUint8Array(PDF_REF_END);
+      return this;
+    },
+
+    /**
+     * Append an Uint8Array. Note that the data is saved by reference. If the
+     * underlying buffer is modified, the changes will also be reflected in the
+     * output of this PDFDataWriter instance.
+     *
+     * @param {Uint8Array} v
+     */
+    appendUint8Array: function PDFDataWriter_appendUint8Array(v) {
+      if (v.byteLength) {
+        this.data.push(v);
+        this.dataByteLength += v.byteLength;
+      }
+      return this;
+    },
+
+    /**
+     * Start a new Stream (PDF32000, 7.3.8) by appending "[dict]\nstream\n".
+     * This dictionary must contain a Length key that states the size of the
+     * stream, including the last line feed appended by this dict.
+     *
+     * Example:
+     *
+     *     var data = new Uint8Array([32, 32]); // some data, e.g. "  ".
+     *     var streamDict = new Dict();
+     *     // + 1 because of the extra newline added by startStream.
+     *     streamDict.set('Length', data.byteLength + 1);
+     *     new PDFDataWriter()
+     *       .startStream(streamDict)
+     *       .append(data)
+     *       .endStream()
+     *       .toUint8Array(); // --> "<</Length 3>>\nstream\n  \nendstream\n"
+     *
+     * @param {Dict} streamDict - Stream dictionary, containing at least Length.
+     */
+    startStream: function PDFDataWriter_startStream(streamDict) {
+      assert(isDict(streamDict) && streamDict.has('Length'),
+          'dict with a Length key is required');
+      assert(!this.inStream,
+          'Cannot start a new stream while the previous one is open');
+      this.inStream = true;
+      this.appendDict(streamDict);
+      this.appendUint8Array(PDF_STREAM_HEAD);
+      return this;
+    },
+
+    /**
+     * End a stream started by {@code startStream}.
+     */
+    endStream: function PDFDataWriter_endStream() {
+      assert(this.inStream, 'Cannot close a stream without opening one');
+      this.inStream = false;
+      this.appendUint8Array(new Uint8Array(PDF_STREAM_TAIL));
+      return this;
+    },
+
+    /**
+     * Start an indirect object (PDF32000, 7.3.10).
+     *
+     * @param {Ref} ref - The reference (object number and generation) to label
+     *   the object with.
+     */
+    startObj: function PDFDataWriter_startObj(ref) {
+      assert(isRef(ref));
+      assert(!this.inObject,
+          'Cannot start a new indirect object while the previous one is open');
+      this.inObject = true;
+      this.newXRefInfo[ref.num] = {
+        // +1 because of the line feed at the start of PDF_OBJ_HEAD_START
+        offset: this.length + 1,
+        gen: ref.gen,
+        free: false,
+      };
+
+      this.appendUint8Array(PDF_OBJ_HEAD_START);
+      this.appendNum(ref.num);
+      this.appendUint8Array(PDF_OBJ_HEAD_SEPARATOR);
+      this.appendNum(ref.gen);
+      this.appendUint8Array(PDF_OBJ_HEAD_END);
+      return this;
+    },
+
+    /**
+     * End the indirect object started by {@code startObj}.
+     */
+    endObj: function PDFDataWriter_endObj() {
+      assert(this.inObject, 'Cannot close a non-existing indirect object');
+      this.inObject = false;
+
+      this.appendUint8Array(PDF_OBJ_TAIL);
+      return this;
+    },
+
+    /**
+     * Append the XRef table of all new indirect objects since the construction
+     * of this PDFDataWriter (PDF32000, 7.5.5)
+     * Append the XRef table and trailer.
+     */
+    appendTrailer: function PDFDataWriter_appendTrailer() {
+      assert(this.trailerDict, 'setTrailer must be called first');
+
+      if (this.shouldWriteXRefStream) {
+        this._appendXRefStream();
+      } else {
+        this._appendXRefTable();
+        this.appendUint8Array(PDF_TRAILER_START);
+        this.appendDict(this.trailerDict);
+      }
+
+      this.appendUint8Array(PDF_TRAILER_STARTXREF);
+      this.appendNum(this.startXRef);
+      this.appendUint8Array(PDF_TRAILER_EOF);
+
+      for (var num in this.newXRefInfo) {
+        if (num !== '0') {
+          delete this.newXRefInfo[num];
+        }
+      }
+
+      return this;
+    },
+
+    /**
+     * Append the XRef table (PDF32000, 7.5.4).
+     * @private
+     * @see {appendTrailer}
+     */
+    _appendXRefTable: function PDFDataWriter_appendXRefTable() {
+      if (this.startXRef) {
+        this.trailerDict.set('Prev', this.startXRef);
+      }
+      // +1 because PDF_XREF_START starts with a '\n'
+      this.startXRef = this.length + 1;
+      this.appendUint8Array(PDF_XREF_START);
+
+      var xrefSections = this._getXRefInOrder();
+      for (var i = 0, ii = xrefSections.length; i < ii; ++i) {
+        var xrefSection = xrefSections[i];
+        this.appendNum(xrefSection.start);
+        this.appendUint8Array(PDF_XREF_SUBSECTION_SEPARATOR);
+        this.appendNum(xrefSection.entries.length);
+        this.appendUint8Array(PDF_XREF_SUBSECTION_END);
+
+        for (var j = 0, jj = xrefSection.entries.length; j < jj; ++j) {
+          var info = xrefSection.entries[j];
+
+          // Use the copy constructor because the value will be modified.
+          // PDF_XREF_ENTRY is '0000000000 00000 f \n'.
+          var entry = new Uint8Array(PDF_XREF_ENTRY);
+          insertIntAsDigitsAtEnd(entry.subarray(0, 10), info.offset);
+          insertIntAsDigitsAtEnd(entry.subarray(11, 16), info.gen);
+          if (!info.free) {
+            entry[17] = 110; // 'n'
+          }
+          this.appendUint8Array(entry);
+        }
+      }
+      return this;
+    },
+
+    /**
+     * Append the XRef stream (PDF32000, 7.5.8)
+     * @private
+     * @see {appendTrailer}
+     */
+    _appendXRefStream: function PDFDataWriter_appendXRefStream() {
+      if (this.startXRef) {
+        this.trailerDict.set('Prev', this.startXRef);
+      }
+      var stmRefNum = this.trailerDict.get('Size');
+      assert(isInt(stmRefNum), 'trailerDict.Size must be an integer');
+      this.trailerDict.set('Size', stmRefNum + 1);
+
+      // +1 because startObj prepends a '\n'.
+      this.startXRef = this.length + 1;
+      this.startObj(new Ref(stmRefNum, 0));
+
+      var xrefSections = this._getXRefInOrder();
+      var maxgen = 0;
+      var maxoffset = 0;
+      var xrefStreamIndex = [];
+      var totalEntryCount = 0;
+      var isAllUsedAndUncompressed = true;
+      for (var i = 0, ii = xrefSections.length; i < ii; ++i) {
+        var xrefSection = xrefSections[i];
+        xrefStreamIndex.push(xrefSection.start);
+        xrefStreamIndex.push(xrefSection.entries.length);
+        totalEntryCount += xrefSection.entries.length;
+        for (var j = 0, jj = xrefSection.entries.length; j < jj; ++j) {
+          var info = xrefSection.entries[j];
+          maxoffset = Math.max(maxoffset, info.offset);
+          maxgen = Math.max(maxgen, info.gen);
+          isAllUsedAndUncompressed = isAllUsedAndUncompressed && !info.free;
+        }
+      }
+      // Widths are multiplied by 2 because the bytes stored using the
+      // ASCIIHexDecode filter.
+      var typWidth = isAllUsedAndUncompressed ? 0 : 2;
+      var offWidth = getHexByteWidth(maxoffset);
+      var genWidth = getHexByteWidth(maxgen);
+      var fieldWidth = (typWidth + offWidth + genWidth);
+
+      var streamData = new Uint8Array(totalEntryCount * fieldWidth + 1);
+      streamData[streamData.length - 1] = 0x3E; // '>', EOD (PDF32000, 7.4.2).
+
+      var byteOffset = 0;
+      for (i = 0, ii = xrefSections.length; i < ii; ++i) {
+        var xrefEntries = xrefSections[i].entries;
+        for (j = 0, jj = xrefEntries.length; j < jj; ++j) {
+          info = xrefEntries[j];
+          var entry = streamData.subarray(byteOffset, byteOffset + fieldWidth);
+          byteOffset += fieldWidth;
+          if (typWidth) {
+            entry[0] = NUM_TO_HEX_ORD[0];
+            entry[1] = info.free ? NUM_TO_HEX_ORD[0] : NUM_TO_HEX_ORD[1];
+          }
+          insertIntAsHexAtEnd(entry.subarray(typWidth, typWidth + offWidth),
+              info.offset);
+          insertIntAsHexAtEnd(entry.subarray(typWidth + offWidth, fieldWidth),
+              info.gen);
+        }
+      }
+
+      var xrefDict = Dict.merge(null, [this.trailerDict]);
+      xrefDict.set('Filter', new Name('ASCIIHexDecode'));
+      // + 1 because of the extra newline added by startStream.
+      xrefDict.set('Length', streamData.byteLength + 1);
+      xrefDict.set('Type', new Name('XRef'));
+      xrefDict.set('Index', xrefStreamIndex);
+      xrefDict.set('W', [typWidth / 2, offWidth / 2, genWidth / 2]);
+
+      this.startStream(xrefDict);
+      this.appendUint8Array(streamData);
+      this.endStream();
+      this.endObj();
+      return this;
+    },
+
+    /**
+     * @private
+     * @return {Object[]} List of {num:number,entries:Object[]} objects. Each
+     *   object specifies a continuous sequence of xref entries, starting at the
+     *   object number given by the "num" key.
+     */
+    _getXRefInOrder: function PDFDataWriter_getXRefInOrder() {
+      var xrefEntries = [];
+
+      var lastSection;
+      // The XRef table must be sorted by object number, in ascending order.
+      var nums = Object.keys(this.newXRefInfo).map(function(num) {
+        return parseInt(num, 10);
+      }).sort(function(a, b) {
+        return a - b;
+      });
+
+      for (var i = 0, ii = nums.length; i < ii; ++i) {
+        var num = nums[i];
+        if (nums[i - 1] !== num - 1) {
+          // Start a new subsection if the entry's object number is different
+          // from the previous object number.
+          lastSection = [];
+          xrefEntries.push({start: num, entries: lastSection});
+        }
+
+        lastSection.push(this.newXRefInfo[num]);
+      }
+
+      return xrefEntries;
+    },
+
+    /**
+     * Get the data of this builder as a Uint8Array. Note that the return value
+     * is a direct reference to the underlying storage, so do not modify the
+     * return value if you want to re-use the builder!
+     *
+     * @returns {Uint8Array}
+     */
+    toUint8Array: function PDFDataWriter_toUint8Array() {
+      if (this.data.length > 1) {
+        var newData = new Uint8Array(this.dataByteLength);
+        var offset = 0;
+        this.data.forEach(function(chunk) {
+          newData.set(chunk, offset);
+          offset += chunk.byteLength;
+        });
+        this.data.length = 1;
+        this.data[0] = newData;
+      }
+      return this.data[0] || new Uint8Array(0);
+    },
+  };
+  return PDFDataWriter;
+})();

--- a/src/editing/printing.js
+++ b/src/editing/printing.js
@@ -34,6 +34,10 @@ function getDataForPrintingImplementation(pdfManager) {
     var startXRef = pdfDocument.startXRef;
     var catalogRef = trailer.getRaw('Root');
 
+    if (trailer.get('Encrypt')) {
+      return Promise.reject('Encrypted PDFs cannot be modified yet');
+    }
+
     var newCatDict = new Dict();
     for (var k in catDict.map) {
       if (k !== 'OpenAction') {

--- a/src/editing/printing.js
+++ b/src/editing/printing.js
@@ -1,0 +1,64 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/* Copyright 2015 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* globals Promise, assert, isRef, Dict, Name, PDFDataWriter */
+
+'use strict';
+//#if !CHROME && !GENERIC
+//#error This module should not be loaded in non-Chromium browsers
+//#endif
+
+function getDataForPrintingImplementation(pdfManager) {
+  pdfManager.requestLoadedStream();
+  return pdfManager.onParsedDoc().then(function() {
+    return pdfManager.onLoadedStream();
+  }).then(function(stream) {
+    var pdfData = stream.bytes;
+    var pdfDocument = pdfManager.pdfDocument;
+
+    var catDict = pdfDocument.catalog.catDict;
+    var trailer = pdfDocument.xref.trailer;
+    var startXRef = pdfDocument.startXRef;
+    var catalogRef = trailer.getRaw('Root');
+
+    var newCatDict = new Dict();
+    for (var k in catDict.map) {
+      if (k !== 'OpenAction') {
+        newCatDict.set(k, catDict.getRaw(k));
+      }
+    }
+    var openActionDict = new Dict();
+    openActionDict.set('Type', new Name('Action'));
+    openActionDict.set('S', new Name('JavaScript'));
+    openActionDict.set('JS', 'this.print();');
+    newCatDict.set('OpenAction', openActionDict);
+
+    var extraData = new PDFDataWriter(null, pdfData.byteLength)
+      .setTrailer(trailer)
+      .setStartXRef(startXRef)
+      .startObj(catalogRef)
+      .appendDict(newCatDict)
+      .endObj()
+      .appendTrailer()
+      .toUint8Array();
+    var blob = new Blob([pdfData, extraData], {
+      type: 'application/pdf'
+    });
+    return {
+      pdfBlobUrl: URL.createObjectURL(blob),
+    };
+  });
+}

--- a/src/worker_loader.js
+++ b/src/worker_loader.js
@@ -52,7 +52,9 @@ var otherFiles = [
   'core/jpx.js',
   'core/jbig2.js',
   'core/bidi.js',
-  'core/murmurhash3.js'
+  'core/murmurhash3.js',
+  'editing/pdf_data_writer.js',
+  'editing/printing.js',
 ];
 
 function loadInOrder(index, path, files) {

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -147,3 +147,4 @@
 !issue6081.pdf
 !issue6069.pdf
 !issue6108.pdf
+!written-with-pdfjs.pdf

--- a/test/pdfs/written-with-pdfjs.pdf
+++ b/test/pdfs/written-with-pdfjs.pdf
@@ -1,0 +1,34 @@
+%PDF-1.1
+1 0 obj
+<</Type /Catalog/Pages 2 0 R>>
+endobj
+
+2 0 obj
+<</Type /Pages/Count 1/Kids [3 0 R]/MediaBox [0 0 200 100]>>
+endobj
+
+3 0 obj
+<</Type /Page/Parent 2 0 R/Resources <</Font <</F1 <</Type /Font/Subtype /Type1/BaseFont /Arial>>>>>>/Contents 4 0 R>>
+endobj
+
+4 0 obj
+<</Length 46>>
+stream
+BT/F1 20 Tf 0 0 Td(Written with PDF.js) Tj ET
+endstream
+
+endobj
+
+xref
+0 5
+0000000000 65535 f 
+0000000009 00000 n 
+0000000056 00000 n 
+0000000133 00000 n 
+0000000268 00000 n 
+
+trailer
+<</Size 5/Root 1 0 R>>
+startxref
+363
+%%EOF

--- a/test/unit/pdf_data_writer_spec.js
+++ b/test/unit/pdf_data_writer_spec.js
@@ -1,0 +1,461 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/* globals expect, it, describe, beforeEach, Name, Dict, Ref, PDFDataWriter,
+           jasmine, bytesToString, stringToBytes */
+
+'use strict';
+
+describe('pdf_data_writer', function() {
+  beforeEach(function() {
+    function toReadableString(s) {
+      if (s instanceof Uint8Array) {
+        s = bytesToString(s);
+      }
+      s = s.replace(/[^\x20-\x7E]/g, function(c) {
+        c = c.charCodeAt(0);
+        if (c === 10) {
+          return '\\n';
+        }
+        if (c === 13) {
+          return '\\r';
+        }
+        if (c < 16) {
+          return '\\x0' + c.toString(16);
+        }
+        return '\\x' + c.toString(16);
+      });
+      return '"' + s.replace(/"/g, '\\"') + '"';
+    }
+    this.addMatchers({
+      /**
+       * Verifies that the input is a typed array whose content equals the
+       * given string (which only contains 8-bit characters).
+       */
+      toMatchTypedString: function(expected) {
+        var actual = this.actual;
+        if (!(actual instanceof Uint8Array)) {
+          this.message = function() {
+            return 'Expected ' + toReadableString(actual) + ' to be ' +
+              'a Uint8Array matching ' + toReadableString(expected) + '.';
+          };
+          return false;
+        }
+        this.message = function() {
+          return 'Expected ' + toReadableString(actual) +
+            ' to be equal to ' + toReadableString(expected) + '.';
+        };
+        if (actual.length !== expected.length) {
+          return false;
+        }
+        for (var i = 0, ii = expected.length; i < ii; i++) {
+          var a = actual[i], b = expected.charCodeAt(i);
+          if (a !== b) {
+            return false;
+          }
+        }
+        return true;
+      },
+    });
+  });
+
+  describe('PDFDataWriter', function() {
+
+    it('should support a constructor that takes existing data', function() {
+      expect(new PDFDataWriter(stringToBytes('initial data')).toUint8Array())
+        .toMatchTypedString('initial data');
+      expect(new PDFDataWriter(null, 3).length).toEqual(3);
+      expect(new PDFDataWriter(new Uint8Array(8), 3).length).toEqual(11);
+    });
+
+    it('should support booleans', function() {
+      expect(new PDFDataWriter().appendBool(true).toUint8Array())
+        .toMatchTypedString('true');
+
+      expect(new PDFDataWriter().append(true).toUint8Array())
+        .toMatchTypedString('true');
+      expect(new PDFDataWriter().append(false).toUint8Array())
+        .toMatchTypedString('false');
+    });
+
+    it('should support integers', function() {
+      expect(new PDFDataWriter().appendNum(-1).toUint8Array())
+        .toMatchTypedString('-1');
+
+      expect(new PDFDataWriter().append(-1).toUint8Array())
+        .toMatchTypedString('-1');
+      expect(new PDFDataWriter().append(0).toUint8Array())
+        .toMatchTypedString('0');
+      expect(new PDFDataWriter().append(1).toUint8Array())
+        .toMatchTypedString('1');
+      expect(new PDFDataWriter().append(-2147483647).toUint8Array())
+        .toMatchTypedString('-2147483647');
+      expect(new PDFDataWriter().append(2147483647).toUint8Array())
+        .toMatchTypedString('2147483647');
+      expect(new PDFDataWriter().append(4294967295).toUint8Array())
+        .toMatchTypedString('4294967295');
+      expect(new PDFDataWriter().append(1e100).toUint8Array())
+        .toMatchTypedString('1e+100');
+      expect(new PDFDataWriter().append(1.23e-45).toUint8Array())
+        .toMatchTypedString('1.23e-45');
+      expect(new PDFDataWriter().append(-1.23e-45).toUint8Array())
+        .toMatchTypedString('-1.23e-45');
+    });
+
+    it('should support reals', function() {
+      expect(new PDFDataWriter().appendNum(-1.01).toUint8Array())
+        .toMatchTypedString('-1.01');
+
+      expect(new PDFDataWriter().append(-1.01).toUint8Array())
+        .toMatchTypedString('-1.01');
+      expect(new PDFDataWriter().append(0.01).toUint8Array())
+        .toMatchTypedString('0.01');
+    });
+
+    it('should support strings', function() {
+      expect(new PDFDataWriter().appendString('').toUint8Array())
+        .toMatchTypedString('<>');
+
+      expect(new PDFDataWriter().append('').toUint8Array())
+        .toMatchTypedString('<>');
+      expect(new PDFDataWriter().append('Test').toUint8Array())
+        .toMatchTypedString('<54657374>');
+    });
+
+    it('should support Name', function() {
+      expect(new PDFDataWriter().appendName(new Name('')).toUint8Array())
+        .toMatchTypedString('/');
+
+      expect(new PDFDataWriter().append(new Name('')).toUint8Array())
+        .toMatchTypedString('/');
+      expect(new PDFDataWriter().append(new Name('abc123!~')).toUint8Array())
+        .toMatchTypedString('/abc123!~');
+      expect(new PDFDataWriter().append(new Name('#()<>[]{}/%')).toUint8Array())
+        .toMatchTypedString('/#23#28#29#3C#3E#5B#5D#7B#7D#2F#25');
+      expect(new PDFDataWriter().append(new Name('~\n\r\t\b\f')).toUint8Array())
+        .toMatchTypedString('/~#0A#0D#09#08#0C');
+    });
+
+    it('should support null', function() {
+      expect(new PDFDataWriter().appendNull().toUint8Array())
+        .toMatchTypedString('null');
+
+      expect(new PDFDataWriter().append(null).toUint8Array())
+        .toMatchTypedString('null');
+      expect(new PDFDataWriter().append(undefined).toUint8Array())
+        .toMatchTypedString('null');
+    });
+
+    it('should support Ref', function() {
+      expect(new PDFDataWriter().appendRef(new Ref(0, 0)).toUint8Array())
+        .toMatchTypedString('0 0 R');
+
+      expect(new PDFDataWriter().append(new Ref(0, 0)).toUint8Array())
+        .toMatchTypedString('0 0 R');
+      expect(new PDFDataWriter().append(new Ref(123, 45)).toUint8Array())
+        .toMatchTypedString('123 45 R');
+    });
+
+    it('should support Array', function() {
+      expect(new PDFDataWriter().appendArray([]).toUint8Array())
+        .toMatchTypedString('[]');
+
+      expect(new PDFDataWriter().append([]).toUint8Array())
+        .toMatchTypedString('[]');
+      expect(new PDFDataWriter().append([1, 2, 3]).toUint8Array())
+        .toMatchTypedString('[1 2 3]');
+      expect(new PDFDataWriter().append([1, '1', 0, '0', [2]]).toUint8Array())
+        .toMatchTypedString('[1 <31> 0 <30> [2]]');
+    });
+
+    it('should support Dict', function() {
+      expect(new PDFDataWriter().appendDict(new Dict()).toUint8Array())
+        .toMatchTypedString('<<>>');
+
+      expect(new PDFDataWriter().append(new Dict()).toUint8Array())
+        .toMatchTypedString('<<>>');
+
+      var dict = new Dict();
+      dict.set('some key', '& value');
+      expect(new PDFDataWriter().append(dict).toUint8Array())
+        .toMatchTypedString('<</some#20key <262076616C7565>>>');
+
+      dict.set('another', '');
+      dict.set('and', null);
+      dict.set('etc', 1.1);
+      dict.set('dict', new Dict());
+      dict.set('ref', new Ref(0, 0));
+      expect(new PDFDataWriter().append(dict).toUint8Array())
+        .toMatchTypedString('<</some#20key <262076616C7565>' +
+              '/another <>/and null/etc 1.1/dict <<>>/ref 0 0 R>>');
+    });
+
+    it('should support typed arrays', function() {
+      var expectedData = 'test value';
+      var data = stringToBytes(expectedData);
+      expect(new PDFDataWriter().appendUint8Array(data).toUint8Array())
+        .toMatchTypedString(expectedData);
+
+      expect(new PDFDataWriter().append(data).toUint8Array())
+        .toMatchTypedString(expectedData);
+      expect(new PDFDataWriter().append(data.buffer).toUint8Array())
+        .toMatchTypedString(expectedData);
+    });
+
+    it('should expose a length property', function() {
+      var writer = new PDFDataWriter();
+      expect(writer.length).toEqual(0);
+      expect(writer.append(new Uint8Array(1)).length).toEqual(1);
+      expect(writer.append(new Uint8Array(2)).length).toEqual(3);
+    });
+
+    it('should not make unnecessary copies', function() {
+      var data = new Uint8Array([1, 2, 3]);
+      var writer = new PDFDataWriter();
+      expect(writer.append(data).toUint8Array()).toBe(data);
+      expect(writer.append(new Uint8Array(0)).toUint8Array()).toBe(data);
+    });
+
+    it('should not support plain objects', function() {
+      var writer = new PDFDataWriter();
+      expect(function() {
+        writer.append({});
+      }).toThrow(
+        new Error('Cannot append object of unknown type: [object Object]'));
+    });
+
+    it('should support stream objects', function() {
+      var data = new Uint8Array([32, 32]);
+      var streamDict = new Dict();
+      streamDict.set('Length', data.byteLength + 1);
+      expect(new PDFDataWriter()
+        .startStream(streamDict)
+        .append(data)
+        .endStream()
+        .toUint8Array()
+      ).toMatchTypedString('<</Length 3>>\nstream\n  \nendstream\n');
+
+      expect(function() {
+        new PDFDataWriter().endStream();
+      }).toThrow(new Error('Cannot close a stream without opening one'));
+
+      expect(function() {
+        new PDFDataWriter().startStream(streamDict).startStream(streamDict);
+      }).toThrow(new Error(
+          'Cannot start a new stream while the previous one is open'));
+    });
+
+    it('should support indirect objects', function() {
+      expect(new PDFDataWriter()
+          .startObj(new Ref(123, 45))
+          .append(6789)
+          .endObj()
+          .toUint8Array()
+      ).toMatchTypedString('\n123 45 obj\n6789\nendobj\n');
+
+      expect(function() {
+        new PDFDataWriter().endObj();
+      }).toThrow(new Error('Cannot close a non-existing indirect object'));
+
+      expect(function() {
+        new PDFDataWriter().startObj(new Ref(0, 1)).startObj(new Ref(0, 1));
+      }).toThrow(new Error(
+          'Cannot start a new indirect object while the previous one is open'));
+    });
+
+    it('should support XRef tables and trailer', function() {
+      var trailerDict = new Dict();
+      trailerDict.set('Root', new Ref(1, 0));
+      trailerDict.set('Size', 1);
+
+      expect(new PDFDataWriter(stringToBytes('%PDF-1.1'))
+          .startObj(new Ref(1, 0))
+          .append(6789)
+          .endObj()
+          .setTrailer(trailerDict)
+          .appendTrailer()
+          .toUint8Array()
+      ).toMatchTypedString('%PDF-1.1\n1 0 obj\n6789\nendobj\n' +
+          '\nxref\n0 2\n0000000000 65535 f \n0000000009 00000 n \n' +
+          '\ntrailer\n<</Size 1/Root 1 0 R>>\nstartxref\n30\n%%EOF\n');
+
+      var pdfDataWriter = new PDFDataWriter(stringToBytes('%PDF-1.1'))
+          .startObj(new Ref(5, 1))
+          .append(6789)
+          .endObj()
+          .setTrailer(trailerDict)
+          .appendTrailer();
+
+      var expectedPDFData =
+          '%PDF-1.1\n5 1 obj\n6789\nendobj\n' +
+          '\nxref\n0 1\n0000000000 65535 f \n5 1\n0000000009 00001 n \n' +
+          '\ntrailer\n<</Size 1/Root 1 0 R>>\nstartxref\n30\n%%EOF\n';
+
+      // Sparse XRef table should result in two subsections.
+      expect(pdfDataWriter.toUint8Array()).toMatchTypedString(expectedPDFData);
+
+      // Check whether the new second generated xref table points to the
+      // previous one. And also whether the new table does not contain the
+      // previous entries.
+      expect(pdfDataWriter.appendTrailer().toUint8Array()).toMatchTypedString(
+          expectedPDFData +
+          '\nxref\n0 1\n0000000000 65535 f \n' +
+          '\ntrailer\n<</Size 1/Root 1 0 R/Prev 30>>\nstartxref\n135\n%%EOF\n');
+
+      expect(function() {
+        new PDFDataWriter(null).appendTrailer();
+      }).toThrow(new Error('setTrailer must be called first'));
+    });
+
+    it('should generate XRef table starting at offset 0', function() {
+      var trailerDict = new Dict();
+      trailerDict.set('Root', new Ref(1, 0));
+      trailerDict.set('Size', 1);
+
+      expect(new PDFDataWriter(stringToBytes('%PDF-1.1'))
+          .setTrailer(trailerDict)
+          .appendTrailer()
+          .toUint8Array()
+      ).toMatchTypedString('%PDF-1.1\nxref\n0 1\n0000000000 65535 f \n' +
+          '\ntrailer\n<</Size 1/Root 1 0 R>>\nstartxref\n9\n%%EOF\n');
+
+      expect(new PDFDataWriter(null, 0)
+          .setTrailer(trailerDict)
+          .appendTrailer()
+          .toUint8Array()
+      ).toMatchTypedString('\nxref\n0 1\n0000000000 65535 f \n' +
+          '\ntrailer\n<</Size 1/Root 1 0 R>>\nstartxref\n1\n%%EOF\n');
+
+      expect(new PDFDataWriter(null, 1337)
+          .setTrailer(trailerDict)
+          .appendTrailer()
+          .toUint8Array()
+      ).toMatchTypedString('\nxref\n0 1\n0000000000 65535 f \n' +
+          '\ntrailer\n<</Size 1/Root 1 0 R>>\nstartxref\n1338\n%%EOF\n');
+    });
+
+    it('should support a pure XRef stream and trailer', function() {
+      var trailerDict = new Dict();
+      trailerDict.set('Type', new Name('XRef'));
+      trailerDict.set('Root', new Ref(1, 0));
+      trailerDict.set('Size', 2);
+
+      expect(new PDFDataWriter(null)
+          .startObj(new Ref(1, 0))
+          .append(6789)
+          .endObj()
+          .setTrailer(trailerDict)
+          .appendTrailer()
+          .toUint8Array()
+      ).toMatchTypedString('\n1 0 obj\n6789\nendobj\n' +
+        '\n2 0 obj\n<</Size 3/Root 1 0 R/Filter /ASCIIHexDecode' +
+        '/Length 26/Type /XRef/Index [0 3]/W [1 1 2]>>\nstream\n' +
+        '0000FFFF' +
+        '01010000' +
+        '01160000>' +
+        '\nendstream\n\nendobj\n\nstartxref\n22\n%%EOF\n');
+
+      // Test whether Index contains multiple pairs for a sparse xref table.
+      expect(new PDFDataWriter(null)
+          .setTrailer(trailerDict)
+          .appendTrailer()
+          .toUint8Array()
+      ).toMatchTypedString(
+        '\n2 0 obj\n<</Size 3/Root 1 0 R/Filter /ASCIIHexDecode' +
+        '/Length 18/Type /XRef/Index [0 1 2 1]/W [1 1 2]>>\nstream\n' +
+        '0000FFFF' +
+        '01010000>' +
+        '\nendstream\n\nendobj\n\nstartxref\n1\n%%EOF\n');
+    });
+
+    it('should point to the xref as set by setStartXRef', function() {
+      var trailerDict = new Dict();
+      trailerDict.set('Root', new Ref(1, 0));
+      trailerDict.set('Size', 1);
+
+      expect(new PDFDataWriter(null)
+          .setStartXRef(7777)
+          .setTrailer(trailerDict)
+          .appendTrailer()
+          .toUint8Array()
+      ).toMatchTypedString('\nxref\n0 1\n0000000000 65535 f \n' +
+          '\ntrailer\n<</Size 1/Root 1 0 R/Prev 7777>>\nstartxref\n1\n%%EOF\n');
+
+      trailerDict.set('Type', new Name('XRef'));
+      expect(new PDFDataWriter(null)
+          .setStartXRef(7777)
+          .setTrailer(trailerDict)
+          .appendTrailer()
+          .toUint8Array()
+      ).toMatchTypedString(
+        '\n1 0 obj\n<</Size 2/Root 1 0 R/Prev 7777/Filter /ASCIIHexDecode' +
+        '/Length 18/Type /XRef/Index [0 2]/W [1 1 2]>>\nstream\n' +
+        '0000FFFF' +
+        '01010000>' +
+        '\nendstream\n\nendobj\n\nstartxref\n1\n%%EOF\n');
+    });
+
+    it('should be able to generate a valid PDF file', function(done) {
+      var fixtureFileLocation = '../pdfs/written-with-pdfjs.pdf';
+      var x = new XMLHttpRequest();
+      x.open('GET', fixtureFileLocation, false);
+      x.send();
+      var expectedPDFData = x.responseText;
+
+      var catalog = new Dict();
+      catalog.set('Type', new Name('Catalog'));
+      catalog.set('Pages', new Ref(2, 0));
+
+      var pages = new Dict();
+      pages.set('Type', new Name('Pages'));
+      pages.set('Count', 1);
+      pages.set('Kids', [new Ref(3, 0)]);
+      pages.set('MediaBox', [0, 0, 200, 100]);
+
+      var type1FontDict = new Dict();
+      type1FontDict.set('Type', new Name('Font'));
+      type1FontDict.set('Subtype', new Name('Type1'));
+      type1FontDict.set('BaseFont', new Name('Arial'));
+
+      var fontDict = new Dict();
+      fontDict.set('F1', type1FontDict);
+
+      var resourcesDict = new Dict();
+      resourcesDict.set('Font', fontDict);
+
+      var page1 = new Dict();
+      page1.set('Type', new Name('Page'));
+      page1.set('Parent', new Ref(2, 0));
+      page1.set('Resources', resourcesDict);
+      page1.set('Contents', new Ref(4, 0));
+
+      var streamData =
+        stringToBytes('BT/F1 20 Tf 0 0 Td(Written with PDF.js) Tj ET');
+      var streamDict = new Dict();
+      streamDict.set('Length', streamData.byteLength + 1);
+
+      var trailerDict = new Dict();
+      trailerDict.set('Size', 5);
+      trailerDict.set('Root', new Ref(1, 0));
+
+      expect(new PDFDataWriter(stringToBytes('%PDF-1.1'))
+          .startObj(new Ref(1, 0))
+          .append(catalog)
+          .endObj()
+          .startObj(new Ref(2, 0))
+          .append(pages)
+          .endObj()
+          .startObj(new Ref(3, 0))
+          .append(page1)
+          .endObj()
+          .startObj(new Ref(4, 0))
+          .startStream(streamDict)
+          .append(streamData)
+          .endStream()
+          .endObj()
+          .setTrailer(trailerDict)
+          .appendTrailer()
+          .toUint8Array()
+      ).toMatchTypedString(expectedPDFData);
+    });
+  });
+});

--- a/test/unit/unit_test.html
+++ b/test/unit/unit_test.html
@@ -40,6 +40,7 @@
   <script src="../../src/core/worker.js"></script>
   <script src="../../src/display/metadata.js"></script>
   <script src="../../src/core/jpg.js"></script>
+  <script src="../../src/editing/pdf_data_writer.js"></script>
   <script src="../../web/ui_utils.js"></script>
   <script>PDFJS.workerSrc = '../../src/worker_loader.js';</script>
 
@@ -57,6 +58,7 @@
   <script src="util_spec.js"></script>
   <script src="cmap_spec.js"></script>
   <script src="annotation_layer_spec.js"></script>
+  <script src="pdf_data_writer_spec.js"></script>
   <script>
     'use strict';
 

--- a/web/mozPrintCallback_polyfill.js
+++ b/web/mozPrintCallback_polyfill.js
@@ -119,7 +119,7 @@
     if (event.keyCode === 27 && canvases) { // Esc
       abort();
     }
-  }, true);
+  }, false);
   if (hasAttachEvent) {
     document.attachEvent('onkeydown', function(event) {
       event = event || window.event;

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -80,7 +80,7 @@ var SecondaryToolbar = {
   },
 
   printClick: function secondaryToolbarPrintClick(evt) {
-    window.print();
+    PDFViewerApplication.requestPrint();
     this.close();
   },
 


### PR DESCRIPTION
This PR adds a minimalistic and low-level `PDFDataWriter` class to PDF.js, which allows us to (incrementally) update PDFs. With this new class, I add print instructions to the PDF, which significantly improves the printing performance in Chromium-based browsers with a built-in PDF previewer (so, basically every Chromium browser AFAIK).

I suggest to separately review each commit, instead of checking the combined diff of the PR, because each commit is focused on a specific feature and has a detailed commit message.

To verify that the whole works as expected:
1. `node make chromium`
2. Open Chrome, visit chrome://extensions and load the unpacked extension from build/chromium/.
3. Open any PDF (preferably one with 10+ pages) with Chrome.
4. Focus the page and press Ctrl + P.
5. A print preview should immediately be displayed, without rendering all pages upfront.
6. Close the preview and click on the print button (or Ctr+P).
7. Same as 5.

and
1. `node make generic`
2. `node make server` (to start the server).
3. Visit localhost:8888 and open a PDF
4. See step 4 - 7 of the previous list.

and
1. Visit `http://localhost:8888/test/unit/unit_test.html?spec=pdf_data_writer` and verify that all tests are green.
