### PR TITLE
Remove the scale-not-initialized hack from `webViewerResize` (in app.js)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1790,19 +1790,18 @@ function webViewerUpdateViewarea(evt) {
 }
 
 function webViewerResize() {
-  let currentScaleValue = PDFViewerApplication.pdfViewer.currentScaleValue;
+  let { pdfDocument, pdfViewer, } = PDFViewerApplication;
+  if (!pdfDocument) {
+    return;
+  }
+  let currentScaleValue = pdfViewer.currentScaleValue;
   if (currentScaleValue === 'auto' ||
       currentScaleValue === 'page-fit' ||
       currentScaleValue === 'page-width') {
     // Note: the scale is constant for 'page-actual'.
-    PDFViewerApplication.pdfViewer.currentScaleValue = currentScaleValue;
-  } else if (!currentScaleValue) {
-    // Normally this shouldn't happen, but if the scale wasn't initialized
-    // we set it to the default value in order to prevent any issues.
-    // (E.g. the document being rendered with the wrong scale on load.)
-    PDFViewerApplication.pdfViewer.currentScaleValue = DEFAULT_SCALE_VALUE;
+    pdfViewer.currentScaleValue = currentScaleValue;
   }
-  PDFViewerApplication.pdfViewer.update();
+  pdfViewer.update();
 }
 
 function webViewerHashchange(evt) {

--- a/web/app.js
+++ b/web/app.js
@@ -985,6 +985,12 @@ let PDFViewerApplication = {
 
         pdfViewer.currentScaleValue = pdfViewer.currentScaleValue;
         this.setInitialView(initialParams.hash);
+      }).then(function() {
+        // At this point, rendering of the initial page(s) should always have
+        // started (and may even have completed).
+        // To prevent any future issues, e.g. the document being completely
+        // blank on load, always trigger rendering here.
+        pdfViewer.update();
       });
     });
 


### PR DESCRIPTION
 - Remove the scale-not-initialized hack from `webViewerResize` (in app.js)

   Since we no longer, after PR #8555, allow changing the scale until the document is loaded, that hack is no longer necessary. Furthermore, no part of that event handling function needs to run unless a document is loaded.

   The reason that this hack was initially added, is that previously the `ViewHistory` might be updated *before* `PDFViewerApplication.setInitialView` had run (in some cases leading to incorrect inital document scale). Since that is no longer possible, this is now dead code.


- Ensure that the document is rendered on load, no matter what happens, by always calling `PDFViewer.update` *after* the initial position has been set

