### PR TITLE
Fix incorrect behaviour in `PDFThumbnailViewer.scrollThumbnailIntoView` for multiple columns of thumbnails

### DIFF
--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -84,7 +84,20 @@ class PDFThumbnailViewer {
       let first = visibleThumbs.first.id;
       // Account for only one thumbnail being visible.
       let last = (numVisibleThumbs > 1 ? visibleThumbs.last.id : first);
+
+      let shouldScroll = false;
       if (page <= first || page >= last) {
+        shouldScroll = true;
+      } else {
+        visibleThumbs.views.some(function(view) {
+          if (view.id !== page) {
+            return false;
+          }
+          shouldScroll = view.percent < 100;
+          return true;
+        });
+      }
+      if (shouldScroll) {
         scrollIntoView(thumbnail, { top: THUMBNAIL_SCROLL_MARGIN, });
       }
     }


### PR DESCRIPTION
If the sidebar is resized such that the thumbnails are displayed in multiple columns, then scrolling the currently active thumbnail into view doesn't work correctly in some cases.
The reason is that the code in `PDFThumbnailViewer.scrollThumbnailIntoView` implicitly assumes that the thumbnails will be present in just *one* column. Since that may no longer be the case, it's not sufficient to simply check if the thumbnail is visible. Instead we must explicitly check that *all*, i.e. 100 percent, of the thumbnail is already visible, and otherwise scroll it into view.

---
For an example of this issue, please refer to the screen-shot below where the currently active thumbnail is only partially visible.

![scrollthumbnailintoview-multi-cols](https://user-images.githubusercontent.com/2692120/32694012-fddfbd74-c735-11e7-9a7a-89e537732701.png)
