### PR TITLE
Move handling of the 'custom' scale value from pdf_viewer.js to viewer.js

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -415,9 +415,6 @@ var PDFViewer = (function pdfViewer() {
     },
 
     _setScale: function pdfViewer_setScale(value, noScroll) {
-      if (value === 'custom') {
-        return;
-      }
       var scale = parseFloat(value);
 
       if (scale > 0) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1440,6 +1440,9 @@ function webViewerInitialized() {
   });
 
   document.getElementById('scaleSelect').addEventListener('change', function() {
+    if (this.value === 'custom') {
+      return;
+    }
     PDFViewerApplication.pdfViewer.currentScaleValue = this.value;
   });
 


### PR DESCRIPTION
The special handling of the 'custom' scale value is only relevant for the `scaleSelect` dropdown in the standard viewer, hence I think that it should be placed in `viewer.js` instead.

_Another small round of viewer clean-up._ @timvandermeij would you mind reviewing this?
