### PR TITLE
Zero the width/height of the temporary canvas used during `TextLayer` rendering

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -490,6 +490,17 @@ var renderTextLayer = (function renderTextLayerClosure() {
     this._capability = createPromiseCapability();
     this._renderTimer = null;
     this._bounds = [];
+
+    // Always clean-up the temporary canvas once rendering is no longer pending.
+    this._capability.promise.finally(() => {
+      if (this._layoutTextCtx) {
+        // Zeroing the width and height cause Firefox to release graphics
+        // resources immediately, which can greatly reduce memory consumption.
+        this._layoutTextCtx.canvas.width = 0;
+        this._layoutTextCtx.canvas.height = 0;
+        this._layoutTextCtx = null;
+      }
+    });
   }
   TextLayerRenderTask.prototype = {
     get promise() {
@@ -497,16 +508,16 @@ var renderTextLayer = (function renderTextLayerClosure() {
     },
 
     cancel: function TextLayer_cancel() {
+      this._canceled = true;
       if (this._reader) {
-        this._reader.cancel(new AbortException('text layer task cancelled'));
+        this._reader.cancel(new AbortException('TextLayer task cancelled.'));
         this._reader = null;
       }
-      this._canceled = true;
       if (this._renderTimer !== null) {
         clearTimeout(this._renderTimer);
         this._renderTimer = null;
       }
-      this._capability.reject('canceled');
+      this._capability.reject(new Error('TextLayer task cancelled.'));
     },
 
     _processItems(items, styleCache) {


### PR DESCRIPTION
The default size of these canvases seem to be `300 x 150` (two orders of magnitude larger than the ones in PR #10597), which probably is sufficient enough to matter since there's one such canvas for each textLayer that's rendered in the viewer.

Also fixes the incorrect rejection reason, i.e. one using a string rather than an `Error`, in the `TextLayerRenderTask.cancel` method.