### PR TITLE
Use `ChildNode.remove` instead of `ChildNode.ParentNode.removeChild` in a couple of places (bug 1334831, issue 8008)

### DIFF
--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -59,13 +59,10 @@ FontLoader.prototype = {
   },
 
   clear: function fontLoaderClear() {
-    var styleElement = this.styleElement;
-    if (styleElement) {
-      if (styleElement.parentNode) {
-        // Prevent "TypeError: styleElement.parentNode is null" during testing.
-        styleElement.parentNode.removeChild(styleElement);
-      }
-      styleElement = this.styleElement = null;
+    if (this.styleElement) {
+      // Note: ChildNode.remove doesn't throw if the parentNode is undefined.
+      this.styleElement.remove();
+      this.styleElement = null;
     }
     if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL')) {
       this.nativeFontFaces.forEach(function(nativeFontFace) {

--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -646,4 +646,17 @@ if (typeof PDFJS === 'undefined') {
   });
 })();
 
+// Provides support for ChildNode.remove in legacy browsers.
+// Support: IE.
+(function checkChildNodeRemove() {
+  if (typeof Element.prototype.remove !== 'undefined') {
+    return;
+  }
+  Element.prototype.remove = function () {
+    if (this.parentNode) {
+      this.parentNode.removeChild(this);
+    }
+  };
+})();
+
 }).call((typeof window === 'undefined') ? this : window);

--- a/web/grab_to_pan.js
+++ b/web/grab_to_pan.js
@@ -184,9 +184,8 @@
       this.element.removeEventListener('scroll', this._endPan, true);
       this.document.removeEventListener('mousemove', this._onmousemove, true);
       this.document.removeEventListener('mouseup', this._endPan, true);
-      if (this.overlay.parentNode) {
-        this.overlay.parentNode.removeChild(this.overlay);
-      }
+      // Note: ChildNode.remove doesn't throw if the parentNode is undefined.
+      this.overlay.remove();
     }
   };
 


### PR DESCRIPTION
Re: [bug 1334831](https://bugzilla.mozilla.org/show_bug.cgi?id=1334831) and issue #8008.

Note that according to the specification, see https://dom.spec.whatwg.org/#interface-childnode, the `remove` method shouldn't throw.
This is also consistent with e.g. the Firefox implementation, see http://searchfox.org/mozilla-central/rev/d3307f19d5dac31d7d36fc206b00b686de82eee4/dom/base/nsINode.cpp#1852.

Obviously this isn't supported in IE (because that would be too easy), however we can easily polyfill it to avoid having to WONTFIX the bug/issue.

*Note:* This seems like a better approach than doing nothing, and definitely better than using the preprocessor!

/cc @rvandermeulen