### PR TITLE
Remove the unused `isStream` property on various `Stream`s

### DIFF
--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -271,8 +271,6 @@ var ChunkedStream = (function ChunkedStreamClosure() {
       subStream.dict = dict;
       return subStream;
     },
-
-    isStream: true
   };
 
   return ChunkedStream;

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -129,7 +129,6 @@ var Stream = (function StreamClosure() {
     makeSubStream: function Stream_makeSubStream(start, length, dict) {
       return new Stream(this.bytes.buffer, start, length, dict);
     },
-    isStream: true
   };
 
   return Stream;


### PR DESCRIPTION
This property was added all the way back in PR #542, but hasn't actually been relied upon ever since PR #692.
Note that there's a `isStream()` utility function which replaced the property years ago, hence the `isStream` property is now dead code.