### PR TITLE
Apply transformation matrix to RadialGradient radiuses

### DIFF
--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -205,6 +205,11 @@ Shadings.RadialAxial = (function RadialAxialClosure() {
       if (matrix) {
         p0 = Util.applyTransform(p0, matrix);
         p1 = Util.applyTransform(p1, matrix);
+        if (shadingType === ShadingType.RADIAL) {
+          var scale = Util.singularValueDecompose2dScale(matrix);
+          r0 *= scale[0];
+          r1 *= scale[1];
+        }
       }
 
       return ['RadialAxial', type, this.colorStops, p0, p1, r0, r1];

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -60,6 +60,7 @@
 !bug1157493.pdf
 !pdfjsbad1586.pdf
 !freeculture.pdf
+!issue6006.pdf
 !pdfkit_compressed.pdf
 !TAMReview.pdf
 !pr4922.pdf

--- a/test/pdfs/issue6006.pdf
+++ b/test/pdfs/issue6006.pdf
@@ -1,0 +1,124 @@
+%PDF-1.5
+%‚„œ”
+1 0 obj 
+<<
+/Kids [2 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+2 0 obj 
+<<
+/Parent 1 0 R
+/Resources 3 0 R
+/MediaBox [0 0 100 100]
+/Contents 4 0 R
+/Type /Page
+>>
+endobj 
+4 0 obj 
+<<
+/Length 42
+>>
+stream
+q
+/Pattern cs /p4 scn
+0 0 100 100 re f
+Q 
+
+endstream 
+endobj 
+3 0 obj 
+<<
+/Pattern 
+<<
+/p4 5 0 R
+>>
+>>
+endobj 
+5 0 obj 
+<<
+/Matrix [50 0 0 50 50 50]
+/Shading 
+<<
+/ColorSpace /DeviceRGB
+/Function 6 0 R
+/Coords [0 0 0 0 0 1]
+/ShadingType 3
+/Extend [true true]
+>>
+/PatternType 2
+/Type /Pattern
+>>
+endobj 
+6 0 obj 
+<<
+/FunctionType 3
+/Functions [7 0 R 8 0 R 9 0 R]
+/Encode [-1 1 0 1 0 1]
+/Bounds [0.40 0.50]
+/Domain [0 1]
+>>
+endobj 
+7 0 obj 
+<<
+/FunctionType 2
+/N 1
+/C1 [1 1 1]
+/Domain [0 1]
+/C0 [0 0 1]
+>>
+endobj 
+8 0 obj 
+<<
+/FunctionType 2
+/N 1
+/C1 [1 1 1]
+/Domain [0 1]
+/C0 [1 1 1]
+>>
+endobj 
+9 0 obj 
+<<
+/FunctionType 2
+/N 1
+/C1 [1 0 0]
+/Domain [0 1]
+/C0 [1 1 1]
+>>
+endobj 
+10 0 obj 
+<<
+/Pages 1 0 R
+/Type /Catalog
+>>
+endobj 
+11 0 obj 
+<<
+/Title (PDF.js test case for issue #6006)
+/Author (Daan Sprenkels <dsprenkels@gmail.com>)
+>>
+endobj xref
+0 12
+0000000000 65535 f 
+0000000015 00000 n 
+0000000074 00000 n 
+0000000275 00000 n 
+0000000180 00000 n 
+0000000324 00000 n 
+0000000515 00000 n 
+0000000642 00000 n 
+0000000724 00000 n 
+0000000806 00000 n 
+0000000888 00000 n 
+0000000940 00000 n 
+trailer
+
+<<
+/Info 11 0 R
+/Root 10 0 R
+/Size 12
+>>
+startxref
+1053
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1617,6 +1617,13 @@
       "link": true,
       "type": "eq"
     },
+    {
+      "id": "issue6006",
+      "file": "pdfs/issue6006.pdf",
+      "md5": "65558dcdd2f20d4372458419c10bfa72",
+      "rounds": 1,
+      "type": "eq"
+    },
     {  "id": "issue1810",
       "file": "pdfs/issue1810.pdf",
       "md5": "b173a9dfb7bf00e1a298c6e8cb95c03e",


### PR DESCRIPTION
It looked like #6006 was caused by the fact that the transformation matrix of some pattern was only applied to the origin points of the two circles describing the gradient. This change makes it so that also the radii of the circles will be scaled.

Note that this commit does _not_ fix #6296.

~~I have not really tested the commit very thoroughly, using the unit tests. I ran into some problems.~~

Fixes #6006.
