### PR TITLE
Issue 6994.  PDF version 1.3, with nested xref, signals 'bad xref entry' 

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -726,6 +726,18 @@ var XRef = (function XRefClosure() {
             error('Invalid entry in XRef subsection: ' + first + ', ' + count);
           }
 
+          // Some PDFs have a nested xref which looks like:
+          // xref
+          // 1 7                    // incorrect: should be 0 7
+          // 0000000000 65535 f
+          // 0000000009 0     n     // where '1 0 obj.<<...' begins at offset 9
+          // ...
+          // This was found in a 1.3 PDF with unspecified /Creator and /Producer.  
+          // In this case, just adjust first keep going.
+          if(i==0 && first==1 && entry.offset==0 && entry.gen==65535 && entry.free) {
+            first=0;
+          }
+          
           if (!this.entries[i + first]) {
             this.entries[i + first] = entry;
           }

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -732,10 +732,12 @@ var XRef = (function XRefClosure() {
           // 0000000000 65535 f
           // 0000000009 0     n     // where '1 0 obj.<<...' begins at offset 9
           // ...
-          // This was found in a 1.3 PDF with unspecified /Creator and /Producer.  
+          // This was found in a 1.3 PDF with unspecified /Creator 
+          // and /Producer.  
           // In this case, just adjust first keep going.
-          if(i==0 && first==1 && entry.offset==0 && entry.gen==65535 && entry.free) {
-            first=0;
+          if(i===0 && first===1 && entry.offset===0 && 
+            entry.gen===65535 && entry.free) {
+               first=0;
           }
           
           if (!this.entries[i + first]) {


### PR DESCRIPTION
The PDF in question contains confidential information...I am still trying to get a non-confidential version as a test case.

Until then, here's what I found.  File contains 2 xrefs.  The master xref (at EOF) contains:
xref
0 1  
0000000000 65535 f
3 1  
0000691433 00000 n          == <</Contents[2 0 R]/MediaBox[0 0 596 842]/Parent 4 0 R/Resources<</ProcSet[/PDF/ImageC/ImageB/ImageI]/XObject<</Im1 1 0 R>>>>/Rotate 90/Type/Page>>.endobj
5 3  
0000691595 00000 n          == obj 5 <</Metadata 7 0 R/Pages 4 0 R/Type/Catalog>>.endobj
0000691655 00000 n          == obj 6 <</Author()/CreationDate()/CreationDate--Text()/Creator()/ModDate(D:20160209110716+05'30')/Producer()/Subject()/Title()>>.endobj
0000691792 00000 n          == obj 7 metadata stream, 
trailer

The nested xref (in middle of file) contains:
xref
1 7
0000000000 65535 f
0000000009 00000 n     // start of object 1
0000690726 00000 n     // start of object 2
0000690823 00000 n     // start of object 3 <<./Type /Page./MediaBox [0 0 596 842]./Parent 4 0 R ./Rotate 0 /Resources <<./ProcSet [/PDF /ImageC /ImageB /ImageI]./XObject <<./Im1 1 0 R. >>. >>./Contents [ 2 0 R.].>>.endobj
0000691010 00000 n     // start of object 4
0000691068 00000 n     // start of object 5 <<./Type /Catalog./Pages 4 0 R  .>>.endobj.
0000691119 00000 n     // start of object 6 << /Creator ()./CreationDate ()./Author ()./Producer ()./Title ()./Subject ().>>

THe problem was that the dict created by merging these 2 looked like this (notice 2 'obj 3''s).
index 0: offset=0
index 1: offset=9           (obj 1, from 1st xref) OK
index 2: offset=691433 (obj 3, from 2nd xref) OK
index 3: offset=690823 (obj 3, from 1st xref) -- wrong!
index 4: offset=691595 (obj 5, from 2nd xref) OK
index 5: offset=691655 (obj 6, from 2nd xref) OK
index 6: offset=691792 (obj 7, from 2nd xref) OK

I traced the problem back to XRef_readXRefTable in core/obj.js, and decided that the safest fix was to treat the starting object number (tableState.firstEntryNum) of the xref subsection (1 7, above) as invalid (eg, treat it as 0 7).  
