### PR TITLE
Attempt to tweak the error messages, in `BaseViewer`, for invalid pageNumbers/pageLabels (bug 1505824)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1905,7 +1905,11 @@ function webViewerZoomOut() {
 }
 function webViewerPageNumberChanged(evt) {
   let pdfViewer = PDFViewerApplication.pdfViewer;
-  pdfViewer.currentPageLabel = evt.value;
+  // Note that for `<input type="number">` HTML elements, an empty string will
+  // be returned for non-number inputs; hence we simply do nothing in that case.
+  if (evt.value !== '') {
+    pdfViewer.currentPageLabel = evt.value;
+  }
 
   // Ensure that the page number input displays the correct value, even if the
   // value entered by the user was invalid (e.g. a floating point number).

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -212,10 +212,14 @@ class BaseViewer {
       return;
     }
     // The intent can be to just reset a scroll position and/or scale.
-    this._setCurrentPageNumber(val, /* resetCurrentPageView = */ true);
+    if (!this._setCurrentPageNumber(val, /* resetCurrentPageView = */ true)) {
+      console.error(
+        `${this._name}.currentPageNumber: "${val}" is not a valid page.`);
+    }
   }
 
   /**
+   * @return {boolean} Whether the pageNumber is valid (within bounds).
    * @private
    */
   _setCurrentPageNumber(val, resetCurrentPageView = false) {
@@ -223,13 +227,11 @@ class BaseViewer {
       if (resetCurrentPageView) {
         this._resetCurrentPageView();
       }
-      return;
+      return true;
     }
 
     if (!(0 < val && val <= this.pagesCount)) {
-      console.error(
-        `${this._name}._setCurrentPageNumber: "${val}" is out of bounds.`);
-      return;
+      return false;
     }
     this._currentPageNumber = val;
 
@@ -242,6 +244,7 @@ class BaseViewer {
     if (resetCurrentPageView) {
       this._resetCurrentPageView();
     }
+    return true;
   }
 
   /**
@@ -256,14 +259,21 @@ class BaseViewer {
    * @param {string} val - The page label.
    */
   set currentPageLabel(val) {
-    let pageNumber = val | 0; // Fallback page number.
+    if (!this.pdfDocument) {
+      return;
+    }
+    let page = val | 0; // Fallback page number.
     if (this._pageLabels) {
       let i = this._pageLabels.indexOf(val);
       if (i >= 0) {
-        pageNumber = i + 1;
+        page = i + 1;
       }
     }
-    this.currentPageNumber = pageNumber;
+    // The intent can be to just reset a scroll position and/or scale.
+    if (!this._setCurrentPageNumber(page, /* resetCurrentPageView = */ true)) {
+      console.error(
+        `${this._name}.currentPageLabel: "${val}" is not a valid page.`);
+    }
   }
 
   /**
@@ -279,7 +289,7 @@ class BaseViewer {
    */
   set currentScale(val) {
     if (isNaN(val)) {
-      throw new Error('Invalid numeric scale');
+      throw new Error('Invalid numeric scale.');
     }
     if (!this.pdfDocument) {
       return;
@@ -668,8 +678,8 @@ class BaseViewer {
     const pageView = (Number.isInteger(pageNumber) &&
                       this._pages[pageNumber - 1]);
     if (!pageView) {
-      console.error(
-        `${this._name}.scrollPageIntoView: Invalid "pageNumber" parameter.`);
+      console.error(`${this._name}.scrollPageIntoView: ` +
+        `"${pageNumber}" is not a valid pageNumber parameter.`);
       return;
     }
 


### PR DESCRIPTION
Rather than closing [bug 1505824](https://bugzilla.mozilla.org/show_bug.cgi?id=1505824) as WONTFIX (which is my preferred solution), given how *minor* this "problem" is, it's still possible to adjust the error messages a bit.

The main point here, which is relevant even if the changes in `BaseViewer` are ultimately rejected during review, is that we'll no longer attempt to call `BaseViewer.currentPageLabel` with an empty string from `webViewerPageNumberChanged` in `app.js`.

The other changes are:
 - Stop printing an error in `BaseViewer._setCurrentPageNumber`, and have it return a boolean indicating if the page is within bounds.
 - Have the `BaseViewer.{currentPageNumber, currentPageLabel}` setters print their own errors for invalid pages.
 - Have the `BaseViewer.currentPageLabel` setter no longer depend, indirectly, on the `BaseViewer.currentPageNumber` setter.
 - Improve a couple of other error messages.