### PR TITLE
Remove a superfluous `linkService.isPageVisible` check from `PDFFindController` (PR 10217 follow-up)

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -252,9 +252,9 @@ class PDFFindController {
         // over matches at the top/bottom of pages thus making them completely
         // inaccessible when there's multiple pages visible in the viewer.
         if (pageNumber >= 1 && pageNumber <= linkService.pagesCount &&
-            linkService.page !== pageNumber && linkService.isPageVisible &&
+            pageNumber !== linkService.page &&
             !linkService.isPageVisible(pageNumber)) {
-          break;
+          return true;
         }
         return false;
       case 'findhighlightallchange':


### PR DESCRIPTION
Unless the `PDFLinkService` instance contains all of the expected methods, a lot of things will break in various places in the default viewer. Hence there's not much value in having this check, and outright falling seems more appropriate.

Finally, this also makes the return value explicit in this case, since that's consistent with the rest of the `PDFFindController._shouldDirtyMatch` method.