### PR TITLE
Clean-up `getMainThreadWorkerMessageHandler` for non-PRODUCTION mode

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1317,13 +1317,7 @@ var PDFWorker = (function PDFWorkerClosure() {
     if (typeof window === 'undefined') {
       return null;
     }
-    if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION')) {
-      return (window.pdfjsNonProductionPdfWorker &&
-              window.pdfjsNonProductionPdfWorker.WorkerMessageHandler);
-    }
-    // PRODUCTION
-    return (window.pdfjsWorker &&
-            window.pdfjsWorker.WorkerMessageHandler);
+    return (window.pdfjsWorker && window.pdfjsWorker.WorkerMessageHandler);
   }
 
   let fakeWorkerFilesLoadedCapability;

--- a/web/app.js
+++ b/web/app.js
@@ -1524,11 +1524,11 @@ function loadFakeWorker() {
     if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION')) {
       if (typeof SystemJS === 'object') {
         SystemJS.import('pdfjs/core/worker').then((worker) => {
-          window.pdfjsNonProductionPdfWorker = worker;
+          window.pdfjsWorker = worker;
           resolve();
         });
       } else if (typeof require === 'function') {
-        window.pdfjsNonProductionPdfWorker = require('../src/core/worker.js');
+        window.pdfjsWorker = require('../src/core/worker.js');
         resolve();
       } else {
         reject(new Error(


### PR DESCRIPTION
*This is a final piece of clean-up of code that I recently wrote, after which I'm done :-)*

When the `getMainThreadWorkerMessageHandler` function was added, in PR #9385, it did so by basically introducing a `web/app.js` dependency in `src/display/api.js` through the `window.pdfjsNonProductionPdfWorker` property[1]. Even though this is limited to non-`PRODUCTION` mode, i.e. `gulp server`, it still seems unfortunate to have that sort of viewer dependency in the API code itself.

With the new, much nicer and shorter, names introduced in PR #9565 we can remove this non-`PRODUCTION` hack and just use `window.pdfjsWorker` in both the viewer and the API regardless of the build mode.

---

[1] It didn't seem correct to piggy-back on the `window.pdfjsDistBuildPdfWorker` property in non-`PRODUCTION` mode.