### PR TITLE
Attempt to support plural forms in the matches counter of the findbar (issue 10067)

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -168,13 +168,20 @@ find_match_case_label=Match case
 find_entire_word_label=Whole words
 find_reached_top=Reached top of document, continued from bottom
 find_reached_bottom=Reached end of document, continued from top
-# LOCALIZATION NOTE (find_matches_count): "{{current}}" and "{{total}}" will be
-# replaced by a number representing the index of the currently active find result,
-# respectively a number representing the total number of matches in the document.
-find_matches_count={{current}} of {{total}} matches
-# LOCALIZATION NOTE (find_matches_count_limit): "{{limit}}" will be replaced by
-# a numerical value.
-find_matches_count_limit=More than {{limit}} matches
+# LOCALIZATION NOTE (find_matches_count): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_matches_count={[ plural(n) ]}
+find_matches_count[one]={{current}} of {{total}} match
+find_matches_count[other]={{current}} of {{total}} matches
+# LOCALIZATION NOTE (find_matches_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_matches_count_limit={[ plural(n) ]}
+find_matches_count_limit[one]=More than {{limit}} match
+find_matches_count_limit[other]=More than {{limit}} matches
 find_not_found=Phrase not found
 
 # Error panel labels

--- a/l10n/nl/viewer.properties
+++ b/l10n/nl/viewer.properties
@@ -168,13 +168,20 @@ find_match_case_label=Hoofdlettergevoelig
 find_entire_word_label=Hele woorden
 find_reached_top=Bovenkant van document bereikt, doorgegaan vanaf onderkant
 find_reached_bottom=Onderkant van document bereikt, doorgegaan vanaf bovenkant
-# LOCALIZATION NOTE (find_matches_count): "{{current}}" and "{{total}}" will be
-# replaced by a number representing the index of the currently active find result,
-# respectively a number representing the total number of matches in the document.
-find_matches_count={{current}} van {{total}} overeenkomsten
-# LOCALIZATION NOTE (find_matches_count_limit): "{{limit}}" will be replaced by
-# a numerical value.
-find_matches_count_limit=Meer dan {{limit}} overeenkomsten
+# LOCALIZATION NOTE (find_matches_count): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_matches_count={[ plural(n) ]}
+find_matches_count[one]={{current}} van {{total}} overeenkomst
+find_matches_count[other]={{current}} van {{total}} overeenkomsten
+# LOCALIZATION NOTE (find_matches_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_matches_count_limit={[ plural(n) ]}
+find_matches_count_limit[one]=Meer dan {{limit}} overeenkomst
+find_matches_count_limit[other]=Meer dan {{limit}} overeenkomsten
 find_not_found=Tekst niet gevonden
 
 # Error panel labels

--- a/l10n/sv-SE/viewer.properties
+++ b/l10n/sv-SE/viewer.properties
@@ -168,13 +168,20 @@ find_match_case_label=Matcha versal/gemen
 find_entire_word_label=Hela ord
 find_reached_top=Nådde början av dokumentet, började från slutet
 find_reached_bottom=Nådde slutet på dokumentet, började från början
-# LOCALIZATION NOTE (find_matches_count): "{{current}}" and "{{total}}" will be
-# replaced by a number representing the index of the currently active find result,
-# respectively a number representing the total number of matches in the document.
-find_matches_count={{current}} av {{total}} matchande
-# LOCALIZATION NOTE (find_matches_count_limit): "{{limit}}" will be replaced by
-# a numerical value.
-find_matches_count_limit=Fler än {{limit}} matchningar
+# LOCALIZATION NOTE (find_matches_count): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_matches_count={[ plural(n) ]}
+find_matches_count[one]={{current}} av {{total}} matchningar
+find_matches_count[other]={{current}} av {{total}} matchande
+# LOCALIZATION NOTE (find_matches_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_matches_count_limit={[ plural(n) ]}
+find_matches_count_limit[one]=Fler än {{limit}} matchning
+find_matches_count_limit[other]=Fler än {{limit}} matchningar
 find_not_found=Frasen hittades inte
 
 # Error panel labels

--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -157,18 +157,20 @@ class PDFFindBar {
     if (!this.findResultsCount) {
       return; // No UI control is provided.
     }
-    let matchesCountMsg = '';
+    let matchesCountMsg = '', limit = MATCHES_COUNT_LIMIT;
 
     if (total) {
-      if (total > MATCHES_COUNT_LIMIT) {
+      if (total > limit) {
         matchesCountMsg = this.l10n.get('find_matches_count_limit', {
-          limit: MATCHES_COUNT_LIMIT.toLocaleString(),
-        }, 'More than {{limit}} matches');
+          n: limit,
+          limit: limit.toLocaleString(),
+        }, 'More than {{limit}} match' + (limit !== 1 ? 'es' : ''));
       } else {
         matchesCountMsg = this.l10n.get('find_matches_count', {
+          n: total,
           current: current.toLocaleString(),
           total: total.toLocaleString(),
-        }, '{{current}} of {{total}} matches');
+        }, '{{current}} of {{total}} match' + (total !== 1 ? 'es' : ''));
       }
     }
     Promise.resolve(matchesCountMsg).then((msg) => {


### PR DESCRIPTION
Based on a quick look at https://github.com/fabi1cazenave/webL10n/#pluralization, it seems that supporting plural forms shouldn't be as difficult as I first thought it might be.

Fixes #10067