### PR TITLE
Ignore the rest of the image when encountering an EOI (End of Image) marker while parsing Scan data (issue 9679)

### DIFF
--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -907,8 +907,7 @@ var JpegImage = (function JpegImageClosure() {
               offset += processed;
             } catch (ex) {
               if (ex instanceof DNLMarkerError) {
-                warn('Attempting to re-parse JPEG image using "scanLines" ' +
-                     'parameter found in DNL marker (0xFFDC) segment.');
+                warn(`${ex.message} -- attempting to re-parse the JPEG image.`);
                 return this.parse(data, { dnlScanLines: ex.scanLines, });
               } else if (ex instanceof EOIMarkerError) {
                 warn(`${ex.message} -- ignoring the rest of the image data.`);

--- a/test/pdfs/issue9679.pdf.link
+++ b/test/pdfs/issue9679.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/1929531/K.BIS.PDF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -3223,6 +3223,13 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue9679",
+       "file": "pdfs/issue9679.pdf",
+       "md5": "3077d06add3875705aa1021c7b116023",
+       "rounds": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "bug1108753",
        "file": "pdfs/bug1108753.pdf",
        "md5": "a7aaf92d55b4602afb0ca3d75198b56b",


### PR DESCRIPTION
When submitting the "separate image-decoders" PR, I happened to glance briefly at other open JPEG issues and noticed that issue #9679 looked really simple, so...

One caveat here is that I've not run *any* tests locally, so I suppose that this could fail spectacularly :-)

*Edit:* The Windows failures looks intermittent (the `forms` tests), or unrelated to the built-in JPEG decoder. The Linux "failures" are only in `text` tests, and should thus be unrelated as well; they look like the old "Firefox was updated on the bots, and `makeref` is thus needed".