### PR TITLE
[DO NOT MERGE] Use `src/core/jpg.js` for all JPEG image decoding

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -358,6 +358,7 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
           PDFJS.getDocument({
             url: absoluteUrl,
             password: task.password,
+            nativeImageDecoderSupport: 'none',
           }).then((doc) => {
             task.pdfDoc = doc;
             this._nextPage(task, failure);


### PR DESCRIPTION
This is only intended to compare the functionality/quality of `jpg.js` with the native browser decoding of JPEG images, to see if there's any obvious features missing from `jpg.js`.

/cc @brendandahl This is inspired by your comment in https://github.com/mozilla/pdf.js/pull/6984#issuecomment-184778220.