### PR TITLE
Write the l10n files to the correct destination for `gulp mozcentral` builds (PR 8023 follow-up)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -773,8 +773,7 @@ gulp.task('mozcentral-pre', ['buildnumber', 'locale'], function () {
     gulp.src(FIREFOX_EXTENSION_DIR + 'chrome-mozcentral.manifest')
         .pipe(rename('chrome.manifest'))
         .pipe(gulp.dest(MOZCENTRAL_EXTENSION_DIR)),
-    gulp.src(FIREFOX_EXTENSION_DIR + 'locale/en-US/*.properties',
-             {base: FIREFOX_EXTENSION_DIR})
+    gulp.src(FIREFOX_EXTENSION_DIR + 'locale/en-US/*.properties')
         .pipe(gulp.dest(MOZCENTRAL_L10N_DIR)),
     gulp.src(FIREFOX_EXTENSION_DIR + 'README.mozilla')
         .pipe(replace(/\bPDFJSSCRIPT_VERSION\b/g, version))


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1338395#c2.

/cc @rvandermeulen