### PR TITLE
Display a notification on the `sidebarToggle` button for PDF documents with outline/attachments

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -101,6 +101,7 @@ print_progress_close=Cancel
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Toggle Sidebar
+toggle_sidebar_notification.title=Toggle Sidebar (document contains outline/attachments)
 toggle_sidebar_label=Toggle Sidebar
 document_outline.title=Show Document Outline (double-click to expand/collapse all items)
 document_outline_label=Document Outline

--- a/l10n/sv-SE/viewer.properties
+++ b/l10n/sv-SE/viewer.properties
@@ -101,6 +101,7 @@ print_progress_close=Avbryt
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Visa/dölj sidofält
+toggle_sidebar_notification.title=Visa/dölj sidofält (dokumentet innehåller disposition/bilagor)
 toggle_sidebar_label=Visa/dölj sidofält
 document_outline.title=Visa dokumentdisposition (dubbelklicka för att expandera/komprimera alla objekt)
 document_outline_label=Dokumentöversikt

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -29,6 +29,7 @@
 
 var AnnotationBorderStyleType = sharedUtil.AnnotationBorderStyleType;
 var AnnotationType = sharedUtil.AnnotationType;
+var stringToPDFString = sharedUtil.stringToPDFString;
 var Util = sharedUtil.Util;
 var addLinkAttributes = displayDOMUtils.addLinkAttributes;
 var LinkTarget = displayDOMUtils.LinkTarget;
