### PR TITLE
Update `JpegImage.getData` to support `forceRGBoutput` for images with `numComponents === 1` (issue 6066)

### DIFF
--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -1019,7 +1019,18 @@ var JpegImage = (function jpegImage() {
       // type of data: Uint8Array(width * height * numComponents)
       var data = this._getLinearizedBlockData(width, height);
 
-      if (this.numComponents === 3) {
+      if (this.numComponents === 1 && forceRGBoutput) {
+        var dataLength = data.length;
+        var rgbData = new Uint8Array(dataLength * 3);
+        var offset = 0;
+        for (var i = 0; i < dataLength; i++) {
+          var grayColor = data[i];
+          rgbData[offset++] = grayColor;
+          rgbData[offset++] = grayColor;
+          rgbData[offset++] = grayColor;
+        }
+        return rgbData;
+      } else if (this.numComponents === 3) {
         return this._convertYccToRgb(data);
       } else if (this.numComponents === 4) {
         if (this._isColorConversionNeeded()) {

--- a/test/pdfs/issue6066.pdf.link
+++ b/test/pdfs/issue6066.pdf.link
@@ -1,0 +1,1 @@
+http://web.archive.org/web/20160213124006/http://www.leon.pl/userfiles/file/Zapytanie%20ofertowe%201-2014.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -980,6 +980,15 @@
        "lastPage": 3,
        "type": "eq"
     },
+    {  "id": "issue6066",
+       "file": "pdfs/issue6066.pdf",
+       "md5": "b26eb08fc5ab2518ba8fde603bdfc46b",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 2,
+       "lastPage": 2,
+       "type": "eq"
+    },
     {  "id": "issue1905",
        "file": "pdfs/issue1905.pdf",
        "md5": "b1bbd72ca6522ae1502aa26320f81994",


### PR DESCRIPTION
_A more robust solution for issue #6066._

As a temporary work-around for (the upstream) [bug 1164199](https://bugzilla.mozilla.org/show_bug.cgi?id=1164199), we parsed _all_ images in the Firefox addon during a short time.
Doing so uncovered an issue with our image handling (see #6066), for JPEG images with a `DeviceGray` ColorSpace _and_ `bpc !== 1` (bits per component).

As long as we let the browser handle image decoding in this case, this isn't going to be an issue, but I do think that we should proactively fix this to avoid future issues if we change where the images are decoded (in `jpg.js` vs in browser).
Also, we currently don't seem to have a test-case for that kind of image data.
