### PR TITLE
Ensure that we don't ignore `0` values in `Page.getInheritedPageProp` (issue 8125)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -112,7 +112,7 @@ var Page = (function PageClosure() {
       // e.g. \Resources placed on multiple levels of the tree.
       while (dict) {
         var value = getArray ? dict.getArray(key) : dict.get(key);
-        if (value) {
+        if (value !== undefined) {
           if (!valueArray) {
             valueArray = [];
           }

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -47,6 +47,7 @@
 !issue7901.pdf
 !issue8061.pdf
 !issue8088.pdf
+!issue8125.pdf
 !bad-PageLabels.pdf
 !filled-background.pdf
 !ArabicCIDTrueType.pdf

--- a/test/pdfs/issue8125.pdf
+++ b/test/pdfs/issue8125.pdf
@@ -1,0 +1,69 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/Pages 2 0 R
+/Type /Catalog
+>>
+endobj 
+2 0 obj 
+<<
+/Rotate 180
+/Kids [3 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+3 0 obj 
+<<
+/Rotate 0
+/Parent 2 0 R
+/MediaBox [0 0 275 50]
+/Resources 
+<<
+/Font 
+<<
+/F1 4 0 R
+>>
+>>
+/Contents 5 0 R
+/Type /Page
+>>
+endobj 
+4 0 obj 
+<<
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/Type /Font
+>>
+endobj 
+5 0 obj 
+<<
+/Length 77
+>>
+stream
+BT
+10 20 TD
+/F1 14 Tf
+(Issue 8125 - The text should be right-side up.) Tj
+ET
+
+endstream 
+endobj xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000066 00000 n 
+0000000137 00000 n 
+0000000276 00000 n 
+0000000377 00000 n 
+trailer
+
+<<
+/Root 1 0 R
+/Size 6
+>>
+startxref
+506
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -726,6 +726,13 @@
        "link": false,
        "type": "eq"
     },
+    {  "id": "issue8125",
+       "file": "pdfs/issue8125.pdf",
+       "md5": "2073d699ea82156682542f811300b3e8",
+       "rounds": 1,
+       "link": false,
+       "type": "eq"
+    },
     {  "id": "txt2pdf",
        "file": "pdfs/txt2pdf.pdf",
        "md5": "02cefa0f5e8d96313bb05163b2f88c8c",


### PR DESCRIPTION
It appears that I accidentally broke this in PR #6065, sorry about that!

The issue in this particular PDF file is that there's `/Rotate` entries on different levels of the `/Pages` tree. We're supposed to use the `/Rotate` entry in the `/Page` dict (which is `0`), but because of an incorrect condition we instead ended up with the one from the `/Pages` dict (which is `180`).

Fixes #8125.