### PR TITLE
Expose the optional UserUnit entry as a page property

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -42,6 +42,7 @@ var error = sharedUtil.error;
 var info = sharedUtil.info;
 var isArray = sharedUtil.isArray;
 var isArrayBuffer = sharedUtil.isArrayBuffer;
+var isNum = sharedUtil.isNum;
 var isString = sharedUtil.isString;
 var shadow = sharedUtil.shadow;
 var stringToBytes = sharedUtil.stringToBytes;
@@ -67,6 +68,7 @@ var AnnotationFactory = coreAnnotation.AnnotationFactory;
 
 var Page = (function PageClosure() {
 
+  var DEFAULT_USER_UNIT = 1.0;
   var LETTER_SIZE_MEDIABOX = [0, 0, 612, 792];
 
   function Page(pdfManager, xref, pageIndex, pageDict, ref, fontCache) {
@@ -136,6 +138,14 @@ var Page = (function PageClosure() {
         obj = LETTER_SIZE_MEDIABOX;
       }
       return shadow(this, 'mediaBox', obj);
+    },
+
+    get userUnit() {
+      var obj = this.getPageProp('UserUnit');
+      if (!isNum(obj) || obj <= 0) {
+        obj = DEFAULT_USER_UNIT;
+      }
+      return shadow(this, 'userUnit', obj);
     },
 
     get view() {

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -747,14 +747,17 @@ var WorkerMessageHandler = {
       return pdfManager.getPage(data.pageIndex).then(function(page) {
         var rotatePromise = pdfManager.ensure(page, 'rotate');
         var refPromise = pdfManager.ensure(page, 'ref');
+        var userUnitPromise = pdfManager.ensure(page, 'userUnit');
         var viewPromise = pdfManager.ensure(page, 'view');
 
-        return Promise.all([rotatePromise, refPromise, viewPromise]).then(
-            function(results) {
+        return Promise.all([
+          rotatePromise, refPromise, userUnitPromise, viewPromise
+        ]).then(function(results) {
           return {
             rotate: results[0],
             ref: results[1],
-            view: results[2]
+            userUnit: results[2],
+            view: results[3]
           };
         });
       });

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -748,6 +748,12 @@ var PDFPageProxy = (function PDFPageProxyClosure() {
       return this.pageInfo.ref;
     },
     /**
+     * @return {number} The default size of units in 1/72nds of an inch.
+     */
+    get userUnit() {
+      return this.pageInfo.userUnit;
+    },
+    /**
      * @return {Array} An array of the visible portion of the PDF page in the
      * user space units - [x1, y1, x2, y2].
      */

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -769,6 +769,9 @@ describe('api', function() {
     it('gets ref', function () {
       expect(page.ref).toEqual({ num: 15, gen: 0 });
     });
+    it('gets userUnit', function () {
+      expect(page.userUnit).toEqual(1.0);
+    });
     it('gets view', function () {
       expect(page.view).toEqual([0, 0, 595.28, 841.89]);
     });


### PR DESCRIPTION
This provides access to the optional `UserUnit` page entry from spec v1.6+ for consumers of the API. Returns a default value of 1.0 (per spec) when entry is not present.

I've attempted to follow the pattern used by other page entries, as found in the surrounding code.