### PR TITLE
Remove the only remaining `Dict_getAll` usage (in evaluator.js) and the method itself

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1005,9 +1005,20 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
               // but doing so is meaningless without knowing the semantics.
               continue;
             default:
-              // Note: Let's hope that the ignored operator does not have any
-              // non-serializable arguments, otherwise postMessage will throw
+              // Note: Ignore the operator if it has `Dict` arguments, since
+              // those are non-serializable, otherwise postMessage will throw
               // "An object could not be cloned.".
+              if (args !== null) {
+                for (i = 0, ii = args.length; i < ii; i++) {
+                  if (args[i] instanceof Dict) {
+                    break;
+                  }
+                }
+                if (i < ii) {
+                  warn('getOperatorList - ignoring operator: ' + fn);
+                  continue;
+                }
+              }
           }
           operatorList.addOp(fn, args);
         }
@@ -2555,7 +2566,7 @@ var EvaluatorPreprocessor = (function EvaluatorPreprocessorClosure() {
             if (!args) {
               args = [];
             }
-            args.push((obj instanceof Dict ? obj.getAll() : obj));
+            args.push(obj);
             assert(args.length <= 33, 'Too many arguments');
           }
         }

--- a/test/pdfs/issue6549.pdf.link
+++ b/test/pdfs/issue6549.pdf.link
@@ -1,0 +1,1 @@
+http://web.archive.org/web/20150306062422/http://www.kokuyo-st.co.jp/stationery/camiapp/CamiApp_Sample.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -781,6 +781,15 @@
        "rounds": 1,
        "type": "load"
     },
+    {  "id": "issue6549",
+       "file": "pdfs/issue6549.pdf",
+       "md5": "699aeea73a6f45375022ffc6cc80f12a",
+       "link": true,
+       "rounds": 1,
+       "firstPage": 2,
+       "lastPage": 3,
+       "type": "load"
+    },
     {  "id": "ibwa-bad",
        "file": "pdfs/ibwa-bad.pdf",
        "md5": "6ca059d32b74ac2688ae06f727fee755",


### PR DESCRIPTION
- Add a linked `load` test for issue 6549
-  Remove `getAll` from `EvaluatorPreprocessor_read`
  
  > For the operators that we currently support, the arguments are not `Dict`s, which means that it's not really necessary to use `Dict_getAll` in `EvaluatorPreprocessor_read`.
  > Also, I do think that if/when we support operators that use `Dict`s as arguments, that should be dealt with in the corresponding `case` in `PartialEvaluator_getOperatorList` which handles the operator.
  > 
  > The only reason that I can find for using `Dict_getAll` like that, is that prior to PR #6550 we would just append certain (currently unsupported) operators without doing any further processing/checking. But as issue #6549 showed, that can lead to issues in practice, which is why it was changed.
  > 
  > In an effort to prevent possible issues with unsupported operators, this patch simply ignores operators with `Dict` arguments in `PartialEvaluator_getOperatorList`.
- Remove `Dict_getAll` since it is now unused
  
  > `Dict_getAll` is problematic for a number of reasons. First of all, as issue #6961 shows, it can be really bad for performance, since it dereferences all indirect objects.
  > Second of all, all the derefencing can lead to data being unncessarily requested when ranged/chunked loading is used, thus unnecessarily delaying rendering.
  > 
  > Note: For cases where `Dict_getAll` was previously used, `Dict_getKeys` in combination with `Dict_get` can be used instead. This has the advantage that data isn't requested until it's actually needed.
