### PR TITLE
Remove SeaMonkey support from the install.rdf

### DIFF
--- a/extensions/firefox/install.rdf
+++ b/extensions/firefox/install.rdf
@@ -18,15 +18,6 @@
      </Description>
     </em:targetApplication>
 
-    <!-- SeaMonkey -->
-    <em:targetApplication>
-      <Description>
-       <em:id>{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}</em:id>
-       <em:minVersion>2.46</em:minVersion>
-       <em:maxVersion>2.51a1</em:maxVersion>
-     </Description>
-    </em:targetApplication>
-
     <!-- Android -->
     <em:targetApplication>
       <Description>


### PR DESCRIPTION
Since pull request #9433 was merged, the pdf.js extension no longer supports SeaMonkey, so it should be removed from the install.rdf.