### PR TITLE
Fix typo in `test_manifest.json` that prevents test-case `issue1419.pdf` from running

### DIFF
--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1501,7 +1501,7 @@
        "md5": "b5b6c6405d7b48418bccf97277957664",
        "rounds": 1,
        "link": true,
-       "lastPage": 1,
+       "lastPage": 2,
        "skipPages": [1],
        "type": "eq"
     },


### PR DESCRIPTION
Currently we only attempt to test the _first_ page, since `lastPage == 1`, but given that it's subsequently skipped we end up not testing anything.

_Note:_ I've verified that the _second_ page actually contains the kind of Colour space that the test was intended to check for.

**Edit:** Looking at PR #1903, which added the test, I'm wondering if it ever worked as intended.
