### PR TITLE
Fix inconsistent spacing and trailing commas in objects in `test/` files, so we can enable the `comma-dangle` and `object-curly-spacing` ESLint rules later on

### DIFF
--- a/test/chromium/test-telemetry.js
+++ b/test/chromium/test-telemetry.js
@@ -46,7 +46,7 @@ function createExtensionGlobal() {
   window.chrome.runtime = {};
   window.chrome.runtime.id = 'oemmndcbldboiebfnladdacbdfmadadm';
   window.chrome.runtime.getManifest = function() {
-    return {version: '1.0.0'};
+    return { version: '1.0.0', };
   };
 
   function createStorageAPI() {
@@ -324,7 +324,7 @@ var tests = [
     var window = createExtensionGlobal();
     telemetryScript.runInNewContext(window);
     window.chrome.runtime.getManifest = function() {
-     return {version: '1.0.1'};
+      return { version: '1.0.1', };
     };
     window.Date.test_now_value += 12 * 36E5;
     telemetryScript.runInNewContext(window);

--- a/test/downloadutils.js
+++ b/test/downloadutils.js
@@ -108,7 +108,7 @@ function downloadManifestFiles(manifest, callback) {
     var linkfile = file + '.link';
     var url = fs.readFileSync(linkfile).toString();
     url = url.replace(/\s+$/, '');
-    return {file: file, url: url};
+    return { file: file, url: url, };
   });
 
   var i = 0;

--- a/test/driver.js
+++ b/test/driver.js
@@ -199,7 +199,7 @@ var rasterizeAnnotationLayer = (function rasterizeAnnotationLayerClosure() {
       stylePromise.then(function (styles) {
         style.textContent = styles;
 
-        var annotation_viewport = viewport.clone({ dontFlip: true });
+        var annotation_viewport = viewport.clone({ dontFlip: true, });
         var parameters = {
           viewport: annotation_viewport,
           div,
@@ -347,7 +347,7 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
         let task = this.manifest[this.currentTask];
         task.round = 0;
         task.pageNum = task.firstPage || 1;
-        task.stats = { times: [] };
+        task.stats = { times: [], };
 
         this._log('Loading file "' + task.file + '"\n');
 
@@ -460,7 +460,7 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
           this._log(' Loading page ' + task.pageNum + '/' +
             task.pdfDoc.numPages + '... ');
           this.canvas.mozOpaque = true;
-          ctx = this.canvas.getContext('2d', {alpha: false});
+          ctx = this.canvas.getContext('2d', { alpha: false, });
           task.pdfDoc.getPage(task.pageNum).then(function(page) {
             var viewport = page.getViewport(PDF_TO_CSS_UNITS);
             self.canvas.width = viewport.width;
@@ -516,7 +516,7 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
 
                 // The annotation builder will draw its content on the canvas.
                 initPromise =
-                  page.getAnnotations({ intent: 'display' }).then(
+                  page.getAnnotations({ intent: 'display', }).then(
                     function(annotations) {
                       return rasterizeAnnotationLayer(annotationLayerContext,
                                                       viewport, annotations,
@@ -572,7 +572,7 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
     },
 
     _clearCanvas: function Driver_clearCanvas() {
-      var ctx = this.canvas.getContext('2d', {alpha: false});
+      var ctx = this.canvas.getContext('2d', { alpha: false, });
       ctx.beginPath();
       ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
     },
@@ -649,7 +649,7 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
         round: task.round,
         page: task.pageNum,
         snapshot,
-        stats: task.stats.times
+        stats: task.stats.times,
       });
       this._send('/submit_task_results', result, callback);
     },
@@ -676,7 +676,7 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
       };
       this.inflight.textContent = this.inFlightRequests++;
       r.send(message);
-    }
+    },
   };
 
   return Driver;

--- a/test/font/jasmine-boot.js
+++ b/test/font/jasmine-boot.js
@@ -73,7 +73,7 @@ function initializePDFJS(callback) {
   var queryString = new jasmine.QueryString({
     getWindowLocation() {
       return window.location;
-    }
+    },
   });
 
   var catchingExceptions = queryString.getParam('catch');
@@ -116,7 +116,7 @@ function initializePDFJS(callback) {
     createTextNode() {
       return document.createTextNode.apply(document, arguments);
     },
-    timer: new jasmine.Timer()
+    timer: new jasmine.Timer(),
   });
 
   env.addReporter(htmlReporter);
@@ -132,7 +132,7 @@ function initializePDFJS(callback) {
   var specFilter = new jasmine.HtmlSpecFilter({
     filterString() {
       return queryString.getParam('spec');
-    }
+    },
   });
 
   env.specFilter = function(spec) {

--- a/test/font/ttxdriver.js
+++ b/test/font/ttxdriver.js
@@ -35,11 +35,11 @@ function runTtx(ttxResourcesHome, fontPath, registerOnCancel, callback) {
       }
       var ttxEnv = {
         'PYTHONPATH': path.join(fontToolsHome, 'Lib'),
-        'PYTHONDONTWRITEBYTECODE': true
+        'PYTHONDONTWRITEBYTECODE': true,
       };
       var ttxStdioMode = 'ignore';
       var ttx = spawn('python', [ttxPath, fontPath],
-        {cwd: fontToolsHome, stdio: ttxStdioMode, env: ttxEnv});
+        { cwd: fontToolsHome, stdio: ttxStdioMode, env: ttxEnv, });
       var ttxRunError;
       registerOnCancel(function (reason) {
         ttxRunError = reason;

--- a/test/stats/statcmp.js
+++ b/test/stats/statcmp.js
@@ -60,7 +60,7 @@ function flatten(stats) {
         pdf: stat['pdf'],
         round: stat['round'],
         stat: s['name'],
-        time: s['end'] - s['start']
+        time: s['end'] - s['start'],
       });
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -472,7 +472,7 @@ function refTestPostHandler(req, res) {
     body += data;
   });
   req.on('end', function () {
-    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.writeHead(200, { 'Content-Type': 'text/plain', });
     res.end();
 
     var session;
@@ -517,7 +517,7 @@ function refTestPostHandler(req, res) {
 
     taskResults[round][page] = {
       failure: failure,
-      snapshot: snapshot
+      snapshot: snapshot,
     };
     if (stats) {
       stats.push({
@@ -525,7 +525,7 @@ function refTestPostHandler(req, res) {
         'pdf': id,
         'page': page,
         'round': round,
-        'stats': data.stats
+        'stats': data.stats,
       });
     }
 
@@ -594,13 +594,13 @@ function unitTestPostHandler(req, res) {
           onCancel = fn;
         }, function (err, xml) {
           clearTimeout(timeoutId);
-          res.writeHead(200, {'Content-Type': 'text/xml'});
+          res.writeHead(200, { 'Content-Type': 'text/xml', });
           res.end(err ? '<error>' + err + '</error>' : xml);
         });
       return;
     }
 
-    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.writeHead(200, { 'Content-Type': 'text/plain', });
     res.end();
 
     var data = JSON.parse(body);
@@ -633,7 +633,7 @@ function startBrowsers(url, initSessionCallback) {
   } else if (options.browser) {
     var browserPath = options.browser;
     var name = path.basename(browserPath, path.extname(browserPath));
-    browsers = [{name: name, path: browserPath}];
+    browsers = [{ name: name, path: browserPath, }];
   } else {
     console.error('Specify either browser or browserManifestFile.');
     process.exit(1);
@@ -653,7 +653,7 @@ function startBrowsers(url, initSessionCallback) {
       name: b.name,
       config: b,
       browser: browser,
-      closed: false
+      closed: false,
     };
     if (initSessionCallback) {
       initSessionCallback(session);

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -705,7 +705,7 @@ describe('annotation', function() {
 
       expect(data.url).toBeUndefined();
       expect(data.unsafeUrl).toBeUndefined();
-      expect(data.dest).toEqual([{ num: 17, gen: 0, }, { name: 'XYZ' },
+      expect(data.dest).toEqual([{ num: 17, gen: 0, }, { name: 'XYZ', },
                                  0, 841.89, null]);
     });
   });
@@ -1085,11 +1085,11 @@ describe('annotation', function() {
       var expected = [
         {
           exportValue: 'foo_export',
-          displayValue: 'Foo'
+          displayValue: 'Foo',
         },
         {
           exportValue: 'bar_export',
-          displayValue: 'Bar'
+          displayValue: 'Bar',
         }
       ];
 
@@ -1118,11 +1118,11 @@ describe('annotation', function() {
       var expected = [
         {
           exportValue: 'Foo',
-          displayValue: 'Foo'
+          displayValue: 'Foo',
         },
         {
           exportValue: 'Bar',
-          displayValue: 'Bar'
+          displayValue: 'Bar',
         }
       ];
 
@@ -1148,8 +1148,8 @@ describe('annotation', function() {
         ['Value2', 'Description2'],
       ];
       var expected = [
-        { exportValue: 'Value1', displayValue: 'Description1' },
-        { exportValue: 'Value2', displayValue: 'Description2' },
+        { exportValue: 'Value1', displayValue: 'Description1', },
+        { exportValue: 'Value2', displayValue: 'Description2', },
       ];
 
       var parentDict = new Dict();

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -480,7 +480,7 @@ describe('api', function() {
     });
     it('gets page index', function(done) {
       // reference to second page
-      var ref = {num: 17, gen: 0};
+      var ref = { num: 17, gen: 0, };
       var promise = doc.getPageIndex(ref);
       promise.then(function(pageIndex) {
         expect(pageIndex).toEqual(1);
@@ -490,7 +490,7 @@ describe('api', function() {
       });
     });
     it('gets invalid page index', function (done) {
-      var ref = { num: 3, gen: 0 }; // Reference to a font dictionary.
+      var ref = { num: 3, gen: 0, }; // Reference to a font dictionary.
       var promise = doc.getPageIndex(ref);
       promise.then(function () {
         done.fail('shall fail for invalid page reference.');
@@ -503,8 +503,9 @@ describe('api', function() {
     it('gets destinations, from /Dests dictionary', function(done) {
       var promise = doc.getDestinations();
       promise.then(function(data) {
-        expect(data).toEqual({ chapter1: [{ gen: 0, num: 17 }, { name: 'XYZ' },
-                                          0, 841.89, null] });
+        expect(data).toEqual({
+          chapter1: [{ gen: 0, num: 17, }, { name: 'XYZ', }, 0, 841.89, null],
+        });
         done();
       }).catch(function (reason) {
         done.fail(reason);
@@ -513,7 +514,7 @@ describe('api', function() {
     it('gets a destination, from /Dests dictionary', function(done) {
       var promise = doc.getDestination('chapter1');
       promise.then(function(data) {
-        expect(data).toEqual([{ gen: 0, num: 17 }, { name: 'XYZ' },
+        expect(data).toEqual([{ gen: 0, num: 17, }, { name: 'XYZ', },
                               0, 841.89, null]);
         done();
       }).catch(function (reason) {
@@ -538,8 +539,8 @@ describe('api', function() {
       });
       promise.then(function (destinations) {
         expect(destinations).toEqual({
-          'Page.1': [{ num: 1, gen: 0}, { name: 'XYZ' }, 0, 375, null],
-          'Page.2': [{ num: 6, gen: 0}, { name: 'XYZ' }, 0, 375, null],
+          'Page.1': [{ num: 1, gen: 0, }, { name: 'XYZ', }, 0, 375, null],
+          'Page.2': [{ num: 6, gen: 0, }, { name: 'XYZ', }, 0, 375, null],
         });
 
         loadingTask.destroy().then(done);
@@ -553,7 +554,7 @@ describe('api', function() {
         return pdfDocument.getDestination('Page.1');
       });
       promise.then(function (destination) {
-        expect(destination).toEqual([{ num: 1, gen: 0}, { name: 'XYZ' },
+        expect(destination).toEqual([{ num: 1, gen: 0, }, { name: 'XYZ', },
                                      0, 375, null]);
 
         loadingTask.destroy().then(done);
@@ -793,7 +794,7 @@ describe('api', function() {
     it('gets download info', function(done) {
       var promise = doc.getDownloadInfo();
       promise.then(function (data) {
-        expect(data).toEqual({ length: basicApiFileLength });
+        expect(data).toEqual({ length: basicApiFileLength, });
         done();
       }).catch(function (reason) {
         done.fail(reason);
@@ -802,7 +803,7 @@ describe('api', function() {
     it('gets stats', function(done) {
       var promise = doc.getStats();
       promise.then(function (stats) {
-        expect(stats).toEqual({ streamTypes: [], fontTypes: [] });
+        expect(stats).toEqual({ streamTypes: [], fontTypes: [], });
         done();
       }).catch(function (reason) {
         done.fail(reason);
@@ -864,7 +865,7 @@ describe('api', function() {
       expect(page.rotate).toEqual(0);
     });
     it('gets ref', function () {
-      expect(page.ref).toEqual({ num: 15, gen: 0 });
+      expect(page.ref).toEqual({ num: 15, gen: 0, });
     });
     it('gets userUnit', function () {
       expect(page.userUnit).toEqual(1.0);
@@ -886,12 +887,12 @@ describe('api', function() {
         expect(data.length).toEqual(4);
       });
 
-      var displayPromise = page.getAnnotations({ intent: 'display' }).then(
+      var displayPromise = page.getAnnotations({ intent: 'display', }).then(
           function (data) {
         expect(data.length).toEqual(4);
       });
 
-      var printPromise = page.getAnnotations({ intent: 'print' }).then(
+      var printPromise = page.getAnnotations({ intent: 'print', }).then(
           function (data) {
         expect(data.length).toEqual(4);
       });
@@ -1011,7 +1012,7 @@ describe('api', function() {
 
       promise.then(function (stats) {
         expect(stats).toEqual({ streamTypes: expectedStreamTypes,
-                                fontTypes: expectedFontTypes });
+                                fontTypes: expectedFontTypes, });
         done();
       }).catch(function (reason) {
         done.fail(reason);

--- a/test/unit/cff_parser_spec.js
+++ b/test/unit/cff_parser_spec.js
@@ -283,7 +283,7 @@ describe('CFFParser', function() {
                               ]);
     parser.bytes = bytes;
     var encoding = parser.parseEncoding(2, {}, new CFFStrings(), null);
-    expect(encoding.encoding).toEqual(createWithNullProto({0x8: 1}));
+    expect(encoding.encoding).toEqual(createWithNullProto({ 0x8: 1, }));
   });
 
   it('parses encoding format 1', function() {
@@ -297,7 +297,7 @@ describe('CFFParser', function() {
     parser.bytes = bytes;
     var encoding = parser.parseEncoding(2, {}, new CFFStrings(), null);
     expect(encoding.encoding).toEqual(
-      createWithNullProto({0x7: 0x01, 0x08: 0x02}));
+      createWithNullProto({ 0x7: 0x01, 0x08: 0x02, }));
   });
 
   it('parses fdselect format 0', function() {

--- a/test/unit/custom_spec.js
+++ b/test/unit/custom_spec.js
@@ -72,7 +72,7 @@ describe('custom canvas rendering', function() {
       canvasContext: canvasAndCtx.context,
       viewport,
     }).then(function() {
-      var { r, g, b, a } = getTopLeftPixel(canvasAndCtx.context);
+      var { r, g, b, a, } = getTopLeftPixel(canvasAndCtx.context);
       CanvasFactory.destroy(canvasAndCtx);
       expect(r).toEqual(255);
       expect(g).toEqual(255);
@@ -94,9 +94,9 @@ describe('custom canvas rendering', function() {
     page.render({
       canvasContext: canvasAndCtx.context,
       viewport,
-      background: 'rgba(255,0,0,1.0)'
+      background: 'rgba(255,0,0,1.0)',
     }).then(function() {
-      var { r, g, b, a } = getTopLeftPixel(canvasAndCtx.context);
+      var { r, g, b, a, } = getTopLeftPixel(canvasAndCtx.context);
       CanvasFactory.destroy(canvasAndCtx);
       expect(r).toEqual(255);
       expect(g).toEqual(0);

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -26,7 +26,7 @@ describe('evaluator', function() {
   XrefMock.prototype = {
     fetchIfRef() {
       return this.queue.shift();
-    }
+    },
   };
   function HandlerMock() {
     this.inputs = [];
@@ -34,13 +34,13 @@ describe('evaluator', function() {
   HandlerMock.prototype = {
     send(name, data) {
       this.inputs.push({ name, data, });
-    }
+    },
   };
   function ResourcesMock() { }
   ResourcesMock.prototype = {
     get(name) {
       return this[name];
-    }
+    },
   };
 
   function PdfManagerMock() { }

--- a/test/unit/function_spec.js
+++ b/test/unit/function_spec.js
@@ -56,9 +56,9 @@ describe('function', function() {
               }
             }
             return result;
-          }
+          },
         };
-      }
+      },
     });
   });
 
@@ -463,78 +463,80 @@ describe('function', function() {
     }
 
     it('check compiled add', function() {
-      check([0.25, 0.5, 'add'], [], [0, 1], [{input: [], output: [0.75]}]);
-      check([0, 'add'], [0, 1], [0, 1], [{input: [0.25], output: [0.25]}]);
-      check([0.5, 'add'], [0, 1], [0, 1], [{input: [0.25], output: [0.75]}]);
+      check([0.25, 0.5, 'add'], [], [0, 1], [{ input: [], output: [0.75], }]);
+      check([0, 'add'], [0, 1], [0, 1], [{ input: [0.25], output: [0.25], }]);
+      check([0.5, 'add'], [0, 1], [0, 1], [{ input: [0.25], output: [0.75], }]);
       check([0, 'exch', 'add'], [0, 1], [0, 1],
-            [{input: [0.25], output: [0.25]}]);
+            [{ input: [0.25], output: [0.25], }]);
       check([0.5, 'exch', 'add'], [0, 1], [0, 1],
-            [{input: [0.25], output: [0.75]}]);
+            [{ input: [0.25], output: [0.75], }]);
       check(['add'], [0, 1, 0, 1], [0, 1],
-            [{input: [0.25, 0.5], output: [0.75]}]);
+            [{ input: [0.25, 0.5], output: [0.75], }]);
       check(['add'], [0, 1], [0, 1], null);
     });
     it('check compiled sub', function() {
-      check([0.5, 0.25, 'sub'], [], [0, 1], [{input: [], output: [0.25]}]);
-      check([0, 'sub'], [0, 1], [0, 1], [{input: [0.25], output: [0.25]}]);
-      check([0.5, 'sub'], [0, 1], [0, 1], [{input: [0.75], output: [0.25]}]);
+      check([0.5, 0.25, 'sub'], [], [0, 1], [{ input: [], output: [0.25], }]);
+      check([0, 'sub'], [0, 1], [0, 1], [{ input: [0.25], output: [0.25], }]);
+      check([0.5, 'sub'], [0, 1], [0, 1], [{ input: [0.75], output: [0.25], }]);
       check([0, 'exch', 'sub'], [0, 1], [-1, 1],
-            [{input: [0.25], output: [-0.25]}]);
+            [{ input: [0.25], output: [-0.25], }]);
       check([0.75, 'exch', 'sub'], [0, 1], [-1, 1],
-            [{input: [0.25], output: [0.5]}]);
+            [{ input: [0.25], output: [0.5], }]);
       check(['sub'], [0, 1, 0, 1], [-1, 1],
-            [{input: [0.25, 0.5], output: [-0.25]}]);
+            [{ input: [0.25, 0.5], output: [-0.25], }]);
       check(['sub'], [0, 1], [0, 1], null);
 
       check([1, 'dup', 3, 2, 'roll', 'sub', 'sub'], [0, 1], [0, 1],
-            [{input: [0.75], output: [0.75]}]);
+            [{ input: [0.75], output: [0.75], }]);
     });
     it('check compiled mul', function() {
-      check([0.25, 0.5, 'mul'], [], [0, 1], [{input: [], output: [0.125]}]);
-      check([0, 'mul'], [0, 1], [0, 1], [{input: [0.25], output: [0]}]);
-      check([0.5, 'mul'], [0, 1], [0, 1], [{input: [0.25], output: [0.125]}]);
-      check([1, 'mul'], [0, 1], [0, 1], [{input: [0.25], output: [0.25]}]);
-      check([0, 'exch', 'mul'], [0, 1], [0, 1], [{input: [0.25], output: [0]}]);
+      check([0.25, 0.5, 'mul'], [], [0, 1], [{ input: [], output: [0.125], }]);
+      check([0, 'mul'], [0, 1], [0, 1], [{ input: [0.25], output: [0], }]);
+      check([0.5, 'mul'], [0, 1], [0, 1],
+            [{ input: [0.25], output: [0.125], }]);
+      check([1, 'mul'], [0, 1], [0, 1], [{ input: [0.25], output: [0.25], }]);
+      check([0, 'exch', 'mul'], [0, 1], [0, 1],
+            [{ input: [0.25], output: [0], }]);
       check([0.5, 'exch', 'mul'], [0, 1], [0, 1],
-            [{input: [0.25], output: [0.125]}]);
+            [{ input: [0.25], output: [0.125], }]);
       check([1, 'exch', 'mul'], [0, 1], [0, 1],
-            [{input: [0.25], output: [0.25]}]);
+            [{ input: [0.25], output: [0.25], }]);
       check(['mul'], [0, 1, 0, 1], [0, 1],
-            [{input: [0.25, 0.5], output: [0.125]}]);
+            [{ input: [0.25, 0.5], output: [0.125], }]);
       check(['mul'], [0, 1], [0, 1], null);
     });
     it('check compiled max', function() {
       check(['dup', 0.75, 'gt', 7, 'jz', 'pop', 0.75], [0, 1], [0, 1],
-            [{input: [0.5], output: [0.5]}]);
+            [{ input: [0.5], output: [0.5], }]);
       check(['dup', 0.75, 'gt', 7, 'jz', 'pop', 0.75], [0, 1], [0, 1],
-            [{input: [1], output: [0.75]}]);
+            [{ input: [1], output: [0.75], }]);
       check(['dup', 0.75, 'gt', 5, 'jz', 'pop', 0.75], [0, 1], [0, 1], null);
     });
     it('check pop/roll/index', function() {
-      check([1, 'pop'], [0, 1], [0, 1], [{input: [0.5], output: [0.5]}]);
+      check([1, 'pop'], [0, 1], [0, 1], [{ input: [0.5], output: [0.5], }]);
       check([1, 3, -1, 'roll'], [0, 1, 0, 1], [0, 1, 0, 1, 0, 1],
-            [{input: [0.25, 0.5], output: [0.5, 1, 0.25]}]);
+            [{ input: [0.25, 0.5], output: [0.5, 1, 0.25], }]);
       check([1, 3, 1, 'roll'], [0, 1, 0, 1], [0, 1, 0, 1, 0, 1],
-            [{input: [0.25, 0.5], output: [1, 0.25, 0.5]}]);
+            [{ input: [0.25, 0.5], output: [1, 0.25, 0.5], }]);
       check([1, 3, 1.5, 'roll'], [0, 1, 0, 1], [0, 1, 0, 1, 0, 1], null);
       check([1, 1, 'index'], [0, 1], [0, 1, 0, 1, 0, 1],
-            [{input: [0.5], output: [0.5, 1, 0.5]}]);
+            [{ input: [0.5], output: [0.5, 1, 0.5], }]);
       check([1, 3, 'index', 'pop'], [0, 1], [0, 1], null);
       check([1, 0.5, 'index', 'pop'], [0, 1], [0, 1], null);
     });
     it('check input boundaries', function () {
-      check([], [0, 0.5], [0, 1], [{input: [1], output: [0.5]}]);
-      check([], [0.5, 1], [0, 1], [{input: [0], output: [0.5]}]);
+      check([], [0, 0.5], [0, 1], [{ input: [1], output: [0.5], }]);
+      check([], [0.5, 1], [0, 1], [{ input: [0], output: [0.5], }]);
       check(['dup'], [0.5, 0.75], [0, 1, 0, 1],
-            [{input: [0], output: [0.5, 0.5]}]);
-      check([], [100, 1001], [0, 10000], [{input: [1000], output: [1000]}]);
+            [{ input: [0], output: [0.5, 0.5], }]);
+      check([], [100, 1001], [0, 10000], [{ input: [1000], output: [1000], }]);
     });
     it('check output boundaries', function () {
-      check([], [0, 1], [0, 0.5], [{input: [1], output: [0.5]}]);
-      check([], [0, 1], [0.5, 1], [{input: [0], output: [0.5]}]);
+      check([], [0, 1], [0, 0.5], [{ input: [1], output: [0.5], }]);
+      check([], [0, 1], [0.5, 1], [{ input: [0], output: [0.5], }]);
       check(['dup'], [0, 1], [0.5, 1, 0.75, 1],
-            [{input: [0], output: [0.5, 0.75]}]);
-      check([], [0, 10000], [100, 1001], [{input: [1000], output: [1000]}]);
+            [{ input: [0], output: [0.5, 0.75], }]);
+      check([], [0, 10000], [100, 1001], [{ input: [1000], output: [1000], }]);
     });
     it('compile optimized', function () {
       var compiler = new PostScriptCompiler();

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -82,7 +82,7 @@ function initializePDFJS(callback) {
   var queryString = new jasmine.QueryString({
     getWindowLocation() {
       return window.location;
-    }
+    },
   });
 
   var catchingExceptions = queryString.getParam('catch');
@@ -125,7 +125,7 @@ function initializePDFJS(callback) {
     createTextNode() {
       return document.createTextNode.apply(document, arguments);
     },
-    timer: new jasmine.Timer()
+    timer: new jasmine.Timer(),
   });
 
   env.addReporter(htmlReporter);
@@ -141,7 +141,7 @@ function initializePDFJS(callback) {
   var specFilter = new jasmine.HtmlSpecFilter({
     filterString() {
       return queryString.getParam('spec');
-    }
+    },
   });
 
   env.specFilter = function(spec) {

--- a/test/unit/network_spec.js
+++ b/test/unit/network_spec.js
@@ -28,7 +28,7 @@ describe('network', function() {
         rangeChunkSize: 65536,
         disableStream: true,
       },
-      disableRange: true
+      disableRange: true,
     });
 
     var fullReader = stream.getFullReader();
@@ -82,7 +82,7 @@ describe('network', function() {
         rangeChunkSize: 65536,
         disableStream: false,
       },
-      disableRange: false
+      disableRange: false,
     });
 
     var fullReader = stream.getFullReader();
@@ -129,7 +129,7 @@ describe('network', function() {
         rangeChunkSize: rangeSize,
         disableStream: true,
       },
-      disableRange: false
+      disableRange: false,
     });
 
     var fullReader = stream.getFullReader();
@@ -150,7 +150,7 @@ describe('network', function() {
                                              pdf1Length - tailSize);
     var range2Reader = stream.getRangeReader(pdf1Length - tailSize, pdf1Length);
 
-    var result1 = {value: 0}, result2 = {value: 0};
+    var result1 = { value: 0, }, result2 = { value: 0, };
     var read = function (reader, lenResult) {
       return reader.read().then(function (result) {
         if (result.done) {

--- a/test/unit/stream_spec.js
+++ b/test/unit/stream_spec.js
@@ -38,9 +38,9 @@ describe('stream', function() {
               }
             }
             return result;
-          }
+          },
         };
-      }
+      },
     });
   });
   describe('PredictorStream', function() {

--- a/test/unit/type1_parser_spec.js
+++ b/test/unit/type1_parser_spec.js
@@ -111,7 +111,7 @@ describe('Type1Parser', function() {
       'dup 33 /arrowright put\n' +
       'readonly def\n');
     var parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
-    var props = { overridableEncoding: true };
+    var props = { overridableEncoding: true, };
     parser.extractFontHeader(props);
     expect(props.builtInEncoding[33]).toEqual('arrowright');
   });

--- a/test/webbrowser.js
+++ b/test/webbrowser.js
@@ -145,18 +145,18 @@ WebBrowser.prototype = {
         'and CommandLine like \'%' + this.uniqStringId + '%\'"'];
       cmdKillAll = {
         file: 'wmic',
-        args: wmicPrefix.concat(['call', 'terminate'])
+        args: wmicPrefix.concat(['call', 'terminate']),
       };
       cmdCheckAllKilled = {
         file: 'wmic',
-        args: wmicPrefix.concat(['get', 'CommandLine'])
+        args: wmicPrefix.concat(['get', 'CommandLine']),
       };
       isAllKilled = function(exitCode, stdout) {
         return stdout.indexOf(this.uniqStringId) === -1;
       }.bind(this);
     } else {
-      cmdKillAll = {file: 'pkill', args: ['-f', this.uniqStringId]};
-      cmdCheckAllKilled = {file: 'pgrep', args: ['-f', this.uniqStringId]};
+      cmdKillAll = { file: 'pkill', args: ['-f', this.uniqStringId], };
+      cmdCheckAllKilled = { file: 'pgrep', args: ['-f', this.uniqStringId], };
       isAllKilled = function(pgrepStatus) {
         return pgrepStatus === 1; // "No process matched.", per man pgrep.
       };

--- a/test/webserver.js
+++ b/test/webserver.js
@@ -34,7 +34,7 @@ var mimeTypes = {
   '.png': 'image/png',
   '.log': 'text/plain',
   '.bcmap': 'application/octet-stream',
-  '.properties': 'text/plain'
+  '.properties': 'text/plain',
 };
 
 var defaultMimeType = 'application/octet-stream';
@@ -49,7 +49,7 @@ function WebServer() {
   this.disableRangeRequests = false;
   this.hooks = {
     'GET': [],
-    'POST': []
+    'POST': [],
   };
 }
 WebServer.prototype = {
@@ -245,7 +245,7 @@ WebServer.prototype = {
     }
 
     function serveRequestedFile(filePath) {
-      var stream = fs.createReadStream(filePath, {flags: 'rs'});
+      var stream = fs.createReadStream(filePath, { flags: 'rs', });
 
       stream.on('error', function (error) {
         res.writeHead(500);
@@ -272,7 +272,7 @@ WebServer.prototype = {
 
     function serveRequestedFileRange(filePath, start, end) {
       var stream = fs.createReadStream(filePath, {
-        flags: 'rs', start: start, end: end - 1});
+        flags: 'rs', start: start, end: end - 1, });
 
       stream.on('error', function (error) {
         res.writeHead(500);
@@ -292,7 +292,7 @@ WebServer.prototype = {
       stream.pipe(res);
     }
 
-  }
+  },
 };
 
 exports.WebServer = WebServer;


### PR DESCRIPTION
http://eslint.org/docs/rules/comma-dangle
http://eslint.org/docs/rules/object-curly-spacing

Given that we currently have quite inconsistent object formatting, fixing this in *one* big patch probably wouldn't be feasible (since I cannot imagine anyone wanting to review that); hence I've opted to try and do this piecewise instead.

Please note: This patch was created automatically, using the ESLint `--fix` command line option. In a couple of places this caused lines to become too long, and I've fixed those manually; please refer to the interdiff below for the only hand-edits in this patch.

```diff
diff --git a/test/chromium/test-telemetry.js b/test/chromium/test-telemetry.js
index cc412a31..2e5bdfa1 100755
--- a/test/chromium/test-telemetry.js
+++ b/test/chromium/test-telemetry.js
@@ -324,7 +324,7 @@ var tests = [
     var window = createExtensionGlobal();
     telemetryScript.runInNewContext(window);
     window.chrome.runtime.getManifest = function() {
-     return { version: '1.0.1', };
+      return { version: '1.0.1', };
     };
     window.Date.test_now_value += 12 * 36E5;
     telemetryScript.runInNewContext(window);
diff --git a/test/unit/api_spec.js b/test/unit/api_spec.js
index 1f00747a..f22988e7 100644
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -503,8 +503,9 @@ describe('api', function() {
     it('gets destinations, from /Dests dictionary', function(done) {
       var promise = doc.getDestinations();
       promise.then(function(data) {
-        expect(data).toEqual({ chapter1: [{ gen: 0, num: 17, }, { name: 'XYZ', },
-                                          0, 841.89, null], });
+        expect(data).toEqual({
+          chapter1: [{ gen: 0, num: 17, }, { name: 'XYZ', }, 0, 841.89, null],
+        });
         done();
       }).catch(function (reason) {
         done.fail(reason);
diff --git a/test/unit/function_spec.js b/test/unit/function_spec.js
index 66441212..62127eb9 100644
--- a/test/unit/function_spec.js
+++ b/test/unit/function_spec.js
@@ -492,9 +492,11 @@ describe('function', function() {
     it('check compiled mul', function() {
       check([0.25, 0.5, 'mul'], [], [0, 1], [{ input: [], output: [0.125], }]);
       check([0, 'mul'], [0, 1], [0, 1], [{ input: [0.25], output: [0], }]);
-      check([0.5, 'mul'], [0, 1], [0, 1], [{ input: [0.25], output: [0.125], }]);
+      check([0.5, 'mul'], [0, 1], [0, 1],
+            [{ input: [0.25], output: [0.125], }]);
       check([1, 'mul'], [0, 1], [0, 1], [{ input: [0.25], output: [0.25], }]);
-      check([0, 'exch', 'mul'], [0, 1], [0, 1], [{ input: [0.25], output: [0], }]);
+      check([0, 'exch', 'mul'], [0, 1], [0, 1],
+            [{ input: [0.25], output: [0], }]);
       check([0.5, 'exch', 'mul'], [0, 1], [0, 1],
             [{ input: [0.25], output: [0.125], }]);
       check([1, 'exch', 'mul'], [0, 1], [0, 1],
```