### PR TITLE
Update `BaseViewer.scrollPageIntoView` to always validate the `pageNumber` parameter

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -1086,7 +1086,7 @@ class BaseViewer {
     if (this._currentScaleValue && isNaN(this._currentScaleValue)) {
       this._setScale(this._currentScaleValue, true);
     }
-    this.scrollPageIntoView({ pageNumber, });
+    this._setCurrentPageNumber(pageNumber, /* resetCurrentPageView = */ true);
     this.update();
   }
 
@@ -1146,7 +1146,7 @@ class BaseViewer {
     if (!pageNumber) {
       return;
     }
-    this.scrollPageIntoView({ pageNumber, });
+    this._setCurrentPageNumber(pageNumber, /* resetCurrentPageView = */ true);
     this.update();
   }
 }


### PR DESCRIPTION
Note that when e.g. presentation mode is active, we fail[1] to ensure that the `pageNumber` parameter is actually an integer before calling `_setCurrentPageNumber` (that method expects the argument be an integer).
Also changes the method signature, of `scrollPageIntoView`, to use object destructuring instead.

---
[1] Most likely, this is actually *my* oversight :-)