### PR TITLE
Ensure that `JpegImage.getData` returns the correct data length when `forceRGBoutput == true` (issue 4888)

### DIFF
--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -1083,7 +1083,8 @@ var JpegImage = (function JpegImageClosure() {
                0.116935020465145) +
           k * (-0.000343531996510555 * k + 0.24165260232407);
       }
-      return data;
+      // Ensure that only the converted RGB data is returned.
+      return data.subarray(0, offset);
     },
 
     _convertYcckToCmyk: function convertYcckToCmyk(data) {
@@ -1140,7 +1141,8 @@ var JpegImage = (function JpegImageClosure() {
                193.58209356861505) -
           k * (22.33816807309886 * k + 180.12613974708367);
       }
-      return data;
+      // Ensure that only the converted RGB data is returned.
+      return data.subarray(0, offset);
     },
 
     getData: function getData(width, height, forceRGBoutput) {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -18,7 +18,7 @@ import {
 } from './test_utils';
 import {
   createPromiseCapability, FontType, InvalidPDFException, MissingPDFException,
-  PasswordException, PasswordResponses, StreamType, stringToBytes
+  OPS, PasswordException, PasswordResponses, StreamType, stringToBytes
 } from '../../src/shared/util';
 import {
   DOMCanvasFactory, RenderingCancelledException
@@ -1100,6 +1100,25 @@ describe('api', function() {
         expect(!!oplist.argsArray).toEqual(true);
         expect(oplist.lastChunk).toEqual(true);
         done();
+      }).catch(function (reason) {
+        done.fail(reason);
+      });
+    });
+    it('gets operatorList with JPEG image (issue 4888)', function(done) {
+      let loadingTask = getDocument(buildGetDocumentParams('cmykjpeg.pdf'));
+
+      loadingTask.promise.then((pdfDoc) => {
+        pdfDoc.getPage(1).then((pdfPage) => {
+          pdfPage.getOperatorList().then((opList) => {
+            let imgIndex = opList.fnArray.indexOf(OPS.paintImageXObject);
+            let imgArgs = opList.argsArray[imgIndex];
+            let { data: imgData, } = pdfPage.objs.get(imgArgs[0]);
+
+            expect(imgData instanceof Uint8ClampedArray).toEqual(true);
+            expect(imgData.length).toEqual(90000);
+            done();
+          });
+        });
       }).catch(function (reason) {
         done.fail(reason);
       });


### PR DESCRIPTION
With PDF.js version `2.0` we'll only support browsers with built-in `TypedArray` functionality, hence there doesn't seem to be any good reason not to implement this now.

Fixes #4888.

*Edit:* Please note that I've also run the full test-suite locally, using `nativeImageDecoderSupport: 'none',` instead of https://github.com/mozilla/pdf.js/blob/be2674a0e8d4bf239e08eb33a42d1f4d15fde7ee/test/driver.js#L347 to ensure that everything still works correctly with this patch.