### PR TITLE
Set type="password" for the `PasswordPrompt` input dynamically, to prevent unnecessary warnings in Firefox for http:// documents (issue 6898)

### DIFF
--- a/web/password_prompt.js
+++ b/web/password_prompt.js
@@ -49,6 +49,7 @@ var PasswordPrompt = {
 
   open: function passwordPromptOpen() {
     OverlayManager.open(this.overlayName).then(function () {
+      this.passwordField.type = 'password';
       this.passwordField.focus();
 
       var promptString = mozL10n.get('password_label', null,
@@ -66,6 +67,7 @@ var PasswordPrompt = {
   close: function passwordPromptClose() {
     OverlayManager.close(this.overlayName).then(function () {
       this.passwordField.value = '';
+      this.passwordField.type = '';
     }.bind(this));
   },
 

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -331,7 +331,8 @@ See https://github.com/adobe-type-tools/cmap-resources
               <p id="passwordText" data-l10n-id="password_label">Enter the password to open this PDF file:</p>
             </div>
             <div class="row">
-              <input type="password" id="password" class="toolbarField" />
+              <!-- The type="password" attribute is set via script, to prevent warnings in Firefox for all http:// documents. -->
+              <input id="password" class="toolbarField" />
             </div>
             <div class="buttonRow">
               <button id="passwordCancel" class="overlayButton"><span data-l10n-id="password_cancel">Cancel</span></button>


### PR DESCRIPTION
Fixes #6898.

Note that this doesn't prevent the warning for PDF files that _do_ ask for a password, e.g. http://async5.org/moz/passwordOU.pdf, but it's not clear to me if/how we could avoid that.
