### PR TITLE
Use eslint-plugin-mozilla and the webextensions environment to avoid defining globals in each file.

### DIFF
--- a/extensions/chromium/.eslintrc
+++ b/extensions/chromium/.eslintrc
@@ -3,11 +3,20 @@
     ../../.eslintrc
   ],
 
+  "env": {
+    "webextensions": true
+  },
+
+  "plugins": [
+    "mozilla"
+  ],
+
   "parserOptions": {
     "sourceType": "script"
   },
 
   "rules": {
+    "mozilla/import-globals": "error",
     "object-shorthand": "off",
   },
 }

--- a/extensions/chromium/contentscript.js
+++ b/extensions/chromium/contentscript.js
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-/* globals chrome, CSS */
 
 'use strict';
 

--- a/extensions/chromium/extension-router.js
+++ b/extensions/chromium/extension-router.js
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-/* globals chrome */
 
 'use strict';
 

--- a/extensions/chromium/feature-detect.js
+++ b/extensions/chromium/feature-detect.js
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-/* globals chrome */
 
 'use strict';
 

--- a/extensions/chromium/options/migration.js
+++ b/extensions/chromium/options/migration.js
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 /* eslint strict: ["error", "function"] */
-/* globals chrome */
 
 (function() {
   'use strict';

--- a/extensions/chromium/options/options.js
+++ b/extensions/chromium/options/options.js
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-/* globals chrome */
 
 'use strict';
 var storageAreaName = chrome.storage.sync ? 'sync' : 'local';

--- a/extensions/chromium/pageAction/background.js
+++ b/extensions/chromium/pageAction/background.js
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-/* globals chrome */
 
 'use strict';
 

--- a/extensions/chromium/pdfHandler-vcros.js
+++ b/extensions/chromium/pdfHandler-vcros.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 /* eslint strict: ["error", "function"] */
-/* globals chrome, getViewerURL */
+/* import-globals-from pdfHandler.js */
 
 (function() {
   'use strict';

--- a/extensions/chromium/pdfHandler.js
+++ b/extensions/chromium/pdfHandler.js
@@ -13,7 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-/* globals chrome, Features, saveReferer */
+/* import-globals-from feature-detect.js */
+/* import-globals-from preserve-referer.js */
 
 'use strict';
 

--- a/extensions/chromium/preserve-referer.js
+++ b/extensions/chromium/preserve-referer.js
@@ -13,8 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-/* globals chrome, getHeaderFromHeaders */
-/* exported saveReferer */
+/* import-globals-from pdfHandler.js */
 
 'use strict';
 /**

--- a/extensions/chromium/suppress-update.js
+++ b/extensions/chromium/suppress-update.js
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-/* globals chrome */
 
 'use strict';
 

--- a/extensions/chromium/telemetry.js
+++ b/extensions/chromium/telemetry.js
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 /* eslint strict: ["error", "function"] */
-/* globals chrome, crypto, Headers, Request */
 
 (function() {
   'use strict';

--- a/extensions/firefox/.eslintrc
+++ b/extensions/firefox/.eslintrc
@@ -8,7 +8,18 @@
     "sourceType": "script"
   },
 
+  "plugins": [
+    "mozilla"
+  ],
+
+  "globals": {
+    "Components": false,
+    "dump": false
+  },
+
   "rules": {
+    "mozilla/import-globals": "error",
+
     // Best Practices
     "consistent-return": "error",
 

--- a/extensions/firefox/bootstrap.js
+++ b/extensions/firefox/bootstrap.js
@@ -12,8 +12,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals Components, Services, dump, XPCOMUtils, PdfStreamConverter,
-           APP_SHUTDOWN, PdfjsChromeUtils, PdfjsContentUtils */
+/* globals PdfStreamConverter, APP_SHUTDOWN, PdfjsChromeUtils,
+           PdfjsContentUtils */
 
 "use strict";
 

--- a/extensions/firefox/chrome/content.js
+++ b/extensions/firefox/chrome/content.js
@@ -12,8 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals Components, Services, XPCOMUtils, PdfjsContentUtils,
-           PdfjsContentUtils, PdfStreamConverter, addMessageListener */
+/* eslint-env mozilla/frame-script */
 
 "use strict";
 

--- a/extensions/firefox/content/PdfJs.jsm
+++ b/extensions/firefox/content/PdfJs.jsm
@@ -12,8 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals Components, Services, XPCOMUtils, PdfjsChromeUtils,
-           PdfjsContentUtils, PdfStreamConverter */
 
 "use strict";
 

--- a/extensions/firefox/content/PdfJsNetwork.jsm
+++ b/extensions/firefox/content/PdfJsNetwork.jsm
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals Components, Services */
 
 "use strict";
 

--- a/extensions/firefox/content/PdfJsTelemetry.jsm
+++ b/extensions/firefox/content/PdfJsTelemetry.jsm
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 /* eslint max-len: ["error", 100] */
-/* globals Components, Services */
 
 "use strict";
 

--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -12,8 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals Components, Services, XPCOMUtils, NetUtil, PrivateBrowsingUtils,
-           dump, NetworkManager, PdfJsTelemetry, PdfjsContentUtils */
 
 "use strict";
 

--- a/extensions/firefox/content/PdfjsChromeUtils.jsm
+++ b/extensions/firefox/content/PdfjsChromeUtils.jsm
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals Components, Services, XPCOMUtils */
 
 "use strict";
 

--- a/extensions/firefox/content/PdfjsContentUtils.jsm
+++ b/extensions/firefox/content/PdfjsContentUtils.jsm
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals Components, Services, XPCOMUtils */
 
 "use strict";
 

--- a/extensions/firefox/content/pdfjschildbootstrap-enabled.js
+++ b/extensions/firefox/content/pdfjschildbootstrap-enabled.js
@@ -12,7 +12,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-/* globals Components, PdfJs, Services */
 
 "use strict";
 

--- a/extensions/firefox/content/pdfjschildbootstrap.js
+++ b/extensions/firefox/content/pdfjschildbootstrap.js
@@ -12,7 +12,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-/* globals Components, PdfjsContentUtils */
 
 "use strict";
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "babel-preset-es2015": "^6.24.1",
     "escodegen": "^1.8.0",
     "eslint": "^3.11.1",
+    "eslint-plugin-mozilla": "^0.2.47",
     "gulp": "^3.9.1",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",


### PR DESCRIPTION
eslint-plugin-mozilla has various tools to make it easier to find globals - this patch enables some of them for `extensions/firefox`.

Additionally, I also specify the `webextensions` environment for `extensions/chrome` and also use some importing globals rules to simplify the global definitions there.

eslint-plugin-mozilla does have a recommended configuration, however, give the discussion in #7957 I've left that alone for now.