### PR TITLE
Update the `gulp minified` command to use uglify-es

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -702,25 +702,27 @@ gulp.task('minified-pre', ['buildnumber', 'locale'], function () {
 });
 
 gulp.task('minified-post', ['minified-pre'], function () {
-  var viewerFiles = [
-    MINIFIED_DIR + BUILD_DIR + 'pdf.js',
-    MINIFIED_DIR + '/web/viewer.js'
-  ];
+  var pdfFile = fs.readFileSync(MINIFIED_DIR + '/build/pdf.js').toString();
+  var pdfWorkerFile =
+    fs.readFileSync(MINIFIED_DIR + '/build/pdf.worker.js').toString();
+  var viewerFiles = {
+    'pdf.js': pdfFile,
+    'viewer.js': fs.readFileSync(MINIFIED_DIR + '/web/viewer.js').toString(),
+  };
 
   console.log();
   console.log('### Minifying js files');
 
-  var UglifyJS = require('uglify-js');
+  var UglifyES = require('uglify-es');
   // V8 chokes on very long sequences. Works around that.
   var optsForHugeFile = { compress: { sequences: false, }, };
 
   fs.writeFileSync(MINIFIED_DIR + '/web/pdf.viewer.js',
-                   UglifyJS.minify(viewerFiles).code);
+                   UglifyES.minify(viewerFiles).code);
   fs.writeFileSync(MINIFIED_DIR + '/build/pdf.min.js',
-                   UglifyJS.minify(MINIFIED_DIR + '/build/pdf.js').code);
+                   UglifyES.minify(pdfFile).code);
   fs.writeFileSync(MINIFIED_DIR + '/build/pdf.worker.min.js',
-                   UglifyJS.minify(MINIFIED_DIR + '/build/pdf.worker.js',
-                                   optsForHugeFile).code);
+                   UglifyES.minify(pdfWorkerFile, optsForHugeFile).code);
 
   console.log();
   console.log('### Cleaning js files');

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "systemjs-plugin-babel": "0.0.21",
     "ttest": "^1.1.0",
     "typogr": "^0.6.6",
-    "uglify-js": "^2.6.1",
+    "uglify-es": "^3.0.28",
     "vinyl-fs": "^2.4.4",
     "webpack": "^2.2.1",
     "webpack-stream": "^3.2.0",


### PR DESCRIPTION
By updating to uglify-es, rather than uglify-js, the minifier *itself* now supports ES6 code. This means that it's now possible to minify code built with `PDFJS_NEXT = true` set, i.e. with Babel transpilation disabled, which wasn't the case previously.

Note that uglify-es is based on the API of uglify-js v3, which differs from the one that we previously used.
Of particular importance is the fact that it's no longer possible to provide a path to a file for minification, but one must instead directly provide the source of the file.

For more information, please see https://github.com/mishoo/UglifyJS2/tree/harmony