### PR TITLE
[api-minor] Support custom `offsetX`/`offsetY` values in `PDFPageProxy.getViewport` and `PageViewport.clone`

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -805,6 +805,10 @@ class PDFDocumentProxy {
  * @property {number} scale - The desired scale of the viewport.
  * @property {number} [rotation] - The desired rotation, in degrees, of
  *   the viewport. If omitted it defaults to the page rotation.
+ * @property {number} [offsetX] - The horizontal, i.e. x-axis, offset.
+ *   The default value is `0`.
+ * @property {number} [offsetY] - The vertical, i.e. y-axis, offset.
+ *   The default value is `0`.
  * @property {boolean} [dontFlip] - If true, the y-axis will not be
  *   flipped. The default value is `false`.
  */
@@ -958,7 +962,8 @@ class PDFPageProxy {
    * @returns {PageViewport} Contains 'width' and 'height' properties
    *   along with transforms required for rendering.
    */
-  getViewport({ scale, rotation = this.rotate, dontFlip = false, } = {}) {
+  getViewport({ scale, rotation = this.rotate,
+                offsetX = 0, offsetY = 0, dontFlip = false, } = {}) {
     if ((typeof PDFJSDev !== 'undefined' && PDFJSDev.test('GENERIC')) &&
         (arguments.length > 1 || typeof arguments[0] === 'number')) {
       throw new Error(
@@ -968,6 +973,8 @@ class PDFPageProxy {
       viewBox: this.view,
       scale,
       rotation,
+      offsetX,
+      offsetY,
       dontFlip,
     });
   }

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -174,6 +174,10 @@ class DOMSVGFactory {
  *   viewport. The default value is `this.scale`.
  * @property {number} [rotation] - The rotation, in degrees, overriding the one
  *   in the cloned viewport. The default value is `this.rotation`.
+ * @property {number} [offsetX] - The horizontal, i.e. x-axis, offset.
+ *   The default value is `this.offsetX`.
+ * @property {number} [offsetY] - The vertical, i.e. y-axis, offset.
+ *   The default value is `this.offsetY`.
  * @property {boolean} [dontFlip] - If true, the x-axis will not be flipped.
  *   The default value is `false`.
  */
@@ -254,14 +258,14 @@ class PageViewport {
    * @param {PageViewportCloneParameters} [params]
    * @returns {PageViewport} Cloned viewport.
    */
-  clone({ scale = this.scale, rotation = this.rotation,
-          dontFlip = false, } = {}) {
+  clone({ scale = this.scale, rotation = this.rotation, offsetX = this.offsetX,
+          offsetY = this.offsetY, dontFlip = false, } = {}) {
     return new PageViewport({
       viewBox: this.viewBox.slice(),
       scale,
       rotation,
-      offsetX: this.offsetX,
-      offsetY: this.offsetY,
+      offsetX,
+      offsetY,
       dontFlip,
     });
   }

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1100,6 +1100,11 @@ describe('api', function() {
       expect(viewport.width).toEqual(1262.835);
       expect(viewport.height).toEqual(892.92);
     });
+    it('gets viewport with "offsetX/offsetY" arguments', function () {
+      const viewport = page.getViewport({ scale: 1, rotation: 0,
+                                          offsetX: 100, offsetY: -100, });
+      expect(viewport.transform).toEqual([1, 0, 0, -1, 100, 741.89]);
+    });
     it('gets viewport respecting "dontFlip" argument', function () {
       const scale = 1, rotation = 0;
       let viewport = page.getViewport({ scale, rotation, });

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1101,8 +1101,7 @@ describe('api', function() {
       expect(viewport.height).toEqual(892.92);
     });
     it('gets viewport respecting "dontFlip" argument', function () {
-      const scale = 1;
-      const rotation = 135;
+      const scale = 1, rotation = 0;
       let viewport = page.getViewport({ scale, rotation, });
       let dontFlipViewport = page.getViewport({ scale, rotation,
                                                 dontFlip: true, });


### PR DESCRIPTION
There's no good reason, as far as I can tell, to not also support `offsetX`/`offsetY` in addition to e.g. `dontFlip`.

Fixes #11239.