### PR TITLE
Improve work-around for importScripts bug.

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1276,16 +1276,7 @@ var PDFWorker = (function PDFWorkerClosure() {
           // https://bugzilla.mozilla.org/show_bug.cgi?id=683280
           var worker = new Worker(workerSrc);
           var messageHandler = new MessageHandler('main', 'worker', worker);
-//#if !PRODUCTION
-          // Don't allow worker to be destroyed by Chrome, see:
-          // https://code.google.com/p/chromium/issues/detail?id=572225
-          var jsWorkerId = '_workerKungfuGrip_' + Math.random();
-          window[jsWorkerId] = worker;
-//#endif
           messageHandler.on('test', function PDFWorker_test(data) {
-//#if !PRODUCTION
-            delete window[jsWorkerId];
-//#endif
             if (this.destroyed) {
               this._readyCapability.reject(new Error('Worker was destroyed'));
               messageHandler.destroy();

--- a/src/worker_loader.js
+++ b/src/worker_loader.js
@@ -15,6 +15,17 @@
 
 'use strict';
 
+//#if !PRODUCTION
+//// Patch importScripts to work around a bug in WebKit and Chrome 48-.
+//// See https://crbug.com/572225 and https://webkit.org/b/153317.
+self.importScripts = (function (importScripts) {
+  return function() {
+    setTimeout(function () {}, 0);
+    return importScripts.apply(this, arguments);
+  };
+})(importScripts);
+//#endif
+
 importScripts('../node_modules/requirejs/require.js');
 
 require.config({paths: {'pdfjs': '.'}});


### PR DESCRIPTION
Reverts "Hack to avoid intermidiate Chrome failures during tests." (2b2c5212133dc69d238a286ae69d49eda571db2f).

Updates require.js to the latest version (pre-release), which includes an alternative work-around for the bug that was worked around by the reverted commit. The advantage of the new work-around is that it allows the runtime to garbage-collect idle Workers.

References:
- https://crbug.com/572225
- https://webkit.org/b/153317
- https://github.com/jrburke/requirejs/pull/1469

Addresses #6877
