### PR TITLE
Fix rendering multiple blanks in SVG

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -746,6 +746,8 @@ SVGGraphics = (function SVGGraphicsClosure() {
       var vertical = font.vertical;
       var widthAdvanceScale = fontSize * current.fontMatrix[0];
 
+      var prevCharacter = '';
+
       var x = 0, i;
       for (i = 0; i < glyphsLength; ++i) {
         var glyph = glyphs[i];
@@ -771,9 +773,12 @@ SVGGraphics = (function SVGGraphicsClosure() {
           // might actually map to a different glyph.
           continue;
         }
-        current.xcoords.push(current.x + x * textHScale);
-        current.tspan.textContent += character;
+        if (!(prevCharacter.trim() === '' && character.trim() === '')) {
+          current.xcoords.push(current.x + x * textHScale);
+          current.tspan.textContent += character;
+        }
         x += charWidth;
+        prevCharacter = character;
       }
       if (vertical) {
         current.y -= x * textHScale;


### PR DESCRIPTION
The given PR is a simple fix for the dealing with multiple blanks in the text blocks for the SVG renderer. This issue is specific to Safari on both MacOS and iOS and the best example is the I-9 form (see https://www.uscis.gov/system/files_force/files/form/i-9-paper-version.pdf) where bottom parts look like below: 
![image](https://user-images.githubusercontent.com/1661986/45778806-96875c80-bc27-11e8-9ff6-48e134d466d9.png)

The root cause is that Safari joins all multiple blanks in the SVG tspan control and as result the x-component of it becomes out of sync with the text. Chrome and Firefox don't seem affected and keep text as it was rendered.

Here is the sample of the tspan:

`<svg:tspan font-family="Times" font-size="1px" y="-0.0913" x="54.733 54.983 55.2331 55.7891 56.2331 56.7331 57.1771 57.4271 57.9271 58.1771 58.6771 59.0101 59.2601" fill="rgb(35,31,32)">  
 Page 1 of 3</svg:tspan>`

Safari drops the second space before 'Page', as result we have 13 x coordinates and just 12 characters. So basically in this fix we ignore all blanks in the beginning of the text as well as multiple spaces between words. Search in the SVG text is affected a little bit but it works differently with Adobe Reader anyway where all multiple blanks in the search expression are ignored.