### PR TITLE
Remove the unused `mainContainer` parameter from the `Toolbar` constructor

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -311,8 +311,8 @@ let PDFViewerApplication = {
     });
     this.findController = findController;
 
-    let container = appConfig.mainContainer;
-    let viewer = appConfig.viewerContainer;
+    const container = appConfig.mainContainer;
+    const viewer = appConfig.viewerContainer;
     this.pdfViewer = new PDFViewer({
       container,
       viewer,
@@ -361,8 +361,7 @@ let PDFViewerApplication = {
       cursorToolOnLoad: AppOptions.get('cursorToolOnLoad'),
     });
 
-    this.toolbar = new Toolbar(appConfig.toolbar, container, eventBus,
-                               this.l10n);
+    this.toolbar = new Toolbar(appConfig.toolbar, eventBus, this.l10n);
 
     this.secondaryToolbar =
       new SecondaryToolbar(appConfig.secondaryToolbar, container, eventBus);

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -49,13 +49,11 @@ const SCALE_SELECT_PADDING = 22;
 class Toolbar {
   /**
    * @param {ToolbarOptions} options
-   * @param {HTMLDivElement} mainContainer
    * @param {EventBus} eventBus
    * @param {IL10n} l10n - Localization service.
    */
-  constructor(options, mainContainer, eventBus, l10n = NullL10n) {
+  constructor(options, eventBus, l10n = NullL10n) {
     this.toolbar = options.container;
-    this.mainContainer = mainContainer;
     this.eventBus = eventBus;
     this.l10n = l10n;
     this.items = options;


### PR DESCRIPTION
Looking at the history of this code, this parameter has never been used.
I'm guessing that most likely the code in `web/toolbar.js` began life as a copy of `web/secondary_toolbar.js`, which would probably explain why that parameter exists.