### PR TITLE
A couple of small image caching/sending improvements

### DIFF
--- a/src/core/image_utils.js
+++ b/src/core/image_utils.js
@@ -107,11 +107,10 @@ class GlobalImageCache {
   }
 
   getData(ref, pageIndex) {
-    if (!this._refCache.has(ref)) {
+    const pageIndexSet = this._refCache.get(ref);
+    if (!pageIndexSet) {
       return null;
     }
-    const pageIndexSet = this._refCache.get(ref);
-
     if (pageIndexSet.size < GlobalImageCache.NUM_PAGES_THRESHOLD) {
       return null;
     }


### PR DESCRIPTION
 - Remove an unnecessary `RefSetCache.prototype.has()` call from `GlobalImageCache.getData`

   We can simply attempt to get the data *directly*, and instead check the result, rather than first checking if it exists.

 - Extract the actual sending of image data from the `PartialEvaluator.buildPaintImageXObject` method

   After PRs #10727 and #11912, the code responsible for sending the decoded image data to the main-thread has now become a fair bit more involved the previously.
   To reduce the amount of duplication here, the actual code responsible for sending the data is thus extracted into a new helper method instead.
