### PR TITLE
Cleans test manifest from absent files.

### DIFF
--- a/test/pdfs/ecma262.pdf.link
+++ b/test/pdfs/ecma262.pdf.link
@@ -1,1 +1,1 @@
-http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf
+http://web.archive.org/web/20110902042030/http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf

--- a/test/pdfs/issue4926.pdf.link
+++ b/test/pdfs/issue4926.pdf.link
@@ -1,1 +1,1 @@
-http://www.conservation.ca.gov/cgs/information/publications/cgs_notes/note_17/documents/note_17.pdf
+http://web.archive.org/web/20140802003728/http://www.conservation.ca.gov/cgs/information/publications/cgs_notes/note_17/Documents/note_17.pdf

--- a/test/pdfs/ocs.pdf.link
+++ b/test/pdfs/ocs.pdf.link
@@ -1,1 +1,1 @@
-http://krechetov.net/~ikr/Cyrillic_Alphabets-Chars.pdf
+http://web.archive.org/web/20100215194419/http://www.unibuc.ro/uploads_en/29535/10/Cyrillic_Alphabets-Chars.pdf

--- a/test/pdfs/vesta.pdf.link
+++ b/test/pdfs/vesta.pdf.link
@@ -1,1 +1,1 @@
-http://www-csag.ucsd.edu/~jburke/Vesta/Vesta_Overview.pdf
+http://web.archive.org/web/20140514052657/http://www-csag.ucsd.edu/~jburke/Vesta/Vesta_Overview.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1941,7 +1941,7 @@
        "link": false,
        "type": "load",
        "password": "\u00E6\u00F8\u00E5",
-       "about": "The password (æøå) is UTF8 encoded."
+       "about": "The password (Ã¦Ã¸Ã¥) is UTF8 encoded."
     },
     {  "id": "High-Pressure-Measurement-WP-001287",
        "file": "pdfs/High-Pressure-Measurement-WP-001287.pdf",


### PR DESCRIPTION
<del>Adds "disabled" property for the test with missing linked files. To enable these tests (e.g. at botio) `--allowDisabled` parameters shall be used with test.js.</del>
