### PR TITLE
Optimize text layer: Avoid unneeded .textContent access

### DIFF
--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -197,7 +197,7 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
       // We don't bother scaling single-char text divs, because it has very
       // little effect on text highlighting. This makes scrolling on docs with
       // lots of such divs a lot faster.
-      if (textDiv.textContent.length > 1) {
+      if (geom.str.length > 1) {
         if (style.vertical) {
           textDiv.dataset.canvasWidth = geom.height * this.viewport.scale;
         } else {


### PR DESCRIPTION
Built-in DOM properties are slower than plain JS properties. A few lines before, `textContent` is assigned a value as follows:

```
textDiv.textContent = geom.str;
```

So replacing `textDiv.textContent.length` with `geom.str.length` slightly improves performance without side effects.

Benchmark:

``` javascript
var a = document.createElement('div');
console.time('benchmark');
for (var i = 0; i < 1000000; ++i) {
  var geom = {str: String(i) };
  a.textContent = geom.str;
  //if(a.textContent.length); // Firefox 38: ~4.5s, Chrome 43: ~6s
  if(geom.str.length);        // Firefox 38: ~4s, Chrome 43: ~4.5s
}

console.timeEnd('benchmark');
```
