### PR TITLE
Change the `warn` to `info` in `recoverGlyphName` to reduce the console spam

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -200,7 +200,7 @@ function recoverGlyphName(name, glyphsUnicodeMap) {
       }
     }
   }
-  warn('Unable to recover a standard glyph name for: ' + name);
+  info('Unable to recover a standard glyph name for: ' + name);
   return name;
 }
 


### PR DESCRIPTION
After PR #7441, where `recoverGlyphName` is used a lot more than before, many PDF files will generate a lot of warnings the console. For normal usage, compared to debugging/development, this is probably more annoying than helpful.
