### PR TITLE
Don't warn when navigating away from a modified form, if printing has occurred (issue 12262)

### DIFF
--- a/src/display/annotation_storage.js
+++ b/src/display/annotation_storage.js
@@ -58,7 +58,7 @@ class AnnotationStorage {
    */
   setValue(key, value) {
     if (this._storage.get(key) !== value) {
-      this.setModified();
+      this._setModified();
     }
     this._storage.set(key, value);
   }
@@ -74,7 +74,10 @@ class AnnotationStorage {
     return this._storage.size;
   }
 
-  setModified() {
+  /**
+   * @private
+   */
+  _setModified() {
     if (!this._modified) {
       this._modified = true;
       if (typeof this.onSetModified === "function") {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2544,7 +2544,9 @@ class WorkerTransport {
         filename: this._fullReader ? this._fullReader.filename : null,
       })
       .finally(() => {
-        annotationStorage.resetModified();
+        if (annotationStorage) {
+          annotationStorage.resetModified();
+        }
       });
   }
 

--- a/web/app.js
+++ b/web/app.js
@@ -1687,6 +1687,10 @@ const PDFViewerApplication = {
     if (this.printService) {
       this.printService.destroy();
       this.printService = null;
+
+      if (this.pdfDocument) {
+        this.pdfDocument.annotationStorage.resetModified();
+      }
     }
     this.forceRendering();
   },


### PR DESCRIPTION
This solution is obviously *not* perfect, since printing being cancelled will thus remove the warning as well. However, a similar problem already exists for saving, since the user may cancel that one as well.

All-in-all, since way cannot really detect with absolute certainty that either saving or printing actually finished, this seems good enough for now.

Fixes #12262