### PR TITLE
Switch to HTTPS for the license link on the website

### DIFF
--- a/docs/contents/getting_started/index.md
+++ b/docs/contents/getting_started/index.md
@@ -80,11 +80,11 @@ Note that we only mention the most relevant files and folders.
 │   ├── cmaps/                             - character maps (required by core)
 │   ├── compressed.tracemonkey-pldi-09.pdf - PDF file for testing purposes
 │   ├── debugger.js                        - helpful debugging features
-│   └── images/                            - images for the viewer and annotation icons
+│   ├── images/                            - images for the viewer and annotation icons
 │   ├── locale/                            - translation files
 │   ├── viewer.css                         - viewer style sheet
 │   ├── viewer.html                        - viewer layout
-│   └── viewer.js                          - viewer layer
+│   ├── viewer.js                          - viewer layer
 │   └── viewer.js.map                      - viewer layer's source map
 └── LICENSE
 ```

--- a/docs/templates/layout.jade
+++ b/docs/templates/layout.jade
@@ -45,7 +45,7 @@ html(lang='en')
         p &copy;Mozilla and individual contributors
         :markdown-it
           PDF.js is licensed under [Apache](https://github.com/mozilla/pdf.js/blob/master/LICENSE),
-          documentation is licensed under [CC BY-SA 2.5](http://creativecommons.org/licenses/by-sa/2.5/)
+          documentation is licensed under [CC BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/)
 
     // Bootstrap core JavaScript
     script(src=makeRelative(page.url, '/js/jquery-2.1.0.min.js'))


### PR DESCRIPTION
Moreover, fix a small oversight in how the file tree is rendered.