### PR TITLE
Cache the fallback font dictionary on the `PartialEvaluator` (PR 11218 follow-up)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -33,7 +33,14 @@ import {
   warn,
 } from "../shared/util.js";
 import { Catalog, ObjectLoader, XRef } from "./obj.js";
-import { Dict, isDict, isName, isStream, Ref } from "./primitives.js";
+import {
+  clearPrimitiveCaches,
+  Dict,
+  isDict,
+  isName,
+  isStream,
+  Ref,
+} from "./primitives.js";
 import {
   getInheritableProperty,
   MissingDataException,
@@ -815,8 +822,8 @@ class PDFDocument {
     return this.catalog.fontFallback(id, handler);
   }
 
-  cleanup() {
-    return this.catalog.cleanup();
+  async cleanup() {
+    return this.catalog ? this.catalog.cleanup() : clearPrimitiveCaches();
   }
 }
 

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -935,11 +935,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
         // Falling back to a default font to avoid completely broken rendering,
         // but note that there're no guarantees that things will look "correct".
-        fontRef = new Dict();
-        fontRef.set("BaseFont", Name.get("PDFJS-FallbackFont"));
-        fontRef.set("Type", Name.get("FallbackType"));
-        fontRef.set("Subtype", Name.get("FallbackType"));
-        fontRef.set("Encoding", Name.get("WinAnsiEncoding"));
+        fontRef = PartialEvaluator.getFallbackFontDict();
       }
 
       if (this.fontCache.has(fontRef)) {
@@ -3132,6 +3128,21 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         buildPath(accent.fontChar);
       }
     }
+  };
+
+  // TODO: Change this to a `static` getter, using shadowing, once
+  //       `PartialEvaluator` is converted to a proper class.
+  PartialEvaluator.getFallbackFontDict = function() {
+    if (this._fallbackFontDict) {
+      return this._fallbackFontDict;
+    }
+    const dict = new Dict();
+    dict.set("BaseFont", Name.get("PDFJS-FallbackFont"));
+    dict.set("Type", Name.get("FallbackType"));
+    dict.set("Subtype", Name.get("FallbackType"));
+    dict.set("Encoding", Name.get("WinAnsiEncoding"));
+
+    return (this._fallbackFontDict = dict);
   };
 
   return PartialEvaluator;

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -593,16 +593,22 @@ var WorkerMessageHandler = {
 
     handler.on("Terminate", function wphTerminate(data) {
       terminated = true;
+
+      const waitOn = [];
       if (pdfManager) {
         pdfManager.terminate(new AbortException("Worker was terminated."));
+
+        const cleanupPromise = pdfManager.cleanup();
+        waitOn.push(cleanupPromise);
+
         pdfManager = null;
+      } else {
+        clearPrimitiveCaches();
       }
       if (cancelXHRs) {
         cancelXHRs(new AbortException("Worker was terminated."));
       }
-      clearPrimitiveCaches();
 
-      var waitOn = [];
       WorkerTasks.forEach(function(task) {
         waitOn.push(task.finished);
         task.terminate();


### PR DESCRIPTION
 - Ensure that full clean-up is always run when handling the "Terminate" message in `src/core/worker.js`

   This is beneficial in situations where the Worker is being re-used, for example with fake workers, since it ensures that things like font resources are actually released.

 - Cache the fallback font dictionary on the `PartialEvaluator` (PR 11218 follow-up)

   This way we'll benefit from the existing font caching, and can thus avoid re-creating a fallback font over and over again during parsing.
(Thece changes necessitated the previous patch, since otherwise breakage could occur e.g. with fake workers.)

