### PR TITLE
Remove variable shadowing from the JavaScript files in the `web/` folder

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1741,7 +1741,7 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
     "http://mozilla.github.io",
     "https://mozilla.github.io",
   ];
-  validateFileURL = function validateFileURL(file) {
+  validateFileURL = function(file) {
     if (file === undefined) {
       return;
     }
@@ -1917,7 +1917,7 @@ function webViewerInitialized() {
 
 let webViewerOpenFileViaURL;
 if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-  webViewerOpenFileViaURL = function webViewerOpenFileViaURL(file) {
+  webViewerOpenFileViaURL = function(file) {
     if (file && file.lastIndexOf("file:", 0) === 0) {
       // file:-scheme. Load the contents in the main thread because QtWebKit
       // cannot load file:-URLs in a Web Worker. file:-URLs are usually loaded
@@ -1938,12 +1938,12 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
     }
   };
 } else if (PDFJSDev.test("MOZCENTRAL || CHROME")) {
-  webViewerOpenFileViaURL = function webViewerOpenFileViaURL(file) {
+  webViewerOpenFileViaURL = function(file) {
     PDFViewerApplication.setTitleUsingUrl(file);
     PDFViewerApplication.initPassiveLoading();
   };
 } else {
-  webViewerOpenFileViaURL = function webViewerOpenFileViaURL(file) {
+  webViewerOpenFileViaURL = function(file) {
     if (file) {
       throw new Error("Not implemented: webViewerOpenFileViaURL");
     }
@@ -2149,7 +2149,7 @@ function webViewerHashchange(evt) {
 
 let webViewerFileInputChange;
 if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-  webViewerFileInputChange = function webViewerFileInputChange(evt) {
+  webViewerFileInputChange = function(evt) {
     if (
       PDFViewerApplication.pdfViewer &&
       PDFViewerApplication.pdfViewer.isInPresentationMode
@@ -2168,8 +2168,8 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       PDFViewerApplication.setTitleUsingUrl(file.name);
       // Read the local file into a Uint8Array.
       const fileReader = new FileReader();
-      fileReader.onload = function webViewerChangeFileReaderOnload(evt) {
-        const buffer = evt.target.result;
+      fileReader.onload = function webViewerChangeFileReaderOnload(event) {
+        const buffer = event.target.result;
         PDFViewerApplication.open(new Uint8Array(buffer));
       };
       fileReader.readAsArrayBuffer(file);

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -109,7 +109,7 @@ var FontInspector = (function FontInspectorClosure() {
         return moreInfo;
       }
       var moreInfo = properties(fontObj, ["name", "type"]);
-      var fontName = fontObj.loadedName;
+      const fontName = fontObj.loadedName;
       var font = document.createElement("div");
       var name = document.createElement("span");
       name.textContent = fontName;
@@ -130,17 +130,12 @@ var FontInspector = (function FontInspectorClosure() {
         event.preventDefault();
         console.log(fontObj);
       });
-      var select = document.createElement("input");
+      const select = document.createElement("input");
       select.setAttribute("type", "checkbox");
       select.dataset.fontName = fontName;
-      select.addEventListener(
-        "click",
-        (function(select, fontName) {
-          return function() {
-            selectFont(fontName, select.checked);
-          };
-        })(select, fontName)
-      );
+      select.addEventListener("click", function() {
+        selectFont(fontName, select.checked);
+      });
       font.appendChild(select);
       font.appendChild(name);
       font.appendChild(document.createTextNode(" "));
@@ -476,7 +471,7 @@ var Stats = (function Stats() {
       }
       var statsIndex = getStatIndex(pageNumber);
       if (statsIndex !== false) {
-        var b = stats[statsIndex];
+        const b = stats[statsIndex];
         this.panel.removeChild(b.div);
         stats.splice(statsIndex, 1);
       }

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -338,12 +338,12 @@ class PDFDocumentProperties {
     };
 
     let pageName = null;
-    let name =
+    let rawName =
       getPageName(sizeInches, isPortrait, US_PAGE_NAMES) ||
       getPageName(sizeMillimeters, isPortrait, METRIC_PAGE_NAMES);
 
     if (
-      !name &&
+      !rawName &&
       !(
         Number.isInteger(sizeMillimeters.width) &&
         Number.isInteger(sizeMillimeters.height)
@@ -366,8 +366,8 @@ class PDFDocumentProperties {
         Math.abs(exactMillimeters.width - intMillimeters.width) < 0.1 &&
         Math.abs(exactMillimeters.height - intMillimeters.height) < 0.1
       ) {
-        name = getPageName(intMillimeters, isPortrait, METRIC_PAGE_NAMES);
-        if (name) {
+        rawName = getPageName(intMillimeters, isPortrait, METRIC_PAGE_NAMES);
+        if (rawName) {
           // Update *both* sizes, computed above, to ensure that the displayed
           // dimensions always correspond to the detected page name.
           sizeInches = {
@@ -378,11 +378,11 @@ class PDFDocumentProperties {
         }
       }
     }
-    if (name) {
+    if (rawName) {
       pageName = this.l10n.get(
-        "document_properties_page_size_name_" + name.toLowerCase(),
+        "document_properties_page_size_name_" + rawName.toLowerCase(),
         null,
-        name
+        rawName
       );
     }
 

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -277,7 +277,7 @@ class PDFFindController {
    * the `matches` and keeps elements with a longer match length.
    */
   _prepareMatches(matchesWithLength, matches, matchesLength) {
-    function isSubTerm(matchesWithLength, currentIndex) {
+    function isSubTerm(currentIndex) {
       const currentElem = matchesWithLength[currentIndex];
       const nextElem = matchesWithLength[currentIndex + 1];
 
@@ -318,7 +318,7 @@ class PDFFindController {
         : a.match - b.match;
     });
     for (let i = 0, len = matchesWithLength.length; i < len; i++) {
-      if (isSubTerm(matchesWithLength, i)) {
+      if (isSubTerm(i)) {
         continue;
       }
       matches.push(matchesWithLength[i].match);

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -218,7 +218,7 @@ PDFPrintService.prototype = {
 };
 
 const print = window.print;
-window.print = function print() {
+window.print = function() {
   if (activeService) {
     console.warn("Ignored window.print() because of a pending print job.");
     return;

--- a/web/pdf_sidebar.js
+++ b/web/pdf_sidebar.js
@@ -367,8 +367,8 @@ class PDFSidebar {
       return;
     }
 
-    const removeNotification = view => {
-      switch (view) {
+    const removeNotification = sidebarView => {
+      switch (sidebarView) {
         case SidebarView.OUTLINE:
           this.outlineButton.classList.remove(UI_NOTIFICATION_CLASS);
           break;


### PR DESCRIPTION
*This is part of a series of patches that will try to split PR #11566 into smaller chunks, to make reviewing more feasible.*

Once all the code has been fixed, we'll be able to eventually enable the ESLint `no-shadow` rule; see https://eslint.org/docs/rules/no-shadow