### PR TITLE
Enable the `no-else-return` ESLint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,6 +45,7 @@
     "curly": ["error", "all"],
     "eqeqeq": ["error", "always"],
     "no-caller": "error",
+    "no-else-return": "error",
     "no-eval": "error",
     "no-extend-native": "error",
     "no-extra-bind": "error",

--- a/extensions/chromium/pdfHandler.js
+++ b/extensions/chromium/pdfHandler.js
@@ -143,9 +143,8 @@ chrome.webRequest.onHeadersReceived.addListener(
         url: viewerUrl
       });
       return { cancel: true };
-    } else {
-      console.warn('Child frames are not supported in ancient Chrome builds!');
     }
+    console.warn('Child frames are not supported in ancient Chrome builds!');
   },
   {
     urls: [

--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -348,10 +348,9 @@ var CFFParser = (function CFFParserClosure() {
           return ((value - 247) * 256) + dict[pos++] + 108;
         } else if (value >= 251 && value <= 254) {
           return -((value - 251) * 256) - dict[pos++] - 108;
-        } else {
-          warn('CFFParser_parseDict: "' + value + '" is a reserved command.');
-          return NaN;
         }
+        warn('CFFParser_parseDict: "' + value + '" is a reserved command.');
+        return NaN;
       }
 
       function parseFloatOperand() {
@@ -1363,9 +1362,8 @@ var CFFCompiler = (function CFFCompilerClosure() {
     encodeNumber: function CFFCompiler_encodeNumber(value) {
       if (parseFloat(value) === parseInt(value, 10) && !isNaN(value)) { // isInt
         return this.encodeInteger(value);
-      } else {
-        return this.encodeFloat(value);
       }
+      return this.encodeFloat(value);
     },
     encodeFloat: function CFFCompiler_encodeFloat(num) {
       var value = num.toString();

--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -1216,11 +1216,13 @@ var LabCS = (function LabCSClosure() {
 
   // Function g(x) from spec
   function fn_g(x) {
+    var result;
     if (x >= 6 / 29) {
-      return x * x * x;
+      result = x * x * x;
     } else {
-      return (108 / 841) * (x - 4 / 29);
+      result = (108 / 841) * (x - 4 / 29);
     }
+    return result;
   }
 
   function decode(value, high1, low2, high2) {

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -823,9 +823,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
                                          this.handler);
           operatorList.addOp(fn, pattern.getIR());
           return Promise.resolve();
-        } else {
-          return Promise.reject('Unknown PatternType: ' + typeNum);
         }
+        return Promise.reject('Unknown PatternType: ' + typeNum);
       }
       // TODO shall we fail here?
       operatorList.addOp(fn, args);
@@ -2902,18 +2901,17 @@ var EvaluatorPreprocessor = (function EvaluatorPreprocessorClosure() {
           operation.fn = fn;
           operation.args = args;
           return true;
-        } else {
-          if (isEOF(obj)) {
-            return false; // no more commands
+        }
+        if (isEOF(obj)) {
+          return false; // no more commands
+        }
+        // argument
+        if (obj !== null) {
+          if (args === null) {
+            args = [];
           }
-          // argument
-          if (obj !== null) {
-            if (args === null) {
-              args = [];
-            }
-            args.push(obj);
-            assert(args.length <= 33, 'Too many arguments');
-          }
+          args.push(obj);
+          assert(args.length <= 33, 'Too many arguments');
         }
       }
     },

--- a/src/core/font_renderer.js
+++ b/src/core/font_renderer.js
@@ -729,9 +729,8 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
                           [1 / unitsPerEm, 0, 0, 1 / unitsPerEm, 0, 0]);
         return new TrueTypeCompiled(
           parseGlyfTable(glyf, loca, indexToLocFormat), cmap, fontMatrix);
-      } else {
-        return new Type2Compiled(cff, cmap, font.fontMatrix, font.glyphNameMap);
       }
+      return new Type2Compiled(cff, cmap, font.fontMatrix, font.glyphNameMap);
     }
   };
 })();

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -53,9 +53,8 @@ var PDFImage = (function PDFImageClosure() {
   function handleImageData(image, nativeDecoder) {
     if (nativeDecoder && nativeDecoder.canDecode(image)) {
       return nativeDecoder.decode(image);
-    } else {
-      return Promise.resolve(image);
     }
+    return Promise.resolve(image);
   }
 
   /**

--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -918,15 +918,15 @@ var JpegImage = (function JpegImageClosure() {
           return false;
         }
         return true;
-      } else { // `this.numComponents !== 3`
-        if (!this.adobe && this.colorTransform === 1) {
-          // If the Adobe transform marker is not present and the image
-          // dictionary has a 'ColorTransform' entry, explicitly set to `1`,
-          // then the colours should be transformed.
-          return true;
-        }
-        return false;
       }
+      // `this.numComponents !== 3`
+      if (!this.adobe && this.colorTransform === 1) {
+        // If the Adobe transform marker is not present and the image
+        // dictionary has a 'ColorTransform' entry, explicitly set to `1`,
+        // then the colours should be transformed.
+        return true;
+      }
+      return false;
     },
 
     _convertYccToRgb: function convertYccToRgb(data) {
@@ -1072,9 +1072,8 @@ var JpegImage = (function JpegImageClosure() {
         if (this._isColorConversionNeeded()) {
           if (forceRGBoutput) {
             return this._convertYcckToRgb(data);
-          } else {
-            return this._convertYcckToCmyk(data);
           }
+          return this._convertYcckToCmyk(data);
         } else if (forceRGBoutput) {
           return this._convertCmykToRgb(data);
         }

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -1585,9 +1585,8 @@ var FileSpec = (function FileSpecClosure() {
       return dict.get('Mac');
     } else if (dict.has('DOS')) {
       return dict.get('DOS');
-    } else {
-      return null;
     }
+    return null;
   }
 
   FileSpec.prototype = {

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -81,9 +81,8 @@ AnnotationElementFactory.prototype =
               return new RadioButtonWidgetAnnotationElement(parameters);
             } else if (parameters.data.checkBox) {
               return new CheckboxWidgetAnnotationElement(parameters);
-            } else {
-              warn('Unimplemented button widget annotation: pushbutton');
             }
+            warn('Unimplemented button widget annotation: pushbutton');
             break;
           case 'Ch':
             return new ChoiceWidgetAnnotationElement(parameters);

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1945,9 +1945,8 @@ var PDFObjects = (function PDFObjectsClosure() {
 
       if (!objs[objId]) {
         return false;
-      } else {
-        return objs[objId].resolved;
       }
+      return objs[objId].resolved;
     },
 
     hasData: function PDFObjects_hasData(objId) {
@@ -1961,9 +1960,8 @@ var PDFObjects = (function PDFObjectsClosure() {
       var objs = this.objs;
       if (!objs[objId] || !objs[objId].resolved) {
         return null;
-      } else {
-        return objs[objId].data;
       }
+      return objs[objId].data;
     },
 
     clear: function PDFObjects_clear() {

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -376,7 +376,7 @@ var FontFaceObject = (function FontFaceObjectClosure() {
           this.options.fontRegistry.registerFont(this);
         }
         return nativeFontFace;
-      } else {
+      } else { // eslint-disable-line no-else-return
         throw new Error('Not implemented: createNativeFontFace');
       }
     },

--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -202,9 +202,8 @@ if (typeof PDFJS === 'undefined') {
       get: function xmlHttpRequestResponseGet() {
         if (this.responseType === 'arraybuffer') {
           return new Uint8Array(new VBArray(this.responseBody).toArray());
-        } else {
-          return this.responseText;
         }
+        return this.responseText;
       }
     });
     return;

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -178,12 +178,11 @@ var PDFDocumentProperties = (function PDFDocumentPropertiesClosure() {
           size_kb: (+kb.toPrecision(3)).toLocaleString(),
           size_b: fileSize.toLocaleString()
         }, '{{size_kb}} KB ({{size_b}} bytes)');
-      } else {
-        return mozL10n.get('document_properties_mb', {
-          size_mb: (+(kb / 1024).toPrecision(3)).toLocaleString(),
-          size_b: fileSize.toLocaleString()
-        }, '{{size_mb}} MB ({{size_b}} bytes)');
       }
+      return mozL10n.get('document_properties_mb', {
+        size_mb: (+(kb / 1024).toPrecision(3)).toLocaleString(),
+        size_b: fileSize.toLocaleString()
+      }, '{{size_mb}} MB ({{size_b}} bytes)');
     },
 
     /**

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -399,22 +399,21 @@ var PDFFindController = (function PDFFindControllerClosure() {
         offset.matchIdx = (previous ? numMatches - 1 : 0);
         this.updateMatch(true);
         return true;
-      } else {
-        // No matches, so attempt to search the next page.
-        this.advanceOffsetPage(previous);
-        if (offset.wrapped) {
-          offset.matchIdx = null;
-          if (this.pagesToSearch < 0) {
-            // No point in wrapping again, there were no matches.
-            this.updateMatch(false);
-            // while matches were not found, searching for a page
-            // with matches should nevertheless halt.
-            return true;
-          }
-        }
-        // Matches were not found (and searching is not done).
-        return false;
       }
+      // No matches, so attempt to search the next page.
+      this.advanceOffsetPage(previous);
+      if (offset.wrapped) {
+        offset.matchIdx = null;
+        if (this.pagesToSearch < 0) {
+          // No point in wrapping again, there were no matches.
+          this.updateMatch(false);
+          // while matches were not found, searching for a page
+          // with matches should nevertheless halt.
+          return true;
+        }
+      }
+      // Matches were not found (and searching is not done).
+      return false;
     },
 
     /**

--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -284,9 +284,8 @@
           this.nextHashParam = null;
           this.updatePreviousBookmark = true;
           return;
-        } else {
-          this.nextHashParam = null;
         }
+        this.nextHashParam = null;
       }
 
       if (params.hash) {

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -624,7 +624,7 @@ var PDFPageView = (function PDFPageViewClosure() {
           onRenderContinue: function (cont) { },
           cancel: function () { },
         };
-      } else {
+      } else { // eslint-disable-line no-else-return
         var cancelled = false;
         var ensureNotCancelled = function () {
           if (cancelled) {

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -833,14 +833,13 @@ var PDFViewer = (function pdfViewer() {
     _getVisiblePages: function () {
       if (!this.isInPresentationMode) {
         return getVisibleElements(this.container, this._pages, true);
-      } else {
-        // The algorithm in getVisibleElements doesn't work in all browsers and
-        // configurations when presentation mode is active.
-        var visible = [];
-        var currentPage = this._pages[this._currentPageNumber - 1];
-        visible.push({ id: currentPage.id, view: currentPage });
-        return { first: currentPage, last: currentPage, views: visible };
       }
+      // The algorithm in getVisibleElements doesn't work in all browsers and
+      // configurations when presentation mode is active.
+      var visible = [];
+      var currentPage = this._pages[this._currentPageNumber - 1];
+      visible.push({ id: currentPage.id, view: currentPage });
+      return { first: currentPage, last: currentPage, views: visible };
     },
 
     cleanup: function () {

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -280,12 +280,14 @@ function approximateFraction(x) {
       a = p; b = q;
     }
   }
+  var result;
   // Select closest of the neighbours to x.
   if (x_ - a / b < c / d - x_) {
-    return x_ === x ? [a, b] : [b, a];
+    result = x_ === x ? [a, b] : [b, a];
   } else {
-    return x_ === x ? [c, d] : [d, c];
+    result = x_ === x ? [c, d] : [d, c];
   }
+  return result;
 }
 
 function roundToDivide(x, div) {


### PR DESCRIPTION
Using `else` after `return` is not necessary, and can often lead to unnecessarily cluttered code. By using the `no-else-return` rule in ESLint we can avoid this pattern, see http://eslint.org/docs/rules/no-else-return.

*Please note:* This is one ESLint rules that could perhaps be considered a bit too opinionated by some people, so even though I'd like enable it, I understand if others do not.
*Easier reviewing with:* https://github.com/mozilla/pdf.js/pull/7935/files?w=1.