### PR TITLE
Remove outdated, and misleading, JSDoc comment from the `PDFDocument` class

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -362,10 +362,7 @@ function find(stream, needle, limit, backwards = false) {
 }
 
 /**
- * The `PDFDocument` class holds all the data of the PDF file. There exists
- * one `PDFDocument` object on the main thread and one object for each worker.
- * If no worker support is enabled, two `PDFDocument` objects are created on
- * the main thread.
+ * The `PDFDocument` class holds all the (worker-thread) data of the PDF file.
  */
 class PDFDocument {
   constructor(pdfManager, arg) {


### PR DESCRIPTION
The contents of this comment hasn't been correct for *years*, ever since the library was properly split into main/worker-threads, so it's probably high time for this to be updated.