### PR TITLE
Move `NativeImageDecoder` into a separate file, and convert it to a `class`

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -20,7 +20,6 @@ import {
   UNSUPPORTED_FEATURES, Util, warn
 } from '../shared/util';
 import { CMapFactory, IdentityCMap } from './cmap';
-import { DecodeStream, Stream } from './stream';
 import {
   Dict, isCmd, isDict, isEOF, isName, isRef, isStream, Name
 } from './primitives';
@@ -41,12 +40,14 @@ import { getTilingPatternIR, Pattern } from './pattern';
 import { Lexer, Parser } from './parser';
 import { bidi } from './bidi';
 import { ColorSpace } from './colorspace';
+import { DecodeStream } from './stream';
 import { getGlyphsUnicode } from './glyphlist';
 import { getLookupTableFactory } from './core_utils';
 import { getMetrics } from './metrics';
 import { isPDFFunction } from './function';
 import { JpegStream } from './jpeg_stream';
 import { MurmurHash3_64 } from './murmurhash3';
+import { NativeImageDecoder } from './image_utils';
 import { OperatorList } from './operator_list';
 import { PDFImage } from './image';
 
@@ -58,67 +59,6 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     nativeImageDecoderSupport: NativeImageDecoding.DECODE,
     ignoreErrors: false,
     isEvalSupported: true,
-  };
-
-  function NativeImageDecoder({ xref, resources, handler,
-                                forceDataSchema = false,
-                                pdfFunctionFactory, }) {
-    this.xref = xref;
-    this.resources = resources;
-    this.handler = handler;
-    this.forceDataSchema = forceDataSchema;
-    this.pdfFunctionFactory = pdfFunctionFactory;
-  }
-  NativeImageDecoder.prototype = {
-    canDecode(image) {
-      return image instanceof JpegStream &&
-             NativeImageDecoder.isDecodable(image, this.xref, this.resources,
-                                            this.pdfFunctionFactory);
-    },
-    decode(image) {
-      // For natively supported JPEGs send them to the main thread for decoding.
-      var dict = image.dict;
-      var colorSpace = dict.get('ColorSpace', 'CS');
-      colorSpace = ColorSpace.parse(colorSpace, this.xref, this.resources,
-                                    this.pdfFunctionFactory);
-
-      return this.handler.sendWithPromise('JpegDecode', [
-        image.getIR(this.forceDataSchema), colorSpace.numComps
-      ]).then(function({ data, width, height, }) {
-        return new Stream(data, 0, data.length, image.dict);
-      });
-    },
-  };
-  /**
-   * Checks if the image can be decoded and displayed by the browser without any
-   * further processing such as color space conversions.
-   */
-  NativeImageDecoder.isSupported = function(image, xref, res,
-                                            pdfFunctionFactory) {
-    var dict = image.dict;
-    if (dict.has('DecodeParms') || dict.has('DP')) {
-      return false;
-    }
-    var cs = ColorSpace.parse(dict.get('ColorSpace', 'CS'), xref, res,
-                              pdfFunctionFactory);
-    // isDefaultDecode() of DeviceGray and DeviceRGB needs no `bpc` argument.
-    return (cs.name === 'DeviceGray' || cs.name === 'DeviceRGB') &&
-           cs.isDefaultDecode(dict.getArray('Decode', 'D'));
-  };
-  /**
-   * Checks if the image can be decoded by the browser.
-   */
-  NativeImageDecoder.isDecodable = function(image, xref, res,
-                                            pdfFunctionFactory) {
-    var dict = image.dict;
-    if (dict.has('DecodeParms') || dict.has('DP')) {
-      return false;
-    }
-    var cs = ColorSpace.parse(dict.get('ColorSpace', 'CS'), xref, res,
-                              pdfFunctionFactory);
-    const bpc = dict.get('BitsPerComponent', 'BPC') || 1;
-    return (cs.numComps === 1 || cs.numComps === 3) &&
-           cs.isDefaultDecode(dict.getArray('Decode', 'D'), bpc);
   };
 
   function PartialEvaluator({ pdfManager, xref, handler, pageIndex, idFactory,

--- a/src/core/image_utils.js
+++ b/src/core/image_utils.js
@@ -1,0 +1,85 @@
+/* Copyright 2019 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint no-var: error */
+
+import { ColorSpace } from './colorspace';
+import { JpegStream } from './jpeg_stream';
+import { Stream } from './stream';
+
+class NativeImageDecoder {
+  constructor({ xref, resources, handler, forceDataSchema = false,
+                pdfFunctionFactory, }) {
+    this.xref = xref;
+    this.resources = resources;
+    this.handler = handler;
+    this.forceDataSchema = forceDataSchema;
+    this.pdfFunctionFactory = pdfFunctionFactory;
+  }
+
+  canDecode(image) {
+    return image instanceof JpegStream &&
+           NativeImageDecoder.isDecodable(image, this.xref, this.resources,
+                                          this.pdfFunctionFactory);
+  }
+
+  decode(image) {
+    // For natively supported JPEGs send them to the main thread for decoding.
+    const dict = image.dict;
+    let colorSpace = dict.get('ColorSpace', 'CS');
+    colorSpace = ColorSpace.parse(colorSpace, this.xref, this.resources,
+                                  this.pdfFunctionFactory);
+
+    return this.handler.sendWithPromise('JpegDecode', [
+      image.getIR(this.forceDataSchema), colorSpace.numComps
+    ]).then(function({ data, width, height, }) {
+      return new Stream(data, 0, data.length, dict);
+    });
+  }
+
+  /**
+   * Checks if the image can be decoded and displayed by the browser without any
+   * further processing such as color space conversions.
+   */
+  static isSupported(image, xref, res, pdfFunctionFactory) {
+    const dict = image.dict;
+    if (dict.has('DecodeParms') || dict.has('DP')) {
+      return false;
+    }
+    const cs = ColorSpace.parse(dict.get('ColorSpace', 'CS'), xref, res,
+                                pdfFunctionFactory);
+    // isDefaultDecode() of DeviceGray and DeviceRGB needs no `bpc` argument.
+    return (cs.name === 'DeviceGray' || cs.name === 'DeviceRGB') &&
+           cs.isDefaultDecode(dict.getArray('Decode', 'D'));
+  }
+
+  /**
+   * Checks if the image can be decoded by the browser.
+   */
+  static isDecodable(image, xref, res, pdfFunctionFactory) {
+    const dict = image.dict;
+    if (dict.has('DecodeParms') || dict.has('DP')) {
+      return false;
+    }
+    const cs = ColorSpace.parse(dict.get('ColorSpace', 'CS'), xref, res,
+                                pdfFunctionFactory);
+    const bpc = dict.get('BitsPerComponent', 'BPC') || 1;
+    return (cs.numComps === 1 || cs.numComps === 3) &&
+           cs.isDefaultDecode(dict.getArray('Decode', 'D'), bpc);
+  }
+}
+
+export {
+  NativeImageDecoder,
+};


### PR DESCRIPTION
Given the size of the `src/core/evaluator.js` file, it cannot hurt to move some of its (image related) helper functionality into a separate file.

Split from PR #10613, since I think this makes sense in general.