### PR TITLE
Handle broken, Ghostscript generated, Metadata that contains HTML character names (bug 1424938)

### DIFF
--- a/src/display/metadata.js
+++ b/src/display/metadata.js
@@ -37,6 +37,20 @@ class Metadata {
       let bytes = codes.replace(/\\([0-3])([0-7])([0-7])/g,
           function(code, d1, d2, d3) {
         return String.fromCharCode(d1 * 64 + d2 * 8 + d3 * 1);
+      }).replace(/&(amp|apos|gt|lt|quot);/g, function(str, name) {
+        switch (name) {
+          case 'amp':
+            return '&';
+          case 'apos':
+            return '\'';
+          case 'gt':
+            return '>';
+          case 'lt':
+            return '<';
+          case 'quot':
+            return '\"';
+        }
+        throw new Error(`_repair: ${name} isn't defined.`);
       });
 
       let chars = '';

--- a/test/unit/metadata_spec.js
+++ b/test/unit/metadata_spec.js
@@ -49,4 +49,51 @@ describe('metadata', function() {
 
     expect(metadata.getAll()).toEqual({ 'dc:title': 'PDF&', });
   });
+
+  it('should repair and handle invalid metadata (bug 1424938)', function() {
+    let invalidData = '<x:xmpmeta xmlns:x=\'adobe:ns:meta/\' ' +
+      'x:xmptk=\'XMP toolkit 2.9.1-13, framework 1.6\'>' +
+      '<rdf:RDF xmlns:rdf=\'http://www.w3.org/1999/02/22-rdf-syntax-ns#\' ' +
+      'xmlns:iX=\'http://ns.adobe.com/iX/1.0/\'>' +
+      '<rdf:Description rdf:about=\'61652fa7-fc1f-11dd-0000-ce81d41f9ecf\' ' +
+      'xmlns:pdf=\'http://ns.adobe.com/pdf/1.3/\' ' +
+      'pdf:Producer=\'GPL Ghostscript 8.63\'/>' +
+      '<rdf:Description rdf:about=\'61652fa7-fc1f-11dd-0000-ce81d41f9ecf\' ' +
+      'xmlns:xap=\'http://ns.adobe.com/xap/1.0/\' ' +
+      'xap:ModifyDate=\'2009-02-13T12:42:54+01:00\' ' +
+      'xap:CreateDate=\'2009-02-13T12:42:54+01:00\'>' +
+      '<xap:CreatorTool>\\376\\377\\000P\\000D\\000F\\000C\\000r\\000e\\000a' +
+      '\\000t\\000o\\000r\\000 \\000V\\000e\\000r\\000s\\000i\\000o\\000n' +
+      '\\000 \\0000\\000.\\0009\\000.\\0006</xap:CreatorTool>' +
+      '</rdf:Description><rdf:Description ' +
+      'rdf:about=\'61652fa7-fc1f-11dd-0000-ce81d41f9ecf\' ' +
+      'xmlns:xapMM=\'http://ns.adobe.com/xap/1.0/mm/\' ' +
+      'xapMM:DocumentID=\'61652fa7-fc1f-11dd-0000-ce81d41f9ecf\'/>' +
+      '<rdf:Description rdf:about=\'61652fa7-fc1f-11dd-0000-ce81d41f9ecf\' ' +
+      'xmlns:dc=\'http://purl.org/dc/elements/1.1/\' ' +
+      'dc:format=\'application/pdf\'><dc:title><rdf:Alt>' +
+      '<rdf:li xml:lang=\'x-default\'>\\376\\377\\000L\\000&apos;\\000O\\000d' +
+      '\\000i\\000s\\000s\\000e\\000e\\000 \\000t\\000h\\000\\351\\000m\\000a' +
+      '\\000t\\000i\\000q\\000u\\000e\\000 \\000l\\000o\\000g\\000o\\000 ' +
+      '\\000O\\000d\\000i\\000s\\000s\\000\\351\\000\\351\\000 \\000-\\000 ' +
+      '\\000d\\000\\351\\000c\\000e\\000m\\000b\\000r\\000e\\000 \\0002\\0000' +
+      '\\0000\\0008\\000.\\000p\\000u\\000b</rdf:li></rdf:Alt></dc:title>' +
+      '<dc:creator><rdf:Seq><rdf:li>\\376\\377\\000O\\000D\\000I\\000S' +
+      '</rdf:li></rdf:Seq></dc:creator></rdf:Description></rdf:RDF>' +
+      '</x:xmpmeta>';
+    let metadata = new Metadata(invalidData);
+
+    expect(metadata.has('dc:title')).toBeTruthy();
+    expect(metadata.has('dc:qux')).toBeFalsy();
+
+    expect(metadata.get('dc:title')).toEqual(
+      'L\'Odissee thématique logo Odisséé - décembre 2008.pub');
+    expect(metadata.get('dc:qux')).toEqual(null);
+
+    expect(metadata.getAll()).toEqual({
+      'dc:creator': 'ODIS',
+      'dc:title': 'L\'Odissee thématique logo Odisséé - décembre 2008.pub',
+      'xap:creatortool': 'PDFCreator Version 0.9.6',
+    });
+  });
 });


### PR DESCRIPTION
Please note that while this could be considered a regression in user-facing behaviour, I'm not convinced that it's really a regression as such since prior to PR #8912 the Metadata would fail to parse (with an XML error) and thus be ignored when setting the viewer title.
With the refactored Metadata parsing we're now able to parse this, which uncovered issues with a subset of broken Ghostscript Metadata that uses HTML character names.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1424938