### PR TITLE
Enable running the `ui_utils` unit-tests on Travis

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -77,6 +77,7 @@ var DEFINES = {
   MINIFIED: false,
   SINGLE_FILE: false,
   COMPONENTS: false,
+  LIB: false,
   PDFJS_NEXT: false,
 };
 
@@ -998,6 +999,7 @@ gulp.task('lib', ['buildnumber'], function () {
     saveComments: false,
     defines: builder.merge(DEFINES, {
       GENERIC: true,
+      LIB: true,
       BUNDLE_VERSION: versionInfo.version,
       BUNDLE_BUILD: versionInfo.commit
     })

--- a/test/unit/clitests.json
+++ b/test/unit/clitests.json
@@ -16,6 +16,7 @@
     "primitives_spec.js",
     "stream_spec.js",
     "type1_parser_spec.js",
+    "ui_utils_spec.js",
     "unicode_spec.js",
     "util_spec.js"
   ]

--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -31,6 +31,7 @@ var binarySearchFirstItem = webUiUtils.binarySearchFirstItem;
 var getPDFFileNameFromURL = webUiUtils.getPDFFileNameFromURL;
 var EventBus = webUiUtils.EventBus;
 var createObjectURL = sharedUtil.createObjectURL;
+var isNodeJS = sharedUtil.isNodeJS;
 
 describe('ui_utils', function() {
   describe('binary search', function() {
@@ -160,6 +161,9 @@ describe('ui_utils', function() {
 
     it('gets PDF filename from query string appended to "blob:" URL',
         function() {
+      if (isNodeJS()) {
+        pending('Blob in not supported in Node.js.');
+      }
       var typedArray = new Uint8Array([1, 2, 3, 4, 5]);
       var blobUrl = createObjectURL(typedArray, 'application/pdf');
       // Sanity check to ensure that a "blob:" URL was returned.

--- a/web/pdfjs.js
+++ b/web/pdfjs.js
@@ -23,7 +23,11 @@ if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('PRODUCTION')) {
     if (typeof window !== 'undefined' && window['pdfjs-dist/build/pdf']) {
       pdfjsLib = window['pdfjs-dist/build/pdf'];
     } else if (typeof require === 'function') {
-      pdfjsLib = require('../build/pdf.js');
+      if (PDFJSDev.test('LIB')) {
+        pdfjsLib = require('../pdf.js');
+      } else {
+        pdfjsLib = require('../build/pdf.js');
+      }
     } else {
       throw new Error('Neither `require` nor `window` found');
     }

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -30,7 +30,8 @@ var RendererType = {
   SVG: 'svg',
 };
 
-var mozL10n = document.mozL10n || document.webL10n;
+var mozL10n = typeof document !== 'undefined' ?
+  (document.mozL10n || document.webL10n) : undefined;
 
 /**
  * Disables fullscreen support, and by extension Presentation Mode,
@@ -81,8 +82,9 @@ if (typeof PDFJSDev === 'undefined' ||
    * Interface locale settings.
    * @var {string}
    */
-  PDFJS.locale = (PDFJS.locale === undefined ? navigator.language :
-                  PDFJS.locale);
+  PDFJS.locale =
+    (PDFJS.locale === undefined && typeof navigator !== 'undefined' ?
+     navigator.language : PDFJS.locale);
 }
 
 /**


### PR DESCRIPTION
With the exception of just one test-case, all the current `ui_utils` unit-tests can run successfully on Node.js (since most of them doesn't rely on the DOM).

To get this working, I had to first of all add a new `LIB` build flag such that `gulp lib` produces a `web/pdfjs.js` file that is able to load `pdf.js` successfully.
Second of all, since neither `document` nor `navigator` is available in Node.js, `web/ui_utils.js` was adjusted slightly to avoid errors.