### PR TITLE
Support UTF-16 little-endian strings in the `stringToPDFString` helper function (bug 1593902)

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -752,6 +752,12 @@ function stringToPDFString(str) {
       strBuf.push(String.fromCharCode(
         (str.charCodeAt(i) << 8) | str.charCodeAt(i + 1)));
     }
+  } else if (str[0] === '\xFF' && str[1] === '\xFE') {
+    // UTF16LE BOM
+    for (let i = 2; i < length; i += 2) {
+      strBuf.push(String.fromCharCode(
+        (str.charCodeAt(i + 1) << 8) | str.charCodeAt(i)));
+    }
   } else {
     for (let i = 0; i < length; ++i) {
       const code = PDFStringTranslateTable[str.charCodeAt(i)];

--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -179,8 +179,13 @@ describe('util', function() {
       expect(stringToPDFString(str)).toEqual('\u201Cstring\u201D');
     });
 
-    it('handles UTF-16BE strings', function() {
+    it('handles UTF-16 big-endian strings', function() {
       let str = '\xFE\xFF\x00\x73\x00\x74\x00\x72\x00\x69\x00\x6E\x00\x67';
+      expect(stringToPDFString(str)).toEqual('string');
+    });
+
+    it('handles UTF-16 little-endian strings', function() {
+      let str = '\xFF\xFE\x73\x00\x74\x00\x72\x00\x69\x00\x6E\x00\x67\x00';
       expect(stringToPDFString(str)).toEqual('string');
     });
 
@@ -192,6 +197,10 @@ describe('util', function() {
       // UTF-16BE
       let str2 = '\xFE\xFF';
       expect(stringToPDFString(str2)).toEqual('');
+
+      // UTF-16LE
+      let str3 = '\xFF\xFE';
+      expect(stringToPDFString(str3)).toEqual('');
     });
   });
 


### PR DESCRIPTION
The bug report seem to suggest that we don't support UTF-16 strings with a BOM (byte order mark), which we *actually* do as evident by both the code and a unit-test.
The issue at play here is rather that we previously only supported big-endian UTF-16 BOM, and the `Title` string in the PDF document is using a *little-endian* UTF-16 BOM instead.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1593902

*Edit:* The PDF spec only mentions *big* endian as supported (in addition to `PDFDocEncoding` of course), see https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#G6.1957385, hence this is actually a case where a PDF generator is (yet again) creating corrupt/invalid data.