### PR TITLE
[api-minor] Fix completely broken `getStats` method by returning stats in Objects, rather than in Arrays (PR 11029 follow-up)

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -1046,8 +1046,8 @@ var XRef = (function XRefClosure() {
     // prepare the XRef cache
     this.cache = [];
     this.stats = {
-      streamTypes: [],
-      fontTypes: [],
+      streamTypes: Object.create(null),
+      fontTypes: Object.create(null),
     };
   }
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -205,10 +205,10 @@ function setPDFNetworkStreamFactory(pdfNetworkStreamFactory) {
 
 /**
  * @typedef {Object} PDFDocumentStats
- * @property {Array} streamTypes - Used stream types in the document (an item
+ * @property {Object} streamTypes - Used stream types in the document (an item
  *   is set to true if specific stream ID was used in the document).
- * @property {Array} fontTypes - Used font type in the document (an item is set
- *   to true if specific font ID was used in the document).
+ * @property {Object} fontTypes - Used font types in the document (an item
+ *   is set to true if specific font ID was used in the document).
  */
 
 /**

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -926,7 +926,7 @@ describe('api', function() {
     it('gets document stats', function(done) {
       var promise = doc.getStats();
       promise.then(function (stats) {
-        expect(stats).toEqual({ streamTypes: [], fontTypes: [], });
+        expect(stats).toEqual({ streamTypes: {}, fontTypes: {}, });
         done();
       }).catch(done.fail);
     });
@@ -1293,9 +1293,9 @@ describe('api', function() {
       var promise = page.getOperatorList().then(function () {
         return pdfDocument.getStats();
       });
-      var expectedStreamTypes = [];
+      var expectedStreamTypes = {};
       expectedStreamTypes[StreamType.FLATE] = true;
-      var expectedFontTypes = [];
+      var expectedFontTypes = {};
       expectedFontTypes[FontType.TYPE1] = true;
       expectedFontTypes[FontType.CIDFONTTYPE2] = true;
 


### PR DESCRIPTION
With the changes to the `StreamType`/`FontType` "enums" in PR #11029, one unfortunate result is that `getStats` now *always* returns empty Arrays. Something that everyone, myself included, apparently missed is that you obviously cannot index an Array with Strings :-)

I wrongly assumed that the unit-tests would catch any bugs, but they apparently suffered from the same issue as the code in `src/core/`.

Another possible option could perhaps be to use `Set`s, rather than objects, but that will require larger changes since `LoopbackPort` (in `src/display/api.js`) doesn't support them.

/cc @brendandahl 
/cc @timvandermeij 