### PR TITLE
Ensure that `XRef.indexObjects` can handle object numbers with zero-padding (issue 10491)

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -1237,10 +1237,11 @@ var XRef = (function XRefClosure() {
           trailers.push(position);
           position += skipUntil(buffer, position, startxrefBytes);
         } else if ((m = objRegExp.exec(token))) {
-          if (typeof this.entries[m[1]] === 'undefined') {
-            this.entries[m[1]] = {
+          const num = m[1] | 0, gen = m[2] | 0;
+          if (typeof this.entries[num] === 'undefined') {
+            this.entries[num] = {
               offset: position - stream.start,
-              gen: m[2] | 0,
+              gen,
               uncompressed: true,
             };
           }

--- a/test/pdfs/issue10491.pdf.link
+++ b/test/pdfs/issue10491.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/2793574/14_09_02.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -840,6 +840,14 @@
        "link": false,
        "type": "eq"
     },
+    {  "id": "issue10491",
+       "file": "pdfs/issue10491.pdf",
+       "md5": "0759ec46739b13bb0b66170a18d33d4f",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 2,
+       "type": "eq"
+    },
     {  "id": "issue6289",
        "file": "pdfs/issue6289.pdf",
        "md5": "0869f3d147c734ec484ffd492104095d",


### PR DESCRIPTION
All objects in the PDF document follow this pattern:
```
0000000001 0 obj
<<
% Some content here...
>>
endobj
0000000002 0 obj
<<
% More content here...
endobj

```

Fixes #10491.