### PR TITLE
Enable the `eslint-plugin-no-unsanitized` ESLint plugin to disallow unsafe usage of e.g. `innerHTML`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@
   "plugins": [
     "import",
     "mozilla",
+    "no-unsanitized",
     "unicorn",
   ],
 
@@ -28,6 +29,8 @@
     "import/no-unresolved": "error",
     "mozilla/avoid-removeChild": "error",
     "mozilla/use-includes-instead-of-indexOf": "error",
+    "no-unsanitized/method": "error",
+    "no-unsanitized/property": "error",
     "unicorn/no-array-instanceof": "error",
 
     // Possible errors

--- a/src/core/operator_list.js
+++ b/src/core/operator_list.js
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint-disable no-unsanitized/method */
 
 import { assert, ImageKind, OPS } from '../shared/util';
 

--- a/test/driver.js
+++ b/test/driver.js
@@ -627,6 +627,7 @@ var Driver = (function DriverClosure() { // eslint-disable-line no-unused-vars
       // Using insertAdjacentHTML yields a large performance gain and
       // reduces runtime significantly.
       if (this.output.insertAdjacentHTML) {
+        // eslint-disable-next-line no-unsanitized/method
         this.output.insertAdjacentHTML('BeforeEnd', message);
       } else {
         this.output.textContent += message;


### PR DESCRIPTION
See https://github.com/mozilla/eslint-plugin-no-unsanitized

Since we've generally never allowed e.g. `innerHTML`, which is enforced during review, there's only one linting failure with this patch. (Which is white-listed, according to the existing comment and the fact that it's test-only code.)