### PR TITLE
Add support for outline items, in the default viewer, which default to collapsed when the outline is built

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -144,6 +144,7 @@ class Catalog {
       const title = outlineDict.get('Title');
       const flags = outlineDict.get('F') || 0;
       const color = outlineDict.getArray('C');
+      const count = outlineDict.get('Count');
       let rgbColor = blackColor;
 
       // We only need to parse the color when it's valid, and non-default.
@@ -159,7 +160,7 @@ class Catalog {
         newWindow: data.newWindow,
         title: stringToPDFString(title),
         color: rgbColor,
-        count: outlineDict.get('Count'),
+        count: Number.isInteger(count) ? count : undefined,
         bold: !!(flags & 2),
         italic: !!(flags & 1),
         items: [],

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -715,6 +715,7 @@ class PDFDocumentProxy {
    *     bold: boolean,
    *     italic: boolean,
    *     color: rgb Uint8ClampedArray,
+   *     count: integer or undefined,
    *     dest: dest obj,
    *     url: string,
    *     items: array of more items like this

--- a/web/pdf_outline_viewer.js
+++ b/web/pdf_outline_viewer.js
@@ -112,9 +112,12 @@ class PDFOutlineViewer {
    *
    * @private
    */
-  _addToggleButton(div) {
+  _addToggleButton(div, { count, items, }) {
     let toggler = document.createElement('div');
     toggler.className = 'outlineItemToggler';
+    if (count < 0 && Math.abs(count) === items.length) {
+      toggler.classList.add('outlineItemsHidden');
+    }
     toggler.onclick = (evt) => {
       evt.stopPropagation();
       toggler.classList.toggle('outlineItemsHidden');
@@ -173,10 +176,8 @@ class PDFOutlineViewer {
     let queue = [{ parent: fragment, items: this.outline, }];
     let hasAnyNesting = false;
     while (queue.length > 0) {
-      let levelData = queue.shift();
-      for (let i = 0, len = levelData.items.length; i < len; i++) {
-        let item = levelData.items[i];
-
+      const levelData = queue.shift();
+      for (const item of levelData.items) {
         let div = document.createElement('div');
         div.className = 'outlineItem';
 
@@ -190,7 +191,7 @@ class PDFOutlineViewer {
 
         if (item.items.length > 0) {
           hasAnyNesting = true;
-          this._addToggleButton(div);
+          this._addToggleButton(div, item);
 
           let itemsDiv = document.createElement('div');
           itemsDiv.className = 'outlineItems';
@@ -204,6 +205,9 @@ class PDFOutlineViewer {
     }
     if (hasAnyNesting) {
       this.container.classList.add('outlineWithDeepNesting');
+
+      this.lastToggleIsShow =
+        (fragment.querySelectorAll('.outlineItemsHidden').length === 0);
     }
 
     this.container.appendChild(fragment);


### PR DESCRIPTION
The PDF specification supports this feature, which is commonly used in large/long documents (such as the spec itself), and it seems reasonably straightforward to implement; see https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#G11.2095911