### PR TITLE
Fix auto-rotate for printing landscape PDFs where the first page is also landscape

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -167,7 +167,7 @@
     },
     "enablePrintAutoRotate": {
       "title": "Automatically rotate printed pages",
-      "description": "When enabled, pages whose orientation differ from the first page are rotated when printed.",
+      "description": "When enabled, landscape pages are rotated when printed.",
       "type": "boolean",
       "default": false
     },

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -67,8 +67,7 @@ const DEFAULT_CACHE_SIZE = 10;
  * @property {boolean} [renderInteractiveForms] - Enables rendering of
  *   interactive form elements. The default is `false`.
  * @property {boolean} [enablePrintAutoRotate] - Enables automatic rotation of
- *   pages whose orientation differ from the first page upon printing. The
- *   default is `false`.
+ *   landscape pages upon printing. The default is `false`.
  * @property {string} renderer - 'canvas' or 'svg'. The default is 'canvas'.
  * @property {boolean} [enableWebGL] - Enables WebGL accelerated rendering for
  *   some operations. The default value is `false`.
@@ -1203,9 +1202,8 @@ class BaseViewer {
     if (!this.enablePrintAutoRotate) {
       return pagesOverview;
     }
-    const isFirstPagePortrait = isPortraitOrientation(pagesOverview[0]);
     return pagesOverview.map(function (size) {
-      if (isFirstPagePortrait === isPortraitOrientation(size)) {
+      if (isPortraitOrientation(size)) {
         return size;
       }
       return {


### PR DESCRIPTION
The current behavior for `getPagesOverview` assumes we want to only
auto-rotate if:

- `enablePrintAutoRotate` is `true`
- `isFirstPagePortrait !== isPortraitOrientation(size)`

This second check is what is breaking #9297. The two PDFs linked have a
landscape orientation first page, as well as subsequent pages. Since
`false === false`, we print portrait.

Let's drop the comparison with `isFirstPagePortrait`, and print
landscape if `!isPortraitOrientation(size)`.

Fixes #9297.