### PR TITLE
Add `btoa` back to domstubs.js

### DIFF
--- a/examples/node/domstubs.js
+++ b/examples/node/domstubs.js
@@ -197,6 +197,10 @@ DOMElementSerializer.prototype = {
   },
 };
 
+function btoa (chars) {
+  return Buffer.from(chars, 'binary').toString('base64');
+}
+
 const document = {
   childNodes : [],
 
@@ -241,6 +245,7 @@ Image.prototype = {
   }
 }
 
+exports.btoa = btoa;
 exports.document = document;
 exports.Image = Image;
 


### PR DESCRIPTION
`btoa` polyfill was removed in compatibility.js, but in node.js environment we still need it.