### PR TITLE
Improve the structure for widget annotations

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -98,9 +98,14 @@ AnnotationFactory.prototype = /** @lends AnnotationFactory.prototype */ {
 
       case 'Widget':
         var fieldType = Util.getInheritableProperty(dict, 'FT');
-        if (isName(fieldType, 'Tx')) {
-          return new TextWidgetAnnotation(parameters);
+        fieldType = isName(fieldType) ? fieldType.name : null;
+
+        switch (fieldType) {
+          case 'Tx':
+            return new TextWidgetAnnotation(parameters);
         }
+        warn('Unimplemented widget field type "' + fieldType + '", ' +
+             'falling back to base field type.');
         return new WidgetAnnotation(parameters);
 
       case 'Popup':
@@ -615,13 +620,12 @@ var WidgetAnnotation = (function WidgetAnnotationClosure() {
     data.alternativeText = stringToPDFString(dict.get('TU') || '');
     data.defaultAppearance = Util.getInheritableProperty(dict, 'DA') || '';
     var fieldType = Util.getInheritableProperty(dict, 'FT');
-    data.fieldType = isName(fieldType) ? fieldType.name : '';
+    data.fieldType = isName(fieldType) ? fieldType.name : null;
     data.fieldFlags = Util.getInheritableProperty(dict, 'Ff') || 0;
     this.fieldResources = Util.getInheritableProperty(dict, 'DR') || Dict.empty;
 
-    // Hide unsupported Widget signatures.
+    // Hide signatures because we cannot validate them.
     if (data.fieldType === 'Sig') {
-      warn('unimplemented annotation type: Widget signature');
       this.setFlags(AnnotationFlag.HIDDEN);
     }
 

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -69,6 +69,12 @@ AnnotationElementFactory.prototype =
         return new TextAnnotationElement(parameters);
 
       case AnnotationType.WIDGET:
+        var fieldType = parameters.data.fieldType;
+
+        switch (fieldType) {
+          case 'Tx':
+            return new TextWidgetAnnotationElement(parameters);
+        }
         return new WidgetAnnotationElement(parameters);
 
       case AnnotationType.POPUP:
@@ -392,9 +398,7 @@ var TextAnnotationElement = (function TextAnnotationElementClosure() {
  */
 var WidgetAnnotationElement = (function WidgetAnnotationElementClosure() {
   function WidgetAnnotationElement(parameters) {
-    var isRenderable = !parameters.data.hasAppearance &&
-                       !!parameters.data.fieldValue;
-    AnnotationElement.call(this, parameters, isRenderable);
+    AnnotationElement.call(this, parameters, true);
   }
 
   Util.inherit(WidgetAnnotationElement, AnnotationElement, {
@@ -406,6 +410,33 @@ var WidgetAnnotationElement = (function WidgetAnnotationElementClosure() {
      * @returns {HTMLSectionElement}
      */
     render: function WidgetAnnotationElement_render() {
+      // Show only the container for unsupported field types.
+      return this.container;
+    }
+  });
+
+  return WidgetAnnotationElement;
+})();
+
+/**
+ * @class
+ * @alias TextWidgetAnnotationElement
+ */
+var TextWidgetAnnotationElement = (
+    function TextWidgetAnnotationElementClosure() {
+  function TextWidgetAnnotationElement(parameters) {
+    WidgetAnnotationElement.call(this, parameters);
+  }
+
+  Util.inherit(TextWidgetAnnotationElement, WidgetAnnotationElement, {
+    /**
+     * Render the text widget annotation's HTML element in the empty container.
+     *
+     * @public
+     * @memberof TextWidgetAnnotationElement
+     * @returns {HTMLSectionElement}
+     */
+    render: function TextWidgetAnnotationElement_render() {
       var content = document.createElement('div');
       content.textContent = this.data.fieldValue;
       var textAlignment = this.data.textAlignment;
@@ -427,10 +458,10 @@ var WidgetAnnotationElement = (function WidgetAnnotationElementClosure() {
      * @private
      * @param {HTMLDivElement} element
      * @param {Object} font
-     * @memberof WidgetAnnotationElement
+     * @memberof TextWidgetAnnotationElement
      */
     _setTextStyle:
-        function WidgetAnnotationElement_setTextStyle(element, font) {
+        function TextWidgetAnnotationElement_setTextStyle(element, font) {
       // TODO: This duplicates some of the logic in CanvasGraphics.setFont().
       var style = element.style;
       style.fontSize = this.data.fontSize + 'px';
@@ -452,7 +483,7 @@ var WidgetAnnotationElement = (function WidgetAnnotationElementClosure() {
     }
   });
 
-  return WidgetAnnotationElement;
+  return TextWidgetAnnotationElement;
 })();
 
 /**


### PR DESCRIPTION
Currently, we only support text widget annotations (field type 'Tx') partially. However, the current code does not make this entirely clear and does not provide a warning when an unsupported field type is encountered, making it harder to determine why rendering fails.

Moreover, in the display layer we make no distinction between the various types of widget annotations, causing the code for text widget annotations to also be executed for other types of widget annotations in a fallback situation.

This patch improves the structure of the widget annotation code. In the core layer, we use the same structure we use for non-widget annotations in the factory and provide a clear warning when an unsupported type is encountered. In the display layer, we do the same and split the `WidgetAnnotationElement` class into two classes, namely `TextWidgetAnnotationElement` for text widget annotations and `WidgetAnnotationElement` for other unsupported annotations as a
fallback. From this it clear that we only support text widget annotations and nothing else.

@Snuffleupagus Since you previously reviewed annotation PRs, would you be willing to review this one as well? I have follow-up ideas that depend on this refactoring to make the code more understandable. The check at https://github.com/mozilla/pdf.js/pull/7596/files#diff-1097e3b131ba22f8e8a6c2f20e3ab5ecL395 has been removed because it is unnecessary. It is not required to have a field value for rendering, for example for text boxes in forms with no prefilled value, which is really common and for which this patch prepares the code. Appearance streams are already ignored in the core layer, so there is no need to check for this either in the display layer.

The following documents may be used for testing this. Rendering should be equal before and after this patch, but the button and signature documents should now both have a similar message in the console.
- Signature: https://dl.dropboxusercontent.com/u/5681461/dev/test-signature.pdf
- Button: https://dbr.ee/uR8F
- Text: https://github.com/mozilla/pdf.js/raw/master/test/pdfs/annotation-tx.pdf
