### PR TITLE
Disable ftp support in Chrome 59+, add file chooser at file

### DIFF
--- a/extensions/chromium/pdfHandler.js
+++ b/extensions/chromium/pdfHandler.js
@@ -153,10 +153,16 @@ chrome.webRequest.onBeforeRequest.addListener(
     urls: [
       'file://*/*.pdf',
       'file://*/*.PDF',
-      // Note: Chrome 59 has disabled ftp resource loading by default:
-      // https://www.chromestatus.com/feature/5709390967472128
-      'ftp://*/*.pdf',
-      'ftp://*/*.PDF',
+      ...(
+        // Duck-typing: MediaError.prototype.message was added in Chrome 59.
+        MediaError.prototype.hasOwnProperty('message') ? [] :
+        [
+          // Note: Chrome 59 has disabled ftp resource loading by default:
+          // https://www.chromestatus.com/feature/5709390967472128
+          'ftp://*/*.pdf',
+          'ftp://*/*.PDF',
+        ]
+      ),
     ],
     types: ['main_frame', 'sub_frame'],
   },

--- a/web/app.js
+++ b/web/app.js
@@ -597,7 +597,7 @@ let PDFViewerApplication = {
           args = { length, };
         }
         if (originalURL !== undefined) {
-          file = { file: url, originalURL, };
+          file = { url, originalURL, };
         }
         PDFViewerApplication.open(file, args);
       },

--- a/web/viewer-snippet-chrome-overlays.html
+++ b/web/viewer-snippet-chrome-overlays.html
@@ -22,5 +22,11 @@
         to view <span id="chrome-url-of-local-file">this PDF file.</span>
       </p>
     </div>
+    <div class="row">
+      <p>
+        or select the file again:
+        <input type="file" id="chrome-file-fallback" accept=".pdf">
+      </p>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #9411
Work-around for #8926

Test case for ftp: Visit `ftp://ftp.sagu.edu/` and try to open a PDF file that appears there.