### PR TITLE
Improve the pageSize entry in the document properties dialog, by also displaying page names and orientation

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -92,10 +92,12 @@ document_properties_page_count=Page Count:
 document_properties_page_size=Page Size:
 document_properties_page_size_unit_inches=in
 document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=portrait
+document_properties_page_size_orientation_landscape=landscape
 # LOCALIZATION NOTE (document_properties_page_size_dimension_string):
-# "{{width}}", "{{height}}", and {{unit}} will be replaced by the size,
-# respectively their unit of measurement, of the (current) page.
-document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}}
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
 document_properties_close=Close
 
 print_progress_message=Preparing document for printing…

--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -94,10 +94,18 @@ document_properties_page_size_unit_inches=in
 document_properties_page_size_unit_millimeters=mm
 document_properties_page_size_orientation_portrait=portrait
 document_properties_page_size_orientation_landscape=landscape
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
 # LOCALIZATION NOTE (document_properties_page_size_dimension_string):
 # "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
 # the size, respectively their unit of measurement and orientation, of the (current) page.
 document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
 document_properties_close=Close
 
 print_progress_message=Preparing document for printing…

--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -90,12 +90,12 @@ document_properties_producer=PDF Producer:
 document_properties_version=PDF Version:
 document_properties_page_count=Page Count:
 document_properties_page_size=Page Size:
-# LOCALIZATION NOTE (document_properties_page_size_in_2): "{{width}}" and "{{height}}"
-# will be replaced by the size of the (current) page, in inches.
-document_properties_page_size_in_2={{width}} × {{height}} in
-# LOCALIZATION NOTE (document_properties_page_size_mm_2): "{{width}}" and "{{height}}"
-# will be replaced by the size of the (current) page, in millimeters.
-document_properties_page_size_mm_2={{width}} × {{height}} mm
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", and {{unit}} will be replaced by the size,
+# respectively their unit of measurement, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}}
 document_properties_close=Close
 
 print_progress_message=Preparing document for printing…

--- a/l10n/sv-SE/viewer.properties
+++ b/l10n/sv-SE/viewer.properties
@@ -90,12 +90,12 @@ document_properties_producer=PDF-producent:
 document_properties_version=PDF-version:
 document_properties_page_count=Sidantal:
 document_properties_page_size=Sidstorlek:
-# LOCALIZATION NOTE (document_properties_page_size_in_2): "{{width}}" and "{{height}}"
-# will be replaced by the size of the (current) page, in inches.
-document_properties_page_size_in_2={{width}} × {{height}} tum
-# LOCALIZATION NOTE (document_properties_page_size_mm_2): "{{width}}" and "{{height}}"
-# will be replaced by the size of the (current) page, in millimeters.
-document_properties_page_size_mm_2={{width}} × {{height}} mm
+document_properties_page_size_unit_inches=tum
+document_properties_page_size_unit_millimeters=mm
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", and {{unit}} will be replaced by the size,
+# respectively their unit of measurement, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}}
 document_properties_close=Stäng
 
 print_progress_message=Förbereder sidor för utskrift…

--- a/l10n/sv-SE/viewer.properties
+++ b/l10n/sv-SE/viewer.properties
@@ -94,10 +94,18 @@ document_properties_page_size_unit_inches=tum
 document_properties_page_size_unit_millimeters=mm
 document_properties_page_size_orientation_portrait=stående
 document_properties_page_size_orientation_landscape=liggande
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
 # LOCALIZATION NOTE (document_properties_page_size_dimension_string):
 # "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
 # the size, respectively their unit of measurement and orientation, of the (current) page.
 document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
 document_properties_close=Stäng
 
 print_progress_message=Förbereder sidor för utskrift…

--- a/l10n/sv-SE/viewer.properties
+++ b/l10n/sv-SE/viewer.properties
@@ -92,10 +92,12 @@ document_properties_page_count=Sidantal:
 document_properties_page_size=Sidstorlek:
 document_properties_page_size_unit_inches=tum
 document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=stående
+document_properties_page_size_orientation_landscape=liggande
 # LOCALIZATION NOTE (document_properties_page_size_dimension_string):
-# "{{width}}", "{{height}}", and {{unit}} will be replaced by the size,
-# respectively their unit of measurement, of the (current) page.
-document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}}
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
 document_properties_close=Stäng
 
 print_progress_message=Förbereder sidor för utskrift…

--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -15,7 +15,7 @@
 
 import {
   binarySearchFirstItem, EventBus, getPageSizeInches, getPDFFileNameFromURL,
-  isValidRotation, waitOnEventOrTimeout, WaitOnType
+  isPortraitOrientation, isValidRotation, waitOnEventOrTimeout, WaitOnType
 } from '../../web/ui_utils';
 import { createObjectURL } from '../../src/shared/util';
 import isNodeJS from '../../src/shared/is_node';
