### PR TITLE
[Firefox addon] Change the minimum supported version to Firefox 38 and remove a bunch old no longer necessary fallback code

### DIFF
--- a/extensions/firefox/content/PdfjsChromeUtils.jsm
+++ b/extensions/firefox/content/PdfjsChromeUtils.jsm
@@ -170,18 +170,7 @@ var PdfjsChromeUtils = {
   _findbarFromMessage: function(aMsg) {
     let browser = aMsg.target;
     let tabbrowser = browser.getTabBrowser();
-    let tab;
-//#if MOZCENTRAL
-    tab = tabbrowser.getTabForBrowser(browser);
-//#else
-    if (tabbrowser.getTabForBrowser) {
-      tab = tabbrowser.getTabForBrowser(browser);
-    } else {
-      // _getTabForBrowser is deprecated in Firefox 35, see
-      // https://bugzilla.mozilla.org/show_bug.cgi?id=1039500.
-      tab = tabbrowser._getTabForBrowser(browser);
-    }
-//#endif
+    let tab = tabbrowser.getTabForBrowser(browser);
     return tabbrowser.getFindBar(tab);
   },
 

--- a/extensions/firefox/install.rdf
+++ b/extensions/firefox/install.rdf
@@ -13,8 +13,8 @@
     <em:targetApplication>
       <Description>
        <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
-       <em:minVersion>10.0</em:minVersion>
-       <em:maxVersion>46.0a1</em:maxVersion>
+       <em:minVersion>38.0</em:minVersion>
+       <em:maxVersion>50.0a1</em:maxVersion>
      </Description>
     </em:targetApplication>
 
@@ -31,8 +31,8 @@
     <em:targetApplication>
       <Description>
        <em:id>{aa3c5121-dab2-40e2-81ca-7ea25febc110}</em:id>
-       <em:minVersion>11.0</em:minVersion>
-       <em:maxVersion>46.0a1</em:maxVersion>
+       <em:minVersion>38.0</em:minVersion>
+       <em:maxVersion>50.0a1</em:maxVersion>
      </Description>
     </em:targetApplication>
 

--- a/extensions/firefox/update.rdf
+++ b/extensions/firefox/update.rdf
@@ -14,8 +14,8 @@
             <em:targetApplication>
               <RDF:Description>
                 <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
-                <em:minVersion>10.0</em:minVersion>
-                <em:maxVersion>46.0</em:maxVersion>
+                <em:minVersion>38.0</em:minVersion>
+                <em:maxVersion>50.0</em:maxVersion>
                 <!-- Use the raw link for updates so we we can use SSL. -->
                 <em:updateLink>https://raw.githubusercontent.com/mozilla/pdf.js/gh-pages/extensions/firefox/pdf.js.xpi</em:updateLink>
               </RDF:Description>
@@ -25,8 +25,8 @@
             <em:targetApplication>
               <RDF:Description>
                 <em:id>{aa3c5121-dab2-40e2-81ca-7ea25febc110}</em:id>
-                <em:minVersion>10.0</em:minVersion>
-                <em:maxVersion>46.0</em:maxVersion>
+                <em:minVersion>38.0</em:minVersion>
+                <em:maxVersion>50.0</em:maxVersion>
                 <!-- Use the raw link for updates so we we can use SSL. -->
                 <em:updateLink>https://raw.githubusercontent.com/mozilla/pdf.js/gh-pages/extensions/firefox/pdf.js.xpi</em:updateLink>
               </RDF:Description>


### PR DESCRIPTION
From the discussion in issue #7386, it wasn't really clear if we can restrict addon support to Firefox `45` (i.e. the version that corresponds to the _current_ ESR version).

However, we have a bunch of code for _very_ old Firefox versions. Hence this patch changes the minimum supported version to Firefox `38` (which was released on `2015-05-12`, and correspond to the _previous_ ESR version), and removes code that only applies to old Firefox versions.

Regardless what we end up deciding regarding addon support for previous Firefox versions, given the amount of code that even the Firefox `>= 38` condition lets us remove, I certainly think that there is value in doing this.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/pdf.js/7400)

<!-- Reviewable:end -->
