### PR TITLE
Rename `annotation_layer_spec.js` to `annotation_spec.js` to better describe what is actually tested, and simplify the `FileAttachmentAnnotation` unit-test to avoid having to use the entire API in the test

### DIFF
--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -18,21 +18,19 @@
   if (typeof define === 'function' && define.amd) {
     define('pdfjs-test/unit/annotation_spec', ['exports',
       'pdfjs/core/primitives', 'pdfjs/core/annotation', 'pdfjs/core/stream',
-      'pdfjs/core/parser', 'pdfjs/shared/util', 'pdfjs/display/global'],
-      factory);
+      'pdfjs/core/parser', 'pdfjs/shared/util'], factory);
   } else if (typeof exports !== 'undefined') {
     factory(exports, require('../../src/core/primitives.js'),
       require('../../src/core/annotation.js'),
       require('../../src/core/stream.js'), require('../../src/core/parser.js'),
-      require('../../src/shared/util.js'),
-      require('../../src/display/global.js'));
+      require('../../src/shared/util.js'));
   } else {
     factory((root.pdfjsTestUnitAnnotationSpec = {}),
       root.pdfjsCorePrimitives, root.pdfjsCoreAnnotation, root.pdfjsCoreStream,
-      root.pdfjsCoreParser, root.pdfjsSharedUtil, root.pdfjsDisplayGlobal);
+      root.pdfjsCoreParser, root.pdfjsSharedUtil);
   }
 }(this, function (exports, corePrimitives, coreAnnotation, coreStream,
-                  coreParser, sharedUtil, displayGlobal) {
+                  coreParser, sharedUtil) {
 
 var Annotation = coreAnnotation.Annotation;
 var AnnotationBorderStyle = coreAnnotation.AnnotationBorderStyle;
@@ -44,7 +42,6 @@ var Dict = corePrimitives.Dict;
 var Name = corePrimitives.Name;
 var Ref = corePrimitives.Ref;
 var StringStream = coreStream.StringStream;
-var PDFJS = displayGlobal.PDFJS;
 var AnnotationType = sharedUtil.AnnotationType;
 var AnnotationFlag = sharedUtil.AnnotationFlag;
 var AnnotationBorderStyleType = sharedUtil.AnnotationBorderStyleType;
@@ -1211,33 +1208,56 @@ describe('annotation', function() {
   });
 
   describe('FileAttachmentAnnotation', function() {
-    var loadingTask;
-    var annotations;
-
-    beforeEach(function(done) {
-      var pdfUrl = new URL('../pdfs/annotation-fileattachment.pdf',
-                           window.location).href;
-      loadingTask = PDFJS.getDocument(pdfUrl);
-      loadingTask.promise.then(function(pdfDocument) {
-        return pdfDocument.getPage(1).then(function(pdfPage) {
-          return pdfPage.getAnnotations().then(function (pdfAnnotations) {
-            annotations = pdfAnnotations;
-            done();
-          });
-        });
-      }).catch(function (reason) {
-        done.fail(reason);
-      });
-    });
-
-    afterEach(function() {
-      loadingTask.destroy();
-    });
-
     it('should correctly parse a file attachment', function() {
-      var annotation = annotations[0];
-      expect(annotation.file.filename).toEqual('Test.txt');
-      expect(annotation.file.content).toEqual(stringToBytes('Test attachment'));
+      var fileStream = new StringStream(
+        '<<\n' +
+        '/Type /EmbeddedFile\n' +
+        '/Subtype /text#2Fplain\n' +
+        '>>\n' +
+        'stream\n' +
+        'Test attachment' +
+        'endstream\n'
+      );
+      var lexer = new Lexer(fileStream);
+      var parser = new Parser(lexer, /* allowStreams = */ true);
+
+      var fileStreamRef = new Ref(18, 0);
+      var fileStreamDict = parser.getObj();
+
+      var embeddedFileDict = new Dict();
+      embeddedFileDict.set('F', fileStreamRef);
+
+      var fileSpecRef = new Ref(19, 0);
+      var fileSpecDict = new Dict();
+      fileSpecDict.set('Type', Name.get('Filespec'));
+      fileSpecDict.set('Desc', '');
+      fileSpecDict.set('EF', embeddedFileDict);
+      fileSpecDict.set('UF', 'Test.txt');
+
+      var fileAttachmentRef = new Ref(20, 0);
+      var fileAttachmentDict = new Dict();
+      fileAttachmentDict.set('Type', Name.get('Annot'));
+      fileAttachmentDict.set('Subtype', Name.get('FileAttachment'));
+      fileAttachmentDict.set('FS', fileSpecRef);
+      fileAttachmentDict.set('T', 'Topic');
+      fileAttachmentDict.set('Contents', 'Test.txt');
+
+      var xref = new XRefMock([
+        { ref: fileStreamRef, data: fileStreamDict, },
+        { ref: fileSpecRef, data: fileSpecDict, },
+        { ref: fileAttachmentRef, data: fileAttachmentDict, }
+      ]);
+      embeddedFileDict.assignXref(xref);
+      fileSpecDict.assignXref(xref);
+      fileAttachmentDict.assignXref(xref);
+
+      var annotation = annotationFactory.create(xref, fileAttachmentRef,
+                                                pdfManagerMock, idFactoryMock);
+      var data = annotation.data;
+      expect(data.annotationType).toEqual(AnnotationType.FILEATTACHMENT);
+
+      expect(data.file.filename).toEqual('Test.txt');
+      expect(data.file.content).toEqual(stringToBytes('Test attachment'));
     });
   });
 

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -16,7 +16,7 @@
 
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/annotation_layer_spec', ['exports',
+    define('pdfjs-test/unit/annotation_spec', ['exports',
       'pdfjs/core/primitives', 'pdfjs/core/annotation', 'pdfjs/core/stream',
       'pdfjs/core/parser', 'pdfjs/shared/util', 'pdfjs/display/global'],
       factory);
@@ -27,7 +27,7 @@
       require('../../src/shared/util.js'),
       require('../../src/display/global.js'));
   } else {
-    factory((root.pdfjsTestUnitAnnotationLayerSpec = {}),
+    factory((root.pdfjsTestUnitAnnotationSpec = {}),
       root.pdfjsCorePrimitives, root.pdfjsCoreAnnotation, root.pdfjsCoreStream,
       root.pdfjsCoreParser, root.pdfjsSharedUtil, root.pdfjsDisplayGlobal);
   }
@@ -52,7 +52,7 @@ var AnnotationFieldFlag = sharedUtil.AnnotationFieldFlag;
 var stringToBytes = sharedUtil.stringToBytes;
 var stringToUTF8String = sharedUtil.stringToUTF8String;
 
-describe('Annotation layer', function() {
+describe('annotation', function() {
   function XRefMock(array) {
     this.map = Object.create(null);
     for (var elem in array) {

--- a/test/unit/clitests.json
+++ b/test/unit/clitests.json
@@ -1,6 +1,7 @@
 {
   "spec_dir": "test/unit",
   "spec_files": [
+    "annotation_spec.js",
     "bidi_spec.js",
     "cff_parser_spec.js",
     "crypto_spec.js",

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -45,7 +45,7 @@ var pdfjsLibs;
 function initializePDFJS(callback) {
   require.config({paths: {'pdfjs': '../../src', 'pdfjs-web': '../../web',
                  'pdfjs-test': '..'}});
-  require(['pdfjs/display/global', 'pdfjs-test/unit/annotation_layer_spec',
+  require(['pdfjs/display/global', 'pdfjs-test/unit/annotation_spec',
            'pdfjs-test/unit/api_spec', 'pdfjs-test/unit/bidi_spec',
            'pdfjs-test/unit/cff_parser_spec', 'pdfjs-test/unit/cmap_spec',
            'pdfjs-test/unit/crypto_spec', 'pdfjs-test/unit/document_spec',
@@ -57,7 +57,7 @@ function initializePDFJS(callback) {
            'pdfjs-test/unit/type1_parser_spec',
            'pdfjs-test/unit/ui_utils_spec', 'pdfjs-test/unit/unicode_spec',
            'pdfjs-test/unit/util_spec'],
-    function (displayGlobal, testUnitAnnotationLayerSpec, testUnitApiSpec,
+    function (displayGlobal, testUnitAnnotationSpec, testUnitApiSpec,
               testUnitBidiSpec, testUnitCFFParserSpec, testUnitCMapSpec,
               testUnitCryptoSpec, testUnitDocumentSpec, testUnitDOMUtilsSpec,
               testUnitEvaluatorSpec, testUnitFontsSpec, testUnitFunctionSpec,


### PR DESCRIPTION
Every other unit-test in `annotation_spec.js` is already only testing the annotation code. Hence it seems unnecessarily convoluted to make use of the API here, when we can (fairly) simply provide the necessary data explicitly as in all the other annotation unit-test.

**Edit:** Note how doing this will also allow us to run the annotation unit-tests on Travis!
Compare the run with this PR: https://travis-ci.org/mozilla/pdf.js/builds/191392213#L369; with a previous run: https://travis-ci.org/mozilla/pdf.js/builds/191349139#L350.