### PR TITLE
Fix a typo, in the `Catalog.numPages` getter, than prevents shadowing from working correctly

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -168,7 +168,7 @@ var Catalog = (function CatalogClosure() {
         'page count in top level pages object is not an integer'
       );
       // shadow the prototype getter
-      return shadow(this, 'num', obj);
+      return shadow(this, 'numPages', obj);
     },
     get destinations() {
       function fetchDestination(dest) {


### PR DESCRIPTION
Looking at the blame, it seems that this typo was present even before PR #700 (almost six years ago).
The result of using `'num'`, rather than the *correct* `'numPages'` string, is that the `Catalog.numPages` getter isn't actually being shadowed.