### PR TITLE
[api-minor] Add support for relative URLs, in both annotations and the outline, by adding a `docBaseUrl` parameter to `PDFJS.getDocument` (bug 766086)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -64,11 +64,12 @@ AnnotationFactory.prototype = /** @lends AnnotationFactory.prototype */ {
   /**
    * @param {XRef} xref
    * @param {Object} ref
+   * @param {PDFManager} pdfManager
    * @param {string} uniquePrefix
    * @param {Object} idCounters
    * @returns {Annotation}
    */
-  create: function AnnotationFactory_create(xref, ref,
+  create: function AnnotationFactory_create(xref, ref, pdfManager,
                                             uniquePrefix, idCounters) {
     var dict = xref.fetchIfRef(ref);
     if (!isDict(dict)) {
@@ -88,6 +89,7 @@ AnnotationFactory.prototype = /** @lends AnnotationFactory.prototype */ {
       ref: isRef(ref) ? ref : null,
       subtype: subtype,
       id: id,
+      pdfManager: pdfManager,
     };
 
     switch (subtype) {
@@ -846,6 +848,7 @@ var LinkAnnotation = (function LinkAnnotationClosure() {
     Catalog.parseDestDictionary({
       destDict: params.dict,
       resultObj: data,
+      docBaseUrl: params.pdfManager.docBaseUrl,
     });
   }
 

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -38,14 +38,11 @@ var AnnotationFlag = sharedUtil.AnnotationFlag;
 var AnnotationType = sharedUtil.AnnotationType;
 var OPS = sharedUtil.OPS;
 var Util = sharedUtil.Util;
-var isBool = sharedUtil.isBool;
 var isString = sharedUtil.isString;
 var isArray = sharedUtil.isArray;
 var isInt = sharedUtil.isInt;
-var isValidUrl = sharedUtil.isValidUrl;
 var stringToBytes = sharedUtil.stringToBytes;
 var stringToPDFString = sharedUtil.stringToPDFString;
-var stringToUTF8String = sharedUtil.stringToUTF8String;
 var warn = sharedUtil.warn;
 var Dict = corePrimitives.Dict;
 var isDict = corePrimitives.isDict;
@@ -53,6 +50,7 @@ var isName = corePrimitives.isName;
 var isRef = corePrimitives.isRef;
 var Stream = coreStream.Stream;
 var ColorSpace = coreColorSpace.ColorSpace;
+var Catalog = coreObj.Catalog;
 var ObjectLoader = coreObj.ObjectLoader;
 var FileSpec = coreObj.FileSpec;
 var OperatorList = coreEvaluator.OperatorList;
@@ -842,103 +840,13 @@ var LinkAnnotation = (function LinkAnnotationClosure() {
   function LinkAnnotation(params) {
     Annotation.call(this, params);
 
-    var dict = params.dict;
     var data = this.data;
     data.annotationType = AnnotationType.LINK;
 
-    var action = dict.get('A'), url, dest;
-    if (action && isDict(action)) {
-      var linkType = action.get('S').name;
-      switch (linkType) {
-        case 'URI':
-          url = action.get('URI');
-          if (isName(url)) {
-            // Some bad PDFs do not put parentheses around relative URLs.
-            url = '/' + url.name;
-          } else if (url) {
-            url = addDefaultProtocolToUrl(url);
-          }
-          // TODO: pdf spec mentions urls can be relative to a Base
-          // entry in the dictionary.
-          break;
-
-        case 'GoTo':
-          dest = action.get('D');
-          break;
-
-        case 'GoToR':
-          var urlDict = action.get('F');
-          if (isDict(urlDict)) {
-            // We assume that we found a FileSpec dictionary
-            // and fetch the URL without checking any further.
-            url = urlDict.get('F') || null;
-          } else if (isString(urlDict)) {
-            url = urlDict;
-          }
-
-          // NOTE: the destination is relative to the *remote* document.
-          var remoteDest = action.get('D');
-          if (remoteDest) {
-            if (isName(remoteDest)) {
-              remoteDest = remoteDest.name;
-            }
-            if (isString(url)) {
-              var baseUrl = url.split('#')[0];
-              if (isString(remoteDest)) {
-                // In practice, a named destination may contain only a number.
-                // If that happens, use the '#nameddest=' form to avoid the link
-                // redirecting to a page, instead of the correct destination.
-                url = baseUrl + '#' +
-                  (/^\d+$/.test(remoteDest) ? 'nameddest=' : '') + remoteDest;
-              } else if (isArray(remoteDest)) {
-                url = baseUrl + '#' + JSON.stringify(remoteDest);
-              }
-            }
-          }
-          // The 'NewWindow' property, equal to `LinkTarget.BLANK`.
-          var newWindow = action.get('NewWindow');
-          if (isBool(newWindow)) {
-            data.newWindow = newWindow;
-          }
-          break;
-
-        case 'Named':
-          data.action = action.get('N').name;
-          break;
-
-        default:
-          warn('unrecognized link type: ' + linkType);
-      }
-    } else if (dict.has('Dest')) { // Simple destination link.
-      dest = dict.get('Dest');
-    }
-
-    if (url) {
-      if (isValidUrl(url, /* allowRelative = */ false)) {
-        data.url = tryConvertUrlEncoding(url);
-      }
-    }
-    if (dest) {
-      data.dest = isName(dest) ? dest.name : dest;
-    }
-  }
-
-  // Lets URLs beginning with 'www.' default to using the 'http://' protocol.
-  function addDefaultProtocolToUrl(url) {
-    if (isString(url) && url.indexOf('www.') === 0) {
-      return ('http://' + url);
-    }
-    return url;
-  }
-
-  function tryConvertUrlEncoding(url) {
-    // According to ISO 32000-1:2008, section 12.6.4.7, URIs should be encoded
-    // in 7-bit ASCII. Some bad PDFs use UTF-8 encoding, see Bugzilla 1122280.
-    try {
-      return stringToUTF8String(url);
-    } catch (e) {
-      return url;
-    }
+    Catalog.parseDestDictionary({
+      destDict: params.dict,
+      resultObj: data,
+    });
   }
 
   Util.inherit(LinkAnnotation, Annotation, {});

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -329,6 +329,7 @@ var Page = (function PageClosure() {
       for (var i = 0, n = annotationRefs.length; i < n; ++i) {
         var annotationRef = annotationRefs[i];
         var annotation = annotationFactory.create(this.xref, annotationRef,
+                                                  this.pdfManager,
                                                   this.uniquePrefix,
                                                   this.idCounters);
         if (annotation) {

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -48,7 +48,7 @@ var shadow = sharedUtil.shadow;
 var stringToPDFString = sharedUtil.stringToPDFString;
 var stringToUTF8String = sharedUtil.stringToUTF8String;
 var warn = sharedUtil.warn;
-var isValidUrl = sharedUtil.isValidUrl;
+var createValidAbsoluteUrl = sharedUtil.createValidAbsoluteUrl;
 var Util = sharedUtil.Util;
 var Ref = corePrimitives.Ref;
 var RefSet = corePrimitives.RefSet;
@@ -694,13 +694,9 @@ var Catalog = (function CatalogClosure() {
 
     if (isString(url)) {
       url = tryConvertUrlEncoding(url);
-      var absoluteUrl;
-      try {
-        absoluteUrl = new URL(url).href;
-      } catch (ex) { /* `new URL()` will throw on incorrect data. */ }
-
-      if (isValidUrl(absoluteUrl, /* allowRelative = */ false)) {
-        resultObj.url = absoluteUrl;
+      var absoluteUrl = createValidAbsoluteUrl(url);
+      if (absoluteUrl) {
+        resultObj.url = absoluteUrl.href;
       }
       resultObj.unsafeUrl = url;
     }

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -157,6 +157,7 @@ var Catalog = (function CatalogClosure() {
         Catalog.parseDestDictionary({
           destDict: outlineDict,
           resultObj: data,
+          docBaseUrl: this.pdfManager.docBaseUrl,
         });
         var title = outlineDict.get('Title');
         var flags = outlineDict.get('F') || 0;
@@ -590,6 +591,8 @@ var Catalog = (function CatalogClosure() {
    * @param {Dict} destDict - The dictionary containing the destination.
    * @param {Object} resultObj - The object where the parsed destination
    *   properties will be placed.
+   * @param {string} docBaseUrl - (optional) The document base URL that is used
+   *   when attempting to recover valid absolute URLs from relative ones.
    */
   Catalog.parseDestDictionary = function Catalog_parseDestDictionary(params) {
     // Lets URLs beginning with 'www.' default to using the 'http://' protocol.
@@ -619,6 +622,7 @@ var Catalog = (function CatalogClosure() {
       warn('Catalog_parseDestDictionary: "resultObj" must be an object.');
       return;
     }
+    var docBaseUrl = params.docBaseUrl || null;
 
     var action = destDict.get('A'), url, dest;
     if (isDict(action)) {
@@ -694,7 +698,7 @@ var Catalog = (function CatalogClosure() {
 
     if (isString(url)) {
       url = tryConvertUrlEncoding(url);
-      var absoluteUrl = createValidAbsoluteUrl(url);
+      var absoluteUrl = createValidAbsoluteUrl(url, docBaseUrl);
       if (absoluteUrl) {
         resultObj.url = absoluteUrl.href;
       }

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -31,6 +31,9 @@
 }(this, function (exports, sharedUtil, coreStream, coreChunkedStream,
                   coreDocument) {
 
+var warn = sharedUtil.warn;
+var createValidAbsoluteUrl = sharedUtil.createValidAbsoluteUrl;
+var shadow = sharedUtil.shadow;
 var NotImplementedException = sharedUtil.NotImplementedException;
 var MissingDataException = sharedUtil.MissingDataException;
 var createPromiseCapability = sharedUtil.createPromiseCapability;
@@ -47,6 +50,19 @@ var BasePdfManager = (function BasePdfManagerClosure() {
   BasePdfManager.prototype = {
     get docId() {
       return this._docId;
+    },
+
+    get docBaseUrl() {
+      var docBaseUrl = null;
+      if (this._docBaseUrl) {
+        var absoluteUrl = createValidAbsoluteUrl(this._docBaseUrl);
+        if (absoluteUrl) {
+          docBaseUrl = absoluteUrl.href;
+        } else {
+          warn('Invalid absolute docBaseUrl: "' + this._docBaseUrl + '".');
+        }
+      }
+      return shadow(this, 'docBaseUrl', docBaseUrl);
     },
 
     onLoadedStream: function BasePdfManager_onLoadedStream() {
@@ -110,8 +126,10 @@ var BasePdfManager = (function BasePdfManagerClosure() {
 })();
 
 var LocalPdfManager = (function LocalPdfManagerClosure() {
-  function LocalPdfManager(docId, data, password, evaluatorOptions) {
+  function LocalPdfManager(docId, data, password, evaluatorOptions,
+                           docBaseUrl) {
     this._docId = docId;
+    this._docBaseUrl = docBaseUrl;
     this.evaluatorOptions = evaluatorOptions;
     var stream = new Stream(data);
     this.pdfDocument = new PDFDocument(this, stream, password);
@@ -158,8 +176,10 @@ var LocalPdfManager = (function LocalPdfManagerClosure() {
 })();
 
 var NetworkPdfManager = (function NetworkPdfManagerClosure() {
-  function NetworkPdfManager(docId, pdfNetworkStream, args, evaluatorOptions) {
+  function NetworkPdfManager(docId, pdfNetworkStream, args, evaluatorOptions,
+                             docBaseUrl) {
     this._docId = docId;
+    this._docBaseUrl = docBaseUrl;
     this.msgHandler = args.msgHandler;
     this.evaluatorOptions = evaluatorOptions;
 

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -480,6 +480,7 @@ var WorkerMessageHandler = {
     var WorkerTasks = [];
 
     var docId = docParams.docId;
+    var docBaseUrl = docParams.docBaseUrl;
     var workerHandlerName = docParams.docId + '_worker';
     var handler = new MessageHandler(workerHandlerName, docId, port);
 
@@ -544,7 +545,7 @@ var WorkerMessageHandler = {
       if (source.data) {
         try {
           pdfManager = new LocalPdfManager(docId, source.data, source.password,
-                                           evaluatorOptions);
+                                           evaluatorOptions, docBaseUrl);
           pdfManagerCapability.resolve(pdfManager);
         } catch (ex) {
           pdfManagerCapability.reject(ex);
@@ -593,7 +594,7 @@ var WorkerMessageHandler = {
           length: fullRequest.contentLength,
           disableAutoFetch: disableAutoFetch,
           rangeChunkSize: source.rangeChunkSize
-        }, evaluatorOptions);
+        }, evaluatorOptions, docBaseUrl);
         pdfManagerCapability.resolve(pdfManager);
         cancelXHRs = null;
       }).catch(function (reason) {
@@ -610,7 +611,7 @@ var WorkerMessageHandler = {
         // the data is array, instantiating directly from it
         try {
           pdfManager = new LocalPdfManager(docId, pdfFile, source.password,
-                                           evaluatorOptions);
+                                           evaluatorOptions, docBaseUrl);
           pdfManagerCapability.resolve(pdfManager);
         } catch (ex) {
           pdfManagerCapability.reject(ex);

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -129,6 +129,9 @@ if (typeof PDFJSDev !== 'undefined' &&
  *   2^16 = 65536.
  * @property {PDFWorker}  worker - The worker that will be used for the loading
  *   and parsing of the PDF data.
+ * @property {string} docBaseUrl - (optional) The base URL of the document,
+ *   used when attempting to recover valid absolute URLs for annotations, and
+ *   outline items, that (incorrectly) only specify relative URLs.
  */
 
 /**
@@ -301,6 +304,7 @@ function _fetchDocument(worker, source, pdfDataRangeTransport, docId) {
     disableCreateObjectURL: getDefaultSetting('disableCreateObjectURL'),
     postMessageTransfers: getDefaultSetting('postMessageTransfers') &&
                           !isPostMessageTransfersDisabled,
+    docBaseUrl: source.docBaseUrl,
   }).then(function (workerId) {
     if (worker.destroyed) {
       throw new Error('Worker was destroyed');

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -28,6 +28,8 @@
 
 var removeNullCharacters = sharedUtil.removeNullCharacters;
 var warn = sharedUtil.warn;
+var deprecated = sharedUtil.deprecated;
+var createValidAbsoluteUrl = sharedUtil.createValidAbsoluteUrl;
 
 /**
  * Optimised CSS custom property getter/setter.
@@ -229,9 +231,16 @@ function isExternalLinkTargetSet() {
   }
 }
 
+function isValidUrl(url, allowRelative) {
+  deprecated('isValidUrl(), please use createValidAbsoluteUrl() instead.');
+  var baseUrl = allowRelative ? 'http://example.com' : null;
+  return createValidAbsoluteUrl(url, baseUrl) !== null;
+}
+
 exports.CustomStyle = CustomStyle;
 exports.addLinkAttributes = addLinkAttributes;
 exports.isExternalLinkTargetSet = isExternalLinkTargetSet;
+exports.isValidUrl = isValidUrl;
 exports.getFilenameFromUrl = getFilenameFromUrl;
 exports.LinkTarget = LinkTarget;
 exports.hasCanvasTypedArrays = hasCanvasTypedArrays;

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -76,7 +76,7 @@
   PDFJS.VERBOSITY_LEVELS = sharedUtil.VERBOSITY_LEVELS;
   PDFJS.OPS = sharedUtil.OPS;
   PDFJS.UNSUPPORTED_FEATURES = sharedUtil.UNSUPPORTED_FEATURES;
-  PDFJS.isValidUrl = sharedUtil.isValidUrl;
+  PDFJS.isValidUrl = displayDOMUtils.isValidUrl;
   PDFJS.shadow = sharedUtil.shadow;
   PDFJS.createBlob = sharedUtil.createBlob;
   PDFJS.createObjectURL = function PDFJS_createObjectURL(data, contentType) {

--- a/src/main_loader.js
+++ b/src/main_loader.js
@@ -55,12 +55,12 @@
   exports.UnexpectedResponseException = sharedUtil.UnexpectedResponseException;
   exports.OPS = sharedUtil.OPS;
   exports.UNSUPPORTED_FEATURES = sharedUtil.UNSUPPORTED_FEATURES;
-  exports.isValidUrl = sharedUtil.isValidUrl;
+  exports.isValidUrl = displayDOMUtils.isValidUrl;
+  exports.createValidAbsoluteUrl = sharedUtil.createValidAbsoluteUrl;
   exports.createObjectURL = sharedUtil.createObjectURL;
   exports.removeNullCharacters = sharedUtil.removeNullCharacters;
   exports.shadow = sharedUtil.shadow;
   exports.createBlob = sharedUtil.createBlob;
   exports.getFilenameFromUrl = displayDOMUtils.getFilenameFromUrl;
   exports.addLinkAttributes = displayDOMUtils.addLinkAttributes;
-
 }));

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -64,7 +64,9 @@
     exports.OPS = pdfjsLibs.pdfjsSharedUtil.OPS;
     exports.UNSUPPORTED_FEATURES =
       pdfjsLibs.pdfjsSharedUtil.UNSUPPORTED_FEATURES;
-    exports.isValidUrl = pdfjsLibs.pdfjsSharedUtil.isValidUrl;
+    exports.isValidUrl = pdfjsLibs.pdfjsDisplayDOMUtils.isValidUrl;
+    exports.createValidAbsoluteUrl =
+      pdfjsLibs.pdfjsSharedUtil.createValidAbsoluteUrl;
     exports.createObjectURL = pdfjsLibs.pdfjsSharedUtil.createObjectURL;
     exports.removeNullCharacters =
       pdfjsLibs.pdfjsSharedUtil.removeNullCharacters;

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -332,28 +332,40 @@ function isSameOrigin(baseUrl, otherUrl) {
   return base.origin === other.origin;
 }
 
-// Validates if URL is safe and allowed, e.g. to avoid XSS.
-function isValidUrl(url, allowRelative) {
-  if (!url || typeof url !== 'string') {
+// Checks if URLs use one of the whitelisted protocols, e.g. to avoid XSS.
+function isValidProtocol(url) {
+  if (!url) {
     return false;
   }
-  // RFC 3986 (http://tools.ietf.org/html/rfc3986#section-3.1)
-  // scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
-  var protocol = /^[a-z][a-z0-9+\-.]*(?=:)/i.exec(url);
-  if (!protocol) {
-    return allowRelative;
-  }
-  protocol = protocol[0].toLowerCase();
-  switch (protocol) {
-    case 'http':
-    case 'https':
-    case 'ftp':
-    case 'mailto':
-    case 'tel':
+  switch (url.protocol) {
+    case 'http:':
+    case 'https:':
+    case 'ftp:':
+    case 'mailto:':
+    case 'tel:':
       return true;
     default:
       return false;
   }
+}
+
+/**
+ * Attempts to create a valid absolute URL (utilizing `isValidProtocol`).
+ * @param {URL|string} url - An absolute, or relative, URL.
+ * @param {URL|string} baseUrl - An absolute URL.
+ * @returns Either a valid {URL}, or `null` otherwise.
+ */
+function createValidAbsoluteUrl(url, baseUrl) {
+  if (!url) {
+    return null;
+  }
+  try {
+    var absoluteUrl = baseUrl ? new URL(url, baseUrl) : new URL(url);
+    if (isValidProtocol(absoluteUrl)) {
+      return absoluteUrl;
+    }
+  } catch (ex) { /* `new URL()` will throw on incorrect data. */ }
+  return null;
 }
 
 function shadow(obj, prop, value) {
@@ -2431,7 +2443,7 @@ exports.isNum = isNum;
 exports.isString = isString;
 exports.isSpace = isSpace;
 exports.isSameOrigin = isSameOrigin;
-exports.isValidUrl = isValidUrl;
+exports.createValidAbsoluteUrl = createValidAbsoluteUrl;
 exports.isLittleEndian = isLittleEndian;
 exports.isEvalSupported = isEvalSupported;
 exports.loadJpegStream = loadJpegStream;

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -46,6 +46,7 @@
 !arial_unicode_ab_cidfont.pdf
 !arial_unicode_en_cidfont.pdf
 !asciihexdecode.pdf
+!bug766086.pdf
 !bug793632.pdf
 !bug1020858.pdf
 !bug1050040.pdf

--- a/test/pdfs/bug766086.pdf
+++ b/test/pdfs/bug766086.pdf
@@ -1,0 +1,85 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/Pages 2 0 R
+/Type /Catalog
+>>
+endobj 
+2 0 obj 
+<<
+/Kids [3 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+3 0 obj 
+<<
+/Parent 2 0 R
+/Annots [4 0 R]
+/MediaBox [0 0 200 50]
+/Resources 
+<<
+/Font 
+<<
+/F1 5 0 R
+>>
+>>
+/Contents 6 0 R
+/Type /Page
+>>
+endobj 
+4 0 obj 
+<<
+/Border [0 0 1]
+/Subtype /Link
+/C [1 0 0]
+/A 
+<<
+/F (../../0021/002156/215675E.pdf)
+/D (15)
+/Type /Action
+/S /GoToR
+>>
+/Type /Annot
+/Rect [5 10 190 40]
+>>
+endobj 
+5 0 obj 
+<<
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/Type /Font
+>>
+endobj 
+6 0 obj 
+<<
+/Length 58
+>>
+stream
+BT
+10 20 TD
+/F1 16 Tf
+(Bug 766086 - relative links) Tj
+ET
+
+endstream 
+endobj xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000066 00000 n 
+0000000125 00000 n 
+0000000270 00000 n 
+0000000445 00000 n 
+0000000546 00000 n 
+trailer
+
+<<
+/Root 1 0 R
+/Size 7
+>>
+startxref
+656
+%%EOF

--- a/test/unit/annotation_layer_spec.js
+++ b/test/unit/annotation_layer_spec.js
@@ -27,15 +27,24 @@ describe('Annotation layer', function() {
     },
   };
 
-  var annotationFactory;
+  function PDFManagerMock(params) {
+    this.docBaseUrl = params.docBaseUrl || null;
+  }
+  PDFManagerMock.prototype = {};
+
+  var annotationFactory, pdfManagerMock;
 
   beforeAll(function (done) {
     annotationFactory = new AnnotationFactory();
+    pdfManagerMock = new PDFManagerMock({
+      docBaseUrl: null,
+    });
     done();
   });
 
   afterAll(function () {
     annotationFactory = null;
+    pdfManagerMock = null;
   });
 
   describe('AnnotationFactory', function () {
@@ -49,7 +58,8 @@ describe('Annotation layer', function() {
         { ref: annotationRef, data: annotationDict, }
       ]);
 
-      var annotation = annotationFactory.create(xref, annotationRef);
+      var annotation = annotationFactory.create(xref, annotationRef,
+                                                pdfManagerMock);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -66,8 +76,10 @@ describe('Annotation layer', function() {
       var uniquePrefix = 'p0_', idCounters = { obj: 0, };
 
       var annotation1 = annotationFactory.create(xref, annotationDict,
+                                                 pdfManagerMock,
                                                  uniquePrefix, idCounters);
       var annotation2 = annotationFactory.create(xref, annotationDict,
+                                                 pdfManagerMock,
                                                  uniquePrefix, idCounters);
       var data1 = annotation1.data, data2 = annotation2.data;
       expect(data1.annotationType).toEqual(AnnotationType.LINK);
@@ -86,7 +98,8 @@ describe('Annotation layer', function() {
         { ref: annotationRef, data: annotationDict, }
       ]);
 
-      var annotation = annotationFactory.create(xref, annotationRef);
+      var annotation = annotationFactory.create(xref, annotationRef,
+                                                pdfManagerMock);
       var data = annotation.data;
       expect(data.annotationType).toBeUndefined();
     });
@@ -270,7 +283,8 @@ describe('Annotation layer', function() {
         { ref: annotationRef, data: annotationDict, }
       ]);
 
-      var annotation = annotationFactory.create(xref, annotationRef);
+      var annotation = annotationFactory.create(xref, annotationRef,
+                                                pdfManagerMock);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -297,7 +311,8 @@ describe('Annotation layer', function() {
         { ref: annotationRef, data: annotationDict, }
       ]);
 
-      var annotation = annotationFactory.create(xref, annotationRef);
+      var annotation = annotationFactory.create(xref, annotationRef,
+                                                pdfManagerMock);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -329,7 +344,8 @@ describe('Annotation layer', function() {
         { ref: annotationRef, data: annotationDict, }
       ]);
 
-      var annotation = annotationFactory.create(xref, annotationRef);
+      var annotation = annotationFactory.create(xref, annotationRef,
+                                                pdfManagerMock);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -356,7 +372,8 @@ describe('Annotation layer', function() {
         { ref: annotationRef, data: annotationDict, }
       ]);
 
-      var annotation = annotationFactory.create(xref, annotationRef);
+      var annotation = annotationFactory.create(xref, annotationRef,
+                                                pdfManagerMock);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -384,7 +401,8 @@ describe('Annotation layer', function() {
         { ref: annotationRef, data: annotationDict, }
       ]);
 
-      var annotation = annotationFactory.create(xref, annotationRef);
+      var annotation = annotationFactory.create(xref, annotationRef,
+                                                pdfManagerMock);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -392,6 +410,38 @@ describe('Annotation layer', function() {
       expect(data.unsafeUrl).toEqual('../../0013/001346/134685E.pdf#4.3');
       expect(data.dest).toBeUndefined();
       expect(data.newWindow).toEqual(true);
+    });
+
+    it('should correctly parse a GoToR action, containing a relative URL, ' +
+       'with the "docBaseUrl" parameter specified', function() {
+      var actionDict = new Dict();
+      actionDict.set('Type', Name.get('Action'));
+      actionDict.set('S', Name.get('GoToR'));
+      actionDict.set('F', '../../0013/001346/134685E.pdf');
+      actionDict.set('D', '4.3');
+
+      var annotationDict = new Dict();
+      annotationDict.set('Type', Name.get('Annot'));
+      annotationDict.set('Subtype', Name.get('Link'));
+      annotationDict.set('A', actionDict);
+
+      var annotationRef = new Ref(489, 0);
+      var xref = new XRefMock([
+        { ref: annotationRef, data: annotationDict, }
+      ]);
+      var pdfManager = new PDFManagerMock({
+        docBaseUrl: 'http://www.example.com/test/pdfs/qwerty.pdf',
+      });
+
+      var annotation = annotationFactory.create(xref, annotationRef,
+                                                pdfManager);
+      var data = annotation.data;
+      expect(data.annotationType).toEqual(AnnotationType.LINK);
+
+      expect(data.url).toEqual(
+        'http://www.example.com/0013/001346/134685E.pdf#4.3');
+      expect(data.unsafeUrl).toEqual('../../0013/001346/134685E.pdf#4.3');
+      expect(data.dest).toBeUndefined();
     });
 
     it('should correctly parse a GoToR action, with named destination',
@@ -412,7 +462,8 @@ describe('Annotation layer', function() {
         { ref: annotationRef, data: annotationDict, }
       ]);
 
-      var annotation = annotationFactory.create(xref, annotationRef);
+      var annotation = annotationFactory.create(xref, annotationRef,
+                                                pdfManagerMock);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -441,7 +492,8 @@ describe('Annotation layer', function() {
         { ref: annotationRef, data: annotationDict, }
       ]);
 
-      var annotation = annotationFactory.create(xref, annotationRef);
+      var annotation = annotationFactory.create(xref, annotationRef,
+                                                pdfManagerMock);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -469,7 +521,8 @@ describe('Annotation layer', function() {
         { ref: annotationRef, data: annotationDict, }
       ]);
 
-      var annotation = annotationFactory.create(xref, annotationRef);
+      var annotation = annotationFactory.create(xref, annotationRef,
+                                                pdfManagerMock);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -489,7 +542,8 @@ describe('Annotation layer', function() {
         { ref: annotationRef, data: annotationDict, }
       ]);
 
-      var annotation = annotationFactory.create(xref, annotationRef);
+      var annotation = annotationFactory.create(xref, annotationRef,
+                                                pdfManagerMock);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -511,7 +565,8 @@ describe('Annotation layer', function() {
         { ref: annotationRef, data: annotationDict, }
       ]);
 
-      var annotation = annotationFactory.create(xref, annotationRef);
+      var annotation = annotationFactory.create(xref, annotationRef,
+                                                pdfManagerMock);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -545,7 +600,8 @@ describe('Annotation layer', function() {
         { ref: textWidgetRef, data: textWidgetDict, }
       ]);
 
-      var textWidgetAnnotation = annotationFactory.create(xref, textWidgetRef);
+      var textWidgetAnnotation = annotationFactory.create(xref, textWidgetRef,
+                                                          pdfManagerMock);
       expect(textWidgetAnnotation.data.textAlignment).toEqual(null);
       expect(textWidgetAnnotation.data.maxLen).toEqual(null);
       expect(textWidgetAnnotation.data.readOnly).toEqual(false);
@@ -564,7 +620,8 @@ describe('Annotation layer', function() {
         { ref: textWidgetRef, data: textWidgetDict, }
       ]);
 
-      var textWidgetAnnotation = annotationFactory.create(xref, textWidgetRef);
+      var textWidgetAnnotation = annotationFactory.create(xref, textWidgetRef,
+                                                          pdfManagerMock);
       expect(textWidgetAnnotation.data.textAlignment).toEqual(null);
       expect(textWidgetAnnotation.data.maxLen).toEqual(null);
       expect(textWidgetAnnotation.data.readOnly).toEqual(false);
@@ -584,7 +641,8 @@ describe('Annotation layer', function() {
         { ref: textWidgetRef, data: textWidgetDict, }
       ]);
 
-      var textWidgetAnnotation = annotationFactory.create(xref, textWidgetRef);
+      var textWidgetAnnotation = annotationFactory.create(xref, textWidgetRef,
+                                                          pdfManagerMock);
       expect(textWidgetAnnotation.data.textAlignment).toEqual(1);
       expect(textWidgetAnnotation.data.maxLen).toEqual(20);
       expect(textWidgetAnnotation.data.readOnly).toEqual(true);
@@ -599,7 +657,8 @@ describe('Annotation layer', function() {
         { ref: textWidgetRef, data: textWidgetDict, }
       ]);
 
-      var textWidgetAnnotation = annotationFactory.create(xref, textWidgetRef);
+      var textWidgetAnnotation = annotationFactory.create(xref, textWidgetRef,
+                                                          pdfManagerMock);
       expect(textWidgetAnnotation.data.comb).toEqual(false);
     });
 
@@ -612,7 +671,8 @@ describe('Annotation layer', function() {
         { ref: textWidgetRef, data: textWidgetDict, }
       ]);
 
-      var textWidgetAnnotation = annotationFactory.create(xref, textWidgetRef);
+      var textWidgetAnnotation = annotationFactory.create(xref, textWidgetRef,
+                                                          pdfManagerMock);
       expect(textWidgetAnnotation.data.comb).toEqual(true);
     });
 
@@ -636,9 +696,8 @@ describe('Annotation layer', function() {
           { ref: textWidgetRef, data: textWidgetDict, }
         ]);
 
-        var textWidgetAnnotation = annotationFactory.create(xref,
-                                                            textWidgetRef);
-
+        var textWidgetAnnotation = annotationFactory.create(xref, textWidgetRef,
+                                                            pdfManagerMock);
         var valid = (invalidFieldFlags.length === 0);
         expect(textWidgetAnnotation.data.comb).toEqual(valid);
 
@@ -673,7 +732,8 @@ describe('Annotation layer', function() {
       ]);
 
       var choiceWidgetAnnotation = annotationFactory.create(xref,
-                                                            choiceWidgetRef);
+                                                            choiceWidgetRef,
+                                                            pdfManagerMock);
       var data = choiceWidgetAnnotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
       expect(data.options).toEqual([]);
@@ -700,7 +760,8 @@ describe('Annotation layer', function() {
       ]);
 
       var choiceWidgetAnnotation = annotationFactory.create(xref,
-                                                            choiceWidgetRef);
+                                                            choiceWidgetRef,
+                                                            pdfManagerMock);
       var data = choiceWidgetAnnotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
       expect(data.options).toEqual(expected);
@@ -727,7 +788,8 @@ describe('Annotation layer', function() {
       ]);
 
       var choiceWidgetAnnotation = annotationFactory.create(xref,
-                                                            choiceWidgetRef);
+                                                            choiceWidgetRef,
+                                                            pdfManagerMock);
       var data = choiceWidgetAnnotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
       expect(data.options).toEqual(expected);
@@ -744,7 +806,8 @@ describe('Annotation layer', function() {
       ]);
 
       var choiceWidgetAnnotation = annotationFactory.create(xref,
-                                                            choiceWidgetRef);
+                                                            choiceWidgetRef,
+                                                            pdfManagerMock);
       var data = choiceWidgetAnnotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
       expect(data.fieldValue).toEqual(fieldValue);
@@ -761,7 +824,8 @@ describe('Annotation layer', function() {
       ]);
 
       var choiceWidgetAnnotation = annotationFactory.create(xref,
-                                                            choiceWidgetRef);
+                                                            choiceWidgetRef,
+                                                            pdfManagerMock);
       var data = choiceWidgetAnnotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
       expect(data.fieldValue).toEqual([fieldValue]);
@@ -774,7 +838,8 @@ describe('Annotation layer', function() {
       ]);
 
       var choiceWidgetAnnotation = annotationFactory.create(xref,
-                                                            choiceWidgetRef);
+                                                            choiceWidgetRef,
+                                                            pdfManagerMock);
       var data = choiceWidgetAnnotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
       expect(data.readOnly).toEqual(false);
@@ -791,7 +856,8 @@ describe('Annotation layer', function() {
       ]);
 
       var choiceWidgetAnnotation = annotationFactory.create(xref,
-                                                            choiceWidgetRef);
+                                                            choiceWidgetRef,
+                                                            pdfManagerMock);
       var data = choiceWidgetAnnotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
       expect(data.readOnly).toEqual(false);
@@ -810,7 +876,8 @@ describe('Annotation layer', function() {
       ]);
 
       var choiceWidgetAnnotation = annotationFactory.create(xref,
-                                                            choiceWidgetRef);
+                                                            choiceWidgetRef,
+                                                            pdfManagerMock);
       var data = choiceWidgetAnnotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
       expect(data.readOnly).toEqual(true);
@@ -869,7 +936,8 @@ describe('Annotation layer', function() {
         { ref: popupRef, data: popupDict, }
       ]);
 
-      var popupAnnotation = annotationFactory.create(xref, popupRef);
+      var popupAnnotation = annotationFactory.create(xref, popupRef,
+                                                     pdfManagerMock);
       var data = popupAnnotation.data;
       expect(data.annotationType).toEqual(AnnotationType.POPUP);
 

--- a/test/unit/annotation_layer_spec.js
+++ b/test/unit/annotation_layer_spec.js
@@ -275,6 +275,8 @@ describe('Annotation layer', function() {
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
       expect(data.url).toEqual('http://www.ctan.org/tex-archive/info/lshort');
+      expect(data.unsafeUrl).toEqual(
+        'http://www.ctan.org/tex-archive/info/lshort');
       expect(data.dest).toBeUndefined();
     });
 
@@ -299,7 +301,8 @@ describe('Annotation layer', function() {
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
-      expect(data.url).toEqual('http://www.hmrc.gov.uk');
+      expect(data.url).toEqual('http://www.hmrc.gov.uk/');
+      expect(data.unsafeUrl).toEqual('http://www.hmrc.gov.uk');
       expect(data.dest).toBeUndefined();
     });
 
@@ -331,6 +334,8 @@ describe('Annotation layer', function() {
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
       expect(data.url).toEqual(
+        new URL(stringToUTF8String('http://www.example.com/üöä')).href);
+      expect(data.unsafeUrl).toEqual(
         stringToUTF8String('http://www.example.com/üöä'));
       expect(data.dest).toBeUndefined();
     });
@@ -356,6 +361,7 @@ describe('Annotation layer', function() {
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
       expect(data.url).toBeUndefined();
+      expect(data.unsafeUrl).toBeUndefined();
       expect(data.dest).toEqual('page.157');
     });
 
@@ -382,7 +388,8 @@ describe('Annotation layer', function() {
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
-      expect(data.url).toBeUndefined(); // ../../0013/001346/134685E.pdf#4.3
+      expect(data.url).toBeUndefined();
+      expect(data.unsafeUrl).toEqual('../../0013/001346/134685E.pdf#4.3');
       expect(data.dest).toBeUndefined();
       expect(data.newWindow).toEqual(true);
     });
@@ -410,6 +417,8 @@ describe('Annotation layer', function() {
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
       expect(data.url).toEqual('http://www.example.com/test.pdf#nameddest=15');
+      expect(data.unsafeUrl).toEqual(
+        'http://www.example.com/test.pdf#nameddest=15');
       expect(data.dest).toBeUndefined();
       expect(data.newWindow).toBeFalsy();
     });
@@ -436,8 +445,10 @@ describe('Annotation layer', function() {
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
-      expect(data.url).toEqual('http://www.example.com/test.pdf#' +
-                               '[14,{"name":"XYZ"},null,298.043,null]');
+      expect(data.url).toEqual(new URL('http://www.example.com/test.pdf#' +
+                                 '[14,{"name":"XYZ"},null,298.043,null]').href);
+      expect(data.unsafeUrl).toEqual('http://www.example.com/test.pdf#' +
+                                     '[14,{"name":"XYZ"},null,298.043,null]');
       expect(data.dest).toBeUndefined();
       expect(data.newWindow).toBeFalsy();
     });
@@ -463,6 +474,7 @@ describe('Annotation layer', function() {
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
       expect(data.url).toBeUndefined();
+      expect(data.unsafeUrl).toBeUndefined();
       expect(data.action).toEqual('GoToPage');
     });
 
@@ -482,7 +494,31 @@ describe('Annotation layer', function() {
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
       expect(data.url).toBeUndefined();
+      expect(data.unsafeUrl).toBeUndefined();
       expect(data.dest).toEqual('LI0');
+    });
+
+    it('should correctly parse a simple Dest, with explicit destination array',
+        function() {
+      var annotationDict = new Dict();
+      annotationDict.set('Type', Name.get('Annot'));
+      annotationDict.set('Subtype', Name.get('Link'));
+      annotationDict.set('Dest', [new Ref(17, 0), Name.get('XYZ'),
+                                  0, 841.89, null]);
+
+      var annotationRef = new Ref(10, 0);
+      var xref = new XRefMock([
+        { ref: annotationRef, data: annotationDict, }
+      ]);
+
+      var annotation = annotationFactory.create(xref, annotationRef);
+      var data = annotation.data;
+      expect(data.annotationType).toEqual(AnnotationType.LINK);
+
+      expect(data.url).toBeUndefined();
+      expect(data.unsafeUrl).toBeUndefined();
+      expect(data.dest).toEqual([{ num: 17, gen: 0, }, { name: 'XYZ' },
+                                 0, 841.89, null]);
     });
   });
 

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -644,6 +644,7 @@ describe('api', function() {
           expect(typeof outlineItemTwo.title).toEqual('string');
           expect(outlineItemTwo.dest).toEqual(null);
           expect(outlineItemTwo.url).toEqual('http://google.com');
+          expect(outlineItemTwo.newWindow).toBeUndefined();
 
           var outlineItemOne = outline[1];
           expect(outlineItemOne.bold).toEqual(false);

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -643,7 +643,7 @@ describe('api', function() {
           var outlineItemTwo = outline[2];
           expect(typeof outlineItemTwo.title).toEqual('string');
           expect(outlineItemTwo.dest).toEqual(null);
-          expect(outlineItemTwo.url).toEqual('http://google.com');
+          expect(outlineItemTwo.url).toEqual('http://google.com/');
           expect(outlineItemTwo.newWindow).toBeUndefined();
 
           var outlineItemOne = outline[1];

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -789,6 +789,68 @@ describe('api', function() {
         done.fail(reason);
       });
     });
+
+    it('gets annotations containing relative URLs (bug 766086)',
+        function (done) {
+      var url = new URL('../pdfs/bug766086.pdf', window.location).href;
+
+      var defaultLoadingTask = PDFJS.getDocument(url);
+      var defaultPromise = defaultLoadingTask.promise.then(function (pdfDoc) {
+        return pdfDoc.getPage(1).then(function (pdfPage) {
+          return pdfPage.getAnnotations();
+        });
+      });
+
+      var docBaseUrlLoadingTask = PDFJS.getDocument({
+        url: url,
+        docBaseUrl: 'http://www.example.com/test/pdfs/qwerty.pdf',
+      });
+      var docBaseUrlPromise = docBaseUrlLoadingTask.promise.then(
+          function (pdfDoc) {
+        return pdfDoc.getPage(1).then(function (pdfPage) {
+          return pdfPage.getAnnotations();
+        });
+      });
+
+      var invalidDocBaseUrlLoadingTask = PDFJS.getDocument({
+        url: url,
+        docBaseUrl: 'qwerty.pdf',
+      });
+      var invalidDocBaseUrlPromise = invalidDocBaseUrlLoadingTask.promise.then(
+          function (pdfDoc) {
+        return pdfDoc.getPage(1).then(function (pdfPage) {
+          return pdfPage.getAnnotations();
+        });
+      });
+
+      Promise.all([defaultPromise, docBaseUrlPromise,
+                   invalidDocBaseUrlPromise]).then(function (data) {
+        var defaultAnnotations = data[0];
+        var docBaseUrlAnnotations = data[1];
+        var invalidDocBaseUrlAnnotations = data[2];
+
+        expect(defaultAnnotations[0].url).toBeUndefined();
+        expect(defaultAnnotations[0].unsafeUrl).toEqual(
+          '../../0021/002156/215675E.pdf#nameddest=15');
+
+        expect(docBaseUrlAnnotations[0].url).toEqual(
+          'http://www.example.com/0021/002156/215675E.pdf#nameddest=15');
+        expect(docBaseUrlAnnotations[0].unsafeUrl).toEqual(
+          '../../0021/002156/215675E.pdf#nameddest=15');
+
+        expect(invalidDocBaseUrlAnnotations[0].url).toBeUndefined();
+        expect(invalidDocBaseUrlAnnotations[0].unsafeUrl).toEqual(
+          '../../0021/002156/215675E.pdf#nameddest=15');
+
+        defaultLoadingTask.destroy();
+        docBaseUrlLoadingTask.destroy();
+        invalidDocBaseUrlLoadingTask.destroy();
+        done();
+      }).catch(function (reason) {
+        done.fail(reason);
+      });
+    });
+
     it('gets text content', function (done) {
       var defaultPromise = page.getTextContent();
       var parametersPromise = page.getTextContent({

--- a/web/app.js
+++ b/web/app.js
@@ -180,6 +180,7 @@ var PDFViewerApplication = {
   preferenceDefaultZoomValue: '',
   isViewerEmbedded: (window.parent !== window),
   url: '',
+  baseUrl: '',
   externalServices: DefaultExernalServices,
 
   // called once when the document is loaded
@@ -522,6 +523,7 @@ var PDFViewerApplication = {
 
   setTitleUsingUrl: function pdfViewSetTitleUsingUrl(url) {
     this.url = url;
+    this.baseUrl = url.split('#')[0];
     try {
       this.setTitle(decodeURIComponent(
         pdfjsLib.getFilenameFromUrl(url)) || url);
@@ -614,6 +616,11 @@ var PDFViewerApplication = {
       this.setTitleUsingUrl(file.originalUrl);
       parameters.url = file.url;
     }
+    if (typeof PDFJSDev !== 'undefined' &&
+        PDFJSDev.test('FIREFOX || MOZCENTRAL || CHROME')) {
+      parameters.docBaseUrl = this.baseUrl;
+    }
+
     if (args) {
       for (var prop in args) {
         parameters[prop] = args[prop];
@@ -682,7 +689,7 @@ var PDFViewerApplication = {
       downloadManager.downloadUrl(url, filename);
     }
 
-    var url = this.url.split('#')[0];
+    var url = this.baseUrl;
     var filename = getPDFFileNameFromURL(url);
     var downloadManager = this.downloadManager;
     downloadManager.onerror = function (err) {
@@ -719,14 +726,15 @@ var PDFViewerApplication = {
         return;
       }
       this.fellback = true;
-      var url = this.url.split('#')[0];
-      this.externalServices.fallback({ featureId: featureId, url: url },
-        function response(download) {
-          if (!download) {
-            return;
-          }
-          PDFViewerApplication.download();
-        });
+      this.externalServices.fallback({
+        featureId: featureId,
+        url: this.baseUrl,
+      }, function response(download) {
+        if (!download) {
+          return;
+        }
+        PDFViewerApplication.download();
+      });
     }
   },
 
@@ -856,7 +864,7 @@ var PDFViewerApplication = {
     if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
       baseDocumentUrl = null;
     } else if (PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
-      baseDocumentUrl = this.url.split('#')[0];
+      baseDocumentUrl = this.baseUrl;
     } else if (PDFJSDev.test('CHROME')) {
       baseDocumentUrl = location.href.split('#')[0];
     }

--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -67,10 +67,9 @@ if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC || CHROME')) {
 
   DownloadManager.prototype = {
     downloadUrl: function DownloadManager_downloadUrl(url, filename) {
-      if (!pdfjsLib.isValidUrl(url, true)) {
+      if (!pdfjsLib.createValidAbsoluteUrl(url, 'http://example.com')) {
         return; // restricted/invalid URL
       }
-
       download(url + '#pdfjs.action=download', filename);
     },
 

--- a/web/pdf_outline_viewer.js
+++ b/web/pdf_outline_viewer.js
@@ -26,6 +26,8 @@
   }
 }(this, function (exports, pdfjsLib) {
 
+var PDFJS = pdfjsLib.PDFJS;
+
 var DEFAULT_TITLE = '\u2013';
 
 /**
@@ -82,7 +84,10 @@ var PDFOutlineViewer = (function PDFOutlineViewerClosure() {
      */
     _bindLink: function PDFOutlineViewer_bindLink(element, item) {
       if (item.url) {
-        pdfjsLib.addLinkAttributes(element, { url: item.url });
+        pdfjsLib.addLinkAttributes(element, {
+          url: item.url,
+          target: (item.newWindow ? PDFJS.LinkTarget.BLANK : undefined),
+        });
         return;
       }
       var linkService = this.linkService;


### PR DESCRIPTION
_Please refer to the individual commit messages._

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=766086.
(_Note:_ This PR attempts to implement https://github.com/mozilla/pdf.js/pull/7212#issuecomment-216678039, hence it supersedes that one.)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/pdf.js/7689)

<!-- Reviewable:end -->
