### PR TITLE
Prevent getOperatorList from failing to correctly parse OPS.paintXObject for TilingPatterns that are missing some /Resources entries (issue 6541)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -286,9 +286,13 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
                                                    operatorList) {
       // Create an IR of the pattern code.
       var tilingOpList = new OperatorList();
-      return this.getOperatorList(pattern,
-        (patternDict.get('Resources') || resources), tilingOpList).
-        then(function () {
+      // Merge the available resources, to prevent issues when the patternDict
+      // is missing some /Resources entries (fixes issue6541.pdf).
+      var resourcesArray = [patternDict.get('Resources'), resources];
+      var patternResources = Dict.merge(this.xref, resourcesArray);
+
+      return this.getOperatorList(pattern, patternResources, tilingOpList).then(
+        function () {
           // Add the dependencies to the parent operator list so they are
           // resolved before sub operator list is executed synchronously.
           operatorList.addDependencies(tilingOpList.dependencies);

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -14,10 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals error, PDFJS, assert, info, shadow, TextRenderingMode,
-           FONT_IDENTITY_MATRIX, Uint32ArrayView, IDENTITY_MATRIX, ImageData,
-           ImageKind, isArray, isNum, TilingPattern, OPS, Util, warn,
-           getShadingPatternFromIR, WebGLUtils */
+/* globals IDENTITY_MATRIX, FONT_IDENTITY_MATRIX, TextRenderingMode, ImageData,
+           ImageKind, PDFJS, Uint32ArrayView, error, WebGLUtils, OPS, warn,
+           shadow, isNum, Util, TilingPattern, getShadingPatternFromIR, isArray,
+           info, assert, UnsupportedManager, UNSUPPORTED_FEATURES */
 
 'use strict';
 
@@ -2071,6 +2071,11 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     paintSolidColorImageMask:
       function CanvasGraphics_paintSolidColorImageMask() {
         this.ctx.fillRect(0, 0, 1, 1);
+    },
+
+    paintXObject: function CanvasGraphics_paintXObject() {
+      UnsupportedManager.notify(UNSUPPORTED_FEATURES.unknown);
+      warn('Unsupported \'paintXObject\' command.');
     },
 
     // Marked content

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -28,6 +28,7 @@
 !javauninstall-7r.pdf
 !issue3205r.pdf
 !close-path-bug.pdf
+!issue6541.pdf
 !issue2948.pdf
 !issue6231_1.pdf
 !issue6413.pdf

--- a/test/pdfs/issue6541.pdf
+++ b/test/pdfs/issue6541.pdf
@@ -1,0 +1,204 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/Kids [2 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+2 0 obj 
+<<
+/Parent 1 0 R
+/Resources 
+<<
+/ColorSpace 3 0 R
+/Font 4 0 R
+/XObject 5 0 R
+/Pattern 6 0 R
+/ProcSet [/PDF /Text]
+>>
+/MediaBox [0 0 595.28 841.89]
+/Type /Page
+/Contents 7 0 R
+>>
+endobj 
+3 0 obj 
+<<
+/R43 8 0 R
+>>
+endobj 
+5 0 obj 
+<<
+/R44 9 0 R
+/R41 10 0 R
+/R57 11 0 R
+/R45 12 0 R
+>>
+endobj 
+4 0 obj 
+<<
+/F1 13 0 R
+>>
+endobj 
+6 0 obj 
+<<
+/R42 14 0 R
+>>
+endobj 
+7 0 obj 
+<<
+/Length 135
+>>
+stream
+q
+0.1 0 0 0.1 0 0 cm
+q
+0 0 5952.93 8419 re
+W n
+/R57 Do
+q
+10 0 0 10 0 0 cm
+BT
+/F1 20 Tf
+1 0 0 1 34.016 808.15 Tm
+(Issue 6541) Tj
+ET
+Q
+Q
+
+endstream 
+endobj 
+8 0 obj [/Pattern]
+endobj 
+12 0 obj 
+<<
+/Matrix [1 0 0 1 0 0]
+/Subtype /Form
+/Length 12
+/FormType 1
+/Type /XObject
+/BBox [3916.83 5146.43 5459.14 6380.28]
+>>
+stream
+q
+/R44 Do
+Q
+
+endstream 
+endobj 
+9 0 obj 
+<<
+/Matrix [1 0 0 1 0 0]
+/Subtype /Form
+/Length 58
+/FormType 1
+/Type /XObject
+/BBox [3916.83 5146.43 5459.14 6380.28]
+>>
+stream
+q
+/R43 cs
+/R42 scn
+3916.82 5146.43 1542.32 1233.86 re
+f
+Q
+
+endstream 
+endobj 
+10 0 obj 
+<<
+/Matrix [1 0 0 1 0 0]
+/Subtype /Form
+/Length 0
+/FormType 1
+/Type /XObject
+/BBox [0 0 5760 4610]
+>>
+stream
+
+endstream 
+endobj 
+11 0 obj 
+<<
+/Matrix [1 0 0 1 0 0]
+/Subtype /Form
+/Length 12
+/FormType 1
+/Type /XObject
+/BBox [-0.13 -0.18 5952.93 8419.14]
+>>
+stream
+q
+/R45 Do
+Q
+
+endstream 
+endobj 
+13 0 obj 
+<<
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/Type /Font
+>>
+endobj 
+14 0 obj 
+<<
+/PatternType 1
+/YStep 2074
+/XStep 2074
+/Resources 
+<<
+/Font 
+<<
+/F1 13 0 R
+>>
+/ProcSet [/PDF]
+>>
+/BBox [0 0 576 461]
+/Matrix [2.67763 0 0 2.67763 3917 5146]
+/TilingType 1
+/PaintType 1
+/Length 12
+/Type /Pattern
+>>
+stream
+q
+/R41 Do
+Q
+
+endstream 
+endobj 
+15 0 obj 
+<<
+/Pages 1 0 R
+/Type /Catalog
+>>
+endobj xref
+0 16
+0000000000 65535 f 
+0000000015 00000 n 
+0000000074 00000 n 
+0000000269 00000 n 
+0000000373 00000 n 
+0000000303 00000 n 
+0000000407 00000 n 
+0000000442 00000 n 
+0000000631 00000 n 
+0000000828 00000 n 
+0000001043 00000 n 
+0000001182 00000 n 
+0000000658 00000 n 
+0000001348 00000 n 
+0000001450 00000 n 
+0000001715 00000 n 
+trailer
+
+<<
+/Root 15 0 R
+/Size 16
+>>
+startxref
+1766
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -694,6 +694,13 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "issue6541",
+       "file": "pdfs/issue6541.pdf",
+       "md5": "81bc5b146404207ea40f2c55301b2bb6",
+       "link": false,
+       "rounds": 1,
+       "type": "eq"
+    },
     {  "id": "issue6231_1",
        "file": "pdfs/issue6231_1.pdf",
        "md5": "eb13a9366a5142833a858472c68b4749",


### PR DESCRIPTION
Fixes #6541.

~~_Note:_ I've not yet had time to create a reduced test-case, hence the `WIP` label.~~
