### PR TITLE
Use `stringToBytes` in more places

### DIFF
--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -14,7 +14,7 @@
  */
 
 import {
-  createObjectURL, FormatError, isSpace, shadow, Util
+  createObjectURL, FormatError, isSpace, shadow, stringToBytes, Util
 } from '../shared/util';
 import { isDict } from './primitives';
 import { JpegImage } from './jpg';
@@ -109,11 +109,7 @@ var Stream = (function StreamClosure() {
 
 var StringStream = (function StringStreamClosure() {
   function StringStream(str) {
-    var length = str.length;
-    var bytes = new Uint8Array(length);
-    for (var n = 0; n < length; ++n) {
-      bytes[n] = str.charCodeAt(n);
-    }
+    let bytes = stringToBytes(str);
     Stream.call(this, bytes);
   }
 

--- a/src/display/network.js
+++ b/src/display/network.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { assert, createPromiseCapability } from '../shared/util';
+import { assert, createPromiseCapability, stringToBytes } from '../shared/util';
 import {
   createResponseStatusError, validateRangeRequestCapabilities
 } from './network_utils';
@@ -48,11 +48,7 @@ function getArrayBuffer(xhr) {
   if (typeof data !== 'string') {
     return data;
   }
-  var length = data.length;
-  var array = new Uint8Array(length);
-  for (var i = 0; i < length; i++) {
-    array[i] = data.charCodeAt(i) & 0xFF;
-  }
+  let array = stringToBytes(data);
   return array.buffer;
 }
 


### PR DESCRIPTION
Rather than having (basically) verbatim copies of `stringToBytes` in a few places, we can simply use the helper function directly instead.