### PR TITLE
Pin `systemjs` to avoid breakage

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node-ensure": "^0.0.0",
     "rimraf": "^2.6.2",
     "streamqueue": "^1.1.2",
-    "systemjs": "^0.21.0",
+    "systemjs": "0.21.0",
     "systemjs-plugin-babel": "^0.0.25",
     "ttest": "^1.1.0",
     "typogr": "^0.6.7",


### PR DESCRIPTION
SystemJS version 0.21.0 works, but version 0.21.1 breaks with various `Unable to load transpiler to transpile` errors. Pin the version to 0.21.0 for now to avoid this issue.

I filed an upstream issue to get this fixed: https://github.com/systemjs/systemjs/issues/1809

Fixes #9617.