### PR TITLE
Don't display error messages, in the default viewer, for PDF files other than the current one

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -759,6 +759,10 @@ let PDFViewerApplication = {
     return loadingTask.promise.then((pdfDocument) => {
       this.load(pdfDocument);
     }, (exception) => {
+      if (loadingTask !== this.pdfLoadingTask) {
+        return; // Ignore errors for previously opened PDF files.
+      }
+
       let message = exception && exception.message;
       let loadingErrorMessage;
       if (exception instanceof InvalidPDFException) {


### PR DESCRIPTION
We've never attempted to limit the errors displayed in the default viewer to the current PDF file, but that's not really been a problem before. However after PR #7926, it's now possible to get password related error messages for *previously* opened PDF files in the default viewer.

**STR:**
 1. Open a password protected PDF file, e.g. `issue6010_1.pdf` from the test-suite.
 2. Cancel the password prompt.
 3. Open any new PDF file in the viewer.

**AR:**
The error UI is displayed, with a `No password given` message.

**ER:**
No error displayed, since it's only relevent for a now closed PDF file.

This is obviously a minor issue, caused by us now rejecting the still pending `pdfLoadingTask` during the `PDFViewerApplication.close` call, but I don't think that it (generally) makes sense to show errors if they're not relevant to the *currently* displayed PDF file.