### PR TITLE
Attempt to reduce resource usage, by not eagerly fetching all pages, for long/large documents

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -454,7 +454,10 @@ class BaseViewer {
           this.findController.setDocument(pdfDocument); // Enable searching.
         }
 
-        if (pdfDocument.loadingParams['disableAutoFetch']) {
+        // In addition to 'disableAutoFetch' being set, also attempt to reduce
+        // resource usage when loading *very* long/large documents.
+        if (pdfDocument.loadingParams['disableAutoFetch'] ||
+            pagesCount > 7500) {
           // XXX: Printing is semi-broken with auto fetch disabled.
           pagesCapability.resolve();
           return;


### PR DESCRIPTION
For *very* long/large documents fetching all pages on load may cause quite bad performance, both memory and CPU wise. In order to at least slightly alleviate this, we can let the viewer treat these kind of documents[1] as if `disableAutoFetch` were set.

---
[1] One example of a really bad case is https://bugzilla.mozilla.org/show_bug.cgi?id=1588435, which this patch should at least help somewhat. In general, for these cases, we'd probably need to implement switching between `PDFViewer`/`PDFSinglePageViewer` (as already tracked on GitHub) and use the latter for these kind of long documents.