### PR TITLE
Allow skipping of errors when parsing broken/unsupported ColorSpaces (issue 6707, issue 11287)

### DIFF
--- a/test/pdfs/issue11287.pdf.link
+++ b/test/pdfs/issue11287.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/3786520/FLEXSTEEL.PIPELINE.TECHNOLOGIES.INC.vs.FEDON.DARREN.LOUIS.201834640.No.80265332.Texas.State.Harris.County.113th.District.Court.Jun.7.2018.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2977,6 +2977,14 @@
        "link": false,
        "type": "eq"
     },
+    {  "id": "issue11287",
+       "file": "pdfs/issue11287.pdf",
+       "md5": "d7d6a7c124fad7b00f79112b71ee09d6",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue4890",
        "file": "pdfs/issue4890.pdf",
        "md5": "1666feb4cd26318c2bdbea6a175dce87",


### PR DESCRIPTION
This will allow us to attempt to recover as much as possible of a page, rather than immediately failing, when a broken/unsupported ColorSpace is encountered. This patch thus extends the framework added in PRs such as e.g. #8240 and #8922, to also cover parsing of ColorSpaces.

Fixes #6707
Fixes #11287