### PR TITLE
Removes core/stream circular dependency on core/parser.

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -1116,7 +1116,4 @@ exports.Lexer = Lexer;
 exports.Linearization = Linearization;
 exports.Parser = Parser;
 exports.isEOF = isEOF;
-
-// TODO refactor to remove dependency on stream.js
-coreStream._setCoreParser(exports);
 }));


### PR DESCRIPTION
We were using EOF as an object. Making it a number might make CCITT faster (easier for JIT).

Partially addresses #6777
