### PR TITLE
Attempt to cache repeated images at the document, rather than the page, level (issue 11878)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -74,6 +74,7 @@ class Page {
     ref,
     fontCache,
     builtInCMapCache,
+    globalImageCache,
     pdfFunctionFactory,
   }) {
     this.pdfManager = pdfManager;
@@ -83,6 +84,7 @@ class Page {
     this.ref = ref;
     this.fontCache = fontCache;
     this.builtInCMapCache = builtInCMapCache;
+    this.globalImageCache = globalImageCache;
     this.pdfFunctionFactory = pdfFunctionFactory;
     this.evaluatorOptions = pdfManager.evaluatorOptions;
     this.resourcesPromise = null;
@@ -261,6 +263,7 @@ class Page {
       idFactory: this.idFactory,
       fontCache: this.fontCache,
       builtInCMapCache: this.builtInCMapCache,
+      globalImageCache: this.globalImageCache,
       options: this.evaluatorOptions,
       pdfFunctionFactory: this.pdfFunctionFactory,
     });
@@ -354,6 +357,7 @@ class Page {
         idFactory: this.idFactory,
         fontCache: this.fontCache,
         builtInCMapCache: this.builtInCMapCache,
+        globalImageCache: this.globalImageCache,
         options: this.evaluatorOptions,
         pdfFunctionFactory: this.pdfFunctionFactory,
       });
@@ -816,6 +820,7 @@ class PDFDocument {
         ref,
         fontCache: catalog.fontCache,
         builtInCMapCache: catalog.builtInCMapCache,
+        globalImageCache: catalog.globalImageCache,
         pdfFunctionFactory: this.pdfFunctionFactory,
       });
     }));

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -54,6 +54,7 @@ import {
 } from "./core_utils.js";
 import { CipherTransformFactory } from "./crypto.js";
 import { ColorSpace } from "./colorspace.js";
+import { GlobalImageCache } from "./image_utils.js";
 
 function fetchDestination(dest) {
   return isDict(dest) ? dest.get("D") : dest;
@@ -71,6 +72,7 @@ class Catalog {
 
     this.fontCache = new RefSetCache();
     this.builtInCMapCache = new Map();
+    this.globalImageCache = new GlobalImageCache();
     this.pageKidsCountCache = new RefSetCache();
   }
 
@@ -716,6 +718,7 @@ class Catalog {
 
   cleanup() {
     clearPrimitiveCaches();
+    this.globalImageCache.clear();
     this.pageKidsCountCache.clear();
 
     const promises = [];

--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -251,6 +251,10 @@ var RefSetCache = (function RefSetCacheClosure() {
   }
 
   RefSetCache.prototype = {
+    get size() {
+      return Object.keys(this.dict).length;
+    },
+
     get: function RefSetCache_get(ref) {
       return this.dict[ref.toString()];
     },

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2288,6 +2288,7 @@ class WorkerTransport {
           break;
         case "FontPath":
         case "FontType3Res":
+        case "Image":
           this.commonObjs.resolve(id, exportedData);
           break;
         default:

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -2114,7 +2114,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     },
 
     paintJpegXObject: function CanvasGraphics_paintJpegXObject(objId, w, h) {
-      const domImage = this.processingType3
+      const domImage = objId.startsWith("g_")
         ? this.commonObjs.get(objId)
         : this.objs.get(objId);
       if (!domImage) {
@@ -2277,7 +2277,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     },
 
     paintImageXObject: function CanvasGraphics_paintImageXObject(objId) {
-      const imgData = this.processingType3
+      const imgData = objId.startsWith("g_")
         ? this.commonObjs.get(objId)
         : this.objs.get(objId);
       if (!imgData) {
@@ -2294,7 +2294,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       scaleY,
       positions
     ) {
-      const imgData = this.processingType3
+      const imgData = objId.startsWith("g_")
         ? this.commonObjs.get(objId)
         : this.objs.get(objId);
       if (!imgData) {

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -90,6 +90,7 @@
 !issue11362.pdf
 !issue11578_reduced.pdf
 !issue11651.pdf
+!issue11878.pdf
 !bad-PageLabels.pdf
 !decodeACSuccessive.pdf
 !filled-background.pdf


### PR DESCRIPTION
Currently image resources, as opposed to e.g. font resources, are handled exclusively on a page-specific basis. Generally speaking this makes sense, since pages are separate from each other, however there's PDF documents where many (or even all) pages actually references exactly the image resources (through the XRef table). Hence, in some cases, we're decoding the *same* images over and over for every page which is obviously slow and wasting both CPU and memory resources better used elsewhere.[1]

Obviously we cannot simply treat all image resources as-if they're used throughout the entire PDF document, since that would end up increasing memory usage too much.[2]
However, by introducing a `GlobalImageCache` in the worker we can track image resources that appear on more than one page. Hence we can switch image resources from being page-specific to being document-specific, once the image resource has been seen on more than a certain number of pages.

In many cases, such as e.g. the referenced issue, this patch will thus lead to reduced memory usage for image resources. Scrolling through all pages of the document, there's now only a few main-thread copies of the same image data, as opposed to one for each rendered page (i.e. there could theoretically be *twenty* copies of the image data).
While this obviously benefit both CPU and memory usage in this case, for *very* large image data this patch *may* possibly increase persistent main-thread memory usage a tiny bit. Thus to avoid negatively affecting memory usage too much in general, particularly on the main-thread, the `GlobalImageCache` will *only* cache a certain number of image resources at the document level and simply fallback to the default behaviour.

Unfortunately the asynchronous nature of the code, with ranged/streamed loading of data, actually makes all of this much more complicated than if all data could be assumed to be immediately available.[3]

*Please note:* The patch will lead to *small* movement in some existing test-cases, since we're now using the built-in PDF.js JPEG decoder more. This was done in order to simplify the overall implementation, especially on the main-thread, by limiting it to only the `OPS.paintImageXObject` operator.

Fixes #11878 (and probably a few more issues/bugs).

Also *slightly* improves cases such e.g. issue #11518, issue #11612, and [bug 1536420](https://bugzilla.mozilla.org/show_bug.cgi?id=1536420)

---
[1] There's e.g. PDF documents that use the same image as background on all pages.

[2] Given that data stored in the `commonObjs`, on the main-thread, are only cleared manually through `PDFDocumentProxy.cleanup`. This as opposed to data stored in the `objs` of each page, which is automatically removed when the page is cleaned-up e.g. by being evicted from the cache in the default viewer.

[3] If the latter case were true, we could simply check for repeat images *before* parsing started and thus avoid handling *any* duplicate image resources.