### PR TITLE
Fix inconsistent spacing and trailing commas in objects in remaining `src/` files, so we can enable the `comma-dangle` and `object-curly-spacing` ESLint rules later on

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -97,7 +97,7 @@ AnnotationElementFactory.prototype =
       default:
         return new AnnotationElement(parameters);
     }
-  }
+  },
 };
 
 /**
@@ -242,7 +242,7 @@ var AnnotationElement = (function AnnotationElementClosure() {
         color: data.color,
         title: data.title,
         contents: data.contents,
-        hideWrapper: true
+        hideWrapper: true,
       });
       var popup = popupElement.render();
 
@@ -260,7 +260,7 @@ var AnnotationElement = (function AnnotationElementClosure() {
      */
     render: function AnnotationElement_render() {
       throw new Error('Abstract method AnnotationElement.render called');
-    }
+    },
   };
 
   return AnnotationElement;
@@ -340,7 +340,7 @@ var LinkAnnotationElement = (function LinkAnnotationElementClosure() {
         return false;
       };
       link.className = 'internalLink';
-    }
+    },
   });
 
   return LinkAnnotationElement;
@@ -375,7 +375,7 @@ var TextAnnotationElement = (function TextAnnotationElementClosure() {
         this.data.name.toLowerCase() + '.svg';
       image.alt = '[{{type}} Annotation]';
       image.dataset.l10nId = 'text_annotation_type';
-      image.dataset.l10nArgs = JSON.stringify({type: this.data.name});
+      image.dataset.l10nArgs = JSON.stringify({ type: this.data.name, });
 
       if (!this.data.hasPopup) {
         this._createPopup(this.container, image, this.data);
@@ -383,7 +383,7 @@ var TextAnnotationElement = (function TextAnnotationElementClosure() {
 
       this.container.appendChild(image);
       return this.container;
-    }
+    },
   });
 
   return TextAnnotationElement;
@@ -409,7 +409,7 @@ var WidgetAnnotationElement = (function WidgetAnnotationElementClosure() {
     render: function WidgetAnnotationElement_render() {
       // Show only the container for unsupported field types.
       return this.container;
-    }
+    },
   });
 
   return WidgetAnnotationElement;
@@ -516,7 +516,7 @@ var TextWidgetAnnotationElement = (
       var fontFamily = font.loadedName ? '"' + font.loadedName + '", ' : '';
       var fallbackName = font.fallbackName || 'Helvetica, sans-serif';
       style.fontFamily = fontFamily + fallbackName;
-    }
+    },
   });
 
   return TextWidgetAnnotationElement;
@@ -554,7 +554,7 @@ var CheckboxWidgetAnnotationElement =
 
       this.container.appendChild(element);
       return this.container;
-    }
+    },
   });
 
   return CheckboxWidgetAnnotationElement;
@@ -593,7 +593,7 @@ var RadioButtonWidgetAnnotationElement =
 
       this.container.appendChild(element);
       return this.container;
-    }
+    },
   });
 
   return RadioButtonWidgetAnnotationElement;
@@ -651,7 +651,7 @@ var ChoiceWidgetAnnotationElement = (
 
       this.container.appendChild(selectElement);
       return this.container;
-    }
+    },
   });
 
   return ChoiceWidgetAnnotationElement;
@@ -697,7 +697,7 @@ var PopupAnnotationElement = (function PopupAnnotationElementClosure() {
         trigger: parentElement,
         color: this.data.color,
         title: this.data.title,
-        contents: this.data.contents
+        contents: this.data.contents,
       });
 
       // Position the popup next to the parent annotation's container.
@@ -711,7 +711,7 @@ var PopupAnnotationElement = (function PopupAnnotationElementClosure() {
 
       this.container.appendChild(popup.render());
       return this.container;
-    }
+    },
   });
 
   return PopupAnnotationElement;
@@ -849,7 +849,7 @@ var PopupElement = (function PopupElementClosure() {
         this.hideElement.setAttribute('hidden', true);
         this.container.style.zIndex -= 1;
       }
-    }
+    },
   };
 
   return PopupElement;
@@ -912,7 +912,7 @@ var LineAnnotationElement = (function LineAnnotationElementClosure() {
       this._createPopup(this.container, line, this.data);
 
       return this.container;
-    }
+    },
   });
 
   return LineAnnotationElement;
@@ -946,7 +946,7 @@ var HighlightAnnotationElement = (
         this._createPopup(this.container, null, this.data);
       }
       return this.container;
-    }
+    },
   });
 
   return HighlightAnnotationElement;
@@ -980,7 +980,7 @@ var UnderlineAnnotationElement = (
         this._createPopup(this.container, null, this.data);
       }
       return this.container;
