### PR TITLE
Fix a stupid spelling error in the `ASCII85Decode` name in `Parser.makeInlineImage` (issue 8613)

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -373,7 +373,7 @@ var Parser = (function ParserClosure() {
       var startPos = stream.pos, length, i, ii;
       if (filterName === 'DCTDecode' || filterName === 'DCT') {
         length = this.findDCTDecodeInlineStreamEnd(stream);
-      } else if (filterName === 'ASCII85Decide' || filterName === 'A85') {
+      } else if (filterName === 'ASCII85Decode' || filterName === 'A85') {
         length = this.findASCII85DecodeInlineStreamEnd(stream);
       } else if (filterName === 'ASCIIHexDecode' || filterName === 'AHx') {
         length = this.findASCIIHexDecodeInlineStreamEnd(stream);

--- a/test/pdfs/issue8613.pdf.link
+++ b/test/pdfs/issue8613.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/1125062/Factuur.9.Schilderwerk.Dr.Stiemensweg.22-24.Dichterbij.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2945,6 +2945,13 @@
        "type": "eq",
        "about": "Inline image with ASCII85Decode filter."
     },
+    {  "id": "issue8613",
+       "file": "pdfs/issue8613.pdf",
+       "md5": "bc7ad2db75710aa9916c5769e0c02123",
+       "rounds": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "bug1108753",
        "file": "pdfs/bug1108753.pdf",
        "md5": "a7aaf92d55b4602afb0ca3d75198b56b",


### PR DESCRIPTION
This is a trivial follow-up to PR #5383, and it's a bit strange that this has been wrong since late 2014 without anyone noticing (maybe because inline images aren't too common).
So, apparently code works better if you actually spell correctly, who knew ;-)

Fixes #8613.