### PR TITLE
Set `direction: ltr;` on the canvases used during printing (bug 1335712)

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1800,6 +1800,7 @@ html[dir='rtl'] #documentPropertiesOverlay .row > * {
   }
   #printContainer canvas,
   #printContainer img {
+    direction: ltr;
     display: block;
   }
 }


### PR DESCRIPTION
This essentially mirrors the CSS rules used for the viewer itself, see `web/pdf_viewer.css`, and according to my very quick tests it seems to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1335712

/cc @brendandahl 