### PR TITLE
Refactor the find controller

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -62,7 +62,6 @@ class PDFFindController {
   }
 
   reset() {
-    this.startedTextExtraction = false;
     this.extractTextPromises = [];
     this.pendingFindMatches = Object.create(null);
     this.active = false; // If active, find results will be highlighted.
@@ -309,11 +308,10 @@ class PDFFindController {
   }
 
   _extractText() {
-    if (this.startedTextExtraction) {
+    // Perform text extraction once if this method is called multiple times.
+    if (this.extractTextPromises.length > 0) {
       return;
     }
-    this.startedTextExtraction = true;
-    this.pageContents.length = 0;
 
     let promise = Promise.resolve();
     for (let i = 0, ii = this.pdfViewer.pagesCount; i < ii; i++) {

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -16,7 +16,6 @@
 import { createPromiseCapability } from 'pdfjs-lib';
 import { getCharacterType } from './pdf_find_utils';
 import { getGlobalEventBus } from './dom_events';
-import { scrollIntoView } from './ui_utils';
 
 const FindState = {
   FOUND: 0,
@@ -25,8 +24,6 @@ const FindState = {
   PENDING: 3,
 };
 
-const FIND_SCROLL_OFFSET_TOP = -50;
-const FIND_SCROLL_OFFSET_LEFT = -400;
 const FIND_TIMEOUT = 250; // ms
 
 const CHARACTERS_TO_NORMALIZE = {
@@ -128,26 +125,6 @@ class PDFFindController {
         this._nextMatch();
       }
     });
-  }
-
-  /**
-   * Called from the text layer when match presentation is updated.
-   *
-   * @param {number} pageIndex - The index of the page.
-   * @param {number} matchIndex - The index of the match.
-   * @param {Array} elements - Text layer `div` elements.
-   * @param {number} beginIdx - Start index of the `div` array for the match.
-   */
-  updateMatchPosition(pageIndex, matchIndex, elements, beginIdx) {
-    if (this.selected.matchIdx === matchIndex &&
-        this.selected.pageIdx === pageIndex) {
-      const spot = {
-        top: FIND_SCROLL_OFFSET_TOP,
-        left: FIND_SCROLL_OFFSET_LEFT,
-      };
-      scrollIntoView(elements[beginIdx], spot,
-                     /* skipOverflowHiddenElements = */ true);
-    }
   }
 
   _normalize(text) {

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -368,7 +368,6 @@ class PDFFindController {
       this.selected.pageIdx = this.selected.matchIdx = -1;
       this.offset.pageIdx = currentPageIndex;
       this.offset.matchIdx = null;
-      this.hadMatch = false;
       this.resumePageIdx = null;
       this.pageMatches = [];
       this.matchesCountTotal = 0;
@@ -411,7 +410,6 @@ class PDFFindController {
           (previous && offset.matchIdx > 0)) {
         // The simple case; we just have advance the matchIdx to select
         // the next match on the page.
-        this.hadMatch = true;
         offset.matchIdx = (previous ? offset.matchIdx - 1 :
                                       offset.matchIdx + 1);
         this._updateMatch(/* found = */ true);
@@ -432,7 +430,6 @@ class PDFFindController {
 
     if (numMatches) {
       // There were matches for the page, so initialize `matchIdx`.
-      this.hadMatch = true;
       offset.matchIdx = (previous ? numMatches - 1 : 0);
       this._updateMatch(/* found = */ true);
       return true;

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -15,8 +15,11 @@
 
 import { getGlobalEventBus } from './dom_events';
 import { renderTextLayer } from 'pdfjs-lib';
+import { scrollIntoView } from './ui_utils';
 
 const EXPAND_DIVS_TIMEOUT = 300; // ms
+const MATCH_SCROLL_OFFSET_TOP = -50;
+const MATCH_SCROLL_OFFSET_LEFT = -400;
 
 /**
  * @typedef {Object} TextLayerBuilderOptions
@@ -243,9 +246,17 @@ class TextLayerBuilder {
       let isSelected = (isSelectedPage && i === selectedMatchIdx);
       let highlightSuffix = (isSelected ? ' selected' : '');
 
+      // Scroll the selected match into view.
       if (this.findController) {
-        this.findController.updateMatchPosition(pageIdx, i, textDivs,
-                                                begin.divIdx);
+        if (this.findController.selected.matchIdx === i &&
+            this.findController.selected.pageIdx === pageIdx) {
+          const spot = {
+            top: MATCH_SCROLL_OFFSET_TOP,
+            left: MATCH_SCROLL_OFFSET_LEFT,
+          };
+          scrollIntoView(textDivs[begin.divIdx], spot,
+                         /* skipOverflowHiddenElements = */ true);
+        }
       }
 
       // Match inside new div.


### PR DESCRIPTION
I looked into #7356 and quickly found that the find controller code is a bit complex, mainly because there is quite a bit of code to actually compute the matches, but also because it performs other tasks like scrolling matches into view and updating matches on pages.

The objective of this pull request is to work towards making this issue easier to solve. We do so by removing unnecessary/dead code to simplify the code and to reduce the amount of state that the object has to keep track of. Moreover, we modernize the code to make it more readable. Finally, we move the code for scrolling matches into view to the text layer builder since that shouldn't be the responsibility of the find controller and the match rendering logic is already there.

If this is merged, the code will be easier to refactor further (as described in the issue mentioned before) and to start adding unit tests for it.

@Snuffleupagus Would you perhaps be willing to review this? I would suggest checking this per commit since I explained some of the changes in the commit message and each commit is relatively small.