### PR TITLE
Improve print quality for all browsers

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -538,7 +538,7 @@ var PDFPageView = (function PDFPageViewClosure() {
       var viewport = pdfPage.getViewport(1);
       // Use the same hack we use for high dpi displays for printing to get
       // better output until bug 811002 is fixed in FF.
-      var PRINT_OUTPUT_SCALE = 2;
+      var PRINT_OUTPUT_SCALE = 4;
       var canvas = document.createElement('canvas');
 
       // The logical size of the canvas.

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -546,10 +546,9 @@ var PDFPageView = (function PDFPageViewClosure() {
       canvas.height = Math.floor(viewport.height) * PRINT_OUTPUT_SCALE;
 
       // The rendered size of the canvas, relative to the size of canvasWrapper.
-      canvas.style.width = (PRINT_OUTPUT_SCALE * 100) + '%';
+      canvas.style.width = '100%';
 
-      var cssScale = 'scale(' + (1 / PRINT_OUTPUT_SCALE) + ', ' +
-                                (1 / PRINT_OUTPUT_SCALE) + ')';
+      var cssScale = 'scale(1,1)';
       CustomStyle.setProp('transform' , canvas, cssScale);
       CustomStyle.setProp('transformOrigin' , canvas, '0% 0%');
 


### PR DESCRIPTION
Improved print quality by increasing the PRINT_OUTPUT_SCALE factor from 2 to 4.

**Acceptance Criteria** 
Compare quality of the print when the scale factor is 2 (fuzzy/blurry) and 4 (sharper and clearer).

**Notes**
Addresses Issue #2750 and #7094
Increases quality of print but results in a larger memory footprint 
