### PR TITLE
[api-minor] Fix various issues related to pageSize, and display the size for the active page in the document properties dialog

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -90,12 +90,12 @@ document_properties_producer=PDF Producer:
 document_properties_version=PDF Version:
 document_properties_page_count=Page Count:
 document_properties_page_size=Page Size:
-# LOCALIZATION NOTE (document_properties_page_size_in): "{{width_in}}" and "{{height_in}}"
-# will be replaced by the size of the first page of the PDF file in inches.
-document_properties_page_size_in={{width_in}}in × {{height_in}}in
-# LOCALIZATION NOTE (document_properties_page_size_mm): "{{width_mm}}" and "{{height_mm}}"
-# will be replaced by the size of the first page of the PDF file in millimeters.
-document_properties_page_size_mm={{width_mm}}mm × {{height_mm}}mm
+# LOCALIZATION NOTE (document_properties_page_size_in_2): "{{width}}" and "{{height}}"
+# will be replaced by the size of the (current) page, in inches.
+document_properties_page_size_in_2={{width}} × {{height}} in
+# LOCALIZATION NOTE (document_properties_page_size_mm_2): "{{width}}" and "{{height}}"
+# will be replaced by the size of the (current) page, in millimeters.
+document_properties_page_size_mm_2={{width}} × {{height}} mm
 document_properties_close=Close
 
 print_progress_message=Preparing document for printing…

--- a/l10n/sv-SE/viewer.properties
+++ b/l10n/sv-SE/viewer.properties
@@ -89,6 +89,13 @@ document_properties_creator=Skapare:
 document_properties_producer=PDF-producent:
 document_properties_version=PDF-version:
 document_properties_page_count=Sidantal:
+document_properties_page_size=Sidstorlek:
+# LOCALIZATION NOTE (document_properties_page_size_in_2): "{{width}}" and "{{height}}"
+# will be replaced by the size of the (current) page, in inches.
+document_properties_page_size_in_2={{width}} × {{height}} tum
+# LOCALIZATION NOTE (document_properties_page_size_mm_2): "{{width}}" and "{{height}}"
+# will be replaced by the size of the (current) page, in millimeters.
+document_properties_page_size_mm_2={{width}} × {{height}} mm
 document_properties_close=Stäng
 
 print_progress_message=Förbereder sidor för utskrift…

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -693,23 +693,6 @@ var PDFDocumentProxy = (function PDFDocumentProxyClosure() {
       return this.transport.getMetadata();
     },
     /**
-     * @param {number} pageNumber The page number to get the page size from.
-     * The first page is 1, which is also the default page used.
-     * @return {Promise} A promise that is resolved with an dict containing the
-     * width and height in inches.
-     */
-    getPageSizeInches(pageNumber) {
-      pageNumber = pageNumber || 1;
-      return this.getPage(pageNumber).then((page) => {
-        const [x1, y1, x2, y2] = page.view;
-        // convert values from user units to inches
-        return {
-          width: (x2 - x1) / 72 * page.userUnit,
-          height: (y2 - y1) / 72 * page.userUnit,
-        };
-      });
-    },
-    /**
      * @return {Promise} A promise that is resolved with a TypedArray that has
      * the raw data from the PDF.
      */
@@ -890,6 +873,20 @@ var PDFPageProxy = (function PDFPageProxyClosure() {
     get view() {
       return this.pageInfo.view;
     },
+
+    /**
+     * The size of the current page, converted from PDF units to inches.
+     * @return {Object} An Object containing the properties: {number} `width`
+     *   and {number} `height`, given in inches.
+     */
+    get pageSizeInches() {
+      const [x1, y1, x2, y2] = this.view, userUnit = this.userUnit;
+      return {
+        width: (x2 - x1) / 72 * userUnit,
+        height: (y2 - y1) / 72 * userUnit,
+      };
+    },
+
     /**
      * @param {number} scale The desired scale of the viewport.
      * @param {number} rotate Degrees to rotate the viewport. If omitted this

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -964,6 +964,14 @@ describe('api', function() {
     it('gets view', function () {
       expect(page.view).toEqual([0, 0, 595.28, 841.89]);
     });
+
+    it('gets page size (in inches)', function() {
+      const { width, height, } = page.pageSizeInches;
+
+      expect(+width.toPrecision(3)).toEqual(8.27);
+      expect(+height.toPrecision(4)).toEqual(11.69);
+    });
+
     it('gets viewport', function () {
       var viewport = page.getViewport(1.5, 90);
       expect(viewport.viewBox).toEqual(page.view);

--- a/web/app.js
+++ b/web/app.js
@@ -429,7 +429,7 @@ let PDFViewerApplication = {
 
       this.pdfDocumentProperties =
         new PDFDocumentProperties(appConfig.documentProperties,
-                                  this.overlayManager, this.l10n);
+                                  this.overlayManager, eventBus, this.l10n);
 
       this.pdfCursorTools = new PDFCursorTools({
         container,

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -228,15 +228,15 @@ class PDFDocumentProperties {
     const { width, height, } = pageSizeInches;
 
     return Promise.all([
-      this.l10n.get('document_properties_page_size_in', {
-          width_in: Math.round(width * 100) / 100,
-          height_in: Math.round(height * 100) / 100,
-        }, '{{width_in}}in × {{height_in}}in'),
+      this.l10n.get('document_properties_page_size_in_2', {
+          width: (Math.round(width * 100) / 100).toLocaleString(),
+          height: (Math.round(height * 100) / 100).toLocaleString(),
+        }, '{{width}} × {{height}} in'),
       // 1in = 25.4mm; no need to round to 2 decimals for millimeters.
-      this.l10n.get('document_properties_page_size_mm', {
-          width_mm: Math.round(width * 25.4 * 10) / 10,
-          height_mm: Math.round(height * 25.4 * 10) / 10,
-        }, '{{width_mm}}mm × {{height_mm}}mm'),
+      this.l10n.get('document_properties_page_size_mm_2', {
+          width: (Math.round(width * 25.4 * 10) / 10).toLocaleString(),
+          height: (Math.round(height * 25.4 * 10) / 10).toLocaleString(),
+        }, '{{width}} × {{height}} mm'),
     ]).then((sizes) => {
       return {
         inch: sizes[0],

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -108,8 +108,12 @@ class PDFDocumentProperties {
         // `this.setFileSize` wasn't called) or may be incorrectly set.
         return this.pdfDocument.getDownloadInfo();
       }).then(({ length, }) => {
+        this.maybeFileSize = length;
         return this._parseFileSize(length);
       }).then((fileSize) => {
+        if (fileSize === this.fieldData['fileSize']) {
+          return; // The fileSize has already been correctly set.
+        }
         let data = cloneObj(this.fieldData);
         data['fileSize'] = fileSize;
 
@@ -157,7 +161,7 @@ class PDFDocumentProperties {
    * @param {number} fileSize - The file size of the PDF document.
    */
   setFileSize(fileSize) {
-    if (typeof fileSize === 'number' && fileSize > 0) {
+    if (Number.isInteger(fileSize) && fileSize > 0) {
       this.maybeFileSize = fileSize;
     }
   }


### PR DESCRIPTION
Glancing quickly at the recent implementation of pageSize, for the document properties dialog, there were a couple of things that seemed to benefit from some refactoring; please see the commit messages for details.

*Edit:* Can be tested with e.g. https://github.com/mozilla/pdf.js/blob/master/test/pdfs/sizes.pdf.