### PR TITLE
Interactive forms: make choice widget options inheritable (issue 8094)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -845,9 +845,12 @@ var ChoiceWidgetAnnotation = (function ChoiceWidgetAnnotationClosure() {
     // the display value. If the array consists of strings, then these
     // represent both the export and display value. In this case, we convert
     // it to an array of arrays as well for convenience in the display layer.
+    // Note that the specification does not state that the `Opt` field is
+    // inheritable, but in practice PDF generators do make annotations
+    // inherit the options from a parent annotation (issue 8094).
     this.data.options = [];
 
-    var options = params.dict.get('Opt');
+    var options = Util.getInheritableProperty(params.dict, 'Opt');
     if (isArray(options)) {
       var xref = params.xref;
       for (var i = 0, ii = options.length; i < ii; i++) {

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -1142,6 +1142,34 @@ describe('annotation', function() {
       expect(data.options).toEqual(expected);
     });
 
+    it('should handle inherited option arrays (issue 8094)', function() {
+      var options = [
+        ['Value1', 'Description1'],
+        ['Value2', 'Description2'],
+      ];
+      var expected = [
+        { exportValue: 'Value1', displayValue: 'Description1' },
+        { exportValue: 'Value2', displayValue: 'Description2' },
+      ];
+
+      var parentDict = new Dict();
+      parentDict.set('Opt', options);
+
+      choiceWidgetDict.set('Parent', parentDict);
+
+      var choiceWidgetRef = new Ref(123, 0);
+      var xref = new XRefMock([
+        { ref: choiceWidgetRef, data: choiceWidgetDict, },
+      ]);
+
+      var annotation = annotationFactory.create(xref, choiceWidgetRef,
+                                                pdfManagerMock, idFactoryMock);
+      var data = annotation.data;
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+
+      expect(data.options).toEqual(expected);
+    });
+
     it('should handle array field values', function() {
       var fieldValue = ['Foo', 'Bar'];
 


### PR DESCRIPTION
Even though the PDF specification does not state that `Opt` fields are inheritable, in practice there are PDF generators that let annotations inherit the options from a parent.

The unit test fails when this patch is not applied. If you also want to test this in the viewer, use the following steps:

1. Download the PDF file from issue #8094.
2. Open the preview viewer from below.
3. Open the developer tools when the viewer is opened and run `PDFViewerApplication.preferences.set('renderInteractiveForms', true);`.
4. Reload the viewer and open the downloaded PDF file. Verify that both dropdowns present three options instead of zero.

Fixes #8094.