### PR TITLE
Reduce the amount of errors logged, primarily in Node.js/Travis, when running the unit-tests

### DIFF
--- a/examples/node/pdf2png/pdf2png.js
+++ b/examples/node/pdf2png/pdf2png.js
@@ -56,14 +56,8 @@ var pdfURL = '../../../web/compressed.tracemonkey-pldi-09.pdf';
 // Read the PDF file into a typed array so PDF.js can load it.
 var rawData = new Uint8Array(fs.readFileSync(pdfURL));
 
-// Load the PDF file. The `disableFontFace` and `nativeImageDecoderSupport`
-// options must be passed because Node.js has no native `@font-face` and
-// `Image` support.
-pdfjsLib.getDocument({
-  data: rawData,
-  disableFontFace: true,
-  nativeImageDecoderSupport: 'none',
-}).then(function (pdfDocument) {
+// Load the PDF file.
+pdfjsLib.getDocument(rawData).then(function (pdfDocument) {
   console.log('# PDF document loaded.');
 
   // Get the first page.

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -574,9 +574,9 @@ var WorkerMessageHandler = {
             finishWorkerTask(task);
             pdfManager.updatePassword(data.password);
             pdfManagerReady();
-          }).catch(function (ex) {
+          }).catch(function (boundException) {
             finishWorkerTask(task);
-            handler.send('PasswordException', ex);
+            handler.send('PasswordException', boundException);
           }.bind(null, e));
         } else if (e instanceof InvalidPDFException) {
           handler.send('InvalidPDF', e);

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1788,7 +1788,11 @@ var WorkerTransport = (function WorkerTransportClosure() {
               password,
             });
           };
-          loadingTask.onPassword(updatePassword, exception.code);
+          try {
+            loadingTask.onPassword(updatePassword, exception.code);
+          } catch (ex) {
+            this._passwordCapability.reject(ex);
+          }
         } else {
           this._passwordCapability.reject(
             new PasswordException(exception.message, exception.code));

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -274,7 +274,9 @@ function getDocument(src) {
   const NativeImageDecoderValues = Object.values(NativeImageDecoding);
   if (params.nativeImageDecoderSupport === undefined ||
       !NativeImageDecoderValues.includes(params.nativeImageDecoderSupport)) {
-    params.nativeImageDecoderSupport = NativeImageDecoding.DECODE;
+    params.nativeImageDecoderSupport =
+      (apiCompatibilityParams.nativeImageDecoderSupport ||
+       NativeImageDecoding.DECODE);
   }
   if (!Number.isInteger(params.maxImageSize)) {
     params.maxImageSize = -1;
@@ -283,7 +285,7 @@ function getDocument(src) {
     params.isEvalSupported = true;
   }
   if (typeof params.disableFontFace !== 'boolean') {
-    params.disableFontFace = false;
+    params.disableFontFace = apiCompatibilityParams.disableFontFace || false;
   }
 
   if (typeof params.disableRange !== 'boolean') {
@@ -2168,6 +2170,8 @@ var WorkerTransport = (function WorkerTransportClosure() {
         disableStream: params.disableStream,
         disableAutoFetch: params.disableAutoFetch,
         disableCreateObjectURL: params.disableCreateObjectURL,
+        disableFontFace: params.disableFontFace,
+        nativeImageDecoderSupport: params.nativeImageDecoderSupport,
       });
     },
   };

--- a/src/display/api_compatibility.js
+++ b/src/display/api_compatibility.js
@@ -15,6 +15,8 @@
 
 let compatibilityParams = Object.create(null);
 if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
+  const isNodeJS = require('../shared/is_node');
+
   const userAgent =
     (typeof navigator !== 'undefined' && navigator.userAgent) || '';
   const isIE = /Trident/.test(userAgent);
@@ -42,9 +44,15 @@ if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
       compatibilityParams.disableStream = true;
     }
   })();
-}
-const apiCompatibilityParams = Object.freeze(compatibilityParams);
 
-export {
-  apiCompatibilityParams,
-};
+  // Support: Node.js
+  (function checkFontFaceAndImage() {
+    // Node.js is missing native support for `@font-face` and `Image`.
+    if (isNodeJS()) {
+      compatibilityParams.disableFontFace = true;
+      compatibilityParams.nativeImageDecoderSupport = 'none';
+    }
+  })();
+}
+
+exports.apiCompatibilityParams = Object.freeze(compatibilityParams);

--- a/test/unit/clitests_helper.js
+++ b/test/unit/clitests_helper.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import { setVerbosityLevel, VerbosityLevel } from '../../src/shared/util';
 import isNodeJS from '../../src/shared/is_node';
 import { PDFNodeStream } from '../../src/display/node_stream';
 import { setPDFNetworkStreamFactory } from '../../src/display/api';
@@ -22,6 +23,10 @@ if (!isNodeJS()) {
   throw new Error('The `gulp unittestcli` command can only be used in ' +
                   'Node.js environments.');
 }
+
+// Reduce the amount of console "spam", by ignoring `info`/`warn` calls,
+// when running the unit-tests in Node.js/Travis.
+setVerbosityLevel(VerbosityLevel.ERRORS);
 
 // Set the network stream factory for the unit-tests.
 setPDFNetworkStreamFactory(function(params) {

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -681,6 +681,13 @@ function waitOnEventOrTimeout({ target, name, delay = 0, }) {
  * Promise that is resolved when DOM window becomes visible.
  */
 let animationStarted = new Promise(function (resolve) {
+  if ((typeof PDFJSDev !== 'undefined' && PDFJSDev.test('LIB')) &&
+      typeof window === 'undefined') {
+    // Prevent "ReferenceError: window is not defined" errors when running the
+    // unit-tests in Node.js/Travis.
+    setTimeout(resolve, 20);
+    return;
+  }
   window.requestAnimationFrame(resolve);
 });
 

--- a/web/viewer_compatibility.js
+++ b/web/viewer_compatibility.js
@@ -37,8 +37,5 @@ if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
     }
   })();
 }
-const viewerCompatibilityParams = Object.freeze(compatibilityParams);
 
-export {
-  viewerCompatibilityParams,
-};
+exports.viewerCompatibilityParams = Object.freeze(compatibilityParams);


### PR DESCRIPTION
*Split off from PR #9729, as requested in https://github.com/mozilla/pdf.js/pull/9729#issuecomment-393698402.* /cc @timvandermeij 

Compare the output without these patches https://travis-ci.org/mozilla/pdf.js/builds/386523654, to the output *with* the patches https://travis-ci.org/mozilla/pdf.js/builds/386612114.