### PR TITLE
Manually blend when encountering unsupported blend modes

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -934,6 +934,12 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
             break;
           case 'BM':
             this.ctx.globalCompositeOperation = value;
+            // We only manually blend if the mode is not 'source-over'
+            // which is the only supported blend mode does no blending
+            // See issue https://github.com/mozilla/pdf.js/issues/5264
+            this.blendModeFallback =
+              this.ctx.globalCompositeOperation !== value &&
+              value !== 'source-over';
             break;
           case 'SMask':
             if (this.current.activeSMask) {
@@ -955,6 +961,11 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
             this.tempSMask = null;
             break;
         }
+      }
+
+      if (this.blendModeFallback) {
+        this.ctx.globalAlpha = 0.5;
+        this.blendModeFallback = false;
       }
     },
     beginSMaskGroup: function CanvasGraphics_beginSMaskGroup() {

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -934,12 +934,6 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
             break;
           case 'BM':
             this.ctx.globalCompositeOperation = value;
-            // We only manually blend if the mode is not 'source-over'
-            // which is the only supported blend mode does no blending
-            // See issue https://github.com/mozilla/pdf.js/issues/5264
-            this.blendModeFallback =
-              this.ctx.globalCompositeOperation !== value &&
-              value !== 'source-over';
             break;
           case 'SMask':
             if (this.current.activeSMask) {
@@ -963,9 +957,13 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         }
       }
 
-      if (this.blendModeFallback) {
-        this.ctx.globalAlpha = 0.5;
-        this.blendModeFallback = false;
+      if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
+        // See checkBlendModeSupport() in compatiblity.js
+        if (this.ctx.blendModeFallback) {
+          // 0.5 is chosen to allow equal visibility for top and bottom content
+          this.ctx.globalAlpha = 0.5;
+          this.ctx.blendModeFallback = false;
+        }
       }
     },
     beginSMaskGroup: function CanvasGraphics_beginSMaskGroup() {

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -958,9 +958,9 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       }
 
       if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
-        // See checkBlendModeSupport() in compatiblity.js
-        if (this.ctx.blendModeFallback) {
-          // 0.5 is chosen to allow equal visibility for top and bottom content
+        // See checkBlendModeSupport() in compatiblity.js.
+        if (this.ctx.blendModeFallback && this.ctx.globalAlpha === 1) {
+          // 0.5 is chosen to allow equal visibility for top and bottom content.
           this.ctx.globalAlpha = 0.5;
           this.ctx.blendModeFallback = false;
         }

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -851,3 +851,35 @@ PDFJS.compatibilityChecked = true;
 })();
 
 }
+
+// Provides a partial workaround when blend modes are not supported
+// See issue https://github.com/mozilla/pdf.js/issues/5264
+// NOTE: This is not a blend mode polyfill, but a way to see blended content
+// that would otherwise be unviewable
+// Support: IE11
+(function checkBlendModeSupport() {
+  if (!hasDOM) {
+    return;
+  }
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  ctx.globalCompositeOperation = 'multiply';
+
+  // Check to see if the current browser supports globalCompositeOperation
+  if (ctx.globalCompositeOperation === 'multiply') {
+    return;
+  }
+
+  /* eslint-disable accessor-pairs, object-shorthand */
+  Object.defineProperty(CanvasRenderingContext2D.prototype,
+    'globalCompositeOperation', {
+    set: function(value) {
+      // We only manually blend if the mode is not 'source-over'
+      // which is the only supported blend mode that does no blending
+      if (value !== 'source-over') {
+        this.blendModeFallback = true;
+      }
+    },
+  });
+  /* eslint-enable accessor-pairs, object-shorthand */
+})();

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -89,6 +89,38 @@ PDFJS.compatibilityChecked = true;
   }
 })();
 
