### PR TITLE
Remove the `supportsDocumentColors` warning in MOZCENTRAL builds (bug 844349 follow-up)

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -245,4 +245,3 @@ password_cancel=Cancel
 printing_not_supported=Warning: Printing is not fully supported by this browser.
 printing_not_ready=Warning: The PDF is not fully loaded for printing.
 web_fonts_disabled=Web fonts are disabled: unable to use embedded PDF fonts.
-document_colors_not_allowed=PDF documents are not allowed to use their own colors: “Allow pages to choose their own colors” is deactivated in the browser.

--- a/web/app.js
+++ b/web/app.js
@@ -119,10 +119,6 @@ class DefaultExternalServices {
     return shadow(this, "supportsDocumentFonts", true);
   }
 
-  static get supportsDocumentColors() {
-    return shadow(this, "supportsDocumentColors", true);
-  }
-
   static get supportedMouseWheelZoomModifierKeys() {
     return shadow(this, "supportedMouseWheelZoomModifierKeys", {
       ctrlKey: true,
@@ -568,10 +564,6 @@ const PDFViewerApplication = {
 
   get supportsDocumentFonts() {
     return this.externalServices.supportsDocumentFonts;
-  },
-
-  get supportsDocumentColors() {
-    return this.externalServices.supportsDocumentColors;
   },
 
   get loadingBar() {
@@ -1609,7 +1601,6 @@ const PDFViewerApplication = {
     eventBus.on("beforeprint", _boundEvents.beforePrint);
     eventBus.on("afterprint", _boundEvents.afterPrint);
     eventBus.on("pagerendered", webViewerPageRendered);
-    eventBus.on("textlayerrendered", webViewerTextLayerRendered);
     eventBus.on("updateviewarea", webViewerUpdateViewarea);
     eventBus.on("pagechanging", webViewerPageChanging);
     eventBus.on("scalechanging", webViewerScaleChanging);
@@ -1684,7 +1675,6 @@ const PDFViewerApplication = {
     eventBus.off("beforeprint", _boundEvents.beforePrint);
     eventBus.off("afterprint", _boundEvents.afterPrint);
     eventBus.off("pagerendered", webViewerPageRendered);
-    eventBus.off("textlayerrendered", webViewerTextLayerRendered);
     eventBus.off("updateviewarea", webViewerUpdateViewarea);
     eventBus.off("pagechanging", webViewerPageChanging);
     eventBus.off("scalechanging", webViewerScaleChanging);
@@ -2022,28 +2012,6 @@ function webViewerPageRendered(evt) {
         stats,
       });
     });
-  }
-}
-
-function webViewerTextLayerRendered(evt) {
-  if (
-    typeof PDFJSDev !== "undefined" &&
-    PDFJSDev.test("FIREFOX || MOZCENTRAL") &&
-    evt.numTextDivs > 0 &&
-    !PDFViewerApplication.supportsDocumentColors
-  ) {
-    PDFViewerApplication.l10n
-      .get(
-        "document_colors_not_allowed",
-        null,
-        "PDF documents are not allowed to use their own colors: " +
-          "'Allow pages to choose their own colors' " +
-          "is deactivated in the browser."
-      )
-      .then(msg => {
-        console.error(msg);
-      });
-    PDFViewerApplication.fallback();
   }
 }
 

--- a/web/app.js
+++ b/web/app.js
@@ -84,29 +84,52 @@ const ViewOnLoad = {
   INITIAL: 1,
 };
 
-const DefaultExternalServices = {
-  updateFindControlState(data) {},
-  updateFindMatchesCount(data) {},
-  initPassiveLoading(callbacks) {},
-  fallback(data, callback) {},
-  reportTelemetry(data) {},
-  createDownloadManager(options) {
+class DefaultExternalServices {
+  constructor() {
+    throw new Error("Cannot initialize DefaultExternalServices.");
+  }
+
+  static updateFindControlState(data) {}
+
+  static updateFindMatchesCount(data) {}
+
+  static initPassiveLoading(callbacks) {}
+
+  static fallback(data, callback) {}
+
+  static reportTelemetry(data) {}
+
+  static createDownloadManager(options) {
     throw new Error("Not implemented: createDownloadManager");
-  },
-  createPreferences() {
+  }
+
+  static createPreferences() {
     throw new Error("Not implemented: createPreferences");
-  },
-  createL10n(options) {
+  }
+
+  static createL10n(options) {
     throw new Error("Not implemented: createL10n");
-  },
-  supportsIntegratedFind: false,
-  supportsDocumentFonts: true,
-  supportsDocumentColors: true,
-  supportedMouseWheelZoomModifierKeys: {
-    ctrlKey: true,
-    metaKey: true,
-  },
-};
+  }
+
+  static get supportsIntegratedFind() {
+    return shadow(this, "supportsIntegratedFind", false);
+  }
+
+  static get supportsDocumentFonts() {
+    return shadow(this, "supportsDocumentFonts", true);
+  }
+
+  static get supportsDocumentColors() {
+    return shadow(this, "supportsDocumentColors", true);
+  }
+
+  static get supportedMouseWheelZoomModifierKeys() {
+    return shadow(this, "supportedMouseWheelZoomModifierKeys", {
+      ctrlKey: true,
+      metaKey: true,
+    });
+  }
+}
 
 const PDFViewerApplication = {
   initialBookmark: document.location.hash.substring(1),

--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -404,27 +404,30 @@ class ChromePreferences extends BasePreferences {
   }
 }
 
-const ChromeExternalServices = Object.create(DefaultExternalServices);
-ChromeExternalServices.initPassiveLoading = function(callbacks) {
-  const { overlayManager } = PDFViewerApplication;
-  // defaultUrl is set in viewer.js
-  ChromeCom.resolvePDFFile(
-    AppOptions.get("defaultUrl"),
-    overlayManager,
-    function(url, length, originalUrl) {
-      callbacks.onOpenWithURL(url, length, originalUrl);
-    }
-  );
-};
-ChromeExternalServices.createDownloadManager = function(options) {
-  return new DownloadManager(options);
-};
-ChromeExternalServices.createPreferences = function() {
-  return new ChromePreferences();
-};
-ChromeExternalServices.createL10n = function(options) {
-  return new GenericL10n(navigator.language);
-};
+class ChromeExternalServices extends DefaultExternalServices {
+  static initPassiveLoading(callbacks) {
+    // defaultUrl is set in viewer.js
+    ChromeCom.resolvePDFFile(
+      AppOptions.get("defaultUrl"),
+      PDFViewerApplication.overlayManager,
+      function(url, length, originalUrl) {
+        callbacks.onOpenWithURL(url, length, originalUrl);
+      }
+    );
+  }
+
+  static createDownloadManager(options) {
+    return new DownloadManager(options);
+  }
+
+  static createPreferences() {
+    return new ChromePreferences();
+  }
+
+  static createL10n(options) {
+    return new GenericL10n(navigator.language);
+  }
+}
 PDFViewerApplication.externalServices = ChromeExternalServices;
 
 export { ChromeCom };

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -343,11 +343,6 @@ class FirefoxExternalServices extends DefaultExternalServices {
     return shadow(this, "supportsDocumentFonts", support);
   }
 
-  static get supportsDocumentColors() {
-    const support = FirefoxCom.requestSync("supportsDocumentColors");
-    return shadow(this, "supportsDocumentColors", support);
-  }
-
   static get supportedMouseWheelZoomModifierKeys() {
     const support = FirefoxCom.requestSync(
       "supportedMouseWheelZoomModifierKeys"

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -15,9 +15,9 @@
 
 import "../extensions/firefox/tools/l10n";
 import { createObjectURL, PDFDataRangeTransport, shadow } from "pdfjs-lib";
+import { DefaultExternalServices, PDFViewerApplication } from "./app.js";
 import { BasePreferences } from "./preferences.js";
 import { DEFAULT_SCALE_VALUE } from "./ui_utils.js";
-import { PDFViewerApplication } from "./app.js";
 
 if (
   typeof PDFJSDev === "undefined" ||
@@ -241,16 +241,16 @@ class FirefoxComDataRangeTransport extends PDFDataRangeTransport {
   }
 }
 
-PDFViewerApplication.externalServices = {
-  updateFindControlState(data) {
+class FirefoxExternalServices extends DefaultExternalServices {
+  static updateFindControlState(data) {
     FirefoxCom.request("updateFindControlState", data);
-  },
+  }
 
-  updateFindMatchesCount(data) {
+  static updateFindMatchesCount(data) {
     FirefoxCom.request("updateFindMatchesCount", data);
-  },
+  }
 
-  initPassiveLoading(callbacks) {
+  static initPassiveLoading(callbacks) {
     let pdfDataRangeTransport;
 
     window.addEventListener("message", function windowMessage(e) {
@@ -309,52 +309,53 @@ PDFViewerApplication.externalServices = {
       }
     });
     FirefoxCom.requestSync("initPassiveLoading", null);
-  },
+  }
 
-  fallback(data, callback) {
+  static fallback(data, callback) {
     FirefoxCom.request("fallback", data, callback);
-  },
+  }
 
-  reportTelemetry(data) {
+  static reportTelemetry(data) {
     FirefoxCom.request("reportTelemetry", JSON.stringify(data));
-  },
+  }
 
-  createDownloadManager(options) {
+  static createDownloadManager(options) {
     return new DownloadManager(options);
-  },
+  }
 
-  createPreferences() {
+  static createPreferences() {
     return new FirefoxPreferences();
-  },
+  }
 
-  createL10n(options) {
+  static createL10n(options) {
     const mozL10n = document.mozL10n;
     // TODO refactor mozL10n.setExternalLocalizerServices
     return new MozL10n(mozL10n);
-  },
+  }
 
-  get supportsIntegratedFind() {
+  static get supportsIntegratedFind() {
     const support = FirefoxCom.requestSync("supportsIntegratedFind");
     return shadow(this, "supportsIntegratedFind", support);
-  },
+  }
 
-  get supportsDocumentFonts() {
+  static get supportsDocumentFonts() {
     const support = FirefoxCom.requestSync("supportsDocumentFonts");
     return shadow(this, "supportsDocumentFonts", support);
-  },
+  }
 
-  get supportsDocumentColors() {
+  static get supportsDocumentColors() {
     const support = FirefoxCom.requestSync("supportsDocumentColors");
     return shadow(this, "supportsDocumentColors", support);
-  },
+  }
 
-  get supportedMouseWheelZoomModifierKeys() {
+  static get supportedMouseWheelZoomModifierKeys() {
     const support = FirefoxCom.requestSync(
       "supportedMouseWheelZoomModifierKeys"
     );
     return shadow(this, "supportedMouseWheelZoomModifierKeys", support);
-  },
-};
+  }
+}
+PDFViewerApplication.externalServices = FirefoxExternalServices;
 
 // l10n.js for Firefox extension expects services to be set.
 document.mozL10n.setExternalLocalizerServices({

--- a/web/genericcom.js
+++ b/web/genericcom.js
@@ -37,16 +37,19 @@ class GenericPreferences extends BasePreferences {
   }
 }
 
-const GenericExternalServices = Object.create(DefaultExternalServices);
-GenericExternalServices.createDownloadManager = function(options) {
-  return new DownloadManager(options);
-};
-GenericExternalServices.createPreferences = function() {
-  return new GenericPreferences();
-};
-GenericExternalServices.createL10n = function({ locale = "en-US" }) {
-  return new GenericL10n(locale);
-};
+class GenericExternalServices extends DefaultExternalServices {
+  static createDownloadManager(options) {
+    return new DownloadManager(options);
+  }
+
+  static createPreferences() {
+    return new GenericPreferences();
+  }
+
+  static createL10n({ locale = "en-US" }) {
+    return new GenericL10n(locale);
+  }
+}
 PDFViewerApplication.externalServices = GenericExternalServices;
 
 export { GenericCom };


### PR DESCRIPTION
With https://bugzilla.mozilla.org/show_bug.cgi?id=844349 now being fixed in Firefox, the textLayer will now actually stay hidden as intended regardless of the browser settings.
Hence it should no longer be necessary to display the fallback bar, nor print a warning in the console, for documents which contains a textLayer.

Besides removing the `supportsDocumentColors` methods in the default viewer, we can also remove a now unused l10n string.

