### PR TITLE
Improve formatting when copying text from the text layer

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -105,41 +105,18 @@ var renderTextLayer = (function renderTextLayerClosure() {
 
     // line adjustments aren't supported for angled text
     if (angle === 0) {
-      /*
-      if this item:
-      * has approximately the same y-position as the last item
-      * is adjacent to the last item
-      it is likely on the same line of text, so it shouldn't be modified
-        */
       if (
         task._lastLineStart &&
-        Math.abs(task._lastLineBottom - (top + fontHeight)) <
-          (fontHeight * 0.4) &&
-        Math.abs(left - task._lastLineEnd) < 15
-        ) {
-
-        /* If the item:
-           * has approximately the same x-position as the start of the previous
-             line
-           * is immediately below the previous line
-           * is approximately the same font size
-          It is likely part of the same text block, which is being wrapped onto
-             a new line.
-          In this case, the new line should still be treated as an inline
-            element, but it might be necessary to insert a space between the
-            last word of the last line and the first word of this line.
-             */
-      } else if (
-        task._lastLineStart &&
-         Math.abs(task._lastLineBottom - top) < (fontHeight * 0.55) &&
-          /* outdent on 2nd line is OK (because the first line of a paragraph
-            is often indented), but indent is not (because it is almost always
-              an intentional line break)
-          */
-         ((task._lastLineStart - left) < (fontHeight * 2) &&
-          (task._lastLineStart - left) > (fontHeight * -0.5)) &&
+        top > task._lastLineBottom &&
+        Math.abs(task._lastLineBottom - top) < (fontHeight * 0.55) &&
+        /* outdent on 2nd line is OK (because the first line of a paragraph
+           is often indented), but indent is not (because it is almost always
+           an intentional line break)
+        */
+        ((task._lastLineStart - left) < (fontHeight * 2) &&
+        (task._lastLineStart - left) > (fontHeight * -0.5)) &&
         (fontHeight / task._lastFontSize > 0.9 &&
-          fontHeight / task._lastFontSize < 1.1)
+        fontHeight / task._lastFontSize < 1.1)
       ) {
         if (!isAllWhitespace(task._lastText[task._lastText.length - 1]) &&
             !isAllWhitespace(geom.str[0])) {

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -100,11 +100,8 @@ var renderTextLayer = (function renderTextLayerClosure() {
       top = tx[5] - (fontAscent * Math.cos(angle));
     }
 
-    /* determine where to insert line breaks in order to make copying text work
+    /* determine where to insert spaces in order to make copying text work
      as expected */
-
-    var topAdjustment = 0;
-    var hasPrecedingLineBreak = false;
 
     // line adjustments aren't supported for angled text
     if (angle === 0) {
@@ -151,13 +148,6 @@ var renderTextLayer = (function renderTextLayerClosure() {
           // shift the text left to account for the added space
           left -= fontHeight * 0.2;
         }
-      } else {
-        /*
-        the text is likely the start of a new text block. In this case, a <br>
-        will be inserted between the last block and this one.
-        */
-        topAdjustment += fontHeight;
-        hasPrecedingLineBreak = true;
       }
 
       if (Math.abs((top + fontHeight) - task._lastLineBottom) > 5) {
@@ -172,16 +162,13 @@ var renderTextLayer = (function renderTextLayerClosure() {
     task._lastFontSize = fontHeight;
 
     styleBuf[1] = left;
-    styleBuf[3] = top - topAdjustment;
+    styleBuf[3] = top;
     styleBuf[5] = fontHeight;
     styleBuf[7] = style.fontFamily;
     textDivProperties.style = styleBuf.join('');
     textDiv.setAttribute('style', textDivProperties.style);
 
     textDiv.textContent = geom.str;
-    if (hasPrecedingLineBreak) {
-      textDiv.insertBefore(document.createElement('br'), textDiv.childNodes[0]);
-    }
 
     // `fontName` is only used by the FontInspector, and we only use `dataset`
     // here to make the font name available in the debugger.

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -104,7 +104,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
      as expected */
 
     // line adjustments aren't supported for angled text
-    if (angle === 0) {
+    if (angle === 0 && geom.dir === 'ltr') {
       if (
         task._lastLineStart &&
         top > task._lastLineBottom &&

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -24,7 +24,7 @@
   line-height: 1.0;
 }
 
-.textLayer > div {
+.textLayer > span {
   color: transparent;
   position: absolute;
   white-space: pre;


### PR DESCRIPTION
Currently, the textLayer uses `div` elements for every text item, which results in extra newlines being inserted when the text is copied into another application. For example, copying a few paragraphs from the tracemonkey file results in this:

<img width="416" alt="screen shot 2018-10-21 at 11 46 45 am" src="https://user-images.githubusercontent.com/10314059/47269904-a1385880-d529-11e8-895f-f79ad4f387fe.png">

This PR modifies the text layer to use `span`'s instead, which removes the unnecessary line breaks. In order to preserve line breaks between paragraphs, it detects when a text item appears to be the start of a new paragraph (based on its position relative to the last line and changes in font size). If the item is the start of a new paragraph, a `br` is inserted at the beginning of the text item. Additionally, spaces will be inserted at the end of each line if there is not already a space there, so that copying multiple lines results in the correct word spacing.

While this doesn't always work on every PDF, it seems to work pretty well on most common cases, and I haven't found any files where the new behavior is substantially worse than the old formatting. Some examples:


| File | Old | New |
|----- | ----- | ---- |
|compressed.tracemonkey-pldi-09.pdf | <img width="416" alt="screen shot 2018-10-21 at 11 46 45 am" src="https://user-images.githubusercontent.com/10314059/47269680-06d71580-d527-11e8-9c4f-60cde48d2549.png"> | <img width="415" alt="screen shot 2018-10-21 at 11 55 06 am" src="https://user-images.githubusercontent.com/10314059/47269776-30dd0780-d528-11e8-997d-402d05685b85.png"> |
| http://www.pdf995.com/samples/pdf.pdf | <img width="414" alt="screen shot 2018-10-21 at 11 57 23 am" src="https://user-images.githubusercontent.com/10314059/47269837-c8daf100-d528-11e8-9ec9-ff3f52c30ee5.png"> | <img width="410" alt="screen shot 2018-10-21 at 11 58 37 am" src="https://user-images.githubusercontent.com/10314059/47269826-ad6fe600-d528-11e8-8421-8a1167279045.png"> |
| https://github.com/mozilla/pdf.js/blob/master/test/pdfs/TAMReview.pdf | <img width="506" alt="screen shot 2018-10-21 at 12 02 01 pm" src="https://user-images.githubusercontent.com/10314059/47269866-2707d400-d529-11e8-97b8-f3dc0c0d552f.png"> | <img width="502" alt="screen shot 2018-10-21 at 12 02 25 pm" src="https://user-images.githubusercontent.com/10314059/47269868-35ee8680-d529-11e8-94bf-3cc1d04d619a.png"> |
| https://eloquentjavascript.net/Eloquent_JavaScript.pdf | <img width="505" alt="screen shot 2018-10-21 at 12 04 10 pm" src="https://user-images.githubusercontent.com/10314059/47269882-764e0480-d529-11e8-8e62-96d918dcc89e.png"> | <img width="504" alt="screen shot 2018-10-21 at 12 04 53 pm" src="https://user-images.githubusercontent.com/10314059/47269897-8cf45b80-d529-11e8-8ac4-b25fdb47f579.png"> |
| http://www.music.mcgill.ca/~cmckay/papers/musictech/ISMIR_2006_Codaich.pdf | <img width="396" alt="screen shot 2018-10-21 at 12 06 09 pm" src="https://user-images.githubusercontent.com/10314059/47269923-d775d800-d529-11e8-83e2-3965316c0669.png"> | <img width="397" alt="screen shot 2018-10-21 at 12 06 57 pm" src="https://user-images.githubusercontent.com/10314059/47269926-dd6bb900-d529-11e8-8a63-05745d8cc80a.png"> |

This only works with horizontal text; angled or vertical text will always use `span`'s, and will not have any line breaks. I think this is OK, because it's rare to have large paragraphs of text at an angle, but I can try to add support for that if you think it's important.

I would expect this to be slower than the previous implementation because it does more work to detect paragraphs and because it inserts additional DOM elements, although based on the measurements I've taken, memory and CPU use seem to be about the same as they were before. The Firefox profiler isn't recording any information for `appendText` for some reason, but since it doesn't have a large performance impact in Chrome I would expect it to be OK in Firefox as well.