### PR TITLE
Viewer: remove unused CSS rule

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -777,12 +777,6 @@ html[dir='rtl'] .toolbarButton:first-child {
   height: 1px;
 }
 
-.toolbarButtonFlexibleSpacer {
-  -webkit-box-flex: 1;
-  -moz-box-flex: 1;
-  min-width: 30px;
-}
-
 html[dir='ltr'] #findPrevious {
   margin-left: 3px;
 }


### PR DESCRIPTION
This appears to have been part of the first mock-up of the viewer, but hasn't been used since.