### PR TITLE
Restore the `URL.createObjectURL` check to the `createObjectURL` utility function (issue 8344)

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1199,7 +1199,7 @@ var createObjectURL = (function createObjectURLClosure() {
     'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
 
   return function createObjectURL(data, contentType, forceDataSchema = false) {
-    if (!forceDataSchema) {
+    if (!forceDataSchema && URL.createObjectURL) {
       var blob = createBlob(data, contentType);
       return URL.createObjectURL(blob);
     }


### PR DESCRIPTION
This is a regression from commit https://github.com/mozilla/pdf.js/commit/3888a993b125e22fdfffd36bf603baf830e6fbe2.

It turns out the even though we have a `URL` polyfill, it's still dependent on the existence of native `URL.{createObjectURL, revokeObjectURL}` functions.
Since no such thing exists in Node.js, our `createObjectURL` utility function breaks there.

Fixes #8344.