### PR TITLE
Attempt to clean-up/restore pending rendering operations on `RenderTask.cancel` (issue 10200)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2439,6 +2439,9 @@ var InternalRenderTask = (function InternalRenderTaskClosure() {
     cancel: function InternalRenderTask_cancel() {
       this.running = false;
       this.cancelled = true;
+      if (this.gfx) {
+        this.gfx.endDrawing();
+      }
       if (this._canvas) {
         canvasInRendering.delete(this._canvas);
       }


### PR DESCRIPTION
Please note that, given the lack of a runnable example, I'm not totally sure if this first of all is enough to *completely* address the issue as filed and second of all if we actually want this new behaviour.

Probably fixes #10200.

*Edit:* Given that every call to `PDFPageProxy.render` will create a new `InternalRenderTask`, closing the pending rendering operations on `cancel` in this way shouldn't be a problem.
Furthermore note that, on `cancel`, rendering isn't immediately aborted anyway, but will continue until [`CanvasGraphics.executeOperatorList`](https://github.com/mozilla/pdf.js/blob/f6bc93402ef35675ce61a278e3abe6b93d7fd393/src/display/canvas.js#L771) has finished processing the *current* chunk of the `operatorList`. Hence attempting to close any pending operations on `cancel` shouldn't be a problem, and would even be a good thing since it will ensure that any temporary canvases are [actually being removed](https://github.com/mozilla/pdf.js/blob/f6bc93402ef35675ce61a278e3abe6b93d7fd393/src/display/canvas.js#L859-L860) on `cancel`.