### PR TITLE
Fix the remaining cases of inconsistent spacing and trailing commas in objects, and enable the `comma-dangle` and `object-curly-spacing` ESLint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -102,6 +102,13 @@
     "brace-style": ["error", "1tbs", {
       "allowSingleLine": false,
     }],
+    "comma-dangle": ["error", {
+      "arrays": "ignore",
+      "objects": "always",
+      "imports": "never",
+      "exports": "always",
+      "functions": "never",
+    }],
     "comma-spacing": ["error", { "before": false, "after": true, }],
     "comma-style": ["error", "last"],
     "eol-last": "error",
@@ -118,6 +125,7 @@
     "no-tabs": "error",
     "no-trailing-spaces": ["error", { "skipBlankLines": false, }],
     "no-whitespace-before-property": "error",
+    "object-curly-spacing": ["error", "always"],
     "operator-linebreak": ["error", "after", { "overrides": { ":": "ignore", } }],
     "quotes": ["error", "single"],
     "semi-spacing": ["error", { "before": false, "after": true, }],

--- a/external/builder/builder.js
+++ b/external/builder/builder.js
@@ -53,7 +53,7 @@ function preprocess(inFilename, outFilename, defines) {
       throw new Error('No JavaScript expression given at ' + loc());
     }
     try {
-      return vm.runInNewContext(code, defines, {displayErrors: false});
+      return vm.runInNewContext(code, defines, { displayErrors: false, });
     } catch (e) {
       throw new Error('Could not evaluate "' + code + '" at ' + loc() + '\n' +
                       e.name + ': ' + e.message);

--- a/external/builder/preprocessor2.js
+++ b/external/builder/preprocessor2.js
@@ -22,7 +22,7 @@ function evalWithDefines(code, defines, loc) {
   if (!code || !code.trim()) {
     throw new Error('No JavaScript expression given');
   }
-  return vm.runInNewContext(code, defines, {displayErrors: false});
+  return vm.runInNewContext(code, defines, { displayErrors: false, });
 }
 
 function handlePreprocessorAction(ctx, actionName, args, loc) {
@@ -36,7 +36,7 @@ function handlePreprocessorAction(ctx, actionName, args, loc) {
           throw new Error('No code for testing is given');
         }
         var isTrue = !!evalWithDefines(arg.value, ctx.defines);
-        return {type: 'Literal', value: isTrue, loc: loc};
+        return { type: 'Literal', value: isTrue, loc: loc, };
       case 'eval':
         arg = args[0];
         if (!arg || arg.type !== 'Literal' ||
@@ -46,7 +46,7 @@ function handlePreprocessorAction(ctx, actionName, args, loc) {
         var result = evalWithDefines(arg.value, ctx.defines);
         if (typeof result === 'boolean' || typeof result === 'string' ||
             typeof result === 'number') {
-          return {type: 'Literal', value: result, loc: loc};
+          return { type: 'Literal', value: result, loc: loc, };
         }
         if (typeof result === 'object') {
           var parsedObj = acorn.parse('(' + JSON.stringify(result) + ')');
@@ -94,7 +94,7 @@ function postprocessNode(ctx, node) {
         return node.consequent;
       } else if (isLiteral(node.test, false)) {
         // if (false) stmt1; else stmt2; => stmt2
-        return node.alternate || {type: 'EmptyStatement', loc: node.loc};
+        return node.alternate || { type: 'EmptyStatement', loc: node.loc, };
       }
       break;
     case 'ConditionalExpression':
@@ -110,13 +110,13 @@ function postprocessNode(ctx, node) {
       if (node.operator === 'typeof' &&
           isPDFJSPreprocessor(node.argument)) {
         // typeof PDFJSDev => 'object'
-        return {type: 'Literal', value: 'object', loc: node.loc};
+        return { type: 'Literal', value: 'object', loc: node.loc, };
       }
       if (node.operator === '!' &&
           node.argument.type === 'Literal' &&
           typeof node.argument.value === 'boolean') {
         // !true => false,  !false => true
-        return {type: 'Literal', value: !node.argument.value, loc: node.loc};
+        return { type: 'Literal', value: !node.argument.value, loc: node.loc, };
       }
       break;
     case 'LogicalExpression':
@@ -157,7 +157,7 @@ function postprocessNode(ctx, node) {
                  return {
                    type: 'Literal',
                    value: (node.operator[0] === '=') === equal,
-                   loc: node.loc
+                   loc: node.loc,
                  };
              }
           }
@@ -285,7 +285,7 @@ function preprocessPDFJSCode(ctx, code) {
   var format = ctx.format || {
     indent: {
       style: ' ',
-    }
+    },
   };
   var parseOptions = {
     locations: true,

--- a/external/builder/test-fixtures_esprima.js
+++ b/external/builder/test-fixtures_esprima.js
@@ -21,8 +21,8 @@ files.forEach(function(expectationFilename) {
   var defines = {
     TRUE: true,
     FALSE: false,
-    OBJ: {obj: {i: 1}, j: 2},
-    TEXT: 'text'
+    OBJ: { obj: { i: 1, }, j: 2, },
+    TEXT: 'text',
   };
   var map = {
     'import-alias': 'import-name',

--- a/external/systemjs/plugin-babel-cached.js
+++ b/external/systemjs/plugin-babel-cached.js
@@ -26,7 +26,7 @@ function getDb() {
       var request = indexedDB.open(dbName, dbVersion);
       request.onupgradeneeded = function() {
         var db = request.result;
-        db.createObjectStore(dbCacheTable, {keyPath: 'address'});
+        db.createObjectStore(dbCacheTable, { keyPath: 'address', });
       };
       request.onsuccess = function() {
         var db = request.result;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -106,13 +106,13 @@ function safeSpawnSync(command, parameters, options) {
 }
 
 function createStringSource(filename, content) {
-  var source = stream.Readable({ objectMode: true });
+  var source = stream.Readable({ objectMode: true, });
   source._read = function () {
     this.push(new gutil.File({
       cwd: '',
       base: '',
       path: filename,
-      contents: new Buffer(content)
+      contents: new Buffer(content),
     }));
     this.push(null);
   };
@@ -126,7 +126,7 @@ function createWebpackConfig(defines, output) {
   var versionInfo = getVersionJSON();
   var bundleDefines = builder.merge(defines, {
     BUNDLE_VERSION: versionInfo.version,
-    BUNDLE_BUILD: versionInfo.commit
+    BUNDLE_BUILD: versionInfo.commit,
   });
   var licenseHeader = fs.readFileSync('./src/license_header.js').toString();
   var enableSourceMaps = !bundleDefines.FIREFOX && !bundleDefines.MOZCENTRAL &&
@@ -137,7 +137,7 @@ function createWebpackConfig(defines, output) {
   return {
     output: output,
     plugins: [
-      new webpack2.BannerPlugin({banner: licenseHeader, raw: true}),
+      new webpack2.BannerPlugin({ banner: licenseHeader, raw: true, }),
       new BlockRequirePlugin()
     ],
     resolve: {
@@ -145,7 +145,7 @@ function createWebpackConfig(defines, output) {
         'pdfjs': path.join(__dirname, 'src'),
         'pdfjs-web': path.join(__dirname, 'web'),
         'pdfjs-lib': path.join(__dirname, 'web/pdfjs'),
-      }
+      },
     },
     devtool: enableSourceMaps ? 'source-map' : undefined,
     module: {
@@ -155,19 +155,19 @@ function createWebpackConfig(defines, output) {
           exclude: /src\/core\/(glyphlist|unicode)/, // babel is too slow
           options: {
             presets: pdfjsNext ? undefined : ['es2015'],
-            plugins: ['transform-es2015-modules-commonjs']
-          }
+            plugins: ['transform-es2015-modules-commonjs'],
+          },
         },
         {
           loader: path.join(__dirname, 'external/webpack/pdfjsdev-loader.js'),
           options: {
             rootPath: __dirname,
             saveComments: false,
-            defines: bundleDefines
-          }
+            defines: bundleDefines,
+          },
         },
-      ]
-    }
+      ],
+    },
   };
 }
 
@@ -243,7 +243,7 @@ function createBundle(defines) {
     filename: mainOutputName,
     library: mainAMDName,
     libraryTarget: 'umd',
-    umdNamedDefine: true
+    umdNamedDefine: true,
   });
   var mainOutput = gulp.src('./src/pdf.js')
     .pipe(webpack2Stream(mainFileConfig))
@@ -260,7 +260,7 @@ function createBundle(defines) {
     filename: workerOutputName,
     library: workerAMDName,
     libraryTarget: 'umd',
-    umdNamedDefine: true
+    umdNamedDefine: true,
   });
   var workerOutput = gulp.src('./src/pdf.worker.js')
     .pipe(webpack2Stream(workerFileConfig))
@@ -273,7 +273,7 @@ function createWebBundle(defines) {
   var viewerOutputName = 'viewer.js';
 
   var viewerFileConfig = createWebpackConfig(defines, {
-    filename: viewerOutputName
+    filename: viewerOutputName,
   });
   return gulp.src('./web/viewer.js')
              .pipe(webpack2Stream(viewerFileConfig));
@@ -287,7 +287,7 @@ function createComponentsBundle(defines) {
     filename: componentsOutputName,
     library: componentsAMDName,
     libraryTarget: 'umd',
-    umdNamedDefine: true
+    umdNamedDefine: true,
   });
   return gulp.src('./web/pdf_viewer.component.js')
     .pipe(webpack2Stream(componentsFileConfig))
@@ -303,7 +303,7 @@ function createCompatibilityBundle(defines) {
     filename: compatibilityOutputName,
     library: compatibilityAMDName,
     libraryTarget: 'umd',
-    umdNamedDefine: true
+    umdNamedDefine: true,
   });
   return gulp.src('./web/compatibility.js')
     .pipe(webpack2Stream(compatibilityFileConfig));
@@ -342,7 +342,7 @@ function getTempFile(prefix, suffix) {
 }
 
 function createTestSource(testsName) {
-  var source = stream.Readable({ objectMode: true });
+  var source = stream.Readable({ objectMode: true, });
   source._read = function () {
     console.log();
     console.log('### Running ' + testsName + ' tests');
@@ -380,7 +380,7 @@ function createTestSource(testsName) {
     }
     args.push('--browserManifestFile=' + PDF_BROWSERS);
 
-    var testProcess = spawn('node', args, {cwd: TEST_DIR, stdio: 'inherit'});
+    var testProcess = spawn('node', args, { cwd: TEST_DIR, stdio: 'inherit', });
     testProcess.on('close', function (code) {
       source.push(null);
     });
@@ -409,7 +409,7 @@ function makeRef(done, noPrompts) {
     args.push('--noPrompts');
   }
   args.push('--browserManifestFile=' + PDF_BROWSERS);
-  var testProcess = spawn('node', args, {cwd: TEST_DIR, stdio: 'inherit'});
+  var testProcess = spawn('node', args, { cwd: TEST_DIR, stdio: 'inherit', });
   testProcess.on('close', function (code) {
     done();
   });
@@ -451,7 +451,7 @@ gulp.task('buildnumber', function (done) {
       createStringSource('version.json', JSON.stringify({
         version: version,
         build: buildNumber,
-        commit: buildCommit
+        commit: buildCommit,
       }, null, 2))
         .pipe(gulp.dest(BUILD_DIR))
         .on('end', done);
@@ -514,13 +514,13 @@ gulp.task('locale', function () {
     createStringSource('chrome.manifest.inc', chromeManifestContent)
       .pipe(gulp.dest(METADATA_OUTPUT)),
     gulp.src(L10N_DIR + '/{' + locales.join(',') + '}' +
-             '/{viewer,chrome}.properties', {base: L10N_DIR})
+             '/{viewer,chrome}.properties', { base: L10N_DIR, })
       .pipe(gulp.dest(EXTENSION_LOCALE_OUTPUT)),
 
     createStringSource('locale.properties', viewerOutput)
       .pipe(gulp.dest(VIEWER_LOCALE_OUTPUT)),
     gulp.src(L10N_DIR + '/{' + locales.join(',') + '}' +
-             '/viewer.properties', {base: L10N_DIR})
+             '/viewer.properties', { base: L10N_DIR, })
       .pipe(gulp.dest(VIEWER_LOCALE_OUTPUT))
   ]);
 });
@@ -598,22 +598,22 @@ function preprocessJS(source, defines, cleanup) {
 gulp.task('generic', ['buildnumber', 'locale'], function () {
   console.log();
   console.log('### Creating generic viewer');
-  var defines = builder.merge(DEFINES, {GENERIC: true});
+  var defines = builder.merge(DEFINES, { GENERIC: true, });
 
   rimraf.sync(GENERIC_DIR);
 
   return merge([
     createBundle(defines).pipe(gulp.dest(GENERIC_DIR + 'build')),
     createWebBundle(defines).pipe(gulp.dest(GENERIC_DIR + 'web')),
-    gulp.src(COMMON_WEB_FILES, {base: 'web/'})
+    gulp.src(COMMON_WEB_FILES, { base: 'web/', })
         .pipe(gulp.dest(GENERIC_DIR + 'web')),
     gulp.src('LICENSE').pipe(gulp.dest(GENERIC_DIR)),
     gulp.src([
       'web/locale/*/viewer.properties',
       'web/locale/locale.properties'
-    ], {base: 'web/'}).pipe(gulp.dest(GENERIC_DIR + 'web')),
+    ], { base: 'web/', }).pipe(gulp.dest(GENERIC_DIR + 'web')),
     gulp.src(['external/bcmaps/*.bcmap', 'external/bcmaps/LICENSE'],
-             {base: 'external/bcmaps'})
+             { base: 'external/bcmaps', })
         .pipe(gulp.dest(GENERIC_DIR + 'web/cmaps')),
     preprocessHTML('web/viewer.html', defines)
         .pipe(gulp.dest(GENERIC_DIR + 'web')),
@@ -628,7 +628,7 @@ gulp.task('generic', ['buildnumber', 'locale'], function () {
 gulp.task('components', ['buildnumber'], function () {
   console.log();
   console.log('### Creating generic components');
-  var defines = builder.merge(DEFINES, {COMPONENTS: true, GENERIC: true});
+  var defines = builder.merge(DEFINES, { COMPONENTS: true, GENERIC: true, });
 
   rimraf.sync(COMPONENTS_DIR);
 
@@ -651,7 +651,7 @@ gulp.task('components', ['buildnumber'], function () {
 gulp.task('singlefile', ['buildnumber'], function () {
   console.log();
   console.log('### Creating singlefile build');
-  var defines = builder.merge(DEFINES, {SINGLE_FILE: true});
+  var defines = builder.merge(DEFINES, { SINGLE_FILE: true, });
 
   var SINGLE_FILE_BUILD_DIR = SINGLE_FILE_DIR + 'build/';
 
@@ -663,21 +663,21 @@ gulp.task('singlefile', ['buildnumber'], function () {
 gulp.task('minified-pre', ['buildnumber', 'locale'], function () {
   console.log();
   console.log('### Creating minified viewer');
-  var defines = builder.merge(DEFINES, {MINIFIED: true, GENERIC: true});
+  var defines = builder.merge(DEFINES, { MINIFIED: true, GENERIC: true, });
 
   rimraf.sync(MINIFIED_DIR);
 
   return merge([
     createBundle(defines).pipe(gulp.dest(MINIFIED_DIR + 'build')),
     createWebBundle(defines).pipe(gulp.dest(MINIFIED_DIR + 'web')),
-    gulp.src(COMMON_WEB_FILES, {base: 'web/'})
+    gulp.src(COMMON_WEB_FILES, { base: 'web/', })
         .pipe(gulp.dest(MINIFIED_DIR + 'web')),
     gulp.src([
       'web/locale/*/viewer.properties',
       'web/locale/locale.properties'
-    ], {base: 'web/'}).pipe(gulp.dest(MINIFIED_DIR + 'web')),
+    ], { base: 'web/', }).pipe(gulp.dest(MINIFIED_DIR + 'web')),
     gulp.src(['external/bcmaps/*.bcmap', 'external/bcmaps/LICENSE'],
-             {base: 'external/bcmaps'})
+             { base: 'external/bcmaps', })
         .pipe(gulp.dest(MINIFIED_DIR + 'web/cmaps')),
 
     preprocessHTML('web/viewer.html', defines)
@@ -701,7 +701,7 @@ gulp.task('minified-post', ['minified-pre'], function () {
 
   var UglifyJS = require('uglify-js');
   // V8 chokes on very long sequences. Works around that.
-  var optsForHugeFile = {compress: {sequences: false}};
+  var optsForHugeFile = { compress: { sequences: false, }, };
 
   fs.writeFileSync(MINIFIED_DIR + '/web/pdf.viewer.js',
                    UglifyJS.minify(viewerFiles).code);
@@ -750,13 +750,13 @@ gulp.task('firefox-pre', ['buildnumber', 'locale'], function () {
   return merge([
     createBundle(defines).pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR + 'build')),
     createWebBundle(defines).pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR + 'web')),
-    gulp.src(COMMON_WEB_FILES, {base: 'web/'})
+    gulp.src(COMMON_WEB_FILES, { base: 'web/', })
         .pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR + 'web')),
     gulp.src(FIREFOX_EXTENSION_DIR + 'locale/**/*.properties',
-             {base: FIREFOX_EXTENSION_DIR})
+             { base: FIREFOX_EXTENSION_DIR, })
         .pipe(gulp.dest(FIREFOX_BUILD_DIR)),
     gulp.src(['external/bcmaps/*.bcmap', 'external/bcmaps/LICENSE'],
-             {base: 'external/bcmaps'})
+             { base: 'external/bcmaps', })
         .pipe(gulp.dest(FIREFOX_BUILD_CONTENT_DIR + 'web/cmaps')),
 
     preprocessHTML('web/viewer.html', defines)
@@ -781,7 +781,7 @@ gulp.task('firefox-pre', ['buildnumber', 'locale'], function () {
                       localizedMetadata))
         .pipe(gulp.dest(FIREFOX_BUILD_DIR)),
     gulp.src(FIREFOX_EXTENSION_DIR + 'chrome/content.js',
-             {base: FIREFOX_EXTENSION_DIR})
+             { base: FIREFOX_EXTENSION_DIR, })
         .pipe(gulp.dest(FIREFOX_BUILD_DIR)),
     gulp.src('LICENSE').pipe(gulp.dest(FIREFOX_BUILD_DIR)),
 
@@ -820,7 +820,7 @@ gulp.task('firefox', ['firefox-pre'], function (done) {
   var zipExecOptions = {
     cwd: FIREFOX_BUILD_DIR,
     // Set timezone to UTC before calling zip to get reproducible results.
-    env: {'TZ': 'UTC'},
+    env: { 'TZ': 'UTC', },
   };
 
   exec('zip -r ' + FIREFOX_EXTENSION_NAME + ' ' +
@@ -858,10 +858,10 @@ gulp.task('mozcentral-pre', ['buildnumber', 'locale'], function () {
   return merge([
     createBundle(defines).pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'build')),
     createWebBundle(defines).pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'web')),
-    gulp.src(COMMON_WEB_FILES, {base: 'web/'})
+    gulp.src(COMMON_WEB_FILES, { base: 'web/', })
         .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'web')),
     gulp.src(['external/bcmaps/*.bcmap', 'external/bcmaps/LICENSE'],
-             {base: 'external/bcmaps'})
+             { base: 'external/bcmaps', })
         .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'web/cmaps')),
 
     preprocessHTML('web/viewer.html', defines)
@@ -923,15 +923,15 @@ gulp.task('chromium-pre', ['buildnumber', 'locale'], function () {
   return merge([
     createBundle(defines).pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'build')),
     createWebBundle(defines).pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web')),
-    gulp.src(COMMON_WEB_FILES, {base: 'web/'})
+    gulp.src(COMMON_WEB_FILES, { base: 'web/', })
         .pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web')),
 
     gulp.src([
       'web/locale/*/viewer.properties',
       'web/locale/locale.properties'
-    ], {base: 'web/'}).pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web')),
+    ], { base: 'web/', }).pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web')),
     gulp.src(['external/bcmaps/*.bcmap', 'external/bcmaps/LICENSE'],
-             {base: 'external/bcmaps'})
+             { base: 'external/bcmaps', })
         .pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web/cmaps')),
 
     preprocessHTML('web/viewer.html', defines)
@@ -946,7 +946,7 @@ gulp.task('chromium-pre', ['buildnumber', 'locale'], function () {
     gulp.src([
       'extensions/chromium/**/*.{html,js,css,png}',
       'extensions/chromium/preferences_schema.json'
-    ], {base: 'extensions/chromium/'})
+    ], { base: 'extensions/chromium/', })
         .pipe(gulp.dest(CHROME_BUILD_DIR)),
   ]);
 });
@@ -999,11 +999,11 @@ gulp.task('lib', ['buildnumber'], function () {
       GENERIC: true,
       LIB: true,
       BUNDLE_VERSION: versionInfo.version,
-      BUNDLE_BUILD: versionInfo.commit
+      BUNDLE_BUILD: versionInfo.commit,
     }),
     map: {
-      'pdfjs-lib': '../pdf'
-    }
+      'pdfjs-lib': '../pdf',
+    },
   };
   var licenseHeader = fs.readFileSync('./src/license_header.js').toString();
   var preprocessor2 = require('./external/builder/preprocessor2.js');
@@ -1012,19 +1012,19 @@ gulp.task('lib', ['buildnumber'], function () {
       'src/{core,display}/*.js',
       'src/shared/{compatibility,util}.js',
       'src/{pdf,pdf.worker}.js',
-    ], {base: 'src/'}),
+    ], { base: 'src/', }),
     gulp.src([
       'web/*.js',
       '!web/pdfjs.js',
       '!web/viewer.js',
       '!web/compatibility.js',
-    ], {base: '.'}),
-    gulp.src('test/unit/*.js', {base: '.'}),
+    ], { base: '.', }),
+    gulp.src('test/unit/*.js', { base: '.', }),
   ]).pipe(transform(preprocess))
     .pipe(gulp.dest('build/lib/'));
   return merge([
     buildLib,
-    gulp.src('external/streams/streams-lib.js', {base: '.'})
+    gulp.src('external/streams/streams-lib.js', { base: '.', })
       .pipe(gulp.dest('build/')),
   ]);
 });
