### PR TITLE
[Regression] Ensure that `PDFFindBar.updateResultsCount` doesn't throw when the viewer is closed, by providing proper default values

### DIFF
--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -153,7 +153,7 @@ class PDFFindBar {
     this.updateResultsCount(matchesCount);
   }
 
-  updateResultsCount({ current, total, }) {
+  updateResultsCount({ current = 0, total = 0, } = {}) {
     if (!this.findResultsCount) {
       return; // No UI control is provided.
     }


### PR DESCRIPTION
The error can be reproduced by opening any file in the viewer, and then running `PDFViewerApplication.close()` in the console.

/cc @timvandermeij 
/cc @rvandermeulen

*Edit:* Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1489996#c2