### PR TITLE
Support spaces and semicolons in filename (Content-Disposition)

### DIFF
--- a/test/unit/network_utils_spec.js
+++ b/test/unit/network_utils_spec.js
@@ -176,7 +176,25 @@ describe('network_utils', function() {
 
       expect(extractFilenameFromHeader((headerName) => {
         if (headerName === 'Content-Disposition') {
+          return 'attachment; filename="filename.pdf and spaces.pdf"';
+        }
+      })).toEqual('filename.pdf and spaces.pdf');
+
+      expect(extractFilenameFromHeader((headerName) => {
+        if (headerName === 'Content-Disposition') {
+          return 'attachment; filename="tl;dr.pdf"';
+        }
+      })).toEqual('tl;dr.pdf');
+
+      expect(extractFilenameFromHeader((headerName) => {
+        if (headerName === 'Content-Disposition') {
           return 'attachment; filename=filename.pdf';
+        }
+      })).toEqual('filename.pdf');
+
+      expect(extractFilenameFromHeader((headerName) => {
+        if (headerName === 'Content-Disposition') {
+          return 'attachment; filename=filename.pdf someotherparam';
         }
       })).toEqual('filename.pdf');
     });


### PR DESCRIPTION
This PR is a follow-up to https://github.com/mozilla/pdf.js/pull/9383#issuecomment-362203603 and adds support for spaces and quoted strings in the filename of a `Content-Disposition` header.

It imports the following changes:
https://github.com/Rob--W/open-in-browser/commit/5b1afa7c29339627a7ed230473ab715d1364a740 (an insignificant one-character deletion).
https://github.com/Rob--W/open-in-browser/commit/7e2e35a38b8b4e981b11da7b2f01df0149049e92 (supports ; and " in quoted strings).

The changes are covered by unit tests at https://github.com/Rob--W/open-in-browser/blob/7e2e35a38b8b4e981b11da7b2f01df0149049e92/test/test-content-disposition.js#L268-L274 (and there are no regressions on previous tests)