### PR TITLE
Prevent showing the fallback bar when XRef parsing fails at the first attempt, i.e. when `recoveryMode = false`

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -16,10 +16,11 @@
  */
 /* globals assert, bytesToString, CipherTransformFactory, error, info,
            InvalidPDFException, isArray, isCmd, isDict, isInt, isName, isRef,
-           isStream, Lexer, Page, Parser, Promise, shadow,
+           isStream, Lexer, Page, Parser, Promise, shadow, UnsupportedManager,
            stringToPDFString, stringToUTF8String, warn, isString,
            Promise, MissingDataException, XRefParseException, Stream,
-           ChunkedStream, createPromiseCapability */
+           ChunkedStream, createPromiseCapability, UNSUPPORTED_FEATURES,
+           suppressErrorNotificationForFunctionNames */
 
 'use strict';
 
@@ -776,7 +777,7 @@ var XRef = (function XRefClosure() {
       if (!recoveryMode) {
         trailerDict = this.readXRef();
       } else {
-        warn('Indexing all PDF objects');
+        warn('Invalid XRef table: Indexing all PDF objects');
         trailerDict = this.indexObjects();
       }
       trailerDict.assignXref(this);
@@ -1136,10 +1137,13 @@ var XRef = (function XRefClosure() {
       }
       // nothing helps
       // calling error() would reject worker with an UnknownErrorException.
+      UnsupportedManager.notify(UNSUPPORTED_FEATURES.unknown);
       throw new InvalidPDFException('Invalid PDF structure');
     },
 
     readXRef: function XRef_readXRef(recoveryMode) {
+      suppressErrorNotificationForFunctionNames['XRef_readXRef'] = true;
+
       var stream = this.stream;
 
       try {
@@ -1207,7 +1211,7 @@ var XRef = (function XRefClosure() {
         if (e instanceof MissingDataException) {
           throw e;
         }
-        info('(while reading XRef): ' + e);
+        warn('(while reading XRef): ' + e);
       }
 
       if (recoveryMode) {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -213,12 +213,26 @@ function warn(msg) {
   }
 }
 
+// Used in order to prevent displaying the fallback UI, and logging debug
+// information, when calling `error`. This can be useful for code executed
+// e.g. within a try-catch block, where custom exception handling is wanted.
+var suppressErrorNotificationForFunctionNames = Object.create(null);
+
 // Fatal errors that should trigger the fallback UI and halt execution by
 // throwing an exception.
 function error(msg) {
+  var backTrace;
+  if (suppressErrorNotificationForFunctionNames) {
+    backTrace = backtrace();
+    for (var name in suppressErrorNotificationForFunctionNames) {
+      if ((new RegExp('\\b' + name + '\\b')).test(backTrace)) {
+        throw new Error(msg);
+      }
+    }
+  }
   if (PDFJS.verbosity >= PDFJS.VERBOSITY_LEVELS.errors) {
     console.log('Error: ' + msg);
-    console.log(backtrace());
+    console.log(backTrace || backtrace());
   }
   UnsupportedManager.notify(UNSUPPORTED_FEATURES.unknown);
   throw new Error(msg);


### PR DESCRIPTION
_Please refer to the individual commit messages._

This is a tentative attempt at removing the error notifications when we're able to successfully recover from failures when parsing the XRef table.

Fixes #4419.
Fixes #6376.
