### PR TITLE
Enable the `mozilla/avoid-removeChild` and `mozilla/use-includes-instead-of-indexOf` ESLint rules globally

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,7 @@
   "rules": {
     // Plugins
     "mozilla/avoid-removeChild": "error",
+    "mozilla/use-includes-instead-of-indexOf": "error",
 
     // Possible errors
     "for-direction": "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,10 @@
     "sourceType": "module",
   },
 
+  "plugins": [
+    "mozilla"
+  ],
+
   "env": {
     "browser": true,
     "es6": true,
@@ -18,6 +22,9 @@
   },
 
   "rules": {
+    // Plugins
+    "mozilla/avoid-removeChild": "error",
+
     // Possible errors
     "for-direction": "error",
     "no-cond-assign": ["error", "except-parens"],

--- a/extensions/chromium/extension-router.js
+++ b/extensions/chromium/extension-router.js
@@ -46,7 +46,7 @@ limitations under the License.
       return;
     }
     var scheme = url.slice(0, schemeIndex).toLowerCase();
-    if (schemes.indexOf(scheme) >= 0) {
+    if (schemes.includes(scheme)) {
       url = url.split('#')[0];
       if (url.charAt(schemeIndex) === ':') {
         url = encodeURIComponent(url);

--- a/extensions/chromium/pdfHandler.js
+++ b/extensions/chromium/pdfHandler.js
@@ -29,7 +29,7 @@ function getViewerURL(pdf_url) {
  * @return {boolean} True if the PDF file should be downloaded.
  */
 function isPdfDownloadable(details) {
-  if (details.url.indexOf('pdfjs.action=download') >= 0) {
+  if (details.url.includes('pdfjs.action=download')) {
     return true;
   }
   // Display the PDF viewer regardless of the Content-Disposition header if the
@@ -39,8 +39,7 @@ function isPdfDownloadable(details) {
   // viewer to open the PDF, but first check whether the Content-Disposition
   // header specifies an attachment. This allows sites like Google Drive to
   // operate correctly (#6106).
-  if (details.type === 'main_frame' &&
-      details.url.indexOf('=download') === -1) {
+  if (details.type === 'main_frame' && !details.url.includes('=download')) {
     return false;
   }
   var cdHeader = (details.responseHeaders &&

--- a/external/.eslintrc
+++ b/external/.eslintrc
@@ -8,6 +8,8 @@
   },
 
   "rules": {
+    "mozilla/use-includes-instead-of-indexOf": "off",
+
     "object-shorthand": "off",
   },
 }

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable no-extend-native */
+/* eslint-disable no-extend-native, mozilla/use-includes-instead-of-indexOf */
 /* globals PDFJS */
 
 // Skip compatibility checks for the extensions and if we already ran

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -152,6 +152,7 @@ PDFJS.compatibilityChecked = true;
   }
   Element.prototype.remove = function () {
     if (this.parentNode) {
+      // eslint-disable-next-line mozilla/avoid-removeChild
       this.parentNode.removeChild(this);
     }
   };

--- a/test/downloadutils.js
+++ b/test/downloadutils.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable object-shorthand */
+/* eslint-disable object-shorthand, mozilla/use-includes-instead-of-indexOf */
 
 'use strict';
 

--- a/test/driver.js
+++ b/test/driver.js
@@ -367,8 +367,7 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
         while (styleSheet.cssRules.length > 0) {
           styleSheet.deleteRule(0);
         }
-        let ownerNode = styleSheet.ownerNode;
-        ownerNode.parentNode.removeChild(ownerNode);
+        styleSheet.ownerNode.remove();
       }
       let body = document.body;
       while (body.lastChild !== this.end) {

--- a/test/driver.js
+++ b/test/driver.js
@@ -305,7 +305,7 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
           self.manifest = JSON.parse(r.responseText);
           if (self.testFilter && self.testFilter.length) {
             self.manifest = self.manifest.filter(function(item) {
-              return self.testFilter.indexOf(item.id) !== -1;
+              return self.testFilter.includes(item.id);
             });
           }
           self.currentTask = 0;
@@ -433,7 +433,7 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
         }
       }
 
-      if (task.skipPages && task.skipPages.indexOf(task.pageNum) >= 0) {
+      if (task.skipPages && task.skipPages.includes(task.pageNum)) {
         this._log(' Skipping page ' + task.pageNum + '/' +
                   task.pdfDoc.numPages + '...\n');
         task.pageNum++;

--- a/test/stats/statcmp.js
+++ b/test/stats/statcmp.js
@@ -1,3 +1,5 @@
+/* eslint-disable mozilla/use-includes-instead-of-indexOf */
+
 'use strict';
 
 var fs = require('fs');

--- a/test/webbrowser.js
+++ b/test/webbrowser.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable object-shorthand */
+/* eslint-disable object-shorthand, mozilla/use-includes-instead-of-indexOf */
 
 'use strict';
 

--- a/web/app.js
+++ b/web/app.js
@@ -1208,7 +1208,7 @@ let PDFViewerApplication = {
         ];
         if (info.Producer) {
           KNOWN_GENERATORS.some(function (generator, s, i) {
-            if (generator.indexOf(s) < 0) {
+            if (!generator.includes(s)) {
               return false;
             }
             generatorId = i + 1;
@@ -1490,7 +1490,7 @@ if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
     }
     try {
       let viewerOrigin = new URL(window.location.href).origin || 'null';
-      if (HOSTED_VIEWER_ORIGINS.indexOf(viewerOrigin) >= 0) {
+      if (HOSTED_VIEWER_ORIGINS.includes(viewerOrigin)) {
         // Hosted or local viewer, allow for any file locations
         return;
       }

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -338,7 +338,7 @@ var Stepper = (function StepperClosure() {
         line.className = 'line';
         line.dataset.idx = i;
         chunk.appendChild(line);
-        var checked = this.breakPoints.indexOf(i) !== -1;
+        var checked = this.breakPoints.includes(i);
         var args = operatorList.argsArray[i] || [];
 
         var breakCell = c('td');
@@ -521,7 +521,7 @@ window.PDFBug = (function PDFBugClosure() {
       }
       for (var i = 0; i < tools.length; ++i) {
         var tool = tools[i];
-        if (all || ids.indexOf(tool.id) !== -1) {
+        if (all || ids.includes(tool.id)) {
           tool.enabled = true;
         }
       }

--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -43,7 +43,7 @@ function download(blobUrl, filename) {
     // (otherwise .click() is ignored)
     (document.body || document.documentElement).appendChild(a);
     a.click();
-    a.parentNode.removeChild(a);
+    a.remove();
   } else {
     if (window.top === window &&
         blobUrl.split('#')[0] === window.location.href.split('#')[0]) {

--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -49,7 +49,7 @@ function download(blobUrl, filename) {
         blobUrl.split('#')[0] === window.location.href.split('#')[0]) {
       // If _parent == self, then opening an identical URL with different
       // location hash will only cause a navigation, not a download.
-      let padCharacter = blobUrl.indexOf('?') === -1 ? '?' : '&';
+      let padCharacter = blobUrl.includes('?') ? '&' : '?';
       blobUrl = blobUrl.replace(/#|$/, padCharacter + '$&');
     }
     window.open(blobUrl, '_parent');

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -192,7 +192,7 @@ class PDFLinkService {
    */
   setHash(hash) {
     let pageNumber, dest;
-    if (hash.indexOf('=') >= 0) {
+    if (hash.includes('=')) {
       let params = parseQueryString(hash);
       if ('search' in params) {
         this.eventBus.dispatch('findfromurlhash', {
@@ -215,7 +215,7 @@ class PDFLinkService {
         let zoomArg = zoomArgs[0];
         let zoomArgNumber = parseFloat(zoomArg);
 
-        if (zoomArg.indexOf('Fit') === -1) {
+        if (!zoomArg.includes('Fit')) {
           // If the zoomArg is a number, it has to get divided by 100. If it's
           // a string, it should stay as it is.
           dest = [null, { name: 'XYZ', },

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -111,8 +111,8 @@ PDFPrintService.prototype = {
       return;
     }
     this.printContainer.textContent = '';
-    if (this.pageStyleSheet && this.pageStyleSheet.parentNode) {
-      this.pageStyleSheet.parentNode.removeChild(this.pageStyleSheet);
+    if (this.pageStyleSheet) {
+      this.pageStyleSheet.remove();
       this.pageStyleSheet = null;
     }
     this.scratchCanvas.width = this.scratchCanvas.height = 0;

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -420,7 +420,7 @@ function getPDFFileNameFromURL(url, defaultFilename = 'document.pdf') {
                           reFilename.exec(splitURI[3]);
   if (suggestedFilename) {
     suggestedFilename = suggestedFilename[0];
-    if (suggestedFilename.indexOf('%') !== -1) {
+    if (suggestedFilename.includes('%')) {
       // URL-encoded %2Fpath%2Fto%2Ffile.pdf should be file.pdf
       try {
         suggestedFilename =


### PR DESCRIPTION
~~*Currently depends on the `eslint-plugin-mozilla` version upgrade included in PR #9453.*~~

 - Enable the `mozilla/avoid-removeChild` ESLint rule globally

   This rule is available from https://www.npmjs.com/package/eslint-plugin-mozilla, and is enforced in mozilla-central. Note that we have a polyfill for `ChildNode.remove()` and that most cases have already been fixed, see PRs #8056 and #8138.

 - Enable the `mozilla/use-includes-instead-of-indexOf` ESLint rule globally

   This rule is available from https://www.npmjs.com/package/eslint-plugin-mozilla, and is enforced in mozilla-central. Note that we have the necessary `Array`/`String` polyfills and that most cases have already been fixed, see PRs #9032 and #9434.