### PR TITLE
Interactive forms: values for checkboxes

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -784,28 +784,33 @@ var TextWidgetAnnotation = (function TextWidgetAnnotationClosure() {
 var ButtonWidgetAnnotation = (function ButtonWidgetAnnotationClosure() {
   function ButtonWidgetAnnotation(params) {
     WidgetAnnotation.call(this, params);
-
+    // Bool: is button widget a checkbox
     this.data.checkBox = !this.hasFieldFlag(AnnotationFieldFlag.RADIO) &&
                          !this.hasFieldFlag(AnnotationFieldFlag.PUSHBUTTON);
-    if (this.data.checkBox) {
-      if (!isName(this.data.fieldValue)) {
-        return;
-      }
-      this.data.fieldValue = this.data.fieldValue.name;
+    // if the button is not a checkBox, check to see if its a radio button
+    if (!this.data.checkBox) {
+      // Bool: is button widget a radio button
+      this.data.radioButton = this.hasFieldFlag(AnnotationFieldFlag.RADIO) &&
+                            !this.hasFieldFlag(AnnotationFieldFlag.PUSHBUTTON);
     }
 
-    this.data.radioButton = this.hasFieldFlag(AnnotationFieldFlag.RADIO) &&
-                            !this.hasFieldFlag(AnnotationFieldFlag.PUSHBUTTON);
-    if (this.data.radioButton) {
-      this.data.fieldValue = this.data.buttonValue = null;
+    if (this.data.checkBox || this.data.radioButton) {
+      // Set fieldValue
+      if (this.data.checkBox) { // For checkbox button widgets
+        if (isName(this.data.fieldValue)) {
+          this.data.fieldValue = this.data.fieldValue.name;
+        }
+      } else { // For radio button widgets
+        this.data.fieldValue = this.data.buttonValue = null;
 
-      // The parent field's `V` entry holds a `Name` object with the appearance
-      // state of whichever child field is currently in the "on" state.
-      var fieldParent = params.dict.get('Parent');
-      if (isDict(fieldParent) && fieldParent.has('V')) {
-        var fieldParentValue = fieldParent.get('V');
-        if (isName(fieldParentValue)) {
-          this.data.fieldValue = fieldParentValue.name;
+        // The parent field's `V` entry holds a `Name` object with the appearance
+        // state of whichever child field is currently in the "on" state.
+        var fieldParent = params.dict.get('Parent');
+        if (isDict(fieldParent) && fieldParent.has('V')) {
+          var fieldParentValue = fieldParent.get('V');
+          if (isName(fieldParentValue)) {
+            this.data.fieldValue = fieldParentValue.name;
+          }
         }
       }
 

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -787,12 +787,9 @@ var ButtonWidgetAnnotation = (function ButtonWidgetAnnotationClosure() {
     // Bool: is button widget a checkbox
     this.data.checkBox = !this.hasFieldFlag(AnnotationFieldFlag.RADIO) &&
                          !this.hasFieldFlag(AnnotationFieldFlag.PUSHBUTTON);
-    // if the button is not a checkBox, check to see if its a radio button
-    if (!this.data.checkBox) {
-      // Bool: is button widget a radio button
-      this.data.radioButton = this.hasFieldFlag(AnnotationFieldFlag.RADIO) &&
-                            !this.hasFieldFlag(AnnotationFieldFlag.PUSHBUTTON);
-    }
+    // Bool: is button widget a radio button
+    this.data.radioButton = this.hasFieldFlag(AnnotationFieldFlag.RADIO) &&
+                          !this.hasFieldFlag(AnnotationFieldFlag.PUSHBUTTON);
 
     if (this.data.checkBox || this.data.radioButton) {
       // Set fieldValue
@@ -803,7 +800,7 @@ var ButtonWidgetAnnotation = (function ButtonWidgetAnnotationClosure() {
       } else { // For radio button widgets
         this.data.fieldValue = this.data.buttonValue = null;
 
-        // The parent field's `V` entry holds a `Name` object with the appearance
+        // The parent fiel's `V` entry holds a `Name` object with the appearance
         // state of whichever child field is currently in the "on" state.
         var fieldParent = params.dict.get('Parent');
         if (isDict(fieldParent) && fieldParent.has('V')) {

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -970,8 +970,18 @@ describe('annotation', function() {
       buttonWidgetDict = null;
     });
 
-    it('should handle checkboxes', function() {
-      buttonWidgetDict.set('V', Name.get('1'));
+    it('should handle checkboxes with a field value', function() {
+      var parentDict = new Dict();
+      parentDict.set('V', Name.get('1'));
+
+      var normalAppearanceStateDict = new Dict();
+      normalAppearanceStateDict.set('2', null);
+
+      var appearanceStatesDict = new Dict();
+      appearanceStatesDict.set('N', normalAppearanceStateDict);
+
+      buttonWidgetDict.set('Parent', parentDict);
+      buttonWidgetDict.set('AP', appearanceStatesDict);
 
       var buttonWidgetRef = new Ref(124, 0);
       var xref = new XRefMock([
@@ -984,8 +994,34 @@ describe('annotation', function() {
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
       expect(data.checkBox).toEqual(true);
-      expect(data.fieldValue).toEqual('1');
       expect(data.radioButton).toEqual(false);
+      expect(data.fieldValue).toEqual('1');
+      expect(data.buttonValue).toEqual('2');
+    });
+
+    it('should handle checkboxes without a field value', function() {
+      var normalAppearanceStateDict = new Dict();
+      normalAppearanceStateDict.set('2', null);
+
+      var appearanceStatesDict = new Dict();
+      appearanceStatesDict.set('N', normalAppearanceStateDict);
+
+      buttonWidgetDict.set('AP', appearanceStatesDict);
+
+      var buttonWidgetRef = new Ref(124, 0);
+      var xref = new XRefMock([
+        { ref: buttonWidgetRef, data: buttonWidgetDict, }
+      ]);
+
+      var annotation = annotationFactory.create(xref, buttonWidgetRef,
+                                                pdfManagerMock, idFactoryMock);
+      var data = annotation.data;
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+
+      expect(data.checkBox).toEqual(true);
+      expect(data.radioButton).toEqual(false);
+      expect(data.fieldValue).toEqual(null);
+      expect(data.buttonValue).toEqual('2');
     });
 
     it('should handle radio buttons with a field value', function() {


### PR DESCRIPTION
When coming across a recently resolved issue (#6995) of radio buttons not having buttonValues, it helped solve an issue for a project that I am currently working on when it was coming to setting the value attribute on radio inputs. 
However, I noticed that buttonValue was still not getting set for checkbox button widgets as well. I am proposing the following fix so that we can properly set value attributes on  generated checkbox inputs from Acroform annotations. 
Please let me know if I am missing something or if this is actually not an issue.