### PR TITLE
Upgrade `terser` to version 5

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -916,7 +916,7 @@ gulp.task(
   })
 );
 
-function parseMinified(dir) {
+async function parseMinified(dir) {
   var pdfFile = fs.readFileSync(dir + "/build/pdf.js").toString();
   var pdfWorkerFile = fs.readFileSync(dir + "/build/pdf.worker.js").toString();
   var pdfImageDecodersFile = fs
@@ -942,19 +942,19 @@ function parseMinified(dir) {
 
   fs.writeFileSync(
     dir + "/web/pdf.viewer.js",
-    Terser.minify(viewerFiles, options).code
+    (await Terser.minify(viewerFiles, options)).code
   );
   fs.writeFileSync(
     dir + "/build/pdf.min.js",
-    Terser.minify(pdfFile, options).code
+    (await Terser.minify(pdfFile, options)).code
   );
   fs.writeFileSync(
     dir + "/build/pdf.worker.min.js",
-    Terser.minify(pdfWorkerFile, options).code
+    (await Terser.minify(pdfWorkerFile, options)).code
   );
   fs.writeFileSync(
     dir + "image_decoders/pdf.image_decoders.min.js",
-    Terser.minify(pdfImageDecodersFile, options).code
+    (await Terser.minify(pdfImageDecodersFile, options)).code
   );
 
   console.log();
@@ -975,16 +975,16 @@ function parseMinified(dir) {
 
 gulp.task(
   "minified",
-  gulp.series("minified-pre", function (done) {
-    parseMinified(MINIFIED_DIR);
+  gulp.series("minified-pre", async function (done) {
+    await parseMinified(MINIFIED_DIR);
     done();
   })
 );
 
 gulp.task(
   "minified-es5",
-  gulp.series("minified-es5-pre", function (done) {
-    parseMinified(MINIFIED_ES5_DIR);
+  gulp.series("minified-es5-pre", async function (done) {
+    await parseMinified(MINIFIED_ES5_DIR);
     done();
   })
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -16042,20 +16042,26 @@
       }
     },
     "terser": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.4.tgz",
+      "integrity": "sha512-dxuB8KQo8Gt6OVOeLg/rxfcxdNZI/V1G6ze1czFUzPeCFWZRtvZMgSzlZZ5OYBZ4HoG607F6pFPNLekJyV+yVw==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.19"
       },
       "dependencies": {
         "commander": {
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
         }
       }
@@ -16077,6 +16083,12 @@
         "worker-farm": "^1.7.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
         "schema-utils": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -16086,6 +16098,17 @@
             "ajv": "^6.1.0",
             "ajv-errors": "^1.0.0",
             "ajv-keywords": "^3.1.0"
+          }
+        },
+        "terser": {
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+          "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.12"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "stylelint-prettier": "^1.1.2",
     "systemjs": "^0.21.6",
     "systemjs-plugin-babel": "^0.0.25",
-    "terser": "^4.8.0",
+    "terser": "^5.3.4",
     "through2": "^4.0.2",
     "ttest": "^3.0.0",
     "typescript": "^4.0.3",


### PR DESCRIPTION
The only significant change is that the `minify` command is now asynchronous, which we can handle easily by simply making the containing functions `async`.
Based on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function#Browser_compatibility, using `async`/`await` in the gulpfile should no longer be an issue as far as I can tell.