### PR TITLE
Moves preprocessor stuff to the gulpfile.

### DIFF
--- a/examples/learning/helloworld.html
+++ b/examples/learning/helloworld.html
@@ -13,7 +13,7 @@
 <!-- for legacy browsers add compatibility.js -->
 <!--<script src="../compatibility.js"></script>-->
 
-<script src="../../build/pdf.js"></script>
+<script src="../../build/generic/build/pdf.js"></script>
 
 <script id="script">
   //
@@ -32,7 +32,7 @@
   //
   // The workerSrc property shall be specified.
   //
-  PDFJS.workerSrc = '../../build/pdf.worker.js';
+  PDFJS.workerSrc = '../../build/generic/build/pdf.worker.js';
 
   //
   // Asynchronous download PDF

--- a/examples/learning/helloworld64.html
+++ b/examples/learning/helloworld64.html
@@ -13,7 +13,7 @@
 <!-- for legacy browsers we need to use compatibility.js -->
 <script src="../../web/compatibility.js"></script>
 
-<script src="../../build/pdf.js"></script>
+<script src="../../build/generic/build/pdf.js"></script>
 
 <script id="script">
   // atob() is used to convert base64 encoded PDF to binary-like data.
@@ -43,7 +43,7 @@
   //
   // The workerSrc property shall be specified.
   //
-  PDFJS.workerSrc = '../../build/pdf.worker.js';
+  PDFJS.workerSrc = '../../build/generic/build/pdf.worker.js';
 
   // Opening PDF by passing its binary data as a string. It is still preferable
   // to use Uint8Array, but string or array-like structure will work too.

--- a/examples/learning/prevnext.html
+++ b/examples/learning/prevnext.html
@@ -22,7 +22,7 @@
 <!-- for legacy browsers add compatibility.js -->
 <!--<script src="../compatibility.js"></script>-->
 
-<script src="../../build/pdf.js"></script>
+<script src="../../build/generic/build/pdf.js"></script>
 
 <script id="script">
   //
@@ -44,7 +44,7 @@
   // pdf.js's one, or the pdf.js is executed via eval(), the workerSrc property
   // shall be specified.
   //
-  // PDFJS.workerSrc = '../../build/pdf.worker.js';
+  // PDFJS.workerSrc = '../../build/generic/build/pdf.worker.js';
 
   var pdfDoc = null,
       pageNum = 1,

--- a/examples/text-only/index.html
+++ b/examples/text-only/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta charset="UTF-8">
     <title>Text-only PDF.js example</title>
     <script src="../../build/generic/build/pdf.js"></script>
     <script src="pdf2svg.js"></script>

--- a/examples/text-only/pdf2svg.js
+++ b/examples/text-only/pdf2svg.js
@@ -18,7 +18,7 @@ var PAGE_NUMBER = 1;
 var PAGE_SCALE = 1.5;
 var SVG_NS = 'http://www.w3.org/2000/svg';
 
