### PR TITLE
Split only on the first `=` found in a key-value segment when parsing the parameters passed to the web viewer.

### DIFF
--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -208,7 +208,7 @@ function parseQueryString(query) {
   const parts = query.split("&");
   const params = Object.create(null);
   for (let i = 0, ii = parts.length; i < ii; ++i) {
-    const param = parts[i].split("=");
+    const param = parts[i].split(/=(.*)/);
     const key = param[0].toLowerCase();
     const value = param.length > 1 ? param[1] : null;
     params[decodeURIComponent(key)] = decodeURIComponent(value);


### PR DESCRIPTION
Fixes #12390.