### PR TITLE
Remove the unused `sizes` and `encoding` properties on `Font` instances

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -523,7 +523,6 @@ var Font = (function FontClosure() {
     this.name = name;
     this.loadedName = properties.loadedName;
     this.isType3Font = properties.isType3Font;
-    this.sizes = [];
     this.missingFile = false;
 
     this.glyphCache = Object.create(null);
@@ -652,7 +651,6 @@ var Font = (function FontClosure() {
     this.widths = properties.widths;
     this.defaultWidth = properties.defaultWidth;
     this.toUnicode = properties.toUnicode;
-    this.encoding = properties.baseEncoding;
     this.seacMap = properties.seacMap;
   }
 
@@ -1253,7 +1251,6 @@ var Font = (function FontClosure() {
     name: null,
     font: null,
     mimetype: null,
-    encoding: null,
     disableFontFace: false,
 
     get renderer() {


### PR DESCRIPTION
The `sizes` property doesn't appear to have been used ever since the code was first split into main/worker-threads, which is so many years ago that I wasn't able to easily find exactly in which PR/commit it became unused.

The `encoding` property is always assigned the `properties.baseEncoding` value, however the `PartialEvaluator` doesn't actually compute/set that value any more. Again it was difficult to determine when it became unused, but it's been that way for years.