@@ -1007,8 +1008,15 @@ var FileAttachmentAnnotationElement = (
   function FileAttachmentAnnotationElement(parameters) {
     AnnotationElement.call(this, parameters, true);
 
-    this.filename = getFilenameFromUrl(parameters.data.file.filename);
-    this.content = parameters.data.file.content;
+    var file = this.data.file;
+    this.filename = getFilenameFromUrl(file.filename);
+    this.content = file.content;
+
+    this.linkService.onFileAttachmentAnnotation({
+      id: stringToPDFString(file.filename),
+      filename: file.filename,
+      content: file.content,
+    });
   }
 
   Util.inherit(FileAttachmentAnnotationElement, AnnotationElement, {
@@ -1086,8 +1094,7 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
         if (!data) {
           continue;
         }
-
-        var properties = {
+        var element = annotationElementFactory.create({
           data: data,
           layer: parameters.div,
           page: parameters.page,
@@ -1097,8 +1104,7 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
           imageResourcesPath: parameters.imageResourcesPath ||
                               getDefaultSetting('imageResourcesPath'),
           renderInteractiveForms: parameters.renderInteractiveForms || false,
-        };
-        var element = annotationElementFactory.create(properties);
+        });
         if (element.isRenderable) {
           parameters.div.appendChild(element.render());
         }

--- a/src/main_loader.js
+++ b/src/main_loader.js
@@ -48,6 +48,7 @@
   exports.renderTextLayer = displayTextLayer.renderTextLayer;
   exports.AnnotationLayer = displayAnnotationLayer.AnnotationLayer;
   exports.CustomStyle = displayDOMUtils.CustomStyle;
+  exports.createPromiseCapability = sharedUtil.createPromiseCapability;
   exports.PasswordResponses = sharedUtil.PasswordResponses;
   exports.InvalidPDFException = sharedUtil.InvalidPDFException;
   exports.MissingPDFException = sharedUtil.MissingPDFException;

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -55,6 +55,8 @@
     exports.AnnotationLayer =
       pdfjsLibs.pdfjsDisplayAnnotationLayer.AnnotationLayer;
     exports.CustomStyle = pdfjsLibs.pdfjsDisplayDOMUtils.CustomStyle;
+    exports.createPromiseCapability =
+      pdfjsLibs.pdfjsSharedUtil.createPromiseCapability;
     exports.PasswordResponses = pdfjsLibs.pdfjsSharedUtil.PasswordResponses;
     exports.InvalidPDFException = pdfjsLibs.pdfjsSharedUtil.InvalidPDFException;
     exports.MissingPDFException = pdfjsLibs.pdfjsSharedUtil.MissingPDFException;

--- a/test/driver.js
+++ b/test/driver.js
@@ -26,6 +26,12 @@ var LinkServiceMock = (function LinkServiceMockClosure() {
   function LinkServiceMock() {}
 
   LinkServiceMock.prototype = {
+    get page() {
+      return 0;
+    },
+
+    set page(value) {},
+
     navigateTo: function (dest) {},
 
     getDestinationHash: function (dest) {
@@ -36,7 +42,13 @@ var LinkServiceMock = (function LinkServiceMockClosure() {
       return '#';
     },
 
-    executeNamedAction: function (action) {}
+    setHash: function (hash) {},
+
+    executeNamedAction: function (action) {},
+
+    onFileAttachmentAnnotation: function (params) {},
+
+    cachePageRef: function (pageNum, pageRef) {},
   };
 
   return LinkServiceMock;

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -351,6 +351,18 @@ var PDFLinkService = (function PDFLinkServiceClosure() {
     },
 
     /**
+     * @param {Object} params
+     */
+    onFileAttachmentAnnotation: function (params) {
+      this.eventBus.dispatch('fileattachmentannotation', {
+        source: this,
+        id: params.id,
+        filename: params.filename,
+        content: params.content,
+      });
+    },
+
+    /**
      * @param {number} pageNum - page number.
      * @param {Object} pageRef - reference to the page.
      */
@@ -462,6 +474,10 @@ var SimpleLinkService = (function SimpleLinkServiceClosure() {
      * @param {string} action
      */
     executeNamedAction: function (action) {},
+    /**
+     * @param {Object} params
+     */
+    onFileAttachmentAnnotation: function (params) {},
     /**
      * @param {number} pageNum - page number.
      * @param {Object} pageRef - reference to the page.

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -920,6 +920,24 @@ html[dir="rtl"] #viewOutline.toolbarButton::before {
   content: url(images/toolbarButton-search.png);
 }
 
+.toolbarButton.pdfSidebarNotification::after {
+  position: absolute;
+  display: inline-block;
+  top: 1px;
+  /* Create a filled circle, with a diameter of 9 pixels, using only CSS: */
+  content: '';
+  background-color: #70DB55;
+  height: 9px;
+  width: 9px;
+  border-radius: 50%;
+}
+html[dir='ltr'] .toolbarButton.pdfSidebarNotification::after {
+  left: 17px;
+}
+html[dir='rtl'] .toolbarButton.pdfSidebarNotification::after {
+  right: 17px;
+}
+
 .secondaryToolbarButton {
   position: relative;
   margin: 0 0 4px 0;


### PR DESCRIPTION
*This is something that I've had lying around for quite a while locally, and I figured that I might as well just submit it to see if others think there's value in it!*

Fixes #5961
Fixes #7025

---

 - Display a notification on the `sidebarToggle` button for PDF documents with outline/attachments

   > A longstanding issue with the viewer is that you cannot tell if a PDF document includes an outline and/or attachments without actually opening the sidebar.
This patch contains a suggested solution for that, by displaying an hide-on-interaction notification on the `sidebarToggle` button (and the relevant sidebar view buttons). Note that this was inspired by e.g. the update notification that is displayed on the menu button in Firefox.
   >
   > For an initial implementation, I've tried to do this in such a way that the notification isn't too distracting. Without being an UX expert, I don't think that we'd want something too in-your-face, in order to keep the viewer toolbars reasonable clean. (We probably do *not* want e.g. an entire notification bar in these situations, since that would take up unnecessary screen space and require actions from the user to close.)
   >
   > However it's certainly possible that the current notification might simply be *too* inconspicuous to be truly helpful to users, but we could probably iterate on that if the feature itself is deemed useful.
One idea could be to e.g. use a modified tooltip for the `sidebarToggle`, e.g. "Toggle Sidebar (outline and/or attachments available)", when the notification is used.

 - Append the contents of `FileAttachment` annotations to the attachments view of the sidebar, for easier access to the embedded files

   > Other PDF viewers, e.g. Adobe Reader, seem to append `FileAttachment`s to their attachments views.
One obvious difference in PDF.js is that we cannot append all the annotations on document load, since that would require parsing *every* page. Despite that, it still seems like a good idea to add `FileAttachment`s, since it's thus possible to access all the various types of attachments from a single place.
   >
   > *Note:* With the previous patch we display a notification when a `FileAttachment` is added to the sidebar, which thus makes appending the contents of these annotations to the sidebar slightly more visible/useful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/pdf.js/7959)
<!-- Reviewable:end -->
