### PR TITLE
[feat] add multiphrase search

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2272,6 +2272,7 @@ function webViewerFind(evt) {
   PDFViewerApplication.findController.executeCommand("find" + evt.type, {
     query: evt.query,
     phraseSearch: evt.phraseSearch,
+    multiplePhraseSearch: evt.multiplePhraseSearch,
     caseSensitive: evt.caseSensitive,
     entireWord: evt.entireWord,
     highlightAll: evt.highlightAll,
@@ -2283,6 +2284,7 @@ function webViewerFindFromUrlHash(evt) {
   PDFViewerApplication.findController.executeCommand("find", {
     query: evt.query,
     phraseSearch: evt.phraseSearch,
+    multiplePhraseSearch: evt.multiplePhraseSearch,
     caseSensitive: false,
     entireWord: false,
     highlightAll: true,

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -367,11 +367,15 @@ class PDFFindController {
     this._pageMatches[pageIndex] = matches;
   }
 
-  _calculateWordMatch(query, pageIndex, pageContent, entireWord) {
+  _calculateMultiplePhraseMatch(query, pageIndex, pageContent, entireWord) {
+    this._calculateWordMatch(query, pageIndex, pageContent, entireWord, "$$");
+  }
+
+  _calculateWordMatch(query, pageIndex, pageContent, entireWord, separator=" ") {
     const matchesWithLength = [];
 
     // Divide the query into pieces and search for text in each piece.
-    const queryArray = query.match(/\S+/g);
+    const queryArray = query.split(separator);
     for (let i = 0, len = queryArray.length; i < len; i++) {
       const subquery = queryArray[i];
       const subqueryLen = subquery.length;
@@ -413,7 +417,7 @@ class PDFFindController {
   _calculateMatch(pageIndex) {
     let pageContent = this._pageContents[pageIndex];
     let query = this._query;
-    const { caseSensitive, entireWord, phraseSearch } = this._state;
+    const { caseSensitive, entireWord, phraseSearch, multiplePhraseSearch, } = this._state;
 
     if (query.length === 0) {
       // Do nothing: the matches should be wiped out already.
@@ -427,6 +431,8 @@ class PDFFindController {
 
     if (phraseSearch) {
       this._calculatePhraseMatch(query, pageIndex, pageContent, entireWord);
+    } else if (multiplePhraseSearch){
+      this._calculateMultiplePhraseMatch(query, pageIndex, pageContent, entireWord);
     } else {
       this._calculateWordMatch(query, pageIndex, pageContent, entireWord);
     }

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -228,8 +228,9 @@ class PDFLinkService {
       if ("search" in params) {
         this.eventBus.dispatch("findfromurlhash", {
           source: this,
-          query: params["search"].replace(/"/g, ""),
-          phraseSearch: params["phrase"] === "true",
+          query: params['search'].replace(/"/g, ''),
+          phraseSearch: (params['phrase'] === 'true'),
+          multiplePhraseSearch: (params['multiplephrase'] === 'true'),
         });
       }
       // borrowing syntax from "Parameters for Opening PDF Files"

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -74,10 +74,9 @@ function PDFPrintService(pdfDocument, pagesOverview, printContainer, l10n) {
 
 PDFPrintService.prototype = {
   layout() {
-    this.viewerContainer = window.PDFViewerConfig.appContainer;
     this.throwIfInactive();
 
-    const body = this.viewerContainer;
+    const body = document.querySelector("body");
     body.setAttribute("data-pdfjsprinting", true);
 
     const hasEqualPageSizes = this.pagesOverview.every(function(size) {
@@ -126,7 +125,7 @@ PDFPrintService.prototype = {
     }
     this.printContainer.textContent = "";
 
-    const body = this.viewerContainer;
+    const body = document.querySelector("body");
     body.removeAttribute("data-pdfjsprinting");
 
     if (this.pageStyleSheet) {
@@ -278,9 +277,7 @@ function abort() {
 }
 
 function renderProgress(index, total, l10n) {
-  this.viewerContainer = window.PDFViewerConfig.appContainer;
-
-  const progressContainer = this.viewerContainer.getElementById("printServiceOverlay");
+  const progressContainer = document.getElementById("printServiceOverlay");
   const progress = Math.round((100 * index) / total);
   const progressBar = progressContainer.querySelector("progress");
   const progressPerc = progressContainer.querySelector(".relative-progress");
@@ -330,7 +327,6 @@ if ("onbeforeprint" in window) {
 
 let overlayPromise;
 function ensureOverlay() {
-  this.viewerContainer = window.PDFViewerConfig.appContainer;
   if (!overlayPromise) {
     overlayManager = PDFViewerApplication.overlayManager;
     if (!overlayManager) {
@@ -339,11 +335,11 @@ function ensureOverlay() {
 
     overlayPromise = overlayManager.register(
       "printServiceOverlay",
-      this.viewerContainer.getElementById("printServiceOverlay"),
+      document.getElementById("printServiceOverlay"),
       abort,
       true
     );
-    this.viewerContainer.getElementById("printCancel").onclick = abort;
+    document.getElementById("printCancel").onclick = abort;
   }
   return overlayPromise;
 }

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -74,9 +74,10 @@ function PDFPrintService(pdfDocument, pagesOverview, printContainer, l10n) {
 
 PDFPrintService.prototype = {
   layout() {
+    this.viewerContainer = window.PDFViewerConfig.appContainer;
     this.throwIfInactive();
 
-    const body = document.querySelector("body");
+    const body = this.viewerContainer;
     body.setAttribute("data-pdfjsprinting", true);
 
     const hasEqualPageSizes = this.pagesOverview.every(function(size) {
@@ -125,7 +126,7 @@ PDFPrintService.prototype = {
     }
     this.printContainer.textContent = "";
 
-    const body = document.querySelector("body");
+    const body = this.viewerContainer;
     body.removeAttribute("data-pdfjsprinting");
 
     if (this.pageStyleSheet) {
@@ -277,7 +278,9 @@ function abort() {
 }
 
 function renderProgress(index, total, l10n) {
-  const progressContainer = document.getElementById("printServiceOverlay");
+  this.viewerContainer = window.PDFViewerConfig.appContainer;
+
+  const progressContainer = this.viewerContainer.getElementById("printServiceOverlay");
   const progress = Math.round((100 * index) / total);
   const progressBar = progressContainer.querySelector("progress");
   const progressPerc = progressContainer.querySelector(".relative-progress");
@@ -327,6 +330,7 @@ if ("onbeforeprint" in window) {
 
 let overlayPromise;
 function ensureOverlay() {
+  this.viewerContainer = window.PDFViewerConfig.appContainer;
   if (!overlayPromise) {
     overlayManager = PDFViewerApplication.overlayManager;
     if (!overlayManager) {
@@ -335,11 +339,11 @@ function ensureOverlay() {
 
     overlayPromise = overlayManager.register(
       "printServiceOverlay",
-      document.getElementById("printServiceOverlay"),
+      this.viewerContainer.getElementById("printServiceOverlay"),
       abort,
       true
     );
-    document.getElementById("printCancel").onclick = abort;
+    this.viewerContainer.getElementById("printCancel").onclick = abort;
   }
   return overlayPromise;
 }


### PR DESCRIPTION
This feature allows to make a multi-phrase search in the pdf.

Combined with the highlightAll option, we are able to highlight multiple phrases.

Each phrases must be separated by "$$" and passed in the search url parameter.  