### PR TITLE
Enable the `unicorn/no-abusive-eslint-disable` ESLint plugin rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,6 +36,7 @@
     "mozilla/use-includes-instead-of-indexOf": "error",
     "no-unsanitized/method": "error",
     "no-unsanitized/property": "error",
+    "unicorn/no-abusive-eslint-disable": "error",
     "unicorn/no-array-instanceof": "error",
     "unicorn/prefer-starts-ends-with": "error",
 


### PR DESCRIPTION
This rule prevents *accidental* disabling of ESLint completely, be ensuring that inline ESLint disable comments always list the affected rules explicitly.

Please see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-abusive-eslint-disable.md for additional information.