### PR TITLE
Deduct file type from content-disposition if needed

### DIFF
--- a/extensions/chromium/pdfHandler.js
+++ b/extensions/chromium/pdfHandler.js
@@ -73,9 +73,19 @@ function isPdfFile(details) {
   var header = getHeaderFromHeaders(details.responseHeaders, 'content-type');
   if (header) {
     var headerValue = header.value.toLowerCase().split(';',1)[0].trim();
-    return (headerValue === 'application/pdf' ||
-            headerValue === 'application/octet-stream' &&
-            details.url.toLowerCase().indexOf('.pdf') > 0);
+    if (headerValue === 'application/pdf') {
+      return true;
+    }
+    if (headerValue === 'application/octet-stream') {
+      if (details.url.toLowerCase().indexOf('.pdf') > 0) {
+        return true;
+      }
+      var cdHeader =
+        getHeaderFromHeaders(details.responseHeaders, 'content-disposition');
+      if (cdHeader && /\.pdf(["']|$)/i.test(cdHeader.value)) {
+        return true;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
A user encountered a response that looks like:

URL: some gibberish
Headers:

```
Content-Type: application/octet-stream
Content-Disposition: attachment; filename="something.pdf"
```

In the Chrome extension, the "attachment" content disposition is almost always ignored (i.e. the PDF Viewer will try to view it anyway). So we need to fall back to the Content-Disposition header if the URL check is inconclusive.

I'm not sure whether the user wants the PDF to be public, so I have mailed it to you @timvandermeij 
