### PR TITLE
Mozilla bug 1319111

### DIFF
--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -1013,6 +1013,7 @@ PdfStreamConverter.prototype = {
 
     // Keep the URL the same so the browser sees it as the same.
     channel.originalURI = aRequest.URI;
+    channel.loadInfo.resultPrincipalURI = aRequest.loadInfo.resultPrincipalURI;
     channel.loadGroup = aRequest.loadGroup;
     channel.loadInfo.originAttributes = aRequest.loadInfo.originAttributes;
 


### PR DESCRIPTION
This is a downstream change introduced in [1].  That mozilla bug is adding a new property to channel's loadinfo object (nsILoadInfo) that protocol handlers has to set on channels when originalURI on the result channel is set to a different URI than the channel has been created for.

Existence of the new property on nsILoadInfo depends on landing [1].

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1319111