### PR TITLE
Remove a couple of unnecessary `PDFJSDev` checks from the viewer

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -299,11 +299,7 @@ const PDFViewerApplication = {
    * @private
    */
   async _parseHashParameters() {
-    if (
-      typeof PDFJSDev !== "undefined" &&
-      PDFJSDev.test("PRODUCTION") &&
-      !AppOptions.get("pdfBugEnabled")
-    ) {
+    if (!AppOptions.get("pdfBugEnabled")) {
       return undefined;
     }
     const hash = document.location.hash.substring(1);
@@ -1931,11 +1927,7 @@ function webViewerInitialized() {
     appConfig.secondaryToolbar.openFileButton.setAttribute("hidden", "true");
   }
 
-  if (
-    (typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("MOZCENTRAL || GENERIC")) &&
-    !PDFViewerApplication.supportsDocumentFonts
-  ) {
+  if (!PDFViewerApplication.supportsDocumentFonts) {
     AppOptions.set("disableFontFace", true);
     PDFViewerApplication.l10n
       .get(

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -112,7 +112,7 @@ const defaultOptions = {
   },
   pdfBugEnabled: {
     /** @type {boolean} */
-    value: false,
+    value: typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION"),
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
   printResolution: {


### PR DESCRIPTION
 - Given the `DefaultExternalServices` implementation, the `PDFViewerApplication.supportsDocumentFonts` getter is guaranteed to be defined and we can thus remove some (now) unnecessary `PDFJSDev` checks from the `webViewerInitialized` function.
 - By slightly tweaking the "pdfBugEnabled" definition in `web/app_options`, similar to the existing ones for "workerSrc" and "cMapUrl", we can remove some `PDFJSDev` checks from the `PDFViewerApplication._parseHashParameters` method.