### PR TITLE
Right-size the `map` array in PartialEvaluator_readToUnicode

### DIFF
--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -306,6 +306,10 @@ var CMap = (function CMapClosure() {
       out.length = 1;
     },
 
+    get length() {
+      return this._map.length;
+    },
+
     get isIdentityCMap() {
       if (!(this.name === 'Identity-H' || this.name === 'Identity-V')) {
         return false;
@@ -381,6 +385,10 @@ var IdentityCMap = (function IdentityCMapClosure() {
     },
 
     readCharCode: CMap.prototype.readCharCode,
+
+    get length() {
+      return 0x10000;
+    },
 
     get isIdentityCMap() {
       error('should not access .isIdentityCMap');

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1380,7 +1380,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         if (cmap instanceof IdentityCMap) {
           return new IdentityToUnicodeMap(0, 0xFFFF);
         }
-        var map = [];
+        var map = new Array(cmap.length);
         // Convert UTF-16BE
         // NOTE: cmap can be a sparse array, so use forEach instead of for(;;)
         // to iterate over all keys.

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -96,6 +96,7 @@ describe('cmap', function() {
     expect(cmap instanceof CMap).toEqual(true);
     expect(cmap.useCMap).not.toBeNull();
     expect(cmap.builtInCMap).toBeFalsy();
+    expect(cmap.length).toEqual(0x20A7);
     expect(cmap.isIdentityCMap).toEqual(false);
   });
   it('parses cmapname', function() {
@@ -116,6 +117,7 @@ describe('cmap', function() {
     expect(cmap instanceof CMap).toEqual(true);
     expect(cmap.useCMap).toBeNull();
     expect(cmap.builtInCMap).toBeTruthy();
+    expect(cmap.length).toEqual(0x20A7);
     expect(cmap.isIdentityCMap).toEqual(false);
   });
   it('loads built in identity cmap', function() {
@@ -123,6 +125,7 @@ describe('cmap', function() {
                                   { url: cMapUrl, packed: cMapPacked }, null);
     expect(cmap instanceof IdentityCMap).toEqual(true);
     expect(cmap.vertical).toEqual(false);
+    expect(cmap.length).toEqual(0x10000);
     expect(function() { return cmap.isIdentityCMap; }).toThrow(
       new Error('should not access .isIdentityCMap'));
   });


### PR DESCRIPTION
We can avoid a lot of intermediate resizings, by directly allocating the required number of elements for the `map` array.
