### PR TITLE
add a name attribute on input and select element

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -455,7 +455,7 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
         element.setAttribute("value", this.data.fieldValue);
       }
 
-      element.setAttribute("name", this.data.fieldName);
+      element.name = this.data.fieldName;
       element.disabled = this.data.readOnly;
 
       if (this.data.maxLen !== null) {
@@ -621,8 +621,8 @@ class ChoiceWidgetAnnotationElement extends WidgetAnnotationElement {
 
     const selectElement = document.createElement("select");
     selectElement.disabled = this.data.readOnly;
-    selectElement.setAttribute("name", this.data.fieldName);
-    
+    selectElement.name = this.data.fieldName;
+
     if (!this.data.combo) {
       // List boxes have a size and (optionally) multiple selection.
       selectElement.size = this.data.options.length;

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -549,6 +549,7 @@ class CheckboxWidgetAnnotationElement extends WidgetAnnotationElement {
     if (this.data.fieldValue && this.data.fieldValue !== "Off") {
       element.setAttribute("checked", true);
     }
+    element.name = this.data.fieldName;
 
     this.container.appendChild(element);
     return this.container;

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -455,6 +455,7 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
         element.setAttribute("value", this.data.fieldValue);
       }
 
+      element.setAttribute("name", this.data.fieldName);
       element.disabled = this.data.readOnly;
 
       if (this.data.maxLen !== null) {
@@ -620,7 +621,8 @@ class ChoiceWidgetAnnotationElement extends WidgetAnnotationElement {
 
     const selectElement = document.createElement("select");
     selectElement.disabled = this.data.readOnly;
-
+    selectElement.setAttribute("name", this.data.fieldName);
+    
     if (!this.data.combo) {
       // List boxes have a size and (optionally) multiple selection.
       selectElement.size = this.data.options.length;


### PR DESCRIPTION
Adding a name attribute corresponding to the fielname of the form enable us to find a specific field by its name using document.getElementsByName. It is then possible to read and write the content of the element.