### PR TITLE
Replace deprecated new Buffer(string) constructor with Buffer.from(string)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -124,7 +124,7 @@ function createStringSource(filename, content) {
   source._read = function () {
     this.push(new Vinyl({
       path: filename,
-      contents: new Buffer(content),
+      contents: Buffer.from(content),
     }));
     this.push(null);
   };


### PR DESCRIPTION
Fixes #9739.