### PR TITLE
[Firefox addon] Remove the `window.FirefoxCom` hack from `web/viewer.js`, since it was made redunant by the `setExternalLocalizerServices` refactoring (PR 7202 follow-up)

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -41,8 +41,7 @@ if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('PRODUCTION')) {
 }
 
 if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
-  // FIXME the l10n.js file in the Firefox extension needs global FirefoxCom.
-  window.FirefoxCom = require('./firefoxcom.js').FirefoxCom;
+  require('./firefoxcom.js');
   require('./firefox_print_service.js');
 }
 if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('GENERIC')) {


### PR DESCRIPTION
After PR #7202, there are no remaining references to `FirefoxCom` in the `/extensions/firefox/tools/l10n.js` file.