### PR TITLE
Fix the type definition of TypedArray. (PR 12156 follow-up)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -100,9 +100,10 @@ function setPDFNetworkStreamFactory(pdfNetworkStreamFactory) {
 }
 
 /**
- * @typedef {
- *   Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array |
- *   Int32Array | Uint32Array | Float32Array | Float64Array
+ * @typedef { Int8Array | Uint8Array | Uint8ClampedArray |
+ *            Int16Array | Uint16Array |
+ *            Int32Array | Uint32Array | Float32Array |
+ *            Float64Array
  * } TypedArray
  */
 


### PR DESCRIPTION
Fix the type definition of `TypedArray`. 

The type of `TypedArray` is `any` in the current generated files.
