### PR TITLE
Ensure that `PDFImage.buildImage` won't accidentally swallow errors, e.g. from ColorSpace parsing (issue 6707, PR 11601 follow-up)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -579,7 +579,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
           return this._sendImgData(objId, imgData, cacheGlobally);
         })
         .catch(reason => {
-          warn("Unable to decode image: " + reason);
+          warn(`Unable to decode image "${objId}": "${reason}".`);
 
           return this._sendImgData(objId, /* imgData = */ null, cacheGlobally);
         });

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -248,7 +248,7 @@ var PDFImage = (function PDFImageClosure() {
    * Handles processing of image data and returns the Promise that is resolved
    * with a PDFImage when the image is ready to be used.
    */
-  PDFImage.buildImage = function ({
+  PDFImage.buildImage = async function ({
     xref,
     res,
     image,
@@ -271,17 +271,16 @@ var PDFImage = (function PDFImageClosure() {
         warn("Unsupported mask format.");
       }
     }
-    return Promise.resolve(
-      new PDFImage({
-        xref,
-        res,
-        image: imageData,
-        isInline,
-        smask: smaskData,
-        mask: maskData,
-        pdfFunctionFactory,
-      })
-    );
+
+    return new PDFImage({
+      xref,
+      res,
+      image: imageData,
+      isInline,
+      smask: smaskData,
+      mask: maskData,
+      pdfFunctionFactory,
+    });
   };
 
   PDFImage.createMask = function ({

--- a/test/pdfs/issue6707.pdf.link
+++ b/test/pdfs/issue6707.pdf.link
@@ -1,0 +1,1 @@
+https://web.archive.org/web/20151201202008/https://secure.dynaccount.com/data/voucher/30000/400/30452_93e074c4c8b2301a24b33176331c49e5755e02fa.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -669,6 +669,14 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue6707",
+       "file": "pdfs/issue6707.pdf",
+       "md5": "068ceaec23d265b1d38dfa6ab279f017",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue6721_reduced",
        "file": "pdfs/issue6721_reduced.pdf",
        "md5": "719aa66d8081a15e3ba6032ed4279237",


### PR DESCRIPTION
Because of a really stupid `Promise`-related mistake on my part, when re-factoring `PDFImage.buildImage` during the `NativeImageDecoder` removal, we're no longer re-throwing errors occuring during image parsing/decoding as intended.
The result is that some (fairly) corrupt documents will never finish loading, and unfortunately there were apparently no sufficiently corrupt images in the test-suite to catch this.