### PR TITLE
[api-minor] Add more general OpenAction support (PR 10334 follow-up, issue 11642)

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -592,9 +592,12 @@ class Catalog {
     return shadow(this, "viewerPreferences", prefs);
   }
 
-  get openActionDestination() {
+  /**
+   * NOTE: "JavaScript" actions are, for now, handled by `get javaScript` below.
+   */
+  get openAction() {
     const obj = this.catDict.get("OpenAction");
-    let openActionDest = null;
+    let openAction = null;
 
     if (isDict(obj)) {
       // Convert the OpenAction dictionary into a format that works with
@@ -602,16 +605,27 @@ class Catalog {
       const destDict = new Dict(this.xref);
       destDict.set("A", obj);
 
-      const resultObj = { url: null, dest: null };
+      const resultObj = { url: null, dest: null, action: null };
       Catalog.parseDestDictionary({ destDict, resultObj });
 
       if (Array.isArray(resultObj.dest)) {
-        openActionDest = resultObj.dest;
+        if (!openAction) {
+          openAction = Object.create(null);
+        }
+        openAction.dest = resultObj.dest;
+      } else if (resultObj.action) {
+        if (!openAction) {
+          openAction = Object.create(null);
+        }
+        openAction.action = resultObj.action;
       }
     } else if (Array.isArray(obj)) {
-      openActionDest = obj;
+      if (!openAction) {
+        openAction = Object.create(null);
+      }
+      openAction.dest = obj;
     }
-    return shadow(this, "openActionDestination", openActionDest);
+    return shadow(this, "openAction", openAction);
   }
 
   get attachments() {
@@ -668,27 +682,10 @@ class Catalog {
       }
     }
 
-    // Append OpenAction actions to the JavaScript array.
-    const openActionDict = this.catDict.get("OpenAction");
-    if (
-      isDict(openActionDict) &&
-      (isName(openActionDict.get("Type"), "Action") ||
-        !openActionDict.has("Type"))
-    ) {
-      const actionType = openActionDict.get("S");
-      if (isName(actionType, "Named")) {
-        // The named Print action is not a part of the PDF 1.7 specification,
-        // but is supported by many PDF readers/writers (including Adobe's).
-        const action = openActionDict.get("N");
-        if (isName(action, "Print")) {
-          if (!javaScript) {
-            javaScript = [];
-          }
-          javaScript.push("print({});");
-        }
-      } else {
-        appendIfJavaScriptDict(openActionDict);
-      }
+    // Append OpenAction "JavaScript" actions to the JavaScript array.
+    const openAction = this.catDict.get("OpenAction");
+    if (isDict(openAction) && isName(openAction.get("S"), "JavaScript")) {
+      appendIfJavaScriptDict(openAction);
     }
 
     return shadow(this, "javaScript", javaScript);

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -458,8 +458,8 @@ var WorkerMessageHandler = {
       return pdfManager.ensureCatalog("viewerPreferences");
     });
 
-    handler.on("GetOpenActionDestination", function(data) {
-      return pdfManager.ensureCatalog("openActionDestination");
+    handler.on("GetOpenAction", function(data) {
+      return pdfManager.ensureCatalog("openAction");
     });
 
     handler.on("GetAttachments", function wphSetupGetAttachments(data) {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -668,11 +668,18 @@ class PDFDocumentProxy {
   }
 
   /**
-   * @returns {Promise} A promise that is resolved with an {Array} containing
-   *   the destination, or `null` when no open action is present in the PDF.
+   * @returns {Promise} A promise that is resolved with an {Object} containing
+   *   the currently supported actions, or `null` when no OpenAction exists.
    */
+  getOpenAction() {
+    return this._transport.getOpenAction();
+  }
+
   getOpenActionDestination() {
-    return this._transport.getOpenActionDestination();
+    deprecated("getOpenActionDestination, use getOpenAction instead.");
+    return this.getOpenAction().then(function(openAction) {
+      return openAction && openAction.dest ? openAction.dest : null;
+    });
   }
 
   /**
@@ -2518,11 +2525,8 @@ class WorkerTransport {
     return this.messageHandler.sendWithPromise("GetViewerPreferences", null);
   }
 
-  getOpenActionDestination() {
-    return this.messageHandler.sendWithPromise(
-      "GetOpenActionDestination",
-      null
-    );
+  getOpenAction() {
+    return this.messageHandler.sendWithPromise("GetOpenAction", null);
   }
 
   getAttachments() {


### PR DESCRIPTION
This patch deprecates the existing `getOpenActionDestination` API method, in favor of a better and more general `getOpenAction` method instead. (For now JavaScript actions, related to printing, are still handled as before.)

By clearly separating "regular" Print actions from the JavaScript handling, it's thus possible to get rid of the somewhat annoying and strictly incorrect warning when the viewer loads.

Fixes #11642