### PR TITLE
[api-minor] Ensure that the `getDocument` Promise is rejected if the `loadingTask` is destroyed, or an `Error` is thrown, inside of the `onPassword` callback (issue 7806)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -370,22 +370,20 @@ var PDFDocument = (function PDFDocumentClosure() {
   var EMPTY_FINGERPRINT = '\x00\x00\x00\x00\x00\x00\x00' +
     '\x00\x00\x00\x00\x00\x00\x00\x00\x00';
 
-  function PDFDocument(pdfManager, arg, password) {
+  function PDFDocument(pdfManager, arg) {
+    var stream;
     if (isStream(arg)) {
-      init.call(this, pdfManager, arg, password);
+      stream = arg;
     } else if (isArrayBuffer(arg)) {
-      init.call(this, pdfManager, new Stream(arg), password);
+      stream = new Stream(arg);
     } else {
       error('PDFDocument: Unknown argument type');
     }
-  }
-
-  function init(pdfManager, stream, password) {
     assert(stream.length > 0, 'stream must have data');
+
     this.pdfManager = pdfManager;
     this.stream = stream;
-    var xref = new XRef(this.stream, password, pdfManager);
-    this.xref = xref;
+    this.xref = new XRef(stream, pdfManager);
   }
 
   function find(stream, needle, limit, backwards) {

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -758,13 +758,13 @@ var Catalog = (function CatalogClosure() {
 })();
 
 var XRef = (function XRefClosure() {
-  function XRef(stream, password) {
+  function XRef(stream, pdfManager) {
     this.stream = stream;
+    this.pdfManager = pdfManager;
     this.entries = [];
     this.xrefstms = Object.create(null);
     // prepare the XRef cache
     this.cache = [];
-    this.password = password;
     this.stats = {
       streamTypes: [],
       fontTypes: []
@@ -789,7 +789,7 @@ var XRef = (function XRefClosure() {
       trailerDict.assignXref(this);
       this.trailer = trailerDict;
       var encrypt = trailerDict.get('Encrypt');
-      if (encrypt) {
+      if (isDict(encrypt)) {
         var ids = trailerDict.get('ID');
         var fileId = (ids && ids.length) ? ids[0] : '';
         // The 'Encrypt' dictionary itself should not be encrypted, and by
@@ -798,7 +798,7 @@ var XRef = (function XRefClosure() {
         // objects (fixes issue7665.pdf).
         encrypt.suppressEncryption = true;
         this.encrypt = new CipherTransformFactory(encrypt, fileId,
-                                                  this.password);
+                                                  this.pdfManager.password);
       }
 
       // get the root dictionary (catalog) object

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -52,6 +52,10 @@ var BasePdfManager = (function BasePdfManagerClosure() {
       return this._docId;
     },
 
+    get password() {
+      return this._password;
+    },
+
     get docBaseUrl() {
       var docBaseUrl = null;
       if (this._docBaseUrl) {
@@ -106,7 +110,7 @@ var BasePdfManager = (function BasePdfManagerClosure() {
     },
 
     updatePassword: function BasePdfManager_updatePassword(password) {
-      this.pdfDocument.xref.password = this.password = password;
+      this._password = password;
     },
 
     terminate: function BasePdfManager_terminate() {
@@ -121,10 +125,11 @@ var LocalPdfManager = (function LocalPdfManagerClosure() {
   function LocalPdfManager(docId, data, password, evaluatorOptions,
                            docBaseUrl) {
     this._docId = docId;
+    this._password = password;
     this._docBaseUrl = docBaseUrl;
     this.evaluatorOptions = evaluatorOptions;
     var stream = new Stream(data);
-    this.pdfDocument = new PDFDocument(this, stream, password);
+    this.pdfDocument = new PDFDocument(this, stream);
     this._loadedStreamCapability = createPromiseCapability();
     this._loadedStreamCapability.resolve(stream);
   }
@@ -171,6 +176,7 @@ var NetworkPdfManager = (function NetworkPdfManagerClosure() {
   function NetworkPdfManager(docId, pdfNetworkStream, args, evaluatorOptions,
                              docBaseUrl) {
     this._docId = docId;
+    this._password = args.password;
     this._docBaseUrl = docBaseUrl;
     this.msgHandler = args.msgHandler;
     this.evaluatorOptions = evaluatorOptions;
@@ -183,8 +189,7 @@ var NetworkPdfManager = (function NetworkPdfManagerClosure() {
       rangeChunkSize: args.rangeChunkSize
     };
     this.streamManager = new ChunkedStreamManager(pdfNetworkStream, params);
-    this.pdfDocument = new PDFDocument(this, this.streamManager.getStream(),
-                                       args.password);
+    this.pdfDocument = new PDFDocument(this, this.streamManager.getStream());
   }
 
   Util.inherit(NetworkPdfManager, BasePdfManager, {

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -107,14 +107,6 @@ var BasePdfManager = (function BasePdfManagerClosure() {
 
     updatePassword: function BasePdfManager_updatePassword(password) {
       this.pdfDocument.xref.password = this.password = password;
-      if (this._passwordChangedCapability) {
-        this._passwordChangedCapability.resolve();
-      }
-    },
-
-    passwordChanged: function BasePdfManager_passwordChanged() {
-      this._passwordChangedCapability = createPromiseCapability();
-      return this._passwordChangedCapability.promise;
     },
 
     terminate: function BasePdfManager_terminate() {


### PR DESCRIPTION
Tentatively fixes #7806 (and replaces PR #7924).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/pdf.js/7926)
<!-- Reviewable:end -->
