### PR TITLE
Fix TypeError that occurs in colorspace.js on accidentally passing an 'Array' instead of 'TypedArray'

### DIFF
--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -538,7 +538,7 @@ var IndexedCS = (function IndexedCSClosure() {
                                               dest, destOffset) {
       var numComps = this.base.numComps;
       var start = src[srcOffset] * numComps;
-      this.base.getRgbItem(this.lookup, start, dest, destOffset);
+      this.base.getRgbBuffer(this.lookup, start, 1, dest, destOffset, 8, 0);
     },
     getRgbBuffer: function IndexedCS_getRgbBuffer(src, srcOffset, count,
                                                   dest, destOffset, bits,


### PR DESCRIPTION
Hi, 
**(Assumption: The base color space is set to be DeviceRGB)**
If an `Array`(not as `TypedArray` or `String`) is passed in `IndexedCS` constructor(https://github.com/mozilla/pdf.js/blob/master/src/core/colorspace.js#L509) as `lookup`, **TypeError** occurs on calling `fillRgb(...)`(on `IndexedCS` object), passing `lookup` as `comps`(https://github.com/mozilla/pdf.js/blob/master/src/core/colorspace.js#L116-L118). The error occurs because of `src.subarray(...)` in https://github.com/mozilla/pdf.js/blob/master/src/core/colorspace.js#L635 since `src` is expected to be a `TypedArray`. I made a small change to fix this.