### PR TITLE
Fixed partial printing for IE / Edge and improved print quality for all browsers

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -535,10 +535,11 @@ var PDFPageView = (function PDFPageViewClosure() {
       var CustomStyle = pdfjsLib.CustomStyle;
       var pdfPage = this.pdfPage;
 
-      var viewport = pdfPage.getViewport(1);
+      // increase to improve quality
+      var viewport = pdfPage.getViewport(4);
       // Use the same hack we use for high dpi displays for printing to get
       // better output until bug 811002 is fixed in FF.
-      var DPI = 200; // increase to improve quality
+      var DPI = 72; // increase to improve quality
       var PRINT_OUTPUT_SCALE = DPI/72; 
       var canvas = document.createElement('canvas');
 
@@ -553,8 +554,8 @@ var PDFPageView = (function PDFPageViewClosure() {
       CustomStyle.setProp('transformOrigin' , canvas, '0% 0%');
 
       var canvasWrapper = document.createElement('div');
-      canvasWrapper.style.width = viewport.width + 'pt';
-      canvasWrapper.style.height = viewport.height + 'pt';
+      canvasWrapper.style.width = '100%';
+      canvasWrapper.style.height = '100%';
 
       canvasWrapper.appendChild(canvas);
       printContainer.appendChild(canvasWrapper);

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -546,10 +546,9 @@ var PDFPageView = (function PDFPageViewClosure() {
       canvas.height = Math.floor(viewport.height) * PRINT_OUTPUT_SCALE;
 
       // The rendered size of the canvas, relative to the size of canvasWrapper.
-      canvas.style.width = (PRINT_OUTPUT_SCALE * 100) + '%';
+      canvas.style.width = '100%';
 
-      var cssScale = 'scale(' + (1 / PRINT_OUTPUT_SCALE) + ', ' +
-                                (1 / PRINT_OUTPUT_SCALE) + ')';
+      var cssScale = 'scale(1,1)';
       CustomStyle.setProp('transform' , canvas, cssScale);
       CustomStyle.setProp('transformOrigin' , canvas, '0% 0%');
 

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -538,21 +538,24 @@ var PDFPageView = (function PDFPageViewClosure() {
       var viewport = pdfPage.getViewport(1);
       // Use the same hack we use for high dpi displays for printing to get
       // better output until bug 811002 is fixed in FF.
-      var PRINT_OUTPUT_SCALE = 2;
+      var DPI = 200; // increase to improve quality
+      var PRINT_OUTPUT_SCALE = DPI/72; 
       var canvas = document.createElement('canvas');
 
       // The logical size of the canvas.
-      canvas.width = Math.floor(viewport.width) * PRINT_OUTPUT_SCALE;
-      canvas.height = Math.floor(viewport.height) * PRINT_OUTPUT_SCALE;
+      canvas.width = Math.floor(viewport.width * PRINT_OUTPUT_SCALE);
+      canvas.height = Math.floor(viewport.height * PRINT_OUTPUT_SCALE);
 
       // The rendered size of the canvas, relative to the size of canvasWrapper.
       canvas.style.width = '100%';
 
-      var cssScale = 'scale(1,1)';
-      CustomStyle.setProp('transform' , canvas, cssScale);
+      CustomStyle.setProp('transform' , canvas, 'scale(1,1)');
       CustomStyle.setProp('transformOrigin' , canvas, '0% 0%');
 
       var canvasWrapper = document.createElement('div');
+      canvasWrapper.style.width = viewport.width + 'pt';
+      canvasWrapper.style.height = viewport.height + 'pt';
+
       canvasWrapper.appendChild(canvas);
       printContainer.appendChild(canvasWrapper);
 


### PR DESCRIPTION
Fixed partial printing and print quality issues as described in issue #3983.

**Issue Description** 
When printing a PDF from the PDF.js viewer, the printed output is of poor quality and being cutoff near the bottom of the page. 

**Steps to reproduce** 
1.  Open a PDF from PDF.js viewer
2.  Click the "Print" button
3.  Select a printer
4.  Check the quality of the printed output, and observe that the bottom portion of the page is cutoff.

**Fix Description**
The issue was fixed by changing the rendered size of the canvas to 100%,  setting the CSS scale factor to 1 for both the width and height, changing the PRINT_OUTPUT_SCALE to be dependent on DPI, fixed PT to PX conversion between the viewport measurements and the canvas measurements, increased the viewport factor.

**Notes**
All tests pass.
Confirmed that the issue has been fixed on IE 11.494, Edge 25.1, FF 47.0.1, Chrome 51.0
