### PR TITLE
Remove 'tcpdf_033.pdf.link', since it has been replaced with a reduced test-case

### DIFF
--- a/test/pdfs/tcpdf_033.pdf.link
+++ b/test/pdfs/tcpdf_033.pdf.link
@@ -1,1 +1,0 @@
-http://www.tcpdf.org/examples/example_033.pdf


### PR DESCRIPTION
In PR #1556 Brendan replaced the linked test, but apparently the `.link` file stuck around despite not being needed anymore.

Re: PR #6854.
