### PR TITLE
Refactor the `getTempCanvas` function in `pdf_thumbnail_view.js` to a factory, in preparation for ES6 conversion of the thumbnail related code

### DIFF
--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -104,14 +104,7 @@ var PDFThumbnailViewer = (function PDFThumbnailViewerClosure() {
     },
 
     cleanup: function PDFThumbnailViewer_cleanup() {
-      var tempCanvas = PDFThumbnailView.tempImageCache;
-      if (tempCanvas) {
-        // Zeroing the width and height causes Firefox to release graphics
-        // resources immediately, which can greatly reduce memory consumption.
-        tempCanvas.width = 0;
-        tempCanvas.height = 0;
-      }
-      PDFThumbnailView.tempImageCache = null;
+      PDFThumbnailView.cleanup();
     },
 
     /**


### PR DESCRIPTION
This patch intends to simplify future ES6 refactoring of the thumbnail code, since the current code isn't going to work well together with proper `Class`es.

*Edit:* Somewhat simpler reviewing with https://github.com/mozilla/pdf.js/pull/8458/files?w=1.