### PR TITLE
[api-minor] Add support for ViewerPreferences in the API (issue 10736)

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -525,7 +525,11 @@ var WorkerMessageHandler = {
       return pdfManager.ensureCatalog('pageMode');
     });
 
-    handler.on('getOpenActionDestination', function(data) {
+    handler.on('GetViewerPreferences', function(data) {
+      return pdfManager.ensureCatalog('viewerPreferences');
+    });
+
+    handler.on('GetOpenActionDestination', function(data) {
       return pdfManager.ensureCatalog('openActionDestination');
     });
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -675,6 +675,14 @@ class PDFDocumentProxy {
   }
 
   /**
+   * @return {Promise} A promise that is resolved with an {Object} containing
+   *   the viewer preferences.
+   */
+  getViewerPreferences() {
+    return this._transport.getViewerPreferences();
+  }
+
+  /**
    * @return {Promise} A promise that is resolved with an {Array} containing the
    *   destination, or `null` when no open action is present in the PDF file.
    */
@@ -2246,8 +2254,12 @@ class WorkerTransport {
     return this.messageHandler.sendWithPromise('GetPageMode', null);
   }
 
+  getViewerPreferences() {
+    return this.messageHandler.sendWithPromise('GetViewerPreferences', null);
+  }
+
   getOpenActionDestination() {
-    return this.messageHandler.sendWithPromise('getOpenActionDestination',
+    return this.messageHandler.sendWithPromise('GetOpenActionDestination',
                                                null);
   }
 

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -18,8 +18,9 @@ import {
   NodeFileReaderFactory, TEST_PDFS_PATH
 } from './test_utils';
 import {
-  createPromiseCapability, FontType, InvalidPDFException, MissingPDFException,
-  OPS, PasswordException, PasswordResponses, PermissionFlag, StreamType
+  createPromiseCapability, FontType, InvalidPDFException, isEmptyObj,
+  MissingPDFException, OPS, PasswordException, PasswordResponses,
+  PermissionFlag, StreamType
 } from '../../src/shared/util';
 import {
   DOMCanvasFactory, RenderingCancelledException, StatTimer
@@ -642,6 +643,27 @@ describe('api', function() {
     it('gets non-default page mode', function(done) {
       doc.getPageMode().then(function(mode) {
         expect(mode).toEqual('UseOutlines');
+        done();
+      }).catch(done.fail);
+    });
+
+    it('gets default viewer preferences', function(done) {
+      var loadingTask = getDocument(buildGetDocumentParams('tracemonkey.pdf'));
+
+      loadingTask.promise.then(function(pdfDocument) {
+        return pdfDocument.getViewerPreferences();
+      }).then(function(prefs) {
+        expect(typeof prefs === 'object' && prefs !== null &&
+               isEmptyObj(prefs)).toEqual(true);
+
+        loadingTask.destroy().then(done);
+      }).catch(done.fail);
+    });
+    it('gets non-default viewer preferences', function(done) {
+      doc.getViewerPreferences().then(function(prefs) {
+        expect(prefs).toEqual({
+          Direction: 'L2R',
+        });
         done();
       }).catch(done.fail);
     });


### PR DESCRIPTION
Please see the specification, https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#M11.9.12864.1Heading.71.Viewer.Preferences

Furthermore, note that this patch *only* adds API support and unit-tests but does not attempt to integrate e.g. the `ViewerPreferences -> Direction` property into the viewer (which would be necessary to address issue #10736).
The reason for this is that it's not entirely clear to me exactly if/how that could be implemented; e.g. would it be as simple as setting the `dir` attribute on the `viewerContainer` DOM element, or will it be more complicated?
There's also the question of how the `ViewerPreferences -> Direction` value interacts with the `PageMode`, and this will generally require a fair bit of manual testing. Since the direction of the *entire* viewer depends on the browser locale, there's also a somewhat open question regarding what default value to use for different locales.
Finally, if the viewer supports `ViewerPreferences -> Direction` then I'm assuming that it will be necessary to allow users to override the default value, which will require (most likely) new `SecondaryToolbar` buttons and icons for those etc.

Hence this patch only lays the necessary foundation for eventually addressing issue #10736, but defers the actual implementation until later. (Time permitting, I'll try to look into the viewer part later.)