### PR TITLE
Fix a number of code style issues found by various ESLint rules, to make it easier to switch from JSHint to ESLint

### DIFF
--- a/extensions/chromium/pdfHandler.js
+++ b/extensions/chromium/pdfHandler.js
@@ -54,7 +54,7 @@ function isPdfDownloadable(details) {
  * @return {undefined|{name: string, value: string}} The header, if found.
  */
 function getHeaderFromHeaders(headers, headerName) {
-  for (var i=0; i<headers.length; ++i) {
+  for (var i = 0; i < headers.length; ++i) {
     var header = headers[i];
     if (header.name.toLowerCase() === headerName) {
       return header;

--- a/extensions/chromium/pdfHandler.js
+++ b/extensions/chromium/pdfHandler.js
@@ -72,7 +72,7 @@ function getHeaderFromHeaders(headers, headerName) {
 function isPdfFile(details) {
   var header = getHeaderFromHeaders(details.responseHeaders, 'content-type');
   if (header) {
-    var headerValue = header.value.toLowerCase().split(';',1)[0].trim();
+    var headerValue = header.value.toLowerCase().split(';', 1)[0].trim();
     if (headerValue === 'application/pdf') {
       return true;
     }
@@ -153,7 +153,7 @@ chrome.webRequest.onHeadersReceived.addListener(
     ],
     types: ['main_frame', 'sub_frame']
   },
-  ['blocking','responseHeaders']);
+  ['blocking', 'responseHeaders']);
 
 chrome.webRequest.onBeforeRequest.addListener(
   function onBeforeRequestForFTP(details) {

--- a/extensions/firefox/content/PdfjsChromeUtils.jsm
+++ b/extensions/firefox/content/PdfjsChromeUtils.jsm
@@ -338,4 +338,3 @@ var PdfjsChromeUtils = {
     });
   }
 };
-

--- a/external/builder/preprocessor2.js
+++ b/external/builder/preprocessor2.js
@@ -68,7 +68,7 @@ function handlePreprocessorAction(ctx, actionName, args, loc) {
                                jsonPath.substring(ROOT_PREFIX.length));
         }
         var jsonContent = fs.readFileSync(jsonPath).toString();
-        var parsedJSON = esprima.parse('(' +jsonContent + ')');
+        var parsedJSON = esprima.parse('(' + jsonContent + ')');
         parsedJSON.body[0].expression.loc = loc;
         return parsedJSON.body[0].expression;
     }

--- a/external/crlfchecker/crlfchecker.js
+++ b/external/crlfchecker/crlfchecker.js
@@ -24,4 +24,3 @@ function checkIfCrlfIsPresent(files) {
 }
 
 exports.checkIfCrlfIsPresent = checkIfCrlfIsPresent;
-

--- a/external/umdutils/verifier.js
+++ b/external/umdutils/verifier.js
@@ -210,7 +210,7 @@ function readDependencies(rootPaths) {
       }
     });
     if (discovered.length === 0) {
-      throw new Error ('Some circular references exist: somewhere at ' +
+      throw new Error('Some circular references exist: somewhere at ' +
         left.join(','));
     }
     discovered.sort();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -197,7 +197,7 @@ function createBundle(defines) {
       case 'mainfile':
         // 'buildnumber' shall create BUILD_DIR for us
         tmpFile = BUILD_DIR + '~' + mainOutputName + '.tmp';
-        bundle('src/pdf.js', tmpFile, 'src/', mainFiles,  mainAMDName,
+        bundle('src/pdf.js', tmpFile, 'src/', mainFiles, mainAMDName,
           defines, true, versionJSON);
         this.push(new gutil.File({
           cwd: '',

--- a/make.js
+++ b/make.js
@@ -883,7 +883,7 @@ target.chromium = function() {
         'extensions/chromium/*.html',
         'extensions/chromium/*.js',
         'extensions/chromium/*.css',
-        'extensions/chromium/icon*.png',],
+        'extensions/chromium/icon*.png'],
        CHROME_BUILD_DIR],
       ['extensions/chromium/pageAction/*.*', CHROME_BUILD_DIR + '/pageAction'],
       ['extensions/chromium/options/*.*', CHROME_BUILD_DIR + '/options'],

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -435,7 +435,7 @@ var Annotation = (function AnnotationClosure() {
         // Properties
       ]);
       var bbox = appearanceDict.getArray('BBox') || [0, 0, 1, 1];
-      var matrix = appearanceDict.getArray('Matrix') || [1, 0, 0, 1, 0 ,0];
+      var matrix = appearanceDict.getArray('Matrix') || [1, 0, 0, 1, 0, 0];
       var transform = getTransformMatrix(data.rect, bbox, matrix);
       var self = this;
 

--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -568,7 +568,7 @@ var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
       if (this.pdfNetworkStream) {
         this.pdfNetworkStream.cancelAllRequests('abort');
       }
-      for(var requestId in this.promisesByRequest) {
+      for (var requestId in this.promisesByRequest) {
         var capability = this.promisesByRequest[requestId];
         capability.reject(new Error('Request was aborted'));
       }

--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -1729,13 +1729,13 @@ var PDF20 = (function PDF20Closure() {
 
 var CipherTransform = (function CipherTransformClosure() {
   function CipherTransform(stringCipherConstructor, streamCipherConstructor) {
-    this.stringCipherConstructor = stringCipherConstructor;
-    this.streamCipherConstructor = streamCipherConstructor;
+    this.StringCipherConstructor = stringCipherConstructor;
+    this.StreamCipherConstructor = streamCipherConstructor;
   }
 
   CipherTransform.prototype = {
     createStream: function CipherTransform_createStream(stream, length) {
-      var cipher = new this.streamCipherConstructor();
+      var cipher = new this.StreamCipherConstructor();
       return new DecryptStream(stream, length,
         function cipherTransformDecryptStream(data, finalize) {
           return cipher.decryptBlock(data, finalize);
@@ -1743,7 +1743,7 @@ var CipherTransform = (function CipherTransformClosure() {
       );
     },
     decryptString: function CipherTransform_decryptString(s) {
-      var cipher = new this.stringCipherConstructor();
+      var cipher = new this.StringCipherConstructor();
       var data = stringToBytes(s);
       data = cipher.decryptBlock(data, true);
       return bytesToString(data);

--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -609,22 +609,22 @@ var calculateSHA512 = (function calculateSHA512Closure() {
     var result;
     if (!mode384) {
       result = new Uint8Array(64);
-      h0.copyTo(result,0);
-      h1.copyTo(result,8);
-      h2.copyTo(result,16);
-      h3.copyTo(result,24);
-      h4.copyTo(result,32);
-      h5.copyTo(result,40);
-      h6.copyTo(result,48);
-      h7.copyTo(result,56);
+      h0.copyTo(result, 0);
+      h1.copyTo(result, 8);
+      h2.copyTo(result, 16);
+      h3.copyTo(result, 24);
+      h4.copyTo(result, 32);
+      h5.copyTo(result, 40);
+      h6.copyTo(result, 48);
+      h7.copyTo(result, 56);
     } else {
       result = new Uint8Array(48);
-      h0.copyTo(result,0);
-      h1.copyTo(result,8);
-      h2.copyTo(result,16);
-      h3.copyTo(result,24);
-      h4.copyTo(result,32);
-      h5.copyTo(result,40);
+      h0.copyTo(result, 0);
+      h1.copyTo(result, 8);
+      h2.copyTo(result, 16);
+      h3.copyTo(result, 24);
+      h4.copyTo(result, 32);
+      h5.copyTo(result, 40);
     }
     return result;
   }

--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -2057,17 +2057,17 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
         return new NullCipher();
       };
     }
-    if ('V2' === cfm.name) {
+    if (cfm.name === 'V2') {
       return function cipherTransformFactoryBuildCipherConstructorV2() {
         return new ARCFourCipher(buildObjectKey(num, gen, key, false));
       };
     }
-    if ('AESV2' === cfm.name) {
+    if (cfm.name === 'AESV2') {
       return function cipherTransformFactoryBuildCipherConstructorAESV2() {
         return new AES128Cipher(buildObjectKey(num, gen, key, true));
       };
     }
-    if ('AESV3' === cfm.name) {
+    if (cfm.name === 'AESV3') {
       return function cipherTransformFactoryBuildCipherConstructorAESV3() {
         return new AES256Cipher(key);
       };

--- a/src/core/font_renderer.js
+++ b/src/core/font_renderer.js
@@ -437,7 +437,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
                 x = xb; y = yb;
                 if (Math.abs(x - x0) > Math.abs(y - y0)) {
                   x += stack.shift();
-                } else  {
+                } else {
                   y += stack.shift();
                 }
                 bezierCurveTo(xa, ya, xb, yb, x, y);

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -2943,6 +2943,7 @@ var ErrorFont = (function ErrorFontClosure() {
 function type1FontGlyphMapping(properties, builtInEncoding, glyphNames) {
   var charCodeToGlyphId = Object.create(null);
   var glyphId, charCode, baseEncoding;
+  var isSymbolicFont = !!(properties.flags & FontFlags.Symbolic);
 
   if (properties.baseEncodingName) {
     // If a valid base encoding name was used, the mapping is initialized with
@@ -2956,9 +2957,8 @@ function type1FontGlyphMapping(properties, builtInEncoding, glyphNames) {
         charCodeToGlyphId[charCode] = 0; // notdef
       }
     }
-  } else if (!!(properties.flags & FontFlags.Symbolic)) {
-    // For a symbolic font the encoding should be the fonts built-in
-    // encoding.
+  } else if (isSymbolicFont) {
+    // For a symbolic font the encoding should be the fonts built-in encoding.
     for (charCode in builtInEncoding) {
       charCodeToGlyphId[charCode] = builtInEncoding[charCode];
     }

--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -977,7 +977,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
       var combinationOperator = pageInfo.combinationOperatorOverride ?
         regionInfo.combinationOperator : pageInfo.combinationOperator;
       var buffer = this.buffer;
-      var mask0 =  128 >> (regionInfo.x & 7);
+      var mask0 = 128 >> (regionInfo.x & 7);
       var offset0 = regionInfo.y * rowSize + (regionInfo.x >> 3);
       var i, j, mask, offset;
       switch (combinationOperator) {

--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -616,7 +616,7 @@ var JpegImage = (function JpegImageClosure() {
           component = frame.components[i];
           var blocksPerLine = Math.ceil(Math.ceil(frame.samplesPerLine / 8) *
                                         component.h / frame.maxH);
-          var blocksPerColumn = Math.ceil(Math.ceil(frame.scanLines  / 8) *
+          var blocksPerColumn = Math.ceil(Math.ceil(frame.scanLines / 8) *
                                           component.v / frame.maxV);
           var blocksPerLineForMcu = mcusPerLine * component.h;
           var blocksPerColumnForMcu = mcusPerColumn * component.v;

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -1484,7 +1484,7 @@ var JpxImage = (function JpxImageClosure() {
       var qcdOrQcc = (context.currentTile.QCC[c] !== undefined ?
         context.currentTile.QCC[c] : context.currentTile.QCD);
       component.quantizationParameters = qcdOrQcc;
-      var codOrCoc = (context.currentTile.COC[c] !== undefined  ?
+      var codOrCoc = (context.currentTile.COC[c] !== undefined ?
         context.currentTile.COC[c] : context.currentTile.COD);
       component.codingStyleParameters = codOrCoc;
     }
@@ -1552,7 +1552,7 @@ var JpxImage = (function JpxImageClosure() {
   })();
 
   var InclusionTree = (function InclusionTreeClosure() {
-    function InclusionTree(width, height,  defaultValue) {
+    function InclusionTree(width, height, defaultValue) {
       var levelsLength = log2(Math.max(width, height)) + 1;
       this.levels = [];
       for (var i = 0; i < levelsLength; i++) {

--- a/src/core/murmurhash3.js
+++ b/src/core/murmurhash3.js
@@ -32,12 +32,12 @@
 
 var Uint32ArrayView = sharedUtil.Uint32ArrayView;
 
-var MurmurHash3_64 = (function MurmurHash3_64Closure (seed) {
+var MurmurHash3_64 = (function MurmurHash3_64Closure(seed) {
   // Workaround for missing math precision in JS.
   var MASK_HIGH = 0xffff0000;
   var MASK_LOW = 0xffff;
 
-  function MurmurHash3_64 (seed) {
+  function MurmurHash3_64(seed) {
     var SEED = 0xc3d2e1f0;
     this.h1 = seed ? seed & 0xffffffff : SEED;
     this.h2 = seed ? seed & 0xffffffff : SEED;
@@ -145,7 +145,7 @@ var MurmurHash3_64 = (function MurmurHash3_64Closure (seed) {
       return this;
     },
 
-    hexdigest: function MurmurHash3_64_hexdigest () {
+    hexdigest: function MurmurHash3_64_hexdigest() {
       var h1 = this.h1;
       var h2 = this.h2;
 

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -895,7 +895,7 @@ var Lexer = (function LexerClosure() {
             var x2 = toHexDigit(ch);
             if (x2 === -1) {
               warn('Lexer_getName: Illegal digit (' +
-                   String.fromCharCode(ch) +') in hexadecimal number.');
+                   String.fromCharCode(ch) + ') in hexadecimal number.');
               strBuf.push('#', String.fromCharCode(previousCh));
               if (specialChars[ch]) {
                 break;

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -210,7 +210,7 @@ var NetworkPdfManager = (function NetworkPdfManagerClosure() {
               result = value;
             }
             resolve(result);
-          } catch(e) {
+          } catch (e) {
             if (!(e instanceof MissingDataException)) {
               reject(e);
               return;

--- a/src/core/type1_parser.js
+++ b/src/core/type1_parser.js
@@ -86,7 +86,7 @@ var Type1CharString = (function Type1CharStringClosure() {
     'rrcurveto': [8],
     'callsubr': [10],
     'flex': [12, 35],
-    'drop' : [12, 18],
+    'drop': [12, 18],
     'endchar': [14],
     'rmoveto': [21],
     'hmoveto': [22],
@@ -483,7 +483,7 @@ var Type1Parser = (function Type1ParserClosure() {
       return token === 'true' ? 1 : 0;
     },
 
-    nextChar : function Type1_nextChar() {
+    nextChar: function Type1_nextChar() {
       return (this.currentChar = this.stream.getByte());
     },
 

--- a/src/core/type1_parser.js
+++ b/src/core/type1_parser.js
@@ -550,7 +550,7 @@ var Type1Parser = (function Type1ParserClosure() {
             this.getToken(); // read in 'dict'
             this.getToken(); // read in 'dup'
             this.getToken(); // read in 'begin'
-            while(true) {
+            while (true) {
               token = this.getToken();
               if (token === null || token === 'end') {
                 break;

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1314,7 +1314,7 @@ var PDFWorker = (function PDFWorkerClosure() {
             }
             try {
               sendTest();
-            } catch (e)  {
+            } catch (e) {
               // We need fallback to a faked worker.
               this._setupFakeWorker();
             }

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1780,13 +1780,13 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       this.save();
       this.baseTransformStack.push(this.baseTransform);
 
-      if (isArray(matrix) && 6 === matrix.length) {
+      if (isArray(matrix) && matrix.length === 6) {
         this.transform.apply(this, matrix);
       }
 
       this.baseTransform = this.ctx.mozCurrentTransform;
 
-      if (isArray(bbox) && 4 === bbox.length) {
+      if (isArray(bbox) && bbox.length === 4) {
         var width = bbox[2] - bbox[0];
         var height = bbox[3] - bbox[1];
         this.ctx.rect(bbox[0], bbox[1], width, height);
@@ -1947,7 +1947,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
                                                              matrix) {
       this.save();
 
-      if (isArray(rect) && 4 === rect.length) {
+      if (isArray(rect) && rect.length === 4) {
         var width = rect[2] - rect[0];
         var height = rect[3] - rect[1];
         this.ctx.rect(rect[0], rect[1], width, height);

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -654,7 +654,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     }
     if (sourceCtx.setLineDash !== undefined) {
       destCtx.setLineDash(sourceCtx.getLineDash());
-      destCtx.lineDashOffset =  sourceCtx.lineDashOffset;
+      destCtx.lineDashOffset = sourceCtx.lineDashOffset;
     }
   }
 
@@ -1862,7 +1862,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       var cacheId = 'groupAt' + this.groupLevel;
       if (group.smask) {
         // Using two cache entries is case if masks are used one after another.
-        cacheId +=  '_smask_' + ((this.smaskCounter++) % 2);
+        cacheId += '_smask_' + ((this.smaskCounter++) % 2);
       }
       var scratchCanvas = this.cachedCanvases.getCanvas(
         cacheId, drawnWidth, drawnHeight, true);

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -841,7 +841,7 @@ var SVGGraphics = (function SVGGraphicsClosure() {
             var height = args[j++];
             var xw = x + width;
             var yh = y + height;
-            d.push('M', pf(x), pf(y), 'L', pf(xw) , pf(y), 'L', pf(xw), pf(yh),
+            d.push('M', pf(x), pf(y), 'L', pf(xw), pf(y), 'L', pf(xw), pf(yh),
                    'L', pf(x), pf(yh), 'Z');
             break;
           case OPS.moveTo:
@@ -852,7 +852,7 @@ var SVGGraphics = (function SVGGraphicsClosure() {
           case OPS.lineTo:
             x = args[j++];
             y = args[j++];
-            d.push('L', pf(x) , pf(y));
+            d.push('L', pf(x), pf(y));
             break;
           case OPS.curveTo:
             x = args[j + 4];

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -374,7 +374,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
         i++;
       }
       var j = horizon.length - 1;
-      while(j >= 0 && horizon[j].start >= boundary.y2) {
+      while (j >= 0 && horizon[j].start >= boundary.y2) {
         j--;
       }
 

--- a/src/display/webgl.js
+++ b/src/display/webgl.js
@@ -186,7 +186,7 @@ var WebGLUtils = (function WebGLUtilsClosure() {
     if (!smaskCache) {
       initSmaskGL();
     }
-    var cache = smaskCache,canvas = cache.canvas, gl = cache.gl;
+    var cache = smaskCache, canvas = cache.canvas, gl = cache.gl;
     canvas.width = width;
     canvas.height = height;
     gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);

--- a/src/display/webgl.js
+++ b/src/display/webgl.js
@@ -165,12 +165,12 @@ var WebGLUtils = (function WebGLUtilsClosure() {
     var texCoordBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, texCoordBuffer);
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
-      0.0,  0.0,
-      1.0,  0.0,
-      0.0,  1.0,
-      0.0,  1.0,
-      1.0,  0.0,
-      1.0,  1.0]), gl.STATIC_DRAW);
+      0.0, 0.0,
+      1.0, 0.0,
+      0.0, 1.0,
+      0.0, 1.0,
+      1.0, 0.0,
+      1.0, 1.0]), gl.STATIC_DRAW);
     gl.enableVertexAttribArray(texCoordLocation);
     gl.vertexAttribPointer(texCoordLocation, 2, gl.FLOAT, false, 0, 0);
 

--- a/src/shared/cffStandardStrings.js
+++ b/src/shared/cffStandardStrings.js
@@ -148,7 +148,7 @@ var CFFDictDataMap = {
     },
     '7': {
       name: 'FontMatrix',
-      operand: [0.001, 0, 0, 0.001, 0 , 0]
+      operand: [0.001, 0, 0, 0.001, 0, 0]
     },
     '8': {
       name: 'StrokeWidth',

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1766,7 +1766,7 @@ if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL')) {
       u.pathname = 'c%20d';
       hasWorkingUrl = u.href === 'http://a/c%20d';
     }
-  } catch(e) { }
+  } catch (e) { }
 
   if (hasWorkingUrl) {
     return;

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -557,7 +557,7 @@ function arraysToBytes(arr) {
   }
   var resultLength = 0;
   var i, ii = arr.length;
-  var item, itemLength ;
+  var item, itemLength;
   for (i = 0; i < ii; i++) {
     item = arr[i];
     itemLength = arrayByteLength(item);

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -2166,7 +2166,7 @@ if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL')) {
               err('\\ not allowed in relative path.');
             }
             var tmp;
-            if (tmp = relativePathDotMapping[buffer.toLowerCase()]) {
+            if ((tmp = relativePathDotMapping[buffer.toLowerCase()])) {
               buffer = tmp;
             }
             if ('..' === buffer) {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1925,7 +1925,7 @@ if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL')) {
           break;
 
         case 'relative or authority':
-          if ('/' === c && '/' === input[cursor+1]) {
+          if ('/' === c && '/' === input[cursor + 1]) {
             state = 'authority ignore slashes';
           } else {
             err('Expected /, got: ' + c);
@@ -1970,8 +1970,8 @@ if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL')) {
             this._password = base._password;
             state = 'fragment';
           } else {
-            var nextC = input[cursor+1];
-            var nextNextC = input[cursor+2];
+            var nextC = input[cursor + 1];
+            var nextNextC = input[cursor + 2];
             if ('file' !== this._scheme || !ALPHA.test(c) ||
                 (nextC !== ':' && nextC !== '|') ||
                 (EOF !== nextNextC && '/' !== nextNextC && '\\' !== nextNextC &&

--- a/test/driver.js
+++ b/test/driver.js
@@ -288,7 +288,7 @@ var Driver = (function DriverClosure() {
       var self = this;
       window.onerror = function(message, source, line, column, error) {
         self._info('Error: ' + message + ' Script: ' + source + ' Line: ' +
-                  line + ' Column: ' + column + ' StackTrace: ' +  error);
+                   line + ' Column: ' + column + ' StackTrace: ' + error);
       };
       this._info('User agent: ' + navigator.userAgent);
       this._log('Harness thinks this browser is "' + this.browser +

--- a/test/stats/statcmp.js
+++ b/test/stats/statcmp.js
@@ -179,14 +179,14 @@ function main() {
   try {
     var baselineFile = fs.readFileSync(options.baseline).toString();
     baseline = flatten(JSON.parse(baselineFile));
-  } catch(e) {
+  } catch (e) {
     console.log('Error reading file "' + options.baseline + '": ' + e);
     process.exit(0);
   }
   try {
     var currentFile = fs.readFileSync(options.current).toString();
     current = flatten(JSON.parse(currentFile));
-  } catch(e) {
+  } catch (e) {
     console.log('Error reading file "' + options.current + '": ' + e);
     process.exit(0);
   }

--- a/test/stats/statcmp.js
+++ b/test/stats/statcmp.js
@@ -159,7 +159,7 @@ function stat(baseline, current) {
   }
 
   // add horizontal line
-  var hline = width.map(function(w) { return new Array(w+1).join('-'); });
+  var hline = width.map(function(w) { return new Array(w + 1).join('-'); });
   rows.splice(1, 0, hline);
 
   // print output

--- a/test/test.js
+++ b/test/test.js
@@ -81,7 +81,7 @@ function parseOptions() {
       'test_manifest.json'))
     .check(describeCheck(function (argv) {
       return !argv.browser || !argv.browserManifestFile;
-    }, '--browser and --browserManifestFile must not be specified at the ' +'' +
+    }, '--browser and --browserManifestFile must not be specified at the ' +
       'same time.'));
   var result = yargs.argv;
   if (result.help) {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -505,7 +505,7 @@ describe('api', function() {
 
       // PageLabels with bad "Prefix" entries.
       var url3 = new URL('../pdfs/bad-PageLabels.pdf', window.location).href;
-      var loadingTask3 = new PDFJS.getDocument(url3);
+      var loadingTask3 = PDFJS.getDocument(url3);
       var promise3 = loadingTask3.promise.then(function (pdfDoc) {
         return pdfDoc.getPageLabels();
       });

--- a/test/unit/crypto_spec.js
+++ b/test/unit/crypto_spec.js
@@ -250,7 +250,7 @@ describe('crypto', function() {
         key = hex2binary('000102030405060708090a0b0c0d0e0f');
         iv = hex2binary('00000000000000000000000000000000');
         cipher = new AES128Cipher(key);
-        result = cipher.encrypt(input,iv);
+        result = cipher.encrypt(input, iv);
         expected = hex2binary('69c4e0d86a7b0430d8cdb78070b4c55a');
         expect(result).toEqual(expected);
       });
@@ -279,7 +279,7 @@ describe('crypto', function() {
                          '191a1b1c1d1e1f');
         iv = hex2binary('00000000000000000000000000000000');
         cipher = new AES256Cipher(key);
-        result = cipher.encrypt(input,iv);
+        result = cipher.encrypt(input, iv);
         expected = hex2binary('8ea2b7ca516745bfeafc49904b496089');
         expect(result).toEqual(expected);
       });
@@ -293,7 +293,7 @@ describe('crypto', function() {
                          '191a1b1c1d1e1f');
         iv = hex2binary('00000000000000000000000000000000');
         cipher = new AES256Cipher(key);
-        result = cipher.decryptBlock(input,false,iv);
+        result = cipher.decryptBlock(input, false, iv);
         expected = hex2binary('00112233445566778899aabbccddeeff');
         expect(result).toEqual(expected);
       });
@@ -304,7 +304,7 @@ describe('crypto', function() {
         key = hex2binary('000102030405060708090a0b0c0d0e0f101112131415161718' +
                          '191a1b1c1d1e1f');
         cipher = new AES256Cipher(key);
-        result = cipher.decryptBlock(input,false);
+        result = cipher.decryptBlock(input, false);
         expected = hex2binary('00112233445566778899aabbccddeeff');
         expect(result).toEqual(expected);
       });

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -203,4 +203,3 @@ function initializePDFJS(callback) {
     return destination;
   }
 }());
-

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -346,12 +346,12 @@ describe('primitives', function() {
   });
 
   describe('isRef', function () {
-    it ('handles non-refs', function () {
+    it('handles non-refs', function () {
       var nonRef = {};
       expect(isRef(nonRef)).toEqual(false);
     });
 
-    it ('handles refs', function () {
+    it('handles refs', function () {
       var ref = new Ref(1, 0);
       expect(isRef(ref)).toEqual(true);
     });

--- a/test/unit/type1_parser_spec.js
+++ b/test/unit/type1_parser_spec.js
@@ -70,7 +70,7 @@ describe('Type1Parser', function() {
     var stream = new StringStream(
       '/ExpansionFactor  99\n' +
       '/Subrs 1 array\n' +
-      'dup 0 1 RD x noaccess put\n'+
+      'dup 0 1 RD x noaccess put\n' +
       'end\n' +
       '/CharStrings 46 dict dup begin\n' +
       '/.notdef 1 RD x ND\n' +

--- a/test/unit/type1_parser_spec.js
+++ b/test/unit/type1_parser_spec.js
@@ -73,7 +73,7 @@ describe('Type1Parser', function() {
       'dup 0 1 RD x noaccess put\n'+
       'end\n' +
       '/CharStrings 46 dict dup begin\n' +
-      '/.notdef 1 RD x ND' + '\n' +
+      '/.notdef 1 RD x ND\n' +
       'end');
     var parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
     var program = parser.extractFontProgram();

--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -117,4 +117,3 @@ describe('ui_utils', function() {
     });
   });
 });
-

--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -270,7 +270,7 @@ if (typeof PDFJS === 'undefined') {
       // initialize result and counters
       var bc = 0, bs, buffer, idx = 0, output = '';
       // get next character
-      buffer = input.charAt(idx++);
+      (buffer = input.charAt(idx++));
       // character found in table?
       // initialize bit storage and add its ascii value
       ~buffer && (bs = bc % 4 ? bs * 64 + buffer : buffer,

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -173,7 +173,7 @@ Preferences._readFromStorage = function (prefObj) {
       highlightAll: !!evt.detail.highlightAll,
       findPrevious: !!evt.detail.findPrevious
     });
-  }.bind(this);
+  };
 
   for (var i = 0, len = events.length; i < len; i++) {
     window.addEventListener(events[i], handleEvent);

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -200,22 +200,22 @@ var PDFDocumentProperties = (function PDFDocumentPropertiesClosure() {
       }
 
       // Remove the D: prefix if it is available.
-      if (dateToParse.substring(0,2) === 'D:') {
+      if (dateToParse.substring(0, 2) === 'D:') {
         dateToParse = dateToParse.substring(2);
       }
 
       // Get all elements from the PDF date string.
       // JavaScript's Date object expects the month to be between
       // 0 and 11 instead of 1 and 12, so we're correcting for this.
-      var year = parseInt(dateToParse.substring(0,4), 10);
-      var month = parseInt(dateToParse.substring(4,6), 10) - 1;
-      var day = parseInt(dateToParse.substring(6,8), 10);
-      var hours = parseInt(dateToParse.substring(8,10), 10);
-      var minutes = parseInt(dateToParse.substring(10,12), 10);
-      var seconds = parseInt(dateToParse.substring(12,14), 10);
-      var utRel = dateToParse.substring(14,15);
-      var offsetHours = parseInt(dateToParse.substring(15,17), 10);
-      var offsetMinutes = parseInt(dateToParse.substring(18,20), 10);
+      var year = parseInt(dateToParse.substring(0, 4), 10);
+      var month = parseInt(dateToParse.substring(4, 6), 10) - 1;
+      var day = parseInt(dateToParse.substring(6, 8), 10);
+      var hours = parseInt(dateToParse.substring(8, 10), 10);
+      var minutes = parseInt(dateToParse.substring(10, 12), 10);
+      var seconds = parseInt(dateToParse.substring(12, 14), 10);
+      var utRel = dateToParse.substring(14, 15);
+      var offsetHours = parseInt(dateToParse.substring(15, 17), 10);
+      var offsetMinutes = parseInt(dateToParse.substring(18, 20), 10);
 
       // As per spec, utRel = 'Z' means equal to universal time.
       // The other cases ('-' and '+') have to be handled here.

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -188,7 +188,7 @@ var SecondaryToolbar = (function SecondaryToolbarClosure() {
           toggleHandToolButton.firstElementChild.textContent =
             mozL10n.get('hand_tool_enable_label', null, 'Enable hand tool');
         }
-      }.bind(this));
+      });
     },
 
     open: function SecondaryToolbar_open() {

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -384,7 +384,7 @@ function getPDFFileNameFromURL(url) {
       try {
         suggestedFilename =
           reFilename.exec(decodeURIComponent(suggestedFilename))[0];
-      } catch(e) { // Possible (extremely rare) errors:
+      } catch (e) { // Possible (extremely rare) errors:
         // URIError "Malformed URI", e.g. for "%AA.pdf"
         // TypeError "null has no properties", e.g. for "%2F.pdf"
       }

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -260,7 +260,7 @@ function approximateFraction(x) {
   var limit = 8;
   if (xinv > limit) {
     return [1, limit];
-  } else  if (Math.floor(xinv) === xinv) {
+  } else if (Math.floor(xinv) === xinv) {
     return [1, xinv];
   }
 

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -54,7 +54,7 @@ function getViewerConfiguration() {
   return {
     appContainer: document.body,
     mainContainer: document.getElementById('viewerContainer'),
-    viewerContainer:  document.getElementById('viewer'),
+    viewerContainer: document.getElementById('viewer'),
     eventBus: null, // using global event bus with DOM events
     toolbar: {
       container: document.getElementById('toolbarViewer'),


### PR DESCRIPTION
I've been looking into switching to ESLint, which I mentioned on IRC about a year ago and have finally had time to actually do now, since it's got a number of benefits compared to JSHint[1]. Among those are:
rules that can help find subtle bugs (e.g. PR #7881), a lot more (fine-grained) options, the ability to enforce larger parts of the style guide, more modern and thus easier to work with. (Also, locally `gulp lint` actually seems to run ~25% quicker when using ESLint instead of JSHint.)

In order to be able to make the switch, and to enable a decent amount of rules from the start, I figured that one big PR that both changes the linter *and* fixes various new linting failures would be unnecessarily big and thus time consuming to review.
Hence I'm submitting this PR which addresses a bunch of linting issue found by ESLint first, to make the PR that actually changes the linter somewhat smaller and simpler to review. (I'm hoping to have time to finish it up, and submit the actual ESLint PR this weekend.)

@timvandermeij Since you very graciously offered to help with reviewing, in https://github.com/mozilla/pdf.js/pull/7881#issuecomment-266449803, I'm assigning this to you :-)

---
[1] Looking at http://jshint.com/docs/options/, it seems that some of the JSHint rules that we depend on is (or will be) removed in upcoming versions, so we wouldn't be able to upgrade without loosing lint coverage.