### PR TITLE
Replace `getAll` with `getKeys` in `loadType3Data`

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -2100,13 +2100,13 @@ var TranslatedFont = (function TranslatedFontClosure() {
 
       var translatedFont = this.font;
       var loadCharProcsPromise = Promise.resolve();
-      var charProcs = this.dict.get('CharProcs').getAll();
+      var charProcs = this.dict.get('CharProcs');
       var fontResources = this.dict.get('Resources') || resources;
-      var charProcKeys = Object.keys(charProcs);
+      var charProcKeys = charProcs.getKeys();
       var charProcOperatorList = Object.create(null);
       for (var i = 0, n = charProcKeys.length; i < n; ++i) {
         loadCharProcsPromise = loadCharProcsPromise.then(function (key) {
-          var glyphStream = charProcs[key];
+          var glyphStream = charProcs.get(key);
           var operatorList = new OperatorList();
           return evaluator.getOperatorList(glyphStream, task, fontResources,
                                            operatorList).then(function () {


### PR DESCRIPTION
Not only is `getAll` less efficient, but given that we actually need the keys here, using `getKeys` seems much more suitable.
