### PR TITLE
Gulp: migrate `baseline` target from `make.js`

### DIFF
--- a/make.js
+++ b/make.js
@@ -498,31 +498,7 @@ target.botmakeref = function() {
 // Baseline operation
 //
 target.baseline = function() {
-  cd(ROOT_DIR);
-
-  echo();
-  echo('### Creating baseline environment');
-
-  var baselineCommit = env['BASELINE'];
-  if (!baselineCommit) {
-    echo('Baseline commit is not provided. Please specify BASELINE variable');
-    exit(1);
-  }
-
-  if (!test('-d', BUILD_DIR)) {
-    mkdir(BUILD_DIR);
-  }
-
-  var BASELINE_DIR = BUILD_DIR + 'baseline';
-  if (test('-d', BASELINE_DIR)) {
-    cd(BASELINE_DIR);
-    exec('git fetch origin');
-  } else {
-    cd(BUILD_DIR);
-    exec('git clone .. baseline');
-    cd(ROOT_DIR + BASELINE_DIR);
-  }
-  exec('git checkout ' + baselineCommit);
+  execGulp('baseline');
 };
 
 target.mozcentralbaseline = function() {


### PR DESCRIPTION
Fixes a part of #7062 (which belongs to the ES6 modules project).

Testing steps:

- Run `gulp baseline` and verify that an error is thrown since the `BASELINE` variable is missing.
- Run `BASELINE=bc3bceb gulp baseline` and verify that the success message is shown and that the `build/basline` directory is a Git repository at commit `bc3bceb`.
- Run `BASELINE=bc3bceb gulp baseline` again and verify that it finishes sooner because it only does a fetch (print `initializeCommand` when in doubt).
- Run `BASELINE=foobar gulp baseline` and verify that an error is thrown since `foobar` is not a valid commit hash.
- Run `BASELINE=bc3bceb node make mozcentralbaseline mozcentraldiff` and verify that a diff is created (issue #7743).