### PR TITLE
Include a unit test for OpenAction dictionaries without `Type` entries (PR 11443 follow-up)

### DIFF
--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -350,6 +350,7 @@
 !operator-in-TJ-array.pdf
 !issue7878.pdf
 !font_ascent_descent.pdf
+!issue11442_reduced.pdf
 !issue8097_reduced.pdf
 !transparent.pdf
 !xobject-image.pdf

--- a/test/pdfs/issue11442_reduced.pdf
+++ b/test/pdfs/issue11442_reduced.pdf
@@ -1,0 +1,72 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/OpenAction 
+<<
+/N /Print
+/S /Named
+>>
+/Pages 2 0 R
+/Type /Catalog
+>>
+endobj 
+2 0 obj 
+<<
+/Kids [3 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+3 0 obj 
+<<
+/Parent 2 0 R
+/MediaBox [0 0 200 50]
+/Resources 
+<<
+/Font 
+<<
+/F1 4 0 R
+>>
+>>
+/Contents 5 0 R
+/Type /Page
+>>
+endobj 
+4 0 obj 
+<<
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/Type /Font
+>>
+endobj 
+5 0 obj 
+<<
+/Length 59
+>>
+stream
+BT
+10 20 TD
+/F1 14 Tf
+(Print dialog should be shown) Tj
+ET
+
+endstream 
+endobj xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000105 00000 n 
+0000000164 00000 n 
+0000000293 00000 n 
+0000000394 00000 n 
+trailer
+
+<<
+/Root 1 0 R
+/Size 6
+>>
+startxref
+505
+%%EOF

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -889,7 +889,7 @@ describe("api", function() {
     // detect whether or not to automatically start printing.
     var viewerPrintRegExp = /\bprint\s*\(/;
     it("gets javascript with printing instructions (Print action)", function(done) {
-      // PDF document with "Print" Named action in OpenAction
+      // PDF document with "Print" Named action in the OpenAction dictionary.
       var loadingTask = getDocument(buildGetDocumentParams("bug1001080.pdf"));
       var promise = loadingTask.promise.then(function(doc) {
         return doc.getJavaScript();
@@ -902,8 +902,25 @@ describe("api", function() {
         })
         .catch(done.fail);
     });
+    it("gets javascript with printing instructions (Print action without type)", function(done) {
+      // PDF document with "Print" Named action in the OpenAction dictionary,
+      // but the OpenAction dictionary is missing the `Type` entry.
+      var loadingTask = getDocument(
+        buildGetDocumentParams("issue11442_reduced.pdf")
+      );
+      var promise = loadingTask.promise.then(function(doc) {
+        return doc.getJavaScript();
+      });
+      promise
+        .then(function(data) {
+          expect(data).toEqual(["print({});"]);
+          expect(data[0]).toMatch(viewerPrintRegExp);
+          loadingTask.destroy().then(done);
+        })
+        .catch(done.fail);
+    });
     it("gets javascript with printing instructions (JS action)", function(done) {
-      // PDF document with "JavaScript" action in OpenAction
+      // PDF document with "JavaScript" action in the OpenAction dictionary.
       var loadingTask = getDocument(buildGetDocumentParams("issue6106.pdf"));
       var promise = loadingTask.promise.then(function(doc) {
         return doc.getJavaScript();
@@ -918,6 +935,7 @@ describe("api", function() {
         })
         .catch(done.fail);
     });
+
     it("gets non-existent outline", function(done) {
       var loadingTask = getDocument(buildGetDocumentParams("tracemonkey.pdf"));
 


### PR DESCRIPTION
The original issue did not contain a (reduced) test case that we could include and linked test cases are not ideal for unit tests, so the original PR could only be verified manually.

I found this a bit unfortunate considering that the print data is exposed through the API, so I thought about how we could have an automated test and managed to create a reduced test case with the OpenAction dictionary from the file in the original issue.

Therefore, this commit includes a unit test for parsing OpenAction dictionaries without `Type` entries. I verified that this PDF file behaves the same as the original one, i.e., no print dialog is shown for older viewers and the print dialog is shown for the most recent viewer.

@Snuffleupagus Would you perhaps be willing to review this?