### PR TITLE
Don't clip if path is undefined in SVG back-end

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -1137,6 +1137,10 @@ SVGGraphics = class SVGGraphics {
     if (!this.pendingClip) {
       return;
     }
+    if (!current.element) {
+      this.pendingClip = null;
+      return;
+    }
 
     // Add the current path to a clipping path.
     const clipId = `clippath${clipCount++}`;


### PR DESCRIPTION
Fixes #10846

The PDF in the issue uses an empty path as the clipping path:

```
q
    W*
    n
Q
```
Because of this, `display/svg.js` attempts to call function `cloneNode` of an `undefined` object.