### PR TITLE
Enable the `no-nested-ternary` ESLint rule (PR 11488 follow-up)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -136,7 +136,7 @@
     "new-cap": ["error", { "newIsCap": true, "capIsNew": false, }],
     "no-array-constructor": "error",
     "no-multiple-empty-lines": ["error", { "max": 1, "maxEOF": 0, "maxBOF": 1, }],
-    "no-nested-ternary": "off",
+    "no-nested-ternary": "error",
     "no-new-object": "error",
     "no-unneeded-ternary": "error",
     "spaced-comment": ["error", "always", {

--- a/extensions/chromium/options/migration.js
+++ b/extensions/chromium/options/migration.js
@@ -109,11 +109,12 @@ limitations under the License.
         }
         // Migration code for https://github.com/mozilla/pdf.js/pull/9479.
         if (typeof items.disableTextLayer === "boolean") {
-          var textLayerMode = items.disableTextLayer
-            ? 0
-            : items.enhanceTextSelection
-            ? 2
-            : 1;
+          var textLayerMode = 1;
+          if (items.disableTextLayer) {
+            textLayerMode = 0;
+          } else if (items.enhanceTextSelection) {
+            textLayerMode = 2;
+          }
           if (textLayerMode !== 1) {
             // Overwrite if computed textLayerMode is not the default value (1).
             storageSync.set(

--- a/extensions/chromium/options/options.js
+++ b/extensions/chromium/options/options.js
@@ -113,12 +113,12 @@ Promise.all([
 
     // Automatically update the UI when the preferences were changed elsewhere.
     chrome.storage.onChanged.addListener(function(changes, areaName) {
-      var prefs =
-        areaName === storageAreaName
-          ? userPrefs
-          : areaName === "managed"
-          ? managedPrefs
-          : null;
+      var prefs = null;
+      if (areaName === storageAreaName) {
+        prefs = userPrefs;
+      } else if (areaName === "managed") {
+        prefs = managedPrefs;
+      }
       if (prefs) {
         renderedPrefNames.forEach(function(prefName) {
           var prefChanges = changes[prefName];

--- a/src/core/bidi.js
+++ b/src/core/bidi.js
@@ -104,11 +104,14 @@ function reverseValues(arr, start, end) {
   }
 }
 
-function createBidiText(str, isLTR, vertical) {
-  return {
-    str,
-    dir: vertical ? "ttb" : isLTR ? "ltr" : "rtl",
-  };
+function createBidiText(str, isLTR, vertical = false) {
+  let dir = "ltr";
+  if (vertical) {
+    dir = "ttb";
+  } else if (!isLTR) {
+    dir = "rtl";
+  }
+  return { str, dir };
 }
 
 // These are used in bidi(), which is called frequently. We re-use them on

--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -1331,8 +1331,16 @@ const LabCS = (function LabCSClosure() {
     }
 
     // Adjust limits of 'as' and 'bs'
-    as = as > cs.amax ? cs.amax : as < cs.amin ? cs.amin : as;
-    bs = bs > cs.bmax ? cs.bmax : bs < cs.bmin ? cs.bmin : bs;
+    if (as > cs.amax) {
+      as = cs.amax;
+    } else if (as < cs.amin) {
+      as = cs.amin;
+    }
+    if (bs > cs.bmax) {
+      bs = cs.bmax;
+    } else if (bs < cs.bmin) {
+      bs = cs.bmin;
+    }
 
     // Computes intermediate variables X,Y,Z as per spec
     let M = (Ls + 16) / 116;

--- a/src/core/font_renderer.js
+++ b/src/core/font_renderer.js
@@ -39,6 +39,17 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
     return (data[offset] << 8) | data[offset + 1];
   }
 
+  function getSubroutineBias(subrs) {
+    const numSubrs = subrs.length;
+    let bias = 32768;
+    if (numSubrs < 1240) {
+      bias = 107;
+    } else if (numSubrs < 33900) {
+      bias = 1131;
+    }
+    return bias;
+  }
+
   function parseCmap(data, start, end) {
     var offset =
       getUshort(data, start + 2) === 1
@@ -422,9 +433,8 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
                   subrs = fontDict.privateDict.subrsIndex.objects;
                 }
                 if (subrs) {
-                  let numSubrs = subrs.length;
                   // Add subroutine bias.
-                  n += numSubrs < 1240 ? 107 : numSubrs < 33900 ? 1131 : 32768;
+                  n += getSubroutineBias(subrs);
                   subrCode = subrs[n];
                 }
               } else {
@@ -804,18 +814,8 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
       this.cmap = cmap;
       this.glyphNameMap = glyphNameMap || getGlyphsUnicode();
 
-      this.gsubrsBias =
-        this.gsubrs.length < 1240
-          ? 107
-          : this.gsubrs.length < 33900
-          ? 1131
-          : 32768;
-      this.subrsBias =
-        this.subrs.length < 1240
-          ? 107
-          : this.subrs.length < 33900
-          ? 1131
-          : 32768;
+      this.gsubrsBias = getSubroutineBias(this.gsubrs);
+      this.subrsBias = getSubroutineBias(this.subrs);
 
       this.isCFFCIDFont = cffInfo.isCFFCIDFont;
       this.fdSelect = cffInfo.fdSelect;

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -752,11 +752,13 @@ var Font = (function FontClosure() {
     this.type = type;
     this.subtype = subtype;
 
-    this.fallbackName = this.isMonospace
-      ? "monospace"
-      : this.isSerifFont
-      ? "serif"
-      : "sans-serif";
+    let fallbackName = "sans-serif";
+    if (this.isMonospace) {
+      fallbackName = "monospace";
+    } else if (this.isSerifFont) {
+      fallbackName = "serif";
+    }
+    this.fallbackName = fallbackName;
 
     this.differences = properties.differences;
     this.widths = properties.widths;
@@ -901,7 +903,11 @@ var Font = (function FontClosure() {
 
   function safeString16(value) {
     // clamp value to the 16-bit int range
-    value = value > 0x7fff ? 0x7fff : value < -0x8000 ? -0x8000 : value;
+    if (value > 0x7fff) {
+      value = 0x7fff;
+    } else if (value < -0x8000) {
+      value = -0x8000;
+    }
     return String.fromCharCode((value >> 8) & 0xff, value & 0xff);
   }
 
@@ -2075,9 +2081,19 @@ var Font = (function FontClosure() {
             // reserved flags must be zero, cleaning up
             glyf[j - 1] = flag & 0x3f;
           }
-          var xyLength =
-            (flag & 2 ? 1 : flag & 16 ? 0 : 2) +
-            (flag & 4 ? 1 : flag & 32 ? 0 : 2);
+          let xLength = 2;
+          if (flag & 2) {
+            xLength = 1;
+          } else if (flag & 16) {
+            xLength = 0;
+          }
+          let yLength = 2;
+          if (flag & 4) {
+            yLength = 1;
+          } else if (flag & 32) {
+            yLength = 0;
+          }
+          const xyLength = xLength + yLength;
           coordinatesLength += xyLength;
           if (flag & 8) {
             var repeat = glyf[j++];
@@ -2620,14 +2636,14 @@ var Font = (function FontClosure() {
           }
           // Adjusting stack not extactly, but just enough to get function id
           if (!inFDEF && !inELSE) {
-            var stackDelta =
-              op <= 0x8e
-                ? TTOpsStackDeltas[op]
-                : op >= 0xc0 && op <= 0xdf
-                ? -1
-                : op >= 0xe0
-                ? -2
-                : 0;
+            let stackDelta = 0;
+            if (op <= 0x8e) {
+              stackDelta = TTOpsStackDeltas[op];
+            } else if (op >= 0xc0 && op <= 0xdf) {
+              stackDelta = -1;
+            } else if (op >= 0xe0) {
+              stackDelta = -2;
+            }
             if (op >= 0x71 && op <= 0x75) {
               n = stack.pop();
               if (!isNaN(n)) {

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -45,7 +45,12 @@ var PDFImage = (function PDFImageClosure() {
   function decodeAndClamp(value, addend, coefficient, max) {
     value = addend + value * coefficient;
     // Clamp the value to the range
-    return value < 0 ? 0 : value > max ? max : value;
+    if (value < 0) {
+      value = 0;
+    } else if (value > max) {
+      value = max;
+    }
+    return value;
   }
 
   /**
@@ -60,12 +65,14 @@ var PDFImage = (function PDFImageClosure() {
    */
   function resizeImageMask(src, bpc, w1, h1, w2, h2) {
     var length = w2 * h2;
-    var dest =
-      bpc <= 8
-        ? new Uint8Array(length)
-        : bpc <= 16
-        ? new Uint16Array(length)
-        : new Uint32Array(length);
+    let dest;
+    if (bpc <= 8) {
+      dest = new Uint8Array(length);
+    } else if (bpc <= 16) {
+      dest = new Uint16Array(length);
+    } else {
+      dest = new Uint32Array(length);
+    }
     var xRatio = w1 / w2;
     var yRatio = h1 / h2;
     var i,
@@ -421,12 +428,14 @@ var PDFImage = (function PDFImageClosure() {
 
       var length = width * height * numComps;
       var bufferPos = 0;
-      var output =
-        bpc <= 8
-          ? new Uint8Array(length)
-          : bpc <= 16
-          ? new Uint16Array(length)
-          : new Uint32Array(length);
+      let output;
+      if (bpc <= 8) {
+        output = new Uint8Array(length);
+      } else if (bpc <= 16) {
+        output = new Uint16Array(length);
+      } else {
+        output = new Uint32Array(length);
+      }
       var rowComps = width * numComps;
 
       var max = (1 << bpc) - 1;
@@ -481,8 +490,13 @@ var PDFImage = (function PDFImageClosure() {
           }
 
           var remainingBits = bits - bpc;
-          var value = buf >> remainingBits;
-          output[i] = value < 0 ? 0 : value > max ? max : value;
+          let value = buf >> remainingBits;
+          if (value < 0) {
+            value = 0;
+          } else if (value > max) {
+            value = max;
+          }
+          output[i] = value;
           buf = buf & ((1 << remainingBits) - 1);
           bits = remainingBits;
         }

--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -79,6 +79,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
 
     var sign = readBits(1);
     // prettier-ignore
+    /* eslint-disable no-nested-ternary */
     var value = readBits(1) ?
                   (readBits(1) ?
                     (readBits(1) ?
@@ -90,7 +91,13 @@ var Jbig2Image = (function Jbig2ImageClosure() {
                     readBits(6) + 20) :
                   readBits(4) + 4) :
                 readBits(2);
-    return sign === 0 ? value : value > 0 ? -value : null;
+    /* eslint-enable no-nested-ternary */
+    if (sign === 0) {
+      return value;
+    } else if (value > 0) {
+      return -value;
+    }
+    return null;
   }
 
   // A.3 The IAID decoding procedure
@@ -1176,17 +1183,24 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     }
 
     segmentHeader.retainBits = retainBits;
-    var referredToSegmentNumberSize =
-      segmentHeader.number <= 256 ? 1 : segmentHeader.number <= 65536 ? 2 : 4;
+
+    let referredToSegmentNumberSize = 4;
+    if (segmentHeader.number <= 256) {
+      referredToSegmentNumberSize = 1;
+    } else if (segmentHeader.number <= 65536) {
+      referredToSegmentNumberSize = 2;
+    }
     var referredTo = [];
     var i, ii;
     for (i = 0; i < referredToCount; i++) {
-      var number =
-        referredToSegmentNumberSize === 1
-          ? data[position]
-          : referredToSegmentNumberSize === 2
-          ? readUint16(data, position)
-          : readUint32(data, position);
+      let number;
+      if (referredToSegmentNumberSize === 1) {
+        number = data[position];
+      } else if (referredToSegmentNumberSize === 2) {
+        number = readUint16(data, position);
+      } else {
+        number = readUint32(data, position);
+      }
       referredTo.push(number);
       position += referredToSegmentNumberSize;
     }

--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -557,8 +557,14 @@ var JpegImage = (function JpegImageClosure() {
       // check for all-zero AC coefficients
       if ((p1 | p2 | p3 | p4 | p5 | p6 | p7) === 0) {
         t = (dctSqrt2 * p0 + 8192) >> 14;
-        // convert to 8 bit
-        t = t < -2040 ? 0 : t >= 2024 ? 255 : (t + 2056) >> 4;
+        // Convert to 8-bit.
+        if (t < -2040) {
+          t = 0;
+        } else if (t >= 2024) {
+          t = 255;
+        } else {
+          t = (t + 2056) >> 4;
+        }
         blockData[blockBufferOffset + col] = t;
         blockData[blockBufferOffset + col + 8] = t;
         blockData[blockBufferOffset + col + 16] = t;
@@ -615,15 +621,63 @@ var JpegImage = (function JpegImageClosure() {
       p3 = v3 + v4;
       p4 = v3 - v4;
 
-      // convert to 8-bit integers
-      p0 = p0 < 16 ? 0 : p0 >= 4080 ? 255 : p0 >> 4;
-      p1 = p1 < 16 ? 0 : p1 >= 4080 ? 255 : p1 >> 4;
-      p2 = p2 < 16 ? 0 : p2 >= 4080 ? 255 : p2 >> 4;
-      p3 = p3 < 16 ? 0 : p3 >= 4080 ? 255 : p3 >> 4;
-      p4 = p4 < 16 ? 0 : p4 >= 4080 ? 255 : p4 >> 4;
-      p5 = p5 < 16 ? 0 : p5 >= 4080 ? 255 : p5 >> 4;
-      p6 = p6 < 16 ? 0 : p6 >= 4080 ? 255 : p6 >> 4;
-      p7 = p7 < 16 ? 0 : p7 >= 4080 ? 255 : p7 >> 4;
+      // Convert to 8-bit integers.
+      if (p0 < 16) {
+        p0 = 0;
+      } else if (p0 >= 4080) {
+        p0 = 255;
+      } else {
+        p0 >>= 4;
+      }
+      if (p1 < 16) {
+        p1 = 0;
+      } else if (p1 >= 4080) {
+        p1 = 255;
+      } else {
+        p1 >>= 4;
+      }
+      if (p2 < 16) {
+        p2 = 0;
+      } else if (p2 >= 4080) {
+        p2 = 255;
+      } else {
+        p2 >>= 4;
+      }
+      if (p3 < 16) {
+        p3 = 0;
+      } else if (p3 >= 4080) {
+        p3 = 255;
+      } else {
+        p3 >>= 4;
+      }
+      if (p4 < 16) {
+        p4 = 0;
+      } else if (p4 >= 4080) {
+        p4 = 255;
+      } else {
+        p4 >>= 4;
+      }
+      if (p5 < 16) {
+        p5 = 0;
+      } else if (p5 >= 4080) {
+        p5 = 255;
+      } else {
+        p5 >>= 4;
+      }
+      if (p6 < 16) {
+        p6 = 0;
+      } else if (p6 >= 4080) {
+        p6 = 255;
+      } else {
+        p6 >>= 4;
+      }
+      if (p7 < 16) {
+        p7 = 0;
+      } else if (p7 >= 4080) {
+        p7 = 255;
+      } else {
+        p7 >>= 4;
+      }
 
       // store block data
       blockData[blockBufferOffset + col] = p0;

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -1762,12 +1762,15 @@ var JpxImage = (function JpxImageClosure() {
       this.width = width;
       this.height = height;
 
-      this.contextLabelTable =
-        subband === "HH"
-          ? HHContextLabel
-          : subband === "HL"
-          ? HLContextLabel
-          : LLAndLHContextsLabel;
+      let contextLabelTable;
+      if (subband === "HH") {
+        contextLabelTable = HHContextLabel;
+      } else if (subband === "HL") {
+        contextLabelTable = HLContextLabel;
+      } else {
+        contextLabelTable = LLAndLHContextsLabel;
+      }
+      this.contextLabelTable = contextLabelTable;
 
       var coefficientCount = width * height;
 
@@ -1775,12 +1778,15 @@ var JpxImage = (function JpxImageClosure() {
       // add border state cells for significanceState
       this.neighborsSignificance = new Uint8Array(coefficientCount);
       this.coefficentsSign = new Uint8Array(coefficientCount);
-      this.coefficentsMagnitude =
-        mb > 14
-          ? new Uint32Array(coefficientCount)
-          : mb > 6
-          ? new Uint16Array(coefficientCount)
-          : new Uint8Array(coefficientCount);
+      let coefficentsMagnitude;
+      if (mb > 14) {
+        coefficentsMagnitude = new Uint32Array(coefficientCount);
+      } else if (mb > 6) {
+        coefficentsMagnitude = new Uint16Array(coefficientCount);
+      } else {
+        coefficentsMagnitude = new Uint8Array(coefficientCount);
+      }
+      this.coefficentsMagnitude = coefficentsMagnitude;
       this.processingFlags = new Uint8Array(coefficientCount);
 
       var bitsDecoded = new Uint8Array(coefficientCount);

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -510,13 +510,7 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
       return;
     }
 
-    style.fontWeight = font.black
-      ? font.bold
-        ? "900"
-        : "bold"
-      : font.bold
-      ? "bold"
-      : "normal";
+    style.fontWeight = font.black ? "900" : font.bold ? "bold" : "normal";
     style.fontStyle = font.italic ? "italic" : "normal";
 
     // Use a reasonable default font if the font doesn't specify a fallback.

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -510,7 +510,13 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
       return;
     }
 
-    style.fontWeight = font.black ? "900" : font.bold ? "bold" : "normal";
+    let bold = "normal";
+    if (font.black) {
+      bold = "900";
+    } else if (font.bold) {
+      bold = "bold";
+    }
+    style.fontWeight = bold;
     style.fontStyle = font.italic ? "italic" : "normal";
 
     // Use a reasonable default font if the font doesn't specify a fallback.

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1441,7 +1441,13 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       }
 
       var name = fontObj.loadedName || "sans-serif";
-      var bold = fontObj.black ? "900" : fontObj.bold ? "bold" : "normal";
+
+      let bold = "normal";
+      if (fontObj.black) {
+        bold = "900";
+      } else if (fontObj.bold) {
+        bold = "bold";
+      }
       var italic = fontObj.italic ? "italic" : "normal";
       var typeface = `"${name}", ${fontObj.fallbackName}`;
 
@@ -1449,12 +1455,12 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       // Keeping the font at minimal size and using the fontSizeScale to change
       // the current transformation matrix before the fillText/strokeText.
       // See https://bugzilla.mozilla.org/show_bug.cgi?id=726227
-      var browserFontSize =
-        size < MIN_FONT_SIZE
-          ? MIN_FONT_SIZE
-          : size > MAX_FONT_SIZE
-          ? MAX_FONT_SIZE
-          : size;
+      let browserFontSize = size;
+      if (size < MIN_FONT_SIZE) {
+        browserFontSize = MIN_FONT_SIZE;
+      } else if (size > MAX_FONT_SIZE) {
+        browserFontSize = MAX_FONT_SIZE;
+      }
       this.current.fontSizeScale = size / browserFontSize;
 
       this.ctx.font = `${italic} ${bold} ${browserFontSize}px ${typeface}`;

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -113,22 +113,43 @@ var createMeshCanvas = (function createMeshCanvasClosure() {
       maxY = Math.round(y3);
     var xa, car, cag, cab;
     var xb, cbr, cbg, cbb;
-    var k;
     for (var y = minY; y <= maxY; y++) {
       if (y < y2) {
-        k = y < y1 ? 0 : y1 === y2 ? 1 : (y1 - y) / (y1 - y2);
+        let k;
+        if (y < y1) {
+          k = 0;
+        } else if (y1 === y2) {
+          k = 1;
+        } else {
+          k = (y1 - y) / (y1 - y2);
+        }
         xa = x1 - (x1 - x2) * k;
         car = c1r - (c1r - c2r) * k;
         cag = c1g - (c1g - c2g) * k;
         cab = c1b - (c1b - c2b) * k;
       } else {
-        k = y > y3 ? 1 : y2 === y3 ? 0 : (y2 - y) / (y2 - y3);
+        let k;
+        if (y > y3) {
+          k = 1;
+        } else if (y2 === y3) {
+          k = 0;
+        } else {
+          k = (y2 - y) / (y2 - y3);
+        }
         xa = x2 - (x2 - x3) * k;
         car = c2r - (c2r - c3r) * k;
         cag = c2g - (c2g - c3g) * k;
         cab = c2b - (c2b - c3b) * k;
       }
-      k = y < y1 ? 0 : y > y3 ? 1 : (y1 - y) / (y1 - y3);
+
+      let k;
+      if (y < y1) {
+        k = 0;
+      } else if (y > y3) {
+        k = 1;
+      } else {
+        k = (y1 - y) / (y1 - y3);
+      }
       xb = x1 - (x1 - x3) * k;
       cbr = c1r - (c1r - c3r) * k;
       cbg = c1g - (c1g - c3g) * k;
@@ -137,8 +158,12 @@ var createMeshCanvas = (function createMeshCanvasClosure() {
       var x2_ = Math.round(Math.max(xa, xb));
       var j = rowSize * y + x1_ * 4;
       for (var x = x1_; x <= x2_; x++) {
-        k = (xa - x) / (xa - xb);
-        k = k < 0 ? 0 : k > 1 ? 1 : k;
+        let k = (xa - x) / (xa - xb);
+        if (k < 0) {
+          k = 0;
+        } else if (k > 1) {
+          k = 1;
+        }
         bytes[j++] = (car - (car - cbr) * k) | 0;
         bytes[j++] = (cag - (cag - cbg) * k) | 0;
         bytes[j++] = (cab - (cab - cbb) * k) | 0;

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -942,7 +942,12 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
         ? fontObj.fontMatrix
         : FONT_IDENTITY_MATRIX;
 
-      const bold = fontObj.black ? "900" : fontObj.bold ? "bold" : "normal";
+      let bold = "normal";
+      if (fontObj.black) {
+        bold = "900";
+      } else if (fontObj.bold) {
+        bold = "bold";
+      }
       const italic = fontObj.italic ? "italic" : "normal";
 
       if (size < 0) {

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -942,13 +942,7 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
         ? fontObj.fontMatrix
         : FONT_IDENTITY_MATRIX;
 
-      const bold = fontObj.black
-        ? fontObj.bold
-          ? "bolder"
-          : "bold"
-        : fontObj.bold
-        ? "bold"
-        : "normal";
+      const bold = fontObj.black ? "900" : fontObj.bold ? "bold" : "normal";
       const italic = fontObj.italic ? "italic" : "normal";
 
       if (size < 0) {

--- a/web/.eslintrc
+++ b/web/.eslintrc
@@ -7,9 +7,6 @@
     // Plugins
     "import/no-unresolved": ["error", { "ignore": ["pdfjs-lib"]}],
 
-    // Stylistic Issues
-    "no-nested-ternary": "error",
-
     // ECMAScript 6
     "no-var": "error",
     "prefer-const": "error",


### PR DESCRIPTION
This rule is already enabled in mozilla-central, and helps avoid some confusing formatting, see https://searchfox.org/mozilla-central/rev/9e45d74b956be046e5021a746b0c8912f1c27318/tools/lint/eslint/eslint-plugin-mozilla/lib/configs/recommended.js#209-210

With the recent introduction of Prettier some of the existing nested ternary statements became even more difficult to read, since any possibly helpful indentation was removed.
This particular ESLint rule wasn't entirely straightforward to enable, and I do recognize that there's a certain amount of subjectivity in the changes being made. Generally, the changes in this patch fall into three categories:
 - Cases where a value is only clamped to a certain range (the easiest ones to update).
 - Cases where the values involved are "simple", such as Numbers and Strings, which are re-factored to initialize the variable with the *default* value and only update it when necessary by using `if`/`else if` statements.
 - Cases with more complex and/or larger values, such as TypedArrays, which are re-factored to let the variable be (implicitly) undefined and where all values are then set through `if`/`else if`/`else` statements.

Please find additional details about the ESLint rule at https://eslint.org/docs/rules/no-nested-ternary

