### PR TITLE
Parse  content disposition  header

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "uglify-es": "^3.1.2",
     "vinyl": "^2.1.0",
     "vinyl-fs": "^2.4.4",
-    "webpack": "^3.6.0",
+    "webpack": "^3.10.0",
     "webpack-stream": "^4.0.0",
     "wintersmith": "^2.4.1",
     "yargs": "^9.0.1"

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2001,8 +2001,10 @@ var WorkerTransport = (function WorkerTransportClosure() {
         return {
           info: results[0],
           metadata: (results[1] ? new Metadata(results[1]) : null),
+          contentDispositionFileName: (this._fullReader ?
+                                       this._fullReader.fileName : null),
         };
-      });
+      }.bind(this));
     },
 
     getStats: function WorkerTransport_getStats() {

--- a/src/display/network_utils.js
+++ b/src/display/network_utils.js
@@ -16,6 +16,7 @@
 import {
   assert, MissingPDFException, UnexpectedResponseException
 } from '../shared/util';
+import { getFilenameFromUrl } from './dom_utils';
 
 function validateRangeRequestCapabilities({ getResponseHeader, isHttp,
                                             rangeChunkSize, disableRange, }) {
@@ -65,8 +66,23 @@ function validateResponseStatus(status) {
   return status === 200 || status === 206;
 }
 
+function extractFilenameFromHeader(getResponseHeader) {
+  const contentDisposition = getResponseHeader('Content-Disposition');
+
+  if (contentDisposition) {
+    let parts =
+      /.+;\s*filename=(?:"|')(.+\.pdf)(?:"|')/gi.exec(contentDisposition);
+    if (parts !== null && parts.length > 1) {
+      return getFilenameFromUrl(parts[1]);
+    }
+  }
+
+  return null;
+}
+
 export {
   createResponseStatusError,
   validateRangeRequestCapabilities,
   validateResponseStatus,
+  extractFilenameFromHeader,
 };

--- a/web/app.js
+++ b/web/app.js
@@ -153,6 +153,7 @@ let PDFViewerApplication = {
   baseUrl: '',
   externalServices: DefaultExternalServices,
   _boundEvents: {},
+  contentDispositionFileName: null,
 
   // Called once when the document is loaded.
   initialize(appConfig) {
@@ -675,6 +676,7 @@ let PDFViewerApplication = {
     this.store = null;
     this.isInitialViewSet = false;
     this.downloadComplete = false;
+    this.contentDispositionFileName = null;
 
     this.pdfSidebar.reset();
     this.pdfOutlineViewer.reset();
@@ -792,7 +794,8 @@ let PDFViewerApplication = {
     let url = this.baseUrl;
     // Use this.url instead of this.baseUrl to perform filename detection based
     // on the reference fragment as ultimate fallback if needed.
-    let filename = getPDFFileNameFromURL(this.url);
+    let filename = this.contentDispositionFileName ||
+      getPDFFileNameFromURL(this.url);
     let downloadManager = this.downloadManager;
     downloadManager.onerror = (err) => {
       // This error won't really be helpful because it's likely the
@@ -1144,9 +1147,11 @@ let PDFViewerApplication = {
       });
     });
 
-    pdfDocument.getMetadata().then(({ info, metadata, }) => {
+    pdfDocument.getMetadata().then(
+        ({ info, metadata, contentDispositionFileName, }) => {
       this.documentInfo = info;
       this.metadata = metadata;
+      this.contentDispositionFileName = contentDispositionFileName;
 
       // Provides some basic debug information
       console.log('PDF ' + pdfDocument.fingerprint + ' [' +
@@ -1170,6 +1175,10 @@ let PDFViewerApplication = {
 
       if (pdfTitle) {
         this.setTitle(pdfTitle + ' - ' + document.title);
+      }
+
+      if (!pdfTitle && contentDispositionFileName) {
+        this.setTitle(contentDispositionFileName);
       }
 
       if (info.IsAcroFormPresent) {


### PR DESCRIPTION
Good afternoon.

This is my small contribution to this project. My  patch uses the file name received in the content disposition  header instead of infer it from the URL. 

In case no content disposition is received it will work as usual.

Fixes #4284.
Fixes #6396.