### PR TITLE
Fix display_svg_spec tests.

### DIFF
--- a/examples/node/domstubs.js
+++ b/examples/node/domstubs.js
@@ -60,7 +60,22 @@ function DOMElement(name) {
 DOMElement.prototype = {
 
   getAttributeNS: function DOMElement_getAttributeNS(NS, name) {
-    return name in this.attributes ? this.attributes[name] : null;
+    // Fast path
+    if (name in this.attributes) {
+      return this.attributes[name];
+    }
+    // Slow path - used by test/unit/display_svg_spec.js
+    // Assuming that there is only one matching attribute for a given name,
+    // across all namespaces.
+    if (NS) {
+      var suffix = ':' + name;
+      for (var fullName in this.attributes) {
+        if (fullName.slice(-suffix.length) === suffix) {
+          return this.attributes[fullName];
+        }
+      }
+    }
+    return null;
   },
 
   setAttributeNS: function DOMElement_setAttributeNS(NS, name, value) {


### PR DESCRIPTION
Follow-up to #8620 (reported test failure at https://github.com/mozilla/pdf.js/pull/8620#issuecomment-315387111).

Successfully tested in a browser and in Node.js:

Browser: The test now pass at http://localhost:8888/test/unit/unit_test.html?spec=SVGGraphics%20paintImageXObject%20should%20produce%20a%20svg%3Aimage%20even%20if%20zlib%20is%20unavailable

Node v0.11.x:
```
$ JASMINE_CONFIG_PATH=test/unit/clitests.json /tmp/node/node0.11.12 ./node_modules/.bin/jasmine --filter=SVG
Started
.Warning: Not compressing PNG because zlib.deflateSync is unavailable: Error: zlib.deflateSync is explicitly disabled for testing.
.


Ran 2 of 416 specs
2 specs, 0 failures
Finished in 0.334 seconds
```

Node v8.1.3:
```
$ JASMINE_CONFIG_PATH=test/unit/clitests.json node ./node_modules/.bin/jasmine --filter=SVG
Started
(node:5208) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): ReferenceError: window is not defined
(node:5208) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
.Warning: Not compressing PNG because zlib.deflateSync is unavailable: Error: zlib.deflateSync is explicitly disabled for testing.
.


Ran 2 of 416 specs
2 specs, 0 failures
Finished in 0.064 seconds
```

(that promise rejection is caused by requestAnimationFrame in ui_utils.js, unrelated to my test)