### PR TITLE
Prevent failures in the Annotation code if the `Rect` array contains indirect objects (issue 7115)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -171,7 +171,7 @@ var Annotation = (function AnnotationClosure() {
     var dict = params.dict;
 
     this.setFlags(dict.get('F'));
-    this.setRectangle(dict.get('Rect'));
+    this.setRectangle(dict.getArray('Rect'));
     this.setColor(dict.get('C'));
     this.setBorderStyle(dict);
     this.appearance = getDefaultAppearance(dict);

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -20,6 +20,7 @@
 !issue6782.pdf
 !issue6961.pdf
 !issue7020.pdf
+!issue7115.pdf
 !filled-background.pdf
 !ArabicCIDTrueType.pdf
 !ThuluthFeatures.pdf

--- a/test/pdfs/issue7115.pdf
+++ b/test/pdfs/issue7115.pdf
@@ -1,0 +1,97 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/Pages 2 0 R
+/Type /Catalog
+>>
+endobj 
+2 0 obj 
+<<
+/Kids [3 0 R]
+/Type /Pages
+/Count 1
+>>
+endobj 
+3 0 obj 
+<<
+/Parent 2 0 R
+/Annots [4 0 R]
+/Resources 
+<<
+/Font 
+<<
+/F1 5 0 R
+>>
+>>
+/MediaBox [0 0 200 50]
+/Type /Page
+/Contents 6 0 R
+>>
+endobj 
+4 0 obj 
+<<
+/Border [0 0 1]
+/Subtype /Link
+/C [0 1 0]
+/A 
+<<
+/URI (http://www.example.com)
+/Type /Action
+/S /URI
+>>
+/Type /Annot
+/Rect [7 0 R 8 0 R 9 0 R 10 0 R]
+>>
+endobj 
+5 0 obj 
+<<
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Type /Font
+/Encoding /WinAnsiEncoding
+>>
+endobj 
+6 0 obj 
+<<
+/Length 55
+>>
+stream
+1 0 0 rg
+BT
+10 20 TD
+/F1 20 Tf
+(www.example.com) Tj
+ET
+
+endstream 
+endobj 
+7 0 obj 5
+endobj 
+8 0 obj 10
+endobj 
+9 0 obj 170
+endobj 
+10 0 obj 40
+endobj xref
+0 11
+0000000000 65535 f 
+0000000015 00000 n 
+0000000066 00000 n 
+0000000125 00000 n 
+0000000270 00000 n 
+0000000443 00000 n 
+0000000544 00000 n 
+0000000652 00000 n 
+0000000670 00000 n 
+0000000689 00000 n 
+0000000709 00000 n 
+trailer
+
+<<
+/Root 1 0 R
+/Size 11
+>>
+startxref
+728
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -577,6 +577,15 @@
        "type": "eq",
        "about": "XObject with BBox array containing indirect object."
     },
+    {  "id": "issue7115",
+       "file": "pdfs/issue7115.pdf",
+       "md5": "63c78e25a0433dd5a01ddff6ec720f29",
+       "link": false,
+       "rounds": 1,
+       "type": "eq",
+       "annotations": true,
+       "about": "Annotation with Rect array containing indirect objects."
+    },
     {  "id": "issue4934",
        "file": "pdfs/issue4934.pdf",
        "md5": "6099da44f677702ae65a648b51a2226d",


### PR DESCRIPTION
Note that in the PDF files provided by the reporter, this issue was limited to `Rect` arrays in AcroForm entries (which we currently don't support).
However, since a bad PDF generator could create this problem in _any_ kind of annotation, the reduced test-case included here uses a simple LinkAnnotation instead.

Fixes #7115.

**A note for the reviewer:** If you need a copy of the original PDF files for verification purposes, please let me know!
