### PR TITLE
Fixes issue #6071 - TIFF with 1 bit-depth

### DIFF
--- a/test/pdfs/issue6071.pdf.link
+++ b/test/pdfs/issue6071.pdf.link
@@ -1,0 +1,1 @@
+https://web.archive.org/web/20170107214304/https://www.pdf-archive.com/2017/01/07/issue6071/issue6071.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1146,6 +1146,13 @@
        "lastPage": 2,
        "type": "eq"
     },
+    {  "id": "issue6071",
+       "file": "pdfs/issue6071.pdf",
+       "md5": "2e08526d8e7c9ba4269fc12ef488d3eb",
+       "rounds": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "issue1905",
        "file": "pdfs/issue1905.pdf",
        "md5": "b1bbd72ca6522ae1502aa26320f81994",


### PR DESCRIPTION
This commit is a simple solution to this [issue](https://github.com/mozilla/pdf.js/issues/6071). 

The [PDF](https://www.dropbox.com/s/w5cb3li354rtgcb/issue6071.pdf?dl=0) on this issue has a TIFF image with bit-depth equal to 1. This issue was created because on stream.js, the case on  readBlockTiff() function which treats the TIFFs with bits == 1 was reading bytes wrongly: not only does it invert the colors, but I believe it also affects resolution.

The thing is, I tried to read TIFF specification and adapt the code that was already written, but I couldn't find this specific situation on the specification and I couldn't figure out what was wrong with the code.

I read in the issue page that the else fallback condition was working, and that the bits == 1 condition was there because of performance enhancement.

So I tried to write the else condition that I knew was working and optimize it for 1 bit depth. 

I concluded that when a received bit is 1, the buffer bit (the bit that will belong to the predictor) has to be the opposite of the previous bit. When a received bit is 0, the bit given to the predictor stays the same. 

For example, in TIFF 1-bit, a byte can be 128 or 0, so it can be either 1000 0000 or 0000 0000. The complement variable starts at 0 and only changes when there is a 1 in the received bits. I start reading the inbyte from the **highest** bit. I take the resulting complement value and I put it in the **lowest** order bit of the outbyte.

Now, according to TIFF specification, an image with 1-bit depth was not supposed to have any other values besides 128 and 0, but this one had, so I am forced to check for **all** the bits in a byte, besides the highest order one.

I have tested the performance between the else case and my 1-bit case, and although I based myself on the first, the second can be faster and it fixes the bug.

This is what I got, by running only the [PDF](https://www.dropbox.com/s/w5cb3li354rtgcb/issue6071.pdf?dl=0) on the issue page 20 times:

| browser | stat | Count | Baseline(ms) | Current (ms) | +/- | % |
| ---- | ---- | ---- | ---- | ---- | ---- | ---- |
| Firefox | Overall | 20 | 95 | 68 | -27  | -28.17 |
| Firefox | Page Request | 20 | 3 | 6 | 3 | 130.19 |
| Firefox | Rendering | 20 | 92 | 62 | -30 | -32.77 |

I'm unsure of what caused the Page Request to take longer. 

I've tested it using gulp test with ReferencePages created before the merge and all worked fine.

Also, working on this, I noticed that the PDF does not have support for the **PhotometricInterpretation** tag that some 1-bit depth TIFFs can have. This tag defines whether WhiteIsZero or BlackIsZero, this is the color which a bit with value 0 represents.

I couldn't work out how to get that tag out of the PDF file, but once the value is retrieved, implementing it is very easy. The initial value of the "complement" variable could change according to the tag, inverting the color scheme. For example, if on the issue PDF you start complement with 1, the background turns black and the letters white, but with better resolution than the current code.
