### PR TITLE
Fallback to plain object for globalScope.

### DIFF
--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -24,7 +24,8 @@ if ((typeof PDFJSDev === 'undefined' ||
 var globalScope =
   (typeof window !== 'undefined' && window.Math === Math) ? window :
   (typeof global !== 'undefined' && global.Math === Math) ? global :
-  (typeof self !== 'undefined' && self.Math === Math) ? self : this;
+  (typeof self !== 'undefined' && self.Math === Math) ? self :
+  (typeof this !== 'undefined' && this.Math === Math) ? this : {};
 
 var userAgent = (typeof navigator !== 'undefined' && navigator.userAgent) || '';
 var isAndroid = /Android/.test(userAgent);


### PR DESCRIPTION
When loading PDF.js in non-browser,non-node,strict-mode environments (e.g. loading within a jsm module), globalScope is set to undefined. Should fallback to a plain object instead.