### PR TITLE
Change the `GoToPage` Named Action to select the contents of the `pageNumber` input, rather than just focusing the element

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1707,7 +1707,7 @@ function webViewerNamedAction(e) {
   var action = e.action;
   switch (action) {
     case 'GoToPage':
-      PDFViewerApplication.appConfig.toolbar.pageNumber.focus();
+      PDFViewerApplication.appConfig.toolbar.pageNumber.select();
       break;
 
     case 'Find':


### PR DESCRIPTION
When clicking on the `pageNumber` input, or when using the keyboard shortcut <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>G</kbd>, the element isn't just focused but its contents is actually _selected_ so that the user doesn't need to clear the input before entering a new `pageNumber`.
However, the `GoToPage` named action is only using `focus`, so let's change this to be consistent.

The following document can be used for testing: http://www2.informatik.uni-freiburg.de/~frank/ENG/beamer/example/Beamer-class-example1.pdf#zoom=page-fit

![gotopage](https://cloud.githubusercontent.com/assets/2692120/18165997/d93eb7a8-7048-11e6-9e13-e83c854657a5.png)
