### PR TITLE
Do the `AppOptions.get("printResolution")` lookup once in `web/app.js `, when initializing `PDFPrintServiceFactory`-instances, rather than for every printed page

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1609,10 +1609,13 @@ const PDFViewerApplication = {
 
     const pagesOverview = this.pdfViewer.getPagesOverview();
     const printContainer = this.appConfig.printContainer;
+    const printResolution = AppOptions.get("printResolution");
+
     const printService = PDFPrintServiceFactory.instance.createPrintService(
       this.pdfDocument,
       pagesOverview,
       printContainer,
+      printResolution,
       this.l10n
     );
     this.printService = printService;

--- a/web/firefox_print_service.js
+++ b/web/firefox_print_service.js
@@ -13,18 +13,22 @@
  * limitations under the License.
  */
 
-import { AppOptions } from "./app_options.js";
 import { CSS_UNITS } from "./ui_utils.js";
 import { PDFPrintServiceFactory } from "./app.js";
 import { shadow } from "pdfjs-lib";
 
 // Creates a placeholder with div and canvas with right size for the page.
-function composePage(pdfDocument, pageNumber, size, printContainer) {
+function composePage(
+  pdfDocument,
+  pageNumber,
+  size,
+  printContainer,
+  printResolution
+) {
   const canvas = document.createElement("canvas");
 
   // The size of the canvas in pixels for printing.
-  const PRINT_RESOLUTION = AppOptions.get("printResolution") || 150;
-  const PRINT_UNITS = PRINT_RESOLUTION / 72.0;
+  const PRINT_UNITS = printResolution / 72.0;
   canvas.width = Math.floor(size.width * PRINT_UNITS);
   canvas.height = Math.floor(size.height * PRINT_UNITS);
 
@@ -76,21 +80,38 @@ function composePage(pdfDocument, pageNumber, size, printContainer) {
   };
 }
 
-function FirefoxPrintService(pdfDocument, pagesOverview, printContainer) {
+function FirefoxPrintService(
+  pdfDocument,
+  pagesOverview,
+  printContainer,
+  printResolution
+) {
   this.pdfDocument = pdfDocument;
   this.pagesOverview = pagesOverview;
   this.printContainer = printContainer;
+  this._printResolution = printResolution || 150;
 }
 
 FirefoxPrintService.prototype = {
   layout() {
-    const { pdfDocument, pagesOverview, printContainer } = this;
+    const {
+      pdfDocument,
+      pagesOverview,
+      printContainer,
+      _printResolution,
+    } = this;
 
     const body = document.querySelector("body");
     body.setAttribute("data-pdfjsprinting", true);
 
     for (let i = 0, ii = pagesOverview.length; i < ii; ++i) {
-      composePage(pdfDocument, i + 1, pagesOverview[i], printContainer);
+      composePage(
+        pdfDocument,
+        /* pageNumber = */ i + 1,
+        pagesOverview[i],
+        printContainer,
+        _printResolution
+      );
     }
   },
 
@@ -110,8 +131,18 @@ PDFPrintServiceFactory.instance = {
     return shadow(this, "supportsPrinting", value);
   },
 
-  createPrintService(pdfDocument, pagesOverview, printContainer) {
-    return new FirefoxPrintService(pdfDocument, pagesOverview, printContainer);
+  createPrintService(
+    pdfDocument,
+    pagesOverview,
+    printContainer,
+    printResolution
+  ) {
+    return new FirefoxPrintService(
+      pdfDocument,
+      pagesOverview,
+      printContainer,
+      printResolution
+    );
   },
 };
 


### PR DESCRIPTION
There's really no point in repeating these lookups over and over, since the value should be constant for the duration of one print invocation anyway.