### PR TITLE
Enable the `object-shorthand` ESLint rule in `src/shared` and `src/display`

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -237,8 +237,8 @@ var AnnotationElement = (function AnnotationElementClosure() {
       }
 
       var popupElement = new PopupElement({
-        container: container,
-        trigger: trigger,
+        container,
+        trigger,
         color: data.color,
         title: data.title,
         contents: data.contents,
@@ -1154,7 +1154,7 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
           continue;
         }
         var element = annotationElementFactory.create({
-          data: data,
+          data,
           layer: parameters.div,
           page: parameters.page,
           viewport: parameters.viewport,

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -182,7 +182,7 @@ var CachedCanvases = (function CachedCanvasesClosure() {
       }
       return canvasEntry;
     },
-    clear: function () {
+    clear() {
       for (var id in this.cache) {
         var canvasEntry = this.cache[id];
         this.canvasFactory.destroy(canvasEntry);
@@ -688,7 +688,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     var backdrop = smask.backdrop || null;
     if (!smask.transferMap && WebGLUtils.isEnabled) {
       var composed = WebGLUtils.composeSMask(layerCtx.canvas, mask,
-        {subtype: smask.subtype, backdrop: backdrop});
+        { subtype: smask.subtype, backdrop, });
       ctx.setTransform(1, 0, 0, 1, 0, 0);
       ctx.drawImage(composed, smask.offsetX, smask.offsetY);
       return;
@@ -1376,10 +1376,10 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         var paths = this.pendingTextPaths || (this.pendingTextPaths = []);
         paths.push({
           transform: ctx.mozCurrentTransform,
-          x: x,
-          y: y,
-          fontSize: fontSize,
-          addToPath: addToPath
+          x,
+          y,
+          fontSize,
+          addToPath,
         });
       }
     },
@@ -1630,11 +1630,10 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         var color = IR[1];
         var baseTransform = this.baseTransform ||
                             this.ctx.mozCurrentTransform.slice();
-        var self = this;
         var canvasGraphicsFactory = {
-          createCanvasGraphics: function (ctx) {
-            return new CanvasGraphics(ctx, self.commonObjs, self.objs,
-                                      self.canvasFactory);
+          createCanvasGraphics: (ctx) => {
+            return new CanvasGraphics(ctx, this.commonObjs, this.objs,
+                                      this.canvasFactory);
           }
         };
         pattern = new TilingPattern(IR, color, this.ctx, canvasGraphicsFactory,
@@ -1812,10 +1811,10 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         this.smaskStack.push({
           canvas: scratchCanvas.canvas,
           context: groupCtx,
-          offsetX: offsetX,
-          offsetY: offsetY,
-          scaleX: scaleX,
-          scaleY: scaleY,
+          offsetX,
+          offsetY,
+          scaleX,
+          scaleY,
           subtype: group.smask.subtype,
           backdrop: group.smask.backdrop,
           transferMap: group.smask.transferMap || null,
@@ -1915,7 +1914,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         var currentTransform = ctx.mozCurrentTransformInverse;
         var position = this.getCanvasPosition(0, 0);
         this.imageLayer.appendImage({
-          objId: objId,
+          objId,
           left: position[0],
           top: position[1],
           width: w / currentTransform[0],
@@ -1936,7 +1935,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       if (COMPILE_TYPE3_GLYPHS && glyph && glyph.compiled === undefined) {
         if (width <= MAX_SIZE_TO_COMPILE && height <= MAX_SIZE_TO_COMPILE) {
           glyph.compiled =
-            compileType3Glyph({data: img.data, width: width, height: height});
+            compileType3Glyph({ data: img.data, width, height, });
         } else {
           glyph.compiled = null;
         }
@@ -2123,7 +2122,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       if (this.imageLayer) {
         var position = this.getCanvasPosition(0, -height);
         this.imageLayer.appendImage({
-          imgData: imgData,
+          imgData,
           left: position[0],
           top: position[1],
           width: width / currentTransform[0],
@@ -2153,7 +2152,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         if (this.imageLayer) {
           var position = this.getCanvasPosition(entry.x, entry.y);
           this.imageLayer.appendImage({
-            imgData: imgData,
+            imgData,
             left: position[0],
             top: position[1],
             width: w,

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -29,8 +29,8 @@ DOMCanvasFactory.prototype = {
     canvas.width = width;
     canvas.height = height;
     return {
-      canvas: canvas,
-      context: context,
+      canvas,
+      context,
     };
   },
 
@@ -59,7 +59,7 @@ var DOMCMapReaderFactory = (function DOMCMapReaderFactoryClosure() {
   }
 
   DOMCMapReaderFactory.prototype = {
-    fetch: function(params) {
+    fetch(params) {
       var name = params.name;
       if (!name) {
         return Promise.reject(new Error('CMap name must be specified.'));

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -87,7 +87,7 @@ if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL')) {
       'ABAAAAAAAAAAAD6AAAAAAAAA==');
   };
   Object.defineProperty(FontLoader.prototype, 'loadTestFont', {
-    get: function () {
+    get() {
       return shadow(this, 'loadTestFont', getLoadTestFont());
     },
     configurable: true
@@ -170,7 +170,7 @@ if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL')) {
     var request = {
       id: requestId,
       complete: LoadLoader_completeRequest,
-      callback: callback,
+      callback,
       started: Date.now()
     };
     context.requests.push(request);
@@ -320,7 +320,7 @@ if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL || CHROME')) {
     return supported;
   };
   Object.defineProperty(FontLoader, 'isSyncFontLoadingSupported', {
-    get: function () {
+    get() {
       return shadow(FontLoader, 'isSyncFontLoadingSupported',
                     isSyncFontLoadingSupported());
     },

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -55,10 +55,10 @@ if (PDFJS.verbosity !== undefined) {
 }
 delete PDFJS.verbosity;
 Object.defineProperty(PDFJS, 'verbosity', {
-  get: function () {
+  get() {
     return getVerbosityLevel();
   },
-  set: function (level) {
+  set(level) {
     setVerbosityLevel(level);
   },
   enumerable: true,
@@ -250,10 +250,10 @@ if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL')) {
   var savedOpenExternalLinksInNewWindow = PDFJS.openExternalLinksInNewWindow;
   delete PDFJS.openExternalLinksInNewWindow;
   Object.defineProperty(PDFJS, 'openExternalLinksInNewWindow', {
-    get: function () {
+    get() {
       return PDFJS.externalLinkTarget === LinkTarget.BLANK;
     },
-    set: function (value) {
+    set(value) {
       if (value) {
         deprecated('PDFJS.openExternalLinksInNewWindow, please use ' +
           '"PDFJS.externalLinkTarget = PDFJS.LinkTarget.BLANK" instead.');

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -169,8 +169,8 @@ var createMeshCanvas = (function createMeshCanvasClosure() {
     var scaleY = boundsHeight / height;
 
     var context = {
-      coords: coords,
-      colors: colors,
+      coords,
+      colors,
       offsetX: -offsetX,
       offsetY: -offsetY,
       scaleX: 1 / scaleX,
@@ -212,10 +212,13 @@ var createMeshCanvas = (function createMeshCanvasClosure() {
       canvas = tmpCanvas.canvas;
     }
 
-    return {canvas: canvas,
-            offsetX: offsetX - BORDER_SIZE * scaleX,
-            offsetY: offsetY - BORDER_SIZE * scaleY,
-            scaleX: scaleX, scaleY: scaleY};
+    return {
+      canvas,
+      offsetX: offsetX - BORDER_SIZE * scaleX,
+      offsetY: offsetY - BORDER_SIZE * scaleY,
+      scaleX,
+      scaleY,
+    };
   }
   return createMeshCanvas;
 })();

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -148,7 +148,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
         bottom: b[3],
         div: textDiv,
         size: [divWidth, divHeight],
-        m: m
+        m,
       });
     }
   }

--- a/src/display/webgl.js
+++ b/src/display/webgl.js
@@ -430,8 +430,8 @@ var WebGLUtils = (function WebGLUtilsClosure() {
       } catch (e) { }
       return shadow(this, 'isEnabled', enabled);
     },
-    composeSMask: composeSMask,
-    drawFigures: drawFigures,
+    composeSMask,
+    drawFigures,
     clear: cleanup
   };
 })();

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -105,12 +105,12 @@ PDFJS.compatibilityChecked = true;
   var uint32ArrayViewSetters = 0;
   function createUint32ArrayProp(index) {
     return {
-      get: function () {
+      get() {
         var buffer = this.buffer, offset = index << 2;
         return (buffer[offset] | (buffer[offset + 1] << 8) |
           (buffer[offset + 2] << 16) | (buffer[offset + 3] << 24)) >>> 0;
       },
-      set: function (value) {
+      set(value) {
         var buffer = this.buffer, offset = index << 2;
         buffer[offset] = value & 255;
         buffer[offset + 1] = (value >> 8) & 255;
@@ -190,14 +190,14 @@ PDFJS.compatibilityChecked = true;
   }
   // Trying to fake CanvasPixelArray as Uint8ClampedArray.
   Object.defineProperty(cpaProto, 'buffer', {
-    get: function () {
+    get() {
       return this;
     },
     enumerable: false,
     configurable: true
   });
   Object.defineProperty(cpaProto, 'byteLength', {
-    get: function () {
+    get() {
       return this.length;
     },
     enumerable: false,
@@ -411,7 +411,7 @@ PDFJS.compatibilityChecked = true;
   }
 
   Object.defineProperty(HTMLElement.prototype, 'dataset', {
-    get: function() {
+    get() {
       if (this._dataset) {
         return this._dataset;
       }
@@ -470,22 +470,22 @@ PDFJS.compatibilityChecked = true;
   }
 
   var classListPrototype = {
-    add: function(name) {
+    add(name) {
       changeList(this.element, name, true, false);
     },
-    contains: function(name) {
+    contains(name) {
       return changeList(this.element, name, false, false);
     },
-    remove: function(name) {
+    remove(name) {
       changeList(this.element, name, false, true);
     },
-    toggle: function(name) {
+    toggle(name) {
       changeList(this.element, name, true, true);
     }
   };
 
   Object.defineProperty(HTMLElement.prototype, 'classList', {
-    get: function() {
+    get() {
       if (this._classList) {
         return this._classList;
       }
@@ -562,9 +562,9 @@ PDFJS.compatibilityChecked = true;
   }
   if (!('console' in window)) {
     window.console = {
-      log: function() {},
-      error: function() {},
-      warn: function() {}
+      log() {},
+      error() {},
+      warn() {}
     };
     return;
   }
@@ -772,7 +772,7 @@ PDFJS.compatibilityChecked = true;
     return;
   }
   Object.defineProperty(document, 'currentScript', {
-    get: function () {
+    get() {
       var scripts = document.getElementsByTagName('script');
       return scripts[scripts.length - 1];
     },
@@ -794,10 +794,10 @@ PDFJS.compatibilityChecked = true;
     var inputProto = el.constructor.prototype;
     var typeProperty = Object.getOwnPropertyDescriptor(inputProto, 'type');
     Object.defineProperty(inputProto, 'type', {
-      get: function () {
+      get() {
         return typeProperty.get.call(this);
       },
-      set: function (value) {
+      set(value) {
         typeProperty.set.call(this, value === 'number' ? 'text' : value);
       },
       enumerable: true,
@@ -819,11 +819,11 @@ PDFJS.compatibilityChecked = true;
   var readyStateProto = Object.getOwnPropertyDescriptor(documentProto,
                                                         'readyState');
   Object.defineProperty(documentProto, 'readyState', {
-    get: function () {
+    get() {
       var value = readyStateProto.get.call(this);
       return value === 'interactive' ? 'loading' : value;
     },
-    set: function (value) {
+    set(value) {
       readyStateProto.set.call(this, value);
     },
     enumerable: true,
@@ -979,7 +979,7 @@ PDFJS.compatibilityChecked = true;
 
     addUnhandledRejection: function addUnhandledRejection(promise) {
       this.unhandledRejections.push({
-        promise: promise,
+        promise,
         time: Date.now()
       });
       this.scheduleRejectionCheck();
@@ -1160,9 +1160,9 @@ PDFJS.compatibilityChecked = true;
       });
       this._handlers.push({
         thisPromise: this,
-        onResolve: onResolve,
-        onReject: onReject,
-        nextPromise: nextPromise
+        onResolve,
+        onReject,
+        nextPromise,
       });
       HandlerManager.scheduleHandlers(this);
       return nextPromise;
@@ -1186,20 +1186,20 @@ PDFJS.compatibilityChecked = true;
     this.id = '$weakmap' + (id++);
   }
   WeakMap.prototype = {
-    has: function(obj) {
+    has(obj) {
       return !!Object.getOwnPropertyDescriptor(obj, this.id);
     },
-    get: function(obj, defaultValue) {
+    get(obj, defaultValue) {
       return this.has(obj) ? obj[this.id] : defaultValue;
     },
-    set: function(obj, value) {
+    set(obj, value) {
       Object.defineProperty(obj, this.id, {
-        value: value,
+        value,
         enumerable: false,
         configurable: true
       });
     },
-    delete: function(obj) {
+    delete(obj) {
       delete obj[this.id];
     }
   };
@@ -1703,7 +1703,7 @@ PDFJS.compatibilityChecked = true;
   }
 
   JURL.prototype = {
-    toString: function() {
+    toString() {
       return this.href;
     },
     get href() {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -376,7 +376,7 @@ function createValidAbsoluteUrl(url, baseUrl) {
 }
 
 function shadow(obj, prop, value) {
-  Object.defineProperty(obj, prop, { value: value,
+  Object.defineProperty(obj, prop, { value,
                                      enumerable: true,
                                      configurable: true,
                                      writable: false });
@@ -1254,8 +1254,8 @@ function MessageHandler(sourceName, targetName, comObj) {
           return action[0].call(action[1], data.data);
         }).then(function (result) {
           comObj.postMessage({
-            sourceName: sourceName,
-            targetName: targetName,
+            sourceName,
+            targetName,
             isReply: true,
             callbackId: data.callbackId,
             data: result
@@ -1266,8 +1266,8 @@ function MessageHandler(sourceName, targetName, comObj) {
             reason = reason + '';
           }
           comObj.postMessage({
-            sourceName: sourceName,
-            targetName: targetName,
+            sourceName,
+            targetName,
             isReply: true,
             callbackId: data.callbackId,
             error: reason
@@ -1284,7 +1284,7 @@ function MessageHandler(sourceName, targetName, comObj) {
 }
 
 MessageHandler.prototype = {
-  on: function messageHandlerOn(actionName, handler, scope) {
+  on(actionName, handler, scope) {
     var ah = this.actionHandler;
     if (ah[actionName]) {
       error('There is already an actionName called "' + actionName + '"');
@@ -1297,12 +1297,12 @@ MessageHandler.prototype = {
    * @param {JSON} data JSON data to send.
    * @param {Array} [transfers] Optional list of transfers/ArrayBuffers
    */
-  send: function messageHandlerSend(actionName, data, transfers) {
+  send(actionName, data, transfers) {
     var message = {
       sourceName: this.sourceName,
       targetName: this.targetName,
       action: actionName,
-      data: data
+      data,
     };
     this.postMessage(message, transfers);
   },
@@ -1314,15 +1314,14 @@ MessageHandler.prototype = {
    * @param {Array} [transfers] Optional list of transfers/ArrayBuffers.
    * @returns {Promise} Promise to be resolved with response data.
    */
-  sendWithPromise:
-    function messageHandlerSendWithPromise(actionName, data, transfers) {
+  sendWithPromise(actionName, data, transfers) {
     var callbackId = this.callbackIndex++;
     var message = {
       sourceName: this.sourceName,
       targetName: this.targetName,
       action: actionName,
-      data: data,
-      callbackId: callbackId
+      data,
+      callbackId,
     };
     var capability = createPromiseCapability();
     this.callbacksCapabilities[callbackId] = capability;
@@ -1339,7 +1338,7 @@ MessageHandler.prototype = {
    * @param message {Object} Raw message.
    * @param transfers List of transfers/ArrayBuffers, or undefined.
    */
-  postMessage: function (message, transfers) {
+  postMessage(message, transfers) {
     if (transfers && this.postMessageTransfers) {
       this.comObj.postMessage(message, transfers);
     } else {
@@ -1347,7 +1346,7 @@ MessageHandler.prototype = {
     }
   },
 
-  destroy: function () {
+  destroy() {
     this.comObj.removeEventListener('message', this._onComObjOnMessage);
   }
 };


### PR DESCRIPTION
Since we're using Babel, it's now possible for us to use the more compact object notation available in ES6 (see [this MDN article](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Object_initializer#New_notations_in_ECMAScript_2015)).

Please see http://eslint.org/docs/rules/object-shorthand; this is one of the rules mentioned in issue #7957.

*Note:* I initially created *one* big patch for this change, see https://github.com/mozilla/pdf.js/compare/master...Snuffleupagus:eslint-object-shorthand, but after looking at the diff I quickly realized that it was too big and I don't think anyone would want to review that. Hence I've decided to split it up into more manageable chunks instead.