### PR TITLE
[Regression] Ensure that "Highlight All" is propagated to all pages for 'findagain' events where the findbar was previously closed (PR 10100 follow-up)

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -139,6 +139,16 @@ class PDFFindController {
           this._nextMatch();
           this._findTimeout = null;
         }, FIND_TIMEOUT);
+      } else if (cmd === 'findagain' && !this._dirtyMatch) {
+        const updateHighlightAll = (!this._highlightMatches &&
+                                    this._state.highlightAll);
+        this._nextMatch();
+
+        // When the findbar was previously closed, and `highlightAll` is set,
+        // ensure that the matches on all active pages are highlighted again.
+        if (updateHighlightAll) {
+          this._updateAllPages();
+        }
       } else {
         this._nextMatch();
       }


### PR DESCRIPTION
**STR:**
1. Open the default viewer, with the `tracemonkey` file.
2. Open the findbar, and search for "trace".
3. Enable the "Highlight All" option.
4. Close the findbar.
5. Re-open the findbar, and click on the "findNext" button.
6. Scroll down to the *second* page of the document.

**ER:**
Since "Highlight All" is active, all matches on the *second* page should be highlighted.

**AR:**
No matches are highlighted on the *second* page.

---
/cc @timvandermeij I should have caught this when working on PR #10100, but I obviously didn't; sorry about that!