### PR TITLE
Convert the various `...Exception`s to proper classes, to reduce code duplication

### DIFF
--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -14,7 +14,7 @@
  */
 /* eslint no-var: error */
 
-import { assert, warn } from '../shared/util';
+import { assert, BaseException, warn } from '../shared/util';
 
 function getLookupTableFactory(initializer) {
   let lookup;
@@ -28,43 +28,17 @@ function getLookupTableFactory(initializer) {
   };
 }
 
-const MissingDataException = (function MissingDataExceptionClosure() {
-  function MissingDataException(begin, end) {
+class MissingDataException extends BaseException {
+  constructor(begin, end) {
+    super(`Missing data [${begin}, ${end})`);
     this.begin = begin;
     this.end = end;
-    this.message = `Missing data [${begin}, ${end})`;
   }
+}
 
-  MissingDataException.prototype = new Error();
-  MissingDataException.prototype.name = 'MissingDataException';
-  MissingDataException.constructor = MissingDataException;
+class XRefEntryException extends BaseException { }
 
-  return MissingDataException;
-})();
-
-const XRefEntryException = (function XRefEntryExceptionClosure() {
-  function XRefEntryException(msg) {
-    this.message = msg;
-  }
-
-  XRefEntryException.prototype = new Error();
-  XRefEntryException.prototype.name = 'XRefEntryException';
-  XRefEntryException.constructor = XRefEntryException;
-
-  return XRefEntryException;
-})();
-
-const XRefParseException = (function XRefParseExceptionClosure() {
-  function XRefParseException(msg) {
-    this.message = msg;
-  }
-
-  XRefParseException.prototype = new Error();
-  XRefParseException.prototype.name = 'XRefParseException';
-  XRefParseException.constructor = XRefParseException;
-
-  return XRefParseException;
-})();
+class XRefParseException extends BaseException { }
 
 /**
  * Get the value of an inheritable property.

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -15,8 +15,8 @@
 /* eslint no-var: error */
 
 import {
-  assert, CMapCompressionType, isString, removeNullCharacters, stringToBytes,
-  unreachable, Util, warn
+  assert, BaseException, CMapCompressionType, isString, removeNullCharacters,
+  stringToBytes, unreachable, Util, warn
 } from '../shared/util';
 
 const DEFAULT_LINK_REL = 'noopener noreferrer nofollow';
@@ -307,18 +307,12 @@ class PageViewport {
   }
 }
 
-const RenderingCancelledException = (function RenderingCancelledException() {
-  function RenderingCancelledException(msg, type) {
-    this.message = msg;
+class RenderingCancelledException extends BaseException {
+  constructor(msg, type) {
+    super(msg);
     this.type = type;
   }
-
-  RenderingCancelledException.prototype = new Error();
-  RenderingCancelledException.prototype.name = 'RenderingCancelledException';
-  RenderingCancelledException.constructor = RenderingCancelledException;
-
-  return RenderingCancelledException;
-})();
+}
 
 const LinkTarget = {
   NONE: 0, // Default value.

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -401,99 +401,54 @@ function shadow(obj, prop, value) {
   return value;
 }
 
-const PasswordException = (function PasswordExceptionClosure() {
-  function PasswordException(msg, code) {
-    this.name = 'PasswordException';
-    this.message = msg;
+const BaseException = (function BaseExceptionClosure() {
+  function BaseException(message) {
+    if (this.constructor === BaseException) {
+      unreachable('Cannot initialize BaseException.');
+    }
+    this.message = message;
+    this.name = this.constructor.name;
+  }
+  BaseException.prototype = new Error();
+  BaseException.constructor = BaseException;
+
+  return BaseException;
+})();
+
+class PasswordException extends BaseException {
+  constructor(msg, code) {
+    super(msg);
     this.code = code;
   }
+}
 
-  PasswordException.prototype = new Error();
-  PasswordException.constructor = PasswordException;
-
-  return PasswordException;
-})();
-
-const UnknownErrorException = (function UnknownErrorExceptionClosure() {
-  function UnknownErrorException(msg, details) {
-    this.name = 'UnknownErrorException';
-    this.message = msg;
+class UnknownErrorException extends BaseException {
+  constructor(msg, details) {
+    super(msg);
     this.details = details;
   }
+}
 
-  UnknownErrorException.prototype = new Error();
-  UnknownErrorException.constructor = UnknownErrorException;
+class InvalidPDFException extends BaseException { }
 
-  return UnknownErrorException;
-})();
+class MissingPDFException extends BaseException { }
 
-const InvalidPDFException = (function InvalidPDFExceptionClosure() {
-  function InvalidPDFException(msg) {
-    this.name = 'InvalidPDFException';
-    this.message = msg;
-  }
-
-  InvalidPDFException.prototype = new Error();
-  InvalidPDFException.constructor = InvalidPDFException;
-
-  return InvalidPDFException;
-})();
-
-const MissingPDFException = (function MissingPDFExceptionClosure() {
-  function MissingPDFException(msg) {
-    this.name = 'MissingPDFException';
-    this.message = msg;
-  }
-
-  MissingPDFException.prototype = new Error();
-  MissingPDFException.constructor = MissingPDFException;
-
-  return MissingPDFException;
-})();
-
-const UnexpectedResponseException =
-    (function UnexpectedResponseExceptionClosure() {
-  function UnexpectedResponseException(msg, status) {
-    this.name = 'UnexpectedResponseException';
-    this.message = msg;
+class UnexpectedResponseException extends BaseException {
+  constructor(msg, status) {
+    super(msg);
     this.status = status;
   }
-
-  UnexpectedResponseException.prototype = new Error();
-  UnexpectedResponseException.constructor = UnexpectedResponseException;
-
-  return UnexpectedResponseException;
-})();
+}
 
 /**
  * Error caused during parsing PDF data.
  */
-const FormatError = (function FormatErrorClosure() {
-  function FormatError(msg) {
-    this.message = msg;
-  }
-
-  FormatError.prototype = new Error();
-  FormatError.prototype.name = 'FormatError';
-  FormatError.constructor = FormatError;
-
-  return FormatError;
-})();
+class FormatError extends BaseException { }
 
 /**
  * Error used to indicate task cancellation.
  */
-const AbortException = (function AbortExceptionClosure() {
-  function AbortException(msg) {
-    this.name = 'AbortException';
-    this.message = msg;
-  }
-
-  AbortException.prototype = new Error();
-  AbortException.constructor = AbortException;
-
-  return AbortException;
-})();
+class AbortException extends BaseException { }
 
 const NullCharactersRegExp = /\x00/g;
 
@@ -915,6 +870,7 @@ const createObjectURL = (function createObjectURLClosure() {
 })();
 
 export {
+  BaseException,
   FONT_IDENTITY_MATRIX,
   IDENTITY_MATRIX,
   OPS,


### PR DESCRIPTION
By utilizing a base "class", things become significantly simpler. Unfortunately the new `BaseException` cannot be a proper ES6 class and just extend `Error`, since the SystemJS dependency doesn't seem to play well with that.
Note also that we (generally) need to keep the `name` property on the actual `...Exception` object, rather than on its prototype, since the property will otherwise be dropped during the structured cloning used with `postMessage`.