### PR TITLE
Pin the version of `eslint-plugin-mozilla` to prevent failures on Travis (issue 10901)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "escodegen": "^1.11.1",
     "eslint": "^5.16.0",
     "eslint-plugin-import": "^2.17.3",
-    "eslint-plugin-mozilla": "^1.2.1",
+    "eslint-plugin-mozilla": "1.2.1",
     "eslint-plugin-no-unsanitized": "^3.0.2",
     "eslint-plugin-unicorn": "^7.1.0",
     "fancy-log": "^1.3.3",


### PR DESCRIPTION
It appears that the changes in `eslint-plugin-mozilla` version `1.3.0`, see https://bugzilla.mozilla.org/show_bug.cgi?id=1556013, causes dependency issues on Travis.

Fixes #10901 (this at least fixes Travis for now, and figuring out why PR #10904 didn't work can be done once the package actually needs updating).