### PR TITLE
Ensure that the `viewer` property, on `BaseViewer`-instances, is a valid div-element (issue 12320)

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -143,6 +143,17 @@ class BaseViewer {
 
     this.container = options.container;
     this.viewer = options.viewer || options.container.firstElementChild;
+
+    if (
+      (typeof PDFJSDev === "undefined" ||
+        PDFJSDev.test("!PRODUCTION || GENERIC")) &&
+      !(
+        this.container instanceof HTMLDivElement &&
+        this.viewer instanceof HTMLDivElement
+      )
+    ) {
+      throw new Error("Invalid `container` and/or `viewer` option.");
+    }
     this.eventBus = options.eventBus;
     this.linkService = options.linkService || new SimpleLinkService();
     this.downloadManager = options.downloadManager || null;


### PR DESCRIPTION
This should help prevent future issues, caused by the user omitting the `viewer` option and/or providing an incorrect `container` option, when initializing a `BaseViewer`-instance.