### PR TITLE
Avoid handling keyboard shortcuts for `contentEditable` DOM elements (issue 7156)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2283,7 +2283,8 @@ function webViewerKeyDown(evt) {
   let curElementTagName = curElement && curElement.tagName.toUpperCase();
   if (curElementTagName === 'INPUT' ||
       curElementTagName === 'TEXTAREA' ||
-      curElementTagName === 'SELECT') {
+      curElementTagName === 'SELECT' ||
+      (curElement && curElement.isContentEditable)) {
     // Make sure that the secondary toolbar is closed when Escape is pressed.
     if (evt.keyCode !== 27) { // 'Esc'
       return;


### PR DESCRIPTION
The issue has been open for years now, and has even been marked with `5-good-beginner-bug` for *months*, without any movement.
Considering just how simple the suggested solution is, I'm submitting this patch just to close out a long-standing issue.

Fixes #7156