### PR TITLE
[Firefox addon] Remove the unused `MOZ_CENTRAL` constant

### DIFF
--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -23,8 +23,7 @@ const Cc = Components.classes;
 const Ci = Components.interfaces;
 const Cr = Components.results;
 const Cu = Components.utils;
-// True only if this is the version of pdf.js that is included with firefox.
-const MOZ_CENTRAL = JSON.parse("PDFJSSCRIPT_MOZ_CENTRAL");
+
 const PDFJS_EVENT_ID = "pdf.js.message";
 const PDF_CONTENT_TYPE = "application/pdf";
 const PREF_PREFIX = "PDFJSSCRIPT_PREF_PREFIX";

--- a/make.js
+++ b/make.js
@@ -397,8 +397,6 @@ target.firefox = function() {
       FIREFOX_BUILD_CONTENT_DIR + 'PdfStreamConverter.jsm');
   sed('-i', /PDFJSSCRIPT_PREF_PREFIX/, FIREFOX_PREF_PREFIX,
       FIREFOX_BUILD_CONTENT_DIR + 'PdfStreamConverter.jsm');
-  sed('-i', /PDFJSSCRIPT_MOZ_CENTRAL/, 'false',
-      FIREFOX_BUILD_CONTENT_DIR + 'PdfStreamConverter.jsm');
   sed('-i', /PDFJSSCRIPT_PREF_PREFIX/, FIREFOX_PREF_PREFIX,
       FIREFOX_BUILD_CONTENT_DIR + 'PdfjsChromeUtils.jsm');
 
@@ -450,8 +448,6 @@ target.mozcentral = function() {
   sed('-i', /PDFJSSCRIPT_STREAM_CONVERTER2_ID/, MOZCENTRAL_STREAM_CONVERTER2_ID,
       MOZCENTRAL_CONTENT_DIR + 'PdfStreamConverter.jsm');
   sed('-i', /PDFJSSCRIPT_PREF_PREFIX/, MOZCENTRAL_PREF_PREFIX,
-      MOZCENTRAL_CONTENT_DIR + 'PdfStreamConverter.jsm');
-  sed('-i', /PDFJSSCRIPT_MOZ_CENTRAL/, 'true',
       MOZCENTRAL_CONTENT_DIR + 'PdfStreamConverter.jsm');
   sed('-i', /PDFJSSCRIPT_PREF_PREFIX/, MOZCENTRAL_PREF_PREFIX,
       MOZCENTRAL_CONTENT_DIR + 'PdfjsChromeUtils.jsm');


### PR DESCRIPTION
The last (and only) usage of `MOZ_CENTRAL` was removed in PR #3036, so it's been unused for almost four years now.
If we need to have different code-paths for `FIREFOX`/`MOZCENTRAL` builds, the preprocessor should (and has) been used instead.