### PR TITLE
Use Array.isArray in the LoopbackPort.

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -16,7 +16,7 @@
 
 import {
   assert, createPromiseCapability, deprecated, getVerbosityLevel,
-  info, InvalidPDFException, isArray, isArrayBuffer, isInt, isSameOrigin,
+  info, InvalidPDFException, isArrayBuffer, isInt, isSameOrigin,
   loadJpegStream, MessageHandler, MissingPDFException, NativeImageDecoding,
   PageViewport, PasswordException, StatTimer, stringToBytes,
   UnexpectedResponseException, UnknownErrorException, Util, warn
@@ -1183,7 +1183,7 @@ class LoopbackPort {
         cloned.set(value, result);
         return result;
       }
-      result = isArray(value) ? [] : {};
+      result = Array.isArray(value) ? [] : {};
       cloned.set(value, result); // adding to cache now for cyclic references
       // Cloning all value and object properties, however ignoring properties
       // defined via getter.


### PR DESCRIPTION
For better serialization of Arrays that belong to different sandboxes.

See also http://logs.glob.uno/?c=mozilla%23pdfjs#c66373

/cc @tobytailor 
