### PR TITLE
Don't block origin-less blob:-URLs in hosted viewer

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1503,11 +1503,14 @@ if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
         // Hosted or local viewer, allow for any file locations
         return;
       }
-      let fileOrigin = new URL(file, window.location.href).origin;
+      let { origin, protocol, } = new URL(file, window.location.href);
       // Removing of the following line will not guarantee that the viewer will
       // start accepting URLs from foreign origin -- CORS headers on the remote
       // server must be properly configured.
-      if (fileOrigin !== viewerOrigin) {
+      // IE10 / IE11 does not include an origin in `blob:`-URLs. So don't block
+      // any blob:-URL. The browser's same-origin policy will block requests to
+      // blob:-URLs from other origins, so this is safe.
+      if (origin !== viewerOrigin && protocol !== 'blob:') {
         throw new Error('file origin does not match viewer\'s');
       }
     } catch (ex) {


### PR DESCRIPTION
This is to work around a bug in IE11 (and IE10, earlier versions of IE do not support `URL.createObjectURL` for creating `blob:`-URLs anyway) - #9498 .

I could have checked for an empty or null `origin`, but since the browser's Same-origin policy already blocks cross-origin `blob:`-URL requests, I decided to have simpler code and just rely on the browser's same-origin policy enforcement for access control of `blob:`-URLs.