### PR TITLE
Avoid reading the "disablePreferences"/"locale" options, when initializing the viewer, in extension builds

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -229,7 +229,11 @@ const PDFViewerApplication = {
    * @private
    */
   async _readPreferences() {
-    if (AppOptions.get("disablePreferences") === true) {
+    if (
+      (typeof PDFJSDev === "undefined" ||
+        PDFJSDev.test("!PRODUCTION || GENERIC")) &&
+      AppOptions.get("disablePreferences")
+    ) {
       // Give custom implementations of the default viewer a simpler way to
       // opt-out of having the `Preferences` override existing `AppOptions`.
       return;
@@ -328,9 +332,11 @@ const PDFViewerApplication = {
    * @private
    */
   async _initializeL10n() {
-    this.l10n = this.externalServices.createL10n({
-      locale: AppOptions.get("locale"),
-    });
+    this.l10n = this.externalServices.createL10n(
+      typeof PDFJSDev === "undefined" || PDFJSDev.test("!PRODUCTION || GENERIC")
+        ? { locale: AppOptions.get("locale") }
+        : null
+    );
     const dir = await this.l10n.getDirection();
     document.getElementsByTagName("html")[0].dir = dir;
   },

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -53,14 +53,14 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
+  /**
+   * The `disablePreferences` is, conditionally, defined below.
+   */
   enablePermissions: {
     /** @type {boolean} */
     value: false,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
-  /**
-   * The `disablePreferences` is, conditionally, defined below.
-   */
   enablePrintAutoRotate: {
     /** @type {boolean} */
     value: false,
@@ -110,9 +110,11 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
-  /**
-   * The `printResolution` is, conditionally, defined below.
-   */
+  printResolution: {
+    /** @type {number} */
+    value: 150,
+    kind: OptionKind.VIEWER,
+  },
   renderer: {
     /** @type {string} */
     value: "canvas",
@@ -250,11 +252,6 @@ if (
   defaultOptions.locale = {
     /** @type {string} */
     value: typeof navigator !== "undefined" ? navigator.language : "en-US",
-    kind: OptionKind.VIEWER,
-  };
-  defaultOptions.printResolution = {
-    /** @type {number} */
-    value: 150,
     kind: OptionKind.VIEWER,
   };
 }


### PR DESCRIPTION
These two `AppOptions` are only defined in GENERIC builds, hence it's completely unnecessary to check them in the extension builds (e.g. MOZCENTRAL and CHROME).

Also, simply let the "printResolution" option be defined in all builds since it's being accessed in `web/firefox_print_service.js` as well.