### PR TITLE
Re-factor `destinations`/`getDestination` to reduce unnecessary duplication, and reject non-string inputs

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -627,7 +627,7 @@ var PDFDocumentProxy = (function PDFDocumentProxyClosure() {
       return this.transport.getDestinations();
     },
     /**
-     * @param {string} id The named destination to get.
+     * @param {string} id - The named destination to get.
      * @return {Promise} A promise that is resolved with all information
      * of the given named destination.
      */
@@ -2119,6 +2119,9 @@ var WorkerTransport = (function WorkerTransportClosure() {
     },
 
     getDestination: function WorkerTransport_getDestination(id) {
+      if (typeof id !== 'string') {
+        return Promise.reject(new Error('Invalid destination request.'));
+      }
       return this.messageHandler.sendWithPromise('GetDestination', {
         id,
       });

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -583,6 +583,32 @@ describe('api', function() {
       });
     });
 
+    it('gets non-string destination', function(done) {
+      let numberPromise = doc.getDestination(4.3);
+      let booleanPromise = doc.getDestination(true);
+      let arrayPromise = doc.getDestination([
+        { num: 17, gen: 0, }, { name: 'XYZ', }, 0, 841.89, null]);
+
+      numberPromise = numberPromise.then(function() {
+        throw new Error('shall fail for non-string destination.');
+      }, function(reason) {
+        expect(reason instanceof Error).toEqual(true);
+      });
+      booleanPromise = booleanPromise.then(function() {
+        throw new Error('shall fail for non-string destination.');
+      }, function(reason) {
+        expect(reason instanceof Error).toEqual(true);
+      });
+      arrayPromise = arrayPromise.then(function() {
+        throw new Error('shall fail for non-string destination.');
+      }, function(reason) {
+        expect(reason instanceof Error).toEqual(true);
+      });
+
+      Promise.all([numberPromise, booleanPromise, arrayPromise]).then(
+        done, done.fail);
+    });
+
     it('gets non-existent page labels', function (done) {
       var promise = doc.getPageLabels();
       promise.then(function (data) {


### PR DESCRIPTION
 - Re-factor `destinations`/`getDestination`, in the `Catalog`, to reduce unnecessary duplication

   Currently, these two methods contain the same boilerplate code for getting the /Dests data.

- Reject `getDestination`, in the API, for non-string inputs

  Note how e.g. the `getPage` method does basic validation of the input.