### PR TITLE
Fix worker resolution on using minified version

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1097,7 +1097,7 @@ var PDFWorker = (function PDFWorkerClosure() {
     if (typeof PDFJSDev !== 'undefined' &&
         PDFJSDev.test('PRODUCTION && !(MOZCENTRAL || FIREFOX)') &&
         pdfjsFilePath) {
-      return pdfjsFilePath.replace(/\.js$/i, '.worker.js');
+      return pdfjsFilePath.replace(/(\.(?:min\.)?js)$/i, '.worker$1');
     }
     error('No PDFJS.workerSrc specified');
   }


### PR DESCRIPTION
- When the minified version is used the resolver of the worker can not find it properly and throws 404 error.
- The problem was that:
  - It was getting the current name of the file.
  - It was replacing **.js** by **.worker.js**
- When it was loading the unminified version it was working fine because:
  - *pdf.js - .js + .worker.js*  = **pdf.worker.js**
- When it was loading the minified version it didtn't work because:
  - *pdf.min.js - .js + .worker.js* = **pdf.min.worker.js**
  - **pdf.min.worker.js** doesn't exist the real file name is **pdf.worker.min.js**