### PR TITLE
Prevent errors in various methods in `SimpleDOMNode` when the `childNodes` property is not defined (issue 10395)

### DIFF
--- a/src/display/xml_parser.js
+++ b/src/display/xml_parser.js
@@ -278,12 +278,16 @@ class SimpleDOMNode {
   }
 
   get firstChild() {
-    return this.childNodes[0];
+    return this.childNodes && this.childNodes[0];
   }
 
   get nextSibling() {
-    let index = this.parentNode.childNodes.indexOf(this);
-    return this.parentNode.childNodes[index + 1];
+    const childNodes = this.parentNode.childNodes;
+    if (!childNodes) {
+      return undefined;
+    }
+    const index = childNodes.indexOf(this);
+    return childNodes[index + 1];
   }
 
   get textContent() {


### PR DESCRIPTION
Given that the issue, as filed, is incomplete since no PDF file was provided for debugging, this patch is really the best that we can do here. *Please note:* This patch will *not* enable the Metadata to be successfully parsed, but it should at least prevent the errors.

Fixes #10395.