### PR TITLE
Ensure that the same exact version of PDF.js is used in both the API and the Worker

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -364,6 +364,15 @@ var WorkerMessageHandler = {
     var cancelXHRs = null;
     var WorkerTasks = [];
 
+    let apiVersion = docParams.apiVersion;
+    let workerVersion =
+      typeof PDFJSDev !== 'undefined' ? PDFJSDev.eval('BUNDLE_VERSION') : null;
+    // The `apiVersion !== null` check is needed to avoid errors during testing.
+    if (apiVersion !== null && apiVersion !== workerVersion) {
+      throw new Error(`The API version "${apiVersion}" does not match ` +
+                      `the Worker version "${workerVersion}".`);
+    }
+
     var docId = docParams.docId;
     var docBaseUrl = docParams.docBaseUrl;
     var workerHandlerName = docParams.docId + '_worker';

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -331,6 +331,8 @@ function _fetchDocument(worker, source, pdfDataRangeTransport, docId) {
   if (worker.destroyed) {
     return Promise.reject(new Error('Worker was destroyed'));
   }
+  let apiVersion =
+    typeof PDFJSDev !== 'undefined' ? PDFJSDev.eval('BUNDLE_VERSION') : null;
 
   source.disableAutoFetch = getDefaultSetting('disableAutoFetch');
   source.disableStream = getDefaultSetting('disableStream');
@@ -341,6 +343,7 @@ function _fetchDocument(worker, source, pdfDataRangeTransport, docId) {
   }
   return worker.messageHandler.sendWithPromise('GetDocRequest', {
     docId,
+    apiVersion,
     source: {
       data: source.data,
       url: source.url,


### PR DESCRIPTION
I don't have a good example at hand right know, but I recall seeing custom deployments of PDF.js that bundle a *specific* version of the `build/pdf.js` file and then set `PDFJS.workerSrc` to point to https://mozilla.github.io/pdf.js/build/pdf.worker.js.
That practice seems really bad since, besides (obviously) causing unnecessary server load, it will very quickly result in a version mismatch between the `pdf.js` and `pdf.worker.js` files in those PDF.js deployments.
Such a version mismatch could easily lead to either breaking errors, or even worse slightly inconsistent behaviour for an API call (if the API -> Worker interface changes, which does happen from time to time).

To avoid the problems described above, I'm thus proposing that we enforce that the versions of the `pdf.js` and `pdf.worker.js` files must always match.