### PR TITLE
Hide unsupported `LinkAnnotation`s (issue 3897)

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -251,7 +251,9 @@ class AnnotationElement {
 
 class LinkAnnotationElement extends AnnotationElement {
   constructor(parameters) {
-    super(parameters, /* isRenderable = */ true);
+    let isRenderable = !!(parameters.data.url || parameters.data.dest ||
+                          parameters.data.action);
+    super(parameters, isRenderable);
   }
 
   /**

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -89,6 +89,7 @@
 !simpletype3font.pdf
 !sizes.pdf
 !javauninstall-7r.pdf
+!file_url_link.pdf
 !multiple-filters-length-zero.pdf
 !non-embedded-NuptialScript.pdf
 !issue3205r.pdf

--- a/test/pdfs/file_url_link.pdf
+++ b/test/pdfs/file_url_link.pdf
@@ -1,0 +1,85 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/Pages 2 0 R
+/Type /Catalog
+>>
+endobj 
+2 0 obj 
+<<
+/Kids [3 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+3 0 obj 
+<<
+/Parent 2 0 R
+/Annots [4 0 R]
+/MediaBox [0 0 200 50]
+/Resources 
+<<
+/Font 
+<<
+/F1 5 0 R
+>>
+>>
+/Contents 6 0 R
+/Type /Page
+>>
+endobj 
+4 0 obj 
+<<
+/Border [0 0 1]
+/Subtype /Link
+/C [0 1 0]
+/A 
+<<
+/URI (file://path/to/local/file.pdf)
+/Type /Action
+/S /URI
+>>
+/Type /Annot
+/Rect [5 10 180 40]
+>>
+endobj 
+5 0 obj 
+<<
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/Type /Font
+>>
+endobj 
+6 0 obj 
+<<
+/Length 62
+>>
+stream
+1 0 0 rg
+BT
+10 20 TD
+/F1 20 Tf
+(path/to/local/file.pdf) Tj
+ET
+
+endstream 
+endobj xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000066 00000 n 
+0000000125 00000 n 
+0000000270 00000 n 
+0000000437 00000 n 
+0000000538 00000 n 
+trailer
+
+<<
+/Root 1 0 R
+/Size 7
+>>
+startxref
+652
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -623,6 +623,15 @@
        "annotations": true,
        "about": "Annotation with Rect array containing indirect objects."
     },
+    {  "id": "file_url_link",
+       "file": "pdfs/file_url_link.pdf",
+       "md5": "b0253c96c38d43bc49259bbf36db938a",
+       "link": false,
+       "rounds": 1,
+       "type": "eq",
+       "annotations": true,
+       "about": "Annotation with (unsupported) file:// URL."
+    },
     {  "id": "issue4934",
        "file": "pdfs/issue4934.pdf",
        "md5": "6099da44f677702ae65a648b51a2226d",

--- a/web/app.js
+++ b/web/app.js
@@ -658,8 +658,10 @@ let PDFViewerApplication = {
       this.setTitleUsingUrl(file.originalUrl);
       parameters.url = file.url;
     }
-    if (typeof PDFJSDev !== 'undefined' &&
-        PDFJSDev.test('FIREFOX || MOZCENTRAL || CHROME')) {
+    if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION')) {
+      parameters.docBaseUrl = document.URL.split('#')[0];
+    } else if (typeof PDFJSDev !== 'undefined' &&
+               PDFJSDev.test('FIREFOX || MOZCENTRAL || CHROME')) {
       parameters.docBaseUrl = this.baseUrl;
     }
 


### PR DESCRIPTION
Rather than displaying links that does *nothing* when clicked, it probably makes more sense to simply not render them instead. Especially since it turns out that, at least at this point in time, this is *very* easy to both implement and test.

Fixes #3897.