### PR TITLE
Move the `isSpace` utility function from core/parser.js to shared/util.js

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -47,6 +47,7 @@ var shadow = sharedUtil.shadow;
 var stringToBytes = sharedUtil.stringToBytes;
 var stringToPDFString = sharedUtil.stringToPDFString;
 var warn = sharedUtil.warn;
+var isSpace = sharedUtil.isSpace;
 var Dict = corePrimitives.Dict;
 var isDict = corePrimitives.isDict;
 var isName = corePrimitives.isName;
@@ -57,7 +58,6 @@ var StreamsSequenceStream = coreStream.StreamsSequenceStream;
 var Catalog = coreObj.Catalog;
 var ObjectLoader = coreObj.ObjectLoader;
 var XRef = coreObj.XRef;
-var Lexer = coreParser.Lexer;
 var Linearization = coreParser.Linearization;
 var calculateMD5 = coreCrypto.calculateMD5;
 var OperatorList = coreEvaluator.OperatorList;
@@ -470,7 +470,7 @@ var PDFDocument = (function PDFDocumentClosure() {
           var ch;
           do {
             ch = stream.getByte();
-          } while (Lexer.isSpace(ch));
+          } while (isSpace(ch));
           var str = '';
           while (ch >= 0x20 && ch <= 0x39) { // < '9'
             str += String.fromCharCode(ch);

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -18,25 +18,24 @@
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
     define('pdfjs/core/fonts', ['exports', 'pdfjs/shared/util',
-      'pdfjs/core/primitives', 'pdfjs/core/stream', 'pdfjs/core/parser',
-      'pdfjs/core/glyphlist', 'pdfjs/core/font_renderer',
-      'pdfjs/core/encodings', 'pdfjs/core/standard_fonts', 'pdfjs/core/unicode',
+      'pdfjs/core/primitives', 'pdfjs/core/stream', 'pdfjs/core/glyphlist',
+      'pdfjs/core/font_renderer', 'pdfjs/core/encodings',
+      'pdfjs/core/standard_fonts', 'pdfjs/core/unicode',
       'pdfjs/core/type1_parser', 'pdfjs/core/cff_parser'], factory);
   } else if (typeof exports !== 'undefined') {
     factory(exports, require('../shared/util.js'), require('./primitives.js'),
-      require('./stream.js'), require('./parser.js'), require('./glyphlist.js'),
+      require('./stream.js'), require('./glyphlist.js'),
       require('./font_renderer.js'), require('./encodings.js'),
       require('./standard_fonts.js'), require('./unicode.js'),
       require('./type1_parser.js'), require('./cff_parser.js'));
   } else {
     factory((root.pdfjsCoreFonts = {}), root.pdfjsSharedUtil,
-      root.pdfjsCorePrimitives, root.pdfjsCoreStream, root.pdfjsCoreParser,
-      root.pdfjsCoreGlyphList, root.pdfjsCoreFontRenderer,
-      root.pdfjsCoreEncodings, root.pdfjsCoreStandardFonts,
-      root.pdfjsCoreUnicode, root.pdfjsCoreType1Parser,
-      root.pdfjsCoreCFFParser);
+      root.pdfjsCorePrimitives, root.pdfjsCoreStream, root.pdfjsCoreGlyphList,
+      root.pdfjsCoreFontRenderer, root.pdfjsCoreEncodings,
+      root.pdfjsCoreStandardFonts, root.pdfjsCoreUnicode,
+      root.pdfjsCoreType1Parser, root.pdfjsCoreCFFParser);
   }
