### PR TITLE
Store image dictionary interpolate entry. Apply it as smoothing in pa…

### DIFF
--- a/src/core/image.js
+++ b/src/core/image.js
@@ -502,7 +502,8 @@ var PDFImage = (function PDFImageClosure() {
       var drawHeight = this.drawHeight;
       var imgData = { // other fields are filled in below
         width: drawWidth,
-        height: drawHeight
+        height: drawHeight,
+        interpolate: this.interpolate
       };
 
       var numComps = this.numComps;

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -2117,8 +2117,44 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         paintHeight = newHeight;
         tmpCanvasId = tmpCanvasId === 'prescale1' ? 'prescale2' : 'prescale1';
       }
+
+      var smoothingToggle = false;
+      if (ctx.imageSmoothingEnabled !== undefined) {
+        if (imgData.interpolate !== ctx.imageSmoothingEnabled) {
+          ctx.imageSmoothingEnabled = imgData.interpolate;
+          smoothingToggle = true;
+        }
+      } else if (ctx.mozImageSmoothingEnabled !== undefined) {
+        if (imgData.interpolate !== ctx.mozImageSmoothingEnabled) {
+          ctx.mozImageSmoothingEnabled = imgData.interpolate;
+          smoothingToggle = true;
+        }
+      } else if (ctx.webkitImageSmoothingEnabled !== undefined) {
+        if (imgData.interpolate !== ctx.webkitImageSmoothingEnabled) {
+          ctx.webkitImageSmoothingEnabled = imgData.interpolate;
+          smoothingToggle = true;
+        }
+      } else if (ctx.msImageSmoothingEnabled !== undefined) {
+        if (imgData.interpolate !== ctx.msImageSmoothingEnabled) {
+          ctx.msImageSmoothingEnabled = imgData.interpolate;
+          smoothingToggle = true;
+        }
+      }
+
       ctx.drawImage(imgToPaint, 0, 0, paintWidth, paintHeight,
                                 0, -height, width, height);
+
+      if (smoothingToggle) {
+        if (ctx.imageSmoothingEnabled !== undefined) {
+          ctx.imageSmoothingEnabled = !imgData.interpolate;
+        } else if (ctx.mozImageSmoothingEnabled !== undefined) {
+          ctx.mozImageSmoothingEnabled = !imgData.interpolate;
+        } else if (ctx.webkitImageSmoothingEnabled !== undefined) {
+          ctx.webkitImageSmoothingEnabled = !imgData.interpolate;
+        } else if (ctx.msImageSmoothingEnabled !== undefined) {
+          ctx.msImageSmoothingEnabled = !imgData.interpolate;
+        }
+      }
 
       if (this.imageLayer) {
         var position = this.getCanvasPosition(0, -height);


### PR DESCRIPTION
I would like to have the image dictionary interpolate boolean entry applied to image painting so that hard pixel edges are possible. This uses canvas context imageSmoothingEnabled (https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/imageSmoothingEnabled).

Fixes issue #5757

Test PDF:
[issue5757.pdf](https://github.com/mozilla/pdf.js/files/960522/issue5757.pdf)

Before:
![image](https://cloud.githubusercontent.com/assets/5540936/25436370/5a81983c-2a50-11e7-900f-a0619515fd51.png)

After:
![image](https://cloud.githubusercontent.com/assets/5540936/25436386/62af1638-2a50-11e7-9950-0998d5daced1.png)

Acrobat Reader:
![image](https://cloud.githubusercontent.com/assets/5540936/25419875/83f32a84-2a12-11e7-906e-91464c1bc76e.png)

