### PR TITLE
Fix for white hairlines rendering in pdf

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1082,21 +1082,34 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       var ctx = this.ctx;
       var current = this.current;
       var x = current.x, y = current.y;
+      let xw, yh, origX, origY, pixelSize = this.getSinglePixelWidth();
       for (var i = 0, j = 0, ii = ops.length; i < ii; i++) {
         switch (ops[i] | 0) {
           case OPS.rectangle:
-            x = args[j++];
-            y = args[j++];
+            origX = args[j++];
+            origY = args[j++];
+            if (pixelSize) {
+              x = Math.floor(origX / pixelSize) * pixelSize;
+              y = Math.ceil(origY / pixelSize) * pixelSize;
+            } else {
+              x = origX;
+              y = origY;
+            }
             var width = args[j++];
             var height = args[j++];
             if (width === 0) {
-              width = this.getSinglePixelWidth();
+              width = pixelSize;
             }
             if (height === 0) {
-              height = this.getSinglePixelWidth();
+              height = pixelSize;
             }
-            var xw = x + width;
-            var yh = y + height;
+            if (pixelSize) {
+              xw = Math.ceil((origX + width) / pixelSize) * pixelSize;
+              yh = Math.ceil((origY + height) / pixelSize) * pixelSize;
+            } else {
+              xw = x + width;
+              yh = y + height;
+            }
             this.ctx.moveTo(x, y);
             this.ctx.lineTo(xw, y);
             this.ctx.lineTo(xw, yh);
@@ -1941,7 +1954,9 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       var ctx = this.ctx;
       // scale the image to the unit square
       ctx.scale(1 / w, -1 / h);
-
+      const pixelSize = this.getSinglePixelWidth();
+      h = Math.ceil(h / pixelSize) * pixelSize;
+      w = Math.ceil(w / pixelSize) * pixelSize;
       ctx.drawImage(domImage, 0, 0, domImage.width, domImage.height,
                     0, -h, w, h);
       if (this.imageLayer) {
@@ -2144,6 +2159,9 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
                                                   newWidth, newHeight);
         tmpCtx = tmpCanvas.context;
         tmpCtx.clearRect(0, 0, newWidth, newHeight);
+        const pixelSize = this.getSinglePixelWidth();
+        newHeight = Math.ceil(newHeight / pixelSize) * pixelSize;
+        newWidth = Math.ceil(newWidth / pixelSize) * pixelSize;
         tmpCtx.drawImage(imgToPaint, 0, 0, paintWidth, paintHeight,
                                      0, 0, newWidth, newHeight);
         imgToPaint = tmpCanvas.canvas;


### PR DESCRIPTION
This fix will provide a solution to the following issues:

#3351
#4860
#3331
#9464 (Closed) (Duplicate)
#9481 (Closed) (Duplicate)
#9829 (Closed) (Duplicate)
#9953 (Closed) (Duplicate)

This solution takes into account the resolution of the viewer before painting images to the canvas and rounds the painting to the nearest full pixel. The problem in the issues above is caused by drawing to a canvas with a width/height that is more accurate than pixel width allows. This results in the drawing coloring part of a pixel, which causes a partial transparency. This transparency creates what appears to be a thin line between images. Rounding the images to the nearest pixel insures there will be no partially filled pixels, and therefore no thin lines.

Performance Tests
```
Run1:
browser | stat         | Count | Baseline(ms) | Current(ms) |  +/- |     %  | Result(P<.05)
------- | ------------ | ----- | ------------ | ----------- | ---- | ------ | -------------
Firefox | Overall      |    50 |        17427 |       16954 | -474 |  -2.72 |              
Firefox | Page Request |    50 |           11 |           9 |   -2 | -14.34 |              
Firefox | Rendering    |    50 |        17416 |       16944 | -472 |  -2.71 |   
```
```
Run2:
browser | stat         | Count | Baseline(ms) | Current(ms) |   +/- |     %  | Result(P<.05)
------- | ------------ | ----- | ------------ | ----------- | ----- | ------ | -------------
Firefox | Overall      |    50 |        18640 |       15158 | -3481 | -18.68 |        faster
Firefox | Page Request |    50 |           11 |          10 |    -1 |  -5.59 |              
Firefox | Rendering    |    50 |        18629 |       15148 | -3481 | -18.69 |        faster
```