### PR TITLE
Support running the tests headlessly.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -140,7 +140,9 @@ function examineRefImages() {
   startServer();
   var startUrl = 'http://' + server.host + ':' + server.port +
                  '/test/resources/reftest-analyzer.html#web=/test/eq.log';
-  var browser = WebBrowser.create(sessions[0].config);
+  var config = Object.assign({}, sessions[0].config);
+  config['headless'] = false;
+  var browser = WebBrowser.create(config);
   browser.start(startUrl);
 }
 

--- a/test/webbrowser.js
+++ b/test/webbrowser.js
@@ -26,9 +26,10 @@ var crypto = require('crypto');
 
 var tempDirPrefix = 'pdfjs_';
 
-function WebBrowser(name, path) {
+function WebBrowser(name, path, headless) {
   this.name = name;
   this.path = path;
+  this.headless = headless;
   this.tmpDir = null;
   this.profileDir = null;
   this.process = null;
@@ -69,7 +70,11 @@ WebBrowser.prototype = {
 
     var args = this.buildArguments(url);
     args = args.concat('--' + this.uniqStringId);
-    this.process = spawn(this.path, args);
+
+    this.process = spawn(this.path, args, { stdio: [process.stdin,
+                                                    process.stdout,
+                                                    process.stderr], });
+
     this.process.on('exit', function (code, signal) {
       this.process = null;
       var exitInfo = code !== null ? ' with status ' + code :
@@ -204,14 +209,14 @@ WebBrowser.prototype = {
 
 var firefoxResourceDir = path.join(__dirname, 'resources', 'firefox');
 
-function FirefoxBrowser(name, path) {
+function FirefoxBrowser(name, path, headless) {
   if (os.platform() === 'darwin') {
     var m = /([^.\/]+)\.app(\/?)$/.exec(path);
     if (m) {
       path += (m[2] ? '' : '/') + 'Contents/MacOS/firefox';
     }
   }
-  WebBrowser.call(this, name, path);
+  WebBrowser.call(this, name, path, headless);
 }
 FirefoxBrowser.prototype = Object.create(WebBrowser.prototype);
 FirefoxBrowser.prototype.buildArguments = function (url) {
@@ -220,6 +225,9 @@ FirefoxBrowser.prototype.buildArguments = function (url) {
   if (os.platform() === 'darwin') {
     args.push('-foreground');
   }
+  if (this.headless) {
+    args.push('--headless');
+  }
   args.push('-no-remote', '-profile', profileDir, url);
   return args;
 };
@@ -227,7 +235,7 @@ FirefoxBrowser.prototype.setupProfileDir = function (dir) {
   testUtils.copySubtreeSync(firefoxResourceDir, dir);
 };
 
-function ChromiumBrowser(name, path) {
+function ChromiumBrowser(name, path, headless) {
   if (os.platform() === 'darwin') {
     var m = /([^.\/]+)\.app(\/?)$/.exec(path);
     if (m) {
@@ -235,14 +243,28 @@ function ChromiumBrowser(name, path) {
       console.log(path);
     }
   }
-  WebBrowser.call(this, name, path);
+  WebBrowser.call(this, name, path, headless);
 }
 ChromiumBrowser.prototype = Object.create(WebBrowser.prototype);
 ChromiumBrowser.prototype.buildArguments = function (url) {
   var profileDir = this.getProfileDir();
-  return ['--user-data-dir=' + profileDir,
-    '--no-first-run', '--disable-sync',
-    '--no-default-browser-check', url];
+  var crashDumpsDir = path.join(this.tmpDir, 'crash_dumps');
+  var args = ['--user-data-dir=' + profileDir,
+              '--no-first-run',
+              '--disable-sync',
+              '--no-default-browser-check',
+              '--disable-device-discovery-notifications',
+              '--disable-translate',
+              '--disable-background-timer-throttling',
+              '--disable-renderer-backgrounding'];
+  if (this.headless) {
+    args.push('--headless',
+              '--crash-dumps-dir=' + crashDumpsDir,
+              '--disable-gpu',
+              '--remote-debugging-port=9222');
+  }
+  args.push(url);
+  return args;
 };
 
 WebBrowser.create = function (desc) {
@@ -253,12 +275,12 @@ WebBrowser.create = function (desc) {
   }
 
   if (/firefox/i.test(name)) {
-    return new FirefoxBrowser(name, path);
+    return new FirefoxBrowser(name, path, desc.headless);
   }
   if (/(chrome|chromium|opera)/i.test(name)) {
-    return new ChromiumBrowser(name, path);
+    return new ChromiumBrowser(name, path, desc.headless);
   }
-  return new WebBrowser(name, path);
+  return new WebBrowser(name, path, desc.headless);
 };
 
 exports.WebBrowser = WebBrowser;


### PR DESCRIPTION
Now you can add "headless: true" to the browser_manifest.json. I can't get headless to work on Chrome with MacOS though.