### PR TITLE
Ensure that the empty dictionary won't be accidentally modified, and slightly improve the "SaveDocument" handler in `src/core/worker.js`

### DIFF
--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -171,7 +171,14 @@ var Dict = (function DictClosure() {
     },
   };
 
-  Dict.empty = new Dict(null);
+  Dict.empty = (function () {
+    const emptyDict = new Dict(null);
+
+    emptyDict.set = (key, value) => {
+      unreachable("Should not call `set` on the empty dictionary.");
+    };
+    return emptyDict;
+  })();
 
   Dict.merge = function ({ xref, dictArray, mergeSubDicts = false }) {
     const mergedDict = new Dict(xref);

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -32,7 +32,7 @@ import {
   VerbosityLevel,
   warn,
 } from "../shared/util.js";
-import { clearPrimitiveCaches, Dict, isDict, Ref } from "./primitives.js";
+import { clearPrimitiveCaches, Dict, Ref } from "./primitives.js";
 import { LocalPdfManager, NetworkPdfManager } from "./pdf_manager.js";
 import { incrementalUpdate } from "./writer.js";
 import { isNodeJS } from "../shared/is_node.js";
@@ -548,8 +548,7 @@ class WorkerMessageHandler {
           return stream.bytes;
         }
 
-        acroForm = isDict(acroForm) ? acroForm : Dict.empty;
-        const xfa = acroForm.get("XFA") || [];
+        const xfa = (acroForm instanceof Dict && acroForm.get("XFA")) || [];
         let xfaDatasets = null;
         if (Array.isArray(xfa)) {
           for (let i = 0, ii = xfa.length; i < ii; i += 2) {
@@ -568,7 +567,7 @@ class WorkerMessageHandler {
           // Get string info from Info in order to compute fileId
           const _info = Object.create(null);
           const xrefInfo = xref.trailer.get("Info") || null;
-          if (xrefInfo) {
+          if (xrefInfo instanceof Dict) {
             xrefInfo.forEach((key, value) => {
               if (isString(key) && isString(value)) {
                 _info[key] = stringToPDFString(value);


### PR DESCRIPTION
 - Ensure that the empty dictionary won't be accidentally modified
   
   Currently there's nothing that prevents modification of the `Dict.empty` primitive, which obviously needs to be *truly* empty to prevent any future (hard to find) bugs.

 - A couple of small improvements in the "SaveDocument" handler in `src/core/worker.js`

   - Check that the "Info"-entry, in the XRef-trailer, is actually a dictionary before accessing it. This is similar to the `PDFDocument.documentInfo` method and follows the general principal of validating data carefully before accessing it, given how often PDF-software may create corrupt PDF files.

   - Slightly simplify the "XFA"-lookup, since there's no point in trying to fetch something from the empty dictionary.



