### PR TITLE
[Firefox addon] Enforce double quotes, using ESLint, to avoid linting errors in mozilla-central (issue 7957)

### DIFF
--- a/extensions/firefox/.eslintrc
+++ b/extensions/firefox/.eslintrc
@@ -17,6 +17,7 @@
     }],
 
     // Stylistic Issues
+    "quotes": ["error", "double"],
     "space-before-function-paren": ["error", "never"],
 
     // ECMAScript 6

--- a/extensions/firefox/bootstrap.js
+++ b/extensions/firefox/bootstrap.js
@@ -15,10 +15,10 @@
 /* globals Components, Services, dump, XPCOMUtils, PdfStreamConverter,
            APP_SHUTDOWN, PdfjsChromeUtils, PdfjsContentUtils */
 
-'use strict';
+"use strict";
 
-const RESOURCE_NAME = 'pdf.js';
-const EXT_PREFIX = 'extensions.uriloader@pdf.js';
+const RESOURCE_NAME = "pdf.js";
+const EXT_PREFIX = "extensions.uriloader@pdf.js";
 
 const Cc = Components.classes;
 const Ci = Components.interfaces;
@@ -26,8 +26,8 @@ const Cm = Components.manager;
 const Cu = Components.utils;
 const Cr = Components.results;
 
