### PR TITLE
Rename PdfJsTelemetry-addon.jsm to PdfJsTelemetry-stub.jsm

### DIFF
--- a/extensions/firefox/content/PdfJsTelemetry-stub.jsm
+++ b/extensions/firefox/content/PdfJsTelemetry-stub.jsm
@@ -12,8 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint max-len: ["error", 120] */
-/* globals Components, Services */
 
 "use strict";
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -714,7 +714,7 @@ gulp.task('firefox-pre', ['buildnumber', 'locale'], function () {
     gulp.src(FIREFOX_CONTENT_DIR + 'PdfJs-stub.jsm')
         .pipe(rename('PdfJs.jsm'))
         .pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR)),
-    gulp.src(FIREFOX_CONTENT_DIR + 'PdfJsTelemetry-addon.jsm')
+    gulp.src(FIREFOX_CONTENT_DIR + 'PdfJsTelemetry-stub.jsm')
         .pipe(rename('PdfJsTelemetry.jsm'))
         .pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR)),
     gulp.src(FIREFOX_EXTENSION_DIR + '*.png')


### PR DESCRIPTION
And remove unused linting comments.

*Please note:* This is a redo of PR #8254, obviously keeping the author information (and squashing the commits into one, since a separate commit for the ESLint clean-up seemed excessive).