### PR TITLE
[api-minor] Change `Font.exportData` to use an explicit white-list of exportable properties, and stop exporting internal/unused properties

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1761,7 +1761,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
             fontFamily: font.fallbackName,
             ascent: font.ascent,
             descent: font.descent,
-            vertical: !!font.vertical,
+            vertical: font.vertical,
           };
         }
         textContentItem.fontName = font.loadedName;

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -87,6 +87,49 @@ var PDF_GLYPH_SPACE_UNITS = 1000;
 // custom one. Windows just refuses to draw glyphs with seac operators.
 var SEAC_ANALYSIS_ENABLED = true;
 
+const EXPORT_DATA_PROPERTIES = [
+  "_shadowWidth",
+  "ascent",
+  "bbox",
+  "black",
+  "bold",
+  "cMap",
+  "charProcOperatorList",
+  "charsCache",
+  "cidEncoding",
+  "composite",
+  "data",
+  "defaultEncoding",
+  "defaultVMetrics",
+  "defaultWidth",
+  "descent",
+  "differences",
+  "fallbackName",
+  "fallbackToUnicode",
+  "fontMatrix",
+  "fontType",
+  "glyphCache",
+  "isMonospace",
+  "isOpenType",
+  "isSerifFont",
+  "isSymbolicFont",
+  "isType3Font",
+  "italic",
+  "loadedName",
+  "mimetype",
+  "missingFile",
+  "name",
+  "remeasure",
+  "seacMap",
+  "subtype",
+  "toFontChar",
+  "toUnicode",
+  "type",
+  "vertical",
+  "vmetrics",
+  "widths",
+];
+
 var FontFlags = {
   FixedPitch: 1,
   Serif: 2,
@@ -1258,12 +1301,14 @@ var Font = (function FontClosure() {
       return shadow(this, "renderer", renderer);
     },
 
-    exportData: function Font_exportData() {
-      // TODO remove enumerating of the properties, e.g. hardcode exact names.
-      var data = {};
-      for (var i in this) {
-        if (this.hasOwnProperty(i)) {
-          data[i] = this[i];
+    exportData() {
+      const data = Object.create(null);
+      let property, value;
+      for (property of EXPORT_DATA_PROPERTIES) {
+        value = this[property];
+        // Ignore properties that haven't been explicitly set.
+        if (value !== undefined) {
+          data[property] = value;
         }
       }
       return data;

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -3158,10 +3158,6 @@ var Font = (function FontClosure() {
     },
 
     get spaceWidth() {
-      if ("_shadowWidth" in this) {
-        return this._shadowWidth;
-      }
-
       // trying to estimate space character width
       var possibleSpaceReplacements = ["space", "minus", "one", "i", "I"];
       var width;
@@ -3176,10 +3172,8 @@ var Font = (function FontClosure() {
         var glyphUnicode = glyphsUnicodeMap[glyphName];
         // finding the charcode via unicodeToCID map
         var charcode = 0;
-        if (this.composite) {
-          if (this.cMap.contains(glyphUnicode)) {
-            charcode = this.cMap.lookup(glyphUnicode);
-          }
+        if (this.composite && this.cMap.contains(glyphUnicode)) {
+          charcode = this.cMap.lookup(glyphUnicode);
         }
         // ... via toUnicode map
         if (!charcode && this.toUnicode) {
@@ -3196,10 +3190,7 @@ var Font = (function FontClosure() {
         }
       }
       width = width || this.defaultWidth;
-      // Do not shadow the property here. See discussion:
-      // https://github.com/mozilla/pdf.js/pull/2127#discussion_r1662280
-      this._shadowWidth = width;
-      return width;
+      return shadow(this, "spaceWidth", width);
     },
 
     charToGlyph: function Font_charToGlyph(charcode, isSpace) {

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -607,7 +607,7 @@ var Font = (function FontClosure() {
     }
 
     this.cidEncoding = properties.cidEncoding;
-    this.vertical = properties.vertical;
+    this.vertical = !!properties.vertical;
     if (this.vertical) {
       this.vmetrics = properties.vmetrics;
       this.defaultVMetrics = properties.defaultVMetrics;

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -88,15 +88,12 @@ var PDF_GLYPH_SPACE_UNITS = 1000;
 var SEAC_ANALYSIS_ENABLED = true;
 
 const EXPORT_DATA_PROPERTIES = [
-  "_shadowWidth",
   "ascent",
   "bbox",
   "black",
   "bold",
   "cMap",
   "charProcOperatorList",
-  "charsCache",
-  "cidEncoding",
   "composite",
   "data",
   "defaultEncoding",
@@ -105,12 +102,9 @@ const EXPORT_DATA_PROPERTIES = [
   "descent",
   "differences",
   "fallbackName",
-  "fallbackToUnicode",
   "fontMatrix",
   "fontType",
-  "glyphCache",
   "isMonospace",
-  "isOpenType",
   "isSerifFont",
   "isSymbolicFont",
   "isType3Font",


### PR DESCRIPTION
*Please refer to the individual commit messages for addition details.*

---

Note that there's *still* a number of potentially very large data-structures, containing e.g. Arrays and Objects, being exported despite being completely unused on the main-thread and/or in the API.
However, since we cannot be sure that they're  completely unused in all custom implementations of the PDF.js library, we probably cannot just remove them without also providing users with a way to still get this information (that we've been *accidentally* exposing for years).

To not unnecessarily delay the changes in this PR, which on their own should already be beneficial in my opinion, I thus decided to post-phone any further clean-up to a separate PR.