### PR TITLE
Add a fallback for non-embedded SegoeUISymbol font (issue 8697)

### DIFF
--- a/src/core/standard_fonts.js
+++ b/src/core/standard_fonts.js
@@ -57,6 +57,7 @@ var getStdFontMap = getLookupTableFactory(function (t) {
   t['Helvetica-BoldOblique'] = 'Helvetica-BoldOblique';
   t['Helvetica-Italic'] = 'Helvetica-Oblique';
   t['Helvetica-Oblique'] = 'Helvetica-Oblique';
+  t['SegoeUISymbol'] = 'Helvetica';
   t['Symbol-Bold'] = 'Symbol';
   t['Symbol-BoldItalic'] = 'Symbol';
   t['Symbol-Italic'] = 'Symbol';

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -55,6 +55,7 @@
 !issue8424.pdf
 !issue8480.pdf
 !issue8570.pdf
+!issue8697.pdf
 !bad-PageLabels.pdf
 !filled-background.pdf
 !ArabicCIDTrueType.pdf

--- a/test/pdfs/issue8697.pdf
+++ b/test/pdfs/issue8697.pdf
@@ -1,0 +1,95 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/FontName /SegoeUISymbol
+/StemV 44
+/Leading 33
+/Ascent 905
+/Flags 32
+/FontWeight 400
+/XHeight 250
+/Descent -210
+/AvgWidth 441
+/ItalicAngle 0
+/MaxWidth 2665
+/FontBBox [-665 -210 2000 728]
+/Type /FontDescriptor
+/CapHeight 728
+>>
+endobj 
+2 0 obj [278 0 0 0 0 0 0 0 333 333 0 0 278 333 278 278 0 556 556 0 0 0 0 0 0 0 278 278 584 0 0 0 0 667 667 722 722 667 611 0 722 278 0 0 556 833 722 778 667 0 722 667 611 722 667 944 0 0 0 0 0 0 0 0 0 556 556 500 556 556 278 556 556 222 222 500 222 833 556 556 556 556 333 500 278 556 500 722 500 500 500]
+endobj 
+3 0 obj 
+<<
+/Pages 4 0 R
+/Type /Catalog
+>>
+endobj 
+4 0 obj 
+<<
+/MediaBox [0 0 250 50]
+/Kids [5 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+5 0 obj 
+<<
+/Parent 4 0 R
+/MediaBox [0 0 250 50]
+/Resources 
+<<
+/Font 
+<<
+/F1 6 0 R
+>>
+>>
+/Contents 7 0 R
+/Type /Page
+>>
+endobj 
+6 0 obj 
+<<
+/FirstChar 32
+/FontDescriptor 1 0 R
+/Name /F4
+/Encoding /WinAnsiEncoding
+/BaseFont /SegoeUISymbol
+/Subtype /TrueType
+/LastChar 122
+/Widths 2 0 R
+/Type /Font
+>>
+endobj 
+7 0 obj 
+<<
+/Length 104
+>>
+stream
+BT
+10 20 TD
+/F1 18 Tf
+[(W)-2(ha)-3(t )17(Op)-3(er)-3(ating)-2( )21(Sy)4(s)-3(tems)-3( )9(D)-3(o)] TJ
+ET
+
+endstream 
+endobj xref
+0 8
+0000000000 65535 f 
+0000000015 00000 n 
+0000000262 00000 n 
+0000000576 00000 n 
+0000000627 00000 n 
+0000000709 00000 n 
+0000000838 00000 n 
+0000001018 00000 n 
+trailer
+
+<<
+/Root 3 0 R
+/Size 8
+>>
+startxref
+1175
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1765,6 +1765,13 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "issue8697",
+       "file": "pdfs/issue8697.pdf",
+       "md5": "65c6f0d861d49fa685051a64c3f78694",
+       "link": false,
+       "rounds": 1,
+       "type": "eq"
+    },
     {  "id": "non-embedded-NuptialScript",
        "file": "pdfs/non-embedded-NuptialScript.pdf",
        "md5": "94225085d3fbf5d2d12b8be1c52bb3c1",


### PR DESCRIPTION
The PDF file uses a non-embedded SegoeUISymbol font, which is *not* a standard font (and is mainly used by Microsoft, see https://en.wikipedia.org/wiki/Segoe).

Fixes #8697.