### PR TITLE
Split the existing `ColorSpace` in two classes, a private `ColorSpace` and a public `ColorSpaceFactory`, and utilize the latter in `PDFDocument` to allow various code to access the methods of `ColorSpace`

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -19,7 +19,6 @@ import {
 } from '../shared/util';
 import { Catalog, FileSpec, ObjectLoader } from './obj';
 import { Dict, isDict, isName, isRef, isStream } from './primitives';
-import { ColorSpace } from './colorspace';
 import { OperatorList } from './evaluator';
 import { Stream } from './stream';
 
@@ -31,7 +30,7 @@ class AnnotationFactory {
    * @param {Object} idFactory
    * @returns {Annotation}
    */
-  static create(xref, ref, pdfManager, idFactory) {
+  static create(xref, ref, pdfManager, idFactory, colorSpaceFactory) {
     let dict = xref.fetchIfRef(ref);
     if (!isDict(dict)) {
       return;
@@ -50,6 +49,7 @@ class AnnotationFactory {
       subtype,
       id,
       pdfManager,
+      colorSpaceFactory,
     };
 
     switch (subtype) {
@@ -152,6 +152,7 @@ function getTransformMatrix(rect, bbox, matrix) {
 class Annotation {
   constructor(params) {
     let dict = params.dict;
+    this.colorSpaceFactory = params.colorSpaceFactory;
 
     this.setFlags(dict.get('F'));
     this.setRectangle(dict.getArray('Rect'));
@@ -280,17 +281,17 @@ class Annotation {
         break;
 
       case 1: // Convert grayscale to RGB
-        ColorSpace.singletons.gray.getRgbItem(color, 0, rgbColor, 0);
+        this.colorSpaceFactory.gray.getRgbItem(color, 0, rgbColor, 0);
         this.color = rgbColor;
         break;
 
       case 3: // Convert RGB percentages to RGB
-        ColorSpace.singletons.rgb.getRgbItem(color, 0, rgbColor, 0);
+        this.colorSpaceFactory.rgb.getRgbItem(color, 0, rgbColor, 0);
         this.color = rgbColor;
         break;
 
       case 4: // Convert CMYK to RGB
-        ColorSpace.singletons.cmyk.getRgbItem(color, 0, rgbColor, 0);
+        this.colorSpaceFactory.cmyk.getRgbItem(color, 0, rgbColor, 0);
         this.color = rgbColor;
         break;
 

--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -63,19 +63,20 @@ var ColorSpace = (function ColorSpaceClosure() {
      * located in the src array starting from the srcOffset. Returns the array
      * of the rgb components, each value ranging from [0,255].
      */
-    getRgb: function ColorSpace_getRgb(src, srcOffset) {
+    getRgb(src, srcOffset) {
       var rgb = new Uint8Array(3);
       this.getRgbItem(src, srcOffset, rgb, 0);
       return rgb;
     },
+
     /**
      * Converts the color value to the RGB color, similar to the getRgb method.
      * The result placed into the dest array starting from the destOffset.
      */
-    getRgbItem: function ColorSpace_getRgbItem(src, srcOffset,
-                                               dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       throw new Error('Should not call ColorSpace.getRgbItem');
     },
+
     /**
      * Converts the specified number of the color values to the RGB colors.
      * The colors are located in the src array starting from the srcOffset.
@@ -85,34 +86,33 @@ var ColorSpace = (function ColorSpaceClosure() {
      * there are in the dest array; it will be either 0 (RGB array) or 1 (RGBA
      * array).
      */
-    getRgbBuffer: function ColorSpace_getRgbBuffer(src, srcOffset, count,
-                                                   dest, destOffset, bits,
-                                                   alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       throw new Error('Should not call ColorSpace.getRgbBuffer');
     },
+
     /**
      * Determines the number of bytes required to store the result of the
      * conversion done by the getRgbBuffer method. As in getRgbBuffer,
      * |alpha01| is either 0 (RGB output) or 1 (RGBA output).
      */
-    getOutputLength: function ColorSpace_getOutputLength(inputLength,
-                                                         alpha01) {
+    getOutputLength(inputLength, alpha01) {
       throw new Error('Should not call ColorSpace.getOutputLength');
     },
+
     /**
      * Returns true if source data will be equal the result/output data.
      */
-    isPassthrough: function ColorSpace_isPassthrough(bits) {
+    isPassthrough(bits) {
       return false;
     },
+
     /**
      * Fills in the RGB colors in the destination buffer.  alpha01 indicates
      * how many alpha components there are in the dest array; it will be either
      * 0 (RGB array) or 1 (RGBA array).
      */
-    fillRgb: function ColorSpace_fillRgb(dest, originalWidth,
-                                         originalHeight, width, height,
-                                         actualHeight, bpc, comps, alpha01) {
+    fillRgb(dest, originalWidth, originalHeight, width, height, actualHeight,
+            bpc, comps, alpha01) {
       var count = originalWidth * originalHeight;
       var rgbBuf = null;
       var numComponentColors = 1 << bpc;
@@ -122,7 +122,7 @@ var ColorSpace = (function ColorSpaceClosure() {
       if (this.isPassthrough(bpc)) {
         rgbBuf = comps;
       } else if (this.numComps === 1 && count > numComponentColors &&
-          this.name !== 'DeviceGray' && this.name !== 'DeviceRGB') {
+                 this.name !== 'DeviceGray' && this.name !== 'DeviceRGB') {
         // Optimization: create a color map when there is just one component and
         // we are converting more colors than the size of the color map. We
         // don't build the map if the colorspace is gray or rgb since those
@@ -191,6 +191,7 @@ var ColorSpace = (function ColorSpaceClosure() {
         }
       }
     },
+
     /**
      * True if the colorspace has components in the default range of [0, 1].
      * This should be true for all colorspaces except for lab color spaces
@@ -372,6 +373,7 @@ var ColorSpace = (function ColorSpaceClosure() {
     }
     throw new FormatError(`unrecognized color space object: "${cs}"`);
   };
+
   /**
    * Checks if a decode map matches the default decode map for a color space.
    * This handles the general decode maps where there are two values per
@@ -381,7 +383,7 @@ var ColorSpace = (function ColorSpaceClosure() {
    * @param {Array} decode Decode map (usually from an image).
    * @param {Number} n Number of components the color space has.
    */
-  ColorSpace.isDefaultDecode = function ColorSpace_isDefaultDecode(decode, n) {
+  ColorSpace.isDefaultDecode = function(decode, n) {
     if (!Array.isArray(decode)) {
       return true;
     }
@@ -434,15 +436,12 @@ var AlternateCS = (function AlternateCSClosure() {
 
   AlternateCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function AlternateCS_getRgbItem(src, srcOffset,
-                                                dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       var tmpBuf = this.tmpBuf;
       this.tintFn(src, srcOffset, tmpBuf, 0);
       this.base.getRgbItem(tmpBuf, 0, dest, destOffset);
     },
-    getRgbBuffer: function AlternateCS_getRgbBuffer(src, srcOffset, count,
-                                                    dest, destOffset, bits,
-                                                    alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       var tintFn = this.tintFn;
       var base = this.base;
       var scale = 1 / ((1 << bits) - 1);
@@ -477,15 +476,14 @@ var AlternateCS = (function AlternateCSClosure() {
         base.getRgbBuffer(baseBuf, 0, count, dest, destOffset, 8, alpha01);
       }
     },
-    getOutputLength: function AlternateCS_getOutputLength(inputLength,
-                                                          alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return this.base.getOutputLength(inputLength *
                                        this.base.numComps / this.numComps,
                                        alpha01);
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function AlternateCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     },
     usesZeroToOneRange: true,
@@ -533,15 +531,12 @@ var IndexedCS = (function IndexedCSClosure() {
 
   IndexedCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function IndexedCS_getRgbItem(src, srcOffset,
-                                              dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       var numComps = this.base.numComps;
       var start = src[srcOffset] * numComps;
       this.base.getRgbBuffer(this.lookup, start, 1, dest, destOffset, 8, 0);
     },
-    getRgbBuffer: function IndexedCS_getRgbBuffer(src, srcOffset, count,
-                                                  dest, destOffset, bits,
-                                                  alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       var base = this.base;
       var numComps = base.numComps;
       var outputDelta = base.getOutputLength(numComps, alpha01);
@@ -553,13 +548,13 @@ var IndexedCS = (function IndexedCSClosure() {
         destOffset += outputDelta;
       }
     },
-    getOutputLength: function IndexedCS_getOutputLength(inputLength, alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return this.base.getOutputLength(inputLength * this.base.numComps,
                                        alpha01);
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function IndexedCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       // indexed color maps shouldn't be changed
       return true;
     },
@@ -577,15 +572,12 @@ var DeviceGrayCS = (function DeviceGrayCSClosure() {
 
   DeviceGrayCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function DeviceGrayCS_getRgbItem(src, srcOffset,
-                                                 dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       var c = (src[srcOffset] * 255) | 0;
       c = c < 0 ? 0 : c > 255 ? 255 : c;
       dest[destOffset] = dest[destOffset + 1] = dest[destOffset + 2] = c;
     },
-    getRgbBuffer: function DeviceGrayCS_getRgbBuffer(src, srcOffset, count,
-                                                     dest, destOffset, bits,
-                                                     alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       var scale = 255 / ((1 << bits) - 1);
       var j = srcOffset, q = destOffset;
       for (var i = 0; i < count; ++i) {
@@ -596,13 +588,12 @@ var DeviceGrayCS = (function DeviceGrayCSClosure() {
         q += alpha01;
       }
     },
-    getOutputLength: function DeviceGrayCS_getOutputLength(inputLength,
-                                                           alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return inputLength * (3 + alpha01);
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function DeviceGrayCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     },
     usesZeroToOneRange: true,
@@ -618,8 +609,7 @@ var DeviceRgbCS = (function DeviceRgbCSClosure() {
   }
   DeviceRgbCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function DeviceRgbCS_getRgbItem(src, srcOffset,
-                                                dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       var r = (src[srcOffset] * 255) | 0;
       var g = (src[srcOffset + 1] * 255) | 0;
       var b = (src[srcOffset + 2] * 255) | 0;
@@ -627,9 +617,7 @@ var DeviceRgbCS = (function DeviceRgbCSClosure() {
       dest[destOffset + 1] = g < 0 ? 0 : g > 255 ? 255 : g;
       dest[destOffset + 2] = b < 0 ? 0 : b > 255 ? 255 : b;
     },
-    getRgbBuffer: function DeviceRgbCS_getRgbBuffer(src, srcOffset, count,
-                                                    dest, destOffset, bits,
-                                                    alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       if (bits === 8 && alpha01 === 0) {
         dest.set(src.subarray(srcOffset, srcOffset + count * 3), destOffset);
         return;
@@ -643,15 +631,14 @@ var DeviceRgbCS = (function DeviceRgbCSClosure() {
         q += alpha01;
       }
     },
-    getOutputLength: function DeviceRgbCS_getOutputLength(inputLength,
-                                                          alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return (inputLength * (3 + alpha01) / 3) | 0;
     },
-    isPassthrough: function DeviceRgbCS_isPassthrough(bits) {
+    isPassthrough(bits) {
       return bits === 8;
     },
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function DeviceRgbCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     },
     usesZeroToOneRange: true,
@@ -713,13 +700,10 @@ var DeviceCmykCS = (function DeviceCmykCSClosure() {
   }
   DeviceCmykCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function DeviceCmykCS_getRgbItem(src, srcOffset,
-                                                 dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       convertToRgb(src, srcOffset, 1, dest, destOffset);
     },
-    getRgbBuffer: function DeviceCmykCS_getRgbBuffer(src, srcOffset, count,
-                                                     dest, destOffset, bits,
-                                                     alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       var scale = 1 / ((1 << bits) - 1);
       for (var i = 0; i < count; i++) {
         convertToRgb(src, srcOffset, scale, dest, destOffset);
@@ -727,13 +711,12 @@ var DeviceCmykCS = (function DeviceCmykCSClosure() {
         destOffset += 3 + alpha01;
       }
     },
-    getOutputLength: function DeviceCmykCS_getOutputLength(inputLength,
-                                                           alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return (inputLength / 4 * (3 + alpha01)) | 0;
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function DeviceCmykCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     },
     usesZeroToOneRange: true,
@@ -742,9 +725,9 @@ var DeviceCmykCS = (function DeviceCmykCSClosure() {
   return DeviceCmykCS;
 })();
 
-//
-// CalGrayCS: Based on "PDF Reference, Sixth Ed", p.245
-//
+/**
+ * CalGrayCS: Based on "PDF Reference, Sixth Ed", p.245
+ */
 var CalGrayCS = (function CalGrayCSClosure() {
   function CalGrayCS(whitePoint, blackPoint, gamma) {
     this.name = 'CalGray';
@@ -811,13 +794,10 @@ var CalGrayCS = (function CalGrayCSClosure() {
 
   CalGrayCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function CalGrayCS_getRgbItem(src, srcOffset,
-                                              dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       convertToRgb(this, src, srcOffset, dest, destOffset, 1);
     },
-    getRgbBuffer: function CalGrayCS_getRgbBuffer(src, srcOffset, count,
-                                                  dest, destOffset, bits,
-                                                  alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       var scale = 1 / ((1 << bits) - 1);
 
       for (var i = 0; i < count; ++i) {
@@ -826,12 +806,12 @@ var CalGrayCS = (function CalGrayCSClosure() {
         destOffset += 3 + alpha01;
       }
     },
-    getOutputLength: function CalGrayCS_getOutputLength(inputLength, alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return inputLength * (3 + alpha01);
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function CalGrayCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     },
     usesZeroToOneRange: true,
@@ -839,11 +819,10 @@ var CalGrayCS = (function CalGrayCSClosure() {
   return CalGrayCS;
 })();
 
-//
-// CalRGBCS: Based on "PDF Reference, Sixth Ed", p.247
-//
+/**
+ * CalRGBCS: Based on "PDF Reference, Sixth Ed", p.247
+ */
 var CalRGBCS = (function CalRGBCSClosure() {
-
   // See http://www.brucelindbloom.com/index.html?Eqn_ChromAdapt.html for these
   // matrices.
   var BRADFORD_SCALE_MATRIX = new Float32Array([
@@ -987,7 +966,6 @@ var CalRGBCS = (function CalRGBCSClosure() {
   }
 
   function compensateBlackPoint(sourceBlackPoint, XYZ_Flat, result) {
-
     // In case the blackPoint is already the default blackPoint then there is
     // no need to do compensation.
     if (sourceBlackPoint[0] === 0 &&
@@ -1029,7 +1007,6 @@ var CalRGBCS = (function CalRGBCSClosure() {
   }
 
   function normalizeWhitePointToFlat(sourceWhitePoint, XYZ_In, result) {
-
     // In case the whitePoint is already flat then there is no need to do
     // normalization.
     if (sourceWhitePoint[0] === 1 && sourceWhitePoint[2] === 1) {
@@ -1049,7 +1026,6 @@ var CalRGBCS = (function CalRGBCSClosure() {
   }
 
   function normalizeWhitePointToD65(sourceWhitePoint, XYZ_In, result) {
-
     var LMS = result;
     matrixProduct(BRADFORD_SCALE_MATRIX, XYZ_In, LMS);
 
@@ -1111,13 +1087,10 @@ var CalRGBCS = (function CalRGBCSClosure() {
 
   CalRGBCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function CalRGBCS_getRgbItem(src, srcOffset,
-                                             dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       convertToRgb(this, src, srcOffset, dest, destOffset, 1);
     },
-    getRgbBuffer: function CalRGBCS_getRgbBuffer(src, srcOffset, count,
-                                                 dest, destOffset, bits,
-                                                 alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       var scale = 1 / ((1 << bits) - 1);
 
       for (var i = 0; i < count; ++i) {
@@ -1126,12 +1099,12 @@ var CalRGBCS = (function CalRGBCSClosure() {
         destOffset += 3 + alpha01;
       }
     },
-    getOutputLength: function CalRGBCS_getOutputLength(inputLength, alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return (inputLength * (3 + alpha01) / 3) | 0;
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function CalRGBCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     },
     usesZeroToOneRange: true,
@@ -1139,9 +1112,9 @@ var CalRGBCS = (function CalRGBCSClosure() {
   return CalRGBCS;
 })();
 
-//
-// LabCS: Based on "PDF Reference, Sixth Ed", p.250
-//
+/**
+ * LabCS: Based on "PDF Reference, Sixth Ed", p.250
+ */
 var LabCS = (function LabCSClosure() {
   function LabCS(whitePoint, blackPoint, range) {
     this.name = 'Lab';
@@ -1257,12 +1230,10 @@ var LabCS = (function LabCSClosure() {
 
   LabCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function LabCS_getRgbItem(src, srcOffset, dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       convertToRgb(this, src, srcOffset, false, dest, destOffset);
     },
-    getRgbBuffer: function LabCS_getRgbBuffer(src, srcOffset, count,
-                                              dest, destOffset, bits,
-                                              alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       var maxVal = (1 << bits) - 1;
       for (var i = 0; i < count; i++) {
         convertToRgb(this, src, srcOffset, maxVal, dest, destOffset);
@@ -1270,12 +1241,12 @@ var LabCS = (function LabCSClosure() {
         destOffset += 3 + alpha01;
       }
     },
-    getOutputLength: function LabCS_getOutputLength(inputLength, alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return (inputLength * (3 + alpha01) / 3) | 0;
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function LabCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       // XXX: Decoding is handled with the lab conversion because of the strange
       // ranges that are used.
       return true;

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -56,9 +56,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     isEvalSupported: true,
   };
 
-  function NativeImageDecoder({ xref, resources, handler,
+  function NativeImageDecoder({ resources, handler,
                                 forceDataSchema = false, colorSpaceFactory, }) {
-    this.xref = xref;
     this.resources = resources;
     this.handler = handler;
     this.forceDataSchema = forceDataSchema;
@@ -67,7 +66,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
   NativeImageDecoder.prototype = {
     canDecode(image) {
       return image instanceof JpegStream &&
-             NativeImageDecoder.isDecodable(image, this.xref, this.resources,
+             NativeImageDecoder.isDecodable(image, this.resources,
                                             this.colorSpaceFactory);
     },
     decode(image) {
@@ -88,8 +87,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
    * Checks if the image can be decoded and displayed by the browser without any
    * further processing such as color space conversions.
    */
-  NativeImageDecoder.isSupported = function(image, xref, res,
-                                            colorSpaceFactory) {
+  NativeImageDecoder.isSupported = function(image, res, colorSpaceFactory) {
     var dict = image.dict;
     if (dict.has('DecodeParms') || dict.has('DP')) {
       return false;
@@ -102,8 +100,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
   /**
    * Checks if the image can be decoded by the browser.
    */
-  NativeImageDecoder.isDecodable = function(image, xref, res,
-                                            colorSpaceFactory) {
+  NativeImageDecoder.isDecodable = function(image, res, colorSpaceFactory) {
     var dict = image.dict;
     if (dict.has('DecodeParms') || dict.has('DP')) {
       return false;
@@ -405,7 +402,6 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       if (inline && !softMask && !mask && !(image instanceof JpegStream) &&
           (w + h) < SMALL_IMAGE_DIMENSIONS) {
         let imageObj = new PDFImage({
-          xref: this.xref,
           res: resources,
           image,
           colorSpaceFactory: this.colorSpaceFactory,
@@ -426,7 +422,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
       if (nativeImageDecoderSupport !== NativeImageDecoding.NONE &&
           !softMask && !mask && image instanceof JpegStream &&
-          NativeImageDecoder.isSupported(image, this.xref, resources,
+          NativeImageDecoder.isSupported(image, resources,
                                          this.colorSpaceFactory)) {
         // These JPEGs don't need any more processing so we can just send it.
         operatorList.addOp(OPS.paintJpegXObject, args);
@@ -447,7 +443,6 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           (image instanceof JpegStream || mask instanceof JpegStream ||
            softMask instanceof JpegStream)) {
         nativeImageDecoder = new NativeImageDecoder({
-          xref: this.xref,
           resources,
           handler: this.handler,
           forceDataSchema: this.options.forceDataSchema,
@@ -457,7 +452,6 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
       PDFImage.buildImage({
         handler: this.handler,
-        xref: this.xref,
         res: resources,
         image,
         nativeDecoder: nativeImageDecoder,
@@ -885,7 +879,6 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           pattern = Pattern.parseShading({
             shading,
             matrix,
-            xref: this.xref,
             res: resources,
             handler: this.handler,
             pdfFunctionFactory: this.pdfFunctionFactory,
@@ -1156,8 +1149,6 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
               var shadingFill = Pattern.parseShading({
                 shading,
-                matrix: null,
-                xref,
                 res: resources,
                 handler: self.handler,
                 pdfFunctionFactory: self.pdfFunctionFactory,

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -527,9 +527,13 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         operatorList: tilingOpList,
       }).then(function() {
         return getTilingPatternIR({
-          fnArray: tilingOpList.fnArray,
-          argsArray: tilingOpList.argsArray,
-        }, patternDict, args);
+          operatorList: {
+            fnArray: tilingOpList.fnArray,
+            argsArray: tilingOpList.argsArray,
+          },
+          dict: patternDict,
+          args,
+        });
       }).then(function(tilingPatternIR) {
         // Add the dependencies to the parent operator list so they are
         // resolved before the sub operator list is executed synchronously.
@@ -880,8 +884,14 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         } else if (typeNum === SHADING_PATTERN) {
           var shading = dict.get('Shading');
           var matrix = dict.getArray('Matrix');
-          pattern = Pattern.parseShading(shading, matrix, this.xref, resources,
-                                         this.handler, this.pdfFunctionFactory);
+          pattern = Pattern.parseShading({
+            shading,
+            matrix,
+            xref: this.xref,
+            res: resources,
+            handler: this.handler,
+            pdfFunctionFactory: this.pdfFunctionFactory,
+          });
           operatorList.addOp(fn, pattern.getIR());
           return Promise.resolve();
         }
@@ -1147,8 +1157,14 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
                 throw new FormatError('No shading object found');
               }
 
-              var shadingFill = Pattern.parseShading(shading, null, xref,
-                resources, self.handler, self.pdfFunctionFactory);
+              var shadingFill = Pattern.parseShading({
+                shading,
+                matrix: null,
+                xref,
+                res: resources,
+                handler: self.handler,
+                pdfFunctionFactory: self.pdfFunctionFactory,
+              });
               var patternIR = shadingFill.getIR();
               args = [patternIR];
               fn = OPS.shadingFill;

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -73,8 +73,8 @@ var PDFImage = (function PDFImageClosure() {
     return dest;
   }
 
-  function PDFImage({ xref, res, image, smask = null, mask = null,
-                      isMask = false, colorSpaceFactory, }) {
+  function PDFImage({ res, image, smask = null, mask = null, isMask = false,
+                      colorSpaceFactory, }) {
     this.image = image;
     var dict = image.dict;
     if (dict.has('Filter')) {
@@ -161,7 +161,6 @@ var PDFImage = (function PDFImageClosure() {
 
     if (smask) {
       this.smask = new PDFImage({
-        xref,
         res,
         image: smask,
         colorSpaceFactory,
@@ -173,7 +172,6 @@ var PDFImage = (function PDFImageClosure() {
           warn('Ignoring /Mask in image without /ImageMask.');
         } else {
           this.mask = new PDFImage({
-            xref,
             res,
             image: mask,
             isMask: true,
@@ -190,8 +188,8 @@ var PDFImage = (function PDFImageClosure() {
    * Handles processing of image data and returns the Promise that is resolved
    * with a PDFImage when the image is ready to be used.
    */
-  PDFImage.buildImage = function({ handler, xref, res, image,
-                                   nativeDecoder = null, colorSpaceFactory, }) {
+  PDFImage.buildImage = function({ handler, res, image, nativeDecoder = null,
+                                   colorSpaceFactory, }) {
     var imagePromise = handleImageData(image, nativeDecoder);
     var smaskPromise;
     var maskPromise;
@@ -220,7 +218,6 @@ var PDFImage = (function PDFImageClosure() {
     return Promise.all([imagePromise, smaskPromise, maskPromise]).then(
       function([imageData, smaskData, maskData]) {
         return new PDFImage({
-          xref,
           res,
           image: imageData,
           smask: smaskData,

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -25,12 +25,12 @@ import {
 import { Lexer, Parser } from './parser';
 import { ChunkedStream } from './chunked_stream';
 import { CipherTransformFactory } from './crypto';
-import { ColorSpace } from './colorspace';
 
 var Catalog = (function CatalogClosure() {
-  function Catalog(pdfManager, xref, pageFactory) {
+  function Catalog({ pdfManager, xref, pageFactory, colorSpaceFactory, }) {
     this.pdfManager = pdfManager;
     this.xref = xref;
+    this.colorSpaceFactory = colorSpaceFactory;
     this.catDict = xref.getCatalogObj();
     if (!isDict(this.catDict)) {
       throw new FormatError('catalog object is not a dictionary');
@@ -138,7 +138,7 @@ var Catalog = (function CatalogClosure() {
         // We only need to parse the color when it's valid, and non-default.
         if (Array.isArray(color) && color.length === 3 &&
             (color[0] !== 0 || color[1] !== 0 || color[2] !== 0)) {
-          rgbColor = ColorSpace.singletons.rgb.getRgb(color, 0);
+          rgbColor = this.colorSpaceFactory.rgb.getRgb(color, 0);
         }
         var outlineItem = {
           dest: data.dest,

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -45,8 +45,8 @@ var Pattern = (function PatternClosure() {
     },
   };
 
-  Pattern.parseShading = function(shading, matrix, xref, res, handler,
-                                  pdfFunctionFactory) {
+  Pattern.parseShading = function({ shading, matrix, xref, res, handler,
+                                    pdfFunctionFactory, }) {
     var dict = isStream(shading) ? shading.dict : shading;
     var type = dict.get('ShadingType');
 
@@ -55,14 +55,14 @@ var Pattern = (function PatternClosure() {
         case ShadingType.AXIAL:
         case ShadingType.RADIAL:
           // Both radial and axial shadings are handled by RadialAxial shading.
-          return new Shadings.RadialAxial(dict, matrix, xref, res,
-                                          pdfFunctionFactory);
+          return new Shadings.RadialAxial({ dict, matrix, xref, res,
+                                            pdfFunctionFactory, });
         case ShadingType.FREE_FORM_MESH:
         case ShadingType.LATTICE_FORM_MESH:
         case ShadingType.COONS_PATCH_MESH:
         case ShadingType.TENSOR_PATCH_MESH:
-          return new Shadings.Mesh(shading, matrix, xref, res,
-                                   pdfFunctionFactory);
+          return new Shadings.Mesh({ shading, matrix, xref, res,
+                                     pdfFunctionFactory, });
         default:
           throw new FormatError('Unsupported ShadingType: ' + type);
       }
@@ -88,7 +88,7 @@ Shadings.SMALL_NUMBER = 1e-6;
 // Radial and axial shading have very similar implementations
 // If needed, the implementations can be broken into two classes
 Shadings.RadialAxial = (function RadialAxialClosure() {
-  function RadialAxial(dict, matrix, xref, res, pdfFunctionFactory) {
+  function RadialAxial({ dict, matrix, xref, res, pdfFunctionFactory, }) {
     this.matrix = matrix;
     this.coordsArr = dict.getArray('Coords');
     this.shadingType = dict.get('ShadingType');
@@ -711,11 +711,11 @@ Shadings.Mesh = (function MeshClosure() {
     }
   }
 
-  function Mesh(stream, matrix, xref, res, pdfFunctionFactory) {
-    if (!isStream(stream)) {
+  function Mesh({ shading, matrix, xref, res, pdfFunctionFactory, }) {
+    if (!isStream(shading)) {
       throw new FormatError('Mesh data is not a stream');
     }
-    var dict = stream.dict;
+    var dict = shading.dict;
     this.matrix = matrix;
     this.shadingType = dict.get('ShadingType');
     this.type = 'Pattern';
@@ -742,7 +742,7 @@ Shadings.Mesh = (function MeshClosure() {
       colorSpace: cs,
       numComps: fn ? 1 : cs.numComps,
     };
-    var reader = new MeshStreamReader(stream, decodeContext);
+    var reader = new MeshStreamReader(shading, decodeContext);
 
     var patchMesh = false;
     switch (this.shadingType) {
@@ -805,7 +805,7 @@ Shadings.Dummy = (function DummyClosure() {
   return Dummy;
 })();
 
-function getTilingPatternIR(operatorList, dict, args) {
+function getTilingPatternIR({ operatorList, dict, args, }) {
   let matrix = dict.getArray('Matrix');
   let bbox = Util.normalizeRect(dict.getArray('BBox'));
   let xstep = dict.get('XStep');

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -18,7 +18,6 @@ import {
   assert, FormatError, info, MissingDataException, unreachable,
   UNSUPPORTED_FEATURES, Util, warn
 } from '../shared/util';
-import { ColorSpace } from './colorspace';
 import { isStream } from './primitives';
 
 var ShadingType = {
@@ -46,7 +45,7 @@ var Pattern = (function PatternClosure() {
   };
 
   Pattern.parseShading = function({ shading, matrix, xref, res, handler,
-                                    pdfFunctionFactory, }) {
+                                    pdfFunctionFactory, colorSpaceFactory, }) {
     var dict = isStream(shading) ? shading.dict : shading;
     var type = dict.get('ShadingType');
 
@@ -56,13 +55,14 @@ var Pattern = (function PatternClosure() {
         case ShadingType.RADIAL:
           // Both radial and axial shadings are handled by RadialAxial shading.
           return new Shadings.RadialAxial({ dict, matrix, xref, res,
-                                            pdfFunctionFactory, });
+                                            pdfFunctionFactory,
+                                            colorSpaceFactory, });
         case ShadingType.FREE_FORM_MESH:
         case ShadingType.LATTICE_FORM_MESH:
         case ShadingType.COONS_PATCH_MESH:
         case ShadingType.TENSOR_PATCH_MESH:
           return new Shadings.Mesh({ shading, matrix, xref, res,
-                                     pdfFunctionFactory, });
+                                     pdfFunctionFactory, colorSpaceFactory, });
         default:
           throw new FormatError('Unsupported ShadingType: ' + type);
       }
@@ -88,13 +88,14 @@ Shadings.SMALL_NUMBER = 1e-6;
 // Radial and axial shading have very similar implementations
 // If needed, the implementations can be broken into two classes
 Shadings.RadialAxial = (function RadialAxialClosure() {
-  function RadialAxial({ dict, matrix, xref, res, pdfFunctionFactory, }) {
+  function RadialAxial({ dict, matrix, xref, res, pdfFunctionFactory,
+                         colorSpaceFactory, }) {
     this.matrix = matrix;
     this.coordsArr = dict.getArray('Coords');
     this.shadingType = dict.get('ShadingType');
     this.type = 'Pattern';
-    var cs = dict.get('ColorSpace', 'CS');
-    cs = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+    let cs = colorSpaceFactory.create({ cs: dict.get('ColorSpace', 'CS'),
+                                        res, });
     this.cs = cs;
 
     var t0 = 0.0, t1 = 1.0;
@@ -711,7 +712,8 @@ Shadings.Mesh = (function MeshClosure() {
     }
   }
 
-  function Mesh({ shading, matrix, xref, res, pdfFunctionFactory, }) {
+  function Mesh({ shading, matrix, xref, res, pdfFunctionFactory,
+                  colorSpaceFactory, }) {
     if (!isStream(shading)) {
       throw new FormatError('Mesh data is not a stream');
     }
@@ -720,8 +722,8 @@ Shadings.Mesh = (function MeshClosure() {
     this.shadingType = dict.get('ShadingType');
     this.type = 'Pattern';
     this.bbox = dict.getArray('BBox');
-    var cs = dict.get('ColorSpace', 'CS');
-    cs = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+    let cs = colorSpaceFactory.create({ cs: dict.get('ColorSpace', 'CS'),
+                                        res, });
     this.cs = cs;
     this.background = dict.has('Background') ?
       cs.getRgb(dict.get('Background'), 0) : null;

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -44,7 +44,7 @@ var Pattern = (function PatternClosure() {
     },
   };
 
-  Pattern.parseShading = function({ shading, matrix, xref, res, handler,
+  Pattern.parseShading = function({ shading, matrix = null, res, handler,
                                     pdfFunctionFactory, colorSpaceFactory, }) {
     var dict = isStream(shading) ? shading.dict : shading;
     var type = dict.get('ShadingType');
@@ -54,14 +54,14 @@ var Pattern = (function PatternClosure() {
         case ShadingType.AXIAL:
         case ShadingType.RADIAL:
           // Both radial and axial shadings are handled by RadialAxial shading.
-          return new Shadings.RadialAxial({ dict, matrix, xref, res,
+          return new Shadings.RadialAxial({ dict, matrix, res,
                                             pdfFunctionFactory,
                                             colorSpaceFactory, });
         case ShadingType.FREE_FORM_MESH:
         case ShadingType.LATTICE_FORM_MESH:
         case ShadingType.COONS_PATCH_MESH:
         case ShadingType.TENSOR_PATCH_MESH:
-          return new Shadings.Mesh({ shading, matrix, xref, res,
+          return new Shadings.Mesh({ shading, matrix, res,
                                      pdfFunctionFactory, colorSpaceFactory, });
         default:
           throw new FormatError('Unsupported ShadingType: ' + type);
@@ -88,7 +88,7 @@ Shadings.SMALL_NUMBER = 1e-6;
 // Radial and axial shading have very similar implementations
 // If needed, the implementations can be broken into two classes
 Shadings.RadialAxial = (function RadialAxialClosure() {
-  function RadialAxial({ dict, matrix, xref, res, pdfFunctionFactory,
+  function RadialAxial({ dict, matrix, res, pdfFunctionFactory,
                          colorSpaceFactory, }) {
     this.matrix = matrix;
     this.coordsArr = dict.getArray('Coords');
@@ -712,7 +712,7 @@ Shadings.Mesh = (function MeshClosure() {
     }
   }
 
-  function Mesh({ shading, matrix, xref, res, pdfFunctionFactory,
+  function Mesh({ shading, matrix, res, pdfFunctionFactory,
                   colorSpaceFactory, }) {
     if (!isStream(shading)) {
       throw new FormatError('Mesh data is not a stream');

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -22,6 +22,8 @@ import {
 } from '../../src/shared/util';
 import { Dict, Name, Ref } from '../../src/core/primitives';
 import { Lexer, Parser } from '../../src/core/parser';
+import { ColorSpaceFactory } from '../../src/core/colorspace';
+import { PDFFunctionFactory } from '../../src/core/function';
 import { StringStream } from '../../src/core/stream';
 import { XRefMock } from './test_utils';
 
@@ -44,19 +46,29 @@ describe('annotation', function() {
   }
   IdFactoryMock.prototype = {};
 
-  var pdfManagerMock, idFactoryMock;
+  var pdfManagerMock, idFactoryMock, colorSpaceFactory;
 
   beforeAll(function (done) {
     pdfManagerMock = new PDFManagerMock({
       docBaseUrl: null,
     });
     idFactoryMock = new IdFactoryMock({ });
+
+    let xref = new XRefMock();
+    let pdfFunctionFactory = new PDFFunctionFactory({
+      xref,
+    });
+    colorSpaceFactory = new ColorSpaceFactory({
+      xref,
+      pdfFunctionFactory,
+    });
     done();
   });
 
   afterAll(function () {
     pdfManagerMock = null;
     idFactoryMock = null;
+    colorSpaceFactory = null;
   });
 
   describe('AnnotationFactory', function () {
@@ -71,7 +83,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, annotationRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -91,9 +104,11 @@ describe('annotation', function() {
       });
 
       var annotation1 = AnnotationFactory.create(xref, annotationDict,
-                                                 pdfManagerMock, idFactory);
+                                                 pdfManagerMock, idFactory,
+                                                 colorSpaceFactory);
       var annotation2 = AnnotationFactory.create(xref, annotationDict,
-                                                 pdfManagerMock, idFactory);
+                                                 pdfManagerMock, idFactory,
+                                                 colorSpaceFactory);
       var data1 = annotation1.data, data2 = annotation2.data;
       expect(data1.annotationType).toEqual(AnnotationType.LINK);
       expect(data2.annotationType).toEqual(AnnotationType.LINK);
@@ -112,7 +127,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, annotationRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toBeUndefined();
     });
@@ -132,7 +148,7 @@ describe('annotation', function() {
     });
 
     it('should set and get flags', function() {
-      var annotation = new Annotation({ dict, ref, });
+      var annotation = new Annotation({ dict, ref, colorSpaceFactory, });
       annotation.setFlags(13);
 
       expect(annotation.hasFlag(AnnotationFlag.INVISIBLE)).toEqual(true);
@@ -142,63 +158,63 @@ describe('annotation', function() {
     });
 
     it('should be viewable and not printable by default', function() {
-      var annotation = new Annotation({ dict, ref, });
+      var annotation = new Annotation({ dict, ref, colorSpaceFactory, });
 
       expect(annotation.viewable).toEqual(true);
       expect(annotation.printable).toEqual(false);
     });
 
     it('should set and get a valid rectangle', function() {
-      var annotation = new Annotation({ dict, ref, });
+      var annotation = new Annotation({ dict, ref, colorSpaceFactory, });
       annotation.setRectangle([117, 694, 164.298, 720]);
 
       expect(annotation.rectangle).toEqual([117, 694, 164.298, 720]);
     });
 
     it('should not set and get an invalid rectangle', function() {
-      var annotation = new Annotation({ dict, ref, });
+      var annotation = new Annotation({ dict, ref, colorSpaceFactory, });
       annotation.setRectangle([117, 694, 164.298]);
 
       expect(annotation.rectangle).toEqual([0, 0, 0, 0]);
     });
 
     it('should reject a color if it is not an array', function() {
-      var annotation = new Annotation({ dict, ref, });
+      var annotation = new Annotation({ dict, ref, colorSpaceFactory, });
       annotation.setColor('red');
 
       expect(annotation.color).toEqual(new Uint8Array([0, 0, 0]));
     });
 
     it('should set and get a transparent color', function() {
-      var annotation = new Annotation({ dict, ref, });
+      var annotation = new Annotation({ dict, ref, colorSpaceFactory, });
       annotation.setColor([]);
 
       expect(annotation.color).toEqual(null);
     });
 
     it('should set and get a grayscale color', function() {
-      var annotation = new Annotation({ dict, ref, });
+      var annotation = new Annotation({ dict, ref, colorSpaceFactory, });
       annotation.setColor([0.4]);
 
       expect(annotation.color).toEqual(new Uint8Array([102, 102, 102]));
     });
 
     it('should set and get an RGB color', function() {
-      var annotation = new Annotation({ dict, ref, });
+      var annotation = new Annotation({ dict, ref, colorSpaceFactory, });
       annotation.setColor([0, 0, 1]);
 
       expect(annotation.color).toEqual(new Uint8Array([0, 0, 255]));
     });
 
     it('should set and get a CMYK color', function() {
-      var annotation = new Annotation({ dict, ref, });
+      var annotation = new Annotation({ dict, ref, colorSpaceFactory, });
       annotation.setColor([0.1, 0.92, 0.84, 0.02]);
 
       expect(annotation.color).toEqual(new Uint8Array([233, 59, 47]));
     });
 
     it('should not set and get an invalid color', function() {
-      var annotation = new Annotation({ dict, ref, });
+      var annotation = new Annotation({ dict, ref, colorSpaceFactory, });
       annotation.setColor([0.4, 0.6]);
 
       expect(annotation.color).toEqual(new Uint8Array([0, 0, 0]));
@@ -297,7 +313,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, annotationRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -325,7 +342,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, annotationRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -358,7 +376,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, annotationRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -388,7 +407,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, annotationRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -417,7 +437,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, annotationRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -449,7 +470,8 @@ describe('annotation', function() {
       });
 
       var annotation = AnnotationFactory.create(xref, annotationRef,
-                                                pdfManager, idFactoryMock);
+                                                pdfManager, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -478,7 +500,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, annotationRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -507,7 +530,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, annotationRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -547,7 +571,8 @@ describe('annotation', function() {
       });
 
       var annotation = AnnotationFactory.create(xref, annotationRef,
-                                                pdfManager, idFactoryMock);
+                                                pdfManager, idFactoryMock.
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -582,8 +607,8 @@ describe('annotation', function() {
         ]);
 
         var annotation = AnnotationFactory.create(xref, annotationRef,
-                                                  pdfManagerMock,
-                                                  idFactoryMock);
+                                                  pdfManagerMock, idFactoryMock,
+                                                  colorSpaceFactory);
         var data = annotation.data;
         expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -634,7 +659,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, annotationRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -655,7 +681,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, annotationRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -678,7 +705,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, annotationRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -708,7 +736,8 @@ describe('annotation', function() {
       ]);
 
       let annotation = AnnotationFactory.create(xref, annotationRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       let data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINK);
 
@@ -741,7 +770,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, widgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -758,7 +788,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, widgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -782,7 +813,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, widgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -804,7 +836,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, widgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -836,7 +869,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, textWidgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -859,7 +893,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, textWidgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -883,7 +918,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, textWidgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -902,7 +938,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, textWidgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -919,7 +956,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, textWidgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -947,8 +985,8 @@ describe('annotation', function() {
         ]);
 
         var annotation = AnnotationFactory.create(xref, textWidgetRef,
-                                                  pdfManagerMock,
-                                                  idFactoryMock);
+                                                  pdfManagerMock, idFactoryMock,
+                                                  colorSpaceFactory);
         var data = annotation.data;
         expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -988,7 +1026,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, buttonWidgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -1017,7 +1056,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, buttonWidgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -1043,7 +1083,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, buttonWidgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -1077,7 +1118,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, choiceWidgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -1112,7 +1154,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, choiceWidgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -1144,7 +1187,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, choiceWidgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -1172,7 +1216,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, choiceWidgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -1190,7 +1235,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, choiceWidgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -1208,7 +1254,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, choiceWidgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -1222,7 +1269,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, choiceWidgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -1240,7 +1288,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, choiceWidgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -1260,7 +1309,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, choiceWidgetRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
 
@@ -1283,7 +1333,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, lineRef, pdfManagerMock,
-                                                idFactoryMock);
+                                                idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.LINE);
 
@@ -1336,7 +1387,8 @@ describe('annotation', function() {
       fileAttachmentDict.assignXref(xref);
 
       var annotation = AnnotationFactory.create(xref, fileAttachmentRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.FILEATTACHMENT);
 
@@ -1365,7 +1417,8 @@ describe('annotation', function() {
       ]);
 
       var annotation = AnnotationFactory.create(xref, popupRef,
-                                                pdfManagerMock, idFactoryMock);
+                                                pdfManagerMock, idFactoryMock,
+                                                colorSpaceFactory);
       var data = annotation.data;
       expect(data.annotationType).toEqual(AnnotationType.POPUP);
 

--- a/test/unit/colorspace_spec.js
+++ b/test/unit/colorspace_spec.js
@@ -15,33 +15,53 @@
 
 import { Dict, Name, Ref } from '../../src/core/primitives';
 import { Stream, StringStream } from '../../src/core/stream';
-import { ColorSpace } from '../../src/core/colorspace';
+import { ColorSpaceFactory } from '../../src/core/colorspace';
 import { PDFFunctionFactory } from '../../src/core/function';
 import { XRefMock } from './test_utils';
 
 describe('colorspace', function () {
   describe('ColorSpace', function () {
+    let colorSpaceFactory;
+
+    beforeAll(function(done) {
+      let xref = new XRefMock();
+      let pdfFunctionFactory = new PDFFunctionFactory({
+        xref,
+      });
+      colorSpaceFactory = new ColorSpaceFactory({
+        xref,
+        pdfFunctionFactory,
+      });
+      done();
+    });
+
+    afterAll(function() {
+      colorSpaceFactory = null;
+    });
+
     it('should be true if decode is not an array', function () {
-      expect(ColorSpace.isDefaultDecode('string', 0)).toBeTruthy();
+      expect(colorSpaceFactory.isDefaultDecode('string', 0)).toBeTruthy();
     });
     it('should be true if length of decode array is not correct',
         function () {
-      expect(ColorSpace.isDefaultDecode([0], 1)).toBeTruthy();
-      expect(ColorSpace.isDefaultDecode([0, 1, 0], 1)).toBeTruthy();
+      expect(colorSpaceFactory.isDefaultDecode([0], 1)).toBeTruthy();
+      expect(colorSpaceFactory.isDefaultDecode([0, 1, 0], 1)).toBeTruthy();
     });
     it('should be true if decode map matches the default decode map',
         function () {
-      expect(ColorSpace.isDefaultDecode([], 0)).toBeTruthy();
+      expect(colorSpaceFactory.isDefaultDecode([], 0)).toBeTruthy();
 
-      expect(ColorSpace.isDefaultDecode([0, 0], 1)).toBeFalsy();
-      expect(ColorSpace.isDefaultDecode([0, 1], 1)).toBeTruthy();
+      expect(colorSpaceFactory.isDefaultDecode([0, 0], 1)).toBeFalsy();
+      expect(colorSpaceFactory.isDefaultDecode([0, 1], 1)).toBeTruthy();
 
-      expect(ColorSpace.isDefaultDecode([0, 1, 0, 1, 0, 1], 3)).toBeTruthy();
-      expect(ColorSpace.isDefaultDecode([0, 1, 0, 1, 1, 1], 3)).toBeFalsy();
-
-      expect(ColorSpace.isDefaultDecode([0, 1, 0, 1, 0, 1, 0, 1], 4))
+      expect(colorSpaceFactory.isDefaultDecode([0, 1, 0, 1, 0, 1], 3))
         .toBeTruthy();
-      expect(ColorSpace.isDefaultDecode([1, 0, 0, 1, 0, 1, 0, 1], 4))
+      expect(colorSpaceFactory.isDefaultDecode([0, 1, 0, 1, 1, 1], 3))
+        .toBeFalsy();
+
+      expect(colorSpaceFactory.isDefaultDecode([0, 1, 0, 1, 0, 1, 0, 1], 4))
+        .toBeTruthy();
+      expect(colorSpaceFactory.isDefaultDecode([1, 0, 0, 1, 0, 1, 0, 1], 4))
         .toBeFalsy();
     });
   });
@@ -58,7 +78,11 @@ describe('colorspace', function () {
       let pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      let colorSpaceFactory = new ColorSpaceFactory({
+        xref,
+        pdfFunctionFactory,
+      });
+      let colorSpace = colorSpaceFactory.create({ cs, res, });
 
       let testSrc = new Uint8Array([27, 125, 250, 131]);
       let testDest = new Uint8Array(4 * 4 * 3);
@@ -99,7 +123,11 @@ describe('colorspace', function () {
       let pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      let colorSpaceFactory = new ColorSpaceFactory({
+        xref,
+        pdfFunctionFactory,
+      });
+      let colorSpace = colorSpaceFactory.create({ cs, res, });
 
       let testSrc = new Uint8Array([27, 125, 250, 131]);
       let testDest = new Uint8Array(3 * 3 * 3);
@@ -136,7 +164,11 @@ describe('colorspace', function () {
       let pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      let colorSpaceFactory = new ColorSpaceFactory({
+        xref,
+        pdfFunctionFactory,
+      });
+      let colorSpace = colorSpaceFactory.create({ cs, res, });
 
       let testSrc = new Uint8Array([
         27, 125, 250,
@@ -182,7 +214,11 @@ describe('colorspace', function () {
       let pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      let colorSpaceFactory = new ColorSpaceFactory({
+        xref,
+        pdfFunctionFactory,
+      });
+      let colorSpace = colorSpaceFactory.create({ cs, res, });
 
       let testSrc = new Uint8Array([
         27, 125, 250,
@@ -224,7 +260,11 @@ describe('colorspace', function () {
       let pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      let colorSpaceFactory = new ColorSpaceFactory({
+        xref,
+        pdfFunctionFactory,
+      });
+      let colorSpace = colorSpaceFactory.create({ cs, res, });
 
       let testSrc = new Uint8Array([
         27, 125, 250, 128,
@@ -270,7 +310,11 @@ describe('colorspace', function () {
       let pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      let colorSpaceFactory = new ColorSpaceFactory({
+        xref,
+        pdfFunctionFactory,
+      });
+      let colorSpace = colorSpaceFactory.create({ cs, res, });
 
       let testSrc = new Uint8Array([
         27, 125, 250, 128,
@@ -320,7 +364,11 @@ describe('colorspace', function () {
       let pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      let colorSpaceFactory = new ColorSpaceFactory({
+        xref,
+        pdfFunctionFactory,
+      });
+      let colorSpace = colorSpaceFactory.create({ cs, res, });
 
       let testSrc = new Uint8Array([27, 125, 250, 131]);
       let testDest = new Uint8Array(4 * 4 * 3);
@@ -373,7 +421,11 @@ describe('colorspace', function () {
       let pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      let colorSpaceFactory = new ColorSpaceFactory({
+        xref,
+        pdfFunctionFactory,
+      });
+      let colorSpace = colorSpaceFactory.create({ cs, res, });
 
       let testSrc = new Uint8Array([
         27, 125, 250,
@@ -423,7 +475,11 @@ describe('colorspace', function () {
       let pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      let colorSpaceFactory = new ColorSpaceFactory({
+        xref,
+        pdfFunctionFactory,
+      });
+      let colorSpace = colorSpaceFactory.create({ cs, res, });
 
       let testSrc = new Uint8Array([
         27, 25, 50,
@@ -476,7 +532,11 @@ describe('colorspace', function () {
       let pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      let colorSpaceFactory = new ColorSpaceFactory({
+        xref,
+        pdfFunctionFactory,
+      });
+      let colorSpace = colorSpaceFactory.create({ cs, res, });
 
       let testSrc = new Uint8Array([2, 2, 0, 1]);
       let testDest = new Uint8Array(3 * 3 * 3);
@@ -531,7 +591,11 @@ describe('colorspace', function () {
       let pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      let colorSpaceFactory = new ColorSpaceFactory({
+        xref,
+        pdfFunctionFactory,
+      });
+      let colorSpace = colorSpaceFactory.create({ cs, res, });
 
       let testSrc = new Uint8Array([27, 25, 50, 31]);
       let testDest = new Uint8Array(3 * 3 * 3);

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -17,6 +17,8 @@ import { Dict, Name } from '../../src/core/primitives';
 import { FormatError, OPS } from '../../src/shared/util';
 import { OperatorList, PartialEvaluator } from '../../src/core/evaluator';
 import { Stream, StringStream } from '../../src/core/stream';
+import { ColorSpaceFactory } from '../../src/core/colorspace';
+import { PDFFunctionFactory } from '../../src/core/function';
 import { WorkerTask } from '../../src/core/worker';
 import { XRefMock } from './test_utils';
 
@@ -56,11 +58,22 @@ describe('evaluator', function() {
   var partialEvaluator;
 
   beforeAll(function(done) {
+    let xref = new XRefMock();
+    let pdfFunctionFactory = new PDFFunctionFactory({
+      xref,
+    });
+    let colorSpaceFactory = new ColorSpaceFactory({
+      xref,
+      pdfFunctionFactory,
+    });
+
     partialEvaluator = new PartialEvaluator({
       pdfManager: new PdfManagerMock(),
-      xref: new XRefMock(),
+      xref,
       handler: new HandlerMock(),
       pageIndex: 0,
+      colorSpaceFactory,
+      pdfFunctionFactory,
     });
     done();
   });


### PR DESCRIPTION
*Follows the same pattern as PR #8968.*