### PR TITLE
Removing "entry-loader" dependency from webpack.

### DIFF
--- a/examples/browserify/README.md
+++ b/examples/browserify/README.md
@@ -16,10 +16,11 @@ http://localhost:8888/examples/browserify/index.html
 
 See main.js, worker.js and gulpfile.js files. Please notice that PDF.js
 packaging requires packaging of the main application and PDF.js worker code,
-and the `workerSrc` path shall be set to the latter file.
+and the `workerSrc` path shall be set to the latter file. The pdf.worker.js file
+shall be excluded from the main bundle.
 
 Alternatives to the gulp commands (without compression) are:
 
     $ mkdir -p ../../build/browserify
-    $ node_modules/.bin/browserify main.js -o ../../build/browserify/bundle.js
+    $ node_modules/.bin/browserify main.js -u ./node_modules/pdfjs-dist/build/pdf.worker.js -o ../../build/browserify/main.bundle.js
     $ node_modules/.bin/browserify worker.js -o ../../build/browserify/pdf.worker.bundle.js

--- a/examples/browserify/gulpfile.js
+++ b/examples/browserify/gulpfile.js
@@ -10,15 +10,18 @@ var TMP_FILE_PREFIX = '../../build/browserify_';
 
 gulp.task('build-bundle', function() {
   return browserify('main.js', {output: TMP_FILE_PREFIX + 'main.tmp'})
+    .ignore(require.resolve('pdfjs-dist/build/pdf.worker')) // Reducing size
     .bundle()
     .pipe(source(TMP_FILE_PREFIX + 'main.tmp'))
     .pipe(streamify(uglify()))
-    .pipe(rename('bundle.js'))
+    .pipe(rename('main.bundle.js'))
     .pipe(gulp.dest(OUTPUT_PATH));
 });
 
 gulp.task('build-worker', function() {
-  return browserify('worker.js', {output: TMP_FILE_PREFIX + 'worker.tmp'})
+  // We can create our own viewer (see worker.js) or use already defined one.
+  var workerSrc = require.resolve('pdfjs-dist/build/pdf.worker.entry');
+  return browserify(workerSrc, {output: TMP_FILE_PREFIX + 'worker.tmp'})
     .bundle()
     .pipe(source(TMP_FILE_PREFIX + 'worker.tmp'))
     .pipe(streamify(uglify({compress:{

--- a/examples/browserify/index.html
+++ b/examples/browserify/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>browserify example</title>
-  <script src="../../build/browserify/bundle.js"></script>
+  <script src="../../build/browserify/main.bundle.js"></script>
 </head>
 <body>
   <canvas id="theCanvas"></canvas>

--- a/examples/browserify/main.js
+++ b/examples/browserify/main.js
@@ -7,7 +7,7 @@ require('pdfjs-dist');
 
 var pdfPath = '../helloworld/helloworld.pdf';
 
-// Setting worker path to worker bundle
+// Setting worker path to worker bundle.
 PDFJS.workerSrc = '../../build/browserify/pdf.worker.bundle.js';
 
 // It is also possible to disable workers via `PDFJS.disableWorker = true`,

--- a/examples/webpack/README.md
+++ b/examples/webpack/README.md
@@ -14,5 +14,6 @@ To build Webpack bundles, run `node_modules/.bin/webpack`. If you are running
 a web server, you can observe the build results at
 http://localhost:8888/examples/webpack/index.html
 
-See main.js and webpack.config.js files. Please notice that PDF.js packaging
-requires the `entry` loader.
+See main.js and webpack.config.js files. Please notice that PDF.js
+packaging requires packaging of the main application and PDF.js worker code,
+and the `workerSrc` path shall be set to the latter file.

--- a/examples/webpack/index.html
+++ b/examples/webpack/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>webpack example</title>
-  <script src="../../build/webpack/bundle.js"></script>
+  <script src="../../build/webpack/main.bundle.js"></script>
 </head>
 <body>
   <canvas id="theCanvas"></canvas>

--- a/examples/webpack/main.js
+++ b/examples/webpack/main.js
@@ -7,6 +7,9 @@ var pdfjsLib = require('pdfjs-dist');
 
 var pdfPath = '../helloworld/helloworld.pdf';
 
+// Setting worker path to worker bundle.
+pdfjsLib.PDFJS.workerSrc = '../../build/webpack/pdf.worker.bundle.js';
+
 // It is also possible to disable workers via `PDFJS.disableWorker = true`,
 // however that might degrade the UI performance in web browsers.
 

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "devDependencies": {
     "webpack": "~1.12.9",
-    "entry-loader": "~0.1.0",
     "pdfjs-dist": "../../build/dist"
   }
 }

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -3,11 +3,14 @@ var path = require('path');
 
 module.exports = {
   context: __dirname,
-  entry: './main.js',
+  entry: {
+    'main': './main.js',
+    'pdf.worker': 'pdfjs-dist/build/pdf.worker.entry'
+  },
   output: {
     path: path.join(__dirname, '../../build/webpack'),
     publicPath: '../../build/webpack/',
-    filename: 'bundle.js'
+    filename: '[name].bundle.js'
   },
   plugins: [
     new webpack.optimize.UglifyJsPlugin({

--- a/make.js
+++ b/make.js
@@ -308,6 +308,7 @@ target.dist = function() {
     GENERIC_DIR + 'build/pdf.js',
     GENERIC_DIR + 'build/pdf.worker.js',
     SINGLE_FILE_DIR + 'build/pdf.combined.js',
+    SRC_DIR + 'pdf.worker.entry.js',
   ], DIST_DIR + 'build/');
 
   mkdir('-p', DIST_DIR + 'web/');
@@ -333,9 +334,10 @@ target.dist = function() {
     homepage: DIST_HOMEPAGE,
     bugs: DIST_BUGS_URL,
     license: DIST_LICENSE,
-    browser: { // used by browserify and ignores following files during bundle
-      'entry?name=[hash]-worker.js!./pdf.worker.js': false,
-      './build/pdf.worker.js': false,
+    dependencies: {
+      'node-ensure': '^0.0.0' // shim for node for require.ensure
+    },
+    browser: {
       'node-ensure': false
     },
     format: 'amd', // to not allow system.js to choose 'cjs'

--- a/src/frameworks.js
+++ b/src/frameworks.js
@@ -29,8 +29,6 @@ if (typeof window === 'undefined') {
   useRequireEnsure = true;
 }
 if (typeof __webpack_require__ !== 'undefined') {
-  // Webpack - get/bundle pdf.worker.js as additional file.
-  workerSrc = require('entry?name=[hash]-worker.js!./pdf.worker.js');
   useRequireEnsure = true;
 }
 if (typeof requirejs !== 'undefined' && requirejs.toUrl) {

--- a/src/pdf.worker.entry.js
+++ b/src/pdf.worker.entry.js
@@ -1,0 +1,18 @@
+/* Copyright 2016 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+(typeof window !== 'undefined' ? window : {}).pdfjsDistBuildPdfWorker =
+  require('./pdf.worker.js');
+


### PR DESCRIPTION
Fixes #7165

Basically webpack and browserify users are now responsible for making pdf.worker.js bundle. They can use pdfjs-dist/build/pdf.worker.entry file as entry point for that.

Ugly 'entry?name=[hash]-worker.js!./pdf.worker.js' is gone, but it can be used in PDFJS.workerSrc context in the main file. Webpack will generate one additional bundle for main one -- it's loaded for disableWorker mode (aka IE9 compat).
