### PR TITLE
Moves global scope out of shared/util.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1040,7 +1040,7 @@ gulp.task('lib', ['buildnumber'], function () {
   var buildLib = merge([
     gulp.src([
       'src/{core,display}/*.js',
-      'src/shared/{compatibility,util,streams_polyfill}.js',
+      'src/shared/{compatibility,util,streams_polyfill,global_scope}.js',
       'src/{pdf,pdf.worker}.js',
     ], { base: 'src/', }),
     gulp.src([

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -15,7 +15,7 @@
 /* globals requirejs, __non_webpack_require__ */
 
 import {
-  assert, createPromiseCapability, deprecated, getVerbosityLevel, globalScope,
+  assert, createPromiseCapability, deprecated, getVerbosityLevel,
   info, InvalidPDFException, isArray, isArrayBuffer, isInt, isSameOrigin,
   loadJpegStream, MessageHandler, MissingPDFException, NativeImageDecoding,
   PageViewport, PasswordException, StatTimer, stringToBytes,
@@ -27,6 +27,7 @@ import {
 } from './dom_utils';
 import { FontFaceObject, FontLoader } from './font_loader';
 import { CanvasGraphics } from './canvas';
+import globalScope from '../shared/global_scope';
 import { Metadata } from './metadata';
 import { PDFDataTransportStream } from './transport_stream';
 

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -14,9 +14,10 @@
  */
 
 import {
-  CMapCompressionType, createValidAbsoluteUrl, deprecated, globalScope,
+  CMapCompressionType, createValidAbsoluteUrl, deprecated,
   removeNullCharacters, stringToBytes, warn
 } from '../shared/util';
+import globalScope from '../shared/global_scope';
 
 var DEFAULT_LINK_REL = 'noopener noreferrer nofollow';
 

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -23,12 +23,13 @@ import {
 } from './dom_utils';
 import {
   createBlob, createObjectURL, createPromiseCapability, deprecated,
-  getVerbosityLevel, globalScope, InvalidPDFException, isLittleEndian,
+  getVerbosityLevel, InvalidPDFException, isLittleEndian,
   MissingPDFException, OPS, PageViewport, PasswordException, PasswordResponses,
   removeNullCharacters, setVerbosityLevel, shadow, UnexpectedResponseException,
   UnknownErrorException, UNSUPPORTED_FEATURES, Util, VERBOSITY_LEVELS, warn
 } from '../shared/util';
 import { AnnotationLayer } from './annotation_layer';
+import globalScope from '../shared/global_scope';
 import { Metadata } from './metadata';
 import { renderTextLayer } from './text_layer';
 import { SVGGraphics } from './svg';

--- a/src/display/network.js
+++ b/src/display/network.js
@@ -14,9 +14,10 @@
  */
 
 import {
-  assert, createPromiseCapability, globalScope, isInt, MissingPDFException,
+  assert, createPromiseCapability, isInt, MissingPDFException,
   UnexpectedResponseException
 } from '../shared/util';
+import globalScope from '../shared/global_scope';
 import { setPDFNetworkStreamClass } from './api';
 
 if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('FIREFOX || MOZCENTRAL')) {

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -21,11 +21,7 @@ if ((typeof PDFJSDev === 'undefined' ||
      !PDFJSDev.test('FIREFOX || MOZCENTRAL || CHROME')) &&
     (typeof PDFJS === 'undefined' || !PDFJS.compatibilityChecked)) {
 
-var globalScope =
-  (typeof window !== 'undefined' && window.Math === Math) ? window :
-  (typeof global !== 'undefined' && global.Math === Math) ? global :
-  (typeof self !== 'undefined' && self.Math === Math) ? self :
-  (typeof this !== 'undefined' && this.Math === Math) ? this : {};
+var globalScope = require('./global_scope');
 
 var userAgent = (typeof navigator !== 'undefined' && navigator.userAgent) || '';
 var isAndroid = /Android/.test(userAgent);

--- a/src/shared/global_scope.js
+++ b/src/shared/global_scope.js
@@ -1,0 +1,21 @@
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* globals module */
+
+module.exports =
+  (typeof window !== 'undefined' && window.Math === Math) ? window :
+  // eslint-disable-next-line no-undef
+  (typeof global !== 'undefined' && global.Math === Math) ? global :
+  (typeof self !== 'undefined' && self.Math === Math) ? self : {};

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -16,12 +16,6 @@
 import './compatibility';
 import { ReadableStream } from './streams_polyfill';
 
-var globalScope =
-  (typeof window !== 'undefined' && window.Math === Math) ? window :
-  // eslint-disable-next-line no-undef
-  (typeof global !== 'undefined' && global.Math === Math) ? global :
-  (typeof self !== 'undefined' && self.Math === Math) ? self : this;
-
 var FONT_IDENTITY_MATRIX = [0.001, 0, 0, 0.001, 0, 0];
 
 const NativeImageDecoding = {
@@ -1696,7 +1690,6 @@ export {
   deprecated,
   getLookupTableFactory,
   getVerbosityLevel,
-  globalScope,
   info,
   isArray,
   isArrayBuffer,

--- a/src/worker_loader.js
+++ b/src/worker_loader.js
@@ -24,7 +24,6 @@ self.importScripts = (function (importScripts) {
   };
 })(importScripts);
 
-importScripts('./shared/compatibility.js');
 importScripts('../node_modules/systemjs/dist/system.js');
 importScripts('../systemjs.config.js');
 


### PR DESCRIPTION
Follow up on #8761

Using `this` in modules is tricky. (It will be replaced by babel to `undefined`). Moving globalScope out of shared/utils into separate file -- this will allow to create single object for compatibility and util usages.