### PR TITLE
Remove `Util.appendToArray` and `Util.prependToArray`

### DIFF
--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { FormatError, isSpace, stringToBytes, Util } from '../shared/util';
+import { FormatError, isSpace, stringToBytes } from '../shared/util';
 import { isDict } from './primitives';
 
 var Stream = (function StreamClosure() {
@@ -274,7 +274,7 @@ var StreamsSequenceStream = (function StreamsSequenceStreamClosure() {
     for (var i = 0, ii = this.streams.length; i < ii; i++) {
       var stream = this.streams[i];
       if (stream.getBaseStreams) {
-        Util.appendToArray(baseStreams, stream.getBaseStreams());
+        baseStreams.push(...stream.getBaseStreams());
       }
     }
     return baseStreams;

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1075,7 +1075,7 @@ var PDFPageProxy = (function PDFPageProxyClosure() {
               return;
             }
             Util.extendObj(textContent.styles, value.styles);
-            Util.appendToArray(textContent.items, value.items);
+            textContent.items.push(...value.items);
             pump();
           }, reject);
         }

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -886,14 +886,6 @@ var Util = (function UtilClosure() {
     return (lowerCase ? romanStr.toLowerCase() : romanStr);
   };
 
-  Util.appendToArray = function Util_appendToArray(arr1, arr2) {
-    Array.prototype.push.apply(arr1, arr2);
-  };
-
-  Util.prependToArray = function Util_prependToArray(arr1, arr2) {
-    Array.prototype.unshift.apply(arr1, arr2);
-  };
-
   Util.extendObj = function extendObj(obj1, obj2) {
     for (var key in obj2) {
       obj1[key] = obj2[key];


### PR DESCRIPTION
The former may be replaced by regular JavaScript array concatenation and the latter is unused. This avoids unnecessary function calls/imports.