### PR TITLE
Add a (linked) `load` test for PR 4731

### DIFF
--- a/test/pdfs/pr4731.pdf.link
+++ b/test/pdfs/pr4731.pdf.link
@@ -1,0 +1,1 @@
+http://web.archive.org/web/20150830132600/http://rudar.ruc.dk/bitstream/1800/12945/1/samlet-29Nov1035.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1035,6 +1035,14 @@
        "link": false,
        "type": "eq"
     },
+    {  "id": "pr4731",
+       "file": "pdfs/pr4731.pdf",
+       "md5": "0121642027e525c4b95357f1b5669e64",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "load"
+    },
     {  "id": "S2-eq",
        "file": "pdfs/S2.pdf",
        "md5": "d0b6137846df6e0fe058f234a87fb588",


### PR DESCRIPTION
Re: PR #4731.
Since the URL points to the Internet Archive, I think that adding a linked test-case should be OK. (Also, it's difficult to create reduced, or even `unit`, tests that accurately captures the brokenness of real-world PDF files.)

_Please note:_ Since this is a `load` test, `makeref`ing won't be needed.
