### PR TITLE
Fix #5927: Page Rotation is saved for reload

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -215,6 +215,12 @@ var PDFViewer = (function pdfViewer() {
         pageView.update(pageView.scale, rotation);
       }
 
+      if (!this._currentScaleValue) {
+        // If the rotation is changed before the the scale has been set,
+        // don't try and update it since doing so results in an error.
+        return;
+      }
+
       this._setScale(this._currentScaleValue, true);
 
       if (this.defaultRenderingQueue) {
@@ -595,7 +601,7 @@ var PDFViewer = (function pdfViewer() {
         top: intTop,
         left: intLeft,
         pdfOpenParams: pdfOpenParams,
-        rotation: this.pagesRotation
+        rotation: this._pagesRotation
       };
     },
 

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -594,7 +594,8 @@ var PDFViewer = (function pdfViewer() {
         scale: normalizedScaleValue,
         top: intTop,
         left: intLeft,
-        pdfOpenParams: pdfOpenParams
+        pdfOpenParams: pdfOpenParams,
+        rotation: this.pagesRotation
       };
     },
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -884,13 +884,14 @@ var PDFViewerApplication = {
                      store.get('zoom', DEFAULT_SCALE_VALUE);
           var left = store.get('scrollLeft', '0');
           var top = store.get('scrollTop', '0');
+          var rotation = store.get('rotation', '0') | 0;
 
           storedHash = 'page=' + pageNum + '&zoom=' + zoom + ',' +
                        left + ',' + top;
         } else if (self.preferenceDefaultZoomValue) {
           storedHash = 'page=1&zoom=' + self.preferenceDefaultZoomValue;
         }
-        self.setInitialView(storedHash, scale);
+        self.setInitialView(storedHash, scale, rotation);
 
         initialParams.hash = storedHash;
 
@@ -1061,8 +1062,12 @@ var PDFViewerApplication = {
     });
   },
 
-  setInitialView: function pdfViewSetInitialView(storedHash, scale) {
+  setInitialView: function pdfViewSetInitialView(storedHash, scale, rotation) {
     this.isInitialViewSet = true;
+
+    if (rotation && rotation !== this.pageRotation) {
+      this.rotatePages(rotation);
+    }
 
     // When opening a new file, when one is already loaded in the viewer,
     // ensure that the 'pageNumber' element displays the correct value.
@@ -1784,7 +1789,8 @@ window.addEventListener('updateviewarea', function (evt) {
       'page': location.pageNumber,
       'zoom': location.scale,
       'scrollLeft': location.left,
-      'scrollTop': location.top
+      'scrollTop': location.top,
+      'rotation': location.rotation
     }).catch(function() {
       // unable to write to storage
     });

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -1065,8 +1065,9 @@ var PDFViewerApplication = {
   setInitialView: function pdfViewSetInitialView(storedHash, scale, rotation) {
     this.isInitialViewSet = true;
 
-    if (rotation && rotation !== this.pageRotation) {
-      this.rotatePages(rotation);
+    if ((rotation | 0) === rotation &&
+        rotation !== this.pageRotation) {
+      this.setRotation(rotation - this.pageRotation);
     }
 
     // When opening a new file, when one is already loaded in the viewer,
@@ -1288,11 +1289,16 @@ var PDFViewerApplication = {
     this.forceRendering();
   },
 
-  rotatePages: function pdfViewRotatePages(delta) {
-    var pageNumber = this.page;
+  setRotation: function pdfViewSetRotation(delta) {
     this.pageRotation = (this.pageRotation + 360 + delta) % 360;
     this.pdfViewer.pagesRotation = this.pageRotation;
     this.pdfThumbnailViewer.pagesRotation = this.pageRotation;
+  },
+
+  rotatePages: function pdfViewRotatePages(delta) {
+    var pageNumber = this.page;
+
+    this.setRotation(delta);
 
     this.forceRendering();
 


### PR DESCRIPTION
The fix for #5927. Similar to #5949, with the suggestions in the notes taken into account.

This passes all Jasmine Unit Tests and the Lint tests.
