### PR TITLE
Use `Uint8ClampedArray`, when returning data, and remove manual clamping in `src/core/jpg.js` (issue 4901)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "babel-loader": "^6.4.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
+    "core-js": "^2.5.0",
     "escodegen": "^1.8.0",
     "eslint": "^4.2.0",
     "eslint-plugin-mozilla": "^0.4.0",

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -53,6 +53,12 @@ PDFJS.compatibilityChecked = true;
 // Checking if the typed arrays are supported
 // Support: iOS<6.0 (subarray), IE<10, Android<4.0
 (function checkTypedArrayCompatibility() {
+  if (typeof Uint8ClampedArray === 'undefined') {
+    // Support: IE<11
+    globalScope.Uint8ClampedArray =
+      require('core-js/fn/typed/uint8-clamped-array');
+  }
+
   if (typeof Uint8Array !== 'undefined') {
     // Support: iOS<6.0
     if (typeof Uint8Array.prototype.subarray === 'undefined') {

--- a/systemjs.config.js
+++ b/systemjs.config.js
@@ -50,6 +50,7 @@
       'pdfjs-web': new URL('web', baseLocation).href,
       'pdfjs-test': new URL('test', baseLocation).href,
       'pdfjs-lib': new URL('src/pdf', baseLocation).href,
+      'core-js': new URL('node_modules/core-js', baseLocation).href,
     },
     meta: {
       '*': {

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -45,10 +45,6 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!--#endif-->
 
 <!--#if !PRODUCTION-->
-    <script src="../src/shared/compatibility.js"></script>
-<!--#endif-->
-
-<!--#if !PRODUCTION-->
     <script src="../node_modules/systemjs/dist/system.js"></script>
     <script src="../systemjs.config.js"></script>
 <!--#endif-->


### PR DESCRIPTION
This patch removes the `clamp0to255` helper function, as well as manual clamping code in `src/core/jpg.js`.
The adjusted constants in `_convertCmykToRgb` were taken from CMYK to RGB conversion code found in `src/core/colorspace.js`.

*Please note:* There will be some very slight movement in a number of existing test-cases, since `Uint8ClampedArray` appears to use `Math.round` (or equivalent) and the old code used (basically) `Math.floor`.

Fixes #4901.
