### PR TITLE
Use the correct path when checking if a `/l10n` directory exists, to avoid errors during `gulp importl10n` (PR 7063 followup)

### DIFF
--- a/external/importL10n/locales.js
+++ b/external/importL10n/locales.js
@@ -55,13 +55,14 @@ function downloadLanguageFiles(root, langCode, callback) {
   var files = ['chrome.properties', 'viewer.properties'];
   var downloadsLeft = files.length;
 
-  if (!fs.existsSync(langCode)) {
-    fs.mkdirSync(path.join(root, langCode));
+  var outputDir = path.join(root, langCode);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir);
   }
 
   // Download the necessary files for this language.
   files.forEach(function(fileName) {
-    var outputPath = path.join(root, langCode, fileName);
+    var outputPath = path.join(outputDir, fileName);
     var url = MOZCENTRAL_ROOT + langCode + MOZCENTRAL_PDFJS_DIR +
               fileName + MOZCENTRAL_RAW_FLAG;
     var request = http.get(url, function(response) {


### PR DESCRIPTION
This is regression from PR #7063, causing `gulp importl10n` to fail:

```
$ gulp importl10n
[19:45:02] Using gulpfile c:\Users\Jonas\Git\pdfjs\gulpfile.js
[19:45:02] Starting 'importl10n'...

Downloading ach...
[19:45:02] 'importl10n' errored after 4.42 ms
[19:45:02] Error: EEXIST, file already exists 'c:\Users\Jonas\Git\pdfjs\l10n\ach
'
    at Error (native)
    at Object.fs.mkdirSync (fs.js:747:18)
    at downloadLanguageFiles (c:\Users\Jonas\Git\pdfjs\external\importL10n\local
es.js:59:8)
    at next (c:\Users\Jonas\Git\pdfjs\external\importL10n\locales.js:90:5)
    at Object.downloadL10n (c:\Users\Jonas\Git\pdfjs\external\importL10n\locales
.js:91:5)
    at Gulp.<anonymous> (c:\Users\Jonas\Git\pdfjs\gulpfile.js:92:11)
    at module.exports (c:\Users\Jonas\Git\pdfjs\node_modules\gulp\node_modules\o
rchestrator\lib\runTask.js:34:7)
    at Gulp.Orchestrator._runTask (c:\Users\Jonas\Git\pdfjs\node_modules\gulp\no
de_modules\orchestrator\index.js:273:3)
    at Gulp.Orchestrator._runStep (c:\Users\Jonas\Git\pdfjs\node_modules\gulp\no
de_modules\orchestrator\index.js:214:10)
    at Gulp.Orchestrator.start (c:\Users\Jonas\Git\pdfjs\node_modules\gulp\node_
modules\orchestrator\index.js:134:8)
```
