### PR TITLE
Stop building the AMO extension

### DIFF
--- a/make.js
+++ b/make.js
@@ -659,8 +659,7 @@ target.firefox = function() {
          'chrome',
          'locale',
          'LICENSE'],
-      FIREFOX_EXTENSION_NAME = 'pdf.js.xpi',
-      FIREFOX_AMO_EXTENSION_NAME = 'pdf.js.amo.xpi';
+      FIREFOX_EXTENSION_NAME = 'pdf.js.xpi';
 
   target.locale();
   exec('gulp bundle-firefox');
@@ -753,14 +752,6 @@ target.firefox = function() {
   exec('zip -r ' + FIREFOX_EXTENSION_NAME + ' ' +
        FIREFOX_EXTENSION_FILES.join(' '));
   echo('extension created: ' + FIREFOX_EXTENSION_NAME);
-  cd(ROOT_DIR);
-
-  // Build the amo extension too (remove the updateUrl)
-  cd(FIREFOX_BUILD_DIR);
-  sed('-i', /.*updateURL.*\n/, '', 'install.rdf');
-  exec('zip -r ' + FIREFOX_AMO_EXTENSION_NAME + ' ' +
-       FIREFOX_EXTENSION_FILES.join(' '));
-  echo('AMO extension created: ' + FIREFOX_AMO_EXTENSION_NAME);
   cd(ROOT_DIR);
 };
 


### PR DESCRIPTION
The AMO extension is no longer supported as PDF.js is integrated in Firefox. It was already removed from the bot's preview messages around a year ago and has not been used or updated since.
