### PR TITLE
Proper Error Handling for Build Numbers of Downloaded Sources (Non-Git repositories).

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -449,6 +449,8 @@ gulp.task('buildnumber', function (done) {
     if (!err) {
       // Build number is the number of commits since base version
       buildNumber = stdout ? stdout.match(/\n/g).length : 0;
+    } else {
+      console.log('This is not a Git repository; using default build number.');
     }
 
     console.log('Extension build number: ' + buildNumber);


### PR DESCRIPTION
Implemented proper Error Handling along with error message for pdf.js downloaded from other sources like the PDF.JS Mozilla Release Page.
https://github.com/mozilla/pdf.js/releases

Closes #9834 