### PR TITLE
Simplify the check, and remove the warning, for the `nativeImageDecoderSupport` API parameter

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -223,13 +223,9 @@ function getDocument(src) {
   params.rangeChunkSize = params.rangeChunkSize || DEFAULT_RANGE_CHUNK_SIZE;
   params.ignoreErrors = params.stopAtErrors !== true;
 
-  params.nativeImageDecoderSupport = params.nativeImageDecoderSupport ||
-                                     NativeImageDecoding.DECODE;
-  if (params.nativeImageDecoderSupport !== NativeImageDecoding.DECODE &&
-      params.nativeImageDecoderSupport !== NativeImageDecoding.NONE &&
-      params.nativeImageDecoderSupport !== NativeImageDecoding.DISPLAY) {
-    warn('Invalid parameter nativeImageDecoderSupport: ' +
-      'need a state of enum {NativeImageDecoding}');
+  const nativeImageDecoderValues = Object.values(NativeImageDecoding);
+  if (params.nativeImageDecoderSupport === undefined ||
+      !nativeImageDecoderValues.includes(params.nativeImageDecoderSupport)) {
     params.nativeImageDecoderSupport = NativeImageDecoding.DECODE;
   }
 

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -839,6 +839,25 @@ PDFJS.compatibilityChecked = true;
   };
 })();
 
+// Provides support for Object.values in legacy browsers.
+// Support: IE.
+(function checkObjectValues() {
+  if (Object.values) {
+    return;
+  }
+  Object.values = require('core-js/fn/object/values');
+})();
+
+// Provides support for Array.prototype.includes in legacy browsers.
+// Support: IE.
+(function checkArrayIncludes() {
+  if (Array.prototype.includes) {
+    return;
+  }
+  Array.prototype.includes = require('core-js/fn/array/includes');
+})();
+
+
 // Provides support for Number.isNaN in legacy browsers.
 // Support: IE.
 (function checkNumberIsNaN() {


### PR DESCRIPTION
As discussed in PR https://github.com/mozilla/pdf.js/pull/8982#discussion_r142392423.

**TODO**
 - [x] Check if we possibly need to include [core-js](https://github.com/zloirock/core-js) polyfills for `Object.values` and/or `Array.includes`.