### PR TITLE
Add a `ignoreDestinationZoom` option/preference to allow users to preserve the current zoom level when navigating to internal destinations (issue 5064, 11606)

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -159,6 +159,12 @@
       "type": "boolean",
       "default": false
     },
+    "ignoreDestinationZoom": {
+      "title": "Ignore the zoom argument in destinations",
+      "description": "When enabled it will maintain the currently active zoom level, rather than letting the PDF document modify it, when navigating to internal destinations.",
+      "type": "boolean",
+      "default": false
+    },
     "enablePrintAutoRotate": {
       "title": "Automatically rotate printed pages",
       "description": "When enabled, pages whose orientation differ from the first page are rotated when printed.",

--- a/web/app.js
+++ b/web/app.js
@@ -354,6 +354,7 @@ const PDFViewerApplication = {
       eventBus,
       externalLinkTarget: AppOptions.get("externalLinkTarget"),
       externalLinkRel: AppOptions.get("externalLinkRel"),
+      ignoreDestinationZoom: AppOptions.get("ignoreDestinationZoom"),
     });
     this.pdfLinkService = pdfLinkService;
 

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -86,6 +86,11 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
+  ignoreDestinationZoom: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+  },
   imageResourcesPath: {
     /** @type {string} */
     value: "./images/",

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -734,6 +734,8 @@ class BaseViewer {
    *   format: <page-ref> </XYZ|/FitXXX> <args..>
    * @property {boolean} [allowNegativeOffset] - Allow negative page offsets.
    *   The default value is `false`.
+   * @property {boolean} [ignoreDestinationZoom] - Ignore the zoom argument in
+   *   the destination array. The default value is `false`.
    */
 
   /**
@@ -744,6 +746,7 @@ class BaseViewer {
     pageNumber,
     destArray = null,
     allowNegativeOffset = false,
+    ignoreDestinationZoom = false,
   }) {
     if (!this.pdfDocument) {
       return;
@@ -834,10 +837,12 @@ class BaseViewer {
         return;
     }
 
-    if (scale && scale !== this._currentScale) {
-      this.currentScaleValue = scale;
-    } else if (this._currentScale === UNKNOWN_SCALE) {
-      this.currentScaleValue = DEFAULT_SCALE_VALUE;
+    if (!ignoreDestinationZoom) {
+      if (scale && scale !== this._currentScale) {
+        this.currentScaleValue = scale;
+      } else if (this._currentScale === UNKNOWN_SCALE) {
+        this.currentScaleValue = DEFAULT_SCALE_VALUE;
+      }
     }
 
     if (scale === "page-fit" && !destArray[4]) {

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -23,6 +23,9 @@ import { getGlobalEventBus, parseQueryString } from "./ui_utils.js";
  *   Defaults to using no target.
  * @property {string} [externalLinkRel] - Specifies the `rel` attribute for
  *   external links. Defaults to stripping the referrer.
+ * @property {boolean} [ignoreDestinationZoom] - Ignores the zoom argument,
+ *   thus preserving the current zoom level in the viewer, when navigating
+ *   to internal destinations. The default value is `false`.
  */
 
 /**
@@ -39,11 +42,13 @@ class PDFLinkService {
     externalLinkTarget = null,
     externalLinkRel = null,
     externalLinkEnabled = true,
+    ignoreDestinationZoom = false,
   } = {}) {
     this.eventBus = eventBus || getGlobalEventBus();
     this.externalLinkTarget = externalLinkTarget;
     this.externalLinkRel = externalLinkRel;
     this.externalLinkEnabled = externalLinkEnabled;
+    this._ignoreDestinationZoom = ignoreDestinationZoom;
 
     this.baseUrl = null;
     this.pdfDocument = null;
@@ -158,6 +163,7 @@ class PDFLinkService {
       this.pdfViewer.scrollPageIntoView({
         pageNumber,
         destArray: explicitDest,
+        ignoreDestinationZoom: this._ignoreDestinationZoom,
       });
     };
 
@@ -468,6 +474,7 @@ class SimpleLinkService {
     this.externalLinkTarget = null;
     this.externalLinkRel = null;
     this.externalLinkEnabled = true;
+    this._ignoreDestinationZoom = false;
   }
 
   /**


### PR DESCRIPTION
Fixes #5064
Fixes #11606