### PR TITLE
Better parsing of annotation data in worker thread. 

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -16,7 +16,8 @@
 
 import {
   AnnotationBorderStyleType, AnnotationFieldFlag, AnnotationFlag,
-  AnnotationType, OPS, stringToBytes, stringToPDFString, Util, warn
+  AnnotationReplyType, AnnotationType, OPS, stringToBytes,
+  stringToPDFString, Util, warn
 } from '../shared/util';
 import { Catalog, FileSpec, ObjectLoader } from './obj';
 import { Dict, isDict, isName, isRef, isStream } from './primitives';
@@ -101,6 +102,9 @@ class AnnotationFactory {
       case 'Circle':
         return new CircleAnnotation(parameters);
 
+      case 'FreeText':
+        return new FreeTextAnnotation(parameters);
+
       case 'PolyLine':
         return new PolylineAnnotation(parameters);
 
@@ -125,8 +129,35 @@ class AnnotationFactory {
       case 'Stamp':
         return new StampAnnotation(parameters);
 
+      case 'Caret':
+        return new CaretAnnotation(parameters);
+
+      case 'Sound':
+        return new SoundAnnotation(parameters);
+
+      case 'Movie':
+        return new MovieAnnotation(parameters);
+
       case 'FileAttachment':
         return new FileAttachmentAnnotation(parameters);
+
+      case 'Screen':
+        return new ScreenAnnotation(parameters);
+
+      case 'PrinterMark':
+        return new PrinterMarkAnnotation(parameters);
+
+      case 'TrapNet':
+        return new TrapNetAnnotation(parameters);
+
+      case 'Watermark':
+        return new WatermarkAnnotation(parameters);
+
+      case '3D':
+        return new ThreeDAnnotation(parameters);
+
+      case 'Redact':
+        return new RedactAnnotation(parameters);
 
       default:
         if (!subtype) {
@@ -166,6 +197,58 @@ function getTransformMatrix(rect, bbox, matrix) {
   ];
 }
 
+const pdfDateStringRegexp = new RegExp(
+  '^D:(\\d{4})(\\d{2})?(\\d{2})?(\\d{2})?' +
+  '(\\d{2})?(\\d{2})?([Z|+|-])?(\\d{2})?\'?(\\d{2})?\'?$'
+);
+
+const pdfDateStringMatchParse = function (match, year, month,
+  day, hour, minute, second, tz, tzHour, tzMinute) {
+
+  if (match === '') {
+    return;
+  }
+
+  let result = year + (month ? '-' + month : '') +
+    (day ? '-' + day : '');
+
+  if (hour) {
+    result +=
+      'T' + hour + ':' + (minute || '00') +
+      (second ? ':' + second : '') + (tz || '');
+
+    if (tzHour) {
+      result += tzHour + ':' + (tzMinute || '00');
+    }
+  }
+  return result;
+};
+/**
+ * Converts pdf date string to ISO8061 string.
+ * @param {any} str
+ * @return {undefined} When pdf date string doesn't meet spec of pdf date string
+ * @throws {Error} When non-string or non-pdf-date-string is on input
+ * (Has to start with 'D:' and have at least length of 6 chars).
+ */
+function pdfDateStringToISOString(str) {
+
+  if (typeof str === 'string') {
+    let result = str.replace(
+      pdfDateStringRegexp,
+      pdfDateStringMatchParse
+    );
+
+    if (result === str || result === '') {
+      warn('Unsupported pdf date format: ' + str);
+      return;
+    }
+
+    return result;
+  }
+
+  throw new Error('Invalid argument for pdfDateStringToJsDateString');
+}
+
 class Annotation {
   constructor(params) {
     let dict = params.dict;
@@ -175,6 +258,10 @@ class Annotation {
     this.setColor(dict.getArray('C'));
     this.setBorderStyle(dict);
     this.setAppearance(dict);
+
+    if (dict.has('M')) {
+      this.setModifiedDate(dict.get('M'));
+    }
 
     // Expose public properties using a data object.
     this.data = {
@@ -186,6 +273,15 @@ class Annotation {
       rect: this.rectangle,
       subtype: params.subtype,
     };
+
+    if (dict.has('Contents')) {
+      this.data.contents = stringToPDFString(dict.get('Contents') || '');
+    }
+
+    if (this.modifiedDate) {
+      this.data.modifiedDate = this.modifiedDate;
+    }
+
   }
 
   /**
@@ -395,21 +491,16 @@ class Annotation {
   }
 
   /**
-   * Prepare the annotation for working with a popup in the display layer.
-   *
-   * @private
+   * Set ModifiedDate (PdfStringDate) to annotation.
+   * @public
    * @memberof Annotation
-   * @param {Dict} dict - The annotation's data dictionary
+   * @param {PdfStringDate} modifiedDate Date in PDF Date format (ASN.1 ISO)
    */
-  _preparePopup(dict) {
-    if (!dict.has('C')) {
-      // Fall back to the default background color.
-      this.data.color = null;
+  setModifiedDate(modifiedDate) {
+    let dateString = pdfDateStringToISOString(modifiedDate);
+    if (dateString) {
+      this.modifiedDate = new Date(dateString);
     }
-
-    this.data.hasPopup = dict.has('Popup');
-    this.data.title = stringToPDFString(dict.get('T') || '');
-    this.data.contents = stringToPDFString(dict.get('Contents') || '');
   }
 
   loadResources(keys) {
@@ -460,6 +551,86 @@ class Annotation {
         return opList;
       });
     });
+  }
+}
+
+/**
+ * Class for Markup Annotations
+ * defined in spec: PDF 32000-1:2008 (page 391, chapter 12.5.6.2)
+ */
+class MarkupAnnotation extends Annotation {
+  constructor(parameters) {
+    super(parameters);
+    let dict = parameters.dict;
+
+    this.data.isMarkup = true;
+
+    if (dict.has('IT')) {
+      this.data.intent = dict.get('IT').name;
+    }
+
+    if (dict.has('IRT')) {
+      this.data.inReplyTo = dict.getRaw('IRT').toString();
+      this.data.replyType = dict.has('RT') ? dict.get('RT').name : 'R';
+    }
+
+    if (this.data.replyType === AnnotationReplyType.GROUP) {
+      let parent = dict.get('IRT');
+
+      this.data.title = stringToPDFString(parent.get('T') || '');
+      this.data.subject = stringToPDFString(parent.get('Subj') || '');
+      this.data.contents = stringToPDFString(parent.get('Contents') || '');
+      this.setCreationDate(parent);
+
+      if (parent.has('M')) {
+        this.setModifiedDate(parent.get('M'));
+      }
+
+      // parent's popup should be used
+      this.data.hasPopup = parent.has('Popup');
+
+      if (!parent.has('C')) {
+        // Fall back to the default background color.
+        this.data.color = null;
+      } else {
+        this.setColor(parent.getArray('C'));
+        this.data.color = this.color;
+      }
+
+    } else {
+      this.data.hasPopup = dict.has('Popup');
+
+      this.data.title = stringToPDFString(dict.get('T') || '');
+      this.data.subject = stringToPDFString(dict.get('Subj') || '');
+
+      if (!dict.has('C')) {
+        // Fall back to the default background color.
+        this.data.color = null;
+      }
+
+      this.setCreationDate(dict);
+    }
+
+    if (dict.has('RC')) {
+      let richText = dict.get('RC');
+      if (typeof richText === 'string') {
+        this.data.richText = stringToPDFString(richText);
+      }/* TODO: how to parse string stream into string ?
+       * else if (isStream(richText)) {
+          this.data.subject = bytesToString(richText.getBytes());
+      } */
+    }
+  }
+
+  setCreationDate(dict) {
+    if (dict.has('CreationDate')) {
+      let creationDateString =
+        pdfDateStringToISOString(dict.get('CreationDate'));
+
+      if (creationDateString) {
+        this.data.creationDate = new Date(creationDateString);
+      }
+    }
   }
 }
 
@@ -890,12 +1061,12 @@ class ChoiceWidgetAnnotation extends WidgetAnnotation {
   }
 }
 
-class TextAnnotation extends Annotation {
+class TextAnnotation extends MarkupAnnotation {
   constructor(parameters) {
     const DEFAULT_ICON_SIZE = 22; // px
 
     super(parameters);
-
+    let dict = parameters.dict;
     this.data.annotationType = AnnotationType.TEXT;
 
     if (this.data.hasAppearance) {
@@ -903,11 +1074,16 @@ class TextAnnotation extends Annotation {
     } else {
       this.data.rect[1] = this.data.rect[3] - DEFAULT_ICON_SIZE;
       this.data.rect[2] = this.data.rect[0] + DEFAULT_ICON_SIZE;
-      this.data.name = parameters.dict.has('Name') ?
-                       parameters.dict.get('Name').name : 'Note';
+      this.data.name = dict.has('Name') ? dict.get('Name').name : 'Note';
     }
-    this._preparePopup(parameters.dict);
+
+    if (dict.has('State')) {
+      this.data.state = dict.get('State');
+      this.data.stateModel = dict.get('StateModel');
+    }
+
   }
+
 }
 
 class LinkAnnotation extends Annotation {
@@ -942,6 +1118,7 @@ class PopupAnnotation extends Annotation {
     this.data.parentId = dict.getRaw('Parent').toString();
     this.data.title = stringToPDFString(parentItem.get('T') || '');
     this.data.contents = stringToPDFString(parentItem.get('Contents') || '');
+    this.data.open = dict.get('Open') || false;
 
     if (!parentItem.has('C')) {
       // Fall back to the default background color.
@@ -963,7 +1140,7 @@ class PopupAnnotation extends Annotation {
   }
 }
 
-class LineAnnotation extends Annotation {
+class LineAnnotation extends MarkupAnnotation {
   constructor(parameters) {
     super(parameters);
 
@@ -971,29 +1148,34 @@ class LineAnnotation extends Annotation {
 
     let dict = parameters.dict;
     this.data.lineCoordinates = Util.normalizeRect(dict.getArray('L'));
-    this._preparePopup(dict);
   }
 }
 
-class SquareAnnotation extends Annotation {
+class SquareAnnotation extends MarkupAnnotation {
   constructor(parameters) {
     super(parameters);
 
     this.data.annotationType = AnnotationType.SQUARE;
-    this._preparePopup(parameters.dict);
   }
 }
 
-class CircleAnnotation extends Annotation {
+class CircleAnnotation extends MarkupAnnotation {
   constructor(parameters) {
     super(parameters);
 
     this.data.annotationType = AnnotationType.CIRCLE;
-    this._preparePopup(parameters.dict);
   }
 }
 
-class PolylineAnnotation extends Annotation {
+class FreeTextAnnotation extends MarkupAnnotation {
+  constructor(parameters) {
+    super(parameters);
+
+    this.data.annotationType = AnnotationType.FREETEXT;
+  }
+}
+
+class PolylineAnnotation extends MarkupAnnotation {
   constructor(parameters) {
     super(parameters);
 
@@ -1012,8 +1194,6 @@ class PolylineAnnotation extends Annotation {
         y: rawVertices[i + 1],
       });
     }
-
-    this._preparePopup(dict);
   }
 }
 
@@ -1026,7 +1206,7 @@ class PolygonAnnotation extends PolylineAnnotation {
   }
 }
 
-class InkAnnotation extends Annotation {
+class InkAnnotation extends MarkupAnnotation {
   constructor(parameters) {
     super(parameters);
 
@@ -1050,56 +1230,122 @@ class InkAnnotation extends Annotation {
         });
       }
     }
-    this._preparePopup(dict);
   }
 }
 
-class HighlightAnnotation extends Annotation {
+class HighlightAnnotation extends MarkupAnnotation {
   constructor(parameters) {
     super(parameters);
 
     this.data.annotationType = AnnotationType.HIGHLIGHT;
-    this._preparePopup(parameters.dict);
   }
 }
 
-class UnderlineAnnotation extends Annotation {
+class UnderlineAnnotation extends MarkupAnnotation {
   constructor(parameters) {
     super(parameters);
 
     this.data.annotationType = AnnotationType.UNDERLINE;
-    this._preparePopup(parameters.dict);
   }
 }
 
-class SquigglyAnnotation extends Annotation {
+class SquigglyAnnotation extends MarkupAnnotation {
   constructor(parameters) {
     super(parameters);
 
     this.data.annotationType = AnnotationType.SQUIGGLY;
-    this._preparePopup(parameters.dict);
   }
 }
 
-class StrikeOutAnnotation extends Annotation {
+class StrikeOutAnnotation extends MarkupAnnotation {
   constructor(parameters) {
     super(parameters);
 
     this.data.annotationType = AnnotationType.STRIKEOUT;
-    this._preparePopup(parameters.dict);
   }
 }
 
-class StampAnnotation extends Annotation {
+class CaretAnnotation extends MarkupAnnotation {
+  constructor(parameters) {
+    super(parameters);
+
+    this.data.annotationType = AnnotationType.CARET;
+  }
+}
+
+class StampAnnotation extends MarkupAnnotation {
   constructor(parameters) {
     super(parameters);
 
     this.data.annotationType = AnnotationType.STAMP;
-    this._preparePopup(parameters.dict);
   }
 }
 
-class FileAttachmentAnnotation extends Annotation {
+class SoundAnnotation extends MarkupAnnotation {
+  constructor(parameters) {
+    super(parameters);
+
+    this.data.annotationType = AnnotationType.SOUND;
+  }
+}
+
+class MovieAnnotation extends Annotation {
+  constructor(parameters) {
+    super(parameters);
+
+    this.data.annotationType = AnnotationType.MOVIE;
+  }
+}
+
+class ScreenAnnotation extends Annotation {
+  constructor(parameters) {
+    super(parameters);
+
+    this.data.annotationType = AnnotationType.SCREEN;
+  }
+}
+
+class PrinterMarkAnnotation extends Annotation {
+  constructor(parameters) {
+    super(parameters);
+
+    this.data.annotationType = AnnotationType.PRINTERMARK;
+  }
+}
+
+class TrapNetAnnotation extends Annotation {
+  constructor(parameters) {
+    super(parameters);
+
+    this.data.annotationType = AnnotationType.TRAPNET;
+  }
+}
+
+class WatermarkAnnotation extends Annotation {
+  constructor(parameters) {
+    super(parameters);
+
+    this.data.annotationType = AnnotationType.WATERMARK;
+  }
+}
+
+class ThreeDAnnotation extends Annotation {
+  constructor(parameters) {
+    super(parameters);
+
+    this.data.annotationType = AnnotationType.THREED;
+  }
+}
+
+class RedactAnnotation extends Annotation {
+  constructor(parameters) {
+    super(parameters);
+
+    this.data.annotationType = AnnotationType.REDACT;
+  }
+}
+
+class FileAttachmentAnnotation extends MarkupAnnotation {
   constructor(parameters) {
     super(parameters);
 
@@ -1107,7 +1353,6 @@ class FileAttachmentAnnotation extends Annotation {
 
     this.data.annotationType = AnnotationType.FILEATTACHMENT;
     this.data.file = file.serializable;
-    this._preparePopup(parameters.dict);
   }
 }
 
@@ -1115,4 +1360,5 @@ export {
   Annotation,
   AnnotationBorderStyle,
   AnnotationFactory,
+  pdfDateStringToISOString,
 };

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -1116,8 +1116,6 @@ class PopupAnnotation extends Annotation {
     let parentSubtype = parentItem.get('Subtype');
     this.data.parentType = isName(parentSubtype) ? parentSubtype.name : null;
     this.data.parentId = dict.getRaw('Parent').toString();
-    this.data.title = stringToPDFString(parentItem.get('T') || '');
-    this.data.contents = stringToPDFString(parentItem.get('Contents') || '');
     this.data.open = dict.get('Open') || false;
 
     if (!parentItem.has('C')) {
@@ -1137,6 +1135,18 @@ class PopupAnnotation extends Annotation {
         this.setFlags(parentFlags);
       }
     }
+
+    if (parentItem.has('RT')) {
+      if ((parentItem.get('RT').name ||
+        AnnotationReplyType.REPLY) === AnnotationReplyType.GROUP) {
+        // If parent item is group reply,
+        // we have to take data of it's master(IRT)
+        parentItem = parentItem.get('IRT');
+      }
+    }
+
+    this.data.title = stringToPDFString(parentItem.get('T') || '');
+    this.data.contents = stringToPDFString(parentItem.get('Contents') || '');
   }
 }
 

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -86,6 +86,29 @@ const AnnotationType = {
   REDACT: 26,
 };
 
+const AnnotationStateModelType = {
+  MARKED: 'Marked',
+  REVIEW: 'Review',
+};
+
+const AnnotationMarkedState = {
+  MARKED: 'Marked',
+  UNMARKED: 'Unmarked',
+};
+
+const AnnotationReviewState = {
+  ACCEPTED: 'Accepted',
+  REJECTED: 'Rejected',
+  CANCELLED: 'Cancelled',
+  COMPLETED: 'Completed',
+  NONE: 'None',
+};
+
+const AnnotationReplyType = {
+  GROUP: 'Group',
+  REPLY: 'R',
+};
+
 const AnnotationFlag = {
   INVISIBLE: 0x01,
   HIDDEN: 0x02,
@@ -910,6 +933,10 @@ export {
   AnnotationBorderStyleType,
   AnnotationFieldFlag,
   AnnotationFlag,
+  AnnotationMarkedState,
+  AnnotationReplyType,
+  AnnotationReviewState,
+  AnnotationStateModelType,
   AnnotationType,
   FontType,
   ImageKind,


### PR DESCRIPTION
Added parsing of IRT, RT, StateModel, State, CreationDate, ModifiedDate, RichText, IT, ... .
_preparePopup replaced with MarkupAnnotation base class. 
Added classes for missing annotations, so all anotations have correct subtype in data property.

Date parsing is done like this: pdf date string -> ISO 8601 string ( parse pdf date with regex and construct ISO string from that) -> new Date constructor. There are also unit tests, which should cover all cases (I hope).

There are also some unit tests to test some of the newly parsed properties.

This should help others (and pdf.js too) to build better UI layer for displaying annotations, because worker thread will provide a lot more info about annotations.


As of issue #10677 : there is missing implementation of caret annotation element in viewer part, but that should be easy, as there is nothing special ... it should be same as strikeout annotation.  

To make work strikeout + caret, there will be needed some changes in viewer part to correctly display master annotation(caret) popup on child annotation (strikeout) or some more changes in worker part. 

Child annotation has it's own popup, but during parsing, popup annotation is grabing raw data from child annotation (not-yet-parsed), so the master content is not there yet :/. I'm affraid, it is not currently possible to access parsed data of other annotations during parsing process ... so it should be probably handled in viewer part or there should be added some after-process into worker part, which will handle this ... Or maybe, popup annot could look at parent, check if it is RT Group and if it is, then go for it's parent ?

 What do you think guys?