### PR TITLE
Refactor annotation flags code

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -268,8 +268,7 @@ var Page = (function PageClosure() {
       for (var i = 0, n = annotationRefs.length; i < n; ++i) {
         var annotationRef = annotationRefs[i];
         var annotation = annotationFactory.create(this.xref, annotationRef);
-        if (annotation &&
-            (annotation.isViewable() || annotation.isPrintable())) {
+        if (annotation && (annotation.viewable || annotation.printable)) {
           annotations.push(annotation);
         }
       }

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -48,6 +48,19 @@ var AnnotationType = {
   LINK: 3
 };
 
+var AnnotationFlag = {
+  INVISIBLE: 0x01,
+  HIDDEN: 0x02,
+  PRINT: 0x04,
+  NOZOOM: 0x08,
+  NOROTATE: 0x10,
+  NOVIEW: 0x20,
+  READONLY: 0x40,
+  LOCKED: 0x80,
+  TOGGLENOVIEW: 0x100,
+  LOCKEDCONTENTS: 0x200
+};
+
 var AnnotationBorderStyleType = {
   SOLID: 1,
   DASHED: 2,

--- a/test/unit/annotation_layer_spec.js
+++ b/test/unit/annotation_layer_spec.js
@@ -1,10 +1,31 @@
 /* globals expect, it, describe, Dict, Name, Annotation, AnnotationBorderStyle,
-           AnnotationBorderStyleType */
+           AnnotationBorderStyleType, AnnotationFlag */
 
 'use strict';
 
 describe('Annotation layer', function() {
   describe('Annotation', function() {
+    it('should set and get flags', function() {
+      var dict = new Dict();
+      dict.set('Subtype', '');
+      var annotation = new Annotation({ dict: dict, ref: 0 });
+      annotation.setFlags(13);
+
+      expect(annotation.hasFlag(AnnotationFlag.INVISIBLE)).toEqual(true);
+      expect(annotation.hasFlag(AnnotationFlag.NOZOOM)).toEqual(true);
+      expect(annotation.hasFlag(AnnotationFlag.PRINT)).toEqual(true);
+      expect(annotation.hasFlag(AnnotationFlag.READONLY)).toEqual(false);
+    });
+
+    it('should be viewable and not printable by default', function() {
+      var dict = new Dict();
+      dict.set('Subtype', '');
+      var annotation = new Annotation({ dict: dict, ref: 0 });
+
+      expect(annotation.viewable).toEqual(true);
+      expect(annotation.printable).toEqual(false);
+    });
+
     it('should set and get a valid rectangle', function() {
       var dict = new Dict();
       dict.set('Subtype', '');


### PR DESCRIPTION
This patch makes it possible to set and get all possible flags that the PDF specification defines. Even though we do not support all possible annotation types and not all possible annotation flags yet, this general framework makes it easy to access all flags for each annotation such that annotation type implementations can use this information.

We add constants for all possible annotation flags such that we do not need to hardcode the flags in the code anymore. The `isViewable()` and `isPrintable()` methods are now easier to read. Additionally, unit tests have been added to ensure correct behavior.

This is another part of #5218.

I have tested this patch, both with displaying and with printing, with a corpus of 23 PDF files with different annotation types and annotation flags in them and observed no difference with the current master.
