### PR TITLE
Allow `BaseLocalCache` to, optionally, only allocate storage for caching of references (PR 12034 follow-up)

### DIFF
--- a/src/core/image_utils.js
+++ b/src/core/image_utils.js
@@ -18,12 +18,14 @@ import { assert, info, shadow, unreachable } from "../shared/util.js";
 import { RefSetCache } from "./primitives.js";
 
 class BaseLocalCache {
-  constructor() {
+  constructor(options) {
     if (this.constructor === BaseLocalCache) {
       unreachable("Cannot initialize BaseLocalCache.");
     }
-    this._nameRefMap = new Map();
-    this._imageMap = new Map();
+    if (!options || !options.onlyRefs) {
+      this._nameRefMap = new Map();
+      this._imageMap = new Map();
+    }
     this._imageCache = new RefSetCache();
   }
 
@@ -92,6 +94,10 @@ class LocalColorSpaceCache extends BaseLocalCache {
 }
 
 class LocalFunctionCache extends BaseLocalCache {
+  constructor(options) {
+    super({ onlyRefs: true });
+  }
+
   getByName(name) {
     unreachable("Should not call `getByName` method.");
   }


### PR DESCRIPTION
*Yet another instalment in the never-ending series of things that you think of __after__ a patch has landed.*

Since `Function`s are only cached by reference, we thus don't need to allocate storage for names in `LocalFunctionCache` instances. Obviously the effect of these changes are *really tiny*, but it seems reasonable in principle to avoid allocating data structures that are guaranteed to be unused.