### PR TITLE
Use more compact keys in `PDFLinkService._pagesRefCache`

### DIFF
--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -344,12 +344,14 @@ class PDFLinkService {
     if (!pageRef) {
       return;
     }
-    let refStr = pageRef.num + ' ' + pageRef.gen + ' R';
+    const refStr = pageRef.gen === 0 ? `${pageRef.num}R` :
+                                       `${pageRef.num}R${pageRef.gen}`;
     this._pagesRefCache[refStr] = pageNum;
   }
 
   _cachedPageNumber(pageRef) {
-    let refStr = pageRef.num + ' ' + pageRef.gen + ' R';
+    const refStr = pageRef.gen === 0 ? `${pageRef.num}R` :
+                                       `${pageRef.num}R${pageRef.gen}`;
     return (this._pagesRefCache && this._pagesRefCache[refStr]) || null;
   }
 


### PR DESCRIPTION
By using the same internal formatting here as in the `Ref.toString` method, in `src/core/primitives.js`, all cache-keys will become at least two bytes shorter (and most three bytes shorter).
Obviously this won't have a huge effect on memory since there's only one cache entry per page, but it nonetheless seems wasteful to use longer keys than strictly required.