### PR TITLE
Fix char spacing bug in SVG mode

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -693,7 +693,8 @@ SVGGraphics = (function SVGGraphicsClosure() {
 
         var width = glyph.width;
         var character = glyph.fontChar;
-        var charWidth = width * widthAdvanceScale + charSpacing * fontDirection;
+        var spacing = (glyph.isSpace ? wordSpacing : 0) + charSpacing;
+        var charWidth = width * widthAdvanceScale + spacing * fontDirection;
         x += charWidth;
 
         current.tspan.textContent += character;


### PR DESCRIPTION
When use svg mode, a word which first char is blank won't get accurate position. Because canvas mode renders well, I compared code between them and found some code in svg mode was too old. I just modify the code which make my pdf looks bad, but I'm not sure there's any other bugs in other condition like `font.vertical = true`. Nevertheless, this PR won't trigger any new problems.

Here's my example

- Former
![former](https://cloud.githubusercontent.com/assets/1191515/25480967/be720c40-2b7d-11e7-9c4d-dc0aec9010c0.png)
- After
![after](https://cloud.githubusercontent.com/assets/1191515/25480975/c25f4322-2b7d-11e7-8872-1ece1702aa07.png)