### PR TITLE
[api-minor] Move annotation DOM manipulation logic to src/display/annotation_layer.js

### DIFF
--- a/examples/acroforms/index.html
+++ b/examples/acroforms/index.html
@@ -12,7 +12,7 @@
   <script src="../../src/display/pattern_helper.js"></script>
   <script src="../../src/display/font_loader.js"></script>
   <script src="../../src/display/dom_utils.js"></script>
-  <script src="../../src/display/annotation_helper.js"></script>
+  <script src="../../src/display/annotation_layer.js"></script>
   <script src="../../src/display/text_layer.js"></script>
 
   <script>

--- a/examples/helloworld/index.html
+++ b/examples/helloworld/index.html
@@ -12,7 +12,7 @@
   <script src="../../src/display/pattern_helper.js"></script>
   <script src="../../src/display/font_loader.js"></script>
   <script src="../../src/display/dom_utils.js"></script>
-  <script src="../../src/display/annotation_helper.js"></script>
+  <script src="../../src/display/annotation_layer.js"></script>
   <script src="../../src/display/text_layer.js"></script>
 
   <script>

--- a/make.js
+++ b/make.js
@@ -531,7 +531,7 @@ target.bundle = function(args) {
     'display/pattern_helper.js',
     'display/font_loader.js',
     'display/dom_utils.js',
-    'display/annotation_helper.js',
+    'display/annotation_layer.js',
     'display/text_layer.js',
     'display/svg.js'
   ]);

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -19,7 +19,7 @@
 
 var ANNOT_MIN_SIZE = 10; // px
 
-var AnnotationUtils = (function AnnotationUtilsClosure() {
+var AnnotationLayer = (function AnnotationLayerClosure() {
   // TODO(mack): This dupes some of the logic in CanvasGraphics.setFont()
   function setTextStyles(element, item, fontObj) {
 
@@ -286,4 +286,5 @@ var AnnotationUtils = (function AnnotationUtilsClosure() {
     getHtmlElement: getHtmlElement
   };
 })();
-PDFJS.AnnotationUtils = AnnotationUtils;
+
+PDFJS.AnnotationLayer = AnnotationLayer;

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -324,8 +324,34 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
     }
   }
 
+  function render(viewport, div, annotations, page, linkService) {
+    for (var i = 0, ii = annotations.length; i < ii; i++) {
+      var data = annotations[i];
+      if (!data || !data.hasHtml) {
+        continue;
+      }
+
+      var element = getHtmlElement(data, page, viewport, linkService);
+      div.appendChild(element);
+    }
+  }
+
+  function update(viewport, div, annotations) {
+    for (var i = 0, ii = annotations.length; i < ii; i++) {
+      var data = annotations[i];
+      var element = div.querySelector(
+        '[data-annotation-id="' + data.id + '"]');
+      if (element) {
+        CustomStyle.setProp('transform', element,
+          'matrix(' + viewport.transform.join(',') + ')');
+      }
+    }
+    div.removeAttribute('hidden');
+  }
+
   return {
-    getHtmlElement: getHtmlElement
+    render: render,
+    update: update
   };
 })();
 

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -47,10 +47,8 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
     var width = data.rect[2] - data.rect[0];
     var height = data.rect[3] - data.rect[1];
 
-    // ID
     container.setAttribute('data-annotation-id', data.id);
 
-    // Normalize rectangle
     data.rect = Util.normalizeRect([
       data.rect[0],
       page.view[3] - data.rect[1] + page.view[1],
@@ -58,15 +56,12 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
       page.view[3] - data.rect[3] + page.view[1]
     ]);
 
-    // Transform
     CustomStyle.setProp('transform', container,
                         'matrix(' + viewport.transform.join(',') + ')');
     CustomStyle.setProp('transformOrigin', container,
                         -data.rect[0] + 'px ' + -data.rect[1] + 'px');
 
