### PR TITLE
Prevent lookup errors in `PartialEvaluator.hasBlendModes` from breaking all parsing/rendering of a page (issue 11678)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -61,6 +61,7 @@ import {
   WinAnsiEncoding,
   ZapfDingbatsEncoding,
 } from "./encodings.js";
+import { getLookupTableFactory, MissingDataException } from "./core_utils.js";
 import {
   getNormalizedUnicodes,
   getUnicodeForGlyph,
@@ -77,7 +78,6 @@ import { bidi } from "./bidi.js";
 import { ColorSpace } from "./colorspace.js";
 import { DecodeStream } from "./stream.js";
 import { getGlyphsUnicode } from "./glyphlist.js";
-import { getLookupTableFactory } from "./core_utils.js";
 import { getMetrics } from "./metrics.js";
 import { isPDFFunction } from "./function.js";
 import { JpegStream } from "./jpeg_stream.js";
@@ -266,7 +266,27 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
               if (processed[graphicState.toString()]) {
                 continue; // The ExtGState has already been processed.
               }
-              graphicState = xref.fetch(graphicState);
+              try {
+                graphicState = xref.fetch(graphicState);
+              } catch (ex) {
+                if (ex instanceof MissingDataException) {
+                  throw ex;
+                }
+                if (this.options.ignoreErrors) {
+                  if (graphicState instanceof Ref) {
+                    // Avoid parsing a corrupt ExtGState more than once.
+                    processed[graphicState.toString()] = true;
+                  }
+                  // Error(s) in the ExtGState -- sending unsupported feature
+                  // notification and allow parsing/rendering to continue.
+                  this.handler.send("UnsupportedFeature", {
+                    featureId: UNSUPPORTED_FEATURES.unknown,
+                  });
+                  warn(`hasBlendModes - ignoring ExtGState: "${ex}".`);
+                  continue;
+                }
+                throw ex;
+              }
             }
             if (!(graphicState instanceof Dict)) {
               continue;
@@ -308,7 +328,27 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
               // time for badly generated PDF files (fixes issue6961.pdf).
               continue;
             }
-            xObject = xref.fetch(xObject);
+            try {
+              xObject = xref.fetch(xObject);
+            } catch (ex) {
+              if (ex instanceof MissingDataException) {
+                throw ex;
+              }
+              if (this.options.ignoreErrors) {
+                if (xObject instanceof Ref) {
+                  // Avoid parsing a corrupt XObject more than once.
+                  processed[xObject.toString()] = true;
+                }
+                // Error(s) in the XObject -- sending unsupported feature
+                // notification and allow parsing/rendering to continue.
+                this.handler.send("UnsupportedFeature", {
+                  featureId: UNSUPPORTED_FEATURES.unknown,
+                });
+                warn(`hasBlendModes - ignoring XObject: "${ex}".`);
+                continue;
+              }
+              throw ex;
+            }
           }
           if (!isStream(xObject)) {
             continue;

--- a/test/pdfs/issue11678.pdf.link
+++ b/test/pdfs/issue11678.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/4304559/default.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -3064,6 +3064,15 @@
        "link": false,
        "type": "eq"
     },
+    {  "id": "issue11678",
+       "file": "pdfs/issue11678.pdf",
+       "md5": "e2efadeb91932f4c21e4fc682cce7de9",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 2,
+       "lastPage": 2,
+       "type": "eq"
+    },
     {  "id": "issue4890",
        "file": "pdfs/issue4890.pdf",
        "md5": "1666feb4cd26318c2bdbea6a175dce87",


### PR DESCRIPTION
The PDF document in question is *corrupt*, since it contains an XObject with a truncated dictionary and where the stream contents start without a "stream" operator.

Fixes #11678