### PR TITLE
Remove unused globals from fonts unit test file

### DIFF
--- a/test/unit/fonts_spec.js
+++ b/test/unit/fonts_spec.js
@@ -1,5 +1,4 @@
-/* globals describe, it, expect, beforeAll, afterAll,
-           checkProblematicCharRanges */
+/* globals describe, it, expect, checkProblematicCharRanges */
 
 'use strict';
 


### PR DESCRIPTION
Somehow I did not notice this while reviewing PR #7540. It's nothing major, but let's clean it up.
