### PR TITLE
Performance optimizations

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -2107,12 +2107,9 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       var paintWidth = width, paintHeight = height;
       var tmpCanvasId = 'prescale';
       // Vertial or horizontal scaling shall not be more than 2 to not loose the
-      // pixels during drawImage operation, painting on the temporary canvas(es)
-      // that are twice smaller in size
-      while (
-        (widthScale > 2 && paintWidth > 1) ||
-        (heightScale > 2 && paintHeight > 1)
-      ) {
+      // pixels during drawImage operation
+      while ((widthScale > 2 && paintWidth > 1) ||
+             (heightScale > 2 && paintHeight > 1)) {
         var newWidth = paintWidth, newHeight = paintHeight;
         if (widthScale > 2 && paintWidth > 1) {
           newWidth = Math.ceil(paintWidth / 2);
@@ -2127,14 +2124,16 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         paintHeight = newHeight;
       }
 
+      // painting on the temporary canvas
       tmpCanvas = this.cachedCanvases.getCanvas(tmpCanvasId,
                                                 newWidth, newHeight);
       tmpCtx = tmpCanvas.context;
       tmpCtx.clearRect(0, 0, newWidth, newHeight);
       tmpCtx.drawImage(imgToPaint, 0, 0, width, height,
-                                  0, 0, newWidth, newHeight);
+                                   0, 0, newWidth, newHeight);
       imgToPaint = tmpCanvas.canvas;
 
+      // final painting
       ctx.drawImage(imgToPaint, 0, 0, paintWidth, paintHeight,
                                 0, -height, width, height);
 

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -2105,12 +2105,14 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       }
 
       var paintWidth = width, paintHeight = height;
-      var tmpCanvasId = 'prescale1';
+      var tmpCanvasId = 'prescale';
       // Vertial or horizontal scaling shall not be more than 2 to not loose the
       // pixels during drawImage operation, painting on the temporary canvas(es)
       // that are twice smaller in size
-      while ((widthScale > 2 && paintWidth > 1) ||
-             (heightScale > 2 && paintHeight > 1)) {
+      while (
+        (widthScale > 2 && paintWidth > 1) ||
+        (heightScale > 2 && paintHeight > 1)
+      ) {
         var newWidth = paintWidth, newHeight = paintHeight;
         if (widthScale > 2 && paintWidth > 1) {
           newWidth = Math.ceil(paintWidth / 2);
@@ -2120,17 +2122,19 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
           newHeight = Math.ceil(paintHeight / 2);
           heightScale /= paintHeight / newHeight;
         }
-        tmpCanvas = this.cachedCanvases.getCanvas(tmpCanvasId,
-                                                  newWidth, newHeight);
-        tmpCtx = tmpCanvas.context;
-        tmpCtx.clearRect(0, 0, newWidth, newHeight);
-        tmpCtx.drawImage(imgToPaint, 0, 0, paintWidth, paintHeight,
-                                     0, 0, newWidth, newHeight);
-        imgToPaint = tmpCanvas.canvas;
+
         paintWidth = newWidth;
         paintHeight = newHeight;
-        tmpCanvasId = tmpCanvasId === 'prescale1' ? 'prescale2' : 'prescale1';
       }
+
+      tmpCanvas = this.cachedCanvases.getCanvas(tmpCanvasId,
+                                                newWidth, newHeight);
+      tmpCtx = tmpCanvas.context;
+      tmpCtx.clearRect(0, 0, newWidth, newHeight);
+      tmpCtx.drawImage(imgToPaint, 0, 0, width, height,
+                                  0, 0, newWidth, newHeight);
+      imgToPaint = tmpCanvas.canvas;
+
       ctx.drawImage(imgToPaint, 0, 0, paintWidth, paintHeight,
                                 0, -height, width, height);
 

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -2105,32 +2105,35 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       }
 
       var paintWidth = width, paintHeight = height;
+      var tmpWidth = paintWidth, tmpHeight = paintHeight;
       var tmpCanvasId = 'prescale';
       // Vertial or horizontal scaling shall not be more than 2 to not loose the
       // pixels during drawImage operation
       while ((widthScale > 2 && paintWidth > 1) ||
              (heightScale > 2 && paintHeight > 1)) {
-        var newWidth = paintWidth, newHeight = paintHeight;
+        tmpWidth = paintWidth;
+        tmpHeight = paintHeight;
+
         if (widthScale > 2 && paintWidth > 1) {
-          newWidth = Math.ceil(paintWidth / 2);
-          widthScale /= paintWidth / newWidth;
+          tmpWidth = Math.ceil(paintWidth / 2);
+          widthScale /= paintWidth / tmpWidth;
         }
         if (heightScale > 2 && paintHeight > 1) {
-          newHeight = Math.ceil(paintHeight / 2);
-          heightScale /= paintHeight / newHeight;
+          tmpHeight = Math.ceil(paintHeight / 2);
+          heightScale /= paintHeight / tmpHeight;
         }
 
-        paintWidth = newWidth;
-        paintHeight = newHeight;
+        paintWidth = tmpWidth;
+        paintHeight = tmpHeight;
       }
 
       // painting on the temporary canvas
       tmpCanvas = this.cachedCanvases.getCanvas(tmpCanvasId,
-                                                newWidth, newHeight);
+                                                tmpWidth, tmpHeight);
       tmpCtx = tmpCanvas.context;
