### PR TITLE
Adjust a comment discussing transferred ArrayBuffers, to refer to those buffers being detached, not neutered (consistent with bug 1079844)

### DIFF
--- a/src/core/image.js
+++ b/src/core/image.js
@@ -573,10 +573,10 @@ var PDFImage = (function PDFImageClosure() {
 
           imgArray = this.getImageBytes(originalHeight * rowBytes);
           // If imgArray came from a DecodeStream, we're safe to transfer it
-          // (and thus neuter it) because it will constitute the entire
-          // DecodeStream's data.  But if it came from a Stream, we need to
-          // copy it because it'll only be a portion of the Stream's data, and
-          // the rest will be read later on.
+          // (and thus detach its underlying buffer) because it will constitute
+          // the entire DecodeStream's data.  But if it came from a Stream, we
+          // need to copy it because it'll only be a portion of the Stream's
+          // data, and the rest will be read later on.
           if (this.image instanceof DecodeStream) {
             imgData.data = imgArray;
           } else {


### PR DESCRIPTION
This change makes the comment consistent with terminology used in the ECMAScript specification.  (I made this change in mozilla-central yesterday for very nearly all other code in the tree, just cleaning up this imported loose end.)

Note that `imgArray` is a typed array, but the spec refers to detachment as a concept applicable to `ArrayBuffer` _only_.  There is no special terminology to describe an `ArrayBuffer` view that views a detached buffer.  Hence referring to `imgArray`'s buffer being detached, not to `imgArray` itself being detached.
