### PR TITLE
Replace unnecessary `bind(this)` and `var self = this` statements with arrow functions in `src/core/evaluator.js`

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1584,8 +1584,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         var spacing = (glyph.isSpace ? wordSpacing : 0) + charSpacing;
         var operatorList = font.charProcOperatorList[glyph.operatorListId];
         if (!operatorList) {
-          warn('Type3 character \"' + glyph.operatorListId +
-               '\" is not available');
+          warn(`Type3 character "${glyph.operatorListId}" is not available.`);
           continue;
         }
         this.processingType3 = glyph;


### PR DESCRIPTION
Note that by using `let` instead of `var` in `PartialEvaluator.setGState` and `TranslatedFont.loadType3Data`, we can get rid of further `bind` usages since `let` is block-scoped.
Also, the fact that `bind` wasn't used in the `Font` case inside of `setGState` is actually a bug which has been present ever since PR #5205, where a closure was replaced by a standard loop.[1]

---
[1] I'm not aware of any bugs caused by this, but that is probably more a happy accident than anything else, since e.g. just removing the `bind` from the `SMask` case without using block-scoped variables causes test failures.

*Edit:* Slightly smaller diff with https://github.com/mozilla/pdf.js/pull/8355/files?w=1.