### PR TITLE
Return searchString with the match count

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -720,7 +720,11 @@ class PDFFindController {
     if (current < 1 || current > total) {
       current = total = 0;
     }
-    return { current, total };
+    return {
+      current,
+      total,
+      searchString: this._query,
+    };
   }
 
   _updateUIResultsCount() {


### PR DESCRIPTION
Firefox [D85140](https://phabricator.services.mozilla.com/D85140#2729587) needs this since on macOS the search string is saved to the find clipboard if there are search results or if this is the first find that fails.

An alternative considered was returning it here:

https://github.com/mozilla/pdf.js/blob/50bc4a18e8c564753365d927d5ec6a6d2cce3072/web/pdf_find_controller.js#L726-L731