### PR TITLE
iOS Chrome: Fix broken download button

### DIFF
--- a/web/compatibility.js
+++ b/web/compatibility.js
@@ -26,6 +26,7 @@ var isAndroidPre3 = /Android\s[0-2][^\d]/.test(userAgent);
 var isAndroidPre5 = /Android\s[0-4][^\d]/.test(userAgent);
 var isChrome = userAgent.indexOf('Chrom') >= 0;
 var isChromeWithRangeBug = /Chrome\/(39|40)\./.test(userAgent);
+var isIOSChrome = userAgent.indexOf('CriOS') >= 0;
 var isIE = userAgent.indexOf('Trident') >= 0;
 var isIOS = /\b(iPad|iPhone|iPod)(?=;)/.test(userAgent);
 var isOpera = userAgent.indexOf('Opera') >= 0;
@@ -456,10 +457,11 @@ if (typeof PDFJS === 'undefined') {
 })();
 
 // Checks if possible to use URL.createObjectURL()
-// Support: IE
+// Support: IE, Chrome on iOS
 (function checkOnBlobSupport() {
-  // sometimes IE loosing the data created with createObjectURL(), see #3977
-  if (isIE) {
+  // sometimes IE and Chrome on iOS loosing the data created with
+  // createObjectURL(), see #3977 and #8081
+  if (isIE || isIOSChrome) {
     PDFJS.disableCreateObjectURL = true;
   }
 })();

--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -86,17 +86,17 @@ if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC || CHROME')) {
     },
 
     download: function DownloadManager_download(blob, url, filename) {
-      if (!URL) {
-        // URL.createObjectURL is not supported
-        this.downloadUrl(url, filename);
-        return;
-      }
-
       if (navigator.msSaveBlob) {
         // IE10 / IE11
         if (!navigator.msSaveBlob(blob, filename)) {
           this.downloadUrl(url, filename);
         }
+        return;
+      }
+
+      if (pdfjsLib.PDFJS.disableCreateObjectURL) {
+        // URL.createObjectURL is not supported
+        this.downloadUrl(url, filename);
         return;
       }
 


### PR DESCRIPTION
Reproduction Steps
---

1. Open Chrome on iOS (I'm using an iPhone 6, iOS 10.2.1, Chrome 56.0.2924.79)
2. Open https://mozilla.github.io/pdf.js/web/viewer.html (I tested on commit cfaa621a05cb5360f6834cf96a16c44c1a9aed5b)
3. Open the dropdown menu and click "Download."
4. Nothing happens.

On iOS Safari, however, the download button works fine.

Cause
---

It appears that `URL.createObjectURL` is unreliable in iOS Chrome. Going to the blob URL doesn't do anything. Opening the blob URL in a new window shows a blank page. See https://groups.google.com/a/chromium.org/forum/#!topic/chromium-html5/RKQ0ZJIj7c4 for more details.

Solution
---

Add iOS Chrome to the list of browsers that set `disableCreateObjectURL` in `compatibility.js`. The `downloadUrl` fallback works fine.

I'm not sure if this is the appropriate place to make the change, since I had to rearrange some code in `download_manager.js`. Please let me know if I should make any different changes.
