### PR TITLE
Remove the `pageRotation` getter in `PDFViewerApplication`

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -525,10 +525,6 @@ let PDFViewerApplication = {
     return this.pdfDocument ? this.pdfDocument.numPages : 0;
   },
 
-  get pageRotation() {
-    return this.pdfViewer.pagesRotation;
-  },
-
   set page(val) {
     this.pdfViewer.currentPageNumber = val;
   },


### PR DESCRIPTION
This was added, during the refactoring in PR #8556, to avoid outright breaking third-party users of the default viewer.
With PDF.js version `2.0`, where we're making API changes that aren't backwards compatible, we ought to be able to remove this piece of viewer code as well.