-PDFJS.workerSrc = '../../build/pdf.worker.js';
+PDFJS.workerSrc = '../../build/generic/build/pdf.worker.js';
 
 function buildSVG(viewport, textContent) {
   // Building SVG with size of the viewport (for simplicity)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,6 +20,7 @@
 var fs = require('fs');
 var gulp = require('gulp');
 var gutil = require('gulp-util');
+var rename = require('gulp-rename');
 var mkdirp = require('mkdirp');
 var rimraf = require('rimraf');
 var runSequence = require('run-sequence');
@@ -34,10 +35,19 @@ var BUILD_DIR = 'build/';
 var JSDOC_DIR = 'jsdoc/';
 var L10N_DIR = 'l10n/';
 var TEST_DIR = 'test/';
+var EXTENSION_SRC_DIR = 'extensions/';
 
-var makeFile = require('./make.js');
-var stripCommentHeaders = makeFile.stripCommentHeaders;
-var builder = makeFile.builder;
+var GENERIC_DIR = BUILD_DIR + 'generic/';
+var COMPONENTS_DIR = BUILD_DIR + 'components/';
+var SINGLE_FILE_DIR = BUILD_DIR + 'singlefile/';
+var MINIFIED_DIR = BUILD_DIR + 'minified/';
+var FIREFOX_BUILD_DIR = BUILD_DIR + 'firefox/';
+var COMMON_WEB_FILES = [
+  'web/images/*.{png,svg,gif,cur}',
+  'web/debugger.js'
+];
+
+var builder = require('./external/builder/builder.js');
 
 var CONFIG_FILE = 'pdfjs.config';
 var config = JSON.parse(fs.readFileSync(CONFIG_FILE).toString());
@@ -74,6 +84,16 @@ function stripUMDHeaders(content) {
     '\\} else if \\(typeof exports !== \'undefined\'\\) \\{[^}]*' +
     '\\} else ', 'g');
   return content.replace(reg, '');
+}
+
+function stripCommentHeaders(content) {
+  var notEndOfComment = '(?:[^*]|\\*(?!/))+';
+  var reg = new RegExp(
+    '\n/\\* Copyright' + notEndOfComment + '\\*/\\s*' +
+    '(?:/\\*' + notEndOfComment + '\\*/\\s*|//(?!#).*\n\\s*)*' +
+    '\\s*\'use strict\';', 'g');
+  content = content.replace(reg, '');
+  return content;
 }
 
 function checkChromePreferencesFile(chromePrefsPath, webPrefsPath) {
@@ -296,6 +316,14 @@ function checkDir(path) {
   }
 }
 
