### PR TITLE
Fixes for JS reserved words catch, char, and delete

### DIFF
--- a/examples/webpack/main.js
+++ b/examples/webpack/main.js
@@ -27,6 +27,6 @@ loadingTask.promise.then(function (pdfDocument) {
     });
     return renderTask.promise;
   });
-}).catch(function (reason) {
+})['catch'](function (reason) {
   console.error('Error: ' + reason);
 });

--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -568,7 +568,7 @@ var BinaryCMapReader = (function BinaryCMapReaderClosure() {
       var useCMap = null;
       var start = new Uint8Array(MAX_NUM_SIZE);
       var end = new Uint8Array(MAX_NUM_SIZE);
-      var char = new Uint8Array(MAX_NUM_SIZE);
+      var character = new Uint8Array(MAX_NUM_SIZE);
       var charCode = new Uint8Array(MAX_NUM_SIZE);
       var tmp = new Uint8Array(MAX_NUM_SIZE);
       var code;
@@ -629,17 +629,17 @@ var BinaryCMapReader = (function BinaryCMapReaderClosure() {
             }
             break;
           case 2: // cidchar
-            stream.readHex(char, dataSize);
+            stream.readHex(character, dataSize);
             code = stream.readNumber();
-            cMap.mapOne(hexToInt(char, dataSize), code);
+            cMap.mapOne(hexToInt(character, dataSize), code);
             for (i = 1; i < subitemsCount; i++) {
-              incHex(char, dataSize);
+              incHex(character, dataSize);
               if (!sequence) {
                 stream.readHexNumber(tmp, dataSize);
-                addHex(char, tmp, dataSize);
+                addHex(character, tmp, dataSize);
               }
               code = stream.readSigned() + (code + 1);
-              cMap.mapOne(hexToInt(char, dataSize), code);
+              cMap.mapOne(hexToInt(character, dataSize), code);
             }
             break;
           case 3: // cidrange
@@ -665,20 +665,20 @@ var BinaryCMapReader = (function BinaryCMapReaderClosure() {
             }
             break;
           case 4: // bfchar
-            stream.readHex(char, ucs2DataSize);
+            stream.readHex(character, ucs2DataSize);
             stream.readHex(charCode, dataSize);
-            cMap.mapOne(hexToInt(char, ucs2DataSize),
+            cMap.mapOne(hexToInt(character, ucs2DataSize),
                         hexToStr(charCode, dataSize));
             for (i = 1; i < subitemsCount; i++) {
-              incHex(char, ucs2DataSize);
+              incHex(character, ucs2DataSize);
               if (!sequence) {
                 stream.readHexNumber(tmp, ucs2DataSize);
-                addHex(char, tmp, ucs2DataSize);
+                addHex(character, tmp, ucs2DataSize);
               }
               incHex(charCode, dataSize);
               stream.readHexSigned(tmp, dataSize);
               addHex(charCode, tmp, dataSize);
-              cMap.mapOne(hexToInt(char, ucs2DataSize),
+              cMap.mapOne(hexToInt(character, ucs2DataSize),
                           hexToStr(charCode, dataSize));
             }
             break;
@@ -990,7 +990,7 @@ var CMapFactory = (function CMapFactoryClosure() {
             parseCMap(cMap, lexer, builtInCMapParams, null).then(
                 function (parsedCMap) {
               resolve(parsedCMap);
-            }).catch(function (e) {
+            })['catch'](function (e) {
               reject(new Error({ message: 'Invalid CMap data', error: e }));
             });
           } else {

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -595,7 +595,7 @@ var WorkerMessageHandler = {
         }, evaluatorOptions);
         pdfManagerCapability.resolve(pdfManager);
         cancelXHRs = null;
-      }).catch(function (reason) {
+      })['catch'](function (reason) {
         pdfManagerCapability.reject(reason);
         cancelXHRs = null;
       });
@@ -650,7 +650,7 @@ var WorkerMessageHandler = {
         };
         fullRequest.read().then(readChunk, reject);
       });
-      readPromise.catch(function (e) {
+      readPromise['catch'](function (e) {
         pdfManagerCapability.reject(e);
         cancelXHRs = null;
       });

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -410,7 +410,7 @@ PDFJS.getDocument = function getDocument(src,
       task._transport = transport;
       messageHandler.send('Ready', null);
     });
-  }).catch(task._capability.reject);
+  })['catch'](task._capability.reject);
 
   return task;
 };

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -72,7 +72,7 @@ FontLoader.prototype = {
     }
 //#if !(MOZCENTRAL)
     this.nativeFontFaces.forEach(function(nativeFontFace) {
-      document.fonts.delete(nativeFontFace);
+      document.fonts['delete'](nativeFontFace);
     });
     this.nativeFontFaces.length = 0;
 //#endif
@@ -121,7 +121,7 @@ FontLoader.prototype = {
     var getNativeFontPromise = function(nativeFontFace) {
       // Return a promise that is always fulfilled, even when the font fails to
       // load.
-      return nativeFontFace.loaded.catch(function(e) {
+      return nativeFontFace.loaded['catch'](function(e) {
         warn('Failed to load font "' + nativeFontFace.family + '": ' + e);
       });
     };

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1163,8 +1163,8 @@ function createPromiseCapability() {
         });
       };
     }
-    if (typeof globalScope.Promise.prototype.catch !== 'function') {
-      globalScope.Promise.prototype.catch = function (onReject) {
+    if (typeof globalScope.Promise.prototype['catch'] !== 'function') {
+      globalScope.Promise.prototype['catch'] = function (onReject) {
         return globalScope.Promise.prototype.then(undefined, onReject);
       };
     }
@@ -1424,7 +1424,7 @@ function createPromiseCapability() {
       return nextPromise;
     },
 
-    catch: function Promise_catch(onReject) {
+    'catch': function Promise_catch(onReject) {
       return this.then(undefined, onReject);
     }
   };

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -272,7 +272,7 @@ describe('evaluator', function() {
         var result = new OperatorList();
         var task = new WorkerTask('OperatorListAbort');
         task.terminate();
-        evaluator.getOperatorList(stream, task, resources, result).catch(
+        evaluator.getOperatorList(stream, task, resources, result)['catch'](
           function () {
             done = true;
             expect(!!result.fnArray && !!result.argsArray).toEqual(true);
@@ -293,7 +293,7 @@ describe('evaluator', function() {
       runs(function () {
         var task = new WorkerTask('TextContentAbort');
         task.terminate();
-        evaluator.getTextContent(stream, task, resources).catch(
+        evaluator.getTextContent(stream, task, resources)['catch'](
           function () {
             done = true;
           });

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -333,7 +333,7 @@ var PDFViewerApplication = {
         PDFJS.externalLinkTarget = value;
       }),
       // TODO move more preferences and other async stuff here
-    ]).catch(function (reason) { });
+    ])['catch'](function (reason) { });
 
     return initializedPromise.then(function () {
       if (self.isViewerEmbedded && !PDFJS.isExternalLinkTargetSet()) {
@@ -1689,7 +1689,7 @@ window.addEventListener('updateviewarea', function (evt) {
       'zoom': location.scale,
       'scrollLeft': location.left,
       'scrollTop': location.top
-    }).catch(function() {
+    })['catch'](function() {
       // unable to write to storage
     });
   });


### PR DESCRIPTION
Using pdf.js in a project that leverages http://yui.github.io/yuicompressor/ caused errors due to pdf.js's use of JavaScript reserved words.
