### PR TITLE
Update comment regarding beforeprint event support

### DIFF
--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -301,7 +301,7 @@ if (hasAttachEvent) {
 
 if ('onbeforeprint' in window) {
   // Do not propagate before/afterprint events when they are not triggered
-  // from within this polyfill. (FF/IE).
+  // from within this polyfill. (FF /IE / Chrome 63+).
   let stopPropagationIfNeeded = function(event) {
     if (event.detail !== 'custom' && event.stopImmediatePropagation) {
       event.stopImmediatePropagation();


### PR DESCRIPTION
"beforeprint" / "afterprint" are standard features these days, and Chrome added support for it in Chrome 63: https://www.chromestatus.com/feature/5700595042222080

This is just a comment update, the added events are not really useful for PDF.js because these events are synchronous and non-cancelable. For that we would need async print events, but that doesn't seem to happen anytime soon - https://github.com/whatwg/html/issues/2532