### PR TITLE
Add support for ResetForm Action

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -616,6 +616,14 @@ var WidgetAnnotation = (function WidgetAnnotationClosure() {
       this.setFlags(AnnotationFlag.HIDDEN);
     }
 
+    // Support ResetForm Action Widget
+    if (data.fieldType === 'Btn' && dict.get('A') !== undefined) {
+      var actionRef = dict.map.A.num;
+      var xrefObject = dict.xref.fetchIfRef(dict.map.A);
+      data.formAction = {};
+      data.formAction.S = xrefObject.map.S.name;
+    }
+
     // Building the full field name by collecting the field and
     // its ancestors 'T' data and joining them using '.'.
     var fieldName = [];


### PR DESCRIPTION
See PDF 32000-1:2008, 12.7.5.3 Reset-Form Action (p. 455).

This will be used to support clearing a form's values when viewing a form using pdf.js. It will enhance the functionality of the pdf.js acroforms demo (examples/acroforms).
