### PR TITLE
Replace the unavailable linked test-case for issue 4436 with a reduced test-case

### DIFF
--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -77,6 +77,7 @@
 !zerowidthline.pdf
 !bug868745.pdf
 !mmtype1.pdf
+!issue4436r.pdf
 !issue5704.pdf
 !issue5751.pdf
 !bug893730.pdf

--- a/test/pdfs/issue4436.pdf.link
+++ b/test/pdfs/issue4436.pdf.link
@@ -1,2 +1,0 @@
-http://arxiv.org/pdf/1203.6597v3.pdf
-

--- a/test/pdfs/issue4436r.pdf
+++ b/test/pdfs/issue4436r.pdf
@@ -1,0 +1,78 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/Pages 2 0 R
+/Type /Catalog
+>>
+endobj 
+2 0 obj 
+<<
+/Kids [3 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+3 0 obj 
+<<
+/Parent 2 0 R
+/MediaBox [0 0 200 50]
+/Resources 
+<<
+/Font 
+<<
+/F1 4 0 R
+>>
+>>
+/Contents 5 0 R
+/Type /Page
+>>
+endobj 
+4 0 obj 
+<<
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/Type /Font
+>>
+endobj 
+5 0 obj 
+<<
+/Length 185
+>>
+stream
+BT
+10 30 TD
+/F1 16 Tf
+(Issue 4436) Tj
+/F1 10 Tf
+0 -20 TD
+(A thin line should be visible above this text.) Tj
+ET
+180 0 0 -0.48 10 25 cm
+BI
+  /IM true
+  /W 1
+  /H 1
+  /BPC 1
+  ID 0x00
+EI
+
+endstream 
+endobj xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000066 00000 n 
+0000000125 00000 n 
+0000000254 00000 n 
+0000000355 00000 n 
+trailer
+
+<<
+/Root 1 0 R
+/Size 6
+>>
+startxref
+593
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2370,12 +2370,10 @@
       "about": "Image mask in higher resolution than the image itself"
     },
     {  "id": "issue4436",
-       "file": "pdfs/issue4436.pdf",
-       "md5": "34e6af7441961f5940e6440a62e37427",
+       "file": "pdfs/issue4436r.pdf",
+       "md5": "4e43d692d213f56674fcac92110c7364",
        "rounds": 1,
-       "link": true,
-       "firstPage": 9,
-       "lastPage": 9,
+       "link": false,
        "type": "eq"
     },
     {  "id": "issue4926",


### PR DESCRIPTION
Issue #4436 actually contains enough information to create a reduced test-case, which this patch uses to replace a currently unavailable linked test.
