### PR TITLE
Make the `customScaleOption` disabled to prevent it being keyboard accessible (bug 1315608)

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -239,7 +239,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                     <option id="pageActualOption" title="" value="page-actual" data-l10n-id="page_scale_actual">Actual Size</option>
                     <option id="pageFitOption" title="" value="page-fit" data-l10n-id="page_scale_fit">Fit Page</option>
                     <option id="pageWidthOption" title="" value="page-width" data-l10n-id="page_scale_width">Full Width</option>
-                    <option id="customScaleOption" title="" value="custom" hidden="true"></option>
+                    <option id="customScaleOption" title="" value="custom" disabled="disabled" hidden="true"></option>
                     <option title="" value="0.5" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 50 }'>50%</option>
                     <option title="" value="0.75" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 75 }'>75%</option>
                     <option title="" value="1" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 100 }'>100%</option>


### PR DESCRIPTION
Given that the `customScaleOption` should already be hidden, provided that the browser supports that, this patch also prevents it from being accessible via the keyboard.
As far as my testing goes in various browsers, this doesn't seem to have any ill effects, and note that we're already explicitly ignoring the `custom` value in the `select` event handler.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1315608.