### PR TITLE
Ensure that the `baseTransform` is applied after rendering SMasks (bug 1199237)

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1004,6 +1004,10 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       composeSMask(this.ctx, this.current.activeSMask, groupCtx);
       this.ctx.restore();
       copyCtxState(groupCtx, this.ctx);
+
+      if (this.baseTransform) {
+        this.ctx.setTransform.apply(this.ctx, this.baseTransform);
+      }
     },
     save: function CanvasGraphics_save() {
       this.ctx.save();

--- a/test/pdfs/bug1199237.pdf.link
+++ b/test/pdfs/bug1199237.pdf.link
@@ -1,0 +1,1 @@
+https://bug1199237.bmoattachments.org/attachment.cgi?id=8653724

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1475,6 +1475,14 @@
       "lastPage": 1,
       "type": "eq"
     },
+    {  "id": "bug1199237",
+       "file": "pdfs/bug1199237.pdf",
+       "md5": "e9a63d3207ccc65a4955d5723546e962",
+       "rounds": 1,
+       "lastPage": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "IdentityToUnicodeMap_charCodeOf",
        "file": "pdfs/IdentityToUnicodeMap_charCodeOf.pdf",
        "md5": "da030686418c5e37d889127a05dafb83",


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1199237.
