### PR TITLE
Allow foriegn origin URLs only for hosted viewers.

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1332,6 +1332,37 @@ window.PDFView = PDFViewerApplication; // obsolete name, using it as an alias
 //})();
 //#endif
 
+//#if GENERIC
+var HOSTED_VIEWER_ORIGINS = ['null',
+  'http://mozilla.github.io', 'https://mozilla.github.io'];
+function validateFileURL(file) {
+  try {
+    var viewerOrigin = new URL(window.location.href).origin || 'null';
+    if (HOSTED_VIEWER_ORIGINS.indexOf(viewerOrigin) >= 0) {
+      // Hosted or local viewer, allow for any file locations
+      return;
+    }
+    var fileOrigin = new URL(file, window.location.href).origin;
+    // Removing of the following line will not guarantee that the viewer will
+    // start accepting URLs from foreign origin -- CORS headers on the remote
+    // server must be properly configured.
+    if (fileOrigin !== viewerOrigin) {
+      throw new Error('file origin does not match viewer\'s');
+    }
+  } catch (e) {
+    var message = e && e.message;
+    var loadingErrorMessage = mozL10n.get('loading_error', null,
+      'An error occurred while loading the PDF.');
+
+    var moreInfo = {
+      message: message
+    };
+    PDFViewerApplication.error(loadingErrorMessage, moreInfo);
+    throw e;
+  }
+}
+//#endif
+
 function webViewerLoad(evt) {
 //#if !PRODUCTION
   require.config({paths: {'pdfjs': '../src'}});
@@ -1351,6 +1382,7 @@ function webViewerInitialized() {
   var queryString = document.location.search.substring(1);
   var params = parseQueryString(queryString);
   var file = 'file' in params ? params.file : DEFAULT_URL;
+  validateFileURL(file);
 //#endif
 //#if (FIREFOX || MOZCENTRAL)
 //var file = window.location.href.split('#')[0];


### PR DESCRIPTION
Currently we provide demo viewer source code so web developers can extend and build custom viewers upon it. The "file" parameter is causing confusions among developers due to XHR restrictions such as CORS or passing binary data.

Also, most of the developers don’t want or forget to modify viewer to adapt it to their own use case. The primary use case the PDF.js team considered is hosting generic viewer to view files from different locations.

This patch locks down the "file" parameter to be used only for the files located at the same server by default. The main reason for it is to minimize unintended use of viewer host network resources to display somebody else’s documents (e.g. full viewer size might reach up to 2MB) and avoid content spoofing to avoid presenting false information on behalf of the host domain. The exceptions for now are viewers that are hosted at "file:///..." and "http://mozilla.github.io/" locations. If a host's use case matches ours, the validation function/parameters can be adjusted to change that.
