### PR TITLE
Refactor the 'resize' event handler in viewer.js (issue 6158)

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1643,13 +1643,16 @@ window.addEventListener('updateviewarea', function (evt) {
 }, true);
 
 window.addEventListener('resize', function webViewerResize(evt) {
-  if (PDFViewerApplication.initialized &&
-      (document.getElementById('pageAutoOption').selected ||
-       /* Note: the scale is constant for |pageActualOption|. */
-       document.getElementById('pageFitOption').selected ||
-       document.getElementById('pageWidthOption').selected)) {
-    var selectedScale = document.getElementById('scaleSelect').value;
-    PDFViewerApplication.setScale(selectedScale, false);
+  if (PDFViewerApplication.initialized) {
+    var currentScaleValue = PDFViewerApplication.pdfViewer.currentScaleValue;
+    switch (currentScaleValue) {
+      case 'auto':
+      case 'page-fit':
+      case 'page-width':
+        // Note: the scale is constant for 'page-actual'.
+        PDFViewerApplication.pdfViewer.currentScaleValue = currentScaleValue;
+        break;
+    }
   }
   updateViewarea();
 
@@ -1707,7 +1710,7 @@ window.addEventListener('change', function webViewerChange(evt) {
 function selectScaleOption(value) {
   var options = document.getElementById('scaleSelect').options;
   var predefinedValueFound = false;
-  for (var i = 0; i < options.length; i++) {
+  for (var i = 0, ii = options.length; i < ii; i++) {
     var option = options[i];
     if (option.value !== value) {
       option.selected = false;


### PR DESCRIPTION
_This is the next step towards fixing #6158._

This patch removes the dependency on the state of the scale `<select>` dropdown from the `resize` event handler, and instead uses the (in `PDFViewer`) stored `currentScaleValue`.
I believe that the way this code is currently written is purely for historical reasons, since originally _only_ the numerical scale was stored internally (hence there was no other way to access the scale value).
However, since we now store the scale value, we should use it instead of quering the DOM. This helps ensure that the internally stored scale value is always accurately displayed in the UI (which should be good since, after the creation of `PDFViewer`, the `<select>` DOM element is now updated by an event handler).

@timvandermeij Since you've been kind enough to review the previous patches in this series, could you please review this one as well?
