### PR TITLE
remove the viewer page div id

### DIFF
--- a/web/page_view.js
+++ b/web/page_view.js
@@ -44,7 +44,6 @@ var PageView = function pageView(container, id, scale,
   anchor.name = '' + this.id;
 
   var div = this.el = document.createElement('div');
-  div.id = 'pageContainer' + this.id;
   div.className = 'page';
   div.style.width = Math.floor(this.viewport.width) + 'px';
   div.style.height = Math.floor(this.viewport.height) + 'px';


### PR DESCRIPTION
This removes the page div id from the viewer. The id, and parsing it for the page number, is replaced by the data-page-number attribute.

The mozilla-cental test that depended on the div.id has been updated to use the data-page-number (checked-in for Target Milestone: Firefox 53, Bug 1331795).