### PR TITLE
Upstream the changes from: Bug 1339461 - Convert foo.indexOf(...) == -1 to foo.includes() and implement an eslint rule to enforce this

### DIFF
--- a/extensions/firefox/content/PdfJs.jsm
+++ b/extensions/firefox/content/PdfJs.jsm
@@ -243,7 +243,7 @@ var PdfJs = {
       types = stringTypes.split(",");
     }
 
-    if (types.indexOf(PDF_CONTENT_TYPE) === -1) {
+    if (!types.includes(PDF_CONTENT_TYPE)) {
       types.push(PDF_CONTENT_TYPE);
     }
     prefs.setCharPref(PREF_DISABLED_PLUGIN_TYPES, types.join(","));
@@ -271,7 +271,7 @@ var PdfJs = {
     if (Services.prefs.prefHasUserValue(PREF_DISABLED_PLUGIN_TYPES)) {
       let disabledPluginTypes =
         Services.prefs.getCharPref(PREF_DISABLED_PLUGIN_TYPES).split(",");
-      if (disabledPluginTypes.indexOf(PDF_CONTENT_TYPE) >= 0) {
+      if (disabledPluginTypes.includes(PDF_CONTENT_TYPE)) {
         return true;
       }
     }

--- a/extensions/firefox/content/PdfStreamConverter.jsm
+++ b/extensions/firefox/content/PdfStreamConverter.jsm
@@ -930,12 +930,12 @@ PdfStreamConverter.prototype = {
                      aRequest.contentLength >= 0 &&
                      !getBoolPref(PREF_PREFIX + ".disableRange", false) &&
                      (!isPDFBugEnabled ||
-                      hash.toLowerCase().indexOf("disablerange=true") < 0);
+                      !hash.toLowerCase().includes("disablerange=true"));
       streamRequest = contentEncoding === "identity" &&
                       aRequest.contentLength >= 0 &&
                       !getBoolPref(PREF_PREFIX + ".disableStream", false) &&
                       (!isPDFBugEnabled ||
-                       hash.toLowerCase().indexOf("disablestream=true") < 0);
+                       !hash.toLowerCase().includes("disablestream=true"));
     }
 
     aRequest.QueryInterface(Ci.nsIChannel);

--- a/extensions/firefox/content/PdfjsChromeUtils.jsm
+++ b/extensions/firefox/content/PdfjsChromeUtils.jsm
@@ -258,7 +258,7 @@ var PdfjsChromeUtils = {
   _ensurePreferenceAllowed(aPrefName) {
     let unPrefixedName = aPrefName.split(PREF_PREFIX + ".");
     if (unPrefixedName[0] !== "" ||
-        this._allowedPrefNames.indexOf(unPrefixedName[1]) === -1) {
+        !this._allowedPrefNames.includes(unPrefixedName[1])) {
       let msg = "\"" + aPrefName + "\" " +
                 "can't be accessed from content. See PdfjsChromeUtils.";
       throw new Error(msg);

--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -411,7 +411,7 @@ var ChunkedStreamManager = (function ChunkedStreamManagerClosure() {
         var beginChunk = this.getBeginChunk(ranges[i].begin);
         var endChunk = this.getEndChunk(ranges[i].end);
         for (var chunk = beginChunk; chunk < endChunk; ++chunk) {
-          if (chunksToRequest.indexOf(chunk) < 0) {
+          if (!chunksToRequest.includes(chunk)) {
             chunksToRequest.push(chunk);
           }
         }

--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -942,7 +942,7 @@ var CMapFactory = (function CMapFactoryClosure() {
     } else if (name === 'Identity-V') {
       return Promise.resolve(new IdentityCMap(true, 2));
     }
-    if (BUILT_IN_CMAPS.indexOf(name) === -1) {
+    if (!BUILT_IN_CMAPS.includes(name)) {
       return Promise.reject(new Error('Unknown CMap name: ' + name));
     }
     if (!fetchBuiltInCMap) {

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -1316,7 +1316,7 @@ var Font = (function FontClosure() {
 
         for (let i = 0; i < numTables; i++) {
           let table = readTableEntry(font);
-          if (VALID_TABLES.indexOf(table.tag) < 0) {
+          if (!VALID_TABLES.includes(table.tag)) {
             continue; // skipping table if it's not a required or optional table
           }
           if (table.length === 0) {
@@ -2113,7 +2113,7 @@ var Font = (function FontClosure() {
               if (funcId in ttContext.functionsStackDeltas) {
                 stack.length += ttContext.functionsStackDeltas[funcId];
               } else if (funcId in ttContext.functionsDefined &&
-                         functionsCalled.indexOf(funcId) < 0) {
+                         !functionsCalled.includes(funcId)) {
                 callstack.push({ data, i, stackTop: stack.length - 1, });
                 functionsCalled.push(funcId);
                 pc = ttContext.functionsDefined[funcId];

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -596,7 +596,7 @@ class ChoiceWidgetAnnotationElement extends WidgetAnnotationElement {
       optionElement.textContent = option.displayValue;
       optionElement.value = option.exportValue;
 
-      if (this.data.fieldValue.indexOf(option.displayValue) >= 0) {
+      if (this.data.fieldValue.includes(option.displayValue)) {
         optionElement.setAttribute('selected', true);
       }
 
@@ -628,7 +628,7 @@ class PopupAnnotationElement extends AnnotationElement {
 
     this.container.className = 'popupAnnotation';
 
-    if (IGNORE_TYPES.indexOf(this.data.parentType) >= 0) {
+    if (IGNORE_TYPES.includes(this.data.parentType)) {
       return this.container;
     }
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1131,7 +1131,7 @@ class LoopbackPort {
       var buffer;
       if ((buffer = value.buffer) && isArrayBuffer(buffer)) {
         // We found object with ArrayBuffer (typed array).
-        var transferable = transfers && transfers.indexOf(buffer) >= 0;
+        var transferable = transfers && transfers.includes(buffer);
         if (value === buffer) {
           // Special case when we are faking typed arrays in compatibility.js.
           result = value;

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -229,7 +229,7 @@ class SimpleXMLParser {
   }
 
   _decodeXML(text) {
-    if (text.indexOf('&') < 0) {
+    if (!text.includes('&')) {
       return text;
     }
 

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -157,6 +157,15 @@ PDFJS.compatibilityChecked = true;
   };
 })();
 
+// Provides support for String.prototype.includes in legacy browsers.
+// Support: IE, Chrome<41
+(function checkStringIncludes() {
+  if (String.prototype.includes) {
+    return;
+  }
+  String.prototype.includes = require('core-js/fn/string/includes');
+})();
+
 // Provides support for Array.prototype.includes in legacy browsers.
 // Support: IE, Chrome<47
 (function checkArrayIncludes() {


### PR DESCRIPTION
 - Polyfill `String.prototype.includes` using core-js

   See https://github.com/zloirock/core-js#ecmascript-6-string.

 - Upstream the changes from: Bug 1339461 - Convert foo.indexOf(...) == -1 to foo.includes() and implement an eslint rule to enforce this

   Yet another case where PDF.js code was modified in `mozilla-central` without the changes happening in the GitHub repo first; *sigh*.
If we don't upstream at least the changes in `extensions/firefox/`, any future update of PDF.js in `mozilla-central` will be blocked.

   Please see:
    - https://bugzilla.mozilla.org/show_bug.cgi?id=1339461
    - https://hg.mozilla.org/mozilla-central/rev/d5a5ad1dbbf2

/cc @rvandermeulen Since this blocks the next PDF.js update.