### PR TITLE
Bug 1291709 - PdfjsChromeUtils.jsm leaks browser.xul windows.

### DIFF
--- a/extensions/firefox/content/PdfjsChromeUtils.jsm
+++ b/extensions/firefox/content/PdfjsChromeUtils.jsm
@@ -53,7 +53,7 @@ var PdfjsChromeUtils = {
    */
 
   init: function () {
-    this._browsers = new Set();
+    this._browsers = new WeakSet();
     if (!this._ppmm) {
       // global parent process message manager (PPMM)
       this._ppmm = Cc['@mozilla.org/parentprocessmessagemanager;1'].


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1291709
