### PR TITLE
Update `src/shared/compatibility.js` to only run with `SKIP_BABEL = false` set

### DIFF
--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -12,13 +12,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint no-var: error */
 
 const globalScope = require('./global_scope');
 
-// Skip compatibility checks for the extensions and if we already ran
-// this module.
-if ((typeof PDFJSDev === 'undefined' ||
-     !PDFJSDev.test('FIREFOX || MOZCENTRAL')) &&
+// Skip compatibility checks for modern builds and if we already ran the module.
+if ((typeof PDFJSDev === 'undefined' || !PDFJSDev.test('SKIP_BABEL')) &&
     !globalScope._pdfjsCompatibilityChecked) {
 
 globalScope._pdfjsCompatibilityChecked = true;


### PR DESCRIPTION
Rather than specifying certain build targets manually, it seems much more appropriate (and future-proof) to use the `SKIP_BABEL` build target instead.

Also, the patch adds a missing `/* eslint no-var: error */` line since I'm touch the file anyway and no code-changes were necessary for it.