### PR TITLE
Remove an unnecessary `PDFDocumentProperties.setFileSize` call, relevant for the Firefox built-in viewer, and use the "normal" code-path in `PDFViewerApplication.open` instead

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -512,11 +512,7 @@ let PDFViewerApplication = {
     }
     this.externalServices.initPassiveLoading({
       onOpenWithTransport(url, length, transport) {
-        PDFViewerApplication.open(url, { range: transport, });
-
-        if (length) {
-          PDFViewerApplication.pdfDocumentProperties.setFileSize(length);
-        }
+        PDFViewerApplication.open(url, { length, range: transport, });
       },
       onOpenWithData(data) {
         PDFViewerApplication.open(data);
@@ -659,11 +655,13 @@ let PDFViewerApplication = {
     }
 
     if (args) {
-      for (let prop in args) {
-        if (prop === 'length') {
-          this.pdfDocumentProperties.setFileSize(args[prop]);
+      for (let key in args) {
+        const value = args[key];
+
+        if (key === 'length') {
+          this.pdfDocumentProperties.setFileSize(value);
         }
-        parameters[prop] = args[prop];
+        parameters[key] = value;
       }
     }
 


### PR DESCRIPTION
Since calling `getDocument` with a `PDFDataRangeTransport` argument will always unconditionally override a manually provided `length` argument, see https://github.com/mozilla/pdf.js/blob/a1a667809f286b761644bf34a4fb21dd524da8c8/src/display/api.js#L390-L394, this patch should thus be safe.