### PR TITLE
Add unit-tests for `stringToPDFString`

### DIFF
--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -1,6 +1,7 @@
 /* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
-/* globals expect, it, describe, combineUrl, Dict, isDict, Name */
+/* globals expect, it, describe, combineUrl, Dict, isDict, Name,
+           stringToPDFString */
 
 'use strict';
 
@@ -77,4 +78,25 @@ describe('util', function() {
     });
   });
 
+  describe('stringToPDFString', function() {
+    it('handles ISO Latin 1 strings', function() {
+      var str = '\x8Dstring\x8E';
+      expect(stringToPDFString(str)).toEqual('\u201Cstring\u201D');
+    });
+
+    it('handles UTF-16BE strings', function() {
+      var str = '\xFE\xFF\x00\x73\x00\x74\x00\x72\x00\x69\x00\x6E\x00\x67';
+      expect(stringToPDFString(str)).toEqual('string');
+    });
+
+    it('handles empty strings', function() {
+      // ISO Latin 1
+      var str1 = '';
+      expect(stringToPDFString(str1)).toEqual('');
+
+      // UTF-16BE
+      var str2 = '\xFE\xFF';
+      expect(stringToPDFString(str2)).toEqual('');
+    });
+  });
 });


### PR DESCRIPTION
The other day I was looking as the utilily function `stringToPDFString`, and I noticed that it didn't have any unit-tests. This patch fixes that.
