### PR TITLE
Ensure that `PDFDocument.checkFirstPage` waits for cleanup to complete (PR 10392 follow-up)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -664,13 +664,13 @@ class PDFDocument {
   }
 
   checkFirstPage() {
-    return this.getPage(0).catch((reason) => {
+    return this.getPage(0).catch(async (reason) => {
       if (reason instanceof XRefEntryException) {
         // Clear out the various caches to ensure that we haven't stored any
         // inconsistent and/or incorrect state, since that could easily break
         // subsequent `this.getPage` calls.
         this._pagePromises.length = 0;
-        this.cleanup();
+        await this.cleanup();
 
         throw new XRefParseException();
       }

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -671,9 +671,8 @@ class Catalog {
     });
 
     return Promise.all(promises).then((translatedFonts) => {
-      for (let i = 0, ii = translatedFonts.length; i < ii; i++) {
-        const font = translatedFonts[i].dict;
-        delete font.translated;
+      for (const { dict, } of translatedFonts) {
+        delete dict.translated;
       }
       this.fontCache.clear();
       this.builtInCMapCache.clear();


### PR DESCRIPTION
Given how this method is currently used there shouldn't be any fonts loaded at the point in time where it's called, but it does seem like a bad idea to assume that that's always going to be the case. Since `PDFDocument.checkFirstPage` is already asynchronous, it's easy enough to simply await `Catalog.cleanup` here.

(The patch also makes a tiny simplification in a loop in `Catalog.cleanup`.)