### PR TITLE
Add basic support for the nullish coalescing operator `??`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -215,6 +215,12 @@ function createWebpackConfig(defines, output) {
           options: {
             presets: skipBabel ? undefined : ["@babel/preset-env"],
             plugins: [
+              [
+                "@babel/plugin-proposal-nullish-coalescing-operator",
+                {
+                  loose: true,
+                },
+              ],
               "@babel/plugin-transform-modules-commonjs",
               [
                 "@babel/plugin-transform-runtime",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "devDependencies": {
     "@babel/core": "^7.10.1",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.1",
     "@babel/plugin-transform-modules-commonjs": "^7.10.1",
     "@babel/plugin-transform-runtime": "^7.10.1",
     "@babel/preset-env": "^7.10.1",

--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -448,7 +448,7 @@ class PDFThumbnailView {
   get _thumbPageTitle() {
     return this.l10n.get(
       "thumb_page_title",
-      { page: this.pageLabel !== null ? this.pageLabel : this.id },
+      { page: this.pageLabel ?? this.id },
       "Page {{page}}"
     );
   }
@@ -456,7 +456,7 @@ class PDFThumbnailView {
   get _thumbPageCanvas() {
     return this.l10n.get(
       "thumb_page_canvas",
-      { page: this.pageLabel !== null ? this.pageLabel : this.id },
+      { page: this.pageLabel ?? this.id },
       "Thumbnail of Page {{page}}"
     );
   }


### PR DESCRIPTION
For now we need to use a Babel-plugin, since Webpack 4.x doesn't seem to support it yet. (Most likely we'll have to update to Webpack 5, once that becomes available, in order for this to be directly supported. This is thus also blocked on removing the `webpack-stream` package.)

While the `??` operator will thus always be transpiled by Babel, even in modern builds, simply supporting it for development purposes seems like a step in the right direction.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator