### PR TITLE
[api-minor] Update telemetry to use 'categorical' histograms.

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -696,7 +696,7 @@ class Parser {
         return new CCITTFaxStream(stream, maybeLength, params);
       }
       if (name === 'RunLengthDecode' || name === 'RL') {
-        xrefStreamStats[StreamType.RL] = true;
+        xrefStreamStats[StreamType.RLX] = true;
         return new RunLengthStream(stream, maybeLength);
       }
       if (name === 'JBIG2Decode') {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -153,30 +153,30 @@ const AnnotationBorderStyleType = {
 };
 
 const StreamType = {
-  UNKNOWN: 0,
-  FLATE: 1,
-  LZW: 2,
-  DCT: 3,
-  JPX: 4,
-  JBIG: 5,
-  A85: 6,
-  AHX: 7,
-  CCF: 8,
-  RL: 9,
+  UNKNOWN: 'UNKNOWN',
+  FLATE: 'FLATE',
+  LZW: 'LZW',
+  DCT: 'DCT',
+  JPX: 'JPX',
+  JBIG: 'JBIG',
+  A85: 'A85',
+  AHX: 'AHX',
+  CCF: 'CCF',
+  RLX: 'RLX', // PDF short name is 'RL', but telemetry requires three chars.
 };
 
 const FontType = {
-  UNKNOWN: 0,
-  TYPE1: 1,
-  TYPE1C: 2,
-  CIDFONTTYPE0: 3,
-  CIDFONTTYPE0C: 4,
-  TRUETYPE: 5,
-  CIDFONTTYPE2: 6,
-  TYPE3: 7,
-  OPENTYPE: 8,
-  TYPE0: 9,
-  MMTYPE1: 10,
+  UNKNOWN: 'UNKNOWN',
+  TYPE1: 'TYPE1',
+  TYPE1C: 'TYPE1C',
+  CIDFONTTYPE0: 'CIDFONTTYPE0',
+  CIDFONTTYPE0C: 'CIDFONTTYPE0C',
+  TRUETYPE: 'TRUETYPE',
+  CIDFONTTYPE2: 'CIDFONTTYPE2',
+  TYPE3: 'TYPE3',
+  OPENTYPE: 'OPENTYPE',
+  TYPE0: 'TYPE0',
+  MMTYPE1: 'MMTYPE1',
 };
 
 const VerbosityLevel = {

--- a/web/app.js
+++ b/web/app.js
@@ -1137,8 +1137,10 @@ let PDFViewerApplication = {
 
       if (typeof PDFJSDev !== 'undefined' &&
           PDFJSDev.test('FIREFOX || MOZCENTRAL')) {
-        let versionId = String(info.PDFFormatVersion).slice(-1) | 0;
-        let generatorId = 0;
+        // Telemetry labels must be C++ variable friendly.
+        const versionId = `v${info.PDFFormatVersion.replace('.', '_')}`;
+        let generatorId = 'other';
+        // Keep these in sync with mozilla central's Histograms.json.
         const KNOWN_GENERATORS = [
           'acrobat distiller', 'acrobat pdfwriter', 'adobe livecycle',
           'adobe pdf library', 'adobe photoshop', 'ghostscript', 'tcpdf',
@@ -1151,7 +1153,7 @@ let PDFViewerApplication = {
             if (!generator.includes(s)) {
               return false;
             }
-            generatorId = i + 1;
+            generatorId = s.replace(/[ .\-]/g, '_');
             return true;
           }.bind(null, info.Producer.toLowerCase()));
         }


### PR DESCRIPTION
Firefox telemetry supports using string labels now. Convert our integers
that we used for categories to just use strings.

The upstream work will happen in:
https://bugzilla.mozilla.org/show_bug.cgi?id=1566882