### PR TITLE
Prevent "Prefixed Fullscreen API is deprecated." warnings in the MOZCENTRAL version (issue 7270)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -415,6 +415,9 @@ var PDFViewerApplication = {
   },
 
   get supportsFullscreen() {
+//#if MOZCENTRAL
+//  var support = document.fullscreenEnabled === true;
+//#else
     var doc = document.documentElement;
     var support = !!(doc.requestFullscreen || doc.mozRequestFullScreen ||
                      doc.webkitRequestFullScreen || doc.msRequestFullscreen);
@@ -425,6 +428,7 @@ var PDFViewerApplication = {
         document.msFullscreenEnabled === false) {
       support = false;
     }
+//#endif
     if (support && pdfjsLib.PDFJS.disableFullscreen === true) {
       support = false;
     }


### PR DESCRIPTION
We're already, since quite some time, using the standard Fullscreen API provided that it's available in the browser. The warning is only caused by the code that checks if the Fullscreen API is supported.

This patch uses a simple preprocessor tag to avoid the warning, since I'm assuming that in general, we want to try and remain backwards compatible with the prefixed versions of the Fullscreen API.

Fixes #7270.
