### PR TITLE
Ignore double negative in `Lexer_getNumber` (issue 6218)

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -671,6 +671,11 @@ var Lexer = (function LexerClosure() {
       if (ch === 0x2D) { // '-'
         sign = -1;
         ch = this.nextChar();
+
+        if (ch === 0x2D) { // '-'
+          // Ignore double negative (this is consistent with Adobe Reader).
+          ch = this.nextChar();
+        }
       } else if (ch === 0x2B) { // '+'
         ch = this.nextChar();
       }

--- a/test/unit/parser_spec.js
+++ b/test/unit/parser_spec.js
@@ -27,6 +27,13 @@ describe('parser', function() {
       }
     });
 
+    it('should ignore double negative before number', function() {
+      var input = new StringStream('--205.88');
+      var lexer = new Lexer(input);
+      var result = lexer.getNumber();
+
+      expect(result).toEqual(-205.88);
+    });
 
     it('should handle glued numbers and operators', function() {
       var input = new StringStream('123ET');


### PR DESCRIPTION
Basic mathematics would suggest that a double negative should always become positive, but it appears that Adobe Reader simply ignores that case. Hence I think that it makes sense for us to do the same.

Fixes #6218.
