### PR TITLE
Split pdfjschildbootstrap.js to avoid sync IPC

### DIFF
--- a/extensions/firefox/content/PdfJs.jsm
+++ b/extensions/firefox/content/PdfJs.jsm
@@ -173,9 +173,9 @@ var PdfJs = {
 
   updateRegistration: function updateRegistration() {
     if (this.enabled) {
-      this._ensureRegistered();
+      this.ensureRegistered();
     } else {
-      this._ensureUnregistered();
+      this.ensureUnregistered();
     }
   },
 
@@ -188,7 +188,7 @@ var PdfJs = {
       Services.obs.removeObserver(this, TOPIC_PLUGIN_INFO_UPDATED);
       this._initialized = false;
     }
-    this._ensureUnregistered();
+    this.ensureUnregistered();
   },
 
   _migrate: function migrate() {
@@ -307,7 +307,7 @@ var PdfJs = {
     return !enabledPluginFound;
   },
 
-  _ensureRegistered: function _ensureRegistered() {
+  ensureRegistered: function ensureRegistered() {
     if (this._registered) {
       return;
     }
@@ -318,7 +318,7 @@ var PdfJs = {
     this._registered = true;
   },
 
-  _ensureUnregistered: function _ensureUnregistered() {
+  ensureUnregistered: function ensureUnregistered() {
     if (!this._registered) {
       return;
     }

--- a/extensions/firefox/content/pdfjschildbootstrap-enabled.js
+++ b/extensions/firefox/content/pdfjschildbootstrap-enabled.js
@@ -27,5 +27,5 @@ Components.utils.import("resource://pdf.js/PdfJs.jsm");
 
 if (Services.appinfo.processType === Services.appinfo.PROCESS_TYPE_CONTENT) {
   // register various pdfjs factories that hook us into content loading.
-  PdfJs.updateRegistration();
+  PdfJs.ensureRegistered();
 }

--- a/extensions/firefox/content/pdfjschildbootstrap-enabled.js
+++ b/extensions/firefox/content/pdfjschildbootstrap-enabled.js
@@ -12,16 +12,20 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-/* globals Components, PdfjsContentUtils */
+/* globals Components, PdfJs, Services */
 
 "use strict";
 
 /*
- * pdfjschildbootstrap.js loads into the content process to take care of
- * initializing our built-in version of pdfjs when running remote.
+ * pdfjschildbootstrap-enabled.js loads into the content process to
+ * take care of initializing our built-in version of pdfjs when
+ * running remote. It will only be run when PdfJs.enable is true.
  */
 
-Components.utils.import("resource://pdf.js/PdfjsContentUtils.jsm");
+Components.utils.import("resource://gre/modules/Services.jsm");
+Components.utils.import("resource://pdf.js/PdfJs.jsm");
 
-// init content utils shim pdfjs will use to access privileged apis.
-PdfjsContentUtils.init();
+if (Services.appinfo.processType === Services.appinfo.PROCESS_TYPE_CONTENT) {
+  // register various pdfjs factories that hook us into content loading.
+  PdfJs.updateRegistration();
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -821,6 +821,8 @@ gulp.task('mozcentral-pre', ['buildnumber', 'locale'], function () {
         .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR)),
     gulp.src(FIREFOX_CONTENT_DIR + 'pdfjschildbootstrap.js')
         .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR)),
+    gulp.src(FIREFOX_CONTENT_DIR + 'pdfjschildbootstrap-enabled.js')
+        .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR)),
     gulp.src(FIREFOX_EXTENSION_DIR + 'chrome-mozcentral.manifest')
         .pipe(rename('chrome.manifest'))
         .pipe(gulp.dest(MOZCENTRAL_EXTENSION_DIR)),


### PR DESCRIPTION
See the commit messages for a more detailed explanation.

In terms of local testing, I only ran the linter but it doesn't seem like this should really affect the addon.