### PR TITLE
Update the `webpack-stream` dependency (issue 11996)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16772,22 +16772,38 @@
       }
     },
     "webpack-stream": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-stream/-/webpack-stream-5.0.0.tgz",
-      "integrity": "sha512-cxYTQHqg2FX0cAf5fw1E3eXrnhpZ9g3+GF0egXHGI0SrvN1cIggIvo7esGja/9TYinsLZ+SJtS0KuhAs8tU4YQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webpack-stream/-/webpack-stream-6.1.0.tgz",
+      "integrity": "sha512-kFMnDzFTzyvVmn4ajaj0xEJavvYizd3I/KmQ6C5aUstcAkNwZUidxkk/uEaEPSydaAn66v8ZcP1+bhKSshNJUQ==",
       "dev": true,
       "requires": {
-        "fancy-log": "^1.3.2",
+        "fancy-log": "^1.3.3",
         "lodash.clone": "^4.3.2",
         "lodash.some": "^4.2.2",
-        "memory-fs": "^0.4.1",
+        "memory-fs": "^0.5.0",
         "plugin-error": "^1.0.1",
-        "supports-color": "^5.3.0",
+        "supports-color": "^7.2.0",
         "through": "^2.3.8",
         "vinyl": "^2.1.0",
-        "webpack": "^4.7.0"
+        "webpack": "^4.26.1"
       },
       "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "memory-fs": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+          "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+          "dev": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
+          }
+        },
         "plugin-error": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
@@ -16798,6 +16814,15 @@
             "arr-diff": "^4.0.0",
             "arr-union": "^3.1.0",
             "extend-shallow": "^3.0.2"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "vinyl-fs": "^3.0.3",
     "web-streams-polyfill": "^2.1.1",
     "webpack": "^4.44.2",
-    "webpack-stream": "~5.0.0",
+    "webpack-stream": "~6.1.0",
     "wintersmith": "^2.5.0",
     "yargs": "^11.1.1"
   },


### PR DESCRIPTION
Given that the long-standing `webpack-stream` [issue 201](https://github.com/shama/webpack-stream/issues/201) was recently fixed in [PR 207](https://github.com/shama/webpack-stream/pull/207), and a new version released, we should now finally be able to update the dependency.
However, depending on if/when `webpack-stream` gets support for Webpack 5 (which is currently in beta) we may still want remove our `webpack-stream` dependency.

