### PR TITLE
Make the detection of Node.js environments on Electron strict.

### DIFF
--- a/src/shared/is_node.js
+++ b/src/shared/is_node.js
@@ -16,11 +16,12 @@
 
 // NW.js / Electron is a browser context, but copies some Node.js objects; see
 // http://docs.nwjs.io/en/latest/For%20Users/Advanced/JavaScript%20Contexts%20in%20NW.js/#access-nodejs-and-nwjs-api-in-browser-context
-// https://electronjs.org/docs/api/process#processversionselectron
+// https://www.electronjs.org/docs/api/process#processversionselectron-readonly
+// https://www.electronjs.org/docs/api/process#processtype-readonly
 const isNodeJS =
   typeof process === "object" &&
   process + "" === "[object process]" &&
   !process.versions.nw &&
-  !process.versions.electron;
+  !(process.versions.electron && process.type && process.type !== "browser");
 
 export { isNodeJS };


### PR DESCRIPTION
Make the detection of Node.js environments on Electron strict. The main process and its child processes should be detected as Node.js environments.

- https://www.electronjs.org/docs/api/process#processtype-readonly

Without this PR, `pdfjsLib.getDocument(...).promise.then` fails with an error message `Setting up fake worker failed: "No "GlobalWorkerOptions.workerSrc" specified.".` on the main process and its child processes of Electron.