### PR TITLE
Allow setting the `rotation` when creating `PDFPageView` and `PDFThumbnailView` instances

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -32,6 +32,7 @@ const TEXT_LAYER_RENDER_DELAY = 200; // ms
  * @property {EventBus} eventBus - The application event bus.
  * @property {number} id - The page unique ID (normally its number).
  * @property {number} scale - The page scale display.
+ * @property {number} rotation - The page rotation angle.
  * @property {PageViewport} defaultViewport - The page viewport.
  * @property {PDFRenderingQueue} renderingQueue - The rendering queue object.
  * @property {IPDFTextLayerFactory} textLayerFactory
@@ -59,8 +60,8 @@ class PDFPageView {
     this.renderingId = 'page' + this.id;
 
     this.pageLabel = null;
-    this.rotation = 0;
     this.scale = options.scale || DEFAULT_SCALE;
+    this.rotation = options.rotation || 0;
     this.viewport = defaultViewport;
     this.pdfPageRotate = defaultViewport.rotation;
     this.hasRestrictedScaling = false;

--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -27,6 +27,7 @@ const THUMBNAIL_WIDTH = 98; // px
  * @typedef {Object} PDFThumbnailViewOptions
  * @property {HTMLDivElement} container - The viewer element.
  * @property {number} id - The thumbnail's unique ID (normally its number).
+ * @property {number} rotation - The thumbnail rotation angle.
  * @property {PageViewport} defaultViewport - The page viewport.
  * @property {IPDFLinkService} linkService - The navigation/linking service.
  * @property {PDFRenderingQueue} renderingQueue - The rendering queue object.
@@ -84,14 +85,15 @@ class PDFThumbnailView {
   /**
    * @param {PDFThumbnailViewOptions} options
    */
-  constructor({ container, id, defaultViewport, linkService, renderingQueue,
-                disableCanvasToImageConversion = false, l10n = NullL10n, }) {
+  constructor({ container, id, rotation, defaultViewport, linkService,
+                renderingQueue, disableCanvasToImageConversion = false,
+                l10n = NullL10n, }) {
     this.id = id;
     this.renderingId = 'thumbnail' + id;
     this.pageLabel = null;
 
     this.pdfPage = null;
-    this.rotation = 0;
+    this.rotation = rotation || 0;
     this.viewport = defaultViewport;
     this.pdfPageRotate = defaultViewport.rotation;
 

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -130,12 +130,13 @@ class PDFThumbnailViewer {
     }
 
     return pdfDocument.getPage(1).then((firstPage) => {
-      let pagesCount = pdfDocument.numPages;
-      let viewport = firstPage.getViewport(1.0);
+      let pagesCount = pdfDocument.numPages, rotation = this.pagesRotation;
+      let viewport = firstPage.getViewport(1.0, rotation);
       for (let pageNum = 1; pageNum <= pagesCount; ++pageNum) {
         let thumbnail = new PDFThumbnailView({
           container: this.container,
           id: pageNum,
+          rotation,
           defaultViewport: viewport.clone(),
           linkService: this.linkService,
           renderingQueue: this.renderingQueue,

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -351,8 +351,8 @@ var PDFViewer = (function pdfViewer() {
       // Fetch a single page so we can get a viewport that will be the default
       // viewport for all pages
       return firstPagePromise.then((pdfPage) => {
-        var scale = this.currentScale;
-        var viewport = pdfPage.getViewport(scale * CSS_UNITS);
+        let scale = this.currentScale, rotation = this.pagesRotation;
+        let viewport = pdfPage.getViewport(scale * CSS_UNITS, rotation);
         for (var pageNum = 1; pageNum <= pagesCount; ++pageNum) {
           var textLayerFactory = null;
           if (!PDFJS.disableTextLayer) {
@@ -363,6 +363,7 @@ var PDFViewer = (function pdfViewer() {
             eventBus: this.eventBus,
             id: pageNum,
             scale,
+            rotation,
             defaultViewport: viewport.clone(),
             renderingQueue: this.renderingQueue,
             textLayerFactory,


### PR DESCRIPTION
Since it's currently possible to provide a custom `scale` when initializing these components, it seems reasonable to add a `rotation` parameter as well.

***Please note:*** Even though PR #8555 will make this technically redundant for the default viewer, it probably makes sense to support `rotation` for general usage with e.g. the [`pageviewer` example](https://github.com/mozilla/pdf.js/blob/master/examples/components/pageviewer.js) anyway.