### PR TITLE
Ensure that `getMainThreadWorkerMessageHandler` won't accidentally break `getDocument` (PR 10139 follow-up)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1358,10 +1358,12 @@ var PDFWorker = (function PDFWorkerClosure() {
   }
 
   function getMainThreadWorkerMessageHandler() {
-    if (typeof window === 'undefined') {
-      return null;
-    }
-    return (window.pdfjsWorker && window.pdfjsWorker.WorkerMessageHandler);
+    try {
+      if (typeof window !== 'undefined') {
+        return (window.pdfjsWorker && window.pdfjsWorker.WorkerMessageHandler);
+      }
+    } catch (ex) { }
+    return null;
   }
 
   let fakeWorkerFilesLoadedCapability;


### PR DESCRIPTION
*This should have been part of PR #10139.*

In the event that a user has attempted to manually load the worker file on the main-thread, but somehow failed to do that correctly, there's a possibility that `getMainThreadWorkerMessageHandler` could throw. Considering how/where that helper function is being called, an error could still prevent `PDFDocumentLoadingTask` from completing (regardless if it's being resolved/rejected).