### PR TITLE
Support for array queries (allows to highlight "hello world" and "my name is Allice" in the same search query)

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -241,22 +241,26 @@ class PDFFindController {
    * @type {array} The (current) normalized search query array.
    */
   get _arrayQuery() {
-	if(!this._isArrayQuery()) return [this._query];
-	this._rawQuery = this._state.query;
-	this._normalizedQuery = [];
-	for(let i=0; i<this._state.query.length; i++) {
-		this._normalizedQuery.push(normalize(this._state.query[i]))
-	}
+    if(!this._isArrayQuery()) {
+      return [this._query];
+    }
+    this._rawQuery = this._state.query;
+    this._normalizedQuery = [];
+    for (let i = 0; i < this._state.query.length; i++) {
+      this._normalizedQuery.push(normalize(this._state.query[i]))
+    }
     return this._normalizedQuery;
   }
 
   _isArrayQuery() {
-	return Array.isArray(this._state.query);
+    return Array.isArray(this._state.query);
   }
 
   _isEmptyQuery() {
-	if(this._isArrayQuery()) return this._state.query.length == 0;
-	return this._query === "";
+    if (this._isArrayQuery()) {
+      return this._state.query.length === 0;
+    }
+    return this._query === "";
   }
 
   _shouldDirtyMatch(cmd, state) {
@@ -435,6 +439,7 @@ class PDFFindController {
       this._pageMatchesLength[pageIndex]
     );
   }
+
   _calculateMatch(pageIndex) {
     let pageContent = this._pageContents[pageIndex];
     let query;
@@ -448,7 +453,7 @@ class PDFFindController {
       query = this._arrayQuery;
       if (!caseSensitive) {
         pageContent = pageContent.toLowerCase();
-        for(i=0; i<query.length; i++) {
+        for (let i = 0; i < query.length; i++) {
           query[i] = query[i].toLowerCase();
         }
       }
@@ -466,8 +471,6 @@ class PDFFindController {
         this._calculateWordMatch(query, pageIndex, pageContent, entireWord);
       }
     }
-
-    
 
     // When `highlightAll` is set, ensure that the matches on previously
     // rendered (and still active) pages are correctly highlighted.

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -241,13 +241,13 @@ class PDFFindController {
    * @type {array} The (current) normalized search query array.
    */
   get _arrayQuery() {
-    if(!this._isArrayQuery()) {
+    if (!this._isArrayQuery()) {
       return [this._query];
     }
     this._rawQuery = this._state.query;
     this._normalizedQuery = [];
     for (let i = 0; i < this._state.query.length; i++) {
-      this._normalizedQuery.push(normalize(this._state.query[i]))
+      this._normalizedQuery.push(normalize(this._state.query[i]));
     }
     return this._normalizedQuery;
   }
@@ -445,11 +445,11 @@ class PDFFindController {
     let query;
     const { caseSensitive, entireWord, phraseSearch } = this._state;
 
-    if(this._isEmptyQuery()) {
+    if (this._isEmptyQuery()) {
       // Do nothing: the matches should be wiped out already.
       return;
     }
-    if(this._isArrayQuery()) {
+    if( this._isArrayQuery()) {
       query = this._arrayQuery;
       if (!caseSensitive) {
         pageContent = pageContent.toLowerCase();
@@ -458,7 +458,7 @@ class PDFFindController {
         }
       }
       this._calculateArrayMatch(query, pageIndex, pageContent, entireWord);
-    } else{
+    } else {
       query = this._query;
       if (!caseSensitive) {
         pageContent = pageContent.toLowerCase();

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -449,7 +449,7 @@ class PDFFindController {
       // Do nothing: the matches should be wiped out already.
       return;
     }
-    if( this._isArrayQuery()) {
+    if (this._isArrayQuery()) {
       query = this._arrayQuery;
       if (!caseSensitive) {
         pageContent = pageContent.toLowerCase();

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -232,6 +232,13 @@ class PDFLinkService {
           phraseSearch: params["phrase"] === "true",
         });
       }
+      if ("searchArray" in params) {
+        this.eventBus.dispatch("findfromurlhash", {
+          source: this,
+          query: JSON.parse(params["search"]),
+          phraseSearch: true, // This does not matter
+        });
+      }
       // borrowing syntax from "Parameters for Opening PDF Files"
       if ("nameddest" in params) {
         this.navigateTo(params.nameddest);


### PR DESCRIPTION
Added support for array queries in order to allow complex searches like ["Hello world", "I'm Alice", "bye"] to combine phrase search with standard term search. Multi-word terms are searched just the way phrase search would work.

Included searchArray param (analogue to search) to not interfere with existing functionalities.

Arrays are provided as JSON stringified text via the new searchArray param (just as you would do with the existing search param, but it will use JSON.parse(params['searchArray ']) instead of params['searchArray '].replace(/"/g,'');

closes #11748 
closes #7442
closes  #11128