### PR TITLE
Update `SVGGraphics` to account for globally cached images (PR 11912 follow-up)

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -1560,7 +1560,9 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
     }
 
     paintImageXObject(objId) {
-      const imgData = this.objs.get(objId);
+      const imgData = objId.startsWith("g_")
+        ? this.commonObjs.get(objId)
+        : this.objs.get(objId);
       if (!imgData) {
         warn(`Dependent image with object ID ${objId} is not ready yet`);
         return;


### PR DESCRIPTION
Since there's (essentially) no tests for the SVG-backend, these changes didn't make in into PR #11912 when the code in the `src/display/canvas.js` file was modified.