### PR TITLE
Suppress browser autofill on page number

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -222,7 +222,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                     <span data-l10n-id="next_label">Next</span>
                   </button>
                 </div>
-                <input type="number" id="pageNumber" class="toolbarField pageNumber" title="Page" value="1" size="4" min="1" tabindex="15" data-l10n-id="page">
+                <input type="number" id="pageNumber" class="toolbarField pageNumber" title="Page" value="1" size="4" min="1" tabindex="15" data-l10n-id="page" autocomplete="off">
                 <span id="numPages" class="toolbarLabel"></span>
               </div>
               <div id="toolbarViewerRight">


### PR DESCRIPTION
What the user did:
    Open the PDF Viewer in Chrome;
    Mouse click into the “Page number” input field;

What they saw:
    A pop-up list with seemingly random numbers

What you were expecting to see:
    Nothing

What they see is the Chrome “Autofill” feature at work – that is suggesting values that you have previously entered into number fields in forms, as possible values you may want to enter into this field.  The list has nothing to do with the PDF currently open but the user does not know this.