### PR TITLE
Attempt to improve the `PDFDocument` error message for empty files (issue 5887)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -15,9 +15,9 @@
 /* eslint no-var: error */
 
 import {
-  assert, bytesToString, FormatError, info, isArrayBuffer, isArrayEqual, isBool,
-  isNum, isSpace, isString, OPS, shadow, stringToBytes, stringToPDFString, Util,
-  warn
+  assert, bytesToString, FormatError, info, InvalidPDFException, isArrayBuffer,
+  isArrayEqual, isBool, isNum, isSpace, isString, OPS, shadow, stringToBytes,
+  stringToPDFString, Util, warn
 } from '../shared/util';
 import { Catalog, ObjectLoader, XRef } from './obj';
 import { Dict, isDict, isName, isStream, Ref } from './primitives';
@@ -375,7 +375,8 @@ class PDFDocument {
       throw new Error('PDFDocument: Unknown argument type');
     }
     if (stream.length <= 0) {
-      throw new Error('PDFDocument: Stream must have data');
+      throw new InvalidPDFException(
+        'The PDF file is empty, i.e. its size is zero bytes.');
     }
 
     this.pdfManager = pdfManager;

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -1519,7 +1519,7 @@ var XRef = (function XRefClosure() {
         return trailerDict;
       }
       // nothing helps
-      throw new InvalidPDFException('Invalid PDF structure');
+      throw new InvalidPDFException('Invalid PDF structure.');
     },
 
     readXRef: function XRef_readXRef(recoveryMode) {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -148,8 +148,10 @@ describe('api', function() {
       var loadingTask = getDocument(buildGetDocumentParams('bug1020226.pdf'));
       loadingTask.promise.then(function () {
         done.fail('shall fail loading');
-      }).catch(function (error) {
-        expect(error instanceof InvalidPDFException).toEqual(true);
+      }).catch(function(reason) {
+        expect(reason instanceof InvalidPDFException).toEqual(true);
+        expect(reason.message).toEqual('Invalid PDF structure.');
+
         loadingTask.destroy().then(done);
       });
     });
@@ -291,6 +293,20 @@ describe('api', function() {
       Promise.all([result1, result2]).then(function () {
         done();
       }).catch(done.fail);
+    });
+
+    it('creates pdf doc from empty typed array', function(done) {
+      const loadingTask = getDocument(new Uint8Array(0));
+
+      loadingTask.promise.then(function() {
+        done.fail('shall not open empty file');
+      }, function(reason) {
+        expect(reason instanceof InvalidPDFException);
+        expect(reason.message).toEqual(
+          'The PDF file is empty, i.e. its size is zero bytes.');
+
+        loadingTask.destroy().then(done);
+      });
     });
   });
 


### PR DESCRIPTION
Given that the error in question is surfaced on the API-side, this patch makes the following changes:
 - Updates the wording such that it'll hopefully be slightly easier for users to understand.
 - Changes the plain `Error` to an `InvalidPDFException` instead, since that should work better with the existing Error handling.
 - Adds a unit-test which loads an empty PDF document (and also improves a pre-existing `InvalidPDFException` message and its test-case).

Fixes #5887