### PR TITLE
[api-minor] Add an `IsLinearized` property to the `PDFDocument.documentInfo` getter, to allow accessing the linearization status through the API (via `PDFDocumentProxy.getMetadata`)

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -120,6 +120,11 @@ document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} 
 # "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
 # the size, respectively their unit of measurement, name, and orientation, of the (current) page.
 document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Fast Web View:
+document_properties_linearized_yes=Yes
+document_properties_linearized_no=No
 document_properties_close=Close
 
 print_progress_message=Preparing document for printing…

--- a/l10n/nl/viewer.properties
+++ b/l10n/nl/viewer.properties
@@ -120,6 +120,11 @@ document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} 
 # "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
 # the size, respectively their unit of measurement, name, and orientation, of the (current) page.
 document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Snelle webweergave:
+document_properties_linearized_yes=Ja
+document_properties_linearized_no=Nee
 document_properties_close=Sluiten
 
 print_progress_message=Document voorbereiden voor afdrukken…

--- a/l10n/sv-SE/viewer.properties
+++ b/l10n/sv-SE/viewer.properties
@@ -120,6 +120,11 @@ document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} 
 # "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
 # the size, respectively their unit of measurement, name, and orientation, of the (current) page.
 document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Snabb webbvisning:
+document_properties_linearized_yes=Ja
+document_properties_linearized_no=Nej
 document_properties_close=Stäng
 
 print_progress_message=Förbereder sidor för utskrift…

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -424,16 +424,14 @@ var PDFDocument = (function PDFDocumentClosure() {
     },
 
     get linearization() {
-      var linearization = null;
-      if (this.stream.length) {
-        try {
-          linearization = Linearization.create(this.stream);
-        } catch (err) {
-          if (err instanceof MissingDataException) {
-            throw err;
-          }
-          info(err);
+      let linearization = null;
+      try {
+        linearization = Linearization.create(this.stream);
+      } catch (err) {
+        if (err instanceof MissingDataException) {
+          throw err;
         }
+        info(err);
       }
       // shadow the prototype getter with a data property
       return shadow(this, 'linearization', linearization);

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -535,12 +535,13 @@ var PDFDocument = (function PDFDocumentClosure() {
       return shadow(this, 'numPages', num);
     },
     get documentInfo() {
-      var docInfo = {
+      const docInfo = {
         PDFFormatVersion: this.pdfFormatVersion,
+        IsLinearized: !!this.linearization,
         IsAcroFormPresent: !!this.acroForm,
         IsXFAPresent: !!this.xfa,
       };
-      var infoDict;
+      let infoDict;
       try {
         infoDict = this.xref.trailer.get('Info');
       } catch (err) {

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -377,22 +377,16 @@ var PDFDocument = (function PDFDocumentClosure() {
     return true; /* found */
   }
 
-  var DocumentInfoValidators = {
-    get entries() {
-      // Lazily build this since all the validation functions below are not
-      // defined until after this file loads.
-      return shadow(this, 'entries', {
-        Title: isString,
-        Author: isString,
-        Subject: isString,
-        Keywords: isString,
-        Creator: isString,
-        Producer: isString,
-        CreationDate: isString,
-        ModDate: isString,
-        Trapped: isName,
-      });
-    },
+  const DocumentInfoValidators = {
+    Title: isString,
+    Author: isString,
+    Subject: isString,
+    Keywords: isString,
+    Creator: isString,
+    Producer: isString,
+    CreationDate: isString,
+    ModDate: isString,
+    Trapped: isName,
   };
 
   PDFDocument.prototype = {
@@ -555,14 +549,13 @@ var PDFDocument = (function PDFDocumentClosure() {
         }
         info('The document information dictionary is invalid.');
       }
-      if (infoDict) {
-        var validEntries = DocumentInfoValidators.entries;
+      if (isDict(infoDict)) {
         // Only fill the document info with valid entries from the spec.
-        for (var key in validEntries) {
+        for (let key in DocumentInfoValidators) {
           if (infoDict.has(key)) {
-            var value = infoDict.get(key);
+            const value = infoDict.get(key);
             // Make sure the value conforms to the spec.
-            if (validEntries[key](value)) {
+            if (DocumentInfoValidators[key](value)) {
               docInfo[key] = (typeof value !== 'string' ?
                               value : stringToPDFString(value));
             } else {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -28,6 +28,7 @@ import {
 } from '../../src/display/api';
 import { GlobalWorkerOptions } from '../../src/display/worker_options';
 import isNodeJS from '../../src/shared/is_node';
+import { Metadata } from '../../src/display/metadata';
 
 describe('api', function() {
   let basicApiFileName = 'basicapi.pdf';
@@ -802,11 +803,18 @@ describe('api', function() {
     });
     it('gets metadata', function(done) {
       var promise = doc.getMetadata();
-      promise.then(function(metadata) {
-        expect(metadata.info['Title']).toEqual('Basic API Test');
-        expect(metadata.info['PDFFormatVersion']).toEqual('1.7');
-        expect(metadata.metadata.get('dc:title')).toEqual('Basic API Test');
-        expect(metadata.contentDispositionFilename).toEqual(null);
+      promise.then(function({ info, metadata, contentDispositionFilename, }) {
+        expect(info['Title']).toEqual('Basic API Test');
+        // The following are PDF.js specific, non-standard, properties.
+        expect(info['PDFFormatVersion']).toEqual('1.7');
+        expect(info['IsLinearized']).toEqual(false);
+        expect(info['IsAcroFormPresent']).toEqual(false);
+        expect(info['IsXFAPresent']).toEqual(false);
+
+        expect(metadata instanceof Metadata).toEqual(true);
+        expect(metadata.get('dc:title')).toEqual('Basic API Test');
+
+        expect(contentDispositionFilename).toEqual(null);
         done();
       }).catch(function (reason) {
         done.fail(reason);

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -128,9 +128,10 @@ class PDFDocumentProperties {
             return this._parsePageSize(getPageSizeInches(pdfPage),
                                        pagesRotation);
           }),
+          this._parseLinearization(info.IsLinearized),
         ]);
       }).then(([info, metadata, fileName, fileSize, creationDate, modDate,
-                pageSize]) => {
+                pageSize, isLinearized]) => {
         freezeFieldData({
           'fileName': fileName,
           'fileSize': fileSize,
@@ -145,6 +146,7 @@ class PDFDocumentProperties {
           'version': info.PDFFormatVersion,
           'pageCount': this.pdfDocument.numPages,
           'pageSize': pageSize,
+          'linearized': isLinearized,
           '_currentPageNumber': currentPageNumber,
           '_pagesRotation': pagesRotation,
         });
@@ -405,6 +407,15 @@ class PDFDocumentProperties {
     return this.l10n.get('document_properties_date_string',
                          { date: dateString, time: timeString, },
                          '{{date}}, {{time}}');
+  }
+
+  /**
+   * @private
+   */
+  _parseLinearization(isLinearized) {
+    return this.l10n.get('document_properties_linearized_' +
+                         (isLinearized ? 'yes' : 'no'), null,
+                         (isLinearized ? 'Yes' : 'No'));
   }
 }
 

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -378,6 +378,10 @@ See https://github.com/adobe-type-tools/cmap-resources
             <div class="row">
               <span data-l10n-id="document_properties_page_size">Page Size:</span> <p id="pageSizeField">-</p>
             </div>
+            <div class="separator"></div>
+            <div class="row">
+              <span data-l10n-id="document_properties_linearized">Fast Web View:</span> <p id="linearizedField">-</p>
+            </div>
             <div class="buttonRow">
               <button id="documentPropertiesClose" class="overlayButton"><span data-l10n-id="document_properties_close">Close</span></button>
             </div>

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -166,6 +166,7 @@ function getViewerConfiguration() {
         'version': document.getElementById('versionField'),
         'pageCount': document.getElementById('pageCountField'),
         'pageSize': document.getElementById('pageSizeField'),
+        'linearized': document.getElementById('linearizedField'),
       },
     },
     errorWrapper: {


### PR DESCRIPTION
*Please refer to the individual commit messages for additional details.*