### PR TITLE
Change the `importl10n` script to use the Beta channel, since Aurora is being removed

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,7 +8,7 @@ The issue tracking system is designed to record a single technical problem. A bu
 
 If you are developing a custom solution, first check the examples at https://github.com/mozilla/pdf.js#learning and search existing issues. If this does not help, please prepare a short well-documented example that demonstrates the problem and make it accessible online on your website, JS Bin, GitHub, etc. before opening a new issue or contacting us on the IRC channel -- keep in mind that just code snippets won't help us troubleshoot the problem.
 
-Note that the translations for PDF.js in the `l10n` folder are synchronized with the Aurora branch of Mozilla Firefox. This means that we will only accept pull requests that add strings currently missing in the Aurora branch (because it will take at least six weeks before the most recent translations are in the Aurora branch), but keep in mind that the changes will be overwritten when we synchronize again.
+Note that the translations for PDF.js in the `l10n` folder are synchronized with the Beta branch of Mozilla Firefox. This means that we will only accept pull requests that add strings currently missing in the Beta branch (because it will take at least six weeks before the most recent translations are in the Beta branch), but keep in mind that the changes will be overwritten when we synchronize again.
 
 See also:
 - https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions

--- a/external/importL10n/locales.js
+++ b/external/importL10n/locales.js
@@ -19,7 +19,7 @@ var fs = require('fs');
 var https = require('https');
 var path = require('path');
 
