### PR TITLE
Fix inconsistent spacing and trailing commas in objects in `extensions/` files, so we can enable the `comma-dangle` and `object-curly-spacing` ESLint rules later on

### DIFF
--- a/extensions/chromium/contentscript.js
+++ b/extensions/chromium/contentscript.js
@@ -103,7 +103,7 @@ function watchObjectOrEmbed(elem) {
     attributes: true,
     childList: false,
     characterData: false,
-    attributeFilter: [srcAttribute]
+    attributeFilter: [srcAttribute],
   });
 }
 

--- a/extensions/chromium/extension-router.js
+++ b/extensions/chromium/extension-router.js
@@ -70,14 +70,14 @@ limitations under the License.
         url += details.url.slice(i);
       }
       console.log('Redirecting ' + details.url + ' to ' + url);
-      return { redirectUrl: url };
+      return { redirectUrl: url, };
     }
   }, {
     types: ['main_frame', 'sub_frame'],
     urls: schemes.map(function(scheme) {
       // Format: "chrome-extension://[EXTENSIONID]/<scheme>*"
       return CRX_BASE_URL + scheme + '*';
-    })
+    }),
   }, ['blocking']);
 
   // When session restore is used, viewer pages may be loaded before the
@@ -85,7 +85,7 @@ limitations under the License.
   // Or the extension could have been crashed (OOM), leaving a sad tab behind.
   // Reload these tabs.
   chrome.tabs.query({
-    url: CRX_BASE_URL + '*:*'
+    url: CRX_BASE_URL + '*:*',
   }, function(tabsFromLastSession) {
     for (var i = 0; i < tabsFromLastSession.length; ++i) {
       chrome.tabs.reload(tabsFromLastSession[i].id);
@@ -107,7 +107,7 @@ limitations under the License.
           url: chrome.runtime.getURL('restoretab.html') +
             '?' + encodeURIComponent(url) +
             '#' + encodeURIComponent(localStorage.getItem(key)),
-          active: !isHidden
+          active: !isHidden,
         });
       }
       localStorage.removeItem(key);

--- a/extensions/chromium/feature-detect.js
+++ b/extensions/chromium/feature-detect.js
@@ -95,12 +95,12 @@ function featureTestRedirectOnHeadersReceived(callback) {
     // If supported, the request is redirected.
     // If not supported, the return value is ignored.
     return {
-      redirectUrl: chrome.runtime.getURL('/manifest.json')
+      redirectUrl: chrome.runtime.getURL('/manifest.json'),
     };
   }
   chrome.webRequest.onHeadersReceived.addListener(onHeadersReceived, {
     types: ['xmlhttprequest'],
-    urls: [url]
+    urls: [url],
   }, ['blocking']);
 
   var x = new XMLHttpRequest();

