### PR TITLE
Replace the `coded` property with `isType3Font` when building the font `properties` object in `PartialEvaluator.translateFont`

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -2459,7 +2459,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         capHeight: descriptor.get('CapHeight'),
         flags: descriptor.get('Flags'),
         italicAngle: descriptor.get('ItalicAngle'),
-        coded: false,
+        isType3Font: false,
       };
 
       var cMapPromise;


### PR DESCRIPTION
This appears to simply have been forgotten in the re-factoring in PR #4815, where the `coded` property was renamed to the *much* more descriptive `isType3Font` property.