### PR TITLE
Use `span` instead of `div` in the text layer

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -55,7 +55,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
 
   function appendText(task, geom, styles) {
     // Initialize all used properties to keep the caches monomorphic.
-    var textDiv = document.createElement('div');
+    var textDiv = document.createElement('span');
     var textDivProperties = {
       style: null,
       angle: 0,

--- a/test/text_layer_test.css
+++ b/test/text_layer_test.css
@@ -22,7 +22,7 @@
   right: 0;
   bottom: 0;
 }
-.textLayer > div {
+.textLayer > span {
   position: absolute;
   white-space: pre;
   -webkit-transform-origin: 0% 0%;

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -24,7 +24,7 @@
   line-height: 1.0;
 }
 
-.textLayer > div {
+.textLayer > span {
   color: transparent;
   position: absolute;
   white-space: pre;

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -77,12 +77,12 @@ select {
   display: none;
 }
 
-.pdfPresentationMode:fullscreen .textLayer > div {
+.pdfPresentationMode:fullscreen .textLayer > span {
   cursor: none;
 }
 
 .pdfPresentationMode.pdfPresentationModeControls > *,
-.pdfPresentationMode.pdfPresentationModeControls .textLayer > div {
+.pdfPresentationMode.pdfPresentationModeControls .textLayer > span {
   cursor: default;
 }
 
@@ -1518,19 +1518,19 @@ html[dir='rtl'] #documentPropertiesOverlay .row > * {
   mix-blend-mode: screen;
 }
 
-#viewer.textLayer-visible .textLayer > div {
+#viewer.textLayer-visible .textLayer > span {
   background-color: rgba(255, 255, 0, 0.1);
   color: black;
   border: solid 1px rgba(255, 0, 0, 0.5);
   box-sizing: border-box;
 }
 
-#viewer.textLayer-hover .textLayer > div:hover {
+#viewer.textLayer-hover .textLayer > span:hover {
   background-color: white;
   color: black;
 }
 
-#viewer.textLayer-shadow .textLayer > div {
+#viewer.textLayer-shadow .textLayer > span {
   background-color: rgba(255,255,255, .6);
   color: black;
 }


### PR DESCRIPTION
This improves copy/pasting text content since it reduces the amount of unnecessary newlines.