### PR TITLE
Ensure that `PDFThumbnailView.draw` is able to handle `RenderingCancelledException` correctly (PR 8157 follow-up)

### DIFF
--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -14,6 +14,7 @@
  */
 
 import { getOutputScale, mozL10n } from './ui_utils';
+import { RenderingCancelledException } from './pdfjs';
 import { RenderingStates } from './pdf_rendering_queue';
 
 var THUMBNAIL_WIDTH = 98; // px
@@ -288,8 +289,11 @@ var PDFThumbnailView = (function PDFThumbnailViewClosure() {
         if (renderTask === self.renderTask) {
           self.renderTask = null;
         }
-        if (error === 'cancelled') {
-          rejectRenderPromise(error);
+
+        if (((typeof PDFJSDev === 'undefined' ||
+              !PDFJSDev.test('PDFJS_NEXT')) && error === 'cancelled') ||
+            error instanceof RenderingCancelledException) {
+          resolveRenderPromise(undefined);
           return;
         }
 


### PR DESCRIPTION
In PR #8157, I embarrassingly enough forgot to change `pdf_thumbnail_view.js` to match the changes made to `pdf_page_view.js`; see [pdf_page_view.js#L426-L431](https://github.com/mozilla/pdf.js/blob/27c3c33eec4e08a90637b7a932699a9f8669dd22/web/pdf_page_view.js#L426-L431).