### PR TITLE
Remove the `for ... of` loop from the `PDFDocument.fingerprint` getter (issue 10401)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -600,8 +600,8 @@ class PDFDocument {
     }
 
     let fingerprint = '';
-    for (const hashPart of hash) {
-      const hex = hashPart.toString(16);
+    for (let i = 0, ii = hash.length; i < ii; i++) {
+      const hex = hash[i].toString(16);
       fingerprint += (hex.length === 1 ? '0' + hex : hex);
     }
     return shadow(this, 'fingerprint', fingerprint);


### PR DESCRIPTION
It appears that the `Symbol` polyfill doesn't work well in conjunction with `TypedArray`s, and that part of PR #10393 is thus reverted.

Fixes #10401.

/cc @timvandermeij 