### PR TITLE
[api-minor] Change `getPageLabels` to take a boolean value to indicate if standard page numbering should be skipped

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -264,17 +264,30 @@ var Catalog = (function CatalogClosure() {
       return dest;
     },
 
-    get pageLabels() {
-      var obj = null;
-      try {
-        obj = this.readPageLabels();
-      } catch (ex) {
-        if (ex instanceof MissingDataException) {
-          throw ex;
+    getPageLabels: function Catalog_getPageLabels(ignoreStandardNumbering) {
+      if (!this._pageLabels) {
+        var obj = null;
+        try {
+          obj = this.readPageLabels();
+        } catch (ex) {
+          if (ex instanceof MissingDataException) {
+            throw ex;
+          }
+          warn('Unable to read page labels.');
         }
-        warn('Unable to read page labels.');
+        this._pageLabels = obj;
       }
-      return shadow(this, 'pageLabels', obj);
+
+      if (this._pageLabels !== null && ignoreStandardNumbering) {
+        var i = 0, ii = this.numPages;
+        while (i < ii && this._pageLabels[i] === (i + 1).toString()) {
+          i++;
+        }
+        if (i === ii) {
+          return null;
+        }
+      }
+      return this._pageLabels;
     },
     readPageLabels: function Catalog_readPageLabels() {
       var obj = this.catDict.getRaw('PageLabels');
@@ -343,14 +356,7 @@ var Catalog = (function CatalogClosure() {
         currentLabel = '';
         currentIndex++;
       }
-
-      // Ignore PageLabels if they correspond to standard page numbering.
-      for (i = 0, ii = this.numPages; i < ii; i++) {
-        if (pageLabels[i] !== (i + 1).toString()) {
-          break;
-        }
-      }
-      return (i === ii ? [] : pageLabels);
+      return pageLabels;
     },
 
     get attachments() {

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -451,11 +451,10 @@ var WorkerMessageHandler = PDFJS.WorkerMessageHandler = {
       }
     );
 
-    handler.on('GetPageLabels',
-      function wphSetupGetPageLabels(data) {
-        return pdfManager.ensureCatalog('pageLabels');
-      }
-    );
+    handler.on('GetPageLabels', function wphSetupGetPageLabels(data) {
+      return pdfManager.ensureCatalog('getPageLabels',
+                                      [data.ignoreStandardNumbering]);
+    });
 
     handler.on('GetAttachments',
       function wphSetupGetAttachments(data) {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -683,7 +683,7 @@ var PDFDocumentProxy = (function PDFDocumentProxyClosure() {
       return this.transport.getDestinations();
     },
     /**
-     * @param {string} id The named destination to get.
+     * @param {string} id - The named destination to get.
      * @return {Promise} A promise that is resolved with all information
      * of the given named destination.
      */
@@ -691,14 +691,17 @@ var PDFDocumentProxy = (function PDFDocumentProxyClosure() {
       return this.transport.getDestination(id);
     },
     /**
-     * @return {Promise} A promise that is resolved with: an Array containing
-     *   the pageLabels that correspond to the pageIndexes; or null, when no
-     *   pageLabels are present in the PDF file.
-     *   NOTE: If the pageLabels are all identical to standard page numbering,
-     *         i.e. [1, 2, 3, ...], the promise is resolved with an empty Array.
+     * @param {boolean} ignoreStandardNumbering - Ignore pageLabels if they are
+     *   all identical to standard page numbering, i.e. [1, 2, 3, ...].
+     *   The default value is `false`.
+     * @return {Promise} A promise that is resolved with either:
+     *   an Array containing the pageLabels that correspond to the pageIndexes;
+     *   or null, when no pageLabels are present in the PDF file.
      */
-    getPageLabels: function PDFDocumentProxy_getPageLabels() {
-      return this.transport.getPageLabels();
+    getPageLabels:
+        function PDFDocumentProxy_getPageLabels(ignoreStandardNumbering) {
+      var param = ignoreStandardNumbering || false;
+      return this.transport.getPageLabels(param);
     },
     /**
      * @return {Promise} A promise that is resolved with a lookup table for
@@ -1814,8 +1817,11 @@ var WorkerTransport = (function WorkerTransportClosure() {
       return this.messageHandler.sendWithPromise('GetDestination', { id: id });
     },
 
-    getPageLabels: function WorkerTransport_getPageLabels() {
-      return this.messageHandler.sendWithPromise('GetPageLabels', null);
+    getPageLabels:
+        function WorkerTransport_getPageLabels(ignoreStandardNumbering) {
+      return this.messageHandler.sendWithPromise('GetPageLabels', {
+        ignoreStandardNumbering: ignoreStandardNumbering,
+      });
     },
 
     getAttachments: function WorkerTransport_getAttachments() {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -338,25 +338,40 @@ describe('api', function() {
     it('gets page labels', function () {
       // PageLabels with Roman/Arabic numerals.
       var url0 = combineUrl(window.location.href, '../pdfs/bug793632.pdf');
-      var promise0 = PDFJS.getDocument(url0).promise.then(function (pdfDoc) {
-        return pdfDoc.getPageLabels();
+      var loadingTask0 = PDFJS.getDocument(url0);
+      var promise0 = loadingTask0.promise.then(function (pdfDoc) {
+        return pdfDoc.getPageLabels(/* ignoreStandardNumbering = */ true);
       });
+
       // PageLabels with only a label prefix.
       var url1 = combineUrl(window.location.href, '../pdfs/issue1453.pdf');
-      var promise1 = PDFJS.getDocument(url1).promise.then(function (pdfDoc) {
-        return pdfDoc.getPageLabels();
+      var loadingTask1 = PDFJS.getDocument(url1);
+      var promise1 = loadingTask1.promise.then(function (pdfDoc) {
+        return pdfDoc.getPageLabels(/* ignoreStandardNumbering = */ true);
       });
-      // PageLabels identical to standard page numbering.
+
+      // Should *ignore* pageLabels identical to standard page numbering.
       var url2 = combineUrl(window.location.href, '../pdfs/rotation.pdf');
-      var promise2 = PDFJS.getDocument(url2).promise.then(function (pdfDoc) {
+      var loadingTask2 = PDFJS.getDocument(url2);
+      var promise2 = loadingTask2.promise.then(function (pdfDoc) {
+        return pdfDoc.getPageLabels(/* ignoreStandardNumbering = */ true);
+      });
+
+      // Should *get* pageLabels identical to standard page numbering.
+      var promise2second = loadingTask2.promise.then(function (pdfDoc) {
         return pdfDoc.getPageLabels();
       });
 
-      waitsForPromiseResolved(Promise.all([promise0, promise1, promise2]),
-          function (pageLabels) {
+      waitsForPromiseResolved(Promise.all([promise0, promise1, promise2,
+          promise2second]), function (pageLabels) {
         expect(pageLabels[0]).toEqual(['i', 'ii', 'iii', '1']);
         expect(pageLabels[1]).toEqual(['Front Page1']);
-        expect(pageLabels[2]).toEqual([]);
+        expect(pageLabels[2]).toEqual(null);
+        expect(pageLabels[3]).toEqual(['1', '2']);
+
+        loadingTask0.destroy();
+        loadingTask1.destroy();
+        loadingTask2.destroy();
       });
     });
     it('gets attachments', function() {


### PR DESCRIPTION
When prototyping the viewer integration for pageLabels, it became apparent that returning an empty array for "standard" page numbering is quite clunky.
It should obviously be possible to fetch the pageLabels, through the API, _exactly_ as they appear in the PDF file. Sorry about this oversight!

/cc @timvandermeij Since you reviewed PR #6803, would you mind reviewing this as well?

**Edit:** Perhaps marginally easier reviewing with https://github.com/mozilla/pdf.js/pull/6923/files?w=1.
