### PR TITLE
Use Dict.getArray, instead of Dict.get, when getting the 'Size' in constructSampled in src/core/function.js

### DIFF
--- a/src/core/function.js
+++ b/src/core/function.js
@@ -186,7 +186,7 @@ var PDFFunction = (function PDFFunctionClosure() {
       domain = toMultiArray(domain);
       range = toMultiArray(range);
 
-      var size = toNumberArray(dict.get('Size'));
+      var size = toNumberArray(dict.getArray('Size'));
       var bps = dict.get('BitsPerSample');
       var order = dict.get('Order') || 1;
       if (order !== 1) {


### PR DESCRIPTION
Use Dict.getArray, instead of Dict.get, when getting the 'Size' in constructSampled on line 189 of src/core/function.js

Fixes #9734.