### PR TITLE
Sanitize the display value for choice widget annotations

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -798,7 +798,8 @@ class ChoiceWidgetAnnotation extends WidgetAnnotation {
 
         this.data.options[i] = {
           exportValue: isOptionArray ? xref.fetchIfRef(option[0]) : option,
-          displayValue: isOptionArray ? xref.fetchIfRef(option[1]) : option,
+          displayValue: stringToPDFString(isOptionArray ?
+                                          xref.fetchIfRef(option[1]) : option),
         };
       }
     }

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -1092,14 +1092,8 @@ describe('annotation', function() {
 
       var options = [['foo_export', 'Foo'], optionOneRef];
       var expected = [
-        {
-          exportValue: 'foo_export',
-          displayValue: 'Foo',
-        },
-        {
-          exportValue: 'bar_export',
-          displayValue: 'Bar',
-        }
+        { exportValue: 'foo_export', displayValue: 'Foo', },
+        { exportValue: 'bar_export', displayValue: 'Bar', },
       ];
 
       choiceWidgetDict.set('Opt', options);
@@ -1125,14 +1119,8 @@ describe('annotation', function() {
 
       var options = ['Foo', optionBarRef];
       var expected = [
-        {
-          exportValue: 'Foo',
-          displayValue: 'Foo',
-        },
-        {
-          exportValue: 'Bar',
-          displayValue: 'Bar',
-        }
+        { exportValue: 'Foo', displayValue: 'Foo', },
+        { exportValue: 'Bar', displayValue: 'Bar', },
       ];
 
       choiceWidgetDict.set('Opt', options);
@@ -1167,6 +1155,31 @@ describe('annotation', function() {
       choiceWidgetDict.set('Parent', parentDict);
 
       var choiceWidgetRef = new Ref(123, 0);
+      var xref = new XRefMock([
+        { ref: choiceWidgetRef, data: choiceWidgetDict, },
+      ]);
+
+      var annotation = AnnotationFactory.create(xref, choiceWidgetRef,
+                                                pdfManagerMock, idFactoryMock);
+      var data = annotation.data;
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+
+      expect(data.options).toEqual(expected);
+    });
+
+    it('should sanitize display values in option arrays (issue 8947)',
+        function() {
+      // The option value is a UTF-16BE string. The display value should be
+      // sanitized, but the export value should remain the same since that
+      // may be used as a unique identifier when exporting form values.
+      var options = ['\xFE\xFF\x00F\x00o\x00o'];
+      var expected = [
+        { exportValue: '\xFE\xFF\x00F\x00o\x00o', displayValue: 'Foo', },
+      ];
+
+      choiceWidgetDict.set('Opt', options);
+
+      var choiceWidgetRef = new Ref(984, 0);
       var xref = new XRefMock([
         { ref: choiceWidgetRef, data: choiceWidgetDict, },
       ]);


### PR DESCRIPTION
Moreover, change the formatting of two other test cases to be more compact and more in line with the other test cases.

To verify this patch, use the following steps:
1. Open https://mozilla.github.io/pdf.js/web/viewer.html.
2. Open the console and enter `PDFViewerApplication.preferences.set('renderInteractiveForms', true);`.
3. Refresh the page and open the file from the issue. Notice that the dropdown has unsanitized strings.
4. Repeat these steps with the link in the preview below. Notice that the dropdown has sanitized strings.

Fixes #8947.