### PR TITLE
Update README.md to only guarantee Firefox addon compatibility with the current ESR version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,15 @@ irc.mozilla.org.
 
 ### Browser Extensions
 
-#### Firefox and Seamonkey
+#### Firefox (and Seamonkey)
 
-PDF.js is built into version 19+ of Firefox, however the extension is still available:
+PDF.js is built into version 19+ of Firefox, however one extension is still available:
 
-+ [Development Version](http://mozilla.github.io/pdf.js/extensions/firefox/pdf.js.xpi) - This version is updated every time new code is merged into the PDF.js codebase. This should be quite stable but still might break from time to time. This version is also reported to work when installed as extension in Seamonkey 2.39.
++ [Development Version](http://mozilla.github.io/pdf.js/extensions/firefox/pdf.js.xpi) - This extension is mainly intended for developers/testers, and it is updated every time new code is merged into the PDF.js codebase. It should be quite stable, but might break from time to time.
+
+  + Please note that the extension is *not* guaranteed to be compatible with Firefox versions that are *older* than the current ESR version, see the [Release Calendar](https://wiki.mozilla.org/RapidRelease/Calendar#Past_branch_dates).
+
+  + The extension should also work in Seamonkey, provided that it is based on a Firefox version as above (see [Which version of Firefox does SeaMonkey 2.x correspond with?](https://wiki.mozilla.org/SeaMonkey/FAQ#General)), but we do *not* guarantee compatibility.
 
 #### Chrome
 


### PR DESCRIPTION
To reduced the amount of compatibility code that we need to maintain in the addon, I think that we should be more explicit about which Firefox versions we intend to support. In the future, this should allow us to more quickly remove old compatibility code.
Furthermore, this patch also tries to be more explicit about the addon support for Seamonkey, by defining it in terms of the underlying Firefox version.