-}(this, function (exports, sharedUtil, corePrimitives, coreStream, coreParser,
+}(this, function (exports, sharedUtil, corePrimitives, coreStream,
                   coreGlyphList, coreFontRenderer, coreEncodings,
                   coreStandardFonts, coreUnicode, coreType1Parser,
                   coreCFFParser) {
@@ -55,8 +54,8 @@ var shadow = sharedUtil.shadow;
 var string32 = sharedUtil.string32;
 var warn = sharedUtil.warn;
 var MissingDataException = sharedUtil.MissingDataException;
+var isSpace = sharedUtil.isSpace;
 var Stream = coreStream.Stream;
-var Lexer = coreParser.Lexer;
 var getGlyphsUnicode = coreGlyphList.getGlyphsUnicode;
 var getDingbatsGlyphsUnicode = coreGlyphList.getDingbatsGlyphsUnicode;
 var FontRendererFactory = coreFontRenderer.FontRendererFactory;
@@ -2889,7 +2888,7 @@ var Type1Font = (function Type1FontClosure() {
       }
       if (j >= signatureLength) { // `signature` found, skip over whitespace.
         i += j;
-        while (i < streamBytesLength && Lexer.isSpace(streamBytes[i])) {
+        while (i < streamBytesLength && isSpace(streamBytes[i])) {
           i++;
         }
         found = true;

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -652,11 +652,6 @@ var Lexer = (function LexerClosure() {
     this.knownCommands = knownCommands;
   }
 
-  Lexer.isSpace = function Lexer_isSpace(ch) {
-    // Space is one of the following characters: SPACE, TAB, CR or LF.
-    return (ch === 0x20 || ch === 0x09 || ch === 0x0D || ch === 0x0A);
-  };
-
   // A '1' in this array means the character is white space. A '1' or
   // '2' means the character ends a name or command.
   var specialChars = [

--- a/src/core/ps_parser.js
+++ b/src/core/ps_parser.js
@@ -28,8 +28,8 @@
 }(this, function (exports, sharedUtil, coreParser) {
 
 var error = sharedUtil.error;
+var isSpace = sharedUtil.isSpace;
 var EOF = coreParser.EOF;
-var Lexer = coreParser.Lexer;
 
 var PostScriptParser = (function PostScriptParserClosure() {
   function PostScriptParser(lexer) {
@@ -173,7 +173,7 @@ var PostScriptLexer = (function PostScriptLexerClosure() {
           }
         } else if (ch === 0x25) { // '%'
           comment = true;
-        } else if (!Lexer.isSpace(ch)) {
+        } else if (!isSpace(ch)) {
           break;
         }
         ch = this.nextChar();

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -38,6 +38,7 @@ var isArray = sharedUtil.isArray;
 var createObjectURL = sharedUtil.createObjectURL;
 var shadow = sharedUtil.shadow;
 var warn = sharedUtil.warn;
+var isSpace = sharedUtil.isSpace;
 var Dict = corePrimitives.Dict;
 var isDict = corePrimitives.isDict;
 var Jbig2Image = coreJbig2.Jbig2Image;
@@ -1146,11 +1147,6 @@ var DecryptStream = (function DecryptStreamClosure() {
 })();
 
 var Ascii85Stream = (function Ascii85StreamClosure() {
-  // Checks if ch is one of the following characters: SPACE, TAB, CR or LF.
-  function isSpace(ch) {
-    return (ch === 0x20 || ch === 0x09 || ch === 0x0D || ch === 0x0A);
-  }
-
   function Ascii85Stream(str, maybeLength) {
     this.str = str;
     this.dict = str.dict;

--- a/src/core/type1_parser.js
+++ b/src/core/type1_parser.js
@@ -18,20 +18,19 @@
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
     define('pdfjs/core/type1_parser', ['exports', 'pdfjs/shared/util',
-      'pdfjs/core/stream', 'pdfjs/core/parser', 'pdfjs/core/encodings'],
-      factory);
+      'pdfjs/core/stream', 'pdfjs/core/encodings'], factory);
   } else if (typeof exports !== 'undefined') {
     factory(exports, require('../shared/util.js'), require('./stream.js'),
-      require('./parser.js'), require('./encodings.js'));
+      require('./encodings.js'));
   } else {
     factory((root.pdfjsCoreType1Parser = {}), root.pdfjsSharedUtil,
-      root.pdfjsCoreStream, root.pdfjsCoreParser, root.pdfjsCoreEncodings);
+      root.pdfjsCoreStream, root.pdfjsCoreEncodings);
   }
-}(this, function (exports, sharedUtil, coreStream, coreParser, coreEncodings) {
+}(this, function (exports, sharedUtil, coreStream, coreEncodings) {
 
 var warn = sharedUtil.warn;
+var isSpace = sharedUtil.isSpace;
 var Stream = coreStream.Stream;
-var Lexer = coreParser.Lexer;
 var getEncoding = coreEncodings.getEncoding;
 
 // Hinting is currently disabled due to unknown problems on windows
@@ -503,7 +502,7 @@ var Type1Parser = (function Type1ParserClosure() {
           }
         } else if (ch === 0x25) { // '%'
           comment = true;
-        } else if (!Lexer.isSpace(ch)) {
+        } else if (!isSpace(ch)) {
           break;
         }
         ch = this.nextChar();
@@ -516,7 +515,7 @@ var Type1Parser = (function Type1ParserClosure() {
       do {
         token += String.fromCharCode(ch);
         ch = this.nextChar();
-      } while (ch >= 0 && !Lexer.isSpace(ch) && !isSpecial(ch));
+      } while (ch >= 0 && !isSpace(ch) && !isSpecial(ch));
       return token;
     },
 

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1092,6 +1092,11 @@ function isArrayBuffer(v) {
   return typeof v === 'object' && v !== null && v.byteLength !== undefined;
 }
 
+// Checks if ch is one of the following characters: SPACE, TAB, CR or LF.
+function isSpace(ch) {
+  return (ch === 0x20 || ch === 0x09 || ch === 0x0D || ch === 0x0A);
+}
+
 /**
  * Promise Capability object.
  *
@@ -2345,6 +2350,7 @@ exports.isEmptyObj = isEmptyObj;
 exports.isInt = isInt;
 exports.isNum = isNum;
 exports.isString = isString;
+exports.isSpace = isSpace;
 exports.isSameOrigin = isSameOrigin;
 exports.isValidUrl = isValidUrl;
 exports.isLittleEndian = isLittleEndian;


### PR DESCRIPTION
Currently the `isSpace` utility function is a member of `Lexer`, which seems suboptimal, given that it's placed in `core/parser.js`. In practice, this means that in a number of `core/*.js` files we thus have an _otherwise_ completely unnecessary dependency on `core/parser.js` for a one-line function.

Instead, this patch moves `isSpace` into `shared/util.js` which seems more appropriate for this kind of utility function. Not to mention that since all the affected `core/*.js` files already depends on `shared/util.js`, this doesn't incur any more file dependencies.
