### PR TITLE
Remove the Firefox-specific 'read with streaming' unit-test

### DIFF
--- a/test/unit/network_spec.js
+++ b/test/unit/network_spec.js
@@ -18,8 +18,6 @@ import { PDFNetworkStream } from '../../src/display/network';
 describe('network', function() {
   var pdf1 = new URL('../pdfs/tracemonkey.pdf', window.location).href;
   var pdf1Length = 1016315;
-  var pdf2 = new URL('../pdfs/pdf.pdf', window.location).href;
-  var pdf2Length = 32472771;
 
   it('read without stream and range', function(done) {
     var stream = new PDFNetworkStream({
@@ -56,58 +54,6 @@ describe('network', function() {
       expect(count).toEqual(1);
       expect(isStreamingSupported).toEqual(false);
       expect(isRangeSupported).toEqual(false);
-      done();
-    }).catch(function (reason) {
-      done.fail(reason);
-    });
-  });
-
-  it('read with streaming', function(done) {
-    var userAgent = window.navigator.userAgent;
-    // The test is valid for FF only: the XHR has support of the
-    // 'moz-chunked-array' response type.
-    // TODO enable for other browsers, e.g. when fetch/streams API is supported.
-    var m = /Mozilla\/5.0.*?rv:(\d+).*? Gecko/.exec(userAgent);
-    if (!m || m[1] < 9) {
-      expect(true).toEqual(true);
-      done();
-      return;
-    }
-
-    var stream = new PDFNetworkStream({
-      url: pdf2,
-      rangeChunkSize: 65536,
-      disableStream: false,
-      disableRange: false,
-    });
-
-    var fullReader = stream.getFullReader();
-
-    var isStreamingSupported, isRangeSupported;
-    var promise = fullReader.headersReady.then(function () {
-      isStreamingSupported = fullReader.isStreamingSupported;
-      isRangeSupported = fullReader.isRangeSupported;
-    });
-
-    var len = 0, count = 0;
-    var read = function () {
-      return fullReader.read().then(function (result) {
-        if (result.done) {
-          return;
-        }
-        count++;
-        len += result.value.byteLength;
-        return read();
-      });
-    };
-
-    var readPromise = Promise.all([read(), promise]);
-
-    readPromise.then(function () {
-      expect(len).toEqual(pdf2Length);
-      expect(count).toBeGreaterThan(1);
-      expect(isStreamingSupported).toEqual(true);
-      expect(isRangeSupported).toEqual(true);
       done();
     }).catch(function (reason) {
       done.fail(reason);


### PR DESCRIPTION
Support for the non-standard `moz-chunked-arraybuffer` response type is in the process of being removed from Firefox; see e.g. https://bugzilla.mozilla.org/show_bug.cgi?id=1411865

For the time being, you probably want to keep support for this in the general PDF.js library given that feature detection is used. However, removing the unit-test immediately seems reasonable, since it will otherwise start failing once the platform support for `moz-chunked-arraybuffer` is gone.

Fixes #8851; please note that if unit-tests for the code in `fetch_stream.js` are wanted, which I'm assuming they are, those should live in their own file rather than being lumped into `network_spec.js` anyway.