### PR TITLE
[api-minor] Remove the `document.currentScript` polyfill

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -90,7 +90,8 @@ if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('GENERIC')) {
     });
   }) : null;
 
-  if (!fallbackWorkerSrc && typeof document !== 'undefined') {
+  if (!fallbackWorkerSrc && typeof document === 'object' &&
+      'currentScript' in document) {
     const pdfjsFilePath = document.currentScript && document.currentScript.src;
     if (pdfjsFilePath) {
       fallbackWorkerSrc =

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -54,25 +54,6 @@ const hasDOM = typeof window === 'object' && typeof document === 'object';
   };
 })();
 
-// Provides document.currentScript support
-// Support: IE, Chrome<29.
-(function checkCurrentScript() {
-  if (!hasDOM) {
-    return;
-  }
-  if ('currentScript' in document) {
-    return;
-  }
-  Object.defineProperty(document, 'currentScript', {
-    get() {
-      var scripts = document.getElementsByTagName('script');
-      return scripts[scripts.length - 1];
-    },
-    enumerable: true,
-    configurable: true,
-  });
-})();
-
 // Provides support for ChildNode.remove in legacy browsers.
 // Support: IE.
 (function checkChildNodeRemove() {


### PR DESCRIPTION
This polyfill is currently used in only *one* file, i.e. `src/display/api.js`, and only when trying to build a *fallback* `workerSrc` path.

Given that the global `workerSrc` should *always* be set[1] when using the PDF.js library[2], and that the fallback `workerSrc` should only be regarded as a best-effort solution anyway, there isn't a particularily strong reason to keep the compatibility code in my opinion.

---
[1] Other supported options include setting the global `workerPort`, or passing in a `PDFWorker` instance as part of the `getDocument` call.

[2] Which is clearly mentioned in the JSDocs in `src/display/worker_options.js`.