### PR TITLE
Make `stripCommentHeaders` less greedy, to ensure that it doesn't eat 'use strict' directive at the top of files (PR 6627 follow-up)

### DIFF
--- a/make.js
+++ b/make.js
@@ -606,8 +606,9 @@ target.singlefile = function() {
 function stripCommentHeaders(content, filename) {
   var notEndOfComment = '(?:[^*]|\\*(?!/))+';
   var reg = new RegExp(
-    '\n(?:/\\*' + notEndOfComment + '\\*/\\s*|//(?!#).*\n\\s*)+' +
-    '\'use strict\';', 'g');
+    '\n/\\* Copyright' + notEndOfComment + '\\*/\\s*' +
+    '(?:/\\*' + notEndOfComment + '\\*/\\s*|//(?!#).*\n\\s*)*' +
+    '\\s*\'use strict\';', 'g');
   content = content.replace(reg, '');
   return content;
 }

--- a/src/core/bidi.js
+++ b/src/core/bidi.js
@@ -1,4 +1,3 @@
-/* globals PDFJS */
 /* Copyright 2012 Mozilla Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* globals PDFJS */
 
 'use strict';
 

--- a/src/display/metadata.js
+++ b/src/display/metadata.js
@@ -1,4 +1,3 @@
-/* globals Document, error, PDFJS */
 /* Copyright 2012 Mozilla Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* globals Document, error, PDFJS */
 
 'use strict';
 


### PR DESCRIPTION
- Move the `globals` comments in bidi.js and metadata.js to after the Copyright comments
- Make `stripCommentHeaders` less greedy, to ensure that it doesn't eat 'use strict' directive at the top of files (PR 6627 follow-up)
  
  While browsing through the latest PDF.js update on mozilla-central, see https://hg.mozilla.org/integration/fx-team/rev/aef06cd725fc, I noticed that the `'use strict';` directives were missing at the top of a number of files.
  This is fallout from the changes made in `make.js` in PR #6627, since `stripCommentHeaders` previously relied on the existence of the mode-lines.
  
  I'm assuming that we do want _all_ of the code (e.g. the viewer too) to execute in strict mode, hence this patch tweaks `stripCommentHeaders` to make it less greedy.
