### PR TITLE
Error, rather than warn, once a number of invalid path operators are encountered in `EvaluatorPreprocessor.read` (bug 1443140)

### DIFF
--- a/test/pdfs/bug1443140.pdf.link
+++ b/test/pdfs/bug1443140.pdf.link
@@ -1,0 +1,1 @@
+https://web.archive.org/web/20180324105403/https://engineering.purdue.edu/~chengkok/papers/2005/p507-li.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -126,14 +126,22 @@
       "file": "pdfs/issue2391-1.pdf",
       "md5": "25ae9cb959612e7b343b55da63af2716",
       "rounds": 1,
-      "lastPage": 1,
-      "type": "load"
+      "type": "eq"
     },
     {  "id": "issue2391-2",
       "file": "pdfs/issue2391-2.pdf",
       "md5": "7e68756d11021a087383eaac95ba45dd",
       "rounds": 1,
       "type": "eq"
+    },
+    {  "id": "bug1443140",
+       "file": "pdfs/bug1443140.pdf",
+       "md5": "8f9347b0d5620537850b24b8385b0982",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 4,
+       "lastPage": 4,
+       "type": "eq"
     },
     {  "id": "issue2531",
       "file": "pdfs/issue2531.pdf",

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -216,6 +216,34 @@ describe('evaluator', function() {
         done();
       });
     });
+
+    it('should error if (many) path operators have too few arguments ' +
+       '(bug 1443140)', function(done) {
+      const NUM_INVALID_OPS = 25;
+      const tempArr = new Array(NUM_INVALID_OPS + 1);
+
+      // Non-path operators, should be ignored.
+      const invalidMoveText = tempArr.join('10 Td\n');
+      const moveTextStream = new StringStream(invalidMoveText);
+      runOperatorListCheck(partialEvaluator, moveTextStream,
+                           new ResourcesMock(), function(result) {
+        expect(result.argsArray).toEqual([]);
+        expect(result.fnArray).toEqual([]);
+        done();
+      });
+
+      // Path operators, should throw error.
+      const invalidLineTo = tempArr.join('20 l\n');
+      const lineToStream = new StringStream(invalidLineTo);
+      runOperatorListCheck(partialEvaluator, lineToStream, new ResourcesMock(),
+          function(error) {
+        expect(error instanceof FormatError).toEqual(true);
+        expect(error.message).toEqual(
+          'Invalid command l: expected 2 args, but received 1 args.');
+        done();
+      });
+    });
+
     it('should close opened saves', function(done) {
       var stream = new StringStream('qq');
       runOperatorListCheck(partialEvaluator, stream, new ResourcesMock(),


### PR DESCRIPTION
Incomplete path operators, in particular, can result in fairly chaotic rendering artifacts, as can be observed on page four of the referenced PDF file.

The initial (naive) solution that was attempted, was to simply throw a `FormatError` as soon as any invalid (i.e. too short) operator was found and rely on the existing `ignoreErrors` code-paths. However, doing so would have caused regressions in some files; see the existing `issue2391-1` test-case, which was promoted to an `eq` test to help prevent future bugs.
Hence this patch, which adds special handling for invalid path operators since those may cause quite bad rendering artifacts.

You could, in all fairness, argue that the patch is a handwavy solution and I wouldn't object. However, given that this only concerns *corrupt* PDF files, the way that PDF viewers (PDF.js included) try to gracefully deal with those could probably be described as a best-effort solution anyway.

This patch also adjusts the existing `warn`/`info` messages to print the command name according to the PDF specification, rather than an internal PDF.js enumeration value. The former should be much more useful for debugging purposes.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1443140.