### PR TITLE
Rename and reorder link annotation CSS

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -217,7 +217,7 @@ var LinkAnnotationElement = (function LinkAnnotationElementClosure() {
      * @returns {HTMLSectionElement}
      */
     render: function LinkAnnotationElement_render() {
-      this.container.className = 'annotLink';
+      this.container.className = 'linkAnnotation';
 
       var link = document.createElement('a');
       link.href = link.title = this.data.url || '';

--- a/test/annotation_layer_test.css
+++ b/test/annotation_layer_test.css
@@ -27,7 +27,7 @@
   position: absolute;
 }
 
-.annotationLayer .annotLink > a {
+.annotationLayer .linkAnnotation > a {
   position: absolute;
   font-size: 1em;
   top: 0;

--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -17,7 +17,20 @@
   position: absolute;
 }
 
-.annotationLayer .annotLink > a:hover {
+.annotationLayer .linkAnnotation > a {
+  position: absolute;
+  font-size: 1em;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.annotationLayer .linkAnnotation > a /* -ms-a */  {
+  background: url("data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7") 0 0 repeat;
+}
+
+.annotationLayer .linkAnnotation > a:hover {
   opacity: 0.2;
   background: #ff0;
   box-shadow: 0px 2px 10px #ff0;
@@ -54,17 +67,4 @@
 
 .annotationLayer .popup p {
   padding-top: 0.2em;
-}
-
-.annotationLayer .annotLink > a {
-  position: absolute;
-  font-size: 1em;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-}
-
-.annotationLayer .annotLink > a /* -ms-a */  {
-  background: url("data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7") 0 0 repeat;
 }


### PR DESCRIPTION
This makes the class name for Link annotations consistent with the other existing annotation types. We also reorder the link annotation CSS in `web/annotation_layer_builder.css` to put all rules together.

@Snuffleupagus Could you check this one too?
