### PR TITLE
[Firefox] Block the "load" event until all pages are loaded, to ensure that printing works (bug 1618553)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -943,6 +943,8 @@ const PDFViewerApplication = {
         this.load(pdfDocument);
       },
       exception => {
+        this._unblockDocumentLoadEvent();
+
         if (loadingTask !== this.pdfLoadingTask) {
           return undefined; // Ignore errors for previously opened PDF files.
         }
@@ -1420,6 +1422,8 @@ const PDFViewerApplication = {
     });
 
     pagesPromise.then(() => {
+      this._unblockDocumentLoadEvent();
+
       this._initializeAutoPrint(pdfDocument, openActionPromise);
     });
 
@@ -2333,6 +2337,19 @@ const PDFViewerApplication = {
       Math.floor(Math.abs(this._wheelUnusedTicks));
     this._wheelUnusedTicks -= wholeTicks;
     return wholeTicks;
+  },
+
+  /**
+   * Should be called *after* all pages have loaded, or if an error occurred,
+   * to unblock the "load" event; see https://bugzilla.mozilla.org/show_bug.cgi?id=1618553
+   * @private
+   */
+  _unblockDocumentLoadEvent() {
+    if (document.blockUnblockOnload) {
+      document.blockUnblockOnload(false);
+    }
+    // Ensure that this method is only ever run once.
+    this._unblockDocumentLoadEvent = () => {};
   },
 
   /**

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -236,6 +236,12 @@ function webViewerLoad() {
   }
 }
 
+// Block the "load" event until all pages are loaded, to ensure that printing
+// works in Firefox; see https://bugzilla.mozilla.org/show_bug.cgi?id=1618553
+if (document.blockUnblockOnload) {
+  document.blockUnblockOnload(true);
+}
+
 if (
   document.readyState === "interactive" ||
   document.readyState === "complete"


### PR DESCRIPTION
Add the PDF viewer parts that are necessary as part of fixing https://bugzilla.mozilla.org/show_bug.cgi?id=1618553
