### PR TITLE
Convert more code in the `/src` folder to use ES6 classes, such that `Util.inherit` can be removed

### DIFF
--- a/src/core/font_renderer.js
+++ b/src/core/font_renderer.js
@@ -14,7 +14,7 @@
  */
 
 import {
-  bytesToString, FONT_IDENTITY_MATRIX, FormatError, unreachable, Util, warn
+  bytesToString, FONT_IDENTITY_MATRIX, FormatError, unreachable, warn
 } from '../shared/util';
 import { CFFParser } from './cff_parser';
 import { getGlyphsUnicode } from './glyphlist';
@@ -618,15 +618,20 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
 
   const NOOP = [];
 
-  function CompiledFont(fontMatrix) {
-    this.compiledGlyphs = Object.create(null);
-    this.compiledCharCodeToGlyphId = Object.create(null);
-    this.fontMatrix = fontMatrix;
-  }
-  CompiledFont.prototype = {
+  class CompiledFont {
+    constructor(fontMatrix) {
+      if (this.constructor === CompiledFont) {
+        unreachable('Cannot initialize CompiledFont.');
+      }
+      this.fontMatrix = fontMatrix;
+
+      this.compiledGlyphs = Object.create(null);
+      this.compiledCharCodeToGlyphId = Object.create(null);
+    }
+
     getPathJs(unicode) {
-      var cmap = lookupCmap(this.cmap, unicode);
-      var fn = this.compiledGlyphs[cmap.glyphId];
+      const cmap = lookupCmap(this.cmap, unicode);
+      let fn = this.compiledGlyphs[cmap.glyphId];
       if (!fn) {
         fn = this.compileGlyph(this.glyphs[cmap.glyphId], cmap.glyphId);
         this.compiledGlyphs[cmap.glyphId] = fn;
@@ -635,7 +640,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
         this.compiledCharCodeToGlyphId[cmap.charCode] = cmap.glyphId;
       }
       return fn;
-    },
+    }
 
     compileGlyph(code, glyphId) {
       if (!code || code.length === 0 || code[0] === 14) {
@@ -655,7 +660,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
         }
       }
 
-      var cmds = [];
+      const cmds = [];
       cmds.push({ cmd: 'save', });
       cmds.push({ cmd: 'transform', args: fontMatrix.slice(), });
       cmds.push({ cmd: 'scale', args: ['size', '-size'], });
@@ -665,58 +670,56 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
       cmds.push({ cmd: 'restore', });
 
       return cmds;
-    },
+    }
 
     compileGlyphImpl() {
       unreachable('Children classes should implement this.');
-    },
+    }
 
     hasBuiltPath(unicode) {
-      var cmap = lookupCmap(this.cmap, unicode);
+      const cmap = lookupCmap(this.cmap, unicode);
       return (this.compiledGlyphs[cmap.glyphId] !== undefined &&
               this.compiledCharCodeToGlyphId[cmap.charCode] !== undefined);
-    },
-  };
-
-  function TrueTypeCompiled(glyphs, cmap, fontMatrix) {
-    fontMatrix = fontMatrix || [0.000488, 0, 0, 0.000488, 0, 0];
-    CompiledFont.call(this, fontMatrix);
-
-    this.glyphs = glyphs;
-    this.cmap = cmap;
+    }
   }
 
