### PR TITLE
Reduce the number of function calls in `EvaluatorPreprocessor.read`

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -21,7 +21,7 @@ import {
 } from '../shared/util';
 import { CMapFactory, IdentityCMap } from './cmap';
 import {
-  Dict, isCmd, isDict, isEOF, isName, isRef, isStream, Name
+  Cmd, Dict, EOF, isDict, isName, isRef, isStream, Name
 } from './primitives';
 import {
   ErrorFont, Font, FontFlags, getFontType, IdentityToUnicodeMap, ToUnicodeMap
@@ -2999,7 +2999,7 @@ var EvaluatorPreprocessor = (function EvaluatorPreprocessorClosure() {
       var args = operation.args;
       while (true) {
         var obj = this.parser.getObj();
-        if (isCmd(obj)) {
+        if (obj instanceof Cmd) {
           var cmd = obj.cmd;
           // Check that the command is valid
           var opSpec = this.opMap[cmd];
@@ -3061,7 +3061,7 @@ var EvaluatorPreprocessor = (function EvaluatorPreprocessorClosure() {
           operation.args = args;
           return true;
         }
-        if (isEOF(obj)) {
+        if (obj === EOF) {
           return false; // no more commands
         }
         // argument


### PR DESCRIPTION
For very large and complex PDF files this will help performance slightly, since `EvaluatorPreprocessor.read` is called a lot during parsing in the worker.

This patch was tested using the PDF file from issue #2618, i.e. http://bugzilla-attachments.gnome.org/attachment.cgi?id=226471, using the following manifest file:
```
[
    {  "id": "issue2618",
       "file": "../web/pdfs/issue2618.pdf",
       "md5": "",
       "rounds": 200,
       "type": "eq"
    }
]
```

This gave the following results when comparing this patch against the `master` branch:
```
-- Grouped By browser, stat --
browser | stat         | Count | Baseline(ms) | Current(ms) | +/- |    %  | Result(P<.05)
------- | ------------ | ----- | ------------ | ----------- | --- | ----- | -------------
Firefox | Overall      |   200 |         3402 |        3358 | -43 | -1.28 |        faster
Firefox | Page Request |   200 |            1 |           1 |   0 | 26.71 |
Firefox | Rendering    |   200 |         3401 |        3357 | -44 | -1.28 |        faster
```