### PR TITLE
[api-minor] Invalidate an annotation with no quadPoints (when it's required)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -194,7 +194,11 @@ function getQuadPoints(dict, rect) {
   // The region is described as a number of quadrilaterals.
   // Each quadrilateral must consist of eight coordinates.
   const quadPoints = dict.getArray("QuadPoints");
-  if (!Array.isArray(quadPoints) || quadPoints.length % 8 > 0) {
+  if (
+    !Array.isArray(quadPoints) ||
+    quadPoints.length === 0 ||
+    quadPoints.length % 8 > 0
+  ) {
     return null;
   }
 
@@ -312,6 +316,9 @@ class Annotation {
    * @type {boolean}
    */
   get viewable() {
+    if (this.data.quadPoints === null) {
+      return false;
+    }
     if (this.flags === 0) {
       return true;
     }
@@ -322,6 +329,9 @@ class Annotation {
    * @type {boolean}
    */
   get printable() {
+    if (this.data.quadPoints === null) {
+      return false;
+    }
     if (this.flags === 0) {
       return false;
     }
@@ -2222,10 +2232,11 @@ class HighlightAnnotation extends MarkupAnnotation {
     super(parameters);
 
     this.data.annotationType = AnnotationType.HIGHLIGHT;
-
-    const quadPoints = getQuadPoints(parameters.dict, null);
+    const quadPoints = (this.data.quadPoints = getQuadPoints(
+      parameters.dict,
+      null
+    ));
     if (quadPoints) {
-      this.data.quadPoints = quadPoints;
       if (!this.appearance) {
         // Default color is yellow in Acrobat Reader
         const fillColor = this.color
@@ -2245,6 +2256,8 @@ class HighlightAnnotation extends MarkupAnnotation {
           },
         });
       }
+    } else {
+      this.data.hasPopup = false;
     }
   }
 }
@@ -2254,10 +2267,11 @@ class UnderlineAnnotation extends MarkupAnnotation {
     super(parameters);
 
     this.data.annotationType = AnnotationType.UNDERLINE;
-
-    const quadPoints = getQuadPoints(parameters.dict, null);
+    const quadPoints = (this.data.quadPoints = getQuadPoints(
+      parameters.dict,
+      null
+    ));
     if (quadPoints) {
-      this.data.quadPoints = quadPoints;
       if (!this.appearance) {
         // Default color is black
         const strokeColor = this.color
@@ -2275,6 +2289,8 @@ class UnderlineAnnotation extends MarkupAnnotation {
           },
         });
       }
+    } else {
+      this.data.hasPopup = false;
     }
   }
 }
@@ -2285,9 +2301,11 @@ class SquigglyAnnotation extends MarkupAnnotation {
 
     this.data.annotationType = AnnotationType.SQUIGGLY;
 
-    const quadPoints = getQuadPoints(parameters.dict, null);
+    const quadPoints = (this.data.quadPoints = getQuadPoints(
+      parameters.dict,
+      null
+    ));
     if (quadPoints) {
-      this.data.quadPoints = quadPoints;
       if (!this.appearance) {
         // Default color is black
         const strokeColor = this.color
@@ -2314,6 +2332,8 @@ class SquigglyAnnotation extends MarkupAnnotation {
           },
         });
       }
+    } else {
+      this.data.hasPopup = false;
     }
   }
 }
@@ -2324,9 +2344,11 @@ class StrikeOutAnnotation extends MarkupAnnotation {
 
     this.data.annotationType = AnnotationType.STRIKEOUT;
 
-    const quadPoints = getQuadPoints(parameters.dict, null);
+    const quadPoints = (this.data.quadPoints = getQuadPoints(
+      parameters.dict,
+      null
+    ));
     if (quadPoints) {
-      this.data.quadPoints = quadPoints;
       if (!this.appearance) {
         // Default color is black
         const strokeColor = this.color
@@ -2350,6 +2372,8 @@ class StrikeOutAnnotation extends MarkupAnnotation {
           },
         });
       }
+    } else {
+      this.data.hasPopup = false;
     }
   }
 }

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -3367,7 +3367,7 @@ describe("annotation", function () {
   });
 
   describe("HightlightAnnotation", function () {
-    it("should not set quadpoints if not defined", function (done) {
+    it("should set quadpoints to null if not defined", function (done) {
       const highlightDict = new Dict();
       highlightDict.set("Type", Name.get("Annot"));
       highlightDict.set("Subtype", Name.get("Highlight"));
@@ -3382,7 +3382,7 @@ describe("annotation", function () {
         idFactoryMock
       ).then(({ data }) => {
         expect(data.annotationType).toEqual(AnnotationType.HIGHLIGHT);
-        expect(data.quadPoints).toBeUndefined();
+        expect(data.quadPoints).toEqual(null);
         done();
       }, done.fail);
     });
@@ -3415,10 +3415,32 @@ describe("annotation", function () {
         done();
       }, done.fail);
     });
+
+    it("should set quadpoints to null when empty", function (done) {
+      const highlightDict = new Dict();
+      highlightDict.set("Type", Name.get("Annot"));
+      highlightDict.set("Subtype", Name.get("Highlight"));
+      highlightDict.set("Rect", [10, 10, 20, 20]);
+      highlightDict.set("QuadPoints", []);
+
+      const highlightRef = Ref.get(121, 0);
+      const xref = new XRefMock([{ ref: highlightRef, data: highlightDict }]);
+
+      AnnotationFactory.create(
+        xref,
+        highlightRef,
+        pdfManagerMock,
+        idFactoryMock
+      ).then(({ data }) => {
+        expect(data.annotationType).toEqual(AnnotationType.HIGHLIGHT);
+        expect(data.quadPoints).toEqual(null);
+        done();
+      }, done.fail);
+    });
   });
 
   describe("UnderlineAnnotation", function () {
-    it("should not set quadpoints if not defined", function (done) {
+    it("should set quadpoints to null if not defined", function (done) {
       const underlineDict = new Dict();
       underlineDict.set("Type", Name.get("Annot"));
       underlineDict.set("Subtype", Name.get("Underline"));
@@ -3433,7 +3455,7 @@ describe("annotation", function () {
         idFactoryMock
       ).then(({ data }) => {
         expect(data.annotationType).toEqual(AnnotationType.UNDERLINE);
-        expect(data.quadPoints).toBeUndefined();
+        expect(data.quadPoints).toEqual(null);
         done();
       }, done.fail);
     });
@@ -3469,7 +3491,7 @@ describe("annotation", function () {
   });
 
   describe("SquigglyAnnotation", function () {
-    it("should not set quadpoints if not defined", function (done) {
+    it("should set quadpoints to null if not defined", function (done) {
       const squigglyDict = new Dict();
       squigglyDict.set("Type", Name.get("Annot"));
       squigglyDict.set("Subtype", Name.get("Squiggly"));
@@ -3484,7 +3506,7 @@ describe("annotation", function () {
         idFactoryMock
       ).then(({ data }) => {
         expect(data.annotationType).toEqual(AnnotationType.SQUIGGLY);
-        expect(data.quadPoints).toBeUndefined();
+        expect(data.quadPoints).toEqual(null);
         done();
       }, done.fail);
     });
@@ -3520,7 +3542,7 @@ describe("annotation", function () {
   });
 
   describe("StrikeOutAnnotation", function () {
-    it("should not set quadpoints if not defined", function (done) {
+    it("should set quadpoints to null if not defined", function (done) {
       const strikeOutDict = new Dict();
       strikeOutDict.set("Type", Name.get("Annot"));
       strikeOutDict.set("Subtype", Name.get("StrikeOut"));
@@ -3535,7 +3557,7 @@ describe("annotation", function () {
         idFactoryMock
       ).then(({ data }) => {
         expect(data.annotationType).toEqual(AnnotationType.STRIKEOUT);
-        expect(data.quadPoints).toBeUndefined();
+        expect(data.quadPoints).toEqual(null);
         done();
       }, done.fail);
     });


### PR DESCRIPTION
Some pdf softwares don't remove highlight annotations but make the QuadPoints array empty.
And the Rect for the annotation can be [-32768, -32768, 32768, 32768] so it leads to have a giant div which catches all the mouse events and make the pdf unusable when there are some forms elements.
I aims to fix issue #12506.