### PR TITLE
Add webpack.overwrite.js to change webpack.config

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -131,7 +131,7 @@ function createWebpackConfig(defines, output) {
   var skipBabel = bundleDefines.SKIP_BABEL ||
                   process.env['SKIP_BABEL'] === 'true';
 
-  return {
+  return Object.assign({
     output: output,
     plugins: [
       new webpack2.BannerPlugin({ banner: licenseHeaderLibre, raw: true, }),
@@ -167,7 +167,7 @@ function createWebpackConfig(defines, output) {
     // Avoid shadowing actual Node.js variables with polyfills, by disabling
     // polyfills/mocks - https://webpack.js.org/configuration/node/
     node: false,
-  };
+  }, require('./webpack.overwrite').overwrite);
 }
 
 function webpack2Stream(config) {

--- a/webpack.overwrite.js
+++ b/webpack.overwrite.js
@@ -1,0 +1,1 @@
+exports.overwrite = {};


### PR DESCRIPTION
I want the easy way to change webpack.config for 'gulp generic'.
So I add webpack.overwrite.js to change webpack.config. It's a useful for CI.

Use like below.
```
// webpack.overwrite.js
exports.overwrite = {
  devtool: false  // suppress to emit sourcemap
}
```

