### PR TITLE
Tweak the heuristic, in `src/core/jpg.js`, that handles JPEG images with a wildly incorrect SOF (Start of Frame) `scanLines` parameter (issue 10989)

### DIFF
--- a/test/pdfs/issue10989.pdf.link
+++ b/test/pdfs/issue10989.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/3410726/ArchitecturalPlanProblemPDF_2.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -3746,6 +3746,14 @@
        "lastPage": 7,
        "type": "eq"
     },
+    {  "id": "issue10989",
+       "file": "pdfs/issue10989.pdf",
+       "md5": "c16de154d9ae6dbeec0a113911957efe",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue9650",
        "file": "pdfs/issue9650.pdf",
        "md5": "20d50bda6b1080b6d9088811299c791e",


### PR DESCRIPTION
Fixes #10989