### PR TITLE
Tweak the `isIOS` check, in `web/viewer_compatibility`, to attempt to support newer Safari versions (issue 11245)

### DIFF
--- a/web/viewer_compatibility.js
+++ b/web/viewer_compatibility.js
@@ -17,8 +17,14 @@ let compatibilityParams = Object.create(null);
 if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
   const userAgent =
     (typeof navigator !== 'undefined' && navigator.userAgent) || '';
+  const platform =
+    (typeof navigator !== 'undefined' && navigator.platform) || '';
+  const maxTouchPoints =
+    (typeof navigator !== 'undefined' && navigator.maxTouchPoints) || 1;
+
   const isAndroid = /Android/.test(userAgent);
-  const isIOS = /\b(iPad|iPhone|iPod)(?=;)/.test(userAgent);
+  const isIOS = /\b(iPad|iPhone|iPod)(?=;)/.test(userAgent) ||
+                (platform === 'MacIntel' && maxTouchPoints > 1);
 
   // Limit canvas size to 5 mega-pixels on mobile.
   // Support: Android, iOS


### PR DESCRIPTION
Obviously userAgent checks aren't that great, since it's very easy to spoof, but it probably doesn't hurt to attempt to extend this (since it's limited to `GENERIC` builds).
Besides, anyone using the default viewer can always set the `maxCanvasPixels` option to a value of their choosing.

Fixes #11245