### PR TITLE
Added masks & gradients support, and group hierarchy management in SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ PDF.js is community-driven and supported by Mozilla Labs. Our goal is to
 create a general-purpose, web standards-based platform for parsing and
 rendering PDFs.
 
+## Difference with mozilla repo
+
+This fork improves SVG rendering of PDF docs, and more specifically:
++ adds masks support
++ adds radial/axial gradients (shadingFill) support
++ manages groups hierarchy
+
 ## Contributing
 
 PDF.js is an open source project and always looking for more contributors. To

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ rendering PDFs.
 ## Difference with mozilla repo
 
 This fork improves SVG rendering of PDF docs, and more specifically:
-+ adds masks support
-+ adds radial/axial gradients (shadingFill) support
++ adds masks, pattern, blend mode, gradients (shading fill) support
 + manages groups hierarchy
 
 ## Contributing

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -830,7 +830,7 @@ class LineAnnotationElement extends AnnotationElement {
 
     // PDF coordinates are calculated from a bottom left origin, so transform
     // the line coordinates to a top left origin for the SVG element.
-    let line = this.svgFactory.createElement('svg:line');
+    let line = this.svgFactory.createElement('line');
     line.setAttribute('x1', data.rect[2] - data.lineCoordinates[0]);
     line.setAttribute('y1', data.rect[3] - data.lineCoordinates[1]);
     line.setAttribute('x2', data.rect[2] - data.lineCoordinates[2]);
@@ -878,7 +878,7 @@ class SquareAnnotationElement extends AnnotationElement {
     // the borders outside the square by default. This behavior cannot be
     // changed programmatically, so correct for that here.
     let borderWidth = data.borderStyle.width;
-    let square = this.svgFactory.createElement('svg:rect');
+    let square = this.svgFactory.createElement('rect');
     square.setAttribute('x', borderWidth / 2);
     square.setAttribute('y', borderWidth / 2);
     square.setAttribute('width', width - borderWidth);
@@ -927,7 +927,7 @@ class CircleAnnotationElement extends AnnotationElement {
     // the borders outside the circle by default. This behavior cannot be
     // changed programmatically, so correct for that here.
     let borderWidth = data.borderStyle.width;
-    let circle = this.svgFactory.createElement('svg:ellipse');
+    let circle = this.svgFactory.createElement('ellipse');
     circle.setAttribute('cx', width / 2);
     circle.setAttribute('cy', height / 2);
     circle.setAttribute('rx', (width / 2) - (borderWidth / 2));
@@ -954,7 +954,7 @@ class PolylineAnnotationElement extends AnnotationElement {
     super(parameters, isRenderable, /* ignoreBorder = */ true);
 
     this.containerClassName = 'polylineAnnotation';
-    this.svgElementName = 'svg:polyline';
+    this.svgElementName = 'polyline';
   }
 
   /**
@@ -1012,7 +1012,7 @@ class PolygonAnnotationElement extends PolylineAnnotationElement {
     super(parameters);
 
     this.containerClassName = 'polygonAnnotation';
-    this.svgElementName = 'svg:polygon';
+    this.svgElementName = 'polygon';
   }
 }
 

--- a/src/display/dom_utils.js
+++ b/src/display/dom_utils.js
@@ -118,12 +118,14 @@ class DOMSVGFactory {
   create(width, height) {
     assert(width > 0 && height > 0, 'Invalid SVG dimensions');
 
-    let svg = document.createElementNS(SVG_NS, 'svg:svg');
+    let svg = document.createElementNS(SVG_NS, 'svg');
     svg.setAttribute('version', '1.1');
     svg.setAttribute('width', width + 'px');
     svg.setAttribute('height', height + 'px');
     svg.setAttribute('preserveAspectRatio', 'none');
     svg.setAttribute('viewBox', '0 0 ' + width + ' ' + height);
+    svg.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+    svg.setAttribute('xmlns', 'http://www.w3.org/XML/1998/namespace');
 
     return svg;
   }

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -1084,10 +1084,12 @@ SVGGraphics = (function SVGGraphicsClosure() {
     },
     setFillColorN: function SVGGraphics_setFillColorN(args) {
       var current = this.current;
+      var color = args[1];
+      var paintType = args[7];
       if (args[0] == 'TilingPattern') {
         if (paintType == 2 && Array.isArray(color) && color.length == 3)
           current.fillColor = Util.makeCssRgb(color[0], color[1], color[2]);
-        current.fillPatternId = this.group.id;
+        current.fillPatternId = this.buildPattern(args);
       }
       else if (args[0] == 'RadialAxial')
         current.fillColor = 'url(#' + this.buildGradient(args, pm(Util.inverseTransform(this.transformMatrix))) + ')';
@@ -1097,6 +1099,8 @@ SVGGraphics = (function SVGGraphicsClosure() {
     },
     setStrokeColorN: function SVGGraphics_setStrokeColorN(args) {
       var current = this.current;
+      var color = args[1];
+      var paintType = args[7];
       if (args[0] == 'TilingPattern') {
         if (paintType == 2 && Array.isArray(color) && color.length == 3)
           current.strokeColor = Util.makeCssRgb(color[0], color[1], color[2]);

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -752,6 +752,7 @@ SVGGraphics = (function SVGGraphicsClosure() {
       current.tspan.setAttributeNS(null, 'y', pf(-current.y));
 
       current.txtElement = this.svgFactory.createElement('text');
+      current.txtElement.style.whiteSpace = 'pre';
       current.txtElement.appendChild(current.tspan);
     },
 
@@ -762,6 +763,7 @@ SVGGraphics = (function SVGGraphicsClosure() {
       this.current.lineMatrix = IDENTITY_MATRIX;
       this.current.tspan = this.svgFactory.createElement('tspan');
       this.current.txtElement = this.svgFactory.createElement('text');
+      this.current.txtElement.style.whiteSpace = 'pre';
       this.current.txtgrp = this.svgFactory.createElement('g');
       this.current.element = this.current.txtgrp;
       this.current.xcoords = [];

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -1493,6 +1493,7 @@ SVGGraphics = (function SVGGraphicsClosure() {
       // groups and applies the viewport transform.
       let rootGroup = this.svgFactory.createElement('g');
       rootGroup.setAttributeNS(null, 'transform', pm(viewport.transform));
+      rootGroup.style.isolation = 'isolate';
       svg.appendChild(rootGroup);
 
       // For the construction of the SVG image we are only interested in the

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -432,6 +432,7 @@ SVGGraphics = (function SVGGraphicsClosure() {
     this.forceDataSchema = !!forceDataSchema;
   }
 
+  var XML_NS = 'http://www.w3.org/XML/1998/namespace';
   var XLINK_NS = 'http://www.w3.org/1999/xlink';
   var LINE_CAP_STYLES = ['butt', 'round', 'square'];
   var LINE_JOIN_STYLES = ['miter', 'round', 'bevel'];
@@ -752,7 +753,7 @@ SVGGraphics = (function SVGGraphicsClosure() {
       current.tspan.setAttributeNS(null, 'y', pf(-current.y));
 
       current.txtElement = this.svgFactory.createElement('text');
-      current.txtElement.style.whiteSpace = 'pre';
+      current.txtElement.setAttributeNS(XML_NS, 'xml:space', 'preserve');
       current.txtElement.appendChild(current.tspan);
     },
 
@@ -763,7 +764,7 @@ SVGGraphics = (function SVGGraphicsClosure() {
       this.current.lineMatrix = IDENTITY_MATRIX;
       this.current.tspan = this.svgFactory.createElement('tspan');
       this.current.txtElement = this.svgFactory.createElement('text');
-      this.current.txtElement.style.whiteSpace = 'pre';
+      this.current.txtElement.setAttributeNS(XML_NS, 'xml:space', 'preserve');
       this.current.txtgrp = this.svgFactory.createElement('g');
       this.current.element = this.current.txtgrp;
       this.current.xcoords = [];

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -432,7 +432,6 @@ SVGGraphics = (function SVGGraphicsClosure() {
     this.forceDataSchema = !!forceDataSchema;
   }
 
-  var XML_NS = 'http://www.w3.org/XML/1998/namespace';
   var XLINK_NS = 'http://www.w3.org/1999/xlink';
   var LINE_CAP_STYLES = ['butt', 'round', 'square'];
   var LINE_JOIN_STYLES = ['miter', 'round', 'bevel'];
@@ -883,7 +882,6 @@ SVGGraphics = (function SVGGraphicsClosure() {
 
       current.txtElement.setAttributeNS(null, 'transform',
                                         pm(textMatrix) + ' scale(1, -1)');
-      current.txtElement.setAttributeNS(XML_NS, 'xml:space', 'preserve');
       current.txtElement.appendChild(current.tspan);
       current.txtgrp.appendChild(current.txtElement);
       this._clipnAppend(current.txtgrp);
@@ -1494,6 +1492,7 @@ SVGGraphics = (function SVGGraphicsClosure() {
       let rootGroup = this.svgFactory.createElement('g');
       rootGroup.setAttributeNS(null, 'transform', pm(viewport.transform));
       rootGroup.style.isolation = 'isolate';
+      rootGroup.style.whiteSpace = 'pre';
       svg.appendChild(rootGroup);
 
       // For the construction of the SVG image we are only interested in the

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -753,7 +753,6 @@ SVGGraphics = (function SVGGraphicsClosure() {
       current.tspan.setAttributeNS(null, 'y', pf(-current.y));
 
       current.txtElement = this.svgFactory.createElement('text');
-      current.txtElement.setAttributeNS(XML_NS, 'xml:space', 'preserve');
       current.txtElement.appendChild(current.tspan);
     },
 
@@ -764,7 +763,6 @@ SVGGraphics = (function SVGGraphicsClosure() {
       this.current.lineMatrix = IDENTITY_MATRIX;
       this.current.tspan = this.svgFactory.createElement('tspan');
       this.current.txtElement = this.svgFactory.createElement('text');
-      this.current.txtElement.setAttributeNS(XML_NS, 'xml:space', 'preserve');
       this.current.txtgrp = this.svgFactory.createElement('g');
       this.current.element = this.current.txtgrp;
       this.current.xcoords = [];
@@ -1489,6 +1487,11 @@ SVGGraphics = (function SVGGraphicsClosure() {
       let definitions = this.svgFactory.createElement('defs');
       svg.appendChild(definitions);
       this.defs = definitions;
+
+      // Create a style to preserve multiple white-space
+      var style = this.svgFactory.createElement('style');
+      style.textContent = "tspan, text {white-space:pre;}";
+      this.defs.appendChild(style);
 
       // Create the root group element, which acts a container for all other
       // groups and applies the viewport transform.

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -263,6 +263,7 @@ const OPS = {
   paintImageMaskXObjectRepeat: 89,
   paintSolidColorImageMask: 90,
   constructPath: 91,
+  group: 92,
 };
 
 const UNSUPPORTED_FEATURES = {


### PR DESCRIPTION
Hi all.
In order to have a better PDF to SVG conversion for one of our projects, I forked the repo and improved the SVG graphic rendering on some points (gradients support, path filling, masking, and groups hierarchy).
The tracemonkey file renders correctly (or at least better on the p.11 graph), as far as I checked.

The modifications do not respect the initial authors way of making groups, so a merge may not be acceptable, however, it could help or inspire people working on it.

I noticed that shadingFill ( = gradients) do not render exactly as on canvas (or desktop apps like evince) and couldn't figure out how to improve this, but the result looks pretty similar to what inkscape produces. See the example page below:

source:
[page1.pdf](https://github.com/mozilla/pdf.js/files/2460333/page1.pdf)

canvas rendering:
![pdf2canvas](https://user-images.githubusercontent.com/23312101/46669086-b4b0fe80-cbce-11e8-89fa-bf9c7875050e.png)

svg rendering:
![pdf2svg](https://user-images.githubusercontent.com/23312101/46669087-b4b0fe80-cbce-11e8-889a-c91d90c63a36.png)

inkscape conversion  (do not pay attention to fonts):
![pdf2svg_inkscape](https://user-images.githubusercontent.com/23312101/46669088-b4b0fe80-cbce-11e8-93bb-112b5f128e9d.png)


