### PR TITLE
[api-minor] Fix the return value of `PDFDocumentProxy.getViewerPreferences` when no viewer preferences are present (PR 10738 follow-up)

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -479,7 +479,7 @@ class Catalog {
     };
 
     const obj = this.catDict.get("ViewerPreferences");
-    const prefs = Object.create(null);
+    let prefs = null;
 
     if (isDict(obj)) {
       for (const key in ViewerPreferencesValidators) {
@@ -583,6 +583,9 @@ class Catalog {
         }
 
         if (prefValue !== undefined) {
+          if (!prefs) {
+            prefs = Object.create(null);
+          }
           prefs[key] = prefValue;
         } else {
           info(`Bad value in ViewerPreferences for "${key}".`);

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -663,7 +663,8 @@ class PDFDocumentProxy {
 
   /**
    * @returns {Promise} A promise that is resolved with an {Object} containing
-   *   the viewer preferences.
+   *   the viewer preferences, or `null` when no viewer preferences are present
+   *   in the PDF file.
    */
   getViewerPreferences() {
     return this._transport.getViewerPreferences();

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -24,7 +24,6 @@ import {
   createPromiseCapability,
   FontType,
   InvalidPDFException,
-  isEmptyObj,
   MissingPDFException,
   OPS,
   PasswordException,
@@ -846,9 +845,7 @@ describe("api", function () {
           return pdfDoc.getViewerPreferences();
         })
         .then(function (prefs) {
-          expect(
-            typeof prefs === "object" && prefs !== null && isEmptyObj(prefs)
-          ).toEqual(true);
+          expect(prefs).toEqual(null);
 
           loadingTask.destroy().then(done);
         })


### PR DESCRIPTION
This patch fixes yet another instalment in the never-ending series of "what the \*bleep\* was I thinking", by changing the `PDFDocumentProxy.getViewerPreferences` method to return `null` by default.
Not only is this method now consistent with many other API methods, for the data not present case, but it also avoids having to e.g. loop through an object to check if it's actually empty (note the old unit-test).