### PR TITLE
Replace deprecated `new Buffer(string, 'base64')` constructor with `Buffer.from(string, 'base64')

### DIFF
--- a/test/font/ttxdriver.js
+++ b/test/font/ttxdriver.js
@@ -62,7 +62,7 @@ function runTtx(ttxResourcesHome, fontPath, registerOnCancel, callback) {
 
 exports.translateFont = function translateFont(content, registerOnCancel,
                                                callback) {
-  var buffer = new Buffer(content, 'base64');
+  var buffer = Buffer.from(content, 'base64');
   var taskId = (nextTTXTaskId++).toString();
   var fontPath = path.join(ttxResourcesHome, taskId + '.otf');
   var resultPath = path.join(ttxResourcesHome, taskId + '.ttx');

--- a/test/test.js
+++ b/test/test.js
@@ -320,7 +320,7 @@ function checkEq(task, results, browser, masterMode) {
     }
     var testSnapshot = pageResults[page].snapshot;
     if (testSnapshot && testSnapshot.indexOf('data:image/png;base64,') === 0) {
-      testSnapshot = new Buffer(testSnapshot.substring(22), 'base64');
+      testSnapshot = Buffer.from(testSnapshot.substring(22), 'base64');
     } else {
       console.error('Valid snapshot was not found.');
     }


### PR DESCRIPTION
Fixes #9797.