### PR TITLE
Add general support for re-dispatching events, on `EventBus` instances, to the DOM

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -47,6 +47,10 @@
       "type": "boolean",
       "default": false
     },
+    "eventBusDispatchToDOM": {
+      "type": "boolean",
+      "default": false
+    },
     "pdfBugEnabled": {
       "title": "Enable debugging tools",
       "description": "Whether to enable debugging tools.",

--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -262,6 +262,45 @@ describe('ui_utils', function() {
       eventBus.dispatch('test');
       expect(count).toEqual(2);
     });
+
+    it('should not, by default, re-dispatch to DOM', function(done) {
+      if (isNodeJS()) {
+        pending('Document in not supported in Node.js.');
+      }
+      const eventBus = new EventBus();
+      let count = 0;
+      eventBus.on('test', function() {
+        count++;
+      });
+      document.addEventListener('test', function() {
+        count++;
+      });
+      eventBus.dispatch('test');
+
+      Promise.resolve().then(() => {
+        expect(count).toEqual(1);
+        done();
+      });
+    });
+    it('should re-dispatch to DOM', function(done) {
+      if (isNodeJS()) {
+        pending('Document in not supported in Node.js.');
+      }
+      const eventBus = new EventBus({ dispatchToDOM: true, });
+      let count = 0;
+      eventBus.on('test', function() {
+        count++;
+      });
+      document.addEventListener('test', function() {
+        count++;
+      });
+      eventBus.dispatch('test');
+
+      Promise.resolve().then(() => {
+        expect(count).toEqual(2);
+        done();
+      });
+    });
   });
 
   describe('isValidRotation', function() {

--- a/web/app.js
+++ b/web/app.js
@@ -288,7 +288,8 @@ let PDFViewerApplication = {
     return new Promise((resolve, reject) => {
       this.overlayManager = new OverlayManager();
 
-      let eventBus = appConfig.eventBus || getGlobalEventBus();
+      const dispatchToDOM = AppOptions.get('eventBusDispatchToDOM');
+      let eventBus = appConfig.eventBus || getGlobalEventBus(dispatchToDOM);
       this.eventBus = eventBus;
 
       let pdfRenderingQueue = new PDFRenderingQueue();

--- a/web/app.js
+++ b/web/app.js
@@ -160,7 +160,7 @@ let PDFViewerApplication = {
       this.l10n.translate(appContainer).then(() => {
         // Dispatch the 'localized' event on the `eventBus` once the viewer
         // has been fully initialized and translated.
-        this.eventBus.dispatch('localized');
+        this.eventBus.dispatch('localized', { source: this, });
       });
 
       this.initialized = true;
@@ -1371,14 +1371,15 @@ let PDFViewerApplication = {
     };
     _boundEvents.windowHashChange = () => {
       eventBus.dispatch('hashchange', {
+        source: window,
         hash: document.location.hash.substring(1),
       });
     };
     _boundEvents.windowBeforePrint = () => {
-      eventBus.dispatch('beforeprint');
+      eventBus.dispatch('beforeprint', { source: window, });
     };
     _boundEvents.windowAfterPrint = () => {
-      eventBus.dispatch('afterprint');
+      eventBus.dispatch('afterprint', { source: window, });
     };
 
     window.addEventListener('wheel', webViewerWheel);
@@ -1560,6 +1561,7 @@ function webViewerInitialized() {
         return;
       }
       PDFViewerApplication.eventBus.dispatch('fileinputchange', {
+        source: this,
         fileInput: evt.target,
       });
     });
@@ -1578,6 +1580,7 @@ function webViewerInitialized() {
         return;
       }
       PDFViewerApplication.eventBus.dispatch('fileinputchange', {
+        source: this,
         fileInput: evt.dataTransfer,
       });
     });

--- a/web/app.js
+++ b/web/app.js
@@ -897,6 +897,9 @@ let PDFViewerApplication = {
       this.loadingBar.hide();
 
       firstPagePromise.then(() => {
+        this.eventBus.dispatch('documentloaded', { source: this, });
+        // TODO: Remove the following event, i.e. 'documentload',
+        //       once the mozilla-central tests have been updated.
         this.eventBus.dispatch('documentload', { source: this, });
       });
     });
@@ -1000,6 +1003,7 @@ let PDFViewerApplication = {
         this.setInitialView(hash, {
           rotation, sidebarView, scrollMode, spreadMode,
         });
+        this.eventBus.dispatch('documentinit', { source: this, });
 
         // Make all navigation keys work on document load,
         // unless the viewer is embedded in a web page.

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -68,6 +68,11 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.VIEWER,
   },
+  eventBusDispatchToDOM: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER,
+  },
   externalLinkRel: {
     /** @type {string} */
     value: 'noopener noreferrer nofollow',

--- a/web/default_preferences.json
+++ b/web/default_preferences.json
@@ -4,6 +4,7 @@
   "sidebarViewOnLoad": 0,
   "cursorToolOnLoad": 0,
   "enableWebGL": false,
+  "eventBusDispatchToDOM": false,
   "pdfBugEnabled": false,
   "disableRange": false,
   "disableStream": false,

--- a/web/dom_events.js
+++ b/web/dom_events.js
@@ -129,12 +129,13 @@ function attachDOMEventsToEventBus(eventBus) {
 }
 
 let globalEventBus = null;
-function getGlobalEventBus() {
-  if (globalEventBus) {
-    return globalEventBus;
+function getGlobalEventBus(dispatchToDOM = false) {
+  if (!globalEventBus) {
+    globalEventBus = new EventBus({ dispatchToDOM, });
+    if (!dispatchToDOM) {
+      attachDOMEventsToEventBus(globalEventBus);
+    }
   }
-  globalEventBus = new EventBus();
-  attachDOMEventsToEventBus(globalEventBus);
   return globalEventBus;
 }
 

--- a/web/pdf_presentation_mode.js
+++ b/web/pdf_presentation_mode.js
@@ -60,19 +60,19 @@ class PDFPresentationMode {
     if (contextMenuItems) {
       contextMenuItems.contextFirstPage.addEventListener('click', () => {
         this.contextMenuOpen = false;
-        this.eventBus.dispatch('firstpage');
+        this.eventBus.dispatch('firstpage', { source: this, });
       });
       contextMenuItems.contextLastPage.addEventListener('click', () => {
         this.contextMenuOpen = false;
-        this.eventBus.dispatch('lastpage');
+        this.eventBus.dispatch('lastpage', { source: this, });
       });
       contextMenuItems.contextPageRotateCw.addEventListener('click', () => {
         this.contextMenuOpen = false;
-        this.eventBus.dispatch('rotatecw');
+        this.eventBus.dispatch('rotatecw', { source: this, });
       });
       contextMenuItems.contextPageRotateCcw.addEventListener('click', () => {
         this.contextMenuOpen = false;
-        this.eventBus.dispatch('rotateccw');
+        this.eventBus.dispatch('rotateccw', { source: this, });
       });
     }
   }

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -100,19 +100,19 @@ class Toolbar {
     let self = this;
 
     items.previous.addEventListener('click', function() {
-      eventBus.dispatch('previouspage');
+      eventBus.dispatch('previouspage', { source: self, });
     });
 
     items.next.addEventListener('click', function() {
-      eventBus.dispatch('nextpage');
+      eventBus.dispatch('nextpage', { source: self, });
     });
 
     items.zoomIn.addEventListener('click', function() {
-      eventBus.dispatch('zoomin');
+      eventBus.dispatch('zoomin', { source: self, });
     });
 
     items.zoomOut.addEventListener('click', function() {
-      eventBus.dispatch('zoomout');
+      eventBus.dispatch('zoomout', { source: self, });
     });
 
     items.pageNumber.addEventListener('click', function() {
@@ -137,19 +137,19 @@ class Toolbar {
     });
 
     items.presentationModeButton.addEventListener('click', function() {
-      eventBus.dispatch('presentationmode');
+      eventBus.dispatch('presentationmode', { source: self, });
     });
 
     items.openFile.addEventListener('click', function() {
-      eventBus.dispatch('openfile');
+      eventBus.dispatch('openfile', { source: self, });
     });
 
     items.print.addEventListener('click', function() {
-      eventBus.dispatch('print');
+      eventBus.dispatch('print', { source: self, });
     });
 
     items.download.addEventListener('click', function() {
-      eventBus.dispatch('download');
+      eventBus.dispatch('download', { source: self, });
     });
 
     // Suppress context menus for some controls.


### PR DESCRIPTION
This patch is the first step to be able to eventually get rid of the `attachDOMEventsToEventBus` function, by allowing `EventBus` instances to simply re-dispatch most[1] events to the DOM.
Note that the re-dispatching is purposely implemented to occur *after* all registered `EventBus` listeners have been serviced, to prevent the ordering issues that necessitated the duplicated page/scale-change events.

The DOM events are currently necessary for the `mozilla-central` tests, see https://hg.mozilla.org/mozilla-central/file/tip/browser/extensions/pdfjs/test, and perhaps also for custom deployments of the PDF.js default viewer.

Once this have landed, and been successfully uplifted to `mozilla-central`, I intent to submit [a patch to update the test-code](https://gist.github.com/Snuffleupagus/68bbd9650ad3144b7d311a7b2748ec98) to utilize the new preference. This will thus, eventually, make it possible to [remove the `attachDOMEventsToEventBus` functionality](https://gist.github.com/Snuffleupagus/19e3228a442f86921a9fde1cd61f34b6).

*Please note:* I've successfully ran all `mozilla-central` tests locally, with these patches applied.

---
[1] The exception being events that originated on the `window` or `document`, since those are already globally available anyway.