### PR TITLE
Avoid setting incorrect document URLs, in IE 11, when the browser history is updated (PR 10423 follow-up)

### DIFF
--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -306,10 +306,18 @@ class PDFHistory {
       }
     }
     if (shouldReplace) {
-      window.history.replaceState(newState, '', newUrl);
+      if (newUrl) {
+        window.history.replaceState(newState, '', newUrl);
+      } else {
+        window.history.replaceState(newState, '');
+      }
     } else {
       this._maxUid = this._uid;
-      window.history.pushState(newState, '', newUrl);
+      if (newUrl) {
+        window.history.pushState(newState, '', newUrl);
+      } else {
+        window.history.pushState(newState, '');
+      }
     }
 
     if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('CHROME') &&


### PR DESCRIPTION
Apparently in IE 11 when `history.{pushState, replaceState}` is called, there's actually a difference between not providing the *third* argument vs providing it set implicitly to `undefined`. It appears that in IE 11 it's actually being stringified, rather than ignored, which seems completely wrong (obviously other browsers aren't affected, so no surprises there).

This is yet another reason why I think the feature itself was a really bad idea, since it now requires extra/duplicated code just to prevent weird/incorrect URL behaviour in crappy browsers.

/cc @timvandermeij 