### PR TITLE
Adds post UI control change events.

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1231,8 +1231,8 @@ var PDFViewerApplication = {
     eventBus.on('pagerendered', webViewerPageRendered);
     eventBus.on('textlayerrendered', webViewerTextLayerRendered);
     eventBus.on('updateviewarea', webViewerUpdateViewarea);
-    eventBus.on('pagechange', webViewerPageChange);
-    eventBus.on('scalechange', webViewerScaleChange);
+    eventBus.on('pagechanging', webViewerPageChanging);
+    eventBus.on('scalechanging', webViewerScaleChanging);
     eventBus.on('sidebarviewchanged', webViewerSidebarViewChanged);
     eventBus.on('pagemode', webViewerPageMode);
     eventBus.on('namedaction', webViewerNamedAction);
@@ -1873,7 +1873,7 @@ function webViewerFind(e) {
   });
 }
 
-function webViewerScaleChange(e) {
+function webViewerScaleChanging(e) {
   var appConfig = PDFViewerApplication.appConfig;
   appConfig.toolbar.zoomOut.disabled = (e.scale === MIN_SCALE);
   appConfig.toolbar.zoomIn.disabled = (e.scale === MAX_SCALE);
@@ -1894,7 +1894,7 @@ function webViewerScaleChange(e) {
   PDFViewerApplication.pdfViewer.update();
 }
 
-function webViewerPageChange(e) {
+function webViewerPageChanging(e) {
   var page = e.pageNumber;
   if (e.previousPageNumber !== page) {
     PDFViewerApplication.appConfig.toolbar.pageNumber.value = page;

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -166,23 +166,28 @@ var PDFViewer = (function pdfViewer() {
         return;
       }
 
+      var arg;
       if (!(0 < val && val <= this.pagesCount)) {
-        this.eventBus.dispatch('pagechange', {
+        arg = {
           source: this,
           updateInProgress: this.updateInProgress,
           pageNumber: this._currentPageNumber,
           previousPageNumber: val
-        });
+        };
+        this.eventBus.dispatch('pagechanging', arg);
+        this.eventBus.dispatch('pagechange', arg);
         return;
       }
 
-      this.eventBus.dispatch('pagechange', {
+      arg = {
         source: this,
         updateInProgress: this.updateInProgress,
         pageNumber: val,
         previousPageNumber: this._currentPageNumber
-      });
+      };
+      this.eventBus.dispatch('pagechanging', arg);
       this._currentPageNumber = val;
+      this.eventBus.dispatch('pagechange', arg);
 
       // Check if the caller is `PDFViewer_update`, to avoid breaking scrolling.
       if (this.updateInProgress) {
@@ -403,11 +408,13 @@ var PDFViewer = (function pdfViewer() {
 
     _setScaleDispatchEvent: function pdfViewer_setScaleDispatchEvent(
         newScale, newValue, preset) {
-      this.eventBus.dispatch('scalechange', {
+      var arg = {
         source: this,
         scale: newScale,
         presetValue: preset ? newValue : undefined
-      });
+      };
+      this.eventBus.dispatch('scalechanging', arg);
+      this.eventBus.dispatch('scalechange', arg);
     },
 
     _setScaleUpdatePages: function pdfViewer_setScaleUpdatePages(


### PR DESCRIPTION
Fixes test issue at https://bugzilla.mozilla.org/show_bug.cgi?id=1268706 -- the m-c tests rely on input control content to determine current page number. Before #7254, "pagechange" was attached after the handler which was updating UI, after the PR the control update is happening after DOM events are fired.
