### PR TITLE
Avoid calling Math.pow if possible.

### DIFF
--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -1057,6 +1057,15 @@ const CalRGBCS = (function CalRGBCSClosure() {
     if (color <= 0.0031308) {
       return adjustToRange(0, 1, 12.92 * color);
     }
+    // Optimization:
+    // If color is close enough to 1, skip calling the following transform
+    // since calling Math.pow is expensive. If color is larger than
+    // the threshold, the final result is larger than 254.5 since
+    // ((1 + 0.055) * 0.99554525 ** (1 / 2.4) - 0.055) * 255 ===
+    // 254.50000003134699
+    if (color >= 0.99554525) {
+      return 1;
+    }
     return adjustToRange(0, 1, (1 + 0.055) * color ** (1 / 2.4) - 0.055);
   }
 
@@ -1156,9 +1165,9 @@ const CalRGBCS = (function CalRGBCSClosure() {
     // A <---> AGR in the spec
     // B <---> BGG in the spec
     // C <---> CGB in the spec
-    const AGR = A ** cs.GR;
-    const BGG = B ** cs.GG;
-    const CGB = C ** cs.GB;
+    const AGR = A === 1 ? 1 : A ** cs.GR;
+    const BGG = B === 1 ? 1 : B ** cs.GG;
+    const CGB = C === 1 ? 1 : C ** cs.GB;
 
     // Computes intermediate variables L, M, N as per spec.
     // To decode X, Y, Z values map L, M, N directly to them.


### PR DESCRIPTION
Related to #9581.

When loading a high-resolution image, I have found that the most time-consuming part is converting sRGB to RGB. Especially calling `Math.pow` is expensive. The following profile of Chrome is the one when loading the PDF file of #9581.

![スクリーンショット 2020-06-03 8 10 58](https://user-images.githubusercontent.com/10665499/83578751-8259cf00-a572-11ea-9605-93e311d91bc7.png)

![スクリーンショット 2020-06-03 8 11 41](https://user-images.githubusercontent.com/10665499/83578801-9ef60700-a572-11ea-8a87-059685db398f.png)

In this PR, we avoid calling `Math.pow` if the value of `color` is close enough to `1`. The threshold is determined to assure that the result is larger than `254.5`.

```
> ((1 + 0.055) * 0.99554525**(1/2.4) - 0.055)*255
 254.50000003134699
```

The benchmark result for the PDF file of #9581 is significant.

```
$  node stats/statcmp.js stats/results/baseline.json stats/results/current.json
-- Grouped By browser, stat --
browser | stat         | Count | Baseline(ms) | Current(ms) |    +/- |     %  | Result(P<.05)
------- | ------------ | ----- | ------------ | ----------- | ------ | ------ | -------------
chrome  | Overall      |     3 |        26821 |       11648 | -15172 | -56.57 |        faster
chrome  | Page Request |     3 |            7 |           7 |      0 |   0.00 |              
chrome  | Rendering    |     3 |        26814 |       11641 | -15173 | -56.59 |        faster
firefox | Overall      |     3 |        14270 |        9383 |  -4887 | -34.25 |        faster
firefox | Page Request |     3 |            6 |           5 |     -1 | -16.67 |              
firefox | Rendering    |     3 |        14264 |        9378 |  -4886 | -34.26 |        faster
```

One of other possible solutions is to avoid converting sRGB to RGB if not necessary. I think it is not necessary when we just display images without transparency operations. 