### PR TITLE
Reset the `styleElement` when clearing out loaded fonts (bug 1232071)

### DIFF
--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -49,6 +49,7 @@ FontLoader.prototype = {
     var styleElement = this.styleElement;
     if (styleElement) {
       styleElement.parentNode.removeChild(styleElement);
+      styleElement = this.styleElement = null;
     }
 //#if !(MOZCENTRAL)
     this.nativeFontFaces.forEach(function(nativeFontFace) {


### PR DESCRIPTION
_This is a follow-up to PR #6571._

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1232071.
