### PR TITLE
Remove a redundant `PDFViewer.currentScale` call from `PDFViewerApplication.load`

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -907,7 +907,6 @@ var PDFViewerApplication = {
     this.pdfDocumentProperties.setDocument(pdfDocument, this.url);
 
     let pdfViewer = this.pdfViewer;
-    pdfViewer.currentScale = scale;
     pdfViewer.setDocument(pdfDocument);
     let firstPagePromise = pdfViewer.firstPagePromise;
     let pagesPromise = pdfViewer.pagesPromise;


### PR DESCRIPTION
Since this call occurs *before* the `PDFViewer.setDocument` call, it won't actually cause any scale change.
Furthermore, moving it should not be necessary, since the `scale` is already used as the fallback case in `PDFViewerApplication.setInitialView` (provided it's non-zero, which isn't even the case in the default viewer).

Hence this patch should cause no functional changes at all, since it simply removes a piece of unnecessary code.