### PR TITLE
Use high DPI icons on semi-high DPI screens.

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1566,7 +1566,7 @@ html[dir='rtl'] #documentPropertiesOverlay .row > * {
   display: none;
 }
 
-@media screen and (min-resolution: 2dppx) {
+@media screen and (min-resolution: 1.1dppx) {
   /* Rules for Retina screens */
   .toolbarButton::before {
     transform: scale(0.5);


### PR DESCRIPTION
The icons looks really fuzzy on a machine with a device pixel ratio of
1.5. Using the 2x icons looks much better.