### PR TITLE
Correctly validate the response status for non-HTTP fetch requests (PR 8768 follow-up)

### DIFF
--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -94,7 +94,7 @@ class PDFFetchStreamReader {
     let url = this._stream.source.url;
     fetch(url, createFetchOptions(this._headers, this._withCredentials)).
         then((response) => {
-      if (!validateResponseStatus(response.status, this._stream.isHttp)) {
+      if (!validateResponseStatus(response.status)) {
         throw createResponseStatusError(response.status, url);
       }
       this._reader = response.body.getReader();
@@ -188,7 +188,7 @@ class PDFFetchStreamRangeReader {
     let url = this._stream.source.url;
     fetch(url, createFetchOptions(this._headers, this._withCredentials)).
         then((response) => {
-      if (!validateResponseStatus(response.status, this._stream.isHttp)) {
+      if (!validateResponseStatus(response.status)) {
         throw createResponseStatusError(response.status, url);
       }
       this._readCapability.resolve();

--- a/src/display/network_utils.js
+++ b/src/display/network_utils.js
@@ -61,10 +61,7 @@ function createResponseStatusError(status, url) {
     ') while retrieving PDF "' + url + '".', status);
 }
 
-function validateResponseStatus(status, isHttp) {
-  if (!isHttp) {
-    return status === 0;
-  }
+function validateResponseStatus(status) {
   return status === 200 || status === 206;
 }
 


### PR DESCRIPTION
It seems that the status check, for non-HTTP loads, has been inverted which causes the default viewer to *refuse* to open local PDF files. *Follow-up to PR #8768.*

***STR:***
 1. Make sure that fetch support is enabled in the browser. In Firefox Nightly, set `dom.streams.enabled = true` and `javascript.options.streams = true` in `about:config`. *Edit:* Just to clarify, please note that the issue is reproducible in Google Chrome too.
 2. Open https://mozilla.github.io/pdf.js/web/viewer.html.
 3. Click on the "Open file" button, and open a new PDF file.

***ER:***
 A new PDF file should open in the viewer.

***AR:***
 The PDF file fails to open, with an error message of the following format:
`Message: Unexpected server response (200) while retrieving PDF "blob:https://mozilla.github.io/a4fc455f-bc05-45b5-b6aa-2ecff3cb45ce".`

*Edit:* Fixes #8870.