### PR TITLE
Fix errors in `setGState` in `PartialEvaluator_getTextContent` that prevents text-selection from working properly

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1402,7 +1402,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
             case OPS.setFont:
               flushTextContentItem();
               textState.fontSize = args[1];
-              next(handleSetFont(args[0].name));
+              next(handleSetFont(args[0].name, null));
               return;
             case OPS.setTextRise:
               flushTextContentItem();
@@ -1608,21 +1608,17 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
               var dictName = args[0];
               var extGState = resources.get('ExtGState');
 
-              if (!isDict(extGState) || !extGState.has(dictName.name)) {
+              if (!isDict(extGState) || !isName(dictName)) {
                 break;
               }
-
-              var gsStateMap = extGState.get(dictName.name);
-              var gsStateFont = null;
-              for (var key in gsStateMap) {
-                if (key === 'Font') {
-                  assert(!gsStateFont);
-                  gsStateFont = gsStateMap[key];
-                }
+              var gState = extGState.get(dictName.name);
+              if (!isDict(gState)) {
+                break;
               }
-              if (gsStateFont) {
-                textState.fontSize = gsStateFont[1];
-                next(handleSetFont(gsStateFont[0]));
+              var gStateFont = gState.get('Font');
+              if (gStateFont) {
+                textState.fontSize = gStateFont[1];
+                next(handleSetFont(null, gStateFont[0]));
                 return;
               }
               break;

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -737,6 +737,13 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "extgstate-text",
+       "file": "pdfs/extgstate.pdf",
+       "md5": "001bb4ec04463a01d93aad748361f049",
+       "link": false,
+       "rounds": 1,
+       "type": "text"
+    },
     {  "id": "usmanm-bad",
        "file": "pdfs/usmanm-bad.pdf",
        "md5": "38afb822433aaf07fc8f54807cd4f61a",


### PR DESCRIPTION
Currently `setGState` is completely broken, and looking through the history of that code, it seems to me that this may never have worked correctly.
This patch fixes the text-selection in `extgstate.pdf` in the test-suite, which is also added as a `text` test.
