### PR TITLE
Fixes WeakMap polyfill (and improves PDFWorker port check).

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1232,7 +1232,7 @@ var PDFWorker = (function PDFWorkerClosure() {
   let pdfWorkerPorts = new WeakMap();
 
   function PDFWorker(name, port) {
-    if (pdfWorkerPorts.has(port)) {
+    if (port && pdfWorkerPorts.has(port)) {
       throw new Error('Cannot use more than one PDFWorker per port');
     }
 

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -1176,10 +1176,14 @@ PDFJS.compatibilityChecked = true;
   }
   WeakMap.prototype = {
     has(obj) {
+      if ((typeof obj !== 'object' && typeof obj !== 'function') ||
+          obj === null) {
+        return false;
+      }
       return !!Object.getOwnPropertyDescriptor(obj, this.id);
     },
-    get(obj, defaultValue) {
-      return this.has(obj) ? obj[this.id] : defaultValue;
+    get(obj) {
+      return this.has(obj) ? obj[this.id] : undefined;
     },
     set(obj, value) {
       Object.defineProperty(obj, this.id, {


### PR DESCRIPTION
Regressed on IE9 after #8508 -- WeakMap polyfill did not work per spec.