### PR TITLE
Remove leftover `args[0].code` checks from the `OPS.paintXObject` cases in evaluator.js

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -915,9 +915,6 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
           switch (fn | 0) {
             case OPS.paintXObject:
-              if (args[0].code) {
-                break;
-              }
               // eagerly compile XForm objects
               var name = args[0].name;
               if (!name) {
@@ -1631,10 +1628,6 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
               break;
             case OPS.paintXObject:
               flushTextContentItem();
-              if (args[0].code) {
-                break;
-              }
-
               if (!xobjs) {
                 xobjs = (resources.get('XObject') || Dict.empty);
               }


### PR DESCRIPTION
From looking at blame, it seems that these checks became obsolete with PR #692 (which landed close to six years ago). Note how, after that PR, there's no longer anything being assigned to the `code` property of an Object.