### PR TITLE
Enable the `object-shorthand` ESLint rule in `web`

### DIFF
--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -45,7 +45,7 @@ class AnnotationLayerBuilder {
    * @param {string} intent (default value is 'display')
    */
   render(viewport, intent = 'display') {
-    this.pdfPage.getAnnotations({ intent }).then((annotations) => {
+    this.pdfPage.getAnnotations({ intent, }).then((annotations) => {
       var parameters = {
         viewport: viewport.clone({ dontFlip: true }),
         div: this.div,

--- a/web/app.js
+++ b/web/app.js
@@ -67,11 +67,11 @@ function configure(PDFJS) {
 }
 
 var DefaultExternalServices = {
-  updateFindControlState: function (data) {},
-  initPassiveLoading: function (callbacks) {},
-  fallback: function (data, callback) {},
-  reportTelemetry: function (data) {},
-  createDownloadManager: function () {
+  updateFindControlState(data) {},
+  initPassiveLoading(callbacks) {},
+  fallback(data, callback) {},
+  reportTelemetry(data) {},
+  createDownloadManager() {
     throw new Error('Not implemented: createDownloadManager');
   },
   createPreferences() {
@@ -181,7 +181,7 @@ var PDFViewerApplication = {
   /**
    * @private
    */
-  _readPreferences: function () {
+  _readPreferences() {
     var { preferences, viewerPrefs, } = this;
 
     return Promise.all([
@@ -257,20 +257,20 @@ var PDFViewerApplication = {
   /**
    * @private
    */
-  _initializeViewerComponents: function () {
+  _initializeViewerComponents() {
     var self = this;
     var appConfig = this.appConfig;
 
     return new Promise((resolve, reject) => {
       var eventBus = appConfig.eventBus || getGlobalEventBus();
-      self.eventBus = eventBus;
+      this.eventBus = eventBus;
 
       var pdfRenderingQueue = new PDFRenderingQueue();
       pdfRenderingQueue.onIdle = self.cleanup.bind(self);
       self.pdfRenderingQueue = pdfRenderingQueue;
 
       var pdfLinkService = new PDFLinkService({
-        eventBus: eventBus
+        eventBus,
       });
       self.pdfLinkService = pdfLinkService;
 
@@ -280,12 +280,12 @@ var PDFViewerApplication = {
       var container = appConfig.mainContainer;
       var viewer = appConfig.viewerContainer;
       self.pdfViewer = new PDFViewer({
-        container: container,
-        viewer: viewer,
-        eventBus: eventBus,
+        container,
+        viewer,
+        eventBus,
         renderingQueue: pdfRenderingQueue,
         linkService: pdfLinkService,
-        downloadManager: downloadManager,
+        downloadManager,
         renderer: self.viewerPrefs['renderer'],
         enhanceTextSelection: self.viewerPrefs['enhanceTextSelection'],
         renderInteractiveForms: self.viewerPrefs['renderInteractiveForms'],
@@ -304,7 +304,7 @@ var PDFViewerApplication = {
 
       self.pdfHistory = new PDFHistory({
         linkService: pdfLinkService,
-        eventBus: eventBus,
+        eventBus,
       });
       pdfLinkService.setHistory(self.pdfHistory);
 
@@ -353,10 +353,10 @@ var PDFViewerApplication = {
 
       if (self.supportsFullscreen) {
         self.pdfPresentationMode = new PDFPresentationMode({
-          container: container,
-          viewer: viewer,
+          container,
+          viewer,
           pdfViewer: self.pdfViewer,
-          eventBus: eventBus,
+          eventBus,
           contextMenuItems: appConfig.fullscreen
         });
       }
@@ -365,14 +365,14 @@ var PDFViewerApplication = {
 
       self.pdfOutlineViewer = new PDFOutlineViewer({
         container: appConfig.sidebar.outlineView,
-        eventBus: eventBus,
+        eventBus,
         linkService: pdfLinkService,
       });
 
       self.pdfAttachmentViewer = new PDFAttachmentViewer({
         container: appConfig.sidebar.attachmentsView,
-        eventBus: eventBus,
-        downloadManager: downloadManager,
+        eventBus,
+        downloadManager,
       });
 
       // FIXME better PDFSidebar constructor parameters
@@ -482,31 +482,31 @@ var PDFViewerApplication = {
     if (typeof PDFJSDev !== 'undefined' &&
         PDFJSDev.test('FIREFOX || MOZCENTRAL || CHROME')) {
       this.externalServices.initPassiveLoading({
-        onOpenWithTransport: function (url, length, transport) {
-          PDFViewerApplication.open(url, {range: transport});
+        onOpenWithTransport(url, length, transport) {
+          PDFViewerApplication.open(url, { range: transport, });
 
           if (length) {
             PDFViewerApplication.pdfDocumentProperties.setFileSize(length);
           }
         },
-        onOpenWithData: function (data) {
+        onOpenWithData(data) {
           PDFViewerApplication.open(data);
         },
-        onOpenWithURL: function (url, length, originalURL) {
+        onOpenWithURL(url, length, originalURL) {
           var file = url, args = null;
           if (length !== undefined) {
-            args = {length: length};
+            args = { length, };
           }
           if (originalURL !== undefined) {
-            file = {file: url, originalURL: originalURL};
+            file = { file: url, originalURL, };
           }
           PDFViewerApplication.open(file, args);
         },
-        onError: function (e) {
+        onError(err) {
           PDFViewerApplication.error(mozL10n.get('loading_error', null,
-            'An error occurred while loading the PDF.'), e);
+            'An error occurred while loading the PDF.'), err);
         },
-        onProgress: function (loaded, total) {
+        onProgress(loaded, total) {
           PDFViewerApplication.progress(loaded / total);
         }
       });
@@ -674,7 +674,7 @@ var PDFViewerApplication = {
         }
 
         var moreInfo = {
-          message: message
+          message,
         };
         self.error(loadingErrorMessage, moreInfo);
 
@@ -728,7 +728,7 @@ var PDFViewerApplication = {
       }
       this.fellback = true;
       this.externalServices.fallback({
-        featureId: featureId,
+        featureId,
         url: this.baseUrl,
       }, function response(download) {
         if (!download) {
@@ -1019,10 +1019,10 @@ var PDFViewerApplication = {
 
     Promise.all([onePageRendered, animationStarted]).then(function() {
       pdfDocument.getOutline().then(function(outline) {
-        self.pdfOutlineViewer.render({ outline: outline });
+        self.pdfOutlineViewer.render({ outline, });
       });
       pdfDocument.getAttachments().then(function(attachments) {
-        self.pdfAttachmentViewer.render({ attachments: attachments });
+        self.pdfAttachmentViewer.render({ attachments, });
       });
     });
 
@@ -1086,7 +1086,7 @@ var PDFViewerApplication = {
           type: 'documentInfo',
           version: versionId,
           generator: generatorId,
-          formType: formType
+          formType,
         });
       }
     });
@@ -1322,7 +1322,7 @@ if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
         'An error occurred while loading the PDF.');
 
       var moreInfo = {
-        message: message
+        message,
       };
       PDFViewerApplication.error(loadingErrorMessage, moreInfo);
       throw e;
@@ -1582,7 +1582,7 @@ function webViewerPageRendered(e) {
     PDFViewerApplication.pdfDocument.getStats().then(function (stats) {
       PDFViewerApplication.externalServices.reportTelemetry({
         type: 'documentStats',
-        stats: stats
+        stats,
       });
     });
   }
@@ -2206,7 +2206,7 @@ localized.then(function webViewerLocalized() {
 var PDFPrintServiceFactory = {
   instance: {
     supportsPrinting: false,
-    createPrintService: function () {
+    createPrintService() {
       throw new Error('Not implemented: createPrintService');
     }
   }

--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -38,8 +38,8 @@ var ChromeCom = {};
  */
 ChromeCom.request = function ChromeCom_request(action, data, callback) {
   var message = {
-    action: action,
-    data: data
+    action,
+    data,
   };
   if (!chrome.runtime) {
     console.error('chrome.runtime is undefined.');

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -459,14 +459,14 @@ var Stats = (function Stats() {
     name: 'Stats',
     panel: null,
     manager: null,
-    init: function init(pdfjsLib) {
+    init(pdfjsLib) {
       this.panel.setAttribute('style', 'padding: 5px;');
       pdfjsLib.PDFJS.enableStats = true;
     },
     enabled: false,
     active: false,
     // Stats specific functions.
-    add: function(pageNumber, stat) {
+    add(pageNumber, stat) {
       if (!stat) {
         return;
       }
@@ -485,7 +485,7 @@ var Stats = (function Stats() {
       statsDiv.textContent = stat.toString();
       wrapper.appendChild(title);
       wrapper.appendChild(statsDiv);
-      stats.push({ pageNumber: pageNumber, div: wrapper });
+      stats.push({ pageNumber, div: wrapper, });
       stats.sort(function(a, b) {
         return a.pageNumber - b.pageNumber;
       });
@@ -494,7 +494,7 @@ var Stats = (function Stats() {
         this.panel.appendChild(stats[i].div);
       }
     },
-    cleanup: function () {
+    cleanup() {
       stats = [];
       clear(this.panel);
     }
@@ -513,7 +513,7 @@ window.PDFBug = (function PDFBugClosure() {
       StepperManager,
       Stats
     ],
-    enable: function(ids) {
+    enable(ids) {
       var all = false, tools = this.tools;
       if (ids.length === 1 && ids[0] === 'all') {
         all = true;
@@ -535,7 +535,7 @@ window.PDFBug = (function PDFBugClosure() {
         });
       }
     },
-    init: function init(pdfjsLib, container) {
+    init(pdfjsLib, container) {
       /*
        * Basic Layout:
        * PDFBug
@@ -588,14 +588,14 @@ window.PDFBug = (function PDFBugClosure() {
       }
       this.selectPanel(0);
     },
-    cleanup: function cleanup() {
+    cleanup() {
       for (var i = 0, ii = this.tools.length; i < ii; i++) {
         if (this.tools[i].enabled) {
           this.tools[i].cleanup();
         }
       }
     },
-    selectPanel: function selectPanel(index) {
+    selectPanel(index) {
       if (typeof index !== 'number') {
         index = this.tools.indexOf(index);
       }

--- a/web/firefox_print_service.js
+++ b/web/firefox_print_service.js
@@ -75,7 +75,7 @@ function FirefoxPrintService(pdfDocument, pagesOverview, printContainer) {
 }
 
 FirefoxPrintService.prototype = {
-  layout: function () {
+  layout() {
     var pdfDocument = this.pdfDocument;
     var printContainer = this.printContainer;
     var body = document.querySelector('body');
@@ -86,7 +86,7 @@ FirefoxPrintService.prototype = {
     }
   },
 
-  destroy: function () {
+  destroy() {
     this.printContainer.textContent = '';
   }
 };
@@ -99,9 +99,8 @@ PDFPrintServiceFactory.instance = {
     return shadow(this, 'supportsPrinting', value);
   },
 
-  createPrintService: function (pdfDocument, pagesOverview, printContainer) {
-    return new FirefoxPrintService(pdfDocument, pagesOverview,
-                                   printContainer);
+  createPrintService(pdfDocument, pagesOverview, printContainer) {
+    return new FirefoxPrintService(pdfDocument, pagesOverview, printContainer);
   }
 };
 

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -34,13 +34,13 @@ var FirefoxCom = (function FirefoxComClosure() {
      * @param {String} data Optional data to send.
      * @return {*} The response.
      */
-    requestSync: function(action, data) {
+    requestSync(action, data) {
       var request = document.createTextNode('');
       document.documentElement.appendChild(request);
 
       var sender = document.createEvent('CustomEvent');
       sender.initCustomEvent('pdf.js.message', true, false,
-                             {action: action, data: data, sync: true});
+                             { action, data, sync: true, });
       request.dispatchEvent(sender);
       var response = sender.detail.response;
       document.documentElement.removeChild(request);
@@ -54,7 +54,7 @@ var FirefoxCom = (function FirefoxComClosure() {
      * @param {Function} callback Optional response callback that will be called
      * with one data argument.
      */
-    request: function(action, data, callback) {
+    request(action, data, callback) {
       var request = document.createTextNode('');
       if (callback) {
         document.addEventListener('pdf.js.response', function listener(event) {
@@ -71,8 +71,8 @@ var FirefoxCom = (function FirefoxComClosure() {
 
       var sender = document.createEvent('CustomEvent');
       sender.initCustomEvent('pdf.js.message', true, false, {
-        action: action,
-        data: data,
+        action,
+        data,
         sync: false,
         responseExpected: !!callback
       });
@@ -88,7 +88,7 @@ var DownloadManager = (function DownloadManagerClosure() {
     downloadUrl: function DownloadManager_downloadUrl(url, filename) {
       FirefoxCom.request('download', {
         originalUrl: url,
-        filename: filename
+        filename,
       });
     },
 
@@ -97,9 +97,9 @@ var DownloadManager = (function DownloadManagerClosure() {
       var blobUrl = createObjectURL(data, contentType, false);
 
       FirefoxCom.request('download', {
-        blobUrl: blobUrl,
+        blobUrl,
         originalUrl: blobUrl,
-        filename: filename,
+        filename,
         isAttachment: true
       });
     },
@@ -108,9 +108,9 @@ var DownloadManager = (function DownloadManagerClosure() {
       var blobUrl = window.URL.createObjectURL(blob);
 
       FirefoxCom.request('download', {
-        blobUrl: blobUrl,
+        blobUrl,
         originalUrl: url,
-        filename: filename
+        filename,
       },
         function response(err) {
           if (err && this.onerror) {
@@ -176,7 +176,7 @@ FirefoxComDataRangeTransport.prototype =
   Object.create(PDFDataRangeTransport.prototype);
 FirefoxComDataRangeTransport.prototype.requestDataRange =
     function FirefoxComDataRangeTransport_requestDataRange(begin, end) {
-  FirefoxCom.request('requestDataRange', { begin: begin, end: end });
+  FirefoxCom.request('requestDataRange', { begin, end, });
 };
 FirefoxComDataRangeTransport.prototype.abort =
     function FirefoxComDataRangeTransport_abort() {
@@ -185,11 +185,11 @@ FirefoxComDataRangeTransport.prototype.abort =
 };
 
 PDFViewerApplication.externalServices = {
-  updateFindControlState: function (data) {
+  updateFindControlState(data) {
     FirefoxCom.request('updateFindControlState', data);
   },
 
-  initPassiveLoading: function (callbacks) {
+  initPassiveLoading(callbacks) {
     var pdfDataRangeTransport;
 
     window.addEventListener('message', function windowMessage(e) {
@@ -235,15 +235,15 @@ PDFViewerApplication.externalServices = {
     FirefoxCom.requestSync('initPassiveLoading', null);
   },
 
-  fallback: function (data, callback) {
+  fallback(data, callback) {
     FirefoxCom.request('fallback', data, callback);
   },
 
-  reportTelemetry: function (data) {
+  reportTelemetry(data) {
     FirefoxCom.request('reportTelemetry', JSON.stringify(data));
   },
 
-  createDownloadManager: function () {
+  createDownloadManager() {
     return new DownloadManager();
   },
 
@@ -274,11 +274,11 @@ PDFViewerApplication.externalServices = {
 
 // l10n.js for Firefox extension expects services to be set.
 document.mozL10n.setExternalLocalizerServices({
-  getLocale: function () {
+  getLocale() {
     return FirefoxCom.requestSync('getLocale', null);
   },
 
-  getStrings: function (key) {
+  getStrings(key) {
     return FirefoxCom.requestSync('getStrings', key);
   }
 });

--- a/web/hand_tool.js
+++ b/web/hand_tool.js
@@ -39,9 +39,9 @@ var HandTool = (function HandToolClosure() {
 
     this.handTool = new GrabToPan({
       element: this.container,
-      onActiveChanged: function(isActive) {
-        this.eventBus.dispatch('handtoolchanged', {isActive: isActive});
-      }.bind(this)
+      onActiveChanged: (isActive) => {
+        this.eventBus.dispatch('handtoolchanged', { isActive, });
+      },
     });
 
     this.eventBus.on('togglehandtool', this.toggle.bind(this));

--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint-disable no-unused-vars */
 
 'use strict';
 
@@ -31,31 +32,31 @@ IPDFLinkService.prototype = {
   /**
    * @param dest - The PDF destination object.
    */
-  navigateTo: function (dest) {},
+  navigateTo(dest) {},
   /**
    * @param dest - The PDF destination object.
    * @returns {string} The hyperlink to the PDF object.
    */
-  getDestinationHash: function (dest) {},
+  getDestinationHash(dest) {},
   /**
    * @param hash - The PDF parameters/hash.
    * @returns {string} The hyperlink to the PDF object.
    */
-  getAnchorUrl: function (hash) {},
+  getAnchorUrl(hash) {},
   /**
    * @param {string} hash
    */
-  setHash: function (hash) {},
+  setHash(hash) {},
   /**
    * @param {string} action
    */
-  executeNamedAction: function (action) {},
+  executeNamedAction(action) {},
 
   /**
    * @param {number} pageNum - page number.
    * @param {Object} pageRef - reference to the page.
    */
-  cachePageRef: function (pageNum, pageRef) {},
+  cachePageRef(pageNum, pageRef) {},
 };
 
 /**
@@ -63,10 +64,10 @@ IPDFLinkService.prototype = {
  */
 function IPDFHistory() {}
 IPDFHistory.prototype = {
-  forward: function () {},
-  back: function () {},
-  push: function (params) {},
-  updateNextHashParam: function (hash) {},
+  forward() {},
+  back() {},
+  push(params) {},
+  updateNextHashParam(hash) {},
 };
 
 /**
@@ -85,8 +86,8 @@ IRenderableView.prototype = {
   /**
    * @returns {Promise} Resolved on draw completion.
    */
-  draw: function () {},
-  resume: function () {},
+  draw() {},
+  resume() {},
 };
 
 /**
@@ -101,14 +102,14 @@ IPDFTextLayerFactory.prototype = {
    * @param {boolean} enhanceTextSelection
    * @returns {TextLayerBuilder}
    */
-  createTextLayerBuilder: function (textLayerDiv, pageIndex, viewport,
-                                    enhanceTextSelection) {}
+  createTextLayerBuilder(textLayerDiv, pageIndex, viewport,
+                         enhanceTextSelection = false) {}
 };
 
 /**
  * @interface
  */
-class IPDFAnnotationLayerFactory { // eslint-disable-line no-unused-vars
+class IPDFAnnotationLayerFactory {
   /**
    * @param {HTMLDivElement} pageDiv
    * @param {PDFPage} pdfPage

--- a/web/overlay_manager.js
+++ b/web/overlay_manager.js
@@ -39,10 +39,12 @@ var OverlayManager = {
       } else if (this.overlays[name]) {
         throw new Error('The overlay is already registered.');
       }
-      this.overlays[name] = { element: element,
-                              container: container,
-                              callerCloseMethod: (callerCloseMethod || null),
-                              canForceClose: (canForceClose || false) };
+      this.overlays[name] = {
+        element,
+        container,
+        callerCloseMethod: (callerCloseMethod || null),
+        canForceClose: (canForceClose || false),
+      };
       resolve();
     }.bind(this));
   },

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -111,14 +111,14 @@ var PDFLinkService = (function PDFLinkServiceClosure() {
             return;
           }
           self.pdfViewer.scrollPageIntoView({
-            pageNumber: pageNumber,
+            pageNumber,
             destArray: dest,
           });
 
           if (self.pdfHistory) {
             // Update the browsing history.
             self.pdfHistory.push({
-              dest: dest,
+              dest,
               hash: destString,
               page: pageNumber
             });
@@ -333,14 +333,14 @@ var PDFLinkService = (function PDFLinkServiceClosure() {
 
       this.eventBus.dispatch('namedaction', {
         source: this,
-        action: action
+        action,
       });
     },
 
     /**
      * @param {Object} params
      */
-    onFileAttachmentAnnotation: function (params) {
+    onFileAttachmentAnnotation(params = {}) {
       this.eventBus.dispatch('fileattachmentannotation', {
         source: this,
         id: params.id,
@@ -438,38 +438,38 @@ var SimpleLinkService = (function SimpleLinkServiceClosure() {
     /**
      * @param dest - The PDF destination object.
      */
-    navigateTo: function (dest) {},
+    navigateTo(dest) {},
     /**
      * @param dest - The PDF destination object.
      * @returns {string} The hyperlink to the PDF object.
      */
-    getDestinationHash: function (dest) {
+    getDestinationHash(dest) {
       return '#';
     },
     /**
      * @param hash - The PDF parameters/hash.
      * @returns {string} The hyperlink to the PDF object.
      */
-    getAnchorUrl: function (hash) {
+    getAnchorUrl(hash) {
       return '#';
     },
     /**
      * @param {string} hash
      */
-    setHash: function (hash) {},
+    setHash(hash) {},
     /**
      * @param {string} action
      */
-    executeNamedAction: function (action) {},
+    executeNamedAction(action) {},
     /**
      * @param {Object} params
      */
-    onFileAttachmentAnnotation: function (params) {},
+    onFileAttachmentAnnotation(params) {},
     /**
      * @param {number} pageNum - page number.
      * @param {Object} pageRef - reference to the page.
      */
-    cachePageRef: function (pageNum, pageRef) {}
+    cachePageRef(pageNum, pageRef) {}
   };
   return SimpleLinkService;
 })();

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -127,7 +127,7 @@ var PDFPageView = (function PDFPageViewClosure() {
     /**
      * @private
      */
-    _resetZoomLayer: function(removeFromDOM) {
+    _resetZoomLayer(removeFromDOM = false) {
       if (!this.zoomLayer) {
         return;
       }
@@ -493,15 +493,15 @@ var PDFPageView = (function PDFPageViewClosure() {
       return resultPromise;
     },
 
-    paintOnCanvas: function (canvasWrapper) {
+    paintOnCanvas(canvasWrapper) {
       var renderCapability = createPromiseCapability();
 
       var result = {
         promise: renderCapability.promise,
-        onRenderContinue: function (cont) {
+        onRenderContinue(cont) {
           cont();
         },
-        cancel: function () {
+        cancel() {
           renderTask.cancel();
         }
       };
@@ -568,7 +568,7 @@ var PDFPageView = (function PDFPageViewClosure() {
         [outputScale.sx, 0, 0, outputScale.sy, 0, 0];
       var renderContext = {
         canvasContext: ctx,
-        transform: transform,
+        transform,
         viewport: this.viewport,
         renderInteractiveForms: this.renderInteractiveForms,
         // intent: 'default', // === 'display'
@@ -604,8 +604,8 @@ var PDFPageView = (function PDFPageViewClosure() {
         // "TypeError: paintTask.promise is undefined".
         return {
           promise: Promise.reject(new Error('SVG rendering is not supported.')),
-          onRenderContinue: function (cont) { },
-          cancel: function () { },
+          onRenderContinue(cont) { },
+          cancel() { },
         };
       }
 
@@ -641,11 +641,11 @@ var PDFPageView = (function PDFPageViewClosure() {
       });
 
       return {
-        promise: promise,
-        onRenderContinue: function (cont) {
+        promise,
+        onRenderContinue(cont) {
           cont();
         },
-        cancel: function () {
+        cancel() {
           cancelled = true;
         }
       };

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -51,8 +51,8 @@ function renderPage(activeServiceOnEntry, pdfDocument, pageNumber, size) {
     return pdfPage.render(renderContext).promise;
   }).then(function () {
     return {
-      width: width,
-      height: height,
+      width,
+      height,
     };
   });
 }
@@ -67,7 +67,7 @@ function PDFPrintService(pdfDocument, pagesOverview, printContainer) {
 }
 
 PDFPrintService.prototype = {
-  layout: function () {
+  layout() {
     this.throwIfInactive();
 
     var body = document.querySelector('body');
@@ -102,7 +102,7 @@ PDFPrintService.prototype = {
     body.appendChild(this.pageStyleSheet);
   },
 
-  destroy: function () {
+  destroy() {
     if (activeService !== this) {
       // |activeService| cannot be replaced without calling destroy() first,
       // so if it differs then an external consumer has a stale reference to
@@ -125,7 +125,7 @@ PDFPrintService.prototype = {
     });
   },
 
-  renderPages: function () {
+  renderPages() {
     var pageCount = this.pagesOverview.length;
     var renderNextPage = function (resolve, reject) {
       this.throwIfInactive();
@@ -145,7 +145,7 @@ PDFPrintService.prototype = {
     return new Promise(renderNextPage);
   },
 
-  useRenderedPage: function (printItem) {
+  useRenderedPage(printItem) {
     this.throwIfInactive();
     var img = document.createElement('img');
     img.style.width = printItem.width;
@@ -170,7 +170,7 @@ PDFPrintService.prototype = {
     });
   },
 
-  performPrint: function () {
+  performPrint() {
     this.throwIfInactive();
     return new Promise(function (resolve) {
       // Push window.print in the macrotask queue to avoid being affected by
@@ -192,7 +192,7 @@ PDFPrintService.prototype = {
     return this === activeService;
   },
 
-  throwIfInactive: function () {
+  throwIfInactive() {
     if (!this.active) {
       throw new Error('This print request was cancelled or completed.');
     }
@@ -260,7 +260,7 @@ function renderProgress(index, total) {
   var progressPerc = progressContainer.querySelector('.relative-progress');
   progressBar.value = progress;
   progressPerc.textContent = mozL10n.get('print_progress_percent',
-    {progress: progress}, progress + '%');
+    { progress, }, progress + '%');
 }
 
 var hasAttachEvent = !!document.attachEvent;
@@ -320,7 +320,7 @@ function ensureOverlay() {
 PDFPrintServiceFactory.instance = {
   supportsPrinting: true,
 
-  createPrintService: function (pdfDocument, pagesOverview, printContainer) {
+  createPrintService(pdfDocument, pagesOverview, printContainer) {
     if (activeService) {
       throw new Error('The print service is created and active.');
     }

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -195,8 +195,7 @@ var PDFThumbnailViewer = (function PDFThumbnailViewerClosure() {
      * @returns {PDFPage}
      * @private
      */
-    _ensurePdfPageLoaded:
-        function PDFThumbnailViewer_ensurePdfPageLoaded(thumbView) {
+    _ensurePdfPageLoaded(thumbView) {
       if (thumbView.pdfPage) {
         return Promise.resolve(thumbView.pdfPage);
       }
@@ -204,25 +203,24 @@ var PDFThumbnailViewer = (function PDFThumbnailViewerClosure() {
       if (this._pagesRequests[pageNumber]) {
         return this._pagesRequests[pageNumber];
       }
-      var promise = this.pdfDocument.getPage(pageNumber).then(
-        function (pdfPage) {
-          thumbView.setPdfPage(pdfPage);
-          this._pagesRequests[pageNumber] = null;
-          return pdfPage;
-        }.bind(this));
+      var promise = this.pdfDocument.getPage(pageNumber).then((pdfPage) => {
+        thumbView.setPdfPage(pdfPage);
+        this._pagesRequests[pageNumber] = null;
+        return pdfPage;
+      });
       this._pagesRequests[pageNumber] = promise;
       return promise;
     },
 
-    forceRendering: function () {
+    forceRendering() {
       var visibleThumbs = this._getVisibleThumbs();
       var thumbView = this.renderingQueue.getHighestPriority(visibleThumbs,
                                                              this.thumbnails,
                                                              this.scroll.down);
       if (thumbView) {
-        this._ensurePdfPageLoaded(thumbView).then(function () {
+        this._ensurePdfPageLoaded(thumbView).then(() => {
           this.renderingQueue.renderView(thumbView);
-        }.bind(this));
+        });
         return true;
       }
       return false;

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -138,7 +138,7 @@ var PDFViewer = (function pdfViewer() {
       return this._pages.length;
     },
 
-    getPageView: function (index) {
+    getPageView(index) {
       return this._pages[index];
     },
 
@@ -301,7 +301,7 @@ var PDFViewer = (function pdfViewer() {
     /**
      * @param pdfDocument {PDFDocument}
      */
-    setDocument: function (pdfDocument) {
+    setDocument(pdfDocument) {
       if (this.pdfDocument) {
         this._cancelRendering();
         this._resetView();
@@ -360,10 +360,10 @@ var PDFViewer = (function pdfViewer() {
             container: this.viewer,
             eventBus: this.eventBus,
             id: pageNum,
-            scale: scale,
+            scale,
             defaultViewport: viewport.clone(),
             renderingQueue: this.renderingQueue,
-            textLayerFactory: textLayerFactory,
+            textLayerFactory,
             annotationLayerFactory: this,
             enhanceTextSelection: this.enhanceTextSelection,
             renderInteractiveForms: this.renderInteractiveForms,
@@ -433,7 +433,7 @@ var PDFViewer = (function pdfViewer() {
       }
     },
 
-    _resetView: function () {
+    _resetView() {
       this._pages = [];
       this._currentPageNumber = 1;
       this._currentScale = UNKNOWN_SCALE;
@@ -560,7 +560,7 @@ var PDFViewer = (function pdfViewer() {
      * Refreshes page view: scrolls to the current page and updates the scale.
      * @private
      */
-    _resetCurrentPageView: function () {
+    _resetCurrentPageView() {
       if (this.isInPresentationMode) {
         // Fixes the case when PDF has different page sizes.
         this._setScale(this._currentScaleValue, true);
@@ -701,10 +701,10 @@ var PDFViewer = (function pdfViewer() {
         left = Math.max(left, 0);
         top = Math.max(top, 0);
       }
-      scrollIntoView(pageView.div, { left: left, top: top });
+      scrollIntoView(pageView.div, { left, top, });
     },
 
-    _updateLocation: function (firstPage) {
+    _updateLocation(firstPage) {
       var currentScale = this._currentScale;
       var currentScaleValue = this._currentScaleValue;
       var normalizedScaleValue =
@@ -724,11 +724,11 @@ var PDFViewer = (function pdfViewer() {
       pdfOpenParams += ',' + intLeft + ',' + intTop;
 
       this._location = {
-        pageNumber: pageNumber,
+        pageNumber,
         scale: normalizedScaleValue,
         top: intTop,
         left: intLeft,
-        pdfOpenParams: pdfOpenParams
+        pdfOpenParams,
       };
     },
 
@@ -777,11 +777,11 @@ var PDFViewer = (function pdfViewer() {
       });
     },
 
-    containsElement: function (element) {
+    containsElement(element) {
       return this.container.contains(element);
     },
 
-    focus: function () {
+    focus() {
       this.container.focus();
     },
 
@@ -798,7 +798,7 @@ var PDFViewer = (function pdfViewer() {
         false : (this.container.scrollWidth > this.container.clientWidth));
     },
 
-    _getVisiblePages: function () {
+    _getVisiblePages() {
       if (!this.isInPresentationMode) {
         return getVisibleElements(this.container, this._pages, true);
       }
@@ -810,7 +810,7 @@ var PDFViewer = (function pdfViewer() {
       return { first: currentPage, last: currentPage, views: visible };
     },
 
-    cleanup: function () {
+    cleanup() {
       for (var i = 0, ii = this._pages.length; i < ii; i++) {
         if (this._pages[i] &&
             this._pages[i].renderingState !== RenderingStates.FINISHED) {
@@ -835,7 +835,7 @@ var PDFViewer = (function pdfViewer() {
      * @returns {PDFPage}
      * @private
      */
-    _ensurePdfPageLoaded: function (pageView) {
+    _ensurePdfPageLoaded(pageView) {
       if (pageView.pdfPage) {
         return Promise.resolve(pageView.pdfPage);
       }
@@ -854,7 +854,7 @@ var PDFViewer = (function pdfViewer() {
       return promise;
     },
 
-    forceRendering: function (currentlyVisiblePages) {
+    forceRendering(currentlyVisiblePages) {
       var visiblePages = currentlyVisiblePages || this._getVisiblePages();
       var pageView = this.renderingQueue.getHighestPriority(visiblePages,
                                                             this._pages,
@@ -868,7 +868,7 @@ var PDFViewer = (function pdfViewer() {
       return false;
     },
 
-    getPageTextContent: function (pageIndex) {
+    getPageTextContent(pageIndex) {
       return this.pdfDocument.getPage(pageIndex + 1).then(function (page) {
         return page.getTextContent({
           normalizeWhitespace: true,
@@ -882,13 +882,13 @@ var PDFViewer = (function pdfViewer() {
      * @param {PageViewport} viewport
      * @returns {TextLayerBuilder}
      */
-    createTextLayerBuilder: function (textLayerDiv, pageIndex, viewport,
-                                      enhanceTextSelection) {
+    createTextLayerBuilder(textLayerDiv, pageIndex, viewport,
+                           enhanceTextSelection = false) {
       return new TextLayerBuilder({
-        textLayerDiv: textLayerDiv,
+        textLayerDiv,
         eventBus: this.eventBus,
-        pageIndex: pageIndex,
-        viewport: viewport,
+        pageIndex,
+        viewport,
         findController: this.isInPresentationMode ? null : this.findController,
         enhanceTextSelection: this.isInPresentationMode ? false :
                                                           enhanceTextSelection,
@@ -901,18 +901,18 @@ var PDFViewer = (function pdfViewer() {
      * @param {boolean} renderInteractiveForms
      * @returns {AnnotationLayerBuilder}
      */
-    createAnnotationLayerBuilder: function (pageDiv, pdfPage,
-                                            renderInteractiveForms) {
+    createAnnotationLayerBuilder(pageDiv, pdfPage,
+                                 renderInteractiveForms = false) {
       return new AnnotationLayerBuilder({
-        pageDiv: pageDiv,
-        pdfPage: pdfPage,
-        renderInteractiveForms: renderInteractiveForms,
+        pageDiv,
+        pdfPage,
+        renderInteractiveForms,
         linkService: this.linkService,
         downloadManager: this.downloadManager
       });
     },
 
-    setFindController: function (findController) {
+    setFindController(findController) {
       this.findController = findController;
     },
 
@@ -920,7 +920,7 @@ var PDFViewer = (function pdfViewer() {
      * Returns sizes of the pages.
      * @returns {Array} Array of objects with width/height/rotation fields.
      */
-    getPagesOverview: function () {
+    getPagesOverview() {
       var pagesOverview = this._pages.map(function (pageView) {
         var viewport = pageView.pdfPage.getViewport(1);
         return {

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -91,7 +91,7 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
         container: textLayerFrag,
         viewport: this.viewport,
         textDivs: this.textDivs,
-        timeout: timeout,
+        timeout,
         enhanceTextSelection: this.enhanceTextSelection,
       });
       this.textLayerRenderTask.promise.then(function () {
@@ -397,13 +397,13 @@ DefaultTextLayerFactory.prototype = {
    * @param {boolean} enhanceTextSelection
    * @returns {TextLayerBuilder}
    */
-  createTextLayerBuilder: function (textLayerDiv, pageIndex, viewport,
-                                    enhanceTextSelection) {
+  createTextLayerBuilder(textLayerDiv, pageIndex, viewport,
+                         enhanceTextSelection = false) {
     return new TextLayerBuilder({
-      textLayerDiv: textLayerDiv,
-      pageIndex: pageIndex,
-      viewport: viewport,
-      enhanceTextSelection: enhanceTextSelection
+      textLayerDiv,
+      pageIndex,
+      viewport,
+      enhanceTextSelection,
     });
   }
 };

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -70,25 +70,25 @@ var Toolbar = (function ToolbarClosure() {
   }
 
   Toolbar.prototype = {
-    setPageNumber: function (pageNumber, pageLabel) {
+    setPageNumber(pageNumber, pageLabel) {
       this.pageNumber = pageNumber;
       this.pageLabel = pageLabel;
       this._updateUIState(false);
     },
 
-    setPagesCount: function (pagesCount, hasPageLabels) {
+    setPagesCount(pagesCount, hasPageLabels) {
       this.pagesCount = pagesCount;
       this.hasPageLabels = hasPageLabels;
       this._updateUIState(true);
     },
 
-    setPageScale: function (pageScaleValue, pageScale) {
+    setPageScale(pageScaleValue, pageScale) {
       this.pageScaleValue = pageScaleValue;
       this.pageScale = pageScale;
       this._updateUIState(false);
     },
 
-    reset: function () {
+    reset() {
       this.pageNumber = 0;
       this.pageLabel = null;
       this.hasPageLabels = false;
@@ -209,7 +209,7 @@ var Toolbar = (function ToolbarClosure() {
         } else {
           items.pageNumber.type = 'number';
           items.numPages.textContent = mozL10n.get('of_pages',
-            { pagesCount: pagesCount }, 'of {{pagesCount}}');
+            { pagesCount, }, 'of {{pagesCount}}');
         }
         items.pageNumber.max = pagesCount;
       }
@@ -217,8 +217,7 @@ var Toolbar = (function ToolbarClosure() {
       if (this.hasPageLabels) {
         items.pageNumber.value = this.pageLabel;
         items.numPages.textContent = mozL10n.get('page_of_pages',
-          { pageNumber: pageNumber, pagesCount: pagesCount },
-          '({{pageNumber}} of {{pagesCount}})');
+          { pageNumber, pagesCount, }, '({{pageNumber}} of {{pagesCount}})');
       } else {
         items.pageNumber.value = pageNumber;
       }

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -328,7 +328,7 @@ function getVisibleElements(scrollEl, views, sortByVisibility) {
       id: view.id,
       x: currentWidth,
       y: currentHeight,
-      view: view,
+      view,
       percent: percentHeight
     });
   }
@@ -345,7 +345,7 @@ function getVisibleElements(scrollEl, views, sortByVisibility) {
       return a.id - b.id; // ensure stability
     });
   }
-  return {first: first, last: last, views: visible};
+  return { first, last, views: visible, };
 }
 
 /**


### PR DESCRIPTION
Since we're using Babel, it's now possible for us to use the more compact object notation available in ES6 (see [this MDN article](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Object_initializer#New_notations_in_ECMAScript_2015)).

Please see http://eslint.org/docs/rules/object-shorthand; this is one of the rules mentioned in issue #7957.

*Note:* I initially created *one* big patch for this change, see https://github.com/mozilla/pdf.js/compare/master...Snuffleupagus:eslint-object-shorthand, but after looking at the diff I quickly realized that it was too big and I don't think anyone would want to review that. Hence I've decided to split it up into more manageable chunks instead.