### PR TITLE
Adjust the `brace-style` ESLint rule to disallow single lines (and also enable `no-iterator`)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -56,6 +56,7 @@
     "no-floating-decimal": "error",
     "no-global-assign": "error",
     "no-implied-eval": "error",
+    "no-iterator": "error",
     "no-lone-blocks": "error",
     "no-multi-spaces": "error",
     "no-multi-str": "error",
@@ -92,7 +93,9 @@
     // Stylistic Issues
     "array-bracket-spacing": ["error", "never"],
     "block-spacing": ["error", "always"],
-    "brace-style": ["error", "1tbs", { "allowSingleLine": true, }],
+    "brace-style": ["error", "1tbs", {
+      "allowSingleLine": false,
+    }],
     "comma-spacing": ["error", { "before": false, "after": true, }],
     "comma-style": ["error", "last"],
     "eol-last": "error",
@@ -127,7 +130,7 @@
         "balanced": true,
       }
     }],
-  },
 
-  // ECMAScript 6
+    // ECMAScript 6
+  },
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -125,7 +125,9 @@ function bundle(filename, outfilename, pathPrefix, initFiles, amdName, defines,
   // readDependencies returns AMD module names: removing 'pdfjs' prefix and
   // adding '.js' extensions to the name.
   var umd = require('./external/umdutils/verifier.js');
-  initFiles = initFiles.map(function (p) { return pathPrefix + p; });
+  initFiles = initFiles.map(function (p) {
+    return pathPrefix + p;
+  });
   var files = umd.readDependencies(initFiles).loadOrder.map(function (name) {
     return pathPrefix + name.replace(/^[\w\-]+\//, '') + '.js';
   });
@@ -166,7 +168,9 @@ function bundle(filename, outfilename, pathPrefix, initFiles, amdName, defines,
 
   var templateContent = fs.readFileSync(filename).toString();
   templateContent = templateContent.replace(
-    /\/\/#expand\s+__BUNDLE__\s*\n/, function (all) { return bundleContent; });
+    /\/\/#expand\s+__BUNDLE__\s*\n/, function (all) {
+      return bundleContent;
+    });
   bundleContent = null;
 
   templateContent = p2.preprocessPDFJSCode(ctx, templateContent);

--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -430,7 +430,9 @@ var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
         }
       }
 
