### PR TITLE
Reduce unnecessary duplication of the `isDefaultDecode` methods on `ColorSpace` instances

### DIFF
--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -110,6 +110,13 @@ class ColorSpace {
   }
 
   /**
+   * Refer to the static `ColorSpace.isDefaultDecode` method below.
+   */
+  isDefaultDecode(decodeMap, bpc) {
+    return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
+  }
+
+  /**
    * Fills in the RGB colors in the destination buffer.  alpha01 indicates
    * how many alpha components there are in the dest array; it will be either
    * 0 (RGB array) or 1 (RGBA array).
@@ -379,18 +386,17 @@ class ColorSpace {
   /**
    * Checks if a decode map matches the default decode map for a color space.
    * This handles the general decode maps where there are two values per
-   * component. e.g. [0, 1, 0, 1, 0, 1] for a RGB color.
+   * component, e.g. [0, 1, 0, 1, 0, 1] for a RGB color.
    * This does not handle Lab, Indexed, or Pattern decode maps since they are
    * slightly different.
-   * @param {Array} decode Decode map (usually from an image).
-   * @param {Number} n Number of components the color space has.
+   * @param {Array} decode - Decode map (usually from an image).
+   * @param {Number} numComps - Number of components the color space has.
    */
-  static isDefaultDecode(decode, n) {
+  static isDefaultDecode(decode, numComps) {
     if (!Array.isArray(decode)) {
       return true;
     }
-
-    if (n * 2 !== decode.length) {
+    if (numComps * 2 !== decode.length) {
       warn('The decode map is not the correct length');
       return true;
     }
@@ -491,16 +497,16 @@ class AlternateCS extends ColorSpace {
                                      this.base.numComps / this.numComps,
                                      alpha01);
   }
-
-  isDefaultDecode(decodeMap, bpc) {
-    return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
-  }
 }
 
 class PatternCS extends ColorSpace {
   constructor(baseCS) {
     super('Pattern', null);
     this.base = baseCS;
+  }
+
+  isDefaultDecode(decodeMap, bpc) {
+    unreachable('Should not call PatternCS.isDefaultDecode');
   }
 }
 
@@ -619,10 +625,6 @@ class DeviceGrayCS extends ColorSpace {
   getOutputLength(inputLength, alpha01) {
     return inputLength * (3 + alpha01);
   }
-
-  isDefaultDecode(decodeMap, bpc) {
-    return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
-  }
 }
 
 /**
@@ -670,10 +672,6 @@ class DeviceRgbCS extends ColorSpace {
 
   isPassthrough(bits) {
     return bits === 8;
-  }
-
-  isDefaultDecode(decodeMap, bpc) {
-    return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
   }
 }
 
@@ -753,10 +751,6 @@ const DeviceCmykCS = (function DeviceCmykCSClosure() {
 
     getOutputLength(inputLength, alpha01) {
       return (inputLength / 4 * (3 + alpha01)) | 0;
-    }
-
-    isDefaultDecode(decodeMap, bpc) {
-      return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     }
   }
   return DeviceCmykCS;
@@ -856,10 +850,6 @@ const CalGrayCS = (function CalGrayCSClosure() {
 
     getOutputLength(inputLength, alpha01) {
       return inputLength * (3 + alpha01);
-    }
-
-    isDefaultDecode(decodeMap, bpc) {
-      return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     }
   }
   return CalGrayCS;
@@ -1138,10 +1128,6 @@ const CalRGBCS = (function CalRGBCSClosure() {
 
     getOutputLength(inputLength, alpha01) {
       return (inputLength * (3 + alpha01) / 3) | 0;
-    }
-
-    isDefaultDecode(decodeMap, bpc) {
-      return ColorSpace.isDefaultDecode(decodeMap, this.numComps);
     }
   }
   return CalRGBCS;

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -171,7 +171,8 @@ var PDFImage = (function PDFImageClosure() {
     if (this.decode &&
         ((this.colorSpace &&
           !this.colorSpace.isDefaultDecode(this.decode, bitsPerComponent)) ||
-         (isMask && !ColorSpace.isDefaultDecode(this.decode, 1)))) {
+         (isMask &&
+          !ColorSpace.isDefaultDecode(this.decode, /* numComps = */ 1)))) {
       this.needsDecode = true;
       // Do some preprocessing to avoid more math.
       var max = (1 << bitsPerComponent) - 1;


### PR DESCRIPTION
The recent PR 10482 made me realize that I missed an opportunity for simplification when doing the class conversion of this code in PR #10007.