### PR TITLE
Refactor annotation rectangle code and add unit tests

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -75,9 +75,10 @@ var Annotation = (function AnnotationClosure() {
     var data = this.data = {};
 
     data.subtype = dict.get('Subtype').name;
-    var rect = dict.get('Rect') || [0, 0, 0, 0];
-    data.rect = Util.normalizeRect(rect);
     data.annotationFlags = dict.get('F');
+
+    this.setRectangle(dict.get('Rect'));
+    data.rect = this.rectangle;
 
     this.setColor(dict.get('C'));
     data.color = this.color;
@@ -91,6 +92,21 @@ var Annotation = (function AnnotationClosure() {
   }
 
   Annotation.prototype = {
+    /**
+     * Set the rectangle.
+     *
+     * @public
+     * @memberof Annotation
+     * @param {Array} rectangle - The rectangle array with exactly four entries
+     */
+    setRectangle: function Annotation_setRectangle(rectangle) {
+      if (isArray(rectangle) && rectangle.length === 4) {
+        this.rectangle = Util.normalizeRect(rectangle);
+      } else {
+        this.rectangle = [0, 0, 0, 0];
+      }
+    },
+
     /**
      * Set the color and take care of color space conversion.
      *

--- a/test/unit/annotation_layer_spec.js
+++ b/test/unit/annotation_layer_spec.js
@@ -7,6 +7,24 @@
 
 describe('Annotation layer', function() {
   describe('Annotation', function() {
+    it('should set and get a valid rectangle', function() {
+      var dict = new Dict();
+      dict.set('Subtype', '');
+      var annotation = new Annotation({ dict: dict, ref: 0 });
+      annotation.setRectangle([117, 694, 164.298, 720]);
+
+      expect(annotation.rectangle).toEqual([117, 694, 164.298, 720]);
+    });
+
+    it('should not set and get an invalid rectangle', function() {
+      var dict = new Dict();
+      dict.set('Subtype', '');
+      var annotation = new Annotation({ dict: dict, ref: 0 });
+      annotation.setRectangle([117, 694, 164.298]);
+
+      expect(annotation.rectangle).toEqual([0, 0, 0, 0]);
+    });
+
     it('should reject a color if it is not an array', function() {
       var dict = new Dict();
       dict.set('Subtype', '');


### PR DESCRIPTION
This patch refactors the code responsible for setting the annotation's rectangle. Its goal is to:
- Actually check that the input array is an array, and if so, that it contains exactly four elements.
- Only call `normalizeRect` if the input array is valid, i.e., we do not call it for the default rectangle anymore.
- Provide unit test coverage (just like the other patches in this series).

@Snuffleupagus Could you review this one? I have tested this patch manually (aside from with the unit tests) with 15 PDF files with different annotation types (Link, Text, Widget, FileAttachment, et cetera) to make sure that the rendering is identical before and after the patch.
