### PR TITLE
Fixes canvas state after smask group ends.

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -973,6 +973,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
 
       composeSMask(this.ctx, this.current.activeSMask, groupCtx);
       this.ctx.restore();
+      copyCtxState(groupCtx, this.ctx);
     },
     save: function CanvasGraphics_save() {
       this.ctx.save();

--- a/test/pdfs/issue6032.pdf.link
+++ b/test/pdfs/issue6032.pdf.link
@@ -1,0 +1,1 @@
+http://web.archive.org/web/20151203200805/http://www.barkleyus.com/files/moonshot_techroadmap_poster.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1324,6 +1324,14 @@
        "type": "eq"
     },
     {
+      "id": "issue6032",
+      "file": "pdfs/issue6032.pdf",
+      "md5": "88b4cc989f5a1e072b992dec5635e83c",
+      "rounds": 1,
+      "link": true,
+      "type": "eq"
+    },
+    {
       "id": "issue6019-text",
       "file": "pdfs/issue6019.pdf",
       "md5": "7a2e5dda3b0fc5c2e9060e378a8cdc4e",


### PR DESCRIPTION
Fixes #5712 and #6032 regression (Probably more). Problem was that smask state was set after fill/stroke colors are changed.
