### PR TITLE
Replace unnecessary `bind(this)` statements with arrow functions in `web/` files

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -833,10 +833,10 @@ var PDFViewerApplication = {
         }
         this.loadingBar.show();
 
-        this.disableAutoFetchLoadingBarTimeout = setTimeout(function () {
+        this.disableAutoFetchLoadingBarTimeout = setTimeout(() => {
           this.loadingBar.hide();
           this.disableAutoFetchLoadingBarTimeout = null;
-        }.bind(this), DISABLE_AUTO_FETCH_LOADING_BAR_TIMEOUT);
+        }, DISABLE_AUTO_FETCH_LOADING_BAR_TIMEOUT);
       }
     }
   },

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -149,11 +149,11 @@ var FontInspector = (function FontInspectorClosure() {
       fonts.appendChild(font);
       // Somewhat of a hack, should probably add a hook for when the text layer
       // is done rendering.
-      setTimeout(function() {
+      setTimeout(() => {
         if (this.active) {
           resetSelection();
         }
-      }.bind(this), 2000);
+      }, 2000);
     }
   };
 })();

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -105,20 +105,19 @@ var DownloadManager = (function DownloadManagerClosure() {
     },
 
     download: function DownloadManager_download(blob, url, filename) {
-      var blobUrl = window.URL.createObjectURL(blob);
+      let blobUrl = window.URL.createObjectURL(blob);
+      let onResponse = (err) => {
+        if (err && this.onerror) {
+          this.onerror(err);
+        }
+        window.URL.revokeObjectURL(blobUrl);
+      };
 
       FirefoxCom.request('download', {
         blobUrl,
         originalUrl: url,
         filename,
-      },
-        function response(err) {
-          if (err && this.onerror) {
-            this.onerror(err);
-          }
-          window.URL.revokeObjectURL(blobUrl);
-        }.bind(this)
-      );
+      }, onResponse);
     }
   };
 

--- a/web/hand_tool.js
+++ b/web/hand_tool.js
@@ -53,16 +53,16 @@ var HandTool = (function HandToolClosure() {
       }
     }).catch(function rejected(reason) { });
 
