### PR TITLE
Ensure that `Toolbar.setPageScale` always sets the `pageScaleValue` property to a valid value

### DIFF
--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -80,7 +80,7 @@ class Toolbar {
   }
 
   setPageScale(pageScaleValue, pageScale) {
-    this.pageScaleValue = pageScaleValue;
+    this.pageScaleValue = (pageScaleValue || pageScale).toString();
     this.pageScale = pageScale;
     this._updateUIState(false);
   }
@@ -171,9 +171,7 @@ class Toolbar {
       // Don't update the UI state until we localize the toolbar.
       return;
     }
-    let { pageNumber, pagesCount, items, } = this;
-    let scaleValue = (this.pageScaleValue || this.pageScale).toString();
-    let scale = this.pageScale;
+    const { pageNumber, pagesCount, pageScaleValue, pageScale, items, } = this;
 
     if (resetNumPages) {
       if (this.hasPageLabels) {
@@ -201,17 +199,17 @@ class Toolbar {
     items.previous.disabled = (pageNumber <= 1);
     items.next.disabled = (pageNumber >= pagesCount);
 
-    items.zoomOut.disabled = (scale <= MIN_SCALE);
-    items.zoomIn.disabled = (scale >= MAX_SCALE);
+    items.zoomOut.disabled = (pageScale <= MIN_SCALE);
+    items.zoomIn.disabled = (pageScale >= MAX_SCALE);
 
-    let customScale = Math.round(scale * 10000) / 100;
+    let customScale = Math.round(pageScale * 10000) / 100;
     this.l10n.get('page_scale_percent', { scale: customScale, },
                   '{{scale}}%').then((msg) => {
       let options = items.scaleSelect.options;
       let predefinedValueFound = false;
       for (let i = 0, ii = options.length; i < ii; i++) {
         let option = options[i];
-        if (option.value !== scaleValue) {
+        if (option.value !== pageScaleValue) {
           option.selected = false;
           continue;
         }


### PR DESCRIPTION
Rather than having every invocation of `Toolbar._updateUIState` compute a valid `pageScaleValue`, it seems easier to simply ensure that it happens when the value is actually updated.