### PR TITLE
Attempt to clean-up/restore pending rendering operations when errors occurs while a `RenderTask` runs (PR 10202 follow-up)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2434,7 +2434,7 @@ const InternalRenderTask = (function InternalRenderTaskClosure() {
       }
     }
 
-    cancel() {
+    cancel(error = null) {
       this.running = false;
       this.cancelled = true;
       if (this.gfx) {
@@ -2443,8 +2443,8 @@ const InternalRenderTask = (function InternalRenderTaskClosure() {
       if (this._canvas) {
         canvasInRendering.delete(this._canvas);
       }
-      this.callback(new RenderingCancelledException(
-        'Rendering cancelled, page ' + this.pageNumber, 'canvas'));
+      this.callback(error || new RenderingCancelledException(
+        `Rendering cancelled, page ${this.pageNumber}`, 'canvas'));
     }
 
     operatorListChanged() {
@@ -2480,10 +2480,10 @@ const InternalRenderTask = (function InternalRenderTaskClosure() {
     _scheduleNext() {
       if (this._useRequestAnimationFrame) {
         window.requestAnimationFrame(() => {
-          this._nextBound().catch(this.callback);
+          this._nextBound().catch(this.cancel.bind(this));
         });
       } else {
-        Promise.resolve().then(this._nextBound).catch(this.callback);
+        Promise.resolve().then(this._nextBound).catch(this.cancel.bind(this));
       }
     }
 

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -432,7 +432,7 @@ class PDFPageView {
       };
     }
 
-    let finishPaintTask = (error) => {
+    const finishPaintTask = async (error) => {
       // The paintTask may have been replaced by a new one, so only remove
       // the reference to the paintTask if it matches the one that is
       // triggering this callback.
@@ -442,7 +442,7 @@ class PDFPageView {
 
       if (error instanceof RenderingCancelledException) {
         this.error = null;
-        return Promise.resolve(undefined);
+        return;
       }
 
       this.renderingState = RenderingStates.FINISHED;
@@ -465,9 +465,8 @@ class PDFPageView {
       });
 
       if (error) {
-        return Promise.reject(error);
+        throw error;
       }
-      return Promise.resolve(undefined);
     };
 
     let paintTask = this.renderer === RendererType.SVG ?


### PR DESCRIPTION
This piggybacks of the existing `cancel` functionality, to ensure that any pending operations are closed *and* that any temporary canvases are actually being removed.

Also simplifies `finishPaintTask` in `PDFPageView.draw` slightly, by converting it to an async function.