### PR TITLE
Improve the comment and deprecation warning for `PDFJS.openExternalLinksInNewWindow`

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -173,6 +173,9 @@ PDFJS.maxCanvasPixels = (PDFJS.maxCanvasPixels === undefined ?
 /**
  * (Deprecated) Opens external links in a new window if enabled.
  * The default behavior opens external links in the PDF.js window.
+ *
+ * NOTE: This property has been deprecated, please use
+ *       `PDFJS.externalLinkTarget = PDFJS.LinkTarget.BLANK` instead.
  * @var {boolean}
  */
 PDFJS.openExternalLinksInNewWindow = (

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -360,10 +360,10 @@ var LinkTargetStringMap = [
 ];
 
 function isExternalLinkTargetSet() {
-//#if GENERIC
+//#if !MOZCENTRAL
   if (PDFJS.openExternalLinksInNewWindow) {
-    warn('PDFJS.openExternalLinksInNewWindow is deprecated, ' +
-         'use PDFJS.externalLinkTarget instead.');
+    deprecated('PDFJS.openExternalLinksInNewWindow, please use ' +
+               '"PDFJS.externalLinkTarget = PDFJS.LinkTarget.BLANK" instead.');
     if (PDFJS.externalLinkTarget === LinkTarget.NONE) {
       PDFJS.externalLinkTarget = LinkTarget.BLANK;
     }


### PR DESCRIPTION
This patch:
- Updates the JSDoc comment in `api.js`, to more clearly point out that `PDFJS.openExternalLinksInNewWindow` is deprecated, and explains what to use instead.
- Changes the `warn`, in `isExternalLinkTargetSet()`, to use the new `deprecated` function instead. Also updates the message with more detailed information about what to use instead.
- Changes the pre-processor tag to ensure the deprecation warning is seen in all build types where it could possibly matter (in case people are using `PDFJS.openExternalLinksInNewWindow` in e.g. custom-built extensions).

These changes were prompted by seeing http://stackoverflow.com/questions/33813373/pdf-js-how-to-open-hyperlinks-in-a-new-tab-window, since it seems to me that the current comments/warnings might not be worded well enough.
