### PR TITLE
Remove unused variables

### DIFF
--- a/make.js
+++ b/make.js
@@ -27,7 +27,6 @@ try {
 }
 
 var builder = require('./external/builder/builder.js');
-var path = require('path');
 var fs = require('fs');
 
 var CONFIG_FILE = 'pdfjs.config';

--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals NetworkManager */
 
 'use strict';
 

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -31,7 +31,6 @@ var Util = sharedUtil.Util;
 var createPromiseCapability = sharedUtil.createPromiseCapability;
 var CustomStyle = displayDOMUtils.CustomStyle;
 var getDefaultSetting = displayDOMUtils.getDefaultSetting;
-var PageViewport = sharedUtil.PageViewport;
 
 /**
  * Text layer render parameters.

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1,7 +1,7 @@
 /* globals PDFJS, expect, it, describe, Promise, beforeAll,
            InvalidPDFException, MissingPDFException, StreamType, FontType,
            PDFDocumentProxy, PasswordException, PasswordResponses, afterAll,
-           PDFPageProxy, createPromiseCapability, beforeEach, afterEach */
+           PDFPageProxy, createPromiseCapability, afterEach */
 
 'use strict';
 

--- a/web/app.js
+++ b/web/app.js
@@ -857,7 +857,6 @@ var PDFViewerApplication = {
     pdfViewer.setDocument(pdfDocument);
     var firstPagePromise = pdfViewer.firstPagePromise;
     var pagesPromise = pdfViewer.pagesPromise;
-    var onePageRendered = pdfViewer.onePageRendered;
 
     this.pageRotation = 0;
 

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -24,7 +24,7 @@
   } else {
     factory((root.pdfjsWebPDFFindController = {}), root.pdfjsWebUIUtils);
   }
-}(this, function (exports, uiUtils, firefoxCom) {
+}(this, function (exports, uiUtils) {
 
 var scrollIntoView = uiUtils.scrollIntoView;
 
@@ -322,10 +322,9 @@ var PDFFindController = (function PDFFindControllerClosure() {
      * @param {number} index - match index.
      * @param {Array} elements - text layer div elements array.
      * @param {number} beginIdx - start index of the div array for the match.
-     * @param {number} endIdx - end index of the div array for the match.
      */
     updateMatchPosition: function PDFFindController_updateMatchPosition(
-        pageIndex, index, elements, beginIdx, endIdx) {
+        pageIndex, index, elements, beginIdx) {
       if (this.selected.matchIdx === index &&
           this.selected.pageIdx === pageIndex) {
         var spot = {

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -187,7 +187,6 @@ var PDFPageView = (function PDFPageViewClosure() {
       var isScalingRestricted = false;
       if (this.canvas && pdfjsLib.PDFJS.maxCanvasPixels > 0) {
         var outputScale = this.outputScale;
-        var pixelsInViewport = this.viewport.width * this.viewport.height;
         if (((Math.floor(this.viewport.width) * outputScale.sx) | 0) *
             ((Math.floor(this.viewport.height) * outputScale.sy) | 0) >
             pdfjsLib.PDFJS.maxCanvasPixels) {

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -225,7 +225,7 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
 
         if (this.findController) {
           this.findController.updateMatchPosition(pageIdx, i, textDivs,
-                                                  begin.divIdx, end.divIdx);
+                                                  begin.divIdx);
         }
 
         // Match inside new div.


### PR DESCRIPTION
These have been found using `gulp lint` in combination with the `unused: true` parameter for JSHint. Unfortunately there are too many false positives to enable this feature, but now that most globals have been removed because of the conversion to UMD the results are much more useful than before.
