### PR TITLE
ensure a secure version of Node.js is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "yargs": "^3.14.0"
   },
   "engines": {
-    "node": "^6.11.1",
+    "node": "^6.11.1"
   },
   "scripts": {
     "test": "gulp lint unittestcli externaltest"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "wintersmith": "^2.0.0",
     "yargs": "^3.14.0"
   },
+  "engines": {
+    "node": "^6.11.1",
+  },
   "scripts": {
     "test": "gulp lint unittestcli externaltest"
   },


### PR DESCRIPTION
this PR makes sure that a secure version of the LTS version of Node.js gets used (see https://nodejs.org/en/blog/vulnerability/july-2017-security-releases)