### PR TITLE
Add comments to the `export` list in the `src/pdf.js` file (PR 11914 follow-up)

### DIFF
--- a/src/pdf.js
+++ b/src/pdf.js
@@ -124,18 +124,21 @@ if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
 }
 
 export {
+  // From "./display/display_utils.js":
   addLinkAttributes,
   getFilenameFromUrl,
   LinkTarget,
   loadScript,
   PDFDateString,
   RenderingCancelledException,
+  // From "./display/api.js":
   build,
   getDocument,
   LoopbackPort,
   PDFDataRangeTransport,
   PDFWorker,
   version,
+  // From "./shared/util.js":
   CMapCompressionType,
   createObjectURL,
   createPromiseCapability,
@@ -151,9 +154,14 @@ export {
   UNSUPPORTED_FEATURES,
   Util,
   VerbosityLevel,
+  // From "./display/annotation_layer.js":
   AnnotationLayer,
+  // From "./display/api_compatibility.js":
   apiCompatibilityParams,
+  // From "./display/worker_options.js":
   GlobalWorkerOptions,
+  // From "./display/text_layer.js":
   renderTextLayer,
+  // From "./display/svg.js":
   SVGGraphics,
 };


### PR DESCRIPTION
When converting this file to use standard `import`/`export` statements, I sorted the exports in the same order as the imports to simplify things.

However, looking at the list of `export`ed properties it probably doesn't hurt to add a couple of comments to clarify from where specifically the `export`s originated.