### PR TITLE
[api-minor] Change `PageViewport` to throw when the `rotation` is not a multiple of 90 degrees

### DIFF
--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -245,13 +245,16 @@ class PageViewport {
         rotateC = -1;
         rotateD = 0;
         break;
-      // case 0:
-      default:
+      case 0:
         rotateA = 1;
         rotateB = 0;
         rotateC = 0;
         rotateD = -1;
         break;
+      default:
+        throw new Error(
+          "PageViewport: Invalid rotation, must be a multiple of 90 degrees."
+        );
     }
 
     if (dontFlip) {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1427,6 +1427,16 @@ describe("api", function () {
       expect(viewport.transform).toEqual([1, 0, 0, -1, 0, 841.89]);
       expect(dontFlipViewport.transform).toEqual([1, 0, -0, 1, 0, 0]);
     });
+    it("gets viewport with invalid rotation", function () {
+      expect(function () {
+        page.getViewport({ scale: 1, rotation: 45 });
+      }).toThrow(
+        new Error(
+          "PageViewport: Invalid rotation, must be a multiple of 90 degrees."
+        )
+      );
+    });
+
     it("gets annotations", function (done) {
       var defaultPromise = page.getAnnotations().then(function (data) {
         expect(data.length).toEqual(4);


### PR DESCRIPTION
As evident from the code, `PageViewport` only supports[1] `rotation` values which are a multiple of 90 degrees. Besides it being somewhat difficult to imagine meaningful use-cases for a non-multiple of 90 degrees `rotation`, the code also becomes both simpler and more efficient by not having to consider arbitrary `rotation` values.

However, any invalid rotation will *silently* fallback to assume zero `rotation` which probably isn't great for e.g. `PDFPageProxy.getViewport` in the API. Hence this patch, which will now enforce that only valid `rotation` values are accepted.

---
[1] As far as I can tell, from looking through the history, nothing else has ever been supported either.