### PR TITLE
[PDFHistory] Move the IE11 `pushState`/`replaceState` work-around to `src/shared/compatibility.js` (PR 10461 follow-up)

### DIFF
--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -25,6 +25,9 @@ globalScope._pdfjsCompatibilityChecked = true;
 const { isNodeJS, } = require('./is_node');
 
 const hasDOM = typeof window === 'object' && typeof document === 'object';
+const userAgent =
+  (typeof navigator !== 'undefined' && navigator.userAgent) || '';
+const isIE = /Trident/.test(userAgent);
 
 // Support: Node.js
 (function checkNodeBtoa() {
@@ -109,6 +112,26 @@ const hasDOM = typeof window === 'object' && typeof document === 'object';
   DOMTokenList.prototype.toggle = function(token) {
     let force = (arguments.length > 1 ? !!arguments[1] : !this.contains(token));
     return (this[force ? 'add' : 'remove'](token), force);
+  };
+})();
+
+// Provides support for window.history.{pushState, replaceState}, with the
+// `url` parameter set to `undefined`, without breaking the document URL.
+// Support: IE
+(function checkWindowHistoryPushStateReplaceState() {
+  if (!hasDOM || !isIE) {
+    return;
+  }
+  const OriginalPushState = window.history.pushState;
+  const OriginalReplaceState = window.history.replaceState;
+
+  window.history.pushState = function(state, title, url) {
+    const args = (url === undefined ? [state, title] : [state, title, url]);
+    OriginalPushState.apply(this, args);
+  };
+  window.history.replaceState = function(state, title, url) {
+    const args = (url === undefined ? [state, title] : [state, title, url]);
+    OriginalReplaceState.apply(this, args);
   };
 })();
 

--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -306,18 +306,10 @@ class PDFHistory {
       }
     }
     if (shouldReplace) {
-      if (newUrl) {
-        window.history.replaceState(newState, '', newUrl);
-      } else {
-        window.history.replaceState(newState, '');
-      }
+      window.history.replaceState(newState, '', newUrl);
     } else {
       this._maxUid = this._uid;
-      if (newUrl) {
-        window.history.pushState(newState, '', newUrl);
-      } else {
-        window.history.pushState(newState, '');
-      }
+      window.history.pushState(newState, '', newUrl);
     }
 
     if (typeof PDFJSDev !== 'undefined' && PDFJSDev.test('CHROME') &&


### PR DESCRIPTION
I've always disliked the solution in PR #10461, since it required changes to the `PDFHistory` code itself to deal with a bug in IE11.
Now that IE11 support is limited, it seems reasonable to remove these `pushState`/`replaceState` hacks from the main code-base and simply use polyfills instead.