### PR TITLE
Add validation of the `rotation` argument passed to `set pagesRotation` in `PDFViewer`

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -259,8 +259,14 @@ var PDFViewer = (function pdfViewer() {
      * @param {number} rotation - The rotation of the pages (0, 90, 180, 270).
      */
     set pagesRotation(rotation) {
+      if (!(typeof rotation === 'number' && rotation % 90 === 0)) {
+        throw new Error('Invalid pages rotation angle.');
+      }
       this._pagesRotation = rotation;
 
+      if (!this.pdfDocument) {
+        return;
+      }
       for (var i = 0, l = this._pages.length; i < l; i++) {
         var pageView = this._pages[i];
         pageView.update(pageView.scale, rotation);


### PR DESCRIPTION
_Similar to the validation done when setting page/scale._
