### PR TITLE
Add unit-tests for destionations in /Names (NameTree) dictionaries where all entries are indirect objects

### DIFF
--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -17,6 +17,7 @@
 !issue5946.pdf
 !issue5972.pdf
 !issue5874.pdf
+!issue6204.pdf
 !issue6782.pdf
 !issue6961.pdf
 !issue7020.pdf

--- a/test/pdfs/issue6204.pdf
+++ b/test/pdfs/issue6204.pdf
@@ -1,0 +1,217 @@
+%PDF-1.5
+%‚„œ”
+1 0 obj 
+<<
+/Parent 2 0 R
+/Annots [3 0 R]
+/MediaBox [0 0 325 375]
+/Resources 4 0 R
+/Contents 5 0 R
+/Type /Page
+>>
+endobj 
+2 0 obj 
+<<
+/Kids [1 0 R 6 0 R]
+/Count 2
+/Type /Pages
+>>
+endobj 
+3 0 obj 
+<<
+/Border [0 0 1]
+/Subtype /Link
+/C [1 0 0]
+/A 
+<<
+/D (Page.2)
+/S /GoTo
+>>
+/Type /Annot
+/Rect [205 345 310 320]
+/H /I
+>>
+endobj 
+4 0 obj 
+<<
+/Font 
+<<
+/F1 7 0 R
+>>
+>>
+endobj 
+5 0 obj 
+<<
+/Length 77
+>>
+stream
+BT
+1 0 0 1 10 325 Tm
+/F1 20 Tf
+(This is page 1. Goto the second page.) Tj
+ET
+
+endstream 
+endobj 
+6 0 obj 
+<<
+/Parent 2 0 R
+/Annots [8 0 R]
+/MediaBox [0 0 325 375]
+/Resources 9 0 R
+/Contents 10 0 R
+/Type /Page
+>>
+endobj 
+7 0 obj 
+<<
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Type /Font
+/Encoding /WinAnsiEncoding
+>>
+endobj 
+11 0 obj 
+<<
+/D 12 0 R
+>>
+endobj 
+12 0 obj [1 0 R /XYZ 0 375 null]
+endobj 
+8 0 obj 
+<<
+/Border [0 0 1]
+/Subtype /Link
+/C [1 0 0]
+/A 
+<<
+/D (Page.1)
+/S /GoTo
+>>
+/Type /Annot
+/Rect [205 345 290 320]
+/H /I
+>>
+endobj 
+9 0 obj 
+<<
+/Font 
+<<
+/F1 7 0 R
+>>
+>>
+endobj 
+10 0 obj 
+<<
+/Length 76
+>>
+stream
+BT
+1 0 0 1 10 325 Tm
+/F1 20 Tf
+(This is page 2. Goto the first page.) Tj
+ET
+
+endstream 
+endobj 
+13 0 obj 
+<<
+/D 14 0 R
+>>
+endobj 
+14 0 obj [6 0 R /XYZ 0 375 null]
+endobj 
+15 0 obj 
+<<
+/Names 16 0 R
+/Limits 17 0 R
+>>
+endobj 
+16 0 obj [18 0 R 11 0 R 19 0 R 13 0 R]
+endobj 
+17 0 obj [20 0 R 21 0 R]
+endobj 
+22 0 obj 
+<<
+/Dests 23 0 R
+>>
+endobj 
+24 0 obj 
+<<
+/Names 22 0 R
+/Pages 2 0 R
+/Type /Catalog
+>>
+endobj 
+18 0 obj (Page.1)
+endobj 
+19 0 obj (Page.2)
+endobj 
+20 0 obj (Page.1)
+endobj 
+21 0 obj (Page.2)
+endobj 
+23 0 obj 
+<<
+/Limits 25 0 R
+/Kids 26 0 R
+>>
+endobj 
+25 0 obj [20 0 R 21 0 R]
+endobj 
+26 0 obj [15 0 R]
+endobj 
+27 0 obj 
+<<
+/Author (Jonas Jenwald)
+/Producer (pdfTeX-1.40.16)
+/Creator (LaTeX with hyperref package)
+/Trapped /False
+/Keywords ()
+/ModDate (D:20160329133418+02'00')
+/PTEX.Fullbanner (This is MiKTeX-pdfTeX 2.9.5840 \(1.40.16\))
+/Title (Issue 6204 - reduced)
+/Subject ()
+/CreationDate (D:20160329133418+02'00')
+>>
+endobj xref
+0 28
+0000000000 65535 f 
+0000000015 00000 n 
+0000000137 00000 n 
+0000000202 00000 n 
+0000000341 00000 n 
+0000000387 00000 n 
+0000000517 00000 n 
+0000000640 00000 n 
+0000000816 00000 n 
+0000000955 00000 n 
+0000001001 00000 n 
+0000000741 00000 n 
+0000000775 00000 n 
+0000001131 00000 n 
+0000001165 00000 n 
+0000001206 00000 n 
+0000001259 00000 n 
+0000001306 00000 n 
+0000001443 00000 n 
+0000001469 00000 n 
+0000001495 00000 n 
+0000001521 00000 n 
+0000001339 00000 n 
+0000001547 00000 n 
+0000001377 00000 n 
+0000001599 00000 n 
+0000001632 00000 n 
+0000001658 00000 n 
+trailer
+
+<<
+/Info 27 0 R
+/Root 24 0 R
+/Size 28
+/ID [<540bf4f50da824e0b40f8749e21d3a3a> <540bf4f50da824e0b40f8749e21d3a3a>]
+>>
+startxref
+1979
+%%EOF

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -360,7 +360,8 @@ describe('api', function() {
         done.fail(reason);
       });
     });
