### PR TITLE
Convert the `src/pdf.js` and `src/pdf.worker.js` files to use standard `import`/`export` statements; Re-factor `setPDFNetworkStreamFactory`, in src/display/api.js, to take an asynchronous function 

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -678,7 +678,7 @@ function isMessagePort(maybePort) {
   );
 }
 
-// Worker thread (and not node.js)?
+// Worker thread (and not Node.js)?
 if (
   typeof window === "undefined" &&
   !isNodeJS &&

--- a/src/display/api_compatibility.js
+++ b/src/display/api_compatibility.js
@@ -13,10 +13,10 @@
  * limitations under the License.
  */
 
+import { isNodeJS } from "../shared/is_node.js";
+
 const compatibilityParams = Object.create(null);
 if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-  const { isNodeJS } = require("../shared/is_node.js");
-
   const userAgent =
     (typeof navigator !== "undefined" && navigator.userAgent) || "";
   const isIE = /Trident/.test(userAgent);
@@ -42,4 +42,4 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
   })();
 }
 
-exports.apiCompatibilityParams = Object.freeze(compatibilityParams);
+export const apiCompatibilityParams = Object.freeze(compatibilityParams);

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -12,36 +12,66 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable no-unused-vars */
 
-"use strict";
+import {
+  addLinkAttributes,
+  getFilenameFromUrl,
+  isFetchSupported,
+  isValidFetchUrl,
+  LinkTarget,
+  loadScript,
+  PDFDateString,
+  RenderingCancelledException,
+} from "./display/display_utils.js";
+import {
+  build,
+  getDocument,
+  LoopbackPort,
+  PDFDataRangeTransport,
+  PDFWorker,
+  setPDFNetworkStreamFactory,
+  version,
+} from "./display/api.js";
+import {
+  CMapCompressionType,
+  createObjectURL,
+  createPromiseCapability,
+  createValidAbsoluteUrl,
+  InvalidPDFException,
+  MissingPDFException,
+  NativeImageDecoding,
+  OPS,
+  PasswordResponses,
+  PermissionFlag,
+  removeNullCharacters,
+  shadow,
+  UnexpectedResponseException,
+  UNSUPPORTED_FEATURES,
+  Util,
+  VerbosityLevel,
+} from "./shared/util.js";
+import { AnnotationLayer } from "./display/annotation_layer.js";
+import { apiCompatibilityParams } from "./display/api_compatibility.js";
+import { GlobalWorkerOptions } from "./display/worker_options.js";
+import { renderTextLayer } from "./display/text_layer.js";
+import { SVGGraphics } from "./display/svg.js";
 
-var pdfjsVersion =
+/* eslint-disable-next-line no-unused-vars */
+const pdfjsVersion =
   typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_VERSION") : void 0;
-var pdfjsBuild =
+/* eslint-disable-next-line no-unused-vars */
+const pdfjsBuild =
   typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_BUILD") : void 0;
-
-var pdfjsSharedUtil = require("./shared/util.js");
-var pdfjsDisplayAPI = require("./display/api.js");
-var pdfjsDisplayTextLayer = require("./display/text_layer.js");
-var pdfjsDisplayAnnotationLayer = require("./display/annotation_layer.js");
-var pdfjsDisplayDisplayUtils = require("./display/display_utils.js");
-var pdfjsDisplaySVG = require("./display/svg.js");
-const pdfjsDisplayWorkerOptions = require("./display/worker_options.js");
-const pdfjsDisplayAPICompatibility = require("./display/api_compatibility.js");
 
 if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
   const streamsPromise = Promise.all([
     SystemJS.import("pdfjs/display/network.js"),
     SystemJS.import("pdfjs/display/fetch_stream.js"),
   ]);
