### PR TITLE
Update Webpack and Browserify example README files

### DIFF
--- a/examples/browserify/README.md
+++ b/examples/browserify/README.md
@@ -1,25 +1,25 @@
 ## Overview
 
-Example to demonstrate PDF.js library usage with browserify.
+Example to demonstrate PDF.js library usage with Browserify.
 
 ## Getting started
 
 Build project and install the example dependencies:
 
-  $ gulp dist
-  $ cd examples/browserify
-  $ npm install
+    $ gulp dist
+    $ cd examples/browserify
+    $ npm install
 
-To build browserify bundles, run `gulp build`.  If you are running
+To build Browserify bundles, run `gulp build`. If you are running
 a web server, you can observe the build results at
 http://localhost:8888/examples/browserify/index.html
 
 See main.js, worker.js and gulpfile.js files. Please notice that PDF.js
 packaging requires packaging of the main application and PDF.js worker code,
-and the workerSrc path shall be set to the latter file.
+and the `workerSrc` path shall be set to the latter file.
 
 Alternatives to the gulp commands (without compression) are:
 
-  $ mkdir -p ../../build/browserify
-  $ node_modules/.bin/browserify main.js -o ../../build/browserify/bundle.js
-  $ node_modules/.bin/browserify worker.js -o ../../build/browserify/pdf.worker.bundle.js
+    $ mkdir -p ../../build/browserify
+    $ node_modules/.bin/browserify main.js -o ../../build/browserify/bundle.js
+    $ node_modules/.bin/browserify worker.js -o ../../build/browserify/pdf.worker.bundle.js

--- a/examples/webpack/README.md
+++ b/examples/webpack/README.md
@@ -1,18 +1,18 @@
 ## Overview
 
-Example to demonstrate PDF.js library usage with webpack.
+Example to demonstrate PDF.js library usage with Webpack.
 
 ## Getting started
 
 Build project and install the example dependencies:
 
-  $ gulp dist
-  $ cd examples/webpack
-  $ npm install
+    $ gulp dist
+    $ cd examples/webpack
+    $ npm install
 
-To build webpack bundles, run `node_modules/.bin/webpack`.  If you are running
+To build Webpack bundles, run `node_modules/.bin/webpack`. If you are running
 a web server, you can observe the build results at
 http://localhost:8888/examples/webpack/index.html
 
 See main.js and webpack.config.js files. Please notice that PDF.js packaging
-requires 'entry' loader.
+requires the `entry` loader.


### PR DESCRIPTION
Previously the commands were not properly parsed as such by GitHub because they need to be indented with four spaces.

Furthermore, address some minor textual nits.
