### PR TITLE
Fix issue with src="about:blank" on chrome v >= 76

### DIFF
--- a/extensions/chromium/contentscript.js
+++ b/extensions/chromium/contentscript.js
@@ -70,7 +70,7 @@ function watchObjectOrEmbed(elem) {
     // Starting from Chrome 76, internal embeds do not have the original URL,
     // but "about:blank" instead.
     // See https://github.com/mozilla/pdf.js/issues/11137
-    return;
+    elem.src = elem.baseURI;
   }
 
   if (elem.__I_saw_this_element) {


### PR DESCRIPTION
Fix issue with src="about:blank" on chrome version >= 76