### PR TITLE
Enabled "read with streaming" unit test for browsers that support streaming

### DIFF
--- a/test/unit/network_spec.js
+++ b/test/unit/network_spec.js
@@ -64,14 +64,15 @@ describe('network', function() {
 
   it('read with streaming', function(done) {
     var userAgent = window.navigator.userAgent;
-    // The test is valid for FF only: the XHR has support of the
-    // 'moz-chunked-array' response type.
-    // TODO enable for other browsers, e.g. when fetch/streams API is supported.
-    var m = /Mozilla\/5.0.*?rv:(\d+).*? Gecko/.exec(userAgent);
-    if (!m || m[1] < 9) {
-      expect(true).toEqual(true);
-      done();
-      return;
+    let isFirefoxWithMozChunkedEncodingSupport =
+      /Mozilla\/5.0.*?rv:(?:\d+).*? Gecko/.test(userAgent);
+    let isFetchWithStreamSupport = (typeof Response !== 'undefined' &&
+                                    'body' in Response.prototype &&
+                                    typeof ReadableStream !== 'undefined');
+
+    if (!isFirefoxWithMozChunkedEncodingSupport &&
+        !isFetchWithStreamSupport) {
+      pending('Streaming not supported by user agent');
     }
 
     var stream = new PDFNetworkStream({


### PR DESCRIPTION
As mentioned by @timvandermeij 3 days ago, I have made the required changes, also referring to the comments mentioned by @Snuffleupagus [here](https://github.com/mozilla/pdf.js/pull/9050/files/).

This hopefully closes #8851 .
 