### PR TITLE
Ignore `fetch()` errors, in `PDFFetchStreamRangeReader`, once the request has been aborted

### DIFF
--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -243,13 +243,20 @@ class PDFFetchStreamRangeReader {
         this._withCredentials,
         this._abortController
       )
-    ).then(response => {
-      if (!validateResponseStatus(response.status)) {
-        throw createResponseStatusError(response.status, url);
-      }
-      this._readCapability.resolve();
-      this._reader = response.body.getReader();
-    });
+    )
+      .then(response => {
+        if (!validateResponseStatus(response.status)) {
+          throw createResponseStatusError(response.status, url);
+        }
+        this._readCapability.resolve();
+        this._reader = response.body.getReader();
+      })
+      .catch(reason => {
+        if (reason && reason.name === "AbortError") {
+          return;
+        }
+        throw reason;
+      });
 
     this.onProgress = null;
   }


### PR DESCRIPTION
Besides making general sense, as far as I can tell, this patch should also prevent *one* source of `Uncaught (in promise) ...` exceptions.
Unfortunately `reason instanceof AbortError` doesn't work here, since `AbortError` isn't actually defined in browsers; note how even the DOM specification contains an example using the `name` property: https://dom.spec.whatwg.org/#aborting-ongoing-activities

This patch prevents the following errors from being logged in the console, when the unit-tests are running:
 - Firefox: `Uncaught (in promise) DOMException: The operation was aborted.`
 - Chrome: `Uncaught (in promise) DOMException: The user aborted a request.`