### PR TITLE
Replace the linked test-case for issue 1155 with a reduced one

### DIFF
--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -7,6 +7,7 @@
 !franz_2.pdf
 !german-umlaut-r.pdf
 !xref_command_missing.pdf
+!issue1155r.pdf
 !issue2391-1.pdf
 !issue2391-2.pdf
 !issue4665.pdf

--- a/test/pdfs/issue1155.pdf.link
+++ b/test/pdfs/issue1155.pdf.link
@@ -1,1 +1,0 @@
-http://www.madbad.altervista.org/_altervista_ht/2142.pdf

--- a/test/pdfs/issue1155r.pdf
+++ b/test/pdfs/issue1155r.pdf
@@ -1,0 +1,70 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/Pages 2 0 R
+/Type /Catalog
+>>
+endobj 
+2 0 obj 
+<<
+/Kids [3 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+3 0 obj 
+<<
+/CropBox [0 0 1687.41 2386.46]
+/Parent 2 0 R
+/TrimBox [0 0 4783.2 6764.77]
+/MediaBox [0 0 595.28 841.890]
+/Resources 
+<<
+/Font 
+<<
+/F1 4 0 R
+>>
+>>
+/BleedBox [0 0 4783.2 6764.77]
+/Contents 5 0 R
+/Type /Page
+>>
+endobj 
+4 0 obj 
+<<
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/Type /Font
+>>
+endobj 
+5 0 obj 
+<<
+/Length 85
+>>
+stream
+BT
+1 0 0 1 50 600 Tm
+/F1 20 Tf
+(Issue 1155 - Intersect /CropBox and /MediaBox) Tj
+ET
+
+endstream 
+endobj xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000066 00000 n 
+0000000125 00000 n 
+0000000354 00000 n 
+0000000455 00000 n 
+trailer
+
+<<
+/Root 1 0 R
+/Size 6
+>>
+startxref
+592
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1638,10 +1638,10 @@
       "type": "eq"
     },
     {  "id": "issue1155",
-      "file": "pdfs/issue1155.pdf",
-      "md5": "b732ef25c16c9c20a77e40edef5aa6fe",
+      "file": "pdfs/issue1155r.pdf",
+      "md5": "8d772a3c6109bda860b8d80d42d4c08c",
       "rounds": 1,
-      "link": true,
+      "link": false,
       "type": "eq"
     },
     {  "id": "link-annotation-border",


### PR DESCRIPTION
As part of the link cleanup in issue #6854, obtaining this file through the Internet Archive didn't work.
However, given that the file was added in order to test an issue with `CropBox/MediaBox`, a reduced test-case should do just fine instead.

Please refer to issue #1155, and PR #1212.
