### PR TITLE
Remove the `Number.isInteger` checks from `XRef.fetchUncompressed` (PR 8857 follow-up)

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -1682,12 +1682,6 @@ var XRef = (function XRefClosure() {
       var obj2 = parser.getObj();
       var obj3 = parser.getObj();
 
-      if (!Number.isInteger(obj1)) {
-        obj1 = parseInt(obj1, 10);
-      }
-      if (!Number.isInteger(obj2)) {
-        obj2 = parseInt(obj2, 10);
-      }
       if (obj1 !== num || obj2 !== gen || !(obj3 instanceof Cmd)) {
         throw new XRefEntryException(`Bad (uncompressed) XRef entry: ${ref}`);
       }


### PR DESCRIPTION
Having ran the entire test-suite locally with these `Number.isInteger` checks removed, there wasn't a single test failure anywhere; see also PR #8857.
Hence everything points to this being completely unnecessary now, however I'm still slightly worried about inadvertently breaking something with a simple code removal. Hence these checks are moved, and a warning is printed, such that they only occur when the there was a type mismatch; hence there's fewer function calls in the normal case.

*Edit:* Smaller and simpler diff with https://github.com/mozilla/pdf.js/pull/11363/files?w=1