### PR TITLE
locally hosted viewer should allow any file location

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1482,7 +1482,7 @@ let PDFViewerApplication = {
 
 let validateFileURL;
 if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
-  const HOSTED_VIEWER_ORIGINS = ['null',
+  const HOSTED_VIEWER_ORIGINS = ['null', 'file://', 'qrc://'
     'http://mozilla.github.io', 'https://mozilla.github.io'];
   validateFileURL = function validateFileURL(file) {
     if (file === undefined) {


### PR DESCRIPTION
Included 'qrc://' for Qt resource files