### PR TITLE
Prevent "offsetParent is not set -- cannot scroll" errors when the viewer loads in e.g. a hidden <iframe>

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -939,8 +939,13 @@ let PDFViewerApplication = {
       }).catch(() => { /* Unable to read from storage; ignoring errors. */ });
 
       Promise.all([
-        storePromise, pageLayoutPromise, pageModePromise, openActionDestPromise,
-      ]).then(async ([values = {}, pageLayout, pageMode, openActionDest]) => {
+        animationStarted,
+        storePromise,
+        pageLayoutPromise,
+        pageModePromise,
+        openActionDestPromise,
+      ]).then(async ([timeStamp, values = {}, pageLayout, pageMode,
+                      openActionDest]) => {
         const viewOnLoad = AppOptions.get('viewOnLoad');
 
         this._initializePdfHistory({
@@ -1088,7 +1093,7 @@ let PDFViewerApplication = {
       });
     });
 
-    Promise.all([onePageRendered, animationStarted]).then(() => {
+    onePageRendered.then(() => {
       pdfDocument.getOutline().then((outline) => {
         this.pdfOutlineViewer.render({ outline, });
       });


### PR DESCRIPTION
Besides avoiding errors during loading, this also ensures that the document will be correctly scrolled/zoomed into view once the viewer becomes visible.
This "new" behaviour was always intended, see PR #2613, however various re-factoring over the years seem to have broken this (and I'm probably at least somewhat responsible for that).