### PR TITLE
Make `XRef_indexObjects` more robust against bad PDF files (issue 5752)

### DIFF
--- a/test/pdfs/issue5752.pdf.link
+++ b/test/pdfs/issue5752.pdf.link
@@ -1,0 +1,1 @@
+http://web.archive.org/web/20150821144004/http://222.247.54.152/Fulltext/qkyxlcyjy200504007.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1071,6 +1071,15 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue5752",
+       "file": "pdfs/issue5752.pdf",
+       "md5": "aa20ad7cff71e9481c0cd623ddbff3b7",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 1,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue2931",
        "file": "pdfs/issue2931.pdf",
        "md5": "ea40940eaf3541b312bda9329167da11",


### PR DESCRIPTION
This patch improves the detection of `xref` in files where it is followed by an arbitrary whitespace character (not just a line-breaking char).
It also adds a check for missing whitespace, e.g. `1 0 obj<<`, to speed up `readToken` for the PDF file in the referenced issue.
Finally, the patch also replaces a bunch of magic numbers with suitably named constants.

Fixes #5752.

Also improves #6243, but there are still issues.
