### PR TITLE
Adjust the `min-width` of outline items and use more consistent `border-radius` (PR 6242 follow-up)

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1206,6 +1206,8 @@ html[dir='rtl'] .outlineItem > .outlineItems {
   text-decoration: none;
   display: inline-block;
   min-width: 95%;
+  min-width: calc(100% - 4px); /* Subtract the right padding (left, in RTL mode)
+                                  of the container. */
   height: auto;
   margin-bottom: 1px;
   border-radius: 2px;
@@ -1280,6 +1282,7 @@ html[dir='rtl'] .outlineItemToggler::before {
   box-shadow: 0 1px 0 hsla(0,0%,100%,.05) inset,
               0 0 1px hsla(0,0%,100%,.2) inset,
               0 0 1px hsla(0,0%,0%,.2);
+  border-radius: 2px;
   color: hsla(0,0%,100%,.9);
 }
 


### PR DESCRIPTION
Prior to PR #6242, the width of all outline items was set such that their right (or left, in RTL locales) edges lined up vertically. In my opinion that looked more consistent, therefore this patch adjusts the CSS to make sure that this will be the case again.

![outlineitem_a_width](https://cloud.githubusercontent.com/assets/2692120/9704012/65492276-5496-11e5-873c-0101d86cf129.png)

---

The patch also makes the `border-radius` values of outline items a bit more consistent.

![outlineitem_a_hover_radius](https://cloud.githubusercontent.com/assets/2692120/9704014/6ebdb13c-5496-11e5-849d-34332795f377.png)

---

/cc @Rob--W 
