### PR TITLE
Fix a couple of edge-cases in `PDFViewerApplication._initializeJavaScript` (PR 12432 follow-up)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1345,10 +1345,14 @@ const PDFViewerApplication = {
    * @private
    */
   async _initializeJavaScript(pdfDocument) {
-    if (!AppOptions.get("enableScripting")) {
+    const objects = await pdfDocument.getFieldObjects();
+
+    if (pdfDocument !== this.pdfDocument) {
+      return; // The document was closed while the JavaScript data resolved.
+    }
+    if (!objects || !AppOptions.get("enableScripting")) {
       return;
     }
-    const objects = await pdfDocument.getFieldObjects();
     const scripting = this.externalServices.scripting;
 
     window.addEventListener("updateFromSandbox", function (event) {

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -254,17 +254,19 @@ class FirefoxComDataRangeTransport extends PDFDataRangeTransport {
   }
 }
 
-const FirefoxScripting = {
-  createSandbox(data) {
+class FirefoxScripting {
+  static createSandbox(data) {
     FirefoxCom.requestSync("createSandbox", data);
-  },
-  dispatchEventInSandbox(event, sandboxID) {
+  }
+
+  static dispatchEventInSandbox(event, sandboxID) {
     FirefoxCom.requestSync("dispatchEventInSandbox", event);
-  },
-  destroySandbox() {
+  }
+
+  static destroySandbox() {
     FirefoxCom.requestSync("destroySandbox", null);
-  },
-};
+  }
+}
 
 class FirefoxExternalServices extends DefaultExternalServices {
   static updateFindControlState(data) {

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -1010,8 +1010,8 @@ function getActiveOrFocusedElement() {
 /**
  * Generate a random string which is not define somewhere in actions.
  *
- * @param {WaitOnEventOrTimeoutParameters}
- * @returns {Promise} A promise that is resolved with a {WaitOnType} value.
+ * @param {Object} objects - The value returned by `getFieldObjects` in the API.
+ * @returns {string} A unique string.
  */
 function generateRandomStringForSandbox(objects) {
   const allObjects = Object.values(objects).flat(2);


### PR DESCRIPTION
 - Return early in `PDFViewerApplication._initializeJavaScript` for PDF documents without any `fieldObjects`, which is the vast majority of all documents, to prevent errors when trying to parse a non-existent object.

 - Similar to the other `PDFViewerApplication._initialize*` methods, ignore the `fieldObjects` if the document was closed before the data resolved.

 - Fix the JSDoc comment for the `generateRandomStringForSandbox` helper function, since there's currently a bit too much copy-and-paste going on :-)

 - Change `FirefoxScripting` to a class with static methods, which is consistent with the surrounding code in `web/firefoxcom.js`.