### PR TITLE
Add support for transfer functions to Images (issue 6931)

### DIFF
--- a/src/core/function.js
+++ b/src/core/function.js
@@ -111,7 +111,7 @@ var PDFFunction = (function PDFFunctionClosure() {
     },
 
     parse: function PDFFunction_parse(xref, fn) {
-      var IR = this.getIR(xref, fn);
+      var IR = this.getIR(xref, xref.fetchIfRef(fn));
       return this.fromIR(IR);
     },
 
@@ -123,8 +123,7 @@ var PDFFunction = (function PDFFunctionClosure() {
 
       var fnArray = [];
       for (var j = 0, jj = fnObj.length; j < jj; j++) {
-        var obj = xref.fetchIfRef(fnObj[j]);
-        fnArray.push(PDFFunction.parse(xref, obj));
+        fnArray.push(PDFFunction.parse(xref, fnObj[j]));
       }
       return function (src, srcOffset, dest, destOffset) {
         for (var i = 0, ii = fnArray.length; i < ii; i++) {


### PR DESCRIPTION
This is a **_very**_ tentative patch that fixes issue #6931 and [bug 1149713](https://bugzilla.mozilla.org/show_bug.cgi?id=1149713), by adding support for transfer functions to images.

It seems to me that it's easiest to handle this in `PDFImage`, since trying to do it in `canvas.js` didn't seem particularly simple given that there are different methods for painting various kind of images.
The way that this patch is implemented means that we skip all the various optimizations when dealing with these images, but considering how rare images utilizing transfer functions seem to be in practice, that probably doesn't matter too much.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/pdf.js/6942)

<!-- Reviewable:end -->
