### PR TITLE
Makes PDF data reading Streams API friendly.

### DIFF
--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -28,6 +28,8 @@
 }(this, function (exports, sharedUtil) {
 
 var MissingDataException = sharedUtil.MissingDataException;
+var arrayByteLength = sharedUtil.arrayByteLength;
+var arraysToBytes = sharedUtil.arraysToBytes;
 var assert = sharedUtil.assert;
 var createPromiseCapability = sharedUtil.createPromiseCapability;
 var isInt = sharedUtil.isInt;
@@ -279,37 +281,16 @@ var ChunkedStream = (function ChunkedStreamClosure() {
 
 var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
 
-  function ChunkedStreamManager(length, chunkSize, url, args) {
+  function ChunkedStreamManager(pdfNetworkStream, args) {
+    var chunkSize = args.rangeChunkSize;
+    var length = args.length;
     this.stream = new ChunkedStream(length, chunkSize, this);
     this.length = length;
     this.chunkSize = chunkSize;
-    this.url = url;
+    this.pdfNetworkStream = pdfNetworkStream;
+    this.url = args.url;
     this.disableAutoFetch = args.disableAutoFetch;
-    var msgHandler = this.msgHandler = args.msgHandler;
-
-    if (args.chunkedViewerLoading) {
-      msgHandler.on('OnDataRange', this.onReceiveData.bind(this));
-      msgHandler.on('OnDataProgress', this.onProgress.bind(this));
-      this.sendRequest = function ChunkedStreamManager_sendRequest(begin, end) {
-        msgHandler.send('RequestDataRange', { begin: begin, end: end });
-      };
-    } else {
-
-      var getXhr = function getXhr() {
-        return new XMLHttpRequest();
-      };
-      this.networkManager = new NetworkManager(this.url, {
-        getXhr: getXhr,
-        httpHeaders: args.httpHeaders,
-        withCredentials: args.withCredentials
-      });
-      this.sendRequest = function ChunkedStreamManager_sendRequest(begin, end) {
-        this.networkManager.requestRange(begin, end, {
-          onDone: this.onReceiveData.bind(this),
-          onProgress: this.onProgress.bind(this)
-        });
-      };
-    }
+    this.msgHandler = args.msgHandler;
 
     this.currRequestId = 0;
 
@@ -317,17 +298,52 @@ var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
     this.requestsByChunk = Object.create(null);
     this.promisesByRequest = Object.create(null);
     this.progressiveDataLength = 0;
+    this.aborted = false;
 
     this._loadedStreamCapability = createPromiseCapability();
-
-    if (args.initialData) {
-      this.onReceiveData({chunk: args.initialData});
-    }
   }
 
   ChunkedStreamManager.prototype = {
     onLoadedStream: function ChunkedStreamManager_getLoadedStream() {
       return this._loadedStreamCapability.promise;
+    },
+
+    sendRequest: function ChunkedStreamManager_sendRequest(begin, end) {
+      var rangeReader = this.pdfNetworkStream.getRangeReader(begin, end);
+      if (!rangeReader.isStreamingSupported) {
+        rangeReader.onProgress = this.onProgress.bind(this);
+      }
+      var chunks = [], loaded = 0;
+      var manager = this;
+      var promise = new Promise(function (resolve, reject) {
+        var readChunk = function (chunk) {
+          try {
+            if (!chunk.done) {
+              var data = chunk.value;
+              chunks.push(data);
+              loaded += arrayByteLength(data);
+              if (rangeReader.isStreamingSupported) {
+                manager.onProgress({loaded: loaded});
+              }
+              rangeReader.read().then(readChunk, reject);
+              return;
+            }
+            var chunkData = arraysToBytes(chunks);
+            chunks = null;
+            resolve(chunkData);
+          } catch (e) {
+            reject(e);
+          }
+        };
+        rangeReader.read().then(readChunk, reject);
+      });
+      promise.then(function (data) {
+        if (this.aborted) {
+          return; // ignoring any data after abort
+        }
+        this.onReceiveData({chunk: data, begin: begin});
+      }.bind(this));
+      // TODO check errors
     },
 
     // Get all the chunks that are not yet loaded and groups them into
@@ -549,8 +565,9 @@ var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
     },
 
     abort: function ChunkedStreamManager_abort() {
-      if (this.networkManager) {
-        this.networkManager.abortAllRequests();
+      this.aborted = true;
+      if (this.pdfNetworkStream) {
+        this.pdfNetworkStream.cancelAllRequests('abort');
       }
       for(var requestId in this.promisesByRequest) {
         var capability = this.promisesByRequest[requestId];

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -157,21 +157,18 @@ var LocalPdfManager = (function LocalPdfManagerClosure() {
 })();
 
 var NetworkPdfManager = (function NetworkPdfManagerClosure() {
-  function NetworkPdfManager(docId, args, msgHandler) {
+  function NetworkPdfManager(docId, pdfNetworkStream, args) {
     this._docId = docId;
-    this.msgHandler = msgHandler;
+    this.msgHandler = args.msgHandler;
 
     var params = {
-      msgHandler: msgHandler,
-      httpHeaders: args.httpHeaders,
-      withCredentials: args.withCredentials,
-      chunkedViewerLoading: args.chunkedViewerLoading,
+      msgHandler: args.msgHandler,
+      url: args.url,
+      length: args.length,
       disableAutoFetch: args.disableAutoFetch,
-      initialData: args.initialData
+      rangeChunkSize: args.rangeChunkSize
     };
-    this.streamManager = new ChunkedStreamManager(args.length,
-                                                  args.rangeChunkSize,
-                                                  args.url, params);
+    this.streamManager = new ChunkedStreamManager(pdfNetworkStream, params);
     this.pdfDocument = new PDFDocument(this, this.streamManager.getStream(),
                                        args.password);
   }

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -567,6 +567,55 @@ function stringToBytes(str) {
   return bytes;
 }
 
+/**
+ * Gets length of the array (Array, Uint8Array, or string) in bytes.
+ * @param {Array|Uint8Array|string} arr
+ * @returns {number}
+ */
+function arrayByteLength(arr) {
+  if (arr.length !== undefined) {
+    return arr.length;
+  }
+  assert(arr.byteLength !== undefined);
+  return arr.byteLength;
+}
+
+/**
+ * Combines array items (arrays) into single Uint8Array object.
+ * @param {Array} arr - the array of the arrays (Array, Uint8Array, or string).
+ * @returns {Uint8Array}
+ */
+function arraysToBytes(arr) {
+  // Shortcut: if first and only item is Uint8Array, return it.
+  if (arr.length === 1 && (arr[0] instanceof Uint8Array)) {
+    return arr[0];
+  }
+  var resultLength = 0;
+  var i, ii = arr.length;
+  var item, itemLength ;
+  for (i = 0; i < ii; i++) {
+    item = arr[i];
+    itemLength = arrayByteLength(item);
+    resultLength += itemLength;
+  }
+  var pos = 0;
+  var data = new Uint8Array(resultLength);
+  for (i = 0; i < ii; i++) {
+    item = arr[i];
+    if (!(item instanceof Uint8Array)) {
+      if (typeof item === 'string') {
+        item = stringToBytes(item);
+      } else {
+        item = new Uint8Array(item);
+      }
+    }
+    itemLength = item.byteLength;
+    data.set(item, pos);
+    pos += itemLength;
+  }
+  return data;
+}
+
 function string32(value) {
   return String.fromCharCode((value >> 24) & 0xff, (value >> 16) & 0xff,
                              (value >> 8) & 0xff, value & 0xff);
@@ -2361,6 +2410,8 @@ exports.UnexpectedResponseException = UnexpectedResponseException;
 exports.UnknownErrorException = UnknownErrorException;
 exports.Util = Util;
 exports.XRefParseException = XRefParseException;
+exports.arrayByteLength = arrayByteLength;
+exports.arraysToBytes = arraysToBytes;
 exports.assert = assert;
 exports.bytesToString = bytesToString;
 exports.combineUrl = combineUrl;

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -8,6 +8,7 @@
 describe('api', function() {
   var basicApiUrl = combineUrl(window.location.href, '../pdfs/basicapi.pdf');
   var basicApiFileLength = 105779; // bytes
+  var TEST_TIMEOUT = 20000;
   function waitsForPromiseResolved(promise, successCallback) {
     var resolved = false;
     promise.then(function(val) {
@@ -20,7 +21,7 @@ describe('api', function() {
     });
     waitsFor(function() {
       return resolved;
-    }, 20000);
+    }, TEST_TIMEOUT);
   }
   function waitsForPromiseRejected(promise, failureCallback) {
     var rejected = false;
@@ -34,7 +35,13 @@ describe('api', function() {
     });
     waitsFor(function() {
       return rejected;
-    }, 20000);
+    }, TEST_TIMEOUT);
+  }
+  function waitSome(callback) {
+    var WAIT_TIMEOUT = 10;
+    setTimeout(function () {
+      callback();
+    }, WAIT_TIMEOUT);
   }
 
   describe('PDFJS', function() {
@@ -708,6 +715,88 @@ describe('api', function() {
         return true;
       });
       waitsForPromiseResolved(promiseDone, function() {});
+    });
+  });
+  describe('PDFDataRangeTransport', function () {
+    var pdfPath = combineUrl(window.location.href, '../pdfs/tracemonkey.pdf');
+    var loadPromise;
+    function getDocumentData() {
+      if (loadPromise) {
+        return loadPromise;
+      }
+      loadPromise = new Promise(function (resolve, reject) {
+        var xhr = new XMLHttpRequest(pdfPath);
+        xhr.open('GET', pdfPath);
+        xhr.responseType = 'arraybuffer';
+        xhr.onload = function () { resolve(new Uint8Array(xhr.response)); };
+        xhr.onerror = function () { reject(new Error('PDF is not loaded')); };
+        xhr.send();
+      });
+      return loadPromise;
+    }
+    it('should fetch document info and page using ranges', function () {
+      var transport;
+      var initialDataLength = 4000;
+      var fetches = 0;
+      var getDocumentPromise = getDocumentData().then(function (data) {
+        var initialData = data.subarray(0, initialDataLength);
+        transport = new PDFJS.PDFDataRangeTransport(data.length, initialData);
+        transport.requestDataRange = function (begin, end) {
+          fetches++;
+          waitSome(function () {
+            transport.onDataProgress(4000);
+            transport.onDataRange(begin, data.subarray(begin, end));
+          });
+        };
+        var loadingTask = PDFJS.getDocument(transport);
+        return loadingTask.promise;
+      });
+      var pdfDocument;
+      var getPagePromise = getDocumentPromise.then(function (pdfDocument_) {
+        pdfDocument = pdfDocument_;
+        var pagePromise = pdfDocument.getPage(10);
+        return pagePromise;
+      });
+
+      waitsForPromiseResolved(getPagePromise, function (page) {
+        expect(pdfDocument.numPages).toEqual(14);
+        expect(page.rotate).toEqual(0);
+        expect(fetches).toBeGreaterThan(2);
+      });
+    });
+    it('should fetch document info and page using range and streaming',
+        function () {
+      var transport;
+      var initialDataLength = 4000;
+      var fetches = 0;
+      var getDocumentPromise = getDocumentData().then(function (data) {
+        var initialData = data.subarray(0, initialDataLength);
+        transport = new PDFJS.PDFDataRangeTransport(data.length, initialData);
+        transport.requestDataRange = function (begin, end) {
+          fetches++;
+          if (fetches === 1) {
+            // send rest of the data on first range request.
+            transport.onDataProgressiveRead(data.subarray(initialDataLength));
+          }
+          waitSome(function () {
+            transport.onDataRange(begin, data.subarray(begin, end));
+          });
+        };
+        var loadingTask = PDFJS.getDocument(transport);
+        return loadingTask.promise;
+      });
+      var pdfDocument;
+      var getPagePromise = getDocumentPromise.then(function (pdfDocument_) {
+        pdfDocument = pdfDocument_;
+        var pagePromise = pdfDocument.getPage(10);
+        return pagePromise;
+      });
+
+      waitsForPromiseResolved(getPagePromise, function (page) {
+        expect(pdfDocument.numPages).toEqual(14);
+        expect(page.rotate).toEqual(0);
+        expect(fetches).toEqual(1);
+      });
     });
   });
 });

--- a/test/unit/network_spec.js
+++ b/test/unit/network_spec.js
@@ -1,0 +1,169 @@
+/* globals expect, it, describe, waitsFor, combineUrl, PDFNetworkStream */
+
+'use strict';
+
+describe('network', function() {
+  var pdf1 = combineUrl(window.location.href, '../pdfs/tracemonkey.pdf');
+  var pdf1Length = 1016315;
+  var pdf2 = combineUrl(window.location.href, '../pdfs/pdf.pdf');
+  var pdf2Length = 32472771;
+
+  function waitsForPromiseResolved(promise, successCallback) {
+    var TEST_TIMEOUT = 20000;
+    var resolved = false;
+    promise.then(function(val) {
+        resolved = true;
+        successCallback(val);
+      },
+      function(error) {
+        // Shouldn't get here.
+        expect(error).toEqual('the promise should not have been rejected');
+      });
+    waitsFor(function() {
+      return resolved;
+    }, TEST_TIMEOUT);
+  }
+
+  it('read without stream and range', function() {
+    var stream = new PDFNetworkStream({
+      source: {
+        url: pdf1,
+        rangeChunkSize: 65536,
+        disableStream: true,
+      },
+      disableRange: true
+    });
+
+    var fullReader = stream.getFullReader();
+
+    var isStreamingSupported, isRangeSupported;
+    var promise = fullReader.headersReady.then(function () {
+      isStreamingSupported = fullReader.isStreamingSupported;
+      isRangeSupported = fullReader.isRangeSupported;
+    });
+
+    var len = 0, count = 0;
+    var read = function () {
+      return fullReader.read().then(function (result) {
+        if (result.done) {
+          return;
+        }
+        count++;
+        len += result.value.byteLength;
+        return read();
+      });
+    };
+
+    var readPromise = read();
+
+    waitsForPromiseResolved(readPromise, function (page) {
+      expect(len).toEqual(pdf1Length);
+      expect(count).toEqual(1);
+      expect(isStreamingSupported).toEqual(false);
+      expect(isRangeSupported).toEqual(false);
+    });
+  });
+
+  it('read with streaming', function() {
+    var userAgent = window.navigator.userAgent;
+    // The test is valid for FF only: the XHR has support of the
+    // 'moz-chunked-array' response type.
+    // TODO enable for other browsers, e.g. when fetch/streams API is supported.
+    var m = /Mozilla\/5.0.*?rv:(\d+).*? Gecko/.exec(userAgent);
+    if (!m || m[1] < 9) {
+      return;
+    }
+
+    var stream = new PDFNetworkStream({
+      source: {
+        url: pdf2,
+        rangeChunkSize: 65536,
+        disableStream: false,
+      },
+      disableRange: false
+    });
+
+    var fullReader = stream.getFullReader();
+
+    var isStreamingSupported, isRangeSupported;
+    var promise = fullReader.headersReady.then(function () {
+      isStreamingSupported = fullReader.isStreamingSupported;
+      isRangeSupported = fullReader.isRangeSupported;
+    });
+
+    var len = 0, count = 0;
+    var read = function () {
+      return fullReader.read().then(function (result) {
+        if (result.done) {
+          return;
+        }
+        count++;
+        len += result.value.byteLength;
+        return read();
+      });
+    };
+
+    var readPromise = read();
+
+    waitsForPromiseResolved(readPromise, function (page) {
+      expect(len).toEqual(pdf2Length);
+      expect(count).toBeGreaterThan(1);
+      expect(isStreamingSupported).toEqual(true);
+    });
+  });
+
+  it('read custom ranges', function () {
+    // We don't test on browsers that don't support range request, so
+    // requiring this test to pass.
+    var rangeSize = 32768;
+    var stream = new PDFNetworkStream({
+      source: {
+        url: pdf1,
+        length: pdf1Length,
+        rangeChunkSize: rangeSize,
+        disableStream: true,
+      },
+      disableRange: false
+    });
+
+    var fullReader = stream.getFullReader();
+
+    var isStreamingSupported, isRangeSupported, fullReaderCancelled;
+    var promise = fullReader.headersReady.then(function () {
+      isStreamingSupported = fullReader.isStreamingSupported;
+      isRangeSupported = fullReader.isRangeSupported;
+      // we shall be able to close the full reader without issues
+      fullReader.cancel('Don\'t need full reader');
+      fullReaderCancelled = true;
+    });
+
+    // Skipping fullReader results, requesting something from the PDF end.
+    var tailSize = (pdf1Length % rangeSize) || rangeSize;
+
+    var range1Reader = stream.getRangeReader(pdf1Length - tailSize - rangeSize,
+                                             pdf1Length - tailSize);
+    var range2Reader = stream.getRangeReader(pdf1Length - tailSize, pdf1Length);
+
+    var result1 = {value: 0}, result2 = {value: 0};
+    var read = function (reader, lenResult) {
+      return reader.read().then(function (result) {
+        if (result.done) {
+          return;
+        }
+        lenResult.value += result.value.byteLength;
+        return read(reader, lenResult);
+      });
+    };
+
+    var readPromises = Promise.all([read(range1Reader, result1),
+                                    read(range2Reader, result2),
+                                    promise]);
+
+    waitsForPromiseResolved(readPromises, function (page) {
+      expect(result1.value).toEqual(rangeSize);
+      expect(result2.value).toEqual(tailSize);
+      expect(isRangeSupported).toEqual(true);
+      expect(fullReaderCancelled).toEqual(true);
+    });
+  });
+});

--- a/test/unit/unit_test.html
+++ b/test/unit/unit_test.html
@@ -36,6 +36,7 @@
   <script src="util_spec.js"></script>
   <script src="cmap_spec.js"></script>
   <script src="annotation_layer_spec.js"></script>
+  <script src="network_spec.js"></script>
 
   <script>
     'use strict';
@@ -48,11 +49,12 @@
           'pdfjs/core/annotation', 'pdfjs/core/crypto', 'pdfjs/core/stream',
           'pdfjs/core/fonts', 'pdfjs/core/ps_parser', 'pdfjs/core/function',
           'pdfjs/core/parser', 'pdfjs/core/evaluator', 'pdfjs/core/cmap',
-          'pdfjs/core/worker', 'pdfjs/display/api', 'pdfjs/display/metadata'],
+          'pdfjs/core/worker', 'pdfjs/core/network', 'pdfjs/display/api',
+          'pdfjs/display/metadata'],
           function (sharedUtil, sharedGlobal, corePrimitives, coreAnnotation,
                     coreCrypto, coreStream, coreFonts, corePsParser, coreFunction,
-                    coreParser, coreEvaluator, coreCMap, coreWorker, displayAPI,
-                    displayMetadata) {
+                    coreParser, coreEvaluator, coreCMap, coreWorker,
+                    coreNetwork, displayAPI, displayMetadata) {
 
         pdfjsLibs = {
           sharedUtil: sharedUtil,
@@ -68,6 +70,7 @@
           coreEvaluator: coreEvaluator,
           coreCMap: coreCMap,
           coreWorker: coreWorker,
+          coreNetwork: coreNetwork,
           displayAPI: displayAPI,
           displayMetadata: displayMetadata
         };


### PR DESCRIPTION
Adds PDFWorkerStream and PDFNetworkStream with classes that can provide readers (that are compatible with ReadableByteStream, see Streams API). 

In the future PDFNetworkStream can be re-written to support Fetch API. The PDFWorkerStream can be refactored to be more lightweight and move most of I/O logic to the main thread.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/pdf.js/6879)

<!-- Reviewable:end -->
