### PR TITLE
removed parseJbig2 function

### DIFF
--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -1099,27 +1099,6 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     }
   }
 
-  function parseJbig2(data, start, end) { // eslint-disable-line no-unused-vars
-    var position = start;
-    if (data[position] !== 0x97 || data[position + 1] !== 0x4A ||
-        data[position + 2] !== 0x42 || data[position + 3] !== 0x32 ||
-        data[position + 4] !== 0x0D || data[position + 5] !== 0x0A ||
-        data[position + 6] !== 0x1A || data[position + 7] !== 0x0A) {
-      throw new Jbig2Error('invalid header');
-    }
-    var header = {};
-    position += 8;
-    var flags = data[position++];
-    header.randomAccess = !(flags & 1);
-    if (!(flags & 2)) {
-      header.numberOfPages = readUint32(data, position);
-      position += 4;
-    }
-    readSegments(header, data, position, end); // segments
-    throw new Error('Not implemented');
-    // processSegments(segments, new SimpleSegmentVisitor());
-  }
-
   function parseJbig2Chunks(chunks) {
     var visitor = new SimpleSegmentVisitor();
     for (var i = 0, ii = chunks.length; i < ii; i++) {


### PR DESCRIPTION
As suggested by @timvandermeij at #8018. The unused method `parseJbig2` has been removed. Please review.