### PR TITLE
Allow unit-tests to use linked PDF files, by having the `unittest` command download unavailable ones (issue 7117)

### DIFF
--- a/make.js
+++ b/make.js
@@ -1249,6 +1249,7 @@ target.unittest = function(options, callback) {
   echo();
   echo('### Running unit tests');
 
+  var PDF_TEST = env['PDF_TEST'] || 'test_manifest.json';
   var PDF_BROWSERS = env['PDF_BROWSERS'] ||
                      'resources/browser_manifests/browser_manifest.json';
 
@@ -1260,7 +1261,7 @@ target.unittest = function(options, callback) {
   callback = callback || function() {};
   cd('test');
   exec('node test.js --unitTest --browserManifestFile=' +
-       PDF_BROWSERS, {async: true}, callback);
+       PDF_BROWSERS + ' --manifestFile=' + PDF_TEST, {async: true}, callback);
 };
 
 //

--- a/test/test.js
+++ b/test/test.js
@@ -730,7 +730,9 @@ function main() {
   } else if (!options.browser && !options.browserManifestFile) {
     startServer();
   } else if (options.unitTest) {
-    startUnitTest('/test/unit/unit_test.html', 'unit');
+    ensurePDFsDownloaded(function() { // Allows linked PDF files in unit-tests.
+      startUnitTest('/test/unit/unit_test.html', 'unit');
+    });
   } else if (options.fontTest) {
     startUnitTest('/test/font/font_test.html', 'font');
   } else {


### PR DESCRIPTION
Re: #7117.
