### PR TITLE
Fix `NameOrNumberTree.get` to actually perform a binary search to find the requested key

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -1686,7 +1686,7 @@ class NameOrNumberTree {
       while (l <= r) {
         // Check only even indices (0, 2, 4, ...) because the
         // odd indices contain the actual data.
-        const m = (l + r) & ~1;
+        const tmp = (l + r) >> 1, m = tmp + (tmp & 1);
         const currentKey = xref.fetchIfRef(entries[m]);
         if (key < currentKey) {
           r = m - 2;


### PR DESCRIPTION
The intent of the code, based on existing comments, is to perform a binary search. However, because of what appears to be a typo in the code responsible for computing the current search index, this code is always checking *every* entry (albeit only at the "final" node) starting from the last one.