### PR TITLE
Change test-case `issue4914` to an `annotations` test

### DIFF
--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -498,6 +498,7 @@
        "link": true,
        "lastPage": 1,
        "type": "eq",
+       "annotations": true,
        "about": "PDF with annotations, some of which have the Hidden flag set."
     },
     {  "id": "issue4665-text",


### PR DESCRIPTION
This PDF file (see issue #4914) originally regressed in PR #4318, and was subsequently fixed in PR #4915.

I added the PDF file as a (linked) test-case in PR #6481, in an effort to prevent regressions. Since we at that time didn't have the necessary framework in place, in order to correctly test annotations, this almost regressed _again_ in PR https://github.com/mozilla/pdf.js/pull/6672#issuecomment-158689392.

In that PDF file, some of the annotations are both printable and hidden, and should definitely _not_ be visible on normal display. Hence this patch, which adds the `annotations` flag to the manifest in order to ensure that those annotations won't be rendered when `intent === 'display'`.

@timvandermeij Would you mind reviewing this?
