### PR TITLE
Attempt to reduce intermittent failures in the "cleans up document resources during rendering of page" unit-test

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1906,7 +1906,11 @@ describe("api", function () {
               viewport,
             });
 
-            pdfDoc
+            renderTask.onContinue = function (cont) {
+              waitSome(cont);
+            };
+
+            return pdfDoc
               .cleanup()
               .then(
                 () => {


### PR DESCRIPTION
This patch should *hopefully* remove the `Unhandled promise rejection: ...` errors, by returning the "final" promise. Also, by pausing/delaying of rendering slightly the likelihood of the test failing in the first place should thus be reduced.