### PR TITLE
fixing #7590 by delaying div shrink after mouse up

### DIFF
--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -28,6 +28,8 @@
   }
 }(this, function (exports, domEvents, pdfjsLib) {
 
+var EXPAND_DIVS_TIMEOUT = 300; // ms
+
 /**
  * @typedef {Object} TextLayerBuilderOptions
  * @property {HTMLDivElement} textLayerDiv - The text layer container.
@@ -321,9 +323,16 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
     _bindMouse: function TextLayerBuilder_bindMouse() {
       var div = this.textLayerDiv;
       var self = this;
+      var expandDivsTimer = null;
       div.addEventListener('mousedown', function (e) {
         if (self.enhanceTextSelection && self.textLayerRenderTask) {
           self.textLayerRenderTask.expandTextDivs(true);
+//#if !(MOZCENTRAL || FIREFOX)
+          if (expandDivsTimer) {
+            clearTimeout(expandDivsTimer);
+            expandDivsTimer = null;
+          }
+//#endif
           return;
         }
         var end = div.querySelector('.endOfContent');
@@ -350,7 +359,14 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
       });
       div.addEventListener('mouseup', function (e) {
         if (self.enhanceTextSelection && self.textLayerRenderTask) {
-          self.textLayerRenderTask.expandTextDivs(false);
+//#if !(MOZCENTRAL || FIREFOX)
+          expandDivsTimer = setTimeout(function() {
+            self.textLayerRenderTask.expandTextDivs(false);
+            expandDivsTimer = null;
+          }, EXPAND_DIVS_TIMEOUT);
+//#else
+//        self.textLayerRenderTask.expandTextDivs(false);
+//#endif
           return;
         }
         var end = div.querySelector('.endOfContent');


### PR DESCRIPTION
Uses a timeout to delay shrinking of divs, if another mousedown event occurs, it resets the timer. This fixes double click and right click highlighting on webkit browsers. This logic only applies when the enhanced text selection is turned on.

Fixes #7590.
