### PR TITLE
[Firefox] Slightly simplify how the generator is determined, when sending telemetry data from the viewer

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1365,16 +1365,16 @@ const PDFViewerApplication = {
             "fpdf",
           ];
           if (info.Producer) {
-            KNOWN_GENERATORS.some(
-              function(generator, s, i) {
-                if (!generator.includes(s)) {
-                  return false;
-                }
-                generatorId = s.replace(/[ .\-]/g, "_");
-                return true;
-              }.bind(null, info.Producer.toLowerCase())
-            );
+            const producer = info.Producer.toLowerCase();
+            KNOWN_GENERATORS.some(function(generator) {
+              if (!producer.includes(generator)) {
+                return false;
+              }
+              generatorId = generator.replace(/[ .\-]/g, "_");
+              return true;
+            });
           }
+
           const formType = !info.IsAcroFormPresent
             ? null
             : info.IsXFAPresent


### PR DESCRIPTION
When working on PR #11463 I couldn't help thinking that the `Array.prototype.some` callback function, used when determining the generator, was somewhat difficult to read with its partly unused and strangely named parameters.