### PR TITLE
Ignore 'endobj' commands inside of `ObjStm` streams (issue 5241, bug 898610, bug 1037816)

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -1175,6 +1175,11 @@ var XRef = (function XRefClosure() {
       // read stream objects for cache
       for (i = 0; i < n; ++i) {
         entries.push(parser.getObj());
+        // The ObjStm should not contain 'endobj'. If it's present, skip over it
+        // to support corrupt PDFs (fixes issue 5241, bug 898610, bug 1037816).
+        if (isCmd(parser.buf1, 'endobj')) {
+          parser.shift();
+        }
         num = nums[i];
         var entry = this.entries[num];
         if (entry && entry.offset === tableOffset && entry.gen === i) {

--- a/test/pdfs/bug1037816.pdf.link
+++ b/test/pdfs/bug1037816.pdf.link
@@ -1,0 +1,1 @@
+http://web.archive.org/web/20160509072707/http://www.oranjewoudnv.nl/sites/default/files/Oranjewoud%20NV%20-%20%20besluiten%20aandeelhoudersvergadering%2011%20juni%202014.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1128,6 +1128,15 @@
        "type": "eq",
        "about": "Font with an empty font file."
     },
+    {  "id": "bug1037816",
+       "file": "pdfs/bug1037816.pdf",
+       "md5": "8a45299d7b102a9c1cadb8883b8debc9",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "load",
+       "about": "ObjStm stream containing 'endobj' commands."
+    },
     {  "id": "ocs",
       "file": "pdfs/ocs.pdf",
       "md5": "2ade57e954ae7632749cf328daeaa7a8",


### PR DESCRIPTION
According to an example in the PDF specification, see http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#page=56, an `ObjStm` stream should not contain 'endobj' commands.

Fixes #5241.
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=898610.
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1037816.
