### PR TITLE
Enable the ESLint `no-shadow` rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -119,8 +119,8 @@
     "no-catch-shadow": "error",
     "no-delete-var": "error",
     "no-label-var": "error",
+    "no-shadow": "error",
     "no-shadow-restricted-names": "error",
-    "no-shadow": "off",
     "no-undef-init": "error",
     "no-undef": ["error", { "typeof": true, }],
     "no-unused-vars": ["error", {

--- a/external/builder/preprocessor2.js
+++ b/external/builder/preprocessor2.js
@@ -289,7 +289,7 @@ function traverseTree(ctx, node) {
   for (var i in node) {
     var child = node[i];
     if (typeof child === "object" && child !== null && child.type) {
-      var result = traverseTree(ctx, child);
+      const result = traverseTree(ctx, child);
       if (result !== child) {
         node[i] = result;
       }
@@ -300,7 +300,7 @@ function traverseTree(ctx, node) {
           childItem !== null &&
           childItem.type
         ) {
-          var result = traverseTree(ctx, childItem);
+          const result = traverseTree(ctx, childItem);
           if (result !== childItem) {
             child[index] = result;
           }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -167,8 +167,6 @@ function createStringSource(filename, content) {
 }
 
 function createWebpackConfig(defines, output) {
-  var path = require("path");
-
   var versionInfo = getVersionJSON();
   var bundleDefines = builder.merge(defines, {
     BUNDLE_VERSION: versionInfo.version,
@@ -243,9 +241,9 @@ function createWebpackConfig(defines, output) {
   };
 }
 
-function webpack2Stream(config) {
+function webpack2Stream(webpackConfig) {
   // Replacing webpack1 to webpack2 in the webpack-stream.
-  return webpackStream(config, webpack2);
+  return webpackStream(webpackConfig, webpack2);
 }
 
 function getVersionJSON() {
@@ -378,26 +376,26 @@ function createImageDecodersBundle(defines) {
     .pipe(replaceJSRootName(imageDecodersAMDName, "pdfjsImageDecoders"));
 }
 
-function checkFile(path) {
+function checkFile(filePath) {
   try {
-    var stat = fs.lstatSync(path);
+    var stat = fs.lstatSync(filePath);
     return stat.isFile();
   } catch (e) {
     return false;
   }
 }
 
-function checkDir(path) {
+function checkDir(dirPath) {
   try {
-    var stat = fs.lstatSync(path);
+    var stat = fs.lstatSync(dirPath);
     return stat.isDirectory();
   } catch (e) {
     return false;
   }
 }
 
-function replaceInFile(path, find, replacement) {
-  var content = fs.readFileSync(path).toString();
+function replaceInFile(filePath, find, replacement) {
+  var content = fs.readFileSync(filePath).toString();
   content = content.replace(find, replacement);
   fs.writeFileSync(path, content);
 }
@@ -407,9 +405,9 @@ function getTempFile(prefix, suffix) {
   var bytes = require("crypto")
     .randomBytes(6)
     .toString("hex");
-  var path = BUILD_DIR + "tmp/" + prefix + bytes + suffix;
-  fs.writeFileSync(path, "");
-  return path;
+  var filePath = BUILD_DIR + "tmp/" + prefix + bytes + suffix;
+  fs.writeFileSync(filePath, "");
+  return filePath;
 }
 
 function createTestSource(testsName, bot) {
@@ -527,10 +525,10 @@ gulp.task("buildnumber", function(done) {
 
     var version = config.versionPrefix + buildNumber;
 
-    exec('git log --format="%h" -n 1', function(err, stdout, stderr) {
+    exec('git log --format="%h" -n 1', function(err2, stdout2, stderr2) {
       var buildCommit = "";
-      if (!err) {
-        buildCommit = stdout.replace("\n", "");
+      if (!err2) {
+        buildCommit = stdout2.replace("\n", "");
       }
 
       createStringSource(
@@ -559,9 +557,9 @@ gulp.task("default_preferences-pre", function() {
   function babelPluginReplaceNonWebPackRequire(babel) {
     return {
       visitor: {
-        Identifier(path, state) {
-          if (path.node.name === "__non_webpack_require__") {
-            path.replaceWith(babel.types.identifier("require"));
+        Identifier(curPath, state) {
+          if (curPath.node.name === "__non_webpack_require__") {
+            curPath.replaceWith(babel.types.identifier("require"));
           }
         },
       },
@@ -643,8 +641,8 @@ gulp.task("locale", function() {
   var locales = [];
   for (var i = 0; i < subfolders.length; i++) {
     var locale = subfolders[i];
-    var path = L10N_DIR + locale;
-    if (!checkDir(path)) {
+    var dirPath = L10N_DIR + locale;
+    if (!checkDir(dirPath)) {
       continue;
     }
     if (!/^[a-z][a-z]([a-z])?(-[A-Z][A-Z])?$/.test(locale)) {
@@ -656,7 +654,7 @@ gulp.task("locale", function() {
 
     locales.push(locale);
 
-    if (checkFile(path + "/viewer.properties")) {
+    if (checkFile(dirPath + "/viewer.properties")) {
       viewerOutput +=
         "[" +
         locale +
@@ -1163,9 +1161,9 @@ gulp.task(
     function babelPluginReplaceNonWebPackRequire(babel) {
       return {
         visitor: {
-          Identifier(path, state) {
-            if (path.node.name === "__non_webpack_require__") {
-              path.replaceWith(babel.types.identifier("require"));
+          Identifier(curPath, state) {
+            if (curPath.node.name === "__non_webpack_require__") {
+              curPath.replaceWith(babel.types.identifier("require"));
             }
           },
         },
@@ -1358,9 +1356,9 @@ gulp.task("baseline", function(done) {
     }
 
     exec("git checkout " + baselineCommit, { cwd: workingDirectory }, function(
-      error
+      error2
     ) {
-      if (error) {
+      if (error2) {
         done(new Error("Baseline commit checkout failed."));
         return;
       }

--- a/src/core/ccitt.js
+++ b/src/core/ccitt.js
@@ -465,6 +465,7 @@ const CCITTFaxDecoder = (function CCITTFaxDecoder() {
    * @param {CCITTFaxDecoderSource} source - The data which should be decoded.
    * @param {Object} [options] - Decoding options.
    */
+  // eslint-disable-next-line no-shadow
   function CCITTFaxDecoder(source, options = {}) {
     if (!source || typeof source.next !== "function") {
       throw new Error('CCITTFaxDecoder - invalid "source" parameter.');

--- a/src/core/ccitt_stream.js
+++ b/src/core/ccitt_stream.js
@@ -18,6 +18,7 @@ import { CCITTFaxDecoder } from "./ccitt.js";
 import { DecodeStream } from "./stream.js";
 
 var CCITTFaxStream = (function CCITTFaxStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function CCITTFaxStream(str, maybeLength, params) {
     this.str = str;
     this.dict = str.dict;

--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -217,6 +217,7 @@ var CFFParser = (function CFFParserClosure() {
     { id: "flex1", min: 11, resetStack: true },
   ];
 
+  // eslint-disable-next-line no-shadow
   function CFFParser(file, properties, seacAnalysisEnabled) {
     this.bytes = file.getBytes();
     this.properties = properties;
@@ -964,6 +965,7 @@ var CFFParser = (function CFFParserClosure() {
 
 // Compact Font Format
 var CFF = (function CFFClosure() {
+  // eslint-disable-next-line no-shadow
   function CFF() {
     this.header = null;
     this.names = [];
@@ -1009,6 +1011,7 @@ var CFF = (function CFFClosure() {
 })();
 
 var CFFHeader = (function CFFHeaderClosure() {
+  // eslint-disable-next-line no-shadow
   function CFFHeader(major, minor, hdrSize, offSize) {
     this.major = major;
     this.minor = minor;
@@ -1019,6 +1022,7 @@ var CFFHeader = (function CFFHeaderClosure() {
 })();
 
 var CFFStrings = (function CFFStringsClosure() {
+  // eslint-disable-next-line no-shadow
   function CFFStrings() {
     this.strings = [];
   }
@@ -1054,6 +1058,7 @@ var CFFStrings = (function CFFStringsClosure() {
 })();
 
 var CFFIndex = (function CFFIndexClosure() {
+  // eslint-disable-next-line no-shadow
   function CFFIndex() {
     this.objects = [];
     this.length = 0;
@@ -1078,6 +1083,7 @@ var CFFIndex = (function CFFIndexClosure() {
 })();
 
 var CFFDict = (function CFFDictClosure() {
+  // eslint-disable-next-line no-shadow
   function CFFDict(tables, strings) {
     this.keyToNameMap = tables.keyToNameMap;
     this.nameToKeyMap = tables.nameToKeyMap;
@@ -1205,6 +1211,8 @@ var CFFTopDict = (function CFFTopDictClosure() {
     [[12, 38], "FontName", "sid", null],
   ];
   var tables = null;
+
+  // eslint-disable-next-line no-shadow
   function CFFTopDict(strings) {
     if (tables === null) {
       tables = CFFDict.createTables(layout);
@@ -1238,6 +1246,8 @@ var CFFPrivateDict = (function CFFPrivateDictClosure() {
     [19, "Subrs", "offset", null],
   ];
   var tables = null;
+
+  // eslint-disable-next-line no-shadow
   function CFFPrivateDict(strings) {
     if (tables === null) {
       tables = CFFDict.createTables(layout);
@@ -1255,6 +1265,7 @@ var CFFCharsetPredefinedTypes = {
   EXPERT_SUBSET: 2,
 };
 var CFFCharset = (function CFFCharsetClosure() {
+  // eslint-disable-next-line no-shadow
   function CFFCharset(predefined, format, charset, raw) {
     this.predefined = predefined;
     this.format = format;
@@ -1265,6 +1276,7 @@ var CFFCharset = (function CFFCharsetClosure() {
 })();
 
 var CFFEncoding = (function CFFEncodingClosure() {
+  // eslint-disable-next-line no-shadow
   function CFFEncoding(predefined, format, encoding, raw) {
     this.predefined = predefined;
     this.format = format;
@@ -1275,6 +1287,7 @@ var CFFEncoding = (function CFFEncodingClosure() {
 })();
 
 var CFFFDSelect = (function CFFFDSelectClosure() {
+  // eslint-disable-next-line no-shadow
   function CFFFDSelect(format, fdSelect) {
     this.format = format;
     this.fdSelect = fdSelect;
@@ -1293,6 +1306,7 @@ var CFFFDSelect = (function CFFFDSelectClosure() {
 // Helper class to keep track of where an offset is within the data and helps
 // filling in that offset once it's known.
 var CFFOffsetTracker = (function CFFOffsetTrackerClosure() {
+  // eslint-disable-next-line no-shadow
   function CFFOffsetTracker() {
     this.offsets = Object.create(null);
   }
@@ -1352,6 +1366,7 @@ var CFFOffsetTracker = (function CFFOffsetTrackerClosure() {
 
 // Takes a CFF and converts it to the binary representation.
 var CFFCompiler = (function CFFCompilerClosure() {
+  // eslint-disable-next-line no-shadow
   function CFFCompiler(cff) {
     this.cff = cff;
   }

--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -519,15 +519,15 @@ class ChunkedStreamManager {
     }
 
     const loadedRequests = [];
-    for (let chunk = beginChunk; chunk < endChunk; ++chunk) {
+    for (let curChunk = beginChunk; curChunk < endChunk; ++curChunk) {
       // The server might return more chunks than requested.
-      const requestIds = this.requestsByChunk[chunk] || [];
-      delete this.requestsByChunk[chunk];
+      const requestIds = this.requestsByChunk[curChunk] || [];
+      delete this.requestsByChunk[curChunk];
 
       for (const requestId of requestIds) {
         const chunksNeeded = this.chunksNeededByRequest[requestId];
-        if (chunk in chunksNeeded) {
-          delete chunksNeeded[chunk];
+        if (curChunk in chunksNeeded) {
+          delete chunksNeeded[curChunk];
         }
 
         if (!isEmptyObj(chunksNeeded)) {

--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -713,6 +713,7 @@ var BinaryCMapReader = (function BinaryCMapReaderClosure() {
     });
   }
 
+  // eslint-disable-next-line no-shadow
   function BinaryCMapReader() {}
 
   BinaryCMapReader.prototype = {

--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -836,6 +836,7 @@ const DeviceCmykCS = (function DeviceCmykCSClosure() {
       k * (-22.33816807309886 * k - 180.12613974708367);
   }
 
+  // eslint-disable-next-line no-shadow
   class DeviceCmykCS extends ColorSpace {
     constructor() {
       super("DeviceCMYK", 4);
@@ -902,6 +903,7 @@ const CalGrayCS = (function CalGrayCSClosure() {
     dest[destOffset + 2] = val;
   }
 
+  // eslint-disable-next-line no-shadow
   class CalGrayCS extends ColorSpace {
     constructor(whitePoint, blackPoint, gamma) {
       super("CalGray", 1);
@@ -1190,6 +1192,7 @@ const CalRGBCS = (function CalRGBCSClosure() {
     dest[destOffset + 2] = sRGBTransferFunction(SRGB[2]) * 255;
   }
 
+  // eslint-disable-next-line no-shadow
   class CalRGBCS extends ColorSpace {
     constructor(whitePoint, blackPoint, gamma, matrix) {
       super("CalRGB", 3);
@@ -1371,6 +1374,7 @@ const LabCS = (function LabCSClosure() {
     dest[destOffset + 2] = Math.sqrt(b) * 255;
   }
 
+  // eslint-disable-next-line no-shadow
   class LabCS extends ColorSpace {
     constructor(whitePoint, blackPoint, range) {
       super("Lab", 3);

--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -161,7 +161,7 @@ function readUint32(data, offset) {
 }
 
 // Checks if ch is one of the following characters: SPACE, TAB, CR or LF.
-function isSpace(ch) {
+function isWhiteSpace(ch) {
   return ch === 0x20 || ch === 0x09 || ch === 0x0d || ch === 0x0a;
 }
 
@@ -176,5 +176,5 @@ export {
   readInt8,
   readUint16,
   readUint32,
-  isSpace,
+  isWhiteSpace,
 };

--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -27,6 +27,7 @@ import { isDict, isName, Name } from "./primitives.js";
 import { DecryptStream } from "./stream.js";
 
 var ARCFourCipher = (function ARCFourCipherClosure() {
+  // eslint-disable-next-line no-shadow
   function ARCFourCipher(key) {
     this.a = 0;
     this.b = 0;
@@ -177,6 +178,7 @@ var calculateMD5 = (function calculateMD5Closure() {
   return hash;
 })();
 var Word64 = (function Word64Closure() {
+  // eslint-disable-next-line no-shadow
   function Word64(highInteger, lowInteger) {
     this.high = highInteger | 0;
     this.low = lowInteger | 0;
@@ -690,6 +692,7 @@ var calculateSHA384 = (function calculateSHA384Closure() {
   return hash;
 })();
 var NullCipher = (function NullCipherClosure() {
+  // eslint-disable-next-line no-shadow
   function NullCipher() {}
 
   NullCipher.prototype = {
@@ -1265,6 +1268,7 @@ var PDF17 = (function PDF17Closure() {
     return true;
   }
 
+  // eslint-disable-next-line no-shadow
   function PDF17() {}
 
   PDF17.prototype = {
@@ -1372,6 +1376,7 @@ var PDF20 = (function PDF20Closure() {
     return k.subarray(0, 32);
   }
 
+  // eslint-disable-next-line no-shadow
   function PDF20() {}
 
   function compareByteArrays(array1, array2) {
@@ -1446,6 +1451,7 @@ var PDF20 = (function PDF20Closure() {
 })();
 
 var CipherTransform = (function CipherTransformClosure() {
+  // eslint-disable-next-line no-shadow
   function CipherTransform(stringCipherConstructor, streamCipherConstructor) {
     this.StringCipherConstructor = stringCipherConstructor;
     this.StreamCipherConstructor = streamCipherConstructor;
@@ -1661,6 +1667,7 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
 
   var identityName = Name.get("Identity");
 
+  // eslint-disable-next-line no-shadow
   function CipherTransformFactory(dict, fileId, password) {
     var filter = dict.get("Filter");
     if (!isName(filter, "Standard")) {

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -216,8 +216,8 @@ class Page {
       // Fetching the individual streams from the array.
       const xref = this.xref;
       const streams = [];
-      for (const stream of content) {
-        streams.push(xref.fetchIfRef(stream));
+      for (const subStream of content) {
+        streams.push(xref.fetchIfRef(subStream));
       }
       stream = new StreamsSequenceStream(streams);
     } else if (isStream(content)) {

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -42,7 +42,7 @@ import {
 } from "./primitives.js";
 import {
   getInheritableProperty,
-  isSpace,
+  isWhiteSpace,
   MissingDataException,
   XRefEntryException,
   XRefParseException,
@@ -598,7 +598,7 @@ class PDFDocument {
         let ch;
         do {
           ch = stream.getByte();
-        } while (isSpace(ch));
+        } while (isWhiteSpace(ch));
         let str = "";
         while (ch >= /* Space = */ 0x20 && ch <= /* '9' = */ 0x39) {
           str += String.fromCharCode(ch);

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -630,7 +630,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         pdfFunctionFactory: this.pdfFunctionFactory,
       })
         .then(imageObj => {
-          var imgData = imageObj.createImageData(/* forceRGBA = */ false);
+          imgData = imageObj.createImageData(/* forceRGBA = */ false);
 
           if (this.parsingType3Font) {
             return this.handler.sendWithPromise(
@@ -2480,16 +2480,16 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       properties.hasEncoding = !!baseEncodingName || differences.length > 0;
       properties.dict = dict;
       return toUnicodePromise
-        .then(toUnicode => {
-          properties.toUnicode = toUnicode;
+        .then(readToUnicode => {
+          properties.toUnicode = readToUnicode;
           return this.buildToUnicode(properties);
         })
-        .then(toUnicode => {
-          properties.toUnicode = toUnicode;
+        .then(builtToUnicode => {
+          properties.toUnicode = builtToUnicode;
           if (cidToGidBytes) {
             properties.cidToGidMap = this.readCidToGidMap(
               cidToGidBytes,
-              toUnicode
+              builtToUnicode
             );
           }
           return properties;
@@ -3093,21 +3093,21 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           };
           const widths = dict.get("Widths");
           return this.extractDataStructures(dict, dict, properties).then(
-            properties => {
+            newProperties => {
               if (widths) {
                 const glyphWidths = [];
                 let j = firstChar;
                 for (let i = 0, ii = widths.length; i < ii; i++) {
                   glyphWidths[j++] = this.xref.fetchIfRef(widths[i]);
                 }
-                properties.widths = glyphWidths;
+                newProperties.widths = glyphWidths;
               } else {
-                properties.widths = this.buildCharCodeToWidth(
+                newProperties.widths = this.buildCharCodeToWidth(
                   metrics.widths,
-                  properties
+                  newProperties
                 );
               }
-              return new Font(baseFontName, null, properties);
+              return new Font(baseFontName, null, newProperties);
             }
           );
         }
@@ -3214,13 +3214,13 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         .then(() => {
           return this.extractDataStructures(dict, baseDict, properties);
         })
-        .then(properties => {
-          this.extractWidths(dict, descriptor, properties);
+        .then(newProperties => {
+          this.extractWidths(dict, descriptor, newProperties);
 
           if (type === "Type3") {
-            properties.isType3Font = true;
+            newProperties.isType3Font = true;
           }
-          return new Font(fontName.name, fontFile, properties);
+          return new Font(fontName.name, fontFile, newProperties);
         });
     },
   };
@@ -3355,8 +3355,8 @@ var TranslatedFont = (function TranslatedFontClosure() {
             })
             .catch(function(reason) {
               warn(`Type3 font resource "${key}" is not available.`);
-              var operatorList = new OperatorList();
-              charProcOperatorList[key] = operatorList.getIR();
+              const dummyOperatorList = new OperatorList();
+              charProcOperatorList[key] = dummyOperatorList.getIR();
             });
         });
       }

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -96,6 +96,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     isEvalSupported: true,
   };
 
+  // eslint-disable-next-line no-shadow
   function PartialEvaluator({
     xref,
     handler,
@@ -3267,6 +3268,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 })();
 
 var TranslatedFont = (function TranslatedFontClosure() {
+  // eslint-disable-next-line no-shadow
   function TranslatedFont(loadedName, font, dict) {
     this.loadedName = loadedName;
     this.font = font;
@@ -3368,6 +3370,7 @@ var TranslatedFont = (function TranslatedFontClosure() {
 })();
 
 var StateManager = (function StateManagerClosure() {
+  // eslint-disable-next-line no-shadow
   function StateManager(initialState) {
     this.state = initialState;
     this.stateStack = [];
@@ -3392,6 +3395,7 @@ var StateManager = (function StateManagerClosure() {
 })();
 
 var TextState = (function TextStateClosure() {
+  // eslint-disable-next-line no-shadow
   function TextState() {
     this.ctm = new Float32Array(IDENTITY_MATRIX);
     this.fontName = null;
@@ -3497,6 +3501,7 @@ var TextState = (function TextStateClosure() {
 })();
 
 var EvalState = (function EvalStateClosure() {
+  // eslint-disable-next-line no-shadow
   function EvalState() {
     this.ctm = new Float32Array(IDENTITY_MATRIX);
     this.font = null;
@@ -3638,6 +3643,7 @@ var EvaluatorPreprocessor = (function EvaluatorPreprocessorClosure() {
 
   const MAX_INVALID_PATH_OPS = 20;
 
+  // eslint-disable-next-line no-shadow
   function EvaluatorPreprocessor(stream, xref, stateManager) {
     this.opMap = getOPMap();
     // TODO(mduan): pass array of knownCommands rather than this.opMap

--- a/src/core/font_renderer.js
+++ b/src/core/font_renderer.js
@@ -345,12 +345,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
     }
   }
 
-  function compileCharString(code, cmds, font, glyphId) {
-    var stack = [];
-    var x = 0,
-      y = 0;
-    var stems = 0;
-
+  function compileCharString(charStringCode, cmds, font, glyphId) {
     function moveTo(x, y) {
       cmds.push({ cmd: "moveTo", args: [x, y] });
     }
@@ -360,6 +355,11 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
     function bezierCurveTo(x1, y1, x2, y2, x, y) {
       cmds.push({ cmd: "bezierCurveTo", args: [x1, y1, x2, y2, x, y] });
     }
+
+    var stack = [];
+    var x = 0,
+      y = 0;
+    var stems = 0;
 
     function parse(code) {
       var i = 0;
@@ -719,7 +719,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
         }
       }
     }
-    parse(code);
+    parse(charStringCode);
   }
 
   const NOOP = [];

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -58,7 +58,11 @@ import {
   getUnicodeRangeFor,
   mapSpecialUnicodeValues,
 } from "./unicode.js";
-import { isSpace, MissingDataException, readUint32 } from "./core_utils.js";
+import {
+  isWhiteSpace,
+  MissingDataException,
+  readUint32,
+} from "./core_utils.js";
 import { FontRendererFactory } from "./font_renderer.js";
 import { IdentityCMap } from "./cmap.js";
 import { Stream } from "./stream.js";
@@ -3413,7 +3417,7 @@ var Type1Font = (function Type1FontClosure() {
       if (j >= signatureLength) {
         // `signature` found, skip over whitespace.
         i += j;
-        while (i < streamBytesLength && isSpace(streamBytes[i])) {
+        while (i < streamBytesLength && isWhiteSpace(streamBytes[i])) {
           i++;
         }
         found = true;

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -222,6 +222,7 @@ function recoverGlyphName(name, glyphsUnicodeMap) {
 }
 
 var Glyph = (function GlyphClosure() {
+  // eslint-disable-next-line no-shadow
   function Glyph(
     fontChar,
     unicode,
@@ -268,6 +269,7 @@ var Glyph = (function GlyphClosure() {
 })();
 
 var ToUnicodeMap = (function ToUnicodeMapClosure() {
+  // eslint-disable-next-line no-shadow
   function ToUnicodeMap(cmap = []) {
     // The elements of this._map can be integers or strings, depending on how
     // `cmap` was created.
@@ -319,6 +321,7 @@ var ToUnicodeMap = (function ToUnicodeMapClosure() {
 })();
 
 var IdentityToUnicodeMap = (function IdentityToUnicodeMapClosure() {
+  // eslint-disable-next-line no-shadow
   function IdentityToUnicodeMap(firstChar, lastChar) {
     this.firstChar = firstChar;
     this.lastChar = lastChar;
@@ -389,6 +392,7 @@ var OpenTypeFileBuilder = (function OpenTypeFileBuilderClosure() {
     }
   }
 
+  // eslint-disable-next-line no-shadow
   function OpenTypeFileBuilder(sfnt) {
     this.sfnt = sfnt;
     this.tables = Object.create(null);
@@ -512,6 +516,7 @@ var OpenTypeFileBuilder = (function OpenTypeFileBuilderClosure() {
  *   type1Font.bind();
  */
 var Font = (function FontClosure() {
+  // eslint-disable-next-line no-shadow
   function Font(name, file, properties) {
     var charCode;
 
@@ -3308,6 +3313,7 @@ var Font = (function FontClosure() {
 })();
 
 var ErrorFont = (function ErrorFontClosure() {
+  // eslint-disable-next-line no-shadow
   function ErrorFont(error) {
     this.error = error;
     this.loadedName = "g_font_error";
@@ -3521,6 +3527,7 @@ var Type1Font = (function Type1FontClosure() {
     };
   }
 
+  // eslint-disable-next-line no-shadow
   function Type1Font(name, file, properties) {
     // Some bad generators embed pfb file as is, we have to strip 6-byte header.
     // Also, length1 and length2 might be off by 6 bytes as well.
@@ -3787,6 +3794,7 @@ var Type1Font = (function Type1FontClosure() {
 })();
 
 var CFFFont = (function CFFFontClosure() {
+  // eslint-disable-next-line no-shadow
   function CFFFont(file, properties) {
     this.properties = properties;
 

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -1275,7 +1275,6 @@ var Font = (function FontClosure() {
 
     fallbackToSystemFont: function Font_fallbackToSystemFont() {
       this.missingFile = true;
-      var charCode, unicode;
       // The file data is not specified. Trying to fix the font name
       // to be used with the canvas.font.
       var name = this.name;
@@ -1309,17 +1308,17 @@ var Font = (function FontClosure() {
         // Standard fonts might be embedded as CID font without glyph mapping.
         // Building one based on GlyphMapForStandardFonts.
         const map = [];
-        for (charCode in GlyphMapForStandardFonts) {
+        for (const charCode in GlyphMapForStandardFonts) {
           map[+charCode] = GlyphMapForStandardFonts[charCode];
         }
         if (/Arial-?Black/i.test(name)) {
           var SupplementalGlyphMapForArialBlack = getSupplementalGlyphMapForArialBlack();
-          for (charCode in SupplementalGlyphMapForArialBlack) {
+          for (const charCode in SupplementalGlyphMapForArialBlack) {
             map[+charCode] = SupplementalGlyphMapForArialBlack[charCode];
           }
         } else if (/Calibri/i.test(name)) {
           const SupplementalGlyphMapForCalibri = getSupplementalGlyphMapForCalibri();
-          for (charCode in SupplementalGlyphMapForCalibri) {
+          for (const charCode in SupplementalGlyphMapForCalibri) {
             map[+charCode] = SupplementalGlyphMapForCalibri[charCode];
           }
         }
@@ -1360,7 +1359,7 @@ var Font = (function FontClosure() {
           if (!this.composite) {
             var glyphName =
               this.differences[charCode] || this.defaultEncoding[charCode];
-            unicode = getUnicodeForGlyph(glyphName, glyphsUnicodeMap);
+            const unicode = getUnicodeForGlyph(glyphName, glyphsUnicodeMap);
             if (unicode !== -1) {
               unicodeCharCode = unicode;
             }
@@ -1374,7 +1373,7 @@ var Font = (function FontClosure() {
           if (/Verdana/i.test(name)) {
             // Fixes issue11242_reduced.pdf
             const GlyphMapForStandardFonts = getGlyphMapForStandardFonts();
-            for (charCode in GlyphMapForStandardFonts) {
+            for (const charCode in GlyphMapForStandardFonts) {
               map[+charCode] = GlyphMapForStandardFonts[charCode];
             }
           }
@@ -1415,7 +1414,7 @@ var Font = (function FontClosure() {
         tables["post"] = null;
 
         for (let i = 0; i < numTables; i++) {
-          const table = readTableEntry(font);
+          const table = readTableEntry(file);
           if (!VALID_TABLES.includes(table.tag)) {
             continue; // skipping table if it's not a required or optional table
           }
@@ -1535,7 +1534,7 @@ var Font = (function FontClosure() {
        * Read the appropriate subtable from the cmap according to 9.6.6.4 from
        * PDF spec
        */
-      function readCmapTable(cmap, font, isSymbolicFont, hasEncoding) {
+      function readCmapTable(cmap, file, isSymbolicFont, hasEncoding) {
         if (!cmap) {
           warn("No cmap table available.");
           return {
@@ -1546,11 +1545,11 @@ var Font = (function FontClosure() {
           };
         }
         var segment;
-        var start = (font.start ? font.start : 0) + cmap.offset;
-        font.pos = start;
+        var start = (file.start ? file.start : 0) + cmap.offset;
+        file.pos = start;
 
-        font.getUint16(); // version
-        var numTables = font.getUint16();
+        file.getUint16(); // version
+        var numTables = file.getUint16();
 
         var potentialTable;
         var canBreak = false;
@@ -1561,9 +1560,9 @@ var Font = (function FontClosure() {
         // The following takes advantage of the fact that the tables are sorted
         // to work.
         for (var i = 0; i < numTables; i++) {
-          var platformId = font.getUint16();
-          var encodingId = font.getUint16();
-          var offset = font.getInt32() >>> 0;
+          var platformId = file.getUint16();
+          var encodingId = file.getUint16();
+          var offset = file.getInt32() >>> 0;
           var useTable = false;
 
           // Sometimes there are multiple of the same type of table. Default
@@ -1611,9 +1610,9 @@ var Font = (function FontClosure() {
         }
 
         if (potentialTable) {
-          font.pos = start + potentialTable.offset;
+          file.pos = start + potentialTable.offset;
         }
-        if (!potentialTable || font.peekByte() === -1) {
+        if (!potentialTable || file.peekByte() === -1) {
           warn("Could not find a preferred cmap table.");
           return {
             platformId: -1,
@@ -1623,9 +1622,9 @@ var Font = (function FontClosure() {
           };
         }
 
-        var format = font.getUint16();
-        font.getUint16(); // length
-        font.getUint16(); // language
+        var format = file.getUint16();
+        file.getUint16(); // length
+        file.getUint16(); // language
 
         var hasShortCmap = false;
         var mappings = [];
@@ -1634,7 +1633,7 @@ var Font = (function FontClosure() {
         // TODO(mack): refactor this cmap subtable reading logic out
         if (format === 0) {
           for (j = 0; j < 256; j++) {
-            var index = font.getByte();
+            var index = file.getByte();
             if (!index) {
               continue;
             }
@@ -1647,26 +1646,26 @@ var Font = (function FontClosure() {
         } else if (format === 4) {
           // re-creating the table in format 4 since the encoding
           // might be changed
-          var segCount = font.getUint16() >> 1;
-          font.getBytes(6); // skipping range fields
+          var segCount = file.getUint16() >> 1;
+          file.getBytes(6); // skipping range fields
           var segIndex,
             segments = [];
           for (segIndex = 0; segIndex < segCount; segIndex++) {
-            segments.push({ end: font.getUint16() });
+            segments.push({ end: file.getUint16() });
           }
-          font.getUint16();
+          file.getUint16();
           for (segIndex = 0; segIndex < segCount; segIndex++) {
-            segments[segIndex].start = font.getUint16();
+            segments[segIndex].start = file.getUint16();
           }
 
           for (segIndex = 0; segIndex < segCount; segIndex++) {
-            segments[segIndex].delta = font.getUint16();
+            segments[segIndex].delta = file.getUint16();
           }
 
           var offsetsCount = 0;
           for (segIndex = 0; segIndex < segCount; segIndex++) {
             segment = segments[segIndex];
-            var rangeOffset = font.getUint16();
+            var rangeOffset = file.getUint16();
             if (!rangeOffset) {
               segment.offsetIndex = -1;
               continue;
@@ -1682,7 +1681,7 @@ var Font = (function FontClosure() {
 
           var offsets = [];
           for (j = 0; j < offsetsCount; j++) {
-            offsets.push(font.getUint16());
+            offsets.push(file.getUint16());
           }
 
           for (segIndex = 0; segIndex < segCount; segIndex++) {
@@ -1711,11 +1710,11 @@ var Font = (function FontClosure() {
           // table. (This looks weird, so I can have missed something), this
           // works on Linux but seems to fails on Mac so let's rewrite the
           // cmap table to a 3-1-4 style
-          var firstCode = font.getUint16();
-          var entryCount = font.getUint16();
+          var firstCode = file.getUint16();
+          var entryCount = file.getUint16();
 
           for (j = 0; j < entryCount; j++) {
-            glyphId = font.getUint16();
+            glyphId = file.getUint16();
             var charCode = firstCode + j;
 
             mappings.push({
@@ -1753,7 +1752,7 @@ var Font = (function FontClosure() {
       }
 
       function sanitizeMetrics(
-        font,
+        file,
         header,
         metrics,
         numGlyphs,
@@ -1766,21 +1765,21 @@ var Font = (function FontClosure() {
           return;
         }
 
-        font.pos = (font.start ? font.start : 0) + header.offset;
-        font.pos += 4; // version
-        font.pos += 2; // ascent
-        font.pos += 2; // descent
-        font.pos += 2; // linegap
-        font.pos += 2; // adv_width_max
-        font.pos += 2; // min_sb1
-        font.pos += 2; // min_sb2
-        font.pos += 2; // max_extent
-        font.pos += 2; // caret_slope_rise
-        font.pos += 2; // caret_slope_run
-        font.pos += 2; // caret_offset
-        font.pos += 8; // reserved
-        font.pos += 2; // format
-        var numOfMetrics = font.getUint16();
+        file.pos = (file.start ? file.start : 0) + header.offset;
+        file.pos += 4; // version
+        file.pos += 2; // ascent
+        file.pos += 2; // descent
+        file.pos += 2; // linegap
+        file.pos += 2; // adv_width_max
+        file.pos += 2; // min_sb1
+        file.pos += 2; // min_sb2
+        file.pos += 2; // max_extent
+        file.pos += 2; // caret_slope_rise
+        file.pos += 2; // caret_slope_run
+        file.pos += 2; // caret_offset
+        file.pos += 8; // reserved
+        file.pos += 2; // format
+        var numOfMetrics = file.getUint16();
 
         if (numOfMetrics > numGlyphs) {
           info(
@@ -2113,7 +2112,7 @@ var Font = (function FontClosure() {
         };
       }
 
-      function readPostScriptTable(post, properties, maxpNumGlyphs) {
+      function readPostScriptTable(post, propertiesObj, maxpNumGlyphs) {
         var start = (font.start ? font.start : 0) + post.offset;
         font.pos = start;
 
@@ -2174,12 +2173,12 @@ var Font = (function FontClosure() {
           default:
             warn("Unknown/unsupported post table version " + version);
             valid = false;
-            if (properties.defaultEncoding) {
-              glyphNames = properties.defaultEncoding;
+            if (propertiesObj.defaultEncoding) {
+              glyphNames = propertiesObj.defaultEncoding;
             }
             break;
         }
-        properties.glyphNames = glyphNames;
+        propertiesObj.glyphNames = glyphNames;
         return valid;
       }
 
@@ -2712,8 +2711,7 @@ var Font = (function FontClosure() {
         data: createPostTable(properties),
       };
 
-      var charCodeToGlyphId = [],
-        charCode;
+      const charCodeToGlyphId = [];
 
       // Helper function to try to skip mapping of empty glyphs.
       function hasGlyph(glyphId) {
@@ -2779,7 +2777,7 @@ var Font = (function FontClosure() {
             baseEncoding = getEncoding(properties.baseEncodingName);
           }
           var glyphsUnicodeMap = getGlyphsUnicode();
-          for (charCode = 0; charCode < 256; charCode++) {
+          for (let charCode = 0; charCode < 256; charCode++) {
             var glyphName, standardGlyphName;
             if (this.differences && charCode in this.differences) {
               glyphName = this.differences[charCode];
@@ -2846,7 +2844,7 @@ var Font = (function FontClosure() {
           // (e.g. 0x2013) which when masked would overwrite other values in the
           // cmap.
           for (let i = 0; i < cmapMappingsLength; ++i) {
-            charCode = cmapMappings[i].charCode;
+            let charCode = cmapMappings[i].charCode;
             if (
               cmapPlatformId === 3 &&
               charCode >= 0xf000 &&
@@ -3006,7 +3004,7 @@ var Font = (function FontClosure() {
             // to begin with.
             continue;
           }
-          for (var i = 0, ii = charCodes.length; i < ii; i++) {
+          for (let i = 0, ii = charCodes.length; i < ii; i++) {
             var charCode = charCodes[i];
             // Find a fontCharCode that maps to the base and accent glyphs.
             // If one doesn't exists, create it.
@@ -3095,7 +3093,7 @@ var Font = (function FontClosure() {
           var charstrings = font.charstrings;
           var cffWidths = font.cff ? font.cff.widths : null;
           var hmtx = "\x00\x00\x00\x00"; // Fake .notdef
-          for (var i = 1, ii = numGlyphs; i < ii; i++) {
+          for (let i = 1, ii = numGlyphs; i < ii; i++) {
             var width = 0;
             if (charstrings) {
               var charstring = charstrings[i - 1];
@@ -3572,8 +3570,8 @@ var Type1Font = (function Type1FontClosure() {
       SEAC_ANALYSIS_ENABLED
     );
     var data = eexecBlockParser.extractFontProgram(properties);
-    for (var info in data.properties) {
-      properties[info] = data.properties[info];
+    for (const key in data.properties) {
+      properties[key] = data.properties[key];
     }
 
     var charstrings = data.charstrings;

--- a/src/core/function.js
+++ b/src/core/function.js
@@ -17,18 +17,11 @@ import {
   FormatError,
   info,
   isBool,
-  isEvalSupported,
-  shadow,
+  IsEvalSupportedCached,
   unreachable,
 } from "../shared/util.js";
 import { isDict, isStream } from "./primitives.js";
 import { PostScriptLexer, PostScriptParser } from "./ps_parser.js";
-
-const IsEvalSupportedCached = {
-  get value() {
-    return shadow(this, "value", isEvalSupported());
-  },
-};
 
 class PDFFunctionFactory {
   constructor({ xref, isEvalSupported = true }) {

--- a/src/core/function.js
+++ b/src/core/function.js
@@ -55,8 +55,8 @@ function toNumberArray(arr) {
     if (typeof arr[i] !== "number") {
       // Non-number is found -- convert all items to numbers.
       const result = new Array(length);
-      for (let i = 0; i < length; i++) {
-        result[i] = +arr[i];
+      for (let j = 0; j < length; j++) {
+        result[j] = +arr[j];
       }
       return result;
     }
@@ -1092,18 +1092,17 @@ var PostScriptCompiler = (function PostScriptCompilerClosure() {
   PostScriptCompiler.prototype = {
     compile: function PostScriptCompiler_compile(code, domain, range) {
       var stack = [];
-      var i, ii;
       var instructions = [];
       var inputSize = domain.length >> 1,
         outputSize = range.length >> 1;
       var lastRegister = 0;
       var n, j;
       var num1, num2, ast1, ast2, tmpVar, item;
-      for (i = 0; i < inputSize; i++) {
+      for (let i = 0; i < inputSize; i++) {
         stack.push(new AstArgument(i, domain[i * 2], domain[i * 2 + 1]));
       }
 
-      for (i = 0, ii = code.length; i < ii; i++) {
+      for (let i = 0, ii = code.length; i < ii; i++) {
         item = code[i];
         if (typeof item === "number") {
           stack.push(new AstLiteral(item));

--- a/src/core/function.js
+++ b/src/core/function.js
@@ -565,6 +565,8 @@ function isPDFFunction(v) {
 
 var PostScriptStack = (function PostScriptStackClosure() {
   var MAX_STACK_SIZE = 100;
+
+  // eslint-disable-next-line no-shadow
   function PostScriptStack(initialStack) {
     this.stack = !initialStack
       ? []
@@ -625,6 +627,7 @@ var PostScriptStack = (function PostScriptStackClosure() {
   return PostScriptStack;
 })();
 var PostScriptEvaluator = (function PostScriptEvaluatorClosure() {
+  // eslint-disable-next-line no-shadow
   function PostScriptEvaluator(operators) {
     this.operators = operators;
   }
@@ -1084,6 +1087,7 @@ var PostScriptCompiler = (function PostScriptCompilerClosure() {
     return new AstMin(num1, max);
   }
 
+  // eslint-disable-next-line no-shadow
   function PostScriptCompiler() {}
   PostScriptCompiler.prototype = {
     compile: function PostScriptCompiler_compile(code, domain, range) {

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -96,6 +96,7 @@ var PDFImage = (function PDFImageClosure() {
     return dest;
   }
 
+  // eslint-disable-next-line no-shadow
   function PDFImage({
     xref,
     res,

--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -2567,6 +2567,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     return bitmap;
   }
 
+  // eslint-disable-next-line no-shadow
   function Jbig2Image() {}
 
   Jbig2Image.prototype = {

--- a/src/core/jbig2_stream.js
+++ b/src/core/jbig2_stream.js
@@ -23,6 +23,7 @@ import { shadow } from "../shared/util.js";
  * the stream behaves like all the other DecodeStreams.
  */
 const Jbig2Stream = (function Jbig2StreamClosure() {
+  // eslint-disable-next-line no-shadow
   function Jbig2Stream(stream, maybeLength, dict, params) {
     this.stream = stream;
     this.maybeLength = maybeLength;

--- a/src/core/jpeg_stream.js
+++ b/src/core/jpeg_stream.js
@@ -26,6 +26,7 @@ import { JpegImage } from "./jpg.js";
  * DecodeStreams.
  */
 const JpegStream = (function JpegStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function JpegStream(stream, maybeLength, dict, params) {
     // Some images may contain 'junk' before the SOI (start-of-image) marker.
     // Note: this seems to mainly affect inline images.

--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -73,6 +73,7 @@ var JpegImage = (function JpegImageClosure() {
   var dctSqrt2 = 5793; // sqrt(2)
   var dctSqrt1d2 = 2896; // sqrt(2) / 2
 
+  // eslint-disable-next-line no-shadow
   function JpegImage({ decodeTransform = null, colorTransform = -1 } = {}) {
     this._decodeTransform = decodeTransform;
     this._colorTransform = colorTransform;

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -738,7 +738,7 @@ var JpxImage = (function JpxImageClosure() {
     var l, r, c, p;
     var maxDecompositionLevelsCount = 0;
     for (c = 0; c < componentsCount; c++) {
-      var component = tile.components[c];
+      const component = tile.components[c];
       maxDecompositionLevelsCount = Math.max(
         maxDecompositionLevelsCount,
         component.codingStyleParameters.decompositionLevelsCount
@@ -770,7 +770,7 @@ var JpxImage = (function JpxImageClosure() {
       for (; r <= maxDecompositionLevelsCount; r++) {
         for (; p < maxNumPrecinctsInLevel[r]; p++) {
           for (; c < componentsCount; c++) {
-            var component = tile.components[c];
+            const component = tile.components[c];
             if (r > component.codingStyleParameters.decompositionLevelsCount) {
               continue;
             }

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -31,6 +31,8 @@ var JpxImage = (function JpxImageClosure() {
     HL: 1,
     HH: 2,
   };
+
+  // eslint-disable-next-line no-shadow
   function JpxImage() {
     this.failOnCorruptedImage = false;
   }
@@ -1585,6 +1587,7 @@ var JpxImage = (function JpxImageClosure() {
 
   // Section B.10.2 Tag trees
   var TagTree = (function TagTreeClosure() {
+    // eslint-disable-next-line no-shadow
     function TagTree(width, height) {
       var levelsLength = log2(Math.max(width, height)) + 1;
       this.levels = [];
@@ -1646,6 +1649,7 @@ var JpxImage = (function JpxImageClosure() {
   })();
 
   var InclusionTree = (function InclusionTreeClosure() {
+    // eslint-disable-next-line no-shadow
     function InclusionTree(width, height, defaultValue) {
       var levelsLength = log2(Math.max(width, height)) + 1;
       this.levels = [];
@@ -1752,6 +1756,7 @@ var JpxImage = (function JpxImageClosure() {
       8, 0, 8, 8, 8, 0, 8, 8, 8, 0, 0, 0, 0, 0, 8, 8, 8, 0, 8, 8, 8, 0, 8, 8, 8
     ]);
 
+    // eslint-disable-next-line no-shadow
     function BitModel(width, height, subband, zeroBitPlanes, mb) {
       this.width = width;
       this.height = height;
@@ -2107,6 +2112,7 @@ var JpxImage = (function JpxImageClosure() {
 
   // Section F, Discrete wavelet transformation
   var Transform = (function TransformClosure() {
+    // eslint-disable-next-line no-shadow
     function Transform() {}
 
     Transform.prototype.calculate = function transformCalculate(
@@ -2248,6 +2254,7 @@ var JpxImage = (function JpxImageClosure() {
 
   // Section 3.8.2 Irreversible 9-7 filter
   var IrreversibleTransform = (function IrreversibleTransformClosure() {
+    // eslint-disable-next-line no-shadow
     function IrreversibleTransform() {
       Transform.call(this);
     }
@@ -2345,6 +2352,7 @@ var JpxImage = (function JpxImageClosure() {
 
   // Section 3.8.1 Reversible 5-3 filter
   var ReversibleTransform = (function ReversibleTransformClosure() {
+    // eslint-disable-next-line no-shadow
     function ReversibleTransform() {
       Transform.call(this);
     }

--- a/src/core/jpx_stream.js
+++ b/src/core/jpx_stream.js
@@ -22,6 +22,7 @@ import { shadow } from "../shared/util.js";
  * the stream behaves like all the other DecodeStreams.
  */
 const JpxStream = (function JpxStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function JpxStream(stream, maybeLength, dict, params) {
     this.stream = stream;
     this.maybeLength = maybeLength;

--- a/src/core/metrics.js
+++ b/src/core/metrics.js
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint-disable no-shadow */
 
 import { getLookupTableFactory } from "./core_utils.js";
 

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -1119,6 +1119,7 @@ class Catalog {
 }
 
 var XRef = (function XRefClosure() {
+  // eslint-disable-next-line no-shadow
   function XRef(stream, pdfManager) {
     this.stream = stream;
     this.pdfManager = pdfManager;
@@ -2092,6 +2093,7 @@ class NumberTree extends NameOrNumberTree {
  * collections attributes and related files (/RF)
  */
 var FileSpec = (function FileSpecClosure() {
+  // eslint-disable-next-line no-shadow
   function FileSpec(root, xref) {
     if (!root || !isDict(root)) {
       return;
@@ -2217,6 +2219,7 @@ const ObjectLoader = (function() {
     }
   }
 
+  // eslint-disable-next-line no-shadow
   function ObjectLoader(dict, keys, xref) {
     this.dict = dict;
     this.keys = keys;

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -897,12 +897,12 @@ class Catalog {
               break;
             }
             kidPromises.push(
-              xref.fetchAsync(kid).then(function(kid) {
-                if (!isDict(kid)) {
+              xref.fetchAsync(kid).then(function(obj) {
+                if (!isDict(obj)) {
                   throw new FormatError("Kid node must be a dictionary.");
                 }
-                if (kid.has("Count")) {
-                  total += kid.get("Count");
+                if (obj.has("Count")) {
+                  total += obj.get("Count");
                 } else {
                   // Page leaf node.
                   total++;

--- a/src/core/operator_list.js
+++ b/src/core/operator_list.js
@@ -491,6 +491,7 @@ var QueueOptimizer = (function QueueOptimizerClosure() {
     }
   );
 
+  // eslint-disable-next-line no-shadow
   function QueueOptimizer(queue) {
     this.queue = queue;
     this.state = null;
@@ -585,6 +586,7 @@ var QueueOptimizer = (function QueueOptimizerClosure() {
 })();
 
 var NullOptimizer = (function NullOptimizerClosure() {
+  // eslint-disable-next-line no-shadow
   function NullOptimizer(queue) {
     this.queue = queue;
   }
@@ -607,6 +609,7 @@ var OperatorList = (function OperatorListClosure() {
   var CHUNK_SIZE = 1000;
   var CHUNK_SIZE_ABOUT = CHUNK_SIZE - 5; // close to chunk size
 
+  // eslint-disable-next-line no-shadow
   function OperatorList(intent, streamSink, pageIndex) {
     this._streamSink = streamSink;
     this.fnArray = [];

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -43,7 +43,7 @@ import {
   Name,
   Ref,
 } from "./primitives.js";
-import { isSpace, MissingDataException } from "./core_utils.js";
+import { isWhiteSpace, MissingDataException } from "./core_utils.js";
 import { CCITTFaxStream } from "./ccitt_stream.js";
 import { Jbig2Stream } from "./jbig2_stream.js";
 import { JpegStream } from "./jpeg_stream.js";
@@ -270,7 +270,7 @@ class Parser {
 
     // Ensure that we don't accidentally truncate the inline image, when the
     // data is immediately followed by the "EI" marker (fixes issue10388.pdf).
-    if (!isSpace(ch)) {
+    if (!isWhiteSpace(ch)) {
       endOffset--;
     }
     return stream.pos - endOffset - startPos;
@@ -394,7 +394,7 @@ class Parser {
         ch = stream.peekByte();
         // Handle corrupt PDF documents which contains whitespace "inside" of
         // the EOD marker (fixes issue10614.pdf).
-        while (isSpace(ch)) {
+        while (isWhiteSpace(ch)) {
           stream.skip();
           ch = stream.peekByte();
         }
@@ -640,7 +640,7 @@ class Parser {
             // Ensure that the byte immediately following the truncated
             // endstream command is a space, to prevent false positives.
             const lastByte = stream.peekBytes(end + 1)[end];
-            if (!isSpace(lastByte)) {
+            if (!isWhiteSpace(lastByte)) {
               break;
             }
             info(
@@ -886,7 +886,7 @@ class Lexer {
       if (
         divideBy === 10 &&
         sign === 0 &&
-        (isSpace(ch) || ch === /* EOF = */ -1)
+        (isWhiteSpace(ch) || ch === /* EOF = */ -1)
       ) {
         // This is consistent with Adobe Reader (fixes issue9252.pdf).
         warn("Lexer.getNumber - treating a single decimal point as zero.");

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -38,6 +38,7 @@ var ShadingType = {
 
 var Pattern = (function PatternClosure() {
   // Constructor should define this.getPattern
+  // eslint-disable-next-line no-shadow
   function Pattern() {
     unreachable("should not call Pattern constructor");
   }
@@ -450,6 +451,8 @@ Shadings.Mesh = (function MeshClosure() {
       return lut;
     }
     var cache = [];
+
+    // eslint-disable-next-line no-shadow
     return function getB(count) {
       if (!cache[count]) {
         cache[count] = buildB(count);

--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -21,6 +21,7 @@ var EOF = {};
 var Name = (function NameClosure() {
   let nameCache = Object.create(null);
 
+  // eslint-disable-next-line no-shadow
   function Name(name) {
     this.name = name;
   }
@@ -43,6 +44,7 @@ var Name = (function NameClosure() {
 var Cmd = (function CmdClosure() {
   let cmdCache = Object.create(null);
 
+  // eslint-disable-next-line no-shadow
   function Cmd(cmd) {
     this.cmd = cmd;
   }
@@ -68,6 +70,7 @@ var Dict = (function DictClosure() {
   };
 
   // xref is optional
+  // eslint-disable-next-line no-shadow
   function Dict(xref) {
     // Map should only be used internally, use functions below to access.
     this._map = Object.create(null);
@@ -185,6 +188,7 @@ var Dict = (function DictClosure() {
 var Ref = (function RefClosure() {
   let refCache = Object.create(null);
 
+  // eslint-disable-next-line no-shadow
   function Ref(num, gen) {
     this.num = num;
     this.gen = gen;
@@ -218,6 +222,7 @@ var Ref = (function RefClosure() {
 // The reference is identified by number and generation.
 // This structure stores only one instance of the reference.
 var RefSet = (function RefSetClosure() {
+  // eslint-disable-next-line no-shadow
   function RefSet() {
     this.dict = Object.create(null);
   }
@@ -240,6 +245,7 @@ var RefSet = (function RefSetClosure() {
 })();
 
 var RefSetCache = (function RefSetCacheClosure() {
+  // eslint-disable-next-line no-shadow
   function RefSetCache() {
     this.dict = Object.create(null);
   }

--- a/src/core/ps_parser.js
+++ b/src/core/ps_parser.js
@@ -16,7 +16,7 @@
 
 import { FormatError, shadow } from "../shared/util.js";
 import { EOF } from "./primitives.js";
-import { isSpace } from "./core_utils.js";
+import { isWhiteSpace } from "./core_utils.js";
 
 class PostScriptParser {
   constructor(lexer) {
@@ -193,7 +193,7 @@ class PostScriptLexer {
         }
       } else if (ch === /* '%' = */ 0x25) {
         comment = true;
-      } else if (!isSpace(ch)) {
+      } else if (!isWhiteSpace(ch)) {
         break;
       }
       ch = this.nextChar();

--- a/src/core/ps_parser.js
+++ b/src/core/ps_parser.js
@@ -113,6 +113,7 @@ const PostScriptTokenTypes = {
 const PostScriptToken = (function PostScriptTokenClosure() {
   const opCache = Object.create(null);
 
+  // eslint-disable-next-line no-shadow
   class PostScriptToken {
     constructor(type, value) {
       this.type = type;

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -24,6 +24,7 @@ import { isDict } from "./primitives.js";
 import { isWhiteSpace } from "./core_utils.js";
 
 var Stream = (function StreamClosure() {
+  // eslint-disable-next-line no-shadow
   function Stream(arrayBuffer, start, length, dict) {
     this.bytes =
       arrayBuffer instanceof Uint8Array
@@ -129,6 +130,7 @@ var Stream = (function StreamClosure() {
 })();
 
 var StringStream = (function StringStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function StringStream(str) {
     const bytes = stringToBytes(str);
     Stream.call(this, bytes);
@@ -147,6 +149,7 @@ var DecodeStream = (function DecodeStreamClosure() {
   // buffer.
   var emptyBuffer = new Uint8Array(0);
 
+  // eslint-disable-next-line no-shadow
   function DecodeStream(maybeMinBufferLength) {
     this._rawMinBufferLength = maybeMinBufferLength || 0;
 
@@ -282,6 +285,7 @@ var DecodeStream = (function DecodeStreamClosure() {
 })();
 
 var StreamsSequenceStream = (function StreamsSequenceStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function StreamsSequenceStream(streams) {
     this.streams = streams;
 
@@ -426,6 +430,7 @@ var FlateStream = (function FlateStreamClosure() {
     0x50003, 0x50013, 0x5000b, 0x5001b, 0x50007, 0x50017, 0x5000f, 0x00000
   ]), 5];
 
+  // eslint-disable-next-line no-shadow
   function FlateStream(str, maybeLength) {
     this.str = str;
     this.dict = str.dict;
@@ -711,6 +716,7 @@ var FlateStream = (function FlateStreamClosure() {
 })();
 
 var PredictorStream = (function PredictorStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function PredictorStream(str, maybeLength, params) {
     if (!isDict(params)) {
       return str; // no prediction
@@ -932,6 +938,7 @@ var PredictorStream = (function PredictorStreamClosure() {
 })();
 
 var DecryptStream = (function DecryptStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function DecryptStream(str, maybeLength, decrypt) {
     this.str = str;
     this.dict = str.dict;
@@ -978,6 +985,7 @@ var DecryptStream = (function DecryptStreamClosure() {
 })();
 
 var Ascii85Stream = (function Ascii85StreamClosure() {
+  // eslint-disable-next-line no-shadow
   function Ascii85Stream(str, maybeLength) {
     this.str = str;
     this.dict = str.dict;
@@ -1062,6 +1070,7 @@ var Ascii85Stream = (function Ascii85StreamClosure() {
 })();
 
 var AsciiHexStream = (function AsciiHexStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function AsciiHexStream(str, maybeLength) {
     this.str = str;
     this.dict = str.dict;
@@ -1128,6 +1137,7 @@ var AsciiHexStream = (function AsciiHexStreamClosure() {
 })();
 
 var RunLengthStream = (function RunLengthStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function RunLengthStream(str, maybeLength) {
     this.str = str;
     this.dict = str.dict;
@@ -1175,6 +1185,7 @@ var RunLengthStream = (function RunLengthStreamClosure() {
 })();
 
 var LZWStream = (function LZWStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function LZWStream(str, maybeLength, earlyChange) {
     this.str = str;
     this.dict = str.dict;
@@ -1311,6 +1322,7 @@ var LZWStream = (function LZWStreamClosure() {
 })();
 
 var NullStream = (function NullStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function NullStream() {
     Stream.call(this, new Uint8Array(0));
   }

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -21,7 +21,7 @@
 
 import { FormatError, stringToBytes, unreachable } from "../shared/util.js";
 import { isDict } from "./primitives.js";
-import { isSpace } from "./core_utils.js";
+import { isWhiteSpace } from "./core_utils.js";
 
 var Stream = (function StreamClosure() {
   function Stream(arrayBuffer, start, length, dict) {
@@ -1001,7 +1001,7 @@ var Ascii85Stream = (function Ascii85StreamClosure() {
     var str = this.str;
 
     var c = str.getByte();
-    while (isSpace(c)) {
+    while (isWhiteSpace(c)) {
       c = str.getByte();
     }
 
@@ -1026,7 +1026,7 @@ var Ascii85Stream = (function Ascii85StreamClosure() {
       input[0] = c;
       for (i = 1; i < 5; ++i) {
         c = str.getByte();
-        while (isSpace(c)) {
+        while (isWhiteSpace(c)) {
           c = str.getByte();
         }
 

--- a/src/core/type1_parser.js
+++ b/src/core/type1_parser.js
@@ -79,6 +79,7 @@ var Type1CharString = (function Type1CharStringClosure() {
     hvcurveto: [31],
   };
 
+  // eslint-disable-next-line no-shadow
   function Type1CharString() {
     this.width = 0;
     this.lsb = 0;
@@ -451,6 +452,7 @@ var Type1Parser = (function Type1ParserClosure() {
     );
   }
 
+  // eslint-disable-next-line no-shadow
   function Type1Parser(stream, encrypted, seacAnalysisEnabled) {
     if (encrypted) {
       var data = stream.getBytes();

--- a/src/core/type1_parser.js
+++ b/src/core/type1_parser.js
@@ -14,7 +14,7 @@
  */
 
 import { getEncoding } from "./encodings.js";
-import { isSpace } from "./core_utils.js";
+import { isWhiteSpace } from "./core_utils.js";
 import { Stream } from "./stream.js";
 import { warn } from "../shared/util.js";
 
@@ -524,7 +524,7 @@ var Type1Parser = (function Type1ParserClosure() {
           }
         } else if (ch === /* '%' = */ 0x25) {
           comment = true;
-        } else if (!isSpace(ch)) {
+        } else if (!isWhiteSpace(ch)) {
           break;
         }
         ch = this.nextChar();
@@ -537,7 +537,7 @@ var Type1Parser = (function Type1ParserClosure() {
       do {
         token += String.fromCharCode(ch);
         ch = this.nextChar();
-      } while (ch >= 0 && !isSpace(ch) && !isSpecial(ch));
+      } while (ch >= 0 && !isWhiteSpace(ch) && !isSpecial(ch));
       return token;
     },
 

--- a/src/core/type1_parser.js
+++ b/src/core/type1_parser.js
@@ -614,7 +614,7 @@ var Type1Parser = (function Type1ParserClosure() {
             this.readInt(); // num
             this.getToken(); // read in 'array'
             while (this.getToken() === "dup") {
-              var index = this.readInt();
+              const index = this.readInt();
               length = this.readInt();
               this.getToken(); // read in 'RD' or '-|'
               data = length > 0 ? stream.getBytes(length) : new Uint8Array(0);

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -38,6 +38,7 @@ import { PDFWorkerStream } from "./worker_stream.js";
 import { XRefParseException } from "./core_utils.js";
 
 var WorkerTask = (function WorkerTaskClosure() {
+  // eslint-disable-next-line no-shadow
   function WorkerTask(name) {
     this.name = name;
     this.terminated = false;

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -183,19 +183,19 @@ var WorkerMessageHandler = {
 
     function getPdfManager(data, evaluatorOptions) {
       var pdfManagerCapability = createPromiseCapability();
-      var pdfManager;
+      let newPdfManager;
 
       var source = data.source;
       if (source.data) {
         try {
-          pdfManager = new LocalPdfManager(
+          newPdfManager = new LocalPdfManager(
             docId,
             source.data,
             source.password,
             evaluatorOptions,
             docBaseUrl
           );
-          pdfManagerCapability.resolve(pdfManager);
+          pdfManagerCapability.resolve(newPdfManager);
         } catch (ex) {
           pdfManagerCapability.reject(ex);
         }
@@ -221,7 +221,7 @@ var WorkerMessageHandler = {
           // We don't need auto-fetch when streaming is enabled.
           var disableAutoFetch =
             source.disableAutoFetch || fullRequest.isStreamingSupported;
-          pdfManager = new NetworkPdfManager(
+          newPdfManager = new NetworkPdfManager(
             docId,
             pdfStream,
             {
@@ -234,16 +234,15 @@ var WorkerMessageHandler = {
             evaluatorOptions,
             docBaseUrl
           );
-          // There may be a chance that `pdfManager` is not initialized
-          // for first few runs of `readchunk` block of code. Be sure
-          // to send all cached chunks, if any, to chunked_stream via
-          // pdf_manager.
+          // There may be a chance that `newPdfManager` is not initialized for
+          // the first few runs of `readchunk` block of code. Be sure to send
+          // all cached chunks, if any, to chunked_stream via pdf_manager.
           for (let i = 0; i < cachedChunks.length; i++) {
-            pdfManager.sendProgressiveData(cachedChunks[i]);
+            newPdfManager.sendProgressiveData(cachedChunks[i]);
           }
 
           cachedChunks = [];
-          pdfManagerCapability.resolve(pdfManager);
+          pdfManagerCapability.resolve(newPdfManager);
           cancelXHRs = null;
         })
         .catch(function(reason) {
@@ -259,33 +258,32 @@ var WorkerMessageHandler = {
         }
         // the data is array, instantiating directly from it
         try {
-          pdfManager = new LocalPdfManager(
+          newPdfManager = new LocalPdfManager(
             docId,
             pdfFile,
             source.password,
             evaluatorOptions,
             docBaseUrl
           );
-          pdfManagerCapability.resolve(pdfManager);
+          pdfManagerCapability.resolve(newPdfManager);
         } catch (ex) {
           pdfManagerCapability.reject(ex);
         }
         cachedChunks = [];
       };
       var readPromise = new Promise(function(resolve, reject) {
-        var readChunk = function(chunk) {
+        var readChunk = function({ value, done }) {
           try {
             ensureNotTerminated();
-            if (chunk.done) {
-              if (!pdfManager) {
+            if (done) {
+              if (!newPdfManager) {
                 flushChunks();
               }
               cancelXHRs = null;
               return;
             }
 
-            var data = chunk.value;
-            loaded += arrayByteLength(data);
+            loaded += arrayByteLength(value);
             if (!fullRequest.isStreamingSupported) {
               handler.send("DocProgress", {
                 loaded,
@@ -293,10 +291,10 @@ var WorkerMessageHandler = {
               });
             }
 
-            if (pdfManager) {
-              pdfManager.sendProgressiveData(data);
+            if (newPdfManager) {
+              newPdfManager.sendProgressiveData(value);
             } else {
-              cachedChunks.push(data);
+              cachedChunks.push(value);
             }
 
             fullRequest.read().then(readChunk, reject);
@@ -333,9 +331,9 @@ var WorkerMessageHandler = {
 
           handler
             .sendWithPromise("PasswordRequest", ex)
-            .then(function(data) {
+            .then(function({ password }) {
               finishWorkerTask(task);
-              pdfManager.updatePassword(data.password);
+              pdfManager.updatePassword(password);
               pdfManagerReady();
             })
             .catch(function() {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2338,7 +2338,7 @@ class WorkerTransport {
       this._onUnsupportedFeature.bind(this)
     );
 
-    messageHandler.on("JpegDecode", data => {
+    messageHandler.on("JpegDecode", ([imageUrl, components]) => {
       if (this.destroyed) {
         return Promise.reject(new Error("Worker was destroyed"));
       }
@@ -2349,7 +2349,6 @@ class WorkerTransport {
         return Promise.reject(new Error('"document" is not defined.'));
       }
 
-      const [imageUrl, components] = data;
       if (components !== 3 && components !== 1) {
         return Promise.reject(
           new Error("Only 3 components or 1 component can be returned")

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -415,6 +415,7 @@ const PDFDocumentLoadingTask = (function PDFDocumentLoadingTaskClosure() {
    * (such as network requests) and provides a way to listen for completion,
    * after which individual pages can be rendered.
    */
+  // eslint-disable-next-line no-shadow
   class PDFDocumentLoadingTask {
     constructor() {
       this._capability = createPromiseCapability();
@@ -1687,6 +1688,7 @@ const PDFWorker = (function PDFWorkerClosure() {
    * thread to the worker thread and vice versa. If the creation of a web
    * worker is not possible, a "fake" worker will be used instead.
    */
+  // eslint-disable-next-line no-shadow
   class PDFWorker {
     /**
      * @param {PDFWorkerParameters} params - Worker initialization parameters.
@@ -2723,6 +2725,7 @@ class RenderTask {
 const InternalRenderTask = (function InternalRenderTaskClosure() {
   const canvasInRendering = new WeakSet();
 
+  // eslint-disable-next-line no-shadow
   class InternalRenderTask {
     constructor({
       callback,

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -368,11 +368,11 @@ function compileType3Glyph(imgData) {
     c.scale(1 / width, -1 / height);
     c.translate(0, -height);
     c.beginPath();
-    for (var i = 0, ii = outlines.length; i < ii; i++) {
-      var o = outlines[i];
+    for (let k = 0, kk = outlines.length; k < kk; k++) {
+      var o = outlines[k];
       c.moveTo(o[0], o[1]);
-      for (var j = 2, jj = o.length; j < jj; j += 2) {
-        c.lineTo(o[j], o[j + 1]);
+      for (let l = 2, ll = o.length; l < ll; l += 2) {
+        c.lineTo(o[l], o[l + 1]);
       }
     }
     c.fill();

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -18,7 +18,7 @@ import {
   IDENTITY_MATRIX,
   ImageKind,
   info,
-  isLittleEndian,
+  IsLittleEndianCached,
   isNum,
   OPS,
   shadow,
@@ -45,12 +45,6 @@ var COMPILE_TYPE3_GLYPHS = true;
 var MAX_SIZE_TO_COMPILE = 1000;
 
 var FULL_CHUNK_HEIGHT = 16;
-
-var IsLittleEndianCached = {
-  get value() {
-    return shadow(IsLittleEndianCached, "value", isLittleEndian());
-  },
-};
 
 function addContextCurrentTransform(ctx) {
   // If the context doesn't expose a `mozCurrentTransform`, add a JS based one.

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -168,6 +168,7 @@ function addContextCurrentTransform(ctx) {
 }
 
 var CachedCanvases = (function CachedCanvasesClosure() {
+  // eslint-disable-next-line no-shadow
   function CachedCanvases(canvasFactory) {
     this.canvasFactory = canvasFactory;
     this.cache = Object.create(null);
@@ -383,6 +384,7 @@ function compileType3Glyph(imgData) {
 }
 
 var CanvasExtraState = (function CanvasExtraStateClosure() {
+  // eslint-disable-next-line no-shadow
   function CanvasExtraState() {
     // Are soft masks and alpha values shapes or opacities?
     this.alphaIsShape = false;
@@ -435,6 +437,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
   // Defines the number of steps before checking the execution time
   var EXECUTION_STEPS = 10;
 
+  // eslint-disable-next-line no-shadow
   function CanvasGraphics(
     canvasCtx,
     commonObjs,

--- a/src/display/content_disposition.js
+++ b/src/display/content_disposition.js
@@ -115,13 +115,13 @@ function getFilenameFromContentDispositionHeader(contentDisposition) {
     }
     return value;
   }
-  function rfc2231getparam(contentDisposition) {
+  function rfc2231getparam(contentDispositionStr) {
     const matches = [];
     let match;
     // Iterate over all filename*n= and filename*n*= with n being an integer
     // of at least zero. Any non-zero number must not start with '0'.
     const iter = toParamRegExp("filename\\*((?!0\\d)\\d+)(\\*?)", "ig");
-    while ((match = iter.exec(contentDisposition)) !== null) {
+    while ((match = iter.exec(contentDispositionStr)) !== null) {
       let [, n, quot, part] = match; // eslint-disable-line prefer-const
       n = parseInt(n, 10);
       if (n in matches) {
@@ -205,11 +205,11 @@ function getFilenameFromContentDispositionHeader(contentDisposition) {
     //        ... but Firefox permits ? and space.
     return value.replace(
       /=\?([\w-]*)\?([QqBb])\?((?:[^?]|\?(?!=))*)\?=/g,
-      function(_, charset, encoding, text) {
+      function(all, charset, encoding, text) {
         if (encoding === "q" || encoding === "Q") {
           // RFC 2047 section 4.2.
           text = text.replace(/_/g, " ");
-          text = text.replace(/=([0-9a-fA-F]{2})/g, function(_, hex) {
+          text = text.replace(/=([0-9a-fA-F]{2})/g, function(code, hex) {
             return String.fromCharCode(parseInt(hex, 16));
           });
           return textdecode(charset, text);

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -16,7 +16,7 @@
 import {
   assert,
   bytesToString,
-  isEvalSupported,
+  IsEvalSupportedCached,
   shadow,
   string32,
   unreachable,
@@ -336,12 +336,6 @@ if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
     }
   };
 } // End of PDFJSDev.test('CHROME || GENERIC')
-
-const IsEvalSupportedCached = {
-  get value() {
-    return shadow(this, "value", isEvalSupported());
-  },
-};
 
 class FontFaceObject {
   constructor(

--- a/src/display/node_stream.js
+++ b/src/display/node_stream.js
@@ -292,13 +292,13 @@ class BaseRangeReader {
   }
 }
 
-function createRequestOptions(url, headers) {
+function createRequestOptions(parsedUrl, headers) {
   return {
-    protocol: url.protocol,
-    auth: url.auth,
-    host: url.hostname,
-    port: url.port,
-    path: url.path,
+    protocol: parsedUrl.protocol,
+    auth: parsedUrl.auth,
+    host: parsedUrl.hostname,
+    port: parsedUrl.port,
+    path: parsedUrl.path,
     method: "GET",
     headers,
   };

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -158,7 +158,7 @@ var createMeshCanvas = (function createMeshCanvasClosure() {
       var x2_ = Math.round(Math.max(xa, xb));
       var j = rowSize * y + x1_ * 4;
       for (var x = x1_; x <= x2_; x++) {
-        let k = (xa - x) / (xa - xb);
+        k = (xa - x) / (xa - xb);
         if (k < 0) {
           k = 0;
         } else if (k > 1) {

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -226,6 +226,7 @@ var createMeshCanvas = (function createMeshCanvasClosure() {
     }
   }
 
+  // eslint-disable-next-line no-shadow
   function createMeshCanvas(
     bounds,
     combinesScale,
@@ -413,6 +414,7 @@ var TilingPattern = (function TilingPatternClosure() {
 
   var MAX_PATTERN_SIZE = 3000; // 10in @ 300dpi shall be enough
 
+  // eslint-disable-next-line no-shadow
   function TilingPattern(IR, color, ctx, canvasGraphicsFactory, baseTransform) {
     this.operatorList = IR[2];
     this.matrix = IR[3] || [1, 0, 0, 1, 0, 0];

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -286,6 +286,7 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       return createObjectURL(data, "image/png", forceDataSchema);
     }
 
+    // eslint-disable-next-line no-shadow
     return function convertImgDataToPng(imgData, forceDataSchema, isMask) {
       const kind =
         imgData.kind === undefined ? ImageKind.GRAYSCALE_1BPP : imgData.kind;
@@ -437,6 +438,7 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
   let maskCount = 0;
   let shadingCount = 0;
 
+  // eslint-disable-next-line no-shadow
   SVGGraphics = class SVGGraphics {
     constructor(commonObjs, objs, forceDataSchema) {
       this.svgFactory = new DOMSVGFactory();

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -718,6 +718,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
    * @param {TextLayerRenderParameters} renderParameters
    * @returns {TextLayerRenderTask}
    */
+  // eslint-disable-next-line no-shadow
   function renderTextLayer(renderParameters) {
     var task = new TextLayerRenderTask({
       textContent: renderParameters.textContent,

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -182,6 +182,17 @@ var renderTextLayer = (function renderTextLayerClosure() {
     capability.resolve();
   }
 
+  function findPositiveMin(ts, offset, count) {
+    let result = 0;
+    for (let i = 0; i < count; i++) {
+      const t = ts[offset++];
+      if (t > 0) {
+        result = result ? Math.min(t, result) : t;
+      }
+    }
+    return result;
+  }
+
   function expand(task) {
     var bounds = task._bounds;
     var viewport = task._viewport;
@@ -208,38 +219,28 @@ var renderTextLayer = (function renderTextLayerClosure() {
       // Finding intersections with expanded box.
       var points = [[0, 0], [0, b.size[1]], [b.size[0], 0], b.size];
       var ts = new Float64Array(64);
-      points.forEach(function(p, i) {
+      points.forEach(function(p, j) {
         var t = Util.applyTransform(p, m);
-        ts[i + 0] = c && (e.left - t[0]) / c;
-        ts[i + 4] = s && (e.top - t[1]) / s;
-        ts[i + 8] = c && (e.right - t[0]) / c;
-        ts[i + 12] = s && (e.bottom - t[1]) / s;
+        ts[j + 0] = c && (e.left - t[0]) / c;
+        ts[j + 4] = s && (e.top - t[1]) / s;
+        ts[j + 8] = c && (e.right - t[0]) / c;
+        ts[j + 12] = s && (e.bottom - t[1]) / s;
 
-        ts[i + 16] = s && (e.left - t[0]) / -s;
-        ts[i + 20] = c && (e.top - t[1]) / c;
-        ts[i + 24] = s && (e.right - t[0]) / -s;
-        ts[i + 28] = c && (e.bottom - t[1]) / c;
+        ts[j + 16] = s && (e.left - t[0]) / -s;
+        ts[j + 20] = c && (e.top - t[1]) / c;
+        ts[j + 24] = s && (e.right - t[0]) / -s;
+        ts[j + 28] = c && (e.bottom - t[1]) / c;
 
-        ts[i + 32] = c && (e.left - t[0]) / -c;
-        ts[i + 36] = s && (e.top - t[1]) / -s;
-        ts[i + 40] = c && (e.right - t[0]) / -c;
-        ts[i + 44] = s && (e.bottom - t[1]) / -s;
+        ts[j + 32] = c && (e.left - t[0]) / -c;
+        ts[j + 36] = s && (e.top - t[1]) / -s;
+        ts[j + 40] = c && (e.right - t[0]) / -c;
+        ts[j + 44] = s && (e.bottom - t[1]) / -s;
 
-        ts[i + 48] = s && (e.left - t[0]) / s;
-        ts[i + 52] = c && (e.top - t[1]) / -c;
-        ts[i + 56] = s && (e.right - t[0]) / s;
-        ts[i + 60] = c && (e.bottom - t[1]) / -c;
+        ts[j + 48] = s && (e.left - t[0]) / s;
+        ts[j + 52] = c && (e.top - t[1]) / -c;
+        ts[j + 56] = s && (e.right - t[0]) / s;
+        ts[j + 60] = c && (e.bottom - t[1]) / -c;
       });
-      var findPositiveMin = function(ts, offset, count) {
-        var result = 0;
-        for (var i = 0; i < count; i++) {
-          var t = ts[offset++];
-          if (t > 0) {
-            result = result ? Math.min(t, result) : t;
-          }
-        }
-        return result;
-      };
       // Not based on math, but to simplify calculations, using cos and sin
       // absolute values to not exceed the box (it can but insignificantly).
       var boxScale = 1 + Math.min(Math.abs(c), Math.abs(s));

--- a/src/shared/message_handler.js
+++ b/src/shared/message_handler.js
@@ -114,15 +114,15 @@ class MessageHandler {
         throw new Error(`Unknown action from worker: ${data.action}`);
       }
       if (data.callbackId) {
-        const sourceName = this.sourceName;
-        const targetName = data.sourceName;
+        const cbSourceName = this.sourceName;
+        const cbTargetName = data.sourceName;
         new Promise(function(resolve) {
           resolve(action(data.data));
         }).then(
           function(result) {
             comObj.postMessage({
-              sourceName,
-              targetName,
+              sourceName: cbSourceName,
+              targetName: cbTargetName,
               callback: CallbackKind.DATA,
               callbackId: data.callbackId,
               data: result,
@@ -130,8 +130,8 @@ class MessageHandler {
           },
           function(reason) {
             comObj.postMessage({
-              sourceName,
-              targetName,
+              sourceName: cbSourceName,
+              targetName: cbTargetName,
               callback: CallbackKind.ERROR,
               callbackId: data.callbackId,
               reason: wrapReason(reason),

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -547,14 +547,18 @@ function string32(value) {
   );
 }
 
-// Lazy test the endianness of the platform
-// NOTE: This will be 'true' for simulated TypedArrays
+// Checks the endianness of the platform.
 function isLittleEndian() {
   const buffer8 = new Uint8Array(4);
   buffer8[0] = 1;
   const view32 = new Uint32Array(buffer8.buffer, 0, 1);
   return view32[0] === 1;
 }
+const IsLittleEndianCached = {
+  get value() {
+    return shadow(this, "value", isLittleEndian());
+  },
+};
 
 // Checks if it's possible to eval JS expressions.
 function isEvalSupported() {
@@ -565,6 +569,11 @@ function isEvalSupported() {
     return false;
   }
 }
+const IsEvalSupportedCached = {
+  get value() {
+    return shadow(this, "value", isEvalSupported());
+  },
+};
 
 const rgbBuf = ["rgb(", 0, ",", 0, ",", 0, ")"];
 
@@ -918,8 +927,8 @@ export {
   isString,
   isSameOrigin,
   createValidAbsoluteUrl,
-  isLittleEndian,
-  isEvalSupported,
+  IsLittleEndianCached,
+  IsEvalSupportedCached,
   removeNullCharacters,
   setVerbosityLevel,
   shadow,

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -405,6 +405,7 @@ function shadow(obj, prop, value) {
 }
 
 const BaseException = (function BaseExceptionClosure() {
+  // eslint-disable-next-line no-shadow
   function BaseException(message) {
     if (this.constructor === BaseException) {
       unreachable("Cannot initialize BaseException.");
@@ -859,6 +860,7 @@ const createObjectURL = (function createObjectURLClosure() {
   const digits =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
 
+  // eslint-disable-next-line no-shadow
   return function createObjectURL(data, contentType, forceDataSchema = false) {
     if (!forceDataSchema && URL.createObjectURL) {
       const blob = new Blob([data], { type: contentType });

--- a/test/add_test.js
+++ b/test/add_test.js
@@ -22,9 +22,9 @@ if (!fs.existsSync(file)) {
   throw new Error(`PDF file does not exist '${file}'.`);
 }
 
-function calculateMD5(file, callback) {
+function calculateMD5(pdfFile, callback) {
   var hash = crypto.createHash("md5");
-  var stream = fs.createReadStream(file);
+  var stream = fs.createReadStream(pdfFile);
   stream.on("data", function(data) {
     hash.update(data);
   });

--- a/test/driver.js
+++ b/test/driver.js
@@ -230,10 +230,10 @@ var rasterizeAnnotationLayer = (function rasterizeAnnotationLayerClosure() {
           for (var i = 0, ii = data.length; i < ii; i++) {
             images[i].src = data[i];
             loadedPromises.push(
-              new Promise(function(resolve, reject) {
-                images[i].onload = resolve;
+              new Promise(function(resolveImages, rejectImages) {
+                images[i].onload = resolveImages;
                 images[i].onerror = function(e) {
-                  reject(new Error("Error loading image " + e));
+                  rejectImages(new Error("Error loading image " + e));
                 };
               })
             );

--- a/test/driver.js
+++ b/test/driver.js
@@ -45,6 +45,7 @@ var rasterizeTextLayer = (function rasterizeTextLayerClosure() {
     return textLayerStylePromise;
   }
 
+  // eslint-disable-next-line no-shadow
   function rasterizeTextLayer(
     ctx,
     viewport,
@@ -178,6 +179,7 @@ var rasterizeAnnotationLayer = (function rasterizeAnnotationLayerClosure() {
     return imagePromises;
   }
 
+  // eslint-disable-next-line no-shadow
   function rasterizeAnnotationLayer(
     ctx,
     viewport,
@@ -283,6 +285,7 @@ var Driver = (function DriverClosure() {
    * @constructs Driver
    * @param {DriverOptions} options
    */
+  // eslint-disable-next-line no-shadow
   function Driver(options) {
     // Configure the global worker options.
     pdfjsLib.GlobalWorkerOptions.workerSrc = WORKER_SRC;

--- a/test/font/ttxdriver.js
+++ b/test/font/ttxdriver.js
@@ -24,10 +24,10 @@ var ttxResourcesHome = path.join(__dirname, "..", "ttx");
 
 var nextTTXTaskId = Date.now();
 
-function runTtx(ttxResourcesHome, fontPath, registerOnCancel, callback) {
-  fs.realpath(ttxResourcesHome, function(err, ttxResourcesHome) {
-    var fontToolsHome = path.join(ttxResourcesHome, "fonttools-code");
-    fs.realpath(fontPath, function(err, fontPath) {
+function runTtx(ttxResourcesHomePath, fontPath, registerOnCancel, callback) {
+  fs.realpath(ttxResourcesHomePath, function(error, realTtxResourcesHomePath) {
+    var fontToolsHome = path.join(realTtxResourcesHomePath, "fonttools-code");
+    fs.realpath(fontPath, function(errorFontPath, realFontPath) {
       var ttxPath = path.join("Tools", "ttx");
       if (!fs.existsSync(path.join(fontToolsHome, ttxPath))) {
         callback("TTX was not found, please checkout PDF.js submodules");
@@ -38,7 +38,7 @@ function runTtx(ttxResourcesHome, fontPath, registerOnCancel, callback) {
         PYTHONDONTWRITEBYTECODE: true,
       };
       var ttxStdioMode = "ignore";
-      var ttx = spawn("python", [ttxPath, fontPath], {
+      var ttx = spawn("python", [ttxPath, realFontPath], {
         cwd: fontToolsHome,
         stdio: ttxStdioMode,
         env: ttxEnv,
@@ -49,8 +49,8 @@ function runTtx(ttxResourcesHome, fontPath, registerOnCancel, callback) {
         callback(reason);
         ttx.kill();
       });
-      ttx.on("error", function(err) {
-        ttxRunError = err;
+      ttx.on("error", function(errorTtx) {
+        ttxRunError = errorTtx;
         callback("Unable to execute ttx");
       });
       ttx.on("close", function(code) {

--- a/test/stats/statcmp.js
+++ b/test/stats/statcmp.js
@@ -37,16 +37,16 @@ function parseOptions() {
 function group(stats, groupBy) {
   var vals = [];
   for (var i = 0; i < stats.length; i++) {
-    var stat = stats[i];
+    var curStat = stats[i];
     var keyArr = [];
     for (var j = 0; j < groupBy.length; j++) {
-      keyArr.push(stat[groupBy[j]]);
+      keyArr.push(curStat[groupBy[j]]);
     }
     var key = keyArr.join(",");
     if (vals[key] === undefined) {
       vals[key] = [];
     }
-    vals[key].push(stat["time"]);
+    vals[key].push(curStat["time"]);
   }
   return vals;
 }
@@ -57,13 +57,13 @@ function group(stats, groupBy) {
  */
 function flatten(stats) {
   var rows = [];
-  stats.forEach(function(stat) {
-    stat["stats"].forEach(function(s) {
+  stats.forEach(function(curStat) {
+    curStat["stats"].forEach(function(s) {
       rows.push({
-        browser: stat["browser"],
-        page: stat["page"],
-        pdf: stat["pdf"],
-        round: stat["round"],
+        browser: curStat["browser"],
+        page: curStat["page"],
+        pdf: curStat["pdf"],
+        round: curStat["round"],
         stat: s["name"],
         time: s["end"] - s["start"],
       });

--- a/test/test.js
+++ b/test/test.js
@@ -619,8 +619,8 @@ function refTestPostHandler(req, res) {
     if (pathname === "/tellMeToQuit") {
       // finding by path
       var browserPath = parsedUrl.query.path;
-      session = sessions.filter(function(session) {
-        return session.config.path === browserPath;
+      session = sessions.filter(function(curSession) {
+        return curSession.config.path === browserPath;
       })[0];
       monitorBrowserTimeout(session, null);
       closeSession(session.name);
@@ -689,7 +689,7 @@ function refTestPostHandler(req, res) {
   return true;
 }
 
-function startUnitTest(url, name) {
+function startUnitTest(testUrl, name) {
   var startTime = Date.now();
   startServer();
   server.hooks["POST"].push(unitTestPostHandler);
@@ -712,7 +712,7 @@ function startUnitTest(url, name) {
     var runtime = (Date.now() - startTime) / 1000;
     console.log(name + " tests runtime was " + runtime.toFixed(1) + " seconds");
   };
-  startBrowsers(url, function(session) {
+  startBrowsers(testUrl, function(session) {
     session.numRuns = 0;
     session.numErrors = 0;
   });
@@ -784,7 +784,7 @@ function unitTestPostHandler(req, res) {
   return true;
 }
 
-function startBrowsers(url, initSessionCallback) {
+function startBrowsers(testUrl, initSessionCallback) {
   var browsers;
   if (options.browserManifestFile) {
     browsers = JSON.parse(fs.readFileSync(options.browserManifestFile));
@@ -801,7 +801,7 @@ function startBrowsers(url, initSessionCallback) {
     var browser = WebBrowser.create(b);
     var startUrl =
       getServerBaseAddress() +
-      url +
+      testUrl +
       "?browser=" +
       encodeURIComponent(b.name) +
       "&manifestFile=" +

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -479,29 +479,30 @@ describe("api", function() {
     });
   });
   describe("PDFDocument", function() {
-    var loadingTask;
-    var doc;
+    let pdfLoadingTask, pdfDocument;
 
     beforeAll(function(done) {
-      loadingTask = getDocument(basicApiGetDocumentParams);
-      loadingTask.promise.then(function(data) {
-        doc = data;
+      pdfLoadingTask = getDocument(basicApiGetDocumentParams);
+      pdfLoadingTask.promise.then(function(data) {
+        pdfDocument = data;
         done();
       });
     });
 
     afterAll(function(done) {
-      loadingTask.destroy().then(done);
+      pdfLoadingTask.destroy().then(done);
     });
 
     it("gets number of pages", function() {
-      expect(doc.numPages).toEqual(3);
+      expect(pdfDocument.numPages).toEqual(3);
     });
     it("gets fingerprint", function() {
-      expect(doc.fingerprint).toEqual("ea8b35919d6279a369e835bde778611b");
+      expect(pdfDocument.fingerprint).toEqual(
+        "ea8b35919d6279a369e835bde778611b"
+      );
     });
     it("gets page", function(done) {
-      var promise = doc.getPage(1);
+      var promise = pdfDocument.getPage(1);
       promise
         .then(function(data) {
           expect(data instanceof PDFPageProxy).toEqual(true);
@@ -511,9 +512,9 @@ describe("api", function() {
         .catch(done.fail);
     });
     it("gets non-existent page", function(done) {
-      var outOfRangePromise = doc.getPage(100);
-      var nonIntegerPromise = doc.getPage(2.5);
-      var nonNumberPromise = doc.getPage("1");
+      var outOfRangePromise = pdfDocument.getPage(100);
+      var nonIntegerPromise = pdfDocument.getPage(2.5);
+      var nonNumberPromise = pdfDocument.getPage("1");
 
       outOfRangePromise = outOfRangePromise.then(
         function() {
@@ -586,7 +587,7 @@ describe("api", function() {
     it("gets page index", function(done) {
       // reference to second page
       var ref = { num: 17, gen: 0 };
-      var promise = doc.getPageIndex(ref);
+      var promise = pdfDocument.getPageIndex(ref);
       promise
         .then(function(pageIndex) {
           expect(pageIndex).toEqual(1);
@@ -596,7 +597,7 @@ describe("api", function() {
     });
     it("gets invalid page index", function(done) {
       var ref = { num: 3, gen: 0 }; // Reference to a font dictionary.
-      var promise = doc.getPageIndex(ref);
+      var promise = pdfDocument.getPageIndex(ref);
       promise
         .then(function() {
           done.fail("shall fail for invalid page reference.");
@@ -608,7 +609,7 @@ describe("api", function() {
     });
 
     it("gets destinations, from /Dests dictionary", function(done) {
-      var promise = doc.getDestinations();
+      var promise = pdfDocument.getDestinations();
       promise
         .then(function(data) {
           expect(data).toEqual({
@@ -619,7 +620,7 @@ describe("api", function() {
         .catch(done.fail);
     });
     it("gets a destination, from /Dests dictionary", function(done) {
-      var promise = doc.getDestination("chapter1");
+      var promise = pdfDocument.getDestination("chapter1");
       promise
         .then(function(data) {
           expect(data).toEqual([
@@ -634,7 +635,9 @@ describe("api", function() {
         .catch(done.fail);
     });
     it("gets a non-existent destination, from /Dests dictionary", function(done) {
-      var promise = doc.getDestination("non-existent-named-destination");
+      const promise = pdfDocument.getDestination(
+        "non-existent-named-destination"
+      );
       promise
         .then(function(data) {
           expect(data).toEqual(null);
@@ -645,8 +648,8 @@ describe("api", function() {
 
     it("gets destinations, from /Names (NameTree) dictionary", function(done) {
       var loadingTask = getDocument(buildGetDocumentParams("issue6204.pdf"));
-      var promise = loadingTask.promise.then(function(pdfDocument) {
-        return pdfDocument.getDestinations();
+      var promise = loadingTask.promise.then(function(pdfDoc) {
+        return pdfDoc.getDestinations();
       });
       promise
         .then(function(destinations) {
@@ -661,8 +664,8 @@ describe("api", function() {
     });
     it("gets a destination, from /Names (NameTree) dictionary", function(done) {
       var loadingTask = getDocument(buildGetDocumentParams("issue6204.pdf"));
-      var promise = loadingTask.promise.then(function(pdfDocument) {
-        return pdfDocument.getDestination("Page.1");
+      var promise = loadingTask.promise.then(function(pdfDoc) {
+        return pdfDoc.getDestination("Page.1");
       });
       promise
         .then(function(destination) {
@@ -680,8 +683,8 @@ describe("api", function() {
     });
     it("gets a non-existent destination, from /Names (NameTree) dictionary", function(done) {
       var loadingTask = getDocument(buildGetDocumentParams("issue6204.pdf"));
-      var promise = loadingTask.promise.then(function(pdfDocument) {
-        return pdfDocument.getDestination("non-existent-named-destination");
+      var promise = loadingTask.promise.then(function(pdfDoc) {
+        return pdfDoc.getDestination("non-existent-named-destination");
       });
       promise
         .then(function(destination) {
@@ -693,9 +696,9 @@ describe("api", function() {
     });
 
     it("gets non-string destination", function(done) {
-      let numberPromise = doc.getDestination(4.3);
-      let booleanPromise = doc.getDestination(true);
-      let arrayPromise = doc.getDestination([
+      let numberPromise = pdfDocument.getDestination(4.3);
+      let booleanPromise = pdfDocument.getDestination(true);
+      let arrayPromise = pdfDocument.getDestination([
         { num: 17, gen: 0 },
         { name: "XYZ" },
         0,
@@ -735,7 +738,7 @@ describe("api", function() {
     });
 
     it("gets non-existent page labels", function(done) {
-      var promise = doc.getPageLabels();
+      var promise = pdfDocument.getPageLabels();
       promise
         .then(function(data) {
           expect(data).toEqual(null);
@@ -791,8 +794,8 @@ describe("api", function() {
       var loadingTask = getDocument(buildGetDocumentParams("tracemonkey.pdf"));
 
       loadingTask.promise
-        .then(function(pdfDocument) {
-          return pdfDocument.getPageLayout();
+        .then(function(pdfDoc) {
+          return pdfDoc.getPageLayout();
         })
         .then(function(mode) {
           expect(mode).toEqual("");
@@ -802,7 +805,7 @@ describe("api", function() {
         .catch(done.fail);
     });
     it("gets non-default page layout", function(done) {
-      doc
+      pdfDocument
         .getPageLayout()
         .then(function(mode) {
           expect(mode).toEqual("SinglePage");
@@ -815,8 +818,8 @@ describe("api", function() {
       var loadingTask = getDocument(buildGetDocumentParams("tracemonkey.pdf"));
 
       loadingTask.promise
-        .then(function(pdfDocument) {
-          return pdfDocument.getPageMode();
+        .then(function(pdfDoc) {
+          return pdfDoc.getPageMode();
         })
         .then(function(mode) {
           expect(mode).toEqual("UseNone");
@@ -826,7 +829,7 @@ describe("api", function() {
         .catch(done.fail);
     });
     it("gets non-default page mode", function(done) {
-      doc
+      pdfDocument
         .getPageMode()
         .then(function(mode) {
           expect(mode).toEqual("UseOutlines");
@@ -839,8 +842,8 @@ describe("api", function() {
       var loadingTask = getDocument(buildGetDocumentParams("tracemonkey.pdf"));
 
       loadingTask.promise
-        .then(function(pdfDocument) {
-          return pdfDocument.getViewerPreferences();
+        .then(function(pdfDoc) {
+          return pdfDoc.getViewerPreferences();
         })
         .then(function(prefs) {
           expect(
@@ -852,7 +855,7 @@ describe("api", function() {
         .catch(done.fail);
     });
     it("gets non-default viewer preferences", function(done) {
-      doc
+      pdfDocument
         .getViewerPreferences()
         .then(function(prefs) {
           expect(prefs).toEqual({
@@ -867,8 +870,8 @@ describe("api", function() {
       var loadingTask = getDocument(buildGetDocumentParams("tracemonkey.pdf"));
 
       loadingTask.promise
-        .then(function(pdfDocument) {
-          return pdfDocument.getOpenActionDestination();
+        .then(function(pdfDoc) {
+          return pdfDoc.getOpenActionDestination();
         })
         .then(function(dest) {
           expect(dest).toEqual(null);
@@ -878,7 +881,7 @@ describe("api", function() {
         .catch(done.fail);
     });
     it("gets non-default open action destination", function(done) {
-      doc
+      pdfDocument
         .getOpenActionDestination()
         .then(function(dest) {
           expect(dest).toEqual([{ num: 15, gen: 0 }, { name: "FitH" }, null]);
@@ -888,7 +891,7 @@ describe("api", function() {
     });
 
     it("gets non-existent attachments", function(done) {
-      var promise = doc.getAttachments();
+      var promise = pdfDocument.getAttachments();
       promise
         .then(function(data) {
           expect(data).toEqual(null);
@@ -915,7 +918,7 @@ describe("api", function() {
     });
 
     it("gets javascript", function(done) {
-      var promise = doc.getJavaScript();
+      var promise = pdfDocument.getJavaScript();
       promise
         .then(function(data) {
           expect(data).toEqual(null);
@@ -974,8 +977,8 @@ describe("api", function() {
     it("gets non-existent outline", function(done) {
       var loadingTask = getDocument(buildGetDocumentParams("tracemonkey.pdf"));
 
-      var promise = loadingTask.promise.then(function(pdfDocument) {
-        return pdfDocument.getOutline();
+      var promise = loadingTask.promise.then(function(pdfDoc) {
+        return pdfDoc.getOutline();
       });
       promise
         .then(function(outline) {
@@ -986,7 +989,7 @@ describe("api", function() {
         .catch(done.fail);
     });
     it("gets outline", function(done) {
-      var promise = doc.getOutline();
+      var promise = pdfDocument.getOutline();
       promise
         .then(function(outline) {
           // Two top level entries.
@@ -1016,8 +1019,8 @@ describe("api", function() {
       var loadingTask = getDocument(buildGetDocumentParams("issue3214.pdf"));
 
       loadingTask.promise
-        .then(function(pdfDocument) {
-          pdfDocument.getOutline().then(function(outline) {
+        .then(function(pdfDoc) {
+          pdfDoc.getOutline().then(function(outline) {
             expect(Array.isArray(outline)).toEqual(true);
             expect(outline.length).toEqual(5);
 
@@ -1042,7 +1045,7 @@ describe("api", function() {
     });
 
     it("gets non-existent permissions", function(done) {
-      doc
+      pdfDocument
         .getPermissions()
         .then(function(permissions) {
           expect(permissions).toEqual(null);
@@ -1057,24 +1060,24 @@ describe("api", function() {
       const loadingTask0 = getDocument(
         buildGetDocumentParams("issue9972-1.pdf")
       );
-      const promise0 = loadingTask0.promise.then(function(pdfDocument) {
-        return pdfDocument.getPermissions();
+      const promise0 = loadingTask0.promise.then(function(pdfDoc) {
+        return pdfDoc.getPermissions();
       });
 
       // Printing not allowed.
       const loadingTask1 = getDocument(
         buildGetDocumentParams("issue9972-2.pdf")
       );
-      const promise1 = loadingTask1.promise.then(function(pdfDocument) {
-        return pdfDocument.getPermissions();
+      const promise1 = loadingTask1.promise.then(function(pdfDoc) {
+        return pdfDoc.getPermissions();
       });
 
       // Copying not allowed.
       const loadingTask2 = getDocument(
         buildGetDocumentParams("issue9972-3.pdf")
       );
-      const promise2 = loadingTask2.promise.then(function(pdfDocument) {
-        return pdfDocument.getPermissions();
+      const promise2 = loadingTask2.promise.then(function(pdfDoc) {
+        return pdfDoc.getPermissions();
       });
 
       const totalPermissionCount = Object.keys(PermissionFlag).length;
@@ -1104,7 +1107,7 @@ describe("api", function() {
     });
 
     it("gets metadata", function(done) {
-      var promise = doc.getMetadata();
+      var promise = pdfDocument.getMetadata();
       promise
         .then(function({ info, metadata, contentDispositionFilename }) {
           expect(info["Title"]).toEqual("Basic API Test");
@@ -1129,8 +1132,8 @@ describe("api", function() {
       var loadingTask = getDocument(buildGetDocumentParams("tracemonkey.pdf"));
 
       loadingTask.promise
-        .then(function(pdfDocument) {
-          return pdfDocument.getMetadata();
+        .then(function(pdfDoc) {
+          return pdfDoc.getMetadata();
         })
         .then(function({ info, metadata, contentDispositionFilename }) {
           expect(info["Creator"]).toEqual("TeX");
@@ -1162,8 +1165,8 @@ describe("api", function() {
       const loadingTask = getDocument(buildGetDocumentParams("bug1606566.pdf"));
 
       loadingTask.promise
-        .then(function(pdfDocument) {
-          return pdfDocument.getMetadata();
+        .then(function(pdfDoc) {
+          return pdfDoc.getMetadata();
         })
         .then(function({ info, metadata, contentDispositionFilename }) {
           // The following are PDF.js specific, non-standard, properties.
@@ -1182,7 +1185,7 @@ describe("api", function() {
     });
 
     it("gets data", function(done) {
-      var promise = doc.getData();
+      var promise = pdfDocument.getData();
       promise
         .then(function(data) {
           expect(data instanceof Uint8Array).toEqual(true);
@@ -1192,7 +1195,7 @@ describe("api", function() {
         .catch(done.fail);
     });
     it("gets download info", function(done) {
-      var promise = doc.getDownloadInfo();
+      var promise = pdfDocument.getDownloadInfo();
       promise
         .then(function(data) {
           expect(data).toEqual({ length: basicApiFileLength });
@@ -1201,7 +1204,7 @@ describe("api", function() {
         .catch(done.fail);
     });
     it("gets document stats", function(done) {
-      var promise = doc.getStats();
+      var promise = pdfDocument.getStats();
       promise
         .then(function(stats) {
           expect(stats).toEqual({ streamTypes: {}, fontTypes: {} });
@@ -1211,7 +1214,7 @@ describe("api", function() {
     });
 
     it("cleans up document resources", function(done) {
-      const promise = doc.cleanup();
+      const promise = pdfDocument.cleanup();
       promise.then(function() {
         expect(true).toEqual(true);
         done();
@@ -1321,12 +1324,11 @@ describe("api", function() {
     });
   });
   describe("Page", function() {
-    var loadingTask;
-    var pdfDocument, page;
+    let pdfLoadingTask, pdfDocument, page;
 
     beforeAll(function(done) {
-      loadingTask = getDocument(basicApiGetDocumentParams);
-      loadingTask.promise
+      pdfLoadingTask = getDocument(basicApiGetDocumentParams);
+      pdfLoadingTask.promise
         .then(function(doc) {
           pdfDocument = doc;
           pdfDocument.getPage(1).then(function(data) {
@@ -1338,7 +1340,7 @@ describe("api", function() {
     });
 
     afterAll(function(done) {
-      loadingTask.destroy().then(done);
+      pdfLoadingTask.destroy().then(done);
     });
 
     it("gets page number", function() {

--- a/test/unit/cff_parser_spec.js
+++ b/test/unit/cff_parser_spec.js
@@ -172,17 +172,21 @@ describe("CFFParser", function() {
   });
 
   it("parses a CharString endchar with 4 args w/seac enabled", function() {
-    var parser = new CFFParser(fontData, {}, /* seacAnalysisEnabled = */ true);
-    parser.parse(); // cff
+    const cffParser = new CFFParser(
+      fontData,
+      {},
+      /* seacAnalysisEnabled = */ true
+    );
+    cffParser.parse(); // cff
 
     // prettier-ignore
     var bytes = new Uint8Array([0, 1, // count
                                 1,  // offsetSize
                                 0,  // offset[0]
                                 237, 247, 22, 247, 72, 204, 247, 86, 14]);
-    parser.bytes = bytes;
-    var charStringsIndex = parser.parseIndex(0).obj;
-    var result = parser.parseCharStrings({
+    cffParser.bytes = bytes;
+    var charStringsIndex = cffParser.parseIndex(0).obj;
+    var result = cffParser.parseCharStrings({
       charStrings: charStringsIndex,
       privateDict: privateDictStub,
     });
@@ -197,17 +201,21 @@ describe("CFFParser", function() {
   });
 
   it("parses a CharString endchar with 4 args w/seac disabled", function() {
-    var parser = new CFFParser(fontData, {}, /* seacAnalysisEnabled = */ false);
-    parser.parse(); // cff
+    const cffParser = new CFFParser(
+      fontData,
+      {},
+      /* seacAnalysisEnabled = */ false
+    );
+    cffParser.parse(); // cff
 
     // prettier-ignore
     var bytes = new Uint8Array([0, 1, // count
                                 1,  // offsetSize
                                 0,  // offset[0]
                                 237, 247, 22, 247, 72, 204, 247, 86, 14]);
-    parser.bytes = bytes;
-    var charStringsIndex = parser.parseIndex(0).obj;
-    var result = parser.parseCharStrings({
+    cffParser.bytes = bytes;
+    var charStringsIndex = cffParser.parseIndex(0).obj;
+    var result = cffParser.parseCharStrings({
       charStrings: charStringsIndex,
       privateDict: privateDictStub,
     });

--- a/test/unit/core_utils_spec.js
+++ b/test/unit/core_utils_spec.js
@@ -16,7 +16,7 @@
 import { Dict, Ref } from "../../src/core/primitives.js";
 import {
   getInheritableProperty,
-  isSpace,
+  isWhiteSpace,
   log2,
   toRomanNumerals,
 } from "../../src/core/core_utils.js";
@@ -197,18 +197,18 @@ describe("core_utils", function() {
     });
   });
 
-  describe("isSpace", function() {
+  describe("isWhiteSpace", function() {
     it("handles space characters", function() {
-      expect(isSpace(0x20)).toEqual(true);
-      expect(isSpace(0x09)).toEqual(true);
-      expect(isSpace(0x0d)).toEqual(true);
-      expect(isSpace(0x0a)).toEqual(true);
+      expect(isWhiteSpace(0x20)).toEqual(true);
+      expect(isWhiteSpace(0x09)).toEqual(true);
+      expect(isWhiteSpace(0x0d)).toEqual(true);
+      expect(isWhiteSpace(0x0a)).toEqual(true);
     });
 
     it("handles non-space characters", function() {
-      expect(isSpace(0x0b)).toEqual(false);
-      expect(isSpace(null)).toEqual(false);
-      expect(isSpace(undefined)).toEqual(false);
+      expect(isWhiteSpace(0x0b)).toEqual(false);
+      expect(isWhiteSpace(null)).toEqual(false);
+      expect(isWhiteSpace(undefined)).toEqual(false);
     });
   });
 });

--- a/test/unit/parser_spec.js
+++ b/test/unit/parser_spec.js
@@ -159,11 +159,11 @@ describe("parser", function() {
 
         const numbers = ["..", "-.", "+.", "-\r\n.", "+\r\n."];
         for (const number of numbers) {
-          const input = new StringStream(number);
-          const lexer = new Lexer(input);
+          const invalidInput = new StringStream(number);
+          const invalidLexer = new Lexer(invalidInput);
 
           expect(function() {
-            return lexer.getNumber();
+            return invalidLexer.getNumber();
           }).toThrowError(FormatError, /^Invalid number:\s/);
         }
       });

--- a/test/webbrowser.js
+++ b/test/webbrowser.js
@@ -26,9 +26,9 @@ var crypto = require("crypto");
 
 var tempDirPrefix = "pdfjs_";
 
-function WebBrowser(name, path, headless) {
+function WebBrowser(name, execPath, headless) {
   this.name = name;
-  this.path = path;
+  this.path = execPath;
   this.headless = headless;
   this.tmpDir = null;
   this.profileDir = null;
@@ -197,7 +197,7 @@ WebBrowser.prototype = {
     // Note: First process' output it shown, the later outputs are suppressed.
     execAsyncNoStdin(
       cmdKillAll,
-      function checkAlive(exitCode, firstStdout) {
+      function checkAlive(firstExitCode, firstStdout) {
         execAsyncNoStdin(
           cmdCheckAllKilled,
           function(exitCode, stdout) {
@@ -227,14 +227,14 @@ WebBrowser.prototype = {
 
 var firefoxResourceDir = path.join(__dirname, "resources", "firefox");
 
-function FirefoxBrowser(name, path, headless) {
+function FirefoxBrowser(name, execPath, headless) {
   if (os.platform() === "darwin") {
-    var m = /([^.\/]+)\.app(\/?)$/.exec(path);
+    var m = /([^.\/]+)\.app(\/?)$/.exec(execPath);
     if (m) {
-      path += (m[2] ? "" : "/") + "Contents/MacOS/firefox";
+      execPath += (m[2] ? "" : "/") + "Contents/MacOS/firefox";
     }
   }
-  WebBrowser.call(this, name, path, headless);
+  WebBrowser.call(this, name, execPath, headless);
 }
 FirefoxBrowser.prototype = Object.create(WebBrowser.prototype);
 FirefoxBrowser.prototype.buildArguments = function(url) {
@@ -253,15 +253,15 @@ FirefoxBrowser.prototype.setupProfileDir = function(dir) {
   testUtils.copySubtreeSync(firefoxResourceDir, dir);
 };
 
-function ChromiumBrowser(name, path, headless) {
+function ChromiumBrowser(name, execPath, headless) {
   if (os.platform() === "darwin") {
-    var m = /([^.\/]+)\.app(\/?)$/.exec(path);
+    var m = /([^.\/]+)\.app(\/?)$/.exec(execPath);
     if (m) {
-      path += (m[2] ? "" : "/") + "Contents/MacOS/" + m[1];
-      console.log(path);
+      execPath += (m[2] ? "" : "/") + "Contents/MacOS/" + m[1];
+      console.log(execPath);
     }
   }
-  WebBrowser.call(this, name, path, headless);
+  WebBrowser.call(this, name, execPath, headless);
 }
 ChromiumBrowser.prototype = Object.create(WebBrowser.prototype);
 ChromiumBrowser.prototype.buildArguments = function(url) {
@@ -291,18 +291,18 @@ ChromiumBrowser.prototype.buildArguments = function(url) {
 
 WebBrowser.create = function(desc) {
   var name = desc.name;
-  var path = fs.realpathSync(desc.path);
-  if (!path) {
+  var execPath = fs.realpathSync(desc.path);
+  if (!execPath) {
     throw new Error("Browser executable not found: " + desc.path);
   }
 
   if (/firefox/i.test(name)) {
-    return new FirefoxBrowser(name, path, desc.headless);
+    return new FirefoxBrowser(name, execPath, desc.headless);
   }
   if (/(chrome|chromium|opera)/i.test(name)) {
-    return new ChromiumBrowser(name, path, desc.headless);
+    return new ChromiumBrowser(name, execPath, desc.headless);
   }
-  return new WebBrowser(name, path, desc.headless);
+  return new WebBrowser(name, execPath, desc.headless);
 };
 
 exports.WebBrowser = WebBrowser;

--- a/test/webserver.js
+++ b/test/webserver.js
@@ -283,15 +283,15 @@ WebServer.prototype = {
       });
     }
 
-    function serveRequestedFile(filePath) {
-      var stream = fs.createReadStream(filePath, { flags: "rs" });
+    function serveRequestedFile(reqFilePath) {
+      var stream = fs.createReadStream(reqFilePath, { flags: "rs" });
 
       stream.on("error", function(error) {
         res.writeHead(500);
         res.end();
       });
 
-      var ext = path.extname(filePath).toLowerCase();
+      var ext = path.extname(reqFilePath).toLowerCase();
       var contentType = mimeTypes[ext] || defaultMimeType;
 
       if (!disableRangeRequests) {
@@ -309,8 +309,8 @@ WebServer.prototype = {
       stream.pipe(res);
     }
 
-    function serveRequestedFileRange(filePath, start, end) {
-      var stream = fs.createReadStream(filePath, {
+    function serveRequestedFileRange(reqFilePath, start, end) {
+      var stream = fs.createReadStream(reqFilePath, {
         flags: "rs",
         start: start,
         end: end - 1,
@@ -321,7 +321,7 @@ WebServer.prototype = {
         res.end();
       });
 
-      var ext = path.extname(filePath).toLowerCase();
+      var ext = path.extname(reqFilePath).toLowerCase();
       var contentType = mimeTypes[ext] || defaultMimeType;
 
       res.setHeader("Accept-Ranges", "bytes");

--- a/web/app.js
+++ b/web/app.js
@@ -1741,7 +1741,7 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
     "http://mozilla.github.io",
     "https://mozilla.github.io",
   ];
-  validateFileURL = function validateFileURL(file) {
+  validateFileURL = function(file) {
     if (file === undefined) {
       return;
     }
@@ -1917,7 +1917,7 @@ function webViewerInitialized() {
 
 let webViewerOpenFileViaURL;
 if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-  webViewerOpenFileViaURL = function webViewerOpenFileViaURL(file) {
+  webViewerOpenFileViaURL = function(file) {
     if (file && file.lastIndexOf("file:", 0) === 0) {
       // file:-scheme. Load the contents in the main thread because QtWebKit
       // cannot load file:-URLs in a Web Worker. file:-URLs are usually loaded
@@ -1938,12 +1938,12 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
     }
   };
 } else if (PDFJSDev.test("MOZCENTRAL || CHROME")) {
-  webViewerOpenFileViaURL = function webViewerOpenFileViaURL(file) {
+  webViewerOpenFileViaURL = function(file) {
     PDFViewerApplication.setTitleUsingUrl(file);
     PDFViewerApplication.initPassiveLoading();
   };
 } else {
-  webViewerOpenFileViaURL = function webViewerOpenFileViaURL(file) {
+  webViewerOpenFileViaURL = function(file) {
     if (file) {
       throw new Error("Not implemented: webViewerOpenFileViaURL");
     }
@@ -2149,7 +2149,7 @@ function webViewerHashchange(evt) {
 
 let webViewerFileInputChange;
 if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-  webViewerFileInputChange = function webViewerFileInputChange(evt) {
+  webViewerFileInputChange = function(evt) {
     if (
       PDFViewerApplication.pdfViewer &&
       PDFViewerApplication.pdfViewer.isInPresentationMode
@@ -2168,8 +2168,8 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       PDFViewerApplication.setTitleUsingUrl(file.name);
       // Read the local file into a Uint8Array.
       const fileReader = new FileReader();
-      fileReader.onload = function webViewerChangeFileReaderOnload(evt) {
-        const buffer = evt.target.result;
+      fileReader.onload = function webViewerChangeFileReaderOnload(event) {
+        const buffer = event.target.result;
         PDFViewerApplication.open(new Uint8Array(buffer));
       };
       fileReader.readAsArrayBuffer(file);

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -290,6 +290,7 @@ var Stepper = (function StepperClosure() {
     return simpleObj;
   }
 
+  // eslint-disable-next-line no-shadow
   function Stepper(panel, pageIndex, initialBreakPoints) {
     this.panel = panel;
     this.breakPoint = 0;

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -109,7 +109,7 @@ var FontInspector = (function FontInspectorClosure() {
         return moreInfo;
       }
       var moreInfo = properties(fontObj, ["name", "type"]);
-      var fontName = fontObj.loadedName;
+      const fontName = fontObj.loadedName;
       var font = document.createElement("div");
       var name = document.createElement("span");
       name.textContent = fontName;
@@ -130,17 +130,12 @@ var FontInspector = (function FontInspectorClosure() {
         event.preventDefault();
         console.log(fontObj);
       });
-      var select = document.createElement("input");
+      const select = document.createElement("input");
       select.setAttribute("type", "checkbox");
       select.dataset.fontName = fontName;
-      select.addEventListener(
-        "click",
-        (function(select, fontName) {
-          return function() {
-            selectFont(fontName, select.checked);
-          };
-        })(select, fontName)
-      );
+      select.addEventListener("click", function() {
+        selectFont(fontName, select.checked);
+      });
       font.appendChild(select);
       font.appendChild(name);
       font.appendChild(document.createTextNode(" "));
@@ -477,7 +472,7 @@ var Stats = (function Stats() {
       }
       var statsIndex = getStatIndex(pageNumber);
       if (statsIndex !== false) {
-        var b = stats[statsIndex];
+        const b = stats[statsIndex];
         this.panel.removeChild(b.div);
         stats.splice(statsIndex, 1);
       }

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -338,12 +338,12 @@ class PDFDocumentProperties {
     };
 
     let pageName = null;
-    let name =
+    let rawName =
       getPageName(sizeInches, isPortrait, US_PAGE_NAMES) ||
       getPageName(sizeMillimeters, isPortrait, METRIC_PAGE_NAMES);
 
     if (
-      !name &&
+      !rawName &&
       !(
         Number.isInteger(sizeMillimeters.width) &&
         Number.isInteger(sizeMillimeters.height)
@@ -366,8 +366,8 @@ class PDFDocumentProperties {
         Math.abs(exactMillimeters.width - intMillimeters.width) < 0.1 &&
         Math.abs(exactMillimeters.height - intMillimeters.height) < 0.1
       ) {
-        name = getPageName(intMillimeters, isPortrait, METRIC_PAGE_NAMES);
-        if (name) {
+        rawName = getPageName(intMillimeters, isPortrait, METRIC_PAGE_NAMES);
+        if (rawName) {
           // Update *both* sizes, computed above, to ensure that the displayed
           // dimensions always correspond to the detected page name.
           sizeInches = {
@@ -378,11 +378,11 @@ class PDFDocumentProperties {
         }
       }
     }
-    if (name) {
+    if (rawName) {
       pageName = this.l10n.get(
-        "document_properties_page_size_name_" + name.toLowerCase(),
+        "document_properties_page_size_name_" + rawName.toLowerCase(),
         null,
-        name
+        rawName
       );
     }
 

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -277,7 +277,7 @@ class PDFFindController {
    * the `matches` and keeps elements with a longer match length.
    */
   _prepareMatches(matchesWithLength, matches, matchesLength) {
-    function isSubTerm(matchesWithLength, currentIndex) {
+    function isSubTerm(currentIndex) {
       const currentElem = matchesWithLength[currentIndex];
       const nextElem = matchesWithLength[currentIndex + 1];
 
@@ -318,7 +318,7 @@ class PDFFindController {
         : a.match - b.match;
     });
     for (let i = 0, len = matchesWithLength.length; i < len; i++) {
-      if (isSubTerm(matchesWithLength, i)) {
+      if (isSubTerm(i)) {
         continue;
       }
       matches.push(matchesWithLength[i].match);

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -218,7 +218,7 @@ PDFPrintService.prototype = {
 };
 
 const print = window.print;
-window.print = function print() {
+window.print = function() {
   if (activeService) {
     console.warn("Ignored window.print() because of a pending print job.");
     return;

--- a/web/pdf_sidebar.js
+++ b/web/pdf_sidebar.js
@@ -367,8 +367,8 @@ class PDFSidebar {
       return;
     }
 
-    const removeNotification = view => {
-      switch (view) {
+    const removeNotification = sidebarView => {
+      switch (sidebarView) {
         case SidebarView.OUTLINE:
           this.outlineButton.classList.remove(UI_NOTIFICATION_CLASS);
           break;


### PR DESCRIPTION
This rule is *not* currently enabled in mozilla-central, but it appears commented out[1] in the ESLint definition file; see https://searchfox.org/mozilla-central/rev/2e355fa82aaa87e8424a9927c8136be184eeb6c7/tools/lint/eslint/eslint-plugin-mozilla/lib/configs/recommended.js#238-239

Unfortunately this rule is, for fairly obvious reasons, impossible to `--fix` automatically (even partially) and each case thus require careful manual tweaks.
Hence this ESLint rule is, by some margin, probably the most difficult one that we've enabled thus far. However, using this rule does seem like a good idea in general since allowing variable shadowing could lead to subtle (and difficult to find) bugs or at the very least confusing code.

*Please note:* Possibly these changes ought to have been split into *multiple* commits, e.g. one per directory, so if this is considered "un-reviewable" as-is I can try to do that.

Please find additional details about the ESLint rule at https://eslint.org/docs/rules/no-shadow

---
[1] This suggests, at least to me, a desire to possibly enable it at some future point. Most likely, a *very* large number of failures currently prevent doing so.