-    }
+    },
   });
 
   return UnderlineAnnotationElement;
@@ -1013,7 +1013,7 @@ var SquigglyAnnotationElement = (function SquigglyAnnotationElementClosure() {
         this._createPopup(this.container, null, this.data);
       }
       return this.container;
-    }
+    },
   });
 
   return SquigglyAnnotationElement;
@@ -1047,7 +1047,7 @@ var StrikeOutAnnotationElement = (
         this._createPopup(this.container, null, this.data);
       }
       return this.container;
-    }
+    },
   });
 
   return StrikeOutAnnotationElement;
@@ -1110,7 +1110,7 @@ var FileAttachmentAnnotationElement = (
         return;
       }
       this.downloadManager.downloadData(this.content, this.filename, '');
-    }
+    },
   });
 
   return FileAttachmentAnnotationElement;
@@ -1183,7 +1183,7 @@ var AnnotationLayer = (function AnnotationLayerClosure() {
         }
       }
       parameters.div.removeAttribute('hidden');
-    }
+    },
   };
 })();
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -191,11 +191,11 @@ function getDocument(src, pdfDataRangeTransport,
 
   var source;
   if (typeof src === 'string') {
-    source = { url: src };
+    source = { url: src, };
   } else if (isArrayBuffer(src)) {
-    source = { data: src };
+    source = { data: src, };
   } else if (src instanceof PDFDataRangeTransport) {
-    source = { range: src };
+    source = { range: src, };
   } else {
     if (typeof src !== 'object') {
       error('Invalid parameter in getDocument, need either Uint8Array, ' +
@@ -415,7 +415,7 @@ var PDFDocumentLoadingTask = (function PDFDocumentLoadingTaskClosure() {
      */
     then: function PDFDocumentLoadingTask_then(onFulfilled, onRejected) {
       return this.promise.then.apply(this.promise, arguments);
-    }
+    },
   };
 
   return PDFDocumentLoadingTask;
@@ -491,7 +491,7 @@ var PDFDataRangeTransport = (function pdfDataRangeTransportClosure() {
     },
 
     abort: function PDFDataRangeTransport_abort() {
-    }
+    },
   };
   return PDFDataRangeTransport;
 })();
@@ -639,7 +639,7 @@ var PDFDocumentProxy = (function PDFDocumentProxyClosure() {
      */
     destroy: function PDFDocumentProxy_destroy() {
       return this.loadingTask.destroy();
-    }
+    },
   };
   return PDFDocumentProxy;
 })();
@@ -843,7 +843,7 @@ var PDFPageProxy = (function PDFPageProxyClosure() {
         intentState.operatorList = {
           fnArray: [],
           argsArray: [],
-          lastChunk: false
+          lastChunk: false,
         };
 
         this.stats.time('Page Request');
@@ -939,7 +939,7 @@ var PDFPageProxy = (function PDFPageProxyClosure() {
         intentState.operatorList = {
           fnArray: [],
           argsArray: [],
-          lastChunk: false
+          lastChunk: false,
         };
 
         this.transport.messageHandler.send('RenderPageRequest', {
@@ -1066,7 +1066,7 @@ var PDFPageProxy = (function PDFPageProxyClosure() {
         intentState.receivingOperatorList = false;
         this._tryCleanup();
       }
-    }
+    },
   };
   return PDFPageProxy;
 })();
@@ -1125,13 +1125,13 @@ class LoopbackPort {
 
     if (!this._defer) {
       this._listeners.forEach(function (listener) {
-        listener.call(this, {data: obj});
+        listener.call(this, { data: obj, });
       }, this);
       return;
     }
 
     var cloned = new WeakMap();
-    var e = {data: cloneValue(obj)};
+    var e = { data: cloneValue(obj), };
     this._deferred.then(() => {
       this._listeners.forEach(function (listener) {
         listener.call(this, e);
@@ -1332,7 +1332,7 @@ var PDFWorker = (function PDFWorkerClosure() {
               this._readyCapability.resolve();
               // Send global setting, e.g. verbosity level.
               messageHandler.send('configure', {
-                verbosity: getVerbosityLevel()
+                verbosity: getVerbosityLevel(),
               });
             } else {
               this._setupFakeWorker();
@@ -1441,7 +1441,7 @@ var PDFWorker = (function PDFWorkerClosure() {
         this._messageHandler.destroy();
         this._messageHandler = null;
       }
-    }
+    },
   };
 
   return PDFWorker;
@@ -1658,7 +1658,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
               fontRegistry = {
                 registerFont(font, url) {
                   globalScope['FontInspector'].fontAdded(font, url);
-                }
+                },
               };
             }
             var font = new FontFaceObject(exportedData, {
@@ -1724,7 +1724,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
         if (loadingTask.onProgress) {
           loadingTask.onProgress({
             loaded: data.loaded,
-            total: data.total
+            total: data.total,
           });
         }
       }, this);
@@ -1902,7 +1902,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
         then(function transportMetadata(results) {
         return {
           info: results[0],
-          metadata: (results[1] ? new Metadata(results[1]) : null)
+          metadata: (results[1] ? new Metadata(results[1]) : null),
         };
       });
     },
@@ -1922,7 +1922,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
         this.commonObjs.clear();
         this.fontLoader.clear();
       });
-    }
+    },
   };
   return WorkerTransport;
 
