### PR TITLE
Implement `closeEOFillStroke` in SVG backend

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -642,6 +642,9 @@ SVGGraphics = (function SVGGraphicsClosure() {
           case OPS.closeFillStroke:
             this.closeFillStroke();
             break;
+          case OPS.closeEOFillStroke:
+            this.closeEOFillStroke();
+            break;
           case OPS.nextLine:
             this.nextLine();
             break;
@@ -1118,6 +1121,11 @@ SVGGraphics = (function SVGGraphicsClosure() {
     closeFillStroke: function SVGGraphics_closeFillStroke() {
       this.closePath();
       this.fillStroke();
+    },
+
+    closeEOFillStroke() {
+      this.closePath();
+      this.eoFillStroke();
     },
 
     paintSolidColorImageMask:


### PR DESCRIPTION
That's the PDF operator `b*`.

Here's a reduced PDF:
[path_painting_ops.pdf](https://github.com/mozilla/pdf.js/files/1616137/path_painting_ops.pdf)
