### PR TITLE
Implement unit tests for the encodings and fix missing items

### DIFF
--- a/src/core/encodings.js
+++ b/src/core/encodings.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-var ExpertEncoding = [
+const ExpertEncoding = [
   '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
   '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
   'space', 'exclamsmall', 'Hungarumlautsmall', '', 'dollaroldstyle',
@@ -56,7 +56,7 @@ var ExpertEncoding = [
   'Ucircumflexsmall', 'Udieresissmall', 'Yacutesmall', 'Thornsmall',
   'Ydieresissmall'];
 
-var MacExpertEncoding = [
+const MacExpertEncoding = [
   '', '', '', '', '', '', '', '', '', '', '', '', '', '',
   '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
   'space', 'exclamsmall', 'Hungarumlautsmall', 'centoldstyle',
@@ -86,7 +86,7 @@ var MacExpertEncoding = [
   'eightinferior', 'seveninferior', 'Scaronsmall', '', 'centinferior',
   'twoinferior', '', 'Dieresissmall', '', 'Caronsmall', 'osuperior',
   'fiveinferior', '', 'commainferior', 'periodinferior', 'Yacutesmall', '',
-  'dollarinferior', '', 'Thornsmall', '', 'nineinferior', 'zeroinferior',
+  'dollarinferior', '', '', 'Thornsmall', '', 'nineinferior', 'zeroinferior',
   'Zcaronsmall', 'AEsmall', 'Oslashsmall', 'questiondownsmall',
   'oneinferior', 'Lslashsmall', '', '', '', '', '', '', 'Cedillasmall', '',
   '', '', '', '', 'OEsmall', 'figuredash', 'hyphensuperior', '', '', '', '',
@@ -96,9 +96,9 @@ var MacExpertEncoding = [
   'rsuperior', 'tsuperior', '', '', 'isuperior', 'ssuperior', 'dsuperior',
   '', '', '', '', '', 'lsuperior', 'Ogoneksmall', 'Brevesmall',
   'Macronsmall', 'bsuperior', 'nsuperior', 'msuperior', 'commasuperior',
-  'periodsuperior', 'Dotaccentsmall', 'Ringsmall'];
+  'periodsuperior', 'Dotaccentsmall', 'Ringsmall', '', '', '', ''];
 
-var MacRomanEncoding = [
+const MacRomanEncoding = [
   '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
   '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
   'space', 'exclam', 'quotedbl', 'numbersign', 'dollar', 'percent',
@@ -134,7 +134,7 @@ var MacRomanEncoding = [
   'tilde', 'macron', 'breve', 'dotaccent', 'ring', 'cedilla', 'hungarumlaut',
   'ogonek', 'caron'];
 
-var StandardEncoding = [
+const StandardEncoding = [
   '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
   '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
   'space', 'exclam', 'quotedbl', 'numbersign', 'dollar', 'percent',
@@ -159,9 +159,10 @@ var StandardEncoding = [
   '', 'hungarumlaut', 'ogonek', 'caron', 'emdash', '', '', '', '', '', '',
   '', '', '', '', '', '', '', '', '', '', 'AE', '', 'ordfeminine', '', '',
   '', '', 'Lslash', 'Oslash', 'OE', 'ordmasculine', '', '', '', '', '', 'ae',
-  '', '', '', 'dotlessi', '', '', 'lslash', 'oslash', 'oe', 'germandbls'];
+  '', '', '', 'dotlessi', '', '', 'lslash', 'oslash', 'oe', 'germandbls', '',
+  '', '', ''];
 
-var WinAnsiEncoding = [
+const WinAnsiEncoding = [
   '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
   '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
   'space', 'exclam', 'quotedbl', 'numbersign', 'dollar', 'percent',
@@ -197,7 +198,7 @@ var WinAnsiEncoding = [
   'ugrave', 'uacute', 'ucircumflex', 'udieresis', 'yacute', 'thorn',
   'ydieresis'];
 
-var SymbolSetEncoding = [
+const SymbolSetEncoding = [
   '', '', '', '', '', '', '', '', '', '', '', '', '', '',
   '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
   'space', 'exclam', 'universal', 'numbersign', 'existential', 'percent',
@@ -233,9 +234,9 @@ var SymbolSetEncoding = [
   '', 'angleright', 'integral', 'integraltp', 'integralex', 'integralbt',
   'parenrighttp', 'parenrightex', 'parenrightbt', 'bracketrighttp',
   'bracketrightex', 'bracketrightbt', 'bracerighttp', 'bracerightmid',
-  'bracerightbt'];
+  'bracerightbt', ''];
 
-var ZapfDingbatsEncoding = [
+const ZapfDingbatsEncoding = [
   '', '', '', '', '', '', '', '', '', '', '', '', '', '',
   '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
   'space', 'a1', 'a2', 'a202', 'a3', 'a4', 'a5', 'a119', 'a118', 'a117',
@@ -259,7 +260,7 @@ var ZapfDingbatsEncoding = [
   'a192', 'a166', 'a167', 'a168', 'a169', 'a170', 'a171', 'a172', 'a173',
   'a162', 'a174', 'a175', 'a176', 'a177', 'a178', 'a179', 'a193', 'a180',
   'a199', 'a181', 'a200', 'a182', '', 'a201', 'a183', 'a184', 'a197', 'a185',
-  'a194', 'a198', 'a186', 'a195', 'a187', 'a188', 'a189', 'a190', 'a191'];
+  'a194', 'a198', 'a186', 'a195', 'a187', 'a188', 'a189', 'a190', 'a191', ''];
 
 function getEncoding(encodingName) {
   switch (encodingName) {

--- a/test/unit/clitests.json
+++ b/test/unit/clitests.json
@@ -11,6 +11,7 @@
     "display_svg_spec.js",
     "document_spec.js",
     "dom_utils_spec.js",
+    "encodings_spec.js",
     "evaluator_spec.js",
     "fonts_spec.js",
     "function_spec.js",

--- a/test/unit/encodings_spec.js
+++ b/test/unit/encodings_spec.js
@@ -1,0 +1,42 @@
+/* Copyright 2017 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getEncoding } from '../../src/core/encodings';
+
+describe('encodings', function() {
+  describe('getEncoding', function() {
+    it('fetches a valid array for known encoding names', function() {
+      const knownEncodingNames = [
+        'ExpertEncoding', 'MacExpertEncoding', 'MacRomanEncoding',
+        'StandardEncoding', 'SymbolSetEncoding', 'WinAnsiEncoding',
+        'ZapfDingbatsEncoding',
+      ];
+
+      for (const knownEncodingName of knownEncodingNames) {
+        const encoding = getEncoding(knownEncodingName);
+        expect(Array.isArray(encoding)).toEqual(true);
+        expect(encoding.length).toEqual(256);
+
+        for (const item of encoding) {
+          expect(typeof item).toEqual('string');
+        }
+      }
+    });
+
+    it('fetches `null` for unknown encoding names', function() {
+      expect(getEncoding('FooBarEncoding')).toEqual(null);
+    });
+  });
+});

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -57,6 +57,7 @@ function initializePDFJS(callback) {
     'pdfjs-test/unit/display_svg_spec',
     'pdfjs-test/unit/document_spec',
     'pdfjs-test/unit/dom_utils_spec',
+    'pdfjs-test/unit/encodings_spec',
     'pdfjs-test/unit/evaluator_spec',
     'pdfjs-test/unit/fonts_spec',
     'pdfjs-test/unit/function_spec',


### PR DESCRIPTION
Initially I just implemented the unit tests, but quickly found that they were failing my expectation of having a size of 256 items. Some of them did contain 256 items and some did not. I looked up various resources and figured that they indeed all need to have 256 items. One of the good
resources is https://github.com/davidben/poppler/blob/master/poppler/FontEncodingTables.cc

Aside from some missing `notdef` (empty string) entries at the end of the arrays, which I assume causes issues since it may cause out-of-bounds array access which in JavaScript gives `undefined`, there was a `notdef` entry missing in the `MacExpertEncoding`, causing the entries after that to be shifted. This fix for this is similar to the one in #8589.

The unit tests verify that, for known encoding names, the return value is not only an array, but that it is also of the right length and contains only strings.