### PR TITLE
Attempt to fix the `Array.prototype.includes` and `String.prototype.includes` polyfills (issue 9514, 9516)

### DIFF
--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable no-extend-native, mozilla/use-includes-instead-of-indexOf */
+/* eslint-disable mozilla/use-includes-instead-of-indexOf */
 /* globals PDFJS */
 
 // Skip compatibility checks for the extensions and if we already ran
@@ -131,7 +131,7 @@ PDFJS.compatibilityChecked = true;
   if (String.prototype.includes) {
     return;
   }
-  String.prototype.includes = require('core-js/fn/string/includes');
+  require('core-js/fn/string/includes');
 })();
 
 // Provides support for Array.prototype.includes in legacy browsers.
@@ -140,7 +140,7 @@ PDFJS.compatibilityChecked = true;
   if (Array.prototype.includes) {
     return;
   }
-  Array.prototype.includes = require('core-js/fn/array/includes');
+  require('core-js/fn/array/includes');
 })();
 
 // Provides support for Math.log2 in legacy browsers.


### PR DESCRIPTION
I don't understand why the previous way importing the polyfills didn't work, and I don't have time to try and figure it out, however this patch seems to fix things.

Fixes #9514.
Fixes #9516.