### PR TITLE
Try to recover when encountering JPEG markers with too short marker lengths (issue 8169)

### DIFF
--- a/test/pdfs/issue8169.pdf.link
+++ b/test/pdfs/issue8169.pdf.link
@@ -1,0 +1,1 @@
+http://web.archive.org/save/_embed/http://210.243.166.143/prob1.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -733,6 +733,13 @@
        "link": false,
        "type": "eq"
     },
+    {  "id": "issue8169",
+       "file": "pdfs/issue8169.pdf",
+       "md5": "62fd6479f9e1c8c5ce8cba6b1781d0a5",
+       "rounds": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "txt2pdf",
        "file": "pdfs/txt2pdf.pdf",
        "md5": "02cefa0f5e8d96313bb05163b2f88c8c",


### PR DESCRIPTION
The issue with the JPEG image in question, is that the COM (Comment) marker has an incorrect length entry.

Fixes #8169.