### PR TITLE
[Firefox] Ensure that telemetry will be correctly recorded even when the PDF header is missing (bug 1606566)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1314,7 +1314,28 @@ const PDFViewerApplication = {
           PDFJSDev.test("FIREFOX || MOZCENTRAL")
         ) {
           // Telemetry labels must be C++ variable friendly.
-          const versionId = `v${info.PDFFormatVersion.replace(".", "_")}`;
+          let versionId = "other";
+          // Keep these in sync with mozilla central's Histograms.json.
+          const KNOWN_VERSIONS = [
+            "1.0",
+            "1.1",
+            "1.2",
+            "1.3",
+            "1.4",
+            "1.5",
+            "1.6",
+            "1.7",
+            "1.8",
+            "1.9",
+            "2.0",
+            "2.1",
+            "2.2",
+            "2.3",
+          ];
+          if (KNOWN_VERSIONS.includes(info.PDFFormatVersion)) {
+            versionId = `v${info.PDFFormatVersion.replace(".", "_")}`;
+          }
+
           let generatorId = "other";
           // Keep these in sync with mozilla central's Histograms.json.
           const KNOWN_GENERATORS = [


### PR DESCRIPTION
As suggested in the bug we'll now always fallback to "other", which should be fine considering that that value is listed in the histogram definition; see https://searchfox.org/mozilla-central/rev/331f0c3b25089c9a16be65f4dc8c601aeaac8cc4/toolkit/components/telemetry/Histograms.json#9097-9106

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1606566

/cc @Rob--W