+function getTempFile(prefix, suffix) {
+  mkdirp.sync(BUILD_DIR + 'tmp/');
+  var bytes = require('crypto').randomBytes(6).toString('hex');
+  var path = BUILD_DIR + 'tmp/' + prefix + bytes + suffix;
+  fs.writeFileSync(path, '');
+  return path;
+}
+
 function createTestSource(testsName) {
   var source = stream.Readable({ objectMode: true });
   source._read = function () {
@@ -484,53 +512,326 @@ gulp.task('cmaps', function () {
   compressCmaps(CMAP_INPUT, VIEWER_CMAP_OUTPUT, true);
 });
 
-gulp.task('bundle-firefox', ['buildnumber'], function () {
-  var defines = builder.merge(DEFINES, {FIREFOX: true});
-  return streamqueue({ objectMode: true },
-    createBundle(defines), createWebBundle(defines))
-    .pipe(gulp.dest(BUILD_DIR));
-});
-
-gulp.task('bundle-mozcentral', ['buildnumber'], function () {
-  var defines = builder.merge(DEFINES, {MOZCENTRAL: true});
-  return streamqueue({ objectMode: true },
-    createBundle(defines), createWebBundle(defines))
-    .pipe(gulp.dest(BUILD_DIR));
-});
-
-gulp.task('bundle-chromium', ['buildnumber'], function () {
-  var defines = builder.merge(DEFINES, {CHROME: true});
-  return streamqueue({ objectMode: true },
-    createBundle(defines), createWebBundle(defines))
-    .pipe(gulp.dest(BUILD_DIR));
-});
-
-gulp.task('bundle-singlefile', ['buildnumber'], function () {
-  var defines = builder.merge(DEFINES, {SINGLE_FILE: true});
-  return createBundle(defines).pipe(gulp.dest(BUILD_DIR));
-});
-
-gulp.task('bundle-generic', ['buildnumber'], function () {
-  var defines = builder.merge(DEFINES, {GENERIC: true});
-  return streamqueue({ objectMode: true },
-    createBundle(defines), createWebBundle(defines))
-    .pipe(gulp.dest(BUILD_DIR));
-});
-
-gulp.task('bundle-minified', ['buildnumber'], function () {
-  var defines = builder.merge(DEFINES, {MINIFIED: true, GENERIC: true});
-  return streamqueue({ objectMode: true },
-    createBundle(defines), createWebBundle(defines))
-    .pipe(gulp.dest(BUILD_DIR));
-});
-
-gulp.task('bundle-components', ['buildnumber'], function () {
-  var defines = builder.merge(DEFINES, {COMPONENTS: true, GENERIC: true});
-  return createWebBundle(defines).pipe(gulp.dest(BUILD_DIR));
-});
-
 gulp.task('bundle', ['buildnumber'], function () {
   return createBundle(DEFINES).pipe(gulp.dest(BUILD_DIR));
+});
+
+function preprocessCSS(source, mode, defines, cleanup) {
+  var outName = getTempFile('~preprocess', '.css');
+  var setup = {
+    defines: defines,
+    copy: [],
+    preprocess: [],
+    preprocessCSS: [
+      [mode, source, outName]
+    ]
+  };
+  builder.build(setup);
+  var out = fs.readFileSync(outName).toString();
+  fs.unlinkSync(outName);
+  if (cleanup) {
+    // Strip out all license headers in the middle.
+    var reg = /\n\/\* Copyright(.|\n)*?Mozilla Foundation(.|\n)*?\*\//g;
+    out = out.replace(reg, '');
+  }
+
+  var i = source.lastIndexOf('/');
+  return createStringSource(source.substr(i + 1), out);
+}
+
+function preprocessHTML(source, defines) {
+  var outName = getTempFile('~preprocess', '.html');
+  var setup = {
+    defines: defines,
+    copy: [],
+    preprocess: [
+      [source, outName]
+    ],
+    preprocessCSS: []
+  };
+  builder.build(setup);
+  var out = fs.readFileSync(outName).toString();
+  fs.unlinkSync(outName);
+
+  var i = source.lastIndexOf('/');
+  return createStringSource(source.substr(i + 1), out);
+}
+
+function preprocessJS(source, defines, cleanup) {
+  var outName = getTempFile('~preprocess', '.js');
+  var setup = {
+    defines: defines,
+    copy: [],
+    preprocess: [
+      [source, outName]
+    ],
+    preprocessCSS: []
+  };
+  builder.build(setup);
+  var out = fs.readFileSync(outName).toString();
+  fs.unlinkSync(outName);
+  if (cleanup) {
+    out = stripCommentHeaders(out);
+  }
+
+  var i = source.lastIndexOf('/');
+  return createStringSource(source.substr(i + 1), out);
+}
+
+// Builds the generic production viewer that should be compatible with most
+// modern HTML5 browsers.
+gulp.task('generic', ['buildnumber', 'locale'], function () {
+  console.log();
+  console.log('### Creating generic viewer');
+  var defines = builder.merge(DEFINES, {GENERIC: true});
+
+  rimraf.sync(GENERIC_DIR);
+
+  return merge([
+    createBundle(defines).pipe(gulp.dest(GENERIC_DIR + 'build')),
+    createWebBundle(defines).pipe(gulp.dest(GENERIC_DIR + 'web')),
+    gulp.src(COMMON_WEB_FILES, {base: 'web/'})
+        .pipe(gulp.dest(GENERIC_DIR + 'web')),
+    gulp.src('LICENSE').pipe(gulp.dest(GENERIC_DIR)),
+    gulp.src([
+      'external/webL10n/l10n.js',
+      'web/compatibility.js'
+    ]).pipe(gulp.dest(GENERIC_DIR + 'web')),
+    gulp.src([
+      'web/locale/*/viewer.properties',
+      'web/locale/locale.properties'
+    ], {base: 'web/'}).pipe(gulp.dest(GENERIC_DIR + 'web')),
+    gulp.src(['external/bcmaps/*.bcmap', 'external/bcmaps/LICENSE'],
+             {base: 'external/bcmaps'})
+        .pipe(gulp.dest(GENERIC_DIR + 'web/cmaps')),
+    preprocessHTML('web/viewer.html', defines)
+        .pipe(gulp.dest(GENERIC_DIR + 'web')),
+    preprocessCSS('web/viewer.css', 'generic', defines, true)
+        .pipe(gulp.dest(GENERIC_DIR + 'web')),
+
+    gulp.src('web/compressed.tracemonkey-pldi-09.pdf')
+        .pipe(gulp.dest(GENERIC_DIR + 'web')),
+  ]);
+});
+
+gulp.task('components', ['buildnumber'], function () {
+  console.log();
+  console.log('### Creating generic components');
+  var defines = builder.merge(DEFINES, {COMPONENTS: true, GENERIC: true});
+
+  rimraf.sync(COMPONENTS_DIR);
+
+  var COMPONENTS_IMAGES = [
+    'web/images/annotation-*.svg',
+    'web/images/loading-icon.gif',
+    'web/images/shadow.png',
+    'web/images/texture.png',
+  ];
+
+  return merge([
+    createWebBundle(defines).pipe(gulp.dest(COMPONENTS_DIR)),
+    gulp.src(COMPONENTS_IMAGES).pipe(gulp.dest(COMPONENTS_DIR + 'images')),
+    gulp.src('web/compatibility.js').pipe(gulp.dest(COMPONENTS_DIR)),
+    preprocessCSS('web/pdf_viewer.css', 'components', defines, true)
+        .pipe(gulp.dest(COMPONENTS_DIR)),
+  ]);
+});
+
+gulp.task('singlefile', ['buildnumber'], function () {
+  console.log();
+  console.log('### Creating singlefile build');
+  var defines = builder.merge(DEFINES, {SINGLE_FILE: true});
+
+  var SINGLE_FILE_BUILD_DIR = SINGLE_FILE_DIR + 'build/';
+
+  rimraf.sync(SINGLE_FILE_DIR);
+
+  return createBundle(defines).pipe(gulp.dest(SINGLE_FILE_BUILD_DIR));
+});
+
+gulp.task('minified-pre', ['buildnumber', 'locale'], function () {
+  console.log();
+  console.log('### Creating minified viewer');
+  var defines = builder.merge(DEFINES, {MINIFIED: true, GENERIC: true});
+
+  rimraf.sync(MINIFIED_DIR);
+
+  return merge([
+    createBundle(defines).pipe(gulp.dest(MINIFIED_DIR + 'build')),
+    createWebBundle(defines).pipe(gulp.dest(MINIFIED_DIR + 'web')),
+    gulp.src(COMMON_WEB_FILES, {base: 'web/'})
+        .pipe(gulp.dest(MINIFIED_DIR + 'web')),
+    gulp.src([
+      'web/locale/*/viewer.properties',
+      'web/locale/locale.properties'
+    ], {base: 'web/'}).pipe(gulp.dest(MINIFIED_DIR + 'web')),
+    gulp.src(['external/bcmaps/*.bcmap', 'external/bcmaps/LICENSE'],
+             {base: 'external/bcmaps'})
+        .pipe(gulp.dest(MINIFIED_DIR + 'web/cmaps')),
+
+    preprocessHTML('web/viewer.html', defines)
+        .pipe(gulp.dest(MINIFIED_DIR + 'web')),
+    preprocessCSS('web/viewer.css', 'minified', defines, true)
+        .pipe(gulp.dest(MINIFIED_DIR + 'web')),
+
+    gulp.src('web/compressed.tracemonkey-pldi-09.pdf')
+        .pipe(gulp.dest(MINIFIED_DIR + 'web')),
+  ]);
+});
+
+gulp.task('firefox-pre', ['buildnumber', 'locale'], function () {
+  console.log();
+  console.log('### Building Firefox extension');
+  var defines = builder.merge(DEFINES, {FIREFOX: true});
+
+  var FIREFOX_BUILD_CONTENT_DIR = FIREFOX_BUILD_DIR + '/content/',
+      FIREFOX_EXTENSION_DIR = 'extensions/firefox/',
+      FIREFOX_CONTENT_DIR = EXTENSION_SRC_DIR + '/firefox/content/';
+
+  // Clear out everything in the firefox extension build directory
+  rimraf.sync(FIREFOX_BUILD_DIR);
+
+  return merge([
+    createBundle(defines).pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR + 'build')),
+    createWebBundle(defines).pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR + 'web')),
+    gulp.src(COMMON_WEB_FILES, {base: 'web/'})
+        .pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR + 'web')),
+    gulp.src(FIREFOX_EXTENSION_DIR + 'locale/**/*.properties',
+             {base: FIREFOX_EXTENSION_DIR})
+        .pipe(gulp.dest(FIREFOX_BUILD_DIR)),
+    gulp.src(['external/bcmaps/*.bcmap', 'external/bcmaps/LICENSE'],
+             {base: 'external/bcmaps'})
+        .pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR + 'web/cmaps')),
+
+    preprocessHTML('web/viewer.html', defines)
+        .pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR + 'web')),
+    preprocessCSS('web/viewer.css', 'firefox', defines, true)
+        .pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR + 'web')),
+
+    gulp.src(FIREFOX_CONTENT_DIR + 'PdfJs-stub.jsm')
+        .pipe(rename('PdfJs.jsm'))
+        .pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR)),
+    gulp.src(FIREFOX_CONTENT_DIR + 'PdfJsTelemetry-addon.jsm')
+        .pipe(rename('PdfJsTelemetry.jsm'))
+        .pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR)),
+    gulp.src(FIREFOX_EXTENSION_DIR + '**/*.{rdf,png,manifest}',
+             {base: FIREFOX_EXTENSION_DIR})
+        .pipe(gulp.dest(FIREFOX_BUILD_DIR)),
+    gulp.src(FIREFOX_EXTENSION_DIR + 'chrome/content.js',
+             {base: FIREFOX_EXTENSION_DIR})
+        .pipe(gulp.dest(FIREFOX_BUILD_DIR)),
+    gulp.src('LICENSE').pipe(gulp.dest(FIREFOX_BUILD_DIR)),
+
+    gulp.src(FIREFOX_EXTENSION_DIR + 'tools/l10n.js')
+        .pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR + '/web')),
+
+    preprocessJS(FIREFOX_CONTENT_DIR + 'PdfStreamConverter.jsm', defines, true)
+        .pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR)),
+    preprocessJS(FIREFOX_CONTENT_DIR + 'PdfJsNetwork.jsm', defines, true)
+        .pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR)),
+    preprocessJS(FIREFOX_CONTENT_DIR + 'PdfjsContentUtils.jsm', defines, true)
+        .pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR)),
+    preprocessJS(FIREFOX_CONTENT_DIR + 'PdfjsChromeUtils.jsm', defines, true)
+        .pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR)),
+    preprocessJS(FIREFOX_EXTENSION_DIR + 'bootstrap.js', defines, true)
+        .pipe(gulp.dest(FIREFOX_BUILD_DIR)),
+  ]);
+});
+
+gulp.task('mozcentral-pre', ['buildnumber', 'locale'], function () {
+  console.log();
+  console.log('### Building mozilla-central extension');
+  var defines = builder.merge(DEFINES, {MOZCENTRAL: true});
+
+  var MOZCENTRAL_DIR = BUILD_DIR + 'mozcentral/',
+      MOZCENTRAL_EXTENSION_DIR = MOZCENTRAL_DIR + 'browser/extensions/pdfjs/',
+      MOZCENTRAL_CONTENT_DIR = MOZCENTRAL_EXTENSION_DIR + 'content/',
+      FIREFOX_EXTENSION_DIR = 'extensions/firefox/',
+      MOZCENTRAL_L10N_DIR = MOZCENTRAL_DIR + 'browser/locales/en-US/pdfviewer/',
+      FIREFOX_CONTENT_DIR = EXTENSION_SRC_DIR + '/firefox/content/';
+
+  // Clear out everything in the firefox extension build directory
+  rimraf.sync(MOZCENTRAL_DIR);
+
+  return merge([
+    createBundle(defines).pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'build')),
+    createWebBundle(defines).pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'web')),
+    gulp.src(COMMON_WEB_FILES, {base: 'web/'})
+        .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'web')),
+    gulp.src(['external/bcmaps/*.bcmap', 'external/bcmaps/LICENSE'],
+             {base: 'external/bcmaps'})
+        .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'web/cmaps')),
+
+    preprocessHTML('web/viewer.html', defines)
+        .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'web')),
+    preprocessCSS('web/viewer.css', 'mozcentral', defines, true)
+        .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'web')),
+
+    gulp.src(FIREFOX_CONTENT_DIR + 'PdfJsTelemetry.jsm')
+        .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR)),
+    gulp.src(FIREFOX_EXTENSION_DIR + 'chrome-mozcentral.manifest')
+        .pipe(rename('chrome.manifest'))
+        .pipe(gulp.dest(MOZCENTRAL_EXTENSION_DIR)),
+    gulp.src(FIREFOX_EXTENSION_DIR + 'locale/en-US/*.properties',
+             {base: FIREFOX_EXTENSION_DIR})
+        .pipe(gulp.dest(MOZCENTRAL_L10N_DIR)),
+    gulp.src(FIREFOX_EXTENSION_DIR + 'README.mozilla')
+        .pipe(gulp.dest(MOZCENTRAL_EXTENSION_DIR)),
+    gulp.src('LICENSE').pipe(gulp.dest(MOZCENTRAL_EXTENSION_DIR)),
+    gulp.src(FIREFOX_EXTENSION_DIR + 'tools/l10n.js')
+        .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + '/web')),
+
+    preprocessJS(FIREFOX_CONTENT_DIR + 'PdfJs.jsm', defines, true)
+        .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR)),
+    preprocessJS(FIREFOX_CONTENT_DIR + 'PdfStreamConverter.jsm', defines, true)
+        .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR)),
+    preprocessJS(FIREFOX_CONTENT_DIR + 'PdfJsNetwork.jsm', defines, true)
+        .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR)),
+    preprocessJS(FIREFOX_CONTENT_DIR + 'PdfjsContentUtils.jsm', defines, true)
+        .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR)),
+    preprocessJS(FIREFOX_CONTENT_DIR + 'PdfjsChromeUtils.jsm', defines, true)
+        .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR)),
+  ]);
+});
+
+gulp.task('chromium-pre', ['buildnumber', 'locale'], function () {
+  console.log();
+  console.log('### Building Chromium extension');
+  var defines = builder.merge(DEFINES, {CHROME: true});
+
+  var CHROME_BUILD_DIR = BUILD_DIR + '/chromium/',
+      CHROME_BUILD_CONTENT_DIR = CHROME_BUILD_DIR + '/content/';
+
+  // Clear out everything in the chrome extension build directory
+  rimraf.sync(CHROME_BUILD_DIR);
+  return merge([
+    createBundle(defines).pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'build')),
+    createWebBundle(defines).pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web')),
+    gulp.src(COMMON_WEB_FILES, {base: 'web/'})
+        .pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web')),
+
+    gulp.src('external/webL10n/l10n.js')
+        .pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web')),
+    gulp.src([
+      'web/locale/*/viewer.properties',
+      'web/locale/locale.properties'
+    ], {base: 'web/'}).pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web')),
+    gulp.src(['external/bcmaps/*.bcmap', 'external/bcmaps/LICENSE'],
+             {base: 'external/bcmaps'})
+        .pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web/cmaps')),
+
+    preprocessHTML('web/viewer.html', defines)
+        .pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web')),
+    preprocessCSS('web/viewer.css', 'chrome', defines, true)
+        .pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web')),
+
+    gulp.src('LICENSE').pipe(gulp.dest(CHROME_BUILD_DIR)),
+    gulp.src('extensions/chromium/*.{json,html,js,css,png}')
+        .pipe(gulp.dest(CHROME_BUILD_DIR)),
+    gulp.src('extensions/chromium/**/*.{json,html,js,css,png}',
+             {base: 'extensions/chromium/'})
+        .pipe(gulp.dest(CHROME_BUILD_DIR)),
+  ]);
 });
 
 gulp.task('jsdoc', function (done) {
@@ -723,6 +1024,8 @@ gulp.task('importl10n', function(done) {
 });
 
 // Getting all shelljs registered tasks and register them with gulp
+require('./make.js');
+
 var gulpContext = false;
 for (var taskName in global.target) {
   if (taskName in gulp.tasks) {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "eslint": "^3.11.1",
     "esprima": "^2.7.2",
     "gulp": "^3.9.1",
+    "gulp-rename": "^1.2.2",
     "gulp-util": "^3.0.7",
     "gulp-zip": "^3.2.0",
     "jasmine": "^2.5.2",


### PR DESCRIPTION
Moves all preprocessor logic and code from the make.js file and removes intermediate build/pdf.js, build/pdf.worker.js and build/viewer.js files (they were "last build configuration"-processed)

P.S. #7062