### PR TITLE
Enable the `spaced-comment` ESLint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -105,5 +105,14 @@
     "space-in-parens": ["error", "never"],
     "space-infix-ops": ["error", { "int32Hint": false }],
     "space-unary-ops": ["error", { "words": true, "nonwords": false, }],
+    "spaced-comment": ["error", "always", {
+      "line": {
+        "exceptions": ["//", "#else", "#endif"],
+        "markers": ["#if", "#elif", "#include", "#expand", "#error"],
+      },
+      "block": {
+        "balanced": true,
+      }
+    }],
   },
 }

--- a/make.js
+++ b/make.js
@@ -1168,7 +1168,7 @@ target.makefile = function () {
 };
 
 //
-//make importl10n
+// make importl10n
 //
 target.importl10n = function() {
   execGulp('importl10n');

--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -891,11 +891,11 @@ var AES128Cipher = (function AES128CipherClosure() {
     }
 
     for (i = 1; i < 10; i++) {
-      //SubBytes
+      // SubBytes
       for (j = 0; j < 16; ++j) {
         state[j] = s[state[j]];
       }
-      //ShiftRows
+      // ShiftRows
       v = state[1];
       state[1] = state[5];
       state[5] = state[9];
@@ -914,7 +914,7 @@ var AES128Cipher = (function AES128CipherClosure() {
       state[7] = v;
       state[11] = u;
       state[15] = t;
-      //MixColumns
+      // MixColumns
       for (var j = 0; j < 16; j += 4) {
         var s0 = state[j + 0], s1 = state[j + 1];
         var s2 = state[j + 2], s3 = state[j + 3];
@@ -924,17 +924,17 @@ var AES128Cipher = (function AES128CipherClosure() {
         state[j + 2] ^= t ^ mixCol[s2 ^ s3];
         state[j + 3] ^= t ^ mixCol[s3 ^ s0];
       }
-      //AddRoundKey
+      // AddRoundKey
       for (j = 0, k = i * 16; j < 16; ++j, ++k) {
         state[j] ^= key[k];
       }
     }
 
-    //SubBytes
+    // SubBytes
     for (j = 0; j < 16; ++j) {
       state[j] = s[state[j]];
     }
-    //ShiftRows
+    // ShiftRows
     v = state[1];
     state[1] = state[5];
     state[5] = state[9];
@@ -953,7 +953,7 @@ var AES128Cipher = (function AES128CipherClosure() {
     state[7] = v;
     state[11] = u;
     state[15] = t;
-    //AddRoundKey
+    // AddRoundKey
     for (j = 0, k = 160; j < 16; ++j, ++k) {
       state[j] ^= key[k];
     }
@@ -1337,11 +1337,11 @@ var AES256Cipher = (function AES256CipherClosure() {
     }
 
     for (i = 1; i < 14; i++) {
-      //SubBytes
+      // SubBytes
       for (j = 0; j < 16; ++j) {
         state[j] = s[state[j]];
       }
-      //ShiftRows
+      // ShiftRows
       v = state[1];
       state[1] = state[5];
       state[5] = state[9];
@@ -1360,7 +1360,7 @@ var AES256Cipher = (function AES256CipherClosure() {
       state[7] = v;
       state[11] = u;
       state[15] = t;
-      //MixColumns
+      // MixColumns
       for (var j = 0; j < 16; j += 4) {
         var s0 = state[j + 0], s1 = state[j + 1];
         var s2 = state[j + 2], s3 = state[j + 3];
@@ -1370,17 +1370,17 @@ var AES256Cipher = (function AES256CipherClosure() {
         state[j + 2] ^= t ^ mixCol[s2 ^ s3];
         state[j + 3] ^= t ^ mixCol[s3 ^ s0];
       }
-      //AddRoundKey
+      // AddRoundKey
       for (j = 0, k = i * 16; j < 16; ++j, ++k) {
         state[j] ^= key[k];
       }
     }
 
-    //SubBytes
+    // SubBytes
     for (j = 0; j < 16; ++j) {
       state[j] = s[state[j]];
     }
-    //ShiftRows
+    // ShiftRows
     v = state[1];
     state[1] = state[5];
     state[5] = state[9];
@@ -1399,7 +1399,7 @@ var AES256Cipher = (function AES256CipherClosure() {
     state[7] = v;
     state[11] = u;
     state[15] = t;
-    //AddRoundKey
+    // AddRoundKey
     for (j = 0, k = 224; j < 16; ++j, ++k) {
       state[j] ^= key[k];
     }
@@ -1482,8 +1482,7 @@ var AES256Cipher = (function AES256CipherClosure() {
              i < sourceLength; ++i, ++bufferLength) {
           buffer[bufferLength] = data[i];
         }
-        if (bufferLength < 16) {
-          //need more data
+        if (bufferLength < 16) { // Need more data.
           this.bufferLength = bufferLength;
           return new Uint8Array([]);
         }
@@ -1596,7 +1595,7 @@ var PDF17 = (function PDF17Closure() {
       var hashData = new Uint8Array(password.length + 8);
       hashData.set(password, 0);
       hashData.set(userKeySalt, password.length);
-      //key is the decryption key for the UE string
+      // `key` is the decryption key for the UE string.
       var key = calculateSHA256(hashData, 0, hashData.length);
       var cipher = new AES256Cipher(key);
       return cipher.decryptBlock(userEncryption,
@@ -1617,7 +1616,7 @@ var PDF20 = (function PDF20Closure() {
   }
 
   function calculatePDF20Hash(password, input, userBytes) {
-    //This refers to Algorithm 2.B as defined in ISO 32000-2
+    // This refers to Algorithm 2.B as defined in ISO 32000-2.
     var k = calculateSHA256(input, 0, input.length).subarray(0, 32);
     var e = [0];
     var i = 0;
@@ -1630,16 +1629,14 @@ var PDF20 = (function PDF20Closure() {
       for (var j = 0, pos = 0; j < 64; j++, pos += arrayLength) {
         k1.set(array, pos);
       }
-      //AES128 CBC NO PADDING with
-      //first 16 bytes of k as the key and the second 16 as the iv.
+      // AES128 CBC NO PADDING with first 16 bytes of k as the key
+      // and the second 16 as the iv.
       var cipher = new AES128Cipher(k.subarray(0, 16));
       e = cipher.encrypt(k1, k.subarray(16, 32));
-      //Now we have to take the first 16 bytes of an unsigned
-      //big endian integer... and compute the remainder
-      //modulo 3.... That is a fairly large number and
-      //JavaScript isn't going to handle that well...
-      //So we're using a trick that allows us to perform
-      //modulo math byte by byte
+      // Now we have to take the first 16 bytes of an unsigned big endian
+      // integer and compute the remainder modulo 3. That is a fairly large
+      // number and JavaScript isn't going to handle that well, so we're using
+      // a trick that allows us to perform modulo math byte by byte.
       var remainder = 0;
       for (var z = 0; z < 16; z++) {
         remainder *= (256 % 3);
@@ -1716,7 +1713,7 @@ var PDF20 = (function PDF20Closure() {
       var hashData = new Uint8Array(password.length + 8);
       hashData.set(password, 0);
       hashData.set(userKeySalt, password.length);
-      //key is the decryption key for the UE string
+      // `key` is the decryption key for the UE string.
       var key = calculatePDF20Hash(password, hashData, []);
       var cipher = new AES256Cipher(key);
       return cipher.decryptBlock(userEncryption,

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -1369,7 +1369,7 @@ var Font = (function FontClosure() {
         if (tag === 'head') {
           // clearing checksum adjustment
           data[8] = data[9] = data[10] = data[11] = 0;
-          data[17] |= 0x20; //Set font optimized for cleartype flag
+          data[17] |= 0x20; // Set font optimized for cleartype flag.
         }
 
         return {

--- a/src/core/function.js
+++ b/src/core/function.js
@@ -104,7 +104,7 @@ var PDFFunction = (function PDFFunctionClosure() {
           return this.constructInterpolatedFromIR(IR);
         case CONSTRUCT_STICHED:
           return this.constructStichedFromIR(IR);
-        //case CONSTRUCT_POSTSCRIPT:
+        // case CONSTRUCT_POSTSCRIPT:
         default:
           return this.constructPostScriptFromIR(IR);
       }
@@ -207,7 +207,7 @@ var PDFFunction = (function PDFFunctionClosure() {
         var samples = IR[5];
         var size = IR[6];
         var n = IR[7];
-        //var mask = IR[8];
+        // var mask = IR[8];
         var range = IR[9];
 
         // Building the cube vertices: its part and sample index

--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -447,13 +447,13 @@ var Jbig2Image = (function Jbig2ImageClosure() {
           if (numberOfInstances > 1) {
             bitmap = decodeTextRegion(huffman, refinement,
                                       currentWidth, currentHeight, 0,
-                                      numberOfInstances, 1, //strip size
+                                      numberOfInstances, 1, // strip size
                                       symbols.concat(newSymbols),
                                       symbolCodeLength,
-                                      0, //transposed
-                                      0, //ds offset
-                                      1, //top left 7.4.3.1.1
-                                      0, //OR operator
+                                      0, // transposed
+                                      0, // ds offset
+                                      1, // top left 7.4.3.1.1
+                                      0, // OR operator
                                       huffmanTables,
                                       refinementTemplateIndex, refinementAt,
                                       decodingContext);

--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -709,7 +709,7 @@ var JpegImage = (function JpegImageClosure() {
                   z = dctZigZag[j];
                   tableData[z] = data[offset++];
                 }
-              } else if ((quantizationTableSpec >> 4) === 1) { //16 bit
+              } else if ((quantizationTableSpec >> 4) === 1) { // 16 bit values
                 for (j = 0; j < 64; j++) {
                   z = dctZigZag[j];
                   tableData[z] = readUint16();

--- a/src/core/unicode.js
+++ b/src/core/unicode.js
@@ -1627,7 +1627,7 @@
 
   function reverseIfRtl(chars) {
     var charsLength = chars.length;
-    //reverse an arabic ligature
+    // Reverse an arabic ligature.
     if (charsLength <= 1 || !isRTLRangeFor(chars.charCodeAt(0))) {
       return chars;
     }

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1710,10 +1710,10 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       }
       return pattern;
     },
-    setStrokeColorN: function CanvasGraphics_setStrokeColorN(/*...*/) {
+    setStrokeColorN: function CanvasGraphics_setStrokeColorN() {
       this.current.strokeColor = this.getColorN_Pattern(arguments);
     },
-    setFillColorN: function CanvasGraphics_setFillColorN(/*...*/) {
+    setFillColorN: function CanvasGraphics_setFillColorN() {
       this.current.fillColor = this.getColorN_Pattern(arguments);
       this.current.patternFill = true;
     },

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -71,7 +71,7 @@ var CustomStyle = (function CustomStyleClosure() {
       }
     }
 
-    //if all fails then set to undefined
+    // If all fails then set to undefined.
     return (_cache[propName] = 'undefined');
   };
 

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -239,13 +239,13 @@ var createMeshCanvas = (function createMeshCanvasClosure() {
 
 ShadingIRs.Mesh = {
   fromIR: function Mesh_fromIR(raw) {
-    //var type = raw[1];
+    // var type = raw[1];
     var coords = raw[2];
     var colors = raw[3];
     var figures = raw[4];
     var bounds = raw[5];
     var matrix = raw[6];
-    //var bbox = raw[7];
+    // var bbox = raw[7];
     var background = raw[8];
     return {
       type: 'Pattern',

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -961,7 +961,7 @@ var PageViewport = (function PageViewportClosure() {
       case 270:
         rotateA = 0; rotateB = -1; rotateC = -1; rotateD = 0;
         break;
-      //case 0:
+      // case 0:
       default:
         rotateA = 1; rotateB = 0; rotateC = 0; rotateD = -1;
         break;

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -280,7 +280,7 @@ PDFViewerApplication.externalServices = {
   },
 };
 
-//// l10n.js for Firefox extension expects services to be set.
+// l10n.js for Firefox extension expects services to be set.
 document.mozL10n.setExternalLocalizerServices({
   getLocale: function () {
     return FirefoxCom.requestSync('getLocale', null);

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -285,7 +285,7 @@
   window.addEventListener('keydown', function(event) {
     // Intercept Cmd/Ctrl + P in all browsers.
     // Also intercept Cmd/Ctrl + Shift + P in Chrome and Opera
-    if (event.keyCode === 80/*P*/ && (event.ctrlKey || event.metaKey) &&
+    if (event.keyCode === /* P= */ 80 && (event.ctrlKey || event.metaKey) &&
         !event.altKey && (!event.shiftKey || window.chrome || window.opera)) {
       window.print();
       if (hasAttachEvent) {
@@ -305,7 +305,7 @@
   if (hasAttachEvent) {
     document.attachEvent('onkeydown', function(event) {
       event = event || window.event;
-      if (event.keyCode === 80/*P*/ && event.ctrlKey) {
+      if (event.keyCode === /* P= */ 80 && event.ctrlKey) {
         event.keyCode = 0;
         return false;
       }


### PR DESCRIPTION
Please see http://eslint.org/docs/rules/spaced-comment.

Note that the exceptions added for `line` comments are intended to still allow use of the old preprocessor without linting errors.
Also, I took the opportunity to improve the grammar slightly (w.r.t. capitalization and punctuation) for comments touched in the patch.