### PR TITLE
Fix multibyte decoding in content_disposition.js

### DIFF
--- a/src/display/content_disposition.js
+++ b/src/display/content_disposition.js
@@ -78,24 +78,27 @@ function getFilenameFromContentDispositionHeader(contentDisposition) {
   }
   function textdecode(encoding, value) {
     if (encoding) {
-      if (!/^[^\x00-\xFF]+$/.test(value)) {
+      if (!/^[\x00-\xFF]+$/.test(value)) {
         return value;
       }
       try {
         let decoder = new TextDecoder(encoding, { fatal: true, });
         let bytes = new Array(value.length);
         for (let i = 0; i < value.length; ++i) {
-          bytes[i] = value.charCodeAt(0);
+          bytes[i] = value.charCodeAt(i);
         }
         value = decoder.decode(new Uint8Array(bytes));
         needsEncodingFixup = false;
       } catch (e) {
         // TextDecoder constructor threw - unrecognized encoding.
-        // Or TextDecoder API is not available.
+        // Or TextDecoder API is not available (in IE / Edge).
         if (/^utf-?8$/i.test(encoding)) {
           // UTF-8 is commonly used, try to support it in another way:
-          value = decodeURIComponent(escape(value));
-          needsEncodingFixup = false;
+          try {
+            value = decodeURIComponent(escape(value));
+            needsEncodingFixup = false;
+          } catch (err) {
+          }
         }
       }
     }

--- a/src/display/content_disposition.js
+++ b/src/display/content_disposition.js
@@ -107,7 +107,11 @@ function getFilenameFromContentDispositionHeader(contentDisposition) {
   function fixupEncoding(value) {
     if (needsEncodingFixup && /[\x80-\xff]/.test(value)) {
       // Maybe multi-byte UTF-8.
-      return textdecode('utf-8', value);
+      value = textdecode('utf-8', value);
+      if (needsEncodingFixup) {
+        // Try iso-8859-1 encoding.
+        value = textdecode('iso-8859-1', value);
+      }
     }
     return value;
   }
@@ -209,10 +213,10 @@ function getFilenameFromContentDispositionHeader(contentDisposition) {
           return textdecode(charset, text);
         } // else encoding is b or B - base64 (RFC 2047 section 4.1)
         try {
-          return atob(text);
+          text = atob(text);
         } catch (e) {
-          return text;
         }
+        return textdecode(charset, text);
       });
   }
 


### PR DESCRIPTION
I made some mistakes when trying to make the content_disposition.js compatible with non-modern browsers (IE/Edge). As a result text decoding was mostly broken (the original at https://github.com/Rob--W/open-in-browser/blob/55c71eb44e0ad71a3bb443457666fd48421612ac/extension/content-disposition.js works as expected).

I fixed and verified that it works as expected (see the commit description).
The tests in `test-content-disposition.js` contain multiple UTF-8 decoding tests, but just to make sure that #9616 is really fixed, I inserted the following too:

```javascript
console.log('Test from https://github.com/mozilla/pdf.js/issues/9616');
check("attachment; filename=\"test-a-test.pdf\"; filename*=UTF-8''test-%C3%A4-%D1%82%D0%B5%D1%81%D1%82.pdf",
      "test-ä-тест.pdf");
```

Fixes #9616