### PR TITLE
Add timestamp to the page rendered event.

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -222,6 +222,7 @@ class PDFPageView {
         source: this,
         pageNumber: this.id,
         cssTransform: true,
+        timestamp: performance.now(),
       });
       return;
     }
@@ -245,6 +246,7 @@ class PDFPageView {
           source: this,
           pageNumber: this.id,
           cssTransform: true,
+          timestamp: performance.now(),
         });
         return;
       }
@@ -456,6 +458,7 @@ class PDFPageView {
         source: this,
         pageNumber: this.id,
         cssTransform: false,
+        timestamp: performance.now(),
       });
 
       if (error) {


### PR DESCRIPTION
This is needed to track rendering time in Firefox's talos performance
framework. See https://bugzilla.mozilla.org/show_bug.cgi?id=1565680