### PR TITLE
Fallback to the built-in font renderer when font loading fails

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -1159,6 +1159,8 @@ var Font = (function FontClosure() {
     font: null,
     mimetype: null,
     encoding: null,
+    disableFontFace: false,
+
     get renderer() {
       var renderer = FontRendererFactory.create(this, SEAC_ANALYSIS_ENABLED);
       return shadow(this, 'renderer', renderer);

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1946,7 +1946,7 @@ class WorkerTransport {
               fontRegistry,
             });
 
-            this.fontLoader.bind([font]).then((fontObjs) => {
+            this.fontLoader.bind(font).then(() => {
               this.commonObjs.resolve(id, font);
               resolve();
             }, (reason) => {

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -29,6 +29,10 @@ describe('evaluator', function() {
     send(name, data) {
       this.inputs.push({ name, data, });
     },
+
+    async sendWithPromise(name, data) {
+      this.inputs.push({ name, data, });
+    },
   };
   function ResourcesMock() { }
   ResourcesMock.prototype = {


### PR DESCRIPTION
After PR #9340 all glyphs are now re-mapped to a Private Use Area (PUA) which means that if a font fails to load, for whatever reason[1], all glyphs in the font will now render as Unicode glyph outlines.
This obviously doesn't look good, to say the least, and might be seen as a "regression" since previously many glyphs were left in their original positions which provided a slightly better fallback[2].

Hence this patch, which implements a *general* fallback to the PDF.js built-in font renderer for fonts that fail to load (i.e. are rejected by the sanitizer). One caveat here is that this only works for the Font Loading API, since it's easy to handle errors in that case[3].

*Please note:* This patch doesn't fix any of the underlying PDF.js font conversion bugs that's responsible for creating corrupt font files, however it does *improve* rendering in a number of cases; refer to this possibly incomplete list:

https://bugzilla.mozilla.org/show_bug.cgi?id=1524888
https://github.com/mozilla/pdf.js/issues/10175
https://github.com/mozilla/pdf.js/issues/10232

---
[1] Usually because the PDF.js font conversion code wasn't able to parse the font file correctly.

[2] Glyphs fell back to some default font, which while not accurate was more useful than the current state.

[3] Furthermore I'm not sure how to implement this generally, assuming that's even possible, and don't really have time/interest to look into it either.