### PR TITLE
Make the `decodeHuffman` function, in `src/core/jpg.js`, slightly more efficient

### DIFF
--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -178,12 +178,13 @@ var JpegImage = (function JpegImageClosure() {
       var node = tree;
       while (true) {
         node = node[readBit()];
-        if (typeof node === "number") {
-          return node;
+        switch (typeof node) {
+          case "number":
+            return node;
+          case "object":
+            continue;
         }
-        if (typeof node !== "object") {
-          throw new JpegError("invalid huffman sequence");
-        }
+        throw new JpegError("invalid huffman sequence");
       }
     }
 


### PR DESCRIPTION
Rather than repeating the `typeof node` check twice, we can use a `switch` statement instead.

This patch was tested using the PDF file from issue #3809, i.e. https://web.archive.org/web/20140801150504/http://vs.twonky.dk/invitation.pdf, with the following manifest file:
```
[
    {  "id": "issue3809",
       "file": "../web/pdfs/issue3809.pdf",
       "md5": "",
       "rounds": 50,
       "type": "eq"
    }
]
```

which gave the following results when comparing this patch against the `master` branch:
```
-- Grouped By browser, stat --
browser | stat         | Count | Baseline(ms) | Current(ms) | +/- |    %  | Result(P<.05)
------- | ------------ | ----- | ------------ | ----------- | --- | ----- | -------------
Firefox | Overall      |    50 |        12537 |       12451 | -86 | -0.69 |        faster
Firefox | Page Request |    50 |            5 |           5 |   0 |  0.77 |
Firefox | Rendering    |    50 |        12532 |       12446 | -86 | -0.69 |        faster
```