### PR TITLE
Turn on ESLint in examples

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,7 +2,6 @@ build/
 l10n/
 docs/
 node_modules/
-examples/
 external/bcmaps/
 external/webL10n/
 external/cmapscompress/

--- a/examples/.eslintrc
+++ b/examples/.eslintrc
@@ -1,0 +1,24 @@
+{
+  "extends": [
+    "../.eslintrc"
+  ],
+
+  "parserOptions": {
+    "ecmaVersion": 5,
+  },
+
+  "env": {
+    "es6": false,
+  },
+
+  "globals": {
+    "pdfjsImageDecoders": false,
+    "pdfjsLib": false,
+    "pdfjsViewer": false,
+    "Uint8Array": false,
+  },
+
+  "rules": {
+    "object-shorthand": ["error", "never"]
+  }
+}

--- a/examples/acroforms/acroforms.js
+++ b/examples/acroforms/acroforms.js
@@ -38,7 +38,8 @@ loadingTask.promise.then(function(doc) {
           id: pageNum,
           scale: DEFAULT_SCALE,
           defaultViewport: pdfPage.getViewport(DEFAULT_SCALE),
-          annotationLayerFactory: new pdfjsViewer.DefaultAnnotationLayerFactory(),
+          annotationLayerFactory:
+            new pdfjsViewer.DefaultAnnotationLayerFactory(),
           renderInteractiveForms: true,
         });
 

