### PR TITLE
Convert the remaining code in `src/display/api.js` to use ES6 classes

### DIFF
--- a/examples/acroforms/acroforms.js
+++ b/examples/acroforms/acroforms.js
@@ -24,7 +24,8 @@ var DEFAULT_SCALE = 1.0;
 var container = document.getElementById('pageContainer');
 
 // Fetch the PDF document from the URL using promises.
-pdfjsLib.getDocument(DEFAULT_URL).then(function (doc) {
+var loadingTask = pdfjsLib.getDocument(DEFAULT_URL);
+loadingTask.promise.then(function(doc) {
   // Use a promise to fetch and render the next page.
   var promise = Promise.resolve();
 

--- a/examples/components/pageviewer.js
+++ b/examples/components/pageviewer.js
@@ -37,11 +37,12 @@ var SCALE = 1.0;
 var container = document.getElementById('pageContainer');
 
 // Loading document.
-pdfjsLib.getDocument({
+var loadingTask = pdfjsLib.getDocument({
   url: DEFAULT_URL,
   cMapUrl: CMAP_URL,
   cMapPacked: CMAP_PACKED,
-}).then(function(pdfDocument) {
+});
+loadingTask.promise.then(function(pdfDocument) {
   // Document loaded, retrieving the page.
   return pdfDocument.getPage(PAGE_TO_VIEW).then(function (pdfPage) {
     // Creating the page view with default parameters.

--- a/examples/components/simpleviewer.js
+++ b/examples/components/simpleviewer.js
@@ -60,11 +60,12 @@ document.addEventListener('pagesinit', function () {
 });
 
 // Loading document.
-pdfjsLib.getDocument({
+var loadingTask = pdfjsLib.getDocument({
   url: DEFAULT_URL,
   cMapUrl: CMAP_URL,
   cMapPacked: CMAP_PACKED,
-}).then(function(pdfDocument) {
+});
+loadingTask.promise.then(function(pdfDocument) {
   // Document loaded, specifying document for the viewer and
   // the (optional) linkService.
   pdfViewer.setDocument(pdfDocument);

--- a/examples/components/singlepageviewer.js
+++ b/examples/components/singlepageviewer.js
@@ -60,11 +60,12 @@ document.addEventListener('pagesinit', function () {
 });
 
 // Loading document.
-pdfjsLib.getDocument({
+var loadingTask = pdfjsLib.getDocument({
   url: DEFAULT_URL,
   cMapUrl: CMAP_URL,
   cMapPacked: CMAP_PACKED,
-}).then(function(pdfDocument) {
+});
+loadingTask.promise.then(function(pdfDocument) {
   // Document loaded, specifying document for the viewer and
   // the (optional) linkService.
   pdfSinglePageViewer.setDocument(pdfDocument);

--- a/examples/learning/helloworld.html
+++ b/examples/learning/helloworld.html
@@ -28,11 +28,12 @@
   //
   // Asynchronous download PDF
   //
-  pdfjsLib.getDocument(url).then(function getPdfHelloWorld(pdf) {
+  var loadingTask = pdfjsLib.getDocument(url);
+  loadingTask.promise.then(function(pdf) {
     //
     // Fetch the first page
     //
-    pdf.getPage(1).then(function getPageHelloWorld(page) {
+    pdf.getPage(1).then(function(page) {
       var scale = 1.5;
       var viewport = page.getViewport(scale);
 

--- a/examples/learning/helloworld64.html
+++ b/examples/learning/helloworld64.html
@@ -39,9 +39,10 @@
 
   // Opening PDF by passing its binary data as a string. It is still preferable
   // to use Uint8Array, but string or array-like structure will work too.
-  pdfjsLib.getDocument({data: pdfData}).then(function getPdfHelloWorld(pdf) {
+  var loadingTask = pdfjsLib.getDocument({data: pdfData});
+  loadingTask.promise.then(function(pdf) {
     // Fetch the first page.
-    pdf.getPage(1).then(function getPageHelloWorld(page) {
+    pdf.getPage(1).then(function(page) {
       var scale = 1.5;
       var viewport = page.getViewport(scale);
 

--- a/examples/learning/prevnext.html
+++ b/examples/learning/prevnext.html
@@ -117,7 +117,8 @@
   /**
    * Asynchronously downloads PDF.
    */
-  pdfjsLib.getDocument(url).then(function (pdfDoc_) {
+  var loadingTask = pdfjsLib.getDocument(url);
+  loadingTask.promise.then(function(pdfDoc_) {
     pdfDoc = pdfDoc_;
     document.getElementById('page_count').textContent = pdfDoc.numPages;
 

--- a/examples/node/getinfo.js
+++ b/examples/node/getinfo.js
@@ -17,7 +17,8 @@ var pdfPath = process.argv[2] || '../../web/compressed.tracemonkey-pldi-09.pdf';
 
 // Will be using promises to load document, pages and misc data instead of
 // callback.
-pdfjsLib.getDocument(pdfPath).then(function (doc) {
+var loadingTask = pdfjsLib.getDocument(pdfPath);
+loadingTask.promise.then(function(doc) {
   var numPages = doc.numPages;
   console.log('# Document Loaded');
   console.log('Number of Pages: ' + numPages);

--- a/examples/node/pdf2png/pdf2png.js
+++ b/examples/node/pdf2png/pdf2png.js
@@ -73,7 +73,8 @@ loadingTask.promise.then(function(pdfDocument) {
       canvasFactory: canvasFactory
     };
 
-    page.render(renderContext).then(function () {
+    var renderTask = page.render(renderContext);
+    renderTask.promise.then(function() {
       // Convert the canvas to an image buffer.
       var image = canvasAndContext.canvas.toBuffer();
       fs.writeFile('output.png', image, function (error) {

--- a/examples/node/pdf2png/pdf2png.js
+++ b/examples/node/pdf2png/pdf2png.js
@@ -57,7 +57,8 @@ var pdfURL = '../../../web/compressed.tracemonkey-pldi-09.pdf';
 var rawData = new Uint8Array(fs.readFileSync(pdfURL));
 
 // Load the PDF file.
-pdfjsLib.getDocument(rawData).then(function (pdfDocument) {
+var loadingTask = pdfjsLib.getDocument(rawData);
+loadingTask.promise.then(function(pdfDocument) {
   console.log('# PDF document loaded.');
 
   // Get the first page.

--- a/examples/node/pdf2svg.js
+++ b/examples/node/pdf2svg.js
@@ -84,11 +84,12 @@ function writeSvgToFile(svgElement, filePath) {
 
 // Will be using promises to load document, pages and misc data instead of
 // callback.
-pdfjsLib.getDocument({
+var loadingTask = pdfjsLib.getDocument({
   data: data,
   // Try to export JPEG images directly if they don't need any further processing.
   nativeImageDecoderSupport: pdfjsLib.NativeImageDecoding.DISPLAY
-}).then(function (doc) {
+});
+loadingTask.promise.then(function(doc) {
   var numPages = doc.numPages;
   console.log('# Document Loaded');
   console.log('Number of Pages: ' + numPages);

--- a/examples/svgviewer/viewer.js
+++ b/examples/svgviewer/viewer.js
@@ -51,11 +51,12 @@ document.addEventListener('pagesinit', function () {
 });
 
 // Loading document.
-pdfjsLib.getDocument({
+var loadingTask = pdfjsLib.getDocument({
   url: DEFAULT_URL,
   cMapUrl: CMAP_URL,
   cMapPacked: CMAP_PACKED,
-}).then(function(pdfDocument) {
+});
+loadingTask.promise.then(function(pdfDocument) {
   // Document loaded, specifying document for the viewer and
   // the (optional) linkService.
   pdfViewer.setDocument(pdfDocument);

--- a/examples/text-only/pdf2svg.js
+++ b/examples/text-only/pdf2svg.js
@@ -49,7 +49,8 @@ function buildSVG(viewport, textContent) {
 
 function pageLoaded() {
   // Loading document and page text content
-  pdfjsLib.getDocument({url: PDF_PATH}).then(function (pdfDocument) {
+  var loadingTask = pdfjsLib.getDocument({url: PDF_PATH});
+  loadingTask.promise.then(function(pdfDocument) {
     pdfDocument.getPage(PAGE_NUMBER).then(function (page) {
       var viewport = page.getViewport(PAGE_SCALE);
       page.getTextContent().then(function (textContent) {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2280,11 +2280,10 @@ class PDFObjects {
 
 /**
  * Allows controlling of the rendering tasks.
- * @class
  * @alias RenderTask
  */
-var RenderTask = (function RenderTaskClosure() {
-  function RenderTask(internalRenderTask) {
+class RenderTask {
+  constructor(internalRenderTask) {
     this._internalRenderTask = internalRenderTask;
 
     /**
@@ -2296,39 +2295,36 @@ var RenderTask = (function RenderTaskClosure() {
     this.onContinue = null;
   }
 
-  RenderTask.prototype = /** @lends RenderTask.prototype */ {
-    /**
-     * Promise for rendering task completion.
-     * @return {Promise}
-     */
-    get promise() {
-      return this._internalRenderTask.capability.promise;
-    },
+  /**
+   * Promise for rendering task completion.
+   * @return {Promise}
+   */
+  get promise() {
+    return this._internalRenderTask.capability.promise;
+  }
 
-    /**
-     * Cancels the rendering task. If the task is currently rendering it will
-     * not be cancelled until graphics pauses with a timeout. The promise that
-     * this object extends will be rejected when cancelled.
-     */
-    cancel: function RenderTask_cancel() {
-      this._internalRenderTask.cancel();
-    },
+  /**
+   * Cancels the rendering task. If the task is currently rendering it will
+   * not be cancelled until graphics pauses with a timeout. The promise that
+   * this object extends will be rejected when cancelled.
+   */
+  cancel() {
+    this._internalRenderTask.cancel();
+  }
 
-    /**
-     * Registers callbacks to indicate the rendering task completion.
-     *
-     * @param {function} onFulfilled The callback for the rendering completion.
-     * @param {function} onRejected The callback for the rendering failure.
-     * @return {Promise} A promise that is resolved after the onFulfilled or
-     *                   onRejected callback.
-     */
-    then: function RenderTask_then(onFulfilled, onRejected) {
-      return this.promise.then.apply(this.promise, arguments);
-    },
-  };
-
-  return RenderTask;
-})();
+  /**
+   * Registers callbacks to indicate the rendering task completion.
+   *
+   * @param {function} onFulfilled The callback for the rendering completion.
+   * @param {function} onRejected The callback for the rendering failure.
+   * @return {Promise} A promise that is resolved after the onFulfilled or
+   *                   onRejected callback.
+   */
+  then(onFulfilled, onRejected) {
+    deprecated('RenderTask.then method, use the `promise` getter instead.');
+    return this.promise.then.apply(this.promise, arguments);
+  }
+}
 
 /**
  * For internal use only.

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 /* globals requirejs, __non_webpack_require__ */
+/* eslint no-var: error */
 
 import {
   assert, createPromiseCapability, deprecated, getVerbosityLevel, info,
@@ -106,7 +107,7 @@ if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('GENERIC')) {
  */
 
 /** @type IPDFStreamFactory */
-var createPDFNetworkStream;
+let createPDFNetworkStream;
 
 /**
  * Sets the function that instantiates a IPDFStream as an alternative PDF data
@@ -221,9 +222,9 @@ function setPDFNetworkStreamFactory(pdfNetworkStreamFactory) {
  * @return {PDFDocumentLoadingTask}
  */
 function getDocument(src) {
-  var task = new PDFDocumentLoadingTask();
+  const task = new PDFDocumentLoadingTask();
 
-  var source;
+  let source;
   if (typeof src === 'string') {
     source = { url: src, };
   } else if (isArrayBuffer(src)) {
@@ -239,15 +240,12 @@ function getDocument(src) {
       throw new Error(
         'Invalid parameter object: need either .data, .range or .url');
     }
-
     source = src;
   }
+  const params = Object.create(null);
+  let rangeTransport = null, worker = null;
 
-  let params = Object.create(null);
-  var rangeTransport = null;
-  let worker = null;
-
-  for (var key in source) {
+  for (const key in source) {
     if (key === 'url' && typeof window !== 'undefined') {
       // The full path is required in the 'url' field.
       params[key] = new URL(source[key], window.location).href;
@@ -260,7 +258,7 @@ function getDocument(src) {
       continue;
     } else if (key === 'data' && !(source[key] instanceof Uint8Array)) {
       // Converting string or array-like data to Uint8Array.
-      var pdfBytes = source[key];
+      const pdfBytes = source[key];
       if (typeof pdfBytes === 'string') {
         params[key] = stringToBytes(pdfBytes);
       } else if (typeof pdfBytes === 'object' && pdfBytes !== null &&
@@ -329,13 +327,13 @@ function getDocument(src) {
                                  new PDFWorker(workerParams);
     task._worker = worker;
   }
-  var docId = task.docId;
-  worker.promise.then(function () {
+  const docId = task.docId;
+  worker.promise.then(function() {
     if (task.destroyed) {
       throw new Error('Loading aborted');
     }
     return _fetchDocument(worker, params, rangeTransport, docId).then(
-        function (workerId) {
+        function(workerId) {
       if (task.destroyed) {
         throw new Error('Loading aborted');
       }
@@ -360,10 +358,10 @@ function getDocument(src) {
         });
       }
 
-      var messageHandler = new MessageHandler(docId, workerId, worker.port);
+      const messageHandler = new MessageHandler(docId, workerId, worker.port);
       messageHandler.postMessageTransfers = worker.postMessageTransfers;
-      var transport = new WorkerTransport(messageHandler, task, networkStream,
-                                          params);
+      const transport = new WorkerTransport(messageHandler, task, networkStream,
+                                            params);
       task._transport = transport;
       messageHandler.send('Ready', null);
     });
@@ -411,7 +409,7 @@ function _fetchDocument(worker, source, pdfDataRangeTransport, docId) {
     nativeImageDecoderSupport: source.nativeImageDecoderSupport,
     ignoreErrors: source.ignoreErrors,
     isEvalSupported: source.isEvalSupported,
-  }).then(function (workerId) {
+  }).then(function(workerId) {
     if (worker.destroyed) {
       throw new Error('Worker was destroyed');
     }
@@ -1257,11 +1255,10 @@ class LoopbackPort {
       if (cloned.has(value)) { // already cloned the object
         return cloned.get(value);
       }
-      var result;
-      var buffer;
+      let buffer, result;
       if ((buffer = value.buffer) && isArrayBuffer(buffer)) {
         // We found object with ArrayBuffer (typed array).
-        var transferable = transfers && transfers.includes(buffer);
+        const transferable = transfers && transfers.includes(buffer);
         if (value === buffer) {
           // Special case when we are faking typed arrays in compatibility.js.
           result = value;
@@ -1278,8 +1275,8 @@ class LoopbackPort {
       cloned.set(value, result); // adding to cache now for cyclic references
       // Cloning all value and object properties, however ignoring properties
       // defined via getter.
-      for (var i in value) {
-        var desc, p = value;
+      for (const i in value) {
+        let desc, p = value;
         while (!(desc = Object.getOwnPropertyDescriptor(p, i))) {
           p = Object.getPrototypeOf(p);
         }
@@ -1293,16 +1290,16 @@ class LoopbackPort {
     }
 
     if (!this._defer) {
-      this._listeners.forEach(function (listener) {
+      this._listeners.forEach(function(listener) {
         listener.call(this, { data: obj, });
       }, this);
       return;
     }
 
-    var cloned = new WeakMap();
-    var e = { data: cloneValue(obj), };
+    const cloned = new WeakMap();
+    const e = { data: cloneValue(obj), };
     this._deferred.then(() => {
-      this._listeners.forEach(function (listener) {
+      this._listeners.forEach(function(listener) {
         listener.call(this, e);
       }, this);
     });
@@ -1313,7 +1310,7 @@ class LoopbackPort {
   }
 
   removeEventListener(name, listener) {
-    var i = this._listeners.indexOf(listener);
+    const i = this._listeners.indexOf(listener);
     this._listeners.splice(i, 1);
   }
 
@@ -2036,9 +2033,9 @@ class WorkerTransport {
           new Error('Only 3 components or 1 component can be returned'));
       }
 
-      return new Promise(function (resolve, reject) {
+      return new Promise(function(resolve, reject) {
         const img = new Image();
-        img.onload = function () {
+        img.onload = function() {
           const width = img.width;
           const height = img.height;
           const size = width * height;
@@ -2064,7 +2061,7 @@ class WorkerTransport {
           }
           resolve({ data: buf, width, height, });
         };
-        img.onerror = function () {
+        img.onerror = function() {
           reject(new Error('JpegDecode failed to load image'));
         };
         img.src = imageUrl;
@@ -2485,11 +2482,10 @@ const InternalRenderTask = (function InternalRenderTaskClosure() {
   return InternalRenderTask;
 })();
 
-var version, build;
-if (typeof PDFJSDev !== 'undefined') {
-  version = PDFJSDev.eval('BUNDLE_VERSION');
-  build = PDFJSDev.eval('BUNDLE_BUILD');
-}
+const version = (typeof PDFJSDev !== 'undefined' ?
+                 PDFJSDev.eval('BUNDLE_VERSION') : null);
+const build = (typeof PDFJSDev !== 'undefined' ?
+               PDFJSDev.eval('BUNDLE_BUILD') : null);
 
 export {
   getDocument,

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -15,10 +15,11 @@
 /* globals requirejs, __non_webpack_require__ */
 
 import {
-  assert, createPromiseCapability, getVerbosityLevel, info, InvalidPDFException,
-  isArrayBuffer, isSameOrigin, MissingPDFException, NativeImageDecoding,
-  PasswordException, setVerbosityLevel, shadow, stringToBytes,
-  UnexpectedResponseException, UnknownErrorException, unreachable, URL, warn
+  assert, createPromiseCapability, deprecated, getVerbosityLevel, info,
+  InvalidPDFException, isArrayBuffer, isSameOrigin, MissingPDFException,
+  NativeImageDecoding, PasswordException, setVerbosityLevel, shadow,
+  stringToBytes, UnexpectedResponseException, UnknownErrorException,
+  unreachable, URL, warn
 } from '../shared/util';
 import {
   DOMCanvasFactory, DOMCMapReaderFactory, DummyStatTimer, loadScript,
@@ -427,56 +428,55 @@ function _fetchDocument(worker, source, pdfDataRangeTransport, docId) {
  * @class
  * @alias PDFDocumentLoadingTask
  */
-var PDFDocumentLoadingTask = (function PDFDocumentLoadingTaskClosure() {
-  var nextDocumentId = 0;
+const PDFDocumentLoadingTask = (function PDFDocumentLoadingTaskClosure() {
+  let nextDocumentId = 0;
 
   /** @constructs PDFDocumentLoadingTask */
-  function PDFDocumentLoadingTask() {
-    this._capability = createPromiseCapability();
-    this._transport = null;
-    this._worker = null;
+  class PDFDocumentLoadingTask {
+    constructor() {
+      this._capability = createPromiseCapability();
+      this._transport = null;
+      this._worker = null;
 
-    /**
-     * Unique document loading task id -- used in MessageHandlers.
-     * @type {string}
-     */
-    this.docId = 'd' + (nextDocumentId++);
+      /**
+       * Unique document loading task id -- used in MessageHandlers.
+       * @type {string}
+       */
+      this.docId = 'd' + (nextDocumentId++);
 
-    /**
-     * Shows if loading task is destroyed.
-     * @type {boolean}
-     */
-    this.destroyed = false;
+      /**
+       * Shows if loading task is destroyed.
+       * @type {boolean}
+       */
+      this.destroyed = false;
 
-    /**
-     * Callback to request a password if wrong or no password was provided.
-     * The callback receives two parameters: function that needs to be called
-     * with new password and reason (see {PasswordResponses}).
-     */
-    this.onPassword = null;
+      /**
+       * Callback to request a password if wrong or no password was provided.
+       * The callback receives two parameters: function that needs to be called
+       * with new password and reason (see {PasswordResponses}).
+       */
+      this.onPassword = null;
 
-    /**
-     * Callback to be able to monitor the loading progress of the PDF file
-     * (necessary to implement e.g. a loading bar). The callback receives
-     * an {Object} with the properties: {number} loaded and {number} total.
-     */
-    this.onProgress = null;
+      /**
+       * Callback to be able to monitor the loading progress of the PDF file
+       * (necessary to implement e.g. a loading bar). The callback receives
+       * an {Object} with the properties: {number} loaded and {number} total.
+       */
+      this.onProgress = null;
 
-    /**
-     * Callback to when unsupported feature is used. The callback receives
-     * an {UNSUPPORTED_FEATURES} argument.
-     */
-    this.onUnsupportedFeature = null;
-  }
+      /**
+       * Callback to when unsupported feature is used. The callback receives
+       * an {UNSUPPORTED_FEATURES} argument.
+       */
+      this.onUnsupportedFeature = null;
+    }
 
-  PDFDocumentLoadingTask.prototype =
-      /** @lends PDFDocumentLoadingTask.prototype */ {
     /**
      * @return {Promise}
      */
     get promise() {
       return this._capability.promise;
-    },
+    }
 
     /**
      * Aborts all network requests and destroys worker.
@@ -486,7 +486,7 @@ var PDFDocumentLoadingTask = (function PDFDocumentLoadingTaskClosure() {
     destroy() {
       this.destroyed = true;
 
-      var transportDestroyed = !this._transport ? Promise.resolve() :
+      const transportDestroyed = !this._transport ? Promise.resolve() :
         this._transport.destroy();
       return transportDestroyed.then(() => {
         this._transport = null;
@@ -495,7 +495,7 @@ var PDFDocumentLoadingTask = (function PDFDocumentLoadingTaskClosure() {
           this._worker = null;
         }
       });
-    },
+    }
 
     /**
      * Registers callbacks to indicate the document loading completion.
@@ -505,11 +505,12 @@ var PDFDocumentLoadingTask = (function PDFDocumentLoadingTaskClosure() {
      * @return {Promise} A promise that is resolved after the onFulfilled or
      *                   onRejected callback.
      */
-    then: function PDFDocumentLoadingTask_then(onFulfilled, onRejected) {
+    then(onFulfilled, onRejected) {
+      deprecated('PDFDocumentLoadingTask.then method, ' +
+                 'use the `promise` getter instead.');
       return this.promise.then.apply(this.promise, arguments);
-    },
-  };
-
+    }
+  }
   return PDFDocumentLoadingTask;
 })();
 

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -726,7 +726,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
 
   CanvasGraphics.prototype = {
 
-    beginDrawing({ transform, viewport, transparency,
+    beginDrawing({ transform, viewport, transparency = false,
                    background = null, }) {
       // For pdfs that use blend modes we have to clear the canvas else certain
       // blend modes can look wrong since we'd be blending with a white

--- a/test/driver.js
+++ b/test/driver.js
@@ -358,7 +358,7 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
 
         let absoluteUrl = new URL(task.file, window.location).href;
         try {
-          pdfjsLib.getDocument({
+          const loadingTask = pdfjsLib.getDocument({
             url: absoluteUrl,
             password: task.password,
             nativeImageDecoderSupport: task.nativeImageDecoderSupport,
@@ -367,7 +367,8 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
             disableRange: task.disableRange,
             disableAutoFetch: !task.enableAutoFetch,
             pdfBug: true,
-          }).then((doc) => {
+          });
+          loadingTask.promise.then((doc) => {
             task.pdfDoc = doc;
             this._nextPage(task, failure);
           }, (err) => {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1332,26 +1332,23 @@ describe('api', function() {
 
     // Render the first page of the given PDF file.
     // Fulfills the promise with the base64-encoded version of the PDF.
-    function renderPDF(filename) {
-      var loadingTask = getDocument(filename);
+    async function renderPDF(filename) {
+      const loadingTask = getDocument(filename);
       loadingTasks.push(loadingTask);
-      return loadingTask.promise
-        .then(function(pdf) {
-          pdfDocuments.push(pdf);
-          return pdf.getPage(1);
-        }).then(function(page) {
-          var viewport = page.getViewport(1.2);
-          var canvasAndCtx = CanvasFactory.create(viewport.width,
-                                                  viewport.height);
-          return page.render({
-            canvasContext: canvasAndCtx.context,
-            viewport,
-          }).then(function() {
-            var data = canvasAndCtx.canvas.toDataURL();
-            CanvasFactory.destroy(canvasAndCtx);
-            return data;
-          });
-        });
+      const pdf = await loadingTask.promise;
+      pdfDocuments.push(pdf);
+      const page = await pdf.getPage(1);
+      const viewport = page.getViewport(1.2);
+      const canvasAndCtx = CanvasFactory.create(viewport.width,
+                                                viewport.height);
+      const renderTask = page.render({
+        canvasContext: canvasAndCtx.context,
+        viewport,
+      });
+      await renderTask.promise;
+      const data = canvasAndCtx.canvas.toDataURL();
+      CanvasFactory.destroy(canvasAndCtx);
+      return data;
     }
 
     afterEach(function(done) {

--- a/test/unit/custom_spec.js
+++ b/test/unit/custom_spec.js
@@ -48,9 +48,7 @@ describe('custom canvas rendering', function() {
     }).then(function(data) {
       page = data;
       done();
-    }).catch(function (reason) {
-      done.fail(reason);
-    });
+    }).catch(done.fail);
   });
 
   afterAll(function(done) {
@@ -66,20 +64,16 @@ describe('custom canvas rendering', function() {
     var viewport = page.getViewport(1);
     var canvasAndCtx = CanvasFactory.create(viewport.width, viewport.height);
 
-    page.render({
+    const renderTask = page.render({
       canvasContext: canvasAndCtx.context,
       viewport,
-    }).then(function() {
-      var { r, g, b, a, } = getTopLeftPixel(canvasAndCtx.context);
-      CanvasFactory.destroy(canvasAndCtx);
-      expect(r).toEqual(255);
-      expect(g).toEqual(255);
-      expect(b).toEqual(255);
-      expect(a).toEqual(255);
-      done();
-    }).catch(function (reason) {
-      done(reason);
     });
+    renderTask.promise.then(function() {
+      expect(getTopLeftPixel(canvasAndCtx.context)).toEqual(
+        { r: 255, g: 255, b: 255, a: 255, });
+      CanvasFactory.destroy(canvasAndCtx);
+      done();
+    }).catch(done.fail);
   });
 
   it('renders to canvas with a custom background', function(done) {
@@ -89,20 +83,16 @@ describe('custom canvas rendering', function() {
     var viewport = page.getViewport(1);
     var canvasAndCtx = CanvasFactory.create(viewport.width, viewport.height);
 
-    page.render({
+    const renderTask = page.render({
       canvasContext: canvasAndCtx.context,
       viewport,
       background: 'rgba(255,0,0,1.0)',
-    }).then(function() {
-      var { r, g, b, a, } = getTopLeftPixel(canvasAndCtx.context);
-      CanvasFactory.destroy(canvasAndCtx);
-      expect(r).toEqual(255);
-      expect(g).toEqual(0);
-      expect(b).toEqual(0);
-      expect(a).toEqual(255);
-      done();
-    }).catch(function (reason) {
-      done(reason);
     });
+    renderTask.promise.then(function() {
+      expect(getTopLeftPixel(canvasAndCtx.context)).toEqual(
+        { r: 255, g: 0, b: 0, a: 255, });
+      CanvasFactory.destroy(canvasAndCtx);
+      done();
+    }).catch(done.fail);
   });
 });


### PR DESCRIPTION
Apart from the `class` conversion, this also changes all `var` to `let`/`const` and (temporarily) enables the ESLint `no-var` rule in this file (until such a time that it can be enabled globally).

It's obviously possible that the `deprecated` calls aren't actually wanted here, and I won't insist on keeping them if there's any objections :-)
However, I do think that it would be good to at least do a slightly better job of "promoting" `PDFDocumentLoadingTask`/`RenderTask`, since they contain more functionality than just a promise (see e.g. the `destroy` respectively `cancel` methods).

*Please note:* It's highly recommended to look at each commit separately and ignoring whitespace changes, with `?w=1`, when reviewing this. For some reason GitHub completely chokes on the `PDFPageProxy` diff, so for convenience here's the `git diff -w` output: https://gist.github.com/Snuffleupagus/d44fd9aa1f63abe2e377e138de2d6fef