### PR TITLE
Fix regressions in preferences in Chrome

### DIFF
--- a/extensions/chromium/options/migration.js
+++ b/extensions/chromium/options/migration.js
@@ -78,6 +78,9 @@ limitations under the License.
     storageSync.get([
       'enableHandToolOnLoad',
       'cursorToolOnLoad',
+      'disableTextLayer',
+      'enhanceTextSelection',
+      'textLayerMode',
     ], function(items) {
       // Migration code for https://github.com/mozilla/pdf.js/pull/7635.
       if (typeof items.enableHandToolOnLoad === 'boolean') {
@@ -91,6 +94,23 @@ limitations under the License.
           });
         } else {
           storageSync.remove('enableHandToolOnLoad');
+        }
+      }
+      // Migration code for https://github.com/mozilla/pdf.js/pull/9479.
+      if (typeof items.disableTextLayer === 'boolean') {
+        var textLayerMode = items.disableTextLayer ? 0 :
+          items.enhanceTextSelection ? 2 : 1;
+        if (textLayerMode !== 1) {
+          // Overwrite if computed textLayerMode is not the default value (1).
+          storageSync.set({
+            textLayerMode: textLayerMode,
+          }, function() {
+            if (!chrome.runtime.lastError) {
+              storageSync.remove(['disableTextLayer', 'enhanceTextSelection']);
+            }
+          });
+        } else {
+          storageSync.remove(['disableTextLayer', 'enhanceTextSelection']);
         }
       }
     });

--- a/extensions/chromium/options/options.html
+++ b/extensions/chromium/options/options.html
@@ -92,6 +92,19 @@ body {
 </div>
 </template>
 
+<template id="textLayerMode-template">
+<div class="settings-row">
+  <label>
+    <span></span>
+    <select>
+      <option value="0">Disable text selection</option>
+      <option value="1">Enable text selection</option>
+      <option value="2">Enable enhanced mode (experimental)</option>
+    </select>
+  </label>
+</div>
+</template>
+
 <template id="externalLinkTarget-template">
 <div class="settings-row">
   <label>

--- a/extensions/chromium/options/options.js
+++ b/extensions/chromium/options/options.js
@@ -81,6 +81,8 @@ Promise.all([
       renderPreference = renderSidebarViewOnLoad(prefSchema.title);
     } else if (prefName === 'cursorToolOnLoad') {
       renderPreference = renderCursorToolOnLoad(prefSchema.title);
+    } else if (prefName === 'textLayerMode') {
+      renderPreference = renderTextLayerMode(prefSchema.title);
     } else if (prefName === 'externalLinkTarget') {
       renderPreference = renderExternalLinkTarget(prefSchema.title);
     } else {
@@ -206,6 +208,23 @@ function renderCursorToolOnLoad(shortDescription) {
   select.onchange = function() {
     storageArea.set({
       cursorToolOnLoad: parseInt(this.value),
+    });
+  };
+  wrapper.querySelector('span').textContent = shortDescription;
+  document.getElementById('settings-boxes').appendChild(wrapper);
+
+  function renderPreference(value) {
+    select.value = value;
+  }
+  return renderPreference;
+}
+
+function renderTextLayerMode(shortDescription) {
+  var wrapper = importTemplate('textLayerMode-template');
+  var select = wrapper.querySelector('select');
+  select.onchange = function() {
+    storageArea.set({
+      textLayerMode: parseInt(this.value),
     });
   };
   wrapper.querySelector('span').textContent = shortDescription;

--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -75,6 +75,16 @@
       "type": "boolean",
       "default": false
     },
+    "disableTextLayer": {
+      "description": "DEPRECATED. Set textLayerMode to 0 to disable the text selection layer by default.",
+      "type": "boolean",
+      "default": false
+    },
+    "enhanceTextSelection": {
+      "description": "DEPRECATED. Set textLayerMode to 2 to use the enhanced text selection layer by default.",
+      "type": "boolean",
+      "default": false
+    },
     "textLayerMode": {
       "title": "Text layer mode",
       "description": "Controls if the text layer is enabled, and the selection mode that is used.\n 0 = Disabled.\n 1 = Enabled.\n 2 = (Experimental) Enabled, with enhanced text selection.",

--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -26,6 +26,11 @@
       ],
       "default": 0
     },
+    "enableHandToolOnLoad": {
+      "description": "DEPRECATED. Set cursorToolOnLoad to 1 to enable the hand tool by default.",
+      "type": "boolean",
+      "default": false
+    },
     "cursorToolOnLoad": {
       "title": "Cursor tool on load",
       "description": "The cursor tool that is enabled upon load.\n 0 = Text selection tool.\n 1 = Hand tool.",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -192,6 +192,13 @@ function getVersionJSON() {
 function checkChromePreferencesFile(chromePrefsPath, webPrefsPath) {
   var chromePrefs = JSON.parse(fs.readFileSync(chromePrefsPath).toString());
   var chromePrefsKeys = Object.keys(chromePrefs.properties);
+  chromePrefsKeys = chromePrefsKeys.filter(function (key) {
+    var description = chromePrefs.properties[key].description;
+    // Deprecated keys are allowed in the managed preferences file.
+    // The code maintained is responsible for adding migration logic to
+    // extensions/chromium/options/migration.js and web/chromecom.js .
+    return !description || !description.startsWith('DEPRECATED.');
+  });
   chromePrefsKeys.sort();
   var webPrefs = JSON.parse(fs.readFileSync(webPrefsPath).toString());
   var webPrefsKeys = Object.keys(webPrefs);

--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -308,16 +308,25 @@ class ChromePreferences extends BasePreferences {
         // Get preferences as set by the system administrator.
         // See extensions/chromium/preferences_schema.json for more information.
         // These preferences can be overridden by the user.
-        chrome.storage.managed.get(this.defaults, function(items) {
+
+        // Deprecated preferences are removed from web/default_preferences.json,
+        // but kept in extensions/chromium/preferences_schema.json for backwards
+        // compatibility with managed preferences.
+        let defaultManagedPrefs = Object.assign({
+          enableHandToolOnLoad: false,
+        }, this.defaults);
+
+        chrome.storage.managed.get(defaultManagedPrefs, function(items) {
+          items = items || defaultManagedPrefs;
           // Migration code for https://github.com/mozilla/pdf.js/pull/7635.
           // Never remove this, because we have no means of modifying managed
           // preferences.
-          if (items && items.enableHandToolOnLoad && !items.cursorToolOnLoad) {
+          if (items.enableHandToolOnLoad && !items.cursorToolOnLoad) {
             // if the old enableHandToolOnLoad has a non-default value,
             // and cursorToolOnLoad has a default value, migrate.
-            items.enableHandToolOnLoad = false;
             items.cursorToolOnLoad = 1;
           }
+          delete items.enableHandToolOnLoad;
           getPreferences(items);
         });
       } else {


### PR DESCRIPTION
Fixes #9489 

The two commits can be reviewed in isolation, see their commit messages.

I've tested this PR by opening the preferences page and observing that the preferences are back. Also, I will shortly open a new bug report to prevent such regressions from happening again.