### PR TITLE
Skip inherited props in object iteration

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -228,8 +228,9 @@ var ToUnicodeMap = (function ToUnicodeMapClosure() {
 
     forEach: function(callback) {
       for (var charCode in this._map) {
-        if (this._map.hasOwnProperty(charCode))
+        if (this._map.hasOwnProperty(charCode)) {
           callback(charCode, this._map[charCode].charCodeAt(0));
+        }
       }
     },
 

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -228,7 +228,8 @@ var ToUnicodeMap = (function ToUnicodeMapClosure() {
 
     forEach: function(callback) {
       for (var charCode in this._map) {
-        callback(charCode, this._map[charCode].charCodeAt(0));
+        if (this._map.hasOwnProperty(charCode))
+          callback(charCode, this._map[charCode].charCodeAt(0));
       }
     },
 


### PR DESCRIPTION
Caused 'Error during font loading: this._map[charCode].charCodeAt is not a function'

Sample file: https://yadi.sk/d/xgAl_jmCsN3fA
