### PR TITLE
Improve AcroForm/XFA form type detection

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -51,7 +51,7 @@ class AnnotationFactory {
    *   instance.
    */
   static create(xref, ref, pdfManager, idFactory) {
-    return pdfManager.ensureDoc("acroForm").then(acroForm => {
+    return pdfManager.ensureCatalog("acroForm").then(acroForm => {
       return pdfManager.ensure(this, "_create", [
         xref,
         ref,

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -600,19 +600,6 @@ class PDFDocument {
       info("Cannot fetch AcroForm entry; assuming no AcroForms are present");
       this.acroForm = null;
     }
-
-    // Check if a Collection dictionary is present in the document.
-    try {
-      const collection = this.catalog.catDict.get("Collection");
-      if (isDict(collection) && collection.size > 0) {
-        this.collection = collection;
-      }
-    } catch (ex) {
-      if (ex instanceof MissingDataException) {
-        throw ex;
-      }
-      info("Cannot fetch Collection dictionary.");
-    }
   }
 
   get linearization() {
@@ -745,7 +732,7 @@ class PDFDocument {
       IsLinearized: !!this.linearization,
       IsAcroFormPresent: !!this.acroForm,
       IsXFAPresent: !!this.xfa,
-      IsCollectionPresent: !!this.collection,
+      IsCollectionPresent: !!this.catalog.collection,
     };
 
     let infoDict;

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -573,7 +573,8 @@ class PDFDocument {
   }
 
   parse(recoveryMode) {
-    this.setup(recoveryMode);
+    this.xref.parse(recoveryMode);
+    this.catalog = new Catalog(this.pdfManager, this.xref);
 
     // The `checkHeader` method is called before this method and parses the
     // version from the header. The specification states in section 7.5.2
@@ -674,11 +675,6 @@ class PDFDocument {
 
   parseStartXRef() {
     this.xref.setStartXRef(this.startXRef);
-  }
-
-  setup(recoveryMode) {
-    this.xref.parse(recoveryMode);
-    this.catalog = new Catalog(this.pdfManager, this.xref);
   }
 
   get numPages() {

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -584,21 +584,13 @@ class PDFDocument {
     }
 
     // Check if AcroForms are present in the document.
-    try {
-      this.acroForm = this.catalog.catDict.get("AcroForm");
-      if (this.acroForm) {
-        this.xfa = this.acroForm.get("XFA");
-        const fields = this.acroForm.get("Fields");
-        if ((!Array.isArray(fields) || fields.length === 0) && !this.xfa) {
-          this.acroForm = null; // No fields and no XFA, so it's not a form.
-        }
+    this._hasAcroForm = !!this.catalog.acroForm;
+    if (this._hasAcroForm) {
+      this.xfa = this.catalog.acroForm.get("XFA");
+      const fields = this.catalog.acroForm.get("Fields");
+      if ((!Array.isArray(fields) || fields.length === 0) && !this.xfa) {
+        this._hasAcroForm = false; // No fields and no XFA, so it's not a form.
       }
-    } catch (ex) {
-      if (ex instanceof MissingDataException) {
-        throw ex;
-      }
-      info("Cannot fetch AcroForm entry; assuming no AcroForms are present");
-      this.acroForm = null;
     }
   }
 
@@ -730,7 +722,7 @@ class PDFDocument {
     const docInfo = {
       PDFFormatVersion: version,
       IsLinearized: !!this.linearization,
-      IsAcroFormPresent: !!this.acroForm,
+      IsAcroFormPresent: this._hasAcroForm,
       IsXFAPresent: !!this.xfa,
       IsCollectionPresent: !!this.catalog.collection,
     };

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -100,6 +100,22 @@ class Catalog {
     return shadow(this, "collection", collection);
   }
 
+  get acroForm() {
+    let acroForm = null;
+    try {
+      const obj = this.catDict.get("AcroForm");
+      if (isDict(obj) && obj.size > 0) {
+        acroForm = obj;
+      }
+    } catch (ex) {
+      if (ex instanceof MissingDataException) {
+        throw ex;
+      }
+      info("Cannot fetch AcroForm entry; assuming no forms are present.");
+    }
+    return shadow(this, "acroForm", acroForm);
+  }
+
   get metadata() {
     const streamRef = this.catDict.getRaw("Metadata");
     if (!isRef(streamRef)) {

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -65,8 +65,8 @@ class Catalog {
     this.pdfManager = pdfManager;
     this.xref = xref;
 
-    this.catDict = xref.getCatalogObj();
-    if (!isDict(this.catDict)) {
+    this._catDict = xref.getCatalogObj();
+    if (!isDict(this._catDict)) {
       throw new FormatError("Catalog object is not a dictionary.");
     }
 
@@ -77,7 +77,7 @@ class Catalog {
   }
 
   get version() {
-    const version = this.catDict.get("Version");
+    const version = this._catDict.get("Version");
     if (!isName(version)) {
       return shadow(this, "version", null);
     }
@@ -87,7 +87,7 @@ class Catalog {
   get collection() {
     let collection = null;
     try {
-      const obj = this.catDict.get("Collection");
+      const obj = this._catDict.get("Collection");
       if (isDict(obj) && obj.size > 0) {
         collection = obj;
       }
@@ -103,7 +103,7 @@ class Catalog {
   get acroForm() {
     let acroForm = null;
     try {
-      const obj = this.catDict.get("AcroForm");
+      const obj = this._catDict.get("AcroForm");
       if (isDict(obj) && obj.size > 0) {
         acroForm = obj;
       }
@@ -117,7 +117,7 @@ class Catalog {
   }
 
   get metadata() {
-    const streamRef = this.catDict.getRaw("Metadata");
+    const streamRef = this._catDict.getRaw("Metadata");
     if (!isRef(streamRef)) {
       return shadow(this, "metadata", null);
     }
@@ -152,7 +152,7 @@ class Catalog {
   }
 
   get toplevelPagesDict() {
-    const pagesObj = this.catDict.get("Pages");
+    const pagesObj = this._catDict.get("Pages");
     if (!isDict(pagesObj)) {
       throw new FormatError("Invalid top-level pages dictionary.");
     }
@@ -176,7 +176,7 @@ class Catalog {
    * @private
    */
   _readDocumentOutline() {
-    let obj = this.catDict.get("Outlines");
+    let obj = this._catDict.get("Outlines");
     if (!isDict(obj)) {
       return null;
     }
@@ -297,7 +297,7 @@ class Catalog {
   get optionalContentConfig() {
     let config = null;
     try {
-      const properties = this.catDict.get("OCProperties");
+      const properties = this._catDict.get("OCProperties");
       if (!properties) {
         return shadow(this, "optionalContentConfig", null);
       }
@@ -410,12 +410,12 @@ class Catalog {
    * @private
    */
   _readDests() {
-    const obj = this.catDict.get("Names");
+    const obj = this._catDict.get("Names");
     if (obj && obj.has("Dests")) {
       return new NameTree(obj.getRaw("Dests"), this.xref);
-    } else if (this.catDict.has("Dests")) {
+    } else if (this._catDict.has("Dests")) {
       // Simple destination dictionary.
-      return this.catDict.get("Dests");
+      return this._catDict.get("Dests");
     }
     return undefined;
   }
@@ -437,7 +437,7 @@ class Catalog {
    * @private
    */
   _readPageLabels() {
-    const obj = this.catDict.getRaw("PageLabels");
+    const obj = this._catDict.getRaw("PageLabels");
     if (!obj) {
       return null;
     }
@@ -537,7 +537,7 @@ class Catalog {
   }
 
   get pageLayout() {
-    const obj = this.catDict.get("PageLayout");
+    const obj = this._catDict.get("PageLayout");
     // Purposely use a non-standard default value, rather than 'SinglePage', to
     // allow differentiating between `undefined` and /SinglePage since that does
     // affect the Scroll mode (continuous/non-continuous) used in Adobe Reader.
@@ -558,7 +558,7 @@ class Catalog {
   }
 
   get pageMode() {
-    const obj = this.catDict.get("PageMode");
+    const obj = this._catDict.get("PageMode");
     let pageMode = "UseNone"; // Default value.
 
     if (isName(obj)) {
@@ -596,7 +596,7 @@ class Catalog {
       NumCopies: Number.isInteger,
     };
 
-    const obj = this.catDict.get("ViewerPreferences");
+    const obj = this._catDict.get("ViewerPreferences");
     let prefs = null;
 
     if (isDict(obj)) {
@@ -721,7 +721,7 @@ class Catalog {
    * NOTE: "JavaScript" actions are, for now, handled by `get javaScript` below.
    */
   get openAction() {
-    const obj = this.catDict.get("OpenAction");
+    const obj = this._catDict.get("OpenAction");
     let openAction = null;
 
     if (isDict(obj)) {
@@ -754,7 +754,7 @@ class Catalog {
   }
 
   get attachments() {
-    const obj = this.catDict.get("Names");
+    const obj = this._catDict.get("Names");
     let attachments = null;
 
     if (obj && obj.has("EmbeddedFiles")) {
@@ -772,7 +772,7 @@ class Catalog {
   }
 
   get javaScript() {
-    const obj = this.catDict.get("Names");
+    const obj = this._catDict.get("Names");
 
     let javaScript = null;
     function appendIfJavaScriptDict(jsDict) {
@@ -808,7 +808,7 @@ class Catalog {
     }
 
     // Append OpenAction "JavaScript" actions to the JavaScript array.
-    const openAction = this.catDict.get("OpenAction");
+    const openAction = this._catDict.get("OpenAction");
     if (isDict(openAction) && isName(openAction.get("S"), "JavaScript")) {
       appendIfJavaScriptDict(openAction);
     }
@@ -853,7 +853,7 @@ class Catalog {
 
   getPageDict(pageIndex) {
     const capability = createPromiseCapability();
-    const nodesToVisit = [this.catDict.getRaw("Pages")];
+    const nodesToVisit = [this._catDict.getRaw("Pages")];
     const visitedNodes = new RefSet();
     const xref = this.xref,
       pageKidsCountCache = this.pageKidsCountCache;

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -76,6 +76,14 @@ class Catalog {
     this.pageKidsCountCache = new RefSetCache();
   }
 
+  get version() {
+    const version = this.catDict.get("Version");
+    if (!isName(version)) {
+      return shadow(this, "version", null);
+    }
+    return shadow(this, "version", version.name);
+  }
+
   get metadata() {
     const streamRef = this.catDict.getRaw("Metadata");
     if (!isRef(streamRef)) {

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -84,6 +84,22 @@ class Catalog {
     return shadow(this, "version", version.name);
   }
 
+  get collection() {
+    let collection = null;
+    try {
+      const obj = this.catDict.get("Collection");
+      if (isDict(obj) && obj.size > 0) {
+        collection = obj;
+      }
+    } catch (ex) {
+      if (ex instanceof MissingDataException) {
+        throw ex;
+      }
+      info("Cannot fetch Collection entry; assuming no collection is present.");
+    }
+    return shadow(this, "collection", collection);
+  }
+
   get metadata() {
     const streamRef = this.catDict.getRaw("Metadata");
     if (!isRef(streamRef)) {

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -41,7 +41,9 @@ describe("annotation", function () {
     constructor(params) {
       this.docBaseUrl = params.docBaseUrl || null;
       this.pdfDocument = {
-        acroForm: new Dict(),
+        catalog: {
+          acroForm: new Dict(),
+        },
       };
     }
 
@@ -56,8 +58,8 @@ describe("annotation", function () {
       });
     }
 
-    ensureDoc(prop, args) {
-      return this.ensure(this.pdfDocument, prop, args);
+    ensureCatalog(prop, args) {
+      return this.ensure(this.pdfDocument.catalog, prop, args);
     }
   }
 

--- a/test/unit/document_spec.js
+++ b/test/unit/document_spec.js
@@ -13,7 +13,10 @@
  * limitations under the License.
  */
 
-import { createIdFactory } from "./test_utils.js";
+import { createIdFactory, XRefMock } from "./test_utils.js";
+import { Dict, Name, Ref } from "../../src/core/primitives.js";
+import { PDFDocument } from "../../src/core/document.js";
+import { StringStream } from "../../src/core/stream.js";
 
 describe("document", function () {
   describe("Page", function () {
@@ -38,6 +41,113 @@ describe("document", function () {
       expect(idFactory1.createFontId()).toEqual("f3");
       expect(idFactory1.createFontId()).toEqual("f4");
       expect(idFactory1.getDocId()).toEqual("g_d0");
+    });
+  });
+
+  describe("PDFDocument", function () {
+    const pdfManager = {
+      get docId() {
+        return "d0";
+      },
+    };
+    const stream = new StringStream("Dummy_PDF_data");
+
+    function getDocument(acroForm) {
+      const pdfDocument = new PDFDocument(pdfManager, stream);
+      pdfDocument.catalog = { acroForm };
+      return pdfDocument;
+    }
+
+    it("should get form info when no form data is present", function () {
+      const pdfDocument = getDocument(null);
+      expect(pdfDocument.formInfo).toEqual({
+        hasAcroForm: false,
+        hasXfa: false,
+      });
+    });
+
+    it("should get form info when XFA is present", function () {
+      const acroForm = new Dict();
+
+      // The `XFA` entry can only be a non-empty array or stream.
+      acroForm.set("XFA", []);
+      let pdfDocument = getDocument(acroForm);
+      expect(pdfDocument.formInfo).toEqual({
+        hasAcroForm: false,
+        hasXfa: false,
+      });
+
+      acroForm.set("XFA", ["foo", "bar"]);
+      pdfDocument = getDocument(acroForm);
+      expect(pdfDocument.formInfo).toEqual({
+        hasAcroForm: false,
+        hasXfa: true,
+      });
+
+      acroForm.set("XFA", new StringStream(""));
+      pdfDocument = getDocument(acroForm);
+      expect(pdfDocument.formInfo).toEqual({
+        hasAcroForm: false,
+        hasXfa: false,
+      });
+
+      acroForm.set("XFA", new StringStream("non-empty"));
+      pdfDocument = getDocument(acroForm);
+      expect(pdfDocument.formInfo).toEqual({
+        hasAcroForm: false,
+        hasXfa: true,
+      });
+    });
+
+    it("should get form info when AcroForm is present", function () {
+      const acroForm = new Dict();
+
+      // The `Fields` entry can only be a non-empty array.
+      acroForm.set("Fields", []);
+      let pdfDocument = getDocument(acroForm);
+      expect(pdfDocument.formInfo).toEqual({
+        hasAcroForm: false,
+        hasXfa: false,
+      });
+
+      acroForm.set("Fields", ["foo", "bar"]);
+      pdfDocument = getDocument(acroForm);
+      expect(pdfDocument.formInfo).toEqual({
+        hasAcroForm: true,
+        hasXfa: false,
+      });
+
+      // If the first bit of the `SigFlags` entry is set and the `Fields` array
+      // only contains document signatures, then there is no AcroForm data.
+      acroForm.set("Fields", ["foo", "bar"]);
+      acroForm.set("SigFlags", 2);
+      pdfDocument = getDocument(acroForm);
+      expect(pdfDocument.formInfo).toEqual({
+        hasAcroForm: true,
+        hasXfa: false,
+      });
+
+      const annotationDict = new Dict();
+      annotationDict.set("FT", Name.get("Sig"));
+      annotationDict.set("Rect", [0, 0, 0, 0]);
+      const annotationRef = Ref.get(11, 0);
+
+      const kidsDict = new Dict();
+      kidsDict.set("Kids", [annotationRef]);
+      const kidsRef = Ref.get(10, 0);
+
+      pdfDocument.xref = new XRefMock([
+        { ref: annotationRef, data: annotationDict },
+        { ref: kidsRef, data: kidsDict },
+      ]);
+
+      acroForm.set("Fields", [kidsRef]);
+      acroForm.set("SigFlags", 3);
+      pdfDocument = getDocument(acroForm);
+      expect(pdfDocument.formInfo).toEqual({
+        hasAcroForm: false,
+        hasXfa: false,
+      });
     });
   });
 });

--- a/web/app.js
+++ b/web/app.js
@@ -1426,14 +1426,14 @@ const PDFViewerApplication = {
       this.setTitle(contentDispositionFilename);
     }
 
-    if (info.IsXFAPresent) {
+    if (info.IsXFAPresent && !info.IsAcroFormPresent) {
       console.warn("Warning: XFA is not supported");
       this._delayedFallback(UNSUPPORTED_FEATURES.forms);
     } else if (
-      info.IsAcroFormPresent &&
+      (info.IsAcroFormPresent || info.IsXFAPresent) &&
       !this.pdfViewer.renderInteractiveForms
     ) {
-      console.warn("Warning: AcroForm support is not enabled");
+      console.warn("Warning: Interactive form support is not enabled");
       this._delayedFallback(UNSUPPORTED_FEATURES.forms);
     }
 
@@ -1454,8 +1454,10 @@ const PDFViewerApplication = {
       });
     }
     let formType = null;
-    if (info.IsAcroFormPresent) {
-      formType = info.IsXFAPresent ? "xfa" : "acroform";
+    if (info.IsXFAPresent) {
+      formType = "xfa";
+    } else if (info.IsAcroFormPresent) {
+      formType = "acroform";
     }
     this.externalServices.reportTelemetry({
       type: "documentInfo",


### PR DESCRIPTION
The commit messages contain more information about the individual changes.

Fixes #12217.
Replaces #12254.

For completeness, here is the list of test PDF files with the form type detection results from before/after this patch (note that we only fallback if _only_ XFA is available):

| File  | Before | After | Notes |
| ------ | -------- | ------- | ------- |
| http://www.aloaha.com/wp-content/uploads/2016/07/SampleForm-1.pdf  | AcroForm, XFA, fallback | AcroForm, XFA, no fallback|
| http://www.cic.gc.ca/english/pdf/kits/forms/IMM5257E.PDF  | AcroForm, XFA, fallback | XFA, fallback | `SigFlags` bit set and nested signature in `Fields`.
| https://web.archive.org/web/20121105185256if_/http://www.northeastern.edu/hrm/pdfs/resources/benefits/MBTA-pretax-form-July2012.pdf | AcroForm, XFA, fallback | XFA, fallback | Empty `Fields`.
| https://web.archive.org/web/20110918100215/http://www.irs.gov/pub/irs-pdf/f1040.pdf | AcroForm, no fallback | AcroForm, no fallback | `SigFlags` available, but first bit not set.
| https://github.com/mozilla/pdf.js/files/762326/212241.6.pdf | AcroForm, no fallback | AcroForm, no fallback | `SigFlags` bit set and multiple signatures in `Fields`.