### PR TITLE
Include the `pdfjschildbootstrap.js` file in the output for `gulp mozcentral` builds (PR 8023 follow-up)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -770,6 +770,8 @@ gulp.task('mozcentral-pre', ['buildnumber', 'locale'], function () {
 
     gulp.src(FIREFOX_CONTENT_DIR + 'PdfJsTelemetry.jsm')
         .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR)),
+    gulp.src(FIREFOX_CONTENT_DIR + 'pdfjschildbootstrap.js')
+        .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR)),
     gulp.src(FIREFOX_EXTENSION_DIR + 'chrome-mozcentral.manifest')
         .pipe(rename('chrome.manifest'))
         .pipe(gulp.dest(MOZCENTRAL_EXTENSION_DIR)),


### PR DESCRIPTION
*Yet another thing that I unfortunately missed during review of PR #8023.*

Note that previously, in `make.js` this file was being preprocessed, however as far as I can tell that wasn't actually necessary. Hence this patch just copies the file to the proper output directory.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1338395#c8.

/cc @rvandermeulen