### PR TITLE
Add `direction: ltr;` to the canvases used in `examples/learning`, to ensure correct text rendering (issue 11457)

### DIFF
--- a/examples/learning/helloworld.html
+++ b/examples/learning/helloworld.html
@@ -8,7 +8,7 @@
 
 <h1>'Hello, world!' example</h1>
 
-<canvas id="the-canvas" style="border:1px  solid black"></canvas>
+<canvas id="the-canvas" style="border: 1px solid black; direction: ltr;"></canvas>
 
 <script src="../../node_modules/pdfjs-dist/build/pdf.js"></script>
 

--- a/examples/learning/helloworld64.html
+++ b/examples/learning/helloworld64.html
@@ -8,7 +8,7 @@
 
 <h1>'Hello, world!' example</h1>
 
-<canvas id="the-canvas" style="border:1px  solid black"></canvas>
+<canvas id="the-canvas" style="border: 1px solid black; direction: ltr;"></canvas>
 
 <script src="../../node_modules/pdfjs-dist/build/pdf.js"></script>
 

--- a/examples/learning/prevnext.html
+++ b/examples/learning/prevnext.html
@@ -16,7 +16,7 @@
 </div>
 
 <div>
-  <canvas id="the-canvas" style="border:1px solid black"></canvas>
+  <canvas id="the-canvas" style="border: 1px solid black; direction: ltr;"></canvas>
 </div>
 
 <script src="../../node_modules/pdfjs-dist/build/pdf.js"></script>


### PR DESCRIPTION
This is currently the only possible way of addressing the issue, until https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/direction becomes generally available in browsers.

*Note:* This will also require manually updating https://mozilla.github.io/pdf.js/examples/#interactive-examples

Fixes #11457