### PR TITLE
[Chrome extension] Add missing "type" entry for the `viewOnLoad` preference in the `preferences_schema.json` file (PR 10502 follow-up)

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -9,6 +9,7 @@
     "viewOnLoad": {
       "title": "View position on load",
       "description": "The position in the document upon load.\n -1 = Default (uses OpenAction if available, otherwise equal to `viewOnLoad = 0`).\n 0 = The last viewed page/position.\n 1 = The initial page/position.",
+      "type": "integer",
       "enum": [
         -1,
         0,


### PR DESCRIPTION
Fixes #10538 