### PR TITLE
Revert "Populate the find field with the search query when URL has #search hash"

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2349,10 +2349,6 @@ function webViewerFindFromUrlHash(evt) {
     highlightAll: true,
     findPrevious: false,
   });
-
-  if (PDFViewerApplication.findBar) {
-    PDFViewerApplication.findBar.findField.value = evt.query;
-  }
 }
 
 function webViewerUpdateFindMatchesCount({ matchesCount }) {


### PR DESCRIPTION
This reverts commit 50f73092e1f74e0fb1ea8d40763a5fba709c00c0. This causes an inconsistency with the integrated find bar that should be discussed more before moving on with this (refer to PR #12141).