### PR TITLE
Remove most `assert()` calls (issue 8506) 

### DIFF
--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -14,7 +14,7 @@
  */
 
 import {
-  assert, bytesToString, FormatError, info, isArray, stringToBytes, Util, warn
+  bytesToString, FormatError, info, isArray, stringToBytes, Util, warn
 } from '../shared/util';
 import {
   ExpertCharset, ExpertSubsetCharset, ISOAdobeCharset
@@ -871,7 +871,9 @@ var CFFParser = (function CFFParserClosure() {
         default:
           throw new FormatError(`parseFDSelect: Unknown format "${format}".`);
       }
-      assert(fdSelect.length === length, 'parseFDSelect: Invalid font data.');
+      if (fdSelect.length !== length) {
+        throw new FormatError('parseFDSelect: Invalid font data.');
+      }
 
       return new CFFFDSelect(fdSelect, rawBytes);
     },
@@ -1440,9 +1442,10 @@ var CFFCompiler = (function CFFCompilerClosure() {
                                                                   output) {
       for (var i = 0, ii = dicts.length; i < ii; ++i) {
         var fontDict = dicts[i];
-        assert(fontDict.privateDict && fontDict.hasName('Private'),
-               'There must be an private dictionary.');
         var privateDict = fontDict.privateDict;
+        if (!privateDict || !fontDict.hasName('Private')) {
+          throw new FormatError('There must be a private dictionary.');
+        }
         var privateDictTracker = new CFFOffsetTracker();
         var privateDictData = this.compileDict(privateDict, privateDictTracker);
 

--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -14,8 +14,8 @@
  */
 
 import {
-  arrayByteLength, arraysToBytes, assert, createPromiseCapability, isEmptyObj,
-  isInt, MissingDataException
+  arrayByteLength, arraysToBytes, createPromiseCapability, isEmptyObj, isInt,
+  MissingDataException
 } from '../shared/util';
 
 var ChunkedStream = (function ChunkedStreamClosure() {
@@ -58,12 +58,15 @@ var ChunkedStream = (function ChunkedStreamClosure() {
     onReceiveData: function ChunkedStream_onReceiveData(begin, chunk) {
       var end = begin + chunk.byteLength;
 
-      assert(begin % this.chunkSize === 0, 'Bad begin offset: ' + begin);
+      if (begin % this.chunkSize !== 0) {
+        throw new Error(`Bad begin offset: ${begin}`);
+      }
       // Using this.length is inaccurate here since this.start can be moved
       // See ChunkedStream.moveStart()
       var length = this.bytes.length;
-      assert(end % this.chunkSize === 0 || end === length,
-             'Bad end offset: ' + end);
+      if (end % this.chunkSize !== 0 && end !== length) {
+        throw new Error(`Bad end offset: ${end}`);
+      }
 
       this.bytes.set(new Uint8Array(chunk), begin);
       var chunkSize = this.chunkSize;

--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -14,8 +14,8 @@
  */
 
 import {
-  assert, bytesToString, FormatError, isInt, PasswordException,
-  PasswordResponses, stringToBytes, utf8StringToString, warn
+  bytesToString, FormatError, isInt, PasswordException, PasswordResponses,
+  stringToBytes, utf8StringToString, warn
 } from '../shared/util';
 import { isDict, isName, Name } from './primitives';
 import { DecryptStream } from './stream';
@@ -1997,7 +1997,9 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
   }
 
   function buildCipherConstructor(cf, name, num, gen, key) {
-    assert(isName(name), 'Invalid crypt filter name.');
+    if (!isName(name)) {
+      throw new FormatError('Invalid crypt filter name.');
+    }
     var cryptFilter = cf.get(name.name);
     var cfm;
     if (cryptFilter !== null && cryptFilter !== undefined) {

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -13,13 +13,12 @@
  * limitations under the License.
  */
 
-import {
-  assert, info, isArray, isArrayBuffer, isNum, isSpace, isString,
-  MissingDataException, OPS, shadow, stringToBytes, stringToPDFString, Util,
-  warn
-} from '../shared/util';
 import { Catalog, ObjectLoader, XRef } from './obj';
 import { Dict, isDict, isName, isStream } from './primitives';
+import {
+  info, isArray, isArrayBuffer, isNum, isSpace, isString, MissingDataException,
+  OPS, shadow, stringToBytes, stringToPDFString, Util, warn
+} from '../shared/util';
 import { NullStream, Stream, StreamsSequenceStream } from './stream';
 import { OperatorList, PartialEvaluator } from './evaluator';
 import { AnnotationFactory } from './annotation';
@@ -355,7 +354,9 @@ var PDFDocument = (function PDFDocumentClosure() {
     } else {
       throw new Error('PDFDocument: Unknown argument type');
     }
-    assert(stream.length > 0, 'stream must have data');
+    if (stream.length <= 0) {
+      throw new Error('PDFDocument: stream must have data');
+    }
 
     this.pdfManager = pdfManager;
     this.stream = stream;

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -673,7 +673,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
       var fontRef, xref = this.xref;
       if (font) { // Loading by ref.
-        assert(isRef(font));
+        if (!isRef(font)) {
+          throw new Error('The "font" object should be a reference.');
+        }
         fontRef = font;
       } else { // Loading by name.
         var fontRes = resources.get('Font');
@@ -866,7 +868,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       resources = resources || Dict.empty;
       initialState = initialState || new EvalState();
 
-      assert(operatorList, 'getOperatorList: missing "operatorList" parameter');
+      if (!operatorList) {
+        throw new Error('getOperatorList: missing "operatorList" parameter');
+      }
 
       var self = this;
       var xref = this.xref;
@@ -928,10 +932,14 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
               var xobj = xobjs.get(name);
               if (xobj) {
-                assert(isStream(xobj), 'XObject should be a stream');
+                if (!isStream(xobj)) {
+                  throw new FormatError('XObject should be a stream');
+                }
 
                 var type = xobj.dict.get('Subtype');
-                assert(isName(type), 'XObject should have a Name subtype');
+                if (!isName(type)) {
+                  throw new FormatError('XObject should have a Name subtype');
+                }
 
                 if (type.name === 'Form') {
                   stateManager.save();
@@ -1087,10 +1095,14 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
             case OPS.shadingFill:
               var shadingRes = resources.get('Shading');
-              assert(shadingRes, 'No shading resource found');
+              if (!shadingRes) {
+                throw new FormatError('No shading resource found');
+              }
 
               var shading = shadingRes.get(args[0].name);
-              assert(shading, 'No shading object found');
+              if (!shading) {
+                throw new FormatError('No shading object found');
+              }
 
               var shadingFill = Pattern.parseShading(shading, null, xref,
                 resources, self.handler);
@@ -1636,10 +1648,14 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
               if (!xobj) {
                 break;
               }
-              assert(isStream(xobj), 'XObject should be a stream');
+              if (!isStream(xobj)) {
+                throw new FormatError('XObject should be a stream');
+              }
 
               var type = xobj.dict.get('Subtype');
-              assert(isName(type), 'XObject should have a Name subtype');
+              if (!isName(type)) {
+                throw new FormatError('XObject should have a Name subtype');
+              }
 
               if (type.name !== 'Form') {
                 skipEmptyXObjs[name] = true;
@@ -1977,7 +1993,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           var cMap = properties.cMap;
           toUnicode = [];
           cMap.forEach(function(charcode, cid) {
-            assert(cid <= 0xffff, 'Max size of CID is 65,535');
+            if (cid > 0xffff) {
+              throw new FormatError('Max size of CID is 65,535');
+            }
             // e) Map the CID obtained in step (a) according to the CMap
             // obtained in step (d), producing a Unicode value.
             var ucs2 = ucs2CMap.lookup(cid);
@@ -2229,7 +2247,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     preEvaluateFont: function PartialEvaluator_preEvaluateFont(dict) {
       var baseDict = dict;
       var type = dict.get('Subtype');
-      assert(isName(type), 'invalid font Subtype');
+      if (!isName(type)) {
+        throw new FormatError('invalid font Subtype');
+      }
 
       var composite = false;
       var uint8array;
@@ -2239,11 +2259,15 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         //  - set the type according to the descendant font
         //  - get the FontDescriptor from the descendant font
         var df = dict.get('DescendantFonts');
-        assert(df, 'Descendant fonts are not specified');
+        if (!df) {
+          throw new FormatError('Descendant fonts are not specified');
+        }
         dict = (isArray(df) ? this.xref.fetchIfRef(df[0]) : df);
 
         type = dict.get('Subtype');
-        assert(isName(type), 'invalid font Subtype');
+        if (!isName(type)) {
+          throw new FormatError('invalid font Subtype');
+        }
         composite = true;
       }
 
@@ -2331,7 +2355,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           // FontDescriptor was not required.
           // This case is here for compatibility.
           var baseFontName = dict.get('BaseFont');
-          assert(isName(baseFontName), 'Base font is not specified');
+          if (!isName(baseFontName)) {
+            throw new FormatError('Base font is not specified');
+          }
 
           // Using base font name as a font name.
           baseFontName = baseFontName.name.replace(/[,_]/g, '-');
@@ -2398,7 +2424,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       }
       fontName = (fontName || baseFont);
 
-      assert(isName(fontName), 'invalid font name');
+      if (!isName(fontName)) {
+        throw new FormatError('invalid font name');
+      }
 
       var fontFile = descriptor.get('FontFile', 'FontFile2', 'FontFile3');
       if (fontFile) {
@@ -2494,7 +2522,9 @@ var TranslatedFont = (function TranslatedFontClosure() {
       this.sent = true;
     },
     loadType3Data(evaluator, resources, parentOperatorList, task) {
-      assert(this.font.isType3Font);
+      if (!this.font.isType3Font) {
+        throw new Error('Must be a Type3 font.');
+      }
 
       if (this.type3Loaded) {
         return this.type3Loaded;
@@ -2997,7 +3027,9 @@ var EvaluatorPreprocessor = (function EvaluatorPreprocessorClosure() {
             args = [];
           }
           args.push(obj);
-          assert(args.length <= 33, 'Too many arguments');
+          if (args.length > 33) {
+            throw new FormatError('Too many arguments');
+          }
         }
       }
     },

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -14,9 +14,9 @@
  */
 
 import {
-  assert, bytesToString, FONT_IDENTITY_MATRIX, FontType, FormatError, info,
-  isArray, isInt, isNum, isSpace, MissingDataException, readUint32, shadow,
-  string32, warn
+  bytesToString, FONT_IDENTITY_MATRIX, FontType, FormatError, info, isArray,
+  isInt, isNum, isSpace, MissingDataException, readUint32, shadow, string32,
+  warn
 } from '../shared/util';
 import {
   CFF, CFFCharset, CFFCompiler, CFFHeader, CFFIndex, CFFParser, CFFPrivateDict,
@@ -2286,7 +2286,9 @@ var Font = (function FontClosure() {
         var isCidToGidMapEmpty = cidToGidMap.length === 0;
 
         properties.cMap.forEach(function(charCode, cid) {
-          assert(cid <= 0xffff, 'Max size of CID is 65,535');
+          if (cid > 0xffff) {
+            throw new FormatError('Max size of CID is 65,535');
+          }
           var glyphId = -1;
           if (isCidToGidMapEmpty) {
             glyphId = cid;

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -328,7 +328,9 @@ Shadings.Mesh = (function MeshClosure() {
       var coord = reader.readCoordinate();
       var color = reader.readComponents();
       if (verticesLeft === 0) { // ignoring flags if we started a triangle
-        assert((0 <= f && f <= 2), 'Unknown type4 flag');
+        if (!(0 <= f && f <= 2)) {
+          throw new FormatError('Unknown type4 flag');
+        }
         switch (f) {
           case 0:
             verticesLeft = 3;
@@ -492,7 +494,9 @@ Shadings.Mesh = (function MeshClosure() {
     var cs = new Int32Array(4); // c00, c30, c03, c33
     while (reader.hasData) {
       var f = reader.readFlag();
-      assert((0 <= f && f <= 3), 'Unknown type6 flag');
+      if (!(0 <= f && f <= 3)) {
+        throw new FormatError('Unknown type6 flag');
+      }
       var i, ii;
       var pi = coords.length;
       for (i = 0, ii = (f !== 0 ? 8 : 12); i < ii; i++) {
@@ -602,7 +606,9 @@ Shadings.Mesh = (function MeshClosure() {
     var cs = new Int32Array(4); // c00, c30, c03, c33
     while (reader.hasData) {
       var f = reader.readFlag();
-      assert((0 <= f && f <= 3), 'Unknown type7 flag');
+      if (!(0 <= f && f <= 3)) {
+        throw new FormatError('Unknown type7 flag');
+      }
       var i, ii;
       var pi = coords.length;
       for (i = 0, ii = (f !== 0 ? 12 : 16); i < ii; i++) {
@@ -706,7 +712,9 @@ Shadings.Mesh = (function MeshClosure() {
   }
 
   function Mesh(stream, matrix, xref, res) {
-    assert(isStream(stream), 'Mesh data is not a stream');
+    if (!isStream(stream)) {
+      throw new FormatError('Mesh data is not a stream');
+    }
     var dict = stream.dict;
     this.matrix = matrix;
     this.shadingType = dict.get('ShadingType');
@@ -743,7 +751,9 @@ Shadings.Mesh = (function MeshClosure() {
         break;
       case ShadingType.LATTICE_FORM_MESH:
         var verticesPerRow = dict.get('VerticesPerRow') | 0;
-        assert(verticesPerRow >= 2, 'Invalid VerticesPerRow');
+        if (verticesPerRow < 2) {
+          throw new FormatError('Invalid VerticesPerRow');
+        }
         decodeType5Shading(this, reader, verticesPerRow);
         break;
       case ShadingType.COONS_PATCH_MESH:

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -541,7 +541,9 @@ var WorkerMessageHandler = {
         if (source.chunkedViewerLoading) {
           pdfStream = new PDFWorkerStream(source, handler);
         } else {
-          assert(PDFNetworkStream, './network module is not loaded');
+          if (!PDFNetworkStream) {
+            throw new Error('./network module is not loaded');
+          }
           pdfStream = new PDFNetworkStream(data);
         }
       } catch (ex) {

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -14,7 +14,7 @@
  */
 
 import {
-  assert, FONT_IDENTITY_MATRIX, IDENTITY_MATRIX, ImageKind, info, isArray,
+  FONT_IDENTITY_MATRIX, IDENTITY_MATRIX, ImageKind, info, isArray,
   isLittleEndian, isNum, OPS, shadow, TextRenderingMode, Util, warn
 } from '../shared/util';
 import { getShadingPatternFromIR, TilingPattern } from './pattern_helper';
@@ -1777,7 +1777,9 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       if (group.matrix) {
         currentCtx.transform.apply(currentCtx, group.matrix);
       }
-      assert(group.bbox, 'Bounding box is required.');
+      if (!group.bbox) {
+        throw new Error('Bounding box is required.');
+      }
 
       // Based on the current transform figure out how big the bounding box
       // will actually be.

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -14,7 +14,7 @@
  */
 
 import {
-  assert, CMapCompressionType, createValidAbsoluteUrl, deprecated, globalScope,
+  CMapCompressionType, createValidAbsoluteUrl, deprecated, globalScope,
   removeNullCharacters, stringToBytes, warn
 } from '../shared/util';
 
@@ -22,7 +22,9 @@ var DEFAULT_LINK_REL = 'noopener noreferrer nofollow';
 
 class DOMCanvasFactory {
   create(width, height) {
-    assert(width > 0 && height > 0, 'invalid canvas size');
+    if (width <= 0 || height <= 0) {
+      throw new Error('invalid canvas size');
+    }
     let canvas = document.createElement('canvas');
     let context = canvas.getContext('2d');
     canvas.width = width;
@@ -34,14 +36,20 @@ class DOMCanvasFactory {
   }
 
   reset(canvasAndContext, width, height) {
-    assert(canvasAndContext.canvas, 'canvas is not specified');
-    assert(width > 0 && height > 0, 'invalid canvas size');
+    if (!canvasAndContext.canvas) {
+      throw new Error('canvas is not specified');
+    }
+    if (width <= 0 || height <= 0) {
+      throw new Error('invalid canvas size');
+    }
     canvasAndContext.canvas.width = width;
     canvasAndContext.canvas.height = height;
   }
 
   destroy(canvasAndContext) {
-    assert(canvasAndContext.canvas, 'canvas is not specified');
+    if (!canvasAndContext.canvas) {
+      throw new Error('canvas is not specified');
+    }
     // Zeroing the width and height cause Firefox to release graphics
     // resources immediately, which can greatly reduce memory consumption.
     canvasAndContext.canvas.width = 0;


### PR DESCRIPTION
This replaces `assert` calls with `throw new FormatError()`/`throw new Error()`.
In a few places, throwing an `Error` (which is what `assert` meant) isn't correct since the enclosing function is supposed to return a `Promise`, hence some cases were changed to `Promise.reject(...)` and similarily for `createPromiseCapability` instances.

Fixes #8506.

@yurydelendik Based on https://github.com/mozilla/pdf.js/issues/8506#issuecomment-307455596 in particular: I wasn't really sure if we should leave some, and if so *which* ones, of the current `assert` calls in place.
~~This patch is currently replacing *all* of the them, but I figured that might not be what you actually want here which is why I've marked the PR as `work-in-progress` and would very much appreciate feedback on this!~~