### PR TITLE
correctly recognize fonts with a `-bd` suffix in their name as bold

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -1216,7 +1216,8 @@ var Font = (function FontClosure() {
         !!(nonStdFontMap[fontName] && stdFontMap[nonStdFontMap[fontName]]);
       fontName = stdFontMap[fontName] || nonStdFontMap[fontName] || fontName;
 
-      this.bold = (fontName.search(/bold/gi) !== -1);
+      this.bold = ((fontName.search(/bold/gi) !== -1) ||
+                   (fontName.search(/-bd/gi) !== -1));
       this.italic = ((fontName.search(/oblique/gi) !== -1) ||
                      (fontName.search(/italic/gi) !== -1));
 


### PR DESCRIPTION
Example of a such a font name in the wild is `ABZSMO+HelveticaNeueLTStd-Bd`.

I am unfortunately unable to share a document that contains that font, but it's readily googleable as an existing bolded font variant.