### PR TITLE
Add a `PDFViewerApplication.initializedPromise` property to allow (easier) tracking of when the default viewer has been initialized

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -38,6 +38,7 @@ import {
 import { AppOptions, OptionKind } from "./app_options.js";
 import {
   build,
+  createPromiseCapability,
   getDocument,
   getFilenameFromUrl,
   GlobalWorkerOptions,
@@ -128,7 +129,7 @@ class DefaultExternalServices {
 
 const PDFViewerApplication = {
   initialBookmark: document.location.hash.substring(1),
-  initialized: false,
+  _initializedCapability: createPromiseCapability(),
   fellback: false,
   appConfig: null,
   pdfDocument: null,
@@ -215,7 +216,7 @@ const PDFViewerApplication = {
       this.eventBus.dispatch("localized", { source: this });
     });
 
-    this.initialized = true;
+    this._initializedCapability.resolve();
   },
 
   /**
@@ -474,6 +475,14 @@ const PDFViewerApplication = {
 
   run(config) {
     this.initialize(config).then(webViewerInitialized);
+  },
+
+  get initialized() {
+    return this._initializedCapability.settled;
+  },
+
+  get initializedPromise() {
+    return this._initializedCapability.promise;
   },
 
   zoomIn(ticks) {


### PR DESCRIPTION
This complements the existing `PDFViewerApplication.initialized` boolean property, and may be helpful for custom implementations of the default viewer. This will thus provide users of the default viewer an alternative to setting the preference to dispatch events to the DOM (and listen for the "localized" event), since they can instead use:
```javascript
document.addEventListener("webviewerloaded", function() {
  PDFViewerApplication.initializedPromise.then(function() {
    // The viewer has now been initialized.
  })
});
```

Note that in order to avoid manually tracking the initialization state *twice*, this implementation purposely uses the `PromiseCapability` functionality to handle both `PDFViewerApplication.initialized` and `PDFViewerApplication.initializedPromise` internally.