### PR TITLE
Use native `Math` functions in the custom `log2` function

### DIFF
--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -348,6 +348,14 @@ PDFJS.compatibilityChecked = true;
   Array.prototype.includes = require('core-js/fn/array/includes');
 })();
 
+// Provides support for Math.log2 in legacy browsers.
+// Support: IE.
+(function checkMathLog2() {
+  if (Math.log2) {
+    return;
+  }
+  Math.log2 = require('core-js/fn/math/log2');
+})();
 
 // Provides support for Number.isNaN in legacy browsers.
 // Support: IE.

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -600,13 +600,14 @@ function string32(value) {
                              (value >> 8) & 0xff, value & 0xff);
 }
 
+// Calculate the base 2 logarithm of the number `x`. This differs from the
+// native function in the sense that it returns the ceiling value and that it
+// returns 0 instead of `Infinity`/`NaN` for `x` values smaller than/equal to 0.
 function log2(x) {
-  var n = 1, i = 0;
-  while (x > n) {
-    n <<= 1;
-    i++;
+  if (x <= 0) {
+    return 0;
   }
-  return i;
+  return Math.ceil(Math.log2(x));
 }
 
 function readInt8(data, start) {

--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -15,7 +15,7 @@
 
 import {
   bytesToString, isArrayBuffer, isBool, isEmptyObj, isNum, isSpace, isString,
-  ReadableStream, removeNullCharacters, stringToBytes, stringToPDFString
+  log2, ReadableStream, removeNullCharacters, stringToBytes, stringToPDFString
 } from '../../src/shared/util';
 
 describe('util', function() {
@@ -133,6 +133,20 @@ describe('util', function() {
       expect(isString(1)).toEqual(false);
       expect(isString(null)).toEqual(false);
       expect(isString(undefined)).toEqual(false);
+    });
+  });
+
+  describe('log2', function() {
+    it('handles values smaller than/equal to zero', function() {
+      expect(log2(0)).toEqual(0);
+      expect(log2(-1)).toEqual(0);
+    });
+
+    it('handles values larger than zero', function() {
+      expect(log2(1)).toEqual(0);
+      expect(log2(2)).toEqual(1);
+      expect(log2(3)).toEqual(2);
+      expect(log2(3.14)).toEqual(2);
     });
   });
 


### PR DESCRIPTION
It is quite confusing that the custom function is called `log2` while it actually returns the ceiling value and handles zero and negative values differently than the native function.

To resolve this, we add a comment that explains these differences and make the function use the native `Math` functions internally instead of using our own custom logic. To verify that the function does what we expect, we add unit tests.

All browsers except for IE support `Math.log2` for quite a long time already (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log2). For IE, we use the core-js polyfill.

According to the microbenchmark at https://jsperf.com/log2-pdfjs/1, using the native functions should also be faster, in my testing almost six times as fast.