### PR TITLE
CORS with credentials fix.

### DIFF
--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -26,7 +26,7 @@ function createFetchOptions(headers, withCredentials) {
     method: 'GET',
     headers,
     mode: 'cors',
-    credentials: withCredentials ? 'omit' : 'include',
+    credentials: withCredentials ? 'include' : 'omit',
     redirect: 'follow',
   };
 }


### PR DESCRIPTION
Because of incorrect ternary condition, 
```
The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'.
```
 error is shown and file fails to load even though no credential is not required.