### PR TITLE
Move the `Preferences` initialization/fetching code to the top of `PDFViewerApplication.initialize`, and add a `enhanceTextSelection` preference to the viewer

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -94,6 +94,10 @@
       "type": "boolean",
       "description": "Whether to prevent the extension from reporting the extension and browser version to the extension developers.",
       "default": false
+    },
+    "enhanceTextSelection": {
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/web/app.js
+++ b/web/app.js
@@ -101,7 +101,6 @@ var SCALE_SELECT_CONTAINER_PADDING = 8;
 var SCALE_SELECT_PADDING = 22;
 var PAGE_NUMBER_LOADING_INDICATOR = 'visiblePageIsLoading';
 var DISABLE_AUTO_FETCH_LOADING_BAR_TIMEOUT = 5000;
-var ENHANCE_TEXT_SELECTION = false;
 
 function configure(PDFJS) {
   PDFJS.imageResourcesPath = './images/';
@@ -177,6 +176,7 @@ var PDFViewerApplication = {
   preferencePdfBugEnabled: false,
   preferenceShowPreviousViewOnLoad: true,
   preferenceDefaultZoomValue: '',
+  preferenceEnhanceTextSelection: false,
   isViewerEmbedded: (window.parent !== window),
   url: '',
   externalServices: DefaultExernalServices,
@@ -205,6 +205,9 @@ var PDFViewerApplication = {
       }),
       Preferences.get('defaultZoomValue').then(function resolved(value) {
         self.preferenceDefaultZoomValue = value;
+      }),
+      Preferences.get('enhanceTextSelection').then(function resolved(value) {
+        self.preferenceEnhanceTextSelection = value;
       }),
       Preferences.get('disableTextLayer').then(function resolved(value) {
         if (PDFJS.disableTextLayer === true) {
@@ -274,7 +277,7 @@ var PDFViewerApplication = {
         renderingQueue: pdfRenderingQueue,
         linkService: pdfLinkService,
         downloadManager: downloadManager,
-        enhanceTextSelection: ENHANCE_TEXT_SELECTION,
+        enhanceTextSelection: this.preferenceEnhanceTextSelection,
       });
       pdfRenderingQueue.setViewer(this.pdfViewer);
       pdfLinkService.setViewer(this.pdfViewer);

--- a/web/app.js
+++ b/web/app.js
@@ -183,131 +183,14 @@ var PDFViewerApplication = {
 
   // called once when the document is loaded
   initialize: function pdfViewInitialize(appConfig) {
-    configure(pdfjsLib.PDFJS);
-    this.appConfig = appConfig;
-
-    var eventBus = appConfig.eventBus || getGlobalEventBus();
-    this.eventBus = eventBus;
-    this.bindEvents();
-
-    var pdfRenderingQueue = new PDFRenderingQueue();
-    pdfRenderingQueue.onIdle = this.cleanup.bind(this);
-    this.pdfRenderingQueue = pdfRenderingQueue;
-
-    var pdfLinkService = new PDFLinkService({
-      eventBus: eventBus
-    });
-    this.pdfLinkService = pdfLinkService;
-
-    var downloadManager = this.externalServices.createDownloadManager();
-    this.downloadManager = downloadManager;
-
-    var container = appConfig.mainContainer;
-    var viewer = appConfig.viewerContainer;
-    this.pdfViewer = new PDFViewer({
-      container: container,
-      viewer: viewer,
-      eventBus: eventBus,
-      renderingQueue: pdfRenderingQueue,
-      linkService: pdfLinkService,
-      downloadManager: downloadManager,
-      enhanceTextSelection: ENHANCE_TEXT_SELECTION,
-    });
-    pdfRenderingQueue.setViewer(this.pdfViewer);
-    pdfLinkService.setViewer(this.pdfViewer);
-
-    var thumbnailContainer = appConfig.sidebar.thumbnailView;
-    this.pdfThumbnailViewer = new PDFThumbnailViewer({
-      container: thumbnailContainer,
-      renderingQueue: pdfRenderingQueue,
-      linkService: pdfLinkService
-    });
-    pdfRenderingQueue.setThumbnailViewer(this.pdfThumbnailViewer);
+    var self = this;
+    var PDFJS = pdfjsLib.PDFJS;
 
     Preferences.initialize();
     this.preferences = Preferences;
-
-    this.pdfHistory = new PDFHistory({
-      linkService: pdfLinkService,
-      eventBus: this.eventBus
-    });
-    pdfLinkService.setHistory(this.pdfHistory);
-
-    this.findController = new PDFFindController({
-      pdfViewer: this.pdfViewer
-    });
-    this.findController.onUpdateResultsCount = function (matchCount) {
-      if (this.supportsIntegratedFind) {
-        return;
-      }
-      this.findBar.updateResultsCount(matchCount);
-    }.bind(this);
-    this.findController.onUpdateState = function (state, previous, matchCount) {
-      if (this.supportsIntegratedFind) {
-        this.externalServices.updateFindControlState(
-          {result: state, findPrevious: previous});
-      } else {
-        this.findBar.updateUIState(state, previous, matchCount);
-      }
-    }.bind(this);
-
-    this.pdfViewer.setFindController(this.findController);
-
-    // FIXME better PDFFindBar constructor parameters
-    var findBarConfig = Object.create(appConfig.findBar);
-    findBarConfig.findController = this.findController;
-    findBarConfig.eventBus = this.eventBus;
-    this.findBar = new PDFFindBar(findBarConfig);
-
-    this.overlayManager = OverlayManager;
-
-    this.handTool = new HandTool({
-      container: container,
-      eventBus: this.eventBus,
-    });
-
-    this.pdfDocumentProperties =
-      new PDFDocumentProperties(appConfig.documentProperties);
-
-    this.secondaryToolbar =
-      new SecondaryToolbar(appConfig.secondaryToolbar, eventBus);
-
-    if (this.supportsFullscreen) {
-      this.pdfPresentationMode = new PDFPresentationMode({
-        container: container,
-        viewer: viewer,
-        pdfViewer: this.pdfViewer,
-        eventBus: this.eventBus,
-        contextMenuItems: appConfig.fullscreen
-      });
-    }
-
-    this.passwordPrompt = new PasswordPrompt(appConfig.passwordOverlay);
-
-    this.pdfOutlineViewer = new PDFOutlineViewer({
-      container: appConfig.sidebar.outlineView,
-      eventBus: this.eventBus,
-      linkService: pdfLinkService,
-    });
-
-    this.pdfAttachmentViewer = new PDFAttachmentViewer({
-      container: appConfig.sidebar.attachmentsView,
-      eventBus: this.eventBus,
-      downloadManager: downloadManager
-    });
-
-    // FIXME better PDFSidebar constructor parameters
-    var sidebarConfig = Object.create(appConfig.sidebar);
-    sidebarConfig.pdfViewer = this.pdfViewer;
-    sidebarConfig.pdfThumbnailViewer = this.pdfThumbnailViewer;
-    sidebarConfig.pdfOutlineViewer = this.pdfOutlineViewer;
-    sidebarConfig.eventBus = this.eventBus;
-    this.pdfSidebar = new PDFSidebar(sidebarConfig);
-    this.pdfSidebar.onToggled = this.forceRendering.bind(this);
-
-    var self = this;
-    var PDFJS = pdfjsLib.PDFJS;
-    var initializedPromise = Promise.all([
+    // Fetch the `Preferences` first, so that they can be used below when the
+    // various viewer components are initialized.
+    var preferencesPromise = Promise.all([
       Preferences.get('enableWebGL').then(function resolved(value) {
         PDFJS.disableWebGL = !value;
       }),
@@ -361,6 +244,129 @@ var PDFViewerApplication = {
       }),
       // TODO move more preferences and other async stuff here
     ]).catch(function (reason) { });
+
+    var initializedPromise = preferencesPromise.then(function () {
+      configure(pdfjsLib.PDFJS);
+      this.appConfig = appConfig;
+
+      var eventBus = appConfig.eventBus || getGlobalEventBus();
+      this.eventBus = eventBus;
+      this.bindEvents();
+
+      var pdfRenderingQueue = new PDFRenderingQueue();
+      pdfRenderingQueue.onIdle = this.cleanup.bind(this);
+      this.pdfRenderingQueue = pdfRenderingQueue;
+
+      var pdfLinkService = new PDFLinkService({
+        eventBus: eventBus
+      });
+      this.pdfLinkService = pdfLinkService;
+
+      var downloadManager = this.externalServices.createDownloadManager();
+      this.downloadManager = downloadManager;
+
+      var container = appConfig.mainContainer;
+      var viewer = appConfig.viewerContainer;
+      this.pdfViewer = new PDFViewer({
+        container: container,
+        viewer: viewer,
+        eventBus: eventBus,
+        renderingQueue: pdfRenderingQueue,
+        linkService: pdfLinkService,
+        downloadManager: downloadManager,
+        enhanceTextSelection: ENHANCE_TEXT_SELECTION,
+      });
+      pdfRenderingQueue.setViewer(this.pdfViewer);
+      pdfLinkService.setViewer(this.pdfViewer);
+
+      var thumbnailContainer = appConfig.sidebar.thumbnailView;
+      this.pdfThumbnailViewer = new PDFThumbnailViewer({
+        container: thumbnailContainer,
+        renderingQueue: pdfRenderingQueue,
+        linkService: pdfLinkService
+      });
+      pdfRenderingQueue.setThumbnailViewer(this.pdfThumbnailViewer);
+
+      this.pdfHistory = new PDFHistory({
+        linkService: pdfLinkService,
+        eventBus: this.eventBus
+      });
+      pdfLinkService.setHistory(this.pdfHistory);
+
+      this.findController = new PDFFindController({
+        pdfViewer: this.pdfViewer
+      });
+      this.findController.onUpdateResultsCount = function (matchCount) {
+        if (this.supportsIntegratedFind) {
+          return;
+        }
+        this.findBar.updateResultsCount(matchCount);
+      }.bind(this);
+      this.findController.onUpdateState = function (state, previous,
+                                                    matchCount) {
+        if (this.supportsIntegratedFind) {
+          this.externalServices.updateFindControlState(
+            {result: state, findPrevious: previous});
+        } else {
+          this.findBar.updateUIState(state, previous, matchCount);
+        }
+      }.bind(this);
+
+      this.pdfViewer.setFindController(this.findController);
+
+      // FIXME better PDFFindBar constructor parameters
+      var findBarConfig = Object.create(appConfig.findBar);
+      findBarConfig.findController = this.findController;
+      findBarConfig.eventBus = this.eventBus;
+      this.findBar = new PDFFindBar(findBarConfig);
+
+      this.overlayManager = OverlayManager;
+
+      this.handTool = new HandTool({
+        container: container,
+        eventBus: this.eventBus,
+      });
+
+      this.pdfDocumentProperties =
+        new PDFDocumentProperties(appConfig.documentProperties);
+
+      this.secondaryToolbar =
+        new SecondaryToolbar(appConfig.secondaryToolbar, eventBus);
+
+      if (this.supportsFullscreen) {
+        this.pdfPresentationMode = new PDFPresentationMode({
+          container: container,
+          viewer: viewer,
+          pdfViewer: this.pdfViewer,
+          eventBus: this.eventBus,
+          contextMenuItems: appConfig.fullscreen
+        });
+      }
+
+      this.passwordPrompt = new PasswordPrompt(appConfig.passwordOverlay);
+
+      this.pdfOutlineViewer = new PDFOutlineViewer({
+        container: appConfig.sidebar.outlineView,
+        eventBus: this.eventBus,
+        linkService: pdfLinkService,
+      });
+
+      this.pdfAttachmentViewer = new PDFAttachmentViewer({
+        container: appConfig.sidebar.attachmentsView,
+        eventBus: this.eventBus,
+        downloadManager: downloadManager
+      });
+
+      // FIXME better PDFSidebar constructor parameters
+      var sidebarConfig = Object.create(appConfig.sidebar);
+      sidebarConfig.pdfViewer = this.pdfViewer;
+      sidebarConfig.pdfThumbnailViewer = this.pdfThumbnailViewer;
+      sidebarConfig.pdfOutlineViewer = this.pdfOutlineViewer;
+      sidebarConfig.eventBus = this.eventBus;
+      this.pdfSidebar = new PDFSidebar(sidebarConfig);
+      this.pdfSidebar.onToggled = this.forceRendering.bind(this);
+
+    }.bind(this));
 
     return initializedPromise.then(function () {
       if (self.isViewerEmbedded && !PDFJS.isExternalLinkTargetSet()) {

--- a/web/default_preferences.json
+++ b/web/default_preferences.json
@@ -11,5 +11,6 @@
   "disableFontFace": false,
   "disableTextLayer": false,
   "useOnlyCssZoom": false,
-  "externalLinkTarget": 0
+  "externalLinkTarget": 0,
+  "enhanceTextSelection": false
 }

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -36,7 +36,7 @@
  * @property {PageViewport} viewport - The viewport of the text layer.
  * @property {PDFFindController} findController
  * @property {boolean} enhanceTextSelection - Option to turn on improved
- *   text selection.
+ *   text selection. The default value is `false`.
  */
 
 /**
@@ -59,7 +59,7 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
     this.textDivs = [];
     this.findController = options.findController || null;
     this.textLayerRenderTask = null;
-    this.enhanceTextSelection = options.enhanceTextSelection;
+    this.enhanceTextSelection = options.enhanceTextSelection || false;
     this._bindMouse();
   }
 


### PR DESCRIPTION
_Please refer to the individual commit messages._

This PR should make it easier to switch the text-selection modes, e.g. for someone working on the tasks in issue #7584. It should also simplify things for third-party implementers of the default viewer, since this allows you to choose text-selection mode without having to edit the code. 

/cc @yurydelendik You suggested on IRC that we move the `Preferences` initialization, so I'm submitting this for feedback.

**Edit:** Probably easier reviewing with https://github.com/mozilla/pdf.js/pull/7586/files?w=1.
