### PR TITLE
Added missing network stream for svgviewer example

### DIFF
--- a/examples/svgviewer/viewer.js
+++ b/examples/svgviewer/viewer.js
@@ -39,11 +39,13 @@ function renderDocument(pdf, svgLib) {
 Promise.all([System.import('pdfjs/display/api'),
              System.import('pdfjs/display/svg'),
              System.import('pdfjs/display/global'),
+             System.import('pdfjs/display/network'),
              System.resolve('pdfjs/worker_loader')])
        .then(function (modules) {
-  var api = modules[0], svg = modules[1], global = modules[2];
+  var api = modules[0], svg = modules[1], global = modules[2], network = modules[3];
+  api.setPDFNetworkStreamClass(network.PDFNetworkStream);
   // In production, change this to point to the built `pdf.worker.js` file.
-  global.PDFJS.workerSrc = modules[3];
+  global.PDFJS.workerSrc = modules[4];
 
   // In production, change this to point to where the cMaps are placed.
   global.PDFJS.cMapUrl = '../../external/bcmaps/';


### PR DESCRIPTION
The example svgviewer project currently does not render an SVG and returns an error in the console:
Uncaught (in promise) TypeError: PDFNetworkStream is not a constructor

I have forked and fixed this issue by adding in the PDFNetworkStream.