### PR TITLE
Tweak the "gets page stats after rendering page, with `pdfBug` set" unit-test to remove an intermittent failure on Travis

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1405,7 +1405,7 @@ describe('api', function() {
 
         let [statEntryOne, statEntryTwo, statEntryThree] = stats.times;
         expect(statEntryOne.name).toEqual('Page Request');
-        expect(statEntryOne.end - statEntryOne.start).toBeGreaterThan(0);
+        expect(statEntryOne.end - statEntryOne.start).toBeGreaterThanOrEqual(0);
 
         expect(statEntryTwo.name).toEqual('Rendering');
         expect(statEntryTwo.end - statEntryTwo.start).toBeGreaterThan(0);


### PR DESCRIPTION
I recently noticed a couple of intermittent failures on Travis, hence this patch which changes the expectation to be identical to the 'Page Request' check in the preceding test-case.