### PR TITLE
Improve visibility of the findInput placeholder in Chrome

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -433,6 +433,7 @@ html[dir='rtl'] .findbar {
 }
 #findInput::-webkit-input-placeholder {
   font-style: italic;
+  color: hsl(0, 0%, 75%);
 }
 #findInput::-moz-placeholder {
   font-style: italic;


### PR DESCRIPTION
this pull request is with reference to the issue #9237 and I have closed my previous pull request of #9265 . I have also made the changes requested by @Snuffleupagus 