### PR TITLE
README.md: suggest usage of https instead of git protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ directory `build/chromium`.
 
 To get a local copy of the current code, clone it using git:
 
-    $ git clone git://github.com/mozilla/pdf.js.git
+    $ git clone https://github.com/mozilla/pdf.js.git
     $ cd pdf.js
 
 Next, install Node.js via the [official package](http://nodejs.org) or via


### PR DESCRIPTION
The `git` protocol is unencrypted which means other parties could potentially eavesdrop your traffic. `https` or `ssh` is often encouraged because of this. (For example, the Ruby package manager `bundler` prints a warning when `git` sources are being used.)