### PR TITLE
Dispatch event when annotations have finished rendering.

### DIFF
--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -60,9 +60,11 @@ class AnnotationLayerBuilder {
   /**
    * @param {PageViewport} viewport
    * @param {string} intent (default value is 'display')
+   * @returns {Promise<void>} A promise that is resolved when rendering of the
+   *   annotations is complete.
    */
   render(viewport, intent = "display") {
-    this.pdfPage.getAnnotations({ intent }).then(annotations => {
+    return this.pdfPage.getAnnotations({ intent }).then(annotations => {
       if (this._cancelled) {
         return;
       }

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -145,6 +145,24 @@ class PDFPageView {
   /**
    * @private
    */
+  async _renderAnnotationLayer() {
+    let error = null;
+    try {
+      await this.annotationLayer.render(this.viewport, "display");
+    } catch (ex) {
+      error = ex;
+    } finally {
+      this.eventBus.dispatch("annotationlayerrendered", {
+        source: this,
+        pageNumber: this.id,
+        error,
+      });
+    }
+  }
+
+  /**
+   * @private
+   */
   _resetZoomLayer(removeFromDOM = false) {
     if (!this.zoomLayer) {
       return;
@@ -384,7 +402,7 @@ class PDFPageView {
     }
 
     if (redrawAnnotations && this.annotationLayer) {
-      this.annotationLayer.render(this.viewport, "display");
+      this._renderAnnotationLayer();
     }
   }
 
@@ -542,7 +560,7 @@ class PDFPageView {
           this.l10n
         );
       }
-      this.annotationLayer.render(this.viewport, "display");
+      this._renderAnnotationLayer();
     }
     div.setAttribute("data-loaded", true);
 


### PR DESCRIPTION
This is needed for some smoke tests in mozilla central for testing forms
in pdf.js.

Note: AnnotationLayerBuilder.render() doesn't really need to be async, but
we're talking of making the annotation's render functions async, so this
will make that switch easier.