### PR TITLE
Correct a minor name issue in the outline viewer code

### DIFF
--- a/web/pdf_outline_viewer.js
+++ b/web/pdf_outline_viewer.js
@@ -85,7 +85,7 @@ var PDFOutlineViewer = (function PDFOutlineViewerClosure() {
     /**
      * @private
      */
-    _setStyles: function PDFOutlineView_setStyles(element, item) {
+    _setStyles: function PDFOutlineViewer_setStyles(element, item) {
       var styleStr = '';
       if (item.bold) {
         styleStr += 'font-weight: bold;';


### PR DESCRIPTION
I just found this after reviewing the bold/italic outline item support patch.
