### PR TITLE
Fix the type of SVGGraphics (PR 12102 follow-up)

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -29,6 +29,7 @@ import {
 import { DOMSVGFactory } from "./display_utils.js";
 import { isNodeJS } from "../shared/is_node.js";
 
+/** @type {any} */
 let SVGGraphics = function () {
   throw new Error("Not implemented: SVGGraphics");
 };


### PR DESCRIPTION
Fix the type of `SVGGraphics`.

The current generated type of `SVGGraphics` is:
```typescript
export function SVGGraphics(): never;
```
We can never call `new SVGGraphics(...)`  in TypeScript.