### PR TITLE
[l10n] Add Swedish translations for a couple of new/changed localization IDs

### DIFF
--- a/l10n/sv-SE/viewer.properties
+++ b/l10n/sv-SE/viewer.properties
@@ -91,13 +91,19 @@ document_properties_version=PDF-version:
 document_properties_page_count=Sidantal:
 document_properties_close=Stäng
 
+print_progress_message=Förbereder dokumentet för utskrift…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Avbryt
+
 # Tooltips and alt text for side panel toolbar buttons
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Visa/dölj sidofält
 toggle_sidebar_label=Visa/dölj sidofält
-outline.title=Visa dokumentöversikt
-outline_label=Dokumentöversikt
+document_outline.title=Visa dokumentöversikt (dubbelklicka för att expandera/komprimera alla element)
+document_outline_label=Dokumentöversikt
 attachments.title=Visa Bilagor
 attachments_label=Bilagor
 thumbs.title=Visa miniatyrer


### PR DESCRIPTION
I got tired of staring at a bunch of localization warnings every time that I open the console, hence this patch adds the missing translations to the Swedish locale.