### PR TITLE
Re-factor the `imageCache` used in `PartialEvaluator.getOperatorList`

### DIFF
--- a/src/core/image.js
+++ b/src/core/image.js
@@ -305,7 +305,7 @@ var PDFImage = (function PDFImageClosure() {
       }
     }
 
-    return { data, width, height, };
+    return { data, width, height, downsized: false, };
   };
 
   PDFImage.prototype = {
@@ -535,6 +535,7 @@ var PDFImage = (function PDFImageClosure() {
         height: drawHeight,
         kind: 0,
         data: null,
+        downsized: false,
       };
 
       var numComps = this.numComps;


### PR DESCRIPTION
This changes the `imageCache` from a simple object to a class, which will allow (future) support for re-sizing of large images.
Compared to my initial attempt(s) at implementing this, this patch purposely avoids trying to fix "everything" at once, since that required too large/invasive changes to the relevant code.

*Please note:* This patch, on its own, won't completely unblock PR #9255. However once this patch has landed, that PR can be re-factored on top of it and the new `ImageCache` class extended to properly support re-sized images.