### PR TITLE
Accumulate streamed PDF data into array of buffers.

### DIFF
--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -154,7 +154,7 @@ function getLocalizedString(strings, id, property) {
 // PDF data storage
 function PdfDataListener(length) {
   this.length = length; // less than 0, if length is unknown
-  this.buffer = null;
+  this.buffers = [];
   this.loaded = 0;
 }
 
@@ -162,15 +162,7 @@ PdfDataListener.prototype = {
   append: function PdfDataListener_append(chunk) {
     // In most of the cases we will pass data as we receive it, but at the
     // beginning of the loading we may accumulate some data.
-    if (!this.buffer) {
-      this.buffer = new Uint8Array(chunk);
-    } else {
-      var buffer = this.buffer;
-      var newBuffer = new Uint8Array(buffer.length + chunk.length);
-      newBuffer.set(buffer);
-      newBuffer.set(chunk, buffer.length);
-      this.buffer = newBuffer;
-    }
+    this.buffers.push(chunk);
     this.loaded += chunk.length;
     if (this.length >= 0 && this.length < this.loaded) {
       this.length = -1; // reset the length, server is giving incorrect one
@@ -178,9 +170,26 @@ PdfDataListener.prototype = {
     this.onprogress(this.loaded, this.length >= 0 ? this.length : void 0);
   },
   readData: function PdfDataListener_readData() {
-    var result = this.buffer;
-    this.buffer = null;
-    return result;
+    if (this.buffers.length === 0) {
+      return null;
+    }
+    if (this.buffers.length === 1) {
+      return this.buffers.pop();
+    }
+    // There are multiple buffers that need to be combined into a single
+    // buffer.
+    let combinedLength = 0;
+    for (let buffer of this.buffers) {
+      combinedLength += buffer.length;
+    }
+    let combinedArray = new Uint8Array(combinedLength);
+    let writeOffset = 0;
+    while (this.buffers.length) {
+      let buffer = this.buffers.shift();
+      combinedArray.set(buffer, writeOffset);
+      writeOffset += buffer.length;
+    }
+    return combinedArray;
   },
   finish: function PdfDataListener_finish() {
     this.isDataReady = true;
@@ -888,8 +897,9 @@ PdfStreamConverter.prototype = {
 
     var binaryStream = this.binaryStream;
     binaryStream.setInputStream(aInputStream);
-    var chunk = binaryStream.readByteArray(aCount);
-    this.dataListener.append(chunk);
+    let chunk = new ArrayBuffer(aCount);
+    binaryStream.readArrayBuffer(aCount, chunk);
+    this.dataListener.append(new Uint8Array(chunk));
   },
 
   // nsIRequestObserver::onStartRequest


### PR DESCRIPTION
While investigating [bug 1410381](https://bugzilla.mozilla.org/show_bug.cgi?id=1410381) I noticed the [PDF](http://de.free.aero/contents/light2017de.pdf) took much longer to load in the Firefox extension than in the plain web version of PDF.js. After running gecko profiler, I found we spent a lot of time in the stream converter doing append(). What was happening was Firefox was loading the entire PDF before the PDF.js viewer was loaded, which means we were always following [this](http://searchfox.org/mozilla-central/rev/c99d035f00dd894feff38e4ad28a73fb679c63a6/browser/extensions/pdfjs/content/PdfStreamConverter.jsm#163) code path, where we create a new typed array to handle the old data + the new chunk and copy it over. For the above PDF that is 27MB, this was called roughly 200 times until the array was expanded to the full 27MB!

With this new code I see the above PDF (hosted locally),  go from 15s to 3s and peak-rss go from 1GB to 300MB.

@yurydelendik We had talked about using blobs, but I don't really see an advantage to that since we have to message across the data anyways. After you review, I'll ping mossop to review as well.