### PR TITLE
amends Babel cache (#8364) implementation to also work on Safari

### DIFF
--- a/systemjs.config.js
+++ b/systemjs.config.js
@@ -36,7 +36,8 @@
 
   var isCachingPossible = typeof indexedDB !== 'undefined' &&
                           typeof TextEncoder !== 'undefined' &&
-                          typeof crypto !== 'undefined';
+                          typeof crypto !== 'undefined' &&
+                          typeof crypto.subtle !== 'undefined';
 
   SystemJS.config({
     packages: {


### PR DESCRIPTION
Fixes a problem with Safari having `crypto.webkitSubtle` instead of `crypto.subtle`, which can cause digest generation for cached files to fail, and the viewer eventually not load in development mode.

Fixes #8386