### PR TITLE
Expand allowed pdf.worker.js load methods

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1107,8 +1107,9 @@ var PDFWorker = (function PDFWorkerClosure() {
       WorkerMessageHandler = pdfjsLibs.pdfjsCoreWorker.WorkerMessageHandler;
       fakeWorkerFilesLoadedCapability.resolve(WorkerMessageHandler);
     } else if(window.pdfjsDistBuildPdfWorker.WorkerMessageHandler) {
-      // pdf.worker.js is already present - either via evaluated script or <script />
-      fakeWorkerFilesLoadedCapability.resolve(window.pdfjsDistBuildPdfWorker.WorkerMessageHandler);
+      // pdf.worker.js is already present
+      WorkerMessageHandler = window.pdfjsDistBuildPdfWorker.WorkerMessageHandler;
+      fakeWorkerFilesLoadedCapability.resolve(WorkerMessageHandler);
     } else {
       var loader = fakeWorkerFilesLoader || function (callback) {
         Util.loadScript(getWorkerSrc(), function () {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1106,6 +1106,9 @@ var PDFWorker = (function PDFWorkerClosure() {
     } else if (PDFJSDev.test('SINGLE_FILE')) {
       WorkerMessageHandler = pdfjsLibs.pdfjsCoreWorker.WorkerMessageHandler;
       fakeWorkerFilesLoadedCapability.resolve(WorkerMessageHandler);
+    } else if(window.pdfjsDistBuildPdfWorker.WorkerMessageHandler) {
+      // pdf.worker.js is already present - either via evaluated script or <script />
+      fakeWorkerFilesLoadedCapability.resolve(window.pdfjsDistBuildPdfWorker.WorkerMessageHandler);
     } else {
       var loader = fakeWorkerFilesLoader || function (callback) {
         Util.loadScript(getWorkerSrc(), function () {


### PR DESCRIPTION
Allows for `pdf.worker.js` to be included in the page by `<script>` or other means, and eliminates unnecessary requests for it.