### PR TITLE
[api-minor] Fix the `annotationStorage` parameter in `PDFPageProxy.render`

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1133,7 +1133,8 @@ class PDFPageProxy {
         pageIndex: this._pageIndex,
         intent: renderingIntent,
         renderInteractiveForms: renderInteractiveForms === true,
-        annotationStorage,
+        annotationStorage:
+          (annotationStorage && annotationStorage.getAll()) || null,
       });
     }
 

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -435,6 +435,8 @@ class BaseViewer {
     const pagesCount = pdfDocument.numPages;
     const firstPagePromise = pdfDocument.getPage(1);
 
+    const annotationStorage = pdfDocument.annotationStorage;
+
     this._pagesCapability.promise.then(() => {
       this.eventBus.dispatch("pagesloaded", {
         source: this,
@@ -481,6 +483,7 @@ class BaseViewer {
             eventBus: this.eventBus,
             id: pageNum,
             scale,
+            annotationStorage,
             defaultViewport: viewport.clone(),
             renderingQueue: this.renderingQueue,
             textLayerFactory,
@@ -1153,6 +1156,7 @@ class BaseViewer {
   createAnnotationLayerBuilder(
     pageDiv,
     pdfPage,
+    annotationStorage = null,
     imageResourcesPath = "",
     renderInteractiveForms = false,
     l10n = NullL10n
@@ -1160,11 +1164,11 @@ class BaseViewer {
     return new AnnotationLayerBuilder({
       pageDiv,
       pdfPage,
+      annotationStorage,
       imageResourcesPath,
       renderInteractiveForms,
       linkService: this.linkService,
       downloadManager: this.downloadManager,
-      annotationStorage: this.pdfDocument.annotationStorage,
       l10n,
     });
   }

--- a/web/firefox_print_service.js
+++ b/web/firefox_print_service.js
@@ -57,7 +57,7 @@ function composePage(
           transform: [PRINT_UNITS, 0, 0, PRINT_UNITS, 0, 0],
           viewport: pdfPage.getViewport({ scale: 1, rotation: size.rotation }),
           intent: "print",
-          annotationStorage: pdfDocument.annotationStorage.getAll(),
+          annotationStorage: pdfDocument.annotationStorage,
         };
         return pdfPage.render(renderContext).promise;
       })

--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -165,7 +165,8 @@ class IPDFAnnotationLayerFactory {
   /**
    * @param {HTMLDivElement} pageDiv
    * @param {PDFPage} pdfPage
-   * @param {AnnotationStorage} [annotationStorage]
+   * @param {AnnotationStorage} [annotationStorage] - Storage for annotation
+   *   data in forms.
    * @param {string} [imageResourcesPath] - Path for image resources, mainly
    *   for annotation icons. Include trailing slash.
    * @param {boolean} renderInteractiveForms

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -38,6 +38,8 @@ import { viewerCompatibilityParams } from "./viewer_compatibility.js";
  * @property {number} id - The page unique ID (normally its number).
  * @property {number} scale - The page scale display.
  * @property {PageViewport} defaultViewport - The page viewport.
+ * @property {AnnotationStorage} [annotationStorage] - Storage for annotation
+ *   data in forms. The default value is `null`.
  * @property {PDFRenderingQueue} renderingQueue - The rendering queue object.
  * @property {IPDFTextLayerFactory} textLayerFactory
  * @property {number} [textLayerMode] - Controls if the text layer used for
@@ -81,6 +83,7 @@ class PDFPageView {
     this.rotation = 0;
     this.scale = options.scale || DEFAULT_SCALE;
     this.viewport = defaultViewport;
+    this._annotationStorage = options.annotationStorage || null;
     this.pdfPageRotate = defaultViewport.rotation;
     this.hasRestrictedScaling = false;
     this.textLayerMode = Number.isInteger(options.textLayerMode)
@@ -533,6 +536,7 @@ class PDFPageView {
         this.annotationLayer = this.annotationLayerFactory.createAnnotationLayerBuilder(
           div,
           pdfPage,
+          this._annotationStorage,
           this.imageResourcesPath,
           this.renderInteractiveForms,
           this.l10n

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -54,7 +54,7 @@ function renderPage(
         transform: [PRINT_UNITS, 0, 0, PRINT_UNITS, 0, 0],
         viewport: pdfPage.getViewport({ scale: 1, rotation: size.rotation }),
         intent: "print",
-        annotationStorage: pdfDocument.annotationStorage.getAll(),
+        annotationStorage: pdfDocument.annotationStorage,
       };
       return pdfPage.render(renderContext).promise;
     })


### PR DESCRIPTION
While the parameter name (clearly) suggests that an `AnnotationStorage`-instance is expected, looking at the only call-sites that include the parameter (i.e. the `PDFPrintServiceFactory` instances) it actually contains just a normal Object.

Hence it seems much more reasonable to actually pass a valid `AnnotationStorage`-instance, as the name suggests, and simply have `PDFPageProxy.render` do the `annotationStorage.getAll()` call. (Since we cannot send an `AnnotationStorage`-instance as-is to the worker-thread, given the "structured clone algorithm".)

