### PR TITLE
Add description metatag to docs

### DIFF
--- a/docs/templates/layout.jade
+++ b/docs/templates/layout.jade
@@ -4,7 +4,7 @@ html(lang='en')
   head
     meta(charset='utf-8')
     meta(name='viewport', content='width=device-width, initial-scale=1.0')
-    meta(name='description', content='')
+    meta(name='description', content='A general-purpose, web standards-based platform for parsing and rendering PDFs.')
     meta(name='author', content='')
     link(rel='shortcut icon', href=makeRelative(page.url, '/images/favicon.ico'))
     title=page.title


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5832930/39965557-25c8e010-56a4-11e8-90ab-cc2f3cc3c0c1.png)

Currently all the other junk comes with it on Google.