### PR TITLE
Bump minimum eslint version to 3.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "escodegen": "^1.8.0",
-    "eslint": "^3.11.1",
+    "eslint": "^3.19.0",
     "eslint-plugin-mozilla": "^0.2.47",
     "gulp": "^3.9.1",
     "gulp-rename": "^1.2.2",


### PR DESCRIPTION
The previously referenced eslint version is not compatible with our code base.
For example, rule "prefer-promise-reject-errors" requires 3.14.0, while package.json specifies `^3.11.1`.