### PR TITLE
Simplify the handling of unsupported/incorrect markers in `src/core/jpg.js`

### DIFF
--- a/test/pdfs/issue1877.pdf.link
+++ b/test/pdfs/issue1877.pdf.link
@@ -1,0 +1,1 @@
+https://web.archive.org/web/20160313045333/http://brianmckenna.org/files/IC-Roy.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2927,6 +2927,14 @@
       "link": true,
       "type": "eq"
     },
+    {  "id": "issue1877",
+       "file": "pdfs/issue1877.pdf",
+       "md5": "feac01f414f2e6792e4d3174944622f5",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue7308",
        "file": "pdfs/issue7308.pdf",
        "md5": "ba2e23d3af93ac2c634d77ccbe2e79d5",


### PR DESCRIPTION
 - Re-factor the "incorrect encoding" check, since this can be easily achieved using the general `findNextFileMarker` helper function (with a suitable `startPos` argument).

 - Tweak a condition, to make it easier to see that the end of the data has been reached.

 - Add a reference test for issue 1877, since it's what prompted the "incorrect encoding" check.