### PR TITLE
Return a mock object in `paintOnSvg` when SVG rendering is not supported, to prevent `TypeError`s in the addons

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -612,7 +612,13 @@ var PDFPageView = (function PDFPageViewClosure() {
     paintOnSvg: function PDFPageView_paintOnSvg(wrapper) {
       if (typeof PDFJSDev !== 'undefined' &&
           PDFJSDev.test('FIREFOX || MOZCENTRAL || CHROME')) {
-        return Promise.resolve('SVG rendering is not supported.');
+        // Return a mock object, to prevent errors such as e.g.
+        // "TypeError: paintTask.promise is undefined".
+        return {
+          promise: Promise.reject(new Error('SVG rendering is not supported.')),
+          onRenderContinue: function (cont) { },
+          cancel: function () { },
+        };
       } else {
         var cancelled = false;
         var ensureNotCancelled = function () {


### PR DESCRIPTION
Currently if you try to enable SVG rendering in the addons, a `TypeError` is thrown by the browser since we have code that depends on what `paintOnCanvas`/`paintOnSvg` (should) return.

**Steps to reproduce:**
1. Install the latest Firefox addon, http://mozilla.github.io/pdf.js/extensions/firefox/pdf.js.xpi.
2. Open `about:config`, and set the `extensions.uriloader@pdf.js.renderer` preference to `svg`.
3. Load any PDF file, e.g. http://mirrors.ctan.org/info/lshort/english/lshort.pdf.

**Expected result:**
Rendering is aborted, with a `SVG rendering is not supported.` error printed in the console.

**Actual result:**
Nothing renders, and no error messages from PDF.js in the console. Instead a `TypeError: paintTask.promise is undefined` warning is printed in the console.
