### PR TITLE
Enable running the `cmap` unit-tests on Travis by utilizing a `NodeCMapReaderFactory`

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals process, __pdfjsdev_webpack__ */
 
 'use strict';
 
@@ -46,6 +45,7 @@ var error = sharedUtil.error;
 var info = sharedUtil.info;
 var warn = sharedUtil.warn;
 var setVerbosityLevel = sharedUtil.setVerbosityLevel;
+var isNodeJS = sharedUtil.isNodeJS;
 var Ref = corePrimitives.Ref;
 var LocalPdfManager = corePdfManager.LocalPdfManager;
 var NetworkPdfManager = corePdfManager.NetworkPdfManager;
@@ -1005,14 +1005,6 @@ function initializeWorker() {
   var handler = new MessageHandler('worker', 'main', self);
   WorkerMessageHandler.setup(handler, self);
   handler.send('ready', null);
-}
-
-function isNodeJS() {
-  // The if below protected by __pdfjsdev_webpack__ check from webpack parsing.
-  if (typeof __pdfjsdev_webpack__ === 'undefined') {
-    return typeof process === 'object' && process + '' === '[object process]';
-  }
-  return false;
 }
 
 // Worker thread (and not node.js)?

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals global */
+/* globals global, process, __pdfjsdev_webpack__ */
 
 'use strict';
 
