### PR TITLE
Remove some unused `require` statements, used when loading fake workers, in non-`PRODUCTION` mode

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1569,16 +1569,9 @@ const PDFWorker = (function PDFWorkerClosure() {
         SystemJS.import('pdfjs/core/worker').then((worker) => {
           fakeWorkerFilesLoadedCapability.resolve(worker.WorkerMessageHandler);
         }).catch(fakeWorkerFilesLoadedCapability.reject);
-      } else if (typeof require === 'function') {
-        try {
-          const worker = require('../core/worker.js');
-          fakeWorkerFilesLoadedCapability.resolve(worker.WorkerMessageHandler);
-        } catch (ex) {
-          fakeWorkerFilesLoadedCapability.reject(ex);
-        }
       } else {
-        fakeWorkerFilesLoadedCapability.reject(new Error(
-          'SystemJS or CommonJS must be used to load fake worker.'));
+        fakeWorkerFilesLoadedCapability.reject(
+          new Error('SystemJS must be used to load fake worker.'));
       }
     } else {
       const loader = fakeWorkerFilesLoader || function() {

--- a/web/app.js
+++ b/web/app.js
@@ -1532,16 +1532,8 @@ function loadFakeWorker() {
           window.pdfjsWorker = worker;
           resolve();
         }).catch(reject);
-      } else if (typeof require === 'function') {
-        try {
-          window.pdfjsWorker = require('../src/core/worker.js');
-          resolve();
-        } catch (ex) {
-          reject(ex);
-        }
       } else {
-        reject(new Error(
-          'SystemJS or CommonJS must be used to load fake worker.'));
+        reject(new Error('SystemJS must be used to load fake worker.'));
       }
     });
   }

--- a/web/preferences.js
+++ b/web/preferences.js
@@ -23,15 +23,8 @@ function getDefaultPreferences() {
       defaultPreferences = new Promise(function(resolve, reject) {
         if (typeof SystemJS === 'object') {
           SystemJS.import('./app_options').then(resolve, reject);
-        } else if (typeof require === 'function') {
-          try {
-            resolve(require('./app_options.js'));
-          } catch (ex) {
-            reject(ex);
-          }
         } else {
-          reject(new Error(
-            'SystemJS or CommonJS must be used to load AppOptions.'));
+          reject(new Error('SystemJS must be used to load AppOptions.'));
         }
       }).then(function({ AppOptions, OptionKind, }) {
         return AppOptions.getAll(OptionKind.PREFERENCE);


### PR DESCRIPTION
The code in question is *only* relevant in non-`PRODUCTION` mode, i.e. the *development* version of the viewer run with `gulp server`, and has been completely unused at least since SystemJS was added.
I really cannot see any reason to keep this, since it's code which first of all isn't shipping and secondly isn't even being used in the development viewer.