### PR TITLE
'worker-loader' requires 'webpack' as peerDependency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1301,7 +1301,10 @@ gulp.task('dist-pre',
     license: DIST_LICENSE,
     dependencies: {
       'node-ensure': '^0.0.0', // shim for node for require.ensure
-      'worker-loader': '^1.0.0', // used in external/dist/webpack.json
+      'worker-loader': '^1.1.0', // used in external/dist/webpack.json
+    },
+    peerDependencies: {
+      'webpack': '^2.0.0 || ^3.0.0', // peerDependency of 'worker-loader'
     },
     browser: {
       'fs': false,


### PR DESCRIPTION
Closes #9248

Ref: https://github.com/webpack-contrib/worker-loader/blob/master/package.json#L34