### PR TITLE
Re-add the en-US `chrome.properties` l10n file, to avoid it being removed at mozilla-central (PR 11256 follow-up)

### DIFF
--- a/external/importL10n/locales.js
+++ b/external/importL10n/locales.js
@@ -22,6 +22,8 @@ var path = require('path');
 // Fetches all languages that have an *active* translation in mozilla-central.
 // This is used in gulpfile.js for the `importl10n` command.
 
+var DEFAULT_LOCALE = 'en-US';
+
 var EXCLUDE_LANG_CODES = ['ca-valencia', 'ja-JP-mac'];
 
 function normalizeText(s) {
@@ -105,7 +107,8 @@ async function downloadL10n(root, callback) {
   var langCodes = await downloadLanguageCodes();
 
   for (var langCode of langCodes) {
-    if (!langCode || EXCLUDE_LANG_CODES.includes(langCode)) {
+    if (!langCode || langCode === DEFAULT_LOCALE ||
+        EXCLUDE_LANG_CODES.includes(langCode)) {
       continue;
     }
     await downloadLanguageFiles(root, langCode);
@@ -115,7 +118,7 @@ async function downloadL10n(root, callback) {
   for (var entry of fs.readdirSync(root)) {
     var dirPath = path.join(root, entry), stat = fs.lstatSync(dirPath);
 
-    if (stat.isDirectory() && entry !== 'en-US' &&
+    if (stat.isDirectory() && entry !== DEFAULT_LOCALE &&
         (!langCodes.includes(entry) || EXCLUDE_LANG_CODES.includes(entry))) {
       removeCodes.push(entry);
     }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -837,7 +837,7 @@ function preprocessDefaultPreferences(content) {
 }
 
 gulp.task('mozcentral-pre', gulp.series('buildnumber', 'default_preferences',
-                                        'locale', function() {
+                                        function() {
   console.log();
   console.log('### Building mozilla-central extension');
   var defines = builder.merge(DEFINES, { MOZCENTRAL: true, SKIP_BABEL: true, });
@@ -872,7 +872,7 @@ gulp.task('mozcentral-pre', gulp.series('buildnumber', 'default_preferences',
         ]))
         .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'web')),
 
-    gulp.src('web/locale/en-US/*.properties')
+    gulp.src('l10n/en-US/*.properties')
         .pipe(gulp.dest(MOZCENTRAL_L10N_DIR)),
     gulp.src(FIREFOX_EXTENSION_DIR + 'README.mozilla')
         .pipe(replace(/\bPDFJSSCRIPT_VERSION\b/g, version))

--- a/l10n/en-US/chrome.properties
+++ b/l10n/en-US/chrome.properties
@@ -1,0 +1,19 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Chrome notification bar messages and buttons
+unsupported_feature=This PDF document might not be displayed correctly.
+unsupported_feature_forms=This PDF document contains forms. The filling of form fields is not supported.
+open_with_different_viewer=Open With Different Viewer
+open_with_different_viewer.accessKey=o


### PR DESCRIPTION
Unfortunately I forgot to test `gulp mozcentraldiff` with PR #11256, which is really bad since it will cause the en-US `chrome.properties` l10n file to be deleted at mozilla-central; sorry about breaking this!

In order to address this we'll have to re-add (only) the en-US `chrome.properties` l10n file, which is simple enough. Furthermore, since we're not doing any sort of build-specific parsing of the l10n files, we can just copy the en-US files as-is rather than having to run `gulp locale` during `gulp mozcentral`.