### PR TITLE
Use `fs.unlinkSync` instead of `fs.unlink` when removing `eq.log`

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -207,7 +207,7 @@ function startRefTest(masterMode, showRefImages) {
     }
 
     if (fs.existsSync(eqLog)) {
-      fs.unlink(eqLog);
+      fs.unlinkSync(eqLog);
     }
     if (fs.existsSync(testResultDir)) {
       testUtils.removeDirSync(testResultDir);


### PR DESCRIPTION
*Another issue I found when hardening the test infrastructure.*

This is necessary because Node.js crashes when `fs.unlink` is called without a callback function.