### PR TITLE
Add at least *some* test-coverage for the `RenderTask.onContinue` functionality

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -22,6 +22,7 @@ const CMAP_URL = "../external/bcmaps/";
 const CMAP_PACKED = true;
 const IMAGE_RESOURCES_PATH = "/web/images/";
 const WORKER_SRC = "../build/generic/build/pdf.worker.js";
+const RENDER_TASK_ON_CONTINUE_DELAY = 5; // ms
 
 /**
  * @class
@@ -626,7 +627,15 @@ var Driver = (function DriverClosure() {
               };
               initPromise
                 .then(function () {
-                  return page.render(renderContext).promise.then(function () {
+                  const renderTask = page.render(renderContext);
+
+                  if (task.renderTaskOnContinue) {
+                    renderTask.onContinue = function (cont) {
+                      // Slightly delay the continued rendering.
+                      setTimeout(cont, RENDER_TASK_ON_CONTINUE_DELAY);
+                    };
+                  }
+                  return renderTask.promise.then(function () {
                     completeRender(false);
                   });
                 })

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -11,6 +11,13 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "tracemonkey-renderTaskOnContinue",
+       "file": "pdfs/tracemonkey.pdf",
+       "md5": "9a192d8b1a7dc652a19835f6f08098bd",
+       "rounds": 1,
+       "type": "eq",
+       "renderTaskOnContinue": true
+    },
     {  "id": "tracemonkey-fbf",
        "file": "pdfs/tracemonkey.pdf",
        "md5": "9a192d8b1a7dc652a19835f6f08098bd",


### PR DESCRIPTION
The default viewer, and thus Firefox, depends on the `RenderTask.onContinue` functionality to pause/continue rendering (such that the most visible page always renders first).
Despite this functionality thus being very important, it has however never actually been tested *at all* as far as I can tell. Hence this patch which adds a new boolean `renderTaskOnContinue` parameter (`false` by default), that can be used to force a reference-test to use the `RenderTask.onContinue` code-path in the `InternalRenderTask` class.

Note that I purposely made this new reference-test behaviour *optional*, since I didn't want to negatively affect the general runtime of the tests (given that there's a slight delay added to the rendering). Also, for e.g. benchmarking you'd most likely want to stay away from the `RenderTask.onContinue` functionality for similar reasons.