### PR TITLE
[FIX] ui_utils.js -> parseQueryString

### DIFF
--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -217,7 +217,7 @@ function parseQueryString(query) {
   for (let i = 0, ii = parts.length; i < ii; ++i) {
     let param = parts[i].split('=');
     let key = param[0].toLowerCase();
-    let value = param.length > 1 ? param[1] : null;
+    let value = param.length > 1 ? param.slice(1, param.length).join("=") : null;
     params[decodeURIComponent(key)] = decodeURIComponent(value);
   }
   return params;


### PR DESCRIPTION
A complex URL passed to the file parameter gets cut off.

input: ?file=/web/preview/converter/msoffice?url=%2Fweb%2Fcontent%2F8279%3Fdownload%3Dtrue&title=Rechnung.docx

output: file = /web/preview/converter/msoffice?url

Changed the function parseQueryString to fix this issue.