### PR TITLE
Enable the ESLint `no-var` rule in the `src/` folder

### DIFF
--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "extends": [
+    "../.eslintrc"
+  ],
+
+  "rules": {
+    // ECMAScript 6
+    "no-var": "error",
+  },
+}

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 import {
   AnnotationBorderStyleType,

--- a/src/core/arithmetic_decoder.js
+++ b/src/core/arithmetic_decoder.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 // Table C-2
 const QeTable = [

--- a/src/core/bidi.js
+++ b/src/core/bidi.js
@@ -18,7 +18,7 @@ import { warn } from "../shared/util.js";
 // Character types for symbols from 0000 to 00FF.
 // Source: ftp://ftp.unicode.org/Public/UNIDATA/UnicodeData.txt
 // prettier-ignore
-var baseTypes = [
+const baseTypes = [
   "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "S", "B", "S",
   "WS", "B", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN",
   "BN", "BN", "BN", "BN", "B", "B", "B", "S", "WS", "ON", "ON", "ET",
@@ -48,7 +48,7 @@ var baseTypes = [
 // empty string and issue a warning if we encounter this character. The
 // empty string is required to properly index the items after it.
 // prettier-ignore
-var arabicTypes = [
+const arabicTypes = [
   "AN", "AN", "AN", "AN", "AN", "AN", "ON", "ON", "AL", "ET", "ET", "AL",
   "CS", "AL", "ON", "ON", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM",
   "NSM", "NSM", "NSM", "NSM", "AL", "AL", "", "AL", "AL", "AL", "AL", "AL",
@@ -91,14 +91,14 @@ function findUnequal(arr, start, value) {
 }
 
 function setValues(arr, start, end, value) {
-  for (var j = start; j < end; ++j) {
+  for (let j = start; j < end; ++j) {
     arr[j] = value;
   }
 }
 
 function reverseValues(arr, start, end) {
-  for (var i = start, j = end - 1; i < j; ++i, --j) {
-    var temp = arr[i];
+  for (let i = start, j = end - 1; i < j; ++i, --j) {
+    const temp = arr[i];
     arr[i] = arr[j];
     arr[j] = temp;
   }
@@ -116,12 +116,12 @@ function createBidiText(str, isLTR, vertical = false) {
 
 // These are used in bidi(), which is called frequently. We re-use them on
 // each call to avoid unnecessary allocations.
-var chars = [];
-var types = [];
+const chars = [];
+const types = [];
 
 function bidi(str, startLevel, vertical) {
-  var isLTR = true;
-  var strLength = str.length;
+  let isLTR = true;
+  const strLength = str.length;
   if (strLength === 0 || vertical) {
     return createBidiText(str, isLTR, vertical);
   }
@@ -129,14 +129,14 @@ function bidi(str, startLevel, vertical) {
   // Get types and fill arrays
   chars.length = strLength;
   types.length = strLength;
-  var numBidi = 0;
+  let numBidi = 0;
 
-  var i, ii;
+  let i, ii;
   for (i = 0; i < strLength; ++i) {
     chars[i] = str.charAt(i);
 
-    var charCode = str.charCodeAt(i);
-    var charType = "L";
+    const charCode = str.charCodeAt(i);
+    let charType = "L";
     if (charCode <= 0x00ff) {
       charType = baseTypes[charCode];
     } else if (0x0590 <= charCode && charCode <= 0x05f4) {
@@ -174,7 +174,7 @@ function bidi(str, startLevel, vertical) {
     }
   }
 
-  var levels = [];
+  const levels = [];
   for (i = 0; i < strLength; ++i) {
     levels[i] = startLevel;
   }
@@ -182,16 +182,16 @@ function bidi(str, startLevel, vertical) {
   /*
    X1-X10: skip most of this, since we are NOT doing the embeddings.
    */
-  var e = isOdd(startLevel) ? "R" : "L";
-  var sor = e;
-  var eor = sor;
+  const e = isOdd(startLevel) ? "R" : "L";
+  const sor = e;
+  const eor = sor;
 
   /*
    W1. Examine each non-spacing mark (NSM) in the level run, and change the
    type of the NSM to the type of the previous character. If the NSM is at the
    start of the level run, it will get the type of sor.
    */
-  var lastType = sor;
+  let lastType = sor;
   for (i = 0; i < strLength; ++i) {
     if (types[i] === "NSM") {
       types[i] = lastType;
@@ -206,7 +206,7 @@ function bidi(str, startLevel, vertical) {
    the type of the European number to Arabic number.
    */
   lastType = sor;
-  var t;
+  let t;
   for (i = 0; i < strLength; ++i) {
     t = types[i];
     if (t === "EN") {
@@ -301,13 +301,13 @@ function bidi(str, startLevel, vertical) {
    */
   for (i = 0; i < strLength; ++i) {
     if (types[i] === "ON") {
-      var end = findUnequal(types, i + 1, "ON");
-      var before = sor;
+      const end = findUnequal(types, i + 1, "ON");
+      let before = sor;
       if (i > 0) {
         before = types[i - 1];
       }
 
-      var after = eor;
+      let after = eor;
       if (end + 1 < strLength) {
         after = types[end + 1];
       }
@@ -376,9 +376,9 @@ function bidi(str, startLevel, vertical) {
    */
 
   // find highest level & lowest odd level
-  var highestLevel = -1;
-  var lowestOddLevel = 99;
-  var level;
+  let highestLevel = -1;
+  let lowestOddLevel = 99;
+  let level;
   for (i = 0, ii = levels.length; i < ii; ++i) {
     level = levels[i];
     if (highestLevel < level) {
@@ -392,7 +392,7 @@ function bidi(str, startLevel, vertical) {
   // now reverse between those limits
   for (level = highestLevel; level >= lowestOddLevel; --level) {
     // find segments to reverse
-    var start = -1;
+    let start = -1;
     for (i = 0, ii = levels.length; i < ii; ++i) {
       if (levels[i] < level) {
         if (start >= 0) {
@@ -427,7 +427,7 @@ function bidi(str, startLevel, vertical) {
 
   // Finally, return string
   for (i = 0, ii = chars.length; i < ii; ++i) {
-    var ch = chars[i];
+    const ch = chars[i];
     if (ch === "<" || ch === ">") {
       chars[i] = "";
     }

--- a/src/core/ccitt_stream.js
+++ b/src/core/ccitt_stream.js
@@ -17,7 +17,7 @@ import { Dict, isDict } from "./primitives.js";
 import { CCITTFaxDecoder } from "./ccitt.js";
 import { DecodeStream } from "./stream.js";
 
-var CCITTFaxStream = (function CCITTFaxStreamClosure() {
+const CCITTFaxStream = (function CCITTFaxStreamClosure() {
   function CCITTFaxStream(str, maybeLength, params) {
     this.str = str;
     this.dict = str.dict;

--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -29,14 +29,14 @@ import {
 import { ExpertEncoding, StandardEncoding } from "./encodings.js";
 
 // Maximum subroutine call depth of type 2 chartrings. Matches OTS.
-var MAX_SUBR_NESTING = 10;
+const MAX_SUBR_NESTING = 10;
 
 /**
  * The CFF class takes a Type1 file and wrap it into a
  * 'Compact Font Format' which itself embed Type2 charstrings.
  */
 // prettier-ignore
-var CFFStandardStrings = [
+const CFFStandardStrings = [
   ".notdef", "space", "exclam", "quotedbl", "numbersign", "dollar", "percent",
   "ampersand", "quoteright", "parenleft", "parenright", "asterisk", "plus",
   "comma", "hyphen", "period", "slash", "zero", "one", "two", "three", "four",
@@ -106,8 +106,8 @@ var CFFStandardStrings = [
 
 const NUM_STANDARD_CFF_STRINGS = 391;
 
-var CFFParser = (function CFFParserClosure() {
-  var CharstringValidationData = [
+const CFFParser = (function CFFParserClosure() {
+  const CharstringValidationData = [
     null,
     { id: "hstem", min: 2, stackClearing: true, stem: true },
     null,
@@ -141,7 +141,7 @@ var CFFParser = (function CFFParserClosure() {
     { id: "vhcurveto", min: 4, resetStack: true },
     { id: "hvcurveto", min: 4, resetStack: true },
   ];
-  var CharstringValidationData12 = [
+  const CharstringValidationData12 = [
     null,
     null,
     null,
@@ -224,20 +224,20 @@ var CFFParser = (function CFFParserClosure() {
   }
   CFFParser.prototype = {
     parse: function CFFParser_parse() {
-      var properties = this.properties;
-      var cff = new CFF();
+      const properties = this.properties;
+      const cff = new CFF();
       this.cff = cff;
 
       // The first five sections must be in order, all the others are reached
       // via offsets contained in one of the below.
-      var header = this.parseHeader();
-      var nameIndex = this.parseIndex(header.endPos);
-      var topDictIndex = this.parseIndex(nameIndex.endPos);
-      var stringIndex = this.parseIndex(topDictIndex.endPos);
-      var globalSubrIndex = this.parseIndex(stringIndex.endPos);
+      const header = this.parseHeader();
+      const nameIndex = this.parseIndex(header.endPos);
+      const topDictIndex = this.parseIndex(nameIndex.endPos);
+      const stringIndex = this.parseIndex(topDictIndex.endPos);
+      const globalSubrIndex = this.parseIndex(stringIndex.endPos);
 
-      var topDictParsed = this.parseDict(topDictIndex.obj.get(0));
-      var topDict = this.createDict(CFFTopDict, topDictParsed, cff.strings);
+      const topDictParsed = this.parseDict(topDictIndex.obj.get(0));
+      const topDict = this.createDict(CFFTopDict, topDictParsed, cff.strings);
 
       cff.header = header.obj;
       cff.names = this.parseNameIndex(nameIndex.obj);
@@ -249,15 +249,15 @@ var CFFParser = (function CFFParserClosure() {
 
       cff.isCIDFont = topDict.hasName("ROS");
 
-      var charStringOffset = topDict.getByName("CharStrings");
-      var charStringIndex = this.parseIndex(charStringOffset).obj;
+      const charStringOffset = topDict.getByName("CharStrings");
+      const charStringIndex = this.parseIndex(charStringOffset).obj;
 
-      var fontMatrix = topDict.getByName("FontMatrix");
+      const fontMatrix = topDict.getByName("FontMatrix");
       if (fontMatrix) {
         properties.fontMatrix = fontMatrix;
       }
 
-      var fontBBox = topDict.getByName("FontBBox");
+      const fontBBox = topDict.getByName("FontBBox");
       if (fontBBox) {
         // adjusting ascent/descent
         properties.ascent = Math.max(fontBBox[3], fontBBox[1]);
@@ -265,12 +265,12 @@ var CFFParser = (function CFFParserClosure() {
         properties.ascentScaled = true;
       }
 
-      var charset, encoding;
+      let charset, encoding;
       if (cff.isCIDFont) {
-        var fdArrayIndex = this.parseIndex(topDict.getByName("FDArray")).obj;
-        for (var i = 0, ii = fdArrayIndex.count; i < ii; ++i) {
-          var dictRaw = fdArrayIndex.get(i);
-          var fontDict = this.createDict(
+        const fdArrayIndex = this.parseIndex(topDict.getByName("FDArray")).obj;
+        for (let i = 0, ii = fdArrayIndex.count; i < ii; ++i) {
+          const dictRaw = fdArrayIndex.get(i);
+          const fontDict = this.createDict(
             CFFTopDict,
             this.parseDict(dictRaw),
             cff.strings
@@ -308,7 +308,7 @@ var CFFParser = (function CFFParserClosure() {
       cff.charset = charset;
       cff.encoding = encoding;
 
-      var charStringsAndSeacs = this.parseCharStrings({
+      const charStringsAndSeacs = this.parseCharStrings({
         charStrings: charStringIndex,
         localSubrIndex: topDict.privateDict.subrsIndex,
         globalSubrIndex: globalSubrIndex.obj,
@@ -323,9 +323,9 @@ var CFFParser = (function CFFParserClosure() {
       return cff;
     },
     parseHeader: function CFFParser_parseHeader() {
-      var bytes = this.bytes;
-      var bytesLength = bytes.length;
-      var offset = 0;
+      let bytes = this.bytes;
+      const bytesLength = bytes.length;
+      let offset = 0;
 
       // Prevent an infinite loop, by checking that the offset is within the
       // bounds of the bytes array. Necessary in empty, or invalid, font files.
@@ -340,18 +340,18 @@ var CFFParser = (function CFFParserClosure() {
         bytes = bytes.subarray(offset);
         this.bytes = bytes;
       }
-      var major = bytes[0];
-      var minor = bytes[1];
-      var hdrSize = bytes[2];
-      var offSize = bytes[3];
-      var header = new CFFHeader(major, minor, hdrSize, offSize);
+      const major = bytes[0];
+      const minor = bytes[1];
+      const hdrSize = bytes[2];
+      const offSize = bytes[3];
+      const header = new CFFHeader(major, minor, hdrSize, offSize);
       return { obj: header, endPos: hdrSize };
     },
     parseDict: function CFFParser_parseDict(dict) {
-      var pos = 0;
+      let pos = 0;
 
       function parseOperand() {
-        var value = dict[pos++];
+        let value = dict[pos++];
         if (value === 30) {
           return parseFloatOperand();
         } else if (value === 28) {
@@ -376,16 +376,16 @@ var CFFParser = (function CFFParserClosure() {
       }
 
       function parseFloatOperand() {
-        var str = "";
-        var eof = 15;
+        let str = "";
+        const eof = 15;
         // prettier-ignore
         const lookup = ["0", "1", "2", "3", "4", "5", "6", "7", "8",
                         "9", ".", "E", "E-", null, "-"];
-        var length = dict.length;
+        const length = dict.length;
         while (pos < length) {
-          var b = dict[pos++];
-          var b1 = b >> 4;
-          var b2 = b & 15;
+          const b = dict[pos++];
+          const b1 = b >> 4;
+          const b2 = b & 15;
 
           if (b1 === eof) {
             break;
@@ -400,13 +400,13 @@ var CFFParser = (function CFFParserClosure() {
         return parseFloat(str);
       }
 
-      var operands = [];
-      var entries = [];
+      let operands = [];
+      const entries = [];
 
       pos = 0;
-      var end = dict.length;
+      const end = dict.length;
       while (pos < end) {
-        var b = dict[pos];
+        let b = dict[pos];
         if (b <= 21) {
           if (b === 12) {
             b = (b << 8) | dict[++pos];
@@ -421,21 +421,21 @@ var CFFParser = (function CFFParserClosure() {
       return entries;
     },
     parseIndex: function CFFParser_parseIndex(pos) {
-      var cffIndex = new CFFIndex();
-      var bytes = this.bytes;
-      var count = (bytes[pos++] << 8) | bytes[pos++];
-      var offsets = [];
-      var end = pos;
-      var i, ii;
+      const cffIndex = new CFFIndex();
+      const bytes = this.bytes;
+      const count = (bytes[pos++] << 8) | bytes[pos++];
+      const offsets = [];
+      let end = pos;
+      let i, ii;
 
       if (count !== 0) {
-        var offsetSize = bytes[pos++];
+        const offsetSize = bytes[pos++];
         // add 1 for offset to determine size of last object
-        var startPos = pos + (count + 1) * offsetSize - 1;
+        const startPos = pos + (count + 1) * offsetSize - 1;
 
         for (i = 0, ii = count + 1; i < ii; ++i) {
-          var offset = 0;
-          for (var j = 0; j < offsetSize; ++j) {
+          let offset = 0;
+          for (let j = 0; j < offsetSize; ++j) {
             offset <<= 8;
             offset += bytes[pos++];
           }
@@ -444,34 +444,34 @@ var CFFParser = (function CFFParserClosure() {
         end = offsets[count];
       }
       for (i = 0, ii = offsets.length - 1; i < ii; ++i) {
-        var offsetStart = offsets[i];
-        var offsetEnd = offsets[i + 1];
+        const offsetStart = offsets[i];
+        const offsetEnd = offsets[i + 1];
         cffIndex.add(bytes.subarray(offsetStart, offsetEnd));
       }
       return { obj: cffIndex, endPos: end };
     },
     parseNameIndex: function CFFParser_parseNameIndex(index) {
-      var names = [];
-      for (var i = 0, ii = index.count; i < ii; ++i) {
-        var name = index.get(i);
+      const names = [];
+      for (let i = 0, ii = index.count; i < ii; ++i) {
+        const name = index.get(i);
         names.push(bytesToString(name));
       }
       return names;
     },
     parseStringIndex: function CFFParser_parseStringIndex(index) {
-      var strings = new CFFStrings();
-      for (var i = 0, ii = index.count; i < ii; ++i) {
-        var data = index.get(i);
+      const strings = new CFFStrings();
+      for (let i = 0, ii = index.count; i < ii; ++i) {
+        const data = index.get(i);
         strings.add(bytesToString(data));
       }
       return strings;
     },
     createDict: function CFFParser_createDict(Type, dict, strings) {
-      var cffDict = new Type(strings);
-      for (var i = 0, ii = dict.length; i < ii; ++i) {
-        var pair = dict[i];
-        var key = pair[0];
-        var value = pair[1];
+      const cffDict = new Type(strings);
+      for (let i = 0, ii = dict.length; i < ii; ++i) {
+        const pair = dict[i];
+        const key = pair[0];
+        const value = pair[1];
         cffDict.setByKey(key, value);
       }
       return cffDict;
@@ -485,16 +485,16 @@ var CFFParser = (function CFFParserClosure() {
       if (!data || state.callDepth > MAX_SUBR_NESTING) {
         return false;
       }
-      var stackSize = state.stackSize;
-      var stack = state.stack;
+      let stackSize = state.stackSize;
+      const stack = state.stack;
 
-      var length = data.length;
+      const length = data.length;
 
-      for (var j = 0; j < length; ) {
-        var value = data[j++];
-        var validationCommand = null;
+      for (let j = 0; j < length; ) {
+        const value = data[j++];
+        let validationCommand = null;
         if (value === 12) {
-          var q = data[j++];
+          const q = data[j++];
           if (q === 0) {
             // The CFF specification state that the 'dotsection' command
             // (12, 0) is deprecated and treated as a no-op, but all Type2
@@ -561,13 +561,13 @@ var CFFParser = (function CFFParserClosure() {
             warn("Missing subrsIndex for " + validationCommand.id);
             return false;
           }
-          var bias = 32768;
+          let bias = 32768;
           if (subrsIndex.count < 1240) {
             bias = 107;
           } else if (subrsIndex.count < 33900) {
             bias = 1131;
           }
-          var subrNumber = stack[--stackSize] + bias;
+          const subrNumber = stack[--stackSize] + bias;
           if (
             subrNumber < 0 ||
             subrNumber >= subrsIndex.count ||
@@ -579,7 +579,7 @@ var CFFParser = (function CFFParserClosure() {
           }
           state.stackSize = stackSize;
           state.callDepth++;
-          var valid = this.parseCharString(
+          const valid = this.parseCharString(
             state,
             subrsIndex.get(subrNumber),
             localSubrIndex,
@@ -667,12 +667,12 @@ var CFFParser = (function CFFParserClosure() {
       fdArray,
       privateDict,
     }) {
-      var seacs = [];
-      var widths = [];
-      var count = charStrings.count;
-      for (var i = 0; i < count; i++) {
-        var charstring = charStrings.get(i);
-        var state = {
+      const seacs = [];
+      const widths = [];
+      const count = charStrings.count;
+      for (let i = 0; i < count; i++) {
+        const charstring = charStrings.get(i);
+        const state = {
           callDepth: 0,
           stackSize: 0,
           stack: [],
@@ -683,11 +683,11 @@ var CFFParser = (function CFFParserClosure() {
           width: null,
           hasVStems: false,
         };
-        var valid = true;
-        var localSubrToUse = null;
-        var privateDictToUse = privateDict;
+        let valid = true;
+        let localSubrToUse = null;
+        let privateDictToUse = privateDict;
         if (fdSelect && fdArray.length) {
-          var fdIndex = fdSelect.getFDIndex(i);
+          const fdIndex = fdSelect.getFDIndex(i);
           if (fdIndex === -1) {
             warn("Glyph index is not in fd select.");
             valid = false;
@@ -731,7 +731,11 @@ var CFFParser = (function CFFParserClosure() {
     emptyPrivateDictionary: function CFFParser_emptyPrivateDictionary(
       parentDict
     ) {
-      var privateDict = this.createDict(CFFPrivateDict, [], parentDict.strings);
+      const privateDict = this.createDict(
+        CFFPrivateDict,
+        [],
+        parentDict.strings
+      );
       parentDict.setByKey(18, [0, 0]);
       parentDict.privateDict = privateDict;
     },
@@ -741,24 +745,24 @@ var CFFParser = (function CFFParserClosure() {
         this.emptyPrivateDictionary(parentDict);
         return;
       }
-      var privateOffset = parentDict.getByName("Private");
+      const privateOffset = parentDict.getByName("Private");
       // make sure the params are formatted correctly
       if (!Array.isArray(privateOffset) || privateOffset.length !== 2) {
         parentDict.removeByName("Private");
         return;
       }
-      var size = privateOffset[0];
-      var offset = privateOffset[1];
+      const size = privateOffset[0];
+      const offset = privateOffset[1];
       // remove empty dicts or ones that refer to invalid location
       if (size === 0 || offset >= this.bytes.length) {
         this.emptyPrivateDictionary(parentDict);
         return;
       }
 
-      var privateDictEnd = offset + size;
-      var dictData = this.bytes.subarray(offset, privateDictEnd);
-      var dict = this.parseDict(dictData);
-      var privateDict = this.createDict(
+      const privateDictEnd = offset + size;
+      const dictData = this.bytes.subarray(offset, privateDictEnd);
+      const dict = this.parseDict(dictData);
+      const privateDict = this.createDict(
         CFFPrivateDict,
         dict,
         parentDict.strings
@@ -769,14 +773,14 @@ var CFFParser = (function CFFParserClosure() {
       if (!privateDict.getByName("Subrs")) {
         return;
       }
-      var subrsOffset = privateDict.getByName("Subrs");
-      var relativeOffset = offset + subrsOffset;
+      const subrsOffset = privateDict.getByName("Subrs");
+      const relativeOffset = offset + subrsOffset;
       // Validate the offset.
       if (subrsOffset === 0 || relativeOffset >= this.bytes.length) {
         this.emptyPrivateDictionary(parentDict);
         return;
       }
-      var subrsIndex = this.parseIndex(relativeOffset);
+      const subrsIndex = this.parseIndex(relativeOffset);
       privateDict.subrsIndex = subrsIndex.obj;
     },
     parseCharsets: function CFFParser_parseCharsets(pos, length, strings, cid) {
@@ -800,11 +804,11 @@ var CFFParser = (function CFFParserClosure() {
         );
       }
 
-      var bytes = this.bytes;
-      var start = pos;
-      var format = bytes[pos++];
-      var charset = [".notdef"];
-      var id, count, i;
+      const bytes = this.bytes;
+      const start = pos;
+      const format = bytes[pos++];
+      const charset = [".notdef"];
+      let id, count, i;
 
       // subtract 1 for the .notdef glyph
       length -= 1;
@@ -838,8 +842,8 @@ var CFFParser = (function CFFParserClosure() {
           throw new FormatError("Unknown charset format");
       }
       // Raw won't be needed if we actually compile the charset.
-      var end = pos;
-      var raw = bytes.subarray(start, end);
+      const end = pos;
+      const raw = bytes.subarray(start, end);
 
       return new CFFCharset(false, format, charset, raw);
     },
@@ -849,17 +853,17 @@ var CFFParser = (function CFFParserClosure() {
       strings,
       charset
     ) {
-      var encoding = Object.create(null);
-      var bytes = this.bytes;
-      var predefined = false;
-      var format, i, ii;
-      var raw = null;
+      const encoding = Object.create(null);
+      const bytes = this.bytes;
+      let predefined = false;
+      let format, i, ii;
+      let raw = null;
 
       function readSupplement() {
-        var supplementsCount = bytes[pos++];
+        const supplementsCount = bytes[pos++];
         for (i = 0; i < supplementsCount; i++) {
-          var code = bytes[pos++];
-          var sid = (bytes[pos++] << 8) + (bytes[pos++] & 0xff);
+          const code = bytes[pos++];
+          const sid = (bytes[pos++] << 8) + (bytes[pos++] & 0xff);
           encoding[code] = charset.indexOf(strings.get(sid));
         }
       }
@@ -867,15 +871,15 @@ var CFFParser = (function CFFParserClosure() {
       if (pos === 0 || pos === 1) {
         predefined = true;
         format = pos;
-        var baseEncoding = pos ? ExpertEncoding : StandardEncoding;
+        const baseEncoding = pos ? ExpertEncoding : StandardEncoding;
         for (i = 0, ii = charset.length; i < ii; i++) {
-          var index = baseEncoding.indexOf(charset[i]);
+          const index = baseEncoding.indexOf(charset[i]);
           if (index !== -1) {
             encoding[index] = i;
           }
         }
       } else {
-        var dataStart = pos;
+        const dataStart = pos;
         format = bytes[pos++];
         switch (format & 0x7f) {
           case 0:
@@ -889,9 +893,9 @@ var CFFParser = (function CFFParserClosure() {
             var rangesCount = bytes[pos++];
             var gid = 1;
             for (i = 0; i < rangesCount; i++) {
-              var start = bytes[pos++];
-              var left = bytes[pos++];
-              for (var j = start; j <= start + left; j++) {
+              const start = bytes[pos++];
+              const left = bytes[pos++];
+              for (let j = start; j <= start + left; j++) {
                 encoding[j] = gid++;
               }
             }
@@ -900,7 +904,7 @@ var CFFParser = (function CFFParserClosure() {
           default:
             throw new FormatError(`Unknown encoding format: ${format} in CFF`);
         }
-        var dataEnd = pos;
+        const dataEnd = pos;
         if (format & 0x80) {
           // hasSupplement
           // The font sanitizer does not support CFF encoding with a
@@ -917,22 +921,22 @@ var CFFParser = (function CFFParserClosure() {
       return new CFFEncoding(predefined, format, encoding, raw);
     },
     parseFDSelect: function CFFParser_parseFDSelect(pos, length) {
-      var bytes = this.bytes;
-      var format = bytes[pos++];
-      var fdSelect = [];
-      var i;
+      const bytes = this.bytes;
+      const format = bytes[pos++];
+      const fdSelect = [];
+      let i;
 
       switch (format) {
         case 0:
           for (i = 0; i < length; ++i) {
-            var id = bytes[pos++];
+            const id = bytes[pos++];
             fdSelect.push(id);
           }
           break;
         case 3:
           var rangesCount = (bytes[pos++] << 8) | bytes[pos++];
           for (i = 0; i < rangesCount; ++i) {
-            var first = (bytes[pos++] << 8) | bytes[pos++];
+            let first = (bytes[pos++] << 8) | bytes[pos++];
             if (i === 0 && first !== 0) {
               warn(
                 "parseFDSelect: The first range must have a first GID of 0" +
@@ -940,9 +944,9 @@ var CFFParser = (function CFFParserClosure() {
               );
               first = 0;
             }
-            var fdIndex = bytes[pos++];
-            var next = (bytes[pos] << 8) | bytes[pos + 1];
-            for (var j = first; j < next; ++j) {
+            const fdIndex = bytes[pos++];
+            const next = (bytes[pos] << 8) | bytes[pos + 1];
+            for (let j = first; j < next; ++j) {
               fdSelect.push(fdIndex);
             }
           }
@@ -990,7 +994,7 @@ var CFF = (function CFFClosure() {
         warn("Not enough space in charstrings to duplicate first glyph.");
         return;
       }
-      var glyphZero = this.charStrings.get(0);
+      const glyphZero = this.charStrings.get(0);
       this.charStrings.add(glyphZero);
       if (this.isCIDFont) {
         this.fdSelect.fdSelect.push(this.fdSelect.fdSelect[0]);
@@ -1000,7 +1004,7 @@ var CFF = (function CFFClosure() {
       if (id < 0 || id >= this.charStrings.count) {
         return false;
       }
-      var glyph = this.charStrings.get(id);
+      const glyph = this.charStrings.get(id);
       return glyph.length > 0;
     },
   };
@@ -1077,7 +1081,7 @@ var CFFIndex = (function CFFIndexClosure() {
   return CFFIndex;
 })();
 
-var CFFDict = (function CFFDictClosure() {
+const CFFDict = (function CFFDictClosure() {
   function CFFDict(tables, strings) {
     this.keyToNameMap = tables.keyToNameMap;
     this.nameToKeyMap = tables.nameToKeyMap;
@@ -1094,19 +1098,19 @@ var CFFDict = (function CFFDictClosure() {
       if (!(key in this.keyToNameMap)) {
         return false;
       }
-      var valueLength = value.length;
+      const valueLength = value.length;
       // ignore empty values
       if (valueLength === 0) {
         return true;
       }
       // Ignore invalid values (fixes bug1068432.pdf and bug1308536.pdf).
-      for (var i = 0; i < valueLength; i++) {
+      for (let i = 0; i < valueLength; i++) {
         if (isNaN(value[i])) {
           warn('Invalid CFFDict value: "' + value + '" for key "' + key + '".');
           return true;
         }
       }
-      var type = this.types[key];
+      const type = this.types[key];
       // remove the array wrapping these types of values
       if (type === "num" || type === "sid" || type === "offset") {
         value = value[0];
@@ -1127,7 +1131,7 @@ var CFFDict = (function CFFDictClosure() {
       if (!(name in this.nameToKeyMap)) {
         throw new FormatError(`Invalid dictionary name ${name}"`);
       }
-      var key = this.nameToKeyMap[name];
+      const key = this.nameToKeyMap[name];
       if (!(key in this.values)) {
         return this.defaults[key];
       }
@@ -1138,7 +1142,7 @@ var CFFDict = (function CFFDictClosure() {
     },
   };
   CFFDict.createTables = function CFFDict_createTables(layout) {
-    var tables = {
+    const tables = {
       keyToNameMap: {},
       nameToKeyMap: {},
       defaults: {},
@@ -1146,9 +1150,9 @@ var CFFDict = (function CFFDictClosure() {
       opcodes: {},
       order: [],
     };
-    for (var i = 0, ii = layout.length; i < ii; ++i) {
-      var entry = layout[i];
-      var key = Array.isArray(entry[0])
+    for (let i = 0, ii = layout.length; i < ii; ++i) {
+      const entry = layout[i];
+      const key = Array.isArray(entry[0])
         ? (entry[0][0] << 8) + entry[0][1]
         : entry[0];
       tables.keyToNameMap[key] = entry[1];
@@ -1164,7 +1168,7 @@ var CFFDict = (function CFFDictClosure() {
 })();
 
 var CFFTopDict = (function CFFTopDictClosure() {
-  var layout = [
+  const layout = [
     [[12, 30], "ROS", ["sid", "sid", "num"], null],
     [[12, 20], "SyntheticBase", "num", null],
     [0, "version", "sid", null],
@@ -1204,7 +1208,7 @@ var CFFTopDict = (function CFFTopDictClosure() {
     [[12, 36], "FDArray", "offset", null],
     [[12, 38], "FontName", "sid", null],
   ];
-  var tables = null;
+  let tables = null;
   function CFFTopDict(strings) {
     if (tables === null) {
       tables = CFFDict.createTables(layout);
@@ -1217,7 +1221,7 @@ var CFFTopDict = (function CFFTopDictClosure() {
 })();
 
 var CFFPrivateDict = (function CFFPrivateDictClosure() {
-  var layout = [
+  const layout = [
     [6, "BlueValues", "delta", null],
     [7, "OtherBlues", "delta", null],
     [8, "FamilyBlues", "delta", null],
@@ -1237,7 +1241,7 @@ var CFFPrivateDict = (function CFFPrivateDictClosure() {
     [21, "nominalWidthX", "num", 0],
     [19, "Subrs", "offset", null],
   ];
-  var tables = null;
+  let tables = null;
   function CFFPrivateDict(strings) {
     if (tables === null) {
       tables = CFFDict.createTables(layout);
@@ -1292,7 +1296,7 @@ var CFFFDSelect = (function CFFFDSelectClosure() {
 
 // Helper class to keep track of where an offset is within the data and helps
 // filling in that offset once it's known.
-var CFFOffsetTracker = (function CFFOffsetTrackerClosure() {
+const CFFOffsetTracker = (function CFFOffsetTrackerClosure() {
   function CFFOffsetTracker() {
     this.offsets = Object.create(null);
   }
@@ -1307,7 +1311,7 @@ var CFFOffsetTracker = (function CFFOffsetTrackerClosure() {
       this.offsets[key] = location;
     },
     offset: function CFFOffsetTracker_offset(value) {
-      for (var key in this.offsets) {
+      for (const key in this.offsets) {
         this.offsets[key] += value;
       }
     },
@@ -1319,15 +1323,15 @@ var CFFOffsetTracker = (function CFFOffsetTrackerClosure() {
       if (!(key in this.offsets)) {
         throw new FormatError(`Not tracking location of ${key}`);
       }
-      var data = output.data;
-      var dataOffset = this.offsets[key];
-      var size = 5;
-      for (var i = 0, ii = values.length; i < ii; ++i) {
-        var offset0 = i * size + dataOffset;
-        var offset1 = offset0 + 1;
-        var offset2 = offset0 + 2;
-        var offset3 = offset0 + 3;
-        var offset4 = offset0 + 4;
+      const data = output.data;
+      const dataOffset = this.offsets[key];
+      const size = 5;
+      for (let i = 0, ii = values.length; i < ii; ++i) {
+        const offset0 = i * size + dataOffset;
+        const offset1 = offset0 + 1;
+        const offset2 = offset0 + 2;
+        const offset3 = offset0 + 3;
+        const offset4 = offset0 + 4;
         // It's easy to screw up offsets so perform this sanity check.
         if (
           data[offset0] !== 0x1d ||
@@ -1338,7 +1342,7 @@ var CFFOffsetTracker = (function CFFOffsetTrackerClosure() {
         ) {
           throw new FormatError("writing to an offset that is not empty");
         }
-        var value = values[i];
+        const value = values[i];
         data[offset0] = 0x1d;
         data[offset1] = (value >> 24) & 0xff;
         data[offset2] = (value >> 16) & 0xff;
@@ -1351,14 +1355,14 @@ var CFFOffsetTracker = (function CFFOffsetTrackerClosure() {
 })();
 
 // Takes a CFF and converts it to the binary representation.
-var CFFCompiler = (function CFFCompilerClosure() {
+const CFFCompiler = (function CFFCompilerClosure() {
   function CFFCompiler(cff) {
     this.cff = cff;
   }
   CFFCompiler.prototype = {
     compile: function CFFCompiler_compile() {
-      var cff = this.cff;
-      var output = {
+      const cff = this.cff;
+      const output = {
         data: [],
         length: 0,
         add: function CFFCompiler_add(data) {
@@ -1368,10 +1372,10 @@ var CFFCompiler = (function CFFCompilerClosure() {
       };
 
       // Compile the five entries that must be in order.
-      var header = this.compileHeader(cff.header);
+      const header = this.compileHeader(cff.header);
       output.add(header);
 
-      var nameIndex = this.compileNameIndex(cff.names);
+      const nameIndex = this.compileNameIndex(cff.names);
       output.add(nameIndex);
 
       if (cff.isCIDFont) {
@@ -1388,11 +1392,11 @@ var CFFCompiler = (function CFFCompilerClosure() {
         // To make this work on all platforms we move the top matrix into each
         // sub top dict and concat if necessary.
         if (cff.topDict.hasName("FontMatrix")) {
-          var base = cff.topDict.getByName("FontMatrix");
+          const base = cff.topDict.getByName("FontMatrix");
           cff.topDict.removeByName("FontMatrix");
-          for (var i = 0, ii = cff.fdArray.length; i < ii; i++) {
-            var subDict = cff.fdArray[i];
-            var matrix = base.slice(0);
+          for (let i = 0, ii = cff.fdArray.length; i < ii; i++) {
+            const subDict = cff.fdArray[i];
+            let matrix = base.slice(0);
             if (subDict.hasName("FontMatrix")) {
               matrix = Util.transform(matrix, subDict.getByName("FontMatrix"));
             }
@@ -1402,18 +1406,18 @@ var CFFCompiler = (function CFFCompilerClosure() {
       }
 
       cff.topDict.setByName("charset", 0);
-      var compiled = this.compileTopDicts(
+      let compiled = this.compileTopDicts(
         [cff.topDict],
         output.length,
         cff.isCIDFont
       );
       output.add(compiled.output);
-      var topDictTracker = compiled.trackers[0];
+      const topDictTracker = compiled.trackers[0];
 
-      var stringIndex = this.compileStringIndex(cff.strings.strings);
+      const stringIndex = this.compileStringIndex(cff.strings.strings);
       output.add(stringIndex);
 
-      var globalSubrIndex = this.compileIndex(cff.globalSubrIndex);
+      const globalSubrIndex = this.compileIndex(cff.globalSubrIndex);
       output.add(globalSubrIndex);
 
       // Now start on the other entries that have no specific order.
@@ -1425,12 +1429,12 @@ var CFFCompiler = (function CFFCompilerClosure() {
             output
           );
         } else {
-          var encoding = this.compileEncoding(cff.encoding);
+          const encoding = this.compileEncoding(cff.encoding);
           topDictTracker.setEntryLocation("Encoding", [output.length], output);
           output.add(encoding);
         }
       }
-      var charset = this.compileCharset(
+      const charset = this.compileCharset(
         cff.charset,
         cff.charStrings.count,
         cff.strings,
@@ -1439,7 +1443,7 @@ var CFFCompiler = (function CFFCompilerClosure() {
       topDictTracker.setEntryLocation("charset", [output.length], output);
       output.add(charset);
 
-      var charStrings = this.compileCharStrings(cff.charStrings);
+      const charStrings = this.compileCharStrings(cff.charStrings);
       topDictTracker.setEntryLocation("CharStrings", [output.length], output);
       output.add(charStrings);
 
@@ -1447,14 +1451,14 @@ var CFFCompiler = (function CFFCompilerClosure() {
         // For some reason FDSelect must be in front of FDArray on windows. OSX
         // and linux don't seem to care.
         topDictTracker.setEntryLocation("FDSelect", [output.length], output);
-        var fdSelect = this.compileFDSelect(cff.fdSelect);
+        const fdSelect = this.compileFDSelect(cff.fdSelect);
         output.add(fdSelect);
         // It is unclear if the sub font dictionary can have CID related
         // dictionary keys, but the sanitizer doesn't like them so remove them.
         compiled = this.compileTopDicts(cff.fdArray, output.length, true);
         topDictTracker.setEntryLocation("FDArray", [output.length], output);
         output.add(compiled.output);
-        var fontDictTrackers = compiled.trackers;
+        const fontDictTrackers = compiled.trackers;
 
         this.compilePrivateDicts(cff.fdArray, fontDictTrackers, output);
       }
@@ -1475,19 +1479,19 @@ var CFFCompiler = (function CFFCompilerClosure() {
       return this.encodeFloat(value);
     },
     encodeFloat: function CFFCompiler_encodeFloat(num) {
-      var value = num.toString();
+      let value = num.toString();
 
       // rounding inaccurate doubles
-      var m = /\.(\d*?)(?:9{5,20}|0{5,20})\d{0,2}(?:e(.+)|$)/.exec(value);
+      const m = /\.(\d*?)(?:9{5,20}|0{5,20})\d{0,2}(?:e(.+)|$)/.exec(value);
       if (m) {
-        var epsilon = parseFloat("1e" + ((m[2] ? +m[2] : 0) + m[1].length));
+        const epsilon = parseFloat("1e" + ((m[2] ? +m[2] : 0) + m[1].length));
         value = (Math.round(num * epsilon) / epsilon).toString();
       }
 
-      var nibbles = "";
-      var i, ii;
+      let nibbles = "";
+      let i, ii;
       for (i = 0, ii = value.length; i < ii; ++i) {
-        var a = value[i];
+        const a = value[i];
         if (a === "e") {
           nibbles += value[++i] === "-" ? "c" : "b";
         } else if (a === ".") {
@@ -1499,14 +1503,14 @@ var CFFCompiler = (function CFFCompilerClosure() {
         }
       }
       nibbles += nibbles.length & 1 ? "f" : "ff";
-      var out = [30];
+      const out = [30];
       for (i = 0, ii = nibbles.length; i < ii; i += 2) {
         out.push(parseInt(nibbles.substring(i, i + 2), 16));
       }
       return out;
     },
     encodeInteger: function CFFCompiler_encodeInteger(value) {
-      var code;
+      let code;
       if (value >= -107 && value <= 107) {
         code = [value + 139];
       } else if (value >= 108 && value <= 1131) {
@@ -1532,16 +1536,16 @@ var CFFCompiler = (function CFFCompilerClosure() {
       return [header.major, header.minor, header.hdrSize, header.offSize];
     },
     compileNameIndex: function CFFCompiler_compileNameIndex(names) {
-      var nameIndex = new CFFIndex();
-      for (var i = 0, ii = names.length; i < ii; ++i) {
-        var name = names[i];
+      const nameIndex = new CFFIndex();
+      for (let i = 0, ii = names.length; i < ii; ++i) {
+        const name = names[i];
         // OTS doesn't allow names to be over 127 characters.
-        var length = Math.min(name.length, 127);
-        var sanitizedName = new Array(length);
-        for (var j = 0; j < length; j++) {
+        const length = Math.min(name.length, 127);
+        let sanitizedName = new Array(length);
+        for (let j = 0; j < length; j++) {
           // OTS requires chars to be between a range and not certain other
           // chars.
-          var char = name[j];
+          let char = name[j];
           if (
             char < "!" ||
             char > "~" ||
@@ -1574,10 +1578,10 @@ var CFFCompiler = (function CFFCompilerClosure() {
       length,
       removeCidKeys
     ) {
-      var fontDictTrackers = [];
-      var fdArrayIndex = new CFFIndex();
-      for (var i = 0, ii = dicts.length; i < ii; ++i) {
-        var fontDict = dicts[i];
+      const fontDictTrackers = [];
+      let fdArrayIndex = new CFFIndex();
+      for (let i = 0, ii = dicts.length; i < ii; ++i) {
+        const fontDict = dicts[i];
         if (removeCidKeys) {
           fontDict.removeByName("CIDFontVersion");
           fontDict.removeByName("CIDFontRevision");
@@ -1585,8 +1589,8 @@ var CFFCompiler = (function CFFCompilerClosure() {
           fontDict.removeByName("CIDCount");
           fontDict.removeByName("UIDBase");
         }
-        var fontDictTracker = new CFFOffsetTracker();
-        var fontDictData = this.compileDict(fontDict, fontDictTracker);
+        const fontDictTracker = new CFFOffsetTracker();
+        const fontDictData = this.compileDict(fontDict, fontDictTracker);
         fontDictTrackers.push(fontDictTracker);
         fdArrayIndex.add(fontDictData);
         fontDictTracker.offset(length);
@@ -1602,16 +1606,19 @@ var CFFCompiler = (function CFFCompilerClosure() {
       trackers,
       output
     ) {
-      for (var i = 0, ii = dicts.length; i < ii; ++i) {
-        var fontDict = dicts[i];
-        var privateDict = fontDict.privateDict;
+      for (let i = 0, ii = dicts.length; i < ii; ++i) {
+        const fontDict = dicts[i];
+        const privateDict = fontDict.privateDict;
         if (!privateDict || !fontDict.hasName("Private")) {
           throw new FormatError("There must be a private dictionary.");
         }
-        var privateDictTracker = new CFFOffsetTracker();
-        var privateDictData = this.compileDict(privateDict, privateDictTracker);
+        const privateDictTracker = new CFFOffsetTracker();
+        const privateDictData = this.compileDict(
+          privateDict,
+          privateDictTracker
+        );
 
-        var outputLength = output.length;
+        let outputLength = output.length;
         privateDictTracker.offset(outputLength);
         if (!privateDictData.length) {
           // The private dictionary was empty, set the output length to zero to
@@ -1628,7 +1635,7 @@ var CFFCompiler = (function CFFCompilerClosure() {
         output.add(privateDictData);
 
         if (privateDict.subrsIndex && privateDict.hasName("Subrs")) {
-          var subrs = this.compileIndex(privateDict.subrsIndex);
+          const subrs = this.compileIndex(privateDict.subrsIndex);
           privateDictTracker.setEntryLocation(
             "Subrs",
             [privateDictData.length],
@@ -1639,16 +1646,16 @@ var CFFCompiler = (function CFFCompilerClosure() {
       }
     },
     compileDict: function CFFCompiler_compileDict(dict, offsetTracker) {
-      var out = [];
+      let out = [];
       // The dictionary keys must be in a certain order.
-      var order = dict.order;
-      for (var i = 0; i < order.length; ++i) {
-        var key = order[i];
+      const order = dict.order;
+      for (let i = 0; i < order.length; ++i) {
+        const key = order[i];
         if (!(key in dict.values)) {
           continue;
         }
-        var values = dict.values[key];
-        var types = dict.types[key];
+        let values = dict.values[key];
+        let types = dict.types[key];
         if (!Array.isArray(types)) {
           types = [types];
         }
@@ -1661,9 +1668,9 @@ var CFFCompiler = (function CFFCompilerClosure() {
           continue;
         }
 
-        for (var j = 0, jj = types.length; j < jj; ++j) {
-          var type = types[j];
-          var value = values[j];
+        for (let j = 0, jj = types.length; j < jj; ++j) {
+          const type = types[j];
+          const value = values[j];
           switch (type) {
             case "num":
             case "sid":
@@ -1684,7 +1691,7 @@ var CFFCompiler = (function CFFCompilerClosure() {
             case "array":
             case "delta":
               out = out.concat(this.encodeNumber(value));
-              for (var k = 1, kk = values.length; k < kk; ++k) {
+              for (let k = 1, kk = values.length; k < kk; ++k) {
                 out = out.concat(this.encodeNumber(values[k]));
               }
               break;
@@ -1697,20 +1704,20 @@ var CFFCompiler = (function CFFCompilerClosure() {
       return out;
     },
     compileStringIndex: function CFFCompiler_compileStringIndex(strings) {
-      var stringIndex = new CFFIndex();
-      for (var i = 0, ii = strings.length; i < ii; ++i) {
+      const stringIndex = new CFFIndex();
+      for (let i = 0, ii = strings.length; i < ii; ++i) {
         stringIndex.add(stringToBytes(strings[i]));
       }
       return this.compileIndex(stringIndex);
     },
     compileGlobalSubrIndex: function CFFCompiler_compileGlobalSubrIndex() {
-      var globalSubrIndex = this.cff.globalSubrIndex;
+      const globalSubrIndex = this.cff.globalSubrIndex;
       this.out.writeByteArray(this.compileIndex(globalSubrIndex));
     },
     compileCharStrings: function CFFCompiler_compileCharStrings(charStrings) {
-      var charStringsIndex = new CFFIndex();
-      for (var i = 0; i < charStrings.count; i++) {
-        var glyph = charStrings.get(i);
+      const charStringsIndex = new CFFIndex();
+      for (let i = 0; i < charStrings.count; i++) {
+        const glyph = charStrings.get(i);
         // If the CharString outline is empty, replace it with .notdef to
         // prevent OTS from rejecting the font (fixes bug1252420.pdf).
         if (glyph.length === 0) {
@@ -1811,17 +1818,17 @@ var CFFCompiler = (function CFFCompilerClosure() {
       return this.compileTypedArray(out);
     },
     compileTypedArray: function CFFCompiler_compileTypedArray(data) {
-      var out = [];
-      for (var i = 0, ii = data.length; i < ii; ++i) {
+      const out = [];
+      for (let i = 0, ii = data.length; i < ii; ++i) {
         out[i] = data[i];
       }
       return out;
     },
     compileIndex: function CFFCompiler_compileIndex(index, trackers) {
       trackers = trackers || [];
-      var objects = index.objects;
+      const objects = index.objects;
       // First 2 bytes contains the number of objects contained into this index
-      var count = objects.length;
+      const count = objects.length;
 
       // If there is no object, just create an index. This technically
       // should just be [0, 0] but OTS has an issue with that.
@@ -1829,15 +1836,15 @@ var CFFCompiler = (function CFFCompilerClosure() {
         return [0, 0, 0];
       }
 
-      var data = [(count >> 8) & 0xff, count & 0xff];
+      const data = [(count >> 8) & 0xff, count & 0xff];
 
-      var lastOffset = 1,
+      let lastOffset = 1,
         i;
       for (i = 0; i < count; ++i) {
         lastOffset += objects[i].length;
       }
 
-      var offsetSize;
+      let offsetSize;
       if (lastOffset < 0x100) {
         offsetSize = 1;
       } else if (lastOffset < 0x10000) {
@@ -1852,7 +1859,7 @@ var CFFCompiler = (function CFFCompilerClosure() {
       data.push(offsetSize);
 
       // Add another offset after this one because we need a new offset
-      var relativeOffset = 1;
+      let relativeOffset = 1;
       for (i = 0; i < count + 1; i++) {
         if (offsetSize === 1) {
           data.push(relativeOffset & 0xff);
@@ -1883,7 +1890,7 @@ var CFFCompiler = (function CFFCompilerClosure() {
         if (trackers[i]) {
           trackers[i].offset(data.length);
         }
-        for (var j = 0, jj = objects[i].length; j < jj; j++) {
+        for (let j = 0, jj = objects[i].length; j < jj; j++) {
           data.push(objects[i][j]);
         }
       }

--- a/src/core/charsets.js
+++ b/src/core/charsets.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 // prettier-ignore
 const ISOAdobeCharset = [

--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 import {
   arrayByteLength,

--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -25,7 +25,7 @@ import { Lexer } from "./parser.js";
 import { MissingDataException } from "./core_utils.js";
 import { Stream } from "./stream.js";
 
-var BUILT_IN_CMAPS = [
+const BUILT_IN_CMAPS = [
   // << Start unicode maps.
   "Adobe-GB1-UCS2",
   "Adobe-CNS1-UCS2",
@@ -229,7 +229,7 @@ class CMap {
   }
 
   mapBfRange(low, high, dstLow) {
-    var lastByte = dstLow.length - 1;
+    const lastByte = dstLow.length - 1;
     while (low <= high) {
       this._map[low++] = dstLow;
       // Only the last byte has to be incremented.
@@ -407,10 +407,10 @@ class IdentityCMap extends CMap {
   }
 }
 
-var BinaryCMapReader = (function BinaryCMapReaderClosure() {
+const BinaryCMapReader = (function BinaryCMapReaderClosure() {
   function hexToInt(a, size) {
-    var n = 0;
-    for (var i = 0; i <= size; i++) {
+    let n = 0;
+    for (let i = 0; i <= size; i++) {
       n = (n << 8) | a[i];
     }
     return n >>> 0;
@@ -429,8 +429,8 @@ var BinaryCMapReader = (function BinaryCMapReaderClosure() {
   }
 
   function addHex(a, b, size) {
-    var c = 0;
-    for (var i = size; i >= 0; i--) {
+    let c = 0;
+    for (let i = size; i >= 0; i--) {
       c += a[i] + b[i];
       a[i] = c & 255;
       c >>= 8;
@@ -438,16 +438,16 @@ var BinaryCMapReader = (function BinaryCMapReaderClosure() {
   }
 
   function incHex(a, size) {
-    var c = 1;
-    for (var i = size; i >= 0 && c > 0; i--) {
+    let c = 1;
+    for (let i = size; i >= 0 && c > 0; i--) {
       c += a[i];
       a[i] = c & 255;
       c >>= 8;
     }
   }
 
-  var MAX_NUM_SIZE = 16;
-  var MAX_ENCODED_NUM_SIZE = 19; // ceil(MAX_NUM_SIZE * 7 / 8)
+  const MAX_NUM_SIZE = 16;
+  const MAX_ENCODED_NUM_SIZE = 19; // ceil(MAX_NUM_SIZE * 7 / 8)
 
   function BinaryCMapStream(data) {
     this.buffer = data;
@@ -464,10 +464,10 @@ var BinaryCMapReader = (function BinaryCMapReaderClosure() {
       return this.buffer[this.pos++];
     },
     readNumber() {
-      var n = 0;
-      var last;
+      let n = 0;
+      let last;
       do {
-        var b = this.readByte();
+        const b = this.readByte();
         if (b < 0) {
           throw new FormatError("unexpected EOF in bcmap");
         }
@@ -477,7 +477,7 @@ var BinaryCMapReader = (function BinaryCMapReaderClosure() {
       return n;
     },
     readSigned() {
-      var n = this.readNumber();
+      const n = this.readNumber();
       return n & 1 ? ~(n >>> 1) : n >>> 1;
     },
     readHex(num, size) {
@@ -485,18 +485,18 @@ var BinaryCMapReader = (function BinaryCMapReaderClosure() {
       this.pos += size + 1;
     },
     readHexNumber(num, size) {
-      var last;
-      var stack = this.tmpBuf,
+      let last;
+      let stack = this.tmpBuf,
         sp = 0;
       do {
-        var b = this.readByte();
+        const b = this.readByte();
         if (b < 0) {
           throw new FormatError("unexpected EOF in bcmap");
         }
         last = !(b & 0x80);
         stack[sp++] = b & 0x7f;
       } while (!last);
-      var i = size,
+      let i = size,
         buffer = 0,
         bufferSize = 0;
       while (i >= 0) {
@@ -512,17 +512,17 @@ var BinaryCMapReader = (function BinaryCMapReaderClosure() {
     },
     readHexSigned(num, size) {
       this.readHexNumber(num, size);
-      var sign = num[size] & 1 ? 255 : 0;
-      var c = 0;
-      for (var i = 0; i <= size; i++) {
+      const sign = num[size] & 1 ? 255 : 0;
+      let c = 0;
+      for (let i = 0; i <= size; i++) {
         c = ((c & 1) << 8) | num[i];
         num[i] = (c >> 1) ^ sign;
       }
     },
     readString() {
-      var len = this.readNumber();
-      var s = "";
-      for (var i = 0; i < len; i++) {
+      const len = this.readNumber();
+      let s = "";
+      for (let i = 0; i < len; i++) {
         s += String.fromCharCode(this.readNumber());
       }
       return s;
@@ -531,21 +531,21 @@ var BinaryCMapReader = (function BinaryCMapReaderClosure() {
 
   function processBinaryCMap(data, cMap, extend) {
     return new Promise(function(resolve, reject) {
-      var stream = new BinaryCMapStream(data);
-      var header = stream.readByte();
+      const stream = new BinaryCMapStream(data);
+      const header = stream.readByte();
       cMap.vertical = !!(header & 1);
 
-      var useCMap = null;
-      var start = new Uint8Array(MAX_NUM_SIZE);
-      var end = new Uint8Array(MAX_NUM_SIZE);
-      var char = new Uint8Array(MAX_NUM_SIZE);
-      var charCode = new Uint8Array(MAX_NUM_SIZE);
-      var tmp = new Uint8Array(MAX_NUM_SIZE);
-      var code;
+      let useCMap = null;
+      const start = new Uint8Array(MAX_NUM_SIZE);
+      const end = new Uint8Array(MAX_NUM_SIZE);
+      const char = new Uint8Array(MAX_NUM_SIZE);
+      const charCode = new Uint8Array(MAX_NUM_SIZE);
+      const tmp = new Uint8Array(MAX_NUM_SIZE);
+      let code;
 
-      var b;
+      let b;
       while ((b = stream.readByte()) >= 0) {
-        var type = b >> 5;
+        const type = b >> 5;
         if (type === 7) {
           // metadata, e.g. comment or usecmap
           switch (b & 0x1f) {
@@ -558,15 +558,15 @@ var BinaryCMapReader = (function BinaryCMapReaderClosure() {
           }
           continue;
         }
-        var sequence = !!(b & 0x10);
-        var dataSize = b & 15;
+        const sequence = !!(b & 0x10);
+        const dataSize = b & 15;
 
         if (dataSize + 1 > MAX_NUM_SIZE) {
           throw new Error("processBinaryCMap: Invalid dataSize.");
         }
 
-        var ucs2DataSize = 1;
-        var subitemsCount = stream.readNumber();
+        const ucs2DataSize = 1;
+        const subitemsCount = stream.readNumber();
         var i;
         switch (type) {
           case 0: // codespacerange
@@ -722,10 +722,10 @@ var BinaryCMapReader = (function BinaryCMapReaderClosure() {
   return BinaryCMapReader;
 })();
 
-var CMapFactory = (function CMapFactoryClosure() {
+const CMapFactory = (function CMapFactoryClosure() {
   function strToInt(str) {
-    var a = 0;
-    for (var i = 0; i < str.length; i++) {
+    let a = 0;
+    for (let i = 0; i < str.length; i++) {
       a = (a << 8) | str.charCodeAt(i);
     }
     return a >>> 0;
@@ -745,7 +745,7 @@ var CMapFactory = (function CMapFactoryClosure() {
 
   function parseBfChar(cMap, lexer) {
     while (true) {
-      var obj = lexer.getObj();
+      let obj = lexer.getObj();
       if (isEOF(obj)) {
         break;
       }
@@ -753,18 +753,18 @@ var CMapFactory = (function CMapFactoryClosure() {
         return;
       }
       expectString(obj);
-      var src = strToInt(obj);
+      const src = strToInt(obj);
       obj = lexer.getObj();
       // TODO are /dstName used?
       expectString(obj);
-      var dst = obj;
+      const dst = obj;
       cMap.mapOne(src, dst);
     }
   }
 
   function parseBfRange(cMap, lexer) {
     while (true) {
-      var obj = lexer.getObj();
+      let obj = lexer.getObj();
       if (isEOF(obj)) {
         break;
       }
@@ -772,17 +772,17 @@ var CMapFactory = (function CMapFactoryClosure() {
         return;
       }
       expectString(obj);
-      var low = strToInt(obj);
+      const low = strToInt(obj);
       obj = lexer.getObj();
       expectString(obj);
-      var high = strToInt(obj);
+      const high = strToInt(obj);
       obj = lexer.getObj();
       if (Number.isInteger(obj) || isString(obj)) {
-        var dstLow = Number.isInteger(obj) ? String.fromCharCode(obj) : obj;
+        const dstLow = Number.isInteger(obj) ? String.fromCharCode(obj) : obj;
         cMap.mapBfRange(low, high, dstLow);
       } else if (isCmd(obj, "[")) {
         obj = lexer.getObj();
-        var array = [];
+        const array = [];
         while (!isCmd(obj, "]") && !isEOF(obj)) {
           array.push(obj);
           obj = lexer.getObj();
@@ -797,7 +797,7 @@ var CMapFactory = (function CMapFactoryClosure() {
 
   function parseCidChar(cMap, lexer) {
     while (true) {
-      var obj = lexer.getObj();
+      let obj = lexer.getObj();
       if (isEOF(obj)) {
         break;
       }
@@ -805,17 +805,17 @@ var CMapFactory = (function CMapFactoryClosure() {
         return;
       }
       expectString(obj);
-      var src = strToInt(obj);
+      const src = strToInt(obj);
       obj = lexer.getObj();
       expectInt(obj);
-      var dst = obj;
+      const dst = obj;
       cMap.mapOne(src, dst);
     }
   }
 
   function parseCidRange(cMap, lexer) {
     while (true) {
-      var obj = lexer.getObj();
+      let obj = lexer.getObj();
       if (isEOF(obj)) {
         break;
       }
@@ -823,20 +823,20 @@ var CMapFactory = (function CMapFactoryClosure() {
         return;
       }
       expectString(obj);
-      var low = strToInt(obj);
+      const low = strToInt(obj);
       obj = lexer.getObj();
       expectString(obj);
-      var high = strToInt(obj);
+      const high = strToInt(obj);
       obj = lexer.getObj();
       expectInt(obj);
-      var dstLow = obj;
+      const dstLow = obj;
       cMap.mapCidRange(low, high, dstLow);
     }
   }
 
   function parseCodespaceRange(cMap, lexer) {
     while (true) {
-      var obj = lexer.getObj();
+      let obj = lexer.getObj();
       if (isEOF(obj)) {
         break;
       }
@@ -846,37 +846,37 @@ var CMapFactory = (function CMapFactoryClosure() {
       if (!isString(obj)) {
         break;
       }
-      var low = strToInt(obj);
+      const low = strToInt(obj);
       obj = lexer.getObj();
       if (!isString(obj)) {
         break;
       }
-      var high = strToInt(obj);
+      const high = strToInt(obj);
       cMap.addCodespaceRange(obj.length, low, high);
     }
     throw new FormatError("Invalid codespace range.");
   }
 
   function parseWMode(cMap, lexer) {
-    var obj = lexer.getObj();
+    const obj = lexer.getObj();
     if (Number.isInteger(obj)) {
       cMap.vertical = !!obj;
     }
   }
 
   function parseCMapName(cMap, lexer) {
-    var obj = lexer.getObj();
+    const obj = lexer.getObj();
     if (isName(obj) && isString(obj.name)) {
       cMap.name = obj.name;
     }
   }
 
   function parseCMap(cMap, lexer, fetchBuiltInCMap, useCMap) {
-    var previous;
-    var embeddedUseCMap;
+    let previous;
+    let embeddedUseCMap;
     objLoop: while (true) {
       try {
-        var obj = lexer.getObj();
+        const obj = lexer.getObj();
         if (isEOF(obj)) {
           break;
         } else if (isName(obj)) {
@@ -938,8 +938,8 @@ var CMapFactory = (function CMapFactoryClosure() {
       // If there aren't any code space ranges defined clone all the parent ones
       // into this cMap.
       if (cMap.numCodespaceRanges === 0) {
-        var useCodespaceRanges = cMap.useCMap.codespaceRanges;
-        for (var i = 0; i < useCodespaceRanges.length; i++) {
+        const useCodespaceRanges = cMap.useCMap.codespaceRanges;
+        for (let i = 0; i < useCodespaceRanges.length; i++) {
           cMap.codespaceRanges[i] = useCodespaceRanges[i].slice();
         }
         cMap.numCodespaceRanges = cMap.useCMap.numCodespaceRanges;
@@ -972,9 +972,9 @@ var CMapFactory = (function CMapFactoryClosure() {
     }
 
     return fetchBuiltInCMap(name).then(function(data) {
-      var cMapData = data.cMapData,
+      const cMapData = data.cMapData,
         compressionType = data.compressionType;
-      var cMap = new CMap(true);
+      const cMap = new CMap(true);
 
       if (compressionType === CMapCompressionType.BINARY) {
         return new BinaryCMapReader().process(cMapData, cMap, function(
@@ -984,7 +984,7 @@ var CMapFactory = (function CMapFactoryClosure() {
         });
       }
       if (compressionType === CMapCompressionType.NONE) {
-        var lexer = new Lexer(new Stream(cMapData));
+        const lexer = new Lexer(new Stream(cMapData));
         return parseCMap(cMap, lexer, fetchBuiltInCMap, null);
       }
       return Promise.reject(
@@ -997,15 +997,15 @@ var CMapFactory = (function CMapFactoryClosure() {
 
   return {
     async create(params) {
-      var encoding = params.encoding;
-      var fetchBuiltInCMap = params.fetchBuiltInCMap;
-      var useCMap = params.useCMap;
+      const encoding = params.encoding;
+      const fetchBuiltInCMap = params.fetchBuiltInCMap;
+      const useCMap = params.useCMap;
 
       if (isName(encoding)) {
         return createBuiltInCMap(encoding.name, fetchBuiltInCMap);
       } else if (isStream(encoding)) {
-        var cMap = new CMap();
-        var lexer = new Lexer(encoding);
+        const cMap = new CMap();
+        const lexer = new Lexer(encoding);
         return parseCMap(cMap, lexer, fetchBuiltInCMap, useCMap).then(function(
           parsedCMap
         ) {

--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 import { assert, BaseException, warn } from "../shared/util.js";
 

--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -26,12 +26,12 @@ import {
 import { isDict, isName, Name } from "./primitives.js";
 import { DecryptStream } from "./stream.js";
 
-var ARCFourCipher = (function ARCFourCipherClosure() {
+const ARCFourCipher = (function ARCFourCipherClosure() {
   function ARCFourCipher(key) {
     this.a = 0;
     this.b = 0;
-    var s = new Uint8Array(256);
-    var i,
+    const s = new Uint8Array(256);
+    let i,
       j = 0,
       tmp,
       keyLength = key.length;
@@ -49,14 +49,14 @@ var ARCFourCipher = (function ARCFourCipherClosure() {
 
   ARCFourCipher.prototype = {
     encryptBlock: function ARCFourCipher_encryptBlock(data) {
-      var i,
+      let i,
         n = data.length,
         tmp,
         tmp2;
-      var a = this.a,
+      let a = this.a,
         b = this.b,
         s = this.s;
-      var output = new Uint8Array(n);
+      const output = new Uint8Array(n);
       for (i = 0; i < n; ++i) {
         a = (a + 1) & 0xff;
         tmp = s[a];
@@ -76,16 +76,16 @@ var ARCFourCipher = (function ARCFourCipherClosure() {
   return ARCFourCipher;
 })();
 
-var calculateMD5 = (function calculateMD5Closure() {
+const calculateMD5 = (function calculateMD5Closure() {
   // prettier-ignore
-  var r = new Uint8Array([
+  const r = new Uint8Array([
     7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22,
     5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20,
     4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23,
     6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21]);
 
   // prettier-ignore
-  var k = new Int32Array([
+  const k = new Int32Array([
     -680876936, -389564586, 606105819, -1044525330, -176418897, 1200080426,
     -1473231341, -45705983, 1770035416, -1958414417, -42063, -1990404162,
     1804603682, -40341101, -1502002290, 1236535329, -165796510, -1069501632,
@@ -99,14 +99,14 @@ var calculateMD5 = (function calculateMD5Closure() {
     -145523070, -1120210379, 718787259, -343485551]);
 
   function hash(data, offset, length) {
-    var h0 = 1732584193,
+    let h0 = 1732584193,
       h1 = -271733879,
       h2 = -1732584194,
       h3 = 271733878;
     // pre-processing
-    var paddedLength = (length + 72) & ~63; // data + 9 extra bytes
-    var padded = new Uint8Array(paddedLength);
-    var i, j, n;
+    const paddedLength = (length + 72) & ~63; // data + 9 extra bytes
+    const padded = new Uint8Array(paddedLength);
+    let i, j, n;
     for (i = 0; i < length; ++i) {
       padded[i] = data[offset++];
     }
@@ -123,7 +123,7 @@ var calculateMD5 = (function calculateMD5Closure() {
     padded[i++] = 0;
     padded[i++] = 0;
     padded[i++] = 0;
-    var w = new Int32Array(16);
+    const w = new Int32Array(16);
     for (i = 0; i < paddedLength; ) {
       for (j = 0; j < 16; ++j, i += 4) {
         w[j] =
@@ -152,7 +152,7 @@ var calculateMD5 = (function calculateMD5Closure() {
           f = c ^ (b | ~d);
           g = (7 * j) & 15;
         }
-        var tmp = d,
+        const tmp = d,
           rotateArg = (a + f + k[j] + w[g]) | 0,
           rotate = r[j];
         d = c;
@@ -176,7 +176,7 @@ var calculateMD5 = (function calculateMD5Closure() {
 
   return hash;
 })();
-var Word64 = (function Word64Closure() {
+const Word64 = (function Word64Closure() {
   function Word64(highInteger, lowInteger) {
     this.high = highInteger | 0;
     this.low = lowInteger | 0;
@@ -217,7 +217,7 @@ var Word64 = (function Word64Closure() {
     },
 
     rotateRight: function Word64_rotateRight(places) {
-      var low, high;
+      let low, high;
       if (places & 32) {
         high = this.low;
         low = this.high;
@@ -236,8 +236,8 @@ var Word64 = (function Word64Closure() {
     },
 
     add: function Word64_add(word) {
-      var lowAdd = (this.low >>> 0) + (word.low >>> 0);
-      var highAdd = (this.high >>> 0) + (word.high >>> 0);
+      const lowAdd = (this.low >>> 0) + (word.low >>> 0);
+      let highAdd = (this.high >>> 0) + (word.high >>> 0);
       if (lowAdd > 0xffffffff) {
         highAdd += 1;
       }
@@ -264,7 +264,7 @@ var Word64 = (function Word64Closure() {
   return Word64;
 })();
 
-var calculateSHA256 = (function calculateSHA256Closure() {
+const calculateSHA256 = (function calculateSHA256Closure() {
   function rotr(x, n) {
     return (x >>> n) | (x << (32 - n));
   }
@@ -294,7 +294,7 @@ var calculateSHA256 = (function calculateSHA256Closure() {
   }
 
   // prettier-ignore
-  var k = [0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+  const k = [0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
            0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
            0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
            0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
@@ -313,7 +313,7 @@ var calculateSHA256 = (function calculateSHA256Closure() {
 
   function hash(data, offset, length) {
     // initial hash values
-    var h0 = 0x6a09e667,
+    let h0 = 0x6a09e667,
       h1 = 0xbb67ae85,
       h2 = 0x3c6ef372,
       h3 = 0xa54ff53a,
@@ -322,9 +322,9 @@ var calculateSHA256 = (function calculateSHA256Closure() {
       h6 = 0x1f83d9ab,
       h7 = 0x5be0cd19;
     // pre-processing
-    var paddedLength = Math.ceil((length + 9) / 64) * 64;
-    var padded = new Uint8Array(paddedLength);
-    var i, j, n;
+    const paddedLength = Math.ceil((length + 9) / 64) * 64;
+    const padded = new Uint8Array(paddedLength);
+    let i, j, n;
     for (i = 0; i < length; ++i) {
       padded[i] = data[offset++];
     }
@@ -341,7 +341,7 @@ var calculateSHA256 = (function calculateSHA256Closure() {
     padded[i++] = (length >> 13) & 0xff;
     padded[i++] = (length >> 5) & 0xff;
     padded[i++] = (length << 3) & 0xff;
-    var w = new Uint32Array(64);
+    const w = new Uint32Array(64);
     // for each 512 bit block
     for (i = 0; i < paddedLength; ) {
       for (j = 0; j < 16; ++j) {
@@ -408,7 +408,7 @@ var calculateSHA256 = (function calculateSHA256Closure() {
   return hash;
 })();
 
-var calculateSHA512 = (function calculateSHA512Closure() {
+const calculateSHA512 = (function calculateSHA512Closure() {
   function ch(result, x, y, z, tmp) {
     result.assign(x);
     result.and(y);
@@ -474,7 +474,7 @@ var calculateSHA512 = (function calculateSHA512Closure() {
   }
 
   // prettier-ignore
-  var k = [
+  const k = [
     new Word64(0x428a2f98, 0xd728ae22), new Word64(0x71374491, 0x23ef65cd),
     new Word64(0xb5c0fbcf, 0xec4d3b2f), new Word64(0xe9b5dba5, 0x8189dbbc),
     new Word64(0x3956c25b, 0xf348b538), new Word64(0x59f111f1, 0xb605d019),
@@ -519,7 +519,7 @@ var calculateSHA512 = (function calculateSHA512Closure() {
   function hash(data, offset, length, mode384) {
     mode384 = !!mode384;
     // initial hash values
-    var h0, h1, h2, h3, h4, h5, h6, h7;
+    let h0, h1, h2, h3, h4, h5, h6, h7;
     if (!mode384) {
       h0 = new Word64(0x6a09e667, 0xf3bcc908);
       h1 = new Word64(0xbb67ae85, 0x84caa73b);
@@ -543,9 +543,9 @@ var calculateSHA512 = (function calculateSHA512Closure() {
     }
 
     // pre-processing
-    var paddedLength = Math.ceil((length + 17) / 128) * 128;
-    var padded = new Uint8Array(paddedLength);
-    var i, j, n;
+    const paddedLength = Math.ceil((length + 17) / 128) * 128;
+    const padded = new Uint8Array(paddedLength);
+    let i, j, n;
     for (i = 0; i < length; ++i) {
       padded[i] = data[offset++];
     }
@@ -571,21 +571,21 @@ var calculateSHA512 = (function calculateSHA512Closure() {
     padded[i++] = (length >> 5) & 0xff;
     padded[i++] = (length << 3) & 0xff;
 
-    var w = new Array(80);
+    const w = new Array(80);
     for (i = 0; i < 80; i++) {
       w[i] = new Word64(0, 0);
     }
-    var a = new Word64(0, 0),
+    let a = new Word64(0, 0),
       b = new Word64(0, 0),
       c = new Word64(0, 0);
-    var d = new Word64(0, 0),
+    let d = new Word64(0, 0),
       e = new Word64(0, 0),
       f = new Word64(0, 0);
-    var g = new Word64(0, 0),
+    let g = new Word64(0, 0),
       h = new Word64(0, 0);
-    var t1 = new Word64(0, 0),
+    const t1 = new Word64(0, 0),
       t2 = new Word64(0, 0);
-    var tmp1 = new Word64(0, 0),
+    let tmp1 = new Word64(0, 0),
       tmp2 = new Word64(0, 0),
       tmp3;
 
@@ -657,7 +657,7 @@ var calculateSHA512 = (function calculateSHA512Closure() {
       h7.add(h);
     }
 
-    var result;
+    let result;
     if (!mode384) {
       result = new Uint8Array(64);
       h0.copyTo(result, 0);
@@ -682,14 +682,14 @@ var calculateSHA512 = (function calculateSHA512Closure() {
 
   return hash;
 })();
-var calculateSHA384 = (function calculateSHA384Closure() {
+const calculateSHA384 = (function calculateSHA384Closure() {
   function hash(data, offset, length) {
     return calculateSHA512(data, offset, length, true);
   }
 
   return hash;
 })();
-var NullCipher = (function NullCipherClosure() {
+const NullCipher = (function NullCipherClosure() {
   function NullCipher() {}
 
   NullCipher.prototype = {
@@ -1252,12 +1252,12 @@ class AES256Cipher extends AESBaseCipher {
   }
 }
 
-var PDF17 = (function PDF17Closure() {
+const PDF17 = (function PDF17Closure() {
   function compareByteArrays(array1, array2) {
     if (array1.length !== array2.length) {
       return false;
     }
-    for (var i = 0; i < array1.length; i++) {
+    for (let i = 0; i < array1.length; i++) {
       if (array1[i] !== array2[i]) {
         return false;
       }
@@ -1274,11 +1274,11 @@ var PDF17 = (function PDF17Closure() {
       userBytes,
       ownerPassword
     ) {
-      var hashData = new Uint8Array(password.length + 56);
+      const hashData = new Uint8Array(password.length + 56);
       hashData.set(password, 0);
       hashData.set(ownerValidationSalt, password.length);
       hashData.set(userBytes, password.length + ownerValidationSalt.length);
-      var result = calculateSHA256(hashData, 0, hashData.length);
+      const result = calculateSHA256(hashData, 0, hashData.length);
       return compareByteArrays(result, ownerPassword);
     },
     checkUserPassword: function PDF17_checkUserPassword(
@@ -1286,10 +1286,10 @@ var PDF17 = (function PDF17Closure() {
       userValidationSalt,
       userPassword
     ) {
-      var hashData = new Uint8Array(password.length + 8);
+      const hashData = new Uint8Array(password.length + 8);
       hashData.set(password, 0);
       hashData.set(userValidationSalt, password.length);
-      var result = calculateSHA256(hashData, 0, hashData.length);
+      const result = calculateSHA256(hashData, 0, hashData.length);
       return compareByteArrays(result, userPassword);
     },
     getOwnerKey: function PDF17_getOwnerKey(
@@ -1298,12 +1298,12 @@ var PDF17 = (function PDF17Closure() {
       userBytes,
       ownerEncryption
     ) {
-      var hashData = new Uint8Array(password.length + 56);
+      const hashData = new Uint8Array(password.length + 56);
       hashData.set(password, 0);
       hashData.set(ownerKeySalt, password.length);
       hashData.set(userBytes, password.length + ownerKeySalt.length);
-      var key = calculateSHA256(hashData, 0, hashData.length);
-      var cipher = new AES256Cipher(key);
+      const key = calculateSHA256(hashData, 0, hashData.length);
+      const cipher = new AES256Cipher(key);
       return cipher.decryptBlock(ownerEncryption, false, new Uint8Array(16));
     },
     getUserKey: function PDF17_getUserKey(
@@ -1311,21 +1311,21 @@ var PDF17 = (function PDF17Closure() {
       userKeySalt,
       userEncryption
     ) {
-      var hashData = new Uint8Array(password.length + 8);
+      const hashData = new Uint8Array(password.length + 8);
       hashData.set(password, 0);
       hashData.set(userKeySalt, password.length);
       // `key` is the decryption key for the UE string.
-      var key = calculateSHA256(hashData, 0, hashData.length);
-      var cipher = new AES256Cipher(key);
+      const key = calculateSHA256(hashData, 0, hashData.length);
+      const cipher = new AES256Cipher(key);
       return cipher.decryptBlock(userEncryption, false, new Uint8Array(16));
     },
   };
   return PDF17;
 })();
 
-var PDF20 = (function PDF20Closure() {
+const PDF20 = (function PDF20Closure() {
   function concatArrays(array1, array2) {
-    var t = new Uint8Array(array1.length + array2.length);
+    const t = new Uint8Array(array1.length + array2.length);
     t.set(array1, 0);
     t.set(array2, array1.length);
     return t;
@@ -1333,28 +1333,28 @@ var PDF20 = (function PDF20Closure() {
 
   function calculatePDF20Hash(password, input, userBytes) {
     // This refers to Algorithm 2.B as defined in ISO 32000-2.
-    var k = calculateSHA256(input, 0, input.length).subarray(0, 32);
-    var e = [0];
-    var i = 0;
+    let k = calculateSHA256(input, 0, input.length).subarray(0, 32);
+    let e = [0];
+    let i = 0;
     while (i < 64 || e[e.length - 1] > i - 32) {
-      var arrayLength = password.length + k.length + userBytes.length;
+      const arrayLength = password.length + k.length + userBytes.length;
 
-      var k1 = new Uint8Array(arrayLength * 64);
-      var array = concatArrays(password, k);
+      const k1 = new Uint8Array(arrayLength * 64);
+      let array = concatArrays(password, k);
       array = concatArrays(array, userBytes);
-      for (var j = 0, pos = 0; j < 64; j++, pos += arrayLength) {
+      for (let j = 0, pos = 0; j < 64; j++, pos += arrayLength) {
         k1.set(array, pos);
       }
       // AES128 CBC NO PADDING with first 16 bytes of k as the key
       // and the second 16 as the iv.
-      var cipher = new AES128Cipher(k.subarray(0, 16));
+      const cipher = new AES128Cipher(k.subarray(0, 16));
       e = cipher.encrypt(k1, k.subarray(16, 32));
       // Now we have to take the first 16 bytes of an unsigned big endian
       // integer and compute the remainder modulo 3. That is a fairly large
       // number and JavaScript isn't going to handle that well, so we're using
       // a trick that allows us to perform modulo math byte by byte.
-      var remainder = 0;
-      for (var z = 0; z < 16; z++) {
+      let remainder = 0;
+      for (let z = 0; z < 16; z++) {
         remainder *= 256 % 3;
         remainder %= 3;
         remainder += (e[z] >>> 0) % 3;
@@ -1378,7 +1378,7 @@ var PDF20 = (function PDF20Closure() {
     if (array1.length !== array2.length) {
       return false;
     }
-    for (var i = 0; i < array1.length; i++) {
+    for (let i = 0; i < array1.length; i++) {
       if (array1[i] !== array2[i]) {
         return false;
       }
@@ -1396,11 +1396,11 @@ var PDF20 = (function PDF20Closure() {
       userBytes,
       ownerPassword
     ) {
-      var hashData = new Uint8Array(password.length + 56);
+      const hashData = new Uint8Array(password.length + 56);
       hashData.set(password, 0);
       hashData.set(ownerValidationSalt, password.length);
       hashData.set(userBytes, password.length + ownerValidationSalt.length);
-      var result = calculatePDF20Hash(password, hashData, userBytes);
+      const result = calculatePDF20Hash(password, hashData, userBytes);
       return compareByteArrays(result, ownerPassword);
     },
     checkUserPassword: function PDF20_checkUserPassword(
@@ -1408,10 +1408,10 @@ var PDF20 = (function PDF20Closure() {
       userValidationSalt,
       userPassword
     ) {
-      var hashData = new Uint8Array(password.length + 8);
+      const hashData = new Uint8Array(password.length + 8);
       hashData.set(password, 0);
       hashData.set(userValidationSalt, password.length);
-      var result = calculatePDF20Hash(password, hashData, []);
+      const result = calculatePDF20Hash(password, hashData, []);
       return compareByteArrays(result, userPassword);
     },
     getOwnerKey: function PDF20_getOwnerKey(
@@ -1420,12 +1420,12 @@ var PDF20 = (function PDF20Closure() {
       userBytes,
       ownerEncryption
     ) {
-      var hashData = new Uint8Array(password.length + 56);
+      const hashData = new Uint8Array(password.length + 56);
       hashData.set(password, 0);
       hashData.set(ownerKeySalt, password.length);
       hashData.set(userBytes, password.length + ownerKeySalt.length);
-      var key = calculatePDF20Hash(password, hashData, userBytes);
-      var cipher = new AES256Cipher(key);
+      const key = calculatePDF20Hash(password, hashData, userBytes);
+      const cipher = new AES256Cipher(key);
       return cipher.decryptBlock(ownerEncryption, false, new Uint8Array(16));
     },
     getUserKey: function PDF20_getUserKey(
@@ -1433,19 +1433,19 @@ var PDF20 = (function PDF20Closure() {
       userKeySalt,
       userEncryption
     ) {
-      var hashData = new Uint8Array(password.length + 8);
+      const hashData = new Uint8Array(password.length + 8);
       hashData.set(password, 0);
       hashData.set(userKeySalt, password.length);
       // `key` is the decryption key for the UE string.
-      var key = calculatePDF20Hash(password, hashData, []);
-      var cipher = new AES256Cipher(key);
+      const key = calculatePDF20Hash(password, hashData, []);
+      const cipher = new AES256Cipher(key);
       return cipher.decryptBlock(userEncryption, false, new Uint8Array(16));
     },
   };
   return PDF20;
 })();
 
-var CipherTransform = (function CipherTransformClosure() {
+const CipherTransform = (function CipherTransformClosure() {
   function CipherTransform(stringCipherConstructor, streamCipherConstructor) {
     this.StringCipherConstructor = stringCipherConstructor;
     this.StreamCipherConstructor = streamCipherConstructor;
@@ -1453,7 +1453,7 @@ var CipherTransform = (function CipherTransformClosure() {
 
   CipherTransform.prototype = {
     createStream: function CipherTransform_createStream(stream, length) {
-      var cipher = new this.StreamCipherConstructor();
+      const cipher = new this.StreamCipherConstructor();
       return new DecryptStream(
         stream,
         length,
@@ -1463,8 +1463,8 @@ var CipherTransform = (function CipherTransformClosure() {
       );
     },
     decryptString: function CipherTransform_decryptString(s) {
-      var cipher = new this.StringCipherConstructor();
-      var data = stringToBytes(s);
+      const cipher = new this.StringCipherConstructor();
+      let data = stringToBytes(s);
       data = cipher.decryptBlock(data, true);
       return bytesToString(data);
     },
@@ -1472,9 +1472,9 @@ var CipherTransform = (function CipherTransformClosure() {
   return CipherTransform;
 })();
 
-var CipherTransformFactory = (function CipherTransformFactoryClosure() {
+const CipherTransformFactory = (function CipherTransformFactoryClosure() {
   // prettier-ignore
-  var defaultPasswordBytes = new Uint8Array([
+  const defaultPasswordBytes = new Uint8Array([
     0x28, 0xBF, 0x4E, 0x5E, 0x4E, 0x75, 0x8A, 0x41,
     0x64, 0x00, 0x4E, 0x56, 0xFF, 0xFA, 0x01, 0x08,
     0x2E, 0x2E, 0x00, 0xB6, 0xD0, 0x68, 0x3E, 0x80,
@@ -1495,12 +1495,12 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
     perms
   ) {
     if (password) {
-      var passwordLength = Math.min(127, password.length);
+      const passwordLength = Math.min(127, password.length);
       password = password.subarray(0, passwordLength);
     } else {
       password = [];
     }
-    var pdfAlgorithm;
+    let pdfAlgorithm;
     if (revision === 6) {
       pdfAlgorithm = new PDF20();
     } else {
@@ -1541,8 +1541,8 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
     keyLength,
     encryptMetadata
   ) {
-    var hashDataSize = 40 + ownerPassword.length + fileId.length;
-    var hashData = new Uint8Array(hashDataSize),
+    const hashDataSize = 40 + ownerPassword.length + fileId.length;
+    let hashData = new Uint8Array(hashDataSize),
       i = 0,
       j,
       n;
@@ -1573,15 +1573,15 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
       hashData[i++] = 0xff;
       hashData[i++] = 0xff;
     }
-    var hash = calculateMD5(hashData, 0, i);
-    var keyLengthInBytes = keyLength >> 3;
+    let hash = calculateMD5(hashData, 0, i);
+    const keyLengthInBytes = keyLength >> 3;
     if (revision >= 3) {
       for (j = 0; j < 50; ++j) {
         hash = calculateMD5(hash, 0, keyLengthInBytes);
       }
     }
-    var encryptionKey = hash.subarray(0, keyLengthInBytes);
-    var cipher, checkData;
+    const encryptionKey = hash.subarray(0, keyLengthInBytes);
+    let cipher, checkData;
 
     if (revision >= 3) {
       for (i = 0; i < 32; ++i) {
@@ -1593,7 +1593,7 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
       cipher = new ARCFourCipher(encryptionKey);
       checkData = cipher.encryptBlock(calculateMD5(hashData, 0, i));
       n = encryptionKey.length;
-      var derivedKey = new Uint8Array(n),
+      let derivedKey = new Uint8Array(n),
         k;
       for (j = 1; j <= 19; ++j) {
         for (k = 0; k < n; ++k) {
@@ -1620,7 +1620,7 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
   }
 
   function decodeUserPassword(password, ownerPassword, revision, keyLength) {
-    var hashData = new Uint8Array(32),
+    let hashData = new Uint8Array(32),
       i = 0,
       j,
       n;
@@ -1632,18 +1632,18 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
     while (i < 32) {
       hashData[i++] = defaultPasswordBytes[j++];
     }
-    var hash = calculateMD5(hashData, 0, i);
-    var keyLengthInBytes = keyLength >> 3;
+    let hash = calculateMD5(hashData, 0, i);
+    const keyLengthInBytes = keyLength >> 3;
     if (revision >= 3) {
       for (j = 0; j < 50; ++j) {
         hash = calculateMD5(hash, 0, hash.length);
       }
     }
 
-    var cipher, userPassword;
+    let cipher, userPassword;
     if (revision >= 3) {
       userPassword = ownerPassword;
-      var derivedKey = new Uint8Array(keyLengthInBytes),
+      let derivedKey = new Uint8Array(keyLengthInBytes),
         k;
       for (j = 19; j >= 0; j--) {
         for (k = 0; k < keyLengthInBytes; ++k) {
@@ -1659,15 +1659,15 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
     return userPassword;
   }
 
-  var identityName = Name.get("Identity");
+  const identityName = Name.get("Identity");
 
   function CipherTransformFactory(dict, fileId, password) {
-    var filter = dict.get("Filter");
+    const filter = dict.get("Filter");
     if (!isName(filter, "Standard")) {
       throw new FormatError("unknown encryption method");
     }
     this.dict = dict;
-    var algorithm = dict.get("V");
+    const algorithm = dict.get("V");
     if (
       !Number.isInteger(algorithm) ||
       (algorithm !== 1 && algorithm !== 2 && algorithm !== 4 && algorithm !== 5)
@@ -1675,7 +1675,7 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
       throw new FormatError("unsupported encryption algorithm");
     }
     this.algorithm = algorithm;
-    var keyLength = dict.get("Length");
+    let keyLength = dict.get("Length");
     if (!keyLength) {
       // Spec asks to rely on encryption dictionary's Length entry, however
       // some PDFs don't have it. Trying to recover.
@@ -1684,11 +1684,11 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
         keyLength = 40;
       } else {
         // Trying to find default handler -- it usually has Length.
-        var cfDict = dict.get("CF");
-        var streamCryptoName = dict.get("StmF");
+        const cfDict = dict.get("CF");
+        const streamCryptoName = dict.get("StmF");
         if (isDict(cfDict) && isName(streamCryptoName)) {
           cfDict.suppressEncryption = true; // See comment below.
-          var handlerDict = cfDict.get(streamCryptoName.name);
+          const handlerDict = cfDict.get(streamCryptoName.name);
           keyLength = (handlerDict && handlerDict.get("Length")) || 128;
           if (keyLength < 40) {
             // Sometimes it's incorrect value of bits, generators specify bytes.
@@ -1702,18 +1702,18 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
     }
 
     // prepare keys
-    var ownerPassword = stringToBytes(dict.get("O")).subarray(0, 32);
-    var userPassword = stringToBytes(dict.get("U")).subarray(0, 32);
-    var flags = dict.get("P");
-    var revision = dict.get("R");
+    const ownerPassword = stringToBytes(dict.get("O")).subarray(0, 32);
+    const userPassword = stringToBytes(dict.get("U")).subarray(0, 32);
+    const flags = dict.get("P");
+    const revision = dict.get("R");
     // meaningful when V is 4 or 5
-    var encryptMetadata =
+    const encryptMetadata =
       (algorithm === 4 || algorithm === 5) &&
       dict.get("EncryptMetadata") !== false;
     this.encryptMetadata = encryptMetadata;
 
-    var fileIdBytes = stringToBytes(fileId);
-    var passwordBytes;
+    const fileIdBytes = stringToBytes(fileId);
+    let passwordBytes;
     if (password) {
       if (revision === 6) {
         try {
@@ -1728,7 +1728,7 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
       passwordBytes = stringToBytes(password);
     }
 
-    var encryptionKey;
+    let encryptionKey;
     if (algorithm !== 5) {
       encryptionKey = prepareKeyData(
         fileIdBytes,
@@ -1741,14 +1741,14 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
         encryptMetadata
       );
     } else {
-      var ownerValidationSalt = stringToBytes(dict.get("O")).subarray(32, 40);
-      var ownerKeySalt = stringToBytes(dict.get("O")).subarray(40, 48);
-      var uBytes = stringToBytes(dict.get("U")).subarray(0, 48);
-      var userValidationSalt = stringToBytes(dict.get("U")).subarray(32, 40);
-      var userKeySalt = stringToBytes(dict.get("U")).subarray(40, 48);
-      var ownerEncryption = stringToBytes(dict.get("OE"));
-      var userEncryption = stringToBytes(dict.get("UE"));
-      var perms = stringToBytes(dict.get("Perms"));
+      const ownerValidationSalt = stringToBytes(dict.get("O")).subarray(32, 40);
+      const ownerKeySalt = stringToBytes(dict.get("O")).subarray(40, 48);
+      const uBytes = stringToBytes(dict.get("U")).subarray(0, 48);
+      const userValidationSalt = stringToBytes(dict.get("U")).subarray(32, 40);
+      const userKeySalt = stringToBytes(dict.get("U")).subarray(40, 48);
+      const ownerEncryption = stringToBytes(dict.get("OE"));
+      const userEncryption = stringToBytes(dict.get("UE"));
+      const perms = stringToBytes(dict.get("Perms"));
       encryptionKey = createEncryptionKey20(
         revision,
         passwordBytes,
@@ -1771,7 +1771,7 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
       );
     } else if (!encryptionKey && password) {
       // Attempting use the password as an owner password
-      var decodedPassword = decodeUserPassword(
+      const decodedPassword = decodeUserPassword(
         passwordBytes,
         ownerPassword,
         revision,
@@ -1799,7 +1799,7 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
     this.encryptionKey = encryptionKey;
 
     if (algorithm >= 4) {
-      var cf = dict.get("CF");
+      const cf = dict.get("CF");
       if (isDict(cf)) {
         // The 'CF' dictionary itself should not be encrypted, and by setting
         // `suppressEncryption` we can prevent an infinite loop inside of
@@ -1815,7 +1815,7 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
   }
 
   function buildObjectKey(num, gen, encryptionKey, isAes) {
-    var key = new Uint8Array(encryptionKey.length + 9),
+    let key = new Uint8Array(encryptionKey.length + 9),
       i,
       n;
     for (i = 0, n = encryptionKey.length; i < n; ++i) {
@@ -1832,7 +1832,7 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
       key[i++] = 0x6c;
       key[i++] = 0x54;
     }
-    var hash = calculateMD5(key, 0, i);
+    const hash = calculateMD5(key, 0, i);
     return hash.subarray(0, Math.min(encryptionKey.length + 5, 16));
   }
 
@@ -1840,8 +1840,8 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
     if (!isName(name)) {
       throw new FormatError("Invalid crypt filter name.");
     }
-    var cryptFilter = cf.get(name.name);
-    var cfm;
+    const cryptFilter = cf.get(name.name);
+    let cfm;
     if (cryptFilter !== null && cryptFilter !== undefined) {
       cfm = cryptFilter.get("CFM");
     }
@@ -1892,8 +1892,8 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
         );
       }
       // algorithms 1 and 2
-      var key = buildObjectKey(num, gen, this.encryptionKey, false);
-      var cipherConstructor = function buildCipherCipherConstructor() {
+      const key = buildObjectKey(num, gen, this.encryptionKey, false);
+      const cipherConstructor = function buildCipherCipherConstructor() {
         return new ARCFourCipher(key);
       };
       return new CipherTransform(cipherConstructor, cipherConstructor);

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 import {
   assert,

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -86,7 +86,7 @@ import { NativeImageDecoder } from "./image_utils.js";
 import { OperatorList } from "./operator_list.js";
 import { PDFImage } from "./image.js";
 
-var PartialEvaluator = (function PartialEvaluatorClosure() {
+const PartialEvaluator = (function PartialEvaluatorClosure() {
   const DefaultPartialEvaluatorOptions = {
     forceDataSchema: false,
     maxImageSize: -1,
@@ -147,8 +147,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
   }
 
   // Trying to minimize Date.now() usage and check every 100 time
-  var TIME_SLOT_DURATION_MS = 20;
-  var CHECK_TIME_EVERY = 100;
+  const TIME_SLOT_DURATION_MS = 20;
+  const CHECK_TIME_EVERY = 100;
   function TimeSlotManager() {
     this.reset();
   }
@@ -228,14 +228,14 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     return "source-over";
   }
 
-  var deferred = Promise.resolve();
+  const deferred = Promise.resolve();
 
-  var TILING_PATTERN = 1,
+  const TILING_PATTERN = 1,
     SHADING_PATTERN = 2;
 
   PartialEvaluator.prototype = {
     clone(newOptions = DefaultPartialEvaluatorOptions) {
-      var newEvaluator = Object.create(this);
+      const newEvaluator = Object.create(this);
       newEvaluator.options = newOptions;
       return newEvaluator;
     },
@@ -245,19 +245,19 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         return false;
       }
 
-      var processed = Object.create(null);
+      const processed = Object.create(null);
       if (resources.objId) {
         processed[resources.objId] = true;
       }
 
-      var nodes = [resources],
+      const nodes = [resources],
         xref = this.xref;
       while (nodes.length) {
-        var node = nodes.shift();
+        const node = nodes.shift();
         // First check the current resources for blend modes.
-        var graphicStates = node.get("ExtGState");
+        const graphicStates = node.get("ExtGState");
         if (graphicStates instanceof Dict) {
-          var graphicStatesKeys = graphicStates.getKeys();
+          const graphicStatesKeys = graphicStates.getKeys();
           for (let i = 0, ii = graphicStatesKeys.length; i < ii; i++) {
             const key = graphicStatesKeys[i];
 
@@ -292,15 +292,15 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           }
         }
         // Descend into the XObjects to look for more resources and blend modes.
-        var xObjects = node.get("XObject");
+        const xObjects = node.get("XObject");
         if (!(xObjects instanceof Dict)) {
           continue;
         }
-        var xObjectsKeys = xObjects.getKeys();
+        const xObjectsKeys = xObjects.getKeys();
         for (let i = 0, ii = xObjectsKeys.length; i < ii; i++) {
           const key = xObjectsKeys[i];
 
-          var xObject = xObjects.getRaw(key);
+          let xObject = xObjects.getRaw(key);
           if (xObject instanceof Ref) {
             if (processed[xObject.toString()]) {
               // The XObject has already been processed, and by avoiding a
@@ -319,7 +319,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
             }
             processed[xObject.dict.objId] = true;
           }
-          var xResources = xObject.dict.get("Resources");
+          const xResources = xObject.dict.get("Resources");
           // Checking objId to detect an infinite loop.
           if (
             xResources instanceof Dict &&
@@ -343,15 +343,15 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       task,
       initialState
     ) {
-      var dict = xobj.dict;
-      var matrix = dict.getArray("Matrix");
-      var bbox = dict.getArray("BBox");
+      const dict = xobj.dict;
+      const matrix = dict.getArray("Matrix");
+      let bbox = dict.getArray("BBox");
       if (Array.isArray(bbox) && bbox.length === 4) {
         bbox = Util.normalizeRect(bbox);
       } else {
         bbox = null;
       }
-      var group = dict.get("Group");
+      const group = dict.get("Group");
       if (group) {
         var groupOptions = {
           matrix,
@@ -361,8 +361,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           knockout: false,
         };
 
-        var groupSubtype = group.get("S");
-        var colorSpace = null;
+        const groupSubtype = group.get("S");
+        let colorSpace = null;
         if (isName(groupSubtype, "Transparency")) {
           groupOptions.isolated = group.get("I") || false;
           groupOptions.knockout = group.get("K") || false;
@@ -408,22 +408,22 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       imageCache,
       forceDisableNativeImageDecoder = false,
     }) {
-      var dict = image.dict;
-      var w = dict.get("Width", "W");
-      var h = dict.get("Height", "H");
+      const dict = image.dict;
+      const w = dict.get("Width", "W");
+      const h = dict.get("Height", "H");
 
       if (!(w && isNum(w)) || !(h && isNum(h))) {
         warn("Image dimensions are missing, or not numbers.");
         return undefined;
       }
-      var maxImageSize = this.options.maxImageSize;
+      const maxImageSize = this.options.maxImageSize;
       if (maxImageSize !== -1 && w * h > maxImageSize) {
         warn("Image exceeded maximum allowed size and was removed.");
         return undefined;
       }
 
-      var imageMask = dict.get("ImageMask", "IM") || false;
-      var imgData, args;
+      const imageMask = dict.get("ImageMask", "IM") || false;
+      let imgData, args;
       if (imageMask) {
         // This depends on a tmpCanvas being filled with the
         // current fillStyle, such that processing the pixel
@@ -431,14 +431,14 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         // complete PDFImage, only read the information needed
         // for later.
 
-        var width = dict.get("Width", "W");
-        var height = dict.get("Height", "H");
-        var bitStrideLength = (width + 7) >> 3;
-        var imgArray = image.getBytes(
+        const width = dict.get("Width", "W");
+        const height = dict.get("Height", "H");
+        const bitStrideLength = (width + 7) >> 3;
+        const imgArray = image.getBytes(
           bitStrideLength * height,
           /* forceClamped = */ true
         );
-        var decode = dict.getArray("Decode", "D");
+        const decode = dict.getArray("Decode", "D");
 
         imgData = PDFImage.createMask({
           imgArray,
@@ -460,10 +460,10 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         return undefined;
       }
 
-      var softMask = dict.get("SMask", "SM") || false;
-      var mask = dict.get("Mask") || false;
+      const softMask = dict.get("SMask", "SM") || false;
+      const mask = dict.get("Mask") || false;
 
-      var SMALL_IMAGE_DIMENSIONS = 200;
+      const SMALL_IMAGE_DIMENSIONS = 200;
       // Inlining small images into the queue as RGB data
       if (
         isInline &&
@@ -558,7 +558,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       }
 
       // Creates native image decoder only if a JPEG image or mask is present.
-      var nativeImageDecoder = null;
+      let nativeImageDecoder = null;
       if (
         nativeImageDecoderSupport === NativeImageDecoding.DECODE &&
         (image instanceof JpegStream ||
@@ -588,7 +588,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         pdfFunctionFactory: this.pdfFunctionFactory,
       })
         .then(imageObj => {
-          var imgData = imageObj.createImageData(/* forceRGBA = */ false);
+          const imgData = imageObj.createImageData(/* forceRGBA = */ false);
 
           if (this.parsingType3Font) {
             return this.handler.sendWithPromise(
@@ -642,20 +642,20 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       task,
       stateManager
     ) {
-      var smaskContent = smask.get("G");
-      var smaskOptions = {
+      const smaskContent = smask.get("G");
+      const smaskOptions = {
         subtype: smask.get("S").name,
         backdrop: smask.get("BC"),
       };
 
       // The SMask might have a alpha/luminosity value transfer function --
       // we will build a map of integer values in range 0..255 to be fast.
-      var transferObj = smask.get("TR");
+      const transferObj = smask.get("TR");
       if (isPDFFunction(transferObj)) {
         const transferFn = this.pdfFunctionFactory.create(transferObj);
-        var transferMap = new Uint8Array(256);
-        var tmp = new Float32Array(1);
-        for (var i = 0; i < 256; i++) {
+        const transferMap = new Uint8Array(256);
+        const tmp = new Float32Array(1);
+        for (let i = 0; i < 256; i++) {
           tmp[0] = i / 255;
           transferFn(tmp, 0, tmp, 0);
           transferMap[i] = (tmp[0] * 255) | 0;
@@ -739,7 +739,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       state
     ) {
       // TODO(mack): Not needed?
-      var fontName;
+      let fontName;
       if (fontArgs) {
         fontArgs = fontArgs.slice();
         fontName = fontArgs[0].name;
@@ -803,10 +803,10 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       stateManager
     ) {
       // This array holds the converted/processed state data.
-      var gStateObj = [];
-      var gStateKeys = gState.getKeys();
-      var promise = Promise.resolve();
-      for (var i = 0, ii = gStateKeys.length; i < ii; i++) {
+      const gStateObj = [];
+      const gStateKeys = gState.getKeys();
+      let promise = Promise.resolve();
+      for (let i = 0, ii = gStateKeys.length; i < ii; i++) {
         const key = gStateKeys[i];
         const value = gState.get(key);
         switch (key) {
@@ -904,7 +904,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         );
       }
 
-      var fontRef,
+      let fontRef,
         xref = this.xref;
       if (font) {
         // Loading by ref.
@@ -914,7 +914,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         fontRef = font;
       } else {
         // Loading by name.
-        var fontRes = resources.get("Font");
+        const fontRes = resources.get("Font");
         if (fontRes) {
           fontRef = fontRes.getRaw(fontName);
         }
@@ -953,12 +953,12 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         return font.translated;
       }
 
-      var fontCapability = createPromiseCapability();
+      const fontCapability = createPromiseCapability();
 
-      var preEvaluatedFont = this.preEvaluateFont(font);
+      const preEvaluatedFont = this.preEvaluateFont(font);
       const { descriptor, hash } = preEvaluatedFont;
 
-      var fontRefIsRef = isRef(fontRef),
+      let fontRefIsRef = isRef(fontRef),
         fontID;
       if (fontRefIsRef) {
         fontID = fontRef.toString();
@@ -968,10 +968,10 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         if (!descriptor.fontAliases) {
           descriptor.fontAliases = Object.create(null);
         }
-        var fontAliases = descriptor.fontAliases;
+        const fontAliases = descriptor.fontAliases;
 
         if (fontAliases[hash]) {
-          var aliasFontRef = fontAliases[hash].aliasRef;
+          const aliasFontRef = fontAliases[hash].aliasRef;
           if (
             fontRefIsRef &&
             aliasFontRef &&
@@ -1026,7 +1026,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       font.translated = fontCapability.promise;
 
       // TODO move promises into translate font
-      var translatedPromise;
+      let translatedPromise;
       try {
         translatedPromise = this.translateFont(preEvaluatedFont);
       } catch (e) {
@@ -1036,7 +1036,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       translatedPromise
         .then(function(translatedFont) {
           if (translatedFont.fontType !== undefined) {
-            var xrefFontStats = xref.stats.fontTypes;
+            const xrefFontStats = xref.stats.fontTypes;
             xrefFontStats[translatedFont.fontType] = true;
           }
 
@@ -1053,13 +1053,13 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
           try {
             // error, but it's still nice to have font type reported
-            var fontFile3 = descriptor && descriptor.get("FontFile3");
-            var subtype = fontFile3 && fontFile3.get("Subtype");
-            var fontType = getFontType(
+            const fontFile3 = descriptor && descriptor.get("FontFile3");
+            const subtype = fontFile3 && fontFile3.get("Subtype");
+            const fontType = getFontType(
               preEvaluatedFont.type,
               subtype && subtype.name
             );
-            var xrefFontStats = xref.stats.fontTypes;
+            const xrefFontStats = xref.stats.fontTypes;
             xrefFontStats[fontType] = true;
           } catch (ex) {}
 
@@ -1075,7 +1075,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     },
 
     buildPath(operatorList, fn, args, parsingText = false) {
-      var lastIndex = operatorList.length - 1;
+      const lastIndex = operatorList.length - 1;
       if (!args) {
         args = [];
       }
@@ -1101,7 +1101,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           operatorList.addOp(OPS.restore, null);
         }
       } else {
-        var opArgs = operatorList.argsArray[lastIndex];
+        const opArgs = operatorList.argsArray[lastIndex];
         opArgs[0].push(fn);
         Array.prototype.push.apply(opArgs[1], args);
       }
@@ -1131,15 +1131,15 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
     async handleColorN(operatorList, fn, args, cs, patterns, resources, task) {
       // compile tiling patterns
-      var patternName = args[args.length - 1];
+      const patternName = args[args.length - 1];
       // SCN/scn applies patterns along with normal colors
-      var pattern;
+      let pattern;
       if (isName(patternName) && (pattern = patterns.get(patternName.name))) {
-        var dict = isStream(pattern) ? pattern.dict : pattern;
-        var typeNum = dict.get("PatternType");
+        const dict = isStream(pattern) ? pattern.dict : pattern;
+        const typeNum = dict.get("PatternType");
 
         if (typeNum === TILING_PATTERN) {
-          var color = cs.base ? cs.base.getRgb(args, 0) : null;
+          const color = cs.base ? cs.base.getRgb(args, 0) : null;
           return this.handleTilingType(
             fn,
             color,
@@ -1150,8 +1150,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
             task
           );
         } else if (typeNum === SHADING_PATTERN) {
-          var shading = dict.get("Shading");
-          var matrix = dict.getArray("Matrix");
+          const shading = dict.get("Shading");
+          const matrix = dict.getArray("Matrix");
           pattern = Pattern.parseShading(
             shading,
             matrix,
@@ -1184,19 +1184,23 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         throw new Error('getOperatorList: missing "operatorList" parameter');
       }
 
-      var self = this;
-      var xref = this.xref;
+      const self = this;
+      const xref = this.xref;
       let parsingText = false;
-      var imageCache = Object.create(null);
+      const imageCache = Object.create(null);
 
-      var xobjs = resources.get("XObject") || Dict.empty;
-      var patterns = resources.get("Pattern") || Dict.empty;
-      var stateManager = new StateManager(initialState);
-      var preprocessor = new EvaluatorPreprocessor(stream, xref, stateManager);
-      var timeSlotManager = new TimeSlotManager();
+      const xobjs = resources.get("XObject") || Dict.empty;
+      const patterns = resources.get("Pattern") || Dict.empty;
+      const stateManager = new StateManager(initialState);
+      const preprocessor = new EvaluatorPreprocessor(
+        stream,
+        xref,
+        stateManager
+      );
+      const timeSlotManager = new TimeSlotManager();
 
       function closePendingRestoreOPS(argument) {
-        for (var i = 0, ii = preprocessor.savedStatesDepth; i < ii; i++) {
+        for (let i = 0, ii = preprocessor.savedStatesDepth; i < ii; i++) {
           operatorList.addOp(OPS.restore, []);
         }
       }
@@ -1213,7 +1217,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         };
         task.ensureNotTerminated();
         timeSlotManager.reset();
-        var stop,
+        let stop,
           operation = {},
           i,
           ii,
@@ -1345,7 +1349,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
             case OPS.endInlineImage:
               var cacheKey = args[0].cacheKey;
               if (cacheKey) {
-                var cacheEntry = imageCache[cacheKey];
+                const cacheEntry = imageCache[cacheKey];
                 if (cacheEntry !== undefined) {
                   operatorList.addOp(cacheEntry.fn, cacheEntry.args);
                   args = null;
@@ -1372,7 +1376,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
               var arrLength = arr.length;
               var state = stateManager.state;
               for (i = 0; i < arrLength; ++i) {
-                var arrItem = arr[i];
+                const arrItem = arr[i];
                 if (isString(arrItem)) {
                   Array.prototype.push.apply(
                     combinedGlyphs,
@@ -1634,13 +1638,13 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       resources = resources || Dict.empty;
       stateManager = stateManager || new StateManager(new TextState());
 
-      var WhitespaceRegexp = /\s/g;
+      const WhitespaceRegexp = /\s/g;
 
-      var textContent = {
+      const textContent = {
         items: [],
         styles: Object.create(null),
       };
-      var textContentItem = {
+      const textContentItem = {
         initialized: false,
         str: [],
         width: 0,
@@ -1657,26 +1661,30 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         transform: null,
         fontName: null,
       };
-      var SPACE_FACTOR = 0.3;
-      var MULTI_SPACE_FACTOR = 1.5;
-      var MULTI_SPACE_FACTOR_MAX = 4;
+      const SPACE_FACTOR = 0.3;
+      const MULTI_SPACE_FACTOR = 1.5;
+      const MULTI_SPACE_FACTOR_MAX = 4;
 
-      var self = this;
-      var xref = this.xref;
+      const self = this;
+      const xref = this.xref;
 
       // The xobj is parsed iff it's needed, e.g. if there is a `DO` cmd.
-      var xobjs = null;
-      var skipEmptyXObjs = Object.create(null);
+      let xobjs = null;
+      const skipEmptyXObjs = Object.create(null);
 
-      var preprocessor = new EvaluatorPreprocessor(stream, xref, stateManager);
+      const preprocessor = new EvaluatorPreprocessor(
+        stream,
+        xref,
+        stateManager
+      );
 
-      var textState;
+      let textState;
 
       function ensureTextContentItem() {
         if (textContentItem.initialized) {
           return textContentItem;
         }
-        var font = textState.font;
+        const font = textState.font;
         if (!(font.loadedName in seenStyles)) {
           seenStyles[font.loadedName] = true;
           textContent.styles[font.loadedName] = {
@@ -1689,7 +1697,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         textContentItem.fontName = font.loadedName;
 
         // 9.4.4 Text Space Details
-        var tsm = [
+        const tsm = [
           textState.fontSize * textState.textHScale,
           0,
           0,
@@ -1709,7 +1717,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           }
         }
 
-        var trm = Util.transform(
+        const trm = Util.transform(
           textState.ctm,
           Util.transform(textState.textMatrix, tsm)
         );
@@ -1724,17 +1732,17 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           textContentItem.vertical = true;
         }
 
-        var a = textState.textLineMatrix[0];
-        var b = textState.textLineMatrix[1];
-        var scaleLineX = Math.sqrt(a * a + b * b);
+        let a = textState.textLineMatrix[0];
+        let b = textState.textLineMatrix[1];
+        const scaleLineX = Math.sqrt(a * a + b * b);
         a = textState.ctm[0];
         b = textState.ctm[1];
-        var scaleCtmX = Math.sqrt(a * a + b * b);
+        const scaleCtmX = Math.sqrt(a * a + b * b);
         textContentItem.textAdvanceScale = scaleCtmX * scaleLineX;
         textContentItem.lastAdvanceWidth = 0;
         textContentItem.lastAdvanceHeight = 0;
 
-        var spaceWidth = (font.spaceWidth / 1000) * textState.fontSize;
+        const spaceWidth = (font.spaceWidth / 1000) * textState.fontSize;
         if (spaceWidth) {
           textContentItem.spaceWidth = spaceWidth;
           textContentItem.fakeSpaceMin = spaceWidth * SPACE_FACTOR;
@@ -1759,7 +1767,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         // Replaces all whitespaces with standard spaces (0x20), to avoid
         // alignment issues between the textLayer and the canvas if the text
         // contains e.g. tabs (fixes issue6612.pdf).
-        var i = 0,
+        let i = 0,
           ii = str.length,
           code;
         while (i < ii && (code = str.charCodeAt(i)) >= 0x20 && code <= 0x7f) {
@@ -1769,8 +1777,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       }
 
       function runBidiTransform(textChunk) {
-        var str = textChunk.str.join("");
-        var bidiResult = bidi(str, -1, textChunk.vertical);
+        const str = textChunk.str.join("");
+        const bidiResult = bidi(str, -1, textChunk.vertical);
         return {
           str: normalizeWhitespace
             ? replaceWhitespace(bidiResult.str)
@@ -1794,44 +1802,44 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       }
 
       function buildTextContentItem(chars) {
-        var font = textState.font;
-        var textChunk = ensureTextContentItem();
-        var width = 0;
-        var height = 0;
-        var glyphs = font.charsToGlyphs(chars);
-        for (var i = 0; i < glyphs.length; i++) {
-          var glyph = glyphs[i];
-          var glyphWidth = null;
+        const font = textState.font;
+        const textChunk = ensureTextContentItem();
+        let width = 0;
+        let height = 0;
+        const glyphs = font.charsToGlyphs(chars);
+        for (let i = 0; i < glyphs.length; i++) {
+          const glyph = glyphs[i];
+          let glyphWidth = null;
           if (font.vertical && glyph.vmetric) {
             glyphWidth = glyph.vmetric[0];
           } else {
             glyphWidth = glyph.width;
           }
 
-          var glyphUnicode = glyph.unicode;
-          var NormalizedUnicodes = getNormalizedUnicodes();
+          let glyphUnicode = glyph.unicode;
+          const NormalizedUnicodes = getNormalizedUnicodes();
           if (NormalizedUnicodes[glyphUnicode] !== undefined) {
             glyphUnicode = NormalizedUnicodes[glyphUnicode];
           }
           glyphUnicode = reverseIfRtl(glyphUnicode);
 
-          var charSpacing = textState.charSpacing;
+          let charSpacing = textState.charSpacing;
           if (glyph.isSpace) {
-            var wordSpacing = textState.wordSpacing;
+            const wordSpacing = textState.wordSpacing;
             charSpacing += wordSpacing;
             if (wordSpacing > 0) {
               addFakeSpaces(wordSpacing, textChunk.str);
             }
           }
 
-          var tx = 0;
-          var ty = 0;
+          let tx = 0;
+          let ty = 0;
           if (!font.vertical) {
-            var w0 = glyphWidth * textState.fontMatrix[0];
+            const w0 = glyphWidth * textState.fontMatrix[0];
             tx = (w0 * textState.fontSize + charSpacing) * textState.textHScale;
             width += tx;
           } else {
-            var w1 = glyphWidth * textState.fontMatrix[0];
+            const w1 = glyphWidth * textState.fontMatrix[0];
             ty = w1 * textState.fontSize + charSpacing;
             height += ty;
           }
@@ -1859,7 +1867,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           strBuf.push(" ");
           return;
         }
-        var fakeSpaces = Math.round(width / textContentItem.spaceWidth);
+        let fakeSpaces = Math.round(width / textContentItem.spaceWidth);
         while (fakeSpaces-- > 0) {
           strBuf.push(" ");
         }
@@ -1891,7 +1899,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         }
       }
 
-      var timeSlotManager = new TimeSlotManager();
+      const timeSlotManager = new TimeSlotManager();
 
       return new Promise(function promiseBody(resolve, reject) {
         const next = function(promise) {
@@ -1906,7 +1914,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         };
         task.ensureNotTerminated();
         timeSlotManager.reset();
-        var stop,
+        let stop,
           operation = {},
           args = [];
         while (!(stop = timeSlotManager.check())) {
@@ -1919,7 +1927,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
             break;
           }
           textState = stateManager.state;
-          var fn = operation.fn;
+          const fn = operation.fn;
           args = operation.args;
           var advance, diff;
 
@@ -2058,7 +2066,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
             case OPS.showSpacedText:
               var items = args[0];
               var offset;
-              for (var j = 0, jj = items.length; j < jj; j++) {
+              for (let j = 0, jj = items.length; j < jj; j++) {
                 if (typeof items[j] === "string") {
                   buildTextContentItem(items[j]);
                 } else if (isNum(items[j])) {
@@ -2073,7 +2081,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
                   // has the effect of moving the next glyph painted either to
                   // the left or down by the given amount.
                   advance = (items[j] * textState.fontSize) / 1000;
-                  var breakTextRun = false;
+                  let breakTextRun = false;
                   if (textState.font.vertical) {
                     offset = advance;
                     textState.translateTextMatrix(0, offset);
@@ -2283,14 +2291,14 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       const xref = this.xref;
       let cidToGidBytes;
       // 9.10.2
-      var toUnicode = dict.get("ToUnicode") || baseDict.get("ToUnicode");
-      var toUnicodePromise = toUnicode
+      const toUnicode = dict.get("ToUnicode") || baseDict.get("ToUnicode");
+      const toUnicodePromise = toUnicode
         ? this.readToUnicode(toUnicode)
         : Promise.resolve(undefined);
 
       if (properties.composite) {
         // CIDSystemInfo helps to match CID to glyphs
-        var cidSystemInfo = dict.get("CIDSystemInfo");
+        const cidSystemInfo = dict.get("CIDSystemInfo");
         if (isDict(cidSystemInfo)) {
           properties.cidSystemInfo = {
             registry: stringToPDFString(cidSystemInfo.get("Registry")),
@@ -2299,7 +2307,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           };
         }
 
-        var cidToGidMap = dict.get("CIDToGIDMap");
+        const cidToGidMap = dict.get("CIDToGIDMap");
         if (isStream(cidToGidMap)) {
           cidToGidBytes = cidToGidMap.getBytes();
         }
@@ -2311,9 +2319,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       // glyph mapping in the font.
       // TODO: Loading the built in encoding in the font would allow the
       // differences to be merged in here not require us to hold on to it.
-      var differences = [];
-      var baseEncodingName = null;
-      var encoding;
+      const differences = [];
+      let baseEncodingName = null;
+      let encoding;
       if (dict.has("Encoding")) {
         encoding = dict.get("Encoding");
         if (isDict(encoding)) {
@@ -2323,10 +2331,10 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
             : null;
           // Load the differences between the base and original
           if (encoding.has("Differences")) {
-            var diffEncoding = encoding.get("Differences");
-            var index = 0;
-            for (var j = 0, jj = diffEncoding.length; j < jj; j++) {
-              var data = xref.fetchIfRef(diffEncoding[j]);
+            const diffEncoding = encoding.get("Differences");
+            let index = 0;
+            for (let j = 0, jj = diffEncoding.length; j < jj; j++) {
+              const data = xref.fetchIfRef(diffEncoding[j]);
               if (isNum(data)) {
                 index = data;
               } else if (isName(data)) {
@@ -2357,8 +2365,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       if (baseEncodingName) {
         properties.defaultEncoding = getEncoding(baseEncodingName).slice();
       } else {
-        var isSymbolicFont = !!(properties.flags & FontFlags.Symbolic);
-        var isNonsymbolicFont = !!(properties.flags & FontFlags.Nonsymbolic);
+        const isSymbolicFont = !!(properties.flags & FontFlags.Symbolic);
+        const isNonsymbolicFont = !!(properties.flags & FontFlags.Nonsymbolic);
         // According to "Table 114" in section "9.6.6.1 General" (under
         // "9.6.6 Character Encoding") of the PDF specification, a Nonsymbolic
         // font should use the `StandardEncoding` if no encoding is specified.
@@ -2595,7 +2603,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     },
 
     readToUnicode: function PartialEvaluator_readToUnicode(toUnicode) {
-      var cmapObj = toUnicode;
+      const cmapObj = toUnicode;
       if (isName(cmapObj)) {
         return CMapFactory.create({
           encoding: cmapObj,
@@ -2617,21 +2625,21 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
             if (cmap instanceof IdentityCMap) {
               return new IdentityToUnicodeMap(0, 0xffff);
             }
-            var map = new Array(cmap.length);
+            const map = new Array(cmap.length);
             // Convert UTF-16BE
             // NOTE: cmap can be a sparse array, so use forEach instead of
             // `for(;;)` to iterate over all keys.
             cmap.forEach(function(charCode, token) {
-              var str = [];
-              for (var k = 0; k < token.length; k += 2) {
-                var w1 = (token.charCodeAt(k) << 8) | token.charCodeAt(k + 1);
+              const str = [];
+              for (let k = 0; k < token.length; k += 2) {
+                const w1 = (token.charCodeAt(k) << 8) | token.charCodeAt(k + 1);
                 if ((w1 & 0xf800) !== 0xd800) {
                   // w1 < 0xD800 || w1 > 0xDFFF
                   str.push(w1);
                   continue;
                 }
                 k += 2;
-                var w2 = (token.charCodeAt(k) << 8) | token.charCodeAt(k + 1);
+                const w2 = (token.charCodeAt(k) << 8) | token.charCodeAt(k + 1);
                 str.push(((w1 & 0x3ff) << 10) + (w2 & 0x3ff) + 0x10000);
               }
               map[charCode] = String.fromCodePoint.apply(String, str);
@@ -2662,9 +2670,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       // Extract the encoding from the CIDToGIDMap
 
       // Set encoding 0 to later verify the font has an encoding
-      var result = [];
-      for (var j = 0, jj = glyphsData.length; j < jj; j++) {
-        var glyphID = (glyphsData[j++] << 8) | glyphsData[j];
+      const result = [];
+      for (let j = 0, jj = glyphsData.length; j < jj; j++) {
+        const glyphID = (glyphsData[j++] << 8) | glyphsData[j];
         const code = j >> 1;
         if (glyphID === 0 && !toUnicode.has(code)) {
           continue;
@@ -2679,12 +2687,12 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       descriptor,
       properties
     ) {
-      var xref = this.xref;
-      var glyphsWidths = [];
-      var defaultWidth = 0;
-      var glyphsVMetrics = [];
-      var defaultVMetrics;
-      var i, ii, j, jj, start, code, widths;
+      const xref = this.xref;
+      let glyphsWidths = [];
+      let defaultWidth = 0;
+      const glyphsVMetrics = [];
+      let defaultVMetrics;
+      let i, ii, j, jj, start, code, widths;
       if (properties.composite) {
         defaultWidth = dict.has("DW") ? dict.get("DW") : 1000;
 
@@ -2698,7 +2706,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
                 glyphsWidths[start++] = xref.fetchIfRef(code[j]);
               }
             } else {
-              var width = xref.fetchIfRef(widths[++i]);
+              const width = xref.fetchIfRef(widths[++i]);
               for (j = start; j <= code; j++) {
                 glyphsWidths[j] = width;
               }
@@ -2707,7 +2715,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         }
 
         if (properties.vertical) {
-          var vmetrics = dict.getArray("DW2") || [880, -1000];
+          let vmetrics = dict.getArray("DW2") || [880, -1000];
           defaultVMetrics = [vmetrics[1], defaultWidth * 0.5, vmetrics[0]];
           vmetrics = dict.get("W2");
           if (vmetrics) {
@@ -2723,7 +2731,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
                   ];
                 }
               } else {
-                var vmetric = [
+                const vmetric = [
                   xref.fetchIfRef(vmetrics[++i]),
                   xref.fetchIfRef(vmetrics[++i]),
                   xref.fetchIfRef(vmetrics[++i]),
@@ -2736,7 +2744,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           }
         }
       } else {
-        var firstChar = properties.firstChar;
+        const firstChar = properties.firstChar;
         widths = dict.get("Widths");
         if (widths) {
           j = firstChar;
@@ -2746,9 +2754,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           defaultWidth = parseFloat(descriptor.get("MissingWidth")) || 0;
         } else {
           // Trying get the BaseFont metrics (see comment above).
-          var baseFontName = dict.get("BaseFont");
+          const baseFontName = dict.get("BaseFont");
           if (isName(baseFontName)) {
-            var metrics = this.getBaseFontMetrics(baseFontName.name);
+            const metrics = this.getBaseFontMetrics(baseFontName.name);
 
             glyphsWidths = this.buildCharCodeToWidth(
               metrics.widths,
@@ -2760,10 +2768,10 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       }
 
       // Heuristic: detection of monospace font by checking all non-zero widths
-      var isMonospace = true;
-      var firstWidth = defaultWidth;
-      for (var glyph in glyphsWidths) {
-        var glyphWidth = glyphsWidths[glyph];
+      let isMonospace = true;
+      let firstWidth = defaultWidth;
+      for (const glyph in glyphsWidths) {
+        const glyphWidth = glyphsWidths[glyph];
         if (!glyphWidth) {
           continue;
         }
@@ -2788,7 +2796,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
     isSerifFont: function PartialEvaluator_isSerifFont(baseFontName) {
       // Simulating descriptor flags attribute
-      var fontNameWoStyle = baseFontName.split("-")[0];
+      const fontNameWoStyle = baseFontName.split("-")[0];
       return (
         fontNameWoStyle in getSerifFonts() ||
         fontNameWoStyle.search(/serif/gi) !== -1
@@ -2796,12 +2804,12 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     },
 
     getBaseFontMetrics: function PartialEvaluator_getBaseFontMetrics(name) {
-      var defaultWidth = 0;
-      var widths = [];
-      var monospace = false;
-      var stdFontMap = getStdFontMap();
-      var lookupName = stdFontMap[name] || name;
-      var Metrics = getMetrics();
+      let defaultWidth = 0;
+      let widths = [];
+      let monospace = false;
+      const stdFontMap = getStdFontMap();
+      let lookupName = stdFontMap[name] || name;
+      const Metrics = getMetrics();
 
       if (!(lookupName in Metrics)) {
         // Use default fonts for looking up font metrics if the passed
@@ -2812,7 +2820,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           lookupName = "Helvetica";
         }
       }
-      var glyphWidths = Metrics[lookupName];
+      const glyphWidths = Metrics[lookupName];
 
       if (isNum(glyphWidths)) {
         defaultWidth = glyphWidths;
@@ -2832,10 +2840,10 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       widthsByGlyphName,
       properties
     ) {
-      var widths = Object.create(null);
-      var differences = properties.differences;
-      var encoding = properties.defaultEncoding;
-      for (var charCode = 0; charCode < 256; charCode++) {
+      const widths = Object.create(null);
+      const differences = properties.differences;
+      const encoding = properties.defaultEncoding;
+      for (let charCode = 0; charCode < 256; charCode++) {
         if (
           charCode in differences &&
           widthsByGlyphName[differences[charCode]]
@@ -2852,20 +2860,20 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     },
 
     preEvaluateFont: function PartialEvaluator_preEvaluateFont(dict) {
-      var baseDict = dict;
-      var type = dict.get("Subtype");
+      const baseDict = dict;
+      let type = dict.get("Subtype");
       if (!isName(type)) {
         throw new FormatError("invalid font Subtype");
       }
 
-      var composite = false;
-      var uint8array;
+      let composite = false;
+      let uint8array;
       if (type.name === "Type0") {
         // If font is a composite
         //  - get the descendant font
         //  - set the type according to the descendant font
         //  - get the FontDescriptor from the descendant font
-        var df = dict.get("DescendantFonts");
+        const df = dict.get("DescendantFonts");
         if (!df) {
           throw new FormatError("Descendant fonts are not specified");
         }
@@ -2878,29 +2886,29 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         composite = true;
       }
 
-      var descriptor = dict.get("FontDescriptor");
+      const descriptor = dict.get("FontDescriptor");
       if (descriptor) {
         var hash = new MurmurHash3_64();
-        var encoding = baseDict.getRaw("Encoding");
+        const encoding = baseDict.getRaw("Encoding");
         if (isName(encoding)) {
           hash.update(encoding.name);
         } else if (isRef(encoding)) {
           hash.update(encoding.toString());
         } else if (isDict(encoding)) {
-          var keys = encoding.getKeys();
-          for (var i = 0, ii = keys.length; i < ii; i++) {
-            var entry = encoding.getRaw(keys[i]);
+          const keys = encoding.getKeys();
+          for (let i = 0, ii = keys.length; i < ii; i++) {
+            const entry = encoding.getRaw(keys[i]);
             if (isName(entry)) {
               hash.update(entry.name);
             } else if (isRef(entry)) {
               hash.update(entry.toString());
             } else if (Array.isArray(entry)) {
               // 'Differences' array (fixes bug1157493.pdf).
-              var diffLength = entry.length,
+              const diffLength = entry.length,
                 diffBuf = new Array(diffLength);
 
-              for (var j = 0; j < diffLength; j++) {
-                var diffEntry = entry[j];
+              for (let j = 0; j < diffLength; j++) {
+                const diffEntry = entry[j];
                 if (isName(diffEntry)) {
                   diffBuf[j] = diffEntry.name;
                 } else if (isNum(diffEntry) || isRef(diffEntry)) {
@@ -2916,9 +2924,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         const lastChar = dict.get("LastChar") || (composite ? 0xffff : 0xff);
         hash.update(`${firstChar}-${lastChar}`);
 
-        var toUnicode = dict.get("ToUnicode") || baseDict.get("ToUnicode");
+        const toUnicode = dict.get("ToUnicode") || baseDict.get("ToUnicode");
         if (isStream(toUnicode)) {
-          var stream = toUnicode.str || toUnicode;
+          const stream = toUnicode.str || toUnicode;
           uint8array = stream.buffer
             ? new Uint8Array(stream.buffer.buffer, 0, stream.bufferLength)
             : new Uint8Array(
@@ -2931,7 +2939,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           hash.update(toUnicode.name);
         }
 
-        var widths = dict.get("Widths") || baseDict.get("Widths");
+        const widths = dict.get("Widths") || baseDict.get("Widths");
         if (widths) {
           uint8array = new Uint8Array(new Uint32Array(widths).buffer);
           hash.update(uint8array);
@@ -2949,13 +2957,13 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     },
 
     translateFont: function PartialEvaluator_translateFont(preEvaluatedFont) {
-      var baseDict = preEvaluatedFont.baseDict;
-      var dict = preEvaluatedFont.dict;
-      var composite = preEvaluatedFont.composite;
-      var descriptor = preEvaluatedFont.descriptor;
-      var type = preEvaluatedFont.type;
-      var maxCharIndex = composite ? 0xffff : 0xff;
-      var properties;
+      const baseDict = preEvaluatedFont.baseDict;
+      const dict = preEvaluatedFont.dict;
+      const composite = preEvaluatedFont.composite;
+      let descriptor = preEvaluatedFont.descriptor;
+      const type = preEvaluatedFont.type;
+      const maxCharIndex = composite ? 0xffff : 0xff;
+      let properties;
       const firstChar = dict.get("FirstChar") || 0;
       const lastChar = dict.get("LastChar") || maxCharIndex;
 
@@ -2970,18 +2978,18 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           // Before PDF 1.5 if the font was one of the base 14 fonts, having a
           // FontDescriptor was not required.
           // This case is here for compatibility.
-          var baseFontName = dict.get("BaseFont");
+          let baseFontName = dict.get("BaseFont");
           if (!isName(baseFontName)) {
             throw new FormatError("Base font is not specified");
           }
 
           // Using base font name as a font name.
           baseFontName = baseFontName.name.replace(/[,_]/g, "-");
-          var metrics = this.getBaseFontMetrics(baseFontName);
+          const metrics = this.getBaseFontMetrics(baseFontName);
 
           // Simulating descriptor flags attribute
-          var fontNameWoStyle = baseFontName.split("-")[0];
-          var flags =
+          const fontNameWoStyle = baseFontName.split("-")[0];
+          const flags =
             (this.isSerifFont(fontNameWoStyle) ? FontFlags.Serif : 0) |
             (metrics.monospace ? FontFlags.FixedPitch : 0) |
             (getSymbolsFonts()[fontNameWoStyle]
@@ -3025,8 +3033,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       // TODO Fill the width array depending on which of the base font this is
       // a variant.
 
-      var fontName = descriptor.get("FontName");
-      var baseFont = dict.get("BaseFont");
+      let fontName = descriptor.get("FontName");
+      let baseFont = dict.get("BaseFont");
       // Some bad PDFs have a string as the font name.
       if (isString(fontName)) {
         fontName = Name.get(fontName);
@@ -3036,8 +3044,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       }
 
       if (type !== "Type3") {
-        var fontNameStr = fontName && fontName.name;
-        var baseFontStr = baseFont && baseFont.name;
+        const fontNameStr = fontName && fontName.name;
+        const baseFontStr = baseFont && baseFont.name;
         if (fontNameStr !== baseFontStr) {
           info(
             `The FontDescriptor\'s FontName is "${fontNameStr}" but ` +
@@ -3060,7 +3068,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         throw new FormatError("invalid font name");
       }
 
-      var fontFile = descriptor.get("FontFile", "FontFile2", "FontFile3");
+      const fontFile = descriptor.get("FontFile", "FontFile2", "FontFile3");
       if (fontFile) {
         if (fontFile.dict) {
           var subtype = fontFile.dict.get("Subtype");
@@ -3098,9 +3106,9 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         isType3Font: false,
       };
 
-      var cMapPromise;
+      let cMapPromise;
       if (composite) {
-        var cidEncoding = baseDict.get("Encoding");
+        const cidEncoding = baseDict.get("Encoding");
         if (isName(cidEncoding)) {
           properties.cidEncoding = cidEncoding.name;
         }
@@ -3226,24 +3234,24 @@ var TranslatedFont = (function TranslatedFontClosure() {
       // Also, ensure that any Type3 image resources (which should be very rare
       // in practice) are completely decoded on the worker-thread, to simplify
       // the rendering code on the main-thread (see issue10717.pdf).
-      var type3Options = Object.create(evaluator.options);
+      const type3Options = Object.create(evaluator.options);
       type3Options.ignoreErrors = false;
       type3Options.nativeImageDecoderSupport = NativeImageDecoding.NONE;
-      var type3Evaluator = evaluator.clone(type3Options);
+      const type3Evaluator = evaluator.clone(type3Options);
       type3Evaluator.parsingType3Font = true;
 
-      var translatedFont = this.font;
-      var loadCharProcsPromise = Promise.resolve();
-      var charProcs = this.dict.get("CharProcs");
-      var fontResources = this.dict.get("Resources") || resources;
-      var charProcKeys = charProcs.getKeys();
-      var charProcOperatorList = Object.create(null);
+      const translatedFont = this.font;
+      let loadCharProcsPromise = Promise.resolve();
+      const charProcs = this.dict.get("CharProcs");
+      const fontResources = this.dict.get("Resources") || resources;
+      const charProcKeys = charProcs.getKeys();
+      const charProcOperatorList = Object.create(null);
 
-      for (var i = 0, n = charProcKeys.length; i < n; ++i) {
+      for (let i = 0, n = charProcKeys.length; i < n; ++i) {
         const key = charProcKeys[i];
         loadCharProcsPromise = loadCharProcsPromise.then(function() {
-          var glyphStream = charProcs.get(key);
-          var operatorList = new OperatorList();
+          const glyphStream = charProcs.get(key);
+          const operatorList = new OperatorList();
           return type3Evaluator
             .getOperatorList({
               stream: glyphStream,
@@ -3260,7 +3268,7 @@ var TranslatedFont = (function TranslatedFontClosure() {
             })
             .catch(function(reason) {
               warn(`Type3 font resource "${key}" is not available.`);
-              var operatorList = new OperatorList();
+              const operatorList = new OperatorList();
               charProcOperatorList[key] = operatorList.getIR();
             });
         });
@@ -3281,12 +3289,12 @@ var StateManager = (function StateManagerClosure() {
   }
   StateManager.prototype = {
     save() {
-      var old = this.state;
+      const old = this.state;
       this.stateStack.push(this.state);
       this.state = old.clone();
     },
     restore() {
-      var prev = this.stateStack.pop();
+      const prev = this.stateStack.pop();
       if (prev) {
         this.state = prev;
       }
@@ -3316,7 +3324,7 @@ var TextState = (function TextStateClosure() {
 
   TextState.prototype = {
     setTextMatrix: function TextState_setTextMatrix(a, b, c, d, e, f) {
-      var m = this.textMatrix;
+      const m = this.textMatrix;
       m[0] = a;
       m[1] = b;
       m[2] = c;
@@ -3325,7 +3333,7 @@ var TextState = (function TextStateClosure() {
       m[5] = f;
     },
     setTextLineMatrix: function TextState_setTextMatrix(a, b, c, d, e, f) {
-      var m = this.textLineMatrix;
+      const m = this.textLineMatrix;
       m[0] = a;
       m[1] = b;
       m[2] = c;
@@ -3334,12 +3342,12 @@ var TextState = (function TextStateClosure() {
       m[5] = f;
     },
     translateTextMatrix: function TextState_translateTextMatrix(x, y) {
-      var m = this.textMatrix;
+      const m = this.textMatrix;
       m[4] = m[0] * x + m[2] * y + m[4];
       m[5] = m[1] * x + m[3] * y + m[5];
     },
     translateTextLineMatrix: function TextState_translateTextMatrix(x, y) {
-      var m = this.textLineMatrix;
+      const m = this.textLineMatrix;
       m[4] = m[0] * x + m[2] * y + m[4];
       m[5] = m[1] * x + m[3] * y + m[5];
     },
@@ -3351,20 +3359,20 @@ var TextState = (function TextStateClosure() {
       e,
       f
     ) {
-      var font = this.font;
+      const font = this.font;
       if (!font) {
         return null;
       }
-      var m = this.textLineMatrix;
+      const m = this.textLineMatrix;
       if (!(a === m[0] && b === m[1] && c === m[2] && d === m[3])) {
         return null;
       }
-      var txDiff = e - m[4],
+      const txDiff = e - m[4],
         tyDiff = f - m[5];
       if ((font.vertical && txDiff !== 0) || (!font.vertical && tyDiff !== 0)) {
         return null;
       }
-      var tx,
+      let tx,
         ty,
         denominator = a * d - b * c;
       if (font.vertical) {
@@ -3378,7 +3386,7 @@ var TextState = (function TextStateClosure() {
     },
     calcRenderMatrix: function TextState_calcRendeMatrix(ctm) {
       // 9.4.4 Text Space Details
-      var tsm = [
+      const tsm = [
         this.fontSize * this.textHScale,
         0,
         0,
@@ -3393,7 +3401,7 @@ var TextState = (function TextStateClosure() {
       this.textMatrix = this.textLineMatrix.slice();
     },
     clone: function TextState_clone() {
-      var clone = Object.create(this);
+      const clone = Object.create(this);
       clone.textMatrix = this.textMatrix.slice();
       clone.textLineMatrix = this.textLineMatrix.slice();
       clone.fontMatrix = this.fontMatrix.slice();
@@ -3424,7 +3432,7 @@ var EvaluatorPreprocessor = (function EvaluatorPreprocessorClosure() {
   //
   // If variableArgs === true: [0, `numArgs`] expected
   // If variableArgs === false: exactly `numArgs` expected
-  var getOPMap = getLookupTableFactory(function(t) {
+  const getOPMap = getLookupTableFactory(function(t) {
     // Graphic state
     t["w"] = { id: OPS.setLineWidth, numArgs: 1, variableArgs: false };
     t["J"] = { id: OPS.setLineCap, numArgs: 1, variableArgs: false };
@@ -3585,26 +3593,26 @@ var EvaluatorPreprocessor = (function EvaluatorPreprocessorClosure() {
     // avoiding allocations where possible is worthwhile.
     //
     read: function EvaluatorPreprocessor_read(operation) {
-      var args = operation.args;
+      let args = operation.args;
       while (true) {
-        var obj = this.parser.getObj();
+        const obj = this.parser.getObj();
         if (obj instanceof Cmd) {
-          var cmd = obj.cmd;
+          const cmd = obj.cmd;
           // Check that the command is valid
-          var opSpec = this.opMap[cmd];
+          const opSpec = this.opMap[cmd];
           if (!opSpec) {
             warn(`Unknown command "${cmd}".`);
             continue;
           }
 
-          var fn = opSpec.id;
-          var numArgs = opSpec.numArgs;
-          var argsLength = args !== null ? args.length : 0;
+          const fn = opSpec.id;
+          const numArgs = opSpec.numArgs;
+          let argsLength = args !== null ? args.length : 0;
 
           if (!opSpec.variableArgs) {
             // Postscript commands can be nested, e.g. /F2 /GS2 gs 5.711 Tf
             if (argsLength !== numArgs) {
-              var nonProcessedArgs = this.nonProcessedArgs;
+              const nonProcessedArgs = this.nonProcessedArgs;
               while (argsLength > numArgs) {
                 nonProcessedArgs.push(args.shift());
                 argsLength--;

--- a/src/core/font_renderer.js
+++ b/src/core/font_renderer.js
@@ -25,7 +25,7 @@ import { getGlyphsUnicode } from "./glyphlist.js";
 import { StandardEncoding } from "./encodings.js";
 import { Stream } from "./stream.js";
 
-var FontRendererFactory = (function FontRendererFactoryClosure() {
+const FontRendererFactory = (function FontRendererFactoryClosure() {
   function getLong(data, offset) {
     return (
       (data[offset] << 24) |
@@ -51,15 +51,15 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
   }
 
   function parseCmap(data, start, end) {
-    var offset =
+    const offset =
       getUshort(data, start + 2) === 1
         ? getLong(data, start + 8)
         : getLong(data, start + 16);
-    var format = getUshort(data, start + offset);
-    var ranges, p, i;
+    const format = getUshort(data, start + offset);
+    let ranges, p, i;
     if (format === 4) {
       getUshort(data, start + offset + 2); // length
-      var segCount = getUshort(data, start + offset + 6) >> 1;
+      const segCount = getUshort(data, start + offset + 6) >> 1;
       p = start + offset + 14;
       ranges = [];
       for (i = 0; i < segCount; i++, p += 2) {
@@ -73,12 +73,12 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
         ranges[i].idDelta = getUshort(data, p);
       }
       for (i = 0; i < segCount; i++, p += 2) {
-        var idOffset = getUshort(data, p);
+        let idOffset = getUshort(data, p);
         if (idOffset === 0) {
           continue;
         }
         ranges[i].ids = [];
-        for (var j = 0, jj = ranges[i].end - ranges[i].start + 1; j < jj; j++) {
+        for (let j = 0, jj = ranges[i].end - ranges[i].start + 1; j < jj; j++) {
           ranges[i].ids[j] = getUshort(data, p + idOffset);
           idOffset += 2;
         }
@@ -86,7 +86,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
       return ranges;
     } else if (format === 12) {
       getLong(data, start + offset + 4); // length
-      var groups = getLong(data, start + offset + 12);
+      const groups = getLong(data, start + offset + 12);
       p = start + offset + 16;
       ranges = [];
       for (i = 0; i < groups; i++) {
@@ -103,13 +103,13 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
   }
 
   function parseCff(data, start, end, seacAnalysisEnabled) {
-    var properties = {};
-    var parser = new CFFParser(
+    const properties = {};
+    const parser = new CFFParser(
       new Stream(data, start, end - start),
       properties,
       seacAnalysisEnabled
     );
-    var cff = parser.parse();
+    const cff = parser.parse();
     return {
       glyphs: cff.charStrings.objects,
       subrs:
@@ -124,7 +124,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
   }
 
   function parseGlyfTable(glyf, loca, isGlyphLocationsLong) {
-    var itemSize, itemDecode;
+    let itemSize, itemDecode;
     if (isGlyphLocationsLong) {
       itemSize = 4;
       itemDecode = function fontItemDecodeLong(data, offset) {
@@ -141,10 +141,10 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
         return (data[offset] << 9) | (data[offset + 1] << 1);
       };
     }
-    var glyphs = [];
-    var startOffset = itemDecode(loca, 0);
-    for (var j = itemSize; j < loca.length; j += itemSize) {
-      var endOffset = itemDecode(loca, j);
+    const glyphs = [];
+    let startOffset = itemDecode(loca, 0);
+    for (let j = itemSize; j < loca.length; j += itemSize) {
+      const endOffset = itemDecode(loca, j);
       glyphs.push(glyf.subarray(startOffset, endOffset));
       startOffset = endOffset;
     }
@@ -152,12 +152,12 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
   }
 
   function lookupCmap(ranges, unicode) {
-    var code = unicode.codePointAt(0),
+    let code = unicode.codePointAt(0),
       gid = 0;
-    var l = 0,
+    let l = 0,
       r = ranges.length - 1;
     while (l < r) {
-      var c = (l + r + 1) >> 1;
+      const c = (l + r + 1) >> 1;
       if (code < ranges[c].start) {
         r = c - 1;
       } else {
@@ -187,17 +187,17 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
       cmds.push({ cmd: "quadraticCurveTo", args: [xa, ya, x, y] });
     }
 
-    var i = 0;
-    var numberOfContours = ((code[i] << 24) | (code[i + 1] << 16)) >> 16;
-    var flags;
-    var x = 0,
+    let i = 0;
+    const numberOfContours = ((code[i] << 24) | (code[i + 1] << 16)) >> 16;
+    let flags;
+    let x = 0,
       y = 0;
     i += 10;
     if (numberOfContours < 0) {
       // composite glyph
       do {
         flags = (code[i] << 8) | code[i + 1];
-        var glyphIndex = (code[i + 2] << 8) | code[i + 3];
+        const glyphIndex = (code[i + 2] << 8) | code[i + 3];
         i += 4;
         var arg1, arg2;
         if (flags & 0x01) {
@@ -215,7 +215,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
           x = 0;
           y = 0; // TODO "they are points" ?
         }
-        var scaleX = 1,
+        let scaleX = 1,
           scaleY = 1,
           scale01 = 0,
           scale10 = 0;
@@ -234,7 +234,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
           scaleY = ((code[i + 6] << 24) | (code[i + 7] << 16)) / 1073741824;
           i += 8;
         }
-        var subglyph = font.glyphs[glyphIndex];
+        const subglyph = font.glyphs[glyphIndex];
         if (subglyph) {
           cmds.push({ cmd: "save" });
           cmds.push({
@@ -247,19 +247,19 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
       } while (flags & 0x20);
     } else {
       // simple glyph
-      var endPtsOfContours = [];
-      var j, jj;
+      const endPtsOfContours = [];
+      let j, jj;
       for (j = 0; j < numberOfContours; j++) {
         endPtsOfContours.push((code[i] << 8) | code[i + 1]);
         i += 2;
       }
-      var instructionLength = (code[i] << 8) | code[i + 1];
+      const instructionLength = (code[i] << 8) | code[i + 1];
       i += 2 + instructionLength; // skipping the instructions
-      var numberOfPoints = endPtsOfContours[endPtsOfContours.length - 1] + 1;
-      var points = [];
+      const numberOfPoints = endPtsOfContours[endPtsOfContours.length - 1] + 1;
+      const points = [];
       while (points.length < numberOfPoints) {
         flags = code[i++];
-        var repeat = 1;
+        let repeat = 1;
         if (flags & 0x08) {
           repeat += code[i++];
         }
@@ -298,12 +298,12 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
         points[j].y = y;
       }
 
-      var startPoint = 0;
+      let startPoint = 0;
       for (i = 0; i < numberOfContours; i++) {
-        var endPoint = endPtsOfContours[i];
+        const endPoint = endPtsOfContours[i];
         // contours might have implicit points, which is located in the middle
         // between two neighboring off-curve points
-        var contour = points.slice(startPoint, endPoint + 1);
+        const contour = points.slice(startPoint, endPoint + 1);
         if (contour[0].flags & 1) {
           contour.push(contour[0]); // using start point at the contour end
         } else if (contour[contour.length - 1].flags & 1) {
@@ -311,7 +311,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
           contour.unshift(contour[contour.length - 1]);
         } else {
           // start and end are off-curve points, creating implicit one
-          var p = {
+          const p = {
             flags: 1,
             x: (contour[0].x + contour[contour.length - 1].x) / 2,
             y: (contour[0].y + contour[contour.length - 1].y) / 2,
@@ -346,10 +346,10 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
   }
 
   function compileCharString(code, cmds, font, glyphId) {
-    var stack = [];
-    var x = 0,
+    const stack = [];
+    let x = 0,
       y = 0;
-    var stems = 0;
+    let stems = 0;
 
     function moveTo(x, y) {
       cmds.push({ cmd: "moveTo", args: [x, y] });
@@ -362,10 +362,10 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
     }
 
     function parse(code) {
-      var i = 0;
+      let i = 0;
       while (i < code.length) {
-        var stackClean = false;
-        var v = code[i++];
+        let stackClean = false;
+        let v = code[i++];
         var xa, xb, ya, yb, y1, y2, y3, n, subrCode;
         switch (v) {
           case 1: // hstem
@@ -522,13 +522,13 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
             break;
           case 14: // endchar
             if (stack.length >= 4) {
-              var achar = stack.pop();
-              var bchar = stack.pop();
+              const achar = stack.pop();
+              const bchar = stack.pop();
               y = stack.pop();
               x = stack.pop();
               cmds.push({ cmd: "save" });
               cmds.push({ cmd: "translate", args: [x, y] });
-              var cmap = lookupCmap(
+              let cmap = lookupCmap(
                 font.cmap,
                 String.fromCharCode(font.glyphNameMap[StandardEncoding[achar]])
               );
@@ -829,13 +829,13 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
 
   return {
     create: function FontRendererFactory_create(font, seacAnalysisEnabled) {
-      var data = new Uint8Array(font.data);
-      var cmap, glyf, loca, cff, indexToLocFormat, unitsPerEm;
-      var numTables = getUshort(data, 4);
-      for (var i = 0, p = 12; i < numTables; i++, p += 16) {
-        var tag = bytesToString(data.subarray(p, p + 4));
-        var offset = getLong(data, p + 8);
-        var length = getLong(data, p + 12);
+      const data = new Uint8Array(font.data);
+      let cmap, glyf, loca, cff, indexToLocFormat, unitsPerEm;
+      const numTables = getUshort(data, 4);
+      for (let i = 0, p = 12; i < numTables; i++, p += 16) {
+        const tag = bytesToString(data.subarray(p, p + 4));
+        const offset = getLong(data, p + 8);
+        const length = getLong(data, p + 12);
         switch (tag) {
           case "cmap":
             cmap = parseCmap(data, offset, offset + length);
@@ -857,7 +857,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
       }
 
       if (glyf) {
-        var fontMatrix = !unitsPerEm
+        const fontMatrix = !unitsPerEm
           ? font.fontMatrix
           : [1 / unitsPerEm, 0, 0, 1 / unitsPerEm, 0, 0];
         return new TrueTypeCompiled(

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -72,7 +72,7 @@ const PRIVATE_USE_AREAS = [
 
 // PDF Glyph Space Units are one Thousandth of a TextSpace Unit
 // except for Type 3 fonts
-var PDF_GLYPH_SPACE_UNITS = 1000;
+const PDF_GLYPH_SPACE_UNITS = 1000;
 
 // Accented characters have issues on Windows and Linux. When this flag is
 // enabled glyphs that use seac and seac style endchar operators are truncated
@@ -81,9 +81,9 @@ var PDF_GLYPH_SPACE_UNITS = 1000;
 // Linux (freetype) requires that when a seac style endchar is used
 // that the charset must be a predefined one, however we build a
 // custom one. Windows just refuses to draw glyphs with seac operators.
-var SEAC_ANALYSIS_ENABLED = true;
+const SEAC_ANALYSIS_ENABLED = true;
 
-var FontFlags = {
+const FontFlags = {
   FixedPitch: 1,
   Serif: 2,
   Symbolic: 4,
@@ -96,7 +96,7 @@ var FontFlags = {
 };
 
 // prettier-ignore
-var MacStandardGlyphOrdering = [
+const MacStandardGlyphOrdering = [
   ".notdef", ".null", "nonmarkingreturn", "space", "exclam", "quotedbl",
   "numbersign", "dollar", "percent", "ampersand", "quotesingle", "parenleft",
   "parenright", "asterisk", "plus", "comma", "hyphen", "period", "slash",
@@ -142,9 +142,9 @@ function adjustWidths(properties) {
     return;
   }
   // adjusting width to fontMatrix scale
-  var scale = 0.001 / properties.fontMatrix[0];
-  var glyphsWidths = properties.widths;
-  for (var glyph in glyphsWidths) {
+  const scale = 0.001 / properties.fontMatrix[0];
+  const glyphsWidths = properties.widths;
+  for (const glyph in glyphsWidths) {
     glyphsWidths[glyph] *= scale;
   }
   properties.defaultWidth *= scale;
@@ -163,11 +163,11 @@ function adjustToUnicode(properties, builtInEncoding) {
   if (properties.toUnicode instanceof IdentityToUnicodeMap) {
     return;
   }
-  var toUnicode = [],
+  const toUnicode = [],
     glyphsUnicodeMap = getGlyphsUnicode();
-  for (var charCode in builtInEncoding) {
-    var glyphName = builtInEncoding[charCode];
-    var unicode = getUnicodeForGlyph(glyphName, glyphsUnicodeMap);
+  for (const charCode in builtInEncoding) {
+    const glyphName = builtInEncoding[charCode];
+    const unicode = getUnicodeForGlyph(glyphName, glyphsUnicodeMap);
     if (unicode !== -1) {
       toUnicode[charCode] = String.fromCharCode(unicode);
     }
@@ -205,9 +205,9 @@ function recoverGlyphName(name, glyphsUnicodeMap) {
     return name;
   }
   // The glyph name is non-standard, trying to recover.
-  var unicode = getUnicodeForGlyph(name, glyphsUnicodeMap);
+  const unicode = getUnicodeForGlyph(name, glyphsUnicodeMap);
   if (unicode !== -1) {
-    for (var key in glyphsUnicodeMap) {
+    for (const key in glyphsUnicodeMap) {
       if (glyphsUnicodeMap[key] === unicode) {
         return key;
       }
@@ -217,7 +217,7 @@ function recoverGlyphName(name, glyphsUnicodeMap) {
   return name;
 }
 
-var Glyph = (function GlyphClosure() {
+const Glyph = (function GlyphClosure() {
   function Glyph(
     fontChar,
     unicode,
@@ -263,7 +263,7 @@ var Glyph = (function GlyphClosure() {
   return Glyph;
 })();
 
-var ToUnicodeMap = (function ToUnicodeMapClosure() {
+const ToUnicodeMap = (function ToUnicodeMapClosure() {
   function ToUnicodeMap(cmap = []) {
     // The elements of this._map can be integers or strings, depending on how
     // `cmap` was created.
@@ -276,7 +276,7 @@ var ToUnicodeMap = (function ToUnicodeMapClosure() {
     },
 
     forEach(callback) {
-      for (var charCode in this._map) {
+      for (const charCode in this._map) {
         callback(charCode, this._map[charCode].charCodeAt(0));
       }
     },
@@ -305,7 +305,7 @@ var ToUnicodeMap = (function ToUnicodeMapClosure() {
     },
 
     amend(map) {
-      for (var charCode in map) {
+      for (const charCode in map) {
         this._map[charCode] = map[charCode];
       }
     },
@@ -326,7 +326,7 @@ var IdentityToUnicodeMap = (function IdentityToUnicodeMapClosure() {
     },
 
     forEach(callback) {
-      for (var i = this.firstChar, ii = this.lastChar; i <= ii; i++) {
+      for (let i = this.firstChar, ii = this.lastChar; i <= ii; i++) {
         callback(i, i);
       }
     },
@@ -356,7 +356,7 @@ var IdentityToUnicodeMap = (function IdentityToUnicodeMapClosure() {
   return IdentityToUnicodeMap;
 })();
 
-var OpenTypeFileBuilder = (function OpenTypeFileBuilderClosure() {
+const OpenTypeFileBuilder = (function OpenTypeFileBuilderClosure() {
   function writeInt16(dest, offset, num) {
     dest[offset] = (num >> 8) & 0xff;
     dest[offset + 1] = num & 0xff;
@@ -370,7 +370,7 @@ var OpenTypeFileBuilder = (function OpenTypeFileBuilderClosure() {
   }
 
   function writeData(dest, offset, data) {
-    var i, ii;
+    let i, ii;
     if (data instanceof Uint8Array) {
       dest.set(data, offset);
     } else if (typeof data === "string") {
@@ -394,13 +394,13 @@ var OpenTypeFileBuilder = (function OpenTypeFileBuilderClosure() {
     entriesCount,
     entrySize
   ) {
-    var maxPower2 = 1,
+    let maxPower2 = 1,
       log2 = 0;
     while ((maxPower2 ^ entriesCount) > maxPower2) {
       maxPower2 <<= 1;
       log2++;
     }
-    var searchRange = maxPower2 * entrySize;
+    const searchRange = maxPower2 * entrySize;
     return {
       range: searchRange,
       entry: log2,
@@ -408,31 +408,31 @@ var OpenTypeFileBuilder = (function OpenTypeFileBuilderClosure() {
     };
   };
 
-  var OTF_HEADER_SIZE = 12;
-  var OTF_TABLE_ENTRY_SIZE = 16;
+  const OTF_HEADER_SIZE = 12;
+  const OTF_TABLE_ENTRY_SIZE = 16;
 
   OpenTypeFileBuilder.prototype = {
     toArray: function OpenTypeFileBuilder_toArray() {
-      var sfnt = this.sfnt;
+      let sfnt = this.sfnt;
 
       // Tables needs to be written by ascendant alphabetic order
-      var tables = this.tables;
-      var tablesNames = Object.keys(tables);
+      const tables = this.tables;
+      const tablesNames = Object.keys(tables);
       tablesNames.sort();
-      var numTables = tablesNames.length;
+      const numTables = tablesNames.length;
 
-      var i, j, jj, table, tableName;
+      let i, j, jj, table, tableName;
       // layout the tables data
-      var offset = OTF_HEADER_SIZE + numTables * OTF_TABLE_ENTRY_SIZE;
-      var tableOffsets = [offset];
+      let offset = OTF_HEADER_SIZE + numTables * OTF_TABLE_ENTRY_SIZE;
+      const tableOffsets = [offset];
       for (i = 0; i < numTables; i++) {
         table = tables[tablesNames[i]];
-        var paddedLength = ((table.length + 3) & ~3) >>> 0;
+        const paddedLength = ((table.length + 3) & ~3) >>> 0;
         offset += paddedLength;
         tableOffsets.push(offset);
       }
 
-      var file = new Uint8Array(offset);
+      const file = new Uint8Array(offset);
       // write the table data first (mostly for checksum)
       for (i = 0; i < numTables; i++) {
         table = tables[tablesNames[i]];
@@ -452,7 +452,7 @@ var OpenTypeFileBuilder = (function OpenTypeFileBuilderClosure() {
       // numTables (2 bytes)
       writeInt16(file, 4, numTables);
 
-      var searchParams = OpenTypeFileBuilder.getSearchParams(numTables, 16);
+      const searchParams = OpenTypeFileBuilder.getSearchParams(numTables, 16);
 
       // searchRange (2 bytes)
       writeInt16(file, 6, searchParams.range);
@@ -471,9 +471,9 @@ var OpenTypeFileBuilder = (function OpenTypeFileBuilderClosure() {
         file[offset + 3] = tableName.charCodeAt(3) & 0xff;
 
         // checksum
-        var checksum = 0;
+        let checksum = 0;
         for (j = tableOffsets[i], jj = tableOffsets[i + 1]; j < jj; j += 4) {
-          var quad = readUint32(file, j);
+          const quad = readUint32(file, j);
           checksum = (checksum + quad) >>> 0;
         }
         writeInt32(file, offset + 4, checksum);
@@ -507,9 +507,9 @@ var OpenTypeFileBuilder = (function OpenTypeFileBuilderClosure() {
  *   var type1Font = new Font("MyFontName", binaryFile, propertiesObject);
  *   type1Font.bind();
  */
-var Font = (function FontClosure() {
+const Font = (function FontClosure() {
   function Font(name, file, properties) {
-    var charCode;
+    let charCode;
 
     this.name = name;
     this.loadedName = properties.loadedName;
@@ -523,8 +523,8 @@ var Font = (function FontClosure() {
     this.isSymbolicFont = !!(properties.flags & FontFlags.Symbolic);
     this.isMonospace = !!(properties.flags & FontFlags.FixedPitch);
 
-    var type = properties.type;
-    var subtype = properties.subtype;
+    let type = properties.type;
+    let subtype = properties.subtype;
     this.type = type;
     this.subtype = subtype;
 
@@ -649,7 +649,7 @@ var Font = (function FontClosure() {
   }
 
   Font.getFontID = (function() {
-    var ID = 1;
+    let ID = 1;
     return function Font_getFontID() {
       return String(ID++);
     };
@@ -665,7 +665,7 @@ var Font = (function FontClosure() {
   }
 
   function signedInt16(b0, b1) {
-    var value = (b0 << 8) + b1;
+    const value = (b0 << 8) + b1;
     return value & (1 << 15) ? value - 0x10000 : value;
   }
 
@@ -688,7 +688,7 @@ var Font = (function FontClosure() {
   }
 
   function isTrueTypeFile(file) {
-    var header = file.peekBytes(4);
+    const header = file.peekBytes(4);
     return (
       readUint32(header, 0) === 0x00010000 || bytesToString(header) === "true"
     );
@@ -700,12 +700,12 @@ var Font = (function FontClosure() {
   }
 
   function isOpenTypeFile(file) {
-    var header = file.peekBytes(4);
+    const header = file.peekBytes(4);
     return bytesToString(header) === "OTTO";
   }
 
   function isType1File(file) {
-    var header = file.peekBytes(2);
+    const header = file.peekBytes(2);
     // All Type1 font programs must begin with the comment '%!' (0x25 + 0x21).
     if (header[0] === 0x25 && header[1] === 0x21) {
       return true;
@@ -776,15 +776,15 @@ var Font = (function FontClosure() {
   }
 
   function buildToFontChar(encoding, glyphsUnicodeMap, differences) {
-    var toFontChar = [],
+    let toFontChar = [],
       unicode;
-    for (var i = 0, ii = encoding.length; i < ii; i++) {
+    for (let i = 0, ii = encoding.length; i < ii; i++) {
       unicode = getUnicodeForGlyph(encoding[i], glyphsUnicodeMap);
       if (unicode !== -1) {
         toFontChar[i] = unicode;
       }
     }
-    for (var charCode in differences) {
+    for (const charCode in differences) {
       unicode = getUnicodeForGlyph(differences[charCode], glyphsUnicodeMap);
       if (unicode !== -1) {
         toFontChar[+charCode] = unicode;
@@ -805,14 +805,14 @@ var Font = (function FontClosure() {
    * 'charCodeToGlyphId' - maps the new font char codes to glyph ids
    */
   function adjustMapping(charCodeToGlyphId, hasGlyph, newGlyphZeroId) {
-    var newMap = Object.create(null);
-    var toFontChar = [];
-    var privateUseAreaIndex = 0;
-    var nextAvailableFontCharCode = PRIVATE_USE_AREAS[privateUseAreaIndex][0];
-    var privateUseOffetEnd = PRIVATE_USE_AREAS[privateUseAreaIndex][1];
-    for (var originalCharCode in charCodeToGlyphId) {
+    const newMap = Object.create(null);
+    const toFontChar = [];
+    let privateUseAreaIndex = 0;
+    let nextAvailableFontCharCode = PRIVATE_USE_AREAS[privateUseAreaIndex][0];
+    let privateUseOffetEnd = PRIVATE_USE_AREAS[privateUseAreaIndex][1];
+    for (let originalCharCode in charCodeToGlyphId) {
       originalCharCode |= 0;
-      var glyphId = charCodeToGlyphId[originalCharCode];
+      let glyphId = charCodeToGlyphId[originalCharCode];
       // For missing glyphs don't create the mappings so the glyph isn't
       // drawn.
       if (!hasGlyph(glyphId)) {
@@ -827,7 +827,7 @@ var Font = (function FontClosure() {
         nextAvailableFontCharCode = PRIVATE_USE_AREAS[privateUseAreaIndex][0];
         privateUseOffetEnd = PRIVATE_USE_AREAS[privateUseAreaIndex][1];
       }
-      var fontCharCode = nextAvailableFontCharCode++;
+      const fontCharCode = nextAvailableFontCharCode++;
       if (glyphId === 0) {
         glyphId = newGlyphZeroId;
       }
@@ -845,8 +845,8 @@ var Font = (function FontClosure() {
   function getRanges(glyphs, numGlyphs) {
     // Array.sort() sorts by characters, not numerically, so convert to an
     // array of characters.
-    var codes = [];
-    for (var charCode in glyphs) {
+    const codes = [];
+    for (const charCode in glyphs) {
       // Remove an invalid glyph ID mappings to make OTS happy.
       if (glyphs[charCode] >= numGlyphs) {
         continue;
@@ -863,13 +863,13 @@ var Font = (function FontClosure() {
     });
 
     // Split the sorted codes into ranges.
-    var ranges = [];
-    var length = codes.length;
-    for (var n = 0; n < length; ) {
-      var start = codes[n].fontCharCode;
-      var codeIndices = [codes[n].glyphId];
+    const ranges = [];
+    const length = codes.length;
+    for (let n = 0; n < length; ) {
+      const start = codes[n].fontCharCode;
+      const codeIndices = [codes[n].glyphId];
       ++n;
-      var end = start;
+      let end = start;
       while (n < length && end + 1 === codes[n].fontCharCode) {
         codeIndices.push(codes[n].glyphId);
         ++end;
@@ -885,39 +885,39 @@ var Font = (function FontClosure() {
   }
 
   function createCmapTable(glyphs, numGlyphs) {
-    var ranges = getRanges(glyphs, numGlyphs);
-    var numTables = ranges[ranges.length - 1][1] > 0xffff ? 2 : 1;
-    var cmap =
+    const ranges = getRanges(glyphs, numGlyphs);
+    const numTables = ranges[ranges.length - 1][1] > 0xffff ? 2 : 1;
+    let cmap =
       "\x00\x00" + // version
       string16(numTables) + // numTables
       "\x00\x03" + // platformID
       "\x00\x01" + // encodingID
       string32(4 + numTables * 8); // start of the table record
 
-    var i, ii, j, jj;
+    let i, ii, j, jj;
     for (i = ranges.length - 1; i >= 0; --i) {
       if (ranges[i][0] <= 0xffff) {
         break;
       }
     }
-    var bmpLength = i + 1;
+    const bmpLength = i + 1;
 
     if (ranges[i][0] < 0xffff && ranges[i][1] === 0xffff) {
       ranges[i][1] = 0xfffe;
     }
-    var trailingRangesCount = ranges[i][1] < 0xffff ? 1 : 0;
-    var segCount = bmpLength + trailingRangesCount;
-    var searchParams = OpenTypeFileBuilder.getSearchParams(segCount, 2);
+    const trailingRangesCount = ranges[i][1] < 0xffff ? 1 : 0;
+    const segCount = bmpLength + trailingRangesCount;
+    const searchParams = OpenTypeFileBuilder.getSearchParams(segCount, 2);
 
     // Fill up the 4 parallel arrays describing the segments.
-    var startCount = "";
-    var endCount = "";
-    var idDeltas = "";
-    var idRangeOffsets = "";
-    var glyphsIds = "";
-    var bias = 0;
+    let startCount = "";
+    let endCount = "";
+    let idDeltas = "";
+    let idRangeOffsets = "";
+    let glyphsIds = "";
+    let bias = 0;
 
-    var range, start, end, codes;
+    let range, start, end, codes;
     for (i = 0, ii = bmpLength; i < ii; i++) {
       range = ranges[i];
       start = range[0];
@@ -925,7 +925,7 @@ var Font = (function FontClosure() {
       startCount += string16(start);
       endCount += string16(end);
       codes = range[2];
-      var contiguous = true;
+      let contiguous = true;
       for (j = 1, jj = codes.length; j < jj; ++j) {
         if (codes[j] !== codes[j - 1] + 1) {
           contiguous = false;
@@ -933,7 +933,7 @@ var Font = (function FontClosure() {
         }
       }
       if (!contiguous) {
-        var offset = (segCount - i) * 2 + bias * 2;
+        const offset = (segCount - i) * 2 + bias * 2;
         bias += end - start + 1;
 
         idDeltas += string16(0);
@@ -943,7 +943,7 @@ var Font = (function FontClosure() {
           glyphsIds += string16(codes[j]);
         }
       } else {
-        var startCode = codes[0];
+        const startCode = codes[0];
 
         idDeltas += string16((startCode - start) & 0xffff);
         idRangeOffsets += string16(0);
@@ -957,7 +957,7 @@ var Font = (function FontClosure() {
       idRangeOffsets += "\x00\x00";
     }
 
-    var format314 =
+    const format314 =
       "\x00\x00" + // language
       string16(2 * segCount) +
       string16(searchParams.range) +
@@ -970,8 +970,8 @@ var Font = (function FontClosure() {
       idRangeOffsets +
       glyphsIds;
 
-    var format31012 = "";
-    var header31012 = "";
+    let format31012 = "";
+    let header31012 = "";
     if (numTables > 1) {
       cmap +=
         "\x00\x03" + // platformID
@@ -982,7 +982,7 @@ var Font = (function FontClosure() {
         range = ranges[i];
         start = range[0];
         codes = range[2];
-        var code = codes[0];
+        let code = codes[0];
         for (j = 1, jj = codes.length; j < jj; ++j) {
           if (codes[j] !== codes[j - 1] + 1) {
             end = range[0] + j - 1;
@@ -1018,22 +1018,22 @@ var Font = (function FontClosure() {
   }
 
   function validateOS2Table(os2) {
-    var stream = new Stream(os2.data);
-    var version = stream.getUint16();
+    const stream = new Stream(os2.data);
+    const version = stream.getUint16();
     // TODO verify all OS/2 tables fields, but currently we validate only those
     // that give us issues
     stream.getBytes(60); // skipping type, misc sizes, panose, unicode ranges
-    var selection = stream.getUint16();
+    const selection = stream.getUint16();
     if (version < 4 && selection & 0x0300) {
       return false;
     }
-    var firstChar = stream.getUint16();
-    var lastChar = stream.getUint16();
+    const firstChar = stream.getUint16();
+    const lastChar = stream.getUint16();
     if (firstChar > lastChar) {
       return false;
     }
     stream.getBytes(6); // skipping sTypoAscender/Descender/LineGap
-    var usWinAscent = stream.getUint16();
+    const usWinAscent = stream.getUint16();
     if (usWinAscent === 0) {
       // makes font unreadable by windows
       return false;
@@ -1053,16 +1053,16 @@ var Font = (function FontClosure() {
       descent: 0,
     };
 
-    var ulUnicodeRange1 = 0;
-    var ulUnicodeRange2 = 0;
-    var ulUnicodeRange3 = 0;
-    var ulUnicodeRange4 = 0;
+    let ulUnicodeRange1 = 0;
+    let ulUnicodeRange2 = 0;
+    let ulUnicodeRange3 = 0;
+    let ulUnicodeRange4 = 0;
 
-    var firstCharIndex = null;
-    var lastCharIndex = 0;
+    let firstCharIndex = null;
+    let lastCharIndex = 0;
 
     if (charstrings) {
-      for (var code in charstrings) {
+      for (let code in charstrings) {
         code |= 0;
         if (firstCharIndex > code || !firstCharIndex) {
           firstCharIndex = code;
@@ -1071,7 +1071,7 @@ var Font = (function FontClosure() {
           lastCharIndex = code;
         }
 
-        var position = getUnicodeRangeFor(code);
+        const position = getUnicodeRangeFor(code);
         if (position < 32) {
           ulUnicodeRange1 |= 1 << position;
         } else if (position < 64) {
@@ -1097,26 +1097,26 @@ var Font = (function FontClosure() {
       lastCharIndex = 255;
     }
 
-    var bbox = properties.bbox || [0, 0, 0, 0];
-    var unitsPerEm =
+    const bbox = properties.bbox || [0, 0, 0, 0];
+    const unitsPerEm =
       override.unitsPerEm ||
       1 / (properties.fontMatrix || FONT_IDENTITY_MATRIX)[0];
 
     // if the font units differ to the PDF glyph space units
     // then scale up the values
-    var scale = properties.ascentScaled
+    const scale = properties.ascentScaled
       ? 1.0
       : unitsPerEm / PDF_GLYPH_SPACE_UNITS;
 
-    var typoAscent =
+    const typoAscent =
       override.ascent || Math.round(scale * (properties.ascent || bbox[3]));
-    var typoDescent =
+    let typoDescent =
       override.descent || Math.round(scale * (properties.descent || bbox[1]));
     if (typoDescent > 0 && properties.descent > 0 && bbox[1] < 0) {
       typoDescent = -typoDescent; // fixing incorrect descent
     }
-    var winAscent = override.yMax || typoAscent;
-    var winDescent = -override.yMin || -typoDescent;
+    const winAscent = override.yMax || typoAscent;
+    const winDescent = -override.yMin || -typoDescent;
 
     return (
       "\x00\x03" + // version
@@ -1162,7 +1162,7 @@ var Font = (function FontClosure() {
   }
 
   function createPostTable(properties) {
-    var angle = Math.floor(properties.italicAngle * Math.pow(2, 16));
+    const angle = Math.floor(properties.italicAngle * Math.pow(2, 16));
     return (
       "\x00\x03\x00\x00" + // Version number
       string32(angle) + // italicAngle
@@ -1181,7 +1181,7 @@ var Font = (function FontClosure() {
       proto = [[], []]; // no strings and unicode strings
     }
 
-    var strings = [
+    const strings = [
       proto[0][0] || "Original licence", // 0.Copyright
       proto[0][1] || name, // 1.Font family
       proto[0][2] || "Unknown", // 2.Font subfamily (font weight)
@@ -1196,36 +1196,36 @@ var Font = (function FontClosure() {
 
     // Mac want 1-byte per character strings while Windows want
     // 2-bytes per character, so duplicate the names table
-    var stringsUnicode = [];
-    var i, ii, j, jj, str;
+    const stringsUnicode = [];
+    let i, ii, j, jj, str;
     for (i = 0, ii = strings.length; i < ii; i++) {
       str = proto[1][i] || strings[i];
 
-      var strBufUnicode = [];
+      const strBufUnicode = [];
       for (j = 0, jj = str.length; j < jj; j++) {
         strBufUnicode.push(string16(str.charCodeAt(j)));
       }
       stringsUnicode.push(strBufUnicode.join(""));
     }
 
-    var names = [strings, stringsUnicode];
-    var platforms = ["\x00\x01", "\x00\x03"];
-    var encodings = ["\x00\x00", "\x00\x01"];
-    var languages = ["\x00\x00", "\x04\x09"];
+    const names = [strings, stringsUnicode];
+    const platforms = ["\x00\x01", "\x00\x03"];
+    const encodings = ["\x00\x00", "\x00\x01"];
+    const languages = ["\x00\x00", "\x04\x09"];
 
-    var namesRecordCount = strings.length * platforms.length;
-    var nameTable =
+    const namesRecordCount = strings.length * platforms.length;
+    let nameTable =
       "\x00\x00" + // format
       string16(namesRecordCount) + // Number of names Record
       string16(namesRecordCount * 12 + 6); // Storage
 
     // Build the name records field
-    var strOffset = 0;
+    let strOffset = 0;
     for (i = 0, ii = platforms.length; i < ii; i++) {
-      var strs = names[i];
+      const strs = names[i];
       for (j = 0, jj = strs.length; j < jj; j++) {
         str = strs[j];
-        var nameRecord =
+        const nameRecord =
           platforms[i] + // platform ID
           encodings[i] + // encoding ID
           languages[i] + // language ID
@@ -1249,14 +1249,14 @@ var Font = (function FontClosure() {
     disableFontFace: false,
 
     get renderer() {
-      var renderer = FontRendererFactory.create(this, SEAC_ANALYSIS_ENABLED);
+      const renderer = FontRendererFactory.create(this, SEAC_ANALYSIS_ENABLED);
       return shadow(this, "renderer", renderer);
     },
 
     exportData: function Font_exportData() {
       // TODO remove enumerating of the properties, e.g. hardcode exact names.
-      var data = {};
-      for (var i in this) {
+      const data = {};
+      for (const i in this) {
         if (this.hasOwnProperty(i)) {
           data[i] = this[i];
         }
@@ -1266,16 +1266,16 @@ var Font = (function FontClosure() {
 
     fallbackToSystemFont: function Font_fallbackToSystemFont() {
       this.missingFile = true;
-      var charCode, unicode;
+      let charCode, unicode;
       // The file data is not specified. Trying to fix the font name
       // to be used with the canvas.font.
-      var name = this.name;
-      var type = this.type;
-      var subtype = this.subtype;
+      const name = this.name;
+      const type = this.type;
+      const subtype = this.subtype;
       let fontName = name.replace(/[,_]/g, "-").replace(/\s/g, "");
-      var stdFontMap = getStdFontMap(),
+      const stdFontMap = getStdFontMap(),
         nonStdFontMap = getNonStdFontMap();
-      var isStandardFont =
+      const isStandardFont =
         !!stdFontMap[fontName] ||
         !!(nonStdFontMap[fontName] && stdFontMap[nonStdFontMap[fontName]]);
       fontName = stdFontMap[fontName] || nonStdFontMap[fontName] || fontName;
@@ -1304,7 +1304,7 @@ var Font = (function FontClosure() {
           map[+charCode] = GlyphMapForStandardFonts[charCode];
         }
         if (/Arial-?Black/i.test(name)) {
-          var SupplementalGlyphMapForArialBlack = getSupplementalGlyphMapForArialBlack();
+          const SupplementalGlyphMapForArialBlack = getSupplementalGlyphMapForArialBlack();
           for (charCode in SupplementalGlyphMapForArialBlack) {
             map[+charCode] = SupplementalGlyphMapForArialBlack[charCode];
           }
@@ -1315,7 +1315,8 @@ var Font = (function FontClosure() {
           }
         }
 
-        var isIdentityUnicode = this.toUnicode instanceof IdentityToUnicodeMap;
+        const isIdentityUnicode =
+          this.toUnicode instanceof IdentityToUnicodeMap;
         if (!isIdentityUnicode) {
           this.toUnicode.forEach(function(charCode, unicodeCharCode) {
             map[+charCode] = unicodeCharCode;
@@ -1349,7 +1350,7 @@ var Font = (function FontClosure() {
         const map = [];
         this.toUnicode.forEach((charCode, unicodeCharCode) => {
           if (!this.composite) {
-            var glyphName =
+            const glyphName =
               this.differences[charCode] || this.defaultEncoding[charCode];
             unicode = getUnicodeForGlyph(glyphName, glyphsUnicodeMap);
             if (unicode !== -1) {
@@ -1419,17 +1420,17 @@ var Font = (function FontClosure() {
       }
 
       function readTableEntry(file) {
-        var tag = bytesToString(file.getBytes(4));
+        const tag = bytesToString(file.getBytes(4));
 
-        var checksum = file.getInt32() >>> 0;
-        var offset = file.getInt32() >>> 0;
-        var length = file.getInt32() >>> 0;
+        const checksum = file.getInt32() >>> 0;
+        const offset = file.getInt32() >>> 0;
+        const length = file.getInt32() >>> 0;
 
         // Read the table associated data
-        var previousPosition = file.pos;
+        const previousPosition = file.pos;
         file.pos = file.start ? file.start : 0;
         file.skip(offset);
-        var data = file.getBytes(length);
+        const data = file.getBytes(length);
         file.pos = previousPosition;
 
         if (tag === "head") {
@@ -1536,15 +1537,15 @@ var Font = (function FontClosure() {
             hasShortCmap: false,
           };
         }
-        var segment;
-        var start = (font.start ? font.start : 0) + cmap.offset;
+        let segment;
+        let start = (font.start ? font.start : 0) + cmap.offset;
         font.pos = start;
 
         font.getUint16(); // version
-        var numTables = font.getUint16();
+        const numTables = font.getUint16();
 
-        var potentialTable;
-        var canBreak = false;
+        let potentialTable;
+        let canBreak = false;
         // There's an order of preference in terms of which cmap subtable to
         // use:
         // - non-symbolic fonts the preference is a 3,1 table then a 1,0 table
@@ -1552,10 +1553,10 @@ var Font = (function FontClosure() {
         // The following takes advantage of the fact that the tables are sorted
         // to work.
         for (var i = 0; i < numTables; i++) {
-          var platformId = font.getUint16();
-          var encodingId = font.getUint16();
-          var offset = font.getInt32() >>> 0;
-          var useTable = false;
+          const platformId = font.getUint16();
+          const encodingId = font.getUint16();
+          const offset = font.getInt32() >>> 0;
+          let useTable = false;
 
           // Sometimes there are multiple of the same type of table. Default
           // to choosing the first table and skip the rest.
@@ -1614,18 +1615,18 @@ var Font = (function FontClosure() {
           };
         }
 
-        var format = font.getUint16();
+        const format = font.getUint16();
         font.getUint16(); // length
         font.getUint16(); // language
 
-        var hasShortCmap = false;
-        var mappings = [];
-        var j, glyphId;
+        let hasShortCmap = false;
+        const mappings = [];
+        let j, glyphId;
 
         // TODO(mack): refactor this cmap subtable reading logic out
         if (format === 0) {
           for (j = 0; j < 256; j++) {
-            var index = font.getByte();
+            const index = font.getByte();
             if (!index) {
               continue;
             }
@@ -1638,9 +1639,9 @@ var Font = (function FontClosure() {
         } else if (format === 4) {
           // re-creating the table in format 4 since the encoding
           // might be changed
-          var segCount = font.getUint16() >> 1;
+          const segCount = font.getUint16() >> 1;
           font.getBytes(6); // skipping range fields
-          var segIndex,
+          let segIndex,
             segments = [];
           for (segIndex = 0; segIndex < segCount; segIndex++) {
             segments.push({ end: font.getUint16() });
@@ -1654,10 +1655,10 @@ var Font = (function FontClosure() {
             segments[segIndex].delta = font.getUint16();
           }
 
-          var offsetsCount = 0;
+          let offsetsCount = 0;
           for (segIndex = 0; segIndex < segCount; segIndex++) {
             segment = segments[segIndex];
-            var rangeOffset = font.getUint16();
+            const rangeOffset = font.getUint16();
             if (!rangeOffset) {
               segment.offsetIndex = -1;
               continue;
@@ -1671,7 +1672,7 @@ var Font = (function FontClosure() {
             );
           }
 
-          var offsets = [];
+          const offsets = [];
           for (j = 0; j < offsetsCount; j++) {
             offsets.push(font.getUint16());
           }
@@ -1679,8 +1680,8 @@ var Font = (function FontClosure() {
           for (segIndex = 0; segIndex < segCount; segIndex++) {
             segment = segments[segIndex];
             start = segment.start;
-            var end = segment.end;
-            var delta = segment.delta;
+            const end = segment.end;
+            const delta = segment.delta;
             offsetIndex = segment.offsetIndex;
 
             for (j = start; j <= end; j++) {
@@ -1702,12 +1703,12 @@ var Font = (function FontClosure() {
           // table. (This looks weird, so I can have missed something), this
           // works on Linux but seems to fails on Mac so let's rewrite the
           // cmap table to a 3-1-4 style
-          var firstCode = font.getUint16();
-          var entryCount = font.getUint16();
+          const firstCode = font.getUint16();
+          const entryCount = font.getUint16();
 
           for (j = 0; j < entryCount; j++) {
             glyphId = font.getUint16();
-            var charCode = firstCode + j;
+            const charCode = firstCode + j;
 
             mappings.push({
               charCode,
@@ -1771,7 +1772,7 @@ var Font = (function FontClosure() {
         font.pos += 2; // caret_offset
         font.pos += 8; // reserved
         font.pos += 2; // format
-        var numOfMetrics = font.getUint16();
+        let numOfMetrics = font.getUint16();
 
         if (numOfMetrics > numGlyphs) {
           info(
@@ -1788,15 +1789,15 @@ var Font = (function FontClosure() {
           header.data[35] = numOfMetrics & 0x00ff;
         }
 
-        var numOfSidebearings = numGlyphs - numOfMetrics;
-        var numMissing =
+        const numOfSidebearings = numGlyphs - numOfMetrics;
+        const numMissing =
           numOfSidebearings - ((metrics.length - numOfMetrics * 4) >> 1);
 
         if (numMissing > 0) {
           // For each missing glyph, we set both the width and lsb to 0 (zero).
           // Since we need to add two properties for each glyph, this explains
           // the use of |numMissing * 2| when initializing the typed array.
-          var entries = new Uint8Array(metrics.length + numMissing * 2);
+          const entries = new Uint8Array(metrics.length + numMissing * 2);
           entries.set(metrics.data);
           if (dupFirstEntry) {
             // Set the sidebearing value of the duplicated glyph.
@@ -1815,7 +1816,7 @@ var Font = (function FontClosure() {
         destStart,
         hintsValid
       ) {
-        var glyphProfile = {
+        const glyphProfile = {
           length: 0,
           sizeOfInstructions: 0,
         };
@@ -1823,8 +1824,8 @@ var Font = (function FontClosure() {
           // glyph with data less than 12 is invalid one
           return glyphProfile;
         }
-        var glyf = source.subarray(sourceStart, sourceEnd);
-        var contoursCount = signedInt16(glyf[0], glyf[1]);
+        const glyf = source.subarray(sourceStart, sourceEnd);
+        let contoursCount = signedInt16(glyf[0], glyf[1]);
         if (contoursCount < 0) {
           // OTS doesn't like contour count to be less than -1.
           contoursCount = -1;
@@ -1835,24 +1836,24 @@ var Font = (function FontClosure() {
           return glyphProfile;
         }
 
-        var i,
+        let i,
           j = 10,
           flagsCount = 0;
         for (i = 0; i < contoursCount; i++) {
-          var endPoint = (glyf[j] << 8) | glyf[j + 1];
+          const endPoint = (glyf[j] << 8) | glyf[j + 1];
           flagsCount = endPoint + 1;
           j += 2;
         }
         // skipping instructions
-        var instructionsStart = j;
-        var instructionsLength = (glyf[j] << 8) | glyf[j + 1];
+        const instructionsStart = j;
+        const instructionsLength = (glyf[j] << 8) | glyf[j + 1];
         glyphProfile.sizeOfInstructions = instructionsLength;
         j += 2 + instructionsLength;
-        var instructionsEnd = j;
+        const instructionsEnd = j;
         // validating flags
-        var coordinatesLength = 0;
+        let coordinatesLength = 0;
         for (i = 0; i < flagsCount; i++) {
-          var flag = glyf[j++];
+          const flag = glyf[j++];
           if (flag & 0xc0) {
             // reserved flags must be zero, cleaning up
             glyf[j - 1] = flag & 0x3f;
@@ -1872,7 +1873,7 @@ var Font = (function FontClosure() {
           const xyLength = xLength + yLength;
           coordinatesLength += xyLength;
           if (flag & 8) {
-            var repeat = glyf[j++];
+            const repeat = glyf[j++];
             i += repeat;
             coordinatesLength += repeat * xyLength;
           }
@@ -1881,7 +1882,7 @@ var Font = (function FontClosure() {
         if (coordinatesLength === 0) {
           return glyphProfile;
         }
-        var glyphDataLength = j + coordinatesLength;
+        let glyphDataLength = j + coordinatesLength;
         if (glyphDataLength > glyf.length) {
           // not enough data for coordinates
           return glyphProfile;
@@ -1914,11 +1915,11 @@ var Font = (function FontClosure() {
       }
 
       function sanitizeHead(head, numGlyphs, locaLength) {
-        var data = head.data;
+        const data = head.data;
 
         // Validate version:
         // Should always be 0x00010000
-        var version = int32(data[0], data[1], data[2], data[3]);
+        const version = int32(data[0], data[1], data[2], data[3]);
         if (version >> 16 !== 1) {
           info("Attempting to fix invalid version in head table: " + version);
           data[0] = 0;
@@ -1927,7 +1928,7 @@ var Font = (function FontClosure() {
           data[3] = 0;
         }
 
-        var indexToLocFormat = int16(data[50], data[51]);
+        const indexToLocFormat = int16(data[50], data[51]);
         if (indexToLocFormat < 0 || indexToLocFormat > 1) {
           info(
             "Attempting to fix invalid indexToLocFormat in head table: " +
@@ -1944,7 +1945,7 @@ var Font = (function FontClosure() {
           // size of each offset in the loca table, and thus figure out the
           // appropriate value for indexToLocFormat.
 
-          var numGlyphsPlusOne = numGlyphs + 1;
+          const numGlyphsPlusOne = numGlyphs + 1;
           if (locaLength === numGlyphsPlusOne << 1) {
             // 0x0000 indicates the loca table consists of short offsets
             data[50] = 0;
@@ -1970,7 +1971,7 @@ var Font = (function FontClosure() {
         dupFirstEntry,
         maxSizeOfInstructions
       ) {
-        var itemSize, itemDecode, itemEncode;
+        let itemSize, itemDecode, itemEncode;
         if (isGlyphLocationsLong) {
           itemSize = 4;
           itemDecode = function fontItemDecodeLong(data, offset) {
@@ -1998,23 +1999,23 @@ var Font = (function FontClosure() {
           };
         }
         // The first glyph is duplicated.
-        var numGlyphsOut = dupFirstEntry ? numGlyphs + 1 : numGlyphs;
-        var locaDataSize = itemSize * (1 + numGlyphsOut);
+        const numGlyphsOut = dupFirstEntry ? numGlyphs + 1 : numGlyphs;
+        const locaDataSize = itemSize * (1 + numGlyphsOut);
         // Resize loca table to account for duplicated glyph.
-        var locaData = new Uint8Array(locaDataSize);
+        const locaData = new Uint8Array(locaDataSize);
         locaData.set(loca.data.subarray(0, locaDataSize));
         loca.data = locaData;
         // removing the invalid glyphs
-        var oldGlyfData = glyf.data;
-        var oldGlyfDataLength = oldGlyfData.length;
-        var newGlyfData = new Uint8Array(oldGlyfDataLength);
-        var startOffset = itemDecode(locaData, 0);
-        var writeOffset = 0;
-        var missingGlyphs = Object.create(null);
+        const oldGlyfData = glyf.data;
+        const oldGlyfDataLength = oldGlyfData.length;
+        const newGlyfData = new Uint8Array(oldGlyfDataLength);
+        let startOffset = itemDecode(locaData, 0);
+        let writeOffset = 0;
+        const missingGlyphs = Object.create(null);
         itemEncode(locaData, 0, writeOffset);
-        var i, j;
+        let i, j;
         for (i = 0, j = itemSize; i < numGlyphs; i++, j += itemSize) {
-          var endOffset = itemDecode(locaData, j);
+          let endOffset = itemDecode(locaData, j);
           // The spec says the offsets should be in ascending order, however
           // some fonts use the offset of 0 to mark a glyph as missing.
           if (endOffset === 0) {
@@ -2033,7 +2034,7 @@ var Font = (function FontClosure() {
             startOffset = endOffset;
           }
 
-          var glyphProfile = sanitizeGlyph(
+          const glyphProfile = sanitizeGlyph(
             oldGlyfData,
             startOffset,
             endOffset,
@@ -2041,7 +2042,7 @@ var Font = (function FontClosure() {
             writeOffset,
             hintsValid
           );
-          var newLength = glyphProfile.length;
+          const newLength = glyphProfile.length;
           if (newLength === 0) {
             missingGlyphs[i] = true;
           }
@@ -2056,7 +2057,7 @@ var Font = (function FontClosure() {
         if (writeOffset === 0) {
           // glyf table cannot be empty -- redoing the glyf and loca tables
           // to have single glyph with one point
-          var simpleGlyph = new Uint8Array([
+          const simpleGlyph = new Uint8Array([
             0,
             1,
             0,
@@ -2082,7 +2083,7 @@ var Font = (function FontClosure() {
           // Browsers will not display a glyph at position 0. Typically glyph 0
           // is notdef, but a number of fonts put a valid glyph there so it must
           // be duplicated and appended.
-          var firstEntryLength = itemDecode(locaData, itemSize);
+          const firstEntryLength = itemDecode(locaData, itemSize);
           if (newGlyfData.length > firstEntryLength + writeOffset) {
             glyf.data = newGlyfData.subarray(0, firstEntryLength + writeOffset);
           } else {
@@ -2105,18 +2106,18 @@ var Font = (function FontClosure() {
       }
 
       function readPostScriptTable(post, properties, maxpNumGlyphs) {
-        var start = (font.start ? font.start : 0) + post.offset;
+        const start = (font.start ? font.start : 0) + post.offset;
         font.pos = start;
 
-        var length = post.length,
+        const length = post.length,
           end = start + length;
-        var version = font.getInt32();
+        const version = font.getInt32();
         // skip rest to the tables
         font.getBytes(28);
 
-        var glyphNames;
-        var valid = true;
-        var i;
+        let glyphNames;
+        let valid = true;
+        let i;
 
         switch (version) {
           case 0x00010000:
@@ -2130,7 +2131,7 @@ var Font = (function FontClosure() {
             }
             var glyphNameIndexes = [];
             for (i = 0; i < numGlyphs; ++i) {
-              var index = font.getUint16();
+              const index = font.getUint16();
               if (index >= 32768) {
                 valid = false;
                 break;
@@ -2143,7 +2144,7 @@ var Font = (function FontClosure() {
             var customNames = [];
             var strBuf = [];
             while (font.pos < end) {
-              var stringLength = font.getByte();
+              const stringLength = font.getByte();
               strBuf.length = stringLength;
               for (i = 0; i < stringLength; ++i) {
                 strBuf[i] = String.fromCharCode(font.getByte());
@@ -2152,7 +2153,7 @@ var Font = (function FontClosure() {
             }
             glyphNames = [];
             for (i = 0; i < numGlyphs; ++i) {
-              var j = glyphNameIndexes[i];
+              const j = glyphNameIndexes[i];
               if (j < 258) {
                 glyphNames.push(MacStandardGlyphOrdering[j]);
                 continue;
@@ -2175,30 +2176,30 @@ var Font = (function FontClosure() {
       }
 
       function readNameTable(nameTable) {
-        var start = (font.start ? font.start : 0) + nameTable.offset;
+        const start = (font.start ? font.start : 0) + nameTable.offset;
         font.pos = start;
 
-        var names = [[], []];
-        var length = nameTable.length,
+        const names = [[], []];
+        const length = nameTable.length,
           end = start + length;
-        var format = font.getUint16();
-        var FORMAT_0_HEADER_LENGTH = 6;
+        const format = font.getUint16();
+        const FORMAT_0_HEADER_LENGTH = 6;
         if (format !== 0 || length < FORMAT_0_HEADER_LENGTH) {
           // unsupported name table format or table "too" small
           return names;
         }
-        var numRecords = font.getUint16();
-        var stringsStart = font.getUint16();
-        var records = [];
-        var NAME_RECORD_LENGTH = 12;
-        var i, ii;
+        const numRecords = font.getUint16();
+        const stringsStart = font.getUint16();
+        const records = [];
+        const NAME_RECORD_LENGTH = 12;
+        let i, ii;
 
         for (
           i = 0;
           i < numRecords && font.pos + NAME_RECORD_LENGTH <= end;
           i++
         ) {
-          var r = {
+          const r = {
             platform: font.getUint16(),
             encoding: font.getUint16(),
             language: font.getUint16(),
@@ -2215,20 +2216,20 @@ var Font = (function FontClosure() {
           }
         }
         for (i = 0, ii = records.length; i < ii; i++) {
-          var record = records[i];
+          const record = records[i];
           if (record.length <= 0) {
             continue; // Nothing to process, ignoring.
           }
-          var pos = start + stringsStart + record.offset;
+          const pos = start + stringsStart + record.offset;
           if (pos + record.length > end) {
             continue; // outside of name table, ignoring
           }
           font.pos = pos;
-          var nameIndex = record.name;
+          const nameIndex = record.name;
           if (record.encoding) {
             // unicode
-            var str = "";
-            for (var j = 0, jj = record.length; j < jj; j += 2) {
+            let str = "";
+            for (let j = 0, jj = record.length; j < jj; j += 2) {
               str += String.fromCharCode(font.getUint16());
             }
             names[1][nameIndex] = str;
@@ -2240,7 +2241,7 @@ var Font = (function FontClosure() {
       }
 
       // prettier-ignore
-      var TTOpsStackDeltas = [
+      const TTOpsStackDeltas = [
         0, 0, 0, 0, 0, 0, 0, 0, -2, -2, -2, -2, 0, 0, -2, -5,
         -1, -1, -1, -1, -1, -1, -1, -1, 0, 0, -1, 0, -1, -1, -1, -1,
         1, -1, -999, 0, 1, 0, -1, -2, 0, -1, -2, -1, -1, 0, -1, -1,
@@ -2253,8 +2254,8 @@ var Font = (function FontClosure() {
       // 0xC0-DF == -1 and 0xE0-FF == -2
 
       function sanitizeTTProgram(table, ttContext) {
-        var data = table.data;
-        var i = 0,
+        let data = table.data;
+        let i = 0,
           j,
           n,
           b,
@@ -2262,15 +2263,15 @@ var Font = (function FontClosure() {
           pc,
           lastEndf = 0,
           lastDeff = 0;
-        var stack = [];
-        var callstack = [];
-        var functionsCalled = [];
-        var tooComplexToFollowFunctions = ttContext.tooComplexToFollowFunctions;
-        var inFDEF = false,
+        const stack = [];
+        const callstack = [];
+        const functionsCalled = [];
+        let tooComplexToFollowFunctions = ttContext.tooComplexToFollowFunctions;
+        let inFDEF = false,
           ifLevel = 0,
           inELSE = 0;
-        for (var ii = data.length; i < ii; ) {
-          var op = data[i++];
+        for (let ii = data.length; i < ii; ) {
+          const op = data[i++];
           // The TrueType instruction set docs can be found at
           // https://developer.apple.com/fonts/TTRefMan/RM05/Chap5.html
           if (op === 0x40) {
@@ -2403,7 +2404,7 @@ var Font = (function FontClosure() {
           } else if (op === 0x1c) {
             // JMPR
             if (!inFDEF && !inELSE) {
-              var offset = stack[stack.length - 1];
+              const offset = stack[stack.length - 1];
               // only jumping forward to prevent infinite loop
               if (offset > 0) {
                 i += offset - 1;
@@ -2437,7 +2438,7 @@ var Font = (function FontClosure() {
           }
         }
         ttContext.tooComplexToFollowFunctions = tooComplexToFollowFunctions;
-        var content = [data];
+        const content = [data];
         if (i > data.length) {
           content.push(new Uint8Array(i - data.length));
         }
@@ -2459,7 +2460,7 @@ var Font = (function FontClosure() {
           ttContext.hintsValid = false;
           return;
         }
-        for (var j = 0, jj = ttContext.functionsUsed.length; j < jj; j++) {
+        for (let j = 0, jj = ttContext.functionsUsed.length; j < jj; j++) {
           if (j > maxFunctionDefs) {
             warn("TT: invalid function id: " + j);
             ttContext.hintsValid = false;
@@ -2476,14 +2477,14 @@ var Font = (function FontClosure() {
       function foldTTTable(table, content) {
         if (content.length > 1) {
           // concatenating the content items
-          var newLength = 0;
-          var j, jj;
+          let newLength = 0;
+          let j, jj;
           for (j = 0, jj = content.length; j < jj; j++) {
             newLength += content[j].length;
           }
           newLength = (newLength + 3) & ~3;
-          var result = new Uint8Array(newLength);
-          var pos = 0;
+          const result = new Uint8Array(newLength);
+          let pos = 0;
           for (j = 0, jj = content.length; j < jj; j++) {
             result.set(content[j], pos);
             pos += content[j].length;
@@ -2494,7 +2495,7 @@ var Font = (function FontClosure() {
       }
 
       function sanitizeTTPrograms(fpgm, prep, cvt, maxFunctionDefs) {
-        var ttContext = {
+        const ttContext = {
           functionsDefined: [],
           functionsUsed: [],
           functionsStackDeltas: [],
@@ -2511,7 +2512,7 @@ var Font = (function FontClosure() {
           checkInvalidFunctions(ttContext, maxFunctionDefs);
         }
         if (cvt && cvt.length & 1) {
-          var cvtData = new Uint8Array(cvt.length + 1);
+          const cvtData = new Uint8Array(cvt.length + 1);
           cvtData.set(cvt.data);
           cvt.data = cvtData;
         }
@@ -2532,7 +2533,7 @@ var Font = (function FontClosure() {
       }
       let cff, cffFile;
 
-      var isTrueType = !tables["CFF "];
+      const isTrueType = !tables["CFF "];
       if (!isTrueType) {
         const isComposite =
           properties.composite &&
@@ -2581,7 +2582,7 @@ var Font = (function FontClosure() {
       }
 
       font.pos = (font.start || 0) + tables["maxp"].offset;
-      var version = font.getInt32();
+      const version = font.getInt32();
       const numGlyphs = font.getUint16();
       // Glyph 0 is duplicated and appended.
       let numGlyphsOut = numGlyphs + 1;
@@ -2591,12 +2592,12 @@ var Font = (function FontClosure() {
         numGlyphsOut = numGlyphs;
         warn("Not enough space in glyfs to duplicate first glyph.");
       }
-      var maxFunctionDefs = 0;
-      var maxSizeOfInstructions = 0;
+      let maxFunctionDefs = 0;
+      let maxSizeOfInstructions = 0;
       if (version >= 0x00010000 && tables["maxp"].length >= 22) {
         // maxZones can be invalid
         font.pos += 8;
-        var maxZones = font.getUint16();
+        const maxZones = font.getUint16();
         if (maxZones > 2) {
           // reset to 2 if font has invalid maxZones
           tables["maxp"].data[14] = 0;
@@ -2611,7 +2612,7 @@ var Font = (function FontClosure() {
       tables["maxp"].data[4] = numGlyphsOut >> 8;
       tables["maxp"].data[5] = numGlyphsOut & 255;
 
-      var hintsValid = sanitizeTTPrograms(
+      const hintsValid = sanitizeTTPrograms(
         tables["fpgm"],
         tables["prep"],
         tables["cvt "],
@@ -2643,13 +2644,13 @@ var Font = (function FontClosure() {
         isTrueType ? tables["loca"].length : 0
       );
 
-      var missingGlyphs = Object.create(null);
+      let missingGlyphs = Object.create(null);
       if (isTrueType) {
-        var isGlyphLocationsLong = int16(
+        const isGlyphLocationsLong = int16(
           tables["head"].data[50],
           tables["head"].data[51]
         );
-        var glyphsInfo = sanitizeGlyphLocations(
+        const glyphsInfo = sanitizeGlyphLocations(
           tables["loca"],
           tables["glyf"],
           numGlyphs,
@@ -2680,7 +2681,7 @@ var Font = (function FontClosure() {
 
       // Extract some more font properties from the OpenType head and
       // hhea tables; yMin and descent value are always negative.
-      var metricsOverride = {
+      const metricsOverride = {
         unitsPerEm: int16(tables["head"].data[18], tables["head"].data[19]),
         yMax: int16(tables["head"].data[42], tables["head"].data[43]),
         yMin: signedInt16(tables["head"].data[38], tables["head"].data[39]),
@@ -2703,7 +2704,7 @@ var Font = (function FontClosure() {
         data: createPostTable(properties),
       };
 
-      var charCodeToGlyphId = [],
+      let charCodeToGlyphId = [],
         charCode;
 
       // Helper function to try to skip mapping of empty glyphs.
@@ -2712,14 +2713,14 @@ var Font = (function FontClosure() {
       }
 
       if (properties.composite) {
-        var cidToGidMap = properties.cidToGidMap || [];
-        var isCidToGidMapEmpty = cidToGidMap.length === 0;
+        const cidToGidMap = properties.cidToGidMap || [];
+        const isCidToGidMapEmpty = cidToGidMap.length === 0;
 
         properties.cMap.forEach(function(charCode, cid) {
           if (cid > 0xffff) {
             throw new FormatError("Max size of CID is 65,535");
           }
-          var glyphId = -1;
+          let glyphId = -1;
           if (isCidToGidMapEmpty) {
             glyphId = cid;
           } else if (cidToGidMap[cid] !== undefined) {
@@ -2733,16 +2734,16 @@ var Font = (function FontClosure() {
       } else {
         // Most of the following logic in this code branch is based on the
         // 9.6.6.4 of the PDF spec.
-        var cmapTable = readCmapTable(
+        const cmapTable = readCmapTable(
           tables["cmap"],
           font,
           this.isSymbolicFont,
           properties.hasEncoding
         );
-        var cmapPlatformId = cmapTable.platformId;
-        var cmapEncodingId = cmapTable.encodingId;
-        var cmapMappings = cmapTable.mappings;
-        var cmapMappingsLength = cmapMappings.length;
+        const cmapPlatformId = cmapTable.platformId;
+        const cmapEncodingId = cmapTable.encodingId;
+        const cmapMappings = cmapTable.mappings;
+        const cmapMappingsLength = cmapMappings.length;
 
         // The spec seems to imply that if the font is symbolic the encoding
         // should be ignored, this doesn't appear to work for 'preistabelle.pdf'
@@ -2762,14 +2763,14 @@ var Font = (function FontClosure() {
           // TODO: Note that this is a hack which should be removed as soon as
           //       we have proper support for more exotic cmap tables.
 
-          var baseEncoding = [];
+          let baseEncoding = [];
           if (
             properties.baseEncodingName === "MacRomanEncoding" ||
             properties.baseEncodingName === "WinAnsiEncoding"
           ) {
             baseEncoding = getEncoding(properties.baseEncodingName);
           }
-          var glyphsUnicodeMap = getGlyphsUnicode();
+          const glyphsUnicodeMap = getGlyphsUnicode();
           for (charCode = 0; charCode < 256; charCode++) {
             var glyphName, standardGlyphName;
             if (this.differences && charCode in this.differences) {
@@ -2796,7 +2797,7 @@ var Font = (function FontClosure() {
               unicodeOrCharCode = MacRomanEncoding.indexOf(standardGlyphName);
             }
 
-            var found = false;
+            let found = false;
             for (let i = 0; i < cmapMappingsLength; ++i) {
               if (cmapMappings[i].charCode !== unicodeOrCharCode) {
                 continue;
@@ -2807,7 +2808,7 @@ var Font = (function FontClosure() {
             }
             if (!found && properties.glyphNames) {
               // Try to map using the post table.
-              var glyphId = properties.glyphNames.indexOf(glyphName);
+              let glyphId = properties.glyphNames.indexOf(glyphName);
               // The post table ought to use the same kind of glyph names as the
               // `differences` array, but check the standard ones as a fallback.
               if (glyphId === -1 && standardGlyphName !== glyphName) {
@@ -2865,7 +2866,11 @@ var Font = (function FontClosure() {
       }
 
       // Converting glyphs and ids into font's cmap table
-      var newMapping = adjustMapping(charCodeToGlyphId, hasGlyph, glyphZeroId);
+      const newMapping = adjustMapping(
+        charCodeToGlyphId,
+        hasGlyph,
+        glyphZeroId
+      );
       this.toFontChar = newMapping.toFontChar;
       tables["cmap"] = {
         tag: "cmap",
@@ -2887,14 +2892,14 @@ var Font = (function FontClosure() {
         try {
           // Trying to repair CFF file
           cffFile = new Stream(tables["CFF "].data);
-          var parser = new CFFParser(
+          const parser = new CFFParser(
             cffFile,
             properties,
             SEAC_ANALYSIS_ENABLED
           );
           cff = parser.parse();
           cff.duplicateFirstGlyph();
-          var compiler = new CFFCompiler(cff);
+          const compiler = new CFFCompiler(cff);
           tables["CFF "].data = compiler.compile();
         } catch (e) {
           warn("Failed to compile font " + properties.loadedName);
@@ -2909,12 +2914,12 @@ var Font = (function FontClosure() {
         };
       } else {
         // ... using existing 'name' table as prototype
-        var namePrototype = readNameTable(tables["name"]);
+        const namePrototype = readNameTable(tables["name"]);
         tables["name"].data = createNameTable(name, namePrototype);
       }
 
-      var builder = new OpenTypeFileBuilder(header.version);
-      for (var tableTag in tables) {
+      const builder = new OpenTypeFileBuilder(header.version);
+      for (const tableTag in tables) {
         builder.addTable(tableTag, tables[tableTag].data);
       }
       return builder.toArray();
@@ -2937,18 +2942,18 @@ var Font = (function FontClosure() {
       if (font instanceof CFFFont) {
         glyphZeroId = font.numGlyphs - 1;
       }
-      var mapping = font.getGlyphMapping(properties);
-      var newMapping = adjustMapping(
+      const mapping = font.getGlyphMapping(properties);
+      const newMapping = adjustMapping(
         mapping,
         font.hasGlyphId.bind(font),
         glyphZeroId
       );
       this.toFontChar = newMapping.toFontChar;
-      var numGlyphs = font.numGlyphs;
+      const numGlyphs = font.numGlyphs;
 
       function getCharCodes(charCodeToGlyphId, glyphId) {
-        var charCodes = null;
-        for (var charCode in charCodeToGlyphId) {
+        let charCodes = null;
+        for (const charCode in charCodeToGlyphId) {
           if (glyphId === charCodeToGlyphId[charCode]) {
             if (!charCodes) {
               charCodes = [];
@@ -2960,7 +2965,7 @@ var Font = (function FontClosure() {
       }
 
       function createCharCode(charCodeToGlyphId, glyphId) {
-        for (var charCode in charCodeToGlyphId) {
+        for (const charCode in charCodeToGlyphId) {
           if (glyphId === charCodeToGlyphId[charCode]) {
             return charCode | 0;
           }
@@ -2971,42 +2976,42 @@ var Font = (function FontClosure() {
         return newMapping.nextAvailableFontCharCode++;
       }
 
-      var seacs = font.seacs;
+      const seacs = font.seacs;
       if (SEAC_ANALYSIS_ENABLED && seacs && seacs.length) {
-        var matrix = properties.fontMatrix || FONT_IDENTITY_MATRIX;
-        var charset = font.getCharset();
-        var seacMap = Object.create(null);
-        for (var glyphId in seacs) {
+        const matrix = properties.fontMatrix || FONT_IDENTITY_MATRIX;
+        const charset = font.getCharset();
+        const seacMap = Object.create(null);
+        for (let glyphId in seacs) {
           glyphId |= 0;
-          var seac = seacs[glyphId];
-          var baseGlyphName = StandardEncoding[seac[2]];
-          var accentGlyphName = StandardEncoding[seac[3]];
-          var baseGlyphId = charset.indexOf(baseGlyphName);
-          var accentGlyphId = charset.indexOf(accentGlyphName);
+          const seac = seacs[glyphId];
+          const baseGlyphName = StandardEncoding[seac[2]];
+          const accentGlyphName = StandardEncoding[seac[3]];
+          const baseGlyphId = charset.indexOf(baseGlyphName);
+          const accentGlyphId = charset.indexOf(accentGlyphName);
           if (baseGlyphId < 0 || accentGlyphId < 0) {
             continue;
           }
-          var accentOffset = {
+          const accentOffset = {
             x: seac[0] * matrix[0] + seac[1] * matrix[2] + matrix[4],
             y: seac[0] * matrix[1] + seac[1] * matrix[3] + matrix[5],
           };
 
-          var charCodes = getCharCodes(mapping, glyphId);
+          const charCodes = getCharCodes(mapping, glyphId);
           if (!charCodes) {
             // There's no point in mapping it if the char code was never mapped
             // to begin with.
             continue;
           }
-          for (var i = 0, ii = charCodes.length; i < ii; i++) {
-            var charCode = charCodes[i];
+          for (let i = 0, ii = charCodes.length; i < ii; i++) {
+            const charCode = charCodes[i];
             // Find a fontCharCode that maps to the base and accent glyphs.
             // If one doesn't exists, create it.
-            var charCodeToGlyphId = newMapping.charCodeToGlyphId;
-            var baseFontCharCode = createCharCode(
+            const charCodeToGlyphId = newMapping.charCodeToGlyphId;
+            const baseFontCharCode = createCharCode(
               charCodeToGlyphId,
               baseGlyphId
             );
-            var accentFontCharCode = createCharCode(
+            const accentFontCharCode = createCharCode(
               charCodeToGlyphId,
               accentGlyphId
             );
@@ -3020,9 +3025,9 @@ var Font = (function FontClosure() {
         properties.seacMap = seacMap;
       }
 
-      var unitsPerEm = 1 / (properties.fontMatrix || FONT_IDENTITY_MATRIX)[0];
+      const unitsPerEm = 1 / (properties.fontMatrix || FONT_IDENTITY_MATRIX)[0];
 
-      var builder = new OpenTypeFileBuilder("\x4F\x54\x54\x4F");
+      const builder = new OpenTypeFileBuilder("\x4F\x54\x54\x4F");
       // PostScript Font Program
       builder.addTable("CFF ", font.data);
       // OS/2 and Windows Specific metrics
@@ -3083,13 +3088,13 @@ var Font = (function FontClosure() {
       builder.addTable(
         "hmtx",
         (function fontFieldsHmtx() {
-          var charstrings = font.charstrings;
-          var cffWidths = font.cff ? font.cff.widths : null;
-          var hmtx = "\x00\x00\x00\x00"; // Fake .notdef
-          for (var i = 1, ii = numGlyphs; i < ii; i++) {
-            var width = 0;
+          const charstrings = font.charstrings;
+          const cffWidths = font.cff ? font.cff.widths : null;
+          let hmtx = "\x00\x00\x00\x00"; // Fake .notdef
+          for (let i = 1, ii = numGlyphs; i < ii; i++) {
+            let width = 0;
             if (charstrings) {
-              var charstring = charstrings[i - 1];
+              const charstring = charstrings[i - 1];
               width = "width" in charstring ? charstring.width : 0;
             } else if (cffWidths) {
               width = Math.ceil(cffWidths[i] || 0);
@@ -3121,19 +3126,19 @@ var Font = (function FontClosure() {
       }
 
       // trying to estimate space character width
-      var possibleSpaceReplacements = ["space", "minus", "one", "i", "I"];
-      var width;
-      for (var i = 0, ii = possibleSpaceReplacements.length; i < ii; i++) {
-        var glyphName = possibleSpaceReplacements[i];
+      const possibleSpaceReplacements = ["space", "minus", "one", "i", "I"];
+      let width;
+      for (let i = 0, ii = possibleSpaceReplacements.length; i < ii; i++) {
+        const glyphName = possibleSpaceReplacements[i];
         // if possible, getting width by glyph name
         if (glyphName in this.widths) {
           width = this.widths[glyphName];
           break;
         }
-        var glyphsUnicodeMap = getGlyphsUnicode();
-        var glyphUnicode = glyphsUnicodeMap[glyphName];
+        const glyphsUnicodeMap = getGlyphsUnicode();
+        const glyphUnicode = glyphsUnicodeMap[glyphName];
         // finding the charcode via unicodeToCID map
-        var charcode = 0;
+        let charcode = 0;
         if (this.composite) {
           if (this.cMap.contains(glyphUnicode)) {
             charcode = this.cMap.lookup(glyphUnicode);
@@ -3161,15 +3166,15 @@ var Font = (function FontClosure() {
     },
 
     charToGlyph: function Font_charToGlyph(charcode, isSpace) {
-      var fontCharCode, width, operatorListId;
+      let fontCharCode, width, operatorListId;
 
-      var widthCode = charcode;
+      let widthCode = charcode;
       if (this.cMap && this.cMap.contains(charcode)) {
         widthCode = this.cMap.lookup(charcode);
       }
       width = this.widths[widthCode];
       width = isNum(width) ? width : this.defaultWidth;
-      var vmetric = this.vmetrics && this.vmetrics[widthCode];
+      const vmetric = this.vmetrics && this.vmetrics[widthCode];
 
       let unicode =
         this.toUnicode.get(charcode) ||
@@ -3179,7 +3184,7 @@ var Font = (function FontClosure() {
         unicode = String.fromCharCode(unicode);
       }
 
-      var isInFont = charcode in this.toFontChar;
+      let isInFont = charcode in this.toFontChar;
       // First try the toFontChar map, if it's not there then try falling
       // back to the char code.
       fontCharCode = this.toFontChar[charcode] || charcode;
@@ -3202,10 +3207,10 @@ var Font = (function FontClosure() {
         operatorListId = fontCharCode;
       }
 
-      var accent = null;
+      let accent = null;
       if (this.seacMap && this.seacMap[charcode]) {
         isInFont = true;
-        var seac = this.seacMap[charcode];
+        const seac = this.seacMap[charcode];
         fontCharCode = seac.baseFontCharCode;
         accent = {
           fontChar: String.fromCodePoint(seac.accentFontCharCode),
@@ -3213,12 +3218,12 @@ var Font = (function FontClosure() {
         };
       }
 
-      var fontChar =
+      const fontChar =
         typeof fontCharCode === "number"
           ? String.fromCodePoint(fontCharCode)
           : "";
 
-      var glyph = this.glyphCache[charcode];
+      let glyph = this.glyphCache[charcode];
       if (
         !glyph ||
         !glyph.matchesForCache(
@@ -3248,8 +3253,8 @@ var Font = (function FontClosure() {
     },
 
     charsToGlyphs: function Font_charsToGlyphs(chars) {
-      var charsCache = this.charsCache;
-      var glyphs, glyph, charcode;
+      let charsCache = this.charsCache;
+      let glyphs, glyph, charcode;
 
       // if we translated this string before, just grab it from the cache
       if (charsCache) {
@@ -3265,21 +3270,21 @@ var Font = (function FontClosure() {
       }
 
       glyphs = [];
-      var charsCacheKey = chars;
-      var i = 0,
+      const charsCacheKey = chars;
+      let i = 0,
         ii;
 
       if (this.cMap) {
         // composite fonts have multi-byte strings convert the string from
         // single-byte to multi-byte
-        var c = Object.create(null);
+        const c = Object.create(null);
         while (i < chars.length) {
           this.cMap.readCharCode(chars, i, c);
           charcode = c.charcode;
-          var length = c.length;
+          const length = c.length;
           i += length;
           // Space is char with code 0x20 and length 1 in multiple-byte codes.
-          var isSpace = length === 1 && chars.charCodeAt(i - 1) === 0x20;
+          const isSpace = length === 1 && chars.charCodeAt(i - 1) === 0x20;
           glyph = this.charToGlyph(charcode, isSpace);
           glyphs.push(glyph);
         }
@@ -3303,7 +3308,7 @@ var Font = (function FontClosure() {
   return Font;
 })();
 
-var ErrorFont = (function ErrorFontClosure() {
+const ErrorFont = (function ErrorFontClosure() {
   function ErrorFont(error) {
     this.error = error;
     this.loadedName = "g_font_error";
@@ -3333,9 +3338,9 @@ var ErrorFont = (function ErrorFontClosure() {
  * @returns {Object} A char code to glyph ID map.
  */
 function type1FontGlyphMapping(properties, builtInEncoding, glyphNames) {
-  var charCodeToGlyphId = Object.create(null);
-  var glyphId, charCode, baseEncoding;
-  var isSymbolicFont = !!(properties.flags & FontFlags.Symbolic);
+  const charCodeToGlyphId = Object.create(null);
+  let glyphId, charCode, baseEncoding;
+  const isSymbolicFont = !!(properties.flags & FontFlags.Symbolic);
 
   if (properties.baseEncodingName) {
     // If a valid base encoding name was used, the mapping is initialized with
@@ -3369,18 +3374,18 @@ function type1FontGlyphMapping(properties, builtInEncoding, glyphNames) {
   }
 
   // Lastly, merge in the differences.
-  var differences = properties.differences,
+  let differences = properties.differences,
     glyphsUnicodeMap;
   if (differences) {
     for (charCode in differences) {
-      var glyphName = differences[charCode];
+      const glyphName = differences[charCode];
       glyphId = glyphNames.indexOf(glyphName);
 
       if (glyphId === -1) {
         if (!glyphsUnicodeMap) {
           glyphsUnicodeMap = getGlyphsUnicode();
         }
-        var standardGlyphName = recoverGlyphName(glyphName, glyphsUnicodeMap);
+        const standardGlyphName = recoverGlyphName(glyphName, glyphsUnicodeMap);
         if (standardGlyphName !== glyphName) {
           glyphId = glyphNames.indexOf(standardGlyphName);
         }
@@ -3398,11 +3403,11 @@ function type1FontGlyphMapping(properties, builtInEncoding, glyphNames) {
 // Type1Font is also a CIDFontType0.
 var Type1Font = (function Type1FontClosure() {
   function findBlock(streamBytes, signature, startIndex) {
-    var streamBytesLength = streamBytes.length;
-    var signatureLength = signature.length;
-    var scanLength = streamBytesLength - signatureLength;
+    const streamBytesLength = streamBytes.length;
+    const signatureLength = signature.length;
+    const scanLength = streamBytesLength - signatureLength;
 
-    var i = startIndex,
+    let i = startIndex,
       j,
       found = false;
     while (i < scanLength) {
@@ -3428,10 +3433,10 @@ var Type1Font = (function Type1FontClosure() {
   }
 
   function getHeaderBlock(stream, suggestedLength) {
-    var EEXEC_SIGNATURE = [0x65, 0x65, 0x78, 0x65, 0x63];
+    const EEXEC_SIGNATURE = [0x65, 0x65, 0x78, 0x65, 0x63];
 
-    var streamStartPos = stream.pos; // Save the initial stream position.
-    var headerBytes, headerBytesLength, block;
+    const streamStartPos = stream.pos; // Save the initial stream position.
+    let headerBytes, headerBytesLength, block;
     try {
       headerBytes = stream.getBytes(suggestedLength);
       headerBytesLength = headerBytes.length;
@@ -3465,10 +3470,10 @@ var Type1Font = (function Type1FontClosure() {
     warn('Invalid "Length1" property in Type1 font -- trying to recover.');
     stream.pos = streamStartPos; // Reset the stream position.
 
-    var SCAN_BLOCK_LENGTH = 2048;
-    var actualLength;
+    const SCAN_BLOCK_LENGTH = 2048;
+    let actualLength;
     while (true) {
-      var scanBytes = stream.peekBytes(SCAN_BLOCK_LENGTH);
+      const scanBytes = stream.peekBytes(SCAN_BLOCK_LENGTH);
       block = findBlock(scanBytes, EEXEC_SIGNATURE, 0);
 
       if (block.length === 0) {
@@ -3510,7 +3515,7 @@ var Type1Font = (function Type1FontClosure() {
     // NOTE: This means that the function can include the fixed-content portion
     // in the returned eexec block. In practice this does *not* seem to matter,
     // since `Type1Parser_extractFontProgram` will skip over any non-commands.
-    var eexecBytes = stream.getBytes();
+    const eexecBytes = stream.getBytes();
     return {
       stream: new Stream(eexecBytes),
       length: eexecBytes.length,
@@ -3521,11 +3526,11 @@ var Type1Font = (function Type1FontClosure() {
     // Some bad generators embed pfb file as is, we have to strip 6-byte header.
     // Also, length1 and length2 might be off by 6 bytes as well.
     // http://www.math.ubc.ca/~cass/piscript/type1.pdf
-    var PFB_HEADER_SIZE = 6;
-    var headerBlockLength = properties.length1;
-    var eexecBlockLength = properties.length2;
-    var pfbHeader = file.peekBytes(PFB_HEADER_SIZE);
-    var pfbHeaderPresent = pfbHeader[0] === 0x80 && pfbHeader[1] === 0x01;
+    const PFB_HEADER_SIZE = 6;
+    let headerBlockLength = properties.length1;
+    let eexecBlockLength = properties.length2;
+    let pfbHeader = file.peekBytes(PFB_HEADER_SIZE);
+    const pfbHeaderPresent = pfbHeader[0] === 0x80 && pfbHeader[1] === 0x01;
     if (pfbHeaderPresent) {
       file.skip(PFB_HEADER_SIZE);
       headerBlockLength =
@@ -3536,8 +3541,8 @@ var Type1Font = (function Type1FontClosure() {
     }
 
     // Get the data block containing glyphs and subrs information
-    var headerBlock = getHeaderBlock(file, headerBlockLength);
-    var headerBlockParser = new Type1Parser(
+    const headerBlock = getHeaderBlock(file, headerBlockLength);
+    const headerBlockParser = new Type1Parser(
       headerBlock.stream,
       false,
       SEAC_ANALYSIS_ENABLED
@@ -3554,20 +3559,20 @@ var Type1Font = (function Type1FontClosure() {
     }
 
     // Decrypt the data blocks and retrieve it's content
-    var eexecBlock = getEexecBlock(file, eexecBlockLength);
-    var eexecBlockParser = new Type1Parser(
+    const eexecBlock = getEexecBlock(file, eexecBlockLength);
+    const eexecBlockParser = new Type1Parser(
       eexecBlock.stream,
       true,
       SEAC_ANALYSIS_ENABLED
     );
-    var data = eexecBlockParser.extractFontProgram(properties);
-    for (var info in data.properties) {
+    const data = eexecBlockParser.extractFontProgram(properties);
+    for (const info in data.properties) {
       properties[info] = data.properties[info];
     }
 
-    var charstrings = data.charstrings;
-    var type2Charstrings = this.getType2Charstrings(charstrings);
-    var subrs = this.getType2Subrs(data.subrs);
+    const charstrings = data.charstrings;
+    const type2Charstrings = this.getType2Charstrings(charstrings);
+    const subrs = this.getType2Subrs(data.subrs);
 
     this.charstrings = charstrings;
     this.data = this.wrap(
@@ -3586,25 +3591,25 @@ var Type1Font = (function Type1FontClosure() {
     },
 
     getCharset: function Type1Font_getCharset() {
-      var charset = [".notdef"];
-      var charstrings = this.charstrings;
-      for (var glyphId = 0; glyphId < charstrings.length; glyphId++) {
+      const charset = [".notdef"];
+      const charstrings = this.charstrings;
+      for (let glyphId = 0; glyphId < charstrings.length; glyphId++) {
         charset.push(charstrings[glyphId].glyphName);
       }
       return charset;
     },
 
     getGlyphMapping: function Type1Font_getGlyphMapping(properties) {
-      var charstrings = this.charstrings;
-      var glyphNames = [".notdef"],
+      const charstrings = this.charstrings;
+      let glyphNames = [".notdef"],
         glyphId;
       for (glyphId = 0; glyphId < charstrings.length; glyphId++) {
         glyphNames.push(charstrings[glyphId].glyphName);
       }
-      var encoding = properties.builtInEncoding;
+      const encoding = properties.builtInEncoding;
       if (encoding) {
         var builtInEncoding = Object.create(null);
-        for (var charCode in encoding) {
+        for (const charCode in encoding) {
           glyphId = glyphNames.indexOf(encoding[charCode]);
           if (glyphId >= 0) {
             builtInEncoding[charCode] = glyphId;
@@ -3623,15 +3628,15 @@ var Type1Font = (function Type1FontClosure() {
         // notdef is always defined.
         return true;
       }
-      var glyph = this.charstrings[id - 1];
+      const glyph = this.charstrings[id - 1];
       return glyph.charstring.length > 0;
     },
 
     getSeacs: function Type1Font_getSeacs(charstrings) {
-      var i, ii;
-      var seacMap = [];
+      let i, ii;
+      const seacMap = [];
       for (i = 0, ii = charstrings.length; i < ii; i++) {
-        var charstring = charstrings[i];
+        const charstring = charstrings[i];
         if (charstring.seac) {
           // Offset by 1 for .notdef
           seacMap[i + 1] = charstring.seac;
@@ -3643,16 +3648,16 @@ var Type1Font = (function Type1FontClosure() {
     getType2Charstrings: function Type1Font_getType2Charstrings(
       type1Charstrings
     ) {
-      var type2Charstrings = [];
-      for (var i = 0, ii = type1Charstrings.length; i < ii; i++) {
+      const type2Charstrings = [];
+      for (let i = 0, ii = type1Charstrings.length; i < ii; i++) {
         type2Charstrings.push(type1Charstrings[i].charstring);
       }
       return type2Charstrings;
     },
 
     getType2Subrs: function Type1Font_getType2Subrs(type1Subrs) {
-      var bias = 0;
-      var count = type1Subrs.length;
+      let bias = 0;
+      const count = type1Subrs.length;
       if (count < 1133) {
         bias = 107;
       } else if (count < 33769) {
@@ -3662,8 +3667,8 @@ var Type1Font = (function Type1FontClosure() {
       }
 
       // Add a bunch of empty subrs to deal with the Type2 bias
-      var type2Subrs = [];
-      var i;
+      const type2Subrs = [];
+      let i;
       for (i = 0; i < bias; i++) {
         type2Subrs.push([0x0b]);
       }
@@ -3682,12 +3687,12 @@ var Type1Font = (function Type1FontClosure() {
       subrs,
       properties
     ) {
-      var cff = new CFF();
+      const cff = new CFF();
       cff.header = new CFFHeader(1, 0, 4, 4);
 
       cff.names = [name];
 
-      var topDict = new CFFTopDict();
+      const topDict = new CFFTopDict();
       // CFF strings IDs 0...390 are predefined names, so refering
       // to entries in our own String INDEX starts at SID 391.
       topDict.setByName("version", 391);
@@ -3703,7 +3708,7 @@ var Type1Font = (function Type1FontClosure() {
       topDict.setByName("Private", null); // placeholder
       cff.topDict = topDict;
 
-      var strings = new CFFStrings();
+      const strings = new CFFStrings();
       strings.add("Version 0.11"); // Version
       strings.add("See original notice"); // Notice
       strings.add(name); // FullName
@@ -3713,9 +3718,9 @@ var Type1Font = (function Type1FontClosure() {
 
       cff.globalSubrIndex = new CFFIndex();
 
-      var count = glyphs.length;
-      var charsetArray = [".notdef"];
-      var i, ii;
+      const count = glyphs.length;
+      const charsetArray = [".notdef"];
+      let i, ii;
       for (i = 0; i < count; i++) {
         const glyphName = charstrings[i].glyphName;
         const index = CFFStandardStrings.indexOf(glyphName);
@@ -3726,16 +3731,16 @@ var Type1Font = (function Type1FontClosure() {
       }
       cff.charset = new CFFCharset(false, 0, charsetArray);
 
-      var charStringsIndex = new CFFIndex();
+      const charStringsIndex = new CFFIndex();
       charStringsIndex.add([0x8b, 0x0e]); // .notdef
       for (i = 0; i < count; i++) {
         charStringsIndex.add(glyphs[i]);
       }
       cff.charStrings = charStringsIndex;
 
-      var privateDict = new CFFPrivateDict();
+      const privateDict = new CFFPrivateDict();
       privateDict.setByName("Subrs", null); // placeholder
-      var fields = [
+      const fields = [
         "BlueValues",
         "OtherBlues",
         "FamilyBlues",
@@ -3752,15 +3757,15 @@ var Type1Font = (function Type1FontClosure() {
         "StdVW",
       ];
       for (i = 0, ii = fields.length; i < ii; i++) {
-        var field = fields[i];
+        const field = fields[i];
         if (!(field in properties.privateData)) {
           continue;
         }
-        var value = properties.privateData[field];
+        const value = properties.privateData[field];
         if (Array.isArray(value)) {
           // All of the private dictionary array data in CFF must be stored as
           // "delta-encoded" numbers.
-          for (var j = value.length - 1; j > 0; j--) {
+          for (let j = value.length - 1; j > 0; j--) {
             value[j] -= value[j - 1]; // ... difference from previous value
           }
         }
@@ -3768,13 +3773,13 @@ var Type1Font = (function Type1FontClosure() {
       }
       cff.topDict.privateDict = privateDict;
 
-      var subrIndex = new CFFIndex();
+      const subrIndex = new CFFIndex();
       for (i = 0, ii = subrs.length; i < ii; i++) {
         subrIndex.add(subrs[i]);
       }
       privateDict.subrsIndex = subrIndex;
 
-      var compiler = new CFFCompiler(cff);
+      const compiler = new CFFCompiler(cff);
       return compiler.compile();
     },
   };
@@ -3786,10 +3791,10 @@ var CFFFont = (function CFFFontClosure() {
   function CFFFont(file, properties) {
     this.properties = properties;
 
-    var parser = new CFFParser(file, properties, SEAC_ANALYSIS_ENABLED);
+    const parser = new CFFParser(file, properties, SEAC_ANALYSIS_ENABLED);
     this.cff = parser.parse();
     this.cff.duplicateFirstGlyph();
-    var compiler = new CFFCompiler(this.cff);
+    const compiler = new CFFCompiler(this.cff);
     this.seacs = this.cff.seacs;
     try {
       this.data = compiler.compile();
@@ -3809,11 +3814,11 @@ var CFFFont = (function CFFFontClosure() {
       return this.cff.charset.charset;
     },
     getGlyphMapping: function CFFFont_getGlyphMapping() {
-      var cff = this.cff;
-      var properties = this.properties;
-      var charsets = cff.charset.charset;
-      var charCodeToGlyphId;
-      var glyphId;
+      const cff = this.cff;
+      const properties = this.properties;
+      const charsets = cff.charset.charset;
+      let charCodeToGlyphId;
+      let glyphId;
 
       if (properties.composite) {
         charCodeToGlyphId = Object.create(null);
@@ -3822,7 +3827,7 @@ var CFFFont = (function CFFFontClosure() {
           // If the font is actually a CID font then we should use the charset
           // to map CIDs to GIDs.
           for (glyphId = 0; glyphId < charsets.length; glyphId++) {
-            var cid = charsets[glyphId];
+            const cid = charsets[glyphId];
             charCode = properties.cMap.charCodeOf(cid);
             charCodeToGlyphId[charCode] = glyphId;
           }
@@ -3837,7 +3842,7 @@ var CFFFont = (function CFFFontClosure() {
         return charCodeToGlyphId;
       }
 
-      var encoding = cff.encoding ? cff.encoding.encoding : null;
+      const encoding = cff.encoding ? cff.encoding.encoding : null;
       charCodeToGlyphId = type1FontGlyphMapping(properties, encoding, charsets);
       return charCodeToGlyphId;
     },

--- a/src/core/function.js
+++ b/src/core/function.js
@@ -79,21 +79,21 @@ var PDFFunction = (function PDFFunctionClosure() {
 
   return {
     getSampleArray(size, outputSize, bps, stream) {
-      var i, ii;
-      var length = 1;
+      let i, ii;
+      let length = 1;
       for (i = 0, ii = size.length; i < ii; i++) {
         length *= size[i];
       }
       length *= outputSize;
 
-      var array = new Array(length);
-      var codeSize = 0;
-      var codeBuf = 0;
+      const array = new Array(length);
+      let codeSize = 0;
+      let codeBuf = 0;
       // 32 is a valid bps so shifting won't work
-      var sampleMul = 1.0 / (Math.pow(2.0, bps) - 1);
+      const sampleMul = 1.0 / (Math.pow(2.0, bps) - 1);
 
-      var strBytes = stream.getBytes((length * bps + 7) / 8);
-      var strIdx = 0;
+      const strBytes = stream.getBytes((length * bps + 7) / 8);
+      let strIdx = 0;
       for (i = 0; i < length; i++) {
         while (codeSize < bps) {
           codeBuf <<= 8;
@@ -108,12 +108,12 @@ var PDFFunction = (function PDFFunctionClosure() {
     },
 
     getIR({ xref, isEvalSupported, fn }) {
-      var dict = fn.dict;
+      let dict = fn.dict;
       if (!dict) {
         dict = fn;
       }
 
-      var types = [
+      const types = [
         this.constructSampled,
         null,
         this.constructInterpolated,
@@ -121,8 +121,8 @@ var PDFFunction = (function PDFFunctionClosure() {
         this.constructPostScript,
       ];
 
-      var typeNum = dict.get("FunctionType");
-      var typeFn = types[typeNum];
+      const typeNum = dict.get("FunctionType");
+      const typeFn = types[typeNum];
       if (!typeFn) {
         throw new FormatError("Unknown type of function");
       }
@@ -131,7 +131,7 @@ var PDFFunction = (function PDFFunctionClosure() {
     },
 
     fromIR({ xref, isEvalSupported, IR }) {
-      var type = IR[0];
+      const type = IR[0];
       switch (type) {
         case CONSTRUCT_SAMPLED:
           return this.constructSampledFromIR({ xref, isEvalSupported, IR });
@@ -160,14 +160,14 @@ var PDFFunction = (function PDFFunctionClosure() {
         return this.parse({ xref, isEvalSupported, fn: fnObj });
       }
 
-      var fnArray = [];
-      for (var j = 0, jj = fnObj.length; j < jj; j++) {
+      const fnArray = [];
+      for (let j = 0, jj = fnObj.length; j < jj; j++) {
         fnArray.push(
           this.parse({ xref, isEvalSupported, fn: xref.fetchIfRef(fnObj[j]) })
         );
       }
       return function(src, srcOffset, dest, destOffset) {
-        for (var i = 0, ii = fnArray.length; i < ii; i++) {
+        for (let i = 0, ii = fnArray.length; i < ii; i++) {
           fnArray[i](src, srcOffset, dest, destOffset + i);
         }
       };
@@ -175,55 +175,55 @@ var PDFFunction = (function PDFFunctionClosure() {
 
     constructSampled({ xref, isEvalSupported, fn, dict }) {
       function toMultiArray(arr) {
-        var inputLength = arr.length;
-        var out = [];
-        var index = 0;
-        for (var i = 0; i < inputLength; i += 2) {
+        const inputLength = arr.length;
+        const out = [];
+        let index = 0;
+        for (let i = 0; i < inputLength; i += 2) {
           out[index] = [arr[i], arr[i + 1]];
           ++index;
         }
         return out;
       }
-      var domain = toNumberArray(dict.getArray("Domain"));
-      var range = toNumberArray(dict.getArray("Range"));
+      let domain = toNumberArray(dict.getArray("Domain"));
+      let range = toNumberArray(dict.getArray("Range"));
 
       if (!domain || !range) {
         throw new FormatError("No domain or range");
       }
 
-      var inputSize = domain.length / 2;
-      var outputSize = range.length / 2;
+      const inputSize = domain.length / 2;
+      const outputSize = range.length / 2;
 
       domain = toMultiArray(domain);
       range = toMultiArray(range);
 
-      var size = toNumberArray(dict.getArray("Size"));
-      var bps = dict.get("BitsPerSample");
-      var order = dict.get("Order") || 1;
+      const size = toNumberArray(dict.getArray("Size"));
+      const bps = dict.get("BitsPerSample");
+      const order = dict.get("Order") || 1;
       if (order !== 1) {
         // No description how cubic spline interpolation works in PDF32000:2008
         // As in poppler, ignoring order, linear interpolation may work as good
         info("No support for cubic spline interpolation: " + order);
       }
 
-      var encode = toNumberArray(dict.getArray("Encode"));
+      let encode = toNumberArray(dict.getArray("Encode"));
       if (!encode) {
         encode = [];
-        for (var i = 0; i < inputSize; ++i) {
+        for (let i = 0; i < inputSize; ++i) {
           encode.push([0, size[i] - 1]);
         }
       } else {
         encode = toMultiArray(encode);
       }
 
-      var decode = toNumberArray(dict.getArray("Decode"));
+      let decode = toNumberArray(dict.getArray("Decode"));
       if (!decode) {
         decode = range;
       } else {
         decode = toMultiArray(decode);
       }
 
-      var samples = this.getSampleArray(size, outputSize, bps, fn);
+      const samples = this.getSampleArray(size, outputSize, bps, fn);
 
       return [
         CONSTRUCT_SAMPLED,
@@ -252,41 +252,41 @@ var PDFFunction = (function PDFFunctionClosure() {
         destOffset
       ) {
         // See chapter 3, page 110 of the PDF reference.
-        var m = IR[1];
-        var domain = IR[2];
-        var encode = IR[3];
-        var decode = IR[4];
-        var samples = IR[5];
-        var size = IR[6];
-        var n = IR[7];
+        const m = IR[1];
+        const domain = IR[2];
+        const encode = IR[3];
+        const decode = IR[4];
+        const samples = IR[5];
+        const size = IR[6];
+        const n = IR[7];
         // var mask = IR[8];
-        var range = IR[9];
+        const range = IR[9];
 
         // Building the cube vertices: its part and sample index
         // http://rjwagner49.com/Mathematics/Interpolation.pdf
-        var cubeVertices = 1 << m;
-        var cubeN = new Float64Array(cubeVertices);
-        var cubeVertex = new Uint32Array(cubeVertices);
-        var i, j;
+        const cubeVertices = 1 << m;
+        const cubeN = new Float64Array(cubeVertices);
+        const cubeVertex = new Uint32Array(cubeVertices);
+        let i, j;
         for (j = 0; j < cubeVertices; j++) {
           cubeN[j] = 1;
         }
 
-        var k = n,
+        let k = n,
           pos = 1;
         // Map x_i to y_j for 0 <= i < m using the sampled function.
         for (i = 0; i < m; ++i) {
           // x_i' = min(max(x_i, Domain_2i), Domain_2i+1)
-          var domain_2i = domain[i][0];
-          var domain_2i_1 = domain[i][1];
-          var xi = Math.min(
+          const domain_2i = domain[i][0];
+          const domain_2i_1 = domain[i][1];
+          const xi = Math.min(
             Math.max(src[srcOffset + i], domain_2i),
             domain_2i_1
           );
 
           // e_i = Interpolate(x_i', Domain_2i, Domain_2i+1,
           //                   Encode_2i, Encode_2i+1)
-          var e = interpolate(
+          let e = interpolate(
             xi,
             domain_2i,
             domain_2i_1,
@@ -295,15 +295,15 @@ var PDFFunction = (function PDFFunctionClosure() {
           );
 
           // e_i' = min(max(e_i, 0), Size_i - 1)
-          var size_i = size[i];
+          const size_i = size[i];
           e = Math.min(Math.max(e, 0), size_i - 1);
 
           // Adjusting the cube: N and vertex sample index
-          var e0 = e < size_i - 1 ? Math.floor(e) : e - 1; // e1 = e0 + 1;
-          var n0 = e0 + 1 - e; // (e1 - e) / (e1 - e0);
-          var n1 = e - e0; // (e - e0) / (e1 - e0);
-          var offset0 = e0 * k;
-          var offset1 = offset0 + k; // e1 * k
+          const e0 = e < size_i - 1 ? Math.floor(e) : e - 1; // e1 = e0 + 1;
+          const n0 = e0 + 1 - e; // (e1 - e) / (e1 - e0);
+          const n1 = e - e0; // (e - e0) / (e1 - e0);
+          const offset0 = e0 * k;
+          const offset1 = offset0 + k; // e1 * k
           for (j = 0; j < cubeVertices; j++) {
             if (j & pos) {
               cubeN[j] *= n1;
@@ -320,7 +320,7 @@ var PDFFunction = (function PDFFunctionClosure() {
 
         for (j = 0; j < n; ++j) {
           // Sum all cube vertices' samples portions
-          var rj = 0;
+          let rj = 0;
           for (i = 0; i < cubeVertices; i++) {
             rj += samples[cubeVertex[i] + j] * cubeN[i];
           }
@@ -339,13 +339,13 @@ var PDFFunction = (function PDFFunctionClosure() {
     },
 
     constructInterpolated({ xref, isEvalSupported, fn, dict }) {
-      var c0 = toNumberArray(dict.getArray("C0")) || [0];
-      var c1 = toNumberArray(dict.getArray("C1")) || [1];
-      var n = dict.get("N");
+      const c0 = toNumberArray(dict.getArray("C0")) || [0];
+      const c1 = toNumberArray(dict.getArray("C1")) || [1];
+      const n = dict.get("N");
 
-      var length = c0.length;
-      var diff = [];
-      for (var i = 0; i < length; ++i) {
+      const length = c0.length;
+      const diff = [];
+      for (let i = 0; i < length; ++i) {
         diff.push(c1[i] - c0[i]);
       }
 
@@ -353,11 +353,11 @@ var PDFFunction = (function PDFFunctionClosure() {
     },
 
     constructInterpolatedFromIR({ xref, isEvalSupported, IR }) {
-      var c0 = IR[1];
-      var diff = IR[2];
-      var n = IR[3];
+      const c0 = IR[1];
+      const diff = IR[2];
+      const n = IR[3];
 
-      var length = diff.length;
+      const length = diff.length;
 
       return function constructInterpolatedFromIRResult(
         src,
@@ -365,46 +365,46 @@ var PDFFunction = (function PDFFunctionClosure() {
         dest,
         destOffset
       ) {
-        var x = n === 1 ? src[srcOffset] : Math.pow(src[srcOffset], n);
+        const x = n === 1 ? src[srcOffset] : Math.pow(src[srcOffset], n);
 
-        for (var j = 0; j < length; ++j) {
+        for (let j = 0; j < length; ++j) {
           dest[destOffset + j] = c0[j] + x * diff[j];
         }
       };
     },
 
     constructStiched({ xref, isEvalSupported, fn, dict }) {
-      var domain = toNumberArray(dict.getArray("Domain"));
+      const domain = toNumberArray(dict.getArray("Domain"));
 
       if (!domain) {
         throw new FormatError("No domain");
       }
 
-      var inputSize = domain.length / 2;
+      const inputSize = domain.length / 2;
       if (inputSize !== 1) {
         throw new FormatError("Bad domain for stiched function");
       }
 
-      var fnRefs = dict.get("Functions");
-      var fns = [];
-      for (var i = 0, ii = fnRefs.length; i < ii; ++i) {
+      const fnRefs = dict.get("Functions");
+      const fns = [];
+      for (let i = 0, ii = fnRefs.length; i < ii; ++i) {
         fns.push(
           this.parse({ xref, isEvalSupported, fn: xref.fetchIfRef(fnRefs[i]) })
         );
       }
 
-      var bounds = toNumberArray(dict.getArray("Bounds"));
-      var encode = toNumberArray(dict.getArray("Encode"));
+      const bounds = toNumberArray(dict.getArray("Bounds"));
+      const encode = toNumberArray(dict.getArray("Encode"));
 
       return [CONSTRUCT_STICHED, domain, bounds, encode, fns];
     },
 
     constructStichedFromIR({ xref, isEvalSupported, IR }) {
-      var domain = IR[1];
-      var bounds = IR[2];
-      var encode = IR[3];
-      var fns = IR[4];
-      var tmpBuf = new Float32Array(1);
+      const domain = IR[1];
+      const bounds = IR[2];
+      const encode = IR[3];
+      const fns = IR[4];
+      const tmpBuf = new Float32Array(1);
 
       return function constructStichedFromIRResult(
         src,
@@ -412,7 +412,7 @@ var PDFFunction = (function PDFFunctionClosure() {
         dest,
         destOffset
       ) {
-        var clip = function constructStichedFromIRClip(v, min, max) {
+        const clip = function constructStichedFromIRClip(v, min, max) {
           if (v > max) {
             v = max;
           } else if (v < min) {
@@ -422,7 +422,7 @@ var PDFFunction = (function PDFFunctionClosure() {
         };
 
         // clip to domain
-        var v = clip(src[srcOffset], domain[0], domain[1]);
+        const v = clip(src[srcOffset], domain[0], domain[1]);
         // calculate which bound the value is in
         for (var i = 0, ii = bounds.length; i < ii; ++i) {
           if (v < bounds[i]) {
@@ -431,17 +431,17 @@ var PDFFunction = (function PDFFunctionClosure() {
         }
 
         // encode value into domain of function
-        var dmin = domain[0];
+        let dmin = domain[0];
         if (i > 0) {
           dmin = bounds[i - 1];
         }
-        var dmax = domain[1];
+        let dmax = domain[1];
         if (i < bounds.length) {
           dmax = bounds[i];
         }
 
-        var rmin = encode[2 * i];
-        var rmax = encode[2 * i + 1];
+        const rmin = encode[2 * i];
+        const rmax = encode[2 * i + 1];
 
         // Prevent the value from becoming NaN as a result
         // of division by zero (fixes issue6113.pdf).
@@ -456,8 +456,8 @@ var PDFFunction = (function PDFFunctionClosure() {
     },
 
     constructPostScript({ xref, isEvalSupported, fn, dict }) {
-      var domain = toNumberArray(dict.getArray("Domain"));
-      var range = toNumberArray(dict.getArray("Range"));
+      const domain = toNumberArray(dict.getArray("Domain"));
+      const range = toNumberArray(dict.getArray("Range"));
 
       if (!domain) {
         throw new FormatError("No domain.");
@@ -467,17 +467,17 @@ var PDFFunction = (function PDFFunctionClosure() {
         throw new FormatError("No range.");
       }
 
-      var lexer = new PostScriptLexer(fn);
-      var parser = new PostScriptParser(lexer);
-      var code = parser.parse();
+      const lexer = new PostScriptLexer(fn);
+      const parser = new PostScriptParser(lexer);
+      const code = parser.parse();
 
       return [CONSTRUCT_POSTSCRIPT, domain, range, code];
     },
 
     constructPostScriptFromIR({ xref, isEvalSupported, IR }) {
-      var domain = IR[1];
-      var range = IR[2];
-      var code = IR[3];
+      const domain = IR[1];
+      const range = IR[2];
+      const code = IR[3];
 
       if (isEvalSupported && IsEvalSupportedCached.value) {
         const compiled = new PostScriptCompiler().compile(code, domain, range);
@@ -497,17 +497,17 @@ var PDFFunction = (function PDFFunctionClosure() {
       }
       info("Unable to compile PS function");
 
-      var numOutputs = range.length >> 1;
-      var numInputs = domain.length >> 1;
-      var evaluator = new PostScriptEvaluator(code);
+      const numOutputs = range.length >> 1;
+      const numInputs = domain.length >> 1;
+      const evaluator = new PostScriptEvaluator(code);
       // Cache the values for a big speed up, the cache size is limited though
       // since the number of possible values can be huge from a PS function.
-      var cache = Object.create(null);
+      const cache = Object.create(null);
       // The MAX_CACHE_SIZE is set to ~4x the maximum number of distinct values
       // seen in our tests.
-      var MAX_CACHE_SIZE = 2048 * 4;
-      var cache_available = MAX_CACHE_SIZE;
-      var tmpBuf = new Float32Array(numInputs);
+      const MAX_CACHE_SIZE = 2048 * 4;
+      let cache_available = MAX_CACHE_SIZE;
+      const tmpBuf = new Float32Array(numInputs);
 
       return function constructPostScriptFromIRResult(
         src,
@@ -515,27 +515,27 @@ var PDFFunction = (function PDFFunctionClosure() {
         dest,
         destOffset
       ) {
-        var i, value;
-        var key = "";
-        var input = tmpBuf;
+        let i, value;
+        let key = "";
+        const input = tmpBuf;
         for (i = 0; i < numInputs; i++) {
           value = src[srcOffset + i];
           input[i] = value;
           key += value + "_";
         }
 
-        var cachedValue = cache[key];
+        const cachedValue = cache[key];
         if (cachedValue !== undefined) {
           dest.set(cachedValue, destOffset);
           return;
         }
 
-        var output = new Float32Array(numOutputs);
-        var stack = evaluator.execute(input);
-        var stackIndex = stack.length - numOutputs;
+        const output = new Float32Array(numOutputs);
+        const stack = evaluator.execute(input);
+        const stackIndex = stack.length - numOutputs;
         for (i = 0; i < numOutputs; i++) {
           value = stack[stackIndex + i];
-          var bound = range[i * 2];
+          let bound = range[i * 2];
           if (value < bound) {
             value = bound;
           } else {
@@ -557,7 +557,7 @@ var PDFFunction = (function PDFFunctionClosure() {
 })();
 
 function isPDFFunction(v) {
-  var fnDict;
+  let fnDict;
   if (typeof v !== "object") {
     return false;
   } else if (isDict(v)) {
@@ -570,8 +570,8 @@ function isPDFFunction(v) {
   return fnDict.has("FunctionType");
 }
 
-var PostScriptStack = (function PostScriptStackClosure() {
-  var MAX_STACK_SIZE = 100;
+const PostScriptStack = (function PostScriptStackClosure() {
+  const MAX_STACK_SIZE = 100;
   function PostScriptStack(initialStack) {
     this.stack = !initialStack
       ? []
@@ -595,8 +595,8 @@ var PostScriptStack = (function PostScriptStackClosure() {
       if (this.stack.length + n >= MAX_STACK_SIZE) {
         throw new Error("PostScript function stack overflow.");
       }
-      var stack = this.stack;
-      for (var i = stack.length - n, j = n - 1; j >= 0; j--, i++) {
+      const stack = this.stack;
+      for (let i = stack.length - n, j = n - 1; j >= 0; j--, i++) {
         stack.push(stack[i]);
       }
     },
@@ -605,9 +605,9 @@ var PostScriptStack = (function PostScriptStackClosure() {
     },
     // rotate the last n stack elements p times
     roll: function PostScriptStack_roll(n, p) {
-      var stack = this.stack;
-      var l = stack.length - n;
-      var r = stack.length - 1,
+      const stack = this.stack;
+      const l = stack.length - n;
+      let r = stack.length - 1,
         c = l + (p - Math.floor(p / n) * n),
         i,
         j,
@@ -637,11 +637,11 @@ var PostScriptEvaluator = (function PostScriptEvaluatorClosure() {
   }
   PostScriptEvaluator.prototype = {
     execute: function PostScriptEvaluator_execute(initialStack) {
-      var stack = new PostScriptStack(initialStack);
-      var counter = 0;
-      var operators = this.operators;
-      var length = operators.length;
-      var operator, a, b;
+      const stack = new PostScriptStack(initialStack);
+      let counter = 0;
+      const operators = this.operators;
+      const length = operators.length;
+      let operator, a, b;
       while (counter < length) {
         operator = operators[counter++];
         if (typeof operator === "number") {
@@ -1035,13 +1035,13 @@ var PostScriptCompiler = (function PostScriptCompilerClosure() {
         return num2; // and it's 1
       }
     }
-    var min = Math.min(
+    const min = Math.min(
       num1.min * num2.min,
       num1.min * num2.max,
       num1.max * num2.min,
       num1.max * num2.max
     );
-    var max = Math.max(
+    const max = Math.max(
       num1.min * num2.min,
       num1.min * num2.max,
       num1.max * num2.min,
@@ -1094,14 +1094,14 @@ var PostScriptCompiler = (function PostScriptCompilerClosure() {
   function PostScriptCompiler() {}
   PostScriptCompiler.prototype = {
     compile: function PostScriptCompiler_compile(code, domain, range) {
-      var stack = [];
-      var i, ii;
-      var instructions = [];
-      var inputSize = domain.length >> 1,
+      const stack = [];
+      let i, ii;
+      const instructions = [];
+      const inputSize = domain.length >> 1,
         outputSize = range.length >> 1;
-      var lastRegister = 0;
-      var n, j;
-      var num1, num2, ast1, ast2, tmpVar, item;
+      let lastRegister = 0;
+      let n, j;
+      let num1, num2, ast1, ast2, tmpVar, item;
       for (i = 0; i < inputSize; i++) {
         stack.push(new AstArgument(i, domain[i * 2], domain[i * 2 + 1]));
       }
@@ -1248,18 +1248,18 @@ var PostScriptCompiler = (function PostScriptCompilerClosure() {
         return null;
       }
 
-      var result = [];
+      const result = [];
       instructions.forEach(function(instruction) {
-        var statementBuilder = new ExpressionBuilderVisitor();
+        const statementBuilder = new ExpressionBuilderVisitor();
         instruction.visit(statementBuilder);
         result.push(statementBuilder.toString());
       });
       stack.forEach(function(expr, i) {
-        var statementBuilder = new ExpressionBuilderVisitor();
+        const statementBuilder = new ExpressionBuilderVisitor();
         expr.visit(statementBuilder);
-        var min = range[i * 2],
+        const min = range[i * 2],
           max = range[i * 2 + 1];
-        var out = [statementBuilder.toString()];
+        const out = [statementBuilder.toString()];
         if (min > expr.min) {
           out.unshift("Math.max(", min, ", ");
           out.push(")");

--- a/src/core/glyphlist.js
+++ b/src/core/glyphlist.js
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint-disable no-var */
 /* no-babel-preset */
 
 var getLookupTableFactory = require("./core_utils.js").getLookupTableFactory;

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -20,7 +20,7 @@ import { DecodeStream } from "./stream.js";
 import { JpegStream } from "./jpeg_stream.js";
 import { JpxImage } from "./jpx.js";
 
-var PDFImage = (function PDFImageClosure() {
+const PDFImage = (function PDFImageClosure() {
   /**
    * Decodes the image using native decoder if possible. Resolves the promise
    * when the image data is ready.
@@ -64,7 +64,7 @@ var PDFImage = (function PDFImageClosure() {
    * @returns {TypedArray} The resized image mask buffer.
    */
   function resizeImageMask(src, bpc, w1, h1, w2, h2) {
-    var length = w2 * h2;
+    const length = w2 * h2;
     let dest;
     if (bpc <= 8) {
       dest = new Uint8Array(length);
@@ -73,15 +73,15 @@ var PDFImage = (function PDFImageClosure() {
     } else {
       dest = new Uint32Array(length);
     }
-    var xRatio = w1 / w2;
-    var yRatio = h1 / h2;
-    var i,
+    const xRatio = w1 / w2;
+    const yRatio = h1 / h2;
+    let i,
       j,
       py,
       newIndex = 0,
       oldIndex;
-    var xScaled = new Uint16Array(w2);
-    var w1Scanline = w1;
+    const xScaled = new Uint16Array(w2);
+    const w1Scanline = w1;
 
     for (i = 0; i < w2; i++) {
       xScaled[i] = Math.floor(i * xRatio);
@@ -107,7 +107,7 @@ var PDFImage = (function PDFImageClosure() {
     pdfFunctionFactory,
   }) {
     this.image = image;
-    var dict = image.dict;
+    const dict = image.dict;
 
     const filter = dict.get("Filter");
     if (isName(filter)) {
@@ -159,7 +159,7 @@ var PDFImage = (function PDFImageClosure() {
     this.imageMask = dict.get("ImageMask", "IM") || false;
     this.matte = dict.get("Matte") || false;
 
-    var bitsPerComponent = image.bitsPerComponent;
+    let bitsPerComponent = image.bitsPerComponent;
     if (!bitsPerComponent) {
       bitsPerComponent = dict.get("BitsPerComponent", "BPC");
       if (!bitsPerComponent) {
@@ -175,7 +175,7 @@ var PDFImage = (function PDFImageClosure() {
     this.bpc = bitsPerComponent;
 
     if (!this.imageMask) {
-      var colorSpace = dict.get("ColorSpace", "CS");
+      let colorSpace = dict.get("ColorSpace", "CS");
       if (!colorSpace) {
         info("JPX images (which do not require color spaces)");
         switch (image.numComps) {
@@ -216,13 +216,13 @@ var PDFImage = (function PDFImageClosure() {
     ) {
       this.needsDecode = true;
       // Do some preprocessing to avoid more math.
-      var max = (1 << bitsPerComponent) - 1;
+      const max = (1 << bitsPerComponent) - 1;
       this.decodeCoefficients = [];
       this.decodeAddends = [];
       const isIndexed = this.colorSpace && this.colorSpace.name === "Indexed";
-      for (var i = 0, j = 0; i < this.decode.length; i += 2, ++j) {
-        var dmin = this.decode[i];
-        var dmax = this.decode[i + 1];
+      for (let i = 0, j = 0; i < this.decode.length; i += 2, ++j) {
+        const dmin = this.decode[i];
+        const dmax = this.decode[i + 1];
         this.decodeCoefficients[j] = isIndexed
           ? (dmax - dmin) / max
           : dmax - dmin;
@@ -240,7 +240,7 @@ var PDFImage = (function PDFImageClosure() {
       });
     } else if (mask) {
       if (isStream(mask)) {
-        var maskDict = mask.dict,
+        const maskDict = mask.dict,
           imageMask = maskDict.get("ImageMask", "IM");
         if (!imageMask) {
           warn("Ignoring /Mask in image without /ImageMask.");
@@ -273,12 +273,12 @@ var PDFImage = (function PDFImageClosure() {
     nativeDecoder = null,
     pdfFunctionFactory,
   }) {
-    var imagePromise = handleImageData(image, nativeDecoder);
-    var smaskPromise;
-    var maskPromise;
+    const imagePromise = handleImageData(image, nativeDecoder);
+    let smaskPromise;
+    let maskPromise;
 
-    var smask = image.dict.get("SMask");
-    var mask = image.dict.get("Mask");
+    const smask = image.dict.get("SMask");
+    const mask = image.dict.get("Mask");
 
     if (smask) {
       smaskPromise = handleImageData(smask, nativeDecoder);
@@ -334,10 +334,10 @@ var PDFImage = (function PDFImageClosure() {
     // In particular, if inverseDecode is true, then the array we return must
     // have a length of |computedLength|.
 
-    var computedLength = ((width + 7) >> 3) * height;
-    var actualLength = imgArray.byteLength;
-    var haveFullData = computedLength === actualLength;
-    var data, i;
+    const computedLength = ((width + 7) >> 3) * height;
+    const actualLength = imgArray.byteLength;
+    const haveFullData = computedLength === actualLength;
+    let data, i;
 
     if (imageIsFromDecodeStream && (!inverseDecode || haveFullData)) {
       // imgArray came from a DecodeStream and its data is in an appropriate
@@ -385,13 +385,13 @@ var PDFImage = (function PDFImageClosure() {
     },
 
     decodeBuffer(buffer) {
-      var bpc = this.bpc;
-      var numComps = this.numComps;
+      const bpc = this.bpc;
+      const numComps = this.numComps;
 
-      var decodeAddends = this.decodeAddends;
-      var decodeCoefficients = this.decodeCoefficients;
-      var max = (1 << bpc) - 1;
-      var i, ii;
+      const decodeAddends = this.decodeAddends;
+      const decodeCoefficients = this.decodeCoefficients;
+      const max = (1 << bpc) - 1;
+      let i, ii;
 
       if (bpc === 1) {
         // If the buffer needed decode that means it just needs to be inverted.
@@ -400,9 +400,9 @@ var PDFImage = (function PDFImageClosure() {
         }
         return;
       }
-      var index = 0;
+      let index = 0;
       for (i = 0, ii = this.width * this.height; i < ii; i++) {
-        for (var j = 0; j < numComps; j++) {
+        for (let j = 0; j < numComps; j++) {
           buffer[index] = decodeAndClamp(
             buffer[index],
             decodeAddends[j],
@@ -415,19 +415,19 @@ var PDFImage = (function PDFImageClosure() {
     },
 
     getComponents(buffer) {
-      var bpc = this.bpc;
+      const bpc = this.bpc;
 
       // This image doesn't require any extra work.
       if (bpc === 8) {
         return buffer;
       }
 
-      var width = this.width;
-      var height = this.height;
-      var numComps = this.numComps;
+      const width = this.width;
+      const height = this.height;
+      const numComps = this.numComps;
 
-      var length = width * height * numComps;
-      var bufferPos = 0;
+      const length = width * height * numComps;
+      let bufferPos = 0;
       let output;
       if (bpc <= 8) {
         output = new Uint8Array(length);
@@ -436,17 +436,17 @@ var PDFImage = (function PDFImageClosure() {
       } else {
         output = new Uint32Array(length);
       }
-      var rowComps = width * numComps;
+      const rowComps = width * numComps;
 
-      var max = (1 << bpc) - 1;
-      var i = 0,
+      const max = (1 << bpc) - 1;
+      let i = 0,
         ii,
         buf;
 
       if (bpc === 1) {
         // Optimization for reading 1 bpc images.
-        var mask, loop1End, loop2End;
-        for (var j = 0; j < height; j++) {
+        let mask, loop1End, loop2End;
+        for (let j = 0; j < height; j++) {
           loop1End = i + (rowComps & ~7);
           loop2End = i + rowComps;
 
@@ -476,7 +476,7 @@ var PDFImage = (function PDFImageClosure() {
         }
       } else {
         // The general case that handles all other bpc values.
-        var bits = 0;
+        let bits = 0;
         buf = 0;
         for (i = 0, ii = length; i < ii; ++i) {
           if (i % rowComps === 0) {
@@ -489,7 +489,7 @@ var PDFImage = (function PDFImageClosure() {
             bits += 8;
           }
 
-          var remainingBits = bits - bpc;
+          const remainingBits = bits - bpc;
           let value = buf >> remainingBits;
           if (value < 0) {
             value = 0;
@@ -514,9 +514,9 @@ var PDFImage = (function PDFImageClosure() {
           'PDFImage.fillOpacity: Unsupported "rgbaBuf" type.'
         );
       }
-      var smask = this.smask;
-      var mask = this.mask;
-      var alphaBuf, sw, sh, i, ii, j;
+      const smask = this.smask;
+      const mask = this.mask;
+      let alphaBuf, sw, sh, i, ii, j;
 
       if (smask) {
         sw = smask.width;
@@ -560,13 +560,13 @@ var PDFImage = (function PDFImageClosure() {
           // Color key mask: if any of the components are outside the range
           // then they should be painted.
           alphaBuf = new Uint8ClampedArray(width * height);
-          var numComps = this.numComps;
+          const numComps = this.numComps;
           for (i = 0, ii = width * height; i < ii; ++i) {
-            var opacity = 0;
-            var imageOffset = i * numComps;
+            let opacity = 0;
+            const imageOffset = i * numComps;
             for (j = 0; j < numComps; ++j) {
-              var color = image[imageOffset + j];
-              var maskOffset = j * 2;
+              const color = image[imageOffset + j];
+              const maskOffset = j * 2;
               if (color < mask[maskOffset] || color > mask[maskOffset + 1]) {
                 opacity = 255;
                 break;
@@ -601,17 +601,17 @@ var PDFImage = (function PDFImageClosure() {
           'PDFImage.undoPreblend: Unsupported "buffer" type.'
         );
       }
-      var matte = this.smask && this.smask.matte;
+      const matte = this.smask && this.smask.matte;
       if (!matte) {
         return;
       }
-      var matteRgb = this.colorSpace.getRgb(matte, 0);
-      var matteR = matteRgb[0];
-      var matteG = matteRgb[1];
-      var matteB = matteRgb[2];
-      var length = width * height * 4;
-      for (var i = 0; i < length; i += 4) {
-        var alpha = buffer[i + 3];
+      const matteRgb = this.colorSpace.getRgb(matte, 0);
+      const matteR = matteRgb[0];
+      const matteG = matteRgb[1];
+      const matteB = matteRgb[2];
+      const length = width * height * 4;
+      for (let i = 0; i < length; i += 4) {
+        const alpha = buffer[i + 3];
         if (alpha === 0) {
           // according formula we have to get Infinity in all components
           // making it white (typical paper color) should be okay
@@ -620,7 +620,7 @@ var PDFImage = (function PDFImageClosure() {
           buffer[i + 2] = 255;
           continue;
         }
-        var k = 255 / alpha;
+        const k = 255 / alpha;
         buffer[i] = (buffer[i] - matteR) * k + matteR;
         buffer[i + 1] = (buffer[i + 1] - matteG) * k + matteG;
         buffer[i + 2] = (buffer[i + 2] - matteB) * k + matteB;
@@ -628,9 +628,9 @@ var PDFImage = (function PDFImageClosure() {
     },
 
     createImageData(forceRGBA = false) {
-      var drawWidth = this.drawWidth;
-      var drawHeight = this.drawHeight;
-      var imgData = {
+      const drawWidth = this.drawWidth;
+      const drawHeight = this.drawHeight;
+      const imgData = {
         width: drawWidth,
         height: drawHeight,
         kind: 0,
@@ -638,14 +638,14 @@ var PDFImage = (function PDFImageClosure() {
         // Other fields are filled in below.
       };
 
-      var numComps = this.numComps;
-      var originalWidth = this.width;
-      var originalHeight = this.height;
-      var bpc = this.bpc;
+      const numComps = this.numComps;
+      const originalWidth = this.width;
+      const originalHeight = this.height;
+      const bpc = this.bpc;
 
       // Rows start at byte boundary.
-      var rowBytes = (originalWidth * numComps * bpc + 7) >> 3;
-      var imgArray;
+      const rowBytes = (originalWidth * numComps * bpc + 7) >> 3;
+      let imgArray;
 
       if (!forceRGBA) {
         // If it is a 1-bit-per-pixel grayscale (i.e. black-and-white) image
@@ -655,7 +655,7 @@ var PDFImage = (function PDFImageClosure() {
         //
         // Similarly, if it is a 24-bit-per pixel RGB image without any
         // complications, we avoid expanding by 1.333x to RGBA form.
-        var kind;
+        let kind;
         if (this.colorSpace.name === "DeviceGray" && bpc === 1) {
           kind = ImageKind.GRAYSCALE_1BPP;
         } else if (
@@ -683,7 +683,7 @@ var PDFImage = (function PDFImageClosure() {
           if (this.image instanceof DecodeStream) {
             imgData.data = imgArray;
           } else {
-            var newArray = new Uint8ClampedArray(imgArray.length);
+            const newArray = new Uint8ClampedArray(imgArray.length);
             newArray.set(imgArray);
             imgData.data = newArray;
           }
@@ -693,8 +693,8 @@ var PDFImage = (function PDFImageClosure() {
               kind === ImageKind.GRAYSCALE_1BPP,
               "PDFImage.createImageData: The image must be grayscale."
             );
-            var buffer = imgData.data;
-            for (var i = 0, ii = buffer.length; i < ii; i++) {
+            const buffer = imgData.data;
+            for (let i = 0, ii = buffer.length; i < ii; i++) {
               buffer[i] ^= 0xff;
             }
           }
@@ -724,14 +724,14 @@ var PDFImage = (function PDFImageClosure() {
 
       imgArray = this.getImageBytes(originalHeight * rowBytes);
       // imgArray can be incomplete (e.g. after CCITT fax encoding).
-      var actualHeight =
+      const actualHeight =
         0 | (((imgArray.length / rowBytes) * drawHeight) / originalHeight);
 
-      var comps = this.getComponents(imgArray);
+      const comps = this.getComponents(imgArray);
 
       // If opacity data is present, use RGBA_32BPP form. Otherwise, use the
       // more compact RGB_24BPP form if allowable.
-      var alpha01, maybeUndoPreblend;
+      let alpha01, maybeUndoPreblend;
       if (!forceRGBA && !this.smask && !this.mask) {
         imgData.kind = ImageKind.RGB_24BPP;
         imgData.data = new Uint8ClampedArray(drawWidth * drawHeight * 3);
@@ -784,23 +784,23 @@ var PDFImage = (function PDFImageClosure() {
           'PDFImage.fillGrayBuffer: Unsupported "buffer" type.'
         );
       }
-      var numComps = this.numComps;
+      const numComps = this.numComps;
       if (numComps !== 1) {
         throw new FormatError(
           `Reading gray scale from a color image: ${numComps}`
         );
       }
 
-      var width = this.width;
-      var height = this.height;
-      var bpc = this.bpc;
+      const width = this.width;
+      const height = this.height;
+      const bpc = this.bpc;
 
       // rows start at byte boundary
-      var rowBytes = (width * numComps * bpc + 7) >> 3;
-      var imgArray = this.getImageBytes(height * rowBytes);
+      const rowBytes = (width * numComps * bpc + 7) >> 3;
+      const imgArray = this.getImageBytes(height * rowBytes);
 
-      var comps = this.getComponents(imgArray);
-      var i, length;
+      const comps = this.getComponents(imgArray);
+      let i, length;
 
       if (bpc === 1) {
         // inline decoding (= inversion) for 1 bpc images
@@ -824,7 +824,7 @@ var PDFImage = (function PDFImageClosure() {
       }
       length = width * height;
       // we aren't using a colorspace so we need to scale the value
-      var scale = 255 / ((1 << bpc) - 1);
+      const scale = 255 / ((1 << bpc) - 1);
       for (i = 0; i < length; ++i) {
         buffer[i] = scale * comps[i];
       }

--- a/src/core/image_utils.js
+++ b/src/core/image_utils.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 import { ColorSpace } from "./colorspace.js";
 import { JpegStream } from "./jpeg_stream.js";

--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -24,7 +24,7 @@ class Jbig2Error extends BaseException {
   }
 }
 
-var Jbig2Image = (function Jbig2ImageClosure() {
+const Jbig2Image = (function Jbig2ImageClosure() {
   // Utility data structures
   function ContextCache() {}
 
@@ -45,11 +45,11 @@ var Jbig2Image = (function Jbig2ImageClosure() {
 
   DecodingContext.prototype = {
     get decoder() {
-      var decoder = new ArithmeticDecoder(this.data, this.start, this.end);
+      const decoder = new ArithmeticDecoder(this.data, this.start, this.end);
       return shadow(this, "decoder", decoder);
     },
     get contextCache() {
-      var cache = new ContextCache();
+      const cache = new ContextCache();
       return shadow(this, "contextCache", cache);
     },
   };
@@ -57,13 +57,13 @@ var Jbig2Image = (function Jbig2ImageClosure() {
   // Annex A. Arithmetic Integer Decoding Procedure
   // A.2 Procedure for decoding values
   function decodeInteger(contextCache, procedure, decoder) {
-    var contexts = contextCache.getContexts(procedure);
-    var prev = 1;
+    const contexts = contextCache.getContexts(procedure);
+    let prev = 1;
 
     function readBits(length) {
-      var v = 0;
-      for (var i = 0; i < length; i++) {
-        var bit = decoder.readBit(contexts, prev);
+      let v = 0;
+      for (let i = 0; i < length; i++) {
+        const bit = decoder.readBit(contexts, prev);
         prev =
           prev < 256 ? (prev << 1) | bit : (((prev << 1) | bit) & 511) | 256;
         v = (v << 1) | bit;
@@ -71,10 +71,10 @@ var Jbig2Image = (function Jbig2ImageClosure() {
       return v >>> 0;
     }
 
-    var sign = readBits(1);
+    const sign = readBits(1);
     // prettier-ignore
     /* eslint-disable no-nested-ternary */
-    var value = readBits(1) ?
+    const value = readBits(1) ?
                   (readBits(1) ?
                     (readBits(1) ?
                       (readBits(1) ?
@@ -96,11 +96,11 @@ var Jbig2Image = (function Jbig2ImageClosure() {
 
   // A.3 The IAID decoding procedure
   function decodeIAID(contextCache, decoder, codeLength) {
-    var contexts = contextCache.getContexts("IAID");
+    const contexts = contextCache.getContexts("IAID");
 
-    var prev = 1;
-    for (var i = 0; i < codeLength; i++) {
-      var bit = decoder.readBit(contexts, prev);
+    let prev = 1;
+    for (let i = 0; i < codeLength; i++) {
+      const bit = decoder.readBit(contexts, prev);
       prev = (prev << 1) | bit;
     }
     if (codeLength < 31) {
@@ -110,7 +110,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
   }
 
   // 7.3 Segment types
-  var SegmentTypes = [
+  const SegmentTypes = [
     "SymbolDictionary",
     null,
     null,
@@ -176,7 +176,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     "Extension",
   ];
 
-  var CodingTemplates = [
+  const CodingTemplates = [
     [
       { x: -1, y: -2 },
       { x: 0, y: -2 },
@@ -229,7 +229,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     ],
   ];
 
-  var RefinementTemplates = [
+  const RefinementTemplates = [
     {
       coding: [
         { x: 0, y: -1 },
@@ -266,22 +266,22 @@ var Jbig2Image = (function Jbig2ImageClosure() {
   ];
 
   // See 6.2.5.7 Decoding the bitmap.
-  var ReusedContexts = [
+  const ReusedContexts = [
     0x9b25, // 10011 0110010 0101
     0x0795, // 0011 110010 101
     0x00e5, // 001 11001 01
     0x0195, // 011001 0101
   ];
 
-  var RefinementReusedContexts = [
+  const RefinementReusedContexts = [
     0x0020, // '000' + '0' (coding) + '00010000' + '0' (reference)
     0x0008, // '0000' + '001000'
   ];
 
   function decodeBitmapTemplate0(width, height, decodingContext) {
-    var decoder = decodingContext.decoder;
-    var contexts = decodingContext.contextCache.getContexts("GB");
-    var contextLabel,
+    const decoder = decodingContext.decoder;
+    const contexts = decodingContext.contextCache.getContexts("GB");
+    let contextLabel,
       i,
       j,
       pixel,
@@ -293,7 +293,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     // ...ooooo....
     // ..ooooooo... Context template for current pixel (X)
     // .ooooX...... (concatenate values of 'o'-pixels to get contextLabel)
-    var OLD_PIXEL_MASK = 0x7bf7; // 01111 0111111 0111
+    const OLD_PIXEL_MASK = 0x7bf7; // 01111 0111111 0111
 
     for (i = 0; i < height; i++) {
       row = bitmap[i] = new Uint8Array(width);
@@ -365,8 +365,8 @@ var Jbig2Image = (function Jbig2ImageClosure() {
       return decodeBitmapTemplate0(width, height, decodingContext);
     }
 
-    var useskip = !!skip;
-    var template = CodingTemplates[templateIndex].concat(at);
+    const useskip = !!skip;
+    const template = CodingTemplates[templateIndex].concat(at);
 
     // Sorting is non-standard, and it is not required. But sorting increases
     // the number of template bits that can be reused from the previous
@@ -375,15 +375,15 @@ var Jbig2Image = (function Jbig2ImageClosure() {
       return a.y - b.y || a.x - b.x;
     });
 
-    var templateLength = template.length;
-    var templateX = new Int8Array(templateLength);
-    var templateY = new Int8Array(templateLength);
-    var changingTemplateEntries = [];
-    var reuseMask = 0,
+    const templateLength = template.length;
+    const templateX = new Int8Array(templateLength);
+    const templateY = new Int8Array(templateLength);
+    const changingTemplateEntries = [];
+    let reuseMask = 0,
       minX = 0,
       maxX = 0,
       minY = 0;
-    var c, k;
+    let c, k;
 
     for (k = 0; k < templateLength; k++) {
       templateX[k] = template[k].x;
@@ -404,11 +404,11 @@ var Jbig2Image = (function Jbig2ImageClosure() {
         changingTemplateEntries.push(k);
       }
     }
-    var changingEntriesLength = changingTemplateEntries.length;
+    const changingEntriesLength = changingTemplateEntries.length;
 
-    var changingTemplateX = new Int8Array(changingEntriesLength);
-    var changingTemplateY = new Int8Array(changingEntriesLength);
-    var changingTemplateBit = new Uint16Array(changingEntriesLength);
+    const changingTemplateX = new Int8Array(changingEntriesLength);
+    const changingTemplateY = new Int8Array(changingEntriesLength);
+    const changingTemplateBit = new Uint16Array(changingEntriesLength);
     for (c = 0; c < changingEntriesLength; c++) {
       k = changingTemplateEntries[c];
       changingTemplateX[c] = template[k].x;
@@ -417,27 +417,27 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     }
 
     // Get the safe bounding box edges from the width, height, minX, maxX, minY
-    var sbb_left = -minX;
-    var sbb_top = -minY;
-    var sbb_right = width - maxX;
+    const sbb_left = -minX;
+    const sbb_top = -minY;
+    const sbb_right = width - maxX;
 
-    var pseudoPixelContext = ReusedContexts[templateIndex];
-    var row = new Uint8Array(width);
-    var bitmap = [];
+    const pseudoPixelContext = ReusedContexts[templateIndex];
+    let row = new Uint8Array(width);
+    const bitmap = [];
 
-    var decoder = decodingContext.decoder;
-    var contexts = decodingContext.contextCache.getContexts("GB");
+    const decoder = decodingContext.decoder;
+    const contexts = decodingContext.contextCache.getContexts("GB");
 
-    var ltp = 0,
+    let ltp = 0,
       j,
       i0,
       j0,
       contextLabel = 0,
       bit,
       shift;
-    for (var i = 0; i < height; i++) {
+    for (let i = 0; i < height; i++) {
       if (prediction) {
-        var sltp = decoder.readBit(contexts, pseudoPixelContext);
+        const sltp = decoder.readBit(contexts, pseudoPixelContext);
         ltp ^= sltp;
         if (ltp) {
           bitmap.push(row); // duplicate previous row
@@ -483,7 +483,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
             }
           }
         }
-        var pixel = decoder.readBit(contexts, contextLabel);
+        const pixel = decoder.readBit(contexts, contextLabel);
         row[j] = pixel;
       }
     }
@@ -502,53 +502,53 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     at,
     decodingContext
   ) {
-    var codingTemplate = RefinementTemplates[templateIndex].coding;
+    let codingTemplate = RefinementTemplates[templateIndex].coding;
     if (templateIndex === 0) {
       codingTemplate = codingTemplate.concat([at[0]]);
     }
-    var codingTemplateLength = codingTemplate.length;
-    var codingTemplateX = new Int32Array(codingTemplateLength);
-    var codingTemplateY = new Int32Array(codingTemplateLength);
-    var k;
+    const codingTemplateLength = codingTemplate.length;
+    const codingTemplateX = new Int32Array(codingTemplateLength);
+    const codingTemplateY = new Int32Array(codingTemplateLength);
+    let k;
     for (k = 0; k < codingTemplateLength; k++) {
       codingTemplateX[k] = codingTemplate[k].x;
       codingTemplateY[k] = codingTemplate[k].y;
     }
 
-    var referenceTemplate = RefinementTemplates[templateIndex].reference;
+    let referenceTemplate = RefinementTemplates[templateIndex].reference;
     if (templateIndex === 0) {
       referenceTemplate = referenceTemplate.concat([at[1]]);
     }
-    var referenceTemplateLength = referenceTemplate.length;
-    var referenceTemplateX = new Int32Array(referenceTemplateLength);
-    var referenceTemplateY = new Int32Array(referenceTemplateLength);
+    const referenceTemplateLength = referenceTemplate.length;
+    const referenceTemplateX = new Int32Array(referenceTemplateLength);
+    const referenceTemplateY = new Int32Array(referenceTemplateLength);
     for (k = 0; k < referenceTemplateLength; k++) {
       referenceTemplateX[k] = referenceTemplate[k].x;
       referenceTemplateY[k] = referenceTemplate[k].y;
     }
-    var referenceWidth = referenceBitmap[0].length;
-    var referenceHeight = referenceBitmap.length;
+    const referenceWidth = referenceBitmap[0].length;
+    const referenceHeight = referenceBitmap.length;
 
-    var pseudoPixelContext = RefinementReusedContexts[templateIndex];
-    var bitmap = [];
+    const pseudoPixelContext = RefinementReusedContexts[templateIndex];
+    const bitmap = [];
 
-    var decoder = decodingContext.decoder;
-    var contexts = decodingContext.contextCache.getContexts("GR");
+    const decoder = decodingContext.decoder;
+    const contexts = decodingContext.contextCache.getContexts("GR");
 
-    var ltp = 0;
-    for (var i = 0; i < height; i++) {
+    let ltp = 0;
+    for (let i = 0; i < height; i++) {
       if (prediction) {
-        var sltp = decoder.readBit(contexts, pseudoPixelContext);
+        const sltp = decoder.readBit(contexts, pseudoPixelContext);
         ltp ^= sltp;
         if (ltp) {
           throw new Jbig2Error("prediction is not supported");
         }
       }
-      var row = new Uint8Array(width);
+      const row = new Uint8Array(width);
       bitmap.push(row);
-      for (var j = 0; j < width; j++) {
+      for (let j = 0; j < width; j++) {
         var i0, j0;
-        var contextLabel = 0;
+        let contextLabel = 0;
         for (k = 0; k < codingTemplateLength; k++) {
           i0 = i + codingTemplateY[k];
           j0 = j + codingTemplateX[k];
@@ -572,7 +572,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
             contextLabel = (contextLabel << 1) | referenceBitmap[i0][j0];
           }
         }
-        var pixel = decoder.readBit(contexts, contextLabel);
+        const pixel = decoder.readBit(contexts, contextLabel);
         row[j] = pixel;
       }
     }
@@ -599,12 +599,12 @@ var Jbig2Image = (function Jbig2ImageClosure() {
       throw new Jbig2Error("symbol refinement with Huffman is not supported");
     }
 
-    var newSymbols = [];
-    var currentHeight = 0;
-    var symbolCodeLength = log2(symbols.length + numberOfNewSymbols);
+    const newSymbols = [];
+    let currentHeight = 0;
+    let symbolCodeLength = log2(symbols.length + numberOfNewSymbols);
 
-    var decoder = decodingContext.decoder;
-    var contextCache = decodingContext.contextCache;
+    const decoder = decodingContext.decoder;
+    const contextCache = decodingContext.contextCache;
     let tableB1, symbolWidths;
     if (huffman) {
       tableB1 = getStandardTable(1); // standard table B.1
@@ -613,7 +613,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     }
 
     while (newSymbols.length < numberOfNewSymbols) {
-      var deltaHeight = huffman
+      const deltaHeight = huffman
         ? huffmanTables.tableDeltaHeight.decode(huffmanInput)
         : decodeInteger(contextCache, "IADH", decoder); // 6.5.6
       currentHeight += deltaHeight;
@@ -621,7 +621,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
         totalWidth = 0;
       const firstSymbol = huffman ? symbolWidths.length : 0;
       while (true) {
-        var deltaWidth = huffman
+        const deltaWidth = huffman
           ? huffmanTables.tableDeltaWidth.decode(huffmanInput)
           : decodeInteger(contextCache, "IADW", decoder); // 6.5.7
         if (deltaWidth === null) {
@@ -632,7 +632,11 @@ var Jbig2Image = (function Jbig2ImageClosure() {
         var bitmap;
         if (refinement) {
           // 6.5.8.2 Refinement/aggregate-coded symbol bitmap
-          var numberOfInstances = decodeInteger(contextCache, "IAAI", decoder);
+          const numberOfInstances = decodeInteger(
+            contextCache,
+            "IAAI",
+            decoder
+          );
           if (numberOfInstances > 1) {
             bitmap = decodeTextRegion(
               huffman,
@@ -656,10 +660,14 @@ var Jbig2Image = (function Jbig2ImageClosure() {
               huffmanInput
             );
           } else {
-            var symbolId = decodeIAID(contextCache, decoder, symbolCodeLength);
-            var rdx = decodeInteger(contextCache, "IARDX", decoder); // 6.4.11.3
-            var rdy = decodeInteger(contextCache, "IARDY", decoder); // 6.4.11.4
-            var symbol =
+            const symbolId = decodeIAID(
+              contextCache,
+              decoder,
+              symbolCodeLength
+            );
+            const rdx = decodeInteger(contextCache, "IARDX", decoder); // 6.4.11.3
+            const rdy = decodeInteger(contextCache, "IARDY", decoder); // 6.4.11.4
+            const symbol =
               symbolId < symbols.length
                 ? symbols[symbolId]
                 : newSymbols[symbolId - symbols.length];
@@ -748,12 +756,12 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     }
 
     // 6.5.10 Exported symbols
-    var exportedSymbols = [];
-    var flags = [],
+    const exportedSymbols = [];
+    let flags = [],
       currentFlag = false;
-    var totalSymbolsLength = symbols.length + numberOfNewSymbols;
+    const totalSymbolsLength = symbols.length + numberOfNewSymbols;
     while (flags.length < totalSymbolsLength) {
-      var runLength = huffman
+      let runLength = huffman
         ? tableB1.decode(huffmanInput)
         : decodeInteger(contextCache, "IAEX", decoder);
       while (runLength--) {
@@ -766,7 +774,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
         exportedSymbols.push(symbols[i]);
       }
     }
-    for (var j = 0; j < numberOfNewSymbols; i++, j++) {
+    for (let j = 0; j < numberOfNewSymbols; i++, j++) {
       if (flags[i]) {
         exportedSymbols.push(newSymbols[j]);
       }
@@ -800,37 +808,37 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     }
 
     // Prepare bitmap
-    var bitmap = [];
-    var i, row;
+    const bitmap = [];
+    let i, row;
     for (i = 0; i < height; i++) {
       row = new Uint8Array(width);
       if (defaultPixelValue) {
-        for (var j = 0; j < width; j++) {
+        for (let j = 0; j < width; j++) {
           row[j] = defaultPixelValue;
         }
       }
       bitmap.push(row);
     }
 
-    var decoder = decodingContext.decoder;
-    var contextCache = decodingContext.contextCache;
+    const decoder = decodingContext.decoder;
+    const contextCache = decodingContext.contextCache;
 
-    var stripT = huffman
+    let stripT = huffman
       ? -huffmanTables.tableDeltaT.decode(huffmanInput)
       : -decodeInteger(contextCache, "IADT", decoder); // 6.4.6
-    var firstS = 0;
+    let firstS = 0;
     i = 0;
     while (i < numberOfSymbolInstances) {
-      var deltaT = huffman
+      const deltaT = huffman
         ? huffmanTables.tableDeltaT.decode(huffmanInput)
         : decodeInteger(contextCache, "IADT", decoder); // 6.4.6
       stripT += deltaT;
 
-      var deltaFirstS = huffman
+      const deltaFirstS = huffman
         ? huffmanTables.tableFirstS.decode(huffmanInput)
         : decodeInteger(contextCache, "IAFS", decoder); // 6.4.7
       firstS += deltaFirstS;
-      var currentS = firstS;
+      let currentS = firstS;
       do {
         let currentT = 0; // 6.4.9
         if (stripSize > 1) {
@@ -838,23 +846,23 @@ var Jbig2Image = (function Jbig2ImageClosure() {
             ? huffmanInput.readBits(logStripSize)
             : decodeInteger(contextCache, "IAIT", decoder);
         }
-        var t = stripSize * stripT + currentT;
-        var symbolId = huffman
+        const t = stripSize * stripT + currentT;
+        const symbolId = huffman
           ? huffmanTables.symbolIDTable.decode(huffmanInput)
           : decodeIAID(contextCache, decoder, symbolCodeLength);
-        var applyRefinement =
+        const applyRefinement =
           refinement &&
           (huffman
             ? huffmanInput.readBit()
             : decodeInteger(contextCache, "IARI", decoder));
-        var symbolBitmap = inputSymbols[symbolId];
-        var symbolWidth = symbolBitmap[0].length;
-        var symbolHeight = symbolBitmap.length;
+        let symbolBitmap = inputSymbols[symbolId];
+        let symbolWidth = symbolBitmap[0].length;
+        let symbolHeight = symbolBitmap.length;
         if (applyRefinement) {
-          var rdw = decodeInteger(contextCache, "IARDW", decoder); // 6.4.11.1
-          var rdh = decodeInteger(contextCache, "IARDH", decoder); // 6.4.11.2
-          var rdx = decodeInteger(contextCache, "IARDX", decoder); // 6.4.11.3
-          var rdy = decodeInteger(contextCache, "IARDY", decoder); // 6.4.11.4
+          const rdw = decodeInteger(contextCache, "IARDW", decoder); // 6.4.11.1
+          const rdh = decodeInteger(contextCache, "IARDH", decoder); // 6.4.11.2
+          const rdx = decodeInteger(contextCache, "IARDX", decoder); // 6.4.11.3
+          const rdy = decodeInteger(contextCache, "IARDY", decoder); // 6.4.11.4
           symbolWidth += rdw;
           symbolHeight += rdh;
           symbolBitmap = decodeRefinement(
@@ -869,8 +877,8 @@ var Jbig2Image = (function Jbig2ImageClosure() {
             decodingContext
           );
         }
-        var offsetT = t - (referenceCorner & 1 ? 0 : symbolHeight - 1);
-        var offsetS = currentS - (referenceCorner & 2 ? symbolWidth - 1 : 0);
+        const offsetT = t - (referenceCorner & 1 ? 0 : symbolHeight - 1);
+        const offsetS = currentS - (referenceCorner & 2 ? symbolWidth - 1 : 0);
         var s2, t2, symbolRow;
         if (transposed) {
           // Place Symbol Bitmap from T1,S1
@@ -882,7 +890,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
             symbolRow = symbolBitmap[s2];
             // To ignore Parts of Symbol bitmap which goes
             // outside bitmap region
-            var maxWidth = Math.min(width - offsetT, symbolWidth);
+            const maxWidth = Math.min(width - offsetT, symbolWidth);
             switch (combinationOperator) {
               case 0: // OR
                 for (t2 = 0; t2 < maxWidth; t2++) {
@@ -928,7 +936,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
           currentS += symbolWidth - 1;
         }
         i++;
-        var deltaS = huffman
+        const deltaS = huffman
           ? huffmanTables.tableDeltaS.decode(huffmanInput)
           : decodeInteger(contextCache, "IADS", decoder); // 6.4.8
         if (deltaS === null) {
@@ -1141,10 +1149,10 @@ var Jbig2Image = (function Jbig2ImageClosure() {
   }
 
   function readSegmentHeader(data, start) {
-    var segmentHeader = {};
+    const segmentHeader = {};
     segmentHeader.number = readUint32(data, start);
-    var flags = data[start + 4];
-    var segmentType = flags & 0x3f;
+    const flags = data[start + 4];
+    const segmentType = flags & 0x3f;
     if (!SegmentTypes[segmentType]) {
       throw new Jbig2Error("invalid segment type: " + segmentType);
     }
@@ -1152,15 +1160,15 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     segmentHeader.typeName = SegmentTypes[segmentType];
     segmentHeader.deferredNonRetain = !!(flags & 0x80);
 
-    var pageAssociationFieldSize = !!(flags & 0x40);
-    var referredFlags = data[start + 5];
-    var referredToCount = (referredFlags >> 5) & 7;
-    var retainBits = [referredFlags & 31];
-    var position = start + 6;
+    const pageAssociationFieldSize = !!(flags & 0x40);
+    const referredFlags = data[start + 5];
+    let referredToCount = (referredFlags >> 5) & 7;
+    const retainBits = [referredFlags & 31];
+    let position = start + 6;
     if (referredFlags === 7) {
       referredToCount = readUint32(data, position - 1) & 0x1fffffff;
       position += 3;
-      var bytes = (referredToCount + 7) >> 3;
+      let bytes = (referredToCount + 7) >> 3;
       retainBits[0] = data[position++];
       while (--bytes > 0) {
         retainBits.push(data[position++]);
@@ -1177,8 +1185,8 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     } else if (segmentHeader.number <= 65536) {
       referredToSegmentNumberSize = 2;
     }
-    var referredTo = [];
-    var i, ii;
+    const referredTo = [];
+    let i, ii;
     for (i = 0; i < referredToCount; i++) {
       let number;
       if (referredToSegmentNumberSize === 1) {
@@ -1205,13 +1213,13 @@ var Jbig2Image = (function Jbig2ImageClosure() {
       // 7.2.7 Segment data length, unknown segment length
       if (segmentType === 38) {
         // ImmediateGenericRegion
-        var genericRegionInfo = readRegionSegmentInformation(data, position);
-        var genericRegionSegmentFlags =
+        const genericRegionInfo = readRegionSegmentInformation(data, position);
+        const genericRegionSegmentFlags =
           data[position + RegionSegmentInformationFieldLength];
-        var genericRegionMmr = !!(genericRegionSegmentFlags & 1);
+        const genericRegionMmr = !!(genericRegionSegmentFlags & 1);
         // searching for the segment end
-        var searchPatternLength = 6;
-        var searchPattern = new Uint8Array(searchPatternLength);
+        const searchPatternLength = 6;
+        const searchPattern = new Uint8Array(searchPatternLength);
         if (!genericRegionMmr) {
           searchPattern[0] = 0xff;
           searchPattern[1] = 0xac;
@@ -1221,7 +1229,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
         searchPattern[4] = (genericRegionInfo.height >> 8) & 0xff;
         searchPattern[5] = genericRegionInfo.height & 0xff;
         for (i = position, ii = data.length; i < ii; i++) {
-          var j = 0;
+          let j = 0;
           while (j < searchPatternLength && searchPattern[j] === data[i + j]) {
             j++;
           }
@@ -1242,12 +1250,12 @@ var Jbig2Image = (function Jbig2ImageClosure() {
   }
 
   function readSegments(header, data, start, end) {
-    var segments = [];
-    var position = start;
+    const segments = [];
+    let position = start;
     while (position < end) {
-      var segmentHeader = readSegmentHeader(data, position);
+      const segmentHeader = readSegmentHeader(data, position);
       position = segmentHeader.headerEnd;
-      var segment = {
+      const segment = {
         header: segmentHeader,
         data,
       };
@@ -1262,7 +1270,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
       }
     }
     if (header.randomAccess) {
-      for (var i = 0, ii = segments.length; i < ii; i++) {
+      for (let i = 0, ii = segments.length; i < ii; i++) {
         segments[i].start = position;
         position += segments[i].header.length;
         segments[i].end = position;
@@ -1284,12 +1292,12 @@ var Jbig2Image = (function Jbig2ImageClosure() {
   var RegionSegmentInformationFieldLength = 17;
 
   function processSegment(segment, visitor) {
-    var header = segment.header;
+    const header = segment.header;
 
-    var data = segment.data,
+    let data = segment.data,
       position = segment.start,
       end = segment.end;
-    var args, at, i, atLength;
+    let args, at, i, atLength;
     switch (header.type) {
       case 0: // SymbolDictionary
         // 7.4.2 Symbol dictionary segment syntax
@@ -1360,7 +1368,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
         textRegion.dsOffset = (textRegionSegmentFlags << 17) >> 27;
         textRegion.refinementTemplate = (textRegionSegmentFlags >> 15) & 1;
         if (textRegion.huffman) {
-          var textRegionHuffmanFlags = readUint16(data, position);
+          const textRegionHuffmanFlags = readUint16(data, position);
           position += 2;
           textRegion.huffmanFS = textRegionHuffmanFlags & 3;
           textRegion.huffmanDS = (textRegionHuffmanFlags >> 2) & 3;
@@ -1487,23 +1495,23 @@ var Jbig2Image = (function Jbig2ImageClosure() {
             " is not implemented"
         );
     }
-    var callbackName = "on" + header.typeName;
+    const callbackName = "on" + header.typeName;
     if (callbackName in visitor) {
       visitor[callbackName].apply(visitor, args);
     }
   }
 
   function processSegments(segments, visitor) {
-    for (var i = 0, ii = segments.length; i < ii; i++) {
+    for (let i = 0, ii = segments.length; i < ii; i++) {
       processSegment(segments[i], visitor);
     }
   }
 
   function parseJbig2Chunks(chunks) {
-    var visitor = new SimpleSegmentVisitor();
-    for (var i = 0, ii = chunks.length; i < ii; i++) {
-      var chunk = chunks[i];
-      var segments = readSegments({}, chunk.data, chunk.start, chunk.end);
+    const visitor = new SimpleSegmentVisitor();
+    for (let i = 0, ii = chunks.length; i < ii; i++) {
+      const chunk = chunks[i];
+      const segments = readSegments({}, chunk.data, chunk.start, chunk.end);
       processSegments(segments, visitor);
     }
     return visitor.buffer;
@@ -1565,29 +1573,29 @@ var Jbig2Image = (function Jbig2ImageClosure() {
   SimpleSegmentVisitor.prototype = {
     onPageInformation: function SimpleSegmentVisitor_onPageInformation(info) {
       this.currentPageInfo = info;
-      var rowSize = (info.width + 7) >> 3;
-      var buffer = new Uint8ClampedArray(rowSize * info.height);
+      const rowSize = (info.width + 7) >> 3;
+      const buffer = new Uint8ClampedArray(rowSize * info.height);
       // The contents of ArrayBuffers are initialized to 0.
       // Fill the buffer with 0xFF only if info.defaultPixelValue is set
       if (info.defaultPixelValue) {
-        for (var i = 0, ii = buffer.length; i < ii; i++) {
+        for (let i = 0, ii = buffer.length; i < ii; i++) {
           buffer[i] = 0xff;
         }
       }
       this.buffer = buffer;
     },
     drawBitmap: function SimpleSegmentVisitor_drawBitmap(regionInfo, bitmap) {
-      var pageInfo = this.currentPageInfo;
-      var width = regionInfo.width,
+      const pageInfo = this.currentPageInfo;
+      const width = regionInfo.width,
         height = regionInfo.height;
-      var rowSize = (pageInfo.width + 7) >> 3;
-      var combinationOperator = pageInfo.combinationOperatorOverride
+      const rowSize = (pageInfo.width + 7) >> 3;
+      const combinationOperator = pageInfo.combinationOperatorOverride
         ? regionInfo.combinationOperator
         : pageInfo.combinationOperator;
-      var buffer = this.buffer;
-      var mask0 = 128 >> (regionInfo.x & 7);
-      var offset0 = regionInfo.y * rowSize + (regionInfo.x >> 3);
-      var i, j, mask, offset;
+      const buffer = this.buffer;
+      const mask0 = 128 >> (regionInfo.x & 7);
+      let offset0 = regionInfo.y * rowSize + (regionInfo.x >> 3);
+      let i, j, mask, offset;
       switch (combinationOperator) {
         case 0: // OR
           for (i = 0; i < height; i++) {
@@ -1635,9 +1643,9 @@ var Jbig2Image = (function Jbig2ImageClosure() {
       start,
       end
     ) {
-      var regionInfo = region.info;
-      var decodingContext = new DecodingContext(data, start, end);
-      var bitmap = decodeBitmap(
+      const regionInfo = region.info;
+      const decodingContext = new DecodingContext(data, start, end);
+      const bitmap = decodeBitmap(
         region.mmr,
         regionInfo.width,
         regionInfo.height,
@@ -1671,13 +1679,13 @@ var Jbig2Image = (function Jbig2ImageClosure() {
       }
 
       // Combines exported symbols from all referred segments
-      var symbols = this.symbols;
+      let symbols = this.symbols;
       if (!symbols) {
         this.symbols = symbols = {};
       }
 
-      var inputSymbols = [];
-      for (var i = 0, ii = referredSegments.length; i < ii; i++) {
+      let inputSymbols = [];
+      for (let i = 0, ii = referredSegments.length; i < ii; i++) {
         const referredSymbols = symbols[referredSegments[i]];
         // referredSymbols is undefined when we have a reference to a Tables
         // segment instead of a SymbolDictionary.
@@ -1686,7 +1694,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
         }
       }
 
-      var decodingContext = new DecodingContext(data, start, end);
+      const decodingContext = new DecodingContext(data, start, end);
       symbols[currentSegment] = decodeSymbolDictionary(
         dictionary.huffman,
         dictionary.refinement,
@@ -1709,13 +1717,13 @@ var Jbig2Image = (function Jbig2ImageClosure() {
       start,
       end
     ) {
-      var regionInfo = region.info;
+      const regionInfo = region.info;
       let huffmanTables, huffmanInput;
 
       // Combines exported symbols from all referred segments
-      var symbols = this.symbols;
-      var inputSymbols = [];
-      for (var i = 0, ii = referredSegments.length; i < ii; i++) {
+      const symbols = this.symbols;
+      let inputSymbols = [];
+      for (let i = 0, ii = referredSegments.length; i < ii; i++) {
         const referredSymbols = symbols[referredSegments[i]];
         // referredSymbols is undefined when we have a reference to a Tables
         // segment instead of a SymbolDictionary.
@@ -1723,7 +1731,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
           inputSymbols = inputSymbols.concat(referredSymbols);
         }
       }
-      var symbolCodeLength = log2(inputSymbols.length);
+      const symbolCodeLength = log2(inputSymbols.length);
       if (region.huffman) {
         huffmanInput = new Reader(data, start, end);
         huffmanTables = getTextRegionHuffmanTables(
@@ -1735,8 +1743,8 @@ var Jbig2Image = (function Jbig2ImageClosure() {
         );
       }
 
-      var decodingContext = new DecodingContext(data, start, end);
-      var bitmap = decodeTextRegion(
+      const decodingContext = new DecodingContext(data, start, end);
+      const bitmap = decodeTextRegion(
         region.huffman,
         region.refinement,
         regionInfo.width,

--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -44,9 +44,9 @@ class EOIMarkerError extends BaseException {}
  *   (partners.adobe.com/public/developer/en/ps/sdk/5116.DCT_Filter.pdf)
  */
 
-var JpegImage = (function JpegImageClosure() {
+const JpegImage = (function JpegImageClosure() {
   // prettier-ignore
-  var dctZigZag = new Uint8Array([
+  const dctZigZag = new Uint8Array([
      0,
      1,  8,
     16,  9,  2,
@@ -64,14 +64,14 @@ var JpegImage = (function JpegImageClosure() {
     63
   ]);
 
-  var dctCos1 = 4017; // cos(pi/16)
-  var dctSin1 = 799; // sin(pi/16)
-  var dctCos3 = 3406; // cos(3*pi/16)
-  var dctSin3 = 2276; // sin(3*pi/16)
-  var dctCos6 = 1567; // cos(6*pi/16)
-  var dctSin6 = 3784; // sin(6*pi/16)
-  var dctSqrt2 = 5793; // sqrt(2)
-  var dctSqrt1d2 = 2896; // sqrt(2) / 2
+  const dctCos1 = 4017; // cos(pi/16)
+  const dctSin1 = 799; // sin(pi/16)
+  const dctCos3 = 3406; // cos(3*pi/16)
+  const dctSin3 = 2276; // sin(3*pi/16)
+  const dctCos6 = 1567; // cos(6*pi/16)
+  const dctSin6 = 3784; // sin(6*pi/16)
+  const dctSqrt2 = 5793; // sqrt(2)
+  const dctSqrt1d2 = 2896; // sqrt(2) / 2
 
   function JpegImage({ decodeTransform = null, colorTransform = -1 } = {}) {
     this._decodeTransform = decodeTransform;
@@ -79,7 +79,7 @@ var JpegImage = (function JpegImageClosure() {
   }
 
   function buildHuffmanTable(codeLengths, values) {
-    var k = 0,
+    let k = 0,
       code = [],
       i,
       j,
@@ -88,7 +88,7 @@ var JpegImage = (function JpegImageClosure() {
       length--;
     }
     code.push({ children: [], index: 0 });
-    var p = code[0],
+    let p = code[0],
       q;
     for (i = 0; i < length; i++) {
       for (j = 0; j < codeLengths[i]; j++) {
@@ -132,10 +132,10 @@ var JpegImage = (function JpegImageClosure() {
     successive,
     parseDNLMarker = false
   ) {
-    var mcusPerLine = frame.mcusPerLine;
-    var progressive = frame.progressive;
+    const mcusPerLine = frame.mcusPerLine;
+    const progressive = frame.progressive;
 
-    var startOffset = offset,
+    let startOffset = offset,
       bitsData = 0,
       bitsCount = 0;
 
@@ -146,7 +146,7 @@ var JpegImage = (function JpegImageClosure() {
       }
       bitsData = data[offset++];
       if (bitsData === 0xff) {
-        var nextByte = data[offset++];
+        const nextByte = data[offset++];
         if (nextByte) {
           if (nextByte === 0xdc && parseDNLMarker) {
             offset += 2; // Skip marker length.
@@ -175,7 +175,7 @@ var JpegImage = (function JpegImageClosure() {
     }
 
     function decodeHuffman(tree) {
-      var node = tree;
+      let node = tree;
       while (true) {
         node = node[readBit()];
         switch (typeof node) {
@@ -189,7 +189,7 @@ var JpegImage = (function JpegImageClosure() {
     }
 
     function receive(length) {
-      var n = 0;
+      let n = 0;
       while (length > 0) {
         n = (n << 1) | readBit();
         length--;
@@ -201,7 +201,7 @@ var JpegImage = (function JpegImageClosure() {
       if (length === 1) {
         return readBit() === 1 ? 1 : -1;
       }
-      var n = receive(length);
+      const n = receive(length);
       if (n >= 1 << (length - 1)) {
         return n;
       }
@@ -209,13 +209,13 @@ var JpegImage = (function JpegImageClosure() {
     }
 
     function decodeBaseline(component, offset) {
-      var t = decodeHuffman(component.huffmanTableDC);
-      var diff = t === 0 ? 0 : receiveAndExtend(t);
+      const t = decodeHuffman(component.huffmanTableDC);
+      const diff = t === 0 ? 0 : receiveAndExtend(t);
       component.blockData[offset] = component.pred += diff;
-      var k = 1;
+      let k = 1;
       while (k < 64) {
-        var rs = decodeHuffman(component.huffmanTableAC);
-        var s = rs & 15,
+        const rs = decodeHuffman(component.huffmanTableAC);
+        const s = rs & 15,
           r = rs >> 4;
         if (s === 0) {
           if (r < 15) {
@@ -225,15 +225,15 @@ var JpegImage = (function JpegImageClosure() {
           continue;
         }
         k += r;
-        var z = dctZigZag[k];
+        const z = dctZigZag[k];
         component.blockData[offset + z] = receiveAndExtend(s);
         k++;
       }
     }
 
     function decodeDCFirst(component, offset) {
-      var t = decodeHuffman(component.huffmanTableDC);
-      var diff = t === 0 ? 0 : receiveAndExtend(t) << successive;
+      const t = decodeHuffman(component.huffmanTableDC);
+      const diff = t === 0 ? 0 : receiveAndExtend(t) << successive;
       component.blockData[offset] = component.pred += diff;
     }
 
@@ -241,17 +241,17 @@ var JpegImage = (function JpegImageClosure() {
       component.blockData[offset] |= readBit() << successive;
     }
 
-    var eobrun = 0;
+    let eobrun = 0;
     function decodeACFirst(component, offset) {
       if (eobrun > 0) {
         eobrun--;
         return;
       }
-      var k = spectralStart,
+      let k = spectralStart,
         e = spectralEnd;
       while (k <= e) {
-        var rs = decodeHuffman(component.huffmanTableAC);
-        var s = rs & 15,
+        const rs = decodeHuffman(component.huffmanTableAC);
+        const s = rs & 15,
           r = rs >> 4;
         if (s === 0) {
           if (r < 15) {
@@ -262,21 +262,21 @@ var JpegImage = (function JpegImageClosure() {
           continue;
         }
         k += r;
-        var z = dctZigZag[k];
+        const z = dctZigZag[k];
         component.blockData[offset + z] =
           receiveAndExtend(s) * (1 << successive);
         k++;
       }
     }
 
-    var successiveACState = 0,
+    let successiveACState = 0,
       successiveACNextValue;
     function decodeACSuccessive(component, offset) {
-      var k = spectralStart;
-      var e = spectralEnd;
-      var r = 0;
-      var s;
-      var rs;
+      let k = spectralStart;
+      const e = spectralEnd;
+      let r = 0;
+      let s;
+      let rs;
       while (k <= e) {
         const offsetZ = offset + dctZigZag[k];
         const sign = component.blockData[offsetZ] < 0 ? -1 : 1;
@@ -338,24 +338,24 @@ var JpegImage = (function JpegImageClosure() {
     }
 
     function decodeMcu(component, decode, mcu, row, col) {
-      var mcuRow = (mcu / mcusPerLine) | 0;
-      var mcuCol = mcu % mcusPerLine;
-      var blockRow = mcuRow * component.v + row;
-      var blockCol = mcuCol * component.h + col;
-      var offset = getBlockBufferOffset(component, blockRow, blockCol);
+      const mcuRow = (mcu / mcusPerLine) | 0;
+      const mcuCol = mcu % mcusPerLine;
+      const blockRow = mcuRow * component.v + row;
+      const blockCol = mcuCol * component.h + col;
+      const offset = getBlockBufferOffset(component, blockRow, blockCol);
       decode(component, offset);
     }
 
     function decodeBlock(component, decode, mcu) {
-      var blockRow = (mcu / component.blocksPerLine) | 0;
-      var blockCol = mcu % component.blocksPerLine;
-      var offset = getBlockBufferOffset(component, blockRow, blockCol);
+      const blockRow = (mcu / component.blocksPerLine) | 0;
+      const blockCol = mcu % component.blocksPerLine;
+      const offset = getBlockBufferOffset(component, blockRow, blockCol);
       decode(component, offset);
     }
 
-    var componentsLength = components.length;
-    var component, i, j, k, n;
-    var decodeFn;
+    const componentsLength = components.length;
+    let component, i, j, k, n;
+    let decodeFn;
     if (progressive) {
       if (spectralStart === 0) {
         decodeFn = successivePrev === 0 ? decodeDCFirst : decodeDCSuccessive;
@@ -366,19 +366,19 @@ var JpegImage = (function JpegImageClosure() {
       decodeFn = decodeBaseline;
     }
 
-    var mcu = 0,
+    let mcu = 0,
       fileMarker;
-    var mcuExpected;
+    let mcuExpected;
     if (componentsLength === 1) {
       mcuExpected = components[0].blocksPerLine * components[0].blocksPerColumn;
     } else {
       mcuExpected = mcusPerLine * frame.mcusPerColumn;
     }
 
-    var h, v;
+    let h, v;
     while (mcu < mcuExpected) {
       // reset interval stuff
-      var mcuToRead = resetInterval
+      const mcuToRead = resetInterval
         ? Math.min(mcuExpected - mcu, resetInterval)
         : mcuExpected;
       for (i = 0; i < componentsLength; i++) {
@@ -423,7 +423,7 @@ var JpegImage = (function JpegImageClosure() {
         );
         offset = fileMarker.offset;
       }
-      var marker = fileMarker && fileMarker.marker;
+      const marker = fileMarker && fileMarker.marker;
       if (!marker || marker <= 0xff00) {
         throw new JpegError("decodeScan - a valid marker was not found.");
       }
@@ -456,18 +456,18 @@ var JpegImage = (function JpegImageClosure() {
   //   IEEE Intl. Conf. on Acoustics, Speech & Signal Processing, 1989,
   //   988-991.
   function quantizeAndInverse(component, blockBufferOffset, p) {
-    var qt = component.quantizationTable,
+    const qt = component.quantizationTable,
       blockData = component.blockData;
-    var v0, v1, v2, v3, v4, v5, v6, v7;
-    var p0, p1, p2, p3, p4, p5, p6, p7;
-    var t;
+    let v0, v1, v2, v3, v4, v5, v6, v7;
+    let p0, p1, p2, p3, p4, p5, p6, p7;
+    let t;
 
     if (!qt) {
       throw new JpegError("missing required Quantization Table.");
     }
 
     // inverse DCT on rows
-    for (var row = 0; row < 64; row += 8) {
+    for (let row = 0; row < 64; row += 8) {
       // gather block data
       p0 = blockData[blockBufferOffset + row];
       p1 = blockData[blockBufferOffset + row + 1];
@@ -548,7 +548,7 @@ var JpegImage = (function JpegImageClosure() {
     }
 
     // inverse DCT on columns
-    for (var col = 0; col < 8; ++col) {
+    for (let col = 0; col < 8; ++col) {
       p0 = p[col];
       p1 = p[col + 8];
       p2 = p[col + 16];
@@ -696,13 +696,13 @@ var JpegImage = (function JpegImageClosure() {
   }
 
   function buildComponentData(frame, component) {
-    var blocksPerLine = component.blocksPerLine;
-    var blocksPerColumn = component.blocksPerColumn;
-    var computationBuffer = new Int16Array(64);
+    const blocksPerLine = component.blocksPerLine;
+    const blocksPerColumn = component.blocksPerColumn;
+    const computationBuffer = new Int16Array(64);
 
-    for (var blockRow = 0; blockRow < blocksPerColumn; blockRow++) {
-      for (var blockCol = 0; blockCol < blocksPerLine; blockCol++) {
-        var offset = getBlockBufferOffset(component, blockRow, blockCol);
+    for (let blockRow = 0; blockRow < blocksPerColumn; blockRow++) {
+      for (let blockCol = 0; blockCol < blocksPerLine; blockCol++) {
+        const offset = getBlockBufferOffset(component, blockRow, blockCol);
         quantizeAndInverse(component, offset, computationBuffer);
       }
     }
@@ -711,12 +711,12 @@ var JpegImage = (function JpegImageClosure() {
 
   function findNextFileMarker(data, currentPos, startPos = currentPos) {
     const maxPos = data.length - 1;
-    var newPos = startPos < currentPos ? startPos : currentPos;
+    let newPos = startPos < currentPos ? startPos : currentPos;
 
     if (currentPos >= maxPos) {
       return null; // Don't attempt to read non-existent data and just return.
     }
-    var currentMarker = readUint16(data, currentPos);
+    const currentMarker = readUint16(data, currentPos);
     if (currentMarker >= 0xffc0 && currentMarker <= 0xfffe) {
       return {
         invalid: null,
@@ -724,7 +724,7 @@ var JpegImage = (function JpegImageClosure() {
         offset: currentPos,
       };
     }
-    var newMarker = readUint16(data, newPos);
+    let newMarker = readUint16(data, newPos);
     while (!(newMarker >= 0xffc0 && newMarker <= 0xfffe)) {
       if (++newPos >= maxPos) {
         return null; // Don't attempt to read non-existent data and just return.
@@ -745,7 +745,7 @@ var JpegImage = (function JpegImageClosure() {
         offset += 2;
         let endOffset = offset + length - 2;
 
-        var fileMarker = findNextFileMarker(data, endOffset, offset);
+        const fileMarker = findNextFileMarker(data, endOffset, offset);
         if (fileMarker && fileMarker.invalid) {
           warn(
             "readDataBlock - incorrect length, current marker is: " +
@@ -754,26 +754,26 @@ var JpegImage = (function JpegImageClosure() {
           endOffset = fileMarker.offset;
         }
 
-        var array = data.subarray(offset, endOffset);
+        const array = data.subarray(offset, endOffset);
         offset += array.length;
         return array;
       }
 
       function prepareComponents(frame) {
-        var mcusPerLine = Math.ceil(frame.samplesPerLine / 8 / frame.maxH);
-        var mcusPerColumn = Math.ceil(frame.scanLines / 8 / frame.maxV);
-        for (var i = 0; i < frame.components.length; i++) {
+        const mcusPerLine = Math.ceil(frame.samplesPerLine / 8 / frame.maxH);
+        const mcusPerColumn = Math.ceil(frame.scanLines / 8 / frame.maxV);
+        for (let i = 0; i < frame.components.length; i++) {
           component = frame.components[i];
-          var blocksPerLine = Math.ceil(
+          const blocksPerLine = Math.ceil(
             (Math.ceil(frame.samplesPerLine / 8) * component.h) / frame.maxH
           );
-          var blocksPerColumn = Math.ceil(
+          const blocksPerColumn = Math.ceil(
             (Math.ceil(frame.scanLines / 8) * component.v) / frame.maxV
           );
-          var blocksPerLineForMcu = mcusPerLine * component.h;
-          var blocksPerColumnForMcu = mcusPerColumn * component.v;
+          const blocksPerLineForMcu = mcusPerLine * component.h;
+          const blocksPerColumnForMcu = mcusPerColumn * component.v;
 
-          var blocksBufferSize =
+          const blocksBufferSize =
             64 * blocksPerColumnForMcu * (blocksPerLineForMcu + 1);
           component.blockData = new Int16Array(blocksBufferSize);
           component.blocksPerLine = blocksPerLine;
@@ -784,12 +784,12 @@ var JpegImage = (function JpegImageClosure() {
       }
 
       var offset = 0;
-      var jfif = null;
-      var adobe = null;
-      var frame, resetInterval;
+      let jfif = null;
+      let adobe = null;
+      let frame, resetInterval;
       let numSOSMarkers = 0;
-      var quantizationTables = [];
-      var huffmanTablesAC = [],
+      const quantizationTables = [];
+      const huffmanTablesAC = [],
         huffmanTablesDC = [];
 
       let fileMarker = readUint16(data, offset);
@@ -871,8 +871,8 @@ var JpegImage = (function JpegImageClosure() {
             var quantizationTablesEnd = quantizationTablesLength + offset - 2;
             var z;
             while (offset < quantizationTablesEnd) {
-              var quantizationTableSpec = data[offset++];
-              var tableData = new Uint16Array(64);
+              const quantizationTableSpec = data[offset++];
+              const tableData = new Uint16Array(64);
               if (quantizationTableSpec >> 4 === 0) {
                 // 8 bit values
                 for (j = 0; j < 64; j++) {
@@ -918,15 +918,15 @@ var JpegImage = (function JpegImageClosure() {
               maxV = 0;
             for (i = 0; i < componentsCount; i++) {
               componentId = data[offset];
-              var h = data[offset + 1] >> 4;
-              var v = data[offset + 1] & 15;
+              const h = data[offset + 1] >> 4;
+              const v = data[offset + 1] & 15;
               if (maxH < h) {
                 maxH = h;
               }
               if (maxV < v) {
                 maxV = v;
               }
-              var qId = data[offset + 2];
+              const qId = data[offset + 2];
               l = frame.components.push({
                 h,
                 v,
@@ -945,13 +945,13 @@ var JpegImage = (function JpegImageClosure() {
             const huffmanLength = readUint16(data, offset);
             offset += 2;
             for (i = 2; i < huffmanLength; ) {
-              var huffmanTableSpec = data[offset++];
-              var codeLengths = new Uint8Array(16);
-              var codeLengthSum = 0;
+              const huffmanTableSpec = data[offset++];
+              const codeLengths = new Uint8Array(16);
+              let codeLengthSum = 0;
               for (j = 0; j < 16; j++, offset++) {
                 codeLengthSum += codeLengths[j] = data[offset];
               }
-              var huffmanValues = new Uint8Array(codeLengthSum);
+              const huffmanValues = new Uint8Array(codeLengthSum);
               for (j = 0; j < codeLengthSum; j++, offset++) {
                 huffmanValues[j] = data[offset];
               }
@@ -983,9 +983,9 @@ var JpegImage = (function JpegImageClosure() {
             var components = [],
               component;
             for (i = 0; i < selectorsCount; i++) {
-              var componentIndex = frame.componentIds[data[offset++]];
+              const componentIndex = frame.componentIds[data[offset++]];
               component = frame.components[componentIndex];
-              var tableSpec = data[offset++];
+              const tableSpec = data[offset++];
               component.huffmanTableDC = huffmanTablesDC[tableSpec >> 4];
               component.huffmanTableAC = huffmanTablesAC[tableSpec & 15];
               components.push(component);
@@ -994,7 +994,7 @@ var JpegImage = (function JpegImageClosure() {
             var spectralEnd = data[offset++];
             var successiveApproximation = data[offset++];
             try {
-              var processed = decodeScan(
+              const processed = decodeScan(
                 data,
                 offset,
                 frame,
@@ -1074,7 +1074,7 @@ var JpegImage = (function JpegImageClosure() {
         // Prevent errors when DQT markers are placed after SOF{n} markers,
         // by assigning the `quantizationTable` entry after the entire image
         // has been parsed (fixes issue7406.pdf).
-        var quantizationTable = quantizationTables[component.quantizationId];
+        const quantizationTable = quantizationTables[component.quantizationId];
         if (quantizationTable) {
           component.quantizationTable = quantizationTable;
         }
@@ -1092,19 +1092,19 @@ var JpegImage = (function JpegImageClosure() {
     },
 
     _getLinearizedBlockData(width, height, isSourcePDF = false) {
-      var scaleX = this.width / width,
+      const scaleX = this.width / width,
         scaleY = this.height / height;
 
-      var component, componentScaleX, componentScaleY, blocksPerScanline;
-      var x, y, i, j, k;
-      var index;
-      var offset = 0;
-      var output;
-      var numComponents = this.components.length;
-      var dataLength = width * height * numComponents;
-      var data = new Uint8ClampedArray(dataLength);
-      var xScaleBlockOffset = new Uint32Array(width);
-      var mask3LSB = 0xfffffff8; // used to clear the 3 LSBs
+      let component, componentScaleX, componentScaleY, blocksPerScanline;
+      let x, y, i, j, k;
+      let index;
+      let offset = 0;
+      let output;
+      const numComponents = this.components.length;
+      const dataLength = width * height * numComponents;
+      const data = new Uint8ClampedArray(dataLength);
+      const xScaleBlockOffset = new Uint32Array(width);
+      const mask3LSB = 0xfffffff8; // used to clear the 3 LSBs
       let lastComponentScaleX;
 
       for (i = 0; i < numComponents; i++) {
@@ -1189,8 +1189,8 @@ var JpegImage = (function JpegImageClosure() {
     },
 
     _convertYccToRgb: function convertYccToRgb(data) {
-      var Y, Cb, Cr;
-      for (var i = 0, length = data.length; i < length; i += 3) {
+      let Y, Cb, Cr;
+      for (let i = 0, length = data.length; i < length; i += 3) {
         Y = data[i];
         Cb = data[i + 1];
         Cr = data[i + 2];
@@ -1202,9 +1202,9 @@ var JpegImage = (function JpegImageClosure() {
     },
 
     _convertYcckToRgb: function convertYcckToRgb(data) {
-      var Y, Cb, Cr, k;
-      var offset = 0;
-      for (var i = 0, length = data.length; i < length; i += 4) {
+      let Y, Cb, Cr, k;
+      let offset = 0;
+      for (let i = 0, length = data.length; i < length; i += 4) {
         Y = data[i];
         Cb = data[i + 1];
         Cr = data[i + 2];
@@ -1272,8 +1272,8 @@ var JpegImage = (function JpegImageClosure() {
     },
 
     _convertYcckToCmyk: function convertYcckToCmyk(data) {
-      var Y, Cb, Cr;
-      for (var i = 0, length = data.length; i < length; i += 4) {
+      let Y, Cb, Cr;
+      for (let i = 0, length = data.length; i < length; i += 4) {
         Y = data[i];
         Cb = data[i + 1];
         Cr = data[i + 2];
@@ -1286,9 +1286,9 @@ var JpegImage = (function JpegImageClosure() {
     },
 
     _convertCmykToRgb: function convertCmykToRgb(data) {
-      var c, m, y, k;
-      var offset = 0;
-      for (var i = 0, length = data.length; i < length; i += 4) {
+      let c, m, y, k;
+      let offset = 0;
+      for (let i = 0, length = data.length; i < length; i += 4) {
         c = data[i];
         m = data[i + 1];
         y = data[i + 2];
@@ -1369,14 +1369,14 @@ var JpegImage = (function JpegImageClosure() {
         throw new JpegError("Unsupported color mode");
       }
       // Type of data: Uint8ClampedArray(width * height * numComponents)
-      var data = this._getLinearizedBlockData(width, height, isSourcePDF);
+      const data = this._getLinearizedBlockData(width, height, isSourcePDF);
 
       if (this.numComponents === 1 && forceRGB) {
-        var dataLength = data.length;
-        var rgbData = new Uint8ClampedArray(dataLength * 3);
-        var offset = 0;
-        for (var i = 0; i < dataLength; i++) {
-          var grayColor = data[i];
+        const dataLength = data.length;
+        const rgbData = new Uint8ClampedArray(dataLength * 3);
+        let offset = 0;
+        for (let i = 0; i < dataLength; i++) {
+          const grayColor = data[i];
           rgbData[offset++] = grayColor;
           rgbData[offset++] = grayColor;
           rgbData[offset++] = grayColor;

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -23,9 +23,9 @@ class JpxError extends BaseException {
   }
 }
 
-var JpxImage = (function JpxImageClosure() {
+const JpxImage = (function JpxImageClosure() {
   // Table E.1
-  var SubbandsGainLog2 = {
+  const SubbandsGainLog2 = {
     LL: 0,
     LH: 1,
     HL: 1,
@@ -36,19 +36,19 @@ var JpxImage = (function JpxImageClosure() {
   }
   JpxImage.prototype = {
     parse: function JpxImage_parse(data) {
-      var head = readUint16(data, 0);
+      const head = readUint16(data, 0);
       // No box header, immediate start of codestream (SOC)
       if (head === 0xff4f) {
         this.parseCodestream(data, 0, data.length);
         return;
       }
 
-      var position = 0,
+      let position = 0,
         length = data.length;
       while (position < length) {
-        var headerSize = 8;
-        var lbox = readUint32(data, position);
-        var tbox = readUint32(data, position + 4);
+        let headerSize = 8;
+        let lbox = readUint32(data, position);
+        const tbox = readUint32(data, position + 4);
         position += headerSize;
         if (lbox === 1) {
           // XLBox: read UInt64 according to spec.
@@ -65,8 +65,8 @@ var JpxImage = (function JpxImageClosure() {
         if (lbox < headerSize) {
           throw new JpxError("Invalid box field size");
         }
-        var dataLength = lbox - headerSize;
-        var jumpDataLength = true;
+        const dataLength = lbox - headerSize;
+        let jumpDataLength = true;
         switch (tbox) {
           case 0x6a703268: // 'jp2h'
             jumpDataLength = false; // parsing child boxes
@@ -76,7 +76,7 @@ var JpxImage = (function JpxImageClosure() {
             var method = data[position];
             if (method === 1) {
               // enumerated colorspace
-              var colorspace = readUint32(data, position + 3);
+              const colorspace = readUint32(data, position + 3);
               switch (colorspace) {
                 case 16: // this indicates a sRGB colorspace
                 case 17: // this indicates a grayscale colorspace
@@ -121,20 +121,20 @@ var JpxImage = (function JpxImageClosure() {
       }
     },
     parseImageProperties: function JpxImage_parseImageProperties(stream) {
-      var newByte = stream.getByte();
+      let newByte = stream.getByte();
       while (newByte >= 0) {
-        var oldByte = newByte;
+        const oldByte = newByte;
         newByte = stream.getByte();
-        var code = (oldByte << 8) | newByte;
+        const code = (oldByte << 8) | newByte;
         // Image and tile size (SIZ)
         if (code === 0xff51) {
           stream.skip(4);
-          var Xsiz = stream.getInt32() >>> 0; // Byte 4
-          var Ysiz = stream.getInt32() >>> 0; // Byte 8
-          var XOsiz = stream.getInt32() >>> 0; // Byte 12
-          var YOsiz = stream.getInt32() >>> 0; // Byte 16
+          const Xsiz = stream.getInt32() >>> 0; // Byte 4
+          const Ysiz = stream.getInt32() >>> 0; // Byte 8
+          const XOsiz = stream.getInt32() >>> 0; // Byte 12
+          const YOsiz = stream.getInt32() >>> 0; // Byte 16
           stream.skip(16);
-          var Csiz = stream.getUint16(); // Byte 36
+          const Csiz = stream.getUint16(); // Byte 36
           this.width = Xsiz - XOsiz;
           this.height = Ysiz - YOsiz;
           this.componentsCount = Csiz;
@@ -146,12 +146,12 @@ var JpxImage = (function JpxImageClosure() {
       throw new JpxError("No size marker found in JPX stream");
     },
     parseCodestream: function JpxImage_parseCodestream(data, start, end) {
-      var context = {};
-      var doNotRecover = false;
+      const context = {};
+      let doNotRecover = false;
       try {
-        var position = start;
+        let position = start;
         while (position + 1 < end) {
-          var code = readUint16(data, position);
+          const code = readUint16(data, position);
           position += 2;
 
           var length = 0,
@@ -182,8 +182,8 @@ var JpxImage = (function JpxImageClosure() {
               siz.Csiz = componentsCount;
               var components = [];
               j = position + 38;
-              for (var i = 0; i < componentsCount; i++) {
-                var component = {
+              for (let i = 0; i < componentsCount; i++) {
+                const component = {
                   precision: (data[j] & 0x7f) + 1,
                   isSigned: !!(data[j] & 0x80),
                   XRsiz: data[j + 1],
@@ -320,9 +320,9 @@ var JpxImage = (function JpxImageClosure() {
               cod.segmentationSymbolUsed = !!(blockStyle & 32);
               cod.reversibleTransformation = data[j++];
               if (cod.entropyCoderWithCustomPrecincts) {
-                var precinctsSizes = [];
+                const precinctsSizes = [];
                 while (j < length + position) {
-                  var precinctsSize = data[j++];
+                  const precinctsSize = data[j++];
                   precinctsSizes.push({
                     PPx: precinctsSize & 0xf,
                     PPy: precinctsSize >> 4,
@@ -428,14 +428,14 @@ var JpxImage = (function JpxImageClosure() {
     component.height = component.y1 - component.y0;
   }
   function calculateTileGrids(context, components) {
-    var siz = context.SIZ;
+    const siz = context.SIZ;
     // Section B.3 Division into tile and tile-components
-    var tile,
+    let tile,
       tiles = [];
-    var numXtiles = Math.ceil((siz.Xsiz - siz.XTOsiz) / siz.XTsiz);
-    var numYtiles = Math.ceil((siz.Ysiz - siz.YTOsiz) / siz.YTsiz);
-    for (var q = 0; q < numYtiles; q++) {
-      for (var p = 0; p < numXtiles; p++) {
+    const numXtiles = Math.ceil((siz.Xsiz - siz.XTOsiz) / siz.XTsiz);
+    const numYtiles = Math.ceil((siz.Ysiz - siz.YTOsiz) / siz.YTsiz);
+    for (let q = 0; q < numYtiles; q++) {
+      for (let p = 0; p < numXtiles; p++) {
         tile = {};
         tile.tx0 = Math.max(siz.XTOsiz + p * siz.XTsiz, siz.XOsiz);
         tile.ty0 = Math.max(siz.YTOsiz + q * siz.YTsiz, siz.YOsiz);
@@ -449,11 +449,11 @@ var JpxImage = (function JpxImageClosure() {
     }
     context.tiles = tiles;
 
-    var componentsCount = siz.Csiz;
-    for (var i = 0, ii = componentsCount; i < ii; i++) {
-      var component = components[i];
-      for (var j = 0, jj = tiles.length; j < jj; j++) {
-        var tileComponent = {};
+    const componentsCount = siz.Csiz;
+    for (let i = 0, ii = componentsCount; i < ii; i++) {
+      const component = components[i];
+      for (let j = 0, jj = tiles.length; j < jj; j++) {
+        const tileComponent = {};
         tile = tiles[j];
         tileComponent.tcx0 = Math.ceil(tile.tx0 / component.XRsiz);
         tileComponent.tcy0 = Math.ceil(tile.ty0 / component.YRsiz);
@@ -466,8 +466,8 @@ var JpxImage = (function JpxImageClosure() {
     }
   }
   function getBlocksDimensions(context, component, r) {
-    var codOrCoc = component.codingStyleParameters;
-    var result = {};
+    const codOrCoc = component.codingStyleParameters;
+    const result = {};
     if (!codOrCoc.entropyCoderWithCustomPrecincts) {
       result.PPx = 15;
       result.PPy = 15;
@@ -488,8 +488,8 @@ var JpxImage = (function JpxImageClosure() {
   }
   function buildPrecincts(context, resolution, dimensions) {
     // Section B.6 Division resolution to precincts
-    var precinctWidth = 1 << dimensions.PPx;
-    var precinctHeight = 1 << dimensions.PPy;
+    const precinctWidth = 1 << dimensions.PPx;
+    const precinctHeight = 1 << dimensions.PPy;
     // Jasper introduces codeblock groups for mapping each subband codeblocks
     // to precincts. Precinct partition divides a resolution according to width
     // and height parameters. The subband that belongs to the resolution level
@@ -504,20 +504,21 @@ var JpxImage = (function JpxImageClosure() {
     // level. This is accomplished by using the coordinate transformation
     // (u, v) = (ceil(x/2), ceil(y/2)) where (x, y) and (u, v) are the
     // coordinates of a point in the LL band and child subband, respectively.
-    var isZeroRes = resolution.resLevel === 0;
-    var precinctWidthInSubband = 1 << (dimensions.PPx + (isZeroRes ? 0 : -1));
-    var precinctHeightInSubband = 1 << (dimensions.PPy + (isZeroRes ? 0 : -1));
-    var numprecinctswide =
+    const isZeroRes = resolution.resLevel === 0;
+    const precinctWidthInSubband = 1 << (dimensions.PPx + (isZeroRes ? 0 : -1));
+    const precinctHeightInSubband =
+      1 << (dimensions.PPy + (isZeroRes ? 0 : -1));
+    const numprecinctswide =
       resolution.trx1 > resolution.trx0
         ? Math.ceil(resolution.trx1 / precinctWidth) -
           Math.floor(resolution.trx0 / precinctWidth)
         : 0;
-    var numprecinctshigh =
+    const numprecinctshigh =
       resolution.try1 > resolution.try0
         ? Math.ceil(resolution.try1 / precinctHeight) -
           Math.floor(resolution.try0 / precinctHeight)
         : 0;
-    var numprecincts = numprecinctswide * numprecinctshigh;
+    const numprecincts = numprecinctswide * numprecinctshigh;
 
     resolution.precinctParameters = {
       precinctWidth,
@@ -531,18 +532,18 @@ var JpxImage = (function JpxImageClosure() {
   }
   function buildCodeblocks(context, subband, dimensions) {
     // Section B.7 Division sub-band into code-blocks
-    var xcb_ = dimensions.xcb_;
-    var ycb_ = dimensions.ycb_;
-    var codeblockWidth = 1 << xcb_;
-    var codeblockHeight = 1 << ycb_;
-    var cbx0 = subband.tbx0 >> xcb_;
-    var cby0 = subband.tby0 >> ycb_;
-    var cbx1 = (subband.tbx1 + codeblockWidth - 1) >> xcb_;
-    var cby1 = (subband.tby1 + codeblockHeight - 1) >> ycb_;
-    var precinctParameters = subband.resolution.precinctParameters;
-    var codeblocks = [];
-    var precincts = [];
-    var i, j, codeblock, precinctNumber;
+    const xcb_ = dimensions.xcb_;
+    const ycb_ = dimensions.ycb_;
+    const codeblockWidth = 1 << xcb_;
+    const codeblockHeight = 1 << ycb_;
+    const cbx0 = subband.tbx0 >> xcb_;
+    const cby0 = subband.tby0 >> ycb_;
+    const cbx1 = (subband.tbx1 + codeblockWidth - 1) >> xcb_;
+    const cby1 = (subband.tby1 + codeblockHeight - 1) >> ycb_;
+    const precinctParameters = subband.resolution.precinctParameters;
+    const codeblocks = [];
+    const precincts = [];
+    let i, j, codeblock, precinctNumber;
     for (j = cby0; j < cby1; j++) {
       for (i = cbx0; i < cbx1; i++) {
         codeblock = {
@@ -562,11 +563,11 @@ var JpxImage = (function JpxImageClosure() {
         // Calculate precinct number for this codeblock, codeblock position
         // should be relative to its subband, use actual dimension and position
         // See comment about codeblock group width and height
-        var pi = Math.floor(
+        const pi = Math.floor(
           (codeblock.tbx0_ - subband.tbx0) /
             precinctParameters.precinctWidthInSubband
         );
-        var pj = Math.floor(
+        const pj = Math.floor(
           (codeblock.tby0_ - subband.tby0) /
             precinctParameters.precinctHeightInSubband
         );
@@ -584,7 +585,7 @@ var JpxImage = (function JpxImageClosure() {
         }
         codeblocks.push(codeblock);
         // building precinct for the sub-band
-        var precinct = precincts[precinctNumber];
+        let precinct = precincts[precinctNumber];
         if (precinct !== undefined) {
           if (i < precinct.cbxMin) {
             precinct.cbxMin = i;
@@ -617,15 +618,15 @@ var JpxImage = (function JpxImageClosure() {
     subband.precincts = precincts;
   }
   function createPacket(resolution, precinctNumber, layerNumber) {
-    var precinctCodeblocks = [];
+    const precinctCodeblocks = [];
     // Section B.10.8 Order of info in packet
-    var subbands = resolution.subbands;
+    const subbands = resolution.subbands;
     // sub-bands already ordered in 'LL', 'HL', 'LH', and 'HH' sequence
-    for (var i = 0, ii = subbands.length; i < ii; i++) {
-      var subband = subbands[i];
-      var codeblocks = subband.codeblocks;
-      for (var j = 0, jj = codeblocks.length; j < jj; j++) {
-        var codeblock = codeblocks[j];
+    for (let i = 0, ii = subbands.length; i < ii; i++) {
+      const subband = subbands[i];
+      const codeblocks = subband.codeblocks;
+      for (let j = 0, jj = codeblocks.length; j < jj; j++) {
+        const codeblock = codeblocks[j];
         if (codeblock.precinctNumber !== precinctNumber) {
           continue;
         }
@@ -638,20 +639,20 @@ var JpxImage = (function JpxImageClosure() {
     };
   }
   function LayerResolutionComponentPositionIterator(context) {
-    var siz = context.SIZ;
-    var tileIndex = context.currentTile.index;
-    var tile = context.tiles[tileIndex];
-    var layersCount = tile.codingStyleDefaultParameters.layersCount;
-    var componentsCount = siz.Csiz;
-    var maxDecompositionLevelsCount = 0;
-    for (var q = 0; q < componentsCount; q++) {
+    const siz = context.SIZ;
+    const tileIndex = context.currentTile.index;
+    const tile = context.tiles[tileIndex];
+    const layersCount = tile.codingStyleDefaultParameters.layersCount;
+    const componentsCount = siz.Csiz;
+    let maxDecompositionLevelsCount = 0;
+    for (let q = 0; q < componentsCount; q++) {
       maxDecompositionLevelsCount = Math.max(
         maxDecompositionLevelsCount,
         tile.components[q].codingStyleParameters.decompositionLevelsCount
       );
     }
 
-    var l = 0,
+    let l = 0,
       r = 0,
       i = 0,
       k = 0;
@@ -661,15 +662,15 @@ var JpxImage = (function JpxImageClosure() {
       for (; l < layersCount; l++) {
         for (; r <= maxDecompositionLevelsCount; r++) {
           for (; i < componentsCount; i++) {
-            var component = tile.components[i];
+            const component = tile.components[i];
             if (r > component.codingStyleParameters.decompositionLevelsCount) {
               continue;
             }
 
-            var resolution = component.resolutions[r];
-            var numprecincts = resolution.precinctParameters.numprecincts;
+            const resolution = component.resolutions[r];
+            const numprecincts = resolution.precinctParameters.numprecincts;
             for (; k < numprecincts; ) {
-              var packet = createPacket(resolution, k, l);
+              const packet = createPacket(resolution, k, l);
               k++;
               return packet;
             }
@@ -683,20 +684,20 @@ var JpxImage = (function JpxImageClosure() {
     };
   }
   function ResolutionLayerComponentPositionIterator(context) {
-    var siz = context.SIZ;
-    var tileIndex = context.currentTile.index;
-    var tile = context.tiles[tileIndex];
-    var layersCount = tile.codingStyleDefaultParameters.layersCount;
-    var componentsCount = siz.Csiz;
-    var maxDecompositionLevelsCount = 0;
-    for (var q = 0; q < componentsCount; q++) {
+    const siz = context.SIZ;
+    const tileIndex = context.currentTile.index;
+    const tile = context.tiles[tileIndex];
+    const layersCount = tile.codingStyleDefaultParameters.layersCount;
+    const componentsCount = siz.Csiz;
+    let maxDecompositionLevelsCount = 0;
+    for (let q = 0; q < componentsCount; q++) {
       maxDecompositionLevelsCount = Math.max(
         maxDecompositionLevelsCount,
         tile.components[q].codingStyleParameters.decompositionLevelsCount
       );
     }
 
-    var r = 0,
+    let r = 0,
       l = 0,
       i = 0,
       k = 0;
@@ -706,15 +707,15 @@ var JpxImage = (function JpxImageClosure() {
       for (; r <= maxDecompositionLevelsCount; r++) {
         for (; l < layersCount; l++) {
           for (; i < componentsCount; i++) {
-            var component = tile.components[i];
+            const component = tile.components[i];
             if (r > component.codingStyleParameters.decompositionLevelsCount) {
               continue;
             }
 
-            var resolution = component.resolutions[r];
-            var numprecincts = resolution.precinctParameters.numprecincts;
+            const resolution = component.resolutions[r];
+            const numprecincts = resolution.precinctParameters.numprecincts;
             for (; k < numprecincts; ) {
-              var packet = createPacket(resolution, k, l);
+              const packet = createPacket(resolution, k, l);
               k++;
               return packet;
             }
@@ -728,27 +729,27 @@ var JpxImage = (function JpxImageClosure() {
     };
   }
   function ResolutionPositionComponentLayerIterator(context) {
-    var siz = context.SIZ;
-    var tileIndex = context.currentTile.index;
-    var tile = context.tiles[tileIndex];
-    var layersCount = tile.codingStyleDefaultParameters.layersCount;
-    var componentsCount = siz.Csiz;
-    var l, r, c, p;
-    var maxDecompositionLevelsCount = 0;
+    const siz = context.SIZ;
+    const tileIndex = context.currentTile.index;
+    const tile = context.tiles[tileIndex];
+    const layersCount = tile.codingStyleDefaultParameters.layersCount;
+    const componentsCount = siz.Csiz;
+    let l, r, c, p;
+    let maxDecompositionLevelsCount = 0;
     for (c = 0; c < componentsCount; c++) {
-      var component = tile.components[c];
+      const component = tile.components[c];
       maxDecompositionLevelsCount = Math.max(
         maxDecompositionLevelsCount,
         component.codingStyleParameters.decompositionLevelsCount
       );
     }
-    var maxNumPrecinctsInLevel = new Int32Array(
+    const maxNumPrecinctsInLevel = new Int32Array(
       maxDecompositionLevelsCount + 1
     );
     for (r = 0; r <= maxDecompositionLevelsCount; ++r) {
-      var maxNumPrecincts = 0;
+      let maxNumPrecincts = 0;
       for (c = 0; c < componentsCount; ++c) {
-        var resolutions = tile.components[c].resolutions;
+        const resolutions = tile.components[c].resolutions;
         if (r < resolutions.length) {
           maxNumPrecincts = Math.max(
             maxNumPrecincts,
@@ -768,17 +769,17 @@ var JpxImage = (function JpxImageClosure() {
       for (; r <= maxDecompositionLevelsCount; r++) {
         for (; p < maxNumPrecinctsInLevel[r]; p++) {
           for (; c < componentsCount; c++) {
-            var component = tile.components[c];
+            const component = tile.components[c];
             if (r > component.codingStyleParameters.decompositionLevelsCount) {
               continue;
             }
-            var resolution = component.resolutions[r];
-            var numprecincts = resolution.precinctParameters.numprecincts;
+            const resolution = component.resolutions[r];
+            const numprecincts = resolution.precinctParameters.numprecincts;
             if (p >= numprecincts) {
               continue;
             }
             for (; l < layersCount; ) {
-              var packet = createPacket(resolution, p, l);
+              const packet = createPacket(resolution, p, l);
               l++;
               return packet;
             }
@@ -792,14 +793,14 @@ var JpxImage = (function JpxImageClosure() {
     };
   }
   function PositionComponentResolutionLayerIterator(context) {
-    var siz = context.SIZ;
-    var tileIndex = context.currentTile.index;
-    var tile = context.tiles[tileIndex];
-    var layersCount = tile.codingStyleDefaultParameters.layersCount;
-    var componentsCount = siz.Csiz;
-    var precinctsSizes = getPrecinctSizesInImageScale(tile);
-    var precinctsIterationSizes = precinctsSizes;
-    var l = 0,
+    const siz = context.SIZ;
+    const tileIndex = context.currentTile.index;
+    const tile = context.tiles[tileIndex];
+    const layersCount = tile.codingStyleDefaultParameters.layersCount;
+    const componentsCount = siz.Csiz;
+    const precinctsSizes = getPrecinctSizesInImageScale(tile);
+    const precinctsIterationSizes = precinctsSizes;
+    let l = 0,
       r = 0,
       c = 0,
       px = 0,
@@ -810,14 +811,14 @@ var JpxImage = (function JpxImageClosure() {
       for (; py < precinctsIterationSizes.maxNumHigh; py++) {
         for (; px < precinctsIterationSizes.maxNumWide; px++) {
           for (; c < componentsCount; c++) {
-            var component = tile.components[c];
-            var decompositionLevelsCount =
+            const component = tile.components[c];
+            const decompositionLevelsCount =
               component.codingStyleParameters.decompositionLevelsCount;
             for (; r <= decompositionLevelsCount; r++) {
-              var resolution = component.resolutions[r];
-              var sizeInImageScale =
+              const resolution = component.resolutions[r];
+              const sizeInImageScale =
                 precinctsSizes.components[c].resolutions[r];
-              var k = getPrecinctIndexIfExist(
+              const k = getPrecinctIndexIfExist(
                 px,
                 py,
                 sizeInImageScale,
@@ -828,7 +829,7 @@ var JpxImage = (function JpxImageClosure() {
                 continue;
               }
               for (; l < layersCount; ) {
-                var packet = createPacket(resolution, k, l);
+                const packet = createPacket(resolution, k, l);
                 l++;
                 return packet;
               }
@@ -844,13 +845,13 @@ var JpxImage = (function JpxImageClosure() {
     };
   }
   function ComponentPositionResolutionLayerIterator(context) {
-    var siz = context.SIZ;
-    var tileIndex = context.currentTile.index;
-    var tile = context.tiles[tileIndex];
-    var layersCount = tile.codingStyleDefaultParameters.layersCount;
-    var componentsCount = siz.Csiz;
-    var precinctsSizes = getPrecinctSizesInImageScale(tile);
-    var l = 0,
+    const siz = context.SIZ;
+    const tileIndex = context.currentTile.index;
+    const tile = context.tiles[tileIndex];
+    const layersCount = tile.codingStyleDefaultParameters.layersCount;
+    const componentsCount = siz.Csiz;
+    const precinctsSizes = getPrecinctSizesInImageScale(tile);
+    let l = 0,
       r = 0,
       c = 0,
       px = 0,
@@ -859,16 +860,16 @@ var JpxImage = (function JpxImageClosure() {
     this.nextPacket = function JpxImage_nextPacket() {
       // Section B.12.1.5 Component-position-resolution-layer
       for (; c < componentsCount; ++c) {
-        var component = tile.components[c];
-        var precinctsIterationSizes = precinctsSizes.components[c];
-        var decompositionLevelsCount =
+        const component = tile.components[c];
+        const precinctsIterationSizes = precinctsSizes.components[c];
+        const decompositionLevelsCount =
           component.codingStyleParameters.decompositionLevelsCount;
         for (; py < precinctsIterationSizes.maxNumHigh; py++) {
           for (; px < precinctsIterationSizes.maxNumWide; px++) {
             for (; r <= decompositionLevelsCount; r++) {
-              var resolution = component.resolutions[r];
-              var sizeInImageScale = precinctsIterationSizes.resolutions[r];
-              var k = getPrecinctIndexIfExist(
+              const resolution = component.resolutions[r];
+              const sizeInImageScale = precinctsIterationSizes.resolutions[r];
+              const k = getPrecinctIndexIfExist(
                 px,
                 py,
                 sizeInImageScale,
@@ -879,7 +880,7 @@ var JpxImage = (function JpxImageClosure() {
                 continue;
               }
               for (; l < layersCount; ) {
-                var packet = createPacket(resolution, k, l);
+                const packet = createPacket(resolution, k, l);
                 l++;
                 return packet;
               }
@@ -901,41 +902,41 @@ var JpxImage = (function JpxImageClosure() {
     precinctIterationSizes,
     resolution
   ) {
-    var posX = pxIndex * precinctIterationSizes.minWidth;
-    var posY = pyIndex * precinctIterationSizes.minHeight;
+    const posX = pxIndex * precinctIterationSizes.minWidth;
+    const posY = pyIndex * precinctIterationSizes.minHeight;
     if (
       posX % sizeInImageScale.width !== 0 ||
       posY % sizeInImageScale.height !== 0
     ) {
       return null;
     }
-    var startPrecinctRowIndex =
+    const startPrecinctRowIndex =
       (posY / sizeInImageScale.width) *
       resolution.precinctParameters.numprecinctswide;
     return posX / sizeInImageScale.height + startPrecinctRowIndex;
   }
   function getPrecinctSizesInImageScale(tile) {
-    var componentsCount = tile.components.length;
-    var minWidth = Number.MAX_VALUE;
-    var minHeight = Number.MAX_VALUE;
-    var maxNumWide = 0;
-    var maxNumHigh = 0;
-    var sizePerComponent = new Array(componentsCount);
-    for (var c = 0; c < componentsCount; c++) {
-      var component = tile.components[c];
-      var decompositionLevelsCount =
+    const componentsCount = tile.components.length;
+    let minWidth = Number.MAX_VALUE;
+    let minHeight = Number.MAX_VALUE;
+    let maxNumWide = 0;
+    let maxNumHigh = 0;
+    const sizePerComponent = new Array(componentsCount);
+    for (let c = 0; c < componentsCount; c++) {
+      const component = tile.components[c];
+      const decompositionLevelsCount =
         component.codingStyleParameters.decompositionLevelsCount;
-      var sizePerResolution = new Array(decompositionLevelsCount + 1);
-      var minWidthCurrentComponent = Number.MAX_VALUE;
-      var minHeightCurrentComponent = Number.MAX_VALUE;
-      var maxNumWideCurrentComponent = 0;
-      var maxNumHighCurrentComponent = 0;
-      var scale = 1;
-      for (var r = decompositionLevelsCount; r >= 0; --r) {
-        var resolution = component.resolutions[r];
-        var widthCurrentResolution =
+      const sizePerResolution = new Array(decompositionLevelsCount + 1);
+      let minWidthCurrentComponent = Number.MAX_VALUE;
+      let minHeightCurrentComponent = Number.MAX_VALUE;
+      let maxNumWideCurrentComponent = 0;
+      let maxNumHighCurrentComponent = 0;
+      let scale = 1;
+      for (let r = decompositionLevelsCount; r >= 0; --r) {
+        const resolution = component.resolutions[r];
+        const widthCurrentResolution =
           scale * resolution.precinctParameters.precinctWidth;
-        var heightCurrentResolution =
+        const heightCurrentResolution =
           scale * resolution.precinctParameters.precinctHeight;
         minWidthCurrentComponent = Math.min(
           minWidthCurrentComponent,
@@ -980,22 +981,22 @@ var JpxImage = (function JpxImageClosure() {
     };
   }
   function buildPackets(context) {
-    var siz = context.SIZ;
-    var tileIndex = context.currentTile.index;
-    var tile = context.tiles[tileIndex];
-    var componentsCount = siz.Csiz;
+    const siz = context.SIZ;
+    const tileIndex = context.currentTile.index;
+    const tile = context.tiles[tileIndex];
+    const componentsCount = siz.Csiz;
     // Creating resolutions and sub-bands for each component
-    for (var c = 0; c < componentsCount; c++) {
-      var component = tile.components[c];
-      var decompositionLevelsCount =
+    for (let c = 0; c < componentsCount; c++) {
+      const component = tile.components[c];
+      const decompositionLevelsCount =
         component.codingStyleParameters.decompositionLevelsCount;
       // Section B.5 Resolution levels and sub-bands
-      var resolutions = [];
-      var subbands = [];
-      for (var r = 0; r <= decompositionLevelsCount; r++) {
-        var blocksDimensions = getBlocksDimensions(context, component, r);
-        var resolution = {};
-        var scale = 1 << (decompositionLevelsCount - r);
+      const resolutions = [];
+      const subbands = [];
+      for (let r = 0; r <= decompositionLevelsCount; r++) {
+        const blocksDimensions = getBlocksDimensions(context, component, r);
+        const resolution = {};
+        const scale = 1 << (decompositionLevelsCount - r);
         resolution.trx0 = Math.ceil(component.tcx0 / scale);
         resolution.try0 = Math.ceil(component.tcy0 / scale);
         resolution.trx1 = Math.ceil(component.tcx1 / scale);
@@ -1018,8 +1019,8 @@ var JpxImage = (function JpxImageClosure() {
           subbands.push(subband);
           resolution.subbands = [subband];
         } else {
-          var bscale = 1 << (decompositionLevelsCount - r + 1);
-          var resolutionSubbands = [];
+          const bscale = 1 << (decompositionLevelsCount - r + 1);
+          const resolutionSubbands = [];
           // three sub-bands (HL, LH and HH) with rest of decompositions
           subband = {};
           subband.type = "HL";
@@ -1061,7 +1062,7 @@ var JpxImage = (function JpxImageClosure() {
       component.subbands = subbands;
     }
     // Generate the packets sequence
-    var progressionOrder = tile.codingStyleDefaultParameters.progressionOrder;
+    const progressionOrder = tile.codingStyleDefaultParameters.progressionOrder;
     switch (progressionOrder) {
       case 0:
         tile.packetsIterator = new LayerResolutionComponentPositionIterator(
@@ -1093,13 +1094,13 @@ var JpxImage = (function JpxImageClosure() {
     }
   }
   function parseTilePackets(context, data, offset, dataLength) {
-    var position = 0;
-    var buffer,
+    let position = 0;
+    let buffer,
       bufferSize = 0,
       skipNextBit = false;
     function readBits(count) {
       while (bufferSize < count) {
-        var b = data[offset + position];
+        const b = data[offset + position];
         position++;
         if (skipNextBit) {
           buffer = (buffer << 7) | b;
@@ -1149,7 +1150,7 @@ var JpxImage = (function JpxImageClosure() {
       if (readBits(1) === 0) {
         return 2;
       }
-      var value = readBits(2);
+      let value = readBits(2);
       if (value < 3) {
         return value + 3;
       }
@@ -1160,31 +1161,31 @@ var JpxImage = (function JpxImageClosure() {
       value = readBits(7);
       return value + 37;
     }
-    var tileIndex = context.currentTile.index;
-    var tile = context.tiles[tileIndex];
-    var sopMarkerUsed = context.COD.sopMarkerUsed;
-    var ephMarkerUsed = context.COD.ephMarkerUsed;
-    var packetsIterator = tile.packetsIterator;
+    const tileIndex = context.currentTile.index;
+    const tile = context.tiles[tileIndex];
+    const sopMarkerUsed = context.COD.sopMarkerUsed;
+    const ephMarkerUsed = context.COD.ephMarkerUsed;
+    const packetsIterator = tile.packetsIterator;
     while (position < dataLength) {
       alignToByte();
       if (sopMarkerUsed && skipMarkerIfEqual(0x91)) {
         // Skip also marker segment length and packet sequence ID
         skipBytes(4);
       }
-      var packet = packetsIterator.nextPacket();
+      const packet = packetsIterator.nextPacket();
       if (!readBits(1)) {
         continue;
       }
-      var layerNumber = packet.layerNumber;
+      const layerNumber = packet.layerNumber;
       var queue = [],
         codeblock;
-      for (var i = 0, ii = packet.codeblocks.length; i < ii; i++) {
+      for (let i = 0, ii = packet.codeblocks.length; i < ii; i++) {
         codeblock = packet.codeblocks[i];
-        var precinct = codeblock.precinct;
-        var codeblockColumn = codeblock.cbx - precinct.cbxMin;
-        var codeblockRow = codeblock.cby - precinct.cbyMin;
-        var codeblockIncluded = false;
-        var firstTimeInclusion = false;
+        let precinct = codeblock.precinct;
+        const codeblockColumn = codeblock.cbx - precinct.cbxMin;
+        const codeblockRow = codeblock.cby - precinct.cbyMin;
+        let codeblockIncluded = false;
+        let firstTimeInclusion = false;
         var valueReady;
         if (codeblock["included"] !== undefined) {
           codeblockIncluded = !!readBits(1);
@@ -1196,8 +1197,8 @@ var JpxImage = (function JpxImageClosure() {
             inclusionTree = precinct.inclusionTree;
           } else {
             // building inclusion and zero bit-planes trees
-            var width = precinct.cbxMax - precinct.cbxMin + 1;
-            var height = precinct.cbyMax - precinct.cbyMin + 1;
+            const width = precinct.cbxMax - precinct.cbxMin + 1;
+            const height = precinct.cbyMax - precinct.cbyMin + 1;
             inclusionTree = new InclusionTree(width, height, layerNumber);
             zeroBitPlanesTree = new TagTree(width, height);
             precinct.inclusionTree = inclusionTree;
@@ -1238,17 +1239,17 @@ var JpxImage = (function JpxImageClosure() {
           }
           codeblock.zeroBitPlanes = zeroBitPlanesTree.value;
         }
-        var codingpasses = readCodingpasses();
+        const codingpasses = readCodingpasses();
         while (readBits(1)) {
           codeblock.Lblock++;
         }
-        var codingpassesLog2 = log2(codingpasses);
+        const codingpassesLog2 = log2(codingpasses);
         // rounding down log2
-        var bits =
+        const bits =
           (codingpasses < 1 << codingpassesLog2
             ? codingpassesLog2 - 1
             : codingpassesLog2) + codeblock.Lblock;
-        var codedDataLength = readBits(bits);
+        const codedDataLength = readBits(bits);
         queue.push({
           codeblock,
           codingpasses,
@@ -1260,7 +1261,7 @@ var JpxImage = (function JpxImageClosure() {
         skipMarkerIfEqual(0x92);
       }
       while (queue.length > 0) {
-        var packetItem = queue.shift();
+        const packetItem = queue.shift();
         codeblock = packetItem.codeblock;
         if (codeblock["data"] === undefined) {
           codeblock.data = [];
@@ -1286,17 +1287,17 @@ var JpxImage = (function JpxImageClosure() {
     reversible,
     segmentationSymbolUsed
   ) {
-    var x0 = subband.tbx0;
-    var y0 = subband.tby0;
-    var width = subband.tbx1 - subband.tbx0;
-    var codeblocks = subband.codeblocks;
-    var right = subband.type.charAt(0) === "H" ? 1 : 0;
-    var bottom = subband.type.charAt(1) === "H" ? levelWidth : 0;
+    const x0 = subband.tbx0;
+    const y0 = subband.tby0;
+    const width = subband.tbx1 - subband.tbx0;
+    const codeblocks = subband.codeblocks;
+    const right = subband.type.charAt(0) === "H" ? 1 : 0;
+    const bottom = subband.type.charAt(1) === "H" ? levelWidth : 0;
 
-    for (var i = 0, ii = codeblocks.length; i < ii; ++i) {
-      var codeblock = codeblocks[i];
-      var blockWidth = codeblock.tbx1_ - codeblock.tbx0_;
-      var blockHeight = codeblock.tby1_ - codeblock.tby0_;
+    for (let i = 0, ii = codeblocks.length; i < ii; ++i) {
+      const codeblock = codeblocks[i];
+      const blockWidth = codeblock.tbx1_ - codeblock.tbx0_;
+      const blockHeight = codeblock.tby1_ - codeblock.tby0_;
       if (blockWidth === 0 || blockHeight === 0) {
         continue;
       }
@@ -1315,7 +1316,7 @@ var JpxImage = (function JpxImageClosure() {
       currentCodingpassType = 2; // first bit plane starts from cleanup
 
       // collect data
-      var data = codeblock.data,
+      let data = codeblock.data,
         totalLength = 0,
         codingpasses = 0;
       var j, jj, dataItem;
@@ -1324,16 +1325,16 @@ var JpxImage = (function JpxImageClosure() {
         totalLength += dataItem.end - dataItem.start;
         codingpasses += dataItem.codingpasses;
       }
-      var encodedData = new Uint8Array(totalLength);
-      var position = 0;
+      const encodedData = new Uint8Array(totalLength);
+      let position = 0;
       for (j = 0, jj = data.length; j < jj; j++) {
         dataItem = data[j];
-        var chunk = dataItem.data.subarray(dataItem.start, dataItem.end);
+        const chunk = dataItem.data.subarray(dataItem.start, dataItem.end);
         encodedData.set(chunk, position);
         position += chunk.length;
       }
       // decoding the item
-      var decoder = new ArithmeticDecoder(encodedData, 0, totalLength);
+      const decoder = new ArithmeticDecoder(encodedData, 0, totalLength);
       bitModel.setDecoder(decoder);
 
       for (j = 0; j < codingpasses; j++) {
@@ -1354,19 +1355,19 @@ var JpxImage = (function JpxImageClosure() {
         currentCodingpassType = (currentCodingpassType + 1) % 3;
       }
 
-      var offset = codeblock.tbx0_ - x0 + (codeblock.tby0_ - y0) * width;
-      var sign = bitModel.coefficentsSign;
-      var magnitude = bitModel.coefficentsMagnitude;
-      var bitsDecoded = bitModel.bitsDecoded;
-      var magnitudeCorrection = reversible ? 0 : 0.5;
+      let offset = codeblock.tbx0_ - x0 + (codeblock.tby0_ - y0) * width;
+      const sign = bitModel.coefficentsSign;
+      const magnitude = bitModel.coefficentsMagnitude;
+      const bitsDecoded = bitModel.bitsDecoded;
+      const magnitudeCorrection = reversible ? 0 : 0.5;
       var k, n, nb;
       position = 0;
       // Do the interleaving of Section F.3.3 here, so we do not need
       // to copy later. LL level is not interleaved, just copied.
-      var interleave = subband.type !== "LL";
+      const interleave = subband.type !== "LL";
       for (j = 0; j < blockHeight; j++) {
-        var row = (offset / width) | 0; // row in the non-interleaved subband
-        var levelOffset = 2 * row * (levelWidth - width) + right + bottom;
+        const row = (offset / width) | 0; // row in the non-interleaved subband
+        const levelOffset = 2 * row * (levelWidth - width) + right + bottom;
         for (k = 0; k < blockWidth; k++) {
           n = magnitude[position];
           if (n !== 0) {
@@ -1375,7 +1376,7 @@ var JpxImage = (function JpxImageClosure() {
               n = -n;
             }
             nb = bitsDecoded[position];
-            var pos = interleave ? levelOffset + (offset << 1) : offset;
+            const pos = interleave ? levelOffset + (offset << 1) : offset;
             if (reversible && nb >= mb) {
               coefficients[pos] = n;
             } else {
@@ -1390,33 +1391,33 @@ var JpxImage = (function JpxImageClosure() {
     }
   }
   function transformTile(context, tile, c) {
-    var component = tile.components[c];
-    var codingStyleParameters = component.codingStyleParameters;
-    var quantizationParameters = component.quantizationParameters;
-    var decompositionLevelsCount =
+    const component = tile.components[c];
+    const codingStyleParameters = component.codingStyleParameters;
+    const quantizationParameters = component.quantizationParameters;
+    const decompositionLevelsCount =
       codingStyleParameters.decompositionLevelsCount;
-    var spqcds = quantizationParameters.SPqcds;
-    var scalarExpounded = quantizationParameters.scalarExpounded;
-    var guardBits = quantizationParameters.guardBits;
-    var segmentationSymbolUsed = codingStyleParameters.segmentationSymbolUsed;
-    var precision = context.components[c].precision;
+    const spqcds = quantizationParameters.SPqcds;
+    const scalarExpounded = quantizationParameters.scalarExpounded;
+    const guardBits = quantizationParameters.guardBits;
+    const segmentationSymbolUsed = codingStyleParameters.segmentationSymbolUsed;
+    const precision = context.components[c].precision;
 
-    var reversible = codingStyleParameters.reversibleTransformation;
-    var transform = reversible
+    const reversible = codingStyleParameters.reversibleTransformation;
+    const transform = reversible
       ? new ReversibleTransform()
       : new IrreversibleTransform();
 
-    var subbandCoefficients = [];
-    var b = 0;
-    for (var i = 0; i <= decompositionLevelsCount; i++) {
-      var resolution = component.resolutions[i];
+    const subbandCoefficients = [];
+    let b = 0;
+    for (let i = 0; i <= decompositionLevelsCount; i++) {
+      const resolution = component.resolutions[i];
 
-      var width = resolution.trx1 - resolution.trx0;
-      var height = resolution.try1 - resolution.try0;
+      const width = resolution.trx1 - resolution.trx0;
+      const height = resolution.try1 - resolution.try0;
       // Allocate space for the whole sublevel.
-      var coefficients = new Float32Array(width * height);
+      const coefficients = new Float32Array(width * height);
 
-      for (var j = 0, jj = resolution.subbands.length; j < jj; j++) {
+      for (let j = 0, jj = resolution.subbands.length; j < jj; j++) {
         var mu, epsilon;
         if (!scalarExpounded) {
           // formula E-5
@@ -1428,14 +1429,14 @@ var JpxImage = (function JpxImageClosure() {
           b++;
         }
 
-        var subband = resolution.subbands[j];
-        var gainLog2 = SubbandsGainLog2[subband.type];
+        const subband = resolution.subbands[j];
+        const gainLog2 = SubbandsGainLog2[subband.type];
 
         // calculate quantization coefficient (Section E.1.1.1)
-        var delta = reversible
+        const delta = reversible
           ? 1
           : Math.pow(2, precision + gainLog2 - epsilon) * (1 + mu / 2048);
-        var mb = guardBits + epsilon - 1;
+        const mb = guardBits + epsilon - 1;
 
         // In the first resolution level, copyCoefficients will fill the
         // whole array with coefficients. In the succeeding passes,
@@ -1460,7 +1461,7 @@ var JpxImage = (function JpxImageClosure() {
       });
     }
 
-    var result = transform.calculate(
+    const result = transform.calculate(
       subbandCoefficients,
       component.tcx0,
       component.tcy0
@@ -1474,20 +1475,20 @@ var JpxImage = (function JpxImageClosure() {
     };
   }
   function transformComponents(context) {
-    var siz = context.SIZ;
-    var components = context.components;
-    var componentsCount = siz.Csiz;
-    var resultImages = [];
-    for (var i = 0, ii = context.tiles.length; i < ii; i++) {
-      var tile = context.tiles[i];
-      var transformedTiles = [];
+    const siz = context.SIZ;
+    const components = context.components;
+    const componentsCount = siz.Csiz;
+    const resultImages = [];
+    for (let i = 0, ii = context.tiles.length; i < ii; i++) {
+      const tile = context.tiles[i];
+      const transformedTiles = [];
       var c;
       for (c = 0; c < componentsCount; c++) {
         transformedTiles[c] = transformTile(context, tile, c);
       }
-      var tile0 = transformedTiles[0];
-      var out = new Uint8ClampedArray(tile0.items.length * componentsCount);
-      var result = {
+      const tile0 = transformedTiles[0];
+      const out = new Uint8ClampedArray(tile0.items.length * componentsCount);
+      const result = {
         left: tile0.left,
         top: tile0.top,
         width: tile0.width,
@@ -1504,11 +1505,11 @@ var JpxImage = (function JpxImageClosure() {
         y1,
         y2;
       if (tile.codingStyleDefaultParameters.multipleComponentTransform) {
-        var fourComponents = componentsCount === 4;
-        var y0items = transformedTiles[0].items;
-        var y1items = transformedTiles[1].items;
-        var y2items = transformedTiles[2].items;
-        var y3items = fourComponents ? transformedTiles[3].items : null;
+        const fourComponents = componentsCount === 4;
+        const y0items = transformedTiles[0].items;
+        const y1items = transformedTiles[1].items;
+        const y2items = transformedTiles[2].items;
+        const y3items = fourComponents ? transformedTiles[3].items : null;
 
         // HACK: The multiple component transform formulas below assume that
         // all components have the same precision. With this in mind, we
@@ -1516,8 +1517,8 @@ var JpxImage = (function JpxImageClosure() {
         shift = components[0].precision - 8;
         offset = (128 << shift) + 0.5;
 
-        var component0 = tile.components[0];
-        var alpha01 = componentsCount - 3;
+        const component0 = tile.components[0];
+        const alpha01 = componentsCount - 3;
         jj = y0items.length;
         if (!component0.codingStyleParameters.reversibleTransformation) {
           // inverse irreversible multiple component transform
@@ -1550,7 +1551,7 @@ var JpxImage = (function JpxImageClosure() {
       } else {
         // no multi-component transform
         for (c = 0; c < componentsCount; c++) {
-          var items = transformedTiles[c].items;
+          const items = transformedTiles[c].items;
           shift = components[c].precision - 8;
           offset = (128 << shift) + 0.5;
           for (pos = c, j = 0, jj = items.length; j < jj; j++) {
@@ -1564,17 +1565,17 @@ var JpxImage = (function JpxImageClosure() {
     return resultImages;
   }
   function initializeTile(context, tileIndex) {
-    var siz = context.SIZ;
-    var componentsCount = siz.Csiz;
-    var tile = context.tiles[tileIndex];
-    for (var c = 0; c < componentsCount; c++) {
-      var component = tile.components[c];
-      var qcdOrQcc =
+    const siz = context.SIZ;
+    const componentsCount = siz.Csiz;
+    const tile = context.tiles[tileIndex];
+    for (let c = 0; c < componentsCount; c++) {
+      const component = tile.components[c];
+      const qcdOrQcc =
         context.currentTile.QCC[c] !== undefined
           ? context.currentTile.QCC[c]
           : context.currentTile.QCD;
       component.quantizationParameters = qcdOrQcc;
-      var codOrCoc =
+      const codOrCoc =
         context.currentTile.COC[c] !== undefined
           ? context.currentTile.COC[c]
           : context.currentTile.COD;
@@ -1586,10 +1587,10 @@ var JpxImage = (function JpxImageClosure() {
   // Section B.10.2 Tag trees
   var TagTree = (function TagTreeClosure() {
     function TagTree(width, height) {
-      var levelsLength = log2(Math.max(width, height)) + 1;
+      const levelsLength = log2(Math.max(width, height)) + 1;
       this.levels = [];
-      for (var i = 0; i < levelsLength; i++) {
-        var level = {
+      for (let i = 0; i < levelsLength; i++) {
+        const level = {
           width,
           height,
           items: [],
@@ -1601,12 +1602,12 @@ var JpxImage = (function JpxImageClosure() {
     }
     TagTree.prototype = {
       reset: function TagTree_reset(i, j) {
-        var currentLevel = 0,
+        let currentLevel = 0,
           value = 0,
           level;
         while (currentLevel < this.levels.length) {
           level = this.levels[currentLevel];
-          var index = i + j * level.width;
+          const index = i + j * level.width;
           if (level.items[index] !== undefined) {
             value = level.items[index];
             break;
@@ -1623,13 +1624,13 @@ var JpxImage = (function JpxImageClosure() {
         delete this.value;
       },
       incrementValue: function TagTree_incrementValue() {
-        var level = this.levels[this.currentLevel];
+        const level = this.levels[this.currentLevel];
         level.items[level.index]++;
       },
       nextLevel: function TagTree_nextLevel() {
-        var currentLevel = this.currentLevel;
-        var level = this.levels[currentLevel];
-        var value = level.items[level.index];
+        let currentLevel = this.currentLevel;
+        let level = this.levels[currentLevel];
+        const value = level.items[level.index];
         currentLevel--;
         if (currentLevel < 0) {
           this.value = value;
@@ -1647,15 +1648,15 @@ var JpxImage = (function JpxImageClosure() {
 
   var InclusionTree = (function InclusionTreeClosure() {
     function InclusionTree(width, height, defaultValue) {
-      var levelsLength = log2(Math.max(width, height)) + 1;
+      const levelsLength = log2(Math.max(width, height)) + 1;
       this.levels = [];
-      for (var i = 0; i < levelsLength; i++) {
-        var items = new Uint8Array(width * height);
-        for (var j = 0, jj = items.length; j < jj; j++) {
+      for (let i = 0; i < levelsLength; i++) {
+        const items = new Uint8Array(width * height);
+        for (let j = 0, jj = items.length; j < jj; j++) {
           items[j] = defaultValue;
         }
 
-        var level = {
+        const level = {
           width,
           height,
           items,
@@ -1668,12 +1669,12 @@ var JpxImage = (function JpxImageClosure() {
     }
     InclusionTree.prototype = {
       reset: function InclusionTree_reset(i, j, stopValue) {
-        var currentLevel = 0;
+        let currentLevel = 0;
         while (currentLevel < this.levels.length) {
-          var level = this.levels[currentLevel];
-          var index = i + j * level.width;
+          const level = this.levels[currentLevel];
+          const index = i + j * level.width;
           level.index = index;
-          var value = level.items[index];
+          const value = level.items[index];
 
           if (value === 0xff) {
             break;
@@ -1694,23 +1695,23 @@ var JpxImage = (function JpxImageClosure() {
         return true;
       },
       incrementValue: function InclusionTree_incrementValue(stopValue) {
-        var level = this.levels[this.currentLevel];
+        const level = this.levels[this.currentLevel];
         level.items[level.index] = stopValue + 1;
         this.propagateValues();
       },
       propagateValues: function InclusionTree_propagateValues() {
-        var levelIndex = this.currentLevel;
-        var level = this.levels[levelIndex];
-        var currentValue = level.items[level.index];
+        let levelIndex = this.currentLevel;
+        let level = this.levels[levelIndex];
+        const currentValue = level.items[level.index];
         while (--levelIndex >= 0) {
           level = this.levels[levelIndex];
           level.items[level.index] = currentValue;
         }
       },
       nextLevel: function InclusionTree_nextLevel() {
-        var currentLevel = this.currentLevel;
-        var level = this.levels[currentLevel];
-        var value = level.items[level.index];
+        let currentLevel = this.currentLevel;
+        let level = this.levels[currentLevel];
+        const value = level.items[level.index];
         level.items[level.index] = 0xff;
         currentLevel--;
         if (currentLevel < 0) {
@@ -1728,25 +1729,25 @@ var JpxImage = (function JpxImageClosure() {
 
   // Section D. Coefficient bit modeling
   var BitModel = (function BitModelClosure() {
-    var UNIFORM_CONTEXT = 17;
-    var RUNLENGTH_CONTEXT = 18;
+    const UNIFORM_CONTEXT = 17;
+    const RUNLENGTH_CONTEXT = 18;
     // Table D-1
     // The index is binary presentation: 0dddvvhh, ddd - sum of Di (0..4),
     // vv - sum of Vi (0..2), and hh - sum of Hi (0..2)
     // prettier-ignore
-    var LLAndLHContextsLabel = new Uint8Array([
+    const LLAndLHContextsLabel = new Uint8Array([
       0, 5, 8, 0, 3, 7, 8, 0, 4, 7, 8, 0, 0, 0, 0, 0, 1, 6, 8, 0, 3, 7, 8, 0, 4,
       7, 8, 0, 0, 0, 0, 0, 2, 6, 8, 0, 3, 7, 8, 0, 4, 7, 8, 0, 0, 0, 0, 0, 2, 6,
       8, 0, 3, 7, 8, 0, 4, 7, 8, 0, 0, 0, 0, 0, 2, 6, 8, 0, 3, 7, 8, 0, 4, 7, 8
     ]);
     // prettier-ignore
-    var HLContextLabel = new Uint8Array([
+    const HLContextLabel = new Uint8Array([
       0, 3, 4, 0, 5, 7, 7, 0, 8, 8, 8, 0, 0, 0, 0, 0, 1, 3, 4, 0, 6, 7, 7, 0, 8,
       8, 8, 0, 0, 0, 0, 0, 2, 3, 4, 0, 6, 7, 7, 0, 8, 8, 8, 0, 0, 0, 0, 0, 2, 3,
       4, 0, 6, 7, 7, 0, 8, 8, 8, 0, 0, 0, 0, 0, 2, 3, 4, 0, 6, 7, 7, 0, 8, 8, 8
     ]);
     // prettier-ignore
-    var HHContextLabel = new Uint8Array([
+    const HHContextLabel = new Uint8Array([
       0, 1, 2, 0, 1, 2, 2, 0, 2, 2, 2, 0, 0, 0, 0, 0, 3, 4, 5, 0, 4, 5, 5, 0, 5,
       5, 5, 0, 0, 0, 0, 0, 6, 7, 7, 0, 7, 7, 7, 0, 7, 7, 7, 0, 0, 0, 0, 0, 8, 8,
       8, 0, 8, 8, 8, 0, 8, 8, 8, 0, 0, 0, 0, 0, 8, 8, 8, 0, 8, 8, 8, 0, 8, 8, 8
@@ -1766,7 +1767,7 @@ var JpxImage = (function JpxImageClosure() {
       }
       this.contextLabelTable = contextLabelTable;
 
-      var coefficientCount = width * height;
+      const coefficientCount = width * height;
 
       // coefficients outside the encoding region treated as insignificant
       // add border state cells for significanceState
@@ -1783,9 +1784,9 @@ var JpxImage = (function JpxImageClosure() {
       this.coefficentsMagnitude = coefficentsMagnitude;
       this.processingFlags = new Uint8Array(coefficientCount);
 
-      var bitsDecoded = new Uint8Array(coefficientCount);
+      const bitsDecoded = new Uint8Array(coefficientCount);
       if (zeroBitPlanes !== 0) {
-        for (var i = 0; i < coefficientCount; i++) {
+        for (let i = 0; i < coefficientCount; i++) {
           bitsDecoded[i] = zeroBitPlanes;
         }
       }
@@ -1814,12 +1815,12 @@ var JpxImage = (function JpxImageClosure() {
         column,
         index
       ) {
-        var neighborsSignificance = this.neighborsSignificance;
-        var width = this.width,
+        const neighborsSignificance = this.neighborsSignificance;
+        const width = this.width,
           height = this.height;
-        var left = column > 0;
-        var right = column + 1 < width;
-        var i;
+        const left = column > 0;
+        const right = column + 1 < width;
+        let i;
 
         if (row > 0) {
           i = index - width;
@@ -1852,25 +1853,25 @@ var JpxImage = (function JpxImageClosure() {
         neighborsSignificance[index] |= 0x80;
       },
       runSignificancePropagationPass: function BitModel_runSignificancePropagationPass() {
-        var decoder = this.decoder;
-        var width = this.width,
+        const decoder = this.decoder;
+        const width = this.width,
           height = this.height;
-        var coefficentsMagnitude = this.coefficentsMagnitude;
-        var coefficentsSign = this.coefficentsSign;
-        var neighborsSignificance = this.neighborsSignificance;
-        var processingFlags = this.processingFlags;
-        var contexts = this.contexts;
-        var labels = this.contextLabelTable;
-        var bitsDecoded = this.bitsDecoded;
-        var processedInverseMask = ~1;
-        var processedMask = 1;
-        var firstMagnitudeBitMask = 2;
+        const coefficentsMagnitude = this.coefficentsMagnitude;
+        const coefficentsSign = this.coefficentsSign;
+        const neighborsSignificance = this.neighborsSignificance;
+        const processingFlags = this.processingFlags;
+        const contexts = this.contexts;
+        const labels = this.contextLabelTable;
+        const bitsDecoded = this.bitsDecoded;
+        const processedInverseMask = ~1;
+        const processedMask = 1;
+        const firstMagnitudeBitMask = 2;
 
-        for (var i0 = 0; i0 < height; i0 += 4) {
-          for (var j = 0; j < width; j++) {
-            var index = i0 * width + j;
-            for (var i1 = 0; i1 < 4; i1++, index += width) {
-              var i = i0 + i1;
+        for (let i0 = 0; i0 < height; i0 += 4) {
+          for (let j = 0; j < width; j++) {
+            let index = i0 * width + j;
+            for (let i1 = 0; i1 < 4; i1++, index += width) {
+              const i = i0 + i1;
               if (i >= height) {
                 break;
               }
@@ -1884,10 +1885,10 @@ var JpxImage = (function JpxImageClosure() {
                 continue;
               }
 
-              var contextLabel = labels[neighborsSignificance[index]];
-              var decision = decoder.readBit(contexts, contextLabel);
+              const contextLabel = labels[neighborsSignificance[index]];
+              const decision = decoder.readBit(contexts, contextLabel);
               if (decision) {
-                var sign = this.decodeSignBit(i, j, index);
+                const sign = this.decodeSignBit(i, j, index);
                 coefficentsSign[index] = sign;
                 coefficentsMagnitude[index] = 1;
                 this.setNeighborsSignificance(i, j, index);
@@ -1900,12 +1901,12 @@ var JpxImage = (function JpxImageClosure() {
         }
       },
       decodeSignBit: function BitModel_decodeSignBit(row, column, index) {
-        var width = this.width,
+        const width = this.width,
           height = this.height;
-        var coefficentsMagnitude = this.coefficentsMagnitude;
-        var coefficentsSign = this.coefficentsSign;
-        var contribution, sign0, sign1, significance1;
-        var contextLabel, decoded;
+        const coefficentsMagnitude = this.coefficentsMagnitude;
+        const coefficentsSign = this.coefficentsSign;
+        let contribution, sign0, sign1, significance1;
+        let contextLabel, decoded;
 
         // calculate horizontal contribution
         significance1 = column > 0 && coefficentsMagnitude[index - 1] !== 0;
@@ -1923,7 +1924,7 @@ var JpxImage = (function JpxImageClosure() {
         } else {
           contribution = 0;
         }
-        var horizontalContribution = 3 * contribution;
+        const horizontalContribution = 3 * contribution;
 
         // calculate vertical contribution and combine with the horizontal
         significance1 = row > 0 && coefficentsMagnitude[index - width] !== 0;
@@ -1952,23 +1953,23 @@ var JpxImage = (function JpxImageClosure() {
         return decoded;
       },
       runMagnitudeRefinementPass: function BitModel_runMagnitudeRefinementPass() {
-        var decoder = this.decoder;
-        var width = this.width,
+        const decoder = this.decoder;
+        const width = this.width,
           height = this.height;
-        var coefficentsMagnitude = this.coefficentsMagnitude;
-        var neighborsSignificance = this.neighborsSignificance;
-        var contexts = this.contexts;
-        var bitsDecoded = this.bitsDecoded;
-        var processingFlags = this.processingFlags;
-        var processedMask = 1;
-        var firstMagnitudeBitMask = 2;
-        var length = width * height;
-        var width4 = width * 4;
+        const coefficentsMagnitude = this.coefficentsMagnitude;
+        const neighborsSignificance = this.neighborsSignificance;
+        const contexts = this.contexts;
+        const bitsDecoded = this.bitsDecoded;
+        const processingFlags = this.processingFlags;
+        const processedMask = 1;
+        const firstMagnitudeBitMask = 2;
+        const length = width * height;
+        const width4 = width * 4;
 
         for (var index0 = 0, indexNext; index0 < length; index0 = indexNext) {
           indexNext = Math.min(length, index0 + width4);
-          for (var j = 0; j < width; j++) {
-            for (var index = index0 + j; index < indexNext; index += width) {
+          for (let j = 0; j < width; j++) {
+            for (let index = index0 + j; index < indexNext; index += width) {
               // significant but not those that have just become
               if (
                 !coefficentsMagnitude[index] ||
@@ -1977,15 +1978,15 @@ var JpxImage = (function JpxImageClosure() {
                 continue;
               }
 
-              var contextLabel = 16;
+              let contextLabel = 16;
               if ((processingFlags[index] & firstMagnitudeBitMask) !== 0) {
                 processingFlags[index] ^= firstMagnitudeBitMask;
                 // first refinement
-                var significance = neighborsSignificance[index] & 127;
+                const significance = neighborsSignificance[index] & 127;
                 contextLabel = significance === 0 ? 15 : 14;
               }
 
-              var bit = decoder.readBit(contexts, contextLabel);
+              const bit = decoder.readBit(contexts, contextLabel);
               coefficentsMagnitude[index] =
                 (coefficentsMagnitude[index] << 1) | bit;
               bitsDecoded[index]++;
@@ -1995,31 +1996,31 @@ var JpxImage = (function JpxImageClosure() {
         }
       },
       runCleanupPass: function BitModel_runCleanupPass() {
-        var decoder = this.decoder;
-        var width = this.width,
+        const decoder = this.decoder;
+        const width = this.width,
           height = this.height;
-        var neighborsSignificance = this.neighborsSignificance;
-        var coefficentsMagnitude = this.coefficentsMagnitude;
-        var coefficentsSign = this.coefficentsSign;
-        var contexts = this.contexts;
-        var labels = this.contextLabelTable;
-        var bitsDecoded = this.bitsDecoded;
-        var processingFlags = this.processingFlags;
-        var processedMask = 1;
-        var firstMagnitudeBitMask = 2;
-        var oneRowDown = width;
-        var twoRowsDown = width * 2;
-        var threeRowsDown = width * 3;
-        var iNext;
-        for (var i0 = 0; i0 < height; i0 = iNext) {
+        const neighborsSignificance = this.neighborsSignificance;
+        const coefficentsMagnitude = this.coefficentsMagnitude;
+        const coefficentsSign = this.coefficentsSign;
+        const contexts = this.contexts;
+        const labels = this.contextLabelTable;
+        const bitsDecoded = this.bitsDecoded;
+        const processingFlags = this.processingFlags;
+        const processedMask = 1;
+        const firstMagnitudeBitMask = 2;
+        const oneRowDown = width;
+        const twoRowsDown = width * 2;
+        const threeRowsDown = width * 3;
+        let iNext;
+        for (let i0 = 0; i0 < height; i0 = iNext) {
           iNext = Math.min(i0 + 4, height);
-          var indexBase = i0 * width;
-          var checkAllEmpty = i0 + 3 < height;
-          for (var j = 0; j < width; j++) {
-            var index0 = indexBase + j;
+          const indexBase = i0 * width;
+          const checkAllEmpty = i0 + 3 < height;
+          for (let j = 0; j < width; j++) {
+            const index0 = indexBase + j;
             // using the property: labels[neighborsSignificance[index]] === 0
             // when neighborsSignificance[index] === 0
-            var allEmpty =
+            const allEmpty =
               checkAllEmpty &&
               processingFlags[index0] === 0 &&
               processingFlags[index0 + oneRowDown] === 0 &&
@@ -2029,12 +2030,12 @@ var JpxImage = (function JpxImageClosure() {
               neighborsSignificance[index0 + oneRowDown] === 0 &&
               neighborsSignificance[index0 + twoRowsDown] === 0 &&
               neighborsSignificance[index0 + threeRowsDown] === 0;
-            var i1 = 0,
+            let i1 = 0,
               index = index0;
             var i = i0,
               sign;
             if (allEmpty) {
-              var hasSignificantCoefficent = decoder.readBit(
+              const hasSignificantCoefficent = decoder.readBit(
                 contexts,
                 RUNLENGTH_CONTEXT
               );
@@ -2060,7 +2061,7 @@ var JpxImage = (function JpxImageClosure() {
               processingFlags[index] |= firstMagnitudeBitMask;
 
               index = index0;
-              for (var i2 = i0; i2 <= i; i2++, index += width) {
+              for (let i2 = i0; i2 <= i; i2++, index += width) {
                 bitsDecoded[index]++;
               }
 
@@ -2074,8 +2075,8 @@ var JpxImage = (function JpxImageClosure() {
                 continue;
               }
 
-              var contextLabel = labels[neighborsSignificance[index]];
-              var decision = decoder.readBit(contexts, contextLabel);
+              const contextLabel = labels[neighborsSignificance[index]];
+              const decision = decoder.readBit(contexts, contextLabel);
               if (decision === 1) {
                 sign = this.decodeSignBit(i, j, index);
                 coefficentsSign[index] = sign;
@@ -2089,9 +2090,9 @@ var JpxImage = (function JpxImageClosure() {
         }
       },
       checkSegmentationSymbol: function BitModel_checkSegmentationSymbol() {
-        var decoder = this.decoder;
-        var contexts = this.contexts;
-        var symbol =
+        const decoder = this.decoder;
+        const contexts = this.contexts;
+        const symbol =
           (decoder.readBit(contexts, UNIFORM_CONTEXT) << 3) |
           (decoder.readBit(contexts, UNIFORM_CONTEXT) << 2) |
           (decoder.readBit(contexts, UNIFORM_CONTEXT) << 1) |
@@ -2106,7 +2107,7 @@ var JpxImage = (function JpxImageClosure() {
   })();
 
   // Section F, Discrete wavelet transformation
-  var Transform = (function TransformClosure() {
+  const Transform = (function TransformClosure() {
     function Transform() {}
 
     Transform.prototype.calculate = function transformCalculate(
@@ -2114,17 +2115,17 @@ var JpxImage = (function JpxImageClosure() {
       u0,
       v0
     ) {
-      var ll = subbands[0];
-      for (var i = 1, ii = subbands.length; i < ii; i++) {
+      let ll = subbands[0];
+      for (let i = 1, ii = subbands.length; i < ii; i++) {
         ll = this.iterate(ll, subbands[i], u0, v0);
       }
       return ll;
     };
     Transform.prototype.extend = function extend(buffer, offset, size) {
       // Section F.3.7 extending... using max extension of 4
-      var i1 = offset - 1,
+      let i1 = offset - 1,
         j1 = offset + 1;
-      var i2 = offset + size - 2,
+      let i2 = offset + size - 2,
         j2 = offset + size;
       buffer[i1--] = buffer[j1++];
       buffer[j2++] = buffer[i2--];
@@ -2141,13 +2142,13 @@ var JpxImage = (function JpxImageClosure() {
       u0,
       v0
     ) {
-      var llWidth = ll.width,
+      let llWidth = ll.width,
         llHeight = ll.height,
         llItems = ll.items;
-      var width = hl_lh_hh.width;
-      var height = hl_lh_hh.height;
-      var items = hl_lh_hh.items;
-      var i, j, k, l, u, v;
+      const width = hl_lh_hh.width;
+      const height = hl_lh_hh.height;
+      const items = hl_lh_hh.items;
+      let i, j, k, l, u, v;
 
       // Interleave LL according to Section F.3.3
       for (k = 0, i = 0; i < llHeight; i++) {
@@ -2159,8 +2160,8 @@ var JpxImage = (function JpxImageClosure() {
       // The LL band is not needed anymore.
       llItems = ll.items = null;
 
-      var bufferPadding = 4;
-      var rowBuffer = new Float32Array(width + 2 * bufferPadding);
+      const bufferPadding = 4;
+      const rowBuffer = new Float32Array(width + 2 * bufferPadding);
 
       // Section F.3.4 HOR_SR
       if (width === 1) {
@@ -2190,12 +2191,12 @@ var JpxImage = (function JpxImageClosure() {
       // have a cache miss every time. To reduce cache misses, get up to
       // 'numBuffers' items at a time and store them into the individual
       // buffers. The colBuffers should be small enough to fit into CPU cache.
-      var numBuffers = 16;
-      var colBuffers = [];
+      let numBuffers = 16;
+      const colBuffers = [];
       for (i = 0; i < numBuffers; i++) {
         colBuffers.push(new Float32Array(height + 2 * bufferPadding));
       }
-      var b,
+      let b,
         currentBuffer = 0;
       ll = bufferPadding + height;
 
@@ -2221,7 +2222,7 @@ var JpxImage = (function JpxImageClosure() {
           }
 
           currentBuffer--;
-          var buffer = colBuffers[currentBuffer];
+          const buffer = colBuffers[currentBuffer];
           this.extend(buffer, bufferPadding, height);
           this.filter(buffer, bufferPadding, height);
 
@@ -2258,16 +2259,16 @@ var JpxImage = (function JpxImageClosure() {
       offset,
       length
     ) {
-      var len = length >> 1;
+      const len = length >> 1;
       offset = offset | 0;
-      var j, n, current, next;
+      let j, n, current, next;
 
-      var alpha = -1.586134342059924;
-      var beta = -0.052980118572961;
-      var gamma = 0.882911075530934;
-      var delta = 0.443506852043971;
-      var K = 1.230174104914001;
-      var K_ = 1 / K;
+      const alpha = -1.586134342059924;
+      const beta = -0.052980118572961;
+      const gamma = 0.882911075530934;
+      const delta = 0.443506852043971;
+      const K = 1.230174104914001;
+      const K_ = 1 / K;
 
       // step 1 is combined with step 3
 
@@ -2355,9 +2356,9 @@ var JpxImage = (function JpxImageClosure() {
       offset,
       length
     ) {
-      var len = length >> 1;
+      const len = length >> 1;
       offset = offset | 0;
-      var j, n;
+      let j, n;
 
       for (j = offset, n = len + 1; n--; j += 2) {
         x[j] -= (x[j - 1] + x[j + 1] + 2) >> 2;

--- a/src/core/metrics.js
+++ b/src/core/metrics.js
@@ -18,7 +18,7 @@ import { getLookupTableFactory } from "./core_utils.js";
 // The Metrics object contains glyph widths (in glyph space units).
 // As per PDF spec, for most fonts (Type 3 being an exception) a glyph
 // space unit corresponds to 1/1000th of text space unit.
-var getMetrics = getLookupTableFactory(function(t) {
+const getMetrics = getLookupTableFactory(function(t) {
   t["Courier"] = 600;
   t["Courier-Bold"] = 600;
   t["Courier-BoldOblique"] = 600;

--- a/src/core/murmurhash3.js
+++ b/src/core/murmurhash3.js
@@ -16,7 +16,6 @@
  * Based on https://code.google.com/p/smhasher/wiki/MurmurHash3.
  * Hashes roughly 100 KB per millisecond on i7 3.4 GHz.
  */
-/* eslint no-var: error */
 
 import { isArrayBuffer, isString } from "../shared/util.js";
 

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -1109,7 +1109,7 @@ class Catalog {
   }
 }
 
-var XRef = (function XRefClosure() {
+const XRef = (function XRefClosure() {
   function XRef(stream, pdfManager) {
     this.stream = stream;
     this.pdfManager = pdfManager;
@@ -1130,7 +1130,7 @@ var XRef = (function XRefClosure() {
     },
 
     parse: function XRef_parse(recoveryMode) {
-      var trailerDict;
+      let trailerDict;
       if (!recoveryMode) {
         trailerDict = this.readXRef();
       } else {
@@ -1150,8 +1150,8 @@ var XRef = (function XRefClosure() {
         warn(`XRef.parse - Invalid "Encrypt" reference: "${ex}".`);
       }
       if (isDict(encrypt)) {
-        var ids = trailerDict.get("ID");
-        var fileId = ids && ids.length ? ids[0] : "";
+        const ids = trailerDict.get("ID");
+        const fileId = ids && ids.length ? ids[0] : "";
         // The 'Encrypt' dictionary itself should not be encrypted, and by
         // setting `suppressEncryption` we can prevent an infinite loop inside
         // of `XRef_fetchUncompressed` if the dictionary contains indirect
@@ -1196,7 +1196,7 @@ var XRef = (function XRefClosure() {
         };
       }
 
-      var obj = this.readXRefTable(parser);
+      const obj = this.readXRefTable(parser);
 
       // Sanity check
       if (!isCmd(obj, "trailer")) {
@@ -1213,7 +1213,7 @@ var XRef = (function XRefClosure() {
       //    >>
       // The parser goes through the entire stream << ... >> and provides
       // a getter interface for the key-value table
-      var dict = parser.getObj();
+      let dict = parser.getObj();
 
       // The pdflib PDF generator can generate a nested trailer dictionary
       if (!isDict(dict) && dict.dict) {
@@ -1240,14 +1240,14 @@ var XRef = (function XRefClosure() {
       // trailer
       // ...
 
-      var stream = parser.lexer.stream;
-      var tableState = this.tableState;
+      const stream = parser.lexer.stream;
+      const tableState = this.tableState;
       stream.pos = tableState.streamPos;
       parser.buf1 = tableState.parserBuf1;
       parser.buf2 = tableState.parserBuf2;
 
       // Outer loop is over subsection headers
-      var obj;
+      let obj;
 
       while (true) {
         if (!("firstEntryNum" in tableState) || !("entryCount" in tableState)) {
@@ -1258,24 +1258,24 @@ var XRef = (function XRefClosure() {
           tableState.entryCount = parser.getObj();
         }
 
-        var first = tableState.firstEntryNum;
-        var count = tableState.entryCount;
+        let first = tableState.firstEntryNum;
+        const count = tableState.entryCount;
         if (!Number.isInteger(first) || !Number.isInteger(count)) {
           throw new FormatError(
             "Invalid XRef table: wrong types in subsection header"
           );
         }
         // Inner loop is over objects themselves
-        for (var i = tableState.entryNum; i < count; i++) {
+        for (let i = tableState.entryNum; i < count; i++) {
           tableState.streamPos = stream.pos;
           tableState.entryNum = i;
           tableState.parserBuf1 = parser.buf1;
           tableState.parserBuf2 = parser.buf2;
 
-          var entry = {};
+          const entry = {};
           entry.offset = parser.getObj();
           entry.gen = parser.getObj();
-          var type = parser.getObj();
+          const type = parser.getObj();
 
           if (type instanceof Cmd) {
             switch (type.cmd) {
@@ -1329,9 +1329,9 @@ var XRef = (function XRefClosure() {
       if (!("streamState" in this)) {
         // Stores state of the stream as we process it so we can resume
         // from middle of stream in case of missing data error
-        var streamParameters = stream.dict;
-        var byteWidths = streamParameters.get("W");
-        var range = streamParameters.get("Index");
+        const streamParameters = stream.dict;
+        const byteWidths = streamParameters.get("W");
+        let range = streamParameters.get("Index");
         if (!range) {
           range = [0, streamParameters.get("Size")];
         }
@@ -1350,19 +1350,19 @@ var XRef = (function XRefClosure() {
     },
 
     readXRefStream: function XRef_readXRefStream(stream) {
-      var i, j;
-      var streamState = this.streamState;
+      let i, j;
+      const streamState = this.streamState;
       stream.pos = streamState.streamPos;
 
-      var byteWidths = streamState.byteWidths;
-      var typeFieldWidth = byteWidths[0];
-      var offsetFieldWidth = byteWidths[1];
-      var generationFieldWidth = byteWidths[2];
+      const byteWidths = streamState.byteWidths;
+      const typeFieldWidth = byteWidths[0];
+      const offsetFieldWidth = byteWidths[1];
+      const generationFieldWidth = byteWidths[2];
 
-      var entryRanges = streamState.entryRanges;
+      const entryRanges = streamState.entryRanges;
       while (entryRanges.length > 0) {
-        var first = entryRanges[0];
-        var n = entryRanges[1];
+        const first = entryRanges[0];
+        const n = entryRanges[1];
 
         if (!Number.isInteger(first) || !Number.isInteger(n)) {
           throw new FormatError(`Invalid XRef range fields: ${first}, ${n}`);
@@ -1380,7 +1380,7 @@ var XRef = (function XRefClosure() {
           streamState.entryNum = i;
           streamState.streamPos = stream.pos;
 
-          var type = 0,
+          let type = 0,
             offset = 0,
             generation = 0;
           for (j = 0; j < typeFieldWidth; ++j) {
@@ -1396,7 +1396,7 @@ var XRef = (function XRefClosure() {
           for (j = 0; j < generationFieldWidth; ++j) {
             generation = (generation << 8) | stream.getByte();
           }
-          var entry = {};
+          const entry = {};
           entry.offset = offset;
           entry.gen = generation;
           switch (type) {
@@ -1425,15 +1425,15 @@ var XRef = (function XRefClosure() {
     indexObjects: function XRef_indexObjects() {
       // Simple scan through the PDF content to find objects,
       // trailers and XRef streams.
-      var TAB = 0x9,
+      const TAB = 0x9,
         LF = 0xa,
         CR = 0xd,
         SPACE = 0x20;
-      var PERCENT = 0x25,
+      const PERCENT = 0x25,
         LT = 0x3c;
 
       function readToken(data, offset) {
-        var token = "",
+        let token = "",
           ch = data[offset];
         while (ch !== LF && ch !== CR && ch !== LT) {
           if (++offset >= data.length) {
@@ -1445,12 +1445,12 @@ var XRef = (function XRefClosure() {
         return token;
       }
       function skipUntil(data, offset, what) {
-        var length = what.length,
+        const length = what.length,
           dataLength = data.length;
-        var skipped = 0;
+        let skipped = 0;
         // finding byte sequence
         while (offset < dataLength) {
-          var i = 0;
+          let i = 0;
           while (i < length && data[offset + i] === what[i]) {
             ++i;
           }
@@ -1462,30 +1462,30 @@ var XRef = (function XRefClosure() {
         }
         return skipped;
       }
-      var objRegExp = /^(\d+)\s+(\d+)\s+obj\b/;
+      const objRegExp = /^(\d+)\s+(\d+)\s+obj\b/;
       const endobjRegExp = /\bendobj[\b\s]$/;
       const nestedObjRegExp = /\s+(\d+\s+\d+\s+obj[\b\s<])$/;
       const CHECK_CONTENT_LENGTH = 25;
 
-      var trailerBytes = new Uint8Array([116, 114, 97, 105, 108, 101, 114]);
+      const trailerBytes = new Uint8Array([116, 114, 97, 105, 108, 101, 114]);
       // prettier-ignore
-      var startxrefBytes = new Uint8Array([115, 116, 97, 114, 116, 120, 114,
+      const startxrefBytes = new Uint8Array([115, 116, 97, 114, 116, 120, 114,
                                            101, 102]);
       const objBytes = new Uint8Array([111, 98, 106]);
-      var xrefBytes = new Uint8Array([47, 88, 82, 101, 102]);
+      const xrefBytes = new Uint8Array([47, 88, 82, 101, 102]);
 
       // Clear out any existing entries, since they may be bogus.
       this.entries.length = 0;
 
-      var stream = this.stream;
+      const stream = this.stream;
       stream.pos = 0;
-      var buffer = stream.getBytes();
-      var position = stream.start,
+      const buffer = stream.getBytes();
+      let position = stream.start,
         length = buffer.length;
-      var trailers = [],
+      const trailers = [],
         xrefStms = [];
       while (position < length) {
-        var ch = buffer[position];
+        let ch = buffer[position];
         if (ch === TAB || ch === LF || ch === CR || ch === SPACE) {
           ++position;
           continue;
@@ -1501,7 +1501,7 @@ var XRef = (function XRefClosure() {
           } while (ch !== LF && ch !== CR);
           continue;
         }
-        var token = readToken(buffer, position);
+        const token = readToken(buffer, position);
         var m;
         if (
           token.startsWith("xref") &&
@@ -1556,7 +1556,7 @@ var XRef = (function XRefClosure() {
 
           // checking XRef stream suspect
           // (it shall have '/XRef' and next char is not a letter)
-          var xrefTagOffset = skipUntil(content, 0, xrefBytes);
+          const xrefTagOffset = skipUntil(content, 0, xrefBytes);
           if (
             xrefTagOffset < contentLength &&
             content[xrefTagOffset + 5] < 64
@@ -1577,7 +1577,7 @@ var XRef = (function XRefClosure() {
         }
       }
       // reading XRef streams
-      var i, ii;
+      let i, ii;
       for (i = 0, ii = xrefStms.length; i < ii; ++i) {
         this.startXRefQueue.push(xrefStms[i]);
         this.readXRef(/* recoveryMode */ true);
@@ -1592,7 +1592,7 @@ var XRef = (function XRefClosure() {
           allowStreams: true,
           recoveryMode: true,
         });
-        var obj = parser.getObj();
+        const obj = parser.getObj();
         if (!isCmd(obj, "trailer")) {
           continue;
         }
@@ -1630,7 +1630,7 @@ var XRef = (function XRefClosure() {
     },
 
     readXRef: function XRef_readXRef(recoveryMode) {
-      var stream = this.stream;
+      const stream = this.stream;
       // Keep track of already parsed XRef tables, to prevent an infinite loop
       // when parsing corrupt PDF files where e.g. the /Prev entries create a
       // circular dependency between tables (fixes bug1393476.pdf).
@@ -1638,7 +1638,7 @@ var XRef = (function XRefClosure() {
 
       try {
         while (this.startXRefQueue.length) {
-          var startXRef = this.startXRefQueue[0];
+          const startXRef = this.startXRefQueue[0];
 
           if (startXRefParsedCache[startXRef]) {
             warn("readXRef - skipping XRef table since it was already parsed.");
@@ -1654,7 +1654,7 @@ var XRef = (function XRefClosure() {
             xref: this,
             allowStreams: true,
           });
-          var obj = parser.getObj();
+          let obj = parser.getObj();
           var dict;
 
           // Get dictionary
@@ -1668,7 +1668,7 @@ var XRef = (function XRefClosure() {
             // Recursively get other XRefs 'XRefStm', if any
             obj = dict.get("XRefStm");
             if (Number.isInteger(obj)) {
-              var pos = obj;
+              const pos = obj;
               // ignore previously loaded xref streams
               // (possible infinite recursion)
               if (!(pos in this.xrefstms)) {
@@ -1724,7 +1724,7 @@ var XRef = (function XRefClosure() {
     },
 
     getEntry: function XRef_getEntry(i) {
-      var xrefEntry = this.entries[i];
+      const xrefEntry = this.entries[i];
       if (xrefEntry && !xrefEntry.free && xrefEntry.offset) {
         return xrefEntry;
       }
@@ -1778,12 +1778,12 @@ var XRef = (function XRefClosure() {
     },
 
     fetchUncompressed(ref, xrefEntry, suppressEncryption = false) {
-      var gen = ref.gen;
-      var num = ref.num;
+      const gen = ref.gen;
+      let num = ref.num;
       if (xrefEntry.gen !== gen) {
         throw new XRefEntryException(`Inconsistent generation in XRef: ${ref}`);
       }
-      var stream = this.stream.makeSubStream(
+      const stream = this.stream.makeSubStream(
         xrefEntry.offset + this.stream.start
       );
       const parser = new Parser({
@@ -1791,9 +1791,9 @@ var XRef = (function XRefClosure() {
         xref: this,
         allowStreams: true,
       });
-      var obj1 = parser.getObj();
-      var obj2 = parser.getObj();
-      var obj3 = parser.getObj();
+      const obj1 = parser.getObj();
+      const obj2 = parser.getObj();
+      const obj3 = parser.getObj();
 
       if (obj1 !== num || obj2 !== gen || !(obj3 instanceof Cmd)) {
         throw new XRefEntryException(`Bad (uncompressed) XRef entry: ${ref}`);
@@ -2125,7 +2125,7 @@ var FileSpec = (function FileSpecClosure() {
   FileSpec.prototype = {
     get filename() {
       if (!this._filename && this.root) {
-        var filename = pickPlatformItem(this.root) || "unnamed";
+        const filename = pickPlatformItem(this.root) || "unnamed";
         this._filename = stringToPDFString(filename)
           .replace(/\\\\/g, "\\")
           .replace(/\\\//g, "/")
@@ -2140,10 +2140,10 @@ var FileSpec = (function FileSpecClosure() {
       if (!this.contentRef && this.root) {
         this.contentRef = pickPlatformItem(this.root.get("EF"));
       }
-      var content = null;
+      let content = null;
       if (this.contentRef) {
-        var xref = this.xref;
-        var fileObj = xref.fetchIfRef(this.contentRef);
+        const xref = this.xref;
+        const fileObj = xref.fetchIfRef(this.contentRef);
         if (fileObj && isStream(fileObj)) {
           content = fileObj.getBytes();
         } else {

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 import {
   Ascii85Stream,

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -26,7 +26,7 @@ import { ColorSpace } from "./colorspace.js";
 import { isStream } from "./primitives.js";
 import { MissingDataException } from "./core_utils.js";
 
-var ShadingType = {
+const ShadingType = {
   FUNCTION_BASED: 1,
   AXIAL: 2,
   RADIAL: 3,
@@ -36,7 +36,7 @@ var ShadingType = {
   TENSOR_PATCH_MESH: 7,
 };
 
-var Pattern = (function PatternClosure() {
+const Pattern = (function PatternClosure() {
   // Constructor should define this.getPattern
   function Pattern() {
     unreachable("should not call Pattern constructor");
@@ -58,8 +58,8 @@ var Pattern = (function PatternClosure() {
     handler,
     pdfFunctionFactory
   ) {
-    var dict = isStream(shading) ? shading.dict : shading;
-    var type = dict.get("ShadingType");
+    const dict = isStream(shading) ? shading.dict : shading;
+    const type = dict.get("ShadingType");
 
     try {
       switch (type) {
@@ -115,7 +115,7 @@ Shadings.RadialAxial = (function RadialAxialClosure() {
     this.coordsArr = dict.getArray("Coords");
     this.shadingType = dict.get("ShadingType");
     this.type = "Pattern";
-    var cs = dict.get("ColorSpace", "CS");
+    let cs = dict.get("ColorSpace", "CS");
     cs = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
     this.cs = cs;
     const bbox = dict.getArray("BBox");
@@ -125,18 +125,18 @@ Shadings.RadialAxial = (function RadialAxialClosure() {
       this.bbox = null;
     }
 
-    var t0 = 0.0,
+    let t0 = 0.0,
       t1 = 1.0;
     if (dict.has("Domain")) {
-      var domainArr = dict.getArray("Domain");
+      const domainArr = dict.getArray("Domain");
       t0 = domainArr[0];
       t1 = domainArr[1];
     }
 
-    var extendStart = false,
+    let extendStart = false,
       extendEnd = false;
     if (dict.has("Extend")) {
-      var extendArr = dict.getArray("Extend");
+      const extendArr = dict.getArray("Extend");
       extendStart = extendArr[0];
       extendEnd = extendArr[1];
     }
@@ -147,13 +147,13 @@ Shadings.RadialAxial = (function RadialAxialClosure() {
     ) {
       // Radial gradient only currently works if either circle is fully within
       // the other circle.
-      var x1 = this.coordsArr[0];
-      var y1 = this.coordsArr[1];
-      var r1 = this.coordsArr[2];
-      var x2 = this.coordsArr[3];
-      var y2 = this.coordsArr[4];
-      var r2 = this.coordsArr[5];
-      var distance = Math.sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
+      const x1 = this.coordsArr[0];
+      const y1 = this.coordsArr[1];
+      const r1 = this.coordsArr[2];
+      const x2 = this.coordsArr[3];
+      const y2 = this.coordsArr[4];
+      const r2 = this.coordsArr[5];
+      const distance = Math.sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
       if (r1 <= r2 + distance && r2 <= r1 + distance) {
         warn("Unsupported radial gradient.");
       }
@@ -162,8 +162,8 @@ Shadings.RadialAxial = (function RadialAxialClosure() {
     this.extendStart = extendStart;
     this.extendEnd = extendEnd;
 
-    var fnObj = dict.get("Function");
-    var fn = pdfFunctionFactory.createFromArray(fnObj);
+    const fnObj = dict.get("Function");
+    const fn = pdfFunctionFactory.createFromArray(fnObj);
 
     // 10 samples seems good enough for now, but probably won't work
     // if there are sharp color changes. Ideally, we would implement
@@ -171,7 +171,7 @@ Shadings.RadialAxial = (function RadialAxialClosure() {
     const NUMBER_OF_SAMPLES = 10;
     const step = (t1 - t0) / NUMBER_OF_SAMPLES;
 
-    var colorStops = (this.colorStops = []);
+    const colorStops = (this.colorStops = []);
 
     // Protect against bad domains.
     if (t0 >= t1 || step <= 0) {
@@ -181,18 +181,18 @@ Shadings.RadialAxial = (function RadialAxialClosure() {
       return;
     }
 
-    var color = new Float32Array(cs.numComps),
+    const color = new Float32Array(cs.numComps),
       ratio = new Float32Array(1);
-    var rgbColor;
+    let rgbColor;
     for (let i = 0; i <= NUMBER_OF_SAMPLES; i++) {
       ratio[0] = t0 + i * step;
       fn(ratio, 0, color, 0);
       rgbColor = cs.getRgb(color, 0);
-      var cssColor = Util.makeCssRgb(rgbColor[0], rgbColor[1], rgbColor[2]);
+      const cssColor = Util.makeCssRgb(rgbColor[0], rgbColor[1], rgbColor[2]);
       colorStops.push([i / NUMBER_OF_SAMPLES, cssColor]);
     }
 
-    var background = "transparent";
+    let background = "transparent";
     if (dict.has("Background")) {
       rgbColor = cs.getRgb(dict.get("Background"), 0);
       background = Util.makeCssRgb(rgbColor[0], rgbColor[1], rgbColor[2]);
@@ -215,9 +215,9 @@ Shadings.RadialAxial = (function RadialAxialClosure() {
 
   RadialAxial.prototype = {
     getIR: function RadialAxial_getIR() {
-      var coordsArr = this.coordsArr;
-      var shadingType = this.shadingType;
-      var type, p0, p1, r0, r1;
+      const coordsArr = this.coordsArr;
+      const shadingType = this.shadingType;
+      let type, p0, p1, r0, r1;
       if (shadingType === ShadingType.AXIAL) {
         p0 = [coordsArr[0], coordsArr[1]];
         p1 = [coordsArr[2], coordsArr[3]];
@@ -234,12 +234,12 @@ Shadings.RadialAxial = (function RadialAxialClosure() {
         unreachable(`getPattern type unknown: ${shadingType}`);
       }
 
-      var matrix = this.matrix;
+      const matrix = this.matrix;
       if (matrix) {
         p0 = Util.applyTransform(p0, matrix);
         p1 = Util.applyTransform(p1, matrix);
         if (shadingType === ShadingType.RADIAL) {
-          var scale = Util.singularValueDecompose2dScale(matrix);
+          const scale = Util.singularValueDecompose2dScale(matrix);
           r0 *= scale[0];
           r1 *= scale[1];
         }
@@ -261,9 +261,9 @@ Shadings.Mesh = (function MeshClosure() {
     this.buffer = 0;
     this.bufferLength = 0;
 
-    var numComps = context.numComps;
+    const numComps = context.numComps;
     this.tmpCompsBuf = new Float32Array(numComps);
-    var csNumComps = context.colorSpace.numComps;
+    const csNumComps = context.colorSpace.numComps;
     this.tmpCsCompsBuf = context.colorFn
       ? new Float32Array(csNumComps)
       : this.tmpCompsBuf;
@@ -276,7 +276,7 @@ Shadings.Mesh = (function MeshClosure() {
       if (this.bufferLength > 0) {
         return true;
       }
-      var nextByte = this.stream.getByte();
+      const nextByte = this.stream.getByte();
       if (nextByte < 0) {
         return false;
       }
@@ -285,8 +285,8 @@ Shadings.Mesh = (function MeshClosure() {
       return true;
     },
     readBits: function MeshStreamReader_readBits(n) {
-      var buffer = this.buffer;
-      var bufferLength = this.bufferLength;
+      let buffer = this.buffer;
+      let bufferLength = this.bufferLength;
       if (n === 32) {
         if (bufferLength === 0) {
           return (
@@ -302,7 +302,7 @@ Shadings.Mesh = (function MeshClosure() {
           (this.stream.getByte() << 16) |
           (this.stream.getByte() << 8) |
           this.stream.getByte();
-        var nextByte = this.stream.getByte();
+        const nextByte = this.stream.getByte();
         this.buffer = nextByte & ((1 << bufferLength) - 1);
         return (
           ((buffer << (8 - bufferLength)) |
@@ -330,11 +330,11 @@ Shadings.Mesh = (function MeshClosure() {
       return this.readBits(this.context.bitsPerFlag);
     },
     readCoordinate: function MeshStreamReader_readCoordinate() {
-      var bitsPerCoordinate = this.context.bitsPerCoordinate;
-      var xi = this.readBits(bitsPerCoordinate);
-      var yi = this.readBits(bitsPerCoordinate);
-      var decode = this.context.decode;
-      var scale =
+      const bitsPerCoordinate = this.context.bitsPerCoordinate;
+      const xi = this.readBits(bitsPerCoordinate);
+      const yi = this.readBits(bitsPerCoordinate);
+      const decode = this.context.decode;
+      const scale =
         bitsPerCoordinate < 32
           ? 1 / ((1 << bitsPerCoordinate) - 1)
           : 2.3283064365386963e-10; // 2 ^ -32
@@ -344,19 +344,19 @@ Shadings.Mesh = (function MeshClosure() {
       ];
     },
     readComponents: function MeshStreamReader_readComponents() {
-      var numComps = this.context.numComps;
-      var bitsPerComponent = this.context.bitsPerComponent;
-      var scale =
+      const numComps = this.context.numComps;
+      const bitsPerComponent = this.context.bitsPerComponent;
+      const scale =
         bitsPerComponent < 32
           ? 1 / ((1 << bitsPerComponent) - 1)
           : 2.3283064365386963e-10; // 2 ^ -32
-      var decode = this.context.decode;
-      var components = this.tmpCompsBuf;
-      for (var i = 0, j = 4; i < numComps; i++, j += 2) {
-        var ci = this.readBits(bitsPerComponent);
+      const decode = this.context.decode;
+      const components = this.tmpCompsBuf;
+      for (let i = 0, j = 4; i < numComps; i++, j += 2) {
+        const ci = this.readBits(bitsPerComponent);
         components[i] = ci * scale * (decode[j + 1] - decode[j]) + decode[j];
       }
-      var color = this.tmpCsCompsBuf;
+      const color = this.tmpCsCompsBuf;
       if (this.context.colorFn) {
         this.context.colorFn(components, 0, color, 0);
       }
@@ -365,15 +365,15 @@ Shadings.Mesh = (function MeshClosure() {
   };
 
   function decodeType4Shading(mesh, reader) {
-    var coords = mesh.coords;
-    var colors = mesh.colors;
-    var operators = [];
-    var ps = []; // not maintaining cs since that will match ps
-    var verticesLeft = 0; // assuming we have all data to start a new triangle
+    const coords = mesh.coords;
+    const colors = mesh.colors;
+    const operators = [];
+    const ps = []; // not maintaining cs since that will match ps
+    let verticesLeft = 0; // assuming we have all data to start a new triangle
     while (reader.hasData) {
-      var f = reader.readFlag();
-      var coord = reader.readCoordinate();
-      var color = reader.readComponents();
+      const f = reader.readFlag();
+      const coord = reader.readCoordinate();
+      const color = reader.readComponents();
       if (verticesLeft === 0) {
         // ignoring flags if we started a triangle
         if (!(0 <= f && f <= 2)) {
@@ -409,12 +409,12 @@ Shadings.Mesh = (function MeshClosure() {
   }
 
   function decodeType5Shading(mesh, reader, verticesPerRow) {
-    var coords = mesh.coords;
-    var colors = mesh.colors;
-    var ps = []; // not maintaining cs since that will match ps
+    const coords = mesh.coords;
+    const colors = mesh.colors;
+    const ps = []; // not maintaining cs since that will match ps
     while (reader.hasData) {
-      var coord = reader.readCoordinate();
-      var color = reader.readComponents();
+      const coord = reader.readCoordinate();
+      const color = reader.readComponents();
       ps.push(coords.length);
       coords.push(coord);
       colors.push(color);
@@ -427,16 +427,16 @@ Shadings.Mesh = (function MeshClosure() {
     });
   }
 
-  var MIN_SPLIT_PATCH_CHUNKS_AMOUNT = 3;
-  var MAX_SPLIT_PATCH_CHUNKS_AMOUNT = 20;
+  const MIN_SPLIT_PATCH_CHUNKS_AMOUNT = 3;
+  const MAX_SPLIT_PATCH_CHUNKS_AMOUNT = 20;
 
-  var TRIANGLE_DENSITY = 20; // count of triangles per entire mesh bounds
+  const TRIANGLE_DENSITY = 20; // count of triangles per entire mesh bounds
 
-  var getB = (function getBClosure() {
+  const getB = (function getBClosure() {
     function buildB(count) {
-      var lut = [];
-      for (var i = 0; i <= count; i++) {
-        var t = i / count,
+      const lut = [];
+      for (let i = 0; i <= count; i++) {
+        const t = i / count,
           t_ = 1 - t;
         lut.push(
           new Float32Array([
@@ -449,7 +449,7 @@ Shadings.Mesh = (function MeshClosure() {
       }
       return lut;
     }
-    var cache = [];
+    const cache = [];
     return function getB(count) {
       if (!cache[count]) {
         cache[count] = buildB(count);
@@ -459,39 +459,39 @@ Shadings.Mesh = (function MeshClosure() {
   })();
 
   function buildFigureFromPatch(mesh, index) {
-    var figure = mesh.figures[index];
+    const figure = mesh.figures[index];
     assert(figure.type === "patch", "Unexpected patch mesh figure");
 
-    var coords = mesh.coords,
+    const coords = mesh.coords,
       colors = mesh.colors;
-    var pi = figure.coords;
-    var ci = figure.colors;
+    const pi = figure.coords;
+    const ci = figure.colors;
 
-    var figureMinX = Math.min(
+    const figureMinX = Math.min(
       coords[pi[0]][0],
       coords[pi[3]][0],
       coords[pi[12]][0],
       coords[pi[15]][0]
     );
-    var figureMinY = Math.min(
+    const figureMinY = Math.min(
       coords[pi[0]][1],
       coords[pi[3]][1],
       coords[pi[12]][1],
       coords[pi[15]][1]
     );
-    var figureMaxX = Math.max(
+    const figureMaxX = Math.max(
       coords[pi[0]][0],
       coords[pi[3]][0],
       coords[pi[12]][0],
       coords[pi[15]][0]
     );
-    var figureMaxY = Math.max(
+    const figureMaxY = Math.max(
       coords[pi[0]][1],
       coords[pi[3]][1],
       coords[pi[12]][1],
       coords[pi[15]][1]
     );
-    var splitXBy = Math.ceil(
+    let splitXBy = Math.ceil(
       ((figureMaxX - figureMinX) * TRIANGLE_DENSITY) /
         (mesh.bounds[2] - mesh.bounds[0])
     );
@@ -499,7 +499,7 @@ Shadings.Mesh = (function MeshClosure() {
       MIN_SPLIT_PATCH_CHUNKS_AMOUNT,
       Math.min(MAX_SPLIT_PATCH_CHUNKS_AMOUNT, splitXBy)
     );
-    var splitYBy = Math.ceil(
+    let splitYBy = Math.ceil(
       ((figureMaxY - figureMinY) * TRIANGLE_DENSITY) /
         (mesh.bounds[3] - mesh.bounds[1])
     );
@@ -508,19 +508,19 @@ Shadings.Mesh = (function MeshClosure() {
       Math.min(MAX_SPLIT_PATCH_CHUNKS_AMOUNT, splitYBy)
     );
 
-    var verticesPerRow = splitXBy + 1;
-    var figureCoords = new Int32Array((splitYBy + 1) * verticesPerRow);
-    var figureColors = new Int32Array((splitYBy + 1) * verticesPerRow);
-    var k = 0;
-    var cl = new Uint8Array(3),
+    const verticesPerRow = splitXBy + 1;
+    const figureCoords = new Int32Array((splitYBy + 1) * verticesPerRow);
+    const figureColors = new Int32Array((splitYBy + 1) * verticesPerRow);
+    let k = 0;
+    const cl = new Uint8Array(3),
       cr = new Uint8Array(3);
-    var c0 = colors[ci[0]],
+    const c0 = colors[ci[0]],
       c1 = colors[ci[1]],
       c2 = colors[ci[2]],
       c3 = colors[ci[3]];
-    var bRow = getB(splitYBy),
+    const bRow = getB(splitYBy),
       bCol = getB(splitXBy);
-    for (var row = 0; row <= splitYBy; row++) {
+    for (let row = 0; row <= splitYBy; row++) {
       cl[0] = ((c0[0] * (splitYBy - row) + c2[0] * row) / splitYBy) | 0;
       cl[1] = ((c0[1] * (splitYBy - row) + c2[1] * row) / splitYBy) | 0;
       cl[2] = ((c0[2] * (splitYBy - row) + c2[2] * row) / splitYBy) | 0;
@@ -529,19 +529,19 @@ Shadings.Mesh = (function MeshClosure() {
       cr[1] = ((c1[1] * (splitYBy - row) + c3[1] * row) / splitYBy) | 0;
       cr[2] = ((c1[2] * (splitYBy - row) + c3[2] * row) / splitYBy) | 0;
 
-      for (var col = 0; col <= splitXBy; col++, k++) {
+      for (let col = 0; col <= splitXBy; col++, k++) {
         if (
           (row === 0 || row === splitYBy) &&
           (col === 0 || col === splitXBy)
         ) {
           continue;
         }
-        var x = 0,
+        let x = 0,
           y = 0;
-        var q = 0;
-        for (var i = 0; i <= 3; i++) {
-          for (var j = 0; j <= 3; j++, q++) {
-            var m = bRow[row][i] * bCol[col][j];
+        let q = 0;
+        for (let i = 0; i <= 3; i++) {
+          for (let j = 0; j <= 3; j++, q++) {
+            const m = bRow[row][i] * bCol[col][j];
             x += coords[pi[q]][0] * m;
             y += coords[pi[q]][1] * m;
           }
@@ -549,7 +549,7 @@ Shadings.Mesh = (function MeshClosure() {
         figureCoords[k] = coords.length;
         coords.push([x, y]);
         figureColors[k] = colors.length;
-        var newColor = new Uint8Array(3);
+        const newColor = new Uint8Array(3);
         newColor[0] = ((cl[0] * (splitXBy - col) + cr[0] * col) / splitXBy) | 0;
         newColor[1] = ((cl[1] * (splitXBy - col) + cr[1] * col) / splitXBy) | 0;
         newColor[2] = ((cl[2] * (splitXBy - col) + cr[2] * col) / splitXBy) | 0;
@@ -575,21 +575,21 @@ Shadings.Mesh = (function MeshClosure() {
 
   function decodeType6Shading(mesh, reader) {
     // A special case of Type 7. The p11, p12, p21, p22 automatically filled
-    var coords = mesh.coords;
-    var colors = mesh.colors;
-    var ps = new Int32Array(16); // p00, p10, ..., p30, p01, ..., p33
-    var cs = new Int32Array(4); // c00, c30, c03, c33
+    const coords = mesh.coords;
+    const colors = mesh.colors;
+    const ps = new Int32Array(16); // p00, p10, ..., p30, p01, ..., p33
+    const cs = new Int32Array(4); // c00, c30, c03, c33
     while (reader.hasData) {
-      var f = reader.readFlag();
+      const f = reader.readFlag();
       if (!(0 <= f && f <= 3)) {
         throw new FormatError("Unknown type6 flag");
       }
       var i, ii;
-      var pi = coords.length;
+      const pi = coords.length;
       for (i = 0, ii = f !== 0 ? 8 : 12; i < ii; i++) {
         coords.push(reader.readCoordinate());
       }
-      var ci = colors.length;
+      const ci = colors.length;
       for (i = 0, ii = f !== 0 ? 2 : 4; i < ii; i++) {
         colors.push(reader.readComponents());
       }
@@ -707,21 +707,21 @@ Shadings.Mesh = (function MeshClosure() {
   }
 
   function decodeType7Shading(mesh, reader) {
-    var coords = mesh.coords;
-    var colors = mesh.colors;
-    var ps = new Int32Array(16); // p00, p10, ..., p30, p01, ..., p33
-    var cs = new Int32Array(4); // c00, c30, c03, c33
+    const coords = mesh.coords;
+    const colors = mesh.colors;
+    const ps = new Int32Array(16); // p00, p10, ..., p30, p01, ..., p33
+    const cs = new Int32Array(4); // c00, c30, c03, c33
     while (reader.hasData) {
-      var f = reader.readFlag();
+      const f = reader.readFlag();
       if (!(0 <= f && f <= 3)) {
         throw new FormatError("Unknown type7 flag");
       }
       var i, ii;
-      var pi = coords.length;
+      const pi = coords.length;
       for (i = 0, ii = f !== 0 ? 12 : 16; i < ii; i++) {
         coords.push(reader.readCoordinate());
       }
-      var ci = colors.length;
+      const ci = colors.length;
       for (i = 0, ii = f !== 0 ? 2 : 4; i < ii; i++) {
         colors.push(reader.readComponents());
       }
@@ -778,12 +778,12 @@ Shadings.Mesh = (function MeshClosure() {
   }
 
   function updateBounds(mesh) {
-    var minX = mesh.coords[0][0],
+    let minX = mesh.coords[0][0],
       minY = mesh.coords[0][1],
       maxX = minX,
       maxY = minY;
-    for (var i = 1, ii = mesh.coords.length; i < ii; i++) {
-      var x = mesh.coords[i][0],
+    for (let i = 1, ii = mesh.coords.length; i < ii; i++) {
+      const x = mesh.coords[i][0],
         y = mesh.coords[i][1];
       minX = minX > x ? x : minX;
       minY = minY > y ? y : minY;
@@ -794,30 +794,30 @@ Shadings.Mesh = (function MeshClosure() {
   }
 
   function packData(mesh) {
-    var i, ii, j, jj;
+    let i, ii, j, jj;
 
-    var coords = mesh.coords;
-    var coordsPacked = new Float32Array(coords.length * 2);
+    const coords = mesh.coords;
+    const coordsPacked = new Float32Array(coords.length * 2);
     for (i = 0, j = 0, ii = coords.length; i < ii; i++) {
-      var xy = coords[i];
+      const xy = coords[i];
       coordsPacked[j++] = xy[0];
       coordsPacked[j++] = xy[1];
     }
     mesh.coords = coordsPacked;
 
-    var colors = mesh.colors;
-    var colorsPacked = new Uint8Array(colors.length * 3);
+    const colors = mesh.colors;
+    const colorsPacked = new Uint8Array(colors.length * 3);
     for (i = 0, j = 0, ii = colors.length; i < ii; i++) {
-      var c = colors[i];
+      const c = colors[i];
       colorsPacked[j++] = c[0];
       colorsPacked[j++] = c[1];
       colorsPacked[j++] = c[2];
     }
     mesh.colors = colorsPacked;
 
-    var figures = mesh.figures;
+    const figures = mesh.figures;
     for (i = 0, ii = figures.length; i < ii; i++) {
-      var figure = figures[i],
+      const figure = figures[i],
         ps = figure.coords,
         cs = figure.colors;
       for (j = 0, jj = ps.length; j < jj; j++) {
@@ -831,7 +831,7 @@ Shadings.Mesh = (function MeshClosure() {
     if (!isStream(stream)) {
       throw new FormatError("Mesh data is not a stream");
     }
-    var dict = stream.dict;
+    const dict = stream.dict;
     this.matrix = matrix;
     this.shadingType = dict.get("ShadingType");
     this.type = "Pattern";
@@ -841,21 +841,21 @@ Shadings.Mesh = (function MeshClosure() {
     } else {
       this.bbox = null;
     }
-    var cs = dict.get("ColorSpace", "CS");
+    let cs = dict.get("ColorSpace", "CS");
     cs = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
     this.cs = cs;
     this.background = dict.has("Background")
       ? cs.getRgb(dict.get("Background"), 0)
       : null;
 
-    var fnObj = dict.get("Function");
-    var fn = fnObj ? pdfFunctionFactory.createFromArray(fnObj) : null;
+    const fnObj = dict.get("Function");
+    const fn = fnObj ? pdfFunctionFactory.createFromArray(fnObj) : null;
 
     this.coords = [];
     this.colors = [];
     this.figures = [];
 
-    var decodeContext = {
+    const decodeContext = {
       bitsPerCoordinate: dict.get("BitsPerCoordinate"),
       bitsPerComponent: dict.get("BitsPerComponent"),
       bitsPerFlag: dict.get("BitsPerFlag"),
@@ -864,9 +864,9 @@ Shadings.Mesh = (function MeshClosure() {
       colorSpace: cs,
       numComps: fn ? 1 : cs.numComps,
     };
-    var reader = new MeshStreamReader(stream, decodeContext);
+    const reader = new MeshStreamReader(stream, decodeContext);
 
-    var patchMesh = false;
+    let patchMesh = false;
     switch (this.shadingType) {
       case ShadingType.FREE_FORM_MESH:
         decodeType4Shading(this, reader);
@@ -894,7 +894,7 @@ Shadings.Mesh = (function MeshClosure() {
     if (patchMesh) {
       // dirty bounds calculation for determining, how dense shall be triangles
       updateBounds(this);
-      for (var i = 0, ii = this.figures.length; i < ii; i++) {
+      for (let i = 0, ii = this.figures.length; i < ii; i++) {
         buildFigureFromPatch(this, i);
       }
     }

--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -16,9 +16,9 @@
 
 import { assert } from "../shared/util.js";
 
-var EOF = {};
+const EOF = {};
 
-var Name = (function NameClosure() {
+const Name = (function NameClosure() {
   let nameCache = Object.create(null);
 
   function Name(name) {
@@ -28,7 +28,7 @@ var Name = (function NameClosure() {
   Name.prototype = {};
 
   Name.get = function Name_get(name) {
-    var nameValue = nameCache[name];
+    const nameValue = nameCache[name];
     return nameValue ? nameValue : (nameCache[name] = new Name(name));
   };
 
@@ -39,7 +39,7 @@ var Name = (function NameClosure() {
   return Name;
 })();
 
-var Cmd = (function CmdClosure() {
+const Cmd = (function CmdClosure() {
   let cmdCache = Object.create(null);
 
   function Cmd(cmd) {
@@ -49,7 +49,7 @@ var Cmd = (function CmdClosure() {
   Cmd.prototype = {};
 
   Cmd.get = function Cmd_get(cmd) {
-    var cmdValue = cmdCache[cmd];
+    const cmdValue = cmdCache[cmd];
     return cmdValue ? cmdValue : (cmdCache[cmd] = new Cmd(cmd));
   };
 
@@ -60,7 +60,7 @@ var Cmd = (function CmdClosure() {
   return Cmd;
 })();
 
-var Dict = (function DictClosure() {
+const Dict = (function DictClosure() {
   var nonSerializable = function nonSerializableClosure() {
     return nonSerializable; // creating closure on some variable
   };
@@ -144,7 +144,7 @@ var Dict = (function DictClosure() {
     },
 
     forEach: function Dict_forEach(callback) {
-      for (var key in this._map) {
+      for (const key in this._map) {
         callback(key, this.get(key));
       }
     },
@@ -207,7 +207,7 @@ var Ref = (function RefClosure() {
 
 // The reference is identified by number and generation.
 // This structure stores only one instance of the reference.
-var RefSet = (function RefSetClosure() {
+const RefSet = (function RefSetClosure() {
   function RefSet() {
     this.dict = Object.create(null);
   }
@@ -229,7 +229,7 @@ var RefSet = (function RefSetClosure() {
   return RefSet;
 })();
 
-var RefSetCache = (function RefSetCacheClosure() {
+const RefSetCache = (function RefSetCacheClosure() {
   function RefSetCache() {
     this.dict = Object.create(null);
   }
@@ -252,7 +252,7 @@ var RefSetCache = (function RefSetCacheClosure() {
     },
 
     forEach: function RefSetCache_forEach(fn, thisArg) {
-      for (var i in this.dict) {
+      for (const i in this.dict) {
         fn.call(thisArg, this.dict[i]);
       }
     },

--- a/src/core/ps_parser.js
+++ b/src/core/ps_parser.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 import { FormatError, shadow } from "../shared/util.js";
 import { EOF } from "./primitives.js";

--- a/src/core/standard_fonts.js
+++ b/src/core/standard_fonts.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 import { getLookupTableFactory } from "./core_utils.js";
 

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -23,7 +23,7 @@ import { FormatError, stringToBytes, unreachable } from "../shared/util.js";
 import { isDict } from "./primitives.js";
 import { isSpace } from "./core_utils.js";
 
-var Stream = (function StreamClosure() {
+const Stream = (function StreamClosure() {
   function Stream(arrayBuffer, start, length, dict) {
     this.bytes =
       arrayBuffer instanceof Uint8Array
@@ -51,32 +51,32 @@ var Stream = (function StreamClosure() {
       return this.bytes[this.pos++];
     },
     getUint16: function Stream_getUint16() {
-      var b0 = this.getByte();
-      var b1 = this.getByte();
+      const b0 = this.getByte();
+      const b1 = this.getByte();
       if (b0 === -1 || b1 === -1) {
         return -1;
       }
       return (b0 << 8) + b1;
     },
     getInt32: function Stream_getInt32() {
-      var b0 = this.getByte();
-      var b1 = this.getByte();
-      var b2 = this.getByte();
-      var b3 = this.getByte();
+      const b0 = this.getByte();
+      const b1 = this.getByte();
+      const b2 = this.getByte();
+      const b3 = this.getByte();
       return (b0 << 24) + (b1 << 16) + (b2 << 8) + b3;
     },
     // Returns subarray of original buffer, should only be read.
     getBytes(length, forceClamped = false) {
-      var bytes = this.bytes;
-      var pos = this.pos;
-      var strEnd = this.end;
+      const bytes = this.bytes;
+      const pos = this.pos;
+      const strEnd = this.end;
 
       if (!length) {
         const subarray = bytes.subarray(pos, strEnd);
         // `this.bytes` is always a `Uint8Array` here.
         return forceClamped ? new Uint8ClampedArray(subarray) : subarray;
       }
-      var end = pos + length;
+      let end = pos + length;
       if (end > strEnd) {
         end = strEnd;
       }
@@ -86,14 +86,14 @@ var Stream = (function StreamClosure() {
       return forceClamped ? new Uint8ClampedArray(subarray) : subarray;
     },
     peekByte: function Stream_peekByte() {
-      var peekedByte = this.getByte();
+      const peekedByte = this.getByte();
       if (peekedByte !== -1) {
         this.pos--;
       }
       return peekedByte;
     },
     peekBytes(length, forceClamped = false) {
-      var bytes = this.getBytes(length, forceClamped);
+      const bytes = this.getBytes(length, forceClamped);
       this.pos -= bytes.length;
       return bytes;
     },
@@ -128,7 +128,7 @@ var Stream = (function StreamClosure() {
   return Stream;
 })();
 
-var StringStream = (function StringStreamClosure() {
+const StringStream = (function StringStreamClosure() {
   function StringStream(str) {
     const bytes = stringToBytes(str);
     Stream.call(this, bytes);
@@ -140,12 +140,12 @@ var StringStream = (function StringStreamClosure() {
 })();
 
 // super class for the decoding streams
-var DecodeStream = (function DecodeStreamClosure() {
+const DecodeStream = (function DecodeStreamClosure() {
   // Lots of DecodeStreams are created whose buffers are never used.  For these
   // we share a single empty buffer. This is (a) space-efficient and (b) avoids
   // having special cases that would be required if we used |null| for an empty
   // buffer.
-  var emptyBuffer = new Uint8Array(0);
+  const emptyBuffer = new Uint8Array(0);
 
   function DecodeStream(maybeMinBufferLength) {
     this._rawMinBufferLength = maybeMinBufferLength || 0;
@@ -171,20 +171,20 @@ var DecodeStream = (function DecodeStreamClosure() {
       return this.bufferLength === 0;
     },
     ensureBuffer: function DecodeStream_ensureBuffer(requested) {
-      var buffer = this.buffer;
+      const buffer = this.buffer;
       if (requested <= buffer.byteLength) {
         return buffer;
       }
-      var size = this.minBufferLength;
+      let size = this.minBufferLength;
       while (size < requested) {
         size *= 2;
       }
-      var buffer2 = new Uint8Array(size);
+      const buffer2 = new Uint8Array(size);
       buffer2.set(buffer);
       return (this.buffer = buffer2);
     },
     getByte: function DecodeStream_getByte() {
-      var pos = this.pos;
+      const pos = this.pos;
       while (this.bufferLength <= pos) {
         if (this.eof) {
           return -1;
@@ -194,22 +194,22 @@ var DecodeStream = (function DecodeStreamClosure() {
       return this.buffer[this.pos++];
     },
     getUint16: function DecodeStream_getUint16() {
-      var b0 = this.getByte();
-      var b1 = this.getByte();
+      const b0 = this.getByte();
+      const b1 = this.getByte();
       if (b0 === -1 || b1 === -1) {
         return -1;
       }
       return (b0 << 8) + b1;
     },
     getInt32: function DecodeStream_getInt32() {
-      var b0 = this.getByte();
-      var b1 = this.getByte();
-      var b2 = this.getByte();
-      var b3 = this.getByte();
+      const b0 = this.getByte();
+      const b1 = this.getByte();
+      const b2 = this.getByte();
+      const b3 = this.getByte();
       return (b0 << 24) + (b1 << 16) + (b2 << 8) + b3;
     },
     getBytes(length, forceClamped = false) {
-      var end,
+      let end,
         pos = this.pos;
 
       if (length) {
@@ -219,7 +219,7 @@ var DecodeStream = (function DecodeStreamClosure() {
         while (!this.eof && this.bufferLength < end) {
           this.readBlock();
         }
-        var bufEnd = this.bufferLength;
+        const bufEnd = this.bufferLength;
         if (end > bufEnd) {
           end = bufEnd;
         }
@@ -238,19 +238,19 @@ var DecodeStream = (function DecodeStreamClosure() {
         : subarray;
     },
     peekByte: function DecodeStream_peekByte() {
-      var peekedByte = this.getByte();
+      const peekedByte = this.getByte();
       if (peekedByte !== -1) {
         this.pos--;
       }
       return peekedByte;
     },
     peekBytes(length, forceClamped = false) {
-      var bytes = this.getBytes(length, forceClamped);
+      const bytes = this.getBytes(length, forceClamped);
       this.pos -= bytes.length;
       return bytes;
     },
     makeSubStream: function DecodeStream_makeSubStream(start, length, dict) {
-      var end = start + length;
+      const end = start + length;
       while (this.bufferLength <= end && !this.eof) {
         this.readBlock();
       }
@@ -281,7 +281,7 @@ var DecodeStream = (function DecodeStreamClosure() {
   return DecodeStream;
 })();
 
-var StreamsSequenceStream = (function StreamsSequenceStreamClosure() {
+const StreamsSequenceStream = (function StreamsSequenceStreamClosure() {
   function StreamsSequenceStream(streams) {
     this.streams = streams;
 
@@ -300,24 +300,24 @@ var StreamsSequenceStream = (function StreamsSequenceStreamClosure() {
   StreamsSequenceStream.prototype = Object.create(DecodeStream.prototype);
 
   StreamsSequenceStream.prototype.readBlock = function streamSequenceStreamReadBlock() {
-    var streams = this.streams;
+    const streams = this.streams;
     if (streams.length === 0) {
       this.eof = true;
       return;
     }
-    var stream = streams.shift();
-    var chunk = stream.getBytes();
-    var bufferLength = this.bufferLength;
-    var newLength = bufferLength + chunk.length;
-    var buffer = this.ensureBuffer(newLength);
+    const stream = streams.shift();
+    const chunk = stream.getBytes();
+    const bufferLength = this.bufferLength;
+    const newLength = bufferLength + chunk.length;
+    const buffer = this.ensureBuffer(newLength);
     buffer.set(chunk, bufferLength);
     this.bufferLength = newLength;
   };
 
   StreamsSequenceStream.prototype.getBaseStreams = function StreamsSequenceStream_getBaseStreams() {
-    var baseStreams = [];
-    for (var i = 0, ii = this.streams.length; i < ii; i++) {
-      var stream = this.streams[i];
+    const baseStreams = [];
+    for (let i = 0, ii = this.streams.length; i < ii; i++) {
+      const stream = this.streams[i];
       if (stream.getBaseStreams) {
         baseStreams.push(...stream.getBaseStreams());
       }
@@ -328,14 +328,14 @@ var StreamsSequenceStream = (function StreamsSequenceStreamClosure() {
   return StreamsSequenceStream;
 })();
 
-var FlateStream = (function FlateStreamClosure() {
+const FlateStream = (function FlateStreamClosure() {
   // prettier-ignore
-  var codeLenCodeMap = new Int32Array([
+  const codeLenCodeMap = new Int32Array([
     16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15
   ]);
 
   // prettier-ignore
-  var lengthDecode = new Int32Array([
+  const lengthDecode = new Int32Array([
     0x00003, 0x00004, 0x00005, 0x00006, 0x00007, 0x00008, 0x00009, 0x0000a,
     0x1000b, 0x1000d, 0x1000f, 0x10011, 0x20013, 0x20017, 0x2001b, 0x2001f,
     0x30023, 0x3002b, 0x30033, 0x3003b, 0x40043, 0x40053, 0x40063, 0x40073,
@@ -343,7 +343,7 @@ var FlateStream = (function FlateStreamClosure() {
   ]);
 
   // prettier-ignore
-  var distDecode = new Int32Array([
+  const distDecode = new Int32Array([
     0x00001, 0x00002, 0x00003, 0x00004, 0x10005, 0x10007, 0x20009, 0x2000d,
     0x30011, 0x30019, 0x40021, 0x40031, 0x50041, 0x50061, 0x60081, 0x600c1,
     0x70101, 0x70181, 0x80201, 0x80301, 0x90401, 0x90601, 0xa0801, 0xa0c01,
@@ -351,7 +351,7 @@ var FlateStream = (function FlateStreamClosure() {
   ]);
 
   // prettier-ignore
-  var fixedLitCodeTab = [new Int32Array([
+  const fixedLitCodeTab = [new Int32Array([
     0x70100, 0x80050, 0x80010, 0x80118, 0x70110, 0x80070, 0x80030, 0x900c0,
     0x70108, 0x80060, 0x80020, 0x900a0, 0x80000, 0x80080, 0x80040, 0x900e0,
     0x70104, 0x80058, 0x80018, 0x90090, 0x70114, 0x80078, 0x80038, 0x900d0,
@@ -419,7 +419,7 @@ var FlateStream = (function FlateStreamClosure() {
   ]), 9];
 
   // prettier-ignore
-  var fixedDistCodeTab = [new Int32Array([
+  const fixedDistCodeTab = [new Int32Array([
     0x50000, 0x50010, 0x50008, 0x50018, 0x50004, 0x50014, 0x5000c, 0x5001c,
     0x50002, 0x50012, 0x5000a, 0x5001a, 0x50006, 0x50016, 0x5000e, 0x00000,
     0x50001, 0x50011, 0x50009, 0x50019, 0x50005, 0x50015, 0x5000d, 0x5001d,
@@ -430,8 +430,8 @@ var FlateStream = (function FlateStreamClosure() {
     this.str = str;
     this.dict = str.dict;
 
-    var cmf = str.getByte();
-    var flg = str.getByte();
+    const cmf = str.getByte();
+    const flg = str.getByte();
     if (cmf === -1 || flg === -1) {
       throw new FormatError(`Invalid header in flate stream: ${cmf}, ${flg}`);
     }
@@ -456,11 +456,11 @@ var FlateStream = (function FlateStreamClosure() {
   FlateStream.prototype = Object.create(DecodeStream.prototype);
 
   FlateStream.prototype.getBits = function FlateStream_getBits(bits) {
-    var str = this.str;
-    var codeSize = this.codeSize;
-    var codeBuf = this.codeBuf;
+    const str = this.str;
+    let codeSize = this.codeSize;
+    let codeBuf = this.codeBuf;
 
-    var b;
+    let b;
     while (codeSize < bits) {
       if ((b = str.getByte()) === -1) {
         throw new FormatError("Bad encoding in flate stream");
@@ -476,13 +476,13 @@ var FlateStream = (function FlateStreamClosure() {
   };
 
   FlateStream.prototype.getCode = function FlateStream_getCode(table) {
-    var str = this.str;
-    var codes = table[0];
-    var maxLen = table[1];
-    var codeSize = this.codeSize;
-    var codeBuf = this.codeBuf;
+    const str = this.str;
+    const codes = table[0];
+    const maxLen = table[1];
+    let codeSize = this.codeSize;
+    let codeBuf = this.codeBuf;
 
-    var b;
+    let b;
     while (codeSize < maxLen) {
       if ((b = str.getByte()) === -1) {
         // premature end of stream. code might however still be valid.
@@ -492,9 +492,9 @@ var FlateStream = (function FlateStreamClosure() {
       codeBuf |= b << codeSize;
       codeSize += 8;
     }
-    var code = codes[codeBuf & ((1 << maxLen) - 1)];
-    var codeLen = code >> 16;
-    var codeVal = code & 0xffff;
+    const code = codes[codeBuf & ((1 << maxLen) - 1)];
+    const codeLen = code >> 16;
+    const codeVal = code & 0xffff;
     if (codeLen < 1 || codeSize < codeLen) {
       throw new FormatError("Bad encoding in flate stream");
     }
@@ -506,11 +506,11 @@ var FlateStream = (function FlateStreamClosure() {
   FlateStream.prototype.generateHuffmanTable = function flateStreamGenerateHuffmanTable(
     lengths
   ) {
-    var n = lengths.length;
+    const n = lengths.length;
 
     // find max code length
-    var maxLen = 0;
-    var i;
+    let maxLen = 0;
+    let i;
     for (i = 0; i < n; ++i) {
       if (lengths[i] > maxLen) {
         maxLen = lengths[i];
@@ -518,18 +518,18 @@ var FlateStream = (function FlateStreamClosure() {
     }
 
     // build the table
-    var size = 1 << maxLen;
-    var codes = new Int32Array(size);
+    const size = 1 << maxLen;
+    const codes = new Int32Array(size);
     for (
-      var len = 1, code = 0, skip = 2;
+      let len = 1, code = 0, skip = 2;
       len <= maxLen;
       ++len, code <<= 1, skip <<= 1
     ) {
-      for (var val = 0; val < n; ++val) {
+      for (let val = 0; val < n; ++val) {
         if (lengths[val] === len) {
           // bit-reverse the code
-          var code2 = 0;
-          var t = code;
+          let code2 = 0;
+          let t = code;
           for (i = 0; i < len; ++i) {
             code2 = (code2 << 1) | (t & 1);
             t >>= 1;
@@ -548,10 +548,10 @@ var FlateStream = (function FlateStreamClosure() {
   };
 
   FlateStream.prototype.readBlock = function FlateStream_readBlock() {
-    var buffer, len;
-    var str = this.str;
+    let buffer, len;
+    const str = this.str;
     // read block header
-    var hdr = this.getBits(3);
+    let hdr = this.getBits(3);
     if (hdr & 1) {
       this.eof = true;
     }
@@ -559,12 +559,12 @@ var FlateStream = (function FlateStreamClosure() {
 
     if (hdr === 0) {
       // uncompressed block
-      var b;
+      let b;
 
       if ((b = str.getByte()) === -1) {
         throw new FormatError("Bad block header in flate stream");
       }
-      var blockLen = b;
+      let blockLen = b;
       if ((b = str.getByte()) === -1) {
         throw new FormatError("Bad block header in flate stream");
       }
@@ -572,7 +572,7 @@ var FlateStream = (function FlateStreamClosure() {
       if ((b = str.getByte()) === -1) {
         throw new FormatError("Bad block header in flate stream");
       }
-      var check = b;
+      let check = b;
       if ((b = str.getByte()) === -1) {
         throw new FormatError("Bad block header in flate stream");
       }
@@ -604,35 +604,35 @@ var FlateStream = (function FlateStreamClosure() {
       return;
     }
 
-    var litCodeTable;
-    var distCodeTable;
+    let litCodeTable;
+    let distCodeTable;
     if (hdr === 1) {
       // compressed block, fixed codes
       litCodeTable = fixedLitCodeTab;
       distCodeTable = fixedDistCodeTab;
     } else if (hdr === 2) {
       // compressed block, dynamic codes
-      var numLitCodes = this.getBits(5) + 257;
-      var numDistCodes = this.getBits(5) + 1;
-      var numCodeLenCodes = this.getBits(4) + 4;
+      const numLitCodes = this.getBits(5) + 257;
+      const numDistCodes = this.getBits(5) + 1;
+      const numCodeLenCodes = this.getBits(4) + 4;
 
       // build the code lengths code table
-      var codeLenCodeLengths = new Uint8Array(codeLenCodeMap.length);
+      const codeLenCodeLengths = new Uint8Array(codeLenCodeMap.length);
 
-      var i;
+      let i;
       for (i = 0; i < numCodeLenCodes; ++i) {
         codeLenCodeLengths[codeLenCodeMap[i]] = this.getBits(3);
       }
-      var codeLenCodeTab = this.generateHuffmanTable(codeLenCodeLengths);
+      const codeLenCodeTab = this.generateHuffmanTable(codeLenCodeLengths);
 
       // build the literal and distance code tables
       len = 0;
       i = 0;
-      var codes = numLitCodes + numDistCodes;
-      var codeLengths = new Uint8Array(codes);
-      var bitsLength, bitsOffset, what;
+      const codes = numLitCodes + numDistCodes;
+      const codeLengths = new Uint8Array(codes);
+      let bitsLength, bitsOffset, what;
       while (i < codes) {
-        var code = this.getCode(codeLenCodeTab);
+        const code = this.getCode(codeLenCodeTab);
         if (code === 16) {
           bitsLength = 2;
           bitsOffset = 3;
@@ -650,7 +650,7 @@ var FlateStream = (function FlateStreamClosure() {
           continue;
         }
 
-        var repeatLength = this.getBits(bitsLength) + bitsOffset;
+        let repeatLength = this.getBits(bitsLength) + bitsOffset;
         while (repeatLength-- > 0) {
           codeLengths[i++] = what;
         }
@@ -667,10 +667,10 @@ var FlateStream = (function FlateStreamClosure() {
     }
 
     buffer = this.buffer;
-    var limit = buffer ? buffer.length : 0;
-    var pos = this.bufferLength;
+    let limit = buffer ? buffer.length : 0;
+    let pos = this.bufferLength;
     while (true) {
-      var code1 = this.getCode(litCodeTable);
+      let code1 = this.getCode(litCodeTable);
       if (code1 < 256) {
         if (pos + 1 >= limit) {
           buffer = this.ensureBuffer(pos + 1);
@@ -685,7 +685,7 @@ var FlateStream = (function FlateStreamClosure() {
       }
       code1 -= 257;
       code1 = lengthDecode[code1];
-      var code2 = code1 >> 16;
+      let code2 = code1 >> 16;
       if (code2 > 0) {
         code2 = this.getBits(code2);
       }
@@ -696,12 +696,12 @@ var FlateStream = (function FlateStreamClosure() {
       if (code2 > 0) {
         code2 = this.getBits(code2);
       }
-      var dist = (code1 & 0xffff) + code2;
+      const dist = (code1 & 0xffff) + code2;
       if (pos + len >= limit) {
         buffer = this.ensureBuffer(pos + len);
         limit = buffer.length;
       }
-      for (var k = 0; k < len; ++k, ++pos) {
+      for (let k = 0; k < len; ++k, ++pos) {
         buffer[pos] = buffer[pos - dist];
       }
     }
@@ -710,12 +710,12 @@ var FlateStream = (function FlateStreamClosure() {
   return FlateStream;
 })();
 
-var PredictorStream = (function PredictorStreamClosure() {
+const PredictorStream = (function PredictorStreamClosure() {
   function PredictorStream(str, maybeLength, params) {
     if (!isDict(params)) {
       return str; // no prediction
     }
-    var predictor = (this.predictor = params.get("Predictor") || 1);
+    const predictor = (this.predictor = params.get("Predictor") || 1);
 
     if (predictor <= 1) {
       return str; // no prediction
@@ -733,9 +733,9 @@ var PredictorStream = (function PredictorStreamClosure() {
     this.str = str;
     this.dict = str.dict;
 
-    var colors = (this.colors = params.get("Colors") || 1);
-    var bits = (this.bits = params.get("BitsPerComponent") || 8);
-    var columns = (this.columns = params.get("Columns") || 1);
+    const colors = (this.colors = params.get("Colors") || 1);
+    const bits = (this.bits = params.get("BitsPerComponent") || 8);
+    const columns = (this.columns = params.get("Columns") || 1);
 
     this.pixBytes = (colors * bits + 7) >> 3;
     this.rowBytes = (columns * colors * bits + 7) >> 3;
@@ -747,32 +747,32 @@ var PredictorStream = (function PredictorStreamClosure() {
   PredictorStream.prototype = Object.create(DecodeStream.prototype);
 
   PredictorStream.prototype.readBlockTiff = function predictorStreamReadBlockTiff() {
-    var rowBytes = this.rowBytes;
+    const rowBytes = this.rowBytes;
 
-    var bufferLength = this.bufferLength;
-    var buffer = this.ensureBuffer(bufferLength + rowBytes);
+    const bufferLength = this.bufferLength;
+    const buffer = this.ensureBuffer(bufferLength + rowBytes);
 
-    var bits = this.bits;
-    var colors = this.colors;
+    const bits = this.bits;
+    const colors = this.colors;
 
-    var rawBytes = this.str.getBytes(rowBytes);
+    const rawBytes = this.str.getBytes(rowBytes);
     this.eof = !rawBytes.length;
     if (this.eof) {
       return;
     }
 
-    var inbuf = 0,
+    let inbuf = 0,
       outbuf = 0;
-    var inbits = 0,
+    let inbits = 0,
       outbits = 0;
-    var pos = bufferLength;
-    var i;
+    let pos = bufferLength;
+    let i;
 
     if (bits === 1 && colors === 1) {
       // Optimized version of the loop in the "else"-branch
       // for 1 bit-per-component and 1 color TIFF images.
       for (i = 0; i < rowBytes; ++i) {
-        var c = rawBytes[i] ^ inbuf;
+        let c = rawBytes[i] ^ inbuf;
         c ^= c >> 1;
         c ^= c >> 2;
         c ^= c >> 4;
@@ -788,12 +788,12 @@ var PredictorStream = (function PredictorStreamClosure() {
         pos++;
       }
     } else if (bits === 16) {
-      var bytesPerPixel = colors * 2;
+      const bytesPerPixel = colors * 2;
       for (i = 0; i < bytesPerPixel; ++i) {
         buffer[pos++] = rawBytes[i];
       }
       for (; i < rowBytes; i += 2) {
-        var sum =
+        const sum =
           ((rawBytes[i] & 0xff) << 8) +
           (rawBytes[i + 1] & 0xff) +
           ((buffer[pos - bytesPerPixel] & 0xff) << 8) +
@@ -802,13 +802,13 @@ var PredictorStream = (function PredictorStreamClosure() {
         buffer[pos++] = sum & 0xff;
       }
     } else {
-      var compArray = new Uint8Array(colors + 1);
-      var bitMask = (1 << bits) - 1;
-      var j = 0,
+      const compArray = new Uint8Array(colors + 1);
+      const bitMask = (1 << bits) - 1;
+      let j = 0,
         k = bufferLength;
-      var columns = this.columns;
+      const columns = this.columns;
       for (i = 0; i < columns; ++i) {
-        for (var kk = 0; kk < colors; ++kk) {
+        for (let kk = 0; kk < colors; ++kk) {
           if (inbits < bits) {
             inbuf = (inbuf << 8) | (rawBytes[j++] & 0xff);
             inbits += 8;
@@ -833,25 +833,25 @@ var PredictorStream = (function PredictorStreamClosure() {
   };
 
   PredictorStream.prototype.readBlockPng = function predictorStreamReadBlockPng() {
-    var rowBytes = this.rowBytes;
-    var pixBytes = this.pixBytes;
+    const rowBytes = this.rowBytes;
+    const pixBytes = this.pixBytes;
 
-    var predictor = this.str.getByte();
-    var rawBytes = this.str.getBytes(rowBytes);
+    const predictor = this.str.getByte();
+    const rawBytes = this.str.getBytes(rowBytes);
     this.eof = !rawBytes.length;
     if (this.eof) {
       return;
     }
 
-    var bufferLength = this.bufferLength;
-    var buffer = this.ensureBuffer(bufferLength + rowBytes);
+    const bufferLength = this.bufferLength;
+    const buffer = this.ensureBuffer(bufferLength + rowBytes);
 
-    var prevRow = buffer.subarray(bufferLength - rowBytes, bufferLength);
+    let prevRow = buffer.subarray(bufferLength - rowBytes, bufferLength);
     if (prevRow.length === 0) {
       prevRow = new Uint8Array(rowBytes);
     }
 
-    var i,
+    let i,
       j = bufferLength,
       up,
       c;
@@ -895,19 +895,19 @@ var PredictorStream = (function PredictorStreamClosure() {
         }
         for (; i < rowBytes; ++i) {
           up = prevRow[i];
-          var upLeft = prevRow[i - pixBytes];
-          var left = buffer[j - pixBytes];
-          var p = left + up - upLeft;
+          const upLeft = prevRow[i - pixBytes];
+          const left = buffer[j - pixBytes];
+          const p = left + up - upLeft;
 
-          var pa = p - left;
+          let pa = p - left;
           if (pa < 0) {
             pa = -pa;
           }
-          var pb = p - up;
+          let pb = p - up;
           if (pb < 0) {
             pb = -pb;
           }
-          var pc = p - upLeft;
+          let pc = p - upLeft;
           if (pc < 0) {
             pc = -pc;
           }
@@ -931,7 +931,7 @@ var PredictorStream = (function PredictorStreamClosure() {
   return PredictorStream;
 })();
 
-var DecryptStream = (function DecryptStreamClosure() {
+const DecryptStream = (function DecryptStreamClosure() {
   function DecryptStream(str, maybeLength, decrypt) {
     this.str = str;
     this.dict = str.dict;
@@ -942,12 +942,12 @@ var DecryptStream = (function DecryptStreamClosure() {
     DecodeStream.call(this, maybeLength);
   }
 
-  var chunkSize = 512;
+  const chunkSize = 512;
 
   DecryptStream.prototype = Object.create(DecodeStream.prototype);
 
   DecryptStream.prototype.readBlock = function DecryptStream_readBlock() {
-    var chunk;
+    let chunk;
     if (this.initialized) {
       chunk = this.nextChunk;
     } else {
@@ -959,15 +959,15 @@ var DecryptStream = (function DecryptStreamClosure() {
       return;
     }
     this.nextChunk = this.str.getBytes(chunkSize);
-    var hasMoreData = this.nextChunk && this.nextChunk.length > 0;
+    const hasMoreData = this.nextChunk && this.nextChunk.length > 0;
 
-    var decrypt = this.decrypt;
+    const decrypt = this.decrypt;
     chunk = decrypt(chunk, !hasMoreData);
 
-    var bufferLength = this.bufferLength;
-    var i,
+    let bufferLength = this.bufferLength;
+    let i,
       n = chunk.length;
-    var buffer = this.ensureBuffer(bufferLength + n);
+    const buffer = this.ensureBuffer(bufferLength + n);
     for (i = 0; i < n; i++) {
       buffer[bufferLength++] = chunk[i];
     }
@@ -977,7 +977,7 @@ var DecryptStream = (function DecryptStreamClosure() {
   return DecryptStream;
 })();
 
-var Ascii85Stream = (function Ascii85StreamClosure() {
+const Ascii85Stream = (function Ascii85StreamClosure() {
   function Ascii85Stream(str, maybeLength) {
     this.str = str;
     this.dict = str.dict;
@@ -994,13 +994,13 @@ var Ascii85Stream = (function Ascii85StreamClosure() {
   Ascii85Stream.prototype = Object.create(DecodeStream.prototype);
 
   Ascii85Stream.prototype.readBlock = function Ascii85Stream_readBlock() {
-    var TILDA_CHAR = 0x7e; // '~'
-    var Z_LOWER_CHAR = 0x7a; // 'z'
-    var EOF = -1;
+    const TILDA_CHAR = 0x7e; // '~'
+    const Z_LOWER_CHAR = 0x7a; // 'z'
+    const EOF = -1;
 
-    var str = this.str;
+    const str = this.str;
 
-    var c = str.getByte();
+    let c = str.getByte();
     while (isSpace(c)) {
       c = str.getByte();
     }
@@ -1010,9 +1010,9 @@ var Ascii85Stream = (function Ascii85StreamClosure() {
       return;
     }
 
-    var bufferLength = this.bufferLength,
+    let bufferLength = this.bufferLength,
       buffer;
-    var i;
+    let i;
 
     // special code for z
     if (c === Z_LOWER_CHAR) {
@@ -1022,7 +1022,7 @@ var Ascii85Stream = (function Ascii85StreamClosure() {
       }
       this.bufferLength += 4;
     } else {
-      var input = this.input;
+      const input = this.input;
       input[0] = c;
       for (i = 1; i < 5; ++i) {
         c = str.getByte();
@@ -1046,7 +1046,7 @@ var Ascii85Stream = (function Ascii85StreamClosure() {
         }
         this.eof = true;
       }
-      var t = 0;
+      let t = 0;
       for (i = 0; i < 5; ++i) {
         t = t * 85 + (input[i] - 0x21);
       }
@@ -1061,7 +1061,7 @@ var Ascii85Stream = (function Ascii85StreamClosure() {
   return Ascii85Stream;
 })();
 
-var AsciiHexStream = (function AsciiHexStreamClosure() {
+const AsciiHexStream = (function AsciiHexStreamClosure() {
   function AsciiHexStream(str, maybeLength) {
     this.str = str;
     this.dict = str.dict;
@@ -1079,19 +1079,19 @@ var AsciiHexStream = (function AsciiHexStreamClosure() {
   AsciiHexStream.prototype = Object.create(DecodeStream.prototype);
 
   AsciiHexStream.prototype.readBlock = function AsciiHexStream_readBlock() {
-    var UPSTREAM_BLOCK_SIZE = 8000;
-    var bytes = this.str.getBytes(UPSTREAM_BLOCK_SIZE);
+    const UPSTREAM_BLOCK_SIZE = 8000;
+    const bytes = this.str.getBytes(UPSTREAM_BLOCK_SIZE);
     if (!bytes.length) {
       this.eof = true;
       return;
     }
 
-    var maxDecodeLength = (bytes.length + 1) >> 1;
-    var buffer = this.ensureBuffer(this.bufferLength + maxDecodeLength);
-    var bufferLength = this.bufferLength;
+    const maxDecodeLength = (bytes.length + 1) >> 1;
+    const buffer = this.ensureBuffer(this.bufferLength + maxDecodeLength);
+    let bufferLength = this.bufferLength;
 
-    var firstDigit = this.firstDigit;
-    for (var i = 0, ii = bytes.length; i < ii; i++) {
+    let firstDigit = this.firstDigit;
+    for (let i = 0, ii = bytes.length; i < ii; i++) {
       var ch = bytes[i],
         digit;
       if (ch >= /* '0' = */ 0x30 && ch <= /* '9' = */ 0x39) {
@@ -1127,7 +1127,7 @@ var AsciiHexStream = (function AsciiHexStreamClosure() {
   return AsciiHexStream;
 })();
 
-var RunLengthStream = (function RunLengthStreamClosure() {
+const RunLengthStream = (function RunLengthStreamClosure() {
   function RunLengthStream(str, maybeLength) {
     this.str = str;
     this.dict = str.dict;
@@ -1142,29 +1142,29 @@ var RunLengthStream = (function RunLengthStreamClosure() {
     // and amount of bytes to repeat/copy: n = 0 through 127 - copy next n bytes
     // (in addition to the second byte from the header), n = 129 through 255 -
     // duplicate the second byte from the header (257 - n) times, n = 128 - end.
-    var repeatHeader = this.str.getBytes(2);
+    const repeatHeader = this.str.getBytes(2);
     if (!repeatHeader || repeatHeader.length < 2 || repeatHeader[0] === 128) {
       this.eof = true;
       return;
     }
 
-    var buffer;
-    var bufferLength = this.bufferLength;
-    var n = repeatHeader[0];
+    let buffer;
+    let bufferLength = this.bufferLength;
+    let n = repeatHeader[0];
     if (n < 128) {
       // copy n bytes
       buffer = this.ensureBuffer(bufferLength + n + 1);
       buffer[bufferLength++] = repeatHeader[1];
       if (n > 0) {
-        var source = this.str.getBytes(n);
+        const source = this.str.getBytes(n);
         buffer.set(source, bufferLength);
         bufferLength += n;
       }
     } else {
       n = 257 - n;
-      var b = repeatHeader[1];
+      const b = repeatHeader[1];
       buffer = this.ensureBuffer(bufferLength + n + 1);
-      for (var i = 0; i < n; i++) {
+      for (let i = 0; i < n; i++) {
         buffer[bufferLength++] = b;
       }
     }
@@ -1174,15 +1174,15 @@ var RunLengthStream = (function RunLengthStreamClosure() {
   return RunLengthStream;
 })();
 
-var LZWStream = (function LZWStreamClosure() {
+const LZWStream = (function LZWStreamClosure() {
   function LZWStream(str, maybeLength, earlyChange) {
     this.str = str;
     this.dict = str.dict;
     this.cachedData = 0;
     this.bitsCached = 0;
 
-    var maxLzwDictionarySize = 4096;
-    var lzwState = {
+    const maxLzwDictionarySize = 4096;
+    const lzwState = {
       earlyChange,
       codeLength: 9,
       nextCode: 258,
@@ -1192,7 +1192,7 @@ var LZWStream = (function LZWStreamClosure() {
       currentSequence: new Uint8Array(maxLzwDictionarySize),
       currentSequenceLength: 0,
     };
-    for (var i = 0; i < 256; ++i) {
+    for (let i = 0; i < 256; ++i) {
       lzwState.dictionaryValues[i] = i;
       lzwState.dictionaryLengths[i] = 1;
     }
@@ -1204,10 +1204,10 @@ var LZWStream = (function LZWStreamClosure() {
   LZWStream.prototype = Object.create(DecodeStream.prototype);
 
   LZWStream.prototype.readBits = function LZWStream_readBits(n) {
-    var bitsCached = this.bitsCached;
-    var cachedData = this.cachedData;
+    let bitsCached = this.bitsCached;
+    let cachedData = this.cachedData;
     while (bitsCached < n) {
-      var c = this.str.getByte();
+      const c = this.str.getByte();
       if (c === -1) {
         this.eof = true;
         return null;
@@ -1222,33 +1222,33 @@ var LZWStream = (function LZWStreamClosure() {
   };
 
   LZWStream.prototype.readBlock = function LZWStream_readBlock() {
-    var blockSize = 512;
-    var estimatedDecodedSize = blockSize * 2,
+    const blockSize = 512;
+    let estimatedDecodedSize = blockSize * 2,
       decodedSizeDelta = blockSize;
-    var i, j, q;
+    let i, j, q;
 
-    var lzwState = this.lzwState;
+    const lzwState = this.lzwState;
     if (!lzwState) {
       return; // eof was found
     }
 
-    var earlyChange = lzwState.earlyChange;
-    var nextCode = lzwState.nextCode;
-    var dictionaryValues = lzwState.dictionaryValues;
-    var dictionaryLengths = lzwState.dictionaryLengths;
-    var dictionaryPrevCodes = lzwState.dictionaryPrevCodes;
-    var codeLength = lzwState.codeLength;
-    var prevCode = lzwState.prevCode;
-    var currentSequence = lzwState.currentSequence;
-    var currentSequenceLength = lzwState.currentSequenceLength;
+    const earlyChange = lzwState.earlyChange;
+    let nextCode = lzwState.nextCode;
+    const dictionaryValues = lzwState.dictionaryValues;
+    const dictionaryLengths = lzwState.dictionaryLengths;
+    const dictionaryPrevCodes = lzwState.dictionaryPrevCodes;
+    let codeLength = lzwState.codeLength;
+    let prevCode = lzwState.prevCode;
+    const currentSequence = lzwState.currentSequence;
+    let currentSequenceLength = lzwState.currentSequenceLength;
 
-    var decodedLength = 0;
-    var currentBufferLength = this.bufferLength;
-    var buffer = this.ensureBuffer(this.bufferLength + estimatedDecodedSize);
+    let decodedLength = 0;
+    let currentBufferLength = this.bufferLength;
+    let buffer = this.ensureBuffer(this.bufferLength + estimatedDecodedSize);
 
     for (i = 0; i < blockSize; i++) {
-      var code = this.readBits(codeLength);
-      var hasPrev = currentSequenceLength > 0;
+      const code = this.readBits(codeLength);
+      const hasPrev = currentSequenceLength > 0;
       if (code < 256) {
         currentSequence[0] = code;
         currentSequenceLength = 1;
@@ -1310,7 +1310,7 @@ var LZWStream = (function LZWStreamClosure() {
   return LZWStream;
 })();
 
-var NullStream = (function NullStreamClosure() {
+const NullStream = (function NullStreamClosure() {
   function NullStream() {
     Stream.call(this, new Uint8Array(0));
   }

--- a/src/core/type1_parser.js
+++ b/src/core/type1_parser.js
@@ -20,7 +20,7 @@ import { warn } from "../shared/util.js";
 
 // Hinting is currently disabled due to unknown problems on windows
 // in tracemonkey and various other pdfs with type1 fonts.
-var HINTING_ENABLED = false;
+const HINTING_ENABLED = false;
 
 /*
  * CharStrings are encoded following the the CharString Encoding sequence
@@ -60,8 +60,8 @@ var HINTING_ENABLED = false;
  * to be encoded and this encoding technique helps to minimize the length of
  * the charStrings.
  */
-var Type1CharString = (function Type1CharStringClosure() {
-  var COMMAND_MAP = {
+const Type1CharString = (function Type1CharStringClosure() {
+  const COMMAND_MAP = {
     hstem: [1],
     vstem: [3],
     vmoveto: [4],
@@ -93,11 +93,11 @@ var Type1CharString = (function Type1CharStringClosure() {
       subrs,
       seacAnalysisEnabled
     ) {
-      var count = encoded.length;
-      var error = false;
-      var wx, sbx, subrNumber;
-      for (var i = 0; i < count; i++) {
-        var value = encoded[i];
+      const count = encoded.length;
+      let error = false;
+      let wx, sbx, subrNumber;
+      for (let i = 0; i < count; i++) {
+        let value = encoded[i];
         if (value < 32) {
           if (value === 12) {
             value = (value << 8) + encoded[++i];
@@ -125,7 +125,7 @@ var Type1CharString = (function Type1CharStringClosure() {
                 }
                 // Add the dx for flex and but also swap the values so they are
                 // the right order.
-                var dy = this.stack.pop();
+                const dy = this.stack.pop();
                 this.stack.push(0, dy);
                 break;
               }
@@ -272,7 +272,7 @@ var Type1CharString = (function Type1CharStringClosure() {
               subrNumber = this.stack.pop();
               var numArgs = this.stack.pop();
               if (subrNumber === 0 && numArgs === 3) {
-                var flexArgs = this.stack.splice(this.stack.length - 17, 17);
+                const flexArgs = this.stack.splice(this.stack.length - 17, 17);
                 this.stack.push(
                   flexArgs[2] + flexArgs[0], // bcp1x + rpx
                   flexArgs[3] + flexArgs[1], // bcp1y + rpy
@@ -331,13 +331,13 @@ var Type1CharString = (function Type1CharStringClosure() {
     },
 
     executeCommand(howManyArgs, command, keepStack) {
-      var stackLength = this.stack.length;
+      const stackLength = this.stack.length;
       if (howManyArgs > stackLength) {
         return true;
       }
-      var start = stackLength - howManyArgs;
-      for (var i = start; i < stackLength; i++) {
-        var value = this.stack[i];
+      const start = stackLength - howManyArgs;
+      for (let i = start; i < stackLength; i++) {
+        let value = this.stack[i];
         if (Number.isInteger(value)) {
           this.output.push(28, (value >> 8) & 0xff, value & 0xff);
         } else {
@@ -373,14 +373,14 @@ var Type1CharString = (function Type1CharStringClosure() {
  * of PostScript, but it is possible in most cases to extract what we need
  * without a full parse.
  */
-var Type1Parser = (function Type1ParserClosure() {
+const Type1Parser = (function Type1ParserClosure() {
   /*
    * Decrypt a Sequence of Ciphertext Bytes to Produce the Original Sequence
    * of Plaintext Bytes. The function took a key as a parameter which can be
    * for decrypting the eexec block of for decoding charStrings.
    */
-  var EEXEC_ENCRYPT_KEY = 55665;
-  var CHAR_STRS_ENCRYPT_KEY = 4330;
+  const EEXEC_ENCRYPT_KEY = 55665;
+  const CHAR_STRS_ENCRYPT_KEY = 4330;
 
   function isHexDigit(code) {
     return (
@@ -394,7 +394,7 @@ var Type1Parser = (function Type1ParserClosure() {
     if (discardNumber >= data.length) {
       return new Uint8Array(0);
     }
-    var r = key | 0,
+    let r = key | 0,
       c1 = 52845,
       c2 = 22719,
       i,
@@ -402,10 +402,10 @@ var Type1Parser = (function Type1ParserClosure() {
     for (i = 0; i < discardNumber; i++) {
       r = ((data[i] + r) * c1 + c2) & ((1 << 16) - 1);
     }
-    var count = data.length - discardNumber;
-    var decrypted = new Uint8Array(count);
+    const count = data.length - discardNumber;
+    const decrypted = new Uint8Array(count);
     for (i = discardNumber, j = 0; j < count; i++, j++) {
-      var value = data[i];
+      const value = data[i];
       decrypted[j] = value ^ (r >> 8);
       r = ((value + r) * c1 + c2) & ((1 << 16) - 1);
     }
@@ -413,15 +413,15 @@ var Type1Parser = (function Type1ParserClosure() {
   }
 
   function decryptAscii(data, key, discardNumber) {
-    var r = key | 0,
+    let r = key | 0,
       c1 = 52845,
       c2 = 22719;
-    var count = data.length,
+    const count = data.length,
       maybeLength = count >>> 1;
-    var decrypted = new Uint8Array(maybeLength);
-    var i, j;
+    const decrypted = new Uint8Array(maybeLength);
+    let i, j;
     for (i = 0, j = 0; i < count; i++) {
-      var digit1 = data[i];
+      const digit1 = data[i];
       if (!isHexDigit(digit1)) {
         continue;
       }
@@ -431,7 +431,7 @@ var Type1Parser = (function Type1ParserClosure() {
         i++;
       }
       if (i < count) {
-        var value = parseInt(String.fromCharCode(digit1, digit2), 16);
+        const value = parseInt(String.fromCharCode(digit1, digit2), 16);
         decrypted[j++] = value ^ (r >> 8);
         r = ((value + r) * c1 + c2) & ((1 << 16) - 1);
       }
@@ -453,8 +453,8 @@ var Type1Parser = (function Type1ParserClosure() {
 
   function Type1Parser(stream, encrypted, seacAnalysisEnabled) {
     if (encrypted) {
-      var data = stream.getBytes();
-      var isBinary = !(
+      const data = stream.getBytes();
+      const isBinary = !(
         isHexDigit(data[0]) &&
         isHexDigit(data[1]) &&
         isHexDigit(data[2]) &&
@@ -475,9 +475,9 @@ var Type1Parser = (function Type1ParserClosure() {
   Type1Parser.prototype = {
     readNumberArray: function Type1Parser_readNumberArray() {
       this.getToken(); // read '[' or '{' (arrays can start with either)
-      var array = [];
+      const array = [];
       while (true) {
-        var token = this.getToken();
+        const token = this.getToken();
         if (token === null || token === "]" || token === "}") {
           break;
         }
@@ -487,19 +487,19 @@ var Type1Parser = (function Type1ParserClosure() {
     },
 
     readNumber: function Type1Parser_readNumber() {
-      var token = this.getToken();
+      const token = this.getToken();
       return parseFloat(token || 0);
     },
 
     readInt: function Type1Parser_readInt() {
       // Use '| 0' to prevent setting a double into length such as the double
       // does not flow into the loop variable.
-      var token = this.getToken();
+      const token = this.getToken();
       return parseInt(token || 0, 10) | 0;
     },
 
     readBoolean: function Type1Parser_readBoolean() {
-      var token = this.getToken();
+      const token = this.getToken();
 
       // Use 1 and 0 since that's what type2 charstrings use.
       return token === "true" ? 1 : 0;
@@ -511,8 +511,8 @@ var Type1Parser = (function Type1ParserClosure() {
 
     getToken: function Type1Parser_getToken() {
       // Eat whitespace and comments.
-      var comment = false;
-      var ch = this.currentChar;
+      let comment = false;
+      let ch = this.currentChar;
       while (true) {
         if (ch === -1) {
           return null;
@@ -533,7 +533,7 @@ var Type1Parser = (function Type1ParserClosure() {
         this.nextChar();
         return String.fromCharCode(ch);
       }
-      var token = "";
+      let token = "";
       do {
         token += String.fromCharCode(ch);
         ch = this.nextChar();
@@ -555,20 +555,20 @@ var Type1Parser = (function Type1ParserClosure() {
      * array extracted from and eexec encrypted block of data
      */
     extractFontProgram: function Type1Parser_extractFontProgram(properties) {
-      var stream = this.stream;
+      const stream = this.stream;
 
-      var subrs = [],
+      const subrs = [],
         charstrings = [];
-      var privateData = Object.create(null);
+      const privateData = Object.create(null);
       privateData["lenIV"] = 4;
-      var program = {
+      const program = {
         subrs: [],
         charstrings: [],
         properties: {
           privateData,
         },
       };
-      var token, length, data, lenIV, encoded;
+      let token, length, data, lenIV, encoded;
       while ((token = this.getToken()) !== null) {
         if (token !== "/") {
           continue;
@@ -612,7 +612,7 @@ var Type1Parser = (function Type1ParserClosure() {
             this.readInt(); // num
             this.getToken(); // read in 'array'
             while (this.getToken() === "dup") {
-              var index = this.readInt();
+              const index = this.readInt();
               length = this.readInt();
               this.getToken(); // read in 'RD' or '-|'
               data = length > 0 ? stream.getBytes(length) : new Uint8Array(0);
@@ -663,16 +663,16 @@ var Type1Parser = (function Type1ParserClosure() {
         }
       }
 
-      for (var i = 0; i < charstrings.length; i++) {
+      for (let i = 0; i < charstrings.length; i++) {
         glyph = charstrings[i].glyph;
         encoded = charstrings[i].encoded;
-        var charString = new Type1CharString();
-        var error = charString.convert(
+        const charString = new Type1CharString();
+        const error = charString.convert(
           encoded,
           subrs,
           this.seacAnalysisEnabled
         );
-        var output = charString.output;
+        let output = charString.output;
         if (error) {
           // It seems when FreeType encounters an error while evaluating a glyph
           // that it completely ignores the glyph so we'll mimic that behaviour
@@ -706,7 +706,7 @@ var Type1Parser = (function Type1ParserClosure() {
     },
 
     extractFontHeader: function Type1Parser_extractFontHeader(properties) {
-      var token;
+      let token;
       while ((token = this.getToken()) !== null) {
         if (token !== "/") {
           continue;
@@ -725,10 +725,10 @@ var Type1Parser = (function Type1ParserClosure() {
               encoding = getEncoding(encodingArg);
             } else {
               encoding = [];
-              var size = parseInt(encodingArg, 10) | 0;
+              const size = parseInt(encodingArg, 10) | 0;
               this.getToken(); // read in 'array'
 
-              for (var j = 0; j < size; j++) {
+              for (let j = 0; j < size; j++) {
                 token = this.getToken();
                 // skipping till first dup or def (e.g. ignoring for statement)
                 while (token !== "dup" && token !== "def") {
@@ -740,9 +740,9 @@ var Type1Parser = (function Type1ParserClosure() {
                 if (token === "def") {
                   break; // read all array data
                 }
-                var index = this.readInt();
+                const index = this.readInt();
                 this.getToken(); // read in '/'
-                var glyph = this.getToken();
+                const glyph = this.getToken();
                 encoding[index] = glyph;
                 this.getToken(); // read the in 'put'
               }

--- a/src/core/unicode.js
+++ b/src/core/unicode.js
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint-disable no-var */
 /* no-babel-preset */
 
 var getLookupTableFactory = require("./core_utils.js").getLookupTableFactory;

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -37,7 +37,7 @@ import { MessageHandler } from "../shared/message_handler.js";
 import { PDFWorkerStream } from "./worker_stream.js";
 import { XRefParseException } from "./core_utils.js";
 
-var WorkerTask = (function WorkerTaskClosure() {
+const WorkerTask = (function WorkerTaskClosure() {
   function WorkerTask(name) {
     this.name = name;
     this.terminated = false;
@@ -69,7 +69,7 @@ var WorkerTask = (function WorkerTaskClosure() {
 
 var WorkerMessageHandler = {
   setup(handler, port) {
-    var testMessageProcessed = false;
+    let testMessageProcessed = false;
     handler.on("test", function wphSetupTest(data) {
       if (testMessageProcessed) {
         return; // we already processed 'test' message once
@@ -99,10 +99,10 @@ var WorkerMessageHandler = {
   createDocumentHandler(docParams, port) {
     // This context is actually holds references on pdfManager and handler,
     // until the latter is destroyed.
-    var pdfManager;
-    var terminated = false;
-    var cancelXHRs = null;
-    var WorkerTasks = [];
+    let pdfManager;
+    let terminated = false;
+    let cancelXHRs = null;
+    const WorkerTasks = [];
     const verbosity = getVerbosityLevel();
 
     const apiVersion = docParams.apiVersion;
@@ -137,10 +137,10 @@ var WorkerMessageHandler = {
       }
     }
 
-    var docId = docParams.docId;
-    var docBaseUrl = docParams.docBaseUrl;
-    var workerHandlerName = docParams.docId + "_worker";
-    var handler = new MessageHandler(workerHandlerName, docId, port);
+    const docId = docParams.docId;
+    const docBaseUrl = docParams.docBaseUrl;
+    const workerHandlerName = docParams.docId + "_worker";
+    let handler = new MessageHandler(workerHandlerName, docId, port);
 
     // Ensure that postMessage transfers are always correctly enabled/disabled,
     // to prevent "DataCloneError" in browsers without transfers support.
@@ -158,7 +158,7 @@ var WorkerMessageHandler = {
 
     function finishWorkerTask(task) {
       task.finish();
-      var i = WorkerTasks.indexOf(task);
+      const i = WorkerTasks.indexOf(task);
       WorkerTasks.splice(i, 1);
     }
 
@@ -181,10 +181,10 @@ var WorkerMessageHandler = {
     }
 
     function getPdfManager(data, evaluatorOptions) {
-      var pdfManagerCapability = createPromiseCapability();
-      var pdfManager;
+      const pdfManagerCapability = createPromiseCapability();
+      let pdfManager;
 
-      var source = data.source;
+      const source = data.source;
       if (source.data) {
         try {
           pdfManager = new LocalPdfManager(
@@ -201,7 +201,7 @@ var WorkerMessageHandler = {
         return pdfManagerCapability.promise;
       }
 
-      var pdfStream,
+      let pdfStream,
         cachedChunks = [];
       try {
         pdfStream = new PDFWorkerStream(handler);
@@ -210,7 +210,7 @@ var WorkerMessageHandler = {
         return pdfManagerCapability.promise;
       }
 
-      var fullRequest = pdfStream.getFullReader();
+      const fullRequest = pdfStream.getFullReader();
       fullRequest.headersReady
         .then(function() {
           if (!fullRequest.isRangeSupported) {
@@ -218,7 +218,7 @@ var WorkerMessageHandler = {
           }
 
           // We don't need auto-fetch when streaming is enabled.
-          var disableAutoFetch =
+          const disableAutoFetch =
             source.disableAutoFetch || fullRequest.isStreamingSupported;
           pdfManager = new NetworkPdfManager(
             docId,
@@ -250,9 +250,9 @@ var WorkerMessageHandler = {
           cancelXHRs = null;
         });
 
-      var loaded = 0;
-      var flushChunks = function() {
-        var pdfFile = arraysToBytes(cachedChunks);
+      let loaded = 0;
+      const flushChunks = function() {
+        const pdfFile = arraysToBytes(cachedChunks);
         if (source.length && pdfFile.length !== source.length) {
           warn("reported HTTP length is different from actual");
         }
@@ -271,7 +271,7 @@ var WorkerMessageHandler = {
         }
         cachedChunks = [];
       };
-      var readPromise = new Promise(function(resolve, reject) {
+      const readPromise = new Promise(function(resolve, reject) {
         var readChunk = function(chunk) {
           try {
             ensureNotTerminated();
@@ -283,7 +283,7 @@ var WorkerMessageHandler = {
               return;
             }
 
-            var data = chunk.value;
+            const data = chunk.value;
             loaded += arrayByteLength(data);
             if (!fullRequest.isStreamingSupported) {
               handler.send("DocProgress", {
@@ -327,7 +327,7 @@ var WorkerMessageHandler = {
         ensureNotTerminated();
 
         if (ex instanceof PasswordException) {
-          var task = new WorkerTask(`PasswordException: response ${ex.code}`);
+          const task = new WorkerTask(`PasswordException: response ${ex.code}`);
           startWorkerTask(task);
 
           handler
@@ -382,7 +382,7 @@ var WorkerMessageHandler = {
 
       ensureNotTerminated();
 
-      var evaluatorOptions = {
+      const evaluatorOptions = {
         forceDataSchema: data.disableCreateObjectURL,
         maxImageSize: data.maxImageSize,
         disableFontFace: data.disableFontFace,
@@ -429,8 +429,8 @@ var WorkerMessageHandler = {
     });
 
     handler.on("GetPageIndex", function wphSetupGetPageIndex(data) {
-      var ref = Ref.get(data.ref.num, data.ref.gen);
-      var catalog = pdfManager.pdfDocument.catalog;
+      const ref = Ref.get(data.ref.num, data.ref.gen);
+      const catalog = pdfManager.pdfDocument.catalog;
       return catalog.getPageIndex(ref);
     });
 
@@ -505,9 +505,9 @@ var WorkerMessageHandler = {
     handler.on(
       "GetOperatorList",
       function wphSetupRenderPage(data, sink) {
-        var pageIndex = data.pageIndex;
+        const pageIndex = data.pageIndex;
         pdfManager.getPage(pageIndex).then(function(page) {
-          var task = new WorkerTask(`GetOperatorList: page ${pageIndex}`);
+          const task = new WorkerTask(`GetOperatorList: page ${pageIndex}`);
           startWorkerTask(task);
 
           // NOTE: Keep this condition in sync with the `info` helper function.
@@ -558,12 +558,12 @@ var WorkerMessageHandler = {
     );
 
     handler.on("GetTextContent", function wphExtractText(data, sink) {
-      var pageIndex = data.pageIndex;
+      const pageIndex = data.pageIndex;
       sink.onPull = function(desiredSize) {};
       sink.onCancel = function(reason) {};
 
       pdfManager.getPage(pageIndex).then(function(page) {
-        var task = new WorkerTask("GetTextContent: page " + pageIndex);
+        const task = new WorkerTask("GetTextContent: page " + pageIndex);
         startWorkerTask(task);
 
         // NOTE: Keep this condition in sync with the `info` helper function.
@@ -649,7 +649,7 @@ var WorkerMessageHandler = {
     return workerHandlerName;
   },
   initializeFromPort(port) {
-    var handler = new MessageHandler("worker", "main", port);
+    const handler = new MessageHandler("worker", "main", port);
     WorkerMessageHandler.setup(handler, port);
     handler.send("ready", null);
   },

--- a/src/core/worker_stream.js
+++ b/src/core/worker_stream.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 import { assert } from "../shared/util.js";
 

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 import {
   addLinkAttributes,

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 /**
  * @module pdfjsLib

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -33,18 +33,18 @@ import { getShadingPatternFromIR, TilingPattern } from "./pattern_helper.js";
 // However, PDF needs a bit more state, which we store here.
 
 // Minimal font size that would be used during canvas fillText operations.
-var MIN_FONT_SIZE = 16;
+const MIN_FONT_SIZE = 16;
 // Maximum font size that would be used during canvas fillText operations.
-var MAX_FONT_SIZE = 100;
-var MAX_GROUP_SIZE = 4096;
+const MAX_FONT_SIZE = 100;
+const MAX_GROUP_SIZE = 4096;
 
 // Heuristic value used when enforcing minimum line widths.
-var MIN_WIDTH_FACTOR = 0.65;
+const MIN_WIDTH_FACTOR = 0.65;
 
-var COMPILE_TYPE3_GLYPHS = true;
-var MAX_SIZE_TO_COMPILE = 1000;
+const COMPILE_TYPE3_GLYPHS = true;
+const MAX_SIZE_TO_COMPILE = 1000;
 
-var FULL_CHUNK_HEIGHT = 16;
+const FULL_CHUNK_HEIGHT = 16;
 
 var IsLittleEndianCached = {
   get value() {
@@ -78,16 +78,16 @@ function addContextCurrentTransform(ctx) {
         // http://www.wolframalpha.com/input/?
         //   i=Inverse+{{a%2C+c%2C+e}%2C+{b%2C+d%2C+f}%2C+{0%2C+0%2C+1}}
 
-        var m = this._transformMatrix;
-        var a = m[0],
+        const m = this._transformMatrix;
+        const a = m[0],
           b = m[1],
           c = m[2],
           d = m[3],
           e = m[4],
           f = m[5];
 
-        var ad_bc = a * d - b * c;
-        var bc_ad = b * c - a * d;
+        const ad_bc = a * d - b * c;
+        const bc_ad = b * c - a * d;
 
         return [
           d / ad_bc,
@@ -101,7 +101,7 @@ function addContextCurrentTransform(ctx) {
     });
 
     ctx.save = function ctxSave() {
-      var old = this._transformMatrix;
+      const old = this._transformMatrix;
       this._transformStack.push(old);
       this._transformMatrix = old.slice(0, 6);
 
@@ -109,7 +109,7 @@ function addContextCurrentTransform(ctx) {
     };
 
     ctx.restore = function ctxRestore() {
-      var prev = this._transformStack.pop();
+      const prev = this._transformStack.pop();
       if (prev) {
         this._transformMatrix = prev;
         this._originalRestore();
@@ -117,7 +117,7 @@ function addContextCurrentTransform(ctx) {
     };
 
     ctx.translate = function ctxTranslate(x, y) {
-      var m = this._transformMatrix;
+      const m = this._transformMatrix;
       m[4] = m[0] * x + m[2] * y + m[4];
       m[5] = m[1] * x + m[3] * y + m[5];
 
@@ -125,7 +125,7 @@ function addContextCurrentTransform(ctx) {
     };
 
     ctx.scale = function ctxScale(x, y) {
-      var m = this._transformMatrix;
+      const m = this._transformMatrix;
       m[0] = m[0] * x;
       m[1] = m[1] * x;
       m[2] = m[2] * y;
@@ -135,7 +135,7 @@ function addContextCurrentTransform(ctx) {
     };
 
     ctx.transform = function ctxTransform(a, b, c, d, e, f) {
-      var m = this._transformMatrix;
+      const m = this._transformMatrix;
       this._transformMatrix = [
         m[0] * a + m[2] * b,
         m[1] * a + m[3] * b,
@@ -155,10 +155,10 @@ function addContextCurrentTransform(ctx) {
     };
 
     ctx.rotate = function ctxRotate(angle) {
-      var cosValue = Math.cos(angle);
-      var sinValue = Math.sin(angle);
+      const cosValue = Math.cos(angle);
+      const sinValue = Math.sin(angle);
 
-      var m = this._transformMatrix;
+      const m = this._transformMatrix;
       this._transformMatrix = [
         m[0] * cosValue + m[2] * sinValue,
         m[1] * cosValue + m[3] * sinValue,
@@ -173,7 +173,7 @@ function addContextCurrentTransform(ctx) {
   }
 }
 
-var CachedCanvases = (function CachedCanvasesClosure() {
+const CachedCanvases = (function CachedCanvasesClosure() {
   function CachedCanvases(canvasFactory) {
     this.canvasFactory = canvasFactory;
     this.cache = Object.create(null);
@@ -185,7 +185,7 @@ var CachedCanvases = (function CachedCanvasesClosure() {
       height,
       trackTransform
     ) {
-      var canvasEntry;
+      let canvasEntry;
       if (this.cache[id] !== undefined) {
         canvasEntry = this.cache[id];
         this.canvasFactory.reset(canvasEntry, width, height);
@@ -201,8 +201,8 @@ var CachedCanvases = (function CachedCanvasesClosure() {
       return canvasEntry;
     },
     clear() {
-      for (var id in this.cache) {
-        var canvasEntry = this.cache[id];
+      for (const id in this.cache) {
+        const canvasEntry = this.cache[id];
         this.canvasFactory.destroy(canvasEntry);
         delete this.cache[id];
       }
@@ -212,27 +212,27 @@ var CachedCanvases = (function CachedCanvasesClosure() {
 })();
 
 function compileType3Glyph(imgData) {
-  var POINT_TO_PROCESS_LIMIT = 1000;
+  const POINT_TO_PROCESS_LIMIT = 1000;
 
-  var width = imgData.width,
+  const width = imgData.width,
     height = imgData.height;
-  var i,
+  let i,
     j,
     j0,
     width1 = width + 1;
-  var points = new Uint8Array(width1 * (height + 1));
+  const points = new Uint8Array(width1 * (height + 1));
   // prettier-ignore
-  var POINT_TYPES =
+  const POINT_TYPES =
       new Uint8Array([0, 2, 4, 0, 1, 0, 5, 4, 8, 10, 0, 8, 0, 2, 1, 0]);
 
   // decodes bit-packed mask data
-  var lineSize = (width + 7) & ~7,
+  const lineSize = (width + 7) & ~7,
     data0 = imgData.data;
-  var data = new Uint8Array(lineSize * height),
+  let data = new Uint8Array(lineSize * height),
     pos = 0,
     ii;
   for (i = 0, ii = data0.length; i < ii; i++) {
-    var mask = 128,
+    let mask = 128,
       elem = data0[i];
     while (mask > 0) {
       data[pos++] = elem & mask ? 0 : 255;
@@ -250,7 +250,7 @@ function compileType3Glyph(imgData) {
   //   - outside corners: 1, 2, 4, 8;
   //   - inside corners: 7, 11, 13, 14;
   //   - and, intersections: 5, 10.
-  var count = 0;
+  let count = 0;
   pos = 0;
   if (data[pos] !== 0) {
     points[0] = 1;
@@ -276,7 +276,7 @@ function compileType3Glyph(imgData) {
     }
     // 'sum' is the position of the current pixel configuration in the 'TYPES'
     // array (in order 8-1-2-4, so we can use '>>2' to shift the column).
-    var sum = (data[pos] ? 4 : 0) + (data[pos - lineSize] ? 8 : 0);
+    let sum = (data[pos] ? 4 : 0) + (data[pos - lineSize] ? 8 : 0);
     for (j = 1; j < width; j++) {
       sum =
         (sum >> 2) +
@@ -320,24 +320,24 @@ function compileType3Glyph(imgData) {
   }
 
   // building outlines
-  var steps = new Int32Array([0, width1, -1, 0, -width1, 0, 0, 0, 1]);
-  var outlines = [];
+  const steps = new Int32Array([0, width1, -1, 0, -width1, 0, 0, 0, 1]);
+  const outlines = [];
   for (i = 0; count && i <= height; i++) {
-    var p = i * width1;
-    var end = p + width;
+    let p = i * width1;
+    const end = p + width;
     while (p < end && !points[p]) {
       p++;
     }
     if (p === end) {
       continue;
     }
-    var coords = [p % width1, i];
+    const coords = [p % width1, i];
 
     var type = points[p],
       p0 = p,
       pp;
     do {
-      var step = steps[type];
+      const step = steps[type];
       do {
         p += step;
       } while (!points[p]);
@@ -367,16 +367,16 @@ function compileType3Glyph(imgData) {
     --i;
   }
 
-  var drawOutline = function(c) {
+  const drawOutline = function(c) {
     c.save();
     // the path shall be painted in [0..1]x[0..1] space
     c.scale(1 / width, -1 / height);
     c.translate(0, -height);
     c.beginPath();
-    for (var i = 0, ii = outlines.length; i < ii; i++) {
-      var o = outlines[i];
+    for (let i = 0, ii = outlines.length; i < ii; i++) {
+      const o = outlines[i];
       c.moveTo(o[0], o[1]);
-      for (var j = 2, jj = o.length; j < jj; j += 2) {
+      for (let j = 2, jj = o.length; j < jj; j += 2) {
         c.lineTo(o[j], o[j + 1]);
       }
     }
@@ -388,7 +388,7 @@ function compileType3Glyph(imgData) {
   return drawOutline;
 }
 
-var CanvasExtraState = (function CanvasExtraStateClosure() {
+const CanvasExtraState = (function CanvasExtraStateClosure() {
   function CanvasExtraState() {
     // Are soft masks and alpha values shapes or opacities?
     this.alphaIsShape = false;
@@ -434,12 +434,12 @@ var CanvasExtraState = (function CanvasExtraStateClosure() {
   return CanvasExtraState;
 })();
 
-var CanvasGraphics = (function CanvasGraphicsClosure() {
+const CanvasGraphics = (function CanvasGraphicsClosure() {
   // Defines the time the executeOperatorList is going to be executing
   // before it stops and shedules a continue of execution.
-  var EXECUTION_TIME = 15;
+  const EXECUTION_TIME = 15;
   // Defines the number of steps before checking the execution time
-  var EXECUTION_STEPS = 10;
+  const EXECUTION_STEPS = 10;
 
   function CanvasGraphics(
     canvasCtx,
@@ -497,40 +497,40 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     // will (conceptually) put pixels past the bounds of the canvas.  But
     // that's ok; any such pixels are ignored.
 
-    var height = imgData.height,
+    const height = imgData.height,
       width = imgData.width;
-    var partialChunkHeight = height % FULL_CHUNK_HEIGHT;
-    var fullChunks = (height - partialChunkHeight) / FULL_CHUNK_HEIGHT;
-    var totalChunks = partialChunkHeight === 0 ? fullChunks : fullChunks + 1;
+    const partialChunkHeight = height % FULL_CHUNK_HEIGHT;
+    const fullChunks = (height - partialChunkHeight) / FULL_CHUNK_HEIGHT;
+    const totalChunks = partialChunkHeight === 0 ? fullChunks : fullChunks + 1;
 
-    var chunkImgData = ctx.createImageData(width, FULL_CHUNK_HEIGHT);
-    var srcPos = 0,
+    const chunkImgData = ctx.createImageData(width, FULL_CHUNK_HEIGHT);
+    let srcPos = 0,
       destPos;
-    var src = imgData.data;
-    var dest = chunkImgData.data;
-    var i, j, thisChunkHeight, elemsInThisChunk;
+    const src = imgData.data;
+    const dest = chunkImgData.data;
+    let i, j, thisChunkHeight, elemsInThisChunk;
 
     // There are multiple forms in which the pixel data can be passed, and
     // imgData.kind tells us which one this is.
     if (imgData.kind === ImageKind.GRAYSCALE_1BPP) {
       // Grayscale, 1 bit per pixel (i.e. black-and-white).
-      var srcLength = src.byteLength;
-      var dest32 = new Uint32Array(dest.buffer, 0, dest.byteLength >> 2);
-      var dest32DataLength = dest32.length;
-      var fullSrcDiff = (width + 7) >> 3;
-      var white = 0xffffffff;
-      var black = IsLittleEndianCached.value ? 0xff000000 : 0x000000ff;
+      const srcLength = src.byteLength;
+      const dest32 = new Uint32Array(dest.buffer, 0, dest.byteLength >> 2);
+      const dest32DataLength = dest32.length;
+      const fullSrcDiff = (width + 7) >> 3;
+      const white = 0xffffffff;
+      const black = IsLittleEndianCached.value ? 0xff000000 : 0x000000ff;
       for (i = 0; i < totalChunks; i++) {
         thisChunkHeight =
           i < fullChunks ? FULL_CHUNK_HEIGHT : partialChunkHeight;
         destPos = 0;
         for (j = 0; j < thisChunkHeight; j++) {
-          var srcDiff = srcLength - srcPos;
-          var k = 0;
-          var kEnd = srcDiff > fullSrcDiff ? width : srcDiff * 8 - 7;
-          var kEndUnrolled = kEnd & ~7;
-          var mask = 0;
-          var srcByte = 0;
+          const srcDiff = srcLength - srcPos;
+          let k = 0;
+          const kEnd = srcDiff > fullSrcDiff ? width : srcDiff * 8 - 7;
+          const kEndUnrolled = kEnd & ~7;
+          let mask = 0;
+          let srcByte = 0;
           for (; k < kEndUnrolled; k += 8) {
             srcByte = src[srcPos++];
             dest32[destPos++] = srcByte & 128 ? white : black;
@@ -601,27 +601,27 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
   }
 
   function putBinaryImageMask(ctx, imgData) {
-    var height = imgData.height,
+    const height = imgData.height,
       width = imgData.width;
-    var partialChunkHeight = height % FULL_CHUNK_HEIGHT;
-    var fullChunks = (height - partialChunkHeight) / FULL_CHUNK_HEIGHT;
-    var totalChunks = partialChunkHeight === 0 ? fullChunks : fullChunks + 1;
+    const partialChunkHeight = height % FULL_CHUNK_HEIGHT;
+    const fullChunks = (height - partialChunkHeight) / FULL_CHUNK_HEIGHT;
+    const totalChunks = partialChunkHeight === 0 ? fullChunks : fullChunks + 1;
 
-    var chunkImgData = ctx.createImageData(width, FULL_CHUNK_HEIGHT);
-    var srcPos = 0;
-    var src = imgData.data;
-    var dest = chunkImgData.data;
+    const chunkImgData = ctx.createImageData(width, FULL_CHUNK_HEIGHT);
+    let srcPos = 0;
+    const src = imgData.data;
+    const dest = chunkImgData.data;
 
-    for (var i = 0; i < totalChunks; i++) {
-      var thisChunkHeight =
+    for (let i = 0; i < totalChunks; i++) {
+      const thisChunkHeight =
         i < fullChunks ? FULL_CHUNK_HEIGHT : partialChunkHeight;
 
       // Expand the mask so it can be used by the canvas.  Any required
       // inversion has already been handled.
-      var destPos = 3; // alpha component offset
-      for (var j = 0; j < thisChunkHeight; j++) {
-        var mask = 0;
-        for (var k = 0; k < width; k++) {
+      let destPos = 3; // alpha component offset
+      for (let j = 0; j < thisChunkHeight; j++) {
+        let mask = 0;
+        for (let k = 0; k < width; k++) {
           if (!mask) {
             var elem = src[srcPos++];
             mask = 128;
@@ -636,7 +636,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
   }
 
   function copyCtxState(sourceCtx, destCtx) {
-    var properties = [
+    const properties = [
       "strokeStyle",
       "fillStyle",
       "fillRule",
@@ -648,8 +648,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       "globalCompositeOperation",
       "font",
     ];
-    for (var i = 0, ii = properties.length; i < ii; i++) {
-      var property = properties[i];
+    for (let i = 0, ii = properties.length; i < ii; i++) {
+      const property = properties[i];
       if (sourceCtx[property] !== undefined) {
         destCtx[property] = sourceCtx[property];
       }
@@ -678,15 +678,15 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
   }
 
   function composeSMaskBackdrop(bytes, r0, g0, b0) {
-    var length = bytes.length;
-    for (var i = 3; i < length; i += 4) {
-      var alpha = bytes[i];
+    const length = bytes.length;
+    for (let i = 3; i < length; i += 4) {
+      const alpha = bytes[i];
       if (alpha === 0) {
         bytes[i - 3] = r0;
         bytes[i - 2] = g0;
         bytes[i - 1] = b0;
       } else if (alpha < 255) {
-        var alpha_ = 255 - alpha;
+        const alpha_ = 255 - alpha;
         bytes[i - 3] = (bytes[i - 3] * alpha + r0 * alpha_) >> 8;
         bytes[i - 2] = (bytes[i - 2] * alpha + g0 * alpha_) >> 8;
         bytes[i - 1] = (bytes[i - 1] * alpha + b0 * alpha_) >> 8;
@@ -695,18 +695,18 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
   }
 
   function composeSMaskAlpha(maskData, layerData, transferMap) {
-    var length = maskData.length;
-    var scale = 1 / 255;
-    for (var i = 3; i < length; i += 4) {
-      var alpha = transferMap ? transferMap[maskData[i]] : maskData[i];
+    const length = maskData.length;
+    const scale = 1 / 255;
+    for (let i = 3; i < length; i += 4) {
+      const alpha = transferMap ? transferMap[maskData[i]] : maskData[i];
       layerData[i] = (layerData[i] * alpha * scale) | 0;
     }
   }
 
   function composeSMaskLuminosity(maskData, layerData, transferMap) {
-    var length = maskData.length;
-    for (var i = 3; i < length; i += 4) {
-      var y =
+    const length = maskData.length;
+    for (let i = 3; i < length; i += 4) {
+      const y =
         maskData[i - 3] * 77 + // * 0.3 / 255 * 0x10000
         maskData[i - 2] * 152 + // * 0.59 ....
         maskData[i - 1] * 28; // * 0.11 ....
@@ -725,12 +725,12 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     backdrop,
     transferMap
   ) {
-    var hasBackdrop = !!backdrop;
-    var r0 = hasBackdrop ? backdrop[0] : 0;
-    var g0 = hasBackdrop ? backdrop[1] : 0;
-    var b0 = hasBackdrop ? backdrop[2] : 0;
+    const hasBackdrop = !!backdrop;
+    const r0 = hasBackdrop ? backdrop[0] : 0;
+    const g0 = hasBackdrop ? backdrop[1] : 0;
+    const b0 = hasBackdrop ? backdrop[2] : 0;
 
-    var composeFn;
+    let composeFn;
     if (subtype === "Luminosity") {
       composeFn = composeSMaskLuminosity;
     } else {
@@ -738,12 +738,12 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     }
 
     // processing image in chunks to save memory
-    var PIXELS_TO_PROCESS = 1048576;
-    var chunkSize = Math.min(height, Math.ceil(PIXELS_TO_PROCESS / width));
-    for (var row = 0; row < height; row += chunkSize) {
-      var chunkHeight = Math.min(chunkSize, height - row);
-      var maskData = maskCtx.getImageData(0, row, width, chunkHeight);
-      var layerData = layerCtx.getImageData(0, row, width, chunkHeight);
+    const PIXELS_TO_PROCESS = 1048576;
+    const chunkSize = Math.min(height, Math.ceil(PIXELS_TO_PROCESS / width));
+    for (let row = 0; row < height; row += chunkSize) {
+      const chunkHeight = Math.min(chunkSize, height - row);
+      const maskData = maskCtx.getImageData(0, row, width, chunkHeight);
+      const layerData = layerCtx.getImageData(0, row, width, chunkHeight);
 
       if (hasBackdrop) {
         composeSMaskBackdrop(maskData.data, r0, g0, b0);
@@ -755,8 +755,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
   }
 
   function composeSMask(ctx, smask, layerCtx, webGLContext) {
-    var mask = smask.canvas;
-    var maskCtx = smask.context;
+    const mask = smask.canvas;
+    const maskCtx = smask.context;
 
     ctx.setTransform(
       smask.scaleX,
@@ -767,7 +767,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       smask.offsetY
     );
 
-    var backdrop = smask.backdrop || null;
+    const backdrop = smask.backdrop || null;
     if (!smask.transferMap && webGLContext.isEnabled) {
       const composed = webGLContext.composeSMask({
         layer: layerCtx.canvas,
@@ -793,10 +793,10 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     ctx.drawImage(mask, 0, 0);
   }
 
-  var LINE_CAP_STYLES = ["butt", "round", "square"];
-  var LINE_JOIN_STYLES = ["miter", "round", "bevel"];
-  var NORMAL_CLIP = {};
-  var EO_CLIP = {};
+  const LINE_CAP_STYLES = ["butt", "round", "square"];
+  const LINE_JOIN_STYLES = ["miter", "round", "bevel"];
+  const NORMAL_CLIP = {};
+  const EO_CLIP = {};
 
   CanvasGraphics.prototype = {
     beginDrawing({
@@ -810,8 +810,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       // backdrop. The problem with a transparent backdrop though is we then
       // don't get sub pixel anti aliasing on text, creating temporary
       // transparent canvas when we have blend modes.
-      var width = this.ctx.canvas.width;
-      var height = this.ctx.canvas.height;
+      const width = this.ctx.canvas.width;
+      const height = this.ctx.canvas.height;
 
       this.ctx.save();
       this.ctx.fillStyle = background || "rgb(255, 255, 255)";
@@ -819,7 +819,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       this.ctx.restore();
 
       if (transparency) {
-        var transparentCanvas = this.cachedCanvases.getCanvas(
+        const transparentCanvas = this.cachedCanvases.getCanvas(
           "transparent",
           width,
           height,
@@ -857,25 +857,25 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       continueCallback,
       stepper
     ) {
-      var argsArray = operatorList.argsArray;
-      var fnArray = operatorList.fnArray;
-      var i = executionStartIdx || 0;
-      var argsArrayLen = argsArray.length;
+      const argsArray = operatorList.argsArray;
+      const fnArray = operatorList.fnArray;
+      let i = executionStartIdx || 0;
+      const argsArrayLen = argsArray.length;
 
       // Sometimes the OperatorList to execute is empty.
       if (argsArrayLen === i) {
         return i;
       }
 
-      var chunkOperations =
+      const chunkOperations =
         argsArrayLen - i > EXECUTION_STEPS &&
         typeof continueCallback === "function";
-      var endTime = chunkOperations ? Date.now() + EXECUTION_TIME : 0;
-      var steps = 0;
+      const endTime = chunkOperations ? Date.now() + EXECUTION_TIME : 0;
+      let steps = 0;
 
-      var commonObjs = this.commonObjs;
-      var objs = this.objs;
-      var fnId;
+      const commonObjs = this.commonObjs;
+      const objs = this.objs;
+      let fnId;
 
       while (true) {
         if (stepper !== undefined && i === stepper.nextBreakPoint) {
@@ -962,7 +962,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       this.ctx.miterLimit = limit;
     },
     setDash: function CanvasGraphics_setDash(dashArray, dashPhase) {
-      var ctx = this.ctx;
+      const ctx = this.ctx;
       if (ctx.setLineDash !== undefined) {
         ctx.setLineDash(dashArray);
         ctx.lineDashOffset = dashPhase;
@@ -975,10 +975,10 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       // This operation is ignored since we haven't found a use case for it yet.
     },
     setGState: function CanvasGraphics_setGState(states) {
-      for (var i = 0, ii = states.length; i < ii; i++) {
-        var state = states[i];
-        var key = state[0];
-        var value = state[1];
+      for (let i = 0, ii = states.length; i < ii; i++) {
+        const state = states[i];
+        const key = state[0];
+        const value = state[1];
 
         switch (key) {
           case "LW":
@@ -1040,22 +1040,22 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       }
     },
     beginSMaskGroup: function CanvasGraphics_beginSMaskGroup() {
-      var activeSMask = this.current.activeSMask;
-      var drawnWidth = activeSMask.canvas.width;
-      var drawnHeight = activeSMask.canvas.height;
-      var cacheId = "smaskGroupAt" + this.groupLevel;
-      var scratchCanvas = this.cachedCanvases.getCanvas(
+      const activeSMask = this.current.activeSMask;
+      const drawnWidth = activeSMask.canvas.width;
+      const drawnHeight = activeSMask.canvas.height;
+      const cacheId = "smaskGroupAt" + this.groupLevel;
+      const scratchCanvas = this.cachedCanvases.getCanvas(
         cacheId,
         drawnWidth,
         drawnHeight,
         true
       );
 
-      var currentCtx = this.ctx;
-      var currentTransform = currentCtx.mozCurrentTransform;
+      const currentCtx = this.ctx;
+      const currentTransform = currentCtx.mozCurrentTransform;
       this.ctx.save();
 
-      var groupCtx = scratchCanvas.context;
+      const groupCtx = scratchCanvas.context;
       groupCtx.scale(1 / activeSMask.scaleX, 1 / activeSMask.scaleY);
       groupCtx.translate(-activeSMask.offsetX, -activeSMask.offsetY);
       groupCtx.transform.apply(groupCtx, currentTransform);
@@ -1075,7 +1075,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     suspendSMaskGroup: function CanvasGraphics_endSMaskGroup() {
       // Similar to endSMaskGroup, the intermediate canvas has to be composed
       // and future ctx state restored.
-      var groupCtx = this.ctx;
+      const groupCtx = this.ctx;
       this.groupLevel--;
       this.ctx = this.groupStack.pop();
 
@@ -1093,7 +1093,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       this.current.resumeSMaskCtx = groupCtx;
       // Transform was changed in the SMask canvas, reflecting this change on
       // this.ctx.
-      var deltaTransform = Util.transform(
+      const deltaTransform = Util.transform(
         this.current.activeSMask.startTransformInverse,
         groupCtx.mozCurrentTransform
       );
@@ -1109,14 +1109,14 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       // Resuming state saved by suspendSMaskGroup. We don't need to restore
       // any groupCtx state since restore() command (the only caller) will do
       // that for us. See also beginSMaskGroup.
-      var groupCtx = this.current.resumeSMaskCtx;
-      var currentCtx = this.ctx;
+      const groupCtx = this.current.resumeSMaskCtx;
+      const currentCtx = this.ctx;
       this.ctx = groupCtx;
       this.groupStack.push(currentCtx);
       this.groupLevel++;
     },
     endSMaskGroup: function CanvasGraphics_endSMaskGroup() {
-      var groupCtx = this.ctx;
+      const groupCtx = this.ctx;
       this.groupLevel--;
       this.ctx = this.groupStack.pop();
 
@@ -1130,7 +1130,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       copyCtxState(groupCtx, this.ctx);
       // Transform was changed in the SMask canvas, reflecting this change on
       // this.ctx.
-      var deltaTransform = Util.transform(
+      const deltaTransform = Util.transform(
         this.current.activeSMask.startTransformInverse,
         groupCtx.mozCurrentTransform
       );
@@ -1138,7 +1138,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     },
     save: function CanvasGraphics_save() {
       this.ctx.save();
-      var old = this.current;
+      const old = this.current;
       this.stateStack.push(old);
       this.current = old.clone();
       this.current.resumeSMaskCtx = null;
@@ -1177,11 +1177,11 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
 
     // Path
     constructPath: function CanvasGraphics_constructPath(ops, args) {
-      var ctx = this.ctx;
-      var current = this.current;
-      var x = current.x,
+      const ctx = this.ctx;
+      const current = this.current;
+      let x = current.x,
         y = current.y;
-      for (var i = 0, j = 0, ii = ops.length; i < ii; i++) {
+      for (let i = 0, j = 0, ii = ops.length; i < ii; i++) {
         switch (ops[i] | 0) {
           case OPS.rectangle:
             x = args[j++];
@@ -1257,8 +1257,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     },
     stroke: function CanvasGraphics_stroke(consumePath) {
       consumePath = typeof consumePath !== "undefined" ? consumePath : true;
-      var ctx = this.ctx;
-      var strokeColor = this.current.strokeColor;
+      const ctx = this.ctx;
+      const strokeColor = this.current.strokeColor;
       // For stroke we want to temporarily change the global alpha to the
       // stroking alpha.
       ctx.globalAlpha = this.current.strokeAlpha;
@@ -1303,10 +1303,10 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     },
     fill: function CanvasGraphics_fill(consumePath) {
       consumePath = typeof consumePath !== "undefined" ? consumePath : true;
-      var ctx = this.ctx;
-      var fillColor = this.current.fillColor;
-      var isPatternFill = this.current.patternFill;
-      var needRestore = false;
+      const ctx = this.ctx;
+      const fillColor = this.current.fillColor;
+      const isPatternFill = this.current.patternFill;
+      let needRestore = false;
 
       if (isPatternFill) {
         ctx.save();
@@ -1374,8 +1374,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       this.current.y = this.current.lineY = 0;
     },
     endText: function CanvasGraphics_endText() {
-      var paths = this.pendingTextPaths;
-      var ctx = this.ctx;
+      const paths = this.pendingTextPaths;
+      const ctx = this.ctx;
       if (paths === undefined) {
         ctx.beginPath();
         return;
@@ -1383,8 +1383,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
 
       ctx.save();
       ctx.beginPath();
-      for (var i = 0; i < paths.length; i++) {
-        var path = paths[i];
+      for (let i = 0; i < paths.length; i++) {
+        const path = paths[i];
         ctx.setTransform.apply(ctx, path.transform);
         ctx.translate(path.x, path.y);
         path.addToPath(ctx, path.fontSize);
@@ -1407,8 +1407,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       this.current.leading = -leading;
     },
     setFont: function CanvasGraphics_setFont(fontRefName, size) {
-      var fontObj = this.commonObjs.get(fontRefName);
-      var current = this.current;
+      const fontObj = this.commonObjs.get(fontRefName);
+      const current = this.current;
 
       if (!fontObj) {
         throw new Error(`Can't find font for ${fontRefName}`);
@@ -1440,7 +1440,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         return; // we don't need ctx.font for Type3 fonts
       }
 
-      var name = fontObj.loadedName || "sans-serif";
+      const name = fontObj.loadedName || "sans-serif";
 
       let bold = "normal";
       if (fontObj.black) {
@@ -1448,8 +1448,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       } else if (fontObj.bold) {
         bold = "bold";
       }
-      var italic = fontObj.italic ? "italic" : "normal";
-      var typeface = `"${name}", ${fontObj.fallbackName}`;
+      const italic = fontObj.italic ? "italic" : "normal";
+      const typeface = `"${name}", ${fontObj.fallbackName}`;
 
       // Some font backends cannot handle fonts below certain size.
       // Keeping the font at minimal size and using the fontSizeScale to change
@@ -1491,19 +1491,19 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     },
 
     paintChar(character, x, y, patternTransform) {
-      var ctx = this.ctx;
-      var current = this.current;
-      var font = current.font;
-      var textRenderingMode = current.textRenderingMode;
-      var fontSize = current.fontSize / current.fontSizeScale;
-      var fillStrokeMode =
+      const ctx = this.ctx;
+      const current = this.current;
+      const font = current.font;
+      const textRenderingMode = current.textRenderingMode;
+      const fontSize = current.fontSize / current.fontSizeScale;
+      const fillStrokeMode =
         textRenderingMode & TextRenderingMode.FILL_STROKE_MASK;
-      var isAddToPathSet = !!(
+      const isAddToPathSet = !!(
         textRenderingMode & TextRenderingMode.ADD_TO_PATH_FLAG
       );
       const patternFill = current.patternFill && font.data;
 
-      var addToPath;
+      let addToPath;
       if (font.disableFontFace || isAddToPathSet || patternFill) {
         addToPath = font.getPathGenerator(this.commonObjs, character);
       }
@@ -1545,7 +1545,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       }
 
       if (isAddToPathSet) {
-        var paths = this.pendingTextPaths || (this.pendingTextPaths = []);
+        const paths = this.pendingTextPaths || (this.pendingTextPaths = []);
         paths.push({
           transform: ctx.mozCurrentTransform,
           x,
@@ -1566,9 +1566,9 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       );
       ctx.scale(1.5, 1);
       ctx.fillText("I", 0, 10);
-      var data = ctx.getImageData(0, 0, 10, 10).data;
-      var enabled = false;
-      for (var i = 3; i < data.length; i += 4) {
+      const data = ctx.getImageData(0, 0, 10, 10).data;
+      let enabled = false;
+      for (let i = 3; i < data.length; i += 4) {
         if (data[i] > 0 && data[i] < 255) {
           enabled = true;
           break;
@@ -1578,30 +1578,30 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     },
 
     showText: function CanvasGraphics_showText(glyphs) {
-      var current = this.current;
-      var font = current.font;
+      const current = this.current;
+      const font = current.font;
       if (font.isType3Font) {
         return this.showType3Text(glyphs);
       }
 
-      var fontSize = current.fontSize;
+      const fontSize = current.fontSize;
       if (fontSize === 0) {
         return undefined;
       }
 
-      var ctx = this.ctx;
-      var fontSizeScale = current.fontSizeScale;
-      var charSpacing = current.charSpacing;
-      var wordSpacing = current.wordSpacing;
-      var fontDirection = current.fontDirection;
-      var textHScale = current.textHScale * fontDirection;
-      var glyphsLength = glyphs.length;
-      var vertical = font.vertical;
-      var spacingDir = vertical ? 1 : -1;
-      var defaultVMetrics = font.defaultVMetrics;
-      var widthAdvanceScale = fontSize * current.fontMatrix[0];
+      const ctx = this.ctx;
+      const fontSizeScale = current.fontSizeScale;
+      const charSpacing = current.charSpacing;
+      const wordSpacing = current.wordSpacing;
+      const fontDirection = current.fontDirection;
+      const textHScale = current.textHScale * fontDirection;
+      const glyphsLength = glyphs.length;
+      const vertical = font.vertical;
+      const spacingDir = vertical ? 1 : -1;
+      const defaultVMetrics = font.defaultVMetrics;
+      const widthAdvanceScale = fontSize * current.fontMatrix[0];
 
-      var simpleFillText =
+      const simpleFillText =
         current.textRenderingMode === TextRenderingMode.FILL &&
         !font.disableFontFace &&
         !current.patternFill;
@@ -1626,10 +1626,10 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         ctx.scale(textHScale, 1);
       }
 
-      var lineWidth = current.lineWidth;
-      var scale = current.textMatrixScale;
+      let lineWidth = current.lineWidth;
+      const scale = current.textMatrixScale;
       if (scale === 0 || lineWidth === 0) {
-        var fillStrokeMode =
+        const fillStrokeMode =
           current.textRenderingMode & TextRenderingMode.FILL_STROKE_MASK;
         if (
           fillStrokeMode === TextRenderingMode.STROKE ||
@@ -1649,21 +1649,21 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
 
       ctx.lineWidth = lineWidth;
 
-      var x = 0,
+      let x = 0,
         i;
       for (i = 0; i < glyphsLength; ++i) {
-        var glyph = glyphs[i];
+        const glyph = glyphs[i];
         if (isNum(glyph)) {
           x += (spacingDir * glyph * fontSize) / 1000;
           continue;
         }
 
-        var restoreNeeded = false;
-        var spacing = (glyph.isSpace ? wordSpacing : 0) + charSpacing;
-        var character = glyph.fontChar;
-        var accent = glyph.accent;
+        let restoreNeeded = false;
+        const spacing = (glyph.isSpace ? wordSpacing : 0) + charSpacing;
+        const character = glyph.fontChar;
+        const accent = glyph.accent;
         var scaledX, scaledY, scaledAccentX, scaledAccentY;
-        var width = glyph.width;
+        let width = glyph.width;
         if (vertical) {
           var vmetric, vx, vy;
           vmetric = glyph.vmetric || defaultVMetrics;
@@ -1683,11 +1683,11 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
           // Some standard fonts may not have the exact width: rescale per
           // character if measured width is greater than expected glyph width
           // and subpixel-aa is enabled, otherwise just center the glyph.
-          var measuredWidth =
+          const measuredWidth =
             ((ctx.measureText(character).width * 1000) / fontSize) *
             fontSizeScale;
           if (width < measuredWidth && this.isFontSubpixelAAEnabled) {
-            var characterScaleX = width / measuredWidth;
+            const characterScaleX = width / measuredWidth;
             restoreNeeded = true;
             ctx.save();
             ctx.scale(characterScaleX, 1);
@@ -1719,7 +1719,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
           }
         }
 
-        var charWidth = width * widthAdvanceScale + spacing * fontDirection;
+        const charWidth = width * widthAdvanceScale + spacing * fontDirection;
         x += charWidth;
 
         if (restoreNeeded) {
@@ -1736,20 +1736,20 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
 
     showType3Text: function CanvasGraphics_showType3Text(glyphs) {
       // Type3 fonts - each glyph is a "mini-PDF"
-      var ctx = this.ctx;
-      var current = this.current;
-      var font = current.font;
-      var fontSize = current.fontSize;
-      var fontDirection = current.fontDirection;
-      var spacingDir = font.vertical ? 1 : -1;
-      var charSpacing = current.charSpacing;
-      var wordSpacing = current.wordSpacing;
-      var textHScale = current.textHScale * fontDirection;
-      var fontMatrix = current.fontMatrix || FONT_IDENTITY_MATRIX;
-      var glyphsLength = glyphs.length;
-      var isTextInvisible =
+      const ctx = this.ctx;
+      const current = this.current;
+      const font = current.font;
+      const fontSize = current.fontSize;
+      const fontDirection = current.fontDirection;
+      const spacingDir = font.vertical ? 1 : -1;
+      const charSpacing = current.charSpacing;
+      const wordSpacing = current.wordSpacing;
+      const textHScale = current.textHScale * fontDirection;
+      const fontMatrix = current.fontMatrix || FONT_IDENTITY_MATRIX;
+      const glyphsLength = glyphs.length;
+      const isTextInvisible =
         current.textRenderingMode === TextRenderingMode.INVISIBLE;
-      var i, glyph, width, spacingLength;
+      let i, glyph, width, spacingLength;
 
       if (isTextInvisible || fontSize === 0) {
         return;
@@ -1771,8 +1771,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
           continue;
         }
 
-        var spacing = (glyph.isSpace ? wordSpacing : 0) + charSpacing;
-        var operatorList = font.charProcOperatorList[glyph.operatorListId];
+        const spacing = (glyph.isSpace ? wordSpacing : 0) + charSpacing;
+        const operatorList = font.charProcOperatorList[glyph.operatorListId];
         if (!operatorList) {
           warn(`Type3 character "${glyph.operatorListId}" is not available.`);
           continue;
@@ -1784,7 +1784,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         this.executeOperatorList(operatorList);
         this.restore();
 
-        var transformed = Util.applyTransform([glyph.width, 0], fontMatrix);
+        const transformed = Util.applyTransform([glyph.width, 0], fontMatrix);
         width = transformed[0] * fontSize + spacing;
 
         ctx.translate(width, 0);
@@ -1816,12 +1816,12 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
 
     // Color
     getColorN_Pattern: function CanvasGraphics_getColorN_Pattern(IR) {
-      var pattern;
+      let pattern;
       if (IR[0] === "TilingPattern") {
-        var color = IR[1];
-        var baseTransform =
+        const color = IR[1];
+        const baseTransform =
           this.baseTransform || this.ctx.mozCurrentTransform.slice();
-        var canvasGraphicsFactory = {
+        const canvasGraphicsFactory = {
           createCanvasGraphics: ctx => {
             return new CanvasGraphics(
               ctx,
@@ -1852,39 +1852,39 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       this.current.patternFill = true;
     },
     setStrokeRGBColor: function CanvasGraphics_setStrokeRGBColor(r, g, b) {
-      var color = Util.makeCssRgb(r, g, b);
+      const color = Util.makeCssRgb(r, g, b);
       this.ctx.strokeStyle = color;
       this.current.strokeColor = color;
     },
     setFillRGBColor: function CanvasGraphics_setFillRGBColor(r, g, b) {
-      var color = Util.makeCssRgb(r, g, b);
+      const color = Util.makeCssRgb(r, g, b);
       this.ctx.fillStyle = color;
       this.current.fillColor = color;
       this.current.patternFill = false;
     },
 
     shadingFill: function CanvasGraphics_shadingFill(patternIR) {
-      var ctx = this.ctx;
+      const ctx = this.ctx;
 
       this.save();
-      var pattern = getShadingPatternFromIR(patternIR);
+      const pattern = getShadingPatternFromIR(patternIR);
       ctx.fillStyle = pattern.getPattern(ctx, this, true);
 
-      var inv = ctx.mozCurrentTransformInverse;
+      const inv = ctx.mozCurrentTransformInverse;
       if (inv) {
-        var canvas = ctx.canvas;
-        var width = canvas.width;
-        var height = canvas.height;
+        const canvas = ctx.canvas;
+        const width = canvas.width;
+        const height = canvas.height;
 
-        var bl = Util.applyTransform([0, 0], inv);
-        var br = Util.applyTransform([0, height], inv);
-        var ul = Util.applyTransform([width, 0], inv);
-        var ur = Util.applyTransform([width, height], inv);
+        const bl = Util.applyTransform([0, 0], inv);
+        const br = Util.applyTransform([0, height], inv);
+        const ul = Util.applyTransform([width, 0], inv);
+        const ur = Util.applyTransform([width, height], inv);
 
-        var x0 = Math.min(bl[0], br[0], ul[0], ur[0]);
-        var y0 = Math.min(bl[1], br[1], ul[1], ur[1]);
-        var x1 = Math.max(bl[0], br[0], ul[0], ur[0]);
-        var y1 = Math.max(bl[1], br[1], ul[1], ur[1]);
+        const x0 = Math.min(bl[0], br[0], ul[0], ur[0]);
+        const y0 = Math.min(bl[1], br[1], ul[1], ur[1]);
+        const x1 = Math.max(bl[0], br[0], ul[0], ur[0]);
+        const y1 = Math.max(bl[1], br[1], ul[1], ur[1]);
 
         this.ctx.fillRect(x0, y0, x1 - x0, y1 - y0);
       } else {
@@ -1922,8 +1922,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       this.baseTransform = this.ctx.mozCurrentTransform;
 
       if (bbox) {
-        var width = bbox[2] - bbox[0];
-        var height = bbox[3] - bbox[1];
+        const width = bbox[2] - bbox[0];
+        const height = bbox[3] - bbox[1];
         this.ctx.rect(bbox[0], bbox[1], width, height);
         this.clip();
         this.endPath();
@@ -1937,7 +1937,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
 
     beginGroup: function CanvasGraphics_beginGroup(group) {
       this.save();
-      var currentCtx = this.ctx;
+      const currentCtx = this.ctx;
       // TODO non-isolated groups - according to Rik at adobe non-isolated
       // group results aren't usually that different and they even have tools
       // that ignore this setting. Notes from Rik on implementing:
@@ -1961,7 +1961,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         warn("Knockout groups not supported.");
       }
 
-      var currentTransform = currentCtx.mozCurrentTransform;
+      const currentTransform = currentCtx.mozCurrentTransform;
       if (group.matrix) {
         currentCtx.transform.apply(currentCtx, group.matrix);
       }
@@ -1971,12 +1971,12 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
 
       // Based on the current transform figure out how big the bounding box
       // will actually be.
-      var bounds = Util.getAxialAlignedBoundingBox(
+      let bounds = Util.getAxialAlignedBoundingBox(
         group.bbox,
         currentCtx.mozCurrentTransform
       );
       // Clip the bounding box to the current canvas.
-      var canvasBounds = [
+      const canvasBounds = [
         0,
         0,
         currentCtx.canvas.width,
@@ -1985,11 +1985,11 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       bounds = Util.intersect(bounds, canvasBounds) || [0, 0, 0, 0];
       // Use ceil in case we're between sizes so we don't create canvas that is
       // too small and make the canvas at least 1x1 pixels.
-      var offsetX = Math.floor(bounds[0]);
-      var offsetY = Math.floor(bounds[1]);
-      var drawnWidth = Math.max(Math.ceil(bounds[2]) - offsetX, 1);
-      var drawnHeight = Math.max(Math.ceil(bounds[3]) - offsetY, 1);
-      var scaleX = 1,
+      const offsetX = Math.floor(bounds[0]);
+      const offsetY = Math.floor(bounds[1]);
+      let drawnWidth = Math.max(Math.ceil(bounds[2]) - offsetX, 1);
+      let drawnHeight = Math.max(Math.ceil(bounds[3]) - offsetY, 1);
+      let scaleX = 1,
         scaleY = 1;
       if (drawnWidth > MAX_GROUP_SIZE) {
         scaleX = drawnWidth / MAX_GROUP_SIZE;
@@ -2000,18 +2000,18 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         drawnHeight = MAX_GROUP_SIZE;
       }
 
-      var cacheId = "groupAt" + this.groupLevel;
+      let cacheId = "groupAt" + this.groupLevel;
       if (group.smask) {
         // Using two cache entries is case if masks are used one after another.
         cacheId += "_smask_" + (this.smaskCounter++ % 2);
       }
-      var scratchCanvas = this.cachedCanvases.getCanvas(
+      const scratchCanvas = this.cachedCanvases.getCanvas(
         cacheId,
         drawnWidth,
         drawnHeight,
         true
       );
-      var groupCtx = scratchCanvas.context;
+      const groupCtx = scratchCanvas.context;
 
       // Since we created a new canvas that is just the size of the bounding box
       // we have to translate the group ctx.
@@ -2058,7 +2058,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
 
     endGroup: function CanvasGraphics_endGroup(group) {
       this.groupLevel--;
-      var groupCtx = this.ctx;
+      const groupCtx = this.ctx;
       this.ctx = this.groupStack.pop();
       // Turn off image smoothing to avoid sub pixel interpolation which can
       // look kind of blurry for some pdfs.
@@ -2096,8 +2096,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       this.current = new CanvasExtraState();
 
       if (Array.isArray(rect) && rect.length === 4) {
-        var width = rect[2] - rect[0];
-        var height = rect[3] - rect[1];
+        const width = rect[2] - rect[0];
+        const height = rect[3] - rect[1];
         this.ctx.rect(rect[0], rect[1], width, height);
         this.clip();
         this.endPath();
@@ -2122,7 +2122,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
 
       this.save();
 
-      var ctx = this.ctx;
+      const ctx = this.ctx;
       // scale the image to the unit square
       ctx.scale(1 / w, -1 / h);
 
@@ -2138,8 +2138,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         h
       );
       if (this.imageLayer) {
-        var currentTransform = ctx.mozCurrentTransformInverse;
-        var position = this.getCanvasPosition(0, 0);
+        const currentTransform = ctx.mozCurrentTransformInverse;
+        const position = this.getCanvasPosition(0, 0);
         this.imageLayer.appendImage({
           objId,
           left: position[0],
@@ -2152,13 +2152,13 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     },
 
     paintImageMaskXObject: function CanvasGraphics_paintImageMaskXObject(img) {
-      var ctx = this.ctx;
-      var width = img.width,
+      const ctx = this.ctx;
+      const width = img.width,
         height = img.height;
-      var fillColor = this.current.fillColor;
-      var isPatternFill = this.current.patternFill;
+      const fillColor = this.current.fillColor;
+      const isPatternFill = this.current.patternFill;
 
-      var glyph = this.processingType3;
+      const glyph = this.processingType3;
 
       if (COMPILE_TYPE3_GLYPHS && glyph && glyph.compiled === undefined) {
         if (width <= MAX_SIZE_TO_COMPILE && height <= MAX_SIZE_TO_COMPILE) {
@@ -2173,12 +2173,12 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         return;
       }
 
-      var maskCanvas = this.cachedCanvases.getCanvas(
+      const maskCanvas = this.cachedCanvases.getCanvas(
         "maskCanvas",
         width,
         height
       );
-      var maskCtx = maskCanvas.context;
+      const maskCtx = maskCanvas.context;
       maskCtx.save();
 
       putBinaryImageMask(maskCtx, img);
@@ -2201,17 +2201,17 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       scaleY,
       positions
     ) {
-      var width = imgData.width;
-      var height = imgData.height;
-      var fillColor = this.current.fillColor;
-      var isPatternFill = this.current.patternFill;
+      const width = imgData.width;
+      const height = imgData.height;
+      const fillColor = this.current.fillColor;
+      const isPatternFill = this.current.patternFill;
 
-      var maskCanvas = this.cachedCanvases.getCanvas(
+      const maskCanvas = this.cachedCanvases.getCanvas(
         "maskCanvas",
         width,
         height
       );
-      var maskCtx = maskCanvas.context;
+      const maskCtx = maskCanvas.context;
       maskCtx.save();
 
       putBinaryImageMask(maskCtx, imgData);
@@ -2225,8 +2225,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
 
       maskCtx.restore();
 
-      var ctx = this.ctx;
-      for (var i = 0, ii = positions.length; i < ii; i += 2) {
+      const ctx = this.ctx;
+      for (let i = 0, ii = positions.length; i < ii; i += 2) {
         ctx.save();
         ctx.transform(scaleX, 0, 0, scaleY, positions[i], positions[i + 1]);
         ctx.scale(1, -1);
@@ -2238,21 +2238,21 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     paintImageMaskXObjectGroup: function CanvasGraphics_paintImageMaskXObjectGroup(
       images
     ) {
-      var ctx = this.ctx;
+      const ctx = this.ctx;
 
-      var fillColor = this.current.fillColor;
-      var isPatternFill = this.current.patternFill;
-      for (var i = 0, ii = images.length; i < ii; i++) {
-        var image = images[i];
-        var width = image.width,
+      const fillColor = this.current.fillColor;
+      const isPatternFill = this.current.patternFill;
+      for (let i = 0, ii = images.length; i < ii; i++) {
+        const image = images[i];
+        const width = image.width,
           height = image.height;
 
-        var maskCanvas = this.cachedCanvases.getCanvas(
+        const maskCanvas = this.cachedCanvases.getCanvas(
           "maskCanvas",
           width,
           height
         );
-        var maskCtx = maskCanvas.context;
+        const maskCtx = maskCanvas.context;
         maskCtx.save();
 
         putBinaryImageMask(maskCtx, image);
@@ -2300,10 +2300,10 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         return;
       }
 
-      var width = imgData.width;
-      var height = imgData.height;
-      var map = [];
-      for (var i = 0, ii = positions.length; i < ii; i += 2) {
+      const width = imgData.width;
+      const height = imgData.height;
+      const map = [];
+      for (let i = 0, ii = positions.length; i < ii; i += 2) {
         map.push({
           transform: [scaleX, 0, 0, scaleY, positions[i], positions[i + 1]],
           x: 0,
@@ -2318,23 +2318,23 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     paintInlineImageXObject: function CanvasGraphics_paintInlineImageXObject(
       imgData
     ) {
-      var width = imgData.width;
-      var height = imgData.height;
-      var ctx = this.ctx;
+      const width = imgData.width;
+      const height = imgData.height;
+      const ctx = this.ctx;
 
       this.save();
       // scale the image to the unit square
       ctx.scale(1 / width, -1 / height);
 
-      var currentTransform = ctx.mozCurrentTransformInverse;
-      var a = currentTransform[0],
+      const currentTransform = ctx.mozCurrentTransformInverse;
+      const a = currentTransform[0],
         b = currentTransform[1];
-      var widthScale = Math.max(Math.sqrt(a * a + b * b), 1);
-      var c = currentTransform[2],
+      let widthScale = Math.max(Math.sqrt(a * a + b * b), 1);
+      const c = currentTransform[2],
         d = currentTransform[3];
-      var heightScale = Math.max(Math.sqrt(c * c + d * d), 1);
+      let heightScale = Math.max(Math.sqrt(c * c + d * d), 1);
 
-      var imgToPaint, tmpCanvas;
+      let imgToPaint, tmpCanvas;
       // typeof check is needed due to node.js support, see issue #8489
       if (
         (typeof HTMLElement === "function" && imgData instanceof HTMLElement) ||
@@ -2348,9 +2348,9 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         imgToPaint = tmpCanvas.canvas;
       }
 
-      var paintWidth = width,
+      let paintWidth = width,
         paintHeight = height;
-      var tmpCanvasId = "prescale1";
+      let tmpCanvasId = "prescale1";
       // Vertial or horizontal scaling shall not be more than 2 to not loose the
       // pixels during drawImage operation, painting on the temporary canvas(es)
       // that are twice smaller in size
@@ -2358,7 +2358,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         (widthScale > 2 && paintWidth > 1) ||
         (heightScale > 2 && paintHeight > 1)
       ) {
-        var newWidth = paintWidth,
+        let newWidth = paintWidth,
           newHeight = paintHeight;
         if (widthScale > 2 && paintWidth > 1) {
           newWidth = Math.ceil(paintWidth / 2);
@@ -2404,7 +2404,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       );
 
       if (this.imageLayer) {
-        var position = this.getCanvasPosition(0, -height);
+        const position = this.getCanvasPosition(0, -height);
         this.imageLayer.appendImage({
           imgData,
           left: position[0],
@@ -2420,16 +2420,16 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       imgData,
       map
     ) {
-      var ctx = this.ctx;
-      var w = imgData.width;
-      var h = imgData.height;
+      const ctx = this.ctx;
+      const w = imgData.width;
+      const h = imgData.height;
 
-      var tmpCanvas = this.cachedCanvases.getCanvas("inlineImage", w, h);
-      var tmpCtx = tmpCanvas.context;
+      const tmpCanvas = this.cachedCanvases.getCanvas("inlineImage", w, h);
+      const tmpCtx = tmpCanvas.context;
       putBinaryImageData(tmpCtx, imgData);
 
-      for (var i = 0, ii = map.length; i < ii; i++) {
-        var entry = map[i];
+      for (let i = 0, ii = map.length; i < ii; i++) {
+        const entry = map[i];
         ctx.save();
         ctx.transform.apply(ctx, entry.transform);
         ctx.scale(1, -1);
@@ -2445,7 +2445,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
           1
         );
         if (this.imageLayer) {
-          var position = this.getCanvasPosition(entry.x, entry.y);
+          const position = this.getCanvasPosition(entry.x, entry.y);
           this.imageLayer.appendImage({
             imgData,
             left: position[0],
@@ -2499,7 +2499,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     // Helper functions
 
     consumePath: function CanvasGraphics_consumePath() {
-      var ctx = this.ctx;
+      const ctx = this.ctx;
       if (this.pendingClip) {
         if (this.pendingClip === EO_CLIP) {
           ctx.clip("evenodd");
@@ -2524,7 +2524,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       return this._cachedGetSinglePixelWidth;
     },
     getCanvasPosition: function CanvasGraphics_getCanvasPosition(x, y) {
-      var transform = this.ctx.mozCurrentTransform;
+      const transform = this.ctx.mozCurrentTransform;
       return [
         transform[0] * x + transform[2] * y + transform[4],
         transform[1] * x + transform[3] * y + transform[5],
@@ -2532,7 +2532,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     },
   };
 
-  for (var op in OPS) {
+  for (const op in OPS) {
     CanvasGraphics.prototype[OPS[op]] = CanvasGraphics.prototype[op];
   }
 

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 import {
   assert,

--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 import {
   AbortException,

--- a/src/display/network.js
+++ b/src/display/network.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 import {
   assert,

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -15,7 +15,7 @@
 
 import { FormatError, info, Util } from "../shared/util.js";
 
-var ShadingIRs = {};
+const ShadingIRs = {};
 
 function applyBoundingBox(ctx, bbox) {
   if (!bbox || typeof Path2D === "undefined") {
@@ -30,26 +30,26 @@ function applyBoundingBox(ctx, bbox) {
 
 ShadingIRs.RadialAxial = {
   fromIR: function RadialAxial_fromIR(raw) {
-    var type = raw[1];
-    var bbox = raw[2];
-    var colorStops = raw[3];
-    var p0 = raw[4];
-    var p1 = raw[5];
-    var r0 = raw[6];
-    var r1 = raw[7];
+    const type = raw[1];
+    const bbox = raw[2];
+    const colorStops = raw[3];
+    const p0 = raw[4];
+    const p1 = raw[5];
+    const r0 = raw[6];
+    const r1 = raw[7];
     return {
       type: "Pattern",
       getPattern: function RadialAxial_getPattern(ctx) {
         applyBoundingBox(ctx, bbox);
-        var grad;
+        let grad;
         if (type === "axial") {
           grad = ctx.createLinearGradient(p0[0], p0[1], p1[0], p1[1]);
         } else if (type === "radial") {
           grad = ctx.createRadialGradient(p0[0], p0[1], r0, p1[0], p1[1], r1);
         }
 
-        for (var i = 0, ii = colorStops.length; i < ii; ++i) {
-          var c = colorStops[i];
+        for (let i = 0, ii = colorStops.length; i < ii; ++i) {
+          const c = colorStops[i];
           grad.addColorStop(c[0], c[1]);
         }
         return grad;
@@ -58,14 +58,14 @@ ShadingIRs.RadialAxial = {
   },
 };
 
-var createMeshCanvas = (function createMeshCanvasClosure() {
+const createMeshCanvas = (function createMeshCanvasClosure() {
   function drawTriangle(data, context, p1, p2, p3, c1, c2, c3) {
     // Very basic Gouraud-shaded triangle rasterization algorithm.
-    var coords = context.coords,
+    const coords = context.coords,
       colors = context.colors;
-    var bytes = data.data,
+    const bytes = data.data,
       rowSize = data.width * 4;
-    var tmp;
+    let tmp;
     if (coords[p1 + 1] > coords[p2 + 1]) {
       tmp = p1;
       p1 = p2;
@@ -90,30 +90,30 @@ var createMeshCanvas = (function createMeshCanvasClosure() {
       c1 = c2;
       c2 = tmp;
     }
-    var x1 = (coords[p1] + context.offsetX) * context.scaleX;
-    var y1 = (coords[p1 + 1] + context.offsetY) * context.scaleY;
-    var x2 = (coords[p2] + context.offsetX) * context.scaleX;
-    var y2 = (coords[p2 + 1] + context.offsetY) * context.scaleY;
-    var x3 = (coords[p3] + context.offsetX) * context.scaleX;
-    var y3 = (coords[p3 + 1] + context.offsetY) * context.scaleY;
+    const x1 = (coords[p1] + context.offsetX) * context.scaleX;
+    const y1 = (coords[p1 + 1] + context.offsetY) * context.scaleY;
+    const x2 = (coords[p2] + context.offsetX) * context.scaleX;
+    const y2 = (coords[p2 + 1] + context.offsetY) * context.scaleY;
+    const x3 = (coords[p3] + context.offsetX) * context.scaleX;
+    const y3 = (coords[p3 + 1] + context.offsetY) * context.scaleY;
     if (y1 >= y3) {
       return;
     }
-    var c1r = colors[c1],
+    const c1r = colors[c1],
       c1g = colors[c1 + 1],
       c1b = colors[c1 + 2];
-    var c2r = colors[c2],
+    const c2r = colors[c2],
       c2g = colors[c2 + 1],
       c2b = colors[c2 + 2];
-    var c3r = colors[c3],
+    const c3r = colors[c3],
       c3g = colors[c3 + 1],
       c3b = colors[c3 + 2];
 
-    var minY = Math.round(y1),
+    const minY = Math.round(y1),
       maxY = Math.round(y3);
-    var xa, car, cag, cab;
-    var xb, cbr, cbg, cbb;
-    for (var y = minY; y <= maxY; y++) {
+    let xa, car, cag, cab;
+    let xb, cbr, cbg, cbb;
+    for (let y = minY; y <= maxY; y++) {
       if (y < y2) {
         let k;
         if (y < y1) {
@@ -154,10 +154,10 @@ var createMeshCanvas = (function createMeshCanvasClosure() {
       cbr = c1r - (c1r - c3r) * k;
       cbg = c1g - (c1g - c3g) * k;
       cbb = c1b - (c1b - c3b) * k;
-      var x1_ = Math.round(Math.min(xa, xb));
-      var x2_ = Math.round(Math.max(xa, xb));
-      var j = rowSize * y + x1_ * 4;
-      for (var x = x1_; x <= x2_; x++) {
+      const x1_ = Math.round(Math.min(xa, xb));
+      const x2_ = Math.round(Math.max(xa, xb));
+      let j = rowSize * y + x1_ * 4;
+      for (let x = x1_; x <= x2_; x++) {
         let k = (xa - x) / (xa - xb);
         if (k < 0) {
           k = 0;
@@ -173,17 +173,17 @@ var createMeshCanvas = (function createMeshCanvasClosure() {
   }
 
   function drawFigure(data, figure, context) {
-    var ps = figure.coords;
-    var cs = figure.colors;
-    var i, ii;
+    const ps = figure.coords;
+    const cs = figure.colors;
+    let i, ii;
     switch (figure.type) {
       case "lattice":
         var verticesPerRow = figure.verticesPerRow;
         var rows = Math.floor(ps.length / verticesPerRow) - 1;
         var cols = verticesPerRow - 1;
         for (i = 0; i < rows; i++) {
-          var q = i * verticesPerRow;
-          for (var j = 0; j < cols; j++, q++) {
+          let q = i * verticesPerRow;
+          for (let j = 0; j < cols; j++, q++) {
             drawTriangle(
               data,
               context,
@@ -238,30 +238,30 @@ var createMeshCanvas = (function createMeshCanvasClosure() {
   ) {
     // we will increase scale on some weird factor to let antialiasing take
     // care of "rough" edges
-    var EXPECTED_SCALE = 1.1;
+    const EXPECTED_SCALE = 1.1;
     // MAX_PATTERN_SIZE is used to avoid OOM situation.
-    var MAX_PATTERN_SIZE = 3000; // 10in @ 300dpi shall be enough
+    const MAX_PATTERN_SIZE = 3000; // 10in @ 300dpi shall be enough
     // We need to keep transparent border around our pattern for fill():
     // createPattern with 'no-repeat' will bleed edges across entire area.
-    var BORDER_SIZE = 2;
+    const BORDER_SIZE = 2;
 
-    var offsetX = Math.floor(bounds[0]);
-    var offsetY = Math.floor(bounds[1]);
-    var boundsWidth = Math.ceil(bounds[2]) - offsetX;
-    var boundsHeight = Math.ceil(bounds[3]) - offsetY;
+    const offsetX = Math.floor(bounds[0]);
+    const offsetY = Math.floor(bounds[1]);
+    const boundsWidth = Math.ceil(bounds[2]) - offsetX;
+    const boundsHeight = Math.ceil(bounds[3]) - offsetY;
 
-    var width = Math.min(
+    const width = Math.min(
       Math.ceil(Math.abs(boundsWidth * combinesScale[0] * EXPECTED_SCALE)),
       MAX_PATTERN_SIZE
     );
-    var height = Math.min(
+    const height = Math.min(
       Math.ceil(Math.abs(boundsHeight * combinesScale[1] * EXPECTED_SCALE)),
       MAX_PATTERN_SIZE
     );
-    var scaleX = boundsWidth / width;
-    var scaleY = boundsHeight / height;
+    const scaleX = boundsWidth / width;
+    const scaleY = boundsHeight / height;
 
-    var context = {
+    const context = {
       coords,
       colors,
       offsetX: -offsetX,
@@ -270,10 +270,10 @@ var createMeshCanvas = (function createMeshCanvasClosure() {
       scaleY: 1 / scaleY,
     };
 
-    var paddedWidth = width + BORDER_SIZE * 2;
-    var paddedHeight = height + BORDER_SIZE * 2;
+    const paddedWidth = width + BORDER_SIZE * 2;
+    const paddedHeight = height + BORDER_SIZE * 2;
 
-    var canvas, tmpCanvas, i, ii;
+    let canvas, tmpCanvas, i, ii;
     if (webGLContext.isEnabled) {
       canvas = webGLContext.drawFigures({
         width,
@@ -298,11 +298,11 @@ var createMeshCanvas = (function createMeshCanvasClosure() {
         paddedHeight,
         false
       );
-      var tmpCtx = tmpCanvas.context;
+      const tmpCtx = tmpCanvas.context;
 
-      var data = tmpCtx.createImageData(width, height);
+      const data = tmpCtx.createImageData(width, height);
       if (backgroundColor) {
-        var bytes = data.data;
+        const bytes = data.data;
         for (i = 0, ii = bytes.length; i < ii; i += 4) {
           bytes[i] = backgroundColor[0];
           bytes[i + 1] = backgroundColor[1];
@@ -331,32 +331,32 @@ var createMeshCanvas = (function createMeshCanvasClosure() {
 ShadingIRs.Mesh = {
   fromIR: function Mesh_fromIR(raw) {
     // var type = raw[1];
-    var coords = raw[2];
-    var colors = raw[3];
-    var figures = raw[4];
-    var bounds = raw[5];
-    var matrix = raw[6];
-    var bbox = raw[7];
-    var background = raw[8];
+    const coords = raw[2];
+    const colors = raw[3];
+    const figures = raw[4];
+    const bounds = raw[5];
+    const matrix = raw[6];
+    const bbox = raw[7];
+    const background = raw[8];
     return {
       type: "Pattern",
       getPattern: function Mesh_getPattern(ctx, owner, shadingFill) {
         applyBoundingBox(ctx, bbox);
-        var scale;
+        let scale;
         if (shadingFill) {
           scale = Util.singularValueDecompose2dScale(ctx.mozCurrentTransform);
         } else {
           // Obtain scale from matrix and current transformation matrix.
           scale = Util.singularValueDecompose2dScale(owner.baseTransform);
           if (matrix) {
-            var matrixScale = Util.singularValueDecompose2dScale(matrix);
+            const matrixScale = Util.singularValueDecompose2dScale(matrix);
             scale = [scale[0] * matrixScale[0], scale[1] * matrixScale[1]];
           }
         }
 
         // Rasterizing on the main thread since sending/queue large canvases
         // might cause OOM.
-        var temporaryPatternCanvas = createMeshCanvas(
+        const temporaryPatternCanvas = createMeshCanvas(
           bounds,
           scale,
           coords,
@@ -398,20 +398,20 @@ ShadingIRs.Dummy = {
 };
 
 function getShadingPatternFromIR(raw) {
-  var shadingIR = ShadingIRs[raw[0]];
+  const shadingIR = ShadingIRs[raw[0]];
   if (!shadingIR) {
     throw new Error(`Unknown IR type: ${raw[0]}`);
   }
   return shadingIR.fromIR(raw);
 }
 
-var TilingPattern = (function TilingPatternClosure() {
-  var PaintType = {
+const TilingPattern = (function TilingPatternClosure() {
+  const PaintType = {
     COLORED: 1,
     UNCOLORED: 2,
   };
 
-  var MAX_PATTERN_SIZE = 3000; // 10in @ 300dpi shall be enough
+  const MAX_PATTERN_SIZE = 3000; // 10in @ 300dpi shall be enough
 
   function TilingPattern(IR, color, ctx, canvasGraphicsFactory, baseTransform) {
     this.operatorList = IR[2];
@@ -430,14 +430,14 @@ var TilingPattern = (function TilingPatternClosure() {
 
   TilingPattern.prototype = {
     createPatternCanvas: function TilinPattern_createPatternCanvas(owner) {
-      var operatorList = this.operatorList;
-      var bbox = this.bbox;
-      var xstep = this.xstep;
-      var ystep = this.ystep;
-      var paintType = this.paintType;
-      var tilingType = this.tilingType;
-      var color = this.color;
-      var canvasGraphicsFactory = this.canvasGraphicsFactory;
+      const operatorList = this.operatorList;
+      const bbox = this.bbox;
+      const xstep = this.xstep;
+      const ystep = this.ystep;
+      const paintType = this.paintType;
+      const tilingType = this.tilingType;
+      const color = this.color;
+      const canvasGraphicsFactory = this.canvasGraphicsFactory;
 
       info("TilingType: " + tilingType);
 
@@ -461,17 +461,17 @@ var TilingPattern = (function TilingPatternClosure() {
       //   TODO: Fix the implementation, to allow this scenario to be painted
       //   correctly.
 
-      var x0 = bbox[0],
+      const x0 = bbox[0],
         y0 = bbox[1],
         x1 = bbox[2],
         y1 = bbox[3];
 
       // Obtain scale from matrix and current transformation matrix.
-      var matrixScale = Util.singularValueDecompose2dScale(this.matrix);
-      var curMatrixScale = Util.singularValueDecompose2dScale(
+      const matrixScale = Util.singularValueDecompose2dScale(this.matrix);
+      const curMatrixScale = Util.singularValueDecompose2dScale(
         this.baseTransform
       );
-      var combinedScale = [
+      const combinedScale = [
         matrixScale[0] * curMatrixScale[0],
         matrixScale[1] * curMatrixScale[1],
       ];
@@ -479,25 +479,25 @@ var TilingPattern = (function TilingPatternClosure() {
       // Use width and height values that are as close as possible to the end
       // result when the pattern is used. Too low value makes the pattern look
       // blurry. Too large value makes it look too crispy.
-      var dimx = this.getSizeAndScale(
+      const dimx = this.getSizeAndScale(
         xstep,
         this.ctx.canvas.width,
         combinedScale[0]
       );
-      var dimy = this.getSizeAndScale(
+      const dimy = this.getSizeAndScale(
         ystep,
         this.ctx.canvas.height,
         combinedScale[1]
       );
 
-      var tmpCanvas = owner.cachedCanvases.getCanvas(
+      const tmpCanvas = owner.cachedCanvases.getCanvas(
         "pattern",
         dimx.size,
         dimy.size,
         true
       );
-      var tmpCtx = tmpCanvas.context;
-      var graphics = canvasGraphicsFactory.createCanvasGraphics(tmpCtx);
+      const tmpCtx = tmpCanvas.context;
+      const graphics = canvasGraphicsFactory.createCanvasGraphics(tmpCtx);
       graphics.groupLevel = owner.groupLevel;
 
       this.setFillAndStrokeStyleToContext(graphics, paintType, color);
@@ -530,8 +530,8 @@ var TilingPattern = (function TilingPatternClosure() {
       // Use the destination canvas's size if it is bigger than the hard-coded
       // limit of MAX_PATTERN_SIZE to avoid clipping patterns that cover the
       // whole canvas.
-      var maxSize = Math.max(MAX_PATTERN_SIZE, realOutputSize);
-      var size = Math.ceil(step * scale);
+      const maxSize = Math.max(MAX_PATTERN_SIZE, realOutputSize);
+      let size = Math.ceil(step * scale);
       if (size >= maxSize) {
         size = maxSize;
       } else {
@@ -542,8 +542,8 @@ var TilingPattern = (function TilingPatternClosure() {
 
     clipBbox: function clipBbox(graphics, bbox, x0, y0, x1, y1) {
       if (Array.isArray(bbox) && bbox.length === 4) {
-        var bboxWidth = x1 - x0;
-        var bboxHeight = y1 - y0;
+        const bboxWidth = x1 - x0;
+        const bboxHeight = y1 - y0;
         graphics.ctx.rect(x0, y0, bboxWidth, bboxHeight);
         graphics.clip();
         graphics.endPath();
@@ -584,7 +584,7 @@ var TilingPattern = (function TilingPatternClosure() {
       ctx.setTransform.apply(ctx, this.baseTransform);
       ctx.transform.apply(ctx, this.matrix);
 
-      var temporaryPatternCanvas = this.createPatternCanvas(owner);
+      const temporaryPatternCanvas = this.createPatternCanvas(owner);
 
       return ctx.createPattern(temporaryPatternCanvas, "repeat");
     },

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 /* globals __non_webpack_require__ */
-/* eslint no-var: error */
 
 import {
   createObjectURL,

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -41,10 +41,10 @@ import {
  * @property {boolean} [enhanceTextSelection] - Whether to turn on the text
  *   selection enhancement.
  */
-var renderTextLayer = (function renderTextLayerClosure() {
-  var MAX_TEXT_DIVS_TO_RENDER = 100000;
+const renderTextLayer = (function renderTextLayerClosure() {
+  const MAX_TEXT_DIVS_TO_RENDER = 100000;
 
-  var NonWhitespaceRegexp = /\S/;
+  const NonWhitespaceRegexp = /\S/;
 
   function isAllWhitespace(str) {
     return !NonWhitespaceRegexp.test(str);
@@ -52,8 +52,8 @@ var renderTextLayer = (function renderTextLayerClosure() {
 
   function appendText(task, geom, styles) {
     // Initialize all used properties to keep the caches monomorphic.
-    var textDiv = document.createElement("span");
-    var textDivProperties = {
+    const textDiv = document.createElement("span");
+    const textDivProperties = {
       angle: 0,
       canvasWidth: 0,
       isWhitespace: false,
@@ -72,14 +72,14 @@ var renderTextLayer = (function renderTextLayerClosure() {
       return;
     }
 
-    var tx = Util.transform(task._viewport.transform, geom.transform);
-    var angle = Math.atan2(tx[1], tx[0]);
-    var style = styles[geom.fontName];
+    const tx = Util.transform(task._viewport.transform, geom.transform);
+    let angle = Math.atan2(tx[1], tx[0]);
+    const style = styles[geom.fontName];
     if (style.vertical) {
       angle += Math.PI / 2;
     }
-    var fontHeight = Math.sqrt(tx[2] * tx[2] + tx[3] * tx[3]);
-    var fontAscent = fontHeight;
+    const fontHeight = Math.sqrt(tx[2] * tx[2] + tx[3] * tx[3]);
+    let fontAscent = fontHeight;
     if (style.ascent) {
       fontAscent = style.ascent * fontAscent;
     } else if (style.descent) {
@@ -126,17 +126,17 @@ var renderTextLayer = (function renderTextLayerClosure() {
     }
 
     if (task._enhanceTextSelection) {
-      var angleCos = 1,
+      let angleCos = 1,
         angleSin = 0;
       if (angle !== 0) {
         angleCos = Math.cos(angle);
         angleSin = Math.sin(angle);
       }
-      var divWidth =
+      const divWidth =
         (style.vertical ? geom.height : geom.width) * task._viewport.scale;
-      var divHeight = fontHeight;
+      const divHeight = fontHeight;
 
-      var m, b;
+      let m, b;
       if (angle !== 0) {
         m = [angleCos, angleSin, -angleSin, angleCos, left, top];
         b = Util.getAxialAlignedBoundingBox([0, 0, divWidth, divHeight], m);
@@ -160,9 +160,9 @@ var renderTextLayer = (function renderTextLayerClosure() {
     if (task._canceled) {
       return;
     }
-    var textDivs = task._textDivs;
-    var capability = task._capability;
-    var textDivsLength = textDivs.length;
+    const textDivs = task._textDivs;
+    const capability = task._capability;
+    const textDivsLength = textDivs.length;
 
     // No point in rendering many divs as it would make the browser
     // unusable even after the divs are rendered.
@@ -173,7 +173,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
     }
 
     if (!task._textContentStream) {
-      for (var i = 0; i < textDivsLength; i++) {
+      for (let i = 0; i < textDivsLength; i++) {
         task._layoutText(textDivs[i]);
       }
     }
@@ -183,13 +183,13 @@ var renderTextLayer = (function renderTextLayerClosure() {
   }
 
   function expand(task) {
-    var bounds = task._bounds;
-    var viewport = task._viewport;
+    const bounds = task._bounds;
+    const viewport = task._viewport;
 
-    var expanded = expandBounds(viewport.width, viewport.height, bounds);
-    for (var i = 0; i < expanded.length; i++) {
-      var div = bounds[i].div;
-      var divProperties = task._textDivProperties.get(div);
+    const expanded = expandBounds(viewport.width, viewport.height, bounds);
+    for (let i = 0; i < expanded.length; i++) {
+      const div = bounds[i].div;
+      const divProperties = task._textDivProperties.get(div);
       if (divProperties.angle === 0) {
         divProperties.paddingLeft = bounds[i].left - expanded[i].left;
         divProperties.paddingTop = bounds[i].top - expanded[i].top;
@@ -206,10 +206,10 @@ var renderTextLayer = (function renderTextLayerClosure() {
         c = m[0],
         s = m[1];
       // Finding intersections with expanded box.
-      var points = [[0, 0], [0, b.size[1]], [b.size[0], 0], b.size];
+      const points = [[0, 0], [0, b.size[1]], [b.size[0], 0], b.size];
       var ts = new Float64Array(64);
       points.forEach(function(p, i) {
-        var t = Util.applyTransform(p, m);
+        const t = Util.applyTransform(p, m);
         ts[i + 0] = c && (e.left - t[0]) / c;
         ts[i + 4] = s && (e.top - t[1]) / s;
         ts[i + 8] = c && (e.right - t[0]) / c;
@@ -230,10 +230,10 @@ var renderTextLayer = (function renderTextLayerClosure() {
         ts[i + 56] = s && (e.right - t[0]) / s;
         ts[i + 60] = c && (e.bottom - t[1]) / -c;
       });
-      var findPositiveMin = function(ts, offset, count) {
-        var result = 0;
-        for (var i = 0; i < count; i++) {
-          var t = ts[offset++];
+      const findPositiveMin = function(ts, offset, count) {
+        let result = 0;
+        for (let i = 0; i < count; i++) {
+          const t = ts[offset++];
           if (t > 0) {
             result = result ? Math.min(t, result) : t;
           }
@@ -242,7 +242,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
       };
       // Not based on math, but to simplify calculations, using cos and sin
       // absolute values to not exceed the box (it can but insignificantly).
-      var boxScale = 1 + Math.min(Math.abs(c), Math.abs(s));
+      const boxScale = 1 + Math.min(Math.abs(c), Math.abs(s));
       divProperties.paddingLeft = findPositiveMin(ts, 32, 16) / boxScale;
       divProperties.paddingTop = findPositiveMin(ts, 48, 16) / boxScale;
       divProperties.paddingRight = findPositiveMin(ts, 0, 16) / boxScale;
@@ -252,7 +252,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
   }
 
   function expandBounds(width, height, boxes) {
-    var bounds = boxes.map(function(box, i) {
+    const bounds = boxes.map(function(box, i) {
       return {
         x1: box.left,
         y1: box.top,
@@ -264,9 +264,9 @@ var renderTextLayer = (function renderTextLayerClosure() {
       };
     });
     expandBoundsLTR(width, bounds);
-    var expanded = new Array(boxes.length);
+    const expanded = new Array(boxes.length);
     bounds.forEach(function(b) {
-      var i = b.index;
+      const i = b.index;
       expanded[i] = {
         left: b.x1New,
         top: 0,
@@ -278,7 +278,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
     // Rotating on 90 degrees and extending extended boxes. Reusing the bounds
     // array and objects.
     boxes.map(function(box, i) {
-      var e = expanded[i],
+      const e = expanded[i],
         b = bounds[i];
       b.x1 = box.top;
       b.y1 = width - e.right;
@@ -291,7 +291,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
     expandBoundsLTR(height, bounds);
 
     bounds.forEach(function(b) {
-      var i = b.index;
+      const i = b.index;
       expanded[i].top = b.x1New;
       expanded[i].bottom = b.x2New;
     });
@@ -305,7 +305,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
     });
 
     // First we see on the horizon is a fake boundary.
-    var fakeBoundary = {
+    const fakeBoundary = {
       x1: -Infinity,
       y1: -Infinity,
       x2: 0,
@@ -314,7 +314,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
       x1New: 0,
       x2New: 0,
     };
-    var horizon = [
+    const horizon = [
       {
         start: -Infinity,
         end: Infinity,
@@ -325,17 +325,17 @@ var renderTextLayer = (function renderTextLayerClosure() {
     bounds.forEach(function(boundary) {
       // Searching for the affected part of horizon.
       // TODO red-black tree or simple binary search
-      var i = 0;
+      let i = 0;
       while (i < horizon.length && horizon[i].end <= boundary.y1) {
         i++;
       }
-      var j = horizon.length - 1;
+      let j = horizon.length - 1;
       while (j >= 0 && horizon[j].start >= boundary.y2) {
         j--;
       }
 
-      var horizonPart, affectedBoundary;
-      var q,
+      let horizonPart, affectedBoundary;
+      let q,
         k,
         maxXNew = -Infinity;
       for (q = i; q <= j; q++) {
@@ -388,13 +388,13 @@ var renderTextLayer = (function renderTextLayerClosure() {
       }
 
       // Fixing the horizon.
-      var changedHorizon = [],
+      let changedHorizon = [],
         lastBoundary = null;
       for (q = i; q <= j; q++) {
         horizonPart = horizon[q];
         affectedBoundary = horizonPart.boundary;
         // Checking which boundary will be visible.
-        var useBoundary =
+        const useBoundary =
           affectedBoundary.x2 > boundary.x2 ? affectedBoundary : boundary;
         if (lastBoundary === useBoundary) {
           // Merging with previous.
@@ -434,7 +434,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
         if (affectedBoundary.x2New !== undefined) {
           continue;
         }
-        var used = false;
+        let used = false;
         for (
           k = i - 1;
           !used && k >= 0 && horizon[k].start >= affectedBoundary.y1;
@@ -465,7 +465,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
 
     // Set new x2 for all unset boundaries.
     horizon.forEach(function(horizonPart) {
-      var affectedBoundary = horizonPart.boundary;
+      const affectedBoundary = horizonPart.boundary;
       if (affectedBoundary.x2New === undefined) {
         affectedBoundary.x2New = Math.max(width, affectedBoundary.x2);
       }
@@ -661,7 +661,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
       const transformBuf = [],
         paddingBuf = [];
 
-      for (var i = 0, ii = this._textDivs.length; i < ii; i++) {
+      for (let i = 0, ii = this._textDivs.length; i < ii; i++) {
         const div = this._textDivs[i];
         const divProps = this._textDivProperties.get(div);
 
@@ -719,7 +719,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
    * @returns {TextLayerRenderTask}
    */
   function renderTextLayer(renderParameters) {
-    var task = new TextLayerRenderTask({
+    const task = new TextLayerRenderTask({
       textContent: renderParameters.textContent,
       textContentStream: renderParameters.textContentStream,
       container: renderParameters.container,

--- a/src/display/transport_stream.js
+++ b/src/display/transport_stream.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 import { assert, createPromiseCapability } from "../shared/util.js";
 

--- a/src/display/webgl.js
+++ b/src/display/webgl.js
@@ -50,12 +50,12 @@ class WebGLContext {
 
 var WebGLUtils = (function WebGLUtilsClosure() {
   function loadShader(gl, code, shaderType) {
-    var shader = gl.createShader(shaderType);
+    const shader = gl.createShader(shaderType);
     gl.shaderSource(shader, code);
     gl.compileShader(shader);
-    var compiled = gl.getShaderParameter(shader, gl.COMPILE_STATUS);
+    const compiled = gl.getShaderParameter(shader, gl.COMPILE_STATUS);
     if (!compiled) {
-      var errorMsg = gl.getShaderInfoLog(shader);
+      const errorMsg = gl.getShaderInfoLog(shader);
       throw new Error("Error during shader compilation: " + errorMsg);
     }
     return shader;
@@ -67,21 +67,21 @@ var WebGLUtils = (function WebGLUtilsClosure() {
     return loadShader(gl, code, gl.FRAGMENT_SHADER);
   }
   function createProgram(gl, shaders) {
-    var program = gl.createProgram();
-    for (var i = 0, ii = shaders.length; i < ii; ++i) {
+    const program = gl.createProgram();
+    for (let i = 0, ii = shaders.length; i < ii; ++i) {
       gl.attachShader(program, shaders[i]);
     }
     gl.linkProgram(program);
-    var linked = gl.getProgramParameter(program, gl.LINK_STATUS);
+    const linked = gl.getProgramParameter(program, gl.LINK_STATUS);
     if (!linked) {
-      var errorMsg = gl.getProgramInfoLog(program);
+      const errorMsg = gl.getProgramInfoLog(program);
       throw new Error("Error during program linking: " + errorMsg);
     }
     return program;
   }
   function createTexture(gl, image, textureId) {
     gl.activeTexture(textureId);
-    var texture = gl.createTexture();
+    const texture = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, texture);
 
     // Set the parameters so we can render any size image.
@@ -95,7 +95,7 @@ var WebGLUtils = (function WebGLUtilsClosure() {
     return texture;
   }
 
-  var currentGL, currentCanvas;
+  let currentGL, currentCanvas;
   function generateGL() {
     if (currentGL) {
       return;
@@ -108,7 +108,7 @@ var WebGLUtils = (function WebGLUtilsClosure() {
     });
   }
 
-  var smaskVertexShaderCode =
+  const smaskVertexShaderCode =
     "\
   attribute vec2 a_position;                                    \
   attribute vec2 a_texCoord;                                    \
@@ -124,7 +124,7 @@ var WebGLUtils = (function WebGLUtilsClosure() {
     v_texCoord = a_texCoord;                                    \
   }                                                             ";
 
-  var smaskFragmentShaderCode =
+  const smaskFragmentShaderCode =
     "\
   precision mediump float;                                      \
                                                                 \
@@ -154,10 +154,10 @@ var WebGLUtils = (function WebGLUtilsClosure() {
     gl_FragColor = imageColor;                                  \
   }                                                             ";
 
-  var smaskCache = null;
+  let smaskCache = null;
 
   function initSmaskGL() {
-    var canvas, gl;
+    let canvas, gl;
 
     generateGL();
     canvas = currentCanvas;
@@ -166,12 +166,12 @@ var WebGLUtils = (function WebGLUtilsClosure() {
     currentGL = null;
 
     // setup a GLSL program
-    var vertexShader = createVertexShader(gl, smaskVertexShaderCode);
-    var fragmentShader = createFragmentShader(gl, smaskFragmentShaderCode);
-    var program = createProgram(gl, [vertexShader, fragmentShader]);
+    const vertexShader = createVertexShader(gl, smaskVertexShaderCode);
+    const fragmentShader = createFragmentShader(gl, smaskFragmentShaderCode);
+    const program = createProgram(gl, [vertexShader, fragmentShader]);
     gl.useProgram(program);
 
-    var cache = {};
+    const cache = {};
     cache.gl = gl;
     cache.canvas = canvas;
     cache.resolutionLocation = gl.getUniformLocation(program, "u_resolution");
@@ -179,12 +179,12 @@ var WebGLUtils = (function WebGLUtilsClosure() {
     cache.backdropLocation = gl.getUniformLocation(program, "u_backdrop");
     cache.subtypeLocation = gl.getUniformLocation(program, "u_subtype");
 
-    var texCoordLocation = gl.getAttribLocation(program, "a_texCoord");
-    var texLayerLocation = gl.getUniformLocation(program, "u_image");
-    var texMaskLocation = gl.getUniformLocation(program, "u_mask");
+    const texCoordLocation = gl.getAttribLocation(program, "a_texCoord");
+    const texLayerLocation = gl.getUniformLocation(program, "u_image");
+    const texMaskLocation = gl.getUniformLocation(program, "u_mask");
 
     // provide texture coordinates for the rectangle.
-    var texCoordBuffer = gl.createBuffer();
+    const texCoordBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, texCoordBuffer);
     // prettier-ignore
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
@@ -204,13 +204,13 @@ var WebGLUtils = (function WebGLUtilsClosure() {
   }
 
   function composeSMask(layer, mask, properties) {
-    var width = layer.width,
+    const width = layer.width,
       height = layer.height;
 
     if (!smaskCache) {
       initSmaskGL();
     }
-    var cache = smaskCache,
+    const cache = smaskCache,
       canvas = cache.canvas,
       gl = cache.gl;
     canvas.width = width;
@@ -235,12 +235,12 @@ var WebGLUtils = (function WebGLUtilsClosure() {
     );
 
     // Create a textures
-    var texture = createTexture(gl, layer, gl.TEXTURE0);
-    var maskTexture = createTexture(gl, mask, gl.TEXTURE1);
+    const texture = createTexture(gl, layer, gl.TEXTURE0);
+    const maskTexture = createTexture(gl, mask, gl.TEXTURE1);
 
     // Create a buffer and put a single clipspace rectangle in
     // it (2 triangles)
-    var buffer = gl.createBuffer();
+    const buffer = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
     // prettier-ignore
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
@@ -270,7 +270,7 @@ var WebGLUtils = (function WebGLUtilsClosure() {
     return canvas;
   }
 
-  var figuresVertexShaderCode =
+  const figuresVertexShaderCode =
     "\
   attribute vec2 a_position;                                    \
   attribute vec3 a_color;                                       \
@@ -289,7 +289,7 @@ var WebGLUtils = (function WebGLUtilsClosure() {
     v_color = vec4(a_color / 255.0, 1.0);                       \
   }                                                             ";
 
-  var figuresFragmentShaderCode =
+  const figuresFragmentShaderCode =
     "\
   precision mediump float;                                      \
                                                                 \
@@ -299,10 +299,10 @@ var WebGLUtils = (function WebGLUtilsClosure() {
     gl_FragColor = v_color;                                     \
   }                                                             ";
 
-  var figuresCache = null;
+  let figuresCache = null;
 
   function initFiguresGL() {
-    var canvas, gl;
+    let canvas, gl;
 
     generateGL();
     canvas = currentCanvas;
@@ -311,12 +311,12 @@ var WebGLUtils = (function WebGLUtilsClosure() {
     currentGL = null;
 
     // setup a GLSL program
-    var vertexShader = createVertexShader(gl, figuresVertexShaderCode);
-    var fragmentShader = createFragmentShader(gl, figuresFragmentShaderCode);
-    var program = createProgram(gl, [vertexShader, fragmentShader]);
+    const vertexShader = createVertexShader(gl, figuresVertexShaderCode);
+    const fragmentShader = createFragmentShader(gl, figuresFragmentShaderCode);
+    const program = createProgram(gl, [vertexShader, fragmentShader]);
     gl.useProgram(program);
 
-    var cache = {};
+    const cache = {};
     cache.gl = gl;
     cache.canvas = canvas;
     cache.resolutionLocation = gl.getUniformLocation(program, "u_resolution");
@@ -332,7 +332,7 @@ var WebGLUtils = (function WebGLUtilsClosure() {
     if (!figuresCache) {
       initFiguresGL();
     }
-    var cache = figuresCache,
+    const cache = figuresCache,
       canvas = cache.canvas,
       gl = cache.gl;
 
@@ -342,8 +342,8 @@ var WebGLUtils = (function WebGLUtilsClosure() {
     gl.uniform2f(cache.resolutionLocation, width, height);
 
     // count triangle points
-    var count = 0;
-    var i, ii, rows;
+    let count = 0;
+    let i, ii, rows;
     for (i = 0, ii = figures.length; i < ii; i++) {
       switch (figures[i].type) {
         case "lattice":
@@ -356,23 +356,23 @@ var WebGLUtils = (function WebGLUtilsClosure() {
       }
     }
     // transfer data
-    var coords = new Float32Array(count * 2);
-    var colors = new Uint8Array(count * 3);
-    var coordsMap = context.coords,
+    const coords = new Float32Array(count * 2);
+    const colors = new Uint8Array(count * 3);
+    const coordsMap = context.coords,
       colorsMap = context.colors;
-    var pIndex = 0,
+    let pIndex = 0,
       cIndex = 0;
     for (i = 0, ii = figures.length; i < ii; i++) {
-      var figure = figures[i],
+      const figure = figures[i],
         ps = figure.coords,
         cs = figure.colors;
       switch (figure.type) {
         case "lattice":
           var cols = figure.verticesPerRow;
           rows = (ps.length / cols) | 0;
-          for (var row = 1; row < rows; row++) {
-            var offset = row * cols + 1;
-            for (var col = 1; col < cols; col++, offset++) {
+          for (let row = 1; row < rows; row++) {
+            let offset = row * cols + 1;
+            for (let col = 1; col < cols; col++, offset++) {
               coords[pIndex] = coordsMap[ps[offset - cols - 1]];
               coords[pIndex + 1] = coordsMap[ps[offset - cols - 1] + 1];
               coords[pIndex + 2] = coordsMap[ps[offset - cols]];
@@ -410,7 +410,7 @@ var WebGLUtils = (function WebGLUtilsClosure() {
           }
           break;
         case "triangles":
-          for (var j = 0, jj = ps.length; j < jj; j++) {
+          for (let j = 0, jj = ps.length; j < jj; j++) {
             coords[pIndex] = coordsMap[ps[j]];
             coords[pIndex + 1] = coordsMap[ps[j] + 1];
             colors[cIndex] = colorsMap[cs[j]];
@@ -436,13 +436,13 @@ var WebGLUtils = (function WebGLUtilsClosure() {
     }
     gl.clear(gl.COLOR_BUFFER_BIT);
 
-    var coordsBuffer = gl.createBuffer();
+    const coordsBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, coordsBuffer);
     gl.bufferData(gl.ARRAY_BUFFER, coords, gl.STATIC_DRAW);
     gl.enableVertexAttribArray(cache.positionLocation);
     gl.vertexAttribPointer(cache.positionLocation, 2, gl.FLOAT, false, 0, 0);
 
-    var colorsBuffer = gl.createBuffer();
+    const colorsBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, colorsBuffer);
     gl.bufferData(gl.ARRAY_BUFFER, colors, gl.STATIC_DRAW);
     gl.enableVertexAttribArray(cache.colorLocation);

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -16,17 +16,17 @@
 
 "use strict";
 
-var pdfjsVersion =
+const pdfjsVersion =
   typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_VERSION") : void 0;
-var pdfjsBuild =
+const pdfjsBuild =
   typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_BUILD") : void 0;
 
-var pdfjsSharedUtil = require("./shared/util.js");
-var pdfjsDisplayAPI = require("./display/api.js");
-var pdfjsDisplayTextLayer = require("./display/text_layer.js");
-var pdfjsDisplayAnnotationLayer = require("./display/annotation_layer.js");
-var pdfjsDisplayDisplayUtils = require("./display/display_utils.js");
-var pdfjsDisplaySVG = require("./display/svg.js");
+const pdfjsSharedUtil = require("./shared/util.js");
+const pdfjsDisplayAPI = require("./display/api.js");
+const pdfjsDisplayTextLayer = require("./display/text_layer.js");
+const pdfjsDisplayAnnotationLayer = require("./display/annotation_layer.js");
+const pdfjsDisplayDisplayUtils = require("./display/display_utils.js");
+const pdfjsDisplaySVG = require("./display/svg.js");
 const pdfjsDisplayWorkerOptions = require("./display/worker_options.js");
 const pdfjsDisplayAPICompatibility = require("./display/api_compatibility.js");
 

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 // Skip compatibility checks for modern builds (unless we're running the
 // unit-tests in Node.js/Travis) and if we already ran the module.

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 import "./compatibility.js";
 


### PR DESCRIPTION
Previously we've been selectively enabling this rule on a file-by-file basis (and the `web/` folder is already done), but it seems like a good idea to enable this in the entire `src/` folder now.
Most likely we don't want to enable this rule in *all* files/folders, e.g. the `examples/` folder should probably be left alone for now, hence why this rule isn't enabled globally.

With the recent introduction of Prettier this sort of mass enabling of ESLint rules also becomes a lot easier, since the code will be automatically reformatted as necessary to account for e.g. changed line lengths.

*Please note:* This patch is generated automatically, by appending the `--fix` argument to the ESLint call used in the `gulp lint` task. It will thus require some additional manual fixes, which will be done in a *separate* commit.

Please find additional details about the ESLint rule at https://eslint.org/docs/rules/no-var