### PR TITLE
Replace `font.bindDOM()` with `font.createFontFaceRule()` in the `FontLoader` for MOZCENTRAL specific code (PR 6571 follow-up)

### DIFF
--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -280,7 +280,10 @@ FontLoader.prototype = {
 //    }
 //
 //    font.attached = true;
-//    font.bindDOM()
+//    var rule = font.createFontFaceRule();
+//    if (rule) {
+//      this.insertRule(rule);
+//    }
 //  }
 //
 //  setTimeout(callback);


### PR DESCRIPTION
This is a follow-up to PR #6571, and fixes font loading in the `MOZCENTRAL` version.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1228603#c2.
