### PR TITLE
[Firefox addon] Change the minimum supported version to Firefox 45, i.e. the current ESR version, and remove no longer necessary fallback code

### DIFF
--- a/extensions/firefox/content/PdfJsTelemetry-addon.jsm
+++ b/extensions/firefox/content/PdfJsTelemetry-addon.jsm
@@ -25,30 +25,7 @@ Cu.import('resource://gre/modules/Services.jsm');
 const ADDON_ID = 'uriloader@pdf.js';
 
 var Telemetry = Services.telemetry;
-
 var registerAddonHistogram = Telemetry.registerAddonHistogram;
-try {
-  // Swapping arguments of the registerAddonHistogram for older Firefox versions.
-  // See https://bugzilla.mozilla.org/show_bug.cgi?id=1069953.
-  var ffVersion = parseInt(Services.appinfo.platformVersion);
-  var oldTelemetryAPI = ffVersion < 36;
-  if (ffVersion === 36) {
-    // Probing FF36 to check if it has new API.
-    try {
-      Telemetry.registerAddonHistogram(ADDON_ID, 'PDF_36',
-        Telemetry.HISTOGRAM_LINEAR, 1, 40, 41);
-      var histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_36');
-      histogram.add(36);
-    } catch (e) {
-      oldTelemetryAPI = true;
-    }
-  }
-  if (oldTelemetryAPI) {
-    registerAddonHistogram = function (p1, p2, p3, p4, p5, p6) {
-      return Telemetry.registerAddonHistogram(p1, p2, p4, p5, p6, p3);
-    };
-  }
-} catch (ex) { }
 
 registerAddonHistogram(ADDON_ID, 'PDF_VIEWER_USED', Telemetry.HISTOGRAM_BOOLEAN, 1, 2, 3);
 registerAddonHistogram(ADDON_ID, 'PDF_VIEWER_FALLBACK_SHOWN', Telemetry.HISTOGRAM_BOOLEAN, 1, 2, 3);

--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -147,44 +147,6 @@ function getLocalizedString(strings, id, property) {
   return id;
 }
 
