### PR TITLE
[TextLayer] Only cache the `originalTransform` when `enhanceTextSelection` is enabled

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -537,14 +537,12 @@ var renderTextLayer = (function renderTextLayerClosure() {
       if (textDivProperties.isWhitespace) {
         return;
       }
-
-      let fontSize = textDiv.style.fontSize;
-      let fontFamily = textDiv.style.fontFamily;
+      const { fontSize, fontFamily, } = textDiv.style;
 
       // Only build font string and set to context if different from last.
       if (fontSize !== this._layoutTextLastFontSize ||
           fontFamily !== this._layoutTextLastFontFamily) {
-        this._layoutTextCtx.font = fontSize + ' ' + fontFamily;
+        this._layoutTextCtx.font = `${fontSize} ${fontFamily}`;
         this._layoutTextLastFontSize = fontSize;
         this._layoutTextLastFontFamily = fontFamily;
       }

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -560,7 +560,9 @@ var renderTextLayer = (function renderTextLayerClosure() {
         transform = `rotate(${textDivProperties.angle}deg) ${transform}`;
       }
       if (transform.length > 0) {
-        textDivProperties.originalTransform = transform;
+        if (this._enhanceTextSelection) {
+          textDivProperties.originalTransform = transform;
+        }
         textDiv.style.transform = transform;
       }
       this._textDivProperties.set(textDiv, textDivProperties);
@@ -668,8 +670,8 @@ var renderTextLayer = (function renderTextLayerClosure() {
             div.style.transform = transform;
           }
         } else {
-          div.style.padding = 0;
-          div.style.transform = divProps.originalTransform || '';
+          div.style.padding = null;
+          div.style.transform = divProps.originalTransform;
         }
       }
     },


### PR DESCRIPTION
Given that this is completely unused in "regular" text-selection mode, there's no reason to unconditionally store one string for every `textDiv`.