### PR TITLE
Enable import/extensions of ESlint plugin to enforce all `import` have a `.js` file extension.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,6 +31,7 @@
 
   "rules": {
     // Plugins
+    "import/extensions": ["error", "always", { "ignorePackages": true, }],
     "import/no-unresolved": "error",
     "mozilla/avoid-removeChild": "error",
     "mozilla/use-includes-instead-of-indexOf": "error",

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -14,7 +14,7 @@
  */
 /* eslint no-var: error */
 
-import "./compatibility";
+import "./compatibility.js";
 
 const IDENTITY_MATRIX = [1, 0, 0, 1, 0, 0];
 const FONT_IDENTITY_MATRIX = [0.001, 0, 0, 0.001, 0, 0];

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import "../extensions/firefox/tools/l10n";
+import "../extensions/firefox/tools/l10n.js";
 import { createObjectURL, PDFDataRangeTransport, shadow } from "pdfjs-lib";
 import { BasePreferences } from "./preferences.js";
 import { DEFAULT_SCALE_VALUE } from "./ui_utils.js";

--- a/web/genericl10n.js
+++ b/web/genericl10n.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import "../external/webL10n/l10n";
+import "../external/webL10n/l10n.js";
 
 const webL10n = document.webL10n;
 


### PR DESCRIPTION
This PR enables the rule `import/extensions` of ESlint `import` plugin to enforce all `import` have a `.js` file extension. Related to  #11465. It would help your development.

- https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md