### PR TITLE
btoa function does not work with Date.now() (Locale problem)

### DIFF
--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -270,7 +270,8 @@ var FontLoader = {
       }
       data = spliceString(data, CFF_CHECKSUM_OFFSET, 4, string32(checksum));
 
-      var url = 'url(data:font/opentype;base64,' + btoa(data) + ');';
+      var url = 'url(data:font/opentype;base64,' +
+                btoa(unescape(encodeURIComponent(data))) + ');';
       var rule = '@font-face { font-family:"' + loadTestFontId + '";src:' +
                  url + '}';
       FontLoader.insertRule(rule);


### PR DESCRIPTION
In my system function Date.now() returns 
"Wed Aug 19 2015 10:58:26 GMT+0600 (RTZ 5 (зима))"
This string becomes part of variable data and I get error when btoa function is called, 
"Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range."
This small fix allow to btoa work with unicode strings.
