### PR TITLE
Unit test files as modules

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -541,7 +541,12 @@ gulp.task('lint', function (done) {
     console.log();
     console.log('### Checking UMD dependencies');
     var umd = require('./external/umdutils/verifier.js');
-    if (!umd.validateFiles({'pdfjs': './src', 'pdfjs-web': './web'})) {
+    var paths = {
+      'pdfjs': './src',
+      'pdfjs-web': './web',
+      'pdfjs-test': './test'
+    };
+    if (!umd.validateFiles(paths)) {
       done(new Error('UMD check failed.'));
       return;
     }

--- a/test/unit/annotation_layer_spec.js
+++ b/test/unit/annotation_layer_spec.js
@@ -1,9 +1,58 @@
-/* globals isRef, AnnotationFactory, Dict, Name, Ref, AnnotationType,
-           AnnotationFlag, Annotation, AnnotationBorderStyle,
-           AnnotationBorderStyleType, StringStream, Lexer, Parser,
-           stringToUTF8String, AnnotationFieldFlag, PDFJS, stringToBytes */
-
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-test/unit/annotation_layer_spec', ['exports',
+           'pdfjs/core/primitives', 'pdfjs/core/annotation',
+           'pdfjs/core/stream', 'pdfjs/core/parser',
+           'pdfjs/shared/util', 'pdfjs/display/global'], factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports, require('../../src/core/primitives.js'),
+            require('../../src/core/annotation.js'),
+            require('../../src/core/stream.js'),
+            require('../../src/core/parser.js'),
+            require('../../src/shared/util.js'),
+            require('../../src/display/global.js'));
+  } else {
+    factory((root.pdfjsTestUnitAnnotationLayerSpec = {}),
+             root.pdfjsCorePrimitives, root.pdfjsCoreAnnotation,
+             root.pdfjsCoreStream, root.pdfjsCoreParser,
+             root.pdfjsSharedUtil, root.pdfjsDisplayGlobal);
+  }
+}(this, function (exports, corePrimitives, coreAnnotation, coreStream,
+                  coreParser, sharedUtil, displayGlobal) {
+
+var Annotation = coreAnnotation.Annotation;
+var AnnotationBorderStyle = coreAnnotation.AnnotationBorderStyle;
+var AnnotationFactory = coreAnnotation.AnnotationFactory;
+var Lexer = coreParser.Lexer;
+var Parser = coreParser.Parser;
+var isRef = corePrimitives.isRef;
+var Dict = corePrimitives.Dict;
+var Name = corePrimitives.Name;
+var Ref = corePrimitives.Ref;
+var StringStream = coreStream.StringStream;
+var PDFJS = displayGlobal.PDFJS;
+var AnnotationType = sharedUtil.AnnotationType;
+var AnnotationFlag = sharedUtil.AnnotationFlag;
+var AnnotationBorderStyleType = sharedUtil.AnnotationBorderStyleType;
+var AnnotationFieldFlag = sharedUtil.AnnotationFieldFlag;
+var stringToBytes = sharedUtil.stringToBytes;
+var stringToUTF8String = sharedUtil.stringToUTF8String;
 
 describe('Annotation layer', function() {
   function XRefMock(array) {
@@ -349,9 +398,11 @@ describe('Annotation layer', function() {
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
       expect(data.url).toEqual(
-        new URL(stringToUTF8String('http://www.example.com/üöä')).href);
+        new URL(stringToUTF8String(
+          'http://www.example.com/\xC3\xBC\xC3\xB6\xC3\xA4')).href);
       expect(data.unsafeUrl).toEqual(
-        stringToUTF8String('http://www.example.com/üöä'));
+        stringToUTF8String(
+          'http://www.example.com/\xC3\xBC\xC3\xB6\xC3\xA4'));
       expect(data.dest).toBeUndefined();
     });
 
@@ -1178,3 +1229,4 @@ describe('Annotation layer', function() {
     });
   });
 });
