### PR TITLE
Enable the `no-lone-blocks` ESLint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -53,6 +53,7 @@
     "no-fallthrough": "error",
     "no-global-assign": "error",
     "no-implied-eval": "error",
+    "no-lone-blocks": "error",
     "no-multi-spaces": "error",
     "no-multi-str": "error",
     "no-new-func": "error",


### PR DESCRIPTION
http://eslint.org/docs/rules/no-lone-blocks

Note that we currently have no code that violates this rule in the source files, but it seems that the built files are possibly affected (see issue #7957).