### PR TITLE
Avoid accidentally rejecting a named destination that looks like a decimal number (PR 7341 follow-up)

### DIFF
--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -264,6 +264,12 @@ var PDFLinkService = (function PDFLinkServiceClosure() {
         dest = unescape(hash);
         try {
           dest = JSON.parse(dest);
+
+          if (typeof dest === 'number') {
+            // Avoid incorrectly rejecting a named destination, such as
+            // e.g. "4.3", because `JSON.parse` converted it to a number.
+            dest = dest.toString();
+          }
         } catch (ex) {}
 
         if (typeof dest === 'string' || isValidExplicitDestination(dest)) {


### PR DESCRIPTION
Without this patch, the following link does not work correctly: http://unesdoc.unesco.org/images/0013/001346/134685E.pdf#4.3
Compare the correct behaviour of this link: http://unesdoc.unesco.org/images/0013/001346/134685E.pdf#nameddest=4.3
