### PR TITLE
Remove an obsolete comment for `onAfterDraw` in pdf_viewer.js

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -323,7 +323,6 @@ var PDFViewer = (function pdfViewer() {
           // rendering.
           self._buffer.push(this);
         };
-        // when page is painted, using the image as thumbnail base
         pageView.onAfterDraw = function pdfViewLoadOnAfterDraw() {
           if (!isOnePageRenderedResolved) {
             isOnePageRenderedResolved = true;


### PR DESCRIPTION
With the viewer code now being split into various components/files, having an obsolete comment in `PDFViewer` that references thumbnails despite there being no other mentions of them in the entire file seems strange.

_Note:_ This comment is simply a left-over from older versions of PDF.js, where the _entire_ default viewer code was placed in just one file (and where we unconditionally created thumbnails, regardless whether they were visible or not).
