### PR TITLE
Handle PDF files with missing 'endobj' operators, by searching for the "obj" string rather than "endobj" in `XRef.indexObjects` (issue 9105)

### DIFF
--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -64,6 +64,7 @@
 !issue8798r.pdf
 !issue8823.pdf
 !issue9084.pdf
+!issue9105_reduced.pdf
 !bad-PageLabels.pdf
 !filled-background.pdf
 !ArabicCIDTrueType.pdf

--- a/test/pdfs/issue9105_reduced.pdf
+++ b/test/pdfs/issue9105_reduced.pdf
@@ -1,0 +1,74 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/Title (Issue 9105)
+/Author (Snuffleupagus)
+>>
+2 0 obj 
+<<
+/Pages 3 0 R
+/Type /Catalog
+>>
+endobj 
+3 0 obj 
+<<
+/Kids [4 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+4 0 obj 
+<<
+/Parent 3 0 R
+/MediaBox [0 0 200 50]
+/Resources 
+<<
+/Font 
+<<
+/F1 5 0 R
+>>
+>>
+/Contents 6 0 R
+/Type /Page
+>>
+endobj 
+5 0 obj 
+<<
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/Type /Font
+>>
+endobj 
+6 0 obj 
+<<
+/Length 41
+>>
+stream
+BT
+10 20 TD
+/F1 20 Tf
+(Issue 9105) Tj
+ET
+
+endstream 
+endobj xref
+0 7
+0000000000 65535 f 
+0000000001 00000 n 
+0000000002 00000 n 
+0000000003 00000 n 
+0000000004 00000 n 
+0000000005 00000 n 
+0000000006 00000 n 
+trailer
+
+<<
+/Info 1 0 R
+/Root 2 0 R
+/Size 7
+>>
+startxref
+491
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -741,6 +741,13 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue9105",
+       "file": "pdfs/issue9105_reduced.pdf",
+       "md5": "f3889f7c7b60e1ab998aac430cc7e08e",
+       "rounds": 1,
+       "link": false,
+       "type": "eq"
+    },
     {  "id": "issue6289",
        "file": "pdfs/issue6289.pdf",
        "md5": "0869f3d147c734ec484ffd492104095d",


### PR DESCRIPTION
This patch refactors the searching for 'endobj', to try and find the next occurance of "obj" and then check if it was in fact an 'endobj' and continue searching otherwise.
This approach is used to avoid having to first find 'endobj', and then re-check the entire contents of the object and having to run (potentially expensive) regular expressions on arbitrary long strings.

Fixes #9105.

---
Replaces PR #9253, since the approach used there would cause needless re-parsing of data and potentially bad regular expression performance.