### PR TITLE
Fix small visual quirk in thumbnail viewer

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1103,10 +1103,7 @@ html[dir='rtl'] .verticalToolbarSeparator {
   -webkit-overflow-scrolling: touch;
 }
 
-#thumbnailView > a:active {
-  outline: 0;
-}
-
+#thumbnailView > a:active,
 #thumbnailView > a:focus {
   outline: 0;
 }

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1103,6 +1103,14 @@ html[dir='rtl'] .verticalToolbarSeparator {
   -webkit-overflow-scrolling: touch;
 }
 
+#thumbnailView > a:active {
+  outline: 0;
+}
+
+#thumbnailView > a:focus {
+  outline: 0;
+}
+
 .thumbnail {
   margin: 0 10px 5px 10px;
 }


### PR DESCRIPTION
Remove the blue/red selection that would appear when you click a thumbnail in the thumbnail viewer in Firefox.

Fixes #10209 