### PR TITLE
Ensure that the `PDFDocumentLoadingTask` is rejected when "setting up fake worker" failed (issue 10135)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -263,7 +263,9 @@ let PDFViewerApplication = {
       AppOptions.set('locale', hashParams['locale']);
     }
 
-    return Promise.all(waitOn);
+    return Promise.all(waitOn).catch((reason) => {
+      console.error(`_parseHashParameters: "${reason.message}".`);
+    });
   },
 
   /**
@@ -1464,10 +1466,14 @@ function loadFakeWorker() {
         SystemJS.import('pdfjs/core/worker').then((worker) => {
           window.pdfjsWorker = worker;
           resolve();
-        });
+        }).catch(reject);
       } else if (typeof require === 'function') {
-        window.pdfjsWorker = require('../src/core/worker.js');
-        resolve();
+        try {
+          window.pdfjsWorker = require('../src/core/worker.js');
+          resolve();
+        } catch (ex) {
+          reject(ex);
+        }
       } else {
         reject(new Error(
           'SystemJS or CommonJS must be used to load fake worker.'));


### PR DESCRIPTION
This should, hopefully, cover all the possible ways[1] in which "fake workers" are loaded. Given the different code-paths, adding unit-tests might not be that simple. ***Edit:*** Also given that "fake workers" are only intended as a fallback anyway, and aren't really tested currently, the patch is hopefully OK even without tests.

Note that in order to make this work, the various `fakeWorkerFilesLoader` functions were converted to return `Promises`. ***Edit:*** Smaller diff with https://github.com/mozilla/pdf.js/pull/10139/files?w=1

Fixes #10135.

---
[1] Unfortunately there's lots of them, for various build targets and configurations.