### PR TITLE
Upstream changes from Bug 1202902 - Give loader scripts and XUL frame scripts a lexical scope that doesn't break everything?

### DIFF
--- a/extensions/firefox/content/PdfJs-stub.jsm
+++ b/extensions/firefox/content/PdfJs-stub.jsm
@@ -22,6 +22,6 @@
 // See https://mxr.mozilla.org/mozilla-central/source/browser/components/nsBrowserGlue.js
 var EXPORTED_SYMBOLS = ['PdfJs'];
 
-let PdfJs = {
+var PdfJs = {
   init: function PdfJs_init() {}
 };

--- a/extensions/firefox/content/PdfJs.jsm
+++ b/extensions/firefox/content/PdfJs.jsm
@@ -43,7 +43,7 @@ const PDF_CONTENT_TYPE = 'application/pdf';
 Cu.import('resource://gre/modules/XPCOMUtils.jsm');
 Cu.import('resource://gre/modules/Services.jsm');
 
-let Svc = {};
+var Svc = {};
 XPCOMUtils.defineLazyServiceGetter(Svc, 'mime',
                                    '@mozilla.org/mime;1',
                                    'nsIMIMEService');
@@ -130,7 +130,7 @@ Factory.prototype = {
   }
 };
 
-let PdfJs = {
+var PdfJs = {
   QueryInterface: XPCOMUtils.generateQI([Ci.nsIObserver]),
   _registered: false,
   _initialized: false,

--- a/extensions/firefox/content/PdfjsChromeUtils.jsm
+++ b/extensions/firefox/content/PdfjsChromeUtils.jsm
@@ -32,7 +32,7 @@ const PDF_CONTENT_TYPE = 'application/pdf';
 Cu.import('resource://gre/modules/XPCOMUtils.jsm');
 Cu.import('resource://gre/modules/Services.jsm');
 
-let Svc = {};
+var Svc = {};
 XPCOMUtils.defineLazyServiceGetter(Svc, 'mime',
                                    '@mozilla.org/mime;1',
                                    'nsIMIMEService');

--- a/extensions/firefox/content/PdfjsContentUtils.jsm
+++ b/extensions/firefox/content/PdfjsContentUtils.jsm
@@ -29,7 +29,7 @@ const Cu = Components.utils;
 Cu.import('resource://gre/modules/XPCOMUtils.jsm');
 Cu.import('resource://gre/modules/Services.jsm');
 
-let PdfjsContentUtils = {
+var PdfjsContentUtils = {
   _mm: null,
 
   /*


### PR DESCRIPTION
One of the patches in https://bugzilla.mozilla.org/show_bug.cgi?id=1202902, specifically [`Mass replace toplevel 'let' with 'var' in preparation for global lexical scope. (rs=jorendorff)`](https://hg.mozilla.org/mozilla-central/rev/380817d573cd), touches PDF.js code. Unfortunately it was landed upstream without, as far as I can tell, notifying us about it.

This patch uplifts the relevant changes to avoid future merge conflicts, and for consistency also tweaks `PdfJs-stub.jsm`.

r? @yurydelendik 
