### PR TITLE
Enable forwarding, in `FirefoxCom`, of the matchesCount to the browser findbar (bug 1062025)

### DIFF
--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -212,7 +212,7 @@ PDFViewerApplication.externalServices = {
   },
 
   updateFindMatchesCount(data) {
-    // FirefoxCom.request('updateFindMatchesCount', data);
+    FirefoxCom.request('updateFindMatchesCount', data);
   },
 
   initPassiveLoading(callbacks) {

--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -161,16 +161,33 @@ class PDFFindBar {
 
     if (total) {
       if (total > limit) {
-        matchesCountMsg = this.l10n.get('find_matches_count_limit', {
-          n: limit,
-          limit: limit.toLocaleString(),
-        }, 'More than {{limit}} match' + (limit !== 1 ? 'es' : ''));
+        if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('MOZCENTRAL')) {
+          // TODO: Remove this hard-coded `[other]` form once plural support has
+          // been implemented in the mozilla-central specific `l10n.js` file.
+          matchesCountMsg = this.l10n.get('find_matches_count_limit[other]', {
+            limit: limit.toLocaleString(),
+          }, 'More than {{limit}} matches');
+        } else {
+          matchesCountMsg = this.l10n.get('find_matches_count_limit', {
+            n: limit,
+            limit: limit.toLocaleString(),
+          }, 'More than {{limit}} match' + (limit !== 1 ? 'es' : ''));
+        }
       } else {
-        matchesCountMsg = this.l10n.get('find_matches_count', {
-          n: total,
-          current: current.toLocaleString(),
-          total: total.toLocaleString(),
-        }, '{{current}} of {{total}} match' + (total !== 1 ? 'es' : ''));
+        if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('MOZCENTRAL')) {
+          // TODO: Remove this hard-coded `[other]` form once plural support has
+          // been implemented in the mozilla-central specific `l10n.js` file.
+          matchesCountMsg = this.l10n.get('find_matches_count[other]', {
+            current: current.toLocaleString(),
+            total: total.toLocaleString(),
+          }, '{{current}} of {{total}} matches');
+        } else {
+          matchesCountMsg = this.l10n.get('find_matches_count', {
+            n: total,
+            current: current.toLocaleString(),
+            total: total.toLocaleString(),
+          }, '{{current}} of {{total}} match' + (total !== 1 ? 'es' : ''));
+        }
       }
     }
     Promise.resolve(matchesCountMsg).then((msg) => {

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -510,7 +510,7 @@ class PDFFindController {
     // When searching starts, this method may be called before the `pageMatches`
     // have been counted (in `_calculateMatch`). Ensure that the UI won't show
     // temporarily broken state when the active find result doesn't make sense.
-    if (current > total) {
+    if (current < 1 || current > total) {
       current = total = 0;
     }
     return { current, total, };


### PR DESCRIPTION
This depends on https://bugzilla.mozilla.org/show_bug.cgi?id=1062025 landing in `mozilla-central` first, since https://searchfox.org/mozilla-central/rev/37663bb87004167184de6f2afa6b05875eb0528e/browser/extensions/pdfjs/content/PdfStreamConverter.jsm#719,740 would otherwise throw for the unknown event name.