### PR TITLE
canvas: Properly restore all the remaining items in stateStack in endDrawing

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1009,8 +1009,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
 
     endDrawing: function CanvasGraphics_endDrawing() {
       // Finishing all opened operations such as SMask group painting.
-      if (this.current.activeSMask !== null) {
-        this.endSMaskGroup();
+      while (this.stateStack.length || this.current.activeSMask !== null) {
+        this.restore();
       }
 
       this.ctx.restore();


### PR DESCRIPTION
We were correctly finishing the SMask group but not restoring all the extra transformations applied in stateStack, so if somebody ends up drawing to the same context after canceling mid-draw we'd get artifacts.

This fixes Mozilla bug 1664178[1].

[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1664178
