### PR TITLE
Re-factor sending of various Exceptions from the worker to the API

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -270,30 +270,29 @@ var WorkerMessageHandler = {
         handler.send('GetDoc', { pdfInfo: doc, });
       }
 
-      function onFailure(e) {
+      function onFailure(ex) {
         ensureNotTerminated();
 
-        if (e instanceof PasswordException) {
-          var task = new WorkerTask('PasswordException: response ' + e.code);
+        if (ex instanceof PasswordException) {
+          var task = new WorkerTask(`PasswordException: response ${ex.code}`);
           startWorkerTask(task);
 
-          handler.sendWithPromise('PasswordRequest', e).then(function (data) {
+          handler.sendWithPromise('PasswordRequest', ex).then(function(data) {
             finishWorkerTask(task);
             pdfManager.updatePassword(data.password);
             pdfManagerReady();
-          }).catch(function (boundException) {
+          }).catch(function() {
             finishWorkerTask(task);
-            handler.send('PasswordException', boundException);
-          }.bind(null, e));
-        } else if (e instanceof InvalidPDFException) {
-          handler.send('InvalidPDF', e);
-        } else if (e instanceof MissingPDFException) {
-          handler.send('MissingPDF', e);
-        } else if (e instanceof UnexpectedResponseException) {
-          handler.send('UnexpectedResponse', e);
+            handler.send('DocException', ex);
+          });
+        } else if (ex instanceof InvalidPDFException ||
+                   ex instanceof MissingPDFException ||
+                   ex instanceof UnexpectedResponseException ||
+                   ex instanceof UnknownErrorException) {
+          handler.send('DocException', ex);
         } else {
-          handler.send('UnknownError',
-                       new UnknownErrorException(e.message, e.toString()));
+          handler.send('DocException',
+                       new UnknownErrorException(ex.message, ex.toString()));
         }
       }
 


### PR DESCRIPTION
As can be seen in the API, there's a number of document loading Exception handlers which are both really simple and highly similar. Hence these are changed such that all the relevant Exceptions are sent via *one* message instead.

Furthermore, the patch also avoids unnecessarily re-creating `UnknownErrorException`s at the worker side and removes an unnecessary `bind` call.