### PR TITLE
[api-minor] Adds noopener and nofollow to rel attribute of hyperlinks.

### DIFF
--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -31,6 +31,8 @@ var warn = sharedUtil.warn;
 var deprecated = sharedUtil.deprecated;
 var createValidAbsoluteUrl = sharedUtil.createValidAbsoluteUrl;
 
+var DEFAULT_LINK_REL = 'noopener noreferrer nofollow';
+
 /**
  * Optimised CSS custom property getter/setter.
  * @class
@@ -210,7 +212,7 @@ function getDefaultSetting(id) {
       globalSettings.externalLinkTarget = LinkTarget.NONE;
       return LinkTarget.NONE;
     case 'externalLinkRel':
-      return globalSettings ? globalSettings.externalLinkRel : 'noreferrer';
+      return globalSettings ? globalSettings.externalLinkRel : DEFAULT_LINK_REL;
     case 'enableStats':
       return !!(globalSettings && globalSettings.enableStats);
     default:
@@ -245,4 +247,5 @@ exports.getFilenameFromUrl = getFilenameFromUrl;
 exports.LinkTarget = LinkTarget;
 exports.hasCanvasTypedArrays = hasCanvasTypedArrays;
 exports.getDefaultSetting = getDefaultSetting;
+exports.DEFAULT_LINK_REL = DEFAULT_LINK_REL;
 }));

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -41,6 +41,7 @@
   var deprecated = sharedUtil.deprecated;
   var warn = sharedUtil.warn;
   var LinkTarget = displayDOMUtils.LinkTarget;
+  var DEFAULT_LINK_REL = displayDOMUtils.DEFAULT_LINK_REL;
 
   var isWorker = (typeof window === 'undefined');
 
@@ -233,7 +234,7 @@
    * @var {string}
    */
   PDFJS.externalLinkRel = (PDFJS.externalLinkRel === undefined ?
-                           'noreferrer' : PDFJS.externalLinkRel);
+                           DEFAULT_LINK_REL : PDFJS.externalLinkRel);
 
   /**
     * Determines if we can eval strings as JS. Primarily used to improve


### PR DESCRIPTION
Fixes #7986 

Based on https://html.spec.whatwg.org/multipage/semantics.html#attr-link-rel : "... the rel attribute, which, if present, must have a value that is a set of space-separated tokens. The allowed keywords and their meanings are defined..." at https://html.spec.whatwg.org/multipage/semantics.html#linkTypes . And we are interested in "noreferrer", "nofollow", and "noopener"