### PR TITLE
[Addon] Catch errors in `getFindBar` (in PdfStreamConverter.jsm) to fix loading of PDF files in the bookmark sidebar (bug 1248959)

### DIFF
--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -82,9 +82,15 @@ function getFindBar(domWindow) {
 //#endif
     return tabbrowser.getFindBar(tab);
   } catch (e) {
-    // FF22 has no _getTabForBrowser, and FF24 has no getFindBar
-    var chromeWindow = browser.ownerDocument.defaultView;
-    return chromeWindow.gFindBar;
+    try {
+      // FF22 has no _getTabForBrowser, and FF24 has no getFindBar
+      var chromeWindow = browser.ownerDocument.defaultView;
+      return chromeWindow.gFindBar;
+    } catch (ex) {
+      // Suppress errors for PDF files opened in the bookmark sidebar, see
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1248959.
+      return null;
+    }
   }
 }
 
@@ -407,7 +413,7 @@ ChromeActions.prototype = {
 
     // ... or when the new find events code exists.
     var findBar = getFindBar(this.domWindow);
-    return findBar && ('updateControlState' in findBar);
+    return !!findBar && ('updateControlState' in findBar);
   },
   supportsDocumentFonts: function() {
     var prefBrowser = getIntPref('browser.display.use_document_fonts', 1);


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1248959.

Even easier reviewing: https://github.com/mozilla/pdf.js/pull/7007/files?w=1. 
