### PR TITLE
[api-minor] Implement caret annotations

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -107,6 +107,9 @@ class AnnotationFactory {
       case 'Polygon':
         return new PolygonAnnotation(parameters);
 
+      case 'Caret':
+        return new CaretAnnotation(parameters);
+
       case 'Ink':
         return new InkAnnotation(parameters);
 
@@ -1023,6 +1026,15 @@ class PolygonAnnotation extends PolylineAnnotation {
     super(parameters);
 
     this.data.annotationType = AnnotationType.POLYGON;
+  }
+}
+
+class CaretAnnotation extends Annotation {
+  constructor(parameters) {
+    super(parameters);
+
+    this.data.annotationType = AnnotationType.CARET;
+    this._preparePopup(parameters.dict);
   }
 }
 

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -83,6 +83,9 @@ class AnnotationElementFactory {
       case AnnotationType.POLYLINE:
         return new PolylineAnnotationElement(parameters);
 
+      case AnnotationType.CARET:
+        return new CaretAnnotationElement(parameters);
+
       case AnnotationType.INK:
         return new InkAnnotationElement(parameters);
 
@@ -1014,6 +1017,30 @@ class PolygonAnnotationElement extends PolylineAnnotationElement {
 
     this.containerClassName = 'polygonAnnotation';
     this.svgElementName = 'svg:polygon';
+  }
+}
+
+class CaretAnnotationElement extends AnnotationElement {
+  constructor(parameters) {
+    const isRenderable = !!(parameters.data.hasPopup ||
+                            parameters.data.title || parameters.data.contents);
+    super(parameters, isRenderable, /* ignoreBorder = */ true);
+  }
+
+  /**
+   * Render the caret annotation's HTML element in the empty container.
+   *
+   * @public
+   * @memberof CaretAnnotationElement
+   * @returns {HTMLSectionElement}
+   */
+  render() {
+    this.container.className = 'caretAnnotation';
+
+    if (!this.data.hasPopup) {
+      this._createPopup(this.container, null, this.data);
+    }
+    return this.container;
   }
 }
 

--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -188,6 +188,7 @@
 .annotationLayer .circleAnnotation svg ellipse,
 .annotationLayer .polylineAnnotation svg polyline,
 .annotationLayer .polygonAnnotation svg polygon,
+.annotationLayer .caretAnnotation,
 .annotationLayer .inkAnnotation svg polyline,
 .annotationLayer .stampAnnotation,
 .annotationLayer .fileAttachmentAnnotation {


### PR DESCRIPTION
The file `test/pdfs/annotation-caret-ink.pdf` is already available in the repository as a reference test for this since I supplied it for another patch that implemented ink annotations.

@Snuffleupagus Could you perhaps review this if you have time? I notice that we have quite a bit of open annotation layer patches at the moment and most are too big or incomplete to be actionable, so I'm hoping to find some time later to fix them up. I already made a test file before, but forgot about actually implementing this annotation type and got reminded thanks to one of those patches. This is the first work to get the ball rolling again.