### PR TITLE
Non/less flashing text layer during selection.

### DIFF
--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -61,3 +61,21 @@
 
 .textLayer ::selection { background: rgb(0,0,255); }
 .textLayer ::-moz-selection { background: rgb(0,0,255); }
+
+.textLayer .endOfContent {
+  display: block;
+  position: absolute;
+  left: 0px;
+  top: 100%;
+  right: 0px;
+  bottom: 0px;
+  z-index: -1;
+  cursor: default;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  -moz-user-select: none;
+}
+
+.textLayer .endOfContent.active {
+  top: 0px;
+}


### PR DESCRIPTION
If we place entire-text-layer div after the content, it will make selection flash in different way: bottom-right part instead of left-top.

`-moz-user-select` fixes flashing for Firefox. (`-webkit-user-select` has no effect -- just added it for company).
