### PR TITLE
Enable the ESLint `grouped-accessor-pairs` rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -77,6 +77,7 @@
     "curly": ["error", "all"],
     "dot-notation": "error",
     "eqeqeq": ["error", "always"],
+    "grouped-accessor-pairs": ["error", "getBeforeSet"],
     "no-caller": "error",
     "no-else-return": "error",
     "no-empty-pattern": "error",

--- a/examples/mobile-viewer/viewer.js
+++ b/examples/mobile-viewer/viewer.js
@@ -312,12 +312,12 @@ var PDFViewerApplication = {
     return this.pdfDocument.numPages;
   },
 
-  set page(val) {
-    this.pdfViewer.currentPageNumber = val;
-  },
-
   get page() {
     return this.pdfViewer.currentPageNumber;
+  },
+
+  set page(val) {
+    this.pdfViewer.currentPageNumber = val;
   },
 
   zoomIn: function pdfViewZoomIn(ticks) {

--- a/web/app.js
+++ b/web/app.js
@@ -531,12 +531,12 @@ const PDFViewerApplication = {
     return this.pdfDocument ? this.pdfDocument.numPages : 0;
   },
 
-  set page(val) {
-    this.pdfViewer.currentPageNumber = val;
-  },
-
   get page() {
     return this.pdfViewer.currentPageNumber;
+  },
+
+  set page(val) {
+    this.pdfViewer.currentPageNumber = val;
   },
 
   get printing() {


### PR DESCRIPTION
This rule complements the existing `accessor-pairs` nicely, and ensures that a getter/setter pair is always consistently ordered.

Please find additional details about this rule at https://eslint.org/docs/rules/grouped-accessor-pairs