### PR TITLE
Adds gulp dist-install command; using pdfjs-dist package in examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ The repository contains a hello world example that you can run locally:
 
 + [examples/helloworld/](https://github.com/mozilla/pdf.js/blob/master/examples/helloworld/)
 
+More examples can be found at the examples folder. Some of them are using the pdfjs-dist package, which can be built and installed in this repo directory via `gulp dist-install` command.
+
 For an introduction to the PDF.js code, check out the presentation by our
 contributor Julian Viereck:
 

--- a/examples/acroforms/acroforms.html
+++ b/examples/acroforms/acroforms.html
@@ -20,10 +20,10 @@ limitations under the License.
 
     <title>AcroForms example</title>
 
-    <link rel="stylesheet" href="../../build/dist/web/pdf_viewer.css">
+    <link rel="stylesheet" href="../../node_modules/pdfjs-dist/web/pdf_viewer.css">
 
-    <script src="../../build/dist/build/pdf.js"></script>
-    <script src="../../build/dist/web/pdf_viewer.js"></script>
+    <script src="../../node_modules/pdfjs-dist/build/pdf.js"></script>
+    <script src="../../node_modules/pdfjs-dist/web/pdf_viewer.js"></script>
 
     <style>
     * {

--- a/examples/acroforms/acroforms.js
+++ b/examples/acroforms/acroforms.js
@@ -15,7 +15,7 @@
 
 'use strict';
 
-PDFJS.workerSrc = '../../build/dist/build/pdf.worker.js';
+PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
 var DEFAULT_URL = '../../test/pdfs/f1040.pdf';
 var DEFAULT_SCALE = 1.0;

--- a/examples/browserify/README.md
+++ b/examples/browserify/README.md
@@ -6,7 +6,7 @@ Example to demonstrate PDF.js library usage with Browserify.
 
 Build project and install the example dependencies:
 
-    $ gulp dist
+    $ gulp dist-install
     $ cd examples/browserify
     $ npm install
 

--- a/examples/browserify/package.json
+++ b/examples/browserify/package.json
@@ -7,7 +7,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-streamify": "^1.0.2",
     "gulp-uglify": "^1.5.3",
-    "pdfjs-dist": "../../build/dist",
+    "pdfjs-dist": "../../node_modules/pdfjs-dist",
     "vinyl-source-stream": "^1.1.0"
   },
   "scripts": {

--- a/examples/components/pageviewer.html
+++ b/examples/components/pageviewer.html
@@ -29,10 +29,10 @@ limitations under the License.
     }
   </style>
 
-  <link rel="stylesheet" href="../../build/dist/web/pdf_viewer.css">
+  <link rel="stylesheet" href="../../node_modules/pdfjs-dist/web/pdf_viewer.css">
 
-  <script src="../../build/dist/build/pdf.js"></script>
-  <script src="../../build/dist/web/pdf_viewer.js"></script>
+  <script src="../../node_modules/pdfjs-dist/build/pdf.js"></script>
+  <script src="../../node_modules/pdfjs-dist/web/pdf_viewer.js"></script>
 </head>
 
 <body tabindex="1">

--- a/examples/components/pageviewer.js
+++ b/examples/components/pageviewer.js
@@ -17,16 +17,16 @@
 
 if (!PDFJS.PDFViewer || !PDFJS.getDocument) {
   alert('Please build the pdfjs-dist library using\n' +
-        '  `gulp dist`');
+        '  `gulp dist-install`');
 }
 
 // The workerSrc property shall be specified.
 //
-PDFJS.workerSrc = '../../build/dist/build/pdf.worker.js';
+PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
 // Some PDFs need external cmaps.
 //
-// PDFJS.cMapUrl = '../../build/dist/cmaps/';
+// PDFJS.cMapUrl = '../../node_modules/pdfjs-dist/cmaps/';
 // PDFJS.cMapPacked = true;
 
 var DEFAULT_URL = '../../web/compressed.tracemonkey-pldi-09.pdf';

--- a/examples/components/simpleviewer.html
+++ b/examples/components/simpleviewer.html
@@ -35,10 +35,10 @@ limitations under the License.
     }
   </style>
 
-  <link rel="stylesheet" href="../../build/dist/web/pdf_viewer.css">
+  <link rel="stylesheet" href="../../node_modules/pdfjs-dist/web/pdf_viewer.css">
 
