### PR TITLE
[Firefox addon] Remove compatibility.js

### DIFF
--- a/make.js
+++ b/make.js
@@ -694,7 +694,6 @@ target.firefox = function() {
       [BUILD_TARGETS, FIREFOX_BUILD_CONTENT_DIR + BUILD_DIR],
       [BUILD_DIR + 'viewer.js', FIREFOX_BUILD_CONTENT_DIR + '/web'],
       [COMMON_WEB_FILES, FIREFOX_BUILD_CONTENT_DIR + '/web'],
-      ['web/compatibility.js', FIREFOX_BUILD_CONTENT_DIR + '/web'],
       ['external/bcmaps/*', FIREFOX_BUILD_CONTENT_DIR + '/web/cmaps'],
       [FIREFOX_EXTENSION_DIR + 'tools/l10n.js',
        FIREFOX_BUILD_CONTENT_DIR + '/web']

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -44,7 +44,7 @@ See https://github.com/adobe-type-tools/cmap-resources
     <link rel="resource" type="application/l10n" href="locale/locale.properties">
 <!--#endif-->
 
-<!--#if !(MOZCENTRAL || CHROME || MINIFIED)-->
+<!--#if !(FIREFOX || MOZCENTRAL || CHROME || MINIFIED)-->
     <script src="compatibility.js"></script>
 <!--#endif-->
 


### PR DESCRIPTION
This was added in PR #4865, but hasn't been necessary for quite some time now (and the minimum version is currently Firefox 38 for the addon).
