### PR TITLE
Ensure that the `OperatorList` constructor actually initializes a `NullOptimizer` when intended (PR 9089 follow-up)

### DIFF
--- a/src/core/operator_list.js
+++ b/src/core/operator_list.js
@@ -525,6 +525,8 @@ var NullOptimizer = (function NullOptimizerClosure() {
     },
 
     flush() { },
+
+    reset() { },
   };
 
   return NullOptimizer;
@@ -538,7 +540,7 @@ var OperatorList = (function OperatorListClosure() {
     this.messageHandler = messageHandler;
     this.fnArray = [];
     this.argsArray = [];
-    if (messageHandler && this.intent !== 'oplist') {
+    if (messageHandler && intent !== 'oplist') {
       this.optimizer = new QueueOptimizer(this);
     } else {
       this.optimizer = new NullOptimizer(this);


### PR DESCRIPTION
It appears that this has been broken ever since PR #9089, which also introduced this code, since the `QueueOptimizer`/`NullOptimizer` choice was made based on the still undefined `this.intent` property.

Furthermore, fixing this also uncovered the fact that the `NullOptimizer.reset` method was missing.