### PR TITLE
Firefox extension: remove unused preference cleanup from `bootstrap.js`

### DIFF
--- a/extensions/firefox/bootstrap.js
+++ b/extensions/firefox/bootstrap.js
@@ -184,8 +184,6 @@ function shutdown(aData, aReason) {
 }
 
 function install(aData, aReason) {
-  // TODO remove after some time -- cleanup of unused preferences
-  Services.prefs.clearUserPref(EXT_PREFIX + ".database");
 }
 
 function uninstall(aData, aReason) {


### PR DESCRIPTION
The comment for the removal has been added three years ago, so we can safely remove this now.