### PR TITLE
Ignore line-breaks between operator and digit in `Lexer.getNumber`

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -721,9 +721,14 @@ var Lexer = (function LexerClosure() {
         divideBy = 10;
         ch = this.nextChar();
       }
+      if (ch === 0x0A || ch === 0x0D) { // LF, CR
+        // Ignore line-breaks (this is consistent with Adobe Reader).
+        do {
+          ch = this.nextChar();
+        } while (ch === 0x0A || ch === 0x0D);
+      }
       if (ch < 0x30 || ch > 0x39) { // '0' - '9'
-        error('Invalid number: ' + String.fromCharCode(ch));
-        return 0;
+        error(`Invalid number: ${String.fromCharCode(ch)} (charCode ${ch})`);
       }
 
       var baseValue = ch - 0x30; // '0'

--- a/test/pdfs/bug1354114.pdf.link
+++ b/test/pdfs/bug1354114.pdf.link
@@ -1,0 +1,1 @@
+https://bug1354114.bmoattachments.org/attachment.cgi?id=8855457

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1485,6 +1485,14 @@
        "link": true,
        "type": "eq"
     },
+    {  "id": "bug1354114",
+       "file": "pdfs/bug1354114.pdf",
+       "md5": "ad718d04702d29a37792c7f222fe1fa6",
+       "rounds": 1,
+       "firstPage": 30,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "issue5874",
        "file": "pdfs/issue5874.pdf",
        "md5": "25922edf223aa91bc259663d0a34a6ab",

--- a/test/unit/parser_spec.js
+++ b/test/unit/parser_spec.js
@@ -48,6 +48,23 @@ describe('parser', function() {
       expect(result).toEqual(-205.88);
     });
 
+    it('should ignore minus signs in the middle of number', function() {
+      var input = new StringStream('205--.88');
+      var lexer = new Lexer(input);
+      var result = lexer.getNumber();
+
+      expect(result).toEqual(205.88);
+    });
+
+    it('should ignore line-breaks between operator and digit in number',
+        function() {
+      var input = new StringStream('-\r\n205.88');
+      var lexer = new Lexer(input);
+      var result = lexer.getNumber();
+
+      expect(result).toEqual(-205.88);
+    });
+
     it('should handle glued numbers and operators', function() {
       var input = new StringStream('123ET');
       var lexer = new Lexer(input);


### PR DESCRIPTION
This is consistent with the behaviour in Adobe Reader (and PDFium), and it fixes the display of page 30 in https://bug1354114.bmoattachments.org/attachment.cgi?id=8855457 (taken from https://bugzilla.mozilla.org/show_bug.cgi?id=1354114).

The patch also makes the `error` message for invalid numbers slightly more useful, by including the charCode as well. (Having that information available would have reduced the time spent on debugging the PDF file above.)