### PR TITLE
Change the `warn` to `info` in `CFFCompiler.compileCharset` to avoid loads of console "spam"

### DIFF
--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -1623,7 +1623,7 @@ var CFFCompiler = (function CFFCompilerClosure() {
             sid = strings.getSID(name);
             if (sid === -1) {
               sid = 0;
-              warn(`Couldn't find ${name} in CFF strings`);
+              info(`Couldn't find ${name} in CFF strings`);
             }
           }
           out[i] = (sid >> 8) & 0xFF;


### PR DESCRIPTION
Note that even for something as simple as the default `tracemonkey.pdf` file, there's now *a lot* of warning messages printed.
Most likely the code actually needs to be adjusted to prevent a majority of these messages, but in the meantime it seems reasonable to use `info` rather than `warn` here.

/cc @brendandahl, see also https://github.com/mozilla/pdf.js/pull/10591#discussion_r261467368