### PR TITLE
Prevent console errors when clicking to change page while in Presentation Mode (issue 8498)

### DIFF
--- a/web/pdf_presentation_mode.js
+++ b/web/pdf_presentation_mode.js
@@ -288,7 +288,12 @@ class PDFPresentationMode {
       if (!isInternalLink) {
         // Unless an internal link was clicked, advance one page.
         evt.preventDefault();
-        this.pdfViewer.currentPageNumber += (evt.shiftKey ? -1 : 1);
+
+        if (evt.shiftKey) {
+          this._goToPreviousPage();
+        } else {
+          this._goToNextPage();
+        }
       }
     }
   }


### PR DESCRIPTION
The click handler used in Presentation Mode didn't check if the first/last page was already reached, which after PR #7529 now causes an unnecessary console error.
Hence we should simply use the already existing `_goToPreviousPage`/`_goToNextPage` methods instead, since they do the necessary bounds checking.

Fixes #8498.