### PR TITLE
Add type validation to the `default_preferences` generation (PR 10548 follow-up)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -535,7 +535,7 @@ gulp.task('default_preferences-pre', function() {
     ], { base: 'src/', }),
     gulp.src([
       'web/*.js',
-      '!web/{pdfjs,preferences,viewer}.js',
+      '!web/{app,pdfjs,preferences,viewer}.js',
     ], { base: '.', }),
   ]).pipe(transform('utf8', preprocess))
     .pipe(gulp.dest(DEFAULT_PREFERENCES_DIR + 'lib/'));

--- a/web/app.js
+++ b/web/app.js
@@ -187,7 +187,9 @@ let PDFViewerApplication = {
       for (const name in prefs) {
         AppOptions.set(name, prefs[name]);
       }
-    } catch (reason) { }
+    } catch (reason) {
+      console.error(`_readPreferences: "${reason.message}".`);
+    }
   },
 
   /**

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -222,7 +222,7 @@ const defaultOptions = {
   },
 };
 if (typeof PDFJSDev === 'undefined' ||
-    PDFJSDev.test('!PRODUCTION || GENERIC')) {
+    PDFJSDev.test('!PRODUCTION || (GENERIC && !LIB)')) {
   defaultOptions.disablePreferences = {
     /** @type {boolean} */
     value: false,
@@ -262,9 +262,15 @@ class AppOptions {
         if ((kind & defaultOption.kind) === 0) {
           continue;
         }
-        if ((kind & OptionKind.PREFERENCE) !== 0) {
-          options[name] = defaultOption.value;
-          continue;
+        if (kind === OptionKind.PREFERENCE) {
+          const value = defaultOption.value, valueType = typeof value;
+
+          if (valueType === 'boolean' || valueType === 'string' ||
+              (valueType === 'number' && Number.isInteger(value))) {
+            options[name] = value;
+            continue;
+          }
+          throw new Error(`Invalid type for preference: ${name}`);
         }
       }
       const userOption = userOptions[name];

--- a/web/preferences.js
+++ b/web/preferences.js
@@ -35,8 +35,6 @@ function getDefaultPreferences() {
         }
       }).then(function({ AppOptions, OptionKind, }) {
         return AppOptions.getAll(OptionKind.PREFERENCE);
-      }, function(reason) {
-        console.error(reason);
       });
     }
   }


### PR DESCRIPTION
The generated `default_preferences.json` file is necessary when initializing the Firefox preferences, which only supports certain types, hence this patch adds additional validation to help prevent run-time errors in Firefox.

Given that these changes add a code-path to `AppOptions.getAll` which could throw, the `OptionKind.PREFERENCE` branch is also modified to require *exact* matching to prevent (future) errors in the viewer.

Finally the conditionally defined `defaultOptions` will no longer (potentially) be considered during the `gulp default_preferences` task, to make it more difficult for them to be accidentally included.