### PR TITLE
Check that the `MessageHandler` isn't already terminated in the `onFailure` handler in `src/core/worker.js` (issue 8584)

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -654,6 +654,8 @@ var WorkerMessageHandler = {
       }
 
       function onFailure(e) {
+        ensureNotTerminated();
+
         if (e instanceof PasswordException) {
           var task = new WorkerTask('PasswordException: response ' + e.code);
           startWorkerTask(task);


### PR DESCRIPTION
All other code-paths already checks that the `MessageHandler` isn't terminated, but apparently `onFailure` was missing that check (compare e.g. with the `onSuccess` function).
From what I can tell, this is only an issue if workers are *disabled*, hence why I didn't bother adding a unit-test.

Fixes #8584.