### PR TITLE
Minimal attempt to fix #8408

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -607,6 +607,9 @@ var renderTextLayer = (function renderTextLayerClosure() {
       }
       this._textDivProperties.set(textDiv, textDivProperties);
       this._container.appendChild(textDiv);
+      if (window.chrome) {
+        this._container.appendChild(document.createElement("br"));
+      }
     },
 
     _render: function TextLayer_render(timeout) {


### PR DESCRIPTION
Added a line break after every text element to prevent Chrome from thinking that the lines are connected.
I'm not familiar with this project so I'm not sure if this is a good implementation, but #8408 should be easy to solve with any similar idea.