### PR TITLE
Use `setPDFNetworkStreamFactory` in the `helloworld` and `svgviewer` examples

### DIFF
--- a/examples/helloworld/hello.js
+++ b/examples/helloworld/hello.js
@@ -7,7 +7,9 @@ Promise.all([System.import('pdfjs/display/api'),
              System.resolve('pdfjs/worker_loader')])
        .then(function (modules) {
   var api = modules[0], global = modules[1], network = modules[2];
-  api.setPDFNetworkStreamClass(network.PDFNetworkStream);
+  api.setPDFNetworkStreamFactory((params) => {
+    return new network.PDFNetworkStream(params);
+  });
 
   // In production, change this to point to the built `pdf.worker.js` file.
   global.PDFJS.workerSrc = modules[3];

--- a/examples/svgviewer/viewer.js
+++ b/examples/svgviewer/viewer.js
@@ -43,7 +43,10 @@ Promise.all([System.import('pdfjs/display/api'),
              System.resolve('pdfjs/worker_loader')])
        .then(function (modules) {
   var api = modules[0], svg = modules[1], global = modules[2], network = modules[3];
-  api.setPDFNetworkStreamClass(network.PDFNetworkStream);
+  api.setPDFNetworkStreamFactory((params) => {
+    return new network.PDFNetworkStream(params);
+  });
+
   // In production, change this to point to the built `pdf.worker.js` file.
   global.PDFJS.workerSrc = modules[4];
 


### PR DESCRIPTION
This patch fixes a regression from #9363, causing the examples not to load anymore.