### PR TITLE
Add (linked) `load` tests for PR 1976 and 4606

### DIFF
--- a/test/pdfs/issue1940.pdf.link
+++ b/test/pdfs/issue1940.pdf.link
@@ -1,0 +1,1 @@
+http://web.archive.org/web/20120105135646/http://www.parallax.com/dl/docs/prod/acc/memsickit.pdf

--- a/test/pdfs/pr4606.pdf.link
+++ b/test/pdfs/pr4606.pdf.link
@@ -1,0 +1,1 @@
+http://web.archive.org/web/20140411084003/http://www.prensalibre.com/multimedia/Terremoto-1976-Sismo-terremoto_del_76-guatemala-Teremoto-temblorgt_PREFIL20140203_0001.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1043,6 +1043,22 @@
        "lastPage": 1,
        "type": "load"
     },
+    {  "id": "issue1940",
+       "file": "pdfs/issue1940.pdf",
+       "md5": "4f0a0b92c1b5e6e86e1a82490087e6e5",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "load"
+    },
+    {  "id": "pr4606",
+       "file": "pdfs/pr4606.pdf",
+       "md5": "6574fde2314648600056bd0e229df98c",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "load"
+    },
     {  "id": "S2-eq",
        "file": "pdfs/S2.pdf",
        "md5": "d0b6137846df6e0fe058f234a87fb588",


### PR DESCRIPTION
Adds a couple of `load` tests for the `XRef` parsing part of the code-base, see PR #1976 and #4606.
