### PR TITLE
Undo the `pdfjs.config` version bumps

### DIFF
--- a/pdfjs.config
+++ b/pdfjs.config
@@ -1,6 +1,6 @@
 {
   "betaVersion": "",
-  "stableVersion": "2.1.245",
-  "baseVersion": "2b6e6364efcb5e592db39bd8d218e75b77ec2b79",
-  "versionPrefix": "2.2."
+  "stableVersion": "2.0.943",
+  "baseVersion": "dc98bf76eb3f610bb86af441a5c71792bb58c825",
+  "versionPrefix": "2.1."
 }


### PR DESCRIPTION
The release needs to be made again for the version number to be correct.