### PR TITLE
Support file save triggered from the Firefox integrated version.

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2541,7 +2541,7 @@ class WorkerTransport {
         numPages: this._numPages,
         annotationStorage:
           (annotationStorage && annotationStorage.getAll()) || null,
-        filename: this._fullReader.filename,
+        filename: this._fullReader ? this._fullReader.filename : null,
       })
       .finally(() => {
         annotationStorage.resetModified();

--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -64,7 +64,13 @@ class DownloadManager {
     download(blobUrl, filename);
   }
 
-  download(blob, url, filename) {
+  /**
+   * @param sourceEventType {string} Used to signal what triggered the download.
+   *   The version of PDF.js integrated with Firefox uses this to to determine
+   *   which dialog to show. "save" triggers "save as" and "download" triggers
+   *   the "open with" dialog.
+   */
+  download(blob, url, filename, sourceEventType = "download") {
     if (navigator.msSaveBlob) {
       // IE10 / IE11
       if (!navigator.msSaveBlob(blob, filename)) {

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -115,7 +115,7 @@ class DownloadManager {
     );
   }
 
-  download(blob, url, filename) {
+  download(blob, url, filename, sourceEventType = "download") {
     const blobUrl = URL.createObjectURL(blob);
     const onResponse = err => {
       if (err && this.onerror) {
@@ -130,6 +130,7 @@ class DownloadManager {
         blobUrl,
         originalUrl: url,
         filename,
+        sourceEventType,
       },
       onResponse
     );
@@ -229,6 +230,17 @@ class MozL10n {
   for (const event of events) {
     window.addEventListener(event, handleEvent);
   }
+})();
+
+(function listenSaveEvent() {
+  const handleEvent = function ({ type, detail }) {
+    if (!PDFViewerApplication.initialized) {
+      return;
+    }
+    PDFViewerApplication.eventBus.dispatch(type, { source: window });
+  };
+
+  window.addEventListener("save", handleEvent);
 })();
 
 class FirefoxComDataRangeTransport extends PDFDataRangeTransport {


### PR DESCRIPTION
Related to https://bugzilla.mozilla.org/show_bug.cgi?id=1659753

This allows Firefox trigger a "download" event from ctrl/cmd+s or the "Save
Page As" context menu, which in turn lets pdf.js generate a new PDF if
there is form data to save.

I also now set an `isFallback` flag on downloads triggered from the
fallback bar so Firefox can keep launching the "open with" dialog instead
of the "save as" dialog.