### PR TITLE
Update evaluator.js -> Proposal to split words for getTextContent layer

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1358,8 +1358,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           textState.translateTextMatrix(tx, ty);
 
           textChunk.str.push(glyphUnicode);
-          
-          if((glyph.isSpace || glyphUnicode == ' ') && splitSpaces) {
+
+          if ((glyph.isSpace || glyphUnicode === ' ') && splitSpaces) {
             if (!font.vertical) {
               textChunk.lastAdvanceWidth = width;
               textChunk.width += width;

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1317,6 +1317,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         var width = 0;
         var height = 0;
         var glyphs = font.charsToGlyphs(chars);
+        var splitSpaces = true;
         for (var i = 0; i < glyphs.length; i++) {
           var glyph = glyphs[i];
           var glyphWidth = null;
@@ -1357,6 +1358,22 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           textState.translateTextMatrix(tx, ty);
 
           textChunk.str.push(glyphUnicode);
+          
+          if((glyph.isSpace || glyphUnicode == ' ') && splitSpaces) {
+            if (!font.vertical) {
+              textChunk.lastAdvanceWidth = width;
+              textChunk.width += width;
+            } else {
+              textChunk.lastAdvanceHeight = height;
+              textChunk.height += Math.abs(height);
+            }
+
+            flushTextContentItem();
+            textChunk = ensureTextContentItem();
+
+            width = 0;
+            height = 0;
+          }
         }
 
         if (!font.vertical) {

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1581,7 +1581,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
                       textContentItem.width += offset;
                     }
                   }
-                  if (breakTextRun || (advance > 0 && !combineTextItems)) {
+                  if (breakTextRun ||
+                      (advance > 0 && !combineTextItems)) {
                     flushTextContentItem();
                   } else if (advance > 0) {
                     addFakeSpaces(advance, textContentItem.str);

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1359,7 +1359,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
           textChunk.str.push(glyphUnicode);
 
-          if ((glyph.isSpace || glyphUnicode === ' ') && splitSpaces) {
+          if ((glyph.isSpace || glyphUnicode === ' ') && !combineTextItems && splitSpaces) {
             if (!font.vertical) {
               textChunk.lastAdvanceWidth = width;
               textChunk.width += width;

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1580,7 +1580,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
                       textContentItem.width += offset;
                     }
                   }
-                  if (breakTextRun) {
+                  if (breakTextRun || (advance > 0 && !combineTextItems)) {
                     flushTextContentItem();
                   } else if (advance > 0) {
                     addFakeSpaces(advance, textContentItem.str);

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1359,7 +1359,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
           textChunk.str.push(glyphUnicode);
 
-          if ((glyph.isSpace || glyphUnicode === ' ') && !combineTextItems && splitSpaces) {
+          if ((glyph.isSpace || glyphUnicode === ' ') &&
+              !combineTextItems && splitSpaces) {
             if (!font.vertical) {
               textChunk.lastAdvanceWidth = width;
               textChunk.width += width;


### PR DESCRIPTION
Changed the way text extraction treats words. Now it extracts word by word, so text selection or markup are more properly alligned. Please review the proposal as it is assuming splitSpaces variable to be set to true, it should be passed through options. This is a quick hack, probably a better solution exists.

Thank you for your time,