### PR TITLE
Use `beforeAll`/`afterAll` in `CipherTransformFactory` in crypto_spec.js (issue 6905)

### DIFF
--- a/test/unit/crypto_spec.js
+++ b/test/unit/crypto_spec.js
@@ -1,20 +1,11 @@
-/* globals expect, it, describe, calculateMD5, ARCFourCipher, Name,
-           CipherTransformFactory, calculateSHA256, calculateSHA384,
-           calculateSHA512, AES128Cipher, AES256Cipher, PDF17, PDF20,
-           PasswordException, PasswordResponses */
+/* globals expect, it, describe, calculateMD5, ARCFourCipher, Name, beforeAll,
+           CipherTransformFactory, calculateSHA256, calculateSHA384, afterAll,
+           calculateSHA512, AES128Cipher, AES256Cipher, PDF17, PDF20, Dict,
+           PasswordException, PasswordResponses, stringToBytes */
 
 'use strict';
 
 describe('crypto', function() {
-  function string2binary(s) {
-    var n = s.length, i;
-    var result = new Uint8Array(n);
-    for (i = 0; i < n; ++i) {
-      result[i] = s.charCodeAt(i) % 0xFF;
-    }
-    return result;
-  }
-
   function hex2binary(s) {
     var digits = '0123456789ABCDEF';
     s = s.toUpperCase();
@@ -33,42 +24,42 @@ describe('crypto', function() {
   describe('calculateMD5', function() {
     it('should pass RFC 1321 test #1', function() {
       var input, result, expected;
-      input = string2binary('');
+      input = stringToBytes('');
       result = calculateMD5(input, 0, input.length);
       expected = hex2binary('d41d8cd98f00b204e9800998ecf8427e');
       expect(result).toEqual(expected);
     });
     it('should pass RFC 1321 test #2', function() {
       var input, result, expected;
-      input = string2binary('a');
+      input = stringToBytes('a');
       result = calculateMD5(input, 0, input.length);
       expected = hex2binary('0cc175b9c0f1b6a831c399e269772661');
       expect(result).toEqual(expected);
     });
     it('should pass RFC 1321 test #3', function() {
       var input, result, expected;
-      input = string2binary('abc');
+      input = stringToBytes('abc');
       result = calculateMD5(input, 0, input.length);
       expected = hex2binary('900150983cd24fb0d6963f7d28e17f72');
       expect(result).toEqual(expected);
     });
     it('should pass RFC 1321 test #4', function() {
       var input, result, expected;
-      input = string2binary('message digest');
+      input = stringToBytes('message digest');
       result = calculateMD5(input, 0, input.length);
       expected = hex2binary('f96b697d7cb7938d525a2f31aaf161d0');
       expect(result).toEqual(expected);
     });
     it('should pass RFC 1321 test #5', function() {
       var input, result, expected;
-      input = string2binary('abcdefghijklmnopqrstuvwxyz');
+      input = stringToBytes('abcdefghijklmnopqrstuvwxyz');
       result = calculateMD5(input, 0, input.length);
       expected = hex2binary('c3fcd3d76192e4007dfb496cca67e13b');
       expect(result).toEqual(expected);
     });
     it('should pass RFC 1321 test #6', function() {
       var input, result, expected;
-      input = string2binary('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuv' +
+      input = stringToBytes('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuv' +
         'wxyz0123456789');
       result = calculateMD5(input, 0, input.length);
       expected = hex2binary('d174ab98d277d9f5a5611c2c9f419d9f');
@@ -76,7 +67,7 @@ describe('crypto', function() {
     });
     it('should pass RFC 1321 test #7', function() {
       var input, result, expected;
-      input = string2binary('123456789012345678901234567890123456789012345678' +
+      input = stringToBytes('123456789012345678901234567890123456789012345678' +
         '90123456789012345678901234567890');
       result = calculateMD5(input, 0, input.length);
       expected = hex2binary('57edf4a22be3c955ac49da2e2107b67a');
@@ -190,7 +181,7 @@ describe('crypto', function() {
   describe('calculateSHA256', function() {
     it('should properly hash abc', function() {
       var input, result, expected;
-      input = string2binary('abc');
+      input = stringToBytes('abc');
       result = calculateSHA256(input, 0, input.length);
       expected = hex2binary('BA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9C' +
                             'B410FF61F20015AD');
@@ -198,7 +189,7 @@ describe('crypto', function() {
     });
     it('should properly hash a multiblock input', function() {
       var input, result, expected;
-      input = string2binary('abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmno' +
+      input = stringToBytes('abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmno' +
                             'mnopnopq');
       result = calculateSHA256(input, 0, input.length);
       expected = hex2binary('248D6A61D20638B8E5C026930C3E6039A33CE45964FF2167' +
@@ -210,7 +201,7 @@ describe('crypto', function() {
   describe('calculateSHA384', function() {
     it('should properly hash abc', function() {
       var input, result, expected;
-      input = string2binary('abc');
+      input = stringToBytes('abc');
       result = calculateSHA384(input, 0, input.length);
       expected = hex2binary('CB00753F45A35E8BB5A03D699AC65007272C32AB0EDED163' +
                             '1A8B605A43FF5BED8086072BA1E7CC2358BAECA134C825A7');
@@ -218,7 +209,7 @@ describe('crypto', function() {
     });
     it('should properly hash a multiblock input', function() {
       var input, result, expected;
-      input = string2binary('abcdefghbcdefghicdefghijdefghijkefghijklfghijklm' +
+      input = stringToBytes('abcdefghbcdefghicdefghijdefghijkefghijklfghijklm' +
                             'ghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrs' +
                             'mnopqrstnopqrstu');
       result = calculateSHA384(input, 0, input.length);
@@ -231,7 +222,7 @@ describe('crypto', function() {
   describe('calculateSHA512', function() {
     it('should properly hash abc', function() {
       var input, result, expected;
-      input = string2binary('abc');
+      input = stringToBytes('abc');
       result = calculateSHA512(input, 0, input.length);
       expected = hex2binary('DDAF35A193617ABACC417349AE20413112E6FA4E89A97EA2' +
                             '0A9EEEE64B55D39A2192992A274FC1A836BA3C23A3FEEBBD' +
@@ -240,7 +231,7 @@ describe('crypto', function() {
     });
     it('should properly hash a multiblock input', function() {
       var input, result, expected;
-      input = string2binary('abcdefghbcdefghicdefghijdefghijkefghijklfghijklm' +
+      input = stringToBytes('abcdefghbcdefghicdefghijdefghijkefghijklfghijklm' +
                             'ghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrs' +
                             'mnopqrstnopqrstu');
       result = calculateSHA512(input, 0, input.length);
@@ -250,8 +241,6 @@ describe('crypto', function() {
       expect(result).toEqual(expected);
     });
   });
-
-
 
   describe('AES128', function() {
     describe('Encryption', function() {
@@ -403,11 +392,10 @@ describe('crypto', function() {
       alg = new PDF20();
       password = new Uint8Array([117, 115, 101, 114]);
       userValidation = new Uint8Array([83, 245, 146, 101, 198, 247, 34, 198]);
-      userPassword = new Uint8Array([
-                                      94, 230, 205, 75, 166, 99, 250, 76, 219,
-                                      128, 17, 85, 57, 17, 33, 164, 150, 46,
-                                      103, 176, 160, 156, 187, 233, 166, 223,
-                                      163, 253, 147, 235, 95, 184]);
+      userPassword = new Uint8Array([94, 230, 205, 75, 166, 99, 250, 76, 219,
+                                     128, 17, 85, 57, 17, 33, 164, 150, 46,
+                                     103, 176, 160, 156, 187, 233, 166, 223,
+                                     163, 253, 147, 235, 95, 184]);
       result = alg.checkUserPassword(password, userValidation, userPassword);
       expect(result).toEqual(true);
     });
@@ -473,189 +461,188 @@ describe('crypto', function() {
   });
 });
 
-
-
 describe('CipherTransformFactory', function() {
-  function DictMock(map) {
-    this.map = map;
-  }
-  DictMock.prototype = {
-    get: function(key) {
-      return this.map[key];
+  function buildDict(map) {
+    var dict = new Dict();
+    for (var key in map) {
+      dict.set(key, map[key]);
     }
-  };
+    return dict;
+  }
 
-  function ensureCipherTransformFactoryPasswordIncorrect(
-      dict, fileId, password) {
-    var exception = null;
+  function ensurePasswordCorrect(done, dict, fileId, password) {
+    try {
+      var factory = new CipherTransformFactory(dict, fileId, password);
+      expect('createCipherTransform' in factory).toEqual(true);
+    } catch (ex) {
+      done.fail('Password should be accepted: ' + ex);
+      return;
+    }
+    done();
+  }
+
+  function ensurePasswordIncorrect(done, dict, fileId, password) {
     try {
       new CipherTransformFactory(dict, fileId, password);
     } catch (ex) {
-      exception = ex;
+      expect(ex instanceof PasswordException).toEqual(true);
+      expect(ex.code).toEqual(PasswordResponses.INCORRECT_PASSWORD);
+
+      done();
+      return;
     }
-    expect(exception instanceof PasswordException).toEqual(true);
-    expect(exception.code).toEqual(PasswordResponses.INCORRECT_PASSWORD);
+    done.fail('Password should be rejected.');
   }
 
-  var map1 = {
-    Filter: Name.get('Standard'),
-    V: 2,
-    Length: 128,
-    O: unescape('%80%C3%04%96%91o%20sl%3A%E6%1B%13T%91%F2%0DV%12%E3%FF%5E%BB%' +
-                'E9VO%D8k%9A%CA%7C%5D'),
-    U: unescape('j%0C%8D%3EY%19%00%BCjd%7D%91%BD%AA%00%18%00%00%00%00%00%00%0' +
-                '0%00%00%00%00%00%00%00%00%00'),
-    P: -1028,
-    R: 3
-  };
-  var fileID1 = unescape('%F6%C6%AF%17%F3rR%8DRM%9A%80%D1%EF%DF%18');
+  var fileId1, fileId2, dict1, dict2;
+  var aes256Dict, aes256IsoDict, aes256BlankDict, aes256IsoBlankDict;
 
-  var map2 = {
-    Filter: Name.get('Standard'),
-    V: 4,
-    Length: 128,
-    O: unescape('sF%14v.y5%27%DB%97%0A5%22%B3%E1%D4%AD%BD%9B%3C%B4%A5%89u%15%' +
-                'B2Y%F1h%D9%E9%F4'),
-    U: unescape('%93%04%89%A9%BF%8AE%A6%88%A2%DB%C2%A0%A8gn%00%00%00%00%00%00' +
-                '%00%00%00%00%00%00%00%00%00%00'),
-    P: -1084,
-    R: 4
-  };
+  beforeAll(function (done) {
+    fileId1 = unescape('%F6%C6%AF%17%F3rR%8DRM%9A%80%D1%EF%DF%18');
+    fileId2 = unescape('%3CL_%3AD%96%AF@%9A%9D%B3%3Cx%1Cv%AC');
 
-  var aes256Map = {
-    Filter: Name.get('Standard'),
-    V: 5,
-    Length: 256,
-    O: unescape('%3Cb%89%233e%C8%98%D2%B2%E2%E4%86%CD%A3%18%CC%7E%B1%24j2%24%' +
-                '7D%D2%AC%ABx%DEl%8Bs%F3vG%99%80%11e%3E%C8%F5%F2%0C%DA%7B%18x'),
-    U: unescape('%83%F2%8F%A0W%02%8A%86O%FD%BD%AD%E0I%90%F1%BEQ%C5%0F%F9i%91%' +
-                '97%0F%C2A%03%01%7E%BB%DDu%A9%04%20%9Fe%16%DC%A8%5E%D7%C0d%26' +
-                '%BC%28'),
-    OE: unescape('%D5%CA%0E%BDnLF%BF%06%C3%0A%BE%9Dd%90U%08%3E%7B%B2%9C%E52%2' +
-                '8%E5%D86%DE%22%26j%DF'),
-    UE: unescape('%23%96%C3%A9%F533%FF%9E%9E%21%F2%E7K%7D%BE%19%7E%ACr%C3%F4%' +
-                 '89%F5%EA%A5*J%3C%26%11%11'),
-    Perms: unescape('%D8%FC%844%E5e%0DB%5D%7Ff%FD%3COMM'),
-    P: -1084,
-    R: 5
-  };
+    dict1 = buildDict({
+      Filter: Name.get('Standard'),
+      V: 2,
+      Length: 128,
+      O: unescape('%80%C3%04%96%91o%20sl%3A%E6%1B%13T%91%F2%0DV%12%E3%FF%5E%B' +
+                  'B%E9VO%D8k%9A%CA%7C%5D'),
+      U: unescape('j%0C%8D%3EY%19%00%BCjd%7D%91%BD%AA%00%18%00%00%00%00%00%00' +
+                  '%00%00%00%00%00%00%00%00%00%00'),
+      P: -1028,
+      R: 3,
+    });
+    dict2 = buildDict({
+      Filter: Name.get('Standard'),
+      V: 4,
+      Length: 128,
+      O: unescape('sF%14v.y5%27%DB%97%0A5%22%B3%E1%D4%AD%BD%9B%3C%B4%A5%89u%1' +
+                  '5%B2Y%F1h%D9%E9%F4'),
+      U: unescape('%93%04%89%A9%BF%8AE%A6%88%A2%DB%C2%A0%A8gn%00%00%00%00%00%' +
+                  '00%00%00%00%00%00%00%00%00%00%00'),
+      P: -1084,
+      R: 4,
+    });
+    aes256Dict = buildDict({
+      Filter: Name.get('Standard'),
+      V: 5,
+      Length: 256,
+      O: unescape('%3Cb%89%233e%C8%98%D2%B2%E2%E4%86%CD%A3%18%CC%7E%B1%24j2%2' +
+                  '4%7D%D2%AC%ABx%DEl%8Bs%F3vG%99%80%11e%3E%C8%F5%F2%0C%DA%7B' +
+                  '%18x'),
+      U: unescape('%83%F2%8F%A0W%02%8A%86O%FD%BD%AD%E0I%90%F1%BEQ%C5%0F%F9i%9' +
+                  '1%97%0F%C2A%03%01%7E%BB%DDu%A9%04%20%9Fe%16%DC%A8%5E%D7%C0' +
+                  'd%26%BC%28'),
+      OE: unescape('%D5%CA%0E%BDnLF%BF%06%C3%0A%BE%9Dd%90U%08%3E%7B%B2%9C%E52' +
+                   '%28%E5%D86%DE%22%26j%DF'),
+      UE: unescape('%23%96%C3%A9%F533%FF%9E%9E%21%F2%E7K%7D%BE%19%7E%ACr%C3%F' +
+                   '4%89%F5%EA%A5*J%3C%26%11%11'),
+      Perms: unescape('%D8%FC%844%E5e%0DB%5D%7Ff%FD%3COMM'),
+      P: -1084,
+      R: 5,
+    });
+    aes256IsoDict = buildDict({
+      Filter: Name.get('Standard'),
+      V: 5,
+      Length: 256,
+      O: unescape('X%E8%3E6%F5%1A%F5%D1%89%7B%DDH%C71%25%D9%1FJs%A7%7F%9E%B0M' +
+                  '-%A3W/%27Z%D9%8D%8E%E8%A9%D0%CA%D6%05%B9%1D%D0%B9.%0BL%87%' +
+                  '95'),
+      U: unescape('%5E%E6%CDK%A6c%FAL%DB%80%11U9%11%21%A4%96.g%B0%A0%9C%BB%E9' +
+                  '%A6%DF%A3%FD%93%EB_%B8S%F5%92e%C6%F7%22%C6%BF%0B%10%5E%ED%' +
+                  'D8%14%AF'),
+      OE: unescape('%D1I%E0Mg%9B%C9%B5%BED%DF%14%3EZ8%D2%05%F0%B2%80%EE%7CD%F' +
+                   'E%FD%F4%3El%D0%87%0A%FB'),
+      UE: unescape('y%D0%02%B5%E6Y%9C%3C%FD%8F%D4%1CT%B4%C4%B1%AD%80%DDk.%14%' +
+                   '5E%BA%873_%18%14%DF%FE%24'),
+      Perms: unescape('l%AD%0F%A0%EBM%86WM%3E%CB%B5%E0X%C97'),
+      P: -1084,
+      R: 6,
+    });
+    aes256BlankDict = buildDict({
+      Filter: Name.get('Standard'),
+      V: 5,
+      Length: 256,
+      O: unescape('%B8p%04%C3g%26%FCW%CCN%D4%16%A1%E8%950YZ%C9%9E%B1-%97%F3%F' +
+                  'E%03%13%19ffZn%8F%F5%EB%EC%CC5sV%10e%CEl%B5%E9G%C1'),
+      U: unescape('%83%D4zi%F1O0%961%12%CC%82%CB%CA%BF5y%FD%21%EB%E4%D1%B5%1D' +
+                  '%D6%FA%14%F3%BE%8Fqs%EF%88%DE%E2%E8%DC%F55%E4%B8%16%C8%14%' +
+                  '8De%1E'),
+      OE: unescape('%8F%19%E8%D4%27%D5%07%CA%C6%A1%11%A6a%5Bt%F4%DF%0F%84%29%' +
+                   '0F%E4%EFF7%5B%5B%11%A0%8F%17e'),
+      UE: unescape('%81%F5%5D%B0%28%81%E4%7F_%7C%8F%85b%A0%7E%10%D0%88lx%7B%7' +
+                   'EJ%5E%912%B6d%12%27%05%F6'),
+      Perms: unescape('%86%1562%0D%AE%A2%FB%5D%3B%22%3Dq%12%B2H'),
+      P: -1084,
+      R: 5,
+    });
+    aes256IsoBlankDict = buildDict({
+      Filter: Name.get('Standard'),
+      V: 5,
+      Length: 256,
+      O: unescape('%F7%DB%99U%A6M%ACk%AF%CF%D7AFw%E9%C1%91%CBDgI%23R%CF%0C%15' +
+                  'r%D74%0D%CE%E9%91@%E4%98QF%BF%88%7Ej%DE%AD%8F%F4@%C1'),
+      U: unescape('%1A%A9%DC%918%83%93k%29%5B%117%B16%DB%E8%8E%FE%28%E5%89%D4' +
+                  '%0E%AD%12%3B%7DN_6fez%8BG%18%05YOh%7DZH%A3Z%87%17*'),
+      OE: unescape('%A4a%88%20h%1B%7F%CD%D5%CAc%D8R%83%E5%D6%1C%D2%98%07%984%' +
+                   'BA%AF%1B%B4%7FQ%F8%1EU%7D'),
+      UE: unescape('%A0%0AZU%27%1D%27%2C%0B%FE%0E%A2L%F9b%5E%A1%B9%D6v7b%B26%' +
+                   'A9N%99%F1%A4Deq'),
+      Perms: unescape('%03%F2i%07%0D%C3%F9%F2%28%80%B7%F5%DD%D1c%EB'),
+      P: -1084,
+      R: 6,
+    });
 
-  var aes256IsoMap = {
-    Filter: Name.get('Standard'),
-    V: 5,
-    Length: 256,
-    O: unescape('X%E8%3E6%F5%1A%F5%D1%89%7B%DDH%C71%25%D9%1FJs%A7%7F%9E%B0M-%' +
-                'A3W/%27Z%D9%8D%8E%E8%A9%D0%CA%D6%05%B9%1D%D0%B9.%0BL%87%95'),
-    U: unescape('%5E%E6%CDK%A6c%FAL%DB%80%11U9%11%21%A4%96.g%B0%A0%9C%BB%E9%A' +
-                '6%DF%A3%FD%93%EB_%B8S%F5%92e%C6%F7%22%C6%BF%0B%10%5E%ED%D8%1' +
-                '4%AF'),
-    OE: unescape('%D1I%E0Mg%9B%C9%B5%BED%DF%14%3EZ8%D2%05%F0%B2%80%EE%7CD%FE%' +
-                 'FD%F4%3El%D0%87%0A%FB'),
-    UE: unescape('y%D0%02%B5%E6Y%9C%3C%FD%8F%D4%1CT%B4%C4%B1%AD%80%DDk.%14%5E' +
-                 '%BA%873_%18%14%DF%FE%24'),
-    Perms: unescape('l%AD%0F%A0%EBM%86WM%3E%CB%B5%E0X%C97'),
-    P: -1084,
-    R: 6
-  };
+    done();
+  });
 
-  var aes256BlankMap = {
-    Filter: Name.get('Standard'),
-    V: 5,
-    Length: 256,
-    O: unescape('%B8p%04%C3g%26%FCW%CCN%D4%16%A1%E8%950YZ%C9%9E%B1-%97%F3%FE%' +
-                '03%13%19ffZn%8F%F5%EB%EC%CC5sV%10e%CEl%B5%E9G%C1'),
-    U: unescape('%83%D4zi%F1O0%961%12%CC%82%CB%CA%BF5y%FD%21%EB%E4%D1%B5%1D%D' +
-                '6%FA%14%F3%BE%8Fqs%EF%88%DE%E2%E8%DC%F55%E4%B8%16%C8%14%8De%' +
-                '1E'),
-    OE: unescape('%8F%19%E8%D4%27%D5%07%CA%C6%A1%11%A6a%5Bt%F4%DF%0F%84%29%0F' +
-                 '%E4%EFF7%5B%5B%11%A0%8F%17e'),
-    UE: unescape('%81%F5%5D%B0%28%81%E4%7F_%7C%8F%85b%A0%7E%10%D0%88lx%7B%7EJ' +
-                 '%5E%912%B6d%12%27%05%F6'),
-    Perms: unescape('%86%1562%0D%AE%A2%FB%5D%3B%22%3Dq%12%B2H'),
-    P: -1084,
-    R: 5
-  };
-
-  var aes256IBlankMap = {
-    Filter: Name.get('Standard'),
-    V: 5,
-    Length: 256,
-    O: unescape('%F7%DB%99U%A6M%ACk%AF%CF%D7AFw%E9%C1%91%CBDgI%23R%CF%0C%15r%' +
-                'D74%0D%CE%E9%91@%E4%98QF%BF%88%7Ej%DE%AD%8F%F4@%C1'),
-    U: unescape('%1A%A9%DC%918%83%93k%29%5B%117%B16%DB%E8%8E%FE%28%E5%89%D4%0' +
-                'E%AD%12%3B%7DN_6fez%8BG%18%05YOh%7DZH%A3Z%87%17*'),
-    OE: unescape('%A4a%88%20h%1B%7F%CD%D5%CAc%D8R%83%E5%D6%1C%D2%98%07%984%BA' +
-                 '%AF%1B%B4%7FQ%F8%1EU%7D'),
-    UE: unescape('%A0%0AZU%27%1D%27%2C%0B%FE%0E%A2L%F9b%5E%A1%B9%D6v7b%B26%A9' +
-                 'N%99%F1%A4Deq'),
-    Perms: unescape('%03%F2i%07%0D%C3%F9%F2%28%80%B7%F5%DD%D1c%EB'),
-    P: -1084,
-    R: 6
-  };
-
-  var fileID2 = unescape('%3CL_%3AD%96%AF@%9A%9D%B3%3Cx%1Cv%AC');
+  afterAll(function () {
+    fileId1 = fileId2 = dict1 = dict2 = null;
+    aes256Dict = aes256IsoDict = aes256BlankDict = aes256IsoBlankDict = null;
+  });
 
   describe('#ctor', function() {
     describe('AES256 Revision 5', function () {
-      it('should accept user password', function () {
-        new CipherTransformFactory(new DictMock(aes256Map), fileID1, 'user');
-        expect(true).toEqual(true);
+      it('should accept user password', function (done) {
+        ensurePasswordCorrect(done, aes256Dict, fileId1, 'user');
       });
-      it('should accept owner password', function () {
-        new CipherTransformFactory(new DictMock(aes256Map), fileID1, 'owner');
-        expect(true).toEqual(true);
+      it('should accept owner password', function (done) {
+        ensurePasswordCorrect(done, aes256Dict, fileId1, 'owner');
       });
-      it('should not accept wrong password', function () {
-        ensureCipherTransformFactoryPasswordIncorrect(
-          new DictMock(aes256Map), fileID1, 'wrong');
-        expect(true).toEqual(true);
+      it('should not accept wrong password', function (done) {
+        ensurePasswordIncorrect(done, aes256Dict, fileId1, 'wrong');
       });
-      it('should accept blank password', function () {
-        new CipherTransformFactory(new DictMock(aes256BlankMap), fileID1);
-        expect(true).toEqual(true);
+      it('should accept blank password', function (done) {
+        ensurePasswordCorrect(done, aes256BlankDict, fileId1);
       });
     });
 
     describe('AES256 Revision 6', function () {
-      it('should accept user password', function () {
-        new CipherTransformFactory(new DictMock(aes256IsoMap), fileID1,
-                                   'user');
-        expect(true).toEqual(true);
+      it('should accept user password', function (done) {
+        ensurePasswordCorrect(done, aes256IsoDict, fileId1, 'user');
       });
-      it('should accept owner password', function () {
-        new CipherTransformFactory(new DictMock(aes256IsoMap), fileID1,
-                                   'owner');
-        expect(true).toEqual(true);
+      it('should accept owner password', function (done) {
+        ensurePasswordCorrect(done, aes256IsoDict, fileId1, 'owner');
       });
-      it('should not accept wrong password', function () {
-        ensureCipherTransformFactoryPasswordIncorrect(
-          new DictMock(aes256IsoMap), fileID1, 'wrong');
-        expect(true).toEqual(true);
+      it('should not accept wrong password', function (done) {
+        ensurePasswordIncorrect(done, aes256IsoDict, fileId1, 'wrong');
       });
-      it('should accept blank password', function () {
-        new CipherTransformFactory(new DictMock(aes256IBlankMap), fileID1);
-        expect(true).toEqual(true);
+      it('should accept blank password', function (done) {
+        ensurePasswordCorrect(done, aes256IsoBlankDict, fileId1);
       });
-    });
-    it('should accept user password', function() {
-      new CipherTransformFactory(new DictMock(map1), fileID1, '123456');
-      expect(true).toEqual(true);
     });
 
-    it('should accept owner password', function() {
-      new CipherTransformFactory(new DictMock(map1), fileID1, '654321');
-      expect(true).toEqual(true);
+    it('should accept user password', function (done) {
+      ensurePasswordCorrect(done, dict1, fileId1, '123456');
     });
-
-    it('should not accept wrong password', function() {
-      ensureCipherTransformFactoryPasswordIncorrect(
-        new DictMock(map1), fileID1, 'wrong');
-      expect(true).toEqual(true);
+    it('should accept owner password', function (done) {
+      ensurePasswordCorrect(done, dict1, fileId1, '654321');
     });
-
-    it('should accept no password', function() {
-      new CipherTransformFactory(new DictMock(map2), fileID2);
-      expect(true).toEqual(true);
+    it('should not accept wrong password', function (done) {
+      ensurePasswordIncorrect(done, dict1, fileId1, 'wrong');
+    });
+    it('should accept no password', function (done) {
+      ensurePasswordCorrect(done, dict2, fileId2);
     });
   });
 });


### PR DESCRIPTION
This patch also adds/improves utility functions for checking if the passwords are correct/incorrect, and replaces `string2binary` with `stringToBytes`. Finally the patch does away with the `DictMock`, in favour of using actual `Dict`s.

Re: issue #6905.

**_Note:**_ Perhaps marginally easier reviewing with https://github.com/mozilla/pdf.js/compare/master...Snuffleupagus:issue-6905-crypto_spec?w=1.
