### PR TITLE
Set this.isCancelled in close method of streamSink.

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1483,6 +1483,7 @@ MessageHandler.prototype = {
         if (this.isCancelled) {
           return;
         }
+        this.isCancelled = true;
         sendStreamRequest({ stream: 'close', });
         delete self.streamSinks[streamId];
       },


### PR DESCRIPTION
Fixes #8816 . This PR tries to fix the intermittent error `Error: close should have stream controller thrown` raised during unit tests.

I cannot see where we are setting `sink.isCancelled = true`, when close() method of streamSink is called. So, I think adding `this.isCancelled = true;` in close() method itself, may fix this intermittent error.

@timvandermeij can you please check if this fixes the problem, as I cannot reproduce this error locally.