### PR TITLE
Remove/deprecate specifying a pageNumber directly after the hash symbol (#), to improve compatibility since other PDF viewers don't support this form (issue 7746)

### DIFF
--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -270,9 +270,15 @@ var PDFLinkService = (function PDFLinkServiceClosure() {
             mode: params.pagemode
           });
         }
-      } else if (isPageNumber(hash)) { // Page number.
-        this.page = hash | 0;
       } else { // Named (or explicit) destination.
+        if ((typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) &&
+            isPageNumber(hash) && hash <= this.pagesCount) {
+          console.warn('PDFLinkService_setHash: specifying a page number ' +
+                       'directly after the hash symbol (#) is deprecated, ' +
+                       'please use the "#page=' + hash + '" form instead.');
+          this.page = hash | 0;
+        }
+
         dest = unescape(hash);
         try {
           dest = JSON.parse(dest);


### PR DESCRIPTION
There's no mention of our `#{pagenum}` form in http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/pdf_open_parameters.pdf, and Adobe Reader doesn't seem to support it either.
Hence this patch removes support for it in the extensions, but keeps it in the `GENERIC` build with a deprecation warning and a fallback to handle it as a destination.

Fixes #7746.
