### PR TITLE
Only take the fast-path in `PDFImage_createImageData` for un-masked JPEG images with "standard" colour spaces (issue 6364)

### DIFF
--- a/src/core/image.js
+++ b/src/core/image.js
@@ -562,7 +562,10 @@ var PDFImage = (function PDFImageClosure() {
           }
           return imgData;
         }
-        if (this.image instanceof JpegStream && !this.smask && !this.mask) {
+        if (this.image instanceof JpegStream && !this.smask && !this.mask &&
+            (this.colorSpace.name === 'DeviceGray' ||
+             this.colorSpace.name === 'DeviceRGB' ||
+             this.colorSpace.name === 'DeviceCMYK')) {
           imgData.kind = ImageKind.RGB_24BPP;
           imgData.data = this.getImageBytes(originalHeight * rowBytes,
                                             drawWidth, drawHeight, true);

--- a/test/pdfs/issue4890.pdf.link
+++ b/test/pdfs/issue4890.pdf.link
@@ -1,0 +1,1 @@
+http://web.archive.org/web/20150502102155/http://sunnuclear.com/documents/DQA3.pdf

--- a/test/pdfs/issue6364.pdf.link
+++ b/test/pdfs/issue6364.pdf.link
@@ -1,0 +1,1 @@
+http://web.archive.org/web/20150818180340/http://www.rightprospectus.com/documents/Osterweis/SEMI_Osterweis.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1496,6 +1496,15 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue4890",
+       "file": "pdfs/issue4890.pdf",
+       "md5": "1666feb4cd26318c2bdbea6a175dce87",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 1,
+       "lastPage": 1,
+       "type": "eq"
+    },
     { "id": "bug898853.pdf",
       "file": "pdfs/bug898853.pdf",
       "md5": "37c37702bf98d33f9f74e2380c4d1a3f",

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1487,6 +1487,15 @@
       "link": true,
       "type": "eq"
     },
+    {  "id": "issue6364",
+       "file": "pdfs/issue6364.pdf",
+       "md5": "b290328531ecdddf6b4c794b4b2fec28",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 1,
+       "lastPage": 1,
+       "type": "eq"
+    },
     { "id": "bug898853.pdf",
       "file": "pdfs/bug898853.pdf",
       "md5": "37c37702bf98d33f9f74e2380c4d1a3f",


### PR DESCRIPTION
Fixes #6364.

_Edit:_ This extends the approach of PR #4892 (which fixed another regression).
