### PR TITLE
Prevent errors, because of incorrect scope, in the `XMLParserBase._resolveEntities` method (issue 10407)

### DIFF
--- a/src/display/xml_parser.js
+++ b/src/display/xml_parser.js
@@ -46,7 +46,7 @@ function isWhitespaceString(s) {
 
 class XMLParserBase {
   _resolveEntities(s) {
-    return s.replace(/&([^;]+);/g, function (all, entity) {
+    return s.replace(/&([^;]+);/g, (all, entity) => {
       if (entity.substring(0, 2) === '#x') {
         return String.fromCharCode(parseInt(entity.substring(2), 16));
       } else if (entity.substring(0, 1) === '#') {

--- a/test/unit/metadata_spec.js
+++ b/test/unit/metadata_spec.js
@@ -127,4 +127,23 @@ describe('metadata', function() {
 
     expect(isEmptyObj(metadata.getAll())).toEqual(true);
   });
+
+  it('should correctly handle metadata containing "&apos" (issue 10407)',
+      function() {
+    const data = '<x:xmpmeta xmlns:x=\'adobe:ns:meta/\'>' +
+      '<rdf:RDF xmlns:rdf=\'http://www.w3.org/1999/02/22-rdf-syntax-ns#\'>' +
+      '<rdf:Description xmlns:dc=\'http://purl.org/dc/elements/1.1/\'>' +
+      '<dc:title><rdf:Alt>' +
+      '<rdf:li xml:lang="x-default">&apos;Foo bar baz&apos;</rdf:li>' +
+      '</rdf:Alt></dc:title></rdf:Description></rdf:RDF></x:xmpmeta>';
+    const metadata = new Metadata(data);
+
+    expect(metadata.has('dc:title')).toBeTruthy();
+    expect(metadata.has('dc:qux')).toBeFalsy();
+
+    expect(metadata.get('dc:title')).toEqual('\'Foo bar baz\'');
+    expect(metadata.get('dc:qux')).toEqual(null);
+
+    expect(metadata.getAll()).toEqual({ 'dc:title': '\'Foo bar baz\'', });
+  });
 });


### PR DESCRIPTION
Now with a unit-test, courtesy of https://github.com/mozilla/pdf.js/pull/10408#issuecomment-451294285.

Fixes #10407.