### PR TITLE
Check for undefined

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1403,10 +1403,10 @@ if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
   const HOSTED_VIEWER_ORIGINS = ['null',
     'http://mozilla.github.io', 'https://mozilla.github.io'];
   validateFileURL = function validateFileURL(file) {
+    if (file === undefined) {
+      return;
+    }
     try {
-      if (file === undefined) {
-        return;
-      }
       let viewerOrigin = new URL(window.location.href).origin || 'null';
       if (HOSTED_VIEWER_ORIGINS.indexOf(viewerOrigin) >= 0) {
         // Hosted or local viewer, allow for any file locations

--- a/web/app.js
+++ b/web/app.js
@@ -1404,10 +1404,9 @@ if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
     'http://mozilla.github.io', 'https://mozilla.github.io'];
   validateFileURL = function validateFileURL(file) {
     try {
-      
-      if (file === undefined)
+      if (file === undefined) {
         return;
-      
+      }
       let viewerOrigin = new URL(window.location.href).origin || 'null';
       if (HOSTED_VIEWER_ORIGINS.indexOf(viewerOrigin) >= 0) {
         // Hosted or local viewer, allow for any file locations

--- a/web/app.js
+++ b/web/app.js
@@ -1404,6 +1404,10 @@ if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
     'http://mozilla.github.io', 'https://mozilla.github.io'];
   validateFileURL = function validateFileURL(file) {
     try {
+      
+      if (file === undefined)
+        return;
+      
       let viewerOrigin = new URL(window.location.href).origin || 'null';
       if (HOSTED_VIEWER_ORIGINS.indexOf(viewerOrigin) >= 0) {
         // Hosted or local viewer, allow for any file locations


### PR DESCRIPTION
`new URL(file, window.location.href)` throws the following error in IE11 + iPad Safari when `file` is undefined:
Unable to get property 'replace' of undefined or null reference