### PR TITLE
Fix pdfjs-dist/webpack causing errors with certain configs

### DIFF
--- a/examples/webpack/README.md
+++ b/examples/webpack/README.md
@@ -20,7 +20,12 @@ the worker code, and the `workerSrc` path shall be set to the latter file.
 
 ## Worker loading
 
-If you are getting the `Setting up fake worker` warning, make sure you are importing `pdfjs-dist/webpack` which is the zero-configuration method for Webpack users:
+If you are getting the `Setting up fake worker` warning, make sure you are
+importing `pdfjs-dist/webpack` which is the zero-configuration method for
+Webpack users. You will need to install
+[worker-loader](https://github.com/webpack-contrib/worker-loader) as a
+dependency in your project in order to use `pdfjs-dist/webpack` (configuring
+`worker-loader` is not necessary; just installing it is sufficient).
 
     import pdfjsLib from 'pdfjs-dist/webpack';
 

--- a/external/dist/webpack.js
+++ b/external/dist/webpack.js
@@ -15,14 +15,6 @@
 
 "use strict";
 
-try {
-  require.resolve("worker-loader");
-} catch (ex) {
-  throw new Error(
-    "Cannot find the `worker-loader` package, please make sure that it's correctly installed."
-  );
-}
-
 var pdfjs = require("./build/pdf.js");
 var PdfjsWorker = require("worker-loader!./build/pdf.worker.js");
 


### PR DESCRIPTION
Using `require.resolve("worker-loader")` to check if `worker-loader` is installed causes webpack to include `worker-loader` in the output bundle ([see docs](https://webpack.js.org/api/module-methods/#requireresolve)), which is not the intended effect. Aside from increasing the bundle size unnecessarily, it also causes errors for webpack configs with targets that don't have node's built-in modules.

These errors can be fixed by configuring webpack `externals` to exclude `worker-loader`, but it's more difficult to figure out this solution than to figure out that `worker-loader` needs to be installed (even without this explicit error message).

To solve this, the explicit check for `worker-loader` has been removed. An alternative solution would be to use webpack's [resolveWeak](https://webpack.js.org/api/module-methods/#requireresolveweak). Documentation has also been added in `examples/webpack` to help users.

The check was originally added in PR [#11474](https://github.com/mozilla/pdf.js/pull/11474). I've set up a minimal project to demonstrate the issue [here](https://gist.github.com/aplum/02727983e17806158337f98091382313).