### PR TITLE
Add a new `pdfjs.enablePermissions` preference, off by default, to allow the PDF documents to disable copying in the viewer (bug 792816)

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -151,6 +151,10 @@
       "type": "boolean",
       "default": false
     },
+    "enablePermissions": {
+      "type": "boolean",
+      "default": false
+    },
     "historyUpdateUrl": {
       "type": "boolean",
       "default": false

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -53,6 +53,11 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
+  enablePermissions: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+  },
   /**
    * The `disablePreferences` is, conditionally, defined below.
    */

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -55,6 +55,11 @@ select {
   display: none !important;
 }
 
+.pdfViewer.enablePermissions .textLayer > span {
+  user-select: none !important;
+  cursor: not-allowed;
+}
+
 #viewerContainer.pdfPresentationMode:-ms-fullscreen {
   top: 0px !important;
   overflow: hidden !important;


### PR DESCRIPTION
*Recently I've been looking through some older issues/bugs, to see if there's any ones that are now easy to address; this is a simple one that I found.* 

---

*Please note:* Most of the necessary API work was done in PR #10033, and the only remaining thing to do here was to implement it in the viewer.

The new preference should thus allow e.g. enterprise users to disable copying in the viewer, for PDF documents whose permissions specify that.

In order to simplify things the "copy"-permission was implemented using CSS, as suggested in https://bugzilla.mozilla.org/show_bug.cgi?id=792816#c55, which should hopefully suffice.[1]
The advantage of this approach, as opposed to e.g. disabling the `textLayer` completely, is first of all that it ensures that searching still works correctly even in copy-protected documents. Secondly this also greatly simplifies the overall implementation, since it doesn't require a lot of code for something that's disabled by default.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=792816 (assuming we care to do so).
Fixes #3471
/cc @brendandahl 

---
[1] As the discussion in the bug shows, this kind of copy-protection is not very strong and is also generally easy to remove/circumvent in various ways. Hence a simple solution, targeting "regular"-users rather than "power"-users is hopefully deemed acceptable here.