### PR TITLE
Add a unit-test to check that `ProblematicCharRanges` contains valid entries

### DIFF
--- a/test/unit/fonts_spec.js
+++ b/test/unit/fonts_spec.js
@@ -1,0 +1,13 @@
+/* globals describe, it, expect, beforeAll, afterAll,
+           checkProblematicCharRanges */
+
+'use strict';
+
+describe('Fonts', function() {
+  it('checkProblematicCharRanges', function() {
+    var EXPECTED_PERCENTAGE = 45;
+    var result = checkProblematicCharRanges();
+
+    expect(result.percentage).toBeLessThan(EXPECTED_PERCENTAGE);
+  });
+});

--- a/test/unit/unit_test.html
+++ b/test/unit/unit_test.html
@@ -15,6 +15,7 @@
   <script src="primitives_spec.js"></script>
   <script src="cff_parser_spec.js"></script>
   <script src="type1_parser_spec.js"></script>
+  <script src="fonts_spec.js"></script>
   <script src="unicode_spec.js"></script>
   <script src="function_spec.js"></script>
   <script src="crypto_spec.js"></script>


### PR DESCRIPTION
When adding new entries to `ProblematicCharRanges`, you have to be careful to not make any mistakes since that could cause glyph mapping issues.
Currently the existing reference tests should probably help catch any errors, but based on experience I think that having a unit-test which specifically checks `ProblematicCharRanges` would be both helpful and timesaving when modifying/reviewing changes to this code.

Hence this patch which adds a function (and unit-test) that is used to validate the entries in `ProblematicCharRanges`, and also checks that we don't accidentally add more character ranges than the Private Use Area can actually contain.
The way that the validation code, and thus the unit-test, is implemented also means that we have an easy way to tell how much of the Private Use Area is potentially utilized by re-mapped characters.

_Note:_ I suppose that the test function could also have been placed inside an [IIFE](https://en.wikipedia.org/wiki/Immediately-invoked_function_expression) that is only invoked in `!PRODUCTION` mode, but having a unit-test seemed like a good approach to me.
