### PR TITLE
In `GENERIC` builds, dispatch a "webviewerloaded" event (from the `webViewerLoad` function) before initializing the viewer

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -169,21 +169,14 @@ let PDFViewerApplication = {
    * @private
    */
   async _readPreferences() {
-    // A subset of the Preferences that `AppOptions`, for compatibility reasons,
-    // is allowed to override if the `AppOptions` values matches the ones below.
-    const OVERRIDES = {
-      disableFontFace: true,
-      disableRange: true,
-      disableStream: true,
-      textLayerMode: TextLayerMode.DISABLE,
-    };
-
+    if (AppOptions.get('disablePreferences') === true) {
+      // Give custom implementations of the default viewer a simpler way to
+      // opt-out of having the `Preferences` override existing `AppOptions`.
+      return;
+    }
     try {
       const prefs = await this.preferences.getAll();
-      for (let name in prefs) {
-        if ((name in OVERRIDES) && AppOptions.get(name) === OVERRIDES[name]) {
-          continue;
-        }
+      for (const name in prefs) {
         AppOptions.set(name, prefs[name]);
       }
     } catch (reason) { }

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -58,6 +58,9 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.VIEWER,
   },
+  /**
+   * The `disablePreferences` is, conditionally, defined below.
+   */
   enablePrintAutoRotate: {
     /** @type {boolean} */
     value: false,
@@ -218,6 +221,11 @@ const defaultOptions = {
 };
 if (typeof PDFJSDev === 'undefined' ||
     PDFJSDev.test('!PRODUCTION || GENERIC')) {
+  defaultOptions.disablePreferences = {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER,
+  };
   defaultOptions.locale = {
     /** @type {string} */
     value: (typeof navigator !== 'undefined' ? navigator.language : 'en-US'),

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -203,6 +203,16 @@ function webViewerLoad() {
 
     window.PDFViewerApplication = pdfjsWebApp.PDFViewerApplication;
     window.PDFViewerApplicationOptions = pdfjsWebAppOptions.AppOptions;
+
+    if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('GENERIC')) {
+      // Give custom implementations of the default viewer a simpler way to
+      // set various `AppOptions`, by dispatching an event once all viewer
+      // files are loaded but *before* the viewer initialization has run.
+      const event = document.createEvent('CustomEvent');
+      event.initCustomEvent('webviewerloaded', true, true, {});
+      document.dispatchEvent(event);
+    }
+
     pdfjsWebApp.PDFViewerApplication.run(config);
   }
 }


### PR DESCRIPTION
 - Replace the `OVERRIDES` list in `PDFViewerApplication._readPreferences` with a `disablePreferences`, in `GENERIC` builds, `AppOption instead
   
   Rather than having a (somewhat) randomly choosen list of Preferences which `AppOptions` are allowed to override, it makes much more sense to simply add an AppOption to allow custom implementations to ignore Preferences altogether (it's also inline with the AppOption that allows the `ViewHistory` to be bypassed on load).

 - In `GENERIC` builds, dispatch a "webviewerloaded" event (from the `webViewerLoad` function) before initializing the viewer
   
   With the removal of the global `PDFJS` object, in PDF.js version `2.0`, the viewer options are no longer as easily accessible as they previously were (and issues have been filed about this).
In particular, since the viewer files aren't necessarily loaded *immediately*, this means that `PDFViewerApplication`/`PDFViewerApplicationOptions` aren't necessarily available directly. By dispatching an event once all viewer files are loaded but *before* the viewer initialization has run, setting `AppOptions` during load (in custom implementations of the default viewer) should hopefully become a little bit easier[1].

/cc @timvandermeij 

---
[1] In hindsight, this should probably have been implemented when the global `PDFJS` object was removed...