### PR TITLE
Disable the `NativeImageDecoder` in the `node/pdf2svg.js` example (issue 7901)

### DIFF
--- a/examples/node/pdf2svg.js
+++ b/examples/node/pdf2svg.js
@@ -44,7 +44,10 @@ function getFileNameFromPath(path) {
 
 // Will be using promises to load document, pages and misc data instead of
 // callback.
-pdfjsLib.getDocument(data).then(function (doc) {
+pdfjsLib.getDocument({
+  data: data,
+  disableNativeImageDecoder: true,
+}).then(function (doc) {
   var numPages = doc.numPages;
   console.log('# Document Loaded');
   console.log('Number of Pages: ' + numPages);


### PR DESCRIPTION
It doesn't really make sense to attempt to utilize the `NativeImageDecoder` in Node, since there's no native image support available, hence building on PR #8035 we can easily disable it in the example.

Fixes #7901.