### PR TITLE
[api-minor] Change the pageIndex, on `PDFPageProxy` instances, to a private property

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -505,7 +505,7 @@ describe("api", function() {
       promise
         .then(function(data) {
           expect(data instanceof PDFPageProxy).toEqual(true);
-          expect(data.pageIndex).toEqual(0);
+          expect(data.pageNumber).toEqual(1);
           done();
         })
         .catch(done.fail);
@@ -1769,7 +1769,9 @@ describe("api", function() {
         })
         .catch(function(error) {
           expect(error instanceof RenderingCancelledException).toEqual(true);
+          expect(error.message).toEqual("Rendering cancelled, page 1");
           expect(error.type).toEqual("canvas");
+
           CanvasFactory.destroy(canvasAndCtx);
           done();
         });

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -678,7 +678,7 @@ class PDFPageView {
     const ensureNotCancelled = () => {
       if (cancelled) {
         throw new RenderingCancelledException(
-          "Rendering cancelled, page " + this.id,
+          `Rendering cancelled, page ${this.id}`,
           "svg"
         );
       }


### PR DESCRIPTION
This property has never been documented and/or *intentionally* exposed through the API, instead the `PDFPageProxy.pageNumber` property is the documented/intended API to use here.
Hence pageIndex is changed to a "private" property on `PDFPageProxy` instances, and internal API functionality is also updated to *consistently* use `this._pageIndex` rather than a mix of formats.