### PR TITLE
Adding withCredentials property to the default preferences

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -75,6 +75,12 @@
     "useOnlyCssZoom": {
       "type": "boolean",
       "default": false
+    },
+    "withCredentials": {
+      "title": "Enable the withCredentials property for XMLHttpRequest requests",
+      "description": "Property indicates whether or not cross-site Access-Control requests should be made using credentials such as cookies, authorization headers or TLS client certificates. Setting withCredentials has no effect on same-site requests",
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/web/default_preferences.js
+++ b/web/default_preferences.js
@@ -32,4 +32,5 @@ var DEFAULT_PREFERENCES = {
   disableTextLayer: false,
   useOnlyCssZoom: false,
   externalLinkTarget: 0,
+  withCredentials: false,
 };

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -297,6 +297,12 @@ var PDFViewerApplication = {
         }
         PDFJS.externalLinkTarget = value;
       }),
+      Preferences.get('withCredentials').then(function resolved(value) {
+        if (PDFJS.withCredentials === true) {
+          return;
+        }
+        PDFJS.withCredentials = value;
+      }),
       // TODO move more preferences and other async stuff here
     ]).catch(function (reason) { });
 
@@ -1454,6 +1460,9 @@ function webViewerInitialized() {
       IGNORE_CURRENT_POSITION_ON_ZOOM =
         (hashParams['ignorecurrentpositiononzoom'] === 'true');
     }
+    if ('withcredentials' in hashParams) {
+      PDFJS.withCredentials = (hashParams['withcredentials'] === 'true');
+    }
 //#if !PRODUCTION
     if ('disablebcmaps' in hashParams && hashParams['disablebcmaps']) {
       PDFJS.cMapUrl = '../external/cmaps/';
@@ -1640,7 +1649,9 @@ function webViewerInitialized() {
   }
 
   if (file) {
-    PDFViewerApplication.open(file);
+    var args = {};
+    args.withCredentials = PDFJS.withCredentials;
+    PDFViewerApplication.open(file, args);
   }
 //#endif
 //#if CHROME


### PR DESCRIPTION
The problem appears when you would like to customize viewer and change value of the withCredentials to enable PDF.JS to use it. It is currently not available inside the viewer.js. It is sounds like good idea to move it to DEFAULT_PREFERENCES object
this pr is sounds like followup on  https://github.com/mozilla/pdf.js/pull/4124
