### PR TITLE
[api-minor] JS - Add a function in api to get the fields ids in AcroForm::CO

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -37,6 +37,7 @@ import {
   Dict,
   isDict,
   isName,
+  isRef,
   isStream,
   Ref,
 } from "./primitives.js";
@@ -1011,6 +1012,21 @@ class PDFDocument {
       "fieldObjects",
       Promise.all(allPromises).then(() => allFields)
     );
+  }
+
+  get calculationOrderIds() {
+    const acroForm = this.catalog.acroForm;
+    if (!acroForm || !acroForm.has("CO")) {
+      return shadow(this, "calculationOrderIds", null);
+    }
+
+    const calculationOrder = acroForm.get("CO");
+    if (!Array.isArray(calculationOrder) || calculationOrder.length === 0) {
+      return shadow(this, "calculationOrderIds", null);
+    }
+
+    const ids = calculationOrder.filter(isRef).map(ref => ref.toString());
+    return shadow(this, "calculationOrderIds", ids);
   }
 }
 

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -520,6 +520,10 @@ class WorkerMessageHandler {
       return pdfManager.ensureDoc("fieldObjects");
     });
 
+    handler.on("GetCalculationOrderIds", function (data) {
+      return pdfManager.ensureDoc("calculationOrderIds");
+    });
+
     handler.on("SaveDocument", function ({
       numPages,
       annotationStorage,

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -885,6 +885,15 @@ class PDFDocumentProxy {
   getFieldObjects() {
     return this._transport.getFieldObjects();
   }
+
+  /**
+   * @returns {Promise<Array<string> | null>} A promise that is resolved with an
+   *   {Array<string>} containing IDs of annotations that have a calculation
+   *   action, or `null` when no such annotations are present in the PDF file.
+   */
+  getCalculationOrderIds() {
+    return this._transport.getCalculationOrderIds();
+  }
 }
 
 /**
@@ -2560,6 +2569,10 @@ class WorkerTransport {
 
   getFieldObjects() {
     return this.messageHandler.sendWithPromise("GetFieldObjects", null);
+  }
+
+  getCalculationOrderIds() {
+    return this.messageHandler.sendWithPromise("GetCalculationOrderIds", null);
   }
 
   getDestinations() {

--- a/test/unit/document_spec.js
+++ b/test/unit/document_spec.js
@@ -159,5 +159,20 @@ describe("document", function () {
         hasFields: true,
       });
     });
+
+    it("should get calculation order array or null", function () {
+      const acroForm = new Dict();
+
+      let pdfDocument = getDocument(acroForm);
+      expect(pdfDocument.calculationOrderIds).toEqual(null);
+
+      acroForm.set("CO", [Ref.get(1, 0), Ref.get(2, 0), Ref.get(3, 0)]);
+      pdfDocument = getDocument(acroForm);
+      expect(pdfDocument.calculationOrderIds).toEqual(["1R", "2R", "3R"]);
+
+      acroForm.set("CO", []);
+      pdfDocument = getDocument(acroForm);
+      expect(pdfDocument.calculationOrderIds).toEqual(null);
+    });
   });
 });


### PR DESCRIPTION
Each time a Field is validate then some `Calculate` actions may be ran just after.
In order to know in which order these actions are ran we must get this information from AcroForm::CO.
See the top of page 365 (and bottom of 364 of course):
https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/js_api_reference.pdf#page=365