-    // Border
     if (data.borderStyle.width > 0) {
-      // Border width
       container.style.borderWidth = data.borderStyle.width + 'px';
       if (data.borderStyle.style !== AnnotationBorderStyleType.UNDERLINE) {
         // Underline styles only have a bottom border, so we do not need
@@ -76,7 +71,6 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
         height = height - 2 * data.borderStyle.width;
       }
 
-      // Horizontal and vertical border radius
       var horizontalRadius = data.borderStyle.horizontalCornerRadius;
       var verticalRadius = data.borderStyle.verticalCornerRadius;
       if (horizontalRadius > 0 || verticalRadius > 0) {
@@ -84,7 +78,6 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
         CustomStyle.setProp('borderRadius', container, radius);
       }
 
-      // Border style
       switch (data.borderStyle.style) {
         case AnnotationBorderStyleType.SOLID:
           container.style.borderStyle = 'solid';
@@ -110,7 +103,6 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
           break;
       }
 
-      // Border color
       if (data.color) {
         container.style.borderColor =
           Util.makeCssRgb(data.color[0] | 0,
@@ -122,11 +114,9 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
       }
     }
 
-    // Position
     container.style.left = data.rect[0] + 'px';
     container.style.top = data.rect[1] + 'px';
 
-    // Size
     container.style.width = width + 'px';
     container.style.height = height + 'px';
 

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -22,7 +22,6 @@ var ANNOT_MIN_SIZE = 10; // px
 var AnnotationLayer = (function AnnotationLayerClosure() {
   // TODO(mack): This dupes some of the logic in CanvasGraphics.setFont()
   function setTextStyles(element, item, fontObj) {
-
     var style = element.style;
     style.fontSize = item.fontSize + 'px';
     style.direction = item.fontDirection < 0 ? 'rtl': 'ltr';
@@ -43,34 +42,34 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
     style.fontFamily = fontFamily + fallbackName;
   }
 
-  function initContainer(item) {
+  function getContainer(data) {
     var container = document.createElement('section');
     var cstyle = container.style;
-    var width = item.rect[2] - item.rect[0];
-    var height = item.rect[3] - item.rect[1];
+    var width = data.rect[2] - data.rect[0];
+    var height = data.rect[3] - data.rect[1];
 
     // Border
-    if (item.borderStyle.width > 0) {
+    if (data.borderStyle.width > 0) {
       // Border width
-      container.style.borderWidth = item.borderStyle.width + 'px';
-      if (item.borderStyle.style !== AnnotationBorderStyleType.UNDERLINE) {
+      container.style.borderWidth = data.borderStyle.width + 'px';
+      if (data.borderStyle.style !== AnnotationBorderStyleType.UNDERLINE) {
         // Underline styles only have a bottom border, so we do not need
         // to adjust for all borders. This yields a similar result as
         // Adobe Acrobat/Reader.
-        width = width - 2 * item.borderStyle.width;
-        height = height - 2 * item.borderStyle.width;
+        width = width - 2 * data.borderStyle.width;
+        height = height - 2 * data.borderStyle.width;
       }
 
       // Horizontal and vertical border radius
-      var horizontalRadius = item.borderStyle.horizontalCornerRadius;
-      var verticalRadius = item.borderStyle.verticalCornerRadius;
+      var horizontalRadius = data.borderStyle.horizontalCornerRadius;
+      var verticalRadius = data.borderStyle.verticalCornerRadius;
       if (horizontalRadius > 0 || verticalRadius > 0) {
         var radius = horizontalRadius + 'px / ' + verticalRadius + 'px';
         CustomStyle.setProp('borderRadius', container, radius);
       }
 
       // Border style
-      switch (item.borderStyle.style) {
+      switch (data.borderStyle.style) {
         case AnnotationBorderStyleType.SOLID:
           container.style.borderStyle = 'solid';
           break;
@@ -96,11 +95,11 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
       }
 
       // Border color
-      if (item.color) {
+      if (data.color) {
         container.style.borderColor =
-          Util.makeCssRgb(item.color[0] | 0,
-                          item.color[1] | 0,
-                          item.color[2] | 0);
+          Util.makeCssRgb(data.color[0] | 0,
+                          data.color[1] | 0,
+                          data.color[2] | 0);
       } else {
         // Transparent (invisible) border, so do not draw it at all.
         container.style.borderWidth = 0;
@@ -147,7 +146,7 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
       rect[2] = rect[0] + (rect[3] - rect[1]); // make it square
     }
 
-    var container = initContainer(item);
+    var container = getContainer(item);
     container.className = 'annotText';
 
     var image  = document.createElement('img');
@@ -254,7 +253,7 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
   }
 
   function getHtmlElementForLinkAnnotation(item) {
-    var container = initContainer(item);
+    var container = getContainer(item);
     container.className = 'annotLink';
 
     var link = document.createElement('a');

--- a/test/font/font_test.html
+++ b/test/font/font_test.html
@@ -36,7 +36,7 @@
   <script src="../../src/core/parser.js"></script>
   <script src="../../src/core/ps_parser.js"></script>
   <script src="../../src/display/pattern_helper.js"></script>
-  <script src="../../src/display/annotation_helper.js"></script>
+  <script src="../../src/display/annotation_layer.js"></script>
   <script src="../../src/display/text_layer.js"></script>
   <script src="../../src/core/stream.js"></script>
   <script src="../../src/core/worker.js"></script>

--- a/test/test_slave.html
+++ b/test/test_slave.html
@@ -26,7 +26,7 @@ limitations under the License.
     <script src="../src/display/pattern_helper.js"></script>
     <script src="../src/display/font_loader.js"></script>
     <script src="../src/display/dom_utils.js"></script>
-    <script src="../src/display/annotation_helper.js"></script>
+    <script src="../src/display/annotation_layer.js"></script>
     <script src="../src/display/text_layer.js"></script>
     <script src="driver.js"></script>
   </head>

--- a/test/unit/unit_test.html
+++ b/test/unit/unit_test.html
@@ -37,7 +37,7 @@
   <script src="../../src/display/pattern_helper.js"></script>
   <script src="../../src/display/font_loader.js"></script>
   <script src="../../src/display/dom_utils.js"></script>
-  <script src="../../src/display/annotation_helper.js"></script>
+  <script src="../../src/display/annotation_layer.js"></script>
   <script src="../../src/display/text_layer.js"></script>
   <script src="../../src/core/stream.js"></script>
   <script src="../../src/core/worker.js"></script>

--- a/web/annotations_layer_builder.css
+++ b/web/annotations_layer_builder.css
@@ -13,6 +13,10 @@
  * limitations under the License.
  */
 
+.annotationLayer section {
+  position: absolute;
+}
+
 .annotationLayer .annotLink > a:hover {
   opacity: 0.2;
   background: #ff0;

--- a/web/annotations_layer_builder.js
+++ b/web/annotations_layer_builder.js
@@ -105,7 +105,7 @@ var AnnotationsLayerBuilder = (function AnnotationsLayerBuilderClosure() {
               continue;
             }
 
-            element = PDFJS.AnnotationUtils.getHtmlElement(data,
+            element = PDFJS.AnnotationLayer.getHtmlElement(data,
               pdfPage.commonObjs);
             element.setAttribute('data-annotation-id', data.id);
             if (typeof mozL10n !== 'undefined') {

--- a/web/annotations_layer_builder.js
+++ b/web/annotations_layer_builder.js
@@ -40,6 +40,7 @@ var AnnotationsLayerBuilder = (function AnnotationsLayerBuilderClosure() {
 
     this.div = null;
   }
+
   AnnotationsLayerBuilder.prototype =
       /** @lends AnnotationsLayerBuilder.prototype */ {
 
@@ -81,8 +82,6 @@ var AnnotationsLayerBuilder = (function AnnotationsLayerBuilderClosure() {
       pdfPage.getAnnotations(getAnnotationsParams).then(
           function (annotationsData) {
         viewport = viewport.clone({ dontFlip: true });
-        var transform = viewport.transform;
-        var transformStr = 'matrix(' + transform.join(',') + ')';
         var data, element, i, ii;
 
         if (self.div) {
@@ -91,9 +90,10 @@ var AnnotationsLayerBuilder = (function AnnotationsLayerBuilderClosure() {
           for (i = 0, ii = annotationsData.length; i < ii; i++) {
             data = annotationsData[i];
             element = self.div.querySelector(
-                '[data-annotation-id="' + data.id + '"]');
+              '[data-annotation-id="' + data.id + '"]');
             if (element) {
-              CustomStyle.setProp('transform', element, transformStr);
+              CustomStyle.setProp('transform', element,
+                'matrix(' + viewport.transform.join(',') + ')');
             }
           }
           // See PDFPageView.reset()
@@ -105,28 +105,11 @@ var AnnotationsLayerBuilder = (function AnnotationsLayerBuilderClosure() {
               continue;
             }
 
-            element = PDFJS.AnnotationLayer.getHtmlElement(data,
-              pdfPage.commonObjs);
-            element.setAttribute('data-annotation-id', data.id);
+            element = PDFJS.AnnotationLayer.getHtmlElement(data, pdfPage,
+                                                           viewport);
             if (typeof mozL10n !== 'undefined') {
               mozL10n.translate(element);
             }
-
-            var rect = data.rect;
-            var view = pdfPage.view;
-            rect = PDFJS.Util.normalizeRect([
-              rect[0],
-                view[3] - rect[1] + view[1],
-              rect[2],
-                view[3] - rect[3] + view[1]
-            ]);
-            element.style.left = rect[0] + 'px';
-            element.style.top = rect[1] + 'px';
-            element.style.position = 'absolute';
-
-            CustomStyle.setProp('transform', element, transformStr);
-            var transformOriginStr = -rect[0] + 'px ' + -rect[1] + 'px';
-            CustomStyle.setProp('transformOrigin', element, transformOriginStr);
 
             if (data.subtype === 'Link' && !data.url) {
               var link = element.getElementsByTagName('a')[0];
@@ -159,6 +142,7 @@ var AnnotationsLayerBuilder = (function AnnotationsLayerBuilderClosure() {
       this.div.setAttribute('hidden', 'true');
     }
   };
+
   return AnnotationsLayerBuilder;
 })();
 

--- a/web/annotations_layer_builder.js
+++ b/web/annotations_layer_builder.js
@@ -27,8 +27,6 @@
  * @class
  */
 var AnnotationsLayerBuilder = (function AnnotationsLayerBuilderClosure() {
-  var CustomStyle = PDFJS.CustomStyle;
-
   /**
    * @param {AnnotationsLayerBuilderOptions} options
    * @constructs AnnotationsLayerBuilder
@@ -56,22 +54,14 @@ var AnnotationsLayerBuilder = (function AnnotationsLayerBuilderClosure() {
 
       this.pdfPage.getAnnotations(parameters).then(function (annotations) {
         viewport = viewport.clone({ dontFlip: true });
-        var data, element, i, ii;
 
         if (self.div) {
           // If an annotationLayer already exists, refresh its children's
           // transformation matrices.
-          for (i = 0, ii = annotations.length; i < ii; i++) {
-            data = annotations[i];
-            element = self.div.querySelector(
-              '[data-annotation-id="' + data.id + '"]');
-            if (element) {
-              CustomStyle.setProp('transform', element,
-                'matrix(' + viewport.transform.join(',') + ')');
-            }
-          }
-          self.div.removeAttribute('hidden');
+          PDFJS.AnnotationLayer.update(viewport, self.div, annotations);
         } else {
+          // Create an annotation layer div and render the annotations
+          // if there is at least one annotation.
           if (annotations.length === 0) {
             return;
           }
@@ -80,19 +70,10 @@ var AnnotationsLayerBuilder = (function AnnotationsLayerBuilderClosure() {
           self.div.className = 'annotationLayer';
           self.pageDiv.appendChild(self.div);
 
-          for (i = 0, ii = annotations.length; i < ii; i++) {
-            data = annotations[i];
-            if (!data || !data.hasHtml) {
-              continue;
-            }
-
-            element = PDFJS.AnnotationLayer.getHtmlElement(data, self.pdfPage,
-                                                           viewport,
-                                                           self.linkService);
-            if (typeof mozL10n !== 'undefined') {
-              mozL10n.translate(element);
-            }
-            self.div.appendChild(element);
+          PDFJS.AnnotationLayer.render(viewport, self.div, annotations,
+                                       self.pdfPage, self.linkService);
+          if (typeof mozL10n !== 'undefined') {
+            mozL10n.translate(self.div);
           }
         }
       });

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -275,7 +275,7 @@ var PDFPageView = (function PDFPageViewClosure() {
       }
 
       if (redrawAnnotations && this.annotationLayer) {
-        this.annotationLayer.setupAnnotations(this.viewport, 'display');
+        this.annotationLayer.render(this.viewport, 'display');
       }
     },
 
@@ -507,7 +507,7 @@ var PDFPageView = (function PDFPageViewClosure() {
           this.annotationLayer = this.annotationsLayerFactory.
             createAnnotationsLayerBuilder(div, this.pdfPage);
         }
-        this.annotationLayer.setupAnnotations(this.viewport, 'display');
+        this.annotationLayer.render(this.viewport, 'display');
       }
       div.setAttribute('data-loaded', true);
 

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -61,7 +61,7 @@ See https://github.com/adobe-type-tools/cmap-resources
     <script src="../src/display/pattern_helper.js"></script>
     <script src="../src/display/font_loader.js"></script>
     <script src="../src/display/dom_utils.js"></script>
-    <script src="../src/display/annotation_helper.js"></script>
+    <script src="../src/display/annotation_layer.js"></script>
     <script src="../src/display/text_layer.js"></script>
     <script>PDFJS.workerSrc = '../src/worker_loader.js';</script>
 <!--#endif-->


### PR DESCRIPTION
Fixes #6689 (as the testing part is tracked in #6673). It is also another part of #5218.

I have tested this PR with a set of 20 PDF files with various kinds of annotations (Link, Text, Widget, et cetera) and found no changes in rendering, behavior or printing.

_Note that I intentionally used multiple commits to make reviewing easier and to split renaming code and moving code as much as possible._
