### PR TITLE
Validate the Preferences when fetching them from storage

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -635,8 +635,6 @@ let PDFViewerApplication = {
     if (this.pdfLoadingTask) {
       // We need to destroy already opened document.
       return this.close().then(() => {
-        // Reload the preferences if a document was previously opened.
-        this.preferences.reload();
         // ... and repeat the open() call.
         return this.open(file, args);
       });

--- a/web/preferences.js
+++ b/web/preferences.js
@@ -60,9 +60,19 @@ class BasePreferences {
 
       this.prefs = Object.assign(Object.create(null), defaults);
       return this._readFromStorage(defaults);
-    }).then((prefObj) => {
-      if (prefObj) {
-        this.prefs = prefObj;
+    }).then((prefs) => {
+      if (!prefs) {
+        return;
+      }
+      for (let name in prefs) {
+        const defaultValue = this.defaults[name], prefValue = prefs[name];
+        // Ignore preferences not present in, or whose types don't match,
+        // the default values.
+        if (defaultValue === undefined ||
+            typeof prefValue !== typeof defaultValue) {
+          continue;
+        }
+        this.prefs[name] = prefValue;
       }
     });
   }

--- a/web/preferences.js
+++ b/web/preferences.js
@@ -100,21 +100,6 @@ class BasePreferences {
   }
 
   /**
-   * Replace the current preference values with the ones from storage.
-   * @return {Promise} A promise that is resolved when the preference values
-   *                   have been updated.
-   */
-  reload() {
-    return this._initializedPromise.then(() => {
-      return this._readFromStorage(this.defaults);
-    }).then((prefObj) => {
-      if (prefObj) {
-        this.prefs = prefObj;
-      }
-    });
-  }
-
-  /**
    * Set the value of a preference.
    * @param {string} name The name of the preference that should be changed.
    * @param {boolean|number|string} value The new value of the preference.


### PR DESCRIPTION
- Stop re-loading the Preferences in `PDFViewerApplication.open`, and remove the `BasePreferences.reload` method

   Given that the various Preferences are currently, and have been for quite some time, only used when initializing `PDFViewerApplication` re-loading them when a new PDF file is opened in the viewer is essentially a no-op.

   Furthermore, with the only usage of `BasePreferences.reload` now gone, the value of that method seems questionable at best. In the event that the functionality is actually needed again, similar to the `ViewHistory`, it'd probably make more sense to simply replace `PDFViewerApplication.preferences` with a new `BasePreferences` instance instead (using e.g. `DefaultExternalServices.createPreferences`).

 - Validate the Preferences when fetching them from storage

   When updating Preferences using the `set` method, the input is carefully validated. However, no validation is (currently) done when a `BasePreferences` instance is created, which probably isn't that great. Hence this patch that simply ignores, to not unnecessarily break loading of the viewer itself, any invalid Preferences.