### PR TITLE
Avoid dispatching range requests to fetch PDF data that's already loaded with streaming (PR 10675 follow-up)

### DIFF
--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -42,6 +42,10 @@ class PDFFetchStream {
     this._rangeRequestReaders = [];
   }
 
+  get _progressiveDataLength() {
+    return (this._fullRequestReader ? this._fullRequestReader._loaded : 0);
+  }
+
   getFullReader() {
     assert(!this._fullRequestReader);
     this._fullRequestReader = new PDFFetchStreamReader(this);
@@ -49,6 +53,9 @@ class PDFFetchStream {
   }
 
   getRangeReader(begin, end) {
+    if (end <= this._progressiveDataLength) {
+      return null;
+    }
     let reader = new PDFFetchStreamRangeReader(this, begin, end);
     this._rangeRequestReaders.push(reader);
     return reader;


### PR DESCRIPTION
*Please note:* This patch purposely ignores `src/display/network.js`, since its support for progressive reading depends on the non-standard `moz-chunked-arraybuffer` responseType which is now in the process of being removed.

/cc @yurydelendik 

*Edit:* Note that PR #10675 ***must*** land first, since otherwise you'd risk breaking the PDF Viewer in Firefox.