### PR TITLE
Add local caching of TilingPatterns in `PartialEvaluator.getOperatorList` (issue 2765 and 8473)

### DIFF
--- a/src/core/image_utils.js
+++ b/src/core/image_utils.js
@@ -133,6 +133,29 @@ class LocalGStateCache extends BaseLocalCache {
   }
 }
 
+class LocalTilingPatternCache extends BaseLocalCache {
+  set(name, ref = null, data) {
+    if (!name) {
+      throw new Error(
+        'LocalTilingPatternCache.set - expected "name" argument.'
+      );
+    }
+    if (ref) {
+      if (this._imageCache.has(ref)) {
+        return;
+      }
+      this._nameRefMap.set(name, ref);
+      this._imageCache.put(ref, data);
+      return;
+    }
+    // name
+    if (this._imageMap.has(name)) {
+      return;
+    }
+    this._imageMap.set(name, data);
+  }
+}
+
 class GlobalImageCache {
   static get NUM_PAGES_THRESHOLD() {
     return shadow(this, "NUM_PAGES_THRESHOLD", 2);
@@ -231,5 +254,6 @@ export {
   LocalColorSpaceCache,
   LocalFunctionCache,
   LocalGStateCache,
+  LocalTilingPatternCache,
   GlobalImageCache,
 };

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -967,7 +967,7 @@ Shadings.Dummy = (function DummyClosure() {
   return Dummy;
 })();
 
-function getTilingPatternIR(operatorList, dict, args) {
+function getTilingPatternIR(operatorList, dict, color) {
   const matrix = dict.getArray("Matrix");
   const bbox = Util.normalizeRect(dict.getArray("BBox"));
   const xstep = dict.get("XStep");
@@ -983,7 +983,7 @@ function getTilingPatternIR(operatorList, dict, args) {
 
   return [
     "TilingPattern",
-    args,
+    color,
     operatorList,
     matrix,
     bbox,


### PR DESCRIPTION
In practice it's not uncommon for PDF documents to re-use the same TilingPatterns more than once, and parsing them is essentially equal to parsing of a (small) page since a `getOperatorList` call is required.

By caching the internal TilingPattern representation we can thus avoid having to re-parse the same data over and over, and there's also *less* asynchronous parsing required for repeated TilingPatterns.

Initially I had intended to include (standard) benchmark results with this patch, however it's not entirely clear that this is actually necessary here given the preliminary results.
When testing this manually in the development viewer, using `pdfBug=Stats`, the following (approximate) reduction in rendering times were observed when comparing `master` against this patch:
 - http://pubs.usgs.gov/sim/3067/pdf/sim3067sheet-2.pdf (from issue #2765): `6800 ms` -> `4100 ms`.
 - https://github.com/mozilla/pdf.js/files/1046131/stepped.pdf (from issue #8473): `54000 ms` -> `13000 ms`
 - https://github.com/mozilla/pdf.js/files/1046130/proof.pdf (from issue #8473): `5900 ms` -> `2500 ms`

As always, whenever you're dealing with documents which are "slow", there's usually a certain level of subjectivity involved with regards to what's deemed acceptable performance.
Hence it's not clear to me that we want to regard any of the referenced issues as fixed, however the improvements are significant enough to warrant caching of TilingPatterns in my opinion.