### PR TITLE
[Bug 1194700] Ensure that the `customScaleOption` is hidden in e10s

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -242,7 +242,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                       <option id="pageActualOption" title="" value="page-actual" data-l10n-id="page_scale_actual">Actual Size</option>
                       <option id="pageFitOption" title="" value="page-fit" data-l10n-id="page_scale_fit">Fit Page</option>
                       <option id="pageWidthOption" title="" value="page-width" data-l10n-id="page_scale_width">Full Width</option>
-                      <option id="customScaleOption" title="" value="custom"></option>
+                      <option id="customScaleOption" title="" value="custom" hidden="true"></option>
                       <option title="" value="0.5" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 50 }'>50%</option>
                       <option title="" value="0.75" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 75 }'>75%</option>
                       <option title="" value="1" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 100 }'>100%</option>


### PR DESCRIPTION
When Firefox is run in e10s mode, which will soon be the default, the PDF.js zoom dropdown menu doesn't look right. This is apparently because the `<select>` DOM element is rendered in the parent, and that all the necessary style information isn't sent up from the child. See the discussion in https://bugzilla.mozilla.org/show_bug.cgi?id=910022.

Besides this causing the PDF.js UI to _look_ worse in e10s, notably it also means that the `customScaleOption` isn't hidden like it ought to be.
To work-around that, this patch utilizes the `hidden` attribute, since https://bugzilla.mozilla.org/show_bug.cgi?id=1242450 at least made that work in e10s.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1194700.

---

![e10s-zoom](https://cloud.githubusercontent.com/assets/2692120/14761945/8ba88e38-096e-11e6-8b49-e6309b82a4ba.png)
