### PR TITLE
Don't read past the EOI marker for JPEG images with non-default restart interval (issue 7828)

### DIFF
--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -329,13 +329,12 @@ var JpegImage = (function JpegImageClosure() {
     } else {
       mcuExpected = mcusPerLine * frame.mcusPerColumn;
     }
-    if (!resetInterval) {
-      resetInterval = mcuExpected;
-    }
 
     var h, v;
     while (mcu < mcuExpected) {
       // reset interval stuff
+      var mcuToRead = resetInterval ?
+        Math.min(mcuExpected - mcu, resetInterval) : mcuExpected;
       for (i = 0; i < componentsLength; i++) {
         components[i].pred = 0;
       }
@@ -343,12 +342,12 @@ var JpegImage = (function JpegImageClosure() {
 
       if (componentsLength === 1) {
         component = components[0];
-        for (n = 0; n < resetInterval; n++) {
+        for (n = 0; n < mcuToRead; n++) {
           decodeBlock(component, decodeFn, mcu);
           mcu++;
         }
       } else {
-        for (n = 0; n < resetInterval; n++) {
+        for (n = 0; n < mcuToRead; n++) {
           for (i = 0; i < componentsLength; i++) {
             component = components[i];
             h = component.h;

--- a/test/pdfs/issue7828.pdf.link
+++ b/test/pdfs/issue7828.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/601312/Untitled_20160807_114311.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2099,6 +2099,13 @@
        "type": "eq",
        "about": "Inline JPEG images."
     },
+    {  "id": "issue7828",
+       "file": "pdfs/issue7828.pdf",
+       "md5": "462f96c877f5761fc3176156e3526184",
+       "rounds": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "issue1655",
        "file": "pdfs/issue1655r.pdf",
        "md5": "569f48449ba57c15c4f9ade151a651c5",


### PR DESCRIPTION
*After browsing through (a version of) the JPEG specification, see https://www.w3.org/Graphics/JPEG/itu-t81.pdf, I hope that this patch makes sense.*

Note that while issue #7828 became a problem after PR #7661, it isn't really a regression from that PR. The explanation is rather that we're now relying on `core/jpg.js` instead of the Native Image decoder in more situations than before, which thus exposed an *existing* issue in our JPEG decoder.
Another factor also seems to be that in many JPEG images, the DRI (Define Restart Interval) marker isn't present, in which case this bug won't manifest either.

According to https://www.w3.org/Graphics/JPEG/itu-t81.pdf#page=89 (at the bottom of the page):
> "NOTE – The final restart interval may be smaller than the size specified by the DRI marker segment, as it includes only the number of MCUs remaining in the scan."

Furthermore, according to https://www.w3.org/Graphics/JPEG/itu-t81.pdf#page=39 (in the middle of the page):
> "[...] If restart is enabled and the restart interval is defined to be Ri, each entropy-coded segment except the last one shall contain Ri MCUs. The last one shall contain whatever number of MCUs completes the scan."

Based on the above, it thus seem to me that we should simply ensure that we're not attempting to continue to parse Scan data once we've found all MCUs (Minimum Coded Unit) of the image.

Fixes #7828.