### PR TITLE
Re-factor the `npm test` command, used by Travis, to avoid running the 'default_preferences' tasks concurrently (issue 10732)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1502,3 +1502,6 @@ gulp.task('externaltest', function (done) {
                 { stdio: 'inherit', });
   done();
 });
+
+gulp.task('npm-test', gulp.series(gulp.parallel('lint', 'externaltest'),
+                                  'unittestcli'));

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "yargs": "^11.1.1"
   },
   "scripts": {
-    "test": "env SKIP_BABEL=true gulp lint unittestcli externaltest"
+    "test": "env SKIP_BABEL=true gulp npm-test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
*Please note:* This patch does *not* prevent the 'default_preferences' task from running more than once during `npm test`, but it does ensure that the tasks won't run *concurrently* by running the relevant tests in *series*.

While it would obviously still make sense to re-factor the gulpfile to account for changes in `gulp` version 4, by at least tweaking the `npm test` command the intermittent failures on Travis should at least go away.