### PR TITLE
Example for converting PDF to PNG using the Node canvas library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tags
 Makefile
 node_modules/
 examples/node/svgdump/
+examples/node/pdf2png/*.png

--- a/examples/node/pdf2png/README.md
+++ b/examples/node/pdf2png/README.md
@@ -1,0 +1,16 @@
+## Overview
+
+Example to demonstrate converting a PDF file to a PNG image using the PDF.js library.
+
+## Getting started
+
+Install the dependencies and build the project:
+
+    $ npm install
+    $ gulp dist
+
+Install the Node canvas library to convert the first page of a PDF file to a PNG image:
+
+    $ npm install canvas
+    $ cd examples/node/pdf2png
+    $ node pdf2png.js

--- a/examples/node/pdf2png/pdf2png.js
+++ b/examples/node/pdf2png/pdf2png.js
@@ -1,0 +1,89 @@
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Canvas = require('canvas');
+var assert = require('assert');
+var fs = require('fs');
+
+function NodeCanvasFactory() {}
+NodeCanvasFactory.prototype = {
+  create: function NodeCanvasFactory_create(width, height) {
+    assert(width > 0 && height > 0, 'Invalid canvas size');
+    var canvas = new Canvas(width, height);
+    var context = canvas.getContext('2d');
+    return {
+      canvas: canvas,
+      context: context,
+    };
+  },
+
+  reset: function NodeCanvasFactory_reset(canvasAndContextPair, width, height) {
+    assert(canvasAndContextPair.canvas, 'Canvas is not specified');
+    assert(width > 0 && height > 0, 'Invalid canvas size');
+    canvasAndContextPair.canvas.width = width;
+    canvasAndContextPair.canvas.height = height;
+  },
+
+  destroy: function NodeCanvasFactory_destroy(canvasAndContextPair) {
+    assert(canvasAndContextPair.canvas, 'Canvas is not specified');
+
+    // Zeroing the width and height cause Firefox to release graphics
+    // resources immediately, which can greatly reduce memory consumption.
+    canvasAndContextPair.canvas.width = 0;
+    canvasAndContextPair.canvas.height = 0;
+    canvasAndContextPair.canvas = null;
+    canvasAndContextPair.context = null;
+  },
+};
+
+var pdfjsLib = require('../../../build/dist');
+
+// Relative path of the PDF file.
+var pdfURL = '../../helloworld/helloworld.pdf';
+
+// Read the PDF file into a typed array so PDF.js can load it.
+var rawData = new Uint8Array(fs.readFileSync(pdfURL));
+
+// Load the PDF file.
+pdfjsLib.getDocument(rawData).then(function (pdfDocument) {
+  console.log('# PDF document loaded.');
+
+  // Get the first page.
+  pdfDocument.getPage(1).then(function (page) {
+    // Render the page on a Node canvas with 100% scale.
+    var viewport = page.getViewport(1.0);
+    var canvasFactory = new NodeCanvasFactory();
+    var canvasAndContextPair = canvasFactory.create(viewport.width, viewport.height);
+    var renderContext = {
+      canvasContext: canvasAndContextPair.context,
+      viewport: viewport,
+      canvasFactory: canvasFactory
+    };
+
+    page.render(renderContext).then(function () {
+      // Convert the canvas to an image buffer.
+      image = canvasAndContextPair.canvas.toBuffer();
+      fs.writeFile('output.png', image, function (error) {
+        if (error) {
+          console.error('Error: ' + error);
+        } else {
+          console.log('Finished converting first page of PDF file to a PNG image.');
+        }
+      });
+    });
+  });
+}).catch(function(reason) {
+  console.log(reason);
+});


### PR DESCRIPTION
Fix-up of #8122 (improved commit message and instructions/comments, replaced tabs and removed trailing whitespace).