### PR TITLE
Add support for `Object.fromEntries`

### DIFF
--- a/src/display/metadata.js
+++ b/src/display/metadata.js
@@ -118,11 +118,7 @@ class Metadata {
   }
 
   getAll() {
-    const obj = Object.create(null);
-    for (const [key, value] of this._metadataMap) {
-      obj[key] = value;
-    }
-    return obj;
+    return Object.fromEntries(this._metadataMap);
   }
 
   has(name) {

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -197,6 +197,15 @@ if (
     require("core-js/es/object/assign.js");
   })();
 
+  // Provides support for Object.fromEntries in legacy browsers.
+  // Support: IE, Chrome<73
+  (function checkObjectFromEntries() {
+    if (Object.fromEntries) {
+      return;
+    }
+    require("core-js/es/object/from-entries.js");
+  })();
+
   // Provides support for Math.log2 in legacy browsers.
   // Support: IE, Chrome<38
   (function checkMathLog2() {


### PR DESCRIPTION
This provides a simpler way of creating an `Object` from e.g. a `Map`, without having to manually iterate over it.
Please see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries