### PR TITLE
Attempt to reduce intermittent failures in the "multiple render() on the same canvas" unit-test

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1826,6 +1826,8 @@ describe("api", function () {
     });
 
     it("multiple render() on the same canvas", function (done) {
+      const optionalContentConfigPromise = pdfDocument.getOptionalContentConfig();
+
       var viewport = page.getViewport({ scale: 1 });
       var canvasAndCtx = CanvasFactory.create(viewport.width, viewport.height);
 
@@ -1833,11 +1835,13 @@ describe("api", function () {
         canvasContext: canvasAndCtx.context,
         canvasFactory: CanvasFactory,
         viewport,
+        optionalContentConfigPromise,
       });
       var renderTask2 = page.render({
         canvasContext: canvasAndCtx.context,
         canvasFactory: CanvasFactory,
         viewport,
+        optionalContentConfigPromise,
       });
 
       Promise.all([


### PR DESCRIPTION
This patch should *hopefully* remove the intermittent unit-test failure, by using the *same* `optionalContentConfigPromise` for both `renderTask`s and thus get more predictable timing behaviour.