### PR TITLE
Simplify annotation data passing

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -175,10 +175,6 @@ var Annotation = (function AnnotationClosure() {
       }
     },
 
-    getData: function Annotation_getData() {
-      return this.data;
-    },
-
     isInvisible: function Annotation_isInvisible() {
       var data = this.data;
       if (data && SUPPORTED_TYPES.indexOf(data.subtype) !== -1) {

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -111,11 +111,6 @@ var Page = (function PageClosure() {
       return shadow(this, 'view', cropBox);
     },
 
-    get annotationRefs() {
-      return shadow(this, 'annotationRefs',
-                    this.getInheritedPageProp('Annots'));
-    },
-
     get rotate() {
       var rotate = this.getInheritedPageProp('Rotate') || 0;
       // Normalize rotation so it's a multiple of 90 and between 0 and 270
@@ -261,14 +256,14 @@ var Page = (function PageClosure() {
       var annotations = this.annotations;
       var annotationsData = [];
       for (var i = 0, n = annotations.length; i < n; ++i) {
-        annotationsData.push(annotations[i].getData());
+        annotationsData.push(annotations[i].data);
       }
       return annotationsData;
     },
 
     get annotations() {
       var annotations = [];
-      var annotationRefs = (this.annotationRefs || []);
+      var annotationRefs = this.getInheritedPageProp('Annots') || [];
       for (var i = 0, n = annotationRefs.length; i < n; ++i) {
         var annotationRef = annotationRefs[i];
         var annotation = Annotation.fromRef(this.xref, annotationRef);

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -688,13 +688,10 @@ var PDFPageProxy = (function PDFPageProxyClosure() {
      * annotation objects.
      */
     getAnnotations: function PDFPageProxy_getAnnotations() {
-      if (this.annotationsPromise) {
-        return this.annotationsPromise;
+      if (!this.annotationsPromise) {
+        this.annotationsPromise = this.transport.getAnnotations(this.pageIndex);
       }
-
-      var promise = this.transport.getAnnotations(this.pageIndex);
-      this.annotationsPromise = promise;
-      return promise;
+      return this.annotationsPromise;
     },
     /**
      * Begins the process of rendering a page to the desired context.


### PR DESCRIPTION
We can avoid the `getData` method call by just accessing the `data` property on the annotation object. We can avoid `get annotationRefs` by directly using its result (like all other methods in that file). Finally, `getAnnotations` in `api.js` can be simplified by interchanging the cases, i.e., always returing the promise and only creating it when it does not exist yet.

I have verified with 15 test files with different annotation types (Link, Text, Widget, Markup, et cetera) that rendering has not changed.

@Snuffleupagus Could you review this PR?