-  <script src="../../build/dist/build/pdf.js"></script>
-  <script src="../../build/dist/web/pdf_viewer.js"></script>
+  <script src="../../node_modules/pdfjs-dist/build/pdf.js"></script>
+  <script src="../../node_modules/pdfjs-dist/web/pdf_viewer.js"></script>
 </head>
 
 <body tabindex="1">

--- a/examples/components/simpleviewer.js
+++ b/examples/components/simpleviewer.js
@@ -17,16 +17,16 @@
 
 if (!PDFJS.PDFViewer || !PDFJS.getDocument) {
   alert('Please build the pdfjs-dist library using\n' +
-        '  `gulp dist`');
+        '  `gulp dist-install`');
 }
 
 // The workerSrc property shall be specified.
 //
-PDFJS.workerSrc = '../../build/dist/build/pdf.worker.js';
+PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
 // Some PDFs need external cmaps.
 //
-// PDFJS.cMapUrl = '../../build/dist/cmaps/';
+// PDFJS.cMapUrl = '../../node_modules/pdfjs-dist/cmaps/';
 // PDFJS.cMapPacked = true;
 
 var DEFAULT_URL = '../../web/compressed.tracemonkey-pldi-09.pdf';

--- a/examples/helloworld/hello.js
+++ b/examples/helloworld/hello.js
@@ -1,12 +1,13 @@
 'use strict';
 
 // In production, the bundled pdf.js shall be used instead of SystemJS.
