### PR TITLE
Add support for combo box choice fields

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -54,6 +54,7 @@ var ColorSpace = coreColorSpace.ColorSpace;
 var ObjectLoader = coreObj.ObjectLoader;
 var FileSpec = coreObj.FileSpec;
 var OperatorList = coreEvaluator.OperatorList;
+var Ref = corePrimitives.Ref;
 
 /**
  * @class
@@ -614,6 +615,31 @@ var WidgetAnnotation = (function WidgetAnnotationClosure() {
     if (data.fieldType === 'Sig') {
       warn('unimplemented annotation type: Widget signature');
       this.setFlags(AnnotationFlag.HIDDEN);
+    }
+
+    // Support Choice Fields (Combo Box only)
+    var dictOpts = dict.get('Opt');
+    if (data.fieldType === 'Ch' && dictOpts !== undefined) {
+      
+      if (dictOpts.num) {
+        // The options are stored in a ref
+        var optionsRefNum = dict.map.Opt.num;
+
+        // Get XRefs synchronously (if not already loaded)
+        var optionsRef = new Ref(optionsRefNum, 
+          dict.xref.entries[optionsRefNum].gen);
+        
+        dict.xref.fetch(optionsRef);
+
+        // Get the options from the xref array
+        if (dict.xref.cache[optionsRefNum]) {
+          data.options = dict.xref.cache[optionsRefNum];
+        }
+
+      } else {
+        // The options are stored directly in the dictionary
+        data.options = dictOpts;
+      }
     }
 
     // Building the full field name by collecting the field and


### PR DESCRIPTION
Add support for combo box / choice fields as outlined in PDF 32000-1:2008, 12.7.4.4 Choice Fields (p. 444-446). This will enhance the functionality of the pdf.js acroforms demo (examples/acroforms).

See for example the combo box in the lower right hand corner of the attached form.
[21-22 Appointment of Veterans Service Organization.pdf](https://github.com/mozilla/pdf.js/files/315133/21-22.Appointment.of.Veterans.Service.Organization.pdf)
