### PR TITLE
Prevent an infinite loop in `XRef.readXRef` by keeping track of already parsed tables (bug 1393476)

### DIFF
--- a/test/pdfs/bug1393476.pdf.link
+++ b/test/pdfs/bug1393476.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=8900754

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -820,6 +820,13 @@
        "link": false,
        "type": "eq"
     },
+    {  "id": "bug1393476",
+       "file": "pdfs/bug1393476.pdf",
+       "md5": "163ee8727c77f27ee651eec777bb20a9",
+       "rounds": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "bug1252420",
        "file": "pdfs/bug1252420.pdf",
        "md5": "f21c911b9b655972b06ef782a1fa6a17",


### PR DESCRIPTION
*Please note that while this passes all tests locally, I don't know if it's necessarily the best solution.*

With this patch, not only is the infinite loop prevented, but we're also able to actually render the file (which e.g. Adobe Reader isn't able to).

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1393476.