### PR TITLE
Fix text spacing with vertical fonts. #7687 and #11526.

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1719,7 +1719,12 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
           }
         }
 
-        var charWidth = width * widthAdvanceScale + spacing * fontDirection;
+        var charWidth;
+        if (vertical) {
+          charWidth = width * widthAdvanceScale - spacing * fontDirection;
+        } else {
+          charWidth = width * widthAdvanceScale + spacing * fontDirection;
+        }
         x += charWidth;
 
         if (restoreNeeded) {

--- a/test/pdfs/issue11526.pdf.link
+++ b/test/pdfs/issue11526.pdf.link
@@ -1,0 +1,1 @@
+https://web.archive.org/web/20200210200830/https://www.nta.go.jp/taxes/tetsuzuki/shinsei/shinkoku/zoyo/yoshiki2019/pdf/006.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -4376,5 +4376,13 @@
       "rounds": 1,
       "link": false,
       "type": "eq"
+    },
+    { "id": "issue11526",
+      "file": "pdfs/issue11526.pdf",
+      "md5": "9babc771fc8792f43e4ada46b0daff8c",
+      "rounds": 1,
+      "lastPage": 1,
+      "link": true,
+      "type": "eq"
     }
 ]


### PR DESCRIPTION
Fix text spacing with vertical fonts. #7687 and #11526.

Since we subtract here,
https://github.com/mozilla/pdf.js/blob/474fe1757e654e67d20a53774edb293aa073ce0b/src/display/canvas.js#L1729-L1731
when the writing mode is vertical, we have to reverse the sign of `spacing`.

I will reedit the commit message later.
