### PR TITLE
Convert the various image decoder `...Error`s to classes extending `BaseException` (PR 11185 follow-up)

### DIFF
--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -13,21 +13,17 @@
  * limitations under the License.
  */
 
-import { log2, readInt8, readUint16, readUint32, shadow } from '../shared/util';
+import {
+  BaseException, log2, readInt8, readUint16, readUint32, shadow
+} from '../shared/util';
 import { ArithmeticDecoder } from './arithmetic_decoder';
 import { CCITTFaxDecoder } from './ccitt';
 
-let Jbig2Error = (function Jbig2ErrorClosure() {
-  function Jbig2Error(msg) {
-    this.message = 'JBIG2 error: ' + msg;
+class Jbig2Error extends BaseException {
+  constructor(msg) {
+    super(`JBIG2 error: ${msg}`);
   }
-
-  Jbig2Error.prototype = new Error();
-  Jbig2Error.prototype.name = 'Jbig2Error';
-  Jbig2Error.constructor = Jbig2Error;
-
-  return Jbig2Error;
-})();
+}
 
 var Jbig2Image = (function Jbig2ImageClosure() {
   // Utility data structures

--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -14,44 +14,22 @@
  */
 /* eslint-disable no-multi-spaces */
 
-import { assert, warn } from '../shared/util';
+import { assert, BaseException, warn } from '../shared/util';
 
-let JpegError = (function JpegErrorClosure() {
-  function JpegError(msg) {
-    this.message = 'JPEG error: ' + msg;
+class JpegError extends BaseException {
+  constructor(msg) {
+    super(`JPEG error: ${msg}`);
   }
+}
 
-  JpegError.prototype = new Error();
-  JpegError.prototype.name = 'JpegError';
-  JpegError.constructor = JpegError;
-
-  return JpegError;
-})();
-
-let DNLMarkerError = (function DNLMarkerErrorClosure() {
-  function DNLMarkerError(message, scanLines) {
-    this.message = message;
+class DNLMarkerError extends BaseException {
+  constructor(message, scanLines) {
+    super(message);
     this.scanLines = scanLines;
   }
+}
 
-  DNLMarkerError.prototype = new Error();
-  DNLMarkerError.prototype.name = 'DNLMarkerError';
-  DNLMarkerError.constructor = DNLMarkerError;
-
-  return DNLMarkerError;
-})();
-
-let EOIMarkerError = (function EOIMarkerErrorClosure() {
-  function EOIMarkerError(message) {
-    this.message = message;
-  }
-
-  EOIMarkerError.prototype = new Error();
-  EOIMarkerError.prototype.name = 'EOIMarkerError';
-  EOIMarkerError.constructor = EOIMarkerError;
-
-  return EOIMarkerError;
-})();
+class EOIMarkerError extends BaseException { }
 
 /**
  * This code was forked from https://github.com/notmasteryet/jpgjs.

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -14,21 +14,15 @@
  */
 
 import {
-  info, log2, readUint16, readUint32, warn
+  BaseException, info, log2, readUint16, readUint32, warn
 } from '../shared/util';
 import { ArithmeticDecoder } from './arithmetic_decoder';
 
-let JpxError = (function JpxErrorClosure() {
-  function JpxError(msg) {
-    this.message = 'JPX error: ' + msg;
+class JpxError extends BaseException {
+  constructor(msg) {
+    super(`JPX error: ${msg}`);
   }
-
-  JpxError.prototype = new Error();
-  JpxError.prototype.name = 'JpxError';
-  JpxError.constructor = JpxError;
-
-  return JpxError;
-})();
+}
 
 var JpxImage = (function JpxImageClosure() {
   // Table E.1


### PR DESCRIPTION
Somehow I missed these in PR #11185, but there's no good reason not to convert them as well.