### PR TITLE
Prevent errors, in `SimpleXMLParser.onEndElement`, when the stack has already been completely parsed (issue 10410)

### DIFF
--- a/src/display/xml_parser.js
+++ b/src/display/xml_parser.js
@@ -287,6 +287,9 @@ class SimpleDOMNode {
       return undefined;
     }
     const index = childNodes.indexOf(this);
+    if (index === -1) {
+      return undefined;
+    }
     return childNodes[index + 1];
   }
 
@@ -364,8 +367,11 @@ class SimpleXMLParser extends XMLParserBase {
   }
 
   onEndElement(name) {
-    this._currentFragment = this._stack.pop();
+    this._currentFragment = this._stack.pop() || [];
     const lastElement = this._currentFragment[this._currentFragment.length - 1];
+    if (!lastElement) {
+      return;
+    }
     for (let i = 0, ii = lastElement.childNodes.length; i < ii; i++) {
       lastElement.childNodes[i].parentNode = lastElement;
     }

--- a/test/unit/metadata_spec.js
+++ b/test/unit/metadata_spec.js
@@ -146,4 +146,26 @@ describe('metadata', function() {
 
     expect(metadata.getAll()).toEqual({ 'dc:title': '\'Foo bar baz\'', });
   });
+
+  it('should gracefully handle unbalanced end tags (issue 10410)', function() {
+    const data = '<?xpacket begin="Ã¯Â»Â¿" id="W5M0MpCehiHzreSzNTczkc9d"?>' +
+      '<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">' +
+      '<rdf:Description rdf:about="" ' +
+      'xmlns:pdf="http://ns.adobe.com/pdf/1.3/">' +
+      '<pdf:Producer>Soda PDF 5</pdf:Producer></rdf:Description>' +
+      '<rdf:Description rdf:about="" ' +
+      'xmlns:xap="http://ns.adobe.com/xap/1.0/">' +
+      '<xap:CreateDate>2018-10-02T08:14:49-05:00</xap:CreateDate>' +
+      '<xap:CreatorTool>Soda PDF 5</xap:CreatorTool>' +
+      '<xap:MetadataDate>2018-10-02T08:14:49-05:00</xap:MetadataDate> ' +
+      '<xap:ModifyDate>2018-10-02T08:14:49-05:00</xap:ModifyDate>' +
+      '</rdf:Description><rdf:Description rdf:about="" ' +
+      'xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/">' +
+      '<xmpMM:DocumentID>uuid:00000000-1c84-3cf9-89ba-bef0e729c831' +
+      '</xmpMM:DocumentID></rdf:Description>' +
+      '</rdf:RDF></x:xmpmeta><?xpacket end="w"?>';
+    const metadata = new Metadata(data);
+
+    expect(isEmptyObj(metadata.getAll())).toEqual(true);
+  });
 });


### PR DESCRIPTION
The error was triggered for a particular set of metadata, where an end tag was encountered without the corresponding begin tag being present in the data.
(The patch also fixes a minor oversight, from a recent PR, in the `SimpleDOMNode.nextSibling` method.)

Fixes #10410.