### PR TITLE
Ensure that the viewer always receives focus when the HOME/END keys are pressed (bug 1186842)

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1935,6 +1935,7 @@ window.addEventListener('keydown', function keydown(evt) {
       return;
     }
   }
+  var ensureViewerFocused = false;
 
   if (cmd === 0) { // no control key pressed at all.
     switch (evt.keyCode) {
@@ -1993,9 +1994,7 @@ window.addEventListener('keydown', function keydown(evt) {
         if (isViewerInPresentationMode || PDFViewerApplication.page > 1) {
           PDFViewerApplication.page = 1;
           handled = true;
-          if (!pdfViewer.containsElement(curElement)) {
-            pdfViewer.focus();
-          }
+          ensureViewerFocused = true;
         }
         break;
       case 35: // end
@@ -2003,9 +2002,7 @@ window.addEventListener('keydown', function keydown(evt) {
             PDFViewerApplication.page < PDFViewerApplication.pagesCount)) {
           PDFViewerApplication.page = PDFViewerApplication.pagesCount;
           handled = true;
-          if (!pdfViewer.containsElement(curElement)) {
-            pdfViewer.focus();
-          }
+          ensureViewerFocused = true;
         }
         break;
 
@@ -2040,17 +2037,10 @@ window.addEventListener('keydown', function keydown(evt) {
   if (!handled && !isViewerInPresentationMode) {
     // 33=Page Up  34=Page Down  35=End    36=Home
     // 37=Left     38=Up         39=Right  40=Down
-    if (evt.keyCode >= 33 && evt.keyCode <= 40 &&
-        !pdfViewer.containsElement(curElement)) {
-      // The page container is not focused, but a page navigation key has been
-      // pressed. Change the focus to the viewer container to make sure that
-      // navigation by keyboard works as expected.
-      pdfViewer.focus();
-    }
     // 32=Spacebar
-    if (evt.keyCode === 32 && curElementTagName !== 'BUTTON' &&
-        !pdfViewer.containsElement(curElement)) {
-      pdfViewer.focus();
+    if ((evt.keyCode >= 33 && evt.keyCode <= 40) ||
+        (evt.keyCode === 32 && curElementTagName !== 'BUTTON')) {
+      ensureViewerFocused = true;
     }
   }
 
@@ -2069,6 +2059,13 @@ window.addEventListener('keydown', function keydown(evt) {
         }
         break;
     }
+  }
+
+  if (ensureViewerFocused && !pdfViewer.containsElement(curElement)) {
+    // The page container is not focused, but a page navigation key has been
+    // pressed. Change the focus to the viewer container to make sure that
+    // navigation by keyboard works as expected.
+    pdfViewer.focus();
   }
 
   if (handled) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1993,6 +1993,9 @@ window.addEventListener('keydown', function keydown(evt) {
         if (isViewerInPresentationMode || PDFViewerApplication.page > 1) {
           PDFViewerApplication.page = 1;
           handled = true;
+          if (!pdfViewer.containsElement(curElement)) {
+            pdfViewer.focus();
+          }
         }
         break;
       case 35: // end
@@ -2000,6 +2003,9 @@ window.addEventListener('keydown', function keydown(evt) {
             PDFViewerApplication.page < PDFViewerApplication.pagesCount)) {
           PDFViewerApplication.page = PDFViewerApplication.pagesCount;
           handled = true;
+          if (!pdfViewer.containsElement(curElement)) {
+            pdfViewer.focus();
+          }
         }
         break;
 


### PR DESCRIPTION
It appears that I broke this with PR #4941.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1186842.

@timvandermeij Could you please review this PR?
