### PR TITLE
Allow automatic print rotation via the enablePrintAutoRotate preference

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -114,6 +114,12 @@
     "renderInteractiveForms": {
       "type": "boolean",
       "default": false
+    },
+    "enablePrintAutoRotate": {
+      "title": "Automatically rotate printed pages",
+      "description": "When enabled, pages whose orientation differ from the first page are rotated when printed.",
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/web/app.js
+++ b/web/app.js
@@ -190,6 +190,7 @@ var PDFViewerApplication = {
     renderer: 'canvas',
     enhanceTextSelection: false,
     renderInteractiveForms: false,
+    enablePrintAutoRotate: false,
   },
   isViewerEmbedded: (window.parent !== window),
   url: '',
@@ -304,6 +305,9 @@ var PDFViewerApplication = {
       Preferences.get('disablePageLabels').then(function resolved(value) {
         self.viewerPrefs['disablePageLabels'] = value;
       }),
+      Preferences.get('enablePrintAutoRotate').then(function resolved(value) {
+        self.viewerPrefs['enablePrintAutoRotate'] = value;
+      }),
     ]).catch(function (reason) { });
   },
 
@@ -342,6 +346,7 @@ var PDFViewerApplication = {
         renderer: self.viewerPrefs['renderer'],
         enhanceTextSelection: self.viewerPrefs['enhanceTextSelection'],
         renderInteractiveForms: self.viewerPrefs['renderInteractiveForms'],
+        enablePrintAutoRotate: self.viewerPrefs['enablePrintAutoRotate'],
       });
       pdfRenderingQueue.setViewer(self.pdfViewer);
       pdfLinkService.setViewer(self.pdfViewer);

--- a/web/default_preferences.json
+++ b/web/default_preferences.json
@@ -15,5 +15,6 @@
   "enhanceTextSelection": false,
   "renderer": "canvas",
   "renderInteractiveForms": false,
+  "enablePrintAutoRotate": false,
   "disablePageLabels": false
 }

--- a/web/firefox_print_service.js
+++ b/web/firefox_print_service.js
@@ -61,7 +61,7 @@
         var renderContext = {
           canvasContext: ctx,
           transform: [PRINT_UNITS, 0, 0, PRINT_UNITS, 0, 0],
-          viewport: pdfPage.getViewport(1),
+          viewport: pdfPage.getViewport(1, size.rotation),
           intent: 'print'
         };
         return pdfPage.render(renderContext).promise;

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -60,7 +60,7 @@
       var renderContext = {
         canvasContext: ctx,
         transform: [PRINT_UNITS, 0, 0, PRINT_UNITS, 0, 0],
-        viewport: pdfPage.getViewport(1),
+        viewport: pdfPage.getViewport(1, size.rotation),
         intent: 'print'
       };
       return pdfPage.render(renderContext).promise;

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -949,12 +949,16 @@ var PDFViewer = (function pdfViewer() {
 
     /**
      * Returns sizes of the pages.
-     * @returns {Array} Array of objects with width/height fields.
+     * @returns {Array} Array of objects with width/height/rotation fields.
      */
     getPagesOverview: function () {
       return this._pages.map(function (pageView) {
         var viewport = pageView.pdfPage.getViewport(1);
-        return {width: viewport.width, height: viewport.height};
+        return {
+          width: viewport.width,
+          height: viewport.height,
+          rotation: viewport.rotation,
+        };
       });
     },
   };


### PR DESCRIPTION
Tests:

1. `gulp server`
2. Download [test1.pdf](https://github.com/mozilla/pdf.js/files/759312/test1.pdf) and [test2.pdf](https://github.com/mozilla/pdf.js/files/759311/test2.pdf) (courtesy of #6103) and save them to the pdf.js repo.
3. Open the viewer, run `PDFViewerApplication.preferences.set('enablePrintAutoRotate', true);` and refresh.
4. Press Ctrl + P within the page (or click on the print button).
5. Verify that the pages have the same orientation.
6. Repeat step 3 - 5 for test1.pdf
7. Repeat step 3 with `false` instead of `true`, then perform step 4 and confirm that the page rotation did not change.

Fixes #6696, supersedes #6103