### PR TITLE
[Firefox] Stop logging `RenderingCancelledException`s as errors when printing

### DIFF
--- a/web/firefox_print_service.js
+++ b/web/firefox_print_service.js
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
+import { RenderingCancelledException, shadow } from "pdfjs-lib";
 import { CSS_UNITS } from "./ui_utils.js";
 import { PDFPrintServiceFactory } from "./app.js";
-import { shadow } from "pdfjs-lib";
 
 // Creates a placeholder with div and canvas with right size for the page.
 function composePage(
@@ -85,8 +85,10 @@ function composePage(
           }
           obj.done();
         },
-        function (error) {
-          console.error(error);
+        function (reason) {
+          if (!(reason instanceof RenderingCancelledException)) {
+            console.error(reason);
+          }
 
           if (currentRenderTask === thisRenderTask) {
             currentRenderTask.cancel();


### PR DESCRIPTION
In the rest of the viewer code-base, we purposely don't treat `RenderingCancelledException`s as actual errors (since they aren't) and consequently we never log them.
Hence it makes sense, as far as I'm concerned, to simply treat `RenderingCancelledException`s the same way when printing in Firefox.

While I don't print a whole lot, I cannot remember seeing these "errors" logged when printing until *very* recently[1]. Given that the browser print functionality and UI, in Firefox, is under active development it's certainly possible that there's some recent changes to the related timings which make `RenderingCancelledException`s more likely now.

---
[1] Interestingly, only some PDF documents seem to be affected as well; I'm able to reproduce this pretty consistently by opening https://www.uni-muenster.de/imperia/md/content/ziv/pdf/printpay_flyer.pdf in Firefox and then repeating the following sequence:
Clicking on the PDF.js print button, and then cancelling printing.