### PR TITLE
Add `disableStream` to the list of preferences read by `PDFViewerApplication.initialize` (issue 6361)

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -271,6 +271,12 @@ var PDFViewerApplication = {
         }
         PDFJS.disableRange = value;
       }),
+      Preferences.get('disableStream').then(function resolved(value) {
+        if (PDFJS.disableStream === true) {
+          return;
+        }
+        PDFJS.disableStream = value;
+      }),
       Preferences.get('disableAutoFetch').then(function resolved(value) {
         PDFJS.disableAutoFetch = value;
       }),


### PR DESCRIPTION
Fixes #6361.
