### PR TITLE
Remove support for the `scope` parameter in the `MessageHandler.on` method

### DIFF
--- a/src/shared/message_handler.js
+++ b/src/shared/message_handler.js
@@ -30,13 +30,6 @@ const StreamKind = {
   START_COMPLETE: 8,
 };
 
-async function resolveCall(fn, args) {
-  if (!fn) {
-    return undefined;
-  }
-  return fn.apply(null, args);
-}
-
 function wrapReason(reason) {
   if (typeof reason !== 'object') {
     return reason;
@@ -318,7 +311,9 @@ MessageHandler.prototype = {
     streamSink.sinkCapability.resolve();
     streamSink.ready = streamSink.sinkCapability.promise;
     this.streamSinks[streamId] = streamSink;
-    resolveCall(action, [data.data, streamSink]).then(() => {
+    Promise.resolve().then(function() {
+      return action(data.data, streamSink);
+    }).then(function() {
       comObj.postMessage({
         sourceName,
         targetName,
@@ -326,7 +321,7 @@ MessageHandler.prototype = {
         streamId,
         success: true,
       });
-    }, (reason) => {
+    }, function(reason) {
       comObj.postMessage({
         sourceName,
         targetName,
@@ -385,7 +380,10 @@ MessageHandler.prototype = {
         }
         // Reset desiredSize property of sink on every pull.
         this.streamSinks[data.streamId].desiredSize = data.desiredSize;
-        resolveCall(this.streamSinks[data.streamId].onPull).then(() => {
+        const { onPull, } = this.streamSinks[data.streamId];
+        Promise.resolve().then(function() {
+          return onPull && onPull();
+        }).then(function() {
           comObj.postMessage({
             sourceName,
             targetName,
@@ -393,7 +391,7 @@ MessageHandler.prototype = {
             streamId,
             success: true,
           });
-        }, (reason) => {
+        }, function(reason) {
           comObj.postMessage({
             sourceName,
             targetName,
@@ -435,8 +433,10 @@ MessageHandler.prototype = {
         if (!this.streamSinks[data.streamId]) {
           break;
         }
-        resolveCall(this.streamSinks[data.streamId].onCancel,
-                    [wrapReason(data.reason)]).then(() => {
+        const { onCancel, } = this.streamSinks[data.streamId];
+        Promise.resolve().then(function() {
+          return onCancel && onCancel(wrapReason(data.reason));
+        }).then(function() {
           comObj.postMessage({
             sourceName,
             targetName,
@@ -444,7 +444,7 @@ MessageHandler.prototype = {
             streamId,
             success: true,
           });
-        }, (reason) => {
+        }, function(reason) {
           comObj.postMessage({
             sourceName,
             targetName,


### PR DESCRIPTION
 - Remove support for the `scope` parameter in the `MessageHandler.on` method

    At this point in time it's easy to convert the `MessageHandler.on` call-sites to use arrow functions, and thus let the JavaScript engine handle scopes for us, rather than having to manually keep references to the relevant scopes in `MessageHandler`.[1]
   An additional benefit of this is that a couple of `Function.prototype.call()` instances can now be converted into "normal" function calls, which should be a tiny bit more efficient.

   All in all, I don't see any compelling reason why it'd be necessary to keep supporting custom `scope`s in the `MessageHandler` implementation.

   ---
   [1] In the event that a custom scope is ever needed, simply using `bind` on the handler function when calling `MessageHandler.on` ought to work as well.

 - Inline the `resolveCall` helper function at its call-sites in `MessageHandler`

   There's only three call-sites and one of them doesn't even need the complete funtionality of `resolveCall`, hence it seems reasonable to just inline this code.
   An additional benefit of this is that the `Function.prototype.apply()` instance can also be converted into "normal" function calls, which should be a tiny bit more efficient.

   The patch also replaces a number of unnecessary arrow functions, in relevant parts of the `MessageHandler` code, with "normal" functions instead.