### PR TITLE
Fixes AMD name in web/the pdf_viewer.js.

### DIFF
--- a/web/pdf_viewer.component.js
+++ b/web/pdf_viewer.component.js
@@ -18,12 +18,12 @@
 (function (root, factory) {
   'use strict';
   if (typeof define === 'function' && define.amd) {
-    define('pdfjs-dist/web/pdf.components', ['exports', 'pdfjs-dist/build/pdf'],
+    define('pdfjs-dist/web/pdf_viewer', ['exports', 'pdfjs-dist/build/pdf'],
       factory);
   } else if (typeof exports !== 'undefined') {
     factory(exports, require('../build/pdf.js'));
   } else {
-    factory((root.pdfjsDistWebPDFComponents = {}), root.pdfjsDistBuildPdf);
+    factory((root.pdfjsDistWebPDFViewer = {}), root.pdfjsDistBuildPdf);
   }
 }(this, function (exports, pdfjsLib) {
   'use strict';


### PR DESCRIPTION
Addressing https://github.com/mozilla/pdf.js/issues/7287#issuecomment-219457631 issue.
