### PR TITLE
Moves Uint32ArrayView and hasCanvasTypedArrays into compatibility.js.

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -36,7 +36,6 @@ var IDENTITY_MATRIX = sharedUtil.IDENTITY_MATRIX;
 var ImageKind = sharedUtil.ImageKind;
 var OPS = sharedUtil.OPS;
 var TextRenderingMode = sharedUtil.TextRenderingMode;
-var Uint32ArrayView = sharedUtil.Uint32ArrayView;
 var Util = sharedUtil.Util;
 var assert = sharedUtil.assert;
 var info = sharedUtil.info;
@@ -49,7 +48,6 @@ var warn = sharedUtil.warn;
 var TilingPattern = displayPatternHelper.TilingPattern;
 var getShadingPatternFromIR = displayPatternHelper.getShadingPatternFromIR;
 var WebGLUtils = displayWebGL.WebGLUtils;
-var hasCanvasTypedArrays = displayDOMUtils.hasCanvasTypedArrays;
 
 // <canvas> contexts store most of the state we need natively.
 // However, PDF needs a bit more state, which we store here.
@@ -67,12 +65,6 @@ var COMPILE_TYPE3_GLYPHS = true;
 var MAX_SIZE_TO_COMPILE = 1000;
 
 var FULL_CHUNK_HEIGHT = 16;
