### PR TITLE
fix: added fallback when no data passed to message handler

### DIFF
--- a/src/shared/message_handler.js
+++ b/src/shared/message_handler.js
@@ -85,7 +85,7 @@ class MessageHandler {
 
     this._onComObjOnMessage = event => {
       const data = event.data;
-      if (data.targetName !== this.sourceName) {
+      if (!data || data.targetName !== this.sourceName) {
         return;
       }
       if (data.stream) {


### PR DESCRIPTION
Sometimes `event.data` seems to get null.