### PR TITLE
fix: electron enviroment detection

### DIFF
--- a/src/shared/is_node.js
+++ b/src/shared/is_node.js
@@ -15,9 +15,10 @@
 /* globals module, process */
 
 module.exports = function isNodeJS() {
-  // NW.js is a browser context, but copies some Node.js objects; see
+  // NW.js / Electron is a browser context, but copies some Node.js objects; see
   // http://docs.nwjs.io/en/latest/For%20Users/Advanced/JavaScript%20Contexts%20in%20NW.js/#access-nodejs-and-nwjs-api-in-browser-context
+  // https://electronjs.org/docs/api/process#processversionselectron
   return typeof process === 'object' &&
          process + '' === '[object process]' &&
-         !process.versions['nw'];
+         !process.versions['nw'] && !process.versions['electron'];
 };


### PR DESCRIPTION
Like #10228 , just treat Electron as a browser, but not Node.js.  

https://electronjs.org/docs/api/process#processversionselectron