### PR TITLE
Limit PDFFetchStream to http(s) in the Chrome extension

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -83,15 +83,25 @@ if (typeof PDFJSDev !== 'undefined' &&
   }) : null;
 }
 
-/** @type IPDFStream */
-var PDFNetworkStream;
+/**
+ * @typedef {function} IPDFStreamFactory
+ * @param {DocumentInitParameters} params The document initialization
+ * parameters. The "url" key is always present.
+ * @return {IPDFStream}
+ */
+
+/** @type IPDFStreamFactory */
+var createPDFNetworkStream;
 
 /**
- * Sets PDFNetworkStream class to be used as alternative PDF data transport.
- * @param {IPDFStream} cls - the PDF data transport.
+ * Sets the function that instantiates a IPDFStream as an alternative PDF data
+ * transport.
+ * @param {IPDFStreamFactory} pdfNetworkStreamFactory - the factory function
+ * that takes document initialization parameters (including a "url") and returns
+ * an instance of IPDFStream.
  */
-function setPDFNetworkStreamClass(cls) {
-  PDFNetworkStream = cls;
+function setPDFNetworkStreamFactory(pdfNetworkStreamFactory) {
+  createPDFNetworkStream = pdfNetworkStreamFactory;
 }
 
 /**
@@ -252,7 +262,7 @@ function getDocument(src) {
       if (rangeTransport) {
         networkStream = new PDFDataTransportStream(params, rangeTransport);
       } else if (!params.data) {
-        networkStream = new PDFNetworkStream(params);
+        networkStream = createPDFNetworkStream(params);
       }
 
       var messageHandler = new MessageHandler(docId, workerId, worker.port);
@@ -2344,7 +2354,7 @@ export {
   PDFWorker,
   PDFDocumentProxy,
   PDFPageProxy,
-  setPDFNetworkStreamClass,
+  setPDFNetworkStreamFactory,
   version,
   build,
 };

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -85,9 +85,13 @@ function initializePDFJS(callback) {
     // Set network stream class for unit tests.
     if (typeof Response !== 'undefined' && 'body' in Response.prototype &&
         typeof ReadableStream !== 'undefined') {
-      displayApi.setPDFNetworkStreamClass(PDFFetchStream);
+      displayApi.setPDFNetworkStreamFactory(function(params) {
+        return new PDFFetchStream(params);
+      });
     } else {
-      displayApi.setPDFNetworkStreamClass(PDFNetworkStream);
+      displayApi.setPDFNetworkStreamFactory(function(params) {
+        return new PDFNetworkStream(params);
+      });
     }
 
     // Configure the worker.


### PR DESCRIPTION
The `fetch` API is only supported for http(s), even in Chrome extensions. Because of this limitation, we should use the `XMLHttpRequest` API when the requested URL is not a http(s) URL.

Fixes #9361