### PR TITLE
Add a stub `createL10n` to `DefaultExternalServices` in app.js

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -75,13 +75,16 @@ var DefaultExternalServices = {
   createPreferences() {
     throw new Error('Not implemented: createPreferences');
   },
+  createL10n() {
+    throw new Error('Not implemented: createL10n');
+  },
   supportsIntegratedFind: false,
   supportsDocumentFonts: true,
   supportsDocumentColors: true,
   supportedMouseWheelZoomModifierKeys: {
     ctrlKey: true,
     metaKey: true,
-  }
+  },
 };
 
 var PDFViewerApplication = {


### PR DESCRIPTION
It appears that this was simply forgotten in PR https://github.com/mozilla/pdf.js/pull/8394#pullrequestreview-39416669.