### PR TITLE
Simplify the `BaseFontLoader.isFontLoadingAPISupported` getter

### DIFF
--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -113,9 +113,9 @@ class BaseFontLoader {
     unreachable("Abstract method `_queueLoadingCallback`.");
   }
 
-  // eslint-disable-next-line getter-return
   get isFontLoadingAPISupported() {
-    unreachable("Abstract method `isFontLoadingAPISupported`.");
+    const supported = typeof document !== "undefined" && !!document.fonts;
+    return shadow(this, "isFontLoadingAPISupported", supported);
   }
 
   // eslint-disable-next-line getter-return
@@ -136,14 +136,6 @@ class BaseFontLoader {
 let FontLoader;
 if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
   FontLoader = class MozcentralFontLoader extends BaseFontLoader {
-    get isFontLoadingAPISupported() {
-      return shadow(
-        this,
-        "isFontLoadingAPISupported",
-        typeof document !== "undefined" && !!document.fonts
-      );
-    }
-
     get isSyncFontLoadingSupported() {
       return shadow(this, "isSyncFontLoadingSupported", true);
     }
@@ -159,24 +151,6 @@ if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
         nextRequestId: 0,
       };
       this.loadTestFontId = 0;
-    }
-
-    get isFontLoadingAPISupported() {
-      let supported = typeof document !== "undefined" && !!document.fonts;
-
-      if (
-        (typeof PDFJSDev === "undefined" || !PDFJSDev.test("CHROME")) &&
-        supported &&
-        typeof navigator !== "undefined"
-      ) {
-        // The Firefox Font Loading API does not work with `mozPrintCallback`
-        // prior to version 63; see https://bugzilla.mozilla.org/show_bug.cgi?id=1473742
-        const m = /Mozilla\/5.0.*?rv:(\d+).*? Gecko/.exec(navigator.userAgent);
-        if (m && m[1] < 63) {
-          supported = false;
-        }
-      }
-      return shadow(this, "isFontLoadingAPISupported", supported);
     }
 
     get isSyncFontLoadingSupported() {


### PR DESCRIPTION
It's no longer necessary to special-case this getter in the `GenericFontLoader` case, since the GENERIC build hasn't been using `mozPrintCallback` for years now (furthermore Firefox 63 is really old as well).