### PR TITLE
Wait until saving has finished before resetting `PDFViewerApplication._saveInProgress` (PR 12137 follow-up)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -939,8 +939,10 @@ const PDFViewerApplication = {
       })
       .catch(() => {
         this.download();
-      }); // Error occurred, try downloading with the URL.
-    this._saveInProgress = false;
+      })
+      .finally(() => {
+        this._saveInProgress = false;
+      });
   },
 
   /**


### PR DESCRIPTION
I obviously missed this during review, but currently `PDFViewerApplication._saveInProgress` is reset *synchronously* in `PDFViewerApplication.save`.
That was probably not intended, since it essentially renders the `PDFViewerApplication._saveInProgress` check pointless given that the actual saving is an *asynchronous* operation.