### PR TITLE
Button widget annotations: implement support for pushbuttons

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -61,8 +61,7 @@ class AnnotationElementFactory {
             } else if (parameters.data.checkBox) {
               return new CheckboxWidgetAnnotationElement(parameters);
             }
-            warn('Unimplemented button widget annotation: pushbutton');
-            break;
+            return new PushButtonWidgetAnnotationElement(parameters);
           case 'Ch':
             return new ChoiceWidgetAnnotationElement(parameters);
         }
@@ -540,6 +539,25 @@ class RadioButtonWidgetAnnotationElement extends WidgetAnnotationElement {
 
     this.container.appendChild(element);
     return this.container;
+  }
+}
+
+class PushButtonWidgetAnnotationElement extends LinkAnnotationElement {
+  /**
+   * Render the push button widget annotation's HTML element
+   * in the empty container.
+   *
+   * @public
+   * @memberof PushButtonWidgetAnnotationElement
+   * @returns {HTMLSectionElement}
+   */
+  render() {
+    // The rendering and functionality of a push button widget annotation is
+    // equal to that of a link annotation, but may have more functionality, such
+    // as performing actions on form fields (resetting, submitting, et cetera).
+    let container = super.render();
+    container.className = 'buttonWidgetAnnotation pushButton';
+    return container;
   }
 }
 

--- a/test/annotation_layer_builder_overrides.css
+++ b/test/annotation_layer_builder_overrides.css
@@ -19,7 +19,8 @@
   position: absolute;
 }
 
-.annotationLayer .linkAnnotation > a {
+.annotationLayer .linkAnnotation > a,
+.annotationLayer .buttonWidgetAnnotation.pushButton > a {
   opacity: 0.2;
   background: #ff0;
   box-shadow: 0px 2px 10px #ff0;

--- a/test/pdfs/issue4872.pdf.link
+++ b/test/pdfs/issue4872.pdf.link
@@ -1,0 +1,1 @@
+https://web.archive.org/web/20171003035412/https://www.cs.utexas.edu/users/EWD/ewd02xx/EWD288.PDF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -3717,6 +3717,16 @@
        "type": "eq",
        "annotations": true
     },
+    {  "id": "issue4872",
+       "file": "pdfs/issue4872.pdf",
+       "md5": "21c6cbc682140d6f6017bbeb45892053",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 1,
+       "lastPage": 1,
+       "type": "eq",
+       "annotations": true
+    },
     {  "id": "issue6108",
        "file": "pdfs/issue6108.pdf",
        "md5": "8961cb55149495989a80bf0487e0f076",

--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -17,7 +17,8 @@
   position: absolute;
 }
 
-.annotationLayer .linkAnnotation > a {
+.annotationLayer .linkAnnotation > a,
+.annotationLayer .buttonWidgetAnnotation.pushButton > a {
   position: absolute;
   font-size: 1em;
   top: 0;
@@ -26,11 +27,16 @@
   height: 100%;
 }
 
-.annotationLayer .linkAnnotation > a /* -ms-a */  {
+.annotationLayer .linkAnnotation > a /* -ms-a */ {
   background: url("data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7") 0 0 repeat;
 }
 
-.annotationLayer .linkAnnotation > a:hover {
+.annotationLayer .buttonWidgetAnnotation.pushButton > a /* -ms-a */ {
+  background: url("data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7") 0 0 repeat;
+}
+
+.annotationLayer .linkAnnotation > a:hover,
+.annotationLayer .buttonWidgetAnnotation.pushButton > a:hover {
   opacity: 0.2;
   background: #ff0;
   box-shadow: 0px 2px 10px #ff0;


### PR DESCRIPTION
While reading the specification, I realized that pushbuttons with action dictionaries are very similar to link annotations. Therefore, this patch implements support for pushbuttons with action dictionaries by inheriting most logic from link annotations.

Note that this patch does not handle appearance streams (which is another part of #7613) and pushbuttons that are specifically for form actions (which is also another part of #7613). However, it provides enough support to resolve the issues below (and there are *many* more PDF files at https://www.cs.utexas.edu/users/EWD/indexChron.html that are now handled correctly) and, by creating a separate class, allows us to extend this later on.

Fixes #4872
Fixes #7538
Fixes a part of #7613

*Easier reviewing with https://github.com/mozilla/pdf.js/pull/9191/files?w=1.*