### PR TITLE
Convert the document properties to ES6 syntax

### DIFF
--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -21,20 +21,17 @@ import { OverlayManager } from './overlay_manager';
  * @typedef {Object} PDFDocumentPropertiesOptions
  * @property {string} overlayName - Name/identifier for the overlay.
  * @property {Object} fields - Names and elements of the overlay's fields.
+ * @property {HTMLDivElement} container - Div container for the overlay.
  * @property {HTMLButtonElement} closeButton - Button for closing the overlay.
  */
 
-/**
- * @class
- */
-var PDFDocumentProperties = (function PDFDocumentPropertiesClosure() {
+class PDFDocumentProperties {
   /**
-   * @constructs PDFDocumentProperties
    * @param {PDFDocumentPropertiesOptions} options
    */
-  function PDFDocumentProperties(options) {
-    this.fields = options.fields;
+  constructor(options) {
     this.overlayName = options.overlayName;
+    this.fields = options.fields;
     this.container = options.container;
 
     this.rawFileSize = 0;
@@ -51,176 +48,171 @@ var PDFDocumentProperties = (function PDFDocumentPropertiesClosure() {
                             this.close.bind(this));
   }
 
-  PDFDocumentProperties.prototype = {
-    /**
-     * Open the document properties overlay.
-     */
-    open: function PDFDocumentProperties_open() {
-      Promise.all([OverlayManager.open(this.overlayName),
-                   this._dataAvailableCapability.promise]).then(() => {
-        this._getProperties();
-      });
-    },
+  /**
+   * Open the document properties overlay.
+   */
+  open() {
+    Promise.all([OverlayManager.open(this.overlayName),
+                 this._dataAvailableCapability.promise]).then(() => {
+      this._getProperties();
+    });
+  }
 
-    /**
-     * Close the document properties overlay.
-     */
-    close: function PDFDocumentProperties_close() {
-      OverlayManager.close(this.overlayName);
-    },
+  /**
+   * Close the document properties overlay.
+   */
+  close() {
+    OverlayManager.close(this.overlayName);
+  }
 
-    /**
-     * Set the file size of the PDF document. This method is used to
-     * update the file size in the document properties overlay once it
-     * is known so we do not have to wait until the entire file is loaded.
-     *
-     * @param {number} fileSize - The file size of the PDF document.
-     */
-    setFileSize: function PDFDocumentProperties_setFileSize(fileSize) {
-      if (fileSize > 0) {
-        this.rawFileSize = fileSize;
-      }
-    },
-
-    /**
-     * Set a reference to the PDF document and the URL in order
-     * to populate the overlay fields with the document properties.
-     * Note that the overlay will contain no information if this method
-     * is not called.
-     *
-     * @param {Object} pdfDocument - A reference to the PDF document.
-     * @param {string} url - The URL of the document.
-     */
-    setDocumentAndUrl:
-        function PDFDocumentProperties_setDocumentAndUrl(pdfDocument, url) {
-      this.pdfDocument = pdfDocument;
-      this.url = url;
-      this._dataAvailableCapability.resolve();
-    },
-
-    /**
-     * @private
-     */
-    _getProperties: function PDFDocumentProperties_getProperties() {
-      if (!OverlayManager.active) {
-        // If the dialog was closed before dataAvailablePromise was resolved,
-        // don't bother updating the properties.
-        return;
-      }
-      // Get the file size (if it hasn't already been set).
-      this.pdfDocument.getDownloadInfo().then((data) => {
-        if (data.length === this.rawFileSize) {
-          return;
-        }
-        this.setFileSize(data.length);
-        this._updateUI(this.fields['fileSize'], this._parseFileSize());
-      });
-
-      // Get the document properties.
-      this.pdfDocument.getMetadata().then((data) => {
-        var content = {
-          'fileName': getPDFFileNameFromURL(this.url),
-          'fileSize': this._parseFileSize(),
-          'title': data.info.Title,
-          'author': data.info.Author,
-          'subject': data.info.Subject,
-          'keywords': data.info.Keywords,
-          'creationDate': this._parseDate(data.info.CreationDate),
-          'modificationDate': this._parseDate(data.info.ModDate),
-          'creator': data.info.Creator,
-          'producer': data.info.Producer,
-          'version': data.info.PDFFormatVersion,
-          'pageCount': this.pdfDocument.numPages
-        };
-
-        // Show the properties in the dialog.
-        for (var identifier in content) {
-          this._updateUI(this.fields[identifier], content[identifier]);
-        }
-      });
-    },
-
-    /**
-     * @private
-     */
-    _updateUI: function PDFDocumentProperties_updateUI(field, content) {
-      if (field && content !== undefined && content !== '') {
-        field.textContent = content;
-      }
-    },
-
-    /**
-     * @private
-     */
-    _parseFileSize: function PDFDocumentProperties_parseFileSize() {
-      var fileSize = this.rawFileSize, kb = fileSize / 1024;
-      if (!kb) {
-        return;
-      } else if (kb < 1024) {
-        return mozL10n.get('document_properties_kb', {
-          size_kb: (+kb.toPrecision(3)).toLocaleString(),
-          size_b: fileSize.toLocaleString()
-        }, '{{size_kb}} KB ({{size_b}} bytes)');
-      }
-      return mozL10n.get('document_properties_mb', {
-        size_mb: (+(kb / 1024).toPrecision(3)).toLocaleString(),
-        size_b: fileSize.toLocaleString()
-      }, '{{size_mb}} MB ({{size_b}} bytes)');
-    },
-
-    /**
-     * @private
-     */
-    _parseDate: function PDFDocumentProperties_parseDate(inputDate) {
-      // This is implemented according to the PDF specification, but note that
-      // Adobe Reader doesn't handle changing the date to universal time
-      // and doesn't use the user's time zone (they're effectively ignoring
-      // the HH' and mm' parts of the date string).
-      var dateToParse = inputDate;
-      if (dateToParse === undefined) {
-        return '';
-      }
-
-      // Remove the D: prefix if it is available.
-      if (dateToParse.substring(0, 2) === 'D:') {
-        dateToParse = dateToParse.substring(2);
-      }
-
-      // Get all elements from the PDF date string.
-      // JavaScript's Date object expects the month to be between
-      // 0 and 11 instead of 1 and 12, so we're correcting for this.
-      var year = parseInt(dateToParse.substring(0, 4), 10);
-      var month = parseInt(dateToParse.substring(4, 6), 10) - 1;
-      var day = parseInt(dateToParse.substring(6, 8), 10);
-      var hours = parseInt(dateToParse.substring(8, 10), 10);
-      var minutes = parseInt(dateToParse.substring(10, 12), 10);
-      var seconds = parseInt(dateToParse.substring(12, 14), 10);
-      var utRel = dateToParse.substring(14, 15);
-      var offsetHours = parseInt(dateToParse.substring(15, 17), 10);
-      var offsetMinutes = parseInt(dateToParse.substring(18, 20), 10);
-
-      // As per spec, utRel = 'Z' means equal to universal time.
-      // The other cases ('-' and '+') have to be handled here.
-      if (utRel === '-') {
-        hours += offsetHours;
-        minutes += offsetMinutes;
-      } else if (utRel === '+') {
-        hours -= offsetHours;
-        minutes -= offsetMinutes;
-      }
-
-      // Return the new date format from the user's locale.
-      var date = new Date(Date.UTC(year, month, day, hours, minutes, seconds));
-      var dateString = date.toLocaleDateString();
-      var timeString = date.toLocaleTimeString();
-      return mozL10n.get('document_properties_date_string',
-                         {date: dateString, time: timeString},
-                         '{{date}}, {{time}}');
+  /**
+   * Set the file size of the PDF document. This method is used to
+   * update the file size in the document properties overlay once it
+   * is known so we do not have to wait until the entire file is loaded.
+   *
+   * @param {number} fileSize - The file size of the PDF document.
+   */
+  setFileSize(fileSize) {
+    if (fileSize > 0) {
+      this.rawFileSize = fileSize;
     }
-  };
+  }
 
-  return PDFDocumentProperties;
-})();
+  /**
+   * Set a reference to the PDF document and the URL in order
+   * to populate the overlay fields with the document properties.
+   * Note that the overlay will contain no information if this method
+   * is not called.
+   *
+   * @param {Object} pdfDocument - A reference to the PDF document.
+   * @param {string} url - The URL of the document.
+   */
+  setDocumentAndUrl(pdfDocument, url) {
+    this.pdfDocument = pdfDocument;
+    this.url = url;
+    this._dataAvailableCapability.resolve();
+  }
+
+  /**
+   * @private
+   */
+  _getProperties() {
+    if (!OverlayManager.active) {
+      // If the dialog was closed before `_dataAvailableCapability` was
+      // resolved, don't bother updating the properties.
+      return;
+    }
+    // Get the file size (if it hasn't already been set).
+    this.pdfDocument.getDownloadInfo().then((data) => {
+      if (data.length === this.rawFileSize) {
+        return;
+      }
+      this.setFileSize(data.length);
+      this._updateUI(this.fields['fileSize'], this._parseFileSize());
+    });
+
+    // Get the document properties.
+    this.pdfDocument.getMetadata().then((data) => {
+      var content = {
+        'fileName': getPDFFileNameFromURL(this.url),
+        'fileSize': this._parseFileSize(),
+        'title': data.info.Title,
+        'author': data.info.Author,
+        'subject': data.info.Subject,
+        'keywords': data.info.Keywords,
+        'creationDate': this._parseDate(data.info.CreationDate),
+        'modificationDate': this._parseDate(data.info.ModDate),
+        'creator': data.info.Creator,
+        'producer': data.info.Producer,
+        'version': data.info.PDFFormatVersion,
+        'pageCount': this.pdfDocument.numPages
+      };
+
+      // Show the properties in the dialog.
+      for (var identifier in content) {
+        this._updateUI(this.fields[identifier], content[identifier]);
+      }
+    });
+  }
+
+  /**
+   * @private
+   */
+  _updateUI(field, content) {
+    if (field && content !== undefined && content !== '') {
+      field.textContent = content;
+    }
+  }
+
+  /**
+   * @private
+   */
+  _parseFileSize() {
+    var fileSize = this.rawFileSize, kb = fileSize / 1024;
+    if (!kb) {
+      return;
+    } else if (kb < 1024) {
+      return mozL10n.get('document_properties_kb', {
+        size_kb: (+kb.toPrecision(3)).toLocaleString(),
+        size_b: fileSize.toLocaleString()
+      }, '{{size_kb}} KB ({{size_b}} bytes)');
+    }
+    return mozL10n.get('document_properties_mb', {
+      size_mb: (+(kb / 1024).toPrecision(3)).toLocaleString(),
+      size_b: fileSize.toLocaleString()
+    }, '{{size_mb}} MB ({{size_b}} bytes)');
+  }
+
+  /**
+   * @private
+   */
+  _parseDate(inputDate) {
+    // This is implemented according to the PDF specification, but note that
+    // Adobe Reader doesn't handle changing the date to universal time
+    // and doesn't use the user's time zone (they're effectively ignoring
+    // the HH' and mm' parts of the date string).
+    var dateToParse = inputDate;
+    if (dateToParse === undefined) {
+      return '';
+    }
+
+    // Remove the D: prefix if it is available.
+    if (dateToParse.substring(0, 2) === 'D:') {
+      dateToParse = dateToParse.substring(2);
+    }
+
+    // Get all elements from the PDF date string.
+    // JavaScript's `Date` object expects the month to be between
+    // 0 and 11 instead of 1 and 12, so we're correcting for this.
+    var year = parseInt(dateToParse.substring(0, 4), 10);
+    var month = parseInt(dateToParse.substring(4, 6), 10) - 1;
+    var day = parseInt(dateToParse.substring(6, 8), 10);
+    var hours = parseInt(dateToParse.substring(8, 10), 10);
+    var minutes = parseInt(dateToParse.substring(10, 12), 10);
+    var seconds = parseInt(dateToParse.substring(12, 14), 10);
+    var utRel = dateToParse.substring(14, 15);
+    var offsetHours = parseInt(dateToParse.substring(15, 17), 10);
+    var offsetMinutes = parseInt(dateToParse.substring(18, 20), 10);
+
+    // As per spec, utRel = 'Z' means equal to universal time.
+    // The other cases ('-' and '+') have to be handled here.
+    if (utRel === '-') {
+      hours += offsetHours;
+      minutes += offsetMinutes;
+    } else if (utRel === '+') {
+      hours -= offsetHours;
+      minutes -= offsetMinutes;
+    }
+
+    // Return the new date format from the user's locale.
+    var date = new Date(Date.UTC(year, month, day, hours, minutes, seconds));
+    var dateString = date.toLocaleDateString();
+    var timeString = date.toLocaleTimeString();
+    return mozL10n.get('document_properties_date_string',
+                       { date: dateString, time: timeString },
+                       '{{date}}, {{time}}');
+  }
+}
 
 export {
   PDFDocumentProperties,


### PR DESCRIPTION
Moreover, add a missing option to the JSDoc comment and reorder the assignments in the constructor to match the order in the JSDoc comment.

*Easier reviewing with https://github.com/mozilla/pdf.js/pull/8296/files?w=1.*