### PR TITLE
In a text widget, Font resources can be in the appearance

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -998,12 +998,16 @@ class WidgetAnnotation extends Annotation {
 
     const localResources = getInheritableProperty({ dict, key: "DR" });
     const acroFormResources = params.acroForm.get("DR");
+    const appearanceResources =
+      this.appearance && this.appearance.dict.get("Resources");
+
     this._fieldResources = {
       localResources,
       acroFormResources,
+      appearanceResources,
       mergedResources: Dict.merge({
         xref: params.xref,
-        dictArray: [localResources, acroFormResources],
+        dictArray: [localResources, appearanceResources, acroFormResources],
         mergeSubDicts: true,
       }),
     };
@@ -1450,17 +1454,25 @@ class WidgetAnnotation extends Annotation {
         "Expected `_getAppearance()` to have been called."
       );
     }
-    const { localResources, acroFormResources } = this._fieldResources;
+    const {
+      localResources,
+      acroFormResources,
+      appearanceResources,
+    } = this._fieldResources;
 
     if (!this._fontName) {
       return localResources || Dict.empty;
     }
-    if (localResources instanceof Dict) {
-      const localFont = localResources.get("Font");
-      if (localFont instanceof Dict && localFont.has(this._fontName)) {
-        return localResources;
+
+    for (const resources of [localResources, appearanceResources]) {
+      if (resources instanceof Dict) {
+        const localFont = resources.get("Font");
+        if (localFont instanceof Dict && localFont.has(this._fontName)) {
+          return resources;
+        }
       }
     }
+
     if (acroFormResources instanceof Dict) {
       const acroFormFont = acroFormResources.get("Font");
       if (acroFormFont instanceof Dict && acroFormFont.has(this._fontName)) {

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -4410,6 +4410,18 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue12394",
+       "file": "pdfs/issue12392.pdf",
+       "md5": "76c3a34c6520940c45c66c92f7df2de5",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq",
+       "print": "true",
+       "annotationStorage": {
+         "35R": "收文"
+       }
+    },
     {  "id": "issue4883",
       "file": "pdfs/issue4883.pdf",
       "md5": "2fac0d9a189ca5fcef8626153d050be8",


### PR DESCRIPTION
In file https://github.com/mozilla/pdf.js/files/5249872/product1.pdf, the fifth text widget has a default appearance using font F1 and this one is neither in DR nor in AcroForm but in AP::N::Resources.

Fixes #12398.