### PR TITLE
Introducing EventBus for the viewer UI.

### DIFF
--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -1,4 +1,4 @@
-/* globals expect, it, describe, binarySearchFirstItem */
+/* globals expect, it, describe, binarySearchFirstItem, EventBus */
 
 'use strict';
 
@@ -28,6 +28,92 @@ describe('ui_utils', function() {
       expect(binarySearchFirstItem([0, 1, 2], isGreater3)).toEqual(3);
       expect(binarySearchFirstItem([2, 3, 4], isGreater3)).toEqual(2);
       expect(binarySearchFirstItem([4, 5, 6], isGreater3)).toEqual(0);
+    });
+  });
+
+  describe('EventBus', function () {
+    it('dispatch event', function () {
+      var eventBus = new EventBus();
+      var count = 0;
+      eventBus.on('test', function () {
+        count++;
+      });
+      eventBus.dispatch('test');
+      expect(count).toEqual(1);
+    });
+    it('dispatch different event', function () {
+      var eventBus = new EventBus();
+      var count = 0;
+      eventBus.on('test', function () {
+        count++;
+      });
+      eventBus.dispatch('nottest');
+      expect(count).toEqual(0);
+    });
+    it('dispatch event multiple times', function () {
+      var eventBus = new EventBus();
+      var count = 0;
+      eventBus.dispatch('test');
+      eventBus.on('test', function () {
+        count++;
+      });
+      eventBus.dispatch('test');
+      eventBus.dispatch('test');
+      expect(count).toEqual(2);
+    });
+    it('dispatch event to multiple handlers', function () {
+      var eventBus = new EventBus();
+      var count = 0;
+      eventBus.on('test', function () {
+        count++;
+      });
+      eventBus.on('test', function () {
+        count++;
+      });
+      eventBus.dispatch('test');
+      expect(count).toEqual(2);
+    });
+    it('dispatch to detached', function () {
+      var eventBus = new EventBus();
+      var count = 0;
+      var listener = function () {
+        count++;
+      };
+      eventBus.on('test', listener);
+      eventBus.dispatch('test');
+      eventBus.off('test', listener);
+      eventBus.dispatch('test');
+      expect(count).toEqual(1);
+    });
+    it('dispatch to wrong detached', function () {
+      var eventBus = new EventBus();
+      var count = 0;
+      eventBus.on('test', function () {
+        count++;
+      });
+      eventBus.dispatch('test');
+      eventBus.off('test', function () {
+        count++;
+      });
+      eventBus.dispatch('test');
+      expect(count).toEqual(2);
+    });
+    it('dispatch to detached during handling', function () {
+      var eventBus = new EventBus();
+      var count = 0;
+      var listener1 = function () {
+        eventBus.off('test', listener2);
+        count++;
+      };
+      var listener2 = function () {
+        eventBus.off('test', listener1);
+        count++;
+      };
+      eventBus.on('test', listener1);
+      eventBus.on('test', listener2);
+      eventBus.dispatch('test');
+      eventBus.dispatch('test');
+      expect(count).toEqual(2);
     });
   });
 });

--- a/web/app.js
+++ b/web/app.js
@@ -248,7 +248,6 @@ var PDFViewerApplication = {
         this.findBar.updateUIState(state, previous, matchCount);
       }
     }.bind(this);
-    this.findController.listenWindowEvents();
 
     this.pdfViewer.setFindController(this.findController);
 
@@ -1249,6 +1248,7 @@ var PDFViewerApplication = {
     eventBus.on('pagemode', webViewerPageMode);
     eventBus.on('namedaction', webViewerNamedAction);
     eventBus.on('presentationmodechanged', webViewerPresentationModeChanged);
+    eventBus.on('find', webViewerFind);
 //#if GENERIC
     eventBus.on('fileinputchange', webViewerFileInputChange);
 //#endif
@@ -1827,6 +1827,15 @@ function webViewerLocalized() {
   });
 }
 
