### PR TITLE
Fix hanging reference test (PR 12107 follow-up)

### DIFF
--- a/src/pdf.js
+++ b/src/pdf.js
@@ -50,6 +50,7 @@ import {
   VerbosityLevel,
 } from "./shared/util.js";
 import { AnnotationLayer } from "./display/annotation_layer.js";
+import { AnnotationStorage } from "./display/annotation_storage.js";
 import { apiCompatibilityParams } from "./display/api_compatibility.js";
 import { GlobalWorkerOptions } from "./display/worker_options.js";
 import { renderTextLayer } from "./display/text_layer.js";
@@ -156,6 +157,8 @@ export {
   VerbosityLevel,
   // From "./display/annotation_layer.js":
   AnnotationLayer,
+  // From "./display/annotation_storage.js":
+  AnnotationStorage,
   // From "./display/api_compatibility.js":
   apiCompatibilityParams,
   // From "./display/worker_options.js":

--- a/test/driver.js
+++ b/test/driver.js
@@ -220,6 +220,7 @@ var rasterizeAnnotationLayer = (function rasterizeAnnotationLayerClosure() {
           linkService: new pdfjsViewer.SimpleLinkService(),
           imageResourcesPath,
           renderInteractiveForms,
+          annotationStorage: new pdfjsLib.AnnotationStorage(),
         };
         pdfjsLib.AnnotationLayer.render(parameters);
 


### PR DESCRIPTION
The f1040-annotations reftest started hanging after #12107. We traced
this to `TypeError: can't access property "getOrCreateValue", storage is
undefined`.

We essentially need to add `annotationStorage` to the parameters in
test/driver.js.