### PR TITLE
Remove any mention of `compatibility.js` from the "Getting Started" docs (issue 8818)

### DIFF
--- a/docs/contents/getting_started/index.md
+++ b/docs/contents/getting_started/index.md
@@ -68,7 +68,6 @@ $ cd pdf.js
 │   └── pdf.worker.js                      - core layer
 └── web/
     ├── cmaps/                             - character maps(required by core)
-    ├── compatibility.js                   - polyfills for missing features
     ├── compressed.tracemonkey-pldi-09.pdf - test pdf
     ├── debugger.js                        - helpful pdf debugging features
     ├── images/                            - images for the viewer and annotation icons


### PR DESCRIPTION
*With PR #8102, `compatibility.js` is now bundled directly into `pdf.js` and `pdf.worker.js`.*

Fixes #8818.