### PR TITLE
Update natives secondary dependency for Node.js 11.0+ compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5790,9 +5790,9 @@
       }
     },
     "natives": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
-      "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
       "dev": true
     },
     "natural-compare": {


### PR DESCRIPTION
See: https://github.com/gulpjs/gulp/issues/2246

It looks like Node.js 11.x runs Gulp 3.x just fine if we update this secondary dependency. Issue #10177 may be partially resolved by this.