### PR TITLE
Ensure that automatic printing still works when the viewer and/or its pages are hidden (bug 1618621, bug 1618955)

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -391,9 +391,9 @@ class BaseViewer {
   /**
    * @private
    */
-  get _setDocumentViewerElement() {
+  get _viewerElement() {
     // In most viewers, e.g. `PDFViewer`, this should return `this.viewer`.
-    throw new Error("Not implemented: _setDocumentViewerElement");
+    throw new Error("Not implemented: _viewerElement");
   }
 
   /**
@@ -479,7 +479,7 @@ class BaseViewer {
 
         for (let pageNum = 1; pageNum <= pagesCount; ++pageNum) {
           const pageView = new PDFPageView({
-            container: this._setDocumentViewerElement,
+            container: this._viewerElement,
             eventBus: this.eventBus,
             id: pageNum,
             scale,

--- a/web/pdf_single_page_viewer.js
+++ b/web/pdf_single_page_viewer.js
@@ -27,12 +27,12 @@ class PDFSinglePageViewer extends BaseViewer {
     });
   }
 
-  get _setDocumentViewerElement() {
+  get _viewerElement() {
     // Since we only want to display *one* page at a time when using the
     // `PDFSinglePageViewer`, we cannot append them to the `viewer` DOM element.
     // Instead, they are placed in a `DocumentFragment`, and only the current
     // page is displayed in the viewer (refer to `this._ensurePageViewVisible`).
-    return shadow(this, "_setDocumentViewerElement", this._shadowViewer);
+    return shadow(this, "_viewerElement", this._shadowViewer);
   }
 
   _resetView() {

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -17,8 +17,8 @@ import { BaseViewer } from "./base_viewer.js";
 import { shadow } from "pdfjs-lib";
 
 class PDFViewer extends BaseViewer {
-  get _setDocumentViewerElement() {
-    return shadow(this, "_setDocumentViewerElement", this.viewer);
+  get _viewerElement() {
+    return shadow(this, "_viewerElement", this.viewer);
   }
 
   _scrollIntoView({ pageDiv, pageSpot = null, pageNumber = null }) {

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -229,7 +229,7 @@ function binarySearchFirstItem(items, condition) {
   let minIndex = 0;
   let maxIndex = items.length - 1;
 
-  if (items.length === 0 || !condition(items[maxIndex])) {
+  if (maxIndex < 0 || !condition(items[maxIndex])) {
     return items.length;
   }
   if (condition(items[minIndex])) {


### PR DESCRIPTION
Please note that this patch, on its own, won't magically fix all of these printing bugs without [bug 1618553](https://bugzilla.mozilla.org/show_bug.cgi?id=1618553) also being fixed.
(However I don't foresee that being too difficult, famous last words :-), but it will as suggested require a platform API that we can notify when the viewer is ready.)

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1618621
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1618955
Fixes #8208

/cc @brendandahl 