### PR TITLE
Cleanup PdfJsTelemetry addon stub

### DIFF
--- a/extensions/firefox/content/PdfJsTelemetry-addon.jsm
+++ b/extensions/firefox/content/PdfJsTelemetry-addon.jsm
@@ -12,8 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint max-len: ["error", 120] */
-/* globals Components, Services */
 
 "use strict";
 

--- a/extensions/firefox/content/PdfJsTelemetry-stub.jsm
+++ b/extensions/firefox/content/PdfJsTelemetry-stub.jsm
@@ -1,0 +1,43 @@
+/* Copyright 2013 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+this.EXPORTED_SYMBOLS = ["PdfJsTelemetry"];
+
+this.PdfJsTelemetry = {
+  onViewerIsUsed() {
+  },
+  onFallback() {
+  },
+  onDocumentSize(size) {
+  },
+  onDocumentVersion(versionId) {
+  },
+  onDocumentGenerator(generatorId) {
+  },
+  onEmbed(isObject) {
+  },
+  onFontType(fontTypeId) {
+  },
+  onForm(isAcroform) {
+  },
+  onPrint() {
+  },
+  onStreamType(streamTypeId) {
+  },
+  onTimeToView(ms) {
+  }
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -714,7 +714,7 @@ gulp.task('firefox-pre', ['buildnumber', 'locale'], function () {
     gulp.src(FIREFOX_CONTENT_DIR + 'PdfJs-stub.jsm')
         .pipe(rename('PdfJs.jsm'))
         .pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR)),
-    gulp.src(FIREFOX_CONTENT_DIR + 'PdfJsTelemetry-addon.jsm')
+    gulp.src(FIREFOX_CONTENT_DIR + 'PdfJsTelemetry-stub.jsm')
         .pipe(rename('PdfJsTelemetry.jsm'))
         .pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR)),
     gulp.src(FIREFOX_EXTENSION_DIR + '*.png')


### PR DESCRIPTION
This is a follow-up to #8239, renaming the PdfJsTelemetry-addon.jsm file and removing left-overs.