### PR TITLE
Default to `DEFAULT_SCALE_VALUE` when the zoom parameter, from `PDFViewerApplication.store`, isn't found in `PDFViewerApplication.setInitialView`

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -790,7 +790,7 @@ var PDFViewerApplication = {
             store.get('exists', false)) {
           var pageNum = store.get('page', '1');
           var zoom = self.preferenceDefaultZoomValue ||
-                     store.get('zoom', self.pdfViewer.currentScale);
+                     store.get('zoom', DEFAULT_SCALE_VALUE);
           var left = store.get('scrollLeft', '0');
           var top = store.get('scrollTop', '0');
 


### PR DESCRIPTION
Currently the code uses `PDFViewer.currentScale`, which can be problematic since by default that will return `1`. In `PDFLinkService.setHash` numeric zoom values are divided by `100`, which can thus lead to an incorrect document scale being set.
Obviously we could fix this by multiplying the zoom parameter in `PDFViewerApplication.setInitialView` by `100`, but it's simpler and seems more logical to just use `DEFAULT_SCALE_VALUE` instead.

@timvandermeij Would you mind reviewing this?
I stumbled upon this issue when opening the PDF file in issue #6243 in a new tab (by middle-clicking, or using the context-menu and choosing "Open Link in New Tab").
