### PR TITLE
[Firefox addon] Stop bundling `src/core/network.js` into the `FIREFOX`/`MOZCENTRAL` builds (PR 7322 follow-up)

### DIFF
--- a/extensions/firefox/content/PdfJsNetwork.jsm
+++ b/extensions/firefox/content/PdfJsNetwork.jsm
@@ -21,7 +21,7 @@ Components.utils.import('resource://gre/modules/Services.jsm');
 var EXPORTED_SYMBOLS = ['NetworkManager'];
 
 function log(aMsg) {
-  var msg = 'network.js: ' + (aMsg.join ? aMsg.join('') : aMsg);
+  var msg = 'PdfJsNetwork.jsm: ' + (aMsg.join ? aMsg.join('') : aMsg);
   Services.console.logStringMessage(msg);
 }
 

--- a/make.js
+++ b/make.js
@@ -605,7 +605,6 @@ target.firefox = function() {
     preprocess: [
       [COMMON_WEB_FILES_PREPROCESS, FIREFOX_BUILD_CONTENT_DIR + '/web'],
       [COMMON_FIREFOX_FILES_PREPROCESS, FIREFOX_BUILD_CONTENT_DIR],
-      [SRC_DIR + 'core/network.js', FIREFOX_BUILD_CONTENT_DIR],
       [FIREFOX_EXTENSION_DIR + 'bootstrap.js', FIREFOX_BUILD_DIR]
     ],
     preprocessCSS: [
@@ -724,7 +723,6 @@ target.mozcentral = function() {
     preprocess: [
       [COMMON_WEB_FILES_PREPROCESS, MOZCENTRAL_CONTENT_DIR + '/web'],
       [FIREFOX_CONTENT_DIR + 'pdfjschildbootstrap.js', MOZCENTRAL_CONTENT_DIR],
-      [SRC_DIR + 'core/network.js', MOZCENTRAL_CONTENT_DIR],
       [COMMON_FIREFOX_FILES_PREPROCESS, MOZCENTRAL_CONTENT_DIR],
       [FIREFOX_CONTENT_DIR + 'PdfJs.jsm', MOZCENTRAL_CONTENT_DIR]
     ],

--- a/src/core/network.js
+++ b/src/core/network.js
@@ -13,9 +13,6 @@
  * limitations under the License.
  */
 
-// NOTE: Be careful what goes in this file, as it is also used from the context
-// of the addon. So using warn/error in here will break the addon.
-
 'use strict';
 
 (function (root, factory) {


### PR DESCRIPTION
PR #7322 added the `PdfJsNetwork.jsm` file, instead of the general `src/core/network.js` file for the Firefox addon. However, `make.js` wasn't updated to actually stop including the now obsolete network file.