### PR TITLE
Add a `minified-es5` gulp task (issue 11858)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -57,6 +57,7 @@ var COMPONENTS_ES5_DIR = BUILD_DIR + "components-es5/";
 var IMAGE_DECODERS_DIR = BUILD_DIR + "image_decoders";
 var DEFAULT_PREFERENCES_DIR = BUILD_DIR + "default_preferences/";
 var MINIFIED_DIR = BUILD_DIR + "minified/";
+var MINIFIED_ES5_DIR = BUILD_DIR + "minified-es5/";
 var JSDOC_BUILD_DIR = BUILD_DIR + "jsdoc/";
 var GH_PAGES_DIR = BUILD_DIR + "gh-pages/";
 var SRC_DIR = "src/";
@@ -828,6 +829,45 @@ gulp.task(
   })
 );
 
+function buildMinified(defines, dir) {
+  rimraf.sync(dir);
+
+  return merge([
+    createMainBundle(defines).pipe(gulp.dest(dir + "build")),
+    createWorkerBundle(defines).pipe(gulp.dest(dir + "build")),
+    createWebBundle(defines).pipe(gulp.dest(dir + "web")),
+    createImageDecodersBundle(
+      builder.merge(defines, { IMAGE_DECODERS: true })
+    ).pipe(gulp.dest(dir + "image_decoders")),
+    gulp.src(COMMON_WEB_FILES, { base: "web/" }).pipe(gulp.dest(dir + "web")),
+    gulp
+      .src(["web/locale/*/viewer.properties", "web/locale/locale.properties"], {
+        base: "web/",
+      })
+      .pipe(gulp.dest(dir + "web")),
+    gulp
+      .src(["external/bcmaps/*.bcmap", "external/bcmaps/LICENSE"], {
+        base: "external/bcmaps",
+      })
+      .pipe(gulp.dest(dir + "web/cmaps")),
+
+    preprocessHTML("web/viewer.html", defines).pipe(gulp.dest(dir + "web")),
+    preprocessCSS("web/viewer.css", "minified", defines, true)
+      .pipe(
+        postcss([
+          cssvariables(CSS_VARIABLES_CONFIG),
+          calc(),
+          autoprefixer(AUTOPREFIXER_CONFIG),
+        ])
+      )
+      .pipe(gulp.dest(dir + "web")),
+
+    gulp
+      .src("web/compressed.tracemonkey-pldi-09.pdf")
+      .pipe(gulp.dest(dir + "web")),
+  ]);
+}
+
 gulp.task(
   "minified-pre",
   gulp.series("buildnumber", "default_preferences", "locale", function () {
@@ -835,113 +875,85 @@ gulp.task(
     console.log("### Creating minified viewer");
     var defines = builder.merge(DEFINES, { MINIFIED: true, GENERIC: true });
 
-    rimraf.sync(MINIFIED_DIR);
-
-    return merge([
-      createMainBundle(defines).pipe(gulp.dest(MINIFIED_DIR + "build")),
-      createWorkerBundle(defines).pipe(gulp.dest(MINIFIED_DIR + "build")),
-      createWebBundle(defines).pipe(gulp.dest(MINIFIED_DIR + "web")),
-      createImageDecodersBundle(
-        builder.merge(defines, { IMAGE_DECODERS: true })
-      ).pipe(gulp.dest(MINIFIED_DIR + "image_decoders")),
-      gulp
-        .src(COMMON_WEB_FILES, { base: "web/" })
-        .pipe(gulp.dest(MINIFIED_DIR + "web")),
-      gulp
-        .src(
-          ["web/locale/*/viewer.properties", "web/locale/locale.properties"],
-          { base: "web/" }
-        )
-        .pipe(gulp.dest(MINIFIED_DIR + "web")),
-      gulp
-        .src(["external/bcmaps/*.bcmap", "external/bcmaps/LICENSE"], {
-          base: "external/bcmaps",
-        })
-        .pipe(gulp.dest(MINIFIED_DIR + "web/cmaps")),
-
-      preprocessHTML("web/viewer.html", defines).pipe(
-        gulp.dest(MINIFIED_DIR + "web")
-      ),
-      preprocessCSS("web/viewer.css", "minified", defines, true)
-        .pipe(
-          postcss([
-            cssvariables(CSS_VARIABLES_CONFIG),
-            calc(),
-            autoprefixer(AUTOPREFIXER_CONFIG),
-          ])
-        )
-        .pipe(gulp.dest(MINIFIED_DIR + "web")),
-
-      gulp
-        .src("web/compressed.tracemonkey-pldi-09.pdf")
-        .pipe(gulp.dest(MINIFIED_DIR + "web")),
-    ]);
+    return buildMinified(defines, MINIFIED_DIR);
   })
 );
 
 gulp.task(
-  "minified-post",
+  "minified-es5-pre",
+  gulp.series("buildnumber", "default_preferences", "locale", function () {
+    console.log();
+    console.log("### Creating minified (ES5) viewer");
+    var defines = builder.merge(DEFINES, {
+      MINIFIED: true,
+      GENERIC: true,
+      SKIP_BABEL: false,
+    });
+
+    return buildMinified(defines, MINIFIED_ES5_DIR);
+  })
+);
+
+function parseMinified(dir) {
+  var pdfFile = fs.readFileSync(dir + "/build/pdf.js").toString();
+  var pdfWorkerFile = fs.readFileSync(dir + "/build/pdf.worker.js").toString();
+  var pdfImageDecodersFile = fs
+    .readFileSync(dir + "/image_decoders/pdf.image_decoders.js")
+    .toString();
+  var viewerFiles = {
+    "pdf.js": pdfFile,
+    "viewer.js": fs.readFileSync(dir + "/web/viewer.js").toString(),
+  };
+
+  console.log();
+  console.log("### Minifying js files");
+
+  var Terser = require("terser");
+  // V8 chokes on very long sequences. Works around that.
+  var optsForHugeFile = { compress: { sequences: false } };
+
+  fs.writeFileSync(dir + "/web/pdf.viewer.js", Terser.minify(viewerFiles).code);
+  fs.writeFileSync(dir + "/build/pdf.min.js", Terser.minify(pdfFile).code);
+  fs.writeFileSync(
+    dir + "/build/pdf.worker.min.js",
+    Terser.minify(pdfWorkerFile, optsForHugeFile).code
+  );
+  fs.writeFileSync(
+    dir + "image_decoders/pdf.image_decoders.min.js",
+    Terser.minify(pdfImageDecodersFile).code
+  );
+
+  console.log();
+  console.log("### Cleaning js files");
+
+  fs.unlinkSync(dir + "/web/viewer.js");
+  fs.unlinkSync(dir + "/web/debugger.js");
+  fs.unlinkSync(dir + "/build/pdf.js");
+  fs.unlinkSync(dir + "/build/pdf.worker.js");
+
+  fs.renameSync(dir + "/build/pdf.min.js", dir + "/build/pdf.js");
+  fs.renameSync(dir + "/build/pdf.worker.min.js", dir + "/build/pdf.worker.js");
+  fs.renameSync(
+    dir + "/image_decoders/pdf.image_decoders.min.js",
+    dir + "/image_decoders/pdf.image_decoders.js"
+  );
+}
+
+gulp.task(
+  "minified",
   gulp.series("minified-pre", function (done) {
-    var pdfFile = fs.readFileSync(MINIFIED_DIR + "/build/pdf.js").toString();
-    var pdfWorkerFile = fs
-      .readFileSync(MINIFIED_DIR + "/build/pdf.worker.js")
-      .toString();
-    var pdfImageDecodersFile = fs
-      .readFileSync(MINIFIED_DIR + "/image_decoders/pdf.image_decoders.js")
-      .toString();
-    var viewerFiles = {
-      "pdf.js": pdfFile,
-      "viewer.js": fs.readFileSync(MINIFIED_DIR + "/web/viewer.js").toString(),
-    };
-
-    console.log();
-    console.log("### Minifying js files");
-
-    var Terser = require("terser");
-    // V8 chokes on very long sequences. Works around that.
-    var optsForHugeFile = { compress: { sequences: false } };
-
-    fs.writeFileSync(
-      MINIFIED_DIR + "/web/pdf.viewer.js",
-      Terser.minify(viewerFiles).code
-    );
-    fs.writeFileSync(
-      MINIFIED_DIR + "/build/pdf.min.js",
-      Terser.minify(pdfFile).code
-    );
-    fs.writeFileSync(
-      MINIFIED_DIR + "/build/pdf.worker.min.js",
-      Terser.minify(pdfWorkerFile, optsForHugeFile).code
-    );
-    fs.writeFileSync(
-      MINIFIED_DIR + "image_decoders/pdf.image_decoders.min.js",
-      Terser.minify(pdfImageDecodersFile).code
-    );
-
-    console.log();
-    console.log("### Cleaning js files");
-
-    fs.unlinkSync(MINIFIED_DIR + "/web/viewer.js");
-    fs.unlinkSync(MINIFIED_DIR + "/web/debugger.js");
-    fs.unlinkSync(MINIFIED_DIR + "/build/pdf.js");
-    fs.unlinkSync(MINIFIED_DIR + "/build/pdf.worker.js");
-    fs.renameSync(
-      MINIFIED_DIR + "/build/pdf.min.js",
-      MINIFIED_DIR + "/build/pdf.js"
-    );
-    fs.renameSync(
-      MINIFIED_DIR + "/build/pdf.worker.min.js",
-      MINIFIED_DIR + "/build/pdf.worker.js"
-    );
-    fs.renameSync(
-      MINIFIED_DIR + "/image_decoders/pdf.image_decoders.min.js",
-      MINIFIED_DIR + "/image_decoders/pdf.image_decoders.js"
-    );
+    parseMinified(MINIFIED_DIR);
     done();
   })
 );
 
-gulp.task("minified", gulp.series("minified-post"));
+gulp.task(
+  "minified-es5",
+  gulp.series("minified-es5-pre", function (done) {
+    parseMinified(MINIFIED_ES5_DIR);
+    done();
+  })
+);
 
 function preprocessDefaultPreferences(content) {
   var preprocessor2 = require("./external/builder/preprocessor2.js");

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -90,7 +90,7 @@ var CSS_VARIABLES_CONFIG = {
   preserve: true,
 };
 
-var DEFINES = {
+const DEFINES = Object.freeze({
   PRODUCTION: true,
   SKIP_BABEL: true,
   TESTING: false,
@@ -102,7 +102,7 @@ var DEFINES = {
   COMPONENTS: false,
   LIB: false,
   IMAGE_DECODERS: false,
-};
+});
 
 function transform(charEncoding, transformFunction) {
   return through.obj(function (vinylFile, enc, done) {


### PR DESCRIPTION
 -  Ensure that the `DEFINES` build target constants, in `gulpfile.js`, cannot be changed

 - Add a `minified-es5` gulp task (issue 11858)

   By re-factoring the existing gulp tasks, most of the code can be re-used for both the existing `gulp minified` as well as the new `gulp minified-es5` task.

Fixes #11858

*Smaller diff with https://github.com/mozilla/pdf.js/pull/11892/files?w=1*
