### PR TITLE
Replace `String.prototype.substr()` occurrences with `String.prototype.substring()`

### DIFF
--- a/docs/plugins/wintersmith-makerelative.coffee
+++ b/docs/plugins/wintersmith-makerelative.coffee
@@ -10,6 +10,6 @@ module.exports = (env, callback) ->
     depth = count(source, '/') # 1 being /
     ret = ""
     ret += "../" while depth = depth - 1
-    ret + dest.substr(1)
+    ret + dest.substring(1)
 
   callback()

--- a/external/builder/builder.js
+++ b/external/builder/builder.js
@@ -240,7 +240,7 @@ function preprocessCSS(mode, source, destination) {
                  !/\}\s*$/.test(lines[i]) &&
                  lines[i].indexOf(':') < 0);
         if (i < lines.length && /\S\s*}\s*$/.test(lines[i])) {
-          lines[i] = lines[i].substr(lines[i].indexOf('}'));
+          lines[i] = lines[i].substring(lines[i].indexOf('}'));
         }
       }
       // collapse whitespaces

--- a/external/cmapscompress/compress.js
+++ b/external/cmapscompress/compress.js
@@ -155,7 +155,7 @@ function parseCMap(binaryData) {
     },
     readHex: function (size) {
       var lengthInChars = (size + 1) << 1;
-      var s = this.buffer.substr(this.pos, lengthInChars);
+      var s = this.buffer.substring(this.pos, this.pos + lengthInChars);
       this.pos += lengthInChars;
       return s;
     },
