### PR TITLE
Update the "gulp jsdoc" task to account for API changes in the `mkdirp` package (PR 11772 follow-up)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1139,7 +1139,7 @@ gulp.task("jsdoc", function(done) {
   var JSDOC_FILES = ["src/doc_helper.js", "src/display/api.js"];
 
   rimraf(JSDOC_BUILD_DIR, function() {
-    mkdirp(JSDOC_BUILD_DIR, function() {
+    mkdirp(JSDOC_BUILD_DIR).then(function() {
       var command =
         '"node_modules/.bin/jsdoc" -d ' +
         JSDOC_BUILD_DIR +


### PR DESCRIPTION
I completely overlooked the fact that we had *one* occurrence of an asynchronous `mkdirp` call in the gulpfile, which thus breaks since the package now uses Promises rather than a callback function; sorry about that!