### PR TITLE
Remove 'issue2537.pdf.link', since it has been replaced with a reduced test-case

### DIFF
--- a/test/pdfs/issue2537.pdf.link
+++ b/test/pdfs/issue2537.pdf.link
@@ -1,1 +1,0 @@
-http://my.herk.ro/test.pdf


### PR DESCRIPTION
In PR #4732, Yury replaced the linked test, but apparently the `.link` file stuck around despite not being needed anymore.

Re: PR #6854.
