### PR TITLE
Reduce the usage of `require` statements in code-paths not protected by pre-processor and/or run-time checks

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -678,7 +678,7 @@ function isMessagePort(maybePort) {
   );
 }
 
-// Worker thread (and not node.js)?
+// Worker thread (and not Node.js)?
 if (
   typeof window === "undefined" &&
   !isNodeJS &&

--- a/src/display/api_compatibility.js
+++ b/src/display/api_compatibility.js
@@ -13,10 +13,10 @@
  * limitations under the License.
  */
 
+import { isNodeJS } from "../shared/is_node.js";
+
 const compatibilityParams = Object.create(null);
 if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-  const { isNodeJS } = require("../shared/is_node.js");
-
   const userAgent =
     (typeof navigator !== "undefined" && navigator.userAgent) || "";
   const isIE = /Trident/.test(userAgent);
@@ -41,5 +41,6 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
     }
   })();
 }
+const apiCompatibilityParams = Object.freeze(compatibilityParams);
 
-exports.apiCompatibilityParams = Object.freeze(compatibilityParams);
+export { apiCompatibilityParams };

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -14,6 +14,8 @@
  */
 /* eslint no-var: error */
 
+import { isNodeJS } from "./is_node.js";
+
 // Skip compatibility checks for modern builds and if we already ran the module.
 if (
   (typeof PDFJSDev === "undefined" || !PDFJSDev.test("SKIP_BABEL")) &&
@@ -26,8 +28,6 @@ if (
     globalThis = require("core-js/es/global-this");
   }
   globalThis._pdfjsCompatibilityChecked = true;
-
-  const { isNodeJS } = require("./is_node.js");
 
   const hasDOM = typeof window === "object" && typeof document === "object";
   const userAgent =
@@ -248,14 +248,17 @@ if (
 
   // Support: IE
   (function checkURL() {
-    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("IMAGE_DECODERS")) {
-      // The current image decoders don't use the `URL` constructor, so it
-      // doesn't need to be polyfilled for the IMAGE_DECODERS build target.
+    if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
+      // Prevent "require is not a function" errors in development mode,
+      // since the `URL` constructor should be available in modern browers.
       return;
-    }
-    if (typeof PDFJSDev !== "undefined" && !PDFJSDev.test("GENERIC")) {
+    } else if (!PDFJSDev.test("GENERIC")) {
       // The `URL` constructor is assumed to be available in the extension
       // builds.
+      return;
+    } else if (PDFJSDev.test("IMAGE_DECODERS")) {
+      // The current image decoders don't use the `URL` constructor, so it
+      // doesn't need to be polyfilled for the IMAGE_DECODERS build target.
       return;
     }
     globalThis.URL = require("core-js/web/url.js");

--- a/web/viewer_compatibility.js
+++ b/web/viewer_compatibility.js
@@ -35,5 +35,6 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
     }
   })();
 }
+const viewerCompatibilityParams = Object.freeze(compatibilityParams);
 
-exports.viewerCompatibilityParams = Object.freeze(compatibilityParams);
+export { viewerCompatibilityParams };


### PR DESCRIPTION
This replaces some additional `require`/`exports` usage with standard `import`/`export` statements instead.
Hence another, small, part in the effort to reduce the reliance on SystemJS-specific functionality in the development viewer.