### PR TITLE
Replace `value === (value | 0)` checks with `Number.isInteger(value)`

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -450,7 +450,7 @@ class AnnotationBorderStyle {
    * @param {integer} width - The width
    */
   setWidth(width) {
-    if (width === (width | 0)) {
+    if (Number.isInteger(width)) {
       this.width = width;
     }
   }
@@ -537,7 +537,7 @@ class AnnotationBorderStyle {
    * @param {integer} radius - The horizontal corner radius
    */
   setHorizontalCornerRadius(radius) {
-    if (radius === (radius | 0)) {
+    if (Number.isInteger(radius)) {
       this.horizontalCornerRadius = radius;
     }
   }
@@ -550,7 +550,7 @@ class AnnotationBorderStyle {
    * @param {integer} radius - The vertical corner radius
    */
   setVerticalCornerRadius(radius) {
-    if (radius === (radius | 0)) {
+    if (Number.isInteger(radius)) {
       this.verticalCornerRadius = radius;
     }
   }

--- a/src/core/function.js
+++ b/src/core/function.js
@@ -1032,7 +1032,7 @@ var PostScriptCompiler = (function PostScriptCompilerClosure() {
               return null;
             }
             n = num1.number;
-            if (n < 0 || (n | 0) !== n || stack.length < n) {
+            if (n < 0 || !Number.isInteger(n) || stack.length < n) {
               return null;
             }
             ast1 = stack[stack.length - n - 1];
@@ -1082,7 +1082,8 @@ var PostScriptCompiler = (function PostScriptCompilerClosure() {
             }
             j = num2.number;
             n = num1.number;
-            if (n <= 0 || (n | 0) !== n || (j | 0) !== j || stack.length < n) {
+            if (n <= 0 || !Number.isInteger(n) || !Number.isInteger(j) ||
+                stack.length < n) {
               // ... and integers
               return null;
             }

--- a/src/core/type1_parser.js
+++ b/src/core/type1_parser.js
@@ -324,7 +324,7 @@ var Type1CharString = (function Type1CharStringClosure() {
       var start = stackLength - howManyArgs;
       for (var i = start; i < stackLength; i++) {
         var value = this.stack[i];
-        if (value === (value | 0)) { // int
+        if (Number.isInteger(value)) {
           this.output.push(28, (value >> 8) & 0xff, value & 0xff);
         } else { // fixed point
           value = (65536 * value) | 0;

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -359,7 +359,7 @@ SVGGraphics = (function SVGGraphicsClosure() {
    * @returns {string}
    */
   function pf(value) {
-    if (value === (value | 0)) { // integer number
+    if (Number.isInteger(value)) {
       return value.toString();
     }
     var s = value.toFixed(10);

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -98,7 +98,7 @@ class PDFLinkService {
           });
           return;
         }
-      } else if ((destRef | 0) === destRef) { // Integer
+      } else if (Number.isInteger(destRef)) {
         pageNumber = destRef + 1;
       } else {
         console.error(`PDFLinkService.navigateTo: "${destRef}" is not ` +
@@ -359,9 +359,8 @@ function isValidExplicitDestination(dest) {
   }
   let page = dest[0];
   if (!(typeof page === 'object' &&
-        typeof page.num === 'number' && (page.num | 0) === page.num &&
-        typeof page.gen === 'number' && (page.gen | 0) === page.gen) &&
-      !(typeof page === 'number' && (page | 0) === page && page >= 0)) {
+        Number.isInteger(page.num) && Number.isInteger(page.gen)) &&
+      !(Number.isInteger(page) && page >= 0)) {
     return false;
   }
   let zoom = dest[1];

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -159,7 +159,7 @@ class PDFViewer {
    * @param {number} val - The page number.
    */
   set currentPageNumber(val) {
-    if ((val | 0) !== val) { // Ensure that `val` is an integer.
+    if (!Number.isInteger(val)) {
       throw new Error('Invalid page number.');
     }
     if (!this.pdfDocument) {

--- a/web/preferences.js
+++ b/web/preferences.js
@@ -141,7 +141,7 @@ class BasePreferences {
                           `expected a ${defaultType}.`);
         }
       } else {
-        if (valueType === 'number' && (value | 0) !== value) {
+        if (valueType === 'number' && !Number.isInteger(value)) {
           throw new Error(`Set preference: "${value}" must be an integer.`);
         }
       }


### PR DESCRIPTION
Rather than doing what (at first) may seem like a fairly obscure comparison, using `Number.isInteger` will clearly indicate the intent of the code.