### PR TITLE
[api-minor] Fixes behaviour of DOMCanvasFactory to return {canvas, context}.

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -207,23 +207,22 @@ var CachedCanvases = (function CachedCanvasesClosure() {
       var canvasEntry;
       if (this.cache[id] !== undefined) {
         canvasEntry = this.cache[id];
-        this.canvasFactory.reset(canvasEntry.canvas, width, height);
+        this.canvasFactory.reset(canvasEntry, width, height);
         // reset canvas transform for emulated mozCurrentTransform, if needed
         canvasEntry.context.setTransform(1, 0, 0, 1, 0, 0);
       } else {
-        var canvas = this.canvasFactory.create(width, height);
-        var ctx = canvas.getContext('2d');
-        if (trackTransform) {
-          addContextCurrentTransform(ctx);
-        }
-        this.cache[id] = canvasEntry = {canvas: canvas, context: ctx};
+        canvasEntry = this.canvasFactory.create(width, height);
+        this.cache[id] = canvasEntry;
+      }
+      if (trackTransform) {
+        addContextCurrentTransform(canvasEntry.context);
       }
       return canvasEntry;
     },
     clear: function () {
       for (var id in this.cache) {
         var canvasEntry = this.cache[id];
-        this.canvasFactory.destroy(canvasEntry.canvas);
+        this.canvasFactory.destroy(canvasEntry);
         delete this.cache[id];
       }
     }
@@ -1440,7 +1439,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     get isFontSubpixelAAEnabled() {
       // Checks if anti-aliasing is enabled when scaled text is painted.
       // On Windows GDI scaled fonts looks bad.
-      var ctx = this.canvasFactory.create(10, 10).getContext('2d');
+      var ctx = this.canvasFactory.create(10, 10).context;
       ctx.scale(1.5, 1);
       ctx.fillText('I', 0, 10);
       var data = ctx.getImageData(0, 0, 10, 10).data;

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -39,24 +39,30 @@ DOMCanvasFactory.prototype = {
   create: function DOMCanvasFactory_create(width, height) {
     assert(width > 0 && height > 0, 'invalid canvas size');
     var canvas = document.createElement('canvas');
+    var context = canvas.getContext('2d');
     canvas.width = width;
     canvas.height = height;
-    return canvas;
+    return {
+      canvas: canvas,
+      context: context,
+    };
   },
 
-  reset: function DOMCanvasFactory_reset(canvas, width, height) {
-    assert(canvas, 'canvas is not specified');
+  reset: function DOMCanvasFactory_reset(canvasAndContextPair, width, height) {
+    assert(canvasAndContextPair.canvas, 'canvas is not specified');
     assert(width > 0 && height > 0, 'invalid canvas size');
-    canvas.width = width;
-    canvas.height = height;
+    canvasAndContextPair.canvas.width = width;
+    canvasAndContextPair.canvas.height = height;
   },
 
-  destroy: function DOMCanvasFactory_destroy(canvas) {
-    assert(canvas, 'canvas is not specified');
+  destroy: function DOMCanvasFactory_destroy(canvasAndContextPair) {
+    assert(canvasAndContextPair.canvas, 'canvas is not specified');
     // Zeroing the width and height cause Firefox to release graphics
     // resources immediately, which can greatly reduce memory consumption.
-    canvas.width = 0;
-    canvas.height = 0;
+    canvasAndContextPair.canvas.width = 0;
+    canvasAndContextPair.canvas.height = 0;
+    canvasAndContextPair.canvas = null;
+    canvasAndContextPair.context = null;
   }
 };
 


### PR DESCRIPTION
Fixes the behaviour of `DOMCanvasFactory` to return {canvas, context} pair instead to make it work for node's canvas.