### PR TITLE
Adding issue link

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,6 @@
     "type": "git",
     "url": "git://github.com/mozilla/pdf.js.git"
   },
+  "bugs": "https://github.com/mozilla/pdf.js/issues",
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
Hi again, :blush:

> _My old pull request #6581 wasn't accepted here._
> So I thought about how I can help you all for this project.

I found out that in the _`package.json` file_ is **missing a link to the Issue page** **_for mozilla/pdf.isc repository**_.
I've added it. I hope I could help you.

_Yours,_
[**Suriyaa Kudo**](https://github.com/SuriyaaKudoIsc) :octocat:

(PS: I **really want to contribute** to _this_ Mozilla project!)
