### PR TITLE
Re-factor `PDFDocumentProperties` such that it's properly reset when a new PDF file is opened (issue 8371)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -561,6 +561,7 @@ var PDFViewerApplication = {
       this.pdfThumbnailViewer.setDocument(null);
       this.pdfViewer.setDocument(null);
       this.pdfLinkService.setDocument(null, null);
+      this.pdfDocumentProperties.setDocument(null, null);
     }
     this.store = null;
     this.isInitialViewSet = false;
@@ -847,8 +848,6 @@ var PDFViewerApplication = {
 
     this.pdfDocument = pdfDocument;
 
-    this.pdfDocumentProperties.setDocumentAndUrl(pdfDocument, this.url);
-
     var downloadedPromise = pdfDocument.getDownloadInfo().then(function() {
       self.downloadComplete = true;
       self.loadingBar.hide();
@@ -869,6 +868,7 @@ var PDFViewerApplication = {
       baseDocumentUrl = location.href.split('#')[0];
     }
     this.pdfLinkService.setDocument(pdfDocument, baseDocumentUrl);
+    this.pdfDocumentProperties.setDocument(pdfDocument, this.url);
 
     var pdfViewer = this.pdfViewer;
     pdfViewer.currentScale = scale;

--- a/web/preferences.js
+++ b/web/preferences.js
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+import { cloneObj } from './ui_utils';
+
 var defaultPreferences = null;
 function getDefaultPreferences() {
   if (!defaultPreferences) {
@@ -36,16 +38,6 @@ function getDefaultPreferences() {
     }
   }
   return defaultPreferences;
-}
-
-function cloneObj(obj) {
-  var result = {};
-  for (var i in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, i)) {
-      result[i] = obj[i];
-    }
-  }
-  return result;
 }
 
 /**

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -422,6 +422,16 @@ function normalizeWheelEventDelta(evt) {
   return delta;
 }
 
+function cloneObj(obj) {
+  var result = {};
+  for (var i in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, i)) {
+      result[i] = obj[i];
+    }
+  }
+  return result;
+}
+
 /**
  * Promise that is resolved when DOM window becomes visible.
  */
@@ -582,6 +592,7 @@ export {
   MAX_AUTO_SCALE,
   SCROLLBAR_PADDING,
   VERTICAL_PADDING,
+  cloneObj,
   RendererType,
   mozL10n,
   EventBus,


### PR DESCRIPTION
This patch contains the following improvements:
 - Only fetch the various document properties *once* per PDF file opened, and cache the result (in a frozen object).
 - Always update the *entire* dialog at once, to prevent inconsistent UI state (issue 8371).
 - Ensure that the dialog, and all its internal properties, are reset when `PDFViewerApplication.close` is called.
 - Inline, and re-factor, the `getProperties` method in `open`, since that's the only call-site.
 - Always overwrite the fileSize with the value obtained from `pdfDocument.getDownloadInfo`, to ensure that it's correct.
 - ES6-ify the code that's touched in this patch.

Fixes #8371.