### PR TITLE
Uses document.currentScript for pdf.worker.js path.

### DIFF
--- a/examples/components/pageviewer.js
+++ b/examples/components/pageviewer.js
@@ -20,11 +20,9 @@ if (!PDFJS.PDFViewer || !PDFJS.getDocument) {
         '  `node make generic components`');
 }
 
-// In cases when the pdf.worker.js is located at the different folder than the
-// pdf.js's one, or the pdf.js is executed via eval(), the workerSrc property
-// shall be specified.
+// The workerSrc property shall be specified.
 //
-// PDFJS.workerSrc = '../../build/pdf.worker.js';
+PDFJS.workerSrc = '../../build/pdf.worker.js';
 
 // Some PDFs need external cmaps.
 //

--- a/examples/components/simpleviewer.js
+++ b/examples/components/simpleviewer.js
@@ -20,11 +20,9 @@ if (!PDFJS.PDFViewer || !PDFJS.getDocument) {
         '  `node make generic components`');
 }
 
-// In cases when the pdf.worker.js is located at the different folder than the
-// pdf.js's one, or the pdf.js is executed via eval(), the workerSrc property
-// shall be specified.
+// The workerSrc property shall be specified.
 //
-// PDFJS.workerSrc = '../../build/pdf.worker.js';
+PDFJS.workerSrc = '../../build/pdf.worker.js';
 
 // Some PDFs need external cmaps.
 //

--- a/examples/learning/helloworld.html
+++ b/examples/learning/helloworld.html
@@ -30,11 +30,9 @@
   // PDFJS.disableWorker = true;
 
   //
-  // In cases when the pdf.worker.js is located at the different folder than the
-  // pdf.js's one, or the pdf.js is executed via eval(), the workerSrc property
-  // shall be specified.
+  // The workerSrc property shall be specified.
   //
-  // PDFJS.workerSrc = '../../build/pdf.worker.js';
+  PDFJS.workerSrc = '../../build/pdf.worker.js';
 
   //
   // Asynchronous download PDF

--- a/examples/learning/helloworld64.html
+++ b/examples/learning/helloworld64.html
@@ -40,11 +40,10 @@
   //
   // PDFJS.disableWorker = true;
 
-  // In cases when the pdf.worker.js is located at the different folder than the
-  // pdf.js's one, or the pdf.js is executed via eval(), the workerSrc property
-  // shall be specified.
   //
-  // PDFJS.workerSrc = '../../build/pdf.worker.js';
+  // The workerSrc property shall be specified.
+  //
+  PDFJS.workerSrc = '../../build/pdf.worker.js';
 
   // Opening PDF by passing its binary data as a string. It is still preferable
   // to use Uint8Array, but string or array-like structure will work too.

--- a/examples/text-only/pdf2svg.js
+++ b/examples/text-only/pdf2svg.js
@@ -18,6 +18,8 @@ var PAGE_NUMBER = 1;
 var PAGE_SCALE = 1.5;
 var SVG_NS = 'http://www.w3.org/2000/svg';
 
+PDFJS.workerSrc = '../../build/pdf.worker.js';
+
 function buildSVG(viewport, textContent) {
   // Building SVG with size of the viewport (for simplicity)
   var svg = document.createElementNS(SVG_NS, 'svg:svg');

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -75,7 +75,9 @@ PDFJS.disableWorker = (PDFJS.disableWorker === undefined ?
 /**
  * Path and filename of the worker file. Required when the worker is enabled in
  * development mode. If unspecified in the production build, the worker will be
- * loaded based on the location of the pdf.js file.
+ * loaded based on the location of the pdf.js file. It is recommended that
+ * the workerSrc is set in a custom application to prevent issues caused by
+ * third-party frameworks and libraries.
  * @var {string}
  */
 PDFJS.workerSrc = (PDFJS.workerSrc === undefined ? null : PDFJS.workerSrc);

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -42,10 +42,8 @@ if (!PDFJS.workerSrc && typeof document !== 'undefined') {
   // workerSrc is not set -- using last script url to define default location
   PDFJS.workerSrc = (function () {
     'use strict';
-    var scriptTagContainer = document.body ||
-                             document.getElementsByTagName('head')[0];
-    var pdfjsSrc = scriptTagContainer.lastChild.src;
-    return pdfjsSrc && pdfjsSrc.replace(/\.js$/i, '.worker.js');
+    var pdfJsSrc = document.currentScript.src;
+    return pdfJsSrc && pdfJsSrc.replace(/\.js$/i, '.worker.js');
   })();
 }
 //#endif

--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -577,3 +577,19 @@ if (typeof PDFJS === 'undefined') {
     PDFJS.disableFullscreen = true;
   }
 })();
+
+// Provides document.currentScript support
+// Support: IE, Chrome<29.
+(function checkCurrentScript() {
+  if ('currentScript' in document) {
+    return;
+  }
+  Object.defineProperty(document, 'currentScript', {
+    get: function () {
+      var scripts = document.getElementsByTagName('script');
+      return scripts[scripts.length - 1];
+    },
+    enumerable: true,
+    configurable: true
+  });
+})();


### PR DESCRIPTION
Addresses #6593 concern <del>by printing a warning in case when workerSrc is not set.</del>
