### PR TITLE
Fix 'Ready' message sequence for Firefox ext disabled worker.

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -414,9 +414,9 @@ PDFJS.getDocument = function getDocument(src,
         throw new Error('Loading aborted');
       }
       var messageHandler = new MessageHandler(docId, workerId, worker.port);
-      messageHandler.send('Ready', null);
       var transport = new WorkerTransport(messageHandler, task, rangeTransport);
       task._transport = transport;
+      messageHandler.send('Ready', null);
     });
   }).catch(task._capability.reject);
 


### PR DESCRIPTION
Fixes #6937

It's a little bit messy since we are handling async messages in sync style. We cannot just add e.g. setTimeout or Promises because in some cases we dispose original objects, e.g. arrays in operator list, and cannot clone objects with JSON since some of them are typed arrays.

Proper and full solution will be to make our fake channel act like a real one.
