### PR TITLE
Prevent "Uncaught promise" messages in the console when cancelling `TextLayer` tasks (PR 10601 follow-up)

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -500,7 +500,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
         this._layoutTextCtx.canvas.height = 0;
         this._layoutTextCtx = null;
       }
-    });
+    }).catch(() => { /* Avoid "Uncaught promise" messages in the console. */ });
   }
   TextLayerRenderTask.prototype = {
     get promise() {


### PR DESCRIPTION
Since `finally` won't stop error propagation, this causes unnecessary messages to be printed in the console whenever a `TextLayer` task is cancelled.