### PR TITLE
Fixed critical unhandled promise that prevented error catching using API

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2453,7 +2453,7 @@ var InternalRenderTask = (function InternalRenderTaskClosure() {
       if (this.useRequestAnimationFrame && typeof window !== 'undefined') {
         window.requestAnimationFrame(this._nextBound);
       } else {
-        Promise.resolve(undefined).then(this._nextBound);
+        Promise.resolve().then(this._nextBound).catch(this.callback);
       }
     },
 


### PR DESCRIPTION
The affected line causes an unhandled rejection if any code inside _nextBound throws an error.

This makes using the API impossible, as there is no way of catching a failing PDF.

For this issue, the offending PDF and the underlying problem throwing the error, please refer to: #9675 

This PR fixes the unhandled rejection error only.  This is not a fix for the error that is being thrown.  It's just an indispensable catch to the promise so that the error can bubble up to where it should in order for the error to be catched.