### PR TITLE
Store the rotation in the `ViewHistory`/`PDFHistory` (issue 5927)

### DIFF
--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -14,8 +14,8 @@
  */
 
 import {
-  binarySearchFirstItem, EventBus, getPDFFileNameFromURL, waitOnEventOrTimeout,
-  WaitOnType
+  binarySearchFirstItem, EventBus, getPDFFileNameFromURL, isValidRotation,
+  waitOnEventOrTimeout, WaitOnType
 } from '../../web/ui_utils';
 import { createObjectURL, isNodeJS } from '../../src/shared/util';
 
@@ -258,6 +258,29 @@ describe('ui_utils', function() {
       eventBus.dispatch('test');
       eventBus.dispatch('test');
       expect(count).toEqual(2);
+    });
+  });
+
+  describe('isValidRotation', function() {
+    it('should reject non-integer angles', function() {
+      expect(isValidRotation()).toEqual(false);
+      expect(isValidRotation(null)).toEqual(false);
+      expect(isValidRotation(NaN)).toEqual(false);
+      expect(isValidRotation([90])).toEqual(false);
+      expect(isValidRotation('90')).toEqual(false);
+      expect(isValidRotation(90.5)).toEqual(false);
+    });
+
+    it('should reject non-multiple of 90 degree angles', function() {
+      expect(isValidRotation(45)).toEqual(false);
+      expect(isValidRotation(-123)).toEqual(false);
+    });
+
+    it('should accept valid angles', function() {
+      expect(isValidRotation(0)).toEqual(true);
+      expect(isValidRotation(90)).toEqual(true);
+      expect(isValidRotation(-270)).toEqual(true);
+      expect(isValidRotation(540)).toEqual(true);
     });
   });
 

--- a/web/app.js
+++ b/web/app.js
@@ -935,6 +935,8 @@ let PDFViewerApplication = {
 
         if (this.pdfHistory.initialBookmark) {
           this.initialBookmark = this.pdfHistory.initialBookmark;
+
+          this.initialRotation = this.pdfHistory.initialRotation;
         }
       }
 
