### PR TITLE
Change to conditions that `pdfjsLib`

### DIFF
--- a/web/pdfjs.js
+++ b/web/pdfjs.js
@@ -21,10 +21,12 @@ if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('PRODUCTION')) {
   var pdfjsLib;
   // The if below protected by __pdfjsdev_webpack__ check from webpack parsing.
   if (typeof __pdfjsdev_webpack__ === 'undefined') {
-    if (typeof require === 'function') {
-      pdfjsLib = require('../build/pdf.js'); // using a bundler to pull the core
+    if (typeof window !== 'undefined' && window['pdfjs-dist/build/pdf']) {
+      pdfjsLib = window['pdfjs-dist/build/pdf'];
+    } else if (typeof require === 'function') {
+      pdfjsLib = require('../build/pdf.js');
     } else {
-      pdfjsLib = window['pdfjs-dist/build/pdf']; // loaded via html script tag
+      throw new Error('Neither `require` nor `window` found');
     }
   }
   module.exports = pdfjsLib;


### PR DESCRIPTION
Changing the order of logical conditions to prefer  in the case where webpack is not used.

In the case where webpack is not being used (presumably in a server-side require context) for the distribution, the case which uses `require` presumes that the require implementation can use a relative path to find the module.

However, the `../build/pdf.js` file may not be available to `require` as expected. The value set on `window` is certainly available in this case. So my thinking here is to prefer the `window` value for setting `pdfjsLib` where it is available and fall back to `require` if doing the rendering on the server-side (where `require` will be more free to find the `pdf.js` module by relative path).
