### PR TITLE
Fix error when using custom CMapReaderFactory

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -211,6 +211,8 @@ function getDocument(src, pdfDataRangeTransport,
   var params = {};
   var rangeTransport = null;
   var worker = null;
+  var CMapReaderFactory = DOMCMapReaderFactory;
+
   for (var key in source) {
     if (key === 'url' && typeof window !== 'undefined') {
       // The full path is required in the 'url' field.
@@ -237,13 +239,15 @@ function getDocument(src, pdfDataRangeTransport,
               'array-like object is expected in the data property.');
       }
       continue;
+    } else if (key === 'CMapReaderFactory') {
+      CMapReaderFactory = source[key];
+      continue;
     }
     params[key] = source[key];
   }
 
   params.rangeChunkSize = params.rangeChunkSize || DEFAULT_RANGE_CHUNK_SIZE;
   params.ignoreErrors = params.stopAtErrors !== true;
-  var CMapReaderFactory = params.CMapReaderFactory || DOMCMapReaderFactory;
 
   if (params.disableNativeImageDecoder !== undefined) {
     deprecated('parameter disableNativeImageDecoder, ' +


### PR DESCRIPTION
When using a source object on `getDocument()` with a custom `CMapReaderFactory` we end up sending that factory to the worker as part of the message. This causes `postMessage()` to throw because it can't clone a function.

So the param object passed to `_fetchDocument()` shouldn't have that factory as part of his properties.

It's really trivial so I didn't add test but I could build something if you want.