### PR TITLE
In `src/core/jpg.js`, ensure that the Adobe JPEG marker always takes precedence, even when the color transform code is zero

### DIFF
--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -958,12 +958,13 @@ var JpegImage = (function JpegImageClosure() {
       return data;
     },
 
-    _isColorConversionNeeded: function isColorConversionNeeded() {
-      if (this.adobe && this.adobe.transformCode) {
-        // The adobe transform marker overrides any previous setting
-        return true;
-      } else if (this.numComponents === 3) {
-        if (!this.adobe && this.colorTransform === 0) {
+    _isColorConversionNeeded() {
+      if (this.adobe) {
+        // The adobe transform marker overrides any previous setting.
+        return !!this.adobe.transformCode;
+      }
+      if (this.numComponents === 3) {
+        if (this.colorTransform === 0) {
           // If the Adobe transform marker is not present and the image
           // dictionary has a 'ColorTransform' entry, explicitly set to `0`,
           // then the colours should *not* be transformed.
@@ -972,7 +973,7 @@ var JpegImage = (function JpegImageClosure() {
         return true;
       }
       // `this.numComponents !== 3`
-      if (!this.adobe && this.colorTransform === 1) {
+      if (this.colorTransform === 1) {
         // If the Adobe transform marker is not present and the image
         // dictionary has a 'ColorTransform' entry, explicitly set to `1`,
         // then the colours should be transformed.

--- a/test/driver.js
+++ b/test/driver.js
@@ -358,6 +358,7 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
           PDFJS.getDocument({
             url: absoluteUrl,
             password: task.password,
+            nativeImageDecoderSupport: task.nativeImageDecoderSupport,
           }).then((doc) => {
             task.pdfDoc = doc;
             this._nextPage(task, failure);

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -3378,6 +3378,15 @@
        "link": true,
        "type": "eq"
     },
+    {  "id": "issue4926-built-in-jpg",
+       "file": "pdfs/issue4926.pdf",
+       "md5": "ed881c8ea2f9bc4be94ecb7f2b2c149b",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq",
+       "nativeImageDecoderSupport": "none"
+    },
     {  "id": "issue5592",
        "file": "pdfs/issue5592.pdf",
        "md5": "a0750f95afa80c880f7966df7062616c",


### PR DESCRIPTION
 - Add support for the `nativeImageDecoderSupport` parameter, to force JPEG image decoding using `src/core/jpg.js`, when running the reference tests

 - In `src/core/jpg.js`, ensure that the Adobe JPEG marker always takes precedence, even when the color transform code is zero

   According to the PDF specification, please see http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#G6.2394361, if an Adobe JPEG marker is present it should always take precedence. This even seem to be consistent with the existing comment that is present in the code.
Hence it seems reasonable to interpret `transformCode === 0` as no color conversion being necessary.

   Fixes the rendering of page 1 in `issue-4926` (from the test-suite), when the built-in `src/core/jpg.js` image decoder is used.






