### PR TITLE
Get rid of a couple `eslint-disable` statements in `web/download_manager.js` by instead relying on the preprocessor dead-code removal added in PR 7942

### DIFF
--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -25,86 +25,87 @@
     factory((root.pdfjsWebDownloadManager = {}), root.pdfjsWebPDFJS);
   }
 }(this, function (exports, pdfjsLib) {
-if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC || CHROME')) {
-  // eslint-disable-next-line no-inner-declarations
-  function download(blobUrl, filename) {
-    var a = document.createElement('a');
-    if (a.click) {
-      // Use a.click() if available. Otherwise, Chrome might show
-      // "Unsafe JavaScript attempt to initiate a navigation change
-      //  for frame with URL" and not open the PDF at all.
-      // Supported by (not mentioned = untested):
-      // - Firefox 6 - 19 (4- does not support a.click, 5 ignores a.click)
-      // - Chrome 19 - 26 (18- does not support a.click)
-      // - Opera 9 - 12.15
-      // - Internet Explorer 6 - 10
-      // - Safari 6 (5.1- does not support a.click)
-      a.href = blobUrl;
-      a.target = '_parent';
-      // Use a.download if available. This increases the likelihood that
-      // the file is downloaded instead of opened by another PDF plugin.
-      if ('download' in a) {
-        a.download = filename;
-      }
-      // <a> must be in the document for IE and recent Firefox versions.
-      // (otherwise .click() is ignored)
-      (document.body || document.documentElement).appendChild(a);
-      a.click();
-      a.parentNode.removeChild(a);
-    } else {
-      if (window.top === window &&
-          blobUrl.split('#')[0] === window.location.href.split('#')[0]) {
-        // If _parent == self, then opening an identical URL with different
-        // location hash will only cause a navigation, not a download.
-        var padCharacter = blobUrl.indexOf('?') === -1 ? '?' : '&';
-        blobUrl = blobUrl.replace(/#|$/, padCharacter + '$&');
-      }
-      window.open(blobUrl, '_parent');
-    }
-  }
-
-  function DownloadManager() {} // eslint-disable-line no-inner-declarations
-
-  DownloadManager.prototype = {
-    downloadUrl: function DownloadManager_downloadUrl(url, filename) {
-      if (!pdfjsLib.createValidAbsoluteUrl(url, 'http://example.com')) {
-        return; // restricted/invalid URL
-      }
-      download(url + '#pdfjs.action=download', filename);
-    },
-
-    downloadData: function DownloadManager_downloadData(data, filename,
-                                                        contentType) {
-      if (navigator.msSaveBlob) { // IE10 and above
-        return navigator.msSaveBlob(new Blob([data], { type: contentType }),
-                                    filename);
-      }
-
-      var blobUrl = pdfjsLib.createObjectURL(data, contentType,
-        pdfjsLib.PDFJS.disableCreateObjectURL);
-      download(blobUrl, filename);
-    },
-
-    download: function DownloadManager_download(blob, url, filename) {
-      if (navigator.msSaveBlob) {
-        // IE10 / IE11
-        if (!navigator.msSaveBlob(blob, filename)) {
-          this.downloadUrl(url, filename);
-        }
-        return;
-      }
-
-      if (pdfjsLib.PDFJS.disableCreateObjectURL) {
-        // URL.createObjectURL is not supported
-        this.downloadUrl(url, filename);
-        return;
-      }
-
-      var blobUrl = URL.createObjectURL(blob);
-      download(blobUrl, filename);
-    }
-  };
-
-  exports.DownloadManager = DownloadManager;
+if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
+  return;
 }
+
+function download(blobUrl, filename) {
+  var a = document.createElement('a');
+  if (a.click) {
+    // Use a.click() if available. Otherwise, Chrome might show
+    // "Unsafe JavaScript attempt to initiate a navigation change
+    //  for frame with URL" and not open the PDF at all.
+    // Supported by (not mentioned = untested):
+    // - Firefox 6 - 19 (4- does not support a.click, 5 ignores a.click)
+    // - Chrome 19 - 26 (18- does not support a.click)
+    // - Opera 9 - 12.15
+    // - Internet Explorer 6 - 10
+    // - Safari 6 (5.1- does not support a.click)
+    a.href = blobUrl;
+    a.target = '_parent';
+    // Use a.download if available. This increases the likelihood that
+    // the file is downloaded instead of opened by another PDF plugin.
+    if ('download' in a) {
+      a.download = filename;
+    }
+    // <a> must be in the document for IE and recent Firefox versions.
+    // (otherwise .click() is ignored)
+    (document.body || document.documentElement).appendChild(a);
+    a.click();
+    a.parentNode.removeChild(a);
+  } else {
+    if (window.top === window &&
+        blobUrl.split('#')[0] === window.location.href.split('#')[0]) {
+      // If _parent == self, then opening an identical URL with different
+      // location hash will only cause a navigation, not a download.
+      var padCharacter = blobUrl.indexOf('?') === -1 ? '?' : '&';
+      blobUrl = blobUrl.replace(/#|$/, padCharacter + '$&');
+    }
+    window.open(blobUrl, '_parent');
+  }
+}
+
+function DownloadManager() {}
+
+DownloadManager.prototype = {
+  downloadUrl: function DownloadManager_downloadUrl(url, filename) {
+    if (!pdfjsLib.createValidAbsoluteUrl(url, 'http://example.com')) {
+      return; // restricted/invalid URL
+    }
+    download(url + '#pdfjs.action=download', filename);
+  },
+
+  downloadData: function DownloadManager_downloadData(data, filename,
+                                                      contentType) {
+    if (navigator.msSaveBlob) { // IE10 and above
+      return navigator.msSaveBlob(new Blob([data], { type: contentType }),
+                                  filename);
+    }
+
+    var blobUrl = pdfjsLib.createObjectURL(data, contentType,
+      pdfjsLib.PDFJS.disableCreateObjectURL);
+    download(blobUrl, filename);
+  },
+
+  download: function DownloadManager_download(blob, url, filename) {
+    if (navigator.msSaveBlob) {
+      // IE10 / IE11
+      if (!navigator.msSaveBlob(blob, filename)) {
+        this.downloadUrl(url, filename);
+      }
+      return;
+    }
+
+    if (pdfjsLib.PDFJS.disableCreateObjectURL) {
+      // URL.createObjectURL is not supported
+      this.downloadUrl(url, filename);
+      return;
+    }
+
+    var blobUrl = URL.createObjectURL(blob);
+    download(blobUrl, filename);
+  }
+};
+
+exports.DownloadManager = DownloadManager;
 }));


### PR DESCRIPTION
*Much* easier reviewing with https://github.com/mozilla/pdf.js/pull/8116/files?w=1.