### PR TITLE
Convert the overlay manager to ES6 syntax

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -119,6 +119,8 @@ var PDFViewerApplication = {
   store: null,
   /** @type {DownloadManager} */
   downloadManager: null,
+  /** @type {OverlayManager} */
+  overlayManager: null,
   /** @type {Preferences} */
   preferences: null,
   /** @type {Toolbar} */
@@ -261,6 +263,8 @@ var PDFViewerApplication = {
     let appConfig = this.appConfig;
 
     return new Promise((resolve, reject) => {
+      this.overlayManager = new OverlayManager();
+
       let eventBus = appConfig.eventBus || getGlobalEventBus();
       this.eventBus = eventBus;
 
@@ -329,16 +333,15 @@ var PDFViewerApplication = {
 
       this.pdfViewer.setFindController(this.findController);
 
-      // FIXME better PDFFindBar constructor parameters
+      // TODO: improve `PDFFindBar` constructor parameter passing
       let findBarConfig = Object.create(appConfig.findBar);
       findBarConfig.findController = this.findController;
       findBarConfig.eventBus = eventBus;
       this.findBar = new PDFFindBar(findBarConfig);
 
-      this.overlayManager = OverlayManager;
-
       this.pdfDocumentProperties =
-        new PDFDocumentProperties(appConfig.documentProperties);
+        new PDFDocumentProperties(appConfig.documentProperties,
+                                  this.overlayManager);
 
       this.pdfCursorTools = new PDFCursorTools({
         container,
@@ -361,7 +364,8 @@ var PDFViewerApplication = {
         });
       }
 
-      this.passwordPrompt = new PasswordPrompt(appConfig.passwordOverlay);
+      this.passwordPrompt = new PasswordPrompt(appConfig.passwordOverlay,
+                                               this.overlayManager);
 
       this.pdfOutlineViewer = new PDFOutlineViewer({
         container: appConfig.sidebar.outlineView,
@@ -375,7 +379,7 @@ var PDFViewerApplication = {
         downloadManager,
       });
 
-      // FIXME better PDFSidebar constructor parameters
+      // TODO: improve `PDFSidebar` constructor parameter passing
       let sidebarConfig = Object.create(appConfig.sidebar);
       sidebarConfig.pdfViewer = this.pdfViewer;
       sidebarConfig.pdfThumbnailViewer = this.pdfThumbnailViewer;
@@ -1911,7 +1915,7 @@ function webViewerClick(evt) {
 }
 
 function webViewerKeyDown(evt) {
-  if (OverlayManager.active) {
+  if (PDFViewerApplication.overlayManager.active) {
     return;
   }
 

--- a/web/overlay_manager.js
+++ b/web/overlay_manager.js
@@ -13,132 +13,137 @@
  * limitations under the License.
  */
 
-var OverlayManager = {
-  overlays: {},
-  active: null,
+class OverlayManager {
+  constructor() {
+    this._overlays = {};
+    this._active = null;
+    this._keyDownBound = this._keyDown.bind(this);
+  }
+
+  get active() {
+    return this._active;
+  }
 
   /**
-   * @param {string} name The name of the overlay that is registered.
-   * @param {HTMLDivElement} element The overlay's DOM element.
-   * @param {function} callerCloseMethod (optional) The method that, if present,
-   *                   will call OverlayManager.close from the Object
+   * @param {string} name - The name of the overlay that is registered.
+   * @param {HTMLDivElement} element - The overlay's DOM element.
+   * @param {function} callerCloseMethod - (optional) The method that, if
+   *                   present, calls `OverlayManager.close` from the object
    *                   registering the overlay. Access to this method is
    *                   necessary in order to run cleanup code when e.g.
-   *                   the overlay is force closed. The default is null.
-   * @param {boolean} canForceClose (optional) Indicates if opening the overlay
-   *                  will close an active overlay. The default is false.
+   *                   the overlay is force closed. The default is `null`.
+   * @param {boolean} canForceClose - (optional) Indicates if opening the
+   *                  overlay closes an active overlay. The default is `false`.
    * @returns {Promise} A promise that is resolved when the overlay has been
    *                    registered.
    */
-  register(name, element, callerCloseMethod, canForceClose) {
+  register(name, element, callerCloseMethod = null, canForceClose = false) {
     return new Promise((resolve) => {
-      var container;
+      let container;
       if (!name || !element || !(container = element.parentNode)) {
         throw new Error('Not enough parameters.');
-      } else if (this.overlays[name]) {
+      } else if (this._overlays[name]) {
         throw new Error('The overlay is already registered.');
       }
-      this.overlays[name] = {
+      this._overlays[name] = {
         element,
         container,
-        callerCloseMethod: (callerCloseMethod || null),
-        canForceClose: (canForceClose || false),
+        callerCloseMethod,
+        canForceClose,
       };
       resolve();
     });
-  },
+  }
 
   /**
-   * @param {string} name The name of the overlay that is unregistered.
+   * @param {string} name - The name of the overlay that is unregistered.
    * @returns {Promise} A promise that is resolved when the overlay has been
    *                    unregistered.
    */
   unregister(name) {
     return new Promise((resolve) => {
-      if (!this.overlays[name]) {
+      if (!this._overlays[name]) {
         throw new Error('The overlay does not exist.');
-      } else if (this.active === name) {
+      } else if (this._active === name) {
         throw new Error('The overlay cannot be removed while it is active.');
       }
-      delete this.overlays[name];
-
+      delete this._overlays[name];
       resolve();
     });
-  },
+  }
 
   /**
-   * @param {string} name The name of the overlay that should be opened.
+   * @param {string} name - The name of the overlay that should be opened.
    * @returns {Promise} A promise that is resolved when the overlay has been
    *                    opened.
    */
   open(name) {
     return new Promise((resolve) => {
-      if (!this.overlays[name]) {
+      if (!this._overlays[name]) {
         throw new Error('The overlay does not exist.');
-      } else if (this.active) {
-        if (this.overlays[name].canForceClose) {
+      } else if (this._active) {
+        if (this._overlays[name].canForceClose) {
           this._closeThroughCaller();
-        } else if (this.active === name) {
+        } else if (this._active === name) {
           throw new Error('The overlay is already active.');
         } else {
           throw new Error('Another overlay is currently active.');
         }
       }
-      this.active = name;
-      this.overlays[this.active].element.classList.remove('hidden');
-      this.overlays[this.active].container.classList.remove('hidden');
+      this._active = name;
+      this._overlays[this._active].element.classList.remove('hidden');
+      this._overlays[this._active].container.classList.remove('hidden');
 
-      window.addEventListener('keydown', this._keyDown);
+      window.addEventListener('keydown', this._keyDownBound);
       resolve();
     });
-  },
+  }
 
   /**
-   * @param {string} name The name of the overlay that should be closed.
+   * @param {string} name - The name of the overlay that should be closed.
    * @returns {Promise} A promise that is resolved when the overlay has been
    *                    closed.
    */
   close(name) {
     return new Promise((resolve) => {
-      if (!this.overlays[name]) {
+      if (!this._overlays[name]) {
         throw new Error('The overlay does not exist.');
-      } else if (!this.active) {
+      } else if (!this._active) {
         throw new Error('The overlay is currently not active.');
-      } else if (this.active !== name) {
+      } else if (this._active !== name) {
         throw new Error('Another overlay is currently active.');
       }
-      this.overlays[this.active].container.classList.add('hidden');
-      this.overlays[this.active].element.classList.add('hidden');
-      this.active = null;
+      this._overlays[this._active].container.classList.add('hidden');
+      this._overlays[this._active].element.classList.add('hidden');
+      this._active = null;
 
-      window.removeEventListener('keydown', this._keyDown);
+      window.removeEventListener('keydown', this._keyDownBound);
       resolve();
     });
-  },
+  }
 
   /**
    * @private
    */
   _keyDown(evt) {
-    var self = OverlayManager;
-    if (self.active && evt.keyCode === 27) { // Esc key.
-      self._closeThroughCaller();
+    if (this._active && evt.keyCode === 27) { // Esc key.
+      this._closeThroughCaller();
       evt.preventDefault();
     }
-  },
+  }
 
   /**
    * @private
    */
   _closeThroughCaller() {
-    if (this.overlays[this.active].callerCloseMethod) {
-      this.overlays[this.active].callerCloseMethod();
+    if (this._overlays[this._active].callerCloseMethod) {
+      this._overlays[this._active].callerCloseMethod();
     }
-    if (this.active) {
-      this.close(this.active);
+    if (this._active) {
+      this.close(this._active);
     }
   }
-};
+}
 
 export {
   OverlayManager,

--- a/web/password_prompt.js
+++ b/web/password_prompt.js
@@ -14,7 +14,6 @@
  */
 
 import { mozL10n } from './ui_utils';
-import { OverlayManager } from './overlay_manager';
 import { PasswordResponses } from './pdfjs';
 
 /**
@@ -33,14 +32,16 @@ import { PasswordResponses } from './pdfjs';
 class PasswordPrompt {
   /**
    * @param {PasswordPromptOptions} options
+   * @param {OverlayManager} overlayManager - Manager for the viewer overlays.
    */
-  constructor(options) {
+  constructor(options, overlayManager) {
     this.overlayName = options.overlayName;
     this.container = options.container;
     this.label = options.label;
     this.input = options.input;
     this.submitButton = options.submitButton;
     this.cancelButton = options.cancelButton;
+    this.overlayManager = overlayManager;
 
     this.updateCallback = null;
     this.reason = null;
@@ -54,12 +55,12 @@ class PasswordPrompt {
       }
     });
 
-    OverlayManager.register(this.overlayName, this.container,
-                            this.close.bind(this), true);
+    this.overlayManager.register(this.overlayName, this.container,
+                                 this.close.bind(this), true);
   }
 
   open() {
-    OverlayManager.open(this.overlayName).then(() => {
+    this.overlayManager.open(this.overlayName).then(() => {
       this.input.focus();
 
       var promptString = mozL10n.get('password_label', null,
@@ -75,7 +76,7 @@ class PasswordPrompt {
   }
 
   close() {
-    OverlayManager.close(this.overlayName).then(() => {
+    this.overlayManager.close(this.overlayName).then(() => {
       this.input.value = '';
     });
   }

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -15,7 +15,6 @@
 
 import { cloneObj, getPDFFileNameFromURL, mozL10n } from './ui_utils';
 import { createPromiseCapability } from './pdfjs';
-import { OverlayManager } from './overlay_manager';
 
 const DEFAULT_FIELD_CONTENT = '-';
 
@@ -30,19 +29,22 @@ const DEFAULT_FIELD_CONTENT = '-';
 class PDFDocumentProperties {
   /**
    * @param {PDFDocumentPropertiesOptions} options
+   * @param {OverlayManager} overlayManager - Manager for the viewer overlays.
    */
-  constructor({ overlayName, fields, container, closeButton, }) {
+  constructor({ overlayName, fields, container, closeButton, },
+              overlayManager) {
     this.overlayName = overlayName;
     this.fields = fields;
     this.container = container;
+    this.overlayManager = overlayManager;
 
     this._reset();
 
     if (closeButton) { // Bind the event listener for the Close button.
       closeButton.addEventListener('click', this.close.bind(this));
     }
-    OverlayManager.register(this.overlayName, this.container,
-                            this.close.bind(this));
+    this.overlayManager.register(this.overlayName, this.container,
+                                 this.close.bind(this));
   }
 
   /**
@@ -58,7 +60,7 @@ class PDFDocumentProperties {
       });
     };
 
-    Promise.all([OverlayManager.open(this.overlayName),
+    Promise.all([this.overlayManager.open(this.overlayName),
                  this._dataAvailableCapability.promise]).then(() => {
       // If the document properties were previously fetched (for this PDF file),
       // just update the dialog immediately to avoid redundant lookups.
@@ -101,7 +103,7 @@ class PDFDocumentProperties {
    * Close the document properties overlay.
    */
   close() {
-    OverlayManager.close(this.overlayName);
+    this.overlayManager.close(this.overlayName);
   }
 
   /**
@@ -165,7 +167,7 @@ class PDFDocumentProperties {
       }
       return;
     }
-    if (OverlayManager.active !== this.overlayName) {
+    if (this.overlayManager.active !== this.overlayName) {
       // Don't bother updating the dialog if has already been closed,
       // since it will be updated the next time `this.open` is called.
       return;


### PR DESCRIPTION
This pull request is a redo of #8119.

You can test that the `web/chromecom.js` change works using the steps from #6233. The other overlays (document properties, password prompt and print) can be tested using the viewer itself. For convenience, you can use http://async5.org/moz/passwordOU.pdf (password: 123456) to test the password prompt.