### PR TITLE
Fix loading PDF files on Chrome 36

### DIFF
--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -106,7 +106,7 @@ var FontLoader = {
   nativeFontFaces: [],
 
   isFontLoadingAPISupported: (!isWorker && typeof document !== 'undefined' &&
-                              !!document.fonts),
+                              !!document.fonts && FontFace.prototype.hasOwnProperty('loaded')),
 
   addNativeFontFace: function fontLoader_addNativeFontFace(nativeFontFace) {
     this.nativeFontFaces.push(nativeFontFace);


### PR DESCRIPTION
Chrome 36 has the font loading API, but doesn’t have the loaded method
on it, which causes getNativeFontPromise() to fail, meaning the PDF
file is never loaded.

This adds an extra check to isFontLoadingAPISupported to account for this.
