### PR TITLE
Use the current location to prevent errors when using CSP headers

### DIFF
--- a/src/core/network.js
+++ b/src/core/network.js
@@ -68,13 +68,14 @@ if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
       (function supportsMozChunkedClosure() {
     try {
       var x = new XMLHttpRequest();
+      var globalScope = sharedUtil.globalScope;
       // Firefox 37- required .open() to be called before setting responseType.
       // https://bugzilla.mozilla.org/show_bug.cgi?id=707484
       // Even though the URL is not visited, .open() could fail if the URL is
       // blocked, e.g. via the connect-src CSP directive or the NoScript addon.
       // When this error occurs, this feature detection method will mistakenly
       // report that moz-chunked-arraybuffer is not supported in Firefox 37-.
-      x.open('GET', self.location.href);
+      x.open('GET', globalScope.location.href);
       x.responseType = 'moz-chunked-arraybuffer';
       return x.responseType === 'moz-chunked-arraybuffer';
     } catch (e) {

--- a/src/core/network.js
+++ b/src/core/network.js
@@ -74,7 +74,7 @@ if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
       // blocked, e.g. via the connect-src CSP directive or the NoScript addon.
       // When this error occurs, this feature detection method will mistakenly
       // report that moz-chunked-arraybuffer is not supported in Firefox 37-.
-      x.open('GET', window.location.href);
+      x.open('GET', self.location.href);
       x.responseType = 'moz-chunked-arraybuffer';
       return x.responseType === 'moz-chunked-arraybuffer';
     } catch (e) {

--- a/src/core/network.js
+++ b/src/core/network.js
@@ -74,7 +74,7 @@ if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
       // blocked, e.g. via the connect-src CSP directive or the NoScript addon.
       // When this error occurs, this feature detection method will mistakenly
       // report that moz-chunked-arraybuffer is not supported in Firefox 37-.
-      x.open('GET', 'https://example.com');
+      x.open('GET', window.location.href);
       x.responseType = 'moz-chunked-arraybuffer';
       return x.responseType === 'moz-chunked-arraybuffer';
     } catch (e) {


### PR DESCRIPTION
When using content-security-headers to restrict connections to same origin, you may not make connections to example.com. This feature detection also works with a request to the current location. 