### PR TITLE
Misc. follow-up fixes to PR 6299 (Convert canvas thumbnails to PNG)

### DIFF
--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -160,6 +160,10 @@ var PDFThumbnailView = (function PDFThumbnailViewClosure() {
         this.canvas.height = 0;
         delete this.canvas;
       }
+      if (this.image) {
+        this.image.removeAttribute('src');
+        delete this.image;
+      }
     },
 
     update: function PDFThumbnailView_update(rotation) {

--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -315,6 +315,7 @@ var PDFThumbnailView = (function PDFThumbnailViewClosure() {
       if (img.width <= 2 * canvas.width) {
         ctx.drawImage(img, 0, 0, img.width, img.height,
                       0, 0, canvas.width, canvas.height);
+        this._convertCanvasToImage();
         return;
       }
       // drawImage does an awful job of rescaling the image, doing it gradually.


### PR DESCRIPTION
_Follow-up to PR #6299._
Please refer to the individual commit messages for detailed information.

@timvandermeij Can you please review this? Since we're getting close to [next Firefox release](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates), it would be good to get this fixed now to avoid having to uplift patches manually.

---

Even with these patches, there are still some visual glitches (from #6299) present. Below is an illustration of what things looks like before thumbnails are rendered (note the small empty rectangles). This seems to be an issue related to the fact that you cannot set the `width/height` of an empty `image` (as opposed to a `canvas`).

I know how I'd like to fix this, but since that might require some discussion regarding the implementation, I wanted to submit the current PR to address the most important breakage first.

![thumbs](https://cloud.githubusercontent.com/assets/2692120/9814505/ff156d8c-588e-11e5-82ca-b7f145298f6d.png)
