### PR TITLE
Convert the files in the `/test/unit` folder to ES6 modules

### DIFF
--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -12,42 +12,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/annotation_spec', ['exports',
-      'pdfjs/core/primitives', 'pdfjs/core/annotation', 'pdfjs/core/stream',
-      'pdfjs/core/parser', 'pdfjs/shared/util'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../../src/core/primitives.js'),
-      require('../../src/core/annotation.js'),
-      require('../../src/core/stream.js'), require('../../src/core/parser.js'),
-      require('../../src/shared/util.js'));
-  } else {
-    factory((root.pdfjsTestUnitAnnotationSpec = {}),
-      root.pdfjsCorePrimitives, root.pdfjsCoreAnnotation, root.pdfjsCoreStream,
-      root.pdfjsCoreParser, root.pdfjsSharedUtil);
-  }
-}(this, function (exports, corePrimitives, coreAnnotation, coreStream,
-                  coreParser, sharedUtil) {
-
-var Annotation = coreAnnotation.Annotation;
-var AnnotationBorderStyle = coreAnnotation.AnnotationBorderStyle;
-var AnnotationFactory = coreAnnotation.AnnotationFactory;
-var Lexer = coreParser.Lexer;
-var Parser = coreParser.Parser;
-var isRef = corePrimitives.isRef;
-var Dict = corePrimitives.Dict;
-var Name = corePrimitives.Name;
-var Ref = corePrimitives.Ref;
-var StringStream = coreStream.StringStream;
-var AnnotationType = sharedUtil.AnnotationType;
-var AnnotationFlag = sharedUtil.AnnotationFlag;
-var AnnotationBorderStyleType = sharedUtil.AnnotationBorderStyleType;
-var AnnotationFieldFlag = sharedUtil.AnnotationFieldFlag;
-var stringToBytes = sharedUtil.stringToBytes;
-var stringToUTF8String = sharedUtil.stringToUTF8String;
+import {
+  Annotation, AnnotationBorderStyle, AnnotationFactory
+} from '../../src/core/annotation';
+import {
+  AnnotationBorderStyleType, AnnotationFieldFlag, AnnotationFlag,
+  AnnotationType, stringToBytes, stringToUTF8String
+} from '../../src/shared/util';
+import { Dict, isRef, Name, Ref } from '../../src/core/primitives';
+import { Lexer, Parser } from '../../src/core/parser';
+import { StringStream } from '../../src/core/stream';
 
 describe('annotation', function() {
   function XRefMock(array) {
@@ -1393,4 +1368,3 @@ describe('annotation', function() {
     });
   });
 });
-}));

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -12,37 +12,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/api_spec', ['exports', 'pdfjs/shared/util',
-      'pdfjs/display/dom_utils', 'pdfjs/display/global', 'pdfjs/display/api'],
-      factory);
-  } else if (typeof exports !== 'undefined') {
-      factory(exports, require('../../src/shared/util.js'),
-        require('../../src/display/dom_utils.js'),
-        require('../../src/display/global.js'),
-        require('../../src/display/api.js'));
-  } else {
-    factory((root.pdfjsTestUnitApiSpec = {}), root.pdfjsSharedUtil,
-      root.pdfjsDisplayDOMUtils, root.pdfjsDisplayGlobal, root.pdfjsDisplayApi);
-  }
-}(this, function (exports, sharedUtil, displayDOMUtils, displayGlobal,
-                  displayApi) {
-
-var PDFJS = displayGlobal.PDFJS;
-var createPromiseCapability = sharedUtil.createPromiseCapability;
-var DOMCanvasFactory = displayDOMUtils.DOMCanvasFactory;
-var RenderingCancelledException = displayDOMUtils.RenderingCancelledException;
-var PDFDocumentProxy = displayApi.PDFDocumentProxy;
-var InvalidPDFException = sharedUtil.InvalidPDFException;
-var MissingPDFException = sharedUtil.MissingPDFException;
-var PasswordResponses = sharedUtil.PasswordResponses;
-var PasswordException = sharedUtil.PasswordException;
-var PDFPageProxy = displayApi.PDFPageProxy;
-var StreamType = sharedUtil.StreamType;
-var FontType = sharedUtil.FontType;
+import {
+  createPromiseCapability, FontType, InvalidPDFException, MissingPDFException,
+  PasswordException, PasswordResponses, StreamType
+} from '../../src/shared/util';
+import {
+  DOMCanvasFactory, RenderingCancelledException
+} from '../../src/display/dom_utils';
+import { PDFDocumentProxy, PDFPageProxy } from '../../src/display/api';
+import { PDFJS } from '../../src/display/global';
 
 describe('api', function() {
   var basicApiUrl = new URL('../pdfs/basicapi.pdf', window.location).href;
@@ -1210,4 +1189,3 @@ describe('api', function() {
     });
   });
 });
