### PR TITLE
Implement fill opacity for shading patterns in the SVG back-end

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -1090,6 +1090,9 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       rect.setAttributeNS(null, "width", x1 - x0);
       rect.setAttributeNS(null, "height", y1 - y0);
       rect.setAttributeNS(null, "fill", this._makeShadingPattern(args));
+      if (this.current.fillAlpha < 1) {
+        rect.setAttributeNS(null, "fill-opacity", this.current.fillAlpha);
+      }
       this._ensureTransformGroup().appendChild(rect);
     }
 


### PR DESCRIPTION
In the PDF file from the issue below, the fill alpha (`ca`) is set before drawing the circles using the `setGState` operator. Doing so causes the global alpha to be set on the canvas' context for the canvas back-end, but this was not handled in the SVG back-end. This patch fixes that by taking the fill opacity into account when drawing shading patterns in the same way as done elsewhere so it is only included if the value is non-default.

Fixes #11812.