### PR TITLE
Always skip over any additional, unexpected, RSTx (restart) markers in corrupt JPEG images (issue 11794)

### DIFF
--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -429,23 +429,17 @@ var JpegImage = (function JpegImageClosure() {
       bitsCount = 0;
       fileMarker = findNextFileMarker(data, offset);
       if (!fileMarker) {
-        // Reached the end of the image data without finding an EOI marker.
-        break;
-      } else if (fileMarker.invalid) {
+        break; // Reached the end of the image data without finding any marker.
+      }
+      if (fileMarker.invalid) {
         // Some bad images seem to pad Scan blocks with e.g. zero bytes, skip
         // past those to attempt to find a valid marker (fixes issue4090.pdf).
         warn(
-          "decodeScan - unexpected MCU data, current marker is: " +
-            fileMarker.invalid
+          `decodeScan - unexpected MCU data, current marker is: ${fileMarker.invalid}`
         );
         offset = fileMarker.offset;
       }
-      var marker = fileMarker && fileMarker.marker;
-      if (!marker || marker <= 0xff00) {
-        throw new JpegError("decodeScan - a valid marker was not found.");
-      }
-
-      if (marker >= 0xffd0 && marker <= 0xffd7) {
+      if (fileMarker.marker >= 0xffd0 && fileMarker.marker <= 0xffd7) {
         // RSTx
         offset += 2;
       } else {
@@ -458,8 +452,7 @@ var JpegImage = (function JpegImageClosure() {
     // attempt to find the next valid marker (fixes issue8182.pdf).
     if (fileMarker && fileMarker.invalid) {
       warn(
-        "decodeScan - unexpected Scan data, current marker is: " +
-          fileMarker.invalid
+        `decodeScan - unexpected Scan data, current marker is: ${fileMarker.invalid}`
       );
       offset = fileMarker.offset;
     }

--- a/test/pdfs/issue11794.pdf.link
+++ b/test/pdfs/issue11794.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/4459214/test.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2468,6 +2468,14 @@
       "link": true,
       "type": "eq"
     },
+    {  "id": "issue11794",
+       "file": "pdfs/issue11794.pdf",
+       "md5": "00d17b10a5fd7c06cddd7a0d2066ecdd",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {
       "id": "bug852992",
       "file": "pdfs/bug852992_reduced.pdf",


### PR DESCRIPTION
Fixes #11794 

*Much smaller/simpler diff with https://github.com/mozilla/pdf.js/pull/11805/files?w=1*

---

With the changes in this PR, I believe that it *should* also be possible to simply remove the code-block shown below. However, I wanted to avoid increasing the size/scope of this PR even more, given that it already contains a clean-up commit.
https://github.com/mozilla/pdf.js/blob/a4dd081d7be075c102abe164c74d5900c73066a8/src/core/jpg.js#L456-L465