### PR TITLE
Replace a couple of leftover `make.js` references with `gulpfile.js` in docs/comments

### DIFF
--- a/docs/contents/getting_started/index.md
+++ b/docs/contents/getting_started/index.md
@@ -92,7 +92,7 @@ $ cd pdf.js
 ├── extensions/                            - various browser extensions
 ├── external/                              - third party code
 ├── l10n/                                  - translation files
-├── make.js                                - build script
+├── gulpfile.js                            - build script
 ├── package.json
 ├── src/
 │   ├── core/                              - core layer

--- a/external/importL10n/locales.js
+++ b/external/importL10n/locales.js
@@ -20,7 +20,7 @@ var https = require('https');
 var path = require('path');
 
 // Defines all languages that have a translation at mozilla-central.
-// This is used in make.js for the importl10n command.
+// This is used in gulpfile.js for the `importl10n` command.
 var langCodes = [
   'ach', 'af', 'ak', 'an', 'ar', 'as', 'ast', 'az', 'be', 'bg',
   'bn-BD', 'bn-IN', 'br', 'bs', 'ca', 'cs', 'csb', 'cy', 'da',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1196,7 +1196,7 @@ gulp.task('importl10n', function(done) {
   var locales = require('./external/importL10n/locales.js');
 
   console.log();
-  console.log('### Importing translations from mozilla-aurora');
+  console.log('### Importing translations from mozilla-central');
 
   if (!fs.existsSync(L10N_DIR)) {
     fs.mkdirSync(L10N_DIR);


### PR DESCRIPTION
Also updates a `console.log` statement in the `gulp importl10n` command (since I forgot it in a previous patch, and it didn't seem necessary with a separate patch for it).