### PR TITLE
SVG: Don't render missing glyphs

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -742,15 +742,23 @@ SVGGraphics = (function SVGGraphicsClosure() {
           x += -glyph * fontSize * 0.001;
           continue;
         }
-        current.xcoords.push(current.x + x * textHScale);
 
         var width = glyph.width;
         var character = glyph.fontChar;
         var spacing = (glyph.isSpace ? wordSpacing : 0) + charSpacing;
         var charWidth = width * widthAdvanceScale + spacing * fontDirection;
-        x += charWidth;
 
+        if (!glyph.isInFont && !font.missingFile) {
+          x += charWidth;
+          // TODO: To assist with text selection, we should replace the missing
+          // character with a space character if charWidth is not zero.
+          // But we cannot just do "character = ' '", because the ' ' character
+          // might actually map to a different glyph.
+          continue;
+        }
+        current.xcoords.push(current.x + x * textHScale);
         current.tspan.textContent += character;
+        x += charWidth;
       }
       if (vertical) {
         current.y -= x * textHScale;


### PR DESCRIPTION
This bug is similar to the canvas bug of #6721, which was fixed by #7023

See commit description for more info and test cases.

New reduced test case introduced with this PR:
- File: https://github.com/mozilla/pdf.js/files/1229507/pcdatainvalidchar.pdf
- Expected rendered result: "hardware performance"
- Actual SVG source (can be generated with `node examples/node/pdf2svg.js pcdatainvalidchar.pdf`): "hardware\x03performance"

(I did not add an automated test because we don't have any ref test framework for SVG (e.g. painting SVG on a canvas, and then doing an image comparison, as done in #5863 - somehow that issue was closed without follow-up...).

The test case from #6721 can be used here too:
- File: https://github.com/mozilla/pdf.js/files/52205/issue6721_reduced.pdf
- Expected: "Issue   6721"
- Actual rendered result (before this patch): "Issue ààà6721"
