### PR TITLE
Add CDN links

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ or to build it from source. We supply pre-built versions for usage with NPM and 
 the `pdfjs-dist` name. For more information and examples please refer to the
 [wiki page](https://github.com/mozilla/pdf.js/wiki/Setup-pdf.js-in-a-website) on this subject.
 
+## Including via a CDN
+
+PDF.js is hosted on several free CDNs:
+ - https://www.jsdelivr.com/package/npm/pdfjs-dist
+ - https://cdnjs.com/libraries/pdf.js
+ - https://unpkg.com/pdfjs-dist/
+
 ## Learning
 
 You can play with the PDF.js API directly from your browser using the live demos below:

--- a/docs/contents/getting_started/index.md
+++ b/docs/contents/getting_started/index.md
@@ -57,6 +57,13 @@ $ cd pdf.js
   </div>
 </div>
 
+## Including via a CDN
+
+PDF.js is hosted on several free CDNs:
+ - https://www.jsdelivr.com/package/npm/pdfjs-dist
+ - https://cdnjs.com/libraries/pdf.js
+ - https://unpkg.com/pdfjs-dist/
+
 ## File Layout Overview
 
 ### Prebuilt


### PR DESCRIPTION
I added [jsDelivr CDN links](https://www.jsdelivr.com/package/npm/pdfjs-dist) to your site and readme for easier and faster usage. jsDelivr is the fastest opensource CDN available and built specifically for production usage.