### PR TITLE
Update examples/ documentation for 2.0

### DIFF
--- a/docs/contents/examples/index.md
+++ b/docs/contents/examples/index.md
@@ -9,6 +9,9 @@ template: layout.jade
 
 PDF.js heavily relies on the use of [Promises](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise). If promises are new to you, it's recommended you become familiar with them before continuing on.
 
+This tutorial shows how PDF.js can be used as a library in a web browser.
+[examples/](https://github.com/mozilla/pdf.js/tree/master/examples) provides more examples, including usage in Node.js (at [examples/node/](https://github.com/mozilla/pdf.js/tree/master/examples/node)).
+
 ### Document
 
 The object structure of PDF.js loosely follows the structure of an actual PDF. At the top level there is a document object. From the document, more information and individual pages can be fetched. To get the document:

--- a/docs/contents/examples/index.md
+++ b/docs/contents/examples/index.md
@@ -17,13 +17,13 @@ This tutorial shows how PDF.js can be used as a library in a web browser.
 The object structure of PDF.js loosely follows the structure of an actual PDF. At the top level there is a document object. From the document, more information and individual pages can be fetched. To get the document:
 
 ```js
-PDFJS.getDocument('helloworld.pdf')
+pdfjsLib.getDocument('helloworld.pdf')
 ```
 
 Remember though that PDF.js uses promises, so the above will return a promise that is resolved with the document object.
 
 ```js
-PDFJS.getDocument('helloworld.pdf').then(function(pdf) {
+pdfjsLib.getDocument('helloworld.pdf').then(function(pdf) {
   // you can now use *pdf* here
 });
 ```


### PR DESCRIPTION
Assuming that #9565 gets merged, this PR should fix the documentation.

Fixes #9528

@yurydelendik Can you update the JSFiddle examples and merge this after #9565 is merged?