### PR TITLE
Minify js and css files and add them to build folder #5487

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "pdf.js",
   "version": "0.8.0",
   "devDependencies": {
+    "clean-css": "^3.4.8",
     "jsdoc": "^3.3.0-alpha9",
     "jshint": "~2.8.0",
     "node-ensure": "^0.0.0",

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -36,8 +36,10 @@ var DISABLE_AUTO_FETCH_LOADING_BAR_TIMEOUT = 5000;
 
 function configure(PDFJS) {
   PDFJS.imageResourcesPath = './images/';
-//#if (FIREFOX || MOZCENTRAL || GENERIC || CHROME)
+//#if (FIREFOX || MOZCENTRAL || GENERIC || CHROME) && !(MINIFIED)
 //PDFJS.workerSrc = '../build/pdf.worker.js';
+//#elif (FIREFOX || MOZCENTRAL || GENERIC || CHROME) && (MINIFIED)
+//PDFJS.workerSrc = '../build/pdf.worker.min.js';
 //#endif
 //#if !PRODUCTION
   PDFJS.cMapUrl = '../external/bcmaps/';


### PR DESCRIPTION
- follows on from #5593
- use npm for dependency on closure compiler and clean-css
- remove unneeded commas

Fixes #5487.
