### PR TITLE
Feature(Search): Adding Support for Searching w/ Index

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1354,6 +1354,7 @@ let PDFViewerApplication = {
     eventBus.on('documentproperties', webViewerDocumentProperties);
     eventBus.on('find', webViewerFind);
     eventBus.on('findfromurlhash', webViewerFindFromUrlHash);
+    eventBus.on('findsearchindexhash', webViewerFindSearchIndexHash);
     eventBus.on('updatefindmatchescount', webViewerUpdateFindMatchesCount);
     eventBus.on('updatefindcontrolstate', webViewerUpdateFindControlState);
     if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
@@ -1987,13 +1988,30 @@ function webViewerFind(evt) {
 }
 
 function webViewerFindFromUrlHash(evt) {
+  PDFViewerApplication.findBar.findField.value = evt.query;
+  PDFViewerApplication.findBar.open();
   PDFViewerApplication.findController.executeCommand('find', {
     query: evt.query,
     phraseSearch: evt.phraseSearch,
     caseSensitive: false,
     entireWord: false,
     highlightAll: true,
-    findPrevious: false,
+    findPrevious: true,
+  });
+}
+
+function webViewerFindSearchIndexHash(evt) {
+  PDFViewerApplication.findBar.findField.value = evt.query;
+  PDFViewerApplication.findBar.open();
+  PDFViewerApplication.findBar.entireWord.checked = true;
+  PDFViewerApplication.findController.executeCommand('findwithindex', {
+     query: evt.query,
+     phraseSearch: evt.phraseSearch,
+     caseSensitive: false,
+     highlightAll: true,
+     findPrevious: false,
+     entireWord: evt.entireWord,
+     occurrence: evt.occurrence,
   });
 }
 

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -142,7 +142,7 @@ class PDFFindController {
         clearTimeout(this._findTimeout);
         this._findTimeout = null;
       }
-      if (cmd === 'find') {
+      if (cmd === 'find' && cmd !== 'findwithindex') {
         // Trigger the find action with a small delay to avoid starting the
         // search when the user is still typing (saving resources).
         this._findTimeout = setTimeout(() => {
@@ -170,6 +170,25 @@ class PDFFindController {
           this._highlightMatches = true;
         }
         this._updateAllPages(); // Update the highlighting on all active pages.
+      } else if (cmd === 'findwithindex') {
+        this._nextMatch();
+        let promises = this._extractTextPromises;
+        Promise.all(promises).then((res) => {
+          // doc_index parameter
+          let index = parseInt(this.state.occurrence);
+          for (let i = 0; i < this.pageMatches.length; i++) {
+            if (this.pageMatches[i].length > 0) {
+              if (this.pageMatches[i].length > index) {
+                this._offset.pageIdx = i;
+                this._offset.matchIdx = index;
+                this._updateMatch(true);
+                break;
+              } else {
+                index = index - this.pageMatches[i].length;
+              }
+            }
+          }
+        });
       } else {
         this._nextMatch();
       }

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -202,11 +202,19 @@ class PDFLinkService {
     let pageNumber, dest;
     if (hash.includes('=')) {
       let params = parseQueryString(hash);
-      if ('search' in params) {
+      if ('search' in params && 'doc_index' in params) {
+        this.eventBus.dispatch('findsearchindexhash', {
+          source: this,
+          query: params['search'].replace(/"/g, ''),
+          phraseSearch: true,
+          entireWord: true,
+          occurrence: params['doc_index'],
+        });
+      } else if ('search' in params) {
         this.eventBus.dispatch('findfromurlhash', {
           source: this,
           query: params['search'].replace(/"/g, ''),
-          phraseSearch: (params['phrase'] === 'true'),
+          phraseSearch: true,
         });
       }
       // borrowing syntax from "Parameters for Opening PDF Files"


### PR DESCRIPTION
Currently, PDF.js does not support searching a document with an index. So if I wanted to search for the 3rd instance of the word "happy", I can't. This code change adds the parameter "doc_index" to allow for that. Now if a search term and an index is applied, the correct instance of the term will be highlighted.