### PR TITLE
Add an API unit-test for the `stopAtErrors` option (PRs 8240 and 8922 follow-up)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2101,6 +2101,8 @@ class WorkerTransport {
 
       if (intentState.displayReadyCapability) {
         intentState.displayReadyCapability.reject(new Error(data.error));
+      } else if (intentState.opListReadCapability) {
+        intentState.opListReadCapability.reject(new Error(data.error));
       } else {
         throw new Error(data.error);
       }


### PR DESCRIPTION
Also fixes an inconsistency in the 'PageError' handler, for `getOperatorList`, in the API.