### PR TITLE
Slightly improved test coverage for vertical text

### DIFF
--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -298,6 +298,14 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "taro",
+       "file": "pdfs/TaroUTR50SortedList112.pdf",
+       "md5": "ce63eab622ff473a43f8a8de85ef8a46",
+       "link": true,
+       "rounds": 1,
+       "lastPage": 4,
+       "type": "eq"
+    },
     {  "id": "taro-text",
        "file": "pdfs/TaroUTR50SortedList112.pdf",
        "md5": "ce63eab622ff473a43f8a8de85ef8a46",


### PR DESCRIPTION
Our current test coverage for vertical text is somewhat lacking, as evident from e.g. issue #6387. That regression could easily have been avoided if the `taro` test-case would have been an `eq` test, as well as an `text` test.
