### PR TITLE
Ensure that the 'pagechanging' event is triggered on load, to avoid incorrect initial button state (PR 7289 followup)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -64,6 +64,7 @@
                   pdfAttachmentViewerLib, pdfFindControllerLib, pdfFindBarLib,
                   domEventsLib, pdfjsLib) {
 
+var DEFAULT_PAGE = uiUtilsLib.DEFAULT_PAGE;
 var UNKNOWN_SCALE = uiUtilsLib.UNKNOWN_SCALE;
 var DEFAULT_SCALE_VALUE = uiUtilsLib.DEFAULT_SCALE_VALUE;
 var ProgressBar = uiUtilsLib.ProgressBar;
@@ -1049,10 +1050,6 @@ var PDFViewerApplication = {
 
     this.isInitialViewSet = true;
 
-    // When opening a new file, when one is already loaded in the viewer,
-    // ensure that the 'pageNumber' element displays the correct value.
-    this.appConfig.toolbar.pageNumber.value = this.pdfViewer.currentPageNumber;
-
     this.pdfSidebar.setInitialView(this.preferenceSidebarViewOnLoad ||
                                    (sidebarView | 0));
 
@@ -1067,7 +1064,7 @@ var PDFViewerApplication = {
       this.pdfLinkService.setHash(storedHash);
     } else if (scale) {
       this.pdfViewer.currentScaleValue = scale;
-      this.page = 1;
+      this.page = DEFAULT_PAGE;
     }
 
     if (!this.pdfViewer.currentScaleValue) {

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -38,6 +38,8 @@
                   textLayerBuilder, annotationLayerBuilder, pdfLinkService,
                   domEvents, pdfjsLib) {
 
+var DEFAULT_PAGE = uiUtils.DEFAULT_PAGE;
+var UNKNOWN_PAGE = uiUtils.UNKNOWN_PAGE;
 var UNKNOWN_SCALE = uiUtils.UNKNOWN_SCALE;
 var SCROLLBAR_PADDING = uiUtils.SCROLLBAR_PADDING;
 var VERTICAL_PADDING = uiUtils.VERTICAL_PADDING;
@@ -156,7 +158,8 @@ var PDFViewer = (function pdfViewer() {
     },
 
     get currentPageNumber() {
-      return this._currentPageNumber;
+      return this._currentPageNumber !== UNKNOWN_PAGE ?
+        this._currentPageNumber : DEFAULT_PAGE;
     },
 
     set currentPageNumber(val) {
@@ -381,7 +384,7 @@ var PDFViewer = (function pdfViewer() {
 
     _resetView: function () {
       this._pages = [];
-      this._currentPageNumber = 1;
+      this._currentPageNumber = UNKNOWN_PAGE;
       this._currentScale = UNKNOWN_SCALE;
       this._currentScaleValue = null;
       this._buffer = new PDFPageViewBuffer(DEFAULT_CACHE_SIZE);
@@ -433,7 +436,7 @@ var PDFViewer = (function pdfViewer() {
       this._currentScale = newScale;
 
       if (!noScroll) {
-        var page = this._currentPageNumber, dest;
+        var page = this.currentPageNumber, dest;
         if (this._location && !pdfjsLib.PDFJS.ignoreCurrentPositionOnZoom &&
             !(this.isInPresentationMode || this.isChangingPresentationMode)) {
           page = this._location.pageNumber;
@@ -456,7 +459,7 @@ var PDFViewer = (function pdfViewer() {
       if (scale > 0) {
         this._setScaleUpdatePages(scale, value, noScroll, false);
       } else {
-        var currentPage = this._pages[this._currentPageNumber - 1];
+        var currentPage = this._pages[this.currentPageNumber - 1];
         if (!currentPage) {
           return;
         }
@@ -507,7 +510,7 @@ var PDFViewer = (function pdfViewer() {
         this._setScale(this._currentScaleValue, true);
       }
 
-      var pageView = this._pages[this._currentPageNumber - 1];
+      var pageView = this._pages[this.currentPageNumber - 1];
       scrollIntoView(pageView.div);
     },
 
@@ -714,7 +717,7 @@ var PDFViewer = (function pdfViewer() {
         // The algorithm in getVisibleElements doesn't work in all browsers and
         // configurations when presentation mode is active.
         var visible = [];
-        var currentPage = this._pages[this._currentPageNumber - 1];
+        var currentPage = this._pages[this.currentPageNumber - 1];
         visible.push({ id: currentPage.id, view: currentPage });
         return { first: currentPage, last: currentPage, views: visible };
       }

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -26,6 +26,8 @@
 }(this, function (exports, pdfjsLib) {
 
 var CSS_UNITS = 96.0 / 72.0;
+var DEFAULT_PAGE = 1;
+var UNKNOWN_PAGE = 0;
 var DEFAULT_SCALE_VALUE = 'auto';
 var DEFAULT_SCALE = 1.0;
 var UNKNOWN_SCALE = 0;
@@ -510,6 +512,8 @@ var ProgressBar = (function ProgressBarClosure() {
 })();
 
 exports.CSS_UNITS = CSS_UNITS;
+exports.DEFAULT_PAGE = DEFAULT_PAGE;
+exports.UNKNOWN_PAGE = UNKNOWN_PAGE;
 exports.DEFAULT_SCALE_VALUE = DEFAULT_SCALE_VALUE;
 exports.DEFAULT_SCALE = DEFAULT_SCALE;
 exports.UNKNOWN_SCALE = UNKNOWN_SCALE;


### PR DESCRIPTION
With the changes in PR #7289, we no longer dispatch a 'pagechanging' event on load. Since most PDF documents open on the first page, this means that the `previous` and `firstPage` buttons are not correctly disabled.

_A picture is worth a thousand words:_

![buttons-disabled](https://cloud.githubusercontent.com/assets/2692120/15985850/9eec2628-2ffa-11e6-8c80-d933cc206ce1.png)

/cc @yurydelendik 
