### PR TITLE
Add `Number.isNaN` and `Number.isInteger` polyfills in compatibility.js, since the Streams polyfill relies on them

### DIFF
--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -836,6 +836,29 @@ PDFJS.compatibilityChecked = true;
   };
 })();
 
+// Provides support for Number.isNaN in legacy browsers.
+// Support: IE.
+(function checkNumberIsNaN() {
+  if (Number.isNaN) {
+    return;
+  }
+  Number.isNaN = function(value) {
+    return typeof value === 'number' && isNaN(value);
+  };
+})();
+
+// Provides support for Number.isInteger in legacy browsers.
+// Support: IE.
+(function checkNumberIsInteger() {
+  if (Number.isInteger) {
+    return;
+  }
+  Number.isInteger = function(value) {
+    return typeof value === 'number' && isFinite(value) &&
+           Math.floor(value) === value;
+  };
+})();
+
 /**
  * Polyfill for Promises:
  * The following promise implementation tries to generally implement the


### PR DESCRIPTION
Without this, the Streams polyfill will fail in Internet Explorer when the code-paths containing these methods are used.

*Please note:* This is something that I noticed when testing PR #8617 in IE (all versions). While, in the context of that PR, it would be sufficient to polyfill `Number.isNaN` I did a quick code search in the Streams polyfill and found `Number.isInteger` being used as well.

***Edit:*** The patch was updated to remove a spurious blank line, however no functional code changes were made.