### PR TITLE
[api-minor] Remove the deprecated `PDFDocumentProxy.getOpenActionDestination` method (PR 11644 follow-up)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -661,13 +661,6 @@ class PDFDocumentProxy {
     return this._transport.getOpenAction();
   }
 
-  getOpenActionDestination() {
-    deprecated("getOpenActionDestination, use getOpenAction instead.");
-    return this.getOpenAction().then(function (openAction) {
-      return openAction && openAction.dest ? openAction.dest : null;
-    });
-  }
-
   /**
    * @returns {Promise} A promise that is resolved with a lookup table for
    *   mapping named attachments to their content.


### PR DESCRIPTION
This method has been printing a `deprecated` warning in two releases, hence it should hopefully be safe to remove now.