### PR TITLE
Move the SegoeUISymbol font to the `getNonStdFontMap` (PR 8698 follow-up)

### DIFF
--- a/src/core/standard_fonts.js
+++ b/src/core/standard_fonts.js
@@ -58,7 +58,6 @@ const getStdFontMap = getLookupTableFactory(function(t) {
   t["Helvetica-BoldOblique"] = "Helvetica-BoldOblique";
   t["Helvetica-Italic"] = "Helvetica-Oblique";
   t["Helvetica-Oblique"] = "Helvetica-Oblique";
-  t["SegoeUISymbol"] = "Helvetica";
   t["Symbol-Bold"] = "Symbol";
   t["Symbol-BoldItalic"] = "Symbol";
   t["Symbol-Italic"] = "Symbol";
@@ -118,6 +117,7 @@ const getNonStdFontMap = getLookupTableFactory(function(t) {
   t["MS-PMincho-BoldItalic"] = "MS PMincho-BoldItalic";
   t["MS-PMincho-Italic"] = "MS PMincho-Italic";
   t["NuptialScript"] = "Times-Italic";
+  t["SegoeUISymbol"] = "Helvetica";
   t["Wingdings"] = "ZapfDingbats";
 });
 


### PR DESCRIPTION
For reasons that I now cannot even begin to understand, the non-standard SegoeUISymbol font was placed in the `getStdFontMap`. That honestly makes no sense, hence this patch which does what I *should* have done from the start.