### PR TITLE
Modify a number of the viewer preferences, whose current default value is `0`, such that they behave as expected with the view history

### DIFF
--- a/extensions/chromium/options/migration.js
+++ b/extensions/chromium/options/migration.js
@@ -81,6 +81,9 @@ limitations under the License.
       'disableTextLayer',
       'enhanceTextSelection',
       'textLayerMode',
+      'showPreviousViewOnLoad',
+      'disablePageMode',
+      'viewOnLoad',
     ], function(items) {
       // Migration code for https://github.com/mozilla/pdf.js/pull/7635.
       if (typeof items.enableHandToolOnLoad === 'boolean') {
@@ -111,6 +114,20 @@ limitations under the License.
           });
         } else {
           storageSync.remove(['disableTextLayer', 'enhanceTextSelection']);
+        }
+      }
+      // Migration code for https://github.com/mozilla/pdf.js/pull/10502.
+      if (typeof items.showPreviousViewOnLoad === 'boolean') {
+        if (!items.showPreviousViewOnLoad) {
+          storageSync.set({
+            viewOnLoad: 1,
+          }, function() {
+            if (!chrome.runtime.lastError) {
+              storageSync.remove(['showPreviousViewOnLoad', 'disablePageMode']);
+            }
+          });
+        } else {
+          storageSync.remove(['showPreviousViewOnLoad', 'disablePageMode']);
         }
       }
     });

--- a/extensions/chromium/options/options.html
+++ b/extensions/chromium/options/options.html
@@ -43,6 +43,19 @@ body {
 </div>
 </template>
 
+<template id="viewOnLoad-template">
+<div class="settings-row">
+  <label>
+    <span></span>
+    <select>
+      <option value="-1">Default</option>
+      <option value="0">Show previous position</option>
+      <option value="1">Show initial position</option>
+    </select>
+  </label>
+</div>
+</template>
+
 <template id="defaultZoomValue-template">
 <div class="settings-row">
   <label>
@@ -71,6 +84,7 @@ body {
   <label>
     <span></span>
     <select>
+      <option value="-1">Default</option>
       <option value="0">Do not show sidebar</option>
       <option value="1">Show thumbnails in sidebar</option>
       <option value="2">Show document outline in sidebar</option>
@@ -125,6 +139,7 @@ body {
   <label>
     <span></span>
     <select>
+      <option value="-1">Default</option>
       <option value="0">Vertical scrolling</option>
       <option value="1">Horizontal scrolling</option>
       <option value="2">Wrapped scrolling</option>
@@ -138,6 +153,7 @@ body {
   <label>
     <span></span>
     <select>
+      <option value="-1">Default</option>
       <option value="0">No spreads</option>
       <option value="1">Odd spreads</option>
       <option value="2">Even spreads</option>

--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -2,10 +2,19 @@
   "type": "object",
   "properties": {
     "showPreviousViewOnLoad": {
-      "title": "Show previous position of PDF upon load",
-      "description": "Whether to view PDF documents in the last page and position upon opening the viewer.",
+      "description": "DEPRECATED. Set viewOnLoad to 1 to disable showing the last page/position on load.",
       "type": "boolean",
       "default": true
+    },
+    "viewOnLoad": {
+      "title": "View position on load",
+      "description": "The position in the document upon load.\n -1 = Default (uses OpenAction if available, otherwise equal to `viewOnLoad = 0`).\n 0 = The last viewed page/position.\n 1 = The initial page/position.",
+      "enum": [
+        -1,
+        0,
+        1
+      ],
+      "default": 0
     },
     "defaultZoomValue": {
       "title": "Default zoom level",
@@ -16,15 +25,16 @@
     },
     "sidebarViewOnLoad": {
       "title": "Sidebar state on load",
-      "description": "Controls the state of the sidebar upon load.\n 0 = do not show sidebar.\n 1 = show thumbnails in sidebar.\n 2 = show document outline in sidebar.\n 3 = Show attachments in sidebar.",
+      "description": "Controls the state of the sidebar upon load.\n -1 = Default (uses PageMode if available, otherwise the last position if available/enabled).\n 0 = Do not show sidebar.\n 1 = Show thumbnails in sidebar.\n 2 = Show document outline in sidebar.\n 3 = Show attachments in sidebar.",
       "type": "integer",
       "enum": [
+        -1,
         0,
         1,
         2,
         3
       ],
-      "default": 0
+      "default": -1
     },
     "enableHandToolOnLoad": {
       "description": "DEPRECATED. Set cursorToolOnLoad to 1 to enable the hand tool by default.",
@@ -117,15 +127,12 @@
       ],
       "default": 0
     },
-    "disableOpenActionDestination": {
-      "type": "boolean",
-      "default": true
-    },
     "disablePageLabels": {
       "type": "boolean",
       "default": false
     },
     "disablePageMode": {
+      "description": "DEPRECATED.",
       "type": "boolean",
       "default": false
     },
@@ -159,25 +166,27 @@
     },
     "scrollModeOnLoad": {
       "title": "Scroll mode on load",
-      "description": "Controls how the viewer scrolls upon load.\n 0 = Vertical scrolling.\n 1 = Horizontal scrolling.\n 2 = Wrapped scrolling.",
+      "description": "Controls how the viewer scrolls upon load.\n -1 = Default (uses the last position if available/enabled).\n 0 = Vertical scrolling.\n 1 = Horizontal scrolling.\n 2 = Wrapped scrolling.",
       "type": "integer",
       "enum": [
+        -1,
         0,
         1,
         2
       ],
-      "default": 0
+      "default": -1
     },
     "spreadModeOnLoad": {
       "title": "Spread mode on load",
-      "description": "Whether the viewer should join pages into spreads upon load.\n 0 = No spreads.\n 1 = Odd spreads.\n 2 = Even spreads.",
+      "description": "Whether the viewer should join pages into spreads upon load.\n -1 = Default (uses the last position if available/enabled).\n 0 = No spreads.\n 1 = Odd spreads.\n 2 = Even spreads.",
       "type": "integer",
       "enum": [
+        -1,
         0,
         1,
         2
       ],
-      "default": 0
+      "default": -1
     }
   }
 }

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -48,17 +48,7 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.VIEWER,
   },