--- a/extensions/chromium/options/options.js
+++ b/extensions/chromium/options/options.js
@@ -157,7 +157,7 @@ function renderDefaultZoomValue(shortDescription) {
   var select = wrapper.querySelector('select');
   select.onchange = function() {
     storageArea.set({
-      defaultZoomValue: this.value
+      defaultZoomValue: this.value,
     });
   };
   wrapper.querySelector('span').textContent = shortDescription;
@@ -186,7 +186,7 @@ function renderSidebarViewOnLoad(shortDescription) {
   var select = wrapper.querySelector('select');
   select.onchange = function() {
     storageArea.set({
-      sidebarViewOnLoad: parseInt(this.value)
+      sidebarViewOnLoad: parseInt(this.value),
     });
   };
   wrapper.querySelector('span').textContent = shortDescription;
@@ -203,7 +203,7 @@ function renderExternalLinkTarget(shortDescription) {
   var select = wrapper.querySelector('select');
   select.onchange = function() {
     storageArea.set({
-      externalLinkTarget: parseInt(this.value)
+      externalLinkTarget: parseInt(this.value),
     });
   };
   wrapper.querySelector('span').textContent = shortDescription;

--- a/extensions/chromium/pageAction/background.js
+++ b/extensions/chromium/pageAction/background.js
@@ -29,7 +29,7 @@ limitations under the License.
       url = url[1];
       chrome.pageAction.setPopup({
         tabId: tabId,
-        popup: '/pageAction/popup.html?file=' + encodeURIComponent(url)
+        popup: '/pageAction/popup.html?file=' + encodeURIComponent(url),
       });
       chrome.pageAction.show(tabId);
     } else {

--- a/extensions/chromium/pdfHandler-vcros.js
+++ b/extensions/chromium/pdfHandler-vcros.js
@@ -49,7 +49,7 @@ limitations under the License.
       chrome.windows.getLastFocused(function(chromeWindow) {
         var windowId = chromeWindow && chromeWindow.id;
         if (windowId) {
-          chrome.windows.update(windowId, { focused: true });
+          chrome.windows.update(windowId, { focused: true, });
         }
         openViewer(windowId, fileEntries);
       });
@@ -77,7 +77,7 @@ limitations under the License.
       chrome.tabs.create({
         windowId: windowId,
         active: true,
-        url: url
+        url: url,
       }, function() {
         openViewer(windowId, fileEntries);
       });
@@ -85,7 +85,7 @@ limitations under the License.
       chrome.windows.create({
         type: 'normal',
         focused: true,
-        url: url
+        url: url,
       }, function(chromeWindow) {
         openViewer(chromeWindow.id, fileEntries);
       });

--- a/extensions/chromium/pdfHandler.js
+++ b/extensions/chromium/pdfHandler.js
@@ -103,12 +103,12 @@ function getHeadersWithContentDispositionAttachment(details) {
   var headers = details.responseHeaders;
   var cdHeader = getHeaderFromHeaders(headers, 'content-disposition');
   if (!cdHeader) {
-    cdHeader = {name: 'Content-Disposition'};
+    cdHeader = { name: 'Content-Disposition', };
     headers.push(cdHeader);
   }
   if (!/^attachment/i.test(cdHeader.value)) {
     cdHeader.value = 'attachment' + cdHeader.value.replace(/^[^;]+/i, '');
-    return { responseHeaders: headers };
+    return { responseHeaders: headers, };
   }
 }
 
@@ -133,7 +133,7 @@ chrome.webRequest.onHeadersReceived.addListener(
 
     // Replace frame with viewer
     if (Features.webRequestRedirectUrl) {
-      return { redirectUrl: viewerUrl };
+      return { redirectUrl: viewerUrl, };
     }
     // Aww.. redirectUrl is not yet supported, so we have to use a different
     // method as fallback (Chromium <35).
@@ -141,9 +141,9 @@ chrome.webRequest.onHeadersReceived.addListener(
     if (details.frameId === 0) {
       // Main frame. Just replace the tab and be done!
       chrome.tabs.update(details.tabId, {
-        url: viewerUrl
+        url: viewerUrl,
       });
-      return { cancel: true };
+      return { cancel: true, };
     }
     console.warn('Child frames are not supported in ancient Chrome builds!');
   },
@@ -151,7 +151,7 @@ chrome.webRequest.onHeadersReceived.addListener(
     urls: [
       '<all_urls>'
     ],
-    types: ['main_frame', 'sub_frame']
+    types: ['main_frame', 'sub_frame'],
   },
   ['blocking', 'responseHeaders']);
 
@@ -165,14 +165,14 @@ chrome.webRequest.onBeforeRequest.addListener(
       return;
     }
     var viewerUrl = getViewerURL(details.url);
-    return { redirectUrl: viewerUrl };
+    return { redirectUrl: viewerUrl, };
   },
   {
     urls: [
       'ftp://*/*.pdf',
       'ftp://*/*.PDF'
     ],
-    types: ['main_frame', 'sub_frame']
+    types: ['main_frame', 'sub_frame'],
   },
   ['blocking']);
 
@@ -187,14 +187,14 @@ chrome.webRequest.onBeforeRequest.addListener(
     // through XMLHttpRequest. Necessary to deal with http://crbug.com/302548
     var viewerUrl = getViewerURL(details.url);
 
-    return { redirectUrl: viewerUrl };
+    return { redirectUrl: viewerUrl, };
   },
   {
     urls: [
       'file://*/*.pdf',
       'file://*/*.PDF'
     ],
-    types: ['main_frame', 'sub_frame']
+    types: ['main_frame', 'sub_frame'],
   },
   ['blocking']);
 
