### PR TITLE
Convert the password prompt to ES6 syntax

### DIFF
--- a/web/password_prompt.js
+++ b/web/password_prompt.js
@@ -60,7 +60,6 @@ class PasswordPrompt {
 
   open() {
     OverlayManager.open(this.overlayName).then(() => {
-      this.input.type = 'password';
       this.input.focus();
 
       var promptString = mozL10n.get('password_label', null,
@@ -78,7 +77,6 @@ class PasswordPrompt {
   close() {
     OverlayManager.close(this.overlayName).then(() => {
       this.input.value = '';
-      this.input.type = '';
     });
   }
 

--- a/web/password_prompt.js
+++ b/web/password_prompt.js
@@ -30,15 +30,11 @@ import { PasswordResponses } from './pdfjs';
  *                                              entry.
  */
 
-/**
- * @class
- */
-var PasswordPrompt = (function PasswordPromptClosure() {
+class PasswordPrompt {
   /**
-   * @constructs PasswordPrompt
    * @param {PasswordPromptOptions} options
    */
-  function PasswordPrompt(options) {
+  constructor(options) {
     this.overlayName = options.overlayName;
     this.container = options.container;
     this.label = options.label;
@@ -52,58 +48,53 @@ var PasswordPrompt = (function PasswordPromptClosure() {
     // Attach the event listeners.
     this.submitButton.addEventListener('click', this.verify.bind(this));
     this.cancelButton.addEventListener('click', this.close.bind(this));
-    this.input.addEventListener('keydown', function (e) {
+    this.input.addEventListener('keydown', (e) => {
       if (e.keyCode === 13) { // Enter key
         this.verify();
       }
-    }.bind(this));
+    });
 
     OverlayManager.register(this.overlayName, this.container,
                             this.close.bind(this), true);
   }
 
-  PasswordPrompt.prototype = {
-    open: function PasswordPrompt_open() {
-      OverlayManager.open(this.overlayName).then(function () {
-        this.input.type = 'password';
-        this.input.focus();
+  open() {
+    OverlayManager.open(this.overlayName).then(() => {
+      this.input.type = 'password';
+      this.input.focus();
 
-        var promptString = mozL10n.get('password_label', null,
-          'Enter the password to open this PDF file.');
+      var promptString = mozL10n.get('password_label', null,
+        'Enter the password to open this PDF file.');
 
-        if (this.reason === PasswordResponses.INCORRECT_PASSWORD) {
-          promptString = mozL10n.get('password_invalid', null,
-            'Invalid password. Please try again.');
-        }
-
-        this.label.textContent = promptString;
-      }.bind(this));
-    },
-
-    close: function PasswordPrompt_close() {
-      OverlayManager.close(this.overlayName).then(function () {
-        this.input.value = '';
-        this.input.type = '';
-      }.bind(this));
-    },
-
-    verify: function PasswordPrompt_verify() {
-      var password = this.input.value;
-      if (password && password.length > 0) {
-        this.close();
-        return this.updateCallback(password);
+      if (this.reason === PasswordResponses.INCORRECT_PASSWORD) {
+        promptString = mozL10n.get('password_invalid', null,
+          'Invalid password. Please try again.');
       }
-    },
 
-    setUpdateCallback:
-        function PasswordPrompt_setUpdateCallback(updateCallback, reason) {
-      this.updateCallback = updateCallback;
-      this.reason = reason;
+      this.label.textContent = promptString;
+    });
+  }
+
+  close() {
+    OverlayManager.close(this.overlayName).then(() => {
+      this.input.value = '';
+      this.input.type = '';
+    });
+  }
+
+  verify() {
+    var password = this.input.value;
+    if (password && password.length > 0) {
+      this.close();
+      return this.updateCallback(password);
     }
-  };
+  }
 
-  return PasswordPrompt;
-})();
+  setUpdateCallback(updateCallback, reason) {
+    this.updateCallback = updateCallback;
+    this.reason = reason;
+  }
+}
 
 export {
   PasswordPrompt,

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -307,8 +307,7 @@ See https://github.com/adobe-type-tools/cmap-resources
               <p id="passwordText" data-l10n-id="password_label">Enter the password to open this PDF file:</p>
             </div>
             <div class="row">
-              <!-- The type="password" attribute is set via script, to prevent warnings in Firefox for all http:// documents. -->
-              <input id="password" class="toolbarField">
+              <input type="password" id="password" class="toolbarField">
             </div>
             <div class="buttonRow">
               <button id="passwordCancel" class="overlayButton"><span data-l10n-id="password_cancel">Cancel</span></button>


### PR DESCRIPTION
Moreover, remove the password prompt input type hack since it is no longer functional.

You can use http://async5.org/moz/passwordOU.pdf (password: 123456) to test this.

*Easier review with https://github.com/mozilla/pdf.js/pull/8293/files?w=1.*