### PR TITLE
make print resolution configurable via AppOptions

### DIFF
--- a/web/app_options.js
+++ b/web/app_options.js
@@ -233,6 +233,11 @@ if (typeof PDFJSDev === 'undefined' ||
     value: (typeof navigator !== 'undefined' ? navigator.language : 'en-US'),
     kind: OptionKind.VIEWER,
   };
+  defaultOptions.printResolution = {
+    /** @type {number} */
+    value: 150,
+    kind: OptionKind.VIEWER,
+  };
 }
 
 const userOptions = Object.create(null);

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -15,6 +15,7 @@
 
 import { CSS_UNITS, NullL10n } from './ui_utils';
 import { PDFPrintServiceFactory, PDFViewerApplication } from './app';
+import { AppOptions } from './app_options';
 import { URL } from 'pdfjs-lib';
 
 let activeService = null;
@@ -26,7 +27,7 @@ function renderPage(activeServiceOnEntry, pdfDocument, pageNumber, size) {
   let scratchCanvas = activeService.scratchCanvas;
 
   // The size of the canvas in pixels for printing.
-  const PRINT_RESOLUTION = 150;
+  const PRINT_RESOLUTION = AppOptions.get('printResolution') || 150;
   const PRINT_UNITS = PRINT_RESOLUTION / 72.0;
   scratchCanvas.width = Math.floor(size.width * PRINT_UNITS);
   scratchCanvas.height = Math.floor(size.height * PRINT_UNITS);


### PR DESCRIPTION
There are many posts online regarding pdf.js print quality. From a [post](https://www.gyrocode.com/articles/how-to-increase-print-quality-of-pdf-file-with-pdf-js-viewer/) by Michael Ryvkin I learned that this can easily be fixed by increasing print resolution. To make this even easier without the need to change the pre-built viewer.js, I propose making print resolution configurable via AppOptions.