@@ -210,17 +210,17 @@ chrome.extension.isAllowedFileSchemeAccess(function(isAllowedAccess) {
   chrome.webNavigation.onBeforeNavigate.addListener(function(details) {
     if (details.frameId === 0 && !isPdfDownloadable(details)) {
       chrome.tabs.update(details.tabId, {
-        url: getViewerURL(details.url)
+        url: getViewerURL(details.url),
       });
     }
   }, {
     url: [{
       urlPrefix: 'file://',
-      pathSuffix: '.pdf'
+      pathSuffix: '.pdf',
     }, {
       urlPrefix: 'file://',
-      pathSuffix: '.PDF'
-    }]
+      pathSuffix: '.PDF',
+    }],
   });
 });
 
@@ -262,11 +262,11 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
         windowId: sender.tab.windowId,
         index: sender.tab.index + 1,
         url: url,
-        openerTabId: sender.tab.id
+        openerTabId: sender.tab.id,
       });
     } else {
       chrome.tabs.update(sender.tab.id, {
-        url: url
+        url: url,
       });
     }
   }

--- a/extensions/chromium/preserve-referer.js
+++ b/extensions/chromium/preserve-referer.js
@@ -44,7 +44,7 @@ var g_referrers = {};
 (function() {
   var requestFilter = {
     urls: ['*://*/*'],
-    types: ['main_frame', 'sub_frame']
+    types: ['main_frame', 'sub_frame'],
   };
   chrome.webRequest.onSendHeaders.addListener(function(details) {
     g_requestHeaders[details.requestId] = details.requestHeaders;
@@ -104,7 +104,7 @@ chrome.runtime.onConnect.addListener(function onReceivePort(port) {
       chrome.webRequest.onBeforeSendHeaders.addListener(onBeforeSendHeaders, {
         urls: [data.requestUrl],
         types: ['xmlhttprequest'],
-        tabId: tabId
+        tabId: tabId,
       }, ['blocking', 'requestHeaders']);
     }
     // Acknowledge the message, and include the latest referer for this frame.
@@ -126,7 +126,7 @@ chrome.runtime.onConnect.addListener(function onReceivePort(port) {
     var headers = details.requestHeaders;
     var refererHeader = getHeaderFromHeaders(headers, 'referer');
     if (!refererHeader) {
-      refererHeader = {name: 'Referer'};
+      refererHeader = { name: 'Referer', };
       headers.push(refererHeader);
     } else if (refererHeader.value &&
         refererHeader.value.lastIndexOf('chrome-extension:', 0) !== 0) {
@@ -135,6 +135,6 @@ chrome.runtime.onConnect.addListener(function onReceivePort(port) {
       return;
     }
     refererHeader.value = referer;
-    return {requestHeaders: headers};
+    return { requestHeaders: headers, };
   }
 });

--- a/extensions/chromium/suppress-update.js
+++ b/extensions/chromium/suppress-update.js
@@ -20,7 +20,7 @@ limitations under the License.
 // viewer is not displaying any PDF files. Otherwise the tabs would close, which
 // is quite disruptive (crbug.com/511670).
 chrome.runtime.onUpdateAvailable.addListener(function() {
-    if (chrome.extension.getViews({type: 'tab'}).length === 0) {
+    if (chrome.extension.getViews({ type: 'tab', }).length === 0) {
         chrome.runtime.reload();
     }
 });

--- a/extensions/firefox/bootstrap.js
+++ b/extensions/firefox/bootstrap.js
@@ -112,7 +112,7 @@ Factory.prototype = {
   lockFactory: function lockFactory(lock) {
     // No longer used as of gecko 1.7.
     throw Cr.NS_ERROR_NOT_IMPLEMENTED;
-  }
+  },
 };
 
 var pdfStreamConverterFactory = new Factory();

--- a/extensions/firefox/chrome/content.js
+++ b/extensions/firefox/chrome/content.js
@@ -66,7 +66,7 @@
     lockFactory: function lockFactory(lock) {
       // No longer used as of gecko 1.7.
       throw Cr.NS_ERROR_NOT_IMPLEMENTED;
-    }
+    },
   };
 
   var pdfStreamConverterFactory = new Factory();

--- a/extensions/firefox/content/PdfJs-stub.jsm
+++ b/extensions/firefox/content/PdfJs-stub.jsm
@@ -22,5 +22,5 @@
 var EXPORTED_SYMBOLS = ["PdfJs"];
 
 var PdfJs = {
-  init: function PdfJs_init() {}
+  init: function PdfJs_init() {},
 };

--- a/extensions/firefox/content/PdfJs.jsm
+++ b/extensions/firefox/content/PdfJs.jsm
@@ -126,7 +126,7 @@ Factory.prototype = {
       registrar.unregisterFactory(this._classID2, this._factory);
     }
     this._factory = null;
-  }
+  },
 };
 
 var PdfJs = {
@@ -325,5 +325,5 @@ var PdfJs = {
     delete this._pdfStreamConverterFactory;
 
     this._registered = false;
-  }
+  },
 };

