### PR TITLE
make the original font name available from getTextContent()

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1259,6 +1259,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           };
         }
         textContentItem.fontName = font.loadedName;
+        textContentItem.originalFontName = font.name;
 
         // 9.4.4 Text Space Details
         var tsm = [textState.fontSize * textState.textHScale, 0,
@@ -1339,6 +1340,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           height: textChunk.height,
           transform: textChunk.transform,
           fontName: textChunk.fontName,
+          originalFontName: textChunk.originalFontName,
         };
       }
 

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1169,6 +1169,7 @@ describe('api', function() {
             expect(items[0]).toEqual({
               dir: 'ltr',
               fontName: 'Times',
+              originalFontName: 'Times-Roman',
               height: 18,
               str: 'Issue 8276',
               transform: [18, 0, 0, 18, 441.81, 708.4499999999999],


### PR DESCRIPTION
The `fontName` available from `getTextContent()` calls appears to be the name of the font loaded to be used in text layer rendering, which can be different from the actual font name loaded from the PDF.  For example, in a test PDF, I see `getTextContent()` always return `fontName` "Helvetica" for chunks which are "Arial", ""Arial,Bold" and "Arial,BoldItalic".  

The original font name can be useful to applications in inferring information about the original PDF text, like determining whether adjacent text chunks belong together or not.  This can help applications improve selection and extraction efforts.

I wasn't able to find any other way to receive this information from the existing APIs, but many discussions/requests about how to retrieve similar information (such as https://github.com/mozilla/pdf.js/issues/7372).   