### PR TITLE
Use streams for OperatorList chunking (issue 10023)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -195,7 +195,7 @@ class Page {
     });
   }
 
-  getOperatorList({ handler, task, intent, renderInteractiveForms, }) {
+  getOperatorList({ handler, sink, task, intent, renderInteractiveForms, }) {
     const contentStreamPromise = this.pdfManager.ensure(this,
                                                         'getContentStream');
     const resourcesPromise = this.loadResources([
@@ -220,7 +220,7 @@ class Page {
 
     const dataPromises = Promise.all([contentStreamPromise, resourcesPromise]);
     const pageListPromise = dataPromises.then(([contentStream]) => {
-      const opList = new OperatorList(intent, handler, this.pageIndex);
+      const opList = new OperatorList(intent, sink, this.pageIndex);
 
       handler.send('StartRenderPage', {
         transparency: partialEvaluator.hasBlendModes(this.resources),
@@ -244,7 +244,7 @@ class Page {
         function([pageOpList, annotations]) {
       if (annotations.length === 0) {
         pageOpList.flush(true);
-        return pageOpList;
+        return { length: pageOpList.totalLength, };
       }
 
       // Collect the operator list promises for the annotations. Each promise
@@ -264,7 +264,7 @@ class Page {
         }
         pageOpList.addOp(OPS.endAnnotations, []);
         pageOpList.flush(true);
-        return pageOpList;
+        return { length: pageOpList.totalLength, };
       });
     });
   }

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -541,6 +541,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         operatorList.addDependencies(tilingOpList.dependencies);
         operatorList.addOp(fn, tilingPatternIR);
       }, (reason) => {
+        if (reason instanceof AbortException) {
+          return;
+        }
         if (this.options.ignoreErrors) {
           // Error(s) in the TilingPattern -- sending unsupported feature
           // notification and allow rendering to continue.
@@ -918,8 +921,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       }
 
       return new Promise(function promiseBody(resolve, reject) {
-        var next = function (promise) {
-          promise.then(function () {
+        let next = function(promise) {
+          Promise.all([promise, operatorList.ready]).then(function () {
             try {
               promiseBody(resolve, reject);
             } catch (ex) {
@@ -1000,6 +1003,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
                 }
                 resolveXObject();
               }).catch(function(reason) {
+                if (reason instanceof AbortException) {
+                  return;
+                }
                 if (self.options.ignoreErrors) {
                   // Error(s) in the XObject -- sending unsupported feature
                   // notification and allow rendering to continue.
@@ -1230,6 +1236,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         closePendingRestoreOPS();
         resolve();
       }).catch((reason) => {
+        if (reason instanceof AbortException) {
+          return;
+        }
         if (this.options.ignoreErrors) {
           // Error(s) in the OperatorList -- sending unsupported feature
           // notification and allow rendering to continue.

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -466,10 +466,10 @@ var WorkerMessageHandler = {
       });
     });
 
-    handler.on('RenderPageRequest', function wphSetupRenderPage(data) {
+    handler.on('GetOperatorList', function wphSetupRenderPage(data, sink) {
       var pageIndex = data.pageIndex;
       pdfManager.getPage(pageIndex).then(function(page) {
-        var task = new WorkerTask('RenderPageRequest: page ' + pageIndex);
+        var task = new WorkerTask(`GetOperatorList: page ${pageIndex}`);
         startWorkerTask(task);
 
         // NOTE: Keep this condition in sync with the `info` helper function.
@@ -478,55 +478,30 @@ var WorkerMessageHandler = {
         // Pre compile the pdf page and fetch the fonts/images.
         page.getOperatorList({
           handler,
+          sink,
           task,
           intent: data.intent,
           renderInteractiveForms: data.renderInteractiveForms,
-        }).then(function(operatorList) {
+        }).then(function(operatorListInfo) {
           finishWorkerTask(task);
 
           if (start) {
             info(`page=${pageIndex + 1} - getOperatorList: time=` +
-                 `${Date.now() - start}ms, len=${operatorList.totalLength}`);
+                 `${Date.now() - start}ms, len=${operatorListInfo.length}`);
           }
-        }, function(e) {
+          sink.close();
+        }, function(reason) {
           finishWorkerTask(task);
           if (task.terminated) {
             return; // ignoring errors from the terminated thread
           }
-
           // For compatibility with older behavior, generating unknown
           // unsupported feature notification on errors.
           handler.send('UnsupportedFeature',
                        { featureId: UNSUPPORTED_FEATURES.unknown, });
 
-          var minimumStackMessage =
-            'worker.js: while trying to getPage() and getOperatorList()';
-
-          var wrappedException;
-
-          // Turn the error into an obj that can be serialized
-          if (typeof e === 'string') {
-            wrappedException = {
-              message: e,
-              stack: minimumStackMessage,
-            };
-          } else if (typeof e === 'object') {
-            wrappedException = {
-              message: e.message || e.toString(),
-              stack: e.stack || minimumStackMessage,
-            };
-          } else {
-            wrappedException = {
-              message: 'Unknown exception type: ' + (typeof e),
-              stack: minimumStackMessage,
-            };
-          }
-
-          handler.send('PageError', {
-            pageIndex,
-            error: wrappedException,
-            intent: data.intent,
-          });
+          sink.error(reason);
+          throw reason;
         });
       });
     }, this);

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -501,7 +501,9 @@ var WorkerMessageHandler = {
                        { featureId: UNSUPPORTED_FEATURES.unknown, });
 
           sink.error(reason);
-          throw reason;
+
+          // TODO: Should `reason` be re-thrown here (currently that casues
+          //       "Uncaught exception: ..." messages in the console)?
         });
       });
     }, this);
@@ -538,7 +540,9 @@ var WorkerMessageHandler = {
             return; // ignoring errors from the terminated thread
           }
           sink.error(reason);
-          throw reason;
+
+          // TODO: Should `reason` be re-thrown here (currently that casues
+          //       "Uncaught exception: ..." messages in the console)?
         });
       });
     });

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1281,11 +1281,6 @@ describe('api', function() {
 
     it('gets operatorList, from corrupt PDF file (issue 8702), ' +
        'with/without `stopAtErrors` set', function(done) {
-      if (isNodeJS()) {
-        pending(
-          'Fails with "Unhandled promise rejection: ..." errors in Node.js.');
-      }
-
       const loadingTask1 = getDocument(buildGetDocumentParams('issue8702.pdf', {
         stopAtErrors: false, // The default value.
       }));

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1281,6 +1281,11 @@ describe('api', function() {
 
     it('gets operatorList, from corrupt PDF file (issue 8702), ' +
        'with/without `stopAtErrors` set', function(done) {
+      if (isNodeJS()) {
+        pending(
+          'Fails with "Unhandled promise rejection: ..." errors in Node.js.');
+      }
+
       const loadingTask1 = getDocument(buildGetDocumentParams('issue8702.pdf', {
         stopAtErrors: false, // The default value.
       }));

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -320,13 +320,12 @@ describe('evaluator', function() {
   });
 
   describe('operator list', function () {
-    function MessageHandlerMock() { }
-    MessageHandlerMock.prototype = {
-      send() { },
-    };
+    class StreamSinkMock {
+      enqueue() { }
+    }
 
     it('should get correct total length after flushing', function () {
-      var operatorList = new OperatorList(null, new MessageHandlerMock());
+      var operatorList = new OperatorList(null, new StreamSinkMock());
       operatorList.addOp(OPS.save, null);
       operatorList.addOp(OPS.restore, null);
 


### PR DESCRIPTION
*Please note:* The majority of this patch was written by Yury, and it's simply been rebased and slightly extended to prevent issues when dealing with `RenderingCancelledException`.

By leveraging streams this (finally) provides a simple way in which parsing can be aborted on the worker-thread, which will ultimately help save resources.
With this patch worker-thread parsing will *only* be aborted when the document is destroyed, and not when rendering is cancelled. There's a couple of reasons for this:

 - The API currently expects the *entire* OperatorList to be extracted, or an Error to occur, once it's been started. Hence additional re-factoring/re-writing of the API code will be necessary to properly support cancelling and re-starting of OperatorList parsing in cases where the `lastChunk` hasn't yet been seen.
 - Even with the above addressed, immediately cancelling when encountering a `RenderingCancelledException` will lead to worse performance in e.g. the default viewer. When zooming and/or rotation of the document occurs it's very likely that `cancel` will be (almost) immediately followed by a new `render` call. In that case you'd obviously *not* want to abort parsing on the worker-thread, since then you'd risk throwing away a partially parsed Page and thus be forced to re-parse it again which will regress perceived performance.
 - This patch is already *somewhat* risky, given that it touches fundamentally important/critical code, and trying to keep it somewhat small should hopefully reduce the risk of regressions (and simplify reviewing as well).

Time permitting, once this has landed and been in Nightly for awhile, I'll try to work on the remaining points outlined above.