### PR TITLE
Do not modify `data.rect` in `AnnotationElement_createContainer`, since that will corrupt the annotation position on subsequent calls

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -109,7 +109,9 @@ var AnnotationElement = (function AnnotationElementClosure() {
 
       container.setAttribute('data-annotation-id', data.id);
 
-      data.rect = Util.normalizeRect([
+      // Do *not* modify `data.rect`, since that will corrupt the annotation
+      // position on subsequent calls to `_createContainer` (see issue 6804).
+      var rect = Util.normalizeRect([
         data.rect[0],
         page.view[3] - data.rect[1] + page.view[1],
         data.rect[2],
@@ -119,7 +121,7 @@ var AnnotationElement = (function AnnotationElementClosure() {
       CustomStyle.setProp('transform', container,
                           'matrix(' + viewport.transform.join(',') + ')');
       CustomStyle.setProp('transformOrigin', container,
-                          -data.rect[0] + 'px ' + -data.rect[1] + 'px');
+                          -rect[0] + 'px ' + -rect[1] + 'px');
 
       if (data.borderStyle.width > 0) {
         container.style.borderWidth = data.borderStyle.width + 'px';
@@ -174,8 +176,8 @@ var AnnotationElement = (function AnnotationElementClosure() {
         }
       }
 
-      container.style.left = data.rect[0] + 'px';
-      container.style.top = data.rect[1] + 'px';
+      container.style.left = rect[0] + 'px';
+      container.style.top = rect[1] + 'px';
 
       container.style.width = width + 'px';
       container.style.height = height + 'px';
@@ -461,7 +463,7 @@ var PopupAnnotationElement = (function PopupAnnotationElementClosure() {
 
 /**
  * @class
- * @alias PopupElement 
+ * @alias PopupElement
  */
 var PopupElement = (function PopupElementClosure() {
   var BACKGROUND_ENLIGHT = 0.7;


### PR DESCRIPTION
Fixes #6804; this regressed in PR #6714.

I'm not yet sure how we're going to test this, but I'm looking into it right now.
**Edit:** I've not been able to find a way to test this, so I'm thinking that we can do without a test for now, given that the patch fixes a recent regression.
