### PR TITLE
Update the `FontLoader.bind` method to avoid explicitly returning `undefined`

### DIFF
--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -71,7 +71,7 @@ class BaseFontLoader {
   async bind(font) {
     // Add the font to the DOM only once; skip if the font is already loaded.
     if (font.attached || font.missingFile) {
-      return undefined;
+      return;
     }
     font.attached = true;
 
@@ -90,7 +90,7 @@ class BaseFontLoader {
           throw ex;
         }
       }
-      return undefined; // The font was, asynchronously, loaded.
+      return; // The font was, asynchronously, loaded.
     }
 
     // !this.isFontLoadingAPISupported
@@ -99,14 +99,14 @@ class BaseFontLoader {
       this.insertRule(rule);
 
       if (this.isSyncFontLoadingSupported) {
-        return undefined; // The font was, synchronously, loaded.
+        return; // The font was, synchronously, loaded.
       }
-      return new Promise(resolve => {
+      await new Promise(resolve => {
         const request = this._queueLoadingCallback(resolve);
         this._prepareFontLoadEvent([rule], [font], request);
       });
+      // The font was, asynchronously, loaded.
     }
-    return undefined;
   }
 
   _queueLoadingCallback(callback) {


### PR DESCRIPTION
The only reason for the `return undefined;` lines was to appease the ESLint `consistent-return` rule, but that's not actually necessary if you make use of the fact that the method is `async` and that we can thus await the Promise rather than returning it.