### PR TITLE
Enabling find functionality on small devices

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -40,6 +40,10 @@ select {
   outline: none;
 }
 
+label > input, label > span {
+  vertical-align: middle;
+}
+
 .hidden {
   display: none !important;
 }
@@ -372,7 +376,7 @@ html[dir='rtl'] #toolbarContainer, .findbar, .secondaryToolbar {
   top: 32px;
   position: absolute;
   z-index: 10000;
-  height: 32px;
+  height: auto;
 
   min-width: 16px;
   padding: 0px 6px 0px 6px;
@@ -477,9 +481,20 @@ html[dir='ltr'] .doorHangerRight:before {
   margin-right: -9px;
 }
 
+#findControls {
+  margin-top: 1px;
+}
+
 #findMsg {
   font-style: italic;
   color: #A6B7D0;
+  margin-top: 2px;
+  vertical-align: middle;
+  display: inline-block;
+}
+
+#findMsg:empty {
+  display: none;
 }
 
 #findInput.notFound {
@@ -1815,29 +1830,42 @@ html[dir='rtl'] #documentPropertiesOverlay .row > * {
   }
 }
 
-@media all and (max-width: 600px) {
-  .hiddenSmallView {
+@media all and (max-width: 570px) {
+  .hiddenSmallView,
+  .hiddenSmallView * {
     display: none;
   }
+
   .visibleSmallView {
     display: inherit;
   }
+
   html[dir='ltr'] #outerContainer.sidebarMoving .outerCenter,
   html[dir='ltr'] #outerContainer.sidebarOpen .outerCenter,
   html[dir='ltr'] .outerCenter {
-    left: 156px;
+    left: 120px;
   }
+
   html[dir='rtl'] #outerContainer.sidebarMoving .outerCenter,
   html[dir='rtl'] #outerContainer.sidebarOpen .outerCenter,
   html[dir='rtl'] .outerCenter {
-    right: 156px;
+    right: 120px;
   }
+
   .toolbarButtonSpacer {
     width: 0;
   }
+
+  html[dir='ltr'] .findbar {
+    left: 38px;
+  }
+
+  html[dir='rtl'] .findbar {
+    right: 38px;
+  }
 }
 
-@media all and (max-width: 510px) {
+@media all and (max-width: 440px) {
   #scaleSelectContainer, #pageNumberLabel {
     display: none;
   }

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -130,7 +130,7 @@ See https://github.com/adobe-type-tools/cmap-resources
       </div>  <!-- sidebarContainer -->
 
       <div id="mainContainer">
-        <div class="findbar hidden doorHanger hiddenSmallView" id="findbar">
+        <div class="findbar hidden doorHanger" id="findbar">
           <label for="findInput" class="toolbarLabel" data-l10n-id="find_label">Find:</label>
           <input id="findInput" class="toolbarField" tabindex="91">
           <div class="splitToolbarButton">
@@ -142,11 +142,17 @@ See https://github.com/adobe-type-tools/cmap-resources
               <span data-l10n-id="find_next_label">Next</span>
             </button>
           </div>
-          <input type="checkbox" id="findHighlightAll" class="toolbarField" tabindex="94">
-          <label for="findHighlightAll" class="toolbarLabel" data-l10n-id="find_highlight">Highlight all</label>
-          <input type="checkbox" id="findMatchCase" class="toolbarField" tabindex="95">
-          <label for="findMatchCase" class="toolbarLabel" data-l10n-id="find_match_case_label">Match case</label>
-          <span id="findMsg" class="toolbarLabel"></span>
+          <div id="findControls">
+            <label class="toolbarLabel">
+              <input type="checkbox" id="findHighlightAll" class="toolbarField" tabindex="94">
+              <span data-l10n-id="find_highlight">Highlight all</span>
+            </label>
+            <label class="toolbarLabel">
+              <input type="checkbox" id="findMatchCase" class="toolbarField" tabindex="95">
+              <span data-l10n-id="find_match_case_label">Match case</span>
+            </label>
+            <div id="findMsg" class="toolbarLabel"></div>
+          </div>
         </div>  <!-- findbar -->
 
         <div id="secondaryToolbar" class="secondaryToolbar hidden doorHangerRight">
@@ -211,10 +217,10 @@ See https://github.com/adobe-type-tools/cmap-resources
                   <span data-l10n-id="toggle_sidebar_label">Toggle Sidebar</span>
                 </button>
                 <div class="toolbarButtonSpacer"></div>
-                <button id="viewFind" class="toolbarButton group hiddenSmallView" title="Find in Document" tabindex="12" data-l10n-id="findbar">
+                <button id="viewFind" class="toolbarButton group" title="Find in Document" tabindex="12" data-l10n-id="findbar">
                    <span data-l10n-id="findbar_label">Find</span>
                 </button>
-                <div class="splitToolbarButton">
+                <div class="splitToolbarButton hiddenSmallView">
                   <button class="toolbarButton pageUp" title="Previous Page" id="previous" tabindex="13" data-l10n-id="previous">
                     <span data-l10n-id="previous_label">Previous</span>
                   </button>


### PR DESCRIPTION
This is a work in progress fix to allow for find functionality when PDF.js is used on small devices, addressing #6191. No attempt was made to address the issues regarding foreign languages in #3683; this will likely be something that is done after find functionality is included on small devices.

At about 600px, find functionality is visible with some of the toolbar icons on the right side being moved to the overflow bar:

![image](https://cloud.githubusercontent.com/assets/6200170/8910763/341b2478-344e-11e5-8bfa-54a594f584c0.png)

When the window shrinks to 570px, all elements with the `hiddenSmallView` CSS class are invisible. This no longer includes the Find functionality, but does include the next and previous buttons, per the discussion on the UX team where they pointed out that finger scrolling was far more likely to be used than a tiny button. Also, the find toolbar becomes extra tall. This will need more work, as there is a lot of empty space:

![image](https://cloud.githubusercontent.com/assets/6200170/8910684/c302ad92-344d-11e5-9191-2beb6d62661b.png)

As the window gets smaller, the find toolbar checkboxes move to fill in the new space. Again, there is a lot of wasted space and improvements could be made:

![image](https://cloud.githubusercontent.com/assets/6200170/8910713/e825370c-344d-11e5-8640-010e64b48192.png)

When the window reaches 440px, the page label and the zoom dropdown menus are removed entirely:

![image](https://cloud.githubusercontent.com/assets/6200170/8910736/08eb0412-344e-11e5-8ed6-fcf40feadca7.png)

I would appreciate feedback on these changes, and any suggestions to solve the issue with extra space on the find toolbar when it gets to double height.
