### PR TITLE
Add optional argument to PDFWorker for custom/bundled workers

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1168,7 +1168,7 @@ var PDFWorker = (function PDFWorkerClosure() {
     return URL.createObjectURL(new Blob([wrapper]));
   }
 
-  function PDFWorker(name) {
+  function PDFWorker(name, customWorker) {
     this.name = name;
     this.destroyed = false;
 
@@ -1176,7 +1176,7 @@ var PDFWorker = (function PDFWorkerClosure() {
     this._port = null;
     this._webWorker = null;
     this._messageHandler = null;
-    this._initialize();
+    this._initialize(customWorker);
   }
 
   PDFWorker.prototype =  /** @lends PDFWorker.prototype */ {
@@ -1192,7 +1192,7 @@ var PDFWorker = (function PDFWorkerClosure() {
       return this._messageHandler;
     },
 
-    _initialize: function PDFWorker_initialize() {
+    _initialize: function PDFWorker_initialize(customWorker) {
       // If worker support isn't disabled explicit and the browser has worker
       // support, create a new web worker and test if it/the browser fulfills
       // all requirements to run parts of pdf.js in a web worker.
@@ -1214,7 +1214,12 @@ var PDFWorker = (function PDFWorkerClosure() {
 //#endif
           // Some versions of FF can't create a worker on localhost, see:
           // https://bugzilla.mozilla.org/show_bug.cgi?id=683280
-          var worker = new Worker(workerSrc);
+          var worker;
+          if (customWorker) {
+            worker = customWorker;
+          } else {
+            worker = new Worker(workerSrc);
+          }
           var messageHandler = new MessageHandler('main', 'worker', worker);
           var terminateEarly = function() {
             worker.removeEventListener('error', onWorkerError);


### PR DESCRIPTION
- Support for webpack, browserify, etc users to pass in the proper web worker
  - E.g. webpack's worker-loader, browserify's webworkify

Meant as a prototype to fix #7612 . This isn't quite implemented as an overloaded constructor but instead with an optional argument.

An update to the [wiki](https://github.com/mozilla/pdf.js/wiki/Setup-pdf.js-in-a-website#with-webpack) documenting how to use this functionality should be followed up.
