### PR TITLE
Remove the SystemJS dependency from the `web/preferences.js` file

### DIFF
--- a/web/preferences.js
+++ b/web/preferences.js
@@ -13,23 +13,19 @@
  * limitations under the License.
  */
 
+import { AppOptions, OptionKind } from "./app_options.js";
+
 let defaultPreferences = null;
 function getDefaultPreferences() {
   if (!defaultPreferences) {
-    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("PRODUCTION")) {
+    if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
+      defaultPreferences = Promise.resolve(
+        AppOptions.getAll(OptionKind.PREFERENCE)
+      );
+    } else {
       defaultPreferences = Promise.resolve(
         PDFJSDev.json("$ROOT/build/default_preferences.json")
       );
-    } else {
-      defaultPreferences = new Promise(function (resolve, reject) {
-        if (typeof SystemJS === "object") {
-          SystemJS.import("./app_options.js").then(resolve, reject);
-        } else {
-          reject(new Error("SystemJS must be used to load AppOptions."));
-        }
-      }).then(function ({ AppOptions, OptionKind }) {
-        return AppOptions.getAll(OptionKind.PREFERENCE);
-      });
     }
   }
   return defaultPreferences;


### PR DESCRIPTION
Originally the `default_preferences.json` file was checked into the repository, and we thus needed to load it in non-PRODUCTION mode (which was originally done asynchronously using `XMLHttpRequest`). Over the years a lot has changed and the `default_preferences.json` file is now built, by the `gulp default_preferences` task, from the `web/app_options.js` file. Hence it's no longer necessary, in non-PRODUCTION mode, to use SystemJS here since we can simply use a standard `import` statement instead.

Note how e.g. `web/app.js` already imports from `web/app_options.js` in the same exact way that `web/preferences.js` now does, hence this patch will *not* result in any significant changes in the built/bundled viewer file.

This is another (small) part in trying to reduce usage of SystemJS, with the goal of hopefully getting rid of it completely. (I've started working on this, and doing so has identified a number of problem areas; this patch addresses one of them.)