### PR TITLE
Lazily load NetUtil.jsm in PdfStreamConverter.jsm.

### DIFF
--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -33,7 +33,9 @@ const MAX_STRING_PREF_LENGTH = 128;
 
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource://gre/modules/NetUtil.jsm");
+
+XPCOMUtils.defineLazyModuleGetter(this, "NetUtil",
+  "resource://gre/modules/NetUtil.jsm");
 
 XPCOMUtils.defineLazyModuleGetter(this, "NetworkManager",
   "resource://pdf.js/PdfJsNetwork.jsm");


### PR DESCRIPTION
This is one step towards not loading NetUtil.jsm at startup in a clean profile.

I ran gulp lint, and tested that Firefox passes the pdf.js tests locally when this is applied.