### PR TITLE
Change `var` to `let`, and use object destructuring, in a couple of previously class converted `web/*.js` files

### DIFF
--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -31,13 +31,14 @@ class AnnotationLayerBuilder {
   /**
    * @param {AnnotationLayerBuilderOptions} options
    */
-  constructor(options) {
-    this.pageDiv = options.pageDiv;
-    this.pdfPage = options.pdfPage;
-    this.renderInteractiveForms = options.renderInteractiveForms;
-    this.linkService = options.linkService;
-    this.downloadManager = options.downloadManager;
-    this.l10n = options.l10n || NullL10n;
+  constructor({ pageDiv, pdfPage, linkService, downloadManager,
+                renderInteractiveForms = false, l10n = NullL10n, }) {
+    this.pageDiv = pageDiv;
+    this.pdfPage = pdfPage;
+    this.linkService = linkService;
+    this.downloadManager = downloadManager;
+    this.renderInteractiveForms = renderInteractiveForms;
+    this.l10n = l10n;
 
     this.div = null;
   }
@@ -48,7 +49,7 @@ class AnnotationLayerBuilder {
    */
   render(viewport, intent = 'display') {
     this.pdfPage.getAnnotations({ intent, }).then((annotations) => {
-      var parameters = {
+      let parameters = {
         viewport: viewport.clone({ dontFlip: true, }),
         div: this.div,
         annotations,
@@ -68,7 +69,6 @@ class AnnotationLayerBuilder {
         if (annotations.length === 0) {
           return;
         }
-
         this.div = document.createElement('div');
         this.div.className = 'annotationLayer';
         this.pageDiv.appendChild(this.div);
@@ -99,8 +99,7 @@ class DefaultAnnotationLayerFactory {
    * @param {IL10n} l10n
    * @returns {AnnotationLayerBuilder}
    */
-  createAnnotationLayerBuilder(pageDiv, pdfPage,
-                               renderInteractiveForms = false,
+  createAnnotationLayerBuilder(pageDiv, pdfPage, renderInteractiveForms = false,
                                l10n = NullL10n) {
     return new AnnotationLayerBuilder({
       pageDiv,

--- a/web/password_prompt.js
+++ b/web/password_prompt.js
@@ -87,7 +87,7 @@ class PasswordPrompt {
   }
 
   verify() {
-    var password = this.input.value;
+    let password = this.input.value;
     if (password && password.length > 0) {
       this.close();
       return this.updateCallback(password);

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -231,15 +231,15 @@ class PDFDocumentProperties {
     // Get all elements from the PDF date string.
     // JavaScript's `Date` object expects the month to be between
     // 0 and 11 instead of 1 and 12, so we're correcting for this.
-    var year = parseInt(dateToParse.substring(0, 4), 10);
-    var month = parseInt(dateToParse.substring(4, 6), 10) - 1;
-    var day = parseInt(dateToParse.substring(6, 8), 10);
-    var hours = parseInt(dateToParse.substring(8, 10), 10);
-    var minutes = parseInt(dateToParse.substring(10, 12), 10);
-    var seconds = parseInt(dateToParse.substring(12, 14), 10);
-    var utRel = dateToParse.substring(14, 15);
-    var offsetHours = parseInt(dateToParse.substring(15, 17), 10);
-    var offsetMinutes = parseInt(dateToParse.substring(18, 20), 10);
+    let year = parseInt(dateToParse.substring(0, 4), 10);
+    let month = parseInt(dateToParse.substring(4, 6), 10) - 1;
+    let day = parseInt(dateToParse.substring(6, 8), 10);
+    let hours = parseInt(dateToParse.substring(8, 10), 10);
+    let minutes = parseInt(dateToParse.substring(10, 12), 10);
+    let seconds = parseInt(dateToParse.substring(12, 14), 10);
+    let utRel = dateToParse.substring(14, 15);
+    let offsetHours = parseInt(dateToParse.substring(15, 17), 10);
+    let offsetMinutes = parseInt(dateToParse.substring(18, 20), 10);
 
     // As per spec, utRel = 'Z' means equal to universal time.
     // The other cases ('-' and '+') have to be handled here.
@@ -252,9 +252,9 @@ class PDFDocumentProperties {
     }
 
     // Return the new date format from the user's locale.
-    var date = new Date(Date.UTC(year, month, day, hours, minutes, seconds));
-    var dateString = date.toLocaleDateString();
-    var timeString = date.toLocaleTimeString();
+    let date = new Date(Date.UTC(year, month, day, hours, minutes, seconds));
+    let dateString = date.toLocaleDateString();
+    let timeString = date.toLocaleTimeString();
     return this.l10n.get('document_properties_date_string',
                          { date: dateString, time: timeString, },
                          '{{date}}, {{time}}');

--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -103,9 +103,9 @@ class PDFFindBar {
   }
 
   updateUIState(state, previous, matchCount) {
-    var notFound = false;
-    var findMsg = '';
-    var status = '';
+    let notFound = false;
+    let findMsg = '';
+    let status = '';
 
     switch (state) {
       case FindState.FOUND:
@@ -206,8 +206,8 @@ class PDFFindBar {
     // wrapped). Here we detect and fix that.
     this.bar.classList.remove('wrapContainers');
 
-    var findbarHeight = this.bar.clientHeight;
-    var inputContainerHeight = this.bar.firstElementChild.clientHeight;
+    let findbarHeight = this.bar.clientHeight;
+    let inputContainerHeight = this.bar.firstElementChild.clientHeight;
 
     if (findbarHeight > inputContainerHeight) {
       // The findbar is taller than the input container, which means that

--- a/web/pdf_outline_viewer.js
+++ b/web/pdf_outline_viewer.js
@@ -35,13 +35,13 @@ class PDFOutlineViewer {
   /**
    * @param {PDFOutlineViewerOptions} options
    */
-  constructor(options) {
+  constructor({ container, linkService, eventBus, }) {
     this.outline = null;
     this.lastToggleIsShow = true;
 
-    this.container = options.container;
-    this.linkService = options.linkService;
-    this.eventBus = options.eventBus;
+    this.container = container;
+    this.linkService = linkService;
+    this.eventBus = eventBus;
   }
 
   reset() {
@@ -77,7 +77,7 @@ class PDFOutlineViewer {
       });
       return;
     }
-    var destination = item.dest;
+    let destination = item.dest;
 
     element.href = this.linkService.getDestinationHash(destination);
     element.onclick = () => {
@@ -92,7 +92,7 @@ class PDFOutlineViewer {
    * @private
    */
   _setStyles(element, item) {
-    var styleStr = '';
+    let styleStr = '';
     if (item.bold) {
       styleStr += 'font-weight: bold;';
     }
@@ -112,14 +112,14 @@ class PDFOutlineViewer {
    * @private
    */
   _addToggleButton(div) {
-    var toggler = document.createElement('div');
+    let toggler = document.createElement('div');
     toggler.className = 'outlineItemToggler';
     toggler.onclick = (evt) => {
       evt.stopPropagation();
       toggler.classList.toggle('outlineItemsHidden');
 
       if (evt.shiftKey) {
-        var shouldShowAll = !toggler.classList.contains('outlineItemsHidden');
+        let shouldShowAll = !toggler.classList.contains('outlineItemsHidden');
         this._toggleOutlineItem(div, shouldShowAll);
       }
     };
@@ -137,8 +137,8 @@ class PDFOutlineViewer {
    */
   _toggleOutlineItem(root, show) {
     this.lastToggleIsShow = show;
-    var togglers = root.querySelectorAll('.outlineItemToggler');
-    for (var i = 0, ii = togglers.length; i < ii; ++i) {
+    let togglers = root.querySelectorAll('.outlineItemToggler');
+    for (let i = 0, ii = togglers.length; i < ii; ++i) {
       togglers[i].classList[show ? 'remove' : 'add']('outlineItemsHidden');
     }
   }
@@ -156,32 +156,31 @@ class PDFOutlineViewer {
   /**
    * @param {PDFOutlineViewerRenderParameters} params
    */
-  render(params = {}) {
-    var outline = params.outline || null;
-    var outlineCount = 0;
+  render({ outline, }) {
+    let outlineCount = 0;
 
     if (this.outline) {
       this.reset();
     }
-    this.outline = outline;
+    this.outline = outline || null;
 
     if (!outline) {
       this._dispatchEvent(outlineCount);
       return;
     }
 
-    var fragment = document.createDocumentFragment();
-    var queue = [{ parent: fragment, items: this.outline, }];
-    var hasAnyNesting = false;
+    let fragment = document.createDocumentFragment();
+    let queue = [{ parent: fragment, items: this.outline, }];
+    let hasAnyNesting = false;
     while (queue.length > 0) {
-      var levelData = queue.shift();
-      for (var i = 0, len = levelData.items.length; i < len; i++) {
-        var item = levelData.items[i];
+      let levelData = queue.shift();
+      for (let i = 0, len = levelData.items.length; i < len; i++) {
+        let item = levelData.items[i];
 
-        var div = document.createElement('div');
+        let div = document.createElement('div');
         div.className = 'outlineItem';
 
-        var element = document.createElement('a');
+        let element = document.createElement('a');
         this._bindLink(element, item);
         this._setStyles(element, item);
         element.textContent =
@@ -193,7 +192,7 @@ class PDFOutlineViewer {
           hasAnyNesting = true;
           this._addToggleButton(div);
 
-          var itemsDiv = document.createElement('div');
+          let itemsDiv = document.createElement('div');
           itemsDiv.className = 'outlineItems';
           div.appendChild(itemsDiv);
           queue.push({ parent: itemsDiv, items: item.items, });

--- a/web/pdf_presentation_mode.js
+++ b/web/pdf_presentation_mode.js
@@ -43,12 +43,12 @@ class PDFPresentationMode {
   /**
    * @param {PDFPresentationModeOptions} options
    */
-  constructor(options) {
-    this.container = options.container;
-    this.viewer = options.viewer || options.container.firstElementChild;
-    this.pdfViewer = options.pdfViewer;
-    this.eventBus = options.eventBus;
-    var contextMenuItems = options.contextMenuItems || null;
+  constructor({ container, viewer = null, pdfViewer, eventBus,
+                contextMenuItems = null, }) {
+    this.container = container;
+    this.viewer = viewer || container.firstElementChild;
+    this.pdfViewer = pdfViewer;
+    this.eventBus = eventBus;
 
     this.active = false;
     this.args = null;
@@ -119,9 +119,9 @@ class PDFPresentationMode {
 
     evt.preventDefault();
 
-    var delta = normalizeWheelEventDelta(evt);
-    var currentTime = (new Date()).getTime();
-    var storedTime = this.mouseScrollTimeStamp;
+    let delta = normalizeWheelEventDelta(evt);
+    let currentTime = (new Date()).getTime();
+    let storedTime = this.mouseScrollTimeStamp;
 
     // If we've already switched page, avoid accidentally switching again.
     if (currentTime > storedTime &&
@@ -136,9 +136,9 @@ class PDFPresentationMode {
     this.mouseScrollDelta += delta;
 
     if (Math.abs(this.mouseScrollDelta) >= PAGE_SWITCH_THRESHOLD) {
-      var totalDelta = this.mouseScrollDelta;
+      let totalDelta = this.mouseScrollDelta;
       this._resetMouseScrollState();
-      var success = totalDelta > 0 ? this._goToPreviousPage()
+      let success = totalDelta > 0 ? this._goToPreviousPage()
                                    : this._goToNextPage();
       if (success) {
         this.mouseScrollTimeStamp = currentTime;
@@ -155,7 +155,7 @@ class PDFPresentationMode {
    * @private
    */
   _goToPreviousPage() {
-    var page = this.pdfViewer.currentPageNumber;
+    let page = this.pdfViewer.currentPageNumber;
     // If we're at the first page, we don't need to do anything.
     if (page <= 1) {
       return false;
@@ -168,7 +168,7 @@ class PDFPresentationMode {
    * @private
    */
   _goToNextPage() {
-    var page = this.pdfViewer.currentPageNumber;
+    let page = this.pdfViewer.currentPageNumber;
     // If we're at the last page, we don't need to do anything.
     if (page >= this.pdfViewer.pagesCount) {
       return false;
@@ -249,7 +249,7 @@ class PDFPresentationMode {
    * @private
    */
   _exit() {
-    var page = this.pdfViewer.currentPageNumber;
+    let page = this.pdfViewer.currentPageNumber;
     this.container.classList.remove(ACTIVE_SELECTOR);
 
     // Ensure that the correct page is scrolled into view when exiting
@@ -283,7 +283,7 @@ class PDFPresentationMode {
     if (evt.button === 0) {
       // Enable clicking of links in presentation mode. Note: only links
       // pointing to destinations in the current PDF document work.
-      var isInternalLink = (evt.target.href &&
+      let isInternalLink = (evt.target.href &&
                             evt.target.classList.contains('internalLink'));
       if (!isInternalLink) {
         // Unless an internal link was clicked, advance one page.
@@ -378,10 +378,10 @@ class PDFPresentationMode {
         if (this.touchSwipeState === null) {
           return;
         }
-        var delta = 0;
-        var dx = this.touchSwipeState.endX - this.touchSwipeState.startX;
-        var dy = this.touchSwipeState.endY - this.touchSwipeState.startY;
-        var absAngle = Math.abs(Math.atan2(dy, dx));
+        let delta = 0;
+        let dx = this.touchSwipeState.endX - this.touchSwipeState.startX;
+        let dy = this.touchSwipeState.endY - this.touchSwipeState.startY;
+        let absAngle = Math.abs(Math.atan2(dy, dx));
         if (Math.abs(dx) > SWIPE_MIN_DISTANCE_THRESHOLD &&
             (absAngle <= SWIPE_ANGLE_THRESHOLD ||
              absAngle >= (Math.PI - SWIPE_ANGLE_THRESHOLD))) {

--- a/web/pdf_sidebar.js
+++ b/web/pdf_sidebar.js
@@ -138,7 +138,7 @@ class PDFSidebar {
       // immediately closing it would be bad UX.
       return;
     }
-    var isViewPreserved = (view === this.visibleView);
+    let isViewPreserved = (view === this.visibleView);
     this.switchView(view, /* forceOpen */ true);
 
     if (isViewPreserved) {
@@ -159,8 +159,8 @@ class PDFSidebar {
       this.close();
       return;
     }
-    var isViewChanged = (view !== this.active);
-    var shouldForceRendering = false;
+    let isViewChanged = (view !== this.active);
+    let shouldForceRendering = false;
 
     switch (view) {
       case SidebarView.THUMBS:
@@ -290,19 +290,18 @@ class PDFSidebar {
    * @private
    */
   _updateThumbnailViewer() {
-    var pdfViewer = this.pdfViewer;
-    var thumbnailViewer = this.pdfThumbnailViewer;
+    let { pdfViewer, pdfThumbnailViewer, } = this;
 
     // Use the rendered pages to set the corresponding thumbnail images.
-    var pagesCount = pdfViewer.pagesCount;
-    for (var pageIndex = 0; pageIndex < pagesCount; pageIndex++) {
-      var pageView = pdfViewer.getPageView(pageIndex);
+    let pagesCount = pdfViewer.pagesCount;
+    for (let pageIndex = 0; pageIndex < pagesCount; pageIndex++) {
+      let pageView = pdfViewer.getPageView(pageIndex);
       if (pageView && pageView.renderingState === RenderingStates.FINISHED) {
-        var thumbnailView = thumbnailViewer.getThumbnail(pageIndex);
+        let thumbnailView = pdfThumbnailViewer.getThumbnail(pageIndex);
         thumbnailView.setImage(pageView);
       }
     }
-    thumbnailViewer.scrollThumbnailIntoView(pdfViewer.currentPageNumber);
+    pdfThumbnailViewer.scrollThumbnailIntoView(pdfViewer.currentPageNumber);
   }
 
   /**
@@ -347,7 +346,7 @@ class PDFSidebar {
       return;
     }
 
-    var removeNotification = (view) => {
+    let removeNotification = (view) => {
       switch (view) {
         case SidebarView.OUTLINE:
           this.outlineButton.classList.remove(UI_NOTIFICATION_CLASS);
@@ -407,7 +406,7 @@ class PDFSidebar {
 
     // Disable/enable views.
     this.eventBus.on('outlineloaded', (evt) => {
-      var outlineCount = evt.outlineCount;
+      let outlineCount = evt.outlineCount;
 
       this.outlineButton.disabled = !outlineCount;
 
@@ -421,7 +420,7 @@ class PDFSidebar {
     });
 
     this.eventBus.on('attachmentsloaded', (evt) => {
-      var attachmentsCount = evt.attachmentsCount;
+      let attachmentsCount = evt.attachmentsCount;
 
       this.attachmentsButton.disabled = !attachmentsCount;
 

--- a/web/view_history.js
+++ b/web/view_history.js
@@ -30,16 +30,16 @@ class ViewHistory {
     this.cacheSize = cacheSize;
 
     this._initializedPromise = this._readFromStorage().then((databaseStr) => {
-      var database = JSON.parse(databaseStr || '{}');
+      let database = JSON.parse(databaseStr || '{}');
       if (!('files' in database)) {
         database.files = [];
       }
       if (database.files.length >= this.cacheSize) {
         database.files.shift();
       }
-      var index;
-      for (var i = 0, length = database.files.length; i < length; i++) {
-        var branch = database.files[i];
+      let index;
+      for (let i = 0, length = database.files.length; i < length; i++) {
+        let branch = database.files[i];
         if (branch.fingerprint === this.fingerprint) {
           index = i;
           break;
@@ -55,7 +55,7 @@ class ViewHistory {
 
   _writeToStorage() {
     return new Promise((resolve) => {
-      var databaseStr = JSON.stringify(this.database);
+      let databaseStr = JSON.stringify(this.database);
 
       if (typeof PDFJSDev !== 'undefined' &&
           PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
@@ -73,16 +73,16 @@ class ViewHistory {
           PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
         resolve(sessionStorage.getItem('pdfjs.history'));
       } else {
-        var value = localStorage.getItem('pdfjs.history');
+        let value = localStorage.getItem('pdfjs.history');
 
         // TODO: Remove this key-name conversion after a suitable time-frame.
         // Note that we only remove the old 'database' entry if it looks like
         // it was created by PDF.js, to avoid removing someone else's data.
         if (!value) {
-          var databaseStr = localStorage.getItem('database');
+          let databaseStr = localStorage.getItem('database');
           if (databaseStr) {
             try {
-              var database = JSON.parse(databaseStr);
+              let database = JSON.parse(databaseStr);
               if (typeof database.files[0].fingerprint === 'string') {
                 localStorage.setItem('pdfjs.history', databaseStr);
                 localStorage.removeItem('database');
@@ -105,7 +105,7 @@ class ViewHistory {
 
   setMultiple(properties) {
     return this._initializedPromise.then(() => {
-      for (var name in properties) {
+      for (let name in properties) {
         this.file[name] = properties[name];
       }
       return this._writeToStorage();
@@ -114,17 +114,17 @@ class ViewHistory {
 
   get(name, defaultValue) {
     return this._initializedPromise.then(() => {
-      var val = this.file[name];
+      let val = this.file[name];
       return val !== undefined ? val : defaultValue;
     });
   }
 
   getMultiple(properties) {
     return this._initializedPromise.then(() => {
-      var values = Object.create(null);
+      let values = Object.create(null);
 
-      for (var name in properties) {
-        var val = this.file[name];
+      for (let name in properties) {
+        let val = this.file[name];
         values[name] = val !== undefined ? val : properties[name];
       }
       return values;


### PR DESCRIPTION
Note that these files were among the first to be converted to ES6 classes, so it probably makes sense to do another pass to bring them inline with the most recent ES6 conversions.

*Edit:* If there would have been any scoping errors from the `var` -> `let` conversion, the `no-undef` ESLint rule would have caught that, which should provide some assurance when reviewing.