### PR TITLE
Add back moz-specific fullscreen support code for `MOZCENTRAL` builds (bug 1268749, PR 7273 follow-up)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -416,7 +416,8 @@ var PDFViewerApplication = {
 
   get supportsFullscreen() {
 //#if MOZCENTRAL
-//  var support = document.fullscreenEnabled === true;
+//  var support = document.fullscreenEnabled === true ||
+//                document.mozFullScreenEnabled === true;
 //#else
     var doc = document.documentElement;
     var support = !!(doc.requestFullscreen || doc.mozRequestFullScreen ||


### PR DESCRIPTION
In PR #7273, we simplified the `MOZCENTRAL` specific check for fullscreen support. Unfortunately I've just, by coincidence, found out about https://bugzilla.mozilla.org/show_bug.cgi?id=1268749, which disabled the unprefixed fullscreen support in release versions of Firefox. If we do nothing, this will lead to Presentation Mode being unavailable in future Firefox releases.

This patch should fix things for now, and I'm afraid that we'll need to uplift it to Firefox 49 as well.
