### PR TITLE
Add "gulp" to package.json scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,31 +35,26 @@ PDF.js is built into version 19+ of Firefox.
 
 + The official extension for Chrome can be installed from the [Chrome Web Store](https://chrome.google.com/webstore/detail/pdf-viewer/oemmndcbldboiebfnladdacbdfmadadm).
 *This extension is maintained by [@Rob--W](https://github.com/Rob--W).*
-+ Build Your Own - Get the code as explained below and issue `gulp chromium`. Then open
++ Build Your Own - Get the code as explained below and issue `npm run gulp chromium`. Then open
 Chrome, go to `Tools > Extension` and load the (unpackaged) extension from the
 directory `build/chromium`.
 
 ## Getting the Code
+Make sure you have Node.js installed via the [official package](https://nodejs.org) or via [nvm](https://github.com/creationix/nvm).
 
 To get a local copy of the current code, clone it using git:
 
     $ git clone https://github.com/mozilla/pdf.js.git
     $ cd pdf.js
 
-Next, install Node.js via the [official package](https://nodejs.org) or via
-[nvm](https://github.com/creationix/nvm). You need to install the gulp package
-globally (see also [gulp's getting started](https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md#getting-started)):
-
-    $ npm install -g gulp-cli
-
-If everything worked out, install all dependencies for PDF.js:
+Next, install all dependencies for PDF.js:
 
     $ npm install
 
 Finally, you need to start a local web server as some browsers do not allow opening
 PDF files using a `file://` URL. Run:
 
-    $ gulp server
+    $ npm run gulp server
 
 and then you can open:
 
@@ -76,7 +71,7 @@ It is also possible to view all test PDF files on the right side by opening:
 In order to bundle all `src/` files into two production scripts and build the generic
 viewer, run:
 
-    $ gulp generic
+    $ npm run gulp generic
 
 This will generate `pdf.js` and `pdf.worker.js` in the `build/generic/build/` directory.
 Both scripts are needed but only `pdf.js` needs to be included since `pdf.worker.js` will
@@ -102,7 +97,7 @@ You can play with the PDF.js API directly from your browser using the live demos
 
 + [Interactive examples](https://mozilla.github.io/pdf.js/examples/index.html#interactive-examples)
 
-More examples can be found in the [examples folder](https://github.com/mozilla/pdf.js/tree/master/examples/). Some of them are using the pdfjs-dist package, which can be built and installed in this repo directory via `gulp dist-install` command.
+More examples can be found in the [examples folder](https://github.com/mozilla/pdf.js/tree/master/examples/). Some of them are using the pdfjs-dist package, which can be built and installed in this repo directory via `npm run gulp dist-install` command.
 
 For an introduction to the PDF.js code, check out the presentation by our
 contributor Julian Viereck:

--- a/docs/contents/getting_started/index.md
+++ b/docs/contents/getting_started/index.md
@@ -115,7 +115,7 @@ Note that we only mention the most relevant files and folders.
 
 ## Trying the Viewer
 
-With the prebuilt or source version, open `web/viewer.html` in a browser and the test pdf should load. Note: the worker is not enabled for file:// urls, so use a server. If you're using the source build and have node, you can run `gulp server`.
+With the prebuilt or source version, open `web/viewer.html` in a browser and the test pdf should load. Note: the worker is not enabled for file:// urls, so use a server. If you're using the source build and have node, you can run `npm run gulp server`.
 
 ## More Information
 

--- a/examples/acroforms/README.md
+++ b/examples/acroforms/README.md
@@ -4,7 +4,7 @@ Example to demonstrate PDF.js library usage for rendering files with AcroForms.
 
 ## Getting started
 
-Build and install PDF.js using `gulp dist-install` and run `gulp server` to
+Build and install PDF.js using `npm run gulp dist-install` and run `npm run gulp server` to
 start a web server. You can then work with the example at
 http://localhost:8888/examples/acroforms/acroforms.html.
 

--- a/examples/browserify/README.md
+++ b/examples/browserify/README.md
@@ -6,11 +6,11 @@ Example to demonstrate PDF.js library usage with Browserify.
 
 Build project and install the example dependencies:
 
-    $ gulp dist-install
+    $ npm run gulp dist-install
     $ cd examples/browserify
     $ npm install
 
-To build Browserify bundles, run `gulp build`. If you are running
+To build Browserify bundles, run `npm run gulp build`. If you are running
 a web server, you can observe the build results at
 http://localhost:8888/examples/browserify/index.html
 

--- a/examples/components/pageviewer.js
+++ b/examples/components/pageviewer.js
@@ -17,7 +17,7 @@
 
 if (!pdfjsLib.getDocument || !pdfjsViewer.PDFPageView) {
   alert('Please build the pdfjs-dist library using\n' +
-        '  `gulp dist-install`');
+        '  `npm run gulp dist-install`');
 }
 
 // The workerSrc property shall be specified.

--- a/examples/components/simpleviewer.js
+++ b/examples/components/simpleviewer.js
@@ -17,7 +17,7 @@
 
 if (!pdfjsLib.getDocument || !pdfjsViewer.PDFViewer) {
   alert('Please build the pdfjs-dist library using\n' +
-        '  `gulp dist-install`');
+        '  `npm run gulp dist-install`');
 }
 
 // The workerSrc property shall be specified.

--- a/examples/components/singlepageviewer.js
+++ b/examples/components/singlepageviewer.js
@@ -17,7 +17,7 @@
 
 if (!pdfjsLib.getDocument || !pdfjsViewer.PDFSinglePageViewer) {
   alert('Please build the pdfjs-dist library using\n' +
-        '  `gulp dist-install`');
+        '  `npm run gulp dist-install`');
 }
 
 // The workerSrc property shall be specified.

--- a/examples/image_decoders/jpeg_viewer.js
+++ b/examples/image_decoders/jpeg_viewer.js
@@ -16,7 +16,8 @@
 'use strict';
 
 if (!pdfjsImageDecoders.JpegImage) {
-  alert('Please build the pdfjs-dist library using `gulp dist-install`');
+  alert('Please build the pdfjs-dist library using\n' +
+        '  `npm run gulp dist-install`');
 }
 
 var JPEG_IMAGE = 'fish.jpg';

--- a/examples/mobile-viewer/README.md
+++ b/examples/mobile-viewer/README.md
@@ -4,7 +4,7 @@ Example to demonstrate PDF.js library usage with a viewer optimized for mobile u
 
 ## Getting started
 
-Build PDF.js using `gulp dist-install` and run `gulp server` to start a web server.
+Build PDF.js using `npm run gulp dist-install` and run `npm run gulp server` to start a web server.
 You can then work with the mobile viewer at
 http://localhost:8888/examples/mobile-viewer/viewer.html.
 

--- a/examples/mobile-viewer/viewer.js
+++ b/examples/mobile-viewer/viewer.js
@@ -17,7 +17,8 @@
 'use strict';
 
 if (!pdfjsLib.getDocument || !pdfjsViewer.PDFViewer) {
-  alert('Please build the pdfjs-dist library using\n `gulp dist-install`');
+  alert('Please build the pdfjs-dist library using\n' +
+        '  `npm run gulp dist-install`');
 }
 
 var USE_ONLY_CSS_ZOOM = true;

--- a/examples/node/getinfo.js
+++ b/examples/node/getinfo.js
@@ -4,10 +4,10 @@
 //
 // Basic node example that prints document metadata and text content.
 // Requires single file built version of PDF.js -- please run
-// `gulp singlefile` before running the example.
+// `npm run gulp singlefile` before running the example.
 //
 
-// Run `gulp dist-install` to generate 'pdfjs-dist' npm package files.
+// Run `npm run gulp dist-install` to generate 'pdfjs-dist' npm package files.
 var pdfjsLib = require('pdfjs-dist');
 
 // Loading file from file system into typed array

--- a/examples/node/pdf2png/README.md
+++ b/examples/node/pdf2png/README.md
@@ -7,7 +7,7 @@ Example to demonstrate converting a PDF file to a PNG image using the PDF.js lib
 Install the dependencies and build the PDF.js library:
 
     $ npm install
-    $ gulp dist-install
+    $ npm run gulp dist-install
 
 Install the Node canvas library and run the example to convert the first page of a
 PDF file to a PNG image:

--- a/examples/node/pdf2svg.js
+++ b/examples/node/pdf2svg.js
@@ -13,7 +13,7 @@ var stream = require('stream');
 // HACK few hacks to let PDF.js be loaded not as a module in global space.
 require('./domstubs.js').setStubs(global);
 
-// Run `gulp dist-install` to generate 'pdfjs-dist' npm package files.
+// Run `npm run gulp dist-install` to generate 'pdfjs-dist' npm package files.
 var pdfjsLib = require('pdfjs-dist');
 
 // Loading file from file system into typed array

--- a/examples/svgviewer/viewer.js
+++ b/examples/svgviewer/viewer.js
@@ -17,7 +17,7 @@
 
 if (!pdfjsLib.getDocument || !pdfjsViewer.PDFViewer) {
   alert('Please build the pdfjs-dist library using\n' +
-        '  `gulp dist-install`');
+        '  `npm run gulp dist-install`');
 }
 
 // The workerSrc property shall be specified.

--- a/examples/text-only/pdf2svg.js
+++ b/examples/text-only/pdf2svg.js
@@ -65,7 +65,7 @@ function pageLoaded() {
 document.addEventListener('DOMContentLoaded', function () {
   if (typeof pdfjsLib === 'undefined') {
     alert('Built version of PDF.js was not found.\n' +
-          'Please run `gulp dist-install`.');
+          'Please run `npm run gulp dist-install`.');
     return;
   }
   pageLoaded();

--- a/examples/webpack/README.md
+++ b/examples/webpack/README.md
@@ -6,12 +6,12 @@ Example to demonstrate PDF.js library usage with Webpack.
 
 Install the example dependencies and build the project:
 
-    $ gulp dist-install
+    $ npm run gulp dist-install
     $ cd examples/webpack
     $ npm install
     $ ./node_modules/webpack/bin/webpack.js
 
-You can observe the build results by running `gulp server` and navigating to
+You can observe the build results by running `npm run gulp server` and navigating to
 http://localhost:8888/examples/webpack/index.html.
 
 Refer to the `main.js` and `webpack.config.js` files for the source code.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4227,8 +4227,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4249,14 +4248,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4271,20 +4268,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4401,8 +4395,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4414,7 +4407,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4429,7 +4421,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4437,14 +4428,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4463,7 +4452,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4544,8 +4532,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4557,7 +4544,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4643,8 +4629,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4680,7 +4665,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4700,7 +4684,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4744,14 +4727,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "yargs": "^11.1.0"
   },
   "scripts": {
-    "test": "env SKIP_BABEL=true gulp lint unittestcli externaltest"
+    "test": "env SKIP_BABEL=true gulp lint unittestcli externaltest",
+    "gulp": "gulp"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This way there is no need to install gulp globally. Instead the gulp version from `node_modules` can be used. We can also consider adding individual scripts that call the gulp equivalent?