### PR TITLE
Remove the `background` compatibility hacks for `linkAnnotation` in old versions of IE

### DIFF
--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -27,14 +27,6 @@
   height: 100%;
 }
 
-.annotationLayer .linkAnnotation > a /* -ms-a */ {
-  background: url("data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7") 0 0 repeat;
-}
-
-.annotationLayer .buttonWidgetAnnotation.pushButton > a /* -ms-a */ {
-  background: url("data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7") 0 0 repeat;
-}
-
 .annotationLayer .linkAnnotation > a:hover,
 .annotationLayer .buttonWidgetAnnotation.pushButton > a:hover {
   opacity: 0.2;


### PR DESCRIPTION
With PDF.js version `2.0` we'll no longer support IE 9 and 10, hence these hacks can now be removed.