### PR TITLE
Use the Width/Height of image dict in JpegStream

### DIFF
--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -871,6 +871,45 @@ var PredictorStream = (function PredictorStreamClosure() {
  * DecodeStreams.
  */
 var JpegStream = (function JpegStreamClosure() {
+  /**
+   * Ensures that the width/height of the JPEG file match the given parameters.
+   *
+   * The relevant parts of the JPEG format are documented at section B2.2 of
+   * https://www.w3.org/Graphics/JPEG/itu-t81.pdf
+  */
+  function setJpegDimensions(bytes, width, height) {
+    function getUint16(offset) {
+      return (bytes[offset] << 8) | bytes[offset + 1];
+    }
+    function setUint16(offset, value) {
+      bytes[offset] = (value >> 8) & 0xFF;
+      bytes[offset + 1] = value & 0xFF;
+    }
+    if (getUint16(0) !== 0xFFD8) {
+      return;  // Invalid JPEG header.
+    }
+    var i = 2;  // The segments start right after the leading 0xFFD8.
+    // The minimum size of a SOF frame is 10.
+    var maxIndex = bytes.length - 10;
+    while (i < maxIndex) {
+      if (bytes[i] !== 0xFF) {
+        return;  // Invalid start of SOF marker.
+      }
+      var marker = bytes[i + 1];
+      if (marker === 0xC0 || marker === 0xC2) { // SOF0 or SOF2
+        if (getUint16(i + 5) !== height) {
+          setUint16(i + 5, height);
+        }
+        if (getUint16(i + 7) !== width) {
+          setUint16(i + 7, width);
+        }
+      }
+      // Advance to the next frame marker.
+      i += getUint16(i + 2) + 2;
+    }
+    return bytes;
+  }
+
   function JpegStream(stream, maybeLength, dict, params) {
     // Some images may contain 'junk' before the SOI (start-of-image) marker.
     // Note: this seems to mainly affect inline images.
@@ -894,7 +933,13 @@ var JpegStream = (function JpegStreamClosure() {
   Object.defineProperty(JpegStream.prototype, 'bytes', {
     get: function JpegStream_bytes() {
       // If this.maybeLength is null, we'll get the entire stream.
-      return shadow(this, 'bytes', this.stream.getBytes(this.maybeLength));
+      var bytes = this.stream.getBytes(this.maybeLength);
+      var width = this.dict.get('Width', 'W');
+      var height = this.dict.get('Height', 'H');
+      if (width && isInt(width) && height && isInt(height)) {
+        setJpegDimensions(bytes, width, height);
+      }
+      return shadow(this, 'bytes', bytes);
     },
     configurable: true,
   });

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -115,6 +115,7 @@
 !alphatrans.pdf
 !devicen.pdf
 !cmykjpeg.pdf
+!jpeg-width-height-mismatch.pdf
 !issue840.pdf
 !issue4402_reduced.pdf
 !issue845r.pdf

--- a/test/pdfs/jpeg-width-height-mismatch.pdf
+++ b/test/pdfs/jpeg-width-height-mismatch.pdf
@@ -1,0 +1,62 @@
+%PDF-1.1
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+2 0 obj
+<</Type/Pages/Count 1/Kids[3 0 R]/MediaBox [0 0 200 100]>>
+endobj
+3 0 obj
+<<
+ /Type/Page
+ /Parent 2 0 R
+ /Resources <<
+  /XObject << /SomeImage 4 0 R >>
+ >>
+ /Contents 5 0 R
+>>
+endobj
+4 0 obj
+<<
+ /Type/XObject
+ /Subtype/Image
+ /Width 1
+ /Height 1
+ /ColorSpace/DeviceRGB
+ /BitsPerComponent 8
+ /Length 580
+ /Filter [ /ASCIIHexDecode /DCTDecode ]
+>>
+% Created a 1x1 red image, and then changed the width & height to be very large (65535x65535).
+% convert -size 1x1 xc:red jpeg:- | sed 's/\(\xff\xc0...\)..../\1\xff\xff\xff\xff/' | xxd -p -c40
+stream
+ffd8ffe000104a46494600010100000100010000ffdb004300030202020202030202020303030304
+060404040404080606050609080a0a090809090a0c0f0c0a0b0e0b09090d110d0e0f101011100a0c
+12131210130f101010ffdb00430103030304030408040408100b090b101010101010101010101010
+1010101010101010101010101010101010101010101010101010101010101010101010101010ffc0
+001108ffffffff03011100021101031101ffc40014000100000000000000000000000000000008ff
+c40014100100000000000000000000000000000000ffc40015010101000000000000000000000000
+00000709ffc40014110100000000000000000000000000000000ffda000c03010002110311003f00
+3a03154dffd9
+endstream
+endobj
+5 0 obj
+<</Length 31>>
+% A red rectangle covering the bottom-left quarter of the page.
+stream
+100 0 0 50 0 0 cm
+/SomeImage Do
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000008 00000 n 
+0000000054 00000 n 
+0000000128 00000 n 
+0000000246 00000 n 
+0000001206 00000 n 
+trailer
+<</Root 1 0 R/Size 6>>
+startxref
+1349
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1052,6 +1052,13 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "jpeg-width-height-mismatch",
+       "file": "pdfs/jpeg-width-height-mismatch.pdf",
+       "md5": "d6ac185a52454913d1c2c81998b365ef",
+       "link": false,
+       "rounds": 1,
+       "type": "eq"
+    },
     {  "id": "issue4402_reduced",
        "file": "pdfs/issue4402_reduced.pdf",
        "md5": "6cc7e61a581889eec3ed7402d87161c4",


### PR DESCRIPTION
This patch provides a work-around that fixes #8614.