### PR TITLE
Update `gulp lint` to support passing of the `--fix` argument on the command line

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1401,6 +1401,9 @@ gulp.task("lint", function(done) {
     ".",
     "--report-unused-disable-directives",
   ];
+  if (process.argv.includes("--fix")) {
+    options.push("--fix");
+  }
   var esLintProcess = startNode(options, { stdio: "inherit" });
   esLintProcess.on("close", function(code) {
     if (code !== 0) {


### PR DESCRIPTION
*I've had this patch locally for awhile, but have apparently missed to upstream it.*

This simplifies enabling of new ESLint rules, since most of them support automatic fixing of errors, without having to edit `gulpfile.js` or manually invoke ESLint directly.