### PR TITLE
Fix incorrect position of text widget

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -123,13 +123,8 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
     return container;
   }
 
-  function getHtmlElementForTextWidgetAnnotation(item, page) {
-    var element = document.createElement('div');
-    var width = item.rect[2] - item.rect[0];
-    var height = item.rect[3] - item.rect[1];
-    element.style.width = width + 'px';
-    element.style.height = height + 'px';
-    element.style.display = 'table';
+  function getHtmlElementForTextWidgetAnnotation(item, page, viewport) {
+    var container = getContainer(item, page, viewport);
 
     var content = document.createElement('div');
     content.textContent = item.fieldValue;
@@ -142,9 +137,9 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
       page.commonObjs.getData(item.fontRefName) : null;
     setTextStyles(content, item, fontObj);
 
-    element.appendChild(content);
+    container.appendChild(content);
 
-    return element;
+    return container;
   }
 
   function getHtmlElementForTextAnnotation(item, page, viewport) {
@@ -313,7 +308,7 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
   function getHtmlElement(data, page, viewport, linkService) {
     switch (data.annotationType) {
       case AnnotationType.WIDGET:
-        return getHtmlElementForTextWidgetAnnotation(data, page);
+        return getHtmlElementForTextWidgetAnnotation(data, page, viewport);
       case AnnotationType.TEXT:
         return getHtmlElementForTextAnnotation(data, page, viewport);
       case AnnotationType.LINK:


### PR DESCRIPTION
While working on rebasing #6172 found this bug.
I think it is regression from #6714

Testing file: https://drive.google.com/file/d/0B6YhVF9p-y2AYmtDbGxUX2lUQkE/view?usp=sharing

Before: (Note the position of text 123)
<img width="481" alt="screen shot 2015-12-16 at 11 25 32 am" src="https://cloud.githubusercontent.com/assets/1201310/11826059/cbc01bcc-a3e7-11e5-8841-94cbb868a376.png">

After: 
<img width="471" alt="screen shot 2015-12-16 at 11 25 51 am" src="https://cloud.githubusercontent.com/assets/1201310/11826061/cf4df41c-a3e7-11e5-9832-0cb4e203136d.png">
