### PR TITLE
Better components examples.

### DIFF
--- a/examples/components/pageviewer.html
+++ b/examples/components/pageviewer.html
@@ -29,16 +29,17 @@ limitations under the License.
     }
   </style>
 
-  <link rel="stylesheet" href="../../build/components/pdf_viewer.css">
+  <link rel="stylesheet" href="../../build/dist/web/pdf_viewer.css">
 
   <!-- for legacy browsers -->
-  <script src="../../build/components/compatibility.js"></script>
-  <script src="../../build/pdf.js"></script>
-  <script src="../../build/components/pdf_viewer.js"></script>
+  <script src="../../build/dist/web/compatibility.js"></script>
+
+  <script src="../../build/dist/build/pdf.js"></script>
+  <script src="../../build/dist/web/pdf_viewer.js"></script>
 </head>
 
 <body tabindex="1">
-  <div id="pageContainer" class="pdfPage"></div>
+  <div id="pageContainer" class="pdfViewer singlePageView"></div>
 
   <script src="pageviewer.js"></script>
 </body>

--- a/examples/components/pageviewer.js
+++ b/examples/components/pageviewer.js
@@ -16,17 +16,17 @@
 'use strict';
 
 if (!PDFJS.PDFViewer || !PDFJS.getDocument) {
-  alert('Please build the library and components using\n' +
-        '  `gulp generic components`');
+  alert('Please build the pdfjs-dist library using\n' +
+        '  `gulp dist`');
 }
 
 // The workerSrc property shall be specified.
 //
-PDFJS.workerSrc = '../../build/pdf.worker.js';
+PDFJS.workerSrc = '../../build/dist/build/pdf.worker.js';
 
 // Some PDFs need external cmaps.
 //
-// PDFJS.cMapUrl = '../../external/bcmaps/';
+// PDFJS.cMapUrl = '../../build/dist/cmaps/';
 // PDFJS.cMapPacked = true;
 
 var DEFAULT_URL = '../../web/compressed.tracemonkey-pldi-09.pdf';

--- a/examples/components/simpleviewer.html
+++ b/examples/components/simpleviewer.html
@@ -35,12 +35,13 @@ limitations under the License.
     }
   </style>
 
-  <link rel="stylesheet" href="../../build/components/pdf_viewer.css">
+  <link rel="stylesheet" href="../../build/dist/web/pdf_viewer.css">
 
   <!-- for legacy browsers -->
-  <script src="../../build/components/compatibility.js"></script>
-  <script src="../../build/pdf.js"></script>
-  <script src="../../build/components/pdf_viewer.js"></script>
+  <script src="../../build/dist/web/compatibility.js"></script>
+
+  <script src="../../build/dist/build/pdf.js"></script>
+  <script src="../../build/dist/web/pdf_viewer.js"></script>
 </head>
 
 <body tabindex="1">

--- a/examples/components/simpleviewer.js
+++ b/examples/components/simpleviewer.js
@@ -16,17 +16,17 @@
 'use strict';
 
 if (!PDFJS.PDFViewer || !PDFJS.getDocument) {
-  alert('Please build the library and components using\n' +
-        '  `gulp generic components`');
+  alert('Please build the pdfjs-dist library using\n' +
+        '  `gulp dist`');
 }
 
 // The workerSrc property shall be specified.
 //
-PDFJS.workerSrc = '../../build/pdf.worker.js';
+PDFJS.workerSrc = '../../build/dist/build/pdf.worker.js';
 
 // Some PDFs need external cmaps.
 //
-// PDFJS.cMapUrl = '../../external/bcmaps/';
+// PDFJS.cMapUrl = '../../build/dist/cmaps/';
 // PDFJS.cMapPacked = true;
 
 var DEFAULT_URL = '../../web/compressed.tracemonkey-pldi-09.pdf';

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -37,6 +37,15 @@
   border: none;
 }
 
+.pdfViewer.singlePageView {
+  display: inline-block;
+}
+
+.pdfViewer.singlePageView .page {
+  margin: 0;
+  border: none;
+}
+
 .pdfViewer .page canvas {
   margin: 0;
   display: block;


### PR DESCRIPTION
It makes a little bit easier to use and customize the examples when used with pdfjs-dist.