-      tmpCtx.clearRect(0, 0, newWidth, newHeight);
+      tmpCtx.clearRect(0, 0, tmpWidth, tmpHeight);
       tmpCtx.drawImage(imgToPaint, 0, 0, width, height,
-                                   0, 0, newWidth, newHeight);
+                                   0, 0, tmpWidth, tmpHeight);
       imgToPaint = tmpCanvas.canvas;
 
       // final painting

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -908,33 +908,35 @@ var PageViewport = (function PageViewportClosure() {
       rotation = rotation + 360;
     }
     var sideways = rotation % 180;
-    var a = rotation < 180 ? 1 : -1;
-    var flip = dontFlip ? -1 : 1;
-    var rotate = sideways ? [0, a, a * flip, 0] : [a, 0, 0, -a * flip];
+    var scaleX = rotation < 180 ? scale : -scale;
+    var scaleY = dontFlip ? scaleX : -scaleX;
     var width, height;
     if (sideways) {
-      width = Math.abs(viewBox[3] - viewBox[1]);
-      height = Math.abs(viewBox[2] - viewBox[0]);
+      width = scale * Math.abs(viewBox[3] - viewBox[1]);
+      height = scale * Math.abs(viewBox[2] - viewBox[0]);
     } else {
-      width = Math.abs(viewBox[2] - viewBox[0]);
-      height = Math.abs(viewBox[3] - viewBox[1]);
+      width = scale * Math.abs(viewBox[2] - viewBox[0]);
+      height = scale * Math.abs(viewBox[3] - viewBox[1]);
     }
 
     // creating transform for the following operations:
     // translate(-centerX, -centerY), rotate and flip vertically,
     // scale, and translate(offsetCanvasX, offsetCanvasY)
-    var centerX = (viewBox[2] + viewBox[0]) / 2;
-    var centerY = (viewBox[3] + viewBox[1]) / 2;
-    this.transform = rotate.map((v) => {
-      return v * scale;
-    }).concat(
-      (width / 2 - rotate[0] * centerX - rotate[2] * centerY) * scale + offsetX,
-      (height / 2 - rotate[1] * centerX - rotate[3] * centerY) * scale + offsetY
-    );
+    var centerX = scaleX * (viewBox[2] + viewBox[0]) / 2;
+    var centerY = scaleY * (viewBox[3] + viewBox[1]) / 2;
 
-    this.width = width * scale;
-    this.height = height * scale;
-    this.fontScale = scale;
+    if (sideways) {
+      this.transform = [0, scaleX, -scaleY, 0,
+                        offsetX + centerY + width / 2,
+                        offsetY - centerX + height / 2];
+    } else {
+      this.transform = [scaleX, 0, 0, scaleY,
+                        offsetX - centerX + width / 2,
+                        offsetY - centerY + height / 2];
+    }
+
+    this.width = width;
+    this.height = height;
   }
   PageViewport.prototype = /** @lends PageViewport.prototype */ {
     /**

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -591,13 +591,9 @@ function string32(value) {
                              (value >> 8) & 0xff, value & 0xff);
 }
 
+// NOTE: This name is misleading as it rounds the result up
 function log2(x) {
-  var n = 1, i = 0;
-  while (x > n) {
-    n <<= 1;
-    i++;
-  }
-  return i;
+  return Math.ceil(Math.log(x) * Math.LOG2E);
 }
 
 function readInt8(data, start) {


### PR DESCRIPTION
Hey, that's my first Pull Request here, so *please do* hate me :)

I dug into the code a little, analyzing performance and trying to find potential bottlenecks.

Here's what I changed:
* **PageViewport**
    * I refactored function by reducing the number of calculations within the function. I simplified some calculations on basic arithmetic level: `((b + a) / 2) - a` => `(b- a) / 2`, `a * n + b * n - c * n` => `(a + b - c) * n` etc.
    * After code analysis, I've optimize the order of calculations (for example, offsetCanvasX was different for different rotation solely because width was switching with height when the viewport was rotated by 90 od 270 degrees) I've managed to reduce the code necessary to output what this function is supposed to.

    That resulted in **20-40% performance increase** in my tests. (~80 => 50 milliseconds per 10000 runs).
* **log2**
    * I replaced custom solution with Math functions.
    * I placed a warning that log2 function is not exactly doing what the name suggests. Didn't change the name because I didn't want to make a commotion.

    While I didn't measure how the change affected the performance in pdf.js, I did a [simple test on jsperf](https://jsperf.com/log2-pdfjs/1) which pointed native Math.log as a clear winner with **500% performance increase**.
    I've decided to use `Math.ceil(Math.log(x) * Math.LOG2E)` instead of `Math.ceil(Math.log2(x));` for compatibility reasons; virtually every browser supports `Math.log`, while `Math.log2` is only supported in modern browsers, while giving no performance bonus whatsoever.
* **CanvasGraphics_paintInlineImageXObject**
    * I rewrote the function painting image so that it would not draw a temporary image on a canvas each time it goes through a loop which purpose is to divide widthScale and heightScale by 2 as long as they are bigger than 2.

    I've measured the performance after implementing this change and the difference is big. In my test file, the function was called twice. Before the change, on average runs took 347 ms and 127 ms. After the change, they took 229 and 95 ms respectively. That's **32% performance increase**. Woo! 🎉 