### PR TITLE
Ensure that `Dict`s found in Object Streams are assigned an `objId` in `XRef.fetch`

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -1241,6 +1241,11 @@ var XRef = (function XRefClosure() {
       var num = ref.num;
       if (num in this.cache) {
         var cacheEntry = this.cache[num];
+        // In documents with Object Streams, it's possible that cached `Dict`s
+        // have not been assigned an `objId` yet (see e.g. issue3115r.pdf).
+        if (isDict(cacheEntry) && !cacheEntry.objId) {
+          cacheEntry.objId = ref.toString();
+        }
         return cacheEntry;
       }
 


### PR DESCRIPTION
This fixes something that I noticed while working with the code in `Catalog.getPageDict` when debugging issue #8088.

Note that while I don't have an example where this patch really matters, given that e.g. `PartialEvaluator.hasBlendModes` depends on the `objId` to avoid cyclic references this patch could potentially help for some PDF files.