### PR TITLE
[SVG] Specify the `PDFJS.cMapUrl`/`PDFJS.cMapPacked` parameters in the svgviewer example

### DIFF
--- a/examples/svgviewer/viewer.js
+++ b/examples/svgviewer/viewer.js
@@ -53,6 +53,10 @@ require(['pdfjs/display/api', 'pdfjs/display/svg'], function (api, svg) {
   // In production, change this to point to the built `pdf.worker.js` file.
   PDFJS.workerSrc = '../../src/worker_loader.js';
 
+  // In production, change this to point to where the cMaps are placed.
+  PDFJS.cMapUrl = '../../external/bcmaps/';
+  PDFJS.cMapPacked = true;
+
   // Fetch the PDF document from the URL using promises.
   api.getDocument(url).then(renderDocument);
 });


### PR DESCRIPTION
Re: issue #7017.
This should prevent the error, but does not fix the broken rendering.

The rendering issues are caused by `svg.js` not supporting the various text rendering modes, in this case specifically "invisible" (as indicated in the console `Warning: Unimplemented method setTextRenderingMode`).

Compared to the canvas case, where we just ignore invisible text, a smarter solution is probably required for the SVG case. Since just ignoring invisible text in `svg.js` would mean that text-selection isn't possible.
