### PR TITLE
Export `CMapCompressionType` and `PermissionFlag` on the `pdfjsLib` object (issue 10148, PR 10033 follow-up)

### DIFF
--- a/src/pdf.js
+++ b/src/pdf.js
@@ -92,6 +92,8 @@ exports.InvalidPDFException = pdfjsSharedUtil.InvalidPDFException;
 exports.MissingPDFException = pdfjsSharedUtil.MissingPDFException;
 exports.SVGGraphics = pdfjsDisplaySVG.SVGGraphics;
 exports.NativeImageDecoding = pdfjsSharedUtil.NativeImageDecoding;
+exports.CMapCompressionType = pdfjsSharedUtil.CMapCompressionType;
+exports.PermissionFlag = pdfjsSharedUtil.PermissionFlag;
 exports.UnexpectedResponseException =
   pdfjsSharedUtil.UnexpectedResponseException;
 exports.OPS = pdfjsSharedUtil.OPS;


### PR DESCRIPTION
`CMapCompressionType` makes a lot of sense to export, for anyone attempting to implement a custom `CMapReaderFactory`; fixes #10148.

`PermissionFlag` likewise needs to be exported, since otherwise the result of the `getPermissions` API methods becomes difficult to interpret; follow-up to #10033.