### PR TITLE
Restore the `btoa`/`atob` polyfills for Node.js

### DIFF
--- a/examples/node/domstubs.js
+++ b/examples/node/domstubs.js
@@ -197,10 +197,6 @@ DOMElementSerializer.prototype = {
   },
 };
 
-function btoa (chars) {
-  return Buffer.from(chars, 'binary').toString('base64');
-}
-
 const document = {
   childNodes : [],
 
@@ -245,7 +241,6 @@ Image.prototype = {
   }
 }
 
-exports.btoa = btoa;
 exports.document = document;
 exports.Image = Image;
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1015,10 +1015,17 @@ gulp.task('lib', ['buildnumber'], function () {
   var licenseHeaderLibre =
     fs.readFileSync('./src/license_header_libre.js').toString();
   var preprocessor2 = require('./external/builder/preprocessor2.js');
+  var sharedFiles = [
+    'compatibility',
+    'global_scope',
+    'is_node',
+    'streams_polyfill',
+    'util',
+  ];
   var buildLib = merge([
     gulp.src([
       'src/{core,display}/*.js',
-      'src/shared/{compatibility,util,streams_polyfill,global_scope}.js',
+      'src/shared/{' + sharedFiles.join() + '}.js',
       'src/{pdf,pdf.worker}.js',
     ], { base: 'src/', }),
     gulp.src([

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -15,11 +15,12 @@
 
 import {
   arrayByteLength, arraysToBytes, assert, createPromiseCapability, info,
-  InvalidPDFException, isNodeJS, MessageHandler, MissingPDFException,
-  PasswordException, setVerbosityLevel, UnexpectedResponseException,
-  UnknownErrorException, UNSUPPORTED_FEATURES, warn, XRefParseException
+  InvalidPDFException, MessageHandler, MissingPDFException, PasswordException,
+  setVerbosityLevel, UnexpectedResponseException, UnknownErrorException,
+  UNSUPPORTED_FEATURES, warn, XRefParseException
 } from '../shared/util';
 import { LocalPdfManager, NetworkPdfManager } from './pdf_manager';
+import isNodeJS from '../shared/is_node';
 import { Ref } from './primitives';
 
 var WorkerTask = (function WorkerTaskClosure() {

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -15,10 +15,11 @@
 /* globals __non_webpack_require__ */
 
 import {
-  createObjectURL, FONT_IDENTITY_MATRIX, IDENTITY_MATRIX, ImageKind, isNodeJS,
-  isNum, OPS, Util, warn
+  createObjectURL, FONT_IDENTITY_MATRIX, IDENTITY_MATRIX, ImageKind, isNum, OPS,
+  Util, warn
 } from '../shared/util';
 import { DOMSVGFactory } from './dom_utils';
+import isNodeJS from '../shared/is_node';
 
 var SVGGraphics = function() {
   throw new Error('Not implemented: SVGGraphics');

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -31,7 +31,8 @@ var pdfjsDisplaySVG = require('./display/svg.js');
 
 if (typeof PDFJSDev === 'undefined' ||
     !PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
-  if (pdfjsSharedUtil.isNodeJS()) {
+  const isNodeJS = require('./shared/is_node.js');
+  if (isNodeJS()) {
     var PDFNodeStream = require('./display/node_stream.js').PDFNodeStream;
     pdfjsDisplayAPI.setPDFNetworkStreamClass(PDFNodeStream);
   } else if (typeof Response !== 'undefined' && 'body' in Response.prototype &&

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -22,6 +22,7 @@ if ((typeof PDFJSDev === 'undefined' ||
     (typeof PDFJS === 'undefined' || !PDFJS.compatibilityChecked)) {
 
 var globalScope = require('./global_scope');
+const isNodeJS = require('./is_node');
 
 var userAgent = (typeof navigator !== 'undefined' && navigator.userAgent) || '';
 var isAndroid = /Android/.test(userAgent);
@@ -40,6 +41,28 @@ if (typeof PDFJS === 'undefined') {
 }
 
 PDFJS.compatibilityChecked = true;
+
+// Support: Node.js
+(function checkNodeBtoa() {
+  if (globalScope.btoa || !isNodeJS()) {
+    return;
+  }
+  globalScope.btoa = function(chars) {
+    // eslint-disable-next-line no-undef
+    return Buffer.from(chars, 'binary').toString('base64');
+  };
+})();
+
+// Support: Node.js
+(function checkNodeAtob() {
+  if (globalScope.atob || !isNodeJS()) {
+    return;
+  }
+  globalScope.atob = function(input) {
+    // eslint-disable-next-line no-undef
+    return Buffer.from(input, 'base64').toString('binary');
+  };
+})();
 
 // Checks if possible to use URL.createObjectURL()
 // Support: IE, Chrome on iOS

--- a/src/shared/is_node.js
+++ b/src/shared/is_node.js
@@ -1,0 +1,19 @@
+/* Copyright 2018 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* globals module, process */
+
+module.exports = function isNodeJS() {
+  return typeof process === 'object' && process + '' === '[object process]';
+};

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1089,11 +1089,6 @@ function isSpace(ch) {
   return (ch === 0x20 || ch === 0x09 || ch === 0x0D || ch === 0x0A);
 }
 
-function isNodeJS() {
-  // eslint-disable-next-line no-undef
-  return typeof process === 'object' && process + '' === '[object process]';
-}
-
 /**
  * Promise Capability object.
  *
@@ -1633,7 +1628,6 @@ export {
   isNum,
   isString,
   isSpace,
-  isNodeJS,
   isSameOrigin,
   createValidAbsoluteUrl,
   isLittleEndian,

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -17,9 +17,8 @@ import {
   buildGetDocumentParams, NodeFileReaderFactory, TEST_PDFS_PATH
 } from './test_utils';
 import {
-  createPromiseCapability, FontType, InvalidPDFException, isNodeJS,
-  MissingPDFException, PasswordException, PasswordResponses, StreamType,
-  stringToBytes
+  createPromiseCapability, FontType, InvalidPDFException, MissingPDFException,
+  PasswordException, PasswordResponses, StreamType, stringToBytes
 } from '../../src/shared/util';
 import {
   DOMCanvasFactory, RenderingCancelledException
@@ -27,6 +26,7 @@ import {
 import {
   getDocument, PDFDocumentProxy, PDFPageProxy
 } from '../../src/display/api';
+import isNodeJS from '../../src/shared/is_node';
 import { PDFJS } from '../../src/display/global';
 
 describe('api', function() {

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -15,7 +15,7 @@
 
 import { CMap, CMapFactory, IdentityCMap } from '../../src/core/cmap';
 import { DOMCMapReaderFactory } from '../../src/display/dom_utils';
-import { isNodeJS } from '../../src/shared/util';
+import isNodeJS from '../../src/shared/is_node';
 import { Name } from '../../src/core/primitives';
 import { NodeCMapReaderFactory } from './test_utils';
 import { StringStream } from '../../src/core/stream';

--- a/test/unit/custom_spec.js
+++ b/test/unit/custom_spec.js
@@ -16,7 +16,7 @@
 import { buildGetDocumentParams } from './test_utils';
 import { DOMCanvasFactory } from '../../src/display/dom_utils';
 import { getDocument } from '../../src/display/api';
-import { isNodeJS } from '../../src/shared/util';
+import isNodeJS from '../../src/shared/is_node';
 
 function getTopLeftPixel(canvasContext) {
   let imgData = canvasContext.getImageData(0, 0, 1, 1);

--- a/test/unit/display_svg_spec.js
+++ b/test/unit/display_svg_spec.js
@@ -14,10 +14,11 @@
  */
 /* globals __non_webpack_require__ */
 
-import { isNodeJS, NativeImageDecoding } from '../../src/shared/util';
 import { setStubs, unsetStubs } from '../../examples/node/domstubs';
 import { buildGetDocumentParams } from './test_utils';
 import { getDocument } from '../../src/display/api';
+import isNodeJS from '../../src/shared/is_node';
+import { NativeImageDecoding } from '../../src/shared/util';
 import { SVGGraphics } from '../../src/display/svg';
 
 const XLINK_NS = 'http://www.w3.org/1999/xlink';

--- a/test/unit/dom_utils_spec.js
+++ b/test/unit/dom_utils_spec.js
@@ -16,7 +16,7 @@
 import {
   DOMSVGFactory, getFilenameFromUrl, isExternalLinkTargetSet, LinkTarget
 } from '../../src/display/dom_utils';
-import { isNodeJS } from '../../src/shared/util';
+import isNodeJS from '../../src/shared/is_node';
 import { PDFJS } from '../../src/display/global';
 
 describe('dom_utils', function() {

--- a/test/unit/node_stream_spec.js
+++ b/test/unit/node_stream_spec.js
@@ -14,7 +14,8 @@
  */
 /* globals __non_webpack_require__ */
 
-import { assert, isNodeJS } from '../../src/shared/util';
+import { assert } from '../../src/shared/util';
+import isNodeJS from '../../src/shared/is_node';
 import { PDFNodeStream } from '../../src/display/node_stream';
 
 // Make sure that we only running this script is Node.js environments.

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -13,7 +13,8 @@
  * limitations under the License.
  */
 
-import { CMapCompressionType, isNodeJS } from '../../src/shared/util';
+import { CMapCompressionType } from '../../src/shared/util';
+import isNodeJS from '../../src/shared/is_node';
 import { isRef } from '../../src/core/primitives';
 
 class NodeFileReaderFactory {

--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -17,7 +17,8 @@ import {
   binarySearchFirstItem, EventBus, getPDFFileNameFromURL, isValidRotation,
   waitOnEventOrTimeout, WaitOnType
 } from '../../web/ui_utils';
-import { createObjectURL, isNodeJS } from '../../src/shared/util';
+import { createObjectURL } from '../../src/shared/util';
+import isNodeJS from '../../src/shared/is_node';
 
 describe('ui_utils', function() {
   describe('binary search', function() {


### PR DESCRIPTION
These were removed in PR #9170, since they were unused in the browsers that we'll support in PDF.js version `2.0`.
However looking at the output of Travis, where a subset of the unit-tests are run using Node.js, there's warnings about `btoa` being undefined. This doesn't appear to cause any errors, which probably explains why we didn't notice this before (despite PR #9201).

*Edit:* See e.g. the previous Travis run https://travis-ci.org/mozilla/pdf.js/builds/325585865#L600