+}));

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1,8 +1,43 @@
-/* globals PDFJS, createPromiseCapability, PDFDocumentProxy,
-           InvalidPDFException, MissingPDFException, PasswordResponses,
-           PasswordException, PDFPageProxy, StreamType, FontType */
-
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-test/unit/api_spec', ['exports', 'pdfjs/shared/util',
+           'pdfjs/display/global', 'pdfjs/display/api'], factory);
+  } else if (typeof exports !== 'undefined') {
+      factory(exports, require('../../src/shared/util.js'),
+              require('../../src/display/global.js'),
+              require('../../src/display/api.js'));
+  } else {
+    factory((root.pdfjsTestUnitApiSpec = {}), root.pdfjsSharedUtil,
+             root.pdfjsDisplayGlobal, root.pdfjsDisplayApi);
+  }
+}(this, function (exports, sharedUtil, displayGlobal, displayApi) {
+
+var PDFJS = displayGlobal.PDFJS;
+var createPromiseCapability = sharedUtil.createPromiseCapability;
+var PDFDocumentProxy = displayApi.PDFDocumentProxy;
+var InvalidPDFException = sharedUtil.InvalidPDFException;
+var MissingPDFException = sharedUtil.MissingPDFException;
+var PasswordResponses = sharedUtil.PasswordResponses;
+var PasswordException = sharedUtil.PasswordException;
+var PDFPageProxy = displayApi.PDFPageProxy;
+var StreamType = sharedUtil.StreamType;
+var FontType = sharedUtil.FontType;
 
 describe('api', function() {
   var basicApiUrl = new URL('../pdfs/basicapi.pdf', window.location).href;
@@ -1135,3 +1170,4 @@ describe('api', function() {
     });
   });
 });
+}));

--- a/test/unit/cff_parser_spec.js
+++ b/test/unit/cff_parser_spec.js
@@ -1,7 +1,40 @@
-/* globals Stream, CFFParser, SEAC_ANALYSIS_ENABLED, CFFIndex, CFFParser,
-           CFFStrings, CFFCompiler */
-
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-test/unit/cff_parser_spec', ['exports',
+           'pdfjs/core/cff_parser', 'pdfjs/core/fonts',
+           'pdfjs/core/stream'], factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports, require('../../src/core/cff_parser.js'),
+            require('../../src/core/fonts.js'),
+            require('../../src/core/stream.js'));
+  } else {
+    factory((root.pdfjsTestUnitCFFParserSpec = {}), root.pdfjsCoreCFFParser,
+             root.pdfjsCoreFonts, root.pdfjsCoreStream);
+  }
+}(this, function (exports, coreCFFParser, coreFonts, coreStream) {
+
+var CFFParser = coreCFFParser.CFFParser;
+var CFFIndex = coreCFFParser.CFFIndex;
+var CFFStrings = coreCFFParser.CFFStrings;
+var CFFCompiler = coreCFFParser.CFFCompiler;
+var SEAC_ANALYSIS_ENABLED = coreFonts.SEAC_ANALYSIS_ENABLED;
+var Stream = coreStream.Stream;
 
 describe('CFFParser', function() {
   function createWithNullProto(obj) {
@@ -355,3 +388,4 @@ describe('CFFCompiler', function() {
 
   // TODO a lot more compiler tests
 });
+}));

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -1,6 +1,38 @@
-/* globals StringStream, CMapFactory, CMap, IdentityCMap, Name */
-
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-test/unit/cmap_spec', ['exports', 'pdfjs/core/cmap',
+           'pdfjs/core/primitives', 'pdfjs/core/stream'], factory);
+  } else if (typeof exports !== 'undefined') {
+      factory(exports, require('../../src/core/cmap.js'),
+              require('../../src/core/primitives.js'),
+              require('../../src/core/stream.js'));
+  } else {
+    factory((root.pdfjsTestUnitCMapSpec = {}), root.pdfjsCoreCMap,
+             root.pdfjsCorePrimitives, root.pdfjsCoreStream);
+  }
+}(this, function (exports, coreCMap, corePrimitives, coreStream) {
+
+var CMapFactory = coreCMap.CMapFactory;
+var CMap = coreCMap.CMap;
+var IdentityCMap = coreCMap.IdentityCMap;
+var Name = corePrimitives.Name;
+var StringStream = coreStream.StringStream;
 
 var cMapUrl = '../../external/bcmaps/';
 var cMapPacked = true;
@@ -187,3 +219,4 @@ describe('cmap', function() {
     });
   });
 });
