### PR TITLE
Upgrade `acorn` to version 8

### DIFF
--- a/external/builder/preprocessor2.js
+++ b/external/builder/preprocessor2.js
@@ -8,6 +8,7 @@ var path = require("path");
 
 var PDFJS_PREPROCESSOR_NAME = "PDFJSDev";
 var ROOT_PREFIX = "$ROOT/";
+const ACORN_ECMA_VERSION = 2020;
 
 function isLiteral(obj, value) {
   return obj.type === "Literal" && obj.value === value;
@@ -49,7 +50,9 @@ function handlePreprocessorAction(ctx, actionName, args, loc) {
           return { type: "Literal", value: result, loc: loc };
         }
         if (typeof result === "object") {
-          var parsedObj = acorn.parse("(" + JSON.stringify(result) + ")");
+          const parsedObj = acorn.parse("(" + JSON.stringify(result) + ")", {
+            ecmaVersion: ACORN_ECMA_VERSION,
+          });
           parsedObj.body[0].expression.loc = loc;
           return parsedObj.body[0].expression;
         }
@@ -67,7 +70,9 @@ function handlePreprocessorAction(ctx, actionName, args, loc) {
           );
         }
         var jsonContent = fs.readFileSync(jsonPath).toString();
-        var parsedJSON = acorn.parse("(" + jsonContent + ")");
+        const parsedJSON = acorn.parse("(" + jsonContent + ")", {
+          ecmaVersion: ACORN_ECMA_VERSION,
+        });
         parsedJSON.body[0].expression.loc = loc;
         return parsedJSON.body[0].expression;
     }
@@ -322,14 +327,16 @@ function preprocessPDFJSCode(ctx, code) {
     },
   };
   var parseOptions = {
-    ecmaVersion: 2020,
+    ecmaVersion: ACORN_ECMA_VERSION,
     locations: true,
     sourceFile: ctx.sourceFile,
     sourceType: "module",
   };
   var codegenOptions = {
     format: format,
-    parse: acorn.parse,
+    parse: function (input) {
+      return acorn.parse(input, { ecmaVersion: ACORN_ECMA_VERSION });
+    },
     sourceMap: ctx.sourceMap,
     sourceMapWithCode: ctx.sourceMap,
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2104,9 +2104,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.4.tgz",
+      "integrity": "sha512-XNP0PqF1XD19ZlLKvB7cMmnZswW4C/03pRHgirB30uSJTaS3A3V1/P4sS3HPvFmjoriPCJQs+JDSbm4bL1TxGQ==",
       "dev": true
     },
     "acorn-globals": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@babel/plugin-transform-runtime": "^7.11.5",
     "@babel/preset-env": "^7.11.5",
     "@babel/runtime": "^7.11.2",
-    "acorn": "^7.4.0",
+    "acorn": "^8.0.4",
     "autoprefixer": "^10.0.1",
     "babel-loader": "^8.1.0",
     "canvas": "^2.6.1",


### PR DESCRIPTION
I've run `gulp mozcentral`, `gulp generic`, and `gulp generic-es5` with `master` respectively this patch and then diffed the build output. With the (obvious) exception of increased version/build numbers, there were no actual changes from the updated Acorn version.