### PR TITLE
Network: use the current location to prevent errors when using CSP headers

### DIFF
--- a/src/core/network.js
+++ b/src/core/network.js
@@ -31,6 +31,8 @@ if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
                   'be used with FIREFOX or MOZCENTRAL build.');
 }
 
+  var globalScope = sharedUtil.globalScope;
+
   var OK_RESPONSE = 200;
   var PARTIAL_CONTENT_RESPONSE = 206;
 
@@ -74,7 +76,7 @@ if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
       // blocked, e.g. via the connect-src CSP directive or the NoScript addon.
       // When this error occurs, this feature detection method will mistakenly
       // report that moz-chunked-arraybuffer is not supported in Firefox 37-.
-      x.open('GET', 'https://example.com');
+      x.open('GET', globalScope.location.href);
       x.responseType = 'moz-chunked-arraybuffer';
       return x.responseType === 'moz-chunked-arraybuffer';
     } catch (e) {


### PR DESCRIPTION
When using content security headers to restrict connections to the same origin, you may not make connections to `example.com`. This feature detection also works with a request to the current location.

Fix-up of #8049.