### PR TITLE
Issue a warning instead of an error for long Names

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -838,9 +838,8 @@ var Lexer = (function LexerClosure() {
           strBuf.push(String.fromCharCode(ch));
         }
       }
-      if (strBuf.length > 128) {
-        error('Warning: name token is longer than allowed by the spec: ' +
-              strBuf.length);
+      if (strBuf.length > 127) {
+        warn('name token is longer than allowed by the spec: ' + strBuf.length);
       }
       return Name.get(strBuf.join(''));
     },


### PR DESCRIPTION
Fixes #6151

The PDF specification (cited below) specifies a maximum length of a name in bytes as a minimal architectural limit. This means that PDF _writers_ should not create names that exceed 127 bytes.

It does not forbid PDF _readers_ to accept such names though. These names are only used internally to link PDF objects to other objects. For these use cases, the lengths of the names do not really matter. Hence I have changed the implementation to not treat long names as errors, but warnings.

> (7.3.5) The length of a name shall be subject to an implementation limit; see Annex C.
> 
> (Annex C.2) Table C.1 describes the minimum architectural limits that should be accommodated by conforming readers running on 32-bit machines. Because conforming readers may be subject to these limits, conforming writers producing PDF files should remain within them.
> 
> (Table C.1) name 127 "Maximum length of a name, in bytes."
> 
> -- http://adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf
