### PR TITLE
Use `Promise.prototype.finally` in the `PDFRenderingQueue.renderView` method

### DIFF
--- a/web/pdf_rendering_queue.js
+++ b/web/pdf_rendering_queue.js
@@ -107,7 +107,7 @@ class PDFRenderingQueue {
 
     let numVisible = visibleViews.length;
     if (numVisible === 0) {
-      return false;
+      return null;
     }
     for (let i = 0; i < numVisible; ++i) {
       let view = visibleViews[i].view;
@@ -162,10 +162,9 @@ class PDFRenderingQueue {
         break;
       case RenderingStates.INITIAL:
         this.highestPriorityPage = view.renderingId;
-        let continueRendering = () => {
+        view.draw().finally(() => {
           this.renderHighestPriority();
-        };
-        view.draw().then(continueRendering, continueRendering);
+        });
         break;
     }
     return true;


### PR DESCRIPTION
Since [`finally`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally) is now supported through `src/shared/compatibility.js`, the temporary variable is no longer necessary.

Also, this patch fixes the inconsistent return type of `PDFRenderingQueue.getHighestPriority` when no pages/thumbnails are visible.