### PR TITLE
Restore the `data.annotationFlags` parameter for annotations (PR 6672 follow-up)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -124,6 +124,7 @@ var Annotation = (function AnnotationClosure() {
     data.subtype = dict.get('Subtype').name;
 
     this.setFlags(dict.get('F'));
+    data.annotationFlags = this.flags;
 
     this.setRectangle(dict.get('Rect'));
     data.rect = this.rectangle;
@@ -678,7 +679,7 @@ var LinkAnnotation = (function LinkAnnotationClosure() {
         if (!isValidUrl(url, false)) {
           url = '';
         }
-        // According to ISO 32000-1:2008, section 12.6.4.7, 
+        // According to ISO 32000-1:2008, section 12.6.4.7,
         // URI should to be encoded in 7-bit ASCII.
         // Some bad PDFs may have URIs in UTF-8 encoding, see Bugzilla 1122280.
         try {


### PR DESCRIPTION
Fixes https://github.com/mozilla/pdf.js/pull/6672#discussion_r45564786.

I don't think `data.annotationFlags` should have been removed, but unfortunately I missed it while reviewing the patch, sorry about that!
