### PR TITLE
Improve how Type3-fonts with dependencies are handled

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -3378,12 +3378,11 @@ class TranslatedFont {
   }
 
   loadType3Data(evaluator, resources, task) {
-    if (!this.font.isType3Font) {
-      throw new Error("Must be a Type3 font.");
-    }
-
     if (this.type3Loaded) {
       return this.type3Loaded;
+    }
+    if (!this.font.isType3Font) {
+      throw new Error("Must be a Type3 font.");
     }
     // When parsing Type3 glyphs, always ignore them if there are errors.
     // Compared to the parsing of e.g. an entire page, it doesn't really

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -455,14 +455,7 @@ class PartialEvaluator {
   _sendImgData(objId, imgData, cacheGlobally = false) {
     const transfers = imgData ? [imgData.data.buffer] : null;
 
-    if (this.parsingType3Font) {
-      return this.handler.send(
-        "commonobj",
-        [objId, "FontType3Res", imgData],
-        transfers
-      );
-    }
-    if (cacheGlobally) {
+    if (this.parsingType3Font || cacheGlobally) {
       return this.handler.send(
         "commonobj",
         [objId, "Image", imgData],

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2265,7 +2265,6 @@ class WorkerTransport {
             });
           break;
         case "FontPath":
-        case "FontType3Res":
         case "Image":
           this.commonObjs.resolve(id, exportedData);
           break;


### PR DESCRIPTION
While the `CharProcs` streams of Type3-fonts *usually* don't rely on dependencies, such as e.g. images, it does happen in some cases.

Currently any dependencies are simply appended to the parent operatorList, which in practice means *only* the operatorList of the *first* page where the Type3-font is being used.
However, there's one thing that's slightly unfortunate with that approach: Since fonts are global to the PDF document, we really ought to ensure that any Type3 dependencies are appended to the operatorList of *all* pages where the Type3-font is being used. Otherwise there's a theoretical risk that, if one page has its rendering paused, another page may try to use a Type3-font whose dependencies are not yet fully resolved. In that case there would be errors, since Type3 operatorLists are executed synchronously.

Hence this patch, which ensures that all relevant pages will have Type3 dependencies appended to the main operatorList. (Note here that the `OperatorList.addDependencies` method, via `OperatorList.addDependency`, ensures that a dependency is only added *once* to any operatorList.)

Finally, these changes also remove the need for the "waiting for the main-thread"-hack that was added to `PartialEvaluator.buildPaintImageXObject` as part of fixing issue 10717.