### PR TITLE
support tiff predictor for 16bit

### DIFF
--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -735,6 +735,19 @@ var PredictorStream = (function PredictorStreamClosure() {
         buffer[pos] = buffer[pos - colors] + rawBytes[i];
         pos++;
       }
+    } else if (bits === 16) {
+      var bytesPerPixel = colors * 2;
+      for (i = 0; i < bytesPerPixel; ++i) {
+        buffer[pos++] = rawBytes[i];
+      }
+      for (; i < rowBytes; i += 2) {
+        var sum = ((rawBytes[i] & 0xFF) << 8) +
+                  (rawBytes[i + 1] & 0xFF) +
+                  ((buffer[pos - bytesPerPixel] & 0xFF) << 8) +
+                  (buffer[pos - bytesPerPixel + 1] & 0xFF);
+        buffer[pos++] = ((sum >> 8) & 0xFF);
+        buffer[pos++] = (sum & 0xFF);
+      }
     } else {
       var compArray = new Uint8Array(colors + 1);
       var bitMask = (1 << bits) - 1;

--- a/test/pdfs/issue6289.pdf.link
+++ b/test/pdfs/issue6289.pdf.link
@@ -1,0 +1,1 @@
+https://issues.apache.org/jira/secure/attachment/12685775/GWG181_16Bit_CMYK_X4.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -706,6 +706,14 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue6289",
+       "file": "pdfs/issue6289.pdf",
+       "md5": "0869f3d147c734ec484ffd492104095d",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue5509",
        "file": "pdfs/issue5509.pdf",
        "md5": "1975ef8db7355b1d691bc79d0749574b",


### PR DESCRIPTION
(for issue #6289)
This does the same for 16 bit as the existing 8 bit tiff predictor code, an addition of the last word to this word.

The last two "& 0xFF" may or may not be needed, I see this isn't done in the 8 bit code, but I'm not a JS developer.