### PR TITLE
Reduce memory requirements of pdf2svg.js example to avoid OOM 

### DIFF
--- a/examples/node/domstubs.js
+++ b/examples/node/domstubs.js
@@ -91,24 +91,27 @@ DOMElement.prototype = {
   },
 
   toString: function DOMElement_toString() {
-    var attrList = [];
-    for (i in this.attributes) {
-      attrList.push(i + '="' + xmlEncode(this.attributes[i]) + '"');
+    var buf = [];
+    buf.push('<' + this.nodeName);
+    if (this.nodeName === 'svg:svg') {
+      buf.push(' xmlns:xlink="http://www.w3.org/1999/xlink"' +
+               ' xmlns:svg="http://www.w3.org/2000/svg"');
+    }
+    for (var i in this.attributes) {
+      buf.push(' ' + i + '="' + xmlEncode(this.attributes[i]) + '"');
     }
 
+    buf.push('>');
+
     if (this.nodeName === 'svg:tspan' || this.nodeName === 'svg:style') {
-      var encText = xmlEncode(this.textContent);
-      return '<' + this.nodeName + ' ' + attrList.join(' ') + '>' +
-             encText + '</' + this.nodeName + '>';
-    } else if (this.nodeName === 'svg:svg') {
-      var ns = 'xmlns:xlink="http://www.w3.org/1999/xlink" ' +
-               'xmlns:svg="http://www.w3.org/2000/svg"'
-      return '<' + this.nodeName + ' ' + ns + ' ' + attrList.join(' ') + '>' +
-             this.childNodes.join('') + '</' + this.nodeName + '>';
+      buf.push(xmlEncode(this.textContent));
     } else {
-      return '<' + this.nodeName + ' ' + attrList.join(' ') + '>' +
-             this.childNodes.join('') + '</' + this.nodeName + '>';
+      this.childNodes.forEach(function(childNode) {
+        buf.push(childNode.toString());
+      });
     }
+    buf.push('</' + this.nodeName + '>');
+    return buf.join('');
   },
 
   cloneNode: function DOMElement_cloneNode() {

--- a/examples/node/pdf2svg.js
+++ b/examples/node/pdf2svg.js
@@ -18,7 +18,7 @@ var pdfPath = process.argv[2] || '../../web/compressed.tracemonkey-pldi-09.pdf';
 var data = new Uint8Array(fs.readFileSync(pdfPath));
 
 // Dumps svg outputs to a folder called svgdump
-function writeToFile(svgdump, pageNum) {
+function writeToFile(svgdump, pageNum, callback) {
   var name = getFileNameFromPath(pdfPath);
   fs.mkdir('./svgdump/', function(err) {
     if (!err || err.code === 'EEXIST') {
@@ -29,7 +29,10 @@ function writeToFile(svgdump, pageNum) {
           } else {
             console.log('Page: ' + pageNum);
           }
+          callback();
         });
+    } else {
+      callback();
     }
   });
 }
@@ -67,7 +70,9 @@ pdfjsLib.getDocument({
         svgGfx.embedFonts = true;
         return svgGfx.getSVG(opList, viewport).then(function (svg) {
           var svgDump = svg.toString();
-          writeToFile(svgDump, pageNum);
+          return new Promise(function(resolve) {
+            writeToFile(svgDump, pageNum, resolve);
+          });
         });
       });
     })


### PR DESCRIPTION
See the individual commit messages for more details. I verified that the output of the first 9 pages (before and after my patches) are identical:

```
$ gdb -ex run --args \
 node --max_old_space_size=200 \
 examples/node/pdf2svg.js /tmp/FatalProcessOutOfMemory.pdf

$ md5sum svgdump/FatalProcessOutOfMemory-[1-9].svg
8d3b9b5ff4bffef8423346f3b964a96f  svgdump/FatalProcessOutOfMemory-1.svg
0c00d37793523580bb45af64cf0b0510  svgdump/FatalProcessOutOfMemory-2.svg
2efeb696ec79a5c2e1318ee8d6c26d78  svgdump/FatalProcessOutOfMemory-3.svg
898f49bbda623137f5edc985bfafcac3  svgdump/FatalProcessOutOfMemory-4.svg
00628f7ebc47afbbc2992b85da7a0828  svgdump/FatalProcessOutOfMemory-5.svg
dec693597bc61286d10b4f0af8b468ea  svgdump/FatalProcessOutOfMemory-6.svg
6c047f815efd2816ace541a23487f48f  svgdump/FatalProcessOutOfMemory-7.svg
f702367a6b8903273a42277a12d40d2d  svgdump/FatalProcessOutOfMemory-8.svg
cd1867d8cb8b88b5d16e3c31b51ef2b5  svgdump/FatalProcessOutOfMemory-9.svg
```

(note that if you wait until the PDF-to-SVG conversion finishes for the given example from #8534, that you end up with a svgdump directory of 1.5G.)

Fixes #8534