### PR TITLE
Display the index of the currently active search result in the matches counter of the findbar (issue 6993, bug 1062025)

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -167,6 +167,13 @@ find_highlight=Highlight all
 find_match_case_label=Match case
 find_reached_top=Reached top of document, continued from bottom
 find_reached_bottom=Reached end of document, continued from top
+# LOCALIZATION NOTE (find_matches_count): "{{current}}" and "{{total}}" will be
+# replaced by a number representing the index of the currently active find result,
+# respectively a number representing the total number of matches in the document.
+find_matches_count={{current}} of {{total}} matches
+# LOCALIZATION NOTE (find_matches_count_limit): "{{limit}}" will be replaced by
+# a numerical value.
+find_matches_count_limit=More than {{limit}} matches
 find_not_found=Phrase not found
 
 # Error panel labels

--- a/l10n/sv-SE/viewer.properties
+++ b/l10n/sv-SE/viewer.properties
@@ -167,6 +167,13 @@ find_highlight=Markera alla
 find_match_case_label=Matcha versal/gemen
 find_reached_top=Nådde början av dokumentet, började från slutet
 find_reached_bottom=Nådde slutet på dokumentet, började från början
+# LOCALIZATION NOTE (find_matches_count): "{{current}}" and "{{total}}" will be
+# replaced by a number representing the index of the currently active find result,
+# respectively a number representing the total number of matches in the document.
+find_matches_count={{current}} av {{total}} matchande
+# LOCALIZATION NOTE (find_matches_count_limit): "{{limit}}" will be replaced by
+# a numerical value.
+find_matches_count_limit=Fler än {{limit}} matchningar
 find_not_found=Frasen hittades inte
 
 # Error panel labels

--- a/web/app.js
+++ b/web/app.js
@@ -54,6 +54,7 @@ const FORCE_PAGES_LOADED_TIMEOUT = 10000; // ms
 
 const DefaultExternalServices = {
   updateFindControlState(data) {},
+  updateFindMatchesCount(data) {},
   initPassiveLoading(callbacks) {},
   fallback(data, callback) {},
   reportTelemetry(data) {},
@@ -345,20 +346,22 @@ let PDFViewerApplication = {
       pdfViewer: this.pdfViewer,
       eventBus,
     });
-    this.findController.onUpdateResultsCount = (matchCount) => {
+    this.findController.onUpdateResultsCount = (matchesCount) => {
       if (this.supportsIntegratedFind) {
-        return;
+        this.externalServices.updateFindMatchesCount(matchesCount);
+      } else {
+        this.findBar.updateResultsCount(matchesCount);
       }
-      this.findBar.updateResultsCount(matchCount);
     };
-    this.findController.onUpdateState = (state, previous, matchCount) => {
+    this.findController.onUpdateState = (state, previous, matchesCount) => {
       if (this.supportsIntegratedFind) {
         this.externalServices.updateFindControlState({
           result: state,
           findPrevious: previous,
+          matchesCount,
         });
       } else {
-        this.findBar.updateUIState(state, previous, matchCount);
+        this.findBar.updateUIState(state, previous, matchesCount);
       }
     };
 

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -209,6 +209,10 @@ PDFViewerApplication.externalServices = {
     FirefoxCom.request('updateFindControlState', data);
   },
 
+  updateFindMatchesCount(data) {
+    // FirefoxCom.request('updateFindMatchesCount', data);
+  },
+
   initPassiveLoading(callbacks) {
     let pdfDataRangeTransport;
 

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -109,10 +109,10 @@ See https://github.com/adobe-type-tools/cmap-resources
             <label for="findHighlightAll" class="toolbarLabel" data-l10n-id="find_highlight">Highlight all</label>
             <input type="checkbox" id="findMatchCase" class="toolbarField" tabindex="95">
             <label for="findMatchCase" class="toolbarLabel" data-l10n-id="find_match_case_label">Match case</label>
-            <span id="findResultsCount" class="toolbarLabel hidden"></span>
           </div>
 
           <div id="findbarMessageContainer">
+            <span id="findResultsCount" class="toolbarLabel hidden"></span>
             <span id="findMsg" class="toolbarLabel"></span>
           </div>
         </div>  <!-- findbar -->


### PR DESCRIPTION
For the `PDFFindBar` implementation, similar to the native Firefox findbar, the matches count displayed is now limited to a (hopefully) reasonable value; compare with https://searchfox.org/mozilla-central/rev/37663bb87004167184de6f2afa6b05875eb0528e/modules/libpref/init/all.js#1031

*Please note:* In order to enable this feature in the `MOZCENTRAL` version, a follow-up patch will be required once this has landed in `mozilla-central`.

Fixes #6993.