### PR TITLE
Attempt to skip zero bytes at the end of Scan blocks when decoding JPEG images (issue 4090)

### DIFF
--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -365,6 +365,12 @@ var JpegImage = (function JpegImageClosure() {
       // find marker
       bitsCount = 0;
       marker = (data[offset] << 8) | data[offset + 1];
+      // Some bad images seem to pad Scan blocks with zero bytes, skip past
+      // those to attempt to find a valid marker (fixes issue4090.pdf).
+      while (data[offset] === 0x00 && offset < data.length - 1) {
+        offset++;
+        marker = (data[offset] << 8) | data[offset + 1];
+      }
       if (marker <= 0xFF00) {
         error('JPEG error: marker was not found');
       }

--- a/test/pdfs/issue4090.pdf.link
+++ b/test/pdfs/issue4090.pdf.link
@@ -1,0 +1,1 @@
+http://web.archive.org/web/20160819222859/http://www.ets.org/Media/Tests/GRE/pdf/gre_research_validity_data.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -639,6 +639,14 @@
        "link": false,
        "type": "eq"
     },
+    {  "id": "issue4090",
+       "file": "pdfs/issue4090.pdf",
+       "md5": "8cec73e090985acf6094c683d7944425",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue5202",
        "file": "pdfs/issue5202.pdf",
        "md5": "bb9cc69211112e66aab40828086a4e5a",


### PR DESCRIPTION
Fixes #4090.
