### PR TITLE
Remove the obsolete `MozBlobBuilder` fallback from the `createBlob` utility function

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals MozBlobBuilder, URL, global */
+/* globals URL, global */
 
 'use strict';
 
@@ -1506,10 +1506,7 @@ var createBlob = function createBlob(data, contentType) {
   if (typeof Blob !== 'undefined') {
     return new Blob([data], { type: contentType });
   }
-  // Blob builder is deprecated in FF14 and removed in FF18.
-  var bb = new MozBlobBuilder();
-  bb.append(data);
-  return bb.getBlob(contentType);
+  warn('The "Blob" constructor is not supported.');
 };
 
 var createObjectURL = (function createObjectURLClosure() {


### PR DESCRIPTION
`MozBlobBuilder` has been obsolete since Firefox 14, so there's no reason to keep this code around anymore.