+// Provides a partial workaround when blend modes are not supported.
+// See issue https://github.com/mozilla/pdf.js/issues/5264.
+// NOTE: This is not a blend mode polyfill, but a way to see blended content
+// that would otherwise be unviewable.
+// Support: IE11
+(function checkBlendModeSupport() {
+  if (!hasDOM) {
+    return;
+  }
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  ctx.globalCompositeOperation = 'multiply';
+
+  // Check to see if the current browser supports globalCompositeOperation.
+  if (ctx.globalCompositeOperation === 'multiply') {
+    return;
+  }
+
+  /* eslint-disable, accessor-pairs, object-shorthand */
+  Object.defineProperty(CanvasRenderingContext2D.prototype,
+    'globalCompositeOperation', {
+    set: function(value) {
+      // We only manually blend if the mode is not 'source-over'
+      // which is the only supported blend mode that does no blending.
+      if (value !== 'source-over') {
+        this.blendModeFallback = true;
+      }
+    },
+  });
+  /* eslint-enable, object-shorthand */
+})();
+
 // Provides document.currentScript support
 // Support: IE, Chrome<29.
 (function checkCurrentScript() {
@@ -851,35 +883,3 @@ PDFJS.compatibilityChecked = true;
 })();
 
 }
-
-// Provides a partial workaround when blend modes are not supported
-// See issue https://github.com/mozilla/pdf.js/issues/5264
-// NOTE: This is not a blend mode polyfill, but a way to see blended content
-// that would otherwise be unviewable
-// Support: IE11
-(function checkBlendModeSupport() {
-  if (!hasDOM) {
-    return;
-  }
-  const canvas = document.createElement('canvas');
-  const ctx = canvas.getContext('2d');
-  ctx.globalCompositeOperation = 'multiply';
-
-  // Check to see if the current browser supports globalCompositeOperation
-  if (ctx.globalCompositeOperation === 'multiply') {
-    return;
-  }
-
-  /* eslint-disable accessor-pairs, object-shorthand */
-  Object.defineProperty(CanvasRenderingContext2D.prototype,
-    'globalCompositeOperation', {
-    set: function(value) {
-      // We only manually blend if the mode is not 'source-over'
-      // which is the only supported blend mode that does no blending
-      if (value !== 'source-over') {
-        this.blendModeFallback = true;
-      }
-    },
-  });
-  /* eslint-enable accessor-pairs, object-shorthand */
-})();


### PR DESCRIPTION
This PR attempts to improve (but not fully solve) blending modes on unsupported browsers. Notably IE11. This PR is based off of @tbasse 's work in https://github.com/mozilla/pdf.js/issues/5264. 

I wanted to open this up to suggestions before a full regression/unit test pass.

Example 1
 When blend modes are supported:
<img width="942" alt="screen shot 2018-02-02 at 10 01 37 am" src="https://user-images.githubusercontent.com/2474027/35747743-41d74550-0800-11e8-9acb-274620cce473.png"> 

When blend modes are not supported:
<img width="671" alt="annotations no blend" src="https://user-images.githubusercontent.com/2474027/35747772-67e28e9e-0800-11e8-981a-4461b9dcda39.PNG">

When blend modes are not supported, with my change:
<img width="827" alt="annotations" src="https://user-images.githubusercontent.com/2474027/35747758-582c758c-0800-11e8-8801-a4a79ba74dfa.PNG">


Example 2
 When blend modes are supported:
<img width="786" alt="screen shot 2018-02-02 at 10 01 30 am" src="https://user-images.githubusercontent.com/2474027/35747779-7220bca0-0800-11e8-9614-dc5640494b19.png">

When blend modes are not supported:
<img width="686" alt="blend no blend" src="https://user-images.githubusercontent.com/2474027/35747805-8b8b0114-0800-11e8-8237-620981629fa4.PNG">

When blend modes are not supported, with my change:
<img width="978" alt="blend modes" src="https://user-images.githubusercontent.com/2474027/35747791-7ecff286-0800-11e8-9b56-868018fb94ee.PNG">