@@ -282,6 +282,27 @@ describe('ui_utils', function() {
       expect(isValidRotation(90)).toEqual(true);
       expect(isValidRotation(-270)).toEqual(true);
       expect(isValidRotation(540)).toEqual(true);
+    });
+  });
+
+  describe('isPortraitOrientation', function() {
+    it('should be portrait orientation', function() {
+      expect(isPortraitOrientation({
+        width: 200,
+        height: 400,
+      })).toEqual(true);
+
+      expect(isPortraitOrientation({
+        width: 500,
+        height: 500,
+      })).toEqual(true);
+    });
+
+    it('should be landscape orientation', function() {
+      expect(isPortraitOrientation({
+        width: 600,
+        height: 300,
+      })).toEqual(false);
     });
   });
 

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -14,9 +14,10 @@
  */
 
 import {
-  CSS_UNITS, DEFAULT_SCALE, DEFAULT_SCALE_VALUE, isValidRotation,
-  MAX_AUTO_SCALE, NullL10n, PresentationModeState, RendererType,
-  SCROLLBAR_PADDING, TextLayerMode, UNKNOWN_SCALE, VERTICAL_PADDING, watchScroll
+  CSS_UNITS, DEFAULT_SCALE, DEFAULT_SCALE_VALUE, isPortraitOrientation,
+  isValidRotation, MAX_AUTO_SCALE, NullL10n, PresentationModeState,
+  RendererType, SCROLLBAR_PADDING, TextLayerMode, UNKNOWN_SCALE,
+  VERTICAL_PADDING, watchScroll
 } from './ui_utils';
 import { PDFRenderingQueue, RenderingStates } from './pdf_rendering_queue';
 import { AnnotationLayerBuilder } from './annotation_layer_builder';
@@ -92,10 +93,6 @@ function isSameScale(oldScale, newScale) {
     return true;
   }
   return false;
-}
-
-function isPortraitOrientation(size) {
-  return size.width <= size.height;
 }
 
 /**
@@ -578,11 +575,10 @@ class BaseViewer {
           scale = Math.min(pageWidthScale, pageHeightScale);
           break;
         case 'auto':
-          let isLandscape = (currentPage.width > currentPage.height);
           // For pages in landscape mode, fit the page height to the viewer
           // *unless* the page would thus become too wide to fit horizontally.
-          let horizontalScale = isLandscape ?
-            Math.min(pageHeightScale, pageWidthScale) : pageWidthScale;
+          let horizontalScale = isPortraitOrientation(currentPage) ?
+            pageWidthScale : Math.min(pageHeightScale, pageWidthScale);
           scale = Math.min(MAX_AUTO_SCALE, horizontalScale);
           break;
         default:

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -145,6 +145,10 @@ class MozL10n {
     this.mozL10n = mozL10n;
   }
 
+  getLanguage() {
+    return Promise.resolve(this.mozL10n.getLanguage());
+  }
+
   getDirection() {
     return Promise.resolve(this.mozL10n.getDirection());
   }

--- a/web/genericl10n.js
+++ b/web/genericl10n.js
@@ -27,6 +27,12 @@ class GenericL10n {
     });
   }
 
+  getLanguage() {
+    return this._ready.then((l10n) => {
+      return l10n.getLanguage();
+    });
+  }
+
   getDirection() {
     return this._ready.then((l10n) => {
       return l10n.getDirection();

--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -161,6 +161,11 @@ class IPDFAnnotationLayerFactory {
  */
 class IL10n {
   /**
+   * @returns {Promise<string>} - Resolves to the current locale.
+   */
+  getLanguage() {}
+
+  /**
    * @returns {Promise<string>} - Resolves to 'rtl' or 'ltr'.
    */
   getDirection() {}

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -247,20 +247,25 @@ class PDFDocumentProperties {
     const { width, height, } = pageSizeInches;
 
     return Promise.all([
-      this.l10n.get('document_properties_page_size_in_2', {
-          width: (Math.round(width * 100) / 100).toLocaleString(),
-          height: (Math.round(height * 100) / 100).toLocaleString(),
-        }, '{{width}} × {{height}} in'),
-      // 1in = 25.4mm; no need to round to 2 decimals for millimeters.
-      this.l10n.get('document_properties_page_size_mm_2', {
-          width: (Math.round(width * 25.4 * 10) / 10).toLocaleString(),
-          height: (Math.round(height * 25.4 * 10) / 10).toLocaleString(),
-        }, '{{width}} × {{height}} mm'),
-    ]).then((sizes) => {
-      return {
-        inch: sizes[0],
-        mm: sizes[1],
-      };
+      this.l10n.get('document_properties_page_size_unit_inches', null, 'in'),
+      this.l10n.get('document_properties_page_size_unit_millimeters', null,
+                    'mm'),
+    ]).then(([unitInches, unitMillimeters]) => {
+      return Promise.all([
+        this.l10n.get('document_properties_page_size_dimension_string', {
+            width: (Math.round(width * 100) / 100).toLocaleString(),
+            height: (Math.round(height * 100) / 100).toLocaleString(),
+            unit: unitInches,
+          }, '{{width}} × {{height}} {{unit}}'),
+        // 1in == 25.4mm; no need to round to 2 decimals for millimeters.
+        this.l10n.get('document_properties_page_size_dimension_string', {
+            width: (Math.round(width * 25.4 * 10) / 10).toLocaleString(),
+            height: (Math.round(height * 25.4 * 10) / 10).toLocaleString(),
+            unit: unitMillimeters,
+          }, '{{width}} × {{height}} {{unit}}'),
+      ]);
+    }).then((sizes) => {
+      return { inch: sizes[0], mm: sizes[1], };
     });
   }
 

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -14,7 +14,8 @@
  */
 
 import {
-  cloneObj, getPageSizeInches, getPDFFileNameFromURL, NullL10n
+  cloneObj, getPageSizeInches, getPDFFileNameFromURL, isPortraitOrientation,
+  NullL10n
 } from './ui_utils';
 import { createPromiseCapability } from 'pdfjs-lib';
 
@@ -266,6 +267,7 @@ class PDFDocumentProperties {
         height: pageSizeInches.width,
       };
     }