+function webViewerFind(e) {
+  PDFViewerApplication.findController.executeCommand('find' + e.type, {
+    query: e.query,
+    caseSensitive: e.caseSensitive,
+    highlightAll: e.highlightAll,
+    findPrevious: e.findPrevious
+  });
+}
+
 function webViewerScaleChange(e) {
   var appConfig = PDFViewerApplication.appConfig;
   appConfig.toolbar.zoomOut.disabled = (e.scale === MIN_SCALE);
@@ -1961,8 +1970,15 @@ window.addEventListener('keydown', function keydown(evt) {
         break;
       case 71: // g
         if (!PDFViewerApplication.supportsIntegratedFind) {
-          PDFViewerApplication.eventBus.dispatch('findagain',
-                                                 cmd === 5 || cmd === 12);
+          var findState = PDFViewerApplication.findController.state;
+          if (findState) {
+            PDFViewerApplication.findController.executeCommand('findagain', {
+              query: findState.query,
+              caseSensitive: findState.caseSensitive,
+              highlightAll: findState.highlightAll,
+              findPrevious: cmd === 5 || cmd === 12
+            });
+          }
           handled = true;
         }
         break;

--- a/web/dom_events.js
+++ b/web/dom_events.js
@@ -1,0 +1,152 @@
+/* Copyright 2016 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-web/dom_events', ['exports', 'pdfjs-web/ui_utils'], factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports, require('./ui_utils.js'));
+  } else {
+    factory((root.pdfjsWebDOMEvents = {}), root.pdfjsWebUIUtils);
+  }
+}(this, function (exports, uiUtils) {
+  var EventBus = uiUtils.EventBus;
+
+  // Attaching to the application event bus to dispatch events to the DOM for
+  // backwards viewer API compatibility.
+  function attachDOMEventsToEventBus(eventBus) {
+    eventBus.on('documentload', function () {
+      var event = document.createEvent('CustomEvent');
+      event.initCustomEvent('documentload', true, true, {});
+      window.dispatchEvent(event);
+    });
+    eventBus.on('pagerendered', function (e) {
+      var event = document.createEvent('CustomEvent');
+      event.initCustomEvent('pagerendered', true, true, {
+        pageNumber: e.pageNumber,
+        cssTransform: e.cssTransform,
+      });
+      e.source.div.dispatchEvent(event);
+    });
+    eventBus.on('textlayerrendered', function (e) {
+      var event = document.createEvent('CustomEvent');
+      event.initCustomEvent('textlayerrendered', true, true, {
+        pageNumber: e.pageNumber
+      });
+      e.source.textLayerDiv.dispatchEvent(event);
+    });
+    eventBus.on('pagechange', function (e) {
+      var event = document.createEvent('UIEvents');
+      event.initUIEvent('pagechange', true, true, window, 0);
+      event.updateInProgress = e.updateInProgress;
+      event.pageNumber = e.pageNumber;
+      event.previousPageNumber = e.previousPageNumber;
+      e.source.container.dispatchEvent(event);
+    });
+    eventBus.on('pagesinit', function (e) {
+      var event = document.createEvent('CustomEvent');
+      event.initCustomEvent('pagesinit', true, true, null);
+      e.source.container.dispatchEvent(event);
+    });
+    eventBus.on('pagesloaded', function (e) {
+      var event = document.createEvent('CustomEvent');
+      event.initCustomEvent('pagesloaded', true, true, {
+        pagesCount: e.pagesCount
+      });
+      e.source.container.dispatchEvent(event);
+    });
+    eventBus.on('scalechange', function (e) {
+      var event = document.createEvent('UIEvents');
+      event.initUIEvent('scalechange', true, true, window, 0);
+      event.scale = e.scale;
+      event.presetValue = e.presetValue;
+      e.source.container.dispatchEvent(event);
+    });
+    eventBus.on('updateviewarea', function (e) {
+      var event = document.createEvent('UIEvents');
+      event.initUIEvent('updateviewarea', true, true, window, 0);
+      event.location = e.location;
+      e.source.container.dispatchEvent(event);
+    });
+    eventBus.on('find', function (e) {
+      var event = document.createEvent('CustomEvent');
+      event.initCustomEvent('find' + e.type, true, true, {
+        query: e.query,
+        caseSensitive: e.caseSensitive,
+        highlightAll: e.highlightAll,
+        findPrevious: e.findPrevious
+      });
+      window.dispatchEvent(event);
+    });
+    eventBus.on('attachmentsloaded', function (e) {
+      var event = document.createEvent('CustomEvent');
+      event.initCustomEvent('attachmentsloaded', true, true, {
+        attachmentsCount: e.attachmentsCount
+      });
+      e.source.container.dispatchEvent(event);
+    });
+    eventBus.on('sidebarviewchanged', function (e) {
+      var event = document.createEvent('CustomEvent');
+      event.initCustomEvent('sidebarviewchanged', true, true, {
+        view: e.view,
+      });
+      e.source.outerContainer.dispatchEvent(event);
+    });
+    eventBus.on('pagemode', function (e) {
+      var event = document.createEvent('CustomEvent');
+      event.initCustomEvent('pagemode', true, true, {
+        mode: e.mode,
+      });
+      e.source.pdfViewer.container.dispatchEvent(event);
+    });
+    eventBus.on('namedaction', function (e) {
+      var event = document.createEvent('CustomEvent');
+      event.initCustomEvent('namedaction', true, true, {
+        action: e.action
+      });
+      e.source.pdfViewer.container.dispatchEvent(event);
+    });
+    eventBus.on('presentationmodechanged', function (e) {
+      var event = document.createEvent('CustomEvent');
+      event.initCustomEvent('presentationmodechanged', true, true, {
+        active: e.active,
+        switchInProgress: e.switchInProgress
+      });
+      window.dispatchEvent(event);
+    });
+    eventBus.on('outlineloaded', function (e) {
+      var event = document.createEvent('CustomEvent');
+      event.initCustomEvent('outlineloaded', true, true, {
+        outlineCount: e.outlineCount
+      });
+      e.source.container.dispatchEvent(event);
+    });
+  }
+
+  var globalEventBus = null;
+  function getGlobalEventBus() {
+    if (globalEventBus) {
+      return globalEventBus;
+    }
+    globalEventBus = new EventBus();
+    attachDOMEventsToEventBus(globalEventBus);
+    return globalEventBus;
+  }
+
+  exports.attachDOMEventsToEventBus = attachDOMEventsToEventBus;
+  exports.getGlobalEventBus = getGlobalEventBus;
+}));

--- a/web/dom_events.js
+++ b/web/dom_events.js
@@ -83,6 +83,9 @@
       e.source.container.dispatchEvent(event);
     });
     eventBus.on('find', function (e) {
+      if (e.source === window) {
+        return; // event comes from FirefoxCom, no need to replicate
+      }
       var event = document.createEvent('CustomEvent');
       event.initCustomEvent('find' + e.type, true, true, {
         query: e.query,

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -148,6 +148,32 @@ Preferences._readFromStorage = function (prefObj) {
   });
 };
 
+(function listenFindEvents() {
+  var events = [
+    'find',
+    'findagain',
+    'findhighlightallchange',
+    'findcasesensitivitychange'
+  ];
+  var handleEvent = function (evt) {
+    if (!PDFViewerApplication.initialized) {
+      return;
+    }
+    PDFViewerApplication.eventBus.dispatch('find', {
+      source: window,
+      type: evt.type.substring('find'.length),
+      query: evt.detail.query,
+      caseSensitive: !!evt.detail.caseSensitive,
+      highlightAll: !!evt.detail.highlightAll,
+      findPrevious: !!evt.detail.findPrevious
+    });
+  }.bind(this);
+
+  for (var i = 0, len = events.length; i < len; i++) {
+    window.addEventListener(events[i], handleEvent);
+  }
+})();
+
 function FirefoxComDataRangeTransport(length, initialData) {
   pdfjsLib.PDFDataRangeTransport.call(this, length, initialData);
 }

--- a/web/hand_tool.js
+++ b/web/hand_tool.js
@@ -40,6 +40,7 @@ var SecondaryToolbar = secondaryToolbar.SecondaryToolbar;
  * @property {HTMLDivElement} container - The document container.
  * @property {HTMLButtonElement} toggleHandTool - The button element for
  *                                                toggling the hand tool.
+ * @property {EventBus} eventBus - The application event bus.
  */
 
 /**
@@ -52,6 +53,7 @@ var HandTool = (function HandToolClosure() {
    */
   function HandTool(options) {
     this.container = options.container;
+    this.eventBus = options.eventBus;
     this.toggleHandTool = options.toggleHandTool;
 
     this.wasActive = false;
@@ -79,7 +81,7 @@ var HandTool = (function HandToolClosure() {
     if (this.toggleHandTool) {
       this.toggleHandTool.addEventListener('click', this.toggle.bind(this));
 
-      window.addEventListener('localized', function (evt) {
+      this.eventBus.on('localized', function (e) {
         Preferences.get('enableHandToolOnLoad').then(function resolved(value) {
           if (value) {
             this.handTool.activate();
@@ -87,11 +89,11 @@ var HandTool = (function HandToolClosure() {
         }.bind(this), function rejected(reason) {});
       }.bind(this));
 
-      window.addEventListener('presentationmodechanged', function (evt) {
-        if (evt.detail.switchInProgress) {
+      this.eventBus.on('presentationmodechanged', function (e) {
+        if (e.switchInProgress) {
           return;
         }
-        if (evt.detail.active) {
+        if (e.active) {
           this.enterPresentationMode();
         } else {
           this.exitPresentationMode();

--- a/web/pdf_attachment_viewer.js
+++ b/web/pdf_attachment_viewer.js
@@ -29,6 +29,7 @@
 /**
  * @typedef {Object} PDFAttachmentViewerOptions
  * @property {HTMLDivElement} container - The viewer element.
+ * @property {EventBus} eventBus - The application event bus.
  * @property {DownloadManager} downloadManager - The download manager.
  */
 
@@ -48,6 +49,7 @@ var PDFAttachmentViewer = (function PDFAttachmentViewerClosure() {
   function PDFAttachmentViewer(options) {
     this.attachments = null;
     this.container = options.container;
+    this.eventBus = options.eventBus;
     this.downloadManager = options.downloadManager;
   }
 
@@ -66,11 +68,10 @@ var PDFAttachmentViewer = (function PDFAttachmentViewerClosure() {
      */
     _dispatchEvent:
         function PDFAttachmentViewer_dispatchEvent(attachmentsCount) {
-      var event = document.createEvent('CustomEvent');
-      event.initCustomEvent('attachmentsloaded', true, true, {
+      this.eventBus.dispatch('attachmentsloaded', {
+        source: this,
         attachmentsCount: attachmentsCount
       });
-      this.container.dispatchEvent(event);
     },
 
     /**

--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -51,6 +51,7 @@ var PDFFindBar = (function PDFFindBarClosure() {
     this.findPreviousButton = options.findPreviousButton || null;
     this.findNextButton = options.findNextButton || null;
     this.findController = options.findController || null;
+    this.eventBus = options.eventBus;
 
     if (this.findController === null) {
       throw new Error('PDFFindBar cannot be used without a ' +
@@ -103,14 +104,14 @@ var PDFFindBar = (function PDFFindBarClosure() {
     },
 
     dispatchEvent: function PDFFindBar_dispatchEvent(type, findPrev) {
-      var event = document.createEvent('CustomEvent');
-      event.initCustomEvent('find' + type, true, true, {
+      this.eventBus.dispatch('find', {
+        source: this,
+        type: type,
         query: this.findField.value,
         caseSensitive: this.caseSensitive.checked,
         highlightAll: this.highlightAll.checked,
         findPrevious: findPrev
       });
-      return window.dispatchEvent(event);
     },
 
     updateUIState:

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -71,22 +71,6 @@ var PDFFindController = (function PDFFindControllerClosure() {
   }
 
   PDFFindController.prototype = {
-    listenWindowEvents: function PDFFindController_listenWindowEvents() {
-      var events = [
-        'find',
-        'findagain',
-        'findhighlightallchange',
-        'findcasesensitivitychange'
-      ];
-      var handleEvent = function (e) {
-        this.executeCommand(e.type, e.detail);
-      }.bind(this);
-
-      for (var i = 0, len = events.length; i < len; i++) {
-        window.addEventListener(events[i], handleEvent);
-      }
-    },
-
     reset: function PDFFindController_reset() {
       this.startedTextExtraction = false;
       this.extractTextPromises = [];

--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -17,16 +17,18 @@
 
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define('pdfjs-web/pdf_history', ['exports'], factory);
+    define('pdfjs-web/pdf_history', ['exports', 'pdfjs-web/dom_events'],
+      factory);
   } else if (typeof exports !== 'undefined') {
-    factory(exports);
+    factory(exports, require('./dom_events.js'));
   } else {
-    factory((root.pdfjsWebPDFHistory = {}));
+    factory((root.pdfjsWebPDFHistory = {}), root.pdfjsWebDOMEvents);
   }
-}(this, function (exports) {
+}(this, function (exports, domEvents) {
 
   function PDFHistory(options) {
     this.linkService = options.linkService;
+    this.eventBus = options.eventBus || domEvents.getGlobalEventBus();
 
     this.initialized = false;
     this.initialDestination = null;
@@ -173,8 +175,8 @@
         window.addEventListener('beforeunload', pdfHistoryBeforeUnload, false);
       }, false);
 
-      window.addEventListener('presentationmodechanged', function(e) {
-        self.isViewerInPresentationMode = !!e.detail.active;
+      self.eventBus.on('presentationmodechanged', function(e) {
+        self.isViewerInPresentationMode = e.active;
       });
     },
 

--- a/web/pdf_outline_viewer.js
+++ b/web/pdf_outline_viewer.js
@@ -32,6 +32,7 @@ var DEFAULT_TITLE = '\u2013';
  * @typedef {Object} PDFOutlineViewerOptions
  * @property {HTMLDivElement} container - The viewer element.
  * @property {IPDFLinkService} linkService - The navigation/linking service.
+ * @property {EventBus} eventBus - The application event bus.
  */
 
 /**
@@ -52,6 +53,7 @@ var PDFOutlineViewer = (function PDFOutlineViewerClosure() {
     this.lastToggleIsShow = true;
     this.container = options.container;
     this.linkService = options.linkService;
+    this.eventBus = options.eventBus;
   }
 
   PDFOutlineViewer.prototype = {
@@ -69,11 +71,10 @@ var PDFOutlineViewer = (function PDFOutlineViewerClosure() {
      * @private
      */
     _dispatchEvent: function PDFOutlineViewer_dispatchEvent(outlineCount) {
-      var event = document.createEvent('CustomEvent');
-      event.initCustomEvent('outlineloaded', true, true, {
+      this.eventBus.dispatch('outlineloaded', {
+        source: this,
         outlineCount: outlineCount
       });
-      this.container.dispatchEvent(event);
     },
 
     /**

--- a/web/pdf_presentation_mode.js
+++ b/web/pdf_presentation_mode.js
@@ -35,6 +35,7 @@ var CONTROLS_SELECTOR = 'pdfPresentationModeControls';
  * @property {HTMLDivElement} container - The container for the viewer element.
  * @property {HTMLDivElement} viewer - (optional) The viewer element.
  * @property {PDFViewer} pdfViewer - The document viewer.
+ * @property {EventBus} eventBus - The application event bus.
  * @property {Array} contextMenuItems - (optional) The menuitems that are added
  *   to the context menu in Presentation Mode.
  */
@@ -51,6 +52,7 @@ var PDFPresentationMode = (function PDFPresentationModeClosure() {
     this.container = options.container;
     this.viewer = options.viewer || options.container.firstElementChild;
     this.pdfViewer = options.pdfViewer;
+    this.eventBus = options.eventBus;
     var contextMenuItems = options.contextMenuItems || null;
 
     this.active = false;
@@ -163,12 +165,11 @@ var PDFPresentationMode = (function PDFPresentationModeClosure() {
      * @private
      */
     _notifyStateChange: function PDFPresentationMode_notifyStateChange() {
-      var event = document.createEvent('CustomEvent');
-      event.initCustomEvent('presentationmodechanged', true, true, {
+      this.eventBus.dispatch('presentationmodechanged', {
+        source: this,
         active: this.active,
         switchInProgress: !!this.switchInProgress
       });
-      window.dispatchEvent(event);
     },
 
     /**

--- a/web/pdf_viewer.component.js
+++ b/web/pdf_viewer.component.js
@@ -52,6 +52,7 @@
   PDFJS.PDFHistory = pdfViewerLibs.pdfjsWebPDFHistory.PDFHistory;
   PDFJS.PDFFindController =
     pdfViewerLibs.pdfjsWebPDFFindController.PDFFindController;
+  PDFJS.EventBus = pdfViewerLibs.pdfjsWebUIUtils.EventBus;
 
   PDFJS.DownloadManager = pdfViewerLibs.pdfjsWebDownloadManager.DownloadManager;
   PDFJS.ProgressBar = pdfViewerLibs.pdfjsWebUIUtils.ProgressBar;

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -17,18 +17,21 @@
 
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define('pdfjs-web/text_layer_builder', ['exports', 'pdfjs-web/pdfjs'],
+    define('pdfjs-web/text_layer_builder', ['exports', 'pdfjs-web/dom_events',
+        'pdfjs-web/pdfjs'],
       factory);
   } else if (typeof exports !== 'undefined') {
-    factory(exports, require('./pdfjs.js'));
+    factory(exports, require('./dom_events.js'), require('./pdfjs.js'));
   } else {
-    factory((root.pdfjsWebTextLayerBuilder = {}), root.pdfjsWebPDFJS);
+    factory((root.pdfjsWebTextLayerBuilder = {}), root.pdfjsWebDOMEvents,
+      root.pdfjsWebPDFJS);
   }
-}(this, function (exports, pdfjsLib) {
+}(this, function (exports, domEvents, pdfjsLib) {
 
 /**
  * @typedef {Object} TextLayerBuilderOptions
  * @property {HTMLDivElement} textLayerDiv - The text layer container.
+ * @property {EventBus} eventBus - The application event bus.
  * @property {number} pageIndex - The page index.
  * @property {PageViewport} viewport - The viewport of the text layer.
  * @property {PDFFindController} findController
@@ -44,6 +47,7 @@
 var TextLayerBuilder = (function TextLayerBuilderClosure() {
   function TextLayerBuilder(options) {
     this.textLayerDiv = options.textLayerDiv;
+    this.eventBus = options.eventBus || domEvents.getGlobalEventBus();
     this.renderingDone = false;
     this.divContentDone = false;
     this.pageIdx = options.pageIndex;
@@ -64,11 +68,10 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
       endOfContent.className = 'endOfContent';
       this.textLayerDiv.appendChild(endOfContent);
 
-      var event = document.createEvent('CustomEvent');
-      event.initCustomEvent('textlayerrendered', true, true, {
+      this.eventBus.dispatch('textlayerrendered', {
+        source: this,
         pageNumber: this.pageNumber
       });
-      this.textLayerDiv.dispatchEvent(event);
     },
 
     /**

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -384,6 +384,49 @@ function getPDFFileNameFromURL(url) {
   return suggestedFilename || 'document.pdf';
 }
 
+/**
+ * Simple event bus for an application. Listeners are attached using the
+ * `on` and `off` methods. To raise an event, the `dispatch` method shall be
+ * used.
+ */
+var EventBus = (function EventBusClosure() {
+  function EventBus() {
+    this._listeners = Object.create(null);
+  }
+  EventBus.prototype = {
+    on: function EventBus_on(eventName, listener) {
+      var eventListeners = this._listeners[eventName];
+      if (!eventListeners) {
+        eventListeners = [];
+        this._listeners[eventName] = eventListeners;
+      }
+      eventListeners.push(listener);
+    },
+    off: function EventBus_on(eventName, listener) {
+      var eventListeners = this._listeners[eventName];
+      var i;
+      if (!eventListeners || ((i = eventListeners.indexOf(listener)) < 0)) {
+        return;
+      }
+      eventListeners.splice(i, 1);
+    },
+    dispatch: function EventBus_dispath(eventName) {
+      var eventListeners = this._listeners[eventName];
+      if (!eventListeners || eventListeners.length === 0) {
+        return;
+      }
+      // Passing all arguments after the eventName to the listeners.
+      var args = Array.prototype.slice.call(arguments, 1);
+      // Making copy of the listeners array in case if it will be modified
+      // during dispatch.
+      eventListeners.slice(0).forEach(function (listener) {
+        listener.apply(null, args);
+      });
+    }
+  };
+  return EventBus;
+})();
+
 var ProgressBar = (function ProgressBarClosure() {
 
   function clamp(v, min, max) {
@@ -474,6 +517,7 @@ exports.MAX_AUTO_SCALE = MAX_AUTO_SCALE;
 exports.SCROLLBAR_PADDING = SCROLLBAR_PADDING;
 exports.VERTICAL_PADDING = VERTICAL_PADDING;
 exports.mozL10n = mozL10n;
+exports.EventBus = EventBus;
 exports.ProgressBar = ProgressBar;
 exports.getPDFFileNameFromURL = getPDFFileNameFromURL;
 exports.noContextMenuHandler = noContextMenuHandler;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -55,6 +55,7 @@ function getViewerConfiguration() {
     appContainer: document.body,
     mainContainer: document.getElementById('viewerContainer'),
     viewerContainer:  document.getElementById('viewer'),
+    eventBus: null, // using global event bus with DOM events
     toolbar: {
       numPages: document.getElementById('numPages'),
       pageNumber: document.getElementById('pageNumber'),


### PR DESCRIPTION
Goal is to reduce amount of callback and dependencies in the application modules. Currently we use DOM events, but they are inconsistent. Replacing all of that with custom EventBus -- we will have one per application. If event bus is not provided, it will use (legacy) global one, which will relay events for the DOM.

Future work will include replacing direct binding between button events with sending DOM events to the event bus, then processing them from app, e.g. toolbar and secondary toolbar will send a presentation mode event, which will be relayed to the presentation mode module (notice that this event shall be handled sync too, which is the reason why we cannot choose async event bus).

Blocks #7204 and #7205
