### PR TITLE
[api-minor] Change `Font.exportData` to use an explicit white-list of exportable properties

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1761,7 +1761,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
             fontFamily: font.fallbackName,
             ascent: font.ascent,
             descent: font.descent,
-            vertical: !!font.vertical,
+            vertical: font.vertical,
           };
         }
         textContentItem.fontName = font.loadedName;

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -3169,10 +3169,6 @@ var Font = (function FontClosure() {
     },
 
     get spaceWidth() {
-      if ("_shadowWidth" in this) {
-        return this._shadowWidth;
-      }
-
       // trying to estimate space character width
       var possibleSpaceReplacements = ["space", "minus", "one", "i", "I"];
       var width;
@@ -3187,10 +3183,8 @@ var Font = (function FontClosure() {
         var glyphUnicode = glyphsUnicodeMap[glyphName];
         // finding the charcode via unicodeToCID map
         var charcode = 0;
-        if (this.composite) {
-          if (this.cMap.contains(glyphUnicode)) {
-            charcode = this.cMap.lookup(glyphUnicode);
-          }
+        if (this.composite && this.cMap.contains(glyphUnicode)) {
+          charcode = this.cMap.lookup(glyphUnicode);
         }
         // ... via toUnicode map
         if (!charcode && this.toUnicode) {
@@ -3207,10 +3201,7 @@ var Font = (function FontClosure() {
         }
       }
       width = width || this.defaultWidth;
-      // Do not shadow the property here. See discussion:
-      // https://github.com/mozilla/pdf.js/pull/2127#discussion_r1662280
-      this._shadowWidth = width;
-      return width;
+      return shadow(this, "spaceWidth", width);
     },
 
     charToGlyph: function Font_charToGlyph(charcode, isSpace) {

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -92,21 +92,17 @@ const EXPORT_DATA_PROPERTIES = [
   "bbox",
   "black",
   "bold",
-  "cMap",
   "charProcOperatorList",
   "composite",
   "data",
-  "defaultEncoding",
   "defaultVMetrics",
   "defaultWidth",
   "descent",
-  "differences",
   "fallbackName",
   "fontMatrix",
   "fontType",
   "isMonospace",
   "isSerifFont",
-  "isSymbolicFont",
   "isType3Font",
   "italic",
   "loadedName",
@@ -114,12 +110,19 @@ const EXPORT_DATA_PROPERTIES = [
   "missingFile",
   "name",
   "remeasure",
-  "seacMap",
   "subtype",
-  "toFontChar",
-  "toUnicode",
   "type",
   "vertical",
+];
+
+const EXPORT_DATA_EXTRA_PROPERTIES = [
+  "cMap",
+  "defaultEncoding",
+  "differences",
+  "isSymbolicFont",
+  "seacMap",
+  "toFontChar",
+  "toUnicode",
   "vmetrics",
   "widths",
 ];
@@ -1295,13 +1298,22 @@ var Font = (function FontClosure() {
       return shadow(this, "renderer", renderer);
     },
 
-    exportData() {
+    exportData(extraProperties = false) {
       const data = Object.create(null);
       for (const property of EXPORT_DATA_PROPERTIES) {
         const value = this[property];
         // Ignore properties that haven't been explictly set.
         if (value !== undefined) {
           data[property] = value;
+        }
+      }
+      if (extraProperties) {
+        for (const property of EXPORT_DATA_EXTRA_PROPERTIES) {
+          const value = this[property];
+          // Ignore properties that haven't been explictly set.
+          if (value !== undefined) {
+            data[property] = value;
+          }
         }
       }
       return data;

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -610,7 +610,7 @@ var Font = (function FontClosure() {
     }
 
     this.cidEncoding = properties.cidEncoding;
-    this.vertical = properties.vertical;
+    this.vertical = !!properties.vertical;
     if (this.vertical) {
       this.vmetrics = properties.vmetrics;
       this.defaultVMetrics = properties.defaultVMetrics;

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -88,15 +88,12 @@ var PDF_GLYPH_SPACE_UNITS = 1000;
 var SEAC_ANALYSIS_ENABLED = true;
 
 const EXPORT_DATA_PROPERTIES = [
-  "_shadowWidth",
   "ascent",
   "bbox",
   "black",
   "bold",
   "cMap",
   "charProcOperatorList",
-  "charsCache",
-  "cidEncoding",
   "composite",
   "data",
   "defaultEncoding",
@@ -105,12 +102,9 @@ const EXPORT_DATA_PROPERTIES = [
   "descent",
   "differences",
   "fallbackName",
-  "fallbackToUnicode",
   "fontMatrix",
   "fontType",
-  "glyphCache",
   "isMonospace",
-  "isOpenType",
   "isSerifFont",
   "isSymbolicFont",
   "isType3Font",

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -87,6 +87,49 @@ var PDF_GLYPH_SPACE_UNITS = 1000;
 // custom one. Windows just refuses to draw glyphs with seac operators.
 var SEAC_ANALYSIS_ENABLED = true;
 
+const EXPORT_DATA_PROPERTIES = [
+  "_shadowWidth",
+  "ascent",
+  "bbox",
+  "black",
+  "bold",
+  "cMap",
+  "charProcOperatorList",
+  "charsCache",
+  "cidEncoding",
+  "composite",
+  "data",
+  "defaultEncoding",
+  "defaultVMetrics",
+  "defaultWidth",
+  "descent",
+  "differences",
+  "fallbackName",
+  "fallbackToUnicode",
+  "fontMatrix",
+  "fontType",
+  "glyphCache",
+  "isMonospace",
+  "isOpenType",
+  "isSerifFont",
+  "isSymbolicFont",
+  "isType3Font",
+  "italic",
+  "loadedName",
+  "mimetype",
+  "missingFile",
+  "name",
+  "remeasure",
+  "seacMap",
+  "subtype",
+  "toFontChar",
+  "toUnicode",
+  "type",
+  "vertical",
+  "vmetrics",
+  "widths",
+];
+
 var FontFlags = {
   FixedPitch: 1,
   Serif: 2,
@@ -1258,12 +1301,13 @@ var Font = (function FontClosure() {
       return shadow(this, "renderer", renderer);
     },
 
-    exportData: function Font_exportData() {
-      // TODO remove enumerating of the properties, e.g. hardcode exact names.
-      var data = {};
-      for (var i in this) {
-        if (this.hasOwnProperty(i)) {
-          data[i] = this[i];
+    exportData() {
+      const data = Object.create(null);
+      for (const property of EXPORT_DATA_PROPERTIES) {
+        const value = this[property];
+        // Ignore properties that haven't been explictly set.
+        if (value !== undefined) {
+          data[property] = value;
         }
       }
       return data;


### PR DESCRIPTION
This patch addresses an existing, and very long standing, TODO in the code such that it's no longer possible to send arbitrary/unnecessary font properties to the main-thread.
Furthermore, by having a white-list it's also very easy to see *exactly* which font properties are being exported.

Please note that in its current form, the list of exported properties contains *every* possible enumerable property that may exist in a `Font` instance.
In practice no single font will contain *all* of these properties, and e.g. embedded/non-embedded/Type3 fonts will all differ slightly with respect to what properties are being defined. Hence why only explicitly set properties are included in the exported data, to avoid half of them being `undefined`, which however should not be a problem for any existing consumer.

Since a fair number of these font properties are completely *internal* functionality, and doesn't make any sense on the main-thread, follow-up patch(es) will be required to trim down the list. (I purposely included all properties here for brevity and future documentation purposes.)