-}));

--- a/test/unit/bidi_spec.js
+++ b/test/unit/bidi_spec.js
@@ -12,20 +12,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/bidi_spec', ['exports', 'pdfjs/core/bidi'],
-           factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../../src/core/bidi.js'));
-  } else {
-    factory((root.pdfjsTestUnitBidiSpec = {}), root.pdfjsCoreBidi);
-  }
-}(this, function (exports, coreBidi) {
-
-var bidi = coreBidi.bidi;
+import { bidi } from '../../src/core/bidi';
 
 describe('bidi', function () {
   it('should mark text as RTL if more than 30% of text is RTL', function() {
@@ -47,4 +35,3 @@ describe('bidi', function () {
     expect(bidiText.dir).toEqual('ltr');
   });
 });
-}));

--- a/test/unit/cff_parser_spec.js
+++ b/test/unit/cff_parser_spec.js
@@ -12,29 +12,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/cff_parser_spec', ['exports',
-           'pdfjs/core/cff_parser', 'pdfjs/core/fonts',
-           'pdfjs/core/stream'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../../src/core/cff_parser.js'),
-            require('../../src/core/fonts.js'),
-            require('../../src/core/stream.js'));
-  } else {
-    factory((root.pdfjsTestUnitCFFParserSpec = {}), root.pdfjsCoreCFFParser,
-             root.pdfjsCoreFonts, root.pdfjsCoreStream);
-  }
-}(this, function (exports, coreCFFParser, coreFonts, coreStream) {
-
-var CFFParser = coreCFFParser.CFFParser;
-var CFFIndex = coreCFFParser.CFFIndex;
-var CFFStrings = coreCFFParser.CFFStrings;
-var CFFCompiler = coreCFFParser.CFFCompiler;
-var SEAC_ANALYSIS_ENABLED = coreFonts.SEAC_ANALYSIS_ENABLED;
-var Stream = coreStream.Stream;
+import {
+  CFFCompiler, CFFIndex, CFFParser, CFFStrings
+} from '../../src/core/cff_parser';
+import { SEAC_ANALYSIS_ENABLED } from '../../src/core/fonts';
+import { Stream } from '../../src/core/stream';
 
 describe('CFFParser', function() {
   function createWithNullProto(obj) {
@@ -388,4 +371,3 @@ describe('CFFCompiler', function() {
 
   // TODO a lot more compiler tests
 });
-}));

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -12,36 +12,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/cmap_spec', ['exports', 'pdfjs/core/cmap',
-      'pdfjs/core/primitives', 'pdfjs/core/stream', 'pdfjs/display/dom_utils',
-      'pdfjs/shared/util', 'pdfjs-test/unit/test_utils'], factory);
-  } else if (typeof exports !== 'undefined') {
-      factory(exports, require('../../src/core/cmap.js'),
-        require('../../src/core/primitives.js'),
-        require('../../src/core/stream.js'),
-        require('../../src/display/dom_utils.js'),
-        require('../../src/shared/util.js'), require('./test_utils.js'));
-  } else {
-    factory((root.pdfjsTestUnitCMapSpec = {}), root.pdfjsCoreCMap,
-      root.pdfjsCorePrimitives, root.pdfjsCoreStream,
-      root.pdfjsDisplayDOMUtils, root.pdfjsSharedUtil,
-      root.pdfjsTestUnitTestUtils);
-  }
-}(this, function (exports, coreCMap, corePrimitives, coreStream,
-                  displayDOMUtils, sharedUtil, testUnitTestUtils) {
-
-var CMapFactory = coreCMap.CMapFactory;
-var CMap = coreCMap.CMap;
-var IdentityCMap = coreCMap.IdentityCMap;
-var Name = corePrimitives.Name;
-var StringStream = coreStream.StringStream;
-var DOMCMapReaderFactory = displayDOMUtils.DOMCMapReaderFactory;
-var isNodeJS = sharedUtil.isNodeJS;
-var NodeCMapReaderFactory = testUnitTestUtils.NodeCMapReaderFactory;
+import { CMap, CMapFactory, IdentityCMap } from '../../src/core/cmap';
+import { DOMCMapReaderFactory } from '../../src/display/dom_utils';
+import { isNodeJS } from '../../src/shared/util';
+import { Name } from '../../src/core/primitives';
+import { NodeCMapReaderFactory } from './test_utils';
+import { StringStream } from '../../src/core/stream';
 
 var cMapUrl = {
   dom: '../../external/bcmaps/',
@@ -310,4 +287,3 @@ describe('cmap', function() {
     });
   });
 });
