### PR TITLE
Fix the inconsistent return types for `Dict.{get, getAsync}`

### DIFF
--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -92,7 +92,7 @@ var Dict = (function DictClosure() {
           key2 in this._map || typeof key3 === 'undefined') {
         return xref ? xref.fetchIfRef(value, suppressEncryption) : value;
       }
-      value = this._map[key3] || null;
+      value = this._map[key3];
       return xref ? xref.fetchIfRef(value, suppressEncryption) : value;
     },
 
@@ -114,7 +114,7 @@ var Dict = (function DictClosure() {
         }
         return Promise.resolve(value);
       }
-      value = this._map[key3] || null;
+      value = this._map[key3];
       if (xref) {
         return xref.fetchIfRefAsync(value, suppressEncryption);
       }

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -67,9 +67,7 @@ describe('primitives', function() {
       expect(dict.get()).toBeUndefined();
       expect(dict.get('Prev')).toBeUndefined();
       expect(dict.get('Decode', 'D')).toBeUndefined();
-
-      // Note that the getter with three arguments breaks the pattern here.
-      expect(dict.get('FontFile', 'FontFile2', 'FontFile3')).toBeNull();
+      expect(dict.get('FontFile', 'FontFile2', 'FontFile3')).toBeUndefined();
     };
 
     var emptyDict, dictWithSizeKey, dictWithManyKeys;
@@ -145,7 +143,7 @@ describe('primitives', function() {
 
       Promise.all(keyPromises).then(function (values) {
         expect(values[0]).toBeUndefined();
-        expect(values[1]).toBeNull();
+        expect(values[1]).toBeUndefined();
         done();
       }).catch(function (reason) {
         done.fail(reason);


### PR DESCRIPTION
Having these methods fallback to returning `null` in only *one* particular case seems outright wrong, since a "falsy" value will thus be handled incorrectly.
The only reason that this hasn't caused issues in practice is that there's only one call-site passing in three keys, and in that case we're trying to read a font file where falling back to `null` isn't a problem.