### PR TITLE
Prevent the development viewer, started with `gulp server`, from breaking completely in Private Browsing mode

### DIFF
--- a/external/systemjs/plugin-babel-cached.js
+++ b/external/systemjs/plugin-babel-cached.js
@@ -33,6 +33,7 @@ function getDb() {
         resolve(db);
       };
       request.onerror = function () {
+        console.warn('getDb: ' + request.error);
         reject(request.error);
       };
     });
@@ -95,7 +96,7 @@ function sha256(str) {
 }
 
 exports.translate = function (load, opt) {
-  var savedHashCode;
+  var savedHashCode, babelTranslateError;
   return sha256(load.source).then(function (hashCode) {
     savedHashCode = hashCode;
     return loadCache(load.address, hashCode);
@@ -109,6 +110,13 @@ exports.translate = function (load, opt) {
                         translated, load.metadata.format).then(function () {
         return translated;
       });
+    }, function(reason) {
+      throw (babelTranslateError = reason);
     });
+  }.bind(this)).catch(function(reason) {
+    if (babelTranslateError) {
+      throw babelTranslateError;
+    }
+    return babel.translate.call(this, load, opt);
   }.bind(this));
 };


### PR DESCRIPTION
Since attempting to access `IndexedDB` in Private Browsing mode in Firefox will throw an error, see https://bugzilla.mozilla.org/show_bug.cgi?id=781982, the development viewer fails to load.