@@ -1953,7 +1953,7 @@ var PDFObjects = (function PDFObjectsClosure() {
       var obj = {
         capability: createPromiseCapability(),
         data: null,
-        resolved: false
+        resolved: false,
       };
       this.objs[objId] = obj;
 
@@ -2027,7 +2027,7 @@ var PDFObjects = (function PDFObjectsClosure() {
 
     clear: function PDFObjects_clear() {
       this.objs = Object.create(null);
-    }
+    },
   };
   return PDFObjects;
 })();
@@ -2078,7 +2078,7 @@ var RenderTask = (function RenderTaskClosure() {
      */
     then: function RenderTask_then(onFulfilled, onRejected) {
       return this.promise.then.apply(this.promise, arguments);
-    }
+    },
   };
 
   return RenderTask;
@@ -2212,7 +2212,7 @@ var InternalRenderTask = (function InternalRenderTaskClosure() {
           this.callback();
         }
       }
-    }
+    },
 
   };
 
@@ -2235,7 +2235,7 @@ var _UnsupportedManager = (function UnsupportedManagerClosure() {
       for (var i = 0, ii = listeners.length; i < ii; i++) {
         listeners[i](featureId);
       }
-    }
+    },
   };
 })();
 

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -40,7 +40,7 @@ var FULL_CHUNK_HEIGHT = 16;
 var IsLittleEndianCached = {
   get value() {
     return shadow(IsLittleEndianCached, 'value', isLittleEndian());
-  }
+  },
 };
 
 function addContextCurrentTransform(ctx) {
@@ -60,7 +60,7 @@ function addContextCurrentTransform(ctx) {
     Object.defineProperty(ctx, 'mozCurrentTransform', {
       get: function getCurrentTransform() {
         return this._transformMatrix;
-      }
+      },
     });
 
     Object.defineProperty(ctx, 'mozCurrentTransformInverse', {
@@ -83,7 +83,7 @@ function addContextCurrentTransform(ctx) {
           (d * e - c * f) / bc_ad,
           (b * e - a * f) / ad_bc
         ];
-      }
+      },
     });
 
     ctx.save = function ctxSave() {
@@ -188,7 +188,7 @@ var CachedCanvases = (function CachedCanvasesClosure() {
         this.canvasFactory.destroy(canvasEntry);
         delete this.cache[id];
       }
-    }
+    },
   };
   return CachedCanvases;
 })();
@@ -394,7 +394,7 @@ var CanvasExtraState = (function CanvasExtraStateClosure() {
     setCurrentPoint: function CanvasExtraState_setCurrentPoint(x, y) {
       this.x = x;
       this.y = y;
-    }
+    },
   };
   return CanvasExtraState;
 })();
@@ -1649,7 +1649,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
           createCanvasGraphics: (ctx) => {
             return new CanvasGraphics(ctx, this.commonObjs, this.objs,
                                       this.canvasFactory);
-          }
+          },
         };
         pattern = new TilingPattern(IR, color, this.ctx, canvasGraphicsFactory,
                                     baseTransform);
@@ -1933,7 +1933,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
           left: position[0],
           top: position[1],
           width: w / currentTransform[0],
-          height: h / currentTransform[3]
+          height: h / currentTransform[3],
         });
       }
       this.restore();
@@ -2070,8 +2070,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       var height = imgData.height;
       var map = [];
       for (var i = 0, ii = positions.length; i < ii; i += 2) {
-        map.push({transform: [scaleX, 0, 0, scaleY, positions[i],
-                 positions[i + 1]], x: 0, y: 0, w: width, h: height});
+        map.push({ transform: [scaleX, 0, 0, scaleY, positions[i],
+                   positions[i + 1]], x: 0, y: 0, w: width, h: height, });
       }
       this.paintInlineImageXObjectGroup(imgData, map);
     },
@@ -2141,7 +2141,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
           left: position[0],
           top: position[1],
           width: width / currentTransform[0],
-          height: height / currentTransform[3]
+          height: height / currentTransform[3],
         });
       }
       this.restore();
@@ -2171,7 +2171,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
             left: position[0],
             top: position[1],
             width: w,
-            height: h
+            height: h,
           });
         }
         ctx.restore();
@@ -2251,7 +2251,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         transform[0] * x + transform[2] * y + transform[4],
         transform[1] * x + transform[3] * y + transform[5]
       ];
-    }
+    },
   };
 
   for (var op in OPS) {

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -25,7 +25,7 @@ function FontLoader(docId) {
     this.loadTestFontId = 0;
     this.loadingContext = {
       requests: [],
-      nextRequestId: 0
+      nextRequestId: 0,
     };
   }
 }
@@ -55,7 +55,7 @@ FontLoader.prototype = {
       });
       this.nativeFontFaces.length = 0;
     }
-  }
+  },
 };
 
 if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL')) {
@@ -90,7 +90,7 @@ if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL')) {
     get() {
       return shadow(this, 'loadTestFont', getLoadTestFont());
     },
-    configurable: true
+    configurable: true,
   });
 
   FontLoader.prototype.addNativeFontFace =
@@ -171,7 +171,7 @@ if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL')) {
       id: requestId,
       complete: LoadLoader_completeRequest,
       callback,
-      started: Date.now()
+      started: Date.now(),
     };
     context.requests.push(request);
     return request;
@@ -325,14 +325,14 @@ if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL || CHROME')) {
                     isSyncFontLoadingSupported());
     },
     enumerable: true,
-    configurable: true
+    configurable: true,
   });
 }
 
 var IsEvalSupportedCached = {
   get value() {
     return shadow(this, 'value', isEvalSupported());
-  }
+  },
 };
 
 var FontFaceObject = (function FontFaceObjectClosure() {
@@ -430,7 +430,7 @@ var FontFaceObject = (function FontFaceObjectClosure() {
         }
       }
       return this.compiledGlyphs[character];
-    }
+    },
   };
 
   return FontFaceObject;

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -63,7 +63,7 @@ Object.defineProperty(PDFJS, 'verbosity', {
     setVerbosityLevel(level);
   },
   enumerable: true,
-  configurable: true
+  configurable: true,
 });
 
 PDFJS.VERBOSITY_LEVELS = VERBOSITY_LEVELS;
@@ -79,7 +79,7 @@ Object.defineProperty(PDFJS, 'isLittleEndian', {
   configurable: true,
   get: function PDFJS_isLittleEndian() {
     return shadow(PDFJS, 'isLittleEndian', isLittleEndian());
-  }
+  },
 });
 PDFJS.removeNullCharacters = removeNullCharacters;
 PDFJS.PasswordResponses = PasswordResponses;
@@ -266,7 +266,7 @@ if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL')) {
       PDFJS.externalLinkTarget = value ? LinkTarget.BLANK : LinkTarget.NONE;
     },
     enumerable: true,
