### PR TITLE
Convert the files in the `/src/display` folder to ES6 modules

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -13,30 +13,13 @@
  * limitations under the License.
  */
 
-'use strict';
-
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs/display/annotation_layer', ['exports', 'pdfjs/shared/util',
-      'pdfjs/display/dom_utils'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../shared/util.js'), require('./dom_utils.js'));
-  } else {
-    factory((root.pdfjsDisplayAnnotationLayer = {}), root.pdfjsSharedUtil,
-      root.pdfjsDisplayDOMUtils);
-  }
-}(this, function (exports, sharedUtil, displayDOMUtils) {
-
-var AnnotationBorderStyleType = sharedUtil.AnnotationBorderStyleType;
-var AnnotationType = sharedUtil.AnnotationType;
-var stringToPDFString = sharedUtil.stringToPDFString;
-var Util = sharedUtil.Util;
-var addLinkAttributes = displayDOMUtils.addLinkAttributes;
-var LinkTarget = displayDOMUtils.LinkTarget;
-var getFilenameFromUrl = displayDOMUtils.getFilenameFromUrl;
-var warn = sharedUtil.warn;
-var CustomStyle = displayDOMUtils.CustomStyle;
-var getDefaultSetting = displayDOMUtils.getDefaultSetting;
+import {
+  addLinkAttributes, CustomStyle, getDefaultSetting, getFilenameFromUrl,
+  LinkTarget
+} from './dom_utils';
+import {
+  AnnotationBorderStyleType, AnnotationType, stringToPDFString, Util, warn
+} from '../shared/util';
 
 /**
  * @typedef {Object} AnnotationElementParameters
@@ -1209,5 +1192,6 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
   };
 })();
 
-exports.AnnotationLayer = AnnotationLayer;
-}));
+export {
+  AnnotationLayer,
+};

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -14,56 +14,20 @@
  */
 /* globals requirejs, __pdfjsdev_webpack__ */
 
-'use strict';
-
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs/display/api', ['exports', 'pdfjs/shared/util',
-      'pdfjs/display/font_loader', 'pdfjs/display/canvas',
-      'pdfjs/display/metadata', 'pdfjs/display/dom_utils',
-      'require'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../shared/util.js'), require('./font_loader.js'),
-      require('./canvas.js'), require('./metadata.js'),
-      require('./dom_utils.js'));
-  } else {
-    factory((root.pdfjsDisplayAPI = {}), root.pdfjsSharedUtil,
-      root.pdfjsDisplayFontLoader, root.pdfjsDisplayCanvas,
-      root.pdfjsDisplayMetadata, root.pdfjsDisplayDOMUtils);
-  }
-}(this, function (exports, sharedUtil, displayFontLoader, displayCanvas,
-                  displayMetadata, displayDOMUtils, amdRequire) {
-
-var InvalidPDFException = sharedUtil.InvalidPDFException;
-var MessageHandler = sharedUtil.MessageHandler;
-var MissingPDFException = sharedUtil.MissingPDFException;
-var PageViewport = sharedUtil.PageViewport;
-var PasswordException = sharedUtil.PasswordException;
-var StatTimer = sharedUtil.StatTimer;
-var UnexpectedResponseException = sharedUtil.UnexpectedResponseException;
-var UnknownErrorException = sharedUtil.UnknownErrorException;
-var Util = sharedUtil.Util;
-var createPromiseCapability = sharedUtil.createPromiseCapability;
-var error = sharedUtil.error;
-var deprecated = sharedUtil.deprecated;
-var getVerbosityLevel = sharedUtil.getVerbosityLevel;
-var info = sharedUtil.info;
-var isInt = sharedUtil.isInt;
-var isArray = sharedUtil.isArray;
-var isArrayBuffer = sharedUtil.isArrayBuffer;
-var isSameOrigin = sharedUtil.isSameOrigin;
-var loadJpegStream = sharedUtil.loadJpegStream;
-var stringToBytes = sharedUtil.stringToBytes;
-var globalScope = sharedUtil.globalScope;
-var warn = sharedUtil.warn;
-var FontFaceObject = displayFontLoader.FontFaceObject;
-var FontLoader = displayFontLoader.FontLoader;
-var CanvasGraphics = displayCanvas.CanvasGraphics;
-var Metadata = displayMetadata.Metadata;
-var RenderingCancelledException = displayDOMUtils.RenderingCancelledException;
-var getDefaultSetting = displayDOMUtils.getDefaultSetting;
-var DOMCanvasFactory = displayDOMUtils.DOMCanvasFactory;
-var DOMCMapReaderFactory = displayDOMUtils.DOMCMapReaderFactory;
+import {
+  createPromiseCapability, deprecated, error, getVerbosityLevel, globalScope,
+  info, InvalidPDFException, isArray, isArrayBuffer, isInt, isSameOrigin,
+  loadJpegStream, MessageHandler, MissingPDFException, PageViewport,
+  PasswordException, StatTimer, stringToBytes, UnexpectedResponseException,
+  UnknownErrorException, Util, warn
+} from '../shared/util';
+import {
+  DOMCanvasFactory, DOMCMapReaderFactory, getDefaultSetting,
+  RenderingCancelledException
+} from './dom_utils';
+import { FontFaceObject, FontLoader } from './font_loader';
+import { CanvasGraphics } from './canvas';
+import { Metadata } from './metadata';
 
 var DEFAULT_RANGE_CHUNK_SIZE = 65536; // 2^16 = 65536
 
@@ -1118,9 +1082,10 @@ var PDFWorker = (function PDFWorkerClosure() {
     // other files and resolves the promise. In production only the
     // pdf.worker.js file is needed.
     if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION')) {
-      if (typeof amdRequire === 'function') {
-        amdRequire(['pdfjs/core/network', 'pdfjs/core/worker'],
-            function (network, worker) {
+      if (typeof SystemJS === 'object') {
+        Promise.all([SystemJS.import('pdfjs/core/network'),
+                     SystemJS.import('pdfjs/core/worker')]).then((modules) => {
+          var worker = modules[1];
           WorkerMessageHandler = worker.WorkerMessageHandler;
           fakeWorkerFilesLoadedCapability.resolve(WorkerMessageHandler);
         });
@@ -1129,7 +1094,8 @@ var PDFWorker = (function PDFWorkerClosure() {
         WorkerMessageHandler = worker.WorkerMessageHandler;
         fakeWorkerFilesLoadedCapability.resolve(WorkerMessageHandler);
       } else {
-        throw new Error('AMD or CommonJS must be used to load fake worker.');
+        throw new Error(
+          'SystemJS or CommonJS must be used to load fake worker.');
       }
     } else if (PDFJSDev.test('SINGLE_FILE')) {
       var pdfjsCoreWorker = require('../core/worker.js');
@@ -2241,15 +2207,19 @@ var _UnsupportedManager = (function UnsupportedManagerClosure() {
   };
 })();
 
+var version, build;
 if (typeof PDFJSDev !== 'undefined') {
-  exports.version = PDFJSDev.eval('BUNDLE_VERSION');
-  exports.build = PDFJSDev.eval('BUNDLE_BUILD');
+  version = PDFJSDev.eval('BUNDLE_VERSION');
+  build = PDFJSDev.eval('BUNDLE_BUILD');
 }
 
-exports.getDocument = getDocument;
-exports.PDFDataRangeTransport = PDFDataRangeTransport;
-exports.PDFWorker = PDFWorker;
-exports.PDFDocumentProxy = PDFDocumentProxy;
-exports.PDFPageProxy = PDFPageProxy;
-exports._UnsupportedManager = _UnsupportedManager;
-}));
+export {
+  getDocument,
+  PDFDataRangeTransport,
+  PDFWorker,
+  PDFDocumentProxy,
+  PDFPageProxy,
+  _UnsupportedManager,
+  version,
+  build,
+};

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -13,41 +13,12 @@
  * limitations under the License.
  */
 
-'use strict';
-
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs/display/canvas', ['exports', 'pdfjs/shared/util',
-      'pdfjs/display/dom_utils', 'pdfjs/display/pattern_helper',
-      'pdfjs/display/webgl'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../shared/util.js'), require('./dom_utils.js'),
-      require('./pattern_helper.js'), require('./webgl.js'));
-  } else {
-    factory((root.pdfjsDisplayCanvas = {}), root.pdfjsSharedUtil,
-      root.pdfjsDisplayDOMUtils, root.pdfjsDisplayPatternHelper,
-      root.pdfjsDisplayWebGL);
-  }
-}(this, function (exports, sharedUtil, displayDOMUtils, displayPatternHelper,
-                  displayWebGL) {
-
-var FONT_IDENTITY_MATRIX = sharedUtil.FONT_IDENTITY_MATRIX;
-var IDENTITY_MATRIX = sharedUtil.IDENTITY_MATRIX;
-var ImageKind = sharedUtil.ImageKind;
-var OPS = sharedUtil.OPS;
-var TextRenderingMode = sharedUtil.TextRenderingMode;
-var Util = sharedUtil.Util;
-var assert = sharedUtil.assert;
-var info = sharedUtil.info;
-var isNum = sharedUtil.isNum;
-var isArray = sharedUtil.isArray;
-var isLittleEndian = sharedUtil.isLittleEndian;
-var error = sharedUtil.error;
-var shadow = sharedUtil.shadow;
-var warn = sharedUtil.warn;
-var TilingPattern = displayPatternHelper.TilingPattern;
-var getShadingPatternFromIR = displayPatternHelper.getShadingPatternFromIR;
-var WebGLUtils = displayWebGL.WebGLUtils;
+import {
+  assert, error, FONT_IDENTITY_MATRIX, IDENTITY_MATRIX, ImageKind, info,
+  isArray, isLittleEndian, isNum, OPS, shadow, TextRenderingMode, Util, warn
+} from '../shared/util';
+import { getShadingPatternFromIR, TilingPattern } from './pattern_helper';
+import { WebGLUtils } from './webgl';
 
 // <canvas> contexts store most of the state we need natively.
 // However, PDF needs a bit more state, which we store here.
@@ -2276,5 +2247,6 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
   return CanvasGraphics;
 })();
 
-exports.CanvasGraphics = CanvasGraphics;
-}));
+export {
+  CanvasGraphics,
+};

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -13,26 +13,10 @@
  * limitations under the License.
  */
 
