### PR TITLE
Prevent the (old) preprocessor from appending trailing whitespace when removing closing HTML comments

### DIFF
--- a/external/builder/builder.js
+++ b/external/builder/builder.js
@@ -181,7 +181,7 @@ function preprocess(inFilename, outFilename, defines) {
         !stack.includes(STATE_IF_FALSE) &&
         !stack.includes(STATE_ELSE_FALSE)
       ) {
-        writeLine(line.replace(/^\/\/|^<!--|-->$/g, "  "));
+        writeLine(line.replace(/^\/\/|^<!--/g, "  ").replace(/-->$/g, ""));
       }
     }
   }


### PR DESCRIPTION
This can currently be seen in the *built* `web/viewer.html` file, at the line containing "  <script src="viewer.js"></script>  ".