### PR TITLE
Fix a typo in api.js

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1280,7 +1280,7 @@ var PDFWorker = (function PDFWorkerClosure() {
 
     _initialize: function PDFWorker_initialize() {
       // If worker support isn't disabled explicit and the browser has worker
-      // support, create a new web worker and test if it/the browser fullfills
+      // support, create a new web worker and test if it/the browser fulfills
       // all requirements to run parts of pdf.js in a web worker.
       // Right now, the requirement is, that an Uint8Array is still an
       // Uint8Array as it arrives on the worker. (Chrome added this with v.15.)


### PR DESCRIPTION
`fulfills` misspelt as `fullfills`
