### PR TITLE
Init PDFWorker via MesssagePort.

### DIFF
--- a/external/dist/webpack.js
+++ b/external/dist/webpack.js
@@ -1,0 +1,21 @@
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var pdfjs = require('./build/pdf.js');
+var PdfjsWorker = require('worker-loader!./build/pdf.worker.js');
+pdfjs.PDFJS.workerPort = new PdfjsWorker();
+
+module.exports = pdfjs;

--- a/make.js
+++ b/make.js
@@ -205,7 +205,8 @@ target.dist = function() {
     bugs: DIST_BUGS_URL,
     license: DIST_LICENSE,
     dependencies: {
-      'node-ensure': '^0.0.0' // shim for node for require.ensure
+      'node-ensure': '^0.0.0', // shim for node for require.ensure
+      'worker-loader': '^0.7.1', // used in external/dist/webpack.json
     },
     browser: {
       'node-ensure': false

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -272,6 +272,8 @@ function getDefaultSetting(id) {
       return globalSettings ? globalSettings.cMapPacked : false;
     case 'postMessageTransfers':
       return globalSettings ? globalSettings.postMessageTransfers : true;
+    case 'workerPort':
+      return globalSettings ? globalSettings.workerPort : null;
     case 'workerSrc':
       return globalSettings ? globalSettings.workerSrc : null;
     case 'disableWorker':

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -161,6 +161,12 @@
   PDFJS.workerSrc = (PDFJS.workerSrc === undefined ? null : PDFJS.workerSrc);
 
   /**
+   * Defines global port for worker process. Overrides workerSrc and
+   * disableWorker setting.
+   */
+  PDFJS.workerPort = (PDFJS.workerPort === undefined ? null : PDFJS.workerPort);
+
+  /**
    * Disable range request loading of PDF files. When enabled and if the server
    * supports partial content requests then the PDF will be fetched in chunks.
    * Enabled (false) by default.


### PR DESCRIPTION
Webpack people can  use 'pdfjs-dist/webpack' module for PDF.js autoconfiguration.

Fixes #7612
Addresses #7683