### PR TITLE
[WIP] Move options from the global `PDFJS` object into the relevant viewer components or API methods

### DIFF
--- a/examples/components/pageviewer.js
+++ b/examples/components/pageviewer.js
@@ -15,7 +15,7 @@
 
 'use strict';
 
-if (!PDFJS.PDFViewer || !PDFJS.getDocument) {
+if (!PDFJS.PDFPageView || !PDFJS.getDocument) {
   alert('Please build the pdfjs-dist library using\n' +
         '  `gulp dist-install`');
 }
@@ -26,8 +26,8 @@ PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
 // Some PDFs need external cmaps.
 //
-// PDFJS.cMapUrl = '../../node_modules/pdfjs-dist/cmaps/';
-// PDFJS.cMapPacked = true;
+var CMAP_URL = '../../node_modules/pdfjs-dist/cmaps/';
+var CMAP_PACKED = true;
 
 var DEFAULT_URL = '../../web/compressed.tracemonkey-pldi-09.pdf';
 var PAGE_TO_VIEW = 1;
@@ -36,7 +36,11 @@ var SCALE = 1.0;
 var container = document.getElementById('pageContainer');
 
 // Loading document.
-PDFJS.getDocument(DEFAULT_URL).then(function (pdfDocument) {
+PDFJS.getDocument({
+  url: DEFAULT_URL,
+  cMapUrl: CMAP_URL,
+  cMapPacked: CMAP_PACKED,
+}).then(function(pdfDocument) {
   // Document loaded, retrieving the page.
   return pdfDocument.getPage(PAGE_TO_VIEW).then(function (pdfPage) {
     // Creating the page view with default parameters.

--- a/examples/components/simpleviewer.js
+++ b/examples/components/simpleviewer.js
@@ -26,8 +26,8 @@ PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
 // Some PDFs need external cmaps.
 //
-// PDFJS.cMapUrl = '../../node_modules/pdfjs-dist/cmaps/';
-// PDFJS.cMapPacked = true;
+var CMAP_URL = '../../node_modules/pdfjs-dist/cmaps/';
+var CMAP_PACKED = true;
 
 var DEFAULT_URL = '../../web/compressed.tracemonkey-pldi-09.pdf';
 var SEARCH_FOR = ''; // try 'Mozilla';
@@ -59,7 +59,11 @@ container.addEventListener('pagesinit', function () {
 });
 
 // Loading document.
-PDFJS.getDocument(DEFAULT_URL).then(function (pdfDocument) {
+PDFJS.getDocument({
+  url: DEFAULT_URL,
+  cMapUrl: CMAP_URL,
+  cMapPacked: CMAP_PACKED,
+}).then(function(pdfDocument) {
   // Document loaded, specifying document for the viewer and
   // the (optional) linkService.
   pdfViewer.setDocument(pdfDocument);

--- a/examples/components/singlepageviewer.js
+++ b/examples/components/singlepageviewer.js
@@ -26,8 +26,8 @@ PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
 // Some PDFs need external cmaps.
 //
-// PDFJS.cMapUrl = '../../node_modules/pdfjs-dist/cmaps/';
-// PDFJS.cMapPacked = true;
+var CMAP_URL = '../../node_modules/pdfjs-dist/cmaps/';
+var CMAP_PACKED = true;
 
 var DEFAULT_URL = '../../web/compressed.tracemonkey-pldi-09.pdf';
 var SEARCH_FOR = ''; // try 'Mozilla';
@@ -59,7 +59,11 @@ container.addEventListener('pagesinit', function () {
 });
 
 // Loading document.
-PDFJS.getDocument(DEFAULT_URL).then(function (pdfDocument) {
+PDFJS.getDocument({
+  url: DEFAULT_URL,
+  cMapUrl: CMAP_URL,
+  cMapPacked: CMAP_PACKED,
+}).then(function(pdfDocument) {
   // Document loaded, specifying document for the viewer and
   // the (optional) linkService.
   pdfSinglePageViewer.setDocument(pdfDocument);

--- a/examples/mobile-viewer/viewer.js
+++ b/examples/mobile-viewer/viewer.js
@@ -22,7 +22,7 @@ if (!PDFJS.PDFViewer || !PDFJS.getDocument) {
 }
 
 PDFJS.useOnlyCssZoom = true;
-PDFJS.disableTextLayer = true;
+var DISABLE_TEXT_LAYER = true;
 PDFJS.maxImageSize = 1024 * 1024;
 PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 PDFJS.cMapUrl = '../../node_modules/pdfjs-dist/cmaps/';
@@ -298,6 +298,7 @@ var PDFViewerApplication = {
       container: container,
       linkService: linkService,
       l10n: this.l10n,
+      disableTextLayer: DISABLE_TEXT_LAYER,
     });
     this.pdfViewer = pdfViewer;
     linkService.setViewer(pdfViewer);

--- a/examples/mobile-viewer/viewer.js
+++ b/examples/mobile-viewer/viewer.js
@@ -21,7 +21,7 @@ if (!PDFJS.PDFViewer || !PDFJS.getDocument) {
         '  `gulp dist-install`');
 }
 
-PDFJS.useOnlyCssZoom = true;
+var USE_ONLY_CSS_ZOOM = true;
 var DISABLE_TEXT_LAYER = true;
 PDFJS.maxImageSize = 1024 * 1024;
 PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
@@ -299,6 +299,7 @@ var PDFViewerApplication = {
       linkService: linkService,
       l10n: this.l10n,
       disableTextLayer: DISABLE_TEXT_LAYER,
+      useOnlyCssZoom: USE_ONLY_CSS_ZOOM,
     });
     this.pdfViewer = pdfViewer;
     linkService.setViewer(pdfViewer);

--- a/examples/mobile-viewer/viewer.js
+++ b/examples/mobile-viewer/viewer.js
@@ -23,7 +23,7 @@ if (!PDFJS.PDFViewer || !PDFJS.getDocument) {
 
 var USE_ONLY_CSS_ZOOM = true;
 var DISABLE_TEXT_LAYER = true;
-PDFJS.maxImageSize = 1024 * 1024;
+var MAX_IMAGE_SIZE = 1024 * 1024;
 PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 PDFJS.cMapUrl = '../../node_modules/pdfjs-dist/cmaps/';
 PDFJS.cMapPacked = true;
@@ -60,7 +60,10 @@ var PDFViewerApplication = {
     this.setTitleUsingUrl(url);
 
     // Loading document.
-    var loadingTask = PDFJS.getDocument(url);
+    var loadingTask = PDFJS.getDocument({
+      url: url,
+      maxImageSize: MAX_IMAGE_SIZE,
+    });
     this.pdfLoadingTask = loadingTask;
 
     loadingTask.onProgress = function (progressData) {

--- a/examples/mobile-viewer/viewer.js
+++ b/examples/mobile-viewer/viewer.js
@@ -25,8 +25,8 @@ var USE_ONLY_CSS_ZOOM = true;
 var DISABLE_TEXT_LAYER = true;
 var MAX_IMAGE_SIZE = 1024 * 1024;
 PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
-PDFJS.cMapUrl = '../../node_modules/pdfjs-dist/cmaps/';
-PDFJS.cMapPacked = true;
+var CMAP_URL = '../../node_modules/pdfjs-dist/cmaps/';
+var CMAP_PACKED = true;
 
 var DEFAULT_URL = '../../web/compressed.tracemonkey-pldi-09.pdf';
 var DEFAULT_SCALE_DELTA = 1.1;
@@ -63,6 +63,8 @@ var PDFViewerApplication = {
     var loadingTask = PDFJS.getDocument({
       url: url,
       maxImageSize: MAX_IMAGE_SIZE,
+      cMapUrl: CMAP_URL,
+      cMapPacked: CMAP_PACKED,
     });
     this.pdfLoadingTask = loadingTask;
 

--- a/examples/svgviewer/viewer.js
+++ b/examples/svgviewer/viewer.js
@@ -48,11 +48,15 @@ Promise.all([System.import('pdfjs/display/api'),
   global.PDFJS.workerSrc = modules[4];
 
   // In production, change this to point to where the cMaps are placed.
-  global.PDFJS.cMapUrl = '../../external/bcmaps/';
-  global.PDFJS.cMapPacked = true;
+  var CMAP_URL = '../../external/bcmaps/';
+  var CMAP_PACKED = true;
 
   // Fetch the PDF document from the URL using promises.
-  api.getDocument(url).then(function (doc) {
+  api.getDocument({
+    url: url,
+    cMapUrl: CMAP_URL,
+    cMapPacked: CMAP_PACKED,
+  }).then(function(doc) {
     renderDocument(doc, svg);
   });
 });

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -607,7 +607,7 @@ var WorkerMessageHandler = {
 
       var evaluatorOptions = {
         forceDataSchema: data.disableCreateObjectURL,
-        maxImageSize: data.maxImageSize === undefined ? -1 : data.maxImageSize,
+        maxImageSize: data.maxImageSize,
         disableFontFace: data.disableFontFace,
         nativeImageDecoderSupport: data.nativeImageDecoderSupport,
         ignoreErrors: data.ignoreErrors,

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -14,8 +14,7 @@
  */
 
 import {
-  addLinkAttributes, CustomStyle, DOMSVGFactory, getDefaultSetting,
-  getFilenameFromUrl, LinkTarget
+  addLinkAttributes, CustomStyle, DOMSVGFactory, getFilenameFromUrl, LinkTarget
 } from './dom_utils';
 import {
   AnnotationBorderStyleType, AnnotationType, stringToPDFString, Util, warn
@@ -29,7 +28,8 @@ import {
  * @property {PageViewport} viewport
  * @property {IPDFLinkService} linkService
  * @property {DownloadManager} downloadManager
- * @property {string} imageResourcesPath
+ * @property {string} imageResourcesPath - (optional) Path for image resources,
+ *   mainly for annotation icons. Include trailing slash.
  * @property {boolean} renderInteractiveForms
  * @property {Object} svgFactory
  */
@@ -1167,7 +1167,8 @@ class FileAttachmentAnnotationElement extends AnnotationElement {
  * @property {Array} annotations
  * @property {PDFPage} page
  * @property {IPDFLinkService} linkService
- * @property {string} imageResourcesPath
+ * @property {string} imageResourcesPath - (optional) Path for image resources,
+ *   mainly for annotation icons. Include trailing slash.
  * @property {boolean} renderInteractiveForms
  */
 
@@ -1192,8 +1193,7 @@ class AnnotationLayer {
         viewport: parameters.viewport,
         linkService: parameters.linkService,
         downloadManager: parameters.downloadManager,
-        imageResourcesPath: parameters.imageResourcesPath ||
-                            getDefaultSetting('imageResourcesPath'),
+        imageResourcesPath: parameters.imageResourcesPath || '',
         renderInteractiveForms: parameters.renderInteractiveForms || false,
         svgFactory: new DOMSVGFactory(),
       });

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -283,17 +283,21 @@ class LinkAnnotationElement extends AnnotationElement {
   render() {
     this.container.className = 'linkAnnotation';
 
+    let { data, linkService, } = this;
     let link = document.createElement('a');
+
     addLinkAttributes(link, {
-      url: this.data.url,
-      target: (this.data.newWindow ? LinkTarget.BLANK : undefined),
+      url: data.url,
+      target: (data.newWindow ?
+               LinkTarget.BLANK : linkService.externalLinkTarget),
+      rel: linkService.externalLinkRel,
     });
 
-    if (!this.data.url) {
-      if (this.data.action) {
-        this._bindNamedAction(link, this.data.action);
+    if (!data.url) {
+      if (data.action) {
+        this._bindNamedAction(link, data.action);
       } else {
-        this._bindLink(link, this.data.dest);
+        this._bindLink(link, data.dest);
       }
     }
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -26,6 +26,7 @@ import {
   RenderingCancelledException
 } from './dom_utils';
 import { FontFaceObject, FontLoader } from './font_loader';
+import { apiCompatibilityParams } from './api_compatibility';
 import { CanvasGraphics } from './canvas';
 import globalScope from '../shared/global_scope';
 import { Metadata } from './metadata';
@@ -150,6 +151,10 @@ function setPDFNetworkStreamClass(cls) {
  *   converted to OpenType fonts and loaded via font face rules. If disabled,
  *   fonts will be rendered using a built-in font renderer that constructs the
  *   glyphs with primitive path commands. The default value is `false`.
+ * @property {boolean} disableRange - (optional) Disable range request loading
+ *   of PDF files. When enabled, and if the server supports partial content
+ *   requests, then the PDF will be fetched in chunks.
+ *   The default value is `false`.
  * @property {boolean} disableAutoFetch - (optional) Disable pre-fetching of PDF
  *   file data. When range requests are enabled PDF.js will automatically keep
  *   fetching more data even if it isn't needed to display the current page.
@@ -260,6 +265,9 @@ function getDocument(src) {
     params.disableFontFace = false;
   }
 
+  if (typeof params.disableRange !== 'boolean') {
+    params.disableRange = apiCompatibilityParams.disableRange || false;
+  }
   if (typeof params.disableAutoFetch !== 'boolean') {
     params.disableAutoFetch = false;
   }
@@ -318,7 +326,6 @@ function _fetchDocument(worker, source, pdfDataRangeTransport, docId) {
   let apiVersion =
     typeof PDFJSDev !== 'undefined' ? PDFJSDev.eval('BUNDLE_VERSION') : null;
 
-  source.disableRange = getDefaultSetting('disableRange');
   source.disableStream = getDefaultSetting('disableStream');
   if (pdfDataRangeTransport) {
     source.length = pdfDataRangeTransport.length;
@@ -2051,6 +2058,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
     get loadingParams() {
       let params = this._params;
       return shadow(this, 'loadingParams', {
+        disableRange: params.disableRange,
         disableAutoFetch: params.disableAutoFetch,
       });
     },

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -128,6 +128,10 @@ function setPDFNetworkStreamClass(cls) {
  *   with limited image support through stubs (useful for SVG conversion),
  *   and 'none' where JPEG images will be decoded entirely by PDF.js.
  *   The default value is 'decode'.
+ * @property {string} cMapUrl - (optional) The URL where the predefined
+ *   Adobe CMaps are located. Include trailing slash.
+ * @property {boolean} cMapPacked - (optional) Specifies if the Adobe CMaps are
+ *   binary packed.
  * @property {Object} CMapReaderFactory - (optional) The factory that will be
  *   used when reading built-in CMap files. Providing a custom factory is useful
  *   for environments without `XMLHttpRequest` support, such as e.g. Node.js.
@@ -187,7 +191,7 @@ function getDocument(src) {
   let params = Object.create(null);
   var rangeTransport = null;
   var worker = null;
-  var CMapReaderFactory = DOMCMapReaderFactory;
+  let CMapReaderFactory = DOMCMapReaderFactory;
 
   for (var key in source) {
     if (key === 'url' && typeof window !== 'undefined') {
@@ -265,7 +269,7 @@ function getDocument(src) {
       var messageHandler = new MessageHandler(docId, workerId, worker.port);
       messageHandler.postMessageTransfers = worker.postMessageTransfers;
       var transport = new WorkerTransport(messageHandler, task, networkStream,
-                                          CMapReaderFactory);
+                                          params, CMapReaderFactory);
       task._transport = transport;
       messageHandler.send('Ready', null);
     });
@@ -1484,14 +1488,15 @@ var PDFWorker = (function PDFWorkerClosure() {
  */
 var WorkerTransport = (function WorkerTransportClosure() {
   function WorkerTransport(messageHandler, loadingTask, networkStream,
-                           CMapReaderFactory) {
+                           params, CMapReaderFactory) {
     this.messageHandler = messageHandler;
     this.loadingTask = loadingTask;
     this.commonObjs = new PDFObjects();
     this.fontLoader = new FontLoader(loadingTask.docId);
+    this._params = params;
     this.CMapReaderFactory = new CMapReaderFactory({
-      baseUrl: getDefaultSetting('cMapUrl'),
-      isCompressed: getDefaultSetting('cMapPacked'),
+      baseUrl: params.cMapUrl,
+      isCompressed: params.cMapPacked,
     });
 
     this.destroyed = false;

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -310,7 +310,15 @@ function getDocument(src) {
       if (rangeTransport) {
         networkStream = new PDFDataTransportStream(params, rangeTransport);
       } else if (!params.data) {
-        networkStream = new PDFNetworkStream(params);
+        networkStream = new PDFNetworkStream({
+          url: params.url,
+          length: params.length,
+          httpHeaders: params.httpHeaders,
+          withCredentials: params.withCredentials,
+          rangeChunkSize: params.rangeChunkSize,
+          disableRange: params.disableRange,
+          disableStream: params.disableStream,
+        });
       }
 
       var messageHandler = new MessageHandler(docId, workerId, worker.port);

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -698,6 +698,8 @@ var PDFDocumentProxy = (function PDFDocumentProxyClosure() {
  *                                calling of PDFPage.getViewport method.
  * @property {string} intent - Rendering intent, can be 'display' or 'print'
  *                    (default value is 'display').
+ * @property {boolean} enableWebGL - (optional) Enables WebGL accelerated
+ *   rendering for some operations. The default value is `false`.
  * @property {boolean} renderInteractiveForms - (optional) Whether or not
  *                     interactive form elements are rendered in the display
  *                     layer. If so, we do not render them on canvas as well.
@@ -820,6 +822,7 @@ var PDFPageProxy = (function PDFPageProxyClosure() {
 
       var renderingIntent = (params.intent === 'print' ? 'print' : 'display');
       var canvasFactory = params.canvasFactory || new DOMCanvasFactory();
+      // TODO: Rebase this on top of the `WebGLFactory`, once that one lands.
 
       if (!this.intentStates[renderingIntent]) {
         this.intentStates[renderingIntent] = Object.create(null);

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -164,6 +164,9 @@ function setPDFNetworkStreamClass(cls) {
  *   The default value is `false`.
  *   NOTE: It is also necessary to disable streaming, see above,
  *         in order for disabling of pre-fetching to work correctly.
+ * @property {boolean} disableCreateObjectURL - (optional) Disable the use of
+ *   `URL.createObjectURL`, for compatibility with older browsers.
+ *   The default value is `false`.
  */
 
 /**
@@ -277,6 +280,10 @@ function getDocument(src) {
   if (typeof params.disableAutoFetch !== 'boolean') {
     params.disableAutoFetch = false;
   }
+  if (typeof params.disableCreateObjectURL !== 'boolean') {
+    params.disableCreateObjectURL =
+      apiCompatibilityParams.disableCreateObjectURL || false;
+  }
 
   if (!worker) {
     // Worker was not provided -- creating and owning our own. If message port
@@ -349,7 +356,7 @@ function _fetchDocument(worker, source, pdfDataRangeTransport, docId) {
     },
     maxImageSize: source.maxImageSize,
     disableFontFace: source.disableFontFace,
-    disableCreateObjectURL: getDefaultSetting('disableCreateObjectURL'),
+    disableCreateObjectURL: source.disableCreateObjectURL,
     postMessageTransfers: getDefaultSetting('postMessageTransfers') &&
                           !isPostMessageTransfersDisabled,
     docBaseUrl: source.docBaseUrl,
@@ -2066,6 +2073,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
         disableRange: params.disableRange,
         disableStream: params.disableStream,
         disableAutoFetch: params.disableAutoFetch,
+        disableCreateObjectURL: params.disableCreateObjectURL,
       });
     },
   };

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -146,6 +146,10 @@ function setPDFNetworkStreamClass(cls) {
  * @property {boolean} isEvalSupported - (optional) Determines if we can eval
  *   strings as JS. Primarily used to improve performance of font rendering,
  *   and when parsing PDF functions. The default value is `true`.
+ * @property {boolean} disableFontFace - (optional) By default fonts are
+ *   converted to OpenType fonts and loaded via font face rules. If disabled,
+ *   fonts will be rendered using a built-in font renderer that constructs the
+ *   glyphs with primitive path commands. The default value is `false`.
  */
 
 /**
@@ -246,6 +250,9 @@ function getDocument(src) {
   if (typeof params.isEvalSupported !== 'boolean') {
     params.isEvalSupported = true;
   }
+  if (typeof params.disableFontFace !== 'boolean') {
+    params.disableFontFace = false;
+  }
 
   if (!worker) {
     // Worker was not provided -- creating and owning our own. If message port
@@ -320,7 +327,7 @@ function _fetchDocument(worker, source, pdfDataRangeTransport, docId) {
       length: source.length,
     },
     maxImageSize: source.maxImageSize,
-    disableFontFace: getDefaultSetting('disableFontFace'),
+    disableFontFace: source.disableFontFace,
     disableCreateObjectURL: getDefaultSetting('disableCreateObjectURL'),
     postMessageTransfers: getDefaultSetting('postMessageTransfers') &&
                           !isPostMessageTransfersDisabled,
@@ -1765,7 +1772,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
             }
             var font = new FontFaceObject(exportedData, {
               isEvalSupported: this._params.isEvalSupported,
-              disableFontFace: getDefaultSetting('disableFontFace'),
+              disableFontFace: this._params.disableFontFace,
               fontRegistry,
             });
             var fontReady = (fontObjs) => {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -143,6 +143,9 @@ function setPDFNetworkStreamClass(cls) {
  * @property {number} maxImageSize - (optional) The maximum allowed image size
  *   in total pixels, i.e. width * height. Images above this value will not be
  *   rendered. Use -1 for no limit, which is also the default value.
+ * @property {boolean} isEvalSupported - (optional) Determines if we can eval
+ *   strings as JS. Primarily used to improve performance of font rendering,
+ *   and when parsing PDF functions. The default value is `true`.
  */
 
 /**
@@ -240,6 +243,9 @@ function getDocument(src) {
   if (!Number.isInteger(params.maxImageSize)) {
     params.maxImageSize = -1;
   }
+  if (typeof params.isEvalSupported !== 'boolean') {
+    params.isEvalSupported = true;
+  }
 
   if (!worker) {
     // Worker was not provided -- creating and owning our own. If message port
@@ -321,7 +327,7 @@ function _fetchDocument(worker, source, pdfDataRangeTransport, docId) {
     docBaseUrl: source.docBaseUrl,
     nativeImageDecoderSupport: source.nativeImageDecoderSupport,
     ignoreErrors: source.ignoreErrors,
-    isEvalSupported: getDefaultSetting('isEvalSupported'),
+    isEvalSupported: source.isEvalSupported,
   }).then(function (workerId) {
     if (worker.destroyed) {
       throw new Error('Worker was destroyed');
@@ -1758,7 +1764,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
               };
             }
             var font = new FontFaceObject(exportedData, {
-              isEvalSupported: getDefaultSetting('isEvalSupported'),
+              isEvalSupported: this._params.isEvalSupported,
               disableFontFace: getDefaultSetting('disableFontFace'),
               fontRegistry,
             });

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -155,6 +155,9 @@ function setPDFNetworkStreamClass(cls) {
  *   of PDF files. When enabled, and if the server supports partial content
  *   requests, then the PDF will be fetched in chunks.
  *   The default value is `false`.
+ * @property {boolean} disableStream - (optional) Disable streaming of PDF file
+ *   data. By default PDF.js attempts to load PDFs in chunks.
+ *   The default value is `false`.
  * @property {boolean} disableAutoFetch - (optional) Disable pre-fetching of PDF
  *   file data. When range requests are enabled PDF.js will automatically keep
  *   fetching more data even if it isn't needed to display the current page.
@@ -268,6 +271,9 @@ function getDocument(src) {
   if (typeof params.disableRange !== 'boolean') {
     params.disableRange = apiCompatibilityParams.disableRange || false;
   }
+  if (typeof params.disableStream !== 'boolean') {
+    params.disableStream = apiCompatibilityParams.disableStream || false;
+  }
   if (typeof params.disableAutoFetch !== 'boolean') {
     params.disableAutoFetch = false;
   }
@@ -326,7 +332,6 @@ function _fetchDocument(worker, source, pdfDataRangeTransport, docId) {
   let apiVersion =
     typeof PDFJSDev !== 'undefined' ? PDFJSDev.eval('BUNDLE_VERSION') : null;
 
-  source.disableStream = getDefaultSetting('disableStream');
   if (pdfDataRangeTransport) {
     source.length = pdfDataRangeTransport.length;
     source.initialData = pdfDataRangeTransport.initialData;
@@ -2059,6 +2064,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
       let params = this._params;
       return shadow(this, 'loadingParams', {
         disableRange: params.disableRange,
+        disableStream: params.disableStream,
         disableAutoFetch: params.disableAutoFetch,
       });
     },

--- a/src/display/api_compatibility.js
+++ b/src/display/api_compatibility.js
@@ -1,0 +1,53 @@
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+let compatibilityParams = Object.create(null);
+
+if (typeof PDFJSDev === 'undefined' ||
+    !PDFJSDev.test('FIREFOX || MOZCENTRAL || CHROME')) {
+  const userAgent =
+    (typeof navigator !== 'undefined' && navigator.userAgent) || '';
+  const isIE = userAgent.indexOf('Trident') >= 0;
+  const isIOS = /\b(iPad|iPhone|iPod)(?=;)/.test(userAgent);
+  const isIOSChrome = userAgent.indexOf('CriOS') >= 0;
+  const isSafari = /Safari\//.test(userAgent) &&
+                   !/(Chrome\/|Android\s)/.test(userAgent);
+
+  // Checks if possible to use URL.createObjectURL()
+  // Support: IE, Chrome on iOS
+  (function checkOnBlobSupport() {
+    // sometimes IE and Chrome on iOS loosing the data created with
+    // createObjectURL(), see #3977 and #8081
+    if (isIE || isIOSChrome) {
+      compatibilityParams.disableCreateObjectURL = true;
+    }
+  })();
+
+  // Support: Safari 6.0+, iOS
+  (function checkRangeRequests() {
+    // Safari has issues with cached range requests see:
+    // https://github.com/mozilla/pdf.js/issues/3260
+    // Last tested with version 6.0.4.
+    if (isSafari || isIOS) {
+      compatibilityParams.disableRange = true;
+      compatibilityParams.disableStream = true;
+    }
+  })();
+}
+const apiCompatibilityParams = Object.freeze(compatibilityParams);
+
+export {
+  apiCompatibilityParams,
+};

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -389,8 +389,6 @@ function getDefaultSetting(id) {
   switch (id) {
     case 'pdfBug':
       return globalSettings ? globalSettings.pdfBug : false;
-    case 'disableAutoFetch':
-      return globalSettings ? globalSettings.disableAutoFetch : false;
     case 'disableStream':
       return globalSettings ? globalSettings.disableStream : false;
     case 'disableRange':

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -407,8 +407,6 @@ function getDefaultSetting(id) {
       return globalSettings ? globalSettings.workerSrc : null;
     case 'disableWorker':
       return globalSettings ? globalSettings.disableWorker : false;
-    case 'isEvalSupported':
-      return globalSettings ? globalSettings.isEvalSupported : true;
     case 'enableStats':
       return !!(globalSettings && globalSettings.enableStats);
     default:

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -389,8 +389,6 @@ function getDefaultSetting(id) {
   switch (id) {
     case 'pdfBug':
       return globalSettings ? globalSettings.pdfBug : false;
-    case 'disableStream':
-      return globalSettings ? globalSettings.disableStream : false;
     case 'disableCreateObjectURL':
       return globalSettings ? globalSettings.disableCreateObjectURL : false;
     case 'postMessageTransfers':

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -68,8 +68,9 @@ class DOMCMapReaderFactory {
 
   fetch({ name, }) {
     if (!this.baseUrl) {
-      return Promise.reject(new Error('CMap baseUrl must be specified, ' +
-        'see "PDFJS.cMapUrl" (and also "PDFJS.cMapPacked").'));
+      return Promise.reject(new Error(
+        'The CMap "baseUrl" parameter must be specified, ensure that ' +
+        'the "cMapUrl" and "cMapPacked" API parameters are provided.'));
     }
     if (!name) {
       return Promise.reject(new Error('CMap name must be specified.'));
@@ -398,10 +399,6 @@ function getDefaultSetting(id) {
       return globalSettings ? globalSettings.disableFontFace : false;
     case 'disableCreateObjectURL':
       return globalSettings ? globalSettings.disableCreateObjectURL : false;
-    case 'cMapUrl':
-      return globalSettings ? globalSettings.cMapUrl : null;
-    case 'cMapPacked':
-      return globalSettings ? globalSettings.cMapPacked : false;
     case 'postMessageTransfers':
       return globalSettings ? globalSettings.postMessageTransfers : true;
     case 'workerPort':

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -398,8 +398,6 @@ function getDefaultSetting(id) {
       return globalSettings ? globalSettings.disableFontFace : false;
     case 'disableCreateObjectURL':
       return globalSettings ? globalSettings.disableCreateObjectURL : false;
-    case 'disableWebGL':
-      return globalSettings ? globalSettings.disableWebGL : true;
     case 'cMapUrl':
       return globalSettings ? globalSettings.cMapUrl : null;
     case 'cMapPacked':

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -418,8 +418,6 @@ function getDefaultSetting(id) {
       return globalSettings ? globalSettings.disableWorker : false;
     case 'maxImageSize':
       return globalSettings ? globalSettings.maxImageSize : -1;
-    case 'imageResourcesPath':
-      return globalSettings ? globalSettings.imageResourcesPath : '';
     case 'isEvalSupported':
       return globalSettings ? globalSettings.isEvalSupported : true;
     case 'externalLinkTarget':

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -14,7 +14,7 @@
  */
 
 import {
-  assert, CMapCompressionType, removeNullCharacters, stringToBytes, warn
+  assert, CMapCompressionType, removeNullCharacters, stringToBytes
 } from '../shared/util';
 import globalScope from '../shared/global_scope';
 
@@ -327,15 +327,16 @@ var RenderingCancelledException = (function RenderingCancelledException() {
   return RenderingCancelledException;
 })();
 
-var LinkTarget = {
+const LinkTarget = {
   NONE: 0, // Default value.
   SELF: 1,
   BLANK: 2,
   PARENT: 3,
   TOP: 4,
 };
+const LinkTargetValues = Object.values(LinkTarget);
 
-var LinkTargetStringMap = [
+const LinkTargetStringMap = [
   '',
   '_self',
   '_blank',
@@ -347,8 +348,10 @@ var LinkTargetStringMap = [
  * @typedef ExternalLinkParameters
  * @typedef {Object} ExternalLinkParameters
  * @property {string} url - An absolute URL.
- * @property {LinkTarget} target - The link target.
- * @property {string} rel - The link relationship.
+ * @property {LinkTarget} target - (optional) The link target.
+ *   The default value is `LinkTarget.NONE`.
+ * @property {string} rel - (optional) The link relationship.
+ *   The default value is `DEFAULT_LINK_REL`.
  */
 
 /**
@@ -356,22 +359,15 @@ var LinkTargetStringMap = [
  * @param {HTMLLinkElement} link - The link element.
  * @param {ExternalLinkParameters} params
  */
-function addLinkAttributes(link, params) {
-  var url = params && params.url;
+function addLinkAttributes(link, { url, target, rel, } = {}) {
   link.href = link.title = (url ? removeNullCharacters(url) : '');
 
   if (url) {
-    var target = params.target;
-    if (typeof target === 'undefined') {
-      target = getDefaultSetting('externalLinkTarget');
-    }
-    link.target = LinkTargetStringMap[target];
+    let targetIndex =
+      LinkTargetValues.includes(target) ? target : LinkTarget.NONE;
+    link.target = LinkTargetStringMap[targetIndex];
 
-    var rel = params.rel;
-    if (typeof rel === 'undefined') {
-      rel = getDefaultSetting('externalLinkRel');
-    }
-    link.rel = rel;
+    link.rel = (typeof rel === 'string' ? rel : DEFAULT_LINK_REL);
   }
 }
 
@@ -420,25 +416,6 @@ function getDefaultSetting(id) {
       return globalSettings ? globalSettings.maxImageSize : -1;
     case 'isEvalSupported':
       return globalSettings ? globalSettings.isEvalSupported : true;
-    case 'externalLinkTarget':
-      if (!globalSettings) {
-        return LinkTarget.NONE;
-      }
-      switch (globalSettings.externalLinkTarget) {
-        case LinkTarget.NONE:
-        case LinkTarget.SELF:
-        case LinkTarget.BLANK:
-        case LinkTarget.PARENT:
-        case LinkTarget.TOP:
-          return globalSettings.externalLinkTarget;
-      }
-      warn('PDFJS.externalLinkTarget is invalid: ' +
-           globalSettings.externalLinkTarget);
-      // Reset the external link target, to suppress further warnings.
-      globalSettings.externalLinkTarget = LinkTarget.NONE;
-      return LinkTarget.NONE;
-    case 'externalLinkRel':
-      return globalSettings ? globalSettings.externalLinkRel : DEFAULT_LINK_REL;
     case 'enableStats':
       return !!(globalSettings && globalSettings.enableStats);
     default:
@@ -446,24 +423,10 @@ function getDefaultSetting(id) {
   }
 }
 
-function isExternalLinkTargetSet() {
-  var externalLinkTarget = getDefaultSetting('externalLinkTarget');
-  switch (externalLinkTarget) {
-    case LinkTarget.NONE:
-      return false;
-    case LinkTarget.SELF:
-    case LinkTarget.BLANK:
-    case LinkTarget.PARENT:
-    case LinkTarget.TOP:
-      return true;
-  }
-}
-
 export {
   CustomStyle,
   RenderingCancelledException,
   addLinkAttributes,
-  isExternalLinkTargetSet,
   getFilenameFromUrl,
   LinkTarget,
   getDefaultSetting,

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -387,8 +387,6 @@ function getDefaultSetting(id) {
   // compatibility and shall not be extended or modified. See also global.js.
   var globalSettings = globalScope.PDFJS;
   switch (id) {
-    case 'pdfBug':
-      return globalSettings ? globalSettings.pdfBug : false;
     case 'postMessageTransfers':
       return globalSettings ? globalSettings.postMessageTransfers : true;
     case 'workerPort':
@@ -397,8 +395,6 @@ function getDefaultSetting(id) {
       return globalSettings ? globalSettings.workerSrc : null;
     case 'disableWorker':
       return globalSettings ? globalSettings.disableWorker : false;
-    case 'enableStats':
-      return !!(globalSettings && globalSettings.enableStats);
     default:
       throw new Error('Unknown default setting: ' + id);
   }

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -389,8 +389,6 @@ function getDefaultSetting(id) {
   switch (id) {
     case 'pdfBug':
       return globalSettings ? globalSettings.pdfBug : false;
-    case 'disableCreateObjectURL':
-      return globalSettings ? globalSettings.disableCreateObjectURL : false;
     case 'postMessageTransfers':
       return globalSettings ? globalSettings.postMessageTransfers : true;
     case 'workerPort':

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -410,8 +410,6 @@ function getDefaultSetting(id) {
       return globalSettings ? globalSettings.workerSrc : null;
     case 'disableWorker':
       return globalSettings ? globalSettings.disableWorker : false;
-    case 'maxImageSize':
-      return globalSettings ? globalSettings.maxImageSize : -1;
     case 'isEvalSupported':
       return globalSettings ? globalSettings.isEvalSupported : true;
     case 'enableStats':

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -395,8 +395,6 @@ function getDefaultSetting(id) {
       return globalSettings ? globalSettings.disableStream : false;
     case 'disableRange':
       return globalSettings ? globalSettings.disableRange : false;
-    case 'disableFontFace':
-      return globalSettings ? globalSettings.disableFontFace : false;
     case 'disableCreateObjectURL':
       return globalSettings ? globalSettings.disableCreateObjectURL : false;
     case 'postMessageTransfers':

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -391,8 +391,6 @@ function getDefaultSetting(id) {
       return globalSettings ? globalSettings.pdfBug : false;
     case 'disableStream':
       return globalSettings ? globalSettings.disableStream : false;
-    case 'disableRange':
-      return globalSettings ? globalSettings.disableRange : false;
     case 'disableCreateObjectURL':
       return globalSettings ? globalSettings.disableCreateObjectURL : false;
     case 'postMessageTransfers':

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -87,19 +87,6 @@ PDFJS.PageViewport = PageViewport;
 PDFJS.createPromiseCapability = createPromiseCapability;
 
 /**
- * The url of where the predefined Adobe CMaps are located. Include trailing
- * slash.
- * @var {string}
- */
-PDFJS.cMapUrl = (PDFJS.cMapUrl === undefined ? null : PDFJS.cMapUrl);
-
-/**
- * Specifies if CMaps are binary packed.
- * @var {boolean}
- */
-PDFJS.cMapPacked = PDFJS.cMapPacked === undefined ? false : PDFJS.cMapPacked;
-
-/**
  * By default fonts are converted to OpenType fonts and loaded via font face
  * rules. If disabled, the font will be rendered using a built in font
  * renderer that constructs the glyphs with primitive path commands.

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -169,14 +169,6 @@ PDFJS.postMessageTransfers = (PDFJS.postMessageTransfers === undefined ?
 PDFJS.disableCreateObjectURL = (PDFJS.disableCreateObjectURL === undefined ?
                                 false : PDFJS.disableCreateObjectURL);
 
-/**
-  * Determines if we can eval strings as JS. Primarily used to improve
-  * performance for font rendering.
-  * @var {boolean}
-  */
-PDFJS.isEvalSupported = (PDFJS.isEvalSupported === undefined ?
-                         true : PDFJS.isEvalSupported);
-
 PDFJS.getDocument = getDocument;
 PDFJS.LoopbackPort = LoopbackPort;
 PDFJS.PDFDataRangeTransport = PDFDataRangeTransport;

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -112,14 +112,6 @@ PDFJS.workerSrc = (PDFJS.workerSrc === undefined ? null : PDFJS.workerSrc);
 PDFJS.workerPort = (PDFJS.workerPort === undefined ? null : PDFJS.workerPort);
 
 /**
- * Disable streaming of PDF file data. By default PDF.js attempts to load PDF
- * in chunks. This default behavior can be disabled.
- * @var {boolean}
- */
-PDFJS.disableStream = (PDFJS.disableStream === undefined ?
-                       false : PDFJS.disableStream);
-
-/**
  * Enables special hooks for debugging PDF.js.
  * @var {boolean}
  */

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -87,14 +87,6 @@ PDFJS.PageViewport = PageViewport;
 PDFJS.createPromiseCapability = createPromiseCapability;
 
 /**
- * The maximum allowed image size in total pixels e.g. width * height. Images
- * above this value will not be drawn. Use -1 for no limit.
- * @var {number}
- */
-PDFJS.maxImageSize = (PDFJS.maxImageSize === undefined ?
-                      -1 : PDFJS.maxImageSize);
-
-/**
  * The url of where the predefined Adobe CMaps are located. Include trailing
  * slash.
  * @var {string}

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -191,13 +191,6 @@ PDFJS.disableCreateObjectURL = (PDFJS.disableCreateObjectURL === undefined ?
                                 false : PDFJS.disableCreateObjectURL);
 
 /**
- * Disables WebGL usage.
- * @var {boolean}
- */
-PDFJS.disableWebGL = (PDFJS.disableWebGL === undefined ?
-                      true : PDFJS.disableWebGL);
-
-/**
   * Determines if we can eval strings as JS. Primarily used to improve
   * performance for font rendering.
   * @var {boolean}

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -14,16 +14,13 @@
  */
 
 import {
-  addLinkAttributes, CustomStyle, DEFAULT_LINK_REL, getFilenameFromUrl,
-  isExternalLinkTargetSet, isValidUrl, LinkTarget
-} from './dom_utils';
-import {
   createBlob, createObjectURL, createPromiseCapability, getVerbosityLevel,
   InvalidPDFException, isLittleEndian, MissingPDFException, OPS, PageViewport,
   PasswordException, PasswordResponses, removeNullCharacters, setVerbosityLevel,
   shadow, UnexpectedResponseException, UnknownErrorException,
   UNSUPPORTED_FEATURES, Util, VERBOSITY_LEVELS
 } from '../shared/util';
+import { CustomStyle, getFilenameFromUrl } from './dom_utils';
 import {
   getDocument, LoopbackPort, PDFDataRangeTransport, PDFWorker
 } from './api';
@@ -67,7 +64,6 @@ Object.defineProperty(PDFJS, 'verbosity', {
 PDFJS.VERBOSITY_LEVELS = VERBOSITY_LEVELS;
 PDFJS.OPS = OPS;
 PDFJS.UNSUPPORTED_FEATURES = UNSUPPORTED_FEATURES;
-PDFJS.isValidUrl = isValidUrl;
 PDFJS.shadow = shadow;
 PDFJS.createBlob = createBlob;
 PDFJS.createObjectURL = function PDFJS_createObjectURL(data, contentType) {
@@ -202,27 +198,6 @@ PDFJS.disableWebGL = (PDFJS.disableWebGL === undefined ?
                       true : PDFJS.disableWebGL);
 
 /**
- * Specifies the |target| attribute for external links.
- * The constants from PDFJS.LinkTarget should be used:
- *  - NONE [default]
- *  - SELF
- *  - BLANK
- *  - PARENT
- *  - TOP
- * @var {number}
- */
-PDFJS.externalLinkTarget = (PDFJS.externalLinkTarget === undefined ?
-                            LinkTarget.NONE : PDFJS.externalLinkTarget);
-
-/**
- * Specifies the |rel| attribute for external links. Defaults to stripping
- * the referrer.
- * @var {string}
- */
-PDFJS.externalLinkRel = (PDFJS.externalLinkRel === undefined ?
-                         DEFAULT_LINK_REL : PDFJS.externalLinkRel);
-
-/**
   * Determines if we can eval strings as JS. Primarily used to improve
   * performance for font rendering.
   * @var {boolean}
@@ -236,10 +211,7 @@ PDFJS.PDFDataRangeTransport = PDFDataRangeTransport;
 PDFJS.PDFWorker = PDFWorker;
 
 PDFJS.CustomStyle = CustomStyle;
-PDFJS.LinkTarget = LinkTarget;
-PDFJS.addLinkAttributes = addLinkAttributes;
 PDFJS.getFilenameFromUrl = getFilenameFromUrl;
-PDFJS.isExternalLinkTargetSet = isExternalLinkTargetSet;
 
 PDFJS.AnnotationLayer = AnnotationLayer;
 

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -121,14 +121,6 @@ PDFJS.disableFontFace = (PDFJS.disableFontFace === undefined ?
                          false : PDFJS.disableFontFace);
 
 /**
- * Path for image resources, mainly for annotation icons. Include trailing
- * slash.
- * @var {string}
- */
-PDFJS.imageResourcesPath = (PDFJS.imageResourcesPath === undefined ?
-                            '' : PDFJS.imageResourcesPath);
-
-/**
  * Disable the web worker and run all code on the main thread. This will
  * happen automatically if the browser doesn't support workers or sending
  * typed arrays to workers.

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -87,15 +87,6 @@ PDFJS.PageViewport = PageViewport;
 PDFJS.createPromiseCapability = createPromiseCapability;
 
 /**
- * By default fonts are converted to OpenType fonts and loaded via font face
- * rules. If disabled, the font will be rendered using a built in font
- * renderer that constructs the glyphs with primitive path commands.
- * @var {boolean}
- */
-PDFJS.disableFontFace = (PDFJS.disableFontFace === undefined ?
-                         false : PDFJS.disableFontFace);
-
-/**
  * Disable the web worker and run all code on the main thread. This will
  * happen automatically if the browser doesn't support workers or sending
  * typed arrays to workers.

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -112,15 +112,6 @@ PDFJS.workerSrc = (PDFJS.workerSrc === undefined ? null : PDFJS.workerSrc);
 PDFJS.workerPort = (PDFJS.workerPort === undefined ? null : PDFJS.workerPort);
 
 /**
- * Disable range request loading of PDF files. When enabled and if the server
- * supports partial content requests then the PDF will be fetched in chunks.
- * Enabled (false) by default.
- * @var {boolean}
- */
-PDFJS.disableRange = (PDFJS.disableRange === undefined ?
-                      false : PDFJS.disableRange);
-
-/**
  * Disable streaming of PDF file data. By default PDF.js attempts to load PDF
  * in chunks. This default behavior can be disabled.
  * @var {boolean}

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -44,8 +44,6 @@ if (typeof PDFJSDev !== 'undefined') {
   PDFJS.build = PDFJSDev.eval('BUNDLE_BUILD');
 }
 
-PDFJS.pdfBug = false;
-
 if (PDFJS.verbosity !== undefined) {
   setVerbosityLevel(PDFJS.verbosity);
 }
@@ -106,12 +104,6 @@ PDFJS.workerSrc = (PDFJS.workerSrc === undefined ? null : PDFJS.workerSrc);
  * disableWorker setting.
  */
 PDFJS.workerPort = (PDFJS.workerPort === undefined ? null : PDFJS.workerPort);
-
-/**
- * Enables special hooks for debugging PDF.js.
- * @var {boolean}
- */
-PDFJS.pdfBug = (PDFJS.pdfBug === undefined ? false : PDFJS.pdfBug);
 
 /**
  * Enables transfer usage in postMessage for ArrayBuffers.

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -14,11 +14,11 @@
  */
 
 import {
-  createBlob, createObjectURL, createPromiseCapability, getVerbosityLevel,
-  InvalidPDFException, isLittleEndian, MissingPDFException, OPS, PageViewport,
-  PasswordException, PasswordResponses, removeNullCharacters, setVerbosityLevel,
-  shadow, UnexpectedResponseException, UnknownErrorException,
-  UNSUPPORTED_FEATURES, Util, VERBOSITY_LEVELS
+  createPromiseCapability, getVerbosityLevel, InvalidPDFException,
+  isLittleEndian, MissingPDFException, OPS, PageViewport, PasswordException,
+  PasswordResponses, removeNullCharacters, setVerbosityLevel, shadow,
+  UnexpectedResponseException, UnknownErrorException, UNSUPPORTED_FEATURES,
+  Util, VERBOSITY_LEVELS
 } from '../shared/util';
 import { CustomStyle, getFilenameFromUrl } from './dom_utils';
 import {
@@ -65,10 +65,6 @@ PDFJS.VERBOSITY_LEVELS = VERBOSITY_LEVELS;
 PDFJS.OPS = OPS;
 PDFJS.UNSUPPORTED_FEATURES = UNSUPPORTED_FEATURES;
 PDFJS.shadow = shadow;
-PDFJS.createBlob = createBlob;
-PDFJS.createObjectURL = function PDFJS_createObjectURL(data, contentType) {
-  return createObjectURL(data, contentType, PDFJS.disableCreateObjectURL);
-};
 Object.defineProperty(PDFJS, 'isLittleEndian', {
   configurable: true,
   get: function PDFJS_isLittleEndian() {
@@ -123,13 +119,6 @@ PDFJS.pdfBug = (PDFJS.pdfBug === undefined ? false : PDFJS.pdfBug);
  */
 PDFJS.postMessageTransfers = (PDFJS.postMessageTransfers === undefined ?
                               true : PDFJS.postMessageTransfers);
-
-/**
- * Disables URL.createObjectURL usage.
- * @var {boolean}
- */
-PDFJS.disableCreateObjectURL = (PDFJS.disableCreateObjectURL === undefined ?
-                                false : PDFJS.disableCreateObjectURL);
 
 PDFJS.getDocument = getDocument;
 PDFJS.LoopbackPort = LoopbackPort;

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -129,18 +129,6 @@ PDFJS.disableStream = (PDFJS.disableStream === undefined ?
                        false : PDFJS.disableStream);
 
 /**
- * Disable pre-fetching of PDF file data. When range requests are enabled
- * PDF.js will automatically keep fetching more data even if it isn't needed
- * to display the current page. This default behavior can be disabled.
- *
- * NOTE: It is also necessary to disable streaming, see above,
- *       in order for disabling of pre-fetching to work correctly.
- * @var {boolean}
- */
-PDFJS.disableAutoFetch = (PDFJS.disableAutoFetch === undefined ?
-                          false : PDFJS.disableAutoFetch);
-
-/**
  * Enables special hooks for debugging PDF.js.
  * @var {boolean}
  */

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -14,7 +14,8 @@
  */
 
 import { AbortException, createPromiseCapability, Util } from '../shared/util';
-import { CustomStyle, getDefaultSetting } from './dom_utils';
+import { CustomStyle } from './dom_utils';
+import globalScope from '../shared/global_scope';
 
 /**
  * Text layer render parameters.
@@ -107,11 +108,9 @@ var renderTextLayer = (function renderTextLayerClosure() {
     textDiv.setAttribute('style', textDivProperties.style);
 
     textDiv.textContent = geom.str;
-    // |fontName| is only used by the Font Inspector. This test will succeed
-    // when e.g. the Font Inspector is off but the Stepper is on, but it's
-    // not worth the effort to do a more accurate test. We only use `dataset`
-    // here to make the font name available for the debugger.
-    if (getDefaultSetting('pdfBug')) {
+    // `fontName` is only used by the FontInspector, and we only use `dataset`
+    // here to make the font name available in the debugger.
+    if (task._fontInspectorEnabled) {
       textDiv.dataset.fontName = geom.fontName;
     }
     if (angle !== 0) {
@@ -479,6 +478,8 @@ var renderTextLayer = (function renderTextLayerClosure() {
     this._textDivs = textDivs || [];
     this._textContentItemsStr = textContentItemsStr || [];
     this._enhanceTextSelection = !!enhanceTextSelection;
+    this._fontInspectorEnabled = (globalScope.FontInspector &&
+                                  globalScope.FontInspector.enabled) || false;
 
     this._reader = null;
     this._layoutTextLastFontSize = null;

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -28,6 +28,7 @@ var pdfjsDisplayTextLayer = require('./display/text_layer.js');
 var pdfjsDisplayAnnotationLayer = require('./display/annotation_layer.js');
 var pdfjsDisplayDOMUtils = require('./display/dom_utils.js');
 var pdfjsDisplaySVG = require('./display/svg.js');
+var pdfjsDisplayAPICompatibility = require('./display/api_compatibility.js');
 
 if (typeof PDFJSDev === 'undefined' ||
     !PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
@@ -74,3 +75,5 @@ exports.RenderingCancelledException =
 exports.getFilenameFromUrl = pdfjsDisplayDOMUtils.getFilenameFromUrl;
 exports.addLinkAttributes = pdfjsDisplayDOMUtils.addLinkAttributes;
 exports.StatTimer = pdfjsSharedUtil.StatTimer;
+exports.apiCompatibilityParams =
+  pdfjsDisplayAPICompatibility.apiCompatibilityParams;

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -73,6 +73,7 @@ exports.createBlob = pdfjsSharedUtil.createBlob;
 exports.RenderingCancelledException =
   pdfjsDisplayDOMUtils.RenderingCancelledException;
 exports.getFilenameFromUrl = pdfjsDisplayDOMUtils.getFilenameFromUrl;
+exports.LinkTarget = pdfjsDisplayDOMUtils.LinkTarget;
 exports.addLinkAttributes = pdfjsDisplayDOMUtils.addLinkAttributes;
 exports.StatTimer = pdfjsSharedUtil.StatTimer;
 exports.apiCompatibilityParams =

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -29,7 +29,6 @@ var isAndroidPre5 = /Android\s[0-4][^\d]/.test(userAgent);
 var isChrome = userAgent.indexOf('Chrom') >= 0;
 var isIOSChrome = userAgent.indexOf('CriOS') >= 0;
 var isIE = userAgent.indexOf('Trident') >= 0;
-var isIOS = /\b(iPad|iPhone|iPod)(?=;)/.test(userAgent);
 var isOpera = userAgent.indexOf('Opera') >= 0;
 var isSafari = /Safari\//.test(userAgent) &&
                !/(Chrome\/|Android\s)/.test(userAgent);
@@ -373,16 +372,6 @@ PDFJS.compatibilityChecked = true;
   // createObjectURL(), see #3977 and #8081
   if (isIE || isIOSChrome) {
     PDFJS.disableCreateObjectURL = true;
-  }
-})();
-
-// Support: Safari 6.0+, iOS
-(function checkRangeRequests() {
-  // Safari has issues with cached range requests see:
-  // https://github.com/mozilla/pdf.js/issues/3260
-  // Last tested with version 6.0.4.
-  if (isSafari || isIOS) {
-    PDFJS.disableStream = true;
   }
 })();
 

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -382,7 +382,6 @@ PDFJS.compatibilityChecked = true;
   // https://github.com/mozilla/pdf.js/issues/3260
   // Last tested with version 6.0.4.
   if (isSafari || isIOS) {
-    PDFJS.disableRange = true;
     PDFJS.disableStream = true;
   }
 })();

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -27,8 +27,6 @@ var userAgent = (typeof navigator !== 'undefined' && navigator.userAgent) || '';
 var isAndroid = /Android/.test(userAgent);
 var isAndroidPre5 = /Android\s[0-4][^\d]/.test(userAgent);
 var isChrome = userAgent.indexOf('Chrom') >= 0;
-var isIOSChrome = userAgent.indexOf('CriOS') >= 0;
-var isIE = userAgent.indexOf('Trident') >= 0;
 var isOpera = userAgent.indexOf('Opera') >= 0;
 var isSafari = /Safari\//.test(userAgent) &&
                !/(Chrome\/|Android\s)/.test(userAgent);
@@ -362,16 +360,6 @@ PDFJS.compatibilityChecked = true;
   if (isOpera) {
     // use browser detection since we cannot feature-check this bug
     document.addEventListener('click', ignoreIfTargetDisabled, true);
-  }
-})();
-
-// Checks if possible to use URL.createObjectURL()
-// Support: IE, Chrome on iOS
-(function checkOnBlobSupport() {
-  // sometimes IE and Chrome on iOS loosing the data created with
-  // createObjectURL(), see #3977 and #8081
-  if (isIE || isIOSChrome) {
-    PDFJS.disableCreateObjectURL = true;
   }
 })();
 

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -376,17 +376,6 @@ PDFJS.compatibilityChecked = true;
   }
 })();
 
-// Checks if navigator.language is supported
-(function checkNavigatorLanguage() {
-  if (typeof navigator === 'undefined') {
-    return;
-  }
-  if ('language' in navigator) {
-    return;
-  }
-  PDFJS.locale = navigator.userLanguage || 'en-US';
-})();
-
 // Support: Safari 6.0+, iOS
 (function checkRangeRequests() {
   // Safari has issues with cached range requests see:
@@ -447,25 +436,6 @@ PDFJS.compatibilityChecked = true;
       // this closure will be kept referenced, so clear its vars
       contextPrototype = null;
     }
-  }
-})();
-
-// Support: Android, iOS
-(function checkCanvasSizeLimitation() {
-  if (isIOS || isAndroid) {
-    // 5MP
-    PDFJS.maxCanvasPixels = 5242880;
-  }
-})();
-
-// Disable fullscreen support for certain problematic configurations.
-// Support: IE11+ (when embedded).
-(function checkFullscreenSupport() {
-  if (!hasDOM) {
-    return;
-  }
-  if (isIE && window.parent !== window) {
-    PDFJS.disableFullscreen = true;
   }
 })();
 

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1125,10 +1125,10 @@ var StatTimer = (function StatTimerClosure() {
     }
     return str;
   }
-  function StatTimer() {
+  function StatTimer(enable = true) {
     this.started = Object.create(null);
     this.times = [];
-    this.enabled = true;
+    this.enabled = !!enable;
   }
   StatTimer.prototype = {
     time: function StatTimer_time(name) {

--- a/test/driver.js
+++ b/test/driver.js
@@ -18,6 +18,7 @@
 
 var WAITING_TIME = 100; // ms
 var PDF_TO_CSS_UNITS = 96.0 / 72.0;
+const IMAGE_RESOURCES_PATH = '/web/images/';
 
 var StatTimer = pdfjsDistBuildPdf.StatTimer;
 
@@ -166,6 +167,7 @@ var rasterizeAnnotationLayer = (function rasterizeAnnotationLayerClosure() {
   }
 
   function rasterizeAnnotationLayer(ctx, viewport, annotations, page,
+                                    imageResourcesPath,
                                     renderInteractiveForms) {
     return new Promise(function (resolve) {
       // Building SVG with size of the viewport.
@@ -196,6 +198,7 @@ var rasterizeAnnotationLayer = (function rasterizeAnnotationLayerClosure() {
           annotations,
           page,
           linkService: new PDFJS.SimpleLinkService(),
+          imageResourcesPath,
           renderInteractiveForms,
         };
         PDFJS.AnnotationLayer.render(parameters);
@@ -254,7 +257,6 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
     PDFJS.cMapPacked = true;
     PDFJS.cMapUrl = '../external/bcmaps/';
     PDFJS.enableStats = true;
-    PDFJS.imageResourcesPath = '/web/images/';
 
     // Set the passed options
     this.inflight = options.inflight;
@@ -509,7 +511,9 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
                     function(annotations) {
                       return rasterizeAnnotationLayer(annotationLayerContext,
                                                       viewport, annotations,
-                                                      page, renderForms);
+                                                      page,
+                                                      IMAGE_RESOURCES_PATH,
+                                                      renderForms);
                   });
               } else {
                 annotationLayerCanvas = null;

--- a/test/driver.js
+++ b/test/driver.js
@@ -343,7 +343,6 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
 
         let absoluteUrl = new URL(task.file, window.location).href;
         PDFJS.disableRange = task.disableRange;
-        PDFJS.disableAutoFetch = !task.enableAutoFetch;
         try {
           PDFJS.getDocument({
             url: absoluteUrl,
@@ -351,6 +350,7 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
             nativeImageDecoderSupport: task.nativeImageDecoderSupport,
             cMapUrl: CMAP_URL,
             cMapPacked: CMAP_PACKED,
+            disableAutoFetch: !task.enableAutoFetch,
           }).then((doc) => {
             task.pdfDoc = doc;
             this._nextPage(task, failure);

--- a/test/driver.js
+++ b/test/driver.js
@@ -342,7 +342,6 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
         this._log('Loading file "' + task.file + '"\n');
 
         let absoluteUrl = new URL(task.file, window.location).href;
-        PDFJS.disableRange = task.disableRange;
         try {
           PDFJS.getDocument({
             url: absoluteUrl,
@@ -350,6 +349,7 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
             nativeImageDecoderSupport: task.nativeImageDecoderSupport,
             cMapUrl: CMAP_URL,
             cMapPacked: CMAP_PACKED,
+            disableRange: task.disableRange,
             disableAutoFetch: !task.enableAutoFetch,
           }).then((doc) => {
             task.pdfDoc = doc;

--- a/test/driver.js
+++ b/test/driver.js
@@ -18,6 +18,8 @@
 
 var WAITING_TIME = 100; // ms
 var PDF_TO_CSS_UNITS = 96.0 / 72.0;
+const CMAP_URL = '../external/bcmaps/';
+const CMAP_PACKED = true;
 const IMAGE_RESOURCES_PATH = '/web/images/';
 
 var StatTimer = pdfjsDistBuildPdf.StatTimer;
@@ -254,8 +256,6 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
   function Driver(options) {
     // Configure the global PDFJS object
     PDFJS.workerSrc = '../build/generic/build/pdf.worker.js';
-    PDFJS.cMapPacked = true;
-    PDFJS.cMapUrl = '../external/bcmaps/';
     PDFJS.enableStats = true;
 
     // Set the passed options
@@ -349,6 +349,8 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
             url: absoluteUrl,
             password: task.password,
             nativeImageDecoderSupport: task.nativeImageDecoderSupport,
+            cMapUrl: CMAP_URL,
+            cMapPacked: CMAP_PACKED,
           }).then((doc) => {
             task.pdfDoc = doc;
             this._nextPage(task, failure);

--- a/test/driver.js
+++ b/test/driver.js
@@ -256,7 +256,6 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
   function Driver(options) {
     // Configure the global PDFJS object
     PDFJS.workerSrc = '../build/generic/build/pdf.worker.js';
-    PDFJS.enableStats = true;
 
     // Set the passed options
     this.inflight = options.inflight;
@@ -351,6 +350,7 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
             cMapPacked: CMAP_PACKED,
             disableRange: task.disableRange,
             disableAutoFetch: !task.enableAutoFetch,
+            pdfBug: true,
           }).then((doc) => {
             task.pdfDoc = doc;
             this._nextPage(task, failure);

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -281,8 +281,9 @@ describe('cmap', function() {
       done.fail('No CMap should be loaded');
     }, function (reason) {
       expect(reason instanceof Error).toEqual(true);
-      expect(reason.message).toEqual('CMap baseUrl must be specified, ' +
-        'see "PDFJS.cMapUrl" (and also "PDFJS.cMapPacked").');
+      expect(reason.message).toEqual(
+        'The CMap "baseUrl" parameter must be specified, ensure that ' +
+        'the "cMapUrl" and "cMapPacked" API parameters are provided.');
       done();
     });
   });

--- a/test/unit/dom_utils_spec.js
+++ b/test/unit/dom_utils_spec.js
@@ -13,11 +13,8 @@
  * limitations under the License.
  */
 
-import {
-  DOMSVGFactory, getFilenameFromUrl, isExternalLinkTargetSet, LinkTarget
-} from '../../src/display/dom_utils';
+import { DOMSVGFactory, getFilenameFromUrl } from '../../src/display/dom_utils';
 import { isNodeJS } from '../../src/shared/util';
-import { PDFJS } from '../../src/display/global';
 
 describe('dom_utils', function() {
   describe('DOMSVGFactory', function() {
@@ -93,39 +90,6 @@ describe('dom_utils', function() {
       var result = getFilenameFromUrl(url);
       var expected = 'filename.pdf';
       expect(result).toEqual(expected);
-    });
-  });
-
-  describe('isExternalLinkTargetSet', function() {
-    var savedExternalLinkTarget;
-
-    beforeAll(function (done) {
-      savedExternalLinkTarget = PDFJS.externalLinkTarget;
-      done();
-    });
-
-    afterAll(function () {
-      PDFJS.externalLinkTarget = savedExternalLinkTarget;
-    });
-
-    it('handles the predefined LinkTargets', function() {
-      for (var key in LinkTarget) {
-        var linkTarget = LinkTarget[key];
-        PDFJS.externalLinkTarget = linkTarget;
-
-        expect(isExternalLinkTargetSet()).toEqual(!!linkTarget);
-      }
-    });
-
-    it('handles incorrect LinkTargets', function() {
-      var targets = [true, '', false, -1, '_blank', null];
-
-      for (var i = 0, ii = targets.length; i < ii; i++) {
-        var linkTarget = targets[i];
-        PDFJS.externalLinkTarget = linkTarget;
-
-        expect(isExternalLinkTargetSet()).toEqual(false);
-      }
     });
   });
 });

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -52,8 +52,9 @@ class NodeCMapReaderFactory {
 
   fetch({ name, }) {
     if (!this.baseUrl) {
-      return Promise.reject(new Error('CMap baseUrl must be specified, ' +
-        'see "PDFJS.cMapUrl" (and also "PDFJS.cMapPacked").'));
+      return Promise.reject(new Error(
+        'The CMap "baseUrl" parameter must be specified, ensure that ' +
+        'the "cMapUrl" and "cMapPacked" API parameters are provided.'));
     }
     if (!name) {
       return Promise.reject(new Error('CMap name must be specified.'));

--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -21,6 +21,8 @@ import { SimpleLinkService } from './pdf_link_service';
  * @typedef {Object} AnnotationLayerBuilderOptions
  * @property {HTMLDivElement} pageDiv
  * @property {PDFPage} pdfPage
+ * @property {string} imageResourcesPath - (optional) Path for image resources,
+ *   mainly for annotation icons. Include trailing slash.
  * @property {boolean} renderInteractiveForms
  * @property {IPDFLinkService} linkService
  * @property {DownloadManager} downloadManager
@@ -32,11 +34,13 @@ class AnnotationLayerBuilder {
    * @param {AnnotationLayerBuilderOptions} options
    */
   constructor({ pageDiv, pdfPage, linkService, downloadManager,
-                renderInteractiveForms = false, l10n = NullL10n, }) {
+                imageResourcesPath = '', renderInteractiveForms = false,
+                l10n = NullL10n, }) {
     this.pageDiv = pageDiv;
     this.pdfPage = pdfPage;
     this.linkService = linkService;
     this.downloadManager = downloadManager;
+    this.imageResourcesPath = imageResourcesPath;
     this.renderInteractiveForms = renderInteractiveForms;
     this.l10n = l10n;
 
@@ -59,6 +63,7 @@ class AnnotationLayerBuilder {
         div: this.div,
         annotations,
         page: this.pdfPage,
+        imageResourcesPath: this.imageResourcesPath,
         renderInteractiveForms: this.renderInteractiveForms,
         linkService: this.linkService,
         downloadManager: this.downloadManager,
@@ -104,15 +109,19 @@ class DefaultAnnotationLayerFactory {
   /**
    * @param {HTMLDivElement} pageDiv
    * @param {PDFPage} pdfPage
+   * @param {string} imageResourcesPath - (optional) Path for image resources,
+   *   mainly for annotation icons. Include trailing slash.
    * @param {boolean} renderInteractiveForms
    * @param {IL10n} l10n
    * @returns {AnnotationLayerBuilder}
    */
-  createAnnotationLayerBuilder(pageDiv, pdfPage, renderInteractiveForms = false,
+  createAnnotationLayerBuilder(pageDiv, pdfPage, imageResourcesPath = '',
+                               renderInteractiveForms = false,
                                l10n = NullL10n) {
     return new AnnotationLayerBuilder({
       pageDiv,
       pdfPage,
+      imageResourcesPath,
       renderInteractiveForms,
       linkService: new SimpleLinkService(),
       l10n,

--- a/web/app.js
+++ b/web/app.js
@@ -386,6 +386,7 @@ let PDFViewerApplication = {
         renderInteractiveForms: AppOptions.get('renderInteractiveForms'),
         enablePrintAutoRotate: AppOptions.get('enablePrintAutoRotate'),
         useOnlyCssZoom: AppOptions.get('useOnlyCssZoom'),
+        maxCanvasPixels: AppOptions.get('maxCanvasPixels'),
       });
       pdfRenderingQueue.setViewer(this.pdfViewer);
       pdfLinkService.setViewer(this.pdfViewer);

--- a/web/app.js
+++ b/web/app.js
@@ -726,6 +726,11 @@ let PDFViewerApplication = {
                PDFJSDev.test('FIREFOX || MOZCENTRAL || CHROME')) {
       parameters.docBaseUrl = this.baseUrl;
     }
+    // Set the necessary API parameters, using the available options.
+    let apiParameters = AppOptions.getAll('api');
+    for (let key in apiParameters) {
+      parameters[key] = apiParameters[key];
+    }
 
     if (args) {
       for (let prop in args) {

--- a/web/app.js
+++ b/web/app.js
@@ -221,10 +221,10 @@ let PDFViewerApplication = {
         PDFJS.disableAutoFetch = value;
       }),
       preferences.get('disableFontFace').then(function resolved(value) {
-        if (PDFJS.disableFontFace === true) {
+        if (AppOptions.get('disableFontFace') === true) {
           return;
         }
-        PDFJS.disableFontFace = value;
+        AppOptions.set('disableFontFace', value);
       }),
       preferences.get('useOnlyCssZoom').then(function resolved(value) {
         AppOptions.set('useOnlyCssZoom', value);
@@ -278,7 +278,8 @@ let PDFViewerApplication = {
         PDFJS.disableAutoFetch = (hashParams['disableautofetch'] === 'true');
       }
       if ('disablefontface' in hashParams) {
-        PDFJS.disableFontFace = (hashParams['disablefontface'] === 'true');
+        AppOptions.set('disableFontFace',
+                       hashParams['disablefontface'] === 'true');
       }
       if ('disablehistory' in hashParams) {
         AppOptions.set('disableHistory',
@@ -1558,7 +1559,7 @@ function webViewerInitialized() {
   if (typeof PDFJSDev !== 'undefined' &&
       PDFJSDev.test('FIREFOX || MOZCENTRAL') &&
       !PDFViewerApplication.supportsDocumentFonts) {
-    PDFJS.disableFontFace = true;
+    AppOptions.set('disableFontFace', true);
     PDFViewerApplication.l10n.get('web_fonts_disabled', null,
       'Web fonts are disabled: unable to use embedded PDF fonts.').
         then((msg) => {

--- a/web/app.js
+++ b/web/app.js
@@ -50,7 +50,6 @@ const DEFAULT_SCALE_DELTA = 1.1;
 const DISABLE_AUTO_FETCH_LOADING_BAR_TIMEOUT = 5000;
 
 function configure(PDFJS) {
-  PDFJS.imageResourcesPath = './images/';
   if (typeof PDFJSDev !== 'undefined' &&
       PDFJSDev.test('FIREFOX || MOZCENTRAL || GENERIC || CHROME')) {
     PDFJS.workerSrc = '../build/pdf.worker.js';

--- a/web/app.js
+++ b/web/app.js
@@ -212,10 +212,10 @@ let PDFViewerApplication = {
         AppOptions.set('disableRange', value);
       }),
       preferences.get('disableStream').then(function resolved(value) {
-        if (PDFJS.disableStream === true) {
+        if (AppOptions.get('disableStream') === true) {
           return;
         }
-        PDFJS.disableStream = value;
+        AppOptions.set('disableStream', value);
       }),
       preferences.get('disableAutoFetch').then(function resolved(value) {
         AppOptions.set('disableAutoFetch', value);
@@ -272,7 +272,7 @@ let PDFViewerApplication = {
         AppOptions.set('disableRange', hashParams['disablerange'] === 'true');
       }
       if ('disablestream' in hashParams) {
-        PDFJS.disableStream = (hashParams['disablestream'] === 'true');
+        AppOptions.set('disableStream', hashParams['disablestream'] === 'true');
       }
       if ('disableautofetch' in hashParams) {
         AppOptions.set('disableAutoFetch',

--- a/web/app.js
+++ b/web/app.js
@@ -63,7 +63,7 @@ const DefaultExternalServices = {
   initPassiveLoading(callbacks) {},
   fallback(data, callback) {},
   reportTelemetry(data) {},
-  createDownloadManager() {
+  createDownloadManager(options) {
     throw new Error('Not implemented: createDownloadManager');
   },
   createPreferences() {
@@ -365,7 +365,9 @@ let PDFViewerApplication = {
       });
       this.pdfLinkService = pdfLinkService;
 
-      let downloadManager = this.externalServices.createDownloadManager();
+      let downloadManager = this.externalServices.createDownloadManager({
+        disableCreateObjectURL: AppOptions.get('disableCreateObjectURL'),
+      });
       this.downloadManager = downloadManager;
 
       let container = appConfig.mainContainer;
@@ -1826,7 +1828,7 @@ if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
   webViewerFileInputChange = function webViewerFileInputChange(evt) {
     let file = evt.fileInput.files[0];
 
-    if (!PDFJS.disableCreateObjectURL && URL.createObjectURL) {
+    if (!AppOptions.get('disableCreateObjectURL') && URL.createObjectURL) {
       PDFViewerApplication.open(URL.createObjectURL(file));
     } else {
       // Read the local file into a Uint8Array.

--- a/web/app.js
+++ b/web/app.js
@@ -385,6 +385,7 @@ let PDFViewerApplication = {
         enhanceTextSelection: AppOptions.get('enhanceTextSelection'),
         renderInteractiveForms: AppOptions.get('renderInteractiveForms'),
         enablePrintAutoRotate: AppOptions.get('enablePrintAutoRotate'),
+        useOnlyCssZoom: AppOptions.get('useOnlyCssZoom'),
       });
       pdfRenderingQueue.setViewer(this.pdfViewer);
       pdfLinkService.setViewer(this.pdfViewer);

--- a/web/app.js
+++ b/web/app.js
@@ -21,8 +21,8 @@ import {
 } from './ui_utils';
 import {
   build, createBlob, getDocument, getFilenameFromUrl, InvalidPDFException,
-  MissingPDFException, OPS, PDFJS, shadow, UnexpectedResponseException,
-  UNSUPPORTED_FEATURES, version
+  LinkTarget, MissingPDFException, OPS, PDFJS, shadow,
+  UnexpectedResponseException, UNSUPPORTED_FEATURES, version
 } from 'pdfjs-lib';
 import { CursorTool, PDFCursorTools } from './pdf_cursor_tools';
 import { PDFRenderingQueue, RenderingStates } from './pdf_rendering_queue';
@@ -169,10 +169,10 @@ let PDFViewerApplication = {
         this.eventBus.dispatch('localized');
       });
 
-      if (this.isViewerEmbedded && !PDFJS.isExternalLinkTargetSet()) {
+      if (this.isViewerEmbedded && !AppOptions.get('externalLinkTarget')) {
         // Prevent external links from "replacing" the viewer,
         // when it's embedded in e.g. an iframe or an object.
-        PDFJS.externalLinkTarget = PDFJS.LinkTarget.TOP;
+        AppOptions.set('externalLinkTarget', LinkTarget.TOP);
       }
 
       this.initialized = true;
@@ -235,10 +235,10 @@ let PDFViewerApplication = {
         AppOptions.set('useOnlyCssZoom', value);
       }),
       preferences.get('externalLinkTarget').then(function resolved(value) {
-        if (PDFJS.isExternalLinkTargetSet()) {
+        if (!AppOptions.get('externalLinkTarget')) {
           return;
         }
-        PDFJS.externalLinkTarget = value;
+        AppOptions.set('externalLinkTarget', value);
       }),
       preferences.get('renderer').then(function resolved(value) {
         AppOptions.set('renderer', value);
@@ -363,6 +363,8 @@ let PDFViewerApplication = {
 
       let pdfLinkService = new PDFLinkService({
         eventBus,
+        externalLinkTarget: AppOptions.get('externalLinkTarget'),
+        externalLinkRel: AppOptions.get('externalLinkRel'),
       });
       this.pdfLinkService = pdfLinkService;
 

--- a/web/app.js
+++ b/web/app.js
@@ -206,10 +206,10 @@ let PDFViewerApplication = {
         AppOptions.set('disableTextLayer', value);
       }),
       preferences.get('disableRange').then(function resolved(value) {
-        if (PDFJS.disableRange === true) {
+        if (AppOptions.get('disableRange') === true) {
           return;
         }
-        PDFJS.disableRange = value;
+        AppOptions.set('disableRange', value);
       }),
       preferences.get('disableStream').then(function resolved(value) {
         if (PDFJS.disableStream === true) {
@@ -269,7 +269,7 @@ let PDFViewerApplication = {
         PDFJS.disableWorker = (hashParams['disableworker'] === 'true');
       }
       if ('disablerange' in hashParams) {
-        PDFJS.disableRange = (hashParams['disablerange'] === 'true');
+        AppOptions.set('disableRange', hashParams['disablerange'] === 'true');
       }
       if ('disablestream' in hashParams) {
         PDFJS.disableStream = (hashParams['disablestream'] === 'true');

--- a/web/app.js
+++ b/web/app.js
@@ -218,7 +218,7 @@ let PDFViewerApplication = {
         PDFJS.disableStream = value;
       }),
       preferences.get('disableAutoFetch').then(function resolved(value) {
-        PDFJS.disableAutoFetch = value;
+        AppOptions.set('disableAutoFetch', value);
       }),
       preferences.get('disableFontFace').then(function resolved(value) {
         if (AppOptions.get('disableFontFace') === true) {
@@ -275,7 +275,8 @@ let PDFViewerApplication = {
         PDFJS.disableStream = (hashParams['disablestream'] === 'true');
       }
       if ('disableautofetch' in hashParams) {
-        PDFJS.disableAutoFetch = (hashParams['disableautofetch'] === 'true');
+        AppOptions.set('disableAutoFetch',
+                       hashParams['disableautofetch'] === 'true');
       }
       if ('disablefontface' in hashParams) {
         AppOptions.set('disableFontFace',
@@ -926,7 +927,10 @@ let PDFViewerApplication = {
       // the loading bar will not be completely filled, nor will it be hidden.
       // To prevent displaying a partially filled loading bar permanently, we
       // hide it when no data has been loaded during a certain amount of time.
-      if (PDFJS.disableAutoFetch && percent) {
+      let disableAutoFetch = this.pdfDocument ?
+        this.pdfDocument.loadingParams['disableAutoFetch'] :
+        AppOptions.get('disableAutoFetch');
+      if (disableAutoFetch && percent) {
         if (this.disableAutoFetchLoadingBarTimeout) {
           clearTimeout(this.disableAutoFetchLoadingBarTimeout);
           this.disableAutoFetchLoadingBarTimeout = null;

--- a/web/app.js
+++ b/web/app.js
@@ -187,7 +187,7 @@ let PDFViewerApplication = {
 
     return Promise.all([
       preferences.get('enableWebGL').then(function resolved(value) {
-        PDFJS.disableWebGL = !value;
+        AppOptions.set('enableWebGL', value);
       }),
       preferences.get('sidebarViewOnLoad').then(function resolved(value) {
         AppOptions.set('sidebarViewOnLoad', value);
@@ -290,7 +290,7 @@ let PDFViewerApplication = {
                        hashParams['disablehistory'] === 'true');
       }
       if ('webgl' in hashParams) {
-        PDFJS.disableWebGL = (hashParams['webgl'] !== 'true');
+        AppOptions.set('enableWebGL', hashParams['webgl'] === 'true');
       }
       if ('useonlycsszoom' in hashParams) {
         AppOptions.set('useOnlyCssZoom',
@@ -386,6 +386,7 @@ let PDFViewerApplication = {
         enhanceTextSelection: AppOptions.get('enhanceTextSelection'),
         renderInteractiveForms: AppOptions.get('renderInteractiveForms'),
         enablePrintAutoRotate: AppOptions.get('enablePrintAutoRotate'),
+        enableWebGL: AppOptions.get('enableWebGL'),
         useOnlyCssZoom: AppOptions.get('useOnlyCssZoom'),
         maxCanvasPixels: AppOptions.get('maxCanvasPixels'),
       });
@@ -1147,7 +1148,7 @@ let PDFViewerApplication = {
                   info.PDFFormatVersion + ' ' + (info.Producer || '-').trim() +
                   ' / ' + (info.Creator || '-').trim() + ']' +
                   ' (PDF.js: ' + (version || '-') +
-                  (!PDFJS.disableWebGL ? ' [WebGL]' : '') + ')');
+                  (AppOptions.get('enableWebGL') ? ' [WebGL]' : '') + ')');
 
       let pdfTitle;
       if (metadata && metadata.has('dc:title')) {

--- a/web/app.js
+++ b/web/app.js
@@ -53,14 +53,9 @@ function configure(PDFJS) {
   if (typeof PDFJSDev !== 'undefined' &&
       PDFJSDev.test('FIREFOX || MOZCENTRAL || GENERIC || CHROME')) {
     PDFJS.workerSrc = '../build/pdf.worker.js';
-  }
-  if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION')) {
-    PDFJS.cMapUrl = '../external/bcmaps/';
+  } else if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION')) {
     PDFJS.workerSrc = '../src/worker_loader.js';
-  } else {
-    PDFJS.cMapUrl = '../web/cmaps/';
   }
-  PDFJS.cMapPacked = true;
 }
 
 const DefaultExternalServices = {
@@ -301,8 +296,8 @@ let PDFViewerApplication = {
       }
       if ((typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION')) &&
           hashParams['disablebcmaps'] === 'true') {
-        PDFJS.cMapUrl = '../external/cmaps/';
-        PDFJS.cMapPacked = false;
+        AppOptions.set('cMapUrl', '../external/cmaps/');
+        AppOptions.set('cMapPacked', false);
       }
       if ('textlayer' in hashParams) {
         switch (hashParams['textlayer']) {

--- a/web/app.js
+++ b/web/app.js
@@ -315,7 +315,7 @@ let PDFViewerApplication = {
         }
       }
       if ('pdfbug' in hashParams) {
-        PDFJS.pdfBug = true;
+        AppOptions.set('pdfBug', true);
         let pdfBug = hashParams['pdfbug'];
         let enabled = pdfBug.split(',');
         waitOn.push(loadAndEnablePDFBug(enabled));
@@ -1505,7 +1505,6 @@ function loadAndEnablePDFBug(enabledTabs) {
     script.onload = function () {
       PDFBug.enable(enabledTabs);
       PDFBug.init({
-        PDFJS,
         OPS,
       }, appConfig.mainContainer);
       resolve();
@@ -1670,7 +1669,8 @@ function webViewerPageRendered(evt) {
     thumbnailView.setImage(pageView);
   }
 
-  if (PDFJS.pdfBug && Stats.enabled && pageView.stats) {
+  if (AppOptions.get('pdfBug') && typeof Stats !== 'undefined' &&
+      Stats.enabled && pageView.stats) {
     Stats.add(pageNumber, pageView.stats);
   }
 
@@ -1958,10 +1958,11 @@ function webViewerPageChanging(evt) {
     PDFViewerApplication.pdfThumbnailViewer.scrollThumbnailIntoView(page);
   }
 
-  // we need to update stats
-  if (PDFJS.pdfBug && Stats.enabled) {
+  // We need to update stats.
+  if (AppOptions.get('pdfBug') && typeof Stats !== 'undefined' &&
+      Stats.enabled) {
     let pageView = PDFViewerApplication.pdfViewer.getPageView(page - 1);
-    if (pageView.stats) {
+    if (pageView && pageView.stats) {
       Stats.add(page, pageView.stats);
     }
   }

--- a/web/app.js
+++ b/web/app.js
@@ -381,6 +381,7 @@ let PDFViewerApplication = {
         downloadManager,
         renderer: AppOptions.get('renderer'),
         l10n: this.l10n,
+        disableTextLayer: AppOptions.get('disableTextLayer'),
         enhanceTextSelection: AppOptions.get('enhanceTextSelection'),
         renderInteractiveForms: AppOptions.get('renderInteractiveForms'),
         enablePrintAutoRotate: AppOptions.get('enablePrintAutoRotate'),

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -57,6 +57,11 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.VIEWER,
   },
+  enableWebGL: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER,
+  },
   enhanceTextSelection: {
     /** @type {boolean} */
     value: false,

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -143,6 +143,11 @@ const defaultOptions = {
     value: apiCompatibilityParams.disableRange || false,
     kind: OptionKind.API,
   },
+  disableStream: {
+    /** @type {boolean} */
+    value: apiCompatibilityParams.disableStream || false,
+    kind: OptionKind.API,
+  },
   isEvalSupported: {
     /** @type {boolean} */
     value: true,

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -117,6 +117,11 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.VIEWER,
   },
+  maxImageSize: {
+    /** @type {number} */
+    value: null,
+    kind: OptionKind.API,
+  },
 };
 if (typeof PDFJSDev === 'undefined' ||
     !PDFJSDev.test('FIREFOX || MOZCENTRAL')) {

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -62,6 +62,11 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.VIEWER,
   },
+  imageResourcesPath: {
+    /** @type {string} */
+    value: '',
+    kind: OptionKind.VIEWER,
+  },
   maxCanvasPixels: {
     /** @type {number} */
     value: viewerCompatibilityParams.maxCanvasPixels || null,

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -128,6 +128,11 @@ const defaultOptions = {
             '../external/bcmaps/' : '../web/cmaps/'),
     kind: OptionKind.API,
   },
+  isEvalSupported: {
+    /** @type {boolean} */
+    value: true,
+    kind: OptionKind.API,
+  },
   maxImageSize: {
     /** @type {number} */
     value: null,

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -128,6 +128,11 @@ const defaultOptions = {
             '../external/bcmaps/' : '../web/cmaps/'),
     kind: OptionKind.API,
   },
+  disableAutoFetch: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.API,
+  },
   disableFontFace: {
     /** @type {boolean} */
     value: false,

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -1,0 +1,164 @@
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import { apiCompatibilityParams } from 'pdfjs-lib';
+import { viewerCompatibilityParams } from './viewer_compatibility';
+
+const OptionKind = {
+  VIEWER: 'viewer',
+  API: 'api',
+};
+
+const defaultOptions = {
+  defaultZoomValue: {
+    /** @type {string} */
+    value: '',
+    kind: OptionKind.VIEWER,
+  },
+  disableFullscreen: {
+    /** @type {boolean} */
+    value: viewerCompatibilityParams.disableFullscreen || false,
+    kind: OptionKind.VIEWER,
+  },
+  disableHistory: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER,
+  },
+  disablePageLabels: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER,
+  },
+  disablePageMode: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER,
+  },
+  disableTextLayer: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER,
+  },
+  enablePrintAutoRotate: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER,
+  },
+  enhanceTextSelection: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER,
+  },
+  maxCanvasPixels: {
+    /** @type {number} */
+    value: viewerCompatibilityParams.maxCanvasPixels || null,
+    kind: OptionKind.VIEWER,
+  },
+  pdfBugEnabled: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER,
+  },
+  renderer: {
+    /** @type {string} */
+    value: 'canvas',
+    kind: OptionKind.VIEWER,
+  },
+  renderInteractiveForms: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER,
+  },
+  showPreviousViewOnLoad: {
+    /** @type {boolean} */
+    value: true,
+    kind: OptionKind.VIEWER,
+  },
+  sidebarViewOnLoad: {
+    /** @type {number} */
+    value: 0,
+    kind: OptionKind.VIEWER,
+  },
+  useOnlyCssZoom: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER,
+  },
+};
+if (typeof PDFJSDev === 'undefined' ||
+    !PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
+  defaultOptions.locale = {
+    /** @type {string} */
+    value: viewerCompatibilityParams.locale ||
+           (typeof navigator !== 'undefined' ? navigator.language : null),
+    kind: OptionKind.VIEWER,
+  };
+}
+
+let userOptions = Object.create(null);
+
+class AppOptions {
+  constructor() {
+    throw new Error('Cannot initialize AppOptions.');
+  }
+
+  static get(name) {
+    let defaultOption = defaultOptions[name], userOption = userOptions[name];
+    if (defaultOption === undefined) {
+      console.error(`AppOptions.get: "${name}" is undefined.`);
+      return;
+    }
+    return (userOption !== undefined ? userOption : defaultOption.value);
+  }
+
+  static getAll(kind = null) {
+    const OptionKindValues = Object.values(OptionKind);
+    if (kind && !OptionKindValues.includes(kind)) {
+      console.error(`AppOptions.getAll: "${kind}" not a valid kind.`);
+      return;
+    }
+    let options = Object.create(null);
+    for (let name in defaultOptions) {
+      let defaultOption = defaultOptions[name], userOption = userOptions[name];
+      if (kind && defaultOption.kind !== kind) {
+        continue;
+      }
+      options[name] = (userOption !== undefined ?
+                       userOption : defaultOption.value);
+    }
+    return options;
+  }
+
+  static set(name, value) {
+    if (defaultOptions[name] === undefined || value === undefined) {
+      console.error(`AppOptions.set: "${name}" ` +
+        `${value === undefined ? 'has no value specified' : 'is undefined'}.`);
+      return;
+    }
+    userOptions[name] = value;
+  }
+
+  static remove(name) {
+    if (defaultOptions[name] === undefined) {
+      console.error(`AppOptions.remove: "${name}" is undefined.`);
+    }
+    delete userOptions[name];
+  }
+}
+
+export {
+  AppOptions,
+};

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-// import { apiCompatibilityParams } from 'pdfjs-lib';
+import { apiCompatibilityParams } from 'pdfjs-lib';
 import { viewerCompatibilityParams } from './viewer_compatibility';
 
 const OptionKind = {
@@ -136,6 +136,11 @@ const defaultOptions = {
   disableFontFace: {
     /** @type {boolean} */
     value: false,
+    kind: OptionKind.API,
+  },
+  disableRange: {
+    /** @type {boolean} */
+    value: apiCompatibilityParams.disableRange || false,
     kind: OptionKind.API,
   },
   isEvalSupported: {

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -62,6 +62,16 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.VIEWER,
   },
+  externalLinkRel: {
+    /** @type {string} */
+    value: null,
+    kind: OptionKind.VIEWER,
+  },
+  externalLinkTarget: {
+    /** @type {number} */
+    value: 0,
+    kind: OptionKind.VIEWER,
+  },
   imageResourcesPath: {
     /** @type {string} */
     value: '',

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -128,6 +128,11 @@ const defaultOptions = {
             '../external/bcmaps/' : '../web/cmaps/'),
     kind: OptionKind.API,
   },
+  disableFontFace: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.API,
+  },
   isEvalSupported: {
     /** @type {boolean} */
     value: true,

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -117,6 +117,17 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.VIEWER,
   },
+  cMapPacked: {
+    /** @type {boolean} */
+    value: true,
+    kind: OptionKind.API,
+  },
+  cMapUrl: {
+    /** @type {string} */
+    value: (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION') ?
+            '../external/bcmaps/' : '../web/cmaps/'),
+    kind: OptionKind.API,
+  },
   maxImageSize: {
     /** @type {number} */
     value: null,

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -133,6 +133,11 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.API,
   },
+  disableCreateObjectURL: {
+    /** @type {boolean} */
+    value: apiCompatibilityParams.disableCreateObjectURL || false,
+    kind: OptionKind.API,
+  },
   disableFontFace: {
     /** @type {boolean} */
     value: false,

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -163,6 +163,11 @@ const defaultOptions = {
     value: null,
     kind: OptionKind.API,
   },
+  pdfBug: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.API,
+  },
 };
 if (typeof PDFJSDev === 'undefined' ||
     !PDFJSDev.test('FIREFOX || MOZCENTRAL')) {

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -52,6 +52,9 @@ const DEFAULT_CACHE_SIZE = 10;
  * @property {string} renderer - 'canvas' or 'svg'. The default is 'canvas'.
  * @property {boolean} useOnlyCssZoom - (optional) Enables CSS only zooming.
  *   The default is `false`.
+ * @property {number} maxCanvasPixels - (optional) The maximum supported canvas
+ *   size in total pixels, i.e. width * height. Use -1 for no limit.
+ *   The default value is 4096 * 4096 (16 mega-pixels).
  * @property {IL10n} l10n - Localization service.
  */
 
@@ -117,6 +120,7 @@ class BaseViewer {
     this.enablePrintAutoRotate = options.enablePrintAutoRotate || false;
     this.renderer = options.renderer || RendererType.CANVAS;
     this.useOnlyCssZoom = options.useOnlyCssZoom || false;
+    this.maxCanvasPixels = options.maxCanvasPixels || null;
     this.l10n = options.l10n || NullL10n;
 
     this.defaultRenderingQueue = !options.renderingQueue;
@@ -384,6 +388,7 @@ class BaseViewer {
           renderInteractiveForms: this.renderInteractiveForms,
           renderer: this.renderer,
           useOnlyCssZoom: this.useOnlyCssZoom,
+          maxCanvasPixels: this.maxCanvasPixels,
           l10n: this.l10n,
         });
         bindOnAfterAndBeforeDraw(pageView);

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-import { createPromiseCapability, PDFJS } from 'pdfjs-lib';
 import {
   CSS_UNITS, DEFAULT_SCALE, DEFAULT_SCALE_VALUE, isValidRotation,
   MAX_AUTO_SCALE, NullL10n, PresentationModeState, RendererType,
@@ -21,6 +20,7 @@ import {
 } from './ui_utils';
 import { PDFRenderingQueue, RenderingStates } from './pdf_rendering_queue';
 import { AnnotationLayerBuilder } from './annotation_layer_builder';
+import { createPromiseCapability } from 'pdfjs-lib';
 import { getGlobalEventBus } from './dom_events';
 import { PDFPageView } from './pdf_page_view';
 import { SimpleLinkService } from './pdf_link_service';
@@ -407,7 +407,7 @@ class BaseViewer {
       // starts to create the correct size canvas. Wait until one page is
       // rendered so we don't tie up too many resources early on.
       onePageRenderedCapability.promise.then(() => {
-        if (PDFJS.disableAutoFetch) {
+        if (pdfDocument.loadingParams['disableAutoFetch']) {
           // XXX: Printing is semi-broken with auto fetch disabled.
           pagesCapability.resolve();
           return;

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -44,6 +44,8 @@ const DEFAULT_CACHE_SIZE = 10;
  *   text layer used for selection and searching. The default is `false`.
  * @property {boolean} enhanceTextSelection - (optional) Enables the improved
  *   text selection behaviour. The default is `false`.
+ * @property {string} imageResourcesPath - (optional) Path for image resources,
+ *   mainly for annotation icons. Include trailing slash.
  * @property {boolean} renderInteractiveForms - (optional) Enables rendering of
  *   interactive form elements. The default is `false`.
  * @property {boolean} enablePrintAutoRotate - (optional) Enables automatic
@@ -116,6 +118,7 @@ class BaseViewer {
     this.removePageBorders = options.removePageBorders || false;
     this.disableTextLayer = options.disableTextLayer || false;
     this.enhanceTextSelection = options.enhanceTextSelection || false;
+    this.imageResourcesPath = options.imageResourcesPath || '';
     this.renderInteractiveForms = options.renderInteractiveForms || false;
     this.enablePrintAutoRotate = options.enablePrintAutoRotate || false;
     this.renderer = options.renderer || RendererType.CANVAS;
@@ -385,6 +388,7 @@ class BaseViewer {
           textLayerFactory,
           annotationLayerFactory: this,
           enhanceTextSelection: this.enhanceTextSelection,
+          imageResourcesPath: this.imageResourcesPath,
           renderInteractiveForms: this.renderInteractiveForms,
           renderer: this.renderer,
           useOnlyCssZoom: this.useOnlyCssZoom,
@@ -884,15 +888,19 @@ class BaseViewer {
   /**
    * @param {HTMLDivElement} pageDiv
    * @param {PDFPage} pdfPage
+   * @param {string} imageResourcesPath - (optional) Path for image resources,
+   *   mainly for annotation icons. Include trailing slash.
    * @param {boolean} renderInteractiveForms
    * @param {IL10n} l10n
    * @returns {AnnotationLayerBuilder}
    */
-  createAnnotationLayerBuilder(pageDiv, pdfPage, renderInteractiveForms = false,
+  createAnnotationLayerBuilder(pageDiv, pdfPage, imageResourcesPath = '',
+                               renderInteractiveForms = false,
                                l10n = NullL10n) {
     return new AnnotationLayerBuilder({
       pageDiv,
       pdfPage,
+      imageResourcesPath,
       renderInteractiveForms,
       linkService: this.linkService,
       downloadManager: this.downloadManager,

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -21,7 +21,6 @@ import {
 } from './ui_utils';
 import { PDFRenderingQueue, RenderingStates } from './pdf_rendering_queue';
 import { AnnotationLayerBuilder } from './annotation_layer_builder';
-import { AppOptions } from './app_options';
 import { getGlobalEventBus } from './dom_events';
 import { PDFPageView } from './pdf_page_view';
 import { SimpleLinkService } from './pdf_link_service';
@@ -40,7 +39,9 @@ const DEFAULT_CACHE_SIZE = 10;
  * @property {PDFRenderingQueue} renderingQueue - (optional) The rendering
  *   queue object.
  * @property {boolean} removePageBorders - (optional) Removes the border shadow
- *   around the pages. The default is false.
+ *   around the pages. The default is `false`.
+ * @property {boolean} disableTextLayer - (optional) Disables creation of the
+ *   text layer used for selection and searching. The default is `false`.
  * @property {boolean} enhanceTextSelection - (optional) Enables the improved
  *   text selection behaviour. The default is `false`.
  * @property {boolean} renderInteractiveForms - (optional) Enables rendering of
@@ -108,6 +109,7 @@ class BaseViewer {
     this.linkService = options.linkService || new SimpleLinkService();
     this.downloadManager = options.downloadManager || null;
     this.removePageBorders = options.removePageBorders || false;
+    this.disableTextLayer = options.disableTextLayer || false;
     this.enhanceTextSelection = options.enhanceTextSelection || false;
     this.renderInteractiveForms = options.renderInteractiveForms || false;
     this.enablePrintAutoRotate = options.enablePrintAutoRotate || false;
@@ -363,7 +365,7 @@ class BaseViewer {
       let viewport = pdfPage.getViewport(scale * CSS_UNITS);
       for (let pageNum = 1; pageNum <= pagesCount; ++pageNum) {
         let textLayerFactory = null;
-        if (!AppOptions.get('disableTextLayer')) {
+        if (!this.disableTextLayer) {
           textLayerFactory = this;
         }
         let pageView = new PDFPageView({

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -50,6 +50,8 @@ const DEFAULT_CACHE_SIZE = 10;
  *   rotation of pages whose orientation differ from the first page upon
  *   printing. The default is `false`.
  * @property {string} renderer - 'canvas' or 'svg'. The default is 'canvas'.
+ * @property {boolean} useOnlyCssZoom - (optional) Enables CSS only zooming.
+ *   The default is `false`.
  * @property {IL10n} l10n - Localization service.
  */
 
@@ -114,6 +116,7 @@ class BaseViewer {
     this.renderInteractiveForms = options.renderInteractiveForms || false;
     this.enablePrintAutoRotate = options.enablePrintAutoRotate || false;
     this.renderer = options.renderer || RendererType.CANVAS;
+    this.useOnlyCssZoom = options.useOnlyCssZoom || false;
     this.l10n = options.l10n || NullL10n;
 
     this.defaultRenderingQueue = !options.renderingQueue;
@@ -380,6 +383,7 @@ class BaseViewer {
           enhanceTextSelection: this.enhanceTextSelection,
           renderInteractiveForms: this.renderInteractiveForms,
           renderer: this.renderer,
+          useOnlyCssZoom: this.useOnlyCssZoom,
           l10n: this.l10n,
         });
         bindOnAfterAndBeforeDraw(pageView);

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -52,6 +52,8 @@ const DEFAULT_CACHE_SIZE = 10;
  *   rotation of pages whose orientation differ from the first page upon
  *   printing. The default is `false`.
  * @property {string} renderer - 'canvas' or 'svg'. The default is 'canvas'.
+ * @property {boolean} enableWebGL - (optional) Enables WebGL accelerated
+ *   rendering for some operations. The default is `false`.
  * @property {boolean} useOnlyCssZoom - (optional) Enables CSS only zooming.
  *   The default is `false`.
  * @property {number} maxCanvasPixels - (optional) The maximum supported canvas
@@ -122,6 +124,7 @@ class BaseViewer {
     this.renderInteractiveForms = options.renderInteractiveForms || false;
     this.enablePrintAutoRotate = options.enablePrintAutoRotate || false;
     this.renderer = options.renderer || RendererType.CANVAS;
+    this.enableWebGL = options.enableWebGL || false;
     this.useOnlyCssZoom = options.useOnlyCssZoom || false;
     this.maxCanvasPixels = options.maxCanvasPixels || null;
     this.l10n = options.l10n || NullL10n;
@@ -391,6 +394,7 @@ class BaseViewer {
           imageResourcesPath: this.imageResourcesPath,
           renderInteractiveForms: this.renderInteractiveForms,
           renderer: this.renderer,
+          enableWebGL: this.enableWebGL,
           useOnlyCssZoom: this.useOnlyCssZoom,
           maxCanvasPixels: this.maxCanvasPixels,
           l10n: this.l10n,

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -21,6 +21,7 @@ import {
 } from './ui_utils';
 import { PDFRenderingQueue, RenderingStates } from './pdf_rendering_queue';
 import { AnnotationLayerBuilder } from './annotation_layer_builder';
+import { AppOptions } from './app_options';
 import { getGlobalEventBus } from './dom_events';
 import { PDFPageView } from './pdf_page_view';
 import { SimpleLinkService } from './pdf_link_service';
@@ -362,7 +363,7 @@ class BaseViewer {
       let viewport = pdfPage.getViewport(scale * CSS_UNITS);
       for (let pageNum = 1; pageNum <= pagesCount; ++pageNum) {
         let textLayerFactory = null;
-        if (!PDFJS.disableTextLayer) {
+        if (!AppOptions.get('disableTextLayer')) {
           textLayerFactory = this;
         }
         let pageView = new PDFPageView({

--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -357,8 +357,8 @@ ChromeExternalServices.initPassiveLoading = function(callbacks) {
     callbacks.onOpenWithURL(url, length, originalURL);
   });
 };
-ChromeExternalServices.createDownloadManager = function() {
-  return new DownloadManager();
+ChromeExternalServices.createDownloadManager = function(options) {
+  return new DownloadManager(options);
 };
 ChromeExternalServices.createPreferences = function() {
   return new ChromePreferences();

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -462,7 +462,6 @@ var Stats = (function Stats() {
     manager: null,
     init(pdfjsLib) {
       this.panel.setAttribute('style', 'padding: 5px;');
-      pdfjsLib.PDFJS.enableStats = true;
     },
     enabled: false,
     active: false,

--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -13,12 +13,17 @@
  * limitations under the License.
  */
 
-import { createObjectURL, createValidAbsoluteUrl, PDFJS } from 'pdfjs-lib';
+import {
+  apiCompatibilityParams, createObjectURL, createValidAbsoluteUrl
+} from 'pdfjs-lib';
 
 if (typeof PDFJSDev !== 'undefined' && !PDFJSDev.test('CHROME || GENERIC')) {
   throw new Error('Module "pdfjs-web/download_manager" shall not be used ' +
                   'outside CHROME and GENERIC builds.');
 }
+
+const DISABLE_CREATE_OBJECT_URL =
+  apiCompatibilityParams.disableCreateObjectURL || false;
 
 function download(blobUrl, filename) {
   let a = document.createElement('a');
@@ -57,6 +62,11 @@ function download(blobUrl, filename) {
 }
 
 class DownloadManager {
+  constructor({ disableCreateObjectURL = null, }) {
+    this.disableCreateObjectURL = (typeof disableCreateObjectURL === 'boolean' ?
+      disableCreateObjectURL : DISABLE_CREATE_OBJECT_URL);
+  }
+
   downloadUrl(url, filename) {
     if (!createValidAbsoluteUrl(url, 'http://example.com')) {
       return; // restricted/invalid URL
@@ -70,7 +80,7 @@ class DownloadManager {
                                   filename);
     }
     let blobUrl = createObjectURL(data, contentType,
-                                  PDFJS.disableCreateObjectURL);
+                                  this.disableCreateObjectURL);
     download(blobUrl, filename);
   }
 
@@ -83,7 +93,7 @@ class DownloadManager {
       return;
     }
 
-    if (PDFJS.disableCreateObjectURL) {
+    if (this.disableCreateObjectURL) {
       // URL.createObjectURL is not supported
       this.downloadUrl(url, filename);
       return;

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -84,6 +84,10 @@ let FirefoxCom = (function FirefoxComClosure() {
 })();
 
 class DownloadManager {
+  constructor(options) {
+    this.disableCreateObjectURL = false;
+  }
+
   downloadUrl(url, filename) {
     FirefoxCom.request('download', {
       originalUrl: url,
@@ -92,7 +96,7 @@ class DownloadManager {
   }
 
   downloadData(data, filename, contentType) {
-    let blobUrl = createObjectURL(data, contentType, false);
+    let blobUrl = createObjectURL(data, contentType);
 
     FirefoxCom.request('download', {
       blobUrl,
@@ -256,8 +260,8 @@ PDFViewerApplication.externalServices = {
     FirefoxCom.request('reportTelemetry', JSON.stringify(data));
   },
 
-  createDownloadManager() {
-    return new DownloadManager();
+  createDownloadManager(options) {
+    return new DownloadManager(options);
   },
 
   createPreferences() {

--- a/web/genericcom.js
+++ b/web/genericcom.js
@@ -14,10 +14,10 @@
  */
 
 import { DefaultExternalServices, PDFViewerApplication } from './app';
+import { AppOptions } from './app_options';
 import { BasePreferences } from './preferences';
 import { DownloadManager } from './download_manager';
 import { GenericL10n } from './genericl10n';
-import { PDFJS } from 'pdfjs-lib';
 
 if (typeof PDFJSDev !== 'undefined' && !PDFJSDev.test('GENERIC')) {
   throw new Error('Module "pdfjs-web/genericcom" shall not be used outside ' +
@@ -50,7 +50,7 @@ GenericExternalServices.createPreferences = function() {
   return new GenericPreferences();
 };
 GenericExternalServices.createL10n = function () {
-  return new GenericL10n(PDFJS.locale);
+  return new GenericL10n(AppOptions.get('locale'));
 };
 PDFViewerApplication.externalServices = GenericExternalServices;
 

--- a/web/genericcom.js
+++ b/web/genericcom.js
@@ -43,8 +43,8 @@ class GenericPreferences extends BasePreferences {
 }
 
 let GenericExternalServices = Object.create(DefaultExternalServices);
-GenericExternalServices.createDownloadManager = function() {
-  return new DownloadManager();
+GenericExternalServices.createDownloadManager = function(options) {
+  return new DownloadManager(options);
 };
 GenericExternalServices.createPreferences = function() {
   return new GenericPreferences();

--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -146,10 +146,12 @@ class IPDFAnnotationLayerFactory {
    * @param {HTMLDivElement} pageDiv
    * @param {PDFPage} pdfPage
    * @param {IL10n} l10n
+   * @param {string} imageResourcesPath - (optional) Path for image resources,
+   *   mainly for annotation icons. Include trailing slash.
    * @param {boolean} renderInteractiveForms
    * @returns {AnnotationLayerBuilder}
    */
-  createAnnotationLayerBuilder(pageDiv, pdfPage,
+  createAnnotationLayerBuilder(pageDiv, pdfPage, imageResourcesPath = '',
                                renderInteractiveForms = false,
                                l10n = undefined) {}
 }

--- a/web/pdf_attachment_viewer.js
+++ b/web/pdf_attachment_viewer.js
@@ -14,7 +14,7 @@
  */
 
 import {
-  createObjectURL, createPromiseCapability, getFilenameFromUrl, PDFJS,
+  createObjectURL, createPromiseCapability, getFilenameFromUrl,
   removeNullCharacters
 } from 'pdfjs-lib';
 
@@ -74,9 +74,9 @@ class PDFAttachmentViewer {
    * @private
    */
   _bindPdfLink(button, content, filename) {
-    if (PDFJS.disableCreateObjectURL) {
-      throw new Error('bindPdfLink: ' +
-                      'Unsupported "PDFJS.disableCreateObjectURL" value.');
+    if (this.downloadManager.disableCreateObjectURL) {
+      throw new Error(
+        'bindPdfLink: Unsupported "disableCreateObjectURL" value.');
     }
     let blobUrl;
     button.onclick = function() {
@@ -141,7 +141,8 @@ class PDFAttachmentViewer {
       div.className = 'attachmentsItem';
       let button = document.createElement('button');
       button.textContent = filename;
-      if (/\.pdf$/i.test(filename) && !PDFJS.disableCreateObjectURL) {
+      if (/\.pdf$/i.test(filename) &&
+          !this.downloadManager.disableCreateObjectURL) {
         this._bindPdfLink(button, item.content, filename);
       } else {
         this._bindLink(button, item.content, filename);

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -19,6 +19,11 @@ import { parseQueryString } from './ui_utils';
 /**
  * @typedef {Object} PDFLinkServiceOptions
  * @property {EventBus} eventBus - The application event bus.
+ * @property {number} externalLinkTarget - (optional) Specifies the `target`
+ *   attribute for external links. Must use one of the values from {LinkTarget}.
+ *   Defaults to using no target.
+ * @property {string} externalLinkRel - (optional) Specifies the `rel` attribute
+ *   for external links. Defaults to stripping the referrer.
  */
 
 /**
@@ -30,8 +35,12 @@ class PDFLinkService {
   /**
    * @param {PDFLinkServiceOptions} options
    */
-  constructor({ eventBus, } = {}) {
+  constructor({ eventBus, externalLinkTarget = null,
+                externalLinkRel = null, } = {}) {
     this.eventBus = eventBus || getGlobalEventBus();
+    this.externalLinkTarget = externalLinkTarget;
+    this.externalLinkRel = externalLinkRel;
+
     this.baseUrl = null;
     this.pdfDocument = null;
     this.pdfViewer = null;

--- a/web/pdf_outline_viewer.js
+++ b/web/pdf_outline_viewer.js
@@ -13,9 +13,7 @@
  * limitations under the License.
  */
 
-import {
-  addLinkAttributes, PDFJS, removeNullCharacters
-} from 'pdfjs-lib';
+import { addLinkAttributes, LinkTarget, removeNullCharacters } from 'pdfjs-lib';
 
 const DEFAULT_TITLE = '\u2013';
 
@@ -68,20 +66,22 @@ class PDFOutlineViewer {
   /**
    * @private
    */
-  _bindLink(element, item) {
-    if (item.url) {
+  _bindLink(element, { url, newWindow, dest, }) {
+    let { linkService, } = this;
+
+    if (url) {
       addLinkAttributes(element, {
-        url: item.url,
-        target: (item.newWindow ? PDFJS.LinkTarget.BLANK : undefined),
+        url,
+        target: (newWindow ? LinkTarget.BLANK : linkService.externalLinkTarget),
+        rel: linkService.externalLinkRel,
       });
       return;
     }
-    let destination = item.dest;
 
-    element.href = this.linkService.getDestinationHash(destination);
+    element.href = this.linkService.getDestinationHash(dest);
     element.onclick = () => {
-      if (destination) {
-        this.linkService.navigateTo(destination);
+      if (dest) {
+        this.linkService.navigateTo(dest);
       }
       return false;
     };
@@ -90,12 +90,12 @@ class PDFOutlineViewer {
   /**
    * @private
    */
-  _setStyles(element, item) {
+  _setStyles(element, { bold, italic, }) {
     let styleStr = '';
-    if (item.bold) {
+    if (bold) {
       styleStr += 'font-weight: bold;';
     }
-    if (item.italic) {
+    if (italic) {
       styleStr += 'font-style: italic;';
     }
 

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -39,6 +39,8 @@ import { RenderingStates } from './pdf_rendering_queue';
  * @property {boolean} renderInteractiveForms - Turns on rendering of
  *   interactive form elements. The default is `false`.
  * @property {string} renderer - 'canvas' or 'svg'. The default is 'canvas'.
+ * @property {boolean} useOnlyCssZoom - (optional) Enables CSS only zooming.
+ *   The default is `false`.
  * @property {IL10n} l10n - Localization service.
  */
 
@@ -65,6 +67,7 @@ class PDFPageView {
     this.hasRestrictedScaling = false;
     this.enhanceTextSelection = options.enhanceTextSelection || false;
     this.renderInteractiveForms = options.renderInteractiveForms || false;
+    this.useOnlyCssZoom = options.useOnlyCssZoom || false;
 
     this.eventBus = options.eventBus || getGlobalEventBus();
     this.renderingQueue = options.renderingQueue;
@@ -219,7 +222,7 @@ class PDFPageView {
     }
 
     if (this.canvas) {
-      if (AppOptions.get('useOnlyCssZoom') ||
+      if (this.useOnlyCssZoom ||
           (this.hasRestrictedScaling && isScalingRestricted)) {
         this.cssTransform(this.canvas, true);
 
@@ -517,7 +520,7 @@ class PDFPageView {
     let outputScale = getOutputScale(ctx);
     this.outputScale = outputScale;
 
-    if (AppOptions.get('useOnlyCssZoom')) {
+    if (this.useOnlyCssZoom) {
       let actualSizeViewport = viewport.clone({ scale: CSS_UNITS, });
       // Use a scale that makes the canvas have the originally intended size
       // of the page.

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -20,9 +20,9 @@ import {
 import {
   createPromiseCapability, CustomStyle, RenderingCancelledException, SVGGraphics
 } from 'pdfjs-lib';
-import { AppOptions } from './app_options';
 import { getGlobalEventBus } from './dom_events';
 import { RenderingStates } from './pdf_rendering_queue';
+import { viewerCompatibilityParams } from './viewer_compatibility';
 
 /**
  * @typedef {Object} PDFPageViewOptions
@@ -41,8 +41,13 @@ import { RenderingStates } from './pdf_rendering_queue';
  * @property {string} renderer - 'canvas' or 'svg'. The default is 'canvas'.
  * @property {boolean} useOnlyCssZoom - (optional) Enables CSS only zooming.
  *   The default is `false`.
+ * @property {number} maxCanvasPixels - (optional) The maximum supported canvas
+ *   size in total pixels, i.e. width * height. Use -1 for no limit.
+ *   The default value is 4096 * 4096 (16 mega-pixels).
  * @property {IL10n} l10n - Localization service.
  */
+
+const MAX_CANVAS_PIXELS = viewerCompatibilityParams.maxCanvasPixels || 16777216;
 
 /**
  * @implements {IRenderableView}
@@ -68,6 +73,8 @@ class PDFPageView {
     this.enhanceTextSelection = options.enhanceTextSelection || false;
     this.renderInteractiveForms = options.renderInteractiveForms || false;
     this.useOnlyCssZoom = options.useOnlyCssZoom || false;
+    this.maxCanvasPixels = (Number.isInteger(options.maxCanvasPixels) ?
+      options.maxCanvasPixels : MAX_CANVAS_PIXELS);
 
     this.eventBus = options.eventBus || getGlobalEventBus();
     this.renderingQueue = options.renderingQueue;
@@ -212,11 +219,11 @@ class PDFPageView {
     }
 
     let isScalingRestricted = false;
-    if (this.canvas && AppOptions.get('maxCanvasPixels') > 0) {
+    if (this.canvas && this.maxCanvasPixels > 0) {
       let outputScale = this.outputScale;
       if (((Math.floor(this.viewport.width) * outputScale.sx) | 0) *
           ((Math.floor(this.viewport.height) * outputScale.sy) | 0) >
-          AppOptions.get('maxCanvasPixels')) {
+          this.maxCanvasPixels) {
         isScalingRestricted = true;
       }
     }
@@ -529,10 +536,9 @@ class PDFPageView {
       outputScale.scaled = true;
     }
 
-    if (AppOptions.get('maxCanvasPixels') > 0) {
+    if (this.maxCanvasPixels > 0) {
       let pixelsInViewport = viewport.width * viewport.height;
-      let maxScale = Math.sqrt(
-        AppOptions.get('maxCanvasPixels') / pixelsInViewport);
+      let maxScale = Math.sqrt(this.maxCanvasPixels / pixelsInViewport);
       if (outputScale.sx > maxScale || outputScale.sy > maxScale) {
         outputScale.sx = maxScale;
         outputScale.sy = maxScale;

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -41,6 +41,8 @@ import { viewerCompatibilityParams } from './viewer_compatibility';
  * @property {boolean} renderInteractiveForms - Turns on rendering of
  *   interactive form elements. The default is `false`.
  * @property {string} renderer - 'canvas' or 'svg'. The default is 'canvas'.
+ * @property {boolean} enableWebGL - (optional) Enables WebGL accelerated
+ *   rendering for some operations. The default is `false`.
  * @property {boolean} useOnlyCssZoom - (optional) Enables CSS only zooming.
  *   The default is `false`.
  * @property {number} maxCanvasPixels - (optional) The maximum supported canvas
@@ -75,6 +77,7 @@ class PDFPageView {
     this.enhanceTextSelection = options.enhanceTextSelection || false;
     this.imageResourcesPath = options.imageResourcesPath || '';
     this.renderInteractiveForms = options.renderInteractiveForms || false;
+    this.enableWebGL = options.enableWebGL || false;
     this.useOnlyCssZoom = options.useOnlyCssZoom || false;
     this.maxCanvasPixels = (Number.isInteger(options.maxCanvasPixels) ?
       options.maxCanvasPixels : MAX_CANVAS_PIXELS);
@@ -568,6 +571,7 @@ class PDFPageView {
       canvasContext: ctx,
       transform,
       viewport: this.viewport,
+      enableWebGL: this.enableWebGL,
       renderInteractiveForms: this.renderInteractiveForms,
     };
     let renderTask = this.pdfPage.render(renderContext);

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -18,9 +18,9 @@ import {
   RendererType, roundToDivide
 } from './ui_utils';
 import {
-  createPromiseCapability, CustomStyle, PDFJS, RenderingCancelledException,
-  SVGGraphics
+  createPromiseCapability, CustomStyle, RenderingCancelledException, SVGGraphics
 } from 'pdfjs-lib';
+import { AppOptions } from './app_options';
 import { getGlobalEventBus } from './dom_events';
 import { RenderingStates } from './pdf_rendering_queue';
 
@@ -209,17 +209,17 @@ class PDFPageView {
     }
 
     let isScalingRestricted = false;
-    if (this.canvas && PDFJS.maxCanvasPixels > 0) {
+    if (this.canvas && AppOptions.get('maxCanvasPixels') > 0) {
       let outputScale = this.outputScale;
       if (((Math.floor(this.viewport.width) * outputScale.sx) | 0) *
           ((Math.floor(this.viewport.height) * outputScale.sy) | 0) >
-          PDFJS.maxCanvasPixels) {
+          AppOptions.get('maxCanvasPixels')) {
         isScalingRestricted = true;
       }
     }
 
     if (this.canvas) {
-      if (PDFJS.useOnlyCssZoom ||
+      if (AppOptions.get('useOnlyCssZoom') ||
           (this.hasRestrictedScaling && isScalingRestricted)) {
         this.cssTransform(this.canvas, true);
 
@@ -517,7 +517,7 @@ class PDFPageView {
     let outputScale = getOutputScale(ctx);
     this.outputScale = outputScale;
 
-    if (PDFJS.useOnlyCssZoom) {
+    if (AppOptions.get('useOnlyCssZoom')) {
       let actualSizeViewport = viewport.clone({ scale: CSS_UNITS, });
       // Use a scale that makes the canvas have the originally intended size
       // of the page.
@@ -526,9 +526,10 @@ class PDFPageView {
       outputScale.scaled = true;
     }
 
-    if (PDFJS.maxCanvasPixels > 0) {
+    if (AppOptions.get('maxCanvasPixels') > 0) {
       let pixelsInViewport = viewport.width * viewport.height;
-      let maxScale = Math.sqrt(PDFJS.maxCanvasPixels / pixelsInViewport);
+      let maxScale = Math.sqrt(
+        AppOptions.get('maxCanvasPixels') / pixelsInViewport);
       if (outputScale.sx > maxScale || outputScale.sy > maxScale) {
         outputScale.sx = maxScale;
         outputScale.sy = maxScale;

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -36,6 +36,8 @@ import { viewerCompatibilityParams } from './viewer_compatibility';
  * @property {IPDFAnnotationLayerFactory} annotationLayerFactory
  * @property {boolean} enhanceTextSelection - Turns on the text selection
  *   enhancement. The default is `false`.
+ * @property {string} imageResourcesPath - (optional) Path for image resources,
+ *   mainly for annotation icons. Include trailing slash.
  * @property {boolean} renderInteractiveForms - Turns on rendering of
  *   interactive form elements. The default is `false`.
  * @property {string} renderer - 'canvas' or 'svg'. The default is 'canvas'.
@@ -71,6 +73,7 @@ class PDFPageView {
     this.pdfPageRotate = defaultViewport.rotation;
     this.hasRestrictedScaling = false;
     this.enhanceTextSelection = options.enhanceTextSelection || false;
+    this.imageResourcesPath = options.imageResourcesPath || '';
     this.renderInteractiveForms = options.renderInteractiveForms || false;
     this.useOnlyCssZoom = options.useOnlyCssZoom || false;
     this.maxCanvasPixels = (Number.isInteger(options.maxCanvasPixels) ?
@@ -475,7 +478,7 @@ class PDFPageView {
     if (this.annotationLayerFactory) {
       if (!this.annotationLayer) {
         this.annotationLayer = this.annotationLayerFactory.
-          createAnnotationLayerBuilder(div, pdfPage,
+          createAnnotationLayerBuilder(div, pdfPage, this.imageResourcesPath,
                                        this.renderInteractiveForms, this.l10n);
       }
       this.annotationLayer.render(this.viewport, 'display');

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -15,7 +15,6 @@
 
 import { CSS_UNITS, NullL10n } from './ui_utils';
 import { PDFPrintServiceFactory, PDFViewerApplication } from './app';
-import { PDFJS } from 'pdfjs-lib';
 
 let activeService = null;
 let overlayManager = null;
@@ -62,6 +61,8 @@ function PDFPrintService(pdfDocument, pagesOverview, printContainer, l10n) {
   this.pagesOverview = pagesOverview;
   this.printContainer = printContainer;
   this.l10n = l10n || NullL10n;
+  this.disableCreateObjectURL =
+    pdfDocument.loadingParams['disableCreateObjectURL'];
   this.currentPage = -1;
   // The temporary canvas where renderPage paints one page at a time.
   this.scratchCanvas = document.createElement('canvas');
@@ -153,7 +154,7 @@ PDFPrintService.prototype = {
     img.style.height = printItem.height;
 
     let scratchCanvas = this.scratchCanvas;
-    if (('toBlob' in scratchCanvas) && !PDFJS.disableCreateObjectURL) {
+    if (('toBlob' in scratchCanvas) && !this.disableCreateObjectURL) {
       scratchCanvas.toBlob(function(blob) {
         img.src = URL.createObjectURL(blob);
       });

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { createPromiseCapability, PDFJS } from 'pdfjs-lib';
+import { createPromiseCapability } from 'pdfjs-lib';
 
 const CSS_UNITS = 96.0 / 72.0;
 const DEFAULT_SCALE_VALUE = 'auto';
@@ -64,54 +64,6 @@ let NullL10n = {
     return Promise.resolve();
   },
 };
-
-/**
- * Disables fullscreen support, and by extension Presentation Mode,
- * in browsers which support the fullscreen API.
- * @var {boolean}
- */
-PDFJS.disableFullscreen = (PDFJS.disableFullscreen === undefined ?
-                           false : PDFJS.disableFullscreen);
-
-/**
- * Enables CSS only zooming.
- * @var {boolean}
- */
-PDFJS.useOnlyCssZoom = (PDFJS.useOnlyCssZoom === undefined ?
-                        false : PDFJS.useOnlyCssZoom);
-
-/**
- * The maximum supported canvas size in total pixels e.g. width * height.
- * The default value is 4096 * 4096. Use -1 for no limit.
- * @var {number}
- */
-PDFJS.maxCanvasPixels = (PDFJS.maxCanvasPixels === undefined ?
-                         16777216 : PDFJS.maxCanvasPixels);
-
-/**
- * Disables saving of the last position of the viewed PDF.
- * @var {boolean}
- */
-PDFJS.disableHistory = (PDFJS.disableHistory === undefined ?
-                        false : PDFJS.disableHistory);
-
-/**
- * Disables creation of the text layer that used for text selection and search.
- * @var {boolean}
- */
-PDFJS.disableTextLayer = (PDFJS.disableTextLayer === undefined ?
-                          false : PDFJS.disableTextLayer);
-
-if (typeof PDFJSDev === 'undefined' ||
-    !PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
-  /**
-   * Interface locale settings.
-   * @var {string}
-   */
-  PDFJS.locale =
-    (PDFJS.locale === undefined && typeof navigator !== 'undefined' ?
-     navigator.language : PDFJS.locale);
-}
 
 /**
  * Returns scale factor for the canvas. It makes sense for the HiDPI displays.

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -35,9 +35,10 @@ if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('CHROME')) {
   })();
 }
 
-let pdfjsWebApp;
+let pdfjsWebApp, pdfjsWebAppOptions;
 if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('PRODUCTION')) {
   pdfjsWebApp = require('./app.js');
+  pdfjsWebAppOptions = require('./app_options.js');
 }
 
 if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
@@ -180,13 +181,18 @@ function webViewerLoad() {
   if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION')) {
     Promise.all([
       SystemJS.import('pdfjs-web/app'),
+      SystemJS.import('pdfjs-web/app_options'),
       SystemJS.import('pdfjs-web/genericcom'),
       SystemJS.import('pdfjs-web/pdf_print_service'),
-    ]).then(function([app, ...otherModules]) {
+    ]).then(function([app, appOptions, ...otherModules]) {
+      window.PDFViewerApplicationOptions = appOptions.AppOptions;
+
       window.PDFViewerApplication = app.PDFViewerApplication;
       app.PDFViewerApplication.run(config);
     });
   } else {
+    window.PDFViewerApplicationOptions = pdfjsWebAppOptions.AppOptions;
+
     window.PDFViewerApplication = pdfjsWebApp.PDFViewerApplication;
     pdfjsWebApp.PDFViewerApplication.run(config);
   }

--- a/web/viewer_compatibility.js
+++ b/web/viewer_compatibility.js
@@ -1,0 +1,54 @@
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+let compatibilityParams = Object.create(null);
+
+if (typeof PDFJSDev === 'undefined' ||
+    !PDFJSDev.test('FIREFOX || MOZCENTRAL || CHROME')) {
+  const userAgent =
+    (typeof navigator !== 'undefined' && navigator.userAgent) || '';
+  const isAndroid = /Android/.test(userAgent);
+  const isIE = userAgent.indexOf('Trident') >= 0;
+  const isIOS = /\b(iPad|iPhone|iPod)(?=;)/.test(userAgent);
+
+  // Disable fullscreen support for certain problematic configurations.
+  // Support: IE11+ (when embedded).
+  (function checkFullscreenSupport() {
+    if (isIE && window.parent !== window) {
+      compatibilityParams.disableFullscreen = true;
+    }
+  })();
+
+  // Limit canvas size to 5 mega-pixels on mobile.
+  // Support: Android, iOS
+  (function checkCanvasSizeLimitation() {
+    if (isIOS || isAndroid) {
+      compatibilityParams.maxCanvasPixels = 5242880;
+    }
+  })();
+
+  // Checks if navigator.language is supported
+  (function checkNavigatorLanguage() {
+    if (typeof navigator === 'undefined' || 'language' in navigator) {
+      return;
+    }
+    compatibilityParams.locale = navigator.userLanguage || 'en-US';
+  })();
+}
+const viewerCompatibilityParams = Object.freeze(compatibilityParams);
+
+export {
+  viewerCompatibilityParams,
+};


### PR DESCRIPTION
*Currently blocked on PRs ~~#9037,~~ #9095, ~~#9125, #9126~~.*

*Edit:* I'm not sure if this is necessarily the best solution, but at this point the PR now moves all (non-worker related, since those may be tricker) options from `PDFJS`.