### PR TITLE
Prevent issues, in `PDFDocument.fieldObjects`, for invalid Annotations

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -969,7 +969,7 @@ class PDFDocument {
         this.pdfManager,
         this._localIdFactory
       )
-        .then(annotation => annotation.getFieldObject())
+        .then(annotation => annotation && annotation.getFieldObject())
         .catch(function (reason) {
           warn(`_collectFieldObjects: "${reason}".`);
           return null;
@@ -999,7 +999,7 @@ class PDFDocument {
     for (const [name, promises] of fieldPromises) {
       allPromises.push(
         Promise.all(promises).then(fields => {
-          fields = fields.filter(field => field !== null);
+          fields = fields.filter(field => !!field);
           if (fields.length > 0) {
             allFields[name] = fields;
           }


### PR DESCRIPTION
For an invalid Annotation, there's one code-path where `undefined` is returned from `AnnotationFactory._create`. That'd currently, incorrectly, trigger an error during the `PDFDocument._collectFieldObjects` parsing which thus seem good to avoid.
Along these lines, the filtering in `PDFDocument.fieldObjects` is also updated to handle both `null` and `undefined` the same way.