-}));

--- a/test/unit/crypto_spec.js
+++ b/test/unit/crypto_spec.js
@@ -12,37 +12,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/crypto_spec', ['exports', 'pdfjs/core/crypto',
-           'pdfjs/core/primitives', 'pdfjs/shared/util'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../../src/core/crypto.js'),
-            require('../../src/core/primitives.js'),
-            require('../../src/shared/util.js'));
-  } else {
-    factory((root.pdfjsTestUnitCryptoSpec = {}), root.pdfjsCoreCrypto,
-             root.pdfjsCorePrimitives, root.pdfjsSharedUtil);
-  }
-}(this, function (exports, coreCrypto, corePrimitives, sharedUtil) {
-
-var calculateMD5 = coreCrypto.calculateMD5;
-var ARCFourCipher = coreCrypto.ARCFourCipher;
-var calculateSHA256 = coreCrypto.calculateSHA256;
-var calculateSHA384 = coreCrypto.calculateSHA384;
-var calculateSHA512 = coreCrypto.calculateSHA512;
-var AES128Cipher = coreCrypto.AES128Cipher;
-var AES256Cipher = coreCrypto.AES256Cipher;
-var PDF17 = coreCrypto.PDF17;
-var PDF20 = coreCrypto.PDF20;
-var CipherTransformFactory = coreCrypto.CipherTransformFactory;
-var Name = corePrimitives.Name;
-var Dict = corePrimitives.Dict;
-var stringToBytes = sharedUtil.stringToBytes;
-var PasswordException = sharedUtil.PasswordException;
-var PasswordResponses = sharedUtil.PasswordResponses;
+import {
+  AES128Cipher, AES256Cipher, ARCFourCipher, calculateMD5, calculateSHA256,
+  calculateSHA384, calculateSHA512, CipherTransformFactory, PDF17, PDF20
+} from '../../src/core/crypto';
+import { Dict, Name } from '../../src/core/primitives';
+import {
+  PasswordException, PasswordResponses, stringToBytes
+} from '../../src/shared/util';
 
 describe('crypto', function() {
   function hex2binary(s) {
@@ -708,4 +686,3 @@ describe('CipherTransformFactory', function() {
     });
   });
 });
-}));

--- a/test/unit/document_spec.js
+++ b/test/unit/document_spec.js
@@ -12,21 +12,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/document_spec', ['exports', 'pdfjs/core/document'],
-      factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../../src/core/document.js'));
-  } else {
-    factory((root.pdfjsTestUnitDocumentSpec = {}),
-      root.pdfjsCoreDocument);
-  }
-}(this, function (exports, coreDocument) {
-
-var Page = coreDocument.Page;
+import { Page } from '../../src/core/document';
 
 describe('document', function () {
   describe('Page', function () {
@@ -55,4 +42,3 @@ describe('document', function () {
     });
   });
 });
-}));

