### PR TITLE
Make type 1 font program decryption faster.

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -5326,15 +5326,21 @@ var Type1Parser = (function Type1ParserClosure() {
   }
 
   function decrypt(data, key, discardNumber) {
-    var r = key | 0, c1 = 52845, c2 = 22719;
-    var count = data.length;
+    if (discardNumber >= data.length) {
+      return new Uint8Array(0);
+    }
+    var r = key | 0, c1 = 52845, c2 = 22719, i, j;
+    for (i = 0; i < discardNumber; i++) {
+      r = ((data[i] + r) * c1 + c2) & ((1 << 16) - 1);
+    }
+    var count = data.length - discardNumber;
     var decrypted = new Uint8Array(count);
-    for (var i = 0; i < count; i++) {
+    for (i = discardNumber, j = 0; j < count; i++, j++) {
       var value = data[i];
-      decrypted[i] = value ^ (r >> 8);
+      decrypted[j] = value ^ (r >> 8);
       r = ((value + r) * c1 + c2) & ((1 << 16) - 1);
     }
-    return Array.prototype.slice.call(decrypted, discardNumber);
+    return decrypted;
   }
 
   function decryptAscii(data, key, discardNumber) {


### PR DESCRIPTION
Discard the values first so we don't have to slice the array.

I noticed this showed up pretty high in a profile so I checked it out. In chrome I see 31ms improvement and in firefox a 13ms improvement in the decrypt time while loading the first two pages of trace monkey.
