### PR TITLE
Update webpack.js to support browsers that do not have the Web Workers API

### DIFF
--- a/external/dist/webpack.js
+++ b/external/dist/webpack.js
@@ -16,6 +16,11 @@
 
 var pdfjs = require('./build/pdf.js');
 var PdfjsWorker = require('worker-loader!./build/pdf.worker.js');
-pdfjs.PDFJS.workerPort = new PdfjsWorker();
+
+if (typeof window !== 'undefined' && 'Worker' in window) {
+  pdfjs.PDFJS.workerPort = new PdfjsWorker();
+} else {
+  pdfjs.PDFJS.disableWorker = true;
+}
 
 module.exports = pdfjs;


### PR DESCRIPTION
Allow to use `pdfjs-dist/webpack.js` even if the final bundle is used by browsers that do not support the Web Workers API (eg. IE9).
See issue #8451