### PR TITLE
pagechange Event out-of-range previousPageNumber

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -137,8 +137,15 @@ var PDFViewer = (function pdfViewer() {
       event.updateInProgress = this.updateInProgress;
 
       if (!(0 < val && val <= this.pagesCount)) {
-        event.pageNumber = this._currentPageNumber;
-        event.previousPageNumber = val;
+        if (val <= 0) {
+          val = 1;
+        }
+        else if (val > this.pagesCount) {
+          val = this.pagesCount;
+        }
+        event.previousPageNumber = this._currentPageNumber;
+        this._currentPageNumber = val;
+        event.pageNumber = val;
         this.container.dispatchEvent(event);
         return;
       }


### PR DESCRIPTION
If the user navigates to the first/last scene and then tries to navigate to previous/next scene respectively using the keyboard left/right
arrows, the "pagechange" event is fired but the "previousPageNumber"
parameter is out or the acceptable range (either 0 or "pagesCount + 1").

This fix just ensures that if the navigation is beyond either range, we
just clip it.
This leads to the "pagechange" event still firing but showing that the
"previousPageNumber" and "pageNumber" are the same... logic within the
event-handler should be checking for that anyway.
