### PR TITLE
Fix exception when rotate page without a document

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -470,6 +470,10 @@ var PDFViewer = (function pdfViewer() {
      */
     scrollPageIntoView: function PDFViewer_scrollPageIntoView(pageNumber,
                                                               dest) {
+      if (!this.pdfDocument) {
+        return;
+      }
+      
       var pageView = this._pages[pageNumber - 1];
 
       if (this.isInPresentationMode) {


### PR DESCRIPTION
Fixes #6438 

This also fixes the exception when click Rotate Clockwise/Counterclockwise buttons in the menu.

There is still exception thrown after 30s
`Uncaught TypeError: Cannot read property 'cleanup' of null`
and it is tracked by #6440 
