### PR TITLE
[api-major] Move the worker related options from the global `PDFJS` object

### DIFF
--- a/examples/acroforms/acroforms.js
+++ b/examples/acroforms/acroforms.js
@@ -15,7 +15,8 @@
 
 'use strict';
 
-PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
+PDFJS.GlobalWorkerOptions.workerSrc =
+  '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
 var DEFAULT_URL = '../../test/pdfs/f1040.pdf';
 var DEFAULT_SCALE = 1.0;

--- a/examples/browserify/main.js
+++ b/examples/browserify/main.js
@@ -8,7 +8,8 @@ require('pdfjs-dist');
 var pdfPath = '../helloworld/helloworld.pdf';
 
 // Setting worker path to worker bundle.
-PDFJS.workerSrc = '../../build/browserify/pdf.worker.bundle.js';
+PDFJS.GlobalWorkerOptions.workerSrc =
+  '../../build/browserify/pdf.worker.bundle.js';
 
 // Loading a document.
 var loadingTask = PDFJS.getDocument(pdfPath);

--- a/examples/components/pageviewer.js
+++ b/examples/components/pageviewer.js
@@ -22,7 +22,8 @@ if (!PDFJS.PDFViewer || !PDFJS.getDocument) {
 
 // The workerSrc property shall be specified.
 //
-PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
+PDFJS.GlobalWorkerOptions.workerSrc =
+  '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
 // Some PDFs need external cmaps.
 //

--- a/examples/components/simpleviewer.js
+++ b/examples/components/simpleviewer.js
@@ -22,7 +22,8 @@ if (!PDFJS.PDFViewer || !PDFJS.getDocument) {
 
 // The workerSrc property shall be specified.
 //
-PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
+PDFJS.GlobalWorkerOptions.workerSrc =
+  '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
 // Some PDFs need external cmaps.
 //

--- a/examples/components/singlepageviewer.js
+++ b/examples/components/singlepageviewer.js
@@ -22,7 +22,8 @@ if (!PDFJS.PDFSinglePageViewer || !PDFJS.getDocument) {
 
 // The workerSrc property shall be specified.
 //
-PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
+PDFJS.GlobalWorkerOptions.workerSrc =
+  '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
 // Some PDFs need external cmaps.
 //

--- a/examples/helloworld/hello.js
+++ b/examples/helloworld/hello.js
@@ -2,17 +2,19 @@
 
 // In production, the bundled pdf.js shall be used instead of SystemJS.
 Promise.all([System.import('pdfjs/display/api'),
-             System.import('pdfjs/display/global'),
+             System.import('pdfjs/display/worker_options'),
              System.import('pdfjs/display/network'),
              System.resolve('pdfjs/worker_loader')])
        .then(function (modules) {
-  var api = modules[0], global = modules[1], network = modules[2];
+  var api = modules[0];
+  var GlobalWorkerOptions = modules[1].GlobalWorkerOptions;
+  var network = modules[2];
   api.setPDFNetworkStreamFactory((params) => {
     return new network.PDFNetworkStream(params);
   });
 
   // In production, change this to point to the built `pdf.worker.js` file.
-  global.PDFJS.workerSrc = modules[3];
+  GlobalWorkerOptions.workerSrc = modules[3];
 
   // Fetch the PDF document from the URL using promises.
   api.getDocument('helloworld.pdf').then(function (pdf) {

--- a/examples/learning/helloworld.html
+++ b/examples/learning/helloworld.html
@@ -22,7 +22,8 @@
   //
   // The workerSrc property shall be specified.
   //
-  PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
+  PDFJS.GlobalWorkerOptions.workerSrc =
+    '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
   //
   // Asynchronous download PDF

--- a/examples/learning/helloworld64.html
+++ b/examples/learning/helloworld64.html
@@ -34,7 +34,8 @@
   //
   // The workerSrc property shall be specified.
   //
-  PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
+  PDFJS.GlobalWorkerOptions.workerSrc =
+    '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
   // Opening PDF by passing its binary data as a string. It is still preferable
   // to use Uint8Array, but string or array-like structure will work too.

--- a/examples/learning/prevnext.html
+++ b/examples/learning/prevnext.html
@@ -33,7 +33,8 @@
   // pdf.js's one, or the pdf.js is executed via eval(), the workerSrc property
   // shall be specified.
   //
-  // PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
+  // PDFJS.GlobalWorkerOptions.workerSrc =
+  //   '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
   var pdfDoc = null,
       pageNum = 1,

--- a/examples/mobile-viewer/viewer.js
+++ b/examples/mobile-viewer/viewer.js
@@ -24,9 +24,11 @@ if (typeof PDFJS === 'undefined' || !PDFJS.PDFViewer || !PDFJS.getDocument) {
 var USE_ONLY_CSS_ZOOM = true;
 var TEXT_LAYER_MODE = 0; // DISABLE
 PDFJS.maxImageSize = 1024 * 1024;
-PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 PDFJS.cMapUrl = '../../node_modules/pdfjs-dist/cmaps/';
 PDFJS.cMapPacked = true;
+
+PDFJS.GlobalWorkerOptions.workerSrc =
+  '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
 var DEFAULT_URL = '../../web/compressed.tracemonkey-pldi-09.pdf';
 var DEFAULT_SCALE_DELTA = 1.1;

--- a/examples/svgviewer/viewer.js
+++ b/examples/svgviewer/viewer.js
@@ -39,16 +39,21 @@ function renderDocument(pdf, svgLib) {
 Promise.all([System.import('pdfjs/display/api'),
              System.import('pdfjs/display/svg'),
              System.import('pdfjs/display/global'),
+             System.import('pdfjs/display/worker_options'),
              System.import('pdfjs/display/network'),
              System.resolve('pdfjs/worker_loader')])
        .then(function (modules) {
-  var api = modules[0], svg = modules[1], global = modules[2], network = modules[3];
+  var api = modules[0];
+  var svg = modules[1];
+  var global = modules[2];
+  var GlobalWorkerOptions = modules[3].GlobalWorkerOptions;
+  var network = modules[4];
   api.setPDFNetworkStreamFactory((params) => {
     return new network.PDFNetworkStream(params);
   });
 
   // In production, change this to point to the built `pdf.worker.js` file.
-  global.PDFJS.workerSrc = modules[4];
+  GlobalWorkerOptions.workerSrc = modules[5];
 
   // In production, change this to point to where the cMaps are placed.
   global.PDFJS.cMapUrl = '../../external/bcmaps/';

--- a/examples/text-only/pdf2svg.js
+++ b/examples/text-only/pdf2svg.js
@@ -18,7 +18,8 @@ var PAGE_NUMBER = 1;
 var PAGE_SCALE = 1.5;
 var SVG_NS = 'http://www.w3.org/2000/svg';
 
-PDFJS.workerSrc = '../../node_modules/pdfjs-dist/build/pdf.worker.js';
+PDFJS.GlobalWorkerOptions.workerSrc =
+  '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
 function buildSVG(viewport, textContent) {
   // Building SVG with size of the viewport (for simplicity)

--- a/examples/webpack/main.js
+++ b/examples/webpack/main.js
@@ -8,7 +8,8 @@ var pdfjsLib = require('pdfjs-dist');
 var pdfPath = '../helloworld/helloworld.pdf';
 
 // Setting worker path to worker bundle.
-pdfjsLib.PDFJS.workerSrc = '../../build/webpack/pdf.worker.bundle.js';
+pdfjsLib.GlobalWorkerOptions.workerSrc =
+  '../../build/webpack/pdf.worker.bundle.js';
 
 // Loading a document.
 var loadingTask = pdfjsLib.getDocument(pdfPath);

--- a/external/dist/webpack.js
+++ b/external/dist/webpack.js
@@ -18,7 +18,7 @@ var pdfjs = require('./build/pdf.js');
 var PdfjsWorker = require('worker-loader!./build/pdf.worker.js');
 
 if (typeof window !== 'undefined' && 'Worker' in window) {
-  pdfjs.PDFJS.workerPort = new PdfjsWorker();
+  pdfjs.GlobalWorkerOptions.workerPort = new PdfjsWorker();
 }
 
 module.exports = pdfjs;

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -27,6 +27,7 @@ import {
 import { FontFaceObject, FontLoader } from './font_loader';
 import { CanvasGraphics } from './canvas';
 import globalScope from '../shared/global_scope';
+import { GlobalWorkerOptions } from './worker_options';
 import { Metadata } from './metadata';
 import { PDFDataTransportStream } from './transport_stream';
 import { WebGLContext } from './webgl';
@@ -240,8 +241,8 @@ function getDocument(src) {
 
   if (!worker) {
     // Worker was not provided -- creating and owning our own. If message port
-    // is specified in global settings, using it.
-    var workerPort = getDefaultSetting('workerPort');
+    // is specified in global worker options, using it.
+    let workerPort = GlobalWorkerOptions.workerPort;
     worker = workerPort ? PDFWorker.fromPort(workerPort) : new PDFWorker();
     task._worker = worker;
   }

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -34,11 +34,11 @@ import { WebGLContext } from './webgl';
 
 var DEFAULT_RANGE_CHUNK_SIZE = 65536; // 2^16 = 65536
 
-var isWorkerDisabled = false;
-var workerSrc;
+let isWorkerDisabled = false;
+let workerSrc;
 var isPostMessageTransfersDisabled = false;
 
-var pdfjsFilePath =
+const pdfjsFilePath =
   typeof PDFJSDev !== 'undefined' &&
   PDFJSDev.test('PRODUCTION && !(MOZCENTRAL || FIREFOX)') &&
   typeof document !== 'undefined' && document.currentScript ?
@@ -47,8 +47,8 @@ var pdfjsFilePath =
 var fakeWorkerFilesLoader = null;
 var useRequireEnsure = false;
 if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('GENERIC')) {
-  // For GENERIC build we need add support of different fake file loaders
-  // for different  frameworks.
+  // For GENERIC build we need to add support for different fake file loaders
+  // for different frameworks.
   if (typeof window === 'undefined') {
     // node.js - disable worker and set require.ensure.
     isWorkerDisabled = true;
@@ -1202,8 +1202,8 @@ var PDFWorker = (function PDFWorkerClosure() {
   let nextFakeWorkerId = 0;
 
   function getWorkerSrc() {
-    if (getDefaultSetting('workerSrc')) {
-      return getDefaultSetting('workerSrc');
+    if (GlobalWorkerOptions.workerSrc) {
+      return GlobalWorkerOptions.workerSrc;
     }
     if (typeof workerSrc !== 'undefined') {
       return workerSrc;
@@ -1213,7 +1213,7 @@ var PDFWorker = (function PDFWorkerClosure() {
         pdfjsFilePath) {
       return pdfjsFilePath.replace(/(\.(?:min\.)?js)(\?.*)?$/i, '.worker$1$2');
     }
-    throw new Error('No PDFJS.workerSrc specified');
+    throw new Error('No "GlobalWorkerOptions.workerSrc" specified.');
   }
 
   function getMainThreadWorkerMessageHandler() {

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -351,8 +351,6 @@ function getDefaultSetting(id) {
       return globalSettings ? globalSettings.cMapPacked : false;
     case 'postMessageTransfers':
       return globalSettings ? globalSettings.postMessageTransfers : true;
-    case 'workerPort':
-      return globalSettings ? globalSettings.workerPort : null;
     case 'workerSrc':
       return globalSettings ? globalSettings.workerSrc : null;
     case 'maxImageSize':

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -351,8 +351,6 @@ function getDefaultSetting(id) {
       return globalSettings ? globalSettings.cMapPacked : false;
     case 'postMessageTransfers':
       return globalSettings ? globalSettings.postMessageTransfers : true;
-    case 'workerSrc':
-      return globalSettings ? globalSettings.workerSrc : null;
     case 'maxImageSize':
       return globalSettings ? globalSettings.maxImageSize : -1;
     case 'isEvalSupported':

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -349,8 +349,6 @@ function getDefaultSetting(id) {
       return globalSettings ? globalSettings.cMapUrl : null;
     case 'cMapPacked':
       return globalSettings ? globalSettings.cMapPacked : false;
-    case 'postMessageTransfers':
-      return globalSettings ? globalSettings.postMessageTransfers : true;
     case 'maxImageSize':
       return globalSettings ? globalSettings.maxImageSize : -1;
     case 'isEvalSupported':

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -123,11 +123,6 @@ PDFJS.disableFontFace = (PDFJS.disableFontFace === undefined ?
 PDFJS.workerSrc = (PDFJS.workerSrc === undefined ? null : PDFJS.workerSrc);
 
 /**
- * Defines global port for worker process. Overrides `workerSrc` setting.
- */
-PDFJS.workerPort = (PDFJS.workerPort === undefined ? null : PDFJS.workerPort);
-
-/**
  * Disable range request loading of PDF files. When enabled and if the server
  * supports partial content requests then the PDF will be fetched in chunks.
  * Enabled (false) by default.

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -113,16 +113,6 @@ PDFJS.disableFontFace = (PDFJS.disableFontFace === undefined ?
                          false : PDFJS.disableFontFace);
 
 /**
- * Path and filename of the worker file. Required when the worker is enabled
- * in development mode. If unspecified in the production build, the worker
- * will be loaded based on the location of the pdf.js file. It is recommended
- * that the workerSrc is set in a custom application to prevent issues caused
- * by third-party frameworks and libraries.
- * @var {string}
- */
-PDFJS.workerSrc = (PDFJS.workerSrc === undefined ? null : PDFJS.workerSrc);
-
-/**
  * Disable range request loading of PDF files. When enabled and if the server
  * supports partial content requests then the PDF will be fetched in chunks.
  * Enabled (false) by default.

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -26,6 +26,7 @@ import {
 } from './api';
 import { AnnotationLayer } from './annotation_layer';
 import globalScope from '../shared/global_scope';
+import { GlobalWorkerOptions } from './worker_options';
 import { Metadata } from './metadata';
 import { renderTextLayer } from './text_layer';
 import { SVGGraphics } from './svg';
@@ -208,6 +209,7 @@ PDFJS.getDocument = getDocument;
 PDFJS.LoopbackPort = LoopbackPort;
 PDFJS.PDFDataRangeTransport = PDFDataRangeTransport;
 PDFJS.PDFWorker = PDFWorker;
+PDFJS.GlobalWorkerOptions = GlobalWorkerOptions;
 
 PDFJS.getFilenameFromUrl = getFilenameFromUrl;
 

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -14,11 +14,10 @@
  */
 
 import {
-  createBlob, createObjectURL, createPromiseCapability, getVerbosityLevel,
-  InvalidPDFException, isLittleEndian, MissingPDFException, OPS, PageViewport,
-  PasswordException, PasswordResponses, removeNullCharacters, setVerbosityLevel,
-  shadow, UnexpectedResponseException, UnknownErrorException,
-  UNSUPPORTED_FEATURES, Util, VERBOSITY_LEVELS
+  createBlob, createObjectURL, createPromiseCapability, InvalidPDFException,
+  isLittleEndian, MissingPDFException, OPS, PageViewport, PasswordException,
+  PasswordResponses, removeNullCharacters, shadow, UnexpectedResponseException,
+  UnknownErrorException, UNSUPPORTED_FEATURES, Util
 } from '../shared/util';
 import { DEFAULT_LINK_REL, getFilenameFromUrl, LinkTarget } from './dom_utils';
 import {
@@ -42,22 +41,6 @@ var PDFJS = globalScope.PDFJS;
 
 PDFJS.pdfBug = false;
 
-if (PDFJS.verbosity !== undefined) {
-  setVerbosityLevel(PDFJS.verbosity);
-}
-delete PDFJS.verbosity;
-Object.defineProperty(PDFJS, 'verbosity', {
-  get() {
-    return getVerbosityLevel();
-  },
-  set(level) {
-    setVerbosityLevel(level);
-  },
-  enumerable: true,
-  configurable: true,
-});
-
-PDFJS.VERBOSITY_LEVELS = VERBOSITY_LEVELS;
 PDFJS.OPS = OPS;
 PDFJS.UNSUPPORTED_FEATURES = UNSUPPORTED_FEATURES;
 PDFJS.shadow = shadow;

--- a/src/display/global.js
+++ b/src/display/global.js
@@ -148,13 +148,6 @@ PDFJS.disableAutoFetch = (PDFJS.disableAutoFetch === undefined ?
 PDFJS.pdfBug = (PDFJS.pdfBug === undefined ? false : PDFJS.pdfBug);
 
 /**
- * Enables transfer usage in postMessage for ArrayBuffers.
- * @var {boolean}
- */
-PDFJS.postMessageTransfers = (PDFJS.postMessageTransfers === undefined ?
-                              true : PDFJS.postMessageTransfers);
-
-/**
  * Disables URL.createObjectURL usage.
  * @var {boolean}
  */

--- a/src/display/worker_options.js
+++ b/src/display/worker_options.js
@@ -1,0 +1,39 @@
+/* Copyright 2018 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const GlobalWorkerOptions = Object.create(null);
+
+/**
+ * Defines global port for worker process. Overrides the `workerSrc` option.
+ * @var {Object}
+ */
+GlobalWorkerOptions.workerPort = (GlobalWorkerOptions.workerPort === undefined ?
+                                  null : GlobalWorkerOptions.workerPort);
+
+/**
+ * Path and filename of the worker file. Required when workers are enabled in
+ * development mode. If unspecified in production builds, the worker will be
+ * loaded based on the location of the `pdf.js` file.
+ *
+ * NOTE: The `workerSrc` should always be set in custom applications, in order
+ *       to prevent issues caused by third-party frameworks and libraries.
+ * @var {string}
+ */
+GlobalWorkerOptions.workerSrc = (GlobalWorkerOptions.workerSrc === undefined ?
+                                 '' : GlobalWorkerOptions.workerSrc);
+
+export {
+  GlobalWorkerOptions,
+};

--- a/src/doc_helper.js
+++ b/src/doc_helper.js
@@ -23,19 +23,9 @@
  * to the PDF.js.
  * @constructor
  */
-function PDFJS() {
+function PDFJS() { // eslint-disable-line no-unused-vars
   // Mock class constructor. See src/display/api.js.
 }
-
-/**
- * Controls the logging level.
- * The constants from PDFJS.VERBOSITY_LEVELS should be used:
- * - errors
- * - warnings [default]
- * - infos
- * @var {number}
- */
-PDFJS.verbosity = PDFJS.VERBOSITY_LEVELS.warnings;
 
 /**
  * Represents the eventual result of an asynchronous operation.

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -28,6 +28,7 @@ var pdfjsDisplayTextLayer = require('./display/text_layer.js');
 var pdfjsDisplayAnnotationLayer = require('./display/annotation_layer.js');
 var pdfjsDisplayDOMUtils = require('./display/dom_utils.js');
 var pdfjsDisplaySVG = require('./display/svg.js');
+let pdfjsDisplayWorkerOptions = require('./display/worker_options.js');
 
 if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
   const isNodeJS = require('./shared/is_node.js');
@@ -93,3 +94,4 @@ exports.RenderingCancelledException =
 exports.getFilenameFromUrl = pdfjsDisplayDOMUtils.getFilenameFromUrl;
 exports.LinkTarget = pdfjsDisplayDOMUtils.LinkTarget;
 exports.addLinkAttributes = pdfjsDisplayDOMUtils.addLinkAttributes;
+exports.GlobalWorkerOptions = pdfjsDisplayWorkerOptions.GlobalWorkerOptions;

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -83,6 +83,7 @@ exports.NativeImageDecoding = pdfjsSharedUtil.NativeImageDecoding;
 exports.UnexpectedResponseException =
   pdfjsSharedUtil.UnexpectedResponseException;
 exports.OPS = pdfjsSharedUtil.OPS;
+exports.VerbosityLevel = pdfjsSharedUtil.VerbosityLevel;
 exports.UNSUPPORTED_FEATURES = pdfjsSharedUtil.UNSUPPORTED_FEATURES;
 exports.createValidAbsoluteUrl = pdfjsSharedUtil.createValidAbsoluteUrl;
 exports.createObjectURL = pdfjsSharedUtil.createObjectURL;

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -142,10 +142,10 @@ var FontType = {
   MMTYPE1: 10,
 };
 
-var VERBOSITY_LEVELS = {
-  errors: 0,
-  warnings: 1,
-  infos: 5,
+const VerbosityLevel = {
+  ERRORS: 0,
+  WARNINGS: 1,
+  INFOS: 5,
 };
 
 var CMapCompressionType = {
@@ -251,10 +251,12 @@ var OPS = {
   constructPath: 91,
 };
 
-var verbosity = VERBOSITY_LEVELS.warnings;
+let verbosity = VerbosityLevel.WARNINGS;
 
 function setVerbosityLevel(level) {
-  verbosity = level;
+  if (Number.isInteger(level)) {
+    verbosity = level;
+  }
 }
 
 function getVerbosityLevel() {
@@ -265,19 +267,19 @@ function getVerbosityLevel() {
 // as warning that Workers were disabled, which is important to devs but not
 // end users.
 function info(msg) {
-  if (verbosity >= VERBOSITY_LEVELS.infos) {
+  if (verbosity >= VerbosityLevel.INFOS) {
     console.log('Info: ' + msg);
   }
 }
 
 // Non-fatal warnings.
 function warn(msg) {
-  if (verbosity >= VERBOSITY_LEVELS.warnings) {
+  if (verbosity >= VerbosityLevel.WARNINGS) {
     console.log('Warning: ' + msg);
   }
 }
 
-// Deprecated API function -- display regardless of the PDFJS.verbosity setting.
+// Deprecated API function -- display regardless of the `verbosity` setting.
 function deprecated(details) {
   console.log('Deprecated API usage: ' + details);
 }
@@ -1573,7 +1575,7 @@ export {
   FONT_IDENTITY_MATRIX,
   IDENTITY_MATRIX,
   OPS,
-  VERBOSITY_LEVELS,
+  VerbosityLevel,
   UNSUPPORTED_FEATURES,
   AnnotationBorderStyleType,
   AnnotationFieldFlag,

--- a/test/driver.js
+++ b/test/driver.js
@@ -16,9 +16,10 @@
 
 'use strict';
 
-var WAITING_TIME = 100; // ms
-var PDF_TO_CSS_UNITS = 96.0 / 72.0;
+const WAITING_TIME = 100; // ms
+const PDF_TO_CSS_UNITS = 96.0 / 72.0;
 const IMAGE_RESOURCES_PATH = '/web/images/';
+const WORKER_SRC = '../build/generic/build/pdf.worker.js';
 
 /**
  * @class
@@ -267,8 +268,9 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
    * @param {DriverOptions} options
    */
   function Driver(options) {
-    // Configure the global PDFJS object
-    PDFJS.workerSrc = '../build/generic/build/pdf.worker.js';
+    // Configure the global worker options.
+    PDFJS.GlobalWorkerOptions.workerSrc = WORKER_SRC;
+
     PDFJS.cMapPacked = true;
     PDFJS.cMapUrl = '../external/bcmaps/';
     PDFJS.pdfBug = true;

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -24,10 +24,10 @@ import {
   DOMCanvasFactory, RenderingCancelledException
 } from '../../src/display/dom_utils';
 import {
-  getDocument, PDFDocumentProxy, PDFPageProxy, PDFWorker
+  getDocument, PDFDataRangeTransport, PDFDocumentProxy, PDFPageProxy, PDFWorker
 } from '../../src/display/api';
+import { GlobalWorkerOptions } from '../../src/display/worker_options';
 import isNodeJS from '../../src/shared/is_node';
-import { PDFJS } from '../../src/display/global';
 
 describe('api', function() {
   let basicApiFileName = 'basicapi.pdf';
@@ -324,7 +324,7 @@ describe('api', function() {
     }
 
     it('worker created or destroyed', function (done) {
-      var worker = new PDFJS.PDFWorker('test1');
+      var worker = new PDFWorker('test1');
       worker.promise.then(function () {
         expect(worker.name).toEqual('test1');
         expect(!!worker.port).toEqual(true);
@@ -361,7 +361,7 @@ describe('api', function() {
       });
     });
     it('worker created and can be used in getDocument', function (done) {
-      var worker = new PDFJS.PDFWorker('test1');
+      var worker = new PDFWorker('test1');
       var loadingTask = getDocument(
         buildGetDocumentParams(basicApiFileName, {
           worker,
@@ -386,9 +386,9 @@ describe('api', function() {
       });
     });
     it('creates more than one worker', function (done) {
-      var worker1 = new PDFJS.PDFWorker('test1');
-      var worker2 = new PDFJS.PDFWorker('test2');
-      var worker3 = new PDFJS.PDFWorker('test3');
+      var worker1 = new PDFWorker('test1');
+      var worker2 = new PDFWorker('test2');
+      var worker3 = new PDFWorker('test3');
       var ready = Promise.all([worker1.promise, worker2.promise,
         worker3.promise]);
       ready.then(function () {
@@ -406,7 +406,7 @@ describe('api', function() {
     it('gets current workerSrc', function() {
       let workerSrc = PDFWorker.getWorkerSrc();
       expect(typeof workerSrc).toEqual('string');
-      expect(workerSrc).toEqual(PDFJS.workerSrc);
+      expect(workerSrc).toEqual(GlobalWorkerOptions.workerSrc);
     });
   });
   describe('PDFDocument', function() {
@@ -1305,7 +1305,7 @@ describe('api', function() {
       var fetches = 0;
       var getDocumentPromise = getDocumentData().then(function (data) {
         var initialData = data.subarray(0, initialDataLength);
-        transport = new PDFJS.PDFDataRangeTransport(data.length, initialData);
+        transport = new PDFDataRangeTransport(data.length, initialData);
         transport.requestDataRange = function (begin, end) {
           fetches++;
           waitSome(function () {
@@ -1339,7 +1339,7 @@ describe('api', function() {
       var fetches = 0;
       var getDocumentPromise = getDocumentData().then(function (data) {
         var initialData = data.subarray(0, initialDataLength);
-        transport = new PDFJS.PDFDataRangeTransport(data.length, initialData);
+        transport = new PDFDataRangeTransport(data.length, initialData);
         transport.requestDataRange = function (begin, end) {
           fetches++;
           if (fetches === 1) {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -324,7 +324,7 @@ describe('api', function() {
     }
 
     it('worker created or destroyed', function (done) {
-      var worker = new PDFWorker('test1');
+      var worker = new PDFWorker({ name: 'test1', });
       worker.promise.then(function () {
         expect(worker.name).toEqual('test1');
         expect(!!worker.port).toEqual(true);
@@ -361,7 +361,7 @@ describe('api', function() {
       });
     });
     it('worker created and can be used in getDocument', function (done) {
-      var worker = new PDFWorker('test1');
+      var worker = new PDFWorker({ name: 'test1', });
       var loadingTask = getDocument(
         buildGetDocumentParams(basicApiFileName, {
           worker,
@@ -386,9 +386,9 @@ describe('api', function() {
       });
     });
     it('creates more than one worker', function (done) {
-      var worker1 = new PDFWorker('test1');
-      var worker2 = new PDFWorker('test2');
-      var worker3 = new PDFWorker('test3');
+      var worker1 = new PDFWorker({ name: 'test1', });
+      var worker2 = new PDFWorker({ name: 'test2', });
+      var worker3 = new PDFWorker({ name: 'test3', });
       var ready = Promise.all([worker1.promise, worker2.promise,
         worker3.promise]);
       ready.then(function () {

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -42,8 +42,8 @@
 
 function initializePDFJS(callback) {
   Promise.all([
-    'pdfjs/display/global',
     'pdfjs/display/api',
+    'pdfjs/display/worker_options',
     'pdfjs/display/network',
     'pdfjs/display/fetch_stream',
     'pdfjs/shared/is_node',
@@ -77,9 +77,9 @@ function initializePDFJS(callback) {
     'pdfjs-test/unit/util_stream_spec',
   ].map(function (moduleName) {
     return SystemJS.import(moduleName);
-  })).then(function (modules) {
-    var displayGlobal = modules[0];
-    var displayApi = modules[1];
+  })).then(function(modules) {
+    var displayApi = modules[0];
+    const GlobalWorkerOptions = modules[1].GlobalWorkerOptions;
     var PDFNetworkStream = modules[2].PDFNetworkStream;
     var PDFFetchStream = modules[3].PDFFetchStream;
     const isNodeJS = modules[4];
@@ -101,7 +101,7 @@ function initializePDFJS(callback) {
     }
 
     // Configure the worker.
-    displayGlobal.PDFJS.workerSrc = '../../build/generic/build/pdf.worker.js';
+    GlobalWorkerOptions.workerSrc = '../../build/generic/build/pdf.worker.js';
 
     callback();
   });

--- a/web/app.js
+++ b/web/app.js
@@ -740,6 +740,8 @@ let PDFViewerApplication = {
                PDFJSDev.test('FIREFOX || MOZCENTRAL || CHROME')) {
       parameters.docBaseUrl = this.baseUrl;
     }
+    // TODO: Remove this once all options are moved from the `PDFJS` object.
+    parameters.verbosity = PDFJS.verbosity;
 
     if (args) {
       for (let prop in args) {

--- a/web/app.js
+++ b/web/app.js
@@ -21,9 +21,9 @@ import {
   ProgressBar, RendererType, TextLayerMode
 } from './ui_utils';
 import {
-  build, createBlob, getDocument, getFilenameFromUrl, InvalidPDFException,
-  LinkTarget, MissingPDFException, OPS, PDFJS, PDFWorker, shadow,
-  UnexpectedResponseException, UNSUPPORTED_FEATURES, version
+  build, createBlob, getDocument, getFilenameFromUrl, GlobalWorkerOptions,
+  InvalidPDFException, LinkTarget, MissingPDFException, OPS, PDFJS, PDFWorker,
+  shadow, UnexpectedResponseException, UNSUPPORTED_FEATURES, version
 } from 'pdfjs-lib';
 import { CursorTool, PDFCursorTools } from './pdf_cursor_tools';
 import { PDFRenderingQueue, RenderingStates } from './pdf_rendering_queue';
@@ -54,11 +54,11 @@ function configure(PDFJS) {
   PDFJS.imageResourcesPath = './images/';
   if (typeof PDFJSDev !== 'undefined' &&
       PDFJSDev.test('FIREFOX || MOZCENTRAL || GENERIC || CHROME')) {
-    PDFJS.workerSrc = '../build/pdf.worker.js';
+    GlobalWorkerOptions.workerSrc = '../build/pdf.worker.js';
   }
   if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION')) {
     PDFJS.cMapUrl = '../external/bcmaps/';
-    PDFJS.workerSrc = '../src/worker_loader.js';
+    GlobalWorkerOptions.workerSrc = '../src/worker_loader.js';
   } else {
     PDFJS.cMapUrl = '../web/cmaps/';
   }


### PR DESCRIPTION
*This PR extracts the worker related changes from PR #9185.*

Please note that, as mentioned in the first commit message, it unfortunately seems to me that we cannot convert *all* of the worker options to parameters on `getDocument`/`PDFWorker` instead (since we probably need to maintain a reasonably easy way to configure workers).
However the `workerPort`/`workerSrc` options can at least be moved from the `PDFJS` object, which does seem worthwhile to me since it gets us closer to be able to remove `PDFJS` completely.

*Edit:* Once this lands I'll rebase/rewrite PR #9185 on top of it, which should thus take care of the major outstanding work required for version `2.0`.

@yurydelendik, @timvandermeij Sorry to bother you again, but any chance that (either of) you could review this PR to unblock the final removal of all options from the global `PDFJS` object (in #9185)?
Also, based on a quick look, it might not actually be that difficult to remove the global `PDFJS` object completely once this and then #9185 lands.

*Edit 2:* Based on this PR, the final round of changes would be https://github.com/Snuffleupagus/pdf.js/compare/refactor-worker-options...Snuffleupagus:refactor-api-options, which converts all remaining options *and* removes `PDFJS` completely. 