### PR TITLE
Skip mapping of glyphs to Unicode "Ideographic space" (issue 7416)

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -444,6 +444,7 @@ var ProblematicCharRanges = new Int32Array([
   0x2028, 0x2030,
   0x205F, 0x2070,
   0x25CC, 0x25CD,
+  0x3000, 0x3001,
   // Chars that is used in complex-script shaping.
   0xAA60, 0xAA80,
   // Specials Unicode block.


### PR DESCRIPTION
Fixes #7416, which is an IE specific issue.

@brendandahl I think this should do it. Since I cannot reproduce the issue in neither Firefox nor Chrome, but only in IE, I'm not sure how meaningful it would be to add a test-case.
But please let me know if you think that we need one anyway!
