### PR TITLE
Solving issue #7307, 'use strict' context in compatibility.js

### DIFF
--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -14,7 +14,8 @@
  */
 /* globals VBArray, PDFJS */
 
-'use strict';
+(function compatibilityWrapper() {
+  'use strict';
 
 // Initializing PDFJS global object here, it case if we need to change/disable
 // some PDF.js features, e.g. range requests
@@ -591,3 +592,5 @@ if (typeof PDFJS === 'undefined') {
     configurable: true
   });
 })();
+
+}).call((typeof window === 'undefined') ? this : window);


### PR DESCRIPTION
Added context to compatibility.js to have 'use strict' directive in our context only.
Solving "['Use strict' in pdfjs context only, compatibility.js #7307](https://github.com/mozilla/pdf.js/issues/7307)"
