### PR TITLE
Ensure that `TilingPattern`s have valid (non-zero) /BBox arrays (issue 8330)

### DIFF
--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -795,12 +795,18 @@ Shadings.Dummy = (function DummyClosure() {
 })();
 
 function getTilingPatternIR(operatorList, dict, args) {
-  var matrix = dict.getArray('Matrix');
-  var bbox = dict.getArray('BBox');
-  var xstep = dict.get('XStep');
-  var ystep = dict.get('YStep');
-  var paintType = dict.get('PaintType');
-  var tilingType = dict.get('TilingType');
+  let matrix = dict.getArray('Matrix');
+  let bbox = Util.normalizeRect(dict.getArray('BBox'));
+  let xstep = dict.get('XStep');
+  let ystep = dict.get('YStep');
+  let paintType = dict.get('PaintType');
+  let tilingType = dict.get('TilingType');
+
+  // Ensure that the pattern has a non-zero width and height, to prevent errors
+  // in `pattern_helper.js` (fixes issue8330.pdf).
+  if ((bbox[2] - bbox[0]) === 0 || (bbox[3] - bbox[1]) === 0) {
+    throw new Error(`getTilingPatternIR - invalid /BBox array: [${bbox}].`);
+  }
 
   return [
     'TilingPattern', args, operatorList, matrix, bbox, xstep, ystep,

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -304,7 +304,7 @@ var TilingPattern = (function TilingPatternClosure() {
   function TilingPattern(IR, color, ctx, canvasGraphicsFactory, baseTransform) {
     this.operatorList = IR[2];
     this.matrix = IR[3] || [1, 0, 0, 1, 0, 0];
-    this.bbox = Util.normalizeRect(IR[4]);
+    this.bbox = IR[4];
     this.xstep = IR[5];
     this.ystep = IR[6];
     this.paintType = IR[7];

--- a/test/pdfs/issue8330.pdf.link
+++ b/test/pdfs/issue8330.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/954710/FailingPDF.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1269,6 +1269,14 @@
       "rounds": 1,
       "type": "eq"
     },
+    {  "id": "issue8330",
+       "file": "pdfs/issue8330.pdf",
+       "md5": "9010093d07dd62d3b49378fd48cf45f9",
+       "rounds": 1,
+       "lastPage": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "issue4573",
        "file": "pdfs/issue4573.pdf",
        "md5": "34b0c4fdee19e57033275b766c5f57a3",


### PR DESCRIPTION
Fixes #8330.

*Please note:* This is a tentative patch, since I'm not entirely certain if it's the best solution; but it does work!