### PR TITLE
Ensure that we don't modify the `Dict` data when the `Differences` array of a font contains indirect objects

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1566,14 +1566,11 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
             var diffEncoding = encoding.get('Differences');
             var index = 0;
             for (var j = 0, jj = diffEncoding.length; j < jj; j++) {
-              var data = diffEncoding[j];
+              var data = xref.fetchIfRef(diffEncoding[j]);
               if (isNum(data)) {
                 index = data;
               } else if (isName(data)) {
                 differences[index++] = data.name;
-              } else if (isRef(data)) {
-                diffEncoding[j--] = xref.fetch(data);
-                continue;
               } else {
                 error('Invalid entry in \'Differences\' array: ' + data);
               }


### PR DESCRIPTION
This patch fixes an issue that I inadvertently introduced in PR #5815, where we accidentally modify the `Differences` array in the encoding dictionary for indirect objects.

Instead of this change, we could also have used the now existing `Dict_getArray`. However in this case I don't think that would have been a good idea, since it would mean iterating through the array _twice_.
