### PR TITLE
Adjust the `space-unary-ops` ESLint rule to comply with mozilla-central lint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -104,6 +104,6 @@
     "space-before-function-paren": ["error", { "anonymous": "ignore", "named": "never", }],
     "space-in-parens": ["error", "never"],
     "space-infix-ops": ["error", { "int32Hint": false }],
-    "space-unary-ops": ["error", { "words": true, "nonwords": false, "overrides": { "void": false, }, }],
+    "space-unary-ops": ["error", { "words": true, "nonwords": false, }],
   },
 }

--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -171,7 +171,7 @@ PdfDataListener.prototype = {
     if (this.length >= 0 && this.length < this.loaded) {
       this.length = -1; // reset the length, server is giving incorrect one
     }
-    this.onprogress(this.loaded, this.length >= 0 ? this.length : void(0));
+    this.onprogress(this.loaded, this.length >= 0 ? this.length : void 0);
   },
   readData: function PdfDataListener_readData() {
     var result = this.buffer;


### PR DESCRIPTION
See http://eslint.org/docs/rules/space-unary-ops; a *very* small part of issue #7957.

*Edit:* It seemed kind of strange/stupid to have an override for just *one* line of code.