### PR TITLE
Update `{PDFLinkService, PDFDocumentProperties}.setDocument` to make the "url" parameter optional

### DIFF
--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -80,6 +80,12 @@ describe('ui_utils', function() {
       expect(getPDFFileNameFromURL('/pdfs/file3.txt', '')).toEqual('');
     });
 
+    it('gets fallback filename when url is not a string', function() {
+      expect(getPDFFileNameFromURL(null)).toEqual('document.pdf');
+
+      expect(getPDFFileNameFromURL(null, 'file.pdf')).toEqual('file.pdf');
+    });
+
     it('gets PDF filename from URL containing leading/trailing whitespace',
         function() {
       // Relative URL

--- a/web/app.js
+++ b/web/app.js
@@ -595,8 +595,8 @@ let PDFViewerApplication = {
 
       this.pdfThumbnailViewer.setDocument(null);
       this.pdfViewer.setDocument(null);
-      this.pdfLinkService.setDocument(null, null);
-      this.pdfDocumentProperties.setDocument(null, null);
+      this.pdfLinkService.setDocument(null);
+      this.pdfDocumentProperties.setDocument(null);
     }
     this.store = null;
     this.isInitialViewSet = false;

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -120,7 +120,7 @@ class PDFDocumentProperties {
         return Promise.all([
           info,
           metadata,
-          contentDispositionFilename || getPDFFileNameFromURL(this.url),
+          contentDispositionFilename || getPDFFileNameFromURL(this.url || ''),
           this._parseFileSize(this.maybeFileSize),
           this._parseDate(info.CreationDate),
           this._parseDate(info.ModDate),
@@ -187,7 +187,7 @@ class PDFDocumentProperties {
    * @param {Object} pdfDocument - A reference to the PDF document.
    * @param {string} url - The URL of the document.
    */
-  setDocument(pdfDocument, url) {
+  setDocument(pdfDocument, url = null) {
     if (this.pdfDocument) {
       this._reset();
       this._updateUI(true);

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -49,7 +49,7 @@ class PDFLinkService {
     this._pagesRefCache = null;
   }
 
-  setDocument(pdfDocument, baseUrl) {
+  setDocument(pdfDocument, baseUrl = null) {
     this.baseUrl = baseUrl;
     this.pdfDocument = pdfDocument;
     this._pagesRefCache = Object.create(null);

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -548,6 +548,9 @@ function isDataSchema(url) {
  * @returns {string} Guessed PDF filename.
  */
 function getPDFFileNameFromURL(url, defaultFilename = 'document.pdf') {
+  if (typeof url !== 'string') {
+    return defaultFilename;
+  }
   if (isDataSchema(url)) {
     console.warn('getPDFFileNameFromURL: ' +
                  'ignoring "data:" URL for performance reasons.');


### PR DESCRIPTION
This way the resetting of `PDFLinkService`/`PDFDocumentProperties` instances, as is done in `PDFViewerApplication.close`, only requires passing in *one* `null` argument instead of two.

---

*Also:* Prevent `getPDFFileNameFromURL` from breaking if the `url` parameter not a string