-
-var HasCanvasTypedArraysCached = {
-  get value() {
-    return shadow(HasCanvasTypedArraysCached, 'value', hasCanvasTypedArrays());
-  }
-};
 
 var IsLittleEndianCached = {
   get value() {
@@ -510,13 +502,11 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     if (imgData.kind === ImageKind.GRAYSCALE_1BPP) {
       // Grayscale, 1 bit per pixel (i.e. black-and-white).
       var srcLength = src.byteLength;
-      var dest32 = HasCanvasTypedArraysCached.value ?
-        new Uint32Array(dest.buffer) : new Uint32ArrayView(dest);
+      var dest32 = new Uint32Array(dest.buffer, 0, dest.byteLength >> 2);
       var dest32DataLength = dest32.length;
       var fullSrcDiff = (width + 7) >> 3;
       var white = 0xFFFFFFFF;
-      var black = (IsLittleEndianCached.value ||
-                   !HasCanvasTypedArraysCached.value) ? 0xFF000000 : 0x000000FF;
+      var black = IsLittleEndianCached.value ? 0xFF000000 : 0x000000FF;
       for (i = 0; i < totalChunks; i++) {
         thisChunkHeight =
           (i < fullChunks) ? FULL_CHUNK_HEIGHT : partialChunkHeight;

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -189,22 +189,6 @@ var RenderingCancelledException = (function RenderingCancelledException() {
   return RenderingCancelledException;
 })();
 
-var hasCanvasTypedArrays;
-if (typeof PDFJSDev === 'undefined' ||
-    !PDFJSDev.test('FIREFOX || MOZCENTRAL || CHROME')) {
-  hasCanvasTypedArrays = function hasCanvasTypedArrays() {
-    var canvas = document.createElement('canvas');
-    canvas.width = canvas.height = 1;
-    var ctx = canvas.getContext('2d');
-    var imageData = ctx.createImageData(1, 1);
-    return (typeof imageData.data.buffer !== 'undefined');
-  };
-} else {
-  hasCanvasTypedArrays = function () {
-    return true;
-  };
-}
-
 var LinkTarget = {
   NONE: 0, // Default value.
   SELF: 1,
@@ -354,7 +338,6 @@ exports.isValidUrl = isValidUrl;
 exports.getFilenameFromUrl = getFilenameFromUrl;
 exports.LinkTarget = LinkTarget;
 exports.RenderingCancelledException = RenderingCancelledException;
-exports.hasCanvasTypedArrays = hasCanvasTypedArrays;
 exports.getDefaultSetting = getDefaultSetting;
 exports.DEFAULT_LINK_REL = DEFAULT_LINK_REL;
 exports.DOMCanvasFactory = DOMCanvasFactory;

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -296,13 +296,7 @@
   PDFJS.PDFDataRangeTransport = displayAPI.PDFDataRangeTransport;
   PDFJS.PDFWorker = displayAPI.PDFWorker;
 
-  Object.defineProperty(PDFJS, 'hasCanvasTypedArrays', {
-    configurable: true,
-    get: function PDFJS_hasCanvasTypedArrays() {
-      var value = displayDOMUtils.hasCanvasTypedArrays();
-      return sharedUtil.shadow(PDFJS, 'hasCanvasTypedArrays', value);
-    }
-  });
+  PDFJS.hasCanvasTypedArrays = true; // compatibility.js ensures this invariant
   PDFJS.CustomStyle = displayDOMUtils.CustomStyle;
   PDFJS.LinkTarget = LinkTarget;
   PDFJS.addLinkAttributes = displayDOMUtils.addLinkAttributes;

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -618,10 +618,10 @@ function readUint32(data, offset) {
 // Lazy test the endianness of the platform
 // NOTE: This will be 'true' for simulated TypedArrays
 function isLittleEndian() {
-  var buffer8 = new Uint8Array(2);
+  var buffer8 = new Uint8Array(4);
   buffer8[0] = 1;
-  var buffer16 = new Uint16Array(buffer8.buffer);
-  return (buffer16[0] === 1);
+  var view32 = new Uint32Array(buffer8.buffer, 0, 1);
+  return (view32[0] === 1);
 }
 
 // Checks if it's possible to eval JS expressions.
@@ -632,50 +632,6 @@ function isEvalSupported() {
   } catch (e) {
     return false;
   }
-}
-
-if (typeof PDFJSDev === 'undefined' ||
-    !PDFJSDev.test('FIREFOX || MOZCENTRAL || CHROME')) {
-  var Uint32ArrayView = (function Uint32ArrayViewClosure() {
-    function Uint32ArrayView(buffer, length) {
-      this.buffer = buffer;
-      this.byteLength = buffer.length;
-      this.length = length === undefined ? (this.byteLength >> 2) : length;
-      ensureUint32ArrayViewProps(this.length);
-    }
-    Uint32ArrayView.prototype = Object.create(null);
-
-    var uint32ArrayViewSetters = 0;
-    function createUint32ArrayProp(index) {
-      return {
-        get: function () {
-          var buffer = this.buffer, offset = index << 2;
-          return (buffer[offset] | (buffer[offset + 1] << 8) |
-            (buffer[offset + 2] << 16) | (buffer[offset + 3] << 24)) >>> 0;
-        },
-        set: function (value) {
-          var buffer = this.buffer, offset = index << 2;
-          buffer[offset] = value & 255;
-          buffer[offset + 1] = (value >> 8) & 255;
-          buffer[offset + 2] = (value >> 16) & 255;
-          buffer[offset + 3] = (value >>> 24) & 255;
-        }
-      };
-    }
-
-    function ensureUint32ArrayViewProps(length) {
-      while (uint32ArrayViewSetters < length) {
-        Object.defineProperty(Uint32ArrayView.prototype,
-          uint32ArrayViewSetters,
-          createUint32ArrayProp(uint32ArrayViewSetters));
-        uint32ArrayViewSetters++;
-      }
-    }
-
-    return Uint32ArrayView;
-  })();
-
-  exports.Uint32ArrayView = Uint32ArrayView;
 }
 
 var IDENTITY_MATRIX = [1, 0, 0, 1, 0, 0];

--- a/test/unit/murmurhash3_spec.js
+++ b/test/unit/murmurhash3_spec.js
@@ -53,7 +53,7 @@ describe('MurmurHash3_64', function() {
   });
   it('correctly generates a hash from a Uint32Array', function() {
     var hash = new MurmurHash3_64();
-    hash.update(new Uint32Array(sourceCharCodes));
+    hash.update(new Uint32Array(new Uint8Array(sourceCharCodes).buffer));
     expect(hash.hexdigest()).toEqual(hexDigestExpected);
   });
 


### PR DESCRIPTION
Following up on https://github.com/mozilla/pdf.js/pull/8155#discussion_r106904617 comment:

>  want to remove this construct: let's add inherited from TypedArray three-args constructor for Uint32Array and use new Uint32Array(dest.buffer, 0, dest.buffer.byteLength >> 2) here. We need to add byteLength and buffer properties for window.CanvasPixelArray though. Hopefully we can rid of HasCanvasTypedArraysCached stuff by doing that.