### PR TITLE
Convert `globalScope` and `isNodeJS` to proper modules

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -21,7 +21,7 @@ import {
 } from '../shared/util';
 import { clearPrimitiveCaches, Ref } from './primitives';
 import { LocalPdfManager, NetworkPdfManager } from './pdf_manager';
-import isNodeJS from '../shared/is_node';
+import { isNodeJS } from '../shared/is_node';
 import { MessageHandler } from '../shared/message_handler';
 import { PDFWorkerStream } from './worker_stream';
 import { XRefParseException } from './core_utils';

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -581,7 +581,7 @@ function isMessagePort(maybePort) {
 }
 
 // Worker thread (and not node.js)?
-if (typeof window === 'undefined' && !isNodeJS() &&
+if (typeof window === 'undefined' && !isNodeJS &&
     typeof self !== 'undefined' && isMessagePort(self)) {
   WorkerMessageHandler.initializeFromPort(self);
 }

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -33,7 +33,7 @@ import {
 import { FontFaceObject, FontLoader } from './font_loader';
 import { apiCompatibilityParams } from './api_compatibility';
 import { CanvasGraphics } from './canvas';
-import globalScope from '../shared/global_scope';
+import { globalScope } from '../shared/global_scope';
 import { GlobalWorkerOptions } from './worker_options';
 import { MessageHandler } from '../shared/message_handler';
 import { Metadata } from './metadata';

--- a/src/display/api_compatibility.js
+++ b/src/display/api_compatibility.js
@@ -15,7 +15,7 @@
 
 let compatibilityParams = Object.create(null);
 if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
-  const isNodeJS = require('../shared/is_node');
+  const { isNodeJS, } = require('../shared/is_node');
 
   const userAgent =
     (typeof navigator !== 'undefined' && navigator.userAgent) || '';

--- a/src/display/api_compatibility.js
+++ b/src/display/api_compatibility.js
@@ -35,7 +35,7 @@ if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
   // Support: Node.js
   (function checkFontFaceAndImage() {
     // Node.js is missing native support for `@font-face` and `Image`.
-    if (isNodeJS()) {
+    if (isNodeJS) {
       compatibilityParams.disableFontFace = true;
       compatibilityParams.nativeImageDecoderSupport = 'none';
     }

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -20,7 +20,7 @@ import {
   TextRenderingMode, Util, warn
 } from '../shared/util';
 import { DOMSVGFactory } from './display_utils';
-import isNodeJS from '../shared/is_node';
+import { isNodeJS } from '../shared/is_node';
 
 let SVGGraphics = function() {
   throw new Error('Not implemented: SVGGraphics');

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -109,7 +109,7 @@ const convertImgDataToPng = (function() {
    *   http://www.libpng.org/pub/png/spec/1.2/PNG-Compression.html
    */
   function deflateSync(literals) {
-    if (!isNodeJS()) {
+    if (!isNodeJS) {
       // zlib is certainly not available outside of Node.js. We can either use
       // the pako library for client-side DEFLATE compression, or use the canvas
       // API of the browser to obtain a more optimal PNG file.

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -14,7 +14,7 @@
  */
 
 import { AbortException, createPromiseCapability, Util } from '../shared/util';
-import globalScope from '../shared/global_scope';
+import { globalScope } from '../shared/global_scope';
 
 /**
  * Text layer render parameters.

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -31,7 +31,7 @@ let pdfjsDisplayWorkerOptions = require('./display/worker_options.js');
 let pdfjsDisplayAPICompatibility = require('./display/api_compatibility.js');
 
 if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
-  const isNodeJS = require('./shared/is_node.js');
+  const { isNodeJS, } = require('./shared/is_node.js');
   if (isNodeJS()) {
     let PDFNodeStream = require('./display/node_stream.js').PDFNodeStream;
     pdfjsDisplayAPI.setPDFNetworkStreamFactory((params) => {

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -32,7 +32,7 @@ let pdfjsDisplayAPICompatibility = require('./display/api_compatibility.js');
 
 if (typeof PDFJSDev === 'undefined' || PDFJSDev.test('GENERIC')) {
   const { isNodeJS, } = require('./shared/is_node.js');
-  if (isNodeJS()) {
+  if (isNodeJS) {
     let PDFNodeStream = require('./display/node_stream.js').PDFNodeStream;
     pdfjsDisplayAPI.setPDFNetworkStreamFactory((params) => {
       return new PDFNodeStream(params);

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -14,7 +14,7 @@
  */
 /* eslint no-var: error */
 
-const globalScope = require('./global_scope');
+const { globalScope, } = require('./global_scope');
 
 // Skip compatibility checks for modern builds and if we already ran the module.
 if ((typeof PDFJSDev === 'undefined' || !PDFJSDev.test('SKIP_BABEL')) &&
@@ -22,7 +22,7 @@ if ((typeof PDFJSDev === 'undefined' || !PDFJSDev.test('SKIP_BABEL')) &&
 
 globalScope._pdfjsCompatibilityChecked = true;
 
-const isNodeJS = require('./is_node');
+const { isNodeJS, } = require('./is_node');
 
 const hasDOM = typeof window === 'object' && typeof document === 'object';
 

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -28,7 +28,7 @@ const hasDOM = typeof window === 'object' && typeof document === 'object';
 
 // Support: Node.js
 (function checkNodeBtoa() {
-  if (globalScope.btoa || !isNodeJS()) {
+  if (globalScope.btoa || !isNodeJS) {
     return;
   }
   globalScope.btoa = function(chars) {
@@ -39,7 +39,7 @@ const hasDOM = typeof window === 'object' && typeof document === 'object';
 
 // Support: Node.js
 (function checkNodeAtob() {
-  if (globalScope.atob || !isNodeJS()) {
+  if (globalScope.atob || !isNodeJS) {
     return;
   }
   globalScope.atob = function(input) {
@@ -69,7 +69,7 @@ const hasDOM = typeof window === 'object' && typeof document === 'object';
 // one parameter, in legacy browsers.
 // Support: IE
 (function checkDOMTokenListAddRemove() {
-  if (!hasDOM || isNodeJS()) {
+  if (!hasDOM || isNodeJS) {
     return;
   }
   const div = document.createElement('div');
@@ -98,7 +98,7 @@ const hasDOM = typeof window === 'object' && typeof document === 'object';
 // "force" parameter, in legacy browsers.
 // Support: IE
 (function checkDOMTokenListToggle() {
-  if (!hasDOM || isNodeJS()) {
+  if (!hasDOM || isNodeJS) {
     return;
   }
   const div = document.createElement('div');

--- a/src/shared/global_scope.js
+++ b/src/shared/global_scope.js
@@ -12,10 +12,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals module */
 
-module.exports =
+const globalScope =
   (typeof window !== 'undefined' && window.Math === Math) ? window :
   // eslint-disable-next-line no-undef
   (typeof global !== 'undefined' && global.Math === Math) ? global :
   (typeof self !== 'undefined' && self.Math === Math) ? self : {};
+
+export {
+  globalScope,
+};

--- a/src/shared/is_node.js
+++ b/src/shared/is_node.js
@@ -12,13 +12,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals module, process */
+/* globals process */
 
-module.exports = function isNodeJS() {
+function isNodeJS() {
   // NW.js / Electron is a browser context, but copies some Node.js objects; see
   // http://docs.nwjs.io/en/latest/For%20Users/Advanced/JavaScript%20Contexts%20in%20NW.js/#access-nodejs-and-nwjs-api-in-browser-context
   // https://electronjs.org/docs/api/process#processversionselectron
   return typeof process === 'object' &&
          process + '' === '[object process]' &&
          !process.versions['nw'] && !process.versions['electron'];
+}
+
+export {
+  isNodeJS,
 };

--- a/src/shared/is_node.js
+++ b/src/shared/is_node.js
@@ -14,14 +14,13 @@
  */
 /* globals process */
 
-function isNodeJS() {
-  // NW.js / Electron is a browser context, but copies some Node.js objects; see
-  // http://docs.nwjs.io/en/latest/For%20Users/Advanced/JavaScript%20Contexts%20in%20NW.js/#access-nodejs-and-nwjs-api-in-browser-context
-  // https://electronjs.org/docs/api/process#processversionselectron
-  return typeof process === 'object' &&
-         process + '' === '[object process]' &&
-         !process.versions['nw'] && !process.versions['electron'];
-}
+// NW.js / Electron is a browser context, but copies some Node.js objects; see
+// http://docs.nwjs.io/en/latest/For%20Users/Advanced/JavaScript%20Contexts%20in%20NW.js/#access-nodejs-and-nwjs-api-in-browser-context
+// https://electronjs.org/docs/api/process#processversionselectron
+const isNodeJS =
+  typeof process === 'object' &&
+  process + '' === '[object process]' &&
+  !process.versions['nw'] && !process.versions['electron'];
 
 export {
   isNodeJS,

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -40,7 +40,7 @@ describe('api', function() {
   let CanvasFactory;
 
   beforeAll(function(done) {
-    if (isNodeJS()) {
+    if (isNodeJS) {
       CanvasFactory = new NodeCanvasFactory();
     } else {
       CanvasFactory = new DOMCanvasFactory();
@@ -111,7 +111,7 @@ describe('api', function() {
     });
     it('creates pdf doc from typed array', function(done) {
       let typedArrayPdfPromise;
-      if (isNodeJS()) {
+      if (isNodeJS) {
         typedArrayPdfPromise = NodeFileReaderFactory.fetch({
           path: TEST_PDFS_PATH.node + basicApiFileName,
         });
@@ -296,7 +296,7 @@ describe('api', function() {
 
   describe('PDFWorker', function() {
     it('worker created or destroyed', function (done) {
-      if (isNodeJS()) {
+      if (isNodeJS) {
         pending('Worker is not supported in Node.js.');
       }
 
@@ -315,7 +315,7 @@ describe('api', function() {
       }).catch(done.fail);
     });
     it('worker created or destroyed by getDocument', function (done) {
-      if (isNodeJS()) {
+      if (isNodeJS) {
         pending('Worker is not supported in Node.js.');
       }
 
@@ -337,7 +337,7 @@ describe('api', function() {
       }).catch(done.fail);
     });
     it('worker created and can be used in getDocument', function (done) {
-      if (isNodeJS()) {
+      if (isNodeJS) {
         pending('Worker is not supported in Node.js.');
       }
 
@@ -364,7 +364,7 @@ describe('api', function() {
       }).catch(done.fail);
     });
     it('creates more than one worker', function (done) {
-      if (isNodeJS()) {
+      if (isNodeJS) {
         pending('Worker is not supported in Node.js.');
       }
 
@@ -384,7 +384,7 @@ describe('api', function() {
       }).catch(done.fail);
     });
     it('gets current workerSrc', function() {
-      if (isNodeJS()) {
+      if (isNodeJS) {
         pending('Worker is not supported in Node.js.');
       }
 
@@ -955,7 +955,7 @@ describe('api', function() {
     describe('Cross-origin', function() {
       var loadingTask;
       function _checkCanLoad(expectSuccess, filename, options) {
-        if (isNodeJS()) {
+        if (isNodeJS) {
           pending('Cannot simulate cross-origin requests in Node.js');
         }
         var params = buildGetDocumentParams(filename, options);
@@ -1551,7 +1551,7 @@ describe('api', function() {
 
     beforeAll(function(done) {
       const fileName = 'tracemonkey.pdf';
-      if (isNodeJS()) {
+      if (isNodeJS) {
         dataPromise = NodeFileReaderFactory.fetch({
           path: TEST_PDFS_PATH.node + fileName,
         });

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -29,7 +29,7 @@ import {
   getDocument, PDFDataRangeTransport, PDFDocumentProxy, PDFPageProxy, PDFWorker
 } from '../../src/display/api';
 import { GlobalWorkerOptions } from '../../src/display/worker_options';
-import isNodeJS from '../../src/shared/is_node';
+import { isNodeJS } from '../../src/shared/is_node';
 import { Metadata } from '../../src/display/metadata';
 
 describe('api', function() {

--- a/test/unit/clitests_helper.js
+++ b/test/unit/clitests_helper.js
@@ -19,7 +19,7 @@ import { PDFNodeStream } from '../../src/display/node_stream';
 import { setPDFNetworkStreamFactory } from '../../src/display/api';
 
 // Ensure that this script only runs in Node.js environments.
-if (!isNodeJS()) {
+if (!isNodeJS) {
   throw new Error('The `gulp unittestcli` command can only be used in ' +
                   'Node.js environments.');
 }

--- a/test/unit/clitests_helper.js
+++ b/test/unit/clitests_helper.js
@@ -14,7 +14,7 @@
  */
 
 import { setVerbosityLevel, VerbosityLevel } from '../../src/shared/util';
-import isNodeJS from '../../src/shared/is_node';
+import { isNodeJS } from '../../src/shared/is_node';
 import { PDFNodeStream } from '../../src/display/node_stream';
 import { setPDFNetworkStreamFactory } from '../../src/display/api';
 

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -32,7 +32,7 @@ describe('cmap', function() {
   beforeAll(function (done) {
     // Allow CMap testing in Node.js, e.g. for Travis.
     var CMapReaderFactory;
-    if (isNodeJS()) {
+    if (isNodeJS) {
       CMapReaderFactory = new NodeCMapReaderFactory({
         baseUrl: cMapUrl.node,
         isCompressed: cMapPacked,
@@ -265,7 +265,7 @@ describe('cmap', function() {
   it('attempts to load a built-in CMap without the necessary API parameters',
       function(done) {
     function tmpFetchBuiltInCMap(name) {
-      var CMapReaderFactory = isNodeJS() ?
+      var CMapReaderFactory = isNodeJS ?
         new NodeCMapReaderFactory({ }) : new DOMCMapReaderFactory({ });
       return CMapReaderFactory.fetch({
         name,
@@ -292,7 +292,7 @@ describe('cmap', function() {
       function(done) {
     function tmpFetchBuiltInCMap(name) {
       let CMapReaderFactory;
-      if (isNodeJS()) {
+      if (isNodeJS) {
         CMapReaderFactory = new NodeCMapReaderFactory({
           baseUrl: cMapUrl.node,
           isCompressed: false,

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -15,7 +15,7 @@
 
 import { CMap, CMapFactory, IdentityCMap } from '../../src/core/cmap';
 import { DOMCMapReaderFactory } from '../../src/display/display_utils';
-import isNodeJS from '../../src/shared/is_node';
+import { isNodeJS } from '../../src/shared/is_node';
 import { Name } from '../../src/core/primitives';
 import { NodeCMapReaderFactory } from './test_utils';
 import { StringStream } from '../../src/core/stream';

--- a/test/unit/custom_spec.js
+++ b/test/unit/custom_spec.js
@@ -16,7 +16,7 @@
 import { buildGetDocumentParams, NodeCanvasFactory } from './test_utils';
 import { DOMCanvasFactory } from '../../src/display/display_utils';
 import { getDocument } from '../../src/display/api';
-import isNodeJS from '../../src/shared/is_node';
+import { isNodeJS } from '../../src/shared/is_node';
 
 function getTopLeftPixel(canvasContext) {
   let imgData = canvasContext.getImageData(0, 0, 1, 1);

--- a/test/unit/custom_spec.js
+++ b/test/unit/custom_spec.js
@@ -36,7 +36,7 @@ describe('custom canvas rendering', function() {
   let page;
 
   beforeAll(function(done) {
-    if (isNodeJS()) {
+    if (isNodeJS) {
       CanvasFactory = new NodeCanvasFactory();
     } else {
       CanvasFactory = new DOMCanvasFactory();

--- a/test/unit/display_svg_spec.js
+++ b/test/unit/display_svg_spec.js
@@ -30,14 +30,14 @@ function withZlib(isZlibRequired, callback) {
   if (isZlibRequired) {
     // We could try to polyfill zlib in the browser, e.g. using pako.
     // For now, only support zlib functionality on Node.js
-    if (!isNodeJS()) {
+    if (!isNodeJS) {
       throw new Error('zlib test can only be run in Node.js');
     }
 
     return callback();
   }
 
-  if (!isNodeJS()) {
+  if (!isNodeJS) {
     // Assume that require('zlib') is unavailable in non-Node.
     return callback();
   }
@@ -94,14 +94,14 @@ describe('SVGGraphics', function () {
 
         // This points to the XObject image in xobject-image.pdf.
         var xobjectObjId = 'img_p0_1';
-        if (isNodeJS()) {
+        if (isNodeJS) {
           setStubs(global);
         }
         try {
           var imgData = svgGfx.objs.get(xobjectObjId);
           svgGfx.paintInlineImageXObject(imgData, elementContainer);
         } finally {
-          if (isNodeJS()) {
+          if (isNodeJS) {
             unsetStubs(global);
           }
         }
@@ -116,7 +116,7 @@ describe('SVGGraphics', function () {
       // Verifies that the script loader replaces __non_webpack_require__ with
       // require.
       expect(testFunc.toString()).toMatch(/\srequire\(["']zlib["']\)/);
-      if (isNodeJS()) {
+      if (isNodeJS) {
         expect(testFunc).not.toThrow();
       } else {
         // require not defined, require('zlib') not a module, etc.
@@ -125,7 +125,7 @@ describe('SVGGraphics', function () {
     });
 
     it('should produce a reasonably small svg:image', function(done) {
-      if (!isNodeJS()) {
+      if (!isNodeJS) {
         pending('zlib.deflateSync is not supported in non-Node environments.');
       }
       withZlib(true, getSVGImage).then(function(svgImg) {

--- a/test/unit/display_svg_spec.js
+++ b/test/unit/display_svg_spec.js
@@ -17,7 +17,7 @@
 import { setStubs, unsetStubs } from '../../examples/node/domstubs';
 import { buildGetDocumentParams } from './test_utils';
 import { getDocument } from '../../src/display/api';
-import isNodeJS from '../../src/shared/is_node';
+import { isNodeJS } from '../../src/shared/is_node';
 import { NativeImageDecoding } from '../../src/shared/util';
 import { SVGGraphics } from '../../src/display/svg';
 

--- a/test/unit/display_utils_spec.js
+++ b/test/unit/display_utils_spec.js
@@ -48,7 +48,7 @@ describe('display_utils', function() {
 
     it('`create` should return a canvas if the dimensions are valid',
         function() {
-      if (isNodeJS()) {
+      if (isNodeJS) {
         pending('Document is not supported in Node.js.');
       }
 
@@ -84,7 +84,7 @@ describe('display_utils', function() {
 
     it('`reset` should alter the canvas/context if the dimensions are valid',
         function() {
-      if (isNodeJS()) {
+      if (isNodeJS) {
         pending('Document is not supported in Node.js.');
       }
 
@@ -105,7 +105,7 @@ describe('display_utils', function() {
     });
 
     it('`destroy` should clear the canvas/context', function() {
-      if (isNodeJS()) {
+      if (isNodeJS) {
         pending('Document is not supported in Node.js.');
       }
 
@@ -145,7 +145,7 @@ describe('display_utils', function() {
 
     it('`create` should return an SVG element if the dimensions are valid',
         function() {
-      if (isNodeJS()) {
+      if (isNodeJS) {
         pending('Document is not supported in Node.js.');
       }
 
@@ -167,7 +167,7 @@ describe('display_utils', function() {
 
     it('`createElement` should return an SVG element if the type is valid',
         function() {
-      if (isNodeJS()) {
+      if (isNodeJS) {
         pending('Document is not supported in Node.js.');
       }
 

--- a/test/unit/display_utils_spec.js
+++ b/test/unit/display_utils_spec.js
@@ -18,7 +18,7 @@ import {
   DOMCanvasFactory, DOMSVGFactory, getFilenameFromUrl, isValidFetchUrl,
   PDFDateString
 } from '../../src/display/display_utils';
-import isNodeJS from '../../src/shared/is_node';
+import { isNodeJS } from '../../src/shared/is_node';
 
 describe('display_utils', function() {
   describe('DOMCanvasFactory', function() {

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -87,7 +87,7 @@ function initializePDFJS(callback) {
     const { PDFFetchStream, } = modules[3];
     const { isNodeJS, } = modules[4];
 
-    if (isNodeJS()) {
+    if (isNodeJS) {
       throw new Error('The `gulp unittest` command cannot be used in ' +
                       'Node.js environments.');
     }

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -81,11 +81,11 @@ function initializePDFJS(callback) {
   ].map(function (moduleName) {
     return SystemJS.import(moduleName);
   })).then(function(modules) {
-    var displayApi = modules[0];
-    const GlobalWorkerOptions = modules[1].GlobalWorkerOptions;
-    var PDFNetworkStream = modules[2].PDFNetworkStream;
-    var PDFFetchStream = modules[3].PDFFetchStream;
-    const isNodeJS = modules[4];
+    const displayApi = modules[0];
+    const { GlobalWorkerOptions, } = modules[1];
+    const { PDFNetworkStream, } = modules[2];
+    const { PDFFetchStream, } = modules[3];
+    const { isNodeJS, } = modules[4];
 
     if (isNodeJS()) {
       throw new Error('The `gulp unittest` command cannot be used in ' +

--- a/test/unit/node_stream_spec.js
+++ b/test/unit/node_stream_spec.js
@@ -19,7 +19,7 @@ import { isNodeJS } from '../../src/shared/is_node';
 import { PDFNodeStream } from '../../src/display/node_stream';
 
 // Make sure that we only running this script is Node.js environments.
-assert(isNodeJS());
+assert(isNodeJS);
 
 let path = __non_webpack_require__('path');
 let url = __non_webpack_require__('url');

--- a/test/unit/node_stream_spec.js
+++ b/test/unit/node_stream_spec.js
@@ -15,7 +15,7 @@
 /* globals __non_webpack_require__ */
 
 import { AbortException, assert } from '../../src/shared/util';
-import isNodeJS from '../../src/shared/is_node';
+import { isNodeJS } from '../../src/shared/is_node';
 import { PDFNodeStream } from '../../src/display/node_stream';
 
 // Make sure that we only running this script is Node.js environments.

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -14,7 +14,7 @@
  */
 
 import { assert, CMapCompressionType } from '../../src/shared/util';
-import isNodeJS from '../../src/shared/is_node';
+import { isNodeJS } from '../../src/shared/is_node';
 import { isRef } from '../../src/core/primitives';
 import { Page } from '../../src/core/document';
 

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -51,7 +51,7 @@ const TEST_PDFS_PATH = {
 
 function buildGetDocumentParams(filename, options) {
   let params = Object.create(null);
-  if (isNodeJS()) {
+  if (isNodeJS) {
     params.url = TEST_PDFS_PATH.node + filename;
   } else {
     params.url = new URL(TEST_PDFS_PATH.dom + filename, window.location).href;

--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -156,7 +156,7 @@ describe('ui_utils', function() {
 
     it('gets PDF filename from query string appended to "blob:" URL',
         function() {
-      if (isNodeJS()) {
+      if (isNodeJS) {
         pending('Blob in not supported in Node.js.');
       }
       var typedArray = new Uint8Array([1, 2, 3, 4, 5]);
@@ -283,7 +283,7 @@ describe('ui_utils', function() {
     });
 
     it('should not, by default, re-dispatch to DOM', function(done) {
-      if (isNodeJS()) {
+      if (isNodeJS) {
         pending('Document in not supported in Node.js.');
       }
       const eventBus = new EventBus();
@@ -307,7 +307,7 @@ describe('ui_utils', function() {
       });
     });
     it('should re-dispatch to DOM', function(done) {
-      if (isNodeJS()) {
+      if (isNodeJS) {
         pending('Document in not supported in Node.js.');
       }
       const eventBus = new EventBus({ dispatchToDOM: true, });
@@ -333,7 +333,7 @@ describe('ui_utils', function() {
     });
     it('should re-dispatch to DOM, with arguments (without internal listeners)',
         function(done) {
-      if (isNodeJS()) {
+      if (isNodeJS) {
         pending('Document in not supported in Node.js.');
       }
       const eventBus = new EventBus({ dispatchToDOM: true, });
@@ -447,7 +447,7 @@ describe('ui_utils', function() {
     });
 
     it('should resolve on event, using the DOM', function(done) {
-      if (isNodeJS()) {
+      if (isNodeJS) {
         pending('Document in not supported in Node.js.');
       }
       let button = document.createElement('button');
@@ -467,7 +467,7 @@ describe('ui_utils', function() {
     });
 
     it('should resolve on timeout, using the DOM', function(done) {
-      if (isNodeJS()) {
+      if (isNodeJS) {
         pending('Document in not supported in Node.js.');
       }
       let button = document.createElement('button');

--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -20,7 +20,7 @@ import {
   waitOnEventOrTimeout, WaitOnType
 } from '../../web/ui_utils';
 import { createObjectURL } from '../../src/shared/util';
-import isNodeJS from '../../src/shared/is_node';
+import { isNodeJS } from '../../src/shared/is_node';
 
 describe('ui_utils', function() {
   describe('binary search', function() {

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals chrome */
 
 'use strict';
 
@@ -30,6 +29,7 @@ if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('CHROME')) {
     let humanReadableUrl = '/' + defaultUrl + location.hash;
     history.replaceState(history.state, '', humanReadableUrl);
     if (top === window) {
+      // eslint-disable-next-line no-undef
       chrome.runtime.sendMessage('showPageAction');
     }
   })();


### PR DESCRIPTION
Slightly unrelated to the rest of the patch, but this also removes an out-of-place `globals` definition from the `web/viewer.js` file.