### PR TITLE
When the search query changes, regardless of the search command, always re-calculate matches (bug 1030622)

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -113,7 +113,7 @@ class PDFFindController {
   executeCommand(cmd, state) {
     const pdfDocument = this._pdfDocument;
 
-    if (this._state === null || this._shouldDirtyMatch(cmd)) {
+    if (this._state === null || this._shouldDirtyMatch(cmd, state)) {
       this._dirtyMatch = true;
     }
     this._state = state;
@@ -198,7 +198,12 @@ class PDFFindController {
     return this._normalizedQuery;
   }
 
-  _shouldDirtyMatch(cmd) {
+  _shouldDirtyMatch(cmd, state) {
+    // When the search query changes, regardless of the actual search command
+    // used, always re-calculate matches to avoid errors (fixes bug 1030622).
+    if (state.query !== this._state.query) {
+      return true;
+    }
     switch (cmd) {
       case 'findagain':
         const pageNumber = this._selected.pageIdx + 1;

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -111,6 +111,9 @@ class PDFFindController {
   }
 
   executeCommand(cmd, state) {
+    if (!state) {
+      return;
+    }
     const pdfDocument = this._pdfDocument;
 
     if (this._state === null || this._shouldDirtyMatch(cmd, state)) {


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1030622

*Edit:* When following the STR in https://bugzilla.mozilla.org/show_bug.cgi?id=1030622#c4, the problem occurs at **step 6** since the automatic population of the findInput apparently doesn't trigger a find event.
Obviously this could, and maybe even should, be seen as a bug in Firefox itself, however it's easy enough to fix in PDF.js and the patch makes sense in general since `PDFFindController.executeCommand` becomes less sensitive to user error when called (e.g. in a custom viewer implementation).