### PR TITLE
Fixing find toolbar checkboxes not being accessible through keyboard

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -142,10 +142,10 @@ See https://github.com/adobe-type-tools/cmap-resources
               <span data-l10n-id="find_next_label">Next</span>
             </button>
           </div>
-          <input type="checkbox" id="findHighlightAll" class="toolbarField">
-          <label for="findHighlightAll" class="toolbarLabel" tabindex="94" data-l10n-id="find_highlight">Highlight all</label>
-          <input type="checkbox" id="findMatchCase" class="toolbarField">
-          <label for="findMatchCase" class="toolbarLabel" tabindex="95" data-l10n-id="find_match_case_label">Match case</label>
+          <input type="checkbox" id="findHighlightAll" class="toolbarField" tabindex="94">
+          <label for="findHighlightAll" class="toolbarLabel" data-l10n-id="find_highlight">Highlight all</label>
+          <input type="checkbox" id="findMatchCase" class="toolbarField" tabindex="95">
+          <label for="findMatchCase" class="toolbarLabel" data-l10n-id="find_match_case_label">Match case</label>
           <span id="findMsg" class="toolbarLabel"></span>
         </div>  <!-- findbar -->
 


### PR DESCRIPTION
Fixes #6210 

The tab index was set on the checkbox labels, rather than on the checkboxes themselves. It seems that Chrome assumed that the user wanted to interact with the checkbox related to the label, but Firefox and Internet Explorer made a literal assumption and had the user interact with the label.
