### PR TITLE
Re-factor `PDFFunction` to be class-like, and introduce a `classFactory` in `PDFDocument` that lazily creates an instance of `PDFFunction`

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -38,12 +38,12 @@ import {
   getSerifFonts, getStdFontMap, getSymbolsFonts
 } from './standard_fonts';
 import { getTilingPatternIR, Pattern } from './pattern';
-import { isPDFFunction, PDFFunction } from './function';
 import { Lexer, Parser } from './parser';
 import { bidi } from './bidi';
 import { ColorSpace } from './colorspace';
 import { getGlyphsUnicode } from './glyphlist';
 import { getMetrics } from './metrics';
+import { isPDFFunction } from './function';
 import { MurmurHash3_64 } from './murmurhash3';
 import { PDFImage } from './image';
 
@@ -58,22 +58,25 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
   };
 
   function NativeImageDecoder({ xref, resources, handler,
-                                forceDataSchema = false, }) {
+                                forceDataSchema = false, classFactory, }) {
     this.xref = xref;
     this.resources = resources;
     this.handler = handler;
     this.forceDataSchema = forceDataSchema;
+    this.classFactory = classFactory;
   }
   NativeImageDecoder.prototype = {
     canDecode(image) {
       return image instanceof JpegStream &&
-             NativeImageDecoder.isDecodable(image, this.xref, this.resources);
+             NativeImageDecoder.isDecodable(image, this.xref, this.resources,
+                                            this.classFactory);
     },
     decode(image) {
       // For natively supported JPEGs send them to the main thread for decoding.
       var dict = image.dict;
       var colorSpace = dict.get('ColorSpace', 'CS');
-      colorSpace = ColorSpace.parse(colorSpace, this.xref, this.resources);
+      colorSpace = ColorSpace.parse(colorSpace, this.xref, this.resources,
+                                    this.classFactory);
       var numComps = colorSpace.numComps;
       var decodePromise = this.handler.sendWithPromise('JpegDecode',
         [image.getIR(this.forceDataSchema), numComps]);
@@ -87,30 +90,33 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
    * Checks if the image can be decoded and displayed by the browser without any
    * further processing such as color space conversions.
    */
-  NativeImageDecoder.isSupported = function(image, xref, res) {
+  NativeImageDecoder.isSupported = function(image, xref, res, classFactory) {
     var dict = image.dict;
     if (dict.has('DecodeParms') || dict.has('DP')) {
       return false;
     }
-    var cs = ColorSpace.parse(dict.get('ColorSpace', 'CS'), xref, res);
+    var cs = ColorSpace.parse(dict.get('ColorSpace', 'CS'), xref, res,
+                              classFactory);
     return (cs.name === 'DeviceGray' || cs.name === 'DeviceRGB') &&
            cs.isDefaultDecode(dict.getArray('Decode', 'D'));
   };
   /**
    * Checks if the image can be decoded by the browser.
    */
-  NativeImageDecoder.isDecodable = function(image, xref, res) {
+  NativeImageDecoder.isDecodable = function(image, xref, res, classFactory) {
     var dict = image.dict;
     if (dict.has('DecodeParms') || dict.has('DP')) {
       return false;
     }
-    var cs = ColorSpace.parse(dict.get('ColorSpace', 'CS'), xref, res);
+    var cs = ColorSpace.parse(dict.get('ColorSpace', 'CS'), xref, res,
+                              classFactory);
     return (cs.numComps === 1 || cs.numComps === 3) &&
            cs.isDefaultDecode(dict.getArray('Decode', 'D'));
   };
 
   function PartialEvaluator({ pdfManager, xref, handler, pageIndex, idFactory,
-                              fontCache, builtInCMapCache, options = null, }) {
+                              fontCache, builtInCMapCache, options = null,
+                              classFactory, }) {
     this.pdfManager = pdfManager;
     this.xref = xref;
     this.handler = handler;
@@ -119,6 +125,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     this.fontCache = fontCache;
     this.builtInCMapCache = builtInCMapCache;
     this.options = options || DefaultPartialEvaluatorOptions;
+    this.classFactory = classFactory;
 
     this.fetchBuiltInCMap = (name) => {
       var cachedCMap = this.builtInCMapCache[name];
@@ -302,12 +309,14 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         };
 
         var groupSubtype = group.get('S');
-        var colorSpace;
+        var colorSpace = null;
         if (isName(groupSubtype, 'Transparency')) {
           groupOptions.isolated = (group.get('I') || false);
           groupOptions.knockout = (group.get('K') || false);
-          colorSpace = (group.has('CS') ?
-            ColorSpace.parse(group.get('CS'), this.xref, resources) : null);
+          if (group.has('CS')) {
+            colorSpace = ColorSpace.parse(group.get('CS'), this.xref, resources,
+                                          this.classFactory);
+          }
         }
 
         if (smask && smask.backdrop) {
@@ -398,6 +407,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           xref: this.xref,
           res: resources,
           image,
+          classFactory: this.classFactory,
         });
         // We force the use of RGBA_32BPP images here, because we can't handle
         // any other kind.
@@ -415,7 +425,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
       if (nativeImageDecoderSupport !== NativeImageDecoding.NONE &&
           !softMask && !mask && image instanceof JpegStream &&
-          NativeImageDecoder.isSupported(image, this.xref, resources)) {
+          NativeImageDecoder.isSupported(image, this.xref, resources,
+                                         this.classFactory)) {
         // These JPEGs don't need any more processing so we can just send it.
         operatorList.addOp(OPS.paintJpegXObject, args);
         this.handler.send('obj', [objId, this.pageIndex, 'JpegStream',
@@ -439,6 +450,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           resources,
           handler: this.handler,
           forceDataSchema: this.options.forceDataSchema,
+          classFactory: this.classFactory,
         });
       }
 
@@ -448,6 +460,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         res: resources,
         image,
         nativeDecoder: nativeImageDecoder,
+        classFactory: this.classFactory,
       }).then((imageObj) => {
         var imgData = imageObj.createImageData(/* forceRGBA = */ false);
         this.handler.send('obj', [objId, this.pageIndex, 'Image', imgData],
@@ -479,7 +492,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       // we will build a map of integer values in range 0..255 to be fast.
       var transferObj = smask.get('TR');
       if (isPDFFunction(transferObj)) {
-        var transferFn = PDFFunction.parse(this.xref, transferObj);
+        let transferFn =
+          this.classFactory.getPDFFunction().parse(this.xref, transferObj);
         var transferMap = new Uint8Array(256);
         var tmp = new Float32Array(1);
         for (var i = 0; i < 256; i++) {
@@ -865,7 +879,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           var shading = dict.get('Shading');
           var matrix = dict.getArray('Matrix');
           pattern = Pattern.parseShading(shading, matrix, this.xref, resources,
-                                         this.handler);
+                                         this.handler, this.classFactory);
           operatorList.addOp(fn, pattern.getIR());
           return Promise.resolve();
         }
@@ -1040,11 +1054,11 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
             case OPS.setFillColorSpace:
               stateManager.state.fillColorSpace =
-                ColorSpace.parse(args[0], xref, resources);
+                ColorSpace.parse(args[0], xref, resources, self.classFactory);
               continue;
             case OPS.setStrokeColorSpace:
               stateManager.state.strokeColorSpace =
-                ColorSpace.parse(args[0], xref, resources);
+                ColorSpace.parse(args[0], xref, resources, self.classFactory);
               continue;
             case OPS.setFillColor:
               cs = stateManager.state.fillColorSpace;
@@ -1117,7 +1131,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
               }
 
               var shadingFill = Pattern.parseShading(shading, null, xref,
-                resources, self.handler);
+                resources, self.handler, self.classFactory);
               var patternIR = shadingFill.getIR();
               args = [patternIR];
               fn = OPS.shadingFill;

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -75,7 +75,7 @@ var PDFImage = (function PDFImageClosure() {
   }
 
   function PDFImage({ xref, res, image, smask = null, mask = null,
-                      isMask = false, }) {
+                      isMask = false, classFactory, }) {
     this.image = image;
     var dict = image.dict;
     if (dict.has('Filter')) {
@@ -138,7 +138,7 @@ var PDFImage = (function PDFImageClosure() {
                             'color components not supported.');
         }
       }
-      this.colorSpace = ColorSpace.parse(colorSpace, xref, res);
+      this.colorSpace = ColorSpace.parse(colorSpace, xref, res, classFactory);
       this.numComps = this.colorSpace.numComps;
     }
 
@@ -165,6 +165,7 @@ var PDFImage = (function PDFImageClosure() {
         xref,
         res,
         image: smask,
+        classFactory,
       });
     } else if (mask) {
       if (isStream(mask)) {
@@ -177,6 +178,7 @@ var PDFImage = (function PDFImageClosure() {
             res,
             image: mask,
             isMask: true,
+            classFactory,
           });
         }
       } else {
@@ -190,7 +192,7 @@ var PDFImage = (function PDFImageClosure() {
    * with a PDFImage when the image is ready to be used.
    */
   PDFImage.buildImage = function({ handler, xref, res, image,
-                                   nativeDecoder = null, }) {
+                                   nativeDecoder = null, classFactory, }) {
     var imagePromise = handleImageData(image, nativeDecoder);
     var smaskPromise;
     var maskPromise;
@@ -224,13 +226,13 @@ var PDFImage = (function PDFImageClosure() {
           image: imageData,
           smask: smaskData,
           mask: maskData,
+          classFactory,
         });
       });
   };
 
   PDFImage.createMask = function({ imgArray, width, height,
                                    imageIsFromDecodeStream, inverseDecode, }) {
-
     // |imgArray| might not contain full data for every pixel of the mask, so
     // we need to distinguish between |computedLength| and |actualLength|.
     // In particular, if inverseDecode is true, then the array we return must

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -28,9 +28,10 @@ import { CipherTransformFactory } from './crypto';
 import { ColorSpace } from './colorspace';
 
 var Catalog = (function CatalogClosure() {
-  function Catalog(pdfManager, xref, pageFactory) {
+  function Catalog(pdfManager, xref, pageFactory, classFactory) {
     this.pdfManager = pdfManager;
     this.xref = xref;
+    this.classFactory = classFactory;
     this.catDict = xref.getCatalogObj();
     if (!isDict(this.catDict)) {
       throw new FormatError('catalog object is not a dictionary');

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -20,7 +20,6 @@ import {
 } from '../shared/util';
 import { ColorSpace } from './colorspace';
 import { isStream } from './primitives';
-import { PDFFunction } from './function';
 
 var ShadingType = {
   FUNCTION_BASED: 1,
@@ -46,9 +45,8 @@ var Pattern = (function PatternClosure() {
     },
   };
 
-  Pattern.parseShading = function Pattern_parseShading(shading, matrix, xref,
-                                                       res, handler) {
-
+  Pattern.parseShading = function(shading, matrix, xref, res, handler,
+                                  classFactory) {
     var dict = isStream(shading) ? shading.dict : shading;
     var type = dict.get('ShadingType');
 
@@ -57,12 +55,13 @@ var Pattern = (function PatternClosure() {
         case ShadingType.AXIAL:
         case ShadingType.RADIAL:
           // Both radial and axial shadings are handled by RadialAxial shading.
-          return new Shadings.RadialAxial(dict, matrix, xref, res);
+          return new Shadings.RadialAxial(dict, matrix, xref, res,
+                                          classFactory);
         case ShadingType.FREE_FORM_MESH:
         case ShadingType.LATTICE_FORM_MESH:
         case ShadingType.COONS_PATCH_MESH:
         case ShadingType.TENSOR_PATCH_MESH:
-          return new Shadings.Mesh(shading, matrix, xref, res);
+          return new Shadings.Mesh(shading, matrix, xref, res, classFactory);
         default:
           throw new FormatError('Unsupported ShadingType: ' + type);
       }
@@ -88,13 +87,13 @@ Shadings.SMALL_NUMBER = 1e-6;
 // Radial and axial shading have very similar implementations
 // If needed, the implementations can be broken into two classes
 Shadings.RadialAxial = (function RadialAxialClosure() {
-  function RadialAxial(dict, matrix, xref, res) {
+  function RadialAxial(dict, matrix, xref, res, classFactory) {
     this.matrix = matrix;
     this.coordsArr = dict.getArray('Coords');
     this.shadingType = dict.get('ShadingType');
     this.type = 'Pattern';
     var cs = dict.get('ColorSpace', 'CS');
-    cs = ColorSpace.parse(cs, xref, res);
+    cs = ColorSpace.parse(cs, xref, res, classFactory);
     this.cs = cs;
 
     var t0 = 0.0, t1 = 1.0;
@@ -132,7 +131,7 @@ Shadings.RadialAxial = (function RadialAxialClosure() {
     this.extendEnd = extendEnd;
 
     var fnObj = dict.get('Function');
-    var fn = PDFFunction.parseArray(xref, fnObj);
+    var fn = classFactory.getPDFFunction().parseArray(xref, fnObj);
 
     // 10 samples seems good enough for now, but probably won't work
     // if there are sharp color changes. Ideally, we would implement
@@ -711,7 +710,7 @@ Shadings.Mesh = (function MeshClosure() {
     }
   }
 
-  function Mesh(stream, matrix, xref, res) {
+  function Mesh(stream, matrix, xref, res, classFactory) {
     if (!isStream(stream)) {
       throw new FormatError('Mesh data is not a stream');
     }
@@ -721,13 +720,14 @@ Shadings.Mesh = (function MeshClosure() {
     this.type = 'Pattern';
     this.bbox = dict.getArray('BBox');
     var cs = dict.get('ColorSpace', 'CS');
-    cs = ColorSpace.parse(cs, xref, res);
+    cs = ColorSpace.parse(cs, xref, res, classFactory);
     this.cs = cs;
     this.background = dict.has('Background') ?
       cs.getRgb(dict.get('Background'), 0) : null;
 
     var fnObj = dict.get('Function');
-    var fn = fnObj ? PDFFunction.parseArray(xref, fnObj) : null;
+    var fn = fnObj ?
+             classFactory.getPDFFunction().parseArray(xref, fnObj) : null;
 
     this.coords = [];
     this.colors = [];

--- a/test/unit/colorspace_spec.js
+++ b/test/unit/colorspace_spec.js
@@ -16,9 +16,32 @@
 import { Dict, Name, Ref } from '../../src/core/primitives';
 import { Stream, StringStream } from '../../src/core/stream';
 import { ColorSpace } from '../../src/core/colorspace';
+import { PDFFunction } from '../../src/core/function';
 import { XRefMock } from './test_utils';
 
 describe('colorspace', function () {
+  let classFactory;
+
+  beforeAll(function(done) {
+    let pdfFunction = null;
+    classFactory = {
+      getPDFFunction() {
+        if (!pdfFunction) {
+          pdfFunction = new PDFFunction({
+            isEvalSupported: true,
+          });
+        }
+        return pdfFunction;
+      },
+    };
+    done();
+  });
+
+  afterAll(function(done) {
+    classFactory = null;
+    done();
+  });
+
   describe('ColorSpace', function () {
     it('should be true if decode is not an array', function () {
       expect(ColorSpace.isDefaultDecode('string', 0)).toBeTruthy();
@@ -54,7 +77,7 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let colorSpace = ColorSpace.parse(cs, xref, res, classFactory);
 
       let testSrc = new Uint8Array([27, 125, 250, 131]);
       let testDest = new Uint8Array(4 * 4 * 3);
@@ -92,7 +115,7 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let colorSpace = ColorSpace.parse(cs, xref, res, classFactory);
 
       let testSrc = new Uint8Array([27, 125, 250, 131]);
       let testDest = new Uint8Array(3 * 3 * 3);
@@ -126,7 +149,7 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let colorSpace = ColorSpace.parse(cs, xref, res, classFactory);
 
       let testSrc = new Uint8Array([
         27, 125, 250,
@@ -169,7 +192,7 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let colorSpace = ColorSpace.parse(cs, xref, res, classFactory);
 
       let testSrc = new Uint8Array([
         27, 125, 250,
@@ -208,7 +231,7 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let colorSpace = ColorSpace.parse(cs, xref, res, classFactory);
 
       let testSrc = new Uint8Array([
         27, 125, 250, 128,
@@ -251,7 +274,7 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let colorSpace = ColorSpace.parse(cs, xref, res, classFactory);
 
       let testSrc = new Uint8Array([
         27, 125, 250, 128,
@@ -298,7 +321,7 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let colorSpace = ColorSpace.parse(cs, xref, res, classFactory);
 
       let testSrc = new Uint8Array([27, 125, 250, 131]);
       let testDest = new Uint8Array(4 * 4 * 3);
@@ -348,7 +371,7 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let colorSpace = ColorSpace.parse(cs, xref, res, classFactory);
 
       let testSrc = new Uint8Array([
         27, 125, 250,
@@ -395,7 +418,7 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let colorSpace = ColorSpace.parse(cs, xref, res, classFactory);
 
       let testSrc = new Uint8Array([
         27, 25, 50,
@@ -445,7 +468,7 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let colorSpace = ColorSpace.parse(cs, xref, res, classFactory);
 
       let testSrc = new Uint8Array([2, 2, 0, 1]);
       let testDest = new Uint8Array(3 * 3 * 3);
@@ -497,7 +520,7 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let colorSpace = ColorSpace.parse(cs, xref, res, classFactory);
 
       let testSrc = new Uint8Array([27, 25, 50, 31]);
       let testDest = new Uint8Array(3 * 3 * 3);

--- a/test/unit/document_spec.js
+++ b/test/unit/document_spec.js
@@ -18,16 +18,14 @@ import { Page } from '../../src/core/document';
 describe('document', function () {
   describe('Page', function () {
     it('should create correct objId using the idFactory', function () {
-      var page1 = new Page(/* pdfManager = */ { }, /* xref = */ null,
-                           /* pageIndex = */ 0,
-                           /* pageDict = */ null, /* ref = */ null,
-                           /* fontCache = */ null,
-                           /* builtInCMapCache = */ null);
-      var page2 = new Page(/* pdfManager = */ { }, /* xref = */ null,
-                           /* pageIndex = */ 1,
-                           /* pageDict = */ null, /* ref = */ null,
-                           /* fontCache = */ null,
-                           /* builtInCMapCache = */ null);
+      var page1 = new Page({
+        pdfManager: { },
+        pageIndex: 0,
+      });
+      var page2 = new Page({
+        pdfManager: { },
+        pageIndex: 1,
+      });
 
       var idFactory1 = page1.idFactory, idFactory2 = page2.idFactory;
 


### PR DESCRIPTION
*Follow-up to PR https://github.com/mozilla/pdf.js/pull/8909#issuecomment-330251733.*

This requires us to pass around `classFactory` to quite a lot of existing code, however I don't see another way of handling this while still guaranteeing that we can access `PDFFunction` as freely as in the old code.

Please note that the patch passes all tests locally (unit, font, reference), and I *very* much hope that we have sufficient test-coverage for the code in question to catch any typos/mistakes in the re-factoring.

/cc @yurydelendik