### PR TITLE
Update links to point to the Internet Archive for issue2799 and issue5726

### DIFF
--- a/test/pdfs/issue2799.pdf.link
+++ b/test/pdfs/issue2799.pdf.link
@@ -1,1 +1,1 @@
-https://dl.dropboxusercontent.com/s/15j936nuidw0e8d/SIMPLE-Vivace.pdf?token_hash=AAEwO6O_zfDfSxC3Zmpoy_cNfiR109Tn-REcWa32slkaSA&disable_range=1
+https://web.archive.org/web/20160118144632/http://www.pdf-archive.com/2016/01/18/simple-vivace-3/simple-vivace-3.pdf

--- a/test/pdfs/issue5726.pdf.link
+++ b/test/pdfs/issue5726.pdf.link
@@ -1,1 +1,1 @@
-http://digipool.bib-bvb.de/bvb/info/OCR_with_TIFFG4.pdf
+https://web.archive.org/web/20160118145140/http://www.pdf-archive.com/2016/01/18/ocr-with-tiffg4-1/ocr-with-tiffg4-1.pdf

--- a/test/pdfs/yo01.pdf.link
+++ b/test/pdfs/yo01.pdf.link
@@ -1,1 +1,0 @@
-http://www.ugokotsu.co.jp/ug/rosen/jikoku/yo01.pdf


### PR DESCRIPTION
We remove yo01. The file is not available, it was introduced in https://github.com/mozilla/pdf.js/commit/3529658ac5a6aa2ca137d8f77ab1470af43abbab along with another test file (so we should not need it) and it was replaced in https://github.com/mozilla/pdf.js/commit/6b2c6fc22397350ace1c65867e33b9b02c1fdc4b, so it was only in the repository for a very short time.

Fixes #6854 and #5091. All test cases are now either reduced or link to trusted sources like Bugzilla and the Internet Archive, making sure that they keep on existing and do not change. MD5 mismatches have also been resolved.
