### PR TITLE
Implement constants for all annotation types

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -515,6 +515,7 @@ var WidgetAnnotation = (function WidgetAnnotationClosure() {
     var dict = params.dict;
     var data = this.data;
 
+    data.annotationType = AnnotationType.WIDGET;
     data.fieldValue = stringToPDFString(
       Util.getInheritableProperty(dict, 'V') || '');
     data.alternativeText = stringToPDFString(dict.get('TU') || '');
@@ -573,7 +574,6 @@ var TextWidgetAnnotation = (function TextWidgetAnnotationClosure() {
     WidgetAnnotation.call(this, params);
 
     this.data.textAlignment = Util.getInheritableProperty(params.dict, 'Q');
-    this.data.annotationType = AnnotationType.WIDGET;
     this.data.hasHtml = !this.data.hasAppearance && !!this.data.fieldValue;
   }
 

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -43,9 +43,32 @@ var ImageKind = {
 };
 
 var AnnotationType = {
-  WIDGET: 1,
-  TEXT: 2,
-  LINK: 3
+  TEXT: 1,
+  LINK: 2,
+  FREETEXT: 3,
+  LINE: 4,
+  SQUARE: 5,
+  CIRCLE: 6,
+  POLYGON: 7,
+  POLYLINE: 8,
+  HIGHLIGHT: 9,
+  UNDERLINE: 10,
+  SQUIGGLY: 11,
+  STRIKEOUT: 12,
+  STAMP: 13,
+  CARET: 14,
+  INK: 15,
+  POPUP: 16,
+  FILEATTACHMENT: 17,
+  SOUND: 18,
+  MOVIE: 19,
+  WIDGET: 20,
+  SCREEN: 21,
+  PRINTERMARK: 22,
+  TRAPNET: 23,
+  WATERMARK: 24,
+  THREED: 25,
+  REDACT: 26
 };
 
 var AnnotationFlag = {


### PR DESCRIPTION
Now we have a full list of all possible annotation types and the numbering corresponds to the order in the specification. Not only is this more consistent and complete, it also prevents having to add these constants when a new annotation type is implemented.

Additionally fix an issue where a regular Widget annotation would not have `data.annotationType` set. It was only set for a TextWidgetAnnotation, but instead move it to the base Widget annotation class to add it for all Widget annotations (since TextWidgetAnnotation inherits from WidgetAnnotation it will have it too).

This is another part of #5218. I have tested this PR with a set of 20 PDF files with various kinds of annotations (Link, Text, Widget, et cetera) and found no changes in rendering, behavior or printing.
