### PR TITLE
Remove the `instanceof AlternateCS` check in `ColorSpace.parse` since it's dead code

### DIFF
--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -201,10 +201,7 @@ var ColorSpace = (function ColorSpaceClosure() {
   };
 
   ColorSpace.parse = function ColorSpace_parse(cs, xref, res) {
-    var IR = ColorSpace.parseToIR(cs, xref, res);
-    if (IR instanceof AlternateCS) {
-      return IR;
-    }
+    let IR = ColorSpace.parseToIR(cs, xref, res);
     return ColorSpace.fromIR(IR);
   };
 


### PR DESCRIPTION
Looking at [`ColorSpace.parseToIR`](https://github.com/mozilla/pdf.js/blob/d7b37ae7453220e75714e502268c89a826e989a7/src/core/colorspace.js#L261-L373), it will do one of the following things when called:
 1. Return a String.
 2. Return an Array.
 3. Throw a `FormatError`.
 4. In one case, return the result of *another* `ColorSpace.parseToIR` call.

However, under no circumstances will it ever return an `AlternateCS` instance.

Since it's often useful to understand why code, which has become unused, existed in the first place, let's grab a hard hat and a shovel and start digging through the history of this code :-)

The current condition was introduced in commit https://github.com/mozilla/pdf.js/commit/c198ec432335956ef564fae1a5e9e9c51bfbe53a, in PR #794, but it was actually already obsolete by that time.
The preceeding `instanceof SeparationCS` condition predates commit https://github.com/mozilla/pdf.js/commit/a7278b7fbc029f2fdf92a5bddeb5465cd0a2d124, in PR #700.
That condition was originally introduced all the way back in commit https://github.com/mozilla/pdf.js/commit/4e3f87b60c231061433f5cd07d38120380f97408, in PR #692. However, it was made obsolete by commit https://github.com/mozilla/pdf.js/commit/9dcefe1efcef436f22beef72ef30176e8da619bd, which is included in the very same PR!

Hence we're left with the conclusion that not only has this code be unused for *almost* six years, it was basically never used at all save for a few refactoring commits that're part of PR #692.