### PR TITLE
[Firefox addon] Upstream changes from: Bug 1346616 - Migrate callsites that are retrieving requested locale from pref, to use LocaleService::GetRequestedLocales

### DIFF
--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -319,7 +319,12 @@ class ChromeActions {
   }
 
   getLocale() {
-    return getStringPref("general.useragent.locale", "en-US");
+//#if !MOZCENTRAL
+    if (!Services.locale.getRequestedLocale) {
+      return getStringPref("general.useragent.locale", "en-US");
+    }
+//#endif
+    return Services.locale.getRequestedLocale() || "en-US";
   }
 
   getStrings(data) {


### PR DESCRIPTION
With [bug 1346616](https://bugzilla.mozilla.org/show_bug.cgi?id=1346616) and [this commit](https://hg.mozilla.org/mozilla-central/rev/39a903b099a6#l7.2), it's apparently no longer recommended to check the `general.useragent.locale` pref directly, but instead the `Services.locale.getRequestedLocale()` function should be used.

In this case, it's at least really easy to feature detect this properly :-)

*Edit:* See also https://groups.google.com/forum/#!topic/mozilla.dev.platform/DAxXcr1rh2c.