### PR TITLE
[Bug 1331081] omit addEventListener/removeEventListener's third parameter when it's false

### DIFF
--- a/web/debugger.js
+++ b/web/debugger.js
@@ -403,13 +403,13 @@ var Stepper = (function StepperClosure() {
       var listener = function(e) {
         switch (e.keyCode) {
           case 83: // step
-            dom.removeEventListener('keydown', listener, false);
+            dom.removeEventListener('keydown', listener);
             self.nextBreakPoint = self.currentIdx + 1;
             self.goTo(-1);
             callback();
             break;
           case 67: // continue
-            dom.removeEventListener('keydown', listener, false);
+            dom.removeEventListener('keydown', listener);
             var breakPoint = self.getNextBreakPoint();
             self.nextBreakPoint = breakPoint;
             self.goTo(-1);
@@ -417,7 +417,7 @@ var Stepper = (function StepperClosure() {
             break;
         }
       };
-      dom.addEventListener('keydown', listener, false);
+      dom.addEventListener('keydown', listener);
       self.goTo(idx);
     },
     goTo: function goTo(idx) {

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -76,9 +76,9 @@ var FirefoxCom = (function FirefoxComClosure() {
 
           document.documentElement.removeChild(node);
 
-          document.removeEventListener('pdf.js.response', listener, false);
+          document.removeEventListener('pdf.js.response', listener);
           return callback(response);
-        }, false);
+        });
       }
       document.documentElement.appendChild(request);
 

--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -114,7 +114,7 @@
         } else {
           updateHistoryWithCurrentHash();
         }
-      }, false);
+      });
 
 
       function updateHistoryWithCurrentHash() {
@@ -162,18 +162,17 @@
         }
         // Remove the event listener when navigating away from the document,
         // since 'beforeunload' prevents Firefox from caching the document.
-        window.removeEventListener('beforeunload', pdfHistoryBeforeUnload,
-                                   false);
+        window.removeEventListener('beforeunload', pdfHistoryBeforeUnload);
       }
 
-      window.addEventListener('beforeunload', pdfHistoryBeforeUnload, false);
+      window.addEventListener('beforeunload', pdfHistoryBeforeUnload);
 
       window.addEventListener('pageshow', function pdfHistoryPageShow(evt) {
         // If the entire viewer (including the PDF file) is cached in
         // the browser, we need to reattach the 'beforeunload' event listener
         // since the 'DOMContentLoaded' event is not fired on 'pageshow'.
-        window.addEventListener('beforeunload', pdfHistoryBeforeUnload, false);
-      }, false);
+        window.addEventListener('beforeunload', pdfHistoryBeforeUnload);
+      });
 
       self.eventBus.on('presentationmodechanged', function(e) {
         self.isViewerInPresentationMode = e.active;

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -320,8 +320,8 @@
         event.stopImmediatePropagation();
       }
     };
-    window.addEventListener('beforeprint', stopPropagationIfNeeded, false);
-    window.addEventListener('afterprint', stopPropagationIfNeeded, false);
+    window.addEventListener('beforeprint', stopPropagationIfNeeded);
+    window.addEventListener('afterprint', stopPropagationIfNeeded);
   }
 
   var overlayPromise;


### PR DESCRIPTION
Upstream changes from https://bugzilla.mozilla.org/show_bug.cgi?id=1331081; this patch also covers one file, `pdf_print_service.js`, that's not present in mozilla-central.

Fixes #7962.