### PR TITLE
Use the `SimpleLinkService` when running "annotations" reference tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1085,22 +1085,22 @@ gulp.task('publish', ['generic'], function (done) {
     });
 });
 
-gulp.task('test', ['generic'], function () {
+gulp.task('test', ['generic', 'components'], function () {
   return streamqueue({ objectMode: true, },
     createTestSource('unit'), createTestSource('browser'));
 });
 
-gulp.task('bottest', ['generic'], function () {
+gulp.task('bottest', ['generic', 'components'], function () {
   return streamqueue({ objectMode: true, },
     createTestSource('unit'), createTestSource('font'),
     createTestSource('browser (no reftest)'));
 });
 
-gulp.task('browsertest', ['generic'], function () {
+gulp.task('browsertest', ['generic', 'components'], function () {
   return createTestSource('browser');
 });
 
-gulp.task('unittest', ['generic'], function () {
+gulp.task('unittest', ['generic', 'components'], function () {
   return createTestSource('unit');
 });
 
@@ -1108,11 +1108,11 @@ gulp.task('fonttest', function () {
   return createTestSource('font');
 });
 
-gulp.task('makeref', ['generic'], function (done) {
+gulp.task('makeref', ['generic', 'components'], function (done) {
   makeRef(done);
 });
 
-gulp.task('botmakeref', ['generic'], function (done) {
+gulp.task('botmakeref', ['generic', 'components'], function (done) {
   makeRef(done, true);
 });
 

--- a/test/driver.js
+++ b/test/driver.js
@@ -24,41 +24,6 @@ var StatTimer = pdfjsDistBuildPdf.StatTimer;
 /**
  * @class
  */
-var LinkServiceMock = (function LinkServiceMockClosure() {
-  function LinkServiceMock() {}
-
-  LinkServiceMock.prototype = {
-    get page() {
-      return 0;
-    },
-
-    set page(value) {},
-
-    navigateTo(dest) {},
-
-    getDestinationHash(dest) {
-      return '#';
-    },
-
-    getAnchorUrl(hash) {
-      return '#';
-    },
-
-    setHash(hash) {},
-
-    executeNamedAction(action) {},
-
-    onFileAttachmentAnnotation(params) {},
-
-    cachePageRef(pageNum, pageRef) {},
-  };
-
-  return LinkServiceMock;
-})();
-
-/**
- * @class
- */
 var rasterizeTextLayer = (function rasterizeTextLayerClosure() {
   var SVG_NS = 'http://www.w3.org/2000/svg';
 
@@ -230,7 +195,7 @@ var rasterizeAnnotationLayer = (function rasterizeAnnotationLayerClosure() {
           div,
           annotations,
           page,
-          linkService: new LinkServiceMock(),
+          linkService: new PDFJS.SimpleLinkService(),
           renderInteractiveForms,
         };
         PDFJS.AnnotationLayer.render(parameters);

--- a/test/test_slave.html
+++ b/test/test_slave.html
@@ -19,6 +19,7 @@ limitations under the License.
     <title>PDF.js test slave</title>
     <meta charset="utf-8">
     <script src="../build/generic/build/pdf.js"></script>
+    <script src="../build/components/pdf_viewer.js"></script>
     <script src="driver.js"></script>
   </head>
   <body>

--- a/web/pdf_viewer.component.js
+++ b/web/pdf_viewer.component.js
@@ -32,6 +32,7 @@ var PDFJS = pdfjsLib.PDFJS;
 PDFJS.PDFViewer = pdfjsWebPDFViewer.PDFViewer;
 PDFJS.PDFPageView = pdfjsWebPDFPageView.PDFPageView;
 PDFJS.PDFLinkService = pdfjsWebPDFLinkService.PDFLinkService;
+PDFJS.SimpleLinkService = pdfjsWebPDFLinkService.SimpleLinkService;
 PDFJS.TextLayerBuilder = pdfjsWebTextLayerBuilder.TextLayerBuilder;
 PDFJS.DefaultTextLayerFactory =
   pdfjsWebTextLayerBuilder.DefaultTextLayerFactory;


### PR DESCRIPTION
Rather than (basically) duplicating the `SimpleLinkService` in `test/driver.js`, with potential test failuires if you forget to update the test mock, it seems much nicer to just re-use the viewer component.

Note that `SimpleLinkService` is already bundled into the `build/components/pdf_viewer.js` file. Hence we only need to expose it similar to the other viewer components in that file, and make sure that the `gulp components` command runs as part of the test-setup.