### PR TITLE
Enable the `object-shorthand` ESLint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -154,7 +154,7 @@
     "no-useless-computed-key": "error",
     "no-useless-constructor": "error",
     "no-useless-rename": "error",
-    "object-shorthand": ["off", "always", {
+    "object-shorthand": ["error", "always", {
       "avoidQuotes": true,
     }],
     "rest-spread-spacing": ["error", "never"],

--- a/extensions/chromium/.eslintrc
+++ b/extensions/chromium/.eslintrc
@@ -6,4 +6,8 @@
   "parserOptions": {
     "sourceType": "script"
   },
+
+  "rules": {
+    "object-shorthand": "off",
+  },
 }

--- a/external/.eslintrc
+++ b/external/.eslintrc
@@ -7,4 +7,8 @@
     "node": true,
     "shelljs": true,
   },
+
+  "rules": {
+    "object-shorthand": "off",
+  },
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 /* eslint-env node */
+/* eslint-disable object-shorthand */
 /* globals target */
 
 'use strict';

--- a/test/chromium/test-telemetry.js
+++ b/test/chromium/test-telemetry.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint-disable object-shorthand */
 
 'use strict';
 

--- a/test/downloadutils.js
+++ b/test/downloadutils.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint-disable object-shorthand */
 
 'use strict';
 

