### PR TITLE
Add ESLint rule for indentation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -37,6 +37,13 @@
     // Possible errors
     "for-direction": "error",
     "getter-return": "error",
+    "indent": ["error", 2, {
+      "CallExpression": { "arguments": "first" },
+      "FunctionExpression": { "parameters": "first" },
+      "ObjectExpression": "first",
+      "SwitchCase": 1,
+      "VariableDeclarator": "first"
+    }],
     "no-async-promise-executor": "error",
     "no-cond-assign": ["error", "except-parens"],
     "no-constant-condition": ["error", { "checkLoops": false, }],


### PR DESCRIPTION
I find formatting a tedious and unproductive task. I often see in code reviews that you want the code indented properly.

I'm trying to understand all the rules you have in your mind and so far, I was able to form the following rules:

* 2 spaces are used for indentation
* If array elements won't fit in one line, align the elements in the next line with the first element:
  ```js
  const arr = ['baa', 'bab', bac',
               'bad', 'bae'];
  ```
* If arguments in call expressions won't fit one line, align the arguments in the next line with the first argument:
  ```js
   function foo(baa, bab, bac
                bad, bae) { ...
  ```
  There are many cases in which this rule is being broken, for example
  ```js
    this.thumbnailButton.classList.toggle('toggled',
      view === SidebarView.THUMBS);
  ```
* If parameters in function expressions won't fit one line, align the parameters in the next line with the first parameter:
  ```js
   const result = foo(baa, bab, bac
                      bad, bae)
  ```
* If object properties won't fit in one line, align the properties in the next line with the first property:
  ```js
  const obj = { baa: 1, bab: 2, bac: 3,
                bad: 4, bae: 4 };
* Switch case should be formatted like this:
  ```js
  switch (case) {
    case 1: ...
    case 2: ...
  }
  ``` 
* Multiple variable declarations should align with the first one:
  ```js
  const a = 0,
        b = 1;
  ```

This ESLint configuration enforces these rules.