### PR TITLE
#11858 Minified build for older browsers called minified-es5

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -943,12 +943,12 @@ gulp.task(
 
 gulp.task("minified", gulp.series("minified-post"));
 
-gulp.task("minifined-es5-config", function(done) {
+gulp.task("minifined-es5-config", function (done) {
   DEFINES.SKIP_BABEL = false;
   done();
 });
 
-gulp.task("minified-es5", gulp.series("minifined-es5-config","minified-post"));
+gulp.task("minified-es5", gulp.series("minifined-es5-config", "minified-post"));
 
 function preprocessDefaultPreferences(content) {
   var preprocessor2 = require("./external/builder/preprocessor2.js");

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -943,6 +943,13 @@ gulp.task(
 
 gulp.task("minified", gulp.series("minified-post"));
 
+gulp.task("minifined-es5-config", function(done) {
+  DEFINES.SKIP_BABEL = false;
+  done();
+});
+
+gulp.task("minified-es5", gulp.series("minifined-es5-config","minified-post"));
+
 function preprocessDefaultPreferences(content) {
   var preprocessor2 = require("./external/builder/preprocessor2.js");
   var licenseHeader = fs.readFileSync("./src/license_header.js").toString();


### PR DESCRIPTION
**Developer Comment**

- Add new gulp task to support older browsers.
- New gulp taks name as `minified-es5`