### PR TITLE
Prevent intermittent "Node was not found" errors when removing the `zoomLayer` in `PDFPageView_draw`

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -443,7 +443,12 @@ var PDFPageView = (function PDFPageViewClosure() {
           zoomLayerCanvas.width = 0;
           zoomLayerCanvas.height = 0;
 
-          div.removeChild(self.zoomLayer);
+          if (div.contains(self.zoomLayer)) {
+            // Prevent "Node was not found" errors if the `zoomLayer` was
+            // already removed. This may occur intermittently if the scale
+            // changes many times in very quick succession.
+            div.removeChild(self.zoomLayer);
+          }
           self.zoomLayer = null;
         }
 


### PR DESCRIPTION
I've seen the above error occasionally when the scale is updated many times in quick succession, but I've not been able to pinpoint exactly why it happens.
Since the error isn't caught, this means that the `pageViewDrawCallback` function doesn't run to completion.

Unfortunately, given the very intermittent nature of the issue, I haven't got any good STR for reliably reproducing this issue. However, I hope that this patch can be accepted anyway, since it's simple and should help prevent unnecessary errors.

**Update:**
For me, the following STR seems to hit this error quite often.
1. Open http://ftp.acc.umu.se/mirror/CTAN/info/lshort/english/lshort.pdf#zoom=page-fit
2. Enter/exit the browser fullscreen mode, using <kbd>F11</kbd>, a number of times.

**Update 2:**
I've pushed a new version of the patch to fix a couple of stupid typos in the commit message.
