### PR TITLE
Ensure that `PDFPageProxy.pageSizeInches` handles non-default /Rotate entries correctly

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -875,19 +875,6 @@ var PDFPageProxy = (function PDFPageProxyClosure() {
     },
 
     /**
-     * The size of the current page, converted from PDF units to inches.
-     * @return {Object} An Object containing the properties: {number} `width`
-     *   and {number} `height`, given in inches.
-     */
-    get pageSizeInches() {
-      const [x1, y1, x2, y2] = this.view, userUnit = this.userUnit;
-      return {
-        width: (x2 - x1) / 72 * userUnit,
-        height: (y2 - y1) / 72 * userUnit,
-      };
-    },
-
-    /**
      * @param {number} scale The desired scale of the viewport.
      * @param {number} rotate Degrees to rotate the viewport. If omitted this
      * defaults to the page rotation.

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -964,14 +964,6 @@ describe('api', function() {
     it('gets view', function () {
       expect(page.view).toEqual([0, 0, 595.28, 841.89]);
     });
-
-    it('gets page size (in inches)', function() {
-      const { width, height, } = page.pageSizeInches;
-
-      expect(+width.toPrecision(3)).toEqual(8.27);
-      expect(+height.toPrecision(4)).toEqual(11.69);
-    });
-
     it('gets viewport', function () {
       var viewport = page.getViewport(1.5, 90);
       expect(viewport.viewBox).toEqual(page.view);

--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -14,8 +14,8 @@
  */
 
 import {
-  binarySearchFirstItem, EventBus, getPDFFileNameFromURL, isValidRotation,
-  waitOnEventOrTimeout, WaitOnType
+  binarySearchFirstItem, EventBus, getPageSizeInches, getPDFFileNameFromURL,
+  isValidRotation, waitOnEventOrTimeout, WaitOnType
 } from '../../web/ui_utils';
 import { createObjectURL } from '../../src/shared/util';
 import isNodeJS from '../../src/shared/is_node';
@@ -396,6 +396,34 @@ describe('ui_utils', function() {
         expect(type).toEqual(WaitOnType.TIMEOUT);
         done();
       }, done.fail);
+    });
+  });
+
+  describe('getPageSizeInches', function () {
+    it('gets page size (in inches)', function() {
+      const page = {
+        view: [0, 0, 595.28, 841.89],
+        userUnit: 1.0,
+        rotate: 0,
+      };
+      const { width, height, } = getPageSizeInches(page);
+
+      expect(+width.toPrecision(3)).toEqual(8.27);
+      expect(+height.toPrecision(4)).toEqual(11.69);
+    });
+
+    it('gets page size (in inches), for non-default /Rotate entry', function() {
+      const pdfPage1 = { view: [0, 0, 612, 792], userUnit: 1, rotate: 0, };
+      const { width: width1, height: height1, } = getPageSizeInches(pdfPage1);
+
+      expect(width1).toEqual(8.5);
+      expect(height1).toEqual(11);
+
+      const pdfPage2 = { view: [0, 0, 612, 792], userUnit: 1, rotate: 90, };
+      const { width: width2, height: height2, } = getPageSizeInches(pdfPage2);
+
+      expect(width2).toEqual(11);
+      expect(height2).toEqual(8.5);
     });
   });
 });

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -13,7 +13,9 @@
  * limitations under the License.
  */
 
-import { cloneObj, getPDFFileNameFromURL, NullL10n } from './ui_utils';
+import {
+  cloneObj, getPageSizeInches, getPDFFileNameFromURL, NullL10n
+} from './ui_utils';
 import { createPromiseCapability } from 'pdfjs-lib';
 
 const DEFAULT_FIELD_CONTENT = '-';
@@ -92,7 +94,7 @@ class PDFDocumentProperties {
           this._parseDate(info.CreationDate),
           this._parseDate(info.ModDate),
           this.pdfDocument.getPage(currentPageNumber).then((pdfPage) => {
-            return this._parsePageSize(pdfPage.pageSizeInches);
+            return this._parsePageSize(getPageSizeInches(pdfPage));
           }),
         ]);
       }).then(([info, metadata, fileName, fileSize, creationDate, modDate,

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -270,6 +270,27 @@ function roundToDivide(x, div) {
 }
 
 /**
+ * Gets the size of the specified page, converted from PDF units to inches.
+ * @param {Object} An Object containing the properties: {Array} `view`,
+ *   {number} `userUnit`, and {number} `rotate`.
+ * @return {Object} An Object containing the properties: {number} `width`
+ *   and {number} `height`, given in inches.
+ */
+function getPageSizeInches({ view, userUnit, rotate, }) {
+  const [x1, y1, x2, y2] = view;
+  // We need to take the page rotation into account as well.
+  const changeOrientation = rotate % 180 !== 0;
+
+  const width = (x2 - x1) / 72 * userUnit;
+  const height = (y2 - y1) / 72 * userUnit;
+
+  return {
+    width: (changeOrientation ? height : width),
+    height: (changeOrientation ? width : height),
+  };
+}
+
+/**
  * Generic helper to find out what elements are visible within a scroll pane.
  */
 function getVisibleElements(scrollEl, views, sortByVisibility = false) {
@@ -645,6 +666,7 @@ export {
   parseQueryString,
   getVisibleElements,
   roundToDivide,
+  getPageSizeInches,
   approximateFraction,
   getOutputScale,
   scrollIntoView,


### PR DESCRIPTION
*Follow-up to PRs #9577 and #9508.*

Without this patch, the pageSize will be incorrectly reported for some PDF files.
*Edit:* One such example is https://github.com/mozilla/pdf.js/blob/master/test/pdfs/rotation.pdf