-    this.eventBus.on('presentationmodechanged', function (e) {
-      if (e.switchInProgress) {
+    this.eventBus.on('presentationmodechanged', (evt) => {
+      if (evt.switchInProgress) {
         return;
       }
-      if (e.active) {
+      if (evt.active) {
         this.enterPresentationMode();
       } else {
         this.exitPresentationMode();
       }
-    }.bind(this));
+    });
   }
 
   HandTool.prototype = {

--- a/web/overlay_manager.js
+++ b/web/overlay_manager.js
@@ -30,9 +30,8 @@ var OverlayManager = {
    * @returns {Promise} A promise that is resolved when the overlay has been
    *                    registered.
    */
-  register: function overlayManagerRegister(name, element,
-                                            callerCloseMethod, canForceClose) {
-    return new Promise(function (resolve) {
+  register(name, element, callerCloseMethod, canForceClose) {
+    return new Promise((resolve) => {
       var container;
       if (!name || !element || !(container = element.parentNode)) {
         throw new Error('Not enough parameters.');
@@ -46,7 +45,7 @@ var OverlayManager = {
         canForceClose: (canForceClose || false),
       };
       resolve();
-    }.bind(this));
+    });
   },
 
   /**
@@ -54,8 +53,8 @@ var OverlayManager = {
    * @returns {Promise} A promise that is resolved when the overlay has been
    *                    unregistered.
    */
-  unregister: function overlayManagerUnregister(name) {
-    return new Promise(function (resolve) {
+  unregister(name) {
+    return new Promise((resolve) => {
       if (!this.overlays[name]) {
         throw new Error('The overlay does not exist.');
       } else if (this.active === name) {
@@ -64,7 +63,7 @@ var OverlayManager = {
       delete this.overlays[name];
 
       resolve();
-    }.bind(this));
+    });
   },
 
   /**
@@ -72,8 +71,8 @@ var OverlayManager = {
    * @returns {Promise} A promise that is resolved when the overlay has been
    *                    opened.
    */
-  open: function overlayManagerOpen(name) {
-    return new Promise(function (resolve) {
+  open(name) {
+    return new Promise((resolve) => {
       if (!this.overlays[name]) {
         throw new Error('The overlay does not exist.');
       } else if (this.active) {
@@ -91,7 +90,7 @@ var OverlayManager = {
 
       window.addEventListener('keydown', this._keyDown);
       resolve();
-    }.bind(this));
+    });
   },
 
   /**
@@ -99,8 +98,8 @@ var OverlayManager = {
    * @returns {Promise} A promise that is resolved when the overlay has been
    *                    closed.
    */
-  close: function overlayManagerClose(name) {
-    return new Promise(function (resolve) {
+  close(name) {
+    return new Promise((resolve) => {
       if (!this.overlays[name]) {
         throw new Error('The overlay does not exist.');
       } else if (!this.active) {
@@ -114,13 +113,13 @@ var OverlayManager = {
 
       window.removeEventListener('keydown', this._keyDown);
       resolve();
-    }.bind(this));
+    });
   },
 
   /**
    * @private
    */
-  _keyDown: function overlayManager_keyDown(evt) {
+  _keyDown(evt) {
     var self = OverlayManager;
     if (self.active && evt.keyCode === 27) { // Esc key.
       self._closeThroughCaller();
@@ -131,7 +130,7 @@ var OverlayManager = {
   /**
    * @private
    */
-  _closeThroughCaller: function overlayManager_closeThroughCaller() {
+  _closeThroughCaller() {
     if (this.overlays[this.active].callerCloseMethod) {
       this.overlays[this.active].callerCloseMethod();
     }

--- a/web/pdf_attachment_viewer.js
+++ b/web/pdf_attachment_viewer.js
@@ -161,8 +161,8 @@ class PDFAttachmentViewer {
    * Used to append FileAttachment annotations to the sidebar.
    * @private
    */
-  _appendAttachment(item) {
-    this._renderedCapability.promise.then(function (id, filename, content) {
+  _appendAttachment({ id, filename, content, }) {
+    this._renderedCapability.promise.then(() => {
       var attachments = this.attachments;
 
       if (!attachments) {
@@ -182,7 +182,7 @@ class PDFAttachmentViewer {
         attachments,
         keepRenderedCapability: true,
       });
-    }.bind(this, item.id, item.filename, item.content));
+    });
   }
 }
 

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -277,7 +277,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
       this.state = state;
       this.updateUIState(FindStates.FIND_PENDING);
 
-      this._firstPagePromise.then(function() {
+      this._firstPagePromise.then(() => {
         this.extractText();
 
         clearTimeout(this.findTimeout);
@@ -287,7 +287,7 @@ var PDFFindController = (function PDFFindControllerClosure() {
         } else {
           this.nextMatch();
         }
-      }.bind(this));
+      });
     },
 
     updatePage: function PDFFindController_updatePage(index) {

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -127,7 +127,7 @@ PDFPrintService.prototype = {
 
   renderPages() {
     var pageCount = this.pagesOverview.length;
-    var renderNextPage = function (resolve, reject) {
+    var renderNextPage = (resolve, reject) => {
       this.throwIfInactive();
       if (++this.currentPage >= pageCount) {
         renderProgress(pageCount, pageCount);
@@ -141,7 +141,7 @@ PDFPrintService.prototype = {
         .then(function () {
           renderNextPage(resolve, reject);
         }, reject);
-    }.bind(this);
+    };
     return new Promise(renderNextPage);
   },
 
@@ -172,11 +172,11 @@ PDFPrintService.prototype = {
 
   performPrint() {
     this.throwIfInactive();
-    return new Promise(function (resolve) {
+    return new Promise((resolve) => {
       // Push window.print in the macrotask queue to avoid being affected by
       // the deprecation of running print() code in a microtask, see
       // https://github.com/mozilla/pdf.js/issues/7547.
-      setTimeout(function () {
+      setTimeout(() => {
         if (!this.active) {
           resolve();
           return;
@@ -184,8 +184,8 @@ PDFPrintService.prototype = {
         print.call(window);
         // Delay promise resolution in case print() was not synchronous.
         setTimeout(resolve, 20);  // Tidy-up.
-      }.bind(this), 0);
-    }.bind(this));
+      }, 0);
+    });
   },
 
   get active() {

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -138,10 +138,10 @@ var PDFThumbnailViewer = (function PDFThumbnailViewerClosure() {
         return Promise.resolve();
       }
 
-      return pdfDocument.getPage(1).then(function (firstPage) {
+      return pdfDocument.getPage(1).then((firstPage) => {
         var pagesCount = pdfDocument.numPages;
         var viewport = firstPage.getViewport(1.0);
-        for (var pageNum = 1; pageNum <= pagesCount; ++pageNum) {
+        for (let pageNum = 1; pageNum <= pagesCount; ++pageNum) {
           var thumbnail = new PDFThumbnailView({
             container: this.container,
             id: pageNum,
@@ -152,7 +152,7 @@ var PDFThumbnailViewer = (function PDFThumbnailViewerClosure() {
           });
           this.thumbnails.push(thumbnail);
         }
-      }.bind(this));
+      });
     },
 
     /**

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -383,8 +383,8 @@ var PDFViewer = (function pdfViewer() {
             return;
           }
           var getPagesLeft = pagesCount;
-          for (var pageNum = 1; pageNum <= pagesCount; ++pageNum) {
-            pdfDocument.getPage(pageNum).then(function(pageNum, pdfPage) {
+          for (let pageNum = 1; pageNum <= pagesCount; ++pageNum) {
+            pdfDocument.getPage(pageNum).then((pdfPage) => {
               var pageView = this._pages[pageNum - 1];
               if (!pageView.pdfPage) {
                 pageView.setPdfPage(pdfPage);
@@ -393,7 +393,7 @@ var PDFViewer = (function pdfViewer() {
               if (--getPagesLeft === 0) {
                 pagesCapability.resolve();
               }
-            }.bind(this, pageNum));
+            });
           }
         });
 

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -139,19 +139,17 @@ var SecondaryToolbar = (function SecondaryToolbarClosure() {
       this.toggleButton.addEventListener('click', this.toggle.bind(this));
 
       // All items within the secondary toolbar.
-      for (var button in this.buttons) {
-        var element = this.buttons[button].element;
-        var eventName = this.buttons[button].eventName;
-        var close = this.buttons[button].close;
+      for (let button in this.buttons) {
+        let { element, eventName, close, } = this.buttons[button];
 
-        element.addEventListener('click', function (eventName, close) {
+        element.addEventListener('click', (evt) => {
           if (eventName !== null) {
             this.eventBus.dispatch(eventName, { source: this, });
           }
           if (close) {
             this.close();
           }
-        }.bind(this, eventName, close));
+        });
       }
     },
 

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -94,11 +94,11 @@ var TextLayerBuilder = (function TextLayerBuilderClosure() {
         timeout,
         enhanceTextSelection: this.enhanceTextSelection,
       });
-      this.textLayerRenderTask.promise.then(function () {
+      this.textLayerRenderTask.promise.then(() => {
         this.textLayerDiv.appendChild(textLayerFrag);
         this._finishRendering();
         this.updateMatches();
-      }.bind(this), function (reason) {
+      }, function (reason) {
         // cancelled or failed to render text layer -- skipping errors
       });
     },


### PR DESCRIPTION
By using `let`, which is block-scoped, instead of `var` in a couple of places we're able to get rid of additional `bind` calls.