### PR TITLE
Adds/modifies examples for node.js and webpack.

### DIFF
--- a/examples/node/domstubs.js
+++ b/examples/node/domstubs.js
@@ -120,8 +120,16 @@ DOMElement.prototype = {
   },
 }
 
+global.window = global;
+
+global.navigator = { userAgent: 'node' };
+
 global.document = {
   childNodes : [],
+
+  get currentScript() {
+    return { src: '' };
+  },
 
   get documentElement() {
     return this;

--- a/examples/node/getinfo.js
+++ b/examples/node/getinfo.js
@@ -9,13 +9,11 @@
 
 var fs = require('fs');
 
-// HACK few hacks to let PDF.js be loaded not as a module in global space.
-global.window = global;
-global.navigator = { userAgent: "node" };
-global.PDFJS = {};
+// HACK adding DOMParser to read XMP metadata.
 global.DOMParser = require('./domparsermock.js').DOMParserMock;
 
-require('../../build/singlefile/build/pdf.combined.js');
+// Run `node make dist` to generate 'pdfjs-dist' npm package files.
+require('../../build/dist');
 
 // Loading file from file system into typed array
 var pdfPath = process.argv[2] || '../../web/compressed.tracemonkey-pldi-09.pdf';

--- a/examples/node/pdf2svg.js
+++ b/examples/node/pdf2svg.js
@@ -8,14 +8,10 @@
 var fs = require('fs');
 
 // HACK few hacks to let PDF.js be loaded not as a module in global space.
-global.window = global;
-global.navigator = { userAgent: 'node' };
-global.PDFJS = {};
-
 require('./domstubs.js');
 
-PDFJS.workerSrc = true;
-require('../../build/singlefile/build/pdf.combined.js');
+// Run `node make dist` to generate 'pdfjs-dist' npm package files.
+require('../../build/dist');
 
 // Loading file from file system into typed array
 var pdfPath = process.argv[2] || '../../web/compressed.tracemonkey-pldi-09.pdf';

--- a/examples/webpack/.gitignore
+++ b/examples/webpack/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/examples/webpack/README.md
+++ b/examples/webpack/README.md
@@ -1,0 +1,18 @@
+## Overview
+
+Example to demonstrate PDF.js library usage with webpack.
+
+## Getting started
+
+Build project and install the example dependencies:
+
+  $ node make dist
+  $ cd examples/webpack
+  $ npm install
+
+To build webpack bundles, run `node_modules/.bin/webpack`.  If you are running
+a web server, you can observe the build results at
+http://localhost:8888/examples/webpack/index.html
+
+See main.js and webpack.config.js files. Please notice that PDF.js packaging
+requires 'entry' loader.

--- a/examples/webpack/index.html
+++ b/examples/webpack/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>webpack example</title>
+  <script src="../../build/webpack/bundle.js"></script>
+</head>
+<body>
+  <canvas id="theCanvas"></canvas>
+</body>
+</html>

--- a/examples/webpack/main.js
+++ b/examples/webpack/main.js
@@ -1,0 +1,32 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/licenses/publicdomain/
+
+// Hello world example for webpack.
+
+require('pdfjs-dist');
+
+var pdfPath = '../helloworld/helloworld.pdf';
+
+// It is also possible to disable workers via `PDFJS.disableWorker = true`,
+// however that might degrade the UI performance in web browsers.
+
+// Loading a document.
+var loadingTask = PDFJS.getDocument(pdfPath);
+loadingTask.promise.then(function (pdfDocument) {
+  // Request a first page
+  return pdfDocument.getPage(1).then(function (pdfPage) {
+    // Display page on the existing canvas with 100% scale.
+    var viewport = pdfPage.getViewport(1.0);
+    var canvas = document.getElementById('theCanvas');
+    canvas.width = viewport.width;
+    canvas.height = viewport.height;
+    var ctx = canvas.getContext('2d');
+    var renderTask = pdfPage.render({
+      canvasContext: ctx,
+      viewport: viewport
+    });
+    return renderTask.promise;
+  });
+}).catch(function (reason) {
+  console.error('Error: ' + reason);
+});

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "webpack-pdf.js-example",
+  "version": "0.1.0",
+  "devDependencies": {
+    "webpack": "~1.12.9",
+    "entry-loader": "~0.1.0",
+    "pdfjs-dist": "../../build/dist"
+  }
+}

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -1,0 +1,20 @@
+var webpack = require('webpack');
+var path = require('path');
+
+module.exports = {
+  context: __dirname,
+  entry: './main.js',
+  output: {
+    path: path.join(__dirname, '../../build/webpack'),
+    publicPath: '../../build/webpack/',
+    filename: 'bundle.js'
+  },
+  plugins: [
+    new webpack.optimize.UglifyJsPlugin({
+      compressor: {
+        screw_ie8: true,
+        warnings: false
+      }
+    })
+  ]
+};

--- a/make.js
+++ b/make.js
@@ -149,6 +149,7 @@ target.generic = function() {
   };
   builder.build(setup);
 
+  cleanupJSSource(GENERIC_DIR + '/build/pdf.js');
   cleanupJSSource(GENERIC_DIR + '/web/viewer.js');
   cleanupCSSSource(GENERIC_DIR + '/web/viewer.css');
 };
