### PR TITLE
Simplify, and inline, the `finalize` function in the `MessageHandler` class

### DIFF
--- a/src/shared/message_handler.js
+++ b/src/shared/message_handler.js
@@ -60,10 +60,6 @@ function resolveOrReject(capability, data) {
   }
 }
 
-function finalize(promise) {
-  return Promise.resolve(promise).catch(() => {});
-}
-
 function MessageHandler(sourceName, targetName, comObj) {
   this.sourceName = sourceName;
   this.targetName = targetName;
@@ -326,14 +322,14 @@ MessageHandler.prototype = {
     };
 
     let deleteStreamController = () => {
-      // Delete streamController only when start, pull and
-      // cancel callbacks are resolved, to avoid "TypeError".
+      // Delete the `streamController` only when the start, pull, and cancel
+      // capabilities have settled, to prevent `TypeError`s.
       Promise.all([
         this.streamControllers[data.streamId].startCall,
         this.streamControllers[data.streamId].pullCall,
         this.streamControllers[data.streamId].cancelCall
       ].map(function(capability) {
-        return capability && finalize(capability.promise);
+        return capability && capability.promise.catch(function() { });
       })).then(() => {
         delete this.streamControllers[data.streamId];
       });


### PR DESCRIPTION
The `finalize` helper function has only a *single* call-site, and furthermore it's just a one-liner too. Furthermore it's only ever called with a `Promise` as its argument, meaning that it's unnecessarily convoluted as well (i.e. the `Promise.resolve()` part shouldn't be necessary).
Hence this code can be both simplified *and* inlined at its only call-site instead.