### PR TITLE
Provide `checked` styles for button widget annotations

### DIFF
--- a/test/annotation_layer_test.css
+++ b/test/annotation_layer_test.css
@@ -63,6 +63,10 @@
   width: 100%;
 }
 
+.annotationLayer .buttonWidgetAnnotation.radioButton input {
+  border-radius: 50%;
+}
+
 .annotationLayer .textWidgetAnnotation textarea {
   font: message-box;
   font-size: 9px;
@@ -78,6 +82,38 @@
   border: 1px solid transparent;
 }
 
+.annotationLayer .buttonWidgetAnnotation.checkBox input:checked:before,
+.annotationLayer .buttonWidgetAnnotation.checkBox input:checked:after,
+.annotationLayer .buttonWidgetAnnotation.radioButton input:checked:before {
+  background-color: #000;
+  content: '';
+  display: block;
+  position: absolute;
+}
+
+.annotationLayer .buttonWidgetAnnotation.radioButton input:checked:before {
+  border-radius: 50%;
+  height: 50%;
+  left: 30%;
+  top: 20%;
+  width: 50%;
+}
+
+.annotationLayer .buttonWidgetAnnotation.checkBox input:checked:before,
+.annotationLayer .buttonWidgetAnnotation.checkBox input:checked:after {
+  height: 80%;
+  left: 45%;
+  width: 1px;
+}
+
+.annotationLayer .buttonWidgetAnnotation.checkBox input:checked:before {
+  transform: rotate(45deg);
+}
+
+.annotationLayer .buttonWidgetAnnotation.checkBox input:checked:after {
+  transform: rotate(-45deg);
+}
+
 .annotationLayer .textWidgetAnnotation input.comb {
   font-family: monospace;
   padding-left: 2px;
@@ -90,6 +126,7 @@
   -moz-appearance: none;
   -ms-appearance: none;
   appearance: none;
+  padding: 0;
 }
 
 .annotationLayer .popupAnnotation {

--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -56,6 +56,10 @@
   width: 100%;
 }
 
+.annotationLayer .buttonWidgetAnnotation.radioButton input {
+  border-radius: 50%;
+}
+
 .annotationLayer .textWidgetAnnotation textarea {
   font: message-box;
   font-size: 9px;
@@ -87,6 +91,38 @@
   border: 1px solid transparent;
 }
 
+.annotationLayer .buttonWidgetAnnotation.checkBox input:checked:before,
+.annotationLayer .buttonWidgetAnnotation.checkBox input:checked:after,
+.annotationLayer .buttonWidgetAnnotation.radioButton input:checked:before {
+  background-color: #000;
+  content: '';
+  display: block;
+  position: absolute;
+}
+
+.annotationLayer .buttonWidgetAnnotation.checkBox input:checked:before,
+.annotationLayer .buttonWidgetAnnotation.checkBox input:checked:after {
+  height: 80%;
+  left: 45%;
+  width: 1px;
+}
+
+.annotationLayer .buttonWidgetAnnotation.checkBox input:checked:before {
+  transform: rotate(45deg);
+}
+
+.annotationLayer .buttonWidgetAnnotation.checkBox input:checked:after {
+  transform: rotate(-45deg);
+}
+
+.annotationLayer .buttonWidgetAnnotation.radioButton input:checked:before {
+  border-radius: 50%;
+  height: 50%;
+  left: 30%;
+  top: 20%;
+  width: 50%;
+}
+
 .annotationLayer .textWidgetAnnotation input.comb {
   font-family: monospace;
   padding-left: 2px;
@@ -109,6 +145,7 @@
   -moz-appearance: none;
   -ms-appearance: none;
   appearance: none;
+  padding: 0;
 }
 
 .annotationLayer .popupWrapper {


### PR DESCRIPTION
Fixes #8875.

Use `test/pdfs/annotation-button-widget.pdf` (existing testcase) to verify this, together with `PDFViewerApplication.preferences.set('renderInteractiveForms', true);`.