### PR TITLE
[api-major] Remove the `SINGLE_FILE` build target and the `PDFJS.disableWorker` option

### DIFF
--- a/examples/browserify/main.js
+++ b/examples/browserify/main.js
@@ -10,9 +10,6 @@ var pdfPath = '../helloworld/helloworld.pdf';
 // Setting worker path to worker bundle.
 PDFJS.workerSrc = '../../build/browserify/pdf.worker.bundle.js';
 
-// It is also possible to disable workers via `PDFJS.disableWorker = true`,
-// however that might degrade the UI performance in web browsers.
-
 // Loading a document.
 var loadingTask = PDFJS.getDocument(pdfPath);
 loadingTask.promise.then(function (pdfDocument) {

--- a/examples/learning/helloworld.html
+++ b/examples/learning/helloworld.html
@@ -20,13 +20,6 @@
   var url = './helloworld.pdf';
 
   //
-  // Disable workers to avoid yet another cross-origin issue (workers need
-  // the URL of the script to be loaded, and dynamically loading a cross-origin
-  // script does not work).
-  //
-  // PDFJS.disableWorker = true;
-
-  //
   // The workerSrc property shall be specified.
   //
   PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';

--- a/examples/learning/helloworld64.html
+++ b/examples/learning/helloworld64.html
@@ -31,12 +31,6 @@
     'MDAwIG4gCjAwMDAwMDAzODAgMDAwMDAgbiAKdHJhaWxlcgo8PAogIC9TaXplIDYKICAvUm9v' +
     'dCAxIDAgUgo+PgpzdGFydHhyZWYKNDkyCiUlRU9G');
 
-  // Disable workers to avoid yet another cross-origin issue (workers need
-  // the URL of the script to be loaded, and dynamically loading a cross-origin
-  // script does not work).
-  //
-  // PDFJS.disableWorker = true;
-
   //
   // The workerSrc property shall be specified.
   //

--- a/examples/learning/prevnext.html
+++ b/examples/learning/prevnext.html
@@ -28,14 +28,6 @@
   //
   var url = '../../web/compressed.tracemonkey-pldi-09.pdf';
 
-
-  //
-  // Disable workers to avoid yet another cross-origin issue (workers need
-  // the URL of the script to be loaded, and dynamically loading a cross-origin
-  // script does not work).
-  //
-  // PDFJS.disableWorker = true;
-
   //
   // In cases when the pdf.worker.js is located at the different folder than the
   // pdf.js's one, or the pdf.js is executed via eval(), the workerSrc property

--- a/examples/webpack/main.js
+++ b/examples/webpack/main.js
@@ -10,9 +10,6 @@ var pdfPath = '../helloworld/helloworld.pdf';
 // Setting worker path to worker bundle.
 pdfjsLib.PDFJS.workerSrc = '../../build/webpack/pdf.worker.bundle.js';
 
-// It is also possible to disable workers via `PDFJS.disableWorker = true`,
-// however that might degrade the UI performance in web browsers.
-
 // Loading a document.
 var loadingTask = pdfjsLib.getDocument(pdfPath);
 loadingTask.promise.then(function (pdfDocument) {

--- a/external/dist/webpack.js
+++ b/external/dist/webpack.js
@@ -19,8 +19,6 @@ var PdfjsWorker = require('worker-loader!./build/pdf.worker.js');
 
 if (typeof window !== 'undefined' && 'Worker' in window) {
   pdfjs.PDFJS.workerPort = new PdfjsWorker();
-} else {
-  pdfjs.PDFJS.disableWorker = true;
 }
 
 module.exports = pdfjs;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,7 +48,6 @@ var BASELINE_DIR = BUILD_DIR + 'baseline/';
 var MOZCENTRAL_BASELINE_DIR = BUILD_DIR + 'mozcentral.baseline/';
 var GENERIC_DIR = BUILD_DIR + 'generic/';
 var COMPONENTS_DIR = BUILD_DIR + 'components/';
-var SINGLE_FILE_DIR = BUILD_DIR + 'singlefile/';
 var MINIFIED_DIR = BUILD_DIR + 'minified/';
 var FIREFOX_BUILD_DIR = BUILD_DIR + 'firefox/';
 var CHROME_BUILD_DIR = BUILD_DIR + 'chromium/';
@@ -79,7 +78,6 @@ var DEFINES = {
   MOZCENTRAL: false,
   CHROME: false,
   MINIFIED: false,
-  SINGLE_FILE: false,
   COMPONENTS: false,
   LIB: false,
   SKIP_BABEL: false,
@@ -235,10 +233,6 @@ function createBundle(defines) {
 
   var mainAMDName = 'pdfjs-dist/build/pdf';
   var mainOutputName = 'pdf.js';
-  if (defines.SINGLE_FILE) {
-    mainAMDName = 'pdfjs-dist/build/pdf.combined';
-    mainOutputName = 'pdf.combined.js';
-  }
 
   var mainFileConfig = createWebpackConfig(defines, {
     filename: mainOutputName,
@@ -250,9 +244,6 @@ function createBundle(defines) {
     .pipe(webpack2Stream(mainFileConfig))
     .pipe(replaceWebpackRequire())
     .pipe(replaceJSRootName(mainAMDName));
-  if (defines.SINGLE_FILE) {
-    return mainOutput; // don't need a worker file.
-  }
 
   var workerAMDName = 'pdfjs-dist/build/pdf.worker';
   var workerOutputName = 'pdf.worker.js';
@@ -632,18 +623,6 @@ gulp.task('components', ['buildnumber'], function () {
     preprocessCSS('web/pdf_viewer.css', 'components', defines, true)
         .pipe(gulp.dest(COMPONENTS_DIR)),
   ]);
-});
-
-gulp.task('singlefile', ['buildnumber'], function () {
-  console.log();
-  console.log('### Creating singlefile build');
-  var defines = builder.merge(DEFINES, { SINGLE_FILE: true, });
-
-  var SINGLE_FILE_BUILD_DIR = SINGLE_FILE_DIR + 'build/';
-
-  rimraf.sync(SINGLE_FILE_DIR);
-
-  return createBundle(defines).pipe(gulp.dest(SINGLE_FILE_BUILD_DIR));
 });
 
 gulp.task('minified-pre', ['buildnumber', 'locale'], function () {
@@ -1275,9 +1254,7 @@ gulp.task('gh-pages-git', ['gh-pages-prepare', 'wintersmith'], function () {
 
 gulp.task('web', ['gh-pages-prepare', 'wintersmith', 'gh-pages-git']);
 
-gulp.task('dist-pre',
-          ['generic', 'singlefile', 'components', 'lib', 'minified'],
-          function () {
+gulp.task('dist-pre', ['generic', 'components', 'lib', 'minified'], function() {
   var VERSION = getVersionJSON().version;
 
   console.log();
@@ -1359,8 +1336,6 @@ gulp.task('dist-pre',
       GENERIC_DIR + 'build/pdf.js.map',
       GENERIC_DIR + 'build/pdf.worker.js',
       GENERIC_DIR + 'build/pdf.worker.js.map',
-      SINGLE_FILE_DIR + 'build/pdf.combined.js',
-      SINGLE_FILE_DIR + 'build/pdf.combined.js.map',
       SRC_DIR + 'pdf.worker.entry.js',
     ]).pipe(gulp.dest(DIST_DIR + 'build/')),
     gulp.src(MINIFIED_DIR + 'build/pdf.js')

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1233,7 +1233,6 @@ var PDFWorker = (function PDFWorkerClosure() {
 
   // Loads worker code into main thread.
   function setupFakeWorkerGlobal() {
-    var WorkerMessageHandler;
     if (fakeWorkerFilesLoadedCapability) {
       return fakeWorkerFilesLoadedCapability.promise;
     }
@@ -1245,26 +1244,24 @@ var PDFWorker = (function PDFWorkerClosure() {
       fakeWorkerFilesLoadedCapability.resolve(mainWorkerMessageHandler);
       return fakeWorkerFilesLoadedCapability.promise;
     }
-    // In the developer build load worker_loader which in turn loads all the
+    // In the developer build load worker_loader.js which in turn loads all the
     // other files and resolves the promise. In production only the
     // pdf.worker.js file is needed.
     if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION')) {
       if (typeof SystemJS === 'object') {
         SystemJS.import('pdfjs/core/worker').then((worker) => {
-          WorkerMessageHandler = worker.WorkerMessageHandler;
-          fakeWorkerFilesLoadedCapability.resolve(WorkerMessageHandler);
+          fakeWorkerFilesLoadedCapability.resolve(worker.WorkerMessageHandler);
         });
       } else if (typeof require === 'function') {
-        var worker = require('../core/worker.js');
-        WorkerMessageHandler = worker.WorkerMessageHandler;
-        fakeWorkerFilesLoadedCapability.resolve(WorkerMessageHandler);
+        let worker = require('../core/worker.js');
+        fakeWorkerFilesLoadedCapability.resolve(worker.WorkerMessageHandler);
       } else {
         throw new Error(
           'SystemJS or CommonJS must be used to load fake worker.');
       }
     } else {
-      var loader = fakeWorkerFilesLoader || function (callback) {
-        Util.loadScript(getWorkerSrc(), function () {
+      let loader = fakeWorkerFilesLoader || function(callback) {
+        Util.loadScript(getWorkerSrc(), function() {
           callback(window.pdfjsDistBuildPdfWorker.WorkerMessageHandler);
         });
       };

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -46,8 +46,7 @@ var pdfjsFilePath =
 
 var fakeWorkerFilesLoader = null;
 var useRequireEnsure = false;
-if (typeof PDFJSDev !== 'undefined' &&
-    PDFJSDev.test('GENERIC && !SINGLE_FILE')) {
+if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('GENERIC')) {
   // For GENERIC build we need add support of different fake file loaders
   // for different  frameworks.
   if (typeof window === 'undefined') {
@@ -1243,10 +1242,6 @@ var PDFWorker = (function PDFWorkerClosure() {
         throw new Error(
           'SystemJS or CommonJS must be used to load fake worker.');
       }
-    } else if (PDFJSDev.test('SINGLE_FILE')) {
-      var pdfjsCoreWorker = require('../core/worker.js');
-      WorkerMessageHandler = pdfjsCoreWorker.WorkerMessageHandler;
-      fakeWorkerFilesLoadedCapability.resolve(WorkerMessageHandler);
     } else {
       var loader = fakeWorkerFilesLoader || function (callback) {
         Util.loadScript(getWorkerSrc(), function () {
@@ -1320,9 +1315,8 @@ var PDFWorker = (function PDFWorkerClosure() {
       // all requirements to run parts of pdf.js in a web worker.
       // Right now, the requirement is, that an Uint8Array is still an
       // Uint8Array as it arrives on the worker. (Chrome added this with v.15.)
-      if ((typeof PDFJSDev === 'undefined' || !PDFJSDev.test('SINGLE_FILE')) &&
-          !isWorkerDisabled && !getDefaultSetting('disableWorker') &&
-          typeof Worker !== 'undefined') {
+      if (typeof Worker !== 'undefined' && !isWorkerDisabled &&
+          !getDefaultSetting('disableWorker')) {
         var workerSrc = getWorkerSrc();
 
         try {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1485,6 +1485,10 @@ var PDFWorker = (function PDFWorkerClosure() {
     return new PDFWorker(null, port);
   };
 
+  PDFWorker.getWorkerSrc = function() {
+    return getWorkerSrc();
+  };
+
   return PDFWorker;
 })();
 

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -361,8 +361,6 @@ function getDefaultSetting(id) {
       return globalSettings ? globalSettings.workerPort : null;
     case 'workerSrc':
       return globalSettings ? globalSettings.workerSrc : null;
-    case 'disableWorker':
-      return globalSettings ? globalSettings.disableWorker : false;
     case 'maxImageSize':
       return globalSettings ? globalSettings.maxImageSize : -1;
     case 'imageResourcesPath':

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -129,15 +129,6 @@ PDFJS.imageResourcesPath = (PDFJS.imageResourcesPath === undefined ?
                             '' : PDFJS.imageResourcesPath);
 
 /**
- * Disable the web worker and run all code on the main thread. This will
- * happen automatically if the browser doesn't support workers or sending
- * typed arrays to workers.
- * @var {boolean}
- */
-PDFJS.disableWorker = (PDFJS.disableWorker === undefined ?
-                       false : PDFJS.disableWorker);
-
-/**
  * Path and filename of the worker file. Required when the worker is enabled
  * in development mode. If unspecified in the production build, the worker
  * will be loaded based on the location of the pdf.js file. It is recommended
@@ -148,8 +139,7 @@ PDFJS.disableWorker = (PDFJS.disableWorker === undefined ?
 PDFJS.workerSrc = (PDFJS.workerSrc === undefined ? null : PDFJS.workerSrc);
 
 /**
- * Defines global port for worker process. Overrides workerSrc and
- * disableWorker setting.
+ * Defines global port for worker process. Overrides `workerSrc` setting.
  */
 PDFJS.workerPort = (PDFJS.workerPort === undefined ? null : PDFJS.workerPort);
 

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -25,8 +25,7 @@ var SVGGraphics = function() {
   throw new Error('Not implemented: SVGGraphics');
 };
 
-if (typeof PDFJSDev === 'undefined' ||
-    PDFJSDev.test('GENERIC || SINGLE_FILE')) {
+if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
 
 var SVG_DEFAULTS = {
   fontStyle: 'normal',

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -29,8 +29,7 @@ var pdfjsDisplayAnnotationLayer = require('./display/annotation_layer.js');
 var pdfjsDisplayDOMUtils = require('./display/dom_utils.js');
 var pdfjsDisplaySVG = require('./display/svg.js');
 
-if (typeof PDFJSDev === 'undefined' ||
-    !PDFJSDev.test('FIREFOX || MOZCENTRAL || CHROME')) {
+if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
   const isNodeJS = require('./shared/is_node.js');
   if (isNodeJS()) {
     let PDFNodeStream = require('./display/node_stream.js').PDFNodeStream;
@@ -43,7 +42,7 @@ if (typeof PDFJSDev === 'undefined' ||
     pdfjsDisplayAPI.setPDFNetworkStreamFactory((params) => {
       return new PDFFetchStream(params);
     });
-   } else {
+  } else {
     let PDFNetworkStream = require('./display/network.js').PDFNetworkStream;
     pdfjsDisplayAPI.setPDFNetworkStreamFactory((params) => {
       return new PDFNetworkStream(params);

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -24,7 +24,7 @@ import {
   DOMCanvasFactory, RenderingCancelledException
 } from '../../src/display/dom_utils';
 import {
-  getDocument, PDFDocumentProxy, PDFPageProxy
+  getDocument, PDFDocumentProxy, PDFPageProxy, PDFWorker
 } from '../../src/display/api';
 import isNodeJS from '../../src/shared/is_node';
 import { PDFJS } from '../../src/display/global';
@@ -404,6 +404,11 @@ describe('api', function() {
       }).catch(function (reason) {
         done.fail(reason);
       });
+    });
+    it('gets current workerSrc', function() {
+      let workerSrc = PDFWorker.getWorkerSrc();
+      expect(typeof workerSrc).toEqual('string');
+      expect(workerSrc).toEqual(PDFJS.workerSrc);
     });
   });
   describe('PDFDocument', function() {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -122,16 +122,14 @@ describe('api', function() {
             path: TEST_PDFS_PATH.node + basicApiFileName,
           });
         } else {
-          var nonBinaryRequest = PDFJS.disableWorker;
-          var request = new XMLHttpRequest();
+          let nonBinaryRequest = false;
+          let request = new XMLHttpRequest();
           request.open('GET', TEST_PDFS_PATH.dom + basicApiFileName, false);
-          if (!nonBinaryRequest) {
-            try {
-              request.responseType = 'arraybuffer';
-              nonBinaryRequest = request.responseType !== 'arraybuffer';
-            } catch (e) {
-              nonBinaryRequest = true;
-            }
+          try {
+            request.responseType = 'arraybuffer';
+            nonBinaryRequest = request.responseType !== 'arraybuffer';
+          } catch (e) {
+            nonBinaryRequest = true;
           }
           if (nonBinaryRequest && request.overrideMimeType) {
             request.overrideMimeType('text/plain; charset=x-user-defined');


### PR DESCRIPTION
*Please refer to the commit messages for additional details.*

This PR is an initial attempt at implementing https://mozilla.logbot.info/pdfjs/20180102#c14068811-c14068833; feedback welcome!

 - [x] Update the examples. Given the performance implications of loading the worker file in the main-thread, do we actually want to mention this in the examples or should we simply not advertise it at all?