### PR TITLE
Stop dispatching a "localized" event from the webL10n library, since it's unused and may clash with the default viewer

### DIFF
--- a/external/webL10n/l10n.js
+++ b/external/webL10n/l10n.js
@@ -26,6 +26,9 @@
     - Removes consoleWarn and consoleLog and use console.log/warn directly.
     - Removes window._ assignment.
     - Remove compatibility code for OldIE.
+    - Replaces `String.prototype.substr()` with `String.prototype.substring()`.
+    - Removes `fireL10nReadyEvent` since the "localized" event it dispatches
+      is unused and may clash with an identically named event in the viewer.
 */
 
 /*jshint browser: true, devel: true, es5: true, globalstrict: true */
@@ -91,13 +94,6 @@ document.webL10n = (function(window, document, undefined) {
       }
     }
     return { id: l10nId, args: args };
-  }
-
-  function fireL10nReadyEvent(lang) {
-    var evtObject = document.createEvent('Event');
-    evtObject.initEvent('localized', true, false);
-    evtObject.language = lang;
-    document.dispatchEvent(evtObject);
   }
 
   function xhrLoadText(url, onSuccess, onFailure) {
@@ -326,7 +322,6 @@ document.webL10n = (function(window, document, undefined) {
         console.log('no resource to load, early way out');
       }
       // early way out
-      fireL10nReadyEvent(lang);
       gReadyState = 'complete';
       return;
     }
@@ -338,7 +333,6 @@ document.webL10n = (function(window, document, undefined) {
       gResourceCount++;
       if (gResourceCount >= langCount) {
         callback();
-        fireL10nReadyEvent(lang);
         gReadyState = 'complete';
       }
     };


### PR DESCRIPTION
Currently this leads to confusing behaviour with `eventBusDispatchToDOM = true` set, since then there's *two* different "localized" events being fired.