### PR TITLE
Fixes bluebeam password protection issue

### DIFF
--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -1762,9 +1762,10 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
       if (pdfAlgorithm.checkUserPassword(password, userValidationSalt,
                                          userPassword)) {
         return pdfAlgorithm.getUserKey(password, userKeySalt, userEncryption);
-      } else if (pdfAlgorithm.checkOwnerPassword(password, ownerValidationSalt,
-                                                 uBytes,
-                                                 ownerPassword)) {
+      } else if (password.length && pdfAlgorithm.checkOwnerPassword(password,
+                                                   ownerValidationSalt,
+                                                   uBytes,
+                                                   ownerPassword)) {
         return pdfAlgorithm.getOwnerKey(password, ownerKeySalt, uBytes,
                                         ownerEncryption);
       }


### PR DESCRIPTION
Fixes issue where a pdf will have a user password but no owner password. Previously, pdf.js will still show the pdf even though no password was given. Now, it checks that a password was given and that it matches either the user or owner password.