+}));

--- a/test/unit/crypto_spec.js
+++ b/test/unit/crypto_spec.js
@@ -1,9 +1,48 @@
-/* globals stringToBytes, calculateMD5, ARCFourCipher, calculateSHA256,
-           calculateSHA384, calculateSHA512, AES128Cipher, AES256Cipher, PDF17,
-           PDF20, Dict, CipherTransformFactory, PasswordException,
-           PasswordResponses, Name */
-
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-test/unit/crypto_spec', ['exports', 'pdfjs/core/crypto',
+           'pdfjs/core/primitives', 'pdfjs/shared/util'], factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports, require('../../src/core/crypto.js'),
+            require('../../src/core/primitives.js'),
+            require('../../src/shared/util.js'));
+  } else {
+    factory((root.pdfjsTestUnitCryptoSpec = {}), root.pdfjsCoreCrypto,
+             root.pdfjsCorePrimitives, root.pdfjsSharedUtil);
+  }
+}(this, function (exports, coreCrypto, corePrimitives, sharedUtil) {
+
+var calculateMD5 = coreCrypto.calculateMD5;
+var ARCFourCipher = coreCrypto.ARCFourCipher;
+var calculateSHA256 = coreCrypto.calculateSHA256;
+var calculateSHA384 = coreCrypto.calculateSHA384;
+var calculateSHA512 = coreCrypto.calculateSHA512;
+var AES128Cipher = coreCrypto.AES128Cipher;
+var AES256Cipher = coreCrypto.AES256Cipher;
+var PDF17 = coreCrypto.PDF17;
+var PDF20 = coreCrypto.PDF20;
+var CipherTransformFactory = coreCrypto.CipherTransformFactory;
+var Name = corePrimitives.Name;
+var Dict = corePrimitives.Dict;
+var stringToBytes = sharedUtil.stringToBytes;
+var PasswordException = sharedUtil.PasswordException;
+var PasswordResponses = sharedUtil.PasswordResponses;
 
 describe('crypto', function() {
   function hex2binary(s) {
@@ -669,3 +708,4 @@ describe('CipherTransformFactory', function() {
     });
   });
 });
+}));

--- a/test/unit/dom_utils_spec.js
+++ b/test/unit/dom_utils_spec.js
@@ -1,6 +1,36 @@
-/* globals getFilenameFromUrl, PDFJS, LinkTarget, isExternalLinkTargetSet */
-
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-test/unit/dom_utils_spec', ['exports',
+           'pdfjs/display/dom_utils', 'pdfjs/display/global'], factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports, require('../../src/display/dom_utils.js'),
+            require('../../src/display/global.js'));
+  } else {
+    factory((root.pdfjsTestUnitDOMUtilsSpec = {}), root.pdfjsDisplayDOMUtils,
+             root.pdfjsDisplayGlobal);
+  }
+}(this, function (exports, displayDOMUtils, displayGlobal) {
+
+var PDFJS = displayGlobal.PDFJS;
+var getFilenameFromUrl = displayDOMUtils.getFilenameFromUrl;
+var LinkTarget = displayDOMUtils.LinkTarget;
+var isExternalLinkTargetSet = displayDOMUtils.isExternalLinkTargetSet;
 
 describe('dom_utils', function() {
   describe('getFilenameFromUrl', function() {
@@ -52,3 +82,4 @@ describe('dom_utils', function() {
     });
   });
 });
+}));

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -1,7 +1,47 @@
-/* globals OperatorList, WorkerTask, PartialEvaluator, StringStream, OPS, Dict,
-           Name, Stream */
-
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-test/unit/evaluator_spec', ['exports',
+           'pdfjs/core/evaluator', 'pdfjs/core/primitives',
+           'pdfjs/core/stream', 'pdfjs/core/worker',
+           'pdfjs/shared/util'], factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports, require('../../src/core/evaluator.js'),
+            require('../../src/core/primitives.js'),
+            require('../../src/core/stream.js'),
+            require('../../src/core/worker.js'),
+            require('../../src/shared/util.js'));
+  } else {
+    factory((root.pdfjsTestUnitEvaluatorSpec = {}), root.pdfjsCoreEvaluator,
+             root.pdfjsCorePrimitives, root.pdfjsCoreStream,
+             root.pdfjsCoreWorker, root.pdfjsSharedUtil);
+  }
+}(this, function (exports, coreEvaluator, corePrimitives, coreStream,
+                  coreWorker, sharedUtil) {
+
+var OperatorList = coreEvaluator.OperatorList;
+var PartialEvaluator = coreEvaluator.PartialEvaluator;
+var Dict = corePrimitives.Dict;
+var Name = corePrimitives.Name;
+var Stream = coreStream.Stream;
+var StringStream = coreStream.StringStream;
+var WorkerTask = coreWorker.WorkerTask;
+var OPS = sharedUtil.OPS;
 
 describe('evaluator', function() {
   function XrefMock(queue) {
@@ -321,3 +361,4 @@ describe('evaluator', function() {
     });
   });
 });
+}));

