### PR TITLE
Ensure that `addLinkAttributes` is always called with a valid `url` parameter

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -294,20 +294,18 @@ class LinkAnnotationElement extends AnnotationElement {
     const { data, linkService, } = this;
     const link = document.createElement('a');
 
-    addLinkAttributes(link, {
-      url: data.url,
-      target: (data.newWindow ?
-               LinkTarget.BLANK : linkService.externalLinkTarget),
-      rel: linkService.externalLinkRel,
-      enabled: linkService.externalLinkEnabled,
-    });
-
-    if (!data.url) {
-      if (data.action) {
-        this._bindNamedAction(link, data.action);
-      } else {
-        this._bindLink(link, data.dest);
-      }
+    if (data.url) {
+      addLinkAttributes(link, {
+        url: data.url,
+        target: (data.newWindow ?
+                 LinkTarget.BLANK : linkService.externalLinkTarget),
+        rel: linkService.externalLinkRel,
+        enabled: linkService.externalLinkEnabled,
+      });
+    } else if (data.action) {
+      this._bindNamedAction(link, data.action);
+    } else {
+      this._bindLink(link, data.dest);
     }
 
     this.container.appendChild(link);

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -354,7 +354,10 @@ const LinkTargetStringMap = [
  * @param {ExternalLinkParameters} params
  */
 function addLinkAttributes(link, { url, target, rel, enabled = true, } = {}) {
-  const urlNullRemoved = (url ? removeNullCharacters(url) : '');
+  assert(url && typeof url === 'string',
+         'addLinkAttributes: A valid "url" parameter must provided.');
+
+  const urlNullRemoved = removeNullCharacters(url);
   if (enabled) {
     link.href = link.title = urlNullRemoved;
   } else {
@@ -365,14 +368,12 @@ function addLinkAttributes(link, { url, target, rel, enabled = true, } = {}) {
     };
   }
 
-  if (url) {
-    const LinkTargetValues = Object.values(LinkTarget);
-    const targetIndex =
-      LinkTargetValues.includes(target) ? target : LinkTarget.NONE;
-    link.target = LinkTargetStringMap[targetIndex];
+  const LinkTargetValues = Object.values(LinkTarget);
+  const targetIndex =
+    LinkTargetValues.includes(target) ? target : LinkTarget.NONE;
+  link.target = LinkTargetStringMap[targetIndex];
 
-    link.rel = (typeof rel === 'string' ? rel : DEFAULT_LINK_REL);
-  }
+  link.rel = (typeof rel === 'string' ? rel : DEFAULT_LINK_REL);
 }
 
 // Gets the file name from a given URL.


### PR DESCRIPTION
There's no good reason for calling this helper function without a `url` parameter, and this way we can prevent that from happening.
Note how the `PDFOutlineViewer` call-site was already doing the right thing here, and only the `LinkAnnotationElement` call-site needed a small adjustment to make it work.

*Smaller diff with https://github.com/mozilla/pdf.js/pull/11134/files?w=1*