--- a/test/unit/dom_utils_spec.js
+++ b/test/unit/dom_utils_spec.js
@@ -12,25 +12,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/dom_utils_spec', ['exports',
-           'pdfjs/display/dom_utils', 'pdfjs/display/global'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../../src/display/dom_utils.js'),
-            require('../../src/display/global.js'));
-  } else {
-    factory((root.pdfjsTestUnitDOMUtilsSpec = {}), root.pdfjsDisplayDOMUtils,
-             root.pdfjsDisplayGlobal);
-  }
-}(this, function (exports, displayDOMUtils, displayGlobal) {
-
-var PDFJS = displayGlobal.PDFJS;
-var getFilenameFromUrl = displayDOMUtils.getFilenameFromUrl;
-var LinkTarget = displayDOMUtils.LinkTarget;
-var isExternalLinkTargetSet = displayDOMUtils.isExternalLinkTargetSet;
+import {
+  getFilenameFromUrl, isExternalLinkTargetSet, LinkTarget
+} from '../../src/display/dom_utils';
+import { PDFJS } from '../../src/display/global';
 
 describe('dom_utils', function() {
   describe('getFilenameFromUrl', function() {
@@ -82,4 +68,3 @@ describe('dom_utils', function() {
     });
   });
 });
-}));

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -12,36 +12,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/evaluator_spec', ['exports',
-           'pdfjs/core/evaluator', 'pdfjs/core/primitives',
-           'pdfjs/core/stream', 'pdfjs/core/worker',
-           'pdfjs/shared/util'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../../src/core/evaluator.js'),
-            require('../../src/core/primitives.js'),
-            require('../../src/core/stream.js'),
-            require('../../src/core/worker.js'),
-            require('../../src/shared/util.js'));
-  } else {
-    factory((root.pdfjsTestUnitEvaluatorSpec = {}), root.pdfjsCoreEvaluator,
-             root.pdfjsCorePrimitives, root.pdfjsCoreStream,
-             root.pdfjsCoreWorker, root.pdfjsSharedUtil);
-  }
-}(this, function (exports, coreEvaluator, corePrimitives, coreStream,
-                  coreWorker, sharedUtil) {
-
-var OperatorList = coreEvaluator.OperatorList;
-var PartialEvaluator = coreEvaluator.PartialEvaluator;
-var Dict = corePrimitives.Dict;
-var Name = corePrimitives.Name;
-var Stream = coreStream.Stream;
-var StringStream = coreStream.StringStream;
-var WorkerTask = coreWorker.WorkerTask;
-var OPS = sharedUtil.OPS;
+import { Dict, Name } from '../../src/core/primitives';
+import { OperatorList, PartialEvaluator } from '../../src/core/evaluator';
+import { Stream, StringStream } from '../../src/core/stream';
+import { OPS } from '../../src/shared/util';
+import { WorkerTask } from '../../src/core/worker';
 
 describe('evaluator', function() {
   function XrefMock(queue) {
@@ -361,4 +337,3 @@ describe('evaluator', function() {
     });
   });
 });
-}));