-  Util.inherit(TrueTypeCompiled, CompiledFont, {
+  class TrueTypeCompiled extends CompiledFont {
+    constructor(glyphs, cmap, fontMatrix) {
+      super(fontMatrix || [0.000488, 0, 0, 0.000488, 0, 0]);
+
+      this.glyphs = glyphs;
+      this.cmap = cmap;
+    }
+
     compileGlyphImpl(code, cmds) {
       compileGlyf(code, cmds, this);
-    },
-  });
-
-  function Type2Compiled(cffInfo, cmap, fontMatrix, glyphNameMap) {
-    fontMatrix = fontMatrix || [0.001, 0, 0, 0.001, 0, 0];
-    CompiledFont.call(this, fontMatrix);
-
-    this.glyphs = cffInfo.glyphs;
-    this.gsubrs = cffInfo.gsubrs || [];
-    this.subrs = cffInfo.subrs || [];
-    this.cmap = cmap;
-    this.glyphNameMap = glyphNameMap || getGlyphsUnicode();
-
-    this.gsubrsBias = (this.gsubrs.length < 1240 ?
-                       107 : (this.gsubrs.length < 33900 ? 1131 : 32768));
-    this.subrsBias = (this.subrs.length < 1240 ?
-                      107 : (this.subrs.length < 33900 ? 1131 : 32768));
-
-    this.isCFFCIDFont = cffInfo.isCFFCIDFont;
-    this.fdSelect = cffInfo.fdSelect;
-    this.fdArray = cffInfo.fdArray;
+    }
   }
 
