### PR TITLE
[api-minor] Split highlight annotation div into multiple divs

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -2086,6 +2086,13 @@ class PopupAnnotation extends Annotation {
     const rawParent = parameters.dict.getRaw("Parent");
     this.data.parentId = isRef(rawParent) ? rawParent.toString() : null;
 
+    const parentRect = parentItem.getArray("Rect");
+    if (Array.isArray(parentRect) && parentRect.length === 4) {
+      this.data.parentRect = Util.normalizeRect(parentRect);
+    } else {
+      this.data.parentRect = [0, 0, 0, 0];
+    }
+
     const rt = parentItem.get("RT");
     if (isName(rt, AnnotationReplyType.GROUP)) {
       // Subordinate annotations in a group should inherit


### PR DESCRIPTION
This patch aims to fix issue #12504.
Instead of using `Annotation::Rect` for the div dimensions, we use several divs where dimensions are in `QuadPoints` and then set mouse handlers on each of them.
