### PR TITLE
Improve the README by removing outdated information

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,15 @@ rendering PDFs.
 ## Contributing
 
 PDF.js is an open source project and always looking for more contributors. To
-get involved checkout:
+get involved, visit:
 
 + [Issue Reporting Guide](https://github.com/mozilla/pdf.js/blob/master/.github/CONTRIBUTING.md)
 + [Code Contribution Guide](https://github.com/mozilla/pdf.js/wiki/Contributing)
 + [Frequently Asked Questions](https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions)
 + [Good Beginner Bugs](https://github.com/mozilla/pdf.js/issues?direction=desc&labels=5-good-beginner-bug&page=1&sort=created&state=open)
-+ [Priorities](https://github.com/mozilla/pdf.js/milestones)
-+ [Attend a Public Meeting](https://github.com/mozilla/pdf.js/wiki/Weekly-Public-Meetings)
++ [Projects](https://github.com/mozilla/pdf.js/projects)
 
-For further questions or guidance feel free to stop by #pdfjs on
-irc.mozilla.org.
+Feel free to stop by #pdfjs on irc.mozilla.org for questions or guidance.
 
 ## Getting Started
 
@@ -79,8 +77,8 @@ It is also possible to view all test PDF files on the right side by opening
 
 ## Building PDF.js
 
-In order to bundle all `src/` files into two productions scripts and build the generic
-viewer, issue:
+In order to bundle all `src/` files into two production scripts and build the generic
+viewer, run:
 
     $ gulp generic
 
@@ -99,12 +97,12 @@ the `pdfjs-dist` name. For more information and examples please refer to the
 
 ## Learning
 
-You can play with the PDF.js API directly from your browser through the live
+You can play with the PDF.js API directly from your browser using the live
 demos below:
 
 + [Interactive examples](http://mozilla.github.io/pdf.js/examples/index.html#interactive-examples)
 
-The repo contains a hello world example that you can run locally:
+The repository contains a hello world example that you can run locally:
 
 + [examples/helloworld/](https://github.com/mozilla/pdf.js/blob/master/examples/helloworld/)
 
@@ -113,12 +111,7 @@ contributor Julian Viereck:
 
 + http://www.youtube.com/watch?v=Iv15UY-4Fg8
 
-You can read more about PDF.js here:
-
-+ http://andreasgal.com/2011/06/15/pdf-js/
-+ http://blog.mozilla.com/cjones/2011/06/15/overview-of-pdf-js-guts/
-
-Even more learning resources can be found at:
+More learning resources can be found at:
 
 + https://github.com/mozilla/pdf.js/wiki/Additional-Learning-Resources
 
@@ -144,7 +137,3 @@ Subscribe either using lists.mozilla.org or Google Groups:
 Follow us on twitter: @pdfjs
 
 + http://twitter.com/#!/pdfjs
-
-Weekly Public Meetings
-
-+ https://github.com/mozilla/pdf.js/wiki/Weekly-Public-Meetings


### PR DESCRIPTION
Fixes #8055.

Moreover, this patch:

- changes the milestones link to the projects link (as we do not use milestones anymore);
- removes information about weekly public meetings (as they're not being done anymore);
- contains minor text fixes.

The two removed links are now on the wiki page, and the dead link has been changed to a Web Archive link.