### PR TITLE
Ensure that the `length` property won't be *accidentally* accessed on a `DecodeStream`-instance

### DIFF
--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -167,6 +167,11 @@ var DecodeStream = (function DecodeStreamClosure() {
   }
 
   DecodeStream.prototype = {
+    // eslint-disable-next-line getter-return
+    get length() {
+      unreachable("Should not access DecodeStream.length");
+    },
+
     get isEmpty() {
       while (!this.eof && this.bufferLength === 0) {
         this.readBlock();


### PR DESCRIPTION
For these streams, compared to `Stream` and `ChunkedStream`, there's no well defined concept of length and consequently no `length` getter.[1] However, attempting to access the non-existent `length` won't currently error, but just return `undefined`, which could thus easily lead to bugs elsewhere in the code-base.

---
[1] However, note that *all* stream implementations have an `isEmpty` getter which can be used instead.