### PR TITLE
Text widget annotations: implement maximum length and text alignment

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -29,6 +29,7 @@
 
 var AnnotationBorderStyleType = sharedUtil.AnnotationBorderStyleType;
 var AnnotationType = sharedUtil.AnnotationType;
+var isInt = sharedUtil.isInt;
 var Util = sharedUtil.Util;
 var addLinkAttributes = displayDOMUtils.addLinkAttributes;
 var LinkTarget = displayDOMUtils.LinkTarget;
@@ -427,6 +428,8 @@ var WidgetAnnotationElement = (function WidgetAnnotationElementClosure() {
  */
 var TextWidgetAnnotationElement = (
     function TextWidgetAnnotationElementClosure() {
+  var TEXT_ALIGNMENT = ['left', 'center', 'right'];
+
   function TextWidgetAnnotationElement(parameters) {
     WidgetAnnotationElement.call(this, parameters);
   }
@@ -442,26 +445,33 @@ var TextWidgetAnnotationElement = (
     render: function TextWidgetAnnotationElement_render() {
       this.container.className = 'textWidgetAnnotation';
 
+      var element = null;
       if (this.renderInteractiveForms) {
-        var input = document.createElement('input');
-        input.type = 'text';
-        input.value = this.data.fieldValue;
+        element = document.createElement('input');
+        element.type = 'text';
+        element.value = this.data.fieldValue;
 
-        this.container.appendChild(input);
+        if (isInt(this.data.maxLen)) {
+          element.maxLength = this.data.maxLen;
+        }
       } else {
-        var content = document.createElement('div');
-        content.textContent = this.data.fieldValue;
-        var textAlignment = this.data.textAlignment;
-        content.style.textAlign = ['left', 'center', 'right'][textAlignment];
-        content.style.verticalAlign = 'middle';
-        content.style.display = 'table-cell';
+        element = document.createElement('div');
+        element.textContent = this.data.fieldValue;
+        element.style.verticalAlign = 'middle';
+        element.style.display = 'table-cell';
 
-        var font = (this.data.fontRefName ?
-          this.page.commonObjs.getData(this.data.fontRefName) : null);
-        this._setTextStyle(content, font);
-
-        this.container.appendChild(content);
+        var font = null;
+        if (this.data.fontRefName) {
+          font = this.page.commonObjs.getData(this.data.fontRefName);
+        }
+        this._setTextStyle(element, font);
       }
+
+      if (isInt(this.data.textAlignment)) {
+        element.style.textAlign = TEXT_ALIGNMENT[this.data.textAlignment];
+      }
+
+      this.container.appendChild(element);
       return this.container;
     },
 


### PR DESCRIPTION
Moreover, we refactor the code a bit to extract code that is shared between the two branches and we only apply text alignment (and create the array) when it is actually defined, since it's optional and left is already the default.

@Snuffleupagus Could you review this PR? This patch is a part of #7613 and improves the support for text widget annotations. You can test this by opening the `f1040.pdf` file and noticing that you can now only enter two characters into the top right input box (with 20 before it) and that most fields in the "Income" section and now right-aligned.
