### PR TITLE
Keep the Link annotation's data URL on one line

### DIFF
--- a/web/annotations_layer_builder.css
+++ b/web/annotations_layer_builder.css
@@ -60,6 +60,5 @@
 }
 
 .annotationLayer .annotLink > a /* -ms-a */  {
-  background: url("data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAA\
-                   LAAAAAABAAEAAAIBRAA7") 0 0 repeat;
+  background: url("data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7") 0 0 repeat;
 }


### PR DESCRIPTION
Fixes #6278.

@raijinsetsu @Rob--W @Snuffleupagus  Could one of you confirm that this fixes the issue? If so, it should be good to merge.
