### PR TITLE
Let Travis lint using `node make lint`, instead of a hard-coded command

### DIFF
--- a/make.js
+++ b/make.js
@@ -1492,9 +1492,11 @@ target.lint = function() {
   var options = '--extra-ext .jsm';
 
   var exitCode = exec('"' + jshintPath + '" ' + options + ' .').code;
-  if (exitCode === 0) {
-    echo('files checked, no errors found');
+  if (exitCode !== 0) {
+    exit(1);
   }
+
+  echo('files checked, no errors found');
 };
 
 //

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "yargs": "^3.14.0"
   },
   "scripts": {
-    "test": "node ./node_modules/.bin/jshint --extra-ext .jsm ."
+    "test": "node make lint"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Re: https://github.com/mozilla/pdf.js/pull/6683#discussion_r46820487.

This seems to work fine locally when running `npm test`, let's see if Travis agrees.
