### PR TITLE
[Firefox addon] Change the minimum supported version to Firefox Nightly, and remove no longer needed fallback code

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ PDF.js is built into version 19+ of Firefox, however, one extension is still ava
 
 + [Development Version](http://mozilla.github.io/pdf.js/extensions/firefox/pdf.js.xpi) - This extension is mainly intended for developers/testers, and it is updated every time new code is merged into the PDF.js codebase. It should be quite stable but might break from time to time.
 
-  + Please note that the extension is *not* guaranteed to be compatible with Firefox versions that are *older* than the current ESR version, see the [Release Calendar](https://wiki.mozilla.org/RapidRelease/Calendar#Past_branch_dates).
+  + Please note that the extension is *not* guaranteed to be compatible with Firefox versions that are *older* than the current Nightly version, see the [Release Calendar](https://wiki.mozilla.org/RapidRelease/Calendar#Past_branch_dates).
 
-  + The extension should also work in Seamonkey, provided that it is based on a Firefox version as above (see [Which version of Firefox does SeaMonkey 2.x correspond with?](https://wiki.mozilla.org/SeaMonkey/FAQ#General)), but we do *not* guarantee compatibility.
+  + The extension *may* also work in Seamonkey, provided that it is based on a Firefox version as above (see [Which version of Firefox does SeaMonkey 2.x correspond with?](https://wiki.mozilla.org/SeaMonkey/FAQ#General)), but we do *not* guarantee compatibility.
 
 #### Chrome
 

--- a/extensions/firefox/.eslintrc
+++ b/extensions/firefox/.eslintrc
@@ -7,17 +7,6 @@
   ],
 
   "parserOptions": {
-    // Note: Remove the ecmaVersion line when Gecko 52 is no longer supported
-    // to pick up the eslint-plugin-mozilla version (or at least update to
-    // ecmaVersion 8).
-    "ecmaVersion": 6,
-    "ecmaFeatures": {
-      // Note: We turn this off as it was only added in Gecko 55 (Bug 1339395)
-      // and we still need to support older versions (eslint-plugin-mozilla turns
-      // it on).
-      "experimentalObjectRestSpread": false
-    },
-
     "sourceType": "script",
   },
 
@@ -27,9 +16,6 @@
 
   "rules": {
     // Items different from the mozilla/recommended configuration.
-
-    // Being enabled soon.
-    "mozilla/use-services": "error",
 
     // Other rules mozilla/recommended hasn't enabled yet.
     "no-shadow": "error",

--- a/extensions/firefox/bootstrap.js
+++ b/extensions/firefox/bootstrap.js
@@ -26,8 +26,8 @@ const Cm = Components.manager;
 const Cu = Components.utils;
 const Cr = Components.results;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 function initializeDefaultPreferences() {
   /* eslint-disable semi */
@@ -120,14 +120,14 @@ function startup(aData, aReason) {
 
   pdfBaseUrl = aData.resourceURI.spec;
 
-  Cu.import(pdfBaseUrl + "content/PdfjsChromeUtils.jsm");
+  ChromeUtils.import(pdfBaseUrl + "content/PdfjsChromeUtils.jsm");
   PdfjsChromeUtils.init();
-  Cu.import(pdfBaseUrl + "content/PdfjsContentUtils.jsm");
+  ChromeUtils.import(pdfBaseUrl + "content/PdfjsContentUtils.jsm");
   PdfjsContentUtils.init();
 
   // Load the component and register it.
   var pdfStreamConverterUrl = pdfBaseUrl + "content/PdfStreamConverter.jsm";
-  Cu.import(pdfStreamConverterUrl);
+  ChromeUtils.import(pdfStreamConverterUrl);
   pdfStreamConverterFactory.register(PdfStreamConverter);
 
   try {

--- a/extensions/firefox/chrome/content.js
+++ b/extensions/firefox/chrome/content.js
@@ -25,8 +25,8 @@
   const Cu = Components.utils;
   const Cr = Components.results;
 
-  Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-  Cu.import("resource://gre/modules/Services.jsm");
+  ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+  ChromeUtils.import("resource://gre/modules/Services.jsm");
 
   var isRemote = Services.appinfo.processType ===
     Services.appinfo.PROCESS_TYPE_CONTENT;
@@ -72,10 +72,10 @@
   var pdfStreamConverterFactory = new Factory();
 
   function startup() {
-    Cu.import("resource://pdf.js/PdfjsContentUtils.jsm");
+    ChromeUtils.import("resource://pdf.js/PdfjsContentUtils.jsm");
     PdfjsContentUtils.init();
 
-    Cu.import("resource://pdf.js/PdfStreamConverter.jsm");
+    ChromeUtils.import("resource://pdf.js/PdfStreamConverter.jsm");
     pdfStreamConverterFactory.register(PdfStreamConverter);
   }
 

--- a/extensions/firefox/content/PdfJs.jsm
+++ b/extensions/firefox/content/PdfJs.jsm
@@ -39,8 +39,8 @@ const TOPIC_PLUGINS_LIST_UPDATED = "plugins-list-updated";
 const TOPIC_PLUGIN_INFO_UPDATED = "plugin-info-updated";
 const PDF_CONTENT_TYPE = "application/pdf";
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 var Svc = {};
 XPCOMUtils.defineLazyServiceGetter(Svc, "mime",
@@ -49,9 +49,9 @@ XPCOMUtils.defineLazyServiceGetter(Svc, "mime",
 XPCOMUtils.defineLazyServiceGetter(Svc, "pluginHost",
                                    "@mozilla.org/plugin/host;1",
                                    "nsIPluginHost");
-XPCOMUtils.defineLazyModuleGetter(this, "PdfjsChromeUtils",
+ChromeUtils.defineModuleGetter(this, "PdfjsChromeUtils",
                                   "resource://pdf.js/PdfjsChromeUtils.jsm");
-XPCOMUtils.defineLazyModuleGetter(this, "PdfjsContentUtils",
+ChromeUtils.defineModuleGetter(this, "PdfjsContentUtils",
                                   "resource://pdf.js/PdfjsContentUtils.jsm");
 
 function getBoolPref(aPref, aDefaultValue) {
@@ -314,7 +314,7 @@ var PdfJs = {
 
     this.updateRegistration();
     let jsm = "resource://pdf.js/PdfjsChromeUtils.jsm";
-    let PdfjsChromeUtils = Components.utils.import(jsm, {}).PdfjsChromeUtils;
+    let PdfjsChromeUtils = ChromeUtils.import(jsm, {}).PdfjsChromeUtils;
     PdfjsChromeUtils.notifyChildOfSettingsChange(this.enabled);
   },
 
@@ -342,7 +342,7 @@ var PdfJs = {
       return;
     }
     this._pdfStreamConverterFactory = new Factory();
-    Cu.import("resource://pdf.js/PdfStreamConverter.jsm");
+    ChromeUtils.import("resource://pdf.js/PdfStreamConverter.jsm");
     this._pdfStreamConverterFactory.register(PdfStreamConverter);
 
     this._registered = true;

--- a/extensions/firefox/content/PdfJsNetwork.jsm
+++ b/extensions/firefox/content/PdfJsNetwork.jsm
@@ -19,7 +19,7 @@ ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 var EXPORTED_SYMBOLS = ["NetworkManager"];
 
-function log(aMsg) {
+function log(aMsg) { // eslint-disable-line no-unused-vars
   var msg = "PdfJsNetwork.jsm: " + (aMsg.join ? aMsg.join("") : aMsg);
   Services.console.logStringMessage(msg);
 }

--- a/extensions/firefox/content/PdfJsNetwork.jsm
+++ b/extensions/firefox/content/PdfJsNetwork.jsm
@@ -15,7 +15,7 @@
 
 "use strict";
 
-Components.utils.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 var EXPORTED_SYMBOLS = ["NetworkManager"];
 

--- a/extensions/firefox/content/PdfJsTelemetry.jsm
+++ b/extensions/firefox/content/PdfJsTelemetry.jsm
@@ -19,7 +19,7 @@
 this.EXPORTED_SYMBOLS = ["PdfJsTelemetry"];
 
 const Cu = Components.utils;
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 this.PdfJsTelemetry = {
   onViewerIsUsed() {

--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -29,22 +29,22 @@ const PDF_VIEWER_WEB_PAGE = "resource://pdf.js/web/viewer.html";
 const MAX_NUMBER_OF_PREFS = 50;
 const MAX_STRING_PREF_LENGTH = 128;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-XPCOMUtils.defineLazyModuleGetter(this, "NetUtil",
+ChromeUtils.defineModuleGetter(this, "NetUtil",
   "resource://gre/modules/NetUtil.jsm");
 
-XPCOMUtils.defineLazyModuleGetter(this, "NetworkManager",
+ChromeUtils.defineModuleGetter(this, "NetworkManager",
   "resource://pdf.js/PdfJsNetwork.jsm");
 
-XPCOMUtils.defineLazyModuleGetter(this, "PrivateBrowsingUtils",
+ChromeUtils.defineModuleGetter(this, "PrivateBrowsingUtils",
   "resource://gre/modules/PrivateBrowsingUtils.jsm");
 
-XPCOMUtils.defineLazyModuleGetter(this, "PdfJsTelemetry",
+ChromeUtils.defineModuleGetter(this, "PdfJsTelemetry",
   "resource://pdf.js/PdfJsTelemetry.jsm");
 
-XPCOMUtils.defineLazyModuleGetter(this, "PdfjsContentUtils",
+ChromeUtils.defineModuleGetter(this, "PdfjsContentUtils",
   "resource://pdf.js/PdfjsContentUtils.jsm");
 
 var Svc = {};

--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -93,11 +93,6 @@ function getIntPref(pref, def) {
 
 function getStringPref(pref, def) {
   try {
-//#if !MOZCENTRAL
-    if (!Services.prefs.getStringPref) {
-      return Services.prefs.getComplexValue(pref, Ci.nsISupportsString).data;
-    }
-//#endif
     return Services.prefs.getStringPref(pref);
   } catch (ex) {
     return def;
@@ -325,11 +320,6 @@ class ChromeActions {
   }
 
   getLocale() {
-//#if !MOZCENTRAL
-    if (!Services.locale.getRequestedLocale) {
-      return getStringPref("general.useragent.locale", "en-US");
-    }
-//#endif
     return Services.locale.getRequestedLocale() || "en-US";
   }
 

--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -23,7 +23,6 @@ const Cr = Components.results;
 const Cu = Components.utils;
 
 const PDFJS_EVENT_ID = "pdf.js.message";
-const PDF_CONTENT_TYPE = "application/pdf";
 const PREF_PREFIX = "PDFJSSCRIPT_PREF_PREFIX";
 const PDF_VIEWER_WEB_PAGE = "resource://pdf.js/web/viewer.html";
 const MAX_NUMBER_OF_PREFS = 50;

--- a/extensions/firefox/content/PdfjsChromeUtils.jsm
+++ b/extensions/firefox/content/PdfjsChromeUtils.jsm
@@ -25,8 +25,8 @@ const Cu = Components.utils;
 const PREF_PREFIX = "PDFJSSCRIPT_PREF_PREFIX";
 const PDF_CONTENT_TYPE = "application/pdf";
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 var Svc = {};
 XPCOMUtils.defineLazyServiceGetter(Svc, "mime",

--- a/extensions/firefox/content/PdfjsChromeUtils.jsm
+++ b/extensions/firefox/content/PdfjsChromeUtils.jsm
@@ -74,18 +74,6 @@ var PdfjsChromeUtils = {
       this._mmg.addMessageListener("PDFJS:Parent:removeEventListener", this);
       this._mmg.addMessageListener("PDFJS:Parent:updateControlState", this);
 
-//#if !MOZCENTRAL
-      // The signature of `Services.obs.addObserver` changed in Firefox 55,
-      // see https://bugzilla.mozilla.org/show_bug.cgi?id=1355216.
-      // PLEASE NOTE: While the third parameter is now optional,
-      // omitting it in prior Firefox versions breaks the addon.
-      var ffVersion = parseInt(Services.appinfo.platformVersion);
-      if (ffVersion <= 55) {
-        // eslint-disable-next-line mozilla/no-useless-parameters
-        Services.obs.addObserver(this, "quit-application", false);
-        return;
-      }
-//#endif
       // Observer to handle shutdown.
       Services.obs.addObserver(this, "quit-application");
     }
@@ -287,15 +275,6 @@ var PdfjsChromeUtils = {
 
   _setStringPref(aPrefName, aPrefValue) {
     this._ensurePreferenceAllowed(aPrefName);
-//#if !MOZCENTRAL
-    if (!Services.prefs.setStringPref) {
-      let str = Cc["@mozilla.org/supports-string;1"]
-                  .createInstance(Ci.nsISupportsString);
-      str.data = aPrefValue;
-      Services.prefs.setComplexValue(aPrefName, Ci.nsISupportsString, str);
-      return;
-    }
-//#endif
     Services.prefs.setStringPref(aPrefName, aPrefValue);
   },
 

--- a/extensions/firefox/content/PdfjsContentUtils.jsm
+++ b/extensions/firefox/content/PdfjsContentUtils.jsm
@@ -22,8 +22,8 @@ const Ci = Components.interfaces;
 const Cr = Components.results;
 const Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 var PdfjsContentUtils = {
   _mm: null,
@@ -131,7 +131,7 @@ var PdfjsContentUtils = {
         if (Services.appinfo.processType ===
             Services.appinfo.PROCESS_TYPE_CONTENT) {
           let jsm = "resource://pdf.js/PdfJs.jsm";
-          let pdfjs = Components.utils.import(jsm, {}).PdfJs;
+          let pdfjs = ChromeUtils.import(jsm, {}).PdfJs;
           if (aMsg.data.enabled) {
             pdfjs.ensureRegistered();
           } else {

--- a/extensions/firefox/content/PdfjsContentUtils.jsm
+++ b/extensions/firefox/content/PdfjsContentUtils.jsm
@@ -45,18 +45,6 @@ var PdfjsContentUtils = {
         getService(Ci.nsISyncMessageSender);
       this._mm.addMessageListener("PDFJS:Child:updateSettings", this);
 
-//#if !MOZCENTRAL
-      // The signature of `Services.obs.addObserver` changed in Firefox 55,
-      // see https://bugzilla.mozilla.org/show_bug.cgi?id=1355216.
-      // PLEASE NOTE: While the third parameter is now optional,
-      // omitting it in prior Firefox versions breaks the addon.
-      var ffVersion = parseInt(Services.appinfo.platformVersion);
-      if (ffVersion <= 55) {
-        // eslint-disable-next-line mozilla/no-useless-parameters
-        Services.obs.addObserver(this, "quit-application", false);
-        return;
-      }
-//#endif
       Services.obs.addObserver(this, "quit-application");
     }
   },

--- a/extensions/firefox/content/pdfjschildbootstrap-enabled.js
+++ b/extensions/firefox/content/pdfjschildbootstrap-enabled.js
@@ -21,8 +21,8 @@
  * running remote. It will only be run when PdfJs.enable is true.
  */
 
-Components.utils.import("resource://gre/modules/Services.jsm");
-Components.utils.import("resource://pdf.js/PdfJs.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://pdf.js/PdfJs.jsm");
 
 if (Services.appinfo.processType === Services.appinfo.PROCESS_TYPE_CONTENT) {
   // register various pdfjs factories that hook us into content loading.

--- a/extensions/firefox/content/pdfjschildbootstrap.js
+++ b/extensions/firefox/content/pdfjschildbootstrap.js
@@ -20,7 +20,7 @@
  * initializing our built-in version of pdfjs when running remote.
  */
 
-Components.utils.import("resource://pdf.js/PdfjsContentUtils.jsm");
+ChromeUtils.import("resource://pdf.js/PdfjsContentUtils.jsm");
 
 // init content utils shim pdfjs will use to access privileged apis.
 PdfjsContentUtils.init();

--- a/extensions/firefox/install.rdf
+++ b/extensions/firefox/install.rdf
@@ -13,8 +13,8 @@
     <em:targetApplication>
       <Description>
        <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
-       <em:minVersion>45.0</em:minVersion>
-       <em:maxVersion>54.0a1</em:maxVersion>
+       <em:minVersion>59.*</em:minVersion>
+       <em:maxVersion>61.0a1</em:maxVersion>
      </Description>
     </em:targetApplication>
 
@@ -31,8 +31,8 @@
     <em:targetApplication>
       <Description>
        <em:id>{aa3c5121-dab2-40e2-81ca-7ea25febc110}</em:id>
-       <em:minVersion>45.0</em:minVersion>
-       <em:maxVersion>54.0a1</em:maxVersion>
+       <em:minVersion>59.*</em:minVersion>
+       <em:maxVersion>61.0a1</em:maxVersion>
      </Description>
     </em:targetApplication>
 

--- a/extensions/firefox/update.rdf
+++ b/extensions/firefox/update.rdf
@@ -14,8 +14,8 @@
             <em:targetApplication>
               <RDF:Description>
                 <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
-                <em:minVersion>45.0</em:minVersion>
-                <em:maxVersion>54.0a1</em:maxVersion>
+                <em:minVersion>59.*</em:minVersion>
+                <em:maxVersion>61.0a1</em:maxVersion>
                 <!-- Use the raw link for updates so we we can use SSL. -->
                 <em:updateLink>https://raw.githubusercontent.com/mozilla/pdf.js/gh-pages/extensions/firefox/pdf.js.xpi</em:updateLink>
               </RDF:Description>
@@ -25,8 +25,8 @@
             <em:targetApplication>
               <RDF:Description>
                 <em:id>{aa3c5121-dab2-40e2-81ca-7ea25febc110}</em:id>
-                <em:minVersion>45.0</em:minVersion>
-                <em:maxVersion>54.0a1</em:maxVersion>
+                <em:minVersion>59.*</em:minVersion>
+                <em:maxVersion>61.0a1</em:maxVersion>
                 <!-- Use the raw link for updates so we we can use SSL. -->
                 <em:updateLink>https://raw.githubusercontent.com/mozilla/pdf.js/gh-pages/extensions/firefox/pdf.js.xpi</em:updateLink>
               </RDF:Description>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "core-js": "^2.5.3",
     "escodegen": "^1.9.0",
     "eslint": "^4.16.0",
-    "eslint-plugin-mozilla": "^0.5.0",
+    "eslint-plugin-mozilla": "^0.7.0",
     "eslint-plugin-no-unsanitized": "^2.0.2",
     "fancy-log": "^1.3.2",
     "gulp": "^3.9.1",


### PR DESCRIPTION
*Please refer to the individual commit messages for additional details.*

/cc @rvandermeulen Since this blocks the next PDF.js update.