### PR TITLE
Ignore Annotations with too large border `width`s, to prevent the `annotationLayer` from rendering it over the surrounding document (bug 1552113)

### DIFF
--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -96,6 +96,7 @@
 !bug1245391_reduced.pdf
 !bug1252420.pdf
 !bug1513120_reduced.pdf
+!bug1552113.pdf
 !issue9949.pdf
 !bug1308536.pdf
 !bug1337429.pdf

--- a/test/pdfs/bug1552113.pdf
+++ b/test/pdfs/bug1552113.pdf
@@ -1,0 +1,86 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/Pages 2 0 R
+/Type /Catalog
+>>
+endobj 
+2 0 obj 
+<<
+/Kids [3 0 R]
+/Type /Pages
+/Count 1
+>>
+endobj 
+3 0 obj 
+<<
+/Parent 2 0 R
+/Annots [4 0 R]
+/Resources 
+<<
+/Font 
+<<
+/F1 5 0 R
+>>
+>>
+/MediaBox [0 0 250 50]
+/Type /Page
+/Contents 6 0 R
+>>
+endobj 
+4 0 obj 
+<<
+/Border [0 0 112]
+/Subtype /Link
+/C [0 0 1]
+/A 
+<<
+/URI (http://www.example.org)
+/Type /Action
+/S /URI
+>>
+/Type /Annot
+/Rect [5 25 155 45]
+>>
+endobj 
+5 0 obj 
+<<
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Type /Font
+/Encoding /WinAnsiEncoding
+>>
+endobj 
+6 0 obj 
+<<
+/Length 111
+>>
+stream
+BT
+10 30 TD
+/F1 14 Tf
+(http://www.example.org/) Tj
+0 -20 Td
+(Bug 1552113 - this text should be visible.) Tj
+ET
+
+endstream 
+endobj xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000066 00000 n 
+0000000125 00000 n 
+0000000270 00000 n 
+0000000432 00000 n 
+0000000533 00000 n 
+trailer
+
+<<
+/Root 1 0 R
+/Size 7
+>>
+startxref
+697
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -680,6 +680,15 @@
        "annotations": true,
        "about": "Annotation with (unsupported) file:// URL."
     },
+    {  "id": "bug1552113",
+       "file": "pdfs/bug1552113.pdf",
+       "md5": "dafb7ba1328e8deaab2e3619c94bf974",
+       "link": false,
+       "rounds": 1,
+       "type": "eq",
+       "annotations": true,
+       "about": "Annotation with (ridiculously) large border width."
+    },
     {  "id": "issue4934",
        "file": "pdfs/issue4934.pdf",
        "md5": "6099da44f677702ae65a648b51a2226d",


### PR DESCRIPTION
The border `width` will instead fallback to the default value of `1`, rather than ignoring it altoghether, to also ensure that e.g. `LinkAnnotation`s become clickable as intended.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1552113