### PR TITLE
Ensure that `blob:` URLs will be revoked when pages are cleaned-up/destroyed (JPEG memory usage)

### DIFF
--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -488,6 +488,7 @@ function releaseImageResources(img) {
       URL.revokeObjectURL) {
     URL.revokeObjectURL(url);
   }
+  img.removeAttribute('src');
 }
 
 export {

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -480,6 +480,16 @@ function deprecated(details) {
   console.log('Deprecated API usage: ' + details);
 }
 
+function releaseImageResources(img) {
+  assert(img instanceof Image, 'Invalid `img` parameter.');
+
+  const url = img.src;
+  if (typeof url === 'string' && url.startsWith('blob:') &&
+      URL.revokeObjectURL) {
+    URL.revokeObjectURL(url);
+  }
+}
+
 export {
   PageViewport,
   RenderingCancelledException,
@@ -496,4 +506,5 @@ export {
   isValidFetchUrl,
   loadScript,
   deprecated,
+  releaseImageResources,
 };


### PR DESCRIPTION
 - Ensure that `blob:` URLs will be revoked when pages are cleaned-up/destroyed

   Natively supported JPEG images are sent as-is, using a `blob:` or possibly a `data` URL, to the main-thread for loading/decoding.
However there's currently no attempt at releasing these resources, which are held alive by `blob:` URLs, which seems unfortunately given that images can be arbitrarily large.

   As mentioned in https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL the lifetime of these URLs are tied to the document, hence they are not being removed when a page is cleaned-up/destroyed (e.g. when being removed from the `PDFPageViewBuffer` in the viewer).
This is easy to test with the help of `about:memory` (in Firefox), which clearly shows the number of `blob:` URLs becomming arbitrarily large *without* this patch. With this patch however the `blob:` URLs are immediately release upon clean-up as expected, and the memory consumption should thus be considerably reduced for long documents with (simple) JPEG images.

 - Remove the `src` attribute from `Image` objects used with natively supported JPEG images, when pages are cleaned-up/destroyed

   This will further help reduce the amount of image data that's currently being held alive, by explicitly removing the `src` attribute.

   Please note that this is mostly relevant for browsers which do not support `URL.createObjectURL`, or where `disableCreateObjectURL` was manually set by the user, since `blob:` URLs will be revoked (see the previous patch).
However, using `about:memory` (in Firefox) it does seem that this may also be generally helpful, given that calling `URL.revokeObjectURL` won't invalidate the image data itself (as far as I can tell).