### PR TITLE
Add a simple cache in `Catalog_getDestination` to avoid looking up the same destination multiple times

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -231,6 +231,14 @@ var Catalog = (function CatalogClosure() {
         return isDict(dest) ? dest.get('D') : dest;
       }
 
+      // Use a simple cache in order to make multiple lookups of the same
+      // destinationId more efficient (useful for big NameTree's).
+      if (!this._getDestinationCache) {
+        this._getDestinationCache = Object.create(null);
+      } else if (this._getDestinationCache[destinationId] !== undefined) {
+        return this._getDestinationCache[destinationId];
+      }
+
       var xref = this.xref;
       var dest = null, nameTreeRef, nameDictionaryRef;
       var obj = this.catDict.get('Names');
@@ -250,6 +258,8 @@ var Catalog = (function CatalogClosure() {
         var nameTree = new NameTree(nameTreeRef, xref);
         dest = fetchDestination(nameTree.get(destinationId));
       }
+
+      this._getDestinationCache[destinationId] = dest;
       return dest;
     },
     get attachments() {


### PR DESCRIPTION
When getting all the destinations (`Catalog.destinations`) the result is cached, to improve performance. However, when individual destinations are fetched, the lookup is repeated every time. Especially for larger PDF files (e.g. the PDF spec), where the `NameTree` containing the destinations can be large, it seems quite unnecessary to repeat the lookup multiple times.
