### PR TITLE
changed decodeURI to decodeURIComponent: Fixes #8987

### DIFF
--- a/src/display/node_stream.js
+++ b/src/display/node_stream.js
@@ -365,7 +365,7 @@ class PDFNodeStreamFsFullReader extends BaseFullReader {
   constructor(stream) {
     super(stream);
 
-    let path = decodeURI(this._url.path);
+    let path = decodeURIComponent(this._url.path);
 
     // Remove the extra slash to get right path from url like `file:///C:/`
     if (fileUriRegex.test(this._url.href)) {
@@ -392,7 +392,7 @@ class PDFNodeStreamFsRangeReader extends BaseRangeReader {
   constructor(stream, start, end) {
     super(stream);
 
-    let path = decodeURI(this._url.path);
+    let path = decodeURIComponent(this._url.path);
 
     // Remove the extra slash to get right path from url like `file:///C:/`
     if (fileUriRegex.test(this._url.href)) {


### PR DESCRIPTION
pdf.js node extension now opens file containing the character `#` in the file name or the path of the file.

Read the following snippet from [here](https://stackoverflow.com/questions/747641/what-is-the-difference-between-decodeuricomponent-and-decodeuri) 
```
The main difference between `decodeURI` and `decodeURIComponent` is that:
     -decodeURI is intended for use on the full URI.
     -decodeURIComponent is intended to be used on URI components, that is, any part that lies between separators (; / ? : @ & = + $ , #).
So, in decodeURIComponent these separators are decoded also because they are regarded as text and not special characters.
 ```
Solves #8987 

Thank you @mukulmishra18 for your help.

Please review.