### PR TITLE
Upstream changes from: Bug 1319111 - Expose result principal URL ("final channel URL") on LoadInfo, convert current consumers of LOAD_REPLACE

### DIFF
--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -1013,6 +1013,14 @@ PdfStreamConverter.prototype = {
 
     // Keep the URL the same so the browser sees it as the same.
     channel.originalURI = aRequest.URI;
+//#if MOZCENTRAL
+    channel.loadInfo.resultPrincipalURI = aRequest.loadInfo.resultPrincipalURI;
+//#else
+    if ("resultPrincipalURI" in aRequest.loadInfo) {
+      channel.loadInfo.resultPrincipalURI =
+        aRequest.loadInfo.resultPrincipalURI;
+    }
+//#endif
     channel.loadGroup = aRequest.loadGroup;
     channel.loadInfo.originAttributes = aRequest.loadInfo.originAttributes;
 


### PR DESCRIPTION
This is a downstream change introduced in [1]. That mozilla bug is adding a new property to channel's loadinfo object (nsILoadInfo) that protocol handlers has to set on channels when originalURI on the result channel is set to a different URI than the channel has been created for.

Existence of the new property on nsILoadInfo depends on landing [1].

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1319111

---

Based on https://bugzilla.mozilla.org/show_bug.cgi?id=1362108#c0, getting PR #8367 landed is going to block the next PDF.js update in mozilla-central.
That PR unfortunately cannot land in its current form, since it completely breaks the addon in Firefox versions < 55, with the following error printed in the browser console:
`NS_ERROR_XPC_CANT_MODIFY_PROP_ON_WN: Cannot modify properties of a WrappedNative`

To expedite getting this fixed, this PR is a redo of #8367 with the necessary code added to main backwards compatibility of the addon. *Please note:* I obviously kept the original author information intact!

/cc @rvandermeulen