### PR TITLE
Update `mxr.mozilla.org` links to point to `dxr.mozilla.org` instead

### DIFF
--- a/extensions/firefox/content/PdfJs-stub.jsm
+++ b/extensions/firefox/content/PdfJs-stub.jsm
@@ -16,8 +16,9 @@
 
 'use strict';
 
-// Don't remove this file. FF15+ expects PdfJs module to be present at resource://pdf.js/PdfJs.jsm
-// See https://mxr.mozilla.org/mozilla-central/source/browser/components/nsBrowserGlue.js
+// Don't remove this file!
+// FF15+ expects `PdfJs` module to be present at `resource://pdf.js/PdfJs.jsm`,
+// see https://dxr.mozilla.org/mozilla-central/source/browser/components/nsBrowserGlue.js
 var EXPORTED_SYMBOLS = ['PdfJs'];
 
 var PdfJs = {

--- a/l10n/README.md
+++ b/l10n/README.md
@@ -1,5 +1,5 @@
 Most of the files in this folder (except for the `en-US` folder and the
 `metadata.inc` files) have been imported from the Firefox Aurora branch,
-which is located at https://mxr.mozilla.org/l10n-mozilla-aurora/source.
+please see https://dxr.mozilla.org/l10n-mozilla-aurora/source/.
 Some of the files are licensed under the MPL license. You can obtain a
-copy of the license at http://mozilla.org/MPL/2.0.
+copy of the license at https://mozilla.org/MPL/2.0.


### PR DESCRIPTION
Given that MXR has been officially retired, see https://groups.google.com/forum/#!topic/mozilla.dev.platform/_k-ditFrne4, we've got a couple of links that are no longer working.
