### PR TITLE
Stop caching the *parsed* Font data on its `Dict` object (PR 7347 follow-up)

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -908,7 +908,7 @@ class Catalog {
 
     return Promise.all(promises).then(translatedFonts => {
       for (const { dict } of translatedFonts) {
-        delete dict.translated;
+        delete dict.cacheKey;
       }
       this.fontCache.clear();
       this.builtInCMapCache.clear();


### PR DESCRIPTION
Given that *all* fonts are, ever since PR #7347, now cached in the "normal" `fontCache` there's actually no reason for the special `font.translated` construction. (Given how Objects in JavaScript are references, rather than raw values, the old code shouldn't have caused any significant memory overhead.)

Instead we can simply store the `cacheKey`, which is a simple string, on only the Font `Dict`s where it's needed and thus look-up all fonts using the `fontCache` instead.