### PR TITLE
When exporting pdf to canvas, can pass a background color parameter

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2067,7 +2067,8 @@ var InternalRenderTask = (function InternalRenderTaskClosure() {
       this.gfx = new CanvasGraphics(params.canvasContext, this.commonObjs,
                                     this.objs, params.imageLayer);
 
-      this.gfx.beginDrawing(params.transform, params.viewport, transparency);
+      this.gfx.beginDrawing(params.transform, params.viewport,
+                                transparency, params.background);
       this.operatorListIdx = 0;
       this.graphicsReady = true;
       if (this.graphicsReadyCallback) {

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -754,7 +754,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
   CanvasGraphics.prototype = {
 
     beginDrawing: function CanvasGraphics_beginDrawing(transform, viewport,
-                                                       transparency) {
+                                                       transparency, background) {
       // For pdfs that use blend modes we have to clear the canvas else certain
       // blend modes can look wrong since we'd be blending with a white
       // backdrop. The problem with a transparent backdrop though is we then
@@ -764,7 +764,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       var height = this.ctx.canvas.height;
 
       this.ctx.save();
-      this.ctx.fillStyle = 'rgb(255, 255, 255)';
+      this.ctx.fillStyle = background != undefined ? background : 'rgb(255, 255, 255)';
       this.ctx.fillRect(0, 0, width, height);
       this.ctx.restore();
 

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -754,7 +754,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
   CanvasGraphics.prototype = {
 
     beginDrawing: function CanvasGraphics_beginDrawing(transform, viewport,
-                                                       transparency, background) {
+                                                       transparency,
+                                                       background) {
       // For pdfs that use blend modes we have to clear the canvas else certain
       // blend modes can look wrong since we'd be blending with a white
       // backdrop. The problem with a transparent backdrop though is we then
@@ -764,7 +765,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       var height = this.ctx.canvas.height;
 
       this.ctx.save();
-      this.ctx.fillStyle = background != undefined ? background : 'rgb(255, 255, 255)';
+      this.ctx.fillStyle = background !== undefined ? background :
+                                                'rgb(255, 255, 255)';
       this.ctx.fillRect(0, 0, width, height);
       this.ctx.restore();
 


### PR DESCRIPTION
When exporting pdf to canvas, can pass a background parameter (rgb or rgba) to set the canvas background color to something other than white.

We are exporting pdfs to canvas and need the ability to change the background color of the canvas, or make it transparent.

This changes allows a background parameter be sent to the render method, which then sets the background color of the exported canvas:
page.render({canvasContext: context, viewport: viewport, background: rgba(255, 255, 255, 0})

If no background is sent, the canvas background defaults to white.