### PR TITLE
Convert `ColorSpace` and `PDFImage` to use `Uint8ClampedArray`s as output from its various methods

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -254,6 +254,7 @@ class Annotation {
 
   /**
    * Set the color and take care of color space conversion.
+   * The default value is black, in RGB color space.
    *
    * @public
    * @memberof Annotation
@@ -262,7 +263,7 @@ class Annotation {
    *                        4 (CMYK) elements
    */
   setColor(color) {
-    let rgbColor = new Uint8Array(3); // Black in RGB color space (default)
+    let rgbColor = new Uint8ClampedArray(3);
     if (!Array.isArray(color)) {
       this.color = rgbColor;
       return;

--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -183,14 +183,16 @@ var ChunkedStream = (function ChunkedStreamClosure() {
 
     // returns subarray of original buffer
     // should only be read
-    getBytes: function ChunkedStream_getBytes(length) {
+    getBytes(length, clampedArray = false) {
       var bytes = this.bytes;
       var pos = this.pos;
       var strEnd = this.end;
 
       if (!length) {
         this.ensureRange(pos, strEnd);
-        return bytes.subarray(pos, strEnd);
+        let subarray = bytes.subarray(pos, strEnd);
+        return !clampedArray || subarray instanceof Uint8ClampedArray ?
+               subarray : new Uint8ClampedArray(subarray);
       }
 
       var end = pos + length;
@@ -200,7 +202,9 @@ var ChunkedStream = (function ChunkedStreamClosure() {
       this.ensureRange(pos, end);
 
       this.pos = end;
-      return bytes.subarray(pos, end);
+      let subarray = bytes.subarray(pos, end);
+      return !clampedArray || subarray instanceof Uint8ClampedArray ?
+             subarray : new Uint8ClampedArray(subarray);
     },
 
     peekByte: function ChunkedStream_peekByte() {
@@ -209,8 +213,8 @@ var ChunkedStream = (function ChunkedStreamClosure() {
       return peekedByte;
     },
 
-    peekBytes: function ChunkedStream_peekBytes(length) {
-      var bytes = this.getBytes(length);
+    peekBytes(length, clampedArray = false) {
+      var bytes = this.getBytes(length, clampedArray);
       this.pos -= bytes.length;
       return bytes;
     },

--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -64,7 +64,7 @@ var ColorSpace = (function ColorSpaceClosure() {
      * located in the src array starting from the srcOffset. Returns the array
      * of the rgb components, each value ranging from [0,255].
      */
-    getRgb: function ColorSpace_getRgb(src, srcOffset) {
+    getRgb(src, srcOffset) {
       let rgb = new Uint8ClampedArray(3);
       this.getRgbItem(src, srcOffset, rgb, 0);
       return rgb;
@@ -73,8 +73,7 @@ var ColorSpace = (function ColorSpaceClosure() {
      * Converts the color value to the RGB color, similar to the getRgb method.
      * The result placed into the dest array starting from the destOffset.
      */
-    getRgbItem: function ColorSpace_getRgbItem(src, srcOffset,
-                                               dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       throw new Error('Should not call ColorSpace.getRgbItem');
     },
     /**
@@ -86,9 +85,7 @@ var ColorSpace = (function ColorSpaceClosure() {
      * there are in the dest array; it will be either 0 (RGB array) or 1 (RGBA
      * array).
      */
-    getRgbBuffer: function ColorSpace_getRgbBuffer(src, srcOffset, count,
-                                                   dest, destOffset, bits,
-                                                   alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       throw new Error('Should not call ColorSpace.getRgbBuffer');
     },
     /**
@@ -96,14 +93,13 @@ var ColorSpace = (function ColorSpaceClosure() {
      * conversion done by the getRgbBuffer method. As in getRgbBuffer,
      * |alpha01| is either 0 (RGB output) or 1 (RGBA output).
      */
-    getOutputLength: function ColorSpace_getOutputLength(inputLength,
-                                                         alpha01) {
+    getOutputLength(inputLength, alpha01) {
       throw new Error('Should not call ColorSpace.getOutputLength');
     },
     /**
      * Returns true if source data will be equal the result/output data.
      */
-    isPassthrough: function ColorSpace_isPassthrough(bits) {
+    isPassthrough(bits) {
       return false;
     },
     /**
@@ -111,9 +107,8 @@ var ColorSpace = (function ColorSpaceClosure() {
      * how many alpha components there are in the dest array; it will be either
      * 0 (RGB array) or 1 (RGBA array).
      */
-    fillRgb: function ColorSpace_fillRgb(dest, originalWidth,
-                                         originalHeight, width, height,
-                                         actualHeight, bpc, comps, alpha01) {
+    fillRgb(dest, originalWidth, originalHeight, width, height, actualHeight,
+            bpc, comps, alpha01) {
       if (!(dest instanceof Uint8ClampedArray)) {
         throw new Error('dest should be a Uint8ClampedArray.');
       }
@@ -436,8 +431,7 @@ var AlternateCS = (function AlternateCSClosure() {
 
   AlternateCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function AlternateCS_getRgbItem(src, srcOffset,
-                                                dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       if (!(dest instanceof Uint8ClampedArray)) {
         throw new Error('dest should be a Uint8ClampedArray.');
       }
@@ -445,9 +439,7 @@ var AlternateCS = (function AlternateCSClosure() {
       this.tintFn(src, srcOffset, tmpBuf, 0);
       this.base.getRgbItem(tmpBuf, 0, dest, destOffset);
     },
-    getRgbBuffer: function AlternateCS_getRgbBuffer(src, srcOffset, count,
-                                                    dest, destOffset, bits,
-                                                    alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       if (!(dest instanceof Uint8ClampedArray)) {
         throw new Error('dest should be a Uint8ClampedArray.');
       }
@@ -486,15 +478,14 @@ var AlternateCS = (function AlternateCSClosure() {
         base.getRgbBuffer(baseBuf, 0, count, dest, destOffset, 8, alpha01);
       }
     },
-    getOutputLength: function AlternateCS_getOutputLength(inputLength,
-                                                          alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return this.base.getOutputLength(inputLength *
                                        this.base.numComps / this.numComps,
                                        alpha01);
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function AlternateCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     },
     usesZeroToOneRange: true,
@@ -542,8 +533,7 @@ var IndexedCS = (function IndexedCSClosure() {
 
   IndexedCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function IndexedCS_getRgbItem(src, srcOffset,
-                                              dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       if (!(dest instanceof Uint8ClampedArray)) {
         throw new Error('dest should be a Uint8ClampedArray.');
       }
@@ -551,9 +541,7 @@ var IndexedCS = (function IndexedCSClosure() {
       var start = src[srcOffset] * numComps;
       this.base.getRgbBuffer(this.lookup, start, 1, dest, destOffset, 8, 0);
     },
-    getRgbBuffer: function IndexedCS_getRgbBuffer(src, srcOffset, count,
-                                                  dest, destOffset, bits,
-                                                  alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       if (!(dest instanceof Uint8ClampedArray)) {
         throw new Error('dest should be a Uint8ClampedArray.');
       }
@@ -568,13 +556,13 @@ var IndexedCS = (function IndexedCSClosure() {
         destOffset += outputDelta;
       }
     },
-    getOutputLength: function IndexedCS_getOutputLength(inputLength, alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return this.base.getOutputLength(inputLength * this.base.numComps,
                                        alpha01);
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function IndexedCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       // indexed color maps shouldn't be changed
       return true;
     },
@@ -592,17 +580,14 @@ var DeviceGrayCS = (function DeviceGrayCSClosure() {
 
   DeviceGrayCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function DeviceGrayCS_getRgbItem(src, srcOffset,
-                                                 dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       if (!(dest instanceof Uint8ClampedArray)) {
         throw new Error('dest should be a Uint8ClampedArray.');
       }
       let c = src[srcOffset] * 255;
       dest[destOffset] = dest[destOffset + 1] = dest[destOffset + 2] = c;
     },
-    getRgbBuffer: function DeviceGrayCS_getRgbBuffer(src, srcOffset, count,
-                                                     dest, destOffset, bits,
-                                                     alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       if (!(dest instanceof Uint8ClampedArray)) {
         throw new Error('dest should be a Uint8ClampedArray.');
       }
@@ -616,13 +601,12 @@ var DeviceGrayCS = (function DeviceGrayCSClosure() {
         q += alpha01;
       }
     },
-    getOutputLength: function DeviceGrayCS_getOutputLength(inputLength,
-                                                           alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return inputLength * (3 + alpha01);
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function DeviceGrayCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     },
     usesZeroToOneRange: true,
@@ -638,8 +622,7 @@ var DeviceRgbCS = (function DeviceRgbCSClosure() {
   }
   DeviceRgbCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function DeviceRgbCS_getRgbItem(src, srcOffset,
-                                                dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       if (!(dest instanceof Uint8ClampedArray)) {
         throw new Error('dest should be a Uint8ClampedArray.');
       }
@@ -647,9 +630,7 @@ var DeviceRgbCS = (function DeviceRgbCSClosure() {
       dest[destOffset + 1] = src[srcOffset + 1] * 255;
       dest[destOffset + 2] = src[srcOffset + 2] * 255;
     },
-    getRgbBuffer: function DeviceRgbCS_getRgbBuffer(src, srcOffset, count,
-                                                    dest, destOffset, bits,
-                                                    alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       if (!(dest instanceof Uint8ClampedArray)) {
         throw new Error('dest should be a Uint8ClampedArray.');
       }
@@ -666,15 +647,14 @@ var DeviceRgbCS = (function DeviceRgbCSClosure() {
         q += alpha01;
       }
     },
-    getOutputLength: function DeviceRgbCS_getOutputLength(inputLength,
-                                                          alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return (inputLength * (3 + alpha01) / 3) | 0;
     },
-    isPassthrough: function DeviceRgbCS_isPassthrough(bits) {
+    isPassthrough(bits) {
       return bits === 8;
     },
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function DeviceRgbCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     },
     usesZeroToOneRange: true,
@@ -734,16 +714,13 @@ var DeviceCmykCS = (function DeviceCmykCSClosure() {
   }
   DeviceCmykCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function DeviceCmykCS_getRgbItem(src, srcOffset,
-                                                 dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       if (!(dest instanceof Uint8ClampedArray)) {
         throw new Error('dest should be a Uint8ClampedArray.');
       }
       convertToRgb(src, srcOffset, 1, dest, destOffset);
     },
-    getRgbBuffer: function DeviceCmykCS_getRgbBuffer(src, srcOffset, count,
-                                                     dest, destOffset, bits,
-                                                     alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       if (!(dest instanceof Uint8ClampedArray)) {
         throw new Error('dest should be a Uint8ClampedArray.');
       }
@@ -754,13 +731,12 @@ var DeviceCmykCS = (function DeviceCmykCSClosure() {
         destOffset += 3 + alpha01;
       }
     },
-    getOutputLength: function DeviceCmykCS_getOutputLength(inputLength,
-                                                           alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return (inputLength / 4 * (3 + alpha01)) | 0;
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function DeviceCmykCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     },
     usesZeroToOneRange: true,
@@ -838,16 +814,13 @@ var CalGrayCS = (function CalGrayCSClosure() {
 
   CalGrayCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function CalGrayCS_getRgbItem(src, srcOffset,
-                                              dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       if (!(dest instanceof Uint8ClampedArray)) {
         throw new Error('dest should be a Uint8ClampedArray.');
       }
       convertToRgb(this, src, srcOffset, dest, destOffset, 1);
     },
-    getRgbBuffer: function CalGrayCS_getRgbBuffer(src, srcOffset, count,
-                                                  dest, destOffset, bits,
-                                                  alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       if (!(dest instanceof Uint8ClampedArray)) {
         throw new Error('dest should be a Uint8ClampedArray.');
       }
@@ -859,12 +832,12 @@ var CalGrayCS = (function CalGrayCSClosure() {
         destOffset += 3 + alpha01;
       }
     },
-    getOutputLength: function CalGrayCS_getOutputLength(inputLength, alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return inputLength * (3 + alpha01);
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function CalGrayCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     },
     usesZeroToOneRange: true,
@@ -876,7 +849,6 @@ var CalGrayCS = (function CalGrayCSClosure() {
 // CalRGBCS: Based on "PDF Reference, Sixth Ed", p.247
 //
 var CalRGBCS = (function CalRGBCSClosure() {
-
   // See http://www.brucelindbloom.com/index.html?Eqn_ChromAdapt.html for these
   // matrices.
   var BRADFORD_SCALE_MATRIX = new Float32Array([
@@ -1020,7 +992,6 @@ var CalRGBCS = (function CalRGBCSClosure() {
   }
 
   function compensateBlackPoint(sourceBlackPoint, XYZ_Flat, result) {
-
     // In case the blackPoint is already the default blackPoint then there is
     // no need to do compensation.
     if (sourceBlackPoint[0] === 0 &&
@@ -1062,7 +1033,6 @@ var CalRGBCS = (function CalRGBCSClosure() {
   }
 
   function normalizeWhitePointToFlat(sourceWhitePoint, XYZ_In, result) {
-
     // In case the whitePoint is already flat then there is no need to do
     // normalization.
     if (sourceWhitePoint[0] === 1 && sourceWhitePoint[2] === 1) {
@@ -1082,7 +1052,6 @@ var CalRGBCS = (function CalRGBCSClosure() {
   }
 
   function normalizeWhitePointToD65(sourceWhitePoint, XYZ_In, result) {
-
     var LMS = result;
     matrixProduct(BRADFORD_SCALE_MATRIX, XYZ_In, LMS);
 
@@ -1140,16 +1109,13 @@ var CalRGBCS = (function CalRGBCSClosure() {
 
   CalRGBCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function CalRGBCS_getRgbItem(src, srcOffset,
-                                             dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       if (!(dest instanceof Uint8ClampedArray)) {
         throw new Error('dest should be a Uint8ClampedArray.');
       }
       convertToRgb(this, src, srcOffset, dest, destOffset, 1);
     },
-    getRgbBuffer: function CalRGBCS_getRgbBuffer(src, srcOffset, count,
-                                                 dest, destOffset, bits,
-                                                 alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       if (!(dest instanceof Uint8ClampedArray)) {
         throw new Error('dest should be a Uint8ClampedArray.');
       }
@@ -1161,12 +1127,12 @@ var CalRGBCS = (function CalRGBCSClosure() {
         destOffset += 3 + alpha01;
       }
     },
-    getOutputLength: function CalRGBCS_getOutputLength(inputLength, alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return (inputLength * (3 + alpha01) / 3) | 0;
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function CalRGBCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     },
     usesZeroToOneRange: true,
@@ -1292,15 +1258,13 @@ var LabCS = (function LabCSClosure() {
 
   LabCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function LabCS_getRgbItem(src, srcOffset, dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       if (!(dest instanceof Uint8ClampedArray)) {
         throw new Error('dest should be a Uint8ClampedArray.');
       }
       convertToRgb(this, src, srcOffset, false, dest, destOffset);
     },
-    getRgbBuffer: function LabCS_getRgbBuffer(src, srcOffset, count,
-                                              dest, destOffset, bits,
-                                              alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       if (!(dest instanceof Uint8ClampedArray)) {
         throw new Error('dest should be a Uint8ClampedArray.');
       }
@@ -1311,12 +1275,12 @@ var LabCS = (function LabCSClosure() {
         destOffset += 3 + alpha01;
       }
     },
-    getOutputLength: function LabCS_getOutputLength(inputLength, alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return (inputLength * (3 + alpha01) / 3) | 0;
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function LabCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       // XXX: Decoding is handled with the lab conversion because of the strange
       // ranges that are used.
       return true;

--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -114,6 +114,9 @@ var ColorSpace = (function ColorSpaceClosure() {
     fillRgb: function ColorSpace_fillRgb(dest, originalWidth,
                                          originalHeight, width, height,
                                          actualHeight, bpc, comps, alpha01) {
+      if (!(dest instanceof Uint8ClampedArray)) {
+        throw new Error('dest should be a Uint8ClampedArray.');
+      }
       var count = originalWidth * originalHeight;
       var rgbBuf = null;
       var numComponentColors = 1 << bpc;
@@ -435,6 +438,9 @@ var AlternateCS = (function AlternateCSClosure() {
     getRgb: ColorSpace.prototype.getRgb,
     getRgbItem: function AlternateCS_getRgbItem(src, srcOffset,
                                                 dest, destOffset) {
+      if (!(dest instanceof Uint8ClampedArray)) {
+        throw new Error('dest should be a Uint8ClampedArray.');
+      }
       var tmpBuf = this.tmpBuf;
       this.tintFn(src, srcOffset, tmpBuf, 0);
       this.base.getRgbItem(tmpBuf, 0, dest, destOffset);
@@ -442,6 +448,9 @@ var AlternateCS = (function AlternateCSClosure() {
     getRgbBuffer: function AlternateCS_getRgbBuffer(src, srcOffset, count,
                                                     dest, destOffset, bits,
                                                     alpha01) {
+      if (!(dest instanceof Uint8ClampedArray)) {
+        throw new Error('dest should be a Uint8ClampedArray.');
+      }
       var tintFn = this.tintFn;
       var base = this.base;
       var scale = 1 / ((1 << bits) - 1);
@@ -535,6 +544,9 @@ var IndexedCS = (function IndexedCSClosure() {
     getRgb: ColorSpace.prototype.getRgb,
     getRgbItem: function IndexedCS_getRgbItem(src, srcOffset,
                                               dest, destOffset) {
+      if (!(dest instanceof Uint8ClampedArray)) {
+        throw new Error('dest should be a Uint8ClampedArray.');
+      }
       var numComps = this.base.numComps;
       var start = src[srcOffset] * numComps;
       this.base.getRgbBuffer(this.lookup, start, 1, dest, destOffset, 8, 0);
@@ -542,6 +554,9 @@ var IndexedCS = (function IndexedCSClosure() {
     getRgbBuffer: function IndexedCS_getRgbBuffer(src, srcOffset, count,
                                                   dest, destOffset, bits,
                                                   alpha01) {
+      if (!(dest instanceof Uint8ClampedArray)) {
+        throw new Error('dest should be a Uint8ClampedArray.');
+      }
       var base = this.base;
       var numComps = base.numComps;
       var outputDelta = base.getOutputLength(numComps, alpha01);
@@ -579,12 +594,18 @@ var DeviceGrayCS = (function DeviceGrayCSClosure() {
     getRgb: ColorSpace.prototype.getRgb,
     getRgbItem: function DeviceGrayCS_getRgbItem(src, srcOffset,
                                                  dest, destOffset) {
+      if (!(dest instanceof Uint8ClampedArray)) {
+        throw new Error('dest should be a Uint8ClampedArray.');
+      }
       let c = src[srcOffset] * 255;
       dest[destOffset] = dest[destOffset + 1] = dest[destOffset + 2] = c;
     },
     getRgbBuffer: function DeviceGrayCS_getRgbBuffer(src, srcOffset, count,
                                                      dest, destOffset, bits,
                                                      alpha01) {
+      if (!(dest instanceof Uint8ClampedArray)) {
+        throw new Error('dest should be a Uint8ClampedArray.');
+      }
       var scale = 255 / ((1 << bits) - 1);
       var j = srcOffset, q = destOffset;
       for (var i = 0; i < count; ++i) {
@@ -619,6 +640,9 @@ var DeviceRgbCS = (function DeviceRgbCSClosure() {
     getRgb: ColorSpace.prototype.getRgb,
     getRgbItem: function DeviceRgbCS_getRgbItem(src, srcOffset,
                                                 dest, destOffset) {
+      if (!(dest instanceof Uint8ClampedArray)) {
+        throw new Error('dest should be a Uint8ClampedArray.');
+      }
       dest[destOffset] = src[srcOffset] * 255;
       dest[destOffset + 1] = src[srcOffset + 1] * 255;
       dest[destOffset + 2] = src[srcOffset + 2] * 255;
@@ -626,6 +650,9 @@ var DeviceRgbCS = (function DeviceRgbCSClosure() {
     getRgbBuffer: function DeviceRgbCS_getRgbBuffer(src, srcOffset, count,
                                                     dest, destOffset, bits,
                                                     alpha01) {
+      if (!(dest instanceof Uint8ClampedArray)) {
+        throw new Error('dest should be a Uint8ClampedArray.');
+      }
       if (bits === 8 && alpha01 === 0) {
         dest.set(src.subarray(srcOffset, srcOffset + count * 3), destOffset);
         return;
@@ -709,11 +736,17 @@ var DeviceCmykCS = (function DeviceCmykCSClosure() {
     getRgb: ColorSpace.prototype.getRgb,
     getRgbItem: function DeviceCmykCS_getRgbItem(src, srcOffset,
                                                  dest, destOffset) {
+      if (!(dest instanceof Uint8ClampedArray)) {
+        throw new Error('dest should be a Uint8ClampedArray.');
+      }
       convertToRgb(src, srcOffset, 1, dest, destOffset);
     },
     getRgbBuffer: function DeviceCmykCS_getRgbBuffer(src, srcOffset, count,
                                                      dest, destOffset, bits,
                                                      alpha01) {
+      if (!(dest instanceof Uint8ClampedArray)) {
+        throw new Error('dest should be a Uint8ClampedArray.');
+      }
       var scale = 1 / ((1 << bits) - 1);
       for (var i = 0; i < count; i++) {
         convertToRgb(src, srcOffset, scale, dest, destOffset);
@@ -807,11 +840,17 @@ var CalGrayCS = (function CalGrayCSClosure() {
     getRgb: ColorSpace.prototype.getRgb,
     getRgbItem: function CalGrayCS_getRgbItem(src, srcOffset,
                                               dest, destOffset) {
+      if (!(dest instanceof Uint8ClampedArray)) {
+        throw new Error('dest should be a Uint8ClampedArray.');
+      }
       convertToRgb(this, src, srcOffset, dest, destOffset, 1);
     },
     getRgbBuffer: function CalGrayCS_getRgbBuffer(src, srcOffset, count,
                                                   dest, destOffset, bits,
                                                   alpha01) {
+      if (!(dest instanceof Uint8ClampedArray)) {
+        throw new Error('dest should be a Uint8ClampedArray.');
+      }
       var scale = 1 / ((1 << bits) - 1);
 
       for (var i = 0; i < count; ++i) {
@@ -1103,11 +1142,17 @@ var CalRGBCS = (function CalRGBCSClosure() {
     getRgb: ColorSpace.prototype.getRgb,
     getRgbItem: function CalRGBCS_getRgbItem(src, srcOffset,
                                              dest, destOffset) {
+      if (!(dest instanceof Uint8ClampedArray)) {
+        throw new Error('dest should be a Uint8ClampedArray.');
+      }
       convertToRgb(this, src, srcOffset, dest, destOffset, 1);
     },
     getRgbBuffer: function CalRGBCS_getRgbBuffer(src, srcOffset, count,
                                                  dest, destOffset, bits,
                                                  alpha01) {
+      if (!(dest instanceof Uint8ClampedArray)) {
+        throw new Error('dest should be a Uint8ClampedArray.');
+      }
       var scale = 1 / ((1 << bits) - 1);
 
       for (var i = 0; i < count; ++i) {
@@ -1248,11 +1293,17 @@ var LabCS = (function LabCSClosure() {
   LabCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
     getRgbItem: function LabCS_getRgbItem(src, srcOffset, dest, destOffset) {
+      if (!(dest instanceof Uint8ClampedArray)) {
+        throw new Error('dest should be a Uint8ClampedArray.');
+      }
       convertToRgb(this, src, srcOffset, false, dest, destOffset);
     },
     getRgbBuffer: function LabCS_getRgbBuffer(src, srcOffset, count,
                                               dest, destOffset, bits,
                                               alpha01) {
+      if (!(dest instanceof Uint8ClampedArray)) {
+        throw new Error('dest should be a Uint8ClampedArray.');
+      }
       var maxVal = (1 << bits) - 1;
       for (var i = 0; i < count; i++) {
         convertToRgb(this, src, srcOffset, maxVal, dest, destOffset);

--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -65,7 +65,7 @@ var ColorSpace = (function ColorSpaceClosure() {
      * of the rgb components, each value ranging from [0,255].
      */
     getRgb: function ColorSpace_getRgb(src, srcOffset) {
-      var rgb = new Uint8Array(3);
+      let rgb = new Uint8ClampedArray(3);
       this.getRgbItem(src, srcOffset, rgb, 0);
       return rgb;
     },
@@ -123,7 +123,7 @@ var ColorSpace = (function ColorSpaceClosure() {
       if (this.isPassthrough(bpc)) {
         rgbBuf = comps;
       } else if (this.numComps === 1 && count > numComponentColors &&
-          this.name !== 'DeviceGray' && this.name !== 'DeviceRGB') {
+                 this.name !== 'DeviceGray' && this.name !== 'DeviceRGB') {
         // Optimization: create a color map when there is just one component and
         // we are converting more colors than the size of the color map. We
         // don't build the map if the colorspace is gray or rgb since those
@@ -139,7 +139,7 @@ var ColorSpace = (function ColorSpaceClosure() {
         for (i = 0; i < numComponentColors; i++) {
           allColors[i] = i;
         }
-        var colorMap = new Uint8Array(numComponentColors * 3);
+        var colorMap = new Uint8ClampedArray(numComponentColors * 3);
         this.getRgbBuffer(allColors, 0, numComponentColors, colorMap, 0, bpc,
                           /* alpha01 = */ 0);
 
@@ -170,7 +170,7 @@ var ColorSpace = (function ColorSpaceClosure() {
           this.getRgbBuffer(comps, 0, width * actualHeight, dest, 0, bpc,
                             alpha01);
         } else {
-          rgbBuf = new Uint8Array(count * 3);
+          rgbBuf = new Uint8ClampedArray(count * 3);
           this.getRgbBuffer(comps, 0, count, rgbBuf, 0, bpc,
                             /* alpha01 = */ 0);
         }
@@ -450,7 +450,8 @@ var AlternateCS = (function AlternateCSClosure() {
       var isPassthrough = (base.isPassthrough(8) || !usesZeroToOneRange) &&
                           alpha01 === 0;
       var pos = isPassthrough ? destOffset : 0;
-      var baseBuf = isPassthrough ? dest : new Uint8Array(baseNumComps * count);
+      var baseBuf = isPassthrough ?
+                    dest : new Uint8ClampedArray(baseNumComps * count);
       var numComps = this.numComps;
 
       var scaled = new Float32Array(numComps);
@@ -578,8 +579,7 @@ var DeviceGrayCS = (function DeviceGrayCSClosure() {
     getRgb: ColorSpace.prototype.getRgb,
     getRgbItem: function DeviceGrayCS_getRgbItem(src, srcOffset,
                                                  dest, destOffset) {
-      var c = (src[srcOffset] * 255) | 0;
-      c = c < 0 ? 0 : c > 255 ? 255 : c;
+      let c = src[srcOffset] * 255;
       dest[destOffset] = dest[destOffset + 1] = dest[destOffset + 2] = c;
     },
     getRgbBuffer: function DeviceGrayCS_getRgbBuffer(src, srcOffset, count,
@@ -588,7 +588,7 @@ var DeviceGrayCS = (function DeviceGrayCSClosure() {
       var scale = 255 / ((1 << bits) - 1);
       var j = srcOffset, q = destOffset;
       for (var i = 0; i < count; ++i) {
-        var c = (scale * src[j++]) | 0;
+        let c = scale * src[j++];
         dest[q++] = c;
         dest[q++] = c;
         dest[q++] = c;
@@ -619,12 +619,9 @@ var DeviceRgbCS = (function DeviceRgbCSClosure() {
     getRgb: ColorSpace.prototype.getRgb,
     getRgbItem: function DeviceRgbCS_getRgbItem(src, srcOffset,
                                                 dest, destOffset) {
-      var r = (src[srcOffset] * 255) | 0;
-      var g = (src[srcOffset + 1] * 255) | 0;
-      var b = (src[srcOffset + 2] * 255) | 0;
-      dest[destOffset] = r < 0 ? 0 : r > 255 ? 255 : r;
-      dest[destOffset + 1] = g < 0 ? 0 : g > 255 ? 255 : g;
-      dest[destOffset + 2] = b < 0 ? 0 : b > 255 ? 255 : b;
+      dest[destOffset] = src[srcOffset] * 255;
+      dest[destOffset + 1] = src[srcOffset + 1] * 255;
+      dest[destOffset + 2] = src[srcOffset + 2] * 255;
     },
     getRgbBuffer: function DeviceRgbCS_getRgbBuffer(src, srcOffset, count,
                                                     dest, destOffset, bits,
@@ -636,9 +633,9 @@ var DeviceRgbCS = (function DeviceRgbCSClosure() {
       var scale = 255 / ((1 << bits) - 1);
       var j = srcOffset, q = destOffset;
       for (var i = 0; i < count; ++i) {
-        dest[q++] = (scale * src[j++]) | 0;
-        dest[q++] = (scale * src[j++]) | 0;
-        dest[q++] = (scale * src[j++]) | 0;
+        dest[q++] = scale * src[j++];
+        dest[q++] = scale * src[j++];
+        dest[q++] = scale * src[j++];
         q += alpha01;
       }
     },
@@ -671,36 +668,34 @@ var DeviceCmykCS = (function DeviceCmykCSClosure() {
     var y = src[srcOffset + 2] * srcScale;
     var k = src[srcOffset + 3] * srcScale;
 
-    var r =
-      (c * (-4.387332384609988 * c + 54.48615194189176 * m +
-            18.82290502165302 * y + 212.25662451639585 * k +
-            -285.2331026137004) +
-       m * (1.7149763477362134 * m - 5.6096736904047315 * y +
-            -17.873870861415444 * k - 5.497006427196366) +
-       y * (-2.5217340131683033 * y - 21.248923337353073 * k +
-            17.5119270841813) +
-       k * (-21.86122147463605 * k - 189.48180835922747) + 255) | 0;
-    var g =
-      (c * (8.841041422036149 * c + 60.118027045597366 * m +
-            6.871425592049007 * y + 31.159100130055922 * k +
-            -79.2970844816548) +
-       m * (-15.310361306967817 * m + 17.575251261109482 * y +
-            131.35250912493976 * k - 190.9453302588951) +
-       y * (4.444339102852739 * y + 9.8632861493405 * k - 24.86741582555878) +
-       k * (-20.737325471181034 * k - 187.80453709719578) + 255) | 0;
-    var b =
-      (c * (0.8842522430003296 * c + 8.078677503112928 * m +
-            30.89978309703729 * y - 0.23883238689178934 * k +
-            -14.183576799673286) +
-       m * (10.49593273432072 * m + 63.02378494754052 * y +
-            50.606957656360734 * k - 112.23884253719248) +
-       y * (0.03296041114873217 * y + 115.60384449646641 * k +
-            -193.58209356861505) +
-       k * (-22.33816807309886 * k - 180.12613974708367) + 255) | 0;
+    dest[destOffset] = 255 +
+      c * (-4.387332384609988 * c + 54.48615194189176 * m +
+           18.82290502165302 * y + 212.25662451639585 * k +
+           -285.2331026137004) +
+      m * (1.7149763477362134 * m - 5.6096736904047315 * y +
+           -17.873870861415444 * k - 5.497006427196366) +
+      y * (-2.5217340131683033 * y - 21.248923337353073 * k +
+           17.5119270841813) +
+      k * (-21.86122147463605 * k - 189.48180835922747);
 
-    dest[destOffset] = r > 255 ? 255 : r < 0 ? 0 : r;
-    dest[destOffset + 1] = g > 255 ? 255 : g < 0 ? 0 : g;
-    dest[destOffset + 2] = b > 255 ? 255 : b < 0 ? 0 : b;
+    dest[destOffset + 1] = 255 +
+      c * (8.841041422036149 * c + 60.118027045597366 * m +
+           6.871425592049007 * y + 31.159100130055922 * k +
+           -79.2970844816548) +
+      m * (-15.310361306967817 * m + 17.575251261109482 * y +
+           131.35250912493976 * k - 190.9453302588951) +
+      y * (4.444339102852739 * y + 9.8632861493405 * k - 24.86741582555878) +
+      k * (-20.737325471181034 * k - 187.80453709719578);
+
+    dest[destOffset + 2] = 255 +
+      c * (0.8842522430003296 * c + 8.078677503112928 * m +
+           30.89978309703729 * y - 0.23883238689178934 * k +
+           -14.183576799673286) +
+      m * (10.49593273432072 * m + 63.02378494754052 * y +
+           50.606957656360734 * k - 112.23884253719248) +
+      y * (0.03296041114873217 * y + 115.60384449646641 * k +
+           -193.58209356861505) +
+      k * (-22.33816807309886 * k - 180.12613974708367);
   }
 
   function DeviceCmykCS() {
@@ -802,7 +797,7 @@ var CalGrayCS = (function CalGrayCSClosure() {
     var L = cs.YW * AG;
     // http://www.poynton.com/notes/colour_and_gamma/ColorFAQ.html, Ch 4.
     // Convert values to rgb range [0, 255].
-    var val = Math.max(295.8 * Math.pow(L, 0.333333333333333333) - 40.8, 0) | 0;
+    let val = Math.max(295.8 * Math.pow(L, 0.333333333333333333) - 40.8, 0);
     dest[destOffset] = val;
     dest[destOffset + 1] = val;
     dest[destOffset + 2] = val;
@@ -1098,14 +1093,10 @@ var CalRGBCS = (function CalRGBCSClosure() {
     var SRGB = tempConvertMatrix1;
     matrixProduct(SRGB_D65_XYZ_TO_RGB_MATRIX, XYZ_D65, SRGB);
 
-    var sR = sRGBTransferFunction(SRGB[0]);
-    var sG = sRGBTransferFunction(SRGB[1]);
-    var sB = sRGBTransferFunction(SRGB[2]);
-
     // Convert the values to rgb range [0, 255].
-    dest[destOffset] = Math.round(sR * 255);
-    dest[destOffset + 1] = Math.round(sG * 255);
-    dest[destOffset + 2] = Math.round(sB * 255);
+    dest[destOffset] = sRGBTransferFunction(SRGB[0]) * 255;
+    dest[destOffset + 1] = sRGBTransferFunction(SRGB[1]) * 255;
+    dest[destOffset + 2] = sRGBTransferFunction(SRGB[2]) * 255;
   }
 
   CalRGBCS.prototype = {
@@ -1248,10 +1239,10 @@ var LabCS = (function LabCSClosure() {
       g = X * -0.9689 + Y * 1.8758 + Z * 0.0415;
       b = X * 0.0557 + Y * -0.2040 + Z * 1.0570;
     }
-    // clamp color values to [0,1] range then convert to [0,255] range.
-    dest[destOffset] = r <= 0 ? 0 : r >= 1 ? 255 : Math.sqrt(r) * 255 | 0;
-    dest[destOffset + 1] = g <= 0 ? 0 : g >= 1 ? 255 : Math.sqrt(g) * 255 | 0;
-    dest[destOffset + 2] = b <= 0 ? 0 : b >= 1 ? 255 : Math.sqrt(b) * 255 | 0;
+    // Convert the values to rgb range [0, 255].
+    dest[destOffset] = r <= 0 ? 0 : Math.sqrt(r) * 255;
+    dest[destOffset + 1] = g <= 0 ? 0 : Math.sqrt(g) * 255;
+    dest[destOffset + 2] = b <= 0 ? 0 : Math.sqrt(b) * 255;
   }
 
   LabCS.prototype = {

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -366,7 +366,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         var width = dict.get('Width', 'W');
         var height = dict.get('Height', 'H');
         var bitStrideLength = (width + 7) >> 3;
-        var imgArray = image.getBytes(bitStrideLength * height);
+        var imgArray = image.getBytes(bitStrideLength * height,
+                                      /* clampedArray = */ true);
         var decode = dict.getArray('Decode', 'D');
         var inverseDecode = (!!decode && decode[0] > 0);
 

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -235,10 +235,10 @@ var PDFImage = (function PDFImageClosure() {
       // form, so we can just transfer it.
       data = imgArray;
     } else if (!inverseDecode) {
-      data = new Uint8Array(actualLength);
+      data = new Uint8ClampedArray(actualLength);
       data.set(imgArray);
     } else {
-      data = new Uint8Array(computedLength);
+      data = new Uint8ClampedArray(computedLength);
       data.set(imgArray);
       for (i = actualLength; i < computedLength; i++) {
         data[i] = 0xff;
@@ -383,7 +383,7 @@ var PDFImage = (function PDFImageClosure() {
       if (smask) {
         sw = smask.width;
         sh = smask.height;
-        alphaBuf = new Uint8Array(sw * sh);
+        alphaBuf = new Uint8ClampedArray(sw * sh);
         smask.fillGrayBuffer(alphaBuf);
         if (sw !== width || sh !== height) {
           alphaBuf = resizeImageMask(alphaBuf, smask.bpc, sw, sh,
@@ -393,7 +393,7 @@ var PDFImage = (function PDFImageClosure() {
         if (mask instanceof PDFImage) {
           sw = mask.width;
           sh = mask.height;
-          alphaBuf = new Uint8Array(sw * sh);
+          alphaBuf = new Uint8ClampedArray(sw * sh);
           mask.numComps = 1;
           mask.fillGrayBuffer(alphaBuf);
 
@@ -409,7 +409,7 @@ var PDFImage = (function PDFImageClosure() {
         } else if (Array.isArray(mask)) {
           // Color key mask: if any of the components are outside the range
           // then they should be painted.
-          alphaBuf = new Uint8Array(width * height);
+          alphaBuf = new Uint8ClampedArray(width * height);
           var numComps = this.numComps;
           for (i = 0, ii = width * height; i < ii; ++i) {
             var opacity = 0;
@@ -451,7 +451,6 @@ var PDFImage = (function PDFImageClosure() {
       var matteG = matteRgb[1];
       var matteB = matteRgb[2];
       var length = width * height * 4;
-      var r, g, b;
       for (var i = 0; i < length; i += 4) {
         var alpha = buffer[i + 3];
         if (alpha === 0) {
@@ -463,12 +462,9 @@ var PDFImage = (function PDFImageClosure() {
           continue;
         }
         var k = 255 / alpha;
-        r = (buffer[i] - matteR) * k + matteR;
-        g = (buffer[i + 1] - matteG) * k + matteG;
-        b = (buffer[i + 2] - matteB) * k + matteB;
-        buffer[i] = r <= 0 ? 0 : r >= 255 ? 255 : r | 0;
-        buffer[i + 1] = g <= 0 ? 0 : g >= 255 ? 255 : g | 0;
-        buffer[i + 2] = b <= 0 ? 0 : b >= 255 ? 255 : b | 0;
+        buffer[i] = (buffer[i] - matteR) * k + matteR;
+        buffer[i + 1] = (buffer[i + 1] - matteG) * k + matteG;
+        buffer[i + 2] = (buffer[i + 2] - matteB) * k + matteB;
       }
     },
 
@@ -478,6 +474,8 @@ var PDFImage = (function PDFImageClosure() {
       var imgData = { // other fields are filled in below
         width: drawWidth,
         height: drawHeight,
+        kind: null,
+        data: null,
       };
 
       var numComps = this.numComps;
@@ -517,7 +515,7 @@ var PDFImage = (function PDFImageClosure() {
           if (this.image instanceof DecodeStream) {
             imgData.data = imgArray;
           } else {
-            var newArray = new Uint8Array(imgArray.length);
+            var newArray = new Uint8ClampedArray(imgArray.length);
             newArray.set(imgArray);
             imgData.data = newArray;
           }
@@ -554,12 +552,12 @@ var PDFImage = (function PDFImageClosure() {
       var alpha01, maybeUndoPreblend;
       if (!forceRGBA && !this.smask && !this.mask) {
         imgData.kind = ImageKind.RGB_24BPP;
-        imgData.data = new Uint8Array(drawWidth * drawHeight * 3);
+        imgData.data = new Uint8ClampedArray(drawWidth * drawHeight * 3);
         alpha01 = 0;
         maybeUndoPreblend = false;
       } else {
         imgData.kind = ImageKind.RGBA_32BPP;
-        imgData.data = new Uint8Array(drawWidth * drawHeight * 4);
+        imgData.data = new Uint8ClampedArray(drawWidth * drawHeight * 4);
         alpha01 = 1;
         maybeUndoPreblend = true;
 
@@ -623,7 +621,7 @@ var PDFImage = (function PDFImageClosure() {
       // we aren't using a colorspace so we need to scale the value
       var scale = 255 / ((1 << bpc) - 1);
       for (i = 0; i < length; ++i) {
-        buffer[i] = (scale * comps[i]) | 0;
+        buffer[i] = scale * comps[i];
       }
     },
 
@@ -634,7 +632,7 @@ var PDFImage = (function PDFImageClosure() {
       this.image.drawWidth = drawWidth || this.width;
       this.image.drawHeight = drawHeight || this.height;
       this.image.forceRGB = !!forceRGB;
-      return this.image.getBytes(length);
+      return this.image.getBytes(length, /* clampedArray = */ true);
     },
   };
   return PDFImage;

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -219,7 +219,9 @@ var PDFImage = (function PDFImageClosure() {
   PDFImage.createMask =
       function PDFImage_createMask(imgArray, width, height,
                                    imageIsFromDecodeStream, inverseDecode) {
-
+    if (!(imgArray instanceof Uint8ClampedArray)) {
+      throw new Error('imgArray should be a Uint8ClampedArray.');
+    }
     // |imgArray| might not contain full data for every pixel of the mask, so
     // we need to distinguish between |computedLength| and |actualLength|.
     // In particular, if inverseDecode is true, then the array we return must
@@ -376,6 +378,9 @@ var PDFImage = (function PDFImageClosure() {
 
     fillOpacity: function PDFImage_fillOpacity(rgbaBuf, width, height,
                                                actualHeight, image) {
+      if (!(rgbaBuf instanceof Uint8ClampedArray)) {
+        throw new Error('rgbaBuf should be a Uint8ClampedArray.');
+      }
       var smask = this.smask;
       var mask = this.mask;
       var alphaBuf, sw, sh, i, ii, j;
@@ -442,6 +447,9 @@ var PDFImage = (function PDFImageClosure() {
     },
 
     undoPreblend: function PDFImage_undoPreblend(buffer, width, height) {
+      if (!(buffer instanceof Uint8ClampedArray)) {
+        throw new Error('buffer should be a Uint8ClampedArray.');
+      }
       var matte = this.smask && this.smask.matte;
       if (!matte) {
         return;
@@ -580,6 +588,9 @@ var PDFImage = (function PDFImageClosure() {
     },
 
     fillGrayBuffer: function PDFImage_fillGrayBuffer(buffer) {
+      if (!(buffer instanceof Uint8ClampedArray)) {
+        throw new Error('buffer should be a Uint8ClampedArray.');
+      }
       var numComps = this.numComps;
       if (numComps !== 1) {
         throw new FormatError(

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -113,7 +113,7 @@ var Catalog = (function CatalogClosure() {
       // To avoid recursion, keep track of the already processed items.
       var processed = new RefSet();
       processed.put(obj);
-      var xref = this.xref, blackColor = new Uint8Array(3);
+      var xref = this.xref, blackColor = new Uint8ClampedArray(3);
 
       while (queue.length > 0) {
         var i = queue.shift();

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -63,28 +63,32 @@ var Stream = (function StreamClosure() {
     },
     // returns subarray of original buffer
     // should only be read
-    getBytes: function Stream_getBytes(length) {
+    getBytes(length, clampedArray = false) {
       var bytes = this.bytes;
       var pos = this.pos;
       var strEnd = this.end;
 
       if (!length) {
-        return bytes.subarray(pos, strEnd);
+        let subarray = bytes.subarray(pos, strEnd);
+        return !clampedArray || subarray instanceof Uint8ClampedArray ?
+               subarray : new Uint8ClampedArray(subarray);
       }
       var end = pos + length;
       if (end > strEnd) {
         end = strEnd;
       }
       this.pos = end;
-      return bytes.subarray(pos, end);
+      let subarray = bytes.subarray(pos, end);
+      return !clampedArray || subarray instanceof Uint8ClampedArray ?
+             subarray : new Uint8ClampedArray(subarray);
     },
     peekByte: function Stream_peekByte() {
       var peekedByte = this.getByte();
       this.pos--;
       return peekedByte;
     },
-    peekBytes: function Stream_peekBytes(length) {
-      var bytes = this.getBytes(length);
+    peekBytes(length, clampedArray = false) {
+      var bytes = this.getBytes(length, clampedArray);
       this.pos -= bytes.length;
       return bytes;
     },
@@ -190,7 +194,7 @@ var DecodeStream = (function DecodeStreamClosure() {
       var b3 = this.getByte();
       return (b0 << 24) + (b1 << 16) + (b2 << 8) + b3;
     },
-    getBytes: function DecodeStream_getBytes(length) {
+    getBytes(length, clampedArray = false) {
       var end, pos = this.pos;
 
       if (length) {
@@ -212,15 +216,17 @@ var DecodeStream = (function DecodeStreamClosure() {
       }
 
       this.pos = end;
-      return this.buffer.subarray(pos, end);
+      let subarray = this.buffer.subarray(pos, end);
+      return !clampedArray || subarray instanceof Uint8ClampedArray ?
+             subarray : new Uint8ClampedArray(subarray);
     },
     peekByte: function DecodeStream_peekByte() {
       var peekedByte = this.getByte();
       this.pos--;
       return peekedByte;
     },
-    peekBytes: function DecodeStream_peekBytes(length) {
-      var bytes = this.getBytes(length);
+    peekBytes(length, clampedArray = false) {
+      var bytes = this.getBytes(length, clampedArray);
       this.pos -= bytes.length;
       return bytes;
     },
@@ -940,9 +946,10 @@ var JpegStream = (function JpegStreamClosure() {
     this.eof = true;
   };
 
-  JpegStream.prototype.getBytes = function JpegStream_getBytes(length) {
+  JpegStream.prototype.getBytes = function(length, clampedArray = false) {
     this.ensureBuffer();
-    return this.buffer;
+    return !clampedArray || this.buffer instanceof Uint8ClampedArray ?
+           this.buffer : new Uint8ClampedArray(this.buffer);
   };
 
   JpegStream.prototype.getIR = function JpegStream_getIR(forceDataSchema) {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -629,7 +629,7 @@ var PDFDocumentProxy = (function PDFDocumentProxyClosure() {
      *   title: string,
      *   bold: boolean,
      *   italic: boolean,
-     *   color: rgb Uint8Array,
+     *   color: rgb Uint8ClampedArray,
      *   dest: dest obj,
      *   url: string,
      *   items: array of more items like this

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -166,7 +166,7 @@ describe('annotation', function() {
       var annotation = new Annotation({ dict, ref, });
       annotation.setColor('red');
 
-      expect(annotation.color).toEqual(new Uint8Array([0, 0, 0]));
+      expect(annotation.color).toEqual(new Uint8ClampedArray([0, 0, 0]));
     });
 
     it('should set and get a transparent color', function() {
@@ -180,28 +180,28 @@ describe('annotation', function() {
       var annotation = new Annotation({ dict, ref, });
       annotation.setColor([0.4]);
 
-      expect(annotation.color).toEqual(new Uint8Array([102, 102, 102]));
+      expect(annotation.color).toEqual(new Uint8ClampedArray([102, 102, 102]));
     });
 
     it('should set and get an RGB color', function() {
       var annotation = new Annotation({ dict, ref, });
       annotation.setColor([0, 0, 1]);
 
-      expect(annotation.color).toEqual(new Uint8Array([0, 0, 255]));
+      expect(annotation.color).toEqual(new Uint8ClampedArray([0, 0, 255]));
     });
 
     it('should set and get a CMYK color', function() {
       var annotation = new Annotation({ dict, ref, });
       annotation.setColor([0.1, 0.92, 0.84, 0.02]);
 
-      expect(annotation.color).toEqual(new Uint8Array([233, 59, 47]));
+      expect(annotation.color).toEqual(new Uint8ClampedArray([234, 59, 48]));
     });
 
     it('should not set and get an invalid color', function() {
       var annotation = new Annotation({ dict, ref, });
       annotation.setColor([0.4, 0.6]);
 
-      expect(annotation.color).toEqual(new Uint8Array([0, 0, 0]));
+      expect(annotation.color).toEqual(new Uint8ClampedArray([0, 0, 0]));
     });
   });
 

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -754,7 +754,7 @@ describe('api', function() {
 
         expect(outlineItem.bold).toEqual(true);
         expect(outlineItem.italic).toEqual(false);
-        expect(outlineItem.color).toEqual(new Uint8Array([0, 64, 128]));
+        expect(outlineItem.color).toEqual(new Uint8ClampedArray([0, 64, 128]));
 
         expect(outlineItem.items.length).toEqual(1);
         expect(outlineItem.items[0].title).toEqual('Paragraph 1.1');
@@ -781,7 +781,8 @@ describe('api', function() {
           var outlineItemOne = outline[1];
           expect(outlineItemOne.bold).toEqual(false);
           expect(outlineItemOne.italic).toEqual(true);
-          expect(outlineItemOne.color).toEqual(new Uint8Array([0, 0, 0]));
+          expect(outlineItemOne.color).toEqual(
+            new Uint8ClampedArray([0, 0, 0]));
 
           loadingTask.destroy().then(done);
         });

--- a/test/unit/colorspace_spec.js
+++ b/test/unit/colorspace_spec.js
@@ -57,8 +57,8 @@ describe('colorspace', function () {
       let colorSpace = ColorSpace.parse(cs, xref, res);
 
       let testSrc = new Uint8Array([27, 125, 250, 131]);
-      let testDest = new Uint8Array(4 * 4 * 3);
-      let expectedDest = new Uint8Array([
+      let testDest = new Uint8ClampedArray(4 * 4 * 3);
+      let expectedDest = new Uint8ClampedArray([
         27, 27, 27,
         27, 27, 27,
         125, 125, 125,
@@ -79,7 +79,7 @@ describe('colorspace', function () {
       colorSpace.fillRgb(testDest, 2, 2, 4, 4, 4, 8, testSrc, 0);
 
       expect(colorSpace.getRgb(new Float32Array([0.1]), 0))
-        .toEqual(new Uint8Array([25, 25, 25]));
+        .toEqual(new Uint8ClampedArray([26, 26, 26]));
       expect(colorSpace.getOutputLength(2, 0)).toEqual(6);
       expect(colorSpace.isPassthrough(8)).toBeFalsy();
       expect(testDest).toEqual(expectedDest);
@@ -95,8 +95,8 @@ describe('colorspace', function () {
       let colorSpace = ColorSpace.parse(cs, xref, res);
 
       let testSrc = new Uint8Array([27, 125, 250, 131]);
-      let testDest = new Uint8Array(3 * 3 * 3);
-      let expectedDest = new Uint8Array([
+      let testDest = new Uint8ClampedArray(3 * 3 * 3);
+      let expectedDest = new Uint8ClampedArray([
         27, 27, 27,
         27, 27, 27,
         125, 125, 125,
@@ -110,7 +110,7 @@ describe('colorspace', function () {
       colorSpace.fillRgb(testDest, 2, 2, 3, 3, 3, 8, testSrc, 0);
 
       expect(colorSpace.getRgb(new Float32Array([0.2]), 0))
-        .toEqual(new Uint8Array([51, 51, 51]));
+        .toEqual(new Uint8ClampedArray([51, 51, 51]));
       expect(colorSpace.getOutputLength(3, 1)).toEqual(12);
       expect(colorSpace.isPassthrough(8)).toBeFalsy();
       expect(testDest).toEqual(expectedDest);
@@ -134,8 +134,8 @@ describe('colorspace', function () {
         111, 25, 198,
         21, 147, 255
       ]);
-      let testDest = new Uint8Array(4 * 4 * 3);
-      let expectedDest = new Uint8Array([
+      let testDest = new Uint8ClampedArray(4 * 4 * 3);
+      let expectedDest = new Uint8ClampedArray([
         27, 125, 250,
         27, 125, 250,
         131, 139, 140,
@@ -156,7 +156,7 @@ describe('colorspace', function () {
       colorSpace.fillRgb(testDest, 2, 2, 4, 4, 4, 8, testSrc, 0);
 
       expect(colorSpace.getRgb(new Float32Array([0.1, 0.2, 0.3]), 0))
-        .toEqual(new Uint8Array([25, 51, 76]));
+        .toEqual(new Uint8ClampedArray([26, 51, 77]));
       expect(colorSpace.getOutputLength(4, 0)).toEqual(4);
       expect(colorSpace.isPassthrough(8)).toBeTruthy();
       expect(testDest).toEqual(expectedDest);
@@ -177,8 +177,8 @@ describe('colorspace', function () {
         111, 25, 198,
         21, 147, 255
       ]);
-      let testDest = new Uint8Array(3 * 3 * 3);
-      let expectedDest = new Uint8Array([
+      let testDest = new Uint8ClampedArray(3 * 3 * 3);
+      let expectedDest = new Uint8ClampedArray([
         27, 125, 250,
         27, 125, 250,
         131, 139, 140,
@@ -192,7 +192,7 @@ describe('colorspace', function () {
       colorSpace.fillRgb(testDest, 2, 2, 3, 3, 3, 8, testSrc, 0);
 
       expect(colorSpace.getRgb(new Float32Array([0.1, 0.2, 0.3]), 0))
-        .toEqual(new Uint8Array([25, 51, 76]));
+        .toEqual(new Uint8ClampedArray([26, 51, 77]));
       expect(colorSpace.getOutputLength(4, 1)).toEqual(5);
       expect(colorSpace.isPassthrough(8)).toBeTruthy();
       expect(testDest).toEqual(expectedDest);
@@ -216,29 +216,29 @@ describe('colorspace', function () {
         111, 25, 198, 78,
         21, 147, 255, 69
       ]);
-      let testDest = new Uint8Array(4 * 4 * 3);
-      let expectedDest = new Uint8Array([
-        135, 80, 18,
-        135, 80, 18,
-        113, 102, 97,
-        113, 102, 97,
-        135, 80, 18,
-        135, 80, 18,
-        113, 102, 97,
-        113, 102, 97,
-        112, 143, 75,
-        112, 143, 75,
+      let testDest = new Uint8ClampedArray(4 * 4 * 3);
+      let expectedDest = new Uint8ClampedArray([
+        135, 81, 18,
+        135, 81, 18,
+        114, 102, 97,
+        114, 102, 97,
+        135, 81, 18,
+        135, 81, 18,
+        114, 102, 97,
+        114, 102, 97,
+        112, 144, 75,
+        112, 144, 75,
         188, 98, 27,
         188, 98, 27,
-        112, 143, 75,
-        112, 143, 75,
+        112, 144, 75,
+        112, 144, 75,
         188, 98, 27,
         188, 98, 27
       ]);
       colorSpace.fillRgb(testDest, 2, 2, 4, 4, 4, 8, testSrc, 0);
 
       expect(colorSpace.getRgb(new Float32Array([0.1, 0.2, 0.3, 1]),
-        0)).toEqual(new Uint8Array([31, 27, 20]));
+        0)).toEqual(new Uint8ClampedArray([32, 28, 21]));
       expect(colorSpace.getOutputLength(4, 0)).toEqual(3);
       expect(colorSpace.isPassthrough(8)).toBeFalsy();
       expect(testDest).toEqual(expectedDest);
@@ -259,22 +259,22 @@ describe('colorspace', function () {
         111, 25, 198, 78,
         21, 147, 255, 69
       ]);
-      let testDest = new Uint8Array(3 * 3 * 3);
-      let expectedDest = new Uint8Array([
-        135, 80, 18,
-        135, 80, 18,
-        113, 102, 97,
-        135, 80, 18,
-        135, 80, 18,
-        113, 102, 97,
-        112, 143, 75,
-        112, 143, 75,
+      let testDest = new Uint8ClampedArray(3 * 3 * 3);
+      let expectedDest = new Uint8ClampedArray([
+        135, 81, 18,
+        135, 81, 18,
+        114, 102, 97,
+        135, 81, 18,
+        135, 81, 18,
+        114, 102, 97,
+        112, 144, 75,
+        112, 144, 75,
         188, 98, 27
       ]);
       colorSpace.fillRgb(testDest, 2, 2, 3, 3, 3, 8, testSrc, 0);
 
       expect(colorSpace.getRgb(new Float32Array([0.1, 0.2, 0.3, 1]), 0))
-        .toEqual(new Uint8Array([31, 27, 20]));
+        .toEqual(new Uint8ClampedArray([32, 28, 21]));
       expect(colorSpace.getOutputLength(4, 1)).toEqual(4);
       expect(colorSpace.isPassthrough(8)).toBeFalsy();
       expect(testDest).toEqual(expectedDest);
@@ -301,8 +301,8 @@ describe('colorspace', function () {
       let colorSpace = ColorSpace.parse(cs, xref, res);
 
       let testSrc = new Uint8Array([27, 125, 250, 131]);
-      let testDest = new Uint8Array(4 * 4 * 3);
-      let expectedDest = new Uint8Array([
+      let testDest = new Uint8ClampedArray(4 * 4 * 3);
+      let expectedDest = new Uint8ClampedArray([
         25, 25, 25,
         25, 25, 25,
         143, 143, 143,
@@ -313,17 +313,17 @@ describe('colorspace', function () {
         143, 143, 143,
         251, 251, 251,
         251, 251, 251,
-        148, 148, 148,
-        148, 148, 148,
+        149, 149, 149,
+        149, 149, 149,
         251, 251, 251,
         251, 251, 251,
-        148, 148, 148,
-        148, 148, 148
+        149, 149, 149,
+        149, 149, 149
       ]);
       colorSpace.fillRgb(testDest, 2, 2, 4, 4, 4, 8, testSrc, 0);
 
       expect(colorSpace.getRgb(new Float32Array([1.0]), 0))
-        .toEqual(new Uint8Array([255, 255, 255]));
+        .toEqual(new Uint8ClampedArray([255, 255, 255]));
       expect(colorSpace.getOutputLength(4, 0)).toEqual(12);
       expect(colorSpace.isPassthrough(8)).toBeFalsy();
       expect(testDest).toEqual(expectedDest);
@@ -356,8 +356,8 @@ describe('colorspace', function () {
         111, 25, 198,
         21, 147, 255
       ]);
-      let testDest = new Uint8Array(3 * 3 * 3);
-      let expectedDest = new Uint8Array([
+      let testDest = new Uint8ClampedArray(3 * 3 * 3);
+      let expectedDest = new Uint8ClampedArray([
         0, 238, 255,
         0, 238, 255,
         185, 196, 195,
@@ -371,7 +371,7 @@ describe('colorspace', function () {
       colorSpace.fillRgb(testDest, 2, 2, 3, 3, 3, 8, testSrc, 0);
 
       expect(colorSpace.getRgb(new Float32Array([0.1, 0.2, 0.3]), 0))
-        .toEqual(new Uint8Array([0, 147, 151]));
+        .toEqual(new Uint8ClampedArray([0, 147, 151]));
       expect(colorSpace.getOutputLength(4, 0)).toEqual(4);
       expect(colorSpace.isPassthrough(8)).toBeFalsy();
       expect(testDest).toEqual(expectedDest);
@@ -403,22 +403,22 @@ describe('colorspace', function () {
         11, 25, 98,
         21, 47, 55
       ]);
-      let testDest = new Uint8Array(3 * 3 * 3);
-      let expectedDest = new Uint8Array([
+      let testDest = new Uint8ClampedArray(3 * 3 * 3);
+      let expectedDest = new Uint8ClampedArray([
         0, 49, 101,
         0, 49, 101,
-        0, 53, 116,
+        0, 53, 117,
         0, 49, 101,
         0, 49, 101,
-        0, 53, 116,
-        0, 40, 39,
-        0, 40, 39,
+        0, 53, 117,
+        0, 41, 40,
+        0, 41, 40,
         0, 43, 90
       ]);
       colorSpace.fillRgb(testDest, 2, 2, 3, 3, 3, 8, testSrc, 0);
 
       expect(colorSpace.getRgb([55, 25, 35], 0))
-        .toEqual(new Uint8Array([188, 99, 61]));
+        .toEqual(new Uint8ClampedArray([188, 100, 61]));
       expect(colorSpace.getOutputLength(4, 0)).toEqual(4);
       expect(colorSpace.isPassthrough(8)).toBeFalsy();
       expect(colorSpace.isDefaultDecode([0, 1])).toBeTruthy();
@@ -448,8 +448,8 @@ describe('colorspace', function () {
       let colorSpace = ColorSpace.parse(cs, xref, res);
 
       let testSrc = new Uint8Array([2, 2, 0, 1]);
-      let testDest = new Uint8Array(3 * 3 * 3);
-      let expectedDest = new Uint8Array([
+      let testDest = new Uint8ClampedArray(3 * 3 * 3);
+      let expectedDest = new Uint8ClampedArray([
         255, 109, 70,
         255, 109, 70,
         255, 109, 70,
@@ -462,7 +462,8 @@ describe('colorspace', function () {
       ]);
       colorSpace.fillRgb(testDest, 2, 2, 3, 3, 3, 8, testSrc, 0);
 
-      expect(colorSpace.getRgb([2], 0)).toEqual(new Uint8Array([255, 109, 70]));
+      expect(colorSpace.getRgb([2], 0)).toEqual(
+        new Uint8ClampedArray([255, 109, 70]));
       expect(colorSpace.isPassthrough(8)).toBeFalsy();
       expect(colorSpace.isDefaultDecode([0, 1])).toBeTruthy();
       expect(testDest).toEqual(expectedDest);
@@ -500,22 +501,22 @@ describe('colorspace', function () {
       let colorSpace = ColorSpace.parse(cs, xref, res);
 
       let testSrc = new Uint8Array([27, 25, 50, 31]);
-      let testDest = new Uint8Array(3 * 3 * 3);
-      let expectedDest = new Uint8Array([
-        227, 243, 242,
-        227, 243, 242,
-        228, 243, 242,
-        227, 243, 242,
-        227, 243, 242,
-        228, 243, 242,
-        203, 233, 229,
-        203, 233, 229,
-        222, 241, 239
+      let testDest = new Uint8ClampedArray(3 * 3 * 3);
+      let expectedDest = new Uint8ClampedArray([
+        226, 242, 241,
+        226, 242, 241,
+        229, 244, 242,
+        226, 242, 241,
+        226, 242, 241,
+        229, 244, 242,
+        203, 232, 229,
+        203, 232, 229,
+        222, 241, 238
       ]);
       colorSpace.fillRgb(testDest, 2, 2, 3, 3, 3, 8, testSrc, 0);
 
       expect(colorSpace.getRgb([0.1], 0))
-        .toEqual(new Uint8Array([228, 243, 241]));
+        .toEqual(new Uint8ClampedArray([228, 243, 242]));
       expect(colorSpace.isPassthrough(8)).toBeFalsy();
       expect(colorSpace.isDefaultDecode([0, 1])).toBeTruthy();
       expect(testDest).toEqual(expectedDest);

--- a/test/unit/stream_spec.js
+++ b/test/unit/stream_spec.js
@@ -59,6 +59,11 @@ describe('stream', function() {
       expect(result).toMatchTypedArray(
         new Uint8Array([100, 3, 101, 2, 102, 1])
       );
+
+      predictor.reset();
+      let clampedResult = predictor.getBytes(6, /* clampedArray = */ true);
+      expect(clampedResult).toEqual(
+        new Uint8ClampedArray([100, 3, 101, 2, 102, 1]));
     });
   });
 });


### PR DESCRIPTION
*Please refer to the individual commit messages for additional details.*

This allows us to remove manual clamping/rounding code, and instead rely on `Uint8ClampedArray` handling that natively.

*Please note:* Because of different rounding behaviour, basically `Math.round` in `Uint8ClampedArray` respectively `Math.floor` in the old code, there will be very slight movement in quite a few existing test-cases. However, the changes should be imperceivable to the naked eye, given that the absolute difference is *at most* `1` for each RGB component when comparing `master` and this patch (see also the updated expectation values in the various unit-tests).

---
Marking as "work-in-progress" for now, since I would very much appreciate feedback on the general approach of the PR!