### PR TITLE
Update viewer.html for Internet Explorer Compatibility

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -27,8 +27,9 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!--#if GENERIC || CHROME-->
     <meta name="google" content="notranslate">
 <!--#endif-->
-    <!-- Ignore legacy IE compatibility settings and prefer HTML5 -->
+<!--#if GENERIC || CHROME-->    
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+<!--#endif-->
     <title>PDF.js viewer</title>
 
 <!--#if FIREFOX || MOZCENTRAL-->

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -27,7 +27,7 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!--#if GENERIC || CHROME-->
     <meta name="google" content="notranslate">
 <!--#endif-->
-<!--#if GENERIC || CHROME-->    
+<!--#if GENERIC-->
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <!--#endif-->
     <title>PDF.js viewer</title>

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -27,6 +27,8 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!--#if GENERIC || CHROME-->
     <meta name="google" content="notranslate">
 <!--#endif-->
+    <!-- Ignore legacy I.E. Compatability settings.  Prefer HTML5 -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>PDF.js viewer</title>
 
 <!--#if FIREFOX || MOZCENTRAL-->

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -27,7 +27,7 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!--#if GENERIC || CHROME-->
     <meta name="google" content="notranslate">
 <!--#endif-->
-    <!-- Ignore legacy I.E. Compatability settings.  Prefer HTML5 -->
+    <!-- Ignore legacy IE compatibility settings and prefer HTML5 -->
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>PDF.js viewer</title>
 


### PR DESCRIPTION
If your Internet Explorer 11 default compatibility settings are set to "I.E 7 Compatibility", the PDF plugin will not load.  This fix is the same one used by AngularJS to force the browser to use HTML5 mode.