-      chunksToRequest.sort(function(a, b) { return a - b; });
+      chunksToRequest.sort(function(a, b) {
+        return a - b;
+      });
       return this._requestChunks(chunksToRequest);
     },
 

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -1010,7 +1010,9 @@ var Font = (function FontClosure() {
 
     var i, ii, j, jj;
     for (i = ranges.length - 1; i >= 0; --i) {
-      if (ranges[i][0] <= 0xFFFF) { break; }
+      if (ranges[i][0] <= 0xFFFF) {
+        break;
+      }
     }
     var bmpLength = i + 1;
 

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -94,7 +94,9 @@ IPDFStream.prototype = {
    * Gets a reader for the entire PDF data.
    * @returns {IPDFStreamReader}
    */
-  getFullReader: function () { return null; },
+  getFullReader: function () {
+    return null;
+  },
 
   /**
    * Gets a reader for the range of the PDF data.
@@ -102,7 +104,9 @@ IPDFStream.prototype = {
    * @param {number} end - the end offset of the data.
    * @returns {IPDFStreamRangeReader}
    */
-  getRangeReader: function (begin, end) { return null; },
+  getRangeReader: function (begin, end) {
+    return null;
+  },
 
   /**
    * Cancels all opened reader and closes all their opened requests.
@@ -123,14 +127,18 @@ IPDFStreamReader.prototype = {
    * the PDF data stream are available.
    * @returns {Promise}
    */
-  get headersReady() { return null; },
+  get headersReady() {
+    return null;
+  },
 
   /**
    * Gets PDF binary data length. It is defined after the headersReady promise
    * is resolved.
    * @returns {number} The data length (or 0 if unknown).
    */
-  get contentLength() { return 0; },
+  get contentLength() {
+    return 0;
+  },
 
   /**
    * Gets ability of the stream to handle range requests. It is defined after
@@ -138,14 +146,18 @@ IPDFStreamReader.prototype = {
    * or an error occurs.
    * @returns {boolean}
    */
-  get isRangeSupported() { return false; },
+  get isRangeSupported() {
+    return false;
+  },
 
   /**
    * Gets ability of the stream to progressively load binary data. It is defined
    * after the headersReady promise is resolved.
    * @returns {boolean}
    */
-  get isStreamingSupported() { return false; },
+  get isStreamingSupported() {
+    return false;
+  },
 
   /**
    * Requests a chunk of the binary data. The method returns the promise, which
@@ -183,7 +195,9 @@ IPDFStreamRangeReader.prototype = {
    * Gets ability of the stream to progressively load binary data.
    * @returns {boolean}
    */
-  get isStreamingSupported() { return false; },
+  get isStreamingSupported() {
+    return false;
+  },
 
   /**
    * Requests a chunk of the binary data. The method returns the promise, which

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -98,7 +98,9 @@ if (typeof PDFJSDev === 'undefined' ||
     return (typeof imageData.data.buffer !== 'undefined');
   };
 } else {
-  hasCanvasTypedArrays = function () { return true; };
+  hasCanvasTypedArrays = function () {
+    return true;
+  };
 }
 
 var LinkTarget = {

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -68,8 +68,12 @@
   }
   delete PDFJS.verbosity;
   Object.defineProperty(PDFJS, 'verbosity', {
-    get: function () { return sharedUtil.getVerbosityLevel(); },
-    set: function (level) { sharedUtil.setVerbosityLevel(level); },
+    get: function () {
+      return sharedUtil.getVerbosityLevel();
+    },
+    set: function (level) {
+      sharedUtil.setVerbosityLevel(level);
+    },
     enumerable: true,
     configurable: true
   });

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -347,7 +347,9 @@ var renderTextLayer = (function renderTextLayerClosure() {
 
   function expandBoundsLTR(width, bounds) {
     // Sorting by x1 coordinate and walk by the bounds in the same order.
-    bounds.sort(function (a, b) { return a.x1 - b.x1 || a.index - b.index; });
+    bounds.sort(function (a, b) {
+      return a.x1 - b.x1 || a.index - b.index;
+    });
 
     // First we see on the horizon is a fake boundary.
     var fakeBoundary = {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1193,7 +1193,9 @@ function createPromiseCapability() {
     }
     if (typeof globalScope.Promise.resolve !== 'function') {
       globalScope.Promise.resolve = function (value) {
-        return new globalScope.Promise(function (resolve) { resolve(value); });
+        return new globalScope.Promise(function (resolve) {
+          resolve(value);
+        });
       };
     }
     if (typeof globalScope.Promise.reject !== 'function') {
@@ -1401,7 +1403,9 @@ if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL')) {
    * @returns {Promise}
    */
   Promise.resolve = function Promise_resolve(value) {
-    return new Promise(function (resolve) { resolve(value); });
+    return new Promise(function (resolve) {
+      resolve(value);
+    });
   };
 
   /**
@@ -1410,7 +1414,9 @@ if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL')) {
    * @returns {Promise}
    */
   Promise.reject = function Promise_reject(reason) {
-    return new Promise(function (resolve, reject) { reject(reason); });
+    return new Promise(function (resolve, reject) {
+      reject(reason);
+    });
   };
 
   Promise.prototype = {

--- a/test/chromium/test-telemetry.js
+++ b/test/chromium/test-telemetry.js
@@ -84,7 +84,9 @@ function createExtensionGlobal() {
   // Network-related mocks.
   window.Request = {};
   window.Request.prototype = {
-    get mode() { throw new TypeError('Illegal invocation'); },
+    get mode() {
+      throw new TypeError('Illegal invocation');
+    },
   };
   window.fetch = function(url, options) {
     assert.equal(url, LOG_URL);
@@ -339,7 +341,9 @@ var tests = [
     var window = createExtensionGlobal();
     var didWarn = false;
     window.console = {};
-    window.console.warn = function() { didWarn = true; };
+    window.console.warn = function() {
+      didWarn = true;
+    };
     window.chrome.runtime.id = 'abcdefghijklmnopabcdefghijklmnop';
     telemetryScript.runInNewContext(window);
     assert.deepEqual(window.test_requests, []);
@@ -373,7 +377,9 @@ var tests = [
   function test_fetch_mode_not_supported() {
     var window = createExtensionGlobal();
     delete window.Request.prototype.mode;
-    window.fetch = function() { throw new Error('Unexpected call to fetch!'); };
+    window.fetch = function() {
+      throw new Error('Unexpected call to fetch!');
+    };
     telemetryScript.runInNewContext(window);
     assert.deepEqual(window.test_requests, [{
       'Deduplication-Id': '4242424242',

--- a/test/font/jasmine-boot.js
+++ b/test/font/jasmine-boot.js
@@ -67,7 +67,9 @@ function initializePDFJS(callback) {
 
   // Runner Parameters
   var queryString = new jasmine.QueryString({
-    getWindowLocation: function() { return window.location; }
+    getWindowLocation: function() {
+      return window.location;
+    }
   });
 
   var catchingExceptions = queryString.getParam('catch');
@@ -101,7 +103,9 @@ function initializePDFJS(callback) {
     addToExistingQueryString: function(key, value) {
       return queryString.fullStringWithNewParam(key, value);
     },
-    getContainer: function() { return document.body; },
+    getContainer: function() {
+      return document.body;
+    },
     createElement: function() {
       return document.createElement.apply(document, arguments);
     },
@@ -122,7 +126,9 @@ function initializePDFJS(callback) {
   // Filter which specs will be run by matching the start of the full name
   // against the `spec` query param.
   var specFilter = new jasmine.HtmlSpecFilter({
-    filterString: function() { return queryString.getParam('spec'); }
+    filterString: function() {
+      return queryString.getParam('spec');
+    }
   });
 
   env.specFilter = function(spec) {

--- a/test/stats/statcmp.js
+++ b/test/stats/statcmp.js
@@ -66,7 +66,9 @@ function flatten(stats) {
   });
   // Use only overall results if not grouped by 'stat'
   if (options.groupBy.indexOf('stat') < 0) {
-    rows = rows.filter(function(s) { return s.stat === 'Overall'; });
+    rows = rows.filter(function(s) {
+      return s.stat === 'Overall';
+    });
   }
   return rows;
 }
@@ -129,7 +131,9 @@ function stat(baseline, current) {
   }
   var i, row, rows = [];
   // collect rows and measure column widths
-  var width = labels.map(function(s) { return s.length; });
+  var width = labels.map(function(s) {
+    return s.length;
+  });
   rows.push(labels);
   for (var k = 0; k < keys.length; k++) {
     var key = keys[k];
@@ -157,7 +161,9 @@ function stat(baseline, current) {
   }
 
   // add horizontal line
-  var hline = width.map(function(w) { return new Array(w + 1).join('-'); });
+  var hline = width.map(function(w) {
+    return new Array(w + 1).join('-');
+  });
   rows.splice(1, 0, hline);
 
   // print output

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1092,8 +1092,12 @@ describe('api', function() {
         var xhr = new XMLHttpRequest(pdfPath);
         xhr.open('GET', pdfPath);
         xhr.responseType = 'arraybuffer';
-        xhr.onload = function () { resolve(new Uint8Array(xhr.response)); };
-        xhr.onerror = function () { reject(new Error('PDF is not loaded')); };
+        xhr.onload = function () {
+          resolve(new Uint8Array(xhr.response));
+        };
+        xhr.onerror = function () {
+          reject(new Error('PDF is not loaded'));
+        };
         xhr.send();
       });
       return loadPromise;

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -211,8 +211,9 @@ describe('cmap', function() {
       expect(cmap instanceof IdentityCMap).toEqual(true);
       expect(cmap.vertical).toEqual(false);
       expect(cmap.length).toEqual(0x10000);
-      expect(function() { return cmap.isIdentityCMap; }).toThrow(
-        new Error('should not access .isIdentityCMap'));
+      expect(function() {
+        return cmap.isIdentityCMap;
+      }).toThrow(new Error('should not access .isIdentityCMap'));
       done();
     }).catch(function (reason) {
       done.fail(reason);

--- a/test/unit/function_spec.js
+++ b/test/unit/function_spec.js
@@ -124,8 +124,9 @@ describe('function', function() {
       expect(program).toMatchArray(expectedProgram);
     });
     it('handles missing brackets', function() {
-      expect(function() { parse('{'); }).toThrow(
-        new Error('Unexpected symbol: found undefined expected 1.'));
+      expect(function() {
+        parse('{');
+      }).toThrow(new Error('Unexpected symbol: found undefined expected 1.'));
     });
     it('handles junk after the end', function() {
       var number = 3.3;

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -83,7 +83,9 @@ function initializePDFJS(callback) {
 
   // Runner Parameters
   var queryString = new jasmine.QueryString({
-    getWindowLocation: function() { return window.location; }
+    getWindowLocation: function() {
+      return window.location;
+    }
   });
 
   var catchingExceptions = queryString.getParam('catch');
@@ -117,7 +119,9 @@ function initializePDFJS(callback) {
     addToExistingQueryString: function(key, value) {
       return queryString.fullStringWithNewParam(key, value);
     },
-    getContainer: function() { return document.body; },
+    getContainer: function() {
+      return document.body;
+    },
     createElement: function() {
       return document.createElement.apply(document, arguments);
     },
@@ -138,7 +142,9 @@ function initializePDFJS(callback) {
   // Filter which specs will be run by matching the start of the full name
   // against the `spec` query param.
   var specFilter = new jasmine.HtmlSpecFilter({
-    filterString: function() { return queryString.getParam('spec'); }
+    filterString: function() {
+      return queryString.getParam('spec');
+    }
   });
 
   env.specFilter = function(spec) {

--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -419,13 +419,19 @@ if (typeof PDFJS === 'undefined') {
   } else if (!('bind' in console.log)) {
     // native functions in IE9 might not have bind
     console.log = (function(fn) {
-      return function(msg) { return fn(msg); };
+      return function(msg) {
+        return fn(msg);
+      };
     })(console.log);
     console.error = (function(fn) {
-      return function(msg) { return fn(msg); };
+      return function(msg) {
+        return fn(msg);
+      };
     })(console.error);
     console.warn = (function(fn) {
-      return function(msg) { return fn(msg); };
+      return function(msg) {
+        return fn(msg);
+      };
     })(console.warn);
   }
 })();
@@ -606,7 +612,9 @@ if (typeof PDFJS === 'undefined') {
     var inputProto = el.constructor.prototype;
     var typeProperty = Object.getOwnPropertyDescriptor(inputProto, 'type');
     Object.defineProperty(inputProto, 'type', {
-      get: function () { return typeProperty.get.call(this); },
+      get: function () {
+        return typeProperty.get.call(this);
+      },
       set: function (value) {
         typeProperty.set.call(this, value === 'number' ? 'text' : value);
       },
@@ -630,7 +638,9 @@ if (typeof PDFJS === 'undefined') {
       var value = readyStateProto.get.call(this);
       return value === 'interactive' ? 'loading' : value;
     },
-    set: function (value) { readyStateProto.set.call(this, value); },
+    set: function (value) {
+      readyStateProto.set.call(this, value);
+    },
     enumerable: true,
     configurable: true
   });

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -387,7 +387,9 @@ var Stepper = (function StepperClosure() {
       this.table.appendChild(chunk);
     },
     getNextBreakPoint: function getNextBreakPoint() {
-      this.breakPoints.sort(function(a, b) { return a - b; });
+      this.breakPoints.sort(function(a, b) {
+        return a - b;
+      });
       for (var i = 0; i < this.breakPoints.length; i++) {
         if (this.breakPoints[i] > this.currentIdx) {
           return this.breakPoints[i];
@@ -484,7 +486,9 @@ var Stats = (function Stats() {
       wrapper.appendChild(title);
       wrapper.appendChild(statsDiv);
       stats.push({ pageNumber: pageNumber, div: wrapper });
-      stats.sort(function(a, b) { return a.pageNumber - b.pageNumber; });
+      stats.sort(function(a, b) {
+        return a.pageNumber - b.pageNumber;
+      });
       clear(this.panel);
       for (var i = 0, ii = stats.length; i < ii; ++i) {
         this.panel.appendChild(stats[i].div);


### PR DESCRIPTION
See http://eslint.org/docs/rules/brace-style.
Having the opening/closing braces on the same line can often make the code slightly more difficult to read, in particular for `if`/`else if` statements, compared to using new lines.

This patch also, for consistency with `mozilla-central`, enables the [`no-iterator`](http://eslint.org/docs/rules/no-iterator) rule. Note that this rule didn't require a single code change.