### PR TITLE
Remove the unused `capability` parameter from the `WorkerTransport.getPage` method

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -516,7 +516,7 @@ var PDFDocumentProxy = (function PDFDocumentProxyClosure() {
      * @return {Promise} A promise that is resolved with a {@link PDFPageProxy}
      * object.
      */
-    getPage: function PDFDocumentProxy_getPage(pageNumber) {
+    getPage(pageNumber) {
       return this.transport.getPage(pageNumber);
     },
     /**
@@ -1917,7 +1917,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
       return this.messageHandler.sendWithPromise('GetData', null);
     },
 
-    getPage: function WorkerTransport_getPage(pageNumber, capability) {
+    getPage(pageNumber) {
       if (!Number.isInteger(pageNumber) ||
           pageNumber <= 0 || pageNumber > this.numPages) {
         return Promise.reject(new Error('Invalid page request'));


### PR DESCRIPTION
That parameter, originally named `promise`, has been unused for over five years; ever since commit https://github.com/mozilla/pdf.js/commit/f0687c4d50f4f674620b5cada5120421d2ba60c8 in PR #1531.