### PR TITLE
SVG: optimize and refactor group creation code

### DIFF
--- a/examples/svgviewer/index.html
+++ b/examples/svgviewer/index.html
@@ -2,21 +2,24 @@
 <html>
 
 <head>
+  <meta charset="utf-8">
+
+  <title>PDF.js SVG viewer example</title>
+
   <script src="../../node_modules/requirejs/require.js"></script>
   <script src="viewer.js"></script>
+
   <style>
     body {
-      background-color: gray;
+      background-color: #404040;
     }
 
     .pageContainer {
-      border : 1px solid black;
-      margin : 5px auto;
-      background-color : white;
+      border: 1px solid #000;
+      margin: 5px auto;
+      background-color: #FFF;
     }
-    </style>
-
-  <title>SVG Viewer Example</title>
+  </style>
 </head>
 
 <body>

--- a/examples/svgviewer/viewer.js
+++ b/examples/svgviewer/viewer.js
@@ -1,40 +1,29 @@
 'use strict';
 
+var DEFAULT_SCALE = 1.5;
+
 // Parse query string to extract some parameters (it can fail for some input)
 var query = document.location.href.replace(/^[^?]*(\?([^#]*))?(#.*)?/, '$2');
 var queryParams = query ? JSON.parse('{' + query.split('&').map(function (a) {
   return a.split('=').map(decodeURIComponent).map(JSON.stringify).join(': ');
 }).join(',') + '}') : {};
 
-var url = queryParams.file || '../../test/pdfs/liveprogramming.pdf';
-var scale = +queryParams.scale || 1.5;
+var url = queryParams.file || '../../web/compressed.tracemonkey-pldi-09.pdf';
 
 function renderDocument(pdf, svgLib) {
-  var numPages = pdf.numPages;
-  // Using promise to fetch the page
-
-  // For testing only.
-  var MAX_NUM_PAGES = 50;
-  var ii = Math.min(MAX_NUM_PAGES, numPages);
-
   var promise = Promise.resolve();
-  for (var i = 1; i <= ii; i++) {
-    var anchor = document.createElement('a');
-    anchor.setAttribute('name', 'page=' + i);
-    anchor.setAttribute('title', 'Page ' + i);
-    document.body.appendChild(anchor);
-
+  for (var i = 1; i <= pdf.numPages; i++) {
     // Using promise to fetch and render the next page
-    promise = promise.then(function (pageNum, anchor) {
+    promise = promise.then(function (pageNum) {
       return pdf.getPage(pageNum).then(function (page) {
-        var viewport = page.getViewport(scale);
+        var viewport = page.getViewport(DEFAULT_SCALE);
 
         var container = document.createElement('div');
         container.id = 'pageContainer' + pageNum;
         container.className = 'pageContainer';
         container.style.width = viewport.width + 'px';
         container.style.height = viewport.height + 'px';
-        anchor.appendChild(container);
+        document.body.appendChild(container);
 
         return page.getOperatorList().then(function (opList) {
           var svgGfx = new svgLib.SVGGraphics(page.commonObjs, page.objs);
@@ -43,7 +32,7 @@ function renderDocument(pdf, svgLib) {
           });
         });
       });
-    }.bind(null, i, anchor));
+    }.bind(null, i));
   }
 }
 


### PR DESCRIPTION
This patch series brings down the number of transform groups for the Tracemonkey paper from 2790 to 1271, resulting in a much lighter DOM and faster rendering/scrolling. Refer to the commit messages for more information.
