### PR TITLE
[CRX] Call callback instead of onCompleted

### DIFF
--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -275,7 +275,7 @@ var ChromeCom = (function ChromeComClosure() {
     function onDisconnect() {
       // When the connection fails, ignore the error and call the callback.
       port = null;
-      onCompleted();
+      callback();
     }
     function onCompleted() {
       port.onDisconnect.removeListener(onDisconnect);


### PR DESCRIPTION
Call `callback()` instead of `onCompleted()` to resolve a TypeError (reported via the CWS):

```
Error in event handler for (unknown): TypeError: Cannot read property 'onDisconnect' of null
    at onCompleted (chrome-extension://oemmndcbldboiebfnladdacbdfmadadm/content/web/viewer.js:1178:11)
    at onDisconnect (chrome-extension://oemmndcbldboiebfnladdacbdfmadadm/content/web/viewer.js:1175:7)
    at Function.target.(anonymous function) (extensions::SafeBuiltins:19:14)
    at Event.dispatchToListener (extensions::event_bindings:394:22)
    at Event.dispatch_ (extensions::event_bindings:378:27)
    at Event.dispatch (extensions::event_bindings:400:17)
    at dispatchOnDisconnect (extensions::messaging:293:27)
```
