### PR TITLE
[api-minor] Add support for a couple of white-listed `JavaScript` actions that contains valid URLs (issue 3897, bug 843699)

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -695,6 +695,33 @@ var Catalog = (function CatalogClosure() {
           }
           break;
 
+        case 'JavaScript':
+          var jsAction = action.get('JS'), js;
+          if (isStream(jsAction)) {
+            js = bytesToString(jsAction.getBytes());
+          } else if (isString(jsAction)) {
+            js = jsAction;
+          }
+
+          if (js) {
+            // Attempt to recover valid URLs from 'JS' entries with certain
+            // white-listed formats, e.g.
+            //  - window.open('http://example.com')
+            //  - app.launchURL('http://example.com', true)
+            var URL_OPEN_METHODS = [
+              'app.launchURL',
+              'window.open'
+            ];
+            var regex = new RegExp('^(?:' + URL_OPEN_METHODS.join('|') + ')' +
+                                   '\\((?:\'|\")(\\S+)(?:\'|\")(?:,|\\))');
+
+            var jsUrl = regex.exec(stringToPDFString(js), 'i');
+            if (jsUrl && jsUrl[1]) {
+              url = jsUrl[1];
+              break;
+            }
+          }
+          /* falls through */
         default:
           warn('Catalog_parseDestDictionary: Unrecognized link type "' +
                linkType + '".');


### PR DESCRIPTION
By only allowing very specific type of `JavaScript` actions, and also utilizing the existing `URL` validation, this patch shouldn't pose too much risk.

Fixes one of the points in issue #3897 (with the PDF file taken from issue #3438).
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=843699 (probably, since that bug doesn't contain a test-case).