### PR TITLE
Move svg:clipPath generation from clip to endPath

### DIFF
--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -90,6 +90,7 @@
 !issue3879r.pdf
 !issue5686.pdf
 !issue3928.pdf
+!clippath.pdf
 !close-path-bug.pdf
 !issue6019.pdf
 !issue6621.pdf

--- a/test/pdfs/clippath.pdf
+++ b/test/pdfs/clippath.pdf
@@ -1,0 +1,37 @@
+%PDF-1.1
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+2 0 obj
+<</Type/Pages/Count 1/Kids[3 0 R]/MediaBox [0 0 200 100]>>
+endobj
+3 0 obj
+<</Type/Page/Parent 2 0 R/Contents 4 0 R>>
+endobj
+4 0 obj
+<</Length 65>>
+stream
+W
+40 20 m
+160 20 l
+160 80 l
+40 80 l
+h
+n
+0 0 0 sc
+0 0 200 100 re
+f
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000009 00000 n 
+0000000054 00000 n 
+0000000128 00000 n 
+0000000186 00000 n 
+trailer
+<</Root 1 0 R/Size 5>>
+startxref
+299
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2776,6 +2776,14 @@
       "type": "eq",
       "about": "CFF font that is drawn with clipping."
     },
+    {  "id": "clippath",
+      "file": "pdfs/clippath.pdf",
+      "md5": "7ab95c0f106dccd90d6569f241fe8771",
+      "rounds": 1,
+      "link": false,
+      "type": "eq",
+      "about": "Clipping before a path exists, followed by adding a path and then drawing a rectangle."
+    },
     {  "id": "annotation-tx",
       "file": "pdfs/annotation-tx.pdf",
       "md5": "56321ea830be9c4f8437ca17ac535b2d",


### PR DESCRIPTION
See the commit message for a detailed explanation.

I think that we also need to check whether it is necessary to add more `.endPath` calls to src/display/svg.js, similar to the many `consumePath` calls in src/display/canvas.js. However I don't understand that part of the code well enough to tell whether it's needed.

Fixes #8527 
Seems to improve #8496 (https://github.com/mozilla/pdf.js/issues/8496#issuecomment-309432026)