### PR TITLE
Fix the vertical writing mode with horizontal scaling. #11555.

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1732,7 +1732,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         }
       }
       if (vertical) {
-        current.y -= x * textHScale;
+        current.y -= x;
       } else {
         current.x += x * textHScale;
       }

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -366,3 +366,4 @@
 !issue9972-3.pdf
 !tiling-pattern-box.pdf
 !tiling-pattern-large-steps.pdf
+!issue11555.pdf

--- a/test/pdfs/issue11555.pdf
+++ b/test/pdfs/issue11555.pdf
@@ -1,0 +1,100 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/Type /Catalog
+/Pages 2 0 R
+>>
+endobj 
+2 0 obj 
+<<
+/Kids [3 0 R]
+/Type /Pages
+/Count 1
+>>
+endobj 
+4 0 obj 
+<<
+/Font 
+<<
+/F0 
+<<
+/Subtype /Type0
+/Type /Font
+/BaseFont /KozMinPro6N-Regular
+/Encoding /90ms-RKSJ-V
+/DescendantFonts [5 0 R]
+>>
+>>
+>>
+endobj 
+3 0 obj 
+<<
+/Contents 6 0 R
+/Type /Page
+/Resources 4 0 R
+/Parent 2 0 R
+/MediaBox [0 0 595 842]
+>>
+endobj 
+6 0 obj 
+<<
+/Length 104
+>>
+stream
+1. 0. 0. 1. 50. 770. cm
+BT
+/F0 36 Tf
+40 TL
+50 Tz
+<6162632082a082a282a4> Tj
+<6162632082a082a282a4> Tj
+ET
+
+endstream 
+endobj 
+5 0 obj 
+<<
+/Subtype /CIDFontType0
+/CIDSystemInfo 
+<<
+/Supplement 6
+/Registry (Adobe)
+/Ordering (Japan1)
+>>
+/Type /Font
+/BaseFont /KozMinPr6N-Regular
+/FontDescriptor 7 0 R
+>>
+endobj 
+7 0 obj 
+<<
+/Descent -349
+/CapHeight 742
+/StemV 80
+/Type /FontDescriptor
+/Flags 4
+/FontName /KozMinPr6N-Regular
+/FontBBox [-437 -340 1147 1317]
+/ItalicAngle 0
+/Ascent 1317
+>>
+endobj xref
+0 8
+0000000000 65535 f 
+0000000015 00000 n 
+0000000066 00000 n 
+0000000279 00000 n 
+0000000125 00000 n 
+0000000543 00000 n 
+0000000385 00000 n 
+0000000726 00000 n 
+trailer
+
+<<
+/Root 1 0 R
+/Size 8
+>>
+startxref
+908
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -4384,5 +4384,11 @@
       "lastPage": 1,
       "link": true,
       "type": "eq"
-    }
+    },
+    {  "id": "issue11555",
+      "file": "pdfs/issue11555.pdf",
+      "md5": "f84ce8b7414f6a18e75a6ce69c902501",
+      "rounds": 1,
+      "type": "eq"
+   }
 ]


### PR DESCRIPTION
Fix the vertical writing mode with horizontal scaling. #11555.
It is not valid to multiply `textHScale` when the writing mode is vertical.

See 9.4.4 Text Space Details, https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#G8.1694762