### PR TITLE
Allow `FontFaceObject.getPathGenerator` to ignore non-embedded fonts during rendering

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1884,6 +1884,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
             var font = new FontFaceObject(exportedData, {
               isEvalSupported: params.isEvalSupported,
               disableFontFace: params.disableFontFace,
+              ignoreErrors: params.ignoreErrors,
               fontRegistry,
             });
             var fontReady = (fontObjs) => {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1885,6 +1885,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
               isEvalSupported: params.isEvalSupported,
               disableFontFace: params.disableFontFace,
               ignoreErrors: params.ignoreErrors,
+              onUnsupportedFeature: this._onUnsupportedFeature.bind(this),
               fontRegistry,
             });
             var fontReady = (fontObjs) => {
@@ -1987,15 +1988,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
         }
       }, this);
 
-      messageHandler.on('UnsupportedFeature', function(data) {
-        if (this.destroyed) {
-          return; // Ignore any pending requests if the worker was terminated.
-        }
-        let loadingTask = this.loadingTask;
-        if (loadingTask.onUnsupportedFeature) {
-          loadingTask.onUnsupportedFeature(data.featureId);
-        }
-      }, this);
+      messageHandler.on('UnsupportedFeature', this._onUnsupportedFeature, this);
 
       messageHandler.on('JpegDecode', function(data) {
         if (this.destroyed) {
@@ -2059,6 +2052,16 @@ var WorkerTransport = (function WorkerTransportClosure() {
           name: data.name,
         });
       }, this);
+    },
+
+    _onUnsupportedFeature({ featureId, }) {
+      if (this.destroyed) {
+        return; // Ignore any pending requests if the worker was terminated.
+      }
+      let loadingTask = this.loadingTask;
+      if (loadingTask.onUnsupportedFeature) {
+        loadingTask.onUnsupportedFeature(featureId);
+      }
     },
 
     getData: function WorkerTransport_getData() {

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -14,7 +14,8 @@
  */
 
 import {
-  assert, bytesToString, isEvalSupported, shadow, string32, warn
+  assert, bytesToString, isEvalSupported, shadow, string32,
+  UNSUPPORTED_FEATURES, warn
 } from '../shared/util';
 
 function FontLoader(docId) {
@@ -339,6 +340,7 @@ var FontFaceObject = (function FontFaceObjectClosure() {
   function FontFaceObject(translatedData, { isEvalSupported = true,
                                             disableFontFace = false,
                                             ignoreErrors = false,
+                                            onUnsupportedFeature = null,
                                             fontRegistry = null, }) {
     this.compiledGlyphs = Object.create(null);
     // importing translated data
@@ -348,6 +350,7 @@ var FontFaceObject = (function FontFaceObjectClosure() {
     this.isEvalSupported = isEvalSupported !== false;
     this.disableFontFace = disableFontFace === true;
     this.ignoreErrors = ignoreErrors === true;
+    this._onUnsupportedFeature = onUnsupportedFeature;
     this.fontRegistry = fontRegistry;
   }
   FontFaceObject.prototype = {
@@ -398,6 +401,9 @@ var FontFaceObject = (function FontFaceObjectClosure() {
       } catch (ex) {
         if (!this.ignoreErrors) {
           throw ex;
+        }
+        if (this._onUnsupportedFeature) {
+          this._onUnsupportedFeature({ featureId: UNSUPPORTED_FEATURES.font, });
         }
         warn(`getPathGenerator - ignoring character: "${ex}".`);
 

--- a/test/pdfs/issue4244.pdf.link
+++ b/test/pdfs/issue4244.pdf.link
@@ -1,0 +1,1 @@
+https://web.archive.org/web/20180613082417/https://tcpdf.org/files/examples/example_026.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2267,6 +2267,13 @@
       "rounds": 1,
       "type": "eq"
     },
+    {  "id": "issue4244",
+       "file": "pdfs/issue4244.pdf",
+       "md5": "26845274a32a537182ced1fd693a38b2",
+       "rounds": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "preistabelle",
       "file": "pdfs/preistabelle.pdf",
       "md5": "d2f0b2086160d4f3d325c79a5dc1fb4d",


### PR DESCRIPTION
This fixes, first of all, the inconsistent error handling that PR #9689 introduced in `InternalRenderTask._scheduleNext`. With the code currently in `master`, a "regular" canvas rendering operation is still left in a perpetually pending state if an error is thrown at any point during rendering (leading to a permanent spinner in the viewer).

Furthermore, rather than stopping all rendering when attempting to draw *non-embedded* fonts as paths, the `FontFaceObject.getPathGenerator` method is now able to ignore errors[1] and let rendering continue with a warning/notification.

*Please note:* While this provides a (perhaps) slightly less jarring behaviour for issue #4244 (and its duplicates), keep in mind that the only "real" solution would be to start shipping standard fonts with the PDF.js library.

---
[1] Similar to PRs #8240 and #8922, this is all controlled with the `stopAtErrors` parameter; please see https://github.com/mozilla/pdf.js/blob/2030d1718f4fb07656ac8ada99dbf7f6f2e4f320/src/display/api.js#L154-L157