### PR TITLE
Accent positioning in Type1 `seac` glyphs

### DIFF
--- a/src/core/type1_parser.js
+++ b/src/core/type1_parser.js
@@ -232,7 +232,9 @@ var Type1CharString = (function Type1CharStringClosure() {
               // seac is like type 2's special endchar but it doesn't use the
               // first argument asb, so remove it.
               if (seacAnalysisEnabled) {
+                const asb = this.stack[this.stack.length - 5];
                 this.seac = this.stack.splice(-4, 4);
+                this.seac[0] += this.lsb - asb;
                 error = this.executeCommand(0, COMMAND_MAP.endchar);
               } else {
                 error = this.executeCommand(4, COMMAND_MAP.endchar);

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1798,8 +1798,10 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
           } else {
             this.paintChar(character, scaledX, scaledY, patternTransform);
             if (accent) {
-              scaledAccentX = scaledX + accent.offset.x / fontSizeScale;
-              scaledAccentY = scaledY - accent.offset.y / fontSizeScale;
+              scaledAccentX =
+                scaledX + (fontSize * accent.offset.x) / fontSizeScale;
+              scaledAccentY =
+                scaledY - (fontSize * accent.offset.y) / fontSizeScale;
               this.paintChar(
                 accent.fontChar,
                 scaledAccentX,


### PR DESCRIPTION
In `display/canvas.js` the accent offsets must be multiplied by `fontSize` to make the offsets large enough. This affects both Type1 and CFF fonts. Another problem is in `core/type1_parser.js` when the Type1 command `seac` is handled. There is an error in the Adobe Type1 spec. See chapter 6 in Type1 Font Format Supplement, which provides an errata: The arguments of `seac` specify the offset of the left side bearing (LSB) points, not the offset of origins. This can be fixed in `core/type1_parser.js` by adding the difference of the LSB values.

I didn't add a new reference test case because the following existing cases will do the job and now they are finally rendered correctly:
- issue818
- issue4573
- issue4801
- bug1308536
- glyph_accent

Fixes #4130
Fixes #12253
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1654296
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=845409

See also:
[Type1 Spec](https://www.adobe.com/content/dam/acom/en/devnet/font/pdfs/T1_SPEC.pdf#%5B%7B%22num%22%3A262%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C87%2C733%2C1%5D)
[Type1 Font Format Supplement](https://www.adobe.com/content/dam/acom/en/devnet/font/pdfs/5015.Type1_Supp.pdf#G4.197)