### PR TITLE
Add a helper method for `_getVisiblePages`, in `BaseViewer`, for the case where only a single page is displayed in the viewer

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -855,6 +855,30 @@ class BaseViewer {
       false : (this.container.scrollHeight > this.container.clientHeight));
   }
 
+  /**
+   * Helper method for `this._getVisiblePages`. Should only ever be used when
+   * the viewer can only display a single page at a time, for example in:
+   *  - `PDFSinglePageViewer`.
+   *  - `PDFViewer` with Presentation Mode active.
+   */
+  _getCurrentVisiblePage() {
+    if (!this.pagesCount) {
+      return { views: [], };
+    }
+    const pageView = this._pages[this._currentPageNumber - 1];
+    // NOTE: Compute the `x` and `y` properties of the current view,
+    // since `this._updateLocation` depends of them being available.
+    const element = pageView.div;
+
+    const view = {
+      id: pageView.id,
+      x: element.offsetLeft + element.clientLeft,
+      y: element.offsetTop + element.clientTop,
+      view: pageView,
+    };
+    return { first: view, last: view, views: [view], };
+  }
+
   _getVisiblePages() {
     throw new Error('Not implemented: _getVisiblePages');
   }

--- a/web/pdf_single_page_viewer.js
+++ b/web/pdf_single_page_viewer.js
@@ -108,21 +108,7 @@ class PDFSinglePageViewer extends BaseViewer {
   }
 
   _getVisiblePages() {
-    if (!this.pagesCount) {
-      return { views: [], };
-    }
-    let pageView = this._pages[this._currentPageNumber - 1];
-    // NOTE: Compute the `x` and `y` properties of the current view,
-    // since `this._updateLocation` depends of them being available.
-    let element = pageView.div;
-
-    let view = {
-      id: pageView.id,
-      x: element.offsetLeft + element.clientLeft,
-      y: element.offsetTop + element.clientTop,
-      view: pageView,
-    };
-    return { first: view, last: view, views: [view], };
+    return this._getCurrentVisiblePage();
   }
 
   update() {

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -40,11 +40,9 @@ class PDFViewer extends BaseViewer {
       return getVisibleElements(this.container, this._pages, true,
                                 this._scrollMode === ScrollMode.HORIZONTAL);
     }
-    // The algorithm in getVisibleElements doesn't work in all browsers and
+    // The algorithm in `getVisibleElements` doesn't work in all browsers and
     // configurations when presentation mode is active.
-    let currentPage = this._pages[this._currentPageNumber - 1];
-    let visible = [{ id: currentPage.id, view: currentPage, }];
-    return { first: currentPage, last: currentPage, views: visible, };
+    return this._getCurrentVisiblePage();
   }
 
   update() {


### PR DESCRIPTION
*This is another small piece of clean-up, split off from PR #10183.*

This is relevant for e.g. `PDFSinglePageViewer`, and `PDFViewer` with Presentation Mode active.
By moving this code to a helper method in `BaseViewer`, it's thus possible to reduce the amount of duplicate code that currently needed in `PDFViewer` and `PDFSinglePageViewer`.