### PR TITLE
Remove the remaining usages of `new {Name,Cmd}` in favor of `{Name,Cmd}.get`

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1619,13 +1619,13 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       });
     },
 
-    extractDataStructures: function
-      partialEvaluatorExtractDataStructures(dict, baseDict,
-                                            xref, properties) {
+    extractDataStructures:
+        function PartialEvaluator_extractDataStructures(dict, baseDict,
+                                                        xref, properties) {
       // 9.10.2
       var toUnicode = (dict.get('ToUnicode') || baseDict.get('ToUnicode'));
       var toUnicodePromise = toUnicode ?
-            this.readToUnicode(toUnicode) : Promise.resolve(undefined);
+        this.readToUnicode(toUnicode) : Promise.resolve(undefined);
 
       if (properties.composite) {
         // CIDSystemInfo helps to match CID to glyphs
@@ -1723,9 +1723,10 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     /**
      * Builds a char code to unicode map based on section 9.10 of the spec.
      * @param {Object} properties Font properties object.
-     * @return {Promise} A Promise resolving to ToUnicodeMap object.
+     * @return {Promise} A Promise that is resolved with a
+     *   {ToUnicodeMap|IdentityToUnicodeMap} object.
      */
-    buildToUnicode: function partialEvaluator_buildToUnicode(properties) {
+    buildToUnicode: function PartialEvaluator_buildToUnicode(properties) {
       // Section 9.10.2 Mapping Character Codes to Unicode Values
       if (properties.toUnicode && properties.toUnicode.length !== 0) {
         return Promise.resolve(properties.toUnicode);
@@ -1826,7 +1827,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         // c) Construct a second CMap name by concatenating the registry and
         // ordering obtained in step (b) in the format registry–ordering–UCS2
         // (for example, Adobe–Japan1–UCS2).
-        var ucs2CMapName = new Name(registry + '-' + ordering + '-UCS2');
+        var ucs2CMapName = Name.get(registry + '-' + ordering + '-UCS2');
         // d) Obtain the CMap with the name constructed in step (c) (available
         // from the ASN Web site; see the Bibliography).
         return CMapFactory.create(ucs2CMapName, this.options.cMapOptions,

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -160,7 +160,7 @@ describe('cmap', function() {
     });
   });
   it('loads built in cmap', function(done) {
-    var cmapPromise = CMapFactory.create(new Name('Adobe-Japan1-1'),
+    var cmapPromise = CMapFactory.create(Name.get('Adobe-Japan1-1'),
                                   { url: cMapUrl, packed: cMapPacked }, null);
     cmapPromise.then(function (cmap) {
       expect(cmap instanceof CMap).toEqual(true);
@@ -174,7 +174,7 @@ describe('cmap', function() {
     });
   });
   it('loads built in identity cmap', function(done) {
-    var cmapPromise = CMapFactory.create(new Name('Identity-H'),
+    var cmapPromise = CMapFactory.create(Name.get('Identity-H'),
                                   { url: cMapUrl, packed: cMapPacked }, null);
     cmapPromise.then(function (cmap) {
       expect(cmap instanceof IdentityCMap).toEqual(true);

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -16,7 +16,7 @@ describe('primitives', function() {
   describe('Cmd', function() {
     it('should retain the given cmd name', function() {
       var givenCmd = 'BT';
-      var cmd = new Cmd(givenCmd);
+      var cmd = Cmd.get(givenCmd);
       expect(cmd.cmd).toEqual(givenCmd);
     });
 


### PR DESCRIPTION
Using `new {Name,Cmd}` should be avoided, since it creates a new object on _every_ call, whereas `{Name,Cmd}.get` uses caches to only create _one_ object regardless of how many times they are called.

Most of these are found in the unit-tests, where increased memory usage probably doesn't matter very much. But it still seems good to get rid of those cases, since no part of the codebase ought to advertise that usage.

Given the small size of the patch, I'm also tweaking a few comments and class names.
