### PR TITLE
[Firefox addon] Replace a `bind(this)` statement with an arrow function in `PdfStreamConverter.jsm` (issue 8343)

### DIFF
--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -804,10 +804,10 @@ class FindEventManager {
   }
 
   bind() {
-    var unload = function(e) {
+    var unload = (evt) => {
       this.unbind();
-      this.contentWindow.removeEventListener(e.type, unload);
-    }.bind(this);
+      this.contentWindow.removeEventListener(evt.type, unload);
+    };
     this.contentWindow.addEventListener("unload", unload);
 
     // We cannot directly attach listeners to for the find events


### PR DESCRIPTION
Please note that I used the addon debugger to set a breakpoint in the `unload` function, in order to ensure that `this` still correctly refers to the `FindEventManager` scope.