### PR TITLE
Improve (local) caching of parsed `ColorSpace`s (PR 12001 follow-up)

### DIFF
--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -491,7 +491,7 @@ class ColorSpace {
             );
             // Parse the /Alternate CS to ensure that the number of components
             // are correct, and also (indirectly) that it is not a PatternCS.
-            const altCS = this.fromIR(altIR, pdfFunctionFactory);
+            const altCS = this.fromIR(altIR);
             if (altCS.numComps === numComps) {
               return altIR;
             }

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -73,13 +73,13 @@ import {
 } from "./standard_fonts.js";
 import { getTilingPatternIR, Pattern } from "./pattern.js";
 import { Lexer, Parser } from "./parser.js";
+import { LocalColorSpaceCache, LocalImageCache } from "./image_utils.js";
 import { bidi } from "./bidi.js";
 import { ColorSpace } from "./colorspace.js";
 import { DecodeStream } from "./stream.js";
 import { getGlyphsUnicode } from "./glyphlist.js";
 import { getMetrics } from "./metrics.js";
 import { isPDFFunction } from "./function.js";
-import { LocalImageCache } from "./image_utils.js";
 import { MurmurHash3_64 } from "./murmurhash3.js";
 import { OperatorList } from "./operator_list.js";
 import { PDFImage } from "./image.js";
@@ -1224,7 +1224,7 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
       var xref = this.xref;
       let parsingText = false;
       const localImageCache = new LocalImageCache();
