### PR TITLE
Prevent browser console errors during testing

### DIFF
--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -61,7 +61,10 @@ FontLoader.prototype = {
   clear: function fontLoaderClear() {
     var styleElement = this.styleElement;
     if (styleElement) {
-      styleElement.parentNode.removeChild(styleElement);
+      if (styleElement.parentNode) {
+        // Prevent "TypeError: styleElement.parentNode is null" during testing.
+        styleElement.parentNode.removeChild(styleElement);
+      }
       styleElement = this.styleElement = null;
     }
     if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL')) {

--- a/test/driver.js
+++ b/test/driver.js
@@ -251,7 +251,7 @@ var rasterizeAnnotationLayer = (function rasterizeAnnotationLayerClosure() {
 /**
  * @class
  */
-var Driver = (function DriverClosure() {
+var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
   /**
    * @constructs Driver
    * @param {DriverOptions} options
@@ -685,5 +685,3 @@ var Driver = (function DriverClosure() {
 
   return Driver;
 })();
-
-exports.Driver = Driver;

--- a/test/font/fontutils.js
+++ b/test/font/fontutils.js
@@ -19,7 +19,7 @@
 var base64alphabet =
   'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
 
-function decodeFontData(base64) {
+function decodeFontData(base64) { // eslint-disable-line no-unused-vars
   var result = [];
 
   var bits = 0, bitsLength = 0;
@@ -62,7 +62,7 @@ function encodeFontData(data) {
   return buffer;
 }
 
-function ttx(data, callback) {
+function ttx(data, callback) { // eslint-disable-line no-unused-vars
   var xhr = new XMLHttpRequest();
   xhr.open('POST', '/ttx');
 
@@ -82,13 +82,9 @@ function ttx(data, callback) {
   xhr.send(encodedData);
 }
 
-function verifyTtxOutput(output) {
+function verifyTtxOutput(output) { // eslint-disable-line no-unused-vars
   var m = /^<error>(.*?)<\/error>/.exec(output);
   if (m) {
     throw m[1];
   }
 }
-
-exports.decodeFontData = decodeFontData;
-exports.ttx = ttx;
-exports.verifyTtxOutput = verifyTtxOutput;

--- a/test/unit/testreporter.js
+++ b/test/unit/testreporter.js
@@ -1,5 +1,6 @@
 'use strict';
 
+// eslint-disable-next-line no-unused-vars
 var TestReporter = function(browser, appPath) {
   function send(action, json, cb) {
     var r = new XMLHttpRequest();
@@ -74,5 +75,3 @@ var TestReporter = function(browser, appPath) {
     setTimeout(sendQuitRequest, 500);
   };
 };
-
-exports.TestReporter = TestReporter;


### PR DESCRIPTION
The `Driver._cleanup` method is removing all stylesheets between test runs, which causes "TypeError: styleElement.parentNode is null" console errors in `FontLoader.clear`.

As can also be seen during various tests, some of the changes I made in PR #7972 unfortunately causes console errors.
It seems that I didn't test this properly, since it *should* have been obvious to me that while tests are triggered using Node.js, the files in question are run within the *browser*.
My apologies for not testing this thoroughly, and for causing unnecessary churn in the code!