### PR TITLE
A couple of small (viewer) tweaks of tooltip-only Annotations (PR 12333 follow-up)

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -348,7 +348,7 @@ class LinkAnnotationElement extends AnnotationElement {
       }
       return false;
     };
-    if (destination) {
+    if (destination || destination === /* isTooltipOnly = */ "") {
       link.className = "internalLink";
     }
   }

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -235,11 +235,14 @@ class PDFLinkService {
    */
   getDestinationHash(dest) {
     if (typeof dest === "string") {
-      return this.getAnchorUrl("#" + escape(dest));
-    }
-    if (Array.isArray(dest)) {
+      if (dest.length > 0) {
+        return this.getAnchorUrl("#" + escape(dest));
+      }
+    } else if (Array.isArray(dest)) {
       const str = JSON.stringify(dest);
-      return this.getAnchorUrl("#" + escape(str));
+      if (str.length > 0) {
+        return this.getAnchorUrl("#" + escape(str));
+      }
     }
     return this.getAnchorUrl("");
   }
@@ -247,7 +250,7 @@ class PDFLinkService {
   /**
    * Prefix the full url on anchor links to make sure that links are resolved
    * relative to the current URL instead of the one defined in <base href>.
-   * @param {string} anchor The anchor hash, including the #.
+   * @param {string} anchor - The anchor hash, including the #.
    * @returns {string} The hyperlink to the PDF object.
    */
   getAnchorUrl(anchor) {


### PR DESCRIPTION
Ensure that these tooltip-only Annotations are handled as "internalLink"s, to ensure that they behave as expected in PresentationMode (e.g. they should still use a `pointer`-cursor).

Ensure that `PDFLinkService.getDestinationHash` won't create links with empty hashes, since those don't really make a lot of sense in general (this improves things for tooltip-only Annotations).

This PDF file can be used for testing: http://mirrors.ctan.org/macros/latex/contrib/pdfcomment/doc/pdfcomment.pdf#page=14