### PR TITLE
Attempt to handle corrupt PDF documents that inline Page dictionaries in a Kids array (issue 9540)

### DIFF
--- a/test/pdfs/issue9540.pdf.link
+++ b/test/pdfs/issue9540.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/1793688/Problem.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -875,6 +875,13 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue9540",
+       "file": "pdfs/issue9540.pdf",
+       "md5": "7de7979270c9136bdd737428185fbbed",
+       "rounds": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "txt2pdf",
        "file": "pdfs/txt2pdf.pdf",
        "md5": "02cefa0f5e8d96313bb05163b2f88c8c",

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -354,6 +354,9 @@ class PDFLinkService {
    * @param {Object} pageRef - reference to the page.
    */
   cachePageRef(pageNum, pageRef) {
+    if (!pageRef) {
+      return;
+    }
     let refStr = pageRef.num + ' ' + pageRef.gen + ' R';
     this._pagesRefCache[refStr] = pageNum;
   }


### PR DESCRIPTION
According to the specification, see https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#G6.1942297, the contents of a Kids array should be indirect objects.

Fixes #9540.

*Edit:* Slightly smaller diff with https://github.com/mozilla/pdf.js/pull/9549/files?w=1.