### PR TITLE
[api-minor] Downsize large image masks before rendering

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -184,7 +184,8 @@ class Page {
     });
   }
 
-  getOperatorList({ handler, task, intent, renderInteractiveForms, }) {
+  getOperatorList({ handler, task, intent, renderInteractiveForms,
+                    combinedInitialTransform, }) {
     const contentStreamPromise = this.pdfManager.ensure(this,
                                                         'getContentStream');
     const resourcesPromise = this.loadResources([
@@ -205,6 +206,7 @@ class Page {
       builtInCMapCache: this.builtInCMapCache,
       options: this.evaluatorOptions,
       pdfFunctionFactory: this.pdfFunctionFactory,
+      combinedInitialTransform,
     });
 
     const dataPromises = Promise.all([contentStreamPromise, resourcesPromise]);

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -481,6 +481,7 @@ var WorkerMessageHandler = {
           task,
           intent: data.intent,
           renderInteractiveForms: data.renderInteractiveForms,
+          combinedInitialTransform: data.combinedInitialTransform,
         }).then(function(operatorList) {
           finishWorkerTask(task);
 


### PR DESCRIPTION
Hi,

This PR addresses #8076 . The problem was the large image mask resolution. The solution was to scale it down in `image.js` and then send the reduced image mask data for rendering via `evaluator.js`.

For downscaling, I used 'point sampling' algorithm which does something like [this](https://www.imagemagick.org/Usage/filter/#point). Since we're dealing with image mask(b&w palette), this would serve the purpose well. Compare [this](https://i.imgur.com/KrTFwR3.png)(pdfium) vs [this](https://i.imgur.com/ICGlJr2.png).

Thanks,
Apoorv