### PR TITLE
Avoid truncating JPEG images with DeviceGray ColourSpaces when using the `src/core/jpg.js` built-in decoder

### DIFF
--- a/src/core/image.js
+++ b/src/core/image.js
@@ -546,14 +546,21 @@ var PDFImage = (function PDFImageClosure() {
           }
           return imgData;
         }
-        if (this.image instanceof JpegStream && !this.smask && !this.mask &&
-            (this.colorSpace.name === 'DeviceGray' ||
-             this.colorSpace.name === 'DeviceRGB' ||
-             this.colorSpace.name === 'DeviceCMYK')) {
-          imgData.kind = ImageKind.RGB_24BPP;
-          imgData.data = this.getImageBytes(originalHeight * rowBytes,
-                                            drawWidth, drawHeight, true);
-          return imgData;
+        if (this.image instanceof JpegStream && !this.smask && !this.mask) {
+          let imageLength = originalHeight * rowBytes;
+          switch (this.colorSpace.name) {
+            case 'DeviceGray':
+              // Avoid truncating the image, since `JpegImage.getData`
+              // will expand the image data when `forceRGB === true`.
+              imageLength *= 3;
+              /* falls through */
+            case 'DeviceRGB':
+            case 'DeviceCMYK':
+              imgData.kind = ImageKind.RGB_24BPP;
+              imgData.data = this.getImageBytes(imageLength,
+                drawWidth, drawHeight, /* forceRGB = */ true);
+              return imgData;
+          }
         }
       }
 

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1318,7 +1318,8 @@
        "link": true,
        "firstPage": 2,
        "lastPage": 2,
-       "type": "eq"
+       "type": "eq",
+       "nativeImageDecoderSupport": "none"
     },
     {  "id": "issue6071",
        "file": "pdfs/issue6071.pdf",


### PR DESCRIPTION
The bug that this patch fixes is limited to the built-in JPEG decoder, and was unearthed by PR #9260. The underlying issue has existed since PR #6984, where the contents of this patch ought to have been included (if it weren't for the fact that we had no *easy* way to test `src/core/jpg.js` back then).

*Please note:* The slight movement in the reference test is a result of using the `src/core/jpg.js` decoder, rather than the native browser one.