### PR TITLE
Do the final text scaling correctly in `flushTextContentItem` (issue 8276)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1332,7 +1332,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
             fontFamily: font.fallbackName,
             ascent: font.ascent,
             descent: font.descent,
-            vertical: font.vertical,
+            vertical: !!font.vertical,
           };
         }
         textContentItem.fontName = font.loadedName;
@@ -1508,9 +1508,12 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           return;
         }
 
-        // Do final text scaling
-        textContentItem.width *= textContentItem.textAdvanceScale;
-        textContentItem.height *= textContentItem.textAdvanceScale;
+        // Do final text scaling.
+        if (!textContentItem.vertical) {
+          textContentItem.width *= textContentItem.textAdvanceScale;
+        } else {
+          textContentItem.height *= textContentItem.textAdvanceScale;
+        }
         textContent.items.push(runBidiTransform(textContentItem));
 
         textContentItem.initialized = false;

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -54,6 +54,7 @@
 !issue8088.pdf
 !issue8125.pdf
 !issue8229.pdf
+!issue8276_reduced.pdf
 !issue8372.pdf
 !issue8424.pdf
 !issue8480.pdf

--- a/test/pdfs/issue8276_reduced.pdf
+++ b/test/pdfs/issue8276_reduced.pdf
@@ -1,0 +1,70 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/Pages 2 0 R
+/Type /Catalog
+>>
+endobj 
+2 0 obj 
+<<
+/Kids [3 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+3 0 obj 
+<<
+/Parent 2 0 R
+/MediaBox [0 0 594.000000 840.239990]
+/Resources 
+<<
+/Font 
+<<
+/F1 4 0 R
+>>
+>>
+/Contents 5 0 R
+/Type /Page
+>>
+endobj 
+4 0 obj 
+<<
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/Type /Font
+>>
+endobj 
+5 0 obj 
+<<
+/Length 76
+>>
+stream
+q
+0.03 0 0 0.03 0 0 cm
+BT
+/F1 600.00 Tf
+14727 23615 TD
+(Issue 8276) Tj
+ET
+Q
+
+endstream 
+endobj xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000066 00000 n 
+0000000125 00000 n 
+0000000269 00000 n 
+0000000370 00000 n 
+trailer
+
+<<
+/Root 1 0 R
+/Size 6
+>>
+startxref
+498
+%%EOF

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1174,6 +1174,39 @@ describe('api', function() {
         done();
       }).catch(done.fail);
     });
+
+    it('gets text content, with correct properties (issue 8276)',
+        function(done) {
+      const loadingTask = getDocument(
+        buildGetDocumentParams('issue8276_reduced.pdf'));
+
+      loadingTask.promise.then((pdfDoc) => {
+        pdfDoc.getPage(1).then((pdfPage) => {
+          pdfPage.getTextContent().then(({ items, styles, }) => {
+            expect(items.length).toEqual(1);
+            expect(Object.keys(styles)).toEqual(['Times']);
+
+            expect(items[0]).toEqual({
+              dir: 'ltr',
+              fontName: 'Times',
+              height: 18,
+              str: 'Issue 8276',
+              transform: [18, 0, 0, 18, 441.81, 708.4499999999999],
+              width: 77.49,
+            });
+            expect(styles.Times).toEqual({
+              fontFamily: 'serif',
+              ascent: NaN,
+              descent: NaN,
+              vertical: false,
+            });
+
+            loadingTask.destroy().then(done);
+          });
+        });
+      }).catch(done.fail);
+    });
+
     it('gets operator list', function(done) {
       var promise = page.getOperatorList();
       promise.then(function (oplist) {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1224,11 +1224,12 @@ describe('api', function() {
           pdfPage.getOperatorList().then((opList) => {
             let imgIndex = opList.fnArray.indexOf(OPS.paintImageXObject);
             let imgArgs = opList.argsArray[imgIndex];
-            let { data: imgData, } = pdfPage.objs.get(imgArgs[0]);
+            let { data, } = pdfPage.objs.get(imgArgs[0]);
 
-            expect(imgData instanceof Uint8ClampedArray).toEqual(true);
-            expect(imgData.length).toEqual(90000);
-            done();
+            expect(data instanceof Uint8ClampedArray).toEqual(true);
+            expect(data.length).toEqual(90000);
+
+            loadingTask.destroy().then(done);
           });
         });
       }).catch(done.fail);


### PR DESCRIPTION
It's necessary to take into account whether or not the text is vertical, to avoid either the textContent `width` or `height` becoming incorrect.

Fixes #8276; and subsumes PR #10456.

---

The other PR caused regressions (as I feared based on looking at its code), which suggests that it wasn't properly tested during development. Furthermore, the PR didn't include *any* kind of test which is necessary to prevent this from regressing yet again (since the existing tests didn't catch it previously).
Finally, after the PR was opened there hasn't been *any* response from the author, regarding either the test failures or the other comments, for two weeks which is why I've now chosen to submit this patch.