### PR TITLE
[TextLayer] Only handle positive padding values in `expandTextDivs`

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -643,21 +643,21 @@ var renderTextLayer = (function renderTextLayerClosure() {
           if (divProps.angle !== 0) {
             transform = `rotate(${divProps.angle}deg) ${transform}`;
           }
-          if (divProps.paddingLeft !== 0) {
+          if (divProps.paddingLeft > 0) {
             padding +=
               ` padding-left: ${divProps.paddingLeft / divProps.scale}px;`;
             transform +=
               ` translateX(${-divProps.paddingLeft / divProps.scale}px)`;
           }
-          if (divProps.paddingTop !== 0) {
+          if (divProps.paddingTop > 0) {
             padding += ` padding-top: ${divProps.paddingTop}px;`;
             transform += ` translateY(${-divProps.paddingTop}px)`;
           }
-          if (divProps.paddingRight !== 0) {
+          if (divProps.paddingRight > 0) {
             padding +=
               ` padding-right: ${divProps.paddingRight / divProps.scale}px;`;
           }
-          if (divProps.paddingBottom !== 0) {
+          if (divProps.paddingBottom > 0) {
             padding += ` padding-bottom: ${divProps.paddingBottom}px;`;
           }
 


### PR DESCRIPTION
Given that browsers will reject padding values smaller than zero (which may be caused by limited numerical precision during calculations in the `expand` code), it makes no sense to include those when expanding the `textDiv`s.