### PR TITLE
Fail early, in modern `GENERIC` builds, if certain required browser functionality is missing (PR 11771 follow-up)

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -140,14 +140,16 @@ var WorkerMessageHandler = {
       // Ensure that (primarily) Node.js users won't accidentally attempt to use
       // a non-translated/non-polyfilled build of the library, since that would
       // quickly fail anyway because of missing functionality (such as e.g.
-      // `ReadableStream).
+      // `ReadableStream` and `Promise.allSettled`).
       if (
         (typeof PDFJSDev === "undefined" || PDFJSDev.test("SKIP_BABEL")) &&
-        typeof ReadableStream === "undefined"
+        (typeof ReadableStream === "undefined" ||
+          typeof Promise.allSettled === "undefined")
       ) {
         throw new Error(
           "The browser/environment lacks native support for critical " +
-            "functionality used by the PDF.js library (e.g. `ReadableStream`); " +
+            "functionality used by the PDF.js library (e.g. " +
+            "`ReadableStream` and/or `Promise.allSettled`); " +
             "please use an ES5-compatible build instead."
         );
       }


### PR DESCRIPTION
With two kind of builds now being produced, with/without translation/polyfills, it's unfortunately somewhat easy for users to accidentally pick the wrong one.

In the case where a user would attempt to use a modern build of PDF.js in an older browser, such as e.g. IE11, the failure would be immediate when the code is loaded (given the use of unsupported ECMAScript features).
However in some browsers/environments, a modern PDF.js build may load correctly and thus *appear* to function, only to fail for e.g. certain API calls. To hopefully lessen the support burden, and to try and improve things overall, this patch adds additional checks to ensure that a modern build of PDF.js cannot be used in browsers/environments which lack native support for `Promise.allSettled`.[1] Hence we'll fail early, with an error message telling users to pick an ES5-compatible build instead.

*Please note:* While it's probably too early to tell if this will be a widespread issue, it's possible that this is the sort of patch that *may* warrant being `git cherry-pick`ed onto the current beta version (v2.4.456).

***See also:*** #11771

---
[1] This was a fairly recent addition to the web platform, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled#Browser_compatibility