### PR TITLE
[Regression] Convert `Catalog.builtInCMapCache` into a `Map`, instead of an Object, to ensure that it's correctly reset (PR 8064 follow-up)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -132,16 +132,15 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     this.pdfFunctionFactory = pdfFunctionFactory;
 
     this.fetchBuiltInCMap = (name) => {
-      var cachedCMap = this.builtInCMapCache[name];
-      if (cachedCMap) {
-        return Promise.resolve(cachedCMap);
+      if (this.builtInCMapCache.has(name)) {
+        return Promise.resolve(this.builtInCMapCache.get(name));
       }
       return this.handler.sendWithPromise('FetchBuiltInCMap', {
         name,
       }).then((data) => {
         if (data.compressionType !== CMapCompressionType.NONE) {
           // Given the size of uncompressed CMaps, only cache compressed ones.
-          this.builtInCMapCache[name] = data;
+          this.builtInCMapCache.set(name, data);
         }
         return data;
       });

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -38,7 +38,7 @@ var Catalog = (function CatalogClosure() {
     }
 
     this.fontCache = new RefSetCache();
-    this.builtInCMapCache = Object.create(null);
+    this.builtInCMapCache = new Map();
     this.pageKidsCountCache = new RefSetCache();
     // TODO refactor to move getPage() to the PDFDocument.
     this.pageFactory = pageFactory;
@@ -449,7 +449,7 @@ var Catalog = (function CatalogClosure() {
           delete font.translated;
         }
         this.fontCache.clear();
-        this.builtInCMapCache = Object.create(null);
+        this.builtInCMapCache.clear();
       });
     },
 


### PR DESCRIPTION
*Fixes a regression from PR #8064 (split off from PR #9931 since it probably deserves more visibility).* 

With the `builtInCMapCache` being a simple Object, it unfortunately means that the `Catalog.cleanup` method isn't resetting it as intended.
By just replacing the `builtInCMapCache` with an empty Object, existing references to it will not actually be updated. The result is that e.g. `Page` instances still keeps references to, what should have been removed, CMap data.

To fix these problems, the `builtInCMapCache` is converted into a `Map` instead (since it can be easily reset).