### PR TITLE
Prevent warning on unimplemented operator thrown for OPS.dependency

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -530,6 +530,9 @@ SVGGraphics = (function SVGGraphicsClosure() {
           case OPS.beginText:
             this.beginText();
             break;
+          case OPS.dependency:
+            // Handled in loadDependencies, warning should not be thrown
+            break;
           case OPS.setLeading:
             this.setLeading(args);
             break;


### PR DESCRIPTION
Fixes #9623