### PR TITLE
Normalize blend mode names.

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -217,6 +217,50 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     }
   };
 
+  // Convert PDF blend mode names to HTML5 blend mode names.
+  function normalizeBlendMode(value) {
+    if (!isName(value)) {
+      return 'source-over';
+    }
+    switch (value.name) {
+      case 'Normal':
+      case 'Compatible':
+        return 'source-over';
+      case 'Multiply':
+        return 'multiply';
+      case 'Screen':
+        return 'screen';
+      case 'Overlay':
+        return 'overlay';
+      case 'Darken':
+        return 'darken';
+      case 'Lighten':
+        return 'lighten';
+      case 'ColorDodge':
+        return 'color-dodge';
+      case 'ColorBurn':
+        return 'color-burn';
+      case 'HardLight':
+        return 'hard-light';
+      case 'SoftLight':
+        return 'soft-light';
+      case 'Difference':
+        return 'difference';
+      case 'Exclusion':
+        return 'exclusion';
+      case 'Hue':
+        return 'hue';
+      case 'Saturation':
+        return 'saturation';
+      case 'Color':
+        return 'color';
+      case 'Luminosity':
+        return 'luminosity';
+    }
+    warn('Unsupported blend mode: ' + value.name);
+    return 'source-over';
+  }
+
   var deferred = Promise.resolve();
 
   var TILING_PATTERN = 1, SHADING_PATTERN = 2;
@@ -606,7 +650,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
             });
             break;
           case 'BM':
-            gStateObj.push([key, value]);
+            gStateObj.push([key, normalizeBlendMode(value)]);
             break;
           case 'SMask':
             if (isName(value, 'None')) {

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -950,20 +950,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
             this.ctx.globalAlpha = state[1];
             break;
           case 'BM':
-            if (value && value.name && (value.name !== 'Normal')) {
-              var mode = value.name.replace(/([A-Z])/g,
-                function(c) {
-                  return '-' + c.toLowerCase();
-                }
-              ).substring(1);
-              this.ctx.globalCompositeOperation = mode;
-              if (this.ctx.globalCompositeOperation !== mode) {
-                warn('globalCompositeOperation "' + mode +
-                     '" is not supported');
-              }
-            } else {
-              this.ctx.globalCompositeOperation = 'source-over';
-            }
+            this.ctx.globalCompositeOperation = value;
             break;
           case 'SMask':
             if (this.current.activeSMask) {
@@ -1010,7 +997,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       copyCtxState(currentCtx, groupCtx);
       this.ctx = groupCtx;
       this.setGState([
-        ['BM', 'Normal'],
+        ['BM', 'source-over'],
         ['ca', 1],
         ['CA', 1]
       ]);
@@ -1885,7 +1872,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       copyCtxState(currentCtx, groupCtx);
       this.ctx = groupCtx;
       this.setGState([
-        ['BM', 'Normal'],
+        ['BM', 'source-over'],
         ['ca', 1],
         ['CA', 1]
       ]);

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -21,6 +21,7 @@
 !issue5874.pdf
 !issue5808.pdf
 !issue6204.pdf
+!issue6652.pdf
 !issue6782.pdf
 !issue6901.pdf
 !issue6961.pdf

--- a/test/pdfs/issue6652.pdf
+++ b/test/pdfs/issue6652.pdf
@@ -1,0 +1,78 @@
+%PDF-1.7
+1 0 obj
+<<
+/Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/MediaBox [ 0 0 100 100 ]
+/Count 1
+/Kids [ 3 0 R ]
+>>
+endobj
+3 0 obj
+<<
+/Type /Page
+/Parent 2 0 R
+/Contents 4 0 R
+/Resources <<
+/ExtGState <<
+/GS1 5 0 R
+/GS2 6 0 R
+>>
+>>
+>>
+endobj
+4 0 obj
+<<
+/Length 58
+>>
+stream
+/GS1 gs
+10 10 40 40 re
+f
+/GS2 gs
+1 1 1 rg
+20 20 40 40 re
+f
+endstream
+
+endobj
+5 0 obj
+<<
+/Type /ExtGState
+/BM /Multiply
+>>
+endobj
+6 0 obj
+<<
+/Type /ExtGState
+/BM /Compatible
+>>
+endobj
+xref
+0 1
+0000000000 65535 f
+1 1
+0000000009 00000 n
+2 1
+0000000058 00000 n
+3 1
+0000000143 00000 n
+4 1
+0000000262 00000 n
+5 1
+0000000371 00000 n
+6 1
+0000000423 00000 n
+trailer
+<<
+/Size 6
+/Root 1 0 R
+>>
+startxref
+477
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1899,6 +1899,13 @@
        "link": false,
        "type": "eq"
     },
+    {  "id": "issue6652",
+       "file": "pdfs/issue6652.pdf",
+       "md5": "1c8e2953f84623bc773eb720c87a9331",
+       "rounds": 1,
+       "link": false,
+       "type": "eq"
+    },
     {  "id": "issue5801",
        "file": "pdfs/issue5801.pdf",
        "md5": "e9548650ad40e13e00d2a486bbc2bb1b",


### PR DESCRIPTION
Fixes #6652
I ran into this issue myself this weekend. This also gets rid of a regex in a potentially hot path.