### PR TITLE
Allow to convert (some of) ES6 code to ES5.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -112,7 +112,9 @@ function createWebpackConfig(defines, output) {
       loaders: [
         {
           loader: 'babel-loader',
+          exclude: /src\/core\/(glyphlist|unicode)/, // babel is too slow
           options: {
+            presets: bundleDefines.PDFJS_NEXT ? undefined : ['es2015'],
             plugins: ['transform-es2015-modules-commonjs']
           }
         },
@@ -936,9 +938,11 @@ gulp.task('jsdoc', function (done) {
 
 gulp.task('lib', ['buildnumber'], function () {
   function preprocess(content) {
+    var noPreset = /\/\*\s*no-babel-preset\s*\*\//.test(content);
     content = preprocessor2.preprocessPDFJSCode(ctx, content);
     content = babel.transform(content, {
       sourceType: 'module',
+      presets: noPreset ? undefined : ['es2015'],
       plugins: ['transform-es2015-modules-commonjs'],
     }).code;
     var removeCjsSrc =

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "babel-core": "^6.23.1",
     "babel-loader": "^6.4.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+    "babel-preset-es2015": "^6.24.1",
     "escodegen": "^1.8.0",
     "eslint": "^3.11.1",
     "gulp": "^3.9.1",

--- a/src/core/glyphlist.js
+++ b/src/core/glyphlist.js
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* no-babel-preset */
 
 'use strict';
 

--- a/src/core/unicode.js
+++ b/src/core/unicode.js
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* no-babel-preset */
 
 'use strict';
 


### PR DESCRIPTION
Currently webpack and lib publishing does not convert ES6 code to the legacy ECMAScript. This will fix it.

glyphlist and unicode are too complex for babel -- ignoring them for now. We can keep them as commonjs modules