### PR TITLE
 Improve the field value parsing for choice widgets to handle `null` values

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -1610,11 +1610,14 @@ class ChoiceWidgetAnnotation extends WidgetAnnotation {
       }
     }
 
-    // Determine the field value. In this case, it may be a string or an
-    // array of strings. For convenience in the display layer, convert the
-    // string to an array of one string as well.
-    if (!Array.isArray(this.data.fieldValue)) {
+    // The field value can be `null` if no item is selected, a string if one
+    // item is selected or an array of strings if multiple items are selected.
+    // For consistency in the API and convenience in the display layer, we
+    // always make the field value an array with zero, one or multiple items.
+    if (isString(this.data.fieldValue)) {
       this.data.fieldValue = [this.data.fieldValue];
+    } else if (!this.data.fieldValue) {
+      this.data.fieldValue = [];
     }
 
     // Process field flags for the display layer.

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -2478,48 +2478,32 @@ describe("annotation", function () {
       }, done.fail);
     });
 
-    it("should handle array field values", function (done) {
-      const fieldValue = ["Foo", "Bar"];
+    it("should convert the field value to an array", function (done) {
+      const inputs = ["Foo", ["Foo", "Bar"]];
+      const outputs = [["Foo"], ["Foo", "Bar"]];
 
-      choiceWidgetDict.set("V", fieldValue);
+      let promise = Promise.resolve();
+      for (let i = 0, ii = inputs.length; i < ii; i++) {
+        promise = promise.then(() => {
+          choiceWidgetDict.set("V", inputs[i]);
 
-      const choiceWidgetRef = Ref.get(968, 0);
-      const xref = new XRefMock([
-        { ref: choiceWidgetRef, data: choiceWidgetDict },
-      ]);
+          const choiceWidgetRef = Ref.get(968, 0);
+          const xref = new XRefMock([
+            { ref: choiceWidgetRef, data: choiceWidgetDict },
+          ]);
 
-      AnnotationFactory.create(
-        xref,
-        choiceWidgetRef,
-        pdfManagerMock,
-        idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.fieldValue).toEqual(fieldValue);
-        done();
-      }, done.fail);
-    });
-
-    it("should handle string field values", function (done) {
-      const fieldValue = "Foo";
-
-      choiceWidgetDict.set("V", fieldValue);
-
-      const choiceWidgetRef = Ref.get(978, 0);
-      const xref = new XRefMock([
-        { ref: choiceWidgetRef, data: choiceWidgetDict },
-      ]);
-
-      AnnotationFactory.create(
-        xref,
-        choiceWidgetRef,
-        pdfManagerMock,
-        idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.fieldValue).toEqual([fieldValue]);
-        done();
-      }, done.fail);
+          return AnnotationFactory.create(
+            xref,
+            choiceWidgetRef,
+            pdfManagerMock,
+            idFactoryMock
+          ).then(({ data }) => {
+            expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+            expect(data.fieldValue).toEqual(outputs[i]);
+          });
+        });
+      }
+      promise.then(done, done.fail);
     });
 
     it("should handle unknown flags", function (done) {

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -2479,8 +2479,8 @@ describe("annotation", function () {
     });
 
     it("should convert the field value to an array", function (done) {
-      const inputs = ["Foo", ["Foo", "Bar"]];
-      const outputs = [["Foo"], ["Foo", "Bar"]];
+      const inputs = [null, "Foo", ["Foo", "Bar"]];
+      const outputs = [[], ["Foo"], ["Foo", "Bar"]];
 
       let promise = Promise.resolve();
       for (let i = 0, ii = inputs.length; i < ii; i++) {


### PR DESCRIPTION
The specification states that the field value is `null` if no item is selected and we didn't handle this case properly. Even though this did not break the rendering because we always convert the value to an array and the `includes` check in the display layer would simply not match, the field value would be `[null]` which is not expected and strange from an API perspective.

This commit fixes that by ensuring that we return an empty array in case the field value is `null`. The API therefore still always gives an array for the field value, but now the code is more specific so that the value is either an empty array or an array of strings.

Fixes something I noticed while debugging #12233 (see https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/PDF32000_2008.pdf#page=454&zoom=auto,-215,765 for the specification).

_Slightly easier review with the `?w=1` parameter._