### PR TITLE
Remove the "useOnlyCssZoom" (debugging) hash parameter

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -239,6 +239,7 @@ const PDFViewerApplication = {
   },
 
   /**
+   * Potentially parse special debugging flags in the hash section of the URL.
    * @private
    */
   async _parseHashParameters() {
@@ -249,11 +250,12 @@ const PDFViewerApplication = {
     ) {
       return undefined;
     }
-    const waitOn = [];
-
-    // Special debugging flags in the hash section of the URL.
     const hash = document.location.hash.substring(1);
-    const hashParams = parseQueryString(hash);
+    if (!hash) {
+      return undefined;
+    }
+    const hashParams = parseQueryString(hash),
+      waitOn = [];
 
     if (
       "disableworker" in hashParams &&

--- a/web/app.js
+++ b/web/app.js
@@ -287,9 +287,6 @@ const PDFViewerApplication = {
     if ("webgl" in hashParams) {
       AppOptions.set("enableWebGL", hashParams["webgl"] === "true");
     }
-    if ("useonlycsszoom" in hashParams) {
-      AppOptions.set("useOnlyCssZoom", hashParams["useonlycsszoom"] === "true");
-    }
     if ("verbosity" in hashParams) {
       AppOptions.set("verbosity", hashParams["verbosity"] | 0);
     }


### PR DESCRIPTION
The debugging hash parameters[1] are intended to facilitate access to various tools/settings in PRODUCTION builds, protected by the `pdfBugEnabled` preference.
At this point, the remaining debugging hash parameters are mainly intended to allow access to the `PDFBug` tools and/or to quickly toggle certain larger features.

The "useOnlyCssZoom" functionality doesn't really seem to fit in with the rest of these hash parameters, since:
 - This is, comparatively speaking, a minor viewer-specific feature.
 - The zooming implementation will (almost) always fallback to CSS-only zooming, for any document, once the canvases becomes large enough. Hence, the majority of the CSS zooming feature can still be tested *directly* in any build of the viewer.
 - After the initial implementation, years ago, the CSS-only zooming code in question hasn't changed much (or even at all), i.e. it doesn't seem like an active development target.[2]
 - If the "useOnlyCssZoom" functionality was added today, it's unlikely that a hash parameter would've been added.
 - Last, but not least, there's also a `useOnlyCssZoom` preference hence toggling this functionality shouldn't be too difficult (e.g. if someone needs to hack on it).

All in all, I'm thus suggesting that we remove the "useOnlyCssZoom" hash parameter.

---
[1] Originally these hash parameters could be used directly in any build, which was bad since it would allow any link to potentially disable functionality and/or reduce performance.

[2] If it had seen active development over the years, I'd be *much* more inclined to keep the hash parameter.

