### PR TITLE
Add the `docBaseUrl` API parameter to `AppOptions` in the viewer

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -642,16 +642,20 @@ let PDFViewerApplication = {
       this.setTitleUsingUrl(file.originalUrl);
       parameters.url = file.url;
     }
-    if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION')) {
-      parameters.docBaseUrl = document.URL.split('#')[0];
-    } else if (typeof PDFJSDev !== 'undefined' &&
-               PDFJSDev.test('FIREFOX || MOZCENTRAL || CHROME')) {
-      parameters.docBaseUrl = this.baseUrl;
-    }
     // Set the necessary API parameters, using the available options.
     const apiParameters = AppOptions.getAll(OptionKind.API);
     for (let key in apiParameters) {
-      parameters[key] = apiParameters[key];
+      let value = apiParameters[key];
+
+      if (key === 'docBaseUrl' && !value) {
+        if (typeof PDFJSDev === 'undefined' || !PDFJSDev.test('PRODUCTION')) {
+          value = document.URL.split('#')[0];
+        } else if (typeof PDFJSDev !== 'undefined' &&
+                   PDFJSDev.test('FIREFOX || MOZCENTRAL || CHROME')) {
+          value = this.baseUrl;
+        }
+      }
+      parameters[key] = value;
     }
 
     if (args) {

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -105,6 +105,9 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
+  /**
+   * The `printResolution` is, conditionally, defined below.
+   */
   renderer: {
     /** @type {string} */
     value: 'canvas',
@@ -182,6 +185,11 @@ const defaultOptions = {
     /** @type {boolean} */
     value: false,
     kind: OptionKind.API + OptionKind.PREFERENCE,
+  },
+  docBaseUrl: {
+    /** @type {string} */
+    value: '',
+    kind: OptionKind.API,
   },
   isEvalSupported: {
     /** @type {boolean} */


### PR DESCRIPTION
This unfortunately required a bit of special handling, to correctly deal with the various extension builds.