### PR TITLE
Remove the API/Worker version warning message in `TESTING` mode

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -109,13 +109,11 @@ var WorkerMessageHandler = {
     var WorkerTasks = [];
     const verbosity = getVerbosityLevel();
 
-    let apiVersion = docParams.apiVersion;
-    let workerVersion =
-      typeof PDFJSDev !== 'undefined' ? PDFJSDev.eval('BUNDLE_VERSION') : null;
-    if ((typeof PDFJSDev !== 'undefined' && PDFJSDev.test('TESTING')) &&
-        apiVersion === null) {
-      warn('Ignoring apiVersion/workerVersion check in TESTING builds.');
-    } else if (apiVersion !== workerVersion) {
+    const apiVersion = docParams.apiVersion;
+    const workerVersion =
+      typeof PDFJSDev !== 'undefined' && !PDFJSDev.test('TESTING') ?
+      PDFJSDev.eval('BUNDLE_VERSION') : null;
+    if (apiVersion !== workerVersion) {
       throw new Error(`The API version "${apiVersion}" does not match ` +
                       `the Worker version "${workerVersion}".`);
     }

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -395,8 +395,8 @@ function _fetchDocument(worker, source, pdfDataRangeTransport, docId) {
   }
   return worker.messageHandler.sendWithPromise('GetDocRequest', {
     docId,
-    apiVersion: (typeof PDFJSDev !== 'undefined' ?
-                 PDFJSDev.eval('BUNDLE_VERSION') : null),
+    apiVersion: typeof PDFJSDev !== 'undefined' && !PDFJSDev.test('TESTING') ?
+                PDFJSDev.eval('BUNDLE_VERSION') : null,
     source: { // Only send the required properties, and *not* the entire object.
       data: source.data,
       url: source.url,


### PR DESCRIPTION
The warning messages turn out to be more annoying than helpful when looking at the `console` during tests, so let's just remove them.