### PR TITLE
Fix zooming with Ctrl+MouseScroll

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -291,23 +291,19 @@ var PDFViewerApplication = {
     });
   },
 
-  zoomIn: function pdfViewZoomIn(ticks) {
+  zoomIn: function pdfViewZoomIn() {
     var newScale = this.pdfViewer.currentScale;
-    do {
-      newScale = (newScale * DEFAULT_SCALE_DELTA).toFixed(2);
-      newScale = Math.ceil(newScale * 10) / 10;
-      newScale = Math.min(MAX_SCALE, newScale);
-    } while (--ticks > 0 && newScale < MAX_SCALE);
+    newScale = (newScale * DEFAULT_SCALE_DELTA).toFixed(2);
+    newScale = Math.ceil(newScale * 10) / 10;
+    newScale = Math.min(MAX_SCALE, newScale);
     this.pdfViewer.currentScaleValue = newScale;
   },
 
-  zoomOut: function pdfViewZoomOut(ticks) {
+  zoomOut: function pdfViewZoomOut() {
     var newScale = this.pdfViewer.currentScale;
-    do {
-      newScale = (newScale / DEFAULT_SCALE_DELTA).toFixed(2);
-      newScale = Math.floor(newScale * 10) / 10;
-      newScale = Math.max(MIN_SCALE, newScale);
-    } while (--ticks > 0 && newScale > MIN_SCALE);
+    newScale = (newScale / DEFAULT_SCALE_DELTA).toFixed(2);
+    newScale = Math.floor(newScale * 10) / 10;
+    newScale = Math.max(MIN_SCALE, newScale);
     this.pdfViewer.currentScaleValue = newScale;
   },
 
@@ -1799,8 +1795,8 @@ function handleMouseWheel(evt) {
     evt.preventDefault();
 
     var previousScale = pdfViewer.currentScale;
-
-    PDFViewerApplication[direction](Math.abs(ticks));
+    // Just zoom in the right direction
+    PDFViewerApplication[direction]();
 
     var currentScale = pdfViewer.currentScale;
     if (previousScale !== currentScale) {


### PR DESCRIPTION
Issue #6263 [Firefox PDF-viewer] - Remove unnecesary code from zoomIn and zoomOut functions, and call them w/o arguments

NOW:
- If you choose to scroll by N lines, and press Ctrl+MouseWheelUp (in Firefox), then you get scale increased N times (as if you pressed Ctrl+"+" N times)
- If you choose to scroll by 1 page, and press Ctrl+MouseWheelUp (in Firefox), then you get scale increased 32768 times (as if you pressed Ctrl+"+" 32768 times)
- If you choose to scroll by N lines or by 1 page, and press Ctrl+MouseWheelUp (in Googlechrome), then you get scale increased 3 times (as if you pressed Ctrl+"+" 3 times)

AFTER these changes:
- If you press Ctrl+MouseWheelUp (in any browser), then you get scale increased 1 time (as if you pressed Ctrl+"+" 1 time) just like in any other PDF viewer. And this is also expected behavior.
