### PR TITLE
Enable the ESLint `no-shadow` rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -119,8 +119,8 @@
     "no-catch-shadow": "error",
     "no-delete-var": "error",
     "no-label-var": "error",
+    "no-shadow": "error",
     "no-shadow-restricted-names": "error",
-    "no-shadow": "off",
     "no-undef-init": "error",
     "no-undef": ["error", { "typeof": true, }],
     "no-unused-vars": ["error", {

--- a/external/builder/preprocessor2.js
+++ b/external/builder/preprocessor2.js
@@ -289,7 +289,7 @@ function traverseTree(ctx, node) {
   for (var i in node) {
     var child = node[i];
     if (typeof child === "object" && child !== null && child.type) {
-      var result = traverseTree(ctx, child);
+      const result = traverseTree(ctx, child);
       if (result !== child) {
         node[i] = result;
       }
@@ -300,7 +300,7 @@ function traverseTree(ctx, node) {
           childItem !== null &&
           childItem.type
         ) {
-          var result = traverseTree(ctx, childItem);
+          const result = traverseTree(ctx, childItem);
           if (result !== childItem) {
             child[index] = result;
           }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -167,8 +167,6 @@ function createStringSource(filename, content) {
 }
 
 function createWebpackConfig(defines, output) {
-  var path = require("path");
-
   var versionInfo = getVersionJSON();
   var bundleDefines = builder.merge(defines, {
     BUNDLE_VERSION: versionInfo.version,
@@ -243,9 +241,9 @@ function createWebpackConfig(defines, output) {
   };
 }
 
-function webpack2Stream(config) {
+function webpack2Stream(webpackConfig) {
   // Replacing webpack1 to webpack2 in the webpack-stream.
-  return webpackStream(config, webpack2);
+  return webpackStream(webpackConfig, webpack2);
 }
 
 function getVersionJSON() {
@@ -378,28 +376,28 @@ function createImageDecodersBundle(defines) {
     .pipe(replaceJSRootName(imageDecodersAMDName, "pdfjsImageDecoders"));
 }
 
-function checkFile(path) {
+function checkFile(filePath) {
   try {
-    var stat = fs.lstatSync(path);
+    var stat = fs.lstatSync(filePath);
     return stat.isFile();
   } catch (e) {
     return false;
   }
 }
 
-function checkDir(path) {
+function checkDir(dirPath) {
   try {
-    var stat = fs.lstatSync(path);
+    var stat = fs.lstatSync(dirPath);
     return stat.isDirectory();
   } catch (e) {
     return false;
   }
 }
 
-function replaceInFile(path, find, replacement) {
-  var content = fs.readFileSync(path).toString();
+function replaceInFile(filePath, find, replacement) {
+  var content = fs.readFileSync(filePath).toString();
   content = content.replace(find, replacement);
-  fs.writeFileSync(path, content);
+  fs.writeFileSync(filePath, content);
 }
 
 function getTempFile(prefix, suffix) {
@@ -407,9 +405,9 @@ function getTempFile(prefix, suffix) {
   var bytes = require("crypto")
     .randomBytes(6)
     .toString("hex");
-  var path = BUILD_DIR + "tmp/" + prefix + bytes + suffix;
-  fs.writeFileSync(path, "");
-  return path;
+  var filePath = BUILD_DIR + "tmp/" + prefix + bytes + suffix;
+  fs.writeFileSync(filePath, "");
+  return filePath;
 }
 
 function createTestSource(testsName, bot) {
@@ -527,10 +525,10 @@ gulp.task("buildnumber", function(done) {
 
     var version = config.versionPrefix + buildNumber;
 
-    exec('git log --format="%h" -n 1', function(err, stdout, stderr) {
+    exec('git log --format="%h" -n 1', function(err2, stdout2, stderr2) {
       var buildCommit = "";
-      if (!err) {
-        buildCommit = stdout.replace("\n", "");
+      if (!err2) {
+        buildCommit = stdout2.replace("\n", "");
       }
 
       createStringSource(
@@ -559,9 +557,9 @@ gulp.task("default_preferences-pre", function() {
   function babelPluginReplaceNonWebPackRequire(babel) {
     return {
       visitor: {
-        Identifier(path, state) {
-          if (path.node.name === "__non_webpack_require__") {
-            path.replaceWith(babel.types.identifier("require"));
+        Identifier(curPath, state) {
+          if (curPath.node.name === "__non_webpack_require__") {
+            curPath.replaceWith(babel.types.identifier("require"));
           }
         },
       },
@@ -643,8 +641,8 @@ gulp.task("locale", function() {
   var locales = [];
   for (var i = 0; i < subfolders.length; i++) {
     var locale = subfolders[i];
-    var path = L10N_DIR + locale;
-    if (!checkDir(path)) {
+    var dirPath = L10N_DIR + locale;
+    if (!checkDir(dirPath)) {
       continue;
     }
     if (!/^[a-z][a-z]([a-z])?(-[A-Z][A-Z])?$/.test(locale)) {
@@ -656,7 +654,7 @@ gulp.task("locale", function() {
 
     locales.push(locale);
 
-    if (checkFile(path + "/viewer.properties")) {
+    if (checkFile(dirPath + "/viewer.properties")) {
       viewerOutput +=
         "[" +
         locale +
@@ -1163,9 +1161,9 @@ gulp.task(
     function babelPluginReplaceNonWebPackRequire(babel) {
       return {
         visitor: {
-          Identifier(path, state) {
-            if (path.node.name === "__non_webpack_require__") {
-              path.replaceWith(babel.types.identifier("require"));
+          Identifier(curPath, state) {
+            if (curPath.node.name === "__non_webpack_require__") {
+              curPath.replaceWith(babel.types.identifier("require"));
             }
           },
         },
@@ -1358,9 +1356,9 @@ gulp.task("baseline", function(done) {
     }
 
     exec("git checkout " + baselineCommit, { cwd: workingDirectory }, function(
-      error
+      error2
     ) {
-      if (error) {
+      if (error2) {
         done(new Error("Baseline commit checkout failed."));
         return;
       }

--- a/src/core/ccitt.js
+++ b/src/core/ccitt.js
@@ -465,6 +465,7 @@ const CCITTFaxDecoder = (function CCITTFaxDecoder() {
    * @param {CCITTFaxDecoderSource} source - The data which should be decoded.
    * @param {Object} [options] - Decoding options.
    */
+  // eslint-disable-next-line no-shadow
   function CCITTFaxDecoder(source, options = {}) {
     if (!source || typeof source.next !== "function") {
       throw new Error('CCITTFaxDecoder - invalid "source" parameter.');

--- a/src/core/ccitt_stream.js
+++ b/src/core/ccitt_stream.js
@@ -18,6 +18,7 @@ import { CCITTFaxDecoder } from "./ccitt.js";
 import { DecodeStream } from "./stream.js";
 
 var CCITTFaxStream = (function CCITTFaxStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function CCITTFaxStream(str, maybeLength, params) {
     this.str = str;
     this.dict = str.dict;

--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -217,6 +217,7 @@ var CFFParser = (function CFFParserClosure() {
     { id: "flex1", min: 11, resetStack: true },
   ];
 
+  // eslint-disable-next-line no-shadow
   function CFFParser(file, properties, seacAnalysisEnabled) {
     this.bytes = file.getBytes();
     this.properties = properties;
@@ -964,6 +965,7 @@ var CFFParser = (function CFFParserClosure() {
 
 // Compact Font Format
 var CFF = (function CFFClosure() {
+  // eslint-disable-next-line no-shadow
   function CFF() {
     this.header = null;
     this.names = [];
@@ -1009,6 +1011,7 @@ var CFF = (function CFFClosure() {
 })();
 
 var CFFHeader = (function CFFHeaderClosure() {
+  // eslint-disable-next-line no-shadow
   function CFFHeader(major, minor, hdrSize, offSize) {
     this.major = major;
     this.minor = minor;
@@ -1019,6 +1022,7 @@ var CFFHeader = (function CFFHeaderClosure() {
 })();
 
 var CFFStrings = (function CFFStringsClosure() {
+  // eslint-disable-next-line no-shadow
   function CFFStrings() {
     this.strings = [];
   }
@@ -1054,6 +1058,7 @@ var CFFStrings = (function CFFStringsClosure() {
 })();
 
 var CFFIndex = (function CFFIndexClosure() {
+  // eslint-disable-next-line no-shadow
   function CFFIndex() {
     this.objects = [];
     this.length = 0;
@@ -1078,6 +1083,7 @@ var CFFIndex = (function CFFIndexClosure() {
 })();
 
 var CFFDict = (function CFFDictClosure() {
+  // eslint-disable-next-line no-shadow
   function CFFDict(tables, strings) {
     this.keyToNameMap = tables.keyToNameMap;
     this.nameToKeyMap = tables.nameToKeyMap;
@@ -1205,6 +1211,8 @@ var CFFTopDict = (function CFFTopDictClosure() {
     [[12, 38], "FontName", "sid", null],
   ];
   var tables = null;
+
+  // eslint-disable-next-line no-shadow
   function CFFTopDict(strings) {
     if (tables === null) {
       tables = CFFDict.createTables(layout);
@@ -1238,6 +1246,8 @@ var CFFPrivateDict = (function CFFPrivateDictClosure() {
     [19, "Subrs", "offset", null],
   ];
   var tables = null;
+
+  // eslint-disable-next-line no-shadow
   function CFFPrivateDict(strings) {
     if (tables === null) {
       tables = CFFDict.createTables(layout);
@@ -1255,6 +1265,7 @@ var CFFCharsetPredefinedTypes = {
   EXPERT_SUBSET: 2,
 };
 var CFFCharset = (function CFFCharsetClosure() {
+  // eslint-disable-next-line no-shadow
   function CFFCharset(predefined, format, charset, raw) {
     this.predefined = predefined;
     this.format = format;
@@ -1265,6 +1276,7 @@ var CFFCharset = (function CFFCharsetClosure() {
 })();
 
 var CFFEncoding = (function CFFEncodingClosure() {
+  // eslint-disable-next-line no-shadow
   function CFFEncoding(predefined, format, encoding, raw) {
     this.predefined = predefined;
     this.format = format;
@@ -1275,6 +1287,7 @@ var CFFEncoding = (function CFFEncodingClosure() {
 })();
 
 var CFFFDSelect = (function CFFFDSelectClosure() {
+  // eslint-disable-next-line no-shadow
   function CFFFDSelect(format, fdSelect) {
     this.format = format;
     this.fdSelect = fdSelect;
@@ -1293,6 +1306,7 @@ var CFFFDSelect = (function CFFFDSelectClosure() {
 // Helper class to keep track of where an offset is within the data and helps
 // filling in that offset once it's known.
 var CFFOffsetTracker = (function CFFOffsetTrackerClosure() {
+  // eslint-disable-next-line no-shadow
   function CFFOffsetTracker() {
     this.offsets = Object.create(null);
   }
@@ -1352,6 +1366,7 @@ var CFFOffsetTracker = (function CFFOffsetTrackerClosure() {
 
 // Takes a CFF and converts it to the binary representation.
 var CFFCompiler = (function CFFCompilerClosure() {
+  // eslint-disable-next-line no-shadow
   function CFFCompiler(cff) {
     this.cff = cff;
   }

--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -713,6 +713,7 @@ var BinaryCMapReader = (function BinaryCMapReaderClosure() {
     });
   }
 
+  // eslint-disable-next-line no-shadow
   function BinaryCMapReader() {}
 
   BinaryCMapReader.prototype = {

--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -836,6 +836,7 @@ const DeviceCmykCS = (function DeviceCmykCSClosure() {
       k * (-22.33816807309886 * k - 180.12613974708367);
   }
 
+  // eslint-disable-next-line no-shadow
   class DeviceCmykCS extends ColorSpace {
     constructor() {
       super("DeviceCMYK", 4);
@@ -902,6 +903,7 @@ const CalGrayCS = (function CalGrayCSClosure() {
     dest[destOffset + 2] = val;
   }
 
+  // eslint-disable-next-line no-shadow
   class CalGrayCS extends ColorSpace {
     constructor(whitePoint, blackPoint, gamma) {
       super("CalGray", 1);
@@ -1190,6 +1192,7 @@ const CalRGBCS = (function CalRGBCSClosure() {
     dest[destOffset + 2] = sRGBTransferFunction(SRGB[2]) * 255;
   }
 
+  // eslint-disable-next-line no-shadow
   class CalRGBCS extends ColorSpace {
     constructor(whitePoint, blackPoint, gamma, matrix) {
       super("CalRGB", 3);
@@ -1371,6 +1374,7 @@ const LabCS = (function LabCSClosure() {
     dest[destOffset + 2] = Math.sqrt(b) * 255;
   }
 
+  // eslint-disable-next-line no-shadow
   class LabCS extends ColorSpace {
     constructor(whitePoint, blackPoint, range) {
       super("Lab", 3);

--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -27,6 +27,7 @@ import { isDict, isName, Name } from "./primitives.js";
 import { DecryptStream } from "./stream.js";
 
 var ARCFourCipher = (function ARCFourCipherClosure() {
+  // eslint-disable-next-line no-shadow
   function ARCFourCipher(key) {
     this.a = 0;
     this.b = 0;
@@ -177,6 +178,7 @@ var calculateMD5 = (function calculateMD5Closure() {
   return hash;
 })();
 var Word64 = (function Word64Closure() {
+  // eslint-disable-next-line no-shadow
   function Word64(highInteger, lowInteger) {
     this.high = highInteger | 0;
     this.low = lowInteger | 0;
@@ -690,6 +692,7 @@ var calculateSHA384 = (function calculateSHA384Closure() {
   return hash;
 })();
 var NullCipher = (function NullCipherClosure() {
+  // eslint-disable-next-line no-shadow
   function NullCipher() {}
 
   NullCipher.prototype = {
@@ -1265,6 +1268,7 @@ var PDF17 = (function PDF17Closure() {
     return true;
   }
 
+  // eslint-disable-next-line no-shadow
   function PDF17() {}
 
   PDF17.prototype = {
@@ -1372,6 +1376,7 @@ var PDF20 = (function PDF20Closure() {
     return k.subarray(0, 32);
   }
 
+  // eslint-disable-next-line no-shadow
   function PDF20() {}
 
   function compareByteArrays(array1, array2) {
@@ -1446,6 +1451,7 @@ var PDF20 = (function PDF20Closure() {
 })();
 
 var CipherTransform = (function CipherTransformClosure() {
+  // eslint-disable-next-line no-shadow
   function CipherTransform(stringCipherConstructor, streamCipherConstructor) {
     this.StringCipherConstructor = stringCipherConstructor;
     this.StreamCipherConstructor = streamCipherConstructor;
@@ -1661,6 +1667,7 @@ var CipherTransformFactory = (function CipherTransformFactoryClosure() {
 
   var identityName = Name.get("Identity");
 
+  // eslint-disable-next-line no-shadow
   function CipherTransformFactory(dict, fileId, password) {
     var filter = dict.get("Filter");
     if (!isName(filter, "Standard")) {

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -96,6 +96,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
     isEvalSupported: true,
   };
 
+  // eslint-disable-next-line no-shadow
   function PartialEvaluator({
     xref,
     handler,
@@ -3266,6 +3267,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 })();
 
 var TranslatedFont = (function TranslatedFontClosure() {
+  // eslint-disable-next-line no-shadow
   function TranslatedFont(loadedName, font, dict) {
     this.loadedName = loadedName;
     this.font = font;
@@ -3367,6 +3369,7 @@ var TranslatedFont = (function TranslatedFontClosure() {
 })();
 
 var StateManager = (function StateManagerClosure() {
+  // eslint-disable-next-line no-shadow
   function StateManager(initialState) {
     this.state = initialState;
     this.stateStack = [];
@@ -3391,6 +3394,7 @@ var StateManager = (function StateManagerClosure() {
 })();
 
 var TextState = (function TextStateClosure() {
+  // eslint-disable-next-line no-shadow
   function TextState() {
     this.ctm = new Float32Array(IDENTITY_MATRIX);
     this.fontName = null;
@@ -3496,6 +3500,7 @@ var TextState = (function TextStateClosure() {
 })();
 
 var EvalState = (function EvalStateClosure() {
+  // eslint-disable-next-line no-shadow
   function EvalState() {
     this.ctm = new Float32Array(IDENTITY_MATRIX);
     this.font = null;
@@ -3637,6 +3642,7 @@ var EvaluatorPreprocessor = (function EvaluatorPreprocessorClosure() {
 
   const MAX_INVALID_PATH_OPS = 20;
 
+  // eslint-disable-next-line no-shadow
   function EvaluatorPreprocessor(stream, xref, stateManager) {
     this.opMap = getOPMap();
     // TODO(mduan): pass array of knownCommands rather than this.opMap

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -222,6 +222,7 @@ function recoverGlyphName(name, glyphsUnicodeMap) {
 }
 
 var Glyph = (function GlyphClosure() {
+  // eslint-disable-next-line no-shadow
   function Glyph(
     fontChar,
     unicode,
@@ -268,6 +269,7 @@ var Glyph = (function GlyphClosure() {
 })();
 
 var ToUnicodeMap = (function ToUnicodeMapClosure() {
+  // eslint-disable-next-line no-shadow
   function ToUnicodeMap(cmap = []) {
     // The elements of this._map can be integers or strings, depending on how
     // `cmap` was created.
@@ -319,6 +321,7 @@ var ToUnicodeMap = (function ToUnicodeMapClosure() {
 })();
 
 var IdentityToUnicodeMap = (function IdentityToUnicodeMapClosure() {
+  // eslint-disable-next-line no-shadow
   function IdentityToUnicodeMap(firstChar, lastChar) {
     this.firstChar = firstChar;
     this.lastChar = lastChar;
@@ -389,6 +392,7 @@ var OpenTypeFileBuilder = (function OpenTypeFileBuilderClosure() {
     }
   }
 
+  // eslint-disable-next-line no-shadow
   function OpenTypeFileBuilder(sfnt) {
     this.sfnt = sfnt;
     this.tables = Object.create(null);
@@ -512,6 +516,7 @@ var OpenTypeFileBuilder = (function OpenTypeFileBuilderClosure() {
  *   type1Font.bind();
  */
 var Font = (function FontClosure() {
+  // eslint-disable-next-line no-shadow
   function Font(name, file, properties) {
     var charCode;
 
@@ -3305,6 +3310,7 @@ var Font = (function FontClosure() {
 })();
 
 var ErrorFont = (function ErrorFontClosure() {
+  // eslint-disable-next-line no-shadow
   function ErrorFont(error) {
     this.error = error;
     this.loadedName = "g_font_error";
@@ -3518,6 +3524,7 @@ var Type1Font = (function Type1FontClosure() {
     };
   }
 
+  // eslint-disable-next-line no-shadow
   function Type1Font(name, file, properties) {
     // Some bad generators embed pfb file as is, we have to strip 6-byte header.
     // Also, length1 and length2 might be off by 6 bytes as well.
@@ -3784,6 +3791,7 @@ var Type1Font = (function Type1FontClosure() {
 })();
 
 var CFFFont = (function CFFFontClosure() {
+  // eslint-disable-next-line no-shadow
   function CFFFont(file, properties) {
     this.properties = properties;
 

--- a/src/core/function.js
+++ b/src/core/function.js
@@ -565,6 +565,8 @@ function isPDFFunction(v) {
 
 var PostScriptStack = (function PostScriptStackClosure() {
   var MAX_STACK_SIZE = 100;
+
+  // eslint-disable-next-line no-shadow
   function PostScriptStack(initialStack) {
     this.stack = !initialStack
       ? []
@@ -625,6 +627,7 @@ var PostScriptStack = (function PostScriptStackClosure() {
   return PostScriptStack;
 })();
 var PostScriptEvaluator = (function PostScriptEvaluatorClosure() {
+  // eslint-disable-next-line no-shadow
   function PostScriptEvaluator(operators) {
     this.operators = operators;
   }
@@ -1084,6 +1087,7 @@ var PostScriptCompiler = (function PostScriptCompilerClosure() {
     return new AstMin(num1, max);
   }
 
+  // eslint-disable-next-line no-shadow
   function PostScriptCompiler() {}
   PostScriptCompiler.prototype = {
     compile: function PostScriptCompiler_compile(code, domain, range) {

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -96,6 +96,7 @@ var PDFImage = (function PDFImageClosure() {
     return dest;
   }
 
+  // eslint-disable-next-line no-shadow
   function PDFImage({
     xref,
     res,

--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -2567,6 +2567,7 @@ var Jbig2Image = (function Jbig2ImageClosure() {
     return bitmap;
   }
 
+  // eslint-disable-next-line no-shadow
   function Jbig2Image() {}
 
   Jbig2Image.prototype = {

--- a/src/core/jbig2_stream.js
+++ b/src/core/jbig2_stream.js
@@ -23,6 +23,7 @@ import { shadow } from "../shared/util.js";
  * the stream behaves like all the other DecodeStreams.
  */
 const Jbig2Stream = (function Jbig2StreamClosure() {
+  // eslint-disable-next-line no-shadow
   function Jbig2Stream(stream, maybeLength, dict, params) {
     this.stream = stream;
     this.maybeLength = maybeLength;

--- a/src/core/jpeg_stream.js
+++ b/src/core/jpeg_stream.js
@@ -26,6 +26,7 @@ import { JpegImage } from "./jpg.js";
  * DecodeStreams.
  */
 const JpegStream = (function JpegStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function JpegStream(stream, maybeLength, dict, params) {
     // Some images may contain 'junk' before the SOI (start-of-image) marker.
     // Note: this seems to mainly affect inline images.

--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -73,6 +73,7 @@ var JpegImage = (function JpegImageClosure() {
   var dctSqrt2 = 5793; // sqrt(2)
   var dctSqrt1d2 = 2896; // sqrt(2) / 2
 
+  // eslint-disable-next-line no-shadow
   function JpegImage({ decodeTransform = null, colorTransform = -1 } = {}) {
     this._decodeTransform = decodeTransform;
     this._colorTransform = colorTransform;

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -31,6 +31,8 @@ var JpxImage = (function JpxImageClosure() {
     HL: 1,
     HH: 2,
   };
+
+  // eslint-disable-next-line no-shadow
   function JpxImage() {
     this.failOnCorruptedImage = false;
   }
@@ -1585,6 +1587,7 @@ var JpxImage = (function JpxImageClosure() {
 
   // Section B.10.2 Tag trees
   var TagTree = (function TagTreeClosure() {
+    // eslint-disable-next-line no-shadow
     function TagTree(width, height) {
       var levelsLength = log2(Math.max(width, height)) + 1;
       this.levels = [];
@@ -1646,6 +1649,7 @@ var JpxImage = (function JpxImageClosure() {
   })();
 
   var InclusionTree = (function InclusionTreeClosure() {
+    // eslint-disable-next-line no-shadow
     function InclusionTree(width, height, defaultValue) {
       var levelsLength = log2(Math.max(width, height)) + 1;
       this.levels = [];
@@ -1752,6 +1756,7 @@ var JpxImage = (function JpxImageClosure() {
       8, 0, 8, 8, 8, 0, 8, 8, 8, 0, 0, 0, 0, 0, 8, 8, 8, 0, 8, 8, 8, 0, 8, 8, 8
     ]);
 
+    // eslint-disable-next-line no-shadow
     function BitModel(width, height, subband, zeroBitPlanes, mb) {
       this.width = width;
       this.height = height;
@@ -2107,6 +2112,7 @@ var JpxImage = (function JpxImageClosure() {
 
   // Section F, Discrete wavelet transformation
   var Transform = (function TransformClosure() {
+    // eslint-disable-next-line no-shadow
     function Transform() {}
 
     Transform.prototype.calculate = function transformCalculate(
@@ -2248,6 +2254,7 @@ var JpxImage = (function JpxImageClosure() {
 
   // Section 3.8.2 Irreversible 9-7 filter
   var IrreversibleTransform = (function IrreversibleTransformClosure() {
+    // eslint-disable-next-line no-shadow
     function IrreversibleTransform() {
       Transform.call(this);
     }
@@ -2345,6 +2352,7 @@ var JpxImage = (function JpxImageClosure() {
 
   // Section 3.8.1 Reversible 5-3 filter
   var ReversibleTransform = (function ReversibleTransformClosure() {
+    // eslint-disable-next-line no-shadow
     function ReversibleTransform() {
       Transform.call(this);
     }

--- a/src/core/jpx_stream.js
+++ b/src/core/jpx_stream.js
@@ -22,6 +22,7 @@ import { shadow } from "../shared/util.js";
  * the stream behaves like all the other DecodeStreams.
  */
 const JpxStream = (function JpxStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function JpxStream(stream, maybeLength, dict, params) {
     this.stream = stream;
     this.maybeLength = maybeLength;

--- a/src/core/metrics.js
+++ b/src/core/metrics.js
@@ -23,6 +23,7 @@ var getMetrics = getLookupTableFactory(function(t) {
   t["Courier-Bold"] = 600;
   t["Courier-BoldOblique"] = 600;
   t["Courier-Oblique"] = 600;
+  // eslint-disable-next-line no-shadow
   t["Helvetica"] = getLookupTableFactory(function(t) {
     t["space"] = 278;
     t["exclam"] = 278;
@@ -340,6 +341,7 @@ var getMetrics = getLookupTableFactory(function(t) {
     t["imacron"] = 278;
     t["Euro"] = 556;
   });
+  // eslint-disable-next-line no-shadow
   t["Helvetica-Bold"] = getLookupTableFactory(function(t) {
     t["space"] = 278;
     t["exclam"] = 333;
@@ -657,6 +659,7 @@ var getMetrics = getLookupTableFactory(function(t) {
     t["imacron"] = 278;
     t["Euro"] = 556;
   });
+  // eslint-disable-next-line no-shadow
   t["Helvetica-BoldOblique"] = getLookupTableFactory(function(t) {
     t["space"] = 278;
     t["exclam"] = 333;
@@ -974,6 +977,7 @@ var getMetrics = getLookupTableFactory(function(t) {
     t["imacron"] = 278;
     t["Euro"] = 556;
   });
+  // eslint-disable-next-line no-shadow
   t["Helvetica-Oblique"] = getLookupTableFactory(function(t) {
     t["space"] = 278;
     t["exclam"] = 278;
@@ -1291,6 +1295,7 @@ var getMetrics = getLookupTableFactory(function(t) {
     t["imacron"] = 278;
     t["Euro"] = 556;
   });
+  // eslint-disable-next-line no-shadow
   t["Symbol"] = getLookupTableFactory(function(t) {
     t["space"] = 250;
     t["exclam"] = 333;
@@ -1483,6 +1488,7 @@ var getMetrics = getLookupTableFactory(function(t) {
     t["bracerightbt"] = 494;
     t["apple"] = 790;
   });
+  // eslint-disable-next-line no-shadow
   t["Times-Roman"] = getLookupTableFactory(function(t) {
     t["space"] = 250;
     t["exclam"] = 333;
@@ -1800,6 +1806,7 @@ var getMetrics = getLookupTableFactory(function(t) {
     t["imacron"] = 278;
     t["Euro"] = 500;
   });
+  // eslint-disable-next-line no-shadow
   t["Times-Bold"] = getLookupTableFactory(function(t) {
     t["space"] = 250;
     t["exclam"] = 333;
@@ -2117,6 +2124,7 @@ var getMetrics = getLookupTableFactory(function(t) {
     t["imacron"] = 278;
     t["Euro"] = 500;
   });
+  // eslint-disable-next-line no-shadow
   t["Times-BoldItalic"] = getLookupTableFactory(function(t) {
     t["space"] = 250;
     t["exclam"] = 389;
@@ -2434,6 +2442,7 @@ var getMetrics = getLookupTableFactory(function(t) {
     t["imacron"] = 278;
     t["Euro"] = 500;
   });
+  // eslint-disable-next-line no-shadow
   t["Times-Italic"] = getLookupTableFactory(function(t) {
     t["space"] = 250;
     t["exclam"] = 333;
@@ -2751,6 +2760,7 @@ var getMetrics = getLookupTableFactory(function(t) {
     t["imacron"] = 278;
     t["Euro"] = 500;
   });
+  // eslint-disable-next-line no-shadow
   t["ZapfDingbats"] = getLookupTableFactory(function(t) {
     t["space"] = 278;
     t["a1"] = 974;

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -1116,6 +1116,7 @@ class Catalog {
 }
 
 var XRef = (function XRefClosure() {
+  // eslint-disable-next-line no-shadow
   function XRef(stream, pdfManager) {
     this.stream = stream;
     this.pdfManager = pdfManager;
@@ -2089,6 +2090,7 @@ class NumberTree extends NameOrNumberTree {
  * collections attributes and related files (/RF)
  */
 var FileSpec = (function FileSpecClosure() {
+  // eslint-disable-next-line no-shadow
   function FileSpec(root, xref) {
     if (!root || !isDict(root)) {
       return;
@@ -2214,6 +2216,7 @@ const ObjectLoader = (function() {
     }
   }
 
+  // eslint-disable-next-line no-shadow
   function ObjectLoader(dict, keys, xref) {
     this.dict = dict;
     this.keys = keys;

--- a/src/core/operator_list.js
+++ b/src/core/operator_list.js
@@ -490,6 +490,7 @@ var QueueOptimizer = (function QueueOptimizerClosure() {
     }
   );
 
+  // eslint-disable-next-line no-shadow
   function QueueOptimizer(queue) {
     this.queue = queue;
     this.state = null;
@@ -584,6 +585,7 @@ var QueueOptimizer = (function QueueOptimizerClosure() {
 })();
 
 var NullOptimizer = (function NullOptimizerClosure() {
+  // eslint-disable-next-line no-shadow
   function NullOptimizer(queue) {
     this.queue = queue;
   }
@@ -606,6 +608,7 @@ var OperatorList = (function OperatorListClosure() {
   var CHUNK_SIZE = 1000;
   var CHUNK_SIZE_ABOUT = CHUNK_SIZE - 5; // close to chunk size
 
+  // eslint-disable-next-line no-shadow
   function OperatorList(intent, streamSink, pageIndex) {
     this._streamSink = streamSink;
     this.fnArray = [];

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -38,6 +38,7 @@ var ShadingType = {
 
 var Pattern = (function PatternClosure() {
   // Constructor should define this.getPattern
+  // eslint-disable-next-line no-shadow
   function Pattern() {
     unreachable("should not call Pattern constructor");
   }
@@ -450,6 +451,8 @@ Shadings.Mesh = (function MeshClosure() {
       return lut;
     }
     var cache = [];
+
+    // eslint-disable-next-line no-shadow
     return function getB(count) {
       if (!cache[count]) {
         cache[count] = buildB(count);

--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -21,6 +21,7 @@ var EOF = {};
 var Name = (function NameClosure() {
   let nameCache = Object.create(null);
 
+  // eslint-disable-next-line no-shadow
   function Name(name) {
     this.name = name;
   }
@@ -43,6 +44,7 @@ var Name = (function NameClosure() {
 var Cmd = (function CmdClosure() {
   let cmdCache = Object.create(null);
 
+  // eslint-disable-next-line no-shadow
   function Cmd(cmd) {
     this.cmd = cmd;
   }
@@ -68,6 +70,7 @@ var Dict = (function DictClosure() {
   };
 
   // xref is optional
+  // eslint-disable-next-line no-shadow
   function Dict(xref) {
     // Map should only be used internally, use functions below to access.
     this._map = Object.create(null);
@@ -185,6 +188,7 @@ var Dict = (function DictClosure() {
 var Ref = (function RefClosure() {
   let refCache = Object.create(null);
 
+  // eslint-disable-next-line no-shadow
   function Ref(num, gen) {
     this.num = num;
     this.gen = gen;
@@ -218,6 +222,7 @@ var Ref = (function RefClosure() {
 // The reference is identified by number and generation.
 // This structure stores only one instance of the reference.
 var RefSet = (function RefSetClosure() {
+  // eslint-disable-next-line no-shadow
   function RefSet() {
     this.dict = Object.create(null);
   }
@@ -240,6 +245,7 @@ var RefSet = (function RefSetClosure() {
 })();
 
 var RefSetCache = (function RefSetCacheClosure() {
+  // eslint-disable-next-line no-shadow
   function RefSetCache() {
     this.dict = Object.create(null);
   }

--- a/src/core/ps_parser.js
+++ b/src/core/ps_parser.js
@@ -113,6 +113,7 @@ const PostScriptTokenTypes = {
 const PostScriptToken = (function PostScriptTokenClosure() {
   const opCache = Object.create(null);
 
+  // eslint-disable-next-line no-shadow
   class PostScriptToken {
     constructor(type, value) {
       this.type = type;

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -24,6 +24,7 @@ import { isDict } from "./primitives.js";
 import { isWhiteSpace } from "./core_utils.js";
 
 var Stream = (function StreamClosure() {
+  // eslint-disable-next-line no-shadow
   function Stream(arrayBuffer, start, length, dict) {
     this.bytes =
       arrayBuffer instanceof Uint8Array
@@ -129,6 +130,7 @@ var Stream = (function StreamClosure() {
 })();
 
 var StringStream = (function StringStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function StringStream(str) {
     const bytes = stringToBytes(str);
     Stream.call(this, bytes);
@@ -147,6 +149,7 @@ var DecodeStream = (function DecodeStreamClosure() {
   // buffer.
   var emptyBuffer = new Uint8Array(0);
 
+  // eslint-disable-next-line no-shadow
   function DecodeStream(maybeMinBufferLength) {
     this._rawMinBufferLength = maybeMinBufferLength || 0;
 
@@ -282,6 +285,7 @@ var DecodeStream = (function DecodeStreamClosure() {
 })();
 
 var StreamsSequenceStream = (function StreamsSequenceStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function StreamsSequenceStream(streams) {
     this.streams = streams;
 
@@ -426,6 +430,7 @@ var FlateStream = (function FlateStreamClosure() {
     0x50003, 0x50013, 0x5000b, 0x5001b, 0x50007, 0x50017, 0x5000f, 0x00000
   ]), 5];
 
+  // eslint-disable-next-line no-shadow
   function FlateStream(str, maybeLength) {
     this.str = str;
     this.dict = str.dict;
@@ -711,6 +716,7 @@ var FlateStream = (function FlateStreamClosure() {
 })();
 
 var PredictorStream = (function PredictorStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function PredictorStream(str, maybeLength, params) {
     if (!isDict(params)) {
       return str; // no prediction
@@ -932,6 +938,7 @@ var PredictorStream = (function PredictorStreamClosure() {
 })();
 
 var DecryptStream = (function DecryptStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function DecryptStream(str, maybeLength, decrypt) {
     this.str = str;
     this.dict = str.dict;
@@ -978,6 +985,7 @@ var DecryptStream = (function DecryptStreamClosure() {
 })();
 
 var Ascii85Stream = (function Ascii85StreamClosure() {
+  // eslint-disable-next-line no-shadow
   function Ascii85Stream(str, maybeLength) {
     this.str = str;
     this.dict = str.dict;
@@ -1062,6 +1070,7 @@ var Ascii85Stream = (function Ascii85StreamClosure() {
 })();
 
 var AsciiHexStream = (function AsciiHexStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function AsciiHexStream(str, maybeLength) {
     this.str = str;
     this.dict = str.dict;
@@ -1128,6 +1137,7 @@ var AsciiHexStream = (function AsciiHexStreamClosure() {
 })();
 
 var RunLengthStream = (function RunLengthStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function RunLengthStream(str, maybeLength) {
     this.str = str;
     this.dict = str.dict;
@@ -1175,6 +1185,7 @@ var RunLengthStream = (function RunLengthStreamClosure() {
 })();
 
 var LZWStream = (function LZWStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function LZWStream(str, maybeLength, earlyChange) {
     this.str = str;
     this.dict = str.dict;
@@ -1311,6 +1322,7 @@ var LZWStream = (function LZWStreamClosure() {
 })();
 
 var NullStream = (function NullStreamClosure() {
+  // eslint-disable-next-line no-shadow
   function NullStream() {
     Stream.call(this, new Uint8Array(0));
   }

--- a/src/core/type1_parser.js
+++ b/src/core/type1_parser.js
@@ -79,6 +79,7 @@ var Type1CharString = (function Type1CharStringClosure() {
     hvcurveto: [31],
   };
 
+  // eslint-disable-next-line no-shadow
   function Type1CharString() {
     this.width = 0;
     this.lsb = 0;
@@ -451,6 +452,7 @@ var Type1Parser = (function Type1ParserClosure() {
     );
   }
 
+  // eslint-disable-next-line no-shadow
   function Type1Parser(stream, encrypted, seacAnalysisEnabled) {
     if (encrypted) {
       var data = stream.getBytes();

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -38,6 +38,7 @@ import { PDFWorkerStream } from "./worker_stream.js";
 import { XRefParseException } from "./core_utils.js";
 
 var WorkerTask = (function WorkerTaskClosure() {
+  // eslint-disable-next-line no-shadow
   function WorkerTask(name) {
     this.name = name;
     this.terminated = false;

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -420,6 +420,7 @@ const PDFDocumentLoadingTask = (function PDFDocumentLoadingTaskClosure() {
    * (such as network requests) and provides a way to listen for completion,
    * after which individual pages can be rendered.
    */
+  // eslint-disable-next-line no-shadow
   class PDFDocumentLoadingTask {
     constructor() {
       this._capability = createPromiseCapability();
@@ -1679,6 +1680,7 @@ const PDFWorker = (function PDFWorkerClosure() {
    * thread to the worker thread and vice versa. If the creation of a web
    * worker is not possible, a "fake" worker will be used instead.
    */
+  // eslint-disable-next-line no-shadow
   class PDFWorker {
     /**
      * @param {PDFWorkerParameters} params - Worker initialization parameters.
@@ -2700,6 +2702,7 @@ class RenderTask {
 const InternalRenderTask = (function InternalRenderTaskClosure() {
   const canvasInRendering = new WeakSet();
 
+  // eslint-disable-next-line no-shadow
   class InternalRenderTask {
     constructor({
       callback,

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -168,6 +168,7 @@ function addContextCurrentTransform(ctx) {
 }
 
 var CachedCanvases = (function CachedCanvasesClosure() {
+  // eslint-disable-next-line no-shadow
   function CachedCanvases(canvasFactory) {
     this.canvasFactory = canvasFactory;
     this.cache = Object.create(null);
@@ -383,6 +384,7 @@ function compileType3Glyph(imgData) {
 }
 
 var CanvasExtraState = (function CanvasExtraStateClosure() {
+  // eslint-disable-next-line no-shadow
   function CanvasExtraState() {
     // Are soft masks and alpha values shapes or opacities?
     this.alphaIsShape = false;
@@ -435,6 +437,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
   // Defines the number of steps before checking the execution time
   var EXECUTION_STEPS = 10;
 
+  // eslint-disable-next-line no-shadow
   function CanvasGraphics(
     canvasCtx,
     commonObjs,

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -226,6 +226,7 @@ var createMeshCanvas = (function createMeshCanvasClosure() {
     }
   }
 
+  // eslint-disable-next-line no-shadow
   function createMeshCanvas(
     bounds,
     combinesScale,
@@ -413,6 +414,7 @@ var TilingPattern = (function TilingPatternClosure() {
 
   var MAX_PATTERN_SIZE = 3000; // 10in @ 300dpi shall be enough
 
+  // eslint-disable-next-line no-shadow
   function TilingPattern(IR, color, ctx, canvasGraphicsFactory, baseTransform) {
     this.operatorList = IR[2];
     this.matrix = IR[3] || [1, 0, 0, 1, 0, 0];

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -286,6 +286,7 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       return createObjectURL(data, "image/png", forceDataSchema);
     }
 
+    // eslint-disable-next-line no-shadow
     return function convertImgDataToPng(imgData, forceDataSchema, isMask) {
       const kind =
         imgData.kind === undefined ? ImageKind.GRAYSCALE_1BPP : imgData.kind;
@@ -437,6 +438,7 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
   let maskCount = 0;
   let shadingCount = 0;
 
+  // eslint-disable-next-line no-shadow
   SVGGraphics = class SVGGraphics {
     constructor(commonObjs, objs, forceDataSchema) {
       this.svgFactory = new DOMSVGFactory();

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -719,6 +719,7 @@ var renderTextLayer = (function renderTextLayerClosure() {
    * @param {TextLayerRenderParameters} renderParameters
    * @returns {TextLayerRenderTask}
    */
+  // eslint-disable-next-line no-shadow
   function renderTextLayer(renderParameters) {
     var task = new TextLayerRenderTask({
       textContent: renderParameters.textContent,

--- a/src/shared/message_handler.js
+++ b/src/shared/message_handler.js
@@ -114,15 +114,15 @@ class MessageHandler {
         throw new Error(`Unknown action from worker: ${data.action}`);
       }
       if (data.callbackId) {
-        const sourceName = this.sourceName;
-        const targetName = data.sourceName;
+        const cbSourceName = this.sourceName;
+        const cbTargetName = data.sourceName;
         new Promise(function(resolve) {
           resolve(action(data.data));
         }).then(
           function(result) {
             comObj.postMessage({
-              sourceName,
-              targetName,
+              sourceName: cbSourceName,
+              targetName: cbTargetName,
               callback: CallbackKind.DATA,
               callbackId: data.callbackId,
               data: result,
@@ -130,8 +130,8 @@ class MessageHandler {
           },
           function(reason) {
             comObj.postMessage({
-              sourceName,
-              targetName,
+              sourceName: cbSourceName,
+              targetName: cbTargetName,
               callback: CallbackKind.ERROR,
               callbackId: data.callbackId,
               reason: wrapReason(reason),

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -405,6 +405,7 @@ function shadow(obj, prop, value) {
 }
 
 const BaseException = (function BaseExceptionClosure() {
+  // eslint-disable-next-line no-shadow
   function BaseException(message) {
     if (this.constructor === BaseException) {
       unreachable("Cannot initialize BaseException.");
@@ -859,6 +860,7 @@ const createObjectURL = (function createObjectURLClosure() {
   const digits =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
 
+  // eslint-disable-next-line no-shadow
   return function createObjectURL(data, contentType, forceDataSchema = false) {
     if (!forceDataSchema && URL.createObjectURL) {
       const blob = new Blob([data], { type: contentType });

--- a/test/add_test.js
+++ b/test/add_test.js
@@ -22,9 +22,9 @@ if (!fs.existsSync(file)) {
   throw new Error(`PDF file does not exist '${file}'.`);
 }
 
-function calculateMD5(file, callback) {
+function calculateMD5(pdfFile, callback) {
   var hash = crypto.createHash("md5");
-  var stream = fs.createReadStream(file);
+  var stream = fs.createReadStream(pdfFile);
   stream.on("data", function(data) {
     hash.update(data);
   });

--- a/test/driver.js
+++ b/test/driver.js
@@ -228,10 +228,10 @@ var rasterizeAnnotationLayer = (function rasterizeAnnotationLayerClosure() {
           for (var i = 0, ii = data.length; i < ii; i++) {
             images[i].src = data[i];
             loadedPromises.push(
-              new Promise(function(resolve, reject) {
-                images[i].onload = resolve;
+              new Promise(function(resolveImage, rejectImage) {
+                images[i].onload = resolveImage;
                 images[i].onerror = function(e) {
-                  reject(new Error("Error loading image " + e));
+                  rejectImage(new Error("Error loading image " + e));
                 };
               })
             );

--- a/test/driver.js
+++ b/test/driver.js
@@ -45,6 +45,7 @@ var rasterizeTextLayer = (function rasterizeTextLayerClosure() {
     return textLayerStylePromise;
   }
 
+  // eslint-disable-next-line no-shadow
   function rasterizeTextLayer(
     ctx,
     viewport,
@@ -178,6 +179,7 @@ var rasterizeAnnotationLayer = (function rasterizeAnnotationLayerClosure() {
     return imagePromises;
   }
 
+  // eslint-disable-next-line no-shadow
   function rasterizeAnnotationLayer(
     ctx,
     viewport,
@@ -283,6 +285,7 @@ var Driver = (function DriverClosure() {
    * @constructs Driver
    * @param {DriverOptions} options
    */
+  // eslint-disable-next-line no-shadow
   function Driver(options) {
     // Configure the global worker options.
     pdfjsLib.GlobalWorkerOptions.workerSrc = WORKER_SRC;

--- a/test/font/ttxdriver.js
+++ b/test/font/ttxdriver.js
@@ -24,10 +24,10 @@ var ttxResourcesHome = path.join(__dirname, "..", "ttx");
 
 var nextTTXTaskId = Date.now();
 
-function runTtx(ttxResourcesHome, fontPath, registerOnCancel, callback) {
-  fs.realpath(ttxResourcesHome, function(err, ttxResourcesHome) {
-    var fontToolsHome = path.join(ttxResourcesHome, "fonttools-code");
-    fs.realpath(fontPath, function(err, fontPath) {
+function runTtx(ttxResourcesHomePath, fontPath, registerOnCancel, callback) {
+  fs.realpath(ttxResourcesHomePath, function(error, realTtxResourcesHomePath) {
+    var fontToolsHome = path.join(realTtxResourcesHomePath, "fonttools-code");
+    fs.realpath(fontPath, function(errorFontPath, realFontPath) {
       var ttxPath = path.join("Tools", "ttx");
       if (!fs.existsSync(path.join(fontToolsHome, ttxPath))) {
         callback("TTX was not found, please checkout PDF.js submodules");
@@ -38,7 +38,7 @@ function runTtx(ttxResourcesHome, fontPath, registerOnCancel, callback) {
         PYTHONDONTWRITEBYTECODE: true,
       };
       var ttxStdioMode = "ignore";
-      var ttx = spawn("python", [ttxPath, fontPath], {
+      var ttx = spawn("python", [ttxPath, realFontPath], {
         cwd: fontToolsHome,
         stdio: ttxStdioMode,
         env: ttxEnv,
@@ -49,8 +49,8 @@ function runTtx(ttxResourcesHome, fontPath, registerOnCancel, callback) {
         callback(reason);
         ttx.kill();
       });
-      ttx.on("error", function(err) {
-        ttxRunError = err;
+      ttx.on("error", function(errorTtx) {
+        ttxRunError = errorTtx;
         callback("Unable to execute ttx");
       });
       ttx.on("close", function(code) {

--- a/test/stats/statcmp.js
+++ b/test/stats/statcmp.js
@@ -37,16 +37,16 @@ function parseOptions() {
 function group(stats, groupBy) {
   var vals = [];
   for (var i = 0; i < stats.length; i++) {
-    var stat = stats[i];
+    var curStat = stats[i];
     var keyArr = [];
     for (var j = 0; j < groupBy.length; j++) {
-      keyArr.push(stat[groupBy[j]]);
+      keyArr.push(curStat[groupBy[j]]);
     }
     var key = keyArr.join(",");
     if (vals[key] === undefined) {
       vals[key] = [];
     }
-    vals[key].push(stat["time"]);
+    vals[key].push(curStat["time"]);
   }
   return vals;
 }
@@ -57,13 +57,13 @@ function group(stats, groupBy) {
  */
 function flatten(stats) {
   var rows = [];
-  stats.forEach(function(stat) {
-    stat["stats"].forEach(function(s) {
+  stats.forEach(function(curStat) {
+    curStat["stats"].forEach(function(s) {
       rows.push({
-        browser: stat["browser"],
-        page: stat["page"],
-        pdf: stat["pdf"],
-        round: stat["round"],
+        browser: curStat["browser"],
+        page: curStat["page"],
+        pdf: curStat["pdf"],
+        round: curStat["round"],
         stat: s["name"],
         time: s["end"] - s["start"],
       });

--- a/test/test.js
+++ b/test/test.js
@@ -619,8 +619,8 @@ function refTestPostHandler(req, res) {
     if (pathname === "/tellMeToQuit") {
       // finding by path
       var browserPath = parsedUrl.query.path;
-      session = sessions.filter(function(session) {
-        return session.config.path === browserPath;
+      session = sessions.filter(function(curSession) {
+        return curSession.config.path === browserPath;
       })[0];
       monitorBrowserTimeout(session, null);
       closeSession(session.name);
@@ -689,7 +689,7 @@ function refTestPostHandler(req, res) {
   return true;
 }
 
-function startUnitTest(url, name) {
+function startUnitTest(testUrl, name) {
   var startTime = Date.now();
   startServer();
   server.hooks["POST"].push(unitTestPostHandler);
@@ -712,7 +712,7 @@ function startUnitTest(url, name) {
     var runtime = (Date.now() - startTime) / 1000;
     console.log(name + " tests runtime was " + runtime.toFixed(1) + " seconds");
   };
-  startBrowsers(url, function(session) {
+  startBrowsers(testUrl, function(session) {
     session.numRuns = 0;
     session.numErrors = 0;
   });
@@ -784,7 +784,7 @@ function unitTestPostHandler(req, res) {
   return true;
 }
 
-function startBrowsers(url, initSessionCallback) {
+function startBrowsers(testUrl, initSessionCallback) {
   var browsers;
   if (options.browserManifestFile) {
     browsers = JSON.parse(fs.readFileSync(options.browserManifestFile));
@@ -801,7 +801,7 @@ function startBrowsers(url, initSessionCallback) {
     var browser = WebBrowser.create(b);
     var startUrl =
       getServerBaseAddress() +
-      url +
+      testUrl +
       "?browser=" +
       encodeURIComponent(b.name) +
       "&manifestFile=" +

--- a/test/webbrowser.js
+++ b/test/webbrowser.js
@@ -26,9 +26,9 @@ var crypto = require("crypto");
 
 var tempDirPrefix = "pdfjs_";
 
-function WebBrowser(name, path, headless) {
+function WebBrowser(name, execPath, headless) {
   this.name = name;
-  this.path = path;
+  this.path = execPath;
   this.headless = headless;
   this.tmpDir = null;
   this.profileDir = null;
@@ -197,7 +197,7 @@ WebBrowser.prototype = {
     // Note: First process' output it shown, the later outputs are suppressed.
     execAsyncNoStdin(
       cmdKillAll,
-      function checkAlive(exitCode, firstStdout) {
+      function checkAlive(firstExitCode, firstStdout) {
         execAsyncNoStdin(
           cmdCheckAllKilled,
           function(exitCode, stdout) {
@@ -227,14 +227,14 @@ WebBrowser.prototype = {
 
 var firefoxResourceDir = path.join(__dirname, "resources", "firefox");
 
-function FirefoxBrowser(name, path, headless) {
+function FirefoxBrowser(name, execPath, headless) {
   if (os.platform() === "darwin") {
-    var m = /([^.\/]+)\.app(\/?)$/.exec(path);
+    var m = /([^.\/]+)\.app(\/?)$/.exec(execPath);
     if (m) {
-      path += (m[2] ? "" : "/") + "Contents/MacOS/firefox";
+      execPath += (m[2] ? "" : "/") + "Contents/MacOS/firefox";
     }
   }
-  WebBrowser.call(this, name, path, headless);
+  WebBrowser.call(this, name, execPath, headless);
 }
 FirefoxBrowser.prototype = Object.create(WebBrowser.prototype);
 FirefoxBrowser.prototype.buildArguments = function(url) {
@@ -253,15 +253,15 @@ FirefoxBrowser.prototype.setupProfileDir = function(dir) {
   testUtils.copySubtreeSync(firefoxResourceDir, dir);
 };
 
-function ChromiumBrowser(name, path, headless) {
+function ChromiumBrowser(name, execPath, headless) {
   if (os.platform() === "darwin") {
-    var m = /([^.\/]+)\.app(\/?)$/.exec(path);
+    var m = /([^.\/]+)\.app(\/?)$/.exec(execPath);
     if (m) {
-      path += (m[2] ? "" : "/") + "Contents/MacOS/" + m[1];
-      console.log(path);
+      execPath += (m[2] ? "" : "/") + "Contents/MacOS/" + m[1];
+      console.log(execPath);
     }
   }
-  WebBrowser.call(this, name, path, headless);
+  WebBrowser.call(this, name, execPath, headless);
 }
 ChromiumBrowser.prototype = Object.create(WebBrowser.prototype);
 ChromiumBrowser.prototype.buildArguments = function(url) {
@@ -291,18 +291,18 @@ ChromiumBrowser.prototype.buildArguments = function(url) {
 
 WebBrowser.create = function(desc) {
   var name = desc.name;
-  var path = fs.realpathSync(desc.path);
-  if (!path) {
+  var execPath = fs.realpathSync(desc.path);
+  if (!execPath) {
     throw new Error("Browser executable not found: " + desc.path);
   }
 
   if (/firefox/i.test(name)) {
-    return new FirefoxBrowser(name, path, desc.headless);
+    return new FirefoxBrowser(name, execPath, desc.headless);
   }
   if (/(chrome|chromium|opera)/i.test(name)) {
-    return new ChromiumBrowser(name, path, desc.headless);
+    return new ChromiumBrowser(name, execPath, desc.headless);
   }
-  return new WebBrowser(name, path, desc.headless);
+  return new WebBrowser(name, execPath, desc.headless);
 };
 
 exports.WebBrowser = WebBrowser;

--- a/test/webbrowser.js
+++ b/test/webbrowser.js
@@ -258,7 +258,6 @@ function ChromiumBrowser(name, execPath, headless) {
     var m = /([^.\/]+)\.app(\/?)$/.exec(execPath);
     if (m) {
       execPath += (m[2] ? "" : "/") + "Contents/MacOS/" + m[1];
-      console.log(execPath);
     }
   }
   WebBrowser.call(this, name, execPath, headless);

--- a/test/webserver.js
+++ b/test/webserver.js
@@ -283,15 +283,15 @@ WebServer.prototype = {
       });
     }
 
-    function serveRequestedFile(filePath) {
-      var stream = fs.createReadStream(filePath, { flags: "rs" });
+    function serveRequestedFile(reqFilePath) {
+      var stream = fs.createReadStream(reqFilePath, { flags: "rs" });
 
       stream.on("error", function(error) {
         res.writeHead(500);
         res.end();
       });
 
-      var ext = path.extname(filePath).toLowerCase();
+      var ext = path.extname(reqFilePath).toLowerCase();
       var contentType = mimeTypes[ext] || defaultMimeType;
 
       if (!disableRangeRequests) {
@@ -309,8 +309,8 @@ WebServer.prototype = {
       stream.pipe(res);
     }
 
-    function serveRequestedFileRange(filePath, start, end) {
-      var stream = fs.createReadStream(filePath, {
+    function serveRequestedFileRange(reqFilePath, start, end) {
+      var stream = fs.createReadStream(reqFilePath, {
         flags: "rs",
         start: start,
         end: end - 1,
@@ -321,7 +321,7 @@ WebServer.prototype = {
         res.end();
       });
 
-      var ext = path.extname(filePath).toLowerCase();
+      var ext = path.extname(reqFilePath).toLowerCase();
       var contentType = mimeTypes[ext] || defaultMimeType;
 
       res.setHeader("Accept-Ranges", "bytes");

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -285,6 +285,7 @@ var Stepper = (function StepperClosure() {
     return simpleObj;
   }
 
+  // eslint-disable-next-line no-shadow
   function Stepper(panel, pageIndex, initialBreakPoints) {
     this.panel = panel;
     this.breakPoint = 0;


### PR DESCRIPTION
This rule is *not* currently enabled in mozilla-central, but it appears commented out[1] in the ESLint definition file; see https://searchfox.org/mozilla-central/rev/c80fa7258c935223fe319c5345b58eae85d4c6ae/tools/lint/eslint/eslint-plugin-mozilla/lib/configs/recommended.js#238-239

Unfortunately this rule is, for fairly obvious reasons, impossible to `--fix` automatically (even partially) and each case thus required careful manual analysis.
Hence this ESLint rule is, by some margin, probably the most difficult one that we've enabled thus far. However, using this rule does seem like a good idea in general since allowing variable shadowing could lead to subtle (and difficult to find) bugs or at the very least confusing code.

Please find additional details about the ESLint rule at https://eslint.org/docs/rules/no-shadow

---
[1] Most likely, a very large number of lint errors have prevented this rule from being enabled thus far.

