### PR TITLE
Attempt to delay disabling of the attachment view until FileAttachment annotations of the *initial* page has been parsed

### DIFF
--- a/web/pdf_attachment_viewer.js
+++ b/web/pdf_attachment_viewer.js
@@ -62,12 +62,12 @@ class PDFAttachmentViewer {
    * @private
    */
   _dispatchEvent(attachmentsCount) {
+    this._renderedCapability.resolve();
+
     this.eventBus.dispatch('attachmentsloaded', {
       source: this,
       attachmentsCount,
     });
-
-    this._renderedCapability.resolve();
   }
 
   /**

--- a/web/pdf_attachment_viewer.js
+++ b/web/pdf_attachment_viewer.js
@@ -35,13 +35,12 @@ class PDFAttachmentViewer {
    * @param {PDFAttachmentViewerOptions} options
    */
   constructor({ container, eventBus, downloadManager, }) {
-    this.attachments = null;
-
     this.container = container;
     this.eventBus = eventBus;
     this.downloadManager = downloadManager;
 
-    this._renderedCapability = createPromiseCapability();
+    this.reset();
+
     this.eventBus.on('fileattachmentannotation',
       this._appendAttachment.bind(this));
   }

--- a/web/pdf_outline_viewer.js
+++ b/web/pdf_outline_viewer.js
@@ -36,12 +36,11 @@ class PDFOutlineViewer {
    * @param {PDFOutlineViewerOptions} options
    */
   constructor({ container, linkService, eventBus, }) {
-    this.outline = null;
-    this.lastToggleIsShow = true;
-
     this.container = container;
     this.linkService = linkService;
     this.eventBus = eventBus;
+
+    this.reset();
   }
 
   reset() {


### PR DESCRIPTION
As discussed in PR https://github.com/mozilla/pdf.js/pull/8673#issuecomment-317241023, we cannot solve the general issue (since that would require parsing every single page). However, we can mitigate the effect somewhat, by waiting for the FileAttachment annotations of the initially rendered page.


