### PR TITLE
Add a default title for outline items, to prevent display issues if the title is missing

### DIFF
--- a/web/pdf_outline_view.js
+++ b/web/pdf_outline_view.js
@@ -16,6 +16,8 @@
 
 'use strict';
 
+var DEFAULT_TITLE = '\u2013';
+
 /**
  * @typedef {Object} PDFOutlineViewOptions
  * @property {HTMLDivElement} container - The viewer element.
@@ -137,11 +139,15 @@ var PDFOutlineView = (function PDFOutlineViewClosure() {
         var levelData = queue.shift();
         for (var i = 0, len = levelData.items.length; i < len; i++) {
           var item = levelData.items[i];
+
           var div = document.createElement('div');
           div.className = 'outlineItem';
+
           var element = document.createElement('a');
           this._bindLink(element, item);
-          element.textContent = PDFJS.removeNullCharacters(item.title);
+          element.textContent =
+            PDFJS.removeNullCharacters(item.title) || DEFAULT_TITLE;
+
           div.appendChild(element);
 
           if (item.items.length > 0) {


### PR DESCRIPTION
Open http://www.puolustusvoimat.fi/wcm/61ba4180411e702ea19ee9e364705c96/luonnonmuonaohjelmalumo1985.pdf?MOD=AJPERES#pagemode=bookmarks.

Note how the outline looks entirely empty, but hovering over it you'll see that there are entries present. There's two separate issues here, first of all the fact that you cannot visually make out the outline items, and secondly that the lack of text means that the clickable area becomes too small.

In Adobe Reader this issue is somewhat mitigated, since they use an icon for every item. For PDF.js, the easist way to address this seems to be making use of a default title.
This issue should be _very_ rare in practice, but given the simplicity of the solution I think that we should fix this.
