### PR TITLE
Change the `dependencies` property, on `OperatorList` instances, from an Object to a Set

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -270,7 +270,7 @@ class Page {
 
     const dataPromises = Promise.all([contentStreamPromise, resourcesPromise]);
     const pageListPromise = dataPromises.then(([contentStream]) => {
-      const opList = new OperatorList(intent, sink, this.pageIndex);
+      const opList = new OperatorList(intent, sink);
 
       handler.send("StartRenderPage", {
         transparency: partialEvaluator.hasBlendModes(this.resources),

--- a/src/core/operator_list.js
+++ b/src/core/operator_list.js
@@ -618,7 +618,7 @@ var OperatorList = (function OperatorListClosure() {
     } else {
       this.optimizer = new NullOptimizer(this);
     }
-    this.dependencies = Object.create(null);
+    this.dependencies = new Set();
     this._totalLength = 0;
     this.weight = 0;
     this._resolved = streamSink ? null : Promise.resolve();
@@ -658,16 +658,16 @@ var OperatorList = (function OperatorListClosure() {
     },
 
     addDependency(dependency) {
-      if (dependency in this.dependencies) {
+      if (this.dependencies.has(dependency)) {
         return;
       }
-      this.dependencies[dependency] = true;
+      this.dependencies.add(dependency);
       this.addOp(OPS.dependency, [dependency]);
     },
 
     addDependencies(dependencies) {
-      for (var key in dependencies) {
-        this.addDependency(key);
+      for (const dependency of dependencies) {
+        this.addDependency(dependency);
       }
     },
 
@@ -676,7 +676,9 @@ var OperatorList = (function OperatorListClosure() {
         warn('addOpList - ignoring invalid "opList" parameter.');
         return;
       }
-      Object.assign(this.dependencies, opList.dependencies);
+      for (const dependency of opList.dependencies) {
+        this.dependencies.add(dependency);
+      }
       for (var i = 0, ii = opList.length; i < ii; i++) {
         this.addOp(opList.fnArray[i], opList.argsArray[i]);
       }
@@ -734,7 +736,7 @@ var OperatorList = (function OperatorListClosure() {
         this._transfers
       );
 
-      this.dependencies = Object.create(null);
+      this.dependencies.clear();
       this.fnArray.length = 0;
       this.argsArray.length = 0;
       this.weight = 0;

--- a/src/core/operator_list.js
+++ b/src/core/operator_list.js
@@ -609,7 +609,7 @@ var OperatorList = (function OperatorListClosure() {
   var CHUNK_SIZE_ABOUT = CHUNK_SIZE - 5; // close to chunk size
 
   // eslint-disable-next-line no-shadow
-  function OperatorList(intent, streamSink, pageIndex) {
+  function OperatorList(intent, streamSink) {
     this._streamSink = streamSink;
     this.fnArray = [];
     this.argsArray = [];
@@ -620,8 +620,6 @@ var OperatorList = (function OperatorListClosure() {
     }
     this.dependencies = Object.create(null);
     this._totalLength = 0;
-    this.pageIndex = pageIndex;
-    this.intent = intent;
     this.weight = 0;
     this._resolved = streamSink ? null : Promise.resolve();
   }


### PR DESCRIPTION
Since this is completely internal functionality, and furthermore limited to the worker-thread, this change should thus not have any observable effect for e.g. an API-user.

