### PR TITLE
Add the viewer to the npm package

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1352,6 +1352,10 @@ gulp.task('dist-pre',
       SINGLE_FILE_DIR + 'build/pdf.combined.js.map',
       SRC_DIR + 'pdf.worker.entry.js',
     ]).pipe(gulp.dest(DIST_DIR + 'build/')),
+    gulp.src([
+      MINIFIED_DIR + '*',
+      MINIFIED_DIR + '**/*',
+    ]).pipe(gulp.dest(DIST_DIR + 'viewer/')),
     gulp.src(MINIFIED_DIR + 'build/pdf.js')
         .pipe(rename('pdf.min.js'))
         .pipe(gulp.dest(DIST_DIR + 'build/')),


### PR DESCRIPTION
To avoid projects vendoring pdf.js because of the missing default viewer in the npm packge, I've added the viewer to the npm package. This also is a workaround for #9127.