### PR TITLE
Lower the `MIN_SCALE` threshold to `0.10` (i.e. 10%) in the viewer, for better compatibility with documents containing very large pages

### DIFF
--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -18,7 +18,7 @@ import { createPromiseCapability, PDFJS } from 'pdfjs-lib';
 const CSS_UNITS = 96.0 / 72.0;
 const DEFAULT_SCALE_VALUE = 'auto';
 const DEFAULT_SCALE = 1.0;
-const MIN_SCALE = 0.25;
+const MIN_SCALE = 0.10;
 const MAX_SCALE = 10.0;
 const UNKNOWN_SCALE = 0;
 const MAX_AUTO_SCALE = 1.25;


### PR DESCRIPTION
For sufficiently large page sizes, always limiting the minimum zoom level to 25% seem a bit too high.  One
example is pages, e.g. the first one, in: [PageSizes_output.pdf](https://github.com/mozilla/pdf.js/files/1513951/PageSizes_output.pdf)

Hence I think that it makes sense to lower `MIN_SCALE` slightly, since other PDF viewers (e.g. Adobe Reader) isn't limiting the minimum zoom level as aggressively. Obviously this will allow a greater number of pages to be visible at the same time in the viewer, but given that they will be small that shouldn't be an issue.

Note also that e.g. the `page-fit`/`page-width` zoom levels already allow `< MIN_SCALE` values, so I don't see why we shouldn't allow users the same functionality directly.