### PR TITLE
Improve rendering of non-embedded NuptialScript font

### DIFF
--- a/src/core/standard_fonts.js
+++ b/src/core/standard_fonts.js
@@ -122,6 +122,7 @@
     t['MS-PMincho-Bold'] = 'MS PMincho-Bold';
     t['MS-PMincho-BoldItalic'] = 'MS PMincho-BoldItalic';
     t['MS-PMincho-Italic'] = 'MS PMincho-Italic';
+    t['NuptialScript'] = 'Times-Italic';
     t['Wingdings'] = 'ZapfDingbats';
   });
 
@@ -223,6 +224,7 @@
     t['New York'] = true;
     t['Nimbus Roman'] = true;
     t['NPS Rawlinson Roadway'] = true;
+    t['NuptialScript'] = true;
     t['Palatino'] = true;
     t['Perpetua'] = true;
     t['Plantin'] = true;

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -71,6 +71,7 @@
 !sizes.pdf
 !javauninstall-7r.pdf
 !multiple-filters-length-zero.pdf
+!non-embedded-NuptialScript.pdf
 !issue3205r.pdf
 !issue3207r.pdf
 !issue3263r.pdf

--- a/test/pdfs/non-embedded-NuptialScript.pdf
+++ b/test/pdfs/non-embedded-NuptialScript.pdf
@@ -1,0 +1,88 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/FontName /NuptialScript
+/StemV 56
+/Ascent 590
+/Flags 98
+/XHeight 280
+/Descent -219
+/ItalicAngle -21
+/StemH 56
+/FontBBox [-216 -295 1000 842]
+/Type /FontDescriptor
+/CapHeight 604
+>>
+endobj 
+2 0 obj 
+<<
+/Pages 3 0 R
+/Type /Catalog
+>>
+endobj 
+3 0 obj 
+<<
+/MediaBox [0 0 350 50]
+/Kids [4 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+4 0 obj 
+<<
+/Parent 3 0 R
+/MediaBox [0 0 350 50]
+/Resources 
+<<
+/Font 
+<<
+/F1 5 0 R
+>>
+>>
+/Contents 6 0 R
+/Type /Page
+>>
+endobj 
+5 0 obj 
+<<
+/BaseFont /NuptialScript
+/LastChar 244
+/Subtype /Type1
+/FontDescriptor 1 0 R
+/Widths [166 333 333 333 333 667 611 222 389 389 333 600 222 333 222 278 333 333 333 333 333 333 333 333 333 333 222 222 600 600 600 333 800 722 778 611 667 556 611 611 778 500 444 778 611 833 778 556 667 500 667 556 500 722 556 667 611 611 667 444 278 444 600 500 222 389 389 333 389 333 222 389 444 222 222 389 222 556 389 333 389 389 333 278 222 389 333 444 333 389 333 389 222 389 600 0 0 0 0 0 0 0 0 0 222 0 0 0 0 0 0 0 0 0 0 0 389 0 0 0 0 0 0 0 0 0 0 0 166 0 333 333 0 0 0 0 0 800 0 0 0 333 0 0 0 600 0 0 222 389 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 389 0 0 0 0 0 0 0 333 333 333 0 0 0 0 0 0 0 0 0 333]
+/Encoding /WinAnsiEncoding
+/Type /Font
+/FirstChar 32
+>>
+endobj 
+6 0 obj 
+<<
+/Length 82
+>>
+stream
+BT
+10 20 TD
+/F1 20 Tf
+(Non-embedded NuptialScript font - should be italic.) Tj
+ET
+
+endstream 
+endobj xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000217 00000 n 
+0000000268 00000 n 
+0000000350 00000 n 
+0000000479 00000 n 
+0000001288 00000 n 
+trailer
+
+<<
+/Root 2 0 R
+/Size 7
+>>
+startxref
+1422
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1613,6 +1613,13 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "non-embedded-NuptialScript",
+       "file": "pdfs/non-embedded-NuptialScript.pdf",
+       "md5": "94225085d3fbf5d2d12b8be1c52bb3c1",
+       "link": false,
+       "rounds": 1,
+       "type": "eq"
+    },
     {  "id": "issue3323",
        "file": "pdfs/issue3323.pdf",
        "md5": "1a14ff574013caeafa9d598269988764",


### PR DESCRIPTION
_This patch fixes something that I noticed while debugging https://bugzilla.mozilla.org/show_bug.cgi?id=1308536._

The PDF file contains a font called "NuptialScript", which unfortunately is not embedded. Since that is a non-standard font we will not be able to render it entirely correct. However, by adding "NuptialScript" to the `getNonStdFontMap`, we can at least improve the rendering slightly by using an italic (serif) fallback font.
