### PR TITLE
Resolve a regression in the Chromium extension's preferences handling

### DIFF
--- a/extensions/chromium/options/options.html
+++ b/extensions/chromium/options/options.html
@@ -80,6 +80,21 @@ body {
 </div>
 </template>
 
+<template id="externalLinkTarget-template">
+<div class="settings-row">
+  <label>
+    <span></span>
+    <select>
+      <option value="0">Default</option>
+      <option value="1">Current window/tab</option>
+      <option value="2">New window/tab</option>
+      <option value="3">Parent window/tab</option>
+      <option value="4">Top window/tab</option>
+    </select>
+  </label>
+</div>
+</template>
+
 <script src="options.js"></script>
 </body>
 </html>

--- a/extensions/chromium/options/options.js
+++ b/extensions/chromium/options/options.js
@@ -74,6 +74,8 @@ Promise.all([
       renderPreference = renderDefaultZoomValue(prefSchema.title);
     } else if (prefName === 'sidebarViewOnLoad') {
       renderPreference = renderSidebarViewOnLoad(prefSchema.title);
+    } else if (prefName === 'externalLinkTarget') {
+      renderPreference = renderExternalLinkTarget(prefSchema.title);
     } else {
       // Should NEVER be reached. Only happens if a new type of preference is
       // added to the storage manifest.
@@ -180,6 +182,23 @@ function renderSidebarViewOnLoad(shortDescription) {
   select.onchange = function() {
     chrome.storage.local.set({
       sidebarViewOnLoad: parseInt(this.value)
+    });
+  };
+  wrapper.querySelector('span').textContent = shortDescription;
+  document.getElementById('settings-boxes').appendChild(wrapper);
+
+  function renderPreference(value) {
+    select.value = value;
+  }
+  return renderPreference;
+}
+
+function renderExternalLinkTarget(shortDescription) {
+  var wrapper = importTemplate('externalLinkTarget-template');
+  var select = wrapper.querySelector('select');
+  select.onchange = function() {
+    chrome.storage.local.set({
+      externalLinkTarget: parseInt(this.value)
     });
   };
   wrapper.querySelector('span').textContent = shortDescription;


### PR DESCRIPTION
Commit https://github.com/mozilla/pdf.js/commit/df10513e103cc165352fb1ee2e2cf5122a73eee1 unfortunately broke the options dialog of the Chromium extension because the logic required to work with the preference was not added. This patch adds the required logic to show the preference in the options dialog and to persist it to the preferences storage.

Verified using Chromium 50 on Arch Linux.
