### PR TITLE
Convert the overlay manager to a class

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -392,15 +392,19 @@ var PDFViewerApplication = {
       findBarConfig.eventBus = eventBus;
       self.findBar = new PDFFindBar(findBarConfig);
 
-      self.overlayManager = OverlayManager;
+      self.overlayManager = new OverlayManager();
 
       self.handTool = new HandTool({
         container: container,
         eventBus: eventBus,
       });
 
+      // FIXME better PDFDocumentProperties constructor parameters
+      var documentPropertiesConfig =
+        Object.create(appConfig.documentProperties);
+      documentPropertiesConfig.overlayManager = self.overlayManager;
       self.pdfDocumentProperties =
-        new PDFDocumentProperties(appConfig.documentProperties);
+        new PDFDocumentProperties(documentPropertiesConfig);
 
       self.toolbar = new Toolbar(appConfig.toolbar, container, eventBus);
 
@@ -417,7 +421,10 @@ var PDFViewerApplication = {
         });
       }
 
-      self.passwordPrompt = new PasswordPrompt(appConfig.passwordOverlay);
+      // FIXME better PasswordPrompt constructor parameters
+      var passwordPromptConfig = Object.create(appConfig.passwordOverlay);
+      passwordPromptConfig.overlayManager = self.overlayManager;
+      self.passwordPrompt = new PasswordPrompt(passwordPromptConfig);
 
       self.pdfOutlineViewer = new PDFOutlineViewer({
         container: appConfig.sidebar.outlineView,
@@ -1977,7 +1984,7 @@ function webViewerClick(evt) {
 }
 
 function webViewerKeyDown(evt) {
-  if (OverlayManager.active) {
+  if (PDFViewerApplication.overlayManager.active) {
     return;
   }
 

--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -19,17 +19,15 @@
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
     define('pdfjs-web/chromecom', ['exports', 'pdfjs-web/app',
-      'pdfjs-web/overlay_manager', 'pdfjs-web/preferences', 'pdfjs-web/pdfjs'],
-      factory);
+      'pdfjs-web/preferences', 'pdfjs-web/pdfjs'], factory);
   } else if (typeof exports !== 'undefined') {
-    factory(exports, require('./app.js'), require('./overlay_manager.js'),
-      require('./preferences.js'), require('./pdfjs.js'));
+    factory(exports, require('./app.js'), require('./preferences.js'),
+      require('./pdfjs.js'));
   } else {
     factory((root.pdfjsWebChromeCom = {}), root.pdfjsWebApp,
-      root.pdfjsWebOverlayManager, root.pdfjsWebPreferences,
-      root.pdfjsWebPDFJS);
+      root.pdfjsWebPreferences, root.pdfjsWebPDFJS);
   }
