### PR TITLE
Stop special-casing the (very unlikely) "no `/XObject` found"-scenario, when parsing `OPS.paintXObject` operators, in `PartialEvaluator.{getOperatorList, getTextContent}`

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1331,11 +1331,6 @@ class PartialEvaluator {
                   xobj = xref.fetch(xobj);
                 }
 
-                if (!xobj) {
-                  operatorList.addOp(fn, args);
-                  resolveXObject();
-                  return;
-                }
                 if (!isStream(xobj)) {
                   throw new FormatError("XObject should be a stream");
                 }
@@ -2287,10 +2282,6 @@ class PartialEvaluator {
                   xobj = xref.fetch(xobj);
                 }
 
-                if (!xobj) {
-                  resolveXObject();
-                  return;
-                }
                 if (!isStream(xobj)) {
                   throw new FormatError("XObject should be a stream");
                 }

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -2433,10 +2433,6 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       this.ctx.fillRect(0, 0, 1, 1);
     },
 
-    paintXObject: function CanvasGraphics_paintXObject() {
-      warn("Unsupported 'paintXObject' command.");
-    },
-
     // Marked content
 
     markPoint: function CanvasGraphics_markPoint(tag) {

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -106,16 +106,32 @@ describe("evaluator", function () {
     });
 
     it("should handle two glued operations", function (done) {
-      var resources = new ResourcesMock();
-      resources.Res1 = {};
+      const imgDict = new Dict();
+      imgDict.set("Subtype", Name.get("Image"));
+      imgDict.set("Width", 1);
+      imgDict.set("Height", 1);
+
+      const imgStream = new Stream([0]);
+      imgStream.dict = imgDict;
+
+      const xObject = new Dict();
+      xObject.set("Res1", imgStream);
+
+      const resources = new ResourcesMock();
+      resources.XObject = xObject;
+
       var stream = new StringStream("/Res1 DoQ");
       runOperatorListCheck(partialEvaluator, stream, resources, function (
         result
       ) {
-        expect(!!result.fnArray && !!result.argsArray).toEqual(true);
-        expect(result.fnArray.length).toEqual(2);
-        expect(result.fnArray[0]).toEqual(OPS.paintXObject);
-        expect(result.fnArray[1]).toEqual(OPS.restore);
+        expect(result.fnArray.length).toEqual(3);
+        expect(result.fnArray[0]).toEqual(OPS.dependency);
+        expect(result.fnArray[1]).toEqual(OPS.paintImageXObject);
+        expect(result.fnArray[2]).toEqual(OPS.restore);
+        expect(result.argsArray.length).toEqual(3);
+        expect(result.argsArray[0]).toEqual(["img_p0_1"]);
+        expect(result.argsArray[1]).toEqual(["img_p0_1", 1, 1]);
+        expect(result.argsArray[2]).toEqual(null);
         done();
       });
     });


### PR DESCRIPTION
Originally there weren't any (generally) good ways to handle errors gracefully, on the worker-side, however that's no longer the case and we can simply fallback to the existing `ignoreErrors` functionality instead.
Also, please note that the "no `/XObject` found"-scenario should be *extremely* unlikely in practice and would only occur in corrupt/broken documents.

Note that the `PartialEvaluator.getOperatorList` case is especially bad currently, since we'll simply (attempt to) send the data as-is to the main-thread. This is quite bad, since in a corrupt/broken document the data *could* contain anything and e.g. be unclonable (which would cause breaking errors).
Also, we're (obviously) not attempting to do anything with this "raw" `OPS.paintXObject` data on the main-thread and simply ensuring that we never send it definately seems like the correct approach.