### PR TITLE
Check that `this.baseUrl` is defined before attempting to fetch any data in `DOMCMapReaderFactory`/`NodeCMapReaderFactory`

### DIFF
--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -68,6 +68,10 @@ class DOMCMapReaderFactory {
   }
 
   fetch({ name, }) {
+    if (!this.baseUrl) {
+      return Promise.reject(new Error('CMap baseUrl must be specified, ' +
+        'see "PDFJS.cMapUrl" (and also "PDFJS.cMapPacked").'));
+    }
     if (!name) {
       return Promise.reject(new Error('CMap name must be specified.'));
     }

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -281,8 +281,44 @@ describe('cmap', function() {
       done.fail('No CMap should be loaded');
     }, function (reason) {
       expect(reason instanceof Error).toEqual(true);
-      expect(reason.message).toEqual(
-        'Unable to load CMap at: nullAdobe-Japan1-1');
+      expect(reason.message).toEqual('CMap baseUrl must be specified, ' +
+        'see "PDFJS.cMapUrl" (and also "PDFJS.cMapPacked").');
+      done();
+    });
+  });
+
+  it('attempts to load a built-in CMap with inconsistent API parameters',
+      function(done) {
+    function tmpFetchBuiltInCMap(name) {
+      let CMapReaderFactory;
+      if (isNodeJS()) {
+        CMapReaderFactory = new NodeCMapReaderFactory({
+          baseUrl: cMapUrl.node,
+          isCompressed: false,
+        });
+      } else {
+        CMapReaderFactory = new DOMCMapReaderFactory({
+          baseUrl: cMapUrl.dom,
+          isCompressed: false,
+        });
+      }
+      return CMapReaderFactory.fetch({
+        name,
+      });
+    }
+
+    let cmapPromise = CMapFactory.create({
+      encoding: Name.get('Adobe-Japan1-1'),
+      fetchBuiltInCMap: tmpFetchBuiltInCMap,
+      useCMap: null,
+    });
+    cmapPromise.then(function () {
+      done.fail('No CMap should be loaded');
+    }, function (reason) {
+      expect(reason instanceof Error).toEqual(true);
+      let message = reason.message;
+      expect(message.startsWith('Unable to load CMap at: ')).toEqual(true);
+      expect(message.endsWith('/external/bcmaps/Adobe-Japan1-1')).toEqual(true);
       done();
     });
   });

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -51,6 +51,10 @@ class NodeCMapReaderFactory {
   }
 
   fetch({ name, }) {
+    if (!this.baseUrl) {
+      return Promise.reject(new Error('CMap baseUrl must be specified, ' +
+        'see "PDFJS.cMapUrl" (and also "PDFJS.cMapPacked").'));
+    }
     if (!name) {
       return Promise.reject(new Error('CMap name must be specified.'));
     }


### PR DESCRIPTION
*Excerpt from https://github.com/mozilla/pdf.js/issues/8937#issuecomment-330941932:*

> > And finally, why baseUrl was null in the first place and why the request was not stopped because of it?

> No reason. Adding the null-check before issuing a request or, even better, using "always fails" CMapReaderFactory will be a good addition to the PDF.js core library.

This PR implements the additional validation suggested above, since that seems like a good idea regardless of if/when a specialized factory is added.