### PR TITLE
Remove the `requestAnimationFrame` polyfill

### DIFF
--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -531,36 +531,6 @@ PDFJS.compatibilityChecked = true;
   }
 })();
 
-// Support: IE<10, Android<4.0, iOS
-(function checkRequestAnimationFrame() {
-  function installFakeAnimationFrameFunctions() {
-    window.requestAnimationFrame = function (callback) {
-      return window.setTimeout(callback, 20);
-    };
-    window.cancelAnimationFrame = function (timeoutID) {
-      window.clearTimeout(timeoutID);
-    };
-  }
-
-  if (!hasDOM) {
-    return;
-  }
-  if (isIOS) {
-    // requestAnimationFrame on iOS is broken, replacing with fake one.
-    installFakeAnimationFrameFunctions();
-    return;
-  }
-  if ('requestAnimationFrame' in window) {
-    return;
-  }
-  window.requestAnimationFrame = window.mozRequestAnimationFrame ||
-                                 window.webkitRequestAnimationFrame;
-  if (window.requestAnimationFrame) {
-    return;
-  }
-  installFakeAnimationFrameFunctions();
-})();
-
 // Support: Android, iOS
 (function checkCanvasSizeLimitation() {
   if (isIOS || isAndroid) {


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame#Browser_compatibility and https://caniuse.com/#feat=requestanimationframe, the browsers we intend to support with PDF.js version 2.0 should all have native `requestAnimationFrame` support.

Note that the reason for indiscriminately polyfilling `requestAnimationFrame` in iOS, see PR #4961, was apparently because of a bug in iOS 6.
However, according to [Wikipedia](https://en.wikipedia.org/wiki/IOS_version_history#iOS_8): "Support for iOS 8 ended in 2017.", hence the lowest version currently supported is iOS 9.

@yurydelendik Are you OK with simply removing this now?