### PR TITLE
[api-minor] Include export value for checkboxes

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -742,7 +742,7 @@ class ButtonWidgetAnnotation extends WidgetAnnotation {
     this.data.pushButton = this.hasFieldFlag(AnnotationFieldFlag.PUSHBUTTON);
 
     if (this.data.checkBox) {
-      this._processCheckBox();
+      this._processCheckBox(params);
     } else if (this.data.radioButton) {
       this._processRadioButton(params);
     } else if (this.data.pushButton) {
@@ -752,11 +752,29 @@ class ButtonWidgetAnnotation extends WidgetAnnotation {
     }
   }
 
-  _processCheckBox() {
-    if (!isName(this.data.fieldValue)) {
+  _processCheckBox(params) {
+    if (isName(this.data.fieldValue)) {
+      this.data.fieldValue = this.data.fieldValue.name;
+    }
+
+    const customAppearance = params.dict.get('AP');
+    if (!isDict(customAppearance)) {
       return;
     }
-    this.data.fieldValue = this.data.fieldValue.name;
+
+    const exportValueOptionsDict = customAppearance.get('D');
+    if (!isDict(exportValueOptionsDict)) {
+      return;
+    }
+
+    const exportValues = exportValueOptionsDict.getKeys();
+    const hasCorrectOptionCount = exportValues.length === 2;
+    if (!hasCorrectOptionCount) {
+      return;
+    }
+
+    this.data.exportValue = exportValues[0] === 'Off' ?
+      exportValues[1] : exportValues[0];
   }
 
   _processRadioButton(params) {

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -979,7 +979,34 @@ describe('annotation', function() {
       buttonWidgetDict = null;
     });
 
-    it('should handle checkboxes', function() {
+    it('should handle checkboxes with export value', function() {
+      buttonWidgetDict.set('V', Name.get('1'));
+
+      var appearanceStatesDict = new Dict();
+      var exportValueOptionsDict = new Dict();
+
+      exportValueOptionsDict.set('Off', 0);
+      exportValueOptionsDict.set('Checked', 1);
+      appearanceStatesDict.set('D', exportValueOptionsDict);
+      buttonWidgetDict.set('AP', appearanceStatesDict);
+
+      var buttonWidgetRef = new Ref(124, 0);
+      var xref = new XRefMock([
+        { ref: buttonWidgetRef, data: buttonWidgetDict, }
+      ]);
+
+      var annotation = AnnotationFactory.create(xref, buttonWidgetRef,
+                                                pdfManagerMock, idFactoryMock);
+      var data = annotation.data;
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+
+      expect(data.checkBox).toEqual(true);
+      expect(data.fieldValue).toEqual('1');
+      expect(data.radioButton).toEqual(false);
+      expect(data.exportValue).toEqual('Checked');
+    });
+
+    it('should handle checkboxes without export value', function() {
       buttonWidgetDict.set('V', Name.get('1'));
 
       var buttonWidgetRef = new Ref(124, 0);


### PR DESCRIPTION
Fixes #8095 

U.S. Government forms often use checkboxes as radios by specifying different export values of checkboxes with the same name. See the USCIS [I-130](https://www.uscis.gov/sites/default/files/files/form/i-130.pdf) as an example.

Adding the `exportValue` property to checkbox annotation widgets enables correct rendering of checkbox state for forms that do this.