### PR TITLE
A couple of (small) tweaks of the `AnnotationStorage` (PR 12173 follow-up)

### DIFF
--- a/src/display/annotation_storage.js
+++ b/src/display/annotation_storage.js
@@ -18,7 +18,7 @@
  */
 class AnnotationStorage {
   constructor() {
-    this._storage = Object.create(null);
+    this._storage = new Map();
   }
 
   /**
@@ -32,11 +32,11 @@ class AnnotationStorage {
    * @returns {Object}
    */
   getOrCreateValue(key, defaultValue) {
-    if (key in this._storage) {
-      return this._storage[key];
+    if (this._storage.has(key)) {
+      return this._storage.get(key);
     }
 
-    this._storage[key] = defaultValue;
+    this._storage.set(key, defaultValue);
     return defaultValue;
   }
 
@@ -49,11 +49,18 @@ class AnnotationStorage {
    * @param {Object} value
    */
   setValue(key, value) {
-    this._storage[key] = value;
+    this._storage.set(key, value);
   }
 
   getAll() {
-    return this._storage;
+    if (this._storage.size === 0) {
+      return null;
+    }
+    return Object.fromEntries(this._storage);
+  }
+
+  get size() {
+    return this._storage.size;
   }
 }
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -632,14 +632,13 @@ class PDFDocumentProxy {
   constructor(pdfInfo, transport) {
     this._pdfInfo = pdfInfo;
     this._transport = transport;
-    this._annotationStorage = new AnnotationStorage();
   }
 
   /**
    * @type {AnnotationStorage} Storage for annotation data in forms.
    */
   get annotationStorage() {
-    return this._annotationStorage;
+    return shadow(this, "annotationStorage", new AnnotationStorage());
   }
 
   /**


### PR DESCRIPTION
 - Initialize the `AnnotationStorage`-instance, on `PDFDocumentProxy`, lazily.
 - Change the `AnnotationStorage` to use a `Map` internally, rather than a regular Object (simplifies the following points).
 - Let `AnnotationStorage.getAll` return `null` when there's no data stored, to avoid unnecessary parsing on the worker-thread. This ought to "just work", since the worker-thread code *should* already handle the `!annotationStorage` case everywhere.
 - Add a new `AnnotationStorage.size` getter, to be able to easily tell if there's any data stored.