### PR TITLE
Re-factor `Toolbar._adjustScaleWidth` to improve/simplify how the zoom dropdown width is calculated

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -700,8 +700,7 @@ html[dir='rtl'] .dropdownToolbarButton {
 }
 
 .dropdownToolbarButton {
-  width: 120px;
-  max-width: 120px;
+  width: 140px;
   padding: 0;
   overflow: hidden;
   background: url(images/toolbarButton-menuArrows.png) no-repeat;
@@ -714,7 +713,8 @@ html[dir='rtl'] .dropdownToolbarButton {
 }
 
 .dropdownToolbarButton > select {
-  min-width: 140px;
+  width: 162px;
+  height: 23px;
   font-size: 12px;
   color: rgba(242, 242, 242, 1);
   margin: 0;


### PR DESCRIPTION
This patch contains some *much* needed clean-up of, and improvements to, this old code thus addressing a number of issues:

 - Set more reasonable *default* values for the widths, in `web/viewer.css`, since the current ones are actually too small even for the (default) `en-US` locale.
   This obviously result in a slightly larger zoom dropdown width for many locales, but the more consistent UI does look good to me.

 - Stop setting the `min-width`/`max-width` and just use `width` instead.

 - Set an explicit `height` of the zoom dropdown, in an attempt to get Google Chrome to display it with the same height as the toolbar buttons.

 - Remove additional `Element.setAttribute("style", ...)` usage.

 - Actually check *all* of the predefined l10n strings, since the old implementation (implicitly) assumed that the currently selected one was the longest (note e.g. the `ja-JP` locale where one string is considerably longer than the rest).

 - Stop invalidating the DOM multiple times when doing the measurements. This was achieved by using a temporary in-memory `canvas`, and we now only need to query the DOM once in order to get the current font properties of the zoom dropdown.

Fixes #11576 