### PR TITLE
Remove a misplaced `false` from a condition in `fixMetadata`, in `metadata.js`, since it currently short circuits the entire condition

### DIFF
--- a/src/display/metadata.js
+++ b/src/display/metadata.js
@@ -37,8 +37,8 @@ var error = sharedUtil.error;
       var chars = '';
       for (var i = 0; i < bytes.length; i += 2) {
         var code = bytes.charCodeAt(i) * 256 + bytes.charCodeAt(i + 1);
-        chars += code >= 32 && code < 127 && code !== 60 && code !== 62 &&
-          code !== 38 && false ? String.fromCharCode(code) :
+        chars += (code >= 32 && code < 127 && code !== 60 && code !== 62 &&
+          code !== 38) ? String.fromCharCode(code) :
           '&#x' + (0x10000 + code).toString(16).substring(1) + ';';
       }
       return '>' + chars;


### PR DESCRIPTION
This looks to me like a simple oversight, which has existed ever since PR #1598 all the way back in 2012.