### PR TITLE
Subtract the X/Y offsets when decoding refinement regions of JBIG2 images (issue 7145, 7308, 7401, 7850, 8270)

### DIFF
--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -394,8 +394,8 @@ var Jbig2Image = (function Jbig2ImageClosure() {
           }
         }
         for (k = 0; k < referenceTemplateLength; k++) {
-          i0 = i + referenceTemplateY[k] + offsetY;
-          j0 = j + referenceTemplateX[k] + offsetX;
+          i0 = i + referenceTemplateY[k] - offsetY;
+          j0 = j + referenceTemplateX[k] - offsetX;
           if (i0 < 0 || i0 >= referenceHeight || j0 < 0 ||
               j0 >= referenceWidth) {
             contextLabel <<= 1; // out of bound pixel

--- a/test/pdfs/issue7308.pdf.link
+++ b/test/pdfs/issue7308.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/256692/ZGTA198001028.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2322,6 +2322,13 @@
       "link": true,
       "type": "eq"
     },
+    {  "id": "issue7308",
+       "file": "pdfs/issue7308.pdf",
+       "md5": "ba2e23d3af93ac2c634d77ccbe2e79d5",
+       "rounds": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "issue1597",
       "file": "pdfs/issue1597.pdf",
       "md5": "a5ebef467fd6e2fc0aeb56c9eb725ae3",


### PR DESCRIPTION
Please refer to the JBIG2 standard, see https://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-T.88-200002-I!!PDF-E&type=items.
In particular, section "6.3.5.3 Fixed templates and adaptive templates" mentions that the offsets should be *subtracted*; where the offsets are defined according to "Table 6" under section "6.3.2 Input parameters".

Fixes #7145.
Fixes #7308.
Fixes #7401.
Fixes #7850.
Fixes #8270.