### PR TITLE
Checkbox fieldValue issue fix

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -980,6 +980,7 @@ var PDFStringTranslateTable = [
 ];
 
 function stringToPDFString(str) {
+  str = typeof str == 'object' ? str[Object.keys(str)[0]] : str;
   var i, n = str.length, strBuf = [];
   if (str[0] === '\xFE' && str[1] === '\xFF') {
     // UTF16BE BOM

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -980,7 +980,7 @@ var PDFStringTranslateTable = [
 ];
 
 function stringToPDFString(str) {
-  str = typeof str == 'object' ? str[Object.keys(str)[0]] : str;
+  str = typeof str === 'object' ? str[Object.keys(str)[0]] : str;
   var i, n = str.length, strBuf = [];
   if (str[0] === '\xFE' && str[1] === '\xFF') {
     // UTF16BE BOM


### PR DESCRIPTION
Fixed issue when checkbox field allways recieves "" value.
The dict.get('V') returns an object and when the stringToPDFString function runs it allways returns "", since the str is from type object.
