### PR TITLE
Properly cancel streams and guard at getTextContent.

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -14,10 +14,10 @@
  */
 
 import {
-  assert, CMapCompressionType, createPromiseCapability, FONT_IDENTITY_MATRIX,
-  FormatError, getLookupTableFactory, IDENTITY_MATRIX, ImageKind, info, isArray,
-  isNum, isString, NativeImageDecoding, OPS, TextRenderingMode,
-  UNSUPPORTED_FEATURES, Util, warn
+  AbortException, assert, CMapCompressionType, createPromiseCapability,
+  FONT_IDENTITY_MATRIX, FormatError, getLookupTableFactory, IDENTITY_MATRIX,
+  ImageKind, info, isArray, isNum, isString, NativeImageDecoding, OPS,
+  TextRenderingMode, UNSUPPORTED_FEATURES, Util, warn
 } from '../shared/util';
 import { CMapFactory, IdentityCMap } from './cmap';
 import { DecodeStream, JpegStream, Stream } from './stream';
@@ -1744,6 +1744,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         enqueueChunk();
         resolve();
       }).catch((reason) => {
+        if (reason instanceof AbortException) {
+          return;
+        }
         if (this.options.ignoreErrors) {
           // Error(s) in the TextContent -- allow text-extraction to continue.
           warn('getTextContent - ignoring errors during task: ' + task.name);

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { createPromiseCapability, Util } from '../shared/util';
+import { AbortException, createPromiseCapability, Util } from '../shared/util';
 import { CustomStyle, getDefaultSetting } from './dom_utils';
 
 /**
@@ -498,7 +498,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
 
     cancel: function TextLayer_cancel() {
       if (this._reader) {
-        this._reader.cancel();
+        this._reader.cancel(new AbortException('text layer task cancelled'));
         this._reader = null;
       }
       this._canceled = true;

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -500,6 +500,21 @@ let FormatError = (function FormatErrorClosure() {
   return FormatError;
 })();
 
+/**
+ * Error used to indicate task cancellation.
+ */
+let AbortException = (function AbortExceptionClosure() {
+  function AbortException(msg) {
+    this.name = 'AbortException';
+    this.message = msg;
+  }
+
+  AbortException.prototype = new Error();
+  AbortException.constructor = AbortException;
+
+  return AbortException;
+})();
+
 var NullCharactersRegExp = /\x00/g;
 
 function removeNullCharacters(str) {
@@ -1227,6 +1242,8 @@ function wrapReason(reason) {
     return reason;
   }
   switch (reason.name) {
+    case 'AbortException':
+      return new AbortException(reason.message);
     case 'MissingPDFException':
       return new MissingPDFException(reason.message);
     case 'UnexpectedResponseException':
@@ -1273,7 +1290,7 @@ function MessageHandler(sourceName, targetName, comObj) {
         let callback = callbacksCapabilities[callbackId];
         delete callbacksCapabilities[callbackId];
         if ('error' in data) {
-          callback.reject(data.error);
+          callback.reject(wrapReason(data.error));
         } else {
           callback.resolve(data.data);
         }
@@ -1651,6 +1668,7 @@ export {
   FontType,
   ImageKind,
   CMapCompressionType,
+  AbortException,
   InvalidPDFException,
   MessageHandler,
   MissingDataException,


### PR DESCRIPTION
Addresses warnings described at https://github.com/mozilla/pdf.js/pull/8696#issuecomment-319036696