### PR TITLE
Make `XRef_indexObjects` even more robust against bad PDF files, by checking for the existence of 'trailer' if 'xref' is not found

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -1118,6 +1118,10 @@ var XRef = (function XRefClosure() {
           }
 
           position += contentLength;
+        } else if (token.indexOf('trailer') === 0 &&
+                   (token.length === 7 || /\s/.test(token[7]))) {
+          trailers.push(position);
+          position += skipUntil(buffer, position, startxrefBytes);
         } else {
           position += token.length + 1;
         }

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -1060,6 +1060,7 @@ var XRef = (function XRefClosure() {
         }
         return skipped;
       }
+      var objRegExp = /^(\d+)\s+(\d+)\s+obj\b/;
       var trailerBytes = new Uint8Array([116, 114, 97, 105, 108, 101, 114]);
       var startxrefBytes = new Uint8Array([115, 116, 97, 114, 116, 120, 114,
                                           101, 102]);
@@ -1097,7 +1098,7 @@ var XRef = (function XRefClosure() {
           position += skipUntil(buffer, position, trailerBytes);
           trailers.push(position);
           position += skipUntil(buffer, position, startxrefBytes);
-        } else if ((m = /^(\d+)\s+(\d+)\s+obj\b/.exec(token))) {
+        } else if ((m = objRegExp.exec(token))) {
           if (typeof this.entries[m[1]] === 'undefined') {
             this.entries[m[1]] = {
               offset: position - stream.start,

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -4,6 +4,7 @@
 !tracemonkey.pdf
 !franz.pdf
 !franz_2.pdf
+!xref_command_missing.pdf
 !issue2391-1.pdf
 !issue2391-2.pdf
 !issue5801.pdf

--- a/test/pdfs/xref_command_missing.pdf
+++ b/test/pdfs/xref_command_missing.pdf
@@ -1,0 +1,66 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/Pages 2 0 R
+/Type /Catalog
+>>
+endobj 
+2 0 obj 
+<<
+/Kids [3 0 R]
+/Type /Pages
+/Count 1
+>>
+endobj 
+3 0 obj 
+<<
+/Parent 2 0 R
+/Resources 
+<<
+/Font 
+<<
+/F1 4 0 R
+>>
+>>
+/MediaBox [0 0 200 50]
+/Type /Page
+/Contents 5 0 R
+>>
+endobj 
+4 0 obj 
+<<
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Type /Font
+/Encoding /WinAnsiEncoding
+>>
+endobj 
+5 0 obj 
+<<
+/Length 48
+>>
+stream
+BT
+10 20 TD
+/F1 20 Tf
+(Reduced test-case) Tj
+ET
+
+endstream 
+endobj 
+0000000000 65535 f 
+0000000015 00000 n 
+0000000066 00000 n 
+0000000125 00000 n 
+0000000254 00000 n 
+0000000355 00000 n 
+trailer
+
+<<
+/Root 1 0 R
+/Size 6
+>>
+startxref
+455
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -572,6 +572,13 @@
        "link": false,
        "type": "eq"
     },
+    {  "id": "xref_command_missing",
+       "file": "pdfs/xref_command_missing.pdf",
+       "md5": "06cdb0f13cfeff41d6bfb24b7bbe1268",
+       "rounds": 1,
+       "link": false,
+       "type": "load"
+    },
     {  "id": "issue5501",
        "file": "pdfs/issue5501.pdf",
        "md5": "55a60699728fc92f491a2d7d490474e4",


### PR DESCRIPTION
Fixes http://www.cyjack.com/cognition/Terence%20McKenna%20-%20Lectures%20on%20Alchemy.pdf.
