### PR TITLE
Ensure that attempting to print with `disableAutoFetch` set will fail gracefully (issue 11339)

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -181,7 +181,14 @@ class BaseViewer {
    * @type {boolean} - True if all {PDFPageView} objects are initialized.
    */
   get pageViewsReady() {
-    return this._pageViewsReady;
+    if (!this._pageViewsReady) {
+      return false;
+    }
+    // Prevent printing errors when 'disableAutoFetch' is set, by ensuring
+    // that *all* pages have in fact been completely loaded.
+    return this._pages.every(function(pageView) {
+      return !!(pageView && pageView.pdfPage);
+    });
   }
 
   /**


### PR DESCRIPTION
This patch simply restores the behaviour that existed prior to PR #7697, see [this code in particular](https://github.com/mozilla/pdf.js/pull/7697/files#diff-529d1853ee1bba753a0fcb40ea778723L1114-L1118), since I cannot imagine that that was changed other than by pure accident.
As mentioned by a comment in `BaseViewer.setDocument`: "Printing is semi-broken with auto fetch disabled.", and note that since triggering of printing is a *synchronous* operation there's generally no easy way to load the missing data.

Fixes #11339