### PR TITLE
Put the string name of the glyph in the charset array.

### DIFF
--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -953,7 +953,7 @@ var CFFStrings = (function CFFStringsClosure() {
       return -1;
     },
     add: function CFFStrings_add(value) {
-      return this.strings.push(value) + NUM_STANDARD_CFF_STRINGS - 1;
+      this.strings.push(value);
     },
     get count() {
       return this.strings.length;
@@ -1616,6 +1616,7 @@ var CFFCompiler = (function CFFCompilerClosure() {
         out[0] = 0; // format 0
         let charsetIndex = 0;
         let numCharsets = charset.charset.length;
+        let warned = false;
         for (let i = 1; i < out.length; i += 2) {
           let sid = 0;
           if (charsetIndex < numCharsets) {
@@ -1623,7 +1624,10 @@ var CFFCompiler = (function CFFCompilerClosure() {
             sid = strings.getSID(name);
             if (sid === -1) {
               sid = 0;
-              warn(`Couldn't find ${name} in CFF strings`);
+              if (!warned) {
+                warned = true;
+                warn(`Couldn't find ${name} in CFF strings`);
+              }
             }
           }
           out[i] = (sid >> 8) & 0xFF;

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -3335,14 +3335,15 @@ var Type1Font = (function Type1FontClosure() {
       cff.globalSubrIndex = new CFFIndex();
 
       var count = glyphs.length;
-      var charsetArray = [0];
+      var charsetArray = ['.notdef'];
       var i, ii;
       for (i = 0; i < count; i++) {
-        var index = CFFStandardStrings.indexOf(charstrings[i].glyphName);
+        let glyphName = charstrings[i].glyphName;
+        let index = CFFStandardStrings.indexOf(glyphName);
         if (index === -1) {
-          index = strings.add(charstrings[i].glyphName);
+          strings.add(glyphName);
         }
-        charsetArray.push(index);
+        charsetArray.push(glyphName);
       }
       cff.charset = new CFFCharset(false, 0, charsetArray);
 


### PR DESCRIPTION
Also, only warn once per font when missing a glyph name.