### PR TITLE
Allow range responses to non-range requests

### DIFF
--- a/src/core/network.js
+++ b/src/core/network.js
@@ -222,7 +222,11 @@ var NetworkManager = (function NetworkManagerClosure() {
           xhrStatus === OK_RESPONSE &&
           pendingRequest.expectedStatus === PARTIAL_CONTENT_RESPONSE;
 
-      if (!ok_response_on_range_request &&
+      var range_response_on_full_request =
+          xhrStatus === PARTIAL_CONTENT_RESPONSE &&
+          pendingRequest.expectedStatus === OK_RESPONSE;
+
+      if (!ok_response_on_range_request && !range_response_on_full_request &&
           xhrStatus !== pendingRequest.expectedStatus) {
         if (pendingRequest.onError) {
           pendingRequest.onError(xhr.status);


### PR DESCRIPTION
We have come across some servers which break the HTTP spec and return a 206 response (with range headers specifying that it's returned the entire file) rather than a 200 response to GET requests, even if the GET request didn't specify a range header.

This works around it by adding a new special case to the response handling code.
