### PR TITLE
Optimize the `Ref` class in `src/core/primitives.js`

### DIFF
--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -185,11 +185,10 @@ var Ref = (function RefClosure() {
     toString: function Ref_toString() {
       // This function is hot, so we make the string as compact as possible.
       // |this.gen| is almost always zero, so we treat that case specially.
-      var str = this.num + 'R';
       if (this.gen !== 0) {
-        str += this.gen;
+        return `${this.num}R${this.gen}`;
       }
-      return str;
+      return `${this.num}R`;
     },
   };
 


### PR DESCRIPTION
The `toString` method always creates two string objects (for the 'R' character and for the `num` concatenation) and in the worst case creates three string objects (one more for the `gen` concatenation). For the Tracemonkey paper alone, this resulted in 12000 string objects when scrolling from the top to the bottom of the document. Since this is a hot function, it's worth minimizing the number of string objects, especially for large documents, to reduce peak memory usage.

This commit refactors the `toString` method to always create only one string object.