### PR TITLE
Attempt to unify the `disableRange`/`contentLength` handling in the various network streams

### DIFF
--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -74,14 +74,14 @@ class PDFFetchStreamReader {
     this._withCredentials = source.withCredentials;
     this._contentLength = source.length;
     this._headersCapability = createPromiseCapability();
-    this._disableRange = source.disableRange;
+    this._disableRange = source.disableRange || false;
     this._rangeChunkSize = source.rangeChunkSize;
     if (!this._rangeChunkSize && !this._disableRange) {
       this._disableRange = true;
     }
 
-    this._isRangeSupported = !source.disableRange;
     this._isStreamingSupported = !source.disableStream;
+    this._isRangeSupported = !source.disableRange;
 
     this._headers = new Headers();
     for (let property in this._stream.httpHeaders) {
@@ -112,8 +112,9 @@ class PDFFetchStreamReader {
           disableRange: this._disableRange,
         });
 
-      this._contentLength = suggestedLength;
       this._isRangeSupported = allowRangeRequests;
+      // Setting right content length.
+      this._contentLength = suggestedLength || this._contentLength;
 
       this._filename = extractFilenameFromHeader(getResponseHeader);
 

--- a/src/display/network.js
+++ b/src/display/network.js
@@ -355,7 +355,6 @@ PDFNetworkStreamFullRequestReader.prototype = {
     const getResponseHeader = (name) => {
       return fullRequestXhr.getResponseHeader(name);
     };
-
     let { allowRangeRequests, suggestedLength, } =
       validateRangeRequestCapabilities({
         getResponseHeader,
@@ -364,12 +363,11 @@ PDFNetworkStreamFullRequestReader.prototype = {
         disableRange: this._disableRange,
       });
 
-    // Setting right content length.
-    this._contentLength = suggestedLength || this._contentLength;
-
     if (allowRangeRequests) {
       this._isRangeSupported = true;
     }
+    // Setting right content length.
+    this._contentLength = suggestedLength || this._contentLength;
 
     this._filename = extractFilenameFromHeader(getResponseHeader);
 

--- a/src/display/node_stream.js
+++ b/src/display/node_stream.js
@@ -304,11 +304,9 @@ class PDFNodeStreamFullReader extends BaseFullReader {
           disableRange: this._disableRange,
         });
 
-      if (allowRangeRequests) {
-        this._isRangeSupported = true;
-      }
+      this._isRangeSupported = allowRangeRequests;
       // Setting right content length.
-      this._contentLength = suggestedLength;
+      this._contentLength = suggestedLength || this._contentLength;
 
       this._filename = extractFilenameFromHeader(getResponseHeader);
     };

--- a/src/display/transport_stream.js
+++ b/src/display/transport_stream.js
@@ -28,8 +28,8 @@ var PDFDataTransportStream = (function PDFDataTransportStreamClosure() {
     }
 
     this._pdfDataRangeTransport = pdfDataRangeTransport;
-    this._isRangeSupported = !(params.disableRange);
-    this._isStreamingSupported = !(params.disableStream);
+    this._isStreamingSupported = !params.disableStream;
+    this._isRangeSupported = !params.disableRange;
     this._contentLength = params.length;
 
     this._fullRequestReader = null;


### PR DESCRIPTION
First of all, note how in both `fetch_stream.js` and `node_stream.js` we always overwrite the `this._contentLength` property even when the response headers doesn't actually contain any (valid) length information. This could thus result in the `length` parameter, as passed to the network stream, being completely ignored despite having no better information available.
Secondly, in `node_stream.js` the `this._isRangeSupported` property wasn't always updated correctly based on the response headers.