### PR TITLE
Bots: disable the default browser test and enable E10s

### DIFF
--- a/test/resources/firefox/user.js
+++ b/test/resources/firefox/user.js
@@ -1,3 +1,2 @@
-user_pref('browser.tabs.remote.autostart', false);
-user_pref('browser.tabs.remote.autostart.1', false);
-user_pref('browser.tabs.remote.autostart.2', false);
+// Disable the default browser test.
+user_pref('browser.shell.checkDefaultBrowser', false);


### PR DESCRIPTION
The test runner is automated, so if the default browser test is performed, the browser hangs waiting for user input it never gets. Disable the test to fix that.

Moreover, enable E10s now that it is mature. This may help with the performance of the test runner as well.