### PR TITLE
Update the PDF.js web page to link to both versions of the demo viewer (PR 11241 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Feel free to stop by #pdfjs on irc.mozilla.org for questions or guidance.
 
 ### Online demo
 
+Please note that the "Modern browsers" version assumes native support for
+features such as e.g. `async`/`await`, `Promise`, and `ReadableStream`.
+
 + Modern browsers: https://mozilla.github.io/pdf.js/web/viewer.html
 
 + Older browsers: https://mozilla.github.io/pdf.js/es5/web/viewer.html

--- a/docs/contents/index.md
+++ b/docs/contents/index.md
@@ -9,6 +9,6 @@ template: layout.jade
 </p>
 <p class="text-center">
   <a type="button" class="btn btn-lg btn-default" href="getting_started/#download">Download</a>
-  <a type="button" class="btn btn-lg btn-default" href="web/viewer.html">Demo</a>
+  <a type="button" class="btn btn-lg btn-default" href="https://github.com/mozilla/pdf.js#online-demo">Demo</a>
   <a type="button" class="btn btn-lg btn-default" href="https://github.com/mozilla/pdf.js">GitHub Project</a>
 </p>


### PR DESCRIPTION
Rather than adding two buttons, it seems easier to simply link to the relevant section of the README instead (since it also means fewer things to keep up-to-date).