### PR TITLE
Fix an incorrect condition in `BaseViewer.isPageVisible` (PR 10217 follow-up)

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -935,7 +935,7 @@ class BaseViewer {
     if (!this.pdfDocument) {
       return false;
     }
-    if (this.pageNumber < 1 || pageNumber > this.pagesCount) {
+    if (pageNumber < 1 || pageNumber > this.pagesCount) {
       console.error(
         `${this._name}.isPageVisible: "${pageNumber}" is out of bounds.`);
       return false;


### PR DESCRIPTION
This was a blatant oversight in PR #10217, since there's obviously no `this.pageNumber` property anywhere in the `BaseViewer`. Luckily this shouldn't have caused any bugs, since the only call-site is also validating the `pageNumber` (but correctly that time).