### PR TITLE
fix: in ToUnicode map, a character id may map to two

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -31,7 +31,7 @@ import {
   WinAnsiEncoding, ZapfDingbatsEncoding
 } from './encodings';
 import {
-  getNormalizedUnicodes, getUnicodeForGlyph, reverseIfRtl
+  getNormalizedUnicodes, getUnicodeForGlyph, reverseIfRtl, keepUnifiedIdeographs
 } from './unicode';
 import {
   getSerifFonts, getStdFontMap, getSymbolsFonts
@@ -1415,9 +1415,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
           var glyphUnicode = glyph.unicode;
           var NormalizedUnicodes = getNormalizedUnicodes();
-          if (NormalizedUnicodes[glyphUnicode] !== undefined) {
-            glyphUnicode = NormalizedUnicodes[glyphUnicode];
-          }
+          glyphUnicode = keepUnifiedIdeographs(glyphUnicode, NormalizedUnicodes)
           glyphUnicode = reverseIfRtl(glyphUnicode);
 
           var charSpacing = textState.charSpacing;

--- a/src/core/unicode.js
+++ b/src/core/unicode.js
@@ -1630,8 +1630,31 @@ function reverseIfRtl(chars) {
   return s;
 }
 
+function keepUnifiedIdeographs(str, normalizedUnicodesMap) {
+  // a character id map to a unicode. replace it if it is not unified
+  if (str.length === 1) {
+    if (normalizedUnicodesMap[str]) {
+      return normalizedUnicodesMap[str]
+    } else {
+      return str
+    }
+    // a character id map to multiple unicode. remove not unified unicodes
+  } else {
+    var outStr = ''
+    for (var i = 0; i < str.length; i++) {
+      var char = str[i]
+      // if a char is not exist in the map, then it is a normal unicode
+      if (!normalizedUnicodesMap[char]) {
+        outStr = outStr + char
+      }
+    }
+    return outStr
+  }
+}
+
 exports.mapSpecialUnicodeValues = mapSpecialUnicodeValues;
 exports.reverseIfRtl = reverseIfRtl;
 exports.getUnicodeRangeFor = getUnicodeRangeFor;
 exports.getNormalizedUnicodes = getNormalizedUnicodes;
 exports.getUnicodeForGlyph = getUnicodeForGlyph;
+exports.keepUnifiedIdeographs = keepUnifiedIdeographs;


### PR DESCRIPTION
some pdf generators will generate a ToUnicode map, which maps a character to more than one unicode in CJK (China, Japan, Korea) character set.

You can see the pdf as a example.
[copy-paste-problem.pdf](https://github.com/mozilla/pdf.js/files/3489976/copy-paste-problem.pdf)

