### PR TITLE
Add types annotations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15224,6 +15224,12 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typescript": {
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "dev": true
+    },
     "typogr": {
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/typogr/-/typogr-0.6.8.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "terser": "^4.8.0",
     "through2": "^3.0.2",
     "ttest": "^2.1.1",
+    "typescript": "^3.9.7",
     "typogr": "^0.6.8",
     "vinyl": "^2.2.0",
     "vinyl-fs": "^3.0.3",

--- a/src/display/annotation_storage.js
+++ b/src/display/annotation_storage.js
@@ -13,6 +13,9 @@
  * limitations under the License.
  */
 
+/**
+ * Key/value storage for annotation data in forms.
+ */
 class AnnotationStorage {
   constructor() {
     this._storage = {};

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -430,6 +430,9 @@ var CanvasExtraState = (function CanvasExtraStateClosure() {
   return CanvasExtraState;
 })();
 
+/**
+ * @type {any}
+ */
 var CanvasGraphics = (function CanvasGraphicsClosure() {
   // Defines the time the executeOperatorList is going to be executing
   // before it stops and shedules a continue of execution.

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -406,6 +406,9 @@ function getShadingPatternFromIR(raw) {
   return shadingIR.fromIR(raw);
 }
 
+/**
+ * @type {any}
+ */
 var TilingPattern = (function TilingPatternClosure() {
   var PaintType = {
     COLORED: 1,

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -23,23 +23,34 @@ import {
  * Text layer render parameters.
  *
  * @typedef {Object} TextLayerRenderParameters
- * @property {TextContent} [textContent] - Text content to render (the object
- *   is returned by the page's `getTextContent` method).
+ * @property {import("./api").TextContent} [textContent] - Text content to
+ *   render (the object is returned by the page's `getTextContent` method).
  * @property {ReadableStream} [textContentStream] - Text content stream to
  *   render (the stream is returned by the page's `streamTextContent` method).
  * @property {HTMLElement} container - HTML element that will contain text runs.
- * @property {PageViewport} viewport - The target viewport to properly
- *   layout the text runs.
- * @property {Array} [textDivs] - HTML elements that are correspond to the
- *   text items of the textContent input. This is output and shall be
+ * @property {import("./display_utils").PageViewport} viewport - The target
+ *   viewport to properly layout the text runs.
+ * @property {Array<HTMLElement>} [textDivs] - HTML elements that are correspond
+ *   to the text items of the textContent input. This is output and shall be
  *   initially be set to empty array.
- * @property {Array} [textContentItemsStr] - Strings that correspond to the
- *   `str` property of the text items of textContent input. This is output
+ * @property {Array<string>} [textContentItemsStr] - Strings that correspond to
+ *    the `str` property of the text items of textContent input. This is output
  *   and shall be initially be set to empty array.
  * @property {number} [timeout] - Delay in milliseconds before rendering of the
  *   text runs occurs.
  * @property {boolean} [enhanceTextSelection] - Whether to turn on the text
  *   selection enhancement.
+ */
+
+/**
+ * @typedef {Object} TextLayerRenderTask
+ * @property {Promise<void>} promise
+ * @property {() => void} cancel
+ * @property {(expandDivs: boolean) => void} expandTextDivs
+ */
+
+/**
+ * @type {(renderParameters: TextLayerRenderParameters) => TextLayerRenderTask}
  */
 var renderTextLayer = (function renderTextLayerClosure() {
   var MAX_TEXT_DIVS_TO_RENDER = 100000;
@@ -728,12 +739,6 @@ var renderTextLayer = (function renderTextLayerClosure() {
     },
   };
 
-  /**
-   * Starts rendering of the text layer.
-   *
-   * @param {TextLayerRenderParameters} renderParameters
-   * @returns {TextLayerRenderTask}
-   */
   // eslint-disable-next-line no-shadow
   function renderTextLayer(renderParameters) {
     var task = new TextLayerRenderTask({

--- a/src/shared/fonts_utils.js
+++ b/src/shared/fonts_utils.js
@@ -397,7 +397,6 @@ var Type2Parser = function type2Parser(aFilePath) {
  *  var file = new Uint8Array(cffFileArray, 0, cffFileSize);
  *  var parser = new Type2Parser();
  *  parser.parse(new Stream(file));
- *
  */
 
 /*

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -412,6 +412,9 @@ function shadow(obj, prop, value) {
   return value;
 }
 
+/**
+ * @type {any}
+ */
 const BaseException = (function BaseExceptionClosure() {
   // eslint-disable-next-line no-shadow
   function BaseException(message) {
@@ -503,7 +506,7 @@ function stringToBytes(str) {
 
 /**
  * Gets length of the array (Array, Uint8Array, or string) in bytes.
- * @param {Array|Uint8Array|string} arr
+ * @param {Array<any>|Uint8Array|string} arr
  * @returns {number}
  */
 function arrayByteLength(arr) {
@@ -516,7 +519,8 @@ function arrayByteLength(arr) {
 
 /**
  * Combines array items (arrays) into single Uint8Array object.
- * @param {Array} arr - the array of the arrays (Array, Uint8Array, or string).
+ * @param {Array<Array<any>|Uint8Array|string>} arr - the array of the arrays
+ *   (Array, Uint8Array, or string).
  * @returns {Uint8Array}
  */
 function arraysToBytes(arr) {
@@ -822,7 +826,7 @@ function isArrayEqual(arr1, arr2) {
  * Promise Capability object.
  *
  * @typedef {Object} PromiseCapability
- * @property {Promise} promise - A Promise object.
+ * @property {Promise<any>} promise - A Promise object.
  * @property {boolean} settled - If the Promise has been fulfilled/rejected.
  * @property {function} resolve - Fulfills the Promise.
  * @property {function} reject - Rejects the Promise.

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -1,0 +1,20 @@
+import { getDocument } from "pdfjs-dist";
+
+class MainTest {
+  task: ReturnType<typeof getDocument> | undefined;
+
+  constructor(public file: string) {
+  }
+
+  loadPdf() {
+    this.task = getDocument("file://" + this.file);
+    return this.task.promise;
+  }
+}
+
+// This is actually never called, as the test only consists in compiling the file.
+// The compilation will crawl through all files and make sure that the types are consistent.
+const mt = new MainTest("../pdfs/basicapi.pdf");
+mt.loadPdf().then(() => {
+  console.log("loaded");
+});

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "outDir": "../../build/tmp",
+    "sourceMap": true,
+    "declaration": false,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "target": "es5",
+    "module": "es2015",
+    "baseUrl": "./",
+    "strict": true,
+    "types": [],
+    "lib": [
+      "es2017",
+      "dom"
+    ],
+    "paths": {
+      "pdfjs-dist": ["../../build/typestest"],
+      "pdfjs-dist/*": ["../../build/typestest/build/*"]
+    }
+  },
+  "files": [
+    "main.ts"
+  ],
+}


### PR DESCRIPTION
Follow-up of #10575:
- merged oBusk's and tamuratak's PRs
- fixed merge conflicts (hopefully correctly)
- added an Array type for a minimum example

I build it using:
```
npm ci
gulp generic
npx tsc -p .
```

And then trying to run the example from https://github.com/ineiti/pdf_example - I hope that's not too complex example to start from...