### PR TITLE
Don't allow setting various properties, such as `currentPageNumber`/`currentScale`/`currentScaleValue`/`pagesRotation`, before `{PDFViewer, PDFThumbnailViewer}.setDocument` has been called

### DIFF
--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -95,8 +95,15 @@ class PDFThumbnailViewer {
   }
 
   set pagesRotation(rotation) {
+    if (!(typeof rotation === 'number' && rotation % 90 === 0)) {
+      throw new Error('Invalid thumbnails rotation angle.');
+    }
+    if (!this.pdfDocument) {
+      return;
+    }
     this._pagesRotation = rotation;
-    for (let i = 0, l = this._thumbnails.length; i < l; i++) {
+
+    for (let i = 0, ii = this._thumbnails.length; i < ii; i++) {
       this._thumbnails[i].update(rotation);
     }
   }

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -166,7 +166,6 @@ var PDFViewer = (function pdfViewer() {
         throw new Error('Invalid page number.');
       }
       if (!this.pdfDocument) {
-        this._currentPageNumber = val;
         return;
       }
       // The intent can be to just reset a scroll position and/or scale.
@@ -217,9 +216,9 @@ var PDFViewer = (function pdfViewer() {
      * @param {string} val - The page label.
      */
     set currentPageLabel(val) {
-      var pageNumber = val | 0; // Fallback page number.
+      let pageNumber = val | 0; // Fallback page number.
       if (this._pageLabels) {
-        var i = this._pageLabels.indexOf(val);
+        let i = this._pageLabels.indexOf(val);
         if (i >= 0) {
           pageNumber = i + 1;
         }
@@ -243,8 +242,6 @@ var PDFViewer = (function pdfViewer() {
         throw new Error('Invalid numeric scale');
       }
       if (!this.pdfDocument) {
-        this._currentScale = val;
-        this._currentScaleValue = val !== UNKNOWN_SCALE ? val.toString() : null;
         return;
       }
       this._setScale(val, false);
@@ -262,8 +259,6 @@ var PDFViewer = (function pdfViewer() {
      */
     set currentScaleValue(val) {
       if (!this.pdfDocument) {
-        this._currentScale = isNaN(val) ? UNKNOWN_SCALE : val;
-        this._currentScaleValue = val.toString();
         return;
       }
       this._setScale(val, false);
@@ -283,13 +278,13 @@ var PDFViewer = (function pdfViewer() {
       if (!(typeof rotation === 'number' && rotation % 90 === 0)) {
         throw new Error('Invalid pages rotation angle.');
       }
-      this._pagesRotation = rotation;
-
       if (!this.pdfDocument) {
         return;
       }
-      for (var i = 0, l = this._pages.length; i < l; i++) {
-        var pageView = this._pages[i];
+      this._pagesRotation = rotation;
+
+      for (let i = 0, ii = this._pages.length; i < ii; i++) {
+        let pageView = this._pages[i];
         pageView.update(pageView.scale, rotation);
       }
 


### PR DESCRIPTION
Currently a number of these properties do not work correctly if set *before* calling `setDocument`; please refer to the discussion starting in https://github.com/mozilla/pdf.js/pull/8539#issuecomment-309706629.

Rather than trying to have *some* of these methods working, but not others, it seems much more consistent to simply always require that `setDocument` has been called.

/cc @timvandermeij Since your comment in https://github.com/mozilla/pdf.js/pull/8539#issuecomment-309897649 seems to support doing this.
/cc @yurydelendik I know that https://github.com/mozilla/pdf.js/pull/8539#issuecomment-309706629 is a long read, but can you please check that you're OK with that reasoning and this PR?