### PR TITLE
Ensure canvas is really hidden when used with pdfjs-dist.

### DIFF
--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -51,6 +51,10 @@
   display: block;
 }
 
+.pdfViewer .page canvas[hidden] {
+  display: none;
+}
+
 .pdfViewer .page .loadingIcon {
   position: absolute;
   display: block;


### PR DESCRIPTION
Avoids black background flickering in such examples as components/simpleviewer.html