### PR TITLE
Export the `DefaultAnnotationLayerFactory` to prevent the viewer components from breaking (PR 7172 followup)

### DIFF
--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -137,4 +137,5 @@ DefaultAnnotationLayerFactory.prototype = {
 };
 
 exports.AnnotationLayerBuilder = AnnotationLayerBuilder;
+exports.DefaultAnnotationLayerFactory = DefaultAnnotationLayerFactory;
 }));


### PR DESCRIPTION
Re: #7172.
