### PR TITLE
Ignore 'change' events that didn't originate in the viewer (issue 8915)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1330,18 +1330,6 @@ let PDFViewerApplication = {
     window.addEventListener('hashchange', _boundEvents.windowHashChange);
     window.addEventListener('beforeprint', _boundEvents.windowBeforePrint);
     window.addEventListener('afterprint', _boundEvents.windowAfterPrint);
-    if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
-      _boundEvents.windowChange = (evt) => {
-        let files = evt.target.files;
-        if (!files || files.length === 0) {
-          return;
-        }
-        eventBus.dispatch('fileinputchange', {
-          fileInput: evt.target,
-        });
-      };
-      window.addEventListener('change', _boundEvents.windowChange);
-    }
   },
 
   unbindEvents() {
@@ -1396,10 +1384,6 @@ let PDFViewerApplication = {
     window.removeEventListener('hashchange', _boundEvents.windowHashChange);
     window.removeEventListener('beforeprint', _boundEvents.windowBeforePrint);
     window.removeEventListener('afterprint', _boundEvents.windowAfterPrint);
-    if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
-      window.removeEventListener('change', _boundEvents.windowChange);
-      _boundEvents.windowChange = null;
-    }
 
     _boundEvents.windowResize = null;
     _boundEvents.windowHashChange = null;
@@ -1492,6 +1476,16 @@ function webViewerInitialized() {
     } else {
       fileInput.value = null;
     }
+
+    fileInput.addEventListener('change', function(evt) {
+      let files = evt.target.files;
+      if (!files || files.length === 0) {
+        return;
+      }
+      PDFViewerApplication.eventBus.dispatch('fileinputchange', {
+        fileInput: evt.target,
+      });
+    });
   } else {
     appConfig.toolbar.openFile.setAttribute('hidden', 'true');
     appConfig.secondaryToolbar.openFileButton.setAttribute('hidden', 'true');
@@ -1859,8 +1853,10 @@ function webViewerPresentationMode() {
   PDFViewerApplication.requestPresentationMode();
 }
 function webViewerOpenFile() {
-  let openFileInputName = PDFViewerApplication.appConfig.openFileInputName;
-  document.getElementById(openFileInputName).click();
+  if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
+    let openFileInputName = PDFViewerApplication.appConfig.openFileInputName;
+    document.getElementById(openFileInputName).click();
+  }
 }
 function webViewerPrint() {
   window.print();


### PR DESCRIPTION
Rather that registering a 'change' event listener on the `window`, which will thus (unnecessarily) fire in *a number* of other situations such as e.g. when the user changes the pageNumber or the current search term, we could/should just register it directly on the dynamically created `fileInput` DOM element instead.
I can see no really compelling reason why we actually need to listen for `file` changes on the `window` itself, and this way we're also able to keep the `fileInput` related code confined to one part of the code which should aid readability.
Furthermore, in custom deployments, there's less risk that we're going to interfere with "outside" code this way.

Finally, preprocessor guards were added to the `webViewerOpenFile` function, since that code doesn't make sense in e.g. the extension builds.

Fixes #8915.