### PR TITLE
[Firefox] Avoid displaying the indeterminate loadingBar when `disableStream=true` is set (PR 10714 follow-up)

### DIFF
--- a/src/display/transport_stream.js
+++ b/src/display/transport_stream.js
@@ -81,18 +81,18 @@ var PDFDataTransportStream = (function PDFDataTransportStreamClosure() {
     },
 
     _onProgress: function PDFDataTransportStream_onDataProgress(evt) {
-       if (evt.total === undefined && this._rangeReaders.length > 0) {
-         // Reporting to first range reader.
-         var firstReader = this._rangeReaders[0];
-         if (firstReader.onProgress) {
-           firstReader.onProgress({ loaded: evt.loaded, });
-           return;
-         }
-       }
-       let fullReader = this._fullRequestReader;
-       if (fullReader && fullReader.onProgress) {
-         fullReader.onProgress({ loaded: evt.loaded, total: evt.total, });
-       }
+      if (evt.total === undefined) {
+        // Reporting to first range reader, if it exists.
+        let firstReader = this._rangeReaders[0];
+        if (firstReader && firstReader.onProgress) {
+          firstReader.onProgress({ loaded: evt.loaded, });
+        }
+      } else {
+        let fullReader = this._fullRequestReader;
+        if (fullReader && fullReader.onProgress) {
+          fullReader.onProgress({ loaded: evt.loaded, total: evt.total, });
+        }
+      }
     },
 
     _onProgressiveDone() {


### PR DESCRIPTION
While PR #10714 did address the `disableRange=true` case, it also managed to "break" the `disableStream=true` case instead since the indeterminate loadingBar is now displayed when it shouldn't; sorry about that!
The solution is simple enough though, don't attempt to fallback to `_fullRequestReader.onProgress` when handling "incomplete" loading information. *Edit:* Smaller diff with https://github.com/mozilla/pdf.js/pull/10742/files?w=1

/cc @timvandermeij 