### PR TITLE
Ensure that that we don't attempt to cache *inline* images in the `GlobalImageCache` (PR 11912 follow-up)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -605,6 +605,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
         });
 
         if (imageRef) {
+          assert(!isInline, "Cannot cache an inline image globally.");
           this.globalImageCache.addPageIndex(imageRef, this.pageIndex);
 
           if (cacheGlobally) {


### PR DESCRIPTION
Since *inline* images, i.e. those defined inside of `/Contents` streams, are by their very definition page-specific it thus seem like a good idea to actually enforce that they won't accidentally end up in the `GlobalImageCache`.