### PR TITLE
Change splice to pop in annotation tests

### DIFF
--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -975,7 +975,7 @@ describe('annotation', function() {
 
             // Remove the last invalid flag for the next iteration.
             if (!valid) {
-              flags -= invalidFieldFlags.splice(-1, 1);
+              flags -= invalidFieldFlags.pop();
             }
           });
         });


### PR DESCRIPTION
This line in the annotation tests subtracts an array from a number. This is because `splice(-1, 1)` returns a one-element array, while `pop()` returns only the element itself.