### PR TITLE
Correctly detect if `requestAnimationFrame` is supported in `compatibility.js` (issue 8272)

### DIFF
--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -663,12 +663,12 @@ PDFJS.compatibilityChecked = true;
   if ('requestAnimationFrame' in window) {
     return;
   }
-  window.requestAnimationFrame =
-    window.mozRequestAnimationFrame ||
-    window.webkitRequestAnimationFrame;
-  if (!('requestAnimationFrame' in window)) {
-    installFakeAnimationFrameFunctions();
+  window.requestAnimationFrame = window.mozRequestAnimationFrame ||
+                                 window.webkitRequestAnimationFrame;
+  if (window.requestAnimationFrame) {
+    return;
   }
+  installFakeAnimationFrameFunctions();
 })();
 
 // Support: Android, iOS


### PR DESCRIPTION
This is a regression from PR #8222.

Fixes #8272.