-'use strict';
-
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs/display/dom_utils', ['exports', 'pdfjs/shared/util'],
-      factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../shared/util.js'));
-  } else {
-    factory((root.pdfjsDisplayDOMUtils = {}), root.pdfjsSharedUtil);
-  }
-}(this, function (exports, sharedUtil) {
-
-var assert = sharedUtil.assert;
-var removeNullCharacters = sharedUtil.removeNullCharacters;
-var warn = sharedUtil.warn;
-var deprecated = sharedUtil.deprecated;
-var createValidAbsoluteUrl = sharedUtil.createValidAbsoluteUrl;
-var stringToBytes = sharedUtil.stringToBytes;
-var CMapCompressionType = sharedUtil.CMapCompressionType;
+import {
+  assert, CMapCompressionType, createValidAbsoluteUrl, deprecated, globalScope,
+  removeNullCharacters, stringToBytes, warn
+} from '../shared/util';
 
 var DEFAULT_LINK_REL = 'noopener noreferrer nofollow';
 
@@ -250,7 +234,7 @@ function getFilenameFromUrl(url) {
 function getDefaultSetting(id) {
   // The list of the settings and their default is maintained for backward
   // compatibility and shall not be extended or modified. See also global.js.
-  var globalSettings = sharedUtil.globalScope.PDFJS;
+  var globalSettings = globalScope.PDFJS;
   switch (id) {
     case 'pdfBug':
       return globalSettings ? globalSettings.pdfBug : false;
@@ -331,15 +315,16 @@ function isValidUrl(url, allowRelative) {
   return createValidAbsoluteUrl(url, baseUrl) !== null;
 }
 
-exports.CustomStyle = CustomStyle;
-exports.addLinkAttributes = addLinkAttributes;
-exports.isExternalLinkTargetSet = isExternalLinkTargetSet;
-exports.isValidUrl = isValidUrl;
-exports.getFilenameFromUrl = getFilenameFromUrl;
-exports.LinkTarget = LinkTarget;
-exports.RenderingCancelledException = RenderingCancelledException;
-exports.getDefaultSetting = getDefaultSetting;
-exports.DEFAULT_LINK_REL = DEFAULT_LINK_REL;
-exports.DOMCanvasFactory = DOMCanvasFactory;
-exports.DOMCMapReaderFactory = DOMCMapReaderFactory;
-}));
+export {
+  CustomStyle,
+  RenderingCancelledException,
+  addLinkAttributes,
+  isExternalLinkTargetSet,
+  isValidUrl,
+  getFilenameFromUrl,
+  LinkTarget,
+  getDefaultSetting,
+  DEFAULT_LINK_REL,
+  DOMCanvasFactory,
+  DOMCMapReaderFactory,
+};

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -13,24 +13,9 @@
  * limitations under the License.
  */
 
-'use strict';
-
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs/display/font_loader', ['exports', 'pdfjs/shared/util'],
-      factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../shared/util.js'));
-  } else {
-    factory((root.pdfjsDisplayFontLoader = {}), root.pdfjsSharedUtil);
-  }
-}(this, function (exports, sharedUtil) {
-
-var assert = sharedUtil.assert;
-var bytesToString = sharedUtil.bytesToString;
-var string32 = sharedUtil.string32;
-var shadow = sharedUtil.shadow;
-var warn = sharedUtil.warn;
+import {
+  assert, bytesToString, isEvalSupported, shadow, string32, warn
+} from '../shared/util';
 
 function FontLoader(docId) {
   this.docId = docId;
@@ -346,7 +331,7 @@ if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL || CHROME')) {
 
 var IsEvalSupportedCached = {
   get value() {
-    return shadow(this, 'value', sharedUtil.isEvalSupported());
+    return shadow(this, 'value', isEvalSupported());
   }
 };
 
@@ -451,6 +436,7 @@ var FontFaceObject = (function FontFaceObjectClosure() {
   return FontFaceObject;
 })();
 
-exports.FontFaceObject = FontFaceObject;
-exports.FontLoader = FontLoader;
-}));
+export {
+  FontFaceObject,
+  FontLoader,
+};

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -13,307 +13,296 @@
  * limitations under the License.
  */
 
