### PR TITLE
Correct the upper bound used when building the `transferMap` for SMasks (PR 6723 followup)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -362,7 +362,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         var transferFn = PDFFunction.parse(this.xref, transferObj);
         var transferMap = new Uint8Array(256);
         var tmp = new Float32Array(1);
-        for (var i = 0; i < 255; i++) {
+        for (var i = 0; i < 256; i++) {
           tmp[0] = i / 255;
           transferFn(tmp, 0, tmp, 0);
           transferMap[i] = (tmp[0] * 255) | 0;


### PR DESCRIPTION
Even though the currently known test-cases render correctly without this patch, that seems more like a lucky coincidence, given that there's no guarantee that `transferMap[255] === 0` for every possible transfer function.