+    const isPortrait = isPortraitOrientation(pageSizeInches);
 
     const sizeInches = {
       width: Math.round(pageSizeInches.width * 100) / 100,
@@ -282,12 +284,16 @@ class PDFDocumentProperties {
       this.l10n.get('document_properties_page_size_unit_' +
                     (this._isNonMetricLocale ? 'inches' : 'millimeters'), null,
                     this._isNonMetricLocale ? 'in' : 'mm'),
-    ]).then(([{ width, height, }, unit]) => {
+      this.l10n.get('document_properties_page_size_orientation_' +
+                    (isPortrait ? 'portrait' : 'landscape'), null,
+                    isPortrait ? 'portrait' : 'landscape'),
+    ]).then(([{ width, height, }, unit, orientation]) => {
       return this.l10n.get('document_properties_page_size_dimension_string', {
           width: width.toLocaleString(),
           height: height.toLocaleString(),
           unit,
-        }, '{{width}} × {{height}} {{unit}}');
+          orientation,
+        }, '{{width}} × {{height}} {{unit}} ({{orientation}})');
     });
   }
 

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -58,6 +58,10 @@ function formatL10nValue(text, args) {
  * @implements {IL10n}
  */
 let NullL10n = {
+  getLanguage() {
+    return Promise.resolve('en-us');
+  },
+
   getDirection() {
     return Promise.resolve('ltr');
   },

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -439,6 +439,10 @@ function isValidRotation(angle) {
   return Number.isInteger(angle) && angle % 90 === 0;
 }
 
+function isPortraitOrientation(size) {
+  return size.width <= size.height;
+}
+
 function cloneObj(obj) {
   let result = Object.create(null);
   for (let i in obj) {
@@ -642,6 +646,7 @@ export {
   SCROLLBAR_PADDING,
   VERTICAL_PADDING,
   isValidRotation,
+  isPortraitOrientation,
   isFileSchema,
   cloneObj,
   PresentationModeState,

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -352,11 +352,7 @@ See https://github.com/adobe-type-tools/cmap-resources
               <span data-l10n-id="document_properties_page_count">Page Count:</span> <p id="pageCountField">-</p>
             </div>
             <div class="row">
-              <span data-l10n-id="document_properties_page_size">Page Size:</span>
-                <p>
-                  <span id="pageSizeFieldMM">-</span><br>
-                  <span id="pageSizeFieldInch">-</span>
-                </p>
+              <span data-l10n-id="document_properties_page_size">Page Size:</span> <p id="pageSizeField">-</p>
             </div>
             <div class="buttonRow">
               <button id="documentPropertiesClose" class="overlayButton"><span data-l10n-id="document_properties_close">Close</span></button>

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -159,8 +159,7 @@ function getViewerConfiguration() {
         'producer': document.getElementById('producerField'),
         'version': document.getElementById('versionField'),
         'pageCount': document.getElementById('pageCountField'),
-        'pageSizeInch': document.getElementById('pageSizeFieldInch'),
-        'pageSizeMM': document.getElementById('pageSizeFieldMM'),
+        'pageSize': document.getElementById('pageSizeField'),
       },
     },
     errorWrapper: {


### PR DESCRIPTION
These patches, which were quickly thrown together, attempts to implement the remaining requests from issue #6990. *Please refer to the individual commit messages for additional details.*