### PR TITLE
Remove the `hasHtml` data property from annotations

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -607,7 +607,7 @@ var TextWidgetAnnotation = (function TextWidgetAnnotationClosure() {
     WidgetAnnotation.call(this, params);
 
     this.data.textAlignment = Util.getInheritableProperty(params.dict, 'Q');
-    this.data.hasHtml = !this.data.hasAppearance && !!this.data.fieldValue;
+    this.data.showable = !this.data.hasAppearance && !!this.data.fieldValue;
   }
 
   Util.inherit(TextWidgetAnnotation, WidgetAnnotation, {
@@ -650,7 +650,6 @@ var TextAnnotation = (function TextAnnotationClosure() {
     data.annotationType = AnnotationType.TEXT;
     data.content = stringToPDFString(content || '');
     data.title = stringToPDFString(title || '');
-    data.hasHtml = true;
 
     if (data.hasAppearance) {
       data.name = 'NoIcon';
@@ -677,7 +676,6 @@ var LinkAnnotation = (function LinkAnnotationClosure() {
     var dict = params.dict;
     var data = this.data;
     data.annotationType = AnnotationType.LINK;
-    data.hasHtml = true;
 
     var action = dict.get('A');
     if (action && isDict(action)) {

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -450,6 +450,10 @@ var WidgetAnnotationElement = (function WidgetAnnotationElementClosure() {
      * @returns {HTMLSectionElement}
      */
     render: function WidgetAnnotationElement_render() {
+      if (!this.data.showable) {
+        return;
+      }
+
       var content = document.createElement('div');
       content.textContent = this.data.fieldValue;
       var textAlignment = this.data.textAlignment;
@@ -525,13 +529,8 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
       var annotationElementFactory = new AnnotationElementFactory();
 
       for (var i = 0, ii = parameters.annotations.length; i < ii; i++) {
-        var data = parameters.annotations[i];
-        if (!data || !data.hasHtml) {
-          continue;
-        }
-
         var properties = {
-          data: data,
+          data: parameters.annotations[i],
           page: parameters.page,
           viewport: parameters.viewport,
           linkService: parameters.linkService


### PR DESCRIPTION
Each annotation type in the PDF specification requires some kind of rendering and thus an HTML element, so we do not need to specify this for each annotation class.

This was only used to hide text widget annotations if there is no content. This is now done with the `showable` property that only applies to that particular annotation.

Furthermore, we can now remove the if-statement in the `render()` method. `hasHtml` is gone and `data` is always defined as each annotation has `data` because each annotation inherits from a base annotation class that specifies these (see https://github.com/mozilla/pdf.js/blob/master/src/core/annotation.js#L162). The check is therefore obsolete.
