### PR TITLE
Add `passive: false` to the `wheel` event listener used in `PDFPresentationMode` (issue 11735, PR 10765 follow-up)

### DIFF
--- a/web/pdf_presentation_mode.js
+++ b/web/pdf_presentation_mode.js
@@ -423,7 +423,7 @@ class PDFPresentationMode {
 
     window.addEventListener("mousemove", this.showControlsBind);
     window.addEventListener("mousedown", this.mouseDownBind);
-    window.addEventListener("wheel", this.mouseWheelBind);
+    window.addEventListener("wheel", this.mouseWheelBind, { passive: false });
     window.addEventListener("keydown", this.resetMouseScrollStateBind);
     window.addEventListener("contextmenu", this.contextMenuBind);
     window.addEventListener("touchstart", this.touchSwipeBind);


### PR DESCRIPTION
Fixes #11735