@@ -1145,6 +1147,9 @@ let PDFViewerApplication = {
     this.pdfSidebar.setInitialView(sidebarView);
 
     if (this.initialBookmark) {
+      setRotation(this.initialRotation);
+      delete this.initialRotation;
+
       this.pdfLinkService.setHash(this.initialBookmark);
       this.initialBookmark = null;
     } else if (storedHash) {

--- a/web/app.js
+++ b/web/app.js
@@ -15,9 +15,9 @@
 /* globals PDFBug, Stats */
 
 import {
-  animationStarted, DEFAULT_SCALE_VALUE, getPDFFileNameFromURL, MAX_SCALE,
-  MIN_SCALE, noContextMenuHandler, normalizeWheelEventDelta, parseQueryString,
-  ProgressBar, RendererType
+  animationStarted, DEFAULT_SCALE_VALUE, getPDFFileNameFromURL, isValidRotation,
+  MAX_SCALE, MIN_SCALE, noContextMenuHandler, normalizeWheelEventDelta,
+  parseQueryString, ProgressBar, RendererType
 } from './ui_utils';
 import {
   build, createBlob, getDocument, getFilenameFromUrl, InvalidPDFException,
@@ -948,6 +948,7 @@ let PDFViewerApplication = {
         zoom: DEFAULT_SCALE_VALUE,
         scrollLeft: '0',
         scrollTop: '0',
+        rotation: null,
         sidebarView: SidebarView.NONE,
       }).catch(() => { /* Unable to read from storage; ignoring errors. */ });
 
@@ -956,12 +957,14 @@ let PDFViewerApplication = {
         // Initialize the default values, from user preferences.
         let hash = this.viewerPrefs['defaultZoomValue'] ?
           ('zoom=' + this.viewerPrefs['defaultZoomValue']) : null;
+        let rotation = null;
         let sidebarView = this.viewerPrefs['sidebarViewOnLoad'];
 
         if (values.exists && this.viewerPrefs['showPreviousViewOnLoad']) {
           hash = 'page=' + values.page +
             '&zoom=' + (this.viewerPrefs['defaultZoomValue'] || values.zoom) +
             ',' + values.scrollLeft + ',' + values.scrollTop;
+          rotation = parseInt(values.rotation, 10);
           sidebarView = sidebarView || (values.sidebarView | 0);
         }
         if (pageMode && !this.viewerPrefs['disablePageMode']) {
@@ -970,13 +973,14 @@ let PDFViewerApplication = {
         }
         return {
           hash,
+          rotation,
           sidebarView,
         };
-      }).then(({ hash, sidebarView, }) => {
+      }).then(({ hash, rotation, sidebarView, }) => {
         initialParams.bookmark = this.initialBookmark;
         initialParams.hash = hash;
 
-        this.setInitialView(hash, { sidebarView, });
+        this.setInitialView(hash, { rotation, sidebarView, });
 
         // Make all navigation keys work on document load,
         // unless the viewer is embedded in a web page.
@@ -1131,7 +1135,12 @@ let PDFViewerApplication = {
     });
   },
 
-  setInitialView(storedHash, { sidebarView, } = {}) {
+  setInitialView(storedHash, { rotation, sidebarView, } = {}) {
+    let setRotation = (angle) => {
+      if (isValidRotation(angle)) {
+        this.pdfViewer.pagesRotation = angle;
+      }
+    };
     this.isInitialViewSet = true;
     this.pdfSidebar.setInitialView(sidebarView);
 
@@ -1139,6 +1148,8 @@ let PDFViewerApplication = {
       this.pdfLinkService.setHash(this.initialBookmark);
       this.initialBookmark = null;
     } else if (storedHash) {
+      setRotation(rotation);
+
       this.pdfLinkService.setHash(storedHash);
     }
 
@@ -1765,6 +1776,7 @@ function webViewerUpdateViewarea(evt) {
       'zoom': location.scale,
       'scrollLeft': location.left,
       'scrollTop': location.top,
+      'rotation': location.rotation,
     }).catch(function() { /* unable to write to storage */ });
   }
   let href =

--- a/web/app.js
+++ b/web/app.js
@@ -1232,16 +1232,10 @@ let PDFViewerApplication = {
     if (!this.pdfDocument) {
       return;
     }
-    let { pdfViewer, pdfThumbnailViewer, } = this;
-    let pageNumber = pdfViewer.currentPageNumber;
-    let newRotation = (pdfViewer.pagesRotation + 360 + delta) % 360;
-
-    pdfViewer.pagesRotation = newRotation;
-    pdfThumbnailViewer.pagesRotation = newRotation;
-
-    this.forceRendering();
-    // Ensure that the active page doesn't change during rotation.
-    pdfViewer.currentPageNumber = pageNumber;
+    let newRotation = (this.pdfViewer.pagesRotation + 360 + delta) % 360;
+    this.pdfViewer.pagesRotation = newRotation;
+    // Note that the thumbnail viewer is updated, and rendering is triggered,
+    // in the 'rotationchanging' event handler.
   },
 
   requestPresentationMode() {
@@ -1266,6 +1260,7 @@ let PDFViewerApplication = {
     eventBus.on('updateviewarea', webViewerUpdateViewarea);
     eventBus.on('pagechanging', webViewerPageChanging);
     eventBus.on('scalechanging', webViewerScaleChanging);
+    eventBus.on('rotationchanging', webViewerRotationChanging);
     eventBus.on('sidebarviewchanged', webViewerSidebarViewChanged);
     eventBus.on('pagemode', webViewerPageMode);
     eventBus.on('namedaction', webViewerNamedAction);
@@ -1343,6 +1338,7 @@ let PDFViewerApplication = {
     eventBus.off('updateviewarea', webViewerUpdateViewarea);
     eventBus.off('pagechanging', webViewerPageChanging);
     eventBus.off('scalechanging', webViewerScaleChanging);
+    eventBus.off('rotationchanging', webViewerRotationChanging);
     eventBus.off('sidebarviewchanged', webViewerSidebarViewChanged);
     eventBus.off('pagemode', webViewerPageMode);
     eventBus.off('namedaction', webViewerNamedAction);
@@ -1924,6 +1920,14 @@ function webViewerScaleChanging(evt) {
   PDFViewerApplication.toolbar.setPageScale(evt.presetValue, evt.scale);
 
   PDFViewerApplication.pdfViewer.update();
+}
+
+function webViewerRotationChanging(evt) {
+  PDFViewerApplication.pdfThumbnailViewer.pagesRotation = evt.pagesRotation;
+
+  PDFViewerApplication.forceRendering();
+  // Ensure that the active page doesn't change during rotation.
+  PDFViewerApplication.pdfViewer.currentPageNumber = evt.pageNumber;
 }
 
 function webViewerPageChanging(evt) {

--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -31,6 +31,16 @@ class IPDFLinkService {
   set page(value) {}
 
   /**
+   * @returns {number}
+   */
+  get rotation() {}
+
+  /**
+   * @param {number} value
+   */
+  set rotation(value) {}
+
+  /**
    * @param dest - The PDF destination object.
    */
   navigateTo(dest) {}

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -76,6 +76,20 @@ class PDFLinkService {
   }
 
   /**
+   * @returns {number}
+   */
+  get rotation() {
+    return this.pdfViewer.pagesRotation;
+  }
+
+  /**
+   * @param {number} value
+   */
+  set rotation(value) {
+    this.pdfViewer.pagesRotation = value;
+  }
+
+  /**
    * @param {string|Array} dest - The named, or explicit, PDF destination.
    */
   navigateTo(dest) {
@@ -414,6 +428,16 @@ class SimpleLinkService {
    * @param {number} value
    */
   set page(value) {}
+  /**
+   * @returns {number}
+   */
+  get rotation() {
+    return 0;
+  }
+  /**
+   * @param {number} value
+   */
+  set rotation(value) {}
   /**
    * @param dest - The PDF destination object.
    */

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -14,7 +14,7 @@
  */
 
 import {
-  getVisibleElements, NullL10n, scrollIntoView, watchScroll
+  getVisibleElements, isValidRotation, NullL10n, scrollIntoView, watchScroll
 } from './ui_utils';
 import { PDFThumbnailView } from './pdf_thumbnail_view';
 
@@ -95,11 +95,14 @@ class PDFThumbnailViewer {
   }
 
   set pagesRotation(rotation) {
-    if (!(typeof rotation === 'number' && rotation % 90 === 0)) {
+    if (!isValidRotation(rotation)) {
       throw new Error('Invalid thumbnails rotation angle.');
     }
     if (!this.pdfDocument) {
       return;
+    }
+    if (this._pagesRotation === rotation) {
+      return; // The rotation didn't change.
     }
     this._pagesRotation = rotation;
 

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -732,6 +732,7 @@ class PDFViewer {
       scale: normalizedScaleValue,
       top: intTop,
       left: intLeft,
+      rotation: this._pagesRotation,
       pdfOpenParams,
     };
   }

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -16,8 +16,8 @@
 import { createPromiseCapability, PDFJS } from 'pdfjs-lib';
 import {
   CSS_UNITS, DEFAULT_SCALE, DEFAULT_SCALE_VALUE, getVisibleElements,
-  MAX_AUTO_SCALE, NullL10n, RendererType, SCROLLBAR_PADDING, scrollIntoView,
-  UNKNOWN_SCALE, VERTICAL_PADDING, watchScroll
+  isValidRotation, MAX_AUTO_SCALE, NullL10n, RendererType, SCROLLBAR_PADDING,
+  scrollIntoView, UNKNOWN_SCALE, VERTICAL_PADDING, watchScroll
 } from './ui_utils';
 import { PDFRenderingQueue, RenderingStates } from './pdf_rendering_queue';
 import { AnnotationLayerBuilder } from './annotation_layer_builder';
@@ -271,20 +271,34 @@ class PDFViewer {
    * @param {number} rotation - The rotation of the pages (0, 90, 180, 270).
    */
   set pagesRotation(rotation) {
-    if (!(typeof rotation === 'number' && rotation % 90 === 0)) {
+    if (!isValidRotation(rotation)) {
       throw new Error('Invalid pages rotation angle.');
     }
     if (!this.pdfDocument) {
       return;
     }
+    if (this._pagesRotation === rotation) {
+      return; // The rotation didn't change.
+    }
     this._pagesRotation = rotation;
+
+    let pageNumber = this._currentPageNumber;
 
     for (let i = 0, ii = this._pages.length; i < ii; i++) {
       let pageView = this._pages[i];
       pageView.update(pageView.scale, rotation);
     }
+    // Prevent errors in case the rotation changes *before* the scale has been
+    // set to a non-default value.
+    if (this._currentScaleValue) {
+      this._setScale(this._currentScaleValue, true);
+    }
 
-    this._setScale(this._currentScaleValue, true);
+    this.eventBus.dispatch('rotationchanging', {
+      source: this,
+      pagesRotation: rotation,
+      pageNumber,
+    });
 
     if (this.defaultRenderingQueue) {
       this.update();

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -443,6 +443,10 @@ function normalizeWheelEventDelta(evt) {
   return delta;
 }
 
+function isValidRotation(angle) {
+  return Number.isInteger(angle) && angle % 90 === 0;
+}
+
 function cloneObj(obj) {
   let result = Object.create(null);
   for (let i in obj) {
@@ -655,6 +659,7 @@ export {
   MAX_AUTO_SCALE,
   SCROLLBAR_PADDING,
   VERTICAL_PADDING,
+  isValidRotation,
   cloneObj,
   RendererType,
   mozL10n,


### PR DESCRIPTION
Please note that compared to previous attempts at fixing this, the commits in this PR adds rotation support to the history implementation as well.

Fixes #5927.