### PR TITLE
[Firefox addon] Upstream changes from: Bug 1356569 - Remove optional trailing parameters (issue 8310)

### DIFF
--- a/extensions/firefox/content/PdfJs.jsm
+++ b/extensions/firefox/content/PdfJs.jsm
@@ -162,11 +162,11 @@ var PdfJs = {
 
     // Listen for when pdf.js is completely disabled or a different pdf handler
     // is chosen.
-    Services.prefs.addObserver(PREF_DISABLED, this, false);
-    Services.prefs.addObserver(PREF_DISABLED_PLUGIN_TYPES, this, false);
-    Services.obs.addObserver(this, TOPIC_PDFJS_HANDLER_CHANGED, false);
-    Services.obs.addObserver(this, TOPIC_PLUGINS_LIST_UPDATED, false);
-    Services.obs.addObserver(this, TOPIC_PLUGIN_INFO_UPDATED, false);
+    Services.prefs.addObserver(PREF_DISABLED, this);
+    Services.prefs.addObserver(PREF_DISABLED_PLUGIN_TYPES, this);
+    Services.obs.addObserver(this, TOPIC_PDFJS_HANDLER_CHANGED);
+    Services.obs.addObserver(this, TOPIC_PLUGINS_LIST_UPDATED);
+    Services.obs.addObserver(this, TOPIC_PLUGIN_INFO_UPDATED);
 
     initializeDefaultPreferences();
   },

--- a/extensions/firefox/content/PdfjsChromeUtils.jsm
+++ b/extensions/firefox/content/PdfjsChromeUtils.jsm
@@ -73,8 +73,19 @@ var PdfjsChromeUtils = {
       this._mmg.addMessageListener("PDFJS:Parent:removeEventListener", this);
       this._mmg.addMessageListener("PDFJS:Parent:updateControlState", this);
 
-      // observer to handle shutdown
-      Services.obs.addObserver(this, "quit-application", false);
+//#if !MOZCENTRAL
+      // The signature of `Services.obs.addObserver` changed in Firefox 55,
+      // see https://bugzilla.mozilla.org/show_bug.cgi?id=1355216.
+      // PLEASE NOTE: While the third parameter is now optional,
+      // omitting it in prior Firefox versions breaks the addon.
+      var ffVersion = parseInt(Services.appinfo.platformVersion);
+      if (ffVersion <= 55) {
+        Services.obs.addObserver(this, "quit-application", false);
+        return;
+      }
+//#endif
+      // Observer to handle shutdown.
+      Services.obs.addObserver(this, "quit-application");
     }
   },
 

--- a/extensions/firefox/content/PdfjsContentUtils.jsm
+++ b/extensions/firefox/content/PdfjsContentUtils.jsm
@@ -45,7 +45,19 @@ var PdfjsContentUtils = {
       this._mm = Cc["@mozilla.org/childprocessmessagemanager;1"].
         getService(Ci.nsISyncMessageSender);
       this._mm.addMessageListener("PDFJS:Child:refreshSettings", this);
-      Services.obs.addObserver(this, "quit-application", false);
+
+//#if !MOZCENTRAL
+      // The signature of `Services.obs.addObserver` changed in Firefox 55,
+      // see https://bugzilla.mozilla.org/show_bug.cgi?id=1355216.
+      // PLEASE NOTE: While the third parameter is now optional,
+      // omitting it in prior Firefox versions breaks the addon.
+      var ffVersion = parseInt(Services.appinfo.platformVersion);
+      if (ffVersion <= 55) {
+        Services.obs.addObserver(this, "quit-application", false);
+        return;
+      }
+//#endif
+      Services.obs.addObserver(this, "quit-application");
     }
   },
 


### PR DESCRIPTION
In https://bugzilla.mozilla.org/show_bug.cgi?id=1355216, the *third* parameter of `Services.obs.addObserver` was made optional.
However, omitting it in Firefox versions *without* that patch causes failures that completely prevents the addon from working (it won't even load).

As far as I can tell, there isn't *any* way to detect ahead of time if the third parameter can be safely omitted, hence we're forced to fallback to manually checking the version number :-(

*Note:* Since the `PdfJs.jsm` file is only used in the `MOZCENTRAL` build, we at least don't need to add any compatibility hacks there.

Fixes #8310.