### PR TITLE
Fix how curveTo2 (v operator) is translated to SVG

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -1231,8 +1231,6 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
             j += 6;
             break;
           case OPS.curveTo2:
-            x = args[j + 2];
-            y = args[j + 3];
             d.push(
               "C",
               pf(x),
@@ -1242,6 +1240,8 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
               pf(args[j + 2]),
               pf(args[j + 3])
             );
+            x = args[j + 2];
+            y = args[j + 3];
             j += 4;
             break;
           case OPS.curveTo3:


### PR DESCRIPTION
Based on [PDF spec](https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/PDF32000_2008.pdf), page 133, with `v` operator, current point should be used as the first control point of the curve.

Do not overwrite current point before an SVG curve is built, so it can be actually used as first control point.
