### PR TITLE
Bug 951051 - Better crypto key length recovery.

### DIFF
--- a/test/pdfs/bug951051.pdf.link
+++ b/test/pdfs/bug951051.pdf.link
@@ -1,0 +1,1 @@
+http://web.archive.org/web/20120618235740/http://www.intreprinzatorturism.ro/wp-content/uploads/2012/05/ITPR-studiu-online-5000-turisti-straini_martie-2012.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2000,6 +2000,14 @@
       "link": true,
       "type": "eq"
     },
+    {  "id": "bug951051",
+      "file": "pdfs/bug951051.pdf",
+      "md5": "05d325a5112bd3f6022367dab7bc07b9",
+      "rounds": 1,
+      "lastPage": 1,
+      "link": true,
+      "type": "load"
+    },
     {  "id": "issue3062",
       "file": "pdfs/issue3062.pdf",
       "md5": "206715f1258f0e117df4180d98dd4d68",


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=951051

See pdf at http://www.intreprinzatorturism.ro/wp-content/uploads/2012/05/ITPR-studiu-online-5000-turisti-straini_martie-2012.pdf. From PDF32000 spec point of view Encrypt dictionary must have Length field, but it does not. Also, as insult to injury, in the specified crypt filter dictionary the Length is specified in bytes and not in bits.
