### PR TITLE
Send the `verbosity` level when setting up fake workers (issue 11536)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1883,6 +1883,10 @@ const PDFWorker = (function PDFWorkerClosure() {
           const messageHandler = new MessageHandler(id, id + "_worker", port);
           this._messageHandler = messageHandler;
           this._readyCapability.resolve();
+          // Send global setting, e.g. verbosity level.
+          messageHandler.send("configure", {
+            verbosity: this.verbosity,
+          });
         })
         .catch(reason => {
           this._readyCapability.reject(


### PR DESCRIPTION
Interestingly the viewer already seem to work correctly as-is, with workers disabled and a non-standard `verbosity` level.
Hence this is possibly Node.js specific, but given that the issue is lacking *both* the PDF file in question and a runnable test-case, so this patch is essentially a best-effort guess at what the problem could be.

Fixes #11536