### PR TITLE
Ensure that `PDFDocument.documentInfo` doesn't fail during document load, when the entire XRef table hasn't been fetched yet (issue 8180)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -595,6 +595,9 @@ var PDFDocument = (function PDFDocumentClosure() {
       try {
         infoDict = this.xref.trailer.get('Info');
       } catch (err) {
+        if (err instanceof MissingDataException) {
+          throw err;
+        }
         info('The document information dictionary is invalid.');
       }
       if (infoDict) {


### PR DESCRIPTION
Similar to other `try-catch` statements in `/core` code, we must re-throw `MissingDataException` to prevent issues with missing data during document loading.
Note that I'm not sure if/how we can test this, which is why the patch doesn't include any test(s).

Fixes #8180.

@Rob--W Thank you for helping with debugging this in https://github.com/mozilla/pdf.js/issues/8180#issuecomment-288386764; do you have time to review the patch?
