### PR TITLE
Update `ColorSpace` and `PDFImage` to use `Uint8ClampedArray`s and remove manual clamping/rounding

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -261,6 +261,7 @@ class Annotation {
 
   /**
    * Set the color and take care of color space conversion.
+   * The default value is black, in RGB color space.
    *
    * @public
    * @memberof Annotation
@@ -269,7 +270,7 @@ class Annotation {
    *                        4 (CMYK) elements
    */
   setColor(color) {
-    let rgbColor = new Uint8Array(3); // Black in RGB color space (default)
+    let rgbColor = new Uint8ClampedArray(3);
     if (!Array.isArray(color)) {
       this.color = rgbColor;
       return;

--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -181,16 +181,17 @@ var ChunkedStream = (function ChunkedStreamClosure() {
       return (b0 << 24) + (b1 << 16) + (b2 << 8) + b3;
     },
 
-    // returns subarray of original buffer
-    // should only be read
-    getBytes: function ChunkedStream_getBytes(length) {
+    // Returns subarray of original buffer, should only be read.
+    getBytes(length, forceClamped = false) {
       var bytes = this.bytes;
       var pos = this.pos;
       var strEnd = this.end;
 
       if (!length) {
         this.ensureRange(pos, strEnd);
-        return bytes.subarray(pos, strEnd);
+        let subarray = bytes.subarray(pos, strEnd);
+        // `this.bytes` is always a `Uint8Array` here.
+        return (forceClamped ? new Uint8ClampedArray(subarray) : subarray);
       }
 
       var end = pos + length;
@@ -200,7 +201,9 @@ var ChunkedStream = (function ChunkedStreamClosure() {
       this.ensureRange(pos, end);
 
       this.pos = end;
-      return bytes.subarray(pos, end);
+      let subarray = bytes.subarray(pos, end);
+      // `this.bytes` is always a `Uint8Array` here.
+      return (forceClamped ? new Uint8ClampedArray(subarray) : subarray);
     },
 
     peekByte: function ChunkedStream_peekByte() {
@@ -209,8 +212,8 @@ var ChunkedStream = (function ChunkedStreamClosure() {
       return peekedByte;
     },
 
-    peekBytes: function ChunkedStream_peekBytes(length) {
-      var bytes = this.getBytes(length);
+    peekBytes(length, forceClamped = false) {
+      var bytes = this.getBytes(length, forceClamped);
       this.pos -= bytes.length;
       return bytes;
     },

--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -65,7 +65,7 @@ var ColorSpace = (function ColorSpaceClosure() {
      * located in the src array starting from the srcOffset. Returns the array
      * of the rgb components, each value ranging from [0,255].
      */
-    getRgb: function ColorSpace_getRgb(src, srcOffset) {
+    getRgb(src, srcOffset) {
       var rgb = new Uint8Array(3);
       this.getRgbItem(src, srcOffset, rgb, 0);
       return rgb;
@@ -74,8 +74,7 @@ var ColorSpace = (function ColorSpaceClosure() {
      * Converts the color value to the RGB color, similar to the getRgb method.
      * The result placed into the dest array starting from the destOffset.
      */
-    getRgbItem: function ColorSpace_getRgbItem(src, srcOffset,
-                                               dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       unreachable('Should not call ColorSpace.getRgbItem');
     },
     /**
@@ -87,9 +86,7 @@ var ColorSpace = (function ColorSpaceClosure() {
      * there are in the dest array; it will be either 0 (RGB array) or 1 (RGBA
      * array).
      */
-    getRgbBuffer: function ColorSpace_getRgbBuffer(src, srcOffset, count,
-                                                   dest, destOffset, bits,
-                                                   alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       unreachable('Should not call ColorSpace.getRgbBuffer');
     },
     /**
@@ -97,14 +94,13 @@ var ColorSpace = (function ColorSpaceClosure() {
      * conversion done by the getRgbBuffer method. As in getRgbBuffer,
      * |alpha01| is either 0 (RGB output) or 1 (RGBA output).
      */
-    getOutputLength: function ColorSpace_getOutputLength(inputLength,
-                                                         alpha01) {
+    getOutputLength(inputLength, alpha01) {
       unreachable('Should not call ColorSpace.getOutputLength');
     },
     /**
      * Returns true if source data will be equal the result/output data.
      */
-    isPassthrough: function ColorSpace_isPassthrough(bits) {
+    isPassthrough(bits) {
       return false;
     },
     /**
@@ -112,9 +108,8 @@ var ColorSpace = (function ColorSpaceClosure() {
      * how many alpha components there are in the dest array; it will be either
      * 0 (RGB array) or 1 (RGBA array).
      */
-    fillRgb: function ColorSpace_fillRgb(dest, originalWidth,
-                                         originalHeight, width, height,
-                                         actualHeight, bpc, comps, alpha01) {
+    fillRgb(dest, originalWidth, originalHeight, width, height, actualHeight,
+            bpc, comps, alpha01) {
       var count = originalWidth * originalHeight;
       var rgbBuf = null;
       var numComponentColors = 1 << bpc;
@@ -385,7 +380,7 @@ var ColorSpace = (function ColorSpaceClosure() {
    * @param {Array} decode Decode map (usually from an image).
    * @param {Number} n Number of components the color space has.
    */
-  ColorSpace.isDefaultDecode = function ColorSpace_isDefaultDecode(decode, n) {
+  ColorSpace.isDefaultDecode = function(decode, n) {
     if (!Array.isArray(decode)) {
       return true;
     }
@@ -438,15 +433,12 @@ var AlternateCS = (function AlternateCSClosure() {
 
   AlternateCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function AlternateCS_getRgbItem(src, srcOffset,
-                                                dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       var tmpBuf = this.tmpBuf;
       this.tintFn(src, srcOffset, tmpBuf, 0);
       this.base.getRgbItem(tmpBuf, 0, dest, destOffset);
     },
-    getRgbBuffer: function AlternateCS_getRgbBuffer(src, srcOffset, count,
-                                                    dest, destOffset, bits,
-                                                    alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       var tintFn = this.tintFn;
       var base = this.base;
       var scale = 1 / ((1 << bits) - 1);
@@ -481,15 +473,14 @@ var AlternateCS = (function AlternateCSClosure() {
         base.getRgbBuffer(baseBuf, 0, count, dest, destOffset, 8, alpha01);
       }
     },
-    getOutputLength: function AlternateCS_getOutputLength(inputLength,
-                                                          alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return this.base.getOutputLength(inputLength *
                                        this.base.numComps / this.numComps,
                                        alpha01);
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function AlternateCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     },
     usesZeroToOneRange: true,
@@ -537,15 +528,12 @@ var IndexedCS = (function IndexedCSClosure() {
 
   IndexedCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function IndexedCS_getRgbItem(src, srcOffset,
-                                              dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       var numComps = this.base.numComps;
       var start = src[srcOffset] * numComps;
       this.base.getRgbBuffer(this.lookup, start, 1, dest, destOffset, 8, 0);
     },
-    getRgbBuffer: function IndexedCS_getRgbBuffer(src, srcOffset, count,
-                                                  dest, destOffset, bits,
-                                                  alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       var base = this.base;
       var numComps = base.numComps;
       var outputDelta = base.getOutputLength(numComps, alpha01);
@@ -557,13 +545,13 @@ var IndexedCS = (function IndexedCSClosure() {
         destOffset += outputDelta;
       }
     },
-    getOutputLength: function IndexedCS_getOutputLength(inputLength, alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return this.base.getOutputLength(inputLength * this.base.numComps,
                                        alpha01);
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function IndexedCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       // indexed color maps shouldn't be changed
       return true;
     },
@@ -581,15 +569,12 @@ var DeviceGrayCS = (function DeviceGrayCSClosure() {
 
   DeviceGrayCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function DeviceGrayCS_getRgbItem(src, srcOffset,
-                                                 dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       var c = (src[srcOffset] * 255) | 0;
       c = c < 0 ? 0 : c > 255 ? 255 : c;
       dest[destOffset] = dest[destOffset + 1] = dest[destOffset + 2] = c;
     },
-    getRgbBuffer: function DeviceGrayCS_getRgbBuffer(src, srcOffset, count,
-                                                     dest, destOffset, bits,
-                                                     alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       var scale = 255 / ((1 << bits) - 1);
       var j = srcOffset, q = destOffset;
       for (var i = 0; i < count; ++i) {
@@ -600,13 +585,12 @@ var DeviceGrayCS = (function DeviceGrayCSClosure() {
         q += alpha01;
       }
     },
-    getOutputLength: function DeviceGrayCS_getOutputLength(inputLength,
-                                                           alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return inputLength * (3 + alpha01);
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function DeviceGrayCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     },
     usesZeroToOneRange: true,
@@ -622,8 +606,7 @@ var DeviceRgbCS = (function DeviceRgbCSClosure() {
   }
   DeviceRgbCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function DeviceRgbCS_getRgbItem(src, srcOffset,
-                                                dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       var r = (src[srcOffset] * 255) | 0;
       var g = (src[srcOffset + 1] * 255) | 0;
       var b = (src[srcOffset + 2] * 255) | 0;
@@ -631,9 +614,7 @@ var DeviceRgbCS = (function DeviceRgbCSClosure() {
       dest[destOffset + 1] = g < 0 ? 0 : g > 255 ? 255 : g;
       dest[destOffset + 2] = b < 0 ? 0 : b > 255 ? 255 : b;
     },
-    getRgbBuffer: function DeviceRgbCS_getRgbBuffer(src, srcOffset, count,
-                                                    dest, destOffset, bits,
-                                                    alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       if (bits === 8 && alpha01 === 0) {
         dest.set(src.subarray(srcOffset, srcOffset + count * 3), destOffset);
         return;
@@ -647,15 +628,14 @@ var DeviceRgbCS = (function DeviceRgbCSClosure() {
         q += alpha01;
       }
     },
-    getOutputLength: function DeviceRgbCS_getOutputLength(inputLength,
-                                                          alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return (inputLength * (3 + alpha01) / 3) | 0;
     },
-    isPassthrough: function DeviceRgbCS_isPassthrough(bits) {
+    isPassthrough(bits) {
       return bits === 8;
     },
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function DeviceRgbCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     },
     usesZeroToOneRange: true,
@@ -717,13 +697,10 @@ var DeviceCmykCS = (function DeviceCmykCSClosure() {
   }
   DeviceCmykCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function DeviceCmykCS_getRgbItem(src, srcOffset,
-                                                 dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       convertToRgb(src, srcOffset, 1, dest, destOffset);
     },
-    getRgbBuffer: function DeviceCmykCS_getRgbBuffer(src, srcOffset, count,
-                                                     dest, destOffset, bits,
-                                                     alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       var scale = 1 / ((1 << bits) - 1);
       for (var i = 0; i < count; i++) {
         convertToRgb(src, srcOffset, scale, dest, destOffset);
@@ -731,13 +708,12 @@ var DeviceCmykCS = (function DeviceCmykCSClosure() {
         destOffset += 3 + alpha01;
       }
     },
-    getOutputLength: function DeviceCmykCS_getOutputLength(inputLength,
-                                                           alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return (inputLength / 4 * (3 + alpha01)) | 0;
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function DeviceCmykCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     },
     usesZeroToOneRange: true,
@@ -815,13 +791,10 @@ var CalGrayCS = (function CalGrayCSClosure() {
 
   CalGrayCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function CalGrayCS_getRgbItem(src, srcOffset,
-                                              dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       convertToRgb(this, src, srcOffset, dest, destOffset, 1);
     },
-    getRgbBuffer: function CalGrayCS_getRgbBuffer(src, srcOffset, count,
-                                                  dest, destOffset, bits,
-                                                  alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       var scale = 1 / ((1 << bits) - 1);
 
       for (var i = 0; i < count; ++i) {
@@ -830,12 +803,12 @@ var CalGrayCS = (function CalGrayCSClosure() {
         destOffset += 3 + alpha01;
       }
     },
-    getOutputLength: function CalGrayCS_getOutputLength(inputLength, alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return inputLength * (3 + alpha01);
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function CalGrayCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     },
     usesZeroToOneRange: true,
@@ -847,7 +820,6 @@ var CalGrayCS = (function CalGrayCSClosure() {
 // CalRGBCS: Based on "PDF Reference, Sixth Ed", p.247
 //
 var CalRGBCS = (function CalRGBCSClosure() {
-
   // See http://www.brucelindbloom.com/index.html?Eqn_ChromAdapt.html for these
   // matrices.
   var BRADFORD_SCALE_MATRIX = new Float32Array([
@@ -991,7 +963,6 @@ var CalRGBCS = (function CalRGBCSClosure() {
   }
 
   function compensateBlackPoint(sourceBlackPoint, XYZ_Flat, result) {
-
     // In case the blackPoint is already the default blackPoint then there is
     // no need to do compensation.
     if (sourceBlackPoint[0] === 0 &&
@@ -1033,7 +1004,6 @@ var CalRGBCS = (function CalRGBCSClosure() {
   }
 
   function normalizeWhitePointToFlat(sourceWhitePoint, XYZ_In, result) {
-
     // In case the whitePoint is already flat then there is no need to do
     // normalization.
     if (sourceWhitePoint[0] === 1 && sourceWhitePoint[2] === 1) {
@@ -1053,7 +1023,6 @@ var CalRGBCS = (function CalRGBCSClosure() {
   }
 
   function normalizeWhitePointToD65(sourceWhitePoint, XYZ_In, result) {
-
     var LMS = result;
     matrixProduct(BRADFORD_SCALE_MATRIX, XYZ_In, LMS);
 
@@ -1115,13 +1084,10 @@ var CalRGBCS = (function CalRGBCSClosure() {
 
   CalRGBCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function CalRGBCS_getRgbItem(src, srcOffset,
-                                             dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       convertToRgb(this, src, srcOffset, dest, destOffset, 1);
     },
-    getRgbBuffer: function CalRGBCS_getRgbBuffer(src, srcOffset, count,
-                                                 dest, destOffset, bits,
-                                                 alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       var scale = 1 / ((1 << bits) - 1);
 
       for (var i = 0; i < count; ++i) {
@@ -1130,12 +1096,12 @@ var CalRGBCS = (function CalRGBCSClosure() {
         destOffset += 3 + alpha01;
       }
     },
-    getOutputLength: function CalRGBCS_getOutputLength(inputLength, alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return (inputLength * (3 + alpha01) / 3) | 0;
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function CalRGBCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     },
     usesZeroToOneRange: true,
@@ -1261,12 +1227,10 @@ var LabCS = (function LabCSClosure() {
 
   LabCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
-    getRgbItem: function LabCS_getRgbItem(src, srcOffset, dest, destOffset) {
+    getRgbItem(src, srcOffset, dest, destOffset) {
       convertToRgb(this, src, srcOffset, false, dest, destOffset);
     },
-    getRgbBuffer: function LabCS_getRgbBuffer(src, srcOffset, count,
-                                              dest, destOffset, bits,
-                                              alpha01) {
+    getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
       var maxVal = (1 << bits) - 1;
       for (var i = 0; i < count; i++) {
         convertToRgb(this, src, srcOffset, maxVal, dest, destOffset);
@@ -1274,12 +1238,12 @@ var LabCS = (function LabCSClosure() {
         destOffset += 3 + alpha01;
       }
     },
-    getOutputLength: function LabCS_getOutputLength(inputLength, alpha01) {
+    getOutputLength(inputLength, alpha01) {
       return (inputLength * (3 + alpha01) / 3) | 0;
     },
     isPassthrough: ColorSpace.prototype.isPassthrough,
     fillRgb: ColorSpace.prototype.fillRgb,
-    isDefaultDecode: function LabCS_isDefaultDecode(decodeMap) {
+    isDefaultDecode(decodeMap) {
       // XXX: Decoding is handled with the lab conversion because of the strange
       // ranges that are used.
       return true;

--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -22,15 +22,14 @@ var ColorSpace = (function ColorSpaceClosure() {
   /**
    * Resizes an RGB image with 3 components.
    * @param {TypedArray} src - The source buffer.
-   * @param {Number} bpc - Number of bits per component.
+   * @param {TypedArray} dest - The destination buffer.
    * @param {Number} w1 - Original width.
    * @param {Number} h1 - Original height.
    * @param {Number} w2 - New width.
    * @param {Number} h2 - New height.
    * @param {Number} alpha01 - Size reserved for the alpha channel.
-   * @param {TypedArray} dest - The destination buffer.
    */
-  function resizeRgbImage(src, bpc, w1, h1, w2, h2, alpha01, dest) {
+  function resizeRgbImage(src, dest, w1, h1, w2, h2, alpha01) {
     var COMPONENTS = 3;
     alpha01 = alpha01 !== 1 ? 0 : alpha01;
     var xRatio = w1 / w2;
@@ -174,8 +173,8 @@ var ColorSpace = (function ColorSpaceClosure() {
 
       if (rgbBuf) {
         if (needsResizing) {
-          resizeRgbImage(rgbBuf, bpc, originalWidth, originalHeight,
-                         width, height, alpha01, dest);
+          resizeRgbImage(rgbBuf, dest, originalWidth, originalHeight,
+                         width, height, alpha01);
         } else {
           rgbPos = 0;
           destPos = 0;

--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -14,7 +14,7 @@
  */
 
 import {
-  FormatError, info, isString, shadow, unreachable, warn
+  assert, FormatError, info, isString, shadow, unreachable, warn
 } from '../shared/util';
 import { isDict, isName, isStream } from './primitives';
 
@@ -109,6 +109,11 @@ var ColorSpace = (function ColorSpaceClosure() {
      */
     fillRgb(dest, originalWidth, originalHeight, width, height, actualHeight,
             bpc, comps, alpha01) {
+      if (typeof PDFJSDev === 'undefined' ||
+          PDFJSDev.test('!PRODUCTION || TESTING')) {
+        assert(dest instanceof Uint8ClampedArray,
+               'ColorSpace.fillRgb: Unsupported "dest" type.');
+      }
       var count = originalWidth * originalHeight;
       var rgbBuf = null;
       var numComponentColors = 1 << bpc;
@@ -433,11 +438,21 @@ var AlternateCS = (function AlternateCSClosure() {
   AlternateCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
     getRgbItem(src, srcOffset, dest, destOffset) {
+      if (typeof PDFJSDev === 'undefined' ||
+          PDFJSDev.test('!PRODUCTION || TESTING')) {
+        assert(dest instanceof Uint8ClampedArray,
+               'AlternateCS.getRgbItem: Unsupported "dest" type.');
+      }
       var tmpBuf = this.tmpBuf;
       this.tintFn(src, srcOffset, tmpBuf, 0);
       this.base.getRgbItem(tmpBuf, 0, dest, destOffset);
     },
     getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
+      if (typeof PDFJSDev === 'undefined' ||
+          PDFJSDev.test('!PRODUCTION || TESTING')) {
+        assert(dest instanceof Uint8ClampedArray,
+               'AlternateCS.getRgbBuffer: Unsupported "dest" type.');
+      }
       var tintFn = this.tintFn;
       var base = this.base;
       var scale = 1 / ((1 << bits) - 1);
@@ -529,11 +544,21 @@ var IndexedCS = (function IndexedCSClosure() {
   IndexedCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
     getRgbItem(src, srcOffset, dest, destOffset) {
+      if (typeof PDFJSDev === 'undefined' ||
+          PDFJSDev.test('!PRODUCTION || TESTING')) {
+        assert(dest instanceof Uint8ClampedArray,
+               'IndexedCS.getRgbItem: Unsupported "dest" type.');
+      }
       var numComps = this.base.numComps;
       var start = src[srcOffset] * numComps;
       this.base.getRgbBuffer(this.lookup, start, 1, dest, destOffset, 8, 0);
     },
     getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
+      if (typeof PDFJSDev === 'undefined' ||
+          PDFJSDev.test('!PRODUCTION || TESTING')) {
+        assert(dest instanceof Uint8ClampedArray,
+               'IndexedCS.getRgbBuffer: Unsupported "dest" type.');
+      }
       var base = this.base;
       var numComps = base.numComps;
       var outputDelta = base.getOutputLength(numComps, alpha01);
@@ -570,10 +595,20 @@ var DeviceGrayCS = (function DeviceGrayCSClosure() {
   DeviceGrayCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
     getRgbItem(src, srcOffset, dest, destOffset) {
+      if (typeof PDFJSDev === 'undefined' ||
+          PDFJSDev.test('!PRODUCTION || TESTING')) {
+        assert(dest instanceof Uint8ClampedArray,
+               'DeviceGrayCS.getRgbItem: Unsupported "dest" type.');
+      }
       let c = src[srcOffset] * 255;
       dest[destOffset] = dest[destOffset + 1] = dest[destOffset + 2] = c;
     },
     getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
+      if (typeof PDFJSDev === 'undefined' ||
+          PDFJSDev.test('!PRODUCTION || TESTING')) {
+        assert(dest instanceof Uint8ClampedArray,
+               'DeviceGrayCS.getRgbBuffer: Unsupported "dest" type.');
+      }
       var scale = 255 / ((1 << bits) - 1);
       var j = srcOffset, q = destOffset;
       for (var i = 0; i < count; ++i) {
@@ -606,11 +641,21 @@ var DeviceRgbCS = (function DeviceRgbCSClosure() {
   DeviceRgbCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
     getRgbItem(src, srcOffset, dest, destOffset) {
+      if (typeof PDFJSDev === 'undefined' ||
+          PDFJSDev.test('!PRODUCTION || TESTING')) {
+        assert(dest instanceof Uint8ClampedArray,
+               'DeviceRgbCS.getRgbItem: Unsupported "dest" type.');
+      }
       dest[destOffset] = src[srcOffset] * 255;
       dest[destOffset + 1] = src[srcOffset + 1] * 255;
       dest[destOffset + 2] = src[srcOffset + 2] * 255;
     },
     getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
+      if (typeof PDFJSDev === 'undefined' ||
+          PDFJSDev.test('!PRODUCTION || TESTING')) {
+        assert(dest instanceof Uint8ClampedArray,
+               'DeviceRgbCS.getRgbBuffer: Unsupported "dest" type.');
+      }
       if (bits === 8 && alpha01 === 0) {
         dest.set(src.subarray(srcOffset, srcOffset + count * 3), destOffset);
         return;
@@ -692,9 +737,19 @@ var DeviceCmykCS = (function DeviceCmykCSClosure() {
   DeviceCmykCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
     getRgbItem(src, srcOffset, dest, destOffset) {
+      if (typeof PDFJSDev === 'undefined' ||
+          PDFJSDev.test('!PRODUCTION || TESTING')) {
+        assert(dest instanceof Uint8ClampedArray,
+               'DeviceCmykCS.getRgbItem: Unsupported "dest" type.');
+      }
       convertToRgb(src, srcOffset, 1, dest, destOffset);
     },
     getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
+      if (typeof PDFJSDev === 'undefined' ||
+          PDFJSDev.test('!PRODUCTION || TESTING')) {
+        assert(dest instanceof Uint8ClampedArray,
+               'DeviceCmykCS.getRgbBuffer: Unsupported "dest" type.');
+      }
       var scale = 1 / ((1 << bits) - 1);
       for (var i = 0; i < count; i++) {
         convertToRgb(src, srcOffset, scale, dest, destOffset);
@@ -786,9 +841,19 @@ var CalGrayCS = (function CalGrayCSClosure() {
   CalGrayCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
     getRgbItem(src, srcOffset, dest, destOffset) {
+      if (typeof PDFJSDev === 'undefined' ||
+          PDFJSDev.test('!PRODUCTION || TESTING')) {
+        assert(dest instanceof Uint8ClampedArray,
+               'CalGrayCS.getRgbItem: Unsupported "dest" type.');
+      }
       convertToRgb(this, src, srcOffset, dest, destOffset, 1);
     },
     getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
+      if (typeof PDFJSDev === 'undefined' ||
+          PDFJSDev.test('!PRODUCTION || TESTING')) {
+        assert(dest instanceof Uint8ClampedArray,
+               'CalGrayCS.getRgbBuffer: Unsupported "dest" type.');
+      }
       var scale = 1 / ((1 << bits) - 1);
 
       for (var i = 0; i < count; ++i) {
@@ -1075,9 +1140,19 @@ var CalRGBCS = (function CalRGBCSClosure() {
   CalRGBCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
     getRgbItem(src, srcOffset, dest, destOffset) {
+      if (typeof PDFJSDev === 'undefined' ||
+          PDFJSDev.test('!PRODUCTION || TESTING')) {
+        assert(dest instanceof Uint8ClampedArray,
+               'CalRGBCS.getRgbItem: Unsupported "dest" type.');
+      }
       convertToRgb(this, src, srcOffset, dest, destOffset, 1);
     },
     getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
+      if (typeof PDFJSDev === 'undefined' ||
+          PDFJSDev.test('!PRODUCTION || TESTING')) {
+        assert(dest instanceof Uint8ClampedArray,
+              'CalRGBCS.getRgbBuffer: Unsupported "dest" type.');
+      }
       var scale = 1 / ((1 << bits) - 1);
 
       for (var i = 0; i < count; ++i) {
@@ -1218,9 +1293,19 @@ var LabCS = (function LabCSClosure() {
   LabCS.prototype = {
     getRgb: ColorSpace.prototype.getRgb,
     getRgbItem(src, srcOffset, dest, destOffset) {
+      if (typeof PDFJSDev === 'undefined' ||
+          PDFJSDev.test('!PRODUCTION || TESTING')) {
+        assert(dest instanceof Uint8ClampedArray,
+               'LabCS.getRgbItem: Unsupported "dest" type.');
+      }
       convertToRgb(this, src, srcOffset, false, dest, destOffset);
     },
     getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
+      if (typeof PDFJSDev === 'undefined' ||
+          PDFJSDev.test('!PRODUCTION || TESTING')) {
+        assert(dest instanceof Uint8ClampedArray,
+               'LabCS.getRgbBuffer: Unsupported "dest" type.');
+      }
       var maxVal = (1 << bits) - 1;
       for (var i = 0; i < count; i++) {
         convertToRgb(this, src, srcOffset, maxVal, dest, destOffset);

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1261,7 +1261,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           // notification and allow rendering to continue.
           this.handler.send('UnsupportedFeature',
                             { featureId: UNSUPPORTED_FEATURES.unknown, });
-          warn('getOperatorList - ignoring errors during task: ' + task.name);
+          warn(`getOperatorList - ignoring errors during "${task.name}" ` +
+               `task: "${reason}".`);
 
           closePendingRestoreOPS();
           return;
@@ -1846,7 +1847,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         }
         if (this.options.ignoreErrors) {
           // Error(s) in the TextContent -- allow text-extraction to continue.
-          warn('getTextContent - ignoring errors during task: ' + task.name);
+          warn(`getTextContent - ignoring errors during "${task.name}" ` +
+               `task: "${reason}".`);
 
           flushTextContentItem();
           enqueueChunk();

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -377,7 +377,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         var width = dict.get('Width', 'W');
         var height = dict.get('Height', 'H');
         var bitStrideLength = (width + 7) >> 3;
-        var imgArray = image.getBytes(bitStrideLength * height);
+        var imgArray = image.getBytes(bitStrideLength * height,
+                                      /* forceClamped = */ true);
         var decode = dict.getArray('Decode', 'D');
 
         imgData = PDFImage.createMask({

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -244,6 +244,11 @@ var PDFImage = (function PDFImageClosure() {
 
   PDFImage.createMask = function({ imgArray, width, height,
                                    imageIsFromDecodeStream, inverseDecode, }) {
+    if (typeof PDFJSDev === 'undefined' ||
+        PDFJSDev.test('!PRODUCTION || TESTING')) {
+      assert(imgArray instanceof Uint8ClampedArray,
+             'PDFImage.createMask: Unsupported "imgArray" type.');
+    }
     // |imgArray| might not contain full data for every pixel of the mask, so
     // we need to distinguish between |computedLength| and |actualLength|.
     // In particular, if inverseDecode is true, then the array we return must
@@ -399,6 +404,11 @@ var PDFImage = (function PDFImageClosure() {
     },
 
     fillOpacity(rgbaBuf, width, height, actualHeight, image) {
+      if (typeof PDFJSDev === 'undefined' ||
+          PDFJSDev.test('!PRODUCTION || TESTING')) {
+        assert(rgbaBuf instanceof Uint8ClampedArray,
+               'PDFImage.fillOpacity: Unsupported "rgbaBuf" type.');
+      }
       var smask = this.smask;
       var mask = this.mask;
       var alphaBuf, sw, sh, i, ii, j;
@@ -465,6 +475,11 @@ var PDFImage = (function PDFImageClosure() {
     },
 
     undoPreblend(buffer, width, height) {
+      if (typeof PDFJSDev === 'undefined' ||
+          PDFJSDev.test('!PRODUCTION || TESTING')) {
+        assert(buffer instanceof Uint8ClampedArray,
+               'PDFImage.undoPreblend: Unsupported "buffer" type.');
+      }
       var matte = this.smask && this.smask.matte;
       if (!matte) {
         return;
@@ -544,7 +559,8 @@ var PDFImage = (function PDFImageClosure() {
           }
           if (this.needsDecode) {
             // Invert the buffer (which must be grayscale if we reached here).
-            assert(kind === ImageKind.GRAYSCALE_1BPP);
+            assert(kind === ImageKind.GRAYSCALE_1BPP,
+                   'PDFImage.createImageData: The image must be grayscale.');
             var buffer = imgData.data;
             for (var i = 0, ii = buffer.length; i < ii; i++) {
               buffer[i] ^= 0xff;
@@ -610,6 +626,11 @@ var PDFImage = (function PDFImageClosure() {
     },
 
     fillGrayBuffer(buffer) {
+      if (typeof PDFJSDev === 'undefined' ||
+          PDFJSDev.test('!PRODUCTION || TESTING')) {
+        assert(buffer instanceof Uint8ClampedArray,
+               'PDFImage.fillGrayBuffer: Unsupported "buffer" type.');
+      }
       var numComps = this.numComps;
       if (numComps !== 1) {
         throw new FormatError(

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -114,7 +114,7 @@ var Catalog = (function CatalogClosure() {
       // To avoid recursion, keep track of the already processed items.
       var processed = new RefSet();
       processed.put(obj);
-      var xref = this.xref, blackColor = new Uint8Array(3);
+      var xref = this.xref, blackColor = new Uint8ClampedArray(3);
 
       while (queue.length > 0) {
         var i = queue.shift();

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -34,8 +34,10 @@ const MAX_ADLER32_LENGTH = 5552;
 
 function computeAdler32(bytes) {
   let bytesLength = bytes.length;
-  if (bytesLength >= MAX_ADLER32_LENGTH) {
-    throw new Error('computeAdler32: The input is too large.');
+  if (typeof PDFJSDev === 'undefined' ||
+      PDFJSDev.test('!PRODUCTION || TESTING')) {
+    assert(bytesLength < MAX_ADLER32_LENGTH,
+           'computeAdler32: Unsupported "bytes" length.');
   }
   let a = 1, b = 0;
   for (let i = 0; i < bytesLength; ++i) {

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -56,30 +56,33 @@ var Stream = (function StreamClosure() {
       var b3 = this.getByte();
       return (b0 << 24) + (b1 << 16) + (b2 << 8) + b3;
     },
-    // returns subarray of original buffer
-    // should only be read
-    getBytes: function Stream_getBytes(length) {
+    // Returns subarray of original buffer, should only be read.
+    getBytes(length, forceClamped = false) {
       var bytes = this.bytes;
       var pos = this.pos;
       var strEnd = this.end;
 
       if (!length) {
-        return bytes.subarray(pos, strEnd);
+        let subarray = bytes.subarray(pos, strEnd);
+        // `this.bytes` is always a `Uint8Array` here.
+        return (forceClamped ? new Uint8ClampedArray(subarray) : subarray);
       }
       var end = pos + length;
       if (end > strEnd) {
         end = strEnd;
       }
       this.pos = end;
-      return bytes.subarray(pos, end);
+      let subarray = bytes.subarray(pos, end);
+      // `this.bytes` is always a `Uint8Array` here.
+      return (forceClamped ? new Uint8ClampedArray(subarray) : subarray);
     },
     peekByte: function Stream_peekByte() {
       var peekedByte = this.getByte();
       this.pos--;
       return peekedByte;
     },
-    peekBytes: function Stream_peekBytes(length) {
-      var bytes = this.getBytes(length);
+    peekBytes(length, forceClamped = false) {
+      var bytes = this.getBytes(length, forceClamped);
       this.pos -= bytes.length;
       return bytes;
     },
@@ -181,7 +184,7 @@ var DecodeStream = (function DecodeStreamClosure() {
       var b3 = this.getByte();
       return (b0 << 24) + (b1 << 16) + (b2 << 8) + b3;
     },
-    getBytes: function DecodeStream_getBytes(length) {
+    getBytes(length, forceClamped = false) {
       var end, pos = this.pos;
 
       if (length) {
@@ -203,15 +206,18 @@ var DecodeStream = (function DecodeStreamClosure() {
       }
 
       this.pos = end;
-      return this.buffer.subarray(pos, end);
+      let subarray = this.buffer.subarray(pos, end);
+      // `this.buffer` is either a `Uint8Array` or `Uint8ClampedArray` here.
+      return (forceClamped && !(subarray instanceof Uint8ClampedArray) ?
+              new Uint8ClampedArray(subarray) : subarray);
     },
     peekByte: function DecodeStream_peekByte() {
       var peekedByte = this.getByte();
       this.pos--;
       return peekedByte;
     },
-    peekBytes: function DecodeStream_peekBytes(length) {
-      var bytes = this.getBytes(length);
+    peekBytes(length, forceClamped = false) {
+      var bytes = this.getBytes(length, forceClamped);
       this.pos -= bytes.length;
       return bytes;
     },

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -379,8 +379,10 @@ var WorkerMessageHandler = {
     let apiVersion = docParams.apiVersion;
     let workerVersion =
       typeof PDFJSDev !== 'undefined' ? PDFJSDev.eval('BUNDLE_VERSION') : null;
-    // The `apiVersion !== null` check is needed to avoid errors during testing.
-    if (apiVersion !== null && apiVersion !== workerVersion) {
+    if ((typeof PDFJSDev !== 'undefined' && PDFJSDev.test('TESTING')) &&
+        apiVersion === null) {
+      warn('Ignoring apiVersion/workerVersion check in TESTING builds.');
+    } else if (apiVersion !== workerVersion) {
       throw new Error(`The API version "${apiVersion}" does not match ` +
                       `the Worker version "${workerVersion}".`);
     }

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -671,7 +671,7 @@ var PDFDocumentProxy = (function PDFDocumentProxyClosure() {
      *   title: string,
      *   bold: boolean,
      *   italic: boolean,
-     *   color: rgb Uint8Array,
+     *   color: rgb Uint8ClampedArray,
      *   dest: dest obj,
      *   url: string,
      *   items: array of more items like this

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -166,7 +166,7 @@ describe('annotation', function() {
       var annotation = new Annotation({ dict, ref, });
       annotation.setColor('red');
 
-      expect(annotation.color).toEqual(new Uint8Array([0, 0, 0]));
+      expect(annotation.color).toEqual(new Uint8ClampedArray([0, 0, 0]));
     });
 
     it('should set and get a transparent color', function() {
@@ -180,28 +180,28 @@ describe('annotation', function() {
       var annotation = new Annotation({ dict, ref, });
       annotation.setColor([0.4]);
 
-      expect(annotation.color).toEqual(new Uint8Array([102, 102, 102]));
+      expect(annotation.color).toEqual(new Uint8ClampedArray([102, 102, 102]));
     });
 
     it('should set and get an RGB color', function() {
       var annotation = new Annotation({ dict, ref, });
       annotation.setColor([0, 0, 1]);
 
-      expect(annotation.color).toEqual(new Uint8Array([0, 0, 255]));
+      expect(annotation.color).toEqual(new Uint8ClampedArray([0, 0, 255]));
     });
 
     it('should set and get a CMYK color', function() {
       var annotation = new Annotation({ dict, ref, });
       annotation.setColor([0.1, 0.92, 0.84, 0.02]);
 
-      expect(annotation.color).toEqual(new Uint8Array([233, 59, 47]));
+      expect(annotation.color).toEqual(new Uint8ClampedArray([234, 59, 48]));
     });
 
     it('should not set and get an invalid color', function() {
       var annotation = new Annotation({ dict, ref, });
       annotation.setColor([0.4, 0.6]);
 
-      expect(annotation.color).toEqual(new Uint8Array([0, 0, 0]));
+      expect(annotation.color).toEqual(new Uint8ClampedArray([0, 0, 0]));
     });
   });
 

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -764,7 +764,7 @@ describe('api', function() {
 
         expect(outlineItem.bold).toEqual(true);
         expect(outlineItem.italic).toEqual(false);
-        expect(outlineItem.color).toEqual(new Uint8Array([0, 64, 128]));
+        expect(outlineItem.color).toEqual(new Uint8ClampedArray([0, 64, 128]));
 
         expect(outlineItem.items.length).toEqual(1);
         expect(outlineItem.items[0].title).toEqual('Paragraph 1.1');
@@ -791,7 +791,8 @@ describe('api', function() {
           var outlineItemOne = outline[1];
           expect(outlineItemOne.bold).toEqual(false);
           expect(outlineItemOne.italic).toEqual(true);
-          expect(outlineItemOne.color).toEqual(new Uint8Array([0, 0, 0]));
+          expect(outlineItemOne.color).toEqual(
+            new Uint8ClampedArray([0, 0, 0]));
 
           loadingTask.destroy().then(done);
         });

--- a/test/unit/colorspace_spec.js
+++ b/test/unit/colorspace_spec.js
@@ -61,8 +61,8 @@ describe('colorspace', function () {
       let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
 
       let testSrc = new Uint8Array([27, 125, 250, 131]);
-      let testDest = new Uint8Array(4 * 4 * 3);
-      let expectedDest = new Uint8Array([
+      let testDest = new Uint8ClampedArray(4 * 4 * 3);
+      let expectedDest = new Uint8ClampedArray([
         27, 27, 27,
         27, 27, 27,
         125, 125, 125,
@@ -83,7 +83,7 @@ describe('colorspace', function () {
       colorSpace.fillRgb(testDest, 2, 2, 4, 4, 4, 8, testSrc, 0);
 
       expect(colorSpace.getRgb(new Float32Array([0.1]), 0))
-        .toEqual(new Uint8Array([25, 25, 25]));
+        .toEqual(new Uint8ClampedArray([26, 26, 26]));
       expect(colorSpace.getOutputLength(2, 0)).toEqual(6);
       expect(colorSpace.isPassthrough(8)).toBeFalsy();
       expect(testDest).toEqual(expectedDest);
@@ -102,8 +102,8 @@ describe('colorspace', function () {
       let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
 
       let testSrc = new Uint8Array([27, 125, 250, 131]);
-      let testDest = new Uint8Array(3 * 3 * 3);
-      let expectedDest = new Uint8Array([
+      let testDest = new Uint8ClampedArray(3 * 3 * 3);
+      let expectedDest = new Uint8ClampedArray([
         27, 27, 27,
         27, 27, 27,
         125, 125, 125,
@@ -117,7 +117,7 @@ describe('colorspace', function () {
       colorSpace.fillRgb(testDest, 2, 2, 3, 3, 3, 8, testSrc, 0);
 
       expect(colorSpace.getRgb(new Float32Array([0.2]), 0))
-        .toEqual(new Uint8Array([51, 51, 51]));
+        .toEqual(new Uint8ClampedArray([51, 51, 51]));
       expect(colorSpace.getOutputLength(3, 1)).toEqual(12);
       expect(colorSpace.isPassthrough(8)).toBeFalsy();
       expect(testDest).toEqual(expectedDest);
@@ -144,8 +144,8 @@ describe('colorspace', function () {
         111, 25, 198,
         21, 147, 255
       ]);
-      let testDest = new Uint8Array(4 * 4 * 3);
-      let expectedDest = new Uint8Array([
+      let testDest = new Uint8ClampedArray(4 * 4 * 3);
+      let expectedDest = new Uint8ClampedArray([
         27, 125, 250,
         27, 125, 250,
         131, 139, 140,
@@ -166,7 +166,7 @@ describe('colorspace', function () {
       colorSpace.fillRgb(testDest, 2, 2, 4, 4, 4, 8, testSrc, 0);
 
       expect(colorSpace.getRgb(new Float32Array([0.1, 0.2, 0.3]), 0))
-        .toEqual(new Uint8Array([25, 51, 76]));
+        .toEqual(new Uint8ClampedArray([26, 51, 77]));
       expect(colorSpace.getOutputLength(4, 0)).toEqual(4);
       expect(colorSpace.isPassthrough(8)).toBeTruthy();
       expect(testDest).toEqual(expectedDest);
@@ -190,8 +190,8 @@ describe('colorspace', function () {
         111, 25, 198,
         21, 147, 255
       ]);
-      let testDest = new Uint8Array(3 * 3 * 3);
-      let expectedDest = new Uint8Array([
+      let testDest = new Uint8ClampedArray(3 * 3 * 3);
+      let expectedDest = new Uint8ClampedArray([
         27, 125, 250,
         27, 125, 250,
         131, 139, 140,
@@ -205,7 +205,7 @@ describe('colorspace', function () {
       colorSpace.fillRgb(testDest, 2, 2, 3, 3, 3, 8, testSrc, 0);
 
       expect(colorSpace.getRgb(new Float32Array([0.1, 0.2, 0.3]), 0))
-        .toEqual(new Uint8Array([25, 51, 76]));
+        .toEqual(new Uint8ClampedArray([26, 51, 77]));
       expect(colorSpace.getOutputLength(4, 1)).toEqual(5);
       expect(colorSpace.isPassthrough(8)).toBeTruthy();
       expect(testDest).toEqual(expectedDest);
@@ -232,29 +232,29 @@ describe('colorspace', function () {
         111, 25, 198, 78,
         21, 147, 255, 69
       ]);
-      let testDest = new Uint8Array(4 * 4 * 3);
-      let expectedDest = new Uint8Array([
-        135, 80, 18,
-        135, 80, 18,
-        113, 102, 97,
-        113, 102, 97,
-        135, 80, 18,
-        135, 80, 18,
-        113, 102, 97,
-        113, 102, 97,
-        112, 143, 75,
-        112, 143, 75,
+      let testDest = new Uint8ClampedArray(4 * 4 * 3);
+      let expectedDest = new Uint8ClampedArray([
+        135, 81, 18,
+        135, 81, 18,
+        114, 102, 97,
+        114, 102, 97,
+        135, 81, 18,
+        135, 81, 18,
+        114, 102, 97,
+        114, 102, 97,
+        112, 144, 75,
+        112, 144, 75,
         188, 98, 27,
         188, 98, 27,
-        112, 143, 75,
-        112, 143, 75,
+        112, 144, 75,
+        112, 144, 75,
         188, 98, 27,
         188, 98, 27
       ]);
       colorSpace.fillRgb(testDest, 2, 2, 4, 4, 4, 8, testSrc, 0);
 
       expect(colorSpace.getRgb(new Float32Array([0.1, 0.2, 0.3, 1]),
-        0)).toEqual(new Uint8Array([31, 27, 20]));
+        0)).toEqual(new Uint8ClampedArray([32, 28, 21]));
       expect(colorSpace.getOutputLength(4, 0)).toEqual(3);
       expect(colorSpace.isPassthrough(8)).toBeFalsy();
       expect(testDest).toEqual(expectedDest);
@@ -278,22 +278,22 @@ describe('colorspace', function () {
         111, 25, 198, 78,
         21, 147, 255, 69
       ]);
-      let testDest = new Uint8Array(3 * 3 * 3);
-      let expectedDest = new Uint8Array([
-        135, 80, 18,
-        135, 80, 18,
-        113, 102, 97,
-        135, 80, 18,
-        135, 80, 18,
-        113, 102, 97,
-        112, 143, 75,
-        112, 143, 75,
+      let testDest = new Uint8ClampedArray(3 * 3 * 3);
+      let expectedDest = new Uint8ClampedArray([
+        135, 81, 18,
+        135, 81, 18,
+        114, 102, 97,
+        135, 81, 18,
+        135, 81, 18,
+        114, 102, 97,
+        112, 144, 75,
+        112, 144, 75,
         188, 98, 27
       ]);
       colorSpace.fillRgb(testDest, 2, 2, 3, 3, 3, 8, testSrc, 0);
 
       expect(colorSpace.getRgb(new Float32Array([0.1, 0.2, 0.3, 1]), 0))
-        .toEqual(new Uint8Array([31, 27, 20]));
+        .toEqual(new Uint8ClampedArray([32, 28, 21]));
       expect(colorSpace.getOutputLength(4, 1)).toEqual(4);
       expect(colorSpace.isPassthrough(8)).toBeFalsy();
       expect(testDest).toEqual(expectedDest);
@@ -323,8 +323,8 @@ describe('colorspace', function () {
       let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
 
       let testSrc = new Uint8Array([27, 125, 250, 131]);
-      let testDest = new Uint8Array(4 * 4 * 3);
-      let expectedDest = new Uint8Array([
+      let testDest = new Uint8ClampedArray(4 * 4 * 3);
+      let expectedDest = new Uint8ClampedArray([
         25, 25, 25,
         25, 25, 25,
         143, 143, 143,
@@ -335,17 +335,17 @@ describe('colorspace', function () {
         143, 143, 143,
         251, 251, 251,
         251, 251, 251,
-        148, 148, 148,
-        148, 148, 148,
+        149, 149, 149,
+        149, 149, 149,
         251, 251, 251,
         251, 251, 251,
-        148, 148, 148,
-        148, 148, 148
+        149, 149, 149,
+        149, 149, 149
       ]);
       colorSpace.fillRgb(testDest, 2, 2, 4, 4, 4, 8, testSrc, 0);
 
       expect(colorSpace.getRgb(new Float32Array([1.0]), 0))
-        .toEqual(new Uint8Array([255, 255, 255]));
+        .toEqual(new Uint8ClampedArray([255, 255, 255]));
       expect(colorSpace.getOutputLength(4, 0)).toEqual(12);
       expect(colorSpace.isPassthrough(8)).toBeFalsy();
       expect(testDest).toEqual(expectedDest);
@@ -381,8 +381,8 @@ describe('colorspace', function () {
         111, 25, 198,
         21, 147, 255
       ]);
-      let testDest = new Uint8Array(3 * 3 * 3);
-      let expectedDest = new Uint8Array([
+      let testDest = new Uint8ClampedArray(3 * 3 * 3);
+      let expectedDest = new Uint8ClampedArray([
         0, 238, 255,
         0, 238, 255,
         185, 196, 195,
@@ -396,7 +396,7 @@ describe('colorspace', function () {
       colorSpace.fillRgb(testDest, 2, 2, 3, 3, 3, 8, testSrc, 0);
 
       expect(colorSpace.getRgb(new Float32Array([0.1, 0.2, 0.3]), 0))
-        .toEqual(new Uint8Array([0, 147, 151]));
+        .toEqual(new Uint8ClampedArray([0, 147, 151]));
       expect(colorSpace.getOutputLength(4, 0)).toEqual(4);
       expect(colorSpace.isPassthrough(8)).toBeFalsy();
       expect(testDest).toEqual(expectedDest);
@@ -431,22 +431,22 @@ describe('colorspace', function () {
         11, 25, 98,
         21, 47, 55
       ]);
-      let testDest = new Uint8Array(3 * 3 * 3);
-      let expectedDest = new Uint8Array([
+      let testDest = new Uint8ClampedArray(3 * 3 * 3);
+      let expectedDest = new Uint8ClampedArray([
         0, 49, 101,
         0, 49, 101,
-        0, 53, 116,
+        0, 53, 117,
         0, 49, 101,
         0, 49, 101,
-        0, 53, 116,
-        0, 40, 39,
-        0, 40, 39,
+        0, 53, 117,
+        0, 41, 40,
+        0, 41, 40,
         0, 43, 90
       ]);
       colorSpace.fillRgb(testDest, 2, 2, 3, 3, 3, 8, testSrc, 0);
 
       expect(colorSpace.getRgb([55, 25, 35], 0))
-        .toEqual(new Uint8Array([188, 99, 61]));
+        .toEqual(new Uint8ClampedArray([188, 100, 61]));
       expect(colorSpace.getOutputLength(4, 0)).toEqual(4);
       expect(colorSpace.isPassthrough(8)).toBeFalsy();
       expect(colorSpace.isDefaultDecode([0, 1])).toBeTruthy();
@@ -479,8 +479,8 @@ describe('colorspace', function () {
       let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
 
       let testSrc = new Uint8Array([2, 2, 0, 1]);
-      let testDest = new Uint8Array(3 * 3 * 3);
-      let expectedDest = new Uint8Array([
+      let testDest = new Uint8ClampedArray(3 * 3 * 3);
+      let expectedDest = new Uint8ClampedArray([
         255, 109, 70,
         255, 109, 70,
         255, 109, 70,
@@ -493,7 +493,8 @@ describe('colorspace', function () {
       ]);
       colorSpace.fillRgb(testDest, 2, 2, 3, 3, 3, 8, testSrc, 0);
 
-      expect(colorSpace.getRgb([2], 0)).toEqual(new Uint8Array([255, 109, 70]));
+      expect(colorSpace.getRgb([2], 0)).toEqual(
+        new Uint8ClampedArray([255, 109, 70]));
       expect(colorSpace.isPassthrough(8)).toBeFalsy();
       expect(colorSpace.isDefaultDecode([0, 1])).toBeTruthy();
       expect(testDest).toEqual(expectedDest);
@@ -534,22 +535,22 @@ describe('colorspace', function () {
       let colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
 
       let testSrc = new Uint8Array([27, 25, 50, 31]);
-      let testDest = new Uint8Array(3 * 3 * 3);
-      let expectedDest = new Uint8Array([
-        227, 243, 242,
-        227, 243, 242,
-        228, 243, 242,
-        227, 243, 242,
-        227, 243, 242,
-        228, 243, 242,
-        203, 233, 229,
-        203, 233, 229,
-        222, 241, 239
+      let testDest = new Uint8ClampedArray(3 * 3 * 3);
+      let expectedDest = new Uint8ClampedArray([
+        226, 242, 241,
+        226, 242, 241,
+        229, 244, 242,
+        226, 242, 241,
+        226, 242, 241,
+        229, 244, 242,
+        203, 232, 229,
+        203, 232, 229,
+        222, 241, 238
       ]);
       colorSpace.fillRgb(testDest, 2, 2, 3, 3, 3, 8, testSrc, 0);
 
       expect(colorSpace.getRgb([0.1], 0))
-        .toEqual(new Uint8Array([228, 243, 241]));
+        .toEqual(new Uint8ClampedArray([228, 243, 242]));
       expect(colorSpace.isPassthrough(8)).toBeFalsy();
       expect(colorSpace.isDefaultDecode([0, 1])).toBeTruthy();
       expect(testDest).toEqual(expectedDest);

--- a/test/unit/stream_spec.js
+++ b/test/unit/stream_spec.js
@@ -59,6 +59,11 @@ describe('stream', function() {
       expect(result).toMatchTypedArray(
         new Uint8Array([100, 3, 101, 2, 102, 1])
       );
+
+      predictor.reset();
+      let clampedResult = predictor.getBytes(6, /* forceClamped = */ true);
+      expect(clampedResult).toEqual(
+        new Uint8ClampedArray([100, 3, 101, 2, 102, 1]));
     });
   });
 });


### PR DESCRIPTION
*This supersedes PR #8789.*

/cc @timvandermeij 