### PR TITLE
Two small `PDFHistory` fixes, concerning the `this._maxUid` property and the 'pagehide' event

### DIFF
--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -133,6 +133,9 @@ class PDFHistory {
     let destination = state.destination;
     this._updateInternalState(destination, state.uid,
                               /* removeTemporary = */ true);
+    if (this._uid > this._maxUid) {
+      this._maxUid = this._uid;
+    }
 
     if (destination.rotation !== undefined) {
       this.initialRotation = destination.rotation;
@@ -510,6 +513,9 @@ class PDFHistory {
     let destination = state.destination;
     this._updateInternalState(destination, state.uid,
                               /* removeTemporary = */ true);
+    if (this._uid > this._maxUid) {
+      this._maxUid = this._uid;
+    }
 
     if (isValidRotation(destination.rotation)) {
       this.linkService.rotation = destination.rotation;

--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -547,10 +547,10 @@ class PDFHistory {
     _boundEvents.pageHide = (evt) => {
       // Attempt to push the `this._position` into the browser history when
       // navigating away from the document. This is *only* done if the history
-      // is currently empty, since otherwise an existing browser history entry
+      // is empty/temporary, since otherwise an existing browser history entry
       // will end up being overwritten (given that new entries cannot be pushed
       // into the browser history when the 'unload' event has already fired).
-      if (!this._destination) {
+      if (!this._destination || this._destination.temporary) {
         this._tryPushCurrentPosition();
       }
     };


### PR DESCRIPTION
 - Ensure that the `PDFHistory._maxUid` property is correctly updated when initializing/navigating the history
   
   This is a follow-up to commit e772124, in PR #8994, to cover a couple of cases missed there.

 - Allow overwriting temporary, in addition to empty, history entries on 'pagehide'

   When navigating away from the viewer, there's no good reason for disallowing replacement of a *temporary* history entry (in addition to empty ones).
   
   Given that the current position is temporarily added to the browser history using a (short) timeout, the history entry will most likely already be correct when the 'pagehide' event fires. However, if the user is quick enough that might not always be the case, in which case the adjusted logic may help.