### PR TITLE
Don't include `web/compatibility.js` in the output for `gulp lib` (PR 8120 follow-up)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -954,7 +954,11 @@ gulp.task('lib', ['buildnumber'], function () {
       'src/shared/{compatibility,util}.js',
       'src/{pdf,pdf.worker}.js',
     ], {base: 'src/'}),
-    gulp.src(['web/*.js', '!web/viewer.js'], {base: '.'}),
+    gulp.src([
+      'web/*.js',
+      '!web/viewer.js',
+      '!web/compatibility.js',
+    ], {base: '.'}),
     gulp.src('test/unit/*.js', {base: '.'}),
   ]).pipe(transform(preprocess))
     .pipe(gulp.dest('build/lib/'));


### PR DESCRIPTION
First of all, `compatibility.js` is already available in `lib/shared/compatibility.js`. Second of all, as can be seen in https://github.com/mozilla/pdfjs-dist/commit/9142301f3572cd386092cb4f4d69e186142ae23e#diff-9432ebaa58e10ab02874fcb86f689caa, the `lib/web/compatibility.js` file cannot work since the `require` statement isn't compatible with the output of `gulp lib`.