### PR TITLE
Enable the `consistent-return` ESLint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -57,6 +57,7 @@
 
     // Best Practices
     "accessor-pairs": ["error", { "setWithoutGet": true, }],
+    "consistent-return": "error",
     "curly": ["error", "all"],
     "eqeqeq": ["error", "always"],
     "no-caller": "error",

--- a/extensions/chromium/extension-router.js
+++ b/extensions/chromium/extension-router.js
@@ -43,7 +43,7 @@ limitations under the License.
     // Find the (url-encoded) colon and verify that the scheme is whitelisted.
     var schemeIndex = url.search(/:|%3A/i);
     if (schemeIndex === -1) {
-      return;
+      return undefined;
     }
     var scheme = url.slice(0, schemeIndex).toLowerCase();
     if (schemes.includes(scheme)) {
@@ -53,6 +53,7 @@ limitations under the License.
       }
       return url;
     }
+    return undefined;
   }
 
   // TODO(rob): Use declarativeWebRequest once declared URL-encoding is
@@ -72,6 +73,7 @@ limitations under the License.
       console.log('Redirecting ' + details.url + ' to ' + url);
       return { redirectUrl: url, };
     }
+    return undefined;
   }, {
     types: ['main_frame', 'sub_frame'],
     urls: schemes.map(function(scheme) {

--- a/extensions/chromium/pdfHandler.js
+++ b/extensions/chromium/pdfHandler.js
@@ -59,6 +59,7 @@ function getHeaderFromHeaders(headers, headerName) {
       return header;
     }
   }
+  return undefined;
 }
 
 /**
@@ -86,6 +87,7 @@ function isPdfFile(details) {
       }
     }
   }
+  return false;
 }
 
 /**
@@ -108,16 +110,17 @@ function getHeadersWithContentDispositionAttachment(details) {
     cdHeader.value = 'attachment' + cdHeader.value.replace(/^[^;]+/i, '');
     return { responseHeaders: headers, };
   }
+  return undefined;
 }
 
 chrome.webRequest.onHeadersReceived.addListener(
   function(details) {
     if (details.method !== 'GET') {
       // Don't intercept POST requests until http://crbug.com/104058 is fixed.
-      return;
+      return undefined;
     }
     if (!isPdfFile(details)) {
-      return;
+      return undefined;
     }
     if (isPdfDownloadable(details)) {
       // Force download by ensuring that Content-Disposition: attachment is set
@@ -142,7 +145,7 @@ chrome.webRequest.onHeadersReceived.addListener(
 chrome.webRequest.onBeforeRequest.addListener(
   function(details) {
     if (isPdfDownloadable(details)) {
-      return;
+      return undefined;
     }
 
     var viewerUrl = getViewerURL(details.url);
@@ -200,7 +203,7 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
     // sensitive (local) file in a frame.
     if (!sender.tab) {
       sendResponse('');
-      return;
+      return undefined;
     }
     // TODO: This should be the URL of the parent frame, not the tab. But
     // chrome-extension:-URLs are not visible in the webNavigation API
@@ -209,11 +212,11 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
     var parentUrl = sender.tab.url;
     if (!parentUrl) {
       sendResponse('');
-      return;
+      return undefined;
     }
     if (parentUrl.lastIndexOf('file:', 0) === 0) {
       sendResponse('file://');
-      return;
+      return undefined;
     }
     // The regexp should always match for valid URLs, but in case it doesn't,
     // just give the full URL (e.g. data URLs).
@@ -240,6 +243,7 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
       });
     }
   }
+  return undefined;
 });
 
 // Remove keys from storage that were once part of the deleted feature-detect.js

--- a/extensions/chromium/preserve-referer.js
+++ b/extensions/chromium/preserve-referer.js
@@ -130,7 +130,7 @@ chrome.runtime.onConnect.addListener(function onReceivePort(port) {
 
   function onBeforeSendHeaders(details) {
     if (details.frameId !== frameId) {
-      return;
+      return undefined;
     }
     var headers = details.requestHeaders;
     var refererHeader = getHeaderFromHeaders(headers, 'referer');
@@ -141,7 +141,7 @@ chrome.runtime.onConnect.addListener(function onReceivePort(port) {
         refererHeader.value.lastIndexOf('chrome-extension:', 0) !== 0) {
       // Sanity check. If the referer is set, and the value is not the URL of
       // this extension, then the request was not initiated by this extension.
-      return;
+      return undefined;
     }
     refererHeader.value = referer;
     return { requestHeaders: headers, };
@@ -149,7 +149,7 @@ chrome.runtime.onConnect.addListener(function onReceivePort(port) {
 
   function exposeOnHeadersReceived(details) {
     if (details.frameId !== frameId) {
-      return;
+      return undefined;
     }
     var headers = details.responseHeaders;
     var aceh = getHeaderFromHeaders(headers, 'access-control-expose-headers');

--- a/external/webpack/pdfjsdev-loader.js
+++ b/external/webpack/pdfjsdev-loader.js
@@ -19,7 +19,7 @@
 var preprocessor2 = require('../builder/preprocessor2.js');
 var path = require('path');
 
-module.exports = function (source) {
+module.exports = function(source) {
   // Options must be specified, ignoring request if not.
   if (!this.query || typeof this.query !== 'object') {
     return source;
@@ -40,4 +40,5 @@ module.exports = function (source) {
   // escodegen does not embed source -- setting map's sourcesContent.
   map.sourcesContent = [source];
   callback(null, sourceAndMap.code, map);
+  return undefined;
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -365,7 +365,7 @@ function getTempFile(prefix, suffix) {
 
 function createTestSource(testsName, bot) {
   var source = stream.Readable({ objectMode: true, });
-  source._read = function () {
+  source._read = function() {
     console.log();
     console.log('### Running ' + testsName + ' tests');
 
@@ -409,6 +409,7 @@ function createTestSource(testsName, bot) {
     testProcess.on('close', function (code) {
       source.push(null);
     });
+    return undefined;
   };
   return source;
 }
@@ -1245,9 +1246,10 @@ gulp.task('gh-pages-prepare', function () {
 gulp.task('wintersmith', function (done) {
   var wintersmith = require('wintersmith');
   var env = wintersmith('docs/config.json');
-  env.build(GH_PAGES_DIR, function (error) {
+  env.build(GH_PAGES_DIR, function(error) {
     if (error) {
-      return done(error);
+      done(error);
+      return;
     }
     replaceInFile(GH_PAGES_DIR + '/getting_started/index.html',
                   /STABLE_VERSION/g, config.stableVersion);

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -48,7 +48,7 @@ class AnnotationFactory {
   static _create(xref, ref, pdfManager, idFactory) {
     let dict = xref.fetchIfRef(ref);
     if (!isDict(dict)) {
-      return;
+      return undefined;
     }
     let id = isRef(ref) ? ref.toString() : `annot_${idFactory.createObjId()}`;
 
@@ -432,7 +432,7 @@ class Annotation {
   loadResources(keys) {
     return this.appearance.dict.getAsync('Resources').then((resources) => {
       if (!resources) {
-        return;
+        return undefined;
       }
       let objectLoader = new ObjectLoader(resources, keys, resources.xref);
 

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -302,12 +302,12 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
       if (!(w && isNum(w)) || !(h && isNum(h))) {
         warn('Image dimensions are missing, or not numbers.');
-        return;
+        return undefined;
       }
       var maxImageSize = this.options.maxImageSize;
       if (maxImageSize !== -1 && w * h > maxImageSize) {
         warn('Image exceeded maximum allowed size and was removed.');
-        return;
+        return undefined;
       }
 
       var imageMask = (dict.get('ImageMask', 'IM') || false);
@@ -343,7 +343,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
             args,
           };
         }
-        return;
+        return undefined;
       }
 
       var softMask = (dict.get('SMask', 'SM') || false);
@@ -364,7 +364,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         // any other kind.
         imgData = imageObj.createImageData(/* forceRGBA = */ true);
         operatorList.addOp(OPS.paintInlineImageXObject, [imgData]);
