### PR TITLE
Correctly set the `credentials` of a fetch request, when the `withCredentials` parameter was passed to `getDocument`

### DIFF
--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -26,7 +26,7 @@ function createFetchOptions(headers, withCredentials) {
     method: 'GET',
     headers,
     mode: 'cors',
-    credentials: withCredentials ? 'omit' : 'include',
+    credentials: withCredentials ? 'include' : 'omit',
     redirect: 'follow',
   };
 }


### PR DESCRIPTION
Skimming through https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#Sending_a_request_with_credentials_included, it looks to me like the `credentials` option was accidentally inverted.

@yurydelendik If I've completely misunderstood this code, and the MDN docs, please just close this PR (and sorry about wasting your time in that case).