### PR TITLE
Replace the linked test-case for issue 1293 with a reduced test-case

### DIFF
--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -28,6 +28,7 @@
 !javauninstall-7r.pdf
 !issue3205r.pdf
 !close-path-bug.pdf
+!issue1293r.pdf
 !issue6541.pdf
 !issue2948.pdf
 !issue6231_1.pdf

--- a/test/pdfs/issue1293.pdf.link
+++ b/test/pdfs/issue1293.pdf.link
@@ -1,1 +1,0 @@
-http://dl.dropbox.com/u/22242495/pdfjs/pdfkit_uncompressed.pdf

--- a/test/pdfs/issue1293r.pdf
+++ b/test/pdfs/issue1293r.pdf
@@ -1,0 +1,66 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/Pages 2 0 R
+/Type /Catalog
+>>
+endobj 
+2 0 obj 
+<<
+/Kids [3 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+3 0 obj 
+<<
+/Parent 2 0 R
+/MediaBox [0 0 200 50]
+/Resources 
+<<
+/Font 
+<<
+/F1 4 0 R
+>>
+>>
+/Contents 5 0 R
+/Type /Page
+>>
+endobj 
+4 0 obj 
+<<
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/Type /Font
+>>
+endobj 
+5 0 obj 
+<<
+>>
+stream
+BT
+10 20 TD
+/F1 20 Tf
+(Issue 1293) Tj
+ET
+
+endstream 
+endobj xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000066 00000 n 
+0000000125 00000 n 
+0000000254 00000 n 
+0000000355 00000 n 
+trailer
+
+<<
+/Root 1 0 R
+/Size 6
+>>
+startxref
+437
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -33,12 +33,10 @@
        "type": "text"
     },
     {  "id": "issue1293",
-       "file": "pdfs/issue1293.pdf",
-       "md5": "0a744b3bbf2fd8da0131fd3c01dd1e30",
+       "file": "pdfs/issue1293r.pdf",
+       "md5": "4a098f5051f34fab036f5bbe88f8deef",
        "rounds": 1,
-       "link": true,
-       "firstPage": 1,
-       "lastPage": 1,
+       "link": false,
        "type": "load",
        "about": "PDF with undefined stream length."
     },


### PR DESCRIPTION
When I submitted PR #3576, I included a linked test-case. The reason was that I didn't know enough about the PDF format, in order to successfully create a reduced test-case.
Considering that the link points to a Dropbox, there's no guarantee that the PDF file will remain available, hence it seems worthwhile to replace the test-case.

_Note:_ Since this is a `load` test, `makeref` won't be necessary.
