### PR TITLE
Remove old API methods which were previously converted to throwing (PR 11219 follow-up)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -481,17 +481,6 @@ const PDFDocumentLoadingTask = (function PDFDocumentLoadingTaskClosure() {
         }
       });
     }
-
-    /**
-     * Registers callbacks to indicate the document loading completion.
-     * @ignore
-     */
-    then(onFulfilled, onRejected) {
-      throw new Error(
-        "Removed API method: " +
-          "PDFDocumentLoadingTask.then, use the `promise` getter instead."
-      );
-    }
   }
   return PDFDocumentLoadingTask;
 })();
@@ -972,15 +961,6 @@ class PDFPageProxy {
     offsetY = 0,
     dontFlip = false,
   } = {}) {
-    if (
-      typeof PDFJSDev !== "undefined" &&
-      PDFJSDev.test("GENERIC") &&
-      (arguments.length > 1 || typeof arguments[0] === "number")
-    ) {
-      throw new Error(
-        "PDFPageProxy.getViewport is called with obsolete arguments."
-      );
-    }
     return new PageViewport({
       viewBox: this.view,
       scale,
@@ -2705,17 +2685,6 @@ class RenderTask {
    */
   cancel() {
     this._internalRenderTask.cancel();
-  }
-
-  /**
-   * Registers callbacks to indicate the rendering task completion.
-   * @ignore
-   */
-  then(onFulfilled, onRejected) {
-    throw new Error(
-      "Removed API method: " +
-        "RenderTask.then, use the `promise` getter instead."
-    );
   }
 }
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -63,20 +63,25 @@ const RENDERING_CANCELLED_TIMEOUT = 100; // ms
 
 /**
  * @typedef {function} IPDFStreamFactory
- * @param {DocumentInitParameters} params The document initialization
- * parameters. The "url" key is always present.
+ * @param {DocumentInitParameters} params - The document initialization
+ *   parameters. The "url" key is always present.
  * @returns {IPDFStream}
+ * @ignore
  */
 
-/** @type IPDFStreamFactory */
+/**
+ * @type IPDFStreamFactory
+ * @private
+ */
 let createPDFNetworkStream;
 
 /**
- * Sets the function that instantiates a IPDFStream as an alternative PDF data
- * transport.
- * @param {IPDFStreamFactory} pdfNetworkStreamFactory - the factory function
- * that takes document initialization parameters (including a "url") and returns
- * an instance of IPDFStream.
+ * Sets the function that instantiates an {IPDFStream} as an alternative PDF
+ * data transport.
+ * @param {IPDFStreamFactory} pdfNetworkStreamFactory - The factory function
+ *   that takes document initialization parameters (including a "url") and
+ *   returns an instance of {IPDFStream}.
+ * @ignore
  */
 function setPDFNetworkStreamFactory(pdfNetworkStreamFactory) {
   createPDFNetworkStream = pdfNetworkStreamFactory;


### PR DESCRIPTION
 - **Remove old API methods which were previously converted to throwing (PR 11219 follow-up)**

   These methods were deprecated already in PDF.js version `2.1.266`, see PRs #10246 and #10369, and were converted to throw `Error`s upon invocation in PDF.js version `2.4.456`, see PR #11219.
Hence it ought to be possible to remove these methods now.

 - **Exclude the `setPDFNetworkStreamFactory` function from the built API docs**

   Please note that the `setPDFNetworkStreamFactory` functionality isn't exposed in the public API, i.e. not listed among the exports in the `src/pdf.js` file, and that even if it were it wouldn't really be useful considering that none of the `PDFNetworkStream`/`PDFFetchStream`/`PDFNodeStream` classes are exported either.

