### PR TITLE
More cleanup regarding annotation border styles

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -160,7 +160,6 @@ var Annotation = (function AnnotationClosure() {
           this.borderStyle.setHorizontalCornerRadius(array[0]);
           this.borderStyle.setVerticalCornerRadius(array[1]);
           this.borderStyle.setWidth(array[2]);
-          this.borderStyle.setStyle('S');
 
           if (array.length === 4) { // Dash array available
             this.borderStyle.setDashArray(array[3]);

--- a/src/display/annotation_helper.js
+++ b/src/display/annotation_helper.js
@@ -45,7 +45,7 @@ var AnnotationUtils = (function AnnotationUtilsClosure() {
     style.fontFamily = fontFamily + fallbackName;
   }
 
-  function initContainer(item, drawBorder) {
+  function initContainer(item) {
     var container = document.createElement('section');
     var cstyle = container.style;
     var width = item.rect[2] - item.rect[0];
@@ -149,7 +149,7 @@ var AnnotationUtils = (function AnnotationUtilsClosure() {
       rect[2] = rect[0] + (rect[3] - rect[1]); // make it square
     }
 
-    var container = initContainer(item, false);
+    var container = initContainer(item);
     container.className = 'annotText';
 
     var image  = document.createElement('img');
@@ -256,7 +256,7 @@ var AnnotationUtils = (function AnnotationUtilsClosure() {
   }
 
   function getHtmlElementForLinkAnnotation(item) {
-    var container = initContainer(item, true);
+    var container = initContainer(item);
     container.className = 'annotLink';
 
     var link = document.createElement('a');

--- a/test/unit/annotation_layer_spec.js
+++ b/test/unit/annotation_layer_spec.js
@@ -1,6 +1,6 @@
 /* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
-/* globals expect, it, describe, Dict, Annotation, AnnotationBorderStyle,
+/* globals expect, it, describe, Dict, Name, Annotation, AnnotationBorderStyle,
            AnnotationBorderStyleType */
 
 'use strict';
@@ -79,9 +79,7 @@ describe('Annotation layer', function() {
 
     it('should set and get a valid style', function() {
       var borderStyle = new AnnotationBorderStyle();
-      var dict = new Dict();
-      dict.name = 'D';
-      borderStyle.setStyle(dict);
+      borderStyle.setStyle(Name.get('D'));
 
       expect(borderStyle.style).toEqual(AnnotationBorderStyleType.DASHED);
     });


### PR DESCRIPTION
This PR provides (minor) clean-up for the annotation border styles. There are three changes:
- `this.borderStyle.setStyle('S');` is wrong as `setStyle` takes a `Name` as parameter, not a string. Somehow we all missed this during review, but fortunately we do not even need that line because the solid border style is the default.
- The `drawBorder` parameter for `initContainer` has become unused after the annotation border style refactoring, so we can remove it.
- A unit test has been adjusted for the same reason as the first point: `setStyle` takes a `Name` as parameter, not a dictionary (even though that worked too, it is better to keep it the same as what we expect).

@Snuffleupagus Could you review this one too?