-    it('gets destinations', function(done) {
+
+    it('gets destinations, from /Dests dictionary', function(done) {
       var promise = doc.getDestinations();
       promise.then(function(data) {
         expect(data).toEqual({ chapter1: [{ gen: 0, num: 17 }, { name: 'XYZ' },
@@ -370,7 +371,7 @@ describe('api', function() {
         done.fail(reason);
       });
     });
-    it('gets a destination', function(done) {
+    it('gets a destination, from /Dests dictionary', function(done) {
       var promise = doc.getDestination('chapter1');
       promise.then(function(data) {
         expect(data).toEqual([{ gen: 0, num: 17 }, { name: 'XYZ' },
@@ -380,7 +381,8 @@ describe('api', function() {
         done.fail(reason);
       });
     });
-    it('gets a non-existent destination', function(done) {
+    it('gets a non-existent destination, from /Dests dictionary',
+        function(done) {
       var promise = doc.getDestination('non-existent-named-destination');
       promise.then(function(data) {
         expect(data).toEqual(null);
@@ -389,6 +391,58 @@ describe('api', function() {
         done.fail(reason);
       });
     });
+
+    it('gets destinations, from /Names (NameTree) dictionary', function(done) {
+      var url = combineUrl(window.location.href, '../pdfs/issue6204.pdf');
+      var loadingTask = PDFJS.getDocument(url);
+      var promise = loadingTask.promise.then(function (pdfDocument) {
+        return pdfDocument.getDestinations();
+      });
+      promise.then(function (destinations) {
+        expect(destinations).toEqual({
+          'Page.1': [{ num: 1, gen: 0}, { name: 'XYZ' }, 0, 375, null],
+          'Page.2': [{ num: 6, gen: 0}, { name: 'XYZ' }, 0, 375, null],
+        });
+
+        loadingTask.destroy();
+        done();
+      }).catch(function (reason) {
+        done.fail(reason);
+      });
+    });
+    it('gets a destination, from /Names (NameTree) dictionary', function(done) {
+      var url = combineUrl(window.location.href, '../pdfs/issue6204.pdf');
+      var loadingTask = PDFJS.getDocument(url);
+      var promise = loadingTask.promise.then(function (pdfDocument) {
+        return pdfDocument.getDestination('Page.1');
+      });
+      promise.then(function (destination) {
+        expect(destination).toEqual([{ num: 1, gen: 0}, { name: 'XYZ' },
+                                     0, 375, null]);
+
+        loadingTask.destroy();
+        done();
+      }).catch(function (reason) {
+        done.fail(reason);
+      });
+    });
+    it('gets a non-existent destination, from /Names (NameTree) dictionary',
+        function(done) {
+      var url = combineUrl(window.location.href, '../pdfs/issue6204.pdf');
+      var loadingTask = PDFJS.getDocument(url);
+      var promise = loadingTask.promise.then(function (pdfDocument) {
+        return pdfDocument.getDestination('non-existent-named-destination');
+      });
+      promise.then(function (destination) {
+        expect(destination).toEqual(null);
+
+        loadingTask.destroy();
+        done();
+      }).catch(function (reason) {
+        done.fail(reason);
+      });
+    });
+
     it('gets non-existent page labels', function (done) {
       var promise = doc.getPageLabels();
       promise.then(function (data) {


### PR DESCRIPTION
Re: issue #6204 and PR #6208.