-Promise.all([SystemJS.import('pdfjs/display/api'),
-             SystemJS.import('pdfjs/display/global')])
+Promise.all([System.import('pdfjs/display/api'),
+             System.import('pdfjs/display/global'),
+             System.resolve('pdfjs/worker_loader')])
        .then(function (modules) {
   var api = modules[0], global = modules[1];
   // In production, change this to point to the built `pdf.worker.js` file.
-  global.PDFJS.workerSrc = '../../src/worker_loader.js';
+  global.PDFJS.workerSrc = modules[2];
 
   // Fetch the PDF document from the URL using promises.
   api.getDocument('helloworld.pdf').then(function (pdf) {

--- a/examples/learning/helloworld.html
+++ b/examples/learning/helloworld.html
@@ -11,9 +11,9 @@
 <canvas id="the-canvas" style="border:1px  solid black"></canvas>
 
 <!-- for legacy browsers add compatibility.js -->
-<!--<script src="../compatibility.js"></script>-->
+<!--<script src="../../node_modules/pdfjs-dist/web/compatibility.js"></script>-->
 
-<script src="../../build/generic/build/pdf.js"></script>
+<script src="../../node_modules/pdfjs-dist/build/pdf.js"></script>
 
 <script id="script">
   //
@@ -32,7 +32,7 @@
   //
   // The workerSrc property shall be specified.
   //
-  PDFJS.workerSrc = '../../build/generic/build/pdf.worker.js';
+  PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
   //
   // Asynchronous download PDF

--- a/examples/learning/helloworld64.html
+++ b/examples/learning/helloworld64.html
@@ -10,7 +10,7 @@
 
 <canvas id="the-canvas" style="border:1px  solid black"></canvas>
 
-<script src="../../build/generic/build/pdf.js"></script>
+<script src="../../node_modules/pdfjs-dist/build/pdf.js"></script>
 
 <script id="script">
   // atob() is used to convert base64 encoded PDF to binary-like data.
@@ -40,7 +40,7 @@
   //
   // The workerSrc property shall be specified.
   //
-  PDFJS.workerSrc = '../../build/generic/build/pdf.worker.js';
+  PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
   // Opening PDF by passing its binary data as a string. It is still preferable
   // to use Uint8Array, but string or array-like structure will work too.

--- a/examples/learning/prevnext.html
+++ b/examples/learning/prevnext.html
@@ -22,7 +22,7 @@
 <!-- for legacy browsers add compatibility.js -->
 <!--<script src="../compatibility.js"></script>-->
 
-<script src="../../build/generic/build/pdf.js"></script>
+<script src="../../node_modules/pdfjs-dist/build/pdf.js"></script>
 
 <script id="script">
   //
@@ -44,7 +44,7 @@
   // pdf.js's one, or the pdf.js is executed via eval(), the workerSrc property
   // shall be specified.
   //
-  // PDFJS.workerSrc = '../../build/generic/build/pdf.worker.js';
+  // PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
   var pdfDoc = null,
       pageNum = 1,

--- a/examples/mobile-viewer/viewer.html
+++ b/examples/mobile-viewer/viewer.html
@@ -21,11 +21,11 @@ limitations under the License.
 
     <title>PDF.js viewer</title>
 
-    <link rel="stylesheet" href="../../build/dist/web/pdf_viewer.css">
+    <link rel="stylesheet" href="../../node_modules/pdfjs-dist/web/pdf_viewer.css">
     <link rel="stylesheet" type="text/css" href="viewer.css">
 
-    <script src="../../build/dist/build/pdf.js"></script>
-    <script src="../../build/dist/web/pdf_viewer.js"></script>
+    <script src="../../node_modules/pdfjs-dist/build/pdf.js"></script>
+    <script src="../../node_modules/pdfjs-dist/web/pdf_viewer.js"></script>
   </head>
 
   <body>

--- a/examples/mobile-viewer/viewer.js
+++ b/examples/mobile-viewer/viewer.js
@@ -18,14 +18,14 @@
 
 if (!PDFJS.PDFViewer || !PDFJS.getDocument) {
   alert('Please build the pdfjs-dist library using\n' +
-        '  `gulp dist`');
+        '  `gulp dist-install`');
 }
 
 PDFJS.useOnlyCssZoom = true;
 PDFJS.disableTextLayer = true;
 PDFJS.maxImageSize = 1024 * 1024;
-PDFJS.workerSrc = '../../build/dist/build/pdf.worker.js';
-PDFJS.cMapUrl = '../../build/dist/cmaps/';
+PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
+PDFJS.cMapUrl = '../../node_modules/pdfjs-dist/cmaps/';
 PDFJS.cMapPacked = true;
 
 var DEFAULT_URL = '../../web/compressed.tracemonkey-pldi-09.pdf';

--- a/examples/node/getinfo.js
+++ b/examples/node/getinfo.js
@@ -12,8 +12,8 @@ var fs = require('fs');
 // HACK adding DOMParser to read XMP metadata.
 global.DOMParser = require('./domparsermock.js').DOMParserMock;
 
-// Run `gulp dist` to generate 'pdfjs-dist' npm package files.
-var pdfjsLib = require('../../build/dist');
+// Run `gulp dist-install` to generate 'pdfjs-dist' npm package files.
+var pdfjsLib = require('pdfjs-dist');
 
 // Loading file from file system into typed array
 var pdfPath = process.argv[2] || '../../web/compressed.tracemonkey-pldi-09.pdf';

--- a/examples/node/pdf2png/pdf2png.js
+++ b/examples/node/pdf2png/pdf2png.js
@@ -48,7 +48,7 @@ NodeCanvasFactory.prototype = {
   },
 };
 
-var pdfjsLib = require('../../../build/dist');
+var pdfjsLib = require('pdfjs-dist');
 
 // Relative path of the PDF file.
 var pdfURL = '../../helloworld/helloworld.pdf';

--- a/examples/node/pdf2svg.js
+++ b/examples/node/pdf2svg.js
@@ -10,8 +10,8 @@ var fs = require('fs');
 // HACK few hacks to let PDF.js be loaded not as a module in global space.
 require('./domstubs.js');
 
-// Run `gulp dist` to generate 'pdfjs-dist' npm package files.
-var pdfjsLib = require('../../build/dist');
+// Run `gulp dist-install` to generate 'pdfjs-dist' npm package files.
+var pdfjsLib = require('pdfjs-dist');
 
 // Loading file from file system into typed array
 var pdfPath = process.argv[2] || '../../web/compressed.tracemonkey-pldi-09.pdf';

--- a/examples/svgviewer/viewer.js
+++ b/examples/svgviewer/viewer.js
@@ -36,13 +36,14 @@ function renderDocument(pdf, svgLib) {
   }
 }
 
-Promise.all([SystemJS.import('pdfjs/display/api'),
-             SystemJS.import('pdfjs/display/svg'),
-             SystemJS.import('pdfjs/display/global')])
+Promise.all([System.import('pdfjs/display/api'),
+             System.import('pdfjs/display/svg'),
+             System.import('pdfjs/display/global'),
+             System.resolve('pdfjs/worker_loader')])
        .then(function (modules) {
   var api = modules[0], svg = modules[1], global = modules[2];
   // In production, change this to point to the built `pdf.worker.js` file.
-  global.PDFJS.workerSrc = '../../src/worker_loader.js';
+  global.PDFJS.workerSrc = modules[3];
 
   // In production, change this to point to where the cMaps are placed.
   global.PDFJS.cMapUrl = '../../external/bcmaps/';

--- a/examples/text-only/index.html
+++ b/examples/text-only/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Text-only PDF.js example</title>
-    <script src="../../build/generic/build/pdf.js"></script>
+    <script src="../../node_modules/pdfjs-dist/build/pdf.js"></script>
     <script src="pdf2svg.js"></script>
 </head>
 <body>

--- a/examples/text-only/pdf2svg.js
+++ b/examples/text-only/pdf2svg.js
@@ -18,7 +18,7 @@ var PAGE_NUMBER = 1;
 var PAGE_SCALE = 1.5;
 var SVG_NS = 'http://www.w3.org/2000/svg';
 
-PDFJS.workerSrc = '../../build/generic/build/pdf.worker.js';
+PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
 function buildSVG(viewport, textContent) {
   // Building SVG with size of the viewport (for simplicity)
@@ -63,7 +63,7 @@ function pageLoaded() {
 document.addEventListener('DOMContentLoaded', function () {
   if (typeof PDFJS === 'undefined') {
     alert('Built version of PDF.js was not found.\n' +
-          'Please run `gulp generic`.');
+          'Please run `gulp dist-install`.');
     return;
   }
   pageLoaded();

--- a/examples/webpack/README.md
+++ b/examples/webpack/README.md
@@ -6,7 +6,7 @@ Example to demonstrate PDF.js library usage with Webpack.
 
 Build project and install the example dependencies:
 
-    $ gulp dist
+    $ gulp dist-install
     $ cd examples/webpack
     $ npm install
 

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -1,8 +1,11 @@
 {
   "name": "webpack-pdf.js-example",
   "version": "0.1.0",
+  "scripts": {
+    "build": "webpack"
+  },
   "devDependencies": {
     "webpack": "~1.12.9",
-    "pdfjs-dist": "../../build/dist"
+    "pdfjs-dist": "../../node_modules/pdfjs-dist"
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1031,9 +1031,6 @@ gulp.task('lib', ['buildnumber'], function () {
 
 gulp.task('web-pre', ['generic', 'extension', 'jsdoc']);
 
-gulp.task('dist-pre',
-  ['generic', 'singlefile', 'components', 'lib', 'minified']);
-
 gulp.task('publish', ['generic'], function (done) {
   var version = JSON.parse(
     fs.readFileSync(BUILD_DIR + 'version.json').toString()).version;
@@ -1262,7 +1259,9 @@ gulp.task('gh-pages-git', ['gh-pages-prepare', 'wintersmith'], function () {
 
 gulp.task('web', ['gh-pages-prepare', 'wintersmith', 'gh-pages-git']);
 
-gulp.task('dist-repo-prepare', ['dist-pre'], function () {
+gulp.task('dist-pre',
+          ['generic', 'singlefile', 'components', 'lib', 'minified'],
+          function () {
   var VERSION = getVersionJSON().version;
 
   console.log();
@@ -1355,7 +1354,18 @@ gulp.task('dist-repo-prepare', ['dist-pre'], function () {
   ]);
 });
 
-gulp.task('dist-repo-git', ['dist-repo-prepare'], function () {
+gulp.task('dist-install', ['dist-pre'], function () {
+  var distPath = DIST_DIR;
+  var opts = {};
+  var installPath = process.env['PDFJS_INSTALL_PATH'];
+  if (installPath) {
+    opts.cwd = installPath;
+    distPath = path.relative(installPath, distPath);
+  }
+  safeSpawnSync('npm', ['install', distPath], opts);
+});
+
+gulp.task('dist-repo-git', ['dist-pre'], function () {
   var VERSION = getVersionJSON().version;
 
   console.log();


### PR DESCRIPTION
It will simplify example usage (e.g. now examples can be copied and used as is in the custom project that has pdfjs-dist installed) and avoid git-tag error when `gulp dist` run.