### PR TITLE
remove viewer page div id

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -112,7 +112,6 @@ var PDFPageView = (function PDFPageViewClosure() {
     this.annotationLayer = null;
 
     var div = document.createElement('div');
-    div.id = 'pageContainer' + this.id;
     div.className = 'page';
     div.style.width = Math.floor(this.viewport.width) + 'px';
     div.style.height = Math.floor(this.viewport.height) + 'px';

--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -124,8 +124,8 @@ var PDFThumbnailView = (function PDFThumbnailViewClosure() {
     this.anchor = anchor;
 
     var div = document.createElement('div');
-    div.id = 'thumbnailContainer' + id;
     div.className = 'thumbnail';
+    div.setAttribute('data-page-number', this.id);
     this.div = div;
 
     if (id === 1) {

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -87,7 +87,8 @@ var PDFThumbnailViewer = (function PDFThumbnailViewerClosure() {
       if (selected) {
         selected.classList.remove('selected');
       }
-      var thumbnail = document.getElementById('thumbnailContainer' + page);
+      var thumbnail = document.querySelector(
+        'div.thumbnail[data-page-number="' + page + '"]');
       if (thumbnail) {
         thumbnail.classList.add('selected');
       }


### PR DESCRIPTION
This removes the page div id from the viewer. The id, and parsing it for the page number, is replaced by the data-page-number attribute.

The mozilla-cental test that depended on the div.id has been updated to use data-page-number (checked-in for Target Milestone: Firefox 53, Bug 1331795).

This resolves #5897