### PR TITLE
Add a `PDFLinkService` instance to the "simpleviewer" component example

### DIFF
--- a/examples/components/simpleviewer.html
+++ b/examples/components/simpleviewer.html
@@ -27,6 +27,12 @@ limitations under the License.
       margin: 0;
       padding: 0;
     }
+    #viewerContainer {
+      overflow: auto;
+      position: absolute;
+      width: 100%;
+      height: 100%;
+    }
   </style>
 
   <link rel="stylesheet" href="../../build/components/pdf_viewer.css">

--- a/examples/components/simpleviewer.js
+++ b/examples/components/simpleviewer.js
@@ -34,17 +34,26 @@ if (!PDFJS.PDFViewer || !PDFJS.getDocument) {
 var DEFAULT_URL = '../../web/compressed.tracemonkey-pldi-09.pdf';
 
 var container = document.getElementById('viewerContainer');
+
+// (Optionally) enable hyperlinks within PDF files.
+var pdfLinkService = new PDFJS.PDFLinkService();
+
 var pdfViewer = new PDFJS.PDFViewer({
-  container: container
+  container: container,
+  linkService: pdfLinkService,
 });
+pdfLinkService.setViewer(pdfViewer);
 
 container.addEventListener('pagesinit', function () {
-  // we can use pdfViewer now, e.g. let's change default scale.
+  // We can use pdfViewer now, e.g. let's change default scale.
   pdfViewer.currentScaleValue = 'page-width';
 });
 
 // Loading document.
 PDFJS.getDocument(DEFAULT_URL).then(function (pdfDocument) {
-  // Document loaded, specifying document for the viewer.
+  // Document loaded, specifying document for the viewer and
+  // the (optional) linkService.
   pdfViewer.setDocument(pdfDocument);
+
+  pdfLinkService.setDocument(pdfDocument, null);
 });


### PR DESCRIPTION
To test this: apply the patches locally, and do `node make generic components`.
