### PR TITLE
Remove unused globals and updateViewarea function from viewer.js

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -20,10 +20,10 @@
            PDFThumbnailViewer, URL, noContextMenuHandler, SecondaryToolbar,
            PasswordPrompt, PDFPresentationMode, PDFDocumentProperties, HandTool,
            Promise, PDFLinkService, PDFOutlineView, PDFAttachmentView,
-           OverlayManager, PDFFindController, PDFFindBar, getVisibleElements,
-           watchScroll, PDFViewer, PDFRenderingQueue, PresentationModeState,
-           parseQueryString, RenderingStates, UNKNOWN_SCALE,
-           DEFAULT_SCALE_VALUE, IGNORE_CURRENT_POSITION_ON_ZOOM: true */
+           OverlayManager, PDFFindController, PDFFindBar, PDFViewer,
+           PDFRenderingQueue, PresentationModeState, parseQueryString,
+           RenderingStates, UNKNOWN_SCALE, DEFAULT_SCALE_VALUE,
+           IGNORE_CURRENT_POSITION_ON_ZOOM: true */
 
 'use strict';
 
@@ -1591,13 +1591,6 @@ window.addEventListener('presentationmodechanged', function (e) {
     active ? PresentationModeState.FULLSCREEN : PresentationModeState.NORMAL;
 });
 
-function updateViewarea() {
-  if (!PDFViewerApplication.initialized) {
-    return;
-  }
-  PDFViewerApplication.pdfViewer.update();
-}
-
 window.addEventListener('updateviewarea', function (evt) {
   if (!PDFViewerApplication.initialized) {
     return;
@@ -1650,8 +1643,8 @@ window.addEventListener('resize', function webViewerResize(evt) {
       // (E.g. the document being rendered with the wrong scale on load.)
       PDFViewerApplication.pdfViewer.currentScaleValue = DEFAULT_SCALE_VALUE;
     }
+    PDFViewerApplication.pdfViewer.update();
   }
-  updateViewarea();
 
   // Set the 'max-height' CSS property of the secondary toolbar.
   SecondaryToolbar.setMaxHeight(document.getElementById('viewerContainer'));
@@ -1759,7 +1752,10 @@ window.addEventListener('scalechange', function scalechange(evt) {
       mozL10n.get('page_scale_percent', { scale: customScale }, '{{scale}}%');
     customScaleOption.selected = true;
   }
-  updateViewarea();
+  if (!PDFViewerApplication.initialized) {
+    return;
+  }
+  PDFViewerApplication.pdfViewer.update();
 }, true);
 
 window.addEventListener('pagechange', function pagechange(evt) {


### PR DESCRIPTION
This patch cleans up `viewer.js` a bit by removing the unused globals `getVisibleElements` and `watchScroll` (both became obsolete after moving the thumbnail code to its own file) and by removing the `updateViewarea` function. It seems superfluous to have an entire function essentially only for calling `PDFViewerApplication.pdfViewer.update()`. On top of that, it is only used in two places, one of which (the `resize` event handler) already performs the check if PDFViewerApplication is initialized, making the function even less useful as it would do the exact same check again. Therefore inlining that part seemed cleaner and in the `resize` event handler we only use the `update()` line instead of repeating the check.

@Snuffleupagus Could you review this patch?
