### PR TITLE
Stub out Firefox addon Telemetry wrapper

### DIFF
--- a/extensions/firefox/content/PdfJsTelemetry-addon.jsm
+++ b/extensions/firefox/content/PdfJsTelemetry-addon.jsm
@@ -19,70 +19,27 @@
 
 this.EXPORTED_SYMBOLS = ["PdfJsTelemetry"];
 
-const Cu = Components.utils;
-Cu.import("resource://gre/modules/Services.jsm");
-
-const ADDON_ID = "uriloader@pdf.js";
-
-var Telemetry = Services.telemetry;
-var registerAddonHistogram = Telemetry.registerAddonHistogram;
-
-registerAddonHistogram(ADDON_ID, "PDF_VIEWER_USED", Telemetry.HISTOGRAM_BOOLEAN, 1, 2, 3);
-registerAddonHistogram(ADDON_ID, "PDF_VIEWER_FALLBACK_SHOWN", Telemetry.HISTOGRAM_BOOLEAN, 1, 2, 3);
-registerAddonHistogram(ADDON_ID, "PDF_VIEWER_DOCUMENT_VERSION", Telemetry.HISTOGRAM_LINEAR, 1, 10, 11);
-registerAddonHistogram(ADDON_ID, "PDF_VIEWER_DOCUMENT_GENERATOR", Telemetry.HISTOGRAM_LINEAR, 1, 25, 26);
-registerAddonHistogram(ADDON_ID, "PDF_VIEWER_DOCUMENT_SIZE_KB", Telemetry.HISTOGRAM_EXPONENTIAL, 2, 64 * 1024, 20);
-registerAddonHistogram(ADDON_ID, "PDF_VIEWER_EMBED", Telemetry.HISTOGRAM_BOOLEAN, 1, 2, 3);
-registerAddonHistogram(ADDON_ID, "PDF_VIEWER_FONT_TYPES", Telemetry.HISTOGRAM_LINEAR, 1, 19, 20);
-registerAddonHistogram(ADDON_ID, "PDF_VIEWER_FORM", Telemetry.HISTOGRAM_BOOLEAN, 1, 2, 3);
-registerAddonHistogram(ADDON_ID, "PDF_VIEWER_PRINT", Telemetry.HISTOGRAM_BOOLEAN, 1, 2, 3);
-registerAddonHistogram(ADDON_ID, "PDF_VIEWER_STREAM_TYPES", Telemetry.HISTOGRAM_LINEAR, 1, 19, 20);
-registerAddonHistogram(ADDON_ID, "PDF_VIEWER_TIME_TO_VIEW_MS", Telemetry.HISTOGRAM_EXPONENTIAL, 1, 10000, 50);
-
-
 this.PdfJsTelemetry = {
   onViewerIsUsed() {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_USED");
-    histogram.add(true);
   },
   onFallback() {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_FALLBACK_SHOWN");
-    histogram.add(true);
   },
   onDocumentSize(size) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_DOCUMENT_SIZE_KB");
-    histogram.add(size / 1024);
   },
   onDocumentVersion(versionId) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_DOCUMENT_VERSION");
-    histogram.add(versionId);
   },
   onDocumentGenerator(generatorId) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_DOCUMENT_GENERATOR");
-    histogram.add(generatorId);
   },
   onEmbed(isObject) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_EMBED");
-    histogram.add(isObject);
   },
   onFontType(fontTypeId) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_FONT_TYPES");
-    histogram.add(fontTypeId);
   },
   onForm(isAcroform) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_FORM");
-    histogram.add(isAcroform);
   },
   onPrint() {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_PRINT");
-    histogram.add(true);
   },
   onStreamType(streamTypeId) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_STREAM_TYPES");
-    histogram.add(streamTypeId);
   },
   onTimeToView(ms) {
-    let histogram = Telemetry.getAddonHistogram(ADDON_ID, "PDF_VIEWER_TIME_TO_VIEW_MS");
-    histogram.add(ms);
   }
 };


### PR DESCRIPTION
We are planning to remove the addon histogram APIs from Firefox
Telemetry in [bug 1353295](https://bugzilla.mozilla.org/show_bug.cgi?id=1353295).

pdf.js is one of 3 projects that ever used them.
The easy solution here seems to just stub out all calls that use addon histograms, that should keep things working just as before.

linting passes fine locally.
I had trouble getting the tests to run due to `grunt makeref` running into md5 mismatches.