### PR TITLE
Additional check to ensure pdfViewer object is defined before handleMouseWheel event accesses its property isInPresentationMode

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2000,7 +2000,7 @@ function webViewerPageChanging(e) {
 var zoomDisabled = false, zoomDisabledTimeout;
 function handleMouseWheel(evt) {
   var pdfViewer = PDFViewerApplication.pdfViewer;
-  if (pdfViewer.isInPresentationMode) {
+  if (!pdfViewer || pdfViewer.isInPresentationMode) {
     return;
   }
 


### PR DESCRIPTION
Additional check to ensure pdfViewer object is defined before handleMouseWheel event accesses its property isInPresentationMode