### PR TITLE
Fix regression causing the pages to be offset horizontally in Presentation Mode (PR 8993 follow-up)

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -175,7 +175,8 @@ html[dir='rtl'] #sidebarContent {
   bottom: 0;
   left: 0;
   outline: none;
-
+}
+#viewerContainer:not(.pdfPresentationMode) {
   transition-duration: 200ms;
   transition-timing-function: ease;
 }
@@ -191,12 +192,12 @@ html[dir='rtl'] #viewerContainer {
   transition-duration: 0s;
 }
 
-html[dir='ltr'] #outerContainer.sidebarOpen #viewerContainer {
+html[dir='ltr'] #outerContainer.sidebarOpen #viewerContainer:not(.pdfPresentationMode) {
   transition-property: left;
   left: 200px;
   left: var(--sidebar-width);
 }
-html[dir='rtl'] #outerContainer.sidebarOpen #viewerContainer {
+html[dir='rtl'] #outerContainer.sidebarOpen #viewerContainer:not(.pdfPresentationMode) {
   transition-property: right;
   right: 200px;
   right: var(--sidebar-width);


### PR DESCRIPTION
This is a regression from PR #8993; it causes the pages to be offset horizontally in Presentation Mode, if and only if the sidebar is currently open when the user triggers Presentation Mode.

Please note that while this doesn't seem to affect Firefox, both Chrome and IE are however affected.
Interestingly enough, despite the Chrome extension being affected as well, I cannot find any issue filed about this. (Either Presentation Mode isn't used much at all, or users don't open the sidebar before entering Presentation Mode.)

---
Below is a screen-shot, taken in Chrome, of what the regression may look like (the screen-shot depicts the *entire* fullscreen window). It's especially bad if the sidebar, as is the case here, has been resized as well.

![offset-page](https://user-images.githubusercontent.com/2692120/41418840-e8c96d7c-6ff0-11e8-900d-2045ca0b030f.png)
