### PR TITLE
Actually subclass Error

### DIFF
--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -28,43 +28,20 @@ function getLookupTableFactory(initializer) {
   };
 }
 
-const MissingDataException = (function MissingDataExceptionClosure() {
-  function MissingDataException(begin, end) {
+class MissingDataException extends Error {
+  constructor(begin, end) {
+    super(`Missing data [${begin}, ${end})`);
     this.begin = begin;
     this.end = end;
-    this.message = `Missing data [${begin}, ${end})`;
   }
+}
+MissingDataException.prototype.name = 'MissingDataException';
 
-  MissingDataException.prototype = new Error();
-  MissingDataException.prototype.name = 'MissingDataException';
-  MissingDataException.constructor = MissingDataException;
+class XRefEntryException extends Error {}
+XRefEntryException.prototype.name = 'XRefEntryException';
 
-  return MissingDataException;
-})();
-
-const XRefEntryException = (function XRefEntryExceptionClosure() {
-  function XRefEntryException(msg) {
-    this.message = msg;
-  }
-
-  XRefEntryException.prototype = new Error();
-  XRefEntryException.prototype.name = 'XRefEntryException';
-  XRefEntryException.constructor = XRefEntryException;
-
-  return XRefEntryException;
-})();
-
-const XRefParseException = (function XRefParseExceptionClosure() {
-  function XRefParseException(msg) {
-    this.message = msg;
-  }
-
-  XRefParseException.prototype = new Error();
-  XRefParseException.prototype.name = 'XRefParseException';
-  XRefParseException.constructor = XRefParseException;
-
-  return XRefParseException;
-})();
+class XRefParseException extends Error {}
+XRefParseException.prototype.name = 'XRefParseException';
 
 /**
  * Get the value of an inheritable property.

--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -17,17 +17,12 @@ import { log2, readInt8, readUint16, readUint32, shadow } from '../shared/util';
 import { ArithmeticDecoder } from './arithmetic_decoder';
 import { CCITTFaxDecoder } from './ccitt';
 
-let Jbig2Error = (function Jbig2ErrorClosure() {
-  function Jbig2Error(msg) {
-    this.message = 'JBIG2 error: ' + msg;
+class Jbig2Error extends Error {
+  constructor(msg) {
+    super('JBIG2 error: ' + msg);
   }
-
-  Jbig2Error.prototype = new Error();
-  Jbig2Error.prototype.name = 'Jbig2Error';
-  Jbig2Error.constructor = Jbig2Error;
-
-  return Jbig2Error;
-})();
+}
+Jbig2Error.prototype.name = 'Jbig2Error';
 
 var Jbig2Image = (function Jbig2ImageClosure() {
   // Utility data structures

--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -16,42 +16,23 @@
 
 import { assert, warn } from '../shared/util';
 
-let JpegError = (function JpegErrorClosure() {
-  function JpegError(msg) {
-    this.message = 'JPEG error: ' + msg;
+class JpegError extends Error {
+  constructor(msg) {
+    super('JPEG error: ' + msg);
   }
+}
+JpegError.prototype.name = 'JpegError';
 
-  JpegError.prototype = new Error();
-  JpegError.prototype.name = 'JpegError';
-  JpegError.constructor = JpegError;
-
-  return JpegError;
-})();
-
-let DNLMarkerError = (function DNLMarkerErrorClosure() {
-  function DNLMarkerError(message, scanLines) {
-    this.message = message;
+class DNLMarkerError extends Error {
+  constructor(message, scanLines) {
+    super(message);
     this.scanLines = scanLines;
   }
+}
+DNLMarkerError.prototype.name = 'DNLMarkerError';
 
-  DNLMarkerError.prototype = new Error();
-  DNLMarkerError.prototype.name = 'DNLMarkerError';
-  DNLMarkerError.constructor = DNLMarkerError;
-
-  return DNLMarkerError;
-})();
-
-let EOIMarkerError = (function EOIMarkerErrorClosure() {
-  function EOIMarkerError(message) {
-    this.message = message;
-  }
-
-  EOIMarkerError.prototype = new Error();
-  EOIMarkerError.prototype.name = 'EOIMarkerError';
-  EOIMarkerError.constructor = EOIMarkerError;
-
-  return EOIMarkerError;
-})();
+class EOIMarkerError extends Error {}
+EOIMarkerError.prototype.name = 'EOIMarkerError';
 
 /**
  * This code was forked from https://github.com/notmasteryet/jpgjs.

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -18,17 +18,12 @@ import {
 } from '../shared/util';
 import { ArithmeticDecoder } from './arithmetic_decoder';
 
-let JpxError = (function JpxErrorClosure() {
-  function JpxError(msg) {
-    this.message = 'JPX error: ' + msg;
+class JpxError extends Error {
+  constructor(msg) {
+    super('JPX error: ' + msg);
   }
-
-  JpxError.prototype = new Error();
-  JpxError.prototype.name = 'JpxError';
-  JpxError.constructor = JpxError;
-
-  return JpxError;
-})();
+}
+JpxError.prototype.name = 'JpxError';
 
 var JpxImage = (function JpxImageClosure() {
   // Table E.1

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -307,18 +307,13 @@ class PageViewport {
   }
 }
 
-const RenderingCancelledException = (function RenderingCancelledException() {
-  function RenderingCancelledException(msg, type) {
-    this.message = msg;
+class RenderingCancelledException extends Error {
+  constructor(msg, type) {
+    super(msg);
     this.type = type;
   }
-
-  RenderingCancelledException.prototype = new Error();
-  RenderingCancelledException.prototype.name = 'RenderingCancelledException';
-  RenderingCancelledException.constructor = RenderingCancelledException;
-
-  return RenderingCancelledException;
-})();
+}
+RenderingCancelledException.prototype.name = 'RenderingCancelledException';
 
 const LinkTarget = {
   NONE: 0, // Default value.

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -377,99 +377,46 @@ function shadow(obj, prop, value) {
   return value;
 }
 
-var PasswordException = (function PasswordExceptionClosure() {
-  function PasswordException(msg, code) {
-    this.name = 'PasswordException';
-    this.message = msg;
+class PasswordException extends Error {
+  constructor(msg, code) {
+    super(msg);
     this.code = code;
   }
+}
+PasswordException.prototype.name = 'PasswordException';
 
-  PasswordException.prototype = new Error();
-  PasswordException.constructor = PasswordException;
-
-  return PasswordException;
-})();
-
-var UnknownErrorException = (function UnknownErrorExceptionClosure() {
-  function UnknownErrorException(msg, details) {
-    this.name = 'UnknownErrorException';
-    this.message = msg;
+class UnknownErrorException extends Error {
+  constructor(msg, details) {
+    super(msg);
     this.details = details;
   }
+}
 
-  UnknownErrorException.prototype = new Error();
-  UnknownErrorException.constructor = UnknownErrorException;
+class InvalidPDFException extends Error {}
+InvalidPDFException.prototype.name = 'InvalidPDFException';
 
-  return UnknownErrorException;
-})();
+class MissingPDFException extends Error {}
+MissingPDFException.prototype.name = 'MissingPDFException';
 
-var InvalidPDFException = (function InvalidPDFExceptionClosure() {
-  function InvalidPDFException(msg) {
-    this.name = 'InvalidPDFException';
-    this.message = msg;
-  }
-
-  InvalidPDFException.prototype = new Error();
-  InvalidPDFException.constructor = InvalidPDFException;
-
-  return InvalidPDFException;
-})();
-
-var MissingPDFException = (function MissingPDFExceptionClosure() {
-  function MissingPDFException(msg) {
-    this.name = 'MissingPDFException';
-    this.message = msg;
-  }
-
-  MissingPDFException.prototype = new Error();
-  MissingPDFException.constructor = MissingPDFException;
-
-  return MissingPDFException;
-})();
-
-var UnexpectedResponseException =
-    (function UnexpectedResponseExceptionClosure() {
-  function UnexpectedResponseException(msg, status) {
-    this.name = 'UnexpectedResponseException';
-    this.message = msg;
+class UnexpectedResponseException extends Error {
+  constructor(msg, status) {
+    super(msg);
     this.status = status;
   }
-
-  UnexpectedResponseException.prototype = new Error();
-  UnexpectedResponseException.constructor = UnexpectedResponseException;
-
-  return UnexpectedResponseException;
-})();
+}
+UnexpectedResponseException.prototype.name = 'UnexpectedResponseException';
 
 /**
  * Error caused during parsing PDF data.
  */
-let FormatError = (function FormatErrorClosure() {
-  function FormatError(msg) {
-    this.message = msg;
-  }
-
-  FormatError.prototype = new Error();
-  FormatError.prototype.name = 'FormatError';
-  FormatError.constructor = FormatError;
-
-  return FormatError;
-})();
+class FormatError extends Error {}
+FormatError.prototype.name = 'FormatError';
 
 /**
  * Error used to indicate task cancellation.
  */
-let AbortException = (function AbortExceptionClosure() {
-  function AbortException(msg) {
-    this.name = 'AbortException';
-    this.message = msg;
-  }
-
-  AbortException.prototype = new Error();
-  AbortException.constructor = AbortException;
-
-  return AbortException;
-})();
+class AbortException extends Error {}
+AbortException.prototype.name = 'AbortException';
 
 var NullCharactersRegExp = /\x00/g;
 


### PR DESCRIPTION
Convert all the places where we do `klass.prototype = new Error()`
to ES6 classes, so stack traces work in (e.g.) Chrome.

Sadly, it seems we still need the `name` property, but we can at least
put it on the prototype in every case, rather than having a few classes
arbitrarily put it on instances instead.

Everything else that used to be added to constructor/prototype appears
to be either superfluous or automatic.

P.S. The "Classes" section of the Style Guide is woefully out of date.