### PR TITLE
Remove `src/core/annotation.js` from the `gulp jsdoc` build target

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -950,7 +950,6 @@ gulp.task('jsdoc', function (done) {
     'src/doc_helper.js',
     'src/display/api.js',
     'src/shared/util.js',
-    'src/core/annotation.js'
   ];
 
   rimraf(JSDOC_BUILD_DIR, function () {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -795,7 +795,7 @@ class PDFDocumentProxy {
  *
  * @typedef {Object} TextContent
  * @property {array} items - array of {@link TextItem}
- * @property {Object} styles - {@link TextStyles} objects, indexed by font name.
+ * @property {Object} styles - {@link TextStyle} objects, indexed by font name.
  */
 
 /**


### PR DESCRIPTION
Note how at https://mozilla.github.io/pdf.js/api/ it's being described as API docs, however `src/core/annotation.js` is not part of the public API.
Furthermore, given that the code residing in the `src/core/` folder is run in a worker-thread, it's not even accessible on the main-thread (since `postMessage` is being used to transfer the data).
Hence the different API methods simply returns a "proxy" to the underlying data, but not actually the same objects and data structures as in the worker-thread itself; thus it doesn't make a whole lot of sense to expose this in API docs as far as I'm concerned.

Finally, the patch fixes a small JSDoc related typo in `src/display/api.js` when referring to the `TextStyle` typedef.