### PR TITLE
Ensure that `Lexer_getName` does not fail if a `Name` contains in invalid usage of the NUMBER SIGN (#) (issue 6692)

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -832,17 +832,32 @@ var Lexer = (function LexerClosure() {
       return strBuf.join('');
     },
     getName: function Lexer_getName() {
-      var ch;
+      var ch, previousCh;
       var strBuf = this.strBuf;
       strBuf.length = 0;
       while ((ch = this.nextChar()) >= 0 && !specialChars[ch]) {
         if (ch === 0x23) { // '#'
           ch = this.nextChar();
+          if (specialChars[ch]) {
+            warn('Lexer_getName: ' +
+                 'NUMBER SIGN (#) should be followed by a hexadecimal number.');
+            strBuf.push('#');
+            break;
+          }
           var x = toHexDigit(ch);
           if (x !== -1) {
-            var x2 = toHexDigit(this.nextChar());
+            previousCh = ch;
+            ch = this.nextChar();
+            var x2 = toHexDigit(ch);
             if (x2 === -1) {
-              error('Illegal digit in hex char in name: ' + x2);
+              warn('Lexer_getName: Illegal digit (' +
+                   String.fromCharCode(ch) +') in hexadecimal number.');
+              strBuf.push('#', String.fromCharCode(previousCh));
+              if (specialChars[ch]) {
+                break;
+              }
+              strBuf.push(String.fromCharCode(ch));
+              continue;
             }
             strBuf.push(String.fromCharCode((x << 4) | x2));
           } else {

--- a/test/pdfs/issue6692.pdf.link
+++ b/test/pdfs/issue6692.pdf.link
@@ -1,0 +1,1 @@
+http://web.archive.org/web/20151126121615/http://www.inf.ufg.br/~hugoribeiro/OSPs/osp-im.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -817,6 +817,15 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "issue6692",
+       "file": "pdfs/issue6692.pdf",
+       "md5": "ba078e0ddd59cda4b6c51ea10599f49a",
+       "link": true,
+       "rounds": 1,
+       "firstPage": 11,
+       "lastPage": 11,
+       "type": "eq"
+    },
     {  "id": "devicen",
        "file": "pdfs/devicen.pdf",
        "md5": "aac6a91725435d1376c6ff492dc5cb75",

--- a/test/unit/parser_spec.js
+++ b/test/unit/parser_spec.js
@@ -1,4 +1,4 @@
-/* globals expect, it, describe, StringStream, Lexer, Linearization */
+/* globals expect, it, describe, StringStream, Lexer, Name, Linearization */
 
 'use strict';
 
@@ -76,6 +76,19 @@ describe('parser', function() {
       var result = lexer.getString();
 
       expect(result).toEqual('ABCD');
+    });
+
+    it('should handle Names with invalid usage of NUMBER SIGN (#)', function() {
+      var inputNames = ['/# 680 0 R', '/#AQwerty', '/#A<</B'];
+      var expectedNames = ['#', '#AQwerty', '#A'];
+
+      for (var i = 0, ii = inputNames.length; i < ii; i++) {
+        var input = new StringStream(inputNames[i]);
+        var lexer = new Lexer(input);
+        var result = lexer.getName();
+
+        expect(result).toEqual(Name.get(expectedNames[i]));
+      }
     });
   });
 


### PR DESCRIPTION
_This is a regression from PR #3424._

The PDF file in the referenced issue is using `Type3` fonts. In one of those, the `/CharProcs` dictionary contains an entry with the name `/#`. With the changes made in `Lexer_getName` in PR #3424, we're now incrementing the stream position more than we should for the (admittedly rare) case where a "#" character is not followed by a hexDigit.

~~What seems somewhat problematic to me, is that there was no messages printed in the console to indicate what went wrong. Hence I've also added a bit of (defensive) code to the `Type3` font loading, which should make similar issues easier to spot/debug.~~ Removed, since PR #6697 was merged.

It's unfortunate that this has been broken for close to two and a half years before the bug surfaced, but it should at least indicate that this is not a widespread issue.

Fixes #6692.