@@ -325,6 +326,7 @@ target.dist = function() {
   var npmManifest = {
     name: DIST_NAME,
     version: VERSION,
+    main: 'build/pdf.js',
     description: DIST_DESCRIPTION,
     keywords: DIST_KEYWORDS,
     homepage: DIST_HOMEPAGE,

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "jsdoc": "^3.3.0-alpha9",
     "jshint": "~2.8.0",
     "wintersmith": "^2.0.0",
+    "node-ensure": "^0.0.0",
     "rimraf": "^2.4.1",
     "shelljs": "~0.4.0",
     "typogr": "~0.6.5",

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals NetworkManager */
+/* globals NetworkManager, module */
 
 'use strict';
 
@@ -648,7 +648,8 @@ var workerConsole = {
 
 
 // Worker thread?
-if (typeof window === 'undefined' && typeof require === 'undefined') {
+if (typeof window === 'undefined' &&
+    !(typeof module !== 'undefined' && module.require)) {
   if (!('console' in globalScope)) {
     globalScope.console = workerConsole;
   }

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -58,6 +58,14 @@ var globalScope = sharedGlobal.globalScope;
 
 var DEFAULT_RANGE_CHUNK_SIZE = 65536; // 2^16 = 65536
 
+//#if PRODUCTION && !SINGLE_FILE
+//#if GENERIC
+//#include ../src/frameworks.js
+//#else
+//var fakeWorkerFilesLoader = null;
+//#endif
+//#endif
+
 /**
  * The maximum allowed image size in total pixels e.g. width * height. Images
  * above this value will not be drawn. Use -1 for no limit.
@@ -1192,7 +1200,10 @@ var PDFWorker = (function PDFWorkerClosure() {
 //    PDFJS.fakeWorkerFilesLoadedCapability.resolve();
 //#endif
 //#if PRODUCTION && !SINGLE_FILE
-//    Util.loadScript(PDFJS.workerSrc, function() {
+//    var loader = fakeWorkerFilesLoader || function (callback) {
+//      Util.loadScript(PDFJS.workerSrc, callback);
+//    };
+//    loader(function () {
 //      PDFJS.fakeWorkerFilesLoadedCapability.resolve();
 //    });
 //#endif
@@ -1295,8 +1306,10 @@ var PDFWorker = (function PDFWorkerClosure() {
     },
 
     _setupFakeWorker: function PDFWorker_setupFakeWorker() {
-      warn('Setting up fake worker.');
-      globalScope.PDFJS.disableWorker = true;
+      if (!globalScope.PDFJS.disableWorker) {
+        warn('Setting up fake worker.');
+        globalScope.PDFJS.disableWorker = true;
+      }
 
       setupFakeWorkerGlobal().then(function () {
         if (this.destroyed) {

--- a/src/frameworks.js
+++ b/src/frameworks.js
@@ -1,0 +1,40 @@
+/* Copyright 2015 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* globals PDFJS, require, module */
+
+// included from api.js for GENERIC build
+
+'use strict';
+
+var useRequireEnsure = false;
+if (typeof module !== 'undefined' && module.require) {
+  // node.js - disable worker and set require.ensure.
+  PDFJS.disableWorker = true;
+  if (typeof require.ensure === 'undefined') {
+    require.ensure = require('node-ensure');
+  }
+  useRequireEnsure = true;
+}
+if (typeof __webpack_require__ !== 'undefined') {
+  // Webpack - get/bundle pdf.worker.js as additional file.
+  PDFJS.workerSrc = require('entry?name=[hash]-worker.js!./pdf.worker.js');
+  useRequireEnsure = true;
+}
+var fakeWorkerFilesLoader = useRequireEnsure && function (callback) {
+  require.ensure([], function () {
+    require('./pdf.worker.js');
+    callback();
+  });
+};

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -12,12 +12,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*jshint globalstrict: false */
-/* globals PDFJS */
+/* jshint globalstrict: false */
+/* globals PDFJS, global */
 
 // Initializing PDFJS global object (if still undefined)
 if (typeof PDFJS === 'undefined') {
-  (typeof window !== 'undefined' ? window : this).PDFJS = {};
+  (typeof window !== 'undefined' ? window :
+   typeof global !== 'undefined' ? global : this).PDFJS = {};
 }
 
 //#if BUNDLE_VERSION


### PR DESCRIPTION
Modifies and cleans up node.js examples to use pdfjs-dist bundle instead of pdf.combined.js

Introduces webpack example to demonstrate proper way to disconnect worker part from display modules. See examples/webpack/README.md for details.
