### PR TITLE
Reduce the leading padding for the `numPages` span (PR 11077 follow-up)

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1249,6 +1249,13 @@ html[dir='rtl'] .toolbarField[type=checkbox] {
   cursor: default;
 }
 
+html[dir='ltr'] #numPages.toolbarLabel {
+  padding-left: 2px;
+}
+html[dir='rtl'] #numPages.toolbarLabel {
+  padding-right: 2px;
+}
+
 #thumbnailView {
   position: absolute;
   width: calc(100% - 60px);


### PR DESCRIPTION
Currently there's enough leading padding that the `numPages` span feels somewhat "disconnected" from the `pageNumber` input, which seems unfortunate when they contain related state.