### PR TITLE
Move `PDFWorkerStream` and related code to its own file

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -14,15 +14,16 @@
  */
 
 import {
-  arrayByteLength, arraysToBytes, assert, createPromiseCapability,
-  getVerbosityLevel, info, InvalidPDFException, MissingPDFException,
-  PasswordException, setVerbosityLevel, UnexpectedResponseException,
-  UnknownErrorException, UNSUPPORTED_FEATURES, VerbosityLevel, warn
+  arrayByteLength, arraysToBytes, createPromiseCapability, getVerbosityLevel,
+  info, InvalidPDFException, MissingPDFException, PasswordException,
+  setVerbosityLevel, UnexpectedResponseException, UnknownErrorException,
+  UNSUPPORTED_FEATURES, VerbosityLevel, warn
 } from '../shared/util';
 import { clearPrimitiveCaches, Ref } from './primitives';
 import { LocalPdfManager, NetworkPdfManager } from './pdf_manager';
 import isNodeJS from '../shared/is_node';
 import { MessageHandler } from '../shared/message_handler';
+import { PDFWorkerStream } from './worker_stream';
 import { XRefParseException } from './core_utils';
 
 var WorkerTask = (function WorkerTaskClosure() {
@@ -53,122 +54,6 @@ var WorkerTask = (function WorkerTaskClosure() {
   };
 
   return WorkerTask;
-})();
-
-/** @implements {IPDFStream} */
-var PDFWorkerStream = (function PDFWorkerStreamClosure() {
-  function PDFWorkerStream(msgHandler) {
-    this._msgHandler = msgHandler;
-    this._contentLength = null;
-    this._fullRequestReader = null;
-    this._rangeRequestReaders = [];
-  }
-  PDFWorkerStream.prototype = {
-    getFullReader() {
-      assert(!this._fullRequestReader);
-      this._fullRequestReader = new PDFWorkerStreamReader(this._msgHandler);
-      return this._fullRequestReader;
-    },
-
-    getRangeReader(begin, end) {
-      let reader = new PDFWorkerStreamRangeReader(begin, end, this._msgHandler);
-      this._rangeRequestReaders.push(reader);
-      return reader;
-    },
-
-    cancelAllRequests(reason) {
-      if (this._fullRequestReader) {
-        this._fullRequestReader.cancel(reason);
-      }
-      let readers = this._rangeRequestReaders.slice(0);
-      readers.forEach(function (reader) {
-        reader.cancel(reason);
-      });
-    },
-  };
-
-  /** @implements {IPDFStreamReader} */
-  function PDFWorkerStreamReader(msgHandler) {
-    this._msgHandler = msgHandler;
-
-    this._contentLength = null;
-    this._isRangeSupported = false;
-    this._isStreamingSupported = false;
-
-    let readableStream = this._msgHandler.sendWithStream('GetReader');
-
-    this._reader = readableStream.getReader();
-
-    this._headersReady = this._msgHandler.sendWithPromise('ReaderHeadersReady').
-        then((data) => {
-      this._isStreamingSupported = data.isStreamingSupported;
-      this._isRangeSupported = data.isRangeSupported;
-      this._contentLength = data.contentLength;
-    });
-  }
-  PDFWorkerStreamReader.prototype = {
-    get headersReady() {
-      return this._headersReady;
-    },
-
-    get contentLength() {
-      return this._contentLength;
-    },
-
-    get isStreamingSupported() {
-      return this._isStreamingSupported;
-    },
-
-    get isRangeSupported() {
-      return this._isRangeSupported;
-    },
-
-    read() {
-      return this._reader.read().then(function({ value, done, }) {
-        if (done) {
-          return { value: undefined, done: true, };
-        }
-        // `value` is wrapped into Uint8Array, we need to
-        // unwrap it to ArrayBuffer for further processing.
-        return { value: value.buffer, done: false, };
-      });
-    },
-
-    cancel(reason) {
-      this._reader.cancel(reason);
-    },
-  };
-
-  /** @implements {IPDFStreamRangeReader} */
-  function PDFWorkerStreamRangeReader(begin, end, msgHandler) {
-    this._msgHandler = msgHandler;
-    this.onProgress = null;
-
-    let readableStream = this._msgHandler.sendWithStream('GetRangeReader',
-                                                         { begin, end, });
-
-    this._reader = readableStream.getReader();
-  }
-  PDFWorkerStreamRangeReader.prototype = {
-    get isStreamingSupported() {
-      return false;
-    },
-
-    read() {
-      return this._reader.read().then(function({ value, done, }) {
-        if (done) {
-          return { value: undefined, done: true, };
-        }
-        return { value: value.buffer, done: false, };
-      });
-    },
-
-    cancel(reason) {
-      this._reader.cancel(reason);
-    },
-  };
-
-  return PDFWorkerStream;
 })();
 
 var WorkerMessageHandler = {

--- a/src/core/worker_stream.js
+++ b/src/core/worker_stream.js
@@ -1,0 +1,133 @@
+/* Copyright 2019 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint no-var: error */
+
+import { assert } from '../shared/util';
+
+/** @implements {IPDFStream} */
+class PDFWorkerStream {
+  constructor(msgHandler) {
+    this._msgHandler = msgHandler;
+    this._contentLength = null;
+    this._fullRequestReader = null;
+    this._rangeRequestReaders = [];
+  }
+
+  getFullReader() {
+    assert(!this._fullRequestReader);
+    this._fullRequestReader = new PDFWorkerStreamReader(this._msgHandler);
+    return this._fullRequestReader;
+  }
+
+  getRangeReader(begin, end) {
+    const reader = new PDFWorkerStreamRangeReader(begin, end, this._msgHandler);
+    this._rangeRequestReaders.push(reader);
+    return reader;
+  }
+
+  cancelAllRequests(reason) {
+    if (this._fullRequestReader) {
+      this._fullRequestReader.cancel(reason);
+    }
+    const readers = this._rangeRequestReaders.slice(0);
+    readers.forEach(function(reader) {
+      reader.cancel(reason);
+    });
+  }
+}
+
+/** @implements {IPDFStreamReader} */
+class PDFWorkerStreamReader {
+  constructor(msgHandler) {
+    this._msgHandler = msgHandler;
+    this.onProgress = null;
+
+    this._contentLength = null;
+    this._isRangeSupported = false;
+    this._isStreamingSupported = false;
+
+    const readableStream = this._msgHandler.sendWithStream('GetReader');
+    this._reader = readableStream.getReader();
+
+    this._headersReady = this._msgHandler.sendWithPromise('ReaderHeadersReady').
+        then((data) => {
+      this._isStreamingSupported = data.isStreamingSupported;
+      this._isRangeSupported = data.isRangeSupported;
+      this._contentLength = data.contentLength;
+    });
+  }
+
+  get headersReady() {
+    return this._headersReady;
+  }
+
+  get contentLength() {
+    return this._contentLength;
+  }
+
+  get isStreamingSupported() {
+    return this._isStreamingSupported;
+  }
+
+  get isRangeSupported() {
+    return this._isRangeSupported;
+  }
+
+  async read() {
+    const { value, done, } = await this._reader.read();
+    if (done) {
+      return { value: undefined, done: true, };
+    }
+    // `value` is wrapped into Uint8Array, we need to
+    // unwrap it to ArrayBuffer for further processing.
+    return { value: value.buffer, done: false, };
+  }
+
+  cancel(reason) {
+    this._reader.cancel(reason);
+  }
+}
+
+/** @implements {IPDFStreamRangeReader} */
+class PDFWorkerStreamRangeReader {
+  constructor(begin, end, msgHandler) {
+    this._msgHandler = msgHandler;
+    this.onProgress = null;
+
+    const readableStream = this._msgHandler.sendWithStream('GetRangeReader',
+                                                           { begin, end, });
+    this._reader = readableStream.getReader();
+  }
+
+  get isStreamingSupported() {
+    return false;
+  }
+
+  async read() {
+    const { value, done, } = await this._reader.read();
+    if (done) {
+      return { value: undefined, done: true, };
+    }
+    return { value: value.buffer, done: false, };
+  }
+
+  cancel(reason) {
+    this._reader.cancel(reason);
+  }
+}
+
+export {
+  PDFWorkerStream,
+};

--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -67,7 +67,7 @@ class IPDFStreamReader {
    * @returns {Promise}
    */
   get headersReady() {
-    return null;
+    return Promise.resolve();
   }
 
   /**
@@ -116,7 +116,7 @@ class IPDFStreamReader {
    * set to true.
    * @returns {Promise}
    */
-  read() {}
+  async read() {}
 
   /**
    * Cancels all pending read requests and closes the stream.
@@ -157,7 +157,7 @@ class IPDFStreamRangeReader {
    * set to true.
    * @returns {Promise}
    */
-  read() {}
+  async read() {}
 
   /**
    * Cancels all pending read requests and closes the stream.


### PR DESCRIPTION
Since all other `IPDFStream` implementations live in their own files, it seems reasonable for these to do so as well.

Furthermore, converts all of the relevant code to ES6 classes and updates the interface definitions to mark a couple of methods `async`.