-        return;
+        return undefined;
       }
 
       const nativeImageDecoderSupport = forceDisableNativeImageDecoder ?
@@ -452,6 +452,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         }
         this.handler.send('obj', [objId, this.pageIndex, 'Image', imgData],
           [imgData.data.buffer]);
+        return undefined;
       }).catch((reason) => {
         warn('Unable to decode image: ' + reason);
 
@@ -460,6 +461,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
                                               [objId, 'FontType3Res', null]);
         }
         this.handler.send('obj', [objId, this.pageIndex, 'Image', null]);
+        return undefined;
       });
 
       if (this.parsingType3Font) {
@@ -476,6 +478,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           args,
         };
       }
+      return undefined;
     },
 
     handleSMask: function PartialEvaluator_handleSmask(smask, resources,

--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -973,6 +973,7 @@ var JpegImage = (function JpegImageClosure() {
         });
       }
       this.numComponents = this.components.length;
+      return undefined;
     },
 
     _getLinearizedBlockData(width, height, isSourcePDF = false) {

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -266,6 +266,7 @@ class Catalog {
     } else if (this.catDict.has('Dests')) { // Simple destination dictionary.
       return this.catDict.get('Dests');
     }
+    return undefined;
   }
 
   get pageLabels() {
@@ -1596,7 +1597,7 @@ var XRef = (function XRefClosure() {
       }
 
       if (recoveryMode) {
-        return;
+        return undefined;
       }
       throw new XRefParseException();
     },

--- a/src/core/operator_list.js
+++ b/src/core/operator_list.js
@@ -71,6 +71,7 @@ var QueueOptimizer = (function QueueOptimizerClosure() {
         case 3:
           return fnArray[i] === OPS.restore;
       }
+      throw new Error(`iterateInlineImageGroup - invalid pos: ${pos}`);
     },
     function foundInlineImageGroup(context, i) {
       var MIN_IMAGES_IN_INLINE_IMAGES_BLOCK = 10;
@@ -173,6 +174,7 @@ var QueueOptimizer = (function QueueOptimizerClosure() {
         case 3:
           return fnArray[i] === OPS.restore;
       }
+      throw new Error(`iterateImageMaskGroup - invalid pos: ${pos}`);
     },
     function foundImageMaskGroup(context, i) {
       var MIN_IMAGES_IN_MASKS_BLOCK = 10;
@@ -266,7 +268,7 @@ var QueueOptimizer = (function QueueOptimizerClosure() {
       return argsArray[iFirstTransform][1] === 0 &&
              argsArray[iFirstTransform][2] === 0;
     },
-    function (context, i) {
+    function iterateImageGroup(context, i) {
       var fnArray = context.fnArray, argsArray = context.argsArray;
       var iFirstSave = context.iCurr - 3;
       var pos = (i - iFirstSave) % 4;
@@ -300,6 +302,7 @@ var QueueOptimizer = (function QueueOptimizerClosure() {
         case 3:
           return fnArray[i] === OPS.restore;
       }
+      throw new Error(`iterateImageGroup - invalid pos: ${pos}`);
     },
     function (context, i) {
       var MIN_IMAGES_IN_BLOCK = 3;
@@ -346,7 +349,7 @@ var QueueOptimizer = (function QueueOptimizerClosure() {
   addState(InitialState,
     [OPS.beginText, OPS.setFont, OPS.setTextMatrix, OPS.showText, OPS.endText],
     null,
-    function (context, i) {
+    function iterateShowTextGroup(context, i) {
       var fnArray = context.fnArray, argsArray = context.argsArray;
       var iFirstSave = context.iCurr - 4;
       var pos = (i - iFirstSave) % 5;
@@ -372,6 +375,7 @@ var QueueOptimizer = (function QueueOptimizerClosure() {
         case 4:
           return fnArray[i] === OPS.endText;
       }
+      throw new Error(`iterateShowTextGroup - invalid pos: ${pos}`);
     },
     function (context, i) {
       var MIN_CHARS_IN_BLOCK = 3;

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2021,13 +2021,14 @@ class WorkerTransport {
 
     messageHandler.on('obj', function(data) {
       if (this.destroyed) {
-        return; // Ignore any pending requests if the worker was terminated.
+        // Ignore any pending requests if the worker was terminated.
+        return undefined;
       }
 
       const [id, pageIndex, type, imageData] = data;
       const pageProxy = this.pageCache[pageIndex];
       if (pageProxy.objs.has(id)) {
-        return;
+        return undefined;
       }
 
       switch (type) {
@@ -2064,6 +2065,7 @@ class WorkerTransport {
         default:
           throw new Error(`Got unknown object type ${type}`);
       }
+      return undefined;
     }, this);
 
     messageHandler.on('DocProgress', function(data) {

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1435,7 +1435,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
 
       var fontSize = current.fontSize;
       if (fontSize === 0) {
-        return;
+        return undefined;
       }
 
       var ctx = this.ctx;

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -64,7 +64,7 @@ class BaseFontLoader {
   async bind(font) {
     // Add the font to the DOM only once; skip if the font is already loaded.
     if (font.attached || font.missingFile) {
-      return;
+      return undefined;
     }
     font.attached = true;
 
@@ -83,7 +83,7 @@ class BaseFontLoader {
           throw ex;
         }
       }
-      return; // The font was, asynchronously, loaded.
+      return undefined; // The font was, asynchronously, loaded.
     }
 
     // !this.isFontLoadingAPISupported
@@ -92,13 +92,14 @@ class BaseFontLoader {
       this.insertRule(rule);
 
       if (this.isSyncFontLoadingSupported) {
-        return; // The font was, synchronously, loaded.
+        return undefined; // The font was, synchronously, loaded.
       }
       return new Promise((resolve) => {
         const request = this._queueLoadingCallback(resolve);
         this._prepareFontLoadEvent([rule], [font], request);
       });
     }
+    return undefined;
   }
 
   _queueLoadingCallback(callback) {

--- a/src/shared/message_handler.js
+++ b/src/shared/message_handler.js
@@ -20,7 +20,7 @@ import {
 
 async function resolveCall(fn, args, thisArg = null) {
   if (!fn) {
-    return;
+    return undefined;
   }
   return fn.apply(thisArg, args);
 }

--- a/test/test.js
+++ b/test/test.js
@@ -296,10 +296,11 @@ function getTestManifest() {
         testFilter.splice(i, 1);
         return true;
       }
+      return false;
     });
     if (testFilter.length) {
       console.error('Unrecognized test IDs: ' + testFilter.join(' '));
-      return;
+      return undefined;
     }
   }
   return manifest;

--- a/test/unit/fetch_stream_spec.js
+++ b/test/unit/fetch_stream_spec.js
@@ -39,7 +39,7 @@ describe('fetch_stream', function() {
     const read = function() {
       return fullReader.read().then(function(result) {
         if (result.done) {
-          return;
+          return undefined;
         }
 
         len += result.value.byteLength;
@@ -85,7 +85,7 @@ describe('fetch_stream', function() {
     const read = function(reader, lenResult) {
       return reader.read().then(function(result) {
         if (result.done) {
-          return;
+          return undefined;
         }
 
         lenResult.value += result.value.byteLength;

--- a/test/unit/network_spec.js
+++ b/test/unit/network_spec.js
@@ -39,7 +39,7 @@ describe('network', function() {
     var read = function () {
       return fullReader.read().then(function (result) {
         if (result.done) {
-          return;
+          return undefined;
         }
         count++;
         len += result.value.byteLength;
@@ -94,7 +94,7 @@ describe('network', function() {
     var read = function (reader, lenResult) {
       return reader.read().then(function (result) {
         if (result.done) {
-          return;
+          return undefined;
         }
         lenResult.value += result.value.byteLength;
         return read(reader, lenResult);

--- a/test/unit/network_utils_spec.js
+++ b/test/unit/network_utils_spec.js
@@ -37,6 +37,7 @@ describe('network_utils', function() {
           if (headerName === 'Content-Length') {
             return 8;
           }
+          throw new Error(`Unexpected headerName: ${headerName}`);
         },
         rangeChunkSize: 64,
       })).toEqual({
@@ -51,6 +52,7 @@ describe('network_utils', function() {
           if (headerName === 'Content-Length') {
             return 8;
           }
+          throw new Error(`Unexpected headerName: ${headerName}`);
         },
         rangeChunkSize: 64,
       })).toEqual({
@@ -69,6 +71,7 @@ describe('network_utils', function() {
           } else if (headerName === 'Content-Length') {
             return 8;
           }
+          throw new Error(`Unexpected headerName: ${headerName}`);
         },
         rangeChunkSize: 64,
       })).toEqual({
@@ -89,6 +92,7 @@ describe('network_utils', function() {
           } else if (headerName === 'Content-Length') {
             return 8;
           }
+          throw new Error(`Unexpected headerName: ${headerName}`);
         },
         rangeChunkSize: 64,
       })).toEqual({
@@ -109,6 +113,7 @@ describe('network_utils', function() {
           } else if (headerName === 'Content-Length') {
             return 'eight';
           }
+          throw new Error(`Unexpected headerName: ${headerName}`);
         },
         rangeChunkSize: 64,
       })).toEqual({
@@ -129,6 +134,7 @@ describe('network_utils', function() {
           } else if (headerName === 'Content-Length') {
             return 8;
           }
+          throw new Error(`Unexpected headerName: ${headerName}`);
         },
         rangeChunkSize: 64,
       })).toEqual({
@@ -149,6 +155,7 @@ describe('network_utils', function() {
           } else if (headerName === 'Content-Length') {
             return 8192;
           }
+          throw new Error(`Unexpected headerName: ${headerName}`);
         },
         rangeChunkSize: 64,
       })).toEqual({
@@ -164,18 +171,21 @@ describe('network_utils', function() {
         if (headerName === 'Content-Disposition') {
           return null;
         }
+        throw new Error(`Unexpected headerName: ${headerName}`);
       })).toBeNull();
 
       expect(extractFilenameFromHeader((headerName) => {
         if (headerName === 'Content-Disposition') {
           return undefined;
         }
+        throw new Error(`Unexpected headerName: ${headerName}`);
       })).toBeNull();
 
       expect(extractFilenameFromHeader((headerName) => {
         if (headerName === 'Content-Disposition') {
           return '';
         }
+        throw new Error(`Unexpected headerName: ${headerName}`);
       })).toBeNull();
     });
 
@@ -184,42 +194,49 @@ describe('network_utils', function() {
         if (headerName === 'Content-Disposition') {
           return 'inline';
         }
+        throw new Error(`Unexpected headerName: ${headerName}`);
       })).toBeNull();
 
       expect(extractFilenameFromHeader((headerName) => {
         if (headerName === 'Content-Disposition') {
           return 'attachment';
         }
+        throw new Error(`Unexpected headerName: ${headerName}`);
       })).toBeNull();
 
       expect(extractFilenameFromHeader((headerName) => {
         if (headerName === 'Content-Disposition') {
           return 'attachment; filename="filename.pdf"';
         }
+        throw new Error(`Unexpected headerName: ${headerName}`);
       })).toEqual('filename.pdf');
 
       expect(extractFilenameFromHeader((headerName) => {
         if (headerName === 'Content-Disposition') {
           return 'attachment; filename="filename.pdf and spaces.pdf"';
         }
+        throw new Error(`Unexpected headerName: ${headerName}`);
       })).toEqual('filename.pdf and spaces.pdf');
 
       expect(extractFilenameFromHeader((headerName) => {
         if (headerName === 'Content-Disposition') {
           return 'attachment; filename="tl;dr.pdf"';
         }
+        throw new Error(`Unexpected headerName: ${headerName}`);
       })).toEqual('tl;dr.pdf');
 
       expect(extractFilenameFromHeader((headerName) => {
         if (headerName === 'Content-Disposition') {
           return 'attachment; filename=filename.pdf';
         }
+        throw new Error(`Unexpected headerName: ${headerName}`);
       })).toEqual('filename.pdf');
 
       expect(extractFilenameFromHeader((headerName) => {
         if (headerName === 'Content-Disposition') {
           return 'attachment; filename=filename.pdf someotherparam';
         }
+        throw new Error(`Unexpected headerName: ${headerName}`);
       })).toEqual('filename.pdf');
     });
 
@@ -228,30 +245,35 @@ describe('network_utils', function() {
         if (headerName === 'Content-Disposition') {
           return 'attachment; filename*=filename.pdf';
         }
+        throw new Error(`Unexpected headerName: ${headerName}`);
       })).toEqual('filename.pdf');
 
       expect(extractFilenameFromHeader((headerName) => {
         if (headerName === 'Content-Disposition') {
           return 'attachment; filename*=\'\'filename.pdf';
         }
+        throw new Error(`Unexpected headerName: ${headerName}`);
       })).toEqual('filename.pdf');
 
       expect(extractFilenameFromHeader((headerName) => {
         if (headerName === 'Content-Disposition') {
           return 'attachment; filename*=utf-8\'\'filename.pdf';
         }
+        throw new Error(`Unexpected headerName: ${headerName}`);
       })).toEqual('filename.pdf');
 
       expect(extractFilenameFromHeader((headerName) => {
         if (headerName === 'Content-Disposition') {
           return 'attachment; filename=no.pdf; filename*=utf-8\'\'filename.pdf';
         }
+        throw new Error(`Unexpected headerName: ${headerName}`);
       })).toEqual('filename.pdf');
 
       expect(extractFilenameFromHeader((headerName) => {
         if (headerName === 'Content-Disposition') {
           return 'attachment; filename*=utf-8\'\'filename.pdf; filename=no.pdf';
         }
+        throw new Error(`Unexpected headerName: ${headerName}`);
       })).toEqual('filename.pdf');
     });
 
@@ -261,6 +283,7 @@ describe('network_utils', function() {
         if (headerName === 'Content-Disposition') {
           return 'attachment; filename*0=filename; filename*1=.pdf';
         }
+        throw new Error(`Unexpected headerName: ${headerName}`);
       })).toEqual('filename.pdf');
     });
 
@@ -269,6 +292,7 @@ describe('network_utils', function() {
         if (headerName === 'Content-Disposition') {
           return 'attachment; filename="filename.png"';
         }
+        throw new Error(`Unexpected headerName: ${headerName}`);
       })).toBeNull();
     });
 
@@ -277,6 +301,7 @@ describe('network_utils', function() {
         if (headerName === 'Content-Disposition') {
           return 'form-data; name="fieldName"; filename="file.PdF"';
         }
+        throw new Error(`Unexpected headerName: ${headerName}`);
       })).toEqual('file.PdF');
     });
   });

--- a/test/unit/node_stream_spec.js
+++ b/test/unit/node_stream_spec.js
@@ -109,7 +109,7 @@ describe('node_stream', function() {
     let read1 = function () {
       return fullReader1.read().then(function (result) {
         if (result.done) {
-          return;
+          return undefined;
         }
         len1 += result.value.byteLength;
         return read1();
@@ -118,7 +118,7 @@ describe('node_stream', function() {
     let read2 = function () {
       return fullReader2.read().then(function (result) {
         if (result.done) {
-          return;
+          return undefined;
         }
         len2 += result.value.byteLength;
         return read2();
@@ -195,7 +195,7 @@ describe('node_stream', function() {
     let read = function (reader, lenResult) {
       return reader.read().then(function (result) {
         if (result.done) {
-          return;
+          return undefined;
         }
         lenResult.value += result.value.byteLength;
         return read(reader, lenResult);

--- a/web/app.js
+++ b/web/app.js
@@ -198,7 +198,7 @@ let PDFViewerApplication = {
   async _parseHashParameters() {
     if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('PRODUCTION') &&
         !AppOptions.get('pdfBugEnabled')) {
-      return;
+      return undefined;
     }
     const waitOn = [];
 
@@ -576,7 +576,7 @@ let PDFViewerApplication = {
     errorWrapper.setAttribute('hidden', 'true');
 
     if (!this.pdfLoadingTask) {
-      return;
+      return undefined;
     }
 
     let promise = this.pdfLoadingTask.destroy();
@@ -681,7 +681,7 @@ let PDFViewerApplication = {
       this.load(pdfDocument);
     }, (exception) => {
       if (loadingTask !== this.pdfLoadingTask) {
-        return; // Ignore errors for previously opened PDF files.
+        return undefined; // Ignore errors for previously opened PDF files.
       }
 
       let message = exception && exception.message;

--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -58,8 +58,8 @@ class DownloadManager {
 
   downloadData(data, filename, contentType) {
     if (navigator.msSaveBlob) { // IE10 and above
-      return navigator.msSaveBlob(new Blob([data], { type: contentType, }),
-                                  filename);
+      navigator.msSaveBlob(new Blob([data], { type: contentType, }), filename);
+      return;
     }
     let blobUrl = createObjectURL(data, contentType,
                                   this.disableCreateObjectURL);

--- a/web/grab_to_pan.js
+++ b/web/grab_to_pan.js
@@ -221,6 +221,7 @@ function isLeftMouseReleased(event) {
     // Safari 6.0+
     return event.which === 0;
   }
+  return false;
 }
 
 export {

--- a/web/password_prompt.js
+++ b/web/password_prompt.js
@@ -90,7 +90,7 @@ class PasswordPrompt {
     let password = this.input.value;
     if (password && password.length > 0) {
       this.close();
-      return this.updateCallback(password);
+      this.updateCallback(password);
     }
   }
 

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -256,10 +256,10 @@ class PDFDocumentProperties {
   /**
    * @private
    */
-  _parseFileSize(fileSize = 0) {
+  async _parseFileSize(fileSize = 0) {
     let kb = fileSize / 1024;
     if (!kb) {
-      return Promise.resolve(undefined);
+      return undefined;
     } else if (kb < 1024) {
       return this.l10n.get('document_properties_kb', {
         size_kb: (+kb.toPrecision(3)).toLocaleString(),
@@ -275,9 +275,9 @@ class PDFDocumentProperties {
   /**
    * @private
    */
-  _parsePageSize(pageSizeInches, pagesRotation) {
+  async _parsePageSize(pageSizeInches, pagesRotation) {
     if (!pageSizeInches) {
-      return Promise.resolve(undefined);
+      return undefined;
     }
     // Take the viewer rotation into account as well; compare with Adobe Reader.
     if (pagesRotation % 180 !== 0) {
@@ -362,15 +362,15 @@ class PDFDocumentProperties {
   /**
    * @private
    */
-  _parseDate(inputDate) {
+  async _parseDate(inputDate) {
     const dateObject = PDFDateString.toDateObject(inputDate);
-    if (dateObject) {
-      const dateString = dateObject.toLocaleDateString();
-      const timeString = dateObject.toLocaleTimeString();
-      return this.l10n.get('document_properties_date_string',
-                           { date: dateString, time: timeString, },
-                           '{{date}}, {{time}}');
+    if (!dateObject) {
+      return undefined;
     }
+    return this.l10n.get('document_properties_date_string', {
+        date: dateObject.toLocaleDateString(),
+        time: dateObject.toLocaleTimeString(),
+      }, '{{date}}, {{time}}');
   }
 
   /**

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -292,6 +292,7 @@ window.addEventListener('keydown', function(event) {
   }
 }, true);
 if (hasAttachEvent) {
+  // eslint-disable-next-line consistent-return
   document.attachEvent('onkeydown', function(event) {
     event = event || window.event;
     if (event.keyCode === /* P= */ 80 && event.ctrlKey) {


### PR DESCRIPTION
This rule is already enabled in mozilla-central, and helps ensure more consistent functions/methods, see https://searchfox.org/mozilla-central/rev/b9da45f63cb567244933c77b2c7e827a057d3f9b/tools/lint/eslint/eslint-plugin-mozilla/lib/configs/recommended.js#119-120

Please see https://eslint.org/docs/rules/consistent-return for additional information.