### PR TITLE
Make `PDFFindController` less confusing to use, by allowing searching to start when `setDocument` is called

### DIFF
--- a/examples/components/simpleviewer.js
+++ b/examples/components/simpleviewer.js
@@ -70,5 +70,4 @@ pdfjsLib.getDocument({
   pdfViewer.setDocument(pdfDocument);
 
   pdfLinkService.setDocument(pdfDocument, null);
-  pdfFindController.setDocument(pdfDocument);
 });

--- a/examples/components/singlepageviewer.js
+++ b/examples/components/singlepageviewer.js
@@ -70,5 +70,4 @@ pdfjsLib.getDocument({
   pdfSinglePageViewer.setDocument(pdfDocument);
 
   pdfLinkService.setDocument(pdfDocument, null);
-  pdfFindController.setDocument(pdfDocument);
 });

--- a/test/unit/pdf_find_controller_spec.js
+++ b/test/unit/pdf_find_controller_spec.js
@@ -51,18 +51,17 @@ describe('pdf_find_controller', function() {
   beforeEach(function(done) {
     const loadingTask = getDocument(buildGetDocumentParams('tracemonkey.pdf'));
     loadingTask.promise.then(function(pdfDocument) {
+      eventBus = new EventBus();
+
       const linkService = new MockLinkService();
       linkService.setDocument(pdfDocument);
-
-      eventBus = new EventBus();
 
       pdfFindController = new PDFFindController({
         linkService,
         eventBus,
       });
-      pdfFindController.setDocument(pdfDocument);
+      pdfFindController.setDocument(pdfDocument); // Enable searching.
 
-      eventBus.dispatch('pagesinit');
       done();
     });
   });

--- a/web/app.js
+++ b/web/app.js
@@ -569,7 +569,6 @@ let PDFViewerApplication = {
     if (this.pdfDocument) {
       this.pdfDocument = null;
 
-      this.findController.setDocument(null);
       this.pdfThumbnailViewer.setDocument(null);
       this.pdfViewer.setDocument(null);
       this.pdfLinkService.setDocument(null);
@@ -893,7 +892,6 @@ let PDFViewerApplication = {
     } else if (PDFJSDev.test('CHROME')) {
       baseDocumentUrl = location.href.split('#')[0];
     }
-    this.findController.setDocument(pdfDocument);
     this.pdfLinkService.setDocument(pdfDocument, baseDocumentUrl);
     this.pdfDocumentProperties.setDocument(pdfDocument, this.url);
 

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -363,6 +363,10 @@ class BaseViewer {
     if (this.pdfDocument) {
       this._cancelRendering();
       this._resetView();
+
+      if (this.findController) {
+        this.findController.setDocument(null);
+      }
     }
 
     this.pdfDocument = pdfDocument;
@@ -471,6 +475,9 @@ class BaseViewer {
 
       this.eventBus.dispatch('pagesinit', { source: this, });
 
+      if (this.findController) {
+        this.findController.setDocument(pdfDocument); // Enable searching.
+      }
       if (this.defaultRenderingQueue) {
         this.update();
       }


### PR DESCRIPTION
*This patch is based on something that I noticed while working on PR #10126.*

The recent re-factoring of `PDFFindController` brought many improvements, among those the fact that access to `BaseViewer` is no longer required. However, with these changes there's one thing which now strikes me as not particularly user-friendly[1]: The fact that in order for searching to actually work, `PDFFindController.setDocument` must be called *and* a 'pagesinit' event must be dispatched (from somewhere).

For all other viewer components, calling the `setDocument` method[2] is enough in order for the component to actually be usable.
The `PDFFindController` thus stands out quite a bit, and it also becomes difficult to work with in any sort of custom implementation. For example: Imagine someone trying to use `PDFFindController` separately from the viewer[3], which *should* now be relatively simple given the re-factoring, and thus having to (somehow) figure out that they'll also need to manually dispatch a 'pagesinit' event for searching to work.

Note that the above even affects the unit-tests, where an out-of-place 'pagesinit' event is being used.
To attempt to address these problems, I'm thus suggesting that *only* `setDocument` should be used to indicate that searching may start. For the default viewer and/or the viewer components, `BaseViewer.setDocument` will now call `PDFFindController.setDocument` when the document is ready, thus requiring no outside configuration anymore[4]. For custom implementation, and the unit-tests, it's now as simple as just calling `PDFFindController.setDocument` to allow searching to start.

---
[1] I should have caught this during review of PR #10099, but unfortunately it's sometimes not until you actually work with the code in question that things like these become clear.

[2] Assuming, obviously, that the viewer component in question actually implements such a method :-)

[3] There's even a very recent issue, filed by someone trying to do just that.

[4] Short of providing a `PDFFindController` instance when creating a `BaseViewer` instance, of course.