### PR TITLE
Reduce the number of redundant `updatetextlayermatches` events dispatched when calculating matches in `PDFFindController`

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -335,7 +335,12 @@ class PDFFindController {
       this._calculateWordMatch(query, pageIndex, pageContent, entireWord);
     }
 
-    this._updatePage(pageIndex);
+    // In the event that the page *and* its textLayer have both finished
+    // rendering before the pageMatches were calculated, ensure that the
+    // matches will be highlighted and scrolled into view as necessary.
+    if (pageIndex === this._selected.pageIdx || this._state.highlightAll) {
+      this._updatePage(pageIndex);
+    }
     if (this._resumePageIdx === pageIndex) {
       this._resumePageIdx = null;
       this._nextPageMatch();


### PR DESCRIPTION
Currently `PDFFindController._calculateMatch` is (indirectly) dispatching an `updatetextlayermatches` event for *every* single page of the document. For short documents, such as the `tracemonkey` file, this probably doesn't matter too much, but for documents with a couple of thousand pages this seems unfortunate.

As far as I can tell, the only reason for dispatching `updatetextlayermatches` events once the pageMatches have been calculated, is to handle the edge-case where a page *and* its textLayer were both rendered before the matches were ready.
In practice this seem to be quite rare, but theoretically it could certainly happen. Hence the `_updatePage` call obviously cannot be removed, but it seems that we can at least limit the number of dispatched events to the cases where it's known to be necessary.

*Please note:* Hopefully I'm not overlooking some simple reason for needing to call `_updatePage` unconditionally here!