### PR TITLE
Fix a typo in the "file" entry for issue3694_reduced in test_manifest.json

### DIFF
--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -383,7 +383,7 @@
        "type": "eq"
     },
     {  "id": "issue3694_reduced",
-       "file": "pdfs/issue_3694_reduced.pdf",
+       "file": "pdfs/issue3694_reduced.pdf",
        "md5": "c1438c7bad12d70c4cd684f8ce04448f",
        "rounds": 1,
        "type": "eq"


### PR DESCRIPTION
When generating new references locally on Windows, after PR #6724, I get the following output:

```
WARNING: Unable to open file for reading "Error: ENOENT, open 'c:\Users\Jonas\Git\pdfjs\test\pdfs\issue_3694_reduced.pdf'".
Unable to verify the checksum for the files that are used for testing.
Please re-download the files, or adjust the MD5 checksum in the manifest for the files listed above.

```

Compared to the name of the file (`issue3694_reduced.pdf`), you see that the manifest entry has a superfluous underscore in the "file" entry.
