### PR TITLE
Correct the default value for `isRenderable` in the `AnnotationElement` constructor, to fix breaking errors when rendering unsupported annotations

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -95,7 +95,7 @@ class AnnotationElementFactory {
 }
 
 class AnnotationElement {
-  constructor(parameters, isRenderable = true, ignoreBorder = false) {
+  constructor(parameters, isRenderable = false, ignoreBorder = false) {
     this.isRenderable = isRenderable;
     this.data = parameters.data;
     this.layer = parameters.layer;
@@ -250,6 +250,10 @@ class AnnotationElement {
 }
 
 class LinkAnnotationElement extends AnnotationElement {
+  constructor(parameters) {
+    super(parameters, /* isRenderable = */ true);
+  }
+
   /**
    * Render the link annotation's HTML element in the empty container.
    *
@@ -902,7 +906,7 @@ class StrikeOutAnnotationElement extends AnnotationElement {
 
 class FileAttachmentAnnotationElement extends AnnotationElement {
   constructor(parameters) {
-    super(parameters, true);
+    super(parameters, /* isRenderable = */ true);
 
     let file = this.data.file;
     this.filename = getFilenameFromUrl(file.filename);


### PR DESCRIPTION
*This regressed in PR #8828.*

When attempting to open e.g. http://mirrors.ctan.org/macros/latex/contrib/pdfcomment/doc/example.pdf, the annotation layers are now missing since `Error: Abstract method `AnnotationElement.render` called` is thrown multiple times.

**Note:** In the old code we'd fallback to `false`, see https://github.com/mozilla/pdf.js/pull/8828/commits/af10f8b5866a7ec6a2ae1d988271b6ff8f70f5a4#diff-1097e3b131ba22f8e8a6c2f20e3ab5ecL109; but in the re-factored code `true` is being used instead, see https://github.com/mozilla/pdf.js/pull/8828/commits/af10f8b5866a7ec6a2ae1d988271b6ff8f70f5a4#diff-1097e3b131ba22f8e8a6c2f20e3ab5ecR98. Hence this appears to be nothing more than a simple typo :-)