### PR TITLE
Add support for updating the document hash, off by default, when the browser history is updated (issue 5753)

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -147,6 +147,10 @@
       "type": "boolean",
       "default": false
     },
+    "historyUpdateUrl": {
+      "type": "boolean",
+      "default": false
+    },
     "enablePrintAutoRotate": {
       "title": "Automatically rotate printed pages",
       "description": "When enabled, pages whose orientation differ from the first page are rotated when printed.",

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -112,6 +112,24 @@ const hasDOM = typeof window === 'object' && typeof document === 'object';
   };
 })();
 
+// Provides support for String.prototype.startsWith in legacy browsers.
+// Support: IE, Chrome<41
+(function checkStringStartsWith() {
+  if (String.prototype.startsWith) {
+    return;
+  }
+  require('core-js/fn/string/starts-with');
+})();
+
+// Provides support for String.prototype.endsWith in legacy browsers.
+// Support: IE, Chrome<41
+(function checkStringEndsWith() {
+  if (String.prototype.endsWith) {
+    return;
+  }
+  require('core-js/fn/string/ends-with');
+})();
+
 // Provides support for String.prototype.includes in legacy browsers.
 // Support: IE, Chrome<41
 (function checkStringIncludes() {
@@ -222,6 +240,24 @@ const hasDOM = typeof window === 'object' && typeof document === 'object';
 })();
 
 } // End of !PDFJSDev.test('CHROME')
+
+// Provides support for String.prototype.padStart in legacy browsers.
+// Support: IE, Chrome<57
+(function checkStringPadStart() {
+  if (String.prototype.padStart) {
+    return;
+  }
+  require('core-js/fn/string/pad-start');
+})();
+
+// Provides support for String.prototype.padEnd in legacy browsers.
+// Support: IE, Chrome<57
+(function checkStringPadEnd() {
+  if (String.prototype.padEnd) {
+    return;
+  }
+  require('core-js/fn/string/pad-end');
+})();
 
 // Provides support for Object.values in legacy browsers.
 // Support: IE, Chrome<54

--- a/web/app.js
+++ b/web/app.js
@@ -903,8 +903,11 @@ let PDFViewerApplication = {
       if (!AppOptions.get('disableHistory') && !this.isViewerEmbedded) {
         // The browsing history is only enabled when the viewer is standalone,
         // i.e. not when it is embedded in a web page.
-        let resetHistory = !AppOptions.get('showPreviousViewOnLoad');
-        this.pdfHistory.initialize(pdfDocument.fingerprint, resetHistory);
+        this.pdfHistory.initialize({
+          fingerprint: pdfDocument.fingerprint,
+          resetHistory: !AppOptions.get('showPreviousViewOnLoad'),
+          updateUrl: AppOptions.get('historyUpdateUrl'),
+        });
 
         if (this.pdfHistory.initialBookmark) {
           this.initialBookmark = this.pdfHistory.initialBookmark;

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -91,6 +91,11 @@ const defaultOptions = {
     value: 0,
     kind: OptionKind.VIEWER,
   },
+  historyUpdateUrl: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER,
+  },
   imageResourcesPath: {
     /** @type {string} */
     value: './images/',

--- a/web/default_preferences.json
+++ b/web/default_preferences.json
@@ -19,6 +19,7 @@
   "disableOpenActionDestination": true,
   "disablePageMode": false,
   "disablePageLabels": false,
+  "historyUpdateUrl": false,
   "scrollModeOnLoad": 0,
   "spreadModeOnLoad": 0
 }

--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -86,10 +86,9 @@ class IPDFLinkService {
  */
 class IPDFHistory {
   /**
-   * @param {string} fingerprint - The PDF document's unique fingerprint.
-   * @param {boolean} resetHistory - (optional) Reset the browsing history.
+   * @param {Object} params
    */
-  initialize(fingerprint, resetHistory = false) {}
+  initialize({ fingerprint, resetHistory = false, updateUrl = false, }) {}
 
   /**
    * @param {Object} params


### PR DESCRIPTION
This is *really* the best that we can do here, since other proposed solutions would interfere with (and break) the painstakingly implemented browsing history that's present in the default viewer.

I'm still not convinced that this is a good idea in general, but this patch implements it in a way where it is possible to toggle[1] for users that wish to have this feature. In particular, there's a couple of reasons why I'm not finding this feature necessary/great:
 - It's already possible to easily obtain the current hash, by simply clicking on the `viewBookmark` button at any time.
 - Hash changes requires a bit of special handling[2], i.e. extra code, to prevent issues when the browser history is traversed (see `PDFHistory._popState`). Currently this is only necessary when the user has manually changed the hash, with this patch it will always be the case (assuming the feature is active).
 - It's not always possible to change the URL when updating the browser history. For example: In the Firefox built-in viewer, the URL cannot be modified for local files (i.e. those using the `file://` protocol).
This leads to inconsistent behaviour, and may in some cases even result in errors being thrown and the history thus not updating, if the browser prevents changes to the URL during `pushState`/`replaceState` calls.

---
[1] Using the `historyUpdateUrl` viewer preference.

[2] This depends, to a great extent, on browsers always firing `popstate` events *before* `hashchange` events, which may or may not actually be guaranteed.