### PR TITLE
Revert "Upstream changes from: Bug 1319111 - Expose result principal URL ("final channel URL") on LoadInfo, convert current consumers of LOAD_REPLACE"

### DIFF
--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -1011,14 +1011,6 @@ PdfStreamConverter.prototype = {
 
     // Keep the URL the same so the browser sees it as the same.
     channel.originalURI = aRequest.URI;
-//#if MOZCENTRAL
-    channel.loadInfo.resultPrincipalURI = aRequest.loadInfo.resultPrincipalURI;
-//#else
-    if ("resultPrincipalURI" in aRequest.loadInfo) {
-      channel.loadInfo.resultPrincipalURI =
-        aRequest.loadInfo.resultPrincipalURI;
-    }
-//#endif
     channel.loadGroup = aRequest.loadGroup;
     channel.loadInfo.originAttributes = aRequest.loadInfo.originAttributes;
 


### PR DESCRIPTION
Reverts mozilla/pdf.js#8390, since [bug 1319111](https://bugzilla.mozilla.org/show_bug.cgi?id=1319111) was backed out from `mozilla-central` for causing crashes and addon-compatiblity issues; refer to [bug 1319111#c147](https://bugzilla.mozilla.org/show_bug.cgi?id=1319111#c147) and [bug 1319111#c153](https://bugzilla.mozilla.org/show_bug.cgi?id=1319111#c153).

Furthermore, the new patch currently pending review in [bug 1319111](https://bugzilla.mozilla.org/show_bug.cgi?id=1319111) doesn't touch PDF.js code, hence we should just back this out for now to prevent conflicts on the next PDF.js update.

/cc @rvandermeulen