### PR TITLE
[Firefox addon] Temporarily disable the ESLint `semi` rule, around the `DEFAULT_PREFERENCES` declaration, to prevent mozilla-central test errors

### DIFF
--- a/extensions/firefox/bootstrap.js
+++ b/extensions/firefox/bootstrap.js
@@ -45,11 +45,13 @@ function log(str) {
 }
 
 function initializeDefaultPreferences() {
+  /* eslint-disable semi */
   var DEFAULT_PREFERENCES =
 //#include ../../web/default_preferences.json
 //#if false
-    "end of DEFAULT_PREFERENCES";
+    "end of DEFAULT_PREFERENCES"
 //#endif
+  /* eslint-enable semi */
 
   var defaultBranch = Services.prefs.getDefaultBranch(EXT_PREFIX + ".");
   var defaultValue;

--- a/extensions/firefox/content/PdfJs.jsm
+++ b/extensions/firefox/content/PdfJs.jsm
@@ -79,11 +79,13 @@ function isDefaultHandler() {
 }
 
 function initializeDefaultPreferences() {
+  /* eslint-disable semi */
   var DEFAULT_PREFERENCES =
 //#include ../../../web/default_preferences.json
 //#if false
-    "end of DEFAULT_PREFERENCES";
+    "end of DEFAULT_PREFERENCES"
 //#endif
+  /* eslint-enable semi */
 
   var defaultBranch = Services.prefs.getDefaultBranch(PREF_PREFIX + ".");
   var defaultValue;

--- a/extensions/firefox/content/PdfjsChromeUtils.jsm
+++ b/extensions/firefox/content/PdfjsChromeUtils.jsm
@@ -33,11 +33,13 @@ XPCOMUtils.defineLazyServiceGetter(Svc, "mime",
                                    "@mozilla.org/mime;1",
                                    "nsIMIMEService");
 
+/* eslint-disable semi */
 var DEFAULT_PREFERENCES =
 //#include ../../../web/default_preferences.json
 //#if false
-  "end of DEFAULT_PREFERENCES";
+  "end of DEFAULT_PREFERENCES"
 //#endif
+/* eslint-enable semi */
 
 var PdfjsChromeUtils = {
   // For security purposes when running remote, we restrict preferences


### PR DESCRIPTION
While this doesn't actually fix the underlying issue, it should prevent the ESLint errors and thus make future PDF.js updates easier.
Compared to updating (and testing) the preprocessor, this seems like a reasonable workaround given its simplicity.

/cc @rvandermeulen