### PR TITLE
Delay initialization of searching, in the viewer, until the first page has rendered

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -443,6 +443,10 @@ class BaseViewer {
       // starts to create the correct size canvas. Wait until one page is
       // rendered so we don't tie up too many resources early on.
       onePageRenderedCapability.promise.then(() => {
+        if (this.findController) {
+          this.findController.setDocument(pdfDocument); // Enable searching.
+        }
+
         if (pdfDocument.loadingParams['disableAutoFetch']) {
           // XXX: Printing is semi-broken with auto fetch disabled.
           pagesCapability.resolve();
@@ -471,9 +475,6 @@ class BaseViewer {
 
       this.eventBus.dispatch('pagesinit', { source: this, });
 
-      if (this.findController) {
-        this.findController.setDocument(pdfDocument); // Enable searching.
-      }
       if (this.defaultRenderingQueue) {
         this.update();
       }


### PR DESCRIPTION
When searching occurs for the first time in a document, the `textContent` of all pages will be fetched from the API. If there's a pending search operation when the document loads that will thus lead to a lot of `getTextContent` calls very early on, which may unnecessarily delay rendering of the first page. Generally, in the viewer, a number of non-essential API calls[1] will be deferred until the first page has been rendered, and there's no good reason as far as I can tell to handle searching differently.

---
[1] Such as e.g. `getOutline` and `getAttachments`.