### PR TITLE
Move the `maybeValidDimensions` check, used with JPEG images, to occur earlier (PR 11523 follow-up)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -549,13 +549,13 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         !softMask &&
         !mask &&
         image instanceof JpegStream &&
+        image.maybeValidDimensions &&
         NativeImageDecoder.isSupported(
           image,
           this.xref,
           resources,
           this.pdfFunctionFactory
-        ) &&
-        image.maybeValidDimensions
+        )
       ) {
         // These JPEGs don't need any more processing so we can just send it.
         return this.handler

--- a/src/core/image_utils.js
+++ b/src/core/image_utils.js
@@ -36,13 +36,13 @@ class NativeImageDecoder {
   canDecode(image) {
     return (
       image instanceof JpegStream &&
+      image.maybeValidDimensions &&
       NativeImageDecoder.isDecodable(
         image,
         this.xref,
         this.resources,
         this.pdfFunctionFactory
-      ) &&
-      image.maybeValidDimensions
+      )
     );
   }
 


### PR DESCRIPTION
Given that the `NativeImageDecoder.{isSupported, isDecodable}` methods require both dictionary lookups *and* ColorSpace parsing, in hindsight it actually seems more reasonable to the `JpegStream.maybeValidDimensions` checks *first*.