### PR TITLE
Direct all logging to `console.warn` instead of `console.log`

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -296,20 +296,20 @@ function getVerbosityLevel() {
 // end users.
 function info(msg) {
   if (verbosity >= VerbosityLevel.INFOS) {
-    console.log('Info: ' + msg);
+    console.warn('Info: ' + msg);
   }
 }
 
 // Non-fatal warnings.
 function warn(msg) {
   if (verbosity >= VerbosityLevel.WARNINGS) {
-    console.log('Warning: ' + msg);
+    console.warn('Warning: ' + msg);
   }
 }
 
 // Deprecated API function -- display regardless of the `verbosity` setting.
 function deprecated(details) {
-  console.log('Deprecated API usage: ' + details);
+  console.warn('Deprecated API usage: ' + details);
 }
 
 function unreachable(msg) {


### PR DESCRIPTION
This avoids polluting `stdout`, important for node.js programs that are intended to produce machine-readable output.

(Ticket/PR suggested in IRC.)