### PR TITLE
Only export `Uint32ArrayView` when it's actually defined, to prevent breaking e.g. the Firefox addon/built-in version

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -631,6 +631,8 @@ var Uint32ArrayView = (function Uint32ArrayViewClosure() {
 
   return Uint32ArrayView;
 })();
+
+exports.Uint32ArrayView = Uint32ArrayView;
 //#else
 //PDFJS.hasCanvasTypedArrays = true;
 //#endif
@@ -1663,7 +1665,6 @@ exports.PasswordResponses = PasswordResponses;
 exports.StatTimer = StatTimer;
 exports.StreamType = StreamType;
 exports.TextRenderingMode = TextRenderingMode;
-exports.Uint32ArrayView = Uint32ArrayView;
 exports.UnexpectedResponseException = UnexpectedResponseException;
 exports.UnknownErrorException = UnknownErrorException;
 exports.Util = Util;


### PR DESCRIPTION
_This is a follow-up to PR #6683._

The Firefox addon fails with `ReferenceError: Uint32ArrayView is not defined`.
