### PR TITLE
Move `IsLittleEndianCached`/`IsEvalSupportedCached` to `src/shared/util.js`, and rename the `isSpace` helper function to `isWhiteSpace`

### DIFF
--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -161,7 +161,7 @@ function readUint32(data, offset) {
 }
 
 // Checks if ch is one of the following characters: SPACE, TAB, CR or LF.
-function isSpace(ch) {
+function isWhiteSpace(ch) {
   return ch === 0x20 || ch === 0x09 || ch === 0x0d || ch === 0x0a;
 }
 
@@ -176,5 +176,5 @@ export {
   readInt8,
   readUint16,
   readUint32,
-  isSpace,
+  isWhiteSpace,
 };

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -42,7 +42,7 @@ import {
 } from "./primitives.js";
 import {
   getInheritableProperty,
-  isSpace,
+  isWhiteSpace,
   MissingDataException,
   XRefEntryException,
   XRefParseException,
@@ -598,7 +598,7 @@ class PDFDocument {
         let ch;
         do {
           ch = stream.getByte();
-        } while (isSpace(ch));
+        } while (isWhiteSpace(ch));
         let str = "";
         while (ch >= /* Space = */ 0x20 && ch <= /* '9' = */ 0x39) {
           str += String.fromCharCode(ch);

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -58,7 +58,11 @@ import {
   getUnicodeRangeFor,
   mapSpecialUnicodeValues,
 } from "./unicode.js";
-import { isSpace, MissingDataException, readUint32 } from "./core_utils.js";
+import {
+  isWhiteSpace,
+  MissingDataException,
+  readUint32,
+} from "./core_utils.js";
 import { FontRendererFactory } from "./font_renderer.js";
 import { IdentityCMap } from "./cmap.js";
 import { Stream } from "./stream.js";
@@ -3413,7 +3417,7 @@ var Type1Font = (function Type1FontClosure() {
       if (j >= signatureLength) {
         // `signature` found, skip over whitespace.
         i += j;
-        while (i < streamBytesLength && isSpace(streamBytes[i])) {
+        while (i < streamBytesLength && isWhiteSpace(streamBytes[i])) {
           i++;
         }
         found = true;

--- a/src/core/function.js
+++ b/src/core/function.js
@@ -17,18 +17,11 @@ import {
   FormatError,
   info,
   isBool,
-  isEvalSupported,
-  shadow,
+  IsEvalSupportedCached,
   unreachable,
 } from "../shared/util.js";
 import { isDict, isStream } from "./primitives.js";
 import { PostScriptLexer, PostScriptParser } from "./ps_parser.js";
-
-const IsEvalSupportedCached = {
-  get value() {
-    return shadow(this, "value", isEvalSupported());
-  },
-};
 
 class PDFFunctionFactory {
   constructor({ xref, isEvalSupported = true }) {

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -43,7 +43,7 @@ import {
   Name,
   Ref,
 } from "./primitives.js";
-import { isSpace, MissingDataException } from "./core_utils.js";
+import { isWhiteSpace, MissingDataException } from "./core_utils.js";
 import { CCITTFaxStream } from "./ccitt_stream.js";
 import { Jbig2Stream } from "./jbig2_stream.js";
 import { JpegStream } from "./jpeg_stream.js";
@@ -270,7 +270,7 @@ class Parser {
 
     // Ensure that we don't accidentally truncate the inline image, when the
     // data is immediately followed by the "EI" marker (fixes issue10388.pdf).
-    if (!isSpace(ch)) {
+    if (!isWhiteSpace(ch)) {
       endOffset--;
     }
     return stream.pos - endOffset - startPos;
@@ -394,7 +394,7 @@ class Parser {
         ch = stream.peekByte();
         // Handle corrupt PDF documents which contains whitespace "inside" of
         // the EOD marker (fixes issue10614.pdf).
-        while (isSpace(ch)) {
+        while (isWhiteSpace(ch)) {
           stream.skip();
           ch = stream.peekByte();
         }
@@ -640,7 +640,7 @@ class Parser {
             // Ensure that the byte immediately following the truncated
             // endstream command is a space, to prevent false positives.
             const lastByte = stream.peekBytes(end + 1)[end];
-            if (!isSpace(lastByte)) {
+            if (!isWhiteSpace(lastByte)) {
               break;
             }
             info(
@@ -886,7 +886,7 @@ class Lexer {
       if (
         divideBy === 10 &&
         sign === 0 &&
-        (isSpace(ch) || ch === /* EOF = */ -1)
+        (isWhiteSpace(ch) || ch === /* EOF = */ -1)
       ) {
         // This is consistent with Adobe Reader (fixes issue9252.pdf).
         warn("Lexer.getNumber - treating a single decimal point as zero.");

--- a/src/core/ps_parser.js
+++ b/src/core/ps_parser.js
@@ -16,7 +16,7 @@
 
 import { FormatError, shadow } from "../shared/util.js";
 import { EOF } from "./primitives.js";
-import { isSpace } from "./core_utils.js";
+import { isWhiteSpace } from "./core_utils.js";
 
 class PostScriptParser {
   constructor(lexer) {
@@ -193,7 +193,7 @@ class PostScriptLexer {
         }
       } else if (ch === /* '%' = */ 0x25) {
         comment = true;
-      } else if (!isSpace(ch)) {
+      } else if (!isWhiteSpace(ch)) {
         break;
       }
       ch = this.nextChar();

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -21,7 +21,7 @@
 
 import { FormatError, stringToBytes, unreachable } from "../shared/util.js";
 import { isDict } from "./primitives.js";
-import { isSpace } from "./core_utils.js";
+import { isWhiteSpace } from "./core_utils.js";
 
 var Stream = (function StreamClosure() {
   function Stream(arrayBuffer, start, length, dict) {
@@ -1001,7 +1001,7 @@ var Ascii85Stream = (function Ascii85StreamClosure() {
     var str = this.str;
 
     var c = str.getByte();
-    while (isSpace(c)) {
+    while (isWhiteSpace(c)) {
       c = str.getByte();
     }
 
@@ -1026,7 +1026,7 @@ var Ascii85Stream = (function Ascii85StreamClosure() {
       input[0] = c;
       for (i = 1; i < 5; ++i) {
         c = str.getByte();
-        while (isSpace(c)) {
+        while (isWhiteSpace(c)) {
           c = str.getByte();
         }
 

--- a/src/core/type1_parser.js
+++ b/src/core/type1_parser.js
@@ -14,7 +14,7 @@
  */
 
 import { getEncoding } from "./encodings.js";
-import { isSpace } from "./core_utils.js";
+import { isWhiteSpace } from "./core_utils.js";
 import { Stream } from "./stream.js";
 import { warn } from "../shared/util.js";
 
@@ -524,7 +524,7 @@ var Type1Parser = (function Type1ParserClosure() {
           }
         } else if (ch === /* '%' = */ 0x25) {
           comment = true;
-        } else if (!isSpace(ch)) {
+        } else if (!isWhiteSpace(ch)) {
           break;
         }
         ch = this.nextChar();
@@ -537,7 +537,7 @@ var Type1Parser = (function Type1ParserClosure() {
       do {
         token += String.fromCharCode(ch);
         ch = this.nextChar();
-      } while (ch >= 0 && !isSpace(ch) && !isSpecial(ch));
+      } while (ch >= 0 && !isWhiteSpace(ch) && !isSpecial(ch));
       return token;
     },
 

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -18,7 +18,7 @@ import {
   IDENTITY_MATRIX,
   ImageKind,
   info,
-  isLittleEndian,
+  IsLittleEndianCached,
   isNum,
   OPS,
   shadow,
@@ -45,12 +45,6 @@ var COMPILE_TYPE3_GLYPHS = true;
 var MAX_SIZE_TO_COMPILE = 1000;
 
 var FULL_CHUNK_HEIGHT = 16;
-
-var IsLittleEndianCached = {
-  get value() {
-    return shadow(IsLittleEndianCached, "value", isLittleEndian());
-  },
-};
 
 function addContextCurrentTransform(ctx) {
   // If the context doesn't expose a `mozCurrentTransform`, add a JS based one.

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -16,7 +16,7 @@
 import {
   assert,
   bytesToString,
-  isEvalSupported,
+  IsEvalSupportedCached,
   shadow,
   string32,
   unreachable,
@@ -336,12 +336,6 @@ if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
     }
   };
 } // End of PDFJSDev.test('CHROME || GENERIC')
-
-const IsEvalSupportedCached = {
-  get value() {
-    return shadow(this, "value", isEvalSupported());
-  },
-};
 
 class FontFaceObject {
   constructor(

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -547,14 +547,18 @@ function string32(value) {
   );
 }
 
-// Lazy test the endianness of the platform
-// NOTE: This will be 'true' for simulated TypedArrays
+// Checks the endianness of the platform.
 function isLittleEndian() {
   const buffer8 = new Uint8Array(4);
   buffer8[0] = 1;
   const view32 = new Uint32Array(buffer8.buffer, 0, 1);
   return view32[0] === 1;
 }
+const IsLittleEndianCached = {
+  get value() {
+    return shadow(this, "value", isLittleEndian());
+  },
+};
 
 // Checks if it's possible to eval JS expressions.
 function isEvalSupported() {
@@ -565,6 +569,11 @@ function isEvalSupported() {
     return false;
   }
 }
+const IsEvalSupportedCached = {
+  get value() {
+    return shadow(this, "value", isEvalSupported());
+  },
+};
 
 const rgbBuf = ["rgb(", 0, ",", 0, ",", 0, ")"];
 
@@ -918,8 +927,8 @@ export {
   isString,
   isSameOrigin,
   createValidAbsoluteUrl,
-  isLittleEndian,
-  isEvalSupported,
+  IsLittleEndianCached,
+  IsEvalSupportedCached,
   removeNullCharacters,
   setVerbosityLevel,
   shadow,

--- a/test/unit/core_utils_spec.js
+++ b/test/unit/core_utils_spec.js
@@ -16,7 +16,7 @@
 import { Dict, Ref } from "../../src/core/primitives.js";
 import {
   getInheritableProperty,
-  isSpace,
+  isWhiteSpace,
   log2,
   toRomanNumerals,
 } from "../../src/core/core_utils.js";
@@ -197,18 +197,18 @@ describe("core_utils", function() {
     });
   });
 
-  describe("isSpace", function() {
+  describe("isWhiteSpace", function() {
     it("handles space characters", function() {
-      expect(isSpace(0x20)).toEqual(true);
-      expect(isSpace(0x09)).toEqual(true);
-      expect(isSpace(0x0d)).toEqual(true);
-      expect(isSpace(0x0a)).toEqual(true);
+      expect(isWhiteSpace(0x20)).toEqual(true);
+      expect(isWhiteSpace(0x09)).toEqual(true);
+      expect(isWhiteSpace(0x0d)).toEqual(true);
+      expect(isWhiteSpace(0x0a)).toEqual(true);
     });
 
     it("handles non-space characters", function() {
-      expect(isSpace(0x0b)).toEqual(false);
-      expect(isSpace(null)).toEqual(false);
-      expect(isSpace(undefined)).toEqual(false);
+      expect(isWhiteSpace(0x0b)).toEqual(false);
+      expect(isWhiteSpace(null)).toEqual(false);
+      expect(isWhiteSpace(undefined)).toEqual(false);
     });
   });
 });


### PR DESCRIPTION
*This is the first part in a series of patches that will try to split PR #11566 into smaller chunks, to make reviewing more feasible.*

This is part of the work necessary in order to eventually enable the ESLint `no-shadow` rule; see https://eslint.org/docs/rules/no-shadow