### PR TITLE
Prevent the *entire* viewer from zooming, when quickly switching from scrolling to zooming using the mousewheel (PR 7097 followup)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1838,12 +1838,15 @@ function handleMouseWheel(evt) {
   } else if (evt.ctrlKey || evt.metaKey) {
     var support = PDFViewerApplication.supportedMouseWheelZoomModifierKeys;
     if ((evt.ctrlKey && !support.ctrlKey) ||
-        (evt.metaKey && !support.metaKey) ||
-        zoomDisabled) {
+        (evt.metaKey && !support.metaKey)) {
       return;
     }
     // Only zoom the pages, not the entire viewer.
     evt.preventDefault();
+    // NOTE: this check must be placed *after* preventDefault.
+    if (zoomDisabled) {
+      return;
+    }
 
     var previousScale = pdfViewer.currentScale;
 


### PR DESCRIPTION
This is a regression from PR #7097.

(Also, out of scope for this PR, but I think that a `setTimeout` value of `1000 ms` is too large. Switching from scrolling to zooming can fell sluggish, and give the impression that nothing happens.)
