### PR TITLE
Stop warning for non-Name /Filter entries in the `PDFImage` constructor (PR 9897 follow-up)

### DIFF
--- a/src/core/image.js
+++ b/src/core/image.js
@@ -83,27 +83,24 @@ var PDFImage = (function PDFImageClosure() {
                       mask = null, isMask = false, pdfFunctionFactory, }) {
     this.image = image;
     var dict = image.dict;
-    if (dict.has('Filter')) {
-      const filter = dict.get('Filter');
-      if (isName(filter)) {
-        switch (filter.name) {
-          case 'JPXDecode':
-            var jpxImage = new JpxImage();
-            jpxImage.parseImageProperties(image.stream);
-            image.stream.reset();
 
-            image.width = jpxImage.width;
-            image.height = jpxImage.height;
-            image.bitsPerComponent = jpxImage.bitsPerComponent;
-            image.numComps = jpxImage.componentsCount;
-            break;
-          case 'JBIG2Decode':
-            image.bitsPerComponent = 1;
-            image.numComps = 1;
-            break;
-        }
-      } else {
-        warn(`PDFImage - invalid /Filter entry in dictionary: "${filter}".`);
+    const filter = dict.get('Filter');
+    if (isName(filter)) {
+      switch (filter.name) {
+        case 'JPXDecode':
+          var jpxImage = new JpxImage();
+          jpxImage.parseImageProperties(image.stream);
+          image.stream.reset();
+
+          image.width = jpxImage.width;
+          image.height = jpxImage.height;
+          image.bitsPerComponent = jpxImage.bitsPerComponent;
+          image.numComps = jpxImage.componentsCount;
+          break;
+        case 'JBIG2Decode':
+          image.bitsPerComponent = 1;
+          image.numComps = 1;
+          break;
       }
     }
     // TODO cache rendered images?


### PR DESCRIPTION
Fixes a stupid oversight on my part, since /Filter may (obviously) contain an Array, which resulted in unnecessary console warning spam in perfectly valid PDF files.
Note that it still makes sense to check that /Filter is actually a Name, before attempting to access its `name` property, but the warning should definitely be removed.

*Much smaller diff with https://github.com/mozilla/pdf.js/pull/9954/files?w=1*