### PR TITLE
[WIP] Move viewer related option from the `PDFJS` object to their respective viewer components

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -283,17 +283,20 @@ class LinkAnnotationElement extends AnnotationElement {
   render() {
     this.container.className = 'linkAnnotation';
 
+    let { data, linkService, } = this;
     let link = document.createElement('a');
     addLinkAttributes(link, {
-      url: this.data.url,
-      target: (this.data.newWindow ? LinkTarget.BLANK : undefined),
+      url: data.url,
+      target: (data.newWindow ?
+               LinkTarget.BLANK : linkService.externalLinkTarget),
+      rel: linkService.externalLinkRel,
     });
 
-    if (!this.data.url) {
-      if (this.data.action) {
-        this._bindNamedAction(link, this.data.action);
+    if (!data.url) {
+      if (data.action) {
+        this._bindNamedAction(link, data.action);
       } else {
-        this._bindLink(link, this.data.dest);
+        this._bindLink(link, data.dest);
       }
     }
 

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -14,8 +14,7 @@
  */
 
 import {
-  addLinkAttributes, CustomStyle, DOMSVGFactory, getDefaultSetting,
-  getFilenameFromUrl, LinkTarget
+  addLinkAttributes, CustomStyle, DOMSVGFactory, getFilenameFromUrl, LinkTarget
 } from './dom_utils';
 import {
   AnnotationBorderStyleType, AnnotationType, stringToPDFString, Util, warn
@@ -29,7 +28,8 @@ import {
  * @property {PageViewport} viewport
  * @property {IPDFLinkService} linkService
  * @property {DownloadManager} downloadManager
- * @property {string} imageResourcesPath
+ * @property {string} imageResourcesPath - (optional) Path for image resources,
+ *   mainly for annotation icons. Include trailing slash.
  * @property {boolean} renderInteractiveForms
  * @property {Object} svgFactory
  */
@@ -1167,7 +1167,8 @@ class FileAttachmentAnnotationElement extends AnnotationElement {
  * @property {Array} annotations
  * @property {PDFPage} page
  * @property {IPDFLinkService} linkService
- * @property {string} imageResourcesPath
+ * @property {string} imageResourcesPath - (optional) Path for image resources,
+ *   mainly for annotation icons. Include trailing slash.
  * @property {boolean} renderInteractiveForms
  */
 
@@ -1192,8 +1193,7 @@ class AnnotationLayer {
         viewport: parameters.viewport,
         linkService: parameters.linkService,
         downloadManager: parameters.downloadManager,
-        imageResourcesPath: parameters.imageResourcesPath ||
-                            getDefaultSetting('imageResourcesPath'),
+        imageResourcesPath: parameters.imageResourcesPath || '',
         renderInteractiveForms: parameters.renderInteractiveForms || false,
         svgFactory: new DOMSVGFactory(),
       });

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -701,6 +701,8 @@ var PDFDocumentProxy = (function PDFDocumentProxyClosure() {
  *                                calling of PDFPage.getViewport method.
  * @property {string} intent - Rendering intent, can be 'display' or 'print'
  *                    (default value is 'display').
+ * @property {boolean} enableWebGL - (optional) Enables WebGL accelerated
+ *   rendering for some operations. The default value is `false`.
  * @property {boolean} renderInteractiveForms - (optional) Whether or not
  *                     interactive form elements are rendered in the display
  *                     layer. If so, we do not render them on canvas as well.
@@ -823,6 +825,7 @@ var PDFPageProxy = (function PDFPageProxyClosure() {
 
       var renderingIntent = (params.intent === 'print' ? 'print' : 'display');
       var canvasFactory = params.canvasFactory || new DOMCanvasFactory();
+      // TODO: Rebase this on top of the `WebGLFactory`, once that one lands.
 
       if (!this.intentStates[renderingIntent]) {
         this.intentStates[renderingIntent] = Object.create(null);

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -416,8 +416,6 @@ function getDefaultSetting(id) {
       return globalSettings ? globalSettings.disableWorker : false;
     case 'maxImageSize':
       return globalSettings ? globalSettings.maxImageSize : -1;
-    case 'imageResourcesPath':
-      return globalSettings ? globalSettings.imageResourcesPath : '';
     case 'isEvalSupported':
       return globalSettings ? globalSettings.isEvalSupported : true;
     case 'externalLinkTarget':

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -402,8 +402,6 @@ function getDefaultSetting(id) {
       return globalSettings ? globalSettings.disableFontFace : false;
     case 'disableCreateObjectURL':
       return globalSettings ? globalSettings.disableCreateObjectURL : false;
-    case 'disableWebGL':
-      return globalSettings ? globalSettings.disableWebGL : true;
     case 'cMapUrl':
       return globalSettings ? globalSettings.cMapUrl : null;
     case 'cMapPacked':

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -203,13 +203,6 @@ PDFJS.disableCreateObjectURL = (PDFJS.disableCreateObjectURL === undefined ?
                                 false : PDFJS.disableCreateObjectURL);
 
 /**
- * Disables WebGL usage.
- * @var {boolean}
- */
-PDFJS.disableWebGL = (PDFJS.disableWebGL === undefined ?
-                      true : PDFJS.disableWebGL);
-
-/**
  * Specifies the |target| attribute for external links.
  * The constants from PDFJS.LinkTarget should be used:
  *  - NONE [default]

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -121,14 +121,6 @@ PDFJS.disableFontFace = (PDFJS.disableFontFace === undefined ?
                          false : PDFJS.disableFontFace);
 
 /**
- * Path for image resources, mainly for annotation icons. Include trailing
- * slash.
- * @var {string}
- */
-PDFJS.imageResourcesPath = (PDFJS.imageResourcesPath === undefined ?
-                            '' : PDFJS.imageResourcesPath);
-
-/**
  * Disable the web worker and run all code on the main thread. This will
  * happen automatically if the browser doesn't support workers or sending
  * typed arrays to workers.

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -14,16 +14,13 @@
  */
 
 import {
-  addLinkAttributes, CustomStyle, DEFAULT_LINK_REL, getFilenameFromUrl,
-  isExternalLinkTargetSet, isValidUrl, LinkTarget
-} from './dom_utils';
-import {
   createBlob, createObjectURL, createPromiseCapability, getVerbosityLevel,
   InvalidPDFException, isLittleEndian, MissingPDFException, OPS, PageViewport,
   PasswordException, PasswordResponses, removeNullCharacters, setVerbosityLevel,
   shadow, UnexpectedResponseException, UnknownErrorException,
   UNSUPPORTED_FEATURES, Util, VERBOSITY_LEVELS
 } from '../shared/util';
+import { CustomStyle, getFilenameFromUrl } from './dom_utils';
 import {
   getDocument, LoopbackPort, PDFDataRangeTransport, PDFWorker
 } from './api';
@@ -67,7 +64,6 @@ Object.defineProperty(PDFJS, 'verbosity', {
 PDFJS.VERBOSITY_LEVELS = VERBOSITY_LEVELS;
 PDFJS.OPS = OPS;
 PDFJS.UNSUPPORTED_FEATURES = UNSUPPORTED_FEATURES;
-PDFJS.isValidUrl = isValidUrl;
 PDFJS.shadow = shadow;
 PDFJS.createBlob = createBlob;
 PDFJS.createObjectURL = function PDFJS_createObjectURL(data, contentType) {
@@ -195,27 +191,6 @@ PDFJS.disableCreateObjectURL = (PDFJS.disableCreateObjectURL === undefined ?
                                 false : PDFJS.disableCreateObjectURL);
 
 /**
- * Specifies the |target| attribute for external links.
- * The constants from PDFJS.LinkTarget should be used:
- *  - NONE [default]
- *  - SELF
- *  - BLANK
- *  - PARENT
- *  - TOP
- * @var {number}
- */
-PDFJS.externalLinkTarget = (PDFJS.externalLinkTarget === undefined ?
-                            LinkTarget.NONE : PDFJS.externalLinkTarget);
-
-/**
- * Specifies the |rel| attribute for external links. Defaults to stripping
- * the referrer.
- * @var {string}
- */
-PDFJS.externalLinkRel = (PDFJS.externalLinkRel === undefined ?
-                         DEFAULT_LINK_REL : PDFJS.externalLinkRel);
-
-/**
   * Determines if we can eval strings as JS. Primarily used to improve
   * performance for font rendering.
   * @var {boolean}
@@ -229,10 +204,7 @@ PDFJS.PDFDataRangeTransport = PDFDataRangeTransport;
 PDFJS.PDFWorker = PDFWorker;
 
 PDFJS.CustomStyle = CustomStyle;
-PDFJS.LinkTarget = LinkTarget;
-PDFJS.addLinkAttributes = addLinkAttributes;
 PDFJS.getFilenameFromUrl = getFilenameFromUrl;
-PDFJS.isExternalLinkTargetSet = isExternalLinkTargetSet;
 
 PDFJS.AnnotationLayer = AnnotationLayer;
 

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -72,5 +72,6 @@ exports.createBlob = pdfjsSharedUtil.createBlob;
 exports.RenderingCancelledException =
   pdfjsDisplayDOMUtils.RenderingCancelledException;
 exports.getFilenameFromUrl = pdfjsDisplayDOMUtils.getFilenameFromUrl;
+exports.LinkTarget = pdfjsDisplayDOMUtils.LinkTarget;
 exports.addLinkAttributes = pdfjsDisplayDOMUtils.addLinkAttributes;
 exports.StatTimer = pdfjsSharedUtil.StatTimer;

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -459,17 +459,6 @@ PDFJS.compatibilityChecked = true;
   }
 })();
 
-// Checks if navigator.language is supported
-(function checkNavigatorLanguage() {
-  if (typeof navigator === 'undefined') {
-    return;
-  }
-  if ('language' in navigator) {
-    return;
-  }
-  PDFJS.locale = navigator.userLanguage || 'en-US';
-})();
-
 // Support: Safari 6.0+, Android<3.0, Chrome 39/40, iOS
 (function checkRangeRequests() {
   // Safari has issues with cached range requests see:
@@ -485,20 +474,6 @@ PDFJS.compatibilityChecked = true;
   if (isSafari || isAndroidPre3 || isChromeWithRangeBug || isIOS) {
     PDFJS.disableRange = true;
     PDFJS.disableStream = true;
-  }
-})();
-
-// Check if the browser supports manipulation of the history.
-// Support: IE<10, Android<4.2
-(function checkHistoryManipulation() {
-  if (!hasDOM) {
-    return;
-  }
-  // Android 2.x has so buggy pushState support that it was removed in
-  // Android 3.0 and restored as late as in Android 4.2.
-  // Support: Android 2.x
-  if (!history.pushState || isAndroidPre3) {
-    PDFJS.disableHistory = true;
   }
 })();
 
@@ -582,25 +557,6 @@ PDFJS.compatibilityChecked = true;
     return;
   }
   installFakeAnimationFrameFunctions();
-})();
-
-// Support: Android, iOS
-(function checkCanvasSizeLimitation() {
-  if (isIOS || isAndroid) {
-    // 5MP
-    PDFJS.maxCanvasPixels = 5242880;
-  }
-})();
-
-// Disable fullscreen support for certain problematic configurations.
-// Support: IE11+ (when embedded).
-(function checkFullscreenSupport() {
-  if (!hasDOM) {
-    return;
-  }
-  if (isIE && window.parent !== window) {
-    PDFJS.disableFullscreen = true;
-  }
 })();
 
 // Provides document.currentScript support

--- a/test/driver.js
+++ b/test/driver.js
@@ -18,6 +18,7 @@
 
 var WAITING_TIME = 100; // ms
 var PDF_TO_CSS_UNITS = 96.0 / 72.0;
+const IMAGE_RESOURCES_PATH = '/web/images/';
 
 var StatTimer = pdfjsDistBuildPdf.StatTimer;
 
@@ -166,6 +167,7 @@ var rasterizeAnnotationLayer = (function rasterizeAnnotationLayerClosure() {
   }
 
   function rasterizeAnnotationLayer(ctx, viewport, annotations, page,
+                                    imageResourcesPath,
                                     renderInteractiveForms) {
     return new Promise(function (resolve) {
       // Building SVG with size of the viewport.
@@ -196,6 +198,7 @@ var rasterizeAnnotationLayer = (function rasterizeAnnotationLayerClosure() {
           annotations,
           page,
           linkService: new PDFJS.SimpleLinkService(),
+          imageResourcesPath,
           renderInteractiveForms,
         };
         PDFJS.AnnotationLayer.render(parameters);
@@ -254,7 +257,6 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
     PDFJS.cMapPacked = true;
     PDFJS.cMapUrl = '../external/bcmaps/';
     PDFJS.enableStats = true;
-    PDFJS.imageResourcesPath = '/web/images/';
 
     // Set the passed options
     this.inflight = options.inflight;
@@ -509,7 +511,9 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
                     function(annotations) {
                       return rasterizeAnnotationLayer(annotationLayerContext,
                                                       viewport, annotations,
-                                                      page, renderForms);
+                                                      page,
+                                                      IMAGE_RESOURCES_PATH,
+                                                      renderForms);
                   });
               } else {
                 annotationLayerCanvas = null;

--- a/test/unit/dom_utils_spec.js
+++ b/test/unit/dom_utils_spec.js
@@ -13,11 +13,8 @@
  * limitations under the License.
  */
 
-import {
-  DOMSVGFactory, getFilenameFromUrl, isExternalLinkTargetSet, LinkTarget
-} from '../../src/display/dom_utils';
+import { DOMSVGFactory, getFilenameFromUrl } from '../../src/display/dom_utils';
 import { isNodeJS } from '../../src/shared/util';
-import { PDFJS } from '../../src/display/global';
 
 describe('dom_utils', function() {
   describe('DOMSVGFactory', function() {
@@ -93,39 +90,6 @@ describe('dom_utils', function() {
       var result = getFilenameFromUrl(url);
       var expected = 'filename.pdf';
       expect(result).toEqual(expected);
-    });
-  });
-
-  describe('isExternalLinkTargetSet', function() {
-    var savedExternalLinkTarget;
-
-    beforeAll(function (done) {
-      savedExternalLinkTarget = PDFJS.externalLinkTarget;
-      done();
-    });
-
-    afterAll(function () {
-      PDFJS.externalLinkTarget = savedExternalLinkTarget;
-    });
-
-    it('handles the predefined LinkTargets', function() {
-      for (var key in LinkTarget) {
-        var linkTarget = LinkTarget[key];
-        PDFJS.externalLinkTarget = linkTarget;
-
-        expect(isExternalLinkTargetSet()).toEqual(!!linkTarget);
-      }
-    });
-
-    it('handles incorrect LinkTargets', function() {
-      var targets = [true, '', false, -1, '_blank', null];
-
-      for (var i = 0, ii = targets.length; i < ii; i++) {
-        var linkTarget = targets[i];
-        PDFJS.externalLinkTarget = linkTarget;
-
-        expect(isExternalLinkTargetSet()).toEqual(false);
-      }
     });
   });
 });

--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -21,6 +21,8 @@ import { SimpleLinkService } from './pdf_link_service';
  * @typedef {Object} AnnotationLayerBuilderOptions
  * @property {HTMLDivElement} pageDiv
  * @property {PDFPage} pdfPage
+ * @property {string} imageResourcesPath - (optional) Path for image resources,
+ *   mainly for annotation icons. Include trailing slash.
  * @property {boolean} renderInteractiveForms
  * @property {IPDFLinkService} linkService
  * @property {DownloadManager} downloadManager
@@ -32,11 +34,13 @@ class AnnotationLayerBuilder {
    * @param {AnnotationLayerBuilderOptions} options
    */
   constructor({ pageDiv, pdfPage, linkService, downloadManager,
-                renderInteractiveForms = false, l10n = NullL10n, }) {
+                imageResourcesPath = '', renderInteractiveForms = false,
+                l10n = NullL10n, }) {
     this.pageDiv = pageDiv;
     this.pdfPage = pdfPage;
     this.linkService = linkService;
     this.downloadManager = downloadManager;
+    this.imageResourcesPath = imageResourcesPath;
     this.renderInteractiveForms = renderInteractiveForms;
     this.l10n = l10n;
 
@@ -59,6 +63,7 @@ class AnnotationLayerBuilder {
         div: this.div,
         annotations,
         page: this.pdfPage,
+        imageResourcesPath: this.imageResourcesPath,
         renderInteractiveForms: this.renderInteractiveForms,
         linkService: this.linkService,
         downloadManager: this.downloadManager,
@@ -104,15 +109,19 @@ class DefaultAnnotationLayerFactory {
   /**
    * @param {HTMLDivElement} pageDiv
    * @param {PDFPage} pdfPage
+   * @param {string} imageResourcesPath - (optional) Path for image resources,
+   *   mainly for annotation icons. Include trailing slash.
    * @param {boolean} renderInteractiveForms
    * @param {IL10n} l10n
    * @returns {AnnotationLayerBuilder}
    */
-  createAnnotationLayerBuilder(pageDiv, pdfPage, renderInteractiveForms = false,
+  createAnnotationLayerBuilder(pageDiv, pdfPage, imageResourcesPath = '',
+                               renderInteractiveForms = false,
                                l10n = NullL10n) {
     return new AnnotationLayerBuilder({
       pageDiv,
       pdfPage,
+      imageResourcesPath,
       renderInteractiveForms,
       linkService: new SimpleLinkService(),
       l10n,

--- a/web/app.js
+++ b/web/app.js
@@ -144,6 +144,7 @@ let PDFViewerApplication = {
     disablePageMode: false,
     disablePageLabels: false,
     renderer: 'canvas',
+    disableTextLayer: false,
     enhanceTextSelection: false,
     renderInteractiveForms: false,
     enablePrintAutoRotate: false,
@@ -195,7 +196,7 @@ let PDFViewerApplication = {
    * @private
    */
   _readPreferences() {
-    let { preferences, viewerPrefs, } = this;
+    let { appConfig, preferences, viewerPrefs, } = this;
 
     return Promise.all([
       preferences.get('enableWebGL').then(function resolved(value) {
@@ -217,10 +218,8 @@ let PDFViewerApplication = {
         viewerPrefs['enhanceTextSelection'] = value;
       }),
       preferences.get('disableTextLayer').then(function resolved(value) {
-        if (PDFJS.disableTextLayer === true) {
-          return;
-        }
-        PDFJS.disableTextLayer = value;
+        viewerPrefs['disableTextLayer'] =
+          appConfig.viewerParameters['disableTextLayer'] || value;
       }),
       preferences.get('disableRange').then(function resolved(value) {
         if (PDFJS.disableRange === true) {
@@ -322,7 +321,7 @@ let PDFViewerApplication = {
       if ('textlayer' in hashParams) {
         switch (hashParams['textlayer']) {
           case 'off':
-            PDFJS.disableTextLayer = true;
+            viewerPrefs['disableTextLayer'] = true;
             break;
           case 'visible':
           case 'shadow':
@@ -395,6 +394,7 @@ let PDFViewerApplication = {
         downloadManager,
         renderer: viewerPrefs['renderer'],
         l10n: this.l10n,
+        disableTextLayer: viewerPrefs['disableTextLayer'],
         enhanceTextSelection: viewerPrefs['enhanceTextSelection'],
         renderInteractiveForms: viewerPrefs['renderInteractiveForms'],
         enablePrintAutoRotate: viewerPrefs['enablePrintAutoRotate'],

--- a/web/app.js
+++ b/web/app.js
@@ -162,6 +162,8 @@ let PDFViewerApplication = {
     this.appConfig = appConfig;
 
     return this._readPreferences().then(() => {
+      return this._parseHashParameters();
+    }).then(() => {
       return this._initializeL10n();
     }).then(() => {
       return this._initializeViewerComponents();
@@ -268,19 +270,90 @@ let PDFViewerApplication = {
     ]).catch(function(reason) { });
   },
 
-  _initializeL10n() {
-    // Locale can be changed only when special debugging flags is present in
-    // the hash section of the URL, or development version of viewer is used.
-    // It is not possible to change locale for Firefox extension builds.
+  /**
+   * @private
+   */
+  _parseHashParameters() {
+    let { appConfig, viewerPrefs, } = this;
+    let waitOn = [];
+
     if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION') ||
-        (!PDFJSDev.test('FIREFOX || MOZCENTRAL') &&
-         this.viewerPrefs['pdfBugEnabled'])) {
+        viewerPrefs['pdfBugEnabled']) {
+      // Special debugging flags in the hash section of the URL.
       let hash = document.location.hash.substring(1);
       let hashParams = parseQueryString(hash);
-      if ('locale' in hashParams) {
+
+      if ('disableworker' in hashParams) {
+        PDFJS.disableWorker = (hashParams['disableworker'] === 'true');
+      }
+      if ('disablerange' in hashParams) {
+        PDFJS.disableRange = (hashParams['disablerange'] === 'true');
+      }
+      if ('disablestream' in hashParams) {
+        PDFJS.disableStream = (hashParams['disablestream'] === 'true');
+      }
+      if ('disableautofetch' in hashParams) {
+        PDFJS.disableAutoFetch = (hashParams['disableautofetch'] === 'true');
+      }
+      if ('disablefontface' in hashParams) {
+        PDFJS.disableFontFace = (hashParams['disablefontface'] === 'true');
+      }
+      if ('disablehistory' in hashParams) {
+        PDFJS.disableHistory = (hashParams['disablehistory'] === 'true');
+      }
+      if ('webgl' in hashParams) {
+        PDFJS.disableWebGL = (hashParams['webgl'] !== 'true');
+      }
+      if ('useonlycsszoom' in hashParams) {
+        PDFJS.useOnlyCssZoom = (hashParams['useonlycsszoom'] === 'true');
+      }
+      if ('verbosity' in hashParams) {
+        PDFJS.verbosity = hashParams['verbosity'] | 0;
+      }
+      if ('ignorecurrentpositiononzoom' in hashParams) {
+        PDFJS.ignoreCurrentPositionOnZoom =
+          (hashParams['ignorecurrentpositiononzoom'] === 'true');
+      }
+      if ((typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION')) &&
+          hashParams['disablebcmaps'] === 'true') {
+        PDFJS.cMapUrl = '../external/cmaps/';
+        PDFJS.cMapPacked = false;
+      }
+      if ('textlayer' in hashParams) {
+        switch (hashParams['textlayer']) {
+          case 'off':
+            PDFJS.disableTextLayer = true;
+            break;
+          case 'visible':
+          case 'shadow':
+          case 'hover':
+            let viewer = appConfig.viewerContainer;
+            viewer.classList.add('textLayer-' + hashParams['textlayer']);
+            break;
+        }
+      }
+      if ('pdfbug' in hashParams) {
+        PDFJS.pdfBug = true;
+        let pdfBug = hashParams['pdfbug'];
+        let enabled = pdfBug.split(',');
+        waitOn.push(loadAndEnablePDFBug(enabled));
+      }
+      // Locale can be changed only when special debugging flags is present in
+      // the hash section of the URL, or development version of viewer is used.
+      // It is not possible to change locale for Firefox extension builds.
+      if ((typeof PDFJSDev === 'undefined' ||
+           !PDFJSDev.test('FIREFOX || MOZCENTRAL')) && 'locale' in hashParams) {
         PDFJS.locale = hashParams['locale'];
       }
     }
+
+    return Promise.all(waitOn);
+  },
+
+  /**
+   * @private
+   */
+  _initializeL10n() {
     this.l10n = this.externalServices.createL10n();
     return this.l10n.getDirection().then((dir) => {
       document.getElementsByTagName('html')[0].dir = dir;
@@ -291,7 +364,7 @@ let PDFViewerApplication = {
    * @private
    */
   _initializeViewerComponents() {
-    let appConfig = this.appConfig;
+    let { appConfig, viewerPrefs, } = this;
 
     return new Promise((resolve, reject) => {
       this.overlayManager = new OverlayManager();
@@ -320,11 +393,11 @@ let PDFViewerApplication = {
         renderingQueue: pdfRenderingQueue,
         linkService: pdfLinkService,
         downloadManager,
-        renderer: this.viewerPrefs['renderer'],
+        renderer: viewerPrefs['renderer'],
         l10n: this.l10n,
-        enhanceTextSelection: this.viewerPrefs['enhanceTextSelection'],
-        renderInteractiveForms: this.viewerPrefs['renderInteractiveForms'],
-        enablePrintAutoRotate: this.viewerPrefs['enablePrintAutoRotate'],
+        enhanceTextSelection: viewerPrefs['enhanceTextSelection'],
+        renderInteractiveForms: viewerPrefs['renderInteractiveForms'],
+        enablePrintAutoRotate: viewerPrefs['enablePrintAutoRotate'],
       });
       pdfRenderingQueue.setViewer(this.pdfViewer);
       pdfLinkService.setViewer(this.pdfViewer);
@@ -1461,7 +1534,6 @@ function webViewerInitialized() {
     file = appConfig.defaultUrl;
   }
 
-  let waitForBeforeOpening = [];
   if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
     let fileInput = document.createElement('input');
     fileInput.id = appConfig.openFileInputName;
@@ -1490,70 +1562,6 @@ function webViewerInitialized() {
   } else {
     appConfig.toolbar.openFile.setAttribute('hidden', 'true');
     appConfig.secondaryToolbar.openFileButton.setAttribute('hidden', 'true');
-  }
-
-  if ((typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION')) ||
-      PDFViewerApplication.viewerPrefs['pdfBugEnabled']) {
-    // Special debugging flags in the hash section of the URL.
-    let hash = document.location.hash.substring(1);
-    let hashParams = parseQueryString(hash);
-
-    if ('disableworker' in hashParams) {
-      PDFJS.disableWorker = (hashParams['disableworker'] === 'true');
-    }
-    if ('disablerange' in hashParams) {
-      PDFJS.disableRange = (hashParams['disablerange'] === 'true');
-    }
-    if ('disablestream' in hashParams) {
-      PDFJS.disableStream = (hashParams['disablestream'] === 'true');
-    }
-    if ('disableautofetch' in hashParams) {
-      PDFJS.disableAutoFetch = (hashParams['disableautofetch'] === 'true');
-    }
-    if ('disablefontface' in hashParams) {
-      PDFJS.disableFontFace = (hashParams['disablefontface'] === 'true');
-    }
-    if ('disablehistory' in hashParams) {
-      PDFJS.disableHistory = (hashParams['disablehistory'] === 'true');
-    }
-    if ('webgl' in hashParams) {
-      PDFJS.disableWebGL = (hashParams['webgl'] !== 'true');
-    }
-    if ('useonlycsszoom' in hashParams) {
-      PDFJS.useOnlyCssZoom = (hashParams['useonlycsszoom'] === 'true');
-    }
-    if ('verbosity' in hashParams) {
-      PDFJS.verbosity = hashParams['verbosity'] | 0;
-    }
-    if ('ignorecurrentpositiononzoom' in hashParams) {
-      PDFJS.ignoreCurrentPositionOnZoom =
-        (hashParams['ignorecurrentpositiononzoom'] === 'true');
-    }
-    if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION')) {
-      if ('disablebcmaps' in hashParams && hashParams['disablebcmaps']) {
-        PDFJS.cMapUrl = '../external/cmaps/';
-        PDFJS.cMapPacked = false;
-      }
-    }
-    if ('textlayer' in hashParams) {
-      switch (hashParams['textlayer']) {
-        case 'off':
-          PDFJS.disableTextLayer = true;
-          break;
-        case 'visible':
-        case 'shadow':
-        case 'hover':
-          let viewer = appConfig.viewerContainer;
-          viewer.classList.add('textLayer-' + hashParams['textlayer']);
-          break;
-      }
-    }
-    if ('pdfbug' in hashParams) {
-      PDFJS.pdfBug = true;
-      let pdfBug = hashParams['pdfbug'];
-      let enabled = pdfBug.split(',');
-      waitForBeforeOpening.push(loadAndEnablePDFBug(enabled));
-    }
   }
 
   if (typeof PDFJSDev !== 'undefined' &&
@@ -1591,14 +1599,14 @@ function webViewerInitialized() {
     PDFViewerApplication.pdfSidebar.toggle();
   });
 
-  Promise.all(waitForBeforeOpening).then(function () {
+  try {
     webViewerOpenFileViaURL(file);
-  }).catch(function (reason) {
+  } catch (reason) {
     PDFViewerApplication.l10n.get('loading_error', null,
         'An error occurred while opening.').then((msg) => {
       PDFViewerApplication.error(msg, reason);
     });
-  });
+  }
 }
 
 let webViewerOpenFileViaURL;

--- a/web/app.js
+++ b/web/app.js
@@ -145,6 +145,7 @@ let PDFViewerApplication = {
     disablePageLabels: false,
     renderer: 'canvas',
     enableWebGL: false,
+    useOnlyCssZoom: false,
     disableTextLayer: false,
     enhanceTextSelection: false,
     renderInteractiveForms: false,
@@ -244,7 +245,7 @@ let PDFViewerApplication = {
         PDFJS.disableFontFace = value;
       }),
       preferences.get('useOnlyCssZoom').then(function resolved(value) {
-        PDFJS.useOnlyCssZoom = value;
+        viewerPrefs['useOnlyCssZoom'] = value;
       }),
       preferences.get('externalLinkTarget').then(function resolved(value) {
         if (PDFJS.isExternalLinkTargetSet()) {
@@ -305,7 +306,7 @@ let PDFViewerApplication = {
         viewerPrefs['enableWebGL'] = (hashParams['webgl'] === 'true');
       }
       if ('useonlycsszoom' in hashParams) {
-        PDFJS.useOnlyCssZoom = (hashParams['useonlycsszoom'] === 'true');
+        viewerPrefs['useOnlyCssZoom'] = hashParams['useonlycsszoom'] === 'true';
       }
       if ('verbosity' in hashParams) {
         PDFJS.verbosity = hashParams['verbosity'] | 0;
@@ -400,6 +401,7 @@ let PDFViewerApplication = {
         renderInteractiveForms: viewerPrefs['renderInteractiveForms'],
         enablePrintAutoRotate: viewerPrefs['enablePrintAutoRotate'],
         enableWebGL: viewerPrefs['enableWebGL'],
+        useOnlyCssZoom: viewerPrefs['useOnlyCssZoom'],
       });
       pdfRenderingQueue.setViewer(this.pdfViewer);
       pdfLinkService.setViewer(this.pdfViewer);

--- a/web/app.js
+++ b/web/app.js
@@ -50,7 +50,6 @@ const DEFAULT_SCALE_DELTA = 1.1;
 const DISABLE_AUTO_FETCH_LOADING_BAR_TIMEOUT = 5000;
 
 function configure(appConfig, PDFJS) {
-  PDFJS.imageResourcesPath = './images/';
   if (typeof PDFJSDev !== 'undefined' &&
       PDFJSDev.test('FIREFOX || MOZCENTRAL || GENERIC || CHROME')) {
     PDFJS.workerSrc = '../build/pdf.worker.js';
@@ -400,6 +399,7 @@ let PDFViewerApplication = {
         renderer: viewerPrefs['renderer'],
         l10n: this.l10n,
         disableTextLayer: viewerPrefs['disableTextLayer'],
+        imageResourcesPath: appConfig.viewerParameters['imageResourcesPath'],
         enhanceTextSelection: viewerPrefs['enhanceTextSelection'],
         renderInteractiveForms: viewerPrefs['renderInteractiveForms'],
         enablePrintAutoRotate: viewerPrefs['enablePrintAutoRotate'],

--- a/web/app.js
+++ b/web/app.js
@@ -144,6 +144,7 @@ let PDFViewerApplication = {
     disablePageMode: false,
     disablePageLabels: false,
     renderer: 'canvas',
+    enableWebGL: false,
     disableTextLayer: false,
     enhanceTextSelection: false,
     renderInteractiveForms: false,
@@ -200,7 +201,7 @@ let PDFViewerApplication = {
 
     return Promise.all([
       preferences.get('enableWebGL').then(function resolved(value) {
-        PDFJS.disableWebGL = !value;
+        viewerPrefs['enableWebGL'] = value;
       }),
       preferences.get('sidebarViewOnLoad').then(function resolved(value) {
         viewerPrefs['sidebarViewOnLoad'] = value;
@@ -301,7 +302,7 @@ let PDFViewerApplication = {
         PDFJS.disableHistory = (hashParams['disablehistory'] === 'true');
       }
       if ('webgl' in hashParams) {
-        PDFJS.disableWebGL = (hashParams['webgl'] !== 'true');
+        viewerPrefs['enableWebGL'] = (hashParams['webgl'] === 'true');
       }
       if ('useonlycsszoom' in hashParams) {
         PDFJS.useOnlyCssZoom = (hashParams['useonlycsszoom'] === 'true');
@@ -398,6 +399,7 @@ let PDFViewerApplication = {
         enhanceTextSelection: viewerPrefs['enhanceTextSelection'],
         renderInteractiveForms: viewerPrefs['renderInteractiveForms'],
         enablePrintAutoRotate: viewerPrefs['enablePrintAutoRotate'],
+        enableWebGL: viewerPrefs['enableWebGL'],
       });
       pdfRenderingQueue.setViewer(this.pdfViewer);
       pdfLinkService.setViewer(this.pdfViewer);
@@ -1157,7 +1159,7 @@ let PDFViewerApplication = {
                   info.PDFFormatVersion + ' ' + (info.Producer || '-').trim() +
                   ' / ' + (info.Creator || '-').trim() + ']' +
                   ' (PDF.js: ' + (version || '-') +
-                  (!PDFJS.disableWebGL ? ' [WebGL]' : '') + ')');
+                  (this.viewerPrefs['enableWebGL'] ? ' [WebGL]' : '') + ')');
 
       let pdfTitle;
       if (metadata && metadata.has('dc:title')) {

--- a/web/app.js
+++ b/web/app.js
@@ -311,10 +311,6 @@ let PDFViewerApplication = {
       if ('verbosity' in hashParams) {
         PDFJS.verbosity = hashParams['verbosity'] | 0;
       }
-      if ('ignorecurrentpositiononzoom' in hashParams) {
-        PDFJS.ignoreCurrentPositionOnZoom =
-          (hashParams['ignorecurrentpositiononzoom'] === 'true');
-      }
       if ((typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION')) &&
           hashParams['disablebcmaps'] === 'true') {
         PDFJS.cMapUrl = '../external/cmaps/';

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -50,6 +50,8 @@ const DEFAULT_CACHE_SIZE = 10;
  *   rotation of pages whose orientation differ from the first page upon
  *   printing. The default is `false`.
  * @property {string} renderer - 'canvas' or 'svg'. The default is 'canvas'.
+ * @property {boolean} enableWebGL - (optional) Enables WebGL accelerated
+ *   rendering for some operations. The default is `false`.
  * @property {IL10n} l10n - Localization service.
  */
 
@@ -114,6 +116,7 @@ class BaseViewer {
     this.renderInteractiveForms = options.renderInteractiveForms || false;
     this.enablePrintAutoRotate = options.enablePrintAutoRotate || false;
     this.renderer = options.renderer || RendererType.CANVAS;
+    this.enableWebGL = options.enableWebGL || false;
     this.l10n = options.l10n || NullL10n;
 
     this.defaultRenderingQueue = !options.renderingQueue;
@@ -380,6 +383,7 @@ class BaseViewer {
           enhanceTextSelection: this.enhanceTextSelection,
           renderInteractiveForms: this.renderInteractiveForms,
           renderer: this.renderer,
+          enableWebGL: this.enableWebGL,
           l10n: this.l10n,
         });
         bindOnAfterAndBeforeDraw(pageView);

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -516,7 +516,7 @@ class BaseViewer {
 
     if (!noScroll) {
       let page = this._currentPageNumber, dest;
-      if (this._location && !PDFJS.ignoreCurrentPositionOnZoom &&
+      if (this._location &&
           !(this.isInPresentationMode || this.isChangingPresentationMode)) {
         page = this._location.pageNumber;
         dest = [null, { name: 'XYZ', }, this._location.left,

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -40,6 +40,8 @@ const DEFAULT_CACHE_SIZE = 10;
  *   queue object.
  * @property {boolean} removePageBorders - (optional) Removes the border shadow
  *   around the pages. The default is false.
+ * @property {boolean} disableTextLayer - (optional) Disables creation of the
+ *   text layer used for selection and searching. The default is `false`.
  * @property {boolean} enhanceTextSelection - (optional) Enables the improved
  *   text selection behaviour. The default is `false`.
  * @property {boolean} renderInteractiveForms - (optional) Enables rendering of
@@ -107,6 +109,7 @@ class BaseViewer {
     this.linkService = options.linkService || new SimpleLinkService();
     this.downloadManager = options.downloadManager || null;
     this.removePageBorders = options.removePageBorders || false;
+    this.disableTextLayer = options.disableTextLayer || false;
     this.enhanceTextSelection = options.enhanceTextSelection || false;
     this.renderInteractiveForms = options.renderInteractiveForms || false;
     this.enablePrintAutoRotate = options.enablePrintAutoRotate || false;
@@ -362,7 +365,7 @@ class BaseViewer {
       let viewport = pdfPage.getViewport(scale * CSS_UNITS);
       for (let pageNum = 1; pageNum <= pagesCount; ++pageNum) {
         let textLayerFactory = null;
-        if (!PDFJS.disableTextLayer) {
+        if (!this.disableTextLayer) {
           textLayerFactory = this;
         }
         let pageView = new PDFPageView({

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -52,6 +52,8 @@ const DEFAULT_CACHE_SIZE = 10;
  * @property {string} renderer - 'canvas' or 'svg'. The default is 'canvas'.
  * @property {boolean} enableWebGL - (optional) Enables WebGL accelerated
  *   rendering for some operations. The default is `false`.
+ * @property {boolean} useOnlyCssZoom - (optional) Enables CSS only zooming.
+ *   The default is `false`.
  * @property {IL10n} l10n - Localization service.
  */
 
@@ -117,6 +119,7 @@ class BaseViewer {
     this.enablePrintAutoRotate = options.enablePrintAutoRotate || false;
     this.renderer = options.renderer || RendererType.CANVAS;
     this.enableWebGL = options.enableWebGL || false;
+    this.useOnlyCssZoom = options.useOnlyCssZoom || false;
     this.l10n = options.l10n || NullL10n;
 
     this.defaultRenderingQueue = !options.renderingQueue;
@@ -384,6 +387,7 @@ class BaseViewer {
           renderInteractiveForms: this.renderInteractiveForms,
           renderer: this.renderer,
           enableWebGL: this.enableWebGL,
+          useOnlyCssZoom: this.useOnlyCssZoom,
           l10n: this.l10n,
         });
         bindOnAfterAndBeforeDraw(pageView);

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -54,6 +54,9 @@ const DEFAULT_CACHE_SIZE = 10;
  *   rendering for some operations. The default is `false`.
  * @property {boolean} useOnlyCssZoom - (optional) Enables CSS only zooming.
  *   The default is `false`.
+ * @property {number} maxCanvasPixels - (optional) The maximum supported canvas
+ *   size in total pixels, i.e. width * height. Use -1 for no limit.
+ *   The default value is 4096 * 4096 (16 mega-pixels).
  * @property {IL10n} l10n - Localization service.
  */
 
@@ -120,6 +123,7 @@ class BaseViewer {
     this.renderer = options.renderer || RendererType.CANVAS;
     this.enableWebGL = options.enableWebGL || false;
     this.useOnlyCssZoom = options.useOnlyCssZoom || false;
+    this.maxCanvasPixels = options.maxCanvasPixels || null;
     this.l10n = options.l10n || NullL10n;
 
     this.defaultRenderingQueue = !options.renderingQueue;
@@ -388,6 +392,7 @@ class BaseViewer {
           renderer: this.renderer,
           enableWebGL: this.enableWebGL,
           useOnlyCssZoom: this.useOnlyCssZoom,
+          maxCanvasPixels: this.maxCanvasPixels,
           l10n: this.l10n,
         });
         bindOnAfterAndBeforeDraw(pageView);

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -44,6 +44,8 @@ const DEFAULT_CACHE_SIZE = 10;
  *   text layer used for selection and searching. The default is `false`.
  * @property {boolean} enhanceTextSelection - (optional) Enables the improved
  *   text selection behaviour. The default is `false`.
+ * @property {string} imageResourcesPath - (optional) Path for image resources,
+ *   mainly for annotation icons. Include trailing slash.
  * @property {boolean} renderInteractiveForms - (optional) Enables rendering of
  *   interactive form elements. The default is `false`.
  * @property {boolean} enablePrintAutoRotate - (optional) Enables automatic
@@ -118,6 +120,7 @@ class BaseViewer {
     this.removePageBorders = options.removePageBorders || false;
     this.disableTextLayer = options.disableTextLayer || false;
     this.enhanceTextSelection = options.enhanceTextSelection || false;
+    this.imageResourcesPath = options.imageResourcesPath || '';
     this.renderInteractiveForms = options.renderInteractiveForms || false;
     this.enablePrintAutoRotate = options.enablePrintAutoRotate || false;
     this.renderer = options.renderer || RendererType.CANVAS;
@@ -388,6 +391,7 @@ class BaseViewer {
           textLayerFactory,
           annotationLayerFactory: this,
           enhanceTextSelection: this.enhanceTextSelection,
+          imageResourcesPath: this.imageResourcesPath,
           renderInteractiveForms: this.renderInteractiveForms,
           renderer: this.renderer,
           enableWebGL: this.enableWebGL,
@@ -888,15 +892,19 @@ class BaseViewer {
   /**
    * @param {HTMLDivElement} pageDiv
    * @param {PDFPage} pdfPage
+   * @param {string} imageResourcesPath - (optional) Path for image resources,
+   *   mainly for annotation icons. Include trailing slash.
    * @param {boolean} renderInteractiveForms
    * @param {IL10n} l10n
    * @returns {AnnotationLayerBuilder}
    */
-  createAnnotationLayerBuilder(pageDiv, pdfPage, renderInteractiveForms = false,
+  createAnnotationLayerBuilder(pageDiv, pdfPage, imageResourcesPath = '',
+                               renderInteractiveForms = false,
                                l10n = NullL10n) {
     return new AnnotationLayerBuilder({
       pageDiv,
       pdfPage,
+      imageResourcesPath,
       renderInteractiveForms,
       linkService: this.linkService,
       downloadManager: this.downloadManager,

--- a/web/genericcom.js
+++ b/web/genericcom.js
@@ -17,7 +17,6 @@ import { DefaultExternalServices, PDFViewerApplication } from './app';
 import { BasePreferences } from './preferences';
 import { DownloadManager } from './download_manager';
 import { GenericL10n } from './genericl10n';
-import { PDFJS } from 'pdfjs-lib';
 
 if (typeof PDFJSDev !== 'undefined' && !PDFJSDev.test('GENERIC')) {
   throw new Error('Module "pdfjs-web/genericcom" shall not be used outside ' +
@@ -50,7 +49,8 @@ GenericExternalServices.createPreferences = function() {
   return new GenericPreferences();
 };
 GenericExternalServices.createL10n = function () {
-  return new GenericL10n(PDFJS.locale);
+  let { viewerParameters, } = PDFViewerApplication.appConfig;
+  return new GenericL10n(viewerParameters.locale);
 };
 PDFViewerApplication.externalServices = GenericExternalServices;
 

--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -146,10 +146,12 @@ class IPDFAnnotationLayerFactory {
    * @param {HTMLDivElement} pageDiv
    * @param {PDFPage} pdfPage
    * @param {IL10n} l10n
+   * @param {string} imageResourcesPath - (optional) Path for image resources,
+   *   mainly for annotation icons. Include trailing slash.
    * @param {boolean} renderInteractiveForms
    * @returns {AnnotationLayerBuilder}
    */
-  createAnnotationLayerBuilder(pageDiv, pdfPage,
+  createAnnotationLayerBuilder(pageDiv, pdfPage, imageResourcesPath = '',
                                renderInteractiveForms = false,
                                l10n = undefined) {}
 }

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -19,6 +19,10 @@ import { parseQueryString } from './ui_utils';
 /**
  * @typedef {Object} PDFLinkServiceOptions
  * @property {EventBus} eventBus - The application event bus.
+ * @property {number} externalLinkTarget - (optional) Specifies the `target`
+ *   attribute for external links. Must use one of the values from {LinkTarget}.
+ * @property {string} externalLinkRel - (optional) Specifies the `rel` attribute
+ *   for external links. Defaults to stripping the referrer.
  */
 
 /**
@@ -30,8 +34,12 @@ class PDFLinkService {
   /**
    * @param {PDFLinkServiceOptions} options
    */
-  constructor({ eventBus, } = {}) {
+  constructor({ eventBus, externalLinkTarget = null,
+                externalLinkRel = null, } = {}) {
     this.eventBus = eventBus || getGlobalEventBus();
+    this.externalLinkTarget = externalLinkTarget;
+    this.externalLinkRel = externalLinkRel;
+
     this.baseUrl = null;
     this.pdfDocument = null;
     this.pdfViewer = null;

--- a/web/pdf_outline_viewer.js
+++ b/web/pdf_outline_viewer.js
@@ -14,7 +14,7 @@
  */
 
 import {
-  addLinkAttributes, PDFJS, removeNullCharacters
+  addLinkAttributes, LinkTarget, removeNullCharacters
 } from 'pdfjs-lib';
 
 const DEFAULT_TITLE = '\u2013';
@@ -68,20 +68,22 @@ class PDFOutlineViewer {
   /**
    * @private
    */
-  _bindLink(element, item) {
-    if (item.url) {
+  _bindLink(element, { url, newWindow, dest, }) {
+    let { linkService, } = this;
+
+    if (url) {
       addLinkAttributes(element, {
-        url: item.url,
-        target: (item.newWindow ? PDFJS.LinkTarget.BLANK : undefined),
+        url,
+        target: (newWindow ? LinkTarget.BLANK : linkService.externalLinkTarget),
+        rel: linkService.externalLinkRel,
       });
       return;
     }
-    let destination = item.dest;
 
-    element.href = this.linkService.getDestinationHash(destination);
+    element.href = linkService.getDestinationHash(dest);
     element.onclick = () => {
-      if (destination) {
-        this.linkService.navigateTo(destination);
+      if (dest) {
+        linkService.navigateTo(dest);
       }
       return false;
     };
@@ -90,12 +92,12 @@ class PDFOutlineViewer {
   /**
    * @private
    */
-  _setStyles(element, item) {
+  _setStyles(element, { bold, italic, }) {
     let styleStr = '';
-    if (item.bold) {
+    if (bold) {
       styleStr += 'font-weight: bold;';
     }
-    if (item.italic) {
+    if (italic) {
       styleStr += 'font-style: italic;';
     }
 

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -36,6 +36,8 @@ import { viewerCompatibilityParams } from './viewer_compatibility';
  * @property {IPDFAnnotationLayerFactory} annotationLayerFactory
  * @property {boolean} enhanceTextSelection - Turns on the text selection
  *   enhancement. The default is `false`.
+ * @property {string} imageResourcesPath - (optional) Path for image resources,
+ *   mainly for annotation icons. Include trailing slash.
  * @property {boolean} renderInteractiveForms - Turns on rendering of
  *   interactive form elements. The default is `false`.
  * @property {string} renderer - 'canvas' or 'svg'. The default is 'canvas'.
@@ -72,6 +74,7 @@ class PDFPageView {
     this.pdfPageRotate = defaultViewport.rotation;
     this.hasRestrictedScaling = false;
     this.enhanceTextSelection = options.enhanceTextSelection || false;
+    this.imageResourcesPath = options.imageResourcesPath || '';
     this.renderInteractiveForms = options.renderInteractiveForms || false;
     this.enableWebGL = options.enableWebGL || false;
     this.useOnlyCssZoom = options.useOnlyCssZoom || false;
@@ -477,7 +480,7 @@ class PDFPageView {
     if (this.annotationLayerFactory) {
       if (!this.annotationLayer) {
         this.annotationLayer = this.annotationLayerFactory.
-          createAnnotationLayerBuilder(div, pdfPage,
+          createAnnotationLayerBuilder(div, pdfPage, this.imageResourcesPath,
                                        this.renderInteractiveForms, this.l10n);
       }
       this.annotationLayer.render(this.viewport, 'display');

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -41,6 +41,8 @@ import { RenderingStates } from './pdf_rendering_queue';
  * @property {string} renderer - 'canvas' or 'svg'. The default is 'canvas'.
  * @property {boolean} enableWebGL - (optional) Enables WebGL accelerated
  *   rendering for some operations. The default is `false`.
+ * @property {boolean} useOnlyCssZoom - (optional) Enables CSS only zooming.
+ *   The default is `false`.
  * @property {IL10n} l10n - Localization service.
  */
 
@@ -68,6 +70,7 @@ class PDFPageView {
     this.enhanceTextSelection = options.enhanceTextSelection || false;
     this.renderInteractiveForms = options.renderInteractiveForms || false;
     this.enableWebGL = options.enableWebGL || false;
+    this.useOnlyCssZoom = options.useOnlyCssZoom || false;
 
     this.eventBus = options.eventBus || getGlobalEventBus();
     this.renderingQueue = options.renderingQueue;
@@ -222,7 +225,7 @@ class PDFPageView {
     }
 
     if (this.canvas) {
-      if (PDFJS.useOnlyCssZoom ||
+      if (this.useOnlyCssZoom ||
           (this.hasRestrictedScaling && isScalingRestricted)) {
         this.cssTransform(this.canvas, true);
 
@@ -520,7 +523,7 @@ class PDFPageView {
     let outputScale = getOutputScale(ctx);
     this.outputScale = outputScale;
 
-    if (PDFJS.useOnlyCssZoom) {
+    if (this.useOnlyCssZoom) {
       let actualSizeViewport = viewport.clone({ scale: CSS_UNITS, });
       // Use a scale that makes the canvas have the originally intended size
       // of the page.

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -39,6 +39,8 @@ import { RenderingStates } from './pdf_rendering_queue';
  * @property {boolean} renderInteractiveForms - Turns on rendering of
  *   interactive form elements. The default is `false`.
  * @property {string} renderer - 'canvas' or 'svg'. The default is 'canvas'.
+ * @property {boolean} enableWebGL - (optional) Enables WebGL accelerated
+ *   rendering for some operations. The default is `false`.
  * @property {IL10n} l10n - Localization service.
  */
 
@@ -65,6 +67,7 @@ class PDFPageView {
     this.hasRestrictedScaling = false;
     this.enhanceTextSelection = options.enhanceTextSelection || false;
     this.renderInteractiveForms = options.renderInteractiveForms || false;
+    this.enableWebGL = options.enableWebGL || false;
 
     this.eventBus = options.eventBus || getGlobalEventBus();
     this.renderingQueue = options.renderingQueue;
@@ -555,6 +558,7 @@ class PDFPageView {
       canvasContext: ctx,
       transform,
       viewport: this.viewport,
+      enableWebGL: this.enableWebGL,
       renderInteractiveForms: this.renderInteractiveForms,
     };
     let renderTask = this.pdfPage.render(renderContext);

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -96,13 +96,6 @@ PDFJS.disableHistory = (PDFJS.disableHistory === undefined ?
                         false : PDFJS.disableHistory);
 
 /**
- * Disables creation of the text layer that used for text selection and search.
- * @var {boolean}
- */
-PDFJS.disableTextLayer = (PDFJS.disableTextLayer === undefined ?
-                          false : PDFJS.disableTextLayer);
-
-/**
  * Disables maintaining the current position in the document when zooming.
  */
 PDFJS.ignoreCurrentPositionOnZoom = (PDFJS.ignoreCurrentPositionOnZoom ===

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -74,13 +74,6 @@ PDFJS.disableFullscreen = (PDFJS.disableFullscreen === undefined ?
                            false : PDFJS.disableFullscreen);
 
 /**
- * Enables CSS only zooming.
- * @var {boolean}
- */
-PDFJS.useOnlyCssZoom = (PDFJS.useOnlyCssZoom === undefined ?
-                        false : PDFJS.useOnlyCssZoom);
-
-/**
  * The maximum supported canvas size in total pixels e.g. width * height.
  * The default value is 4096 * 4096. Use -1 for no limit.
  * @var {number}

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { createPromiseCapability, PDFJS } from 'pdfjs-lib';
+import { createPromiseCapability } from 'pdfjs-lib';
 
 const CSS_UNITS = 96.0 / 72.0;
 const DEFAULT_SCALE_VALUE = 'auto';
@@ -64,40 +64,6 @@ let NullL10n = {
     return Promise.resolve();
   },
 };
-
-/**
- * Disables fullscreen support, and by extension Presentation Mode,
- * in browsers which support the fullscreen API.
- * @var {boolean}
- */
-PDFJS.disableFullscreen = (PDFJS.disableFullscreen === undefined ?
-                           false : PDFJS.disableFullscreen);
-
-/**
- * The maximum supported canvas size in total pixels e.g. width * height.
- * The default value is 4096 * 4096. Use -1 for no limit.
- * @var {number}
- */
-PDFJS.maxCanvasPixels = (PDFJS.maxCanvasPixels === undefined ?
-                         16777216 : PDFJS.maxCanvasPixels);
-
-/**
- * Disables saving of the last position of the viewed PDF.
- * @var {boolean}
- */
-PDFJS.disableHistory = (PDFJS.disableHistory === undefined ?
-                        false : PDFJS.disableHistory);
-
-if (typeof PDFJSDev === 'undefined' ||
-    !PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
-  /**
-   * Interface locale settings.
-   * @var {string}
-   */
-  PDFJS.locale =
-    (PDFJS.locale === undefined && typeof navigator !== 'undefined' ?
-     navigator.language : PDFJS.locale);
-}
 
 /**
  * Returns scale factor for the canvas. It makes sense for the HiDPI displays.

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -88,12 +88,6 @@ PDFJS.maxCanvasPixels = (PDFJS.maxCanvasPixels === undefined ?
 PDFJS.disableHistory = (PDFJS.disableHistory === undefined ?
                         false : PDFJS.disableHistory);
 
-/**
- * Disables maintaining the current position in the document when zooming.
- */
-PDFJS.ignoreCurrentPositionOnZoom = (PDFJS.ignoreCurrentPositionOnZoom ===
-  undefined ? false : PDFJS.ignoreCurrentPositionOnZoom);
-
 if (typeof PDFJSDev === 'undefined' ||
     !PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
   /**

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -62,6 +62,12 @@ let viewerParameters = {
   imageResourcesPath: './images/',
 
   /**
+   * Specifies the `rel` attribute for external links. Defaults to stripping
+   * the referrer.
+   */
+  externalLinkRel: null,
+
+  /**
    * Disables fullscreen support, and by extension Presentation Mode,
    * in browsers which support the fullscreen API.
    */

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -54,7 +54,32 @@ if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('CHROME || GENERIC')) {
   require('./pdf_print_service.js');
 }
 
-let viewerParameters = {};
+let viewerParameters = {
+  /**
+   * Disables fullscreen support, and by extension Presentation Mode,
+   * in browsers which support the fullscreen API.
+   */
+  disableFullscreen: false,
+
+  /**
+   * The maximum supported canvas size in total pixels, i.e. width * height.
+   * Use -1 for no limit. The default value is 4096 * 4096 (16 mega-pixels).
+   */
+  maxCanvasPixels: null,
+
+  /**
+   * Disables saving of the last position of the viewed PDF.
+   */
+  disableHistory: false,
+};
+if (typeof PDFJSDev === 'undefined' ||
+    !PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
+  /**
+   * Interface locale settings.
+   */
+  viewerParameters.locale = (typeof navigator !== 'undefined' ?
+    navigator.language : null);
+}
 
 function getViewerConfiguration() {
   return {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -56,6 +56,12 @@ if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('CHROME || GENERIC')) {
 
 let viewerParameters = {
   /**
+   * Path for image resources, mainly for annotation icons. Include trailing
+   * slash.
+   */
+  imageResourcesPath: './images/',
+
+  /**
    * Disables fullscreen support, and by extension Presentation Mode,
    * in browsers which support the fullscreen API.
    */

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -54,8 +54,11 @@ if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('CHROME || GENERIC')) {
   require('./pdf_print_service.js');
 }
 
+let viewerParameters = {};
+
 function getViewerConfiguration() {
   return {
+    viewerParameters,
     appContainer: document.body,
     mainContainer: document.getElementById('viewerContainer'),
     viewerContainer: document.getElementById('viewer'),

--- a/web/viewer_compatibility.js
+++ b/web/viewer_compatibility.js
@@ -1,0 +1,55 @@
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+let compatibilityParams = Object.create(null);
+
+if (typeof PDFJSDev === 'undefined' ||
+    !PDFJSDev.test('FIREFOX || MOZCENTRAL || CHROME')) {
+
+  const userAgent =
+    (typeof navigator !== 'undefined' && navigator.userAgent) || '';
+  const isAndroid = /Android/.test(userAgent);
+  const isIE = userAgent.indexOf('Trident') >= 0;
+  const isIOS = /\b(iPad|iPhone|iPod)(?=;)/.test(userAgent);
+
+  // Disable fullscreen support for certain problematic configurations.
+  // Support: IE11+ (when embedded).
+  (function checkFullscreenSupport() {
+    if (isIE && window.parent !== window) {
+      compatibilityParams['disableFullscreen'] = true;
+    }
+  })();
+
+  // Limit canvas size to 5 mega-pixels on mobile.
+  // Support: Android, iOS
+  (function checkCanvasSizeLimitation() {
+    if (isIOS || isAndroid) {
+      compatibilityParams['maxCanvasPixels'] = 5242880;
+    }
+  })();
+
+  // Checks if navigator.language is supported
+  (function checkNavigatorLanguage() {
+    if (typeof navigator === 'undefined' || 'language' in navigator) {
+      return;
+    }
+    compatibilityParams['locale'] = navigator.userLanguage || 'en-US';
+  })();
+}
+const viewerCompatibilityParams = Object.freeze(compatibilityParams);
+
+export {
+  viewerCompatibilityParams,
+};


### PR DESCRIPTION
*Please note that this is currently blocked on PR #9095 landing (for the `WebGL` changes).*

This PR is a *first* step on the way to reducing our dependency on the global `PDFJS` object, in order to see how feasible this is to implement, and to determine if the general format seems reasonable thus far.

***Edit:*** The more I think about this, the more unsure of the current approach I become. It seems to me that doing it this way could very well make the default viewer *more* difficult to configure (which wasn't really the goal), especially when you also consider doing a similar conversion for the API parameters!?

While it probably won't solve the general (i.e. API configuration) problem, one idea would perhaps be to utilize the `Preferences` to an even larger degree, in an attempt to simplify the mess in [`PDFViewerApplication._readPreferences`](https://github.com/mozilla/pdf.js/blob/0052dc2b0dfec6d7784e215376ae231f72dda420/web/app.js#L195) w.r.t. what settings actually takes precedence!?

Another thing, which may or may not be an issue, is that in `master` it's currently possible to fairly easily *override* values set in `src/shared/compatibility.js`. With the way this patch is written, that's no longer possible. Of course, one could argue that this isn't a problem and that we shouldn't allow users to shoot themselves in the foot like that, but I'd assume that there're situations where it may be useful nonetheless.

So, in summary: I'd appreciate other ideas for reducing our dependency on the global `PDFJS` object.