### PR TITLE
Refactor the `DownloadManager` initialization in `GENERIC`/`CHROME` builds again (PR 8203 follow-up)

### DIFF
--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -15,6 +15,7 @@
 /* globals chrome */
 
 import { DefaultExternalServices, PDFViewerApplication } from './app';
+import { DownloadManager } from './download_manager';
 import { OverlayManager } from './overlay_manager';
 import { PDFJS } from './pdfjs';
 import { Preferences } from './preferences';
@@ -340,6 +341,9 @@ ChromeExternalServices.initPassiveLoading = function (callbacks) {
       function (url, length, originalURL) {
     callbacks.onOpenWithURL(url, length, originalURL);
   });
+};
+ChromeExternalServices.createDownloadManager = function() {
+  return new DownloadManager();
 };
 PDFViewerApplication.externalServices = ChromeExternalServices;
 

--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -13,10 +13,7 @@
  * limitations under the License.
  */
 
-import {
-  createObjectURL, createValidAbsoluteUrl, PDFJS
-} from './pdfjs';
-import { DefaultExternalServices, PDFViewerApplication } from './app';
+import { createObjectURL, createValidAbsoluteUrl, PDFJS } from './pdfjs';
 
 if (typeof PDFJSDev !== 'undefined' && !PDFJSDev.test('CHROME || GENERIC')) {
   throw new Error('Module "pdfjs-web/download_manager" shall not be used ' +
@@ -100,12 +97,6 @@ DownloadManager.prototype = {
     download(blobUrl, filename);
   }
 };
-
-var GenericExternalServices = Object.create(DefaultExternalServices);
-GenericExternalServices.createDownloadManager = function () {
-  return new DownloadManager();
-};
-PDFViewerApplication.externalServices = GenericExternalServices;
 
 export {
   DownloadManager,

--- a/web/genericcom.js
+++ b/web/genericcom.js
@@ -1,0 +1,34 @@
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DefaultExternalServices, PDFViewerApplication } from './app';
+import { DownloadManager } from './download_manager';
+
+if (typeof PDFJSDev !== 'undefined' && !PDFJSDev.test('GENERIC')) {
+  throw new Error('Module "pdfjs-web/genericcom" shall not be used outside ' +
+                  'GENERIC build.');
+}
+
+var GenericCom = {};
+
+var GenericExternalServices = Object.create(DefaultExternalServices);
+GenericExternalServices.createDownloadManager = function () {
+  return new DownloadManager();
+};
+PDFViewerApplication.externalServices = GenericExternalServices;
+
+export {
+  GenericCom,
+};

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -45,12 +45,14 @@ if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
   window.FirefoxCom = require('./firefoxcom.js').FirefoxCom;
   require('./firefox_print_service.js');
 }
+if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('GENERIC')) {
+  require('./genericcom.js');
+}
 if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('CHROME')) {
   require('./chromecom.js');
 }
 if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('CHROME || GENERIC')) {
   require('./pdf_print_service.js');
-  require('./download_manager.js');
 }
 
 function getViewerConfiguration() {
@@ -172,10 +174,11 @@ function getViewerConfiguration() {
 function webViewerLoad() {
   var config = getViewerConfiguration();
   if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION')) {
-    Promise.all([SystemJS.import('pdfjs-web/app'),
-                 SystemJS.import('pdfjs-web/pdf_print_service'),
-                 SystemJS.import('pdfjs-web/download_manager')])
-           .then(function (modules) {
+    Promise.all([
+      SystemJS.import('pdfjs-web/app'),
+      SystemJS.import('pdfjs-web/genericcom'),
+      SystemJS.import('pdfjs-web/pdf_print_service'),
+    ]).then(function (modules) {
       var app = modules[0];
       window.PDFViewerApplication = app.PDFViewerApplication;
       app.PDFViewerApplication.run(config);


### PR DESCRIPTION
In the first commit in PR #8203, I changed how the `DownloadManager` was included/initialized in `GENERIC`/`CHROME` builds.
The change was prompted by the fact that you cannot have conditional `import`s with ES6 modules, and I wanted to avoid bundling the general `DownloadManager` into the various Firefox specific build targets.

What I completely missed though, is that the new code meant that `download_manager.js` will now be pulling in the *entire* viewer (through `app.js`).
This is a *really* stupid mistake on my part, since it causes the special `pdf_viewer.js` file used with the viewer components to now include basically the entire default viewer.

The simplest solution that I could come up with, is to add a `genericcom.js` file (similar to the `firefoxcom.js`/`chromecom.js` files) which will be responsible for importing/initializing the `DownloadManager`.

This *should* fix the remaining warnings in issue #8292, and also restores the viewer components specific `pdf_viewer.js` file to its intended scope/size.

*Edit:* Adding the `genericcom.js` file might seem a bit unnecessary at the moment, however I've got an idea for refactoring of `https://github.com/mozilla/pdf.js/blob/master/web/preferences.js` into a proper class and that work would leverage the new `genericcom.js` file.