### PR TITLE
Ignore Metadata entries with incorrectly encoded characters, when setting the viewer title (bug 1605526)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1126,7 +1126,11 @@ let PDFViewerApplication = {
       if (metadataTitle) {
         // Ghostscript can produce invalid 'dc:title' Metadata entries:
         //  - The title may be "Untitled" (fixes bug 1031612).
-        if (metadataTitle !== 'Untitled') {
+        //  - The title may contain incorrectly encoded characters, which thus
+        //    looks broken, hence we ignore the Metadata entry when it contains
+        //    characters from the Specials Unicode block (fixes bug 1605526).
+        if (metadataTitle !== 'Untitled' &&
+            !/[\uFFF0-\uFFFF]/g.test(metadataTitle)) {
           pdfTitle = metadataTitle;
         }
       }

--- a/web/app.js
+++ b/web/app.js
@@ -1117,16 +1117,18 @@ let PDFViewerApplication = {
                   (AppOptions.get('enableWebGL') ? ' [WebGL]' : '') + ')');
 
       let pdfTitle;
-      if (metadata && metadata.has('dc:title')) {
-        let title = metadata.get('dc:title');
-        // Ghostscript sometimes return 'Untitled', sets the title to 'Untitled'
-        if (title !== 'Untitled') {
-          pdfTitle = title;
-        }
-      }
 
-      if (!pdfTitle && info && info['Title']) {
-        pdfTitle = info['Title'];
+      const infoTitle = info && info['Title'];
+      if (infoTitle) {
+        pdfTitle = infoTitle;
+      }
+      const metadataTitle = metadata && metadata.get('dc:title');
+      if (metadataTitle) {
+        // Ghostscript can produce invalid 'dc:title' Metadata entries:
+        //  - The title may be "Untitled" (fixes bug 1031612).
+        if (metadataTitle !== 'Untitled') {
+          pdfTitle = metadataTitle;
+        }
       }
 
       if (pdfTitle) {


### PR DESCRIPTION
Apparently Ghostscript can, in some cases, generate/include `Metadata` with incorrectly encoded characters.[1] This results in the viewer title looking wrong, which we thus attempt to avoid by falling back to the `Info` entry instead.

*Please note:* Obviously it would be better if this was fixed in the `Metadata` parser instead, rather than using a viewer work-around, but I'm just not sure how or even *if* that could actually be done given that the `Metadata` stream contains no trace of the *original* character.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1605526

---
[1] The problematic characters are from the Specials Unicode block, see https://en.wikipedia.org/wiki/Specials_(Unicode_block)

