### PR TITLE
Use `fs.unlinkSync` instead of `fs.unlink` when removing files in the font tests

### DIFF
--- a/test/font/ttxdriver.js
+++ b/test/font/ttxdriver.js
@@ -69,7 +69,7 @@ exports.translateFont = function translateFont(content, registerOnCancel,
 
   fs.writeFileSync(fontPath, buffer);
   runTtx(ttxResourcesHome, fontPath, registerOnCancel, function (err) {
-    fs.unlink(fontPath);
+    fs.unlinkSync(fontPath);
     if (err) {
       console.error(err);
       callback(err);
@@ -77,7 +77,7 @@ exports.translateFont = function translateFont(content, registerOnCancel,
       callback('Output was not generated');
     } else {
       callback(null, fs.readFileSync(resultPath));
-      fs.unlink(resultPath);
+      fs.unlinkSync(resultPath);
     }
   });
 };


### PR DESCRIPTION
*Another issue found when upgrading the test infrastructure. Refer to https://github.com/mozilla/pdf.js/pull/9758#issuecomment-394187950 for the original report, of which this patch is a follow-up.*

This should prevent `[DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated` in the logs.