-function createNewChannel(uri, node) {
-//#if !MOZCENTRAL
-  if (NetUtil.newChannel2) {
-    var systemPrincipal = Services.scriptSecurityManager.getSystemPrincipal();
-    return NetUtil.newChannel2(uri,
-                               null,
-                               null,
-                               node, // aLoadingNode
-                               systemPrincipal, // aLoadingPrincipal
-                               null, // aTriggeringPrincipal
-                               Ci.nsILoadInfo.SEC_NORMAL,
-                               Ci.nsIContentPolicy.TYPE_OTHER);
-  }
-//#endif
-  return NetUtil.newChannel({
-    uri: uri,
-    loadUsingSystemPrincipal: true,
-  });
-}
-
-function asyncOpenChannel(channel, listener, context) {
-//#if !MOZCENTRAL
-  if (!channel.asyncOpen2 || !('originAttributes' in channel.loadInfo)) {
-    return channel.asyncOpen(listener, context);
-  }
-//#endif
-  return channel.asyncOpen2(listener);
-}
-
-function asyncFetchChannel(channel, callback) {
-//#if !MOZCENTRAL
-  if (NetUtil.asyncFetch2) {
-    return NetUtil.asyncFetch2(channel, callback);
-  }
-//#endif
-  return NetUtil.asyncFetch(channel, callback);
-}
-
 // PDF data storage
 function PdfDataListener(length) {
   this.length = length; // less than 0, if length is unknown
@@ -278,12 +240,15 @@ ChromeActions.prototype = {
              getService(Ci.nsIExternalHelperAppService);
 
     var docIsPrivate = this.isInPrivateBrowsing();
-    var netChannel = createNewChannel(blobUri, this.domWindow.document);
+    var netChannel = NetUtil.newChannel({
+      uri: blobUri,
+      loadUsingSystemPrincipal: true,
+    });
     if ('nsIPrivateBrowsingChannel' in Ci &&
         netChannel instanceof Ci.nsIPrivateBrowsingChannel) {
       netChannel.setPrivate(docIsPrivate);
     }
-    asyncFetchChannel(netChannel, function(aInputStream, aResult) {
+    NetUtil.asyncFetch(netChannel, function(aInputStream, aResult) {
       if (!Components.isSuccessCode(aResult)) {
         if (sendResponse) {
           sendResponse(true);
@@ -341,7 +306,7 @@ ChromeActions.prototype = {
         }
       };
 
-      asyncOpenChannel(channel, listener, null);
+      channel.asyncOpen2(listener);
     });
   },
   getLocale: function() {
@@ -983,7 +948,10 @@ PdfStreamConverter.prototype = {
                         .createInstance(Ci.nsIBinaryInputStream);
 
     // Create a new channel that is viewer loaded as a resource.
-    var channel = createNewChannel(PDF_VIEWER_WEB_PAGE, null);
+    var channel = NetUtil.newChannel({
+      uri: PDF_VIEWER_WEB_PAGE,
+      loadUsingSystemPrincipal: true,
+    });
 
     var listener = this.listener;
     var dataListener = this.dataListener;
@@ -1033,13 +1001,7 @@ PdfStreamConverter.prototype = {
     // Keep the URL the same so the browser sees it as the same.
     channel.originalURI = aRequest.URI;
     channel.loadGroup = aRequest.loadGroup;
-//#if MOZCENTRAL
     channel.loadInfo.originAttributes = aRequest.loadInfo.originAttributes;
-//#else
-    if ('originAttributes' in aRequest.loadInfo) {
-      channel.loadInfo.originAttributes = aRequest.loadInfo.originAttributes;
-    }
-//#endif
 
     // We can use the resource principal when data is fetched by the chrome,
     // e.g. useful for NoScript. Make make sure we reuse the origin attributes
@@ -1047,23 +1009,11 @@ PdfStreamConverter.prototype = {
     var ssm = Cc['@mozilla.org/scriptsecuritymanager;1']
                 .getService(Ci.nsIScriptSecurityManager);
     var uri = NetUtil.newURI(PDF_VIEWER_WEB_PAGE, null, null);
-    var resourcePrincipal;
-//#if MOZCENTRAL
-    resourcePrincipal =
+    var resourcePrincipal =
       ssm.createCodebasePrincipal(uri, aRequest.loadInfo.originAttributes);
-//#else
-    // FF43 replaced `getCodebasePrincipal` with `createCodebasePrincipal`,
-    // see https://bugzilla.mozilla.org/show_bug.cgi?id=1165272.
-    if ('createCodebasePrincipal' in ssm &&
-        'originAttributes' in aRequest.loadInfo) {
-      resourcePrincipal =
-        ssm.createCodebasePrincipal(uri, aRequest.loadInfo.originAttributes);
-    } else {
-      resourcePrincipal = ssm.getCodebasePrincipal(uri);
-    }
-//#endif
     aRequest.owner = resourcePrincipal;
-    asyncOpenChannel(channel, proxy, aContext);
+
+    channel.asyncOpen2(proxy);
   },
 
   // nsIRequestObserver::onStopRequest

--- a/extensions/firefox/install.rdf
+++ b/extensions/firefox/install.rdf
@@ -13,8 +13,8 @@
     <em:targetApplication>
       <Description>
        <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
-       <em:minVersion>38.0</em:minVersion>
-       <em:maxVersion>50.0a1</em:maxVersion>
+       <em:minVersion>45.0</em:minVersion>
+       <em:maxVersion>54.0a1</em:maxVersion>
      </Description>
     </em:targetApplication>
 
@@ -22,8 +22,8 @@
     <em:targetApplication>
       <Description>
        <em:id>{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}</em:id>
-       <em:minVersion>2.40</em:minVersion>
-       <em:maxVersion>2.48a1</em:maxVersion>
+       <em:minVersion>2.46</em:minVersion>
+       <em:maxVersion>2.51a1</em:maxVersion>
      </Description>
     </em:targetApplication>
 
@@ -31,8 +31,8 @@
     <em:targetApplication>
       <Description>
        <em:id>{aa3c5121-dab2-40e2-81ca-7ea25febc110}</em:id>
-       <em:minVersion>38.0</em:minVersion>
-       <em:maxVersion>50.0a1</em:maxVersion>
+       <em:minVersion>45.0</em:minVersion>
+       <em:maxVersion>54.0a1</em:maxVersion>
      </Description>
     </em:targetApplication>
 

--- a/extensions/firefox/update.rdf
+++ b/extensions/firefox/update.rdf
@@ -14,8 +14,8 @@
             <em:targetApplication>
               <RDF:Description>
                 <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
-                <em:minVersion>38.0</em:minVersion>
-                <em:maxVersion>50.0</em:maxVersion>
+                <em:minVersion>45.0</em:minVersion>
+                <em:maxVersion>54.0a1</em:maxVersion>
                 <!-- Use the raw link for updates so we we can use SSL. -->
                 <em:updateLink>https://raw.githubusercontent.com/mozilla/pdf.js/gh-pages/extensions/firefox/pdf.js.xpi</em:updateLink>
               </RDF:Description>
@@ -25,8 +25,8 @@
             <em:targetApplication>
               <RDF:Description>
                 <em:id>{aa3c5121-dab2-40e2-81ca-7ea25febc110}</em:id>
-                <em:minVersion>38.0</em:minVersion>
-                <em:maxVersion>50.0</em:maxVersion>
+                <em:minVersion>45.0</em:minVersion>
+                <em:maxVersion>54.0a1</em:maxVersion>
                 <!-- Use the raw link for updates so we we can use SSL. -->
                 <em:updateLink>https://raw.githubusercontent.com/mozilla/pdf.js/gh-pages/extensions/firefox/pdf.js.xpi</em:updateLink>
               </RDF:Description>


### PR DESCRIPTION
 - [Firefox addon] Change the minimum supported version to Firefox 45, i.e. the current ESR version, and remove no longer necessary fallback code

   > According to https://wiki.mozilla.org/RapidRelease/Calendar#Past_branch_dates: The *last* ESR version of Firefox 38 was released in April this year, and since June the only available ESR version has been based on Firefox 45.
   >
   > Now that Seamonkey has *finally* released a new version, i.e. 2.46 which should correspond to Firefox 49, there doesn't seem to be any reason to keep the fallback code around in the addon anymore.

 - [Firefox addon] Remove the `registerAddonHistogram` fallback code for Firefox versions 36 (and below) from `PdfJsTelemetry-addon.jsm`

   > Given that the addon doesn't even work in Firefox versions prior to 38, this is just dead code that can now be removed.

---

Note that this PR lets us remove *all* the current fallback code from the Firefox addon!
Also, this time I made sure to take the updated version numbers from https://addons.mozilla.org/en-US/firefox/pages/appversions/ to prevent issues.