### PR TITLE
Enable the `prefer-promise-reject-errors` ESLint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -74,6 +74,7 @@
     "no-unused-labels": "error",
     "no-useless-call": "error",
     "no-useless-concat": "error",
+    "prefer-promise-reject-errors": "error",
     "wrap-iife": ["error", "any"],
     "yoda": ["error", "never", {
       "exceptRange": true,

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -843,7 +843,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           operatorList.addOp(fn, pattern.getIR());
           return Promise.resolve();
         }
-        return Promise.reject('Unknown PatternType: ' + typeNum);
+        return Promise.reject(new Error('Unknown PatternType: ' + typeNum));
       }
       // TODO shall we fail here?
       operatorList.addOp(fn, args);


### PR DESCRIPTION
See http://eslint.org/docs/rules/prefer-promise-reject-errors, note that this is similar to the already used  `no-throw-literal` rule.