### PR TITLE
Add a warning when we encounter an empty stream in `Parser_makeFilter`

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -525,6 +525,7 @@ var Parser = (function ParserClosure() {
     },
     makeFilter: function Parser_makeFilter(stream, name, maybeLength, params) {
       if (stream.dict.get('Length') === 0 && !maybeLength) {
+        warn('Empty "' + name + '" stream.');
         return new NullStream(stream);
       }
       try {


### PR DESCRIPTION
Having a warning here would have meant that issue #6360 could have been solved in approximately five minutes, instead of an hour. To avoid that happening again, this patch adds a warning whenever we treat a stream as empty.
