### PR TITLE
Revert "canvas: Properly restore all the remaining items in stateStack in endDrawing"

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1009,8 +1009,8 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
 
     endDrawing: function CanvasGraphics_endDrawing() {
       // Finishing all opened operations such as SMask group painting.
-      while (this.stateStack.length || this.current.activeSMask !== null) {
-        this.restore();
+      if (this.current.activeSMask !== null) {
+        this.endSMaskGroup();
       }
 
       this.ctx.restore();


### PR DESCRIPTION
Reverts mozilla/pdf.js#12363 for causing errors, please see https://github.com/mozilla/pdf.js/pull/12363#issuecomment-691488345 for additional details.

Given that development/testing is hampered by the current state of things, and the complexity of the SMask-code, it seems better/safer to just revert it for now and re-land it later once fixed (and with the source of the bug well understood).

Fixes #12367

/cc @timvandermeij 