### PR TITLE
Fix color of image masks inside uncolored patterns

### DIFF
--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -360,7 +360,7 @@ var TilingPattern = (function TilingPatternClosure() {
       var graphics = canvasGraphicsFactory.createCanvasGraphics(tmpCtx);
       graphics.groupLevel = owner.groupLevel;
 
-      this.setFillAndStrokeStyleToContext(tmpCtx, paintType, color);
+      this.setFillAndStrokeStyleToContext(graphics, paintType, color);
 
       this.setScale(width, height, xstep, ystep);
       this.transformToScale(graphics);
@@ -401,17 +401,23 @@ var TilingPattern = (function TilingPatternClosure() {
     },
 
     setFillAndStrokeStyleToContext:
-      function setFillAndStrokeStyleToContext(context, paintType, color) {
+      function setFillAndStrokeStyleToContext(graphics, paintType, color) {
+        let context = graphics.ctx, current = graphics.current;
         switch (paintType) {
           case PaintType.COLORED:
             var ctx = this.ctx;
             context.fillStyle = ctx.fillStyle;
             context.strokeStyle = ctx.strokeStyle;
+            current.fillColor = ctx.fillStyle;
+            current.strokeColor = ctx.strokeStyle;
             break;
           case PaintType.UNCOLORED:
             var cssColor = Util.makeCssRgb(color[0], color[1], color[2]);
             context.fillStyle = cssColor;
             context.strokeStyle = cssColor;
+            // Set color needed by image masks (fixes issues 3226 and 8741).
+            current.fillColor = cssColor;
+            current.strokeColor = cssColor;
             break;
           default:
             throw new FormatError(`Unsupported paint type: ${paintType}`);

--- a/test/pdfs/pr8808.pdf.link
+++ b/test/pdfs/pr8808.pdf.link
@@ -1,0 +1,1 @@
+http://soap.plansystem.dk/pdfarchive/20_1057347_APPROVED_1193694109382.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -698,6 +698,14 @@
        "lastPage": 1,
        "type": "load"
     },
+    {  "id": "pr8808",
+       "file": "pdfs/pr8808.pdf",
+       "md5": "bdac6051a98fd8dcfc5344b05fed06f4",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue5599",
        "file": "pdfs/issue5599.pdf",
        "md5": "529a4a9409ac024aeb57a047210280fe",


### PR DESCRIPTION
Fixes #8741 
Fixes #3226
Fixes #8860

This is a patch for uncolored (`/PaintType 2`) tiling patterns that contain image masks. When uncolored patterns are used as a fill or stroke, the operator `scn` or `SCN` specifies the color of the pattern. If the pattern contains an image mask, PDF.js incorrectly draws it using black instead of the color specified by `scn` or `SCN`. 

In my patch, I assign the proper color to the `fillColor` property of the `CanvasExtraState` object. That property is used as the color of image masks in functions `paintImageMaskXObject...()` in canvas.js.