### PR TITLE
Fix typo in `drawFigures`, in webgl.js, which causes shadingPatterns with `figure.type === triangles` to render incorrectly

### DIFF
--- a/src/display/webgl.js
+++ b/src/display/webgl.js
@@ -360,7 +360,7 @@ var WebGLUtils = (function WebGLUtilsClosure() {
           for (var j = 0, jj = ps.length; j < jj; j++) {
             coords[pIndex] = coordsMap[ps[j]];
             coords[pIndex + 1] = coordsMap[ps[j] + 1];
-            colors[cIndex] = colorsMap[cs[i]];
+            colors[cIndex] = colorsMap[cs[j]];
             colors[cIndex + 1] = colorsMap[cs[j] + 1];
             colors[cIndex + 2] = colorsMap[cs[j] + 2];
             pIndex += 2;


### PR DESCRIPTION
The file `issue2948.pdf` from the test-suite can be used to (manually) test the patch.

_Note:_ Since we don't test with `webgl` enabled on the bots, I don't think there's any point in running tests.
