### PR TITLE
Reduces the amount of data send via GetDocRequest.

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -340,7 +340,14 @@ function _fetchDocument(worker, source, pdfDataRangeTransport, docId) {
   }
   return worker.messageHandler.sendWithPromise('GetDocRequest', {
     docId,
-    source,
+    source: {
+      data: source.data,
+      url: source.url,
+      password: source.password,
+      disableAutoFetch: source.disableAutoFetch,
+      rangeChunkSize: source.rangeChunkSize,
+      length: source.length,
+    },
     maxImageSize: getDefaultSetting('maxImageSize'),
     disableFontFace: getDefaultSetting('disableFontFace'),
     disableCreateObjectURL: getDefaultSetting('disableCreateObjectURL'),


### PR DESCRIPTION
This PR reduces the amount of data sent via `GetDocRequest`. As mentioned [here](https://github.com/mozilla/pdf.js/pull/8617#issuecomment-314561873), this fulfills one of the TODOs of #8617 .