### PR TITLE
Apply hover style to .overlayButton not only when hovered, but also when focused.

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -591,6 +591,7 @@ html[dir='rtl'] .splitToolbarButton > .toolbarButton {
 .splitToolbarButton > .toolbarButton:focus,
 .dropdownToolbarButton:hover,
 .overlayButton:hover,
+.overlayButton:focus,
 .toolbarButton.textButton:hover,
 .toolbarButton.textButton:focus {
   background-color: hsla(0,0%,0%,.2);


### PR DESCRIPTION
This commit fixes #6261 by taking the focus style of this button to be the same as the hover style.
