### PR TITLE
Fallback to the `StandardEncoding` for Nonsymbolic fonts without `/Encoding` entry (issue 7580)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1738,11 +1738,18 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       if (baseEncodingName) {
         properties.defaultEncoding = getEncoding(baseEncodingName).slice();
       } else {
-        encoding = (properties.type === 'TrueType' ?
-                    WinAnsiEncoding : StandardEncoding);
+        var isSymbolicFont = !!(properties.flags & FontFlags.Symbolic);
+        var isNonsymbolicFont = !!(properties.flags & FontFlags.Nonsymbolic);
+        // According to "Table 114" in section "9.6.6.1 General" (under
+        // "9.6.6 Character Encoding") of the PDF specification, a Nonsymbolic
+        // font should use the `StandardEncoding` if no encoding is specified.
+        encoding = StandardEncoding;
+        if (properties.type === 'TrueType' && !isNonsymbolicFont) {
+          encoding = WinAnsiEncoding;
+        }
         // The Symbolic attribute can be misused for regular fonts
         // Heuristic: we have to check if the font is a standard one also
-        if (!!(properties.flags & FontFlags.Symbolic)) {
+        if (isSymbolicFont) {
           encoding = MacRomanEncoding;
           if (!properties.file) {
             if (/Symbol/i.test(properties.name)) {

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -37,6 +37,7 @@
 !issue7446.pdf
 !issue7492.pdf
 !issue7544.pdf
+!issue7580.pdf
 !issue7598.pdf
 !filled-background.pdf
 !ArabicCIDTrueType.pdf

--- a/test/pdfs/issue7580.pdf
+++ b/test/pdfs/issue7580.pdf
@@ -1,0 +1,85 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/FontName /ArialMT
+/StemV 50
+/Ascent 0
+/Flags 32
+/Descent 0
+/ItalicAngle 0
+/FontBBox [-46 -210 980 728]
+/Type /FontDescriptor
+/CapHeight 0
+>>
+endobj 
+2 0 obj 
+<<
+/Pages 3 0 R
+/Type /Catalog
+>>
+endobj 
+3 0 obj 
+<<
+/MediaBox [0 0 200 50]
+/Kids [4 0 R]
+/Type /Pages
+/Count 1
+>>
+endobj 
+4 0 obj 
+<<
+/Parent 3 0 R
+/Resources 
+<<
+/Font 
+<<
+/F1 5 0 R
+>>
+>>
+/MediaBox [0 0 200 50]
+/Type /Page
+/Contents 6 0 R
+>>
+endobj 
+5 0 obj 
+<<
+/BaseFont /ArialMT
+/LastChar 249
+/Subtype /TrueType
+/FontDescriptor 1 0 R
+/Widths [278 0 0 0 0 0 0 0 0 0 0 584 278 333 278 278 556 556 556 556 556 556 556 556 556 556 278 0 0 0 0 0 1015 667 667 722 722 0 611 0 0 278 500 667 0 0 722 0 667 0 722 0 611 0 667 0 0 0 0 0 0 0 0 0 0 556 556 500 556 556 278 556 556 222 222 500 222 834 556 556 556 0 333 500 278 556 501 722 497 500 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 889 0 0 0 0 0 0 0 611]
+/Type /Font
+/FirstChar 32
+>>
+endobj 
+6 0 obj 
+<<
+/Length 60
+>>
+stream
+BT
+10 20 TD
+/F1 18 Tf
+(Issue 7580: ae,\361 - o,\371.) Tj
+ET
+
+endstream 
+endobj xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000177 00000 n 
+0000000228 00000 n 
+0000000310 00000 n 
+0000000439 00000 n 
+0000001123 00000 n 
+trailer
+
+<<
+/Root 2 0 R
+/Size 7
+>>
+startxref
+1235
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1615,6 +1615,20 @@
        "link": false,
        "type": "eq"
     },
+    {  "id": "issue7580-eq",
+       "file": "pdfs/issue7580.pdf",
+       "md5": "44dd5a9b4373fcab9890cf567722a766",
+       "rounds": 1,
+       "link": false,
+       "type": "eq"
+    },
+    {  "id": "issue7580-text",
+       "file": "pdfs/issue7580.pdf",
+       "md5": "44dd5a9b4373fcab9890cf567722a766",
+       "rounds": 1,
+       "link": false,
+       "type": "text"
+    },
     {  "id": "issue6612-text",
        "file": "pdfs/issue6612.pdf",
        "md5": "657f33236496916597cd70ef1222509a",


### PR DESCRIPTION
Even though this patch passes all tests (unit/font/reference) locally, including the new ones that I added in PR #7621, I'm still a bit nervous about modifying the code that choose the fallback encoding for fonts without an `/Encoding` entry.
Note that over the years this code has been changed on a number of occasions, see a possibly incomplete [list here](https://gist.github.com/Snuffleupagus/a01105336950d876c18c8bd61f30c1e8), to deal with various cases of incorrect font data.

According to the PDF specification, see http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#G8.1904184, it seems that we should fallback to the `StandardEncoding` for Nonsymbolic fonts.
There's obviously a risk that fixing this particular issue _could_ break other PDF files for which we don't have tests. However I've tried to change the logic as little as possible in this patch, to hopefully reduce possible breakage.

Based on debugging numerous font issues, it seems that a lot of fonts actually set the Symbolic flag, even when they are in fact _not_ Symbolic. Fonts actually marked as Nonsymbolic seem to be somewhat less common, which I hope should reduce the risk of the patch somewhat.

Fixes #7580.
