### PR TITLE
Delete workerPort to PDFWorker cache after PDFWorker destroy

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1519,6 +1519,7 @@ var PDFWorker = (function PDFWorkerClosure() {
         this._webWorker.terminate();
         this._webWorker = null;
       }
+      pdfWorkerPorts.delete(this._port);
       this._port = null;
       if (this._messageHandler) {
         this._messageHandler.destroy();


### PR DESCRIPTION
I investigate that issue: 
FranckFreiburger/vue-pdf#9

Found out that even after PDFWorker is destroy, it not deleted from pdfWorkerPorts , what cause problems when workerPort and reusing pdf.js several times.

PDFDocumentLoadingTask destroy function call to to _worker(PDFWorker) destory.
When we gonna get another document we get a destroyed PDFWorker.

this should fix that