### PR TITLE
Account for broken outlines/annotations, where the destination dictionary contains an invalid `/Dest` entry

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -640,20 +640,32 @@ var Catalog = (function CatalogClosure() {
 
     var destDict = params.destDict;
     if (!isDict(destDict)) {
-      warn('Catalog_parseDestDictionary: "destDict" must be a dictionary.');
+      warn('parseDestDictionary: "destDict" must be a dictionary.');
       return;
     }
     var resultObj = params.resultObj;
     if (typeof resultObj !== 'object') {
-      warn('Catalog_parseDestDictionary: "resultObj" must be an object.');
+      warn('parseDestDictionary: "resultObj" must be an object.');
       return;
     }
     var docBaseUrl = params.docBaseUrl || null;
 
     var action = destDict.get('A'), url, dest;
+    if (!isDict(action) && destDict.has('Dest')) {
+      // A /Dest entry should *only* contain a Name or an Array, but some bad
+      // PDF generators ignore that and treat it as an /A entry.
+      action = destDict.get('Dest');
+    }
+
     if (isDict(action)) {
-      var linkType = action.get('S').name;
-      switch (linkType) {
+      let actionType = action.get('S');
+      if (!isName(actionType)) {
+        warn('parseDestDictionary: Invalid type in Action dictionary.');
+        return;
+      }
+      let actionName = actionType.name;
+
+      switch (actionName) {
         case 'URI':
           url = action.get('URI');
           if (isName(url)) {
@@ -748,11 +760,10 @@ var Catalog = (function CatalogClosure() {
           }
           /* falls through */
         default:
-          warn('Catalog_parseDestDictionary: Unrecognized link type "' +
-               linkType + '".');
+          warn(`parseDestDictionary: Unsupported Action type "${actionName}".`);
           break;
       }
-    } else if (destDict.has('Dest')) { // Simple destination link.
+    } else if (destDict.has('Dest')) { // Simple destination.
       dest = destDict.get('Dest');
     }
 


### PR DESCRIPTION
According to the specification, see http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#page=377, a `Dest` entry in an outline item should *not* contain a dictionary.
Unsurprisingly there's PDF generators that completely ignore this, treating is an `A` entry instead.

The patch also adds a little bit more validation code in `Catalog.parseDestDictionary`.

Fixes https://github.com/mozilla/pdf.js/issues/5089#issuecomment-324871440.