### PR TITLE
Add support for lazy merging dictionaries in annotations

### DIFF
--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -15,6 +15,7 @@
 /* eslint no-var: error */
 
 import { assert, BaseException, warn } from "../shared/util.js";
+import { isDict } from "./primitives.js";
 
 function getLookupTableFactory(initializer) {
   let lookup;
@@ -165,12 +166,28 @@ function isWhiteSpace(ch) {
   return ch === 0x20 || ch === 0x09 || ch === 0x0d || ch === 0x0a;
 }
 
+function getLazyMergeDict(dict, fallback) {
+  assert(isDict(dict), "The two arguments must be a Dict");
+  dict.getRaw = function (key) {
+    let value = dict._map[key];
+    if (value === undefined) {
+      assert(isDict(fallback), "The two arguments must be a Dict");
+      assert(dict !== fallback, "The two arguments must be different");
+
+      dict._map[key] = value = fallback.getRaw(key);
+    }
+    return value;
+  };
+  return dict;
+}
+
 export {
   getLookupTableFactory,
   MissingDataException,
   XRefEntryException,
   XRefParseException,
   getInheritableProperty,
+  getLazyMergeDict,
   toRomanNumerals,
   log2,
   readInt8,

--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -91,11 +91,11 @@ var Dict = (function DictClosure() {
 
     // automatically dereferences Ref objects
     get(key1, key2, key3) {
-      let value = this._map[key1];
+      let value = this.getRaw(key1);
       if (value === undefined && key2 !== undefined) {
-        value = this._map[key2];
+        value = this.getRaw(key2);
         if (value === undefined && key3 !== undefined) {
-          value = this._map[key3];
+          value = this.getRaw(key3);
         }
       }
       if (value instanceof Ref && this.xref) {
@@ -106,11 +106,11 @@ var Dict = (function DictClosure() {
 
     // Same as get(), but returns a promise and uses fetchIfRefAsync().
     async getAsync(key1, key2, key3) {
-      let value = this._map[key1];
+      let value = this.getRaw(key1);
       if (value === undefined && key2 !== undefined) {
-        value = this._map[key2];
+        value = this.getRaw(key2);
         if (value === undefined && key3 !== undefined) {
-          value = this._map[key3];
+          value = this.getRaw(key3);
         }
       }
       if (value instanceof Ref && this.xref) {
@@ -161,7 +161,7 @@ var Dict = (function DictClosure() {
     },
 
     has: function Dict_has(key) {
-      return this._map[key] !== undefined;
+      return this.getRaw(key) !== undefined;
     },
 
     forEach: function Dict_forEach(callback) {

--- a/test/unit/core_utils_spec.js
+++ b/test/unit/core_utils_spec.js
@@ -16,6 +16,7 @@
 import { Dict, Ref } from "../../src/core/primitives.js";
 import {
   getInheritableProperty,
+  getLazyMergeDict,
   isWhiteSpace,
   log2,
   toRomanNumerals,
@@ -209,6 +210,23 @@ describe("core_utils", function () {
       expect(isWhiteSpace(0x0b)).toEqual(false);
       expect(isWhiteSpace(null)).toEqual(false);
       expect(isWhiteSpace(undefined)).toEqual(false);
+    });
+  });
+
+  describe("getLazyMergeDict", function () {
+    it("gets values in a dict and lazily merge dictionaries", function () {
+      const base = new Dict(null);
+      base.set("a", 1);
+      const fallback = new Dict(null);
+      fallback.set("b", 2);
+
+      const dict = getLazyMergeDict(base, fallback);
+
+      expect(dict.getRaw("a")).toEqual(1);
+      expect(dict.getRaw("b")).toEqual(2);
+
+      fallback.set("b", 3);
+      expect(dict.getRaw("b")).toEqual(2);
     });
   });
 });


### PR DESCRIPTION
It aims to fix for example issue #12294.
The merge have to be lazy to avoid to write too much potentially useless data when saving a form.  