@@ -1134,6 +1134,14 @@ function isArrayBuffer(v) {
 // Checks if ch is one of the following characters: SPACE, TAB, CR or LF.
 function isSpace(ch) {
   return (ch === 0x20 || ch === 0x09 || ch === 0x0D || ch === 0x0A);
+}
+
+function isNodeJS() {
+  // The if below protected by __pdfjsdev_webpack__ check from webpack parsing.
+  if (typeof __pdfjsdev_webpack__ === 'undefined') {
+    return typeof process === 'object' && process + '' === '[object process]';
+  }
+  return false;
 }
 
 /**
@@ -2454,6 +2462,7 @@ exports.isInt = isInt;
 exports.isNum = isNum;
 exports.isString = isString;
 exports.isSpace = isSpace;
+exports.isNodeJS = isNodeJS;
 exports.isSameOrigin = isSameOrigin;
 exports.createValidAbsoluteUrl = createValidAbsoluteUrl;
 exports.isLittleEndian = isLittleEndian;

--- a/test/unit/clitests.json
+++ b/test/unit/clitests.json
@@ -4,6 +4,7 @@
     "annotation_spec.js",
     "bidi_spec.js",
     "cff_parser_spec.js",
+    "cmap_spec.js",
     "crypto_spec.js",
     "document_spec.js",
     "dom_utils_spec.js",

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -17,20 +17,22 @@
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
     define('pdfjs-test/unit/cmap_spec', ['exports', 'pdfjs/core/cmap',
-      'pdfjs/core/primitives', 'pdfjs/core/stream', 'pdfjs/display/dom_utils'],
-      factory);
+      'pdfjs/core/primitives', 'pdfjs/core/stream', 'pdfjs/display/dom_utils',
+      'pdfjs/shared/util', 'pdfjs-test/unit/test_utils'], factory);
   } else if (typeof exports !== 'undefined') {
       factory(exports, require('../../src/core/cmap.js'),
         require('../../src/core/primitives.js'),
         require('../../src/core/stream.js'),
-        require('../../src/display/dom_utils.js'));
+        require('../../src/display/dom_utils.js'),
+        require('../../src/shared/util.js'), require('./test_utils.js'));
   } else {
     factory((root.pdfjsTestUnitCMapSpec = {}), root.pdfjsCoreCMap,
       root.pdfjsCorePrimitives, root.pdfjsCoreStream,
-      root.pdfjsDisplayDOMUtils);
+      root.pdfjsDisplayDOMUtils, root.pdfjsSharedUtil,
+      root.pdfjsTestUnitTestUtils);
   }
 }(this, function (exports, coreCMap, corePrimitives, coreStream,
-                  displayDOMUtils) {
+                  displayDOMUtils, sharedUtil, testUnitTestUtils) {
 
 var CMapFactory = coreCMap.CMapFactory;
 var CMap = coreCMap.CMap;
@@ -38,18 +40,33 @@ var IdentityCMap = coreCMap.IdentityCMap;
 var Name = corePrimitives.Name;
 var StringStream = coreStream.StringStream;
 var DOMCMapReaderFactory = displayDOMUtils.DOMCMapReaderFactory;
+var isNodeJS = sharedUtil.isNodeJS;
+var NodeCMapReaderFactory = testUnitTestUtils.NodeCMapReaderFactory;
 
-var cMapUrl = '../../external/bcmaps/';
+var cMapUrl = {
+  dom: '../../external/bcmaps/',
+  node: './external/bcmaps/',
+};
 var cMapPacked = true;
 
 describe('cmap', function() {
   var fetchBuiltInCMap;
 
   beforeAll(function (done) {
-    var CMapReaderFactory = new DOMCMapReaderFactory({
-      baseUrl: cMapUrl,
-      isCompressed: cMapPacked,
-    });
+    // Allow CMap testing in Node.js, e.g. for Travis.
+    var CMapReaderFactory;
+    if (isNodeJS()) {
+      CMapReaderFactory = new NodeCMapReaderFactory({
+        baseUrl: cMapUrl.node,
+        isCompressed: cMapPacked,
+      });
+    } else {
+      CMapReaderFactory = new DOMCMapReaderFactory({
+        baseUrl: cMapUrl.dom,
+        isCompressed: cMapPacked,
+      });
+    }
+
     fetchBuiltInCMap = function (name) {
       return CMapReaderFactory.fetch({
         name: name,

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -1,0 +1,69 @@
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define('pdfjs-test/unit/test_utils', ['exports', 'pdfjs/shared/util'],
+      factory);
+  } else if (typeof exports !== 'undefined') {
+    factory(exports, require('../../src/shared/util.js'));
+  } else {
+    factory((root.pdfjsTestUnitTestUtils = {}), root.pdfjsSharedUtil);
+  }
+}(this, function (exports, sharedUtil) {
+
+var CMapCompressionType = sharedUtil.CMapCompressionType;
+
+var NodeCMapReaderFactory = (function NodeCMapReaderFactoryClosure() {
+  function NodeCMapReaderFactory(params) {
+    this.baseUrl = params.baseUrl || null;
+    this.isCompressed = params.isCompressed || false;
+  }
+
+  NodeCMapReaderFactory.prototype = {
+    fetch: function(params) {
+      if (!params.name) {
+        return Promise.reject(new Error('CMap name must be specified.'));
+      }
+      return new Promise(function (resolve, reject) {
+        var url = this.baseUrl + params.name;
+
+        var fs = require('fs');
+        if (this.isCompressed) {
+          url += '.bcmap';
+        }
+        fs.readFile(url, function (error, data) {
+          if (error || !data) {
+            reject(new Error('Unable to load ' +
+                             (this.isCompressed ? 'binary' : '') +
+                             ' CMap at: ' + url));
+            return;
+          }
+          resolve({
+            cMapData: new Uint8Array(data),
+            compressionType: this.isCompressed ?
+              CMapCompressionType.BINARY : CMapCompressionType.NONE,
+          });
+        }.bind(this));
+      }.bind(this));
+    },
+  };
+
+  return NodeCMapReaderFactory;
+})();
+
+exports.NodeCMapReaderFactory = NodeCMapReaderFactory;
+}));


### PR DESCRIPTION
*Note:* This is based on PR #8064.

There might be room for improvements here, but at least it does work as intended :-)
Please compare the (latest) Travis run with this PR in https://travis-ci.org/mozilla/pdf.js/builds/202788158#L407; with a previous run in https://travis-ci.org/mozilla/pdf.js/builds/202184476#L395.