### PR TITLE
Add links to PDF.js homepage and API reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDF.js [![Build Status](https://travis-ci.org/mozilla/pdf.js.svg?branch=master)](https://travis-ci.org/mozilla/pdf.js)
 
-PDF.js is a Portable Document Format (PDF) viewer that is built with HTML5.
+[PDF.js](https://mozilla.github.io/pdf.js/) is a Portable Document Format (PDF) viewer that is built with HTML5.
 
 PDF.js is community-driven and supported by Mozilla Labs. Our goal is to
 create a general-purpose, web standards-based platform for parsing and
@@ -112,6 +112,10 @@ contributor Julian Viereck:
 More learning resources can be found at:
 
 + https://github.com/mozilla/pdf.js/wiki/Additional-Learning-Resources
+
+### API reference
+
+We’re currently working on [better API docs](https://mozilla.github.io/pdf.js/api/draft/index.html), but the API is well documented in [api.js](https://github.com/mozilla/pdf.js/blob/master/src/display/api.js).
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ More learning resources can be found at:
 
 + https://github.com/mozilla/pdf.js/wiki/Additional-Learning-Resources
 
-### API reference
+The API documentation can be found at:
 
-We’re currently working on [better API docs](https://mozilla.github.io/pdf.js/api/draft/index.html), but the API is well documented in [api.js](https://github.com/mozilla/pdf.js/blob/master/src/display/api.js).
++ https://mozilla.github.io/pdf.js/api/
 
 ## Questions
 


### PR DESCRIPTION
Just a tiny quality-of-life change. I frequently find myself landing on the repo from search engines with no quick and visible way to go to the project homepage or API docs. 