### PR TITLE
Publish event when find matches have finished rendering

### DIFF
--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -291,6 +291,11 @@ class TextLayerBuilder {
     if (prevEnd) {
       appendTextToDiv(prevEnd.divIdx, prevEnd.offset, infinity.offset);
     }
+
+    this.eventBus.dispatch('findmatchesrendered', {
+      source: this,
+      pageNumber: this.pageNumber,
+    });
   }
 
   _updateMatches() {


### PR DESCRIPTION
This might be a bit niche but would be very useful for an application I'm working on! 

When using the PDF search capability, it would be nice to have a way of knowing for definite when the viewer has finished jumping to the next match. Since the next match might be on a page which hasn't loaded yet, the creation of the element indicating the match is asynchronous.

My understanding is that `TextLayerBuilder` subscribes to the `updatetextlayermatches` event, which causes them to call `_renderMatches`, which in turn mutates the DOM in order to set the correct class on the span indicating the current match. 

This PR adds a `findmatchesrendered` event to the end of the `_renderMatches` function, which will be fired after all the element changes have happened. 

This allows for knowing exactly when the new current match element is present in the DOM. 