### PR TITLE
Add support for `async`/`await` using Babel

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": 6,
+    "ecmaVersion": 8,
     "sourceType": "module",
   },
 

--- a/external/builder/preprocessor2.js
+++ b/external/builder/preprocessor2.js
@@ -288,6 +288,7 @@ function preprocessPDFJSCode(ctx, code) {
     },
   };
   var parseOptions = {
+    ecmaVersion: 8,
     locations: true,
     sourceFile: ctx.sourceFile,
     sourceType: 'module',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -177,7 +177,14 @@ function createWebpackConfig(defines, output) {
           exclude: /src[\\\/]core[\\\/](glyphlist|unicode)/,
           options: {
             presets: skipBabel ? undefined : ['env'],
-            plugins: ['transform-es2015-modules-commonjs'],
+            plugins: [
+              'transform-es2015-modules-commonjs',
+              ['transform-runtime', {
+                'helpers': false,
+                'polyfill': false,
+                'regenerator': true,
+              }],
+            ],
           },
         },
         {
@@ -808,7 +815,7 @@ gulp.task('mozcentral', ['mozcentral-pre']);
 gulp.task('chromium-pre', ['buildnumber', 'locale'], function () {
   console.log();
   console.log('### Building Chromium extension');
-  var defines = builder.merge(DEFINES, { CHROME: true, SKIP_BABEL: true, });
+  var defines = builder.merge(DEFINES, { CHROME: true, });
 
   var CHROME_BUILD_DIR = BUILD_DIR + '/chromium/',
       CHROME_BUILD_CONTENT_DIR = CHROME_BUILD_DIR + '/content/';
@@ -897,6 +904,11 @@ gulp.task('lib', ['buildnumber'], function () {
       presets: noPreset ? undefined : ['env'],
       plugins: [
         'transform-es2015-modules-commonjs',
+        ['transform-runtime', {
+          'helpers': false,
+          'polyfill': false,
+          'regenerator': true,
+        }],
         babelPluginReplaceNonWebPackRequire,
       ],
     }).code;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1210,6 +1210,15 @@
         "regenerator-transform": "^0.10.0"
       }
     },
+    "babel-plugin-transform-runtime": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+      "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
@@ -3361,14 +3370,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3383,20 +3390,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3513,8 +3517,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3526,7 +3529,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3541,7 +3543,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3549,14 +3550,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3575,7 +3574,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3656,8 +3654,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3669,7 +3666,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3791,7 +3787,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.5",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.7.0",
     "core-js": "^2.5.7",
     "escodegen": "^1.11.0",

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -131,19 +131,17 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     this.options = options || DefaultPartialEvaluatorOptions;
     this.pdfFunctionFactory = pdfFunctionFactory;
 
-    this.fetchBuiltInCMap = (name) => {
+    this.fetchBuiltInCMap = async (name) => {
       if (this.builtInCMapCache.has(name)) {
-        return Promise.resolve(this.builtInCMapCache.get(name));
+        return this.builtInCMapCache.get(name);
       }
-      return this.handler.sendWithPromise('FetchBuiltInCMap', {
-        name,
-      }).then((data) => {
-        if (data.compressionType !== CMapCompressionType.NONE) {
-          // Given the size of uncompressed CMaps, only cache compressed ones.
-          this.builtInCMapCache.set(name, data);
-        }
-        return data;
-      });
+      const data = await this.handler.sendWithPromise('FetchBuiltInCMap',
+                                                      { name, });
+      if (data.compressionType !== CMapCompressionType.NONE) {
+        // Given the size of uncompressed CMaps, only cache compressed ones.
+        this.builtInCMapCache.set(name, data);
+      }
+      return data;
     };
   }
 

--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -152,23 +152,21 @@ class PDFFetchStreamReader {
     return this._isStreamingSupported;
   }
 
-  read() {
-    return this._headersCapability.promise.then(() => {
-      return this._reader.read().then(({ value, done, }) => {
-        if (done) {
-          return Promise.resolve({ value, done, });
-        }
-        this._loaded += value.byteLength;
-        if (this.onProgress) {
-          this.onProgress({
-            loaded: this._loaded,
-            total: this._contentLength,
-          });
-        }
-        let buffer = new Uint8Array(value).buffer;
-        return Promise.resolve({ value: buffer, done: false, });
+  async read() {
+    await this._headersCapability.promise;
+    const { value, done, } = await this._reader.read();
+    if (done) {
+      return { value, done, };
+    }
+    this._loaded += value.byteLength;
+    if (this.onProgress) {
+      this.onProgress({
+        loaded: this._loaded,
+        total: this._contentLength,
       });
-    });
+    }
+    let buffer = new Uint8Array(value).buffer;
+    return { value: buffer, done: false, };
   }
 
   cancel(reason) {
@@ -223,20 +221,18 @@ class PDFFetchStreamRangeReader {
     return this._isStreamingSupported;
   }
 
-  read() {
-    return this._readCapability.promise.then(() => {
-      return this._reader.read().then(({ value, done, }) => {
-        if (done) {
-          return Promise.resolve({ value, done, });
-        }
-        this._loaded += value.byteLength;
-        if (this.onProgress) {
-          this.onProgress({ loaded: this._loaded, });
-        }
-        let buffer = new Uint8Array(value).buffer;
-        return Promise.resolve({ value: buffer, done: false, });
-      });
-    });
+  async read() {
+    await this._readCapability.promise;
+    const { value, done, } = await this._reader.read();
+    if (done) {
+      return { value, done, };
+    }
+    this._loaded += value.byteLength;
+    if (this.onProgress) {
+      this.onProgress({ loaded: this._loaded, });
+    }
+    let buffer = new Uint8Array(value).buffer;
+    return { value: buffer, done: false, };
   }
 
   cancel(reason) {

--- a/src/display/network.js
+++ b/src/display/network.js
@@ -453,16 +453,16 @@ PDFNetworkStreamFullRequestReader.prototype = {
     return this._headersReceivedCapability.promise;
   },
 
-  read: function PDFNetworkStreamFullRequestReader_read() {
+  async read() {
     if (this._storedError) {
-      return Promise.reject(this._storedError);
+      throw this._storedError;
     }
     if (this._cachedChunks.length > 0) {
       var chunk = this._cachedChunks.shift();
-      return Promise.resolve({ value: chunk, done: false, });
+      return { value: chunk, done: false, };
     }
     if (this._done) {
-      return Promise.resolve({ value: undefined, done: true, });
+      return { value: undefined, done: true, };
     }
     var requestCapability = createPromiseCapability();
     this._requests.push(requestCapability);
@@ -534,14 +534,14 @@ PDFNetworkStreamRangeRequestReader.prototype = {
     return false; // TODO allow progressive range bytes loading
   },
 
-  read: function PDFNetworkStreamRangeRequestReader_read() {
+  async read() {
     if (this._queuedChunk !== null) {
       var chunk = this._queuedChunk;
       this._queuedChunk = null;
-      return Promise.resolve({ value: chunk, done: false, });
+      return { value: chunk, done: false, };
     }
     if (this._done) {
-      return Promise.resolve({ value: undefined, done: true, });
+      return { value: undefined, done: true, };
     }
     var requestCapability = createPromiseCapability();
     this._requests.push(requestCapability);

--- a/src/display/node_stream.js
+++ b/src/display/node_stream.js
@@ -131,31 +131,30 @@ class BaseFullReader {
     return this._isStreamingSupported;
   }
 
-  read() {
-    return this._readCapability.promise.then(() => {
-      if (this._done) {
-        return Promise.resolve({ value: undefined, done: true, });
-      }
-      if (this._storedError) {
-        return Promise.reject(this._storedError);
-      }
+  async read() {
+    await this._readCapability.promise;
+    if (this._done) {
+      return { value: undefined, done: true, };
+    }
+    if (this._storedError) {
+      throw this._storedError;
+    }
 
-      let chunk = this._readableStream.read();
-      if (chunk === null) {
-        this._readCapability = createPromiseCapability();
-        return this.read();
-      }
-      this._loaded += chunk.length;
-      if (this.onProgress) {
-        this.onProgress({
-          loaded: this._loaded,
-          total: this._contentLength,
-        });
-      }
-      // Ensure that `read()` method returns ArrayBuffer.
-      let buffer = new Uint8Array(chunk).buffer;
-      return Promise.resolve({ value: buffer, done: false, });
-    });
+    let chunk = this._readableStream.read();
+    if (chunk === null) {
+      this._readCapability = createPromiseCapability();
+      return this.read();
+    }
+    this._loaded += chunk.length;
+    if (this.onProgress) {
+      this.onProgress({
+        loaded: this._loaded,
+        total: this._contentLength,
+      });
+    }
+    // Ensure that `read()` method returns ArrayBuffer.
+    let buffer = new Uint8Array(chunk).buffer;
+    return { value: buffer, done: false, };
   }
 
   cancel(reason) {
@@ -220,28 +219,27 @@ class BaseRangeReader {
     return this._isStreamingSupported;
   }
 
-  read() {
-    return this._readCapability.promise.then(() => {
-      if (this._done) {
-        return Promise.resolve({ value: undefined, done: true, });
-      }
-      if (this._storedError) {
-        return Promise.reject(this._storedError);
-      }
+  async read() {
+    await this._readCapability.promise;
+    if (this._done) {
+      return { value: undefined, done: true, };
+    }
+    if (this._storedError) {
+      throw this._storedError;
+    }
 
-      let chunk = this._readableStream.read();
-      if (chunk === null) {
-        this._readCapability = createPromiseCapability();
-        return this.read();
-      }
-      this._loaded += chunk.length;
-      if (this.onProgress) {
-        this.onProgress({ loaded: this._loaded, });
-      }
-      // Ensure that `read()` method returns ArrayBuffer.
-      let buffer = new Uint8Array(chunk).buffer;
-      return Promise.resolve({ value: buffer, done: false, });
-    });
+    let chunk = this._readableStream.read();
+    if (chunk === null) {
+      this._readCapability = createPromiseCapability();
+      return this.read();
+    }
+    this._loaded += chunk.length;
+    if (this.onProgress) {
+      this.onProgress({ loaded: this._loaded, });
+    }
+    // Ensure that `read()` method returns ArrayBuffer.
+    let buffer = new Uint8Array(chunk).buffer;
+    return { value: buffer, done: false, };
   }
 
   cancel(reason) {

--- a/src/display/transport_stream.js
+++ b/src/display/transport_stream.js
@@ -160,13 +160,13 @@ var PDFDataTransportStream = (function PDFDataTransportStreamClosure() {
       return this._stream._contentLength;
     },
 
-    read: function PDFDataTransportStreamReader_read() {
+    async read() {
       if (this._queuedChunks.length > 0) {
         var chunk = this._queuedChunks.shift();
-        return Promise.resolve({ value: chunk, done: false, });
+        return { value: chunk, done: false, };
       }
       if (this._done) {
-        return Promise.resolve({ value: undefined, done: true, });
+        return { value: undefined, done: true, };
       }
       var requestCapability = createPromiseCapability();
       this._requests.push(requestCapability);
@@ -216,14 +216,14 @@ var PDFDataTransportStream = (function PDFDataTransportStreamClosure() {
       return false;
     },
 
-    read: function PDFDataTransportStreamRangeReader_read() {
+    async read() {
       if (this._queuedChunk) {
         let chunk = this._queuedChunk;
         this._queuedChunk = null;
-        return Promise.resolve({ value: chunk, done: false, });
+        return { value: chunk, done: false, };
       }
       if (this._done) {
-        return Promise.resolve({ value: undefined, done: true, });
+        return { value: undefined, done: true, };
       }
       var requestCapability = createPromiseCapability();
       this._requests.push(requestCapability);

--- a/src/shared/message_handler.js
+++ b/src/shared/message_handler.js
@@ -18,13 +18,11 @@ import {
   ReadableStream, UnexpectedResponseException, UnknownErrorException
 } from './util';
 
-function resolveCall(fn, args, thisArg = null) {
+async function resolveCall(fn, args, thisArg = null) {
   if (!fn) {
-    return Promise.resolve(undefined);
+    return;
   }
-  return new Promise((resolve, reject) => {
-    resolve(fn.apply(thisArg, args));
-  });
+  return fn.apply(thisArg, args);
 }
 
 function wrapReason(reason) {


### PR DESCRIPTION
For proof-of-concept, this patch converts a couple of `Promise` returning methods to use `async` instead.
Please note that the `generic` build, based on this patch, has been successfully testing in IE11 (i.e. the viewer loads and nothing is obviously broken).

Being able to use modern JavaScript features like `async`/`await` is a huge plus, but there's one (obvious) side-effect: The size of the built files will increase slightly (unless `SKIP_BABEL == true`). That's unavoidable, but seems like a small price to pay in the grand scheme of things.

Finally, note that the `chromium` build target was changed to no longer skip Babel translation, since the Chrome extension still supports version `49` of the browser (where native `async` support isn't available).

Split off from PR #9944 as requested by @brendandahl.

*Much more manageable diff with https://github.com/mozilla/pdf.js/pull/9977/files?w=1*