### PR TITLE
For /Filter entries containing `Name`s, ignore the /DecodeParms entry if it contains an Array (issue 8895)

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -528,7 +528,8 @@ var Parser = (function ParserClosure() {
       var params = dict.get('DecodeParms', 'DP');
       if (isName(filter)) {
         if (Array.isArray(params)) {
-          params = this.xref.fetchIfRef(params[0]);
+          warn('/DecodeParms should not contain an Array, ' +
+               'when /Filter contains a Name.');
         }
         return this.makeFilter(stream, filter.name, length, params);
       }

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -1748,8 +1748,9 @@ var CCITTFaxStream = (function CCITTFaxStreamClosure() {
     this.str = str;
     this.dict = str.dict;
 
-    params = params || Dict.empty;
-
+    if (!isDict(params)) {
+      params = Dict.empty;
+    }
     this.encoding = params.get('K') || 0;
     this.eoline = params.get('EndOfLine') || false;
     this.byteAlign = params.get('EncodedByteAlign') || false;

--- a/test/pdfs/issue8895.pdf.link
+++ b/test/pdfs/issue8895.pdf.link
@@ -1,0 +1,1 @@
+https://issues.apache.org/jira/secure/attachment/12887373/PDFJS-8895-p1.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -698,6 +698,14 @@
        "link": false,
        "type": "eq"
     },
+    {  "id": "issue8895",
+       "file": "pdfs/issue8895.pdf",
+       "md5": "098658008fc2bf7d433fd0d6d468a9e1",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue5509",
        "file": "pdfs/issue5509.pdf",
        "md5": "1975ef8db7355b1d691bc79d0749574b",


### PR DESCRIPTION
Fixes #8895.