### PR TITLE
Refactors dependencies of PDFViewerApplication on external services

### DIFF
--- a/examples/components/simpleviewer.js
+++ b/examples/components/simpleviewer.js
@@ -30,6 +30,7 @@ PDFJS.workerSrc = '../../build/pdf.worker.js';
 // PDFJS.cMapPacked = true;
 
 var DEFAULT_URL = '../../web/compressed.tracemonkey-pldi-09.pdf';
+var SEARCH_FOR = ''; // try 'Mozilla';
 
 var container = document.getElementById('viewerContainer');
 
@@ -42,9 +43,19 @@ var pdfViewer = new PDFJS.PDFViewer({
 });
 pdfLinkService.setViewer(pdfViewer);
 
+// (Optionally) enable find controller.
+var pdfFindController = new PDFJS.PDFFindController({
+  pdfViewer: pdfViewer
+});
+pdfViewer.setFindController(pdfFindController);
+
 container.addEventListener('pagesinit', function () {
   // We can use pdfViewer now, e.g. let's change default scale.
   pdfViewer.currentScaleValue = 'page-width';
+
+  if (SEARCH_FOR) { // We can try search for things
+    pdfFindController.executeCommand('find', {query: SEARCH_FOR});
+  }
 });
 
 // Loading document.

--- a/extensions/firefox/tools/l10n.js
+++ b/extensions/firefox/tools/l10n.js
@@ -1,14 +1,14 @@
-/* globals FirefoxCom */
 
 'use strict';
 
 // Small subset of the webL10n API by Fabien Cazenave for pdf.js extension.
 (function(window) {
   var gLanguage = '';
+  var gExternalLocalizerServices = null;
 
   // fetch an l10n objects
   function getL10nData(key) {
-    var response = FirefoxCom.requestSync('getStrings', key);
+    var response = gExternalLocalizerServices.getStrings(key);
     var data = JSON.parse(response);
     if (!data) {
       console.warn('[l10n] #' + key + ' missing for [' + gLanguage + ']');
@@ -94,8 +94,8 @@
     }
   }
 
-  window.addEventListener('DOMContentLoaded', function() {
-    gLanguage = FirefoxCom.requestSync('getLocale', null);
+  function translateDocument() {
+    gLanguage = gExternalLocalizerServices.getLocale();
 
     translateFragment();
 
@@ -104,6 +104,13 @@
     evtObject.initEvent('localized', false, false);
     evtObject.language = gLanguage;
     window.dispatchEvent(evtObject);
+  }
+
+  window.addEventListener('DOMContentLoaded', function() {
+    if (gExternalLocalizerServices) {
+      translateDocument();
+    }
+    // ... else see setExternalLocalizerServices below
   });
 
   // Public API
@@ -126,6 +133,16 @@
       var shortCode = gLanguage.split('-')[0];
 
       return (rtlList.indexOf(shortCode) >= 0) ? 'rtl' : 'ltr';
+    },
+
+    setExternalLocalizerServices: function (externalLocalizerServices) {
+      gExternalLocalizerServices = externalLocalizerServices;
+
+      // ... in case if we missed DOMContentLoaded above.
+      if (window.document.readyState === 'interactive' ||
+          window.document.readyState === 'complete') {
+        translateDocument();
+      }
     },
 
     // translate an element or document fragment

--- a/make.js
+++ b/make.js
@@ -179,6 +179,7 @@ target.components = function() {
   var bundleFiles = [
     'pdf_viewer.js',
     'pdf_history.js',
+    'pdf_find_controller.js',
     'download_manager.js'
   ];
   bundle('pdf_viewer.component.js', ROOT_DIR + TMP_PDF_VIEWER, bundleFiles,

--- a/make.js
+++ b/make.js
@@ -129,7 +129,7 @@ target.generic = function() {
 
   var TMP_VIEWER = GENERIC_DIR + '/web/viewer.js.tmp';
   cd('web/');
-  var viewerBundleFiles = ['app.js'];
+  var viewerBundleFiles = ['app.js', 'mozPrintCallback_polyfill.js'];
   bundle('viewer.js', ROOT_DIR + TMP_VIEWER,  viewerBundleFiles,
     'pdfjs-dist/web/viewer', defines, true);
   cd(ROOT_DIR);
@@ -1132,7 +1132,8 @@ target.chromium = function() {
 
   var TMP_VIEWER = CHROME_BUILD_CONTENT_DIR + '/web/viewer.js.tmp';
   cd('web/');
-  var viewerBundleFiles = ['app.js', 'chromecom.js'];
+  var viewerBundleFiles = ['app.js', 'chromecom.js',
+                           'mozPrintCallback_polyfill.js'];
   bundle('viewer.js', ROOT_DIR + TMP_VIEWER, viewerBundleFiles,
     'pdfjs-dist/web/viewer', defines, true);
   cd(ROOT_DIR);

--- a/web/app.js
+++ b/web/app.js
@@ -19,8 +19,8 @@
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
     define('pdfjs-web/app', ['exports', 'pdfjs-web/ui_utils',
-      'pdfjs-web/firefoxcom', 'pdfjs-web/download_manager',
-      'pdfjs-web/pdf_history', 'pdfjs-web/preferences', 'pdfjs-web/pdf_sidebar',
+      'pdfjs-web/download_manager', 'pdfjs-web/pdf_history',
+      'pdfjs-web/preferences', 'pdfjs-web/pdf_sidebar',
       'pdfjs-web/view_history', 'pdfjs-web/pdf_thumbnail_viewer',
       'pdfjs-web/secondary_toolbar', 'pdfjs-web/password_prompt',
       'pdfjs-web/pdf_presentation_mode', 'pdfjs-web/pdf_document_properties',
@@ -32,12 +32,11 @@
       'pdfjs-web/pdfjs'],
       factory);
   } else if (typeof exports !== 'undefined') {
-    factory(exports, require('./ui_utils.js'), require('./firefoxcom.js'),
-      require('./download_manager.js'), require('./pdf_history.js'),
-      require('./preferences.js'), require('./pdf_sidebar.js'),
-      require('./view_history.js'), require('./pdf_thumbnail_viewer.js'),
-      require('./secondary_toolbar.js'), require('./password_prompt.js'),
-      require('./pdf_presentation_mode.js'),
+    factory(exports, require('./ui_utils.js'), require('./download_manager.js'),
+      require('./pdf_history.js'), require('./preferences.js'),
+      require('./pdf_sidebar.js'), require('./view_history.js'),
+      require('./pdf_thumbnail_viewer.js'), require('./secondary_toolbar.js'),
+      require('./password_prompt.js'), require('./pdf_presentation_mode.js'),
       require('./pdf_document_properties.js'), require('./hand_tool.js'),
       require('./pdf_viewer.js'), require('./pdf_rendering_queue.js'),
       require('./pdf_link_service.js'), require('./pdf_outline_viewer.js'),
@@ -46,20 +45,20 @@
       require('./mozPrintCallback_polyfill.js'), require('./pdfjs.js'));
   } else {
     factory((root.pdfjsWebApp = {}), root.pdfjsWebUIUtils,
-      root.pdfjsWebFirefoxCom, root.pdfjsWebDownloadManager,
-      root.pdfjsWebPDFHistory, root.pdfjsWebPreferences,
-      root.pdfjsWebPDFSidebar, root.pdfjsWebViewHistory,
-      root.pdfjsWebPDFThumbnailViewer, root.pdfjsWebSecondaryToolbar,
-      root.pdfjsWebPasswordPrompt, root.pdfjsWebPDFPresentationMode,
-      root.pdfjsWebPDFDocumentProperties, root.pdfjsWebHandTool,
-      root.pdfjsWebPDFViewer, root.pdfjsWebPDFRenderingQueue,
-      root.pdfjsWebPDFLinkService, root.pdfjsWebPDFOutlineViewer,
-      root.pdfjsWebOverlayManager, root.pdfjsWebPDFAttachmentViewer,
-      root.pdfjsWebPDFFindController, root.pdfjsWebPDFFindBar,
-      root.pdfjsWebMozPrintCallbackPolyfill, root.pdfjsWebPDFJS);
+      root.pdfjsWebDownloadManager, root.pdfjsWebPDFHistory,
+      root.pdfjsWebPreferences, root.pdfjsWebPDFSidebar,
+      root.pdfjsWebViewHistory, root.pdfjsWebPDFThumbnailViewer,
+      root.pdfjsWebSecondaryToolbar, root.pdfjsWebPasswordPrompt,
+      root.pdfjsWebPDFPresentationMode, root.pdfjsWebPDFDocumentProperties,
+      root.pdfjsWebHandTool, root.pdfjsWebPDFViewer,
+      root.pdfjsWebPDFRenderingQueue, root.pdfjsWebPDFLinkService,
+      root.pdfjsWebPDFOutlineViewer, root.pdfjsWebOverlayManager,
+      root.pdfjsWebPDFAttachmentViewer, root.pdfjsWebPDFFindController,
+      root.pdfjsWebPDFFindBar, root.pdfjsWebMozPrintCallbackPolyfill,
+      root.pdfjsWebPDFJS);
   }
-}(this, function (exports, uiUtilsLib, firefoxComLib, downloadManagerLib,
-                  pdfHistoryLib, preferencesLib, pdfSidebarLib, viewHistoryLib,
+}(this, function (exports, uiUtilsLib, downloadManagerLib, pdfHistoryLib,
+                  preferencesLib, pdfSidebarLib, viewHistoryLib,
                   pdfThumbnailViewerLib, secondaryToolbarLib, passwordPromptLib,
                   pdfPresentationModeLib, pdfDocumentPropertiesLib, handToolLib,
                   pdfViewerLib, pdfRenderingQueueLib, pdfLinkServiceLib,
@@ -67,7 +66,6 @@
                   pdfAttachmentViewerLib, pdfFindControllerLib, pdfFindBarLib,
                   mozPrintCallbackPolyfillLib, pdfjsLib) {
 
-var FirefoxCom = firefoxComLib.FirefoxCom;
 var UNKNOWN_SCALE = uiUtilsLib.UNKNOWN_SCALE;
 var DEFAULT_SCALE_VALUE = uiUtilsLib.DEFAULT_SCALE_VALUE;
 var ProgressBar = uiUtilsLib.ProgressBar;
@@ -75,8 +73,6 @@ var getPDFFileNameFromURL = uiUtilsLib.getPDFFileNameFromURL;
 var noContextMenuHandler = uiUtilsLib.noContextMenuHandler;
 var mozL10n = uiUtilsLib.mozL10n;
 var parseQueryString = uiUtilsLib.parseQueryString;
-var DownloadManager = downloadManagerLib.DownloadManager ||
-                      firefoxComLib.DownloadManager;
 var PDFHistory = pdfHistoryLib.PDFHistory;
 var Preferences = preferencesLib.Preferences;
 var SidebarView = pdfSidebarLib.SidebarView;
@@ -122,6 +118,23 @@ function configure(PDFJS) {
 //#endif
 }
 
+var DefaultExernalServices = {
+  updateFindControlState: function (data) {},
+  initPassiveLoading: function (callbacks) {},
+  fallback: function (data, callback) {},
+  reportTelemetry: function (data) {},
+  createDownloadManager: function () {
+    return new downloadManagerLib.DownloadManager();
+  },
+  supportsIntegratedFind: false,
+  supportsDocumentFonts: true,
+  supportsDocumentColors: true,
+  supportedMouseWheelZoomModifierKeys: {
+    ctrlKey: true,
+    metaKey: true,
+  }
+};
+
 var PDFViewerApplication = {
   initialBookmark: document.location.hash.substring(1),
   initialDestination: null,
@@ -153,6 +166,8 @@ var PDFViewerApplication = {
   pdfAttachmentViewer: null,
   /** @type {ViewHistory} */
   store: null,
+  /** @type {DownloadManager} */
+  downloadManager: null,
   pageRotation: 0,
   isInitialViewSet: false,
   animationStartedPromise: null,
@@ -162,6 +177,7 @@ var PDFViewerApplication = {
   preferenceDefaultZoomValue: '',
   isViewerEmbedded: (window.parent !== window),
   url: '',
+  externalServices: DefaultExernalServices,
 
   // called once when the document is loaded
   initialize: function pdfViewInitialize(appConfig) {
@@ -175,6 +191,9 @@ var PDFViewerApplication = {
     var pdfLinkService = new PDFLinkService();
     this.pdfLinkService = pdfLinkService;
 
+    var downloadManager = this.externalServices.createDownloadManager();
+    this.downloadManager = downloadManager;
+
     var container = appConfig.mainContainer;
     var viewer = appConfig.viewerContainer;
     this.pdfViewer = new PDFViewer({
@@ -182,7 +201,7 @@ var PDFViewerApplication = {
       viewer: viewer,
       renderingQueue: pdfRenderingQueue,
       linkService: pdfLinkService,
-      downloadManager: new DownloadManager()
+      downloadManager: downloadManager
     });
     pdfRenderingQueue.setViewer(this.pdfViewer);
     pdfLinkService.setViewer(this.pdfViewer);
@@ -214,8 +233,8 @@ var PDFViewerApplication = {
     }.bind(this);
     this.findController.onUpdateState = function (state, previous, matchCount) {
       if (this.supportsIntegratedFind) {
-        FirefoxCom.request('updateFindControlState',
-                           {result: state, findPrevious: previous});
+        this.externalServices.updateFindControlState(
+          {result: state, findPrevious: previous});
       } else {
         this.findBar.updateUIState(state, previous, matchCount);
       }
@@ -270,7 +289,7 @@ var PDFViewerApplication = {
 
     this.pdfAttachmentViewer = new PDFAttachmentViewer({
       container: appConfig.sidebar.attachmentsView,
-      downloadManager: new DownloadManager(),
+      downloadManager: downloadManager
     });
 
     // FIXME better PDFSidebar constructor parameters
@@ -411,30 +430,15 @@ var PDFViewerApplication = {
   },
 
   get supportsIntegratedFind() {
-    var support = false;
-//#if (FIREFOX || MOZCENTRAL)
-//  support = FirefoxCom.requestSync('supportsIntegratedFind');
-//#endif
-
-    return pdfjsLib.shadow(this, 'supportsIntegratedFind', support);
+    return this.externalServices.supportsIntegratedFind;
   },
 
   get supportsDocumentFonts() {
-    var support = true;
-//#if (FIREFOX || MOZCENTRAL)
-//  support = FirefoxCom.requestSync('supportsDocumentFonts');
-//#endif
-
-    return pdfjsLib.shadow(this, 'supportsDocumentFonts', support);
+    return this.externalServices.supportsDocumentFonts;
   },
 
   get supportsDocumentColors() {
-    var support = true;
-//#if (FIREFOX || MOZCENTRAL)
-//  support = FirefoxCom.requestSync('supportsDocumentColors');
-//#endif
-
-    return pdfjsLib.shadow(this, 'supportsDocumentColors', support);
+    return this.externalServices.supportsDocumentColors;
   },
 
   get loadingBar() {
@@ -444,84 +448,30 @@ var PDFViewerApplication = {
   },
 
   get supportedMouseWheelZoomModifierKeys() {
-    var support = {
-      ctrlKey: true,
-      metaKey: true,
-    };
-//#if (FIREFOX || MOZCENTRAL)
-//  support = FirefoxCom.requestSync('supportedMouseWheelZoomModifierKeys');
-//#endif
-
-    return pdfjsLib.shadow(this, 'supportedMouseWheelZoomModifierKeys',
-                           support);
+    return this.externalServices.supportedMouseWheelZoomModifierKeys;
   },
 
 //#if (FIREFOX || MOZCENTRAL)
   initPassiveLoading: function pdfViewInitPassiveLoading() {
-    function FirefoxComDataRangeTransport(length, initialData) {
-      pdfjsLib.PDFDataRangeTransport.call(this, length, initialData);
-    }
-    FirefoxComDataRangeTransport.prototype =
-      Object.create(pdfjsLib.PDFDataRangeTransport.prototype);
-    FirefoxComDataRangeTransport.prototype.requestDataRange =
-        function FirefoxComDataRangeTransport_requestDataRange(begin, end) {
-      FirefoxCom.request('requestDataRange', { begin: begin, end: end });
-    };
-    FirefoxComDataRangeTransport.prototype.abort =
-        function FirefoxComDataRangeTransport_abort() {
-      // Sync call to ensure abort is really started.
-      FirefoxCom.requestSync('abortLoading', null);
-    };
+    this.externalServices.initPassiveLoading({
+      onOpenWithTransport: function (url, length, transport) {
+        PDFViewerApplication.open(url, {range: transport});
 
-    var pdfDataRangeTransport;
-
-    window.addEventListener('message', function windowMessage(e) {
-      if (e.source !== null) {
-        // The message MUST originate from Chrome code.
-        console.warn('Rejected untrusted message from ' + e.origin);
-        return;
-      }
-      var args = e.data;
-
-      if (typeof args !== 'object' || !('pdfjsLoadAction' in args)) {
-        return;
-      }
-      switch (args.pdfjsLoadAction) {
-        case 'supportsRangedLoading':
-          pdfDataRangeTransport =
-            new FirefoxComDataRangeTransport(args.length, args.data);
-
-          PDFViewerApplication.open(args.pdfUrl,
-                                    {range: pdfDataRangeTransport});
-
-          if (args.length) {
-            PDFViewerApplication.pdfDocumentProperties
-                                .setFileSize(args.length);
-          }
-          break;
-        case 'range':
-          pdfDataRangeTransport.onDataRange(args.begin, args.chunk);
-          break;
-        case 'rangeProgress':
-          pdfDataRangeTransport.onDataProgress(args.loaded);
-          break;
-        case 'progressiveRead':
-          pdfDataRangeTransport.onDataProgressiveRead(args.chunk);
-          break;
-        case 'progress':
-          PDFViewerApplication.progress(args.loaded / args.total);
-          break;
-        case 'complete':
-          if (!args.data) {
-            PDFViewerApplication.error(mozL10n.get('loading_error', null,
-              'An error occurred while loading the PDF.'), e);
-            break;
-          }
-          PDFViewerApplication.open(args.data);
-          break;
+        if (length) {
+          PDFViewerApplication.pdfDocumentProperties.setFileSize(length);
+        }
+      },
+      onOpenWithData: function (data) {
+        PDFViewerApplication.open(data);
+      },
+      onError: function (e) {
+        PDFViewerApplication.error(mozL10n.get('loading_error', null,
+          'An error occurred while loading the PDF.'), e);
+      },
+      onProgress: function (loaded, total) {
+        PDFViewerApplication.progress(loaded / total);
       }
     });
-    FirefoxCom.requestSync('initPassiveLoading', null);
   },
 //#endif
 
@@ -701,7 +651,7 @@ var PDFViewerApplication = {
 
     var url = this.url.split('#')[0];
     var filename = getPDFFileNameFromURL(url);
-    var downloadManager = new DownloadManager();
+    var downloadManager = this.downloadManager;
     downloadManager.onerror = function (err) {
       // This error won't really be helpful because it's likely the
       // fallback won't work either (or is already open).
@@ -741,7 +691,7 @@ var PDFViewerApplication = {
     }
     this.fellback = true;
     var url = this.url.split('#')[0];
-    FirefoxCom.request('fallback', { featureId: featureId, url: url },
+    this.externalServices.fallback({ featureId: featureId, url: url },
       function response(download) {
         if (!download) {
           return;
@@ -1069,12 +1019,12 @@ var PDFViewerApplication = {
       }
       var formType = !info.IsAcroFormPresent ? null : info.IsXFAPresent ?
                      'xfa' : 'acroform';
-      FirefoxCom.request('reportTelemetry', JSON.stringify({
+      self.externalServices.reportTelemetry({
         type: 'documentInfo',
         version: versionId,
         generator: generatorId,
         formType: formType
-      }));
+      });
 //#endif
     });
   },
@@ -1197,9 +1147,9 @@ var PDFViewerApplication = {
     }
 //#endif
 //#if (FIREFOX || MOZCENTRAL)
-    FirefoxCom.request('reportTelemetry', JSON.stringify({
+    this.externalServices.reportTelemetry({
       type: 'print'
-    }));
+    });
 //#endif
   },
 
@@ -1567,15 +1517,15 @@ document.addEventListener('pagerendered', function (e) {
   }
 //#endif
 //#if (FIREFOX || MOZCENTRAL)
-  FirefoxCom.request('reportTelemetry', JSON.stringify({
+  PDFViewerApplication.externalServices.reportTelemetry({
     type: 'pageInfo'
-  }));
+  });
   // It is a good time to report stream and font types.
   PDFViewerApplication.pdfDocument.getStats().then(function (stats) {
-    FirefoxCom.request('reportTelemetry', JSON.stringify({
+    PDFViewerApplication.externalServices.reportTelemetry({
       type: 'documentStats',
       stats: stats
-    }));
+    });
   });
 //#endif
 }, true);

--- a/web/app.js
+++ b/web/app.js
@@ -451,7 +451,7 @@ var PDFViewerApplication = {
     return this.externalServices.supportedMouseWheelZoomModifierKeys;
   },
 
-//#if (FIREFOX || MOZCENTRAL)
+//#if (FIREFOX || MOZCENTRAL || CHROME)
   initPassiveLoading: function pdfViewInitPassiveLoading() {
     this.externalServices.initPassiveLoading({
       onOpenWithTransport: function (url, length, transport) {
@@ -463,6 +463,16 @@ var PDFViewerApplication = {
       },
       onOpenWithData: function (data) {
         PDFViewerApplication.open(data);
+      },
+      onOpenWithURL: function (url, length, originalURL) {
+        var file = url, args = null;
+        if (length !== undefined) {
+          args = {length: length};
+        }
+        if (originalURL !== undefined) {
+          file = {file: url, originalURL: originalURL};
+        }
+        PDFViewerApplication.open(file, args);
       },
       onError: function (e) {
         PDFViewerApplication.error(mozL10n.get('loading_error', null,
@@ -1445,7 +1455,7 @@ function webViewerInitialized() {
   appConfig.toolbar.download.addEventListener('click',
     SecondaryToolbar.downloadClick.bind(SecondaryToolbar));
 
-//#if (FIREFOX || MOZCENTRAL)
+//#if (FIREFOX || MOZCENTRAL || CHROME)
 //PDFViewerApplication.setTitleUsingUrl(file);
 //PDFViewerApplication.initPassiveLoading();
 //return;
@@ -1475,11 +1485,6 @@ function webViewerInitialized() {
   if (file) {
     PDFViewerApplication.open(file);
   }
-//#endif
-//#if CHROME
-//if (file) {
-//  ChromeCom.openPDFFile(file);
-//}
 //#endif
 }
 
@@ -2141,6 +2146,7 @@ window.addEventListener('afterprint', function afterPrint(evt) {
 })();
 
 exports.PDFViewerApplication = PDFViewerApplication;
+exports.DefaultExernalServices = DefaultExernalServices;
 
 // TODO remove circular reference of pdfjs-web/secondary_toolbar on app.
 secondaryToolbarLib._setApp(exports);

--- a/web/app.js
+++ b/web/app.js
@@ -28,8 +28,7 @@
       'pdfjs-web/pdf_rendering_queue', 'pdfjs-web/pdf_link_service',
       'pdfjs-web/pdf_outline_viewer', 'pdfjs-web/overlay_manager',
       'pdfjs-web/pdf_attachment_viewer', 'pdfjs-web/pdf_find_controller',
-      'pdfjs-web/pdf_find_bar', 'pdfjs-web/mozPrintCallback_polyfill',
-      'pdfjs-web/pdfjs'],
+      'pdfjs-web/pdf_find_bar', 'pdfjs-web/pdfjs'],
       factory);
   } else if (typeof exports !== 'undefined') {
     factory(exports, require('./ui_utils.js'), require('./download_manager.js'),
@@ -42,7 +41,7 @@
       require('./pdf_link_service.js'), require('./pdf_outline_viewer.js'),
       require('./overlay_manager.js'), require('./pdf_attachment_viewer.js'),
       require('./pdf_find_controller.js'), require('./pdf_find_bar.js'),
-      require('./mozPrintCallback_polyfill.js'), require('./pdfjs.js'));
+      require('./pdfjs.js'));
   } else {
     factory((root.pdfjsWebApp = {}), root.pdfjsWebUIUtils,
       root.pdfjsWebDownloadManager, root.pdfjsWebPDFHistory,
@@ -54,8 +53,7 @@
       root.pdfjsWebPDFRenderingQueue, root.pdfjsWebPDFLinkService,
       root.pdfjsWebPDFOutlineViewer, root.pdfjsWebOverlayManager,
       root.pdfjsWebPDFAttachmentViewer, root.pdfjsWebPDFFindController,
-      root.pdfjsWebPDFFindBar, root.pdfjsWebMozPrintCallbackPolyfill,
-      root.pdfjsWebPDFJS);
+      root.pdfjsWebPDFFindBar, root.pdfjsWebPDFJS);
   }
 }(this, function (exports, uiUtilsLib, downloadManagerLib, pdfHistoryLib,
                   preferencesLib, pdfSidebarLib, viewHistoryLib,
@@ -64,7 +62,7 @@
                   pdfViewerLib, pdfRenderingQueueLib, pdfLinkServiceLib,
                   pdfOutlineViewerLib, overlayManagerLib,
                   pdfAttachmentViewerLib, pdfFindControllerLib, pdfFindBarLib,
-                  mozPrintCallbackPolyfillLib, pdfjsLib) {
+                  pdfjsLib) {
 
 var UNKNOWN_SCALE = uiUtilsLib.UNKNOWN_SCALE;
 var DEFAULT_SCALE_VALUE = uiUtilsLib.DEFAULT_SCALE_VALUE;

--- a/web/app.js
+++ b/web/app.js
@@ -204,17 +204,30 @@ var PDFViewerApplication = {
     pdfLinkService.setHistory(this.pdfHistory);
 
     this.findController = new PDFFindController({
-      pdfViewer: this.pdfViewer,
-      integratedFind: this.supportsIntegratedFind
+      pdfViewer: this.pdfViewer
     });
+    this.findController.onUpdateResultsCount = function (matchCount) {
+      if (this.supportsIntegratedFind) {
+        return;
+      }
+      this.findBar.updateResultsCount(matchCount);
+    }.bind(this);
+    this.findController.onUpdateState = function (state, previous, matchCount) {
+      if (this.supportsIntegratedFind) {
+        FirefoxCom.request('updateFindControlState',
+                           {result: state, findPrevious: previous});
+      } else {
+        this.findBar.updateUIState(state, previous, matchCount);
+      }
+    }.bind(this);
+    this.findController.listenWindowEvents();
+
     this.pdfViewer.setFindController(this.findController);
 
     // FIXME better PDFFindBar constructor parameters
     var findBarConfig = Object.create(appConfig.findBar);
     findBarConfig.findController = this.findController;
     this.findBar = new PDFFindBar(findBarConfig);
-
-    this.findController.setFindBar(this.findBar);
 
     this.overlayManager = OverlayManager;
 

--- a/web/pdf_viewer.component.js
+++ b/web/pdf_viewer.component.js
@@ -50,6 +50,8 @@
   PDFJS.DefaultAnnotationLayerFactory =
     pdfViewerLibs.pdfjsWebAnnotationLayerBuilder.DefaultAnnotationLayerFactory;
   PDFJS.PDFHistory = pdfViewerLibs.pdfjsWebPDFHistory.PDFHistory;
+  PDFJS.PDFFindController =
+    pdfViewerLibs.pdfjsWebPDFFindController.PDFFindController;
 
   PDFJS.DownloadManager = pdfViewerLibs.pdfjsWebDownloadManager.DownloadManager;
   PDFJS.ProgressBar = pdfViewerLibs.pdfjsWebUIUtils.ProgressBar;

--- a/web/preferences.js
+++ b/web/preferences.js
@@ -161,49 +161,6 @@ var Preferences = {
   }
 };
 
-//#if CHROME
-//Preferences._writeToStorage = function (prefObj) {
-//  return new Promise(function (resolve) {
-//    if (prefObj == DEFAULT_PREFERENCES) {
-//      var keysToRemove = Object.keys(DEFAULT_PREFERENCES);
-//      // If the storage is reset, remove the keys so that the values from
-//      // managed storage are applied again.
-//      chrome.storage.local.remove(keysToRemove, function() {
-//        resolve();
-//      });
-//    } else {
-//      chrome.storage.local.set(prefObj, function() {
-//        resolve();
-//      });
-//    }
-//  });
-//};
-//
-//Preferences._readFromStorage = function (prefObj) {
-//  return new Promise(function (resolve) {
-//    if (chrome.storage.managed) {
-//      // Get preferences as set by the system administrator.
-//      // See extensions/chromium/preferences_schema.json for more information.
-//      // These preferences can be overridden by the user.
-//      chrome.storage.managed.get(DEFAULT_PREFERENCES, getPreferences);
-//    } else {
-//      // Managed storage not supported, e.g. in old Chromium versions.
-//      getPreferences(DEFAULT_PREFERENCES);
-//    }
-//
-//    function getPreferences(defaultPrefs) {
-//      if (chrome.runtime.lastError) {
-//        // Managed storage not supported, e.g. in Opera.
-//        defaultPrefs = DEFAULT_PREFERENCES;
-//      }
-//      chrome.storage.local.get(defaultPrefs, function(readPrefs) {
-//        resolve(readPrefs);
-//      });
-//    }
-//  });
-//};
-//#endif
-
 //#if !(FIREFOX || MOZCENTRAL || CHROME)
 Preferences._writeToStorage = function (prefObj) {
   return new Promise(function (resolve) {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -166,7 +166,7 @@ function webViewerLoad() {
   var config = getViewerConfiguration();
 //#if !PRODUCTION
   require.config({paths: {'pdfjs': '../src', 'pdfjs-web': '.'}});
-  require(['pdfjs-web/app'], function (web) {
+  require(['pdfjs-web/app', 'mozPrintCallback_polyfill.js'], function (web) {
     window.PDFViewerApplication = web.PDFViewerApplication;
     web.PDFViewerApplication.run(config);
   });


### PR DESCRIPTION
... such as FirefoxCom and ChromeCom. It mostly moves external services code into appropriate files. The preprocessor directives will be easier to remove (see #7192). 

PDFFindController does not depend on PDFFindBar or FirefoxCom (not tested, but looks like it can be used by third party apps).

@Rob--W, can you review Chromium part?
