### PR TITLE
In `getVisibleElements`, check `firstVisibleElementInd` rather than `numViews` before backtracking (PR 10443 follow-up)

### DIFF
--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -446,7 +446,8 @@ function getVisibleElements(scrollEl, views, sortByVisibility = false,
 
   // Please note the return value of the `binarySearchFirstItem` function when
   // no valid element is found (hence the `firstVisibleElementInd` check below).
-  if (numViews > 0 && firstVisibleElementInd < numViews && !horizontal) {
+  if (firstVisibleElementInd > 0 && firstVisibleElementInd < numViews &&
+      !horizontal) {
     // In wrapped scrolling (or vertical scrolling with spreads), with some page
     // sizes, isElementBottomAfterViewTop doesn't satisfy the binary search
     // condition: there can be pages with bottoms above the view top between


### PR DESCRIPTION
When `firstVisibleElementInd === 0`, regardless of the number of views, there's no reason to attempt to backtrack at all since it's never possible to find an element before the *first* one anyway.