### PR TITLE
Remove the unused `thisArg` from `RefSetCache.forEach`

### DIFF
--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -251,9 +251,9 @@ var RefSetCache = (function RefSetCacheClosure() {
       this.dict[ref.toString()] = this.get(aliasRef);
     },
 
-    forEach: function RefSetCache_forEach(fn, thisArg) {
-      for (var i in this.dict) {
-        fn.call(thisArg, this.dict[i]);
+    forEach: function RefSetCache_forEach(callback) {
+      for (const i in this.dict) {
+        callback(this.dict[i]);
       }
     },
 


### PR DESCRIPTION
Given that this is completely unused, and that a "normal" function call may be a *tiny* bit more efficient, there's no good reason as far as I can tell to keep it.