### PR TITLE
Keep track of parsed (array) ColourSpaces in `ColorSpace.parseToIR` to prevent infinite loops in corrupt PDF files (issue 9285)

### DIFF
--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -258,8 +258,8 @@ var ColorSpace = (function ColorSpaceClosure() {
     }
   };
 
-  ColorSpace.parseToIR = function(cs, xref, res, pdfFunctionFactory) {
-    if (isName(cs)) {
+  ColorSpace.parseToIR = function(cs, xref, res = null, pdfFunctionFactory) {
+    if (res && isName(cs)) {
       var colorSpaces = res.get('ColorSpace');
       if (isDict(colorSpaces)) {
         var refcs = colorSpaces.get(cs.name);

--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -14,9 +14,59 @@
  */
 
 import {
-  FormatError, info, isString, shadow, unreachable, warn
+  assert, FormatError, info, isArrayBuffer, isNum, isString, shadow,
+  unreachable, warn
 } from '../shared/util';
-import { isDict, isName, isStream } from './primitives';
+import { isDict, isName, isRef, isStream } from './primitives';
+import { MurmurHash3_64 } from './murmurhash3';
+
+function buildColorSpaceHash(cs) {
+  assert(Array.isArray(cs), 'ColorSpace must be an array.');
+  let hash = new MurmurHash3_64();
+
+  function parseElement(element) {
+    if (isName(element)) {
+      hash.update(element.name);
+    } else if (isRef(element) || isNum(element)) {
+      hash.update(element.toString());
+    } else if (isString(element)) {
+      hash.update(element);
+    } else if (isDict(element)) {
+      if (element.objId) {
+        hash.update(element.objId);
+      } else {
+        let keys = element.getKeys();
+        for (let i = 0, ii = element.length; i < ii; i++) {
+          let key = keys[i];
+          hash.update(key);
+          parseElement(element.getRaw(key));
+        }
+      }
+    } else if (isStream(element)) {
+      if (element.dict) {
+        parseElement(element.dict);
+      }
+      let stream = element.str || element;
+      let typedArray = stream.buffer ?
+        new Uint8Array(stream.buffer.buffer, 0, stream.bufferLength) :
+        new Uint8Array(stream.bytes.buffer,
+                       stream.start, stream.end - stream.start);
+      hash.update(typedArray);
+    } else if (isArrayBuffer(element)) {
+      hash.update(element);
+    } else if (Array.isArray(element)) {
+      for (let i = 0, ii = element.length; i < ii; i++) {
+        parseElement(element[i]);
+      }
+    }
+  }
+
+  // Parse the ColourSpace array.
+  for (let i = 0, ii = cs.length; i < ii; i++) {
+    parseElement(cs[i]);
+  }
+  return hash.hexdigest();
+}
 
 var ColorSpace = (function ColorSpaceClosure() {
   /**
@@ -258,7 +308,8 @@ var ColorSpace = (function ColorSpaceClosure() {
     }
   };
 
-  ColorSpace.parseToIR = function(cs, xref, res = null, pdfFunctionFactory) {
+  ColorSpace.parseToIR = function(cs, xref, res = null, pdfFunctionFactory,
+                                  parsedColorSpaceCache) {
     if (res && isName(cs)) {
       var colorSpaces = res.get('ColorSpace');
       if (isDict(colorSpaces)) {
@@ -288,6 +339,20 @@ var ColorSpace = (function ColorSpaceClosure() {
       }
     }
     if (Array.isArray(cs)) {
+      // Keep track of already parsed ColourSpaces, to prevent an infinite loop
+      // when parsing corrupt PDF files where there's a circular dependency
+      // between the ColourSpaces (fixes issue9285.pdf).
+      if (!parsedColorSpaceCache) {
+        parsedColorSpaceCache = Object.create(null);
+      }
+      let hash = buildColorSpaceHash(cs);
+      if (hash) {
+        if (parsedColorSpaceCache[hash]) {
+          throw new FormatError('Circular dependency between ColorSpaces.');
+        }
+        parsedColorSpaceCache[hash] = true;
+      }
+
       var mode = xref.fetchIfRef(cs[0]).name;
       var numComps, params, alt, whitePoint, blackPoint, gamma;
 
@@ -320,13 +385,18 @@ var ColorSpace = (function ColorSpaceClosure() {
           numComps = dict.get('N');
           alt = dict.get('Alternate');
           if (alt) {
-            var altIR = ColorSpace.parseToIR(alt, xref, res,
-                                             pdfFunctionFactory);
-            // Parse the /Alternate CS to ensure that the number of components
-            // are correct, and also (indirectly) that it is not a PatternCS.
-            var altCS = ColorSpace.fromIR(altIR, pdfFunctionFactory);
-            if (altCS.numComps === numComps) {
-              return altIR;
+            try {
+              let altIR = ColorSpace.parseToIR(alt, xref, res,
+                                               pdfFunctionFactory,
+                                               parsedColorSpaceCache);
+              // Parse the /Alternate CS to ensure that the number of components
+              // are correct, and also (indirectly) that it is not a PatternCS.
+              let altCS = ColorSpace.fromIR(altIR, pdfFunctionFactory);
+              if (altCS.numComps === numComps) {
+                return altIR;
+              }
+            } catch (ex) {
+              // Ignore errors here, given the `numComps` fallback below.
             }
             warn('ICCBased color space: Ignoring incorrect /Alternate entry.');
           }
@@ -342,13 +412,15 @@ var ColorSpace = (function ColorSpaceClosure() {
           var basePatternCS = cs[1] || null;
           if (basePatternCS) {
             basePatternCS = ColorSpace.parseToIR(basePatternCS, xref, res,
-                                                 pdfFunctionFactory);
+                                                 pdfFunctionFactory,
+                                                 parsedColorSpaceCache);
           }
           return ['PatternCS', basePatternCS];
         case 'Indexed':
         case 'I':
           var baseIndexedCS = ColorSpace.parseToIR(cs[1], xref, res,
-                                                   pdfFunctionFactory);
+                                                   pdfFunctionFactory,
+                                                   parsedColorSpaceCache);
           var hiVal = xref.fetchIfRef(cs[2]) + 1;
           var lookup = xref.fetchIfRef(cs[3]);
           if (isStream(lookup)) {
@@ -359,7 +431,8 @@ var ColorSpace = (function ColorSpaceClosure() {
         case 'DeviceN':
           var name = xref.fetchIfRef(cs[1]);
           numComps = Array.isArray(name) ? name.length : 1;
-          alt = ColorSpace.parseToIR(cs[2], xref, res, pdfFunctionFactory);
+          alt = ColorSpace.parseToIR(cs[2], xref, res, pdfFunctionFactory,
+                                     parsedColorSpaceCache);
           let tintFnIR = pdfFunctionFactory.createIR(xref.fetchIfRef(cs[3]));
           return ['AlternateCS', numComps, alt, tintFnIR];
         case 'Lab':

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -412,6 +412,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           xref: this.xref,
           res: resources,
           image,
+          isInline: inline,
           pdfFunctionFactory: this.pdfFunctionFactory,
         });
         // We force the use of RGBA_32BPP images here, because we can't handle
@@ -464,6 +465,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         xref: this.xref,
         res: resources,
         image,
+        isInline: inline,
         nativeDecoder: nativeImageDecoder,
         pdfFunctionFactory: this.pdfFunctionFactory,
       }).then((imageObj) => {

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -75,8 +75,8 @@ var PDFImage = (function PDFImageClosure() {
     return dest;
   }
 
-  function PDFImage({ xref, res, image, smask = null, mask = null,
-                      isMask = false, pdfFunctionFactory, }) {
+  function PDFImage({ xref, res, image, isInline = false, smask = null,
+                      mask = null, isMask = false, pdfFunctionFactory, }) {
     this.image = image;
     var dict = image.dict;
     if (dict.has('Filter')) {
@@ -139,7 +139,8 @@ var PDFImage = (function PDFImageClosure() {
                             'color components not supported.');
         }
       }
-      this.colorSpace = ColorSpace.parse(colorSpace, xref, res,
+      let resources = isInline ? res : null;
+      this.colorSpace = ColorSpace.parse(colorSpace, xref, resources,
                                          pdfFunctionFactory);
       this.numComps = this.colorSpace.numComps;
     }
@@ -167,6 +168,7 @@ var PDFImage = (function PDFImageClosure() {
         xref,
         res,
         image: smask,
+        isInline,
         pdfFunctionFactory,
       });
     } else if (mask) {
@@ -179,6 +181,7 @@ var PDFImage = (function PDFImageClosure() {
             xref,
             res,
             image: mask,
+            isInline,
             isMask: true,
             pdfFunctionFactory,
           });
@@ -193,7 +196,7 @@ var PDFImage = (function PDFImageClosure() {
    * Handles processing of image data and returns the Promise that is resolved
    * with a PDFImage when the image is ready to be used.
    */
-  PDFImage.buildImage = function({ handler, xref, res, image,
+  PDFImage.buildImage = function({ handler, xref, res, image, isInline = false,
                                    nativeDecoder = null,
                                    pdfFunctionFactory, }) {
     var imagePromise = handleImageData(image, nativeDecoder);
@@ -227,6 +230,7 @@ var PDFImage = (function PDFImageClosure() {
           xref,
           res,
           image: imageData,
+          isInline,
           smask: smaskData,
           mask: maskData,
           pdfFunctionFactory,

--- a/test/pdfs/issue9285.pdf.link
+++ b/test/pdfs/issue9285.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/1563256/4149180-355989.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -741,6 +741,14 @@
        "link": false,
        "type": "eq"
     },
+    {  "id": "issue9285",
+       "file": "pdfs/issue9285.pdf",
+       "md5": "aa53ad98a72fd76c414101927951448b",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue8707",
        "file": "pdfs/issue8707.pdf",
        "md5": "d3dc670adde9ec9fb82c974027033029",


### PR DESCRIPTION
Since (array) ColourSpaces often aren't simply accessed via References alone, we need to check their actual content to be able to keep track of already parsed ones in `ColorSpace.parseToIR`.

Given the fairly varied data structures that can occur in different types of ColourSpaces, the only simple way that I could come up with was to utilize `MurmurHash3_64` to compute a hash of each ColourSpace.
Obviously doing this isn't free, but since `MurmurHash3_64` is fairly efficient the performance impact should be small. I temporarily added `console.time/timeEnd` around the code doing the hash computations and cache checks, and manually tested a few PDF files. On average, it seems that this patch incurs an additional run-time cost of `< 0.5 milli-seconds`, which does seem acceptable at least to me.

Fixes #9285.

---

*Edit:* Supersedes PR #9299.