### PR TITLE
Use 7-Zip on Windows if possible

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -790,10 +790,13 @@ gulp.task('firefox', ['firefox-pre'], function (done) {
     env: { 'TZ': 'UTC', },
   };
 
-  exec('zip -r ' + FIREFOX_EXTENSION_NAME + ' ' +
+  var exe = process.platform === 'win32' && fs.existsSync('/Program Files/7-Zip/7z.exe')
+    ? '"\\Program Files\\7-Zip\\7z.exe" a'
+    : 'zip';
+  exec(`${exe} -r ` + FIREFOX_EXTENSION_NAME + ' ' +
        FIREFOX_EXTENSION_FILES.join(' '), zipExecOptions, function (err) {
     if (err) {
-      done(new Error('Cannot exec zip: ' + err));
+      done(new Error(`Cannot exec ${exe}: ${err}`));
       return;
     }
     console.log('extension created: ' + FIREFOX_EXTENSION_NAME);


### PR DESCRIPTION
The "zip" utility is not installed by default on Windows.

If the user is running Windows, this code will check the standard 7-Zip installation directory on the current drive. If 7z.exe is found, it will run that instead of zip.

Potential future issues:
* 7z and zip use different command line arguments
* 7-Zip might be installed in a different folder, or on a different drive