### PR TITLE
Use a link, rather than `window.open`, when opening PDF attachments in Firefox (bug 1661259)

### DIFF
--- a/web/pdf_attachment_viewer.js
+++ b/web/pdf_attachment_viewer.js
@@ -118,7 +118,22 @@ class PDFAttachmentViewer extends BaseTreeViewer {
           encodeURIComponent(blobUrl + "#" + filename);
       }
       try {
-        window.open(viewerUrl);
+        if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
+          window.open(viewerUrl);
+        } else {
+          // Since we have a full URL in the MOZCENTRAL-build, use a link rather
+          // than `window.open` since e.g. ad blockers may otherwise force-close
+          // the newly opened window and thus break viewing of PDF attachments
+          // (fixes bug 1661259).
+          const a = document.createElement("a");
+          a.hidden = true;
+          a.href = viewerUrl;
+          a.target = "_blank";
+          // <a> must be in the document, otherwise `a.click()` is ignored.
+          (document.body || document.documentElement).appendChild(a);
+          a.click();
+          a.remove();
+        }
       } catch (ex) {
         console.error(`_bindPdfLink: ${ex}`);
         // Release the `blobUrl`, since opening it failed...


### PR DESCRIPTION
Unfortunately e.g. ad blockers can interfere with `window.open` calls, thus preventing PDF attachments from being opened/viewed. For the MOZCENTRAL-build, we can work-around this problem by using a (hidden) link instead.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1661259