### PR TITLE
Enable the `--report-unused-disable-directives` ESLint command line option

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1160,7 +1160,8 @@ gulp.task('lint', function (done) {
   console.log('### Linting JS files');
 
   // Ensure that we lint the Firefox specific *.jsm files too.
-  var options = ['node_modules/eslint/bin/eslint', '--ext', '.js,.jsm', '.'];
+  var options = ['node_modules/eslint/bin/eslint', '--ext', '.js,.jsm', '.',
+                 '--report-unused-disable-directives'];
   var esLintProcess = spawn('node', options, { stdio: 'inherit', });
   esLintProcess.on('close', function (code) {
     if (code !== 0) {

--- a/src/doc_helper.js
+++ b/src/doc_helper.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable strict */
 
 /*
  NOTE: This file is created as a helper to assist with JSDoc html files.

--- a/src/pdf.worker.entry.js
+++ b/src/pdf.worker.entry.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable strict */
 
 (typeof window !== 'undefined' ? window : {}).pdfjsDistBuildPdfWorker =
   require('./pdf.worker.js');


### PR DESCRIPTION
This option was added in [version `4.8.0` of ESLint](https://github.com/eslint/eslint/releases/tag/v4.8.0), which is already listed as the minimum version in our `package.json` file; please refer to https://eslint.org/docs/user-guide/command-line-interface#--report-unused-disable-directives for additional details.

Despite the caveat listed in the link above, I still think that using this option makes sense since it will help ensure that no longer necessary disable statements are removed.