### PR TITLE
fix bug in text extract that cause break-out with exception

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1418,6 +1418,11 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           // The arguments parsed by read() are not used beyond this loop, so
           // we can reuse the same array on every iteration, thus avoiding
           // unnecessary allocations.
+
+          // In some documents args might be null for some pages. An exception
+          // is raised when trying to set args.length to be 0.
+          // This patch fixing it.
+          if (args === null) {args = [];}
           args.length = 0;
           operation.args = args;
           if (!(preprocessor.read(operation))) {


### PR DESCRIPTION
In some documents args might be null for some pages. An exception is raised when trying to set args.length to be 0.

This patch fixing it.

Tested on Windows 7/10 64 bit and Ubuntu 16.04 64bit With Chrome >=54 and PhantomJS 2.1.1.
I can't upload the document generated the problem because it contains customer confidential data.