### PR TITLE
Fix blank font loading issue.

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -225,7 +225,8 @@ var ToUnicodeMap = (function ToUnicodeMapClosure() {
 
     forEach(callback) {
       for (var charCode in this._map) {
-        callback(charCode, this._map[charCode].charCodeAt(0));
+        if (typeof this._map[charCode].charCodeAt === 'function')
+          callback(charCode, this._map[charCode].charCodeAt(0));
       }
     },
 


### PR DESCRIPTION
If a pdf (particularly in the form of an array buffer) has missing fonts, no fonts will display. This fixes that.