### PR TITLE
Fix the indices of arguments for RadialAxial. It is related to #10646.

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -1118,13 +1118,13 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       switch (args[0]) {
         case "RadialAxial":
           const shadingId = `shading${shadingCount++}`;
-          const colorStops = args[2];
+          const colorStops = args[3];
           let gradient;
 
           switch (args[1]) {
             case "axial":
-              const point0 = args[3];
-              const point1 = args[4];
+              const point0 = args[4];
+              const point1 = args[5];
               gradient = this.svgFactory.createElement("svg:linearGradient");
               gradient.setAttributeNS(null, "id", shadingId);
               gradient.setAttributeNS(null, "gradientUnits", "userSpaceOnUse");
@@ -1134,10 +1134,10 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
               gradient.setAttributeNS(null, "y2", point1[1]);
               break;
             case "radial":
-              const focalPoint = args[3];
-              const circlePoint = args[4];
-              const focalRadius = args[5];
-              const circleRadius = args[6];
+              const focalPoint = args[4];
+              const circlePoint = args[5];
+              const focalRadius = args[6];
+              const circleRadius = args[7];
               gradient = this.svgFactory.createElement("svg:radialGradient");
               gradient.setAttributeNS(null, "id", shadingId);
               gradient.setAttributeNS(null, "gradientUnits", "userSpaceOnUse");


### PR DESCRIPTION
Fix the indices of arguments for the shading pattern of `RadialAxial` with SVG backend. It is related to #10646. 

Load http://warp.da.ndl.go.jp/info:ndljp/pid/10205551/www.city.niigata.lg.jp/shisei/koho/kohoshi/shiho/backnumber/h25/shiho0217/pdf/0217_P1.pdf with SVG backend. Then we can see the following error in the console.

```
Uncaught (in promise) TypeError: object null is not iterable (cannot read property Symbol(Symbol.iterator)) (svg.js:1199)
    at SVGGraphics._makeShadingPattern (svg.js:1199)
    at SVGGraphics.shadingFill (svg.js:1073)
    at SVGGraphics.executeOpTree (svg.js:647)
    at SVGGraphics.group (svg.js:472)
    at SVGGraphics.executeOpTree (svg.js:728)
    at SVGGraphics.group (svg.js:472)
    at SVGGraphics.executeOpTree (svg.js:728)
    at eval (svg.js:540)
```

With this PR, the shading patterns are rendered well.

![スクリーンショット 2020-01-29 19 31 24](https://user-images.githubusercontent.com/10665499/73349137-fe46c080-42cd-11ea-8e94-78d0678bace8.png)


