### PR TITLE
Ensure that the `peekByte` methods, on the various Streams, handles end of data correctly (PR 5286 follow-up)

### DIFF
--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -213,7 +213,9 @@ class ChunkedStream {
 
   peekByte() {
     const peekedByte = this.getByte();
-    this.pos--;
+    if (peekedByte !== -1) {
+      this.pos--;
+    }
     return peekedByte;
   }
 

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -86,7 +86,9 @@ var Stream = (function StreamClosure() {
     },
     peekByte: function Stream_peekByte() {
       var peekedByte = this.getByte();
-      this.pos--;
+      if (peekedByte !== -1) {
+        this.pos--;
+      }
       return peekedByte;
     },
     peekBytes(length, forceClamped = false) {
@@ -234,7 +236,9 @@ var DecodeStream = (function DecodeStreamClosure() {
     },
     peekByte: function DecodeStream_peekByte() {
       var peekedByte = this.getByte();
-      this.pos--;
+      if (peekedByte !== -1) {
+        this.pos--;
+      }
       return peekedByte;
     },
     peekBytes(length, forceClamped = false) {


### PR DESCRIPTION
When the end of data has already been reached for the various Streams, the `getByte` methods will return `-1` to signal that to the caller. Note however that the current position obviously won't be incremented in this case, meaning that the `peekByte` methods will in this case *incorrectly* decrement the position.

Thankfully the corresponding `peekBytes` shouldn't be affected by this bug, since they decrement the current position with the *actually* returned number of bytes.

I'm not aware of any bugs caused by this blatant oversight, but that doesn't mean this shouldn't be fixed :-)