### PR TITLE
#10344 fix

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -545,16 +545,14 @@ var PDFDocument = (function PDFDocumentClosure() {
       }
       if (isDict(infoDict)) {
         // Only fill the document info with valid entries from the spec.
-        for (let key in DocumentInfoValidators) {
-          if (infoDict.has(key)) {
-            const value = infoDict.get(key);
-            // Make sure the value conforms to the spec.
-            if (DocumentInfoValidators[key](value)) {
-              docInfo[key] = (typeof value !== 'string' ?
-                              value : stringToPDFString(value));
-            } else {
-              info('Bad value in document info for "' + key + '"');
-            }
+        for (let key of infoDict.getKeys()) {
+          const value = infoDict.get(key);
+          // Make sure the value conforms to the spec.
+          if (DocumentInfoValidators[key] && !DocumentInfoValidators[key](value)) {
+            info('Bad value in document info for "' + key + '"');
+          } else {
+            docInfo[key] = (typeof value !== 'string' ?
+                            value : stringToPDFString(value));
           }
         }
       }

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -548,7 +548,8 @@ var PDFDocument = (function PDFDocumentClosure() {
         for (let key of infoDict.getKeys()) {
           const value = infoDict.get(key);
           // Make sure the value conforms to the spec.
-          if (DocumentInfoValidators[key] && !DocumentInfoValidators[key](value)) {
+          if (DocumentInfoValidators[key] &&
+              !DocumentInfoValidators[key](value)) {
             info('Bad value in document info for "' + key + '"');
           } else {
             docInfo[key] = (typeof value !== 'string' ?


### PR DESCRIPTION
ref: https://github.com/mozilla/pdf.js/issues/10344

Iterate all keys in `infoDict` instead of all keys in `DocumentInfoValidators` which `infoDict` has the same key of, so as to not ignore the custom info dict entries.