### PR TITLE
Actually skip pages included in the `skipPages` array when running tests, rather than creating empty 1x1 canvases (issue 8241)

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -446,18 +446,9 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
 
       if (task.skipPages && task.skipPages.indexOf(task.pageNum) >= 0) {
         this._log(' Skipping page ' + task.pageNum + '/' +
-          task.pdfDoc.numPages + '... ');
-
-        // Empty the canvas
-        this.canvas.width = 1;
-        this.canvas.height = 1;
-        ctx = this.canvas.getContext('2d', {alpha: false});
-        ctx.save();
-        ctx.fillStyle = 'white';
-        ctx.fillRect(0, 0, 1, 1);
-        ctx.restore();
-
-        this._snapshot(task, '');
+                  task.pdfDoc.numPages + '...\n');
+        task.pageNum++;
+        this._nextPage(task);
         return;
       }
 


### PR DESCRIPTION
Considering how extremely simple this patch turned out to be, I'm almost worried that I completely misunderstood why the current code looks like it does...

Fixes #8241.