### PR TITLE
Adjust how `AnnotationBorderStyle.setWidth` handles the input being a `Name` (issue 10385)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -485,7 +485,8 @@ class AnnotationBorderStyle {
     // Some corrupt PDF generators may provide the width as a `Name`,
     // rather than as a number (fixes issue 10385).
     if (isName(width)) {
-      width = parseFloat(width.name);
+      this.width = 0; // This is consistent with the behaviour in Adobe Reader.
+      return;
     }
     if (Number.isInteger(width)) {
       this.width = width;

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -236,12 +236,15 @@ describe('annotation', function() {
       expect(borderStyle.width).toEqual(1);
     });
 
-    it('should set/get a valid width, when the input is a `Name` (issue 10385)',
+    it('should set the width to zero, when the input is a `Name` (issue 10385)',
         function() {
-      const borderStyle = new AnnotationBorderStyle();
-      borderStyle.setWidth(Name.get('0'));
+      const borderStyleZero = new AnnotationBorderStyle();
+      borderStyleZero.setWidth(Name.get('0'));
+      const borderStyleFive = new AnnotationBorderStyle();
+      borderStyleFive.setWidth(Name.get('5'));
 
-      expect(borderStyle.width).toEqual(0);
+      expect(borderStyleZero.width).toEqual(0);
+      expect(borderStyleFive.width).toEqual(0);
     });
 
     it('should set and get a valid style', function() {


### PR DESCRIPTION
In order to be consistent with the behaviour in Adobe Reader, the width will now always be set to zero when the input is a `Name`.

Fixes #10385.