### PR TITLE
Worker shall wait for MessageHandler to be created at api side.

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -84,7 +84,7 @@ var WorkerMessageHandler = PDFJS.WorkerMessageHandler = {
       return WorkerMessageHandler.createDocumentHandler(data, port);
     });
   },
-  createDocumentHandler: function wphCreateDocumentHandler(data, port) {
+  createDocumentHandler: function wphCreateDocumentHandler(docParams, port) {
     // This context is actually holds references on pdfManager and handler,
     // until the latter is destroyed.
     var pdfManager;
@@ -92,8 +92,8 @@ var WorkerMessageHandler = PDFJS.WorkerMessageHandler = {
     var cancelXHRs = null;
     var WorkerTasks = [];
 
-    var docId = data.docId;
-    var workerHandlerName = data.docId + '_worker';
+    var docId = docParams.docId;
+    var workerHandlerName = docParams.docId + '_worker';
     var handler = new MessageHandler(workerHandlerName, docId, port);
 
     function ensureNotTerminated() {
@@ -346,7 +346,6 @@ var WorkerMessageHandler = PDFJS.WorkerMessageHandler = {
         }
 
         pdfManager = newPdfManager;
-
         handler.send('PDFManagerReady', null);
         pdfManager.onLoadedStream().then(function(stream) {
           handler.send('DataLoaded', { length: stream.bytes.byteLength });
@@ -567,7 +566,10 @@ var WorkerMessageHandler = PDFJS.WorkerMessageHandler = {
       });
     });
 
-    setupDoc(data);
+    handler.on('Ready', function wphReady(data) {
+      setupDoc(docParams);
+      docParams = null; // we don't need docParams anymore -- saving memory.
+    });
     return workerHandlerName;
   }
 };

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -359,6 +359,7 @@ PDFJS.getDocument = function getDocument(src,
         throw new Error('Loading aborted');
       }
       var messageHandler = new MessageHandler(docId, workerId, worker.port);
+      messageHandler.send('Ready', null);
       var transport = new WorkerTransport(messageHandler, task, rangeTransport);
       task._transport = transport;
     });


### PR DESCRIPTION
Regression from #6571, the Firefox extension cannot load non-cached documents, STR:
- open PDF document, with cache disabled
- or press Shift+Ctrl/Cmd+R to reload without cache

Problem is that worker is trying to request the data before MessageHandler is set on other side (api).
