### PR TITLE
Attempt to detect inline images which contain "EI" sequence in the actual image data (issue 11124)

### DIFF
--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -254,6 +254,7 @@
 !issue6336.pdf
 !issue6387.pdf
 !issue6410.pdf
+!issue11124.pdf
 !issue8586.pdf
 !jbig2_symbol_offset.pdf
 !gradientfill.pdf

--- a/test/pdfs/issue11124.pdf
+++ b/test/pdfs/issue11124.pdf
@@ -1,0 +1,33 @@
+%PDF-1.3
+%‚„œ”
+1 0 obj<</Type/Catalog/Pages 3 0 R>>
+endobj
+2 0 obj<</CreationDate(D:20190906183146+02'00')/Producer(PoDoFo - http://podofo.sf.net)>>
+endobj
+3 0 obj<</Type/Pages/Count 1/Kids[ 4 0 R]>>
+endobj
+4 0 obj<</Type/Page/Contents 5 0 R/MediaBox[ 0 0 100 100]/Parent 3 0 R/Resources<</ProcSet[/PDF/Text/ImageB/ImageC/ImageI]>>>>
+endobj
+5 0 obj<</Length 103>>
+stream
+100 0 0 100 0 0 cm
+BI /W 4 /H 4 /CS /RGB /BPC 8
+ID
+00000z0z00zzz00z0zzz0zzzEI aazazaazzzaazazzzazzz
+EI
+
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000059 00000 n 
+0000000156 00000 n 
+0000000207 00000 n 
+0000000341 00000 n 
+trailer
+<</ID[<D047079C2B662F2617BF6BC31251DAB1><D047079C2B662F2617BF6BC31251DAB1>]/Info 2 0 R/Root 1 0 R/Size 6>>
+startxref
+492
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -3147,6 +3147,12 @@
        "type": "text",
        "about": "Invisible (and broken) TrueType font used for text-selection."
     },
+    {  "id": "issue11124",
+       "file": "pdfs/issue11124.pdf",
+       "md5": "9bde831515dc6b8bb2c7c00c8189aca9",
+       "rounds": 1,
+       "type": "eq"
+    },
     {  "id": "issue11768",
        "file": "pdfs/issue11768_reduced.pdf",
        "md5": "0cafde97d78bb6883531a325a996a5ef",


### PR DESCRIPTION
This should reduce the possibility of accidentally truncating some inline images, while *not* causing the "EI" detection to become significantly slower.[1]
There's obviously a possibility that these added checks are not sufficient to catch *every* single case of "EI" sequences within the actual inline image data, but without specific test-cases I decided against over-engineering the solution here.

*Please note:* The interpolation issues are somewhat orthogonal to the main issue here, which is the truncated image, and it's already tracked elsewhere.

Fixes #11124

---
[1] I've looked at the issue a few times, and this is the first approach that I was able to come up with that didn't cause *unacceptable* performance regressions in e.g. issue #2618.