### PR TITLE
Preserve error types during translation

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -817,7 +817,7 @@ const PDFViewerApplication = {
 
         return loadingErrorMessage.then(msg => {
           this.error(msg, { message });
-          throw new Error(msg);
+          throw exception;
         });
       }
     );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #11658 
| License       | Apache License 2.0

By preserving the exception type, more fine-grained error handling can be performed via client-side logic (e.g. redirect to a search page if a PDF is not found, or to a ticket system in case of invalid PDF files).

The original exception type and its properties (e.g. status code) are preserved by cloning the error object and assigning the translated message. Note that only a shallow clone is performed for simplicity.

Fixes #11658