### PR TITLE
Use the `strict` mode `assert` in the pdf2png Node.js example (issue 10768)

### DIFF
--- a/examples/node/pdf2png/pdf2png.js
+++ b/examples/node/pdf2png/pdf2png.js
@@ -14,7 +14,7 @@
  */
 
 var Canvas = require('canvas');
-var assert = require('assert');
+var assert = require('assert').strict;
 var fs = require('fs');
 
 function NodeCanvasFactory() {}


### PR DESCRIPTION
See https://nodejs.org/api/assert.html#assert_strict_mode

Should, hopefully, fix #10768