### PR TITLE
SVG: implement fill and stroke opacity

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -807,6 +807,9 @@ SVGGraphics = (function SVGGraphicsClosure() {
       var color = Util.makeCssRgb(r, g, b);
       this.current.strokeColor = color;
     },
+    setFillAlpha: function SVGGraphics_setFillAlpha(fillAlpha) {
+      this.current.fillAlpha = fillAlpha;
+    },
     setFillRGBColor: function SVGGraphics_setFillRGBColor(r, g, b) {
       var color = Util.makeCssRgb(r, g, b);
       this.current.fillColor = color;
@@ -970,6 +973,9 @@ SVGGraphics = (function SVGGraphicsClosure() {
           case 'Font':
             this.setFont(value);
             break;
+          case 'ca':
+            this.setFillAlpha(value);
+            break;
           default:
             warn('Unimplemented graphic state ' + key);
             break;
@@ -980,6 +986,7 @@ SVGGraphics = (function SVGGraphicsClosure() {
     fill: function SVGGraphics_fill() {
       var current = this.current;
       current.element.setAttributeNS(null, 'fill', current.fillColor);
+      current.element.setAttributeNS(null, 'fill-opacity', current.fillAlpha);
     },
 
     stroke: function SVGGraphics_stroke() {
@@ -989,9 +996,8 @@ SVGGraphics = (function SVGGraphicsClosure() {
     },
 
     eoFill: function SVGGraphics_eoFill() {
-      var current = this.current;
-      current.element.setAttributeNS(null, 'fill', current.fillColor);
-      current.element.setAttributeNS(null, 'fill-rule', 'evenodd');
+      this.current.element.setAttributeNS(null, 'fill-rule', 'evenodd');
+      this.fill();
     },
 
     fillStroke: function SVGGraphics_fillStroke() {

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -803,6 +803,9 @@ SVGGraphics = (function SVGGraphicsClosure() {
     setMiterLimit: function SVGGraphics_setMiterLimit(limit) {
       this.current.miterLimit = limit;
     },
+    setStrokeAlpha: function SVGGraphics_setStrokeAlpha(strokeAlpha) {
+      this.current.strokeAlpha = strokeAlpha;
+    },
     setStrokeRGBColor: function SVGGraphics_setStrokeRGBColor(r, g, b) {
       var color = Util.makeCssRgb(r, g, b);
       this.current.strokeColor = color;
@@ -973,6 +976,9 @@ SVGGraphics = (function SVGGraphicsClosure() {
           case 'Font':
             this.setFont(value);
             break;
+          case 'CA':
+            this.setStrokeAlpha(value);
+            break;
           case 'ca':
             this.setFillAlpha(value);
             break;
@@ -992,6 +998,8 @@ SVGGraphics = (function SVGGraphicsClosure() {
     stroke: function SVGGraphics_stroke() {
       var current = this.current;
       current.element.setAttributeNS(null, 'stroke', current.strokeColor);
+      current.element.setAttributeNS(null, 'stroke-opacity',
+                                     current.strokeAlpha);
       current.element.setAttributeNS(null, 'fill', 'none');
     },
 


### PR DESCRIPTION
Fixes #7764.

To test this with the default viewer, run `PDFViewerApplication.preferences.set('renderer', 'svg');` in the console and refresh the page to use the SVG back-end. To switch back to the canvas back-end after testing, use `PDFViewerApplication.preferences.set('renderer', 'canvas');` .

*Note that we already have test cases for this in the repository, such as `test/pdfs/alphatrans.pdf`.*