### PR TITLE
wip - add support for defaultAppearance fonts in text areas 

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -50,7 +50,7 @@ class AnnotationFactory {
    * @returns {Promise} A promise that is resolved with an {Annotation}
    *   instance.
    */
-  static create(xref, ref, pdfManager, idFactory) {
+  static create(xref, ref, pdfManager, idFactory, defaultAppearanceData) {
     return pdfManager.ensureCatalog("acroForm").then(acroForm => {
       return pdfManager.ensure(this, "_create", [
         xref,
@@ -58,6 +58,7 @@ class AnnotationFactory {
         pdfManager,
         idFactory,
         acroForm,
+        defaultAppearanceData,
       ]);
     });
   }
@@ -65,7 +66,14 @@ class AnnotationFactory {
   /**
    * @private
    */
-  static _create(xref, ref, pdfManager, idFactory, acroForm) {
+  static _create(
+    xref,
+    ref,
+    pdfManager,
+    idFactory,
+    acroForm,
+    defaultAppearanceData
+  ) {
     const dict = xref.fetchIfRef(ref);
     if (!isDict(dict)) {
       return undefined;
@@ -86,6 +94,10 @@ class AnnotationFactory {
       id,
       pdfManager,
       acroForm: acroForm instanceof Dict ? acroForm : Dict.empty,
+      defaultAppearanceData:
+        defaultAppearanceData instanceof Dict
+          ? defaultAppearanceData
+          : Dict.empty,
     };
 
     switch (subtype) {
@@ -242,6 +254,7 @@ class Annotation {
   constructor(params) {
     const dict = params.dict;
 
+    this.defaultAppearanceData = params.defaultAppearanceData;
     this.setContents(dict.get("Contents"));
     this.setModificationDate(dict.get("M"));
     this.setFlags(dict.get("F"));
@@ -1285,6 +1298,14 @@ class WidgetAnnotation extends Annotation {
 class TextWidgetAnnotation extends WidgetAnnotation {
   constructor(params) {
     super(params);
+    if (params.defaultAppearanceData) {
+      const keys = ["fontRefName", "fontName", "fontSize", "fontColor"];
+      for (const key of keys) {
+        if (key in params.defaultAppearanceData && !(key in this.data)) {
+          this.data[key] = params.defaultAppearanceData[key];
+        }
+      }
+    }
 
     this._hasText = true;
 

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -48,7 +48,12 @@ import {
   XRefEntryException,
   XRefParseException,
 } from "./core_utils.js";
-import { NullStream, Stream, StreamsSequenceStream } from "./stream.js";
+import {
+  NullStream,
+  Stream,
+  StreamsSequenceStream,
+  StringStream,
+} from "./stream.js";
 import { AnnotationFactory } from "./annotation.js";
 import { calculateMD5 } from "./crypto.js";
 import { Linearization } from "./parser.js";
@@ -76,6 +81,8 @@ class Page {
     fontCache,
     builtInCMapCache,
     globalImageCache,
+    defaultAppearance,
+    defaultResources,
   }) {
     this.pdfManager = pdfManager;
     this.pageIndex = pageIndex;
@@ -87,6 +94,9 @@ class Page {
     this.globalImageCache = globalImageCache;
     this.evaluatorOptions = pdfManager.evaluatorOptions;
     this.resourcesPromise = null;
+    this.defaultAppearancePromise = null;
+    this.defaultAppearance = defaultAppearance;
+    this.defaultResources = defaultResources;
 
     const idCounters = {
       obj: 0,
@@ -125,11 +135,13 @@ class Page {
     // For robustness: The spec states that a \Resources entry has to be
     // present, but can be empty. Some documents still omit it; in this case
     // we return an empty dictionary.
-    return shadow(
-      this,
-      "resources",
-      this._getInheritableProperty("Resources") || Dict.empty
-    );
+
+    const resources = this._getInheritableProperty("Resources") || Dict.empty;
+    const acroForm = this.pdfManager.pdfDocument.catalog.acroForm;
+    if (acroForm && acroForm.get("DR")) {
+      resources.defaultResources = acroForm.get("DR");
+    }
+    return shadow(this, "resources", resources);
   }
 
   _getBoundingBox(name) {
@@ -307,7 +319,17 @@ class Page {
       options: this.evaluatorOptions,
     });
 
-    const dataPromises = Promise.all([contentStreamPromise, resourcesPromise]);
+    if (!this.defaultAppearancePromise) {
+      this.defaultAppearancePromise = this.handleDefaultAppearance(
+        partialEvaluator,
+        task
+      );
+    }
+    const dataPromises = Promise.all([
+      contentStreamPromise,
+      resourcesPromise,
+      this.defaultAppearancePromise,
+    ]);
     const pageListPromise = dataPromises.then(([contentStream]) => {
       const opList = new OperatorList(intent, sink);
 
@@ -375,6 +397,24 @@ class Page {
     );
   }
 
+  handleDefaultAppearance(partialEvaluator, task) {
+    if (this.defaultAppearanceData) {
+      return new Promise();
+    }
+
+    const opList = new OperatorList();
+
+    const appearanceStream = new StringStream(this.defaultAppearance);
+    this.defaultAppearanceData = Dict.empty;
+    return partialEvaluator.getAcroformDefaultAppearanceData({
+      stream: appearanceStream,
+      task,
+      resources: this.defaultResources,
+      operatorList: opList,
+      data: this.defaultAppearanceData,
+    });
+  }
+
   extractTextContent({
     handler,
     task,
@@ -391,20 +431,29 @@ class Page {
       "XObject",
       "Font",
     ]);
+    const partialEvaluator = new PartialEvaluator({
+      xref: this.xref,
+      handler,
+      pageIndex: this.pageIndex,
+      idFactory: this._localIdFactory,
+      fontCache: this.fontCache,
+      builtInCMapCache: this.builtInCMapCache,
+      globalImageCache: this.globalImageCache,
+      options: this.evaluatorOptions,
+    });
 
-    const dataPromises = Promise.all([contentStreamPromise, resourcesPromise]);
+    if (!this.defaultAppearancePromise) {
+      warn(
+        "extractTextContent ran before this.defaultAppearancePromise was set!"
+      );
+    }
+
+    const dataPromises = Promise.all([
+      contentStreamPromise,
+      resourcesPromise,
+      this.defaultAppearancePromise,
+    ]);
     return dataPromises.then(([contentStream]) => {
-      const partialEvaluator = new PartialEvaluator({
-        xref: this.xref,
-        handler,
-        pageIndex: this.pageIndex,
-        idFactory: this._localIdFactory,
-        fontCache: this.fontCache,
-        builtInCMapCache: this.builtInCMapCache,
-        globalImageCache: this.globalImageCache,
-        options: this.evaluatorOptions,
-      });
-
       return partialEvaluator.getTextContent({
         stream: contentStream,
         task,
@@ -447,7 +496,8 @@ class Page {
               this.xref,
               annotationRef,
               this.pdfManager,
-              this._localIdFactory
+              this._localIdFactory,
+              this.defaultAppearanceData
             ).catch(function (reason) {
               warn(`_parsedAnnotations: "${reason}".`);
               return null;
@@ -552,7 +602,7 @@ class PDFDocument {
     this.stream = stream;
     this.xref = new XRef(stream, pdfManager);
     this._pagePromises = [];
-    this._version = null;
+    this._defaultAppearance = null;
 
     const idCounters = {
       font: 0,
@@ -898,6 +948,13 @@ class PDFDocument {
         ? this._getLinearizationPage(pageIndex)
         : catalog.getPageDict(pageIndex);
 
+    const defaultAppearance = this.catalog.acroForm
+      ? this.catalog.acroForm.get("DA") || ""
+      : "";
+    const defaultResources = this.catalog.acroForm
+      ? this.catalog.acroForm.get("DR") || Dict.empty
+      : Dict.empty;
+
     return (this._pagePromises[pageIndex] = promise.then(([pageDict, ref]) => {
       return new Page({
         pdfManager: this.pdfManager,
@@ -909,6 +966,8 @@ class PDFDocument {
         fontCache: catalog.fontCache,
         builtInCMapCache: catalog.builtInCMapCache,
         globalImageCache: catalog.globalImageCache,
+        defaultAppearance,
+        defaultResources,
       });
     }));
   }

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -694,7 +694,7 @@ class WorkerMessageHandler {
               }
               sink.error(reason);
 
-              // TODO: Should `reason` be re-thrown here (currently that casues
+              // TODO: Should `reason` be re-thrown here (currently that causes
               //       "Uncaught exception: ..." messages in the console)?
             }
           );

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -447,6 +447,7 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
     this.container.className = "textWidgetAnnotation";
 
     let element = null;
+    let font = null;
     if (this.renderInteractiveForms) {
       // NOTE: We cannot set the values using `element.value` below, since it
       //       prevents the AnnotationLayer rasterizer in `test/driver.js`
@@ -480,21 +481,27 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
         element.classList.add("comb");
         element.style.letterSpacing = `calc(${combWidth}px - 1ch)`;
       }
-    } else {
-      element = document.createElement("div");
-      element.textContent = this.data.fieldValue;
-      element.style.verticalAlign = "middle";
-      element.style.display = "table-cell";
-
-      let font = null;
       if (
         this.data.fontRefName &&
         this.page.commonObjs.has(this.data.fontRefName)
       ) {
         font = this.page.commonObjs.get(this.data.fontRefName);
       }
-      this._setTextStyle(element, font);
+    } else {
+      element = document.createElement("div");
+      element.textContent = this.data.fieldValue;
+      element.style.verticalAlign = "middle";
+      element.style.display = "table-cell";
+
+      if (
+        this.data.fontRefName &&
+        this.page.commonObjs.has(this.data.fontRefName)
+      ) {
+        font = this.page.commonObjs.get(this.data.fontRefName);
+      }
     }
+
+    this._setTextStyle(element, font);
 
     if (this.data.textAlignment !== null) {
       element.style.textAlign = TEXT_ALIGNMENT[this.data.textAlignment];
@@ -515,7 +522,9 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
   _setTextStyle(element, font) {
     // TODO: This duplicates some of the logic in CanvasGraphics.setFont().
     const style = element.style;
-    style.fontSize = `${this.data.fontSize}px`;
+    if (this.data.fontSize) {
+      style.fontSize = `${this.data.fontSize}px`;
+    }
     style.direction = this.data.fontDirection < 0 ? "rtl" : "ltr";
 
     if (!font) {
@@ -535,6 +544,7 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
     const fontFamily = font.loadedName ? `"${font.loadedName}", ` : "";
     const fallbackName = font.fallbackName || "Helvetica, sans-serif";
     style.fontFamily = fontFamily + fallbackName;
+    // XXX revisit fontColor. Setting style.color doesn't stick.
   }
 }
 

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -1863,6 +1863,36 @@ describe("annotation", function () {
           done();
         }, done.fail);
     });
+
+    it("should expose document defaultAppearance", function (done) {
+      const defaultAppearanceData = Dict.empty;
+      defaultAppearanceData.set("fontRefName", "g_0");
+      defaultAppearanceData.set("fontName", "Courier");
+      defaultAppearanceData.set("fontSize", 7);
+      const textWidgetRef = Ref.get(123, 0);
+      const xref = new XRefMock([{ ref: textWidgetRef, data: textWidgetDict }]);
+      partialEvaluator.xref = xref;
+
+      AnnotationFactory.create(
+        xref,
+        textWidgetRef,
+        pdfManagerMock,
+        idFactoryMock,
+        Dict.empty,
+        defaultAppearanceData
+      ).then(annotation => {
+        expect(annotation.data.fontRefName).toEqual(
+          defaultAppearanceData.fontRefName
+        );
+        expect(annotation.data.fontName).toEqual(
+          defaultAppearanceData.fontName
+        );
+        expect(annotation.data.fontSize).toEqual(
+          defaultAppearanceData.fontSize
+        );
+        done();
+      }, done.fail);
+    });
   });
 
   describe("ButtonWidgetAnnotation", function () {


### PR DESCRIPTION
This works! If I override the `DA` with something like `/CourierNewPSMT 8 Tf 0 g` in `i9.pdf`, then the text I type in a textarea shows up as Courier instead of Helvetica.

I do have some questions.

- I went the evaluator route because I wanted to load the font in our font cache and get a `fontRefName` back. I wasn't sure if we also wanted to preserve the `OperatorList` ?
  - Because I'm using the evaluator, I need a `handler` and `task`. I added calls to both `Page.getOperatorList` and `Page.extractTextContent` to reuse those handlers and tasks. I'm not sure if there's a more elegant way.
- I'm currently loading the `defaultAppearanceData` once per page, which might be good if we need the `OperatorList` or populate the font cache per page. Otherwise we might be able to load it once per `PDFDocument`. (I'm trying the `PDFDocument` solution in https://github.com/escapewindow/pdf.js/commits/page-acrodict-wip and it breaks the entire form badly. It's quite possible I'm doing something wrong, however.)
- I'm unable to do anything with `fontColor`. I have an rgb color, but setting `style.color` doesn't seem to do anything. If I `console.log(style.color)` before and after, it's unchanged. Maybe it's read-only (or maybe I did something wrong again)?

Most of this is new code, but it's based on @dmitryskey's code from #8625. I commited the rebased patch with @dmitryskey as the author, so we both show up.

What do you think @brendandahl ?