### PR TITLE
[api-minor] Add support for OpenAction destinations (issue 10332)

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -117,6 +117,10 @@
       ],
       "default": 0
     },
+    "disableOpenActionDestination": {
+      "type": "boolean",
+      "default": true
+    },
     "disablePageLabels": {
       "type": "boolean",
       "default": false

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -392,6 +392,28 @@ class Catalog {
     return shadow(this, 'pageMode', pageMode);
   }
 
+  get openActionDestination() {
+    const obj = this.catDict.get('OpenAction');
+    let openActionDest = null;
+
+    if (isDict(obj)) {
+      // Convert the OpenAction dictionary into a format that works with
+      // `parseDestDictionary`, to avoid having to re-implement those checks.
+      const destDict = new Dict(this.xref);
+      destDict.set('A', obj);
+
+      const resultObj = { url: null, dest: null, };
+      Catalog.parseDestDictionary({ destDict, resultObj, });
+
+      if (Array.isArray(resultObj.dest)) {
+        openActionDest = resultObj.dest;
+      }
+    } else if (Array.isArray(obj)) {
+      openActionDest = obj;
+    }
+    return shadow(this, 'openActionDestination', openActionDest);
+  }
+
   get attachments() {
     const obj = this.catDict.get('Names');
     let attachments = null;

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -531,6 +531,10 @@ var WorkerMessageHandler = {
       return pdfManager.ensureCatalog('pageMode');
     });
 
+    handler.on('getOpenActionDestination', function(data) {
+      return pdfManager.ensureCatalog('openActionDestination');
+    });
+
     handler.on('GetAttachments',
       function wphSetupGetAttachments(data) {
         return pdfManager.ensureCatalog('attachments');

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -651,6 +651,14 @@ class PDFDocumentProxy {
   }
 
   /**
+   * @return {Promise} A promise that is resolved with an {Array} containing the
+   *   destination, or `null` when no open action is present in the PDF file.
+   */
+  getOpenActionDestination() {
+    return this._transport.getOpenActionDestination();
+  }
+
+  /**
    * @return {Promise} A promise that is resolved with a lookup table for
    *   mapping named attachments to their content.
    */
@@ -2150,6 +2158,11 @@ class WorkerTransport {
 
   getPageMode() {
     return this.messageHandler.sendWithPromise('GetPageMode', null);
+  }
+
+  getOpenActionDestination() {
+    return this.messageHandler.sendWithPromise('getOpenActionDestination',
+                                               null);
   }
 
   getAttachments() {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -650,6 +650,24 @@ describe('api', function() {
       }).catch(done.fail);
     });
 
+    it('gets default open action destination', function(done) {
+      var loadingTask = getDocument(buildGetDocumentParams('tracemonkey.pdf'));
+
+      loadingTask.promise.then(function(pdfDocument) {
+        return pdfDocument.getOpenActionDestination();
+      }).then(function(dest) {
+        expect(dest).toEqual(null);
+
+        loadingTask.destroy().then(done);
+      }).catch(done.fail);
+    });
+    it('gets non-default open action destination', function(done) {
+      doc.getOpenActionDestination().then(function(dest) {
+        expect(dest).toEqual([{ num: 15, gen: 0, }, { name: 'FitH', }, null]);
+        done();
+      }).catch(done.fail);
+    });
+
     it('gets non-existent attachments', function(done) {
       var promise = doc.getAttachments();
       promise.then(function (data) {

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -48,6 +48,11 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.VIEWER,
   },
+  disableOpenActionDestination: {
+    /** @type {boolean} */
+    value: true,
+    kind: OptionKind.VIEWER,
+  },
   disablePageLabels: {
     /** @type {boolean} */
     value: false,

--- a/web/default_preferences.json
+++ b/web/default_preferences.json
@@ -16,6 +16,7 @@
   "renderer": "canvas",
   "renderInteractiveForms": false,
   "enablePrintAutoRotate": false,
+  "disableOpenActionDestination": true,
   "disablePageMode": false,
   "disablePageLabels": false,
   "scrollModeOnLoad": 0,

--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -94,7 +94,7 @@ class IPDFHistory {
   /**
    * @param {Object} params
    */
-  push({ namedDest, explicitDest, pageNumber, }) {}
+  push({ namedDest = null, explicitDest, pageNumber, }) {}
 
   pushCurrentPosition() {}
 

--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -158,16 +158,27 @@ class PDFHistory {
    * Push an internal destination to the browser history.
    * @param {PushParameters}
    */
-  push({ namedDest, explicitDest, pageNumber, }) {
+  push({ namedDest = null, explicitDest, pageNumber, }) {
     if (!this.initialized) {
       return;
     }
-    if ((namedDest && typeof namedDest !== 'string') ||
-        !Array.isArray(explicitDest) ||
-        !(Number.isInteger(pageNumber) &&
-          pageNumber > 0 && pageNumber <= this.linkService.pagesCount)) {
-      console.error('PDFHistory.push: Invalid parameters.');
+    if (namedDest && typeof namedDest !== 'string') {
+      console.error('PDFHistory.push: ' +
+                    `"${namedDest}" is not a valid namedDest parameter.`);
       return;
+    } else if (!Array.isArray(explicitDest)) {
+      console.error('PDFHistory.push: ' +
+                    `"${explicitDest}" is not a valid explicitDest parameter.`);
+      return;
+    } else if (!(Number.isInteger(pageNumber) &&
+                 pageNumber > 0 && pageNumber <= this.linkService.pagesCount)) {
+      // Allow an unset `pageNumber` if and only if the history is still empty;
+      // please refer to the `this._destination.page = null;` comment above.
+      if (pageNumber !== null || this._destination) {
+        console.error('PDFHistory.push: ' +
+                      `"${pageNumber}" is not a valid pageNumber parameter.`);
+        return;
+      }
     }
 
     let hash = namedDest || JSON.stringify(explicitDest);


### PR DESCRIPTION
Note that the OpenAction dictionary may contain other information besides just a destination array, e.g. instructions for auto-printing[1].
Given first of all that an arbitrary `Dict` cannot be sent from the Worker (since cloning would fail), and second of all that the data obviously needs to be validated, this patch purposely only adds support for fetching a destination from the OpenAction entry[2].

~~For the time being support for this isn't added to the default viewer, since it's really not clear to me if that's desired functionality. Furthermore, actually implementing this will require (some kind of) re-factoring of the `PDFHistory` initialization to prevent odd initial history state.~~

---
[1] This information is, currently in PDF.js, being included through the `getJavaScript` API method.

[2] This significantly reduces the complexity of the implementation, which seems fine for now. If there's ever need for other kinds of OpenAction to be fetched, additional API methods could/should be implemented as necessary (could e.g. follow the `getOpenActionWhatever` naming scheme).