### PR TITLE
Add `passive: false` when removing wheel listeners

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1719,7 +1719,7 @@ const PDFViewerApplication = {
     const { _boundEvents } = this;
 
     window.removeEventListener("visibilitychange", webViewerVisibilityChange);
-    window.removeEventListener("wheel", webViewerWheel);
+    window.removeEventListener("wheel", webViewerWheel, { passive: false });
     window.removeEventListener("click", webViewerClick);
     window.removeEventListener("keydown", webViewerKeyDown);
     window.removeEventListener("resize", _boundEvents.windowResize);

--- a/web/pdf_presentation_mode.js
+++ b/web/pdf_presentation_mode.js
@@ -437,7 +437,9 @@ class PDFPresentationMode {
   _removeWindowListeners() {
     window.removeEventListener("mousemove", this.showControlsBind);
     window.removeEventListener("mousedown", this.mouseDownBind);
-    window.removeEventListener("wheel", this.mouseWheelBind);
+    window.removeEventListener("wheel", this.mouseWheelBind, {
+      passive: false,
+    });
     window.removeEventListener("keydown", this.resetMouseScrollStateBind);
     window.removeEventListener("contextmenu", this.contextMenuBind);
     window.removeEventListener("touchstart", this.touchSwipeBind);


### PR DESCRIPTION
Code of listening `wheel` event uses `{passive: false}`, while this argument will be treated as `true` before Firefox 49, according to https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Browser_compatibility .

This commit adds it when removing wheel listeners, so that such listeners can be really removed.

This is a simple complement to #11736.