### PR TITLE
Travis CI: use most recent version of NPM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
   directories:
     - node_modules
 install:
+  - npm install -g npm@latest
   - npm install -g gulp-cli
   - npm install
   - npm update


### PR DESCRIPTION
Recently a breaking change was introduced that required everyone with the most recent Node.js versions (as we have on Travis CI) to upgrade NPM. This was not directly done by Travis CI, leading to failings builds. This change ensures that we always use the most recent NPM version to prevent these kinds of problems and to ensure an up-to-date environment.
