### PR TITLE
Use `getBytes`, rather than looping over `getByte`, in `FlateStream.prototype.readBlock`

### DIFF
--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -580,21 +580,19 @@ var FlateStream = (function FlateStreamClosure() {
       this.codeBuf = 0;
       this.codeSize = 0;
 
-      var bufferLength = this.bufferLength;
-      buffer = this.ensureBuffer(bufferLength + blockLen);
-      var end = bufferLength + blockLen;
+      const bufferLength = this.bufferLength, end = bufferLength + blockLen;
+      buffer = this.ensureBuffer(end);
       this.bufferLength = end;
+
       if (blockLen === 0) {
         if (str.peekByte() === -1) {
           this.eof = true;
         }
       } else {
-        for (var n = bufferLength; n < end; ++n) {
-          if ((b = str.getByte()) === -1) {
-            this.eof = true;
-            break;
-          }
-          buffer[n] = b;
+        const block = str.getBytes(blockLen);
+        buffer.set(block, bufferLength);
+        if (block.length < blockLen) {
+          this.eof = true;
         }
       }
       return;


### PR DESCRIPTION
*Please note:* A a similar change was attempted in PR #5005, but it was subsequently backed out (in PR #5069) since other parts of the patch caused issues.

With these changes, it's possible to replace repeated function calls within a loop with just a single function call and subsequent assignment instead.