### PR TITLE
Inline the `isCmd` check in the `Parser.shift` method

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -67,7 +67,7 @@ class Parser {
   }
 
   shift() {
-    if (isCmd(this.buf2, 'ID')) {
+    if ((this.buf2 instanceof Cmd) && this.buf2.cmd === 'ID') {
       this.buf1 = this.buf2;
       this.buf2 = null;
     } else {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1331,7 +1331,7 @@ describe('api', function() {
 
         let [statEntry] = stats.times;
         expect(statEntry.name).toEqual('Page Request');
-        expect(statEntry.end - statEntry.start).toBeGreaterThan(0);
+        expect(statEntry.end - statEntry.start).toBeGreaterThanOrEqual(0);
 
         loadingTask.destroy().then(done);
       }, done.fail);


### PR DESCRIPTION
For very large and complex PDF files this will help performance slightly, since `Parser.shift` is called *a lot* during parsing.

This patch was tested using the PDF file from issue #2618, i.e. http://bugzilla-attachments.gnome.org/attachment.cgi?id=226471 (with well over *four million* `Parser.shift` calls for just the one page), using the following manifest file:
```
[
    {  "id": "issue2618",
       "file": "../web/pdfs/issue2618.pdf",
       "md5": "",
       "rounds": 100,
       "type": "eq"
    }
]
```

This gave the following results when comparing this patch against the `master` branch:
```
-- Grouped By browser, stat --
browser | stat         | Count | Baseline(ms) | Current(ms) | +/- |    %  | Result(P<.05)
------- | ------------ | ----- | ------------ | ----------- | --- | ----- | -------------
Firefox | Overall      |   100 |         3386 |        3322 | -65 | -1.92 |        faster
Firefox | Page Request |   100 |            1 |           1 |   0 | -8.08 |
Firefox | Rendering    |   100 |         3385 |        3321 | -65 | -1.92 |        faster
```