### PR TITLE
Adds UMD header to pdf.js and pdf.worker.js files.

### DIFF
--- a/external/umdutils/verifier.js
+++ b/external/umdutils/verifier.js
@@ -55,6 +55,9 @@ var path = require('path');
  */
 function parseUmd(filePath) {
   var jscode = fs.readFileSync(filePath).toString();
+  if (/\/\*\s*umdutils\s+ignore\s*\*\//.test(jscode)) {
+    throw new Error('UMD processing ignored');
+  }
   // Extracts header and body.
   var umdStart = '\\(function\\s\\(root,\\sfactory\\)\\s\\{';
   var umdImports = '\\}\\(this,\\sfunction\\s\\(exports\\b';

--- a/make.js
+++ b/make.js
@@ -484,7 +484,7 @@ target.bundle = function(args) {
   echo();
   echo('### Bundling files into ' + BUILD_TARGET);
 
-  function bundle(filename, outfilename, files, distname) {
+  function bundle(filename, outfilename, files, distname, isMainFile) {
     var bundleContent = cat(files),
         bundleVersion = VERSION,
         bundleBuild = exec('git log --format="%h" -n 1',
@@ -511,7 +511,8 @@ target.bundle = function(args) {
                             BUNDLE_VERSION: bundleVersion,
                             BUNDLE_BUILD: bundleBuild,
                             BUNDLE_AMD_NAME: amdName,
-                            BUNDLE_JS_NAME: jsName}));
+                            BUNDLE_JS_NAME: jsName,
+                            MAIN_FILE: isMainFile}));
   }
 
   if (!test('-d', BUILD_DIR)) {
@@ -521,7 +522,6 @@ target.bundle = function(args) {
   var umd = require('./external/umdutils/verifier.js');
   var MAIN_SRC_FILES = [
     SRC_DIR + 'display/annotation_layer.js',
-    SRC_DIR + 'display/metadata.js',
     SRC_DIR + 'display/text_layer.js',
     SRC_DIR + 'display/api.js'
   ];
@@ -560,13 +560,13 @@ target.bundle = function(args) {
 
   cd(SRC_DIR);
 
-  bundle('pdf.js', ROOT_DIR + BUILD_TARGET, mainFiles, mainFileName);
+  bundle('pdf.js', ROOT_DIR + BUILD_TARGET, mainFiles, mainFileName, true);
 
   if (workerFiles) {
     var srcCopy = ROOT_DIR + BUILD_DIR + 'pdf.worker.js.temp';
     cp('pdf.js', srcCopy);
     bundle(srcCopy, ROOT_DIR + BUILD_WORKER_TARGET, workerFiles,
-           workerFileName);
+           workerFileName, false);
     rm(srcCopy);
   }
 };

--- a/make.js
+++ b/make.js
@@ -484,7 +484,7 @@ target.bundle = function(args) {
   echo();
   echo('### Bundling files into ' + BUILD_TARGET);
 
-  function bundle(filename, outfilename, files) {
+  function bundle(filename, outfilename, files, distname) {
     var bundleContent = cat(files),
         bundleVersion = VERSION,
         bundleBuild = exec('git log --format="%h" -n 1',
@@ -500,12 +500,18 @@ target.bundle = function(args) {
     // Removes AMD and CommonJS branches from UMD headers.
     bundleContent = stripUMDHeaders(bundleContent);
 
+    var amdName = 'pdfjs-dist/build/' + distname.replace(/\.js$/, '');
+    var jsName = amdName.replace(/[\-_\.\/]\w/g, function (all) {
+      return all[1].toUpperCase();
+    });
     // This just preprocesses the empty pdf.js file, we don't actually want to
     // preprocess everything yet since other build targets use this file.
     builder.preprocess(filename, outfilename, builder.merge(defines,
                            {BUNDLE: bundleContent,
                             BUNDLE_VERSION: bundleVersion,
-                            BUNDLE_BUILD: bundleBuild}));
+                            BUNDLE_BUILD: bundleBuild,
+                            BUNDLE_AMD_NAME: amdName,
+                            BUNDLE_JS_NAME: jsName}));
   }
 
   if (!test('-d', BUILD_DIR)) {
@@ -524,6 +530,9 @@ target.bundle = function(args) {
     SRC_DIR + 'core/worker.js'
   ];
 
+  var mainFileName = 'pdf.js';
+  var workerFileName = 'pdf.worker.js';
+
   // Extension does not need svg.js and network.js files.
   if (!defines.FIREFOX && !defines.MOZCENTRAL) {
     MAIN_SRC_FILES.push(SRC_DIR + 'display/svg.js');
@@ -535,6 +544,8 @@ target.bundle = function(args) {
     // the main pdf.js output.
     MAIN_SRC_FILES = MAIN_SRC_FILES.concat(WORKER_SRC_FILES);
     WORKER_SRC_FILES = null; // no need for worker file
+    mainFileName = 'pdf.combined.js';
+    workerFileName = null;
   }
 
   // Reading UMD headers and building loading orders of modules. The
@@ -549,12 +560,13 @@ target.bundle = function(args) {
 
   cd(SRC_DIR);
 
-  bundle('pdf.js', ROOT_DIR + BUILD_TARGET, mainFiles);
+  bundle('pdf.js', ROOT_DIR + BUILD_TARGET, mainFiles, mainFileName);
 
   if (workerFiles) {
     var srcCopy = ROOT_DIR + BUILD_DIR + 'pdf.worker.js.temp';
     cp('pdf.js', srcCopy);
-    bundle(srcCopy, ROOT_DIR + BUILD_WORKER_TARGET, workerFiles);
+    bundle(srcCopy, ROOT_DIR + BUILD_WORKER_TARGET, workerFiles,
+           workerFileName);
     rm(srcCopy);
   }
 };

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -20,17 +20,18 @@
   if (typeof define === 'function' && define.amd) {
     define('pdfjs/display/api', ['exports', 'pdfjs/shared/util',
       'pdfjs/display/font_loader', 'pdfjs/display/canvas',
-      'pdfjs/shared/global', 'require'], factory);
+      'pdfjs/display/metadata', 'pdfjs/shared/global', 'require'], factory);
   } else if (typeof exports !== 'undefined') {
     factory(exports, require('../shared/util.js'), require('./font_loader.js'),
-      require('./canvas.js'), require('../shared/global.js'));
+      require('./canvas.js'), require('./metadata.js'),
+      require('../shared/global.js'));
   } else {
     factory((root.pdfjsDisplayAPI = {}), root.pdfjsSharedUtil,
       root.pdfjsDisplayFontLoader, root.pdfjsDisplayCanvas,
-      root.pdfjsSharedGlobal);
+      root.pdfjsDisplayMetadata, root.pdfjsSharedGlobal);
   }
 }(this, function (exports, sharedUtil, displayFontLoader, displayCanvas,
-                  sharedGlobal, amdRequire) {
+                  displayMetadata, sharedGlobal, amdRequire) {
 
 var InvalidPDFException = sharedUtil.InvalidPDFException;
 var MessageHandler = sharedUtil.MessageHandler;
@@ -54,6 +55,7 @@ var FontFaceObject = displayFontLoader.FontFaceObject;
 var FontLoader = displayFontLoader.FontLoader;
 var CanvasGraphics = displayCanvas.CanvasGraphics;
 var createScratchCanvas = displayCanvas.createScratchCanvas;
+var Metadata = displayMetadata.Metadata;
 var PDFJS = sharedGlobal.PDFJS;
 var globalScope = sharedGlobal.globalScope;
 
@@ -1818,7 +1820,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
         then(function transportMetadata(results) {
         return {
           info: results[0],
-          metadata: (results[1] ? new PDFJS.Metadata(results[1]) : null)
+          metadata: (results[1] ? new Metadata(results[1]) : null)
         };
       });
     },

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* globals pdfjsFilePath */
 
 'use strict';
 
@@ -1177,6 +1178,18 @@ var PDFPageProxy = (function PDFPageProxyClosure() {
 var PDFWorker = (function PDFWorkerClosure() {
   var nextFakeWorkerId = 0;
 
+  function getWorkerSrc() {
+    if (PDFJS.workerSrc) {
+      return PDFJS.workerSrc;
+    }
+//#if PRODUCTION && !(MOZCENTRAL || FIREFOX)
+//  if (pdfjsFilePath) {
+//    return pdfjsFilePath.replace(/\.js$/i, '.worker.js');
+//  }
+//#endif
+    error('No PDFJS.workerSrc specified');
+  }
+
   // Loads worker code into main thread.
   function setupFakeWorkerGlobal() {
     if (!PDFJS.fakeWorkerFilesLoadedCapability) {
@@ -1201,7 +1214,7 @@ var PDFWorker = (function PDFWorkerClosure() {
 //#endif
 //#if PRODUCTION && !SINGLE_FILE
 //    var loader = fakeWorkerFilesLoader || function (callback) {
-//      Util.loadScript(PDFJS.workerSrc, callback);
+//      Util.loadScript(getWorkerSrc(), callback);
 //    };
 //    loader(function () {
 //      PDFJS.fakeWorkerFilesLoadedCapability.resolve();
@@ -1243,10 +1256,7 @@ var PDFWorker = (function PDFWorkerClosure() {
       // Uint8Array as it arrives on the worker. (Chrome added this with v.15.)
 //#if !SINGLE_FILE
       if (!globalScope.PDFJS.disableWorker && typeof Worker !== 'undefined') {
-        var workerSrc = PDFJS.workerSrc;
-        if (!workerSrc) {
-          error('No PDFJS.workerSrc specified');
-        }
+        var workerSrc = getWorkerSrc();
 
         try {
           // Some versions of FF can't create a worker on localhost, see:

--- a/src/frameworks.js
+++ b/src/frameworks.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS, require, module */
+/* globals PDFJS, require, module, requirejs */
 
 // included from api.js for GENERIC build
 
@@ -32,9 +32,16 @@ if (typeof __webpack_require__ !== 'undefined') {
   PDFJS.workerSrc = require('entry?name=[hash]-worker.js!./pdf.worker.js');
   useRequireEnsure = true;
 }
-var fakeWorkerFilesLoader = useRequireEnsure && function (callback) {
+if (typeof requirejs !== 'undefined' && requirejs.toUrl) {
+  PDFJS.workerSrc = requirejs.toUrl('pdfjs-dist/build/pdf.worker.js');
+}
+var fakeWorkerFilesLoader = useRequireEnsure ? (function (callback) {
   require.ensure([], function () {
     require('./pdf.worker.js');
     callback();
   });
-};
+}) : (typeof requirejs !== 'undefined') ? (function (callback) {
+  requirejs(['pdfjs-dist/build/pdf.worker'], function (worker) {
+    callback();
+  });
+}) : null;

--- a/src/main_loader.js
+++ b/src/main_loader.js
@@ -1,0 +1,49 @@
+/* Copyright 2015 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs/main_loader', ['exports', 'pdfjs/display/api',
+      'pdfjs/display/annotation_layer', 'pdfjs/display/text_layer',
+      'pdfjs/display/dom_utils', 'pdfjs/shared/util', 'pdfjs/shared/global'],
+      factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports, require('./display/api.js'),
+      require('./display/annotation_layer.js'),
+      require('./display/text_layer.js'), require('./display/dom_utils.js'),
+      require('./shared/util.js'), require('./shared/global.js'));
+  } else {
+    factory((root.pdfjsMainLoader = {}), root.pdfjsDisplayAPI,
+      root.pdfjsDisplayAnnotationLayer, root.pdfjsDisplayTextLayer,
+      root.pdfjsDisplayDOMUtils, root.pdfjsSharedUtil, root.pdfjsSharedGlobal);
+  }
+}(this, function (exports, displayAPI, displayAnnotationLayer,
+                  displayTextLayer, displayDOMUtils, sharedUtil, sharedGlobal) {
+
+  // Sync the exports below with ./pdf.js file/template.
+  exports.PDFJS = sharedGlobal.PDFJS;
+
+  exports.getDocument = displayAPI.getDocument;
+  exports.PDFDataRangeTransport = displayAPI.PDFDataRangeTransport;
+  exports.renderTextLayer = displayTextLayer.renderTextLayer;
+  exports.AnnotationLayer = displayAnnotationLayer.AnnotationLayer;
+  exports.CustomStyle = displayDOMUtils.CustomStyle;
+  exports.PasswordResponses = sharedUtil.PasswordResponses;
+  exports.InvalidPDFException = sharedUtil.InvalidPDFException;
+  exports.MissingPDFException = sharedUtil.MissingPDFException;
+  exports.UnexpectedResponseException = sharedUtil.UnexpectedResponseException;
+}));

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -44,4 +44,19 @@
   }).call(pdfjsLibs);
 
   exports.PDFJS = pdfjsLibs.pdfjsSharedGlobal.PDFJS;
+
+//#if MAIN_FILE
+  exports.getDocument = pdfjsLibs.pdfjsDisplayAPI.getDocument;
+  exports.PDFDataRangeTransport =
+    pdfjsLibs.pdfjsDisplayAPI.PDFDataRangeTransport;
+  exports.renderTextLayer = pdfjsLibs.pdfjsDisplayTextLayer.renderTextLayer;
+  exports.AnnotationLayer =
+    pdfjsLibs.pdfjsDisplayAnnotationLayer.AnnotationLayer;
+  exports.CustomStyle = pdfjsLibs.pdfjsDisplayDOMUtils.CustomStyle;
+  exports.PasswordResponses = pdfjsLibs.pdfjsSharedUtil.PasswordResponses;
+  exports.InvalidPDFException = pdfjsLibs.pdfjsSharedUtil.InvalidPDFException;
+  exports.MissingPDFException = pdfjsLibs.pdfjsSharedUtil.MissingPDFException;
+  exports.UnexpectedResponseException =
+    pdfjsLibs.pdfjsSharedUtil.UnexpectedResponseException;
+//#endif
 }));

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -13,36 +13,35 @@
  * limitations under the License.
  */
 /* jshint globalstrict: false */
-/* globals PDFJS, global */
+/* umdutils ignore */
 
-// Initializing PDFJS global object (if still undefined)
-if (typeof PDFJS === 'undefined') {
-  (typeof window !== 'undefined' ? window :
-   typeof global !== 'undefined' ? global : this).PDFJS = {};
-}
-
-//#if BUNDLE_VERSION
-//#expand PDFJS.version = '__BUNDLE_VERSION__';
-//#endif
-//#if BUNDLE_BUILD
-//#expand PDFJS.build = '__BUNDLE_BUILD__';
-//#endif
-
-(function pdfjsWrapper() {
+(function (root, factory) {
+  'use strict';
+  if (typeof define === 'function' && define.amd) {
+//#expand define('__BUNDLE_AMD_NAME__', ['exports'], factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports);
+  } else {
+//#expand factory((root.__BUNDLE_JS_NAME__ = {}));
+  }
+}(this, function (exports) {
   // Use strict in our context only - users might not want it
   'use strict';
 
+//#expand var pdfjsVersion = '__BUNDLE_VERSION__';
+//#expand var pdfjsBuild = '__BUNDLE_BUILD__';
+
+  var pdfjsFilePath =
+    typeof document !== 'undefined' && document.currentScript ?
+      document.currentScript.src : null;
+
+  var pdfjsLibs = {};
+
+  (function pdfjsWrapper() {
+
 //#expand __BUNDLE__
 
-}).call((typeof window === 'undefined') ? this : window);
+  }).call(pdfjsLibs);
 
-//#if !(MOZCENTRAL || FIREFOX)
-if (!PDFJS.workerSrc && typeof document !== 'undefined') {
-  // workerSrc is not set -- using last script url to define default location
-  PDFJS.workerSrc = (function () {
-    'use strict';
-    var pdfJsSrc = document.currentScript.src;
-    return pdfJsSrc && pdfJsSrc.replace(/\.js$/i, '.worker.js');
-  })();
-}
-//#endif
+  exports.PDFJS = pdfjsLibs.pdfjsSharedGlobal.PDFJS;
+}));

--- a/src/shared/global.js
+++ b/src/shared/global.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals global */
+/* globals global, pdfjsVersion, pdfjsBuild */
 
 'use strict';
 
@@ -37,6 +37,13 @@
   // In development, it will be declared here
   if (!globalScope.PDFJS) {
     globalScope.PDFJS = {};
+  }
+
+  if (typeof pdfjsVersion !== 'undefined') {
+    globalScope.PDFJS.version = pdfjsVersion;
+  }
+  if (typeof pdfjsVersion !== 'undefined') {
+    globalScope.PDFJS.build = pdfjsBuild;
   }
 
   globalScope.PDFJS.pdfBug = false;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1335,11 +1335,8 @@ window.PDFView = PDFViewerApplication; // obsolete name, using it as an alias
 function webViewerLoad(evt) {
 //#if !PRODUCTION
   require.config({paths: {'pdfjs': '../src'}});
-  require(['pdfjs/display/api',
-           'pdfjs/display/annotation_layer',
-           'pdfjs/display/text_layer',
-           'pdfjs/display/metadata'],
-    function (api, annotationLayer, textLayer, metadata) {
+  require(['pdfjs/main_loader'],
+    function (loader) {
       configure(PDFJS);
       PDFViewerApplication.initialize().then(webViewerInitialized);
     });


### PR DESCRIPTION
Wraps pdf.js and pdf.worker.js with UMD module. Creates ./src/main_loader.js to be used with the viewer.js and also mirror the pdfjs-dist exports.

Fixes #6775 
