### PR TITLE
Improve the error handling when loading of built-in CMap files fail (PR 8064 follow-up)

### DIFF
--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -954,7 +954,7 @@ var CMapFactory = (function CMapFactoryClosure() {
       return Promise.resolve(new IdentityCMap(true, 2));
     }
     if (BUILT_IN_CMAPS.indexOf(name) === -1) {
-      return Promise.reject(new Error('Unknown cMap name: ' + name));
+      return Promise.reject(new Error('Unknown CMap name: ' + name));
     }
     assert(fetchBuiltInCMap, 'Built-in CMap parameters are not provided.');
 

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -90,8 +90,10 @@ var DOMCMapReaderFactory = (function DOMCMapReaderFactoryClosure() {
           request.responseType = 'arraybuffer';
         }
         request.onreadystatechange = function () {
-          if (request.readyState === XMLHttpRequest.DONE &&
-              (request.status === 200 || request.status === 0)) {
+          if (request.readyState !== XMLHttpRequest.DONE) {
+            return;
+          }
+          if (request.status === 200 || request.status === 0) {
             var data;
             if (this.isCompressed && request.response) {
               data = new Uint8Array(request.response);
@@ -106,10 +108,10 @@ var DOMCMapReaderFactory = (function DOMCMapReaderFactoryClosure() {
               });
               return;
             }
-            reject(new Error('Unable to load ' +
-                             (this.isCompressed ? 'binary ' : '') +
-                             'CMap at: ' + url));
           }
+          reject(new Error('Unable to load ' +
+                           (this.isCompressed ? 'binary ' : '') +
+                           'CMap at: ' + url));
         }.bind(this);
 
         request.send(null);

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -269,5 +269,45 @@ describe('cmap', function() {
       done.fail(reason);
     });
   });
+
+  it('attempts to load a non-existent built-in CMap', function(done) {
+    var cmapPromise = CMapFactory.create({
+      encoding: Name.get('null'),
+      fetchBuiltInCMap: fetchBuiltInCMap,
+      useCMap: null,
+    });
+    cmapPromise.then(function () {
+      done.fail('No CMap should be loaded');
+    }, function (reason) {
+      expect(reason instanceof Error).toEqual(true);
+      expect(reason.message).toEqual('Unknown CMap name: null');
+      done();
+    });
+  });
+
+  it('attempts to load a built-in CMap without the necessary API parameters',
+      function(done) {
+    function tmpFetchBuiltInCMap(name) {
+      var CMapReaderFactory = isNodeJS() ?
+        new NodeCMapReaderFactory({ }) : new DOMCMapReaderFactory({ });
+      return CMapReaderFactory.fetch({
+        name: name,
+      });
+    }
+
+    var cmapPromise = CMapFactory.create({
+      encoding: Name.get('Adobe-Japan1-1'),
+      fetchBuiltInCMap: tmpFetchBuiltInCMap,
+      useCMap: null,
+    });
+    cmapPromise.then(function () {
+      done.fail('No CMap should be loaded');
+    }, function (reason) {
+      expect(reason instanceof Error).toEqual(true);
+      expect(reason.message).toEqual(
+        'Unable to load CMap at: nullAdobe-Japan1-1');
+      done();
+    });
+  });
 });
 }));


### PR DESCRIPTION
I happened to notice that the error handling wasn't that great, which I missed previously since there were no unit-tests for failure to load built-in CMap files.
Hence this patch, which improves the error handling *and* adds tests.

*Marginally easier reviewing with https://github.com/mozilla/pdf.js/pull/8205/files?w=1*