### PR TITLE
improve readability of CanvasGraphics's and SVGGraphics's constructPath

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1079,68 +1079,120 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
 
     // Path
     constructPath: function CanvasGraphics_constructPath(ops, args) {
-      var ctx = this.ctx;
-      var current = this.current;
-      var x = current.x, y = current.y;
-      for (var i = 0, j = 0, ii = ops.length; i < ii; i++) {
+      for (let i = 0, j = 0, ii = ops.length; i < ii; ++i) {
         switch (ops[i] | 0) {
           case OPS.rectangle:
-            x = args[j++];
-            y = args[j++];
-            var width = args[j++];
-            var height = args[j++];
-            if (width === 0) {
-              width = this.getSinglePixelWidth();
-            }
-            if (height === 0) {
-              height = this.getSinglePixelWidth();
-            }
-            var xw = x + width;
-            var yh = y + height;
-            this.ctx.moveTo(x, y);
-            this.ctx.lineTo(xw, y);
-            this.ctx.lineTo(xw, yh);
-            this.ctx.lineTo(x, yh);
-            this.ctx.lineTo(x, y);
-            this.ctx.closePath();
+            this.rectangle(
+              args[j++], // x
+              args[j++], // y
+              args[j++], // width
+              args[j++]  // height
+            );
             break;
+
           case OPS.moveTo:
-            x = args[j++];
-            y = args[j++];
-            ctx.moveTo(x, y);
+            this.moveTo(
+              args[j++], // x
+              args[j++]  // y
+            );
             break;
+
           case OPS.lineTo:
-            x = args[j++];
-            y = args[j++];
-            ctx.lineTo(x, y);
+            this.lineTo(
+              args[j++], // x
+              args[j++]  // y
+            );
             break;
+
           case OPS.curveTo:
-            x = args[j + 4];
-            y = args[j + 5];
-            ctx.bezierCurveTo(args[j], args[j + 1], args[j + 2], args[j + 3],
-                              x, y);
-            j += 6;
+            this.curveTo(
+              args[j++], // cp1x
+              args[j++], // cp1y
+              args[j++], // cp2x
+              args[j++], // cp2y
+              args[j++], // x
+              args[j++]  // y
+            );
             break;
+
           case OPS.curveTo2:
-            ctx.bezierCurveTo(x, y, args[j], args[j + 1],
-                              args[j + 2], args[j + 3]);
-            x = args[j + 2];
-            y = args[j + 3];
-            j += 4;
+            this.curveTo2(
+              args[j++], // cp2x
+              args[j++], // cp2y
+              args[j++], // x
+              args[j++]  // y
+            );
             break;
+
           case OPS.curveTo3:
-            x = args[j + 2];
-            y = args[j + 3];
-            ctx.bezierCurveTo(args[j], args[j + 1], x, y, x, y);
-            j += 4;
+            this.curveTo3(
+              args[j++], // cp1x
+              args[j++], // cp1y
+              args[j++], // x
+              args[j++]  // y
+            );
             break;
+
           case OPS.closePath:
-            ctx.closePath();
+            this.closePath();
             break;
         }
       }
-      current.setCurrentPoint(x, y);
     },
+
+    rectangle: function CanvasGraphics_rectangle(x, y, width, height) {
+      // ensure width is not null
+      if (width === 0) {
+        width = this.getSinglePixelWidth();
+      }
+
+      // ensure height is not null
+      if (height === 0) {
+        height = this.getSinglePixelWidth();
+      }
+
+      const xw = x + width;
+      const yh = y + height;
+
+      // draw rectangle
+      this.ctx.moveTo(x, y);
+      this.ctx.lineTo(xw, y);
+      this.ctx.lineTo(xw, yh);
+      this.ctx.lineTo(x, yh);
+      this.ctx.lineTo(x, y);
+      this.ctx.closePath();
+
+      // set pointer to the starting point of
+      // the rectangle
+      this.current.setCurrentPoint(x, y);
+    },
+
+    moveTo: function CanvasGraphics_moveTo(x, y) {
+      this.ctx.moveTo(x, y);
+      this.current.setCurrentPoint(x, y);
+    },
+
+    lineTo: function CanvasGraphics_lineTo(x, y) {
+      this.ctx.lineTo(x, y);
+      this.current.setCurrentPoint(x, y);
+    },
+
+    curveTo: function CanvasGraphics_curveTo(cp1x, cp1y, cp2x, cp2y, x, y) {
+      this.ctx.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, x, y);
+      this.current.setCurrentPoint(x, y);
+    },
+
+    curveTo2: function CanvasGraphics_curveTo2(cp2x, cp2y, x, y) {
+      const { 'x': prevX, 'y': prevY, } = this.current;
+      this.ctx.bezierCurveTo(prevX, prevY, cp2x, cp2y, x, y);
+      this.current.setCurrentPoint(x, y);
+    },
+
+    curveTo3: function CanvasGraphics_curveTo3(cp1x, cp1y, x, y) {
+      this.ctx.bezierCurveTo(cp1x, cp1y, x, y, x, y);
+      this.current.setCurrentPoint(x, y);
+    },
+
     closePath: function CanvasGraphics_closePath() {
       this.ctx.closePath();
     },

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -939,58 +939,62 @@ SVGGraphics = (function SVGGraphicsClosure() {
       var current = this.current;
       var x = current.x, y = current.y;
       current.path = this.svgFactory.createElement('svg:path');
-      var d = [];
       var opLength = ops.length;
 
       for (var i = 0, j = 0; i < opLength; i++) {
         switch (ops[i] | 0) {
           case OPS.rectangle:
-            x = args[j++];
-            y = args[j++];
-            var width = args[j++];
-            var height = args[j++];
-            var xw = x + width;
-            var yh = y + height;
-            d.push('M', pf(x), pf(y), 'L', pf(xw), pf(y), 'L', pf(xw), pf(yh),
-                   'L', pf(x), pf(yh), 'Z');
+            this.rectangle(
+              args[j++], // x
+              args[j++], // y
+              args[j++], // width
+              args[j++]  // height
+            );
             break;
           case OPS.moveTo:
-            x = args[j++];
-            y = args[j++];
-            d.push('M', pf(x), pf(y));
+            this.moveTo(
+              args[j++], // x
+              args[j++]  // y
+            );
             break;
           case OPS.lineTo:
-            x = args[j++];
-            y = args[j++];
-            d.push('L', pf(x), pf(y));
+            this.lineTo(
+              args[j++], // x
+              args[j++]  // y
+            );
             break;
           case OPS.curveTo:
-            x = args[j + 4];
-            y = args[j + 5];
-            d.push('C', pf(args[j]), pf(args[j + 1]), pf(args[j + 2]),
-                   pf(args[j + 3]), pf(x), pf(y));
-            j += 6;
+            this.curveTo(
+              args[j++], // cp1x
+              args[j++], // cp1y
+              args[j++], // cp2x
+              args[j++], // cp2y
+              args[j++], // x
+              args[j++]  // y
+            );
             break;
           case OPS.curveTo2:
-            x = args[j + 2];
-            y = args[j + 3];
-            d.push('C', pf(x), pf(y), pf(args[j]), pf(args[j + 1]),
-                   pf(args[j + 2]), pf(args[j + 3]));
-            j += 4;
+            this.curveTo2(
+              args[j++], // cp2x
+              args[j++], // cp2y
+              args[j++], // x
+              args[j++]  // y
+            );
             break;
           case OPS.curveTo3:
-            x = args[j + 2];
-            y = args[j + 3];
-            d.push('C', pf(args[j]), pf(args[j + 1]), pf(x), pf(y),
-                   pf(x), pf(y));
-            j += 4;
+            this.curveTo3(
+              args[j++], // cp1x
+              args[j++], // cp2x
+              args[j++], // x
+              args[j++]  // y
+            );
             break;
           case OPS.closePath:
-            d.push('Z');
+            this.closePath();
             break;
         }
       }
-      current.path.setAttributeNS(null, 'd', d.join(' '));
+
       current.path.setAttributeNS(null, 'fill', 'none');
 
       this._ensureTransformGroup().appendChild(current.path);
@@ -999,6 +1003,90 @@ SVGGraphics = (function SVGGraphicsClosure() {
       // in 'fill' and 'stroke'
       current.element = current.path;
       current.setCurrentPoint(x, y);
+    },
+
+    rectangle: function SVGGraphics_rectangle(x, y, width, height) {
+      var current = this.current;
+
+      if (current.path) {
+        var xw = x + width;
+        var yh = y + height;
+
+        var d = current.path.getAttributeNS(null, 'd');
+        d += ' ' + [
+          'M', pf(x), pf(y),
+          'L', pf(xw), pf(y),
+          'L', pf(xw), pf(yh),
+          'L', pf(x), pf(yh),
+          'Z'
+        ].join(' ');
+        current.path.setAttributeNS(null, 'd', d);
+      }
+    },
+
+    moveTo: function SVGGraphics_moveTo(x, y) {
+      var current = this.current;
+
+      if (current.path) {
+        var d = current.path.getAttributeNS(null, 'd');
+        d += ' ' + ['M', pf(x), pf(y)].join(' ');
+        current.path.setAttributeNS(null, 'd', d);
+      }
+    },
+
+    lineTo: function SVGGraphics_lineTo(x, y) {
+      var current = this.current;
+
+      if (current.path) {
+        var d = current.path.getAttributeNS(null, 'd');
+        d += ' ' + ['L', pf(x), pf(y)].join(' ');
+        current.path.setAttributeNS(null, 'd', d);
+      }
+    },
+
+    curveTo: function SVGGraphics_curveTo(cp1x, cp1y, cp2x, cp2y, x, y) {
+      var current = this.current;
+
+      if (current.path) {
+        var d = current.path.getAttributeNS(null, 'd');
+        d += ' ' + [
+          'C',
+          pf(cp1x), pf(cp1y),
+          pf(cp2x), pf(cp2y),
+          pf(x), pf(y)
+        ].join(' ');
+        current.path.setAttributeNS(null, 'd', d);
+      }
+    },
+
+    curveTo2: function SVGGraphics_curveTo2(cp2x, cp2y, x, y) {
+      var current = this.current;
+
+      if (current.path) {
+        var d = current.path.getAttributeNS(null, 'd');
+        d += ' ' + [
+          'C',
+          pf(x), pf(y),
+          pf(cp2x), pf(cp2y),
+          pf(x), pf(y)
+        ].join(' ');
+        current.path.setAttributeNS(null, 'd', d);
+      }
+    },
+
+    curveTo3: function SVGGraphics_curveTo3(cp1x, cp1y, x, y) {
+      var current = this.current;
+
+      if (current.path) {
+        var d = current.path.getAttributeNS(null, 'd');
+        d += ' ' + [
+          'C',
+          pf(cp1x), pf(cp1y),
+          pf(x), pf(y),
+          pf(x), pf(y)
+        ].join(' ');
+        current.path.setAttributeNS(null, 'd', d);
+      }
     },
 
     endPath: function SVGGraphics_endPath() {


### PR DESCRIPTION
- extract sub-programs into own functions:
  - `rectangle(x, y, width, height)`
  - `moveTo(x, y)`
  - `lineTo(x, y)`
  - `curveTo(cp1x, cp1y, cp2x, cp2y, x, y)`
  - `curveTo2(cp2x, cp2y, x, y)`
  - `curveTo3(cp1x, cp1y, x, y)`
- align CanvasGraphics's and SVGGraphics's constructPath definition
  as much as possible

## Reason
`constructPath` has now improved readability and an user searching for information about the api and the way how `PDF.js` works can now easier see the parallels between the implementation for Canvas and for SVGs.