### PR TITLE
Remove the `FIREFOX` build flag, since it's completely unused and simplify a couple of `PDFJSDev` checks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -88,7 +88,6 @@ var DEFINES = {
   TESTING: false,
   // The main build targets:
   GENERIC: false,
-  FIREFOX: false,
   MOZCENTRAL: false,
   CHROME: false,
   MINIFIED: false,
@@ -173,7 +172,6 @@ function createWebpackConfig(defines, output) {
     .readFileSync("./src/license_header_libre.js")
     .toString();
   var enableSourceMaps =
-    !bundleDefines.FIREFOX &&
     !bundleDefines.MOZCENTRAL &&
     !bundleDefines.CHROME &&
     !bundleDefines.TESTING;

--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -1291,7 +1291,10 @@ var JpegImage = (function JpegImageClosure() {
     },
 
     getData({ width, height, forceRGB = false, isSourcePDF = false }) {
-      if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("TESTING && !LIB")) {
+      if (
+        typeof PDFJSDev === "undefined" ||
+        PDFJSDev.test("!PRODUCTION || TESTING")
+      ) {
         assert(
           isSourcePDF === true,
           'JpegImage.getData: Unexpected "isSourcePDF" value for PDF files.'

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1639,7 +1639,6 @@ const PDFWorker = (function PDFWorkerClosure() {
         return worker.WorkerMessageHandler;
       }
       if (
-        typeof PDFJSDev !== "undefined" &&
         PDFJSDev.test("GENERIC") &&
         isNodeJS &&
         // eslint-disable-next-line no-undef

--- a/src/display/network.js
+++ b/src/display/network.js
@@ -25,10 +25,9 @@ import {
   validateRangeRequestCapabilities,
 } from "./network_utils.js";
 
-if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("FIREFOX || MOZCENTRAL")) {
+if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
   throw new Error(
-    'Module "./network" shall not ' +
-      "be used with FIREFOX or MOZCENTRAL build."
+    'Module "./network.js" shall not be used with MOZCENTRAL builds.'
   );
 }
 

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -601,7 +601,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
       let canvas = document.createElement("canvas");
       if (
         typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("FIREFOX || MOZCENTRAL || GENERIC")
+        PDFJSDev.test("MOZCENTRAL || GENERIC")
       ) {
         canvas.mozOpaque = true;
       }

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -53,7 +53,7 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       return new PDFNetworkStream(params);
     });
   }
-} else if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("CHROME")) {
+} else if (PDFJSDev.test("CHROME")) {
   let PDFNetworkStream = require("./display/network.js").PDFNetworkStream;
   let PDFFetchStream;
   let isChromeWithFetchCredentials = function() {

--- a/src/shared/message_handler.js
+++ b/src/shared/message_handler.js
@@ -51,9 +51,10 @@ function wrapReason(reason) {
         (typeof reason === "object" && reason !== null),
       'wrapReason: Expected "reason" to be a (possibly cloned) Error.'
     );
-  }
-  if (typeof reason !== "object" || reason === null) {
-    return reason;
+  } else {
+    if (typeof reason !== "object" || reason === null) {
+      return reason;
+    }
   }
   switch (reason.name) {
     case "AbortException":

--- a/web/app.js
+++ b/web/app.js
@@ -731,10 +731,7 @@ const PDFViewerApplication = {
       if (key === "docBaseUrl" && !value) {
         if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
           value = document.URL.split("#")[0];
-        } else if (
-          typeof PDFJSDev !== "undefined" &&
-          PDFJSDev.test("MOZCENTRAL || CHROME")
-        ) {
+        } else if (PDFJSDev.test("MOZCENTRAL || CHROME")) {
           value = this.baseUrl;
         }
       }

--- a/web/app.js
+++ b/web/app.js
@@ -578,7 +578,7 @@ const PDFViewerApplication = {
   initPassiveLoading() {
     if (
       typeof PDFJSDev === "undefined" ||
-      !PDFJSDev.test("FIREFOX || MOZCENTRAL || CHROME")
+      !PDFJSDev.test("MOZCENTRAL || CHROME")
     ) {
       throw new Error("Not implemented: initPassiveLoading");
     }
@@ -733,7 +733,7 @@ const PDFViewerApplication = {
           value = document.URL.split("#")[0];
         } else if (
           typeof PDFJSDev !== "undefined" &&
-          PDFJSDev.test("FIREFOX || MOZCENTRAL || CHROME")
+          PDFJSDev.test("MOZCENTRAL || CHROME")
         ) {
           value = this.baseUrl;
         }
@@ -927,10 +927,7 @@ const PDFViewerApplication = {
       }
     }
 
-    if (
-      typeof PDFJSDev === "undefined" ||
-      !PDFJSDev.test("FIREFOX || MOZCENTRAL")
-    ) {
+    if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
       const errorWrapperConfig = this.appConfig.errorWrapper;
       const errorWrapper = errorWrapperConfig.container;
       errorWrapper.removeAttribute("hidden");
@@ -1045,7 +1042,7 @@ const PDFViewerApplication = {
     let baseDocumentUrl;
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       baseDocumentUrl = null;
-    } else if (PDFJSDev.test("FIREFOX || MOZCENTRAL")) {
+    } else if (PDFJSDev.test("MOZCENTRAL")) {
       baseDocumentUrl = this.baseUrl;
     } else if (PDFJSDev.test("CHROME")) {
       baseDocumentUrl = location.href.split("#")[0];
@@ -1809,7 +1806,7 @@ function webViewerInitialized() {
     const params = parseQueryString(queryString);
     file = "file" in params ? params.file : AppOptions.get("defaultUrl");
     validateFileURL(file);
-  } else if (PDFJSDev.test("FIREFOX || MOZCENTRAL")) {
+  } else if (PDFJSDev.test("MOZCENTRAL")) {
     file = window.location.href.split("#")[0];
   } else if (PDFJSDev.test("CHROME")) {
     file = AppOptions.get("defaultUrl");
@@ -1943,7 +1940,7 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       PDFViewerApplication.open(file);
     }
   };
-} else if (PDFJSDev.test("FIREFOX || MOZCENTRAL || CHROME")) {
+} else if (PDFJSDev.test("MOZCENTRAL || CHROME")) {
   webViewerOpenFileViaURL = function webViewerOpenFileViaURL(file) {
     PDFViewerApplication.setTitleUsingUrl(file);
     PDFViewerApplication.initPassiveLoading();
@@ -2521,10 +2518,7 @@ function webViewerKeyDown(evt) {
     }
   }
 
-  if (
-    typeof PDFJSDev === "undefined" ||
-    !PDFJSDev.test("FIREFOX || MOZCENTRAL")
-  ) {
+  if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
     // CTRL or META without shift
     if (cmd === 1 || cmd === 8) {
       switch (evt.keyCode) {

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -19,13 +19,9 @@ import { DefaultExternalServices, PDFViewerApplication } from "./app.js";
 import { BasePreferences } from "./preferences.js";
 import { DEFAULT_SCALE_VALUE } from "./ui_utils.js";
 
-if (
-  typeof PDFJSDev === "undefined" ||
-  !PDFJSDev.test("FIREFOX || MOZCENTRAL")
-) {
+if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
   throw new Error(
-    'Module "pdfjs-web/firefoxcom" shall not be used outside ' +
-      "FIREFOX and MOZCENTRAL builds."
+    'Module "./firefoxcom.js" shall not be used outside MOZCENTRAL builds.'
   );
 }
 

--- a/web/pdf_attachment_viewer.js
+++ b/web/pdf_attachment_viewer.js
@@ -100,7 +100,7 @@ class PDFAttachmentViewer {
           chrome.runtime.getURL("/content/web/viewer.html") +
           "?file=" +
           encodeURIComponent(blobUrl + "#" + filename);
-      } else if (PDFJSDev.test("FIREFOX || MOZCENTRAL")) {
+      } else if (PDFJSDev.test("MOZCENTRAL")) {
         // Let Firefox's content handler catch the URL and display the PDF.
         viewerUrl = blobUrl + "?" + encodeURIComponent(filename);
       }

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -581,7 +581,7 @@ class PDFPageView {
 
     if (
       typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("MOZCENTRAL || FIREFOX || GENERIC")
+      PDFJSDev.test("MOZCENTRAL || GENERIC")
     ) {
       canvas.mozOpaque = true;
     }
@@ -658,7 +658,7 @@ class PDFPageView {
   paintOnSvg(wrapper) {
     if (
       typeof PDFJSDev !== "undefined" &&
-      PDFJSDev.test("FIREFOX || MOZCENTRAL || CHROME")
+      PDFJSDev.test("MOZCENTRAL || CHROME")
     ) {
       // Return a mock object, to prevent errors such as e.g.
       // "TypeError: paintTask.promise is undefined".

--- a/web/pdf_presentation_mode.js
+++ b/web/pdf_presentation_mode.js
@@ -471,10 +471,7 @@ class PDFPresentationMode {
 
     window.addEventListener("fullscreenchange", this.fullscreenChangeBind);
     window.addEventListener("mozfullscreenchange", this.fullscreenChangeBind);
-    if (
-      typeof PDFJSDev === "undefined" ||
-      !PDFJSDev.test("FIREFOX || MOZCENTRAL")
-    ) {
+    if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
       window.addEventListener(
         "webkitfullscreenchange",
         this.fullscreenChangeBind
@@ -492,10 +489,7 @@ class PDFPresentationMode {
       "mozfullscreenchange",
       this.fullscreenChangeBind
     );
-    if (
-      typeof PDFJSDev === "undefined" ||
-      !PDFJSDev.test("FIREFOX || MOZCENTRAL")
-    ) {
+    if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
       window.removeEventListener(
         "webkitfullscreenchange",
         this.fullscreenChangeBind

--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -54,7 +54,7 @@ const TempImageFactory = (function TempImageFactoryClosure() {
       // background ourselves. `_getPageDrawContext` uses CSS rules for this.
       if (
         typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("MOZCENTRAL || FIREFOX || GENERIC")
+        PDFJSDev.test("MOZCENTRAL || GENERIC")
       ) {
         tempCanvas.mozOpaque = true;
       }
@@ -228,7 +228,7 @@ class PDFThumbnailView {
 
     if (
       typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("MOZCENTRAL || FIREFOX || GENERIC")
+      PDFJSDev.test("MOZCENTRAL || GENERIC")
     ) {
       canvas.mozOpaque = true;
     }

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -373,8 +373,7 @@ class TextLayerBuilder {
       if (this.enhanceTextSelection && this.textLayerRenderTask) {
         this.textLayerRenderTask.expandTextDivs(true);
         if (
-          (typeof PDFJSDev === "undefined" ||
-            !PDFJSDev.test("FIREFOX || MOZCENTRAL")) &&
+          (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) &&
           expandDivsTimer
         ) {
           clearTimeout(expandDivsTimer);
@@ -387,10 +386,7 @@ class TextLayerBuilder {
       if (!end) {
         return;
       }
-      if (
-        typeof PDFJSDev === "undefined" ||
-        !PDFJSDev.test("FIREFOX || MOZCENTRAL")
-      ) {
+      if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
         // On non-Firefox browsers, the selection will feel better if the height
         // of the `endOfContent` div is adjusted to start at mouse click
         // location. This avoids flickering when the selection moves up.
@@ -414,10 +410,7 @@ class TextLayerBuilder {
 
     div.addEventListener("mouseup", () => {
       if (this.enhanceTextSelection && this.textLayerRenderTask) {
-        if (
-          typeof PDFJSDev === "undefined" ||
-          !PDFJSDev.test("FIREFOX || MOZCENTRAL")
-        ) {
+        if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
           expandDivsTimer = setTimeout(() => {
             if (this.textLayerRenderTask) {
               this.textLayerRenderTask.expandTextDivs(false);
@@ -434,10 +427,7 @@ class TextLayerBuilder {
       if (!end) {
         return;
       }
-      if (
-        typeof PDFJSDev === "undefined" ||
-        !PDFJSDev.test("FIREFOX || MOZCENTRAL")
-      ) {
+      if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
         end.style.top = "";
       }
       end.classList.remove("active");

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -745,7 +745,7 @@ function waitOnEventOrTimeout({ target, name, delay = 0 }) {
 const animationStarted = new Promise(function(resolve) {
   if (
     typeof PDFJSDev !== "undefined" &&
-    PDFJSDev.test("LIB") &&
+    PDFJSDev.test("LIB && TESTING") &&
     typeof window === "undefined"
   ) {
     // Prevent "ReferenceError: window is not defined" errors when running the

--- a/web/view_history.js
+++ b/web/view_history.js
@@ -21,8 +21,8 @@ const DEFAULT_VIEW_HISTORY_CACHE_SIZE = 20;
  *
  * The way that the view parameters are stored depends on how PDF.js is built,
  * for 'gulp <flag>' the following cases exist:
- *  - FIREFOX or MOZCENTRAL - uses sessionStorage.
- *  - GENERIC or CHROME     - uses localStorage, if it is available.
+ *  - MOZCENTRAL        - uses sessionStorage.
+ *  - GENERIC or CHROME - uses localStorage, if it is available.
  */
 class ViewHistory {
   constructor(fingerprint, cacheSize = DEFAULT_VIEW_HISTORY_CACHE_SIZE) {
@@ -57,10 +57,7 @@ class ViewHistory {
   async _writeToStorage() {
     const databaseStr = JSON.stringify(this.database);
 
-    if (
-      typeof PDFJSDev !== "undefined" &&
-      PDFJSDev.test("FIREFOX || MOZCENTRAL")
-    ) {
+    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
       sessionStorage.setItem("pdfjs.history", databaseStr);
       return;
     }
@@ -68,10 +65,7 @@ class ViewHistory {
   }
 
   async _readFromStorage() {
-    if (
-      typeof PDFJSDev !== "undefined" &&
-      PDFJSDev.test("FIREFOX || MOZCENTRAL")
-    ) {
+    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
       return sessionStorage.getItem("pdfjs.history");
     }
     return localStorage.getItem("pdfjs.history");

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -32,7 +32,7 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!--#endif-->
     <title>PDF.js viewer</title>
 
-<!--#if FIREFOX || MOZCENTRAL-->
+<!--#if MOZCENTRAL-->
 <!--#include viewer-snippet-firefox-extension.html-->
 <!--#endif-->
 <!--#if CHROME-->
@@ -391,7 +391,7 @@ See https://github.com/adobe-type-tools/cmap-resources
             </div>
           </div>
         </div>
-<!--#if !(FIREFOX || MOZCENTRAL)-->
+<!--#if !MOZCENTRAL-->
         <div id="printServiceOverlay" class="container hidden">
           <div class="dialog">
             <div class="row">

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -41,7 +41,7 @@ if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("PRODUCTION")) {
   pdfjsWebAppOptions = require("./app_options.js");
 }
 
-if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("FIREFOX || MOZCENTRAL")) {
+if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
   require("./firefoxcom.js");
   require("./firefox_print_service.js");
 }


### PR DESCRIPTION
 - Remove the `FIREFOX` build flag, since it's completely unused

    After PR 9566, which removed all of the old Firefox extension code, the `FIREFOX` build flag is no longer used for anything.
    It thus seems to me that it should be removed, for a couple of reasons:
     - It's simply dead code now, which only serves to add confusion when looking at the `PDFJSDev` calls.
     - It used to be that `MOZCENTRAL` and `FIREFOX` was *almost* always used together. However, ever since PR 9566 there's obviously been no effort put into keeping the `FIREFOX` build flags up to date.
     - In the event that a new, Webextension based, Firefox addon is created in the future you'd still need to audit all `MOZCENTRAL` (and possibly `CHROME`) build flags to see what'd make sense for the addon.

- Simplify, and tweak, a couple of `PDFJSDev` checks

   This removes a couple of, thanks to preceeding code, unnecessary `typeof PDFJSDev` checks, and also fixes a couple of incorrectly implemented (my fault) checks intended for `TESTING` builds.

