### PR TITLE
Access the `XRef`/`Catalog` data correctly in the "GetStats"/"GetPageIndex" handlers in `src/core/worker.js`

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -438,10 +438,9 @@ class WorkerMessageHandler {
       });
     });
 
-    handler.on("GetPageIndex", function wphSetupGetPageIndex(data) {
-      var ref = Ref.get(data.ref.num, data.ref.gen);
-      var catalog = pdfManager.pdfDocument.catalog;
-      return catalog.getPageIndex(ref);
+    handler.on("GetPageIndex", function wphSetupGetPageIndex({ ref }) {
+      const pageRef = Ref.get(ref.num, ref.gen);
+      return pdfManager.ensureCatalog("getPageIndex", [pageRef]);
     });
 
     handler.on("GetDestinations", function wphSetupGetDestinations(data) {

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -507,7 +507,7 @@ class WorkerMessageHandler {
     });
 
     handler.on("GetStats", function wphSetupGetStats(data) {
-      return pdfManager.pdfDocument.xref.stats;
+      return pdfManager.ensureXRef("stats");
     });
 
     handler.on("GetAnnotations", function ({ pageIndex, intent }) {


### PR DESCRIPTION
- Access the `XRef` data correctly in the "GetStats" handler in `src/core/worker.js`

   Even though the code obviously works as-is, given that we have unit-tests for it, it still feels incorrect to just *assume* that the `XRef`-instance has all of its properties immediately available. Especially when (almost) all of the other handlers, in `src/core/worker.js`, protect their data accesses with appropriate `pdfManager.ensure` calls.

 - Access the `Catalog` data correctly in the "GetPageIndex" handler in `src/core/worker.js`

   Even though the code obviously works as-is, given that we have unit-tests for it, it still feels incorrect to just *assume* that the `Catalog`-instance has all of its properties immediately available. Especially when (almost) all of the other handlers, in `src/core/worker.js`, protect their data accesses with appropriate `pdfManager.ensure` calls.

