### PR TITLE
Subtract `stream.start` when getting the `startXRef` property for documents with a Linearization dictionary (issue 11330)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -453,7 +453,7 @@ class PDFDocument {
       // Find the end of the first object.
       stream.reset();
       if (find(stream, 'endobj', 1024)) {
-        startXRef = stream.pos + 6;
+        startXRef = (stream.pos + 6) - stream.start;
       }
     } else {
       // Find `startxref` by checking backwards from the end of the file.

--- a/test/pdfs/issue11330.pdf.link
+++ b/test/pdfs/issue11330.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/3844109/9069_10755570.1.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2992,6 +2992,14 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue11330",
+       "file": "pdfs/issue11330.pdf",
+       "md5": "03a8a53d4b0dc825e08554f5c0178308",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue4890",
        "file": "pdfs/issue4890.pdf",
        "md5": "1666feb4cd26318c2bdbea6a175dce87",


### PR DESCRIPTION
For documents with a Linearization dictionary the computed `startXRef` position will be relative to the raw file, rather than the actual PDF document itself (which begins with `%PDF-`).
Hence it's necessary to subtract `stream.start` in this case, since otherwise the `XRef.readXRef` method will increment the position too far resulting in parsing errors.

Fixes #11330