### PR TITLE
[api-minor] Add support for LinkAnnotations with relative URLs, by making it possible to set the baseUrl for those in `PDFLinkService` (bug 766086)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -37,6 +37,7 @@ var AnnotationFlag = sharedUtil.AnnotationFlag;
 var AnnotationType = sharedUtil.AnnotationType;
 var OPS = sharedUtil.OPS;
 var Util = sharedUtil.Util;
+var isString = sharedUtil.isString;
 var isArray = sharedUtil.isArray;
 var isInt = sharedUtil.isInt;
 var isValidUrl = sharedUtil.isValidUrl;
@@ -705,66 +706,77 @@ var LinkAnnotation = (function LinkAnnotationClosure() {
     var data = this.data;
     data.annotationType = AnnotationType.LINK;
 
-    var action = dict.get('A');
+    var action = dict.get('A'), url, dest;
     if (action && isDict(action)) {
       var linkType = action.get('S').name;
-      if (linkType === 'URI') {
-        var url = action.get('URI');
-        if (isName(url)) {
-          // Some bad PDFs do not put parentheses around relative URLs.
-          url = '/' + url.name;
-        } else if (url) {
-          url = addDefaultProtocolToUrl(url);
-        }
-        // TODO: pdf spec mentions urls can be relative to a Base
-        // entry in the dictionary.
-        if (!isValidUrl(url, false)) {
-          url = '';
-        }
-        // According to ISO 32000-1:2008, section 12.6.4.7,
-        // URI should to be encoded in 7-bit ASCII.
-        // Some bad PDFs may have URIs in UTF-8 encoding, see Bugzilla 1122280.
-        try {
-          data.url = stringToUTF8String(url);
-        } catch (e) {
-          // Fall back to a simple copy.
-          data.url = url;
-        }
-      } else if (linkType === 'GoTo') {
-        data.dest = action.get('D');
-      } else if (linkType === 'GoToR') {
-        var urlDict = action.get('F');
-        if (isDict(urlDict)) {
-          // We assume that the 'url' is a Filspec dictionary
-          // and fetch the url without checking any further
-          url = urlDict.get('F') || '';
-        }
+      switch (linkType) {
+        case 'URI':
+          url = action.get('URI');
+          if (isName(url)) {
+            // Some bad PDFs do not put parentheses around relative URLs.
+            url = '/' + url.name;
+          } else if (url) {
+            url = addDefaultProtocolToUrl(url);
+          }
+          // TODO: pdf spec mentions urls can be relative to a Base
+          // entry in the dictionary.
+          break;
 
-        // TODO: pdf reference says that GoToR
-        // can also have 'NewWindow' attribute
-        if (!isValidUrl(url, false)) {
-          url = '';
-        }
-        data.url = url;
-        data.dest = action.get('D');
-      } else if (linkType === 'Named') {
-        data.action = action.get('N').name;
-      } else {
-        warn('unrecognized link type: ' + linkType);
+        case 'GoTo':
+          dest = action.get('D');
+          break;
+
+        case 'GoToR':
+          var urlDict = action.get('F');
+          if (isDict(urlDict)) {
+            // We assume that the 'url' is a Filspec dictionary
+            // and fetch the url without checking any further
+            url = urlDict.get('F') || '';
+          }
+
+          // TODO: pdf reference says that GoToR
+          // can also have 'NewWindow' attribute
+          dest = action.get('D');
+          break;
+
+        case 'Named':
+          data.action = action.get('N').name;
+          break;
+
+        default:
+          warn('unrecognized link type: ' + linkType);
       }
-    } else if (dict.has('Dest')) {
-      // simple destination link
-      var dest = dict.get('Dest');
-      data.dest = isName(dest) ? dest.name : dest;
+    } else if (dict.has('Dest')) { // Simple destination link.
+      var destEntry = dict.get('Dest');
+      dest = isName(destEntry) ? destEntry.name : destEntry;
+    }
+
+    if (url) {
+      if (isValidUrl(url, /* allowRelative = */ false)) {
+        data.url = tryConvertUrlEncoding(url);
+      }
+    }
+    if (dest) {
+      data.dest = dest;
     }
   }
 
   // Lets URLs beginning with 'www.' default to using the 'http://' protocol.
   function addDefaultProtocolToUrl(url) {
-    if (url && url.indexOf('www.') === 0) {
+    if (isString(url) && url.indexOf('www.') === 0) {
       return ('http://' + url);
     }
     return url;
+  }
+
+  function tryConvertUrlEncoding(url) {
+    // According to ISO 32000-1:2008, section 12.6.4.7, URIs should be encoded
+    // in 7-bit ASCII. Some bad PDFs use UTF-8 encoding, see Bugzilla 1122280.
+    try {
+      return stringToUTF8String(url);
+    } catch (e) {
+      return url;
+    }
   }
 
   Util.inherit(LinkAnnotation, Annotation, {});

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -729,14 +729,21 @@ var LinkAnnotation = (function LinkAnnotationClosure() {
         case 'GoToR':
           var urlDict = action.get('F');
           if (isDict(urlDict)) {
-            // We assume that the 'url' is a Filspec dictionary
-            // and fetch the url without checking any further
-            url = urlDict.get('F') || '';
+            // We assume that we found a FileSpec dictionary
+            // and fetch the URL without checking any further.
+            url = urlDict.get('F') || null;
+          } else if (isString(urlDict)) {
+            url = urlDict;
           }
 
-          // TODO: pdf reference says that GoToR
-          // can also have 'NewWindow' attribute
-          dest = action.get('D');
+          // NOTE: the destination is relative to the *remote* document.
+          var remoteDest = action.get('D');
+          if (remoteDest && isString(remoteDest) && isString(url)) {
+            var baseUrl = url.split('#')[0];
+            url = baseUrl + '#' + remoteDest;
+          }
+          // The 'NewWindow' property, equal to `PDFJS.LinkTarget.BLANK`.
+          data.newWindow = action.get('NewWindow') || false;
           break;
 
         case 'Named':

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -761,6 +761,8 @@ var LinkAnnotation = (function LinkAnnotationClosure() {
     if (url) {
       if (isValidUrl(url, /* allowRelative = */ false)) {
         data.url = tryConvertUrlEncoding(url);
+      } else if (isValidUrl(url, /* allowRelative = */ true)) {
+        data.relativeUrl = tryConvertUrlEncoding(url);
       }
     }
     if (dest) {

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -31,6 +31,8 @@
 var AnnotationBorderStyleType = sharedUtil.AnnotationBorderStyleType;
 var AnnotationType = sharedUtil.AnnotationType;
 var Util = sharedUtil.Util;
+var isValidUrl = sharedUtil.isValidUrl;
+var combineUrl = sharedUtil.combineUrl;
 var addLinkAttributes = sharedUtil.addLinkAttributes;
 var getFilenameFromUrl = sharedUtil.getFilenameFromUrl;
 var warn = sharedUtil.warn;
@@ -276,11 +278,26 @@ var LinkAnnotationElement = (function LinkAnnotationElementClosure() {
     render: function LinkAnnotationElement_render() {
       this.container.className = 'linkAnnotation';
 
+      var linkUrl = this.data.url;
       var link = document.createElement('a');
-      addLinkAttributes(link, { url: this.data.url,
+
+      // If the `linkUrl` is undefined, check if a relative URL exists.
+      if (!linkUrl && this.data.relativeUrl) {
+        var baseUrl = this.linkService.relativeLinkAnnotationBaseUrl;
+
+        // Ensure that the `baseUrl` is absolute.
+        if (isValidUrl(baseUrl, false)) {
+          var combinedUrl = combineUrl(baseUrl, this.data.relativeUrl);
+          // Ensure that the final URL is absolute.
+          if (isValidUrl(combinedUrl, false)) {
+            linkUrl = combinedUrl;
+          }
+        }
+      }
+      addLinkAttributes(link, { url: linkUrl,
                                 newWindow: this.data.newWindow });
 
-      if (!this.data.url) {
+      if (!linkUrl) {
         if (this.data.action) {
           this._bindNamedAction(link, this.data.action);
         } else {

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -283,7 +283,7 @@ var LinkAnnotationElement = (function LinkAnnotationElementClosure() {
         if (this.data.action) {
           this._bindNamedAction(link, this.data.action);
         } else {
-          this._bindLink(link, ('dest' in this.data) ? this.data.dest : null);
+          this._bindLink(link, (this.data.dest || null));
         }
       }
 

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -277,7 +277,8 @@ var LinkAnnotationElement = (function LinkAnnotationElementClosure() {
       this.container.className = 'linkAnnotation';
 
       var link = document.createElement('a');
-      addLinkAttributes(link, { url: this.data.url });
+      addLinkAttributes(link, { url: this.data.url,
+                                newWindow: this.data.newWindow });
 
       if (!this.data.url) {
         if (this.data.action) {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -321,7 +321,7 @@ function isSameOrigin(baseUrl, otherUrl) {
 
 // Validates if URL is safe and allowed, e.g. to avoid XSS.
 function isValidUrl(url, allowRelative) {
-  if (!url) {
+  if (!url || typeof url !== 'string') {
     return false;
   }
   // RFC 3986 (http://tools.ietf.org/html/rfc3986#section-3.1)

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -349,14 +349,20 @@ PDFJS.isValidUrl = isValidUrl;
  * @param {HTMLLinkElement} link - The link element.
  * @param {Object} params - An object with the properties:
  * @param {string} params.url - An absolute URL.
+ * @param {boolean} params.newWindow - (optional) The 'NewWindow' property of
+ *   e.g. 'GoToR' destinations.
  */
 function addLinkAttributes(link, params) {
-  var url = params && params.url;
+  var url = (params && params.url) || null;
+  var newWindow = (params && params.newWindow) || false;
+
   link.href = link.title = (url ? removeNullCharacters(url) : '');
 
   if (url) {
     if (isExternalLinkTargetSet()) {
       link.target = LinkTargetStringMap[PDFJS.externalLinkTarget];
+    } else if (newWindow) {
+      link.target = LinkTarget.BLANK;
     }
     // Strip referrer from the URL.
     link.rel = PDFJS.externalLinkRel;

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -28,6 +28,7 @@ var PDFLinkService = (function () {
    */
   function PDFLinkService() {
     this.baseUrl = null;
+    this.relativeLinkAnnotationBaseUrl = null;
     this.pdfDocument = null;
     this.pdfViewer = null;
     this.pdfHistory = null;
@@ -36,9 +37,13 @@ var PDFLinkService = (function () {
   }
 
   PDFLinkService.prototype = {
-    setDocument: function PDFLinkService_setDocument(pdfDocument, baseUrl) {
-      this.baseUrl = baseUrl;
+    setDocument:
+        function PDFLinkService_setDocument(pdfDocument, baseUrl,
+                                            relativeLinkAnnotationBaseUrl) {
       this.pdfDocument = pdfDocument;
+      this.baseUrl = baseUrl;
+      this.relativeLinkAnnotationBaseUrl =
+        relativeLinkAnnotationBaseUrl || null;
       this._pagesRefCache = Object.create(null);
     },
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -864,14 +864,18 @@ var PDFViewerApplication = {
 
 //#if GENERIC
     var baseDocumentUrl = null;
+    var relativeLinkAnnotationBaseUrl = null;
 //#endif
 //#if (FIREFOX || MOZCENTRAL)
 //  var baseDocumentUrl = this.url.split('#')[0];
+//  var relativeLinkAnnotationBaseUrl = baseDocumentUrl;
 //#endif
 //#if CHROME
 //  var baseDocumentUrl = location.href.split('#')[0];
+//  var relativeLinkAnnotationBaseUrl = this.url.split('#')[0];
 //#endif
-    this.pdfLinkService.setDocument(pdfDocument, baseDocumentUrl);
+    this.pdfLinkService.setDocument(pdfDocument, baseDocumentUrl,
+                                    relativeLinkAnnotationBaseUrl);
 
     var pdfViewer = this.pdfViewer;
     pdfViewer.currentScale = scale;


### PR DESCRIPTION
_Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=766086 (and replaces PR #6830)._
- Refactor `LinkAnnotation` slightly to add `data.url`/`data.dest` at the end
  _This should simplify reviewing: https://github.com/Snuffleupagus/pdf.js/commit/9a1410252b6597feff762b0a649dea2b1166d40c?w=1_
- Various improvements for `GoToR` actions
  
  > - Add support for the `NewWindow` property.
  > - Ensure that destinations are applied to the _remote_ document, instead of the current one.
  > - Handle the `F` entry being a standard string, instead of a dictionary.
- Add support for LinkAnnotations with relative URLs, by making it possible to set the baseUrl for those in `PDFLinkService` (bug 766086)
  
  > Some PDF generators unfortunately create files with relative URLs, which thus prevents some inter-PDF links from working in PDF.js.
  > 
  > The reason that `PDFLinkService.baseUrl` wasn't re-used, is that this would only work in the Firefox addon/built-in version (and not in e.g. the Chrome addon).
  > 
  > Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=766086.
  > 
  > **Please note:** Given that this patch could be considered somewhat risky, from a security perspective, I'll understand if we ultimately end up rejecting it. But in that case, I think that we should probably close the referenced bug as WONTFIX.
