### PR TITLE
Ensure that the JavaScript-warning is always displayed, in the viewer, regardless of browser printing support

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1225,9 +1225,6 @@ const PDFViewerApplication = {
     });
 
     pagesPromise.then(async () => {
-      if (!this.supportsPrinting) {
-        return;
-      }
       const [openAction, javaScript] = await Promise.all([
         openActionPromise,
         pdfDocument.getJavaScript(),
@@ -1259,6 +1256,9 @@ const PDFViewerApplication = {
         }
       }
 
+      if (!this.supportsPrinting) {
+        return;
+      }
       if (triggerAutoPrint) {
         setTimeout(function() {
           window.print();


### PR DESCRIPTION
The viewer doesn't currently support executing of any JavaScript, as found in some PDF documents, for security reasons. (Although there's a small hack to at least provide basic support for automatic printing on document load, without running scripts.)

However, in the event that the browser doesn't support printing we're not run *any* of this code. In particular that means that we're also not displaying the "Warning: JavaScript is not supported" message, which seems strange since JavaScript found in a PDF document can really contain *anything* (and not only printing instructions).

It thus seem reasonable, as far as I'm concerned, to always display the JavaScript-warning *even* if printing happens to be unsupported.