### PR TITLE
Add UI for the cursorToolOnLoad pref in the Chrome extension + migration logic

### DIFF
--- a/extensions/chromium/options/migration.js
+++ b/extensions/chromium/options/migration.js
@@ -29,6 +29,8 @@ limitations under the License.
     storageLocal.get(storageKeys, function(values) {
       if (!values || !Object.keys(values).length) {
         // No local storage - nothing to migrate.
+        // ... except possibly for a renamed preference name.
+        migrateRenamedStorage();
         return;
       }
       migrateToSyncStorage(values);
@@ -63,7 +65,34 @@ limitations under the License.
         // the migration successful.
         console.log(
             'Successfully migrated preferences from local to sync storage.');
+        migrateRenamedStorage();
       });
+    });
+  }
+
+  // TODO: Remove this migration code somewhere in the future, when most users
+  // have had their chance of migrating to the new preference format.
+  // Note: We cannot modify managed preferences, so the migration logic is
+  // duplicated in web/chromecom.js too.
+  function migrateRenamedStorage() {
+    storageSync.get([
+      'enableHandToolOnLoad',
+      'cursorToolOnLoad',
+    ], function(items) {
+      // Migration code for https://github.com/mozilla/pdf.js/pull/7635.
+      if (typeof items.enableHandToolOnLoad === 'boolean') {
+        if (items.enableHandToolOnLoad) {
+          storageSync.set({
+            cursorToolOnLoad: 1,
+          }, function() {
+            if (!chrome.runtime.lastError) {
+              storageSync.remove('enableHandToolOnLoad');
+            }
+          });
+        } else {
+          storageSync.remove('enableHandToolOnLoad');
+        }
+      }
     });
   }
 })();

--- a/extensions/chromium/options/options.html
+++ b/extensions/chromium/options/options.html
@@ -80,6 +80,18 @@ body {
 </div>
 </template>
 
+<template id="cursorToolOnLoad-template">
+<div class="settings-row">
+  <label>
+    <span></span>
+    <select>
+      <option value="0">Text selection tool</option>
+      <option value="1">Hand tool</option>
+    </select>
+  </label>
+</div>
+</template>
+
 <template id="externalLinkTarget-template">
 <div class="settings-row">
   <label>

--- a/extensions/chromium/options/options.js
+++ b/extensions/chromium/options/options.js
@@ -79,6 +79,8 @@ Promise.all([
       renderPreference = renderDefaultZoomValue(prefSchema.title);
     } else if (prefName === 'sidebarViewOnLoad') {
       renderPreference = renderSidebarViewOnLoad(prefSchema.title);
+    } else if (prefName === 'cursorToolOnLoad') {
+      renderPreference = renderCursorToolOnLoad(prefSchema.title);
     } else if (prefName === 'externalLinkTarget') {
       renderPreference = renderExternalLinkTarget(prefSchema.title);
     } else {
@@ -187,6 +189,23 @@ function renderSidebarViewOnLoad(shortDescription) {
   select.onchange = function() {
     storageArea.set({
       sidebarViewOnLoad: parseInt(this.value),
+    });
+  };
+  wrapper.querySelector('span').textContent = shortDescription;
+  document.getElementById('settings-boxes').appendChild(wrapper);
+
+  function renderPreference(value) {
+    select.value = value;
+  }
+  return renderPreference;
+}
+
+function renderCursorToolOnLoad(shortDescription) {
+  var wrapper = importTemplate('cursorToolOnLoad-template');
+  var select = wrapper.querySelector('select');
+  select.onchange = function() {
+    storageArea.set({
+      cursorToolOnLoad: parseInt(this.value),
     });
   };
   wrapper.querySelector('span').textContent = shortDescription;

--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -27,6 +27,7 @@
       "default": 0
     },
     "enableHandToolOnLoad": {
+      "description": "Deprecated. Set cursorToolOnLoad to 1 to enable the hand tool by default.",
       "type": "boolean",
       "default": false
     },

--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -328,7 +328,18 @@ class ChromePreferences extends BasePreferences {
         // Get preferences as set by the system administrator.
         // See extensions/chromium/preferences_schema.json for more information.
         // These preferences can be overridden by the user.
-        chrome.storage.managed.get(this.defaults, getPreferences);
+        chrome.storage.managed.get(this.defaults, function(items) {
+          // Migration code for https://github.com/mozilla/pdf.js/pull/7635.
+          // Never remove this, because we have no means of modifying managed
+          // preferences.
+          if (items && items.enableHandToolOnLoad && !items.cursorToolOnLoad) {
+            // if the old enableHandToolOnLoad has a non-default value,
+            // and cursorToolOnLoad has a default value, migrate.
+            items.enableHandToolOnLoad = false;
+            items.cursorToolOnLoad = 1;
+          }
+          getPreferences(items);
+        });
       } else {
         // Managed storage not supported, e.g. in old Chromium versions.
         getPreferences(this.defaults);


### PR DESCRIPTION
While preparing for a release, I encountered the "Don\'t know how to handle cursorToolOnLoad!" error in the console of the options page. After an investigation, I found that the hand tool preference was converted from a boolean to an integer in #7635.

I fixed the UI and added migration logic - see the commit message for more details.

Test:

1. Run `gulp chromium`
2. Go to `chrome://extensions` in Chrome, enable Developer mode and load the extension from `build/chromium/`.
3. Click on Inspect background page of the extension, and run the following code:

    ```javascript
    chrome.storage.local.set({enableHandToolOnLoad: true}, function() {location.reload();});
    ```
4. Run the following code to confirm that the preference has been migrated:

    ```javascript
    chrome.storage.local.get('enableHandToolOnLoad', console.log); // Should be an empty {}.
    ```
5. Click on the "Options" link and confirm that the "Cursor tool on load" dropdown is set to "Hand Tool".

Optional (to check that the migration logic does not interfere with a normal functioning of the migrated pref):

6. Change the dropdown to "Text selection tool", close the options page, reload the extension and open the options page.
7. Confirm that the dropdown value is still at "Text selection".
8. Repeat step 6 and 7, but change from "Text selection" to "Hand tool" instead.