### PR TITLE
[Firefox regression] Fix `disableRange=true` bug in `PDFDataTransportStream`

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1526,5 +1526,30 @@ describe('api', function() {
         });
       }).catch(done.fail);
     });
+
+    it('should fetch document info and page, without range, ' +
+       'using complete initialData', function(done) {
+      let fetches = 0, loadingTask;
+
+      dataPromise.then(function(data) {
+        const transport =
+          new PDFDataRangeTransport(data.length, data,
+                                    /* progressiveDone = */ true);
+        transport.requestDataRange = function(begin, end) {
+          fetches++;
+        };
+        loadingTask = getDocument({ disableRange: true, range: transport, });
+        return loadingTask.promise;
+      }).then(function(pdfDocument) {
+        expect(pdfDocument.numPages).toEqual(14);
+
+        return pdfDocument.getPage(10);
+      }).then(function(pdfPage) {
+        expect(pdfPage.rotate).toEqual(0);
+        expect(fetches).toEqual(0);
+
+        loadingTask.destroy().then(done);
+      }).catch(done.fail);
+    });
   });
 });

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -256,7 +256,7 @@ PDFViewerApplication.externalServices = {
       switch (args.pdfjsLoadAction) {
         case 'supportsRangedLoading':
           pdfDataRangeTransport =
-            new FirefoxComDataRangeTransport(args.length, args.data);
+            new FirefoxComDataRangeTransport(args.length, args.data, args.done);
 
           callbacks.onOpenWithTransport(args.pdfUrl, args.length,
                                         pdfDataRangeTransport);
@@ -269,6 +269,11 @@ PDFViewerApplication.externalServices = {
           break;
         case 'progressiveRead':
           pdfDataRangeTransport.onDataProgressiveRead(args.chunk);
+          break;
+        case 'progressiveDone':
+          if (pdfDataRangeTransport) {
+            pdfDataRangeTransport.onDataProgressiveDone();
+          }
           break;
         case 'progress':
           callbacks.onProgress(args.loaded, args.total);


### PR DESCRIPTION
Currently if trying to set `disableRange=true` in the built-in PDF Viewer in Firefox, either through `about:config` or via the URL hash, the PDF document will never load. It appears that this has been broken for a couple of years, without anyone noticing.

Obviously it's not a good idea to set `disableRange=true`, however it seems that this bug affects the PDF Viewer in Firefox even with default settings:
 - In the case where `initialData` already contains the *entire* file, we're forced to dispatch a range request to re-fetch already available data just so that file loading may complete.
 - (In the case where the data arrives, via streaming, before being specifically requested through `requestDataRange`, we're also forced to re-fetch data unnecessarily.) *This part was removed, to reduce the scope/risk of the patch somewhat.*

In the cases outlined above, we're having to re-fetch already available data thus potentially delaying loading/rendering of PDF files in Firefox (and wasting resources in the process).

/cc @yurydelendik Could you please, time permitting of course, check that this patch makes sense?