### PR TITLE
Remove the non-`a.click()` case from the `DownloadManager`

### DIFF
--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -22,38 +22,21 @@ if (typeof PDFJSDev !== 'undefined' && !PDFJSDev.test('CHROME || GENERIC')) {
 
 function download(blobUrl, filename) {
   let a = document.createElement('a');
-  if (a.click) {
-    // Use a.click() if available. Otherwise, Chrome might show
-    // "Unsafe JavaScript attempt to initiate a navigation change
-    //  for frame with URL" and not open the PDF at all.
-    // Supported by (not mentioned = untested):
-    // - Firefox 6 - 19 (4- does not support a.click, 5 ignores a.click)
-    // - Chrome 19 - 26 (18- does not support a.click)
-    // - Opera 9 - 12.15
-    // - Internet Explorer 6 - 10
-    // - Safari 6 (5.1- does not support a.click)
-    a.href = blobUrl;
-    a.target = '_parent';
-    // Use a.download if available. This increases the likelihood that
-    // the file is downloaded instead of opened by another PDF plugin.
-    if ('download' in a) {
-      a.download = filename;
-    }
-    // <a> must be in the document for IE and recent Firefox versions.
-    // (otherwise .click() is ignored)
-    (document.body || document.documentElement).appendChild(a);
-    a.click();
-    a.remove();
-  } else {
-    if (window.top === window &&
-        blobUrl.split('#')[0] === window.location.href.split('#')[0]) {
-      // If _parent == self, then opening an identical URL with different
-      // location hash will only cause a navigation, not a download.
-      let padCharacter = blobUrl.includes('?') ? '&' : '?';
-      blobUrl = blobUrl.replace(/#|$/, padCharacter + '$&');
-    }
-    window.open(blobUrl, '_parent');
+  if (!a.click) {
+    throw new Error('DownloadManager: "a.click()" is not supported.');
   }
+  a.href = blobUrl;
+  a.target = '_parent';
+  // Use a.download if available. This increases the likelihood that
+  // the file is downloaded instead of opened by another PDF plugin.
+  if ('download' in a) {
+    a.download = filename;
+  }
+  // <a> must be in the document for IE and recent Firefox versions,
+  // otherwise .click() is ignored.
+  (document.body || document.documentElement).appendChild(a);
+  a.click();
+  a.remove();
 }
 
 class DownloadManager {


### PR DESCRIPTION
With PDF.js version `2.0`, all the browsers we intend to support implements `a.click()`; see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click#Browser_compatibility.

*Edit:* Smaller diff with https://github.com/mozilla/pdf.js/pull/9473/files?w=1.