### PR TITLE
Get rid of `element.removeChild(element.firstChild)` usage (bug 1345253)

### DIFF
--- a/web/pdf_attachment_viewer.js
+++ b/web/pdf_attachment_viewer.js
@@ -61,10 +61,8 @@ var PDFAttachmentViewer = (function PDFAttachmentViewerClosure() {
     reset: function PDFAttachmentViewer_reset(keepRenderedCapability) {
       this.attachments = null;
 
-      var container = this.container;
-      while (container.firstChild) {
-        container.removeChild(container.firstChild);
-      }
+      // Remove the attachments from the DOM.
+      this.container.textContent = '';
 
       if (!keepRenderedCapability) {
         // NOTE: The *only* situation in which the `_renderedCapability` should

--- a/web/pdf_outline_viewer.js
+++ b/web/pdf_outline_viewer.js
@@ -63,10 +63,8 @@ var PDFOutlineViewer = (function PDFOutlineViewerClosure() {
       this.outline = null;
       this.lastToggleIsShow = true;
 
-      var container = this.container;
-      while (container.firstChild) {
-        container.removeChild(container.firstChild);
-      }
+      // Remove the outline from the DOM.
+      this.container.textContent = '';
     },
 
     /**

--- a/web/pdf_outline_viewer.js
+++ b/web/pdf_outline_viewer.js
@@ -65,6 +65,9 @@ var PDFOutlineViewer = (function PDFOutlineViewerClosure() {
 
       // Remove the outline from the DOM.
       this.container.textContent = '';
+      // Ensure that the left (right in RTL locales) margin is always reset,
+      // to prevent incorrect outline alignment if a new document is opened.
+      this.container.classList.remove('outlineWithDeepNesting');
     },
 
     /**


### PR DESCRIPTION
Instead of just upstreaming the changes from [bug 1345253](https://bugzilla.mozilla.org/show_bug.cgi?id=1345253) as-is, it seemed better to simply get rid of the loops altogether and use the same approach as in `PDFViewer`/`PDFThumbnailViewer`.

The PR also fixes an existing issue with `PDFOutlineViewer.reset` not actually resetting *all* the state it should.

Fixes #8139.
