### PR TITLE
[Regression] Fix the `FontInspector` in the PDFBug debugging tools

### DIFF
--- a/web/debugger.js
+++ b/web/debugger.js
@@ -21,30 +21,26 @@ var FontInspector = (function FontInspectorClosure() {
   var active = false;
   var fontAttribute = 'data-font-name';
   function removeSelection() {
-    var divs = document.querySelectorAll('div[' + fontAttribute + ']');
-    for (var i = 0, ii = divs.length; i < ii; ++i) {
-      var div = divs[i];
+    let divs = document.querySelectorAll(`span[${fontAttribute}]`);
+    for (let div of divs) {
       div.className = '';
     }
   }
   function resetSelection() {
-    var divs = document.querySelectorAll('div[' + fontAttribute + ']');
-    for (var i = 0, ii = divs.length; i < ii; ++i) {
-      var div = divs[i];
+    let divs = document.querySelectorAll(`span[${fontAttribute}]`);
+    for (let div of divs) {
       div.className = 'debuggerHideText';
     }
   }
   function selectFont(fontName, show) {
-    var divs = document.querySelectorAll('div[' + fontAttribute + '=' +
-                                         fontName + ']');
-    for (var i = 0, ii = divs.length; i < ii; ++i) {
-      var div = divs[i];
+    let divs = document.querySelectorAll(`span[${fontAttribute}=${fontName}]`);
+    for (let div of divs) {
       div.className = show ? 'debuggerShowText' : 'debuggerHideText';
     }
   }
   function textLayerClick(e) {
     if (!e.target.dataset.fontName ||
-        e.target.tagName.toUpperCase() !== 'DIV') {
+        e.target.tagName.toUpperCase() !== 'SPAN') {
       return;
     }
     var fontName = e.target.dataset.fontName;


### PR DESCRIPTION
The `FontInspector` was completely broken by PR 10197, and trying to select a particular font (using the checkboxes) or clicking on a piece of text currently does nothing.