### PR TITLE
Avoid rendering errors by passing in the `webGLContext` when creating a new `CanvasGraphics` in `getColorN_Pattern` (PR 9095 follow-up)

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1665,7 +1665,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         var canvasGraphicsFactory = {
           createCanvasGraphics: (ctx) => {
             return new CanvasGraphics(ctx, this.commonObjs, this.objs,
-                                      this.canvasFactory);
+                                      this.canvasFactory, this.webGLContext);
           },
         };
         pattern = new TilingPattern(IR, color, this.ctx, canvasGraphicsFactory,

--- a/test/pdfs/issue6737.pdf.link
+++ b/test/pdfs/issue6737.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/55597/Florida.Industrial.MarketView.Q3.2015.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -602,6 +602,14 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue6737",
+       "file": "pdfs/issue6737.pdf",
+       "md5": "6f091967ad15ba63855c56049e86c68b",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue5010",
        "file": "pdfs/issue5010.pdf",
        "md5": "419f4b13403a0871c463ec69d96e342c",


### PR DESCRIPTION
This was an oversight in PR #9095, which unfortunately breaks rendering in some PDF files (e.g. the one from issue #6737).

It thus appears that we don't have any test-coverage for this code-path, and given the relative complexity of the PDF files affected by this bug I wasn't able to easily create a reduced test-case.
*Please note:* The linked test-case included in this patch is currently *not* rendered correctly (that'd be the PR #6606), but it at least gives us some test-coverage here.