### PR TITLE
Change `canvasInRendering` to a `WeakSet` instead of a `WeakMap`

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2365,7 +2365,7 @@ var RenderTask = (function RenderTaskClosure() {
  * @ignore
  */
 var InternalRenderTask = (function InternalRenderTaskClosure() {
-  let canvasInRendering = new WeakMap();
+  let canvasInRendering = new WeakSet();
 
   function InternalRenderTask(callback, params, objs, commonObjs, operatorList,
                               pageNumber, canvasFactory, webGLContext,
@@ -2408,7 +2408,7 @@ var InternalRenderTask = (function InternalRenderTaskClosure() {
             'Use different canvas or ensure previous operations were ' +
             'cancelled or completed.');
         }
-        canvasInRendering.set(this._canvas, this);
+        canvasInRendering.add(this._canvas);
       }
 
       if (this._pdfBug && globalScope.StepperManager &&

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -187,6 +187,14 @@ const hasDOM = typeof window === 'object' && typeof document === 'object';
   globalScope.WeakMap = require('core-js/fn/weak-map');
 })();
 
+// Support: IE11
+(function checkWeakSet() {
+  if (globalScope.WeakSet) {
+    return;
+  }
+  globalScope.WeakSet = require('core-js/fn/weak-set');
+})();
+
 // Provides support for String.codePointAt in legacy browsers.
 // Support: IE11.
 (function checkStringCodePointAt() {


### PR DESCRIPTION
Note how nowhere in the code `canvasInRendering.get()` is ever called, and that this structure is really only used to store references to `<canvas>` DOM elements.
The reason for this being a `WeakMap` is probably because at the time we weren't using `core-js` polyfills yet, and since there already existed a manually implemented `WeakMap` polyfill it was probably simpler to use that.