### PR TITLE
Ensure that the loadingBar isn't displayed again when the entire file has already been fetched

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -846,6 +846,11 @@ let PDFViewerApplication = {
   },
 
   progress(level) {
+    if (this.downloadComplete) {
+      // Don't accidentally show the loading bar again when the entire file has
+      // already been fetched (only an issue when disableAutoFetch is enabled).
+      return;
+    }
     let percent = Math.round(level * 100);
     // When we transition from full request to range requests, it's possible
     // that we discard some of the loaded data. This can cause the loading


### PR DESCRIPTION
This could only (potentially) happen when `disableAutoFetch` is used.

*Edit:* This at least avoids the weird loadingBar behaviour described in https://github.com/mozilla/pdf.js/pull/8617#issuecomment-318646822, since based on the discussion there it seems that the underlying behaviour may be intermittent (and I really don't have the time to try and get to the bottom of it).