### PR TITLE
Ensure that the loading indicator, in the pageNumber input, is hidden when the viewer is closed

### DIFF
--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -91,6 +91,7 @@ class Toolbar {
     this.pageScaleValue = DEFAULT_SCALE_VALUE;
     this.pageScale = DEFAULT_SCALE;
     this._updateUIState(true);
+    this.updateLoadingIndicatorState();
   }
 
   _bindListeners() {


### PR DESCRIPTION
Currently the indicator may remain visible even after the document has been closed, which seems weird given that no page is either visible nor rendering :-)