### PR TITLE
[api-minor] Change `getOutline` to actually return the RGB color of outline items

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -721,7 +721,7 @@ var PDFDocumentProxy = (function PDFDocumentProxyClosure() {
      *   title: string,
      *   bold: boolean,
      *   italic: boolean,
-     *   color: rgb array,
+     *   color: rgb Uint8Array,
      *   dest: dest obj,
      *   url: string,
      *   items: array of more items like this

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -455,6 +455,10 @@ describe('api', function() {
         expect(outlineItem.dest instanceof Array).toEqual(true);
         expect(outlineItem.url).toEqual(null);
 
+        expect(outlineItem.bold).toEqual(true);
+        expect(outlineItem.italic).toEqual(false);
+        expect(outlineItem.color).toEqual(new Uint8Array([0, 64, 128]));
+
         expect(outlineItem.items.length).toEqual(1);
         expect(outlineItem.items[0].title).toEqual('Paragraph 1.1');
       });
@@ -468,9 +472,15 @@ describe('api', function() {
           expect(outline instanceof Array).toEqual(true);
           expect(outline.length).toEqual(5);
 
-          var outlineItem = outline[2];
-          expect(outlineItem.dest).toEqual(null);
-          expect(outlineItem.url).toEqual('http://google.com');
+          var outlineItemTwo = outline[2];
+          expect(typeof outlineItemTwo.title).toEqual('string');
+          expect(outlineItemTwo.dest).toEqual(null);
+          expect(outlineItemTwo.url).toEqual('http://google.com');
+
+          var outlineItemOne = outline[1];
+          expect(outlineItemOne.bold).toEqual(false);
+          expect(outlineItemOne.italic).toEqual(true);
+          expect(outlineItemOne.color).toEqual(new Uint8Array([0, 0, 0]));
 
           loadingTask.destroy(); // Cleanup the worker.
         });

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -430,6 +430,19 @@ describe('api', function() {
         loadingTask.destroy();
       });
     });
+    it('gets non-existent outline', function() {
+      var url = combineUrl(window.location.href, '../pdfs/tracemonkey.pdf');
+      var loadingTask = PDFJS.getDocument(url);
+
+      var promise = loadingTask.promise.then(function (pdfDocument) {
+        return pdfDocument.getOutline();
+      });
+      waitsForPromiseResolved(promise, function (outline) {
+        expect(outline).toEqual(null);
+
+        loadingTask.destroy();
+      });
+    });
     it('gets outline', function() {
       var promise = doc.getOutline();
       waitsForPromiseResolved(promise, function(outline) {


### PR DESCRIPTION
_This PR contains the core/test parts from PR #6943._
- Reduce the overall indentation level in `Catalog_readDocumentOutline`, by using early returns, in order to improve readability
  _This should simplify reviewing: https://github.com/Snuffleupagus/pdf.js/commit/98db06807900ebf454145ddac1bdaa17c02e5ad5?w=1._
- [api-minor] Change `getOutline` to actually return the RGB color of outline items
  
  > Currently the `C` entry in an outline item is returned as is, which is neither particularly useful nor what the API documentation claims.
  > 
  > This patch also adds unit-tests for both the color handling, and the `F` entry (bold/italic flags).
