### PR TITLE
Support for Content-Disposition

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -349,22 +349,23 @@ var PDFDocument = (function PDFDocumentClosure() {
   var EMPTY_FINGERPRINT = '\x00\x00\x00\x00\x00\x00\x00' +
     '\x00\x00\x00\x00\x00\x00\x00\x00\x00';
 
-  function PDFDocument(pdfManager, arg, password) {
+  function PDFDocument(pdfManager, arg, password, filename) {
     if (isStream(arg)) {
-      init.call(this, pdfManager, arg, password);
+      init.call(this, pdfManager, arg, password, filename);
     } else if (isArrayBuffer(arg)) {
-      init.call(this, pdfManager, new Stream(arg), password);
+      init.call(this, pdfManager, new Stream(arg), password, filename);
     } else {
       error('PDFDocument: Unknown argument type');
     }
   }
 
-  function init(pdfManager, stream, password) {
+  function init(pdfManager, stream, password, filename) {
     assert(stream.length > 0, 'stream must have data');
     this.pdfManager = pdfManager;
     this.stream = stream;
     var xref = new XRef(this.stream, password, pdfManager);
     this.xref = xref;
+    this.filename = filename;
   }
 
   function find(stream, needle, limit, backwards) {

--- a/src/core/network.js
+++ b/src/core/network.js
@@ -308,8 +308,94 @@ var NetworkManager = (function NetworkManagerClosure() {
   var assert = sharedUtil.assert;
   var createPromiseCapability = sharedUtil.createPromiseCapability;
   var isInt = sharedUtil.isInt;
+  var stringToUTF8String = sharedUtil.stringToUTF8String;
   var MissingPDFException = sharedUtil.MissingPDFException;
   var UnexpectedResponseException = sharedUtil.UnexpectedResponseException;
+  var InvalidHeaderException = sharedUtil.InvalidHeaderException;
+
+  /**
+   * RegExp for various RFC 6266 grammar
+   *
+   * disposition-type = "inline" | "attachment" | disp-ext-type
+   * disp-ext-type    = token
+   * disposition-parm = filename-parm | disp-ext-parm
+   * filename-parm    = "filename" "=" value
+   *                  | "filename*" "=" ext-value
+   * disp-ext-parm    = token "=" value
+   *                  | ext-token "=" ext-value
+   * ext-token        = <the characters in token, followed by "*">
+   */
+  var DISPOSITION_TYPE_REGEXP = /^([!#$%&'\*\+\-\.0-9A-Z\^_`a-z\|~]+) *(?:$|;)/;
+
+  /**
+   * RegExp for various RFC 2616 grammar
+   *
+   * parameter     = token "=" ( token | quoted-string )
+   * token         = 1*<any CHAR except CTLs or separators>
+   * separators    = "(" | ")" | "<" | ">" | "@"
+   *               | "," | ";" | ":" | "\" | <">
+   *               | "/" | "[" | "]" | "?" | "="
+   *               | "{" | "}" | SP | HT
+   * quoted-string = ( <"> *(qdtext | quoted-pair ) <"> )
+   * qdtext        = <any TEXT except <">>
+   * quoted-pair   = "\" CHAR
+   * CHAR          = <any US-ASCII character (octets 0 - 127)>
+   * TEXT          = <any OCTET except CTLs, but including LWS>
+   * LWS           = [CRLF] 1*( SP | HT )
+   * CRLF          = CR LF
+   * CR            = <US-ASCII CR, carriage return (13)>
+   * LF            = <US-ASCII LF, linefeed (10)>
+   * SP            = <US-ASCII SP, space (32)>
+   * HT            = <US-ASCII HT, horizontal-tab (9)>
+   * CTL           = <any US-ASCII control character (octets 0 - 31) and
+   *                 DEL (127)>
+   * OCTET         = <any 8-bit sequence of data>
+   */
+  var PARAM_REGEXP = new RegExp(
+      /; *([!#$%&'\*\+\-\.0-9A-Z\^_`a-z\|~]+) *= */.source + '(' +
+      /"(?:[ !\x23-\x5b\x5d-\x7e\x80-\xff]|\\[\x20-\x7e])*"/.source + '|' +
+      /([!#$%&'\*\+\-\.0-9A-Z\^_`a-z\|~]+)/.source + ')', 'g');
+
+  /**
+   * RegExp for various RFC 5987 grammar
+   *
+   * ext-value     = charset  "'" [ language ] "'" value-chars
+   * charset       = "UTF-8" / "ISO-8859-1" / mime-charset
+   * mime-charset  = 1*mime-charsetc
+   * mime-charsetc = ALPHA / DIGIT
+   *               / "!" / "#" / "$" / "%" / "&"
+   *               / "+" / "-" / "^" / "_" / "`"
+   *               / "{" / "}" / "~"
+   * language      = ( 2*3ALPHA [ extlang ] )
+   *               / 4ALPHA
+   *               / 5*8ALPHA
+   * extlang       = *3( "-" 3ALPHA )
+   * value-chars   = *( pct-encoded / attr-char )
+   * pct-encoded   = "%" HEXDIG HEXDIG
+   * attr-char     = ALPHA / DIGIT
+   *               / "!" / "#" / "$" / "&" / "+" / "-" / "."
+   *               / "^" / "_" / "`" / "|" / "~"
+   */
+
+  var EXT_VALUE_REGEXP = new RegExp(
+      /^([A-Za-z0-9!#$%&+\-^_`{}~]+)/.source + '\'' +
+      /(?:[A-Za-z]{2,3}(?:-[A-Za-z]{3}){0,3}|[A-Za-z]{4,8}|)/.source + '\'' +
+      /((?:%[0-9A-Fa-f]{2}|[A-Za-z0-9!#$&+\-\.^_`|~])+)/.source + '$');
+
+  var HEX_ESCAPE_REPLACE_REGEXP = /%([0-9A-Fa-f]{2})/g;
+
+  /**
+   * RegExp to match non-latin1 characters.
+   */
+  var NON_LATIN1_REGEXP = /[^\x20-\x7e\xa0-\xff]/g;
+
+  /**
+   * RegExp to match quoted-pair in RFC 2616
+   *
+   * quoted-pair = "\" CHAR
+   * CHAR        = <any US-ASCII character (octets 0 - 127)>
+   */
+  var QESC_REGEXP = /\\([\u0000-\u007f])/g;
 
   /** @implements {IPDFStream} */
   function PDFNetworkStream(options) {
@@ -393,6 +479,80 @@ var NetworkManager = (function NetworkManagerClosure() {
     this.onProgress = null;
   }
 
+  /**
+   * Percent decode a single character.
+   *
+   * @param {string} str
+   * @param {string} hex
+   * @return {string}
+   * @api private
+   */
+
+  function pdecode(str, hex) {
+    return String.fromCharCode(parseInt(hex, 16));
+  }
+
+  /**
+   * Get ISO-8859-1 version of string.
+   *
+   * @param {string} val
+   * @return {string}
+   * @api private
+   */
+
+  function getlatin1(val) {
+    // simple Unicode -> ISO-8859-1 transformation
+    return String(val).replace(NON_LATIN1_REGEXP, '?');
+  }
+
+  function getUtf8(binary) {
+    try {
+      return stringToUTF8String(binary);
+    } catch (error) {
+      if (error instanceof URIError) {
+        throw new InvalidHeaderException('invalid extended field value');
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Decode a RFC 6987 field value (gracefully).
+   *
+   * @param {string} str
+   * @return {string}
+   * @api private
+   */
+  function decodefield(str) {
+    var match = EXT_VALUE_REGEXP.exec(str);
+
+    if (!match) {
+      throw new InvalidHeaderException('invalid extended field value');
+    }
+
+    var charset = match[1].toLowerCase();
+    var encoded = match[2];
+    var value;
+
+    // to binary string
+    var binary = encoded.replace(HEX_ESCAPE_REPLACE_REGEXP, pdecode);
+
+    switch (charset) {
+      case 'iso-8859-1':
+        value = getlatin1(binary);
+        break;
+      case 'utf-8':
+        value = getUtf8(binary);
+        break;
+      default:
+        throw new
+          InvalidHeaderException('unsupported charset in extended field');
+    }
+
+    return value;
+  }
+
   PDFNetworkStreamFullRequestReader.prototype = {
     _validateRangeRequestCapabilities: function
         PDFNetworkStreamFullRequestReader_validateRangeRequestCapabilities() {
@@ -432,6 +592,104 @@ var NetworkManager = (function NetworkManagerClosure() {
       return true;
     },
 
+    _parseContentDisposition: function
+      PDFNetworkStreamFullRequestReader_parseContentDisposition(string) {
+        if (!string || typeof string !== 'string') {
+          throw new InvalidHeaderException('argument string is required');
+        }
+
+        var contentDisposition = {};
+        var match = DISPOSITION_TYPE_REGEXP.exec(string);
+        if (!match) {
+          throw new InvalidHeaderException('invalid type format');
+        }
+
+        // normalize type
+        var index = match[0].length;
+        contentDisposition.type = match[1].toLowerCase();
+
+        var key;
+        var names = [];
+        var params = {};
+        var value;
+
+        // calculate index to start at
+        index = PARAM_REGEXP.lastIndex = match[0].substr(-1) === ';' ?
+          index - 1 : index;
+
+        // match parameters
+        while ((match = PARAM_REGEXP.exec(string))) {
+          if (match.index !== index) {
+            throw new InvalidHeaderException('invalid parameter format');
+          }
+
+          index += match[0].length;
+          key = match[1].toLowerCase();
+          value = match[2];
+
+          if (names.indexOf(key) !== -1) {
+            throw new InvalidHeaderException('invalid duplicate parameter');
+          }
+
+          names.push(key);
+
+          if (key.indexOf('*') + 1 === key.length) {
+            // decode extended value
+            key = key.slice(0, -1);
+            value = decodefield(value);
+
+            // overwrite existing value
+            params[key] = value;
+            continue;
+          }
+
+          if (typeof params[key] === 'string') {
+            continue;
+          }
+
+          if (value[0] === '"') {
+            // remove quotes and escapes
+            value = value
+              .substr(1, value.length - 2)
+              .replace(QESC_REGEXP, '$1');
+          }
+
+          params[key] = value;
+        }
+
+        if (index !== -1 && index !== string.length) {
+          throw new InvalidHeaderException('invalid parameter format');
+        }
+
+        contentDisposition.parameters = params;
+        return contentDisposition;
+    },
+
+    _parseHeaders: function PDFNetworkStreamFullRequestReader_parseHeaders() {
+      try {
+        var headers = Object.create(null);
+        var networkManager = this._manager;
+        var fullRequestXhrId = this._fullRequestId;
+        var fullRequestXhr = networkManager.getRequestXhr(fullRequestXhrId);
+        var contentDispositionString =
+          fullRequestXhr.getResponseHeader('Content-Disposition');
+
+        if (contentDispositionString && contentDispositionString.length > 0) {
+          headers.contentDisposition =
+            this._parseContentDisposition(contentDispositionString);
+        }
+
+        return headers;
+      } catch(err) {
+        if (err instanceof InvalidHeaderException) {
+          // Ignore invalid headers
+          return headers;
+        } else {
+          throw err;
+        }
+      }
+    },
+
     _onHeadersReceived:
         function PDFNetworkStreamFullRequestReader_onHeadersReceived() {
 
@@ -441,6 +699,8 @@ var NetworkManager = (function NetworkManagerClosure() {
 
       var networkManager = this._manager;
       var fullRequestXhrId = this._fullRequestId;
+      var headers = this._parseHeaders();
+
       if (networkManager.isStreamingRequest(fullRequestXhrId)) {
         // We can continue fetching when progressive loading is enabled,
         // and we don't need the autoFetch feature.
@@ -454,7 +714,7 @@ var NetworkManager = (function NetworkManagerClosure() {
         networkManager.abortRequest(fullRequestXhrId);
       }
 
-      this._headersReceivedCapability.resolve();
+      this._headersReceivedCapability.resolve(headers);
     },
 
     _onProgressiveData:

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -49,6 +49,10 @@ var BasePdfManager = (function BasePdfManagerClosure() {
       return this._docId;
     },
 
+    get filename() {
+      return this.pdfDocument.filename;
+    },
+
     onLoadedStream: function BasePdfManager_onLoadedStream() {
       throw new NotImplementedException();
     },
@@ -110,11 +114,11 @@ var BasePdfManager = (function BasePdfManagerClosure() {
 })();
 
 var LocalPdfManager = (function LocalPdfManagerClosure() {
-  function LocalPdfManager(docId, data, password, evaluatorOptions) {
+  function LocalPdfManager(docId, data, password, evaluatorOptions, filename) {
     this._docId = docId;
     this.evaluatorOptions = evaluatorOptions;
     var stream = new Stream(data);
-    this.pdfDocument = new PDFDocument(this, stream, password);
+    this.pdfDocument = new PDFDocument(this, stream, password, filename);
     this._loadedStreamCapability = createPromiseCapability();
     this._loadedStreamCapability.resolve(stream);
   }
@@ -172,7 +176,7 @@ var NetworkPdfManager = (function NetworkPdfManagerClosure() {
     };
     this.streamManager = new ChunkedStreamManager(pdfNetworkStream, params);
     this.pdfDocument = new PDFDocument(this, this.streamManager.getStream(),
-                                       args.password);
+                                       args.password, args.filename);
   }
 
   Util.inherit(NetworkPdfManager, BasePdfManager, {

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -474,6 +474,7 @@ var WorkerMessageHandler = {
     // This context is actually holds references on pdfManager and handler,
     // until the latter is destroyed.
     var pdfManager;
+    var filename;
     var terminated = false;
     var cancelXHRs = null;
     var WorkerTasks = [];
@@ -515,6 +516,7 @@ var WorkerMessageHandler = {
             numPages: results[0],
             fingerprint: results[1],
             encrypted: !!results[2],
+            filename: pdfManager.filename
           };
           loadDocumentCapability.resolve(doc);
         },
@@ -565,7 +567,7 @@ var WorkerMessageHandler = {
       }
 
       var fullRequest = pdfStream.getFullReader();
-      fullRequest.headersReady.then(function () {
+      fullRequest.headersReady.then(function (headers) {
         if (!fullRequest.isStreamingSupported ||
             !fullRequest.isRangeSupported) {
           // If stream or range are disabled, it's our only way to report
@@ -576,6 +578,10 @@ var WorkerMessageHandler = {
               total: evt.total
             });
           };
+        }
+
+        if (headers && headers.contentDisposition) {
+          filename = headers.contentDisposition.parameters.filename;
         }
 
         if (!fullRequest.isRangeSupported) {
@@ -591,7 +597,8 @@ var WorkerMessageHandler = {
           password: source.password,
           length: fullRequest.contentLength,
           disableAutoFetch: disableAutoFetch,
-          rangeChunkSize: source.rangeChunkSize
+          rangeChunkSize: source.rangeChunkSize,
+          filename: filename
         }, evaluatorOptions);
         pdfManagerCapability.resolve(pdfManager);
         cancelXHRs = null;
@@ -609,7 +616,7 @@ var WorkerMessageHandler = {
         // the data is array, instantiating directly from it
         try {
           pdfManager = new LocalPdfManager(docId, pdfFile, source.password,
-                                           evaluatorOptions);
+                                           evaluatorOptions, filename);
           pdfManagerCapability.resolve(pdfManager);
         } catch (ex) {
           pdfManagerCapability.reject(ex);

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -466,6 +466,14 @@ var PDFDocumentProxy = (function PDFDocumentProxyClosure() {
       return this.pdfInfo.numPages;
     },
     /**
+     * @return {string} File name of the pdf if available. If the source
+     *   is a URL, file name will be extracted from content-disposition
+     *   header.
+     */
+    get filename() {
+      return this.pdfInfo.filename;
+    },
+    /**
      * @return {string} A unique ID to identify a PDF. Not guaranteed to be
      * unique.
      */

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -423,6 +423,19 @@ var UnexpectedResponseException =
   return UnexpectedResponseException;
 })();
 
+var InvalidHeaderException = (function InvalidHeaderExceptionClosure() {
+  function InvalidHeaderException(msg) {
+    this.name = 'InvalidHeaderException';
+    this.message = msg;
+  }
+
+  InvalidHeaderException.prototype = new Error();
+  InvalidHeaderException.constructor = InvalidHeaderException;
+
+  return InvalidHeaderException;
+})();
+
+
 var NotImplementedException = (function NotImplementedExceptionClosure() {
   function NotImplementedException(msg) {
     this.message = msg;
@@ -2324,6 +2337,7 @@ exports.StatTimer = StatTimer;
 exports.StreamType = StreamType;
 exports.TextRenderingMode = TextRenderingMode;
 exports.UnexpectedResponseException = UnexpectedResponseException;
+exports.InvalidHeaderException = InvalidHeaderException;
 exports.UnknownErrorException = UnknownErrorException;
 exports.Util = Util;
 exports.XRefParseException = XRefParseException;

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -325,6 +325,18 @@ describe('api', function() {
     it('gets number of pages', function() {
       expect(doc.numPages).toEqual(3);
     });
+    it('gets filename', function() {
+      expect(doc.filename).toEqual('basicapi.pdf');
+    });
+    it('gets filename for a document with range fetch', function(done) {
+      // A larger file means the worker will use the range request
+      var url2 = new URL('../pdfs/aboutstacks.pdf', window.location).href;
+      var loadingTask2 = PDFJS.getDocument(url2);
+      loadingTask2.promise.then(function (pdfDoc) {
+        expect(pdfDoc.filename).toEqual('aboutstacks.pdf');
+        done();
+      });
+    });
     it('gets fingerprint', function() {
       var fingerprint = doc.fingerprint;
       expect(typeof fingerprint).toEqual('string');

--- a/test/unit/network_spec.js
+++ b/test/unit/network_spec.js
@@ -1,4 +1,5 @@
-/* globals expect, it, describe, PDFNetworkStream */
+/* globals expect, it, describe, PDFNetworkStream, beforeAll,
+          InvalidHeaderException */
 
 'use strict';
 
@@ -159,6 +160,992 @@ describe('network', function() {
       done();
     }).catch(function (reason) {
       done.fail(reason);
+    });
+  });
+
+  describe('contentDisposition', function() {
+    var parseContentDisposition;
+    beforeAll(function() {
+      var stream = new PDFNetworkStream({
+        source: {
+          url: pdf1,
+          rangeChunkSize: 65536,
+          disableStream: true,
+        },
+        disableRange: true
+      });
+
+      var fullReader = stream.getFullReader();
+      parseContentDisposition =
+        fullReader._parseContentDisposition;
+    });
+
+    it('should require string', function () {
+      expect(parseContentDisposition.bind(null))
+        .toThrowError(InvalidHeaderException, /argument string.*required/);
+    });
+
+    it('should reject non-strings', function () {
+      expect(parseContentDisposition.bind(null, 42))
+        .toThrowError(InvalidHeaderException, /argument string.*required/);
+    });
+
+    describe('with only type', function () {
+      it('should reject quoted value', function () {
+        expect(parseContentDisposition.bind(null, '"attachment"'))
+          .toThrowError(InvalidHeaderException, /invalid type format/);
+      });
+
+      it('should reject trailing semicolon', function () {
+        expect(parseContentDisposition.bind(null, 'attachment;'))
+          .toThrowError(InvalidHeaderException, /invalid.*format/);
+      });
+
+      it('should parse "attachment"', function () {
+        expect(parseContentDisposition('attachment')).toEqual({
+          type: 'attachment',
+          parameters: {}
+        });
+      });
+
+      it('should parse "inline"', function () {
+        expect(parseContentDisposition('inline')).toEqual({
+          type: 'inline',
+          parameters: {}
+        });
+      });
+
+      it('should parse "form-data"', function () {
+        expect(parseContentDisposition('form-data')).toEqual({
+          type: 'form-data',
+          parameters: {}
+        });
+      });
+
+      it('should parse with trailing LWS', function () {
+        expect(parseContentDisposition('attachment   ')).toEqual({
+          type: 'attachment',
+          parameters: {}
+        });
+      });
+
+      it('should normalize to lower-case', function () {
+        expect(parseContentDisposition('ATTACHMENT')).toEqual({
+          type: 'attachment',
+          parameters: {}
+        });
+      });
+    });
+
+    describe('with parameters', function () {
+      it('should reject trailing semicolon', function () {
+        expect(parseContentDisposition.bind(null,
+              'attachment; filename="rates.pdf";'))
+          .toThrowError(InvalidHeaderException, /invalid parameter format/);
+      });
+
+      it('should reject invalid parameter name', function () {
+        expect(parseContentDisposition.bind(null,
+              'attachment; filename@="rates.pdf"'))
+          .toThrowError(InvalidHeaderException, /invalid parameter format/);
+      });
+
+      it('should reject missing parameter value', function () {
+        expect(parseContentDisposition.bind(null, 'attachment; filename='))
+          .toThrowError(InvalidHeaderException, /invalid parameter format/);
+      });
+
+      it('should reject invalid parameter value', function () {
+        expect(parseContentDisposition.bind(null,
+              'attachment; filename=trolly,trains'))
+          .toThrowError(InvalidHeaderException, /invalid parameter format/);
+      });
+
+      it('should reject invalid parameters', function () {
+        expect(parseContentDisposition.bind(null,
+              'attachment; filename=total/; foo=bar'))
+          .toThrowError(InvalidHeaderException, /invalid parameter format/);
+      });
+
+      it('should reject duplicate parameters', function () {
+        expect(parseContentDisposition.bind(null,
+              'attachment; filename=foo; filename=bar'))
+          .toThrowError(InvalidHeaderException, /invalid duplicate parameter/);
+      });
+
+      it('should reject missing type', function () {
+        expect(parseContentDisposition.bind(null, 'filename="plans.pdf"'))
+          .toThrowError(InvalidHeaderException, /invalid type format/);
+        expect(parseContentDisposition.bind(null, '; filename="plans.pdf"'))
+          .toThrowError(InvalidHeaderException, /invalid type format/);
+      });
+
+      it('should lower-case parameter name', function () {
+        expect(parseContentDisposition('attachment; FILENAME="plans.pdf"'))
+          .toEqual({
+            type: 'attachment',
+            parameters: { filename: 'plans.pdf' }
+          });
+      });
+
+      it('should parse quoted parameter value', function () {
+        expect(parseContentDisposition('attachment; filename="plans.pdf"'))
+          .toEqual({
+            type: 'attachment',
+            parameters: { filename: 'plans.pdf' }
+          });
+      });
+
+      it('should parse & unescape quoted value', function () {
+        expect(parseContentDisposition(
+              'attachment; filename="the \\"plans\\".pdf"'))
+          .toEqual({
+            type: 'attachment',
+            parameters: { filename: 'the "plans".pdf' }
+          });
+      });
+
+      it('should include all parameters', function () {
+        expect(parseContentDisposition(
+              'attachment; filename="plans.pdf"; foo=bar'))
+          .toEqual({
+            type: 'attachment',
+            parameters: { filename: 'plans.pdf', foo: 'bar' }
+          });
+      });
+
+      it('should parse token filename', function () {
+        expect(parseContentDisposition(
+              'attachment; filename=plans.pdf'))
+          .toEqual({
+            type: 'attachment',
+            parameters: { filename: 'plans.pdf' }
+          });
+      });
+
+      it('should parse ISO-8859-1 filename', function () {
+        expect(parseContentDisposition(
+              'attachment; filename="£ rates.pdf"'))
+          .toEqual({
+            type: 'attachment',
+            parameters: { filename: '£ rates.pdf' }
+          });
+      });
+    });
+
+    describe('with extended parameters', function () {
+      it('should reject quoted extended parameter value', function () {
+        expect(parseContentDisposition.bind(null,
+              'attachment; filename*="UTF-8\'\'%E2%82%AC%20rates.pdf"'))
+          .toThrowError(InvalidHeaderException, /invalid extended.*value/);
+      });
+
+      it('should parse UTF-8 extended parameter value', function () {
+        expect(parseContentDisposition(
+              'attachment; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf'))
+          .toEqual({
+            type: 'attachment',
+            parameters: { 'filename': '€ rates.pdf' }
+          });
+      });
+
+      it('should parse UTF-8 extended parameter value', function () {
+        expect(parseContentDisposition.bind(null,
+              'attachment; filename*=UTF-8\'\'%E4%20rates.pdf'))
+          .toThrowError(InvalidHeaderException, /invalid extended.*value/);
+      });
+
+      it('should parse ISO-8859-1 extended parameter value', function () {
+        expect(parseContentDisposition(
+              'attachment; filename*=ISO-8859-1\'\'%A3%20rates.pdf'))
+          .toEqual({
+            type: 'attachment',
+            parameters: { 'filename': '£ rates.pdf' }
+          });
+        expect(parseContentDisposition(
+              'attachment; filename*=ISO-8859-1\'\'%82%20rates.pdf'))
+          .toEqual({
+            type: 'attachment',
+            parameters: { 'filename': '? rates.pdf' }
+          });
+      });
+
+      it('should not be case-sensitive for charser', function () {
+        expect(parseContentDisposition(
+              'attachment; filename*=utf-8\'\'%E2%82%AC%20rates.pdf'))
+          .toEqual({
+            type: 'attachment',
+            parameters: { 'filename': '€ rates.pdf' }
+          });
+      });
+
+      it('should reject unsupported charset', function () {
+        expect(parseContentDisposition.bind(null,
+              'attachment; filename*=ISO-8859-2\'\'%A4%20rates.pdf'))
+          .toThrowError(InvalidHeaderException, /unsupported charset/);
+      });
+
+      it('should parse with embedded language', function () {
+        expect(parseContentDisposition(
+              'attachment; filename*=UTF-8\'en\'%E2%82%AC%20rates.pdf'))
+          .toEqual({
+            type: 'attachment',
+            parameters: { 'filename': '€ rates.pdf' }
+          });
+      });
+
+      it('should prefer extended parameter value', function () {
+        expect(parseContentDisposition(
+              'attachment; filename="EURO rates.pdf"; ' +
+              'filename*=UTF-8\'\'%E2%82%AC%20rates.pdf'))
+          .toEqual({
+            type: 'attachment',
+            parameters: { 'filename': '€ rates.pdf' }
+          });
+        expect(parseContentDisposition(
+              'attachment; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf; ' +
+              'filename="EURO rates.pdf"'))
+          .toEqual({
+            type: 'attachment',
+            parameters: { 'filename': '€ rates.pdf' }
+          });
+      });
+    });
+
+    describe('from TC 2231', function () {
+      describe('Disposition-Type Inline', function () {
+        it('should parse "inline"', function () {
+          expect(parseContentDisposition('inline')).toEqual({
+            type: 'inline',
+            parameters: {}
+          });
+        });
+
+        it('should reject ""inline""', function () {
+          expect(parseContentDisposition.bind(null, '"inline"'))
+            .toThrowError(InvalidHeaderException, /invalid type format/);
+        });
+
+        it('should parse "inline; filename="foo.html""', function () {
+          expect(parseContentDisposition('inline; filename="foo.html"'))
+            .toEqual({
+              type: 'inline',
+              parameters: { filename: 'foo.html' }
+            });
+        });
+
+        it('should parse "inline; filename="Not an attachment!""', function () {
+          expect(parseContentDisposition(
+                'inline; filename="Not an attachment!"'))
+            .toEqual({
+              type: 'inline',
+              parameters: { filename: 'Not an attachment!' }
+            });
+        });
+
+        it('should parse "inline; filename="foo.pdf""', function () {
+          expect(parseContentDisposition('inline; filename="foo.pdf"'))
+            .toEqual({
+              type: 'inline',
+              parameters: { filename: 'foo.pdf' }
+            });
+        });
+      });
+
+      describe('Disposition-Type Attachment', function () {
+        it('should parse "attachment"', function () {
+          expect(parseContentDisposition('attachment')).toEqual({
+            type: 'attachment',
+            parameters: {}
+          });
+        });
+
+        it('should reject ""attachment""', function () {
+          expect(parseContentDisposition.bind(null, '"attachment"'))
+            .toThrowError(InvalidHeaderException, /invalid type format/);
+        });
+
+        it('should parse "ATTACHMENT"', function () {
+          expect(parseContentDisposition('ATTACHMENT')).toEqual({
+            type: 'attachment',
+            parameters: {}
+          });
+        });
+
+        it('should parse "attachment; filename="foo.html""', function () {
+          expect(parseContentDisposition('attachment; filename="foo.html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo.html' }
+            });
+        });
+
+        it('should parse "attachment; filename="0000000000111111111122222""',
+            function () {
+          expect(parseContentDisposition(
+                'attachment; filename="0000000000111111111122222"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: '0000000000111111111122222' }
+            });
+        });
+
+        it('should parse "attachment; ' +
+            'filename="00000000001111111111222222222233333""', function () {
+          expect(parseContentDisposition(
+                'attachment; filename="00000000001111111111222222222233333"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: '00000000001111111111222222222233333' }
+            });
+        });
+
+        it('should parse "attachment; filename="f\\oo.html""', function () {
+          expect(parseContentDisposition('attachment; filename="f\\oo.html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo.html' }
+            });
+        });
+
+        it('should parse "attachment; filename="\\"quoting\\" tested.html""',
+            function () {
+          expect(parseContentDisposition(
+              'attachment; filename="\\"quoting\\" tested.html"')) .toEqual({
+              type: 'attachment',
+              parameters: { filename: '"quoting" tested.html' }
+            });
+        });
+
+        it('should parse "attachment; filename="Here\'s a semicolon;.html""',
+            function () {
+          expect(parseContentDisposition(
+                'attachment; filename="Here\'s a semicolon;.html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'Here\'s a semicolon;.html' }
+            });
+        });
+
+        it('should parse "attachment; foo="bar"; filename="foo.html""',
+            function () {
+          expect(parseContentDisposition(
+                'attachment; foo="bar"; filename="foo.html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo.html', foo: 'bar' }
+            });
+        });
+
+        it('should parse "attachment; foo="\\"\\\\";filename="foo.html""',
+            function () {
+          expect(parseContentDisposition(
+                'attachment; foo="\\"\\\\";filename="foo.html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo.html', foo: '"\\' }
+            });
+        });
+
+        it('should parse "attachment; FILENAME="foo.html""', function () {
+          expect(parseContentDisposition('attachment; FILENAME="foo.html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo.html' }
+            });
+        });
+
+        it('should parse "attachment; filename=foo.html"', function () {
+          expect(parseContentDisposition('attachment; filename=foo.html'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo.html' }
+            });
+        });
+
+        it('should reject "attachment; filename=foo,bar.html"', function () {
+          expect(parseContentDisposition.bind(null,
+                'attachment; filename=foo,bar.html'))
+            .toThrowError(InvalidHeaderException, /invalid parameter format/);
+        });
+
+        it('should reject "attachment; filename=foo.html ;"', function () {
+          expect(parseContentDisposition.bind(null,
+                'attachment; filename=foo.html ;'))
+            .toThrowError(InvalidHeaderException, /invalid parameter format/);
+        });
+
+        it('should reject "attachment; ;filename=foo"', function () {
+          expect(parseContentDisposition.bind(null,
+                'attachment; ;filename=foo'))
+            .toThrowError(InvalidHeaderException, /invalid parameter format/);
+        });
+
+        it('should reject "attachment; filename=foo bar.html"', function () {
+          expect(parseContentDisposition.bind(null,
+                'attachment; filename=foo bar.html'))
+            .toThrowError(InvalidHeaderException, /invalid parameter format/);
+        });
+
+        it('should parse "attachment; filename=\'foo.bar\'', function () {
+          expect(parseContentDisposition('attachment; filename=\'foo.bar\''))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: '\'foo.bar\'' }
+            });
+        });
+
+        it('should parse "attachment; filename="foo-ä.html""', function () {
+          expect(parseContentDisposition('attachment; filename="foo-ä.html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo-ä.html' }
+            });
+        });
+
+        it('should parse "attachment; filename="foo-Ã¤.html""', function () {
+          expect(parseContentDisposition(
+                'attachment; filename="foo-Ã¤.html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo-Ã¤.html' }
+            });
+        });
+
+        it('should parse "attachment; filename="foo-%41.html""', function () {
+          expect(parseContentDisposition('attachment; filename="foo-%41.html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo-%41.html' }
+            });
+        });
+
+        it('should parse "attachment; filename="50%.html""', function () {
+          expect(parseContentDisposition('attachment; filename="50%.html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: '50%.html' }
+            });
+        });
+
+        it('should parse "attachment; filename="foo-%\\41.html""', function () {
+          expect(parseContentDisposition(
+                'attachment; filename="foo-%\\41.html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo-%41.html' }
+            });
+        });
+
+        it('should parse "attachment; name="foo-%41.html""', function () {
+          expect(parseContentDisposition('attachment; name="foo-%41.html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { name: 'foo-%41.html' }
+            });
+        });
+
+        it('should parse "attachment; filename="ä-%41.html""', function () {
+          expect(parseContentDisposition('attachment; filename="ä-%41.html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'ä-%41.html' }
+            });
+        });
+
+        it('should parse "attachment; filename="foo-%c3%a4-%e2%82%ac.html""',
+            function () {
+          expect(parseContentDisposition(
+                'attachment; filename="foo-%c3%a4-%e2%82%ac.html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo-%c3%a4-%e2%82%ac.html' }
+            });
+        });
+
+        it('should parse "attachment; filename ="foo.html""', function () {
+          expect(parseContentDisposition('attachment; filename ="foo.html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo.html' }
+            });
+        });
+
+        it('should reject "attachment; ' +
+            'filename="foo.html"; filename="bar.html"', function () {
+          expect(parseContentDisposition.bind(null,
+                'attachment; filename="foo.html"; filename="bar.html"'))
+            .toThrowError(InvalidHeaderException,
+                /invalid duplicate parameter/);
+        });
+
+        it('should reject "attachment; filename=foo[1](2).html"', function () {
+          expect(parseContentDisposition.bind(null,
+                'attachment; filename=foo[1](2).html'))
+            .toThrowError(InvalidHeaderException, /invalid parameter format/);
+        });
+
+        it('should reject "attachment; filename=foo-ä.html"', function () {
+          expect(parseContentDisposition.bind(null,
+                'attachment; filename=foo-ä.html'))
+            .toThrowError(InvalidHeaderException, /invalid parameter format/);
+        });
+
+        it('should reject "attachment; filename=foo-Ã¤.html"', function () {
+          expect(parseContentDisposition.bind(null,
+                'attachment; filename=foo-Ã¤.html'))
+            .toThrowError(InvalidHeaderException, /invalid parameter format/);
+        });
+
+        it('should reject "filename=foo.html"', function () {
+          expect(parseContentDisposition.bind(null, 'filename=foo.html'))
+            .toThrowError(InvalidHeaderException, /invalid type format/);
+        });
+
+        it('should reject "x=y; filename=foo.html"', function () {
+          expect(parseContentDisposition.bind(null, 'x=y; filename=foo.html'))
+            .toThrowError(InvalidHeaderException, /invalid type format/);
+        });
+
+        it('should reject ""foo; filename=bar;baz"; filename=qux"',
+            function () {
+          expect(parseContentDisposition
+              .bind(null, '"foo; filename=bar;baz"; filename=qux'))
+              .toThrowError(InvalidHeaderException, /invalid type format/);
+          });
+
+        it('should reject "filename=foo.html, filename=bar.html"', function () {
+          expect(parseContentDisposition.bind(null,
+                'filename=foo.html, filename=bar.html'))
+            .toThrowError(InvalidHeaderException, /invalid type format/);
+        });
+
+        it('should reject "; filename=foo.html"', function () {
+          expect(parseContentDisposition.bind(null, '; filename=foo.html'))
+            .toThrowError(InvalidHeaderException, /invalid type format/);
+        });
+
+        it('should reject ": inline; attachment; filename=foo.html',
+            function () {
+          expect(parseContentDisposition.bind(null,
+                ': inline; attachment; filename=foo.html'))
+            .toThrowError(InvalidHeaderException, /invalid type format/);
+        });
+
+        it('should reject "inline; attachment; filename=foo.html', function () {
+          expect(parseContentDisposition.bind(null,
+              'inline; attachment; filename=foo.html'))
+            .toThrowError(InvalidHeaderException, /invalid parameter format/);
+        });
+
+        it('should reject "attachment; inline; filename=foo.html', function () {
+          expect(parseContentDisposition.bind(null,
+              'attachment; inline; filename=foo.html'))
+            .toThrowError(InvalidHeaderException, /invalid parameter format/);
+        });
+
+        it('should reject "attachment; filename="foo.html".txt', function () {
+          expect(parseContentDisposition.bind(null,
+              'attachment; filename="foo.html".txt'))
+            .toThrowError(InvalidHeaderException, /invalid parameter format/);
+        });
+
+        it('should reject "attachment; filename="bar', function () {
+          expect(parseContentDisposition.bind(null,
+                'attachment; filename="bar'))
+            .toThrowError(InvalidHeaderException, /invalid parameter format/);
+        });
+
+        it('should reject "attachment; filename=foo"bar;baz"qux', function () {
+          expect(parseContentDisposition.bind(null,
+              'attachment; filename=foo"bar;baz"qux'))
+            .toThrowError(InvalidHeaderException, /invalid parameter format/);
+        });
+
+        it('should reject "attachment; filename=foo.html, ' +
+            'attachment; filename=bar.html', function () {
+          expect(parseContentDisposition.bind(null,
+                'attachment; filename=foo.html, attachment; filename=bar.html'))
+            .toThrowError(InvalidHeaderException, /invalid parameter format/);
+        });
+
+        it('should reject "attachment; foo=foo filename=bar', function () {
+          expect(parseContentDisposition.bind(null,
+              'attachment; foo=foo filename=bar'))
+            .toThrowError(InvalidHeaderException, /invalid parameter format/);
+        });
+
+        it('should reject "attachment; filename=bar foo=foo', function () {
+          expect(parseContentDisposition.bind(null,
+              'attachment; filename=bar foo=foo'))
+            .toThrowError(InvalidHeaderException, /invalid parameter format/);
+        });
+
+        it('should reject "attachment filename=bar', function () {
+          expect(parseContentDisposition.bind(null, 'attachment filename=bar'))
+            .toThrowError(InvalidHeaderException, /invalid type format/);
+        });
+
+        it('should reject "filename=foo.html; attachment', function () {
+          expect(parseContentDisposition.bind(null,
+              'filename=foo.html; attachment'))
+            .toThrowError(InvalidHeaderException, /invalid type format/);
+        });
+
+        it('should parse "attachment; xfilename=foo.html"', function () {
+          expect(parseContentDisposition('attachment; xfilename=foo.html'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { xfilename: 'foo.html' }
+            });
+        });
+
+        it('should parse "attachment; filename="/foo.html""', function () {
+          expect(parseContentDisposition('attachment; filename="/foo.html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: '/foo.html' }
+            });
+        });
+
+        it('should parse "attachment; filename="\\\\foo.html""', function () {
+          expect(parseContentDisposition('attachment; filename="\\\\foo.html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: '\\foo.html' }
+            });
+        });
+      });
+
+      describe('Additional Parameters', function () {
+        it('should parse "attachment; ' +
+            'creation-date="Wed, 12 Feb 1997 16:29:51 -0500""', function () {
+          expect(parseContentDisposition(
+              'attachment; creation-date="Wed, 12 Feb 1997 16:29:51 -0500"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { 'creation-date': 'Wed, 12 Feb 1997 16:29:51 -0500' }
+            });
+        });
+
+        it('should parse "attachment; modification-date=' +
+            '"Wed, 12 Feb 1997 16:29:51 -0500""', function () {
+          expect(parseContentDisposition(
+              'attachment; ' +
+              'modification-date="Wed, 12 Feb 1997 16:29:51 -0500"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: {
+                'modification-date': 'Wed, 12 Feb 1997 16:29:51 -0500'
+              }
+            });
+        });
+      });
+
+      describe('Disposition-Type Extension', function () {
+        it('should parse "foobar"', function () {
+          expect(parseContentDisposition('foobar')).toEqual({
+            type: 'foobar',
+            parameters: {}
+          });
+        });
+
+        it('should parse "attachment; example="filename=example.txt""',
+            function () {
+          expect(parseContentDisposition(
+                'attachment; example="filename=example.txt"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { example: 'filename=example.txt' }
+            });
+        });
+      });
+
+      describe('RFC 2231/5987 Encoding: Character Sets', function () {
+        it('should parse "attachment; filename*=iso-8859-1\'\'foo-%E4.html"',
+            function () {
+          expect(parseContentDisposition(
+                'attachment; filename*=iso-8859-1\'\'foo-%E4.html'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo-ä.html' }
+            });
+        });
+
+        it('should parse "attachment; ' +
+            'filename*=UTF-8\'\'foo-%c3%a4-%e2%82%ac.html"', function () {
+          expect(parseContentDisposition(
+              'attachment; filename*=UTF-8\'\'foo-%c3%a4-%e2%82%ac.html'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo-ä-€.html' }
+            });
+        });
+
+        it('should reject "attachment; ' +
+            'filename*=\'\'foo-%c3%a4-%e2%82%ac.html"', function () {
+          expect(parseContentDisposition.bind(null,
+              'attachment; filename*=\'\'foo-%c3%a4-%e2%82%ac.html'))
+            .toThrowError(InvalidHeaderException, /invalid extended.*value/);
+        });
+
+        it('should parse "attachment; filename*=UTF-8\'\'foo-a%cc%88.html"',
+            function () {
+          expect(parseContentDisposition(
+                'attachment; filename*=UTF-8\'\'foo-a%cc%88.html'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo-ä.html' }
+            });
+        });
+
+        it('should parse "attachment; ' +
+            'filename*=iso-8859-1\'\'foo-%c3%a4-%e2%82%ac.html"', function () {
+          expect(parseContentDisposition(
+              'attachment; filename*=iso-8859-1\'\'foo-%c3%a4-%e2%82%ac.html'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo-Ã¤-â?¬.html' }
+            });
+        });
+
+        it('should parse "attachment; filename*=utf-8\'\'foo-%E4.html"',
+            function () {
+          expect(parseContentDisposition.bind(null,
+                'attachment; filename*=utf-8\'\'foo-%E4.html'))
+            .toThrowError(InvalidHeaderException, /invalid extended.*value/);
+        });
+
+        it('should reject "attachment; filename *=UTF-8\'\'foo-%c3%a4.html"',
+            function () {
+          expect(parseContentDisposition.bind(null,
+                'attachment; filename *=UTF-8\'\'foo-%c3%a4.html'))
+            .toThrowError(InvalidHeaderException, /invalid parameter format/);
+        });
+
+        it('should parse "attachment; filename*= UTF-8\'\'foo-%c3%a4.html"',
+            function () {
+          expect(parseContentDisposition(
+                'attachment; filename*= UTF-8\'\'foo-%c3%a4.html'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo-ä.html' }
+            });
+        });
+
+        it('should parse "attachment; filename* =UTF-8\'\'foo-%c3%a4.html"',
+            function () {
+          expect(parseContentDisposition(
+                'attachment; filename* =UTF-8\'\'foo-%c3%a4.html'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo-ä.html' }
+            });
+        });
+
+        it('should reject "attachment; filename*="UTF-8\'\'foo-%c3%a4.html""',
+            function () {
+          expect(parseContentDisposition.bind(null,
+                'attachment; filename*="UTF-8\'\'foo-%c3%a4.html"'))
+            .toThrowError(InvalidHeaderException,
+                /invalid extended field value/);
+        });
+
+        it('should reject "attachment; filename*="foo%20bar.html""',
+            function () {
+          expect(parseContentDisposition.bind(null,
+                'attachment; filename*="foo%20bar.html"'))
+            .toThrowError(InvalidHeaderException,
+                /invalid extended field value/);
+        });
+
+        it('should reject "attachment; filename*=UTF-8\'foo-%c3%a4.html"',
+            function () {
+          expect(parseContentDisposition.bind(null,
+                'attachment; filename*=UTF-8\'foo-%c3%a4.html'))
+            .toThrowError(InvalidHeaderException,
+                /invalid extended field value/);
+        });
+
+        it('should reject "attachment; filename*=UTF-8\'\'foo%"', function () {
+          expect(parseContentDisposition.bind(null,
+                'attachment; filename*=UTF-8\'\'foo%'))
+            .toThrowError(InvalidHeaderException,
+                /invalid extended field value/);
+        });
+
+        it('should reject "attachment; filename*=UTF-8\'\'f%oo.html"',
+            function () {
+          expect(parseContentDisposition.bind(null,
+                'attachment; filename*=UTF-8\'\'f%oo.html'))
+            .toThrowError(InvalidHeaderException,
+                /invalid extended field value/);
+        });
+
+        it('should parse "attachment; filename*=UTF-8\'\'A-%2541.html"',
+            function () {
+          expect(parseContentDisposition(
+                'attachment; filename*=UTF-8\'\'A-%2541.html'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'A-%41.html' }
+            });
+        });
+
+        it('should parse "attachment; filename*=UTF-8\'\'%5cfoo.html"',
+            function () {
+          expect(parseContentDisposition(
+                'attachment; filename*=UTF-8\'\'%5cfoo.html'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: '\\foo.html' }
+            });
+        });
+      });
+
+      describe('RFC2231 Encoding: Continuations', function () {
+        it('should parse "attachment; filename*0="foo."; filename*1="html""',
+            function () {
+          expect(parseContentDisposition(
+                'attachment; filename*0="foo."; filename*1="html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { 'filename*0': 'foo.', 'filename*1': 'html' }
+            });
+        });
+
+        it('should parse "attachment; ' +
+            'filename*0="foo"; filename*1="\\b\\a\\r.html""', function () {
+          expect(parseContentDisposition(
+              'attachment; filename*0="foo"; filename*1="\\b\\a\\r.html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { 'filename*0': 'foo', 'filename*1': 'bar.html' }
+            });
+        });
+
+        it('should parse "attachment; filename*0*=UTF-8\'\'foo-%c3%a4; ' +
+            'filename*1=".html""', function () {
+          expect(parseContentDisposition(
+              'attachment; filename*0*=UTF-8\'\'foo-%c3%a4; ' +
+              'filename*1=".html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: {
+                'filename*0*': 'UTF-8\'\'foo-%c3%a4',
+                'filename*1': '.html'
+              }
+            });
+        });
+
+        it('should parse "attachment; filename*0="foo"; filename*01="bar""',
+            function () {
+          expect(parseContentDisposition(
+                'attachment; filename*0="foo"; filename*01="bar"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { 'filename*0': 'foo', 'filename*01': 'bar' }
+            });
+        });
+
+        it('should parse "attachment; filename*0="foo"; filename*2="bar""',
+            function () {
+          expect(parseContentDisposition(
+                'attachment; filename*0="foo"; filename*2="bar"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { 'filename*0': 'foo', 'filename*2': 'bar' }
+            });
+        });
+
+        it('should parse "attachment; filename*1="foo."; filename*2="html""',
+            function () {
+          expect(parseContentDisposition(
+                'attachment; filename*1="foo."; filename*2="html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { 'filename*1': 'foo.', 'filename*2': 'html' }
+            });
+        });
+
+        it('should parse "attachment; filename*1="bar"; filename*0="foo""',
+            function () {
+          expect(parseContentDisposition(
+                'attachment; filename*1="bar"; filename*0="foo"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { 'filename*1': 'bar', 'filename*0': 'foo' }
+            });
+        });
+      });
+
+      describe('RFC2231 Encoding: Fallback Behaviour', function () {
+        it('should parse "attachment; filename="foo-ae.html"; ' +
+            'filename*=UTF-8\'\'foo-%c3%a4.html"', function () {
+          expect(parseContentDisposition(
+              'attachment; filename="foo-ae.html"; ' +
+              'filename*=UTF-8\'\'foo-%c3%a4.html'))
+          .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo-ä.html' }
+            });
+        });
+
+        it('should parse "attachment; filename*=UTF-8\'\'foo-%c3%a4.html; ' +
+            'filename="foo-ae.html"', function () {
+          expect(parseContentDisposition(
+                'attachment; filename*=UTF-8\'\'foo-%c3%a4.html; ' +
+                'filename="foo-ae.html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo-ä.html' }
+            });
+        });
+
+        it('should parse "attachment; ' +
+            'filename*0*=ISO-8859-15\'\'euro-sign%3d%a4; ' +
+            'filename*=ISO-8859-1\'\'currency-sign%3d%a4', function () {
+          expect(parseContentDisposition('attachment; ' +
+                'filename*0*=ISO-8859-15\'\'euro-sign%3d%a4; ' +
+                'filename*=ISO-8859-1\'\'currency-sign%3d%a4'))
+            .toEqual({
+              type: 'attachment',
+              parameters: {
+                filename: 'currency-sign=¤',
+                'filename*0*': 'ISO-8859-15\'\'euro-sign%3d%a4'
+              }
+            });
+        });
+
+        it('should parse "attachment; foobar=x; filename="foo.html"',
+            function () {
+          expect(parseContentDisposition(
+                'attachment; foobar=x; filename="foo.html"'))
+            .toEqual({
+              type: 'attachment',
+              parameters: { filename: 'foo.html', foobar: 'x' }
+            });
+        });
+      });
+
+      describe('RFC2047 Encoding', function () {
+        it('should reject "attachment; filename==?ISO-8859-1?Q?foo-=E4.html?="',
+            function () {
+          expect(parseContentDisposition.bind(null,
+                'attachment; filename==?ISO-8859-1?Q?foo-=E4.html?='))
+            .toThrowError(InvalidHeaderException, /invalid parameter format/);
+        });
+
+        it('should parse "attachment; ' +
+            'filename="=?ISO-8859-1?Q?foo-=E4.html?=""', function () {
+          expect(parseContentDisposition(
+              'attachment; filename="=?ISO-8859-1?Q?foo-=E4.html?="'))
+          .toEqual({
+              type: 'attachment',
+              parameters: { filename: '=?ISO-8859-1?Q?foo-=E4.html?=' }
+            });
+        });
+      });
     });
   });
 });

--- a/test/unit/unit_test.html
+++ b/test/unit/unit_test.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8">
   <title>pdf.js unit test</title>
 
   <link rel="stylesheet" type="text/css" href="../../node_modules/jasmine-core/lib/jasmine-core/jasmine.css">

--- a/test/webserver.js
+++ b/test/webserver.js
@@ -47,6 +47,7 @@ function WebServer() {
   this.verbose = false;
   this.cacheExpirationTime = 0;
   this.disableRangeRequests = false;
+  this.addContentDisposition = true;
   this.hooks = {
     'GET': [],
     'POST': []
@@ -103,6 +104,7 @@ WebServer.prototype = {
     }
 
     var disableRangeRequests = this.disableRangeRequests;
+    var addContentDisposition = this.addContentDisposition;
     var cacheExpirationTime = this.cacheExpirationTime;
 
     var filePath;
@@ -253,10 +255,15 @@ WebServer.prototype = {
       });
 
       var ext = path.extname(filePath).toLowerCase();
+      var filename = path.basename(filePath);
       var contentType = mimeTypes[ext] || defaultMimeType;
 
       if (!disableRangeRequests) {
         res.setHeader('Accept-Ranges', 'bytes');
+      }
+      if (addContentDisposition) {
+        var contentDispositionHeader = 'inline; filename="' + filename + '"';
+        res.setHeader('Content-Disposition', contentDispositionHeader);
       }
       res.setHeader('Content-Type', contentType);
       res.setHeader('Content-Length', fileSize);

--- a/web/app.js
+++ b/web/app.js
@@ -675,6 +675,9 @@ var PDFViewerApplication = {
       return;
     }
 
+    // There could be a filename available from network call
+    filename = this.pdfDocumentProperties.getFileName();
+
     this.pdfDocument.getData().then(
       function getDataSuccess(data) {
         var blob = pdfjsLib.createBlob(data, 'application/pdf');
@@ -816,6 +819,8 @@ var PDFViewerApplication = {
     this.pdfDocument = pdfDocument;
 
     this.pdfDocumentProperties.setDocumentAndUrl(pdfDocument, this.url);
+
+    this.setTitle(this.pdfDocumentProperties.getFileName());
 
     var downloadedPromise = pdfDocument.getDownloadInfo().then(function() {
       self.downloadComplete = true;

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -116,6 +116,20 @@ var PDFDocumentProperties = (function PDFDocumentPropertiesClosure() {
     },
 
     /**
+     * Get file name as displayed in the document properties overlay.
+     *
+     */
+    getFileName: function PDFDocumentProperties_getFileName() {
+      var filename = this.pdfDocument.filename;
+
+      if (!filename) {
+        filename = getPDFFileNameFromURL(this.url);
+      }
+
+      return filename;
+    },
+
+    /**
      * @private
      */
     _getProperties: function PDFDocumentProperties_getProperties() {
@@ -136,7 +150,7 @@ var PDFDocumentProperties = (function PDFDocumentPropertiesClosure() {
       // Get the document properties.
       this.pdfDocument.getMetadata().then(function(data) {
         var content = {
-          'fileName': getPDFFileNameFromURL(this.url),
+          'fileName': this.getFileName(),
           'fileSize': this._parseFileSize(),
           'title': data.info.Title,
           'author': data.info.Author,


### PR DESCRIPTION
Fixes #6396 

Some notes for the reviewer,
1. Copied considerable part of the code (both implementation and tests) from [content-disposition](https://www.npmjs.com/package/content-disposition) npm module. I couldn't find an easy way to reuse a node module in browser here.
2. Behavior of parsing content-disposition has been modified from the corresponding node module here in pdf.js for the below case,
   - If there is an invalid encoding in utf8, the npm module will put a replacement character (`\ufffd`) and parses the rest. However, here in pdf.js, we will throw an error. The reason being, in npm module it uses Buffer class while here we use `decodeURIComponent(escape(str));` (Throwing any error during parsing will cause pdf.js to just ignore the entire header.)
3. Only unit tests are checked and updated. I couldn't get the other tests running because of the mismatch in hashes (I think).

Please let me know any feedback.

Rgds,
