### PR TITLE
[api-minor] Fix svg image render

### DIFF
--- a/examples/node/domstubs.js
+++ b/examples/node/domstubs.js
@@ -147,3 +147,21 @@ global.document = {
     return [];
   }
 };
+
+function Image () {
+  this._src = null;
+  this.onload = null;
+}
+Image.prototype = {
+  get src () {
+    return this._src;
+  },
+  set src (value) {
+    this._src = value;
+    if (this.onload) {
+      this.onload();
+    }
+  }
+}
+
+global.Image = Image;

--- a/examples/node/pdf2svg.js
+++ b/examples/node/pdf2svg.js
@@ -39,14 +39,15 @@ function writeToFile(svgdump, pageNum) {
 function getFileNameFromPath(path) {
   var index = path.lastIndexOf('/');
   var extIndex = path.lastIndexOf('.');
-  return path.substring(index , extIndex);
+  return path.substring(index, extIndex);
 }
 
 // Will be using promises to load document, pages and misc data instead of
 // callback.
 pdfjsLib.getDocument({
   data: data,
-  disableNativeImageDecoder: true,
+  // Try to export JPEG images directly if they don't need any further processing.
+  nativeImageDecoderSupport: pdfjsLib.NativeImageDecoding.DISPLAY
 }).then(function (doc) {
   var numPages = doc.numPages;
   console.log('# Document Loaded');

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -52,6 +52,7 @@ var IDENTITY_MATRIX = sharedUtil.IDENTITY_MATRIX;
 var UNSUPPORTED_FEATURES = sharedUtil.UNSUPPORTED_FEATURES;
 var ImageKind = sharedUtil.ImageKind;
 var OPS = sharedUtil.OPS;
+var NativeImageDecoding = sharedUtil.NativeImageDecoding;
 var TextRenderingMode = sharedUtil.TextRenderingMode;
 var CMapCompressionType = sharedUtil.CMapCompressionType;
 var Util = sharedUtil.Util;
@@ -113,7 +114,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     forceDataSchema: false,
     maxImageSize: -1,
     disableFontFace: false,
-    disableNativeImageDecoder: false,
+    nativeImageDecoderSupport: NativeImageDecoding.DECODE,
     ignoreErrors: false,
   };
 
@@ -461,14 +462,14 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         return;
       }
 
-      var useNativeImageDecoder = !this.options.disableNativeImageDecoder;
+      var nativeImageDecoderSupport = this.options.nativeImageDecoderSupport;
       // If there is no imageMask, create the PDFImage and a lot
       // of image processing can be done here.
       var objId = 'img_' + this.idFactory.createObjId();
       operatorList.addDependency(objId);
       args = [objId, w, h];
 
-      if (useNativeImageDecoder &&
+      if (nativeImageDecoderSupport !== NativeImageDecoding.NONE &&
           !softMask && !mask && image instanceof JpegStream &&
           NativeImageDecoder.isSupported(image, this.xref, resources)) {
         // These JPEGs don't need any more processing so we can just send it.
@@ -481,7 +482,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
       // Creates native image decoder only if a JPEG image or mask is present.
       var nativeImageDecoder = null;
-      if (useNativeImageDecoder &&
+      if (nativeImageDecoderSupport === NativeImageDecoding.DECODE &&
           (image instanceof JpegStream || mask instanceof JpegStream ||
            softMask instanceof JpegStream)) {
         nativeImageDecoder = new NativeImageDecoder(this.xref, resources,

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -731,7 +731,7 @@ var WorkerMessageHandler = {
         forceDataSchema: data.disableCreateObjectURL,
         maxImageSize: data.maxImageSize === undefined ? -1 : data.maxImageSize,
         disableFontFace: data.disableFontFace,
-        disableNativeImageDecoder: data.disableNativeImageDecoder,
+        nativeImageDecoderSupport: data.nativeImageDecoderSupport,
         ignoreErrors: data.ignoreErrors,
       };
 

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -1029,8 +1029,8 @@ SVGGraphics = (function SVGGraphicsClosure() {
       var imgObj = this.objs.get(objId);
       var imgEl = document.createElementNS(NS, 'svg:image');
       imgEl.setAttributeNS(XLINK_NS, 'xlink:href', imgObj.src);
-      imgEl.setAttributeNS(null, 'width', imgObj.width + 'px');
-      imgEl.setAttributeNS(null, 'height', imgObj.height + 'px');
+      imgEl.setAttributeNS(null, 'width', pf(w));
+      imgEl.setAttributeNS(null, 'height', pf(h));
       imgEl.setAttributeNS(null, 'x', '0');
       imgEl.setAttributeNS(null, 'y', pf(-h));
       imgEl.setAttributeNS(null, 'transform',

--- a/src/main_loader.js
+++ b/src/main_loader.js
@@ -54,6 +54,7 @@
   exports.InvalidPDFException = sharedUtil.InvalidPDFException;
   exports.MissingPDFException = sharedUtil.MissingPDFException;
   exports.SVGGraphics = displaySVG.SVGGraphics;
+  exports.NativeImageDecoding = sharedUtil.NativeImageDecoding;
   exports.UnexpectedResponseException = sharedUtil.UnexpectedResponseException;
   exports.OPS = sharedUtil.OPS;
   exports.UNSUPPORTED_FEATURES = sharedUtil.UNSUPPORTED_FEATURES;

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -42,6 +42,7 @@ exports.PasswordResponses = pdfjsSharedUtil.PasswordResponses;
 exports.InvalidPDFException = pdfjsSharedUtil.InvalidPDFException;
 exports.MissingPDFException = pdfjsSharedUtil.MissingPDFException;
 exports.SVGGraphics = pdfjsDisplaySVG.SVGGraphics;
+exports.NativeImageDecoding = pdfjsSharedUtil.NativeImageDecoding;
 exports.UnexpectedResponseException =
   pdfjsSharedUtil.UnexpectedResponseException;
 exports.OPS = pdfjsSharedUtil.OPS;

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -22,6 +22,12 @@ var globalScope = (typeof window !== 'undefined') ? window :
 
 var FONT_IDENTITY_MATRIX = [0.001, 0, 0, 0.001, 0, 0];
 
+const NativeImageDecoding = {
+  NONE: 'none',
+  DECODE: 'decode',
+  DISPLAY: 'display'
+};
+
 var TextRenderingMode = {
   FILL: 0,
   STROKE: 1,
@@ -1369,6 +1375,7 @@ export {
   MessageHandler,
   MissingDataException,
   MissingPDFException,
+  NativeImageDecoding,
   NotImplementedException,
   PageViewport,
   PasswordException,


### PR DESCRIPTION
Official example to use pdf2svg force all images export as png and object url from Blob, but in node.js, it won't work, so I try to fix some places in this example:
1. Force generate a base64 string when analyze image stream
2. If image type is jpeg, export it directly maybe better than transform to a png image
3. add a fake `Image` object in node.js environment

Because read image size when load jpeg stream is too complex, `width` and `height` of image in `paintJpegXObject` was replaced by `w` and `h` readed from args