### PR TITLE
Implement a UI for multiple phrase search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tags
 Makefile
 node_modules/
 examples/node/svgdump/
+.idea/

--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -45,6 +45,7 @@ var PDFFindBar = (function PDFFindBarClosure() {
     this.findField = options.findField || null;
     this.highlightAll = options.highlightAllCheckbox || null;
     this.caseSensitive = options.caseSensitiveCheckbox || null;
+    this.phraseSearch = options.phraseCheckbox || null;
     this.findMsg = options.findMsg || null;
     this.findResultsCount = options.findResultsCount || null;
     this.findStatusIcon = options.findStatusIcon || null;
@@ -96,6 +97,10 @@ var PDFFindBar = (function PDFFindBarClosure() {
     this.caseSensitive.addEventListener('click', function() {
       self.dispatchEvent('casesensitivitychange');
     });
+
+    this.phraseSearch.addEventListener('click', function() {
+      self.dispatchEvent('phrasechange');
+    });
   }
 
   PDFFindBar.prototype = {
@@ -109,7 +114,7 @@ var PDFFindBar = (function PDFFindBarClosure() {
         type: type,
         query: this.findField.value,
         caseSensitive: this.caseSensitive.checked,
-        phraseSearch: true,
+        phraseSearch: this.phraseSearch.checked,
         highlightAll: this.highlightAll.checked,
         findPrevious: findPrev
       });

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -116,6 +116,8 @@ See https://github.com/adobe-type-tools/cmap-resources
           <label for="findHighlightAll" class="toolbarLabel" data-l10n-id="find_highlight">Highlight all</label>
           <input type="checkbox" id="findMatchCase" class="toolbarField" tabindex="95">
           <label for="findMatchCase" class="toolbarLabel" data-l10n-id="find_match_case_label">Match case</label>
+          <input type="checkbox" id="findPhrase" class="toolbarField" tabindex="96">
+          <label for="findPhrase" class="toolbarLabel" data-l10n-id="find_phrase_label">Phrase</label>
           <span id="findResultsCount" class="toolbarLabel hidden"></span>
           <span id="findMsg" class="toolbarLabel"></span>
         </div>  <!-- findbar -->

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -118,6 +118,7 @@ function getViewerConfiguration() {
       findField: document.getElementById('findInput'),
       highlightAllCheckbox: document.getElementById('findHighlightAll'),
       caseSensitiveCheckbox: document.getElementById('findMatchCase'),
+      phraseCheckbox: document.getElementById('findPhrase'),
       findMsg: document.getElementById('findMsg'),
       findResultsCount: document.getElementById('findResultsCount'),
       findStatusIcon: document.getElementById('findStatusIcon'),


### PR DESCRIPTION
This adds a **Phrase search** checkbox to the _viewer_. Kindly refers to following topics for more details:
- #7368 
- #5579
 
Important notes:
- Internationalization for _find_phrase_label_ is currently missing.
- Because of missing experience and because I am running out of time, I did not build the whole library from the scratch with given changes. However, the changes have been applied to the artifacts provided by the project homepage to an application running in a production environment. 
