### PR TITLE
Remove the `data-pdfjsprinting` attribute on the `<body>` when destroying `FirefoxPrintService`/`PDFPrintService` instances (issue 10948)

### DIFF
--- a/web/firefox_print_service.js
+++ b/web/firefox_print_service.js
@@ -77,18 +77,21 @@ function FirefoxPrintService(pdfDocument, pagesOverview, printContainer) {
 
 FirefoxPrintService.prototype = {
   layout() {
-    let pdfDocument = this.pdfDocument;
-    let printContainer = this.printContainer;
-    let body = document.querySelector('body');
+    const { pdfDocument, pagesOverview, printContainer, } = this;
+
+    const body = document.querySelector('body');
     body.setAttribute('data-pdfjsprinting', true);
 
-    for (let i = 0, ii = this.pagesOverview.length; i < ii; ++i) {
-      composePage(pdfDocument, i + 1, this.pagesOverview[i], printContainer);
+    for (let i = 0, ii = pagesOverview.length; i < ii; ++i) {
+      composePage(pdfDocument, i + 1, pagesOverview[i], printContainer);
     }
   },
 
   destroy() {
     this.printContainer.textContent = '';
+
+    const body = document.querySelector('body');
+    body.removeAttribute('data-pdfjsprinting');
   },
 };
 

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -74,7 +74,7 @@ PDFPrintService.prototype = {
   layout() {
     this.throwIfInactive();
 
-    let body = document.querySelector('body');
+    const body = document.querySelector('body');
     body.setAttribute('data-pdfjsprinting', true);
 
     let hasEqualPageSizes = this.pagesOverview.every(function(size) {
@@ -114,6 +114,10 @@ PDFPrintService.prototype = {
       return;
     }
     this.printContainer.textContent = '';
+
+    const body = document.querySelector('body');
+    body.removeAttribute('data-pdfjsprinting');
+
     if (this.pageStyleSheet) {
       this.pageStyleSheet.remove();
       this.pageStyleSheet = null;


### PR DESCRIPTION
Also, cleans up variable definitions slightly in the `FirefoxPrintService.layout` method.

Fixes #10948