### PR TITLE
Rethrow MissingDataException when needed

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -467,6 +467,9 @@ var PDFDocument = (function PDFDocumentClosure() {
           }
         }
       } catch (ex) {
+        if (ex instanceof MissingDataException) {
+          throw ex;
+        }
         info('Something wrong with AcroForm entry');
         this.acroForm = null;
       }

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -104,6 +104,9 @@ var Catalog = (function CatalogClosure() {
           try {
             metadata = stringToUTF8String(bytesToString(stream.getBytes()));
           } catch (e) {
+            if (e instanceof MissingDataException) {
+              throw e;
+            }
             info('Skipping invalid metadata.');
           }
         }


### PR DESCRIPTION
@Snuffleupagus Following #8183, I ran `grep -r 'catch (' -A 2 ` and identified some more cases of `try-catch` where the catch clause should rethrow.

In core/document.js: `PDFDocument.prototype.parse` accesses a dictionary property, which could throw if the underlying data is not yet available.

In core/obj.js: `get Catalog.prototype.metadata` calls `stream.getBytes`, which can throw MissingDataException too when the stream is a ChunkedStream.