### PR TITLE
Re-factor the dispatching of "attachmentsloaded" events, when the PDF document contains no "regular" attachments

### DIFF
--- a/web/pdf_attachment_viewer.js
+++ b/web/pdf_attachment_viewer.js
@@ -129,23 +129,22 @@ class PDFAttachmentViewer {
    * @param {PDFAttachmentViewerRenderParameters} params
    */
   render({ attachments, keepRenderedCapability = false }) {
-    let attachmentsCount = 0;
-
     if (this.attachments) {
       this.reset(keepRenderedCapability === true);
     }
     this.attachments = attachments || null;
 
     if (!attachments) {
-      this._dispatchEvent(attachmentsCount);
+      this._dispatchEvent(/* attachmentsCount = */ 0);
       return;
     }
 
     const names = Object.keys(attachments).sort(function (a, b) {
       return a.toLowerCase().localeCompare(b.toLowerCase());
     });
-    attachmentsCount = names.length;
+    const attachmentsCount = names.length;
 
+    const fragment = document.createDocumentFragment();
     for (let i = 0; i < attachmentsCount; i++) {
       const item = attachments[names[i]];
       const filename = removeNullCharacters(getFilenameFromUrl(item.filename));
@@ -164,8 +163,9 @@ class PDFAttachmentViewer {
       }
 
       div.appendChild(button);
-      this.container.appendChild(div);
+      fragment.appendChild(div);
     }
+    this.container.appendChild(fragment);
 
     this._dispatchEvent(attachmentsCount);
   }

--- a/web/pdf_sidebar.js
+++ b/web/pdf_sidebar.js
@@ -445,31 +445,17 @@ class PDFSidebar {
     });
 
     this.eventBus._on("attachmentsloaded", evt => {
-      if (evt.attachmentsCount) {
-        this.attachmentsButton.disabled = false;
+      const attachmentsCount = evt.attachmentsCount;
 
+      this.attachmentsButton.disabled = !attachmentsCount;
+
+      if (attachmentsCount) {
         this._showUINotification(SidebarView.ATTACHMENTS);
-        return;
+      } else if (this.active === SidebarView.ATTACHMENTS) {
+        // If the attachments view was opened during document load, switch away
+        // from it if it turns out that the document has no attachments.
+        this.switchView(SidebarView.THUMBS);
       }
-
-      // Attempt to avoid temporarily disabling, and switching away from, the
-      // attachment view for documents that do not contain proper attachments
-      // but *only* FileAttachment annotations. Hence we defer those operations
-      // slightly to allow time for parsing any FileAttachment annotations that
-      // may be present on the *initially* rendered page of the document.
-      Promise.resolve().then(() => {
-        if (this.attachmentsView.hasChildNodes()) {
-          // FileAttachment annotations were appended to the attachment view.
-          return;
-        }
-        this.attachmentsButton.disabled = true;
-
-        if (this.active === SidebarView.ATTACHMENTS) {
-          // If the attachment view was opened during document load, switch away
-          // from it if it turns out that the document has no attachments.
-          this.switchView(SidebarView.THUMBS);
-        }
-      });
     });
 
     // Update the thumbnailViewer, if visible, when exiting presentation mode.


### PR DESCRIPTION
 - Use a `DocumentFragment` when building the attachmentsView in `PDFAttachmentViewer.render`

   This approach is already used in other parts of the code-base, see e.g. `PDFOutlineViewer`, and has the advantage of only invalidating the DOM once rather than for every attachment item.

 - Re-factor the dispatching of "attachmentsloaded" events, when the PDF document contains no "regular" attachments

   Since the attachment fetching/parsing is already asynchronous, possibly delaying the dispatching of an "attachmentsloaded" event should thus not be a problem in general.
   Note that in some cases, i.e. PDF documents with no "regular" attachments and only FileAttachment annotations, we'll thus no longer dispatch an "attachmentsloaded" event when `attachmentsCount === 0` and instead wait for the FileAttachment parsing to finish. (The use of a timeout still guarantees that an "attachmentsloaded" event is *eventually* dispatched though.)

   This patch *considerably* simplifies the "attachmentsloaded" event handler, in `PDFSidebar`, since the details are now abstracted away from the consumer.

   Finally, add a check in `_appendAttachment` to ensure (indirectly) that the FileAttachment annotation is actually relevant for the active document.



