### PR TITLE
Use the latest stable Node.js version on Travis CI and enable caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: node_js
 node_js:
-  - "0.12"
-before_install:
+  - node
+cache:
+  directories:
+    - node_modules
+install:
   - npm install -g gulp-cli
+  - npm install
+  - npm update


### PR DESCRIPTION
This patch instructs Travis CI to:
- Use the latest version of Node.js at all times. This makes it possible for us to catch any breakage in newer Node.js versions soon and allows us to make use of the newest functionality of Node.js. Note that the version does not need to be in quotes when it is a string, which is now the case. Previously, Travis CI had an issue with their YAML parser, causing for example 0.10 to be interpreted as 0.1, hence the need for the quotes back then (see https://github.com/travis-ci/travis-ci/issues/977).
- Cache the `node_modules` directory. This prevents downloading and installing the same packages for each build and thus speeds up the build quite a bit (I have seen improvements in build times of 20+ seconds). To make sure that new packages are installed when we add them to `package.json`, we have `npm install`, and to ensure that packages are updated when the version changes in `package.json` we have `npm update`. I have tested that this works as expected. Finally we move the `gulp-cli` installation to the `install` section as that it where it belongs.

Supersedes #7500.
