### PR TITLE
[api-minor] Change `getPageLabels` to always return the pageLabels, even if they are identical to standard page numbering

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -343,14 +343,7 @@ var Catalog = (function CatalogClosure() {
         currentLabel = '';
         currentIndex++;
       }
-
-      // Ignore PageLabels if they correspond to standard page numbering.
-      for (i = 0, ii = this.numPages; i < ii; i++) {
-        if (pageLabels[i] !== (i + 1).toString()) {
-          break;
-        }
-      }
-      return (i === ii ? [] : pageLabels);
+      return pageLabels;
     },
 
     get attachments() {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -691,11 +691,9 @@ var PDFDocumentProxy = (function PDFDocumentProxyClosure() {
       return this.transport.getDestination(id);
     },
     /**
-     * @return {Promise} A promise that is resolved with: an Array containing
-     *   the pageLabels that correspond to the pageIndexes; or null, when no
-     *   pageLabels are present in the PDF file.
-     *   NOTE: If the pageLabels are all identical to standard page numbering,
-     *         i.e. [1, 2, 3, ...], the promise is resolved with an empty Array.
+     * @return {Promise} A promise that is resolved with:
+     *   an Array containing the pageLabels that correspond to the pageIndexes,
+     *   or `null` when no pageLabels are present in the PDF file.
      */
     getPageLabels: function PDFDocumentProxy_getPageLabels() {
       return this.transport.getPageLabels();

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -338,17 +338,22 @@ describe('api', function() {
     it('gets page labels', function () {
       // PageLabels with Roman/Arabic numerals.
       var url0 = combineUrl(window.location.href, '../pdfs/bug793632.pdf');
-      var promise0 = PDFJS.getDocument(url0).promise.then(function (pdfDoc) {
+      var loadingTask0 = PDFJS.getDocument(url0);
+      var promise0 = loadingTask0.promise.then(function (pdfDoc) {
         return pdfDoc.getPageLabels();
       });
+
       // PageLabels with only a label prefix.
       var url1 = combineUrl(window.location.href, '../pdfs/issue1453.pdf');
-      var promise1 = PDFJS.getDocument(url1).promise.then(function (pdfDoc) {
+      var loadingTask1 = PDFJS.getDocument(url1);
+      var promise1 = loadingTask1.promise.then(function (pdfDoc) {
         return pdfDoc.getPageLabels();
       });
+
       // PageLabels identical to standard page numbering.
       var url2 = combineUrl(window.location.href, '../pdfs/rotation.pdf');
-      var promise2 = PDFJS.getDocument(url2).promise.then(function (pdfDoc) {
+      var loadingTask2 = PDFJS.getDocument(url2);
+      var promise2 = loadingTask2.promise.then(function (pdfDoc) {
         return pdfDoc.getPageLabels();
       });
 
@@ -356,7 +361,11 @@ describe('api', function() {
           function (pageLabels) {
         expect(pageLabels[0]).toEqual(['i', 'ii', 'iii', '1']);
         expect(pageLabels[1]).toEqual(['Front Page1']);
-        expect(pageLabels[2]).toEqual([]);
+        expect(pageLabels[2]).toEqual(['1', '2']);
+
+        loadingTask0.destroy();
+        loadingTask1.destroy();
+        loadingTask2.destroy();
       });
     });
     it('gets attachments', function() {


### PR DESCRIPTION
_This changes the API according to the review comments in the now closed PR #6923._
