### PR TITLE
Only warn about unsupported JavaScript, in the viewer, when non-empty actions exist (issue 5767)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1047,10 +1047,18 @@ let PDFViewerApplication = {
         return;
       }
       pdfDocument.getJavaScript().then((javaScript) => {
-        if (javaScript.length) {
+        if (javaScript.length === 0) {
+          return;
+        }
+        javaScript.some((js) => {
+          if (!js) { // Don't warn/fallback for empty JavaScript actions.
+            return false;
+          }
           console.warn('Warning: JavaScript is not supported');
           this.fallback(UNSUPPORTED_FEATURES.javaScript);
-        }
+          return true;
+        });
+
         // Hack to support auto printing.
         let regex = /\bprint\s*\(/;
         for (let i = 0, ii = javaScript.length; i < ii; i++) {


### PR DESCRIPTION
Some PDF files contain JavaScript actions that consist of nothing more that one, or possibly several, empty string(s). At least to me, printing a warning/showing the fallback seems completely unnecessary in that case.

Furthermore, this patch also makes use of an early `return`, so that we no longer will attempt to check for printing instructions when no JavaScript is present in the PDF file.

*Note:* It would perhaps make sense to change the API/core code, such that we ignore empty entries there instead. However, that would probably be considered a breaking changing with respect to backwards compatibility, hence this simple viewer only solution.

Fixes #5767.

***Edit:*** The existing test-files `issue6106.pdf` and `bug1001080.pdf` could be used to check that this patch doesn't break the warning/fallback in cases where it's still applicable.

***Edit2:*** Patch updated *only* to fix stupid typos in the commit message!