### PR TITLE
Set returnValues.suggestedLength to Content-Length if integer

### DIFF
--- a/src/display/network_utils.js
+++ b/src/display/network_utils.js
@@ -27,6 +27,20 @@ function validateRangeRequestCapabilities({ getResponseHeader, isHttp,
     allowRangeRequests: false,
     suggestedLength: undefined,
   };
+
+  let length = parseInt(getResponseHeader('Content-Length'), 10);
+  if (!Number.isInteger(length)) {
+    return returnValues;
+  }
+
+  returnValues.suggestedLength = length;
+
+  if (length <= 2 * rangeChunkSize) {
+    // The file size is smaller than the size of two chunks, so it does not
+    // make any sense to abort the request and retry with a range request.
+    return returnValues;
+  }
+
   if (disableRange || !isHttp) {
     return returnValues;
   }
@@ -36,18 +50,6 @@ function validateRangeRequestCapabilities({ getResponseHeader, isHttp,
 
   let contentEncoding = getResponseHeader('Content-Encoding') || 'identity';
   if (contentEncoding !== 'identity') {
-    return returnValues;
-  }
-
-  let length = parseInt(getResponseHeader('Content-Length'), 10);
-  if (!Number.isInteger(length)) {
-    return returnValues;
-  }
-
-  returnValues.suggestedLength = length;
-  if (length <= 2 * rangeChunkSize) {
-    // The file size is smaller than the size of two chunks, so it does not
-    // make any sense to abort the request and retry with a range request.
     return returnValues;
   }
 

--- a/test/unit/network_utils_spec.js
+++ b/test/unit/network_utils_spec.js
@@ -23,11 +23,6 @@ import {
 
 describe('network_utils', function() {
   describe('validateRangeRequestCapabilities', function() {
-    const defaultValues = {
-      allowRangeRequests: false,
-      suggestedLength: undefined,
-    };
-
     it('rejects range chunk sizes that are not larger than zero', function() {
       expect(function() {
         validateRangeRequestCapabilities({ rangeChunkSize: 0, });
@@ -38,14 +33,30 @@ describe('network_utils', function() {
       expect(validateRangeRequestCapabilities({
         disableRange: true,
         isHttp: true,
+        getResponseHeader: (headerName) => {
+          if (headerName === 'Content-Length') {
+            return 8;
+          }
+        },
         rangeChunkSize: 64,
-      })).toEqual(defaultValues);
+      })).toEqual({
+        allowRangeRequests: false,
+        suggestedLength: 8,
+      });
 
       expect(validateRangeRequestCapabilities({
         disableRange: false,
         isHttp: false,
+        getResponseHeader: (headerName) => {
+          if (headerName === 'Content-Length') {
+            return 8;
+          }
+        },
         rangeChunkSize: 64,
-      })).toEqual(defaultValues);
+      })).toEqual({
+        allowRangeRequests: false,
+        suggestedLength: 8,
+      });
     });
 
     it('rejects invalid Accept-Ranges header values', function() {
@@ -55,10 +66,15 @@ describe('network_utils', function() {
         getResponseHeader: (headerName) => {
           if (headerName === 'Accept-Ranges') {
             return 'none';
+          } else if (headerName === 'Content-Length') {
+            return 8;
           }
         },
         rangeChunkSize: 64,
-      })).toEqual(defaultValues);
+      })).toEqual({
+        allowRangeRequests: false,
+        suggestedLength: 8,
+      });
     });
 
     it('rejects invalid Content-Encoding header values', function() {
@@ -70,10 +86,15 @@ describe('network_utils', function() {
             return 'bytes';
           } else if (headerName === 'Content-Encoding') {
             return 'gzip';
+          } else if (headerName === 'Content-Length') {
+            return 8;
           }
         },
         rangeChunkSize: 64,
-      })).toEqual(defaultValues);
+      })).toEqual({
+        allowRangeRequests: false,
+        suggestedLength: 8,
+      });
     });
 
     it('rejects invalid Content-Length header values', function() {
@@ -90,7 +111,10 @@ describe('network_utils', function() {
           }
         },
         rangeChunkSize: 64,
-      })).toEqual(defaultValues);
+      })).toEqual({
+        allowRangeRequests: false,
+        suggestedLength: undefined,
+      });
     });
 
     it('rejects file sizes that are too small for range requests', function() {


### PR DESCRIPTION
Fixes #9103 by setting `returnValues.suggestedLength` to the value of `Content-Length` (provided it is an integer) even if returning early.
