### PR TITLE
Add `passive: false` to the `wheel` event listener, to work-around broken default behaviour in Chrome 73 and above (issue 10761)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1399,7 +1399,7 @@ let PDFViewerApplication = {
     };
 
     window.addEventListener('visibilitychange', webViewerVisibilityChange);
-    window.addEventListener('wheel', webViewerWheel);
+    window.addEventListener('wheel', webViewerWheel, { passive: false, });
     window.addEventListener('click', webViewerClick);
     window.addEventListener('keydown', webViewerKeyDown);
     window.addEventListener('resize', _boundEvents.windowResize);


### PR DESCRIPTION
Let's try this, since it doesn't appear to break scrolling/zooming in IE11.

Fixes #10761