### PR TITLE
Enable the `no-nested-ternary` ESLint rule in the `web/` directory

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -136,6 +136,7 @@
     "new-cap": ["error", { "newIsCap": true, "capIsNew": false, }],
     "no-array-constructor": "error",
     "no-multiple-empty-lines": ["error", { "max": 1, "maxEOF": 0, "maxBOF": 1, }],
+    "no-nested-ternary": "off",
     "no-new-object": "error",
     "spaced-comment": ["error", "always", {
       "block": {

--- a/web/.eslintrc
+++ b/web/.eslintrc
@@ -7,6 +7,9 @@
     // Plugins
     "import/no-unresolved": ["error", { "ignore": ["pdfjs-lib"]}],
 
+    // Stylistic Issues
+    "no-nested-ternary": "error",
+
     // ECMAScript 6
     "no-var": "error",
     "prefer-const": "error",

--- a/web/app.js
+++ b/web/app.js
@@ -1375,11 +1375,10 @@ const PDFViewerApplication = {
             });
           }
 
-          const formType = !info.IsAcroFormPresent
-            ? null
-            : info.IsXFAPresent
-            ? "xfa"
-            : "acroform";
+          let formType = null;
+          if (info.IsAcroFormPresent) {
+            formType = info.IsXFAPresent ? "xfa" : "acroform";
+          }
           this.externalServices.reportTelemetry({
             type: "documentInfo",
             version: versionId,
@@ -2066,13 +2065,14 @@ function webViewerNamedAction(evt) {
   }
 }
 
-function webViewerPresentationModeChanged(evt) {
-  const { active, switchInProgress } = evt;
-  PDFViewerApplication.pdfViewer.presentationModeState = switchInProgress
-    ? PresentationModeState.CHANGING
-    : active
-    ? PresentationModeState.FULLSCREEN
-    : PresentationModeState.NORMAL;
+function webViewerPresentationModeChanged({ active, switchInProgress }) {
+  let state = PresentationModeState.NORMAL;
+  if (switchInProgress) {
+    state = PresentationModeState.CHANGING;
+  } else if (active) {
+    state = PresentationModeState.FULLSCREEN;
+  }
+  PDFViewerApplication.pdfViewer.presentationModeState = state;
 }
 
 function webViewerSidebarViewChanged(evt) {


### PR DESCRIPTION
This rule is already enabled in mozilla-central, and helps avoid some confusing formatting[1], see https://searchfox.org/mozilla-central/rev/a92ed79b0bc746159fc31af1586adbfa9e45e264/tools/lint/eslint/eslint-plugin-mozilla/lib/configs/recommended.js#209-210

Since some cases may not be aren't entirely straightforward to convert, and some we probably don't want to change either[2], this patch is limited to the `web/` directory as a proof-of-concept.

Please find additional details about the ESLint rule at https://eslint.org/docs/rules/no-nested-ternary

---
[1] One example with *three* ternary statements: https://github.com/mozilla/pdf.js/blob/93aa613db7a874e6ed964f394241605d5586c142/src/core/fonts.js#L2623-L2630

[2] One example that should be whitelisted: https://github.com/mozilla/pdf.js/blob/93aa613db7a874e6ed964f394241605d5586c142/src/core/jbig2.js#L82-L92