### PR TITLE
[api-major] Remove the `PDFJS_NEXT` option

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -81,7 +81,7 @@ var DEFINES = {
   SINGLE_FILE: false,
   COMPONENTS: false,
   LIB: false,
-  PDFJS_NEXT: false,
+  SKIP_BABEL: false,
 };
 
 function safeSpawnSync(command, parameters, options) {
@@ -130,8 +130,8 @@ function createWebpackConfig(defines, output) {
   var licenseHeader = fs.readFileSync('./src/license_header.js').toString();
   var enableSourceMaps = !bundleDefines.FIREFOX && !bundleDefines.MOZCENTRAL &&
                          !bundleDefines.CHROME;
-  var pdfjsNext = bundleDefines.PDFJS_NEXT ||
-                  process.env['PDFJS_NEXT'] === 'true';
+  var skipBabel = bundleDefines.SKIP_BABEL ||
+                  process.env['SKIP_BABEL'] === 'true';
 
   return {
     output: output,
@@ -152,7 +152,7 @@ function createWebpackConfig(defines, output) {
           loader: 'babel-loader',
           exclude: /src\/core\/(glyphlist|unicode)/, // babel is too slow
           options: {
-            presets: pdfjsNext ? undefined : ['env'],
+            presets: skipBabel ? undefined : ['env'],
             plugins: ['transform-es2015-modules-commonjs'],
           },
         },
@@ -732,7 +732,7 @@ gulp.task('minified', ['minified-post']);
 gulp.task('firefox-pre', ['buildnumber', 'locale'], function () {
   console.log();
   console.log('### Building Firefox extension');
-  var defines = builder.merge(DEFINES, { FIREFOX: true, PDFJS_NEXT: true, });
+  var defines = builder.merge(DEFINES, { FIREFOX: true, SKIP_BABEL: true, });
 
   var FIREFOX_BUILD_CONTENT_DIR = FIREFOX_BUILD_DIR + '/content/',
       FIREFOX_EXTENSION_DIR = 'extensions/firefox/',
@@ -840,7 +840,7 @@ gulp.task('firefox', ['firefox-pre'], function (done) {
 gulp.task('mozcentral-pre', ['buildnumber', 'locale'], function () {
   console.log();
   console.log('### Building mozilla-central extension');
-  var defines = builder.merge(DEFINES, { MOZCENTRAL: true, PDFJS_NEXT: true, });
+  var defines = builder.merge(DEFINES, { MOZCENTRAL: true, SKIP_BABEL: true, });
 
   var MOZCENTRAL_DIR = BUILD_DIR + 'mozcentral/',
       MOZCENTRAL_EXTENSION_DIR = MOZCENTRAL_DIR + 'browser/extensions/pdfjs/',
@@ -913,7 +913,7 @@ gulp.task('mozcentral', ['mozcentral-pre']);
 gulp.task('chromium-pre', ['buildnumber', 'locale'], function () {
   console.log();
   console.log('### Building Chromium extension');
-  var defines = builder.merge(DEFINES, { CHROME: true, PDFJS_NEXT: true, });
+  var defines = builder.merge(DEFINES, { CHROME: true, SKIP_BABEL: true, });
 
   var CHROME_BUILD_DIR = BUILD_DIR + '/chromium/',
       CHROME_BUILD_CONTENT_DIR = CHROME_BUILD_DIR + '/content/';

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -443,8 +443,6 @@ function getDefaultSetting(id) {
       return globalSettings ? globalSettings.externalLinkRel : DEFAULT_LINK_REL;
     case 'enableStats':
       return !!(globalSettings && globalSettings.enableStats);
-    case 'pdfjsNext':
-      return !!(globalSettings && globalSettings.pdfjsNext);
     default:
       throw new Error('Unknown default setting: ' + id);
   }

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -240,13 +240,6 @@ PDFJS.externalLinkRel = (PDFJS.externalLinkRel === undefined ?
 PDFJS.isEvalSupported = (PDFJS.isEvalSupported === undefined ?
                          true : PDFJS.isEvalSupported);
 
-/**
- * Opt-in to backwards incompatible API changes. NOTE:
- * If the `PDFJS_NEXT` build flag is set, it will override this setting.
- * @var {boolean}
- */
-PDFJS.pdfjsNext = (PDFJS.pdfjsNext === undefined) ? false : PDFJS.pdfjsNext;
-
 PDFJS.getDocument = getDocument;
 PDFJS.LoopbackPort = LoopbackPort;
 PDFJS.PDFDataRangeTransport = PDFDataRangeTransport;

--- a/test/driver.js
+++ b/test/driver.js
@@ -255,8 +255,6 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
     PDFJS.cMapUrl = '../external/bcmaps/';
     PDFJS.enableStats = true;
     PDFJS.imageResourcesPath = '/web/images/';
-    // Opt-in to using the latest API.
-    PDFJS.pdfjsNext = true;
 
     // Set the passed options
     this.inflight = options.inflight;

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -38,7 +38,6 @@ describe('api', function() {
 
   beforeAll(function(done) {
     if (isNodeJS()) {
-      PDFJS.pdfjsNext = true;
       // NOTE: To support running the canvas-related tests in Node.js,
       // a `NodeCanvasFactory` would need to be added (in test_utils.js).
     } else {

--- a/test/unit/custom_spec.js
+++ b/test/unit/custom_spec.js
@@ -17,7 +17,6 @@ import { buildGetDocumentParams } from './test_utils';
 import { DOMCanvasFactory } from '../../src/display/dom_utils';
 import { getDocument } from '../../src/display/api';
 import { isNodeJS } from '../../src/shared/util';
-import { PDFJS } from '../../src/display/global';
 
 function getTopLeftPixel(canvasContext) {
   let imgData = canvasContext.getImageData(0, 0, 1, 1);
@@ -38,7 +37,6 @@ describe('custom canvas rendering', function() {
 
   beforeAll(function(done) {
     if (isNodeJS()) {
-      PDFJS.pdfjsNext = true;
       // NOTE: To support running the canvas-related tests in Node.js,
       // a `NodeCanvasFactory` would need to be added (in test_utils.js).
     } else {

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -90,8 +90,6 @@ function initializePDFJS(callback) {
 
     // Configure the worker.
     displayGlobal.PDFJS.workerSrc = '../../build/generic/build/pdf.worker.js';
-    // Opt-in to using the latest API.
-    displayGlobal.PDFJS.pdfjsNext = true;
 
     callback();
   });

--- a/web/app.js
+++ b/web/app.js
@@ -55,13 +55,11 @@ function configure(PDFJS) {
   }
   if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION')) {
     PDFJS.cMapUrl = '../external/bcmaps/';
-    PDFJS.cMapPacked = true;
     PDFJS.workerSrc = '../src/worker_loader.js';
-    PDFJS.pdfjsNext = true;
   } else {
     PDFJS.cMapUrl = '../web/cmaps/';
-    PDFJS.cMapPacked = true;
   }
+  PDFJS.cMapPacked = true;
 }
 
 const DefaultExternalServices = {


### PR DESCRIPTION
Nothing uses this option anymore, so setting it is a no-op now. We can safely remove it.

Use `SKIP_BABEL` (instead of `PDFJS_NEXT`) now if you want to skip Babel translation for a build.