-// Defines all languages that have a translation at mozilla-aurora.
+// Defines all languages that have a translation at mozilla-beta.
 // This is used in make.js for the importl10n command.
 var langCodes = [
   'ach', 'af', 'ak', 'an', 'ar', 'as', 'ast', 'az', 'be', 'bg',
@@ -44,10 +44,10 @@ function downloadLanguageFiles(root, langCode, callback) {
   console.log('Downloading ' + langCode + '...');
 
   // Constants for constructing the URLs. Translations are taken from the
-  // Aurora channel as those are the most recent ones. The Nightly channel
+  // Beta channel as those are the most recent ones. The Nightly channel
   // does not provide all translations.
-  var MOZ_AURORA_ROOT = 'https://hg.mozilla.org/releases/l10n/mozilla-aurora/';
-  var MOZ_AURORA_PDFJS_DIR = '/raw-file/tip/browser/pdfviewer/';
+  var MOZ_BETA_ROOT = 'https://hg.mozilla.org/releases/l10n/mozilla-beta/';
+  var MOZ_BETA_PDFJS_DIR = '/raw-file/tip/browser/pdfviewer/';
 
   // Defines which files to download for each language.
   var files = ['chrome.properties', 'viewer.properties'];
@@ -61,7 +61,7 @@ function downloadLanguageFiles(root, langCode, callback) {
   // Download the necessary files for this language.
   files.forEach(function(fileName) {
     var outputPath = path.join(outputDir, fileName);
-    var url = MOZ_AURORA_ROOT + langCode + MOZ_AURORA_PDFJS_DIR + fileName;
+    var url = MOZ_BETA_ROOT + langCode + MOZ_BETA_PDFJS_DIR + fileName;
 
     https.get(url, function(response) {
       var content = '';

--- a/l10n/az/viewer.properties
+++ b/l10n/az/viewer.properties
@@ -101,6 +101,7 @@ print_progress_close=Ləğv et
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Yan Paneli Aç/Bağla
+toggle_sidebar_notification.title=Yan paneli çevir (sənəddə icmal/bağlama var)
 toggle_sidebar_label=Yan Paneli Aç/Bağla
 document_outline.title=Sənədin eskizini göstər (bütün bəndləri açmaq/yığmaq üçün iki dəfə klikləyin)
 document_outline_label=Sənəd strukturu

--- a/l10n/da/viewer.properties
+++ b/l10n/da/viewer.properties
@@ -101,9 +101,10 @@ print_progress_close=Annuller
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Slå sidepanel til eller fra
+toggle_sidebar_notification.title=Slå sidepanel til eller fra (dokumentet indeholder disposition/vedhæftede filer)
 toggle_sidebar_label=Slå sidepanel til eller fra
 document_outline.title=Vis dokumentets disposition (dobbeltklik for at vise/skjule alle elementer)
-document_outline_label=Dokument-dosposition
+document_outline_label=Dokument-disposition
 attachments.title=Vis vedhæftede filer
 attachments_label=Vedhæftede filer
 thumbs.title=Vis miniaturer

--- a/l10n/de/viewer.properties
+++ b/l10n/de/viewer.properties
@@ -101,6 +101,7 @@ print_progress_close=Abbrechen
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Sidebar umschalten
+toggle_sidebar_notification.title=Sidebar umschalten (Dokument enthält Dokumentstruktur/Anhänge)
 toggle_sidebar_label=Sidebar umschalten
 document_outline.title=Dokumentstruktur anzeigen (Doppelklicken, um alle Einträge aus- bzw. einzuklappen)
 document_outline_label=Dokumentstruktur

--- a/l10n/en-GB/viewer.properties
+++ b/l10n/en-GB/viewer.properties
@@ -19,11 +19,14 @@ next.title=Next Page
 next_label=Next
 
 # LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Page
 # LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
 # representing the total number of pages in the document.
+of_pages=of {{pagesCount}}
 # LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
 # will be replaced by a number representing the currently visible page,
 # respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} of {{pagesCount}})
 
 zoom_out.title=Zoom Out
 zoom_out_label=Zoom Out
@@ -88,14 +91,19 @@ document_properties_version=PDF Version:
 document_properties_page_count=Page Count:
 document_properties_close=Close
 
+print_progress_message=Preparing document for printing…
 # LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
 # a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Cancel
 
 # Tooltips and alt text for side panel toolbar buttons
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Toggle Sidebar
 toggle_sidebar_label=Toggle Sidebar
+document_outline.title=Show Document Outline (double-click to expand/collapse all items)
+document_outline_label=Document Outline
 attachments.title=Show Attachments
 attachments_label=Attachments
 thumbs.title=Show Thumbnails
@@ -171,4 +179,4 @@ password_cancel=Cancel
 printing_not_supported=Warning: Printing is not fully supported by this browser.
 printing_not_ready=Warning: The PDF is not fully loaded for printing.
 web_fonts_disabled=Web fonts are disabled: unable to use embedded PDF fonts.
-document_colors_not_allowed=PDF documents are not allowed to use their own colours: 'Allow pages to choose their own colours' is deactivated in the browser.
+document_colors_not_allowed=PDF documents are not allowed to use their own colours: “Allow pages to choose their own colours” is deactivated in the browser.

--- a/l10n/es-AR/viewer.properties
+++ b/l10n/es-AR/viewer.properties
@@ -101,6 +101,7 @@ print_progress_close=Cancelar
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Alternar barra lateral
+toggle_sidebar_notification.title=Intercambiar barra lateral (el documento contiene esquema/adjuntos)
 toggle_sidebar_label=Alternar barra lateral
 document_outline.title=Mostrar esquema del documento (doble clic para expandir/colapsar todos los ítems)
 document_outline_label=Esquema del documento

--- a/l10n/fa/viewer.properties
+++ b/l10n/fa/viewer.properties
@@ -101,6 +101,7 @@ print_progress_close=لغو
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=باز و بسته کردن نوار کناری
+toggle_sidebar_notification.title=تغییر وضعیت نوار کناری (سند حاوی طرح/پیوست است)
 toggle_sidebar_label=تغییرحالت نوارکناری
 document_outline.title=نمایش رئوس مطالب مدارک(برای بازشدن/جمع شدن همه موارد دوبار کلیک کنید)
 document_outline_label=طرح نوشتار

--- a/l10n/hu/viewer.properties
+++ b/l10n/hu/viewer.properties
@@ -101,6 +101,7 @@ print_progress_close=Mégse
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Oldalsáv be/ki
+toggle_sidebar_notification.title=Oldalsáv be/ki (a dokumentum vázlatot/mellékleteket tartalmaz)
 toggle_sidebar_label=Oldalsáv be/ki
 document_outline.title=Dokumentum megjelenítése online (dupla kattintás minden elem kinyitásához/összecsukásához)
 document_outline_label=Dokumentumvázlat

--- a/l10n/ko/viewer.properties
+++ b/l10n/ko/viewer.properties
@@ -101,6 +101,7 @@ print_progress_close=취소
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=탐색창 열고 닫기
+toggle_sidebar_notification.title=탐색창 열고 닫기 (문서에 아웃라인이나 첨부파일이 들어있음)
 toggle_sidebar_label=탐색창 열고 닫기
 document_outline.title=문서 아웃라인 보기(더블 클릭해서 모든 항목 열고 닫기)
 document_outline_label=문서 아웃라인

--- a/l10n/lv/viewer.properties
+++ b/l10n/lv/viewer.properties
@@ -22,7 +22,7 @@ next_label=Nākamā
 page.title=Lapa
 # LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
 # representing the total number of pages in the document.
-of_pages=no {{pageCount}}
+of_pages=no {{pagesCount}}
 # LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
 # will be replaced by a number representing the currently visible page,
 # respectively a number representing the total number of pages in the document.

--- a/l10n/pa-IN/viewer.properties
+++ b/l10n/pa-IN/viewer.properties
@@ -19,11 +19,14 @@ next.title=ਸਫ਼ਾ ਅੱਗੇ
 next_label=ਅੱਗੇ
 
 # LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Page
 # LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
 # representing the total number of pages in the document.
+of_pages=of {{pagesCount}}
 # LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
 # will be replaced by a number representing the currently visible page,
 # respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} of {{pagesCount}})
 
 zoom_out.title=ਜ਼ੂਮ ਆਉਟ
 zoom_out_label=ਜ਼ੂਮ ਆਉਟ
@@ -88,14 +91,21 @@ document_properties_version=PDF ਵਰਜਨ:
 document_properties_page_count=ਸਫ਼ੇ ਦੀ ਗਿਣਤੀ:
 document_properties_close=ਬੰਦ ਕਰੋ
 
+
+print_progress_message=Preparing document for printing…
 # LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
 # a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Cancel
 
 # Tooltips and alt text for side panel toolbar buttons
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=ਬਾਹੀ ਬਦਲੋ
+toggle_sidebar_notification.title=Toggle Sidebar (document contains outline/attachments)
 toggle_sidebar_label=ਬਾਹੀ ਬਦਲੋ
+document_outline.title=Show Document Outline (double-click to expand/collapse all items)
+document_outline_label=Document Outline
 attachments.title=ਅਟੈਚਮੈਂਟ ਨੂੰ ਵੇਖਾਓ
 attachments_label=ਅਟੈਚਮੈਂਟ
 thumbs.title=ਥੰਮਨੇਲ ਨੂੰ ਵੇਖਾਓ

--- a/l10n/sl/viewer.properties
+++ b/l10n/sl/viewer.properties
@@ -101,6 +101,7 @@ print_progress_close=Prekliči
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Preklopi stransko vrstico
+toggle_sidebar_notification.title=Preklopi stransko vrstico (dokument vsebuje oris/priponke)
 toggle_sidebar_label=Preklopi stransko vrstico
 document_outline.title=Prikaži oris dokumenta (dvokliknite za razširitev/strnitev vseh predmetov)
 document_outline_label=Oris dokumenta

--- a/l10n/xh/viewer.properties
+++ b/l10n/xh/viewer.properties
@@ -101,6 +101,7 @@ print_progress_close=Rhoxisa
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Togola ngebha eseCaleni
+toggle_sidebar_notification.title=ISidebar yeQhosha (uxwebhu lunolwandlalo/iziqhotyoshelwa)
 toggle_sidebar_label=Togola ngebha eseCaleni
 document_outline.title=Bonisa uLwandlalo loXwebhu (cofa kabini ukuze wandise/diliza zonke izinto)
 document_outline_label=Isishwankathelo soxwebhu


### PR DESCRIPTION
Since the Aurora channel is being removed, and is no longer going to be receiving updates (with the possible exception of security bugs), we need to change the target for the `gulp importl10n` command.

For more information, please refer to:
 - https://groups.google.com/forum/#!topic/firefox-dev/q4Eb5nEcfSg
 - https://hacks.mozilla.org/2017/04/simplifying-firefox-release-channels/
 - https://mozilla.github.io/process-releases/draft/development_overview/
 - http://release.mozilla.org/firefox/release/2017/04/17/Dawn-Project-FAQ.html