### PR TITLE
[Firefox] Prevent internal links from displaying "resource://pdf.js/web/" on hover, by tweaking the fallback case in `PDFLinkService_getDestinationHash`

### DIFF
--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -154,7 +154,7 @@ var PDFLinkService = (function () {
           return pdfOpenParams;
         }
       }
-      return '';
+      return this.getAnchorUrl('');
     },
 
     /**


### PR DESCRIPTION
An example where this is happening is http://www.nyc.gov/html/dcp/pdf/zone/map8c.pdf, check the link just below "Effective Date(s) of Rezoning:" on the right middle of the page.