--- a/test/unit/fonts_spec.js
+++ b/test/unit/fonts_spec.js
@@ -1,6 +1,31 @@
-/* globals checkProblematicCharRanges */
-
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-test/unit/fonts_spec', ['exports', 'pdfjs/core/fonts'],
+           factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports, require('../../src/core/fonts.js'));
+  } else {
+    factory((root.pdfjsTestUnitFontsSpec = {}), root.pdfjsCoreFonts);
+  }
+}(this, function (exports, coreFonts) {
+
+var checkProblematicCharRanges = coreFonts.checkProblematicCharRanges;
 
 describe('Fonts', function() {
   it('checkProblematicCharRanges', function() {
@@ -10,3 +35,4 @@ describe('Fonts', function() {
     expect(result.percentage).toBeLessThan(EXPECTED_PERCENTAGE);
   });
 });
+}));

--- a/test/unit/function_spec.js
+++ b/test/unit/function_spec.js
@@ -1,7 +1,42 @@
-/* globals isArray, StringStream, PostScriptParser, PostScriptLexer,
-           PostScriptEvaluator, PostScriptCompiler */
-
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-test/unit/function_spec', ['exports',
+           'pdfjs/core/function', 'pdfjs/core/ps_parser',
+           'pdfjs/core/stream', 'pdfjs/shared/util'], factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports, require('../../src/core/function.js'),
+            require('../../src/core/ps_parser.js'),
+            require('../../src/core/stream.js'),
+            require('../../src/shared/util.js'));
+  } else {
+    factory((root.pdfjsTestUnitFunctionSpec = {}),
+             root.pdfjsCoreFunction, root.pdfjsCorePsParser,
+             root.pdfjsCoreStream, root.pdfjsSharedUtil);
+  }
+}(this, function (exports, coreFunction, corePsParser, coreStream, sharedUtil) {
+
+var PostScriptEvaluator = coreFunction.PostScriptEvaluator;
+var PostScriptCompiler = coreFunction.PostScriptCompiler;
+var PostScriptParser = corePsParser.PostScriptParser;
+var PostScriptLexer = corePsParser.PostScriptLexer;
+var StringStream = coreStream.StringStream;
+var isArray = sharedUtil.isArray;
 
 describe('function', function() {
   beforeEach(function() {
@@ -528,3 +563,4 @@ describe('function', function() {
     });
   });
 });
+}));

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -1,4 +1,4 @@
-/* Copyright 2016 Mozilla Foundation
+/* Copyright 2017 Mozilla Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,58 +43,28 @@
 var pdfjsLibs;
 
 function initializePDFJS(callback) {
-  require.config({paths: {'pdfjs': '../../src', 'pdfjs-web': '../../web'}});
-  require(['pdfjs/shared/util', 'pdfjs/display/global', 'pdfjs/core/primitives',
-      'pdfjs/core/annotation', 'pdfjs/core/crypto', 'pdfjs/core/stream',
-      'pdfjs/core/fonts', 'pdfjs/core/ps_parser', 'pdfjs/core/function',
-      'pdfjs/core/parser', 'pdfjs/core/evaluator', 'pdfjs/core/cmap',
-      'pdfjs/core/worker', 'pdfjs/core/network', 'pdfjs/core/type1_parser',
-      'pdfjs/core/cff_parser', 'pdfjs/core/murmurhash3', 'pdfjs/display/api',
-      'pdfjs/display/metadata', 'pdfjs/display/dom_utils', 'pdfjs-web/ui_utils',
-      'pdfjs/core/unicode', 'pdfjs/core/glyphlist'],
-    function (sharedUtil, displayGlobal, corePrimitives, coreAnnotation,
-              coreCrypto, coreStream, coreFonts, corePsParser, coreFunction,
-              coreParser, coreEvaluator, coreCMap, coreWorker, coreNetwork,
-              coreType1Parser, coreCFFParser, coreMurmurHash3, displayAPI,
-              displayMetadata, displayDOMUtils, webUIUtils, coreUnicode,
-              coreGlyphList) {
-
-      pdfjsLibs = {
-        sharedUtil: sharedUtil,
-        displayGlobal: displayGlobal,
-        corePrimitives: corePrimitives,
-        coreAnnotation: coreAnnotation,
-        coreCrypto: coreCrypto,
-        coreStream: coreStream,
-        coreFonts: coreFonts,
-        corePsParser: corePsParser,
-        coreFunction: coreFunction,
-        coreParser: coreParser,
-        coreEvaluator: coreEvaluator,
-        coreCMap: coreCMap,
-        coreWorker: coreWorker,
-        coreNetwork: coreNetwork,
-        coreType1Parser: coreType1Parser,
-        coreCFFParser: coreCFFParser,
-        coreMurmurHash3: coreMurmurHash3,
-        displayAPI: displayAPI,
-        displayMetadata: displayMetadata,
-        displayDOMUtils: displayDOMUtils,
-        webUIUtils: webUIUtils,
-        coreUnicode: coreUnicode,
-        coreGlyphList: coreGlyphList,
-      };
-
-      // Expose all loaded internal exported members to global scope.
-      Object.keys(pdfjsLibs).forEach(function (libName) {
-        var lib = pdfjsLibs[libName];
-        Object.keys(lib).forEach(function (name) {
-          if (Object.getOwnPropertyDescriptor(window, name)) {
-            return; // ignoring if already set
-          }
-          window[name] = lib[name];
-        });
-      });
+  require.config({paths: {'pdfjs': '../../src', 'pdfjs-web': '../../web',
+                 'pdfjs-test': '..'}});
+  require(['pdfjs/display/global', 'pdfjs-test/unit/annotation_layer_spec',
+           'pdfjs-test/unit/api_spec', 'pdfjs-test/unit/cff_parser_spec',
+           'pdfjs-test/unit/cmap_spec', 'pdfjs-test/unit/crypto_spec',
+           'pdfjs-test/unit/dom_utils_spec', 'pdfjs-test/unit/evaluator_spec',
+           'pdfjs-test/unit/fonts_spec', 'pdfjs-test/unit/function_spec',
+           'pdfjs-test/unit/metadata_spec', 'pdfjs-test/unit/murmurhash3_spec',
+           'pdfjs-test/unit/network_spec', 'pdfjs-test/unit/parser_spec',
+           'pdfjs-test/unit/primitives_spec', 'pdfjs-test/unit/stream_spec',
+           'pdfjs-test/unit/type1_parser_spec', 'pdfjs-test/unit/ui_utils_spec',
+           'pdfjs-test/unit/unicode_spec', 'pdfjs-test/unit/util_spec'],
+    function (displayGlobal, testUnitAnnotationLayerSpec,
+              testUnitApiSpec, testUnitCFFParserSpec,
+              testUnitCMapSpec, testUnitCryptoSpec,
+              testUnitDOMUtilsSpec, testUnitEvaluatorSpec,
+              testUnitFontsSpec, testUnitFunctionSpec,
+              testUnitMetadataSpec, testUnitMurmurHash3Spec,
+              testUnitNetworkSpec, testUnitParserSpec,
+              testUnitPrimitivesSpec, testUnitStreamSpec,
+              testUnitType1ParserSpec, testUnitUiUtilsSpec,
+              testUnitUnicodeSpec, testUnitUtilSpec) {
 
       // Configure the worker.
       displayGlobal.PDFJS.workerSrc = '../../src/worker_loader.js';

--- a/test/unit/metadata_spec.js
+++ b/test/unit/metadata_spec.js
@@ -1,6 +1,31 @@
-/* globals Metadata */
-
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-test/unit/metadata_spec', ['exports',
+           'pdfjs/display/metadata'], factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports, require('../../src/display/metadata.js'));
+  } else {
+    factory((root.pdfjsTestUnitMetadataSpec = {}), root.pdfjsDisplayMetadata);
+  }
+}(this, function (exports, displayMetadata) {
+
+var Metadata = displayMetadata.Metadata;
 
 describe('metadata', function() {
   describe('incorrect_xmp', function() {
@@ -15,3 +40,4 @@ describe('metadata', function() {
     });
   });
 });
+}));

