### PR TITLE
Move all PDFJS display/ usages into global.js file.

### DIFF
--- a/examples/acroforms/forms.js
+++ b/examples/acroforms/forms.js
@@ -140,9 +140,9 @@ function renderPage(div, pdf, pageNumber, callback) {
 
 // In production, the bundled pdf.js shall be used instead of RequireJS.
 require.config({paths: {'pdfjs': '../../src'}});
-require(['pdfjs/display/api'], function (api) {
+require(['pdfjs/display/api', 'pdfjs/display/global'], function (api, global) {
   // In production, change this to point to the built `pdf.worker.js` file.
-  PDFJS.workerSrc = '../../src/worker_loader.js';
+  global.PDFJS.workerSrc = '../../src/worker_loader.js';
 
   // Fetch the PDF document from the URL using promises.
   api.getDocument(pdfWithFormsPath).then(function getPdfForm(pdf) {

--- a/examples/helloworld/hello.js
+++ b/examples/helloworld/hello.js
@@ -2,9 +2,9 @@
 
 // In production, the bundled pdf.js shall be used instead of RequireJS.
 require.config({paths: {'pdfjs': '../../src'}});
-require(['pdfjs/display/api'], function (api) {
+require(['pdfjs/display/api', 'pdfjs/display/global'], function (api, global) {
   // In production, change this to point to the built `pdf.worker.js` file.
-  PDFJS.workerSrc = '../../src/worker_loader.js';
+  global.PDFJS.workerSrc = '../../src/worker_loader.js';
 
   // Fetch the PDF document from the URL using promises.
   api.getDocument('helloworld.pdf').then(function (pdf) {

--- a/examples/node/domstubs.js
+++ b/examples/node/domstubs.js
@@ -120,10 +120,6 @@ DOMElement.prototype = {
   },
 }
 
-global.window = global;
-
-global.navigator = { userAgent: 'node' };
-
 global.document = {
   childNodes : [],
 

--- a/examples/node/getinfo.js
+++ b/examples/node/getinfo.js
@@ -13,7 +13,7 @@ var fs = require('fs');
 global.DOMParser = require('./domparsermock.js').DOMParserMock;
 
 // Run `gulp dist` to generate 'pdfjs-dist' npm package files.
-require('../../build/dist');
+var pdfjsLib = require('../../build/dist');
 
 // Loading file from file system into typed array
 var pdfPath = process.argv[2] || '../../web/compressed.tracemonkey-pldi-09.pdf';
@@ -21,7 +21,7 @@ var data = new Uint8Array(fs.readFileSync(pdfPath));
 
 // Will be using promises to load document, pages and misc data instead of
 // callback.
-PDFJS.getDocument(data).then(function (doc) {
+pdfjsLib.getDocument(data).then(function (doc) {
   var numPages = doc.numPages;
   console.log('# Document Loaded');
   console.log('Number of Pages: ' + numPages);

--- a/examples/node/pdf2svg.js
+++ b/examples/node/pdf2svg.js
@@ -11,7 +11,7 @@ var fs = require('fs');
 require('./domstubs.js');
 
 // Run `gulp dist` to generate 'pdfjs-dist' npm package files.
-require('../../build/dist');
+var pdfjsLib = require('../../build/dist');
 
 // Loading file from file system into typed array
 var pdfPath = process.argv[2] || '../../web/compressed.tracemonkey-pldi-09.pdf';
@@ -44,7 +44,7 @@ function getFileNameFromPath(path) {
 
 // Will be using promises to load document, pages and misc data instead of
 // callback.
-PDFJS.getDocument(data).then(function (doc) {
+pdfjsLib.getDocument(data).then(function (doc) {
   var numPages = doc.numPages;
   console.log('# Document Loaded');
   console.log('Number of Pages: ' + numPages);
@@ -59,7 +59,7 @@ PDFJS.getDocument(data).then(function (doc) {
       console.log();
 
       return page.getOperatorList().then(function (opList) {
-        var svgGfx = new PDFJS.SVGGraphics(page.commonObjs, page.objs);
+        var svgGfx = new pdfjsLib.SVGGraphics(page.commonObjs, page.objs);
         svgGfx.embedFonts = true;
         return svgGfx.getSVG(opList, viewport).then(function (svg) {
           var svgDump = svg.toString();

--- a/examples/webpack/main.js
+++ b/examples/webpack/main.js
@@ -3,7 +3,7 @@
 
 // Hello world example for webpack.
 
-require('pdfjs-dist');
+var pdfjsLib = require('pdfjs-dist');
 
 var pdfPath = '../helloworld/helloworld.pdf';
 
@@ -11,7 +11,7 @@ var pdfPath = '../helloworld/helloworld.pdf';
 // however that might degrade the UI performance in web browsers.
 
 // Loading a document.
-var loadingTask = PDFJS.getDocument(pdfPath);
+var loadingTask = pdfjsLib.getDocument(pdfPath);
 loadingTask.promise.then(function (pdfDocument) {
   // Request a first page
   return pdfDocument.getPage(1).then(function (pdfPage) {

--- a/make.js
+++ b/make.js
@@ -198,6 +198,7 @@ target.jsdoc = function() {
   var JSDOC_FILES = [
     'src/doc_helper.js',
     'src/display/api.js',
+    'src/display/global.js',
     'src/shared/util.js',
     'src/core/annotation.js'
   ];
@@ -526,9 +527,7 @@ target.bundle = function(args) {
 
   var umd = require('./external/umdutils/verifier.js');
   var MAIN_SRC_FILES = [
-    SRC_DIR + 'display/annotation_layer.js',
-    SRC_DIR + 'display/text_layer.js',
-    SRC_DIR + 'display/api.js'
+    SRC_DIR + 'display/global.js'
   ];
 
   var WORKER_SRC_FILES = [
@@ -538,9 +537,8 @@ target.bundle = function(args) {
   var mainFileName = 'pdf.js';
   var workerFileName = 'pdf.worker.js';
 
-  // Extension does not need svg.js and network.js files.
+  // Extension does not need network.js file.
   if (!defines.FIREFOX && !defines.MOZCENTRAL) {
-    MAIN_SRC_FILES.push(SRC_DIR + 'display/svg.js');
     WORKER_SRC_FILES.push(SRC_DIR + 'core/network.js');
   }
 

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS */
 
 'use strict';
 
@@ -35,6 +34,7 @@ var addLinkAttributes = displayDOMUtils.addLinkAttributes;
 var getFilenameFromUrl = displayDOMUtils.getFilenameFromUrl;
 var warn = sharedUtil.warn;
 var CustomStyle = displayDOMUtils.CustomStyle;
+var getDefaultSetting = displayDOMUtils.getDefaultSetting;
 
 /**
  * @typedef {Object} AnnotationElementParameters
@@ -107,6 +107,7 @@ var AnnotationElement = (function AnnotationElementClosure() {
     this.viewport = parameters.viewport;
     this.linkService = parameters.linkService;
     this.downloadManager = parameters.downloadManager;
+    this.imageResourcesPath = parameters.imageResourcesPath;
 
     if (isRenderable) {
       this.container = this._createContainer();
@@ -363,7 +364,7 @@ var TextAnnotationElement = (function TextAnnotationElementClosure() {
       var image = document.createElement('img');
       image.style.height = this.container.style.height;
       image.style.width = this.container.style.width;
-      image.src = PDFJS.imageResourcesPath + 'annotation-' +
+      image.src = this.imageResourcesPath + 'annotation-' +
         this.data.name.toLowerCase() + '.svg';
       image.alt = '[{{type}} Annotation]';
       image.dataset.l10nId = 'text_annotation_type';
@@ -838,6 +839,7 @@ var FileAttachmentAnnotationElement = (
  * @property {Array} annotations
  * @property {PDFPage} page
  * @property {IPDFLinkService} linkService
+ * @property {string} imageResourcesPath
  */
 
 /**
@@ -868,7 +870,9 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
           page: parameters.page,
           viewport: parameters.viewport,
           linkService: parameters.linkService,
-          downloadManager: parameters.downloadManager
+          downloadManager: parameters.downloadManager,
+          imageResourcesPath: parameters.imageResourcesPath ||
+                              getDefaultSetting('imageResourcesPath')
         };
         var element = annotationElementFactory.create(properties);
         if (element.isRenderable) {
@@ -898,8 +902,6 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
     }
   };
 })();
-
-PDFJS.AnnotationLayer = AnnotationLayer;
 
 exports.AnnotationLayer = AnnotationLayer;
 }));

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2002,7 +2002,7 @@ var InternalRenderTask = (function InternalRenderTaskClosure() {
     },
 
     _scheduleNext: function InternalRenderTask__scheduleNext() {
-      if (this.useRequestAnimationFrame) {
+      if (this.useRequestAnimationFrame && typeof window !== 'undefined') {
         window.requestAnimationFrame(this._nextBound);
       } else {
         Promise.resolve(undefined).then(this._nextBound);

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals pdfjsFilePath */
+/* globals pdfjsFilePath, pdfjsVersion, pdfjsBuild */
 
 'use strict';
 
@@ -2050,6 +2050,13 @@ var _UnsupportedManager = (function UnsupportedManagerClosure() {
     }
   };
 })();
+
+if (typeof pdfjsVersion !== 'undefined') {
+  exports.version = pdfjsVersion;
+}
+if (typeof pdfjsBuild !== 'undefined') {
+  exports.build = pdfjsBuild;
+}
 
 exports.getDocument = getDocument;
 exports.PDFDataRangeTransport = PDFDataRangeTransport;

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -308,19 +308,20 @@ FontLoader.isFontLoadingAPISupported = typeof document !== 'undefined' &&
 //#if !(MOZCENTRAL || CHROME)
 Object.defineProperty(FontLoader, 'isSyncFontLoadingSupported', {
   get: function () {
+    if (typeof navigator === 'undefined') {
+      // node.js - we can pretend sync font loading is supported.
+      return shadow(FontLoader, 'isSyncFontLoadingSupported', true);
+    }
+
     var supported = false;
 
     // User agent string sniffing is bad, but there is no reliable way to tell
     // if font is fully loaded and ready to be used with canvas.
-    var userAgent = window.navigator.userAgent;
-    var m = /Mozilla\/5.0.*?rv:(\d+).*? Gecko/.exec(userAgent);
+    var m = /Mozilla\/5.0.*?rv:(\d+).*? Gecko/.exec(navigator.userAgent);
     if (m && m[1] >= 14) {
       supported = true;
     }
     // TODO other browsers
-    if (userAgent === 'node') {
-      supported = true;
-    }
     return shadow(FontLoader, 'isSyncFontLoadingSupported', supported);
   },
   enumerable: true,
@@ -378,8 +379,7 @@ var FontFaceObject = (function FontFaceObjectClosure() {
       var fontName = this.loadedName;
 
       // Add the font-face rule to the document
-      var url = ('url(data:' + this.mimetype + ';base64,' +
-                 window.btoa(data) + ');');
+      var url = ('url(data:' + this.mimetype + ';base64,' + btoa(data) + ');');
       var rule = '@font-face { font-family:"' + fontName + '";src:' + url + '}';
 
       if (this.options.fontRegistry) {

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -18,21 +18,36 @@
 
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define('pdfjs/display/global', ['exports', 'pdfjs/shared/util'], factory);
+    define('pdfjs/display/global', ['exports', 'pdfjs/shared/util',
+      'pdfjs/display/dom_utils', 'pdfjs/display/api',
+      'pdfjs/display/annotation_layer', 'pdfjs/display/text_layer',
+      'pdfjs/display/metadata', 'pdfjs/display/svg'], factory);
   } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../shared/util.js'));
+    factory(exports, require('../shared/util.js'), require('./dom_utils.js'),
+      require('./api.js'), require('./annotation_layer.js'),
+      require('./text_layer.js'), require('./metadata.js'),
+      require('./svg.js'));
   } else {
-    factory((root.pdfjsDisplayGlobal = {}), root.pdfjsSharedUtil);
+    factory((root.pdfjsDisplayGlobal = {}), root.pdfjsSharedUtil,
+      root.pdfjsDisplayDOMUtils, root.pdfjsDisplayAPI,
+      root.pdfjsDisplayAnnotationLayer, root.pdfjsDisplayTextLayer,
+      root.pdfjsDisplayMetadata, root.pdfjsDisplaySVG);
   }
-}(this, function (exports, sharedUtil) {
+}(this, function (exports, sharedUtil, displayDOMUtils, displayAPI,
+                  displayAnnotationLayer, displayTextLayer, displayMetadata,
+                  displaySVG) {
 
   var globalScope = sharedUtil.globalScope;
+  var deprecated = sharedUtil.deprecated;
+  var warn = sharedUtil.warn;
+  var LinkTarget = displayDOMUtils.LinkTarget;
 
   var isWorker = (typeof window === 'undefined');
 
-  // The global PDFJS object exposes the API
-  // In production, it will be declared outside a global wrapper
-  // In development, it will be declared here
+  // The global PDFJS object is now deprecated and will not be supported in
+  // the future. The members below are maintained for backward  compatibility
+  // and shall not be extended or modified. If the global.js is included as
+  // a module, we will create a global PDFJS object instance or use existing.
   if (!globalScope.PDFJS) {
     globalScope.PDFJS = {};
   }
@@ -85,6 +100,209 @@
   PDFJS.Util = sharedUtil.Util;
   PDFJS.PageViewport = sharedUtil.PageViewport;
   PDFJS.createPromiseCapability = sharedUtil.createPromiseCapability;
+
+  /**
+   * The maximum allowed image size in total pixels e.g. width * height. Images
+   * above this value will not be drawn. Use -1 for no limit.
+   * @var {number}
+   */
+  PDFJS.maxImageSize = (PDFJS.maxImageSize === undefined ?
+                        -1 : PDFJS.maxImageSize);
+
+  /**
+   * The url of where the predefined Adobe CMaps are located. Include trailing
+   * slash.
+   * @var {string}
+   */
+  PDFJS.cMapUrl = (PDFJS.cMapUrl === undefined ? null : PDFJS.cMapUrl);
+
+  /**
+   * Specifies if CMaps are binary packed.
+   * @var {boolean}
+   */
+  PDFJS.cMapPacked = PDFJS.cMapPacked === undefined ? false : PDFJS.cMapPacked;
+
+  /**
+   * By default fonts are converted to OpenType fonts and loaded via font face
+   * rules. If disabled, the font will be rendered using a built in font
+   * renderer that constructs the glyphs with primitive path commands.
+   * @var {boolean}
+   */
+  PDFJS.disableFontFace = (PDFJS.disableFontFace === undefined ?
+                           false : PDFJS.disableFontFace);
+
+  /**
+   * Path for image resources, mainly for annotation icons. Include trailing
+   * slash.
+   * @var {string}
+   */
+  PDFJS.imageResourcesPath = (PDFJS.imageResourcesPath === undefined ?
+                              '' : PDFJS.imageResourcesPath);
+
+  /**
+   * Disable the web worker and run all code on the main thread. This will
+   * happen automatically if the browser doesn't support workers or sending
+   * typed arrays to workers.
+   * @var {boolean}
+   */
+  PDFJS.disableWorker = (PDFJS.disableWorker === undefined ?
+                         false : PDFJS.disableWorker);
+
+  /**
+   * Path and filename of the worker file. Required when the worker is enabled
+   * in development mode. If unspecified in the production build, the worker
+   * will be loaded based on the location of the pdf.js file. It is recommended
+   * that the workerSrc is set in a custom application to prevent issues caused
+   * by third-party frameworks and libraries.
+   * @var {string}
+   */
+  PDFJS.workerSrc = (PDFJS.workerSrc === undefined ? null : PDFJS.workerSrc);
+
+  /**
+   * Disable range request loading of PDF files. When enabled and if the server
+   * supports partial content requests then the PDF will be fetched in chunks.
+   * Enabled (false) by default.
+   * @var {boolean}
+   */
+  PDFJS.disableRange = (PDFJS.disableRange === undefined ?
+                        false : PDFJS.disableRange);
+
+  /**
+   * Disable streaming of PDF file data. By default PDF.js attempts to load PDF
+   * in chunks. This default behavior can be disabled.
+   * @var {boolean}
+   */
+  PDFJS.disableStream = (PDFJS.disableStream === undefined ?
+                         false : PDFJS.disableStream);
+
+  /**
+   * Disable pre-fetching of PDF file data. When range requests are enabled
+   * PDF.js will automatically keep fetching more data even if it isn't needed
+   * to display the current page. This default behavior can be disabled.
+   *
+   * NOTE: It is also necessary to disable streaming, see above,
+   *       in order for disabling of pre-fetching to work correctly.
+   * @var {boolean}
+   */
+  PDFJS.disableAutoFetch = (PDFJS.disableAutoFetch === undefined ?
+                            false : PDFJS.disableAutoFetch);
+
+  /**
+   * Enables special hooks for debugging PDF.js.
+   * @var {boolean}
+   */
+  PDFJS.pdfBug = (PDFJS.pdfBug === undefined ? false : PDFJS.pdfBug);
+
+  /**
+   * Enables transfer usage in postMessage for ArrayBuffers.
+   * @var {boolean}
+   */
+  PDFJS.postMessageTransfers = (PDFJS.postMessageTransfers === undefined ?
+                                true : PDFJS.postMessageTransfers);
+
+  /**
+   * Disables URL.createObjectURL usage.
+   * @var {boolean}
+   */
+  PDFJS.disableCreateObjectURL = (PDFJS.disableCreateObjectURL === undefined ?
+                                  false : PDFJS.disableCreateObjectURL);
+
+  /**
+   * Disables WebGL usage.
+   * @var {boolean}
+   */
+  PDFJS.disableWebGL = (PDFJS.disableWebGL === undefined ?
+                        true : PDFJS.disableWebGL);
+
+  /**
+   * Specifies the |target| attribute for external links.
+   * The constants from PDFJS.LinkTarget should be used:
+   *  - NONE [default]
+   *  - SELF
+   *  - BLANK
+   *  - PARENT
+   *  - TOP
+   * @var {number}
+   */
+  PDFJS.externalLinkTarget = (PDFJS.externalLinkTarget === undefined ?
+                              LinkTarget.NONE : PDFJS.externalLinkTarget);
+
+  /**
+   * Specifies the |rel| attribute for external links. Defaults to stripping
+   * the referrer.
+   * @var {string}
+   */
+  PDFJS.externalLinkRel = (PDFJS.externalLinkRel === undefined ?
+                           'noreferrer' : PDFJS.externalLinkRel);
+
+  /**
+    * Determines if we can eval strings as JS. Primarily used to improve
+    * performance for font rendering.
+    * @var {boolean}
+    */
+  PDFJS.isEvalSupported = (PDFJS.isEvalSupported === undefined ?
+                           true : PDFJS.isEvalSupported);
+
+//#if !MOZCENTRAL
+  var savedOpenExternalLinksInNewWindow = PDFJS.openExternalLinksInNewWindow;
+  delete PDFJS.openExternalLinksInNewWindow;
+  Object.defineProperty(PDFJS, 'openExternalLinksInNewWindow', {
+    get: function () {
+      return PDFJS.externalLinkTarget === LinkTarget.BLANK;
+    },
+    set: function (value) {
+      if (value) {
+        deprecated('PDFJS.openExternalLinksInNewWindow, please use ' +
+          '"PDFJS.externalLinkTarget = PDFJS.LinkTarget.BLANK" instead.');
+      }
+      if (PDFJS.externalLinkTarget !== LinkTarget.NONE) {
+        warn('PDFJS.externalLinkTarget is already initialized');
+        return;
+      }
+      PDFJS.externalLinkTarget = value ? LinkTarget.BLANK : LinkTarget.NONE;
+    },
+    enumerable: true,
+    configurable: true
+  });
+  if (savedOpenExternalLinksInNewWindow) {
+    /**
+     * (Deprecated) Opens external links in a new window if enabled.
+     * The default behavior opens external links in the PDF.js window.
+     *
+     * NOTE: This property has been deprecated, please use
+     *       `PDFJS.externalLinkTarget = PDFJS.LinkTarget.BLANK` instead.
+     * @var {boolean}
+     */
+    PDFJS.openExternalLinksInNewWindow = savedOpenExternalLinksInNewWindow;
+  }
+//#endif
+
+  PDFJS.getDocument = displayAPI.getDocument;
+  PDFJS.PDFDataRangeTransport = displayAPI.PDFDataRangeTransport;
+  PDFJS.PDFWorker = displayAPI.PDFWorker;
+
+  Object.defineProperty(PDFJS, 'hasCanvasTypedArrays', {
+    configurable: true,
+    get: function PDFJS_hasCanvasTypedArrays() {
+      var value = displayDOMUtils.hasCanvasTypedArrays();
+      return sharedUtil.shadow(PDFJS, 'hasCanvasTypedArrays', value);
+    }
+  });
+  PDFJS.CustomStyle = displayDOMUtils.CustomStyle;
+  PDFJS.LinkTarget = LinkTarget;
+  PDFJS.addLinkAttributes = displayDOMUtils.addLinkAttributes;
+  PDFJS.getFilenameFromUrl = displayDOMUtils.getFilenameFromUrl;
+  PDFJS.isExternalLinkTargetSet = displayDOMUtils.isExternalLinkTargetSet;
+
+  PDFJS.AnnotationLayer = displayAnnotationLayer.AnnotationLayer;
+
+  PDFJS.renderTextLayer = displayTextLayer.renderTextLayer;
+
+  PDFJS.Metadata = displayMetadata.Metadata;
+
+  PDFJS.SVGGraphics = displaySVG.SVGGraphics;
+
+  PDFJS.UnsupportedManager = displayAPI._UnsupportedManager;
 
   exports.globalScope = globalScope;
   exports.isWorker = isWorker;

--- a/src/display/metadata.js
+++ b/src/display/metadata.js
@@ -18,20 +18,16 @@
 
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define('pdfjs/display/metadata', ['exports', 'pdfjs/shared/util',
-      'pdfjs/display/global'], factory);
+    define('pdfjs/display/metadata', ['exports', 'pdfjs/shared/util'], factory);
   } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../shared/util.js'), require('./global.js'));
+    factory(exports, require('../shared/util.js'));
   } else {
-    factory((root.pdfjsDisplayMetadata = {}), root.pdfjsSharedUtil,
-      root.pdfjsDisplayGlobal);
+    factory((root.pdfjsDisplayMetadata = {}), root.pdfjsSharedUtil);
   }
-}(this, function (exports, sharedUtil, displayGlobal) {
+}(this, function (exports, sharedUtil) {
 
 var error = sharedUtil.error;
-var PDFJS = displayGlobal.PDFJS;
 
-var Metadata = PDFJS.Metadata = (function MetadataClosure() {
   function fixMetadata(meta) {
     return meta.replace(/>\\376\\377([^<]+)/g, function(all, codes) {
       var bytes = codes.replace(/\\([0-3])([0-7])([0-7])/g,
@@ -107,9 +103,6 @@ var Metadata = PDFJS.Metadata = (function MetadataClosure() {
       return typeof this.metadata[name] !== 'undefined';
     }
   };
-
-  return Metadata;
-})();
 
 exports.Metadata = Metadata;
 }));

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -15,19 +15,16 @@
 
 'use strict';
 
-//#if (GENERIC || SINGLE_FILE)
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define('pdfjs/display/svg', ['exports', 'pdfjs/shared/util',
-      'pdfjs/display/global'], factory);
+    define('pdfjs/display/svg', ['exports', 'pdfjs/shared/util'], factory);
   } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../shared/util.js'), require('./global.js'));
+    factory(exports, require('../shared/util.js'));
   } else {
-    factory((root.pdfjsDisplaySVG = {}), root.pdfjsSharedUtil,
-      root.pdfjsDisplayGlobal);
+    factory((root.pdfjsDisplaySVG = {}), root.pdfjsSharedUtil);
   }
-}(this, function (exports, sharedUtil, displayGlobal) {
-
+}(this, function (exports, sharedUtil) {
+//#if (GENERIC || SINGLE_FILE)
 var FONT_IDENTITY_MATRIX = sharedUtil.FONT_IDENTITY_MATRIX;
 var IDENTITY_MATRIX = sharedUtil.IDENTITY_MATRIX;
 var ImageKind = sharedUtil.ImageKind;
@@ -36,7 +33,7 @@ var Util = sharedUtil.Util;
 var isNum = sharedUtil.isNum;
 var isArray = sharedUtil.isArray;
 var warn = sharedUtil.warn;
-var PDFJS = displayGlobal.PDFJS;
+var createObjectURL = sharedUtil.createObjectURL;
 
 var SVG_DEFAULTS = {
   fontStyle: 'normal',
@@ -110,7 +107,7 @@ var convertImgDataToPng = (function convertImgDataToPngClosure() {
     return (b << 16) | a;
   }
 
-  function encode(imgData, kind) {
+  function encode(imgData, kind, forceDataSchema) {
     var width = imgData.width;
     var height = imgData.height;
     var bitDepth, colorType, lineSize;
@@ -226,13 +223,13 @@ var convertImgDataToPng = (function convertImgDataToPngClosure() {
     offset += CHUNK_WRAPPER_SIZE + idat.length;
     writePngChunk('IEND', new Uint8Array(0), data, offset);
 
-    return PDFJS.createObjectURL(data, 'image/png');
+    return createObjectURL(data, 'image/png', forceDataSchema);
   }
 
-  return function convertImgDataToPng(imgData) {
+  return function convertImgDataToPng(imgData, forceDataSchema) {
     var kind = (imgData.kind === undefined ?
                 ImageKind.GRAYSCALE_1BPP : imgData.kind);
-    return encode(imgData, kind);
+    return encode(imgData, kind, forceDataSchema);
   };
 })();
 
@@ -377,7 +374,7 @@ var SVGGraphics = (function SVGGraphicsClosure() {
       pf(m[3]) + ' ' + pf(m[4]) + ' ' + pf(m[5]) + ')';
   }
 
-  function SVGGraphics(commonObjs, objs) {
+  function SVGGraphics(commonObjs, objs, forceDataSchema) {
     this.current = new SVGExtraState();
     this.transformMatrix = IDENTITY_MATRIX; // Graphics state matrix
     this.transformStack = [];
@@ -389,6 +386,7 @@ var SVGGraphics = (function SVGGraphicsClosure() {
     this.embedFonts = false;
     this.embeddedFonts = Object.create(null);
     this.cssStyle = null;
+    this.forceDataSchema = !!forceDataSchema;
   }
 
   var NS = 'http://www.w3.org/2000/svg';
@@ -453,8 +451,8 @@ var SVGGraphics = (function SVGGraphicsClosure() {
 
     transform: function SVGGraphics_transform(a, b, c, d, e, f) {
       var transformMatrix = [a, b, c, d, e, f];
-      this.transformMatrix = PDFJS.Util.transform(this.transformMatrix,
-                                                  transformMatrix);
+      this.transformMatrix = Util.transform(this.transformMatrix,
+                                            transformMatrix);
 
       this.tgrp = document.createElementNS(NS, 'svg:g');
       this.tgrp.setAttributeNS(null, 'transform', pm(this.transformMatrix));
@@ -777,7 +775,8 @@ var SVGGraphics = (function SVGGraphicsClosure() {
         this.defs.appendChild(this.cssStyle);
       }
 
-      var url = PDFJS.createObjectURL(fontObj.data, fontObj.mimetype);
+      var url = createObjectURL(fontObj.data, fontObj.mimetype,
+                                this.forceDataSchema);
       this.cssStyle.textContent +=
         '@font-face { font-family: "' + fontObj.loadedName + '";' +
         ' src: url(' + url + '); }\n';
@@ -1122,7 +1121,7 @@ var SVGGraphics = (function SVGGraphicsClosure() {
       var width = imgData.width;
       var height = imgData.height;
 
-      var imgSrc = convertImgDataToPng(imgData);
+      var imgSrc = convertImgDataToPng(imgData, this.forceDataSchema);
       var cliprect = document.createElementNS(NS, 'svg:rect');
       cliprect.setAttributeNS(null, 'x', '0');
       cliprect.setAttributeNS(null, 'y', '0');
@@ -1208,8 +1207,6 @@ var SVGGraphics = (function SVGGraphicsClosure() {
   return SVGGraphics;
 })();
 
-PDFJS.SVGGraphics = SVGGraphics;
-
 exports.SVGGraphics = SVGGraphics;
-}));
 //#endif
+}));

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -18,20 +18,20 @@
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
     define('pdfjs/display/text_layer', ['exports', 'pdfjs/shared/util',
-      'pdfjs/display/dom_utils', 'pdfjs/display/global'], factory);
+      'pdfjs/display/dom_utils'], factory);
   } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../shared/util.js'), require('./dom_utils.js'),
-      require('./global.js'));
+    factory(exports, require('../shared/util.js'), require('./dom_utils.js'));
   } else {
     factory((root.pdfjsDisplayTextLayer = {}), root.pdfjsSharedUtil,
-      root.pdfjsDisplayDOMUtils, root.pdfjsDisplayGlobal);
+      root.pdfjsDisplayDOMUtils);
   }
-}(this, function (exports, sharedUtil, displayDOMUtils, displayGlobal) {
+}(this, function (exports, sharedUtil, displayDOMUtils) {
 
 var Util = sharedUtil.Util;
 var createPromiseCapability = sharedUtil.createPromiseCapability;
 var CustomStyle = displayDOMUtils.CustomStyle;
-var PDFJS = displayGlobal.PDFJS;
+var getDefaultSetting = displayDOMUtils.getDefaultSetting;
+var PageViewport = sharedUtil.PageViewport;
 
 /**
  * Text layer render parameters.
@@ -40,7 +40,7 @@ var PDFJS = displayGlobal.PDFJS;
  * @property {TextContent} textContent - Text content to render (the object is
  *   returned by the page's getTextContent() method).
  * @property {HTMLElement} container - HTML element that will contain text runs.
- * @property {PDFJS.PageViewport} viewport - The target viewport to properly
+ * @property {PageViewport} viewport - The target viewport to properly
  *   layout the text runs.
  * @property {Array} textDivs - (optional) HTML elements that are correspond
  *   the text items of the textContent input. This is output and shall be
@@ -96,7 +96,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
     // |fontName| is only used by the Font Inspector. This test will succeed
     // when e.g. the Font Inspector is off but the Stepper is on, but it's
     // not worth the effort to do a more accurate test.
-    if (PDFJS.pdfBug) {
+    if (getDefaultSetting('pdfBug')) {
       textDiv.dataset.fontName = geom.fontName;
     }
     // Storing into dataset will convert number into string.
@@ -183,7 +183,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
    *
    * @param {TextContent} textContent
    * @param {HTMLElement} container
-   * @param {PDFJS.PageViewport} viewport
+   * @param {PageViewport} viewport
    * @param {Array} textDivs
    * @private
    */
@@ -250,8 +250,6 @@ var renderTextLayer = (function renderTextLayerClosure() {
 
   return renderTextLayer;
 })();
-
-PDFJS.renderTextLayer = renderTextLayer;
 
 exports.renderTextLayer = renderTextLayer;
 }));

--- a/src/display/webgl.js
+++ b/src/display/webgl.js
@@ -19,17 +19,17 @@
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
     define('pdfjs/display/webgl', ['exports', 'pdfjs/shared/util',
-      'pdfjs/display/global'], factory);
+      'pdfjs/display/dom_utils'], factory);
   } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../shared/util.js'), require('./global.js'));
+    factory(exports, require('../shared/util.js'), require('./dom_utils.js'));
   } else {
     factory((root.pdfjsDisplayWebGL = {}), root.pdfjsSharedUtil,
-      root.pdfjsDisplayGlobal);
+      root.pdfjsDisplayDOMUtils);
   }
-}(this, function (exports, sharedUtil, displayGlobal) {
+}(this, function (exports, sharedUtil, displayDOMUtils) {
 
 var shadow = sharedUtil.shadow;
-var PDFJS = displayGlobal.PDFJS;
+var getDefaultSetting = displayDOMUtils.getDefaultSetting;
 
 var WebGLUtils = (function WebGLUtilsClosure() {
   function loadShader(gl, code, shaderType) {
@@ -432,7 +432,7 @@ var WebGLUtils = (function WebGLUtilsClosure() {
 
   return {
     get isEnabled() {
-      if (PDFJS.disableWebGL) {
+      if (getDefaultSetting('disableWebGL')) {
         return false;
       }
       var enabled = false;

--- a/src/frameworks.js
+++ b/src/frameworks.js
@@ -12,7 +12,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS, require, module, requirejs */
+/* globals require, module, requirejs,
+           workerSrc: true, isWorkerDisabled: true */
 
 // included from api.js for GENERIC build
 
@@ -21,7 +22,7 @@
 var useRequireEnsure = false;
 if (typeof module !== 'undefined' && module.require) {
   // node.js - disable worker and set require.ensure.
-  PDFJS.disableWorker = true;
+  isWorkerDisabled = true;
   if (typeof require.ensure === 'undefined') {
     require.ensure = require('node-ensure');
   }
@@ -29,11 +30,11 @@ if (typeof module !== 'undefined' && module.require) {
 }
 if (typeof __webpack_require__ !== 'undefined') {
   // Webpack - get/bundle pdf.worker.js as additional file.
-  PDFJS.workerSrc = require('entry?name=[hash]-worker.js!./pdf.worker.js');
+  workerSrc = require('entry?name=[hash]-worker.js!./pdf.worker.js');
   useRequireEnsure = true;
 }
 if (typeof requirejs !== 'undefined' && requirejs.toUrl) {
-  PDFJS.workerSrc = requirejs.toUrl('pdfjs-dist/build/pdf.worker.js');
+  workerSrc = requirejs.toUrl('pdfjs-dist/build/pdf.worker.js');
 }
 var fakeWorkerFilesLoader = useRequireEnsure ? (function (callback) {
   require.ensure([], function () {

--- a/src/frameworks.js
+++ b/src/frameworks.js
@@ -20,7 +20,7 @@
 'use strict';
 
 var useRequireEnsure = false;
-if (typeof module !== 'undefined' && module.require) {
+if (typeof window === 'undefined') {
   // node.js - disable worker and set require.ensure.
   isWorkerDisabled = true;
   if (typeof require.ensure === 'undefined') {

--- a/src/main_loader.js
+++ b/src/main_loader.js
@@ -40,9 +40,11 @@
 
   // Sync the exports below with ./pdf.js file/template.
   exports.PDFJS = displayGlobal.PDFJS;
-
+  exports.build = displayAPI.build;
+  exports.version = displayAPI.version;
   exports.getDocument = displayAPI.getDocument;
   exports.PDFDataRangeTransport = displayAPI.PDFDataRangeTransport;
+  exports.PDFWorker = displayAPI.PDFWorker;
   exports.renderTextLayer = displayTextLayer.renderTextLayer;
   exports.AnnotationLayer = displayAnnotationLayer.AnnotationLayer;
   exports.CustomStyle = displayDOMUtils.CustomStyle;
@@ -51,4 +53,14 @@
   exports.MissingPDFException = sharedUtil.MissingPDFException;
   exports.SVGGraphics = displaySVG.SVGGraphics;
   exports.UnexpectedResponseException = sharedUtil.UnexpectedResponseException;
+  exports.OPS = sharedUtil.OPS;
+  exports.UNSUPPORTED_FEATURES = sharedUtil.UNSUPPORTED_FEATURES;
+  exports.isValidUrl = sharedUtil.isValidUrl;
+  exports.createObjectURL = sharedUtil.createObjectURL;
+  exports.removeNullCharacters = sharedUtil.removeNullCharacters;
+  exports.shadow = sharedUtil.shadow;
+  exports.createBlob = sharedUtil.createBlob;
+  exports.getFilenameFromUrl = displayDOMUtils.getFilenameFromUrl;
+  exports.addLinkAttributes = displayDOMUtils.addLinkAttributes;
+
 }));

--- a/src/main_loader.js
+++ b/src/main_loader.js
@@ -19,21 +19,24 @@
   if (typeof define === 'function' && define.amd) {
     define('pdfjs/main_loader', ['exports', 'pdfjs/display/api',
       'pdfjs/display/annotation_layer', 'pdfjs/display/text_layer',
-      'pdfjs/display/dom_utils', 'pdfjs/shared/util', 'pdfjs/display/global'],
+      'pdfjs/display/dom_utils', 'pdfjs/shared/util', 'pdfjs/display/svg',
+      'pdfjs/display/global'],
       factory);
   } else if (typeof exports !== 'undefined') {
     factory(exports, require('./display/api.js'),
       require('./display/annotation_layer.js'),
       require('./display/text_layer.js'), require('./display/dom_utils.js'),
-      require('./shared/util.js'), require('./display/global.js'));
+      require('./shared/util.js'), require('./display/svg.js'),
+      require('./display/global.js'));
   } else {
     factory((root.pdfjsMainLoader = {}), root.pdfjsDisplayAPI,
       root.pdfjsDisplayAnnotationLayer, root.pdfjsDisplayTextLayer,
-      root.pdfjsDisplayDOMUtils, root.pdfjsSharedUtil, root.pdfjsDisplayGlobal);
+      root.pdfjsDisplayDOMUtils, root.pdfjsSharedUtil, root.pdfjsDisplaySVG,
+      root.pdfjsDisplayGlobal);
   }
 }(this, function (exports, displayAPI, displayAnnotationLayer,
                   displayTextLayer, displayDOMUtils, sharedUtil,
-                  displayGlobal) {
+                  displaySVG, displayGlobal) {
 
   // Sync the exports below with ./pdf.js file/template.
   exports.PDFJS = displayGlobal.PDFJS;
@@ -46,5 +49,6 @@
   exports.PasswordResponses = sharedUtil.PasswordResponses;
   exports.InvalidPDFException = sharedUtil.InvalidPDFException;
   exports.MissingPDFException = sharedUtil.MissingPDFException;
+  exports.SVGGraphics = displaySVG.SVGGraphics;
   exports.UnexpectedResponseException = sharedUtil.UnexpectedResponseException;
 }));

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -55,6 +55,7 @@
   exports.PasswordResponses = pdfjsLibs.pdfjsSharedUtil.PasswordResponses;
   exports.InvalidPDFException = pdfjsLibs.pdfjsSharedUtil.InvalidPDFException;
   exports.MissingPDFException = pdfjsLibs.pdfjsSharedUtil.MissingPDFException;
+  exports.SVGGraphics = pdfjsLibs.pdfjsDisplaySVG.SVGGraphics;
   exports.UnexpectedResponseException =
     pdfjsLibs.pdfjsSharedUtil.UnexpectedResponseException;
 //#else

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -45,9 +45,12 @@
 
 //#if MAIN_FILE
   exports.PDFJS = pdfjsLibs.pdfjsDisplayGlobal.PDFJS;
+  exports.build = pdfjsLibs.pdfjsDisplayAPI.build;
+  exports.version = pdfjsLibs.pdfjsDisplayAPI.version;
   exports.getDocument = pdfjsLibs.pdfjsDisplayAPI.getDocument;
   exports.PDFDataRangeTransport =
     pdfjsLibs.pdfjsDisplayAPI.PDFDataRangeTransport;
+  exports.PDFWorker = pdfjsLibs.pdfjsDisplayAPI.PDFWorker;
   exports.renderTextLayer = pdfjsLibs.pdfjsDisplayTextLayer.renderTextLayer;
   exports.AnnotationLayer =
     pdfjsLibs.pdfjsDisplayAnnotationLayer.AnnotationLayer;
@@ -58,6 +61,16 @@
   exports.SVGGraphics = pdfjsLibs.pdfjsDisplaySVG.SVGGraphics;
   exports.UnexpectedResponseException =
     pdfjsLibs.pdfjsSharedUtil.UnexpectedResponseException;
+  exports.OPS = pdfjsLibs.pdfjsSharedUtil.OPS;
+  exports.UNSUPPORTED_FEATURES = pdfjsLibs.pdfjsSharedUtil.UNSUPPORTED_FEATURES;
+  exports.isValidUrl = pdfjsLibs.pdfjsSharedUtil.isValidUrl;
+  exports.createObjectURL = pdfjsLibs.pdfjsSharedUtil.createObjectURL;
+  exports.removeNullCharacters = pdfjsLibs.pdfjsSharedUtil.removeNullCharacters;
+  exports.shadow = pdfjsLibs.pdfjsSharedUtil.shadow;
+  exports.createBlob = pdfjsLibs.pdfjsSharedUtil.createBlob;
+  exports.getFilenameFromUrl =
+    pdfjsLibs.pdfjsDisplayDOMUtils.getFilenameFromUrl;
+  exports.addLinkAttributes = pdfjsLibs.pdfjsDisplayDOMUtils.addLinkAttributes;
 //#else
   exports.WorkerMessageHandler = pdfjsLibs.pdfjsCoreWorker.WorkerMessageHandler;
 //#endif

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -592,6 +592,17 @@ function isLittleEndian() {
   return (buffer16[0] === 1);
 }
 
+// Checks if it's possible to eval JS expressions.
+function isEvalSupported() {
+  try {
+    /* jshint evil: true */
+    new Function('');
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
 //#if !(FIREFOX || MOZCENTRAL || CHROME)
 var Uint32ArrayView = (function Uint32ArrayViewClosure() {
 
@@ -889,7 +900,7 @@ var Util = (function UtilClosure() {
 /**
  * PDF page viewport created based on scale, rotation and offset.
  * @class
- * @alias PDFJS.PageViewport
+ * @alias PageViewport
  */
 var PageViewport = (function PageViewportClosure() {
   /**
@@ -965,13 +976,13 @@ var PageViewport = (function PageViewportClosure() {
     this.height = height;
     this.fontScale = scale;
   }
-  PageViewport.prototype = /** @lends PDFJS.PageViewport.prototype */ {
+  PageViewport.prototype = /** @lends PageViewport.prototype */ {
     /**
      * Clones viewport with additional properties.
      * @param args {Object} (optional) If specified, may contain the 'scale' or
      * 'rotation' properties to override the corresponding properties in
      * the cloned viewport.
-     * @returns {PDFJS.PageViewport} Cloned viewport.
+     * @returns {PageViewport} Cloned viewport.
      */
     clone: function PageViewPort_clone(args) {
       args = args || {};
@@ -1101,7 +1112,7 @@ function isArrayBuffer(v) {
 
 /**
  * Creates a promise capability object.
- * @alias PDFJS.createPromiseCapability
+ * @alias createPromiseCapability
  *
  * @return {PromiseCapability} A capability object contains:
  * - a Promise, resolve and reject methods.
@@ -2347,6 +2358,7 @@ exports.isString = isString;
 exports.isSameOrigin = isSameOrigin;
 exports.isValidUrl = isValidUrl;
 exports.isLittleEndian = isLittleEndian;
+exports.isEvalSupported = isEvalSupported;
 exports.loadJpegStream = loadJpegStream;
 exports.log2 = log2;
 exports.readInt8 = readInt8;

--- a/test/test_slave.html
+++ b/test/test_slave.html
@@ -33,8 +33,9 @@ limitations under the License.
   <script>
     require.config({paths: {'pdfjs': '../src'}});
     require(['pdfjs/display/api', 'pdfjs/display/text_layer',
-             'pdfjs/display/annotation_layer', 'pdfjs/shared/util'],
-        function (api, textLayer, annotationLayer, pdfjsSharedUtil) {
+             'pdfjs/display/annotation_layer', 'pdfjs/display/global',
+             'pdfjs/shared/util'],
+        function (api, textLayer, annotationLayer, global, pdfjsSharedUtil) {
       window.pdfjsSharedUtil = pdfjsSharedUtil;
 
       var driver = new Driver({

--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*globals PDFJS, mozL10n, SimpleLinkService */
+/*globals pdfjsLib, mozL10n, SimpleLinkService */
 
 'use strict';
 
@@ -68,7 +68,7 @@ var AnnotationLayerBuilder = (function AnnotationLayerBuilderClosure() {
         if (self.div) {
           // If an annotationLayer already exists, refresh its children's
           // transformation matrices.
-          PDFJS.AnnotationLayer.update(parameters);
+          pdfjsLib.AnnotationLayer.update(parameters);
         } else {
           // Create an annotation layer div and render the annotations
           // if there is at least one annotation.
@@ -81,7 +81,7 @@ var AnnotationLayerBuilder = (function AnnotationLayerBuilderClosure() {
           self.pageDiv.appendChild(self.div);
           parameters.div = self.div;
 
-          PDFJS.AnnotationLayer.render(parameters);
+          pdfjsLib.AnnotationLayer.render(parameters);
           if (typeof mozL10n !== 'undefined') {
             mozL10n.translate(self.div);
           }

--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-/* globals chrome, PDFJS, PDFViewerApplication, OverlayManager */
+/* globals chrome, pdfjsLib, PDFViewerApplication, OverlayManager */
 'use strict';
 
 var ChromeCom = (function ChromeComClosure() {
@@ -81,7 +81,7 @@ var ChromeCom = (function ChromeComClosure() {
           return;
         }
       }
-      if (/^filesystem:/.test(file) && !PDFJS.disableWorker) {
+      if (/^filesystem:/.test(file) && !pdfjsLib.PDFJS.disableWorker) {
         // The security origin of filesystem:-URLs are not preserved when the
         // URL is passed to a Web worker, (http://crbug.com/362061), so we have
         // to create an intermediate blob:-URL as a work-around.

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS */
+/* globals pdfjsLib */
 
 'use strict';
 
@@ -307,8 +307,8 @@ var Stepper = (function StepperClosure() {
       this.table = table;
       if (!opMap) {
         opMap = Object.create(null);
-        for (var key in PDFJS.OPS) {
-          opMap[PDFJS.OPS[key]] = key;
+        for (var key in pdfjsLib.OPS) {
+          opMap[pdfjsLib.OPS[key]] = key;
         }
       }
     },
@@ -460,7 +460,7 @@ var Stats = (function Stats() {
     manager: null,
     init: function init() {
       this.panel.setAttribute('style', 'padding: 5px;');
-      PDFJS.enableStats = true;
+      pdfjsLib.PDFJS.enableStats = true;
     },
     enabled: false,
     active: false,

--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals URL, PDFJS */
+/* globals URL, pdfjsLib */
 
 'use strict';
 
@@ -58,7 +58,7 @@ var DownloadManager = (function DownloadManagerClosure() {
 
   DownloadManager.prototype = {
     downloadUrl: function DownloadManager_downloadUrl(url, filename) {
-      if (!PDFJS.isValidUrl(url, true)) {
+      if (!pdfjsLib.isValidUrl(url, true)) {
         return; // restricted/invalid URL
       }
 
@@ -72,7 +72,8 @@ var DownloadManager = (function DownloadManagerClosure() {
                                     filename);
       }
 
-      var blobUrl = PDFJS.createObjectURL(data, contentType);
+      var blobUrl = pdfjsLib.createObjectURL(data, contentType,
+        pdfjsLib.PDFJS.disableCreateObjectURL);
       download(blobUrl, filename);
     },
 

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals Preferences, PDFJS, Promise */
+/* globals Preferences, pdfjsLib, Promise */
 
 'use strict';
 
@@ -87,7 +87,7 @@ var DownloadManager = (function DownloadManagerClosure() {
 
     downloadData: function DownloadManager_downloadData(data, filename,
                                                         contentType) {
-      var blobUrl = PDFJS.createObjectURL(data, contentType);
+      var blobUrl = pdfjsLib.createObjectURL(data, contentType, false);
 
       FirefoxCom.request('download', {
         blobUrl: blobUrl,

--- a/web/password_prompt.js
+++ b/web/password_prompt.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS, mozL10n, OverlayManager */
+/* globals pdfjsLib, mozL10n, OverlayManager */
 
 'use strict';
 
@@ -55,7 +55,7 @@ var PasswordPrompt = {
       var promptString = mozL10n.get('password_label', null,
         'Enter the password to open this PDF file.');
 
-      if (this.reason === PDFJS.PasswordResponses.INCORRECT_PASSWORD) {
+      if (this.reason === pdfjsLib.PasswordResponses.INCORRECT_PASSWORD) {
         promptString = mozL10n.get('password_invalid', null,
           'Invalid password. Please try again.');
       }

--- a/web/pdf_attachment_viewer.js
+++ b/web/pdf_attachment_viewer.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS */
+/* globals pdfjsLib */
 
 'use strict';
 
@@ -98,12 +98,12 @@ var PDFAttachmentViewer = (function PDFAttachmentViewerClosure() {
 
       for (var i = 0; i < attachmentsCount; i++) {
         var item = attachments[names[i]];
-        var filename = PDFJS.getFilenameFromUrl(item.filename);
+        var filename = pdfjsLib.getFilenameFromUrl(item.filename);
         var div = document.createElement('div');
         div.className = 'attachmentsItem';
         var button = document.createElement('button');
         this._bindLink(button, item.content, filename);
-        button.textContent = PDFJS.removeNullCharacters(filename);
+        button.textContent = pdfjsLib.removeNullCharacters(filename);
         div.appendChild(button);
         this.container.appendChild(div);
       }

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS, FirefoxCom, Promise, scrollIntoView */
+/* globals FirefoxCom, Promise, scrollIntoView */
 
 'use strict';
 

--- a/web/pdf_outline_viewer.js
+++ b/web/pdf_outline_viewer.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS */
+/* globals pdfjsLib */
 
 'use strict';
 
@@ -71,7 +71,7 @@ var PDFOutlineViewer = (function PDFOutlineViewerClosure() {
      */
     _bindLink: function PDFOutlineViewer_bindLink(element, item) {
       if (item.url) {
-        PDFJS.addLinkAttributes(element, { url: item.url });
+        pdfjsLib.addLinkAttributes(element, { url: item.url });
         return;
       }
       var linkService = this.linkService;
@@ -180,7 +180,7 @@ var PDFOutlineViewer = (function PDFOutlineViewerClosure() {
           this._bindLink(element, item);
           this._setStyles(element, item);
           element.textContent =
-            PDFJS.removeNullCharacters(item.title) || DEFAULT_TITLE;
+            pdfjsLib.removeNullCharacters(item.title) || DEFAULT_TITLE;
 
           div.appendChild(element);
 

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals RenderingStates, PDFJS, DEFAULT_SCALE, CSS_UNITS, getOutputScale,
+/* globals RenderingStates, pdfjsLib, DEFAULT_SCALE, CSS_UNITS, getOutputScale,
            TextLayerBuilder, Promise, approximateFraction, roundToDivide */
 
 'use strict';
@@ -162,19 +162,18 @@ var PDFPageView = (function PDFPageViewClosure() {
       });
 
       var isScalingRestricted = false;
-      if (this.canvas && PDFJS.maxCanvasPixels > 0) {
+      if (this.canvas && pdfjsLib.PDFJS.maxCanvasPixels > 0) {
         var outputScale = this.outputScale;
         var pixelsInViewport = this.viewport.width * this.viewport.height;
-        var maxScale = Math.sqrt(PDFJS.maxCanvasPixels / pixelsInViewport);
         if (((Math.floor(this.viewport.width) * outputScale.sx) | 0) *
             ((Math.floor(this.viewport.height) * outputScale.sy) | 0) >
-            PDFJS.maxCanvasPixels) {
+            pdfjsLib.PDFJS.maxCanvasPixels) {
           isScalingRestricted = true;
         }
       }
 
       if (this.canvas) {
-        if (PDFJS.useOnlyCssZoom ||
+        if (pdfjsLib.PDFJS.useOnlyCssZoom ||
             (this.hasRestrictedScaling && isScalingRestricted)) {
           this.cssTransform(this.canvas, true);
 
@@ -208,7 +207,7 @@ var PDFPageView = (function PDFPageViewClosure() {
     },
 
     cssTransform: function PDFPageView_transform(canvas, redrawAnnotations) {
-      var CustomStyle = PDFJS.CustomStyle;
+      var CustomStyle = pdfjsLib.CustomStyle;
 
       // Scale canvas, canvas wrapper, and page container.
       var width = this.viewport.width;
@@ -330,7 +329,7 @@ var PDFPageView = (function PDFPageViewClosure() {
       var outputScale = getOutputScale(ctx);
       this.outputScale = outputScale;
 
-      if (PDFJS.useOnlyCssZoom) {
+      if (pdfjsLib.PDFJS.useOnlyCssZoom) {
         var actualSizeViewport = viewport.clone({scale: CSS_UNITS});
         // Use a scale that will make the canvas be the original intended size
         // of the page.
@@ -339,9 +338,10 @@ var PDFPageView = (function PDFPageViewClosure() {
         outputScale.scaled = true;
       }
 
-      if (PDFJS.maxCanvasPixels > 0) {
+      if (pdfjsLib.PDFJS.maxCanvasPixels > 0) {
         var pixelsInViewport = viewport.width * viewport.height;
-        var maxScale = Math.sqrt(PDFJS.maxCanvasPixels / pixelsInViewport);
+        var maxScale =
+          Math.sqrt(pdfjsLib.PDFJS.maxCanvasPixels / pixelsInViewport);
         if (outputScale.sx > maxScale || outputScale.sy > maxScale) {
           outputScale.sx = maxScale;
           outputScale.sy = maxScale;
@@ -517,7 +517,7 @@ var PDFPageView = (function PDFPageViewClosure() {
     },
 
     beforePrint: function PDFPageView_beforePrint() {
-      var CustomStyle = PDFJS.CustomStyle;
+      var CustomStyle = pdfjsLib.CustomStyle;
       var pdfPage = this.pdfPage;
 
       var viewport = pdfPage.getViewport(1);

--- a/web/pdf_viewer.component.js
+++ b/web/pdf_viewer.component.js
@@ -17,13 +17,20 @@
            DefaultTextLayerFactory, AnnotationLayerBuilder, PDFHistory,
            DefaultAnnotationLayerFactory, DownloadManager, ProgressBar */
 
-// Initializing PDFJS global object (if still undefined)
-if (typeof PDFJS === 'undefined') {
-  (typeof window !== 'undefined' ? window : this).PDFJS = {};
-}
-
 (function pdfViewerWrapper() {
   'use strict';
+
+  var root = this;
+  if (!root.pdfjsLib) {
+    Object.defineProperty(root, 'pdfjsLib', {
+      get: function () {
+        return root.pdfjsDistBuildPdf || root.pdfjsDistBuildPdfCombined ||
+               root.pdfjsMainLoader;
+      },
+      enumerable: true,
+      configurable: true
+    });
+  }
 
 //#include ui_utils.js
 //#include pdf_link_service.js

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -15,7 +15,7 @@
  /*globals watchScroll, PDFPageView, UNKNOWN_SCALE,
            SCROLLBAR_PADDING, VERTICAL_PADDING, MAX_AUTO_SCALE, CSS_UNITS,
            DEFAULT_SCALE, scrollIntoView, getVisibleElements, RenderingStates,
-           PDFJS, Promise, TextLayerBuilder, PDFRenderingQueue,
+           pdfjsLib, Promise, TextLayerBuilder, PDFRenderingQueue,
            AnnotationLayerBuilder, DEFAULT_SCALE_VALUE */
 
 'use strict';
@@ -27,7 +27,6 @@ var PresentationModeState = {
   FULLSCREEN: 3,
 };
 
-var IGNORE_CURRENT_POSITION_ON_ZOOM = false;
 var DEFAULT_CACHE_SIZE = 10;
 
 //#include pdf_rendering_queue.js
@@ -287,7 +286,7 @@ var PDFViewer = (function pdfViewer() {
         var viewport = pdfPage.getViewport(scale * CSS_UNITS);
         for (var pageNum = 1; pageNum <= pagesCount; ++pageNum) {
           var textLayerFactory = null;
-          if (!PDFJS.disableTextLayer) {
+          if (!pdfjsLib.PDFJS.disableTextLayer) {
             textLayerFactory = this;
           }
           var pageView = new PDFPageView({
@@ -309,7 +308,7 @@ var PDFViewer = (function pdfViewer() {
         // starts to create the correct size canvas. Wait until one page is
         // rendered so we don't tie up too many resources early on.
         onePageRendered.then(function () {
-          if (!PDFJS.disableAutoFetch) {
+          if (!pdfjsLib.PDFJS.disableAutoFetch) {
             var getPagesLeft = pagesCount;
             for (var pageNum = 1; pageNum <= pagesCount; ++pageNum) {
               pdfDocument.getPage(pageNum).then(function (pageNum, pdfPage) {
@@ -399,7 +398,7 @@ var PDFViewer = (function pdfViewer() {
 
       if (!noScroll) {
         var page = this._currentPageNumber, dest;
-        if (this._location && !IGNORE_CURRENT_POSITION_ON_ZOOM &&
+        if (this._location && !pdfjsLib.PDFJS.ignoreCurrentPositionOnZoom &&
             !(this.isInPresentationMode || this.isChangingPresentationMode)) {
           page = this._location.pageNumber;
           dest = [null, { name: 'XYZ' }, this._location.left,

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals PDFJS */
+/* globals pdfjsLib */
 
 'use strict';
 
@@ -78,7 +78,7 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
 
       this.textDivs = [];
       var textLayerFrag = document.createDocumentFragment();
-      this.textLayerRenderTask = PDFJS.renderTextLayer({
+      this.textLayerRenderTask = pdfjsLib.renderTextLayer({
         textContent: this.textContent,
         container: textLayerFrag,
         viewport: this.viewport,

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+ /* global PDFJS */
 
 'use strict';
 
@@ -24,6 +25,33 @@ var SCROLLBAR_PADDING = 40;
 var VERTICAL_PADDING = 5;
 
 var mozL10n = document.mozL10n || document.webL10n;
+
+if (typeof PDFJS === 'undefined') {
+  window.PDFJS = {};
+}
+
+/**
+ * Disables fullscreen support, and by extension Presentation Mode,
+ * in browsers which support the fullscreen API.
+ * @var {boolean}
+ */
+PDFJS.disableFullscreen = (PDFJS.disableFullscreen === undefined ?
+                           false : PDFJS.disableFullscreen);
+
+/**
+ * Enables CSS only zooming.
+ * @var {boolean}
+ */
+PDFJS.useOnlyCssZoom = (PDFJS.useOnlyCssZoom === undefined ?
+                        false : PDFJS.useOnlyCssZoom);
+
+/**
+ * The maximum supported canvas size in total pixels e.g. width * height.
+ * The default value is 4096 * 4096. Use -1 for no limit.
+ * @var {number}
+ */
+PDFJS.maxCanvasPixels = (PDFJS.maxCanvasPixels === undefined ?
+                         16777216 : PDFJS.maxCanvasPixels);
 
 /**
  * Returns scale factor for the canvas. It makes sense for the HiDPI displays.

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -27,7 +27,7 @@ var VERTICAL_PADDING = 5;
 var mozL10n = document.mozL10n || document.webL10n;
 
 if (typeof PDFJS === 'undefined') {
-  window.PDFJS = {};
+  (typeof window !== 'undefined' ? window : this).PDFJS = {};
 }
 
 /**
@@ -52,6 +52,34 @@ PDFJS.useOnlyCssZoom = (PDFJS.useOnlyCssZoom === undefined ?
  */
 PDFJS.maxCanvasPixels = (PDFJS.maxCanvasPixels === undefined ?
                          16777216 : PDFJS.maxCanvasPixels);
+
+/**
+ * Disables saving of the last position of the viewed PDF.
+ * @var {boolean}
+ */
+PDFJS.disableHistory = (PDFJS.disableHistory === undefined ?
+                        false : PDFJS.disableHistory);
+
+/**
+ * Disables creation of the text layer that used for text selection and search.
+ * @var {boolean}
+ */
+PDFJS.disableTextLayer = (PDFJS.disableTextLayer === undefined ?
+                          false : PDFJS.disableTextLayer);
+
+/**
+ * Disables maintaining the current position in the document when zooming.
+ */
+PDFJS.ignoreCurrentPositionOnZoom = (PDFJS.ignoreCurrentPositionOnZoom ===
+  undefined ? false : PDFJS.ignoreCurrentPositionOnZoom);
+
+//#if !(FIREFOX || MOZCENTRAL)
+/**
+ * Interface locale settings.
+ * @var {string}
+ */
+PDFJS.locale = (PDFJS.locale === undefined ? navigator.language : PDFJS.locale);
+//#endif
 
 /**
  * Returns scale factor for the canvas. It makes sense for the HiDPI displays.

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -41,9 +41,11 @@ function webViewerLoad() {
 //#if !PRODUCTION
   require.config({paths: {'pdfjs': '../src'}});
   require(['pdfjs/main_loader'], function (loader) {
+    window.pdfjsLib = loader;
     PDFViewerApplication.run();
   });
 //#else
+//window.pdfjsLib = window.pdfjsDistBuildPdf;
 //PDFViewerApplication.run();
 //#endif
 }


### PR DESCRIPTION
The dom_utils.js may use global PDFJS to pull values (if the object exists), see getDefaultSetting.

Also, exposed more functions/classes for generic viewer and examples and changed PDFJS object access for these.

Partially addresses #6779
