### PR TITLE
Test the code as-is, in Node.js/Travis, rather than its Babel translated version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -898,11 +898,12 @@ gulp.task('lib', ['buildnumber'], function () {
     };
   }
   function preprocess(content) {
-    var noPreset = /\/\*\s*no-babel-preset\s*\*\//.test(content);
+    var skipBabel = process.env['SKIP_BABEL'] === 'true' ||
+                    /\/\*\s*no-babel-preset\s*\*\//.test(content);
     content = preprocessor2.preprocessPDFJSCode(ctx, content);
     content = babel.transform(content, {
       sourceType: 'module',
-      presets: noPreset ? undefined : ['@babel/preset-env'],
+      presets: skipBabel ? undefined : ['@babel/preset-env'],
       plugins: [
         '@babel/plugin-transform-modules-commonjs',
         ['@babel/plugin-transform-runtime', {
@@ -1057,10 +1058,10 @@ gulp.task('baseline', function (done) {
 });
 
 gulp.task('unittestcli', ['testing-pre', 'lib'], function(done) {
-  var args = ['JASMINE_CONFIG_PATH=test/unit/clitests.json'];
-  var testProcess = spawn('node_modules/.bin/jasmine', args,
-                          { stdio: 'inherit', });
-  testProcess.on('close', function (code) {
+  var options = ['node_modules/jasmine/bin/jasmine',
+                 'JASMINE_CONFIG_PATH=test/unit/clitests.json'];
+  var jasmineProcess = spawn('node', options, { stdio: 'inherit', });
+  jasmineProcess.on('close', function(code) {
     if (code !== 0) {
       done(new Error('Unit tests failed.'));
       return;

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "yargs": "^11.1.0"
   },
   "scripts": {
-    "test": "gulp lint unittestcli externaltest"
+    "test": "env SKIP_BABEL=true gulp lint unittestcli externaltest"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This patch does three things:

 - Updates the `gulp unittestcli` command, using `gulp lint` as a guide, such that it can be run locally on Windows without any modifications.

 - Updates the `gulp lib` command to support disabling of Babel through the `SKIP_BABEL` environment variable. Note that all other build targets support this mode, and there's no good reason for `lib` to be any different here.

 - Updates the `npm test` command, used in Node.js/Travis, to test the code as-is test. Since modern Node.js versions seem to have no problems with ES6 compatible code in general, we should just test the source code as-is instead (similar to the tests running on the regular bots).