### PR TITLE
[api-minor] Add support for `LinkAnnotation`s with relative URLs (bug 766086)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -41,7 +41,6 @@ var isBool = sharedUtil.isBool;
 var isString = sharedUtil.isString;
 var isArray = sharedUtil.isArray;
 var isInt = sharedUtil.isInt;
-var isValidUrl = sharedUtil.isValidUrl;
 var stringToBytes = sharedUtil.stringToBytes;
 var stringToPDFString = sharedUtil.stringToPDFString;
 var stringToUTF8String = sharedUtil.stringToUTF8String;
@@ -767,7 +766,7 @@ var LinkAnnotation = (function LinkAnnotationClosure() {
     }
 
     if (url) {
-      if (isValidUrl(url, /* allowRelative = */ false)) {
+      if (isString(url)) {
         data.url = tryConvertUrlEncoding(url);
       }
     }

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -47,7 +47,6 @@ var shadow = sharedUtil.shadow;
 var stringToPDFString = sharedUtil.stringToPDFString;
 var stringToUTF8String = sharedUtil.stringToUTF8String;
 var warn = sharedUtil.warn;
-var isValidUrl = sharedUtil.isValidUrl;
 var Util = sharedUtil.Util;
 var Ref = corePrimitives.Ref;
 var RefSet = corePrimitives.RefSet;
@@ -159,7 +158,7 @@ var Catalog = (function CatalogClosure() {
             dest = destEntry;
           } else {
             var uriEntry = actionDict.get('URI');
-            if (isString(uriEntry) && isValidUrl(uriEntry, false)) {
+            if (isString(uriEntry)) {
               url = uriEntry;
             }
           }

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -30,6 +30,7 @@
 var AnnotationBorderStyleType = sharedUtil.AnnotationBorderStyleType;
 var AnnotationType = sharedUtil.AnnotationType;
 var Util = sharedUtil.Util;
+var getAbsoluteUrl = displayDOMUtils.getAbsoluteUrl;
 var addLinkAttributes = displayDOMUtils.addLinkAttributes;
 var LinkTarget = displayDOMUtils.LinkTarget;
 var getFilenameFromUrl = displayDOMUtils.getFilenameFromUrl;
@@ -279,12 +280,15 @@ var LinkAnnotationElement = (function LinkAnnotationElementClosure() {
       this.container.className = 'linkAnnotation';
 
       var link = document.createElement('a');
+      var absoluteUrl = getAbsoluteUrl(this.data.url,
+        this.linkService.relativeLinkAnnotBaseUrl);
+
       addLinkAttributes(link, {
-        url: this.data.url,
+        url: absoluteUrl,
         target: (this.data.newWindow ? LinkTarget.BLANK : undefined),
       });
 
-      if (!this.data.url) {
+      if (!absoluteUrl) {
         if (this.data.action) {
           this._bindNamedAction(link, this.data.action);
         } else {

--- a/src/main_loader.js
+++ b/src/main_loader.js
@@ -55,12 +55,13 @@
   exports.UnexpectedResponseException = sharedUtil.UnexpectedResponseException;
   exports.OPS = sharedUtil.OPS;
   exports.UNSUPPORTED_FEATURES = sharedUtil.UNSUPPORTED_FEATURES;
-  exports.isValidUrl = sharedUtil.isValidUrl;
+  exports.isValidUrl = displayDOMUtils.isValidUrl;
   exports.createObjectURL = sharedUtil.createObjectURL;
   exports.removeNullCharacters = sharedUtil.removeNullCharacters;
   exports.shadow = sharedUtil.shadow;
   exports.createBlob = sharedUtil.createBlob;
   exports.getFilenameFromUrl = displayDOMUtils.getFilenameFromUrl;
+  exports.getAbsoluteUrl = displayDOMUtils.getAbsoluteUrl;
   exports.addLinkAttributes = displayDOMUtils.addLinkAttributes;
 
 }));

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -63,13 +63,14 @@
     pdfjsLibs.pdfjsSharedUtil.UnexpectedResponseException;
   exports.OPS = pdfjsLibs.pdfjsSharedUtil.OPS;
   exports.UNSUPPORTED_FEATURES = pdfjsLibs.pdfjsSharedUtil.UNSUPPORTED_FEATURES;
-  exports.isValidUrl = pdfjsLibs.pdfjsSharedUtil.isValidUrl;
+  exports.isValidUrl = pdfjsLibs.pdfjsDisplayDOMUtils.isValidUrl;
   exports.createObjectURL = pdfjsLibs.pdfjsSharedUtil.createObjectURL;
   exports.removeNullCharacters = pdfjsLibs.pdfjsSharedUtil.removeNullCharacters;
   exports.shadow = pdfjsLibs.pdfjsSharedUtil.shadow;
   exports.createBlob = pdfjsLibs.pdfjsSharedUtil.createBlob;
   exports.getFilenameFromUrl =
     pdfjsLibs.pdfjsDisplayDOMUtils.getFilenameFromUrl;
+  exports.getAbsoluteUrl = pdfjsLibs.pdfjsDisplayDOMUtils.getAbsoluteUrl;
   exports.addLinkAttributes = pdfjsLibs.pdfjsDisplayDOMUtils.addLinkAttributes;
 //#else
   exports.WorkerMessageHandler = pdfjsLibs.pdfjsCoreWorker.WorkerMessageHandler;

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -310,30 +310,6 @@ function isSameOrigin(baseUrl, otherUrl) {
   return base.origin === other.origin;
 }
 
-// Validates if URL is safe and allowed, e.g. to avoid XSS.
-function isValidUrl(url, allowRelative) {
-  if (!url || typeof url !== 'string') {
-    return false;
-  }
-  // RFC 3986 (http://tools.ietf.org/html/rfc3986#section-3.1)
-  // scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
-  var protocol = /^[a-z][a-z0-9+\-.]*(?=:)/i.exec(url);
-  if (!protocol) {
-    return allowRelative;
-  }
-  protocol = protocol[0].toLowerCase();
-  switch (protocol) {
-    case 'http':
-    case 'https':
-    case 'ftp':
-    case 'mailto':
-    case 'tel':
-      return true;
-    default:
-      return false;
-  }
-}
-
 function shadow(obj, prop, value) {
   Object.defineProperty(obj, prop, { value: value,
                                      enumerable: true,
@@ -2346,7 +2322,6 @@ exports.isInt = isInt;
 exports.isNum = isNum;
 exports.isString = isString;
 exports.isSameOrigin = isSameOrigin;
-exports.isValidUrl = isValidUrl;
 exports.isLittleEndian = isLittleEndian;
 exports.isEvalSupported = isEvalSupported;
 exports.loadJpegStream = loadJpegStream;

--- a/test/unit/annotation_layer_spec.js
+++ b/test/unit/annotation_layer_spec.js
@@ -270,6 +270,7 @@ describe('Annotation layer', function() {
       actionDict.set('S', Name.get('GoToR'));
       actionDict.set('F', '../../0021/002156/215675E.pdf');
       actionDict.set('D', '15');
+      actionDict.set('NewWindow', true);
 
       var annotationDict = new Dict();
       annotationDict.set('Type', Name.get('Annot'));
@@ -283,9 +284,9 @@ describe('Annotation layer', function() {
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
-      expect(data.url).toBeUndefined();
+      expect(data.url).toEqual('../../0021/002156/215675E.pdf#15');
       expect(data.dest).toBeUndefined();
-      expect(data.newWindow).toBeFalsy();
+      expect(data.newWindow).toEqual(true);
     });
 
     it('should correctly parse a Named action', function() {

--- a/test/unit/dom_utils_spec.js
+++ b/test/unit/dom_utils_spec.js
@@ -1,9 +1,42 @@
 /* globals expect, it, describe, PDFJS, isExternalLinkTargetSet, LinkTarget,
-           getFilenameFromUrl, beforeAll, afterAll */
+           getAbsoluteUrl, getFilenameFromUrl, beforeAll, afterAll */
 
 'use strict';
 
 describe('dom_utils', function() {
+  describe('getAbsoluteUrl', function () {
+    it('should accept an absolute URL', function () {
+      var url = 'http://www.example.com';
+      var baseUrl = null;
+      expect(getAbsoluteUrl(url, baseUrl)).toEqual('http://www.example.com');
+    });
+
+    it('should reject a non-URL', function () {
+      var url = 'An arbitrary string.';
+      var baseUrl = null;
+      expect(getAbsoluteUrl(url, baseUrl)).toEqual(null);
+    });
+
+    it('should accept a relative URL, with a valid baseURL', function () {
+      var url = '../../file.pdf#hash';
+      var baseUrl = 'http://www.example.com/some/path/';
+      expect(getAbsoluteUrl(url, baseUrl)).
+        toEqual('http://www.example.com/file.pdf#hash');
+    });
+
+    it('should reject a relative URL, without a baseURL', function () {
+      var url = '../../file.pdf';
+      var baseUrl = null;
+      expect(getAbsoluteUrl(url, baseUrl)).toEqual(null);
+    });
+
+    it('should reject a relative URL, with an invalid baseURL', function () {
+      var url = '../../file.pdf';
+      var baseUrl = '/some/relative/path/';
+      expect(getAbsoluteUrl(url, baseUrl)).toEqual(null);
+    });
+  });
+
   describe('getFilenameFromUrl', function() {
     it('should get the filename from an absolute URL', function() {
       var url = 'http://server.org/filename.pdf';

--- a/web/app.js
+++ b/web/app.js
@@ -850,14 +850,18 @@ var PDFViewerApplication = {
 
 //#if GENERIC
     var baseDocumentUrl = null;
+    var relativeLinkAnnotBaseUrl = null;
 //#endif
 //#if (FIREFOX || MOZCENTRAL)
 //  var baseDocumentUrl = this.url.split('#')[0];
+//  var relativeLinkAnnotBaseUrl = baseDocumentUrl;
 //#endif
 //#if CHROME
 //  var baseDocumentUrl = location.href.split('#')[0];
+//  var relativeLinkAnnotBaseUrl = this.url.split('#')[0];
 //#endif
-    this.pdfLinkService.setDocument(pdfDocument, baseDocumentUrl);
+    this.pdfLinkService.setDocument(pdfDocument, baseDocumentUrl,
+                                    relativeLinkAnnotBaseUrl);
 
     var pdfViewer = this.pdfViewer;
     pdfViewer.currentScale = scale;

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -48,8 +48,9 @@ var PDFLinkService = (function () {
   function PDFLinkService(options) {
     options = options || {};
     this.eventBus = options.eventBus || domEvents.getGlobalEventBus();
-    this.baseUrl = null;
     this.pdfDocument = null;
+    this.baseUrl = null;
+    this.relativeLinkAnnotBaseUrl = null;
     this.pdfViewer = null;
     this.pdfHistory = null;
 
@@ -57,9 +58,11 @@ var PDFLinkService = (function () {
   }
 
   PDFLinkService.prototype = {
-    setDocument: function PDFLinkService_setDocument(pdfDocument, baseUrl) {
-      this.baseUrl = baseUrl;
+    setDocument: function PDFLinkService_setDocument(pdfDocument, baseUrl,
+                                                     relativeLinkAnnotBaseUrl) {
       this.pdfDocument = pdfDocument;
+      this.baseUrl = baseUrl;
+      this.relativeLinkAnnotBaseUrl = relativeLinkAnnotBaseUrl || null;
       this._pagesRefCache = Object.create(null);
     },
 

--- a/web/pdf_outline_viewer.js
+++ b/web/pdf_outline_viewer.js
@@ -81,11 +81,14 @@ var PDFOutlineViewer = (function PDFOutlineViewerClosure() {
      * @private
      */
     _bindLink: function PDFOutlineViewer_bindLink(element, item) {
-      if (item.url) {
-        pdfjsLib.addLinkAttributes(element, { url: item.url });
+      var linkService = this.linkService;
+      var absoluteUrl = pdfjsLib.getAbsoluteUrl(item.url,
+        linkService.relativeLinkAnnotBaseUrl);
+
+      if (absoluteUrl) {
+        pdfjsLib.addLinkAttributes(element, { url: absoluteUrl });
         return;
       }
-      var linkService = this.linkService;
       element.href = linkService.getDestinationHash(item.dest);
       element.onclick = function goToDestination(e) {
         linkService.navigateTo(item.dest);


### PR DESCRIPTION
This patch moves the validation of URLs, in `LinkAnnotation`, from the `core` to the `display` layer. This should also make the API more useful in custom implementations, since the API will now be able to return relative URLs.

Some PDF generators unfortunately create files with relative URLs, which thus prevents some inter-PDF links from working in PDF.js. To work-around that case, this patch tries to recover valid absolute URLs in those cases.
The reason that `PDFLinkService.baseUrl` wasn't re-used, is that this would only work in the Firefox addon/built-in version (and not in e.g. the Chrome addon, or custom implementations).

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=766086.

Also, since the `isValidUrl` utility function is now only used in the `display` layer, it was moved from `shared/util.js` to `display/dom_utils.js`.
