### PR TITLE
Use Node LTS releases to fix Travis CI builds (issue 10790)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - node
+  - lts/*
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
Hopefully we don't need the *latest* Node.js releases for the unit-tests to work on Travis, and by using "long-term support" releases instead we should be able to avoid these types of sudden failures in the future as well.

Fixes #10790