### PR TITLE
Attempt to find the next valid marker when encountering invalid image data in `JpegImage.parse` (issue 9425)

### DIFF
--- a/test/pdfs/issue9425.pdf.link
+++ b/test/pdfs/issue9425.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/1682471/Test.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -860,6 +860,14 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue9425",
+       "file": "pdfs/issue9425.pdf",
+       "md5": "cb5e99c9ada308304ca2dfcb7f72e3a0",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "txt2pdf",
        "file": "pdfs/txt2pdf.pdf",
        "md5": "02cefa0f5e8d96313bb05163b2f88c8c",


### PR DESCRIPTION
In the JPEG images in the referenced PDF file, the DHT (Define Huffman Tables) segments contain more data than expected based on the length parameter.

Fixes #9425.