### PR TITLE
[api-minor] Fallback to the built-in font renderer when font loading fails

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -666,6 +666,10 @@ class PDFDocument {
     });
   }
 
+  fontFallback(id, handler) {
+    return this.catalog.fontFallback(id, handler);
+  }
+
   cleanup() {
     return this.catalog.cleanup();
   }

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -1159,6 +1159,8 @@ var Font = (function FontClosure() {
     font: null,
     mimetype: null,
     encoding: null,
+    disableFontFace: false,
+
     get renderer() {
       var renderer = FontRendererFactory.create(this, SEAC_ANALYSIS_ENABLED);
       return shadow(this, 'renderer', renderer);
@@ -2943,6 +2945,10 @@ var Font = (function FontClosure() {
 
       // Enter the translated string into the cache
       return (charsCache[charsCacheKey] = glyphs);
+    },
+
+    get glyphCacheValues() {
+      return Object.values(this.glyphCache);
     },
   };
 

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -490,6 +490,22 @@ class Catalog {
     return shadow(this, 'javaScript', javaScript);
   }
 
+  fontFallback(id, handler) {
+    const promises = [];
+    this.fontCache.forEach(function(promise) {
+      promises.push(promise);
+    });
+
+    return Promise.all(promises).then((translatedFonts) => {
+      for (const translatedFont of translatedFonts) {
+        if (translatedFont.loadedName === id) {
+          translatedFont.fallback(handler);
+          return;
+        }
+      }
+    });
+  }
+
   cleanup() {
     this.pageKidsCountCache.clear();
 

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -68,6 +68,10 @@ class BasePdfManager {
     return this.pdfDocument.getPage(pageIndex);
   }
 
+  fontFallback(id, handler) {
+    return this.pdfDocument.fontFallback(id, handler);
+  }
+
   cleanup() {
     return this.pdfDocument.cleanup();
   }

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -667,6 +667,10 @@ var WorkerMessageHandler = {
       });
     });
 
+    handler.on('FontFallback', function(data) {
+      return pdfManager.fontFallback(data.id, handler);
+    });
+
     handler.on('Cleanup', function wphCleanup(data) {
       return pdfManager.cleanup();
     });

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1945,7 +1945,7 @@ class WorkerTransport {
             fontRegistry,
           });
 
-          this.fontLoader.bind([font]).then(() => {
+          this.fontLoader.bind(font).then(() => {
             this.commonObjs.resolve(id, font);
           });
           break;

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1944,11 +1944,10 @@ class WorkerTransport {
             onUnsupportedFeature: this._onUnsupportedFeature.bind(this),
             fontRegistry,
           });
-          const fontReady = (fontObjs) => {
-            this.commonObjs.resolve(id, font);
-          };
 
-          this.fontLoader.bind([font], fontReady);
+          this.fontLoader.bind([font]).then(() => {
+            this.commonObjs.resolve(id, font);
+          });
           break;
         case 'FontPath':
           this.commonObjs.resolve(id, exportedData);

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -23,11 +23,6 @@ if ((typeof PDFJSDev === 'undefined' ||
 
 globalScope._pdfjsCompatibilityChecked = true;
 
-// In the Chrome extension, most of the polyfills are unnecessary.
-// We support down to Chrome 49, because it's still commonly used by Windows XP
-// users - https://github.com/mozilla/pdf.js/issues/9397
-if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('CHROME')) {
-
 const isNodeJS = require('./is_node');
 
 const hasDOM = typeof window === 'object' && typeof document === 'object';
@@ -199,14 +194,15 @@ const hasDOM = typeof window === 'object' && typeof document === 'object';
   Number.isInteger = require('core-js/fn/number/is-integer');
 })();
 
-// Support: IE, Safari<8, Chrome<32
+// Support: IE, Safari<11, Chrome<63
 (function checkPromise() {
   if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('IMAGE_DECODERS')) {
     // The current image decoders are synchronous, hence `Promise` shouldn't
     // need to be polyfilled for the IMAGE_DECODERS build target.
     return;
   }
-  if (globalScope.Promise) {
+  if (globalScope.Promise && (globalScope.Promise.prototype &&
+                              globalScope.Promise.prototype.finally)) {
     return;
   }
   globalScope.Promise = require('core-js/fn/promise');
@@ -253,8 +249,6 @@ const hasDOM = typeof window === 'object' && typeof document === 'object';
   }
   require('core-js/es6/symbol');
 })();
-
-} // End of !PDFJSDev.test('CHROME')
 
 // Provides support for String.prototype.padStart in legacy browsers.
 // Support: IE, Chrome<57


### PR DESCRIPTION
After PR #9340 all glyphs are now re-mapped to a Private Use Area (PUA) which means that if a font fails to load, for whatever reason[1], all glyphs in the font will now render as Unicode glyph outlines.
This obviously doesn't look good, to say the least, and might be seen as a "regression" since previously many glyphs were left in their original positions which provided a slightly better fallback[2].

Hence this patch, which implements a *general* fallback to the PDF.js built-in font renderer for fonts that fail to load (i.e. are rejected by the sanitizer). One caveat here is that this only works for the Font Loading API, since it's easy to handle errors in that case[3].

The solution implemented in this patch does *not* in any way delay the loading of valid fonts, which was the problem with my previous attempt at a solution, and will only require a bit of extra work/waiting for those fonts that actually fail to load.

*Please note:* This patch doesn't fix any of the underlying PDF.js font conversion bugs that's responsible for creating corrupt font files, however it does *improve* rendering in a number of cases; refer to this possibly incomplete list:

 - [Bug 1524888](https://bugzilla.mozilla.org/show_bug.cgi?id=1524888)
 - Issue #10175
 - Issue #10232
 - Issue #10544

---
[1] Usually because the PDF.js font conversion code wasn't able to parse the font file correctly.

[2] Glyphs fell back to some default font, which while not accurate was more useful than the current state.

[3] Furthermore I'm not sure how to implement this generally, assuming that's even possible, and don't really have time/interest to look into it either.