### PR TITLE
Remove gloss on zoom dropdown in Safari

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -721,6 +721,7 @@ html[dir='rtl'] .dropdownToolbarButton {
   padding: 3px 2px 2px;
   border: none;
   background: rgba(0,0,0,0); /* Opera does not support 'transparent' <select> background */
+  -webkit-appearance: none; /* remove gloss in Safari */
 }
 
 .dropdownToolbarButton > select > option {


### PR DESCRIPTION
<img width="233" alt="Screenshot-pdf js-Safari" src="https://user-images.githubusercontent.com/1429104/72592770-9bcfe680-3903-11ea-865f-44a7ea086c42.png">
