### PR TITLE
Refactor `PDFFindController` to use the 'pagesinit' event, dispatched on the `eventBus`, to resolve the `_firstPagePromise`

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -409,6 +409,7 @@ let PDFViewerApplication = {
 
       this.findController = new PDFFindController({
         pdfViewer: this.pdfViewer,
+        eventBus,
       });
       this.findController.onUpdateResultsCount = (matchCount) => {
         if (this.supportsIntegratedFind) {

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -479,10 +479,6 @@ class BaseViewer {
       if (this.defaultRenderingQueue) {
         this.update();
       }
-
-      if (this.findController) {
-        this.findController.resolveFirstPage();
-      }
     }).catch((reason) => {
       console.error('Unable to initialize viewer', reason);
     });

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -14,6 +14,7 @@
  */
 
 import { createPromiseCapability } from 'pdfjs-lib';
+import { getGlobalEventBus } from './dom_events';
 import { scrollIntoView } from './ui_utils';
 
 const FindState = {
@@ -45,8 +46,9 @@ const CHARACTERS_TO_NORMALIZE = {
  * Provides search functionality to find a given string in a PDF document.
  */
 class PDFFindController {
-  constructor({ pdfViewer, }) {
+  constructor({ pdfViewer, eventBus = getGlobalEventBus(), }) {
     this.pdfViewer = pdfViewer;
+    this.eventBus = eventBus;
 
     this.onUpdateResultsCount = null;
     this.onUpdateState = null;
@@ -82,7 +84,11 @@ class PDFFindController {
     this.findTimeout = null;
 
     this._firstPagePromise = new Promise((resolve) => {
-      this.resolveFirstPage = resolve;
+      const eventBus = this.eventBus;
+      eventBus.on('pagesinit', function onPagesInit() {
+        eventBus.off('pagesinit', onPagesInit);
+        resolve();
+      });
     });
   }
 


### PR DESCRIPTION
Rather than having to manually call a method on `PDFFindController` instances from `BaseViewer.setDocument`, thus essentially having to resolve the private `_firstPagePromise` from the "outside", this can be done easily with the 'pagesinit' event dispatched on the `eventBus` instead.
Please note this particular `PDFFindController` code pre-dates the `eventBus` by almost three years, which should explain why the code looks the way it does.