### PR TITLE
Custom background color for highlighting

### DIFF
--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -249,7 +249,7 @@ class TextLayerBuilder {
         const span = document.createElement("span");
         span.className = className;
 
-        if( findController.state.backgroundColorOption ) {
+        if( findController.state.backgroundColorOptions ) {
           // make lowerCase so we have Case Insensitive matching
           var key, keys = Object.keys(findController.state.backgroundColorOptions);
           var n = keys.length;

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -248,6 +248,23 @@ class TextLayerBuilder {
       if (className) {
         const span = document.createElement("span");
         span.className = className;
+
+        if( findController.state.backgroundColorOption ) {
+          // make lowerCase so we have Case Insensitive matching
+          var key, keys = Object.keys(findController.state.backgroundColorOptions);
+          var n = keys.length;
+          var backgroundColor={};
+          while (n--) {
+            key = keys[n];
+            backgroundColor[key.toLowerCase()] = findController.state.backgroundColorOptions[key];
+          }
+
+          // Add the background color if its defined for this word
+          if( content in backgroundColor ) {
+            span.style.background = backgroundColor[ content ];
+          }
+        }
+
         span.appendChild(node);
         div.appendChild(span);
         return;


### PR DESCRIPTION
Adding the option "backgroundColorOptions" allows for custom background color for highlighting. We needed a way to dynamically change the color of the highlighted words.

Sample usage
```
function webViewerFind(evt) {
  PDFViewerApplication.findController.executeCommand("find" + evt.type, {
    query: evt.query,
    phraseSearch: evt.phraseSearch,
    caseSensitive: evt.caseSensitive,
    entireWord: evt.entireWord,
    highlightAll: evt.highlightAll,
    findPrevious: evt.findPrevious,
    backgroundColorOptions: { "the": "red", "no": "green"  }
  });
}
```