### PR TITLE
Strip referrer from link annotation.

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -311,6 +311,11 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
       link.target = LinkTargetStringMap[PDFJS.externalLinkTarget];
     }
 
+    // Strip referrer
+    if (item.url) {
+      link.rel = PDFJS.externalLinkRel;
+    }
+
     if (!item.url) {
       if (item.action) {
         bindNamedAction(link, item.action);

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -231,6 +231,14 @@ PDFJS.externalLinkTarget = (PDFJS.externalLinkTarget === undefined ?
                             PDFJS.LinkTarget.NONE : PDFJS.externalLinkTarget);
 
 /**
+ * Specifies the |rel| attribute for external links. Defaults to stripping
+ * the referrer.
+ * @var {string}
+ */
+PDFJS.externalLinkRel = (PDFJS.externalLinkRel === undefined ?
+                         'noreferrer' : PDFJS.externalLinkRel);
+
+/**
   * Determines if we can eval strings as JS. Primarily used to improve
   * performance for font rendering.
   * @var {boolean}


### PR DESCRIPTION
Strip referrer from link annotations in documents to prevent privacy leak. Links in this test document should not leak referrers after this patch: https://tonyjin.box.com/check-referrer
