### PR TITLE
Don't write an empty PDF file when downloading of a linked test file fails

### DIFF
--- a/test/downloadutils.js
+++ b/test/downloadutils.js
@@ -92,7 +92,6 @@ function downloadManifestFiles(manifest, callback) {
     downloadFile(file, url, function (err) {
       if (err) {
         console.error('Error during downloading of ' + url + ': ' + err);
-        fs.writeFileSync(file, ''); // making it empty file
         fs.writeFileSync(file + '.error', err);
       }
       i++;

--- a/test/test.js
+++ b/test/test.js
@@ -419,12 +419,12 @@ function checkRefTestResults(browser, id, results) {
       }
       if (pageResult.failure) {
         failed = true;
+        session.numErrors++;
         if (fs.existsSync(task.file + '.error')) {
           console.log('TEST-SKIPPED | PDF was not downloaded ' + id + ' | in ' +
                       browser + ' | page' + (page + 1) + ' round ' +
                       (round + 1) + ' | ' + pageResult.failure);
         } else {
-          session.numErrors++;
           console.log('TEST-UNEXPECTED-FAIL | test failed ' + id + ' | in ' +
             browser + ' | page' + (page + 1) + ' round ' +
             (round + 1) + ' | ' + pageResult.failure);


### PR DESCRIPTION
Currently `test/downloadutils.js` will write out an empty file when downloading of a linked file fails. The consequence of this is that since the PDF file now "exists", no further attempts to download it will be made unless the empty PDF is removed.
This is especially annoying when it happens on the bots, since it requires that someone logs in and manually removes the empty PDF file.

I'm really not sure why it was implemented this way to begin with. However, given that `PDFJS.getDocument` fails with `MissingPDFException` if a file is not present, I cannot see a problem with this change.
Furthermore, the patch also changes the `checkRefTestResults` in `test/test.js` such that we treat the "downloading of linked test file failed" case as a failure, so that e.g. the bots won't report "success" when a test file failed to download.