### PR TITLE
Colorspace: refactoring to prevent unnecessary creation of intermediate arrays

### DIFF
--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -492,26 +492,22 @@ var AlternateCS = (function AlternateCSClosure() {
       var scaled = new Float32Array(numComps);
       var tinted = new Float32Array(baseNumComps);
       var i, j;
-      if (usesZeroToOneRange) {
-        for (i = 0; i < count; i++) {
-          for (j = 0; j < numComps; j++) {
-            scaled[j] = src[srcOffset++] * scale;
-          }
-          tintFn(scaled, 0, tinted, 0);
+
+      for (i = 0; i < count; i++) {
+        for (j = 0; j < numComps; j++) {
+          scaled[j] = src[srcOffset++] * scale;
+        }
+        tintFn(scaled, 0, tinted, 0);
+        if (usesZeroToOneRange) {
           for (j = 0; j < baseNumComps; j++) {
             baseBuf[pos++] = tinted[j] * 255;
           }
-        }
-      } else {
-        for (i = 0; i < count; i++) {
-          for (j = 0; j < numComps; j++) {
-            scaled[j] = src[srcOffset++] * scale;
-          }
-          tintFn(scaled, 0, tinted, 0);
+        } else {
           base.getRgbItem(tinted, 0, baseBuf, pos);
           pos += baseNumComps;
         }
       }
+
       if (!isPassthrough) {
         base.getRgbBuffer(baseBuf, 0, count, dest, destOffset, 8, alpha01);
       }

--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -294,13 +294,8 @@ var ColorSpace = (function ColorSpaceClosure() {
     }
 
     cs = xref.fetchIfRef(cs);
-    var mode;
-
     if (isName(cs)) {
-      mode = cs.name;
-      this.mode = mode;
-
-      switch (mode) {
+      switch (cs.name) {
         case 'DeviceGray':
         case 'G':
           return 'DeviceGrayCS';
@@ -313,11 +308,10 @@ var ColorSpace = (function ColorSpaceClosure() {
         case 'Pattern':
           return ['PatternCS', null];
         default:
-          error('unrecognized colorspace ' + mode);
+          error('unrecognized colorspace ' + cs.name);
       }
     } else if (isArray(cs)) {
-      mode = xref.fetchIfRef(cs[0]).name;
-      this.mode = mode;
+      var mode = xref.fetchIfRef(cs[0]).name;
       var numComps, params, alt, whitePoint, blackPoint, gamma;
 
       switch (mode) {
@@ -384,12 +378,7 @@ var ColorSpace = (function ColorSpaceClosure() {
         case 'Separation':
         case 'DeviceN':
           var name = xref.fetchIfRef(cs[1]);
-          numComps = 1;
-          if (isName(name)) {
-            numComps = 1;
-          } else if (isArray(name)) {
-            numComps = name.length;
-          }
+          numComps = isArray(name) ? name.length : 1;
           alt = ColorSpace.parseToIR(cs[2], xref, res);
           var tintFnIR = PDFFunction.getIR(xref, xref.fetchIfRef(cs[3]));
           return ['AlternateCS', numComps, alt, tintFnIR];
@@ -549,23 +538,21 @@ var IndexedCS = (function IndexedCSClosure() {
 
     var baseNumComps = base.numComps;
     var length = baseNumComps * highVal;
-    var lookupArray;
 
     if (isStream(lookup)) {
-      lookupArray = new Uint8Array(length);
+      this.lookup = new Uint8Array(length);
       var bytes = lookup.getBytes(length);
-      lookupArray.set(bytes);
+      this.lookup.set(bytes);
     } else if (isString(lookup)) {
-      lookupArray = new Uint8Array(length);
+      this.lookup = new Uint8Array(length);
       for (var i = 0; i < length; ++i) {
-        lookupArray[i] = lookup.charCodeAt(i);
+        this.lookup[i] = lookup.charCodeAt(i);
       }
     } else if (lookup instanceof Uint8Array || lookup instanceof Array) {
-      lookupArray = lookup;
+      this.lookup = lookup;
     } else {
       error('Unrecognized lookup table: ' + lookup);
     }
-    this.lookup = lookupArray;
   }
 
   IndexedCS.prototype = {
@@ -975,15 +962,15 @@ var CalRGBCS = (function CalRGBCSClosure() {
   }
 
   function matrixProduct(a, b, result) {
-      result[0] = a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
-      result[1] = a[3] * b[0] + a[4] * b[1] + a[5] * b[2];
-      result[2] = a[6] * b[0] + a[7] * b[1] + a[8] * b[2];
+    result[0] = a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+    result[1] = a[3] * b[0] + a[4] * b[1] + a[5] * b[2];
+    result[2] = a[6] * b[0] + a[7] * b[1] + a[8] * b[2];
   }
 
   function convertToFlat(sourceWhitePoint, LMS, result) {
-      result[0] = LMS[0] * 1 / sourceWhitePoint[0];
-      result[1] = LMS[1] * 1 / sourceWhitePoint[1];
-      result[2] = LMS[2] * 1 / sourceWhitePoint[2];
+    result[0] = LMS[0] * 1 / sourceWhitePoint[0];
+    result[1] = LMS[1] * 1 / sourceWhitePoint[1];
+    result[2] = LMS[2] * 1 / sourceWhitePoint[2];
   }
 
   function convertToD65(sourceWhitePoint, LMS, result) {

--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -547,7 +547,7 @@ var IndexedCS = (function IndexedCSClosure() {
   function IndexedCS(base, highVal, lookup) {
     this.name = 'Indexed';
     this.numComps = 1;
-    this.defaultColor = new Uint8Array([0]);
+    this.defaultColor = new Uint8Array(this.numComps);
     this.base = base;
     this.highVal = highVal;
 
@@ -613,7 +613,7 @@ var DeviceGrayCS = (function DeviceGrayCSClosure() {
   function DeviceGrayCS() {
     this.name = 'DeviceGray';
     this.numComps = 1;
-    this.defaultColor = new Float32Array([0]);
+    this.defaultColor = new Float32Array(this.numComps);
   }
 
   DeviceGrayCS.prototype = {
@@ -655,7 +655,7 @@ var DeviceRgbCS = (function DeviceRgbCSClosure() {
   function DeviceRgbCS() {
     this.name = 'DeviceRGB';
     this.numComps = 3;
-    this.defaultColor = new Float32Array([0, 0, 0]);
+    this.defaultColor = new Float32Array(this.numComps);
   }
   DeviceRgbCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
@@ -748,7 +748,9 @@ var DeviceCmykCS = (function DeviceCmykCSClosure() {
   function DeviceCmykCS() {
     this.name = 'DeviceCMYK';
     this.numComps = 4;
-    this.defaultColor = new Float32Array([0, 0, 0, 1]);
+    this.defaultColor = new Float32Array(this.numComps);
+    // Set the fourth component to the maximum value for a black color.
+    this.defaultColor[3] = 1;
   }
   DeviceCmykCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
@@ -788,7 +790,7 @@ var CalGrayCS = (function CalGrayCSClosure() {
   function CalGrayCS(whitePoint, blackPoint, gamma) {
     this.name = 'CalGray';
     this.numComps = 1;
-    this.defaultColor = new Float32Array([0]);
+    this.defaultColor = new Float32Array(this.numComps);
 
     if (!whitePoint) {
       error('WhitePoint missing - required for color space CalGray');
@@ -911,7 +913,7 @@ var CalRGBCS = (function CalRGBCSClosure() {
   function CalRGBCS(whitePoint, blackPoint, gamma, matrix) {
     this.name = 'CalRGB';
     this.numComps = 3;
-    this.defaultColor = new Float32Array(3);
+    this.defaultColor = new Float32Array(this.numComps);
 
     if (!whitePoint) {
       error('WhitePoint missing - required for color space CalRGB');
@@ -1187,7 +1189,7 @@ var LabCS = (function LabCSClosure() {
   function LabCS(whitePoint, blackPoint, range) {
     this.name = 'Lab';
     this.numComps = 3;
-    this.defaultColor = new Float32Array([0, 0, 0]);
+    this.defaultColor = new Float32Array(this.numComps);
 
     if (!whitePoint) {
       error('WhitePoint missing - required for color space Lab');


### PR DESCRIPTION
This commit series refactors the colorspace code to prevent the creation of unnecessary intermediate arrays and to make the code shorter and more readable. The commit messages contain more information about the changes.

*Reviewing is slightly easier with https://github.com/mozilla/pdf.js/pull/7863/files?w=1.*