### PR TITLE
 [api-minor] Add the ability to set a `baseUrl` for relative links when calling `getAnnotations` (bug 766086)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -35,6 +35,7 @@
 }(this, function (exports, sharedUtil, corePrimitives, coreStream, coreObj,
                   coreParser, coreCrypto, coreEvaluator, coreAnnotation) {
 
+var AnnotationType = sharedUtil.AnnotationType;
 var MissingDataException = sharedUtil.MissingDataException;
 var Util = sharedUtil.Util;
 var assert = sharedUtil.assert;
@@ -299,7 +300,7 @@ var Page = (function PageClosure() {
       });
     },
 
-    getAnnotationsData: function Page_getAnnotationsData(intent) {
+    getAnnotationsData: function Page_getAnnotationsData(intent, baseUrl) {
       var annotations = this.annotations;
       var annotationsData = [];
       for (var i = 0, n = annotations.length; i < n; ++i) {
@@ -309,6 +310,11 @@ var Page = (function PageClosure() {
             continue;
           }
         }
+        if (baseUrl &&
+            annotations[i].data.annotationType === AnnotationType.LINK) {
+          annotations[i].addBaseUrlToRelativeLink(baseUrl);
+        }
+
         annotationsData.push(annotations[i].data);
       }
       return annotationsData;

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -495,7 +495,8 @@ var WorkerMessageHandler = PDFJS.WorkerMessageHandler = {
 
     handler.on('GetAnnotations', function wphSetupGetAnnotations(data) {
       return pdfManager.getPage(data.pageIndex).then(function(page) {
-        return pdfManager.ensure(page, 'getAnnotationsData', [data.intent]);
+        return pdfManager.ensure(page, 'getAnnotationsData',
+                                 [data.intent, data.baseUrl]);
       });
     });
 

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -234,12 +234,13 @@ var LinkAnnotationElement = (function LinkAnnotationElementClosure() {
       var link = document.createElement('a');
       link.href = link.title = this.data.url || '';
 
-      if (this.data.url && isExternalLinkTargetSet()) {
-        link.target = LinkTargetStringMap[PDFJS.externalLinkTarget];
-      }
-
-      // Strip referrer from the URL.
       if (this.data.url) {
+        if (isExternalLinkTargetSet()) {
+          link.target = LinkTargetStringMap[PDFJS.externalLinkTarget];
+        } else if (this.data.newWindow) {
+          link.target = '_blank';
+        }
+        // Strip referrer from the URL.
         link.rel = PDFJS.externalLinkRel;
       }
 

--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -50,6 +50,7 @@ var AnnotationLayerBuilder = (function AnnotationLayerBuilderClosure() {
       var self = this;
       var parameters = {
         intent: (intent === undefined ? 'display' : intent),
+        baseUrl: this.linkService.baseUrl,
       };
 
       this.pdfPage.getAnnotations(parameters).then(function (annotations) {


### PR DESCRIPTION
_These patches contains a number of improvements for `LinkAnnotations`, please refer to the individual commit messages._

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=766086.

**Please note:** Given that the last patch could be considered somewhat risky, from a security perspective, I'll understand if we ultimately end up rejecting it. But in that case, I do think that we should close the referenced bug as WONTFIX.
Also, the first patch addresses various TODOs and inconsistencies (w.r.t. to the PDF specification), hence those should be useful on their own, regardless of the last patch.
