### PR TITLE
Fixes supportsMozChunked for node.js

### DIFF
--- a/src/core/network.js
+++ b/src/core/network.js
@@ -73,18 +73,15 @@ var NetworkManager = (function NetworkManagerClosure() {
 
 //#if !(CHROME || FIREFOX || MOZCENTRAL)
   var supportsMozChunked = (function supportsMozChunkedClosure() {
-    var x = new XMLHttpRequest();
     try {
+      var x = new XMLHttpRequest();
       // Firefox 37- required .open() to be called before setting responseType.
       // https://bugzilla.mozilla.org/show_bug.cgi?id=707484
-      x.open('GET', 'https://example.com');
-    } catch (e) {
       // Even though the URL is not visited, .open() could fail if the URL is
       // blocked, e.g. via the connect-src CSP directive or the NoScript addon.
       // When this error occurs, this feature detection method will mistakenly
       // report that moz-chunked-arraybuffer is not supported in Firefox 37-.
-    }
-    try {
+      x.open('GET', 'https://example.com');
       x.responseType = 'moz-chunked-arraybuffer';
       return x.responseType === 'moz-chunked-arraybuffer';
     } catch (e) {


### PR DESCRIPTION
Fixes `cd examples/node; node make getinfo.js` failure (Regression from #5531)
