### PR TITLE
Fix a `PDFHistory` regression with document hashes of the `nameddest=...` form

### DIFF
--- a/test/unit/pdf_history_spec.js
+++ b/test/unit/pdf_history_spec.js
@@ -13,10 +13,36 @@
  * limitations under the License.
  */
 
-import { isDestsEqual } from '../../web/pdf_history';
+import { isDestArraysEqual, isDestHashesEqual } from '../../web/pdf_history';
 
 describe('pdf_history', function() {
-  describe('isDestsEqual', function() {
+  describe('isDestHashesEqual', function() {
+    it('should reject non-equal destination hashes', function() {
+      expect(isDestHashesEqual(null, 'page.157')).toEqual(false);
+      expect(isDestHashesEqual('title.0', 'page.157')).toEqual(false);
+      expect(isDestHashesEqual('page=1&zoom=auto', 'page.157')).toEqual(false);
+
+      expect(isDestHashesEqual('nameddest-page.157', 'page.157')).
+        toEqual(false);
+      expect(isDestHashesEqual('page.157', 'nameddest=page.157')).
+        toEqual(false);
+
+      let destArrayString = JSON.stringify(
+        [{ num: 3757, gen: 0, }, { name: 'XYZ', }, 92.918, 748.972, null]);
+      expect(isDestHashesEqual(destArrayString, 'page.157')).toEqual(false);
+      expect(isDestHashesEqual('page.157', destArrayString)).toEqual(false);
+    });
+
+    it('should accept equal destination hashes', function() {
+      expect(isDestHashesEqual('page.157', 'page.157')).toEqual(true);
+      expect(isDestHashesEqual('nameddest=page.157', 'page.157')).toEqual(true);
+
+      expect(isDestHashesEqual('nameddest=page.157&zoom=100', 'page.157')).
+        toEqual(true);
+    });
+  });
+
+  describe('isDestArraysEqual', function() {
     let firstDest = [{ num: 1, gen: 0, }, { name: 'XYZ', }, 0, 375, null];
     let secondDest = [{ num: 5, gen: 0, }, { name: 'XYZ', }, 0, 375, null];
     let thirdDest = [{ num: 1, gen: 0, }, { name: 'XYZ', }, 750, 0, null];
@@ -24,22 +50,22 @@ describe('pdf_history', function() {
     let fifthDest = [{ gen: 0, num: 1, }, { name: 'XYZ', }, 0, 375, null];
 
     it('should reject non-equal destination arrays', function() {
-      expect(isDestsEqual(firstDest, undefined)).toEqual(false);
-      expect(isDestsEqual(firstDest, [1, 2, 3, 4, 5])).toEqual(false);
+      expect(isDestArraysEqual(firstDest, undefined)).toEqual(false);
+      expect(isDestArraysEqual(firstDest, [1, 2, 3, 4, 5])).toEqual(false);
 
-      expect(isDestsEqual(firstDest, secondDest)).toEqual(false);
-      expect(isDestsEqual(firstDest, thirdDest)).toEqual(false);
-      expect(isDestsEqual(firstDest, fourthDest)).toEqual(false);
+      expect(isDestArraysEqual(firstDest, secondDest)).toEqual(false);
+      expect(isDestArraysEqual(firstDest, thirdDest)).toEqual(false);
+      expect(isDestArraysEqual(firstDest, fourthDest)).toEqual(false);
     });
 
     it('should accept equal destination arrays', function() {
-      expect(isDestsEqual(firstDest, firstDest)).toEqual(true);
-      expect(isDestsEqual(firstDest, fifthDest)).toEqual(true);
+      expect(isDestArraysEqual(firstDest, firstDest)).toEqual(true);
+      expect(isDestArraysEqual(firstDest, fifthDest)).toEqual(true);
 
       let firstDestCopy = firstDest.slice();
       expect(firstDest).not.toBe(firstDestCopy);
 
-      expect(isDestsEqual(firstDest, firstDestCopy)).toEqual(true);
+      expect(isDestArraysEqual(firstDest, firstDestCopy)).toEqual(true);
     });
   });
 });

--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -177,8 +177,8 @@ class PDFHistory {
 
     let forceReplace = false;
     if (this._destination &&
-        (this._destination.hash === hash ||
-         isDestsEqual(this._destination.dest, explicitDest))) {
+        (isDestHashesEqual(this._destination.hash, hash) ||
+         isDestArraysEqual(this._destination.dest, explicitDest))) {
       // When the new destination is identical to `this._destination`, and
       // its `page` is undefined, replace the current browser history entry.
       // NOTE: This can only occur if `this._destination` was set either:
@@ -555,7 +555,21 @@ class PDFHistory {
   }
 }
 
-function isDestsEqual(firstDest, secondDest) {
+function isDestHashesEqual(destHash, pushHash) {
+  if (typeof destHash !== 'string' || typeof pushHash !== 'string') {
+    return false;
+  }
+  if (destHash === pushHash) {
+    return true;
+  }
+  let { nameddest, } = parseQueryString(destHash);
+  if (nameddest === pushHash) {
+    return true;
+  }
+  return false;
+}
+
+function isDestArraysEqual(firstDest, secondDest) {
   function isEntryEqual(first, second) {
     if (typeof first !== typeof second) {
       return false;
@@ -593,5 +607,6 @@ function isDestsEqual(firstDest, secondDest) {
 
 export {
   PDFHistory,
-  isDestsEqual,
+  isDestHashesEqual,
+  isDestArraysEqual,
 };


### PR DESCRIPTION
Unfortunately I've just found out that this isn't working entirely correct; my apologies for accidentally breaking this in PR #8775.

Compare e.g. this link: http://mirrors.ctan.org/info/lshort/english/lshort.pdf#page.157, with this one: http://mirrors.ctan.org/info/lshort/english/lshort.pdf#nameddest=page.157.

Notice how in the *second* case, the history stops working correctly.

*The various edge-case regressions in the new `PDFHistory` code is reminding my why I put off the rewrite for so long :-(*