### PR TITLE
Re-factor how parameters are passed to the network streams

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -251,10 +251,7 @@ function getDocument(src) {
       if (rangeTransport) {
         networkStream = new PDFDataTransportStream(params, rangeTransport);
       } else if (!params.data) {
-        networkStream = new PDFNetworkStream({
-          source: params,
-          disableRange: getDefaultSetting('disableRange'),
-        });
+        networkStream = new PDFNetworkStream(params);
       }
 
       var messageHandler = new MessageHandler(docId, workerId, worker.port);
@@ -286,9 +283,9 @@ function _fetchDocument(worker, source, pdfDataRangeTransport, docId) {
   let apiVersion =
     typeof PDFJSDev !== 'undefined' ? PDFJSDev.eval('BUNDLE_VERSION') : null;
 
+  source.disableRange = getDefaultSetting('disableRange');
   source.disableAutoFetch = getDefaultSetting('disableAutoFetch');
   source.disableStream = getDefaultSetting('disableStream');
-  source.chunkedViewerLoading = !!pdfDataRangeTransport;
   if (pdfDataRangeTransport) {
     source.length = pdfDataRangeTransport.length;
     source.initialData = pdfDataRangeTransport.initialData;

--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -32,11 +32,10 @@ function createFetchOptions(headers, withCredentials) {
 }
 
 class PDFFetchStream {
-  constructor(options) {
-    this.options = options;
-    this.source = options.source;
-    this.isHttp = /^https?:/i.test(this.source.url);
-    this.httpHeaders = (this.isHttp && this.source.httpHeaders) || {};
+  constructor(source) {
+    this.source = source;
+    this.isHttp = /^https?:/i.test(source.url);
+    this.httpHeaders = (this.isHttp && source.httpHeaders) || {};
 
     this._fullRequestReader = null;
     this._rangeRequestReaders = [];
@@ -70,17 +69,18 @@ class PDFFetchStreamReader {
     this._stream = stream;
     this._reader = null;
     this._loaded = 0;
-    this._withCredentials = stream.source.withCredentials;
-    this._contentLength = this._stream.source.length;
+    let source = stream.source;
+    this._withCredentials = source.withCredentials;
+    this._contentLength = source.length;
     this._headersCapability = createPromiseCapability();
-    this._disableRange = this._stream.options.disableRange;
-    this._rangeChunkSize = this._stream.source.rangeChunkSize;
+    this._disableRange = source.disableRange;
+    this._rangeChunkSize = source.rangeChunkSize;
     if (!this._rangeChunkSize && !this._disableRange) {
       this._disableRange = true;
     }
 
-    this._isRangeSupported = !this._stream.options.disableRange;
-    this._isStreamingSupported = !this._stream.source.disableStream;
+    this._isRangeSupported = !source.disableRange;
+    this._isStreamingSupported = !source.disableStream;
 
     this._headers = new Headers();
     for (let property in this._stream.httpHeaders) {
@@ -91,7 +91,7 @@ class PDFFetchStreamReader {
       this._headers.append(property, value);
     }
 
-    let url = this._stream.source.url;
+    let url = source.url;
     fetch(url, createFetchOptions(this._headers, this._withCredentials)).
         then((response) => {
       if (!validateResponseStatus(response.status)) {
@@ -170,9 +170,10 @@ class PDFFetchStreamRangeReader {
     this._stream = stream;
     this._reader = null;
     this._loaded = 0;
-    this._withCredentials = stream.source.withCredentials;
+    let source = stream.source;
+    this._withCredentials = source.withCredentials;
     this._readCapability = createPromiseCapability();
-    this._isStreamingSupported = !stream.source.disableStream;
+    this._isStreamingSupported = !source.disableStream;
 
     this._headers = new Headers();
     for (let property in this._stream.httpHeaders) {
@@ -185,7 +186,7 @@ class PDFFetchStreamRangeReader {
 
     let rangeStr = begin + '-' + (end - 1);
     this._headers.append('Range', 'bytes=' + rangeStr);
-    let url = this._stream.source.url;
+    let url = source.url;
     fetch(url, createFetchOptions(this._headers, this._withCredentials)).
         then((response) => {
       if (!validateResponseStatus(response.status)) {

--- a/src/display/network.js
+++ b/src/display/network.js
@@ -265,9 +265,8 @@ NetworkManager.prototype = {
 };
 
 /** @implements {IPDFStream} */
-function PDFNetworkStream(options) {
-  this._options = options;
-  var source = options.source;
+function PDFNetworkStream(source) {
+  this._source = source;
   this._manager = new NetworkManager(source.url, {
     httpHeaders: source.httpHeaders,
     withCredentials: source.withCredentials,
@@ -289,7 +288,7 @@ PDFNetworkStream.prototype = {
   getFullReader: function PDFNetworkStream_getFullReader() {
     assert(!this._fullRequestReader);
     this._fullRequestReader =
-      new PDFNetworkStreamFullRequestReader(this._manager, this._options);
+      new PDFNetworkStreamFullRequestReader(this._manager, this._source);
     return this._fullRequestReader;
   },
 
@@ -313,10 +312,9 @@ PDFNetworkStream.prototype = {
 };
 
 /** @implements {IPDFStreamReader} */
-function PDFNetworkStreamFullRequestReader(manager, options) {
+function PDFNetworkStreamFullRequestReader(manager, source) {
   this._manager = manager;
 
-  var source = options.source;
   var args = {
     onHeadersReceived: this._onHeadersReceived.bind(this),
     onProgressiveData: source.disableStream ? null :
@@ -328,7 +326,7 @@ function PDFNetworkStreamFullRequestReader(manager, options) {
   this._url = source.url;
   this._fullRequestId = manager.requestFull(args);
   this._headersReceivedCapability = createPromiseCapability();
-  this._disableRange = options.disableRange || false;
+  this._disableRange = source.disableRange || false;
   this._contentLength = source.length; // optional
   this._rangeChunkSize = source.rangeChunkSize;
   if (!this._rangeChunkSize && !this._disableRange) {

--- a/test/unit/network_spec.js
+++ b/test/unit/network_spec.js
@@ -23,11 +23,9 @@ describe('network', function() {
 
   it('read without stream and range', function(done) {
     var stream = new PDFNetworkStream({
-      source: {
-        url: pdf1,
-        rangeChunkSize: 65536,
-        disableStream: true,
-      },
+      url: pdf1,
+      rangeChunkSize: 65536,
+      disableStream: true,
       disableRange: true,
     });
 
@@ -77,11 +75,9 @@ describe('network', function() {
     }
 
     var stream = new PDFNetworkStream({
-      source: {
-        url: pdf2,
-        rangeChunkSize: 65536,
-        disableStream: false,
-      },
+      url: pdf2,
+      rangeChunkSize: 65536,
+      disableStream: false,
       disableRange: false,
     });
 
@@ -123,12 +119,10 @@ describe('network', function() {
     // requiring this test to pass.
     var rangeSize = 32768;
     var stream = new PDFNetworkStream({
-      source: {
-        url: pdf1,
-        length: pdf1Length,
-        rangeChunkSize: rangeSize,
-        disableStream: true,
-      },
+      url: pdf1,
+      length: pdf1Length,
+      rangeChunkSize: rangeSize,
+      disableStream: true,
       disableRange: false,
     });
 

--- a/test/unit/node_stream_spec.js
+++ b/test/unit/node_stream_spec.js
@@ -76,20 +76,16 @@ describe('node_stream', function() {
 
   it('read both http(s) and filesystem pdf files', function(done) {
     let stream1 = new PDFNodeStream({
-      source: {
-        url: `http://127.0.0.1:${port}/tracemonkey.pdf`,
-        rangeChunkSize: 65536,
-        disableStream: true,
-      },
+      url: `http://127.0.0.1:${port}/tracemonkey.pdf`,
+      rangeChunkSize: 65536,
+      disableStream: true,
       disableRange: true,
     });
 
     let stream2 = new PDFNodeStream({
-      source: {
-        url: pdf,
-        rangeChunkSize: 65536,
-        disableStream: true,
-      },
+      url: pdf,
+      rangeChunkSize: 65536,
+      disableStream: true,
       disableRange: true,
     });
 
@@ -146,21 +142,17 @@ describe('node_stream', function() {
       function(done) {
     let rangeSize = 32768;
     let stream1 = new PDFNodeStream({
-      source: {
-        url: `http://127.0.0.1:${port}/tracemonkey.pdf`,
-        length: pdfLength,
-        rangeChunkSize: rangeSize,
-        disableStream: true,
-      },
+      url: `http://127.0.0.1:${port}/tracemonkey.pdf`,
+      length: pdfLength,
+      rangeChunkSize: rangeSize,
+      disableStream: true,
       disableRange: false,
     });
     let stream2 = new PDFNodeStream({
-      source: {
-        url: pdf,
-        length: pdfLength,
-        rangeChunkSize: rangeSize,
-        disableStream: true,
-      },
+      url: pdf,
+      length: pdfLength,
+      rangeChunkSize: rangeSize,
+      disableStream: true,
       disableRange: false,
     });
 


### PR DESCRIPTION
*This patch is the result of me starting to look into moving parameters from `PDFJS` into `getDocument` and other API methods.*

When familiarizing myself with the code, the signatures of the various network streams seemed to be unnecessarily cumbersome since `disableRange` is currently handled separately from other parameters.
I'm assuming that the explanation for this is probably "for historical reasons", as is often the case. Hence I'd like to clean this up *before* we start the larger, and more invasive, `PDFJS` parameter re-factoring.

*Edit:* Slightly smaller diff with https://github.com/mozilla/pdf.js/pull/9037/files?w=1.