### PR TITLE
Move the `Preferences` initialization/fetching code to the top of `PDFViewerApplication.initialize`, to enable using them when initializing e.g. the viewer components

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -215,6 +215,14 @@ var PDFViewerApplication = {
       self.bindEvents();
       self.bindWindowEvents();
 
+      if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
+        // For backwards compatibility, we dispatch the 'localized' event on
+        // the `eventBus` once the viewer has been initialized.
+        localized.then(function () {
+          self.eventBus.dispatch('localized');
+        });
+      }
+
       if (self.isViewerEmbedded && !PDFJS.isExternalLinkTargetSet()) {
         // Prevent external links from "replacing" the viewer,
         // when it's embedded in e.g. an iframe or an object.
@@ -1788,11 +1796,6 @@ if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
   };
 }
 
-function webViewerLocalized() {
-  document.getElementsByTagName('html')[0].dir = mozL10n.getDirection();
-  PDFViewerApplication.eventBus.dispatch('localized');
-}
-
 function webViewerPresentationMode() {
   PDFViewerApplication.requestPresentationMode();
 }
@@ -2241,7 +2244,9 @@ function webViewerKeyDown(evt) {
   }
 }
 
-localized.then(webViewerLocalized);
+localized.then(function webViewerLocalized() {
+  document.getElementsByTagName('html')[0].dir = mozL10n.getDirection();
+});
 
 /* Abstract factory for the print service. */
 var PDFPrintServiceFactory = {

--- a/web/app.js
+++ b/web/app.js
@@ -193,134 +193,36 @@ var PDFViewerApplication = {
 
   // called once when the document is loaded
   initialize: function pdfViewInitialize(appConfig) {
+    var self = this;
+    var PDFJS = pdfjsLib.PDFJS;
+
     configure(pdfjsLib.PDFJS);
     this.appConfig = appConfig;
-
-    var eventBus = appConfig.eventBus || getGlobalEventBus();
-    this.eventBus = eventBus;
-    this.bindEvents();
-
-    var pdfRenderingQueue = new PDFRenderingQueue();
-    pdfRenderingQueue.onIdle = this.cleanup.bind(this);
-    this.pdfRenderingQueue = pdfRenderingQueue;
-
-    var pdfLinkService = new PDFLinkService({
-      eventBus: eventBus
-    });
-    this.pdfLinkService = pdfLinkService;
-
-    var downloadManager = this.externalServices.createDownloadManager();
-    this.downloadManager = downloadManager;
-
-    var container = appConfig.mainContainer;
-    var viewer = appConfig.viewerContainer;
-    this.pdfViewer = new PDFViewer({
-      container: container,
-      viewer: viewer,
-      eventBus: eventBus,
-      renderingQueue: pdfRenderingQueue,
-      linkService: pdfLinkService,
-      downloadManager: downloadManager,
-      enhanceTextSelection: false,
-      renderInteractiveForms: false,
-    });
-    pdfRenderingQueue.setViewer(this.pdfViewer);
-    pdfLinkService.setViewer(this.pdfViewer);
-
-    var thumbnailContainer = appConfig.sidebar.thumbnailView;
-    this.pdfThumbnailViewer = new PDFThumbnailViewer({
-      container: thumbnailContainer,
-      renderingQueue: pdfRenderingQueue,
-      linkService: pdfLinkService
-    });
-    pdfRenderingQueue.setThumbnailViewer(this.pdfThumbnailViewer);
 
     Preferences.initialize();
     this.preferences = Preferences;
 
-    this.pdfHistory = new PDFHistory({
-      linkService: pdfLinkService,
-      eventBus: this.eventBus
-    });
-    pdfLinkService.setHistory(this.pdfHistory);
+    this._initializeViewerComponents();
 
-    this.findController = new PDFFindController({
-      pdfViewer: this.pdfViewer
-    });
-    this.findController.onUpdateResultsCount = function (matchCount) {
-      if (this.supportsIntegratedFind) {
-        return;
+    return this._readPreferences().then(function () {
+      if (self.isViewerEmbedded && !PDFJS.isExternalLinkTargetSet()) {
+        // Prevent external links from "replacing" the viewer,
+        // when it's embedded in e.g. an iframe or an object.
+        PDFJS.externalLinkTarget = PDFJS.LinkTarget.TOP;
       }
-      this.findBar.updateResultsCount(matchCount);
-    }.bind(this);
-    this.findController.onUpdateState = function (state, previous, matchCount) {
-      if (this.supportsIntegratedFind) {
-        this.externalServices.updateFindControlState(
-          {result: state, findPrevious: previous});
-      } else {
-        this.findBar.updateUIState(state, previous, matchCount);
-      }
-    }.bind(this);
 
-    this.pdfViewer.setFindController(this.findController);
-
-    // FIXME better PDFFindBar constructor parameters
-    var findBarConfig = Object.create(appConfig.findBar);
-    findBarConfig.findController = this.findController;
-    findBarConfig.eventBus = this.eventBus;
-    this.findBar = new PDFFindBar(findBarConfig);
-
-    this.overlayManager = OverlayManager;
-
-    this.handTool = new HandTool({
-      container: container,
-      eventBus: this.eventBus,
+      self.initialized = true;
     });
+  },
 
-    this.pdfDocumentProperties =
-      new PDFDocumentProperties(appConfig.documentProperties);
-
-    this.toolbar = new Toolbar(appConfig.toolbar, container, eventBus);
-
-    this.secondaryToolbar =
-      new SecondaryToolbar(appConfig.secondaryToolbar, container, eventBus);
-
-    if (this.supportsFullscreen) {
-      this.pdfPresentationMode = new PDFPresentationMode({
-        container: container,
-        viewer: viewer,
-        pdfViewer: this.pdfViewer,
-        eventBus: this.eventBus,
-        contextMenuItems: appConfig.fullscreen
-      });
-    }
-
-    this.passwordPrompt = new PasswordPrompt(appConfig.passwordOverlay);
-
-    this.pdfOutlineViewer = new PDFOutlineViewer({
-      container: appConfig.sidebar.outlineView,
-      eventBus: this.eventBus,
-      linkService: pdfLinkService,
-    });
-
-    this.pdfAttachmentViewer = new PDFAttachmentViewer({
-      container: appConfig.sidebar.attachmentsView,
-      eventBus: this.eventBus,
-      downloadManager: downloadManager
-    });
-
-    // FIXME better PDFSidebar constructor parameters
-    var sidebarConfig = Object.create(appConfig.sidebar);
-    sidebarConfig.pdfViewer = this.pdfViewer;
-    sidebarConfig.pdfThumbnailViewer = this.pdfThumbnailViewer;
-    sidebarConfig.pdfOutlineViewer = this.pdfOutlineViewer;
-    sidebarConfig.eventBus = this.eventBus;
-    this.pdfSidebar = new PDFSidebar(sidebarConfig);
-    this.pdfSidebar.onToggled = this.forceRendering.bind(this);
-
+  /**
+   * @private
+   */
+  _readPreferences: function () {
     var self = this;
     var PDFJS = pdfjsLib.PDFJS;
-    var initializedPromise = Promise.all([
+
+    return Promise.all([
       Preferences.get('enableWebGL').then(function resolved(value) {
         PDFJS.disableWebGL = !value;
       }),
@@ -401,16 +303,132 @@ var PDFViewerApplication = {
       }),
       // TODO move more preferences and other async stuff here
     ]).catch(function (reason) { });
+  },
 
-    return initializedPromise.then(function () {
-      if (self.isViewerEmbedded && !PDFJS.isExternalLinkTargetSet()) {
-        // Prevent external links from "replacing" the viewer,
-        // when it's embedded in e.g. an iframe or an object.
-        PDFJS.externalLinkTarget = PDFJS.LinkTarget.TOP;
-      }
+  /**
+   * @private
+   */
+  _initializeViewerComponents: function () {
+    var appConfig = this.appConfig;
 
-      self.initialized = true;
+    var eventBus = appConfig.eventBus || getGlobalEventBus();
+    this.eventBus = eventBus;
+    this.bindEvents();
+
+    var pdfRenderingQueue = new PDFRenderingQueue();
+    pdfRenderingQueue.onIdle = this.cleanup.bind(this);
+    this.pdfRenderingQueue = pdfRenderingQueue;
+
+    var pdfLinkService = new PDFLinkService({
+      eventBus: eventBus
     });
+    this.pdfLinkService = pdfLinkService;
+
+    var downloadManager = this.externalServices.createDownloadManager();
+    this.downloadManager = downloadManager;
+
+    var container = appConfig.mainContainer;
+    var viewer = appConfig.viewerContainer;
+    this.pdfViewer = new PDFViewer({
+      container: container,
+      viewer: viewer,
+      eventBus: eventBus,
+      renderingQueue: pdfRenderingQueue,
+      linkService: pdfLinkService,
+      downloadManager: downloadManager,
+      enhanceTextSelection: false,
+      renderInteractiveForms: false,
+    });
+    pdfRenderingQueue.setViewer(this.pdfViewer);
+    pdfLinkService.setViewer(this.pdfViewer);
+
+    var thumbnailContainer = appConfig.sidebar.thumbnailView;
+    this.pdfThumbnailViewer = new PDFThumbnailViewer({
+      container: thumbnailContainer,
+      renderingQueue: pdfRenderingQueue,
+      linkService: pdfLinkService
+    });
+    pdfRenderingQueue.setThumbnailViewer(this.pdfThumbnailViewer);
+
+    this.pdfHistory = new PDFHistory({
+      linkService: pdfLinkService,
+      eventBus: this.eventBus
+    });
+    pdfLinkService.setHistory(this.pdfHistory);
+
+    this.findController = new PDFFindController({
+      pdfViewer: this.pdfViewer
+    });
+    this.findController.onUpdateResultsCount = function (matchCount) {
+      if (this.supportsIntegratedFind) {
+        return;
+      }
+      this.findBar.updateResultsCount(matchCount);
+    }.bind(this);
+    this.findController.onUpdateState = function (state, previous, matchCount) {
+      if (this.supportsIntegratedFind) {
+        this.externalServices.updateFindControlState(
+          {result: state, findPrevious: previous});
+      } else {
+        this.findBar.updateUIState(state, previous, matchCount);
+      }
+    }.bind(this);
+
+    this.pdfViewer.setFindController(this.findController);
+
+    // FIXME better PDFFindBar constructor parameters
+    var findBarConfig = Object.create(appConfig.findBar);
+    findBarConfig.findController = this.findController;
+    findBarConfig.eventBus = this.eventBus;
+    this.findBar = new PDFFindBar(findBarConfig);
+
+    this.overlayManager = OverlayManager;
+
+    this.handTool = new HandTool({
+      container: container,
+      eventBus: this.eventBus,
+    });
+
+    this.pdfDocumentProperties =
+      new PDFDocumentProperties(appConfig.documentProperties);
+
+    this.toolbar = new Toolbar(appConfig.toolbar, container, eventBus);
+
+    this.secondaryToolbar =
+      new SecondaryToolbar(appConfig.secondaryToolbar, container, eventBus);
+
+    if (this.supportsFullscreen) {
+      this.pdfPresentationMode = new PDFPresentationMode({
+        container: container,
+        viewer: viewer,
+        pdfViewer: this.pdfViewer,
+        eventBus: this.eventBus,
+        contextMenuItems: appConfig.fullscreen
+      });
+    }
+
+    this.passwordPrompt = new PasswordPrompt(appConfig.passwordOverlay);
+
+    this.pdfOutlineViewer = new PDFOutlineViewer({
+      container: appConfig.sidebar.outlineView,
+      eventBus: this.eventBus,
+      linkService: pdfLinkService,
+    });
+
+    this.pdfAttachmentViewer = new PDFAttachmentViewer({
+      container: appConfig.sidebar.attachmentsView,
+      eventBus: this.eventBus,
+      downloadManager: downloadManager
+    });
+
+    // FIXME better PDFSidebar constructor parameters
+    var sidebarConfig = Object.create(appConfig.sidebar);
+    sidebarConfig.pdfViewer = this.pdfViewer;
+    sidebarConfig.pdfThumbnailViewer = this.pdfThumbnailViewer;
+    sidebarConfig.pdfOutlineViewer = this.pdfOutlineViewer;
+    sidebarConfig.eventBus = this.eventBus;
+    this.pdfSidebar = new PDFSidebar(sidebarConfig);
+    this.pdfSidebar.onToggled = this.forceRendering.bind(this);
   },
 
   run: function pdfViewRun(config) {

--- a/web/hand_tool.js
+++ b/web/hand_tool.js
@@ -18,17 +18,19 @@
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
     define('pdfjs-web/hand_tool', ['exports', 'pdfjs-web/grab_to_pan',
-      'pdfjs-web/preferences'], factory);
+      'pdfjs-web/preferences', 'pdfjs-web/ui_utils'], factory);
   } else if (typeof exports !== 'undefined') {
-    factory(exports, require('./grab_to_pan.js'), require('./preferences.js'));
+    factory(exports, require('./grab_to_pan.js'), require('./preferences.js'),
+      require('./ui_utils.js'));
   } else {
     factory((root.pdfjsWebHandTool = {}), root.pdfjsWebGrabToPan,
-      root.pdfjsWebPreferences);
+      root.pdfjsWebPreferences, root.pdfjsWebUIUtils);
   }
-}(this, function (exports, grabToPan, preferences) {
+}(this, function (exports, grabToPan, preferences, uiUtils) {
 
 var GrabToPan = grabToPan.GrabToPan;
 var Preferences = preferences.Preferences;
+var localized = uiUtils.localized;
 
 /**
  * @typedef {Object} HandToolOptions
@@ -59,13 +61,12 @@ var HandTool = (function HandToolClosure() {
 
     this.eventBus.on('togglehandtool', this.toggle.bind(this));
 
-    this.eventBus.on('localized', function (e) {
-      Preferences.get('enableHandToolOnLoad').then(function resolved(value) {
-        if (value) {
+    Promise.all([localized, Preferences.get('enableHandToolOnLoad')]).then(
+      function resolved(values) {
+        if (values[1] === true) {
           this.handTool.activate();
         }
-      }.bind(this), function rejected(reason) {});
-    }.bind(this));
+      }.bind(this)).catch(function rejected(reason) { });
 
     this.eventBus.on('presentationmodechanged', function (e) {
       if (e.switchInProgress) {


### PR DESCRIPTION
*This is a new attempt at implementing, the main feature of, PR #7586. With the changes made to the 'localized' event in PR #7789, and the first commits here, this should avoid the issues with the Firefox addon that caused the previous PR to be backed out; see https://github.com/mozilla/pdf.js/pull/7586#issuecomment-244561590.*

I'd suggest looking at one commit at a time, and using the `?w=1` flag should help reduce (or at least simplify) the larger diffs somewhat. Please also note that GitHub may list the commits in a sub-optimal order, according to date, but they should be reviewed as follows:

- Refactor `PDFViewerApplication.initialize` into two methods, one that reads the Preferences and one that initializes the various viewer components

 - Move the `Preferences` initialization/fetching code to the top of `PDFViewerApplication.initialize`, to enable using them when initializing e.g. the viewer components
   > Note that in quick testing using `console.time/timeEnd`, both locally and with the Firefox addon, the total run time of the *entire* `PDFViewerApplication.initialize` function does not seem to change with this patch.

 - Don't call `bindEvents()` until `PDFViewerApplication` has been initialized, and move binding of `window` event listeners to a helper method, to prevent errors if an event manages to arrive too soon
   > With `bindEvents()` now being called after the viewer has been initialized, we no longer need to have `PDFViewerApplication.initialized` checks in the event handler functions.
Furthermore by moving the `window.addEventListener`s to a helper method, `PDFViewerApplication.initialized` checks are no longer necessary in the event handlers, hence we thus address part of issue #7797 here as well.

 - Convert the only remaining consumer (in `hand_tool.js`) of the 'localized' event to use the `localized` Promise instead, and only re-dispatch the 'localized' event on the `eventBus` for `GENERIC` builds
   > Ideally we'd remove the 'localized' event from the `eventBus`, but for backwards compatibility we keep it in `GENERIC` builds.
Note that while we want to ensure that the direction attribute of the HTML is updated as soon as the `localized` Promise is resolved, we purposely wait until the viewer has been initialized to ensure that the 'localized' event will always be dispatched.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/pdf.js/7886)
<!-- Reviewable:end -->
