### PR TITLE
Remove the actual `enableHandToolOnLoad` preference (PR 9040 follow-up)

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -26,11 +26,6 @@
       ],
       "default": 0
     },
-    "enableHandToolOnLoad": {
-      "description": "Deprecated. Set cursorToolOnLoad to 1 to enable the hand tool by default.",
-      "type": "boolean",
-      "default": false
-    },
     "cursorToolOnLoad": {
       "title": "Cursor tool on load",
       "description": "The cursor tool that is enabled upon load.\n 0 = Text selection tool.\n 1 = Hand tool.",

--- a/web/default_preferences.json
+++ b/web/default_preferences.json
@@ -2,7 +2,6 @@
   "showPreviousViewOnLoad": true,
   "defaultZoomValue": "",
   "sidebarViewOnLoad": 0,
-  "enableHandToolOnLoad": false,
   "cursorToolOnLoad": 0,
   "enableWebGL": false,
   "pdfBugEnabled": false,


### PR DESCRIPTION
This should have been removed as part of PR #9040, but was simply overlooked.