### PR TITLE
Add a deprecation warning for the `eventBusDispatchToDOM` option/preference (PR 11631 follow-up)

### DIFF
--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -716,7 +716,7 @@ function waitOnEventOrTimeout({ target, name, delay = 0 }) {
 
     function handler(type) {
       if (target instanceof EventBus) {
-        target.off(name, eventHandler);
+        target._off(name, eventHandler);
       } else {
         target.removeEventListener(name, eventHandler);
       }
@@ -729,7 +729,7 @@ function waitOnEventOrTimeout({ target, name, delay = 0 }) {
 
     const eventHandler = handler.bind(null, WaitOnType.EVENT);
     if (target instanceof EventBus) {
-      target.on(name, eventHandler);
+      target._on(name, eventHandler);
     } else {
       target.addEventListener(name, eventHandler);
     }
@@ -829,7 +829,7 @@ class EventBus {
     }
     eventListeners.push({
       listener,
-      external: options ? options.external : false,
+      external: (options && options.external) === true,
     });
   }
 

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -757,6 +757,29 @@ const animationStarted = new Promise(function(resolve) {
 });
 
 /**
+ * NOTE: Only used to support various PDF viewer tests in `mozilla-central`.
+ */
+function dispatchDOMEvent(eventName, args = null) {
+  const details = Object.create(null);
+  if (args && args.length > 0) {
+    const obj = args[0];
+    for (const key in obj) {
+      const value = obj[key];
+      if (key === "source") {
+        if (value === window || value === document) {
+          return; // No need to re-dispatch (already) global events.
+        }
+        continue; // Ignore the `source` property.
+      }
+      details[key] = value;
+    }
+  }
+  const event = document.createEvent("CustomEvent");
+  event.initCustomEvent(eventName, true, true, details);
+  document.dispatchEvent(event);
+}
+
+/**
  * Simple event bus for an application. Listeners are attached using the `on`
  * and `off` methods. To raise an event, the `dispatch` method shall be used.
  */
@@ -764,6 +787,17 @@ class EventBus {
   constructor({ dispatchToDOM = false } = {}) {
     this._listeners = Object.create(null);
     this._dispatchToDOM = dispatchToDOM === true;
+
+    if (
+      typeof PDFJSDev !== "undefined" &&
+      !PDFJSDev.test("MOZCENTRAL || TESTING") &&
+      dispatchToDOM
+    ) {
+      console.error(
+        "The `eventBusDispatchToDOM` option/preference is deprecated, " +
+          "add event listeners to the EventBus instance rather than the DOM."
+      );
+    }
   }
 
   /**
@@ -787,7 +821,7 @@ class EventBus {
     if (!eventListeners || eventListeners.length === 0) {
       if (this._dispatchToDOM) {
         const args = Array.prototype.slice.call(arguments, 1);
-        this._dispatchDOMEvent(eventName, args);
+        dispatchDOMEvent(eventName, args);
       }
       return;
     }
@@ -815,7 +849,7 @@ class EventBus {
       externalListeners = null;
     }
     if (this._dispatchToDOM) {
-      this._dispatchDOMEvent(eventName, args);
+      dispatchDOMEvent(eventName, args);
     }
   }
 
@@ -847,29 +881,6 @@ class EventBus {
         return;
       }
     }
-  }
-
-  /**
-   * @private
-   */
-  _dispatchDOMEvent(eventName, args = null) {
-    const details = Object.create(null);
-    if (args && args.length > 0) {
-      const obj = args[0];
-      for (const key in obj) {
-        const value = obj[key];
-        if (key === "source") {
-          if (value === window || value === document) {
-            return; // No need to re-dispatch (already) global events.
-          }
-          continue; // Ignore the `source` property.
-        }
-        details[key] = value;
-      }
-    }
-    const event = document.createEvent("CustomEvent");
-    event.initCustomEvent(eventName, true, true, details);
-    document.dispatchEvent(event);
   }
 }
 


### PR DESCRIPTION
 - **Update the `waitOnEventOrTimeout` helper function to handle internal events consistently with the rest of the viewer components (PR 11631 follow-up)**

   I overlooked this in PR #11631; sorry about that!

   Also, ensure that `EventBus` instances *always* track "external" events using a boolean regardless of the actual option value.

 - **Move the `dispatchDOMEvent` functionality out from the `EventBus` and add a deprecation warning for the `eventBusDispatchToDOM` option/preference (PR 11631 follow-up)**

   It occured to me that similar to the `getGlobalEventBus` function, it's probably a good idea to *also* notify users of the fact that `eventBusDispatchToDOM` is now deprecated.

   Rather than depending of the re-dispatching of internal events to the DOM, the default viewer can instead be used in e.g. the following way:
   ```javascript
   document.addEventListener("webviewerloaded", function() {
     PDFViewerApplication.initializedPromise.then(function() {
       // The viewer has now been initialized, and its properties can be accessed.

       PDFViewerApplication.eventBus.on("pagerendered", function(event) {
         console.log("Has rendered page number: " + event.pageNumber);
       });
     });
   });
   ```



