### PR TITLE
Move `Uint32ArrayView` from `shared/util.js` to `shared/compatibility.js`

### DIFF
--- a/src/core/murmurhash3.js
+++ b/src/core/murmurhash3.js
@@ -29,7 +29,7 @@
   }
 }(this, function (exports, sharedUtil) {
 
-var Uint32ArrayView = sharedUtil.Uint32ArrayView;
+var globalScope = sharedUtil.globalScope;
 
 var MurmurHash3_64 = (function MurmurHash3_64Closure(seed) {
   // Workaround for missing math precision in JS.
@@ -87,7 +87,7 @@ var MurmurHash3_64 = (function MurmurHash3_64Closure(seed) {
       var tailLength = length - blockCounts * 4;
       // we don't care about endianness here
       var dataUint32 = useUint32ArrayView ?
-        new Uint32ArrayView(data, blockCounts) :
+        new globalScope.Uint32ArrayView(data, blockCounts) :
         new Uint32Array(data.buffer, 0, blockCounts);
       var k1 = 0;
       var k2 = 0;

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -31,12 +31,12 @@
 }(this, function (exports, sharedUtil, displayDOMUtils, displayPatternHelper,
                   displayWebGL) {
 
+var globalScope = sharedUtil.globalScope;
 var FONT_IDENTITY_MATRIX = sharedUtil.FONT_IDENTITY_MATRIX;
 var IDENTITY_MATRIX = sharedUtil.IDENTITY_MATRIX;
 var ImageKind = sharedUtil.ImageKind;
 var OPS = sharedUtil.OPS;
 var TextRenderingMode = sharedUtil.TextRenderingMode;
-var Uint32ArrayView = sharedUtil.Uint32ArrayView;
 var Util = sharedUtil.Util;
 var assert = sharedUtil.assert;
 var info = sharedUtil.info;
@@ -511,7 +511,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       // Grayscale, 1 bit per pixel (i.e. black-and-white).
       var srcLength = src.byteLength;
       var dest32 = HasCanvasTypedArraysCached.value ?
-        new Uint32Array(dest.buffer) : new Uint32ArrayView(dest);
+        new Uint32Array(dest.buffer) : new globalScope.Uint32ArrayView(dest);
       var dest32DataLength = dest32.length;
       var fullSrcDiff = (width + 7) >> 3;
       var white = 0xFFFFFFFF;

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -133,6 +133,49 @@ PDFJS.compatibilityChecked = true;
   globalScope.Float64Array = TypedArray;
 })();
 
+(function addUint32ArrayView() {
+  var Uint32ArrayView = (function Uint32ArrayViewClosure() {
+    function Uint32ArrayView(buffer, length) {
+      this.buffer = buffer;
+      this.byteLength = buffer.length;
+      this.length = length === undefined ? (this.byteLength >> 2) : length;
+      ensureUint32ArrayViewProps(this.length);
+    }
+    Uint32ArrayView.prototype = Object.create(null);
+
+    var uint32ArrayViewSetters = 0;
+    function createUint32ArrayProp(index) {
+      return {
+        get: function () {
+          var buffer = this.buffer, offset = index << 2;
+          return (buffer[offset] | (buffer[offset + 1] << 8) |
+            (buffer[offset + 2] << 16) | (buffer[offset + 3] << 24)) >>> 0;
+        },
+        set: function (value) {
+          var buffer = this.buffer, offset = index << 2;
+          buffer[offset] = value & 255;
+          buffer[offset + 1] = (value >> 8) & 255;
+          buffer[offset + 2] = (value >> 16) & 255;
+          buffer[offset + 3] = (value >>> 24) & 255;
+        }
+      };
+    }
+
+    function ensureUint32ArrayViewProps(length) {
+      while (uint32ArrayViewSetters < length) {
+        Object.defineProperty(Uint32ArrayView.prototype,
+          uint32ArrayViewSetters,
+          createUint32ArrayProp(uint32ArrayViewSetters));
+        uint32ArrayViewSetters++;
+      }
+    }
+
+    return Uint32ArrayView;
+  })();
+
+  globalScope.Uint32ArrayView = Uint32ArrayView;
+})();
+
 // URL = URL || webkitURL
 // Support: Safari<7, Android 4.2+
 (function normalizeURLObject() {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -634,50 +634,6 @@ function isEvalSupported() {
   }
 }
 
-if (typeof PDFJSDev === 'undefined' ||
-    !PDFJSDev.test('FIREFOX || MOZCENTRAL || CHROME')) {
-  var Uint32ArrayView = (function Uint32ArrayViewClosure() {
-    function Uint32ArrayView(buffer, length) {
-      this.buffer = buffer;
-      this.byteLength = buffer.length;
-      this.length = length === undefined ? (this.byteLength >> 2) : length;
-      ensureUint32ArrayViewProps(this.length);
-    }
-    Uint32ArrayView.prototype = Object.create(null);
-
-    var uint32ArrayViewSetters = 0;
-    function createUint32ArrayProp(index) {
-      return {
-        get: function () {
-          var buffer = this.buffer, offset = index << 2;
-          return (buffer[offset] | (buffer[offset + 1] << 8) |
-            (buffer[offset + 2] << 16) | (buffer[offset + 3] << 24)) >>> 0;
-        },
-        set: function (value) {
-          var buffer = this.buffer, offset = index << 2;
-          buffer[offset] = value & 255;
-          buffer[offset + 1] = (value >> 8) & 255;
-          buffer[offset + 2] = (value >> 16) & 255;
-          buffer[offset + 3] = (value >>> 24) & 255;
-        }
-      };
-    }
-
-    function ensureUint32ArrayViewProps(length) {
-      while (uint32ArrayViewSetters < length) {
-        Object.defineProperty(Uint32ArrayView.prototype,
-          uint32ArrayViewSetters,
-          createUint32ArrayProp(uint32ArrayViewSetters));
-        uint32ArrayViewSetters++;
-      }
-    }
-
-    return Uint32ArrayView;
-  })();
-
-  exports.Uint32ArrayView = Uint32ArrayView;
-}
-
 var IDENTITY_MATRIX = [1, 0, 0, 1, 0, 0];
 
 var Util = (function UtilClosure() {


### PR DESCRIPTION
It seems to me that this code doesn't belong in `shared/util.js`, since it's only necessary for old browsers.

However, what really motivated this patch is that once we move to ES6 modules (which hopefully happens soon), then the current code won't work since `import`/`export` statements must be placed at the top-level of modules.