-}(this, function (exports, app, overlayManager, preferences, pdfjsLib) {
+}(this, function (exports, app, preferences, pdfjsLib) {
   if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('CHROME')) {
     throw new Error('Module "pdfjs-web/chromecom" shall not be used outside ' +
                     'CHROME build.');
@@ -37,7 +35,6 @@
 
   var PDFViewerApplication = app.PDFViewerApplication;
   var DefaultExernalServices = app.DefaultExernalServices;
-  var OverlayManager = overlayManager.OverlayManager;
   var Preferences = preferences.Preferences;
 
   var ChromeCom = {};
@@ -171,6 +168,7 @@
 
   var chromeFileAccessOverlayPromise;
   function requestAccessToLocalFile(fileUrl) {
+    var overlayManager = PDFViewerApplication.overlayManager;
     var onCloseOverlay = null;
     if (top !== window) {
       // When the extension reloads after receiving new permissions, the pages
@@ -184,11 +182,11 @@
       onCloseOverlay = function() {
         window.removeEventListener('focus', reloadIfRuntimeIsUnavailable);
         reloadIfRuntimeIsUnavailable();
-        OverlayManager.close('chromeFileAccessOverlay');
+        overlayManager.close('chromeFileAccessOverlay');
       };
     }
     if (!chromeFileAccessOverlayPromise) {
-      chromeFileAccessOverlayPromise = OverlayManager.register(
+      chromeFileAccessOverlayPromise = overlayManager.register(
         'chromeFileAccessOverlay',
         document.getElementById('chromeFileAccessOverlay'),
         onCloseOverlay, true);
@@ -230,7 +228,7 @@
       // why this permission request is shown.
       document.getElementById('chrome-url-of-local-file').textContent = fileUrl;
 
-      OverlayManager.open('chromeFileAccessOverlay');
+      PDFViewerApplication.overlayManager.open('chromeFileAccessOverlay');
     });
   }
 

--- a/web/overlay_manager.js
+++ b/web/overlay_manager.js
@@ -25,131 +25,143 @@
   }
 }(this, function (exports) {
 
-var OverlayManager = {
-  overlays: {},
-  active: null,
-
+/**
+ * @class
+ */
+var OverlayManager = (function OverlayManagerClosure() {
   /**
-   * @param {string} name The name of the overlay that is registered.
-   * @param {HTMLDivElement} element The overlay's DOM element.
-   * @param {function} callerCloseMethod (optional) The method that, if present,
-   *                   will call OverlayManager.close from the Object
-   *                   registering the overlay. Access to this method is
-   *                   necessary in order to run cleanup code when e.g.
-   *                   the overlay is force closed. The default is null.
-   * @param {boolean} canForceClose (optional) Indicates if opening the overlay
-   *                  will close an active overlay. The default is false.
-   * @returns {Promise} A promise that is resolved when the overlay has been
-   *                    registered.
+   * @constructs OverlayManager
    */
-  register: function overlayManagerRegister(name, element,
-                                            callerCloseMethod, canForceClose) {
-    return new Promise(function (resolve) {
-      var container;
-      if (!name || !element || !(container = element.parentNode)) {
-        throw new Error('Not enough parameters.');
-      } else if (this.overlays[name]) {
-        throw new Error('The overlay is already registered.');
-      }
-      this.overlays[name] = { element: element,
-                              container: container,
-                              callerCloseMethod: (callerCloseMethod || null),
-                              canForceClose: (canForceClose || false) };
-      resolve();
-    }.bind(this));
-  },
+  function OverlayManager() {
+    this.overlays = {};
+    this.active = null;
+  }
 
-  /**
-   * @param {string} name The name of the overlay that is unregistered.
-   * @returns {Promise} A promise that is resolved when the overlay has been
-   *                    unregistered.
-   */
-  unregister: function overlayManagerUnregister(name) {
-    return new Promise(function (resolve) {
-      if (!this.overlays[name]) {
-        throw new Error('The overlay does not exist.');
-      } else if (this.active === name) {
-        throw new Error('The overlay cannot be removed while it is active.');
-      }
-      delete this.overlays[name];
+  OverlayManager.prototype = {
+    /**
+     * @param {string} name The name of the overlay that is registered.
+     * @param {HTMLDivElement} element The overlay's DOM element.
+     * @param {function} callerCloseMethod (optional) The method that, if
+     *                   present, calls OverlayManager.close from the Object
+     *                   registering the overlay. Access to this method is
+     *                   necessary in order to run cleanup code when e.g.
+     *                   the overlay is force closed. The default is null.
+     * @param {boolean} canForceClose (optional) Indicates if opening the
+     *                  overlay closes an active overlay. The default is false.
+     * @returns {Promise} A promise that is resolved when the overlay has been
+     *                    registered.
+     */
+    register:
+        function OverlayManager_register(name, element, callerCloseMethod,
+                                         canForceClose) {
+      return new Promise(function (resolve) {
+        var container;
+        if (!name || !element || !(container = element.parentNode)) {
+          throw new Error('Not enough parameters.');
+        } else if (this.overlays[name]) {
+          throw new Error('The overlay is already registered.');
+        }
+        this.overlays[name] = { element: element,
+                                container: container,
+                                callerCloseMethod: (callerCloseMethod || null),
+                                canForceClose: (canForceClose || false) };
+        resolve();
+      }.bind(this));
+    },
 
-      resolve();
-    }.bind(this));
-  },
-
-  /**
-   * @param {string} name The name of the overlay that should be opened.
-   * @returns {Promise} A promise that is resolved when the overlay has been
-   *                    opened.
-   */
-  open: function overlayManagerOpen(name) {
-    return new Promise(function (resolve) {
-      if (!this.overlays[name]) {
-        throw new Error('The overlay does not exist.');
-      } else if (this.active) {
-        if (this.overlays[name].canForceClose) {
-          this._closeThroughCaller();
+    /**
+     * @param {string} name The name of the overlay that is unregistered.
+     * @returns {Promise} A promise that is resolved when the overlay has been
+     *                    unregistered.
+     */
+    unregister: function OverlayManager_unregister(name) {
+      return new Promise(function (resolve) {
+        if (!this.overlays[name]) {
+          throw new Error('The overlay does not exist.');
         } else if (this.active === name) {
-          throw new Error('The overlay is already active.');
-        } else {
+          throw new Error('The overlay cannot be removed while it is active.');
+        }
+        delete this.overlays[name];
+
+        resolve();
+      }.bind(this));
+    },
+
+    /**
+     * @param {string} name The name of the overlay that should be opened.
+     * @returns {Promise} A promise that is resolved when the overlay has been
+     *                    opened.
+     */
+    open: function OverlayManager_open(name) {
+      return new Promise(function (resolve) {
+        if (!this.overlays[name]) {
+          throw new Error('The overlay does not exist.');
+        } else if (this.active) {
+          if (this.overlays[name].canForceClose) {
+            this._closeThroughCaller();
+          } else if (this.active === name) {
+            throw new Error('The overlay is already active.');
+          } else {
+            throw new Error('Another overlay is currently active.');
+          }
+        }
+        this.active = name;
+        this.overlays[this.active].element.classList.remove('hidden');
+        this.overlays[this.active].container.classList.remove('hidden');
+
+        window.addEventListener('keydown', this._keyDown.bind(this));
+        resolve();
+      }.bind(this));
+    },
+
+    /**
+     * @param {string} name The name of the overlay that should be closed.
+     * @returns {Promise} A promise that is resolved when the overlay has been
+     *                    closed.
+     */
+    close: function OverlayManager_close(name) {
+      return new Promise(function (resolve) {
+        if (!this.overlays[name]) {
+          throw new Error('The overlay does not exist.');
+        } else if (!this.active) {
+          throw new Error('The overlay is currently not active.');
+        } else if (this.active !== name) {
           throw new Error('Another overlay is currently active.');
         }
+        this.overlays[this.active].container.classList.add('hidden');
+        this.overlays[this.active].element.classList.add('hidden');
+        this.active = null;
+
+        window.removeEventListener('keydown', this._keyDown.bind(this));
+        resolve();
+      }.bind(this));
+    },
+
+    /**
+     * @private
+     */
+    _keyDown: function OverlayManager_keyDown(evt) {
+      if (this.active && evt.keyCode === 27) { // Esc key.
+        this._closeThroughCaller();
+        evt.preventDefault();
       }
-      this.active = name;
-      this.overlays[this.active].element.classList.remove('hidden');
-      this.overlays[this.active].container.classList.remove('hidden');
+    },
 
-      window.addEventListener('keydown', this._keyDown);
-      resolve();
-    }.bind(this));
-  },
-
-  /**
-   * @param {string} name The name of the overlay that should be closed.
-   * @returns {Promise} A promise that is resolved when the overlay has been
-   *                    closed.
-   */
-  close: function overlayManagerClose(name) {
-    return new Promise(function (resolve) {
-      if (!this.overlays[name]) {
-        throw new Error('The overlay does not exist.');
-      } else if (!this.active) {
-        throw new Error('The overlay is currently not active.');
-      } else if (this.active !== name) {
-        throw new Error('Another overlay is currently active.');
+    /**
+     * @private
+     */
+    _closeThroughCaller: function OverlayManager_closeThroughCaller() {
+      if (this.overlays[this.active].callerCloseMethod) {
+        this.overlays[this.active].callerCloseMethod();
       }
-      this.overlays[this.active].container.classList.add('hidden');
-      this.overlays[this.active].element.classList.add('hidden');
-      this.active = null;
+      if (this.active) {
+        this.close(this.active);
+      }
+    },
+  };
 
-      window.removeEventListener('keydown', this._keyDown);
-      resolve();
-    }.bind(this));
-  },
-
-  /**
-   * @private
-   */
-  _keyDown: function overlayManager_keyDown(evt) {
-    var self = OverlayManager;
-    if (self.active && evt.keyCode === 27) { // Esc key.
-      self._closeThroughCaller();
-      evt.preventDefault();
-    }
-  },
-
-  /**
-   * @private
-   */
-  _closeThroughCaller: function overlayManager_closeThroughCaller() {
-    if (this.overlays[this.active].callerCloseMethod) {
-      this.overlays[this.active].callerCloseMethod();
-    }
-    if (this.active) {
-      this.close(this.active);
-    }
-  }
-};
+  return OverlayManager;
+})();
 
 exports.OverlayManager = OverlayManager;
 }));

--- a/web/password_prompt.js
+++ b/web/password_prompt.js
@@ -17,23 +17,21 @@
 
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define('pdfjs-web/password_prompt', ['exports',
-      'pdfjs-web/ui_utils', 'pdfjs-web/overlay_manager', 'pdfjs-web/pdfjs'],
-      factory);
+    define('pdfjs-web/password_prompt', ['exports', 'pdfjs-web/ui_utils',
+      'pdfjs-web/pdfjs'], factory);
   } else if (typeof exports !== 'undefined') {
-    factory(exports, require('./ui_utils.js'), require('./overlay_manager.js'),
-      require('./pdfjs.js'));
+    factory(exports, require('./ui_utils.js'), require('./pdfjs.js'));
   } else {
     factory((root.pdfjsWebPasswordPrompt = {}), root.pdfjsWebUIUtils,
-      root.pdfjsWebOverlayManager, root.pdfjsWebPDFJS);
+      root.pdfjsWebPDFJS);
   }
-}(this, function (exports, uiUtils, overlayManager, pdfjsLib) {
+}(this, function (exports, uiUtils, pdfjsLib) {
 
 var mozL10n = uiUtils.mozL10n;
-var OverlayManager = overlayManager.OverlayManager;
 
 /**
  * @typedef {Object} PasswordPromptOptions
+ * @property {OverlayManager} overlayManager - Controls the app's overlays.
  * @property {string} overlayName - Name of the overlay for the overlay manager.
  * @property {HTMLDivElement} container - Div container for the overlay.
  * @property {HTMLParagraphElement} label - Label containing instructions for
@@ -54,6 +52,7 @@ var PasswordPrompt = (function PasswordPromptClosure() {
    * @param {PasswordPromptOptions} options
    */
   function PasswordPrompt(options) {
+    this.overlayManager = options.overlayManager;
     this.overlayName = options.overlayName;
     this.container = options.container;
     this.label = options.label;
@@ -73,13 +72,13 @@ var PasswordPrompt = (function PasswordPromptClosure() {
       }
     }.bind(this));
 
-    OverlayManager.register(this.overlayName, this.container,
-                            this.close.bind(this), true);
+    this.overlayManager.register(this.overlayName, this.container,
+                                 this.close.bind(this), true);
   }
 
   PasswordPrompt.prototype = {
     open: function PasswordPrompt_open() {
-      OverlayManager.open(this.overlayName).then(function () {
+      this.overlayManager.open(this.overlayName).then(function () {
         this.input.type = 'password';
         this.input.focus();
 
@@ -96,7 +95,7 @@ var PasswordPrompt = (function PasswordPromptClosure() {
     },
 
     close: function PasswordPrompt_close() {
-      OverlayManager.close(this.overlayName).then(function () {
+      this.overlayManager.close(this.overlayName).then(function () {
         this.input.value = '';
         this.input.type = '';
       }.bind(this));

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -18,20 +18,19 @@
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
     define('pdfjs-web/pdf_print_service', ['exports', 'pdfjs-web/ui_utils',
-      'pdfjs-web/overlay_manager', 'pdfjs-web/app', 'pdfjs-web/pdfjs'],
-      factory);
+      'pdfjs-web/app', 'pdfjs-web/pdfjs'], factory);
   } else if (typeof exports !== 'undefined') {
-    factory(exports, require('./ui_utils.js'), require('./overlay_manager.js'),
-      require('./app.js'), require('./pdfjs.js'));
+    factory(exports, require('./ui_utils.js'), require('./app.js'),
+      require('./pdfjs.js'));
   } else {
     factory((root.pdfjsWebPDFPrintService = {}), root.pdfjsWebUIUtils,
-      root.pdfjsWebOverlayManager, root.pdfjsWebApp, root.pdfjsWebPDFJS);
+      root.pdfjsWebApp, root.pdfjsWebPDFJS);
   }
-}(this, function (exports, uiUtils, overlayManager, app, pdfjsLib) {
+}(this, function (exports, uiUtils, app, pdfjsLib) {
   var mozL10n = uiUtils.mozL10n;
   var CSS_UNITS = uiUtils.CSS_UNITS;
   var PDFPrintServiceFactory = app.PDFPrintServiceFactory;
-  var OverlayManager = overlayManager.OverlayManager;
+  var PDFViewerApplication = app.PDFViewerApplication;
 
   var activeService = null;
 
@@ -133,10 +132,11 @@
       this.scratchCanvas = null;
       activeService = null;
       ensureOverlay().then(function () {
-        if (OverlayManager.active !== 'printServiceOverlay') {
+        var overlayManager = PDFViewerApplication.overlayManager;
+        if (overlayManager.active !== 'printServiceOverlay') {
           return; // overlay was already closed
         }
-        OverlayManager.close('printServiceOverlay');
+        overlayManager.close('printServiceOverlay');
       });
     },
 
@@ -224,7 +224,7 @@
     }
     ensureOverlay().then(function () {
       if (activeService) {
-        OverlayManager.open('printServiceOverlay');
+        PDFViewerApplication.overlayManager.open('printServiceOverlay');
       }
     });
 
@@ -233,8 +233,10 @@
     } finally {
       if (!activeService) {
         console.error('Expected print service to be initialized.');
-        if (OverlayManager.active === 'printServiceOverlay') {
-          OverlayManager.close('printServiceOverlay');
+
+        var overlayManager = PDFViewerApplication.overlayManager;
+        if (overlayManager.active === 'printServiceOverlay') {
+          overlayManager.close('printServiceOverlay');
         }
         return; // eslint-disable-line no-unsafe-finally
       }
@@ -326,8 +328,10 @@
   var overlayPromise;
   function ensureOverlay() {
     if (!overlayPromise) {
-      overlayPromise = OverlayManager.register('printServiceOverlay',
-        document.getElementById('printServiceOverlay'), abort, true);
+      overlayPromise =
+        PDFViewerApplication.overlayManager.register('printServiceOverlay',
+          document.getElementById('printServiceOverlay'), abort, true);
+
       document.getElementById('printCancel').onclick = abort;
     }
     return overlayPromise;


### PR DESCRIPTION
This work makes the code similar to the other components and reduces the number of dependencies for those components because the overlay manager is no longer a global.

I kept the `FIXME` comments equal to the already existing ones as the way we amend configuration objects should be improved in a follow-up. This way it is at least clear which parts should be refactored.

*Much easier to review with https://github.com/mozilla/pdf.js/pull/8119/files?w=1.*