### PR TITLE
Implement a single `getInheritableProperty` utility function

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -62,10 +62,6 @@ var Page = (function PageClosure() {
   }
 
   Page.prototype = {
-    getPageProp: function Page_getPageProp(key) {
-      return this.pageDict.get(key);
-    },
-
     getInheritedPageProp: function Page_getInheritedPageProp(key, getArray) {
       var dict = this.pageDict, valueArray = null, loopCount = 0;
       var MAX_LOOP_COUNT = 100;
@@ -96,7 +92,7 @@ var Page = (function PageClosure() {
     },
 
     get content() {
-      return this.getPageProp('Contents');
+      return this.pageDict.get('Contents');
     },
 
     get resources() {
@@ -126,7 +122,7 @@ var Page = (function PageClosure() {
     },
 
     get userUnit() {
-      var obj = this.getPageProp('UserUnit');
+      var obj = this.pageDict.get('UserUnit');
       if (!isNum(obj) || obj <= 0) {
         obj = DEFAULT_USER_UNIT;
       }

--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -14,9 +14,12 @@
  */
 
 import {
-  bytesToString, isArrayBuffer, isBool, isEmptyObj, isNum, isSpace, isString,
-  log2, ReadableStream, removeNullCharacters, stringToBytes, stringToPDFString
+  bytesToString, getInheritableProperty, isArrayBuffer, isBool, isEmptyObj,
+  isNum, isSpace, isString, log2, ReadableStream, removeNullCharacters,
+  stringToBytes, stringToPDFString
 } from '../../src/shared/util';
+import { Dict, Ref } from '../../src/core/primitives';
+import { XRefMock } from './test_utils';
 
 describe('util', function() {
   describe('bytesToString', function() {
@@ -47,6 +50,106 @@ describe('util', function() {
       let string = Array(length + 1).join('a');
 
       expect(bytesToString(bytes)).toEqual(string);
+    });
+  });
+
+  describe('getInheritableProperty', function() {
+    it('handles non-dictionary arguments', function() {
+      expect(getInheritableProperty({ dict: null, key: 'foo', }))
+        .toEqual(undefined);
+      expect(getInheritableProperty({ dict: undefined, key: 'foo', }))
+        .toEqual(undefined);
+    });
+
+    it('handles dictionaries that do not contain the property', function() {
+      // Empty dictionary.
+      const emptyDict = new Dict();
+      expect(getInheritableProperty({ dict: emptyDict, key: 'foo', }))
+        .toEqual(undefined);
+
+      // Filled dictionary with a different property.
+      const filledDict = new Dict();
+      filledDict.set('bar', 'baz');
+      expect(getInheritableProperty({ dict: filledDict, key: 'foo', }))
+        .toEqual(undefined);
+    });
+
+    it('fetches the property if it is not inherited', function() {
+      const ref = new Ref(10, 0);
+      const xref = new XRefMock([{ ref, data: 'quux', }]);
+      const dict = new Dict(xref);
+
+      // Regular values should be fetched.
+      dict.set('foo', 'bar');
+      expect(getInheritableProperty({ dict, key: 'foo', })).toEqual('bar');
+
+      // Array value should be fetched (with references resolved).
+      dict.set('baz', ['qux', ref]);
+      expect(getInheritableProperty({ dict, key: 'baz', getArray: true, }))
+        .toEqual(['qux', 'quux']);
+    });
+
+    it('fetches the property if it is inherited and present on one level',
+        function() {
+      const ref = new Ref(10, 0);
+      const xref = new XRefMock([{ ref, data: 'quux', }]);
+      const firstDict = new Dict(xref);
+      const secondDict = new Dict(xref);
+      firstDict.set('Parent', secondDict);
+
+      // Regular values should be fetched.
+      secondDict.set('foo', 'bar');
+      expect(getInheritableProperty({ dict: firstDict, key: 'foo', }))
+        .toEqual('bar');
+
+      // Array value should be fetched (with references resolved).
+      secondDict.set('baz', ['qux', ref]);
+      expect(getInheritableProperty({ dict: firstDict, key: 'baz',
+                                      getArray: true, }))
+        .toEqual(['qux', 'quux']);
+    });
+
+    it('fetches the property if it is inherited and present on multiple levels',
+        function() {
+      const ref = new Ref(10, 0);
+      const xref = new XRefMock([{ ref, data: 'quux', }]);
+      const firstDict = new Dict(xref);
+      const secondDict = new Dict(xref);
+      firstDict.set('Parent', secondDict);
+
+      // Regular values should be fetched.
+      firstDict.set('foo', 'bar1');
+      secondDict.set('foo', 'bar2');
+      expect(getInheritableProperty({ dict: firstDict, key: 'foo', }))
+        .toEqual('bar1');
+      expect(getInheritableProperty({ dict: firstDict, key: 'foo',
+                                      getArray: false, stopWhenFound: false, }))
+        .toEqual(['bar1', 'bar2']);
+
+      // Array value should be fetched (with references resolved).
+      firstDict.set('baz', ['qux1', ref]);
+      secondDict.set('baz', ['qux2', ref]);
+      expect(getInheritableProperty({ dict: firstDict, key: 'baz',
+                                      getArray: true, stopWhenFound: false, }))
+        .toEqual([['qux1', 'quux'], ['qux2', 'quux']]);
+    });
+
+    it('stops searching when the loop limit is reached', function() {
+      const dict = new Dict();
+      let currentDict = dict;
+      let parentDict = null;
+      for (let i = 0; i < 150; i++) { // Exceeds the loop limit of 100.
+        parentDict = new Dict();
+        currentDict.set('Parent', parentDict);
+        currentDict = parentDict;
+      }
+      parentDict.set('foo', 'bar'); // Never found because of loop limit.
+      expect(getInheritableProperty({ dict, key: 'foo', })).toEqual(undefined);
+
+      dict.set('foo', 'baz');
+      expect(getInheritableProperty({ dict, key: 'foo', getArray: false,
+                                      stopWhenFound: false, }))
+        .toEqual(['baz']);
     });
   });
 


### PR DESCRIPTION
This function combines the logic of two separate methods into one. The loop limit is also a good thing to have for the calls in `src/core/annotation.js`.

Moreover, since this is important functionality, a set of unit tests and documentation is added.