### PR TITLE
Replace broken link for `pr8808.pdf.link`

### DIFF
--- a/test/pdfs/pr8808.pdf.link
+++ b/test/pdfs/pr8808.pdf.link
@@ -1,1 +1,1 @@
-https://soap.plansystem.dk/pdfarchive/20_1057347_APPROVED_1193694109382.pdf
+https://dokument.plandata.dk/20_1057347_APPROVED_1193694109382.pdf


### PR DESCRIPTION
The current link had an invalid certificate and was a redirect to this new link anyway. The MD5 hash is equal.

Fixes #10011.