### PR TITLE
Change the signature of the `Parser` constructor to take a parameter object

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -2960,7 +2960,10 @@ var EvaluatorPreprocessor = (function EvaluatorPreprocessorClosure() {
     this.opMap = getOPMap();
     // TODO(mduan): pass array of knownCommands rather than this.opMap
     // dictionary
-    this.parser = new Parser(new Lexer(stream, this.opMap), false, xref);
+    this.parser = new Parser({
+      lexer: new Lexer(stream, this.opMap),
+      xref,
+    });
     this.stateManager = stateManager;
     this.nonProcessedArgs = [];
     this._numInvalidPathOPS = 0;

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -1477,8 +1477,12 @@ var XRef = (function XRefClosure() {
       let trailerDict;
       for (i = 0, ii = trailers.length; i < ii; ++i) {
         stream.pos = trailers[i];
-        var parser = new Parser(new Lexer(stream), /* allowStreams = */ true,
-                                /* xref = */ this, /* recoveryMode = */ true);
+        const parser = new Parser({
+          lexer: new Lexer(stream),
+          xref: this,
+          allowStreams: true,
+          recoveryMode: true,
+        });
         var obj = parser.getObj();
         if (!isCmd(obj, 'trailer')) {
           continue;
@@ -1536,7 +1540,11 @@ var XRef = (function XRefClosure() {
 
           stream.pos = startXRef + stream.start;
 
-          var parser = new Parser(new Lexer(stream), true, this);
+          const parser = new Parser({
+            lexer: new Lexer(stream),
+            xref: this,
+            allowStreams: true,
+          });
           var obj = parser.getObj();
           var dict;
 
@@ -1662,7 +1670,11 @@ var XRef = (function XRefClosure() {
       }
       var stream = this.stream.makeSubStream(xrefEntry.offset +
                                              this.stream.start);
-      var parser = new Parser(new Lexer(stream), true, this);
+      const parser = new Parser({
+        lexer: new Lexer(stream),
+        xref: this,
+        allowStreams: true,
+      });
       var obj1 = parser.getObj();
       var obj2 = parser.getObj();
       var obj3 = parser.getObj();
@@ -1709,8 +1721,11 @@ var XRef = (function XRefClosure() {
         throw new FormatError(
           'invalid first and n parameters for ObjStm stream');
       }
-      var parser = new Parser(new Lexer(stream), false, this);
-      parser.allowStreams = true;
+      const parser = new Parser({
+        lexer: new Lexer(stream),
+        xref: this,
+        allowStreams: true,
+      });
       var i, entries = [], num, nums = [];
       // read the object numbers to populate cache
       for (i = 0; i < n; ++i) {

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -51,10 +51,10 @@ function computeAdler32(bytes) {
 }
 
 class Parser {
-  constructor(lexer, allowStreams, xref, recoveryMode = false) {
+  constructor({ lexer, xref, allowStreams = false, recoveryMode = false, }) {
     this.lexer = lexer;
-    this.allowStreams = allowStreams;
     this.xref = xref;
+    this.allowStreams = allowStreams;
     this.recoveryMode = recoveryMode;
 
     this.imageCache = Object.create(null);
@@ -748,7 +748,7 @@ function toHexDigit(ch) {
 }
 
 class Lexer {
-  constructor(stream, knownCommands) {
+  constructor(stream, knownCommands = null) {
     this.stream = stream;
     this.nextChar();
 
@@ -1202,7 +1202,10 @@ class Linearization {
       throw new Error('Hint array in the linearization dictionary is invalid.');
     }
 
-    const parser = new Parser(new Lexer(stream), false, null);
+    const parser = new Parser({
+      lexer: new Lexer(stream),
+      xref: null,
+    });
     const obj1 = parser.getObj();
     const obj2 = parser.getObj();
     const obj3 = parser.getObj();

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -409,8 +409,10 @@ describe('annotation', function() {
         '/URI (http://www.example.com/\\303\\274\\303\\266\\303\\244)\n' +
         '>>\n'
       );
-      const lexer = new Lexer(actionStream);
-      const parser = new Parser(lexer);
+      const parser = new Parser({
+        lexer: new Lexer(actionStream),
+        xref: null,
+      });
       const actionDict = parser.getObj();
 
       const annotationDict = new Dict();
@@ -1412,8 +1414,11 @@ describe('annotation', function() {
         'Test attachment' +
         'endstream\n'
       );
-      const lexer = new Lexer(fileStream);
-      const parser = new Parser(lexer, /* allowStreams = */ true);
+      const parser = new Parser({
+        lexer: new Lexer(fileStream),
+        xref: null,
+        allowStreams: true,
+      });
 
       const fileStreamRef = Ref.get(18, 0);
       const fileStreamDict = parser.getObj();

--- a/test/unit/parser_spec.js
+++ b/test/unit/parser_spec.js
@@ -26,9 +26,12 @@ describe('parser', function() {
         const string = 'q 1 0 0 1 0 0 cm BI /W 10 /H 10 /BPC 1 ' +
                        '/F /A85 ID abc123~> EI Q';
         const input = new StringStream(string);
-        const lexer = new Lexer(input);
-        const parser = new Parser(lexer, /* allowStreams = */ true,
-                                  /* xref = */ null);
+        const parser = new Parser({
+          lexer: new Lexer(input),
+          xref: null,
+          allowStreams: true,
+        });
+
         parser.inlineStreamSkipEI(input);
         expect(input.pos).toEqual(string.indexOf('Q'));
         expect(input.peekByte()).toEqual(0x51); // 'Q'
@@ -39,9 +42,12 @@ describe('parser', function() {
         const string = 'q 1 0 0 1 0 0 cm BI /W 10 /H 10 /BPC 1 ' +
                        '/F /A85 ID abc123~> Q';
         const input = new StringStream(string);
-        const lexer = new Lexer(input);
-        const parser = new Parser(lexer, /* allowStreams = */ true,
-                                  /* xref = */ null);
+        const parser = new Parser({
+          lexer: new Lexer(input),
+          xref: null,
+          allowStreams: true,
+        });
+
         parser.inlineStreamSkipEI(input);
         expect(input.pos).toEqual(string.length);
         expect(input.peekByte()).toEqual(-1);


### PR DESCRIPTION
A lot of the `new Parser()` call-sites look quite unwieldy/ugly as-is, with a bunch of somewhat randomly ordered arguments, which we can avoid by changing the constructor to accept an object instead. As an added bonus, this provides better documentation without having to add inline argument comments in the code.

Fixes https://github.com/mozilla/pdf.js/pull/10635#discussion_r264059493