### PR TITLE
Re-factor resetting of `StatTimer` instances to fix completely broken benchmarking (PR 9245 follow-up)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1056,8 +1056,8 @@ var PDFPageProxy = (function PDFPageProxyClosure() {
       }, this);
       this.objs.clear();
       this.annotationsPromise = null;
-      if (resetStats) {
-        this._stats.reset();
+      if (resetStats && this._stats instanceof StatTimer) {
+        this._stats = new StatTimer();
       }
       this.pendingCleanup = false;
     },

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -411,10 +411,6 @@ function isExternalLinkTargetSet() {
 class StatTimer {
   constructor(enable = true) {
     this.enabled = !!enable;
-    this.reset();
-  }
-
-  reset() {
     this.started = Object.create(null);
     this.times = [];
   }
@@ -476,8 +472,6 @@ class DummyStatTimer {
   constructor() {
     unreachable('Cannot initialize DummyStatTimer.');
   }
-
-  static reset() {}
 
   static time(name) {}
 


### PR DESCRIPTION
It turns out that PR #9245 unfortunately broke [benchmarking](https://github.com/mozilla/pdf.js/wiki/Benchmarking-your-changes) completely, sorry about that!

The bug is that we were attempting to reset the current instance of `StatTimer`, instead of creating a new one as was previously done. By resetting the current instance, the `StatTimer` data fetched in `test/driver.js` is now wiped out since it points to the *same* underlying object.
This re-use of a `StatTimer` instance was asked for during review, and unfortunately I didn't test this thoroughly enough before submitting the final version of the PR.[1]

---

[1] Note that while I did test the benchmarking scripts with that PR *before* initially submitting it, I did however forget to do that after addressing the review comments which might explain why this problem went unnoticed.