### PR TITLE
Open PDF attachments in the viewer instead of an unconditional download

### DIFF
--- a/extensions/chromium/extension-router.js
+++ b/extensions/chromium/extension-router.js
@@ -27,6 +27,8 @@ limitations under the License.
     'ftp',
     'file',
     'chrome-extension',
+    'blob',
+    'data',
     // Chromium OS
     'filesystem',
     // Chromium OS, shorthand for filesystem:<origin>/external/

--- a/extensions/chromium/manifest.json
+++ b/extensions/chromium/manifest.json
@@ -63,6 +63,8 @@
     "ftp:/*",
     "file:/*",
     "chrome-extension:/*",
+    "blob:*",
+    "data:*",
     "filesystem:/*",
     "drive:*"
   ]

--- a/web/app.js
+++ b/web/app.js
@@ -737,7 +737,9 @@ var PDFViewerApplication = {
     }
 
     var url = this.baseUrl;
-    var filename = getPDFFileNameFromURL(url);
+    // Use this.url instead of this.baseUrl to perform filename detection based
+    // on the reference fragment as ultimate fallback if needed.
+    var filename = getPDFFileNameFromURL(this.url);
     var downloadManager = this.downloadManager;
     downloadManager.onerror = function (err) {
       // This error won't really be helpful because it's likely the

--- a/web/app.js
+++ b/web/app.js
@@ -569,14 +569,17 @@ var PDFViewerApplication = {
   setTitleUsingUrl: function pdfViewSetTitleUsingUrl(url) {
     this.url = url;
     this.baseUrl = url.split('#')[0];
-    try {
-      this.setTitle(decodeURIComponent(
-        pdfjsLib.getFilenameFromUrl(url)) || url);
-    } catch (e) {
-      // decodeURIComponent may throw URIError,
-      // fall back to using the unprocessed url in that case
-      this.setTitle(url);
+    var title = getPDFFileNameFromURL(url, '');
+    if (!title) {
+      try {
+        title = decodeURIComponent(pdfjsLib.getFilenameFromUrl(url)) || url;
+      } catch (e) {
+        // decodeURIComponent may throw URIError,
+        // fall back to using the unprocessed url in that case
+        title = url;
+      }
     }
+    this.setTitle(title);
   },
 
   setTitle: function pdfViewSetTitle(title) {

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -371,8 +371,8 @@ function noContextMenuHandler(e) {
  * @return {String} Guessed PDF file name.
  */
 function getPDFFileNameFromURL(url) {
-  var reURI = /^(?:([^:]+:)?\/\/[^\/]+)?([^?#]*)(\?[^#]*)?(#.*)?$/;
-  //            SCHEME      HOST         1.PATH  2.QUERY   3.REF
+  var reURI = /^(?:(?:[^:]+:)?\/\/[^\/]+)?([^?#]*)(\?[^#]*)?(#.*)?$/;
+  //            SCHEME        HOST         1.PATH  2.QUERY   3.REF
   // Pattern to get last matching NAME.pdf
   var reFilename = /[^\/?#=]+\.pdf\b(?!.*\.pdf\b)/i;
   var splitURI = reURI.exec(url);

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -368,9 +368,13 @@ function noContextMenuHandler(e) {
 /**
  * Returns the filename or guessed filename from the url (see issue 3455).
  * url {String} The original PDF location.
+ * defaultFilename {string} The value to return if the file name is unknown.
  * @return {String} Guessed PDF file name.
  */
-function getPDFFileNameFromURL(url) {
+function getPDFFileNameFromURL(url, defaultFilename) {
+  if (typeof defaultFilename === 'undefined') {
+    defaultFilename = 'document.pdf';
+  }
   var reURI = /^(?:(?:[^:]+:)?\/\/[^\/]+)?([^?#]*)(\?[^#]*)?(#.*)?$/;
   //            SCHEME        HOST         1.PATH  2.QUERY   3.REF
   // Pattern to get last matching NAME.pdf
@@ -392,7 +396,7 @@ function getPDFFileNameFromURL(url) {
       }
     }
   }
-  return suggestedFilename || 'document.pdf';
+  return suggestedFilename || defaultFilename;
 }
 
 function normalizeWheelEventDelta(evt) {


### PR DESCRIPTION
To test:

1. Open the PDF from #6643.
2. Click on the attachment list.
3. Click on a PDF, and confirm that it opens in a new tab.

Tested with Firefox 51 (generic target), Chrome 56 (extension).

Fixes #6643
Relevant for #4282