### PR TITLE
Ability to handle URI annotations

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -45,7 +45,12 @@ class AnnotationElementFactory {
 
     switch (subtype) {
       case AnnotationType.LINK:
-        return new LinkAnnotationElement(parameters);
+        let data = parameters.data;
+        if (data.unsafeUrl !== undefined && data.url === undefined && data.dest === undefined) {
+          return new URIAnnotationElement(parameters);
+        } else {
+          return new LinkAnnotationElement(parameters);
+        }
 
       case AnnotationType.TEXT:
         return new TextAnnotationElement(parameters);
@@ -335,6 +340,43 @@ class LinkAnnotationElement extends AnnotationElement {
       return false;
     };
     link.className = 'internalLink';
+  }
+}
+
+class URIAnnotationElement extends AnnotationElement {
+  constructor(parameters) {
+    super(parameters, true);
+  }
+
+  /**
+   * Render the link annotation's HTML element in the empty container.
+   *
+   * @public
+   * @memberof URIAnnotationElement
+   * @returns {HTMLSectionElement}
+   */
+  render() {
+    this.container.className = 'uriAnnotation';
+
+    let link = document.createElement('a');
+    this._bindURILink(link, this.data);
+
+    this.container.appendChild(link);
+    return this.container;
+  }
+
+  /**
+   * Bind event handler to external links
+   *
+   * @private
+   * @param {Object} link
+   * @memberof LinkAnnotationElement
+   */
+  _bindURILink(link, data) {
+    link.onclick = () => {
+      this.linkService.handleURILink(link, data);
+      return false;
+    };
   }
 }
 

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -45,12 +45,16 @@ class AnnotationElementFactory {
 
     switch (subtype) {
       case AnnotationType.LINK:
+        let elem;
         let data = parameters.data;
-        if (data.unsafeUrl !== undefined && data.url === undefined && data.dest === undefined) {
-          return new URIAnnotationElement(parameters);
+        if (data.unsafeUrl !== undefined &&
+            data.url === undefined &&
+            data.dest === undefined) {
+          elem = new URIAnnotationElement(parameters);
         } else {
-          return new LinkAnnotationElement(parameters);
+          elem = new LinkAnnotationElement(parameters);
         }
+        return elem;
 
       case AnnotationType.TEXT:
         return new TextAnnotationElement(parameters);

--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -18,6 +18,7 @@
 }
 
 .annotationLayer .linkAnnotation > a,
+.annotationLayer .uriAnnotation > a,
 .annotationLayer .buttonWidgetAnnotation.pushButton > a {
   position: absolute;
   font-size: 1em;
@@ -25,6 +26,7 @@
   left: 0;
   width: 100%;
   height: 100%;
+  cursor: pointer;
 }
 
 .annotationLayer .linkAnnotation > a:hover,
@@ -32,6 +34,12 @@
   opacity: 0.2;
   background: #ff0;
   box-shadow: 0px 2px 10px #ff0;
+}
+
+.annotationLayer .uriAnnotation > a:hover{
+  opacity: 0.1;
+  background: #00f;
+  box-shadow: 0px 2px 10px #00f;
 }
 
 .annotationLayer .textAnnotation img {

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -90,6 +90,13 @@ class PDFLinkService {
   }
 
   /**
+   * @param {Object} link - HTML link element
+   */
+  handleURILink(link, data) {
+    this.eventBus.dispatch('uriclicked', { uri: data.unsafeUrl, });
+  }
+
+  /**
    * @param {string|Array} dest - The named, or explicit, PDF destination.
    */
   navigateTo(dest) {
@@ -432,6 +439,11 @@ class SimpleLinkService {
    * @param {number} value
    */
   set rotation(value) {}
+
+  /**
+   * @param {Object} link - HTML link element
+   */
+  handleURILink(link, data) {}
 
   /**
    * @param dest - The PDF destination object.


### PR DESCRIPTION
Added URI annotation for links where schema is different to 'http' (like 'media://' etc.). It allow to handle clicks on those links and do something in viewer (display media player for example).