### PR TITLE
Actually transfer eligible ImageMask data, rather than always copying it

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -333,8 +333,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           imageIsFromDecodeStream: image instanceof DecodeStream,
           inverseDecode: (!!decode && decode[0] > 0),
         });
-        imgData.cached = true;
+        imgData.cached = !!cacheKey;
         args = [imgData];
+
         operatorList.addOp(OPS.paintImageMaskXObject, args);
         if (cacheKey) {
           imageCache[cacheKey] = {


### PR DESCRIPTION
By transfering `ArrayBuffer`s you can avoid having two copies of the same data, i.e. one copy on each of the worker/main-thread, for data that's used only *once* on the worker-thread.

Note how the code in [`PDFImage.createMask`](https://github.com/mozilla/pdf.js/blob/80135378cadd98b55a835446f0857e4bc30524e0/src/core/image.js#L284-L285) goes to great lengths to actually enable tranfering of the image data. However in [`PartialEvaluator.buildPaintImageXObject`](https://github.com/mozilla/pdf.js/blob/80135378cadd98b55a835446f0857e4bc30524e0/src/core/evaluator.js#L336) the `cached` property is always set to `true`, which disqualifies the image data from being transfered; see [`getTransfers`](https://github.com/mozilla/pdf.js/blob/80135378cadd98b55a835446f0857e4bc30524e0/src/core/operator_list.js#L552-L554).

For most ImageMask data this patch won't matter, since images found in the `/Resources -> /XObject` dictionary will always be indexed by name. However for *inline* images which contains ImageMask data, where only "small" images are cached (in both `parser.js` and `evaluator.js`), the current code will result in some unnecessary memory usage.