@@ -343,7 +343,7 @@ function writeNumber(n) {
       s = writeByte((buffer & 0x7f) | (s.length > 0 ? 0x80 : 0)) + s;
     }
     while (s.indexOf('80') === 0) {
-      s = s.substr(2);
+      s = s.substring(2);
     }
     return s;
   } else {

--- a/external/webL10n/l10n.js
+++ b/external/webL10n/l10n.js
@@ -267,7 +267,7 @@ document.webL10n = (function(window, document, undefined) {
           var id, prop, index = key.lastIndexOf('.');
           if (index > 0) { // an attribute has been specified
             id = key.substring(0, index);
-            prop = key.substr(index + 1);
+            prop = key.substring(index + 1);
           } else { // no attribute: assuming text content by default
             id = key;
             prop = gTextProp;
@@ -974,7 +974,7 @@ document.webL10n = (function(window, document, undefined) {
       var index = key.lastIndexOf('.');
       var prop = gTextProp;
       if (index > 0) { // An attribute has been specified
-        prop = key.substr(index + 1);
+        prop = key.substring(index + 1);
         key = key.substring(0, index);
       }
       var fallback;

--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -1366,7 +1366,7 @@ var CFFCompiler = (function CFFCompilerClosure() {
       nibbles += (nibbles.length & 1) ? 'f' : 'ff';
       var out = [30];
       for (i = 0, ii = nibbles.length; i < ii; i += 2) {
-        out.push(parseInt(nibbles.substr(i, 2), 16));
+        out.push(parseInt(nibbles.substring(i, i + 2), 16));
       }
       return out;
     },

--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -228,7 +228,7 @@ class CMap {
     while (low <= high) {
       this._map[low++] = dstLow;
       // Only the last byte has to be incremented.
-      dstLow = dstLow.substr(0, lastByte) +
+      dstLow = dstLow.substring(0, lastByte) +
                String.fromCharCode(dstLow.charCodeAt(lastByte) + 1);
     }
   }

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -2002,18 +2002,18 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           switch (glyphName[0]) {
             case 'G': // Gxx glyph
               if (glyphName.length === 3) {
-                code = parseInt(glyphName.substr(1), 16);
+                code = parseInt(glyphName.substring(1), 16);
               }
               break;
             case 'g': // g00xx glyph
               if (glyphName.length === 5) {
-                code = parseInt(glyphName.substr(1), 16);
+                code = parseInt(glyphName.substring(1), 16);
               }
               break;
             case 'C': // Cddd glyph
             case 'c': // cddd glyph
               if (glyphName.length >= 3) {
-                code = +glyphName.substr(1);
+                code = +glyphName.substring(1);
               }
               break;
             default:

--- a/src/core/unicode.js
+++ b/src/core/unicode.js
@@ -70,9 +70,9 @@ function getUnicodeForGlyph(name, glyphsUnicodeMap) {
     var nameLen = name.length, hexStr;
 
     if (nameLen === 7 && name[1] === 'n' && name[2] === 'i') { // 'uniXXXX'
-      hexStr = name.substr(3);
+      hexStr = name.substring(3);
     } else if (nameLen >= 5 && nameLen <= 7) { // 'uXXXX{XX}'
-      hexStr = name.substr(1);
+      hexStr = name.substring(1);
     } else {
       return -1;
     }

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -195,8 +195,8 @@ if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('MOZCENTRAL')) {
       }
 
       function spliceString(s, offset, remove, insert) {
-        var chunk1 = s.substr(0, offset);
-        var chunk2 = s.substr(offset + remove);
+        var chunk1 = s.substring(0, offset);
+        var chunk2 = s.substring(offset + remove);
         return chunk1 + insert + chunk2;
       }
 

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -373,7 +373,7 @@ SVGGraphics = (function SVGGraphicsClosure() {
     do {
       i--;
     } while (s[i] === '0');
-    return s.substr(0, s[i] === '.' ? i : i + 1);
+    return s.substring(0, s[i] === '.' ? i : i + 1);
   }
 
   /**

--- a/test/add_test.js
+++ b/test/add_test.js
@@ -46,14 +46,15 @@ calculateMD5(file, (err, md5) => {
   }
   let contents = fs.readFileSync(gitIgnore, 'utf8').split('\n');
   let randomLine = getRandomArbitrary(10, contents.length - 2);
-  contents.splice(randomLine, 0, '!' + file.substr(file.lastIndexOf('/') + 1));
+  contents.splice(randomLine, 0,
+                  '!' + file.substring(file.lastIndexOf('/') + 1));
   fs.writeFileSync('test/pdfs/.gitignore', contents.join('\n'));
 
   contents = fs.readFileSync(testManifest, 'utf8');
   let pdf = file.substring(file.lastIndexOf('/') + 1, file.length - 4);
   let randomPoint = getRandomArbitrary(100, contents.length - 20);
   let bracket = contents.indexOf('},\n', randomPoint);
-  let out = contents.substr(0, bracket) +
+  let out = contents.substring(0, bracket) +
     '},\n' +
     `    {  "id": "${pdf}",\n` +
     `       "file": "pdfs/${pdf}.pdf",\n` +
@@ -61,7 +62,7 @@ calculateMD5(file, (err, md5) => {
     '       "rounds": 1,\n' +
     '       "type": "eq"\n' +
     '    ' +
-    contents.substr(bracket);
+    contents.substring(bracket);
   fs.writeFileSync('test/test_manifest.json', out);
   execSync(`git add ${testManifest} ${gitIgnore}`);
   execSync(`git add ${file}`);

--- a/test/resources/reftest-analyzer.js
+++ b/test/resources/reftest-analyzer.js
@@ -52,7 +52,7 @@ window.onload = function() {
 
   function hashParameters() {
     var result = { };
-    var params = window.location.hash.substr(1).split(/[&;]/);
+    var params = window.location.hash.substring(1).split(/[&;]/);
     for (var i = 0; i < params.length; i++) {
       var parts = params[i].split("=");
       result[parts[0]] = unescape(unescape(parts[1]));

--- a/test/unit/cff_parser_spec.js
+++ b/test/unit/cff_parser_spec.js
@@ -52,7 +52,7 @@ describe('CFFParser', function() {
                       'f78e14';
     var fontArr = [];
     for (var i = 0, ii = exampleFont.length; i < ii; i += 2) {
-      var hex = exampleFont.substr(i, 2);
+      var hex = exampleFont.substring(i, i + 2);
       fontArr.push(parseInt(hex, 16));
     }
     fontData = new Stream(fontArr);

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -262,7 +262,7 @@ var Stepper = (function StepperClosure() {
     if (typeof args === 'string') {
       var MAX_STRING_LENGTH = 75;
       return args.length <= MAX_STRING_LENGTH ? args :
-        args.substr(0, MAX_STRING_LENGTH) + '...';
+        args.substring(0, MAX_STRING_LENGTH) + '...';
     }
     if (typeof args !== 'object' || args === null) {
       return args;

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -537,7 +537,7 @@ function isDataSchema(url) {
   while (i < ii && url[i].trim() === '') {
     i++;
   }
-  return url.substr(i, 5).toLowerCase() === 'data:';
+  return url.substring(i, i + 5).toLowerCase() === 'data:';
 }
 
 /**


### PR DESCRIPTION
As outlined in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr, which refers to the ECMA-262 specification, using the `substr` function is advised against.

Hence this PR, which replaces all remaining `substr` occurrences with `substring` instead. Please refer to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr#Syntax respectively https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring#Syntax for the differences between the two functions.

Note that in most cases in the code-base there's only one argument passed to `substr`, and those require no other changes except replacing "substr" with "substring". For the other cases, the `substr(start, length)` calls are changed to `substring(start, start + length)` instead.