### PR TITLE
Download, rather than opening, PDF attachments in Firefox (bug 1661259, PR 12286 follow-up)

### DIFF
--- a/web/pdf_attachment_viewer.js
+++ b/web/pdf_attachment_viewer.js
@@ -17,6 +17,8 @@ import { createPromiseCapability, getFilenameFromUrl } from "pdfjs-lib";
 import { BaseTreeViewer } from "./base_tree_viewer.js";
 import { viewerCompatibilityParams } from "./viewer_compatibility.js";
 
+const PdfFileRegExp = /\.pdf$/i;
+
 /**
  * @typedef {Object} PDFAttachmentViewerOptions
  * @property {HTMLDivElement} container - The viewer element.
@@ -136,7 +138,8 @@ class PDFAttachmentViewer extends BaseTreeViewer {
    */
   _bindLink(element, { content, filename }) {
     element.onclick = () => {
-      this.downloadManager.downloadData(content, filename, "");
+      const contentType = PdfFileRegExp.test(filename) ? "application/pdf" : "";
+      this.downloadManager.downloadData(content, filename, contentType);
       return false;
     };
   }
@@ -169,7 +172,7 @@ class PDFAttachmentViewer extends BaseTreeViewer {
 
       const element = document.createElement("a");
       if (
-        /\.pdf$/i.test(filename) &&
+        PdfFileRegExp.test(filename) &&
         !viewerCompatibilityParams.disableCreateObjectURL
       ) {
         this._bindPdfLink(element, { content: item.content, filename });

--- a/web/pdf_attachment_viewer.js
+++ b/web/pdf_attachment_viewer.js
@@ -118,22 +118,7 @@ class PDFAttachmentViewer extends BaseTreeViewer {
           encodeURIComponent(blobUrl + "#" + filename);
       }
       try {
-        if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
-          window.open(viewerUrl);
-        } else {
-          // Since we have a full URL in the MOZCENTRAL-build, use a link rather
-          // than `window.open` since e.g. ad blockers may otherwise force-close
-          // the newly opened window and thus break viewing of PDF attachments
-          // (fixes bug 1661259).
-          const a = document.createElement("a");
-          a.hidden = true;
-          a.href = viewerUrl;
-          a.target = "_blank";
-          // <a> must be in the document, otherwise `a.click()` is ignored.
-          (document.body || document.documentElement).appendChild(a);
-          a.click();
-          a.remove();
-        }
+        window.open(viewerUrl);
       } catch (ex) {
         console.error(`_bindPdfLink: ${ex}`);
         // Release the `blobUrl`, since opening it failed...

--- a/web/pdf_attachment_viewer.js
+++ b/web/pdf_attachment_viewer.js
@@ -172,6 +172,7 @@ class PDFAttachmentViewer extends BaseTreeViewer {
 
       const element = document.createElement("a");
       if (
+        (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) &&
         PdfFileRegExp.test(filename) &&
         !viewerCompatibilityParams.disableCreateObjectURL
       ) {


### PR DESCRIPTION
Unfortunately the work-around implemented in PR #12286 didn't actually work in all cases, please refer to the previous commit messages.
To prevent opening of PDF attachments from being completely broken for some users, we'll simply force-download them for now in MOZCENTRAL-builds to unbreak things. (Given that the "Open with" dialog now features a "Open with Firefox"-option, this is less bad than it previously would've been.)

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1661259