### PR TITLE
Refactor the `onBeforeDraw`/`onAfterDraw` functionality used in `BaseViewer` and `PDFPageView`

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -96,9 +96,6 @@ class PDFPageView {
     this.resume = null;
     this.error = null;
 
-    this.onBeforeDraw = null;
-    this.onAfterDraw = null;
-
     this.annotationLayer = null;
     this.textLayer = null;
     this.zoomLayer = null;
@@ -451,9 +448,7 @@ class PDFPageView {
 
       this.error = error;
       this.stats = pdfPage.stats;
-      if (this.onAfterDraw) {
-        this.onAfterDraw();
-      }
+
       this.eventBus.dispatch('pagerendered', {
         source: this,
         pageNumber: this.id,
@@ -496,9 +491,10 @@ class PDFPageView {
     }
     div.setAttribute('data-loaded', true);
 
-    if (this.onBeforeDraw) {
-      this.onBeforeDraw();
-    }
+    this.eventBus.dispatch('pagerender', {
+      source: this,
+      pageNumber: this.id,
+    });
     return resultPromise;
   }
 


### PR DESCRIPTION
This functionality is very old, and pre-dates e.g. the introduction of the `EventBus` by a number of years. Rather than attaching two callback functions to every single `PDFPageView` instance, it's thus now possible to utilize the `EventBus` such that you only need a grand total of two listeners to achieve the same result.

For the `onAfterDraw` callback the replacement is particularly simple, given that a 'pagerendered' event is already being dispatched in the appropriate spot. An added benefit here is the ability to remove the event listener, since we only ever care about *one* (arbitrary) page being rendered for the `BaseViewer.onePageRendered` promise.

For the `onBeforeDraw` callback, a new 'pagerender' event was thus added to replace the callback.