### PR TITLE
ignore keydown event when no file is loaded

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1868,6 +1868,10 @@ window.addEventListener('keydown', function keydown(evt) {
     return;
   }
 
+  if (!PDFViewerApplication.pdfDocument) {
+    return;
+  }
+
   var handled = false;
   var cmd = (evt.ctrlKey ? 1 : 0) |
             (evt.altKey ? 2 : 0) |


### PR DESCRIPTION
There is no need to handle keydown event when there is no PDF loaded. None of the shortcuts remain useful without a document.

Fixes #6438 
