### PR TITLE
Add polyfills to support iteration of `Map` and `Set`

### DIFF
--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -281,6 +281,26 @@ if (
     globalThis.ReadableStream = require("web-streams-polyfill/dist/ponyfill.js").ReadableStream;
   })();
 
+  // We want to support Map iteration, but it doesn't seem possible to easily
+  // test for that specifically; hence using a similarly unsupported property.
+  // Support: IE11
+  (function checkMapEntries() {
+    if (globalThis.Map && globalThis.Map.prototype.entries) {
+      return;
+    }
+    globalThis.Map = require("core-js/es/map/index.js");
+  })();
+
+  // We want to support Set iteration, but it doesn't seem possible to easily
+  // test for that specifically; hence using a similarly unsupported property.
+  // Support: IE11
+  (function checkSetEntries() {
+    if (globalThis.Set && globalThis.Set.prototype.entries) {
+      return;
+    }
+    globalThis.Set = require("core-js/es/set/index.js");
+  })();
+
   // Support: IE<11, Safari<8, Chrome<36
   (function checkWeakMap() {
     if (globalThis.WeakMap) {


### PR DESCRIPTION
Without this, things such as e.g. `Metadata.getAll` is broken in IE11 (see PR #11596).

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#Browser_compatibility

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#Browser_compatibility