### PR TITLE
[api-minor] Replaces UnsupportedManager with callback.

### DIFF
--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -13,8 +13,7 @@
  * limitations under the License.
  */
 /* globals ColorSpace, PDFFunction, Util, error, warn, info, isArray, isStream,
-           assert, isPDFFunction, UnsupportedManager, UNSUPPORTED_FEATURES,
-           MissingDataException */
+           assert, isPDFFunction, UNSUPPORTED_FEATURES, MissingDataException */
 
 'use strict';
 
@@ -43,7 +42,7 @@ var Pattern = (function PatternClosure() {
   };
 
   Pattern.parseShading = function Pattern_parseShading(shading, matrix, xref,
-                                                       res) {
+                                                       res, handler) {
 
     var dict = isStream(shading) ? shading.dict : shading;
     var type = dict.get('ShadingType');
@@ -66,7 +65,8 @@ var Pattern = (function PatternClosure() {
       if (ex instanceof MissingDataException) {
         throw ex;
       }
-      UnsupportedManager.notify(UNSUPPORTED_FEATURES.shadingPattern);
+      handler.send('UnsupportedFeature',
+                   {featureId: UNSUPPORTED_FEATURES.shadingPattern});
       warn(ex);
       return new Shadings.Dummy();
     }

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 /* globals PDFJS, createPromiseCapability, LocalPdfManager, NetworkPdfManager,
-           NetworkManager, isInt, MissingPDFException,
+           NetworkManager, isInt, MissingPDFException, UNSUPPORTED_FEATURES,
            UnexpectedResponseException, PasswordException, Promise, warn,
            PasswordResponses, InvalidPDFException, UnknownErrorException,
            XRefParseException, Ref, info, globalScope, error, MessageHandler */
@@ -482,6 +482,11 @@ var WorkerMessageHandler = PDFJS.WorkerMessageHandler = {
             return; // ignoring errors from the terminated thread
           }
 
+          // For compatibility with older behavior, generating unknown
+          // unsupported feature notification on errors.
+          handler.send('UnsupportedFeature',
+                       {featureId: UNSUPPORTED_FEATURES.unknown});
+
           var minimumStackMessage =
             'worker.js: while trying to getPage() and getOperatorList()';
 
@@ -615,15 +620,6 @@ if (typeof window === 'undefined') {
   if (!('console' in globalScope)) {
     globalScope.console = workerConsole;
   }
-
-  // Listen for unsupported features so we can pass them on to the main thread.
-  PDFJS.UnsupportedManager.listen(function (msg) {
-    globalScope.postMessage({
-      targetName: 'main',
-      action: '_unsupported_feature',
-      data: msg
-    });
-  });
 
   var handler = new MessageHandler('worker', 'main', this);
   WorkerMessageHandler.setup(handler, this);

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -17,7 +17,7 @@
            Promise, PasswordResponses, PasswordException, InvalidPDFException,
            MissingPDFException, UnknownErrorException, FontFaceObject,
            loadJpegStream, createScratchCanvas, CanvasGraphics, stringToBytes,
-           UnexpectedResponseException, deprecated, UnsupportedManager */
+           UnexpectedResponseException, deprecated */
 
 'use strict';
 
@@ -447,6 +447,12 @@ var PDFDocumentLoadingTask = (function PDFDocumentLoadingTaskClosure() {
      * an {Object} with the properties: {number} loaded and {number} total.
      */
     this.onProgress = null;
+
+    /**
+     * Callback to when unsupported feature is used. The callback receives
+     * an {PDFJS.UNSUPPORTED_FEATURES} argument.
+     */
+    this.onUnsupportedFeature = null;
   }
 
   PDFDocumentLoadingTask.prototype =
@@ -1214,9 +1220,6 @@ var PDFWorker = (function PDFWorkerClosure() {
           messageHandler.on('console_error', function (data) {
             console.error.apply(console, data);
           });
-          messageHandler.on('_unsupported_feature', function (data) {
-            UnsupportedManager.notify(data);
-          });
 
           var testObj = new Uint8Array([PDFJS.postMessageTransfers ? 255 : 0]);
           // Some versions of Opera throw a DATA_CLONE_ERR on serializing the
@@ -1582,6 +1585,19 @@ var WorkerTransport = (function WorkerTransportClosure() {
         } else {
           error(data.error);
         }
+      }, this);
+
+      messageHandler.on('UnsupportedFeature',
+          function transportUnsupportedFeature(data) {
+        if (this.destroyed) {
+          return; // Ignore any pending requests if the worker was terminated.
+        }
+        var featureId = data.featureId;
+        var loadingTask = this.loadingTask;
+        if (loadingTask.onUnsupportedFeature) {
+          loadingTask.onUnsupportedFeature(featureId);
+        }
+        PDFJS.UnsupportedManager.notify(featureId);
       }, this);
 
       messageHandler.on('JpegDecode', function(data) {
@@ -1999,4 +2015,24 @@ var InternalRenderTask = (function InternalRenderTaskClosure() {
   };
 
   return InternalRenderTask;
+})();
+
+/**
+ * (Deprecated) Global observer of unsupported feature usages. Use
+ * onUnsupportedFeature callback of the {PDFDocumentLoadingTask} instance.
+ */
+PDFJS.UnsupportedManager = (function UnsupportedManagerClosure() {
+  var listeners = [];
+  return {
+    listen: function (cb) {
+      deprecated('Global UnsupportedManager.listen is used: ' +
+                 ' use PDFDocumentLoadingTask.onUnsupportedFeature instead');
+      listeners.push(cb);
+    },
+    notify: function (featureId) {
+      for (var i = 0, ii = listeners.length; i < ii; i++) {
+        listeners[i](featureId);
+      }
+    }
+  };
 })();

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -15,7 +15,7 @@
 /* globals IDENTITY_MATRIX, FONT_IDENTITY_MATRIX, TextRenderingMode, ImageData,
            ImageKind, PDFJS, Uint32ArrayView, error, WebGLUtils, OPS, warn,
            shadow, isNum, Util, TilingPattern, getShadingPatternFromIR, isArray,
-           info, assert, UnsupportedManager, UNSUPPORTED_FEATURES */
+           info, assert */
 
 'use strict';
 
@@ -2092,7 +2092,6 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     },
 
     paintXObject: function CanvasGraphics_paintXObject() {
-      UnsupportedManager.notify(UNSUPPORTED_FEATURES.unknown);
       warn('Unsupported \'paintXObject\' command.');
     },
 

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -236,7 +236,6 @@ function error(msg) {
     console.log('Error: ' + msg);
     console.log(backtrace());
   }
-  UnsupportedManager.notify(UNSUPPORTED_FEATURES.unknown);
   throw new Error(msg);
 }
 
@@ -262,22 +261,6 @@ var UNSUPPORTED_FEATURES = PDFJS.UNSUPPORTED_FEATURES = {
   shadingPattern: 'shadingPattern',
   font: 'font'
 };
-
-var UnsupportedManager = PDFJS.UnsupportedManager =
-  (function UnsupportedManagerClosure() {
-  var listeners = [];
-  return {
-    listen: function (cb) {
-      listeners.push(cb);
-    },
-    notify: function (featureId) {
-      warn('Unsupported feature "' + featureId + '"');
-      for (var i = 0, ii = listeners.length; i < ii; i++) {
-        listeners[i](featureId);
-      }
-    }
-  };
-})();
 
 // Combines two URLs. The baseUrl shall be absolute URL. If the url is an
 // absolute URL, it will be returned as is.

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -599,6 +599,9 @@ var PDFViewerApplication = {
       self.progress(progressData.loaded / progressData.total);
     };
 
+    // Listen for unsupported features to trigger the fallback UI.
+    loadingTask.onUnsupportedFeature = this.fallback.bind(this);
+
     var result = loadingTask.promise.then(
       function getDocumentCallback(pdfDocument) {
         self.load(pdfDocument, scale);
@@ -1464,10 +1467,6 @@ function webViewerInitialized() {
   if (PDFViewerApplication.supportsIntegratedFind) {
     document.getElementById('viewFind').classList.add('hidden');
   }
-
-  // Listen for unsupported features to trigger the fallback UI.
-  PDFJS.UnsupportedManager.listen(
-    PDFViewerApplication.fallback.bind(PDFViewerApplication));
 
   // Suppress context menus for some controls
   document.getElementById('scaleSelect').oncontextmenu = noContextMenuHandler;


### PR DESCRIPTION
UnsupportedManager is only global variable we are using and blocks SharedWorker refactoring. This PR deprecated this API and (temporary?) replaces with PDFDocumentLoadingTask callback.

I don't think we need to use it at the error() function -- we need to pass or exception to the UI via promises, or handle them in the evaluator and send UnsupportedFeature message if needed.
