### PR TITLE
Use a proper `MessageHandler` for `PartialEvaluator.getTextContent` to avoid errors for fonts relying on built-in CMap files (PR 8064 follow-up)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -310,14 +310,9 @@ var Page = (function PageClosure() {
       });
     },
 
-    extractTextContent: function Page_extractTextContent(task,
+    extractTextContent: function Page_extractTextContent(handler, task,
                                                          normalizeWhitespace,
                                                          combineTextItems) {
-      var handler = {
-        on: function nullHandlerOn() {},
-        send: function nullHandlerSend() {}
-      };
-
       var self = this;
 
       var pdfManager = this.pdfManager;

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -906,7 +906,7 @@ var WorkerMessageHandler = {
         startWorkerTask(task);
         var pageNum = pageIndex + 1;
         var start = Date.now();
-        return page.extractTextContent(task, normalizeWhitespace,
+        return page.extractTextContent(handler, task, normalizeWhitespace,
                                        combineTextItems).then(
             function(textContent) {
           finishWorkerTask(task);

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -76,15 +76,17 @@ var DOMCMapReaderFactory = (function DOMCMapReaderFactoryClosure() {
 
   DOMCMapReaderFactory.prototype = {
     fetch: function(params) {
-      if (!params.name) {
+      var name = params.name;
+      if (!name) {
         return Promise.reject(new Error('CMap name must be specified.'));
       }
       return new Promise(function (resolve, reject) {
-        var url = this.baseUrl + params.name;
+        var url = this.baseUrl + name + (this.isCompressed ? '.bcmap' : '');
 
         var request = new XMLHttpRequest();
+        request.open('GET', url, true);
+
         if (this.isCompressed) {
-          url += '.bcmap';
           request.responseType = 'arraybuffer';
         }
         request.onreadystatechange = function () {
@@ -105,12 +107,11 @@ var DOMCMapReaderFactory = (function DOMCMapReaderFactoryClosure() {
               return;
             }
             reject(new Error('Unable to load ' +
-                             (this.isCompressed ? 'binary' : '') +
-                             ' CMap at: ' + url));
+                             (this.isCompressed ? 'binary ' : '') +
+                             'CMap at: ' + url));
           }
         }.bind(this);
 
-        request.open('GET', url, true);
         request.send(null);
       }.bind(this));
     },

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2757,9 +2757,16 @@
       "md5": "797093d67c4d4d4231ac6e1fb66bf6c3",
       "rounds": 1,
       "link": true,
-      "firstPage": 1,
       "lastPage": 1,
       "type": "eq"
+    },
+    {  "id": "mao-text",
+       "file": "pdfs/mao.pdf",
+       "md5": "797093d67c4d4d4231ac6e1fb66bf6c3",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "text"
     },
     {  "id": "noembed-identity",
       "file": "pdfs/noembed-identity.pdf",

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -35,21 +35,19 @@ var NodeCMapReaderFactory = (function NodeCMapReaderFactoryClosure() {
 
   NodeCMapReaderFactory.prototype = {
     fetch: function(params) {
-      if (!params.name) {
+      var name = params.name;
+      if (!name) {
         return Promise.reject(new Error('CMap name must be specified.'));
       }
       return new Promise(function (resolve, reject) {
-        var url = this.baseUrl + params.name;
+        var url = this.baseUrl + name + (this.isCompressed ? '.bcmap' : '');
 
         var fs = require('fs');
-        if (this.isCompressed) {
-          url += '.bcmap';
-        }
         fs.readFile(url, function (error, data) {
           if (error || !data) {
             reject(new Error('Unable to load ' +
-                             (this.isCompressed ? 'binary' : '') +
-                             ' CMap at: ' + url));
+                             (this.isCompressed ? 'binary ' : '') +
+                             'CMap at: ' + url));
             return;
           }
           resolve({


### PR DESCRIPTION
*My apologies for inadvertently breaking this in PR #8064; apparently we don't have any tests that cover this use-case :(*

Without this patch `getTextContent` will fail if called before `getOperatorList`, since loading of fonts during text-extraction may require fetching of built-in CMap files.

*Please note:* The `text` test added here, which uses an already existing PDF file, fails without this patch.

Given that this patch fixes a bad regression, I'm flagging a bunch of people for review (for whoever has time to look at it first).

---
Fixes #8193, courtesy of the second commit.

*Three cheers for all the idiosyncrasies in IE that made the second patch necessary :-P*