### PR TITLE
Enable the `object-shorthand` ESLint rule in `src/core`

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -81,12 +81,12 @@ AnnotationFactory.prototype = /** @lends AnnotationFactory.prototype */ {
 
     // Return the right annotation object based on the subtype and field type.
     var parameters = {
-      xref: xref,
-      dict: dict,
+      xref,
+      dict,
       ref: isRef(ref) ? ref : null,
-      subtype: subtype,
-      id: id,
-      pdfManager: pdfManager,
+      subtype,
+      id,
+      pdfManager,
     };
 
     switch (subtype) {

--- a/src/core/bidi.js
+++ b/src/core/bidi.js
@@ -115,7 +115,7 @@
 
   function createBidiText(str, isLTR, vertical) {
     return {
-      str: str,
+      str,
       dir: (vertical ? 'ttb' : (isLTR ? 'ltr' : 'rtl'))
     };
   }

--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -674,7 +674,7 @@ var CFFParser = (function CFFParserClosure() {
           charStrings.set(i, new Uint8Array([14]));
         }
       }
-      return { charStrings: charStrings, seacs: seacs, widths: widths };
+      return { charStrings, seacs, widths, };
     },
     emptyPrivateDictionary:
       function CFFParser_emptyPrivateDictionary(parentDict) {

--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -320,7 +320,7 @@ var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
               chunks.push(data);
               loaded += arrayByteLength(data);
               if (rangeReader.isStreamingSupported) {
-                manager.onProgress({loaded: loaded});
+                manager.onProgress({ loaded, });
               }
               rangeReader.read().then(readChunk, reject);
               return;
@@ -338,7 +338,7 @@ var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
         if (this.aborted) {
           return; // ignoring any data after abort
         }
-        this.onReceiveData({chunk: data, begin: begin});
+        this.onReceiveData({ chunk: data, begin, });
       }.bind(this));
       // TODO check errors
     },
