### PR TITLE
Add --testfilter and -t flags

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -132,6 +132,8 @@ var Driver = (function DriverClosure() {
     this.appPath = parameters.path;
     this.delay = (parameters.delay | 0) || 0;
     this.inFlightRequests = 0;
+    this.testFilter = parameters.testFilter ?
+      JSON.parse(parameters.testFilter) : [];
 
     // Create a working canvas
     this.canvas = document.createElement('canvas');
@@ -163,6 +165,11 @@ var Driver = (function DriverClosure() {
         if (r.readyState === 4) {
           self._log('done\n');
           self.manifest = JSON.parse(r.responseText);
+          if (self.testFilter && self.testFilter.length) {
+            self.manifest = self.manifest.filter(function(item) {
+              return self.testFilter.indexOf(item.id) !== -1;
+            });
+          }
           self.currentTask = 0;
           self._nextTask();
         }
@@ -422,9 +429,9 @@ var Driver = (function DriverClosure() {
     _done: function Driver_done() {
       if (this.inFlightRequests > 0) {
         this.inflight.textContent = this.inFlightRequests;
-        setTimeout(this._done(), WAITING_TIME);
+        setTimeout(this._done.bind(this), WAITING_TIME);
       } else {
-        setTimeout(this._quit(), WAITING_TIME);
+        setTimeout(this._quit.bind(this), WAITING_TIME);
       }
     },
 

--- a/test/webbrowser.js
+++ b/test/webbrowser.js
@@ -157,17 +157,18 @@ ChromiumBrowser.prototype.buildArguments = function (url) {
 
 WebBrowser.create = function (desc) {
   var name = desc.name;
-
-  // Throws an exception if the path doesn't exist.
-  fs.statSync(desc.path);
+  var path = shelljs.which(desc.path);
+  if (!path) {
+    throw new Error('Browser executable not found: ' + desc.path);
+  }
 
   if (/firefox/i.test(name)) {
-    return new FirefoxBrowser(desc.name, desc.path);
+    return new FirefoxBrowser(name, path);
   }
   if (/(chrome|chromium|opera)/i.test(name)) {
-    return new ChromiumBrowser(desc.name, desc.path);
+    return new ChromiumBrowser(name, path);
   }
-  return new WebBrowser(desc.name, desc.path);
+  return new WebBrowser(name, path);
 };
 
 


### PR DESCRIPTION
- Add a `--testfilter` (`-t`) flag to run a specific test.
- Resolve the browser path to a full path before trying to launch the browser.
- Add an example to the help message, to quickly get started with running tests.
