### PR TITLE
Pass the `PDFJS.postMessageTransfer` parameter to the worker, so that the `MessageHandler` can be setup correctly in `createDocumentHandler` (issue 6957)

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -480,6 +480,10 @@ var WorkerMessageHandler = PDFJS.WorkerMessageHandler = {
     var workerHandlerName = docParams.docId + '_worker';
     var handler = new MessageHandler(workerHandlerName, docId, port);
 
+    // Ensure that postMessage transfers are correctly enabled/disabled,
+    // to prevent "DataCloneError" in older versions of IE (see issue 6957).
+    handler.postMessageTransfers = docParams.postMessageTransfers;
+
     function ensureNotTerminated() {
       if (terminated) {
         throw new Error('Worker was terminated');

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -454,7 +454,8 @@ function _fetchDocument(worker, source, pdfDataRangeTransport, docId) {
     cMapPacked: PDFJS.cMapPacked,
     disableFontFace: PDFJS.disableFontFace,
     disableCreateObjectURL: PDFJS.disableCreateObjectURL,
-    verbosity: PDFJS.verbosity
+    verbosity: PDFJS.verbosity,
+    postMessageTransfers: PDFJS.postMessageTransfers,
   }).then(function (workerId) {
     if (worker.destroyed) {
       throw new Error('Worker was destroyed');


### PR DESCRIPTION
This regressed in commit https://github.com/mozilla/pdf.js/pull/6571/commits/acdd49f48097ffcb27332673a8b51cd653f6de88, i.e. PR #6571.

Fixes #6957.
