### PR TITLE
fix outline may jump to previous page issue

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -565,7 +565,13 @@ var PDFViewer = (function pdfViewer() {
         pageView.viewport.convertToViewportPoint(x + width, y + height)
       ];
       var left = Math.min(boundingRect[0][0], boundingRect[1][0]);
-      var top = Math.min(boundingRect[0][1], boundingRect[1][1]);
+      // Some pdf generator will generate a large top value (e.g. 10000)
+      // for outline destination
+      // which exceeds the hight of the page
+      // Therefore we have to ensure top is not less 0
+      // otherwise viewer will scroll to previous page
+      // See PR 6903 and bug 874482 for more discussion
+      var top = Math.max(Math.min(boundingRect[0][1], boundingRect[1][1]), 0);
 
       scrollIntoView(pageView.div, { left: left, top: top });
     },


### PR DESCRIPTION
Some pdf generator will generate the top value for outline destination with some large value (e.g. 10000) which exceeds the hight of the page, resulting viewer jump to previous page instead of the target page. 

Test file:
https://drive.google.com/file/d/0B6YhVF9p-y2AclR3YU96MVE0Qzg/view?usp=sharing

Without the patch, click Chapter 1 will jump to page 1 instead of page 2.
Note: OS X Preview also have this issue. Adobe Reader and Chrome (PDFium) doesn’t have it.
