### PR TITLE
Fail early, in modern `GENERIC` builds, if certain required browser functionality is missing (issue 11762)

### DIFF
--- a/external/dist/lib/README.md
+++ b/external/dist/lib/README.md
@@ -3,5 +3,5 @@ pre-built library as found in e.g. the `/build`, `/web`, and `/image_decoders`
 folders in the root of this repository.
 
 Please note that the "lib" build target exists mostly to enable unit-testing in
-Node.js/Travis, and that you'll need to handle e.g. any Node.js dependencies
-yourself if using the files in this folder.
+Node.js/Travis, and that you'll need to handle e.g. any necessary polyfills
+and/or Node.js dependencies yourself if using the files in this folder.

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -136,6 +136,21 @@ var WorkerMessageHandler = {
             "; thus breaking e.g. `for...in` iteration of `Array`s."
         );
       }
+
+      // Ensure that (primarily) Node.js users won't accidentally attempt to use
+      // a non-translated/non-polyfilled build of the library, since that would
+      // quickly fail anyway because of missing functionality (such as e.g.
+      // `ReadableStream).
+      if (
+        (typeof PDFJSDev === "undefined" || PDFJSDev.test("SKIP_BABEL")) &&
+        typeof ReadableStream === "undefined"
+      ) {
+        throw new Error(
+          "The browser/environment lacks native support for critical " +
+            "functionality used by the PDF.js library (e.g. `ReadableStream`); " +
+            "please use an ES5-compatible build instead."
+        );
+      }
     }
 
     var docId = docParams.docId;

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -14,11 +14,9 @@
  */
 /* eslint no-var: error */
 
-// Skip compatibility checks for modern builds (unless we're running the
-// unit-tests in Node.js/Travis) and if we already ran the module.
+// Skip compatibility checks for modern builds and if we already ran the module.
 if (
-  (typeof PDFJSDev === "undefined" ||
-    PDFJSDev.test("!SKIP_BABEL || (LIB && TESTING)")) &&
+  (typeof PDFJSDev === "undefined" || !PDFJSDev.test("SKIP_BABEL")) &&
   (typeof globalThis === "undefined" || !globalThis._pdfjsCompatibilityChecked)
 ) {
   // Provides support for globalThis in legacy browsers.

--- a/test/unit/clitests.json
+++ b/test/unit/clitests.json
@@ -1,5 +1,5 @@
 {
-  "spec_dir": "build/lib/test/unit",
+  "spec_dir": "build/lib-es5/test/unit",
 
   "helpers": [
     "clitests_helper.js"


### PR DESCRIPTION
With two kind of builds now being produced, with/without translation/polyfills, it's unfortunately somewhat easy for users to accidentally pick the wrong one.

In the case where a user would attempt to use a modern build of PDF.js in an older browser, such as e.g. IE11, the failure would be immediate when the code is loaded (given the use of unsupported ECMAScript features).
However in some browsers/environments, in particular Node.js, a modern PDF.js build may load correctly and thus *appear* to function, only to fail for e.g. certain API calls. To hopefully lessen the support burden, and to try and improve things overall, this patch adds checks to ensure that a modern build of PDF.js cannot be used in browsers/environments which lack native support for critical functionality (such as e.g. `ReadableStream`). Hence we'll fail early, with an error message telling users to pick an ES5-compatible build instead.

To ensure that we actually test things better especially w.r.t. usage of the PDF.js library in Node.js environments, the `gulp npm-test` task as used by Node.js/Travis was changed (back) to test an ES5-compatible build.
(Since the bots still test the code as-is, without transpilation/polyfills, this shouldn't really be a problem as far as I can tell.)
As part of these changes there's now both `gulp lib` and `gulp lib-es5` build targets, similar to e.g. the generic builds, which thanks to some re-factoring only required adding a small amount of code.

*Please note:* While it's probably too early to tell if this will be a widespread issue, it's possible that this is the sort of patch that *may* warrant being `git cherry-pick`ed onto the current beta version (v2.4.456).

Fixes #11762

*Much smaller/easier diff with https://github.com/mozilla/pdf.js/pull/11771/files?w=1*