### PR TITLE
Fix TypeError: Cannot read property 'getDestinationHash' of undefined

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -310,6 +310,9 @@ class LinkAnnotationElement extends AnnotationElement {
    * @memberof LinkAnnotationElement
    */
   _bindLink(link, destination) {
+    if (!this.linkService) {
+      return;
+    }
     link.href = this.linkService.getDestinationHash(destination);
     link.onclick = () => {
       if (destination) {


### PR DESCRIPTION
If someone happened to call AnnotationLayer.render(params) without giving valid linkService in params, clicking internal link was causing said TypeError.