### PR TITLE
Ensure that `AnnotationBorderStyle.setWidth` is able to handle the input being a `Name`, to correctly deal with corrupt PDF documents (issue 10385)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -482,6 +482,11 @@ class AnnotationBorderStyle {
    * @param {integer} width - The width
    */
   setWidth(width) {
+    // Some corrupt PDF generators may provide the width as a `Name`,
+    // rather than as a number (fixes issue 10385).
+    if (isName(width)) {
+      width = parseFloat(width.name);
+    }
     if (Number.isInteger(width)) {
       this.width = width;
     }

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -492,11 +492,11 @@ class AnnotationBorderStyle {
    *
    * @public
    * @memberof AnnotationBorderStyle
-   * @param {Object} style - The style object
+   * @param {Name} style - The annotation style.
    * @see {@link shared/util.js}
    */
   setStyle(style) {
-    if (!style) {
+    if (!isName(style)) {
       return;
     }
     switch (style.name) {

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -236,6 +236,14 @@ describe('annotation', function() {
       expect(borderStyle.width).toEqual(1);
     });
 
+    it('should set/get a valid width, when the input is a `Name` (issue 10385)',
+        function() {
+      const borderStyle = new AnnotationBorderStyle();
+      borderStyle.setWidth(Name.get('0'));
+
+      expect(borderStyle.width).toEqual(0);
+    });
+
     it('should set and get a valid style', function() {
       const borderStyle = new AnnotationBorderStyle();
       borderStyle.setStyle(Name.get('D'));


### PR DESCRIPTION
Fixes #10385.