--- a/examples/browserify/gulpfile.js
+++ b/examples/browserify/gulpfile.js
@@ -9,7 +9,7 @@ var OUTPUT_PATH = '../../build/browserify';
 var TMP_FILE_PREFIX = '../../build/browserify_';
 
 gulp.task('build-bundle', function() {
-  return browserify('main.js', {output: TMP_FILE_PREFIX + 'main.tmp'})
+  return browserify('main.js', { output: TMP_FILE_PREFIX + 'main.tmp', })
     .ignore(require.resolve('pdfjs-dist/build/pdf.worker')) // Reducing size
     .bundle()
     .pipe(source(TMP_FILE_PREFIX + 'main.tmp'))
@@ -21,12 +21,12 @@ gulp.task('build-bundle', function() {
 gulp.task('build-worker', function() {
   // We can create our own viewer (see worker.js) or use already defined one.
   var workerSrc = require.resolve('pdfjs-dist/build/pdf.worker.entry');
-  return browserify(workerSrc, {output: TMP_FILE_PREFIX + 'worker.tmp'})
+  return browserify(workerSrc, { output: TMP_FILE_PREFIX + 'worker.tmp', })
     .bundle()
     .pipe(source(TMP_FILE_PREFIX + 'worker.tmp'))
-    .pipe(streamify(uglify({compress:{
-      sequences: false // Chrome has issue with the generated code if true
-    }})))
+    .pipe(streamify(uglify({ compress: {
+      sequences: false, // Chrome has issue with the generated code if true
+    }, })))
     .pipe(rename('pdf.worker.bundle.js'))
     .pipe(gulp.dest(OUTPUT_PATH));
 });

--- a/examples/browserify/gulpfile.js
+++ b/examples/browserify/gulpfile.js
@@ -24,9 +24,11 @@ gulp.task('build-worker', function() {
   return browserify(workerSrc, { output: TMP_FILE_PREFIX + 'worker.tmp', })
     .bundle()
     .pipe(source(TMP_FILE_PREFIX + 'worker.tmp'))
-    .pipe(streamify(uglify({ compress: {
-      sequences: false, // Chrome has issue with the generated code if true
-    }, })))
+    .pipe(streamify(uglify({
+      compress: {
+        sequences: false, // Chrome has issue with the generated code if true
+      },
+    })))
     .pipe(rename('pdf.worker.bundle.js'))
     .pipe(gulp.dest(OUTPUT_PATH));
 });

--- a/examples/browserify/main.js
+++ b/examples/browserify/main.js
@@ -24,7 +24,7 @@ loadingTask.promise.then(function (pdfDocument) {
     var ctx = canvas.getContext('2d');
     var renderTask = pdfPage.render({
       canvasContext: ctx,
-      viewport: viewport
+      viewport: viewport,
     });
     return renderTask.promise;
   });

--- a/examples/components/simpleviewer.js
+++ b/examples/components/simpleviewer.js
@@ -15,7 +15,7 @@
 
 'use strict';
 
-if (!pdfjsLib.getDocument || !pdfjsViewer.PDFViewer)  {
+if (!pdfjsLib.getDocument || !pdfjsViewer.PDFViewer) {
   alert('Please build the pdfjs-dist library using\n' +
         '  `gulp dist-install`');
 }

--- a/examples/image_decoders/jpeg_viewer.js
+++ b/examples/image_decoders/jpeg_viewer.js
@@ -68,11 +68,12 @@ var jpegData = jpegImage.getData({
 //
 var imageData = jpegCtx.createImageData(width, height);
 var imageBytes = imageData.data;
-for (var i = 0, j = 0, ii = width * height * 4; i < ii;) {
-  imageBytes[i++] = jpegData[j++];
-  imageBytes[i++] = jpegData[j++];
-  imageBytes[i++] = jpegData[j++];
-  imageBytes[i++] = 255;
+for (var j = 0, k = 0, jj = width * height * 4; j < jj;) {
+  imageBytes[j++] = jpegData[k++];
+  imageBytes[j++] = jpegData[k++];
+  imageBytes[j++] = jpegData[k++];
+  imageBytes[j++] = 255;
 }
-jpegCanvas.width = width, jpegCanvas.height = height;
+jpegCanvas.width = width;
+jpegCanvas.height = height;
 jpegCtx.putImageData(imageData, 0, 0);

--- a/examples/image_decoders/jpeg_viewer.js
+++ b/examples/image_decoders/jpeg_viewer.js
@@ -59,8 +59,8 @@ jpegImage.parse(typedArrayImage);
 
 var width = jpegImage.width, height = jpegImage.height;
 var jpegData = jpegImage.getData({
-  width,
-  height,
+  width: width,
+  height: height,
   forceRGB: true,
 });
 
@@ -76,4 +76,3 @@ for (var i = 0, j = 0, ii = width * height * 4; i < ii;) {
 }
 jpegCanvas.width = width, jpegCanvas.height = height;
 jpegCtx.putImageData(imageData, 0, 0);
-

--- a/examples/mobile-viewer/viewer.js
+++ b/examples/mobile-viewer/viewer.js
@@ -47,7 +47,7 @@ var PDFViewerApplication = {
    * @returns {Promise} - Returns the promise, which is resolved when document
    *                      is opened.
    */
-  open: function (params) {
+  open: function(params) {
     if (this.pdfLoadingTask) {
       // We need to destroy already opened document
       return this.close().then(function () {
@@ -104,7 +104,7 @@ var PDFViewerApplication = {
       }
 
       loadingErrorMessage.then(function (msg) {
-        self.error(msg, {message: message});
+        self.error(msg, { message: message, });
       });
       self.loadingBar.hide();
     });
@@ -115,7 +115,7 @@ var PDFViewerApplication = {
    * @returns {Promise} - Returns the promise, which is resolved when all
    *                      destruction is completed.
    */
-  close: function () {
+  close: function() {
     var errorWrapper = document.getElementById('errorWrapper');
     errorWrapper.setAttribute('hidden', 'true');
 
@@ -154,7 +154,7 @@ var PDFViewerApplication = {
     this.setTitle(title);
   },
 
-  setTitleUsingMetadata: function (pdfDocument) {
+  setTitleUsingMetadata: function(pdfDocument) {
     var self = this;
     pdfDocument.getMetadata().then(function(data) {
       var info = data.info, metadata = data.metadata;
@@ -196,26 +196,26 @@ var PDFViewerApplication = {
     var l10n = this.l10n;
     var moreInfoText = [l10n.get('error_version_info',
       { version: pdfjsLib.version || '?',
-        build: pdfjsLib.build || '?' },
+        build: pdfjsLib.build || '?', },
       'PDF.js v{{version}} (build: {{build}})')];
 
     if (moreInfo) {
       moreInfoText.push(
-        l10n.get('error_message', {message: moreInfo.message},
+        l10n.get('error_message', { message: moreInfo.message, },
           'Message: {{message}}'));
       if (moreInfo.stack) {
         moreInfoText.push(
-          l10n.get('error_stack', {stack: moreInfo.stack},
+          l10n.get('error_stack', { stack: moreInfo.stack, },
             'Stack: {{stack}}'));
       } else {
         if (moreInfo.filename) {
           moreInfoText.push(
-            l10n.get('error_file', {file: moreInfo.filename},
+            l10n.get('error_file', { file: moreInfo.filename, },
               'File: {{file}}'));
         }
         if (moreInfo.lineNumber) {
           moreInfoText.push(
-            l10n.get('error_line', {line: moreInfo.lineNumber},
+            l10n.get('error_line', { line: moreInfo.lineNumber, },
               'Line: {{line}}'));
         }
       }
@@ -311,7 +311,7 @@ var PDFViewerApplication = {
     linkService.setViewer(pdfViewer);
 
     this.pdfHistory = new pdfjsViewer.PDFHistory({
-      linkService: linkService
+      linkService: linkService,
     });
     linkService.setHistory(this.pdfHistory);
 
@@ -359,7 +359,7 @@ var PDFViewerApplication = {
       document.getElementById('previous').disabled = (page <= 1);
       document.getElementById('next').disabled = (page >= numPages);
     }, true);
-  }
+  },
 };
 
 document.addEventListener('DOMContentLoaded', function () {
@@ -378,6 +378,6 @@ document.addEventListener('DOMContentLoaded', function () {
 // We need to delay opening until all HTML is loaded.
 PDFViewerApplication.animationStartedPromise.then(function () {
   PDFViewerApplication.open({
-    url: DEFAULT_URL
+    url: DEFAULT_URL,
   });
 });

--- a/examples/mobile-viewer/viewer.js
+++ b/examples/mobile-viewer/viewer.js
@@ -339,8 +339,9 @@ var PDFViewerApplication = {
         function() {
       PDFViewerApplication.page = (this.value | 0);
 
-      // Ensure that the page number input displays the correct value, even if the
-      // value entered by the user was invalid (e.g. a floating point number).
+      // Ensure that the page number input displays the correct value,
+      // even if the value entered by the user was invalid
+      // (e.g. a floating point number).
       if (this.value !== PDFViewerApplication.page.toString()) {
         this.value = PDFViewerApplication.page;
       }

--- a/examples/node/.eslintrc
+++ b/examples/node/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "extends": [
+    "../.eslintrc"
+  ],
+
+  "env": {
+    "node": true,
+  },
+}

--- a/examples/node/domstubs.js
+++ b/examples/node/domstubs.js
@@ -96,7 +96,7 @@ DOMElement.prototype = {
 
   appendChild: function DOMElement_appendChild(element) {
     var childNodes = this.childNodes;
-    if (childNodes.indexOf(element) === -1) {
+    if (!childNodes.includes(element)) {
       childNodes.push(element);
     }
   },
@@ -152,10 +152,12 @@ DOMElementSerializer.prototype = {
           return ' xmlns:xlink="http://www.w3.org/1999/xlink"' +
                  ' xmlns:svg="http://www.w3.org/2000/svg"';
         }
+        /* falls through */
       case 2:  // Initialize variables for looping over attributes.
         ++this._state;
         this._loopIndex = 0;
         this._attributeKeys = Object.keys(node.attributes);
+        /* falls through */
       case 3:  // Serialize any attributes and end opening tag.
         if (this._loopIndex < this._attributeKeys.length) {
           var name = this._attributeKeys[this._loopIndex++];
@@ -170,6 +172,7 @@ DOMElementSerializer.prototype = {
         }
         ++this._state;
         this._loopIndex = 0;
+        /* falls through */
       case 5:  // Serialize child nodes (only for non-tspan/style elements).
         var value;
         while (true) {
@@ -186,6 +189,7 @@ DOMElementSerializer.prototype = {
             break;
           }
         }
+        /* falls through */
       case 6:  // Ending tag.
         ++this._state;
         return '</' + node.nodeName + '>';

--- a/examples/node/domstubs.js
+++ b/examples/node/domstubs.js
@@ -1,7 +1,7 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
-function xmlEncode(s){
+function xmlEncode(s) {
   var i = 0, ch;
   s = String(s);
   while (i < s.length && (ch = s[i]) !== '&' && ch !== '<' &&
@@ -50,7 +50,7 @@ function DOMElement(name) {
   if (name === 'style') {
     this.sheet = {
       cssRules: [],
-      insertRule: function (rule) {
+      insertRule: function(rule) {
         this.cssRules.push(rule);
       },
     };
@@ -124,8 +124,8 @@ DOMElement.prototype = {
 
   getSerializer: function DOMElement_getSerializer() {
     return new DOMElementSerializer(this);
-  }
-}
+  },
+};
 
 function DOMElementSerializer(node) {
   this._node = node;
@@ -198,48 +198,48 @@ DOMElementSerializer.prototype = {
 };
 
 const document = {
-  childNodes : [],
+  childNodes: [],
 
   get currentScript() {
-    return { src: '' };
+    return { src: '', };
   },
 
   get documentElement() {
     return this;
   },
 
-  createElementNS: function (NS, element) {
+  createElementNS: function(NS, element) {
     var elObject = new DOMElement(element);
     return elObject;
   },
 
-  createElement: function (element) {
+  createElement: function(element) {
     return this.createElementNS('', element);
   },
 
-  getElementsByTagName: function (element) {
+  getElementsByTagName: function(element) {
     if (element === 'head') {
       return [this.head || (this.head = new DOMElement('head'))];
     }
     return [];
-  }
+  },
 };
 
-function Image () {
+function Image() {
   this._src = null;
   this.onload = null;
 }
 Image.prototype = {
-  get src () {
+  get src() {
     return this._src;
   },
-  set src (value) {
+  set src(value) {
     this._src = value;
     if (this.onload) {
       this.onload();
     }
-  }
-}
+  },
+};
 
 exports.document = document;
 exports.Image = Image;

--- a/examples/node/getinfo.js
+++ b/examples/node/getinfo.js
@@ -52,7 +52,7 @@ loadingTask.promise.then(function(doc) {
       }).then(function () {
         console.log();
       });
-    })
+    });
   };
   // Loading of the first page will wait on metadata and subsequent loadings
   // will wait on the previous pages.

--- a/examples/node/pdf2png/pdf2png.js
+++ b/examples/node/pdf2png/pdf2png.js
@@ -70,7 +70,7 @@ loadingTask.promise.then(function(pdfDocument) {
     var renderContext = {
       canvasContext: canvasAndContext.context,
       viewport: viewport,
-      canvasFactory: canvasFactory
+      canvasFactory: canvasFactory,
     };
 
     var renderTask = page.render(renderContext);

--- a/examples/node/pdf2png/pdf2png.js
+++ b/examples/node/pdf2png/pdf2png.js
@@ -66,7 +66,8 @@ loadingTask.promise.then(function(pdfDocument) {
     // Render the page on a Node canvas with 100% scale.
     var viewport = page.getViewport(1.0);
     var canvasFactory = new NodeCanvasFactory();
-    var canvasAndContext = canvasFactory.create(viewport.width, viewport.height);
+    var canvasAndContext =
+      canvasFactory.create(viewport.width, viewport.height);
     var renderContext = {
       canvasContext: canvasAndContext.context,
       viewport: viewport,
@@ -81,7 +82,8 @@ loadingTask.promise.then(function(pdfDocument) {
         if (error) {
           console.error('Error: ' + error);
         } else {
-          console.log('Finished converting first page of PDF file to a PNG image.');
+          console.log(
+            'Finished converting first page of PDF file to a PNG image.');
         }
       });
     });

--- a/examples/node/pdf2svg.js
+++ b/examples/node/pdf2svg.js
@@ -86,8 +86,9 @@ function writeSvgToFile(svgElement, filePath) {
 // callback.
 var loadingTask = pdfjsLib.getDocument({
   data: data,
-  // Try to export JPEG images directly if they don't need any further processing.
-  nativeImageDecoderSupport: pdfjsLib.NativeImageDecoding.DISPLAY
+  // Try to export JPEG images directly if they don't need any further
+  // processing.
+  nativeImageDecoderSupport: pdfjsLib.NativeImageDecoding.DISPLAY,
 });
 loadingTask.promise.then(function(doc) {
   var numPages = doc.numPages;

--- a/examples/node/pdf2svg.js
+++ b/examples/node/pdf2svg.js
@@ -108,11 +108,12 @@ loadingTask.promise.then(function(doc) {
         var svgGfx = new pdfjsLib.SVGGraphics(page.commonObjs, page.objs);
         svgGfx.embedFonts = true;
         return svgGfx.getSVG(opList, viewport).then(function (svg) {
-          return writeSvgToFile(svg, getFilePathForPage(pageNum)).then(function () {
-            console.log('Page: ' + pageNum);
-          }, function(err) {
-            console.log('Error: ' + err);
-          });
+          return writeSvgToFile(svg, getFilePathForPage(pageNum))
+            .then(function () {
+              console.log('Page: ' + pageNum);
+            }, function(err) {
+              console.log('Error: ' + err);
+            });
         });
       });
     });

--- a/examples/svgviewer/viewer.js
+++ b/examples/svgviewer/viewer.js
@@ -15,7 +15,7 @@
 
 'use strict';
 
-if (!pdfjsLib.getDocument || !pdfjsViewer.PDFViewer)  {
+if (!pdfjsLib.getDocument || !pdfjsViewer.PDFViewer) {
   alert('Please build the pdfjs-dist library using\n' +
         '  `gulp dist-install`');
 }

--- a/examples/text-only/pdf2svg.js
+++ b/examples/text-only/pdf2svg.js
@@ -49,7 +49,7 @@ function buildSVG(viewport, textContent) {
 
 function pageLoaded() {
   // Loading document and page text content
-  var loadingTask = pdfjsLib.getDocument({url: PDF_PATH});
+  var loadingTask = pdfjsLib.getDocument({ url: PDF_PATH, });
   loadingTask.promise.then(function(pdfDocument) {
     pdfDocument.getPage(PAGE_NUMBER).then(function (page) {
       var viewport = page.getViewport(PAGE_SCALE);

--- a/examples/webpack/.eslintrc
+++ b/examples/webpack/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "extends": [
+    "../.eslintrc"
+  ],
+
+  "env": {
+    "node": true,
+  },
+}

--- a/examples/webpack/main.js
+++ b/examples/webpack/main.js
@@ -24,7 +24,7 @@ loadingTask.promise.then(function (pdfDocument) {
     var ctx = canvas.getContext('2d');
     var renderTask = pdfPage.render({
       canvasContext: ctx,
-      viewport: viewport
+      viewport: viewport,
     });
     return renderTask.promise;
   });

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -5,12 +5,12 @@ module.exports = {
   context: __dirname,
   entry: {
     'main': './main.js',
-    'pdf.worker': 'pdfjs-dist/build/pdf.worker.entry'
+    'pdf.worker': 'pdfjs-dist/build/pdf.worker.entry',
   },
   mode: 'none',
   output: {
     path: path.join(__dirname, '../../build/webpack'),
     publicPath: '../../build/webpack/',
-    filename: '[name].bundle.js'
-  }
+    filename: '[name].bundle.js',
+  },
 };

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -1,4 +1,4 @@
-var webpack = require('webpack');
+var webpack = require('webpack'); // eslint-disable-line no-unused-vars
 var path = require('path');
 
 module.exports = {


### PR DESCRIPTION
Inspired by #10322, I thought that more often than not, it would be handy to have ESLint in examples directory as well, checking if we don't have any preventable mistakes in the code.

* Enabled ESLint in examples directory
* Ran `eslint --fix`
* Manually fixed remaining 17 errors (mainly max-len and no-redeclare)