### PR TITLE
Move more code/methods into `BaseViewer`, and simplify the `PDFSinglePageViewer._scrollIntoView` method slightly

### DIFF
--- a/web/pdf_single_page_viewer.js
+++ b/web/pdf_single_page_viewer.js
@@ -39,6 +39,7 @@ class PDFSinglePageViewer extends BaseViewer {
     super._resetView();
     this._previousPageNumber = 1;
     this._shadowViewer = document.createDocumentFragment();
+    this._updateScrollDown = null;
   }
 
   _ensurePageViewVisible() {
@@ -82,9 +83,12 @@ class PDFSinglePageViewer extends BaseViewer {
     if (pageNumber) { // Ensure that `this._currentPageNumber` is correct.
       this._setCurrentPageNumber(pageNumber);
     }
-    let scrolledDown = this._currentPageNumber >= this._previousPageNumber;
-    let previousLocation = this._location;
+    const scrolledDown = this._currentPageNumber >= this._previousPageNumber;
+
     this._ensurePageViewVisible();
+    // Ensure that rendering always occurs, to avoid showing a blank page,
+    // even if the current position doesn't change when the page is scrolled.
+    this.update();
 
     super._scrollIntoView({ pageDiv, pageSpot, pageNumber, });
 
@@ -92,18 +96,8 @@ class PDFSinglePageViewer extends BaseViewer {
     // scroll direction during the next `this._scrollUpdate` invocation.
     this._updateScrollDown = () => {
       this.scroll.down = scrolledDown;
-      delete this._updateScrollDown;
+      this._updateScrollDown = null;
     };
-    // If the scroll position doesn't change as a result of the `scrollIntoView`
-    // call, ensure that rendering always occurs to avoid showing a blank page.
-    setTimeout(() => {
-      if (this._location === previousLocation) {
-        if (this._updateScrollDown) {
-          this._updateScrollDown();
-        }
-        this.update();
-      }
-    }, 0);
   }
 
   _getVisiblePages() {

--- a/web/pdf_single_page_viewer.js
+++ b/web/pdf_single_page_viewer.js
@@ -14,7 +14,6 @@
  */
 
 import { BaseViewer } from './base_viewer';
-import { scrollIntoView } from './ui_utils';
 import { shadow } from 'pdfjs-lib';
 
 class PDFSinglePageViewer extends BaseViewer {
@@ -87,7 +86,7 @@ class PDFSinglePageViewer extends BaseViewer {
     let previousLocation = this._location;
     this._ensurePageViewVisible();
 
-    scrollIntoView(pageDiv, pageSpot);
+    super._scrollIntoView({ pageDiv, pageSpot, pageNumber, });
 
     // Since scrolling is tracked using `requestAnimationFrame`, update the
     // scroll direction during the next `this._scrollUpdate` invocation.


### PR DESCRIPTION
 1. Move additional code/methods into `BaseViewer` and have the extending classes override/extend methods as necessary

    This attempts to provide more "default" methods in the base class, in order to reduce unnecessary duplication and to improve self-documentation of the `BaseViewer` class slightly.
The following changes are made (in no particular order):
    - Have `BaseViewer` implement the `_scrollIntoView` method, and *extend* it as necessary in `PDFViewer`/`PDFSinglePageViewer`.
    - Simply inline the `BaseViewer._resizeBuffer` method, in `BaseViewer.update`, since there's only one call-site at this point.
    - Provide a default implementation of `_isScrollModeHorizontal` in `BaseViewer`, and have `PDFSinglePageViewer` override it.
    - Provide a default implementation of `_getVisiblePages`, and have `PDFViewer` extend it and `PDFSinglePageViewer` override it.

2. Try to simplify the `PDFSinglePageViewer._scrollIntoView` method slightly, by unconditionally ensuring that rendering always occurs