### PR TITLE
Re-factor `PDFViewerApplication.load` such that `{PDFViewer, PDFThumbnailViewer}.setDocument` happens slightly earlier

### DIFF
--- a/web/view_history.js
+++ b/web/view_history.js
@@ -31,19 +31,20 @@ class ViewHistory {
 
     this._initializedPromise = this._readFromStorage().then(databaseStr => {
       const database = JSON.parse(databaseStr || "{}");
-      if (!("files" in database)) {
+      let index = -1;
+      if (!Array.isArray(database.files)) {
         database.files = [];
       } else {
         while (database.files.length >= this.cacheSize) {
           database.files.shift();
         }
-      }
-      let index = -1;
-      for (let i = 0, length = database.files.length; i < length; i++) {
-        const branch = database.files[i];
-        if (branch.fingerprint === this.fingerprint) {
-          index = i;
-          break;
+
+        for (let i = 0, ii = database.files.length; i < ii; i++) {
+          const branch = database.files[i];
+          if (branch.fingerprint === this.fingerprint) {
+            index = i;
+            break;
+          }
         }
       }
       if (index === -1) {


### PR DESCRIPTION
*Please refer the the individual commit messages.*

Much smaller diff with https://github.com/mozilla/pdf.js/pull/11725/files?w=1

---
*Edit:* I also, as a follow-up, want to look into delaying the `getPageLabels`/`getMetadata` calls until e.g. `firstPagePromise` is resolved since neither of those API calls should be *necessary* early on.