### PR TITLE
Check `isEvalSupported`, and test that `eval` is actually supported, before attempting to use the `PostScriptCompiler` (issue 5573)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -24,6 +24,7 @@ import { OperatorList, PartialEvaluator } from './evaluator';
 import { AnnotationFactory } from './annotation';
 import { calculateMD5 } from './crypto';
 import { Linearization } from './parser';
+import { PDFFunction } from './function';
 
 var Page = (function PageClosure() {
 
@@ -532,6 +533,9 @@ var PDFDocument = (function PDFDocumentClosure() {
         },
       };
       this.catalog = new Catalog(this.pdfManager, this.xref, pageFactory);
+
+      let evaluatorOptions = this.pdfManager.evaluatorOptions;
+      PDFFunction.setIsEvalSupported(evaluatorOptions.isEvalSupported);
     },
     get numPages() {
       var linearization = this.linearization;

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -54,6 +54,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     disableFontFace: false,
     nativeImageDecoderSupport: NativeImageDecoding.DECODE,
     ignoreErrors: false,
+    isEvalSupported: true,
   };
 
   function NativeImageDecoder(xref, resources, handler, forceDataSchema) {

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -602,6 +602,7 @@ var WorkerMessageHandler = {
         disableFontFace: data.disableFontFace,
         nativeImageDecoderSupport: data.nativeImageDecoderSupport,
         ignoreErrors: data.ignoreErrors,
+        isEvalSupported: data.isEvalSupported,
       };
 
       getPdfManager(data, evaluatorOptions).then(function (newPdfManager) {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -357,6 +357,7 @@ function _fetchDocument(worker, source, pdfDataRangeTransport, docId) {
     docBaseUrl: source.docBaseUrl,
     nativeImageDecoderSupport: source.nativeImageDecoderSupport,
     ignoreErrors: source.ignoreErrors,
+    isEvalSupported: getDefaultSetting('isEvalSupported'),
   }).then(function (workerId) {
     if (worker.destroyed) {
       throw new Error('Worker was destroyed');


### PR DESCRIPTION
Currently `PDFFunction` is implemented (basically) like a class with only `static` methods. Since it's used directly in a number of different `src/core/` files, attempting to pass in `isEvalSupported` would result in code that's *very* messy, not to mention difficult to maintain (since *every* single `PDFFunction` method call would need to include a `isEvalSupported` argument).

Rather than having to wait for a possible re-factoring of `PDFFunction` that would avoid the above problems by design, it probably makes sense to at least set `isEvalSupported` globally for `PDFFunction`.

Please note that there's one caveat with this solution: If `PDFJS.getDocument` is used to open multiple files simultaneously, with *different* `PDFJS.isEvalSupported` values set before each call, then the last one will always win.
However, that seems like enough of an edge-case that we shouldn't have to worry about it. Besides, since we'll also test that `eval` is actually supported, it should be fine.

Fixes #5573.

Supersedes PR #8815 (since that one hasn't seen any activity for weeks, and based on the findings above I'm no longer entirely convinced that it would have been a simple beginner bug).

*Edit:* Slightly smaller diff with https://github.com/mozilla/pdf.js/pull/8909/files?w=1.