### PR TITLE
Use the same non-embedded Wingdings fallback for fonts named "Wingdings-Regular" too (PR 5463 follow-up, issue 11451)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -2373,7 +2373,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           if (!properties.file) {
             if (/Symbol/i.test(properties.name)) {
               encoding = SymbolSetEncoding;
-            } else if (/Dingbats/i.test(properties.name)) {
+            } else if (/Dingbats|Wingdings/i.test(properties.name)) {
               encoding = ZapfDingbatsEncoding;
             }
           }

--- a/src/core/standard_fonts.js
+++ b/src/core/standard_fonts.js
@@ -119,6 +119,7 @@ const getNonStdFontMap = getLookupTableFactory(function(t) {
   t["NuptialScript"] = "Times-Italic";
   t["SegoeUISymbol"] = "Helvetica";
   t["Wingdings"] = "ZapfDingbats";
+  t["Wingdings-Regular"] = "ZapfDingbats";
 });
 
 const getSerifFonts = getLookupTableFactory(function(t) {


### PR DESCRIPTION
This patch extends the existing heuristics, which are really the best that we can do in general for these kinds of non-embedded *and* non-standard fonts.

Furthermore, this patch also tries to improve the copy-and-paste behaviour for non-embedded Wingdings fonts by also using the `ZapfDingbatsEncoding` in this case.

*Note:* I'm not sure that adding additional tests for Wingdings fonts matters that much, given how limited our "support" for them really is.

Fixes #11451