### PR TITLE
Fix the horizontal scaling of texts with SVG backend. #10988

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -823,7 +823,7 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
           // might actually map to a different glyph.
           continue;
         }
-        current.xcoords.push(current.x + x * textHScale);
+        current.xcoords.push(current.x + x);
         current.tspan.textContent += character;
         x += charWidth;
       }
@@ -892,7 +892,7 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       current.txtElement.setAttributeNS(
         null,
         "transform",
-        `${pm(textMatrix)} scale(1, -1)`
+        `${pm(textMatrix)} scale(${pf(textHScale)}, -1)`
       );
       current.txtElement.setAttributeNS(XML_NS, "xml:space", "preserve");
       current.txtElement.appendChild(current.tspan);


### PR DESCRIPTION
Fix the horizontal scaling of texts with SVG backend. #10988.

In the same way as `src/display/canvas.js`.

https://github.com/mozilla/pdf.js/blob/517ccb7a394148942616433d49782cc8126a49fe/src/display/canvas.js#L1624


![スクリーンショット 2020-01-31 7 08 51](https://user-images.githubusercontent.com/10665499/73494937-def88200-43f8-11ea-91ea-ded73b36e091.png)
