### PR TITLE
Use the native `URL.createObjectURL` method in `web/debugger.js`

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -38,7 +38,6 @@ import {
 import { AppOptions, OptionKind } from "./app_options.js";
 import {
   build,
-  createObjectURL,
   getDocument,
   getFilenameFromUrl,
   GlobalWorkerOptions,
@@ -1784,13 +1783,7 @@ function loadAndEnablePDFBug(enabledTabs) {
   const appConfig = PDFViewerApplication.appConfig;
   return loadScript(appConfig.debuggerScriptPath).then(function() {
     PDFBug.enable(enabledTabs);
-    PDFBug.init(
-      {
-        OPS,
-        createObjectURL,
-      },
-      appConfig.mainContainer
-    );
+    PDFBug.init({ OPS }, appConfig.mainContainer);
   });
 }
 

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -17,7 +17,7 @@
 "use strict";
 
 var FontInspector = (function FontInspectorClosure() {
-  var fonts, createObjectURL;
+  var fonts;
   var active = false;
   var fontAttribute = "data-font-name";
   function removeSelection() {
@@ -75,8 +75,6 @@ var FontInspector = (function FontInspectorClosure() {
 
       fonts = document.createElement("div");
       panel.appendChild(fonts);
-
-      createObjectURL = pdfjsLib.createObjectURL;
     },
     cleanup: function cleanup() {
       fonts.textContent = "";
@@ -121,7 +119,9 @@ var FontInspector = (function FontInspectorClosure() {
         url = /url\(['"]?([^\)"']+)/.exec(url);
         download.href = url[1];
       } else if (fontObj.data) {
-        download.href = createObjectURL(fontObj.data, fontObj.mimeType);
+        download.href = URL.createObjectURL(
+          new Blob([fontObj.data], { type: fontObj.mimeType })
+        );
       }
       download.textContent = "Download";
       var logIt = document.createElement("a");


### PR DESCRIPTION
There's no particular reason for using the PDF.js helper function `createObjectURL`[1] in the debugger, instead of the native `URL.createObjectURL` directly, for a couple of reasons:
 - The relevant code-path only applies to fonts loaded with the Font Loading API, and this isn't supported in IE anyway.
 - The debugger can, since quite some time, not even be loaded in IE any more.
 - General support for IE is now limited, and there's no guaratee that everything actually works.

---
[1] It provides a fallback for browsers with broken `Blob` support, which as usual means Internet Explorer :-P