### PR TITLE
Change the signatures of the `PartialEvaluator` "constructor" and its `getOperatorList`/`getTextContent` methods to take parameter objects

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -455,8 +455,12 @@ var Annotation = (function AnnotationClosure() {
       return resourcesPromise.then((resources) => {
         var opList = new OperatorList();
         opList.addOp(OPS.beginAnnotation, [data.rect, transform, matrix]);
-        return evaluator.getOperatorList(this.appearance, task,
-                                         resources, opList).then(() => {
+        return evaluator.getOperatorList({
+          stream: this.appearance,
+          task,
+          resources,
+          operatorList: opList,
+        }).then(() => {
           opList.addOp(OPS.endAnnotation, []);
           this.appearance.reset();
           return opList;
@@ -755,8 +759,12 @@ var TextWidgetAnnotation = (function TextWidgetAnnotationClosure() {
       }
 
       var stream = new Stream(stringToBytes(this.data.defaultAppearance));
-      return evaluator.getOperatorList(stream, task, this.fieldResources,
-                                       operatorList).then(function () {
+      return evaluator.getOperatorList({
+        stream,
+        task,
+        resources: this.fieldResources,
+        operatorList,
+      }).then(function () {
         return operatorList;
       });
     }

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -233,10 +233,9 @@ var Page = (function PageClosure() {
       });
     },
 
-    getOperatorList(handler, task, intent, renderInteractiveForms) {
-      var pdfManager = this.pdfManager;
-      var contentStreamPromise = pdfManager.ensure(this, 'getContentStream',
-                                                   []);
+    getOperatorList({ handler, task, intent, renderInteractiveForms, }) {
+      var contentStreamPromise = this.pdfManager.ensure(this,
+                                                        'getContentStream');
       var resourcesPromise = this.loadResources([
         'ExtGState',
         'ColorSpace',
@@ -248,12 +247,16 @@ var Page = (function PageClosure() {
         // Properties
       ]);
 
-      var partialEvaluator = new PartialEvaluator(pdfManager, this.xref,
-                                                  handler, this.pageIndex,
-                                                  this.idFactory,
-                                                  this.fontCache,
-                                                  this.builtInCMapCache,
-                                                  this.evaluatorOptions);
+      var partialEvaluator = new PartialEvaluator({
+        pdfManager: this.pdfManager,
+        xref: this.xref,
+        handler,
+        pageIndex: this.pageIndex,
+        idFactory: this.idFactory,
+        fontCache: this.fontCache,
+        builtInCMapCache: this.builtInCMapCache,
+        options: this.evaluatorOptions,
+      });
 
       var dataPromises = Promise.all([contentStreamPromise, resourcesPromise]);
       var pageListPromise = dataPromises.then(([contentStream]) => {
@@ -264,15 +267,19 @@ var Page = (function PageClosure() {
           pageIndex: this.pageIndex,
           intent,
         });
-        return partialEvaluator.getOperatorList(contentStream, task,
-          this.resources, opList).then(function () {
-            return opList;
-          });
+        return partialEvaluator.getOperatorList({
+          stream: contentStream,
+          task,
+          resources: this.resources,
+          operatorList: opList,
+        }).then(function () {
+          return opList;
+        });
       });
 
       // Fetch the page's annotations and add their operator lists to the
       // page's operator list to render them.
-      var annotationsPromise = pdfManager.ensure(this, 'annotations');
+      var annotationsPromise = this.pdfManager.ensure(this, 'annotations');
       return Promise.all([pageListPromise, annotationsPromise]).then(
           function ([pageOpList, annotations]) {
         if (annotations.length === 0) {
@@ -303,11 +310,10 @@ var Page = (function PageClosure() {
       });
     },
 
-    extractTextContent(handler, task, normalizeWhitespace, combineTextItems) {
-      var pdfManager = this.pdfManager;
-      var contentStreamPromise = pdfManager.ensure(this, 'getContentStream',
-                                                   []);
-
+    extractTextContent({ handler, task, normalizeWhitespace,
+                         combineTextItems, }) {
+      var contentStreamPromise = this.pdfManager.ensure(this,
+                                                        'getContentStream');
       var resourcesPromise = this.loadResources([
         'ExtGState',
         'XObject',
@@ -316,19 +322,24 @@ var Page = (function PageClosure() {
 
       var dataPromises = Promise.all([contentStreamPromise, resourcesPromise]);
       return dataPromises.then(([contentStream]) => {
-        var partialEvaluator = new PartialEvaluator(pdfManager, this.xref,
-                                                    handler, this.pageIndex,
-                                                    this.idFactory,
-                                                    this.fontCache,
-                                                    this.builtInCMapCache,
-                                                    this.evaluatorOptions);
+        var partialEvaluator = new PartialEvaluator({
+          pdfManager: this.pdfManager,
+          xref: this.xref,
+          handler,
+          pageIndex: this.pageIndex,
+          idFactory: this.idFactory,
+          fontCache: this.fontCache,
+          builtInCMapCache: this.builtInCMapCache,
+          options: this.evaluatorOptions,
+        });
 
-        return partialEvaluator.getTextContent(contentStream,
-                                               task,
-                                               this.resources,
-                                               /* stateManager = */ null,
-                                               normalizeWhitespace,
-                                               combineTextItems);
+        return partialEvaluator.getTextContent({
+          stream: contentStream,
+          task,
+          resources: this.resources,
+          normalizeWhitespace,
+          combineTextItems,
+        });
       });
     },
 

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -848,9 +848,12 @@ var WorkerMessageHandler = {
         var pageNum = pageIndex + 1;
         var start = Date.now();
         // Pre compile the pdf page and fetch the fonts/images.
-        page.getOperatorList(handler, task, data.intent,
-                             data.renderInteractiveForms).then(
-            function(operatorList) {
+        page.getOperatorList({
+          handler,
+          task,
+          intent: data.intent,
+          renderInteractiveForms: data.renderInteractiveForms,
+        }).then(function(operatorList) {
           finishWorkerTask(task);
 
           info('page=' + pageNum + ' - getOperatorList: time=' +
@@ -906,10 +909,14 @@ var WorkerMessageHandler = {
 
         var pageNum = pageIndex + 1;
         var start = Date.now();
-        return page.extractTextContent(handler, task, data.normalizeWhitespace,
-                                       data.combineTextItems).then(
-            function(textContent) {
+        return page.extractTextContent({
+          handler,
+          task,
+          normalizeWhitespace: data.normalizeWhitespace,
+          combineTextItems: data.combineTextItems,
+        }).then(function(textContent) {
           finishWorkerTask(task);
+
           info('text indexing: page=' + pageNum + ' - time=' +
                (Date.now() - start) + 'ms');
           return textContent;


### PR DESCRIPTION
*Slightly smaller diff with https://github.com/mozilla/pdf.js/pull/8358/files?w=1.*

Currently these methods accept a large number of parameters, which creates quite unwieldy call-sites. When invoking them, you have to remember not only what arguments to supply, but also the correct order, to avoid runtime errors.
Furthermore, since some of the parameters are optional, you also have to remember to pass e.g. `null` or `undefined` for those ones.
Also, adding new parameters to these methods (which happens occasionally), often becomes unnecessarily tedious (based on personal experience).

Please note that I do *not* think that we need/should convert *every* single method in `evaluator.js` (or elsewhere in `/core` files) to take parameter objects. However, in my opinion, once a method starts relying on approximately five parameter (or even more), passing them in individually becomes quite cumbersome.

With these changes, I obviously needed to update the `evaluator_spec.js` unit-tests. The main change there, except the new method signatures[1], is that it's now re-using *one* `PartialEvalutor` instance, since I couldn't see any compelling reason for creating a new one in every single test.

*Note:* If this patch is accepted, my intention is to (time permitting) see if it makes sense to convert additional methods in `evaluator.js` (and other `/core` files) in a similar fashion, but I figured that it'd be a good idea to limit the initial scope somewhat.

---

[1] A fun fact here, note how the `PartialEvaluator` signature used in `evaluator_spec.js` wasn't even correct in the current `master`.