### PR TITLE
[CRX] Respect download requests in main frame

### DIFF
--- a/extensions/chromium/pdfHandler.js
+++ b/extensions/chromium/pdfHandler.js
@@ -34,9 +34,15 @@ function isPdfDownloadable(details) {
   if (details.url.indexOf('pdfjs.action=download') >= 0) {
     return true;
   }
-  // Display the PDF viewer regardless of the Content-Disposition header
-  // if the file is displayed in the main frame.
-  if (details.type === 'main_frame') {
+  // Display the PDF viewer regardless of the Content-Disposition header if the
+  // file is displayed in the main frame, since most often users want to view
+  // a PDF, and servers are often misconfigured.
+  // If the query string contains "=download", do not unconditionally force the
+  // viewer to open the PDF, but first check whether the Content-Disposition
+  // header specifies an attachment. This allows sites like Google Drive to
+  // operate correctly (#6106).
+  if (details.type === 'main_frame' &&
+      details.url.indexOf('=download') === -1) {
     return false;
   }
   var cdHeader = (details.responseHeaders &&


### PR DESCRIPTION
When the URL contains "=download", respect the Content-Disposition header in the Chrome extension.

Steps to verify:
1. `node make chromium`
2. Load the extension at `chrome://extensions`
3. Visit  https://drive.google.com/a/notable.ac/file/d/0B6YhVF9p-y2AbUJlcEI5ZGZ5Z2c/view?pli=1
4. Click on the download button.
5. Verify that the PDF is downloaded instead of being opened in the PDF.js Chrome extension.

Fixes half of #6106 (the printing part is still a todo, which I'll address after #6190 gets merged)
