### PR TITLE
Support syncing of settings in Chrome extension

### DIFF
--- a/extensions/chromium/options/migration.js
+++ b/extensions/chromium/options/migration.js
@@ -1,0 +1,69 @@
+/*
+Copyright 2016 Mozilla Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/* globals chrome */
+
+(function() {
+  'use strict';
+  var storageLocal = chrome.storage.local;
+  var storageSync = chrome.storage.sync;
+
+  if (!storageSync) {
+    // No sync storage area - nothing to migrate to.
+    return;
+  }
+
+  getStorageNames(function(storageKeys) {
+    storageLocal.get(storageKeys, function(values) {
+      if (!values || !Object.keys(values).length) {
+        // No local storage - nothing to migrate.
+        return;
+      }
+      migrateToSyncStorage(values);
+    });
+  });
+
+  function getStorageNames(callback) {
+    var x = new XMLHttpRequest();
+    var schema_location = chrome.runtime.getManifest().storage.managed_schema;
+    x.open('get', chrome.runtime.getURL(schema_location));
+    x.onload = function() {
+      var storageKeys = Object.keys(x.response.properties);
+      callback(storageKeys);
+    };
+    x.responseType = 'json';
+    x.send();
+  }
+
+  // Save |values| to storage.sync and delete the values with that key from
+  // storage.local.
+  function migrateToSyncStorage(values) {
+    storageSync.set(values, function() {
+      if (chrome.runtime.lastError) {
+        console.error('Failed to migrate settings due to an error: ' +
+            chrome.runtime.lastError.message);
+        return;
+      }
+      // Migration successful. Delete local settings.
+      storageLocal.remove(Object.keys(values), function() {
+        // In theory remove() could fail (e.g. if the browser's storage
+        // backend is corrupt), but since storageSync.set succeeded, consider
+        // the migration successful.
+        console.log(
+            'Successfully migrated preferences from local to sync storage.');
+      });
+    });
+  }
+})();

--- a/extensions/chromium/options/options.js
+++ b/extensions/chromium/options/options.js
@@ -16,9 +16,15 @@ limitations under the License.
 /* globals chrome, Promise */
 
 'use strict';
