### PR TITLE
Fix caching of small inline images in `Parser.makeInlineImage` (issue 8790)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "streamqueue": "^1.1.1",
     "systemjs": "^0.20.7",
     "systemjs-plugin-babel": "0.0.21",
+    "ttest": "^1.1.0",
     "typogr": "^0.6.6",
     "uglify-js": "^2.6.1",
     "vinyl-fs": "^2.4.4",

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -398,12 +398,13 @@ var Parser = (function ParserClosure() {
         }
         adler32 = ((b % 65521) << 16) | (a % 65521);
 
-        if (this.imageCache.adler32 === adler32) {
+        let cacheEntry = this.imageCache[adler32];
+        if (cacheEntry !== undefined) {
           this.buf2 = Cmd.get('EI');
           this.shift();
 
-          this.imageCache[adler32].reset();
-          return this.imageCache[adler32];
+          cacheEntry.reset();
+          return cacheEntry;
         }
       }
 


### PR DESCRIPTION
*Follow-up to PR #5445.*

Using the PDF file from issue #2618, i.e. http://bugzilla-attachments.gnome.org/attachment.cgi?id=226471, with the following manifest file:
```json
[
    {  "id": "issue2618",
       "file": "../web/pdfs/issue2618.pdf",
       "md5": "",
       "rounds": 50,
       "type": "eq"
    }
]
```
I get the following results when comparing `master` against this patch:
```
browser | stat         | Count | Baseline(ms) | Current(ms) |  +/- |     %  | Result(P<.05)
------- | ------------ | ----- | ------------ | ----------- | ---- | ------ | -------------
firefox | Overall      |    50 |         4694 |        3974 | -721 | -15.35 |        faster
firefox | Page Request |    50 |            2 |           1 |    0 | -22.83 |
firefox | Rendering    |    50 |         4692 |        3972 | -720 | -15.35 |        faster
```

So, based on these results, it seems like a fairly clear win to fix this broken caching :-)

Fixes #8790.


