### PR TITLE
Remove the unused `wideChars` property on `Font` instances

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -3176,7 +3176,6 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         length3,
         loadedName: baseDict.loadedName,
         composite,
-        wideChars: composite,
         fixedPitch: false,
         fontMatrix: dict.getArray("FontMatrix") || FONT_IDENTITY_MATRIX,
         firstChar: firstChar || 0,

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -544,7 +544,6 @@ var Font = (function FontClosure() {
     this.widths = properties.widths;
     this.defaultWidth = properties.defaultWidth;
     this.composite = properties.composite;
-    this.wideChars = properties.wideChars;
     this.cMap = properties.cMap;
     this.ascent = properties.ascent / PDF_GLYPH_SPACE_UNITS;
     this.descent = properties.descent / PDF_GLYPH_SPACE_UNITS;


### PR DESCRIPTION
This property was added in PR #1599 (almost eight years ago), but has been unused ever since PR #3674 (six and a half years ago).