### PR TITLE
Attempt to remove the special `JpegStream.getBytes` method and utilize the regular `DecodeStream` one instead

### DIFF
--- a/src/core/jpeg_stream.js
+++ b/src/core/jpeg_stream.js
@@ -100,11 +100,6 @@ let JpegStream = (function JpegStreamClosure() {
     this.eof = true;
   };
 
-  JpegStream.prototype.getBytes = function(length) {
-    this.readBlock();
-    return this.buffer;
-  };
-
   JpegStream.prototype.getIR = function(forceDataSchema = false) {
     return createObjectURL(this.bytes, 'image/jpeg', forceDataSchema);
   };


### PR DESCRIPTION
Note that no other image stream implements a special `getBytes` method, which makes `JpegStream` look somewhat odd.

I'm actually not sure what purpose this methods serves, since I successfully ran all tests locally with it commented out. Furthermore, I also ran tests with an added `if (length && length !== this.bufferLength) { throw new Error('length mismatch'); }` check, and didn't get a single test failure in that case either.

Looking at the history, it seems that this code originated back in PR #4528, but as far as I can tell there's no mention in either commit messages nor PR comments of why it was necessary to add a "special" `getBytes` function for the `JpegStream`.
My assumption is that there's a good reason why this method was added, e.g. to address a *specific* regression in one of the reference tests. However, I did check out commit https://github.com/mozilla/pdf.js/commit/58f697f977f4a60974d91b09b2da67133227837c locally and ran tests with this method commented out, and there didn't seem to be any image-related failures in that case either!?

Hence I'm suggesting that we attempt to simplify this code slightly be removing this special `getBytes` method. However, please note that there's perhaps a *small* risk of regressions in an edge-case where we currently have insufficient test-coverage.