### PR TITLE
Expose the text widget's maximum length.

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -659,6 +659,7 @@ var TextWidgetAnnotation = (function TextWidgetAnnotationClosure() {
     WidgetAnnotation.call(this, params);
 
     this.data.textAlignment = Util.getInheritableProperty(params.dict, 'Q');
+    this.data.maxLen = Util.getInheritableProperty(params.dict, 'MaxLen');
   }
 
   Util.inherit(TextWidgetAnnotation, WidgetAnnotation, {


### PR DESCRIPTION
Exposing the maximum length of a text widget makes it easier for the user to implement basic AcroForms support.