--- a/test/unit/fonts_spec.js
+++ b/test/unit/fonts_spec.js
@@ -12,25 +12,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/fonts_spec', ['exports', 'pdfjs/core/fonts',
-      'pdfjs/shared/util'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../../src/core/fonts.js'),
-      require('../../src/shared/util.js'));
-  } else {
-    factory((root.pdfjsTestUnitFontsSpec = {}), root.pdfjsCoreFonts,
-      root.pdfjsSharedUtil);
-  }
-}(this, function (exports, coreFonts, sharedUtil) {
-
-var ProblematicCharRanges = coreFonts.ProblematicCharRanges;
-var PRIVATE_USE_OFFSET_START = coreFonts.PRIVATE_USE_OFFSET_START;
-var PRIVATE_USE_OFFSET_END = coreFonts.PRIVATE_USE_OFFSET_END;
-var isInt = sharedUtil.isInt;
+import {
+  PRIVATE_USE_OFFSET_END, PRIVATE_USE_OFFSET_START, ProblematicCharRanges
+} from '../../src/core/fonts';
+import { isInt } from '../../src/shared/util';
 
 /**
  * Used to validate the entries in `ProblematicCharRanges`, and to ensure that
@@ -104,4 +90,3 @@ describe('Fonts', function() {
     expect(result.percentage).toBeLessThan(EXPECTED_PERCENTAGE);
   });
 });
-}));

--- a/test/unit/function_spec.js
+++ b/test/unit/function_spec.js
@@ -12,31 +12,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/function_spec', ['exports',
-           'pdfjs/core/function', 'pdfjs/core/ps_parser',
-           'pdfjs/core/stream', 'pdfjs/shared/util'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../../src/core/function.js'),
-            require('../../src/core/ps_parser.js'),
-            require('../../src/core/stream.js'),
-            require('../../src/shared/util.js'));
-  } else {
-    factory((root.pdfjsTestUnitFunctionSpec = {}),
-             root.pdfjsCoreFunction, root.pdfjsCorePsParser,
-             root.pdfjsCoreStream, root.pdfjsSharedUtil);
-  }
-}(this, function (exports, coreFunction, corePsParser, coreStream, sharedUtil) {
-
-var PostScriptEvaluator = coreFunction.PostScriptEvaluator;
-var PostScriptCompiler = coreFunction.PostScriptCompiler;
-var PostScriptParser = corePsParser.PostScriptParser;
-var PostScriptLexer = corePsParser.PostScriptLexer;
-var StringStream = coreStream.StringStream;
-var isArray = sharedUtil.isArray;
+import {
+  PostScriptCompiler, PostScriptEvaluator
+} from '../../src/core/function';
+import { PostScriptLexer, PostScriptParser } from '../../src/core/ps_parser';
+import { isArray } from '../../src/shared/util';
+import { StringStream } from '../../src/core/stream';
 
 describe('function', function() {
   beforeEach(function() {
@@ -564,4 +546,3 @@ describe('function', function() {
     });
   });
 });
-}));

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -41,30 +41,30 @@
 'use strict';
 
 function initializePDFJS(callback) {
-    Promise.all([
-      'pdfjs/display/global', 'pdfjs-test/unit/annotation_spec',
-      'pdfjs-test/unit/api_spec', 'pdfjs-test/unit/bidi_spec',
-      'pdfjs-test/unit/cff_parser_spec', 'pdfjs-test/unit/cmap_spec',
-      'pdfjs-test/unit/crypto_spec', 'pdfjs-test/unit/document_spec',
-      'pdfjs-test/unit/dom_utils_spec', 'pdfjs-test/unit/evaluator_spec',
-      'pdfjs-test/unit/fonts_spec', 'pdfjs-test/unit/function_spec',
-      'pdfjs-test/unit/metadata_spec', 'pdfjs-test/unit/murmurhash3_spec',
-      'pdfjs-test/unit/network_spec', 'pdfjs-test/unit/parser_spec',
-      'pdfjs-test/unit/primitives_spec', 'pdfjs-test/unit/stream_spec',
-      'pdfjs-test/unit/type1_parser_spec', 'pdfjs-test/unit/ui_utils_spec',
-      'pdfjs-test/unit/unicode_spec', 'pdfjs-test/unit/util_spec'
-    ].map(function (moduleName) {
-      return SystemJS.import(moduleName);
-    })).then(function (modules) {
-      var displayGlobal = modules[0];
+  Promise.all([
+    'pdfjs/display/global', 'pdfjs-test/unit/annotation_spec',
+    'pdfjs-test/unit/api_spec', 'pdfjs-test/unit/bidi_spec',
+    'pdfjs-test/unit/cff_parser_spec', 'pdfjs-test/unit/cmap_spec',
+    'pdfjs-test/unit/crypto_spec', 'pdfjs-test/unit/document_spec',
+    'pdfjs-test/unit/dom_utils_spec', 'pdfjs-test/unit/evaluator_spec',
+    'pdfjs-test/unit/fonts_spec', 'pdfjs-test/unit/function_spec',
+    'pdfjs-test/unit/metadata_spec', 'pdfjs-test/unit/murmurhash3_spec',
+    'pdfjs-test/unit/network_spec', 'pdfjs-test/unit/parser_spec',
+    'pdfjs-test/unit/primitives_spec', 'pdfjs-test/unit/stream_spec',
+    'pdfjs-test/unit/type1_parser_spec', 'pdfjs-test/unit/ui_utils_spec',
+    'pdfjs-test/unit/unicode_spec', 'pdfjs-test/unit/util_spec'
+  ].map(function (moduleName) {
+    return SystemJS.import(moduleName);
+  })).then(function (modules) {
+    var displayGlobal = modules[0];
 
-      // Configure the worker.
-      displayGlobal.PDFJS.workerSrc = '../../src/worker_loader.js';
-      // Opt-in to using the latest API.
-      displayGlobal.PDFJS.pdfjsNext = true;
+    // Configure the worker.
+    displayGlobal.PDFJS.workerSrc = '../../src/worker_loader.js';
+    // Opt-in to using the latest API.
+    displayGlobal.PDFJS.pdfjsNext = true;
 
-      callback();
-    });
+    callback();
+  });
 }
 
 (function() {

--- a/test/unit/metadata_spec.js
+++ b/test/unit/metadata_spec.js
@@ -12,20 +12,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/metadata_spec', ['exports',
-           'pdfjs/display/metadata'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../../src/display/metadata.js'));
-  } else {
-    factory((root.pdfjsTestUnitMetadataSpec = {}), root.pdfjsDisplayMetadata);
-  }
-}(this, function (exports, displayMetadata) {
-
-var Metadata = displayMetadata.Metadata;
+import { Metadata } from '../../src/display/metadata';
 
 describe('metadata', function() {
   describe('incorrect_xmp', function() {
@@ -40,4 +28,3 @@ describe('metadata', function() {
     });
   });
 });
-}));

--- a/test/unit/murmurhash3_spec.js
+++ b/test/unit/murmurhash3_spec.js
@@ -12,21 +12,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/murmurhash3_spec', ['exports',
-           'pdfjs/core/murmurhash3'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../../src/core/murmurhash3.js'));
-  } else {
-    factory((root.pdfjsTestUnitMurmurHash3Spec = {}),
-             root.pdfjsCoreMurmurHash3);
-  }
-}(this, function (exports, coreMurmurHash3) {
-
-var MurmurHash3_64 = coreMurmurHash3.MurmurHash3_64;
+import { MurmurHash3_64 } from '../../src/core/murmurhash3';
 
 describe('MurmurHash3_64', function() {
   it('instantiates without seed', function() {
@@ -76,4 +63,3 @@ describe('MurmurHash3_64', function() {
     expect(hexdigest1).not.toEqual(hexdigest2);
   });
 });
-}));

--- a/test/unit/network_spec.js
+++ b/test/unit/network_spec.js
@@ -12,20 +12,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/network_spec', ['exports', 'pdfjs/core/network'],
-           factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../../src/core/network.js'));
-  } else {
-    factory((root.pdfjsTestUnitNetworkSpec = {}), root.pdfjsCoreNetwork);
-  }
-}(this, function (exports, coreNetwork) {
-
-var PDFNetworkStream = coreNetwork.PDFNetworkStream;
+import { PDFNetworkStream } from '../../src/core/network';
 
 describe('network', function() {
   var pdf1 = new URL('../pdfs/tracemonkey.pdf', window.location).href;
@@ -189,4 +177,3 @@ describe('network', function() {
     });
   });
 });
-}));

--- a/test/unit/parser_spec.js
+++ b/test/unit/parser_spec.js
@@ -12,26 +12,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/parser_spec', ['exports', 'pdfjs/core/parser',
-           'pdfjs/core/primitives', 'pdfjs/core/stream'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../../src/core/parser.js'),
-            require('../../src/core/primitives.js'),
-            require('../../src/core/stream.js'));
-  } else {
-    factory((root.pdfjsTestUnitParserSpec = {}), root.pdfjsCoreParser,
-             root.pdfjsCorePrimitives, root.pdfjsCoreStream);
-  }
-}(this, function (exports, coreParser, corePrimitives, coreStream) {
-
-var Lexer = coreParser.Lexer;
-var Linearization = coreParser.Linearization;
-var Name = corePrimitives.Name;
-var StringStream = coreStream.StringStream;
+import { Lexer, Linearization } from '../../src/core/parser';
+import { Name } from '../../src/core/primitives';
+import { StringStream } from '../../src/core/stream';
 
 describe('parser', function() {
   describe('Lexer', function() {
@@ -294,4 +278,3 @@ describe('parser', function() {
     });
   });
 });
-}));

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -12,29 +12,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/primitives_spec', ['exports',
-           'pdfjs/core/primitives'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../../src/core/primitives.js'));
-  } else {
-    factory((root.pdfjsTestUnitPrimitivesSpec = {}), root.pdfjsCorePrimitives);
-  }
-}(this, function (exports, corePrimitives) {
-
-var Name = corePrimitives.Name;
-var Dict = corePrimitives.Dict;
-var Ref = corePrimitives.Ref;
-var RefSet = corePrimitives.RefSet;
-var Cmd = corePrimitives.Cmd;
-var isName = corePrimitives.isName;
-var isCmd = corePrimitives.isCmd;
-var isDict = corePrimitives.isDict;
-var isRef = corePrimitives.isRef;
-var isRefsEqual = corePrimitives.isRefsEqual;
+import {
+  Cmd, Dict, isCmd, isDict, isName, isRef, isRefsEqual, Name, Ref, RefSet
+} from '../../src/core/primitives';
 
 describe('primitives', function() {
   function XRefMock(array) {
@@ -404,4 +385,3 @@ describe('primitives', function() {
     });
   });
 });
-}));

--- a/test/unit/stream_spec.js
+++ b/test/unit/stream_spec.js
@@ -12,24 +12,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/stream_spec', ['exports',
-           'pdfjs/core/primitives', 'pdfjs/core/stream'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../../src/core/primitives.js'),
-            require('../../src/core/stream.js'));
-  } else {
-    factory((root.pdfjsTestUnitStreamSpec = {}), root.pdfjsCorePrimitives,
-             root.pdfjsCoreStream);
-  }
-}(this, function (exports, corePrimitives, coreStream) {
-
-var Dict = corePrimitives.Dict;
-var Stream = coreStream.Stream;
-var PredictorStream = coreStream.PredictorStream;
+import { PredictorStream, Stream } from '../../src/core/stream';
+import { Dict } from '../../src/core/primitives';
 
 describe('stream', function() {
   beforeEach(function() {
@@ -77,4 +62,3 @@ describe('stream', function() {
     });
   });
 });
-}));

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -12,56 +12,41 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/test_utils', ['exports', 'pdfjs/shared/util'],
-      factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../../src/shared/util.js'));
-  } else {
-    factory((root.pdfjsTestUnitTestUtils = {}), root.pdfjsSharedUtil);
-  }
-}(this, function (exports, sharedUtil) {
+import { CMapCompressionType } from '../../src/shared/util';
 
-var CMapCompressionType = sharedUtil.CMapCompressionType;
-
-var NodeCMapReaderFactory = (function NodeCMapReaderFactoryClosure() {
-  function NodeCMapReaderFactory(params) {
+class NodeCMapReaderFactory {
+  constructor(params) {
     this.baseUrl = params.baseUrl || null;
     this.isCompressed = params.isCompressed || false;
   }
 
-  NodeCMapReaderFactory.prototype = {
-    fetch: function(params) {
-      var name = params.name;
-      if (!name) {
-        return Promise.reject(new Error('CMap name must be specified.'));
-      }
-      return new Promise(function (resolve, reject) {
-        var url = this.baseUrl + name + (this.isCompressed ? '.bcmap' : '');
+  fetch(params) {
+    var name = params.name;
+    if (!name) {
+      return Promise.reject(new Error('CMap name must be specified.'));
+    }
+    return new Promise((resolve, reject) => {
+      var url = this.baseUrl + name + (this.isCompressed ? '.bcmap' : '');
 
-        var fs = require('fs');
-        fs.readFile(url, function (error, data) {
-          if (error || !data) {
-            reject(new Error('Unable to load ' +
-                             (this.isCompressed ? 'binary ' : '') +
-                             'CMap at: ' + url));
-            return;
-          }
-          resolve({
-            cMapData: new Uint8Array(data),
-            compressionType: this.isCompressed ?
-              CMapCompressionType.BINARY : CMapCompressionType.NONE,
-          });
-        }.bind(this));
-      }.bind(this));
-    },
-  };
+      var fs = require('fs');
+      fs.readFile(url, (error, data) => {
+        if (error || !data) {
+          reject(new Error('Unable to load ' +
+                           (this.isCompressed ? 'binary ' : '') +
+                           'CMap at: ' + url));
+          return;
+        }
+        resolve({
+          cMapData: new Uint8Array(data),
+          compressionType: this.isCompressed ?
+            CMapCompressionType.BINARY : CMapCompressionType.NONE,
+        });
+      });
+    });
+  }
+}
 
-  return NodeCMapReaderFactory;
-})();
-
-exports.NodeCMapReaderFactory = NodeCMapReaderFactory;
-}));
+export {
+  NodeCMapReaderFactory,
+};

--- a/test/unit/type1_parser_spec.js
+++ b/test/unit/type1_parser_spec.js
@@ -12,26 +12,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/type1_parser_spec', ['exports',
-           'pdfjs/core/fonts', 'pdfjs/core/stream', 'pdfjs/core/type1_parser'],
-           factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../../src/core/fonts.js'),
-            require('../../src/core/stream.js'),
-            require('../../src/core/type1_parser.js'));
-  } else {
-    factory((root.pdfjsTestUnitType1ParserSpec = {}), root.pdfjsCoreFonts,
-             root.pdfjsCoreStream, root.pdfjsCoreType1Parser);
-  }
-}(this, function (exports, coreFonts, coreStream, coreType1Parser) {
-
-var SEAC_ANALYSIS_ENABLED = coreFonts.SEAC_ANALYSIS_ENABLED;
-var StringStream = coreStream.StringStream;
-var Type1Parser = coreType1Parser.Type1Parser;
+import { SEAC_ANALYSIS_ENABLED } from '../../src/core/fonts';
+import { StringStream } from '../../src/core/stream';
+import { Type1Parser } from '../../src/core/type1_parser';
 
 describe('Type1Parser', function() {
   it('splits tokens', function() {
@@ -132,4 +116,3 @@ describe('Type1Parser', function() {
     expect(props.builtInEncoding[33]).toEqual('arrowright');
   });
 });
-}));

--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -12,26 +12,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/ui_utils_spec', ['exports',
-      'pdfjs-web/ui_utils', 'pdfjs/shared/util'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../../web/ui_utils.js'),
-      require('../../src/shared/util.js'));
-  } else {
-    factory((root.pdfjsTestUnitUiUtilsSpec = {}), root.pdfjsWebUiUtils,
-      root.pdfjsSharedUtil);
-  }
-}(this, function (exports, webUiUtils, sharedUtil) {
-
-var binarySearchFirstItem = webUiUtils.binarySearchFirstItem;
-var getPDFFileNameFromURL = webUiUtils.getPDFFileNameFromURL;
-var EventBus = webUiUtils.EventBus;
-var createObjectURL = sharedUtil.createObjectURL;
-var isNodeJS = sharedUtil.isNodeJS;
+import {
+  binarySearchFirstItem, EventBus, getPDFFileNameFromURL
+} from '../../web/ui_utils';
+import { createObjectURL, isNodeJS } from '../../src/shared/util';
 
 describe('ui_utils', function() {
   describe('binary search', function() {
@@ -275,4 +260,3 @@ describe('ui_utils', function() {
     });
   });
 });
-}));

--- a/test/unit/unicode_spec.js
+++ b/test/unit/unicode_spec.js
@@ -12,28 +12,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/unicode_spec', ['exports',
-           'pdfjs/core/glyphlist', 'pdfjs/core/unicode'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../../src/core/glyphlist.js'),
-            require('../../src/core/unicode.js'));
-  } else {
-    factory((root.pdfjsTestUnitUnicodeSpec = {}),
-             root.pdfjsCoreGlyphList, root.pdfjsCoreUnicode);
-  }
-}(this, function (exports, coreGlyphList, coreUnicode) {
-
-var getGlyphsUnicode = coreGlyphList.getGlyphsUnicode;
-var getDingbatsGlyphsUnicode = coreGlyphList.getDingbatsGlyphsUnicode;
-var mapSpecialUnicodeValues = coreUnicode.mapSpecialUnicodeValues;
-var getUnicodeForGlyph = coreUnicode.getUnicodeForGlyph;
-var getUnicodeRangeFor = coreUnicode.getUnicodeRangeFor;
-var getNormalizedUnicodes = coreUnicode.getNormalizedUnicodes;
-var reverseIfRtl = coreUnicode.reverseIfRtl;
+import {
+  getDingbatsGlyphsUnicode, getGlyphsUnicode
+} from '../../src/core/glyphlist';
+import {
+  getNormalizedUnicodes, getUnicodeForGlyph, getUnicodeRangeFor,
+  mapSpecialUnicodeValues, reverseIfRtl
+} from '../../src/core/unicode';
 
 describe('unicode', function () {
   describe('mapSpecialUnicodeValues', function () {
@@ -159,4 +145,3 @@ describe('unicode', function () {
     });
   });
 });
-}));

--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -12,21 +12,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define('pdfjs-test/unit/util_spec', ['exports',
-           'pdfjs/shared/util'], factory);
-  } else if (typeof exports !== 'undefined') {
-    factory(exports, require('../../src/shared/util.js'));
-  } else {
-    factory((root.pdfjsTestUnitUtilSpec = {}), root.pdfjsSharedUtil);
-  }
-}(this, function (exports, sharedUtil) {
-
-var stringToPDFString = sharedUtil.stringToPDFString;
-var removeNullCharacters = sharedUtil.removeNullCharacters;
+import {
+  removeNullCharacters, stringToPDFString
+} from '../../src/shared/util';
 
 describe('util', function() {
   describe('stringToPDFString', function() {
@@ -63,4 +52,3 @@ describe('util', function() {
     });
   });
 });
-}));


### PR DESCRIPTION
The SystemJS module loader has a very low impact on the runtime of the unit tests. Locally, the runtime increased from 20.4 seconds to 21.9 seconds, so that should be fine.

*Slightly easier reviewing with https://github.com/mozilla/pdf.js/pull/8298/files?w=1.*