### PR TITLE
Add an extra set of `//` to the comment for the URL polyfill, since the preprocessor eats one set, thus breaking the world (PR 6846 followup)

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1633,7 +1633,7 @@ function loadJpegStream(id, imageUrl, objs) {
 }
 
 //#if !(MOZCENTRAL)
-// Polyfill from https://github.com/Polymer/URL
+//// Polyfill from https://github.com/Polymer/URL
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 (function checkURLConstructor(scope) {


### PR DESCRIPTION
The Firefox addon currently fails with:

```
SyntaxError: missing ; before statement pdf.js:1692:12
TypeError: PDFJS.shadow is not a function viewer.js:6228:12
```

Re: PR #6846 (see e.g. https://github.com/mozilla/pdfjs-dist/commit/1a15d54dc59e10b6a76b61037b61c7949f7ad5db#diff-eccf5b94e31b0939738de07167e02af6R11113).
