### PR TITLE
Widget annotation: implement field name according to the specification

### DIFF
--- a/examples/acroforms/forms.js
+++ b/examples/acroforms/forms.js
@@ -91,7 +91,7 @@ function setupForm(div, content, viewport) {
             // select box is not supported
           }
           input.className = 'inputControl';
-          input.name = item.fullName;
+          input.name = item.fieldName;
           input.title = item.alternativeText;
           assignFontStyle(input, item);
           bindInputItem(input, item);

--- a/test/unit/annotation_layer_spec.js
+++ b/test/unit/annotation_layer_spec.js
@@ -577,6 +577,74 @@ describe('Annotation layer', function() {
     });
   });
 
+  describe('WidgetAnnotation', function() {
+    var widgetDict;
+
+    beforeEach(function (done) {
+      widgetDict = new Dict();
+      widgetDict.set('Type', Name.get('Annot'));
+      widgetDict.set('Subtype', Name.get('Widget'));
+
+      done();
+    });
+
+    afterEach(function () {
+      widgetDict = null;
+    });
+
+    it('should handle unknown field names', function() {
+      var widgetRef = new Ref(20, 0);
+      var xref = new XRefMock([
+        { ref: widgetRef, data: widgetDict, }
+      ]);
+
+      var widgetAnnotation = annotationFactory.create(xref, widgetRef,
+                                                      pdfManagerMock);
+      var data = widgetAnnotation.data;
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.fieldName).toEqual('');
+    });
+
+    it('should construct the field name when there are no ancestors',
+        function() {
+      widgetDict.set('T', 'foo');
+
+      var widgetRef = new Ref(21, 0);
+      var xref = new XRefMock([
+        { ref: widgetRef, data: widgetDict, }
+      ]);
+
+      var widgetAnnotation = annotationFactory.create(xref, widgetRef,
+                                                      pdfManagerMock);
+      var data = widgetAnnotation.data;
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.fieldName).toEqual('foo');
+    });
+
+    it('should construct the field name when there are ancestors', function() {
+      var firstParent = new Dict();
+      firstParent.set('T', 'foo');
+
+      var secondParent = new Dict();
+      secondParent.set('Parent', firstParent);
+      secondParent.set('T', 'bar');
+
+      widgetDict.set('Parent', secondParent);
+      widgetDict.set('T', 'baz');
+
+      var widgetRef = new Ref(22, 0);
+      var xref = new XRefMock([
+        { ref: widgetRef, data: widgetDict, }
+      ]);
+
+      var widgetAnnotation = annotationFactory.create(xref, widgetRef,
+                                                      pdfManagerMock);
+      var data = widgetAnnotation.data;
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.fieldName).toEqual('foo.bar.baz');
+    });
+  });
+
   describe('TextWidgetAnnotation', function() {
     var textWidgetDict;
 


### PR DESCRIPTION
The original code is difficult to read and, more importantly, performs actions that are not described in the specification. It replaces empty names with a backtick and an index, but this behavior is not described in the specification. While the specification is not entirely clear about what should happen in this case, it does specify that the `T` field is optional and that multiple field dictionaries may have the same fully qualified name, so to achieve this it makes the most sense to ignore missing `T` fields during construction of the field name. This is the most specification-compliant solution and, judging by opened issue #6623, also the required and expected behavior.

Fixes #6623.
Part of #7613.