### PR TITLE
Decode URL encoded filenames from content disposition headers

### DIFF
--- a/src/display/network_utils.js
+++ b/src/display/network_utils.js
@@ -61,6 +61,11 @@ function extractFilenameFromHeader(getResponseHeader) {
   const contentDisposition = getResponseHeader('Content-Disposition');
   if (contentDisposition) {
     let filename = getFilenameFromContentDispositionHeader(contentDisposition);
+    if (filename.includes('%')) {
+      try {
+        filename = decodeURIComponent(filename);
+      } catch (ex) {}
+    }
     if (/\.pdf$/i.test(filename)) {
       return filename;
     }

--- a/test/unit/network_utils_spec.js
+++ b/test/unit/network_utils_spec.js
@@ -238,6 +238,20 @@ describe('network_utils', function() {
         }
         throw new Error(`Unexpected headerName: ${headerName}`);
       })).toEqual('filename.pdf');
+
+      expect(extractFilenameFromHeader((headerName) => {
+        if (headerName === 'Content-Disposition') {
+          return 'attachment; filename="%e4%b8%ad%e6%96%87.pdf"';
+        }
+        throw new Error(`Unexpected headerName: ${headerName}`);
+      })).toEqual('中文.pdf');
+
+      expect(extractFilenameFromHeader((headerName) => {
+        if (headerName === 'Content-Disposition') {
+          return 'attachment; filename="100%.pdf"';
+        }
+        throw new Error(`Unexpected headerName: ${headerName}`);
+      })).toEqual('100%.pdf');
     });
 
     it('gets the filename from the response header (RFC 6266)', function() {


### PR DESCRIPTION
pdf.js cannot correctly display urlencode contentDispositionFilename, so I add the decode logic of contentDispositionFilename in extractFilenameFromHeader.