### PR TITLE
Improve the instructions and code for the `pdf2png` example

### DIFF
--- a/examples/node/pdf2png/README.md
+++ b/examples/node/pdf2png/README.md
@@ -4,12 +4,13 @@ Example to demonstrate converting a PDF file to a PNG image using the PDF.js lib
 
 ## Getting started
 
-Install the dependencies and build the project:
+Install the dependencies and build the PDF.js library:
 
     $ npm install
-    $ gulp dist
+    $ gulp dist-install
 
-Install the Node canvas library to convert the first page of a PDF file to a PNG image:
+Install the Node canvas library and run the example to convert the first page of a
+PDF file to a PNG image:
 
     $ npm install canvas
     $ cd examples/node/pdf2png

--- a/examples/node/pdf2png/pdf2png.js
+++ b/examples/node/pdf2png/pdf2png.js
@@ -51,13 +51,19 @@ NodeCanvasFactory.prototype = {
 var pdfjsLib = require('pdfjs-dist');
 
 // Relative path of the PDF file.
-var pdfURL = '../../helloworld/helloworld.pdf';
+var pdfURL = '../../../web/compressed.tracemonkey-pldi-09.pdf';
 
 // Read the PDF file into a typed array so PDF.js can load it.
 var rawData = new Uint8Array(fs.readFileSync(pdfURL));
 
-// Load the PDF file.
-pdfjsLib.getDocument(rawData).then(function (pdfDocument) {
+// Load the PDF file. The `disableFontFace` and `nativeImageDecoderSupport`
+// options must be passed because Node.js has no native `@font-face` and
+// `Image` support.
+pdfjsLib.getDocument({
+  data: rawData,
+  disableFontFace: true,
+  nativeImageDecoderSupport: 'none',
+}).then(function (pdfDocument) {
   console.log('# PDF document loaded.');
 
   // Get the first page.


### PR DESCRIPTION
We need to pass `disableFontFace` and `nativeImageDecoderSupport` because Node.js has no native support for `@font-face` and `Image`. Doing so makes it possible to render e.g., the Tracemonkey paper, which failed before. I made this PDF file the default because it's also the default in other examples/demos and because it showcases the possibilities better than the very simple hello world PDF file.

Building the library with `gulp dist-install` is easier and is already recommended in the other examples.

Together with #9588, this:

Fixes #9603 
Fixes #9387
Fixes #8489