### PR TITLE
Convert some usage of `indexOf` to `startsWith`/`includes` where applicable

### DIFF
--- a/external/builder/builder.js
+++ b/external/builder/builder.js
@@ -165,8 +165,8 @@ function preprocess(inFilename, outFilename, defines) {
       if (state === STATE_NONE) {
         writeLine(line);
       } else if ((state === STATE_IF_TRUE || state === STATE_ELSE_TRUE) &&
-          stack.indexOf(STATE_IF_FALSE) === -1 &&
-          stack.indexOf(STATE_ELSE_FALSE) === -1) {
+                 !stack.includes(STATE_IF_FALSE) &&
+                 !stack.includes(STATE_ELSE_FALSE)) {
         writeLine(line.replace(/^\/\/|^<!--|-->$/g, '  '));
       }
     }
@@ -223,7 +223,7 @@ function preprocessCSS(mode, source, destination) {
           if (checkBracket) {
             if (checkBracket[1] === '{') {
               bracketLevel++;
-            } else if (lines[j].indexOf('{') < 0) {
+            } else if (!lines[j].includes('{')) {
               bracketLevel--;
             }
           }
@@ -238,7 +238,7 @@ function preprocessCSS(mode, source, destination) {
           lines.splice(i, 1);
         } while (i < lines.length &&
                  !/\}\s*$/.test(lines[i]) &&
-                 lines[i].indexOf(':') < 0);
+                 !lines[i].includes(':'));
         if (i < lines.length && /\S\s*}\s*$/.test(lines[i])) {
           lines[i] = lines[i].substring(lines[i].indexOf('}'));
         }

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -2533,13 +2533,12 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         var fontNameStr = fontName && fontName.name;
         var baseFontStr = baseFont && baseFont.name;
         if (fontNameStr !== baseFontStr) {
-          info('The FontDescriptor\'s FontName is "' + fontNameStr +
-               '" but should be the same as the Font\'s BaseFont "' +
-               baseFontStr + '"');
+          info(`The FontDescriptor\'s FontName is "${fontNameStr}" but ` +
+               `should be the same as the Font\'s BaseFont "${baseFontStr}".`);
           // Workaround for cases where e.g. fontNameStr = 'Arial' and
           // baseFontStr = 'Arial,Bold' (needed when no font file is embedded).
           if (fontNameStr && baseFontStr &&
-              baseFontStr.indexOf(fontNameStr) === 0) {
+              baseFontStr.startsWith(fontNameStr)) {
             fontName = baseFont;
           }
         }

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -1200,7 +1200,7 @@ var Font = (function FontClosure() {
       // if at least one width is present, remeasure all chars when exists
       this.remeasure = Object.keys(this.widths).length > 0;
       if (isStandardFont && type === 'CIDFontType2' &&
-          this.cidEncoding.indexOf('Identity-') === 0) {
+          this.cidEncoding.startsWith('Identity-')) {
         var GlyphMapForStandardFonts = getGlyphMapForStandardFonts();
         // Standard fonts might be embedded as CID font without glyph mapping.
         // Building one based on GlyphMapForStandardFonts.

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -701,10 +701,7 @@ class Catalog {
   static parseDestDictionary(params) {
     // Lets URLs beginning with 'www.' default to using the 'http://' protocol.
     function addDefaultProtocolToUrl(url) {
-      if (url.indexOf('www.') === 0) {
-        return `http://${url}`;
-      }
-      return url;
+      return (url.startsWith('www.') ? `http://${url}` : url);
     }
 
     // According to ISO 32000-1:2008, section 12.6.4.7, URIs should be encoded
@@ -1234,7 +1231,7 @@ var XRef = (function XRefClosure() {
         }
         var token = readToken(buffer, position);
         var m;
-        if (token.indexOf('xref') === 0 &&
+        if (token.startsWith('xref') &&
             (token.length === 4 || /\s/.test(token[4]))) {
           position += skipUntil(buffer, position, trailerBytes);
           trailers.push(position);
@@ -1288,7 +1285,7 @@ var XRef = (function XRefClosure() {
           }
 
           position += contentLength;
-        } else if (token.indexOf('trailer') === 0 &&
+        } else if (token.startsWith('trailer') &&
                    (token.length === 7 || /\s/.test(token[7]))) {
           trailers.push(position);
           position += skipUntil(buffer, position, startxrefBytes);
@@ -1507,7 +1504,7 @@ var XRef = (function XRefClosure() {
       }
       if (obj3.cmd !== 'obj') {
         // some bad PDFs use "obj1234" and really mean 1234
-        if (obj3.cmd.indexOf('obj') === 0) {
+        if (obj3.cmd.startsWith('obj')) {
           num = parseInt(obj3.cmd.substring(3), 10);
           if (!Number.isNaN(num)) {
             return num;

--- a/src/shared/fonts_utils.js
+++ b/src/shared/fonts_utils.js
@@ -253,7 +253,7 @@ var Type2Parser = function type2Parser(aFilePath) {
   var xhr = new XMLHttpRequest();
   xhr.open('GET', aFilePath, false);
   xhr.responseType = 'arraybuffer';
-  xhr.expected = (document.URL.indexOf('file:') === 0) ? 0 : 200;
+  xhr.expected = document.URL.startsWith('file:') ? 0 : 200;
   xhr.send(null);
   this.data = new Stream(xhr.response);
 

--- a/test/downloadutils.js
+++ b/test/downloadutils.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable object-shorthand, mozilla/use-includes-instead-of-indexOf */
+/* eslint-disable object-shorthand */
 
 'use strict';
 
@@ -52,7 +52,7 @@ function downloadFile(file, url, callback, redirects) {
       downloadFile(file, redirectTo, callback, (redirects || 0) + 1);
       return;
     }
-    if (response.statusCode === 404 && url.indexOf('web.archive.org') < 0) {
+    if (response.statusCode === 404 && !url.includes('web.archive.org')) {
       // trying waybackmachine
       redirectTo = 'http://web.archive.org/web/' + url;
       downloadFile(file, redirectTo, callback, (redirects || 0) + 1);
@@ -84,7 +84,7 @@ function downloadFile(file, url, callback, redirects) {
   }).on('error', function (err) {
     if (!completed) {
       if (typeof err === 'object' && err.errno === 'ENOTFOUND' &&
-          url.indexOf('web.archive.org') < 0) {
+          !url.includes('web.archive.org')) {
         // trying waybackmachine
         var redirectTo = 'http://web.archive.org/web/' + url;
         downloadFile(file, redirectTo, callback, (redirects || 0) + 1);

--- a/test/stats/statcmp.js
+++ b/test/stats/statcmp.js
@@ -1,5 +1,3 @@
-/* eslint-disable mozilla/use-includes-instead-of-indexOf */
-
 'use strict';
 
 var fs = require('fs');
@@ -67,7 +65,7 @@ function flatten(stats) {
     });
   });
   // Use only overall results if not grouped by 'stat'
-  if (options.groupBy.indexOf('stat') < 0) {
+  if (!options.groupBy.includes('stat')) {
     rows = rows.filter(function(s) {
       return s.stat === 'Overall';
     });

--- a/test/test.js
+++ b/test/test.js
@@ -320,7 +320,7 @@ function checkEq(task, results, browser, masterMode) {
       continue;
     }
     var testSnapshot = pageResults[page].snapshot;
-    if (testSnapshot && testSnapshot.indexOf('data:image/png;base64,') === 0) {
+    if (testSnapshot && testSnapshot.startsWith('data:image/png;base64,')) {
       testSnapshot = Buffer.from(testSnapshot.substring(22), 'base64');
     } else {
       console.error('Valid snapshot was not found.');

--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -162,7 +162,7 @@ describe('ui_utils', function() {
       var typedArray = new Uint8Array([1, 2, 3, 4, 5]);
       var blobUrl = createObjectURL(typedArray, 'application/pdf');
       // Sanity check to ensure that a "blob:" URL was returned.
-      expect(blobUrl.indexOf('blob:') === 0).toEqual(true);
+      expect(blobUrl.startsWith('blob:')).toEqual(true);
 
       expect(getPDFFileNameFromURL(blobUrl + '?file.pdf')).toEqual('file.pdf');
     });
@@ -173,7 +173,7 @@ describe('ui_utils', function() {
       var dataUrl = createObjectURL(typedArray, 'application/pdf',
                                     /* forceDataSchema = */ true);
       // Sanity check to ensure that a "data:" URL was returned.
-      expect(dataUrl.indexOf('data:') === 0).toEqual(true);
+      expect(dataUrl.startsWith('data:')).toEqual(true);
 
       expect(getPDFFileNameFromURL(dataUrl + '?file1.pdf')).
         toEqual('document.pdf');

--- a/test/webbrowser.js
+++ b/test/webbrowser.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable object-shorthand, mozilla/use-includes-instead-of-indexOf */
+/* eslint-disable object-shorthand */
 
 'use strict';
 
@@ -157,7 +157,7 @@ WebBrowser.prototype = {
         args: wmicPrefix.concat(['get', 'CommandLine']),
       };
       isAllKilled = function(exitCode, stdout) {
-        return stdout.indexOf(this.uniqStringId) === -1;
+        return !stdout.includes(this.uniqStringId);
       }.bind(this);
     } else {
       cmdKillAll = { file: 'pkill', args: ['-f', this.uniqStringId], };


### PR DESCRIPTION
In many cases in the code you don't actually care about the index itself, but rather just want to know if something exists in a String/Array or if a String starts in a particular way. With modern JavaScript functionality, it's thus possible to remove a number of existing `indexOf` cases.