### PR TITLE
[Viewer] Removing the requestAnimationFrame polyfill for iOS

### DIFF
--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -542,12 +542,6 @@ if (typeof PDFJS === 'undefined') {
     window.setTimeout(callback, 20);
   }
 
-  var isIOS = /(iPad|iPhone|iPod)/g.test(navigator.userAgent);
-  if (isIOS) {
-    // requestAnimationFrame on iOS is broken, replacing with fake one.
-    window.requestAnimationFrame = fakeRequestAnimationFrame;
-    return;
-  }
   if ('requestAnimationFrame' in window) {
     return;
   }


### PR DESCRIPTION
window.requestAnimationFrame(...) seems to work fine now for iOS 9+, no need for the polyfill.
