### PR TITLE
[Firefox] Re-factor the 'zoomreset' message handling in the viewer (PR 10652 follow-up)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -437,13 +437,8 @@ let PDFViewerApplication = {
     this.pdfViewer.currentScaleValue = newScale;
   },
 
-  zoomReset(ignoreDuplicate = false) {
+  zoomReset() {
     if (this.pdfViewer.isInPresentationMode) {
-      return;
-    } else if (ignoreDuplicate &&
-               this.pdfViewer.currentScaleValue === DEFAULT_SCALE_VALUE) {
-      // Avoid attempting to needlessly reset the zoom level *twice* in a row,
-      // when using the `Ctrl + 0` keyboard shortcut in `MOZCENTRAL` builds.
       return;
     }
     this.pdfViewer.currentScaleValue = DEFAULT_SCALE_VALUE;
@@ -1965,8 +1960,8 @@ function webViewerZoomIn() {
 function webViewerZoomOut() {
   PDFViewerApplication.zoomOut();
 }
-function webViewerZoomReset(evt) {
-  PDFViewerApplication.zoomReset(evt && evt.ignoreDuplicate);
+function webViewerZoomReset() {
+  PDFViewerApplication.zoomReset();
 }
 function webViewerPageNumberChanged(evt) {
   let pdfViewer = PDFViewerApplication.pdfViewer;

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -16,6 +16,7 @@
 import '../extensions/firefox/tools/l10n';
 import { createObjectURL, PDFDataRangeTransport, shadow, URL } from 'pdfjs-lib';
 import { BasePreferences } from './preferences';
+import { DEFAULT_SCALE_VALUE } from './ui_utils';
 import { PDFViewerApplication } from './app';
 
 if (typeof PDFJSDev === 'undefined' ||
@@ -208,10 +209,13 @@ class MozL10n {
     if (!PDFViewerApplication.initialized) {
       return;
     }
-    PDFViewerApplication.eventBus.dispatch(type, {
-      source: window,
-      ignoreDuplicate: (type === 'zoomreset' ? true : undefined),
-    });
+    // Avoid attempting to needlessly reset the zoom level *twice* in a row,
+    // when using the `Ctrl + 0` keyboard shortcut.
+    if (type === 'zoomreset' && // eslint-disable-next-line max-len
+        PDFViewerApplication.pdfViewer.currentScaleValue === DEFAULT_SCALE_VALUE) {
+      return;
+    }
+    PDFViewerApplication.eventBus.dispatch(type, { source: window, });
   };
 
   for (const event of events) {

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -177,9 +177,7 @@ class MozL10n {
       return;
     }
     if (type === 'findbarclose') {
-      PDFViewerApplication.eventBus.dispatch('findbarclose', {
-        source: window,
-      });
+      PDFViewerApplication.eventBus.dispatch(type, { source: window, });
       return;
     }
     PDFViewerApplication.eventBus.dispatch('find', {


### PR DESCRIPTION
Given that this special-case only matters for the Firefox PDF viewer, it's probably better to just move it into `firefoxcom.js` instead to reduce unnecessary confusion.

---

Also, unless [bug 786674](https://bugzilla.mozilla.org/show_bug.cgi?id=786674) gets backed out for causing new intermittent failures in [bug 1224848](https://bugzilla.mozilla.org/show_bug.cgi?id=1224848) (which has a potential patch), issue #4042 should now be fixed.