### PR TITLE
Normalize the `BBox` entry in Tiling Pattern dictionaries (issue 8117)

### DIFF
--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -318,7 +318,7 @@ var TilingPattern = (function TilingPatternClosure() {
   function TilingPattern(IR, color, ctx, canvasGraphicsFactory, baseTransform) {
     this.operatorList = IR[2];
     this.matrix = IR[3] || [1, 0, 0, 1, 0, 0];
-    this.bbox = IR[4];
+    this.bbox = Util.normalizeRect(IR[4]);
     this.xstep = IR[5];
     this.ystep = IR[6];
     this.paintType = IR[7];
@@ -406,7 +406,7 @@ var TilingPattern = (function TilingPatternClosure() {
     },
 
     clipBbox: function clipBbox(graphics, bbox, x0, y0, x1, y1) {
-      if (bbox && isArray(bbox) && bbox.length === 4) {
+      if (isArray(bbox) && bbox.length === 4) {
         var bboxWidth = x1 - x0;
         var bboxHeight = y1 - y0;
         graphics.ctx.rect(x0, y0, bboxWidth, bboxHeight);

--- a/test/pdfs/issue8117.pdf.link
+++ b/test/pdfs/issue8117.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/806780/Test.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1905,6 +1905,13 @@
       "rounds": 1,
       "type": "eq"
     },
+    {  "id": "issue8117",
+       "file": "pdfs/issue8117.pdf",
+       "md5": "0c805ae480dd523148a16fe7ed0fc867",
+       "rounds": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "issue7855",
        "file": "pdfs/issue7855.pdf",
        "md5": "290d4d5da041ffbcb1ea5d3b0ed8ee91",


### PR DESCRIPTION
According to the PDF specification, see http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#G7.3982967, the `BBox` entry should have the form `[left, bottom, right, top]`.
Since some PDF generators apparently violates the specification, we normalize the `BBox` to ensure that the pattern is (correctly) rendered.

Fixes #8117.