### PR TITLE
Tweak the MMType1 font detection in `getFontFileType` to improve font telemetry (PR 9961 follow-up)

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -717,17 +717,15 @@ var Font = (function FontClosure() {
     } else if (isType1File(file)) {
       if (composite) {
         fileType = 'CIDFontType0';
-      } else if (type === 'MMType1') {
-        fileType = 'MMType1';
       } else {
-        fileType = 'Type1';
+        fileType = (type === 'MMType1' ? 'MMType1' : 'Type1');
       }
     } else if (isCFFFile(file)) {
       if (composite) {
         fileType = 'CIDFontType0';
         fileSubtype = 'CIDFontType0C';
       } else {
-        fileType = 'Type1';
+        fileType = (type === 'MMType1' ? 'MMType1' : 'Type1');
         fileSubtype = 'Type1C';
       }
     } else {


### PR DESCRIPTION
Please note that this patch does *not* affect rendering in any way, however it's relevant for font telemetry[1].

According to the specification, see https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#G8.1904956, Type1C is a valid subtype for *both* Type1 and MMType1 fonts.

---
[1] Refer to the font telemetry results in https://telemetry.mozilla.org/new-pipeline/dist.html#!cumulative=0&end_date=2018-06-25&keys=__none__!__none__!__none__&max_channel_version=nightly%252F62&measure=PDF_VIEWER_FONT_TYPES&min_channel_version=nightly%252F59&processType=*&product=Firefox&sanitize=1&sort_keys=submissions&start_date=2018-05-07&table=0&trim=1&use_submission_date=0

See also https://github.com/mozilla/pdf.js/wiki/Enumeration-Assignments-for-the-Telemetry-Histograms#pdf_viewer_font_types for help with interpreting the data.