--- a/test/driver.js
+++ b/test/driver.js
@@ -32,23 +32,23 @@ var LinkServiceMock = (function LinkServiceMockClosure() {
 
     set page(value) {},
 
-    navigateTo: function (dest) {},
+    navigateTo(dest) {},
 
-    getDestinationHash: function (dest) {
+    getDestinationHash(dest) {
       return '#';
     },
 
-    getAnchorUrl: function (hash) {
+    getAnchorUrl(hash) {
       return '#';
     },
 
-    setHash: function (hash) {},
+    setHash(hash) {},
 
-    executeNamedAction: function (action) {},
+    executeNamedAction(action) {},
 
-    onFileAttachmentAnnotation: function (params) {},
+    onFileAttachmentAnnotation(params) {},
 
-    cachePageRef: function (pageNum, pageRef) {},
+    cachePageRef(pageNum, pageRef) {},
   };
 
   return LinkServiceMock;
@@ -101,10 +101,10 @@ var rasterizeTextLayer = (function rasterizeTextLayerClosure() {
 
       // Rendering text layer as HTML.
       var task = PDFJS.renderTextLayer({
-        textContent: textContent,
+        textContent,
         container: div,
-        viewport: viewport,
-        enhanceTextSelection: enhanceTextSelection,
+        viewport,
+        enhanceTextSelection,
       });
       Promise.all([stylePromise, task.promise]).then(function (results) {
         task.expandTextDivs(true);
@@ -200,11 +200,11 @@ var rasterizeAnnotationLayer = (function rasterizeAnnotationLayerClosure() {
         var annotation_viewport = viewport.clone({ dontFlip: true });
         var parameters = {
           viewport: annotation_viewport,
-          div: div,
-          annotations: annotations,
-          page: page,
+          div,
+          annotations,
+          page,
           linkService: new LinkServiceMock(),
-          renderInteractiveForms: renderInteractiveForms,
+          renderInteractiveForms,
         };
         PDFJS.AnnotationLayer.render(parameters);
 
@@ -527,7 +527,7 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
 
             var renderContext = {
               canvasContext: ctx,
-              viewport: viewport,
+              viewport,
               renderInteractiveForms: renderForms,
             };
             var completeRender = (function(error) {
@@ -605,7 +605,7 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
     _info: function Driver_info(message) {
       this._send('/info', JSON.stringify({
         browser: this.browser,
-        message: message
+        message,
       }));
     },
 
@@ -641,11 +641,11 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
         numPages: task.pdfDoc ?
                   (task.lastPage || task.pdfDoc.numPages) : 0,
         lastPageNum: this._getLastPageNumber(task),
-        failure: failure,
+        failure,
         file: task.file,
         round: task.round,
         page: task.pageNum,
-        snapshot: snapshot,
+        snapshot,
         stats: task.stats.times
       });
       this._send('/submit_task_results', result, callback);

--- a/test/font/jasmine-boot.js
+++ b/test/font/jasmine-boot.js
@@ -71,7 +71,7 @@ function initializePDFJS(callback) {
 
   // Runner Parameters
   var queryString = new jasmine.QueryString({
-    getWindowLocation: function() {
+    getWindowLocation() {
       return window.location;
     }
   });
@@ -93,27 +93,27 @@ function initializePDFJS(callback) {
 
   // Reporters
   var htmlReporter = new jasmine.HtmlReporter({
-    env: env,
-    onRaiseExceptionsClick: function() {
+    env,
+    onRaiseExceptionsClick() {
       queryString.navigateWithNewParam('catch', !env.catchingExceptions());
     },
-    onThrowExpectationsClick: function() {
+    onThrowExpectationsClick() {
       queryString.navigateWithNewParam('throwFailures',
                                        !env.throwingExpectationFailures());
     },
-    onRandomClick: function() {
+    onRandomClick() {
       queryString.navigateWithNewParam('random', !env.randomTests());
     },
-    addToExistingQueryString: function(key, value) {
+    addToExistingQueryString(key, value) {
       return queryString.fullStringWithNewParam(key, value);
     },
-    getContainer: function() {
+    getContainer() {
       return document.body;
     },
-    createElement: function() {
+    createElement() {
       return document.createElement.apply(document, arguments);
     },
-    createTextNode: function() {
+    createTextNode() {
       return document.createTextNode.apply(document, arguments);
     },
     timer: new jasmine.Timer()
@@ -130,7 +130,7 @@ function initializePDFJS(callback) {
   // Filter which specs will be run by matching the start of the full name
   // against the `spec` query param.
   var specFilter = new jasmine.HtmlSpecFilter({
-    filterString: function() {
+    filterString() {
       return queryString.getParam('spec');
     }
   });

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint-disable object-shorthand */
 
 'use strict';
 

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -34,10 +34,10 @@ describe('annotation', function() {
     }
   }
   XRefMock.prototype = {
-    fetch: function (ref) {
+    fetch(ref) {
       return this.map[ref.toString()];
     },
-    fetchIfRef: function (obj) {
+    fetchIfRef(obj) {
       if (!isRef(obj)) {
         return obj;
       }
@@ -56,7 +56,7 @@ describe('annotation', function() {
       obj: params.startObjId || 0,
     };
     return {
-      createObjId: function () {
+      createObjId() {
         return uniquePrefix + (++idCounters.obj);
       },
     };
@@ -153,7 +153,7 @@ describe('annotation', function() {
     });
 
     it('should set and get flags', function() {
-      var annotation = new Annotation({ dict: dict, ref: ref });
+      var annotation = new Annotation({ dict, ref, });
       annotation.setFlags(13);
 
       expect(annotation.hasFlag(AnnotationFlag.INVISIBLE)).toEqual(true);
@@ -163,63 +163,63 @@ describe('annotation', function() {
     });
 
     it('should be viewable and not printable by default', function() {
-      var annotation = new Annotation({ dict: dict, ref: ref });
+      var annotation = new Annotation({ dict, ref, });
 
       expect(annotation.viewable).toEqual(true);
       expect(annotation.printable).toEqual(false);
     });
 
     it('should set and get a valid rectangle', function() {
-      var annotation = new Annotation({ dict: dict, ref: ref });
+      var annotation = new Annotation({ dict, ref, });
       annotation.setRectangle([117, 694, 164.298, 720]);
 
       expect(annotation.rectangle).toEqual([117, 694, 164.298, 720]);
     });
 
     it('should not set and get an invalid rectangle', function() {
-      var annotation = new Annotation({ dict: dict, ref: ref });
+      var annotation = new Annotation({ dict, ref, });
       annotation.setRectangle([117, 694, 164.298]);
 
       expect(annotation.rectangle).toEqual([0, 0, 0, 0]);
     });
 
     it('should reject a color if it is not an array', function() {
-      var annotation = new Annotation({ dict: dict, ref: ref });
+      var annotation = new Annotation({ dict, ref, });
       annotation.setColor('red');
 
       expect(annotation.color).toEqual(new Uint8Array([0, 0, 0]));
     });
 
     it('should set and get a transparent color', function() {
-      var annotation = new Annotation({ dict: dict, ref: ref });
+      var annotation = new Annotation({ dict, ref, });
       annotation.setColor([]);
 
       expect(annotation.color).toEqual(null);
     });
 
     it('should set and get a grayscale color', function() {
-      var annotation = new Annotation({ dict: dict, ref: ref });
+      var annotation = new Annotation({ dict, ref, });
       annotation.setColor([0.4]);
 
       expect(annotation.color).toEqual(new Uint8Array([102, 102, 102]));
     });
 
     it('should set and get an RGB color', function() {
-      var annotation = new Annotation({ dict: dict, ref: ref });
+      var annotation = new Annotation({ dict, ref, });
       annotation.setColor([0, 0, 1]);
 
       expect(annotation.color).toEqual(new Uint8Array([0, 0, 255]));
     });
 
     it('should set and get a CMYK color', function() {
-      var annotation = new Annotation({ dict: dict, ref: ref });
+      var annotation = new Annotation({ dict, ref, });
       annotation.setColor([0.1, 0.92, 0.84, 0.02]);
 
       expect(annotation.color).toEqual(new Uint8Array([233, 59, 47]));
     });
 
     it('should not set and get an invalid color', function() {
-      var annotation = new Annotation({ dict: dict, ref: ref });
+      var annotation = new Annotation({ dict, ref, });
       annotation.setColor([0.4, 0.6]);
 
       expect(annotation.color).toEqual(new Uint8Array([0, 0, 0]));

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -216,7 +216,7 @@ describe('api', function() {
         var url = new URL('../pdfs/pr6531_2.pdf', window.location).href;
 
         var passwordNeededLoadingTask = PDFJS.getDocument({
-          url: url, password: '',
+          url, password: '',
         });
         var result1 = passwordNeededLoadingTask.promise.then(function () {
           done.fail('shall fail with no password');
@@ -228,7 +228,7 @@ describe('api', function() {
         });
 
         var passwordIncorrectLoadingTask = PDFJS.getDocument({
-          url: url, password: 'qwerty',
+          url, password: 'qwerty',
         });
         var result2 = passwordIncorrectLoadingTask.promise.then(function () {
           done.fail('shall fail with wrong password');
@@ -240,7 +240,7 @@ describe('api', function() {
         });
 
         var passwordAcceptedLoadingTask = PDFJS.getDocument({
-          url: url, password: 'asdfasdf',
+          url, password: 'asdfasdf',
         });
 
         var result3 = passwordAcceptedLoadingTask.promise.then(function (data) {
@@ -259,7 +259,7 @@ describe('api', function() {
         var url = new URL('../pdfs/issue3371.pdf', window.location).href;
         var passwordNeededLoadingTask = PDFJS.getDocument(url);
         var passwordIncorrectLoadingTask = PDFJS.getDocument({
-          url: url, password: 'qwerty',
+          url, password: 'qwerty',
         });
 
         passwordNeededLoadingTask.onPassword = function (callback, reason) {
@@ -342,7 +342,7 @@ describe('api', function() {
     });
     it('worker created and can be used in getDocument', function (done) {
       var worker = new PDFJS.PDFWorker('test1');
-      var loadingTask = PDFJS.getDocument({url: basicApiUrl, worker: worker});
+      var loadingTask = PDFJS.getDocument({ url: basicApiUrl, worker, });
       loadingTask.promise.then(function () {
         var docWorker = loadingTask._worker;
         expect(!!docWorker).toEqual(false);
@@ -893,7 +893,7 @@ describe('api', function() {
       });
 
       var docBaseUrlLoadingTask = PDFJS.getDocument({
-        url: url,
+        url,
         docBaseUrl: 'http://www.example.com/test/pdfs/qwerty.pdf',
       });
       var docBaseUrlPromise = docBaseUrlLoadingTask.promise.then(
@@ -904,7 +904,7 @@ describe('api', function() {
       });
 
       var invalidDocBaseUrlLoadingTask = PDFJS.getDocument({
-        url: url,
+        url,
         docBaseUrl: 'qwerty.pdf',
       });
       var invalidDocBaseUrlPromise = invalidDocBaseUrlLoadingTask.promise.then(
@@ -1001,7 +1001,7 @@ describe('api', function() {
 
       var renderTask = page.render({
         canvasContext: canvasAndCtx.context,
-        viewport: viewport,
+        viewport,
       });
       renderTask.cancel();
 
@@ -1041,7 +1041,7 @@ describe('api', function() {
                                                   viewport.height);
           return page.render({
             canvasContext: canvasAndCtx.context,
-            viewport: viewport,
+            viewport,
           }).then(function() {
             var data = canvasAndCtx.canvas.toDataURL();
             CanvasFactory.destroy(canvasAndCtx);

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -46,7 +46,7 @@ describe('cmap', function() {
 
     fetchBuiltInCMap = function (name) {
       return CMapReaderFactory.fetch({
-        name: name,
+        name,
       });
     };
     done();
@@ -175,7 +175,7 @@ describe('cmap', function() {
     var stream = new StringStream(str);
     var cmapPromise = CMapFactory.create({
       encoding: stream,
-      fetchBuiltInCMap: fetchBuiltInCMap,
+      fetchBuiltInCMap,
       useCMap: null,
     });
     cmapPromise.then(function (cmap) {
@@ -214,7 +214,7 @@ describe('cmap', function() {
   it('loads built in cmap', function(done) {
     var cmapPromise = CMapFactory.create({
       encoding: Name.get('Adobe-Japan1-1'),
-      fetchBuiltInCMap: fetchBuiltInCMap,
+      fetchBuiltInCMap,
       useCMap: null,
     });
     cmapPromise.then(function (cmap) {
@@ -231,7 +231,7 @@ describe('cmap', function() {
   it('loads built in identity cmap', function(done) {
     var cmapPromise = CMapFactory.create({
       encoding: Name.get('Identity-H'),
-      fetchBuiltInCMap: fetchBuiltInCMap,
+      fetchBuiltInCMap,
       useCMap: null,
     });
     cmapPromise.then(function (cmap) {
@@ -250,7 +250,7 @@ describe('cmap', function() {
   it('attempts to load a non-existent built-in CMap', function(done) {
     var cmapPromise = CMapFactory.create({
       encoding: Name.get('null'),
-      fetchBuiltInCMap: fetchBuiltInCMap,
+      fetchBuiltInCMap,
       useCMap: null,
     });
     cmapPromise.then(function () {
@@ -268,7 +268,7 @@ describe('cmap', function() {
       var CMapReaderFactory = isNodeJS() ?
         new NodeCMapReaderFactory({ }) : new DOMCMapReaderFactory({ });
       return CMapReaderFactory.fetch({
-        name: name,
+        name,
       });
     }
 

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -24,7 +24,7 @@ describe('evaluator', function() {
     this.queue = queue || [];
   }
   XrefMock.prototype = {
-    fetchIfRef: function() {
+    fetchIfRef() {
       return this.queue.shift();
     }
   };
@@ -32,13 +32,13 @@ describe('evaluator', function() {
     this.inputs = [];
   }
   HandlerMock.prototype = {
-    send: function(name, data) {
-      this.inputs.push({name: name, data: data});
+    send(name, data) {
+      this.inputs.push({ name, data, });
     }
   };
   function ResourcesMock() { }
   ResourcesMock.prototype = {
-    get: function(name) {
+    get(name) {
       return this[name];
     }
   };
@@ -319,7 +319,7 @@ describe('evaluator', function() {
   describe('operator list', function () {
     function MessageHandlerMock() { }
     MessageHandlerMock.prototype = {
-      send: function () { },
+      send() { },
     };
 
     it('should get correct total length after flushing', function () {

--- a/test/unit/fonts_spec.js
+++ b/test/unit/fonts_spec.js
@@ -76,8 +76,8 @@ var checkProblematicCharRanges = function checkProblematicCharRanges() {
     throw new Error('Total number of chars must not exceed the PUA length.');
   }
   return {
-    numChars: numChars,
-    puaLength: puaLength,
+    numChars,
+    puaLength,
     percentage: 100 * (numChars / puaLength),
   };
 };

--- a/test/unit/function_spec.js
+++ b/test/unit/function_spec.js
@@ -23,9 +23,9 @@ import { StringStream } from '../../src/core/stream';
 describe('function', function() {
   beforeEach(function() {
     jasmine.addMatchers({
-      toMatchArray: function(util, customEqualityTesters) {
+      toMatchArray(util, customEqualityTesters) {
         return {
-          compare: function (actual, expected) {
+          compare(actual, expected) {
             var result = {};
             if (actual.length !== expected.length) {
               result.pass = false;

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -79,7 +79,7 @@ function initializePDFJS(callback) {
 
   // Runner Parameters
   var queryString = new jasmine.QueryString({
-    getWindowLocation: function() {
+    getWindowLocation() {
       return window.location;
     }
   });
@@ -101,27 +101,27 @@ function initializePDFJS(callback) {
 
   // Reporters
   var htmlReporter = new jasmine.HtmlReporter({
-    env: env,
-    onRaiseExceptionsClick: function() {
+    env,
+    onRaiseExceptionsClick() {
       queryString.navigateWithNewParam('catch', !env.catchingExceptions());
     },
-    onThrowExpectationsClick: function() {
+    onThrowExpectationsClick() {
       queryString.navigateWithNewParam('throwFailures',
                                        !env.throwingExpectationFailures());
     },
-    onRandomClick: function() {
+    onRandomClick() {
       queryString.navigateWithNewParam('random', !env.randomTests());
     },
-    addToExistingQueryString: function(key, value) {
+    addToExistingQueryString(key, value) {
       return queryString.fullStringWithNewParam(key, value);
     },
-    getContainer: function() {
+    getContainer() {
       return document.body;
     },
-    createElement: function() {
+    createElement() {
       return document.createElement.apply(document, arguments);
     },
-    createTextNode: function() {
+    createTextNode() {
       return document.createTextNode.apply(document, arguments);
     },
     timer: new jasmine.Timer()
@@ -138,7 +138,7 @@ function initializePDFJS(callback) {
   // Filter which specs will be run by matching the start of the full name
   // against the `spec` query param.
   var specFilter = new jasmine.HtmlSpecFilter({
-    filterString: function() {
+    filterString() {
       return queryString.getParam('spec');
     }
   });

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -27,19 +27,19 @@ describe('primitives', function() {
     }
   }
   XRefMock.prototype = {
-    fetch: function (ref) {
+    fetch(ref) {
       return this.map[ref.toString()];
     },
-    fetchIfRef: function (obj) {
+    fetchIfRef(obj) {
       if (!isRef(obj)) {
         return obj;
       }
       return this.fetch(obj);
     },
-    fetchAsync: function (ref) {
+    fetchAsync(ref) {
       return Promise.resolve(this.fetch(ref));
     },
-    fetchIfRefAsync: function (obj) {
+    fetchIfRefAsync(obj) {
       return Promise.resolve(this.fetchIfRef(obj));
     },
   };

--- a/test/unit/stream_spec.js
+++ b/test/unit/stream_spec.js
@@ -19,9 +19,9 @@ import { Dict } from '../../src/core/primitives';
 describe('stream', function() {
   beforeEach(function() {
     jasmine.addMatchers({
-      toMatchTypedArray: function(util, customEqualityTesters) {
+      toMatchTypedArray(util, customEqualityTesters) {
         return {
-          compare: function (actual, expected) {
+          compare(actual, expected) {
             var result = {};
             if (actual.length !== expected.length) {
               result.pass = false;

--- a/test/unit/testreporter.js
+++ b/test/unit/testreporter.js
@@ -24,13 +24,13 @@ var TestReporter = function(browser, appPath) {
   }
 
   function sendInfo(message) {
-    send('/info', {message: message});
+    send('/info', { message, });
   }
 
   function sendResult(status, description, error) {
     var message = {
-      status: status,
-      description: description
+      status,
+      description,
     };
     if (typeof error !== 'undefined') {
       message['error'] = error;

--- a/test/webbrowser.js
+++ b/test/webbrowser.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint-disable object-shorthand */
 
 'use strict';
 

--- a/test/webserver.js
+++ b/test/webserver.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint-disable object-shorthand */
 
 'use strict';
 


### PR DESCRIPTION
Please see http://eslint.org/docs/rules/object-shorthand. *Note:* This is another part of issue #7957.

Unfortunately, based on commit https://github.com/mozilla/pdf.js/commit/9276d1dcd97b4b0dc45342608a7f1b1a7f1e9c5b, it seems that we still need to maintain compatibility with old Node.js versions, hence certain files/directories that are executed in Node.js are currently exempt from this rule.

Furthermore, since the files specific to the Chromium extension are not run through Babel, the `/extensions/chromium/` directory is also exempt from this rule.