### PR TITLE
Implement text rise for the SVG back-end

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -562,6 +562,9 @@ SVGGraphics = (function SVGGraphicsClosure() {
             this.setTextMatrix(args[0], args[1], args[2],
                                args[3], args[4], args[5]);
             break;
+          case OPS.setTextRise:
+            this.setTextRise(args[0]);
+            break;
           case OPS.setLineWidth:
             this.setLineWidth(args[0]);
             break;
@@ -782,9 +785,17 @@ SVGGraphics = (function SVGGraphicsClosure() {
         current.tspan.setAttributeNS(null, 'fill', current.fillColor);
       }
 
+      // Include the text rise in the text matrix since the `pm` function
+      // creates the SVG element's `translate` entry (work on a copy to avoid
+      // altering the original text matrix).
+      let textMatrix = current.textMatrix;
+      if (current.textRise !== 0) {
+        textMatrix = textMatrix.slice();
+        textMatrix[5] += current.textRise;
+      }
+
       current.txtElement.setAttributeNS(null, 'transform',
-                                        pm(current.textMatrix) +
-                                        ' scale(1, -1)');
+                                        pm(textMatrix) + ' scale(1, -1)');
       current.txtElement.setAttributeNS(XML_NS, 'xml:space', 'preserve');
       current.txtElement.appendChild(current.tspan);
       current.txtgrp.appendChild(current.txtElement);


### PR DESCRIPTION
The property and the setter for text rise were already present, but they were never used or called. This patch completes the implementation by calling the setter when the operator is encountered and by using the text rise value when rendering text.

To verify the current behavior:
1. Open https://mozilla.github.io/pdf.js/web/viewer.html
2. Run `PDFViewerApplication.preferences.set('renderer', 'svg');` in the console and refresh.
3. Download https://www.pdflib.com/fileadmin/pdflib/Cookbook/pdf/footnotes_in_text.pdf and open it using the Open File button in the viewer. Notice that the `1` and `2` in the footnotes are not in superscript and that the console contains a message about the unimplemented operator `setTextRise`.

To verify the new behavior:
1. Open the preview viewer.
2. Run `PDFViewerApplication.preferences.set('renderer', 'svg');` in the console and refresh.
3. Open the `footnotes_in_text.pdf` fule using the Open File button in the viewer. Notice that the `1` and `2` in the footnotes are in superscript and that the console message is gone.