### PR TITLE
Handle some corrupt/truncated JPEG images that are missing the EOI (End of Image) marker (issue 11052)

### DIFF
--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -403,16 +403,19 @@ var JpegImage = (function JpegImageClosure() {
       // find marker
       bitsCount = 0;
       fileMarker = findNextFileMarker(data, offset);
-      // Some bad images seem to pad Scan blocks with e.g. zero bytes, skip past
-      // those to attempt to find a valid marker (fixes issue4090.pdf).
-      if (fileMarker && fileMarker.invalid) {
+      if (!fileMarker) {
+        // Reached the end of the image data without finding an EOI marker.
+        break;
+      } else if (fileMarker.invalid) {
+        // Some bad images seem to pad Scan blocks with e.g. zero bytes, skip
+        // past those to attempt to find a valid marker (fixes issue4090.pdf).
         warn('decodeScan - unexpected MCU data, current marker is: ' +
              fileMarker.invalid);
         offset = fileMarker.offset;
       }
       var marker = fileMarker && fileMarker.marker;
       if (!marker || marker <= 0xFF00) {
-        throw new JpegError('marker was not found');
+        throw new JpegError('decodeScan - a valid marker was not found.');
       }
 
       if (marker >= 0xFFD0 && marker <= 0xFFD7) { // RSTx
@@ -943,7 +946,13 @@ var JpegImage = (function JpegImageClosure() {
               offset = nextFileMarker.offset;
               break;
             }
-            throw new JpegError('unknown marker ' + fileMarker.toString(16));
+            if (offset > (data.length - 2)) {
+              warn('JpegImage.parse - reached the end of the image data ' +
+                   'without finding an EOI marker (0xFFD9).');
+              break markerLoop;
+            }
+            throw new JpegError('JpegImage.parse - unknown marker: ' +
+                                fileMarker.toString(16));
         }
         fileMarker = readUint16();
       }

--- a/test/pdfs/issue11052.pdf.link
+++ b/test/pdfs/issue11052.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/3479488/test.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -3480,6 +3480,13 @@
        "link": true,
        "type": "eq"
     },
+    {  "id": "issue11052",
+       "file": "pdfs/issue11052.pdf",
+       "md5": "67c20e5bec51183c9283baa0cd49593f",
+       "rounds": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "bug1108753",
        "file": "pdfs/bug1108753.pdf",
        "md5": "a7aaf92d55b4602afb0ca3d75198b56b",


### PR DESCRIPTION
Note that even Adobe Reader cannot render the PDF file completely, which is always a good indication that it's corrupt.

Fixes #11052