### PR TITLE
Remove unused `ref` property from the `parameters` object used when creating annotations in `AnnotationFactory._create`

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -60,7 +60,6 @@ class AnnotationFactory {
     let parameters = {
       xref,
       dict,
-      ref: isRef(ref) ? ref : null,
       subtype,
       id,
       pdfManager,


### PR DESCRIPTION
The use-cases for this property was removed in PRs #7570 and #7775, and it's been completely unused ever since the latter one.