### PR TITLE
Pass imageLayer to PDFPageView

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -87,6 +87,7 @@ class PDFPageView {
     this.renderingQueue = options.renderingQueue;
     this.textLayerFactory = options.textLayerFactory;
     this.annotationLayerFactory = options.annotationLayerFactory;
+    this.imageLayer = options.imageLayer;
     this.renderer = options.renderer || RendererType.CANVAS;
     this.enableWebGL = options.enableWebGL || false;
     this.l10n = options.l10n || NullL10n;
@@ -576,6 +577,7 @@ class PDFPageView {
       viewport: this.viewport,
       enableWebGL: this.enableWebGL,
       renderInteractiveForms: this.renderInteractiveForms,
+      imageLayer: this.imageLayer
     };
     let renderTask = this.pdfPage.render(renderContext);
     renderTask.onContinue = function (cont) {


### PR DESCRIPTION
This pull request allows passing a custom `imageLayer` when creating a new PDFPageView.

```
var pdfPageView = new pdfjsViewer.PDFPageView({
    container: container,
    id: PAGE_TO_VIEW,
    scale: SCALE,
    defaultViewport: pdfPage.getViewport(SCALE),
    imageLayer: {
        beginLayout: function (){},
        endLayout: function (){},
        appendImage: function(img){}
    }
});
```