### PR TITLE
[api-minor] Remove the obsolete `createBlob` helper function

### DIFF
--- a/src/pdf.js
+++ b/src/pdf.js
@@ -101,7 +101,6 @@ exports.createValidAbsoluteUrl = pdfjsSharedUtil.createValidAbsoluteUrl;
 exports.createObjectURL = pdfjsSharedUtil.createObjectURL;
 exports.removeNullCharacters = pdfjsSharedUtil.removeNullCharacters;
 exports.shadow = pdfjsSharedUtil.shadow;
-exports.createBlob = pdfjsSharedUtil.createBlob;
 exports.Util = pdfjsSharedUtil.Util;
 exports.ReadableStream = pdfjsSharedUtil.ReadableStream;
 exports.URL = pdfjsSharedUtil.URL;

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -969,13 +969,6 @@ function createPromiseCapability() {
   return capability;
 }
 
-var createBlob = function createBlob(data, contentType) {
-  if (typeof Blob !== 'undefined') {
-    return new Blob([data], { type: contentType, });
-  }
-  throw new Error('The "Blob" constructor is not supported.');
-};
-
 var createObjectURL = (function createObjectURLClosure() {
   // Blob/createObjectURL is not available, falling back to data schema.
   var digits =
@@ -983,7 +976,7 @@ var createObjectURL = (function createObjectURLClosure() {
 
   return function createObjectURL(data, contentType, forceDataSchema = false) {
     if (!forceDataSchema && URL.createObjectURL) {
-      var blob = createBlob(data, contentType);
+      const blob = new Blob([data], { type: contentType, });
       return URL.createObjectURL(blob);
     }
 
@@ -1033,7 +1026,6 @@ export {
   arraysToBytes,
   assert,
   bytesToString,
-  createBlob,
   createPromiseCapability,
   createObjectURL,
   deprecated,

--- a/web/app.js
+++ b/web/app.js
@@ -21,10 +21,10 @@ import {
   TextLayerMode
 } from './ui_utils';
 import {
-  build, createBlob, createObjectURL, getDocument, getFilenameFromUrl,
-  GlobalWorkerOptions, InvalidPDFException, LinkTarget, loadScript,
-  MissingPDFException, OPS, PDFWorker, shadow, UnexpectedResponseException,
-  UNSUPPORTED_FEATURES, URL, version
+  build, createObjectURL, getDocument, getFilenameFromUrl, GlobalWorkerOptions,
+  InvalidPDFException, LinkTarget, loadScript, MissingPDFException, OPS,
+  PDFWorker, shadow, UnexpectedResponseException, UNSUPPORTED_FEATURES, URL,
+  version
 } from 'pdfjs-lib';
 import { CursorTool, PDFCursorTools } from './pdf_cursor_tools';
 import { PDFRenderingQueue, RenderingStates } from './pdf_rendering_queue';
@@ -748,7 +748,7 @@ let PDFViewerApplication = {
     }
 
     this.pdfDocument.getData().then(function(data) {
-      let blob = createBlob(data, 'application/pdf');
+      const blob = new Blob([data], { type: 'application/pdf', });
       downloadManager.download(blob, url, filename);
     }).catch(downloadByUrl); // Error occurred, try downloading with the URL.
   },


### PR DESCRIPTION
At this point in time, all supported browsers have native support for `Blob`; please see https://developer.mozilla.org/en-US/docs/Web/API/Blob/Blob#Browser_compatibility.
Furthermore, note how the helper function was throwing an error if `Blob` isn't available anyway.