### PR TITLE
Remove the superfluous `PDFJS.disableFontFace = false;` statement at the top of font_loader.js (issue 6742)

### DIFF
--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -17,8 +17,6 @@
 
 'use strict';
 
-PDFJS.disableFontFace = false;
-
 function FontLoader(docId) {
   this.docId = docId;
   this.styleElement = null;


### PR DESCRIPTION
Fixes #6742.
