### PR TITLE
Expose a few non-classes on `PDFViewerApplication`

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -192,6 +192,7 @@ var PDFViewerApplication = {
     pdfRenderingQueue.setThumbnailViewer(this.pdfThumbnailViewer);
 
     Preferences.initialize();
+    this.preferences = Preferences;
 
     this.pdfHistory = new PDFHistory({
       linkService: pdfLinkService
@@ -220,10 +221,13 @@ var PDFViewerApplication = {
 
     this.findController.setFindBar(this.findBar);
 
+    this.overlayManager = OverlayManager;
+
     HandTool.initialize({
       container: container,
       toggleHandTool: document.getElementById('toggleHandTool')
     });
+    this.handTool = HandTool;
 
     this.pdfDocumentProperties = new PDFDocumentProperties({
       overlayName: 'documentPropertiesOverlay',
@@ -259,6 +263,7 @@ var PDFViewerApplication = {
       pageRotateCcw: document.getElementById('pageRotateCcw'),
       documentPropertiesButton: document.getElementById('documentProperties')
     });
+    this.secondaryToolbar = SecondaryToolbar;
 
     if (this.supportsFullscreen) {
       var toolbar = SecondaryToolbar;
@@ -286,6 +291,7 @@ var PDFViewerApplication = {
       passwordSubmit: document.getElementById('passwordSubmit'),
       passwordCancel: document.getElementById('passwordCancel')
     });
+    this.passwordPrompt = PasswordPrompt;
 
     this.pdfOutlineViewer = new PDFOutlineViewer({
       container: document.getElementById('outlineView'),


### PR DESCRIPTION
With the recent PR #7172, which made the viewer modular, there's now a couple of modules that are no longer easily accessible (e.g. through the console).
This can make testing/debugging more difficult, and means that e.g. https://github.com/mozilla/pdf.js/wiki/Debugging-PDF.js#enabling no longer works in the generic viewer.

For now, as a simple solution, this patch just exposes those non-classes on `PDFViewerApplication` to ensure that they are available, and to avoid polluting the `window` scope.
