### PR TITLE
ios: Patch cancelAnimationFrame whenever fakeRequestAnimationFrame is used

### DIFF
--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -643,8 +643,13 @@ PDFJS.compatibilityChecked = true;
 
 // Support: IE<10, Android<4.0, iOS
 (function checkRequestAnimationFrame() {
-  function fakeRequestAnimationFrame(callback) {
-    window.setTimeout(callback, 20);
+  function installFakeAnimationFrameFunctions() {
+    window.requestAnimationFrame = function (callback) {
+      return window.setTimeout(callback, 20);
+    };
+    window.cancelAnimationFrame = function (timeoutID) {
+      window.clearTimeout(timeoutID);
+    };
   }
 
   if (!hasDOM) {
@@ -652,7 +657,7 @@ PDFJS.compatibilityChecked = true;
   }
   if (isIOS) {
     // requestAnimationFrame on iOS is broken, replacing with fake one.
-    window.requestAnimationFrame = fakeRequestAnimationFrame;
+    installFakeAnimationFrameFunctions();
     return;
   }
   if ('requestAnimationFrame' in window) {
@@ -660,8 +665,10 @@ PDFJS.compatibilityChecked = true;
   }
   window.requestAnimationFrame =
     window.mozRequestAnimationFrame ||
-    window.webkitRequestAnimationFrame ||
-    fakeRequestAnimationFrame;
+    window.webkitRequestAnimationFrame;
+  if (!('requestAnimationFrame' in window)) {
+    installFakeAnimationFrameFunctions();
+  }
 })();
 
 // Support: Android, iOS


### PR DESCRIPTION
The existing implementation of fakeRequestAnimationFrame
did not return a timer ID, so the frame could not be cancelled
if you wanted to cancel it. But if you do want to cancel it,
it needs to be cancelled through clearTimeout instead of
cancelAnimationFrame, because the timer IDs are different.

ex, without the patch this wouldn't work in iOS:
```js
var frameId = requestAnimationFrame(function() { console.log("called"); });
// do some work
if(!stillNeedsToAnimate) { cancelAnimationFrame(frameId); }
```