### PR TITLE
Editing viewer.properties (SA English Version)

### DIFF
--- a/l10n/en-ZA/viewer.properties
+++ b/l10n/en-ZA/viewer.properties
@@ -25,6 +25,7 @@ of_pages=of {{pagesCount}}
 # LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
 # will be replaced by a number representing the currently visible page,
 # respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} of {{pagesCount}})
 
 zoom_out.title=Zoom Out
 zoom_out_label=Zoom Out
@@ -58,12 +59,17 @@ page_rotate_ccw.title=Rotate Counterclockwise
 page_rotate_ccw.label=Rotate Counterclockwise
 page_rotate_ccw_label=Rotate Counterclockwise
 
+cursor_text_select_tool.title=Enable Text Selection Tool
+cursor_text_select_tool_label=Text Selection Tool
+cursor_hand_tool.title=Enable Hand Tool
+cursor_hand_tool_label=Hand Tool
 
 # Document properties dialog box
 document_properties.title=Document Properties…
 document_properties_label=Document Properties…
 document_properties_file_name=File name:
 document_properties_file_size=File size:
+
 # LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
 # will be replaced by the PDF file size in kilobytes, respectively in bytes.
 document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
@@ -85,13 +91,17 @@ document_properties_version=PDF Version:
 document_properties_page_count=Page Count:
 document_properties_close=Close
 
+print_progress_message=Preparing document for printing...
 # LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
 # a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Cancel
 
 # Tooltips and alt text for side panel toolbar buttons
 # (the _label strings are alt text for the buttons, the .title strings are
 # tooltips)
 toggle_sidebar.title=Toggle Sidebar
+toggle_sidebar_notification.title=Toggle Sidebar (document contains outline/attachments)
 toggle_sidebar_label=Toggle Sidebar
 document_outline.title=Show Document Outline (double-click to expand/collapse all items)
 document_outline_label=Document Outline
@@ -100,6 +110,7 @@ attachments_label=Attachments
 thumbs.title=Show Thumbnails
 thumbs_label=Thumbnails
 findbar.title=Find in Document
+findbar_label=Find
 
 # Thumbnails panel item (tooltip and alt text for images)
 # LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
@@ -110,6 +121,8 @@ thumb_page_title=Page {{page}}
 thumb_page_canvas=Thumbnail of Page {{page}}
 
 # Find panel button title and messages
+find_input.title=Find
+find_input.placeholder=Find in document...
 find_previous.title=Find the previous occurrence of the phrase
 find_previous_label=Previous
 find_next.title=Find the next occurrence of the phrase
@@ -163,6 +176,7 @@ text_annotation_type.alt=[{{type}} Annotation]
 password_label=Enter the password to open this PDF file.
 password_invalid=Invalid password. Please try again.
 password_ok=OK
+password_cancel=Cancel
 
 printing_not_supported=Warning: Printing is not fully supported by this browser.
 printing_not_ready=Warning: The PDF is not fully loaded for printing.


### PR DESCRIPTION
appending codes which were omitted (supposed to be inserted for validating the real functions)


<South Africa English Version Code>
1. pages_of_pages (page number of pagesCount)
2. cursor text select & hand tool (title & label)
3. printing progress codes appended) appending progress message & progress percent & progress close
4. toggle_sidebar_notification
5. findbar_label (there was no label code even though findbar. title was in it)
6. password_cancel (there was no cancel code even though password ok code was in it)