### PR TITLE
Upstream the changes from bug 1345294 - nsIPrefBranch should have methods to get/set unicode strings

### DIFF
--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -93,7 +93,12 @@ function getIntPref(pref, def) {
 
 function getStringPref(pref, def) {
   try {
-    return Services.prefs.getComplexValue(pref, Ci.nsISupportsString).data;
+//#if !MOZCENTRAL
+    if (!Services.prefs.getStringPref) {
+      return Services.prefs.getComplexValue(pref, Ci.nsISupportsString).data;
+    }
+//#endif
+    return Services.prefs.getStringPref(pref);
   } catch (ex) {
     return def;
   }

--- a/extensions/firefox/content/PdfjsChromeUtils.jsm
+++ b/extensions/firefox/content/PdfjsChromeUtils.jsm
@@ -273,10 +273,16 @@ var PdfjsChromeUtils = {
 
   _setStringPref(aPrefName, aPrefValue) {
     this._ensurePreferenceAllowed(aPrefName);
-    let str = Cc["@mozilla.org/supports-string;1"]
-                .createInstance(Ci.nsISupportsString);
-    str.data = aPrefValue;
-    Services.prefs.setComplexValue(aPrefName, Ci.nsISupportsString, str);
+//#if !MOZCENTRAL
+    if (!Services.prefs.setStringPref) {
+      let str = Cc["@mozilla.org/supports-string;1"]
+                  .createInstance(Ci.nsISupportsString);
+      str.data = aPrefValue;
+      Services.prefs.setComplexValue(aPrefName, Ci.nsISupportsString, str);
+      return;
+    }
+//#endif
+    Services.prefs.setStringPref(aPrefName, aPrefValue);
   },
 
   /*


### PR DESCRIPTION
Note that in order to not break compatibility for the Firefox addon, the preprocessor is used.

Re: [bug 1345294](https://bugzilla.mozilla.org/show_bug.cgi?id=1345294) and also [this commit](https://hg.mozilla.org/mozilla-central/rev/5a8192a650e9).

**Edit:** Slightly easier reviewing with https://github.com/mozilla/pdf.js/pull/8172/files?w=1.