### PR TITLE
Update print dialog to reuse existing dialog styles.

### DIFF
--- a/web/viewer-snippet-mozPrintCallback-polyfill.html
+++ b/web/viewer-snippet-mozPrintCallback-polyfill.html
@@ -1,79 +1,45 @@
-<div id="mozPrintCallback-shim" hidden>
+<div id="mozPrintCallback-shim" class="container" hidden>
   <style>
-@media print {
-  #printContainer div {
-    page-break-after: always;
-    page-break-inside: avoid;
-  }
-}
+    @media print {
+      #printContainer div {
+        page-break-after: always;
+        page-break-inside: avoid;
+      }
+    }
   </style>
   <style scoped>
-#mozPrintCallback-shim {
-  position: fixed;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
-  z-index: 9999999;
+    @media print {
+      #mozPrintCallback-shim {
+        display: none;
+      }
+    }
 
-  display: block;
-  text-align: center;
-  background-color: rgba(0, 0, 0, 0.5);
-}
-#mozPrintCallback-shim[hidden] {
-  display: none;
-}
-@media print {
-  #mozPrintCallback-shim {
-    display: none;
-  }
-}
+    #mozPrintCallback-shim .dialog {
+      font-size: 14px;
+    }
 
-#mozPrintCallback-shim .mozPrintCallback-dialog-box {
-  display: inline-block;
-  margin: -50px auto 0;
-  position: relative;
-  top: 45%;
-  left: 0;
-  min-width: 220px;
-  max-width: 400px;
+    #mozPrintCallback-shim progress {
+      margin: 10px auto;
+      width: 100%;
+    }
 
-  padding: 9px;
+    #mozPrintCallback-shim .relative-progress {
+      float: right;
+    }
 
-  border: 1px solid hsla(0, 0%, 0%, .5);
-  border-radius: 2px;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
-
-  background-color: #474747;
-
-  color: hsl(0, 0%, 85%);
-  font-size: 16px;
-  line-height: 20px;
-}
-#mozPrintCallback-shim .progress-row {
-  clear: both;
-  padding: 1em 0;
-}
-#mozPrintCallback-shim progress {
-  width: 100%;
-}
-#mozPrintCallback-shim .relative-progress {
-  clear: both;
-  float: right;
-}
-#mozPrintCallback-shim .progress-actions {
-  clear: both;
-}
+    #mozPrintCallback-shim .buttonRow {
+      clear: both;
+    }
   </style>
-  <div class="mozPrintCallback-dialog-box">
+  <div class="dialog">
     <!-- TODO: Localise the following strings -->
     Preparing document for printing...
     <div class="progress-row">
       <progress value="0" max="100"></progress>
       <span class="relative-progress">0%</span>
     </div>
-    <div class="progress-actions">
-      <input type="button" value="Cancel" class="mozPrintCallback-cancel">
+    <div class="buttonRow">
+      <input class="overlayButton" type="button" value="Cancel">
     </div>
   </div>
 </div>

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -315,6 +315,9 @@ See https://github.com/adobe-type-tools/cmap-resources
             </div>
           </div>
         </div>
+<!--#if !(FIREFOX || MOZCENTRAL)-->
+<!--#include viewer-snippet-mozPrintCallback-polyfill.html-->
+<!--#endif-->
         <div id="documentPropertiesOverlay" class="container hidden">
           <div class="dialog">
             <div class="row">
@@ -367,8 +370,5 @@ See https://github.com/adobe-type-tools/cmap-resources
 
     </div> <!-- outerContainer -->
     <div id="printContainer"></div>
-<!--#if !(FIREFOX || MOZCENTRAL)-->
-<!--#include viewer-snippet-mozPrintCallback-polyfill.html-->
-<!--#endif-->
   </body>
 </html>


### PR DESCRIPTION
Addresses [#3783](https://github.com/mozilla/pdf.js/issues/3783).

[Screenshot: http://cl.ly/2m3K3Z041M0o]

My understanding is that the print dialog was developed to be as modular as possible, with styles packed into the HTML, but this seemed counterintuitive to the issue and to reusability.

This commit is minor and I'm happy to do more if needed, including updating styles as desired. This is my first contribution to this project, so I didn't want to rock the boat.
