### PR TITLE
Reduce usage of `Date.now()` in `src/core/worker.js`

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -14,10 +14,10 @@
  */
 
 import {
-  arrayByteLength, arraysToBytes, assert, createPromiseCapability, info,
-  InvalidPDFException, MissingPDFException, PasswordException,
-  setVerbosityLevel, UnexpectedResponseException, UnknownErrorException,
-  UNSUPPORTED_FEATURES, warn
+  arrayByteLength, arraysToBytes, assert, createPromiseCapability,
+  getVerbosityLevel, info, InvalidPDFException, MissingPDFException,
+  PasswordException, setVerbosityLevel, UnexpectedResponseException,
+  UnknownErrorException, UNSUPPORTED_FEATURES, VerbosityLevel, warn
 } from '../shared/util';
 import { LocalPdfManager, NetworkPdfManager } from './pdf_manager';
 import isNodeJS from '../shared/is_node';
@@ -222,6 +222,7 @@ var WorkerMessageHandler = {
     var terminated = false;
     var cancelXHRs = null;
     var WorkerTasks = [];
+    const verbosity = getVerbosityLevel();
 
     let apiVersion = docParams.apiVersion;
     let workerVersion =
@@ -578,8 +579,9 @@ var WorkerMessageHandler = {
         var task = new WorkerTask('RenderPageRequest: page ' + pageIndex);
         startWorkerTask(task);
 
-        var pageNum = pageIndex + 1;
-        var start = Date.now();
+        // NOTE: Keep this condition in sync with the `info` helper function.
+        const start = (verbosity >= VerbosityLevel.INFOS ? Date.now() : 0);
+
         // Pre compile the pdf page and fetch the fonts/images.
         page.getOperatorList({
           handler,
@@ -589,8 +591,10 @@ var WorkerMessageHandler = {
         }).then(function(operatorList) {
           finishWorkerTask(task);
 
-          info('page=' + pageNum + ' - getOperatorList: time=' +
-               (Date.now() - start) + 'ms, len=' + operatorList.totalLength);
+          if (start) {
+            info(`page=${pageIndex + 1} - getOperatorList: time=` +
+                 `${Date.now() - start}ms, len=${operatorList.totalLength}`);
+          }
         }, function(e) {
           finishWorkerTask(task);
           if (task.terminated) {
@@ -626,7 +630,7 @@ var WorkerMessageHandler = {
           }
 
           handler.send('PageError', {
-            pageNum,
+            pageIndex,
             error: wrappedException,
             intent: data.intent,
           });
@@ -643,8 +647,9 @@ var WorkerMessageHandler = {
         var task = new WorkerTask('GetTextContent: page ' + pageIndex);
         startWorkerTask(task);
 
-        var pageNum = pageIndex + 1;
-        var start = Date.now();
+        // NOTE: Keep this condition in sync with the `info` helper function.
+        const start = (verbosity >= VerbosityLevel.INFOS ? Date.now() : 0);
+
         page.extractTextContent({
           handler,
           task,
@@ -654,8 +659,10 @@ var WorkerMessageHandler = {
         }).then(function() {
           finishWorkerTask(task);
 
-          info('text indexing: page=' + pageNum + ' - time=' +
-               (Date.now() - start) + 'ms');
+          if (start) {
+            info(`page=${pageIndex + 1} - getTextContent: time=` +
+                 `${Date.now() - start}ms`);
+          }
           sink.close();
         }, function (reason) {
           finishWorkerTask(task);

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2028,11 +2028,11 @@ class WorkerTransport {
         return; // Ignore any pending requests if the worker was terminated.
       }
 
-      const page = this.pageCache[data.pageNum - 1];
+      const page = this.pageCache[data.pageIndex];
       const intentState = page.intentStates[data.intent];
 
       if (intentState.displayReadyCapability) {
-        intentState.displayReadyCapability.reject(data.error);
+        intentState.displayReadyCapability.reject(new Error(data.error));
       } else {
         throw new Error(data.error);
       }

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -16,15 +16,14 @@
 /* eslint no-var: error */
 
 import {
-  assert, createPromiseCapability, deprecated, getVerbosityLevel, info,
-  InvalidPDFException, isArrayBuffer, isSameOrigin, MissingPDFException,
-  NativeImageDecoding, PasswordException, setVerbosityLevel, shadow,
-  stringToBytes, UnexpectedResponseException, UnknownErrorException,
-  unreachable, URL, warn
+  assert, createPromiseCapability, getVerbosityLevel, info, InvalidPDFException,
+  isArrayBuffer, isSameOrigin, MissingPDFException, NativeImageDecoding,
+  PasswordException, setVerbosityLevel, shadow, stringToBytes,
+  UnexpectedResponseException, UnknownErrorException, unreachable, URL, warn
 } from '../shared/util';
 import {
-  DOMCanvasFactory, DOMCMapReaderFactory, DummyStatTimer, loadScript,
-  PageViewport, RenderingCancelledException, StatTimer
+  deprecated, DOMCanvasFactory, DOMCMapReaderFactory, DummyStatTimer,
+  loadScript, PageViewport, RenderingCancelledException, StatTimer
 } from './display_utils';
 import { FontFaceObject, FontLoader } from './font_loader';
 import { apiCompatibilityParams } from './api_compatibility';

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -477,6 +477,11 @@ function loadScript(src) {
   });
 }
 
+// Deprecated API function -- display regardless of the `verbosity` setting.
+function deprecated(details) {
+  console.log('Deprecated API usage: ' + details);
+}
+
 export {
   PageViewport,
   RenderingCancelledException,
@@ -492,4 +497,5 @@ export {
   isFetchSupported,
   isValidFetchUrl,
   loadScript,
+  deprecated,
 };

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -307,11 +307,6 @@ function warn(msg) {
   }
 }
 
-// Deprecated API function -- display regardless of the `verbosity` setting.
-function deprecated(details) {
-  console.log('Deprecated API usage: ' + details);
-}
-
 function unreachable(msg) {
   throw new Error(msg);
 }
@@ -929,7 +924,6 @@ export {
   bytesToString,
   createPromiseCapability,
   createObjectURL,
-  deprecated,
   getVerbosityLevel,
   info,
   isArrayBuffer,


### PR DESCRIPTION
Currently for every single parsed/rendered page there's no less than *four* `Date.now()` calls being made on the worker-side. This seems totally unnecessary, since the result of these calls are, by default, not used for anything *unless* the verbosity level is set to `INFO`.