-  Util.inherit(Type2Compiled, CompiledFont, {
+  class Type2Compiled extends CompiledFont {
+    constructor(cffInfo, cmap, fontMatrix, glyphNameMap) {
+      super(fontMatrix || [0.001, 0, 0, 0.001, 0, 0]);
+
+      this.glyphs = cffInfo.glyphs;
+      this.gsubrs = cffInfo.gsubrs || [];
+      this.subrs = cffInfo.subrs || [];
+      this.cmap = cmap;
+      this.glyphNameMap = glyphNameMap || getGlyphsUnicode();
+
+      this.gsubrsBias = (this.gsubrs.length < 1240 ?
+                         107 : (this.gsubrs.length < 33900 ? 1131 : 32768));
+      this.subrsBias = (this.subrs.length < 1240 ?
+                        107 : (this.subrs.length < 33900 ? 1131 : 32768));
+
+      this.isCFFCIDFont = cffInfo.isCFFCIDFont;
+      this.fdSelect = cffInfo.fdSelect;
+      this.fdArray = cffInfo.fdArray;
+    }
+
     compileGlyphImpl(code, cmds, glyphId) {
       compileCharString(code, cmds, this, glyphId);
-    },
-  });
+    }
+  }
 
   return {
     create: function FontRendererFactory_create(font, seacAnalysisEnabled) {

--- a/src/core/font_renderer.js
+++ b/src/core/font_renderer.js
@@ -616,7 +616,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
     parse(code);
   }
 
-  var noop = '';
+  const NOOP = [];
 
   function CompiledFont(fontMatrix) {
     this.compiledGlyphs = Object.create(null);
@@ -639,7 +639,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
 
     compileGlyph(code, glyphId) {
       if (!code || code.length === 0 || code[0] === 14) {
-        return noop;
+        return NOOP;
       }
 
       let fontMatrix = this.fontMatrix;

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -16,7 +16,7 @@
 import {
   bytesToString, createPromiseCapability, createValidAbsoluteUrl, FormatError,
   info, InvalidPDFException, isBool, isString, MissingDataException, shadow,
-  stringToPDFString, stringToUTF8String, unreachable, Util, warn,
+  stringToPDFString, stringToUTF8String, toRomanNumerals, unreachable, warn,
   XRefParseException
 } from '../shared/util';
 import {
@@ -310,7 +310,7 @@ var Catalog = (function CatalogClosure() {
             break;
           case 'R':
           case 'r':
-            currentLabel = Util.toRoman(currentIndex, style === 'r');
+            currentLabel = toRomanNumerals(currentIndex, style === 'r');
             break;
           case 'A':
           case 'a':

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -875,14 +875,6 @@ var Util = (function UtilClosure() {
     return (lowerCase ? romanStr.toLowerCase() : romanStr);
   };
 
-  Util.inherit = function Util_inherit(sub, base, prototype) {
-    sub.prototype = Object.create(base.prototype);
-    sub.prototype.constructor = sub;
-    for (var prop in prototype) {
-      sub.prototype[prop] = prototype[prop];
-    }
-  };
-
   return Util;
 })();
 

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -839,44 +839,45 @@ var Util = (function UtilClosure() {
     return result;
   };
 
-  var ROMAN_NUMBER_MAP = [
-    '', 'C', 'CC', 'CCC', 'CD', 'D', 'DC', 'DCC', 'DCCC', 'CM',
-    '', 'X', 'XX', 'XXX', 'XL', 'L', 'LX', 'LXX', 'LXXX', 'XC',
-    '', 'I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX'
-  ];
-  /**
-   * Converts positive integers to (upper case) Roman numerals.
-   * @param {integer} number - The number that should be converted.
-   * @param {boolean} lowerCase - Indicates if the result should be converted
-   *   to lower case letters. The default is false.
-   * @return {string} The resulting Roman number.
-   */
-  Util.toRoman = function Util_toRoman(number, lowerCase) {
-    assert(Number.isInteger(number) && number > 0,
-           'The number should be a positive integer.');
-    var pos, romanBuf = [];
-    // Thousands
-    while (number >= 1000) {
-      number -= 1000;
-      romanBuf.push('M');
-    }
-    // Hundreds
-    pos = (number / 100) | 0;
-    number %= 100;
-    romanBuf.push(ROMAN_NUMBER_MAP[pos]);
-    // Tens
-    pos = (number / 10) | 0;
-    number %= 10;
-    romanBuf.push(ROMAN_NUMBER_MAP[10 + pos]);
-    // Ones
-    romanBuf.push(ROMAN_NUMBER_MAP[20 + number]);
-
-    var romanStr = romanBuf.join('');
-    return (lowerCase ? romanStr.toLowerCase() : romanStr);
-  };
-
   return Util;
 })();
+
+const ROMAN_NUMBER_MAP = [
+  '', 'C', 'CC', 'CCC', 'CD', 'D', 'DC', 'DCC', 'DCCC', 'CM',
+  '', 'X', 'XX', 'XXX', 'XL', 'L', 'LX', 'LXX', 'LXXX', 'XC',
+  '', 'I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX'
+];
+
+/**
+ * Converts positive integers to (upper case) Roman numerals.
+ * @param {integer} number - The number that should be converted.
+ * @param {boolean} lowerCase - Indicates if the result should be converted
+ *   to lower case letters. The default value is `false`.
+ * @return {string} The resulting Roman number.
+ */
+function toRomanNumerals(number, lowerCase = false) {
+  assert(Number.isInteger(number) && number > 0,
+         'The number should be a positive integer.');
+  let pos, romanBuf = [];
+  // Thousands
+  while (number >= 1000) {
+    number -= 1000;
+    romanBuf.push('M');
+  }
+  // Hundreds
+  pos = (number / 100) | 0;
+  number %= 100;
+  romanBuf.push(ROMAN_NUMBER_MAP[pos]);
+  // Tens
+  pos = (number / 10) | 0;
+  number %= 10;
+  romanBuf.push(ROMAN_NUMBER_MAP[10 + pos]);
+  // Ones
+  romanBuf.push(ROMAN_NUMBER_MAP[20 + number]);
+
+  const romanStr = romanBuf.join('');
+  return (lowerCase ? romanStr.toLowerCase() : romanStr);
+}
 
 var PDFStringTranslateTable = [
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1025,6 +1026,7 @@ export {
   UnexpectedResponseException,
   UnknownErrorException,
   Util,
+  toRomanNumerals,
   XRefParseException,
   FormatError,
   arrayByteLength,


### PR DESCRIPTION
Compared to the time when ES6 classes were originally introduced in the `/web` folder, things have now improved/changed:
 - A fair number of performance improvements for ES6 classes have landed in Firefox; please see https://bugzilla.mozilla.org/show_bug.cgi?id=1167472 for details.
 - ES6 classes are now used very frequently in the Firefox front-end code.
 - There's already (some) ES6 class usage in the `/src` folder, with (seemingly) no ill effects.
 - By converting more code in the `/src` folder to use proper ES6 classes, the `Util.inherit` function may be replaced by native code.

*Much more manageable diff with: https://github.com/mozilla/pdf.js/pull/9887/files?w=1*