### PR TITLE
Fix for #7468 - Cleared all highlights when find bar is closed

### DIFF
--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -193,6 +193,14 @@ var PDFFindBar = (function PDFFindBarClosure() {
       this.toggleButton.classList.remove('toggled');
       this.bar.classList.add('hidden');
       this.findController.active = false;
+      //Wipe out all highlighted matches on close
+      var numPages = this.findController.pdfViewer.pagesCount;
+      for (var i = 0; i < numPages; i++) {
+          var page = this.findController.pdfViewer.getPageView(i);
+          if (page.textLayer) {
+            page.textLayer.updateMatches();
+          }
+        }
     },
 
     toggle: function PDFFindBar_toggle() {

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -307,7 +307,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
       if (this.selected.pageIdx === index) {
         // If the page is selected, scroll the page into view, which triggers
         // rendering the page, which adds the textLayer. Once the textLayer is
-        // build, it will scroll onto the selected match.
+        // built, it will scroll onto the selected match.
         this.pdfViewer.scrollPageIntoView(index + 1);
       }
 


### PR DESCRIPTION
This is a fix for this issue: https://github.com/mozilla/pdf.js/issues/7468 

In the `PDFFindBar_close` function, I added a loop to go through and clear all the highlights from all the pages. I wasn't sure whether to do it directly in that function, or create a `wipeAll` function in `pdf_find_controller.js`, so I just went with the most straightforward option. Let me know if this needs to be reworked in any way or have any feedback!

I also fixed a small grammatical typo in the comments. "Once the textLayer is built" instead of "Once the textLayer is  build"
