### PR TITLE
Fixes wrong structure of fullReader.read() result.

### DIFF
--- a/src/core/network.js
+++ b/src/core/network.js
@@ -491,7 +491,7 @@ PDFNetworkStreamFullRequestReader.prototype = {
     }
     if (this._cachedChunks.length > 0) {
       var chunk = this._cachedChunks.shift();
-      return Promise.resolve(chunk);
+      return Promise.resolve({ value: chunk, done: false, });
     }
     if (this._done) {
       return Promise.resolve({ value: undefined, done: true, });


### PR DESCRIPTION
This PR fixes a minor issue of caching chunks and retuning in `fullReader.read()` method of network.js file. We are pushing `chunk` into [_cachedChunks](https://github.com/mozilla/pdf.js/blob/master/src/core/network.js#L426), and returning as is in read() method, so `fullReader.read()` gives `ArrayBuffer()` instead of `{ value:..., done:..., }`.

If we force to do caching instead of returning chunk directly from [here](https://github.com/mozilla/pdf.js/blob/master/src/core/network.js#L424). It will make [network_spec.js](https://github.com/mozilla/pdf.js/blob/master/test/unit/network_spec.js#L24) test to fail, with `Error: result.value is undefined`.