### PR TITLE
[api-major] Change `getJavaScript` to return `null`, rather than an empty Array, when no JavaScript exists

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -371,7 +371,7 @@ var Catalog = (function CatalogClosure() {
       var xref = this.xref;
       var obj = this.catDict.get('Names');
 
-      var javaScript = [];
+      let javaScript = null;
       function appendIfJavaScriptDict(jsDict) {
         var type = jsDict.get('S');
         if (!isName(type, 'JavaScript')) {
@@ -382,6 +382,9 @@ var Catalog = (function CatalogClosure() {
           js = bytesToString(js.getBytes());
         } else if (!isString(js)) {
           return;
+        }
+        if (!javaScript) {
+          javaScript = [];
         }
         javaScript.push(stringToPDFString(js));
       }
@@ -407,6 +410,9 @@ var Catalog = (function CatalogClosure() {
           // but is supported by many PDF readers/writers (including Adobe's).
           var action = openactionDict.get('N');
           if (isName(action, 'Print')) {
+            if (!javaScript) {
+              javaScript = [];
+            }
             javaScript.push('print({});');
           }
         } else {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -574,10 +574,10 @@ var PDFDocumentProxy = (function PDFDocumentProxyClosure() {
       return this.transport.getAttachments();
     },
     /**
-     * @return {Promise} A promise that is resolved with an array of all the
-     * JavaScript strings in the name tree.
+     * @return {Promise} A promise that is resolved with an {Array} of all the
+     * JavaScript strings in the name tree, or `null` if no JavaScript exists.
      */
-    getJavaScript: function PDFDocumentProxy_getJavaScript() {
+    getJavaScript() {
       return this.transport.getJavaScript();
     },
     /**

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -684,7 +684,7 @@ describe('api', function() {
     it('gets javascript', function(done) {
       var promise = doc.getJavaScript();
       promise.then(function (data) {
-        expect(data).toEqual([]);
+        expect(data).toEqual(null);
         done();
       }).catch(function (reason) {
         done.fail(reason);

--- a/web/app.js
+++ b/web/app.js
@@ -1037,10 +1037,12 @@ let PDFViewerApplication = {
         return;
       }
       pdfDocument.getJavaScript().then((javaScript) => {
-        if (javaScript.length) {
-          console.warn('Warning: JavaScript is not supported');
-          this.fallback(UNSUPPORTED_FEATURES.javaScript);
+        if (!javaScript) {
+          return;
         }
+        console.warn('Warning: JavaScript is not supported');
+        this.fallback(UNSUPPORTED_FEATURES.javaScript);
+
         // Hack to support auto printing.
         let regex = /\bprint\s*\(/;
         for (let i = 0, ii = javaScript.length; i < ii; i++) {


### PR DESCRIPTION
Other API methods already return `null`, rather than empty Arrays/Objects, hence it makes sense to change `getJavaScript` to be consistent.