### PR TITLE
Add a `totalLength` getter to `OperatorList`, since the `length` is zero after flushing

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1920,6 +1920,7 @@ var OperatorList = (function OperatorListClosure() {
     this.fnArray = [];
     this.argsArray = [];
     this.dependencies = {};
+    this._totalLength = 0;
     this.pageIndex = pageIndex;
     this.intent = intent;
   }
@@ -1927,6 +1928,14 @@ var OperatorList = (function OperatorListClosure() {
   OperatorList.prototype = {
     get length() {
       return this.argsArray.length;
+    },
+
+    /**
+     * @returns {number} The total length of the entire operator list,
+     *                   since `this.length === 0` after flushing.
+     */
+    get totalLength() {
+      return (this._totalLength + this.length);
     },
 
     addOp: function(fn, args) {
@@ -1977,12 +1986,15 @@ var OperatorList = (function OperatorListClosure() {
         new QueueOptimizer().optimize(this);
       }
       var transfers = getTransfers(this);
+      var length = this.length;
+      this._totalLength += length;
+
       this.messageHandler.send('RenderPageChunk', {
         operatorList: {
           fnArray: this.fnArray,
           argsArray: this.argsArray,
           lastChunk: lastChunk,
-          length: this.length
+          length: length
         },
         pageIndex: this.pageIndex,
         intent: this.intent

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -467,7 +467,7 @@ var WorkerMessageHandler = PDFJS.WorkerMessageHandler = {
           finishWorkerTask(task);
 
           info('page=' + pageNum + ' - getOperatorList: time=' +
-               (Date.now() - start) + 'ms, len=' + operatorList.fnArray.length);
+               (Date.now() - start) + 'ms, len=' + operatorList.totalLength);
         }, function(e) {
           finishWorkerTask(task);
           if (task.terminated) {

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -305,4 +305,25 @@ describe('evaluator', function() {
       });
     });
   });
+
+  describe('operator list', function () {
+    function MessageHandlerMock() { }
+    MessageHandlerMock.prototype = {
+      send: function () { },
+    };
+
+    it('should get correct total length after flushing', function () {
+      var operatorList = new OperatorList(null, new MessageHandlerMock());
+      operatorList.addOp(OPS.save, null);
+      operatorList.addOp(OPS.restore, null);
+
+      expect(operatorList.totalLength).toEqual(2);
+      expect(operatorList.length).toEqual(2);
+
+      operatorList.flush();
+
+      expect(operatorList.totalLength).toEqual(2);
+      expect(operatorList.length).toEqual(0);
+    });
+  });
 });


### PR DESCRIPTION
In the `RenderPageRequest` handler in `worker.js`, we attempt to print an `info` message containing the rendering time and the length of the operator list. The latter is currently broken (and has been for quite some time), since the `length` of an `OperatorList` is reset when flushing occurs.
This patch attempts to rectify this, by adding a getter which keeps track of the total length.
