### PR TITLE
Support OpenAction dictionaries without `Type` entries when parsing `Print` actions (issue 11442)

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -625,7 +625,9 @@ class Catalog {
 
     // Append OpenAction actions to the JavaScript array.
     const openActionDict = this.catDict.get('OpenAction');
-    if (isDict(openActionDict, 'Action')) {
+    if (isDict(openActionDict) &&
+        (isName(openActionDict.get('Type'), 'Action') ||
+         !openActionDict.has('Type'))) {
       const actionType = openActionDict.get('S');
       if (isName(actionType, 'Named')) {
         // The named Print action is not a part of the PDF 1.7 specification,


### PR DESCRIPTION
The PDF generator didn't bother including the `Type` entry in the OpenAction dictionary, hence we skipped parsing the `Print` action.

Fixes #11442