### PR TITLE
Adds ready capability rejection logic for stream sink.

### DIFF
--- a/test/unit/util_stream_spec.js
+++ b/test/unit/util_stream_spec.js
@@ -154,7 +154,7 @@ describe('util_stream', function () {
         expect(log).toEqual('01p2');
         return reader.cancel();
       }).then(() => {
-        expect(log).toEqual('01p2c');
+        expect(log).toEqual('01p2c4');
         done();
       });
     });


### PR DESCRIPTION
This PR adds rejection logic for stream sink ready capability. Also adds `isCancelled` property in stream sink, so that we can ignore any `enqueue` and `close` operations after stream sink is closed.