### PR TITLE
Adjust the `yoda` ESLint rule to apply to inequalities as well

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -73,7 +73,9 @@
     "no-useless-call": "error",
     "no-useless-concat": "error",
     "wrap-iife": ["error", "any"],
-    "yoda": ["error", "never", { "onlyEquality": true, }],
+    "yoda": ["error", "never", {
+      "exceptRange": true,
+    }],
 
     // Strict Mode
     "strict": ["error", "global"],

--- a/extensions/chromium/contentscript.js
+++ b/extensions/chromium/contentscript.js
@@ -41,7 +41,7 @@ function onAnimationStart(event) {
 // invocations have no effect.
 function watchObjectOrEmbed(elem) {
   var mimeType = elem.type;
-  if (mimeType && 'application/pdf' !== mimeType.toLowerCase()) {
+  if (mimeType && mimeType.toLowerCase() !== 'application/pdf') {
     return;
   }
   // <embed src> <object data>

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1614,7 +1614,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
               var type = xobj.dict.get('Subtype');
               assert(isName(type), 'XObject should have a Name subtype');
 
-              if ('Form' !== type.name) {
+              if (type.name !== 'Form') {
                 xobjsCache.key = name;
                 xobjsCache.texts = null;
                 break;

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -106,7 +106,7 @@ var JpxImage = (function JpxImageClosure() {
             this.parseCodestream(data, position, position + dataLength);
             break;
           case 0x6A502020: // 'jP\024\024'
-            if (0x0d0a870a !== readUint32(data, position)) {
+            if (readUint32(data, position) !== 0x0d0a870a) {
               warn('Invalid JP2 signature');
             }
             break;

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -349,7 +349,7 @@ Shadings.Mesh = (function MeshClosure() {
       var coord = reader.readCoordinate();
       var color = reader.readComponents();
       if (verticesLeft === 0) { // ignoring flags if we started a triangle
-        assert(0 <= f && f <= 2, 'Unknown type4 flag');
+        assert((0 <= f && f <= 2), 'Unknown type4 flag');
         switch (f) {
           case 0:
             verticesLeft = 3;
@@ -513,7 +513,7 @@ Shadings.Mesh = (function MeshClosure() {
     var cs = new Int32Array(4); // c00, c30, c03, c33
     while (reader.hasData) {
       var f = reader.readFlag();
-      assert(0 <= f && f <= 3, 'Unknown type6 flag');
+      assert((0 <= f && f <= 3), 'Unknown type6 flag');
       var i, ii;
       var pi = coords.length;
       for (i = 0, ii = (f !== 0 ? 8 : 12); i < ii; i++) {
@@ -623,7 +623,7 @@ Shadings.Mesh = (function MeshClosure() {
     var cs = new Int32Array(4); // c00, c30, c03, c33
     while (reader.hasData) {
       var f = reader.readFlag();
-      assert(0 <= f && f <= 3, 'Unknown type7 flag');
+      assert((0 <= f && f <= 3), 'Unknown type7 flag');
       var i, ii;
       var pi = coords.length;
       for (i = 0, ii = (f !== 0 ? 12 : 16); i < ii; i++) {

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -1267,7 +1267,7 @@ PDFJS.compatibilityChecked = true;
             cursor = 0;
             state = 'no scheme';
             continue;
-          } else if (EOF === c) {
+          } else if (c === EOF) {
             break loop;
           } else {
             err('Code point not allowed in scheme: ' + c);
@@ -1284,7 +1284,7 @@ PDFJS.compatibilityChecked = true;
             state = 'fragment';
           } else {
             // XXX error handling
-            if (EOF !== c && '\t' !== c && '\n' !== c && '\r' !== c) {
+            if (c !== EOF && c !== '\t' && c !== '\n' && c !== '\r') {
               this._schemeData += percentEscape(c);
             }
           }
@@ -1312,10 +1312,10 @@ PDFJS.compatibilityChecked = true;
 
         case 'relative':
           this._isRelative = true;
-          if ('file' !== this._scheme) {
+          if (this._scheme !== 'file') {
             this._scheme = base._scheme;
           }
-          if (EOF === c) {
+          if (c === EOF) {
             this._host = base._host;
             this._port = base._port;
             this._path = base._path.slice();
@@ -1348,10 +1348,10 @@ PDFJS.compatibilityChecked = true;
           } else {
             var nextC = input[cursor + 1];
             var nextNextC = input[cursor + 2];
-            if ('file' !== this._scheme || !ALPHA.test(c) ||
+            if (this._scheme !== 'file' || !ALPHA.test(c) ||
                 (nextC !== ':' && nextC !== '|') ||
-                (EOF !== nextNextC && '/' !== nextNextC && '\\' !== nextNextC &&
-                '?' !== nextNextC && '#' !== nextNextC)) {
+                (nextNextC !== EOF && nextNextC !== '/' && nextNextC !== '\\' &&
+                 nextNextC !== '?' && nextNextC !== '#')) {
               this._host = base._host;
               this._port = base._port;
               this._username = base._username;
@@ -1375,7 +1375,7 @@ PDFJS.compatibilityChecked = true;
               state = 'authority ignore slashes';
             }
           } else {
-            if ('file' !== this._scheme) {
+            if (this._scheme !== 'file') {
               this._host = base._host;
               this._port = base._port;
               this._username = base._username;
@@ -1398,14 +1398,14 @@ PDFJS.compatibilityChecked = true;
 
         case 'authority second slash':
           state = 'authority ignore slashes';
-          if ('/' !== c) {
+          if (c !== '/') {
             err('Expected \'/\', got: ' + c);
             continue;
           }
           break;
 
         case 'authority ignore slashes':
-          if ('/' !== c && '\\' !== c) {
+          if (c !== '/' && c !== '\\') {
             state = 'authority';
             continue;
           } else {
@@ -1432,7 +1432,7 @@ PDFJS.compatibilityChecked = true;
                 continue;
               }
               var tempC = percentEscape(cp);
-              if (null !== this._password) {
+              if (this._password !== null) {
                 this._password += tempC;
               } else {
                 this._username += tempC;
@@ -1489,7 +1489,7 @@ PDFJS.compatibilityChecked = true;
               break loop;
             }
             continue;
-          } else if ('\t' !== c && '\n' !== c && '\r' !== c) {
+          } else if (c !== '\t' && c !== '\n' && c !== '\r') {
             if (c === '[') {
               seenBracket = true;
             } else if (c === ']') {
@@ -1506,7 +1506,7 @@ PDFJS.compatibilityChecked = true;
             buffer += c;
           } else if (c === EOF || c === '/' || c === '\\' ||
                      c === '?' || c === '#' || stateOverride) {
-            if ('' !== buffer) {
+            if (buffer !== '') {
               var temp = parseInt(buffer, 10);
               if (temp !== relative[this._scheme]) {
                 this._port = temp + '';
@@ -1530,7 +1530,7 @@ PDFJS.compatibilityChecked = true;
             err('\'\\\' not allowed in path.');
           }
           state = 'relative path';
-          if ('/' !== c && '\\' !== c) {
+          if (c !== '/' && c !== '\\') {
             continue;
           }
           break;
@@ -1547,12 +1547,12 @@ PDFJS.compatibilityChecked = true;
             }
             if (buffer === '..') {
               this._path.pop();
-              if ('/' !== c && '\\' !== c) {
+              if (c !== '/' && c !== '\\') {
                 this._path.push('');
               }
-            } else if (buffer === '.' && '/' !== c && '\\' !== c) {
+            } else if (buffer === '.' && c !== '/' && c !== '\\') {
               this._path.push('');
-            } else if ('.' !== buffer) {
+            } else if (buffer !== '.') {
               if (this._scheme === 'file' && this._path.length === 0 &&
                   buffer.length === 2 && ALPHA.test(buffer[0]) &&
                   buffer[1] === '|') {
@@ -1568,7 +1568,7 @@ PDFJS.compatibilityChecked = true;
               this._fragment = '#';
               state = 'fragment';
             }
-          } else if ('\t' !== c && '\n' !== c && '\r' !== c) {
+          } else if (c !== '\t' && c !== '\n' && c !== '\r') {
             buffer += percentEscape(c);
           }
           break;
@@ -1577,13 +1577,13 @@ PDFJS.compatibilityChecked = true;
           if (!stateOverride && c === '#') {
             this._fragment = '#';
             state = 'fragment';
-          } else if (EOF !== c && '\t' !== c && '\n' !== c && '\r' !== c) {
+          } else if (c !== EOF && c !== '\t' && c !== '\n' && c !== '\r') {
             this._query += percentEscapeQuery(c);
           }
           break;
 
         case 'fragment':
-          if (EOF !== c && '\t' !== c && '\n' !== c && '\r' !== c) {
+          if (c !== EOF && c !== '\t' && c !== '\n' && c !== '\r') {
             this._fragment += c;
           }
           break;
@@ -1632,9 +1632,9 @@ PDFJS.compatibilityChecked = true;
         return this._url;
       }
       var authority = '';
-      if ('' !== this._username || null !== this._password) {
+      if (this._username !== '' || this._password !== null) {
         authority = this._username +
-            (null !== this._password ? ':' + this._password : '') + '@';
+          (this._password !== null ? ':' + this._password : '') + '@';
       }
 
       return this.protocol +


### PR DESCRIPTION
I happened to notice that some inequalities had the wrong order, and was surprised since I thought that the `yoda` rule should have caught that.
However, reading http://eslint.org/docs/rules/yoda#options a bit more closely than previously, it's quite obvious that the `onlyEquality` option does *exactly* what its name suggests. Hence I think that it makes sense to adjust the options such that only ranges are allowed instead.