### PR TITLE
Enable running a subset of the API unit-tests on Travis

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -67,7 +67,12 @@ if (typeof PDFJSDev !== 'undefined' &&
     typeof requirejs !== 'undefined' && requirejs.load;
   fakeWorkerFilesLoader = useRequireEnsure ? (function (callback) {
     require.ensure([], function () {
-      var worker = require('./pdf.worker.js');
+      var worker;
+      if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('LIB')) {
+        worker = require('../pdf.worker.js');
+      } else {
+        worker = require('./pdf.worker.js');
+      }
       callback(worker.WorkerMessageHandler);
     });
   }) : dynamicLoaderSupported ? (function (callback) {

--- a/test/unit/clitests.json
+++ b/test/unit/clitests.json
@@ -2,6 +2,7 @@
   "spec_dir": "build/lib/test/unit",
   "spec_files": [
     "annotation_spec.js",
+    "api_spec.js",
     "bidi_spec.js",
     "cff_parser_spec.js",
     "cmap_spec.js",

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -15,6 +15,14 @@
 
 import { CMapCompressionType } from '../../src/shared/util';
 
+class NodeFileReaderFactory {
+  static fetch(params) {
+    var fs = require('fs');
+    var file = fs.readFileSync(params.path);
+    return new Uint8Array(file);
+  }
+}
+
 class NodeCMapReaderFactory {
   constructor({ baseUrl = null, isCompressed = false, }) {
     this.baseUrl = baseUrl;
@@ -47,5 +55,6 @@ class NodeCMapReaderFactory {
 }
 
 export {
+  NodeFileReaderFactory,
   NodeCMapReaderFactory,
 };


### PR DESCRIPTION
Notably, this patch skips all canvas rendering tests in Node.js.

Marginally smaller diff with https://github.com/mozilla/pdf.js/pull/8258/files?w=1.