### PR TITLE
Ensure that `Error`s are handled correctly when using `postMessage` with Streams in `MessageHandler`

### DIFF
--- a/src/shared/message_handler.js
+++ b/src/shared/message_handler.js
@@ -231,7 +231,7 @@ MessageHandler.prototype = {
           targetName,
           stream: StreamKind.CANCEL,
           streamId,
-          reason,
+          reason: wrapReason(reason),
         });
         // Return Promise to signal success or failure.
         return cancelCapability.promise;
@@ -296,7 +296,7 @@ MessageHandler.prototype = {
           targetName,
           stream: StreamKind.ERROR,
           streamId,
-          reason,
+          reason: wrapReason(reason),
         });
       },
 
@@ -327,7 +327,7 @@ MessageHandler.prototype = {
         targetName,
         stream: StreamKind.START_COMPLETE,
         streamId,
-        reason,
+        reason: wrapReason(reason),
       });
     });
   },
@@ -397,7 +397,7 @@ MessageHandler.prototype = {
             targetName,
             stream: StreamKind.PULL_COMPLETE,
             streamId,
-            reason,
+            reason: wrapReason(reason),
           });
         });
         break;
@@ -450,7 +450,7 @@ MessageHandler.prototype = {
             targetName,
             stream: StreamKind.CANCEL_COMPLETE,
             streamId,
-            reason,
+            reason: wrapReason(reason),
           });
         });
         this.streamSinks[data.streamId].sinkCapability.

--- a/src/shared/message_handler.js
+++ b/src/shared/message_handler.js
@@ -223,6 +223,7 @@ MessageHandler.prototype = {
       },
 
       cancel: (reason) => {
+        assert(reason instanceof Error, 'cancel must have a valid reason');
         let cancelCapability = createPromiseCapability();
         this.streamControllers[streamId].cancelCall = cancelCapability;
         this.streamControllers[streamId].isClosed = true;
@@ -287,6 +288,7 @@ MessageHandler.prototype = {
       },
 
       error(reason) {
+        assert(reason instanceof Error, 'error must have a valid reason');
         if (this.isCancelled) {
           return;
         }

--- a/test/unit/message_handler_spec.js
+++ b/test/unit/message_handler_spec.js
@@ -13,7 +13,9 @@
  * limitations under the License.
  */
 
-import { AbortException, createPromiseCapability } from '../../src/shared/util';
+import {
+  AbortException, createPromiseCapability, UnknownErrorException
+} from '../../src/shared/util';
 import { LoopbackPort } from '../../src/display/api';
 import { MessageHandler } from '../../src/shared/message_handler';
 
@@ -149,7 +151,7 @@ describe('message_handler', function () {
           return sink.ready;
         }).then(() => {
           log += 'e';
-          sink.error('error');
+          sink.error(new Error('should not read when errored'));
         });
       });
       let messageHandler1 = new MessageHandler('main', 'worker', port);
@@ -171,7 +173,8 @@ describe('message_handler', function () {
         return reader.read();
       }).catch((reason) => {
         expect(log).toEqual('01pe');
-        expect(reason).toEqual('error');
+        expect(reason instanceof UnknownErrorException).toEqual(true);
+        expect(reason.message).toEqual('should not read when errored');
         done();
       });
     });

--- a/test/unit/message_handler_spec.js
+++ b/test/unit/message_handler_spec.js
@@ -142,11 +142,13 @@ describe('message_handler', function () {
         sink.onCancel = function (reason) {
           log += 'c';
         };
+        log += '0';
         sink.ready.then(() => {
+          log += '1';
           sink.enqueue([1, 2, 3, 4], 4);
           return sink.ready;
         }).then(() => {
-          log += 'error';
+          log += 'e';
           sink.error('error');
         });
       });
@@ -161,14 +163,14 @@ describe('message_handler', function () {
       let reader = readable.getReader();
 
       sleep(10).then(() => {
-        expect(log).toEqual('');
+        expect(log).toEqual('01');
         return reader.read();
       }).then((result) => {
         expect(result.value).toEqual([1, 2, 3, 4]);
         expect(result.done).toEqual(false);
         return reader.read();
-      }).then(() => {
-      }, (reason) => {
+      }).catch((reason) => {
+        expect(log).toEqual('01pe');
         expect(reason).toEqual('error');
         done();
       });


### PR DESCRIPTION
*Please refer to the individual commit messages for additional details.*