### PR TITLE
Remove code-paths only relevant for IE 11/Edge (non-Chromium based) from the `web/` folder

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -611,15 +611,13 @@ const PDFViewerApplication = {
       support = !!(
         doc.requestFullscreen ||
         doc.mozRequestFullScreen ||
-        doc.webkitRequestFullScreen ||
-        doc.msRequestFullscreen
+        doc.webkitRequestFullScreen
       );
 
       if (
         document.fullscreenEnabled === false ||
         document.mozFullScreenEnabled === false ||
-        document.webkitFullscreenEnabled === false ||
-        document.msFullscreenEnabled === false
+        document.webkitFullscreenEnabled === false
       ) {
         support = false;
       }

--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -35,7 +35,7 @@ function download(blobUrl, filename) {
   if ("download" in a) {
     a.download = filename;
   }
-  // <a> must be in the document for IE and recent Firefox versions,
+  // <a> must be in the document for recent Firefox versions,
   // otherwise .click() is ignored.
   (document.body || document.documentElement).appendChild(a);
   a.click();
@@ -51,11 +51,6 @@ class DownloadManager {
   }
 
   downloadData(data, filename, contentType) {
-    if (navigator.msSaveBlob) {
-      // IE10 and above
-      navigator.msSaveBlob(new Blob([data], { type: contentType }), filename);
-      return;
-    }
     const blobUrl = createObjectURL(
       data,
       contentType,
@@ -71,14 +66,6 @@ class DownloadManager {
    *   the "open with" dialog.
    */
   download(blob, url, filename, sourceEventType = "download") {
-    if (navigator.msSaveBlob) {
-      // IE10 / IE11
-      if (!navigator.msSaveBlob(blob, filename)) {
-        this.downloadUrl(url, filename);
-      }
-      return;
-    }
-
     if (viewerCompatibilityParams.disableCreateObjectURL) {
       // URL.createObjectURL is not supported
       this.downloadUrl(url, filename);

--- a/web/grab_to_pan.js
+++ b/web/grab_to_pan.js
@@ -180,7 +180,7 @@ GrabToPan.prototype = {
 
 // Get the correct (vendor-prefixed) name of the matches method.
 let matchesSelector;
-["webkitM", "mozM", "msM", "oM", "m"].some(function (prefix) {
+["webkitM", "mozM", "oM", "m"].some(function (prefix) {
   let name = prefix + "atches";
   if (name in document.documentElement) {
     matchesSelector = name;

--- a/web/pdf_presentation_mode.js
+++ b/web/pdf_presentation_mode.js
@@ -92,8 +92,6 @@ class PDFPresentationMode {
       this.container.mozRequestFullScreen();
     } else if (this.container.webkitRequestFullscreen) {
       this.container.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
-    } else if (this.container.msRequestFullscreen) {
-      this.container.msRequestFullscreen();
     } else {
       return false;
     }
@@ -151,8 +149,7 @@ class PDFPresentationMode {
     return !!(
       document.fullscreenElement ||
       document.mozFullScreen ||
-      document.webkitIsFullScreen ||
-      document.msFullscreenElement
+      document.webkitIsFullScreen
     );
   }
 
@@ -478,7 +475,6 @@ class PDFPresentationMode {
         "webkitfullscreenchange",
         this.fullscreenChangeBind
       );
-      window.addEventListener("MSFullscreenChange", this.fullscreenChangeBind);
     }
   }
 
@@ -494,10 +490,6 @@ class PDFPresentationMode {
     if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
       window.removeEventListener(
         "webkitfullscreenchange",
-        this.fullscreenChangeBind
-      );
-      window.removeEventListener(
-        "MSFullscreenChange",
         this.fullscreenChangeBind
       );
     }

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -341,7 +341,7 @@ window.addEventListener(
 
 if ("onbeforeprint" in window) {
   // Do not propagate before/afterprint events when they are not triggered
-  // from within this polyfill. (FF /IE / Chrome 63+).
+  // from within this polyfill. (FF / Chrome 63+).
   const stopPropagationIfNeeded = function (event) {
     if (event.detail !== "custom" && event.stopImmediatePropagation) {
       event.stopImmediatePropagation();

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -124,10 +124,6 @@
   margin-right: auto;
 }
 
-.pdfPresentationMode:-ms-fullscreen .pdfViewer .page {
-  margin-bottom: 100% !important;
-}
-
 .pdfPresentationMode:fullscreen .pdfViewer .page {
   margin-bottom: 100%;
   border: 0;

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -99,7 +99,6 @@ function getOutputScale(ctx) {
   const backingStoreRatio =
     ctx.webkitBackingStorePixelRatio ||
     ctx.mozBackingStorePixelRatio ||
-    ctx.msBackingStorePixelRatio ||
     ctx.oBackingStorePixelRatio ||
     ctx.backingStorePixelRatio ||
     1;

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -203,15 +203,6 @@ select {
   cursor: not-allowed;
 }
 
-#viewerContainer.pdfPresentationMode:-ms-fullscreen {
-  top: 0px !important;
-  overflow: hidden !important;
-}
-
-#viewerContainer.pdfPresentationMode:-ms-fullscreen::-ms-backdrop {
-  background-color: rgba(0, 0, 0, 1);
-}
-
 #viewerContainer.pdfPresentationMode:fullscreen {
   top: 0px;
   border-top: 2px solid rgba(0, 0, 0, 0);

--- a/web/viewer_compatibility.js
+++ b/web/viewer_compatibility.js
@@ -23,7 +23,6 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
     (typeof navigator !== "undefined" && navigator.maxTouchPoints) || 1;
 
   const isAndroid = /Android/.test(userAgent);
-  const isIE = /Trident/.test(userAgent);
   const isIOS =
     /\b(iPad|iPhone|iPod)(?=;)/.test(userAgent) ||
     (platform === "MacIntel" && maxTouchPoints > 1);
@@ -32,9 +31,9 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
   // Checks if possible to use URL.createObjectURL()
   // Support: IE, Chrome on iOS
   (function checkOnBlobSupport() {
-    // Sometimes IE and Chrome on iOS losing the data created with
-    // createObjectURL(), see issues #3977 and #8081.
-    if (isIE || isIOSChrome) {
+    // Sometimes Chrome on iOS loses data created with createObjectURL(),
+    // see issue #8081.
+    if (isIOSChrome) {
       compatibilityParams.disableCreateObjectURL = true;
     }
   })();


### PR DESCRIPTION
This patch purposely starts small, by removing IE-specific code from various JS/CSS files in the `web/` folder.

There's obviously lots of potential for additional clean-up, especially the removal of no longer necessary polyfills in `src/shared/compatibility.js`, however that will require some care considering that certain polyfills may also be necessary for e.g. Node.js or the Chromium-extension as well.
Generally speaking, once we start removing polyfills it's probably a good idea to consult the compatibility information on https://developer.mozilla.org/ and also https://caniuse.com/ first. (Deciding on the lowest supported Chromium version, for the extension, would also seem like a good idea.)