### PR TITLE
Forbid sending of `Dict`s and `Stream`s, with `postMessage`, when workers are disabled

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1463,8 +1463,14 @@ class LoopbackPort {
         while (!(desc = Object.getOwnPropertyDescriptor(p, i))) {
           p = Object.getPrototypeOf(p);
         }
-        if (typeof desc.value === 'undefined' ||
-            typeof desc.value === 'function') {
+        if (typeof desc.value === 'undefined') {
+          continue;
+        }
+        if (typeof desc.value === 'function') {
+          if (value.hasOwnProperty && value.hasOwnProperty(i)) {
+            throw new Error(
+              `LoopbackPort.postMessage - cannot clone: ${value[i]}`);
+          }
           continue;
         }
         result[i] = cloneValue(desc.value);


### PR DESCRIPTION
By default, i.e. with workers enabled, it's *purposely* not possible to send `Dict`s and `Stream`s from the worker-thread. This is achieved by defining a `function` on every `Dict` instance, since that ensures that [the structured clone algoritm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) will throw an Error on `postMessage`.

However, with workers *disabled* we fall-back to the `LoopbackPort` implementation which just ignores any `function`s, thus incorrectly allowing sending of data which *should* be unclonable.