### PR TITLE
Issue 6854 - Re-enable testing of 'aboutstacks.pdf'

### DIFF
--- a/test/pdfs/aboutstacks.pdf.link
+++ b/test/pdfs/aboutstacks.pdf.link
@@ -1,1 +1,1 @@
-http://greenhousechallenge.org/media/item/313/38/About-Stacks.pdf
+http://web.archive.org/web/20160112115354/http://www.fao.org/fileadmin/user_upload/tci/docs/2_About%20Stacks.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -978,6 +978,14 @@
       "rounds": 1,
       "type": "load"
     },
+    {  "id": "aboutstacks",
+       "file": "pdfs/aboutstacks.pdf",
+       "md5": "6e7c8416a293ba2d83bc8dd20c6ccf51",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "smaskdim",
       "file": "pdfs/smaskdim.pdf",
       "md5": "de80aeca7cbf79940189fd34d59671ee",


### PR DESCRIPTION
This test was disabled in PR #4732, because the file was no longer available. The motivation being that there were two other files which should be good replacements. However, one of those has since been replaced with a reduced test-case (which doesn't exercise the same code-path), and in the other one the error does not appear to be entirely identical.
Hence it seems reasonable to re-add the 'aboutstacks.pdf' test, since it was possible to find it on the Internet Archive (by searching using a different URL, compared to the current one).
