### PR TITLE
Remove unused variables

### DIFF
--- a/external/builder/test.js
+++ b/external/builder/test.js
@@ -6,7 +6,6 @@ require('shelljs/make');
 
 var builder = require('./builder');
 var fs = require('fs');
-var path = require('path');
 
 var errors = 0;
 

--- a/external/umdutils/verifier.js
+++ b/external/umdutils/verifier.js
@@ -418,7 +418,8 @@ function validateDependencies(context) {
     if (!(i in nonRoots)) {
       context.infoCallback('Root module: ' + i);
     }
-  }}
+  }
+}
 
 /**
  * Validates all modules/files in the specified path. The modules must be

--- a/make.js
+++ b/make.js
@@ -446,7 +446,7 @@ target.locale = function() {
 // Compresses cmap files. Ensure that Adobe cmap download and uncompressed at
 // ./external/cmaps location.
 //
-target.cmaps = function (args) {
+target.cmaps = function () {
   var CMAP_INPUT = 'external/cmaps';
   var VIEWER_CMAP_OUTPUT = 'external/bcmaps';
 
@@ -604,7 +604,7 @@ target.singlefile = function() {
 
 };
 
-function stripCommentHeaders(content, filename) {
+function stripCommentHeaders(content) {
   var notEndOfComment = '(?:[^*]|\\*(?!/))+';
   var reg = new RegExp(
     '\n/\\* Copyright' + notEndOfComment + '\\*/\\s*' +
@@ -617,7 +617,7 @@ function stripCommentHeaders(content, filename) {
 function cleanupJSSource(file) {
   var content = cat(file);
 
-  content = stripCommentHeaders(content, file);
+  content = stripCommentHeaders(content);
 
   content.to(file);
 }
@@ -1284,8 +1284,7 @@ target.botmakeref = function() {
   echo();
   echo('### Creating reference images');
 
-  var PDF_TEST = env['PDF_TEST'] || 'test_manifest.json',
-      PDF_BROWSERS = env['PDF_BROWSERS'] ||
+  var PDF_BROWSERS = env['PDF_BROWSERS'] ||
                      'resources/browser_manifests/browser_manifest.json';
 
   if (!test('-f', 'test/' + PDF_BROWSERS)) {

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS */
 
 'use strict';
 
@@ -46,7 +45,6 @@ var stringToPDFString = sharedUtil.stringToPDFString;
 var stringToUTF8String = sharedUtil.stringToUTF8String;
 var warn = sharedUtil.warn;
 var Dict = corePrimitives.Dict;
-var Name = corePrimitives.Name;
 var isDict = corePrimitives.isDict;
 var isName = corePrimitives.isName;
 var Stream = coreStream.Stream;

--- a/src/core/function.js
+++ b/src/core/function.js
@@ -987,7 +987,7 @@ var PostScriptCompiler = (function PostScriptCompilerClosure() {
       var instructions = [];
       var inputSize = domain.length >> 1, outputSize = range.length >> 1;
       var lastRegister = 0;
-      var n, j, min, max;
+      var n, j;
       var num1, num2, ast1, ast2, tmpVar, item;
       for (i = 0; i < inputSize; i++) {
         stack.push(new AstArgument(i, domain[i * 2], domain[i * 2 + 1]));

--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -889,7 +889,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
           delete pageInfo.height;
         }
         var pageSegmentFlags = data[position + 16];
-        var pageStripingInformatiom = readUint16(data, position + 17);
+        var pageStripingInformation = readUint16(data, position + 17);
         pageInfo.lossless = !!(pageSegmentFlags & 1);
         pageInfo.refinement = !!(pageSegmentFlags & 2);
         pageInfo.defaultPixelValue = (pageSegmentFlags >> 2) & 1;

--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -109,12 +109,8 @@ var JpegImage = (function jpegImage() {
 
   function decodeScan(data, offset, frame, components, resetInterval,
                       spectralStart, spectralEnd, successivePrev, successive) {
-    var precision = frame.precision;
-    var samplesPerLine = frame.samplesPerLine;
-    var scanLines = frame.scanLines;
     var mcusPerLine = frame.mcusPerLine;
     var progressive = frame.progressive;
-    var maxH = frame.maxH, maxV = frame.maxV;
 
     var startOffset = offset, bitsData = 0, bitsCount = 0;
 
@@ -622,10 +618,9 @@ var JpegImage = (function jpegImage() {
         frame.mcusPerColumn = mcusPerColumn;
       }
 
-      var offset = 0, length = data.length;
+      var offset = 0;
       var jfif = null;
       var adobe = null;
-      var pixels = null;
       var frame, resetInterval;
       var quantizationTables = [];
       var huffmanTablesAC = [], huffmanTablesDC = [];

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -85,8 +85,6 @@ var JpxImage = (function JpxImageClosure() {
           case 0x636F6C72: // 'colr'
             // Colorspaces are not used, the CS from the PDF is used.
             var method = data[position];
-            var precedence = data[position + 1];
-            var approximation = data[position + 2];
             if (method === 1) {
               // enumerated colorspace
               var colorspace = readUint32(data, position + 3);

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -2201,11 +2201,11 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       return this.cachedGetSinglePixelWidth;
     },
     getCanvasPosition: function CanvasGraphics_getCanvasPosition(x, y) {
-        var transform = this.ctx.mozCurrentTransform;
-        return [
-          transform[0] * x + transform[2] * y + transform[4],
-          transform[1] * x + transform[3] * y + transform[5]
-        ];
+      var transform = this.ctx.mozCurrentTransform;
+      return [
+        transform[0] * x + transform[2] * y + transform[4],
+        transform[1] * x + transform[3] * y + transform[5]
+      ];
     }
   };
 

--- a/src/shared/global.js
+++ b/src/shared/global.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS, global */
+/* globals global */
 
 'use strict';
 

--- a/web/overlay_manager.js
+++ b/web/overlay_manager.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals Promise */
 
 'use strict';
 

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals Promise, mozL10n, getPDFFileNameFromURL, OverlayManager */
+/* globals mozL10n, getPDFFileNameFromURL, OverlayManager */
 
 'use strict';
 

--- a/web/view_history.js
+++ b/web/view_history.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS, Promise */
 
 'use strict';
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS, PDFBug, FirefoxCom, Stats, Cache, ProgressBar,
+/* globals PDFJS, PDFBug, FirefoxCom, Stats, ProgressBar,
            DownloadManager, getFileName, getPDFFileNameFromURL,
            PDFHistory, Preferences, SidebarView, ViewHistory, Stats,
            PDFThumbnailViewer, URL, noContextMenuHandler, SecondaryToolbar,


### PR DESCRIPTION
Found by enabling JSHint's `unused` option temporarily after the UMD patch landed and manually inspecting its results. The option is not nearly ready to be enabled by default because of many false positives, but it did find some interesting things that this PR addresses.

Furthermore:
- Two minor code style issues are fixed at https://github.com/mozilla/pdf.js/pull/6765/files#diff-c661d7e5ab2accb4885eeb725f620eb3R421 and https://github.com/mozilla/pdf.js/pull/6765/files#diff-1ae2243ab84e246d9a06a6c22b5e5ad1R2204.
- One typo in a variable name has been fixed at https://github.com/mozilla/pdf.js/pull/6765/files#diff-c65ab6b0df116c73f80b52e22571eb2cR892. Note that I decided not to remove the unused variable yet since it runs `readUint16` which might change the stream and thus its behavior.
