### PR TITLE
Clear all find highlights when the findbar is closed (issue 7468)

### DIFF
--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -169,20 +169,27 @@ class MozL10n {
     'findhighlightallchange',
     'findcasesensitivitychange',
     'findentirewordchange',
+    'findbarclose',
   ];
-  let handleEvent = function(evt) {
+  let handleEvent = function({ type, detail, }) {
     if (!PDFViewerApplication.initialized) {
+      return;
+    }
+    if (type === 'findbarclose') {
+      PDFViewerApplication.eventBus.dispatch('findbarclose', {
+        source: window,
+      });
       return;
     }
     PDFViewerApplication.eventBus.dispatch('find', {
       source: window,
-      type: evt.type.substring('find'.length),
-      query: evt.detail.query,
+      type: type.substring('find'.length),
+      query: detail.query,
       phraseSearch: true,
-      caseSensitive: !!evt.detail.caseSensitive,
-      entireWord: !!evt.detail.entireWord,
-      highlightAll: !!evt.detail.highlightAll,
-      findPrevious: !!evt.detail.findPrevious,
+      caseSensitive: !!detail.caseSensitive,
+      entireWord: !!detail.entireWord,
+      highlightAll: !!detail.highlightAll,
+      findPrevious: !!detail.findPrevious,
     });
   };
 

--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -216,7 +216,8 @@ class PDFFindBar {
     this.opened = false;
     this.toggleButton.classList.remove('toggled');
     this.bar.classList.add('hidden');
-    this.findController.active = false;
+
+    this.eventBus.dispatch('findbarclose', { source: this, });
   }
 
   toggle() {

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -53,9 +53,22 @@ class PDFFindController {
 
     this.reset();
 
+    eventBus.on('findbarclose', () => {
+      this._highlightMatches = false;
+
+      eventBus.dispatch('updatetextlayermatches', {
+        source: this,
+        pageIndex: -1,
+      });
+    });
+
     // Compile the regular expression for text normalization once.
     const replace = Object.keys(CHARACTERS_TO_NORMALIZE).join('');
     this._normalizationRegex = new RegExp(`[${replace}]`, 'g');
+  }
+
+  get highlightMatches() {
+    return this._highlightMatches;
   }
 
   get pageMatches() {
@@ -75,7 +88,7 @@ class PDFFindController {
   }
 
   reset() {
-    this.active = false; // If active, find results will be highlighted.
+    this._highlightMatches = false;
     this._pageMatches = [];
     this._pageMatchesLength = null;
     this._state = null;
@@ -353,7 +366,7 @@ class PDFFindController {
     const currentPageIndex = this._pdfViewer.currentPageNumber - 1;
     const numPages = this._pdfViewer.pagesCount;
 
-    this.active = true;
+    this._highlightMatches = true;
 
     if (this._dirtyMatch) {
       // Need to recalculate the matches, reset everything.

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -260,6 +260,8 @@ class PDFPageView {
   }
 
   cancelRendering(keepAnnotations = false) {
+    const renderingState = this.renderingState;
+
     if (this.paintTask) {
       this.paintTask.cancel();
       this.paintTask = null;
@@ -274,6 +276,14 @@ class PDFPageView {
     if (!keepAnnotations && this.annotationLayer) {
       this.annotationLayer.cancel();
       this.annotationLayer = null;
+    }
+
+    if (renderingState !== RenderingStates.INITIAL) {
+      this.eventBus.dispatch('pagecancelled', {
+        source: this,
+        pageNumber: this.id,
+        renderingState,
+      });
     }
   }
 

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -317,7 +317,7 @@ class TextLayerBuilder {
       clearedUntilDivIdx = match.end.divIdx + 1;
     }
 
-    if (this.findController === null || !this.findController.active) {
+    if (!this.findController || !this.findController.highlightMatches) {
       return;
     }
 
@@ -357,8 +357,15 @@ class TextLayerBuilder {
         delete _boundEvents[name];
       }
     };
+    _boundEvents.updateTextLayerMatches = (evt) => {
+      if (evt.pageIndex !== -1) {
+        return;
+      }
+      this.updateMatches();
+    };
 
     eventBus.on('pagecancelled', _boundEvents.pageCancelled);
+    eventBus.on('updatetextlayermatches', _boundEvents.updateTextLayerMatches);
   }
 
   /**


### PR DESCRIPTION
Please note that this will require a `mozilla-central` follow-up patch, e.g. looking [something like this](https://gist.github.com/Snuffleupagus/d5e9aa8fe824e2e34f85ccb1430ef3d7), in order for this to work in the built-in Firefox PDF viewer as well.

Fixes #7468.