### PR TITLE
Support broken /FitH destinations that are missing the "top" value (bug 1663390)

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -852,6 +852,10 @@ class BaseViewer {
         if (y === null && this._location) {
           x = this._location.left;
           y = this._location.top;
+        } else if (typeof y !== "number") {
+          // The "top" value isn't optional, according to the spec, however some
+          // bad PDF generators will pretend that it is (fixes bug 1663390).
+          y = pageHeight;
         }
         break;
       case "FitV":


### PR DESCRIPTION
See https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#G11.2095870

Fixes [bug 1663390](https://bugzilla.mozilla.org/show_bug.cgi?id=1663390)