-    configurable: true
+    configurable: true,
   });
   if (savedOpenExternalLinksInNewWindow) {
     /**

--- a/src/display/metadata.js
+++ b/src/display/metadata.js
@@ -88,7 +88,7 @@ Metadata.prototype = {
 
   has: function Metadata_has(name) {
     return typeof this.metadata[name] !== 'undefined';
-  }
+  },
 };
 
 export {

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -41,9 +41,9 @@ ShadingIRs.RadialAxial = {
           grad.addColorStop(c[0], c[1]);
         }
         return grad;
-      }
+      },
     };
-  }
+  },
 };
 
 var createMeshCanvas = (function createMeshCanvasClosure() {
@@ -174,7 +174,7 @@ var createMeshCanvas = (function createMeshCanvasClosure() {
       offsetX: -offsetX,
       offsetY: -offsetY,
       scaleX: 1 / scaleX,
-      scaleY: 1 / scaleY
+      scaleY: 1 / scaleY,
     };
 
     var paddedWidth = width + BORDER_SIZE * 2;
@@ -269,9 +269,9 @@ ShadingIRs.Mesh = {
                   temporaryPatternCanvas.scaleY);
 
         return ctx.createPattern(temporaryPatternCanvas.canvas, 'no-repeat');
-      }
+      },
     };
-  }
+  },
 };
 
 ShadingIRs.Dummy = {
@@ -280,9 +280,9 @@ ShadingIRs.Dummy = {
       type: 'Pattern',
       getPattern: function Dummy_fromIR_getPattern() {
         return 'hotpink';
-      }
+      },
     };
-  }
+  },
 };
 
 function getShadingPatternFromIR(raw) {
@@ -296,7 +296,7 @@ function getShadingPatternFromIR(raw) {
 var TilingPattern = (function TilingPatternClosure() {
   var PaintType = {
     COLORED: 1,
-    UNCOLORED: 2
+    UNCOLORED: 2,
   };
 
   var MAX_PATTERN_SIZE = 3000; // 10in @ 300dpi shall be enough
@@ -428,7 +428,7 @@ var TilingPattern = (function TilingPatternClosure() {
       this.scaleToContext();
 
       return ctx.createPattern(temporaryPatternCanvas, 'repeat');
-    }
+    },
   };
 
   return TilingPattern;

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -28,7 +28,7 @@ if (typeof PDFJSDev === 'undefined' ||
 var SVG_DEFAULTS = {
   fontStyle: 'normal',
   fontWeight: 'normal',
-  fillColor: '#000000'
+  fillColor: '#000000',
 };
 
 var convertImgDataToPng = (function convertImgDataToPngClosure() {
@@ -277,7 +277,7 @@ var SVGExtraState = (function SVGExtraStateClosure() {
     setCurrentPoint: function SVGExtraState_setCurrentPoint(x, y) {
       this.x = x;
       this.y = y;
-    }
+    },
   };
   return SVGExtraState;
 })();
@@ -290,7 +290,7 @@ SVGGraphics = (function SVGGraphicsClosure() {
 
     for (var x = 0; x < opListLen; x++) {
       if (opList[x].fn === 'save') {
-        opTree.push({'fnId': 92, 'fn': 'group', 'items': []});
+        opTree.push({ 'fnId': 92, 'fn': 'group', 'items': [], });
         tmp.push(opTree);
         opTree = opTree[opTree.length - 1].items;
         continue;
@@ -458,7 +458,11 @@ SVGGraphics = (function SVGGraphicsClosure() {
 
       for (var x = 0; x < fnArrayLen; x++) {
         var fnId = fnArray[x];
-        opList.push({'fnId': fnId, 'fn': REVOPS[fnId], 'args': argsArray[x]});
+        opList.push({
+          'fnId': fnId,
+          'fn': REVOPS[fnId],
+          'args': argsArray[x],
+        });
       }
       return opListToTree(opList);
     },
@@ -1187,7 +1191,7 @@ SVGGraphics = (function SVGGraphicsClosure() {
         }
       }
       return this.tgrp;
-    }
+    },
   };
   return SVGGraphics;
 })();

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -176,7 +176,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
         PDFJSDev.test('FIREFOX || MOZCENTRAL || GENERIC')) {
        canvas.mozOpaque = true;
     }
-    var ctx = canvas.getContext('2d', {alpha: false});
+    var ctx = canvas.getContext('2d', { alpha: false, });
 
     var lastFontSize;
     var lastFontFamily;
@@ -293,7 +293,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
         y2: box.bottom,
         index: i,
         x1New: undefined,
-        x2New: undefined
+        x2New: undefined,
       };
     });
     expandBoundsLTR(width, bounds);
@@ -304,7 +304,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
         left: b.x1New,
         top: 0,
         right: b.x2New,
-        bottom: 0
+        bottom: 0,
       };
     });
 
@@ -344,12 +344,12 @@ var renderTextLayer = (function renderTextLayerClosure() {
       y2: Infinity,
       index: -1,
       x1New: 0,
-      x2New: 0
+      x2New: 0,
     };
     var horizon = [{
       start: -Infinity,
       end: Infinity,
-      boundary: fakeBoundary
+      boundary: fakeBoundary,
     }];
 
     bounds.forEach(function (boundary) {
@@ -428,7 +428,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
           changedHorizon.push({
             start: horizonPart.start,
             end: horizonPart.end,
-            boundary: useBoundary
+            boundary: useBoundary,
           });
           lastBoundary = useBoundary;
         }
@@ -438,7 +438,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
         changedHorizon.unshift({
           start: horizon[i].start,
           end: boundary.y1,
-          boundary: horizon[i].boundary
+          boundary: horizon[i].boundary,
         });
       }
       if (boundary.y2 < horizon[j].end) {
@@ -446,7 +446,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
         changedHorizon.push({
           start: boundary.y2,
           end: horizon[j].end,
-          boundary: horizon[j].boundary
+          boundary: horizon[j].boundary,
         });
       }
 

--- a/src/display/webgl.js
+++ b/src/display/webgl.js
@@ -73,7 +73,7 @@ var WebGLUtils = (function WebGLUtilsClosure() {
     // The temporary canvas is used in the WebGL context.
     currentCanvas = document.createElement('canvas');
     currentGL = currentCanvas.getContext('webgl',
-      { premultipliedalpha: false });
+      { premultipliedalpha: false, });
   }
 
   var smaskVertexShaderCode = '\
@@ -432,7 +432,7 @@ var WebGLUtils = (function WebGLUtilsClosure() {
     },
     composeSMask,
     drawFigures,
-    clear: cleanup
+    clear: cleanup,
   };
 })();
 

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -104,7 +104,7 @@ PDFJS.compatibilityChecked = true;
         buffer[offset + 1] = (value >> 8) & 255;
         buffer[offset + 2] = (value >> 16) & 255;
         buffer[offset + 3] = (value >>> 24) & 255;
-      }
+      },
     };
   }
 
@@ -182,14 +182,14 @@ PDFJS.compatibilityChecked = true;
       return this;
     },
     enumerable: false,
-    configurable: true
+    configurable: true,
   });
   Object.defineProperty(cpaProto, 'byteLength', {
     get() {
       return this.length;
     },
     enumerable: false,
-    configurable: true
+    configurable: true,
   });
 })();
 
@@ -210,13 +210,13 @@ PDFJS.compatibilityChecked = true;
       if (hasDOM) {
         // some browsers (e.g. safari) cannot use defineProperty() on DOM
         // objects and thus the native version is not sufficient
-        Object.defineProperty(new Image(), 'id', { value: 'test' });
+        Object.defineProperty(new Image(), 'id', { value: 'test', });
       }
       // ... another test for android gb browser for non-DOM objects
       var Test = function Test() {};
-      Test.prototype = { get id() { } };
+      Test.prototype = { get id() { }, };
       Object.defineProperty(new Test(), 'id',
-        { value: '', configurable: true, enumerable: true, writable: false });
+        { value: '', configurable: true, enumerable: true, writable: false, });
     } catch (e) {
       definePropertyPossible = false;
     }
@@ -258,7 +258,7 @@ PDFJS.compatibilityChecked = true;
     // IE10 might have response, but not overrideMimeType
     // Support: IE10
     Object.defineProperty(xhrPrototype, 'overrideMimeType', {
-      value: function xmlHttpRequestOverrideMimeType(mimeType) {}
+      value: function xmlHttpRequestOverrideMimeType(mimeType) {},
     });
   }
   if ('responseType' in xhr) {
@@ -277,7 +277,7 @@ PDFJS.compatibilityChecked = true;
           this.overrideMimeType('text/plain; charset=x-user-defined');
         }
       }
-    }
+    },
   });
 
   // Support: IE9
@@ -288,7 +288,7 @@ PDFJS.compatibilityChecked = true;
           return new Uint8Array(new VBArray(this.responseBody).toArray());
         }
         return this.responseText;
-      }
+      },
     });
     return;
   }
@@ -305,7 +305,7 @@ PDFJS.compatibilityChecked = true;
         result[i] = text.charCodeAt(i) & 0xFF;
       }
       return result.buffer;
-    }
+    },
   });
 })();
 
@@ -420,11 +420,11 @@ PDFJS.compatibilityChecked = true;
       Object.defineProperty(this, '_dataset', {
         value: dataset,
         writable: false,
-        enumerable: false
+        enumerable: false,
       });
       return dataset;
     },
-    enumerable: true
+    enumerable: true,
   });
 })();
 
@@ -469,7 +469,7 @@ PDFJS.compatibilityChecked = true;
     },
     toggle(name) {
       changeList(this.element, name, true, true);
-    }
+    },
   };
 
   Object.defineProperty(HTMLElement.prototype, 'classList', {
@@ -482,17 +482,17 @@ PDFJS.compatibilityChecked = true;
         element: {
           value: this,
           writable: false,
-          enumerable: true
-        }
+          enumerable: true,
+        },
       });
       Object.defineProperty(this, '_classList', {
         value: classList,
         writable: false,
-        enumerable: false
+        enumerable: false,
       });
       return classList;
     },
-    enumerable: true
+    enumerable: true,
   });
 })();
 
@@ -511,7 +511,7 @@ PDFJS.compatibilityChecked = true;
       globalScope.postMessage({
         targetName: 'main',
         action: 'console_log',
-        data: args
+        data: args,
       });
     },
 
@@ -520,7 +520,7 @@ PDFJS.compatibilityChecked = true;
       globalScope.postMessage({
         targetName: 'main',
         action: 'console_error',
-        data: args
+        data: args,
       });
     },
 
@@ -534,7 +534,7 @@ PDFJS.compatibilityChecked = true;
         throw new Error('Unknown timer name ' + name);
       }
       this.log('Timer:', name, Date.now() - time);
-    }
+    },
   };
 
   globalScope.console = workerConsole;
@@ -552,7 +552,7 @@ PDFJS.compatibilityChecked = true;
     window.console = {
       log() {},
       error() {},
-      warn() {}
+      warn() {},
     };
     return;
   }
@@ -765,7 +765,7 @@ PDFJS.compatibilityChecked = true;
       return scripts[scripts.length - 1];
     },
     enumerable: true,
-    configurable: true
+    configurable: true,
   });
 })();
 
@@ -789,7 +789,7 @@ PDFJS.compatibilityChecked = true;
         typeProperty.set.call(this, value === 'number' ? 'text' : value);
       },
       enumerable: true,
-      configurable: true
+      configurable: true,
     });
   }
 })();
@@ -815,7 +815,7 @@ PDFJS.compatibilityChecked = true;
       readyStateProto.set.call(this, value);
     },
     enumerable: true,
-    configurable: true
+    configurable: true,
   });
 })();
 
@@ -968,7 +968,7 @@ PDFJS.compatibilityChecked = true;
     addUnhandledRejection: function addUnhandledRejection(promise) {
       this.unhandledRejections.push({
         promise,
-        time: Date.now()
+        time: Date.now(),
       });
       this.scheduleRejectionCheck();
     },
@@ -1012,7 +1012,7 @@ PDFJS.compatibilityChecked = true;
           this.scheduleRejectionCheck();
         }
       }, REJECTION_TIMEOUT);
-    }
+    },
   };
 
   var Promise = function Promise(resolver) {
@@ -1158,7 +1158,7 @@ PDFJS.compatibilityChecked = true;
 
     catch: function Promise_catch(onReject) {
       return this.then(undefined, onReject);
-    }
+    },
   };
 
   globalScope.Promise = Promise;
@@ -1184,12 +1184,12 @@ PDFJS.compatibilityChecked = true;
       Object.defineProperty(obj, this.id, {
         value,
         enumerable: false,
-        configurable: true
+        configurable: true,
       });
     },
     delete(obj) {
       delete obj[this.id];
-    }
+    },
   };
 
   globalScope.WeakMap = WeakMap;
@@ -1818,7 +1818,7 @@ PDFJS.compatibilityChecked = true;
         return '';
       }
       return this._scheme + '://' + host;
-    }
+    },
   };
 
   // Copy over the static methods

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -26,7 +26,7 @@ var FONT_IDENTITY_MATRIX = [0.001, 0, 0, 0.001, 0, 0];
 const NativeImageDecoding = {
   NONE: 'none',
   DECODE: 'decode',
-  DISPLAY: 'display'
+  DISPLAY: 'display',
 };
 
 var TextRenderingMode = {
@@ -39,13 +39,13 @@ var TextRenderingMode = {
   FILL_STROKE_ADD_TO_PATH: 6,
   ADD_TO_PATH: 7,
   FILL_STROKE_MASK: 3,
-  ADD_TO_PATH_FLAG: 4
+  ADD_TO_PATH_FLAG: 4,
 };
 
 var ImageKind = {
   GRAYSCALE_1BPP: 1,
   RGB_24BPP: 2,
-  RGBA_32BPP: 3
+  RGBA_32BPP: 3,
 };
 
 var AnnotationType = {
@@ -74,7 +74,7 @@ var AnnotationType = {
   TRAPNET: 23,
   WATERMARK: 24,
   THREED: 25,
-  REDACT: 26
+  REDACT: 26,
 };
 
 var AnnotationFlag = {
@@ -87,7 +87,7 @@ var AnnotationFlag = {
   READONLY: 0x40,
   LOCKED: 0x80,
   TOGGLENOVIEW: 0x100,
-  LOCKEDCONTENTS: 0x200
+  LOCKEDCONTENTS: 0x200,
 };
 
 var AnnotationFieldFlag = {
@@ -117,7 +117,7 @@ var AnnotationBorderStyleType = {
   DASHED: 2,
   BEVELED: 3,
   INSET: 4,
-  UNDERLINE: 5
+  UNDERLINE: 5,
 };
 
 var StreamType = {
@@ -130,7 +130,7 @@ var StreamType = {
   A85: 6,
   AHX: 7,
   CCF: 8,
-  RL: 9
+  RL: 9,
 };
 
 var FontType = {
@@ -144,13 +144,13 @@ var FontType = {
   TYPE3: 7,
   OPENTYPE: 8,
   TYPE0: 9,
-  MMTYPE1: 10
+  MMTYPE1: 10,
 };
 
 var VERBOSITY_LEVELS = {
   errors: 0,
   warnings: 1,
-  infos: 5
+  infos: 5,
 };
 
 var CMapCompressionType = {
@@ -253,7 +253,7 @@ var OPS = {
   paintImageXObjectRepeat: 88,
   paintImageMaskXObjectRepeat: 89,
   paintSolidColorImageMask: 90,
-  constructPath: 91
+  constructPath: 91,
 };
 
 var verbosity = VERBOSITY_LEVELS.warnings;
@@ -317,7 +317,7 @@ var UNSUPPORTED_FEATURES = {
   javaScript: 'javaScript',
   smask: 'smask',
   shadingPattern: 'shadingPattern',
-  font: 'font'
+  font: 'font',
 };
 
 // Checks if URLs have the same origin. For non-HTTP based URLs, returns false.
@@ -375,7 +375,7 @@ function shadow(obj, prop, value) {
   Object.defineProperty(obj, prop, { value,
                                      enumerable: true,
                                      configurable: true,
-                                     writable: false });
+                                     writable: false, });
   return value;
 }
 
@@ -393,7 +393,7 @@ function getLookupTableFactory(initializer) {
 
 var PasswordResponses = {
   NEED_PASSWORD: 1,
-  INCORRECT_PASSWORD: 2
+  INCORRECT_PASSWORD: 2,
 };
 
 var PasswordException = (function PasswordExceptionClosure() {
@@ -1011,7 +1011,7 @@ var PageViewport = (function PageViewportClosure() {
      */
     convertToPdfPoint: function PageViewport_convertToPdfPoint(x, y) {
       return Util.applyInverseTransform([x, y], this.transform);
-    }
+    },
   };
   return PageViewport;
 })();