--- a/extensions/firefox/content/PdfJsTelemetry-stub.jsm
+++ b/extensions/firefox/content/PdfJsTelemetry-stub.jsm
@@ -39,5 +39,5 @@ this.PdfJsTelemetry = {
   onStreamType(streamTypeId) {
   },
   onTimeToView(ms) {
-  }
+  },
 };

--- a/extensions/firefox/content/PdfJsTelemetry.jsm
+++ b/extensions/firefox/content/PdfJsTelemetry.jsm
@@ -65,5 +65,5 @@ this.PdfJsTelemetry = {
   onTimeToView(ms) {
     let histogram = Services.telemetry.getHistogramById("PDF_VIEWER_TIME_TO_VIEW_MS");
     histogram.add(ms);
-  }
+  },
 };

--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -206,7 +206,7 @@ PdfDataListener.prototype = {
     if (this.errorCode) {
       value(null, this.errorCode);
     }
-  }
+  },
 };
 
 /**
@@ -221,7 +221,7 @@ class ChromeActions {
       firstPageInfo: false,
       streamTypesUsed: [],
       fontTypesUsed: [],
-      startAt: Date.now()
+      startAt: Date.now(),
     };
   }
 
@@ -309,7 +309,7 @@ class ChromeActions {
         onDataAvailable(aRequest, aContext, aDataInputStream, aOffset, aCount) {
           this.extListener.onDataAvailable(aRequest, aContext, aDataInputStream,
                                            aOffset, aCount);
-        }
+        },
       };
 
       channel.asyncOpen2(listener);
@@ -583,7 +583,7 @@ class RangedChromeActions extends ChromeActions {
           return;
         }
         this.headers[aHeader] = aValue;
-      }
+      },
     };
     if (originalRequest.visitRequestHeaders) {
       originalRequest.visitRequestHeaders(httpHeaderVisitor);
@@ -680,7 +680,7 @@ class RangedChromeActions extends ChromeActions {
           pdfjsLoadAction: "rangeProgress",
           loaded: evt.loaded,
         }, "*");
-      }
+      },
     });
   }
 
@@ -773,7 +773,8 @@ class RequestListener {
         response = function sendResponse(aResponse) {
           try {
             var listener = doc.createEvent("CustomEvent");
-            let detail = Cu.cloneInto({ response: aResponse }, doc.defaultView);
+            let detail = Cu.cloneInto({ response: aResponse, },
+                                      doc.defaultView);
             listener.initCustomEvent("pdf.js.response", true, false, detail);
             return message.dispatchEvent(listener);
           } catch (e) {
@@ -1006,7 +1007,7 @@ PdfStreamConverter.prototype = {
             domWindow.frameElement.className === "previewPluginContentFrame";
           PdfJsTelemetry.onEmbed(isObjectEmbed);
         }
-      }
+      },
     };
 
     // Keep the URL the same so the browser sees it as the same.
@@ -1041,5 +1042,5 @@ PdfStreamConverter.prototype = {
     }
     delete this.dataListener;
     delete this.binaryStream;
-  }
+  },
 };

--- a/extensions/firefox/content/PdfjsChromeUtils.jsm
+++ b/extensions/firefox/content/PdfjsChromeUtils.jsm
@@ -197,7 +197,7 @@ var PdfjsChromeUtils = {
       query: aEvent.detail.query,
       caseSensitive: aEvent.detail.caseSensitive,
       highlightAll: aEvent.detail.highlightAll,
-      findPrevious: aEvent.detail.findPrevious
+      findPrevious: aEvent.detail.findPrevious,
     };
 
     let browser = aEvent.currentTarget.browser;
@@ -331,7 +331,7 @@ var PdfjsChromeUtils = {
       callback() {
         messageSent = true;
         sendMessage(true);
-      }
+      },
     }];
     notificationBox.appendNotification(data.message, "pdfjs-fallback", null,
                                        notificationBox.PRIORITY_INFO_LOW,
@@ -349,5 +349,5 @@ var PdfjsChromeUtils = {
       }
       sendMessage(false);
     });
-  }
+  },
 };

--- a/extensions/firefox/content/PdfjsContentUtils.jsm
+++ b/extensions/firefox/content/PdfjsContentUtils.jsm
@@ -76,35 +76,35 @@ var PdfjsContentUtils = {
 
   clearUserPref(aPrefName) {
     this._mm.sendSyncMessage("PDFJS:Parent:clearUserPref", {
-      name: aPrefName
+      name: aPrefName,
     });
   },
 
   setIntPref(aPrefName, aPrefValue) {
     this._mm.sendSyncMessage("PDFJS:Parent:setIntPref", {
       name: aPrefName,
-      value: aPrefValue
+      value: aPrefValue,
     });
   },
 
   setBoolPref(aPrefName, aPrefValue) {
     this._mm.sendSyncMessage("PDFJS:Parent:setBoolPref", {
       name: aPrefName,
-      value: aPrefValue
+      value: aPrefValue,
     });
   },
 
   setCharPref(aPrefName, aPrefValue) {
     this._mm.sendSyncMessage("PDFJS:Parent:setCharPref", {
       name: aPrefName,
-      value: aPrefValue
+      value: aPrefValue,
     });
   },
 
   setStringPref(aPrefName, aPrefValue) {
     this._mm.sendSyncMessage("PDFJS:Parent:setStringPref", {
       name: aPrefName,
-      value: aPrefValue
+      value: aPrefValue,
     });
   },
 
@@ -155,5 +155,5 @@ var PdfjsContentUtils = {
         }
         break;
     }
-  }
+  },
 };

--- a/extensions/firefox/tools/l10n.js
+++ b/extensions/firefox/tools/l10n.js
@@ -127,6 +127,6 @@
     },
 
     // translate an element or document fragment
-    translate: translateFragment
+    translate: translateFragment,
   };
 })(this);


### PR DESCRIPTION
http://eslint.org/docs/rules/comma-dangle
http://eslint.org/docs/rules/object-curly-spacing

Given that we currently have quite inconsistent object formatting, fixing this in in one big patch probably wouldn't be feasible (since I cannot imagine anyone wanting to review that); hence I've opted to try and do this piecewise instead.

Please note: This patch was created automatically, using the ESLint `--fix` command line option. In a couple of places this caused lines to become too long, and I've fixed those manually; please refer to the interdiff below for the only hand-edits in this patch.

```diff
diff --git a/extensions/firefox/content/PdfStreamConverter.jsm b/extensions/firefox/content/PdfStreamConverter.jsm
index ea91a71a..0d59dad1 100644
--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -773,7 +773,8 @@ class RequestListener {
         response = function sendResponse(aResponse) {
           try {
             var listener = doc.createEvent("CustomEvent");
-            let detail = Cu.cloneInto({ response: aResponse, }, doc.defaultView);
+            let detail = Cu.cloneInto({ response: aResponse, },
+                                      doc.defaultView);
             listener.initCustomEvent("pdf.js.response", true, false, detail);
             return message.dispatchEvent(listener);
           } catch (e) {
```