### PR TITLE
Add unit-tests for `PDFPageProxy.stats` (PR 9245 follow-up)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1037,6 +1037,7 @@ var PDFPageProxy = (function PDFPageProxyClosure() {
           lastChunk: false,
         };
 
+        this._stats.time('Page Request');
         this.transport.messageHandler.send('RenderPageRequest', {
           pageIndex: this.pageIndex,
           intent: renderingIntent,


### PR DESCRIPTION
This wasn't included in PR #9245, since all the API options were still global at that time.

Writing the unit-tests also uncovered an issue with `getOperatorList` not starting the "Page Request" timer.