### PR TITLE
Avoid window.print in a microtask

### DIFF
--- a/web/mozPrintCallback_polyfill.js
+++ b/web/mozPrintCallback_polyfill.js
@@ -76,8 +76,16 @@
       }
     } else {
       renderProgress();
-      print.call(window);
-      setTimeout(abort, 20); // Tidy-up
+      // Push window.print in the macrotask queue to avoid being affected by
+      // the deprecation of running print() code in a microtask, see
+      // https://github.com/mozilla/pdf.js/issues/7547.
+      setTimeout(function() {
+        if (!canvases) {
+          return; // Print task cancelled by user.
+        }
+        print.call(window);
+        setTimeout(abort, 20); // Tidy-up
+      }, 0);
     }
   }
 


### PR DESCRIPTION
Fixes #7547.

The mozPrintCallback polyfill is not used in Firefox, so if Firefox follows in deprecating window.print and other sync APIs in a microtask, a similar work-around needs to be applied to other `window.print` calls..
