### PR TITLE
Remove the `disableFullscreen` hack for embedded IE 11 (issue 9585)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -553,10 +553,6 @@ let PDFViewerApplication = {
         support = false;
       }
     }
-    if (support && AppOptions.get('disableFullscreen') === true) {
-      support = false;
-    }
-
     return shadow(this, 'supportsFullscreen', support);
   },
 

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -43,11 +43,6 @@ const defaultOptions = {
     value: '',
     kind: OptionKind.VIEWER,
   },
-  disableFullscreen: {
-    /** @type {boolean} */
-    value: viewerCompatibilityParams.disableFullscreen || false,
-    kind: OptionKind.VIEWER,
-  },
   disableHistory: {
     /** @type {boolean} */
     value: false,

--- a/web/viewer_compatibility.js
+++ b/web/viewer_compatibility.js
@@ -18,16 +18,7 @@ if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
   const userAgent =
     (typeof navigator !== 'undefined' && navigator.userAgent) || '';
   const isAndroid = /Android/.test(userAgent);
-  const isIE = /Trident/.test(userAgent);
   const isIOS = /\b(iPad|iPhone|iPod)(?=;)/.test(userAgent);
-
-  // Disable fullscreen support for certain problematic configurations.
-  // Support: IE11+ (when embedded).
-  (function checkFullscreenSupport() {
-    if (isIE && window.parent !== window) {
-      compatibilityParams.disableFullscreen = true;
-    }
-  })();
 
   // Limit canvas size to 5 mega-pixels on mobile.
   // Support: Android, iOS


### PR DESCRIPTION
It appears that Microsoft silently fixed the problem that required disabling of fullscreen mode, in e.g. `iframe`s, in IE 11; please see issue #4711 and PR #5525 for historical context.

Unfortunately my Google-fu isn't strong enough to find any *official* information regarding the fixing of the browser bug in IE. However testing of the default viewer in IE 11, with this patch applied, it now appears that Presentation Mode is working correctly even in an `iframe` in IE 11.
Further anecdotal evidence that the bug is in fact fixed, is for example that jQuery previously contained a work-around for the IE bug. However, that's removed over two years ago now; see https://github.com/jquery/jquery/commit/ff1a0822f72d2b39fac691dfcceab6ede5623b90 and the issues referenced there.

Given that the default viewer isn't intended to be used as-is anyway (in custom deployments), it didn't seem necessary to keep the `disableFullscreen` option around since it was *only* ever added for compatibility purposes.

Fixes #9585.