### PR TITLE
Magnifier positioning in reftest analyzer

### DIFF
--- a/test/resources/reftest-analyzer.html
+++ b/test/resources/reftest-analyzer.html
@@ -104,7 +104,7 @@ Original author: L. David Baron <dbaron@dbaron.org>
         <input type="checkbox" id="differences"> Circle differences
       </label>
     </form>
-    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="800px" height="1130px" viewbox="0 0 800 1130" id="svg">
+    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="800" height="1000" id="svg">
       <defs>
         <!-- use sRGB to avoid loss of data -->
         <filter id="showDifferences" x="0%" y="0%" width="100%" height="100%"

--- a/test/resources/reftest-analyzer.js
+++ b/test/resources/reftest-analyzer.js
@@ -285,13 +285,13 @@ window.onload = function() {
     var img = new Image();
     img.onload = function() {
       var canvas = document.createElement("canvas");
-      canvas.width = 800;
-      canvas.height = 1000;
+      canvas.width = img.naturalWidth;
+      canvas.height = img.naturalHeight;
 
       var ctx = canvas.getContext("2d");
       ctx.drawImage(img, 0, 0);
 
-      whenReady(ctx.getImageData(0, 0, 800, 1000));
+      whenReady(ctx.getImageData(0, 0, img.naturalWidth, img.naturalHeight));
     };
     img.src = gPath + src;
   }
@@ -323,11 +323,17 @@ window.onload = function() {
     }
     cell.style.display = "";
     getImageData(item.images[0], function(data) {
-      gImage1Data = data
+      gImage1Data = data;
+      syncSVGSize(gImage1Data);
     });
     getImageData(item.images[1], function(data) {
       gImage2Data = data
     });
+  }
+
+  function syncSVGSize(imageData) {
+    ID("svg").setAttribute("width", imageData.width);
+    ID("svg").setAttribute("height", imageData.height);
   }
 
   function showImage(i) {
@@ -397,7 +403,7 @@ window.onload = function() {
         var py = y + j;
         var p1 = gMagPixPaths[i + dx_hi][j + dy_hi][0];
         var p2 = gMagPixPaths[i + dx_hi][j + dy_hi][1];
-        if (px < 0 || py < 0 || px >= 800 || py >= 1000) {
+        if (px < 0 || py < 0 || px >= gImage1Data.width || py >= gImage1Data.height) {
           p1.setAttribute("fill", "#aaa");
           p2.setAttribute("fill", "#888");
         } else {


### PR DESCRIPTION
When reftest analyzer shows magnified pixels, there is a seemingly random offset between the mouse position and the magnified position. The reason for this is that reftest analyzer assumes all images have 800 * 1000 pixels but actually the test images have varying sizes.

I copied the needed lines from
https://github.com/mozilla/gecko-dev/blob/master/layout/tools/reftest/reftest-analyzer.xhtml
(I assume that originally reftest analyzer has been copied from similar Mozilla repositories.)