### PR TITLE
Correctly handle /FitH destinations with `null` as the parameter

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -519,6 +519,12 @@ var PDFViewer = (function pdfViewer() {
         case 'FitBH':
           y = dest[2];
           scale = 'page-width';
+          // According to the PDF spec, section 12.3.2.2, a `null` value in the
+          // parameter should maintain the position relative to the new page.
+          if (y === null && this._location) {
+            x = this._location.left;
+            y = this._location.top;
+          }
           break;
         case 'FitV':
         case 'FitBV':


### PR DESCRIPTION
According to http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#G11.2095870, the vertical position shouldn't change if the parameter is `null`.

Fixes #6615.
