### PR TITLE
In `display/api.js` ensure that we always reject with an `Error` in `JpegDecode`, and adjust a couple of other rejection sites as well

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -341,13 +341,32 @@ describe('api', function() {
       });
     });
     it('gets non-existent page', function(done) {
-      var promise = doc.getPage(100);
-      promise.then(function () {
-        done.fail('shall fail for non-existent page');
-      }, function(data) {
-        expect(data instanceof Error).toEqual(true);
-        done();
+      var outOfRangePromise = doc.getPage(100);
+      var nonIntegerPromise = doc.getPage(2.5);
+      var nonNumberPromise = doc.getPage('1');
+
+      outOfRangePromise = outOfRangePromise.then(function () {
+        throw new Error('shall fail for out-of-range pageNumber parameter');
+      }, function (reason) {
+        expect(reason instanceof Error).toEqual(true);
       });
+      nonIntegerPromise = nonIntegerPromise.then(function () {
+        throw new Error('shall fail for non-integer pageNumber parameter');
+      }, function (reason) {
+        expect(reason instanceof Error).toEqual(true);
+      });
+      nonNumberPromise = nonNumberPromise.then(function () {
+        throw new Error('shall fail for non-number pageNumber parameter');
+      }, function (reason) {
+        expect(reason instanceof Error).toEqual(true);
+      });
+
+      Promise.all([outOfRangePromise, nonIntegerPromise, nonNumberPromise]).
+        then(function () {
+          done();
+        }).catch(function (reason) {
+          done.fail(reason);
+        });
     });
     it('gets page index', function(done) {
       // reference to second page
@@ -365,8 +384,8 @@ describe('api', function() {
       var promise = doc.getPageIndex(ref);
       promise.then(function () {
         done.fail('shall fail for invalid page reference.');
-      }, function (data) {
-        expect(data instanceof Error).toEqual(true);
+      }).catch(function (reason) {
+        expect(reason instanceof Error).toEqual(true);
         done();
       });
     });


### PR DESCRIPTION
In the case where the document was destroyed, we were rejecting the `Promise` in `JpegDecode` with a string instead of an `Error`. The patch also brings the wording more inline with other such rejections.

Use the `isInt` utility function when validating the `pageNumber` parameter in `WorkerTransport_getPage`, to make it more obvious what's actually happening. There's also a couple more unit-tests added, to ensure that we always fail in the expected way.

Finally, we can simplify the rejection handling in `WorkerTransport_getPageIndexByRef` somewhat. (Note that the only reason for using `catch` here is that since the promise is rejected on the worker side, the `reason` becomes a string instead of an `Error` which is why we "re-reject" on the display side.)