--- a/test/unit/murmurhash3_spec.js
+++ b/test/unit/murmurhash3_spec.js
@@ -1,6 +1,32 @@
-/* globals MurmurHash3_64 */
-
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-test/unit/murmurhash3_spec', ['exports',
+           'pdfjs/core/murmurhash3'], factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports, require('../../src/core/murmurhash3.js'));
+  } else {
+    factory((root.pdfjsTestUnitMurmurHash3Spec = {}),
+             root.pdfjsCoreMurmurHash3);
+  }
+}(this, function (exports, coreMurmurHash3) {
+
+var MurmurHash3_64 = coreMurmurHash3.MurmurHash3_64;
 
 describe('MurmurHash3_64', function() {
   it('instantiates without seed', function() {
@@ -50,3 +76,4 @@ describe('MurmurHash3_64', function() {
     expect(hexdigest1).not.toEqual(hexdigest2);
   });
 });
+}));

--- a/test/unit/network_spec.js
+++ b/test/unit/network_spec.js
@@ -1,6 +1,31 @@
-/* globals PDFNetworkStream */
-
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-test/unit/network_spec', ['exports', 'pdfjs/core/network'],
+           factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports, require('../../src/core/network.js'));
+  } else {
+    factory((root.pdfjsTestUnitNetworkSpec = {}), root.pdfjsCoreNetwork);
+  }
+}(this, function (exports, coreNetwork) {
+
+var PDFNetworkStream = coreNetwork.PDFNetworkStream;
 
 describe('network', function() {
   var pdf1 = new URL('../pdfs/tracemonkey.pdf', window.location).href;
@@ -162,3 +187,4 @@ describe('network', function() {
     });
   });
 });
