### PR TITLE
Prefer the Width/Height of the image data, rather than the image dictionary, for JPEG 2000 images (issue 9650)

### DIFF
--- a/src/core/image.js
+++ b/src/core/image.js
@@ -91,6 +91,9 @@ var PDFImage = (function PDFImageClosure() {
             var jpxImage = new JpxImage();
             jpxImage.parseImageProperties(image.stream);
             image.stream.reset();
+
+            image.width = jpxImage.width;
+            image.height = jpxImage.height;
             image.bitsPerComponent = jpxImage.bitsPerComponent;
             image.numComps = jpxImage.componentsCount;
             break;
@@ -105,13 +108,23 @@ var PDFImage = (function PDFImageClosure() {
     }
     // TODO cache rendered images?
 
-    this.width = dict.get('Width', 'W');
-    this.height = dict.get('Height', 'H');
+    let width = dict.get('Width', 'W');
+    let height = dict.get('Height', 'H');
 
-    if (this.width < 1 || this.height < 1) {
-      throw new FormatError(`Invalid image width: ${this.width} or ` +
-                            `height: ${this.height}`);
+    if ((Number.isInteger(image.width) && image.width > 0) &&
+        (Number.isInteger(image.height) && image.height > 0) &&
+        (image.width !== width || image.height !== height)) {
+      warn('PDFImage - using the Width/Height of the image data, ' +
+           'rather than the image dictionary.');
+      width = image.width;
+      height = image.height;
     }
+    if (width < 1 || height < 1) {
+      throw new FormatError(`Invalid image width: ${width} or ` +
+                            `height: ${height}`);
+    }
+    this.width = width;
+    this.height = height;
 
     this.interpolate = dict.get('Interpolate', 'I') || false;
     this.imageMask = dict.get('ImageMask', 'IM') || false;

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -142,7 +142,7 @@ var JpxImage = (function JpxImageClosure() {
           this.width = Xsiz - XOsiz;
           this.height = Ysiz - YOsiz;
           this.componentsCount = Csiz;
-          // Results are always returned as Uint8Arrays
+          // Results are always returned as `Uint8ClampedArray`s.
           this.bitsPerComponent = 8;
           return;
         }

--- a/test/pdfs/issue9650.pdf.link
+++ b/test/pdfs/issue9650.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/1898753/Kred.Eingangsrechnungen.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -3259,6 +3259,14 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue9650",
+       "file": "pdfs/issue9650.pdf",
+       "md5": "20d50bda6b1080b6d9088811299c791e",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue9679",
        "file": "pdfs/issue9679.pdf",
        "md5": "3077d06add3875705aa1021c7b116023",


### PR DESCRIPTION
 - Add more validation of the /Filter entry, in image dictionaries, to the `PDFImage` constructor

   Given that the code is currently assuming that the /Filter entry is a `Name`, it probably cannot hurt to actually ensure that's the case.

 - Prefer the Width/Height of the image data, rather than the image dictionary, for JPEG 2000 images (issue 9650)

   According to the PDF specification, see https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#page=45
   > When using the JPXDecode filter with image XObjects, the following changes to and constraints on some entries in the image dictionary shall apply (see 8.9.5, "Image Dictionaries" for details on these entries):
   >
   >  - Width and Height shall match the corresponding width and height values in the JPEG2000 data.
   >
   >  - . . .

   Hence it seems reasonable to use the Width/Height of the image data *itself*, rather than the image dictionary when there's a mismatch. Given that JPEG 2000 images are already being parsed, in order to obtain basic parameters, the actual Width/Height is readily available in the `PDFImage` constructor.

Fixes #9650.