### PR TITLE
fix webpack config problem caused by breaking changes of worker-loader

### DIFF
--- a/external/dist/webpack.js
+++ b/external/dist/webpack.js
@@ -16,7 +16,7 @@
 "use strict";
 
 var pdfjs = require("./build/pdf.js");
-var PdfjsWorker = require("worker-loader!./build/pdf.worker.js");
+var PdfjsWorker = require("worker-loader?esModule=false!./build/pdf.worker.js");
 
 if (typeof window !== "undefined" && "Worker" in window) {
   pdfjs.GlobalWorkerOptions.workerPort = new PdfjsWorker();


### PR DESCRIPTION
Hi, this is my first time to contribute to pdf.js. I already read the `Contributing` wiki and try to follow it. But if I made any mistake please let me know. Thanks!

The problem is caused by a breaking change from worker-loader(https://github.com/webpack-contrib/worker-loader/releases/tag/v3.0.0). It switches on ES module syntax by default now, so if pdfjs webpack config still uses CommonJS module, `esModule=false` need to be set for worker-loader. 
