### PR TITLE
v1.8.188

### DIFF
--- a/pdfjs.config
+++ b/pdfjs.config
@@ -1,6 +1,6 @@
 {
-  "betaVersion": "1.8.170",
-  "stableVersion": "1.7.225",
+  "betaVersion": "1.8.188",
+  "stableVersion": "1.8.170",
   "baseVersion": "d842c9c6b040e726e74a25e9dae28eefa340efd8",
   "versionPrefix": "1.8."
 }


### PR DESCRIPTION
Due to regression in #8222

#8273 Correctly detect if `requestAnimationFrame` is supported in `compatibility.js` (issue 8272)