### PR TITLE
Forces UMD header to have relative path and extension for CommonJS.

### DIFF
--- a/external/umdutils/verifier.js
+++ b/external/umdutils/verifier.js
@@ -294,7 +294,7 @@ function validateFile(path, name, context) {
       }
       var noExtension = i.replace(/\.js$/, '');
       if (noExtension === i || i[0] !== '.') {
-        warn('CommonJS shall have relative path and extension: ' + i);
+        error('CommonJS shall have relative path and extension: ' + i);
         return;
       }
       var base = name.split('/');

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -28,8 +28,8 @@
       require('./stream.js'), require('./parser.js'),
       require('./glyphlist.js'), require('./charsets.js'),
       require('./font_renderer.js'), require('./encodings.js'),
-      require('./standard_fonts'), require('./unicode.js'),
-      require('./type1_parser'), require('./cff_parser'));
+      require('./standard_fonts.js'), require('./unicode.js'),
+      require('./type1_parser.js'), require('./cff_parser.js'));
   } else {
     factory((root.pdfjsCoreFonts = {}), root.pdfjsSharedUtil,
       root.pdfjsCorePrimitives, root.pdfjsCoreStream, root.pdfjsCoreParser,


### PR DESCRIPTION
Fixed regression of building generic viewer (after #7146).
