### PR TITLE
Add a utility function, for the viewer, that removes `null` (\x00) characters (issue 6416)

### DIFF
--- a/web/pdf_attachment_view.js
+++ b/web/pdf_attachment_view.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals getFileName */
+/* globals getFileName, removeNullCharacters */
 
 'use strict';
 
@@ -91,7 +91,7 @@ var PDFAttachmentView = (function PDFAttachmentViewClosure() {
         div.className = 'attachmentsItem';
         var button = document.createElement('button');
         this._bindLink(button, item.content, filename);
-        button.textContent = filename;
+        button.textContent = removeNullCharacters(filename);
         div.appendChild(button);
         this.container.appendChild(div);
       }

--- a/web/pdf_outline_view.js
+++ b/web/pdf_outline_view.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* globals removeNullCharacters */
 
 'use strict';
 
@@ -138,7 +139,7 @@ var PDFOutlineView = (function PDFOutlineViewClosure() {
           div.className = 'outlineItem';
           var element = document.createElement('a');
           this._bindLink(element, item);
-          element.textContent = item.title;
+          element.textContent = removeNullCharacters(item.title);
           div.appendChild(element);
 
           if (item.items.length > 0) {

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -75,6 +75,12 @@ var CustomStyle = (function CustomStyleClosure() {
   return CustomStyle;
 })();
 
+var NullCharactersRegExp = /\x00/g;
+
+function removeNullCharacters(str) {
+  return str.replace(NullCharactersRegExp, '');
+}
+
 function getFileName(url) {
   var anchor = url.indexOf('#');
   var query = url.indexOf('?');


### PR DESCRIPTION
Since some browsers render `null` characters, and others don't, this patch adds a way to remove them to prevent display issues in the viewer UI.

Given that documents may contain very long outlines, I've added a utility function to avoid creating a lot of unnecessary `RegExp` objects.
To avoid any future issues, this utility function is used for both the outline and the attachments.

Fixes #6416.

/cc @yurydelendik I agree that fixing this in the UI is probably better. Does this patch look reasonable to you?
