### PR TITLE
Handle PDF files with missing 'endobj' operators, by scanning through the contents of objects found in `XRef.indexObjects` (issue 9105)

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -1149,6 +1149,27 @@ var XRef = (function XRefClosure() {
           var contentLength = skipUntil(buffer, position, endobjBytes) + 7;
           var content = buffer.subarray(position, position + contentLength);
 
+          // Scan through the 'obj' content, to ensure that we won't miss
+          // any 'obj' operators in corrupt files (fixes issue9105.pdf).
+          let contentPos = token.length;
+          while (contentPos < contentLength) {
+            let contentToken = readToken(content, contentPos);
+
+            if (!contentToken) {
+              contentPos++;
+              continue;
+            }
+            if (objRegExp.exec(contentToken) &&
+                contentToken.trim() !== token.trim()) {
+              warn('indexObjects: found new "obj" inside of another "obj", ' +
+                   'caused by missing "endobj" -- trying to recover.');
+              contentLength = contentPos;
+              content = content.subarray(0, contentLength);
+              break;
+            }
+            contentPos += contentToken.length;
+          }
+
           // checking XRef stream suspect
           // (it shall have '/XRef' and next char is not a letter)
           var xrefTagOffset = skipUntil(content, 0, xrefBytes);

--- a/test/pdfs/issue9105.pdf.link
+++ b/test/pdfs/issue9105.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/1444166/110229_10312017_6810306.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -733,6 +733,14 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue9105",
+       "file": "pdfs/issue9105.pdf",
+       "md5": "69692ea4c78c698046d7e41f0cec9403",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue6289",
        "file": "pdfs/issue6289.pdf",
        "md5": "0869f3d147c734ec484ffd492104095d",


### PR DESCRIPTION
Unfortunately this will, especially for larger documents, cause the parsing of PDF files with *corrupt* XRef data to become (slightly) slower. However, that's probably unavoidable if we want to support PDF generators that appear to treat 'endobj' like an optional operator.

Fixes #9105.

*Edit:* I've looked briefly at reducing the amount of parsing needed in order to fix the issue. However, I've been unable to come up with something better myself here :-(