### PR TITLE
Fix font-string variable name typo

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -531,8 +531,8 @@ var renderTextLayer = (function renderTextLayerClosure() {
       if (fontSize !== this._layoutTextLastFontSize ||
           fontFamily !== this._layoutTextLastFontFamily) {
         this._layoutTextCtx.font = fontSize + ' ' + fontFamily;
-        this._lastFontSize = fontSize;
-        this._lastFontFamily = fontFamily;
+        this._layoutTextLastFontSize = fontSize;
+        this._layoutTextLastFontFamily = fontFamily;
       }
 
       let width = this._layoutTextCtx.measureText(textDiv.textContent).width;


### PR DESCRIPTION
The font-string rebuild condition is always satisfied because the concerned variables are never set.