-Cu.import('resource://gre/modules/XPCOMUtils.jsm');
-Cu.import('resource://gre/modules/Services.jsm');
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+Cu.import("resource://gre/modules/Services.jsm");
 
 function getBoolPref(pref, def) {
   try {
@@ -38,31 +38,31 @@ function getBoolPref(pref, def) {
 }
 
 function log(str) {
-  if (!getBoolPref(EXT_PREFIX + '.pdfBugEnabled', false)) {
+  if (!getBoolPref(EXT_PREFIX + ".pdfBugEnabled", false)) {
     return;
   }
-  dump(str + '\n');
+  dump(str + "\n");
 }
 
 function initializeDefaultPreferences() {
   var DEFAULT_PREFERENCES =
 //#include ../../web/default_preferences.json
 //#if false
-    'end of DEFAULT_PREFERENCES';
+    "end of DEFAULT_PREFERENCES";
 //#endif
 
-  var defaultBranch = Services.prefs.getDefaultBranch(EXT_PREFIX + '.');
+  var defaultBranch = Services.prefs.getDefaultBranch(EXT_PREFIX + ".");
   var defaultValue;
   for (var key in DEFAULT_PREFERENCES) {
     defaultValue = DEFAULT_PREFERENCES[key];
     switch (typeof defaultValue) {
-      case 'boolean':
+      case "boolean":
         defaultBranch.setBoolPref(key, defaultValue);
         break;
-      case 'number':
+      case "number":
         defaultBranch.setIntPref(key, defaultValue);
         break;
-      case 'string':
+      case "string":
         defaultBranch.setCharPref(key, defaultValue);
         break;
     }
@@ -126,27 +126,27 @@ var e10sEnabled = false;
 function startup(aData, aReason) {
   // Setup the resource url.
   var ioService = Services.io;
-  var resProt = ioService.getProtocolHandler('resource')
+  var resProt = ioService.getProtocolHandler("resource")
                   .QueryInterface(Ci.nsIResProtocolHandler);
-  var aliasURI = ioService.newURI('content/', 'UTF-8', aData.resourceURI);
+  var aliasURI = ioService.newURI("content/", "UTF-8", aData.resourceURI);
   resProt.setSubstitution(RESOURCE_NAME, aliasURI);
 
   pdfBaseUrl = aData.resourceURI.spec;
 
-  Cu.import(pdfBaseUrl + 'content/PdfjsChromeUtils.jsm');
+  Cu.import(pdfBaseUrl + "content/PdfjsChromeUtils.jsm");
   PdfjsChromeUtils.init();
-  Cu.import(pdfBaseUrl + 'content/PdfjsContentUtils.jsm');
+  Cu.import(pdfBaseUrl + "content/PdfjsContentUtils.jsm");
   PdfjsContentUtils.init();
 
   // Load the component and register it.
-  var pdfStreamConverterUrl = pdfBaseUrl + 'content/PdfStreamConverter.jsm';
+  var pdfStreamConverterUrl = pdfBaseUrl + "content/PdfStreamConverter.jsm";
   Cu.import(pdfStreamConverterUrl);
   pdfStreamConverterFactory.register(PdfStreamConverter);
 
   try {
-    let globalMM = Cc['@mozilla.org/globalmessagemanager;1']
+    let globalMM = Cc["@mozilla.org/globalmessagemanager;1"]
                      .getService(Ci.nsIFrameScriptLoader);
-    globalMM.loadFrameScript('chrome://pdf.js/content/content.js', true);
+    globalMM.loadFrameScript("chrome://pdf.js/content/content.js", true);
     e10sEnabled = true;
   } catch (ex) {
   }
@@ -160,32 +160,32 @@ function shutdown(aData, aReason) {
   }
 
   if (e10sEnabled) {
-    let globalMM = Cc['@mozilla.org/globalmessagemanager;1']
+    let globalMM = Cc["@mozilla.org/globalmessagemanager;1"]
                      .getService(Ci.nsIMessageBroadcaster);
-    globalMM.broadcastAsyncMessage('PDFJS:Child:shutdown');
-    globalMM.removeDelayedFrameScript('chrome://pdf.js/content/content.js');
+    globalMM.broadcastAsyncMessage("PDFJS:Child:shutdown");
+    globalMM.removeDelayedFrameScript("chrome://pdf.js/content/content.js");
   }
 
   var ioService = Services.io;
-  var resProt = ioService.getProtocolHandler('resource')
+  var resProt = ioService.getProtocolHandler("resource")
                   .QueryInterface(Ci.nsIResProtocolHandler);
   // Remove the resource url.
   resProt.setSubstitution(RESOURCE_NAME, null);
   // Remove the contract/component.
   pdfStreamConverterFactory.unregister();
   // Unload the converter
-  var pdfStreamConverterUrl = pdfBaseUrl + 'content/PdfStreamConverter.jsm';
+  var pdfStreamConverterUrl = pdfBaseUrl + "content/PdfStreamConverter.jsm";
   Cu.unload(pdfStreamConverterUrl);
 
   PdfjsContentUtils.uninit();
-  Cu.unload(pdfBaseUrl + 'content/PdfjsContentUtils.jsm');
+  Cu.unload(pdfBaseUrl + "content/PdfjsContentUtils.jsm");
   PdfjsChromeUtils.uninit();
-  Cu.unload(pdfBaseUrl + 'content/PdfjsChromeUtils.jsm');
+  Cu.unload(pdfBaseUrl + "content/PdfjsChromeUtils.jsm");
 }
 
 function install(aData, aReason) {
   // TODO remove after some time -- cleanup of unused preferences
-  Services.prefs.clearUserPref(EXT_PREFIX + '.database');
+  Services.prefs.clearUserPref(EXT_PREFIX + ".database");
 }
 
 function uninstall(aData, aReason) {

--- a/extensions/firefox/chrome/content.js
+++ b/extensions/firefox/chrome/content.js
@@ -15,7 +15,7 @@
 /* globals Components, Services, XPCOMUtils, PdfjsContentUtils,
            PdfjsContentUtils, PdfStreamConverter, addMessageListener */
 
-'use strict';
+"use strict";
 
 (function contentScriptClosure() {
   // we need to use closure here -- we are running in the global context
@@ -26,8 +26,8 @@
   const Cu = Components.utils;
   const Cr = Components.results;
 
-  Cu.import('resource://gre/modules/XPCOMUtils.jsm');
-  Cu.import('resource://gre/modules/Services.jsm');
+  Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+  Cu.import("resource://gre/modules/Services.jsm");
 
   var isRemote = Services.appinfo.processType ===
     Services.appinfo.PROCESS_TYPE_CONTENT;
@@ -73,10 +73,10 @@
   var pdfStreamConverterFactory = new Factory();
 
   function startup() {
-    Cu.import('resource://pdf.js/PdfjsContentUtils.jsm');
+    Cu.import("resource://pdf.js/PdfjsContentUtils.jsm");
     PdfjsContentUtils.init();
 
-    Cu.import('resource://pdf.js/PdfStreamConverter.jsm');
+    Cu.import("resource://pdf.js/PdfStreamConverter.jsm");
     pdfStreamConverterFactory.register(PdfStreamConverter);
   }
 
@@ -84,16 +84,16 @@
     // Remove the contract/component.
     pdfStreamConverterFactory.unregister();
     // Unload the converter
-    Cu.unload('resource://pdf.js/PdfStreamConverter.jsm');
+    Cu.unload("resource://pdf.js/PdfStreamConverter.jsm");
 
     PdfjsContentUtils.uninit();
-    Cu.unload('resource://pdf.js/PdfjsContentUtils.jsm');
+    Cu.unload("resource://pdf.js/PdfjsContentUtils.jsm");
   }
 
   if (isRemote) {
     startup();
 
-    addMessageListener('PDFJS:Child:shutdown', function() {
+    addMessageListener("PDFJS:Child:shutdown", function() {
       shutdown();
     });
   }

--- a/extensions/firefox/content/PdfJs-stub.jsm
+++ b/extensions/firefox/content/PdfJs-stub.jsm
@@ -14,12 +14,12 @@
  */
 /* eslint max-len: ["error", 100] */
 
-'use strict';
+"use strict";
 
 // Don't remove this file!
 // FF15+ expects `PdfJs` module to be present at `resource://pdf.js/PdfJs.jsm`,
 // see https://dxr.mozilla.org/mozilla-central/source/browser/components/nsBrowserGlue.js
-var EXPORTED_SYMBOLS = ['PdfJs'];
+var EXPORTED_SYMBOLS = ["PdfJs"];
 
 var PdfJs = {
   init: function PdfJs_init() {}

--- a/extensions/firefox/content/PdfJs.jsm
+++ b/extensions/firefox/content/PdfJs.jsm
@@ -15,9 +15,9 @@
 /* globals Components, Services, XPCOMUtils, PdfjsChromeUtils,
            PdfjsContentUtils, PdfStreamConverter */
 
-'use strict';
+"use strict";
 
-var EXPORTED_SYMBOLS = ['PdfJs'];
+var EXPORTED_SYMBOLS = ["PdfJs"];
 
 const Cc = Components.classes;
 const Ci = Components.interfaces;
@@ -25,32 +25,32 @@ const Cr = Components.results;
 const Cm = Components.manager;
 const Cu = Components.utils;
 
-const PREF_PREFIX = 'pdfjs';
-const PREF_DISABLED = PREF_PREFIX + '.disabled';
-const PREF_MIGRATION_VERSION = PREF_PREFIX + '.migrationVersion';
-const PREF_PREVIOUS_ACTION = PREF_PREFIX + '.previousHandler.preferredAction';
+const PREF_PREFIX = "pdfjs";
+const PREF_DISABLED = PREF_PREFIX + ".disabled";
+const PREF_MIGRATION_VERSION = PREF_PREFIX + ".migrationVersion";
+const PREF_PREVIOUS_ACTION = PREF_PREFIX + ".previousHandler.preferredAction";
 const PREF_PREVIOUS_ASK = PREF_PREFIX +
-                          '.previousHandler.alwaysAskBeforeHandling';
-const PREF_DISABLED_PLUGIN_TYPES = 'plugin.disable_full_page_plugin_for_types';
-const TOPIC_PDFJS_HANDLER_CHANGED = 'pdfjs:handlerChanged';
-const TOPIC_PLUGINS_LIST_UPDATED = 'plugins-list-updated';
-const TOPIC_PLUGIN_INFO_UPDATED = 'plugin-info-updated';
-const PDF_CONTENT_TYPE = 'application/pdf';
+                          ".previousHandler.alwaysAskBeforeHandling";
+const PREF_DISABLED_PLUGIN_TYPES = "plugin.disable_full_page_plugin_for_types";
+const TOPIC_PDFJS_HANDLER_CHANGED = "pdfjs:handlerChanged";
+const TOPIC_PLUGINS_LIST_UPDATED = "plugins-list-updated";
+const TOPIC_PLUGIN_INFO_UPDATED = "plugin-info-updated";
+const PDF_CONTENT_TYPE = "application/pdf";
 
-Cu.import('resource://gre/modules/XPCOMUtils.jsm');
-Cu.import('resource://gre/modules/Services.jsm');
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+Cu.import("resource://gre/modules/Services.jsm");
 
 var Svc = {};
-XPCOMUtils.defineLazyServiceGetter(Svc, 'mime',
-                                   '@mozilla.org/mime;1',
-                                   'nsIMIMEService');
-XPCOMUtils.defineLazyServiceGetter(Svc, 'pluginHost',
-                                   '@mozilla.org/plugin/host;1',
-                                   'nsIPluginHost');
-XPCOMUtils.defineLazyModuleGetter(this, 'PdfjsChromeUtils',
-                                  'resource://pdf.js/PdfjsChromeUtils.jsm');
-XPCOMUtils.defineLazyModuleGetter(this, 'PdfjsContentUtils',
-                                  'resource://pdf.js/PdfjsContentUtils.jsm');
+XPCOMUtils.defineLazyServiceGetter(Svc, "mime",
+                                   "@mozilla.org/mime;1",
+                                   "nsIMIMEService");
+XPCOMUtils.defineLazyServiceGetter(Svc, "pluginHost",
+                                   "@mozilla.org/plugin/host;1",
+                                   "nsIPluginHost");
+XPCOMUtils.defineLazyModuleGetter(this, "PdfjsChromeUtils",
+                                  "resource://pdf.js/PdfjsChromeUtils.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "PdfjsContentUtils",
+                                  "resource://pdf.js/PdfjsContentUtils.jsm");
 
 function getBoolPref(aPref, aDefaultValue) {
   try {
@@ -79,21 +79,21 @@ function initializeDefaultPreferences() {
   var DEFAULT_PREFERENCES =
 //#include ../../../web/default_preferences.json
 //#if false
-    'end of DEFAULT_PREFERENCES';
+    "end of DEFAULT_PREFERENCES";
 //#endif
 
-  var defaultBranch = Services.prefs.getDefaultBranch(PREF_PREFIX + '.');
+  var defaultBranch = Services.prefs.getDefaultBranch(PREF_PREFIX + ".");
   var defaultValue;
   for (var key in DEFAULT_PREFERENCES) {
     defaultValue = DEFAULT_PREFERENCES[key];
     switch (typeof defaultValue) {
-      case 'boolean':
+      case "boolean":
         defaultBranch.setBoolPref(key, defaultValue);
         break;
-      case 'number':
+      case "number":
         defaultBranch.setIntPref(key, defaultValue);
         break;
-      case 'string':
+      case "string":
         defaultBranch.setCharPref(key, defaultValue);
         break;
     }
@@ -139,8 +139,8 @@ var PdfJs = {
   init: function init(remote) {
     if (Services.appinfo.processType !==
         Services.appinfo.PROCESS_TYPE_DEFAULT) {
-      throw new Error('PdfJs.init should only get called ' +
-                      'in the parent process.');
+      throw new Error("PdfJs.init should only get called " +
+                      "in the parent process.");
     }
     PdfjsChromeUtils.init();
     if (!remote) {
@@ -203,13 +203,13 @@ var PdfJs = {
     }
     if (currentVersion < 2) {
       // cleaning up of unused database preference (see #3994)
-      Services.prefs.clearUserPref(PREF_PREFIX + '.database');
+      Services.prefs.clearUserPref(PREF_PREFIX + ".database");
     }
     Services.prefs.setIntPref(PREF_MIGRATION_VERSION, VERSION);
   },
 
   _becomeHandler: function _becomeHandler() {
-    let handlerInfo = Svc.mime.getFromTypeAndExtension(PDF_CONTENT_TYPE, 'pdf');
+    let handlerInfo = Svc.mime.getFromTypeAndExtension(PDF_CONTENT_TYPE, "pdf");
     let prefs = Services.prefs;
     if (handlerInfo.preferredAction !== Ci.nsIHandlerInfo.handleInternally &&
         handlerInfo.preferredAction !== false) {
@@ -220,7 +220,7 @@ var PdfJs = {
       prefs.setBoolPref(PREF_PREVIOUS_ASK, handlerInfo.alwaysAskBeforeHandling);
     }
 
-    let handlerService = Cc['@mozilla.org/uriloader/handler-service;1'].
+    let handlerService = Cc["@mozilla.org/uriloader/handler-service;1"].
                          getService(Ci.nsIHandlerService);
 
     // Change and save mime handler settings.
@@ -229,24 +229,24 @@ var PdfJs = {
     handlerService.store(handlerInfo);
 
     // Also disable any plugins for pdfs.
-    var stringTypes = '';
+    var stringTypes = "";
     var types = [];
     if (prefs.prefHasUserValue(PREF_DISABLED_PLUGIN_TYPES)) {
       stringTypes = prefs.getCharPref(PREF_DISABLED_PLUGIN_TYPES);
     }
-    if (stringTypes !== '') {
-      types = stringTypes.split(',');
+    if (stringTypes !== "") {
+      types = stringTypes.split(",");
     }
 
     if (types.indexOf(PDF_CONTENT_TYPE) === -1) {
       types.push(PDF_CONTENT_TYPE);
     }
-    prefs.setCharPref(PREF_DISABLED_PLUGIN_TYPES, types.join(','));
+    prefs.setCharPref(PREF_DISABLED_PLUGIN_TYPES, types.join(","));
 
     // Update the category manager in case the plugins are already loaded.
-    let categoryManager = Cc['@mozilla.org/categorymanager;1'];
+    let categoryManager = Cc["@mozilla.org/categorymanager;1"];
     categoryManager.getService(Ci.nsICategoryManager).
-                    deleteCategoryEntry('Gecko-Content-Viewers',
+                    deleteCategoryEntry("Gecko-Content-Viewers",
                                         PDF_CONTENT_TYPE,
                                         false);
   },
@@ -256,7 +256,7 @@ var PdfJs = {
     this.updateRegistration();
     if (Services.appinfo.processType ===
         Services.appinfo.PROCESS_TYPE_DEFAULT) {
-      let jsm = 'resource://pdf.js/PdfjsChromeUtils.jsm';
+      let jsm = "resource://pdf.js/PdfjsChromeUtils.jsm";
       let PdfjsChromeUtils = Components.utils.import(jsm, {}).PdfjsChromeUtils;
       PdfjsChromeUtils.notifyChildOfSettingsChange();
     }
@@ -281,7 +281,7 @@ var PdfJs = {
     // Check if we have disabled plugin handling of 'application/pdf' in prefs
     if (Services.prefs.prefHasUserValue(PREF_DISABLED_PLUGIN_TYPES)) {
       let disabledPluginTypes =
-        Services.prefs.getCharPref(PREF_DISABLED_PLUGIN_TYPES).split(',');
+        Services.prefs.getCharPref(PREF_DISABLED_PLUGIN_TYPES).split(",");
       if (disabledPluginTypes.indexOf(PDF_CONTENT_TYPE) >= 0) {
         return true;
       }
@@ -290,7 +290,7 @@ var PdfJs = {
     // Check if there is an enabled pdf plugin.
     // Note: this check is performed last because getPluginTags() triggers
     // costly plugin list initialization (bug 881575)
-    let tags = Cc['@mozilla.org/plugin/host;1'].
+    let tags = Cc["@mozilla.org/plugin/host;1"].
                   getService(Ci.nsIPluginHost).
                   getPluginTags();
     let enabledPluginFound = tags.some(function(tag) {
@@ -312,7 +312,7 @@ var PdfJs = {
       return;
     }
     this._pdfStreamConverterFactory = new Factory();
-    Cu.import('resource://pdf.js/PdfStreamConverter.jsm');
+    Cu.import("resource://pdf.js/PdfStreamConverter.jsm");
     this._pdfStreamConverterFactory.register(PdfStreamConverter);
 
     this._registered = true;
@@ -323,7 +323,7 @@ var PdfJs = {
       return;
     }
     this._pdfStreamConverterFactory.unregister();
-    Cu.unload('resource://pdf.js/PdfStreamConverter.jsm');
+    Cu.unload("resource://pdf.js/PdfStreamConverter.jsm");
     delete this._pdfStreamConverterFactory;
 
     this._registered = false;

--- a/extensions/firefox/content/PdfJsNetwork.jsm
+++ b/extensions/firefox/content/PdfJsNetwork.jsm
@@ -14,14 +14,14 @@
  */
 /* globals Components, Services */
 
-'use strict';
+"use strict";
 
-Components.utils.import('resource://gre/modules/Services.jsm');
+Components.utils.import("resource://gre/modules/Services.jsm");
 
-var EXPORTED_SYMBOLS = ['NetworkManager'];
+var EXPORTED_SYMBOLS = ["NetworkManager"];
 
 function log(aMsg) {
-  var msg = 'PdfJsNetwork.jsm: ' + (aMsg.join ? aMsg.join('') : aMsg);
+  var msg = "PdfJsNetwork.jsm: " + (aMsg.join ? aMsg.join("") : aMsg);
   Services.console.logStringMessage(msg);
 }
 
@@ -32,7 +32,7 @@ var NetworkManager = (function NetworkManagerClosure() {
 
   function getArrayBuffer(xhr) {
     var data = xhr.response;
-    if (typeof data !== 'string') {
+    if (typeof data !== "string") {
       return data;
     }
     var length = data.length;
@@ -82,18 +82,18 @@ var NetworkManager = (function NetworkManagerClosure() {
         xhr,
       };
 
-      xhr.open('GET', this.url);
+      xhr.open("GET", this.url);
       xhr.withCredentials = this.withCredentials;
       for (var property in this.httpHeaders) {
         var value = this.httpHeaders[property];
-        if (typeof value === 'undefined') {
+        if (typeof value === "undefined") {
           continue;
         }
         xhr.setRequestHeader(property, value);
       }
-      if (this.isHttp && 'begin' in args && 'end' in args) {
-        var rangeStr = args.begin + '-' + (args.end - 1);
-        xhr.setRequestHeader('Range', 'bytes=' + rangeStr);
+      if (this.isHttp && "begin" in args && "end" in args) {
+        var rangeStr = args.begin + "-" + (args.end - 1);
+        xhr.setRequestHeader("Range", "bytes=" + rangeStr);
         pendingRequest.expectedStatus = 206;
       } else {
         pendingRequest.expectedStatus = 200;
@@ -101,11 +101,11 @@ var NetworkManager = (function NetworkManagerClosure() {
 
       var useMozChunkedLoading = !!args.onProgressiveData;
       if (useMozChunkedLoading) {
-        xhr.responseType = 'moz-chunked-arraybuffer';
+        xhr.responseType = "moz-chunked-arraybuffer";
         pendingRequest.onProgressiveData = args.onProgressiveData;
         pendingRequest.mozChunked = true;
       } else {
-        xhr.responseType = 'arraybuffer';
+        xhr.responseType = "arraybuffer";
       }
 
       if (args.onError) {
@@ -197,7 +197,7 @@ var NetworkManager = (function NetworkManagerClosure() {
 
       var chunk = getArrayBuffer(xhr);
       if (xhrStatus === PARTIAL_CONTENT_RESPONSE) {
-        var rangeHeader = xhr.getResponseHeader('Content-Range');
+        var rangeHeader = xhr.getResponseHeader("Content-Range");
         var matches = /bytes (\d+)-(\d+)\/(\d+)/.exec(rangeHeader);
         var begin = parseInt(matches[1], 10);
         pendingRequest.onDone({

--- a/extensions/firefox/content/PdfJsTelemetry-addon.jsm
+++ b/extensions/firefox/content/PdfJsTelemetry-addon.jsm
@@ -15,74 +15,74 @@
 /* eslint max-len: ["error", 120] */
 /* globals Components, Services */
 
-'use strict';
+"use strict";
 
-this.EXPORTED_SYMBOLS = ['PdfJsTelemetry'];
+this.EXPORTED_SYMBOLS = ["PdfJsTelemetry"];
 
 const Cu = Components.utils;
-Cu.import('resource://gre/modules/Services.jsm');
+Cu.import("resource://gre/modules/Services.jsm");
 
-const ADDON_ID = 'uriloader@pdf.js';
+const ADDON_ID = "uriloader@pdf.js";
 
 var Telemetry = Services.telemetry;
 var registerAddonHistogram = Telemetry.registerAddonHistogram;
 
-registerAddonHistogram(ADDON_ID, 'PDF_VIEWER_USED', Telemetry.HISTOGRAM_BOOLEAN, 1, 2, 3);
-registerAddonHistogram(ADDON_ID, 'PDF_VIEWER_FALLBACK_SHOWN', Telemetry.HISTOGRAM_BOOLEAN, 1, 2, 3);
-registerAddonHistogram(ADDON_ID, 'PDF_VIEWER_DOCUMENT_VERSION', Telemetry.HISTOGRAM_LINEAR, 1, 10, 11);
-registerAddonHistogram(ADDON_ID, 'PDF_VIEWER_DOCUMENT_GENERATOR', Telemetry.HISTOGRAM_LINEAR, 1, 25, 26);
-registerAddonHistogram(ADDON_ID, 'PDF_VIEWER_DOCUMENT_SIZE_KB', Telemetry.HISTOGRAM_EXPONENTIAL, 2, 64 * 1024, 20);
-registerAddonHistogram(ADDON_ID, 'PDF_VIEWER_EMBED', Telemetry.HISTOGRAM_BOOLEAN, 1, 2, 3);
-registerAddonHistogram(ADDON_ID, 'PDF_VIEWER_FONT_TYPES', Telemetry.HISTOGRAM_LINEAR, 1, 19, 20);
-registerAddonHistogram(ADDON_ID, 'PDF_VIEWER_FORM', Telemetry.HISTOGRAM_BOOLEAN, 1, 2, 3);
-registerAddonHistogram(ADDON_ID, 'PDF_VIEWER_PRINT', Telemetry.HISTOGRAM_BOOLEAN, 1, 2, 3);
-registerAddonHistogram(ADDON_ID, 'PDF_VIEWER_STREAM_TYPES', Telemetry.HISTOGRAM_LINEAR, 1, 19, 20);
-registerAddonHistogram(ADDON_ID, 'PDF_VIEWER_TIME_TO_VIEW_MS', Telemetry.HISTOGRAM_EXPONENTIAL, 1, 10000, 50);
+registerAddonHistogram(ADDON_ID, "PDF_VIEWER_USED", Telemetry.HISTOGRAM_BOOLEAN, 1, 2, 3);
+registerAddonHistogram(ADDON_ID, "PDF_VIEWER_FALLBACK_SHOWN", Telemetry.HISTOGRAM_BOOLEAN, 1, 2, 3);
+registerAddonHistogram(ADDON_ID, "PDF_VIEWER_DOCUMENT_VERSION", Telemetry.HISTOGRAM_LINEAR, 1, 10, 11);
+registerAddonHistogram(ADDON_ID, "PDF_VIEWER_DOCUMENT_GENERATOR", Telemetry.HISTOGRAM_LINEAR, 1, 25, 26);
+registerAddonHistogram(ADDON_ID, "PDF_VIEWER_DOCUMENT_SIZE_KB", Telemetry.HISTOGRAM_EXPONENTIAL, 2, 64 * 1024, 20);
+registerAddonHistogram(ADDON_ID, "PDF_VIEWER_EMBED", Telemetry.HISTOGRAM_BOOLEAN, 1, 2, 3);
+registerAddonHistogram(ADDON_ID, "PDF_VIEWER_FONT_TYPES", Telemetry.HISTOGRAM_LINEAR, 1, 19, 20);
+registerAddonHistogram(ADDON_ID, "PDF_VIEWER_FORM", Telemetry.HISTOGRAM_BOOLEAN, 1, 2, 3);
+registerAddonHistogram(ADDON_ID, "PDF_VIEWER_PRINT", Telemetry.HISTOGRAM_BOOLEAN, 1, 2, 3);
+registerAddonHistogram(ADDON_ID, "PDF_VIEWER_STREAM_TYPES", Telemetry.HISTOGRAM_LINEAR, 1, 19, 20);
+registerAddonHistogram(ADDON_ID, "PDF_VIEWER_TIME_TO_VIEW_MS", Telemetry.HISTOGRAM_EXPONENTIAL, 1, 10000, 50);
 
 
 this.PdfJsTelemetry = {
   onViewerIsUsed() {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_USED');
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_USED");
     histogram.add(true);
   },
   onFallback() {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_FALLBACK_SHOWN');
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_FALLBACK_SHOWN");
     histogram.add(true);
   },
   onDocumentSize(size) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_DOCUMENT_SIZE_KB');
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_DOCUMENT_SIZE_KB");
     histogram.add(size / 1024);
   },
   onDocumentVersion(versionId) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_DOCUMENT_VERSION');
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_DOCUMENT_VERSION");
     histogram.add(versionId);
   },
   onDocumentGenerator(generatorId) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_DOCUMENT_GENERATOR');
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_DOCUMENT_GENERATOR");
     histogram.add(generatorId);
   },
   onEmbed(isObject) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_EMBED');
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_EMBED");
     histogram.add(isObject);
   },
   onFontType(fontTypeId) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_FONT_TYPES');
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_FONT_TYPES");
     histogram.add(fontTypeId);
   },
   onForm(isAcroform) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_FORM');
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_FORM");
     histogram.add(isAcroform);
   },
   onPrint() {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_PRINT');
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_PRINT");
     histogram.add(true);
   },
   onStreamType(streamTypeId) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_STREAM_TYPES');
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_STREAM_TYPES");
     histogram.add(streamTypeId);
   },
   onTimeToView(ms) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, 'PDF_VIEWER_TIME_TO_VIEW_MS');
+    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_TIME_TO_VIEW_MS");
     histogram.add(ms);
   }
 };

--- a/extensions/firefox/content/PdfJsTelemetry.jsm
+++ b/extensions/firefox/content/PdfJsTelemetry.jsm
@@ -15,56 +15,56 @@
 /* eslint max-len: ["error", 100] */
 /* globals Components, Services */
 
-'use strict';
+"use strict";
 
-this.EXPORTED_SYMBOLS = ['PdfJsTelemetry'];
+this.EXPORTED_SYMBOLS = ["PdfJsTelemetry"];
 
 const Cu = Components.utils;
-Cu.import('resource://gre/modules/Services.jsm');
+Cu.import("resource://gre/modules/Services.jsm");
 
 this.PdfJsTelemetry = {
   onViewerIsUsed() {
-    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_USED');
+    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_USED");
     histogram.add(true);
   },
   onFallback() {
-    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_FALLBACK_SHOWN');
+    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_FALLBACK_SHOWN");
     histogram.add(true);
   },
   onDocumentSize(size) {
-    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_DOCUMENT_SIZE_KB');
+    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_DOCUMENT_SIZE_KB");
     histogram.add(size / 1024);
   },
   onDocumentVersion(versionId) {
-    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_DOCUMENT_VERSION');
+    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_DOCUMENT_VERSION");
     histogram.add(versionId);
   },
   onDocumentGenerator(generatorId) {
-    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_DOCUMENT_GENERATOR');
+    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_DOCUMENT_GENERATOR");
     histogram.add(generatorId);
   },
   onEmbed(isObject) {
-    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_EMBED');
+    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_EMBED");
     histogram.add(isObject);
   },
   onFontType(fontTypeId) {
-    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_FONT_TYPES');
+    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_FONT_TYPES");
     histogram.add(fontTypeId);
   },
   onForm(isAcroform) {
-    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_FORM');
+    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_FORM");
     histogram.add(isAcroform);
   },
   onPrint() {
-    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_PRINT');
+    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_PRINT");
     histogram.add(true);
   },
   onStreamType(streamTypeId) {
-    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_STREAM_TYPES');
+    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_STREAM_TYPES");
     histogram.add(streamTypeId);
   },
   onTimeToView(ms) {
-    let histogram = Services.telemetry.getHistogramById('PDF_VIEWER_TIME_TO_VIEW_MS');
+    let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_TIME_TO_VIEW_MS");
     histogram.add(ms);
   }
 };

--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -15,43 +15,43 @@
 /* globals Components, Services, XPCOMUtils, NetUtil, PrivateBrowsingUtils,
            dump, NetworkManager, PdfJsTelemetry, PdfjsContentUtils */
 
-'use strict';
+"use strict";
 
-var EXPORTED_SYMBOLS = ['PdfStreamConverter'];
+var EXPORTED_SYMBOLS = ["PdfStreamConverter"];
 
 const Cc = Components.classes;
 const Ci = Components.interfaces;
 const Cr = Components.results;
 const Cu = Components.utils;
 // True only if this is the version of pdf.js that is included with firefox.
-const MOZ_CENTRAL = JSON.parse('PDFJSSCRIPT_MOZ_CENTRAL');
-const PDFJS_EVENT_ID = 'pdf.js.message';
-const PDF_CONTENT_TYPE = 'application/pdf';
-const PREF_PREFIX = 'PDFJSSCRIPT_PREF_PREFIX';
-const PDF_VIEWER_WEB_PAGE = 'resource://pdf.js/web/viewer.html';
+const MOZ_CENTRAL = JSON.parse("PDFJSSCRIPT_MOZ_CENTRAL");
+const PDFJS_EVENT_ID = "pdf.js.message";
+const PDF_CONTENT_TYPE = "application/pdf";
+const PREF_PREFIX = "PDFJSSCRIPT_PREF_PREFIX";
+const PDF_VIEWER_WEB_PAGE = "resource://pdf.js/web/viewer.html";
 const MAX_NUMBER_OF_PREFS = 50;
 const MAX_STRING_PREF_LENGTH = 128;
 
-Cu.import('resource://gre/modules/XPCOMUtils.jsm');
-Cu.import('resource://gre/modules/Services.jsm');
-Cu.import('resource://gre/modules/NetUtil.jsm');
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+Cu.import("resource://gre/modules/Services.jsm");
+Cu.import("resource://gre/modules/NetUtil.jsm");
 
-XPCOMUtils.defineLazyModuleGetter(this, 'NetworkManager',
-  'resource://pdf.js/PdfJsNetwork.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, "NetworkManager",
+  "resource://pdf.js/PdfJsNetwork.jsm");
 
-XPCOMUtils.defineLazyModuleGetter(this, 'PrivateBrowsingUtils',
-  'resource://gre/modules/PrivateBrowsingUtils.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, "PrivateBrowsingUtils",
+  "resource://gre/modules/PrivateBrowsingUtils.jsm");
 
-XPCOMUtils.defineLazyModuleGetter(this, 'PdfJsTelemetry',
-  'resource://pdf.js/PdfJsTelemetry.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, "PdfJsTelemetry",
+  "resource://pdf.js/PdfJsTelemetry.jsm");
 
-XPCOMUtils.defineLazyModuleGetter(this, 'PdfjsContentUtils',
-  'resource://pdf.js/PdfjsContentUtils.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, "PdfjsContentUtils",
+  "resource://pdf.js/PdfjsContentUtils.jsm");
 
 var Svc = {};
-XPCOMUtils.defineLazyServiceGetter(Svc, 'mime',
-                                   '@mozilla.org/mime;1',
-                                   'nsIMIMEService');
+XPCOMUtils.defineLazyServiceGetter(Svc, "mime",
+                                   "@mozilla.org/mime;1",
+                                   "nsIMIMEService");
 
 function getContainingBrowser(domWindow) {
   return domWindow.QueryInterface(Ci.nsIInterfaceRequestor)
@@ -62,7 +62,7 @@ function getContainingBrowser(domWindow) {
 
 function getFindBar(domWindow) {
   if (PdfjsContentUtils.isRemote) {
-    throw new Error('FindBar is not accessible from the content process.');
+    throw new Error("FindBar is not accessible from the content process.");
   }
   try {
     var browser = getContainingBrowser(domWindow);
@@ -101,12 +101,12 @@ function getStringPref(pref, def) {
 }
 
 function log(aMsg) {
-  if (!getBoolPref(PREF_PREFIX + '.pdfBugEnabled', false)) {
+  if (!getBoolPref(PREF_PREFIX + ".pdfBugEnabled", false)) {
     return;
   }
-  var msg = 'PdfStreamConverter.js: ' + (aMsg.join ? aMsg.join('') : aMsg);
+  var msg = "PdfStreamConverter.js: " + (aMsg.join ? aMsg.join("") : aMsg);
   Services.console.logStringMessage(msg);
-  dump(msg + '\n');
+  dump(msg + "\n");
 }
 
 function getDOMWindow(aChannel) {
@@ -118,16 +118,16 @@ function getDOMWindow(aChannel) {
 }
 
 function getLocalizedStrings(path) {
-  var stringBundle = Cc['@mozilla.org/intl/stringbundle;1'].
+  var stringBundle = Cc["@mozilla.org/intl/stringbundle;1"].
       getService(Ci.nsIStringBundleService).
-      createBundle('chrome://pdf.js/locale/' + path);
+      createBundle("chrome://pdf.js/locale/" + path);
 
   var map = {};
   var enumerator = stringBundle.getSimpleEnumeration();
   while (enumerator.hasMoreElements()) {
     var string = enumerator.getNext().QueryInterface(Ci.nsIPropertyElement);
-    var key = string.key, property = 'textContent';
-    var i = key.lastIndexOf('.');
+    var key = string.key, property = "textContent";
+    var i = key.lastIndexOf(".");
     if (i >= 0) {
       property = key.substring(i + 1);
       key = key.substring(0, i);
@@ -140,7 +140,7 @@ function getLocalizedStrings(path) {
   return map;
 }
 function getLocalizedString(strings, id, property) {
-  property = property || 'textContent';
+  property = property || "textContent";
   if (id in strings) {
     return strings[id][property];
   }
@@ -233,13 +233,13 @@ class ChromeActions {
     // the original url.
     var originalUri = NetUtil.newURI(originalUrl);
     var filename = data.filename;
-    if (typeof filename !== 'string' ||
+    if (typeof filename !== "string" ||
         (!/\.pdf$/i.test(filename) && !data.isAttachment)) {
-      filename = 'document.pdf';
+      filename = "document.pdf";
     }
     var blobUri = NetUtil.newURI(blobUrl);
     var extHelperAppSvc =
-          Cc['@mozilla.org/uriloader/external-helper-app-service;1'].
+          Cc["@mozilla.org/uriloader/external-helper-app-service;1"].
              getService(Ci.nsIExternalHelperAppService);
 
     var docIsPrivate = this.isInPrivateBrowsing();
@@ -247,7 +247,7 @@ class ChromeActions {
       uri: blobUri,
       loadUsingSystemPrincipal: true,
     });
-    if ('nsIPrivateBrowsingChannel' in Ci &&
+    if ("nsIPrivateBrowsingChannel" in Ci &&
         netChannel instanceof Ci.nsIPrivateBrowsingChannel) {
       netChannel.setPrivate(docIsPrivate);
     }
@@ -260,7 +260,7 @@ class ChromeActions {
       }
       // Create a nsIInputStreamChannel so we can set the url on the channel
       // so the filename will be correct.
-      var channel = Cc['@mozilla.org/network/input-stream-channel;1'].
+      var channel = Cc["@mozilla.org/network/input-stream-channel;1"].
                        createInstance(Ci.nsIInputStreamChannel);
       channel.QueryInterface(Ci.nsIChannel);
       try {
@@ -275,7 +275,7 @@ class ChromeActions {
       channel.setURI(originalUri);
       channel.loadInfo = netChannel.loadInfo;
       channel.contentStream = aInputStream;
-      if ('nsIPrivateBrowsingChannel' in Ci &&
+      if ("nsIPrivateBrowsingChannel" in Ci &&
           channel instanceof Ci.nsIPrivateBrowsingChannel) {
         channel.setPrivate(docIsPrivate);
       }
@@ -288,8 +288,8 @@ class ChromeActions {
                                 .getInterface(Ci.nsIWebNavigation)
                                 .QueryInterface(Ci.nsILoadContext);
           this.extListener = extHelperAppSvc.doContent(
-            (data.isAttachment ? 'application/octet-stream' :
-                                 'application/pdf'),
+            (data.isAttachment ? "application/octet-stream" :
+                                 "application/pdf"),
             aRequest, loadContext, false);
           this.extListener.onStartRequest(aRequest, aContext);
         },
@@ -313,20 +313,20 @@ class ChromeActions {
   }
 
   getLocale() {
-    return getStringPref('general.useragent.locale', 'en-US');
+    return getStringPref("general.useragent.locale", "en-US");
   }
 
   getStrings(data) {
     try {
       // Lazy initialization of localizedStrings
-      if (!('localizedStrings' in this)) {
-        this.localizedStrings = getLocalizedStrings('viewer.properties');
+      if (!("localizedStrings" in this)) {
+        this.localizedStrings = getLocalizedStrings("viewer.properties");
       }
       var result = this.localizedStrings[data];
       return JSON.stringify(result || null);
     } catch (e) {
-      log('Unable to retrieve localized strings: ' + e);
-      return 'null';
+      log("Unable to retrieve localized strings: " + e);
+      return "null";
     }
   }
 
@@ -343,52 +343,52 @@ class ChromeActions {
 
     // ... or when the new find events code exists.
     var findBar = getFindBar(this.domWindow);
-    return !!findBar && ('updateControlState' in findBar);
+    return !!findBar && ("updateControlState" in findBar);
   }
 
   supportsDocumentFonts() {
-    var prefBrowser = getIntPref('browser.display.use_document_fonts', 1);
-    var prefGfx = getBoolPref('gfx.downloadable_fonts.enabled', true);
+    var prefBrowser = getIntPref("browser.display.use_document_fonts", 1);
+    var prefGfx = getBoolPref("gfx.downloadable_fonts.enabled", true);
     return (!!prefBrowser && prefGfx);
   }
 
   supportsDocumentColors() {
-    return getIntPref('browser.display.document_color_use', 0) !== 2;
+    return getIntPref("browser.display.document_color_use", 0) !== 2;
   }
 
   supportedMouseWheelZoomModifierKeys() {
     return {
-      ctrlKey: getIntPref('mousewheel.with_control.action', 3) === 3,
-      metaKey: getIntPref('mousewheel.with_meta.action', 1) === 3,
+      ctrlKey: getIntPref("mousewheel.with_control.action", 3) === 3,
+      metaKey: getIntPref("mousewheel.with_meta.action", 1) === 3,
     };
   }
 
   reportTelemetry(data) {
     var probeInfo = JSON.parse(data);
     switch (probeInfo.type) {
-      case 'documentInfo':
+      case "documentInfo":
         if (!this.telemetryState.documentInfo) {
           PdfJsTelemetry.onDocumentVersion(probeInfo.version | 0);
           PdfJsTelemetry.onDocumentGenerator(probeInfo.generator | 0);
           if (probeInfo.formType) {
-            PdfJsTelemetry.onForm(probeInfo.formType === 'acroform');
+            PdfJsTelemetry.onForm(probeInfo.formType === "acroform");
           }
           this.telemetryState.documentInfo = true;
         }
         break;
-      case 'pageInfo':
+      case "pageInfo":
         if (!this.telemetryState.firstPageInfo) {
           var duration = Date.now() - this.telemetryState.startAt;
           PdfJsTelemetry.onTimeToView(duration);
           this.telemetryState.firstPageInfo = true;
         }
         break;
-      case 'documentStats':
+      case "documentStats":
         // documentStats can be called several times for one documents.
         // if stream/font types are reported, trying not to submit the same
         // enumeration value multiple times.
         var documentStats = probeInfo.stats;
-        if (!documentStats || typeof documentStats !== 'object') {
+        if (!documentStats || typeof documentStats !== "object") {
           break;
         }
         var i, streamTypes = documentStats.streamTypes;
@@ -414,7 +414,7 @@ class ChromeActions {
           }
         }
         break;
-      case 'print':
+      case "print":
         PdfJsTelemetry.onPrint();
         break;
     }
@@ -428,29 +428,29 @@ class ChromeActions {
     var featureId = args.featureId;
 
     var domWindow = this.domWindow;
-    var strings = getLocalizedStrings('chrome.properties');
+    var strings = getLocalizedStrings("chrome.properties");
     var message;
-    if (featureId === 'forms') {
-      message = getLocalizedString(strings, 'unsupported_feature_forms');
+    if (featureId === "forms") {
+      message = getLocalizedString(strings, "unsupported_feature_forms");
     } else {
-      message = getLocalizedString(strings, 'unsupported_feature');
+      message = getLocalizedString(strings, "unsupported_feature");
     }
     PdfJsTelemetry.onFallback();
     PdfjsContentUtils.displayWarning(domWindow, message,
-      getLocalizedString(strings, 'open_with_different_viewer'),
-      getLocalizedString(strings, 'open_with_different_viewer', 'accessKey'));
+      getLocalizedString(strings, "open_with_different_viewer"),
+      getLocalizedString(strings, "open_with_different_viewer", "accessKey"));
 
     let winmm = domWindow.QueryInterface(Ci.nsIInterfaceRequestor)
                          .getInterface(Ci.nsIDocShell)
                          .QueryInterface(Ci.nsIInterfaceRequestor)
                          .getInterface(Ci.nsIContentFrameMessageManager);
 
-    winmm.addMessageListener('PDFJS:Child:fallbackDownload',
+    winmm.addMessageListener("PDFJS:Child:fallbackDownload",
       function fallbackDownload(msg) {
         let data = msg.data;
         sendResponse(data.download);
 
-        winmm.removeMessageListener('PDFJS:Child:fallbackDownload',
+        winmm.removeMessageListener("PDFJS:Child:fallbackDownload",
                                     fallbackDownload);
       });
   }
@@ -463,8 +463,8 @@ class ChromeActions {
     var result = data.result;
     var findPrevious = data.findPrevious;
     var findPreviousType = typeof findPrevious;
-    if ((typeof result !== 'number' || result < 0 || result > 3) ||
-        (findPreviousType !== 'undefined' && findPreviousType !== 'boolean')) {
+    if ((typeof result !== "number" || result < 0 || result > 3) ||
+        (findPreviousType !== "undefined" && findPreviousType !== "boolean")) {
       return;
     }
 
@@ -473,34 +473,34 @@ class ChromeActions {
                               .QueryInterface(Ci.nsIInterfaceRequestor)
                               .getInterface(Ci.nsIContentFrameMessageManager);
 
-    winmm.sendAsyncMessage('PDFJS:Parent:updateControlState', data);
+    winmm.sendAsyncMessage("PDFJS:Parent:updateControlState", data);
   }
 
   setPreferences(prefs, sendResponse) {
-    var defaultBranch = Services.prefs.getDefaultBranch(PREF_PREFIX + '.');
+    var defaultBranch = Services.prefs.getDefaultBranch(PREF_PREFIX + ".");
     var numberOfPrefs = 0;
     var prefValue, prefName;
     for (var key in prefs) {
       if (++numberOfPrefs > MAX_NUMBER_OF_PREFS) {
-        log('setPreferences - Exceeded the maximum number of preferences ' +
-            'that is allowed to be set at once.');
+        log("setPreferences - Exceeded the maximum number of preferences " +
+            "that is allowed to be set at once.");
         break;
       } else if (!defaultBranch.getPrefType(key)) {
         continue;
       }
       prefValue = prefs[key];
-      prefName = (PREF_PREFIX + '.' + key);
+      prefName = (PREF_PREFIX + "." + key);
       switch (typeof prefValue) {
-        case 'boolean':
+        case "boolean":
           PdfjsContentUtils.setBoolPref(prefName, prefValue);
           break;
-        case 'number':
+        case "number":
           PdfjsContentUtils.setIntPref(prefName, prefValue);
           break;
-        case 'string':
+        case "string":
           if (prefValue.length > MAX_STRING_PREF_LENGTH) {
-            log('setPreferences - Exceeded the maximum allowed length ' +
-                'for a string preference.');
+            log("setPreferences - Exceeded the maximum allowed length " +
+                "for a string preference.");
           } else {
             PdfjsContentUtils.setStringPref(prefName, prefValue);
           }
@@ -513,27 +513,27 @@ class ChromeActions {
   }
 
   getPreferences(prefs, sendResponse) {
-    var defaultBranch = Services.prefs.getDefaultBranch(PREF_PREFIX + '.');
+    var defaultBranch = Services.prefs.getDefaultBranch(PREF_PREFIX + ".");
     var currentPrefs = {}, numberOfPrefs = 0;
     var prefValue, prefName;
     for (var key in prefs) {
       if (++numberOfPrefs > MAX_NUMBER_OF_PREFS) {
-        log('getPreferences - Exceeded the maximum number of preferences ' +
-            'that is allowed to be fetched at once.');
+        log("getPreferences - Exceeded the maximum number of preferences " +
+            "that is allowed to be fetched at once.");
         break;
       } else if (!defaultBranch.getPrefType(key)) {
         continue;
       }
       prefValue = prefs[key];
-      prefName = (PREF_PREFIX + '.' + key);
+      prefName = (PREF_PREFIX + "." + key);
       switch (typeof prefValue) {
-        case 'boolean':
+        case "boolean":
           currentPrefs[key] = getBoolPref(prefName, prefValue);
           break;
-        case 'number':
+        case "number":
           currentPrefs[key] = getIntPref(prefName, prefValue);
           break;
-        case 'string':
+        case "string":
           currentPrefs[key] = getStringPref(prefName, prefValue);
           break;
       }
@@ -566,7 +566,7 @@ class RangedChromeActions extends ChromeActions {
     var httpHeaderVisitor = {
       headers: {},
       visitHeader(aHeader, aValue) {
-        if (aHeader === 'Range') {
+        if (aHeader === "Range") {
           // When loading the PDF from cache, firefox seems to set the Range
           // request header to fetch only the unfetched portions of the file
           // (e.g. 'Range: bytes=1024-'). However, we want to set this header
@@ -584,7 +584,7 @@ class RangedChromeActions extends ChromeActions {
     var xhr_onreadystatechange = function xhr_onreadystatechange() {
       if (this.readyState === 1) { // LOADING
         var netChannel = this.channel;
-        if ('nsIPrivateBrowsingChannel' in Ci &&
+        if ("nsIPrivateBrowsingChannel" in Ci &&
             netChannel instanceof Ci.nsIPrivateBrowsingChannel) {
           var docIsPrivate = self.isInPrivateBrowsing();
           netChannel.setPrivate(docIsPrivate);
@@ -593,9 +593,9 @@ class RangedChromeActions extends ChromeActions {
     };
     var getXhr = function getXhr() {
       const XMLHttpRequest = Components.Constructor(
-          '@mozilla.org/xmlextras/xmlhttprequest;1');
+          "@mozilla.org/xmlextras/xmlhttprequest;1");
       var xhr = new XMLHttpRequest();
-      xhr.addEventListener('readystatechange', xhr_onreadystatechange);
+      xhr.addEventListener("readystatechange", xhr_onreadystatechange);
       return xhr;
     };
 
@@ -606,7 +606,7 @@ class RangedChromeActions extends ChromeActions {
 
     // If we are in range request mode, this means we manually issued xhr
     // requests, which we need to abort when we leave the page
-    domWindow.addEventListener('unload', function unload(e) {
+    domWindow.addEventListener("unload", function unload(e) {
       domWindow.removeEventListener(e.type, unload);
       self.abortLoading();
     });
@@ -624,11 +624,11 @@ class RangedChromeActions extends ChromeActions {
 
       this.dataListener.onprogress = (loaded, total) => {
         this.domWindow.postMessage({
-          pdfjsLoadAction: 'progressiveRead',
+          pdfjsLoadAction: "progressiveRead",
           loaded,
           total,
           chunk: this.dataListener.readData(),
-        }, '*');
+        }, "*");
       };
       this.dataListener.oncomplete = () => {
         this.dataListener = null;
@@ -636,13 +636,13 @@ class RangedChromeActions extends ChromeActions {
     }
 
     this.domWindow.postMessage({
-      pdfjsLoadAction: 'supportsRangedLoading',
+      pdfjsLoadAction: "supportsRangedLoading",
       rangeEnabled: this.rangeEnabled,
       streamingEnabled: this.streamingEnabled,
       pdfUrl: this.pdfUrl,
       length: this.contentLength,
       data,
-    }, '*');
+    }, "*");
 
     return true;
   }
@@ -661,16 +661,16 @@ class RangedChromeActions extends ChromeActions {
     this.networkManager.requestRange(begin, end, {
       onDone: function RangedChromeActions_onDone(aArgs) {
         domWindow.postMessage({
-          pdfjsLoadAction: 'range',
+          pdfjsLoadAction: "range",
           begin: aArgs.begin,
           chunk: aArgs.chunk,
-        }, '*');
+        }, "*");
       },
       onProgress: function RangedChromeActions_onProgress(evt) {
         domWindow.postMessage({
-          pdfjsLoadAction: 'rangeProgress',
+          pdfjsLoadAction: "rangeProgress",
           loaded: evt.loaded,
-        }, '*');
+        }, "*");
       }
     });
   }
@@ -703,18 +703,18 @@ class StandardChromeActions extends ChromeActions {
 
     this.dataListener.onprogress = (loaded, total) => {
       this.domWindow.postMessage({
-        pdfjsLoadAction: 'progress',
+        pdfjsLoadAction: "progress",
         loaded,
         total,
-      }, '*');
+      }, "*");
     };
 
     this.dataListener.oncomplete = (data, errorCode) => {
       this.domWindow.postMessage({
-        pdfjsLoadAction: 'complete',
+        pdfjsLoadAction: "complete",
         data,
         errorCode,
-      }, '*');
+      }, "*");
 
       this.dataListener = null;
       this.originalRequest = null;
@@ -749,7 +749,7 @@ class RequestListener {
     var sync = event.detail.sync;
     var actions = this.actions;
     if (!(action in actions)) {
-      log('Unknown action: ' + action);
+      log("Unknown action: " + action);
       return;
     }
     var response;
@@ -763,9 +763,9 @@ class RequestListener {
       } else {
         response = function sendResponse(aResponse) {
           try {
-            var listener = doc.createEvent('CustomEvent');
+            var listener = doc.createEvent("CustomEvent");
             let detail = Cu.cloneInto({ response: aResponse }, doc.defaultView);
-            listener.initCustomEvent('pdf.js.response', true, false, detail);
+            listener.initCustomEvent("pdf.js.response", true, false, detail);
             return message.dispatchEvent(listener);
           } catch (e) {
             // doc is no longer accessible because the requestor is already
@@ -797,14 +797,14 @@ class FindEventManager {
       this.unbind();
       this.contentWindow.removeEventListener(e.type, unload);
     }.bind(this);
-    this.contentWindow.addEventListener('unload', unload);
+    this.contentWindow.addEventListener("unload", unload);
 
     // We cannot directly attach listeners to for the find events
     // since the FindBar is in the parent process. Instead we're
     // asking the PdfjsChromeUtils to do it for us and forward
     // all the find events to us.
-    this.winmm.sendAsyncMessage('PDFJS:Parent:addEventListener');
-    this.winmm.addMessageListener('PDFJS:Child:handleEvent', this);
+    this.winmm.sendAsyncMessage("PDFJS:Parent:addEventListener");
+    this.winmm.addMessageListener("PDFJS:Child:handleEvent", this);
   }
 
   receiveMessage(msg) {
@@ -813,13 +813,13 @@ class FindEventManager {
     var contentWindow = this.contentWindow;
 
     detail = Cu.cloneInto(detail, contentWindow);
-    var forward = contentWindow.document.createEvent('CustomEvent');
+    var forward = contentWindow.document.createEvent("CustomEvent");
     forward.initCustomEvent(type, true, true, detail);
     contentWindow.dispatchEvent(forward);
   }
 
   unbind() {
-    this.winmm.sendAsyncMessage('PDFJS:Parent:removeEventListener');
+    this.winmm.sendAsyncMessage("PDFJS:Parent:removeEventListener");
   }
 }
 
@@ -829,12 +829,12 @@ function PdfStreamConverter() {
 PdfStreamConverter.prototype = {
 
   // properties required for XPCOM registration:
-  classID: Components.ID('{PDFJSSCRIPT_STREAM_CONVERTER_ID}'),
-  classDescription: 'pdf.js Component',
-  contractID: '@mozilla.org/streamconv;1?from=application/pdf&to=*/*',
+  classID: Components.ID("{PDFJSSCRIPT_STREAM_CONVERTER_ID}"),
+  classDescription: "pdf.js Component",
+  contractID: "@mozilla.org/streamconv;1?from=application/pdf&to=*/*",
 
-  classID2: Components.ID('{PDFJSSCRIPT_STREAM_CONVERTER2_ID}'),
-  contractID2: '@mozilla.org/streamconv;1?from=application/pdf&to=text/html',
+  classID2: Components.ID("{PDFJSSCRIPT_STREAM_CONVERTER2_ID}"),
+  contractID2: "@mozilla.org/streamconv;1?from=application/pdf&to=text/html",
 
   QueryInterface: XPCOMUtils.generateQI([
       Ci.nsISupports,
@@ -894,29 +894,29 @@ PdfStreamConverter.prototype = {
     var rangeRequest = false;
     var streamRequest = false;
     if (isHttpRequest) {
-      var contentEncoding = 'identity';
+      var contentEncoding = "identity";
       try {
-        contentEncoding = aRequest.getResponseHeader('Content-Encoding');
+        contentEncoding = aRequest.getResponseHeader("Content-Encoding");
       } catch (e) {}
 
       var acceptRanges;
       try {
-        acceptRanges = aRequest.getResponseHeader('Accept-Ranges');
+        acceptRanges = aRequest.getResponseHeader("Accept-Ranges");
       } catch (e) {}
 
       var hash = aRequest.URI.ref;
-      var isPDFBugEnabled = getBoolPref(PREF_PREFIX + '.pdfBugEnabled', false);
-      rangeRequest = contentEncoding === 'identity' &&
-                     acceptRanges === 'bytes' &&
+      var isPDFBugEnabled = getBoolPref(PREF_PREFIX + ".pdfBugEnabled", false);
+      rangeRequest = contentEncoding === "identity" &&
+                     acceptRanges === "bytes" &&
                      aRequest.contentLength >= 0 &&
-                     !getBoolPref(PREF_PREFIX + '.disableRange', false) &&
+                     !getBoolPref(PREF_PREFIX + ".disableRange", false) &&
                      (!isPDFBugEnabled ||
-                      hash.toLowerCase().indexOf('disablerange=true') < 0);
-      streamRequest = contentEncoding === 'identity' &&
+                      hash.toLowerCase().indexOf("disablerange=true") < 0);
+      streamRequest = contentEncoding === "identity" &&
                       aRequest.contentLength >= 0 &&
-                      !getBoolPref(PREF_PREFIX + '.disableStream', false) &&
+                      !getBoolPref(PREF_PREFIX + ".disableStream", false) &&
                       (!isPDFBugEnabled ||
-                       hash.toLowerCase().indexOf('disablestream=true') < 0);
+                       hash.toLowerCase().indexOf("disablestream=true") < 0);
     }
 
     aRequest.QueryInterface(Ci.nsIChannel);
@@ -929,15 +929,15 @@ PdfStreamConverter.prototype = {
     } catch (e) {}
 
     // Change the content type so we don't get stuck in a loop.
-    aRequest.setProperty('contentType', aRequest.contentType);
-    aRequest.contentType = 'text/html';
+    aRequest.setProperty("contentType", aRequest.contentType);
+    aRequest.contentType = "text/html";
     if (isHttpRequest) {
       // We trust PDF viewer, using no CSP
-      aRequest.setResponseHeader('Content-Security-Policy', '', false);
-      aRequest.setResponseHeader('Content-Security-Policy-Report-Only', '',
+      aRequest.setResponseHeader("Content-Security-Policy", "", false);
+      aRequest.setResponseHeader("Content-Security-Policy-Report-Only", "",
                                  false);
       // The viewer does not need to handle HTTP Refresh header.
-      aRequest.setResponseHeader('Refresh', '', false);
+      aRequest.setResponseHeader("Refresh", "", false);
     }
 
     PdfJsTelemetry.onViewerIsUsed();
@@ -946,7 +946,7 @@ PdfStreamConverter.prototype = {
     // Creating storage for PDF data
     var contentLength = aRequest.contentLength;
     this.dataListener = new PdfDataListener(contentLength);
-    this.binaryStream = Cc['@mozilla.org/binaryinputstream;1']
+    this.binaryStream = Cc["@mozilla.org/binaryinputstream;1"]
                         .createInstance(Ci.nsIBinaryInputStream);
 
     // Create a new channel that is viewer loaded as a resource.
@@ -993,8 +993,8 @@ PdfStreamConverter.prototype = {
         listener.onStopRequest(aRequest, aContext, statusCode);
 
         if (domWindow.frameElement) {
-          var isObjectEmbed = domWindow.frameElement.tagName !== 'IFRAME' ||
-            domWindow.frameElement.className === 'previewPluginContentFrame';
+          var isObjectEmbed = domWindow.frameElement.tagName !== "IFRAME" ||
+            domWindow.frameElement.className === "previewPluginContentFrame";
           PdfJsTelemetry.onEmbed(isObjectEmbed);
         }
       }
@@ -1008,7 +1008,7 @@ PdfStreamConverter.prototype = {
     // We can use the resource principal when data is fetched by the chrome,
     // e.g. useful for NoScript. Make make sure we reuse the origin attributes
     // from the request channel to keep isolation consistent.
-    var ssm = Cc['@mozilla.org/scriptsecuritymanager;1']
+    var ssm = Cc["@mozilla.org/scriptsecuritymanager;1"]
                 .getService(Ci.nsIScriptSecurityManager);
     var uri = NetUtil.newURI(PDF_VIEWER_WEB_PAGE);
     var resourcePrincipal =

--- a/extensions/firefox/content/PdfjsChromeUtils.jsm
+++ b/extensions/firefox/content/PdfjsChromeUtils.jsm
@@ -14,30 +14,30 @@
  */
 /* globals Components, Services, XPCOMUtils */
 
-'use strict';
+"use strict";
 
-var EXPORTED_SYMBOLS = ['PdfjsChromeUtils'];
+var EXPORTED_SYMBOLS = ["PdfjsChromeUtils"];
 
 const Cc = Components.classes;
 const Ci = Components.interfaces;
 const Cr = Components.results;
 const Cu = Components.utils;
 
-const PREF_PREFIX = 'PDFJSSCRIPT_PREF_PREFIX';
-const PDF_CONTENT_TYPE = 'application/pdf';
+const PREF_PREFIX = "PDFJSSCRIPT_PREF_PREFIX";
+const PDF_CONTENT_TYPE = "application/pdf";
 
-Cu.import('resource://gre/modules/XPCOMUtils.jsm');
-Cu.import('resource://gre/modules/Services.jsm');
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+Cu.import("resource://gre/modules/Services.jsm");
 
 var Svc = {};
-XPCOMUtils.defineLazyServiceGetter(Svc, 'mime',
-                                   '@mozilla.org/mime;1',
-                                   'nsIMIMEService');
+XPCOMUtils.defineLazyServiceGetter(Svc, "mime",
+                                   "@mozilla.org/mime;1",
+                                   "nsIMIMEService");
 
 var DEFAULT_PREFERENCES =
 //#include ../../../web/default_preferences.json
 //#if false
-  'end of DEFAULT_PREFERENCES';
+  "end of DEFAULT_PREFERENCES";
 //#endif
 
 var PdfjsChromeUtils = {
@@ -55,46 +55,46 @@ var PdfjsChromeUtils = {
     this._browsers = new WeakSet();
     if (!this._ppmm) {
       // global parent process message manager (PPMM)
-      this._ppmm = Cc['@mozilla.org/parentprocessmessagemanager;1'].
+      this._ppmm = Cc["@mozilla.org/parentprocessmessagemanager;1"].
         getService(Ci.nsIMessageBroadcaster);
-      this._ppmm.addMessageListener('PDFJS:Parent:clearUserPref', this);
-      this._ppmm.addMessageListener('PDFJS:Parent:setIntPref', this);
-      this._ppmm.addMessageListener('PDFJS:Parent:setBoolPref', this);
-      this._ppmm.addMessageListener('PDFJS:Parent:setCharPref', this);
-      this._ppmm.addMessageListener('PDFJS:Parent:setStringPref', this);
-      this._ppmm.addMessageListener('PDFJS:Parent:isDefaultHandlerApp', this);
+      this._ppmm.addMessageListener("PDFJS:Parent:clearUserPref", this);
+      this._ppmm.addMessageListener("PDFJS:Parent:setIntPref", this);
+      this._ppmm.addMessageListener("PDFJS:Parent:setBoolPref", this);
+      this._ppmm.addMessageListener("PDFJS:Parent:setCharPref", this);
+      this._ppmm.addMessageListener("PDFJS:Parent:setStringPref", this);
+      this._ppmm.addMessageListener("PDFJS:Parent:isDefaultHandlerApp", this);
 
       // global dom message manager (MMg)
-      this._mmg = Cc['@mozilla.org/globalmessagemanager;1'].
+      this._mmg = Cc["@mozilla.org/globalmessagemanager;1"].
         getService(Ci.nsIMessageListenerManager);
-      this._mmg.addMessageListener('PDFJS:Parent:displayWarning', this);
+      this._mmg.addMessageListener("PDFJS:Parent:displayWarning", this);
 
-      this._mmg.addMessageListener('PDFJS:Parent:addEventListener', this);
-      this._mmg.addMessageListener('PDFJS:Parent:removeEventListener', this);
-      this._mmg.addMessageListener('PDFJS:Parent:updateControlState', this);
+      this._mmg.addMessageListener("PDFJS:Parent:addEventListener", this);
+      this._mmg.addMessageListener("PDFJS:Parent:removeEventListener", this);
+      this._mmg.addMessageListener("PDFJS:Parent:updateControlState", this);
 
       // observer to handle shutdown
-      Services.obs.addObserver(this, 'quit-application', false);
+      Services.obs.addObserver(this, "quit-application", false);
     }
   },
 
   uninit() {
     if (this._ppmm) {
-      this._ppmm.removeMessageListener('PDFJS:Parent:clearUserPref', this);
-      this._ppmm.removeMessageListener('PDFJS:Parent:setIntPref', this);
-      this._ppmm.removeMessageListener('PDFJS:Parent:setBoolPref', this);
-      this._ppmm.removeMessageListener('PDFJS:Parent:setCharPref', this);
-      this._ppmm.removeMessageListener('PDFJS:Parent:setStringPref', this);
-      this._ppmm.removeMessageListener('PDFJS:Parent:isDefaultHandlerApp',
+      this._ppmm.removeMessageListener("PDFJS:Parent:clearUserPref", this);
+      this._ppmm.removeMessageListener("PDFJS:Parent:setIntPref", this);
+      this._ppmm.removeMessageListener("PDFJS:Parent:setBoolPref", this);
+      this._ppmm.removeMessageListener("PDFJS:Parent:setCharPref", this);
+      this._ppmm.removeMessageListener("PDFJS:Parent:setStringPref", this);
+      this._ppmm.removeMessageListener("PDFJS:Parent:isDefaultHandlerApp",
                                        this);
 
-      this._mmg.removeMessageListener('PDFJS:Parent:displayWarning', this);
+      this._mmg.removeMessageListener("PDFJS:Parent:displayWarning", this);
 
-      this._mmg.removeMessageListener('PDFJS:Parent:addEventListener', this);
-      this._mmg.removeMessageListener('PDFJS:Parent:removeEventListener', this);
-      this._mmg.removeMessageListener('PDFJS:Parent:updateControlState', this);
+      this._mmg.removeMessageListener("PDFJS:Parent:addEventListener", this);
+      this._mmg.removeMessageListener("PDFJS:Parent:removeEventListener", this);
+      this._mmg.removeMessageListener("PDFJS:Parent:updateControlState", this);
 
-      Services.obs.removeObserver(this, 'quit-application');
+      Services.obs.removeObserver(this, "quit-application");
 
       this._mmg = null;
       this._ppmm = null;
@@ -115,7 +115,7 @@ var PdfjsChromeUtils = {
       // manager, which means this is going to fire to every child process
       // we have open. Unfortunately I can't find a way to get at that
       // process specific mm from js.
-      this._ppmm.broadcastAsyncMessage('PDFJS:Child:refreshSettings', {});
+      this._ppmm.broadcastAsyncMessage("PDFJS:Child:refreshSettings", {});
     }
   },
 
@@ -124,40 +124,40 @@ var PdfjsChromeUtils = {
    */
 
   observe(aSubject, aTopic, aData) {
-    if (aTopic === 'quit-application') {
+    if (aTopic === "quit-application") {
       this.uninit();
     }
   },
 
   receiveMessage(aMsg) {
     switch (aMsg.name) {
-      case 'PDFJS:Parent:clearUserPref':
+      case "PDFJS:Parent:clearUserPref":
         this._clearUserPref(aMsg.data.name);
         break;
-      case 'PDFJS:Parent:setIntPref':
+      case "PDFJS:Parent:setIntPref":
         this._setIntPref(aMsg.data.name, aMsg.data.value);
         break;
-      case 'PDFJS:Parent:setBoolPref':
+      case "PDFJS:Parent:setBoolPref":
         this._setBoolPref(aMsg.data.name, aMsg.data.value);
         break;
-      case 'PDFJS:Parent:setCharPref':
+      case "PDFJS:Parent:setCharPref":
         this._setCharPref(aMsg.data.name, aMsg.data.value);
         break;
-      case 'PDFJS:Parent:setStringPref':
+      case "PDFJS:Parent:setStringPref":
         this._setStringPref(aMsg.data.name, aMsg.data.value);
         break;
-      case 'PDFJS:Parent:isDefaultHandlerApp':
+      case "PDFJS:Parent:isDefaultHandlerApp":
         return this.isDefaultHandlerApp();
-      case 'PDFJS:Parent:displayWarning':
+      case "PDFJS:Parent:displayWarning":
         this._displayWarning(aMsg);
         break;
 
 
-      case 'PDFJS:Parent:updateControlState':
+      case "PDFJS:Parent:updateControlState":
         return this._updateControlState(aMsg);
-      case 'PDFJS:Parent:addEventListener':
+      case "PDFJS:Parent:addEventListener":
         return this._addEventListener(aMsg);
-      case 'PDFJS:Parent:removeEventListener':
+      case "PDFJS:Parent:removeEventListener":
         return this._removeEventListener(aMsg);
     }
   },
@@ -192,25 +192,25 @@ var PdfjsChromeUtils = {
 
     let browser = aEvent.currentTarget.browser;
     if (!this._browsers.has(browser)) {
-      throw new Error('FindEventManager was not bound ' +
-                      'for the current browser.');
+      throw new Error("FindEventManager was not bound " +
+                      "for the current browser.");
     }
     // Only forward the events if the current browser is a registered browser.
     let mm = browser.messageManager;
-    mm.sendAsyncMessage('PDFJS:Child:handleEvent', { type, detail, });
+    mm.sendAsyncMessage("PDFJS:Child:handleEvent", { type, detail, });
     aEvent.preventDefault();
   },
 
-  _types: ['find',
-           'findagain',
-           'findhighlightallchange',
-           'findcasesensitivitychange'],
+  _types: ["find",
+           "findagain",
+           "findhighlightallchange",
+           "findcasesensitivitychange"],
 
   _addEventListener(aMsg) {
     let browser = aMsg.target;
     if (this._browsers.has(browser)) {
-      throw new Error('FindEventManager was bound 2nd time ' +
-                      'without unbinding it first.');
+      throw new Error("FindEventManager was bound 2nd time " +
+                      "without unbinding it first.");
     }
 
     // Since this jsm is global, we need to store all the browsers
@@ -228,7 +228,7 @@ var PdfjsChromeUtils = {
   _removeEventListener(aMsg) {
     let browser = aMsg.target;
     if (!this._browsers.has(browser)) {
-      throw new Error('FindEventManager was unbound without binding it first.');
+      throw new Error("FindEventManager was unbound without binding it first.");
     }
 
     this._browsers.delete(browser);
@@ -242,11 +242,11 @@ var PdfjsChromeUtils = {
   },
 
   _ensurePreferenceAllowed(aPrefName) {
-    let unPrefixedName = aPrefName.split(PREF_PREFIX + '.');
-    if (unPrefixedName[0] !== '' ||
+    let unPrefixedName = aPrefName.split(PREF_PREFIX + ".");
+    if (unPrefixedName[0] !== "" ||
         this._allowedPrefNames.indexOf(unPrefixedName[1]) === -1) {
-      let msg = '"' + aPrefName + '" ' +
-                'can\'t be accessed from content. See PdfjsChromeUtils.';
+      let msg = "\"" + aPrefName + "\" " +
+                "can't be accessed from content. See PdfjsChromeUtils.";
       throw new Error(msg);
     }
   },
@@ -273,7 +273,7 @@ var PdfjsChromeUtils = {
 
   _setStringPref(aPrefName, aPrefValue) {
     this._ensurePreferenceAllowed(aPrefName);
-    let str = Cc['@mozilla.org/supports-string;1']
+    let str = Cc["@mozilla.org/supports-string;1"]
                 .createInstance(Ci.nsISupportsString);
     str.data = aPrefValue;
     Services.prefs.setComplexValue(aPrefName, Ci.nsISupportsString, str);
@@ -285,7 +285,7 @@ var PdfjsChromeUtils = {
    * parent.
    */
   isDefaultHandlerApp() {
-    var handlerInfo = Svc.mime.getFromTypeAndExtension(PDF_CONTENT_TYPE, 'pdf');
+    var handlerInfo = Svc.mime.getFromTypeAndExtension(PDF_CONTENT_TYPE, "pdf");
     return (!handlerInfo.alwaysAskBeforeHandling &&
             handlerInfo.preferredAction === Ci.nsIHandlerInfo.handleInternally);
   },
@@ -307,7 +307,7 @@ var PdfjsChromeUtils = {
     let messageSent = false;
     function sendMessage(download) {
       let mm = browser.messageManager;
-      mm.sendAsyncMessage('PDFJS:Child:fallbackDownload', { download, });
+      mm.sendAsyncMessage("PDFJS:Child:fallbackDownload", { download, });
     }
     let buttons = [{
       label: data.label,
@@ -317,13 +317,13 @@ var PdfjsChromeUtils = {
         sendMessage(true);
       }
     }];
-    notificationBox.appendNotification(data.message, 'pdfjs-fallback', null,
+    notificationBox.appendNotification(data.message, "pdfjs-fallback", null,
                                        notificationBox.PRIORITY_INFO_LOW,
                                        buttons,
                                        function eventsCallback(eventType) {
       // Currently there is only one event "removed" but if there are any other
       // added in the future we still only care about removed at the moment.
-      if (eventType !== 'removed') {
+      if (eventType !== "removed") {
         return;
       }
       // Don't send a response again if we already responded when the button was

--- a/extensions/firefox/content/PdfjsContentUtils.jsm
+++ b/extensions/firefox/content/PdfjsContentUtils.jsm
@@ -14,17 +14,17 @@
  */
 /* globals Components, Services, XPCOMUtils */
 
-'use strict';
+"use strict";
 
-var EXPORTED_SYMBOLS = ['PdfjsContentUtils'];
+var EXPORTED_SYMBOLS = ["PdfjsContentUtils"];
 
 const Cc = Components.classes;
 const Ci = Components.interfaces;
 const Cr = Components.results;
 const Cu = Components.utils;
 
-Cu.import('resource://gre/modules/XPCOMUtils.jsm');
-Cu.import('resource://gre/modules/Services.jsm');
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+Cu.import("resource://gre/modules/Services.jsm");
 
 var PdfjsContentUtils = {
   _mm: null,
@@ -42,17 +42,17 @@ var PdfjsContentUtils = {
     // child *process* mm, or when loaded into the parent for in-content
     // support the psuedo child process mm 'child PPMM'.
     if (!this._mm) {
-      this._mm = Cc['@mozilla.org/childprocessmessagemanager;1'].
+      this._mm = Cc["@mozilla.org/childprocessmessagemanager;1"].
         getService(Ci.nsISyncMessageSender);
-      this._mm.addMessageListener('PDFJS:Child:refreshSettings', this);
-      Services.obs.addObserver(this, 'quit-application', false);
+      this._mm.addMessageListener("PDFJS:Child:refreshSettings", this);
+      Services.obs.addObserver(this, "quit-application", false);
     }
   },
 
   uninit() {
     if (this._mm) {
-      this._mm.removeMessageListener('PDFJS:Child:refreshSettings', this);
-      Services.obs.removeObserver(this, 'quit-application');
+      this._mm.removeMessageListener("PDFJS:Child:refreshSettings", this);
+      Services.obs.removeObserver(this, "quit-application");
     }
     this._mm = null;
   },
@@ -64,34 +64,34 @@ var PdfjsContentUtils = {
    */
 
   clearUserPref(aPrefName) {
-    this._mm.sendSyncMessage('PDFJS:Parent:clearUserPref', {
+    this._mm.sendSyncMessage("PDFJS:Parent:clearUserPref", {
       name: aPrefName
     });
   },
 
   setIntPref(aPrefName, aPrefValue) {
-    this._mm.sendSyncMessage('PDFJS:Parent:setIntPref', {
+    this._mm.sendSyncMessage("PDFJS:Parent:setIntPref", {
       name: aPrefName,
       value: aPrefValue
     });
   },
 
   setBoolPref(aPrefName, aPrefValue) {
-    this._mm.sendSyncMessage('PDFJS:Parent:setBoolPref', {
+    this._mm.sendSyncMessage("PDFJS:Parent:setBoolPref", {
       name: aPrefName,
       value: aPrefValue
     });
   },
 
   setCharPref(aPrefName, aPrefValue) {
-    this._mm.sendSyncMessage('PDFJS:Parent:setCharPref', {
+    this._mm.sendSyncMessage("PDFJS:Parent:setCharPref", {
       name: aPrefName,
       value: aPrefValue
     });
   },
 
   setStringPref(aPrefName, aPrefValue) {
-    this._mm.sendSyncMessage('PDFJS:Parent:setStringPref', {
+    this._mm.sendSyncMessage("PDFJS:Parent:setStringPref", {
       name: aPrefName,
       value: aPrefValue
     });
@@ -102,7 +102,7 @@ var PdfjsContentUtils = {
    * handler app settings only available in the parent process.
    */
   isDefaultHandlerApp() {
-    return this._mm.sendSyncMessage('PDFJS:Parent:isDefaultHandlerApp')[0];
+    return this._mm.sendSyncMessage("PDFJS:Parent:isDefaultHandlerApp")[0];
   },
 
   /*
@@ -115,7 +115,7 @@ var PdfjsContentUtils = {
                        .getInterface(Ci.nsIDocShell)
                        .QueryInterface(Ci.nsIInterfaceRequestor)
                        .getInterface(Ci.nsIContentFrameMessageManager);
-    winmm.sendAsyncMessage('PDFJS:Parent:displayWarning', {
+    winmm.sendAsyncMessage("PDFJS:Parent:displayWarning", {
       message: aMessage,
       label: aLabel,
       accessKey: aAccessKey,
@@ -127,18 +127,18 @@ var PdfjsContentUtils = {
    */
 
   observe(aSubject, aTopic, aData) {
-    if (aTopic === 'quit-application') {
+    if (aTopic === "quit-application") {
       this.uninit();
     }
   },
 
   receiveMessage(aMsg) {
     switch (aMsg.name) {
-      case 'PDFJS:Child:refreshSettings':
+      case "PDFJS:Child:refreshSettings":
         // Only react to this if we are remote.
         if (Services.appinfo.processType ===
             Services.appinfo.PROCESS_TYPE_CONTENT) {
-          let jsm = 'resource://pdf.js/PdfJs.jsm';
+          let jsm = "resource://pdf.js/PdfJs.jsm";
           let pdfjs = Components.utils.import(jsm, {}).PdfJs;
           pdfjs.updateRegistration();
         }

--- a/extensions/firefox/content/pdfjschildbootstrap.js
+++ b/extensions/firefox/content/pdfjschildbootstrap.js
@@ -14,16 +14,16 @@
 */
 /* globals Components, PdfjsContentUtils, PdfJs, Services */
 
-'use strict';
+"use strict";
 
 /*
  * pdfjschildbootstrap.js loads into the content process to take care of
  * initializing our built-in version of pdfjs when running remote.
  */
 
-Components.utils.import('resource://gre/modules/Services.jsm');
-Components.utils.import('resource://pdf.js/PdfJs.jsm');
-Components.utils.import('resource://pdf.js/PdfjsContentUtils.jsm');
+Components.utils.import("resource://gre/modules/Services.jsm");
+Components.utils.import("resource://pdf.js/PdfJs.jsm");
+Components.utils.import("resource://pdf.js/PdfjsContentUtils.jsm");
 
 // init content utils shim pdfjs will use to access privileged apis.
 PdfjsContentUtils.init();

--- a/extensions/firefox/tools/l10n.js
+++ b/extensions/firefox/tools/l10n.js
@@ -1,17 +1,17 @@
-'use strict';
+"use strict";
 
 // Small subset of the webL10n API by Fabien Cazenave for pdf.js extension.
 (function(window) {
-  var gLanguage = '';
+  var gLanguage = "";
   var gExternalLocalizerServices = null;
-  var gReadyState = 'loading';
+  var gReadyState = "loading";
 
   // fetch an l10n objects
   function getL10nData(key) {
     var response = gExternalLocalizerServices.getStrings(key);
     var data = JSON.parse(response);
     if (!data) {
-      console.warn('[l10n] #' + key + ' missing for [' + gLanguage + ']');
+      console.warn("[l10n] #" + key + " missing for [" + gLanguage + "]");
     }
     return data;
   }
@@ -22,25 +22,25 @@
       return text;
     }
     return text.replace(/\{\{\s*(\w+)\s*\}\}/g, function(all, name) {
-      return (name in args ? args[name] : '{{' + name + '}}');
+      return (name in args ? args[name] : "{{" + name + "}}");
     });
   }
 
   // translate a string
   function translateString(key, args, fallback) {
-    var i = key.lastIndexOf('.');
+    var i = key.lastIndexOf(".");
     var name, property;
     if (i >= 0) {
       name = key.substring(0, i);
       property = key.substring(i + 1);
     } else {
       name = key;
-      property = 'textContent';
+      property = "textContent";
     }
     var data = getL10nData(name);
     var value = (data && data[property]) || fallback;
     if (!value) {
-      return '{{' + key + '}}';
+      return "{{" + key + "}}";
     }
     return substArguments(value, args);
   }
@@ -65,7 +65,7 @@
       try {
         args = JSON.parse(element.dataset.l10nArgs);
       } catch (e) {
-        console.warn('[l10n] could not parse arguments for #' + key + '');
+        console.warn("[l10n] could not parse arguments for #" + key + "");
       }
     }
 
@@ -79,10 +79,10 @@
 
   // translate an HTML subtree
   function translateFragment(element) {
-    element = element || document.querySelector('html');
+    element = element || document.querySelector("html");
 
     // check all translatable children (= w/ a `data-l10n-id' attribute)
-    var children = element.querySelectorAll('*[data-l10n-id]');
+    var children = element.querySelectorAll("*[data-l10n-id]");
     var elementCount = children.length;
     for (var i = 0; i < elementCount; i++) {
       translateElement(children[i]);
@@ -99,16 +99,16 @@
 
     translateFragment();
 
-    gReadyState = 'complete';
+    gReadyState = "complete";
 
     // fire a 'localized' DOM event
-    var evtObject = document.createEvent('Event');
-    evtObject.initEvent('localized', false, false);
+    var evtObject = document.createEvent("Event");
+    evtObject.initEvent("localized", false, false);
     evtObject.language = gLanguage;
     window.dispatchEvent(evtObject);
   }
 
-  window.addEventListener('DOMContentLoaded', function() {
+  window.addEventListener("DOMContentLoaded", function() {
     if (gExternalLocalizerServices) {
       translateDocument();
     }
@@ -129,12 +129,12 @@
     getDirection() {
       // http://www.w3.org/International/questions/qa-scripts
       // Arabic, Hebrew, Farsi, Pashto, Urdu
-      var rtlList = ['ar', 'he', 'fa', 'ps', 'ur'];
+      var rtlList = ["ar", "he", "fa", "ps", "ur"];
 
       // use the short language code for "full" codes like 'ar-sa' (issue 5440)
-      var shortCode = gLanguage.split('-')[0];
+      var shortCode = gLanguage.split("-")[0];
 
-      return (rtlList.indexOf(shortCode) >= 0) ? 'rtl' : 'ltr';
+      return (rtlList.indexOf(shortCode) >= 0) ? "rtl" : "ltr";
     },
 
     getReadyState() {
@@ -145,8 +145,8 @@
       gExternalLocalizerServices = externalLocalizerServices;
 
       // ... in case if we missed DOMContentLoaded above.
-      if (window.document.readyState === 'interactive' ||
-          window.document.readyState === 'complete') {
+      if (window.document.readyState === "interactive" ||
+          window.document.readyState === "complete") {
         translateDocument();
       }
     },


### PR DESCRIPTION
Given that this patch causes a lot of churn in the addon code, I wouldn't really mind if we ultimately decide against doing this and just add a rule exception in mozilla-central instead.[1]

**Edit:** Another option, besides taking this patch or adding an ESLint exception in mozilla-central, could perhaps be to run all of the addon specific files through the new preprocessor instead and have it convert the quotes for us.
However, using the preprocessor could potentially hurt readability of those files (depending on what esprima/escodegen parameters are used),  and I'm not sure how important it is that these files are easily readable in mozilla-central.

Re: https://github.com/mozilla/pdf.js/issues/7957#issuecomment-274611659.

---
[1] Note that I used the ESLint `--fix` option, hence writing this commit message actually took longer time than the creation of the patch :-)