### PR TITLE
Remove Opera from the README file as they removed the extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,10 @@ PDF.js is built into version 19+ of Firefox, however the extension is still avai
 
 + [Development Version](http://mozilla.github.io/pdf.js/extensions/firefox/pdf.js.xpi) - This version is updated every time new code is merged into the PDF.js codebase. This should be quite stable but still might break from time to time. This version is also reported to work when installed as extension in Seamonkey 2.39.
 
-#### Chrome and Opera
+#### Chrome
 
 + The official extension for Chrome can be installed from the [Chrome Web Store](https://chrome.google.com/webstore/detail/pdf-viewer/oemmndcbldboiebfnladdacbdfmadadm).
 *This extension is maintained by [@Rob--W](https://github.com/Rob--W).*
-+ Opera has also published an extension for their browser at the [Opera add-ons catalog](https://addons.opera.com/en/extensions/details/pdf-viewer/).
 + Build Your Own - Get the code as explained below and issue `node make chromium`. Then open
 Chrome, go to `Tools > Extension` and load the (unpackaged) extension from the
 directory `build/chromium`.


### PR DESCRIPTION
The extension has been removed from the Opera add-ons catalog a while ago. I can only assume that this was because of a lack of maintenance, judging by the state of their fork at https://github.com/operasoftware/pdf.js.
