### PR TITLE
Add protection against directory traversal attacks

### DIFF
--- a/test/webserver.js
+++ b/test/webserver.js
@@ -80,7 +80,11 @@ WebServer.prototype = {
   _handler: function (req, res) {
     var url = req.url.replace(/\/\//g, '/');
     var urlParts = /([^?]*)((?:\?(.*))?)/.exec(url);
-    var pathPart = decodeURI(urlParts[1]), queryPart = urlParts[3];
+    // guard against directory traversal attacks,
+    // e.g. /../../../../../../../etc/passwd
+    // which let you make GET requests for files outside of this.root
+    var pathPart = path.normalize(decodeURI(urlParts[1]));
+    var queryPart = urlParts[3];
     var verbose = this.verbose;
 
     var methodHooks = this.hooks[req.method];


### PR DESCRIPTION
This prevents people from making a request such as:

```bash
$ curl --path-as-is 'http://127.0.0.1:8888/../../../../../../../../../etc/passwd'
```