-'use strict';
+import {
+  _UnsupportedManager, getDocument, PDFDataRangeTransport, PDFWorker
+} from './api';
+import {
+  addLinkAttributes, CustomStyle, DEFAULT_LINK_REL, getFilenameFromUrl,
+  isExternalLinkTargetSet, isValidUrl, LinkTarget
+} from './dom_utils';
+import {
+  createBlob, createObjectURL, createPromiseCapability, deprecated,
+  getVerbosityLevel, globalScope, InvalidPDFException, isLittleEndian,
+  MissingPDFException, OPS, PageViewport, PasswordException, PasswordResponses,
+  removeNullCharacters, setVerbosityLevel, shadow, UnexpectedResponseException,
+  UnknownErrorException, UNSUPPORTED_FEATURES, Util, VERBOSITY_LEVELS, warn
+} from '../shared/util';
+import { AnnotationLayer } from './annotation_layer';
+import { Metadata } from './metadata';
+import { renderTextLayer } from './text_layer';
+import { SVGGraphics } from './svg';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs/display/global', ['exports', 'pdfjs/shared/util',
-      'pdfjs/display/dom_utils', 'pdfjs/display/api',
-      'pdfjs/display/annotation_layer', 'pdfjs/display/text_layer',
-      'pdfjs/display/metadata', 'pdfjs/display/svg'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../shared/util.js'), require('./dom_utils.js'),
-      require('./api.js'), require('./annotation_layer.js'),
-      require('./text_layer.js'), require('./metadata.js'),
-      require('./svg.js'));
-  } else {
-    factory((root.pdfjsDisplayGlobal = {}), root.pdfjsSharedUtil,
-      root.pdfjsDisplayDOMUtils, root.pdfjsDisplayAPI,
-      root.pdfjsDisplayAnnotationLayer, root.pdfjsDisplayTextLayer,
-      root.pdfjsDisplayMetadata, root.pdfjsDisplaySVG);
+var isWorker = (typeof window === 'undefined');
+
+// The global PDFJS object is now deprecated and will not be supported in
+// the future. The members below are maintained for backward  compatibility
+// and shall not be extended or modified. If the global.js is included as
+// a module, we will create a global PDFJS object instance or use existing.
+if (!globalScope.PDFJS) {
+  globalScope.PDFJS = {};
+}
+var PDFJS = globalScope.PDFJS;
+
+if (typeof PDFJSDev !== 'undefined') {
+  PDFJS.version = PDFJSDev.eval('BUNDLE_VERSION');
+  PDFJS.build = PDFJSDev.eval('BUNDLE_BUILD');
+}
+
+PDFJS.pdfBug = false;
+
+if (PDFJS.verbosity !== undefined) {
+  setVerbosityLevel(PDFJS.verbosity);
+}
+delete PDFJS.verbosity;
+Object.defineProperty(PDFJS, 'verbosity', {
+  get: function () {
+    return getVerbosityLevel();
+  },
+  set: function (level) {
+    setVerbosityLevel(level);
+  },
+  enumerable: true,
+  configurable: true
+});
+
+PDFJS.VERBOSITY_LEVELS = VERBOSITY_LEVELS;
+PDFJS.OPS = OPS;
+PDFJS.UNSUPPORTED_FEATURES = UNSUPPORTED_FEATURES;
+PDFJS.isValidUrl = isValidUrl;
+PDFJS.shadow = shadow;
+PDFJS.createBlob = createBlob;
+PDFJS.createObjectURL = function PDFJS_createObjectURL(data, contentType) {
+  return createObjectURL(data, contentType, PDFJS.disableCreateObjectURL);
+};
+Object.defineProperty(PDFJS, 'isLittleEndian', {
+  configurable: true,
+  get: function PDFJS_isLittleEndian() {
+    return shadow(PDFJS, 'isLittleEndian', isLittleEndian());
   }
-}(this, function (exports, sharedUtil, displayDOMUtils, displayAPI,
-                  displayAnnotationLayer, displayTextLayer, displayMetadata,
-                  displaySVG) {
+});
+PDFJS.removeNullCharacters = removeNullCharacters;
+PDFJS.PasswordResponses = PasswordResponses;
+PDFJS.PasswordException = PasswordException;
+PDFJS.UnknownErrorException = UnknownErrorException;
+PDFJS.InvalidPDFException = InvalidPDFException;
+PDFJS.MissingPDFException = MissingPDFException;
+PDFJS.UnexpectedResponseException = UnexpectedResponseException;
+PDFJS.Util = Util;
+PDFJS.PageViewport = PageViewport;
+PDFJS.createPromiseCapability = createPromiseCapability;
 
-  var globalScope = sharedUtil.globalScope;
-  var deprecated = sharedUtil.deprecated;
-  var warn = sharedUtil.warn;
-  var LinkTarget = displayDOMUtils.LinkTarget;
-  var DEFAULT_LINK_REL = displayDOMUtils.DEFAULT_LINK_REL;
+/**
+ * The maximum allowed image size in total pixels e.g. width * height. Images
+ * above this value will not be drawn. Use -1 for no limit.
+ * @var {number}
+ */
+PDFJS.maxImageSize = (PDFJS.maxImageSize === undefined ?
+                      -1 : PDFJS.maxImageSize);
 
-  var isWorker = (typeof window === 'undefined');
+/**
+ * The url of where the predefined Adobe CMaps are located. Include trailing
+ * slash.
+ * @var {string}
+ */
+PDFJS.cMapUrl = (PDFJS.cMapUrl === undefined ? null : PDFJS.cMapUrl);
 
-  // The global PDFJS object is now deprecated and will not be supported in
-  // the future. The members below are maintained for backward  compatibility
-  // and shall not be extended or modified. If the global.js is included as
-  // a module, we will create a global PDFJS object instance or use existing.
-  if (!globalScope.PDFJS) {
-    globalScope.PDFJS = {};
-  }
-  var PDFJS = globalScope.PDFJS;
+/**
+ * Specifies if CMaps are binary packed.
+ * @var {boolean}
+ */
+PDFJS.cMapPacked = PDFJS.cMapPacked === undefined ? false : PDFJS.cMapPacked;
 
-  if (typeof PDFJSDev !== 'undefined') {
-    PDFJS.version = PDFJSDev.eval('BUNDLE_VERSION');
-    PDFJS.build = PDFJSDev.eval('BUNDLE_BUILD');
-  }
+/**
+ * By default fonts are converted to OpenType fonts and loaded via font face
+ * rules. If disabled, the font will be rendered using a built in font
+ * renderer that constructs the glyphs with primitive path commands.
+ * @var {boolean}
+ */
+PDFJS.disableFontFace = (PDFJS.disableFontFace === undefined ?
+                         false : PDFJS.disableFontFace);
 
-  PDFJS.pdfBug = false;
+/**
+ * Path for image resources, mainly for annotation icons. Include trailing
+ * slash.
+ * @var {string}
+ */
+PDFJS.imageResourcesPath = (PDFJS.imageResourcesPath === undefined ?
+                            '' : PDFJS.imageResourcesPath);
 
-  if (PDFJS.verbosity !== undefined) {
-    sharedUtil.setVerbosityLevel(PDFJS.verbosity);
-  }
-  delete PDFJS.verbosity;
-  Object.defineProperty(PDFJS, 'verbosity', {
+/**
+ * Disable the web worker and run all code on the main thread. This will
+ * happen automatically if the browser doesn't support workers or sending
+ * typed arrays to workers.
+ * @var {boolean}
+ */
+PDFJS.disableWorker = (PDFJS.disableWorker === undefined ?
+                       false : PDFJS.disableWorker);
+
+/**
+ * Path and filename of the worker file. Required when the worker is enabled
+ * in development mode. If unspecified in the production build, the worker
+ * will be loaded based on the location of the pdf.js file. It is recommended
+ * that the workerSrc is set in a custom application to prevent issues caused
+ * by third-party frameworks and libraries.
+ * @var {string}
+ */
+PDFJS.workerSrc = (PDFJS.workerSrc === undefined ? null : PDFJS.workerSrc);
+
+/**
+ * Defines global port for worker process. Overrides workerSrc and
+ * disableWorker setting.
+ */
+PDFJS.workerPort = (PDFJS.workerPort === undefined ? null : PDFJS.workerPort);
+
+/**
+ * Disable range request loading of PDF files. When enabled and if the server
+ * supports partial content requests then the PDF will be fetched in chunks.
+ * Enabled (false) by default.
+ * @var {boolean}
+ */
+PDFJS.disableRange = (PDFJS.disableRange === undefined ?
+                      false : PDFJS.disableRange);
+
+/**
+ * Disable streaming of PDF file data. By default PDF.js attempts to load PDF
+ * in chunks. This default behavior can be disabled.
+ * @var {boolean}
+ */
+PDFJS.disableStream = (PDFJS.disableStream === undefined ?
+                       false : PDFJS.disableStream);
+
+/**
+ * Disable pre-fetching of PDF file data. When range requests are enabled
+ * PDF.js will automatically keep fetching more data even if it isn't needed
+ * to display the current page. This default behavior can be disabled.
+ *
+ * NOTE: It is also necessary to disable streaming, see above,
+ *       in order for disabling of pre-fetching to work correctly.
+ * @var {boolean}
+ */
+PDFJS.disableAutoFetch = (PDFJS.disableAutoFetch === undefined ?
+                          false : PDFJS.disableAutoFetch);
+
+/**
+ * Enables special hooks for debugging PDF.js.
+ * @var {boolean}
+ */
+PDFJS.pdfBug = (PDFJS.pdfBug === undefined ? false : PDFJS.pdfBug);
+
+/**
+ * Enables transfer usage in postMessage for ArrayBuffers.
+ * @var {boolean}
+ */
+PDFJS.postMessageTransfers = (PDFJS.postMessageTransfers === undefined ?
+                              true : PDFJS.postMessageTransfers);
+
+/**
+ * Disables URL.createObjectURL usage.
+ * @var {boolean}
+ */
+PDFJS.disableCreateObjectURL = (PDFJS.disableCreateObjectURL === undefined ?
+                                false : PDFJS.disableCreateObjectURL);
+
+/**
+ * Disables WebGL usage.
+ * @var {boolean}
+ */
+PDFJS.disableWebGL = (PDFJS.disableWebGL === undefined ?
+                      true : PDFJS.disableWebGL);
+
+/**
+ * Specifies the |target| attribute for external links.
+ * The constants from PDFJS.LinkTarget should be used:
+ *  - NONE [default]
+ *  - SELF
+ *  - BLANK
+ *  - PARENT
+ *  - TOP
+ * @var {number}
+ */
+PDFJS.externalLinkTarget = (PDFJS.externalLinkTarget === undefined ?
+                            LinkTarget.NONE : PDFJS.externalLinkTarget);
+
+/**
+ * Specifies the |rel| attribute for external links. Defaults to stripping
+ * the referrer.
+ * @var {string}
+ */
+PDFJS.externalLinkRel = (PDFJS.externalLinkRel === undefined ?
+                         DEFAULT_LINK_REL : PDFJS.externalLinkRel);
+
+/**
+  * Determines if we can eval strings as JS. Primarily used to improve
+  * performance for font rendering.
+  * @var {boolean}
+  */
+PDFJS.isEvalSupported = (PDFJS.isEvalSupported === undefined ?
+                         true : PDFJS.isEvalSupported);
+
+/**
+ * Opt-in to backwards incompatible API changes. NOTE:
+ * If the `PDFJS_NEXT` build flag is set, it will override this setting.
+ * @var {boolean}
+ */
+PDFJS.pdfjsNext = (PDFJS.pdfjsNext === undefined) ? false : PDFJS.pdfjsNext;
+
+if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL')) {
+  var savedOpenExternalLinksInNewWindow = PDFJS.openExternalLinksInNewWindow;
+  delete PDFJS.openExternalLinksInNewWindow;
+  Object.defineProperty(PDFJS, 'openExternalLinksInNewWindow', {
     get: function () {
-      return sharedUtil.getVerbosityLevel();
+      return PDFJS.externalLinkTarget === LinkTarget.BLANK;
     },
-    set: function (level) {
-      sharedUtil.setVerbosityLevel(level);
+    set: function (value) {
+      if (value) {
+        deprecated('PDFJS.openExternalLinksInNewWindow, please use ' +
+          '"PDFJS.externalLinkTarget = PDFJS.LinkTarget.BLANK" instead.');
+      }
+      if (PDFJS.externalLinkTarget !== LinkTarget.NONE) {
+        warn('PDFJS.externalLinkTarget is already initialized');
+        return;
+      }
+      PDFJS.externalLinkTarget = value ? LinkTarget.BLANK : LinkTarget.NONE;
     },
     enumerable: true,
     configurable: true
   });
-
-  PDFJS.VERBOSITY_LEVELS = sharedUtil.VERBOSITY_LEVELS;
-  PDFJS.OPS = sharedUtil.OPS;
-  PDFJS.UNSUPPORTED_FEATURES = sharedUtil.UNSUPPORTED_FEATURES;
-  PDFJS.isValidUrl = displayDOMUtils.isValidUrl;
-  PDFJS.shadow = sharedUtil.shadow;
-  PDFJS.createBlob = sharedUtil.createBlob;
-  PDFJS.createObjectURL = function PDFJS_createObjectURL(data, contentType) {
-    return sharedUtil.createObjectURL(data, contentType,
-                                      PDFJS.disableCreateObjectURL);
-  };
-  Object.defineProperty(PDFJS, 'isLittleEndian', {
-    configurable: true,
-    get: function PDFJS_isLittleEndian() {
-      var value = sharedUtil.isLittleEndian();
-      return sharedUtil.shadow(PDFJS, 'isLittleEndian', value);
-    }
-  });
-  PDFJS.removeNullCharacters = sharedUtil.removeNullCharacters;
-  PDFJS.PasswordResponses = sharedUtil.PasswordResponses;
-  PDFJS.PasswordException = sharedUtil.PasswordException;
-  PDFJS.UnknownErrorException = sharedUtil.UnknownErrorException;
-  PDFJS.InvalidPDFException = sharedUtil.InvalidPDFException;
-  PDFJS.MissingPDFException = sharedUtil.MissingPDFException;
-  PDFJS.UnexpectedResponseException = sharedUtil.UnexpectedResponseException;
-  PDFJS.Util = sharedUtil.Util;
-  PDFJS.PageViewport = sharedUtil.PageViewport;
-  PDFJS.createPromiseCapability = sharedUtil.createPromiseCapability;
-
-  /**
-   * The maximum allowed image size in total pixels e.g. width * height. Images
-   * above this value will not be drawn. Use -1 for no limit.
-   * @var {number}
-   */
-  PDFJS.maxImageSize = (PDFJS.maxImageSize === undefined ?
-                        -1 : PDFJS.maxImageSize);
-
-  /**
-   * The url of where the predefined Adobe CMaps are located. Include trailing
-   * slash.
-   * @var {string}
-   */
-  PDFJS.cMapUrl = (PDFJS.cMapUrl === undefined ? null : PDFJS.cMapUrl);
-
-  /**
-   * Specifies if CMaps are binary packed.
-   * @var {boolean}
-   */
-  PDFJS.cMapPacked = PDFJS.cMapPacked === undefined ? false : PDFJS.cMapPacked;
-
-  /**
-   * By default fonts are converted to OpenType fonts and loaded via font face
-   * rules. If disabled, the font will be rendered using a built in font
-   * renderer that constructs the glyphs with primitive path commands.
-   * @var {boolean}
-   */
-  PDFJS.disableFontFace = (PDFJS.disableFontFace === undefined ?
-                           false : PDFJS.disableFontFace);
-
-  /**
-   * Path for image resources, mainly for annotation icons. Include trailing
-   * slash.
-   * @var {string}
-   */
-  PDFJS.imageResourcesPath = (PDFJS.imageResourcesPath === undefined ?
-                              '' : PDFJS.imageResourcesPath);
-
-  /**
-   * Disable the web worker and run all code on the main thread. This will
-   * happen automatically if the browser doesn't support workers or sending
-   * typed arrays to workers.
-   * @var {boolean}
-   */
-  PDFJS.disableWorker = (PDFJS.disableWorker === undefined ?
-                         false : PDFJS.disableWorker);
-
-  /**
-   * Path and filename of the worker file. Required when the worker is enabled
-   * in development mode. If unspecified in the production build, the worker
-   * will be loaded based on the location of the pdf.js file. It is recommended
-   * that the workerSrc is set in a custom application to prevent issues caused
-   * by third-party frameworks and libraries.
-   * @var {string}
-   */
-  PDFJS.workerSrc = (PDFJS.workerSrc === undefined ? null : PDFJS.workerSrc);
-
-  /**
-   * Defines global port for worker process. Overrides workerSrc and
-   * disableWorker setting.
-   */
-  PDFJS.workerPort = (PDFJS.workerPort === undefined ? null : PDFJS.workerPort);
-
-  /**
-   * Disable range request loading of PDF files. When enabled and if the server
-   * supports partial content requests then the PDF will be fetched in chunks.
-   * Enabled (false) by default.
-   * @var {boolean}
-   */
-  PDFJS.disableRange = (PDFJS.disableRange === undefined ?
-                        false : PDFJS.disableRange);
-
-  /**
-   * Disable streaming of PDF file data. By default PDF.js attempts to load PDF
-   * in chunks. This default behavior can be disabled.
-   * @var {boolean}
-   */
-  PDFJS.disableStream = (PDFJS.disableStream === undefined ?
-                         false : PDFJS.disableStream);
-
-  /**
-   * Disable pre-fetching of PDF file data. When range requests are enabled
-   * PDF.js will automatically keep fetching more data even if it isn't needed
-   * to display the current page. This default behavior can be disabled.
-   *
-   * NOTE: It is also necessary to disable streaming, see above,
-   *       in order for disabling of pre-fetching to work correctly.
-   * @var {boolean}
-   */
-  PDFJS.disableAutoFetch = (PDFJS.disableAutoFetch === undefined ?
-                            false : PDFJS.disableAutoFetch);
-
-  /**
-   * Enables special hooks for debugging PDF.js.
-   * @var {boolean}
-   */
-  PDFJS.pdfBug = (PDFJS.pdfBug === undefined ? false : PDFJS.pdfBug);
-
-  /**
-   * Enables transfer usage in postMessage for ArrayBuffers.
-   * @var {boolean}
-   */
-  PDFJS.postMessageTransfers = (PDFJS.postMessageTransfers === undefined ?
-                                true : PDFJS.postMessageTransfers);
-
-  /**
-   * Disables URL.createObjectURL usage.
-   * @var {boolean}
-   */
-  PDFJS.disableCreateObjectURL = (PDFJS.disableCreateObjectURL === undefined ?
-                                  false : PDFJS.disableCreateObjectURL);
-
-  /**
-   * Disables WebGL usage.
-   * @var {boolean}
-   */
-  PDFJS.disableWebGL = (PDFJS.disableWebGL === undefined ?
-                        true : PDFJS.disableWebGL);
-
-  /**
-   * Specifies the |target| attribute for external links.
-   * The constants from PDFJS.LinkTarget should be used:
-   *  - NONE [default]
-   *  - SELF
-   *  - BLANK
-   *  - PARENT
-   *  - TOP
-   * @var {number}
-   */
-  PDFJS.externalLinkTarget = (PDFJS.externalLinkTarget === undefined ?
-                              LinkTarget.NONE : PDFJS.externalLinkTarget);
-
-  /**
-   * Specifies the |rel| attribute for external links. Defaults to stripping
-   * the referrer.
-   * @var {string}
-   */
-  PDFJS.externalLinkRel = (PDFJS.externalLinkRel === undefined ?
-                           DEFAULT_LINK_REL : PDFJS.externalLinkRel);
-
-  /**
-    * Determines if we can eval strings as JS. Primarily used to improve
-    * performance for font rendering.
-    * @var {boolean}
-    */
-  PDFJS.isEvalSupported = (PDFJS.isEvalSupported === undefined ?
-                           true : PDFJS.isEvalSupported);
-
-  /**
-   * Opt-in to backwards incompatible API changes. NOTE:
-   * If the `PDFJS_NEXT` build flag is set, it will override this setting.
-   * @var {boolean}
-   */
-  PDFJS.pdfjsNext = (PDFJS.pdfjsNext === undefined) ? false : PDFJS.pdfjsNext;
-
-  if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL')) {
-    var savedOpenExternalLinksInNewWindow = PDFJS.openExternalLinksInNewWindow;
-    delete PDFJS.openExternalLinksInNewWindow;
-    Object.defineProperty(PDFJS, 'openExternalLinksInNewWindow', {
-      get: function () {
-        return PDFJS.externalLinkTarget === LinkTarget.BLANK;
-      },
-      set: function (value) {
-        if (value) {
-          deprecated('PDFJS.openExternalLinksInNewWindow, please use ' +
-            '"PDFJS.externalLinkTarget = PDFJS.LinkTarget.BLANK" instead.');
-        }
-        if (PDFJS.externalLinkTarget !== LinkTarget.NONE) {
-          warn('PDFJS.externalLinkTarget is already initialized');
-          return;
-        }
-        PDFJS.externalLinkTarget = value ? LinkTarget.BLANK : LinkTarget.NONE;
-      },
-      enumerable: true,
-      configurable: true
-    });
-    if (savedOpenExternalLinksInNewWindow) {
-      /**
-       * (Deprecated) Opens external links in a new window if enabled.
-       * The default behavior opens external links in the PDF.js window.
-       *
-       * NOTE: This property has been deprecated, please use
-       *       `PDFJS.externalLinkTarget = PDFJS.LinkTarget.BLANK` instead.
-       * @var {boolean}
-       */
-      PDFJS.openExternalLinksInNewWindow = savedOpenExternalLinksInNewWindow;
-    }
+  if (savedOpenExternalLinksInNewWindow) {
+    /**
+     * (Deprecated) Opens external links in a new window if enabled.
+     * The default behavior opens external links in the PDF.js window.
+     *
+     * NOTE: This property has been deprecated, please use
+     *       `PDFJS.externalLinkTarget = PDFJS.LinkTarget.BLANK` instead.
+     * @var {boolean}
+     */
+    PDFJS.openExternalLinksInNewWindow = savedOpenExternalLinksInNewWindow;
   }
+}
 
-  PDFJS.getDocument = displayAPI.getDocument;
-  PDFJS.PDFDataRangeTransport = displayAPI.PDFDataRangeTransport;
-  PDFJS.PDFWorker = displayAPI.PDFWorker;
+PDFJS.getDocument = getDocument;
+PDFJS.PDFDataRangeTransport = PDFDataRangeTransport;
+PDFJS.PDFWorker = PDFWorker;
 
-  PDFJS.hasCanvasTypedArrays = true; // compatibility.js ensures this invariant
-  PDFJS.CustomStyle = displayDOMUtils.CustomStyle;
-  PDFJS.LinkTarget = LinkTarget;
-  PDFJS.addLinkAttributes = displayDOMUtils.addLinkAttributes;
-  PDFJS.getFilenameFromUrl = displayDOMUtils.getFilenameFromUrl;
-  PDFJS.isExternalLinkTargetSet = displayDOMUtils.isExternalLinkTargetSet;
+PDFJS.hasCanvasTypedArrays = true; // compatibility.js ensures this invariant
+PDFJS.CustomStyle = CustomStyle;
+PDFJS.LinkTarget = LinkTarget;
+PDFJS.addLinkAttributes = addLinkAttributes;
+PDFJS.getFilenameFromUrl = getFilenameFromUrl;
+PDFJS.isExternalLinkTargetSet = isExternalLinkTargetSet;
 
-  PDFJS.AnnotationLayer = displayAnnotationLayer.AnnotationLayer;
+PDFJS.AnnotationLayer = AnnotationLayer;
 
-  PDFJS.renderTextLayer = displayTextLayer.renderTextLayer;
+PDFJS.renderTextLayer = renderTextLayer;
 
-  PDFJS.Metadata = displayMetadata.Metadata;
+PDFJS.Metadata = Metadata;
 
-  PDFJS.SVGGraphics = displaySVG.SVGGraphics;
+PDFJS.SVGGraphics = SVGGraphics;
 
-  PDFJS.UnsupportedManager = displayAPI._UnsupportedManager;
+PDFJS.UnsupportedManager = _UnsupportedManager;
 
-  exports.globalScope = globalScope;
-  exports.isWorker = isWorker;
-  exports.PDFJS = globalScope.PDFJS;
-}));
+export {
+  globalScope,
+  isWorker,
+  PDFJS,
+};

--- a/src/display/metadata.js
+++ b/src/display/metadata.js
@@ -13,95 +13,84 @@
  * limitations under the License.
  */
 
-'use strict';
+import { error } from '../shared/util';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs/display/metadata', ['exports', 'pdfjs/shared/util'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../shared/util.js'));
-  } else {
-    factory((root.pdfjsDisplayMetadata = {}), root.pdfjsSharedUtil);
-  }
-}(this, function (exports, sharedUtil) {
-
-var error = sharedUtil.error;
-
-  function fixMetadata(meta) {
-    return meta.replace(/>\\376\\377([^<]+)/g, function(all, codes) {
-      var bytes = codes.replace(/\\([0-3])([0-7])([0-7])/g,
-                                function(code, d1, d2, d3) {
-        return String.fromCharCode(d1 * 64 + d2 * 8 + d3 * 1);
-      });
-      var chars = '';
-      for (var i = 0; i < bytes.length; i += 2) {
-        var code = bytes.charCodeAt(i) * 256 + bytes.charCodeAt(i + 1);
-        chars += (code >= 32 && code < 127 && code !== 60 && code !== 62 &&
-          code !== 38) ? String.fromCharCode(code) :
-          '&#x' + (0x10000 + code).toString(16).substring(1) + ';';
-      }
-      return '>' + chars;
+function fixMetadata(meta) {
+  return meta.replace(/>\\376\\377([^<]+)/g, function(all, codes) {
+    var bytes = codes.replace(/\\([0-3])([0-7])([0-7])/g,
+                              function(code, d1, d2, d3) {
+      return String.fromCharCode(d1 * 64 + d2 * 8 + d3 * 1);
     });
+    var chars = '';
+    for (var i = 0; i < bytes.length; i += 2) {
+      var code = bytes.charCodeAt(i) * 256 + bytes.charCodeAt(i + 1);
+      chars += (code >= 32 && code < 127 && code !== 60 && code !== 62 &&
+        code !== 38) ? String.fromCharCode(code) :
+        '&#x' + (0x10000 + code).toString(16).substring(1) + ';';
+    }
+    return '>' + chars;
+  });
+}
+
+function Metadata(meta) {
+  if (typeof meta === 'string') {
+    // Ghostscript produces invalid metadata
+    meta = fixMetadata(meta);
+
+    var parser = new DOMParser();
+    meta = parser.parseFromString(meta, 'application/xml');
+  } else if (!(meta instanceof Document)) {
+    error('Metadata: Invalid metadata object');
   }
 
-  function Metadata(meta) {
-    if (typeof meta === 'string') {
-      // Ghostscript produces invalid metadata
-      meta = fixMetadata(meta);
+  this.metaDocument = meta;
+  this.metadata = Object.create(null);
+  this.parse();
+}
 
-      var parser = new DOMParser();
-      meta = parser.parseFromString(meta, 'application/xml');
-    } else if (!(meta instanceof Document)) {
-      error('Metadata: Invalid metadata object');
+Metadata.prototype = {
+  parse: function Metadata_parse() {
+    var doc = this.metaDocument;
+    var rdf = doc.documentElement;
+
+    if (rdf.nodeName.toLowerCase() !== 'rdf:rdf') { // Wrapped in <xmpmeta>
+      rdf = rdf.firstChild;
+      while (rdf && rdf.nodeName.toLowerCase() !== 'rdf:rdf') {
+        rdf = rdf.nextSibling;
+      }
     }
 
-    this.metaDocument = meta;
-    this.metadata = Object.create(null);
-    this.parse();
+    var nodeName = (rdf) ? rdf.nodeName.toLowerCase() : null;
+    if (!rdf || nodeName !== 'rdf:rdf' || !rdf.hasChildNodes()) {
+      return;
+    }
+
+    var children = rdf.childNodes, desc, entry, name, i, ii, length, iLength;
+    for (i = 0, length = children.length; i < length; i++) {
+      desc = children[i];
+      if (desc.nodeName.toLowerCase() !== 'rdf:description') {
+        continue;
+      }
+
+      for (ii = 0, iLength = desc.childNodes.length; ii < iLength; ii++) {
+        if (desc.childNodes[ii].nodeName.toLowerCase() !== '#text') {
+          entry = desc.childNodes[ii];
+          name = entry.nodeName.toLowerCase();
+          this.metadata[name] = entry.textContent.trim();
+        }
+      }
+    }
+  },
+
+  get: function Metadata_get(name) {
+    return this.metadata[name] || null;
+  },
+
+  has: function Metadata_has(name) {
+    return typeof this.metadata[name] !== 'undefined';
   }
+};
 
-  Metadata.prototype = {
-    parse: function Metadata_parse() {
-      var doc = this.metaDocument;
-      var rdf = doc.documentElement;
-
-      if (rdf.nodeName.toLowerCase() !== 'rdf:rdf') { // Wrapped in <xmpmeta>
-        rdf = rdf.firstChild;
-        while (rdf && rdf.nodeName.toLowerCase() !== 'rdf:rdf') {
-          rdf = rdf.nextSibling;
-        }
-      }
-
-      var nodeName = (rdf) ? rdf.nodeName.toLowerCase() : null;
-      if (!rdf || nodeName !== 'rdf:rdf' || !rdf.hasChildNodes()) {
-        return;
-      }
-
-      var children = rdf.childNodes, desc, entry, name, i, ii, length, iLength;
-      for (i = 0, length = children.length; i < length; i++) {
-        desc = children[i];
-        if (desc.nodeName.toLowerCase() !== 'rdf:description') {
-          continue;
-        }
-
-        for (ii = 0, iLength = desc.childNodes.length; ii < iLength; ii++) {
-          if (desc.childNodes[ii].nodeName.toLowerCase() !== '#text') {
-            entry = desc.childNodes[ii];
-            name = entry.nodeName.toLowerCase();
-            this.metadata[name] = entry.textContent.trim();
-          }
-        }
-      }
-    },
-
-    get: function Metadata_get(name) {
-      return this.metadata[name] || null;
-    },
-
-    has: function Metadata_has(name) {
-      return typeof this.metadata[name] !== 'undefined';
-    }
-  };
-
-exports.Metadata = Metadata;
-}));
+export {
+  Metadata,
+};

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -13,25 +13,8 @@
  * limitations under the License.
  */
 
-'use strict';
-
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs/display/pattern_helper', ['exports', 'pdfjs/shared/util',
-      'pdfjs/display/webgl'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../shared/util.js'), require('./webgl.js'));
-  } else {
-    factory((root.pdfjsDisplayPatternHelper = {}), root.pdfjsSharedUtil,
-      root.pdfjsDisplayWebGL);
-  }
-}(this, function (exports, sharedUtil, displayWebGL) {
-
-var Util = sharedUtil.Util;
-var info = sharedUtil.info;
-var isArray = sharedUtil.isArray;
-var error = sharedUtil.error;
-var WebGLUtils = displayWebGL.WebGLUtils;
+import { error, info, isArray, Util } from '../shared/util';
+import { WebGLUtils } from './webgl';
 
 var ShadingIRs = {};
 
@@ -448,6 +431,7 @@ var TilingPattern = (function TilingPatternClosure() {
   return TilingPattern;
 })();
 
-exports.getShadingPatternFromIR = getShadingPatternFromIR;
-exports.TilingPattern = TilingPattern;
-}));
+export {
+  getShadingPatternFromIR,
+  TilingPattern,
+};

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -13,28 +13,17 @@
  * limitations under the License.
  */
 
-'use strict';
+import {
+  createObjectURL, FONT_IDENTITY_MATRIX, IDENTITY_MATRIX, ImageKind, isArray,
+  isNum, OPS, Util, warn
+} from '../shared/util';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs/display/svg', ['exports', 'pdfjs/shared/util'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../shared/util.js'));
-  } else {
-    factory((root.pdfjsDisplaySVG = {}), root.pdfjsSharedUtil);
-  }
-}(this, function (exports, sharedUtil) {
+var SVGGraphics = function() {
+  throw new Error('Not implemented: SVGGraphics');
+};
+
 if (typeof PDFJSDev === 'undefined' ||
     PDFJSDev.test('GENERIC || SINGLE_FILE')) {
-var FONT_IDENTITY_MATRIX = sharedUtil.FONT_IDENTITY_MATRIX;
-var IDENTITY_MATRIX = sharedUtil.IDENTITY_MATRIX;
-var ImageKind = sharedUtil.ImageKind;
-var OPS = sharedUtil.OPS;
-var Util = sharedUtil.Util;
-var isNum = sharedUtil.isNum;
-var isArray = sharedUtil.isArray;
-var warn = sharedUtil.warn;
-var createObjectURL = sharedUtil.createObjectURL;
 
 var SVG_DEFAULTS = {
   fontStyle: 'normal',
@@ -293,7 +282,7 @@ var SVGExtraState = (function SVGExtraStateClosure() {
   return SVGExtraState;
 })();
 
-var SVGGraphics = (function SVGGraphicsClosure() {
+SVGGraphics = (function SVGGraphicsClosure() {
   function opListToTree(opList) {
     var opTree = [];
     var tmp = [];
@@ -1203,6 +1192,8 @@ var SVGGraphics = (function SVGGraphicsClosure() {
   return SVGGraphics;
 })();
 
-exports.SVGGraphics = SVGGraphics;
 }
-}));
+
+export {
+  SVGGraphics,
+};

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -13,24 +13,8 @@
  * limitations under the License.
  */
 
-'use strict';
-
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs/display/text_layer', ['exports', 'pdfjs/shared/util',
-      'pdfjs/display/dom_utils'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../shared/util.js'), require('./dom_utils.js'));
-  } else {
-    factory((root.pdfjsDisplayTextLayer = {}), root.pdfjsSharedUtil,
-      root.pdfjsDisplayDOMUtils);
-  }
-}(this, function (exports, sharedUtil, displayDOMUtils) {
-
-var Util = sharedUtil.Util;
-var createPromiseCapability = sharedUtil.createPromiseCapability;
-var CustomStyle = displayDOMUtils.CustomStyle;
-var getDefaultSetting = displayDOMUtils.getDefaultSetting;
+import { createPromiseCapability, Util } from '../shared/util';
+import { CustomStyle, getDefaultSetting } from './dom_utils';
 
 /**
  * Text layer render parameters.
@@ -639,5 +623,6 @@ var renderTextLayer = (function renderTextLayerClosure() {
   return renderTextLayer;
 })();
 
-exports.renderTextLayer = renderTextLayer;
-}));
+export {
+  renderTextLayer,
+};

--- a/src/display/webgl.js
+++ b/src/display/webgl.js
@@ -14,22 +14,8 @@
  */
 /* eslint-disable no-multi-str */
 
-'use strict';
-
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs/display/webgl', ['exports', 'pdfjs/shared/util',
-      'pdfjs/display/dom_utils'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../shared/util.js'), require('./dom_utils.js'));
-  } else {
-    factory((root.pdfjsDisplayWebGL = {}), root.pdfjsSharedUtil,
-      root.pdfjsDisplayDOMUtils);
-  }
-}(this, function (exports, sharedUtil, displayDOMUtils) {
-
-var shadow = sharedUtil.shadow;
-var getDefaultSetting = displayDOMUtils.getDefaultSetting;
+import { getDefaultSetting } from './dom_utils';
+import { shadow } from '../shared/util';
 
 var WebGLUtils = (function WebGLUtilsClosure() {
   function loadShader(gl, code, shaderType) {
@@ -450,5 +436,6 @@ var WebGLUtils = (function WebGLUtilsClosure() {
   };
 })();
 
-exports.WebGLUtils = WebGLUtils;
-}));
+export {
+  WebGLUtils,
+};

--- a/systemjs.config.js
+++ b/systemjs.config.js
@@ -47,7 +47,10 @@
     meta: {
       '*': {
         scriptLoad: false,
-        esModule: true
+        esModule: true,
+        babelOptions: {
+          es2015: false,
+        },
       }
     },
     map: {


### PR DESCRIPTION
Also disables ES2015 transpilation in development mode. *Edit:* This doesn't seem to improve the performance very much, but at least it cannot hurt.

---
As discussed on IRC, here's a PR that *only* converts the `/src/display` folder to ES6 modules, since it's currently infeasible to convert the rest of the `/src` code due to slowness of the SystemJS module loader.

*Easier reviewing with: https://github.com/mozilla/pdf.js/pull/8294/files?w=1.*