### PR TITLE
Always attempt to dispatch the "webviewerloaded" event at the embedding `document` (PR 10318 follow-up, issue 11829)

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -211,8 +211,20 @@ function webViewerLoad() {
       // set various `AppOptions`, by dispatching an event once all viewer
       // files are loaded but *before* the viewer initialization has run.
       const event = document.createEvent("CustomEvent");
-      event.initCustomEvent("webviewerloaded", true, true, {});
-      document.dispatchEvent(event);
+      event.initCustomEvent("webviewerloaded", true, true, {
+        source: window,
+      });
+      try {
+        // Attempt to dispatch the event at the embedding `document`,
+        // in order to support cases where the viewer is embedded in
+        // a *dynamically* created <iframe> element.
+        parent.document.dispatchEvent(event);
+      } catch (ex) {
+        // The viewer could be in e.g. a cross-origin <iframe> element,
+        // fallback to dispatching the event at the current `document`.
+        console.error(`webviewerloaded: ${ex}`);
+        document.dispatchEvent(event);
+      }
     }
 
     pdfjsWebApp.PDFViewerApplication.run(config);


### PR DESCRIPTION
This is necessary in order to support cases where the default viewer is embedded in a *dynamically* created <iframe> element.

In order to also support a use-case where there's *multiple* <iframe> elements (containing default viewers) on the same page, the "webviewerloaded" event now includes a `source` detail parameter such that it's possible to associate an event with the relevant DOM element.

Fixes #11829