### PR TITLE
Specifies package format for jspm.

### DIFF
--- a/make.js
+++ b/make.js
@@ -337,6 +337,7 @@ target.dist = function() {
       './build/pdf.worker.js': false,
       'node-ensure': false
     },
+    format: 'amd', // to not allow system.js to choose 'cjs'
     repository: {
       type: 'git',
       url: DIST_REPO_URL


### PR DESCRIPTION
To support https://github.com/mozilla/pdf.js/issues/6791#issuecomment-205502058

Docs at https://github.com/jspm/registry/wiki/Configuring-Packages-for-jspm#format
