### PR TITLE
Remove the unused `PDFDocument.mainXRefEntriesOffset` method

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -487,15 +487,7 @@ var PDFDocument = (function PDFDocumentClosure() {
       // shadow the prototype getter with a data property
       return shadow(this, 'startXRef', startXRef);
     },
-    get mainXRefEntriesOffset() {
-      var mainXRefEntriesOffset = 0;
-      var linearization = this.linearization;
-      if (linearization) {
-        mainXRefEntriesOffset = linearization.mainXRefEntriesOffset;
-      }
-      // shadow the prototype getter with a data property
-      return shadow(this, 'mainXRefEntriesOffset', mainXRefEntriesOffset);
-    },
+
     // Find the header, remove leading garbage and setup the stream
     // starting from the header.
     checkHeader: function PDFDocument_checkHeader() {


### PR DESCRIPTION
Not only is this method completely unused *now*, looking through the history of the code it never appears to have been used for anything either.
Years ago `mainXRefEntriesOffset` was included when creating `XRef` instances, however it wasn't actually used for anything (the parameter was never checked, nor assigned to a property on `XRef`).

If this method ever becomes useful (again) it's easy enough to restore it thanks to version control, but including dead code in the builds just seems wasteful.