### PR TITLE
Use streams-lib as polyfill

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1040,7 +1040,7 @@ gulp.task('lib', ['buildnumber'], function () {
   var buildLib = merge([
     gulp.src([
       'src/{core,display}/*.js',
-      'src/shared/{compatibility,util}.js',
+      'src/shared/{compatibility,util,streams_polyfill}.js',
       'src/{pdf,pdf.worker}.js',
     ], { base: 'src/', }),
     gulp.src([

--- a/src/shared/streams_polyfill.js
+++ b/src/shared/streams_polyfill.js
@@ -1,0 +1,24 @@
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+if (typeof ReadableStream !== 'undefined') {
+  exports.ReadableStream = ReadableStream;
+} else {
+  if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('CHROME')) {
+    throw new Error('ReadableStream polyfill is not found for Chrome bundle');
+  }
+  exports.ReadableStream =
+    require('../../external/streams/streams-lib').ReadableStream;
+}

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -14,7 +14,7 @@
  */
 
 import './compatibility';
-import { ReadableStream } from '../../external/streams/streams-lib';
+import { ReadableStream } from './streams_polyfill';
 
 var globalScope =
   (typeof window !== 'undefined' && window.Math === Math) ? window :


### PR DESCRIPTION
Chrome natively supports [ReadableStream](https://bugs.chromium.org/p/chromium/issues/detail?id=503491) and Firefox will soon have it (for now via `dom.streams.enabled`). Changing util.js to allow conditionally include ReadableStream as polyfill.