### PR TITLE
Disable source-map generation when running tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -145,7 +145,7 @@ function createWebpackConfig(defines, output) {
   var licenseHeaderLibre =
     fs.readFileSync('./src/license_header_libre.js').toString();
   var enableSourceMaps = !bundleDefines.FIREFOX && !bundleDefines.MOZCENTRAL &&
-                         !bundleDefines.CHROME;
+                         !bundleDefines.CHROME && !bundleDefines.TESTING;
   var skipBabel = bundleDefines.SKIP_BABEL ||
                   process.env['SKIP_BABEL'] === 'true';
 


### PR DESCRIPTION
This should save, a little bit of, time/resources on the bots since source-maps aren't used for anything during testing.