### PR TITLE
Split the existing `PDFFunction` in two classes, a private `PDFFunction` and a public `PDFFunctionFactory``, and utilize the latter in `PDFDocument` to allow various code to access the methods of `PDFFunction`

### DIFF
--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -15,7 +15,6 @@
 
 import { FormatError, info, isString, shadow, warn } from '../shared/util';
 import { isDict, isName, isStream } from './primitives';
-import { PDFFunction } from './function';
 
 var ColorSpace = (function ColorSpaceClosure() {
   /**
@@ -200,12 +199,12 @@ var ColorSpace = (function ColorSpaceClosure() {
     usesZeroToOneRange: true,
   };
 
-  ColorSpace.parse = function ColorSpace_parse(cs, xref, res) {
-    let IR = ColorSpace.parseToIR(cs, xref, res);
-    return ColorSpace.fromIR(IR);
+  ColorSpace.parse = function(cs, xref, res, pdfFunctionFactory) {
+    let IR = ColorSpace.parseToIR(cs, xref, res, pdfFunctionFactory);
+    return ColorSpace.fromIR(IR, pdfFunctionFactory);
   };
 
-  ColorSpace.fromIR = function ColorSpace_fromIR(IR) {
+  ColorSpace.fromIR = function(IR, pdfFunctionFactory) {
     var name = Array.isArray(IR) ? IR[0] : IR;
     var whitePoint, blackPoint, gamma;
 
@@ -230,21 +229,23 @@ var ColorSpace = (function ColorSpaceClosure() {
       case 'PatternCS':
         var basePatternCS = IR[1];
         if (basePatternCS) {
-          basePatternCS = ColorSpace.fromIR(basePatternCS);
+          basePatternCS = ColorSpace.fromIR(basePatternCS, pdfFunctionFactory);
         }
         return new PatternCS(basePatternCS);
       case 'IndexedCS':
         var baseIndexedCS = IR[1];
         var hiVal = IR[2];
         var lookup = IR[3];
-        return new IndexedCS(ColorSpace.fromIR(baseIndexedCS), hiVal, lookup);
+        return new IndexedCS(ColorSpace.fromIR(baseIndexedCS,
+                                               pdfFunctionFactory),
+                             hiVal, lookup);
       case 'AlternateCS':
         var numComps = IR[1];
         var alt = IR[2];
         var tintFnIR = IR[3];
-
-        return new AlternateCS(numComps, ColorSpace.fromIR(alt),
-                               PDFFunction.fromIR(tintFnIR));
+        return new AlternateCS(numComps, ColorSpace.fromIR(alt,
+                                                           pdfFunctionFactory),
+                               pdfFunctionFactory.createFromIR(tintFnIR));
       case 'LabCS':
         whitePoint = IR[1];
         blackPoint = IR[2];
@@ -255,7 +256,7 @@ var ColorSpace = (function ColorSpaceClosure() {
     }
   };
 
-  ColorSpace.parseToIR = function ColorSpace_parseToIR(cs, xref, res) {
+  ColorSpace.parseToIR = function(cs, xref, res, pdfFunctionFactory) {
     if (isName(cs)) {
       var colorSpaces = res.get('ColorSpace');
       if (isDict(colorSpaces)) {
@@ -317,10 +318,11 @@ var ColorSpace = (function ColorSpaceClosure() {
           numComps = dict.get('N');
           alt = dict.get('Alternate');
           if (alt) {
-            var altIR = ColorSpace.parseToIR(alt, xref, res);
+            var altIR = ColorSpace.parseToIR(alt, xref, res,
+                                             pdfFunctionFactory);
             // Parse the /Alternate CS to ensure that the number of components
             // are correct, and also (indirectly) that it is not a PatternCS.
-            var altCS = ColorSpace.fromIR(altIR);
+            var altCS = ColorSpace.fromIR(altIR, pdfFunctionFactory);
             if (altCS.numComps === numComps) {
               return altIR;
             }
@@ -337,12 +339,14 @@ var ColorSpace = (function ColorSpaceClosure() {
         case 'Pattern':
           var basePatternCS = cs[1] || null;
           if (basePatternCS) {
-            basePatternCS = ColorSpace.parseToIR(basePatternCS, xref, res);
+            basePatternCS = ColorSpace.parseToIR(basePatternCS, xref, res,
+                                                 pdfFunctionFactory);
           }
           return ['PatternCS', basePatternCS];
         case 'Indexed':
         case 'I':
-          var baseIndexedCS = ColorSpace.parseToIR(cs[1], xref, res);
+          var baseIndexedCS = ColorSpace.parseToIR(cs[1], xref, res,
+                                                   pdfFunctionFactory);
           var hiVal = xref.fetchIfRef(cs[2]) + 1;
           var lookup = xref.fetchIfRef(cs[3]);
           if (isStream(lookup)) {
@@ -353,8 +357,8 @@ var ColorSpace = (function ColorSpaceClosure() {
         case 'DeviceN':
           var name = xref.fetchIfRef(cs[1]);
           numComps = Array.isArray(name) ? name.length : 1;
-          alt = ColorSpace.parseToIR(cs[2], xref, res);
-          var tintFnIR = PDFFunction.getIR(xref, xref.fetchIfRef(cs[3]));
+          alt = ColorSpace.parseToIR(cs[2], xref, res, pdfFunctionFactory);
+          let tintFnIR = pdfFunctionFactory.createIR(xref.fetchIfRef(cs[3]));
           return ['AlternateCS', numComps, alt, tintFnIR];
         case 'Lab':
           params = xref.fetchIfRef(cs[1]);

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -75,7 +75,7 @@ var PDFImage = (function PDFImageClosure() {
   }
 
   function PDFImage({ xref, res, image, smask = null, mask = null,
-                      isMask = false, }) {
+                      isMask = false, pdfFunctionFactory, }) {
     this.image = image;
     var dict = image.dict;
     if (dict.has('Filter')) {
@@ -138,7 +138,8 @@ var PDFImage = (function PDFImageClosure() {
                             'color components not supported.');
         }
       }
-      this.colorSpace = ColorSpace.parse(colorSpace, xref, res);
+      this.colorSpace = ColorSpace.parse(colorSpace, xref, res,
+                                         pdfFunctionFactory);
       this.numComps = this.colorSpace.numComps;
     }
 
@@ -165,6 +166,7 @@ var PDFImage = (function PDFImageClosure() {
         xref,
         res,
         image: smask,
+        pdfFunctionFactory,
       });
     } else if (mask) {
       if (isStream(mask)) {
@@ -177,6 +179,7 @@ var PDFImage = (function PDFImageClosure() {
             res,
             image: mask,
             isMask: true,
+            pdfFunctionFactory,
           });
         }
       } else {
@@ -190,7 +193,8 @@ var PDFImage = (function PDFImageClosure() {
    * with a PDFImage when the image is ready to be used.
    */
   PDFImage.buildImage = function({ handler, xref, res, image,
-                                   nativeDecoder = null, }) {
+                                   nativeDecoder = null,
+                                   pdfFunctionFactory, }) {
     var imagePromise = handleImageData(image, nativeDecoder);
     var smaskPromise;
     var maskPromise;
@@ -224,13 +228,13 @@ var PDFImage = (function PDFImageClosure() {
           image: imageData,
           smask: smaskData,
           mask: maskData,
+          pdfFunctionFactory,
         });
       });
   };
 
   PDFImage.createMask = function({ imgArray, width, height,
                                    imageIsFromDecodeStream, inverseDecode, }) {
-
     // |imgArray| might not contain full data for every pixel of the mask, so
     // we need to distinguish between |computedLength| and |actualLength|.
     // In particular, if inverseDecode is true, then the array we return must

--- a/test/unit/colorspace_spec.js
+++ b/test/unit/colorspace_spec.js
@@ -16,6 +16,7 @@
 import { Dict, Name, Ref } from '../../src/core/primitives';
 import { Stream, StringStream } from '../../src/core/stream';
 import { ColorSpace } from '../../src/core/colorspace';
+import { PDFFunctionFactory } from '../../src/core/function';
 import { XRefMock } from './test_utils';
 
 describe('colorspace', function () {
@@ -54,7 +55,10 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let pdfFunctionFactory = new PDFFunctionFactory({
+        xref,
+      });
+      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
 
       let testSrc = new Uint8Array([27, 125, 250, 131]);
       let testDest = new Uint8Array(4 * 4 * 3);
@@ -92,7 +96,10 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let pdfFunctionFactory = new PDFFunctionFactory({
+        xref,
+      });
+      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
 
       let testSrc = new Uint8Array([27, 125, 250, 131]);
       let testDest = new Uint8Array(3 * 3 * 3);
@@ -126,7 +133,10 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let pdfFunctionFactory = new PDFFunctionFactory({
+        xref,
+      });
+      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
 
       let testSrc = new Uint8Array([
         27, 125, 250,
@@ -169,7 +179,10 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let pdfFunctionFactory = new PDFFunctionFactory({
+        xref,
+      });
+      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
 
       let testSrc = new Uint8Array([
         27, 125, 250,
@@ -208,7 +221,10 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let pdfFunctionFactory = new PDFFunctionFactory({
+        xref,
+      });
+      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
 
       let testSrc = new Uint8Array([
         27, 125, 250, 128,
@@ -251,7 +267,10 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let pdfFunctionFactory = new PDFFunctionFactory({
+        xref,
+      });
+      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
 
       let testSrc = new Uint8Array([
         27, 125, 250, 128,
@@ -298,7 +317,10 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let pdfFunctionFactory = new PDFFunctionFactory({
+        xref,
+      });
+      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
 
       let testSrc = new Uint8Array([27, 125, 250, 131]);
       let testDest = new Uint8Array(4 * 4 * 3);
@@ -348,7 +370,10 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let pdfFunctionFactory = new PDFFunctionFactory({
+        xref,
+      });
+      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
 
       let testSrc = new Uint8Array([
         27, 125, 250,
@@ -395,7 +420,10 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let pdfFunctionFactory = new PDFFunctionFactory({
+        xref,
+      });
+      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
 
       let testSrc = new Uint8Array([
         27, 25, 50,
@@ -445,7 +473,10 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let pdfFunctionFactory = new PDFFunctionFactory({
+        xref,
+      });
+      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
 
       let testSrc = new Uint8Array([2, 2, 0, 1]);
       let testDest = new Uint8Array(3 * 3 * 3);
@@ -497,7 +528,10 @@ describe('colorspace', function () {
       }]);
       let res = new Dict();
 
-      let colorSpace = ColorSpace.parse(cs, xref, res);
+      let pdfFunctionFactory = new PDFFunctionFactory({
+        xref,
+      });
+      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
 
       let testSrc = new Uint8Array([27, 25, 50, 31]);
       let testDest = new Uint8Array(3 * 3 * 3);

--- a/test/unit/document_spec.js
+++ b/test/unit/document_spec.js
@@ -18,16 +18,14 @@ import { Page } from '../../src/core/document';
 describe('document', function () {
   describe('Page', function () {
     it('should create correct objId using the idFactory', function () {
-      var page1 = new Page(/* pdfManager = */ { }, /* xref = */ null,
-                           /* pageIndex = */ 0,
-                           /* pageDict = */ null, /* ref = */ null,
-                           /* fontCache = */ null,
-                           /* builtInCMapCache = */ null);
-      var page2 = new Page(/* pdfManager = */ { }, /* xref = */ null,
-                           /* pageIndex = */ 1,
-                           /* pageDict = */ null, /* ref = */ null,
-                           /* fontCache = */ null,
-                           /* builtInCMapCache = */ null);
+      var page1 = new Page({
+        pdfManager: { },
+        pageIndex: 0,
+      });
+      var page2 = new Page({
+        pdfManager: { },
+        pageIndex: 1,
+      });
 
       var idFactory1 = page1.idFactory, idFactory2 = page2.idFactory;
 


### PR DESCRIPTION
*Follow-up to PR #8909.*

This requires us to pass around `pdfFunctionFactory` to quite a lot of existing code, however I don't see another way of handling this while still guaranteeing that we can access `PDFFunction` as freely as in the old code.

Please note that the patch passes all tests locally (unit, font, reference), and I *very* much hope that we have sufficient test-coverage for the code in question to catch any typos/mistakes in the re-factoring.