### PR TITLE
SVG clip intersections and operators

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -995,6 +995,8 @@ SVGGraphics = (function SVGGraphicsClosure() {
         this.extraStack.forEach(function (prev) {
           prev.clipGroup = null;
         });
+        // Intersect with the previous clipping path.
+        clipPath.setAttributeNS(null, 'clip-path', current.activeClipUrl);
       }
       current.activeClipUrl = 'url(#' + clipId + ')';
 
@@ -1069,6 +1071,7 @@ SVGGraphics = (function SVGGraphicsClosure() {
       if (current.element) {
         current.element.setAttributeNS(null, 'fill', current.fillColor);
         current.element.setAttributeNS(null, 'fill-opacity', current.fillAlpha);
+        this.endPath();
       }
     },
 
@@ -1092,6 +1095,8 @@ SVGGraphics = (function SVGGraphicsClosure() {
                                        pf(current.dashPhase) + 'px');
 
         current.element.setAttributeNS(null, 'fill', 'none');
+
+        this.endPath();
       }
     },
 


### PR DESCRIPTION
Fixes #8496

When a new clipping path is set, the result should be the *intersection* of the new path with the previous clipping path. Currently the SVG backend incorrectly just *replaces* the previous clipping path with the new one.

SVG can automatically compute the intersection. It's easiest to add a `clip-path` attribute to a `clipPath` element. The [SVG Recommendation](https://www.w3.org/TR/SVG11/masking.html#EstablishingANewClippingPath) says:
> If a valid 'clip-path' reference is placed on a 'clipPath' element, the resulting clipping path is the intersection of the contents of the 'clipPath' element with the referenced clipping path.

In issue #8496 a text-shaped clipping path is first set and then a larger rectangular path. This is repeated in a number of texts on the page.
[issue8496_reduced.pdf](https://github.com/mozilla/pdf.js/files/1920753/issue8496_reduced.pdf)
The reduced PDF should show a black letter 'a', not a rectangle.

I have also fixed all the painting operators `S s f f* B B* b b* n` that should generate clipping paths. Previously only `n` has worked. Here is a file to test these:
[clip_operators.pdf](https://github.com/mozilla/pdf.js/files/1920754/clip_operators.pdf)