### PR TITLE
Fix for IE highlight bug due to lack of blending mode support

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1805,6 +1805,10 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       if (isArray(rect) && 4 === rect.length) {
         var width = rect[2] - rect[0];
         var height = rect[3] - rect[1];
+        // IE does not support blending modes
+        if (document.createElement('canvas').msToBlob) {
+          this.ctx.globalAlpha = 0.4;
+        }
         this.ctx.rect(rect[0], rect[1], width, height);
         this.clip();
         this.endPath();


### PR DESCRIPTION
Issue discussed here: https://github.com/mozilla/pdf.js/issues/5264
