### PR TITLE
Handle line width of zero in SVG

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -903,7 +903,9 @@ SVGGraphics = (function SVGGraphicsClosure() {
 
     // Path properties
     setLineWidth: function SVGGraphics_setLineWidth(width) {
-      this.current.lineWidth = width;
+      if (width > 0) {
+        this.current.lineWidth = width;
+      }
     },
     setLineCap: function SVGGraphics_setLineCap(style) {
       this.current.lineCap = LINE_CAP_STYLES[style];


### PR DESCRIPTION
Fixes #10282

In issue #10282, the SVG back-end doesn't draw stroked paths because the PDF file specifies a line width of 0. In PDF, zero denotes "the thinnest line that can be rendered" but in SVG the attribute `stroke-width="0"` causes no stroke to be painted. My patch makes the SVG back-end work in the same way as the canvas back-end, in which setting `ctx.lineWidth` to zero or a negative value is ignored.