### PR TITLE
Set TZ=UTC before calls to zip

### DIFF
--- a/make.js
+++ b/make.js
@@ -861,6 +861,9 @@ target.firefox = function() {
   sed('-i', /.*PDFJS_SUPPORTED_LOCALES.*\n/, chromeManifest,
       FIREFOX_BUILD_DIR + '/chrome.manifest');
 
+  // Set timezone to UTC before calling zip to get reproducible results.
+  process.env.TZ = 'UTC';
+
   // Create the xpi
   cd(FIREFOX_BUILD_DIR);
   exec('zip -r ' + FIREFOX_EXTENSION_NAME + ' ' +


### PR DESCRIPTION
This change allows to make the package build reproducible.

> While working on the "reproducible builds" effort [1], we have noticed
> that pdf.js could not be built reproducibly.
> 
> The attached patch removes timezone-varying timestamps from the
> files compressed with zip. Once applied, pdf.js can be built
> reproducibly in our current experimental framework.
> 
> [1]: https://wiki.debian.org/ReproducibleBuilds

Bug-Debian: https://bugs.debian.org/793127
