### PR TITLE
Make the keyboard shortcuts `Ctrl + Up/Down` behave as `Home/End` (issue 7852)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1956,7 +1956,7 @@ window.addEventListener('keydown', function keydown(evt) {
     return;
   }
 
-  var handled = false;
+  var handled = false, ensureViewerFocused = false;
   var cmd = (evt.ctrlKey ? 1 : 0) |
             (evt.altKey ? 2 : 0) |
             (evt.shiftKey ? 4 : 0) |
@@ -2019,6 +2019,22 @@ window.addEventListener('keydown', function keydown(evt) {
           handled = false;
         }
         break;
+
+      case 38: // up arrow
+        if (isViewerInPresentationMode || PDFViewerApplication.page > 1) {
+          PDFViewerApplication.page = 1;
+          handled = true;
+          ensureViewerFocused = true;
+        }
+        break;
+      case 40: // down arrow
+        if (isViewerInPresentationMode ||
+            PDFViewerApplication.page < PDFViewerApplication.pagesCount) {
+          PDFViewerApplication.page = PDFViewerApplication.pagesCount;
+          handled = true;
+          ensureViewerFocused = true;
+        }
+        break;
     }
   }
 
@@ -2051,6 +2067,9 @@ window.addEventListener('keydown', function keydown(evt) {
   }
 
   if (handled) {
+    if (ensureViewerFocused && !isViewerInPresentationMode) {
+      pdfViewer.focus();
+    }
     evt.preventDefault();
     return;
   }
@@ -2067,7 +2086,6 @@ window.addEventListener('keydown', function keydown(evt) {
       return;
     }
   }
-  var ensureViewerFocused = false;
 
   if (cmd === 0) { // no control key pressed at all.
     switch (evt.keyCode) {


### PR DESCRIPTION
It seems that for normal web pages, at least in Firefox, the keyboard shortcuts <kbd>Ctrl</kbd> + <kbd>Up</kbd>/<kbd>Down</kbd> are functionally equivalent to <kbd>Home</kbd>/<kbd>End</kbd>. This is obviously an edge-case, but can be easily implemented by using the same logic as we do for <kbd>Home</kbd>/<kbd>End</kbd>.

Fixes #7852.

*Please note:* I'm finding it slightly difficult to interpret issue #7852, and [bug 1285719](https://bugzilla.mozilla.org/show_bug.cgi?id=1285719), since among other things: the title includes the word "reverse" with no other mention of it, and the STR makes reference to print preview which doesn't seem applicable to the PDF viewer.
However, compared to regular web pages in Firefox, I think the behavior of this patch makes sense here.