### PR TITLE
Enable the ESLint `no-unneeded-ternary` rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -138,6 +138,7 @@
     "no-multiple-empty-lines": ["error", { "max": 1, "maxEOF": 0, "maxBOF": 1, }],
     "no-nested-ternary": "off",
     "no-new-object": "error",
+    "no-unneeded-ternary": "error",
     "spaced-comment": ["error", "always", {
       "block": {
         "balanced": true,

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -768,7 +768,7 @@ class BaseViewer {
       height = 0,
       widthScale,
       heightScale;
-    const changeOrientation = pageView.rotation % 180 === 0 ? false : true;
+    const changeOrientation = pageView.rotation % 180 !== 0;
     const pageWidth =
       (changeOrientation ? pageView.height : pageView.width) /
       pageView.scale /


### PR DESCRIPTION
This rule is already enabled in mozilla-central, see https://searchfox.org/mozilla-central/rev/b04e3a28a2ef4dbf957018dbbdc1840d62fdbc32/tools/lint/eslint/eslint-plugin-mozilla/lib/configs/recommended.js#247-248

Please see https://eslint.org/docs/rules/no-unneeded-ternary for additional information.