### PR TITLE
Fix the "should get form info when AcroForm is present" unit-test

### DIFF
--- a/test/unit/document_spec.js
+++ b/test/unit/document_spec.js
@@ -52,8 +52,9 @@ describe("document", function () {
     };
     const stream = new StringStream("Dummy_PDF_data");
 
-    function getDocument(acroForm) {
+    function getDocument(acroForm, xref = new XRefMock()) {
       const pdfDocument = new PDFDocument(pdfManager, stream);
+      pdfDocument.xref = xref;
       pdfDocument.catalog = { acroForm };
       return pdfDocument;
     }
@@ -144,18 +145,18 @@ describe("document", function () {
       kidsDict.set("Kids", [annotationRef]);
       const kidsRef = Ref.get(10, 0);
 
-      pdfDocument.xref = new XRefMock([
+      const xref = new XRefMock([
         { ref: annotationRef, data: annotationDict },
         { ref: kidsRef, data: kidsDict },
       ]);
 
       acroForm.set("Fields", [kidsRef]);
       acroForm.set("SigFlags", 3);
-      pdfDocument = getDocument(acroForm);
+      pdfDocument = getDocument(acroForm, xref);
       expect(pdfDocument.formInfo).toEqual({
         hasAcroForm: false,
         hasXfa: false,
-        fields: null,
+        fields: [kidsRef],
       });
     });
   });

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -93,8 +93,8 @@ class XRefMock {
     return this._map[ref.toString()];
   }
 
-  fetchAsync(ref) {
-    return Promise.resolve(this.fetch(ref));
+  async fetchAsync(ref) {
+    return this.fetch(ref);
   }
 
   fetchIfRef(obj) {
@@ -104,8 +104,8 @@ class XRefMock {
     return this.fetch(obj);
   }
 
-  fetchIfRefAsync(obj) {
-    return Promise.resolve(this.fetchIfRef(obj));
+  async fetchIfRefAsync(obj) {
+    return this.fetchIfRef(obj);
   }
 }
 


### PR DESCRIPTION
The last unit-test didn't work correctly, since an error was thrown in `PDFDocument._hasOnlyDocumentSignatures` because the mocked `XRef`-instance wasn't actually being set correctly.

Also, updates the `XRefMock` to use `async` methods where appropriate.