### PR TITLE
Remove unnecessary checks from the `PDFDocumentProperties` constructor

### DIFF
--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -72,25 +72,21 @@ class PDFDocumentProperties {
     this.l10n = l10n;
 
     this._reset();
+    // Bind the event listener for the Close button.
+    closeButton.addEventListener("click", this.close.bind(this));
 
-    if (closeButton) {
-      // Bind the event listener for the Close button.
-      closeButton.addEventListener("click", this.close.bind(this));
-    }
     this.overlayManager.register(
       this.overlayName,
       this.container,
       this.close.bind(this)
     );
 
-    if (eventBus) {
-      eventBus._on("pagechanging", evt => {
-        this._currentPageNumber = evt.pageNumber;
-      });
-      eventBus._on("rotationchanging", evt => {
-        this._pagesRotation = evt.pagesRotation;
-      });
-    }
+    eventBus._on("pagechanging", evt => {
+      this._currentPageNumber = evt.pageNumber;
+    });
+    eventBus._on("rotationchanging", evt => {
+      this._pagesRotation = evt.pagesRotation;
+    });
 
     this._isNonMetricLocale = true; // The default viewer locale is 'en-us'.
     l10n.getLanguage().then(locale => {


### PR DESCRIPTION
Given that none of the relevant options are marked as optional in the code/JSDocs, and that the `PDFDocumentProperties` class is specific to the default viewer (and not exposed as part of the viewer components), there's no good reason as far as I can tell for these checks.