+}));

--- a/test/unit/parser_spec.js
+++ b/test/unit/parser_spec.js
@@ -1,6 +1,37 @@
-/* globals StringStream, Lexer, Name, Linearization */
-
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-test/unit/parser_spec', ['exports', 'pdfjs/core/parser',
+           'pdfjs/core/primitives', 'pdfjs/core/stream'], factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports, require('../../src/core/parser.js'),
+            require('../../src/core/primitives.js'),
+            require('../../src/core/stream.js'));
+  } else {
+    factory((root.pdfjsTestUnitParserSpec = {}), root.pdfjsCoreParser,
+             root.pdfjsCorePrimitives, root.pdfjsCoreStream);
+  }
+}(this, function (exports, coreParser, corePrimitives, coreStream) {
+
+var Lexer = coreParser.Lexer;
+var Linearization = coreParser.Linearization;
+var Name = corePrimitives.Name;
+var StringStream = coreStream.StringStream;
 
 describe('parser', function() {
   describe('Lexer', function() {
@@ -263,3 +294,4 @@ describe('parser', function() {
     });
   });
 });
+}));

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -1,7 +1,40 @@
-/* globals expect, it, describe, beforeAll, afterAll, jasmine, Name, Dict, Ref,
-           RefSet, Cmd, isName, isCmd, isDict, isRef, isRefsEqual */
-
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-test/unit/primitives_spec', ['exports',
+           'pdfjs/core/primitives'], factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports, require('../../src/core/primitives.js'));
+  } else {
+    factory((root.pdfjsTestUnitPrimitivesSpec = {}), root.pdfjsCorePrimitives);
+  }
+}(this, function (exports, corePrimitives) {
+
+var Name = corePrimitives.Name;
+var Dict = corePrimitives.Dict;
+var Ref = corePrimitives.Ref;
+var RefSet = corePrimitives.RefSet;
+var Cmd = corePrimitives.Cmd;
+var isName = corePrimitives.isName;
+var isCmd = corePrimitives.isCmd;
+var isDict = corePrimitives.isDict;
+var isRef = corePrimitives.isRef;
+var isRefsEqual = corePrimitives.isRefsEqual;
 
 describe('primitives', function() {
   function XRefMock(array) {
@@ -371,3 +404,4 @@ describe('primitives', function() {
     });
   });
 });
+}));

