### PR TITLE
Gracefully handle annotation parsing errors in `Page.getOperatorList` (issue 11871)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -302,11 +302,15 @@ class Page {
         for (const annotation of annotations) {
           if (isAnnotationRenderable(annotation, intent)) {
             opListPromises.push(
-              annotation.getOperatorList(
-                partialEvaluator,
-                task,
-                renderInteractiveForms
-              )
+              annotation
+                .getOperatorList(partialEvaluator, task, renderInteractiveForms)
+                .catch(function (reason) {
+                  warn(
+                    "getOperatorList - ignoring annotation data during " +
+                      `"${task.name}" task: "${reason}".`
+                  );
+                  return null;
+                })
             );
           }
         }

--- a/src/core/operator_list.js
+++ b/src/core/operator_list.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { assert, ImageKind, OPS } from "../shared/util.js";
+import { assert, ImageKind, OPS, warn } from "../shared/util.js";
 
 var QueueOptimizer = (function QueueOptimizerClosure() {
   function addState(parentState, pattern, checkFn, iterateFn, processFn) {
@@ -674,6 +674,10 @@ var OperatorList = (function OperatorListClosure() {
     },
 
     addOpList(opList) {
+      if (!(opList instanceof OperatorList)) {
+        warn('addOpList - ignoring invalid "opList" parameter.');
+        return;
+      }
       Object.assign(this.dependencies, opList.dependencies);
       for (var i = 0, ii = opList.length; i < ii; i++) {
         this.addOp(opList.fnArray[i], opList.argsArray[i]);

--- a/test/pdfs/issue11871.pdf.link
+++ b/test/pdfs/issue11871.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/4575091/bugdoc.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1134,6 +1134,15 @@
        "link": true,
        "type": "eq"
     },
+    {  "id": "issue11871",
+       "file": "pdfs/issue11871.pdf",
+       "md5": "9c533eacd0ca892df4191360848668a2",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 2,
+       "lastPage": 2,
+       "type": "eq"
+    },
     {  "id": "bug1252420",
        "file": "pdfs/bug1252420.pdf",
        "md5": "f21c911b9b655972b06ef782a1fa6a17",


### PR DESCRIPTION
This should ensure that a page will always render successfully, even if there's errors during the Annotation fetching/parsing.
Additionally the `OperatorList.addOpList` method is also adjusted to ignore invalid data, to make it slightly more robust.

Fixes #11871