### PR TITLE
Attempt to simplify the `fileattachmentannotation` event dispatching

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -1130,15 +1130,18 @@ class FileAttachmentAnnotationElement extends AnnotationElement {
   constructor(parameters) {
     super(parameters, /* isRenderable = */ true);
 
-    let file = this.data.file;
-    this.filename = getFilenameFromUrl(file.filename);
-    this.content = file.content;
+    const { filename, content, } = this.data.file;
+    this.filename = getFilenameFromUrl(filename);
+    this.content = content;
 
-    this.linkService.onFileAttachmentAnnotation({
-      id: stringToPDFString(file.filename),
-      filename: file.filename,
-      content: file.content,
-    });
+    if (this.linkService.eventBus) {
+      this.linkService.eventBus.dispatch('fileattachmentannotation', {
+        source: this,
+        id: stringToPDFString(filename),
+        filename,
+        content,
+      });
+    }
   }
 
   /**

--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -68,11 +68,6 @@ class IPDFLinkService {
   executeNamedAction(action) {}
 
   /**
-   * @param {Object} params
-   */
-  onFileAttachmentAnnotation({ id, filename, content, }) {}
-
-  /**
    * @param {number} pageNum - page number.
    * @param {Object} pageRef - reference to the page.
    */

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -338,18 +338,6 @@ class PDFLinkService {
   }
 
   /**
-   * @param {Object} params
-   */
-  onFileAttachmentAnnotation({ id, filename, content, }) {
-    this.eventBus.dispatch('fileattachmentannotation', {
-      source: this,
-      id,
-      filename,
-      content,
-    });
-  }
-
-  /**
    * @param {number} pageNum - page number.
    * @param {Object} pageRef - reference to the page.
    */
@@ -480,11 +468,6 @@ class SimpleLinkService {
    * @param {string} action
    */
   executeNamedAction(action) {}
-
-  /**
-   * @param {Object} params
-   */
-  onFileAttachmentAnnotation({ id, filename, content, }) {}
 
   /**
    * @param {number} pageNum - page number.


### PR DESCRIPTION
This attempts to reduced the level of indirection, and the amount of code, when dispatching `fileattachmentannotation` events, by removing the `PDFLinkService.onFileAttachmentAnnotation` method and just accessing `PDFLinkService.eventBus` directly in the `FileAttachmentAnnotationElement` constructor.
Given that other properties, such as `externalLinkTarget`/`externalLinkRel`, are already being accessed directly this pattern seems fine here as well.