### PR TITLE
Update the `GlobalWorkerOptions.workerSrc` JSDoc comment

### DIFF
--- a/src/display/worker_options.js
+++ b/src/display/worker_options.js
@@ -25,12 +25,10 @@ GlobalWorkerOptions.workerPort =
     : GlobalWorkerOptions.workerPort;
 
 /**
- * Path and filename of the worker file. Required when workers are enabled in
- * development mode. If unspecified in production builds, the worker will be
- * loaded based on the location of the `pdf.js` file.
+ * A string containing the path and filename of the worker file.
  *
- * NOTE: The `workerSrc` should always be set in custom applications, in order
- *       to prevent issues caused by third-party frameworks and libraries.
+ * NOTE: The `workerSrc` option should always be set, in order to prevent any
+ *       issues when using the PDF.js library.
  * @var {string}
  */
 GlobalWorkerOptions.workerSrc =


### PR DESCRIPTION
This particular JSDoc comment is fairly old and it also contains some now unrelated/confusing information.
The only way to *guarantee* that the PDF.js library works as expected is to correctly set the global `workerSrc`[1], hence giving the impression that the option isn't strictly necessary is thus incorrect.

---
[1] Since advertising the fallbackWorkerSrc functionality definitely seems like the *wrong* thing to do.