### PR TITLE
docs: Fix simple typo, occurences -> occurrences

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1159,7 +1159,7 @@ function buildLib(defines, dir) {
   // require with __webpack_require__. When we want to use the real require,
   // __non_webpack_require__ has to be used.
   // In this target, we don't create a bundle, so we have to replace the
-  // occurences of __non_webpack_require__ ourselves.
+  // occurrences of __non_webpack_require__ ourselves.
   function babelPluginReplaceNonWebPackRequire(babel) {
     return {
       visitor: {

--- a/systemjs.config.js
+++ b/systemjs.config.js
@@ -44,7 +44,7 @@
   // require with __webpack_require__. When we want to use the real require,
   // __non_webpack_require__ has to be used.
   // In this target, we don't create a bundle, so we have to replace the
-  // occurences of __non_webpack_require__ ourselves.
+  // occurrences of __non_webpack_require__ ourselves.
   function babelPluginReplaceNonWebPackRequire(babel) {
     return {
       visitor: {


### PR DESCRIPTION
There is a small typo in gulpfile.js, systemjs.config.js.

Should read `occurrences` rather than `occurences`.

