### PR TITLE
Add "npm run" commands for "gulp" commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "yargs": "^3.14.0"
   },
   "scripts": {
-    "test": "gulp lint unittestcli externaltest"
+    "test": "gulp lint unittestcli externaltest",
+    "server": "gulp server",
+    "generic": "gulp generic"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Use case
I don't like having gulp installed globally.
Instead, I prefer having it as a dev-dependency, which can be located and run by npm.

# The Change
The change is simple, add a couple entries to `package.json` which allows typing `npm run server` to do the same as `gulp server`. Similarly, it adds `npm run generate` for `gulp generate`.

That's it.