### PR TITLE
[api-minor] Add offsetX and offsetY to PDFPageProxy.getViewport

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -904,12 +904,15 @@ class PDFPageProxy {
    * @param {number} rotate Degrees to rotate the viewport. If omitted this
    * defaults to the page rotation.
    * @param {boolean} dontFlip (optional) If true, axis Y will not be flipped.
-   * @param {number} offsetX (optional) The vertical, i.e. x-axis, offset.
-   * @param {number} offsetY (optional) The horizontal, i.e. y-axis, offset.
+   * @param {number} offsetX (optional) The horizontal, i.e. x-axis, offset.
+   *   The default value is `0`.
+   * @param {number} offsetY (optional) The vertical, i.e. y-axis, offset.
+   *   The default value is `0`.
    * @return {PageViewport} Contains 'width' and 'height' properties
    * along with transforms required for rendering.
    */
-  getViewport(scale, rotate = this.rotate, dontFlip = false, offsetX = 0, offsetY = 0) {
+  getViewport(scale, rotate = this.rotate, dontFlip = false, 
+              offsetX = 0, offsetY = 0) {
     return new PageViewport({
       viewBox: this.view,
       scale,

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -909,7 +909,7 @@ class PDFPageProxy {
    * @return {PageViewport} Contains 'width' and 'height' properties
    * along with transforms required for rendering.
    */
-  getViewport(scale, rotate = this.rotate, dontFlip = false, offsetX, offsetY) {
+  getViewport(scale, rotate = this.rotate, dontFlip = false, offsetX = 0, offsetY = 0) {
     return new PageViewport({
       viewBox: this.view,
       scale,

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -911,7 +911,7 @@ class PDFPageProxy {
    * @return {PageViewport} Contains 'width' and 'height' properties
    * along with transforms required for rendering.
    */
-  getViewport(scale, rotate = this.rotate, dontFlip = false, 
+  getViewport(scale, rotate = this.rotate, dontFlip = false,
               offsetX = 0, offsetY = 0) {
     return new PageViewport({
       viewBox: this.view,

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -904,15 +904,19 @@ class PDFPageProxy {
    * @param {number} rotate Degrees to rotate the viewport. If omitted this
    * defaults to the page rotation.
    * @param {boolean} dontFlip (optional) If true, axis Y will not be flipped.
+   * @param {number} offsetX (optional) The vertical, i.e. x-axis, offset.
+   * @param {number} offsetY (optional) The horizontal, i.e. y-axis, offset.
    * @return {PageViewport} Contains 'width' and 'height' properties
    * along with transforms required for rendering.
    */
-  getViewport(scale, rotate = this.rotate, dontFlip = false) {
+  getViewport(scale, rotate = this.rotate, dontFlip = false, offsetX, offsetY) {
     return new PageViewport({
       viewBox: this.view,
       scale,
       rotation: rotate,
       dontFlip,
+      offsetX,
+      offsetY,
     });
   }
 


### PR DESCRIPTION
**Objective**
Render partial PDF to canvas at a very high scale (100+).

**Problem**
The canvas has a maximum pixel area. Rendering the full canvas has an upper scale limit before the browser will block it.

**Solution**
Render part of the canvas without rendering the full canvas.

**Current Workaround**

```javascript
const baseViewport = page.getViewport(scale);

// manually override offsets
baseViewport.offsetX = offsetX;
baseViewport.offsetY = offsetY;

// cloning will create a new viewport and use the offset overrides
const viewport = baseViewport.clone();

// set canvas dimensions to be within browser limits
canvas.width = width;
canvas.height = height;

const canvasContext = canvas.getContext("2d");

page.render({ canvasContext, viewport });
```

This PR would allow access to setting `offsetX` and `offsetY`.

An alternative would be exporting `PageViewport`.

**Example**

left: 2160 x 3024 pixel at scale 1 (scaled down to see entire pdf here)
right: 500 x 500 zoomed canvas at scale 50

![image](https://user-images.githubusercontent.com/8754/50304902-1fd84600-0446-11e9-8c72-bbebf76fb625.png)
