### PR TITLE
Improve error message for non-existent local files

### DIFF
--- a/src/core/network.js
+++ b/src/core/network.js
@@ -245,11 +245,13 @@ var NetworkManager = (function NetworkManagerClosure() {
         });
       } else if (pendingRequest.onProgressiveData) {
         pendingRequest.onDone(null);
-      } else {
+      } else if (chunk) {
         pendingRequest.onDone({
           begin: 0,
           chunk: chunk
         });
+      } else if (pendingRequest.onError) {
+        pendingRequest.onError(xhr.status);
       }
     },
 

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -236,7 +236,7 @@ var WorkerMessageHandler = PDFJS.WorkerMessageHandler = {
 
         onError: function onError(status) {
           var exception;
-          if (status === 404) {
+          if (status === 404 || status === 0 && /^file:/.test(source.url)) {
             exception = new MissingPDFException('Missing PDF "' +
                                                 source.url + '".');
             handler.send('MissingPDF', exception);


### PR DESCRIPTION
I received multiple reports about the following cryptic error in the Chrome extension when the user tried to open a local file:

> PDF.js v1.1.527 (build: 2096a2a)
> Message: Cannot read property 'Symbol(Symbol.iterator)' of null

This error most likely originated from core/stream.js:

```
function Stream(arrayBuffer, start, length, dict) {
  this.bytes = (arrayBuffer instanceof Uint8Array ?
                arrayBuffer : new Uint8Array(arrayBuffer));
                                             ^^^^^^^^^^^
```

`arrayBuffer` is `null`, and that in turn is caused by the fact that for non-existing files, there is no data. I've applied two fixes:
1. Never call onDone with a void buffer, but call the error handler
   instead.
2. Show a sensible error message for local files with status = 0.

To get the error, simply install the Chrome extension, open any PDF file to get the extension URL, and then append some non-existent local file. E.g. `chrome-extension://oemmndcbldboiebfnladdacbdfmadadm/file:///tmp/doesnotexist.pdf`
