### PR TITLE
Re-factor the `BaseFontLoader.bind` method to be async

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1945,7 +1945,7 @@ class WorkerTransport {
             fontRegistry,
           });
 
-          this.fontLoader.bind([font]).then(() => {
+          this.fontLoader.bind(font).then(() => {
             this.commonObjs.resolve(id, font);
           });
           break;

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1944,11 +1944,10 @@ class WorkerTransport {
             onUnsupportedFeature: this._onUnsupportedFeature.bind(this),
             fontRegistry,
           });
-          const fontReady = (fontObjs) => {
-            this.commonObjs.resolve(id, font);
-          };
 
-          this.fontLoader.bind([font], fontReady);
+          this.fontLoader.bind([font]).then(() => {
+            this.commonObjs.resolve(id, font);
+          });
           break;
         case 'FontPath':
           this.commonObjs.resolve(id, exportedData);


### PR DESCRIPTION
*This splits out two of the commits from PR #10520, since they seem generally useful regardless of the eventual outcome of that PR.*