### PR TITLE
[Firefox addon] Enable the `consistent-return` ESLint rule (issue 7957)

### DIFF
--- a/extensions/firefox/.eslintrc
+++ b/extensions/firefox/.eslintrc
@@ -8,6 +8,9 @@
   },
 
   "rules": {
+    // Best Practices
+    "consistent-return": "error",
+
     // Variables
     "no-shadow": "error",
     "no-unused-vars": ["error", {
@@ -17,6 +20,7 @@
     }],
 
     // Stylistic Issues
+    "no-nested-ternary": "error",
     "quotes": ["error", "double"],
     "space-before-function-paren": ["error", "never"],
 

--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -538,11 +538,11 @@ class ChromeActions {
           break;
       }
     }
+    let result = JSON.stringify(currentPrefs);
     if (sendResponse) {
-      sendResponse(JSON.stringify(currentPrefs));
-    } else {
-      return JSON.stringify(currentPrefs);
+      sendResponse(result);
     }
+    return result;
   }
 }
 

--- a/extensions/firefox/content/PdfjsChromeUtils.jsm
+++ b/extensions/firefox/content/PdfjsChromeUtils.jsm
@@ -152,7 +152,6 @@ var PdfjsChromeUtils = {
         this._displayWarning(aMsg);
         break;
 
-
       case "PDFJS:Parent:updateControlState":
         return this._updateControlState(aMsg);
       case "PDFJS:Parent:addEventListener":
@@ -160,6 +159,7 @@ var PdfjsChromeUtils = {
       case "PDFJS:Parent:removeEventListener":
         return this._removeEventListener(aMsg);
     }
+    return undefined;
   },
 
   /*


### PR DESCRIPTION
See http://eslint.org/docs/rules/consistent-return; it appears that I overlooked this rule in PR #7982.

Also adds the http://eslint.org/docs/rules/no-nested-ternary rule, which didn't require any code changes, since that rule is being enforced in mozilla-central.

Re: issue #7957.