### PR TITLE
Use `DEFAULT_SCALE` instead of `1.0` as the default value if the `scale` option isn't specified when initializing `PDFPageView`

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals RenderingStates, PDFJS, CSS_UNITS, getOutputScale,
+/* globals RenderingStates, PDFJS, DEFAULT_SCALE, CSS_UNITS, getOutputScale,
            TextLayerBuilder, AnnotationsLayerBuilder, Promise,
            approximateFraction, roundToDivide */
 
@@ -55,7 +55,7 @@ var PDFPageView = (function PDFPageViewClosure() {
     this.renderingId = 'page' + id;
 
     this.rotation = 0;
-    this.scale = scale || 1.0;
+    this.scale = scale || DEFAULT_SCALE;
     this.viewport = defaultViewport;
     this.pdfPageRotate = defaultViewport.rotation;
     this.hasRestrictedScaling = false;


### PR DESCRIPTION
A small piece of cleanup, in order to avoid unnecessarily hardcoding a default value.