--- a/test/unit/stream_spec.js
+++ b/test/unit/stream_spec.js
@@ -1,6 +1,35 @@
-/* globals Stream, PredictorStream, Dict */
-
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-test/unit/stream_spec', ['exports',
+           'pdfjs/core/primitives', 'pdfjs/core/stream'], factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports, require('../../src/core/primitives.js'),
+            require('../../src/core/stream.js'));
+  } else {
+    factory((root.pdfjsTestUnitStreamSpec = {}), root.pdfjsCorePrimitives,
+             root.pdfjsCoreStream);
+  }
+}(this, function (exports, corePrimitives, coreStream) {
+
+var Dict = corePrimitives.Dict;
+var Stream = coreStream.Stream;
+var PredictorStream = coreStream.PredictorStream;
 
 describe('stream', function() {
   beforeEach(function() {
@@ -48,3 +77,4 @@ describe('stream', function() {
     });
   });
 });
+}));

--- a/test/unit/type1_parser_spec.js
+++ b/test/unit/type1_parser_spec.js
@@ -1,6 +1,37 @@
-/* globals StringStream, Type1Parser, SEAC_ANALYSIS_ENABLED */
-
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-test/unit/type1_parser_spec', ['exports',
+           'pdfjs/core/fonts', 'pdfjs/core/stream', 'pdfjs/core/type1_parser'],
+           factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports, require('../../src/core/fonts.js'),
+            require('../../src/core/stream.js'),
+            require('../../src/core/type1_parser.js'));
+  } else {
+    factory((root.pdfjsTestUnitType1ParserSpec = {}), root.pdfjsCoreFonts,
+             root.pdfjsCoreStream, root.pdfjsCoreType1Parser);
+  }
+}(this, function (exports, coreFonts, coreStream, coreType1Parser) {
+
+var SEAC_ANALYSIS_ENABLED = coreFonts.SEAC_ANALYSIS_ENABLED;
+var StringStream = coreStream.StringStream;
+var Type1Parser = coreType1Parser.Type1Parser;
 
 describe('Type1Parser', function() {
   it('splits tokens', function() {
@@ -101,3 +132,4 @@ describe('Type1Parser', function() {
     expect(props.builtInEncoding[33]).toEqual('arrowright');
   });
 });
+}));

--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -1,6 +1,32 @@
-/* globals expect, it, describe, binarySearchFirstItem, EventBus */
-
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-test/unit/ui_utils_spec', ['exports',
+           'pdfjs-web/ui_utils'], factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports, require('../../web/ui_utils.js'));
+  } else {
+    factory((root.pdfjsTestUnitUiUtilsSpec = {}), root.pdfjsWebUiUtils);
+  }
+}(this, function (exports, webUiUtils) {
+
+var binarySearchFirstItem = webUiUtils.binarySearchFirstItem;
+var EventBus = webUiUtils.EventBus;
 
 describe('ui_utils', function() {
   describe('binary search', function() {
@@ -117,3 +143,4 @@ describe('ui_utils', function() {
     });
   });
 });
+}));

