### PR TITLE
Don't bundle the fallback `grab`/`grabbing` cursor images when running `gulp mozcentral`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1027,11 +1027,17 @@ gulp.task(
     var version = versionJSON.version,
       commit = versionJSON.commit;
 
+    // Ignore the fallback cursor images, since they're unnecessary in Firefox.
+    const MOZCENTRAL_COMMON_WEB_FILES = [
+      ...COMMON_WEB_FILES,
+      "!web/images/*.cur",
+    ];
+
     return merge([
       createBundle(defines).pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + "build")),
       createWebBundle(defines).pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + "web")),
       gulp
-        .src(COMMON_WEB_FILES, { base: "web/" })
+        .src(MOZCENTRAL_COMMON_WEB_FILES, { base: "web/" })
         .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + "web")),
       gulp
         .src(["external/bcmaps/*.bcmap", "external/bcmaps/LICENSE"], {


### PR DESCRIPTION
These cursor images are only necessary as a fallback for older browsers, hence there's no reason to keep shipping them in Firefox as far as I can tell; see https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Browser_compatibility