### PR TITLE
Move Chromium URL rewrite to top of viewer.js

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -18,21 +18,6 @@
 
 var DEFAULT_URL = 'compressed.tracemonkey-pldi-09.pdf';
 
-//#if PRODUCTION
-//var pdfjsWebLibs = {
-//  pdfjsWebPDFJS: window.pdfjsDistBuildPdf
-//};
-//
-//(function () {
-//#expand __BUNDLE__
-//}).call(pdfjsWebLibs);
-//#endif
-
-//#if FIREFOX || MOZCENTRAL
-//// FIXME the l10n.js file in the Firefox extension needs global FirefoxCom.
-//window.FirefoxCom = pdfjsWebLibs.pdfjsWebFirefoxCom.FirefoxCom;
-//#endif
-
 //#if CHROME
 //(function rewriteUrlClosure() {
 //  // Run this code outside DOMContentLoaded to make sure that the URL
@@ -48,6 +33,21 @@ var DEFAULT_URL = 'compressed.tracemonkey-pldi-09.pdf';
 //    chrome.runtime.sendMessage('showPageAction');
 //  }
 //})();
+//#endif
+
+//#if PRODUCTION
+//var pdfjsWebLibs = {
+//  pdfjsWebPDFJS: window.pdfjsDistBuildPdf
+//};
+//
+//(function () {
+//#expand __BUNDLE__
+//}).call(pdfjsWebLibs);
+//#endif
+
+//#if FIREFOX || MOZCENTRAL
+//// FIXME the l10n.js file in the Firefox extension needs global FirefoxCom.
+//window.FirefoxCom = pdfjsWebLibs.pdfjsWebFirefoxCom.FirefoxCom;
 //#endif
 
 function getViewerConfiguration() {


### PR DESCRIPTION
Move the Chromium-specific URL rewriting code to the top of viewer.js (before the PDF.js library) to make sure that the URL is as expected.

This ensures that variables that synchronously depends on the URL (e.g. [`PDFViewerApplication.initialBookmark`](https://github.com/mozilla/pdf.js/blob/9a948f3190c61fd28b27c50a04f2a14266a228f6/web/app.js#L138)) are properly set.

Test:
1. Build the extension.
2. Visit https://bitcoin.org/bitcoin.pdf#search=bitcoin
3. Wait until the viewer finished loading, and verify that the "bitcoin" strings (e.g. in the title) are highlighted due to the search param.

This is currently broken, which I learned through a feature request from the Chrome Web Store (asking for `#search=` to work, while I was pretty sure that it should work).
