### PR TITLE
Prevent errors if the 'resize' event is fired before the `eventBus` has been initialized

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1803,6 +1803,9 @@ function webViewerUpdateViewarea(e) {
 }
 
 window.addEventListener('resize', function webViewerResize(evt) {
+  if (!PDFViewerApplication.eventBus) {
+    return;
+  }
   PDFViewerApplication.eventBus.dispatch('resize');
 });
 


### PR DESCRIPTION
When opening a PDF file that triggers the browser fallback bar in the Firefox addon/built-in version, e.g. http://web.archive.org/web/20110918100215/http://www.irs.gov/pub/irs-pdf/f1040.pdf (with forms _disabled_), and then reloading the document an error can be thrown.
The reason is that displaying the fallback bar triggers 'resize' events, and they can arrive _before_ the viewer has had a chance to run all the necessary initialization code.
