### PR TITLE
Remove `combineUrl` and replace it with `new URL`. Issue #7183, for reference.

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -45,7 +45,6 @@ var UnexpectedResponseException = sharedUtil.UnexpectedResponseException;
 var UnknownErrorException = sharedUtil.UnknownErrorException;
 var Util = sharedUtil.Util;
 var createPromiseCapability = sharedUtil.createPromiseCapability;
-var combineUrl = sharedUtil.combineUrl;
 var error = sharedUtil.error;
 var deprecated = sharedUtil.deprecated;
 var getVerbosityLevel = sharedUtil.getVerbosityLevel;
@@ -186,7 +185,7 @@ function getDocument(src, pdfDataRangeTransport,
   for (var key in source) {
     if (key === 'url' && typeof window !== 'undefined') {
       // The full path is required in the 'url' field.
-      params[key] = combineUrl(window.location.href, source[key]);
+      params[key] = new URL(source[key], window.location).href;
       continue;
     } else if (key === 'range') {
       rangeTransport = source[key];
@@ -1121,7 +1120,7 @@ var PDFWorker = (function PDFWorkerClosure() {
 //        // to the same origin.
 //        if (!isSameOrigin(window.location.href, workerSrc)) {
 //          workerSrc = createCDNWrapper(
-//            combineUrl(window.location.href, workerSrc));
+//            new URL(workerSrc, window.location).href);
 //        }
 //#endif
           // Some versions of FF can't create a worker on localhost, see:

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -295,15 +295,6 @@ var UNSUPPORTED_FEATURES = {
   font: 'font'
 };
 
-// Combines two URLs. The baseUrl shall be absolute URL. If the url is an
-// absolute URL, it will be returned as is.
-function combineUrl(baseUrl, url) {
-  if (!url) {
-    return baseUrl;
-  }
-  return new URL(url, baseUrl).href;
-}
-
 // Checks if URLs have the same origin. For non-HTTP based URLs, returns false.
 function isSameOrigin(baseUrl, otherUrl) {
   try {
@@ -2338,7 +2329,6 @@ exports.arrayByteLength = arrayByteLength;
 exports.arraysToBytes = arraysToBytes;
 exports.assert = assert;
 exports.bytesToString = bytesToString;
-exports.combineUrl = combineUrl;
 exports.createBlob = createBlob;
 exports.createPromiseCapability = createPromiseCapability;
 exports.createObjectURL = createObjectURL;

--- a/test/driver.js
+++ b/test/driver.js
@@ -332,9 +332,7 @@ var Driver = (function DriverClosure() {
 
       this._log('Loading file "' + task.file + '"\n');
 
-      var absoluteUrl = pdfjsSharedUtil.combineUrl(window.location.href,
-                                                   task.file);
-
+      var absoluteUrl = new URL(task.file, window.location).href; 
       PDFJS.disableRange = task.disableRange;
       PDFJS.disableAutoFetch = !task.enableAutoFetch;
       try {

--- a/test/unit/annotation_layer_spec.js
+++ b/test/unit/annotation_layer_spec.js
@@ -1,5 +1,5 @@
 /* globals expect, it, describe, Dict, Name, Annotation, AnnotationBorderStyle,
-           AnnotationBorderStyleType, AnnotationFlag, PDFJS, combineUrl,
+           AnnotationBorderStyleType, AnnotationFlag, PDFJS, 
            beforeEach, afterEach, stringToBytes */
 
 'use strict';
@@ -179,8 +179,8 @@ describe('Annotation layer', function() {
     var annotations;
 
     beforeEach(function(done) {
-      var pdfUrl = combineUrl(window.location.href,
-                              '../pdfs/annotation-fileattachment.pdf');
+      var pdfUrl = new URL('../pdfs/annotation-fileattachment.pdf', 
+                           window.location).href;
       loadingTask = PDFJS.getDocument(pdfUrl);
       loadingTask.promise.then(function(pdfDocument) {
         return pdfDocument.getPage(1).then(function(pdfPage) {

--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -1,67 +1,9 @@
-/* globals expect, it, describe, combineUrl, Dict, isDict, Name, PDFJS,
+/* globals expect, it, describe, Dict, isDict, Name, PDFJS,
            stringToPDFString, removeNullCharacters */
 
 'use strict';
 
 describe('util', function() {
-  describe('combineUrl', function() {
-    it('absolute url with protocol stays as is', function() {
-      var baseUrl = 'http://server/index.html';
-      var url = 'http://server2/test2.html';
-      var result = combineUrl(baseUrl, url);
-      var expected = 'http://server2/test2.html';
-      expect(result).toEqual(expected);
-    });
-
-    it('absolute url without protocol uses prefix from base', function() {
-      var baseUrl = 'http://server/index.html';
-      var url = '/test2.html';
-      var result = combineUrl(baseUrl, url);
-      var expected = 'http://server/test2.html';
-      expect(result).toEqual(expected);
-    });
-
-    it('combines relative url with base', function() {
-      var baseUrl = 'http://server/index.html';
-      var url = 'test2.html';
-      var result = combineUrl(baseUrl, url);
-      var expected = 'http://server/test2.html';
-      expect(result).toEqual(expected);
-    });
-
-    it('combines relative url (w/hash) with base', function() {
-      var baseUrl = 'http://server/index.html#!/test';
-      var url = 'test2.html';
-      var result = combineUrl(baseUrl, url);
-      var expected = 'http://server/test2.html';
-      expect(result).toEqual(expected);
-    });
-
-    it('combines relative url (w/query) with base', function() {
-      var baseUrl = 'http://server/index.html?search=/test';
-      var url = 'test2.html';
-      var result = combineUrl(baseUrl, url);
-      var expected = 'http://server/test2.html';
-      expect(result).toEqual(expected);
-    });
-
-    it('returns base url when url is empty', function() {
-      var baseUrl = 'http://server/index.html';
-      var url = '';
-      var result = combineUrl(baseUrl, url);
-      var expected = 'http://server/index.html';
-      expect(result).toEqual(expected);
-    });
-
-    it('returns base url when url is undefined', function() {
-      var baseUrl = 'http://server/index.html';
-      var url;
-      var result = combineUrl(baseUrl, url);
-      var expected = 'http://server/index.html';
-      expect(result).toEqual(expected);
-    });
-  });
-
   describe('isDict', function() {
     it('handles empty dictionaries with type check', function() {
       var dict = new Dict();


### PR DESCRIPTION
changes made to replace 'combineUrl' references to 'new URL' and also removed combineUrl utility function.

Fixes https://github.com/mozilla/pdf.js/issues/7183 
