### PR TITLE
Enable the `unicorn/prefer-starts-ends-with` ESLint plugin rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,6 +38,7 @@
     "no-unsanitized/method": "error",
     "no-unsanitized/property": "error",
     "unicorn/no-array-instanceof": "error",
+    "unicorn/prefer-starts-ends-with": "error",
 
     // Possible errors
     "for-direction": "error",

--- a/src/display/network_utils.js
+++ b/src/display/network_utils.js
@@ -78,7 +78,7 @@ function extractFilenameFromHeader(getResponseHeader) {
 }
 
 function createResponseStatusError(status, url) {
-  if (status === 404 || (status === 0 && /^file:/.test(url))) {
+  if (status === 404 || (status === 0 && url.startsWith("file:"))) {
     return new MissingPDFException('Missing PDF "' + url + '".');
   }
   return new UnexpectedResponseException(


### PR DESCRIPTION
This complements the existing `mozilla/use-includes-instead-of-indexOf` plugin rule, by also disallowing unnecessary regular expressions when comparing strings.

Please see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-starts-ends-with.md for additional information.