### PR TITLE
Add support for /Print and /SaveAs named actions in the viewer (issue 12308)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2210,10 +2210,9 @@ function webViewerPageMode({ mode }) {
 }
 
 function webViewerNamedAction(evt) {
-  // Processing couple of named actions that might be useful.
-  // See also PDFLinkService.executeNamedAction
-  const action = evt.action;
-  switch (action) {
+  // Processing a couple of named actions that might be useful, see also
+  // `PDFLinkService.executeNamedAction`.
+  switch (evt.action) {
     case "GoToPage":
       PDFViewerApplication.appConfig.toolbar.pageNumber.select();
       break;
@@ -2222,6 +2221,16 @@ function webViewerNamedAction(evt) {
       if (!PDFViewerApplication.supportsIntegratedFind) {
         PDFViewerApplication.findBar.toggle();
       }
+      break;
+
+    case "Print":
+      if (PDFViewerApplication.supportsPrinting) {
+        webViewerPrint();
+      }
+      break;
+
+    case "SaveAs":
+      webViewerSave();
       break;
   }
 }


### PR DESCRIPTION
All of the core/display functionality needed to support this already exists, we simply need to handle these named actions in the viewer and the buttons will "just" work.

Unfortunately there's not really any good way of (automatically) testing this, but given the size and scope of the patch that's hopefully OK.

Fixes #12308