### PR TITLE
Faster unit-tests by using `beforeAll`/`afterAll` in api_spec.js

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1,6 +1,6 @@
-/* globals PDFJS, expect, it, describe, Promise, combineUrl,
+/* globals PDFJS, expect, it, describe, Promise, combineUrl, beforeAll,
            InvalidPDFException, MissingPDFException, StreamType, FontType,
-           PDFDocumentProxy, PasswordException, PasswordResponses,
+           PDFDocumentProxy, PasswordException, PasswordResponses, afterAll,
            PDFPageProxy, createPromiseCapability, beforeEach, afterEach */
 
 'use strict';
@@ -310,7 +310,7 @@ describe('api', function() {
     var loadingTask;
     var doc;
 
-    beforeEach(function(done) {
+    beforeAll(function(done) {
       loadingTask = PDFJS.getDocument(basicApiUrl);
       loadingTask.promise.then(function(data) {
         doc = data;
@@ -318,7 +318,7 @@ describe('api', function() {
       });
     });
 
-    afterEach(function() {
+    afterAll(function() {
       loadingTask.destroy();
     });
 
@@ -680,7 +680,7 @@ describe('api', function() {
     var loadingTask;
     var pdfDocument, page;
 
-    beforeEach(function(done) {
+    beforeAll(function(done) {
       loadingTask = PDFJS.getDocument(basicApiUrl);
       loadingTask.promise.then(function(doc) {
         pdfDocument = doc;
@@ -693,7 +693,7 @@ describe('api', function() {
       });
     });
 
-    afterEach(function() {
+    afterAll(function() {
       loadingTask.destroy();
     });
 


### PR DESCRIPTION
In the API unit-tests, we're currently loading the `basicapi.pdf` before every sub-test in `PDFDocument` and `Page`, which slows down the unit-tests quite a bit.
Locally this patch reduces the run time for `gulp unittest` by at least 40% for me.
