### PR TITLE
[Bug 1260585] Stops bleeding of pattern edges for mesh.

### DIFF
--- a/test/pdfs/bug1260585.pdf.link
+++ b/test/pdfs/bug1260585.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=8736063

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2204,6 +2204,14 @@
       "link": true,
       "type": "load"
     },
+    {  "id": "bug1260585",
+      "file": "pdfs/bug1260585.pdf",
+      "md5": "9415b1eb00a43c97c15328cd4c8d136a",
+      "rounds": 1,
+      "lastPage": 1,
+      "link": true,
+      "type": "load"
+    },
     {  "id": "issue3062",
       "file": "pdfs/issue3062.pdf",
       "md5": "206715f1258f0e117df4180d98dd4d68",


### PR DESCRIPTION
The issue affects both Firefox and Chrome (not Safari though). Workaround due to how wide spread is the issue: adding transparent edges on all four sides of the pattern.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1260585
