### PR TITLE
Remove the deprecated `mozDash`/`mozDashOffset` canvas 2D context methods

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -655,9 +655,6 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     if (sourceCtx.setLineDash !== undefined) {
       destCtx.setLineDash(sourceCtx.getLineDash());
       destCtx.lineDashOffset =  sourceCtx.lineDashOffset;
-    } else if (sourceCtx.mozDashOffset !== undefined) {
-      destCtx.mozDash = sourceCtx.mozDash;
-      destCtx.mozDashOffset = sourceCtx.mozDashOffset;
     }
   }
 
@@ -913,9 +910,6 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       if (ctx.setLineDash !== undefined) {
         ctx.setLineDash(dashArray);
         ctx.lineDashOffset = dashPhase;
-      } else {
-        ctx.mozDash = dashArray;
-        ctx.mozDashOffset = dashPhase;
       }
     },
     setRenderingIntent: function CanvasGraphics_setRenderingIntent(intent) {

--- a/test/features/tests.js
+++ b/test/features/tests.js
@@ -408,9 +408,6 @@ var tests = [
       if ('setLineDash' in ctx) {
         ctx.setLineDash([10, 10]);
         ctx.lineDashOffset = 0;
-      } else {
-        ctx.mozDash = [10, 10];
-        ctx.mozDashOffset = 0;
       }
       ctx.stroke();
 


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash#Browser_compatibility) the standard versions of these methods have been supported since Firefox 27, which was released over two and a half years ago. (See the dates in https://wiki.mozilla.org/RapidRelease/Calendar#Past_branch_dates)

Furthermore the non-standard properties are now in the process of being removed, please see https://groups.google.com/forum/#!topic/mozilla.dev.platform/UIudMABegcY.
Hence I don't think that we need to keep the old `moz` prefixed ones as fallback any more.
