### PR TITLE
Update URLs in learning examples

### DIFF
--- a/examples/learning/helloworld.html
+++ b/examples/learning/helloworld.html
@@ -13,7 +13,7 @@
 <!-- for legacy browsers add compatibility.js -->
 <!--<script src="../compatibility.js"></script>-->
 
-<script src="../../build/generic/build/pdf.js"></script>
+<script src="../../build/pdf.js"></script>
 
 <script id="script">
   //
@@ -32,7 +32,7 @@
   //
   // The workerSrc property shall be specified.
   //
-  PDFJS.workerSrc = '../../build/generic/build/pdf.worker.js';
+  PDFJS.workerSrc = '../../build/pdf.worker.js';
 
   //
   // Asynchronous download PDF

--- a/examples/learning/prevnext.html
+++ b/examples/learning/prevnext.html
@@ -22,7 +22,7 @@
 <!-- for legacy browsers add compatibility.js -->
 <!--<script src="../compatibility.js"></script>-->
 
-<script src="../../build/generic/build/pdf.js"></script>
+<script src="../../build/pdf.js"></script>
 
 <script id="script">
   //
@@ -44,7 +44,7 @@
   // pdf.js's one, or the pdf.js is executed via eval(), the workerSrc property
   // shall be specified.
   //
-  // PDFJS.workerSrc = '../../build/generic/build/pdf.worker.js';
+  // PDFJS.workerSrc = '../../build/pdf.worker.js';
 
   var pdfDoc = null,
       pageNum = 1,


### PR DESCRIPTION
Current version does not load pdf.js source, so examples do not work in the browser.