@@ -1154,7 +1154,7 @@ var StatTimer = (function StatTimerClosure() {
       this.times.push({
         'name': name,
         'start': this.started[name],
-        'end': Date.now()
+        'end': Date.now(),
       });
       // Remove timer from started so it can be called again.
       delete this.started[name];
@@ -1177,14 +1177,14 @@ var StatTimer = (function StatTimerClosure() {
         out += rpad(span['name'], ' ', longest) + ' ' + duration + 'ms\n';
       }
       return out;
-    }
+    },
   };
   return StatTimer;
 })();
 
 var createBlob = function createBlob(data, contentType) {
   if (typeof Blob !== 'undefined') {
-    return new Blob([data], { type: contentType });
+    return new Blob([data], { type: contentType, });
   }
   throw new Error('The "Blob" constructor is not supported.');
 };
@@ -1254,7 +1254,7 @@ function MessageHandler(sourceName, targetName, comObj) {
             targetName,
             isReply: true,
             callbackId: data.callbackId,
-            data: result
+            data: result,
           });
         }, function (reason) {
           if (reason instanceof Error) {
@@ -1266,7 +1266,7 @@ function MessageHandler(sourceName, targetName, comObj) {
             targetName,
             isReply: true,
             callbackId: data.callbackId,
-            error: reason
+            error: reason,
           });
         });
       } else {
@@ -1344,7 +1344,7 @@ MessageHandler.prototype = {
 
   destroy() {
     this.comObj.removeEventListener('message', this._onComObjOnMessage);
-  }
+  },
 };
 
 function loadJpegStream(id, imageUrl, objs) {


### PR DESCRIPTION
http://eslint.org/docs/rules/comma-dangle
http://eslint.org/docs/rules/object-curly-spacing

Given that we currently have quite inconsistent object formatting, fixing this in *one* big patch probably wouldn't be feasible (since I cannot imagine anyone wanting to review that); hence I've opted to try and do this piecewise instead.

Please note: This patch was created automatically, using the ESLint `--fix` command line option. In a couple of places this caused lines to become too long, and I've fixed those manually; please refer to the interdiff below for the only hand-edits in this patch.

```diff
diff --git a/src/display/canvas.js b/src/display/canvas.js
index 5739f6f2..4216b2d2 100644
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -2071,7 +2071,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       var map = [];
       for (var i = 0, ii = positions.length; i < ii; i += 2) {
         map.push({ transform: [scaleX, 0, 0, scaleY, positions[i],
-                 positions[i + 1]], x: 0, y: 0, w: width, h: height, });
+                   positions[i + 1]], x: 0, y: 0, w: width, h: height, });
       }
       this.paintInlineImageXObjectGroup(imgData, map);
     },
diff --git a/src/display/svg.js b/src/display/svg.js
index 9eb05dfa..2aa21482 100644
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -458,7 +458,11 @@ SVGGraphics = (function SVGGraphicsClosure() {

       for (var x = 0; x < fnArrayLen; x++) {
         var fnId = fnArray[x];
-        opList.push({ 'fnId': fnId, 'fn': REVOPS[fnId], 'args': argsArray[x], });
+        opList.push({
+          'fnId': fnId,
+          'fn': REVOPS[fnId],
+          'args': argsArray[x],
+        });
       }
       return opListToTree(opList);
     },
```