-      const localColorSpaceCache = new LocalImageCache();
+      const localColorSpaceCache = new LocalColorSpaceCache();
 
       var xobjs = resources.get("XObject") || Dict.empty;
       var patterns = resources.get("Pattern") || Dict.empty;

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1136,12 +1136,12 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
     parseColorSpace({ cs, resources, localColorSpaceCache }) {
       return new Promise(resolve => {
-        const parsedColorSpace = ColorSpace.parse(
+        const parsedColorSpace = ColorSpace.parse({
           cs,
-          this.xref,
+          xref: this.xref,
           resources,
-          this.pdfFunctionFactory
-        );
+          pdfFunctionFactory: this.pdfFunctionFactory,
+        });
 
         const csName = cs instanceof Name ? cs.name : null;
         if (csName) {

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -179,13 +179,12 @@ var PDFImage = (function PDFImageClosure() {
             );
         }
       }
-      const resources = isInline ? res : null;
-      this.colorSpace = ColorSpace.parse(
-        colorSpace,
+      this.colorSpace = ColorSpace.parse({
+        cs: colorSpace,
         xref,
-        resources,
-        pdfFunctionFactory
-      );
+        resources: isInline ? res : null,
+        pdfFunctionFactory,
+      });
       this.numComps = this.colorSpace.numComps;
     }
 

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -89,6 +89,7 @@ var PDFImage = (function PDFImageClosure() {
     mask = null,
     isMask = false,
     pdfFunctionFactory,
+    localColorSpaceCache,
   }) {
     this.image = image;
     var dict = image.dict;
@@ -159,7 +160,7 @@ var PDFImage = (function PDFImageClosure() {
     this.bpc = bitsPerComponent;
 
     if (!this.imageMask) {
-      var colorSpace = dict.get("ColorSpace", "CS");
+      let colorSpace = dict.getRaw("ColorSpace") || dict.getRaw("CS");
       if (!colorSpace) {
         info("JPX images (which do not require color spaces)");
         switch (image.numComps) {
@@ -184,6 +185,7 @@ var PDFImage = (function PDFImageClosure() {
         xref,
         resources: isInline ? res : null,
         pdfFunctionFactory,
+        localColorSpaceCache,
       });
       this.numComps = this.colorSpace.numComps;
     }
@@ -220,6 +222,7 @@ var PDFImage = (function PDFImageClosure() {
         image: smask,
         isInline,
         pdfFunctionFactory,
+        localColorSpaceCache,
       });
     } else if (mask) {
       if (isStream(mask)) {
@@ -235,6 +238,7 @@ var PDFImage = (function PDFImageClosure() {
             isInline,
             isMask: true,
             pdfFunctionFactory,
+            localColorSpaceCache,
           });
         }
       } else {
@@ -253,6 +257,7 @@ var PDFImage = (function PDFImageClosure() {
     image,
     isInline = false,
     pdfFunctionFactory,
+    localColorSpaceCache,
   }) {
     const imageData = image;
     let smaskData = null;
@@ -279,6 +284,7 @@ var PDFImage = (function PDFImageClosure() {
       smask: smaskData,
       mask: maskData,
       pdfFunctionFactory,
+      localColorSpaceCache,
     });
   };
 

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -111,13 +111,17 @@ Shadings.SMALL_NUMBER = 1e-6;
 // Radial and axial shading have very similar implementations
 // If needed, the implementations can be broken into two classes
 Shadings.RadialAxial = (function RadialAxialClosure() {
-  function RadialAxial(dict, matrix, xref, res, pdfFunctionFactory) {
+  function RadialAxial(dict, matrix, xref, resources, pdfFunctionFactory) {
     this.matrix = matrix;
     this.coordsArr = dict.getArray("Coords");
     this.shadingType = dict.get("ShadingType");
     this.type = "Pattern";
-    var cs = dict.get("ColorSpace", "CS");
-    cs = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+    const cs = ColorSpace.parse({
+      cs: dict.get("ColorSpace", "CS"),
+      xref,
+      resources,
+      pdfFunctionFactory,
+    });
     this.cs = cs;
     const bbox = dict.getArray("BBox");
     if (Array.isArray(bbox) && bbox.length === 4) {
@@ -830,7 +834,7 @@ Shadings.Mesh = (function MeshClosure() {
     }
   }
 
-  function Mesh(stream, matrix, xref, res, pdfFunctionFactory) {
+  function Mesh(stream, matrix, xref, resources, pdfFunctionFactory) {
     if (!isStream(stream)) {
       throw new FormatError("Mesh data is not a stream");
     }
@@ -844,8 +848,12 @@ Shadings.Mesh = (function MeshClosure() {
     } else {
       this.bbox = null;
     }
-    var cs = dict.get("ColorSpace", "CS");
-    cs = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+    const cs = ColorSpace.parse({
+      cs: dict.get("ColorSpace", "CS"),
+      xref,
+      resources,
+      pdfFunctionFactory,
+    });
     this.cs = cs;
     this.background = dict.has("Background")
       ? cs.getRgb(dict.get("Background"), 0)

--- a/test/unit/colorspace_spec.js
+++ b/test/unit/colorspace_spec.js
@@ -55,12 +55,17 @@ describe("colorspace", function () {
           data: new Dict(),
         },
       ]);
-      const res = new Dict();
+      const resources = new Dict();
 
       const pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      const colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      const colorSpace = ColorSpace.parse({
+        cs,
+        xref,
+        resources,
+        pdfFunctionFactory,
+      });
 
       const testSrc = new Uint8Array([27, 125, 250, 131]);
       const testDest = new Uint8ClampedArray(4 * 4 * 3);
@@ -100,12 +105,17 @@ describe("colorspace", function () {
           data: Name.get("DeviceGray"),
         },
       ]);
-      const res = new Dict();
+      const resources = new Dict();
 
       const pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      const colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      const colorSpace = ColorSpace.parse({
+        cs,
+        xref,
+        resources,
+        pdfFunctionFactory,
+      });
 
       const testSrc = new Uint8Array([27, 125, 250, 131]);
       const testDest = new Uint8ClampedArray(3 * 3 * 3);
@@ -141,12 +151,17 @@ describe("colorspace", function () {
           data: new Dict(),
         },
       ]);
-      const res = new Dict();
+      const resources = new Dict();
 
       const pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      const colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      const colorSpace = ColorSpace.parse({
+        cs,
+        xref,
+        resources,
+        pdfFunctionFactory,
+      });
 
       // prettier-ignore
       const testSrc = new Uint8Array([
@@ -192,12 +207,17 @@ describe("colorspace", function () {
           data: Name.get("DeviceRGB"),
         },
       ]);
-      const res = new Dict();
+      const resources = new Dict();
 
       const pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      const colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      const colorSpace = ColorSpace.parse({
+        cs,
+        xref,
+        resources,
+        pdfFunctionFactory,
+      });
 
       // prettier-ignore
       const testSrc = new Uint8Array([
@@ -239,12 +259,17 @@ describe("colorspace", function () {
           data: new Dict(),
         },
       ]);
-      const res = new Dict();
+      const resources = new Dict();
 
       const pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      const colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      const colorSpace = ColorSpace.parse({
+        cs,
+        xref,
+        resources,
+        pdfFunctionFactory,
+      });
 
       // prettier-ignore
       const testSrc = new Uint8Array([
@@ -290,12 +315,17 @@ describe("colorspace", function () {
           data: Name.get("DeviceCMYK"),
         },
       ]);
-      const res = new Dict();
+      const resources = new Dict();
 
       const pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      const colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      const colorSpace = ColorSpace.parse({
+        cs,
+        xref,
+        resources,
+        pdfFunctionFactory,
+      });
 
       // prettier-ignore
       const testSrc = new Uint8Array([
@@ -342,12 +372,17 @@ describe("colorspace", function () {
           data: new Dict(),
         },
       ]);
-      const res = new Dict();
+      const resources = new Dict();
 
       const pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      const colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      const colorSpace = ColorSpace.parse({
+        cs,
+        xref,
+        resources,
+        pdfFunctionFactory,
+      });
 
       const testSrc = new Uint8Array([27, 125, 250, 131]);
       const testDest = new Uint8ClampedArray(4 * 4 * 3);
@@ -396,12 +431,17 @@ describe("colorspace", function () {
           data: new Dict(),
         },
       ]);
-      const res = new Dict();
+      const resources = new Dict();
 
       const pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      const colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      const colorSpace = ColorSpace.parse({
+        cs,
+        xref,
+        resources,
+        pdfFunctionFactory,
+      });
 
       // prettier-ignore
       const testSrc = new Uint8Array([
@@ -448,12 +488,17 @@ describe("colorspace", function () {
           data: new Dict(),
         },
       ]);
-      const res = new Dict();
+      const resources = new Dict();
 
       const pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      const colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      const colorSpace = ColorSpace.parse({
+        cs,
+        xref,
+        resources,
+        pdfFunctionFactory,
+      });
 
       // prettier-ignore
       const testSrc = new Uint8Array([
@@ -502,12 +547,17 @@ describe("colorspace", function () {
           data: new Dict(),
         },
       ]);
-      const res = new Dict();
+      const resources = new Dict();
 
       const pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      const colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      const colorSpace = ColorSpace.parse({
+        cs,
+        xref,
+        resources,
+        pdfFunctionFactory,
+      });
 
       const testSrc = new Uint8Array([2, 2, 0, 1]);
       const testDest = new Uint8ClampedArray(3 * 3 * 3);
@@ -564,12 +614,17 @@ describe("colorspace", function () {
           data: fn,
         },
       ]);
-      const res = new Dict();
+      const resources = new Dict();
 
       const pdfFunctionFactory = new PDFFunctionFactory({
         xref,
       });
-      const colorSpace = ColorSpace.parse(cs, xref, res, pdfFunctionFactory);
+      const colorSpace = ColorSpace.parse({
+        cs,
+        xref,
+        resources,
+        pdfFunctionFactory,
+      });
 
       const testSrc = new Uint8Array([27, 25, 50, 31]);
       const testDest = new Uint8ClampedArray(3 * 3 * 3);


### PR DESCRIPTION
This patch contains the following *notable* improvements:
 - Changes the `ColorSpace.parse` call-sites to, where possible, pass in a reference rather than actual ColorSpace data (necessary for the next point).
 - Adds (local) caching of `ColorSpace`s by `Ref`, when applicable, in addition the caching by name. This (generally) improves `ColorSpace` caching for e.g. the SMask code-paths.
 - Extends the (local) `ColorSpace` caching to also apply when handling Images and Patterns, thus further reducing unneeded re-parsing.
 - Adds a new `ColorSpace.parseAsync` method, almost identical to the existing `ColorSpace.parse` one, but returning a Promise instead (this simplifies some code in the `PartialEvaluator`).
