### PR TITLE
Add locatization notes for the DocumentProperties strings with parameters

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -67,7 +67,11 @@ document_properties.title=Document Properties…
 document_properties_label=Document Properties…
 document_properties_file_name=File name:
 document_properties_file_size=File size:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
 document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
 document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
 document_properties_title=Title:
 document_properties_author=Author:
@@ -75,6 +79,8 @@ document_properties_subject=Subject:
 document_properties_keywords=Keywords:
 document_properties_creation_date=Creation Date:
 document_properties_modification_date=Modification Date:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
 document_properties_date_string={{date}}, {{time}}
 document_properties_creator=Creator:
 document_properties_producer=PDF Producer:


### PR DESCRIPTION
This should hopefully help prevent localizers from translating the actual parameters.
