### PR TITLE
Move the initialization of "page labels"/"metadata"/"auto print" out of `PDFViewerApplication.load`

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1270,19 +1270,10 @@ const PDFViewerApplication = {
 
     // Provides some basic debug information
     console.log(
-      "PDF " +
-        pdfDocument.fingerprint +
-        " [" +
-        info.PDFFormatVersion +
-        " " +
-        (info.Producer || "-").trim() +
-        " / " +
-        (info.Creator || "-").trim() +
-        "]" +
-        " (PDF.js: " +
-        (version || "-") +
-        (AppOptions.get("enableWebGL") ? " [WebGL]" : "") +
-        ")"
+      `PDF ${pdfDocument.fingerprint} [${info.PDFFormatVersion} ` +
+        `${(info.Producer || "-").trim()} / ${(info.Creator || "-").trim()}] ` +
+        `(PDF.js: ${version || "-"}` +
+        `${this.pdfViewer.enableWebGL ? " [WebGL]" : ""})`
     );
 
     let pdfTitle;
@@ -1444,7 +1435,7 @@ const PDFViewerApplication = {
    * @private
    */
   _initializePdfHistory({ fingerprint, viewOnLoad, initialDest = null }) {
-    if (AppOptions.get("disableHistory") || this.isViewerEmbedded) {
+    if (this.isViewerEmbedded || AppOptions.get("disableHistory")) {
       // The browsing history is only enabled when the viewer is standalone,
       // i.e. not when it is embedded in a web page.
       return;


### PR DESCRIPTION
*Please refer to the individual commit messages for additional details.*

For awhile now I've been thinking that the `PDFViewerApplication.load` method has become way to large and unwieldy, hence this series of patches that move some of its non-critical code out into helper methods instead.

~~*Edit:* Currently blocked by PR #11781.~~