### PR TITLE
Download button is now hidden for PDFs which are loaded from 'file://'

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -15,9 +15,10 @@
 /* globals PDFBug, Stats */
 
 import {
-  animationStarted, DEFAULT_SCALE_VALUE, getPDFFileNameFromURL, isValidRotation,
-  MAX_SCALE, MIN_SCALE, noContextMenuHandler, normalizeWheelEventDelta,
-  parseQueryString, PresentationModeState, ProgressBar, RendererType
+  animationStarted, DEFAULT_SCALE_VALUE, getPDFFileNameFromURL, isFileSchema,
+  isValidRotation, MAX_SCALE, MIN_SCALE, noContextMenuHandler,
+  normalizeWheelEventDelta, parseQueryString, PresentationModeState,
+  ProgressBar, RendererType
 } from './ui_utils';
 import {
   build, createBlob, getDocument, getFilenameFromUrl, InvalidPDFException,
@@ -675,6 +676,8 @@ let PDFViewerApplication = {
     this.store = null;
     this.isInitialViewSet = false;
     this.downloadComplete = false;
+    this.url = '';
+    this.baseUrl = '';
 
     this.pdfSidebar.reset();
     this.pdfOutlineViewer.reset();
@@ -735,6 +738,12 @@ let PDFViewerApplication = {
         }
         parameters[prop] = args[prop];
       }
+    }
+
+    if (this.url && isFileSchema(this.url)) {
+      let appConfig = this.appConfig;
+      appConfig.toolbar.download.setAttribute('hidden', 'true');
+      appConfig.secondaryToolbar.downloadButton.setAttribute('hidden', 'true');
     }
 
     let loadingTask = getDocument(parameters);

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -381,6 +381,14 @@ function noContextMenuHandler(evt) {
   evt.preventDefault();
 }
 
+function isFileSchema(url) {
+  let i = 0, ii = url.length;
+  while (i < ii && url[i].trim() === '') {
+    i++;
+  }
+  return url.substr(i, 7).toLowerCase() === 'file://';
+}
+
 function isDataSchema(url) {
   let i = 0, ii = url.length;
   while (i < ii && url[i].trim() === '') {
@@ -665,6 +673,7 @@ export {
   SCROLLBAR_PADDING,
   VERTICAL_PADDING,
   isValidRotation,
+  isFileSchema,
   cloneObj,
   PresentationModeState,
   RendererType,


### PR DESCRIPTION
fixes : #9342 

@timvandermeij , I have tried to solve this but I'm not sure if this is the best possible solution. I used `gulp firefox` to build a firefox extension. I can see my changes in the `build/firefox/content/web/viewer.js` but I tried a lot to also install this extension into my firefox browser using `pdf.js.xpi` file but it doesn't get installed as it is not compatible with the newer edition. Can you suggest me how to check this.