### PR TITLE
Switch to using mozilla/recommended configuration for extensions/firefox.

### DIFF
--- a/extensions/firefox/.eslintrc
+++ b/extensions/firefox/.eslintrc
@@ -1,47 +1,42 @@
 {
+  // Note: The root .eslintrc file will define the base rules,
+  // but mozilla/recommended will override them for the rules it sets. Finally,
+  // the rules in this file will take precedence.
+  "extends": [
+    "plugin:mozilla/recommended",
+  ],
+
   "parserOptions": {
+    // Note: Remove the ecmaVersion line when Gecko 52 is no longer supported
+    // to pick up the eslint-plugin-mozilla version (or at least update to
+    // ecmaVersion 8).
     "ecmaVersion": 6,
-    "sourceType": "script"
+    "ecmaFeatures": {
+      // Note: We turn this off as it was only added in Gecko 55 (Bug 1339395)
+      // and we still need to support older versions (eslint-plugin-mozilla turns
+      // it on).
+      "experimentalObjectRestSpread": false
+    },
+
+    "sourceType": "script",
   },
 
   "plugins": [
     "mozilla"
   ],
 
-  "globals": {
-    "Components": false,
-    "dump": false
-  },
-
   "rules": {
-    "mozilla/import-globals": "error",
+    // Items different from the mozilla/recommended configuration.
+
+    // Being enabled soon.
     "mozilla/use-services": "error",
 
-    // Best Practices
-    "consistent-return": "error",
-
-    // Variables
+    // Other rules mozilla/recommended hasn't enabled yet.
     "no-shadow": "error",
-    "no-unused-vars": ["error", {
-      "vars": "local",
-      "varsIgnorePattern": "^Cc|Ci|Cu|Cr|EXPORTED_SYMBOLS",
-      "args": "none",
-    }],
-
-    // Stylistic Issues
-    "no-nested-ternary": "error",
-    "quotes": ["error", "double"],
-    "space-before-function-paren": ["error", "never"],
-
-    // ECMAScript 6
     "arrow-body-style": ["error", "as-needed"],
     "arrow-parens": ["error", "always"],
-    "arrow-spacing": ["error", { "before": true, "after": true, }],
     "constructor-super": "error",
     "no-confusing-arrow": "error",
-    "no-const-assign": "error",
-    "no-dupe-class-members": "error",
     "no-useless-constructor": "error",
-    "object-shorthand": ["error", "always", { "avoidQuotes": true }],
   },
 }

--- a/extensions/firefox/bootstrap.js
+++ b/extensions/firefox/bootstrap.js
@@ -29,21 +29,6 @@ const Cr = Components.results;
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
 
-function getBoolPref(pref, def) {
-  try {
-    return Services.prefs.getBoolPref(pref);
-  } catch (ex) {
-    return def;
-  }
-}
-
-function log(str) {
-  if (!getBoolPref(EXT_PREFIX + ".pdfBugEnabled", false)) {
-    return;
-  }
-  dump(str + "\n");
-}
-
 function initializeDefaultPreferences() {
   /* eslint-disable semi */
   var DEFAULT_PREFERENCES =

--- a/extensions/firefox/content/PdfjsChromeUtils.jsm
+++ b/extensions/firefox/content/PdfjsChromeUtils.jsm
@@ -81,6 +81,7 @@ var PdfjsChromeUtils = {
       // omitting it in prior Firefox versions breaks the addon.
       var ffVersion = parseInt(Services.appinfo.platformVersion);
       if (ffVersion <= 55) {
+        // eslint-disable-next-line mozilla/no-useless-parameters
         Services.obs.addObserver(this, "quit-application", false);
         return;
       }

--- a/extensions/firefox/content/PdfjsContentUtils.jsm
+++ b/extensions/firefox/content/PdfjsContentUtils.jsm
@@ -52,6 +52,7 @@ var PdfjsContentUtils = {
       // omitting it in prior Firefox versions breaks the addon.
       var ffVersion = parseInt(Services.appinfo.platformVersion);
       if (ffVersion <= 55) {
+        // eslint-disable-next-line mozilla/no-useless-parameters
         Services.obs.addObserver(this, "quit-application", false);
         return;
       }


### PR DESCRIPTION
This switches to using the mozilla/recommended configuration for extensions/firefox. The configuration is supplied via eslint-plugin-mozilla, already included via npm in this repository.

The benefits are that this is closer to the Firefox ESLint configuration (which is better when exporting to mozilla-central), and as eslint-plugin-mozilla is updated, you'll get any new rules more-or-less automatically.

I've de-duplicated the configuration file, the only thing I didn't remove was the parser ecmaVersion - currently it is set to 6, for mozilla-central it is currently 8. I wasn't sure if this could/should be changed or not.