### PR TITLE
Prepare the `MOZCENTRAL` viewer for receiving zoom events from the browser UI (bug 786674, bug 1177385)

### DIFF
--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -171,7 +171,7 @@ class MozL10n {
     'findentirewordchange',
     'findbarclose',
   ];
-  let handleEvent = function({ type, detail, }) {
+  const handleEvent = function({ type, detail, }) {
     if (!PDFViewerApplication.initialized) {
       return;
     }
@@ -193,7 +193,28 @@ class MozL10n {
     });
   };
 
-  for (let event of events) {
+  for (const event of events) {
+    window.addEventListener(event, handleEvent);
+  }
+})();
+
+(function listenZoomEvents() {
+  const events = [
+    'zoomin',
+    'zoomout',
+    'zoomreset',
+  ];
+  const handleEvent = function({ type, detail, }) {
+    if (!PDFViewerApplication.initialized) {
+      return;
+    }
+    PDFViewerApplication.eventBus.dispatch(type, {
+      source: window,
+      ignoreDuplicate: (type === 'zoomreset' ? true : undefined),
+    });
+  };
+
+  for (const event of events) {
     window.addEventListener(event, handleEvent);
   }
 })();


### PR DESCRIPTION
This lays the necessary foundation for handling zoom events originating within the browser itself, rather than in the viewer. Please note that this will also require a follow-up patch to `mozilla-central`, such that the viewer is actually notified when zooming occurs. *For example something like this:* https://gist.github.com/Snuffleupagus/8d27775a3b18f1cd6cac88351edf4f7f