### PR TITLE
Refactor `getPage` (in the worker), and attempt to use the `Linearization` dictionary to lookup the first Page

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -29,7 +29,7 @@ import { CipherTransformFactory } from './crypto';
 import { ColorSpace } from './colorspace';
 
 var Catalog = (function CatalogClosure() {
-  function Catalog(pdfManager, xref, pageFactory) {
+  function Catalog(pdfManager, xref) {
     this.pdfManager = pdfManager;
     this.xref = xref;
     this.catDict = xref.getCatalogObj();
@@ -40,9 +40,6 @@ var Catalog = (function CatalogClosure() {
     this.fontCache = new RefSetCache();
     this.builtInCMapCache = Object.create(null);
     this.pageKidsCountCache = new RefSetCache();
-    // TODO refactor to move getPage() to the PDFDocument.
-    this.pageFactory = pageFactory;
-    this.pagePromises = [];
   }
 
   Catalog.prototype = {
@@ -451,18 +448,6 @@ var Catalog = (function CatalogClosure() {
         this.fontCache.clear();
         this.builtInCMapCache = Object.create(null);
       });
-    },
-
-    getPage: function Catalog_getPage(pageIndex) {
-      if (!(pageIndex in this.pagePromises)) {
-        this.pagePromises[pageIndex] = this.getPageDict(pageIndex).then(
-            ([dict, ref]) => {
-          return this.pageFactory.createPage(pageIndex, dict, ref,
-                                             this.fontCache,
-                                             this.builtInCMapCache);
-        });
-      }
-      return this.pagePromises[pageIndex];
     },
 
     getPageDict: function Catalog_getPageDict(pageIndex) {


### PR DESCRIPTION
As expected, using the `Linearization` data doesn't appear to have had any (noticeable) performance impact. This can probably be attributed to [`Catalog.getPageDict`](https://github.com/mozilla/pdf.js/blob/51b0e60f9b344bf43b833295103505c58845ea19/src/core/obj.js#L468) only fetching the required nodes, and *not* the entire `Pages` tree, in combination with caching of already resolved nodes (in `pageKidsCountCache`).

*Edit:* To clarify the above, for Linearized files this patch *does* result in (at most) a handful of fewer invocations of [`this code`](https://github.com/mozilla/pdf.js/blob/d6f378fbafed2079310ed46a8efc519aa77a271a/src/core/obj.js#L486) since the first Page can be accessed directly.
So while the amount of data being loaded when fetching the *first* Page is reduced, the difference is really tiny in practice. Hence it seems that unless the server/connection is really slow, the difference would most likely not be seen/felt. (Also, keeping in mind that the default viewer will pre-render the next/previous page.)

Fixes #9716.