### PR TITLE
Don't `enqueue` unused properties when sending 'GetOperatorList' data from the worker-thread (PR 11069 follow-up)

### DIFF
--- a/src/core/operator_list.js
+++ b/src/core/operator_list.js
@@ -648,14 +648,10 @@ var OperatorList = (function OperatorListClosure() {
       this._totalLength += length;
 
       this._streamSink.enqueue({
-        operatorList: {
-          fnArray: this.fnArray,
-          argsArray: this.argsArray,
-          lastChunk,
-          length,
-        },
-        pageIndex: this.pageIndex,
-        intent: this.intent,
+        fnArray: this.fnArray,
+        argsArray: this.argsArray,
+        lastChunk,
+        length,
       }, 1, this._transfers);
 
       this.dependencies = Object.create(null);

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1324,7 +1324,7 @@ class PDFPageProxy {
         if (this._transport.destroyed) {
           return; // Ignore any pending requests if the worker was terminated.
         }
-        this._renderPageChunk(value.operatorList, intentState);
+        this._renderPageChunk(value, intentState);
         pump();
       }, (reason) => {
         intentState.streamReader = null;


### PR DESCRIPTION
With the changes made in PR #11069, it's no longer necessary to include the `pageIndex`/`intent` parameters when sending 'GetOperatorList' data. In the previous implementation these properties were used to associate the `OperatorList` with the correct `RenderTask`, however now that `ReadableStream`s are used that's handled automatically and it's thus dead code at this point.