### PR TITLE
Attempt to throw `MissingPDFException` when applicable in `node_stream.js` (issue 9791)

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -164,11 +164,6 @@ describe('api', function() {
       });
     });
     it('creates pdf doc from non-existent URL', function(done) {
-      if (isNodeJS()) {
-        pending('Fix `src/display/node_stream.js` to actually throw ' +
-                'a `MissingPDFException` in all cases where a PDF file ' +
-                'cannot be found, such that this test-case can be enabled.');
-      }
       var loadingTask = getDocument(
         buildGetDocumentParams('non-existent.pdf'));
       loadingTask.promise.then(function(error) {


### PR DESCRIPTION
While I'm not very familiar with Node.js, this patch should (hopefully) cover the *multiple* ways in which files can be loaded in Node.js environments; while also taking into account e.g. the differences between the `XMLHttpRequest` and the `{http, https}.request` methods.
Furthermore, the `creates pdf doc from non-existent URL` API unit-test now passes in Node.js/Travis.

Fixes #9791.