### PR TITLE
Keep the original class/function names when minifying code (issue 12209)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -909,18 +909,30 @@ function parseMinified(dir) {
   console.log("### Minifying js files");
 
   var Terser = require("terser");
-  // V8 chokes on very long sequences. Works around that.
-  var optsForHugeFile = { compress: { sequences: false } };
+  var options = {
+    compress: {
+      // V8 chokes on very long sequences, work around that.
+      sequences: false,
+    },
+    keep_classnames: true,
+    keep_fnames: true,
+  };
 
-  fs.writeFileSync(dir + "/web/pdf.viewer.js", Terser.minify(viewerFiles).code);
-  fs.writeFileSync(dir + "/build/pdf.min.js", Terser.minify(pdfFile).code);
+  fs.writeFileSync(
+    dir + "/web/pdf.viewer.js",
+    Terser.minify(viewerFiles, options).code
+  );
+  fs.writeFileSync(
+    dir + "/build/pdf.min.js",
+    Terser.minify(pdfFile, options).code
+  );
   fs.writeFileSync(
     dir + "/build/pdf.worker.min.js",
-    Terser.minify(pdfWorkerFile, optsForHugeFile).code
+    Terser.minify(pdfWorkerFile, options).code
   );
   fs.writeFileSync(
     dir + "image_decoders/pdf.image_decoders.min.js",
-    Terser.minify(pdfImageDecodersFile).code
+    Terser.minify(pdfImageDecodersFile, options).code
   );
 
   console.log();

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2271,11 +2271,16 @@ class WorkerTransport {
           reason = new UnknownErrorException(ex.message, ex.details);
           break;
       }
-      if (
-        typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("!PRODUCTION || TESTING")
-      ) {
-        assert(reason instanceof Error, "DocException: expected an Error.");
+      if (!(reason instanceof Error)) {
+        const msg = "DocException - expected a valid Error.";
+        if (
+          typeof PDFJSDev === "undefined" ||
+          PDFJSDev.test("!PRODUCTION || TESTING")
+        ) {
+          unreachable(msg);
+        } else {
+          warn(msg);
+        }
       }
       loadingTask._capability.reject(reason);
     });


### PR DESCRIPTION
While this will obviously increase the size of the output of `gulp minified`/`gulp minified-es5` *slightly*, the resulting files are still a lot smaller than the non-minified builds.

See https://github.com/terser/terser#minify-options for information about various Terser options.

Fixes #12209
Fixes #11941