### PR TITLE
Enable the ESLint `no-var` rule in the `src/shared/` folder

### DIFF
--- a/src/shared/.eslintrc
+++ b/src/shared/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "extends": [
+    "../../.eslintrc"
+  ],
+
+  "rules": {
+    // ECMAScript 6
+    "no-var": "error",
+  },
+}

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 import { isNodeJS } from "./is_node.js";
 

--- a/src/shared/message_handler.js
+++ b/src/shared/message_handler.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error, prefer-const: error */
 
 import {
   AbortException,

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint no-var: error */
 
 import "./compatibility.js";
 


### PR DESCRIPTION
Previously this rule has been enabled in the `web/` folder, and in select files in the `src/` sub-folders.
In this case, enabling of this rule didn't actually require any further code changes.

Please find additional details about the ESLint rule at https://eslint.org/docs/rules/no-var