### PR TITLE
Port the `publish` target to Gulp

### DIFF
--- a/make.js
+++ b/make.js
@@ -385,16 +385,7 @@ target.dist = function() {
 };
 
 target.publish = function() {
-  target.generic();
-  var VERSION = getCurrentVersion();
-  config.stableVersion = config.betaVersion;
-  config.betaVersion = VERSION;
-  fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
-  cd(GENERIC_DIR);
-  var distFilename = 'pdfjs-' + VERSION + '-dist.zip';
-  exec('zip -r ' + ROOT_DIR + BUILD_DIR + distFilename + ' *');
-  echo('Built distribution file: ' + distFilename);
-  cd(ROOT_DIR);
+  exec('gulp publish');
 };
 
 //

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "devDependencies": {
     "gulp": "^3.9.1",
     "gulp-util": "^3.0.7",
+    "gulp-zip": "^3.2.0",
     "jasmine-core": "^2.4.1",
     "jsdoc": "^3.3.0-alpha9",
     "jshint": "~2.8.0",


### PR DESCRIPTION
This patch is a part of #7062.

Gulp now handles creating the ZIP file so we do not have to rely on `zip` being available on the user's system anymore. The `gulp-zip` package uses the `yazl` package in the background to create ZIP files with pure JS.
