### PR TITLE
Stop scrolling the document when "Highlight All" is toggled in the findbar (issue 5561)

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -117,7 +117,9 @@ class PDFFindController {
       this._dirtyMatch = true;
     }
     this._state = state;
-    this._updateUIState(FindState.PENDING);
+    if (cmd !== 'findhighlightallchange') {
+      this._updateUIState(FindState.PENDING);
+    }
 
     this._firstPageCapability.promise.then(() => {
       // If the document was closed before searching began, or if the search
@@ -129,6 +131,7 @@ class PDFFindController {
       this._extractText();
 
       const findbarClosed = !this._highlightMatches;
+      const pendingTimeout = !!this._findTimeout;
 
       if (this._findTimeout) {
         clearTimeout(this._findTimeout);
@@ -153,6 +156,15 @@ class PDFFindController {
         if (findbarClosed && this._state.highlightAll) {
           this._updateAllPages();
         }
+      } else if (cmd === 'findhighlightallchange') {
+        // If there was a pending search operation, synchronously trigger a new
+        // search *first* to ensure that the correct matches are highlighted.
+        if (pendingTimeout) {
+          this._nextMatch();
+        } else {
+          this._highlightMatches = true;
+        }
+        this._updateAllPages(); // Update the highlighting on all active pages.
       } else {
         this._nextMatch();
       }
@@ -216,6 +228,8 @@ class PDFFindController {
             !linkService.isPageVisible(pageNumber)) {
           break;
         }
+        return false;
+      case 'findhighlightallchange':
         return false;
     }
     return true;


### PR DESCRIPTION
This is consistent with the general, e.g. HTML, search functionality of the Firefox browser.

Fixes #5561; and depends on PR #10220 landing *first* to suppress all scrolling when "Highlight All" changes.