### PR TITLE
Enable the `no-async-promise-executor` ESLint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,6 +35,7 @@
 
     // Possible errors
     "for-direction": "error",
+    "no-async-promise-executor": "error",
     "no-cond-assign": ["error", "except-parens"],
     "no-constant-condition": ["error", { "checkLoops": false, }],
     "no-dupe-args": "error",


### PR DESCRIPTION
This rule is in the process of being rolled out in mozilla-central, and it helps avoid unnecessary `async` functions together with `new Promise(...)`.

Please see https://eslint.org/docs/rules/no-async-promise-executor for additional information.