+var storageAreaName = chrome.storage.sync ? 'sync' : 'local';
+var storageArea = chrome.storage[storageAreaName];
 
 Promise.all([
   new Promise(function getManagedPrefs(resolve) {
+    if (!chrome.storage.managed) {
+      resolve({});
+      return;
+    }
     // Get preferences as set by the system administrator.
     chrome.storage.managed.get(null, function(prefs) {
       // Managed storage may be disabled, e.g. in Opera.
@@ -26,7 +32,7 @@ Promise.all([
     });
   }),
   new Promise(function getUserPrefs(resolve) {
-    chrome.storage.local.get(null, function(prefs) {
+    storageArea.get(null, function(prefs) {
       resolve(prefs || {});
     });
   }),
@@ -93,7 +99,7 @@ Promise.all([
   // Reset button to restore default settings.
   document.getElementById('reset-button').onclick = function() {
     userPrefs = {};
-    chrome.storage.local.remove(prefNames, function() {
+    storageArea.remove(prefNames, function() {
       renderedPrefNames.forEach(function(prefName) {
         renderPreferenceFunctions[prefName](getPrefValue(prefName));
       });
@@ -102,7 +108,7 @@ Promise.all([
 
   // Automatically update the UI when the preferences were changed elsewhere.
   chrome.storage.onChanged.addListener(function(changes, areaName) {
-    var prefs = areaName === 'local' ? userPrefs :
+    var prefs = areaName === storageAreaName ? userPrefs :
                 areaName === 'managed' ? managedPrefs : null;
     if (prefs) {
       renderedPrefNames.forEach(function(prefName) {
@@ -136,7 +142,7 @@ function renderBooleanPref(shortDescription, description, prefName) {
   checkbox.onchange = function() {
     var pref = {};
     pref[prefName] = this.checked;
-    chrome.storage.local.set(pref);
+    storageArea.set(pref);
   };
   wrapper.querySelector('span').textContent = shortDescription;
   document.getElementById('settings-boxes').appendChild(wrapper);
@@ -151,7 +157,7 @@ function renderDefaultZoomValue(shortDescription) {
   var wrapper = importTemplate('defaultZoomValue-template');
   var select = wrapper.querySelector('select');
   select.onchange = function() {
-    chrome.storage.local.set({
+    storageArea.set({
       defaultZoomValue: this.value
     });
   };
@@ -180,7 +186,7 @@ function renderSidebarViewOnLoad(shortDescription) {
   var wrapper = importTemplate('sidebarViewOnLoad-template');
   var select = wrapper.querySelector('select');
   select.onchange = function() {
-    chrome.storage.local.set({
+    storageArea.set({
       sidebarViewOnLoad: parseInt(this.value)
     });
   };
@@ -197,7 +203,7 @@ function renderExternalLinkTarget(shortDescription) {
   var wrapper = importTemplate('externalLinkTarget-template');
   var select = wrapper.querySelector('select');
   select.onchange = function() {
-    chrome.storage.local.set({
+    storageArea.set({
       externalLinkTarget: parseInt(this.value)
     });
   };

--- a/extensions/chromium/pdfHandler.html
+++ b/extensions/chromium/pdfHandler.html
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <script src="feature-detect.js"></script>
+<script src="options/migration.js"></script>
 <script src="preserve-referer.js"></script>
 <script src="pdfHandler.js"></script>
 <script src="extension-router.js"></script>

--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -297,17 +297,22 @@
     }
   }
 
+  // chrome.storage.sync is not supported in every Chromium-derivate.
+  // Note: The background page takes care of migrating values from
+  // chrome.storage.local to chrome.storage.sync when needed.
+  var storageArea = chrome.storage.sync || chrome.storage.local;
+
   Preferences._writeToStorage = function (prefObj) {
     return new Promise(function (resolve) {
       if (prefObj === Preferences.defaults) {
         var keysToRemove = Object.keys(Preferences.defaults);
         // If the storage is reset, remove the keys so that the values from
         // managed storage are applied again.
-        chrome.storage.local.remove(keysToRemove, function() {
+        storageArea.remove(keysToRemove, function() {
           resolve();
         });
       } else {
-        chrome.storage.local.set(prefObj, function() {
+        storageArea.set(prefObj, function() {
           resolve();
         });
       }
@@ -331,7 +336,7 @@
           // Managed storage not supported, e.g. in Opera.
           defaultPrefs = Preferences.defaults;
         }
-        chrome.storage.local.get(defaultPrefs, function(readPrefs) {
+        storageArea.get(defaultPrefs, function(readPrefs) {
           resolve(readPrefs);
         });
       }


### PR DESCRIPTION
Use `chrome.storage.sync` to store preferences instead of `chrome.storage.local`, to allow settings to be synchronized if the user chooses to sign in in Chrome and enables synchronization of extension preferences.

Tested with Chrome 50 as follows:
1. Build the Chrome extension (`node make chromium`).
2. Load the extension at chrome://extensions.
3. Open the options page, right-click and choose Inspect element to open Chrome's devtools and run the following snippet in the console (to simulate the behavior before this PR):
   `storageAreaName = 'local'; storageArea = chrome.storage.local;`
4. Change some preferences in the options page.
5. Close the options page and re-open it. You will observe that the settings are back to their defaults (because the settings at step 3 and 4 are saved to storage.local).
6. Inspect the background page and reload it (e.g. by running `location.reload()` from the console).
7. Confirm that the background page shows "Successfully migrated preferences from local to sync storage."
8. Repeat step 6 (i.e. reload the background page).
9. Confirm that no extra messages are printed (i.e. there is nothing to migrate since the last migration succeeded).

With the above steps, you can verify that the migration logic works as intended. Now, also test whether the preferences are actually applied:
1. Visit the options page of the extension at chrome://extensions
2. Untick the "Activate Hand tool by default" checkbox.
3. Open any PDF file, e.g. http://www.orimi.com/pdf-test.pdf
4. Press the mouse and move it around.
5. Confirm that text is being selected (=handtool is disabled).
6. Go back to the options page, and check the "Activate Hand tool by default" checkbox.
7. Repeat step 3 and 4.
8. Confirm that the page is moved up and down (=handtool is enabled). (If your screen is big then the page fits on one page, in that case just zoom in or resize the window so that the page doesn't fit in the viewport).

Fixes #7325.

/cc @timvandermeij Please review this PR.
