### PR TITLE
Remove unused helper code

### DIFF
--- a/src/display/global.js
+++ b/src/display/global.js
@@ -34,8 +34,6 @@ import { Metadata } from './metadata';
 import { renderTextLayer } from './text_layer';
 import { SVGGraphics } from './svg';
 
-var isWorker = (typeof window === 'undefined');
-
 // The global PDFJS object is now deprecated and will not be supported in
 // the future. The members below are maintained for backward  compatibility
 // and shall not be extended or modified. If the global.js is included as
@@ -306,6 +304,5 @@ PDFJS.UnsupportedManager = _UnsupportedManager;
 
 export {
   globalScope,
-  isWorker,
   PDFJS,
 };

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -800,10 +800,6 @@ var Util = (function UtilClosure() {
     return result;
   };
 
-  Util.sign = function Util_sign(num) {
-    return num < 0 ? -1 : 1;
-  };
-
   var ROMAN_NUMBER_MAP = [
     '', 'C', 'CC', 'CCC', 'CD', 'D', 'DC', 'DCC', 'DCCC', 'CM',
     '', 'X', 'XX', 'XXX', 'XL', 'L', 'LX', 'LXX', 'LXXX', 'XC',


### PR DESCRIPTION
 - Remove the unused `isWorker` property from `src/display/global.js`

   This has been completely unused since commit 1d12aed, in PR #7126, almost one and a half years ago.

 - Remove the unused `Util.sign` function from `src/shared/util.js`

   This has been completely unused since commit 10bb6c9, in PR #2505, more than four and a half years ago.