-  disableOpenActionDestination: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.VIEWER,
-  },
   disablePageLabels: {
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.VIEWER,
-  },
-  disablePageMode: {
     /** @type {boolean} */
     value: false,
     kind: OptionKind.VIEWER,
@@ -124,24 +114,19 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.VIEWER,
   },
-  showPreviousViewOnLoad: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.VIEWER,
-  },
   sidebarViewOnLoad: {
     /** @type {number} */
-    value: 0,
+    value: -1,
     kind: OptionKind.VIEWER,
   },
   scrollModeOnLoad: {
     /** @type {number} */
-    value: 0,
+    value: -1,
     kind: OptionKind.VIEWER,
   },
   spreadModeOnLoad: {
     /** @type {number} */
-    value: 0,
+    value: -1,
     kind: OptionKind.VIEWER,
   },
   textLayerMode: {
@@ -152,6 +137,11 @@ const defaultOptions = {
   useOnlyCssZoom: {
     /** @type {boolean} */
     value: false,
+    kind: OptionKind.VIEWER,
+  },
+  viewOnLoad: {
+    /** @type {boolean} */
+    value: 0,
     kind: OptionKind.VIEWER,
   },
 

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -96,7 +96,8 @@ const defaultOptions = {
    */
   maxCanvasPixels: {
     /** @type {number} */
-    value: viewerCompatibilityParams.maxCanvasPixels || 16777216,
+    value: 16777216,
+    compatibility: viewerCompatibilityParams.maxCanvasPixels,
     kind: OptionKind.VIEWER,
   },
   pdfBugEnabled: {
@@ -163,7 +164,8 @@ const defaultOptions = {
   },
   disableCreateObjectURL: {
     /** @type {boolean} */
-    value: apiCompatibilityParams.disableCreateObjectURL || false,
+    value: false,
+    compatibility: apiCompatibilityParams.disableCreateObjectURL,
     kind: OptionKind.API,
   },
   disableFontFace: {
@@ -241,22 +243,27 @@ class AppOptions {
   }
 
   static get(name) {
-    let defaultOption = defaultOptions[name], userOption = userOptions[name];
+    const userOption = userOptions[name];
     if (userOption !== undefined) {
       return userOption;
     }
-    return (defaultOption !== undefined ? defaultOption.value : undefined);
+    const defaultOption = defaultOptions[name];
+    if (defaultOption !== undefined) {
+      return (defaultOption.compatibility || defaultOption.value);
+    }
+    return undefined;
   }
 
   static getAll(kind = null) {
-    let options = Object.create(null);
-    for (let name in defaultOptions) {
-      let defaultOption = defaultOptions[name], userOption = userOptions[name];
-      if (kind && defaultOption.kind !== kind) {
+    const options = Object.create(null);
+    for (const name in defaultOptions) {
+      const defaultOption = defaultOptions[name];
+      if (kind && kind !== defaultOption.kind) {
         continue;
       }
-      options[name] = (userOption !== undefined ?
-                       userOption : defaultOption.value);
+      const userOption = userOptions[name];
+      options[name] = (userOption !== undefined ? userOption :
+                       (defaultOption.compatibility || defaultOption.value));
     }
     return options;
   }

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -15,10 +15,11 @@
 
 import {
   CSS_UNITS, DEFAULT_SCALE, DEFAULT_SCALE_VALUE, getGlobalEventBus,
-  getVisibleElements, isPortraitOrientation, isValidRotation, MAX_AUTO_SCALE,
-  moveToEndOfArray, NullL10n, PresentationModeState, RendererType,
-  SCROLLBAR_PADDING, scrollIntoView, TextLayerMode, UNKNOWN_SCALE,
-  VERTICAL_PADDING, watchScroll
+  getVisibleElements, isPortraitOrientation, isValidRotation, isValidScrollMode,
+  isValidSpreadMode, MAX_AUTO_SCALE, moveToEndOfArray, NullL10n,
+  PresentationModeState, RendererType, SCROLLBAR_PADDING, scrollIntoView,
+  ScrollMode, SpreadMode, TextLayerMode, UNKNOWN_SCALE, VERTICAL_PADDING,
+  watchScroll
 } from './ui_utils';
 import { PDFRenderingQueue, RenderingStates } from './pdf_rendering_queue';
 import { AnnotationLayerBuilder } from './annotation_layer_builder';
@@ -28,18 +29,6 @@ import { SimpleLinkService } from './pdf_link_service';
 import { TextLayerBuilder } from './text_layer_builder';
 
 const DEFAULT_CACHE_SIZE = 10;
-
-const ScrollMode = {
-  VERTICAL: 0, // The default value.
-  HORIZONTAL: 1,
-  WRAPPED: 2,
-};
-
-const SpreadMode = {
-  NONE: 0, // The default value.
-  ODD: 1,
-  EVEN: 2,
-};
 
 /**
  * @typedef {Object} PDFViewerOptions
@@ -1086,7 +1075,7 @@ class BaseViewer {
     if (this._scrollMode === mode) {
       return; // The Scroll mode didn't change.
     }
-    if (!Number.isInteger(mode) || !Object.values(ScrollMode).includes(mode)) {
+    if (!isValidScrollMode(mode)) {
       throw new Error(`Invalid scroll mode: ${mode}`);
     }
     this._scrollMode = mode;
@@ -1132,7 +1121,7 @@ class BaseViewer {
     if (this._spreadMode === mode) {
       return; // The Spread mode didn't change.
     }
-    if (!Number.isInteger(mode) || !Object.values(SpreadMode).includes(mode)) {
+    if (!isValidSpreadMode(mode)) {
       throw new Error(`Invalid spread mode: ${mode}`);
     }
     this._spreadMode = mode;
@@ -1179,6 +1168,4 @@ class BaseViewer {
 
 export {
   BaseViewer,
-  ScrollMode,
-  SpreadMode,
 };

--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -341,6 +341,8 @@ class ChromePreferences extends BasePreferences {
           enableHandToolOnLoad: false,
           disableTextLayer: false,
           enhanceTextSelection: false,
+          showPreviousViewOnLoad: true,
+          disablePageMode: false,
         }, this.defaults);
 
         chrome.storage.managed.get(defaultManagedPrefs, function(items) {
@@ -369,6 +371,13 @@ class ChromePreferences extends BasePreferences {
           }
           delete items.disableTextLayer;
           delete items.enhanceTextSelection;
+
+          // Migration code for https://github.com/mozilla/pdf.js/pull/10502.
+          if (!items.showPreviousViewOnLoad && !items.viewOnLoad) {
+            items.viewOnLoad = 1;
+          }
+          delete items.showPreviousViewOnLoad;
+          delete items.disablePageMode;
 
           getPreferences(items);
         });

--- a/web/default_preferences.json
+++ b/web/default_preferences.json
@@ -1,7 +1,7 @@
 {
-  "showPreviousViewOnLoad": true,
+  "viewOnLoad": 0,
   "defaultZoomValue": "",
-  "sidebarViewOnLoad": 0,
+  "sidebarViewOnLoad": -1,
   "cursorToolOnLoad": 0,
   "enableWebGL": false,
   "eventBusDispatchToDOM": false,
@@ -16,10 +16,8 @@
   "renderer": "canvas",
   "renderInteractiveForms": false,
   "enablePrintAutoRotate": false,
-  "disableOpenActionDestination": true,
-  "disablePageMode": false,
   "disablePageLabels": false,
   "historyUpdateUrl": false,
-  "scrollModeOnLoad": 0,
-  "spreadModeOnLoad": 0
+  "scrollModeOnLoad": -1,
+  "spreadModeOnLoad": -1
 }

--- a/web/pdf_sidebar.js
+++ b/web/pdf_sidebar.js
@@ -19,10 +19,12 @@ import { RenderingStates } from './pdf_rendering_queue';
 const UI_NOTIFICATION_CLASS = 'pdfSidebarNotification';
 
 const SidebarView = {
+  UNKNOWN: -1,
   NONE: 0,
-  THUMBS: 1,
+  THUMBS: 1, // Default value.
   OUTLINE: 2,
   ATTACHMENTS: 3,
+  LAYERS: 4,
 };
 
 /**
@@ -131,8 +133,8 @@ class PDFSidebar {
     this.isInitialViewSet = true;
 
     // If the user has already manually opened the sidebar, immediately closing
-    // it would be bad UX.
-    if (view === SidebarView.NONE) {
+    // it would be bad UX; also ignore the "unknown" sidebar view value.
+    if (view === SidebarView.NONE || view === SidebarView.UNKNOWN) {
       this._dispatchEvent();
       return;
     }

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -13,10 +13,9 @@
  * limitations under the License.
  */
 
-import { ScrollMode, SpreadMode } from './base_viewer';
+import { SCROLLBAR_PADDING, ScrollMode, SpreadMode } from './ui_utils';
 import { CursorTool } from './pdf_cursor_tools';
 import { PDFSinglePageViewer } from './pdf_single_page_viewer';
-import { SCROLLBAR_PADDING } from './ui_utils';
 
 /**
  * @typedef {Object} SecondaryToolbarOptions

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -41,6 +41,20 @@ const TextLayerMode = {
   ENABLE_ENHANCE: 2,
 };
 
+const ScrollMode = {
+  UNKNOWN: -1,
+  VERTICAL: 0, // Default value.
+  HORIZONTAL: 1,
+  WRAPPED: 2,
+};
+
+const SpreadMode = {
+  UNKNOWN: -1,
+  NONE: 0, // Default value.
+  ODD: 1,
+  EVEN: 2,
+};
+
 // Replaces {{arguments}} with their values.
 function formatL10nValue(text, args) {
   if (!args) {
@@ -602,6 +616,16 @@ function isValidRotation(angle) {
   return Number.isInteger(angle) && angle % 90 === 0;
 }
 
+function isValidScrollMode(mode) {
+  return (Number.isInteger(mode) && Object.values(ScrollMode).includes(mode) &&
+          mode !== ScrollMode.UNKNOWN);
+}
+
+function isValidSpreadMode(mode) {
+  return (Number.isInteger(mode) && Object.values(SpreadMode).includes(mode) &&
+          mode !== SpreadMode.UNKNOWN);
+}
+
 function isPortraitOrientation(size) {
   return size.width <= size.height;
 }
@@ -863,10 +887,14 @@ export {
   SCROLLBAR_PADDING,
   VERTICAL_PADDING,
   isValidRotation,
+  isValidScrollMode,
+  isValidSpreadMode,
   isPortraitOrientation,
   PresentationModeState,
   RendererType,
   TextLayerMode,
+  ScrollMode,
+  SpreadMode,
   NullL10n,
   EventBus,
   getGlobalEventBus,


### PR DESCRIPTION
The intention with preferences such as `sidebarViewOnLoad`/`scrollModeOnLoad`/`spreadModeOnLoad` was always that they should be able to *unconditionally* override their view history counterparts.
Due to the way that these preferences were initially implemented[1], trying to e.g. force the sidebar to remain hidden on load cannot be guaranteed[2]. The reason for this is the use of "enumeration values" containing zero, which in hindsight was an unfortunate choice on my part.
At this point it's also not as simple as just re-numbering the affected structures, since that would wreak havoc on existing (modified) preferences. The only reasonable solution that I was able to come up with was to change the *default* values of the preferences themselves, but not their actual values or the meaning thereof.

As part of the refactoring, the `disablePageMode` preference was combined with the *adjusted* `sidebarViewOnLoad` one, to hopefully reduce confusion by not tracking related state separately.

Additionally, the `showPreviousViewOnLoad` and `disableOpenActionDestination` preferences were combined into a *new* `viewOnLoad` enumeration preference, to further avoid tracking related state separately.

---
[1] This is mostly *my* fault, since I wrote the initial implementation which has then been used as a template when additional preferences were added.
I've been aware of these problems for quite a while now, and seing issue #10335 provided the final impetus needed to actually try and fix this.

[2] Given that a `ViewHistory` value may easily override the relevant `Preference` value.