### PR TITLE
Moves bundle target/task to gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,11 +22,30 @@ var gulp = require('gulp');
 var gutil = require('gulp-util');
 var rimraf = require('rimraf');
 var stream = require('stream');
+var exec = require('child_process').exec;
+var streamqueue = require('streamqueue');
 
 var BUILD_DIR = 'build/';
 var L10N_DIR = 'l10n/';
 
-require('./make.js');
+var makeFile = require('./make.js');
+var stripCommentHeaders = makeFile.stripCommentHeaders;
+var builder = makeFile.builder;
+
+var CONFIG_FILE = 'pdfjs.config';
+var config = JSON.parse(fs.readFileSync(CONFIG_FILE).toString());
+
+var DEFINES = {
+  PRODUCTION: true,
+  // The main build targets:
+  GENERIC: false,
+  FIREFOX: false,
+  MOZCENTRAL: false,
+  CHROME: false,
+  MINIFIED: false,
+  SINGLE_FILE: false,
+  COMPONENTS: false
+};
 
 function createStringSource(filename, content) {
   var source = stream.Readable({ objectMode: true });
@@ -42,6 +61,193 @@ function createStringSource(filename, content) {
   return source;
 }
 
+function stripUMDHeaders(content) {
+  var reg = new RegExp(
+    'if \\(typeof define === \'function\' && define.amd\\) \\{[^}]*' +
+    '\\} else if \\(typeof exports !== \'undefined\'\\) \\{[^}]*' +
+    '\\} else ', 'g');
+  return content.replace(reg, '');
+}
+
+function bundle(filename, outfilename, pathPrefix, initFiles, amdName, defines,
+                isMainFile, versionInfo) {
+  // Reading UMD headers and building loading orders of modules. The
+  // readDependencies returns AMD module names: removing 'pdfjs' prefix and
+  // adding '.js' extensions to the name.
+  var umd = require('./external/umdutils/verifier.js');
+  initFiles = initFiles.map(function (p) { return pathPrefix + p; });
+  var files = umd.readDependencies(initFiles).loadOrder.map(function (name) {
+    return pathPrefix + name.replace(/^[\w\-]+\//, '') + '.js';
+  });
+
+  var crlfchecker = require('./external/crlfchecker/crlfchecker.js');
+  crlfchecker.checkIfCrlfIsPresent(files);
+
+  var bundleContent = files.map(function (file) {
+    var content = fs.readFileSync(file);
+
+    // Prepend a newline because stripCommentHeaders only strips comments that
+    // follow a line feed. The file where bundleContent is inserted already
+    // contains a license header, so the header of bundleContent can be removed.
+    content = stripCommentHeaders('\n' + content);
+
+    // Removes AMD and CommonJS branches from UMD headers.
+    content = stripUMDHeaders(content);
+
+    return content;
+  }).join('');
+
+  var jsName = amdName.replace(/[\-_\.\/]\w/g, function (all) {
+    return all[1].toUpperCase();
+  });
+
+  // Avoiding double processing of the bundle file.
+  var templateContent = fs.readFileSync(filename).toString();
+  var tmpFile = outfilename + '.tmp';
+  fs.writeFileSync(tmpFile, templateContent.replace(
+    /\/\/#expand\s+__BUNDLE__\s*\n/, function (all) { return bundleContent; }));
+  bundleContent = null;
+  templateContent = null;
+
+  // This just preprocesses the empty pdf.js file, we don't actually want to
+  // preprocess everything yet since other build targets use this file.
+  builder.preprocess(tmpFile, outfilename,
+    builder.merge(defines, {
+      BUNDLE_VERSION: versionInfo.version,
+      BUNDLE_BUILD: versionInfo.commit,
+      BUNDLE_AMD_NAME: amdName,
+      BUNDLE_JS_NAME: jsName,
+      MAIN_FILE: isMainFile
+    }));
+  fs.unlinkSync(tmpFile);
+}
+
+function createBundle(defines) {
+  defines = defines || DEFINES;
+
+  var versionJSON = JSON.parse(
+    fs.readFileSync(BUILD_DIR + 'version.json').toString());
+
+  console.log();
+  console.log('### Bundling files into pdf.js');
+
+  var mainFiles = [
+    'display/global.js'
+  ];
+
+  var workerFiles = [
+    'core/worker.js'
+  ];
+
+  var mainAMDName = 'pdfjs-dist/build/pdf';
+  var workerAMDName = 'pdfjs-dist/build/pdf.worker';
+  var mainOutputName = 'pdf.js';
+  var workerOutputName = 'pdf.worker.js';
+
+  // Extension does not need network.js file.
+  if (!defines.FIREFOX && !defines.MOZCENTRAL) {
+    workerFiles.push('core/network.js');
+  }
+
+  if (defines.SINGLE_FILE) {
+    // In singlefile mode, all of the src files will be bundled into
+    // the main pdf.js output.
+    mainFiles = mainFiles.concat(workerFiles);
+    workerFiles = null; // no need for worker file
+    mainAMDName = 'pdfjs-dist/build/pdf.combined';
+    workerAMDName = null;
+    mainOutputName = 'pdf.combined.js';
+    workerOutputName = null;
+  }
+
+  var state = 'mainfile';
+  var source = stream.Readable({ objectMode: true });
+  source._read = function () {
+    var tmpFile;
+    switch (state) {
+      case 'mainfile':
+        // 'buildnumber' shall create BUILD_DIR for us
+        tmpFile = BUILD_DIR + '~' + mainOutputName + '.tmp';
+        bundle('src/pdf.js', tmpFile, 'src/', mainFiles,  mainAMDName,
+          defines, true, versionJSON);
+        this.push(new gutil.File({
+          cwd: '',
+          base: '',
+          path: mainOutputName,
+          contents: fs.readFileSync(tmpFile)
+        }));
+        fs.unlinkSync(tmpFile);
+        state = workerFiles ? 'workerfile' : 'stop';
+        break;
+      case 'workerfile':
+        // 'buildnumber' shall create BUILD_DIR for us
+        tmpFile = BUILD_DIR + '~' + workerOutputName + '.tmp';
+        bundle('src/pdf.js', tmpFile, 'src/', workerFiles, workerAMDName,
+          defines, false, versionJSON);
+        this.push(new gutil.File({
+          cwd: '',
+          base: '',
+          path: workerOutputName,
+          contents: fs.readFileSync(tmpFile)
+        }));
+        fs.unlinkSync(tmpFile);
+        state = 'stop';
+        break;
+      case 'stop':
+        this.push(null);
+        break;
+    }
+  };
+  return source;
+}
+
+function createWebBundle(defines) {
+  var versionJSON = JSON.parse(
+    fs.readFileSync(BUILD_DIR + 'version.json').toString());
+
+  var template, files, outputName, amdName;
+  if (defines.COMPONENTS) {
+    amdName = 'pdfjs-dist/web/pdf_viewer';
+    template = 'web/pdf_viewer.component.js';
+    files = [
+      'pdf_viewer.js',
+      'pdf_history.js',
+      'pdf_find_controller.js',
+      'download_manager.js'
+    ];
+    outputName = 'pdf_viewer.js';
+  } else {
+    amdName = 'pdfjs-dist/web/viewer';
+    outputName = 'viewer.js';
+    template = 'web/viewer.js';
+    files = ['app.js'];
+    if (defines.FIREFOX || defines.MOZCENTRAL) {
+      files.push('firefoxcom.js');
+    } else if (defines.CHROME) {
+      files.push('chromecom.js', 'mozPrintCallback_polyfill.js');
+    } else if (defines.GENERIC) {
+      files.push('mozPrintCallback_polyfill.js');
+    }
+  }
+
+  var source = stream.Readable({ objectMode: true });
+  source._read = function () {
+    // 'buildnumber' shall create BUILD_DIR for us
+    var tmpFile = BUILD_DIR + '~' + outputName + '.tmp';
+    bundle(template, tmpFile, 'web/', files, amdName, defines, false,
+      versionJSON);
+    this.push(new gutil.File({
+      cwd: '',
+      base: '',
+      path: outputName,
+      contents: fs.readFileSync(tmpFile)
+    }));
+    fs.unlinkSync(tmpFile);
+    this.push(null);
+  };
+  return source;
+}
+
 gulp.task('default', function() {
   console.log('Available tasks:');
   var tasks = Object.keys(gulp.tasks);
@@ -49,6 +255,88 @@ gulp.task('default', function() {
   tasks.forEach(function (taskName) {
     console.log('  ' + taskName);
   });
+});
+
+gulp.task('buildnumber', function (done) {
+  console.log();
+  console.log('### Getting extension build number');
+
+  exec('git log --format=oneline ' + config.baseVersion + '..',
+      function (err, stdout, stderr) {
+    var buildNumber = 0;
+    if (!err) {
+      // Build number is the number of commits since base version
+      buildNumber = stdout ? stdout.match(/\n/g).length : 0;
+    }
+
+    console.log('Extension build number: ' + buildNumber);
+
+    var version = config.versionPrefix + buildNumber;
+
+    exec('git log --format="%h" -n 1', function (err, stdout, stderr) {
+      var buildCommit = '';
+      if (!err) {
+        buildCommit = stdout.replace('\n', '');
+      }
+
+      createStringSource('version.json', JSON.stringify({
+        version: version,
+        build: buildNumber,
+        commit: buildCommit
+      }, null, 2))
+        .pipe(gulp.dest(BUILD_DIR))
+        .on('end', done);
+    });
+  });
+});
+
+gulp.task('bundle-firefox', ['buildnumber'], function () {
+  var defines = builder.merge(DEFINES, {FIREFOX: true});
+  return streamqueue({ objectMode: true },
+    createBundle(defines), createWebBundle(defines))
+    .pipe(gulp.dest(BUILD_DIR));
+});
+
+gulp.task('bundle-mozcentral', ['buildnumber'], function () {
+  var defines = builder.merge(DEFINES, {MOZCENTRAL: true});
+  return streamqueue({ objectMode: true },
+    createBundle(defines), createWebBundle(defines))
+    .pipe(gulp.dest(BUILD_DIR));
+});
+
+gulp.task('bundle-chromium', ['buildnumber'], function () {
+  var defines = builder.merge(DEFINES, {CHROME: true});
+  return streamqueue({ objectMode: true },
+    createBundle(defines), createWebBundle(defines))
+    .pipe(gulp.dest(BUILD_DIR));
+});
+
+gulp.task('bundle-singlefile', ['buildnumber'], function () {
+  var defines = builder.merge(DEFINES, {SINGLE_FILE: true});
+  return createBundle(defines).pipe(gulp.dest(BUILD_DIR));
+});
+
+gulp.task('bundle-generic', ['buildnumber'], function () {
+  var defines = builder.merge(DEFINES, {GENERIC: true});
+  return streamqueue({ objectMode: true },
+    createBundle(), createWebBundle(defines))
+    .pipe(gulp.dest(BUILD_DIR));
+});
+
+gulp.task('bundle-minified', ['buildnumber'], function () {
+  var defines = builder.merge(DEFINES, {MINIFIED: true, GENERIC: true});
+  return streamqueue({ objectMode: true },
+    createBundle(), createWebBundle(defines))
+    .pipe(gulp.dest(BUILD_DIR));
+});
+
+gulp.task('bundle-components', ['buildnumber'], function () {
+  var defines = builder.merge(DEFINES, {COMPONENTS: true, GENERIC: true});
+  return createWebBundle(defines).pipe(gulp.dest(BUILD_DIR));
+});
+
+gulp.task('bundle', ['buildnumber'], function () {
+  return createBundle().pipe(gulp.dest(BUILD_DIR));
 });
 
 gulp.task('server', function (done) {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "requirejs": "^2.1.22",
     "rimraf": "^2.4.1",
     "shelljs": "~0.4.0",
+    "streamqueue": "^1.1.1",
     "typogr": "~0.6.5",
     "uglify-js": "^2.6.1",
     "wintersmith": "^2.0.0",

--- a/web/app.js
+++ b/web/app.js
@@ -2146,7 +2146,7 @@ window.addEventListener('afterprint', function afterPrint(evt) {
 exports.PDFViewerApplication = PDFViewerApplication;
 exports.DefaultExernalServices = DefaultExernalServices;
 
-// TODO remove circular reference of pdfjs-web/secondary_toolbar on app.
+//// TODO remove circular reference of pdfjs-web/secondary_toolbar on app.
 secondaryToolbarLib._setApp(exports);
 
 }));


### PR DESCRIPTION
Add fixes double processing of the bundled files -- the `//#expand __BUNDLE__` content was not processed first time.

Ref #7062 
