### PR TITLE
Update the linked test case hmm.pdf to point to the intended version

### DIFF
--- a/test/pdfs/hmm.pdf.link
+++ b/test/pdfs/hmm.pdf.link
@@ -1,1 +1,1 @@
-http://web.archive.org/web/20160106162920/http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.145.4773&rep=rep1&type=pdf
+https://web.archive.org/web/20130626074301/http://speech.tifr.res.in/tutorials/hmmTutorialBarbaraExercises.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -356,7 +356,7 @@
     },
     {  "id": "hmm-pdf",
        "file": "pdfs/hmm.pdf",
-       "md5": "ea163ef2b6b69039e0c2c1364f280f67",
+       "md5": "e08467e60101ee5f4a59716e86db6dc9",
        "link": true,
        "rounds": 1,
        "firstPage": 1,


### PR DESCRIPTION
The test case was changed in https://github.com/mozilla/pdf.js/commit/1faca190216deed1ef6084697d04a1d90621e210 because the original file was not available anymore. However, its hash was also changed, meaning that we do not test the intended version anymore.

This patch makes sure that we test the intented version by reverting to the original hash and using a link, also pointing to the Internet Archive, with the original file.

Note that this should resolve the MD5 mismatch warning in the test logs. The tests should still pass because we have always been testing the original file as it was never replaced on the servers after the above commit. This is a part of #6854.
