### PR TITLE
[api-minor] Add support, in `getMetadata`, for custom information dictionary entries (issue 5970, issue 10344)

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -829,6 +829,8 @@ describe('api', function() {
       var promise = doc.getMetadata();
       promise.then(function({ info, metadata, contentDispositionFilename, }) {
         expect(info['Title']).toEqual('Basic API Test');
+        // Custom, non-standard, information dictionary entries.
+        expect(info['Custom']).toEqual(undefined);
         // The following are PDF.js specific, non-standard, properties.
         expect(info['PDFFormatVersion']).toEqual('1.7');
         expect(info['IsLinearized']).toEqual(false);
@@ -842,6 +844,34 @@ describe('api', function() {
         done();
       }).catch(done.fail);
     });
+    it('gets metadata, with custom info dict entries', function(done) {
+      var loadingTask = getDocument(buildGetDocumentParams('tracemonkey.pdf'));
+
+      loadingTask.promise.then(function(pdfDocument) {
+        return pdfDocument.getMetadata();
+      }).then(function({ info, metadata, contentDispositionFilename, }) {
+        expect(info['Creator']).toEqual('TeX');
+        expect(info['Producer']).toEqual('pdfeTeX-1.21a');
+        expect(info['CreationDate']).toEqual('D:20090401163925-07\'00\'');
+        // Custom, non-standard, information dictionary entries.
+        const custom = info['Custom'];
+        expect(typeof custom === 'object' && custom !== null).toEqual(true);
+
+        expect(custom['PTEX.Fullbanner']).toEqual('This is pdfeTeX, ' +
+          'Version 3.141592-1.21a-2.2 (Web2C 7.5.4) kpathsea version 3.5.6');
+        // The following are PDF.js specific, non-standard, properties.
+        expect(info['PDFFormatVersion']).toEqual('1.4');
+        expect(info['IsLinearized']).toEqual(false);
+        expect(info['IsAcroFormPresent']).toEqual(false);
+        expect(info['IsXFAPresent']).toEqual(false);
+
+        expect(metadata).toEqual(null);
+        expect(contentDispositionFilename).toEqual(null);
+
+        loadingTask.destroy().then(done);
+      }).catch(done.fail);
+    });
+
     it('gets data', function(done) {
       var promise = doc.getData();
       promise.then(function (data) {


### PR DESCRIPTION
The custom entries, provided that they exist *and* that their types are safe to include, are exposed through a new `Custom` infoDict entry to clearly separate them from the standard ones.

Fixes #5970.
Fixes #10344.