### PR TITLE
Fixes incorrect PDF file font metrics.

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -4152,6 +4152,20 @@ var Font = (function FontClosure() {
         tables.hhea.data[11] = 0xFF;
       }
 
+      // Extract some more font properties from the OpenType head and
+      // hhea tables; yMin and descent value are always negative.
+      var metricsOverride = {
+        unitsPerEm: int16(tables.head.data[18], tables.head.data[19]),
+        yMax: int16(tables.head.data[42], tables.head.data[43]),
+        yMin: int16(tables.head.data[38], tables.head.data[39]) - 0x10000,
+        ascent: int16(tables.hhea.data[4], tables.hhea.data[5]),
+        descent: int16(tables.hhea.data[6], tables.hhea.data[7]) - 0x10000
+      };
+
+      // PDF FontDescriptor metrics lie -- using data from actual font.
+      this.ascent = metricsOverride.ascent / metricsOverride.unitsPerEm;
+      this.descent = metricsOverride.descent / metricsOverride.unitsPerEm;
+
       // The 'post' table has glyphs names.
       if (tables.post) {
         var valid = readPostScriptTable(tables.post, properties, numGlyphs);
@@ -4318,20 +4332,10 @@ var Font = (function FontClosure() {
       };
 
       if (!tables['OS/2'] || !validateOS2Table(tables['OS/2'])) {
-        // extract some more font properties from the OpenType head and
-        // hhea tables; yMin and descent value are always negative
-        var override = {
-          unitsPerEm: int16(tables.head.data[18], tables.head.data[19]),
-          yMax: int16(tables.head.data[42], tables.head.data[43]),
-          yMin: int16(tables.head.data[38], tables.head.data[39]) - 0x10000,
-          ascent: int16(tables.hhea.data[4], tables.hhea.data[5]),
-          descent: int16(tables.hhea.data[6], tables.hhea.data[7]) - 0x10000
-        };
-
         tables['OS/2'] = {
           tag: 'OS/2',
           data: createOS2Table(properties, newMapping.charCodeToGlyphId,
-                               override)
+                               metricsOverride)
         };
       }
 


### PR DESCRIPTION
The PDF lies about font metrics in font descriptors, e.g. PDF file from #4339 http://www.nasa.gov/pdf/750614main_NASA_FY_2014_Budget_Estimates-508.pdf . It's noticeable in the text layer.

Font HJMTJJ+TimesNewRoman report in PDF Ascent=1026/1000 and Descent=-307/1000, but the font hhea Ascent=1638/2048 and Descent = -410/2048.

<img width="440" alt="screen shot 2015-11-06 at 2 52 16 pm" src="https://cloud.githubusercontent.com/assets/1523410/11008536/cc4c21b4-8496-11e5-8fff-8fb0133f87f5.png">
