### PR TITLE
Don't catch `MissingDataException` in `Parser_tryShift`

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -58,6 +58,9 @@ var Parser = (function ParserClosure() {
         this.shift();
         return true;
       } catch (e) {
+        if (e instanceof MissingDataException) {
+          throw e;
+        }
         // Upon failure, the caller should reset this.lexer.pos to a known good
         // state and call this.shift() twice to reset the buffers.
         return false;


### PR DESCRIPTION
I overlooked this while reviewing PR #6197, but I don't think that we should be catching that particular kind of exception here; hence this patch.
