### PR TITLE
Handle corrupt ASCII85Decode inline images with truncated EOD markers (issue 11385)

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -344,6 +344,8 @@ class Parser {
     let startPos = stream.pos, ch, length;
     while ((ch = stream.getByte()) !== -1) {
       if (ch === TILDE) {
+        const tildePos = stream.pos;
+
         ch = stream.peekByte();
         // Handle corrupt PDF documents which contains whitespace "inside" of
         // the EOD marker (fixes issue10614.pdf).
@@ -354,6 +356,14 @@ class Parser {
         if (ch === GT) {
           stream.skip();
           break;
+        }
+        // Handle corrupt PDF documents which contains truncated EOD markers,
+        // where the '>' character is missing (fixes issue11385.pdf).
+        if (stream.pos > tildePos) {
+          const maybeEI = stream.peekBytes(2);
+          if (maybeEI[0] === /* E = */ 0x45 && maybeEI[1] === /* I = */ 0x49) {
+            break;
+          }
         }
       }
     }

--- a/test/pdfs/issue11385.pdf.link
+++ b/test/pdfs/issue11385.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/3926686/problematic.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1595,6 +1595,14 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue11385",
+       "file": "pdfs/issue11385.pdf",
+       "md5": "cc04b23b845366857426a5aa6acf227b",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue6071",
        "file": "pdfs/issue6071.pdf",
        "md5": "2e08526d8e7c9ba4269fc12ef488d3eb",


### PR DESCRIPTION
In the PDF document in question, there's an ASCII85Decode inline image where the '>' part of EOD (end-of-data) marker is missing; hence the PDF document is corrupt.

Fixes #11385