### PR TITLE
Move the regular expression, used with auto printing in the viewer, to `web/ui_utils.js` and also use it in the API unit-tests

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -44,6 +44,7 @@ import {
   PDFPageProxy,
   PDFWorker,
 } from "../../src/display/api";
+import { AutoPrintRegExp } from "../../web/ui_utils";
 import { GlobalWorkerOptions } from "../../src/display/worker_options";
 import { isNodeJS } from "../../src/shared/is_node";
 import { Metadata } from "../../src/display/metadata";
@@ -885,9 +886,6 @@ describe("api", function() {
         })
         .catch(done.fail);
     });
-    // Keep this in sync with the pattern in viewer.js. The pattern is used to
-    // detect whether or not to automatically start printing.
-    var viewerPrintRegExp = /\bprint\s*\(/;
     it("gets javascript with printing instructions (Print action)", function(done) {
       // PDF document with "Print" Named action in the OpenAction dictionary.
       var loadingTask = getDocument(buildGetDocumentParams("bug1001080.pdf"));
@@ -897,7 +895,7 @@ describe("api", function() {
       promise
         .then(function(data) {
           expect(data).toEqual(["print({});"]);
-          expect(data[0]).toMatch(viewerPrintRegExp);
+          expect(data[0]).toMatch(AutoPrintRegExp);
           loadingTask.destroy().then(done);
         })
         .catch(done.fail);
@@ -914,7 +912,7 @@ describe("api", function() {
       promise
         .then(function(data) {
           expect(data).toEqual(["print({});"]);
-          expect(data[0]).toMatch(viewerPrintRegExp);
+          expect(data[0]).toMatch(AutoPrintRegExp);
           loadingTask.destroy().then(done);
         })
         .catch(done.fail);
@@ -930,7 +928,7 @@ describe("api", function() {
           expect(data).toEqual([
             "this.print({bUI:true,bSilent:false,bShrinkToFit:true});",
           ]);
-          expect(data[0]).toMatch(viewerPrintRegExp);
+          expect(data[0]).toMatch(AutoPrintRegExp);
           loadingTask.destroy().then(done);
         })
         .catch(done.fail);

--- a/web/app.js
+++ b/web/app.js
@@ -16,6 +16,7 @@
 
 import {
   animationStarted,
+  AutoPrintRegExp,
   DEFAULT_SCALE_VALUE,
   getGlobalEventBus,
   getPDFFileNameFromURL,
@@ -1229,10 +1230,8 @@ let PDFViewerApplication = {
         });
 
         // Hack to support auto printing.
-        let regex = /\bprint\s*\(/;
-        for (let i = 0, ii = javaScript.length; i < ii; i++) {
-          let js = javaScript[i];
-          if (js && regex.test(js)) {
+        for (const js of javaScript) {
+          if (js && AutoPrintRegExp.test(js)) {
             setTimeout(function() {
               window.print();
             });

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -56,6 +56,9 @@ const SpreadMode = {
   EVEN: 2,
 };
 
+// Used by `PDFViewerApplication`, and by the API unit-tests.
+const AutoPrintRegExp = /\bprint\s*\(/;
+
 // Replaces {{arguments}} with their values.
 function formatL10nValue(text, args) {
   if (!args) {
@@ -936,6 +939,7 @@ function moveToEndOfArray(arr, condition) {
 }
 
 export {
+  AutoPrintRegExp,
   CSS_UNITS,
   DEFAULT_SCALE_VALUE,
   DEFAULT_SCALE,


### PR DESCRIPTION
Rather than having a copy of this regular expression in the `test/unit/api_spec.js` file, with a comment about keeping it up-to-date with the code in the viewer (note the incorrect file reference as well), we can just import it instead to simplify all of this.

*This is something I noticed while looking at PR #11445, I'll rebase this once that one has landed.*