### PR TITLE
Ensure that the `Cmd`/`Name`/`Ref` caches are cleared when terminating the worker (PR 10863 follow-up)

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -19,10 +19,10 @@ import {
   PasswordException, setVerbosityLevel, UnexpectedResponseException,
   UnknownErrorException, UNSUPPORTED_FEATURES, VerbosityLevel, warn
 } from '../shared/util';
+import { clearPrimitiveCaches, Ref } from './primitives';
 import { LocalPdfManager, NetworkPdfManager } from './pdf_manager';
 import isNodeJS from '../shared/is_node';
 import { MessageHandler } from '../shared/message_handler';
-import { Ref } from './primitives';
 import { XRefParseException } from './core_utils';
 
 var WorkerTask = (function WorkerTaskClosure() {
@@ -700,6 +700,7 @@ var WorkerMessageHandler = {
       if (cancelXHRs) {
         cancelXHRs();
       }
+      clearPrimitiveCaches();
 
       var waitOn = [];
       WorkerTasks.forEach(function (task) {


### PR DESCRIPTION
Usually when the worker is terminated it will also be completely destroyed/removed, which means that any global caches (such as the ones in `src/core/primitive.js`) should be automatically cleared in the process.

However, for certain ways of loading the `pdf.worker.js` file, e.g. passing in a re-usable worker to `getDocument`, using the `workerPort` functionality, or even disabling workers completely (even though this is never a good idea), the worker file may be kept in memory and these caches will not be cleared as expected.