### PR TITLE
Move the `XRefMock` in the unit tests to a central location

### DIFF
--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -20,31 +20,12 @@ import {
   AnnotationBorderStyleType, AnnotationFieldFlag, AnnotationFlag,
   AnnotationType, stringToBytes, stringToUTF8String
 } from '../../src/shared/util';
-import { Dict, isRef, Name, Ref } from '../../src/core/primitives';
+import { Dict, Name, Ref } from '../../src/core/primitives';
 import { Lexer, Parser } from '../../src/core/parser';
 import { StringStream } from '../../src/core/stream';
+import { XRefMock } from './test_utils';
 
 describe('annotation', function() {
-  function XRefMock(array) {
-    this.map = Object.create(null);
-    for (var elem in array) {
-      var obj = array[elem];
-      var ref = obj.ref, data = obj.data;
-      this.map[ref.toString()] = data;
-    }
-  }
-  XRefMock.prototype = {
-    fetch(ref) {
-      return this.map[ref.toString()];
-    },
-    fetchIfRef(obj) {
-      if (!isRef(obj)) {
-        return obj;
-      }
-      return this.fetch(obj);
-    },
-  };
-
   function PDFManagerMock(params) {
     this.docBaseUrl = params.docBaseUrl || null;
   }

--- a/test/unit/colorspace_spec.js
+++ b/test/unit/colorspace_spec.js
@@ -13,34 +13,12 @@
  * limitations under the License.
  */
 
-import { Dict, isRef, Name, Ref } from '../../src/core/primitives';
+import { Dict, Name, Ref } from '../../src/core/primitives';
 import { Stream, StringStream } from '../../src/core/stream';
 import { ColorSpace } from '../../src/core/colorspace';
+import { XRefMock } from './test_utils';
 
 describe('colorspace', function () {
-  class XRefMock {
-    constructor(array) {
-      this.map = Object.create(null);
-      for (let elem in array) {
-        let obj = array[elem];
-        let ref = obj.ref;
-        let data = obj.data;
-        this.map[ref.toString()] = data;
-      }
-    }
-
-    fetch(ref) {
-      return this.map[ref.toString()];
-    }
-
-    fetchIfRef(obj) {
-      if (!isRef(obj)) {
-        return obj;
-      }
-      return this.fetch(obj);
-    }
-  }
-
   describe('ColorSpace', function () {
     it('should be true if decode is not an array', function () {
       expect(ColorSpace.isDefaultDecode('string', 0)).toBeTruthy();

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -18,16 +18,9 @@ import { OperatorList, PartialEvaluator } from '../../src/core/evaluator';
 import { Stream, StringStream } from '../../src/core/stream';
 import { OPS } from '../../src/shared/util';
 import { WorkerTask } from '../../src/core/worker';
+import { XRefMock } from './test_utils';
 
 describe('evaluator', function() {
-  function XrefMock(queue) {
-    this.queue = queue || [];
-  }
-  XrefMock.prototype = {
-    fetchIfRef() {
-      return this.queue.shift();
-    },
-  };
   function HandlerMock() {
     this.inputs = [];
   }
@@ -63,7 +56,7 @@ describe('evaluator', function() {
   beforeAll(function(done) {
     partialEvaluator = new PartialEvaluator({
       pdfManager: new PdfManagerMock(),
-      xref: new XrefMock(),
+      xref: new XRefMock(),
       handler: new HandlerMock(),
       pageIndex: 0,
     });

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -16,34 +16,9 @@
 import {
   Cmd, Dict, isCmd, isDict, isName, isRef, isRefsEqual, Name, Ref, RefSet
 } from '../../src/core/primitives';
+import { XRefMock } from './test_utils';
 
 describe('primitives', function() {
-  function XRefMock(array) {
-    this.map = Object.create(null);
-    for (var elem in array) {
-      var obj = array[elem];
-      var ref = obj.ref, data = obj.data;
-      this.map[ref.toString()] = data;
-    }
-  }
-  XRefMock.prototype = {
-    fetch(ref) {
-      return this.map[ref.toString()];
-    },
-    fetchIfRef(obj) {
-      if (!isRef(obj)) {
-        return obj;
-      }
-      return this.fetch(obj);
-    },
-    fetchAsync(ref) {
-      return Promise.resolve(this.fetch(ref));
-    },
-    fetchIfRefAsync(obj) {
-      return Promise.resolve(this.fetchIfRef(obj));
-    },
-  };
-
   describe('Name', function() {
     it('should retain the given name', function() {
       var givenName = 'Font';

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -14,6 +14,7 @@
  */
 
 import { CMapCompressionType, isNodeJS } from '../../src/shared/util';
+import { isRef } from '../../src/core/primitives';
 
 class NodeFileReaderFactory {
   static fetch(params) {
@@ -74,9 +75,40 @@ class NodeCMapReaderFactory {
   }
 }
 
+class XRefMock {
+  constructor(array) {
+    this._map = Object.create(null);
+
+    for (let key in array) {
+      let obj = array[key];
+      this._map[obj.ref.toString()] = obj.data;
+    }
+  }
+
+  fetch(ref) {
+    return this._map[ref.toString()];
+  }
+
+  fetchAsync(ref) {
+    return Promise.resolve(this.fetch(ref));
+  }
+
+  fetchIfRef(obj) {
+    if (!isRef(obj)) {
+      return obj;
+    }
+    return this.fetch(obj);
+  }
+
+  fetchIfRefAsync(obj) {
+    return Promise.resolve(this.fetchIfRef(obj));
+  }
+}
+
 export {
   NodeFileReaderFactory,
   NodeCMapReaderFactory,
+  XRefMock,
   buildGetDocumentParams,
   TEST_PDFS_PATH,
 };


### PR DESCRIPTION
This patch helps to avoid code duplication for this mock since more unit tests are depending on it.