### PR TITLE
Fix of out of bounds index occuring in backtrackBeforeAllVisibleElements

### DIFF
--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -447,16 +447,17 @@ function getVisibleElements(scrollEl, views, sortByVisibility = false,
     binarySearchFirstItem(views, horizontal ? isElementRightAfterViewLeft :
                                               isElementBottomAfterViewTop);
 
-  if (views.length > 0 && firstVisibleElementInd !== views.length && !horizontal) {
-    // If there are no pages or no visible page was found (binarySearch returned
-    // length of input array), this cannot be run - index would be out of bounds.
+  if (views.length > 0 && firstVisibleElementInd !== views.length &&
+    !horizontal) {
+    // If there are no pages or no visible page was found (binarySearch
+    // returned length of input array), this cannot be run,
+    // index would be out of bounds.
 
     // In wrapped scrolling (or vertical scrolling with spreads), with some page
     // sizes, isElementBottomAfterViewTop doesn't satisfy the binary search
     // condition: there can be pages with bottoms above the view top between
     // pages with bottoms below. This function detects and corrects that error;
     // see it for more comments.
-
 
     firstVisibleElementInd =
       backtrackBeforeAllVisibleElements(firstVisibleElementInd, views, top);

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -447,12 +447,17 @@ function getVisibleElements(scrollEl, views, sortByVisibility = false,
     binarySearchFirstItem(views, horizontal ? isElementRightAfterViewLeft :
                                               isElementBottomAfterViewTop);
 
-  if (views.length > 0 && !horizontal) {
+  if (views.length > 0 && firstVisibleElementInd !== views.length && !horizontal) {
+    // If there are no pages or no visible page was found (binarySearch returned
+    // length of input array), this cannot be run - index would be out of bounds.
+
     // In wrapped scrolling (or vertical scrolling with spreads), with some page
     // sizes, isElementBottomAfterViewTop doesn't satisfy the binary search
     // condition: there can be pages with bottoms above the view top between
     // pages with bottoms below. This function detects and corrects that error;
     // see it for more comments.
+
+
     firstVisibleElementInd =
       backtrackBeforeAllVisibleElements(firstVisibleElementInd, views, top);
   }


### PR DESCRIPTION
This was recurring issue known as "cannot read div of undefined". ( #10212, #9895)

Problem was not located in backtrackBeforeAllVisibleElements function, where others tried to fix it, but it was caused by insufficient check of result from binarySearchFirstItem function in getVisibleElements function. 

As BinarySearchFirstItem function says in comment - @returns {Number} Index of the first array element to pass the test, **or |items.length|** if no such element exists. 

But backtrackBeforeAllVisibleElements requires index to be index into the given array, so this must be checked before calling backtrack function.

If binarySearch function actually returns views.length, after this fix, getVisibleElements should return {first: undefined, second:undefined, views: []}, which I think is ok, because there are actually no visible pages.