### PR TITLE
[api-minor] Implement contents and creation date for the correct annotation types

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -176,7 +176,6 @@ class Annotation {
     const dict = params.dict;
 
     this.setContents(dict.get('Contents'));
-    this.setCreationDate(dict.get('CreationDate'));
     this.setModificationDate(dict.get('M'));
     this.setFlags(dict.get('F'));
     this.setRectangle(dict.getArray('Rect'));
@@ -190,7 +189,6 @@ class Annotation {
       borderStyle: this.borderStyle,
       color: this.color,
       contents: this.contents,
-      creationDate: this.creationDate,
       hasAppearance: !!this.appearance,
       id: params.id,
       modificationDate: this.modificationDate,
@@ -255,18 +253,6 @@ class Annotation {
    */
   setContents(contents) {
     this.contents = stringToPDFString(contents || '');
-  }
-
-  /**
-   * Set the creation date.
-   *
-   * @public
-   * @memberof Annotation
-   * @param {string} creationDate - PDF date string that indicates when the
-   *                                annotation was originally created
-   */
-  setCreationDate(creationDate) {
-    this.creationDate = isString(creationDate) ? creationDate : null;
   }
 
   /**
@@ -629,15 +615,30 @@ class AnnotationBorderStyle {
 class MarkupAnnotation extends Annotation {
   constructor(parameters) {
     super(parameters);
-    const dict = parameters.dict;
 
+    const dict = parameters.dict;
     if (!dict.has('C')) {
       // Fall back to the default background color.
       this.data.color = null;
     }
 
+    this.setCreationDate(dict.get('CreationDate'));
+    this.data.creationDate = this.creationDate;
+
     this.data.hasPopup = dict.has('Popup');
     this.data.title = stringToPDFString(dict.get('T') || '');
+  }
+
+  /**
+   * Set the creation date.
+   *
+   * @public
+   * @memberof MarkupAnnotation
+   * @param {string} creationDate - PDF date string that indicates when the
+   *                                annotation was originally created
+   */
+  setCreationDate(creationDate) {
+    this.creationDate = isString(creationDate) ? creationDate : null;
   }
 }
 
@@ -989,13 +990,6 @@ class PopupAnnotation extends Annotation {
     this.data.title = stringToPDFString(parentItem.get('T') || '');
     this.data.contents = stringToPDFString(parentItem.get('Contents') || '');
 
-    if (!parentItem.has('CreationDate')) {
-      this.data.creationDate = null;
-    } else {
-      this.setCreationDate(parentItem.get('CreationDate'));
-      this.data.creationDate = this.creationDate;
-    }
-
     if (!parentItem.has('M')) {
       this.data.modificationDate = null;
     } else {
@@ -1179,4 +1173,5 @@ export {
   Annotation,
   AnnotationBorderStyle,
   AnnotationFactory,
+  MarkupAnnotation,
 };

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -173,8 +173,9 @@ function getTransformMatrix(rect, bbox, matrix) {
 
 class Annotation {
   constructor(params) {
-    let dict = params.dict;
+    const dict = params.dict;
 
+    this.setContents(dict.get('Contents'));
     this.setCreationDate(dict.get('CreationDate'));
     this.setModificationDate(dict.get('M'));
     this.setFlags(dict.get('F'));
@@ -188,6 +189,7 @@ class Annotation {
       annotationFlags: this.flags,
       borderStyle: this.borderStyle,
       color: this.color,
+      contents: this.contents,
       creationDate: this.creationDate,
       hasAppearance: !!this.appearance,
       id: params.id,
@@ -240,6 +242,19 @@ class Annotation {
       return false;
     }
     return this._isPrintable(this.flags);
+  }
+
+  /**
+   * Set the contents.
+   *
+   * @public
+   * @memberof Annotation
+   * @param {string} contents - Text to display for the annotation or, if the
+   *                            type of annotation does not display text, a
+   *                            description of the annotation's contents
+   */
+  setContents(contents) {
+    this.contents = stringToPDFString(contents || '');
   }
 
   /**
@@ -623,7 +638,6 @@ class MarkupAnnotation extends Annotation {
 
     this.data.hasPopup = dict.has('Popup');
     this.data.title = stringToPDFString(dict.get('T') || '');
-    this.data.contents = stringToPDFString(dict.get('Contents') || '');
   }
 }
 

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -14,7 +14,7 @@
  */
 
 import {
-  Annotation, AnnotationBorderStyle, AnnotationFactory
+  Annotation, AnnotationBorderStyle, AnnotationFactory, MarkupAnnotation
 } from '../../src/core/annotation';
 import {
   AnnotationBorderStyleType, AnnotationFieldFlag, AnnotationFlag,
@@ -145,20 +145,6 @@ describe('annotation', function() {
       expect(annotation.contents).toEqual('');
     });
 
-    it('should set and get a valid creation date', function() {
-      const annotation = new Annotation({ dict, ref, });
-      annotation.setCreationDate('D:20190422');
-
-      expect(annotation.creationDate).toEqual('D:20190422');
-    });
-
-    it('should set and get an invalid creation date', function() {
-      const annotation = new Annotation({ dict, ref, });
-      annotation.setCreationDate(undefined);
-
-      expect(annotation.creationDate).toEqual(null);
-    });
-
     it('should set and get a valid modification date', function() {
       const annotation = new Annotation({ dict, ref, });
       annotation.setModificationDate('D:20190422');
@@ -166,7 +152,7 @@ describe('annotation', function() {
       expect(annotation.modificationDate).toEqual('D:20190422');
     });
 
-    it('should set and get an invalid modification date', function() {
+    it('should not set and get an invalid modification date', function() {
       const annotation = new Annotation({ dict, ref, });
       annotation.setModificationDate(undefined);
 
@@ -328,6 +314,34 @@ describe('annotation', function() {
       borderStyle.setVerticalCornerRadius('three');
 
       expect(borderStyle.verticalCornerRadius).toEqual(0);
+    });
+  });
+
+  describe('MarkupAnnotation', function() {
+    let dict, ref;
+
+    beforeAll(function(done) {
+      dict = new Dict();
+      ref = new Ref(1, 0);
+      done();
+    });
+
+    afterAll(function() {
+      dict = ref = null;
+    });
+
+    it('should set and get a valid creation date', function() {
+      const markupAnnotation = new MarkupAnnotation({ dict, ref, });
+      markupAnnotation.setCreationDate('D:20190422');
+
+      expect(markupAnnotation.creationDate).toEqual('D:20190422');
+    });
+
+    it('should not set and get an invalid creation date', function() {
+      const markupAnnotation = new MarkupAnnotation({ dict, ref, });
+      markupAnnotation.setCreationDate(undefined);
+
+      expect(markupAnnotation.creationDate).toEqual(null);
     });
   });
 
@@ -1446,7 +1460,6 @@ describe('annotation', function() {
       const parentDict = new Dict();
       parentDict.set('Type', Name.get('Annot'));
       parentDict.set('Subtype', Name.get('Text'));
-      parentDict.set('CreationDate', 'D:20190422');
       parentDict.set('M', 'D:20190423');
       parentDict.set('C', [0, 0, 1]);
 
@@ -1463,7 +1476,6 @@ describe('annotation', function() {
       AnnotationFactory.create(xref, popupRef, pdfManagerMock,
           idFactoryMock).then(({ data, viewable, }) => {
         expect(data.annotationType).toEqual(AnnotationType.POPUP);
-        expect(data.creationDate).toEqual('D:20190422');
         expect(data.modificationDate).toEqual('D:20190423');
         expect(data.color).toEqual(new Uint8ClampedArray([0, 0, 255]));
         done();
@@ -1488,7 +1500,6 @@ describe('annotation', function() {
       AnnotationFactory.create(xref, popupRef, pdfManagerMock,
           idFactoryMock).then(({ data, viewable, }) => {
         expect(data.annotationType).toEqual(AnnotationType.POPUP);
-        expect(data.creationDate).toEqual(null);
         expect(data.modificationDate).toEqual(null);
         expect(data.color).toEqual(null);
         done();

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -131,6 +131,20 @@ describe('annotation', function() {
       dict = ref = null;
     });
 
+    it('should set and get valid contents', function() {
+      const annotation = new Annotation({ dict, ref, });
+      annotation.setContents('Foo bar baz');
+
+      expect(annotation.contents).toEqual('Foo bar baz');
+    });
+
+    it('should not set and get invalid contents', function() {
+      const annotation = new Annotation({ dict, ref, });
+      annotation.setContents(undefined);
+
+      expect(annotation.contents).toEqual('');
+    });
+
     it('should set and get a valid creation date', function() {
       const annotation = new Annotation({ dict, ref, });
       annotation.setCreationDate('D:20190422');


### PR DESCRIPTION
The commit messages contain more information about the individual changes.

Thanks to @vlastimilmaca for finding this! This patch cleans this up so it doesn't have to be done in the scope of the IRT/RT patch.