### PR TITLE
Enable the `no-buffer-constructor` ESLint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -127,6 +127,9 @@
       "args": "none",
     }],
 
+    // Node.js and CommonJS
+    "no-buffer-constructor": "error",
+
     // Stylistic Issues
     "lines-between-class-members": ["error", "always"],
     "max-len": ["error", {

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -145,7 +145,7 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
           input = literals;
         } else {
           // eslint-disable-next-line no-undef
-          input = new Buffer(literals);
+          input = Buffer.from(literals);
         }
         const output = __non_webpack_require__("zlib").deflateSync(input, {
           level: 9,


### PR DESCRIPTION
According to https://nodejs.org/api/buffer.html#buffer_class_buffer: `new Buffer(...)` is deprecated in up-to-date versions of Node.js, hence you want to prevent it from being accidentally used.

Please see https://eslint.org/docs/rules/no-buffer-constructor for additional information.