### PR TITLE
Populate the find field with the search query when URL has #search hash

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2349,6 +2349,10 @@ function webViewerFindFromUrlHash(evt) {
     highlightAll: true,
     findPrevious: false,
   });
+
+  if (PDFViewerApplication.findBar) {
+    PDFViewerApplication.findBar.findField.value = evt.query;
+  }
 }
 
 function webViewerUpdateFindMatchesCount({ matchesCount }) {


### PR DESCRIPTION
These changes improves the existing search functionality triggered when the URL contains a `#search` hash.

In addition to performing the actual search immediately like before, this will ensure the search text field inside the find bar gets populated with the text currently being searched for.

**Picture says more than a thousand words;** the goal is for `tesla` being populated in the search field below because pdf.js was loaded with `#search=tesla` in the URL:

![Screenshot 2020-07-30 at 10 09 01](https://user-images.githubusercontent.com/1231635/88898786-8857ed80-d24d-11ea-80a6-09aa4f321f02.png)

Does this look like a viable approach to you?

_Kudos to @marill for finding this workaround._