### PR TITLE
[TextLayer] Immediately set the padding, rather than checking if it's empty, in `expandTextDivs`

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -658,7 +658,6 @@ var renderTextLayer = (function renderTextLayerClosure() {
         expand(this);
         this._bounds = null;
       }
-      const NO_PADDING = "0 0 0 0";
       const transformBuf = [],
         paddingBuf = [];
 
@@ -701,10 +700,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
             paddingBuf.push(0);
           }
 
-          const padding = paddingBuf.join(" ");
-          if (padding !== NO_PADDING) {
-            div.style.padding = padding;
-          }
+          div.style.padding = paddingBuf.join(" ");
           if (transformBuf.length) {
             div.style.transform = transformBuf.join(" ");
           }


### PR DESCRIPTION
In practice it's extremely rare[1] for the padding to be zero in *all* components, hence it seems better to just set it directly rather than creating a temporary variable and checking for the "no padding"-case.

---
[1] In the `tracemonkey.pdf` file that only happens with `0.08%` of all text elements.