### PR TITLE
Convert more code to use `classList.toggle` with the `force` parameter

### DIFF
--- a/web/pdf_outline_viewer.js
+++ b/web/pdf_outline_viewer.js
@@ -136,11 +136,10 @@ class PDFOutlineViewer {
    *
    * @private
    */
-  _toggleOutlineItem(root, show) {
+  _toggleOutlineItem(root, show = false) {
     this.lastToggleIsShow = show;
-    let togglers = root.querySelectorAll('.outlineItemToggler');
-    for (let i = 0, ii = togglers.length; i < ii; ++i) {
-      togglers[i].classList[show ? 'remove' : 'add']('outlineItemsHidden');
+    for (const toggler of root.querySelectorAll('.outlineItemToggler')) {
+      toggler.classList.toggle('outlineItemsHidden', !show);
     }
   }
 

--- a/web/pdf_sidebar.js
+++ b/web/pdf_sidebar.js
@@ -171,16 +171,7 @@ class PDFSidebar {
         }
         return false;
       case SidebarView.THUMBS:
-        this.thumbnailButton.classList.add('toggled');
-        this.outlineButton.classList.remove('toggled');
-        this.attachmentsButton.classList.remove('toggled');
-
-        this.thumbnailView.classList.remove('hidden');
-        this.outlineView.classList.add('hidden');
-        this.attachmentsView.classList.add('hidden');
-
         if (this.isOpen && isViewChanged) {
-          this._updateThumbnailViewer();
           shouldForceRendering = true;
         }
         break;
@@ -188,25 +179,11 @@ class PDFSidebar {
         if (this.outlineButton.disabled) {
           return false;
         }
-        this.thumbnailButton.classList.remove('toggled');
-        this.outlineButton.classList.add('toggled');
-        this.attachmentsButton.classList.remove('toggled');
-
-        this.thumbnailView.classList.add('hidden');
-        this.outlineView.classList.remove('hidden');
-        this.attachmentsView.classList.add('hidden');
         break;
       case SidebarView.ATTACHMENTS:
         if (this.attachmentsButton.disabled) {
           return false;
         }
-        this.thumbnailButton.classList.remove('toggled');
-        this.outlineButton.classList.remove('toggled');
-        this.attachmentsButton.classList.add('toggled');
-
-        this.thumbnailView.classList.add('hidden');
-        this.outlineView.classList.add('hidden');
-        this.attachmentsView.classList.remove('hidden');
         break;
       default:
         console.error(`PDFSidebar._switchView: "${view}" is not a valid view.`);
@@ -214,13 +191,27 @@ class PDFSidebar {
     }
     // Update the active view *after* it has been validated above,
     // in order to prevent setting it to an invalid state.
-    this.active = view | 0;
+    this.active = view;
+
+    // Update the CSS classes, for all buttons...
+    this.thumbnailButton.classList.toggle('toggled',
+      view === SidebarView.THUMBS);
+    this.outlineButton.classList.toggle('toggled',
+      view === SidebarView.OUTLINE);
+    this.attachmentsButton.classList.toggle('toggled',
+      view === SidebarView.ATTACHMENTS);
+    // ... and for all views.
+    this.thumbnailView.classList.toggle('hidden', view !== SidebarView.THUMBS);
+    this.outlineView.classList.toggle('hidden', view !== SidebarView.OUTLINE);
+    this.attachmentsView.classList.toggle('hidden',
+      view !== SidebarView.ATTACHMENTS);
 
     if (forceOpen && !this.isOpen) {
       this.open();
       return true; // Opening will trigger rendering and dispatch the event.
     }
     if (shouldForceRendering) {
+      this._updateThumbnailViewer();
       this._forceRendering();
     }
     if (isViewChanged) {
@@ -237,8 +228,7 @@ class PDFSidebar {
     this.isOpen = true;
     this.toggleButton.classList.add('toggled');
 
-    this.outerContainer.classList.add('sidebarMoving');
-    this.outerContainer.classList.add('sidebarOpen');
+    this.outerContainer.classList.add('sidebarMoving', 'sidebarOpen');
 
     if (this.active === SidebarView.THUMBS) {
       this._updateThumbnailViewer();

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -188,42 +188,26 @@ class SecondaryToolbar {
   }
 
   _bindCursorToolsListener(buttons) {
-    this.eventBus.on('cursortoolchanged', function(evt) {
-      buttons.cursorSelectToolButton.classList.remove('toggled');
-      buttons.cursorHandToolButton.classList.remove('toggled');
-
-      switch (evt.tool) {
-        case CursorTool.SELECT:
-          buttons.cursorSelectToolButton.classList.add('toggled');
-          break;
-        case CursorTool.HAND:
-          buttons.cursorHandToolButton.classList.add('toggled');
-          break;
-      }
+    this.eventBus.on('cursortoolchanged', function({ tool, }) {
+      buttons.cursorSelectToolButton.classList.toggle('toggled',
+        tool === CursorTool.SELECT);
+      buttons.cursorHandToolButton.classList.toggle('toggled',
+        tool === CursorTool.HAND);
     });
   }
 
   _bindScrollModeListener(buttons) {
-    function scrollModeChanged(evt) {
-      buttons.scrollVerticalButton.classList.remove('toggled');
-      buttons.scrollHorizontalButton.classList.remove('toggled');
-      buttons.scrollWrappedButton.classList.remove('toggled');
-
-      switch (evt.mode) {
-        case ScrollMode.VERTICAL:
-          buttons.scrollVerticalButton.classList.add('toggled');
-          break;
-        case ScrollMode.HORIZONTAL:
-          buttons.scrollHorizontalButton.classList.add('toggled');
-          break;
-        case ScrollMode.WRAPPED:
-          buttons.scrollWrappedButton.classList.add('toggled');
-          break;
-      }
+    function scrollModeChanged({ mode, }) {
+      buttons.scrollVerticalButton.classList.toggle('toggled',
+        mode === ScrollMode.VERTICAL);
+      buttons.scrollHorizontalButton.classList.toggle('toggled',
+        mode === ScrollMode.HORIZONTAL);
+      buttons.scrollWrappedButton.classList.toggle('toggled',
+        mode === ScrollMode.WRAPPED);
 
       // Temporarily *disable* the Spread buttons when horizontal scrolling is
       // enabled, since the non-default Spread modes doesn't affect the layout.
-      const isScrollModeHorizontal = (evt.mode === ScrollMode.HORIZONTAL);
+      const isScrollModeHorizontal = (mode === ScrollMode.HORIZONTAL);
       buttons.spreadNoneButton.disabled = isScrollModeHorizontal;
       buttons.spreadOddButton.disabled = isScrollModeHorizontal;
       buttons.spreadEvenButton.disabled = isScrollModeHorizontal;
@@ -238,22 +222,13 @@ class SecondaryToolbar {
   }
 
   _bindSpreadModeListener(buttons) {
-    function spreadModeChanged(evt) {
-      buttons.spreadNoneButton.classList.remove('toggled');
-      buttons.spreadOddButton.classList.remove('toggled');
-      buttons.spreadEvenButton.classList.remove('toggled');
-
-      switch (evt.mode) {
-        case SpreadMode.NONE:
-          buttons.spreadNoneButton.classList.add('toggled');
-          break;
-        case SpreadMode.ODD:
-          buttons.spreadOddButton.classList.add('toggled');
-          break;
-        case SpreadMode.EVEN:
-          buttons.spreadEvenButton.classList.add('toggled');
-          break;
-      }
+    function spreadModeChanged({ mode, }) {
+      buttons.spreadNoneButton.classList.toggle('toggled',
+        mode === SpreadMode.NONE);
+      buttons.spreadOddButton.classList.toggle('toggled',
+        mode === SpreadMode.ODD);
+      buttons.spreadEvenButton.classList.toggle('toggled',
+        mode === SpreadMode.EVEN);
     }
     this.eventBus.on('spreadmodechanged', spreadModeChanged);
 


### PR DESCRIPTION
There's a bunch of code, in the viewer, which for historical reasons use `switch` statements to add and remove CSS classes.
This code can be simplified, and unnecessary duplication avoided, by using `classList.toggle` instead.