### PR TITLE
Ensure that `PDFViewerApplication.error` outputs proper messages in FIREFOX/MOZCENTRAL builds

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -841,7 +841,9 @@ let PDFViewerApplication = {
         errorMoreInfo.value = parts.join('\n');
       });
     } else {
-      console.error(message + '\n' + moreInfoText);
+      Promise.all(moreInfoText).then((parts) => {
+        console.error(message + '\n' + parts.join('\n'));
+      });
       this.fallback();
     }
   },


### PR DESCRIPTION
*It appears that this accidentally broke with PR #8394.*

Currently, the following will be printed in the console:
```
An error occurred while loading the PDF.
[object Promise],[object Promise]
```

With this patch we'll again get proper output, e.g. something with this format:
```
An error occurred while loading the PDF.
PDF.js v? (build: ?)
Message: unknown encryption method
```