### PR TITLE
Serialize errors before invoking postMessage

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1504,6 +1504,10 @@ function MessageHandler(name, comObj) {
             data: result
           });
         }, function (reason) {
+          if (reason instanceof Error) {
+            // Serialize error to avoid "DataCloneError"
+            reason = reason + '';
+          }
           comObj.postMessage({
             isReply: true,
             callbackId: data.callbackId,


### PR DESCRIPTION
Sometimes (when an error occurs), PDF.js gets stuck. The viewer is then indefinitely waiting for a promise to resolve, which never happens because of the DataCloneError. This PR addresses the issue by converting the error to a string before throwing.

Firefox: "DataCloneError: The object could not be cloned."
Chrome: "DataCloneError: Failed to execute 'postMessage' on 'WorkerGlobalScope': An object could not be cloned."

Here's an isolated test case, if you want to see what happens when an Error object is passed to `postMessage`:

``` js
try {
    window.postMessage(new Error(), '*')
} catch (e) {
    alert(e);
}
```
