### PR TITLE
Avoid unnecessary `PDFFindController.scrollMatchIntoView` calls in `TextLayerBuilder._renderMatches` when `highlightAll` is set (PR 10201 follow-up)

### DIFF
--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -238,15 +238,16 @@ class TextLayerBuilder {
       let match = matches[i];
       let begin = match.begin;
       let end = match.end;
-      let isSelected = (isSelectedPage && i === selectedMatchIdx);
-      let highlightSuffix = (isSelected ? ' selected' : '');
+      const isSelected = (isSelectedPage && i === selectedMatchIdx);
+      const highlightSuffix = (isSelected ? ' selected' : '');
 
-      // Attempt to scroll the selected match into view.
-      findController.scrollMatchIntoView({
-        element: textDivs[begin.divIdx],
-        pageIndex: pageIdx,
-        matchIndex: i,
-      });
+      if (isSelected) { // Attempt to scroll the selected match into view.
+        findController.scrollMatchIntoView({
+          element: textDivs[begin.divIdx],
+          pageIndex: pageIdx,
+          matchIndex: selectedMatchIdx,
+        });
+      }
 
       // Match inside new div.
       if (!prevEnd || begin.divIdx !== prevEnd.divIdx) {


### PR DESCRIPTION
When `highlightAll` is *not* set, there's only going to be a single match per page and unconditionally calling `PDFFindController.scrollMatchIntoView` doesn't really matter.
However, when `highlightAll` is set the current code may result in a large number of unnecessary `PDFFindController.scrollMatchIntoView` calls. Since `TextLayerBuilder._renderMatches` already checks if a particular match is the selected one, for highlighting purposes, it's simple enough to also skip scrolling completely for non-selected matches.