### PR TITLE
Explain double-click behaviour on tool tip

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -99,8 +99,8 @@ print_progress_close=Cancel
 # tooltips)
 toggle_sidebar.title=Toggle Sidebar
 toggle_sidebar_label=Toggle Sidebar
-outline.title=Show Document Outline
-outline_label=Document Outline
+document_outline.title=Show Document Outline (double-click to expand/collapse all items)
+document_outline_label=Document Outline
 attachments.title=Show Attachments
 attachments_label=Attachments
 thumbs.title=Show Thumbnails

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -81,8 +81,8 @@ See https://github.com/adobe-type-tools/cmap-resources
             <button id="viewThumbnail" class="toolbarButton group toggled" title="Show Thumbnails" tabindex="2" data-l10n-id="thumbs">
                <span data-l10n-id="thumbs_label">Thumbnails</span>
             </button>
-            <button id="viewOutline" class="toolbarButton group" title="Show Document Outline" tabindex="3" data-l10n-id="outline">
-               <span data-l10n-id="outline_label">Document Outline</span>
+            <button id="viewOutline" class="toolbarButton group" title="Show Document Outline (double-click to expand/collapse all items)" tabindex="3" data-l10n-id="document_outline">
+               <span data-l10n-id="document_outline_label">Document Outline</span>
             </button>
             <button id="viewAttachments" class="toolbarButton group" title="Show Attachments" tabindex="4" data-l10n-id="attachments">
                <span data-l10n-id="attachments_label">Attachments</span>


### PR DESCRIPTION
The outline toggle button has a feature where it can be double-clicked
to expand/collapse all items shown therein. Although this is described
in the FAQ, can go potentially unnoticed. This, however, being a useful
feature, advertise on the tool tip itself.

l10n translations are untouched.

Signed-off-by: Jeenu Viswambharan jeenuv@gmail.com
