### PR TITLE
Ensure that the `sourceEventType` parameter is actually optional in `PDFViewerApplication.{download, save}` (PR 12248 follow-up)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -874,7 +874,7 @@ const PDFViewerApplication = {
     );
   },
 
-  download({ sourceEventType = "download" }) {
+  download({ sourceEventType = "download" } = {}) {
     function downloadByUrl() {
       downloadManager.downloadUrl(url, filename);
     }
@@ -907,7 +907,7 @@ const PDFViewerApplication = {
       .catch(downloadByUrl); // Error occurred, try downloading with the URL.
   },
 
-  save({ sourceEventType = "download" }) {
+  save({ sourceEventType = "download" } = {}) {
     if (this._saveInProgress) {
       return;
     }
@@ -988,7 +988,7 @@ const PDFViewerApplication = {
         if (!download) {
           return;
         }
-        PDFViewerApplication.download();
+        PDFViewerApplication.download({ sourceEventType: "download" });
       }
     );
   },


### PR DESCRIPTION
Without these changes, clicking on the "Open With Different Viewer"-button on the Firefox fallback bar won't actually do anything and the following is printed in the web-console:
```
Uncaught TypeError: (destructured parameter) is undefined
    download resource://pdf.js/web/viewer.js:956
    response resource://pdf.js/web/viewer.js:1054
    listener resource://pdf.js/web/viewer.js:11891
viewer.js:956:1
```

Furthermore, this patch also fixes `PDFViewerApplication.fallback` to pass in an explicit `sourceEventType` when triggering downloading. While this, on its own, would obviously have been sufficient to fix the bug described above, it seems wrong to outright break backwards compatibility of any older `PDFViewerApplication.download` calls.

---

/cc @brendandahl 
/cc @timvandermeij 