### PR TITLE
Remove unnecessary `xref` parameters from various method signatures in `PartialEvaluator`, since `this.xref` is already available in the relevant scope

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1071,14 +1071,10 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
             case OPS.shadingFill:
               var shadingRes = resources.get('Shading');
-              if (!shadingRes) {
-                error('No shading resource found');
-              }
+              assert(shadingRes, 'No shading resource found');
 
               var shading = shadingRes.get(args[0].name);
-              if (!shading) {
-                error('No shading object found');
-              }
+              assert(shading, 'No shading object found');
 
               var shadingFill = Pattern.parseShading(shading, null, xref,
                 resources, self.handler);
@@ -2166,9 +2162,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         //  - set the type according to the descendant font
         //  - get the FontDescriptor from the descendant font
         var df = dict.get('DescendantFonts');
-        if (!df) {
-          error('Descendant fonts are not specified');
-        }
+        assert(df, 'Descendant fonts are not specified');
         dict = (isArray(df) ? xref.fetchIfRef(df[0]) : df);
 
         type = dict.get('Subtype');
@@ -2261,9 +2255,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           // FontDescriptor was not required.
           // This case is here for compatibility.
           var baseFontName = dict.get('BaseFont');
-          if (!isName(baseFontName)) {
-            error('Base font is not specified');
-          }
+          assert(isName(baseFontName), 'Base font is not specified');
 
           // Using base font name as a font name.
           baseFontName = baseFontName.name.replace(/[,_]/g, '-');


### PR DESCRIPTION
*My intention was, at this time, to avoid adding even more stuff to the review queues. However, this PR ties into the point made in https://github.com/mozilla/pdf.js/pull/8176#pullrequestreview-27977302 about all of the parameter passing in `evaluator.js`, and seems to me to be fairly low-hanging fruit in that regard.*

@timvandermeij I'm flagging you for review, since this is a (small) first step with regards to the issue you raised in https://github.com/mozilla/pdf.js/pull/8176#pullrequestreview-27977302. If you don't have time, just un-assign yourself :-)