### PR TITLE
Normalize BBox of form XObjects in SVG back-end

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -299,6 +299,11 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       var dict = xobj.dict;
       var matrix = dict.getArray('Matrix');
       var bbox = dict.getArray('BBox');
+      if (Array.isArray(bbox) && bbox.length === 4) {
+        bbox = Util.normalizeRect(bbox);
+      } else {
+        bbox = null;
+      }
       var group = dict.get('Group');
       if (group) {
         var groupOptions = {

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1750,7 +1750,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
 
       this.baseTransform = this.ctx.mozCurrentTransform;
 
-      if (Array.isArray(bbox) && bbox.length === 4) {
+      if (bbox) {
         var width = bbox[2] - bbox[0];
         var height = bbox[3] - bbox[1];
         this.ctx.rect(bbox[0], bbox[1], width, height);

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -1278,7 +1278,7 @@ SVGGraphics = (function SVGGraphicsClosure() {
                        matrix[3], matrix[4], matrix[5]);
       }
 
-      if (Array.isArray(bbox) && bbox.length === 4) {
+      if (bbox) {
         var width = bbox[2] - bbox[0];
         var height = bbox[3] - bbox[1];
 


### PR DESCRIPTION
In issue #10151, footnotes are missing because they are form XObjects that have unnormalized BBox entries, for example `/BBox [0.0 765.354 595.276 0.0]`. This makes the height of SVG `<rect>` element negative, so the clipping path fails and the form XObject becomes invisible.

This PR makes the footnote texts visible but some graphics are still missing because shadings haven't been implemented in the SVG back-end.