### PR TITLE
[api-minor] Remove the `postMessageTransfers` parameter, and thus the ability to manually disable transferring of data, from the API

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -73,19 +73,7 @@ var WorkerMessageHandler = {
       // making sure postMessage transfers are working
       var supportTransfers = data[0] === 255;
       handler.postMessageTransfers = supportTransfers;
-      // check if the response property is supported by xhr
-      var xhr = new XMLHttpRequest();
-      var responseExists = 'response' in xhr;
-      // check if the property is actually implemented
-      try {
-        xhr.responseType; // eslint-disable-line no-unused-expressions
-      } catch (e) {
-        responseExists = false;
-      }
-      if (!responseExists) {
-        handler.send('test', false);
-        return;
-      }
+
       handler.send('test', {
         supportTypedArray: true,
         supportTransfers,

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -67,17 +67,14 @@ var WorkerMessageHandler = {
 
       // check if Uint8Array can be sent to worker
       if (!(data instanceof Uint8Array)) {
-        handler.send('test', false);
+        handler.send('test', null);
         return;
       }
       // making sure postMessage transfers are working
-      var supportTransfers = data[0] === 255;
+      const supportTransfers = data[0] === 255;
       handler.postMessageTransfers = supportTransfers;
 
-      handler.send('test', {
-        supportTypedArray: true,
-        supportTransfers,
-      });
+      handler.send('test', { supportTransfers, });
     });
 
     handler.on('configure', function wphConfigure(data) {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1665,7 +1665,7 @@ const PDFWorker = (function PDFWorkerClosure() {
               terminateEarly();
               return; // worker was destroyed
             }
-            if (data && data.supportTypedArray) {
+            if (data) { // supportTypedArray
               this._messageHandler = messageHandler;
               this._port = worker;
               this._webWorker = worker;

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -146,8 +146,6 @@ function setPDFNetworkStreamFactory(pdfNetworkStreamFactory) {
  *   2^16 = 65536.
  * @property {PDFWorker}  worker - (optional) The worker that will be used for
  *   the loading and parsing of the PDF data.
- * @property {boolean} postMessageTransfers - (optional) Enables transfer usage
- *   in postMessage for ArrayBuffers. The default value is `true`.
  * @property {number} verbosity - (optional) Controls the logging level; the
  *   constants from {VerbosityLevel} should be used.
  * @property {string} docBaseUrl - (optional) The base URL of the document,
@@ -319,7 +317,6 @@ function getDocument(src) {
 
   if (!worker) {
     const workerParams = {
-      postMessageTransfers: params.postMessageTransfers,
       verbosity: params.verbosity,
       port: GlobalWorkerOptions.workerPort,
     };
@@ -1476,8 +1473,6 @@ class LoopbackPort {
  * @typedef {Object} PDFWorkerParameters
  * @property {string} name - (optional) The name of the worker.
  * @property {Object} port - (optional) The `workerPort`.
- * @property {boolean} postMessageTransfers - (optional) Enables transfer usage
- *   in postMessage for ArrayBuffers. The default value is `true`.
  * @property {number} verbosity - (optional) Controls the logging level; the
  *   constants from {VerbosityLevel} should be used.
  */
@@ -1568,7 +1563,7 @@ const PDFWorker = (function PDFWorkerClosure() {
    * @param {PDFWorkerParameters} params - The worker initialization parameters.
    */
   class PDFWorker {
-    constructor({ name = null, port = null, postMessageTransfers = true,
+    constructor({ name = null, port = null,
                   verbosity = getVerbosityLevel(), } = {}) {
       if (port && pdfWorkerPorts.has(port)) {
         throw new Error('Cannot use more than one PDFWorker per port');
@@ -1576,7 +1571,7 @@ const PDFWorker = (function PDFWorkerClosure() {
 
       this.name = name;
       this.destroyed = false;
-      this.postMessageTransfers = postMessageTransfers !== false;
+      this.postMessageTransfers = true;
       this.verbosity = verbosity;
 
       this._readyCapability = createPromiseCapability();
@@ -1705,7 +1700,7 @@ const PDFWorker = (function PDFWorkerClosure() {
             try {
               messageHandler.send('test', testObj, [testObj.buffer]);
             } catch (ex) {
-              info('Cannot use postMessage transfers');
+              warn('Cannot use postMessage transfers.');
               testObj[0] = 0;
               messageHandler.send('test', testObj);
             }

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -206,11 +206,6 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.API,
   },
-  postMessageTransfers: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.API,
-  },
   verbosity: {
     /** @type {number} */
     value: 1,


### PR DESCRIPTION
By transferring, rather than copying, `ArrayBuffer`s between the main- and worker-threads, you can avoid unnecessary allocations by only having *one* copy of the same data.
Hence manually setting `postMessageTransfers: false`, when calling `getDocument`, is a performance footgun[1] which will do nothing but waste memory.

Given that every reasonably modern browser supports `postMessage` transfers[2], I really don't see why it should be possible to force-disable this functionality.
Looking at the browser support, for `postMessage` transfers[2], it's highly unlikely that PDF.js is even usable in browsers without it. However, the feature testing of `postMessage` transfers is kept for the time being just to err on the safe side.

---
[1] This is somewhat similar to the, now removed, `disableWorker` parameter which also provided API users a much too simple way of reducing performance.

[2] See e.g. https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/postMessage#Browser_compatibility and https://developer.mozilla.org/en-US/docs/Web/API/Transferable#Browser_compatibility