### PR TITLE
Don't let Travis run `npm update` during setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,3 @@ install:
   - npm install -g npm@latest
   - npm install -g gulp-cli
   - npm install
-  - npm update


### PR DESCRIPTION
Letting Travis update npm packages can lead to unexpected and completely unrelated failures for any PR and/or merge, see e.g. #11719, if there's ever backwards *incompatible* changes when a package is updated.

The *exact* package versions are specified in `package-lock.json`, and they should thus be used when running tests. Note that the bots won't update npm packages, and neither should Travis as far as I'm concerned.