### PR TITLE
Delete the `@ignore` tag in the JSDoc comment for the `PDFObjects` class

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2433,7 +2433,6 @@ class WorkerTransport {
  * A PDF document and page is built of many objects. E.g. there are objects for
  * fonts, images, rendering code, etc. These objects may get processed inside of
  * a worker. This class implements some basic methods to manage these objects.
- * @ignore
  */
 class PDFObjects {
   constructor() {


### PR DESCRIPTION
delete `@ignore` for `class PDFObjects` in JSDoc. Related to #10575. Due to the `@ignore`, `PDFObjects` is not included in the `d.ts` file generated in that PR.

Since `PDFObjects` can be arguments of the constructor of `SVGGraphics`, it is not for internal use only, and `@ignore` is not appropriate.