### PR TITLE
Convert the `DOMCMapReaderFactory` and `DOMCanvasFactory` to ES6 classes

### DIFF
--- a/examples/node/pdf2png/pdf2png.js
+++ b/examples/node/pdf2png/pdf2png.js
@@ -29,22 +29,22 @@ NodeCanvasFactory.prototype = {
     };
   },
 
-  reset: function NodeCanvasFactory_reset(canvasAndContextPair, width, height) {
-    assert(canvasAndContextPair.canvas, 'Canvas is not specified');
+  reset: function NodeCanvasFactory_reset(canvasAndContext, width, height) {
+    assert(canvasAndContext.canvas, 'Canvas is not specified');
     assert(width > 0 && height > 0, 'Invalid canvas size');
-    canvasAndContextPair.canvas.width = width;
-    canvasAndContextPair.canvas.height = height;
+    canvasAndContext.canvas.width = width;
+    canvasAndContext.canvas.height = height;
   },
 
-  destroy: function NodeCanvasFactory_destroy(canvasAndContextPair) {
-    assert(canvasAndContextPair.canvas, 'Canvas is not specified');
+  destroy: function NodeCanvasFactory_destroy(canvasAndContext) {
+    assert(canvasAndContext.canvas, 'Canvas is not specified');
 
     // Zeroing the width and height cause Firefox to release graphics
     // resources immediately, which can greatly reduce memory consumption.
-    canvasAndContextPair.canvas.width = 0;
-    canvasAndContextPair.canvas.height = 0;
-    canvasAndContextPair.canvas = null;
-    canvasAndContextPair.context = null;
+    canvasAndContext.canvas.width = 0;
+    canvasAndContext.canvas.height = 0;
+    canvasAndContext.canvas = null;
+    canvasAndContext.context = null;
   },
 };
 
@@ -65,16 +65,16 @@ pdfjsLib.getDocument(rawData).then(function (pdfDocument) {
     // Render the page on a Node canvas with 100% scale.
     var viewport = page.getViewport(1.0);
     var canvasFactory = new NodeCanvasFactory();
-    var canvasAndContextPair = canvasFactory.create(viewport.width, viewport.height);
+    var canvasAndContext = canvasFactory.create(viewport.width, viewport.height);
     var renderContext = {
-      canvasContext: canvasAndContextPair.context,
+      canvasContext: canvasAndContext.context,
       viewport: viewport,
       canvasFactory: canvasFactory
     };
 
     page.render(renderContext).then(function () {
       // Convert the canvas to an image buffer.
-      image = canvasAndContextPair.canvas.toBuffer();
+      var image = canvasAndContext.canvas.toBuffer();
       fs.writeFile('output.png', image, function (error) {
         if (error) {
           console.error('Error: ' + error);

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -20,37 +20,36 @@ import {
 
 var DEFAULT_LINK_REL = 'noopener noreferrer nofollow';
 
-function DOMCanvasFactory() {}
-DOMCanvasFactory.prototype = {
-  create: function DOMCanvasFactory_create(width, height) {
+class DOMCanvasFactory {
+  create(width, height) {
     assert(width > 0 && height > 0, 'invalid canvas size');
-    var canvas = document.createElement('canvas');
-    var context = canvas.getContext('2d');
+    let canvas = document.createElement('canvas');
+    let context = canvas.getContext('2d');
     canvas.width = width;
     canvas.height = height;
     return {
       canvas,
       context,
     };
-  },
+  }
 
-  reset: function DOMCanvasFactory_reset(canvasAndContextPair, width, height) {
-    assert(canvasAndContextPair.canvas, 'canvas is not specified');
+  reset(canvasAndContext, width, height) {
+    assert(canvasAndContext.canvas, 'canvas is not specified');
     assert(width > 0 && height > 0, 'invalid canvas size');
-    canvasAndContextPair.canvas.width = width;
-    canvasAndContextPair.canvas.height = height;
-  },
+    canvasAndContext.canvas.width = width;
+    canvasAndContext.canvas.height = height;
+  }
 
-  destroy: function DOMCanvasFactory_destroy(canvasAndContextPair) {
-    assert(canvasAndContextPair.canvas, 'canvas is not specified');
+  destroy(canvasAndContext) {
+    assert(canvasAndContext.canvas, 'canvas is not specified');
     // Zeroing the width and height cause Firefox to release graphics
     // resources immediately, which can greatly reduce memory consumption.
-    canvasAndContextPair.canvas.width = 0;
-    canvasAndContextPair.canvas.height = 0;
-    canvasAndContextPair.canvas = null;
-    canvasAndContextPair.context = null;
+    canvasAndContext.canvas.width = 0;
+    canvasAndContext.canvas.height = 0;
+    canvasAndContext.canvas = null;
+    canvasAndContext.context = null;
   }
-};
+}
 
 class DOMCMapReaderFactory {
   constructor({ baseUrl = null, isCompressed = false, }) {

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -16,20 +16,19 @@
 import { CMapCompressionType } from '../../src/shared/util';
 
 class NodeCMapReaderFactory {
-  constructor(params) {
-    this.baseUrl = params.baseUrl || null;
-    this.isCompressed = params.isCompressed || false;
+  constructor({ baseUrl = null, isCompressed = false, }) {
+    this.baseUrl = baseUrl;
+    this.isCompressed = isCompressed;
   }
 
-  fetch(params) {
-    var name = params.name;
+  fetch({ name, }) {
     if (!name) {
       return Promise.reject(new Error('CMap name must be specified.'));
     }
     return new Promise((resolve, reject) => {
-      var url = this.baseUrl + name + (this.isCompressed ? '.bcmap' : '');
+      let url = this.baseUrl + name + (this.isCompressed ? '.bcmap' : '');
 
-      var fs = require('fs');
+      let fs = require('fs');
       fs.readFile(url, (error, data) => {
         if (error || !data) {
           reject(new Error('Unable to load ' +


### PR DESCRIPTION
 - Convert the `DOMCMapReaderFactory` to an ES6 class

   Given that we only create *one* instance of this class per `getDocument` call, this shouldn't matter performance wise.

 - Convert the `DOMCanvasFactory` to an ES6 class

   For consistency, also updates the `pdf2png.js` example to use the slightly less verbose `canvasAndContext` parameter name.

Smaller diff with https://github.com/mozilla/pdf.js/pull/8398/files?w=1.