### PR TITLE
Update the link location for 'issue3666.pdf' to point to the Internet Archive

### DIFF
--- a/test/pdfs/issue3666.pdf.link
+++ b/test/pdfs/issue3666.pdf.link
@@ -1,2 +1,1 @@
-http://www.nfbc.com/Assets/Maps/716NiagaraWineTrail.pdf
-
+http://web.archive.org/web/20160111201835/https://nfbc.com/Assets/Documents/Cuesheet/716NiagaraWineTrail_opt.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2534,7 +2534,7 @@
     },
     {  "id": "issue3666",
        "file": "pdfs/issue3666.pdf",
-       "md5": "c2156a34b9634b174556910732ab9df0",
+       "md5": "cbcaf533d8a4e825d7f12cb4f137babd",
        "rounds": 1,
        "link": true,
        "firstPage": 1,


### PR DESCRIPTION
Note that despite the new file having a different hash than the the current one, it does render _identically_ and most importantly it uses _the same_ JBIG2 functionality.

For reference, please see issue #3666 and PR #3738.

**Edit:** Re: #6854.
