### PR TITLE
Enable the `no-var` ESLint rule in the `/web` folder

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -166,6 +166,7 @@
     "no-useless-computed-key": "error",
     "no-useless-constructor": "error",
     "no-useless-rename": "error",
+    "no-var": "off",
     "object-shorthand": ["error", "always", {
       "avoidQuotes": true,
     }],

--- a/web/.eslintrc
+++ b/web/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "extends": [
+    ../.eslintrc
+  ],
+
+  "rules": {
+    // ECMAScript 6
+    "no-var": "error",
+  },
+}

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint-disable no-var */
 
 'use strict';
 

--- a/web/grab_to_pan.js
+++ b/web/grab_to_pan.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint-disable no-var */
 
 /**
  * Construct a GrabToPan instance for a given HTML element.

--- a/web/pdf_viewer.component.js
+++ b/web/pdf_viewer.component.js
@@ -13,42 +13,43 @@
  * limitations under the License.
  */
 
-'use strict';
+import {
+  AnnotationLayerBuilder, DefaultAnnotationLayerFactory
+} from './annotation_layer_builder.js';
+import {
+  DefaultTextLayerFactory, TextLayerBuilder
+} from './text_layer_builder.js';
+import { EventBus, NullL10n, ProgressBar } from './ui_utils.js';
+import { PDFLinkService, SimpleLinkService } from './pdf_link_service.js';
+import { DownloadManager } from './download_manager.js';
+import { GenericL10n } from './genericl10n.js';
+import { PDFFindController } from './pdf_find_controller.js';
+import { PDFHistory } from './pdf_history.js';
+import pdfjsLib from './pdfjs.js';
+import { PDFPageView } from './pdf_page_view.js';
+import { PDFSinglePageViewer } from './pdf_single_page_viewer';
+import { PDFViewer } from './pdf_viewer.js';
 
-var pdfjsLib = require('./pdfjs.js');
-var pdfjsWebPDFViewer = require('./pdf_viewer.js');
-var pdfjsWebPDFSinglePageViewer = require('./pdf_single_page_viewer');
-var pdfjsWebPDFPageView = require('./pdf_page_view.js');
-var pdfjsWebPDFLinkService = require('./pdf_link_service.js');
-var pdfjsWebTextLayerBuilder = require('./text_layer_builder.js');
-var pdfjsWebAnnotationLayerBuilder = require('./annotation_layer_builder.js');
-var pdfjsWebPDFHistory = require('./pdf_history.js');
-var pdfjsWebPDFFindController = require('./pdf_find_controller.js');
-var pdfjsWebUIUtils = require('./ui_utils.js');
-var pdfjsWebDownloadManager = require('./download_manager.js');
-var pdfjsWebGenericL10n = require('./genericl10n.js');
+let { PDFJS, } = pdfjsLib;
 
-var PDFJS = pdfjsLib.PDFJS;
+PDFJS.PDFViewer = PDFViewer;
+PDFJS.PDFSinglePageViewer = PDFSinglePageViewer;
+PDFJS.PDFPageView = PDFPageView;
+PDFJS.PDFLinkService = PDFLinkService;
+PDFJS.SimpleLinkService = SimpleLinkService;
+PDFJS.TextLayerBuilder = TextLayerBuilder;
+PDFJS.DefaultTextLayerFactory = DefaultTextLayerFactory;
+PDFJS.AnnotationLayerBuilder = AnnotationLayerBuilder;
+PDFJS.DefaultAnnotationLayerFactory = DefaultAnnotationLayerFactory;
+PDFJS.PDFHistory = PDFHistory;
+PDFJS.PDFFindController = PDFFindController;
+PDFJS.EventBus = EventBus;
 
-PDFJS.PDFViewer = pdfjsWebPDFViewer.PDFViewer;
-PDFJS.PDFSinglePageViewer = pdfjsWebPDFSinglePageViewer.PDFSinglePageViewer;
-PDFJS.PDFPageView = pdfjsWebPDFPageView.PDFPageView;
-PDFJS.PDFLinkService = pdfjsWebPDFLinkService.PDFLinkService;
-PDFJS.SimpleLinkService = pdfjsWebPDFLinkService.SimpleLinkService;
-PDFJS.TextLayerBuilder = pdfjsWebTextLayerBuilder.TextLayerBuilder;
-PDFJS.DefaultTextLayerFactory =
-  pdfjsWebTextLayerBuilder.DefaultTextLayerFactory;
-PDFJS.AnnotationLayerBuilder =
-  pdfjsWebAnnotationLayerBuilder.AnnotationLayerBuilder;
-PDFJS.DefaultAnnotationLayerFactory =
-  pdfjsWebAnnotationLayerBuilder.DefaultAnnotationLayerFactory;
-PDFJS.PDFHistory = pdfjsWebPDFHistory.PDFHistory;
-PDFJS.PDFFindController = pdfjsWebPDFFindController.PDFFindController;
-PDFJS.EventBus = pdfjsWebUIUtils.EventBus;
+PDFJS.DownloadManager = DownloadManager;
+PDFJS.ProgressBar = ProgressBar;
+PDFJS.GenericL10n = GenericL10n;
+PDFJS.NullL10n = NullL10n;
 
-PDFJS.DownloadManager = pdfjsWebDownloadManager.DownloadManager;
-PDFJS.ProgressBar = pdfjsWebUIUtils.ProgressBar;
-PDFJS.GenericL10n = pdfjsWebGenericL10n.GenericL10n;
-PDFJS.NullL10n = pdfjsWebUIUtils.NullL10n;
-
-exports.PDFJS = PDFJS;
+export {
+  PDFJS,
+};

--- a/web/pdfjs.js
+++ b/web/pdfjs.js
@@ -16,7 +16,7 @@
 
 'use strict';
 
-var pdfjsLib;
+let pdfjsLib;
 if (typeof window !== 'undefined' && window['pdfjs-dist/build/pdf']) {
   pdfjsLib = window['pdfjs-dist/build/pdf'];
 } else {


### PR DESCRIPTION
 - Use ES6 notation, and replace `var` with `let`, in `web/pdf_viewer.component.js` and `web/pdfjs.js`

 - Enable the `no-var` ESLint rule in the `/web` folder

    https://eslint.org/docs/rules/no-var

    Please note that two files were excluded:
    1. `web/debugger.js`, since there's code in other files that currently depend on the global availability of code in `web/debugger.js`. Furthermore, since that file isn't used in production, doing a ES6 conversion probably isn't a priority.

   2. `web/grab_to_pan.js`, since that file could be considered to be "external" code. We have made smaller changes to that file over the years, however doing a full ES6 `class` conversion might be a step too far!?