### PR TITLE
Don't detect nw.js as node.js

### DIFF
--- a/src/shared/is_node.js
+++ b/src/shared/is_node.js
@@ -15,5 +15,9 @@
 /* globals module, process */
 
 module.exports = function isNodeJS() {
-  return typeof process === 'object' && process + '' === '[object process]';
+  // NW.js is a browser context, but copies some Node.js objects; see
+  // http://docs.nwjs.io/en/latest/For%20Users/Advanced/JavaScript%20Contexts%20in%20NW.js/#access-nodejs-and-nwjs-api-in-browser-context
+  return typeof process === 'object' &&
+         process + '' === '[object process]' &&
+         !process.versions['nw'];
 };


### PR DESCRIPTION
nw.js is chrome plus nodejs.
It will succeed everywhere chrome succeeds, but fail in many cases where nodejs succeeds (see issue 9071).
So it's safer to consider it as a browser context rather than a nodejs context.

Fixes #9071.