### PR TITLE
Fix various :hover effects in the findbar (PR 11077 follow-up)

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -531,11 +531,15 @@ html[dir='rtl'] .findbar .splitToolbarButton > .findNext {
   border-top-right-radius: 0;
 }
 
+.findbar input[type="checkbox"] {
+  pointer-events: none;
+}
+
 .findbar label {
   user-select: none;
 }
 
-.findbar .toolbarLabel:hover, .findbar label:hover,
+.findbar label:hover,
 .findbar input:focus + label {
   background-color: var(--button-hover-color);
 }


### PR DESCRIPTION
This patch:
 - Removes the :hover effect from the `findMsg` element, since it's a simple span and clicking it *obviously* does nothing.
 - Given the way that the checkboxes are visually hidden, with `opacity: 0;` and absolute positioning, they are unfortunately still focusable (fixed by adding `pointer-events: none;`). To reproduce this, in `master`: Place the mouse pointer over the upper left-hand corner of the "Highlight all"-option, and notice that the :hover effect vanishes and clicking toggles the "Match case"-option instead.