### PR TITLE
Attempt to find truncated endstream commands, in the fallback code-path, in `Parser.makeStream` (issue 10004)

### DIFF
--- a/test/pdfs/issue10004.pdf.link
+++ b/test/pdfs/issue10004.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/2315390/2371410.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -726,6 +726,13 @@
        "link": false,
        "type": "load"
     },
+    {  "id": "issue10004",
+       "file": "pdfs/issue10004.pdf",
+       "md5": "64d1853060cefe3be50e5c4617dd0505",
+       "rounds": 1,
+       "link": true,
+       "type": "load"
+    },
     {  "id": "issue7507",
        "file": "pdfs/issue7507.pdf",
        "md5": "f7aeaafe0c89b94436e94eaa63307303",


### PR DESCRIPTION
Apparently there's some PDF generators, in this case the culprit is "Nooog Pdf Library / Nooog PStoPDF v1.5", that manage to mess up PDF creation enough that endstream[1] commands actually become truncated.

*Please note:* The solution implemented here isn't perfect, since it won't be able to cope with PDF files that contains a *mixture* of correct and truncated endstream commands.
However, considering that this particular mode of corruption *fortunately* doesn't seem very common[2], a slightly less complex solution ought to suffice for now.

Fixes #10004.

---
[1] Scanning through the PDF data to find endstream commands becomes necessary, in order to determine the stream length in cases where the `Length` entry of the (stream) dictionary is missing/incorrect.

[2] I cannot recall having seen any (previous) issues/bugs with "Missing endstream" errors.