### PR TITLE
added in information about pdfjs/webpack

### DIFF
--- a/examples/webpack/README.md
+++ b/examples/webpack/README.md
@@ -17,3 +17,11 @@ http://localhost:8888/examples/webpack/index.html.
 Refer to the `main.js` and `webpack.config.js` files for the source code.
 Note that PDF.js packaging requires packaging of the main application and
 the worker code, and the `workerSrc` path shall be set to the latter file.
+
+## Worker loading
+
+If you are getting the `Setting up fake worker` warning, make sure you are importing `pdfjs-dist/webpack` which is the zero-configuration method for Webpack users:
+
+    import pdfjsLib from 'pdfjs-dist/webpack';
+
+For a full working example refer to [this repository](https://github.com/yurydelendik/pdfjs-react).


### PR DESCRIPTION
Added in information about including the import for webpack and the warning that gets generated
included a link to a repo with a working example.

Fixes #10940.