### PR TITLE
Interactive forms: set the `buttonValue` for radio buttons that do not have a `fieldValue`

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -786,14 +786,12 @@ var ButtonWidgetAnnotation = (function ButtonWidgetAnnotationClosure() {
       // The parent field's `V` entry holds a `Name` object with the appearance
       // state of whichever child field is currently in the "on" state.
       var fieldParent = params.dict.get('Parent');
-      if (!isDict(fieldParent) || !fieldParent.has('V')) {
-        return;
+      if (isDict(fieldParent) && fieldParent.has('V')) {
+        var fieldParentValue = fieldParent.get('V');
+        if (isName(fieldParentValue)) {
+          this.data.fieldValue = fieldParentValue.name;
+        }
       }
-      var fieldParentValue = fieldParent.get('V');
-      if (!isName(fieldParentValue)) {
-        return;
-      }
-      this.data.fieldValue = fieldParentValue.name;
 
       // The button's value corresponds to its appearance state.
       var appearanceStates = params.dict.get('AP');

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -988,7 +988,7 @@ describe('annotation', function() {
       expect(data.radioButton).toEqual(false);
     });
 
-    it('should handle radio buttons', function() {
+    it('should handle radio buttons with a field value', function() {
       var parentDict = new Dict();
       parentDict.set('V', Name.get('1'));
 
@@ -1015,6 +1015,32 @@ describe('annotation', function() {
       expect(data.checkBox).toEqual(false);
       expect(data.radioButton).toEqual(true);
       expect(data.fieldValue).toEqual('1');
+      expect(data.buttonValue).toEqual('2');
+    });
+
+    it('should handle radio buttons without a field value', function() {
+      var normalAppearanceStateDict = new Dict();
+      normalAppearanceStateDict.set('2', null);
+
+      var appearanceStatesDict = new Dict();
+      appearanceStatesDict.set('N', normalAppearanceStateDict);
+
+      buttonWidgetDict.set('Ff', AnnotationFieldFlag.RADIO);
+      buttonWidgetDict.set('AP', appearanceStatesDict);
+
+      var buttonWidgetRef = new Ref(124, 0);
+      var xref = new XRefMock([
+        { ref: buttonWidgetRef, data: buttonWidgetDict, }
+      ]);
+
+      var annotation = annotationFactory.create(xref, buttonWidgetRef,
+                                                pdfManagerMock, idFactoryMock);
+      var data = annotation.data;
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+
+      expect(data.checkBox).toEqual(false);
+      expect(data.radioButton).toEqual(true);
+      expect(data.fieldValue).toEqual(null);
       expect(data.buttonValue).toEqual('2');
     });
   });


### PR DESCRIPTION
Previously, we skipped setting the `buttonValue` if the `fieldValue` is not available, due to an early return. Obviously the button still has a value even if the field doesn't, so I'm not sure how I missed that before, but this patch fixes it and adds a unit test for it (that fails when this patch is not applied and passes if it is applied).

Supersedes #8031.