### PR TITLE
Update Needle to 2.5.0 or greater.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8919,9 +8919,9 @@
       "dev": true
     },
     "needle": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
-      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.0.tgz",
+      "integrity": "sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==",
       "dev": true,
       "requires": {
         "debug": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "jstransformer-markdown-it": "^2.1.0",
     "merge-stream": "^1.0.1",
     "mkdirp": "^1.0.4",
+    "needle": "^2.5.0",
     "postcss-calc": "^7.0.2",
     "postcss-css-variables": "^0.14.0",
     "prettier": "^2.0.5",


### PR DESCRIPTION
Versions of `needle` prior to `2.5.0` cannot cope with redirects ([as documented](https://github.com/tomas/needle/issues/312)).

This prevents prebuilt `canvas` binaries from being downloaded on MacOS,
requiring the global install of its dependencies.

Updating `needle` restores it to functionality, addressing this.  This change avoids
the need to add `request` to `package.json` or bundle pre-built binaries,  it also obsoletes https://github.com/mozilla/pdf.js/pull/12018.

(NB: needle was already in use for this package.)