### PR TITLE
Update the link location for the `issue3115` test file

### DIFF
--- a/test/pdfs/issue3115.pdf.link
+++ b/test/pdfs/issue3115.pdf.link
@@ -1,1 +1,0 @@
-http://mirrors.ctan.org/info/lshort/english/lshort.pdf

--- a/test/pdfs/issue3115r.pdf.link
+++ b/test/pdfs/issue3115r.pdf.link
@@ -1,0 +1,1 @@
+http://web.archive.org/web/20130530065353/http://mirror.unl.edu/ctan/info/lshort/english/lshort.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -322,7 +322,7 @@
     },
     {
       "id": "issue3115",
-      "file": "pdfs/issue3115.pdf",
+      "file": "pdfs/issue3115r.pdf",
       "md5": "ea10f4131202b9b8f2a6cb7770d3f185",
       "rounds": 1,
       "type": "eq",


### PR DESCRIPTION
The file (`lshort.pdf`) has changed a couple of times since the test was added, hence there's no guarantee that the current version accurately reflects the issues the test was added to check.
In this patch, I'm updating the link location to point to the _intended_ file version (hosted on the "Internet Archive").
