### PR TITLE
Remove the migration code for old localStorage data in `ViewHistory`

### DIFF
--- a/web/view_history.js
+++ b/web/view_history.js
@@ -73,25 +73,7 @@ class ViewHistory {
           PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
         resolve(sessionStorage.getItem('pdfjs.history'));
       } else {
-        let value = localStorage.getItem('pdfjs.history');
-
-        // TODO: Remove this key-name conversion after a suitable time-frame.
-        // Note that we only remove the old 'database' entry if it looks like
-        // it was created by PDF.js, to avoid removing someone else's data.
-        if (!value) {
-          let databaseStr = localStorage.getItem('database');
-          if (databaseStr) {
-            try {
-              let database = JSON.parse(databaseStr);
-              if (typeof database.files[0].fingerprint === 'string') {
-                localStorage.setItem('pdfjs.history', databaseStr);
-                localStorage.removeItem('database');
-                value = databaseStr;
-              }
-            } catch (ex) { }
-          }
-        }
-        resolve(value);
+        resolve(localStorage.getItem('pdfjs.history'));
       }
     });
   }


### PR DESCRIPTION
This was added in PR #7793, which has now been present in a number of PDF.js releases (from version `v1.7.225`, see https://github.com/mozilla/pdf.js/releases/tag/v1.7.225).
Hence we should be able to remove it now, considering that the migration code was only intended as a best effort solution to avoid wiping out all existing user data at once. Also, keep in mind that `ViewHistory` is already limited with regards to the number of documents it will simultaneous store data for.