@@ -450,12 +450,12 @@ var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
         }
 
         if (prevChunk >= 0 && prevChunk + 1 !== chunk) {
-          groupedChunks.push({ beginChunk: beginChunk,
+          groupedChunks.push({ beginChunk,
                                endChunk: prevChunk + 1 });
           beginChunk = chunk;
         }
         if (i + 1 === chunks.length) {
-          groupedChunks.push({ beginChunk: beginChunk,
+          groupedChunks.push({ beginChunk,
                                endChunk: chunk + 1 });
         }
 

--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -235,18 +235,18 @@ var CMap = (function CMapClosure() {
     this.builtInCMap = builtInCMap;
   }
   CMap.prototype = {
-    addCodespaceRange: function(n, low, high) {
+    addCodespaceRange(n, low, high) {
       this.codespaceRanges[n - 1].push(low, high);
       this.numCodespaceRanges++;
     },
 
-    mapCidRange: function(low, high, dstLow) {
+    mapCidRange(low, high, dstLow) {
       while (low <= high) {
         this._map[low++] = dstLow++;
       }
     },
 
-    mapBfRange: function(low, high, dstLow) {
+    mapBfRange(low, high, dstLow) {
       var lastByte = dstLow.length - 1;
       while (low <= high) {
         this._map[low++] = dstLow;
@@ -256,7 +256,7 @@ var CMap = (function CMapClosure() {
       }
     },
 
-    mapBfRangeToArray: function(low, high, array) {
+    mapBfRangeToArray(low, high, array) {
       var i = 0, ii = array.length;
       while (low <= high && i < ii) {
         this._map[low] = array[i++];
@@ -265,19 +265,19 @@ var CMap = (function CMapClosure() {
     },
 
     // This is used for both bf and cid chars.
-    mapOne: function(src, dst) {
+    mapOne(src, dst) {
       this._map[src] = dst;
     },
 
-    lookup: function(code) {
+    lookup(code) {
       return this._map[code];
     },
 
-    contains: function(code) {
+    contains(code) {
       return this._map[code] !== undefined;
     },
 
-    forEach: function(callback) {
+    forEach(callback) {
       // Most maps have fewer than 65536 entries, and for those we use normal
       // array iteration. But really sparse tables are possible -- e.g. with
       // indices in the *billions*. For such tables we use for..in, which isn't
@@ -299,15 +299,15 @@ var CMap = (function CMapClosure() {
       }
     },
 
-    charCodeOf: function(value) {
+    charCodeOf(value) {
       return this._map.indexOf(value);
     },
 
-    getMap: function() {
+    getMap() {
       return this._map;
     },
 
-    readCharCode: function(str, offset, out) {
+    readCharCode(str, offset, out) {
       var c = 0;
       var codespaceRanges = this.codespaceRanges;
       var codespaceRangesLen = this.codespaceRanges.length;
@@ -366,41 +366,41 @@ var IdentityCMap = (function IdentityCMapClosure() {
   IdentityCMap.prototype = {
     addCodespaceRange: CMap.prototype.addCodespaceRange,
 
-    mapCidRange: function(low, high, dstLow) {
+    mapCidRange(low, high, dstLow) {
       error('should not call mapCidRange');
     },
 
-    mapBfRange: function(low, high, dstLow) {
+    mapBfRange(low, high, dstLow) {
       error('should not call mapBfRange');
     },
 
-    mapBfRangeToArray: function(low, high, array) {
+    mapBfRangeToArray(low, high, array) {
       error('should not call mapBfRangeToArray');
     },
 
-    mapOne: function(src, dst) {
+    mapOne(src, dst) {
       error('should not call mapCidOne');
     },
 
-    lookup: function(code) {
+    lookup(code) {
       return (isInt(code) && code <= 0xffff) ? code : undefined;
     },
 
-    contains: function(code) {
+    contains(code) {
       return isInt(code) && code <= 0xffff;
     },
 
-    forEach: function(callback) {
+    forEach(callback) {
       for (var i = 0; i <= 0xffff; i++) {
         callback(i, i);
       }
     },
 
-    charCodeOf: function(value) {
+    charCodeOf(value) {
       return (isInt(value) && value <= 0xffff) ? value : -1;
     },
 
-    getMap: function() {
+    getMap() {
       // Sometimes identity maps must be instantiated, but it's rare.
       var map = new Array(0x10000);
       for (var i = 0; i <= 0xffff; i++) {
@@ -473,13 +473,13 @@ var BinaryCMapReader = (function BinaryCMapReaderClosure() {
   }
 
   BinaryCMapStream.prototype = {
-    readByte: function () {
+    readByte() {
       if (this.pos >= this.end) {
         return -1;
       }
       return this.buffer[this.pos++];
     },
-    readNumber: function () {
+    readNumber() {
       var n = 0;
       var last;
       do {
@@ -492,16 +492,16 @@ var BinaryCMapReader = (function BinaryCMapReaderClosure() {
       } while (!last);
       return n;
     },
-    readSigned: function () {
+    readSigned() {
       var n = this.readNumber();
       return (n & 1) ? ~(n >>> 1) : n >>> 1;
     },
-    readHex: function (num, size) {
+    readHex(num, size) {
       num.set(this.buffer.subarray(this.pos,
         this.pos + size + 1));
       this.pos += size + 1;
     },
-    readHexNumber: function (num, size) {
+    readHexNumber(num, size) {
       var last;
       var stack = this.tmpBuf, sp = 0;
       do {
@@ -524,7 +524,7 @@ var BinaryCMapReader = (function BinaryCMapReaderClosure() {
         bufferSize -= 8;
       }
     },
-    readHexSigned: function (num, size) {
+    readHexSigned(num, size) {
       this.readHexNumber(num, size);
       var sign = num[size] & 1 ? 255 : 0;
       var c = 0;
@@ -533,7 +533,7 @@ var BinaryCMapReader = (function BinaryCMapReaderClosure() {
         num[i] = (c >> 1) ^ sign;
       }
     },
-    readString: function () {
+    readString() {
       var len = this.readNumber();
       var s = '';
       for (var i = 0; i < len; i++) {
@@ -977,7 +977,7 @@ var CMapFactory = (function CMapFactoryClosure() {
   }
 
   return {
-    create: function (params) {
+    create(params) {
       var encoding = params.encoding;
       var fetchBuiltInCMap = params.fetchBuiltInCMap;
       var useCMap = params.useCMap;

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -93,7 +93,7 @@ var Page = (function PageClosure() {
       obj: 0,
     };
     this.idFactory = {
-      createObjId: function () {
+      createObjId() {
         return uniquePrefix + (++idCounters.obj);
       },
     };
@@ -266,7 +266,7 @@ var Page = (function PageClosure() {
         handler.send('StartRenderPage', {
           transparency: partialEvaluator.hasBlendModes(self.resources),
           pageIndex: self.pageIndex,
-          intent: intent
+          intent,
         });
         return partialEvaluator.getOperatorList(contentStream, task,
           self.resources, opList).then(function () {
@@ -567,11 +567,9 @@ var PDFDocument = (function PDFDocumentClosure() {
     },
     setup: function PDFDocument_setup(recoveryMode) {
       this.xref.parse(recoveryMode);
-      var self = this;
       var pageFactory = {
-        createPage: function (pageIndex, dict, ref, fontCache,
-                              builtInCMapCache) {
-          return new Page(self.pdfManager, self.xref, pageIndex, dict, ref,
+        createPage: (pageIndex, dict, ref, fontCache, builtInCMapCache) => {
+          return new Page(this.pdfManager, this.xref, pageIndex, dict, ref,
                           fontCache, builtInCMapCache);
         }
       };

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -124,11 +124,11 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     this.forceDataSchema = forceDataSchema;
   }
   NativeImageDecoder.prototype = {
-    canDecode: function (image) {
+    canDecode(image) {
       return image instanceof JpegStream &&
              NativeImageDecoder.isDecodable(image, this.xref, this.resources);
     },
-    decode: function (image) {
+    decode(image) {
       // For natively supported JPEGs send them to the main thread for decoding.
       var dict = image.dict;
       var colorSpace = dict.get('ColorSpace', 'CS');
@@ -181,17 +181,17 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     this.builtInCMapCache = builtInCMapCache;
     this.options = options || DefaultPartialEvaluatorOptions;
 
-    this.fetchBuiltInCMap = function (name) {
-      var cachedCMap = builtInCMapCache[name];
+    this.fetchBuiltInCMap = (name) => {
+      var cachedCMap = this.builtInCMapCache[name];
       if (cachedCMap) {
         return Promise.resolve(cachedCMap);
       }
       return handler.sendWithPromise('FetchBuiltInCMap', {
-        name: name,
-      }).then(function (data) {
+        name,
+      }).then((data) => {
         if (data.compressionType !== CMapCompressionType.NONE) {
           // Given the size of uncompressed CMaps, only cache compressed ones.
-          builtInCMapCache[name] = data;
+          this.builtInCMapCache[name] = data;
         }
         return data;
       });
@@ -267,8 +267,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
   var TILING_PATTERN = 1, SHADING_PATTERN = 2;
 
   PartialEvaluator.prototype = {
-    clone: function(newOptions) {
-      newOptions = newOptions || DefaultPartialEvaluatorOptions;
+    clone(newOptions = DefaultPartialEvaluatorOptions) {
       var newEvaluator = Object.create(this);
       newEvaluator.options = newOptions;
       return newEvaluator;
@@ -356,9 +355,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       var group = dict.get('Group');
       if (group) {
         var groupOptions = {
-          matrix: matrix,
-          bbox: bbox,
-          smask: smask,
+          matrix,
+          bbox,
+          smask,
           isolated: false,
           knockout: false
         };
@@ -437,7 +436,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         if (cacheKey) {
           imageCache[cacheKey] = {
             fn: OPS.paintImageMaskXObject,
-            args: args
+            args,
           };
         }
         return;
@@ -501,7 +500,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       if (cacheKey) {
         imageCache[cacheKey] = {
           fn: OPS.paintImageXObject,
-          args: args
+          args,
         };
       }
     },
@@ -2207,9 +2206,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       }
 
       return {
-        defaultWidth: defaultWidth,
-        monospace: monospace,
-        widths: widths
+        defaultWidth,
+        monospace,
+        widths,
       };
     },
 
@@ -2308,10 +2307,10 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       }
 
       return {
-        descriptor: descriptor,
-        dict: dict,
-        baseDict: baseDict,
-        composite: composite,
+        descriptor,
+        dict,
+        baseDict,
+        composite,
         type: type.name,
         hash: hash ? hash.hexdigest() : ''
       };
@@ -2353,11 +2352,11 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
                                                   FontFlags.Nonsymbolic);
 
           properties = {
-            type: type,
+            type,
             name: baseFontName,
             widths: metrics.widths,
             defaultWidth: metrics.defaultWidth,
-            flags: flags,
+            flags,
             firstChar: 0,
             lastChar: maxCharIndex
           };
@@ -2421,15 +2420,15 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       }
 
       properties = {
-        type: type,
+        type,
         name: fontName.name,
-        subtype: subtype,
+        subtype,
         file: fontFile,
-        length1: length1,
-        length2: length2,
-        length3: length3,
+        length1,
+        length2,
+        length3,
         loadedName: baseDict.loadedName,
-        composite: composite,
+        composite,
         wideChars: composite,
         fixedPitch: false,
         fontMatrix: (dict.getArray('FontMatrix') || FONT_IDENTITY_MATRIX),
@@ -2489,7 +2488,7 @@ var TranslatedFont = (function TranslatedFontClosure() {
     this.sent = false;
   }
   TranslatedFont.prototype = {
-    send: function (handler) {
+    send(handler) {
       if (this.sent) {
         return;
       }
@@ -2501,7 +2500,7 @@ var TranslatedFont = (function TranslatedFontClosure() {
       ]);
       this.sent = true;
     },
-    loadType3Data: function (evaluator, resources, parentOperatorList, task) {
+    loadType3Data(evaluator, resources, parentOperatorList, task) {
       assert(this.font.isType3Font);
 
       if (this.type3Loaded) {
@@ -2594,7 +2593,7 @@ var OperatorList = (function OperatorListClosure() {
       return (this._totalLength + this.length);
     },
 
-    addOp: function(fn, args) {
+    addOp(fn, args) {
       this.fnArray.push(fn);
       this.argsArray.push(args);
       if (this.messageHandler) {
@@ -2608,7 +2607,7 @@ var OperatorList = (function OperatorListClosure() {
       }
     },
 
-    addDependency: function(dependency) {
+    addDependency(dependency) {
       if (dependency in this.dependencies) {
         return;
       }
@@ -2616,20 +2615,20 @@ var OperatorList = (function OperatorListClosure() {
       this.addOp(OPS.dependency, [dependency]);
     },
 
-    addDependencies: function(dependencies) {
+    addDependencies(dependencies) {
       for (var key in dependencies) {
         this.addDependency(key);
       }
     },
 
-    addOpList: function(opList) {
+    addOpList(opList) {
       Util.extendObj(this.dependencies, opList.dependencies);
       for (var i = 0, ii = opList.length; i < ii; i++) {
         this.addOp(opList.fnArray[i], opList.argsArray[i]);
       }
     },
 
-    getIR: function() {
+    getIR() {
       return {
         fnArray: this.fnArray,
         argsArray: this.argsArray,
@@ -2637,7 +2636,7 @@ var OperatorList = (function OperatorListClosure() {
       };
     },
 
-    flush: function(lastChunk) {
+    flush(lastChunk) {
       if (this.intent !== 'oplist') {
         new QueueOptimizer().optimize(this);
       }
@@ -2649,8 +2648,8 @@ var OperatorList = (function OperatorListClosure() {
         operatorList: {
           fnArray: this.fnArray,
           argsArray: this.argsArray,
-          lastChunk: lastChunk,
-          length: length
+          lastChunk,
+          length,
         },
         pageIndex: this.pageIndex,
         intent: this.intent
@@ -2670,18 +2669,18 @@ var StateManager = (function StateManagerClosure() {
     this.stateStack = [];
   }
   StateManager.prototype = {
-    save: function () {
+    save() {
       var old = this.state;
       this.stateStack.push(this.state);
       this.state = old.clone();
     },
-    restore: function () {
+    restore() {
       var prev = this.stateStack.pop();
       if (prev) {
         this.state = prev;
       }
     },
-    transform: function (args) {
+    transform(args) {
       this.state.ctm = Util.transform(this.state.ctm, args);
     }
   };
@@ -3110,7 +3109,7 @@ var QueueOptimizer = (function QueueOptimizerClosure() {
           maxLineHeight = 0;
         }
         map.push({
-          transform: transform,
+          transform,
           x: currentX, y: currentY,
           w: img.width, h: img.height
         });
@@ -3403,8 +3402,8 @@ var QueueOptimizer = (function QueueOptimizerClosure() {
       var fnArray = queue.fnArray, argsArray = queue.argsArray;
       var context = {
         iCurr: 0,
-        fnArray: fnArray,
-        argsArray: argsArray
+        fnArray,
+        argsArray,
       };
       var state;
       var i = 0, ii = fnArray.length;

--- a/src/core/font_renderer.js
+++ b/src/core/font_renderer.js
@@ -237,7 +237,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
           repeat += code[i++];
         }
         while (repeat-- > 0) {
-          points.push({flags: flags});
+          points.push({ flags, });
         }
       }
       for (j = 0; j < numberOfPoints; j++) {
@@ -617,7 +617,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
     this.fontMatrix = fontMatrix;
   }
   CompiledFont.prototype = {
-    getPathJs: function (unicode) {
+    getPathJs(unicode) {
       var cmap = lookupCmap(this.cmap, unicode);
       var fn = this.compiledGlyphs[cmap.glyphId];
       if (!fn) {
@@ -630,7 +630,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
       return fn;
     },
 
-    compileGlyph: function (code) {
+    compileGlyph(code) {
       if (!code || code.length === 0 || code[0] === 14) {
         return noop;
       }
@@ -647,11 +647,11 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
       return cmds;
     },
 
-    compileGlyphImpl: function () {
+    compileGlyphImpl() {
       error('Children classes should implement this.');
     },
 
-    hasBuiltPath: function (unicode) {
+    hasBuiltPath(unicode) {
       var cmap = lookupCmap(this.cmap, unicode);
       return (this.compiledGlyphs[cmap.glyphId] !== undefined &&
               this.compiledCharCodeToGlyphId[cmap.charCode] !== undefined);
@@ -667,7 +667,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
   }
 
   Util.inherit(TrueTypeCompiled, CompiledFont, {
-    compileGlyphImpl: function (code, cmds) {
+    compileGlyphImpl(code, cmds) {
       compileGlyf(code, cmds, this);
     }
   });
@@ -689,7 +689,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
   }
 
   Util.inherit(Type2Compiled, CompiledFont, {
-    compileGlyphImpl: function (code, cmds) {
+    compileGlyphImpl(code, cmds) {
       compileCharString(code, cmds, this);
     }
   });

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -269,25 +269,25 @@ var ToUnicodeMap = (function ToUnicodeMapClosure() {
       return this._map.length;
     },
 
-    forEach: function(callback) {
+    forEach(callback) {
       for (var charCode in this._map) {
         callback(charCode, this._map[charCode].charCodeAt(0));
       }
     },
 
-    has: function(i) {
+    has(i) {
       return this._map[i] !== undefined;
     },
 
-    get: function(i) {
+    get(i) {
       return this._map[i];
     },
 
-    charCodeOf: function(v) {
+    charCodeOf(v) {
       return this._map.indexOf(v);
     },
 
-    amend: function (map) {
+    amend(map) {
       for (var charCode in map) {
         this._map[charCode] = map[charCode];
       }
@@ -308,28 +308,28 @@ var IdentityToUnicodeMap = (function IdentityToUnicodeMapClosure() {
       return (this.lastChar + 1) - this.firstChar;
     },
 
-    forEach: function (callback) {
+    forEach(callback) {
       for (var i = this.firstChar, ii = this.lastChar; i <= ii; i++) {
         callback(i, i);
       }
     },
 
-    has: function (i) {
+    has(i) {
       return this.firstChar <= i && i <= this.lastChar;
     },
 
-    get: function (i) {
+    get(i) {
       if (this.firstChar <= i && i <= this.lastChar) {
         return String.fromCharCode(i);
       }
       return undefined;
     },
 
-    charCodeOf: function (v) {
+    charCodeOf(v) {
       return (isInt(v) && v >= this.firstChar && v <= this.lastChar) ? v : -1;
     },
 
-    amend: function (map) {
+    amend(map) {
       error('Should not call amend()');
     },
   };
@@ -887,9 +887,9 @@ var Font = (function FontClosure() {
       usedFontCharCodes[fontCharCode] = true;
     }
     return {
-      toFontChar: toFontChar,
+      toFontChar,
       charCodeToGlyphId: newMap,
-      nextAvailableFontCharCode: nextAvailableFontCharCode
+      nextAvailableFontCharCode,
     };
   }
 
@@ -1303,11 +1303,11 @@ var Font = (function FontClosure() {
         }
 
         return {
-          tag: tag,
-          checksum: checksum,
-          length: length,
-          offset: offset,
-          data: data
+          tag,
+          checksum,
+          length,
+          offset,
+          data,
         };
       }
 
@@ -1377,9 +1377,9 @@ var Font = (function FontClosure() {
 
           if (useTable) {
             potentialTable = {
-              platformId: platformId,
-              encodingId: encodingId,
-              offset: offset
+              platformId,
+              encodingId,
+              offset,
             };
           }
           if (canBreak) {
@@ -1476,7 +1476,7 @@ var Font = (function FontClosure() {
               glyphId = (glyphId + delta) & 0xFFFF;
               mappings.push({
                 charCode: j,
-                glyphId: glyphId
+                glyphId,
               });
             }
           }
@@ -1494,8 +1494,8 @@ var Font = (function FontClosure() {
             var charCode = firstCode + j;
 
             mappings.push({
-              charCode: charCode,
-              glyphId: glyphId
+              charCode,
+              glyphId,
             });
           }
         } else {
@@ -1522,8 +1522,8 @@ var Font = (function FontClosure() {
         return {
           platformId: potentialTable.platformId,
           encodingId: potentialTable.encodingId,
-          mappings: mappings,
-          hasShortCmap: hasShortCmap
+          mappings,
+          hasShortCmap,
         };
       }
 
@@ -1977,7 +1977,7 @@ var Font = (function FontClosure() {
                 stack.length += ttContext.functionsStackDeltas[funcId];
               } else if (funcId in ttContext.functionsDefined &&
                          functionsCalled.indexOf(funcId) < 0) {
-                callstack.push({data: data, i: i, stackTop: stack.length - 1});
+                callstack.push({ data, i, stackTop: stack.length - 1, });
                 functionsCalled.push(funcId);
                 pc = ttContext.functionsDefined[funcId];
                 if (!pc) {
@@ -1998,7 +1998,7 @@ var Font = (function FontClosure() {
             // collecting inforamtion about which functions are defined
             lastDeff = i;
             funcId = stack.pop();
-            ttContext.functionsDefined[funcId] = {data: data, i: i};
+            ttContext.functionsDefined[funcId] = { data, i, };
           } else if (op === 0x2D) { // ENDF - end of function
             if (inFDEF) {
               inFDEF = false;
@@ -2596,9 +2596,9 @@ var Font = (function FontClosure() {
             var accentFontCharCode = createCharCode(charCodeToGlyphId,
                                                     accentGlyphId);
             seacMap[charCode] = {
-              baseFontCharCode: baseFontCharCode,
-              accentFontCharCode: accentFontCharCode,
-              accentOffset: accentOffset
+              baseFontCharCode,
+              accentFontCharCode,
+              accentOffset,
             };
           }
         }
@@ -2953,7 +2953,7 @@ var Type1Font = (function Type1FontClosure() {
       i++;
     }
     return {
-      found: found,
+      found,
       length: i,
     };
   }

--- a/src/core/function.js
+++ b/src/core/function.js
@@ -870,36 +870,36 @@ var PostScriptCompiler = (function PostScriptCompilerClosure() {
     this.parts = [];
   }
   ExpressionBuilderVisitor.prototype = {
-    visitArgument: function (arg) {
+    visitArgument(arg) {
       this.parts.push('Math.max(', arg.min, ', Math.min(',
                       arg.max, ', src[srcOffset + ', arg.index, ']))');
     },
-    visitVariable: function (variable) {
+    visitVariable(variable) {
       this.parts.push('v', variable.index);
     },
-    visitLiteral: function (literal) {
+    visitLiteral(literal) {
       this.parts.push(literal.number);
     },
-    visitBinaryOperation: function (operation) {
+    visitBinaryOperation(operation) {
       this.parts.push('(');
       operation.arg1.visit(this);
       this.parts.push(' ', operation.op, ' ');
       operation.arg2.visit(this);
       this.parts.push(')');
     },
-    visitVariableDefinition: function (definition) {
+    visitVariableDefinition(definition) {
       this.parts.push('var ');
       definition.variable.visit(this);
       this.parts.push(' = ');
       definition.arg.visit(this);
       this.parts.push(';');
     },
-    visitMin: function (max) {
+    visitMin(max) {
       this.parts.push('Math.min(');
       max.arg.visit(this);
       this.parts.push(', ', max.max, ')');
     },
-    toString: function () {
+    toString() {
       return this.parts.join('');
     }
   };

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -280,7 +280,7 @@ var PDFImage = (function PDFImageClosure() {
       }
     }
 
-    return {data: data, width: width, height: height};
+    return { data, width, height, };
   };
 
   PDFImage.prototype = {

--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -41,7 +41,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
   function ContextCache() {}
 
   ContextCache.prototype = {
-    getContexts: function(id) {
+    getContexts(id) {
       if (id in this) {
         return this[id];
       }
@@ -720,7 +720,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
       position = segmentHeader.headerEnd;
       var segment = {
         header: segmentHeader,
-        data: data
+        data,
       };
       if (!header.randomAccess) {
         segment.start = position;

--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -803,8 +803,8 @@ var JpegImage = (function JpegImageClosure() {
               }
               var qId = data[offset + 2];
               l = frame.components.push({
-                h: h,
-                v: v,
+                h,
+                v,
                 quantizationId: qId,
                 quantizationTable: null, // See comment below.
               });

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -512,13 +512,13 @@ var JpxImage = (function JpxImageClosure() {
     var numprecincts = numprecinctswide * numprecinctshigh;
 
     resolution.precinctParameters = {
-      precinctWidth: precinctWidth,
-      precinctHeight: precinctHeight,
-      numprecinctswide: numprecinctswide,
-      numprecinctshigh: numprecinctshigh,
-      numprecincts: numprecincts,
-      precinctWidthInSubband: precinctWidthInSubband,
-      precinctHeightInSubband: precinctHeightInSubband
+      precinctWidth,
+      precinctHeight,
+      numprecinctswide,
+      numprecinctshigh,
+      numprecincts,
+      precinctWidthInSubband,
+      precinctHeightInSubband,
     };
   }
   function buildCodeblocks(context, subband, dimensions) {
@@ -619,7 +619,7 @@ var JpxImage = (function JpxImageClosure() {
       }
     }
     return {
-      layerNumber: layerNumber,
+      layerNumber,
       codeblocks: precinctCodeblocks
     };
   }
@@ -921,10 +921,10 @@ var JpxImage = (function JpxImageClosure() {
     }
     return {
       components: sizePerComponent,
-      minWidth: minWidth,
-      minHeight: minHeight,
-      maxNumWide: maxNumWide,
-      maxNumHigh: maxNumHigh
+      minWidth,
+      minHeight,
+      maxNumWide,
+      maxNumHigh,
     };
   }
   function buildPackets(context) {
@@ -1184,8 +1184,8 @@ var JpxImage = (function JpxImageClosure() {
           codingpassesLog2 - 1 : codingpassesLog2) + codeblock.Lblock;
         var codedDataLength = readBits(bits);
         queue.push({
-          codeblock: codeblock,
-          codingpasses: codingpasses,
+          codeblock,
+          codingpasses,
           dataLength: codedDataLength
         });
       }
@@ -1200,7 +1200,7 @@ var JpxImage = (function JpxImageClosure() {
           codeblock.data = [];
         }
         codeblock.data.push({
-          data: data,
+          data,
           start: offset + position,
           end: offset + position + packetItem.dataLength,
           codingpasses: packetItem.codingpasses
@@ -1363,8 +1363,8 @@ var JpxImage = (function JpxImageClosure() {
                          reversible, segmentationSymbolUsed);
       }
       subbandCoefficients.push({
-        width: width,
-        height: height,
+        width,
+        height,
         items: coefficients
       });
     }
@@ -1498,8 +1498,8 @@ var JpxImage = (function JpxImageClosure() {
       this.levels = [];
       for (var i = 0; i < levelsLength; i++) {
         var level = {
-          width: width,
-          height: height,
+          width,
+          height,
           items: []
         };
         this.levels.push(level);
@@ -1562,9 +1562,9 @@ var JpxImage = (function JpxImageClosure() {
         }
 
         var level = {
-          width: width,
-          height: height,
-          items: items
+          width,
+          height,
+          items,
         };
         this.levels.push(level);
 
@@ -2097,9 +2097,9 @@ var JpxImage = (function JpxImageClosure() {
       }
 
       return {
-        width: width,
-        height: height,
-        items: items
+        width,
+        height,
+        items,
       };
     };
     return Transform;

--- a/src/core/network.js
+++ b/src/core/network.js
@@ -87,8 +87,8 @@ if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
   NetworkManager.prototype = {
     requestRange: function NetworkManager_requestRange(begin, end, listeners) {
       var args = {
-        begin: begin,
-        end: end
+        begin,
+        end,
       };
       for (var prop in listeners) {
         args[prop] = listeners[prop];
@@ -104,7 +104,7 @@ if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
       var xhr = this.getXhr();
       var xhrId = this.currXhrId++;
       var pendingRequest = this.pendingRequests[xhrId] = {
-        xhr: xhr
+        xhr,
       };
 
       xhr.open('GET', this.url);
@@ -226,15 +226,15 @@ if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
         var matches = /bytes (\d+)-(\d+)\/(\d+)/.exec(rangeHeader);
         var begin = parseInt(matches[1], 10);
         pendingRequest.onDone({
-          begin: begin,
-          chunk: chunk
+          begin,
+          chunk,
         });
       } else if (pendingRequest.onProgressiveData) {
         pendingRequest.onDone(null);
       } else if (chunk) {
         pendingRequest.onDone({
           begin: 0,
-          chunk: chunk
+          chunk,
         });
       } else if (pendingRequest.onError) {
         pendingRequest.onError(xhr.status);

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -144,7 +144,7 @@ var Catalog = (function CatalogClosure() {
         return null;
       }
       var root = { items: [] };
-      var queue = [{obj: obj, parent: root}];
+      var queue = [{ obj, parent: root, }];
       // To avoid recursion, keep track of the already processed items.
       var processed = new RefSet();
       processed.put(obj);
@@ -188,12 +188,12 @@ var Catalog = (function CatalogClosure() {
         i.parent.items.push(outlineItem);
         obj = outlineDict.getRaw('First');
         if (isRef(obj) && !processed.has(obj)) {
-          queue.push({obj: obj, parent: outlineItem});
+          queue.push({ obj, parent: outlineItem, });
           processed.put(obj);
         }
         obj = outlineDict.getRaw('Next');
         if (isRef(obj) && !processed.has(obj)) {
-          queue.push({obj: obj, parent: i.parent});
+          queue.push({ obj, parent: i.parent, });
           processed.put(obj);
         }
       }
@@ -962,7 +962,7 @@ var XRef = (function XRefClosure() {
 
         this.streamState = {
           entryRanges: range,
-          byteWidths: byteWidths,
+          byteWidths,
           entryNum: 0,
           streamPos: stream.pos
         };

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -1109,7 +1109,7 @@ var Linearization = {
                       'does not equal the stream length.');
     }
     return {
-      length: length,
+      length,
       hints: getHints(),
       objectNumberFirst: getInt('O'),
       endFirst: getInt('E'),

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -394,7 +394,7 @@ Shadings.Mesh = (function MeshClosure() {
       type: 'lattice',
       coords: new Int32Array(ps),
       colors: new Int32Array(ps),
-      verticesPerRow: verticesPerRow
+      verticesPerRow,
     });
   }
 
@@ -501,7 +501,7 @@ Shadings.Mesh = (function MeshClosure() {
       type: 'lattice',
       coords: figureCoords,
       colors: figureColors,
-      verticesPerRow: verticesPerRow
+      verticesPerRow,
     };
   }
 

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -231,7 +231,7 @@ var NetworkPdfManager = (function NetworkPdfManagerClosure() {
 
     sendProgressiveData:
         function NetworkPdfManager_sendProgressiveData(chunk) {
-      this.streamManager.onReceiveData({ chunk: chunk });
+      this.streamManager.onReceiveData({ chunk, });
     },
 
     onLoadedStream: function NetworkPdfManager_onLoadedStream() {

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -2344,7 +2344,7 @@ var LZWStream = (function LZWStreamClosure() {
 
     var maxLzwDictionarySize = 4096;
     var lzwState = {
-      earlyChange: earlyChange,
+      earlyChange,
       codeLength: 9,
       nextCode: 258,
       dictionaryValues: new Uint8Array(maxLzwDictionarySize),

--- a/src/core/type1_parser.js
+++ b/src/core/type1_parser.js
@@ -332,7 +332,7 @@ var Type1CharString = (function Type1CharStringClosure() {
       return error;
     },
 
-    executeCommand: function(howManyArgs, command, keepStack) {
+    executeCommand(howManyArgs, command, keepStack) {
       var stackLength = this.stack.length;
       if (howManyArgs > stackLength) {
         return true;
@@ -573,8 +573,8 @@ var Type1Parser = (function Type1ParserClosure() {
                 this.getToken(); // read in 'def'
               }
               charstrings.push({
-                glyph: glyph,
-                encoded: encoded
+                glyph,
+                encoded,
               });
             }
             break;

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -61,15 +61,15 @@ var WorkerTask = (function WorkerTaskClosure() {
       return this._capability.promise;
     },
 
-    finish: function () {
+    finish() {
       this._capability.resolve();
     },
 
-    terminate: function () {
+    terminate() {
       this.terminated = true;
     },
 
-    ensureNotTerminated: function () {
+    ensureNotTerminated() {
       if (this.terminated) {
         throw new Error('Worker task was terminated');
       }
@@ -92,7 +92,7 @@ IPDFStream.prototype = {
    * Gets a reader for the entire PDF data.
    * @returns {IPDFStreamReader}
    */
-  getFullReader: function () {
+  getFullReader() {
     return null;
   },
 
@@ -102,7 +102,7 @@ IPDFStream.prototype = {
    * @param {number} end - the end offset of the data.
    * @returns {IPDFStreamRangeReader}
    */
-  getRangeReader: function (begin, end) {
+  getRangeReader(begin, end) {
     return null;
   },
 
@@ -110,7 +110,7 @@ IPDFStream.prototype = {
    * Cancels all opened reader and closes all their opened requests.
    * @param {Object} reason - the reason for cancelling
    */
-  cancelAllRequests: function (reason) {},
+  cancelAllRequests(reason) {},
 };
 
 /**
@@ -165,13 +165,13 @@ IPDFStreamReader.prototype = {
    * set to true.
    * @returns {Promise}
    */
-  read: function () {},
+  read() {},
 
   /**
    * Cancels all pending read requests and closes the stream.
    * @param {Object} reason
    */
-  cancel: function (reason) {},
+  cancel(reason) {},
 
   /**
    * Sets or gets the progress callback. The callback can be useful when the
@@ -205,13 +205,13 @@ IPDFStreamRangeReader.prototype = {
    * set to true.
    * @returns {Promise}
    */
-  read: function () {},
+  read() {},
 
   /**
    * Cancels all pending read requests and closes the stream.
    * @param {Object} reason
    */
-  cancel: function (reason) {},
+  cancel(reason) {},
 
   /**
    * Sets or gets the progress callback. The callback can be useful when the
@@ -289,7 +289,7 @@ var PDFWorkerStream = (function PDFWorkerStreamClosure() {
 
     getRangeReader: function PDFWorkerStream_getRangeReader(begin, end) {
       var reader = new PDFWorkerStreamRangeReader(this, begin, end);
-      this._msgHandler.send('RequestDataRange', { begin: begin, end: end });
+      this._msgHandler.send('RequestDataRange', { begin, end, });
       this._rangeReaders.push(reader);
       return reader;
     },
@@ -469,7 +469,7 @@ var WorkerMessageHandler = {
       }
       handler.send('test', {
         supportTypedArray: true,
-        supportTransfers: supportTransfers
+        supportTransfers,
       });
     });
 
@@ -602,7 +602,7 @@ var WorkerMessageHandler = {
           url: source.url,
           password: source.password,
           length: fullRequest.contentLength,
-          disableAutoFetch: disableAutoFetch,
+          disableAutoFetch,
           rangeChunkSize: source.rangeChunkSize
         }, evaluatorOptions, docBaseUrl);
         pdfManagerCapability.resolve(pdfManager);
@@ -644,7 +644,7 @@ var WorkerMessageHandler = {
             loaded += arrayByteLength(data);
             if (!fullRequest.isStreamingSupported) {
               handler.send('DocProgress', {
-                loaded: loaded,
+                loaded,
                 total: Math.max(loaded, fullRequest.contentLength || 0)
               });
             }
@@ -890,7 +890,7 @@ var WorkerMessageHandler = {
           }
 
           handler.send('PageError', {
-            pageNum: pageNum,
+            pageNum,
             error: wrappedException,
             intent: data.intent
           });


### PR DESCRIPTION
Since we're using Babel, it's now possible for us to use the more compact object notation available in ES6 (see [this MDN article](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Object_initializer#New_notations_in_ECMAScript_2015)).

Please see http://eslint.org/docs/rules/object-shorthand; this is one of the rules mentioned in issue #7957.

*Note:* I initially created *one* big patch for this change, see https://github.com/mozilla/pdf.js/compare/master...Snuffleupagus:eslint-object-shorthand, but after looking at the diff I quickly realized that it was too big and I don't think anyone would want to review that. Hence I've decided to split it up into more manageable chunks instead.