### PR TITLE
Add support, in `Dict.merge`, for merging of "sub"-dictionaries

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -114,7 +114,7 @@ class Page {
     if (value.length === 1 || !isDict(value[0])) {
       return value[0];
     }
-    return Dict.merge(this.xref, value);
+    return Dict.merge({ xref: this.xref, dictArray: value });
   }
 
   get content() {

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -726,8 +726,10 @@ class PartialEvaluator {
     const tilingOpList = new OperatorList();
     // Merge the available resources, to prevent issues when the patternDict
     // is missing some /Resources entries (fixes issue6541.pdf).
-    const resourcesArray = [patternDict.get("Resources"), resources];
-    const patternResources = Dict.merge(this.xref, resourcesArray);
+    const patternResources = Dict.merge({
+      xref: this.xref,
+      dictArray: [patternDict.get("Resources"), resources],
+    });
 
     return this.getOperatorList({
       stream: pattern,

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -390,4 +390,13 @@ if (
     }
     Object.values = require("core-js/es/object/values.js");
   })();
+
+  // Provides support for Object.entries in legacy browsers.
+  // Support: IE, Chrome<54
+  (function checkObjectEntries() {
+    if (Object.entries) {
+      return;
+    }
+    Object.entries = require("core-js/es/object/entries.js");
+  })();
 }

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -317,15 +317,62 @@ describe("primitives", function () {
 
       const fontFileDict = new Dict();
       fontFileDict.set("FontFile", "Type1 font file");
-      const mergedDict = Dict.merge(null, [
-        dictWithManyKeys,
-        dictWithSizeKey,
-        fontFileDict,
-      ]);
+      const mergedDict = Dict.merge({
+        xref: null,
+        dictArray: [dictWithManyKeys, dictWithSizeKey, fontFileDict],
+      });
       const mergedKeys = mergedDict.getKeys();
 
       expect(mergedKeys.sort()).toEqual(expectedKeys);
       expect(mergedDict.get("FontFile")).toEqual(testFontFile);
+    });
+
+    it("should correctly merge sub-dictionaries", function () {
+      const localFontDict = new Dict();
+      localFontDict.set("F1", "Local font one");
+
+      const globalFontDict = new Dict();
+      globalFontDict.set("F1", "Global font one");
+      globalFontDict.set("F2", "Global font two");
+      globalFontDict.set("F3", "Global font three");
+
+      const localDict = new Dict();
+      localDict.set("Font", localFontDict);
+
+      const globalDict = new Dict();
+      globalDict.set("Font", globalFontDict);
+
+      const mergedDict = Dict.merge({
+        xref: null,
+        dictArray: [localDict, globalDict],
+      });
+      const mergedSubDict = Dict.merge({
+        xref: null,
+        dictArray: [localDict, globalDict],
+        mergeSubDicts: true,
+      });
+
+      const mergedFontDict = mergedDict.get("Font");
+      const mergedSubFontDict = mergedSubDict.get("Font");
+
+      expect(mergedFontDict instanceof Dict).toEqual(true);
+      expect(mergedSubFontDict instanceof Dict).toEqual(true);
+
+      const mergedFontDictKeys = mergedFontDict.getKeys();
+      const mergedSubFontDictKeys = mergedSubFontDict.getKeys();
+
+      expect(mergedFontDictKeys).toEqual(["F1"]);
+      expect(mergedSubFontDictKeys).toEqual(["F1", "F2", "F3"]);
+
+      const mergedFontDictValues = mergedFontDict.getRawValues();
+      const mergedSubFontDictValues = mergedSubFontDict.getRawValues();
+
+      expect(mergedFontDictValues).toEqual(["Local font one"]);
+      expect(mergedSubFontDictValues).toEqual([
+        "Local font one",
+        "Global font two",
+        "Global font three",
+      ]);
     });
   });
 


### PR DESCRIPTION
This allows for merging of dictionaries one level deeper than previously. This could be useful e.g. for /Resources dictionaries, where you want to e.g. merge their respective /Font dictionaries (and other) together rather than picking just the first one.