### PR TITLE
#9166 Wrap error reason

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1236,12 +1236,14 @@ function wrapReason(reason) {
 }
 
 function makeReasonSerializable(reason) {
-  if (!(reason instanceof Error) ||
-      reason instanceof AbortException ||
+  if (!(reason instanceof Error)) {
+    return reason;
+  }
+  if (reason instanceof AbortException ||
       reason instanceof MissingPDFException ||
       reason instanceof UnexpectedResponseException ||
       reason instanceof UnknownErrorException) {
-    return reason;
+    return wrapReason(reason);
   }
   return new UnknownErrorException(reason.message, reason.toString());
 }
@@ -1488,7 +1490,7 @@ MessageHandler.prototype = {
           return;
         }
         this.isCancelled = true;
-        sendStreamRequest({ stream: 'error', reason, });
+        sendStreamRequest({ stream: 'error', reason: wrapReason(reason), });
       },
 
       sinkCapability: capability,


### PR DESCRIPTION
It removes not serializable properties from 'reason' object.
They were added by ZoneAwarePromise used in NgZone and Angular 2+
Following object can not be serialized:
`reason {
message:'Missing PDF "http://localhost:8000/pdf-test2.pdf".',
name:'MissingPDFException',
__zone_symbol__currentTask:ZoneTask {_zone: Zone, runCount: 0, _zoneDelegates: null, _state: "notScheduled", ...
}`

By using 'wrapReason' it's converted to:
`reason {
message:'Missing PDF "http://localhost:8000/pdf-test2.pdf".',
name:'MissingPDFException'
}`

Before these changes we have 2 exceptions:
`ERROR Error: Uncaught (in promise): DataCloneError: Failed to execute 'postMessage' on 'Worker': function (delegate, current, target, task, applyThis, applyArgs) {
            try {
                onEnter(zo...<omitted>... } could not be cloned.
Error: Failed to execute 'postMessage' on 'Worker': function (delegate, current, target, task, applyThis, applyArgs) {
            try {
                onEnter(zo...<omitted>... } could not be cloned.
    at eval (util.js:1309)
    at ZoneDelegate.invoke (zone.js:392)
    at Object.onInvoke (ng_zone.ts:296)
    at ZoneDelegate.invoke (zone.js:391)
    at Zone.run (zone.js:142)
    at zone.js:873
    at ZoneDelegate.invokeTask (zone.js:425)
    at Object.onInvokeTask (ng_zone.ts:288)
    at ZoneDelegate.invokeTask (zone.js:424)
    at Zone.runTask (zone.js:192)
    at eval (util.js:1309)
    at ZoneDelegate.invoke (zone.js:392)
    at Object.onInvoke (ng_zone.ts:296)
    at ZoneDelegate.invoke (zone.js:391)
    at Zone.run (zone.js:142)
    at zone.js:873
    at ZoneDelegate.invokeTask (zone.js:425)
    at Object.onInvokeTask (ng_zone.ts:288)
    at ZoneDelegate.invokeTask (zone.js:424)
    at Zone.runTask (zone.js:192)
    at resolvePromise (zone.js:824)
    at zone.js:876
    at ZoneDelegate.invokeTask (zone.js:425)
    at Object.onInvokeTask (ng_zone.ts:288)
    at ZoneDelegate.invokeTask (zone.js:424)
    at Zone.runTask (zone.js:192)
    at drainMicroTaskQueue (zone.js:602)
    at <anonymous>`

`ERROR Error: Uncaught (in promise): DataCloneError: Failed to execute 'postMessage' on 'Worker': function (delegate, current, target, task, applyThis, applyArgs) {
            try {
                onEnter(zo...<omitted>... } could not be cloned.
Error: Failed to execute 'postMessage' on 'Worker': function (delegate, current, target, task, applyThis, applyArgs) {
            try {
                onEnter(zo...<omitted>... } could not be cloned.
    at MessageHandler.postMessage (util.js:1329)
    at sendStreamRequest (util.js:1457)
    at Object.error (util.js:1494)
    at eval (api.js:1573)
    at ZoneDelegate.invoke (zone.js:392)
    at Object.onInvoke (ng_zone.ts:296)
    at ZoneDelegate.invoke (zone.js:391)
    at Zone.run (zone.js:142)
    at zone.js:873
    at ZoneDelegate.invokeTask (zone.js:425)
    at MessageHandler.postMessage (util.js:1329)
    at sendStreamRequest (util.js:1457)
    at Object.error (util.js:1494)
    at eval (api.js:1573)
    at ZoneDelegate.invoke (zone.js:392)
    at Object.onInvoke (ng_zone.ts:296)
    at ZoneDelegate.invoke (zone.js:391)
    at Zone.run (zone.js:142)
    at zone.js:873
    at ZoneDelegate.invokeTask (zone.js:425)
    at resolvePromise (zone.js:824)
    at zone.js:876
    at ZoneDelegate.invokeTask (zone.js:425)
    at Object.onInvokeTask (ng_zone.ts:288)
    at ZoneDelegate.invokeTask (zone.js:424)
    at Zone.runTask (zone.js:192)
    at drainMicroTaskQueue (zone.js:602)
    at <anonymous>`