### PR TITLE
Remove the deprecated ways, in `BaseViewer`, of setting the Scroll/Spread modes (PR 9858 follow-up)

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -594,9 +594,7 @@ class BaseViewer {
       let vPadding = noPadding ? 0 : VERTICAL_PADDING;
 
       if (!noPadding && this._isScrollModeHorizontal) {
-        const temp = hPadding;
-        hPadding = vPadding;
-        vPadding = temp;
+        [hPadding, vPadding] = [vPadding, hPadding]; // Swap the padding values.
       }
       let pageWidthScale = (this.container.clientWidth - hPadding) /
                            currentPage.width * currentPage.scale;

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -171,19 +171,6 @@ class BaseViewer {
     if (this.removePageBorders) {
       this.viewer.classList.add('removePageBorders');
     }
-
-    if ((typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) &&
-        ('scrollMode' in options || 'spreadMode' in options)) {
-      console.error(`The ${this._name} constructor options ` +
-        '`scrollMode`/`spreadMode` are deprecated, use the setters instead.');
-      if (options.scrollMode !== undefined) {
-        this.scrollMode = options.scrollMode;
-      }
-      if (options.spreadMode !== undefined) {
-        this.spreadMode = options.spreadMode;
-      }
-    }
-
     // Defer the dispatching of this event, to give other viewer components
     // time to initialize *and* register 'baseviewerinit' event listeners.
     Promise.resolve().then(() => {
@@ -1080,14 +1067,6 @@ class BaseViewer {
     this.update();
   }
 
-  setScrollMode(mode) {
-    if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
-      console.error(`${this._name}.setScrollMode() is deprecated, ` +
-                    `use the ${this._name}.scrollMode setter instead.`);
-      this.scrollMode = mode;
-    }
-  }
-
   /**
    * @return {number} One of the values in {SpreadMode}.
    */
@@ -1146,14 +1125,6 @@ class BaseViewer {
     }
     this.scrollPageIntoView({ pageNumber, });
     this.update();
-  }
-
-  setSpreadMode(mode) {
-    if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
-      console.error(`${this._name}.setSpreadMode() is deprecated, ` +
-                    `use the ${this._name}.spreadMode setter instead.`);
-      this.spreadMode = mode;
-    }
   }
 }
 

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -145,7 +145,6 @@ class BaseViewer {
     this.removePageBorders = options.removePageBorders || false;
     this.textLayerMode = Number.isInteger(options.textLayerMode) ?
       options.textLayerMode : TextLayerMode.ENABLE;
-    this.enhanceTextSelection = options.enhanceTextSelection || false;
     this.imageResourcesPath = options.imageResourcesPath || '';
     this.renderInteractiveForms = options.renderInteractiveForms || false;
     this.enablePrintAutoRotate = options.enablePrintAutoRotate || false;


### PR DESCRIPTION
Considering that a number of `[api-minor]` changes have landed since PR #9858, removing this code ought to be OK now (the less time these methods remain exposed, the better); implements https://github.com/mozilla/pdf.js/pull/9858#issuecomment-401730065.