### PR TITLE
Ensure that we resolve indirect objects in `Filter` and `DecodeParms` arrays in `parser.js`

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -400,8 +400,11 @@ var Parser = (function ParserClosure() {
       var filter = dict.get('Filter', 'F'), filterName;
       if (isName(filter)) {
         filterName = filter.name;
-      } else if (isArray(filter) && isName(filter[0])) {
-        filterName = filter[0].name;
+      } else if (isArray(filter)) {
+        var filterZero = this.xref.fetchIfRef(filter[0]);
+        if (isName(filterZero)) {
+          filterName = filterZero.name;
+        }
       }
 
       // Parse image stream.
@@ -540,7 +543,7 @@ var Parser = (function ParserClosure() {
       var params = dict.get('DecodeParms', 'DP');
       if (isName(filter)) {
         if (isArray(params)) {
-          params = params[0];
+          params = this.xref.fetchIfRef(params[0]);
         }
         return this.makeFilter(stream, filter.name, length, params);
       }
@@ -550,14 +553,14 @@ var Parser = (function ParserClosure() {
         var filterArray = filter;
         var paramsArray = params;
         for (var i = 0, ii = filterArray.length; i < ii; ++i) {
-          filter = filterArray[i];
+          filter = this.xref.fetchIfRef(filterArray[i]);
           if (!isName(filter)) {
             error('Bad filter name: ' + filter);
           }
 
           params = null;
           if (isArray(paramsArray) && (i in paramsArray)) {
-            params = paramsArray[i];
+            params = this.xref.fetchIfRef(paramsArray[i]);
           }
           stream = this.makeFilter(stream, filter.name, maybeLength, params);
           // after the first stream the length variable is invalid
@@ -575,9 +578,6 @@ var Parser = (function ParserClosure() {
         return new NullStream(stream);
       }
       try {
-        if (params && this.xref) {
-          params = this.xref.fetchIfRef(params);
-        }
         var xrefStreamStats = this.xref.stats.streamTypes;
         if (name === 'FlateDecode' || name === 'Fl') {
           xrefStreamStats[StreamType.FLATE] = true;


### PR DESCRIPTION
I've not actually, thus far, come across a PDF file that this patch fixes. However, given the string of recent patches that has fixed issues with indirect objects in arrays, I think that it makes sense to proactively avoid any issues in this code.