### PR TITLE
Check if the `Decode` entry is non-default when deciding if JPEG images are natively supported/decodable (issue 6238)

### DIFF
--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -351,7 +351,7 @@ var ColorSpace = (function ColorSpaceClosure() {
    * @param {Number} n Number of components the color space has.
    */
   ColorSpace.isDefaultDecode = function ColorSpace_isDefaultDecode(decode, n) {
-    if (!decode) {
+    if (!isArray(decode)) {
       return true;
     }
 

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -942,7 +942,8 @@ var JpegStream = (function JpegStreamClosure() {
   JpegStream.prototype.isNativelySupported =
       function JpegStream_isNativelySupported(xref, res) {
     var cs = ColorSpace.parse(this.dict.get('ColorSpace', 'CS'), xref, res);
-    return cs.name === 'DeviceGray' || cs.name === 'DeviceRGB';
+    return (cs.name === 'DeviceGray' || cs.name === 'DeviceRGB') &&
+           cs.isDefaultDecode(this.dict.get('Decode', 'D'));
   };
   /**
    * Checks if the image can be decoded by the browser.
@@ -950,8 +951,8 @@ var JpegStream = (function JpegStreamClosure() {
   JpegStream.prototype.isNativelyDecodable =
       function JpegStream_isNativelyDecodable(xref, res) {
     var cs = ColorSpace.parse(this.dict.get('ColorSpace', 'CS'), xref, res);
-    var numComps = cs.numComps;
-    return numComps === 1 || numComps === 3;
+    return (cs.numComps === 1 || cs.numComps === 3) &&
+           cs.isDefaultDecode(this.dict.get('Decode', 'D'));
   };
 
   return JpegStream;

--- a/test/pdfs/issue6238.pdf.link
+++ b/test/pdfs/issue6238.pdf.link
@@ -1,0 +1,1 @@
+http://web.archive.org/web/20150720164240/http://fqa.9front.org/dash1.kaptnblaubar.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1338,6 +1338,15 @@
        "lastPage": 6,
        "type": "eq"
     },
+    {  "id": "issue6238",
+       "file": "pdfs/issue6238.pdf",
+       "md5": "6d7731ee22fbbdf746c8da01b8922d50",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 3,
+       "lastPage": 3,
+       "type": "eq"
+    },
     {  "id": "cid_cff",
       "file": "pdfs/cid_cff.pdf",
       "md5": "a19a18eaa626262cc45e0760004d6de9",


### PR DESCRIPTION
Tentatively fixes #6238.

_Edit:_ Linked test-case added.
