### PR TITLE
Gracefully ignore transaction failure in plugin-babel-cached

### DIFF
--- a/external/systemjs/plugin-babel-cached.js
+++ b/external/systemjs/plugin-babel-cached.js
@@ -55,6 +55,9 @@ function storeCache(address, hashCode, translated, format) {
       tx.oncomplete = function () {
         resolve();
       };
+      tx.onerror = function () {
+        resolve();
+      };
     });
   });
 }
@@ -73,6 +76,9 @@ function loadCache(address, hashCode) {
           translated: found.translated,
           format: found.format,
         } : null);
+      };
+      tx.onerror = function () {
+        resolve(null);
       };
     });
   });


### PR DESCRIPTION
Before this PR, any DB transaction error prevents the plugin from completing. Since the cache is a best-efforts attempt, I fix this by ignoring the error (instead of rethrowing the error).