### PR TITLE
Remove `LoopbackPort.postMessage` special-case for polyfilled `TypedArray`s

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1492,10 +1492,7 @@ class LoopbackPort {
       if ((buffer = value.buffer) && isArrayBuffer(buffer)) {
         // We found object with ArrayBuffer (typed array).
         const transferable = transfers && transfers.includes(buffer);
-        if (value === buffer) {
-          // Special case when we are faking typed arrays in compatibility.js.
-          result = value;
-        } else if (transferable) {
+        if (transferable) {
           result = new value.constructor(
             buffer,
             value.byteOffset,


### PR DESCRIPTION
Given that all `TypedArray` polyfills were removed in PDF.js version `2.0`, since native support is now required, this branch has been dead code for awhile.