### PR TITLE
disable range request in iPhone

### DIFF
--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -469,8 +469,10 @@ if (typeof PDFJS === 'undefined') {
 
   // Range requests are broken in Chrome 39 and 40, https://crbug.com/442318
   var isChromeWithRangeBug = /Chrome\/(39|40)\./.test(navigator.userAgent);
+  
+  var isIPhone = /iPhone/.test(navigator.userAgent);
 
-  if (isSafari || isOldAndroid || isChromeWithRangeBug) {
+  if (isSafari || isOldAndroid || isChromeWithRangeBug || isIPhone) {
     PDFJS.disableRange = true;
     PDFJS.disableStream = true;
   }


### PR DESCRIPTION
Better way but NOT necessarily best way to solve the IOS webview APP error: Unexpected server response (206) while retrieving PDF...

Details:
1. At the beginning, I only found the Error in IOS WeChat APP, so I solved it by checking WeChat:
https://github.com/godwin668/pdf.js/commit/9ad57d4ad5c03a33f637da5f8fd3ede3c4c7f39a

2. But I found this error in other IOS app, so I checked UA details of them as follow:

a) iPhone WeChat APP UserAgent (Fail):
Mozilla/5.0 (iPhone; CPU iPhone OS 10_1_1 like Mac OS X) AppleWebKit/602.2.14 (KHTML, like Gecko) Mobile/14B100 MicroMessenger/6.3.30 NetType/WIFI Language/zh_CN

b) iPhone Other APP UserAgent (Fail):
Mozilla/5.0 (iPhone; CPU iPhone OS 10_1_1 like Mac X) AppleWebKit/602.2.14 (KHTML, like Gecko) Mobile/14B100 QYZone

Maybe all webview app in IOS 10 have this problem, and since Safari & Chrome in IOS also does NOT support range request in IOS, so I think it's a better way to disable range request in iPhone by this regex:
var isIPhone = /iPhone/.test(navigator.userAgent);
if (isIPhone) {
    PDFJS.disableRange = true;
    PDFJS.disableStream = true;
}

solve issues:
https://github.com/mozilla/pdf.js/issues/7815
https://github.com/mozilla/pdf.js/issues/7754
https://github.com/mozilla/pdf.js/pull/7800