### PR TITLE
Upstream the changes from: Bug 888600 - Move ContentFrameMessageManager to WebIDL. Part 6: Mark some IDL interfaces as non-scriptable. r=bz.

### DIFF
--- a/extensions/firefox/content/PdfjsChromeUtils.jsm
+++ b/extensions/firefox/content/PdfjsChromeUtils.jsm
@@ -51,8 +51,7 @@ var PdfjsChromeUtils = {
     this._browsers = new WeakSet();
     if (!this._ppmm) {
       // global parent process message manager (PPMM)
-      this._ppmm = Cc["@mozilla.org/parentprocessmessagemanager;1"].
-        getService(Ci.nsIMessageBroadcaster);
+      this._ppmm = Services.ppmm;
       this._ppmm.addMessageListener("PDFJS:Parent:clearUserPref", this);
       this._ppmm.addMessageListener("PDFJS:Parent:setIntPref", this);
       this._ppmm.addMessageListener("PDFJS:Parent:setBoolPref", this);
@@ -61,8 +60,7 @@ var PdfjsChromeUtils = {
       this._ppmm.addMessageListener("PDFJS:Parent:isDefaultHandlerApp", this);
 
       // global dom message manager (MMg)
-      this._mmg = Cc["@mozilla.org/globalmessagemanager;1"].
-        getService(Ci.nsIMessageListenerManager);
+      this._mmg = Services.mm;
       this._mmg.addMessageListener("PDFJS:Parent:displayWarning", this);
 
       this._mmg.addMessageListener("PDFJS:Parent:addEventListener", this);

--- a/extensions/firefox/content/PdfjsContentUtils.jsm
+++ b/extensions/firefox/content/PdfjsContentUtils.jsm
@@ -35,8 +35,7 @@ var PdfjsContentUtils = {
     // child *process* mm, or when loaded into the parent for in-content
     // support the psuedo child process mm 'child PPMM'.
     if (!this._mm) {
-      this._mm = Cc["@mozilla.org/childprocessmessagemanager;1"].
-        getService(Ci.nsISyncMessageSender);
+      this._mm = Services.cpmm;
       this._mm.addMessageListener("PDFJS:Child:updateSettings", this);
 
       Services.obs.addObserver(this, "quit-application");


### PR DESCRIPTION
Please see:
https://bugzilla.mozilla.org/show_bug.cgi?id=888600
https://hg.mozilla.org/mozilla-central/rev/83c87140dc3d