### PR TITLE
Ensure that `PDFFindBar._adjustWidth` is called in all situations where the width of the findbar might have changed

### DIFF
--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -151,15 +151,15 @@ class PDFFindBar {
       return; // No UI control is provided.
     }
 
-    // If there are no matches, hide the counter.
     if (!matchCount) {
+      // If there are no matches, hide and reset the counter.
       this.findResultsCount.classList.add('hidden');
-      return;
+      this.findResultsCount.textContent = '';
+    } else {
+      // Update and show the match counter.
+      this.findResultsCount.textContent = matchCount.toLocaleString();
+      this.findResultsCount.classList.remove('hidden');
     }
-
-    // Create and show the match counter.
-    this.findResultsCount.textContent = matchCount.toLocaleString();
-    this.findResultsCount.classList.remove('hidden');
   }
 
   open() {

--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -140,10 +140,10 @@ class PDFFindBar {
     this.findField.setAttribute('data-status', status);
     Promise.resolve(findMsg).then((msg) => {
       this.findMsg.textContent = msg;
+      this._adjustWidth();
     });
 
     this.updateResultsCount(matchCount);
-    this._adjustWidth();
   }
 
   updateResultsCount(matchCount) {
@@ -160,6 +160,9 @@ class PDFFindBar {
       this.findResultsCount.textContent = matchCount.toLocaleString();
       this.findResultsCount.classList.remove('hidden');
     }
+    // Since `updateResultsCount` may be called from `PDFFindController`,
+    // ensure that the width of the findbar is always updated correctly.
+    this._adjustWidth();
   }
 
   open() {


### PR DESCRIPTION
 - Actually reset the `findResultsCount` label, in addition to hiding it, when no matches are found

   Currently we're *only* hiding the label, but not actually resetting it until a new match is found.
Obviously it's being hidden, but it seems that it really ought to be completely reset as well (since e.g. `PDFFindBar.reset` won't technically reset *all* state otherwise).

 - Ensure that `PDFFindBar._adjustWidth` is called in all situations where the width of the findbar might have changed

   After PR #8394, where the l10n service was converted to be asynchronous, we're no longer calling `_adjustWidth` after updating the `findMsg` label. Hence it's currently possible that the width of the findbar won't be correct. The solution is simple though, just call `_adjustWidth` after the `findMsg` label has been (asynchronously) updated.

   Another existing issue, which was an oversight in PR #8132, is that `PDFFindBar.updateResultsCount` may be called directly from `PDFFindController`. In that case, we're not calling `_adjustWidth` at all, which means that the findbar may also not have the correct width.
The simple solution here is to always call `_adjustWidth` at the end of `updateResultsCount` (which is why we no longer need the `_adjustWidth` call at the end of `updateUIState`).