### PR TITLE
Mispelled isEvalSupported property at FontFaceObject() creation.

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1818,7 +1818,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
               };
             }
             var font = new FontFaceObject(exportedData, {
-              isEvalSuported: getDefaultSetting('isEvalSupported'),
+              isEvalSupported: getDefaultSetting('isEvalSupported'),
               disableFontFace: getDefaultSetting('disableFontFace'),
               fontRegistry,
             });


### PR DESCRIPTION
Hello,

While looking at the code for available options..i've found a typo when creating the `FontFaceObject()` instances, the provided `isEvalSuported` option should actually be `isEvalSupported` (note the extra `p`)

Not sure if that would be causing any real issue since there is a fallback logic, but anyway i thought you may want that fixed, fwiw it got introduced over two years ago on commit 1d12aed5cac6a0cac

Cheers.
