### PR TITLE
Display the CSS tab in the interactive examples (issue 11506 follow-up)

### DIFF
--- a/docs/contents/examples/index.md
+++ b/docs/contents/examples/index.md
@@ -73,17 +73,17 @@ var scaledViewport = page.getViewport({ scale: scale, });
 The example demonstrates how promises can be used to handle errors during loading.
 It also demonstrates how to wait until page loaded and rendered.
 
-<script async src="//jsfiddle.net/pdfjs/9engc9mw/embed/js,html,result/"></script>
+<script async src="//jsfiddle.net/pdfjs/9engc9mw/embed/js,html,css,result/"></script>
 
 ### Hello World using base64 encoded PDF
 
 The PDF.js can accept any decoded base64 data as an array.
 
-<script async src="//jsfiddle.net/pdfjs/cq0asLqz/embed/js,html,result/"></script>
+<script async src="//jsfiddle.net/pdfjs/cq0asLqz/embed/js,html,css,result/"></script>
 
 ### Previous/Next example
 
 The same canvas cannot be used to perform to draw two pages at the same time --
 the example demonstrates how to wait on previous operation to be complete.
 
-<script async src="//jsfiddle.net/pdfjs/wagvs9Lf/embed/js,html,result/"></script>
+<script async src="//jsfiddle.net/pdfjs/wagvs9Lf/embed/js,html,css,result/"></script>


### PR DESCRIPTION
I just happened to notice that we've apparently never displayed the "CSS" tab [in the interactive examples](https://mozilla.github.io/pdf.js/examples/index.html#interactive-examples), which probably limits the number of users who'll notice the `direction: ltr;` CSS rule on the canvas :-)