### PR TITLE
Prevent the zoom dropdown icon from being overridden when the element is `:active` (bug 1619595)

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -699,12 +699,17 @@ html[dir='rtl'] .dropdownToolbarButton {
   width: 140px;
   padding: 0;
   overflow: hidden;
+}
+.dropdownToolbarButton,
+.dropdownToolbarButton:hover:active {
   background: url(images/toolbarButton-menuArrows.png) no-repeat;
 }
-html[dir='ltr'] .dropdownToolbarButton {
+html[dir='ltr'] .dropdownToolbarButton,
+html[dir='ltr'] .dropdownToolbarButton:hover:active {
   background-position: 95%;
 }
-html[dir='rtl'] .dropdownToolbarButton {
+html[dir='rtl'] .dropdownToolbarButton,
+html[dir='rtl'] .dropdownToolbarButton:hover:active {
   background-position: 5%;
 }
 


### PR DESCRIPTION
~~Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1619595~~

This seemed to introduce slight flickering in the *text* of the dropdown, which didn't look good either, closing since a better solution seem to be necessary (and the issue is very minor anyway).