### PR TITLE
Prevent browser exceptions from incorrectly triggering the `assert` in `PDFPageProxy._abortOperatorList` (PR 11069 follow-up)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1378,7 +1378,8 @@ class PDFPageProxy {
    * @private
    */
   _abortOperatorList({ intentState, reason, force = false, }) {
-    assert(reason instanceof Error,
+    assert(reason instanceof Error ||
+           (typeof reason === 'object' && reason !== null),
            'PDFPageProxy._abortOperatorList: Expected "reason" argument.');
 
     if (!intentState.streamReader) {


### PR DESCRIPTION
For certain canvas-related errors (and probably others), the browser rendering exceptions may be propagated "as-is" to the PDF.js code. In this case, the exceptions are of the somewhat cryptic `NS_ERROR_FAILURE` type.
Unfortunately these aren't actual `Error`s, which thus ends up unintentionally triggering the `assert` in `PDFPageProxy._abortOperatorList`; sorry about that!

To reproduce this problem, open https://github.com/mozilla/pdf.js/files/703007/PeakLoadGrowth_Redacted.xlsx.pdf#page=2 (from issue 7952) and zoom in a couple of times until rendering breaks and the fallback bar is displayed in Firefox.