### PR TITLE
[api-minor] Expose the existence of a `Collection` dictionary via the  `getMetadata` API method (issue 10555)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -401,8 +401,7 @@ class PDFDocument {
       if (this.acroForm) {
         this.xfa = this.acroForm.get('XFA');
         const fields = this.acroForm.get('Fields');
-        if ((!fields || !Array.isArray(fields) || fields.length === 0) &&
-            !this.xfa) {
+        if ((!Array.isArray(fields) || fields.length === 0) && !this.xfa) {
           this.acroForm = null; // No fields and no XFA, so it's not a form.
         }
       }
@@ -412,6 +411,19 @@ class PDFDocument {
       }
       info('Cannot fetch AcroForm entry; assuming no AcroForms are present');
       this.acroForm = null;
+    }
+
+    // Check if a Collection dictionary is present in the document.
+    try {
+      const collection = this.catalog.catDict.get('Collection');
+      if (isDict(collection) && collection.getKeys().length > 0) {
+        this.collection = collection;
+      }
+    } catch (ex) {
+      if (ex instanceof MissingDataException) {
+        throw ex;
+      }
+      info('Cannot fetch Collection dictionary.');
     }
   }
 
@@ -534,6 +546,7 @@ class PDFDocument {
       IsLinearized: !!this.linearization,
       IsAcroFormPresent: !!this.acroForm,
       IsXFAPresent: !!this.xfa,
+      IsCollectionPresent: !!this.collection,
     };
 
     let infoDict;

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -846,6 +846,7 @@ describe('api', function() {
         expect(info['IsLinearized']).toEqual(false);
         expect(info['IsAcroFormPresent']).toEqual(false);
         expect(info['IsXFAPresent']).toEqual(false);
+        expect(info['IsCollectionPresent']).toEqual(false);
 
         expect(metadata instanceof Metadata).toEqual(true);
         expect(metadata.get('dc:title')).toEqual('Basic API Test');
@@ -874,6 +875,7 @@ describe('api', function() {
         expect(info['IsLinearized']).toEqual(false);
         expect(info['IsAcroFormPresent']).toEqual(false);
         expect(info['IsXFAPresent']).toEqual(false);
+        expect(info['IsCollectionPresent']).toEqual(false);
 
         expect(metadata).toEqual(null);
         expect(contentDispositionFilename).toEqual(null);


### PR DESCRIPTION
Given the complexity of this functionality, and the fact that it doesn't seem widely used, I highly doubt that it'd ever make sense to support Collections; see also https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#M11.9.39646.2Heading.824.Collections

Fixes #10555.