### PR TITLE
Clean-up the `PDFDocumentProxy.loadingParams` method in the API, and the `locale` viewer option

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -726,6 +726,11 @@ var PDFDocumentProxy = (function PDFDocumentProxyClosure() {
       return this.loadingTask.destroy();
     },
 
+    /**
+     * @return {Object} A subset of the current {DocumentInitParameters},
+     *   which are either needed in the viewer and/or whose default values
+     *   may be affected by the `apiCompatibilityParams`.
+     */
     get loadingParams() {
       return this.transport.loadingParams;
     },
@@ -2170,8 +2175,6 @@ var WorkerTransport = (function WorkerTransportClosure() {
     get loadingParams() {
       let params = this._params;
       return shadow(this, 'loadingParams', {
-        disableRange: params.disableRange,
-        disableStream: params.disableStream,
         disableAutoFetch: params.disableAutoFetch,
         disableCreateObjectURL: params.disableCreateObjectURL,
         disableFontFace: params.disableFontFace,

--- a/web/app.js
+++ b/web/app.js
@@ -319,11 +319,9 @@ let PDFViewerApplication = {
         let enabled = hashParams['pdfbug'].split(',');
         waitOn.push(loadAndEnablePDFBug(enabled));
       }
-      // Locale can be changed only when special debugging flags is present in
-      // the hash section of the URL, or development version of viewer is used.
-      // It is not possible to change locale for Firefox extension builds.
-      if ((typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION') ||
-           !PDFJSDev.test('FIREFOX || MOZCENTRAL')) && 'locale' in hashParams) {
+      // It is not possible to change locale for the (various) extension builds.
+      if ((typeof PDFJSDev === 'undefined' ||
+           PDFJSDev.test('!PRODUCTION || GENERIC')) && 'locale' in hashParams) {
         AppOptions.set('locale', hashParams['locale']);
       }
     }

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -83,11 +83,9 @@ const defaultOptions = {
     value: './images/',
     kind: OptionKind.VIEWER,
   },
-  locale: {
-    /** @type {string} */
-    value: (typeof navigator !== 'undefined' ? navigator.language : 'en-US'),
-    kind: OptionKind.VIEWER,
-  },
+  /**
+   * The `locale` is, conditionally, defined below.
+   */
   maxCanvasPixels: {
     /** @type {number} */
     value: viewerCompatibilityParams.maxCanvasPixels || 16777216,
@@ -203,6 +201,14 @@ const defaultOptions = {
     kind: OptionKind.WORKER,
   },
 };
+if (typeof PDFJSDev === 'undefined' ||
+    PDFJSDev.test('!PRODUCTION || GENERIC')) {
+  defaultOptions.locale = {
+    /** @type {string} */
+    value: (typeof navigator !== 'undefined' ? navigator.language : 'en-US'),
+    kind: OptionKind.VIEWER,
+  };
+}
 
 const userOptions = Object.create(null);
 


### PR DESCRIPTION
*Please refer to the individual commit messages.*