--- a/test/unit/unicode_spec.js
+++ b/test/unit/unicode_spec.js
@@ -1,8 +1,39 @@
-/* globals mapSpecialUnicodeValues, getUnicodeForGlyph, getGlyphsUnicode,
-           getDingbatsGlyphsUnicode, getUnicodeRangeFor, getNormalizedUnicodes,
-           reverseIfRtl */
-
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-test/unit/unicode_spec', ['exports',
+           'pdfjs/core/glyphlist', 'pdfjs/core/unicode'], factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports, require('../../src/core/glyphlist.js'),
+            require('../../src/core/unicode.js'));
+  } else {
+    factory((root.pdfjsTestUnitUnicodeSpec = {}),
+             root.pdfjsCoreGlyphList, root.pdfjsCoreUnicode);
+  }
+}(this, function (exports, coreGlyphList, coreUnicode) {
+
+var getGlyphsUnicode = coreGlyphList.getGlyphsUnicode;
+var getDingbatsGlyphsUnicode = coreGlyphList.getDingbatsGlyphsUnicode;
+var mapSpecialUnicodeValues = coreUnicode.mapSpecialUnicodeValues;
+var getUnicodeForGlyph = coreUnicode.getUnicodeForGlyph;
+var getUnicodeRangeFor = coreUnicode.getUnicodeRangeFor;
+var getNormalizedUnicodes = coreUnicode.getNormalizedUnicodes;
+var reverseIfRtl = coreUnicode.reverseIfRtl;
 
 describe('unicode', function () {
   describe('mapSpecialUnicodeValues', function () {
@@ -128,3 +159,4 @@ describe('unicode', function () {
     });
   });
 });
+}));

--- a/test/unit/unit_test.html
+++ b/test/unit/unit_test.html
@@ -10,27 +10,6 @@
   <script src="../../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
   <script src="testreporter.js"></script>
   <script src="jasmine-boot.js"></script>
-
-  <!-- include spec files here... -->
-  <script src="primitives_spec.js"></script>
-  <script src="cff_parser_spec.js"></script>
-  <script src="type1_parser_spec.js"></script>
-  <script src="fonts_spec.js"></script>
-  <script src="unicode_spec.js"></script>
-  <script src="function_spec.js"></script>
-  <script src="crypto_spec.js"></script>
-  <script src="evaluator_spec.js"></script>
-  <script src="stream_spec.js"></script>
-  <script src="parser_spec.js"></script>
-  <script src="api_spec.js"></script>
-  <script src="metadata_spec.js"></script>
-  <script src="ui_utils_spec.js"></script>
-  <script src="util_spec.js"></script>
-  <script src="cmap_spec.js"></script>
-  <script src="annotation_layer_spec.js"></script>
-  <script src="network_spec.js"></script>
-  <script src="dom_utils_spec.js"></script>
-  <script src="murmurhash3_spec.js"></script>
 </head>
 <body>
 </body>

--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -1,6 +1,32 @@
-/* globals stringToPDFString, removeNullCharacters */
-
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-test/unit/util_spec', ['exports',
+           'pdfjs/shared/util'], factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports, require('../../src/shared/util.js'));
+  } else {
+    factory((root.pdfjsTestUnitUtilSpec = {}), root.pdfjsSharedUtil);
+  }
+}(this, function (exports, sharedUtil) {
+
+var stringToPDFString = sharedUtil.stringToPDFString;
+var removeNullCharacters = sharedUtil.removeNullCharacters;
 
 describe('util', function() {
   describe('stringToPDFString', function() {
@@ -37,3 +63,4 @@ describe('util', function() {
     });
   });
 });
+}));


### PR DESCRIPTION
I changed the unit test files to UMD modules.  I also changed the jasmine-boot.js file to load up the unit test modules and got rid of the lines that load up global variables.  I also changed the unit_test.html file by removing the script tags for the unit test files, since they are now loaded in jasmine-boot.js

Fixes  #7179