### PR TITLE
Fix #7806: Abort loadingTask and throw an error when wrong password is provided to decrypt the pdf.

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1522,10 +1522,6 @@ var WorkerTransport = (function WorkerTransportClosure() {
       messageHandler.on('IncorrectPassword',
                         function transportIncorrectPassword(exception) {
         var loadingTask = this.loadingTask;
-        if (loadingTask.onPassword) {
-          return loadingTask.onPassword(updatePassword,
-                                        PasswordResponses.INCORRECT_PASSWORD);
-        }
         loadingTask._capability.reject(
           new PasswordException(exception.message, exception.code));
       }, this);


### PR DESCRIPTION
```
messageHandler.on('IncorrectPassword',
                        function transportIncorrectPassword(exception) {
        var loadingTask = this.loadingTask;
        if (loadingTask.onPassword) {
          return loadingTask.onPassword(updatePassword,
                                        PasswordResponses.INCORRECT_PASSWORD);
        }
        loadingTask._capability.reject(
          new PasswordException(exception.message, exception.code));
      }, this);
```
The if condition in above handler is calling it repeatedly when wrong password is provided.
Removing it will abort the loadingTask and throw an error on wrong password. 