### PR TITLE
Move the `cursorToolOnLoad` preference handling into `AppOptions` (PR 9493 follow-up)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -179,6 +179,9 @@ let PDFViewerApplication = {
       preferences.get('sidebarViewOnLoad').then(function resolved(value) {
         AppOptions.set('sidebarViewOnLoad', value);
       }),
+      preferences.get('cursorToolOnLoad').then(function resolved(value) {
+        AppOptions.set('cursorToolOnLoad', value);
+      }),
       preferences.get('pdfBugEnabled').then(function resolved(value) {
         AppOptions.set('pdfBugEnabled', value);
       }),
@@ -434,7 +437,7 @@ let PDFViewerApplication = {
       this.pdfCursorTools = new PDFCursorTools({
         container,
         eventBus,
-        preferences: this.preferences,
+        cursorToolOnLoad: AppOptions.get('cursorToolOnLoad'),
       });
 
       this.toolbar = new Toolbar(appConfig.toolbar, container, eventBus,

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -28,6 +28,11 @@ const OptionKind = {
  *              compare with the format of `default_preferences.json`.
  */
 const defaultOptions = {
+  cursorToolOnLoad: {
+    /** @type {number} */
+    value: 0,
+    kind: OptionKind.VIEWER,
+  },
   defaultUrl: {
     /** @type {string} */
     value: 'compressed.tracemonkey-pldi-09.pdf',

--- a/web/pdf_cursor_tools.js
+++ b/web/pdf_cursor_tools.js
@@ -25,15 +25,16 @@ const CursorTool = {
  * @typedef {Object} PDFCursorToolsOptions
  * @property {HTMLDivElement} container - The document container.
  * @property {EventBus} eventBus - The application event bus.
- * @property {BasePreferences} preferences - Object for reading/writing
- *                                           persistent settings.
+ * @property {number} cursorToolOnLoad - (optional) The cursor tool that will be
+ *   enabled on load; the constants from {CursorTool} should be used.
+ *   The default value is `CursorTool.SELECT`.
  */
 
 class PDFCursorTools {
   /**
    * @param {PDFCursorToolsOptions} options
    */
-  constructor({ container, eventBus, preferences, }) {
+  constructor({ container, eventBus, cursorToolOnLoad = CursorTool.SELECT, }) {
     this.container = container;
     this.eventBus = eventBus;
 
@@ -46,9 +47,9 @@ class PDFCursorTools {
 
     this._addEventListeners();
 
-    preferences.get('cursorToolOnLoad').then((value) => {
-      this.switchTool(value);
-    }).catch(() => { });
+    Promise.resolve().then(() => {
+      this.switchTool(cursorToolOnLoad);
+    });
   }
 
   /**

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -492,16 +492,6 @@ let animationStarted = new Promise(function (resolve) {
 });
 
 /**
- * (deprecated) External localization service.
- */
-let mozL10n;
-
-/**
- * (deprecated) Promise that is resolved when UI localization is finished.
- */
-let localized = Promise.resolve();
-
-/**
  * Simple event bus for an application. Listeners are attached using the
  * `on` and `off` methods. To raise an event, the `dispatch` method shall be
  * used.
@@ -636,7 +626,6 @@ export {
   PresentationModeState,
   RendererType,
   TextLayerMode,
-  mozL10n,
   NullL10n,
   EventBus,
   ProgressBar,
@@ -652,7 +641,6 @@ export {
   binarySearchFirstItem,
   normalizeWheelEventDelta,
   animationStarted,
-  localized,
   WaitOnType,
   waitOnEventOrTimeout,
 };


### PR DESCRIPTION
 - Move the `cursorToolOnLoad` preference handling into `AppOptions` (PR 9493 follow-up)

   Since no other viewer component is currently reading preferences itself, this patch thus unifies the behaviour across the viewer.

 - Remove the deprecated `mozL10n` and `localized` properties from `web/ui_utils.js`

   With PDF.js version `2.0`, these can now be removed. ***Edit:** It looks like we missed this previously when removing other deprecated code.*

/cc @timvandermeij 