### PR TITLE
Add support for PageLabels in the viewer (issue 6902, bug 793632)

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -89,6 +89,10 @@
       ],
       "default": 0
     },
+    "disablePageLabels": {
+      "type": "boolean",
+      "default": false
+    },
     "disableTelemetry": {
       "title": "Disable telemetry",
       "type": "boolean",

--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -18,11 +18,10 @@ previous_label=Previous
 next.title=Next Page
 next_label=Next
 
-# LOCALIZATION NOTE (page_label, page_of):
-# These strings are concatenated to form the "Page: X of Y" string.
-# Do not translate "{{pageCount}}", it will be substituted with a number
-# representing the total number of pages.
-page_label=Page:
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Page
+# LOCALIZATION NOTE (page_of): "{{pageCount}}" will be replaced by a number
+# representing the total number of pages in the document.
 page_of=of {{pageCount}}
 
 zoom_out.title=Zoom Out

--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -20,9 +20,13 @@ next_label=Next
 
 # LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
 page.title=Page
-# LOCALIZATION NOTE (page_of): "{{pageCount}}" will be replaced by a number
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
 # representing the total number of pages in the document.
-page_of=of {{pageCount}}
+of_pages=of {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
++page_of_pages=({{pageNumber}} of {{pagesCount}})
 
 zoom_out.title=Zoom Out
 zoom_out_label=Zoom Out

--- a/l10n/sv-SE/viewer.properties
+++ b/l10n/sv-SE/viewer.properties
@@ -20,9 +20,13 @@ next_label=Nästa
 
 # LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
 page.title=Sida
-# LOCALIZATION NOTE (page_of): "{{pageCount}}" will be replaced by a number
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
 # representing the total number of pages in the document.
-page_of=av {{pageCount}}
+of_pages=av {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently active visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} av {{pagesCount}})
 
 zoom_out.title=Zooma ut
 zoom_out_label=Zooma ut

--- a/l10n/sv-SE/viewer.properties
+++ b/l10n/sv-SE/viewer.properties
@@ -18,11 +18,10 @@ previous_label=Föregående
 next.title=Nästa sida
 next_label=Nästa
 
-# LOCALIZATION NOTE (page_label, page_of):
-# These strings are concatenated to form the "Page: X of Y" string.
-# Do not translate "{{pageCount}}", it will be substituted with a number
-# representing the total number of pages.
-page_label=Sida:
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Sida
+# LOCALIZATION NOTE (page_of): "{{pageCount}}" will be replaced by a number
+# representing the total number of pages in the document.
 page_of=av {{pageCount}}
 
 zoom_out.title=Zooma ut

--- a/web/default_preferences.json
+++ b/web/default_preferences.json
@@ -13,5 +13,6 @@
   "useOnlyCssZoom": false,
   "externalLinkTarget": 0,
   "enhanceTextSelection": false,
-  "renderInteractiveForms": false
+  "renderInteractiveForms": false,
+  "disablePageLabels": false
 }

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -78,6 +78,7 @@ var PDFPageView = (function PDFPageViewClosure() {
 
     this.id = id;
     this.renderingId = 'page' + id;
+    this.pageLabel = null;
 
     this.rotation = 0;
     this.scale = scale || DEFAULT_SCALE;
@@ -553,6 +554,19 @@ var PDFPageView = (function PDFPageViewClosure() {
         self.onBeforeDraw();
       }
       return promise;
+    },
+
+    /**
+     * @param {string|null} label
+     */
+    setPageLabel: function PDFView_setPageLabel(label) {
+      this.pageLabel = (typeof label === 'string' ? label : null);
+
+      if (this.pageLabel !== null) {
+        this.div.setAttribute('data-page-label', this.pageLabel);
+      } else {
+        this.div.removeAttribute('data-page-label');
+      }
     },
   };
 

--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -91,6 +91,7 @@ var PDFThumbnailView = (function PDFThumbnailViewClosure() {
 
     this.id = id;
     this.renderingId = 'thumbnail' + id;
+    this.pageLabel = null;
 
     this.pdfPage = null;
     this.rotation = 0;
@@ -120,6 +121,7 @@ var PDFThumbnailView = (function PDFThumbnailViewClosure() {
       linkService.page = id;
       return false;
     };
+    this.anchor = anchor;
 
     var div = document.createElement('div');
     div.id = 'thumbnailContainer' + id;
@@ -247,7 +249,7 @@ var PDFThumbnailView = (function PDFThumbnailViewClosure() {
       }
       var id = this.renderingId;
       var className = 'thumbnailImage';
-      var ariaLabel = mozL10n.get('thumb_page_canvas', { page: this.id },
+      var ariaLabel = mozL10n.get('thumb_page_canvas', { page: this.pageId },
                                   'Thumbnail of Page {{page}}');
 
       if (this.disableCanvasToImageConversion) {
@@ -395,7 +397,32 @@ var PDFThumbnailView = (function PDFThumbnailViewClosure() {
       ctx.drawImage(reducedImage, 0, 0, reducedWidth, reducedHeight,
                     0, 0, canvas.width, canvas.height);
       this._convertCanvasToImage();
-    }
+    },
+
+    get pageId() {
+      return (this.pageLabel !== null ? this.pageLabel : this.id);
+    },
+
+    /**
+     * @param {string|null} label
+     */
+    setPageLabel: function PDFThumbnailView_setPageLabel(label) {
+      this.pageLabel = (typeof label === 'string' ? label : null);
+
+      this.anchor.title = mozL10n.get('thumb_page_title', { page: this.pageId },
+                                      'Page {{page}}');
+
+      if (this.renderingState !== RenderingStates.FINISHED) {
+        return;
+      }
+      var ariaLabel = mozL10n.get('thumb_page_canvas', { page: this.pageId },
+                                  'Thumbnail of Page {{page}}');
+      if (this.image) {
+        this.image.setAttribute('aria-label', ariaLabel);
+      } else if (this.disableCanvasToImageConversion && this.canvas) {
+        this.canvas.setAttribute('aria-label', ariaLabel);
+      }
+    },
   };
 
   return PDFThumbnailView;

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -196,6 +196,12 @@ var PDFThumbnailViewer = (function PDFThumbnailViewerClosure() {
       } else {
         this._pageLabels = labels;
       }
+      // Update all the `PDFThumbnailView` instances.
+      for (var i = 0, ii = this.thumbnails.length; i < ii; i++) {
+        var thumbnailView = this.thumbnails[i];
+        var label = this._pageLabels && this._pageLabels[i];
+        thumbnailView.setPageLabel(label);
+      }
     },
 
     /**

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -133,6 +133,7 @@ var PDFThumbnailViewer = (function PDFThumbnailViewerClosure() {
      */
     _resetView: function PDFThumbnailViewer_resetView() {
       this.thumbnails = [];
+      this._pageLabels = null;
       this._pagesRotation = 0;
       this._pagesRequests = [];
 
@@ -176,6 +177,24 @@ var PDFThumbnailViewer = (function PDFThumbnailViewerClosure() {
         if (this.thumbnails[i]) {
           this.thumbnails[i].cancelRendering();
         }
+      }
+    },
+
+    /**
+     * @param {Array|null} labels
+     */
+    setPageLabels: function PDFThumbnailViewer_setPageLabels(labels) {
+      if (!this.pdfDocument) {
+        return;
+      }
+      if (!labels) {
+        this._pageLabels = null;
+      } else if (!(labels instanceof Array &&
+                   this.pdfDocument.numPages === labels.length)) {
+        this._pageLabels = null;
+        console.error('PDFThumbnailViewer_setPageLabels: Invalid page labels.');
+      } else {
+        this._pageLabels = labels;
       }
     },
 

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -453,6 +453,12 @@ var PDFViewer = (function pdfViewer() {
       } else {
         this._pageLabels = labels;
       }
+      // Update all the `PDFPageView` instances.
+      for (var i = 0, ii = this._pages.length; i < ii; i++) {
+        var pageView = this._pages[i];
+        var label = this._pageLabels && this._pageLabels[i];
+        pageView.setPageLabel(label);
+      }
     },
 
     _resetView: function () {

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -211,6 +211,7 @@ var PDFViewer = (function pdfViewer() {
       var arg = {
         source: this,
         pageNumber: val,
+        pageLabel: this._pageLabels && this._pageLabels[val - 1],
       };
       this._currentPageNumber = val;
       this.eventBus.dispatch('pagechanging', arg);
@@ -219,6 +220,28 @@ var PDFViewer = (function pdfViewer() {
       if (resetCurrentPageView) {
         this._resetCurrentPageView();
       }
+    },
+
+    /**
+     * @returns {string|null} Returns the current page label,
+     *                        or `null` if no page labels exist.
+     */
+    get currentPageLabel() {
+      return this._pageLabels && this._pageLabels[this._currentPageNumber - 1];
+    },
+
+    /**
+     * @param {string} val - The page label.
+     */
+    set currentPageLabel(val) {
+      var pageNumber = val | 0; // Fallback page number.
+      if (this._pageLabels) {
+        var i = this._pageLabels.indexOf(val);
+        if (i >= 0) {
+          pageNumber = i + 1;
+        }
+      }
+      this.currentPageNumber = pageNumber;
     },
 
     /**
@@ -414,11 +437,30 @@ var PDFViewer = (function pdfViewer() {
       }.bind(this));
     },
 
+    /**
+     * @param {Array|null} labels
+     */
+    setPageLabels: function PDFViewer_setPageLabels(labels) {
+      if (!this.pdfDocument) {
+        return;
+      }
+      if (!labels) {
+        this._pageLabels = null;
+      } else if (!(labels instanceof Array &&
+                   this.pdfDocument.numPages === labels.length)) {
+        this._pageLabels = null;
+        console.error('PDFViewer_setPageLabels: Invalid page labels.');
+      } else {
+        this._pageLabels = labels;
+      }
+    },
+
     _resetView: function () {
       this._pages = [];
       this._currentPageNumber = 1;
       this._currentScale = UNKNOWN_SCALE;
       this._currentScaleValue = null;
+      this._pageLabels = null;
       this._buffer = new PDFPageViewBuffer(DEFAULT_CACHE_SIZE);
       this._location = null;
       this._pagesRotation = 0;

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1939,7 +1939,7 @@ html[dir='rtl'] #documentPropertiesOverlay .row > * {
 }
 
 @media all and (max-width: 510px) {
-  #scaleSelectContainer, #pageNumberLabel {
+  #scaleSelectContainer {
     display: none;
   }
 }

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -194,8 +194,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                     <span data-l10n-id="next_label">Next</span>
                   </button>
                 </div>
-                <label id="pageNumberLabel" class="toolbarLabel" for="pageNumber" data-l10n-id="page_label">Page: </label>
-                <input type="number" id="pageNumber" class="toolbarField pageNumber" value="1" size="4" min="1" tabindex="15">
+                <input type="number" id="pageNumber" class="toolbarField pageNumber" title="Page" value="1" size="4" min="1" tabindex="15" data-l10n-id="page">
                 <span id="numPages" class="toolbarLabel"></span>
               </div>
               <div id="toolbarViewerRight">
@@ -236,7 +235,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                      </button>
                   </div>
                   <span id="scaleSelectContainer" class="dropdownToolbarButton">
-                     <select id="scaleSelect" title="Zoom" tabindex="23" data-l10n-id="zoom">
+                    <select id="scaleSelect" title="Zoom" tabindex="23" data-l10n-id="zoom">
                       <option id="pageAutoOption" title="" value="auto" selected="selected" data-l10n-id="page_scale_auto">Automatic Zoom</option>
                       <option id="pageActualOption" title="" value="page-actual" data-l10n-id="page_scale_actual">Actual Size</option>
                       <option id="pageFitOption" title="" value="page-fit" data-l10n-id="page_scale_fit">Fit Page</option>


### PR DESCRIPTION
_Please refer to the individual commit messages._

Can be tested using e.g. the following files: http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf, or http://mirrors.ctan.org/info/lshort/english/lshort.pdf.
Fixes issue #6902 and [bug 793632](https://bugzilla.mozilla.org/show_bug.cgi?id=793632).

**TODO:**
- [x] Localize the new strings, and cleanup the now obsolete ones.
