### PR TITLE
Fix #12198 by setting a non-transparent background

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -713,7 +713,7 @@ html[dir='rtl'] .dropdownToolbarButton::after {
   margin: 0;
   padding: 3px 2px 2px;
   border: none;
-  background: rgba(0,0,0,0); /* Opera does not support 'transparent' <select> background */
+  background-color: rgba(82,82,82,.95);
 }
 
 .dropdownToolbarButton > select > option {


### PR DESCRIPTION
The transparent background causes Firefox to show the rounded popup border on macOS. Because the popup is transparent and also has a background-color that is applied to the option children, the transparent background gets evaluated to the user-agent color, which is a shade of grey.

Setting an explicit color here is the simplest route to fix this. I used rgba(82,82,82,.95) as it was one of the stop colors of the toolbar gradient.