### PR TITLE
Rename the globals to shorter names.

### DIFF
--- a/examples/acroforms/acroforms.js
+++ b/examples/acroforms/acroforms.js
@@ -15,7 +15,7 @@
 
 'use strict';
 
-pdfjsDistBuildPdf.GlobalWorkerOptions.workerSrc =
+pdfjsLib.GlobalWorkerOptions.workerSrc =
   '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
 var DEFAULT_URL = '../../test/pdfs/f1040.pdf';
@@ -24,7 +24,7 @@ var DEFAULT_SCALE = 1.0;
 var container = document.getElementById('pageContainer');
 
 // Fetch the PDF document from the URL using promises.
-pdfjsDistBuildPdf.getDocument(DEFAULT_URL).then(function (doc) {
+pdfjsLib.getDocument(DEFAULT_URL).then(function (doc) {
   // Use a promise to fetch and render the next page.
   var promise = Promise.resolve();
 
@@ -32,12 +32,12 @@ pdfjsDistBuildPdf.getDocument(DEFAULT_URL).then(function (doc) {
     promise = promise.then(function (pageNum) {
       return doc.getPage(pageNum).then(function (pdfPage) {
         // Create the page view.
-        var pdfPageView = new pdfjsDistWebPdfViewer.PDFPageView({
+        var pdfPageView = new pdfjsViewer.PDFPageView({
           container: container,
           id: pageNum,
           scale: DEFAULT_SCALE,
           defaultViewport: pdfPage.getViewport(DEFAULT_SCALE),
-          annotationLayerFactory: new pdfjsDistWebPdfViewer.DefaultAnnotationLayerFactory(),
+          annotationLayerFactory: new pdfjsViewer.DefaultAnnotationLayerFactory(),
           renderInteractiveForms: true,
         });
 

--- a/examples/browserify/worker.js
+++ b/examples/browserify/worker.js
@@ -3,5 +3,5 @@
 
 // Hello world example for browserify: worker bundle.
 
-(typeof window !== 'undefined' ? window : {}).pdfjsDistBuildPdfWorker =
+(typeof window !== 'undefined' ? window : {}).pdfjsWorker =
   require('pdfjs-dist/build/pdf.worker');

--- a/examples/components/pageviewer.js
+++ b/examples/components/pageviewer.js
@@ -15,14 +15,14 @@
 
 'use strict';
 
-if (!pdfjsDistBuildPdf.getDocument || !pdfjsDistWebPdfViewer.PDFPageView) {
+if (!pdfjsLib.getDocument || !pdfjsViewer.PDFPageView) {
   alert('Please build the pdfjs-dist library using\n' +
         '  `gulp dist-install`');
 }
 
 // The workerSrc property shall be specified.
 //
-pdfjsDistBuildPdf.GlobalWorkerOptions.workerSrc =
+pdfjsLib.GlobalWorkerOptions.workerSrc =
   '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
 // Some PDFs need external cmaps.
@@ -37,7 +37,7 @@ var SCALE = 1.0;
 var container = document.getElementById('pageContainer');
 
 // Loading document.
-pdfjsDistBuildPdf.getDocument({
+pdfjsLib.getDocument({
   url: DEFAULT_URL,
   cMapUrl: CMAP_URL,
   cMapPacked: CMAP_PACKED,
@@ -45,14 +45,14 @@ pdfjsDistBuildPdf.getDocument({
   // Document loaded, retrieving the page.
   return pdfDocument.getPage(PAGE_TO_VIEW).then(function (pdfPage) {
     // Creating the page view with default parameters.
-    var pdfPageView = new pdfjsDistWebPdfViewer.PDFPageView({
+    var pdfPageView = new pdfjsViewer.PDFPageView({
       container: container,
       id: PAGE_TO_VIEW,
       scale: SCALE,
       defaultViewport: pdfPage.getViewport(SCALE),
       // We can enable text/annotations layers, if needed
-      textLayerFactory: new pdfjsDistWebPdfViewer.DefaultTextLayerFactory(),
-      annotationLayerFactory: new pdfjsDistWebPdfViewer.DefaultAnnotationLayerFactory(),
+      textLayerFactory: new pdfjsViewer.DefaultTextLayerFactory(),
+      annotationLayerFactory: new pdfjsViewer.DefaultAnnotationLayerFactory(),
     });
     // Associates the actual page with the view, and drawing it
     pdfPageView.setPdfPage(pdfPage);

--- a/examples/components/simpleviewer.js
+++ b/examples/components/simpleviewer.js
@@ -15,14 +15,14 @@
 
 'use strict';
 
-if (!pdfjsDistBuildPdf.getDocument || !pdfjsDistWebPdfViewer.PDFViewer)  {
+if (!pdfjsLib.getDocument || !pdfjsViewer.PDFViewer)  {
   alert('Please build the pdfjs-dist library using\n' +
         '  `gulp dist-install`');
 }
 
 // The workerSrc property shall be specified.
 //
-pdfjsDistBuildPdf.GlobalWorkerOptions.workerSrc =
+pdfjsLib.GlobalWorkerOptions.workerSrc =
   '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
 // Some PDFs need external cmaps.
@@ -36,16 +36,16 @@ var SEARCH_FOR = ''; // try 'Mozilla';
 var container = document.getElementById('viewerContainer');
 
 // (Optionally) enable hyperlinks within PDF files.
-var pdfLinkService = new pdfjsDistWebPdfViewer.PDFLinkService();
+var pdfLinkService = new pdfjsViewer.PDFLinkService();
 
-var pdfViewer = new pdfjsDistWebPdfViewer.PDFViewer({
+var pdfViewer = new pdfjsViewer.PDFViewer({
   container: container,
   linkService: pdfLinkService,
 });
 pdfLinkService.setViewer(pdfViewer);
 
 // (Optionally) enable find controller.
-var pdfFindController = new pdfjsDistWebPdfViewer.PDFFindController({
+var pdfFindController = new pdfjsViewer.PDFFindController({
   pdfViewer: pdfViewer,
 });
 pdfViewer.setFindController(pdfFindController);
@@ -60,7 +60,7 @@ container.addEventListener('pagesinit', function () {
 });
 
 // Loading document.
-pdfjsDistBuildPdf.getDocument({
+pdfjsLib.getDocument({
   url: DEFAULT_URL,
   cMapUrl: CMAP_URL,
   cMapPacked: CMAP_PACKED,

--- a/examples/components/singlepageviewer.js
+++ b/examples/components/singlepageviewer.js
@@ -15,14 +15,14 @@
 
 'use strict';
 
-if (!pdfjsDistBuildPdf.getDocument || !pdfjsDistWebPdfViewer.PDFSinglePageViewer) {
+if (!pdfjsLib.getDocument || !pdfjsViewer.PDFSinglePageViewer) {
   alert('Please build the pdfjs-dist library using\n' +
         '  `gulp dist-install`');
 }
 
 // The workerSrc property shall be specified.
 //
-pdfjsDistBuildPdf.GlobalWorkerOptions.workerSrc =
+pdfjsLib.GlobalWorkerOptions.workerSrc =
   '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
 // Some PDFs need external cmaps.
@@ -36,16 +36,16 @@ var SEARCH_FOR = ''; // try 'Mozilla';
 var container = document.getElementById('viewerContainer');
 
 // (Optionally) enable hyperlinks within PDF files.
-var pdfLinkService = new pdfjsDistWebPdfViewer.PDFLinkService();
+var pdfLinkService = new pdfjsViewer.PDFLinkService();
 
-var pdfSinglePageViewer = new pdfjsDistWebPdfViewer.PDFSinglePageViewer({
+var pdfSinglePageViewer = new pdfjsViewer.PDFSinglePageViewer({
   container: container,
   linkService: pdfLinkService,
 });
 pdfLinkService.setViewer(pdfSinglePageViewer);
 
 // (Optionally) enable find controller.
-var pdfFindController = new pdfjsDistWebPdfViewer.PDFFindController({
+var pdfFindController = new pdfjsViewer.PDFFindController({
   pdfViewer: pdfSinglePageViewer,
 });
 pdfSinglePageViewer.setFindController(pdfFindController);
@@ -60,7 +60,7 @@ container.addEventListener('pagesinit', function () {
 });
 
 // Loading document.
-pdfjsDistBuildPdf.getDocument({
+pdfjsLib.getDocument({
   url: DEFAULT_URL,
   cMapUrl: CMAP_URL,
   cMapPacked: CMAP_PACKED,

--- a/examples/learning/helloworld.html
+++ b/examples/learning/helloworld.html
@@ -22,13 +22,13 @@
   //
   // The workerSrc property shall be specified.
   //
-  pdfjsDistBuildPdf.GlobalWorkerOptions.workerSrc =
+  pdfjsLib.GlobalWorkerOptions.workerSrc =
     '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
   //
   // Asynchronous download PDF
   //
-  pdfjsDistBuildPdf.getDocument(url).then(function getPdfHelloWorld(pdf) {
+  pdfjsLib.getDocument(url).then(function getPdfHelloWorld(pdf) {
     //
     // Fetch the first page
     //

--- a/examples/learning/helloworld64.html
+++ b/examples/learning/helloworld64.html
@@ -34,12 +34,12 @@
   //
   // The workerSrc property shall be specified.
   //
-  pdfjsDistBuildPdf.GlobalWorkerOptions.workerSrc =
+  pdfjsLib.GlobalWorkerOptions.workerSrc =
     '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
   // Opening PDF by passing its binary data as a string. It is still preferable
   // to use Uint8Array, but string or array-like structure will work too.
-  pdfjsDistBuildPdf.getDocument({data: pdfData}).then(function getPdfHelloWorld(pdf) {
+  pdfjsLib.getDocument({data: pdfData}).then(function getPdfHelloWorld(pdf) {
     // Fetch the first page.
     pdf.getPage(1).then(function getPageHelloWorld(page) {
       var scale = 1.5;

--- a/examples/learning/prevnext.html
+++ b/examples/learning/prevnext.html
@@ -33,7 +33,7 @@
   // pdf.js's one, or the pdf.js is executed via eval(), the workerSrc property
   // shall be specified.
   //
-  pdfjsDistBuildPdf.GlobalWorkerOptions.workerSrc =
+  pdfjsLib.GlobalWorkerOptions.workerSrc =
     '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
   var pdfDoc = null,
@@ -117,7 +117,7 @@
   /**
    * Asynchronously downloads PDF.
    */
-  pdfjsDistBuildPdf.getDocument(url).then(function (pdfDoc_) {
+  pdfjsLib.getDocument(url).then(function (pdfDoc_) {
     pdfDoc = pdfDoc_;
     document.getElementById('page_count').textContent = pdfDoc.numPages;
 

--- a/examples/mobile-viewer/viewer.js
+++ b/examples/mobile-viewer/viewer.js
@@ -12,11 +12,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals pdfjsDistBuildPdf, pdfjsDistWebPdfViewer */
+/* globals pdfjsLib, pdfjsViewer */
 
 'use strict';
 
-if (!pdfjsDistBuildPdf.getDocument || !pdfjsDistWebPdfViewer.PDFViewer) {
+if (!pdfjsLib.getDocument || !pdfjsViewer.PDFViewer) {
   alert('Please build the pdfjs-dist library using\n `gulp dist-install`');
 }
 
@@ -26,7 +26,7 @@ var MAX_IMAGE_SIZE = 1024 * 1024;
 var CMAP_URL = '../../node_modules/pdfjs-dist/cmaps/';
 var CMAP_PACKED = true;
 
-pdfjsDistBuildPdf.GlobalWorkerOptions.workerSrc =
+pdfjsLib.GlobalWorkerOptions.workerSrc =
   '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
 var DEFAULT_URL = '../../web/compressed.tracemonkey-pldi-09.pdf';
@@ -61,7 +61,7 @@ var PDFViewerApplication = {
     this.setTitleUsingUrl(url);
 
     // Loading document.
-    var loadingTask = pdfjsDistBuildPdf.getDocument({
+    var loadingTask = pdfjsLib.getDocument({
       url: url,
       maxImageSize: MAX_IMAGE_SIZE,
       cMapUrl: CMAP_URL,
@@ -87,15 +87,15 @@ var PDFViewerApplication = {
       var l10n = self.l10n;
       var loadingErrorMessage;
 
-      if (exception instanceof pdfjsDistBuildPdf.InvalidPDFException) {
+      if (exception instanceof pdfjsLib.InvalidPDFException) {
         // change error message also for other builds
         loadingErrorMessage = l10n.get('invalid_file_error', null,
           'Invalid or corrupted PDF file.');
-      } else if (exception instanceof pdfjsDistBuildPdf.MissingPDFException) {
+      } else if (exception instanceof pdfjsLib.MissingPDFException) {
         // special message for missing PDFs
         loadingErrorMessage = l10n.get('missing_file_error', null,
           'Missing PDF file.');
-      } else if (exception instanceof pdfjsDistBuildPdf.UnexpectedResponseException) {
+      } else if (exception instanceof pdfjsLib.UnexpectedResponseException) {
         loadingErrorMessage = l10n.get('unexpected_response_error', null,
           'Unexpected server response.');
       } else {
@@ -137,14 +137,14 @@ var PDFViewerApplication = {
   },
 
   get loadingBar() {
-    var bar = new pdfjsDistWebPdfViewer.ProgressBar('#loadingBar', {});
+    var bar = new pdfjsViewer.ProgressBar('#loadingBar', {});
 
-    return pdfjsDistBuildPdf.shadow(this, 'loadingBar', bar);
+    return pdfjsLib.shadow(this, 'loadingBar', bar);
   },
 
   setTitleUsingUrl: function pdfViewSetTitleUsingUrl(url) {
     this.url = url;
-    var title = pdfjsDistBuildPdf.getFilenameFromUrl(url) || url;
+    var title = pdfjsLib.getFilenameFromUrl(url) || url;
     try {
       title = decodeURIComponent(title);
     } catch (e) {
@@ -165,7 +165,7 @@ var PDFViewerApplication = {
       console.log('PDF ' + pdfDocument.fingerprint + ' [' +
                   info.PDFFormatVersion + ' ' + (info.Producer || '-').trim() +
                   ' / ' + (info.Creator || '-').trim() + ']' +
-                  ' (PDF.js: ' + (pdfjsDistBuildPdf.version || '-') + ')');
+                  ' (PDF.js: ' + (pdfjsLib.version || '-') + ')');
 
       var pdfTitle;
       if (metadata && metadata.has('dc:title')) {
@@ -195,8 +195,8 @@ var PDFViewerApplication = {
   error: function pdfViewError(message, moreInfo) {
     var l10n = this.l10n;
     var moreInfoText = [l10n.get('error_version_info',
-      { version: pdfjsDistBuildPdf.version || '?',
-        build: pdfjsDistBuildPdf.build || '?' },
+      { version: pdfjsLib.version || '?',
+        build: pdfjsLib.build || '?' },
       'PDF.js v{{version}} (build: {{build}})')];
 
     if (moreInfo) {
@@ -294,13 +294,13 @@ var PDFViewerApplication = {
   },
 
   initUI: function pdfViewInitUI() {
-    var linkService = new pdfjsDistWebPdfViewer.PDFLinkService();
+    var linkService = new pdfjsViewer.PDFLinkService();
     this.pdfLinkService = linkService;
 
-    this.l10n = pdfjsDistWebPdfViewer.NullL10n;
+    this.l10n = pdfjsViewer.NullL10n;
 
     var container = document.getElementById('viewerContainer');
-    var pdfViewer = new pdfjsDistWebPdfViewer.PDFViewer({
+    var pdfViewer = new pdfjsViewer.PDFViewer({
       container: container,
       linkService: linkService,
       l10n: this.l10n,
@@ -310,7 +310,7 @@ var PDFViewerApplication = {
     this.pdfViewer = pdfViewer;
     linkService.setViewer(pdfViewer);
 
-    this.pdfHistory = new pdfjsDistWebPdfViewer.PDFHistory({
+    this.pdfHistory = new pdfjsViewer.PDFHistory({
       linkService: linkService
     });
     linkService.setHistory(this.pdfHistory);

--- a/examples/text-only/pdf2svg.js
+++ b/examples/text-only/pdf2svg.js
@@ -18,7 +18,7 @@ var PAGE_NUMBER = 1;
 var PAGE_SCALE = 1.5;
 var SVG_NS = 'http://www.w3.org/2000/svg';
 
-pdfjsDistBuildPdf.GlobalWorkerOptions.workerSrc =
+pdfjsLib.GlobalWorkerOptions.workerSrc =
   '../../node_modules/pdfjs-dist/build/pdf.worker.js';
 
 function buildSVG(viewport, textContent) {
@@ -33,8 +33,8 @@ function buildSVG(viewport, textContent) {
   textContent.items.forEach(function (textItem) {
     // we have to take in account viewport transform, which includes scale,
     // rotation and Y-axis flip, and not forgetting to flip text.
-    var tx = pdfjsDistBuildPdf.Util.transform(
-      pdfjsDistBuildPdf.Util.transform(viewport.transform, textItem.transform),
+    var tx = pdfjsLib.Util.transform(
+      pdfjsLib.Util.transform(viewport.transform, textItem.transform),
       [1, 0, 0, -1, 0, 0]);
     var style = textContent.styles[textItem.fontName];
     // adding text element
@@ -49,7 +49,7 @@ function buildSVG(viewport, textContent) {
 
 function pageLoaded() {
   // Loading document and page text content
-  pdfjsDistBuildPdf.getDocument({url: PDF_PATH}).then(function (pdfDocument) {
+  pdfjsLib.getDocument({url: PDF_PATH}).then(function (pdfDocument) {
     pdfDocument.getPage(PAGE_NUMBER).then(function (page) {
       var viewport = page.getViewport(PAGE_SCALE);
       page.getTextContent().then(function (textContent) {
@@ -62,7 +62,7 @@ function pageLoaded() {
 }
 
 document.addEventListener('DOMContentLoaded', function () {
-  if (typeof pdfjsDistBuildPdf === 'undefined') {
+  if (typeof pdfjsLib === 'undefined') {
     alert('Built version of PDF.js was not found.\n' +
           'Please run `gulp dist-install`.');
     return;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -225,11 +225,8 @@ function replaceWebpackRequire() {
   return replace('__webpack_require__', '__w_pdfjs_require__');
 }
 
-function replaceJSRootName(amdName) {
+function replaceJSRootName(amdName, jsName) {
   // Saving old-style JS module name.
-  var jsName = amdName.replace(/[\-_\.\/]\w/g, function (all) {
-    return all[1].toUpperCase();
-  });
   return replace('root["' + amdName + '"] = factory()',
                  'root["' + amdName + '"] = root.' + jsName + ' = factory()');
 }
@@ -250,7 +247,7 @@ function createBundle(defines) {
   var mainOutput = gulp.src('./src/pdf.js')
     .pipe(webpack2Stream(mainFileConfig))
     .pipe(replaceWebpackRequire())
-    .pipe(replaceJSRootName(mainAMDName));
+    .pipe(replaceJSRootName(mainAMDName, 'pdfjsLib'));
 
   var workerAMDName = 'pdfjs-dist/build/pdf.worker';
   var workerOutputName = 'pdf.worker.js';
@@ -261,10 +258,11 @@ function createBundle(defines) {
     libraryTarget: 'umd',
     umdNamedDefine: true,
   });
+
   var workerOutput = gulp.src('./src/pdf.worker.js')
     .pipe(webpack2Stream(workerFileConfig))
     .pipe(replaceWebpackRequire())
-    .pipe(replaceJSRootName(workerAMDName));
+    .pipe(replaceJSRootName(workerAMDName, 'pdfjsWorker'));
   return merge([mainOutput, workerOutput]);
 }
 
@@ -291,7 +289,7 @@ function createComponentsBundle(defines) {
   return gulp.src('./web/pdf_viewer.component.js')
     .pipe(webpack2Stream(componentsFileConfig))
     .pipe(replaceWebpackRequire())
-    .pipe(replaceJSRootName(componentsAMDName));
+    .pipe(replaceJSRootName(componentsAMDName, 'pdfjsViewer'));
 }
 
 function checkFile(path) {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1338,8 +1338,8 @@ var PDFWorker = (function PDFWorkerClosure() {
               window.pdfjsNonProductionPdfWorker.WorkerMessageHandler);
     }
     // PRODUCTION
-    return (window.pdfjsDistBuildPdfWorker &&
-            window.pdfjsDistBuildPdfWorker.WorkerMessageHandler);
+    return (window.pdfjsWorker &&
+            window.pdfjsWorker.WorkerMessageHandler);
   }
 
   let fakeWorkerFilesLoadedCapability;
@@ -1375,7 +1375,7 @@ var PDFWorker = (function PDFWorkerClosure() {
     } else {
       let loader = fakeWorkerFilesLoader || function(callback) {
         Util.loadScript(getWorkerSrc(), function() {
-          callback(window.pdfjsDistBuildPdfWorker.WorkerMessageHandler);
+          callback(window.pdfjsWorker.WorkerMessageHandler);
         });
       };
       loader(fakeWorkerFilesLoadedCapability.resolve);

--- a/src/pdf.worker.entry.js
+++ b/src/pdf.worker.entry.js
@@ -13,5 +13,5 @@
  * limitations under the License.
  */
 
-(typeof window !== 'undefined' ? window : {}).pdfjsDistBuildPdfWorker =
+(typeof window !== 'undefined' ? window : {}).pdfjsWorker =
   require('./pdf.worker.js');

--- a/test/driver.js
+++ b/test/driver.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals pdfjsDistBuildPdf, pdfjsDistWebPdfViewer */
+/* globals pdfjsLib, pdfjsViewer */
 
 'use strict';
 
@@ -69,7 +69,7 @@ var rasterizeTextLayer = (function rasterizeTextLayerClosure() {
       foreignObject.appendChild(div);
 
       // Rendering text layer as HTML.
-      var task = pdfjsDistBuildPdf.renderTextLayer({
+      var task = pdfjsLib.renderTextLayer({
         textContent,
         container: div,
         viewport,
@@ -204,11 +204,11 @@ var rasterizeAnnotationLayer = (function rasterizeAnnotationLayerClosure() {
           div,
           annotations,
           page,
-          linkService: new pdfjsDistWebPdfViewer.SimpleLinkService(),
+          linkService: new pdfjsViewer.SimpleLinkService(),
           imageResourcesPath,
           renderInteractiveForms,
         };
-        pdfjsDistBuildPdf.AnnotationLayer.render(parameters);
+        pdfjsLib.AnnotationLayer.render(parameters);
 
         // Inline SVG images from text annotations.
         var images = div.getElementsByTagName('img');
@@ -271,7 +271,7 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
    */
   function Driver(options) {
     // Configure the global worker options.
-    pdfjsDistBuildPdf.GlobalWorkerOptions.workerSrc = WORKER_SRC;
+    pdfjsLib.GlobalWorkerOptions.workerSrc = WORKER_SRC;
 
     // Set the passed options
     this.inflight = options.inflight;
@@ -358,7 +358,7 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
 
         let absoluteUrl = new URL(task.file, window.location).href;
         try {
-          pdfjsDistBuildPdf.getDocument({
+          pdfjsLib.getDocument({
             url: absoluteUrl,
             password: task.password,
             nativeImageDecoderSupport: task.nativeImageDecoderSupport,


### PR DESCRIPTION
pdfjsDistBuildPdf=pdfjsLib
pdfjsDistWebPdfViewer=pdfjsViewer
pdfjsDistBuildPdfWorker=pdfjsWorker

See #9545