### PR TITLE
Allow experimenting with the `printResolution` AppOption when printing with the built-in Firefox version

### DIFF
--- a/web/firefox_print_service.js
+++ b/web/firefox_print_service.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import { AppOptions } from './app_options';
 import { CSS_UNITS } from './ui_utils';
 import { PDFPrintServiceFactory } from './app';
 import { shadow } from 'pdfjs-lib';
@@ -22,7 +23,7 @@ function composePage(pdfDocument, pageNumber, size, printContainer) {
   let canvas = document.createElement('canvas');
 
   // The size of the canvas in pixels for printing.
-  const PRINT_RESOLUTION = 150;
+  const PRINT_RESOLUTION = AppOptions.get('printResolution') || 150;
   const PRINT_UNITS = PRINT_RESOLUTION / 72.0;
   canvas.width = Math.floor(size.width * PRINT_UNITS);
   canvas.height = Math.floor(size.height * PRINT_UNITS);


### PR DESCRIPTION
As have already been stated multiple times, simply increasing the printing resolution may have undesirable effects on both memory usage *and* general performance. Hence why PR #10854 did *not* add a preference, and only exposed AppOption by default in `GENERIC` builds for now.

However, considering how differently printing works in the built-in Firefox version (with `mozPrintCallback`) compared to the general default viewer, any testing done in the latter case might not be completely relevant to the first (and most important) case of the Firefox PDF Viewer.

Note that considering the implementation of `AppOptions.get`, this patch will be safe and should allow experimenting with `printResolution` in all builds of the default viewer[1]. By not, however, having `printResolution` appear in AppOptions for either the `MOZCENTRAL` or `CHROMIUM` build targets, there should be no indication of official support for now.
Furthermore, it shouldn't be a preference at this point in time (or even at all), since that makes it too easy for users to change it permanently[2] and possible "break" printing.

---

[1] By running `PDFViewerApplicationOptions.get('printResolution', /* value here */);` in the console after the viewer loads.

[2] I've seen Firefox bugs, filed in Bugzilla, where users modified e.g. preferences manually in `about:config` and then some time later (maybe months) wondered why something was suddenly broken. In those cases, trying to work out that a preference change was the culprit can take time/effort.