@@ -1056,12 +1056,12 @@ gulp.task('publish', ['generic'], function (done) {
 });
 
 gulp.task('test', ['generic'], function () {
-  return streamqueue({ objectMode: true },
+  return streamqueue({ objectMode: true, },
     createTestSource('unit'), createTestSource('browser'));
 });
 
 gulp.task('bottest', ['generic'], function () {
-  return streamqueue({ objectMode: true },
+  return streamqueue({ objectMode: true, },
     createTestSource('unit'), createTestSource('font'),
     createTestSource('browser (no reftest)'));
 });
@@ -1103,13 +1103,13 @@ gulp.task('baseline', function (done) {
   }
 
   var workingDirectory = path.resolve(process.cwd(), BASELINE_DIR);
-  exec(initializeCommand, { cwd: workingDirectory }, function (error) {
+  exec(initializeCommand, { cwd: workingDirectory, }, function (error) {
     if (error) {
       done(new Error('Baseline clone/fetch failed.'));
       return;
     }
 
-    exec('git checkout ' + baselineCommit, { cwd: workingDirectory },
+    exec('git checkout ' + baselineCommit, { cwd: workingDirectory, },
         function (error) {
       if (error) {
         done(new Error('Baseline commit checkout failed.'));
@@ -1125,7 +1125,7 @@ gulp.task('baseline', function (done) {
 gulp.task('unittestcli', ['lib'], function (done) {
   var args = ['JASMINE_CONFIG_PATH=test/unit/clitests.json'];
   var testProcess = spawn('node_modules/.bin/jasmine', args,
-                          {stdio: 'inherit'});
+                          { stdio: 'inherit', });
   testProcess.on('close', function (code) {
     if (code !== 0) {
       done(new Error('Unit tests failed.'));
@@ -1141,7 +1141,7 @@ gulp.task('lint', function (done) {
 
   // Ensure that we lint the Firefox specific *.jsm files too.
   var options = ['node_modules/eslint/bin/eslint', '--ext', '.js,.jsm', '.'];
-  var esLintProcess = spawn('node', options, {stdio: 'inherit'});
+  var esLintProcess = spawn('node', options, { stdio: 'inherit', });
   esLintProcess.on('close', function (code) {
     if (code !== 0) {
       done(new Error('ESLint failed.'));
@@ -1212,16 +1212,16 @@ gulp.task('gh-pages-prepare', ['web-pre'], function () {
 
   // 'vinyl' because web/viewer.html needs its BOM.
   return merge([
-    vinyl.src(GENERIC_DIR + '**/*', {base: GENERIC_DIR, stripBOM: false})
+    vinyl.src(GENERIC_DIR + '**/*', { base: GENERIC_DIR, stripBOM: false, })
          .pipe(gulp.dest(GH_PAGES_DIR)),
     gulp.src([FIREFOX_BUILD_DIR + '*.xpi',
               FIREFOX_BUILD_DIR + '*.rdf'])
         .pipe(gulp.dest(GH_PAGES_DIR + EXTENSION_SRC_DIR + 'firefox/')),
     gulp.src(CHROME_BUILD_DIR + '*.crx')
         .pipe(gulp.dest(GH_PAGES_DIR + EXTENSION_SRC_DIR + 'chromium/')),
-    gulp.src('test/features/**/*', {base: 'test/'})
+    gulp.src('test/features/**/*', { base: 'test/', })
         .pipe(gulp.dest(GH_PAGES_DIR)),
-    gulp.src(JSDOC_BUILD_DIR + '**/*', {base: JSDOC_BUILD_DIR})
+    gulp.src(JSDOC_BUILD_DIR + '**/*', { base: JSDOC_BUILD_DIR, })
         .pipe(gulp.dest(GH_PAGES_DIR + 'api/draft/')),
   ]);
 });
@@ -1246,14 +1246,15 @@ gulp.task('gh-pages-git', ['gh-pages-prepare', 'wintersmith'], function () {
   var VERSION = getVersionJSON().version;
   var reason = process.env['PDFJS_UPDATE_REASON'];
 
-  safeSpawnSync('git', ['init'], {cwd: GH_PAGES_DIR});
-  safeSpawnSync('git', ['remote', 'add', 'origin', REPO], {cwd: GH_PAGES_DIR});
-  safeSpawnSync('git', ['add', '-A'], {cwd: GH_PAGES_DIR});
+  safeSpawnSync('git', ['init'], { cwd: GH_PAGES_DIR, });
+  safeSpawnSync('git', ['remote', 'add', 'origin', REPO],
+                { cwd: GH_PAGES_DIR, });
+  safeSpawnSync('git', ['add', '-A'], { cwd: GH_PAGES_DIR, });
   safeSpawnSync('git', [
     'commit', '-am', 'gh-pages site created via gulpfile.js script',
     '-m', 'PDF.js version ' + VERSION + (reason ? ' - ' + reason : '')
-  ], {cwd: GH_PAGES_DIR});
-  safeSpawnSync('git', ['branch', '-m', 'gh-pages'], {cwd: GH_PAGES_DIR});
+  ], { cwd: GH_PAGES_DIR, });
+  safeSpawnSync('git', ['branch', '-m', 'gh-pages'], { cwd: GH_PAGES_DIR, });
 
   console.log();
   console.log('Website built in ' + GH_PAGES_DIR);
@@ -1296,12 +1297,12 @@ gulp.task('dist-repo-prepare', ['dist-pre'], function () {
       'worker-loader': '^0.8.0', // used in external/dist/webpack.json
     },
     browser: {
-      'node-ensure': false
+      'node-ensure': false,
     },
     format: 'amd', // to not allow system.js to choose 'cjs'
     repository: {
       type: 'git',
-      url: DIST_REPO_URL
+      url: DIST_REPO_URL,
     },
   };
   var packageJsonSrc =
@@ -1320,17 +1321,17 @@ gulp.task('dist-repo-prepare', ['dist-pre'], function () {
     createStringSource('bower.json', JSON.stringify(bowerManifest, null, 2));
 
   return merge([
-    gulp.src('external/streams/streams-lib.js', {base: '.'})
+    gulp.src('external/streams/streams-lib.js', { base: '.', })
       .pipe(gulp.dest('build/dist/')),
     packageJsonSrc.pipe(gulp.dest(DIST_DIR)),
     bowerJsonSrc.pipe(gulp.dest(DIST_DIR)),
     vinyl.src('external/dist/**/*',
-              {base: 'external/dist', stripBOM: false})
+              { base: 'external/dist', stripBOM: false, })
          .pipe(gulp.dest(DIST_DIR)),
     gulp.src(GENERIC_DIR + 'LICENSE')
         .pipe(gulp.dest(DIST_DIR)),
     gulp.src(GENERIC_DIR + 'web/cmaps/**/*',
-             {base: GENERIC_DIR + 'web'})
+             { base: GENERIC_DIR + 'web', })
         .pipe(gulp.dest(DIST_DIR)),
     gulp.src([
       GENERIC_DIR + 'build/pdf.js',
@@ -1347,9 +1348,9 @@ gulp.task('dist-repo-prepare', ['dist-pre'], function () {
     gulp.src(MINIFIED_DIR + 'build/pdf.worker.js')
         .pipe(rename('pdf.worker.min.js'))
         .pipe(gulp.dest(DIST_DIR + 'build/')),
-    gulp.src(COMPONENTS_DIR + '**/*', {base: COMPONENTS_DIR})
+    gulp.src(COMPONENTS_DIR + '**/*', { base: COMPONENTS_DIR, })
         .pipe(gulp.dest(DIST_DIR + 'web/')),
-    gulp.src(LIB_DIR + '**/*', {base: LIB_DIR})
+    gulp.src(LIB_DIR + '**/*', { base: LIB_DIR, })
         .pipe(gulp.dest(DIST_DIR + 'lib/')),
   ]);
 });
@@ -1362,10 +1363,10 @@ gulp.task('dist-repo-git', ['dist-repo-prepare'], function () {
 
   var reason = process.env['PDFJS_UPDATE_REASON'];
   var message = 'PDF.js version ' + VERSION + (reason ? ' - ' + reason : '');
-  safeSpawnSync('git', ['add', '*'], {cwd: DIST_DIR});
-  safeSpawnSync('git', ['commit', '-am', message], {cwd: DIST_DIR});
+  safeSpawnSync('git', ['add', '*'], { cwd: DIST_DIR, });
+  safeSpawnSync('git', ['commit', '-am', message], { cwd: DIST_DIR, });
   safeSpawnSync('git', ['tag', '-a', 'v' + VERSION, '-m', message],
-                {cwd: DIST_DIR});
+                { cwd: DIST_DIR, });
 
   console.log();
   console.log('Done. Push with');
@@ -1385,7 +1386,7 @@ gulp.task('mozcentralbaseline', ['baseline'], function (done) {
 
   var workingDirectory = path.resolve(process.cwd(), BASELINE_DIR);
   safeSpawnSync('gulp', ['mozcentral'],
-                {env: process.env, cwd: workingDirectory, stdio: 'inherit'});
+                { env: process.env, cwd: workingDirectory, stdio: 'inherit', });
 
   // Copy the mozcentral build to the mozcentral baseline directory.
   rimraf.sync(MOZCENTRAL_BASELINE_DIR);
@@ -1395,10 +1396,10 @@ gulp.task('mozcentralbaseline', ['baseline'], function (done) {
       .pipe(gulp.dest(MOZCENTRAL_BASELINE_DIR))
       .on('end', function () {
         // Commit the mozcentral baseline.
-        safeSpawnSync('git', ['init'], {cwd: MOZCENTRAL_BASELINE_DIR});
-        safeSpawnSync('git', ['add', '.'], {cwd: MOZCENTRAL_BASELINE_DIR});
+        safeSpawnSync('git', ['init'], { cwd: MOZCENTRAL_BASELINE_DIR, });
+        safeSpawnSync('git', ['add', '.'], { cwd: MOZCENTRAL_BASELINE_DIR, });
         safeSpawnSync('git', ['commit', '-m', '"mozcentral baseline"'],
-                      {cwd: MOZCENTRAL_BASELINE_DIR});
+                      { cwd: MOZCENTRAL_BASELINE_DIR, });
         done();
       });
 });
@@ -1418,10 +1419,10 @@ gulp.task('mozcentraldiff', ['mozcentral', 'mozcentralbaseline'],
   gulp.src([BUILD_DIR + 'mozcentral/**/*'])
       .pipe(gulp.dest(MOZCENTRAL_BASELINE_DIR))
       .on('end', function () {
-        safeSpawnSync('git', ['add', '-A'], {cwd: MOZCENTRAL_BASELINE_DIR});
+        safeSpawnSync('git', ['add', '-A'], { cwd: MOZCENTRAL_BASELINE_DIR, });
         var diff = safeSpawnSync('git',
           ['diff', '--binary', '--cached', '--unified=8'],
-          {cwd: MOZCENTRAL_BASELINE_DIR}).stdout;
+          { cwd: MOZCENTRAL_BASELINE_DIR, }).stdout;
 
         createStringSource(MOZCENTRAL_DIFF_FILE, diff)
           .pipe(gulp.dest(BUILD_DIR))
@@ -1436,8 +1437,8 @@ gulp.task('mozcentraldiff', ['mozcentral', 'mozcentralbaseline'],
 gulp.task('externaltest', function () {
   gutil.log('Running test-fixtures.js');
   safeSpawnSync('node', ['external/builder/test-fixtures.js'],
-                {stdio: 'inherit'});
+                { stdio: 'inherit', });
   gutil.log('Running test-fixtures_esprima.js');
   safeSpawnSync('node', ['external/builder/test-fixtures_esprima.js'],
-                {stdio: 'inherit'});
+                { stdio: 'inherit', });
 });

--- a/systemjs.config.js
+++ b/systemjs.config.js
@@ -43,7 +43,7 @@
     packages: {
       '': {
         defaultExtension: 'js',
-      }
+      },
     },
     paths: {
       'pdfjs': new URL('src', baseLocation).href,
@@ -58,7 +58,7 @@
         babelOptions: {
           es2015: false,
         },
-      }
+      },
     },
     map: {
       'plugin-babel': new URL(PluginBabelPath, baseLocation).href,
@@ -66,6 +66,6 @@
         new URL(SystemJSPluginBabelPath, baseLocation).href,
       'plugin-babel-cached': new URL(PluginBabelCachePath, baseLocation).href,
     },
-    transpiler: isCachingPossible ? 'plugin-babel-cached' : 'plugin-babel'
+    transpiler: isCachingPossible ? 'plugin-babel-cached' : 'plugin-babel',
   });
 })();


### PR DESCRIPTION
http://eslint.org/docs/rules/comma-dangle
http://eslint.org/docs/rules/object-curly-spacing

*Please note:* This patch was created automatically, using the ESLint `--fix` command line option. In a couple of places this caused lines to become too long, and I've fixed those manually; please refer to the interdiff below for the only hand-edits in this patch.

```diff
diff --git a/gulpfile.js b/gulpfile.js
index d18b9c58..7d47fd8d 100644
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1247,7 +1247,8 @@ gulp.task('gh-pages-git', ['gh-pages-prepare', 'wintersmith'], function () {
   var reason = process.env['PDFJS_UPDATE_REASON'];

   safeSpawnSync('git', ['init'], { cwd: GH_PAGES_DIR, });
-  safeSpawnSync('git', ['remote', 'add', 'origin', REPO], { cwd: GH_PAGES_DIR, });
+  safeSpawnSync('git', ['remote', 'add', 'origin', REPO],
+                { cwd: GH_PAGES_DIR, });
   safeSpawnSync('git', ['add', '-A'], { cwd: GH_PAGES_DIR, });
   safeSpawnSync('git', [
     'commit', '-am', 'gh-pages site created via gulpfile.js script',
```