### PR TITLE
Convert the `Preferences` to an ES6 class

### DIFF
--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -13,11 +13,9 @@
  * limitations under the License.
  */
 
-import {
-  createObjectURL, PDFDataRangeTransport, shadow
-} from './pdfjs';
+import { createObjectURL, PDFDataRangeTransport, shadow } from './pdfjs';
+import { BasePreferences } from './preferences';
 import { PDFViewerApplication } from './app';
-import { Preferences } from './preferences';
 
 if (typeof PDFJSDev === 'undefined' ||
     !PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
@@ -127,20 +125,22 @@ var DownloadManager = (function DownloadManagerClosure() {
   return DownloadManager;
 })();
 
-Preferences._writeToStorage = function (prefObj) {
-  return new Promise(function (resolve) {
-    FirefoxCom.request('setPreferences', prefObj, resolve);
-  });
-};
-
-Preferences._readFromStorage = function (prefObj) {
-  return new Promise(function (resolve) {
-    FirefoxCom.request('getPreferences', prefObj, function (prefStr) {
-      var readPrefs = JSON.parse(prefStr);
-      resolve(readPrefs);
+class FirefoxPreferences extends BasePreferences {
+  _writeToStorage(prefObj) {
+    return new Promise(function(resolve) {
+      FirefoxCom.request('setPreferences', prefObj, resolve);
     });
-  });
-};
+  }
+
+  _readFromStorage(prefObj) {
+    return new Promise(function(resolve) {
+      FirefoxCom.request('getPreferences', prefObj, function (prefStr) {
+        var readPrefs = JSON.parse(prefStr);
+        resolve(readPrefs);
+      });
+    });
+  }
+}
 
 (function listenFindEvents() {
   var events = [
@@ -245,6 +245,10 @@ PDFViewerApplication.externalServices = {
 
   createDownloadManager: function () {
     return new DownloadManager();
+  },
+
+  createPreferences() {
+    return new FirefoxPreferences();
   },
 
   get supportsIntegratedFind() {

--- a/web/genericcom.js
+++ b/web/genericcom.js
@@ -14,6 +14,7 @@
  */
 
 import { DefaultExternalServices, PDFViewerApplication } from './app';
+import { BasePreferences } from './preferences';
 import { DownloadManager } from './download_manager';
 
 if (typeof PDFJSDev !== 'undefined' && !PDFJSDev.test('GENERIC')) {
@@ -23,9 +24,28 @@ if (typeof PDFJSDev !== 'undefined' && !PDFJSDev.test('GENERIC')) {
 
 var GenericCom = {};
 
+class GenericPreferences extends BasePreferences {
+  _writeToStorage(prefObj) {
+    return new Promise(function(resolve) {
+      localStorage.setItem('pdfjs.preferences', JSON.stringify(prefObj));
+      resolve();
+    });
+  }
+
+  _readFromStorage(prefObj) {
+    return new Promise(function(resolve) {
+      var readPrefs = JSON.parse(localStorage.getItem('pdfjs.preferences'));
+      resolve(readPrefs);
+    });
+  }
+}
+
 var GenericExternalServices = Object.create(DefaultExternalServices);
-GenericExternalServices.createDownloadManager = function () {
+GenericExternalServices.createDownloadManager = function() {
   return new DownloadManager();
+};
+GenericExternalServices.createPreferences = function() {
+  return new GenericPreferences();
 };
 PDFViewerApplication.externalServices = GenericExternalServices;
 

--- a/web/hand_tool.js
+++ b/web/hand_tool.js
@@ -15,7 +15,6 @@
 
 import { GrabToPan } from './grab_to_pan';
 import { localized } from './ui_utils';
-import { Preferences } from './preferences';
 
 /**
  * @typedef {Object} HandToolOptions
@@ -34,6 +33,7 @@ var HandTool = (function HandToolClosure() {
   function HandTool(options) {
     this.container = options.container;
     this.eventBus = options.eventBus;
+    var preferences = options.preferences;
 
     this.wasActive = false;
 
@@ -46,12 +46,12 @@ var HandTool = (function HandToolClosure() {
 
     this.eventBus.on('togglehandtool', this.toggle.bind(this));
 
-    Promise.all([localized, Preferences.get('enableHandToolOnLoad')]).then(
-      function resolved(values) {
-        if (values[1] === true) {
-          this.handTool.activate();
-        }
-      }.bind(this)).catch(function rejected(reason) { });
+    Promise.all([localized,
+                 preferences.get('enableHandToolOnLoad')]).then((values) => {
+      if (values[1] === true) {
+        this.handTool.activate();
+      }
+    }).catch(function rejected(reason) { });
 
     this.eventBus.on('presentationmodechanged', function (e) {
       if (e.switchInProgress) {


### PR DESCRIPTION
Please note that the new `BasePreferences` is an abstract class, and is explicitly *not* usable on its own, which is then sub-classed for the various build targets.

*Slightly smaller diff with https://github.com/mozilla/pdf.js/pull/8303/files?w=1.*