### PR TITLE
Remove usage of `mozFillRule`

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1229,13 +1229,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       }
 
       if (this.pendingEOFill) {
-        if (ctx.mozFillRule !== undefined) {
-          ctx.mozFillRule = 'evenodd';
-          ctx.fill();
-          ctx.mozFillRule = 'nonzero';
-        } else {
-          ctx.fill('evenodd');
-        }
+        ctx.fill('evenodd');
         this.pendingEOFill = false;
       } else {
         ctx.fill();
@@ -2273,13 +2267,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       var ctx = this.ctx;
       if (this.pendingClip) {
         if (this.pendingClip === EO_CLIP) {
-          if (ctx.mozFillRule !== undefined) {
-            ctx.mozFillRule = 'evenodd';
-            ctx.clip();
-            ctx.mozFillRule = 'nonzero';
-          } else {
-            ctx.clip('evenodd');
-          }
+          ctx.clip('evenodd');
         } else {
           ctx.clip();
         }

--- a/test/features/tests.js
+++ b/test/features/tests.js
@@ -372,13 +372,7 @@ var tests = [
       var ctx = canvas.getContext('2d');
       ctx.rect(1, 1, 50, 50);
       ctx.rect(5, 5, 41, 41);
-
-      if ('mozFillRule' in ctx) {
-        ctx.mozFillRule = 'evenodd';
-        ctx.fill();
-      } else {
-        ctx.fill('evenodd');
-      }
+      ctx.fill('evenodd');
 
       var data = ctx.getImageData(0, 0, 50, 50).data;
       var isEvenOddFill = data[20 * 4 + 20 * 200 + 3] == 0 &&


### PR DESCRIPTION
The non-standard `mozFillRule` has been removed in Firefox 51 [1, 2]. Instead, a parameter of the standard methods should be used. Note that this is supported in all major browsers for a long time now, so there should be no need keeping this Firefox-specific code around.

[1] https://developer.mozilla.org/en-US/Firefox/Releases/51
[2] https://bugzilla.mozilla.org/show_bug.cgi?id=826619

*This patch is slightly easier to review with https://github.com/mozilla/pdf.js/pull/8006/files?w=1*