-  pdfjsDisplayAPI.setPDFNetworkStreamFactory(params => {
+  setPDFNetworkStreamFactory(params => {
     return streamsPromise.then(streams => {
       const [{ PDFNetworkStream }, { PDFFetchStream }] = streams;
-      if (
-        pdfjsDisplayDisplayUtils.isFetchSupported() &&
-        pdfjsDisplayDisplayUtils.isValidFetchUrl(params.url)
-      ) {
+      if (isFetchSupported() && isValidFetchUrl(params.url)) {
         return new PDFFetchStream(params);
       }
       return new PDFNetworkStream(params);
@@ -50,28 +80,25 @@ if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
 } else if (PDFJSDev.test("GENERIC")) {
   const { isNodeJS } = require("./shared/is_node.js");
   if (isNodeJS) {
-    const PDFNodeStream = require("./display/node_stream.js").PDFNodeStream;
-    pdfjsDisplayAPI.setPDFNetworkStreamFactory(params => {
+    const { PDFNodeStream } = require("./display/node_stream.js");
+    setPDFNetworkStreamFactory(params => {
       return new PDFNodeStream(params);
     });
   } else {
-    const PDFNetworkStream = require("./display/network.js").PDFNetworkStream;
+    const { PDFNetworkStream } = require("./display/network.js");
     let PDFFetchStream;
-    if (pdfjsDisplayDisplayUtils.isFetchSupported()) {
+    if (isFetchSupported()) {
       PDFFetchStream = require("./display/fetch_stream.js").PDFFetchStream;
     }
-    pdfjsDisplayAPI.setPDFNetworkStreamFactory(params => {
-      if (
-        PDFFetchStream &&
-        pdfjsDisplayDisplayUtils.isValidFetchUrl(params.url)
-      ) {
+    setPDFNetworkStreamFactory(params => {
+      if (PDFFetchStream && isValidFetchUrl(params.url)) {
         return new PDFFetchStream(params);
       }
       return new PDFNetworkStream(params);
     });
   }
 } else if (PDFJSDev.test("CHROME")) {
-  const PDFNetworkStream = require("./display/network.js").PDFNetworkStream;
+  const { PDFNetworkStream } = require("./display/network.js");
   let PDFFetchStream;
   const isChromeWithFetchCredentials = function () {
     // fetch does not include credentials until Chrome 61.0.3138.0 and later.
@@ -86,56 +113,49 @@ if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
       return true;
     }
   };
-  if (
-    pdfjsDisplayDisplayUtils.isFetchSupported() &&
-    isChromeWithFetchCredentials()
-  ) {
+  if (isFetchSupported() && isChromeWithFetchCredentials()) {
     PDFFetchStream = require("./display/fetch_stream.js").PDFFetchStream;
   }
-  pdfjsDisplayAPI.setPDFNetworkStreamFactory(params => {
-    if (
-      PDFFetchStream &&
-      pdfjsDisplayDisplayUtils.isValidFetchUrl(params.url)
-    ) {
+  setPDFNetworkStreamFactory(params => {
+    if (PDFFetchStream && isValidFetchUrl(params.url)) {
       return new PDFFetchStream(params);
     }
     return new PDFNetworkStream(params);
   });
 }
 
-exports.build = pdfjsDisplayAPI.build;
-exports.version = pdfjsDisplayAPI.version;
-exports.getDocument = pdfjsDisplayAPI.getDocument;
-exports.LoopbackPort = pdfjsDisplayAPI.LoopbackPort;
-exports.PDFDataRangeTransport = pdfjsDisplayAPI.PDFDataRangeTransport;
-exports.PDFWorker = pdfjsDisplayAPI.PDFWorker;
-exports.renderTextLayer = pdfjsDisplayTextLayer.renderTextLayer;
-exports.AnnotationLayer = pdfjsDisplayAnnotationLayer.AnnotationLayer;
-exports.createPromiseCapability = pdfjsSharedUtil.createPromiseCapability;
-exports.PasswordResponses = pdfjsSharedUtil.PasswordResponses;
-exports.InvalidPDFException = pdfjsSharedUtil.InvalidPDFException;
-exports.MissingPDFException = pdfjsSharedUtil.MissingPDFException;
-exports.SVGGraphics = pdfjsDisplaySVG.SVGGraphics;
-exports.NativeImageDecoding = pdfjsSharedUtil.NativeImageDecoding;
-exports.CMapCompressionType = pdfjsSharedUtil.CMapCompressionType;
-exports.PermissionFlag = pdfjsSharedUtil.PermissionFlag;
-exports.UnexpectedResponseException =
-  pdfjsSharedUtil.UnexpectedResponseException;
-exports.OPS = pdfjsSharedUtil.OPS;
-exports.VerbosityLevel = pdfjsSharedUtil.VerbosityLevel;
-exports.UNSUPPORTED_FEATURES = pdfjsSharedUtil.UNSUPPORTED_FEATURES;
-exports.createValidAbsoluteUrl = pdfjsSharedUtil.createValidAbsoluteUrl;
-exports.createObjectURL = pdfjsSharedUtil.createObjectURL;
-exports.removeNullCharacters = pdfjsSharedUtil.removeNullCharacters;
-exports.shadow = pdfjsSharedUtil.shadow;
-exports.Util = pdfjsSharedUtil.Util;
-exports.RenderingCancelledException =
-  pdfjsDisplayDisplayUtils.RenderingCancelledException;
-exports.getFilenameFromUrl = pdfjsDisplayDisplayUtils.getFilenameFromUrl;
-exports.LinkTarget = pdfjsDisplayDisplayUtils.LinkTarget;
-exports.addLinkAttributes = pdfjsDisplayDisplayUtils.addLinkAttributes;
-exports.loadScript = pdfjsDisplayDisplayUtils.loadScript;
-exports.PDFDateString = pdfjsDisplayDisplayUtils.PDFDateString;
-exports.GlobalWorkerOptions = pdfjsDisplayWorkerOptions.GlobalWorkerOptions;
-exports.apiCompatibilityParams =
-  pdfjsDisplayAPICompatibility.apiCompatibilityParams;
+export {
+  addLinkAttributes,
+  getFilenameFromUrl,
+  LinkTarget,
+  loadScript,
+  PDFDateString,
+  RenderingCancelledException,
+  build,
+  getDocument,
+  LoopbackPort,
+  PDFDataRangeTransport,
+  PDFWorker,
+  version,
+  CMapCompressionType,
+  createObjectURL,
+  createPromiseCapability,
+  createValidAbsoluteUrl,
+  InvalidPDFException,
+  MissingPDFException,
+  NativeImageDecoding,
+  OPS,
+  PasswordResponses,
+  PermissionFlag,
+  removeNullCharacters,
+  shadow,
+  UnexpectedResponseException,
+  UNSUPPORTED_FEATURES,
+  Util,
+  VerbosityLevel,
+  AnnotationLayer,
+  apiCompatibilityParams,
+  GlobalWorkerOptions,
+  renderTextLayer,
+  SVGGraphics,
+};

--- a/src/pdf.worker.js
+++ b/src/pdf.worker.js
@@ -12,13 +12,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable no-unused-vars */
 
-"use strict";
+import { WorkerMessageHandler } from "./core/worker.js";
 
+/* eslint-disable-next-line no-unused-vars */
 const pdfjsVersion = PDFJSDev.eval("BUNDLE_VERSION");
+/* eslint-disable-next-line no-unused-vars */
 const pdfjsBuild = PDFJSDev.eval("BUNDLE_BUILD");
 
-const pdfjsCoreWorker = require("./core/worker.js");
-
-exports.WorkerMessageHandler = pdfjsCoreWorker.WorkerMessageHandler;
+export { WorkerMessageHandler };

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -14,6 +14,8 @@
  */
 /* eslint no-var: error */
 
+import { isNodeJS } from "./is_node.js";
+
 // Skip compatibility checks for modern builds and if we already ran the module.
 if (
   (typeof PDFJSDev === "undefined" || !PDFJSDev.test("SKIP_BABEL")) &&
@@ -26,8 +28,6 @@ if (
     globalThis = require("core-js/es/global-this");
   }
   globalThis._pdfjsCompatibilityChecked = true;
-
-  const { isNodeJS } = require("./is_node.js");
 
   const hasDOM = typeof window === "object" && typeof document === "object";
   const userAgent =
@@ -248,12 +248,15 @@ if (
 
   // Support: IE
   (function checkURL() {
-    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("IMAGE_DECODERS")) {
+    if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
+      // Prevent "require is not a function" errors in development mode,
+      // since the `URL` constructor should be available in modern browers.
+      return;
+    } else if (PDFJSDev.test("IMAGE_DECODERS")) {
       // The current image decoders don't use the `URL` constructor, so it
       // doesn't need to be polyfilled for the IMAGE_DECODERS build target.
       return;
-    }
-    if (typeof PDFJSDev !== "undefined" && !PDFJSDev.test("GENERIC")) {
+    } else if (!PDFJSDev.test("GENERIC")) {
       // The `URL` constructor is assumed to be available in the extension
       // builds.
       return;

--- a/web/viewer_compatibility.js
+++ b/web/viewer_compatibility.js
@@ -36,4 +36,4 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
   })();
 }
 
-exports.viewerCompatibilityParams = Object.freeze(compatibilityParams);
+export const viewerCompatibilityParams = Object.freeze(compatibilityParams);


### PR DESCRIPTION
*Please refer to the individual commit messages for additional details.*

I've looked briefly at issue #10965, and have concluded that given the changes in SystemJS the upgrade may a bit tricky (since for one I wasn't able to *easily* find a Babel plugin for the new version).

The ideal solution, as outlined briefly in https://github.com/mozilla/pdf.js/issues/10965#issuecomment-568252833, would probably be to try and avoid locking us into these sort of dev-dependencies in the future if at all possible. To that end, I'm thus proposing that we start migrating the code away from `require` statements (unless protected by pre-processor and/or run-time checks) and towards standardized `import`s instead wherever possible.

*Note:* I've not tested it yet, but it *may* even be possible to get rid of SystemJS everywhere *except* in the worker (in development mode) right now. Doing so would also allow us to slowly start using modern ECMAScript features, which the SystemJS Babel plugin doesn't support.