### PR TITLE
Import `getGlobalEventBus` correctly from `web/dom_events.js` in various `/web` files, to un-break e.g. the viewer components (PR 8203 follow-up)

### DIFF
--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -14,11 +14,11 @@
  */
 /* globals chrome */
 
-import { domEvents } from './dom_events';
+import { getGlobalEventBus } from './dom_events';
 
 function PDFHistory(options) {
   this.linkService = options.linkService;
-  this.eventBus = options.eventBus || domEvents.getGlobalEventBus();
+  this.eventBus = options.eventBus || getGlobalEventBus();
 
   this.initialized = false;
   this.initialDestination = null;

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { domEvents } from './dom_events';
+import { getGlobalEventBus } from './dom_events';
 import { parseQueryString } from './ui_utils';
 
 var PageNumberRegExp = /^\d+$/;
@@ -39,7 +39,7 @@ var PDFLinkService = (function PDFLinkServiceClosure() {
    */
   function PDFLinkService(options) {
     options = options || {};
-    this.eventBus = options.eventBus || domEvents.getGlobalEventBus();
+    this.eventBus = options.eventBus || getGlobalEventBus();
     this.baseUrl = null;
     this.pdfDocument = null;
     this.pdfViewer = null;

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -21,7 +21,7 @@ import {
   createPromiseCapability, CustomStyle, PDFJS, RenderingCancelledException,
   SVGGraphics
 } from './pdfjs';
-import { domEvents } from './dom_events';
+import { getGlobalEventBus } from './dom_events';
 import { RenderingStates } from './pdf_rendering_queue';
 
 var TEXT_LAYER_RENDER_DELAY = 200; // ms
@@ -75,7 +75,7 @@ var PDFPageView = (function PDFPageViewClosure() {
     this.enhanceTextSelection = enhanceTextSelection;
     this.renderInteractiveForms = renderInteractiveForms;
 
-    this.eventBus = options.eventBus || domEvents.getGlobalEventBus();
+    this.eventBus = options.eventBus || getGlobalEventBus();
     this.renderingQueue = renderingQueue;
     this.textLayerFactory = textLayerFactory;
     this.annotationLayerFactory = annotationLayerFactory;

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -21,7 +21,7 @@ import {
 } from './ui_utils';
 import { PDFRenderingQueue, RenderingStates } from './pdf_rendering_queue';
 import { AnnotationLayerBuilder } from './annotation_layer_builder';
-import { domEvents } from './dom_events';
+import { getGlobalEventBus } from './dom_events';
 import { PDFPageView } from './pdf_page_view';
 import { SimpleLinkService } from './pdf_link_service';
 import { TextLayerBuilder } from './text_layer_builder';
@@ -106,7 +106,7 @@ var PDFViewer = (function pdfViewer() {
   function PDFViewer(options) {
     this.container = options.container;
     this.viewer = options.viewer || options.container.firstElementChild;
-    this.eventBus = options.eventBus || domEvents.getGlobalEventBus();
+    this.eventBus = options.eventBus || getGlobalEventBus();
     this.linkService = options.linkService || new SimpleLinkService();
     this.downloadManager = options.downloadManager || null;
     this.removePageBorders = options.removePageBorders || false;

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { domEvents } from './dom_events';
+import { getGlobalEventBus } from './dom_events';
 import { renderTextLayer } from './pdfjs';
 
 var EXPAND_DIVS_TIMEOUT = 300; // ms
@@ -39,7 +39,7 @@ var EXPAND_DIVS_TIMEOUT = 300; // ms
 var TextLayerBuilder = (function TextLayerBuilderClosure() {
   function TextLayerBuilder(options) {
     this.textLayerDiv = options.textLayerDiv;
-    this.eventBus = options.eventBus || domEvents.getGlobalEventBus();
+    this.eventBus = options.eventBus || getGlobalEventBus();
     this.textContent = null;
     this.renderingDone = false;
     this.pageIdx = options.pageIndex;


### PR DESCRIPTION
In PR #8203, I somehow managed to mess up the import of `getGlobalEventBus` in *all* files where it's present; my sincere apologies for this!

Fixes the breaking error in issue #8292, but there's still warnings left ~that I currently don't understand~ (*edit:* see PR #8300).