### PR TITLE
Convert `var` to `const`/`let` in the `test/unit` folder 

### DIFF
--- a/test/unit/.eslintrc
+++ b/test/unit/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "extends": [
+    "../.eslintrc"
+  ],
+
+  "rules": {
+    // ECMAScript 6
+    "no-var": "error",
+  },
+}

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -72,7 +72,7 @@ describe("api", function () {
   });
 
   function waitSome(callback) {
-    var WAIT_TIMEOUT = 10;
+    const WAIT_TIMEOUT = 10;
     setTimeout(function () {
       callback();
     }, WAIT_TIMEOUT);
@@ -80,9 +80,9 @@ describe("api", function () {
 
   describe("getDocument", function () {
     it("creates pdf doc from URL", function (done) {
-      var loadingTask = getDocument(basicApiGetDocumentParams);
+      const loadingTask = getDocument(basicApiGetDocumentParams);
 
-      var progressReportedCapability = createPromiseCapability();
+      const progressReportedCapability = createPromiseCapability();
       // Attach the callback that is used to report loading progress;
       // similarly to how viewer.js works.
       loadingTask.onProgress = function (progressData) {
@@ -91,7 +91,10 @@ describe("api", function () {
         }
       };
 
-      var promises = [progressReportedCapability.promise, loadingTask.promise];
+      const promises = [
+        progressReportedCapability.promise,
+        loadingTask.promise,
+      ];
       Promise.all(promises)
         .then(function (data) {
           expect(data[0].loaded / data[0].total >= 0).toEqual(true);
@@ -102,7 +105,7 @@ describe("api", function () {
         .catch(done.fail);
     });
     it("creates pdf doc from URL and aborts before worker initialized", function (done) {
-      var loadingTask = getDocument(basicApiGetDocumentParams);
+      const loadingTask = getDocument(basicApiGetDocumentParams);
       const destroyed = loadingTask.destroy();
 
       loadingTask.promise
@@ -115,10 +118,10 @@ describe("api", function () {
         });
     });
     it("creates pdf doc from URL and aborts loading after worker initialized", function (done) {
-      var loadingTask = getDocument(basicApiGetDocumentParams);
+      const loadingTask = getDocument(basicApiGetDocumentParams);
       // This can be somewhat random -- we cannot guarantee perfect
       // 'Terminate' message to the worker before/after setting up pdfManager.
-      var destroyed = loadingTask._worker.promise.then(function () {
+      const destroyed = loadingTask._worker.promise.then(function () {
         return loadingTask.destroy();
       });
       destroyed
@@ -166,7 +169,7 @@ describe("api", function () {
     });
     it("creates pdf doc from invalid PDF file", function (done) {
       // A severely corrupt PDF file (even Adobe Reader fails to open it).
-      var loadingTask = getDocument(buildGetDocumentParams("bug1020226.pdf"));
+      const loadingTask = getDocument(buildGetDocumentParams("bug1020226.pdf"));
       loadingTask.promise
         .then(function () {
           done.fail("shall fail loading");
@@ -179,7 +182,9 @@ describe("api", function () {
         });
     });
     it("creates pdf doc from non-existent URL", function (done) {
-      var loadingTask = getDocument(buildGetDocumentParams("non-existent.pdf"));
+      const loadingTask = getDocument(
+        buildGetDocumentParams("non-existent.pdf")
+      );
       loadingTask.promise
         .then(function (error) {
           done.fail("shall fail loading");
@@ -190,10 +195,10 @@ describe("api", function () {
         });
     });
     it("creates pdf doc from PDF file protected with user and owner password", function (done) {
-      var loadingTask = getDocument(buildGetDocumentParams("pr6531_1.pdf"));
+      const loadingTask = getDocument(buildGetDocumentParams("pr6531_1.pdf"));
 
-      var passwordNeededCapability = createPromiseCapability();
-      var passwordIncorrectCapability = createPromiseCapability();
+      const passwordNeededCapability = createPromiseCapability();
+      const passwordIncorrectCapability = createPromiseCapability();
       // Attach the callback that is used to request a password;
       // similarly to how viewer.js handles passwords.
       loadingTask.onPassword = function (updatePassword, reason) {
@@ -219,7 +224,7 @@ describe("api", function () {
         expect(false).toEqual(true);
       };
 
-      var promises = [
+      const promises = [
         passwordNeededCapability.promise,
         passwordIncorrectCapability.promise,
         loadingTask.promise,
@@ -232,14 +237,14 @@ describe("api", function () {
         .catch(done.fail);
     });
     it("creates pdf doc from PDF file protected with only a user password", function (done) {
-      var filename = "pr6531_2.pdf";
+      const filename = "pr6531_2.pdf";
 
-      var passwordNeededLoadingTask = getDocument(
+      const passwordNeededLoadingTask = getDocument(
         buildGetDocumentParams(filename, {
           password: "",
         })
       );
-      var result1 = passwordNeededLoadingTask.promise.then(
+      const result1 = passwordNeededLoadingTask.promise.then(
         function () {
           done.fail("shall fail with no password");
           return Promise.reject(new Error("loadingTask should be rejected"));
@@ -251,12 +256,12 @@ describe("api", function () {
         }
       );
 
-      var passwordIncorrectLoadingTask = getDocument(
+      const passwordIncorrectLoadingTask = getDocument(
         buildGetDocumentParams(filename, {
           password: "qwerty",
         })
       );
-      var result2 = passwordIncorrectLoadingTask.promise.then(
+      const result2 = passwordIncorrectLoadingTask.promise.then(
         function () {
           done.fail("shall fail with wrong password");
           return Promise.reject(new Error("loadingTask should be rejected"));
@@ -268,12 +273,12 @@ describe("api", function () {
         }
       );
 
-      var passwordAcceptedLoadingTask = getDocument(
+      const passwordAcceptedLoadingTask = getDocument(
         buildGetDocumentParams(filename, {
           password: "asdfasdf",
         })
       );
-      var result3 = passwordAcceptedLoadingTask.promise.then(function (data) {
+      const result3 = passwordAcceptedLoadingTask.promise.then(function (data) {
         expect(data instanceof PDFDocumentProxy).toEqual(true);
         return passwordAcceptedLoadingTask.destroy();
       });
@@ -288,12 +293,12 @@ describe("api", function () {
       "creates pdf doc from password protected PDF file and aborts/throws " +
         "in the onPassword callback (issue 7806)",
       function (done) {
-        var filename = "issue3371.pdf";
+        const filename = "issue3371.pdf";
 
-        var passwordNeededLoadingTask = getDocument(
+        const passwordNeededLoadingTask = getDocument(
           buildGetDocumentParams(filename)
         );
-        var passwordIncorrectLoadingTask = getDocument(
+        const passwordIncorrectLoadingTask = getDocument(
           buildGetDocumentParams(filename, {
             password: "qwerty",
           })
@@ -308,7 +313,7 @@ describe("api", function () {
           // Shouldn't get here.
           expect(false).toEqual(true);
         };
-        var result1 = passwordNeededLoadingTask.promise.then(
+        const result1 = passwordNeededLoadingTask.promise.then(
           function () {
             done.fail("shall fail since the loadingTask should be destroyed");
             return Promise.reject(new Error("loadingTask should be rejected"));
@@ -327,7 +332,7 @@ describe("api", function () {
           // Shouldn't get here.
           expect(false).toEqual(true);
         };
-        var result2 = passwordIncorrectLoadingTask.promise.then(
+        const result2 = passwordIncorrectLoadingTask.promise.then(
           function () {
             done.fail("shall fail since the onPassword callback should throw");
             return Promise.reject(new Error("loadingTask should be rejected"));
@@ -372,7 +377,7 @@ describe("api", function () {
         pending("Worker is not supported in Node.js.");
       }
 
-      var worker = new PDFWorker({ name: "test1" });
+      const worker = new PDFWorker({ name: "test1" });
       worker.promise
         .then(function () {
           expect(worker.name).toEqual("test1");
@@ -393,19 +398,19 @@ describe("api", function () {
         pending("Worker is not supported in Node.js.");
       }
 
-      var loadingTask = getDocument(basicApiGetDocumentParams);
-      var worker;
+      const loadingTask = getDocument(basicApiGetDocumentParams);
+      let worker;
       loadingTask.promise.then(function () {
         worker = loadingTask._worker;
         expect(!!worker).toEqual(true);
       });
 
-      var destroyPromise = loadingTask.promise.then(function () {
+      const destroyPromise = loadingTask.promise.then(function () {
         return loadingTask.destroy();
       });
       destroyPromise
         .then(function () {
-          var destroyedWorker = loadingTask._worker;
+          const destroyedWorker = loadingTask._worker;
           expect(!!destroyedWorker).toEqual(false);
           expect(worker.destroyed).toEqual(true);
           done();
@@ -417,21 +422,21 @@ describe("api", function () {
         pending("Worker is not supported in Node.js.");
       }
 
-      var worker = new PDFWorker({ name: "test1" });
-      var loadingTask = getDocument(
+      const worker = new PDFWorker({ name: "test1" });
+      const loadingTask = getDocument(
         buildGetDocumentParams(basicApiFileName, {
           worker,
         })
       );
       loadingTask.promise.then(function () {
-        var docWorker = loadingTask._worker;
+        const docWorker = loadingTask._worker;
         expect(!!docWorker).toEqual(false);
         // checking is the same port is used in the MessageHandler
-        var messageHandlerPort = loadingTask._transport.messageHandler.comObj;
+        const messageHandlerPort = loadingTask._transport.messageHandler.comObj;
         expect(messageHandlerPort === worker.port).toEqual(true);
       });
 
-      var destroyPromise = loadingTask.promise.then(function () {
+      const destroyPromise = loadingTask.promise.then(function () {
         return loadingTask.destroy();
       });
       destroyPromise
@@ -447,10 +452,10 @@ describe("api", function () {
         pending("Worker is not supported in Node.js.");
       }
 
-      var worker1 = new PDFWorker({ name: "test1" });
-      var worker2 = new PDFWorker({ name: "test2" });
-      var worker3 = new PDFWorker({ name: "test3" });
-      var ready = Promise.all([
+      const worker1 = new PDFWorker({ name: "test1" });
+      const worker2 = new PDFWorker({ name: "test2" });
+      const worker3 = new PDFWorker({ name: "test3" });
+      const ready = Promise.all([
         worker1.promise,
         worker2.promise,
         worker3.promise,
@@ -503,7 +508,7 @@ describe("api", function () {
       );
     });
     it("gets page", function (done) {
-      var promise = pdfDocument.getPage(1);
+      const promise = pdfDocument.getPage(1);
       promise
         .then(function (data) {
           expect(data instanceof PDFPageProxy).toEqual(true);
@@ -513,9 +518,9 @@ describe("api", function () {
         .catch(done.fail);
     });
     it("gets non-existent page", function (done) {
-      var outOfRangePromise = pdfDocument.getPage(100);
-      var nonIntegerPromise = pdfDocument.getPage(2.5);
-      var nonNumberPromise = pdfDocument.getPage("1");
+      let outOfRangePromise = pdfDocument.getPage(100);
+      let nonIntegerPromise = pdfDocument.getPage(2.5);
+      let nonNumberPromise = pdfDocument.getPage("1");
 
       outOfRangePromise = outOfRangePromise.then(
         function () {
@@ -587,8 +592,8 @@ describe("api", function () {
 
     it("gets page index", function (done) {
       // reference to second page
-      var ref = { num: 17, gen: 0 };
-      var promise = pdfDocument.getPageIndex(ref);
+      const ref = { num: 17, gen: 0 };
+      const promise = pdfDocument.getPageIndex(ref);
       promise
         .then(function (pageIndex) {
           expect(pageIndex).toEqual(1);
@@ -597,8 +602,8 @@ describe("api", function () {
         .catch(done.fail);
     });
     it("gets invalid page index", function (done) {
-      var ref = { num: 3, gen: 0 }; // Reference to a font dictionary.
-      var promise = pdfDocument.getPageIndex(ref);
+      const ref = { num: 3, gen: 0 }; // Reference to a font dictionary.
+      const promise = pdfDocument.getPageIndex(ref);
       promise
         .then(function () {
           done.fail("shall fail for invalid page reference.");
@@ -610,7 +615,7 @@ describe("api", function () {
     });
 
     it("gets destinations, from /Dests dictionary", function (done) {
-      var promise = pdfDocument.getDestinations();
+      const promise = pdfDocument.getDestinations();
       promise
         .then(function (data) {
           expect(data).toEqual({
@@ -621,7 +626,7 @@ describe("api", function () {
         .catch(done.fail);
     });
     it("gets a destination, from /Dests dictionary", function (done) {
-      var promise = pdfDocument.getDestination("chapter1");
+      const promise = pdfDocument.getDestination("chapter1");
       promise
         .then(function (data) {
           expect(data).toEqual([
@@ -636,7 +641,7 @@ describe("api", function () {
         .catch(done.fail);
     });
     it("gets a non-existent destination, from /Dests dictionary", function (done) {
-      var promise = pdfDocument.getDestination(
+      const promise = pdfDocument.getDestination(
         "non-existent-named-destination"
       );
       promise
@@ -648,8 +653,8 @@ describe("api", function () {
     });
 
     it("gets destinations, from /Names (NameTree) dictionary", function (done) {
-      var loadingTask = getDocument(buildGetDocumentParams("issue6204.pdf"));
-      var promise = loadingTask.promise.then(function (pdfDoc) {
+      const loadingTask = getDocument(buildGetDocumentParams("issue6204.pdf"));
+      const promise = loadingTask.promise.then(function (pdfDoc) {
         return pdfDoc.getDestinations();
       });
       promise
@@ -664,8 +669,8 @@ describe("api", function () {
         .catch(done.fail);
     });
     it("gets a destination, from /Names (NameTree) dictionary", function (done) {
-      var loadingTask = getDocument(buildGetDocumentParams("issue6204.pdf"));
-      var promise = loadingTask.promise.then(function (pdfDoc) {
+      const loadingTask = getDocument(buildGetDocumentParams("issue6204.pdf"));
+      const promise = loadingTask.promise.then(function (pdfDoc) {
         return pdfDoc.getDestination("Page.1");
       });
       promise
@@ -683,8 +688,8 @@ describe("api", function () {
         .catch(done.fail);
     });
     it("gets a non-existent destination, from /Names (NameTree) dictionary", function (done) {
-      var loadingTask = getDocument(buildGetDocumentParams("issue6204.pdf"));
-      var promise = loadingTask.promise.then(function (pdfDoc) {
+      const loadingTask = getDocument(buildGetDocumentParams("issue6204.pdf"));
+      const promise = loadingTask.promise.then(function (pdfDoc) {
         return pdfDoc.getDestination("non-existent-named-destination");
       });
       promise
@@ -739,7 +744,7 @@ describe("api", function () {
     });
 
     it("gets non-existent page labels", function (done) {
-      var promise = pdfDocument.getPageLabels();
+      const promise = pdfDocument.getPageLabels();
       promise
         .then(function (data) {
           expect(data).toEqual(null);
@@ -749,28 +754,28 @@ describe("api", function () {
     });
     it("gets page labels", function (done) {
       // PageLabels with Roman/Arabic numerals.
-      var loadingTask0 = getDocument(buildGetDocumentParams("bug793632.pdf"));
-      var promise0 = loadingTask0.promise.then(function (pdfDoc) {
+      const loadingTask0 = getDocument(buildGetDocumentParams("bug793632.pdf"));
+      const promise0 = loadingTask0.promise.then(function (pdfDoc) {
         return pdfDoc.getPageLabels();
       });
 
       // PageLabels with only a label prefix.
-      var loadingTask1 = getDocument(buildGetDocumentParams("issue1453.pdf"));
-      var promise1 = loadingTask1.promise.then(function (pdfDoc) {
+      const loadingTask1 = getDocument(buildGetDocumentParams("issue1453.pdf"));
+      const promise1 = loadingTask1.promise.then(function (pdfDoc) {
         return pdfDoc.getPageLabels();
       });
 
       // PageLabels identical to standard page numbering.
-      var loadingTask2 = getDocument(buildGetDocumentParams("rotation.pdf"));
-      var promise2 = loadingTask2.promise.then(function (pdfDoc) {
+      const loadingTask2 = getDocument(buildGetDocumentParams("rotation.pdf"));
+      const promise2 = loadingTask2.promise.then(function (pdfDoc) {
         return pdfDoc.getPageLabels();
       });
 
       // PageLabels with bad "Prefix" entries.
-      var loadingTask3 = getDocument(
+      const loadingTask3 = getDocument(
         buildGetDocumentParams("bad-PageLabels.pdf")
       );
-      var promise3 = loadingTask3.promise.then(function (pdfDoc) {
+      const promise3 = loadingTask3.promise.then(function (pdfDoc) {
         return pdfDoc.getPageLabels();
       });
 
@@ -792,7 +797,9 @@ describe("api", function () {
     });
 
     it("gets default page layout", function (done) {
-      var loadingTask = getDocument(buildGetDocumentParams("tracemonkey.pdf"));
+      const loadingTask = getDocument(
+        buildGetDocumentParams("tracemonkey.pdf")
+      );
 
       loadingTask.promise
         .then(function (pdfDoc) {
@@ -816,7 +823,9 @@ describe("api", function () {
     });
 
     it("gets default page mode", function (done) {
-      var loadingTask = getDocument(buildGetDocumentParams("tracemonkey.pdf"));
+      const loadingTask = getDocument(
+        buildGetDocumentParams("tracemonkey.pdf")
+      );
 
       loadingTask.promise
         .then(function (pdfDoc) {
@@ -840,7 +849,9 @@ describe("api", function () {
     });
 
     it("gets default viewer preferences", function (done) {
-      var loadingTask = getDocument(buildGetDocumentParams("tracemonkey.pdf"));
+      const loadingTask = getDocument(
+        buildGetDocumentParams("tracemonkey.pdf")
+      );
 
       loadingTask.promise
         .then(function (pdfDoc) {
@@ -866,7 +877,9 @@ describe("api", function () {
     });
 
     it("gets default open action", function (done) {
-      var loadingTask = getDocument(buildGetDocumentParams("tracemonkey.pdf"));
+      const loadingTask = getDocument(
+        buildGetDocumentParams("tracemonkey.pdf")
+      );
 
       loadingTask.promise
         .then(function (pdfDoc) {
@@ -930,7 +943,7 @@ describe("api", function () {
     });
 
     it("gets non-existent attachments", function (done) {
-      var promise = pdfDocument.getAttachments();
+      const promise = pdfDocument.getAttachments();
       promise
         .then(function (data) {
           expect(data).toEqual(null);
@@ -939,13 +952,13 @@ describe("api", function () {
         .catch(done.fail);
     });
     it("gets attachments", function (done) {
-      var loadingTask = getDocument(buildGetDocumentParams("attachment.pdf"));
-      var promise = loadingTask.promise.then(function (pdfDoc) {
+      const loadingTask = getDocument(buildGetDocumentParams("attachment.pdf"));
+      const promise = loadingTask.promise.then(function (pdfDoc) {
         return pdfDoc.getAttachments();
       });
       promise
         .then(function (data) {
-          var attachment = data["foo.txt"];
+          const attachment = data["foo.txt"];
           expect(attachment.filename).toEqual("foo.txt");
           expect(attachment.content).toEqual(
             new Uint8Array([98, 97, 114, 32, 98, 97, 122, 32, 10])
@@ -957,7 +970,7 @@ describe("api", function () {
     });
 
     it("gets javascript", function (done) {
-      var promise = pdfDocument.getJavaScript();
+      const promise = pdfDocument.getJavaScript();
       promise
         .then(function (data) {
           expect(data).toEqual(null);
@@ -967,8 +980,8 @@ describe("api", function () {
     });
     it("gets javascript with printing instructions (JS action)", function (done) {
       // PDF document with "JavaScript" action in the OpenAction dictionary.
-      var loadingTask = getDocument(buildGetDocumentParams("issue6106.pdf"));
-      var promise = loadingTask.promise.then(function (pdfDoc) {
+      const loadingTask = getDocument(buildGetDocumentParams("issue6106.pdf"));
+      const promise = loadingTask.promise.then(function (pdfDoc) {
         return pdfDoc.getJavaScript();
       });
       promise
@@ -983,9 +996,11 @@ describe("api", function () {
     });
 
     it("gets non-existent outline", function (done) {
-      var loadingTask = getDocument(buildGetDocumentParams("tracemonkey.pdf"));
+      const loadingTask = getDocument(
+        buildGetDocumentParams("tracemonkey.pdf")
+      );
 
-      var promise = loadingTask.promise.then(function (pdfDoc) {
+      const promise = loadingTask.promise.then(function (pdfDoc) {
         return pdfDoc.getOutline();
       });
       promise
@@ -997,14 +1012,14 @@ describe("api", function () {
         .catch(done.fail);
     });
     it("gets outline", function (done) {
-      var promise = pdfDocument.getOutline();
+      const promise = pdfDocument.getOutline();
       promise
         .then(function (outline) {
           // Two top level entries.
           expect(Array.isArray(outline)).toEqual(true);
           expect(outline.length).toEqual(2);
           // Make sure some basic attributes are set.
-          var outlineItem = outline[1];
+          const outlineItem = outline[1];
           expect(outlineItem.title).toEqual("Chapter 1");
           expect(Array.isArray(outlineItem.dest)).toEqual(true);
           expect(outlineItem.url).toEqual(null);
@@ -1024,7 +1039,7 @@ describe("api", function () {
         .catch(done.fail);
     });
     it("gets outline containing a url", function (done) {
-      var loadingTask = getDocument(buildGetDocumentParams("issue3214.pdf"));
+      const loadingTask = getDocument(buildGetDocumentParams("issue3214.pdf"));
 
       loadingTask.promise
         .then(function (pdfDoc) {
@@ -1032,14 +1047,14 @@ describe("api", function () {
             expect(Array.isArray(outline)).toEqual(true);
             expect(outline.length).toEqual(5);
 
-            var outlineItemTwo = outline[2];
+            const outlineItemTwo = outline[2];
             expect(typeof outlineItemTwo.title).toEqual("string");
             expect(outlineItemTwo.dest).toEqual(null);
             expect(outlineItemTwo.url).toEqual("http://google.com/");
             expect(outlineItemTwo.unsafeUrl).toEqual("http://google.com");
             expect(outlineItemTwo.newWindow).toBeUndefined();
 
-            var outlineItemOne = outline[1];
+            const outlineItemOne = outline[1];
             expect(outlineItemOne.bold).toEqual(false);
             expect(outlineItemOne.italic).toEqual(true);
             expect(outlineItemOne.color).toEqual(
@@ -1115,7 +1130,7 @@ describe("api", function () {
     });
 
     it("gets metadata", function (done) {
-      var promise = pdfDocument.getMetadata();
+      const promise = pdfDocument.getMetadata();
       promise
         .then(function ({ info, metadata, contentDispositionFilename }) {
           expect(info.Title).toEqual("Basic API Test");
@@ -1137,7 +1152,9 @@ describe("api", function () {
         .catch(done.fail);
     });
     it("gets metadata, with custom info dict entries", function (done) {
-      var loadingTask = getDocument(buildGetDocumentParams("tracemonkey.pdf"));
+      const loadingTask = getDocument(
+        buildGetDocumentParams("tracemonkey.pdf")
+      );
 
       loadingTask.promise
         .then(function (pdfDoc) {
@@ -1193,7 +1210,7 @@ describe("api", function () {
     });
 
     it("gets data", function (done) {
-      var promise = pdfDocument.getData();
+      const promise = pdfDocument.getData();
       promise
         .then(function (data) {
           expect(data instanceof Uint8Array).toEqual(true);
@@ -1203,7 +1220,7 @@ describe("api", function () {
         .catch(done.fail);
     });
     it("gets download info", function (done) {
-      var promise = pdfDocument.getDownloadInfo();
+      const promise = pdfDocument.getDownloadInfo();
       promise
         .then(function (data) {
           expect(data).toEqual({ length: basicApiFileLength });
@@ -1212,7 +1229,7 @@ describe("api", function () {
         .catch(done.fail);
     });
     it("gets document stats", function (done) {
-      var promise = pdfDocument.getStats();
+      const promise = pdfDocument.getStats();
       promise
         .then(function (stats) {
           expect(stats).toEqual({ streamTypes: {}, fontTypes: {} });
@@ -1253,13 +1270,13 @@ describe("api", function () {
     });
 
     describe("Cross-origin", function () {
-      var loadingTask;
+      let loadingTask;
       function _checkCanLoad(expectSuccess, filename, options) {
         if (isNodeJS) {
           pending("Cannot simulate cross-origin requests in Node.js");
         }
-        var params = buildGetDocumentParams(filename, options);
-        var url = new URL(params.url);
+        const params = buildGetDocumentParams(filename, options);
+        const url = new URL(params.url);
         if (url.hostname === "localhost") {
           url.hostname = "127.0.0.1";
         } else if (params.url.hostname === "127.0.0.1") {
@@ -1396,7 +1413,7 @@ describe("api", function () {
     });
 
     it("gets viewport", function () {
-      var viewport = page.getViewport({ scale: 1.5, rotation: 90 });
+      const viewport = page.getViewport({ scale: 1.5, rotation: 90 });
       expect(viewport.viewBox).toEqual(page.view);
       expect(viewport.scale).toEqual(1.5);
       expect(viewport.rotation).toEqual(90);
@@ -1440,17 +1457,17 @@ describe("api", function () {
     });
 
     it("gets annotations", function (done) {
-      var defaultPromise = page.getAnnotations().then(function (data) {
+      const defaultPromise = page.getAnnotations().then(function (data) {
         expect(data.length).toEqual(4);
       });
 
-      var displayPromise = page
+      const displayPromise = page
         .getAnnotations({ intent: "display" })
         .then(function (data) {
           expect(data.length).toEqual(4);
         });
 
-      var printPromise = page
+      const printPromise = page
         .getAnnotations({ intent: "print" })
         .then(function (data) {
           expect(data.length).toEqual(4);
@@ -1463,21 +1480,21 @@ describe("api", function () {
     });
 
     it("gets annotations containing relative URLs (bug 766086)", function (done) {
-      var filename = "bug766086.pdf";
+      const filename = "bug766086.pdf";
 
-      var defaultLoadingTask = getDocument(buildGetDocumentParams(filename));
-      var defaultPromise = defaultLoadingTask.promise.then(function (pdfDoc) {
+      const defaultLoadingTask = getDocument(buildGetDocumentParams(filename));
+      const defaultPromise = defaultLoadingTask.promise.then(function (pdfDoc) {
         return pdfDoc.getPage(1).then(function (pdfPage) {
           return pdfPage.getAnnotations();
         });
       });
 
-      var docBaseUrlLoadingTask = getDocument(
+      const docBaseUrlLoadingTask = getDocument(
         buildGetDocumentParams(filename, {
           docBaseUrl: "http://www.example.com/test/pdfs/qwerty.pdf",
         })
       );
-      var docBaseUrlPromise = docBaseUrlLoadingTask.promise.then(function (
+      const docBaseUrlPromise = docBaseUrlLoadingTask.promise.then(function (
         pdfDoc
       ) {
         return pdfDoc.getPage(1).then(function (pdfPage) {
@@ -1485,12 +1502,12 @@ describe("api", function () {
         });
       });
 
-      var invalidDocBaseUrlLoadingTask = getDocument(
+      const invalidDocBaseUrlLoadingTask = getDocument(
         buildGetDocumentParams(filename, {
           docBaseUrl: "qwerty.pdf",
         })
       );
-      var invalidDocBaseUrlPromise = invalidDocBaseUrlLoadingTask.promise.then(
+      const invalidDocBaseUrlPromise = invalidDocBaseUrlLoadingTask.promise.then(
         function (pdfDoc) {
           return pdfDoc.getPage(1).then(function (pdfPage) {
             return pdfPage.getAnnotations();
@@ -1500,9 +1517,9 @@ describe("api", function () {
 
       Promise.all([defaultPromise, docBaseUrlPromise, invalidDocBaseUrlPromise])
         .then(function (data) {
-          var defaultAnnotations = data[0];
-          var docBaseUrlAnnotations = data[1];
-          var invalidDocBaseUrlAnnotations = data[2];
+          const defaultAnnotations = data[0];
+          const docBaseUrlAnnotations = data[1];
+          const invalidDocBaseUrlAnnotations = data[2];
 
           expect(defaultAnnotations[0].url).toBeUndefined();
           expect(defaultAnnotations[0].unsafeUrl).toEqual(
@@ -1531,13 +1548,13 @@ describe("api", function () {
     });
 
     it("gets text content", function (done) {
-      var defaultPromise = page.getTextContent();
-      var parametersPromise = page.getTextContent({
+      const defaultPromise = page.getTextContent();
+      const parametersPromise = page.getTextContent({
         normalizeWhitespace: true,
         disableCombineTextItems: true,
       });
 
-      var promises = [defaultPromise, parametersPromise];
+      const promises = [defaultPromise, parametersPromise];
       Promise.all(promises)
         .then(function (data) {
           expect(!!data[0].items).toEqual(true);
@@ -1586,7 +1603,7 @@ describe("api", function () {
     });
 
     it("gets operator list", function (done) {
-      var promise = page.getOperatorList();
+      const promise = page.getOperatorList();
       promise
         .then(function (oplist) {
           expect(!!oplist.fnArray).toEqual(true);
@@ -1662,12 +1679,12 @@ describe("api", function () {
     );
 
     it("gets document stats after parsing page", function (done) {
-      var promise = page.getOperatorList().then(function () {
+      const promise = page.getOperatorList().then(function () {
         return pdfDocument.getStats();
       });
-      var expectedStreamTypes = {};
+      const expectedStreamTypes = {};
       expectedStreamTypes[StreamType.FLATE] = true;
-      var expectedFontTypes = {};
+      const expectedFontTypes = {};
       expectedFontTypes[FontType.TYPE1] = true;
       expectedFontTypes[FontType.CIDFONTTYPE2] = true;
 
@@ -1764,10 +1781,13 @@ describe("api", function () {
     });
 
     it("cancels rendering of page", function (done) {
-      var viewport = page.getViewport({ scale: 1 });
-      var canvasAndCtx = CanvasFactory.create(viewport.width, viewport.height);
+      const viewport = page.getViewport({ scale: 1 });
+      const canvasAndCtx = CanvasFactory.create(
+        viewport.width,
+        viewport.height
+      );
 
-      var renderTask = page.render({
+      const renderTask = page.render({
         canvasContext: canvasAndCtx.context,
         canvasFactory: CanvasFactory,
         viewport,
@@ -1828,16 +1848,19 @@ describe("api", function () {
     it("multiple render() on the same canvas", function (done) {
       const optionalContentConfigPromise = pdfDocument.getOptionalContentConfig();
 
-      var viewport = page.getViewport({ scale: 1 });
-      var canvasAndCtx = CanvasFactory.create(viewport.width, viewport.height);
+      const viewport = page.getViewport({ scale: 1 });
+      const canvasAndCtx = CanvasFactory.create(
+        viewport.width,
+        viewport.height
+      );
 
-      var renderTask1 = page.render({
+      const renderTask1 = page.render({
         canvasContext: canvasAndCtx.context,
         canvasFactory: CanvasFactory,
         viewport,
         optionalContentConfigPromise,
       });
-      var renderTask2 = page.render({
+      const renderTask2 = page.render({
         canvasContext: canvasAndCtx.context,
         canvasFactory: CanvasFactory,
         viewport,
@@ -2016,12 +2039,12 @@ describe("api", function () {
   describe("Multiple `getDocument` instances", function () {
     // Regression test for https://github.com/mozilla/pdf.js/issues/6205
     // A PDF using the Helvetica font.
-    var pdf1 = buildGetDocumentParams("tracemonkey.pdf");
+    const pdf1 = buildGetDocumentParams("tracemonkey.pdf");
     // A PDF using the Times font.
-    var pdf2 = buildGetDocumentParams("TAMReview.pdf");
+    const pdf2 = buildGetDocumentParams("TAMReview.pdf");
     // A PDF using the Arial font.
-    var pdf3 = buildGetDocumentParams("issue6068.pdf");
-    var loadingTasks = [];
+    const pdf3 = buildGetDocumentParams("issue6068.pdf");
+    const loadingTasks = [];
 
     // Render the first page of the given PDF file.
     // Fulfills the promise with the base64-encoded version of the PDF.
@@ -2057,8 +2080,8 @@ describe("api", function () {
     });
 
     it("should correctly render PDFs in parallel", function (done) {
-      var baseline1, baseline2, baseline3;
-      var promiseDone = renderPDF(pdf1)
+      let baseline1, baseline2, baseline3;
+      const promiseDone = renderPDF(pdf1)
         .then(function (data1) {
           baseline1 = data1;
           return renderPDF(pdf2);

--- a/test/unit/bidi_spec.js
+++ b/test/unit/bidi_spec.js
@@ -18,18 +18,18 @@ import { bidi } from "../../src/core/bidi.js";
 describe("bidi", function () {
   it("should mark text as RTL if more than 30% of text is RTL", function () {
     // 33% of test text are RTL characters
-    var test = "\u0645\u0635\u0631 Egypt";
-    var result = "Egypt \u0631\u0635\u0645";
-    var bidiText = bidi(test, -1, false);
+    const test = "\u0645\u0635\u0631 Egypt";
+    const result = "Egypt \u0631\u0635\u0645";
+    const bidiText = bidi(test, -1, false);
 
     expect(bidiText.str).toEqual(result);
     expect(bidiText.dir).toEqual("rtl");
   });
 
   it("should mark text as LTR if less than 30% of text is RTL", function () {
-    var test = "Egypt is known as \u0645\u0635\u0631 in Arabic.";
-    var result = "Egypt is known as \u0631\u0635\u0645 in Arabic.";
-    var bidiText = bidi(test, -1, false);
+    const test = "Egypt is known as \u0645\u0635\u0631 in Arabic.";
+    const result = "Egypt is known as \u0631\u0635\u0645 in Arabic.";
+    const bidiText = bidi(test, -1, false);
 
     expect(bidiText.str).toEqual(result);
     expect(bidiText.dir).toEqual("ltr");

--- a/test/unit/cff_parser_spec.js
+++ b/test/unit/cff_parser_spec.js
@@ -25,26 +25,26 @@ import { Stream } from "../../src/core/stream.js";
 
 describe("CFFParser", function () {
   function createWithNullProto(obj) {
-    var result = Object.create(null);
-    for (var i in obj) {
+    const result = Object.create(null);
+    for (const i in obj) {
       result[i] = obj[i];
     }
     return result;
   }
 
   // Stub that returns `0` for any privateDict key.
-  var privateDictStub = {
+  const privateDictStub = {
     getByName(name) {
       return 0;
     },
   };
 
-  var fontData, parser, cff;
+  let fontData, parser, cff;
 
   beforeAll(function (done) {
     // This example font comes from the CFF spec:
     // http://www.adobe.com/content/dam/Adobe/en/devnet/font/pdfs/5176.CFF.pdf
-    var exampleFont =
+    const exampleFont =
       "0100040100010101134142434445462b" +
       "54696d65732d526f6d616e000101011f" +
       "f81b00f81c02f81d03f819041c6f000d" +
@@ -55,9 +55,9 @@ describe("CFFParser", function () {
       "8b06f79a93fc7c8c077d99f85695f75e" +
       "9908fb6e8cf87393f7108b09a70adf0b" +
       "f78e14";
-    var fontArr = [];
-    for (var i = 0, ii = exampleFont.length; i < ii; i += 2) {
-      var hex = exampleFont.substring(i, i + 2);
+    const fontArr = [];
+    for (let i = 0, ii = exampleFont.length; i < ii; i += 2) {
+      const hex = exampleFont.substring(i, i + 2);
       fontArr.push(parseInt(hex, 16));
     }
     fontData = new Stream(fontArr);
@@ -80,7 +80,7 @@ describe("CFFParser", function () {
   });
 
   it("parses header", function () {
-    var header = cff.header;
+    const header = cff.header;
     expect(header.major).toEqual(1);
     expect(header.minor).toEqual(0);
     expect(header.hdrSize).toEqual(4);
@@ -88,20 +88,20 @@ describe("CFFParser", function () {
   });
 
   it("parses name index", function () {
-    var names = cff.names;
+    const names = cff.names;
     expect(names.length).toEqual(1);
     expect(names[0]).toEqual("ABCDEF+Times-Roman");
   });
 
   it("parses string index", function () {
-    var strings = cff.strings;
+    const strings = cff.strings;
     expect(strings.count).toEqual(3);
     expect(strings.get(0)).toEqual(".notdef");
     expect(strings.get(391)).toEqual("001.007");
   });
 
   it("parses top dict", function () {
-    var topDict = cff.topDict;
+    const topDict = cff.topDict;
     // 391 version 392 FullName 393 FamilyName 389 Weight 28416 UniqueID
     // -168 -218 1000 898 FontBBox 94 CharStrings 45 102 Private
     expect(topDict.getByName("version")).toEqual(391);
@@ -115,8 +115,8 @@ describe("CFFParser", function () {
   });
 
   it("refuses to add topDict key with invalid value (bug 1068432)", function () {
-    var topDict = cff.topDict;
-    var defaultValue = topDict.getByName("UnderlinePosition");
+    const topDict = cff.topDict;
+    const defaultValue = topDict.getByName("UnderlinePosition");
 
     topDict.setByKey(/* [12, 3] = */ 3075, [NaN]);
     expect(topDict.getByName("UnderlinePosition")).toEqual(defaultValue);
@@ -127,26 +127,26 @@ describe("CFFParser", function () {
       "keys with invalid values (bug 1308536)",
     function () {
       // prettier-ignore
-      var bytes = new Uint8Array([
+      const bytes = new Uint8Array([
       64, 39, 31, 30, 252, 114, 137, 115, 79, 30, 197, 119, 2, 99, 127, 6
     ]);
       parser.bytes = bytes;
-      var topDict = cff.topDict;
+      const topDict = cff.topDict;
       topDict.setByName("Private", [bytes.length, 0]);
 
-      var parsePrivateDict = function () {
+      const parsePrivateDict = function () {
         parser.parsePrivateDict(topDict);
       };
       expect(parsePrivateDict).not.toThrow();
 
-      var privateDict = topDict.privateDict;
+      const privateDict = topDict.privateDict;
       expect(privateDict.getByName("BlueValues")).toBeNull();
     }
   );
 
   it("parses a CharString having cntrmask", function () {
     // prettier-ignore
-    var bytes = new Uint8Array([0, 1, // count
+    const bytes = new Uint8Array([0, 1, // count
                                 1,  // offsetSize
                                 0,  // offset[0]
                                 38, // end
@@ -161,8 +161,8 @@ describe("CFFParser", function () {
                                 14  // endchar
                               ]);
     parser.bytes = bytes;
-    var charStringsIndex = parser.parseIndex(0).obj;
-    var charStrings = parser.parseCharStrings({
+    const charStringsIndex = parser.parseIndex(0).obj;
+    const charStrings = parser.parseCharStrings({
       charStrings: charStringsIndex,
       privateDict: privateDictStub,
     }).charStrings;
@@ -180,13 +180,13 @@ describe("CFFParser", function () {
     cffParser.parse(); // cff
 
     // prettier-ignore
-    var bytes = new Uint8Array([0, 1, // count
+    const bytes = new Uint8Array([0, 1, // count
                                 1,  // offsetSize
                                 0,  // offset[0]
                                 237, 247, 22, 247, 72, 204, 247, 86, 14]);
     cffParser.bytes = bytes;
-    var charStringsIndex = cffParser.parseIndex(0).obj;
-    var result = cffParser.parseCharStrings({
+    const charStringsIndex = cffParser.parseIndex(0).obj;
+    const result = cffParser.parseCharStrings({
       charStrings: charStringsIndex,
       privateDict: privateDictStub,
     });
@@ -209,13 +209,13 @@ describe("CFFParser", function () {
     cffParser.parse(); // cff
 
     // prettier-ignore
-    var bytes = new Uint8Array([0, 1, // count
+    const bytes = new Uint8Array([0, 1, // count
                                 1,  // offsetSize
                                 0,  // offset[0]
                                 237, 247, 22, 247, 72, 204, 247, 86, 14]);
     cffParser.bytes = bytes;
-    var charStringsIndex = cffParser.parseIndex(0).obj;
-    var result = cffParser.parseCharStrings({
+    const charStringsIndex = cffParser.parseIndex(0).obj;
+    const result = cffParser.parseCharStrings({
       charStrings: charStringsIndex,
       privateDict: privateDictStub,
     });
@@ -226,13 +226,13 @@ describe("CFFParser", function () {
 
   it("parses a CharString endchar no args", function () {
     // prettier-ignore
-    var bytes = new Uint8Array([0, 1, // count
+    const bytes = new Uint8Array([0, 1, // count
                                 1,  // offsetSize
                                 0,  // offset[0]
                                 14]);
     parser.bytes = bytes;
-    var charStringsIndex = parser.parseIndex(0).obj;
-    var result = parser.parseCharStrings({
+    const charStringsIndex = parser.parseIndex(0).obj;
+    const result = parser.parseCharStrings({
       charStrings: charStringsIndex,
       privateDict: privateDictStub,
     });
@@ -242,19 +242,19 @@ describe("CFFParser", function () {
   });
 
   it("parses predefined charsets", function () {
-    var charset = parser.parseCharsets(0, 0, null, true);
+    const charset = parser.parseCharsets(0, 0, null, true);
     expect(charset.predefined).toEqual(true);
   });
 
   it("parses charset format 0", function () {
     // The first three bytes make the offset large enough to skip predefined.
     // prettier-ignore
-    var bytes = new Uint8Array([0x00, 0x00, 0x00,
+    const bytes = new Uint8Array([0x00, 0x00, 0x00,
                                 0x00, // format
                                 0x00, 0x02 // sid/cid
                               ]);
     parser.bytes = bytes;
-    var charset = parser.parseCharsets(3, 2, new CFFStrings(), false);
+    let charset = parser.parseCharsets(3, 2, new CFFStrings(), false);
     expect(charset.charset[1]).toEqual("exclam");
 
     // CID font
@@ -265,13 +265,13 @@ describe("CFFParser", function () {
   it("parses charset format 1", function () {
     // The first three bytes make the offset large enough to skip predefined.
     // prettier-ignore
-    var bytes = new Uint8Array([0x00, 0x00, 0x00,
+    const bytes = new Uint8Array([0x00, 0x00, 0x00,
                                 0x01, // format
                                 0x00, 0x08, // sid/cid start
                                 0x01 // sid/cid left
                               ]);
     parser.bytes = bytes;
-    var charset = parser.parseCharsets(3, 2, new CFFStrings(), false);
+    let charset = parser.parseCharsets(3, 2, new CFFStrings(), false);
     expect(charset.charset).toEqual([".notdef", "quoteright", "parenleft"]);
 
     // CID font
@@ -283,13 +283,13 @@ describe("CFFParser", function () {
     // format 2 is the same as format 1 but the left is card16
     // The first three bytes make the offset large enough to skip predefined.
     // prettier-ignore
-    var bytes = new Uint8Array([0x00, 0x00, 0x00,
+    const bytes = new Uint8Array([0x00, 0x00, 0x00,
                                 0x02, // format
                                 0x00, 0x08, // sid/cid start
                                 0x00, 0x01 // sid/cid left
                               ]);
     parser.bytes = bytes;
-    var charset = parser.parseCharsets(3, 2, new CFFStrings(), false);
+    let charset = parser.parseCharsets(3, 2, new CFFStrings(), false);
     expect(charset.charset).toEqual([".notdef", "quoteright", "parenleft"]);
 
     // CID font
@@ -300,27 +300,27 @@ describe("CFFParser", function () {
   it("parses encoding format 0", function () {
     // The first two bytes make the offset large enough to skip predefined.
     // prettier-ignore
-    var bytes = new Uint8Array([0x00, 0x00,
+    const bytes = new Uint8Array([0x00, 0x00,
                                 0x00, // format
                                 0x01, // count
                                 0x08  // start
                               ]);
     parser.bytes = bytes;
-    var encoding = parser.parseEncoding(2, {}, new CFFStrings(), null);
+    const encoding = parser.parseEncoding(2, {}, new CFFStrings(), null);
     expect(encoding.encoding).toEqual(createWithNullProto({ 0x8: 1 }));
   });
 
   it("parses encoding format 1", function () {
     // The first two bytes make the offset large enough to skip predefined.
     // prettier-ignore
-    var bytes = new Uint8Array([0x00, 0x00,
+    const bytes = new Uint8Array([0x00, 0x00,
                                 0x01, // format
                                 0x01, // num ranges
                                 0x07, // range1 start
                                 0x01 // range2 left
                               ]);
     parser.bytes = bytes;
-    var encoding = parser.parseEncoding(2, {}, new CFFStrings(), null);
+    const encoding = parser.parseEncoding(2, {}, new CFFStrings(), null);
     expect(encoding.encoding).toEqual(
       createWithNullProto({ 0x7: 0x01, 0x08: 0x02 })
     );
@@ -328,12 +328,12 @@ describe("CFFParser", function () {
 
   it("parses fdselect format 0", function () {
     // prettier-ignore
-    var bytes = new Uint8Array([0x00, // format
+    const bytes = new Uint8Array([0x00, // format
                                 0x00, // gid: 0 fd: 0
                                 0x01 // gid: 1 fd: 1
                                ]);
     parser.bytes = bytes.slice();
-    var fdSelect = parser.parseFDSelect(0, 2);
+    const fdSelect = parser.parseFDSelect(0, 2);
 
     expect(fdSelect.fdSelect).toEqual([0, 1]);
     expect(fdSelect.format).toEqual(0);
@@ -341,7 +341,7 @@ describe("CFFParser", function () {
 
   it("parses fdselect format 3", function () {
     // prettier-ignore
-    var bytes = new Uint8Array([0x03, // format
+    const bytes = new Uint8Array([0x03, // format
                                 0x00, 0x02, // range count
                                 0x00, 0x00, // first gid
                                 0x09, // font dict 1 id
@@ -350,7 +350,7 @@ describe("CFFParser", function () {
                                 0x00, 0x04 // sentinel (last gid)
                                ]);
     parser.bytes = bytes.slice();
-    var fdSelect = parser.parseFDSelect(0, 4);
+    const fdSelect = parser.parseFDSelect(0, 4);
 
     expect(fdSelect.fdSelect).toEqual([9, 9, 0xa, 0xa]);
     expect(fdSelect.format).toEqual(3);
@@ -358,7 +358,7 @@ describe("CFFParser", function () {
 
   it("parses invalid fdselect format 3 (bug 1146106)", function () {
     // prettier-ignore
-    var bytes = new Uint8Array([0x03, // format
+    const bytes = new Uint8Array([0x03, // format
                                 0x00, 0x02, // range count
                                 0x00, 0x01, // first gid (invalid)
                                 0x09, // font dict 1 id
@@ -367,7 +367,7 @@ describe("CFFParser", function () {
                                 0x00, 0x04 // sentinel (last gid)
                                ]);
     parser.bytes = bytes.slice();
-    var fdSelect = parser.parseFDSelect(0, 4);
+    const fdSelect = parser.parseFDSelect(0, 4);
 
     expect(fdSelect.fdSelect).toEqual([9, 9, 0xa, 0xa]);
     expect(fdSelect.format).toEqual(3);
@@ -391,7 +391,7 @@ describe("CFFCompiler", function () {
   }
 
   it("encodes integers", function () {
-    var c = new CFFCompiler();
+    const c = new CFFCompiler();
     // all the examples from the spec
     expect(c.encodeInteger(0)).toEqual([0x8b]);
     expect(c.encodeInteger(100)).toEqual([0xef]);
@@ -405,21 +405,21 @@ describe("CFFCompiler", function () {
   });
 
   it("encodes floats", function () {
-    var c = new CFFCompiler();
+    const c = new CFFCompiler();
     expect(c.encodeFloat(-2.25)).toEqual([0x1e, 0xe2, 0xa2, 0x5f]);
     expect(c.encodeFloat(5e-11)).toEqual([0x1e, 0x5c, 0x11, 0xff]);
   });
 
   it("sanitizes name index", function () {
-    var c = new CFFCompiler();
-    var nameIndexCompiled = c.compileNameIndex(["[a"]);
-    var parser = testParser(nameIndexCompiled);
-    var nameIndex = parser.parseIndex(0);
-    var names = parser.parseNameIndex(nameIndex.obj);
+    const c = new CFFCompiler();
+    let nameIndexCompiled = c.compileNameIndex(["[a"]);
+    let parser = testParser(nameIndexCompiled);
+    let nameIndex = parser.parseIndex(0);
+    let names = parser.parseNameIndex(nameIndex.obj);
     expect(names).toEqual(["_a"]);
 
-    var longName = "";
-    for (var i = 0; i < 129; i++) {
+    let longName = "";
+    for (let i = 0; i < 129; i++) {
       longName += "_";
     }
     nameIndexCompiled = c.compileNameIndex([longName]);
@@ -430,9 +430,9 @@ describe("CFFCompiler", function () {
   });
 
   it("compiles fdselect format 0", function () {
-    var fdSelect = new CFFFDSelect(0, [3, 2, 1]);
-    var c = new CFFCompiler();
-    var out = c.compileFDSelect(fdSelect);
+    const fdSelect = new CFFFDSelect(0, [3, 2, 1]);
+    const c = new CFFCompiler();
+    const out = c.compileFDSelect(fdSelect);
     expect(out).toEqual([
       0, // format
       3, // gid: 0 fd 3
@@ -442,9 +442,9 @@ describe("CFFCompiler", function () {
   });
 
   it("compiles fdselect format 3", function () {
-    var fdSelect = new CFFFDSelect(3, [0, 0, 1, 1]);
-    var c = new CFFCompiler();
-    var out = c.compileFDSelect(fdSelect);
+    const fdSelect = new CFFFDSelect(3, [0, 0, 1, 1]);
+    const c = new CFFCompiler();
+    const out = c.compileFDSelect(fdSelect);
     expect(out).toEqual([
       3, // format
       0, // nRanges (high)
@@ -461,9 +461,9 @@ describe("CFFCompiler", function () {
   });
 
   it("compiles fdselect format 3, single range", function () {
-    var fdSelect = new CFFFDSelect(3, [0, 0]);
-    var c = new CFFCompiler();
-    var out = c.compileFDSelect(fdSelect);
+    const fdSelect = new CFFFDSelect(3, [0, 0]);
+    const c = new CFFCompiler();
+    const out = c.compileFDSelect(fdSelect);
     expect(out).toEqual([
       3, // format
       0, // nRanges (high)
@@ -477,10 +477,10 @@ describe("CFFCompiler", function () {
   });
 
   it("compiles charset of CID font", function () {
-    var charset = new CFFCharset();
-    var c = new CFFCompiler();
-    var numGlyphs = 7;
-    var out = c.compileCharset(charset, numGlyphs, new CFFStrings(), true);
+    const charset = new CFFCharset();
+    const c = new CFFCompiler();
+    const numGlyphs = 7;
+    const out = c.compileCharset(charset, numGlyphs, new CFFStrings(), true);
     // All CID charsets get turned into a simple format 2.
     expect(out).toEqual([
       2, // format
@@ -492,10 +492,10 @@ describe("CFFCompiler", function () {
   });
 
   it("compiles charset of non CID font", function () {
-    var charset = new CFFCharset(false, 0, ["space", "exclam"]);
-    var c = new CFFCompiler();
-    var numGlyphs = 3;
-    var out = c.compileCharset(charset, numGlyphs, new CFFStrings(), false);
+    const charset = new CFFCharset(false, 0, ["space", "exclam"]);
+    const c = new CFFCompiler();
+    const numGlyphs = 3;
+    const out = c.compileCharset(charset, numGlyphs, new CFFStrings(), false);
     // All non-CID fonts use a format 0 charset.
     expect(out).toEqual([
       0, // format

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -20,18 +20,18 @@ import { Name } from "../../src/core/primitives.js";
 import { NodeCMapReaderFactory } from "../../src/display/node_utils.js";
 import { StringStream } from "../../src/core/stream.js";
 
-var cMapUrl = {
+const cMapUrl = {
   dom: "../../external/bcmaps/",
   node: "./external/bcmaps/",
 };
-var cMapPacked = true;
+const cMapPacked = true;
 
 describe("cmap", function () {
-  var fetchBuiltInCMap;
+  let fetchBuiltInCMap;
 
   beforeAll(function (done) {
     // Allow CMap testing in Node.js, e.g. for Travis.
-    var CMapReaderFactory;
+    let CMapReaderFactory;
     if (isNodeJS) {
       CMapReaderFactory = new NodeCMapReaderFactory({
         baseUrl: cMapUrl.node,
@@ -58,12 +58,12 @@ describe("cmap", function () {
 
   it("parses beginbfchar", function (done) {
     // prettier-ignore
-    var str = "2 beginbfchar\n" +
+    const str = "2 beginbfchar\n" +
               "<03> <00>\n" +
               "<04> <01>\n" +
               "endbfchar\n";
-    var stream = new StringStream(str);
-    var cmapPromise = CMapFactory.create({ encoding: stream });
+    const stream = new StringStream(str);
+    const cmapPromise = CMapFactory.create({ encoding: stream });
     cmapPromise
       .then(function (cmap) {
         expect(cmap.lookup(0x03)).toEqual(String.fromCharCode(0x00));
@@ -77,11 +77,11 @@ describe("cmap", function () {
   });
   it("parses beginbfrange with range", function (done) {
     // prettier-ignore
-    var str = "1 beginbfrange\n" +
+    const str = "1 beginbfrange\n" +
               "<06> <0B> 0\n" +
               "endbfrange\n";
-    var stream = new StringStream(str);
-    var cmapPromise = CMapFactory.create({ encoding: stream });
+    const stream = new StringStream(str);
+    const cmapPromise = CMapFactory.create({ encoding: stream });
     cmapPromise
       .then(function (cmap) {
         expect(cmap.lookup(0x05)).toBeUndefined();
@@ -96,11 +96,11 @@ describe("cmap", function () {
   });
   it("parses beginbfrange with array", function (done) {
     // prettier-ignore
-    var str = "1 beginbfrange\n" +
+    const str = "1 beginbfrange\n" +
               "<0D> <12> [ 0 1 2 3 4 5 ]\n" +
               "endbfrange\n";
-    var stream = new StringStream(str);
-    var cmapPromise = CMapFactory.create({ encoding: stream });
+    const stream = new StringStream(str);
+    const cmapPromise = CMapFactory.create({ encoding: stream });
     cmapPromise
       .then(function (cmap) {
         expect(cmap.lookup(0x0c)).toBeUndefined();
@@ -115,11 +115,11 @@ describe("cmap", function () {
   });
   it("parses begincidchar", function (done) {
     // prettier-ignore
-    var str = "1 begincidchar\n" +
+    const str = "1 begincidchar\n" +
               "<14> 0\n" +
               "endcidchar\n";
-    var stream = new StringStream(str);
-    var cmapPromise = CMapFactory.create({ encoding: stream });
+    const stream = new StringStream(str);
+    const cmapPromise = CMapFactory.create({ encoding: stream });
     cmapPromise
       .then(function (cmap) {
         expect(cmap.lookup(0x14)).toEqual(0x00);
@@ -132,11 +132,11 @@ describe("cmap", function () {
   });
   it("parses begincidrange", function (done) {
     // prettier-ignore
-    var str = "1 begincidrange\n" +
+    const str = "1 begincidrange\n" +
               "<0016> <001B>   0\n" +
               "endcidrange\n";
-    var stream = new StringStream(str);
-    var cmapPromise = CMapFactory.create({ encoding: stream });
+    const stream = new StringStream(str);
+    const cmapPromise = CMapFactory.create({ encoding: stream });
     cmapPromise
       .then(function (cmap) {
         expect(cmap.lookup(0x15)).toBeUndefined();
@@ -151,15 +151,15 @@ describe("cmap", function () {
   });
   it("decodes codespace ranges", function (done) {
     // prettier-ignore
-    var str = "1 begincodespacerange\n" +
+    const str = "1 begincodespacerange\n" +
               "<01> <02>\n" +
               "<00000003> <00000004>\n" +
               "endcodespacerange\n";
-    var stream = new StringStream(str);
-    var cmapPromise = CMapFactory.create({ encoding: stream });
+    const stream = new StringStream(str);
+    const cmapPromise = CMapFactory.create({ encoding: stream });
     cmapPromise
       .then(function (cmap) {
-        var c = {};
+        const c = {};
         cmap.readCharCode(String.fromCharCode(1), 0, c);
         expect(c.charcode).toEqual(1);
         expect(c.length).toEqual(1);
@@ -174,14 +174,14 @@ describe("cmap", function () {
   });
   it("decodes 4 byte codespace ranges", function (done) {
     // prettier-ignore
-    var str = "1 begincodespacerange\n" +
+    const str = "1 begincodespacerange\n" +
               "<8EA1A1A1> <8EA1FEFE>\n" +
               "endcodespacerange\n";
-    var stream = new StringStream(str);
-    var cmapPromise = CMapFactory.create({ encoding: stream });
+    const stream = new StringStream(str);
+    const cmapPromise = CMapFactory.create({ encoding: stream });
     cmapPromise
       .then(function (cmap) {
-        var c = {};
+        const c = {};
         cmap.readCharCode(String.fromCharCode(0x8e, 0xa1, 0xa1, 0xa1), 0, c);
         expect(c.charcode).toEqual(0x8ea1a1a1);
         expect(c.length).toEqual(4);
@@ -192,9 +192,9 @@ describe("cmap", function () {
       });
   });
   it("read usecmap", function (done) {
-    var str = "/Adobe-Japan1-1 usecmap\n";
-    var stream = new StringStream(str);
-    var cmapPromise = CMapFactory.create({
+    const str = "/Adobe-Japan1-1 usecmap\n";
+    const stream = new StringStream(str);
+    const cmapPromise = CMapFactory.create({
       encoding: stream,
       fetchBuiltInCMap,
       useCMap: null,
@@ -213,9 +213,9 @@ describe("cmap", function () {
       });
   });
   it("parses cmapname", function (done) {
-    var str = "/CMapName /Identity-H def\n";
-    var stream = new StringStream(str);
-    var cmapPromise = CMapFactory.create({ encoding: stream });
+    const str = "/CMapName /Identity-H def\n";
+    const stream = new StringStream(str);
+    const cmapPromise = CMapFactory.create({ encoding: stream });
     cmapPromise
       .then(function (cmap) {
         expect(cmap.name).toEqual("Identity-H");
@@ -226,9 +226,9 @@ describe("cmap", function () {
       });
   });
   it("parses wmode", function (done) {
-    var str = "/WMode 1 def\n";
-    var stream = new StringStream(str);
-    var cmapPromise = CMapFactory.create({ encoding: stream });
+    const str = "/WMode 1 def\n";
+    const stream = new StringStream(str);
+    const cmapPromise = CMapFactory.create({ encoding: stream });
     cmapPromise
       .then(function (cmap) {
         expect(cmap.vertical).toEqual(true);
@@ -239,7 +239,7 @@ describe("cmap", function () {
       });
   });
   it("loads built in cmap", function (done) {
-    var cmapPromise = CMapFactory.create({
+    const cmapPromise = CMapFactory.create({
       encoding: Name.get("Adobe-Japan1-1"),
       fetchBuiltInCMap,
       useCMap: null,
@@ -258,7 +258,7 @@ describe("cmap", function () {
       });
   });
   it("loads built in identity cmap", function (done) {
-    var cmapPromise = CMapFactory.create({
+    const cmapPromise = CMapFactory.create({
       encoding: Name.get("Identity-H"),
       fetchBuiltInCMap,
       useCMap: null,
@@ -279,7 +279,7 @@ describe("cmap", function () {
   });
 
   it("attempts to load a non-existent built-in CMap", function (done) {
-    var cmapPromise = CMapFactory.create({
+    const cmapPromise = CMapFactory.create({
       encoding: Name.get("null"),
       fetchBuiltInCMap,
       useCMap: null,
@@ -298,7 +298,7 @@ describe("cmap", function () {
 
   it("attempts to load a built-in CMap without the necessary API parameters", function (done) {
     function tmpFetchBuiltInCMap(name) {
-      var CMapReaderFactory = isNodeJS
+      const CMapReaderFactory = isNodeJS
         ? new NodeCMapReaderFactory({})
         : new DOMCMapReaderFactory({});
       return CMapReaderFactory.fetch({
@@ -306,7 +306,7 @@ describe("cmap", function () {
       });
     }
 
-    var cmapPromise = CMapFactory.create({
+    const cmapPromise = CMapFactory.create({
       encoding: Name.get("Adobe-Japan1-1"),
       fetchBuiltInCMap: tmpFetchBuiltInCMap,
       useCMap: null,

--- a/test/unit/crypto_spec.js
+++ b/test/unit/crypto_spec.js
@@ -34,16 +34,16 @@ import {
 
 describe("crypto", function () {
   function hex2binary(s) {
-    var digits = "0123456789ABCDEF";
+    const digits = "0123456789ABCDEF";
     s = s.toUpperCase();
-    var n = s.length >> 1,
+    let n = s.length >> 1,
       i,
       j;
-    var result = new Uint8Array(n);
+    const result = new Uint8Array(n);
     for (i = 0, j = 0; i < n; ++i) {
-      var d1 = s.charAt(j++);
-      var d2 = s.charAt(j++);
-      var value = (digits.indexOf(d1) << 4) | digits.indexOf(d2);
+      const d1 = s.charAt(j++);
+      const d2 = s.charAt(j++);
+      const value = (digits.indexOf(d1) << 4) | digits.indexOf(d2);
       result[i] = value;
     }
     return result;
@@ -52,42 +52,42 @@ describe("crypto", function () {
   // RFC 1321, A.5 Test suite
   describe("calculateMD5", function () {
     it("should pass RFC 1321 test #1", function () {
-      var input, result, expected;
+      let input, result, expected;
       input = stringToBytes("");
       result = calculateMD5(input, 0, input.length);
       expected = hex2binary("d41d8cd98f00b204e9800998ecf8427e");
       expect(result).toEqual(expected);
     });
     it("should pass RFC 1321 test #2", function () {
-      var input, result, expected;
+      let input, result, expected;
       input = stringToBytes("a");
       result = calculateMD5(input, 0, input.length);
       expected = hex2binary("0cc175b9c0f1b6a831c399e269772661");
       expect(result).toEqual(expected);
     });
     it("should pass RFC 1321 test #3", function () {
-      var input, result, expected;
+      let input, result, expected;
       input = stringToBytes("abc");
       result = calculateMD5(input, 0, input.length);
       expected = hex2binary("900150983cd24fb0d6963f7d28e17f72");
       expect(result).toEqual(expected);
     });
     it("should pass RFC 1321 test #4", function () {
-      var input, result, expected;
+      let input, result, expected;
       input = stringToBytes("message digest");
       result = calculateMD5(input, 0, input.length);
       expected = hex2binary("f96b697d7cb7938d525a2f31aaf161d0");
       expect(result).toEqual(expected);
     });
     it("should pass RFC 1321 test #5", function () {
-      var input, result, expected;
+      let input, result, expected;
       input = stringToBytes("abcdefghijklmnopqrstuvwxyz");
       result = calculateMD5(input, 0, input.length);
       expected = hex2binary("c3fcd3d76192e4007dfb496cca67e13b");
       expect(result).toEqual(expected);
     });
     it("should pass RFC 1321 test #6", function () {
-      var input, result, expected;
+      let input, result, expected;
       input = stringToBytes(
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
       );
@@ -96,7 +96,7 @@ describe("crypto", function () {
       expect(result).toEqual(expected);
     });
     it("should pass RFC 1321 test #7", function () {
-      var input, result, expected;
+      let input, result, expected;
       input = stringToBytes(
         "123456789012345678901234567890123456789012345678" +
           "90123456789012345678901234567890"
@@ -110,7 +110,7 @@ describe("crypto", function () {
   // http://www.freemedialibrary.com/index.php/RC4_test_vectors are used
   describe("ARCFourCipher", function () {
     it("should pass test #1", function () {
-      var key, input, result, expected, cipher;
+      let key, input, result, expected, cipher;
       key = hex2binary("0123456789abcdef");
       input = hex2binary("0123456789abcdef");
       cipher = new ARCFourCipher(key);
@@ -119,7 +119,7 @@ describe("crypto", function () {
       expect(result).toEqual(expected);
     });
     it("should pass test #2", function () {
-      var key, input, result, expected, cipher;
+      let key, input, result, expected, cipher;
       key = hex2binary("0123456789abcdef");
       input = hex2binary("0000000000000000");
       cipher = new ARCFourCipher(key);
@@ -128,7 +128,7 @@ describe("crypto", function () {
       expect(result).toEqual(expected);
     });
     it("should pass test #3", function () {
-      var key, input, result, expected, cipher;
+      let key, input, result, expected, cipher;
       key = hex2binary("0000000000000000");
       input = hex2binary("0000000000000000");
       cipher = new ARCFourCipher(key);
@@ -137,7 +137,7 @@ describe("crypto", function () {
       expect(result).toEqual(expected);
     });
     it("should pass test #4", function () {
-      var key, input, result, expected, cipher;
+      let key, input, result, expected, cipher;
       key = hex2binary("ef012345");
       input = hex2binary("00000000000000000000");
       cipher = new ARCFourCipher(key);
@@ -146,7 +146,7 @@ describe("crypto", function () {
       expect(result).toEqual(expected);
     });
     it("should pass test #5", function () {
-      var key, input, result, expected, cipher;
+      let key, input, result, expected, cipher;
       key = hex2binary("0123456789abcdef");
       input = hex2binary(
         "010101010101010101010101010101010101010101010101010" +
@@ -189,7 +189,7 @@ describe("crypto", function () {
       expect(result).toEqual(expected);
     });
     it("should pass test #6", function () {
-      var key, input, result, expected, cipher;
+      let key, input, result, expected, cipher;
       key = hex2binary("fb029e3031323334");
       input = hex2binary(
         "aaaa0300000008004500004e661a00008011be640a0001220af" +
@@ -206,7 +206,7 @@ describe("crypto", function () {
       expect(result).toEqual(expected);
     });
     it("should pass test #7", function () {
-      var key, input, result, expected, cipher;
+      let key, input, result, expected, cipher;
       key = hex2binary("0123456789abcdef");
       input = hex2binary(
         "123456789abcdef0123456789abcdef0123456789abcdef012345678"
@@ -222,7 +222,7 @@ describe("crypto", function () {
 
   describe("calculateSHA256", function () {
     it("should properly hash abc", function () {
-      var input, result, expected;
+      let input, result, expected;
       input = stringToBytes("abc");
       result = calculateSHA256(input, 0, input.length);
       expected = hex2binary(
@@ -231,7 +231,7 @@ describe("crypto", function () {
       expect(result).toEqual(expected);
     });
     it("should properly hash a multiblock input", function () {
-      var input, result, expected;
+      let input, result, expected;
       input = stringToBytes(
         "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
       );
@@ -245,7 +245,7 @@ describe("crypto", function () {
 
   describe("calculateSHA384", function () {
     it("should properly hash abc", function () {
-      var input, result, expected;
+      let input, result, expected;
       input = stringToBytes("abc");
       result = calculateSHA384(input, 0, input.length);
       expected = hex2binary(
@@ -255,7 +255,7 @@ describe("crypto", function () {
       expect(result).toEqual(expected);
     });
     it("should properly hash a multiblock input", function () {
-      var input, result, expected;
+      let input, result, expected;
       input = stringToBytes(
         "abcdefghbcdefghicdefghijdefghijkefghijklfghijklm" +
           "ghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrs" +
@@ -272,7 +272,7 @@ describe("crypto", function () {
 
   describe("calculateSHA512", function () {
     it("should properly hash abc", function () {
-      var input, result, expected;
+      let input, result, expected;
       input = stringToBytes("abc");
       result = calculateSHA512(input, 0, input.length);
       expected = hex2binary(
@@ -283,7 +283,7 @@ describe("crypto", function () {
       expect(result).toEqual(expected);
     });
     it("should properly hash a multiblock input", function () {
-      var input, result, expected;
+      let input, result, expected;
       input = stringToBytes(
         "abcdefghbcdefghicdefghijdefghijkefghijklfghijklm" +
           "ghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrs" +
@@ -302,7 +302,7 @@ describe("crypto", function () {
   describe("AES128", function () {
     describe("Encryption", function () {
       it("should be able to encrypt a block", function () {
-        var input, key, result, expected, iv, cipher;
+        let input, key, result, expected, iv, cipher;
         input = hex2binary("00112233445566778899aabbccddeeff");
         key = hex2binary("000102030405060708090a0b0c0d0e0f");
         iv = hex2binary("00000000000000000000000000000000");
@@ -315,7 +315,7 @@ describe("crypto", function () {
 
     describe("Decryption", function () {
       it("should be able to decrypt a block with IV in stream", function () {
-        var input, key, result, expected, cipher;
+        let input, key, result, expected, cipher;
         input = hex2binary(
           "0000000000000000000000000000000069c4e0d86a7b0430d" +
             "8cdb78070b4c55a"
@@ -332,7 +332,7 @@ describe("crypto", function () {
   describe("AES256", function () {
     describe("Encryption", function () {
       it("should be able to encrypt a block", function () {
-        var input, key, result, expected, iv, cipher;
+        let input, key, result, expected, iv, cipher;
         input = hex2binary("00112233445566778899aabbccddeeff");
         key = hex2binary(
           "000102030405060708090a0b0c0d0e0f101112131415161718" +
@@ -348,7 +348,7 @@ describe("crypto", function () {
 
     describe("Decryption", function () {
       it("should be able to decrypt a block with specified iv", function () {
-        var input, key, result, expected, cipher, iv;
+        let input, key, result, expected, cipher, iv;
         input = hex2binary("8ea2b7ca516745bfeafc49904b496089");
         key = hex2binary(
           "000102030405060708090a0b0c0d0e0f101112131415161718" +
@@ -361,7 +361,7 @@ describe("crypto", function () {
         expect(result).toEqual(expected);
       });
       it("should be able to decrypt a block with IV in stream", function () {
-        var input, key, result, expected, cipher;
+        let input, key, result, expected, cipher;
         input = hex2binary(
           "000000000000000000000000000000008ea2b7ca516745bf" +
             "eafc49904b496089"
@@ -380,7 +380,7 @@ describe("crypto", function () {
 
   describe("PDF17Algorithm", function () {
     it("should correctly check a user key", function () {
-      var password, userValidation, userPassword, alg, result;
+      let password, userValidation, userPassword, alg, result;
       alg = new PDF17();
       password = new Uint8Array([117, 115, 101, 114]);
       userValidation = new Uint8Array([117, 169, 4, 32, 159, 101, 22, 220]);
@@ -394,7 +394,7 @@ describe("crypto", function () {
     });
 
     it("should correctly check an owner key", function () {
-      var password, ownerValidation, ownerPassword, alg, result, uBytes;
+      let password, ownerValidation, ownerPassword, alg, result, uBytes;
       alg = new PDF17();
       password = new Uint8Array([111, 119, 110, 101, 114]);
       ownerValidation = new Uint8Array([243, 118, 71, 153, 128, 17, 101, 62]);
@@ -419,7 +419,7 @@ describe("crypto", function () {
     });
 
     it("should generate a file encryption key from the user key", function () {
-      var password, userKeySalt, expected, alg, result, userEncryption;
+      let password, userKeySalt, expected, alg, result, userEncryption;
       alg = new PDF17();
       password = new Uint8Array([117, 115, 101, 114]);
       userKeySalt = new Uint8Array([168, 94, 215, 192, 100, 38, 188, 40]);
@@ -438,8 +438,8 @@ describe("crypto", function () {
     });
 
     it("should generate a file encryption key from the owner key", function () {
-      var password, ownerKeySalt, expected, alg, result, ownerEncryption;
-      var uBytes;
+      let password, ownerKeySalt, expected, alg, result, ownerEncryption;
+      let uBytes;
       alg = new PDF17();
       password = new Uint8Array([111, 119, 110, 101, 114]);
       ownerKeySalt = new Uint8Array([200, 245, 242, 12, 218, 123, 24, 120]);
@@ -466,7 +466,7 @@ describe("crypto", function () {
 
   describe("PDF20Algorithm", function () {
     it("should correctly check a user key", function () {
-      var password, userValidation, userPassword, alg, result;
+      let password, userValidation, userPassword, alg, result;
       alg = new PDF20();
       password = new Uint8Array([117, 115, 101, 114]);
       userValidation = new Uint8Array([83, 245, 146, 101, 198, 247, 34, 198]);
@@ -480,7 +480,7 @@ describe("crypto", function () {
     });
 
     it("should correctly check an owner key", function () {
-      var password, ownerValidation, ownerPassword, alg, result, uBytes;
+      let password, ownerValidation, ownerPassword, alg, result, uBytes;
       alg = new PDF20();
       password = new Uint8Array([111, 119, 110, 101, 114]);
       ownerValidation = new Uint8Array([142, 232, 169, 208, 202, 214, 5, 185]);
@@ -505,7 +505,7 @@ describe("crypto", function () {
     });
 
     it("should generate a file encryption key from the user key", function () {
-      var password, userKeySalt, expected, alg, result, userEncryption;
+      let password, userKeySalt, expected, alg, result, userEncryption;
       alg = new PDF20();
       password = new Uint8Array([117, 115, 101, 114]);
       userKeySalt = new Uint8Array([191, 11, 16, 94, 237, 216, 20, 175]);
@@ -524,8 +524,8 @@ describe("crypto", function () {
     });
 
     it("should generate a file encryption key from the owner key", function () {
-      var password, ownerKeySalt, expected, alg, result, ownerEncryption;
-      var uBytes;
+      let password, ownerKeySalt, expected, alg, result, ownerEncryption;
+      let uBytes;
       alg = new PDF20();
       password = new Uint8Array([111, 119, 110, 101, 114]);
       ownerKeySalt = new Uint8Array([29, 208, 185, 46, 11, 76, 135, 149]);
@@ -553,8 +553,8 @@ describe("crypto", function () {
 
 describe("CipherTransformFactory", function () {
   function buildDict(map) {
-    var dict = new Dict();
-    for (var key in map) {
+    const dict = new Dict();
+    for (const key in map) {
       dict.set(key, map[key]);
     }
     return dict;
@@ -562,7 +562,7 @@ describe("CipherTransformFactory", function () {
 
   function ensurePasswordCorrect(done, dict, fileId, password) {
     try {
-      var factory = new CipherTransformFactory(dict, fileId, password);
+      const factory = new CipherTransformFactory(dict, fileId, password);
       expect("createCipherTransform" in factory).toEqual(true);
     } catch (ex) {
       done.fail("Password should be accepted: " + ex);
@@ -608,8 +608,8 @@ describe("CipherTransformFactory", function () {
     expect(string).toEqual(decrypted);
   }
 
-  var fileId1, fileId2, dict1, dict2, dict3;
-  var aes256Dict, aes256IsoDict, aes256BlankDict, aes256IsoBlankDict;
+  let fileId1, fileId2, dict1, dict2, dict3;
+  let aes256Dict, aes256IsoDict, aes256BlankDict, aes256IsoBlankDict;
 
   beforeAll(function (done) {
     fileId1 = unescape("%F6%C6%AF%17%F3rR%8DRM%9A%80%D1%EF%DF%18");

--- a/test/unit/crypto_spec.js
+++ b/test/unit/crypto_spec.js
@@ -36,11 +36,9 @@ describe("crypto", function () {
   function hex2binary(s) {
     const digits = "0123456789ABCDEF";
     s = s.toUpperCase();
-    let n = s.length >> 1,
-      i,
-      j;
+    const n = s.length >> 1;
     const result = new Uint8Array(n);
-    for (i = 0, j = 0; i < n; ++i) {
+    for (let i = 0, j = 0; i < n; ++i) {
       const d1 = s.charAt(j++);
       const d2 = s.charAt(j++);
       const value = (digits.indexOf(d1) << 4) | digits.indexOf(d2);
@@ -52,57 +50,50 @@ describe("crypto", function () {
   // RFC 1321, A.5 Test suite
   describe("calculateMD5", function () {
     it("should pass RFC 1321 test #1", function () {
-      let input, result, expected;
-      input = stringToBytes("");
-      result = calculateMD5(input, 0, input.length);
-      expected = hex2binary("d41d8cd98f00b204e9800998ecf8427e");
+      const input = stringToBytes("");
+      const result = calculateMD5(input, 0, input.length);
+      const expected = hex2binary("d41d8cd98f00b204e9800998ecf8427e");
       expect(result).toEqual(expected);
     });
     it("should pass RFC 1321 test #2", function () {
-      let input, result, expected;
-      input = stringToBytes("a");
-      result = calculateMD5(input, 0, input.length);
-      expected = hex2binary("0cc175b9c0f1b6a831c399e269772661");
+      const input = stringToBytes("a");
+      const result = calculateMD5(input, 0, input.length);
+      const expected = hex2binary("0cc175b9c0f1b6a831c399e269772661");
       expect(result).toEqual(expected);
     });
     it("should pass RFC 1321 test #3", function () {
-      let input, result, expected;
-      input = stringToBytes("abc");
-      result = calculateMD5(input, 0, input.length);
-      expected = hex2binary("900150983cd24fb0d6963f7d28e17f72");
+      const input = stringToBytes("abc");
+      const result = calculateMD5(input, 0, input.length);
+      const expected = hex2binary("900150983cd24fb0d6963f7d28e17f72");
       expect(result).toEqual(expected);
     });
     it("should pass RFC 1321 test #4", function () {
-      let input, result, expected;
-      input = stringToBytes("message digest");
-      result = calculateMD5(input, 0, input.length);
-      expected = hex2binary("f96b697d7cb7938d525a2f31aaf161d0");
+      const input = stringToBytes("message digest");
+      const result = calculateMD5(input, 0, input.length);
+      const expected = hex2binary("f96b697d7cb7938d525a2f31aaf161d0");
       expect(result).toEqual(expected);
     });
     it("should pass RFC 1321 test #5", function () {
-      let input, result, expected;
-      input = stringToBytes("abcdefghijklmnopqrstuvwxyz");
-      result = calculateMD5(input, 0, input.length);
-      expected = hex2binary("c3fcd3d76192e4007dfb496cca67e13b");
+      const input = stringToBytes("abcdefghijklmnopqrstuvwxyz");
+      const result = calculateMD5(input, 0, input.length);
+      const expected = hex2binary("c3fcd3d76192e4007dfb496cca67e13b");
       expect(result).toEqual(expected);
     });
     it("should pass RFC 1321 test #6", function () {
-      let input, result, expected;
-      input = stringToBytes(
+      const input = stringToBytes(
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
       );
-      result = calculateMD5(input, 0, input.length);
-      expected = hex2binary("d174ab98d277d9f5a5611c2c9f419d9f");
+      const result = calculateMD5(input, 0, input.length);
+      const expected = hex2binary("d174ab98d277d9f5a5611c2c9f419d9f");
       expect(result).toEqual(expected);
     });
     it("should pass RFC 1321 test #7", function () {
-      let input, result, expected;
-      input = stringToBytes(
+      const input = stringToBytes(
         "123456789012345678901234567890123456789012345678" +
           "90123456789012345678901234567890"
       );
-      result = calculateMD5(input, 0, input.length);
-      expected = hex2binary("57edf4a22be3c955ac49da2e2107b67a");
+      const result = calculateMD5(input, 0, input.length);
+      const expected = hex2binary("57edf4a22be3c955ac49da2e2107b67a");
       expect(result).toEqual(expected);
     });
   });
@@ -110,45 +101,40 @@ describe("crypto", function () {
   // http://www.freemedialibrary.com/index.php/RC4_test_vectors are used
   describe("ARCFourCipher", function () {
     it("should pass test #1", function () {
-      let key, input, result, expected, cipher;
-      key = hex2binary("0123456789abcdef");
-      input = hex2binary("0123456789abcdef");
-      cipher = new ARCFourCipher(key);
-      result = cipher.encryptBlock(input);
-      expected = hex2binary("75b7878099e0c596");
+      const key = hex2binary("0123456789abcdef");
+      const input = hex2binary("0123456789abcdef");
+      const cipher = new ARCFourCipher(key);
+      const result = cipher.encryptBlock(input);
+      const expected = hex2binary("75b7878099e0c596");
       expect(result).toEqual(expected);
     });
     it("should pass test #2", function () {
-      let key, input, result, expected, cipher;
-      key = hex2binary("0123456789abcdef");
-      input = hex2binary("0000000000000000");
-      cipher = new ARCFourCipher(key);
-      result = cipher.encryptBlock(input);
-      expected = hex2binary("7494c2e7104b0879");
+      const key = hex2binary("0123456789abcdef");
+      const input = hex2binary("0000000000000000");
+      const cipher = new ARCFourCipher(key);
+      const result = cipher.encryptBlock(input);
+      const expected = hex2binary("7494c2e7104b0879");
       expect(result).toEqual(expected);
     });
     it("should pass test #3", function () {
-      let key, input, result, expected, cipher;
-      key = hex2binary("0000000000000000");
-      input = hex2binary("0000000000000000");
-      cipher = new ARCFourCipher(key);
-      result = cipher.encryptBlock(input);
-      expected = hex2binary("de188941a3375d3a");
+      const key = hex2binary("0000000000000000");
+      const input = hex2binary("0000000000000000");
+      const cipher = new ARCFourCipher(key);
+      const result = cipher.encryptBlock(input);
+      const expected = hex2binary("de188941a3375d3a");
       expect(result).toEqual(expected);
     });
     it("should pass test #4", function () {
-      let key, input, result, expected, cipher;
-      key = hex2binary("ef012345");
-      input = hex2binary("00000000000000000000");
-      cipher = new ARCFourCipher(key);
-      result = cipher.encryptBlock(input);
-      expected = hex2binary("d6a141a7ec3c38dfbd61");
+      const key = hex2binary("ef012345");
+      const input = hex2binary("00000000000000000000");
+      const cipher = new ARCFourCipher(key);
+      const result = cipher.encryptBlock(input);
+      const expected = hex2binary("d6a141a7ec3c38dfbd61");
       expect(result).toEqual(expected);
     });
     it("should pass test #5", function () {
-      let key, input, result, expected, cipher;
-      key = hex2binary("0123456789abcdef");
-      input = hex2binary(
+      const key = hex2binary("0123456789abcdef");
+      const input = hex2binary(
         "010101010101010101010101010101010101010101010101010" +
           "10101010101010101010101010101010101010101010101010101010101010101010" +
           "10101010101010101010101010101010101010101010101010101010101010101010" +
@@ -166,9 +152,9 @@ describe("crypto", function () {
           "10101010101010101010101010101010101010101010101010101010101010101010" +
           "101010101010101010101"
       );
-      cipher = new ARCFourCipher(key);
-      result = cipher.encryptBlock(input);
-      expected = hex2binary(
+      const cipher = new ARCFourCipher(key);
+      const result = cipher.encryptBlock(input);
+      const expected = hex2binary(
         "7595c3e6114a09780c4ad452338e1ffd9a1be9498f813d76" +
           "533449b6778dcad8c78a8d2ba9ac66085d0e53d59c26c2d1c490c1ebbe0ce66d1b6b" +
           "1b13b6b919b847c25a91447a95e75e4ef16779cde8bf0a95850e32af9689444fd377" +
@@ -189,16 +175,15 @@ describe("crypto", function () {
       expect(result).toEqual(expected);
     });
     it("should pass test #6", function () {
-      let key, input, result, expected, cipher;
-      key = hex2binary("fb029e3031323334");
-      input = hex2binary(
+      const key = hex2binary("fb029e3031323334");
+      const input = hex2binary(
         "aaaa0300000008004500004e661a00008011be640a0001220af" +
           "fffff00890089003a000080a601100001000000000000204543454a4548454346434" +
           "550464545494546464343414341434143414341414100002000011bd0b604"
       );
-      cipher = new ARCFourCipher(key);
-      result = cipher.encryptBlock(input);
-      expected = hex2binary(
+      const cipher = new ARCFourCipher(key);
+      const result = cipher.encryptBlock(input);
+      const expected = hex2binary(
         "f69c5806bd6ce84626bcbefb9474650aad1f7909b0f64d5f" +
           "58a503a258b7ed22eb0ea64930d3a056a55742fcce141d485f8aa836dea18df42c53" +
           "80805ad0c61a5d6f58f41040b24b7d1a693856ed0d4398e7aee3bf0e2a2ca8f7"
@@ -206,14 +191,13 @@ describe("crypto", function () {
       expect(result).toEqual(expected);
     });
     it("should pass test #7", function () {
-      let key, input, result, expected, cipher;
-      key = hex2binary("0123456789abcdef");
-      input = hex2binary(
+      const key = hex2binary("0123456789abcdef");
+      const input = hex2binary(
         "123456789abcdef0123456789abcdef0123456789abcdef012345678"
       );
-      cipher = new ARCFourCipher(key);
-      result = cipher.encryptBlock(input);
-      expected = hex2binary(
+      const cipher = new ARCFourCipher(key);
+      const result = cipher.encryptBlock(input);
+      const expected = hex2binary(
         "66a0949f8af7d6891f7f832ba833c00c892ebe30143ce28740011ecf"
       );
       expect(result).toEqual(expected);
@@ -222,21 +206,19 @@ describe("crypto", function () {
 
   describe("calculateSHA256", function () {
     it("should properly hash abc", function () {
-      let input, result, expected;
-      input = stringToBytes("abc");
-      result = calculateSHA256(input, 0, input.length);
-      expected = hex2binary(
+      const input = stringToBytes("abc");
+      const result = calculateSHA256(input, 0, input.length);
+      const expected = hex2binary(
         "BA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD"
       );
       expect(result).toEqual(expected);
     });
     it("should properly hash a multiblock input", function () {
-      let input, result, expected;
-      input = stringToBytes(
+      const input = stringToBytes(
         "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
       );
-      result = calculateSHA256(input, 0, input.length);
-      expected = hex2binary(
+      const result = calculateSHA256(input, 0, input.length);
+      const expected = hex2binary(
         "248D6A61D20638B8E5C026930C3E6039A33CE45964FF2167F6ECEDD419DB06C1"
       );
       expect(result).toEqual(expected);
@@ -245,24 +227,22 @@ describe("crypto", function () {
 
   describe("calculateSHA384", function () {
     it("should properly hash abc", function () {
-      let input, result, expected;
-      input = stringToBytes("abc");
-      result = calculateSHA384(input, 0, input.length);
-      expected = hex2binary(
+      const input = stringToBytes("abc");
+      const result = calculateSHA384(input, 0, input.length);
+      const expected = hex2binary(
         "CB00753F45A35E8BB5A03D699AC65007272C32AB0EDED163" +
           "1A8B605A43FF5BED8086072BA1E7CC2358BAECA134C825A7"
       );
       expect(result).toEqual(expected);
     });
     it("should properly hash a multiblock input", function () {
-      let input, result, expected;
-      input = stringToBytes(
+      const input = stringToBytes(
         "abcdefghbcdefghicdefghijdefghijkefghijklfghijklm" +
           "ghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrs" +
           "mnopqrstnopqrstu"
       );
-      result = calculateSHA384(input, 0, input.length);
-      expected = hex2binary(
+      const result = calculateSHA384(input, 0, input.length);
+      const expected = hex2binary(
         "09330C33F71147E83D192FC782CD1B4753111B173B3B05D2" +
           "2FA08086E3B0F712FCC7C71A557E2DB966C3E9FA91746039"
       );
@@ -272,10 +252,9 @@ describe("crypto", function () {
 
   describe("calculateSHA512", function () {
     it("should properly hash abc", function () {
-      let input, result, expected;
-      input = stringToBytes("abc");
-      result = calculateSHA512(input, 0, input.length);
-      expected = hex2binary(
+      const input = stringToBytes("abc");
+      const result = calculateSHA512(input, 0, input.length);
+      const expected = hex2binary(
         "DDAF35A193617ABACC417349AE20413112E6FA4E89A97EA2" +
           "0A9EEEE64B55D39A2192992A274FC1A836BA3C23A3FEEBBD" +
           "454D4423643CE80E2A9AC94FA54CA49F"
@@ -283,14 +262,13 @@ describe("crypto", function () {
       expect(result).toEqual(expected);
     });
     it("should properly hash a multiblock input", function () {
-      let input, result, expected;
-      input = stringToBytes(
+      const input = stringToBytes(
         "abcdefghbcdefghicdefghijdefghijkefghijklfghijklm" +
           "ghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrs" +
           "mnopqrstnopqrstu"
       );
-      result = calculateSHA512(input, 0, input.length);
-      expected = hex2binary(
+      const result = calculateSHA512(input, 0, input.length);
+      const expected = hex2binary(
         "8E959B75DAE313DA8CF4F72814FC143F8F7779C6EB9F7FA1" +
           "7299AEADB6889018501D289E4900F7E4331B99DEC4B5433A" +
           "C7D329EEB6DD26545E96E55B874BE909"
@@ -302,28 +280,26 @@ describe("crypto", function () {
   describe("AES128", function () {
     describe("Encryption", function () {
       it("should be able to encrypt a block", function () {
-        let input, key, result, expected, iv, cipher;
-        input = hex2binary("00112233445566778899aabbccddeeff");
-        key = hex2binary("000102030405060708090a0b0c0d0e0f");
-        iv = hex2binary("00000000000000000000000000000000");
-        cipher = new AES128Cipher(key);
-        result = cipher.encrypt(input, iv);
-        expected = hex2binary("69c4e0d86a7b0430d8cdb78070b4c55a");
+        const input = hex2binary("00112233445566778899aabbccddeeff");
+        const key = hex2binary("000102030405060708090a0b0c0d0e0f");
+        const iv = hex2binary("00000000000000000000000000000000");
+        const cipher = new AES128Cipher(key);
+        const result = cipher.encrypt(input, iv);
+        const expected = hex2binary("69c4e0d86a7b0430d8cdb78070b4c55a");
         expect(result).toEqual(expected);
       });
     });
 
     describe("Decryption", function () {
       it("should be able to decrypt a block with IV in stream", function () {
-        let input, key, result, expected, cipher;
-        input = hex2binary(
+        const input = hex2binary(
           "0000000000000000000000000000000069c4e0d86a7b0430d" +
             "8cdb78070b4c55a"
         );
-        key = hex2binary("000102030405060708090a0b0c0d0e0f");
-        cipher = new AES128Cipher(key);
-        result = cipher.decryptBlock(input);
-        expected = hex2binary("00112233445566778899aabbccddeeff");
+        const key = hex2binary("000102030405060708090a0b0c0d0e0f");
+        const cipher = new AES128Cipher(key);
+        const result = cipher.decryptBlock(input);
+        const expected = hex2binary("00112233445566778899aabbccddeeff");
         expect(result).toEqual(expected);
       });
     });
@@ -332,47 +308,44 @@ describe("crypto", function () {
   describe("AES256", function () {
     describe("Encryption", function () {
       it("should be able to encrypt a block", function () {
-        let input, key, result, expected, iv, cipher;
-        input = hex2binary("00112233445566778899aabbccddeeff");
-        key = hex2binary(
+        const input = hex2binary("00112233445566778899aabbccddeeff");
+        const key = hex2binary(
           "000102030405060708090a0b0c0d0e0f101112131415161718" +
             "191a1b1c1d1e1f"
         );
-        iv = hex2binary("00000000000000000000000000000000");
-        cipher = new AES256Cipher(key);
-        result = cipher.encrypt(input, iv);
-        expected = hex2binary("8ea2b7ca516745bfeafc49904b496089");
+        const iv = hex2binary("00000000000000000000000000000000");
+        const cipher = new AES256Cipher(key);
+        const result = cipher.encrypt(input, iv);
+        const expected = hex2binary("8ea2b7ca516745bfeafc49904b496089");
         expect(result).toEqual(expected);
       });
     });
 
     describe("Decryption", function () {
       it("should be able to decrypt a block with specified iv", function () {
-        let input, key, result, expected, cipher, iv;
-        input = hex2binary("8ea2b7ca516745bfeafc49904b496089");
-        key = hex2binary(
+        const input = hex2binary("8ea2b7ca516745bfeafc49904b496089");
+        const key = hex2binary(
           "000102030405060708090a0b0c0d0e0f101112131415161718" +
             "191a1b1c1d1e1f"
         );
-        iv = hex2binary("00000000000000000000000000000000");
-        cipher = new AES256Cipher(key);
-        result = cipher.decryptBlock(input, false, iv);
-        expected = hex2binary("00112233445566778899aabbccddeeff");
+        const iv = hex2binary("00000000000000000000000000000000");
+        const cipher = new AES256Cipher(key);
+        const result = cipher.decryptBlock(input, false, iv);
+        const expected = hex2binary("00112233445566778899aabbccddeeff");
         expect(result).toEqual(expected);
       });
       it("should be able to decrypt a block with IV in stream", function () {
-        let input, key, result, expected, cipher;
-        input = hex2binary(
+        const input = hex2binary(
           "000000000000000000000000000000008ea2b7ca516745bf" +
             "eafc49904b496089"
         );
-        key = hex2binary(
+        const key = hex2binary(
           "000102030405060708090a0b0c0d0e0f101112131415161718" +
             "191a1b1c1d1e1f"
         );
-        cipher = new AES256Cipher(key);
-        result = cipher.decryptBlock(input, false);
-        expected = hex2binary("00112233445566778899aabbccddeeff");
+        const cipher = new AES256Cipher(key);
+        const result = cipher.decryptBlock(input, false);
+        const expected = hex2binary("00112233445566778899aabbccddeeff");
         expect(result).toEqual(expected);
       });
     });
@@ -380,36 +353,50 @@ describe("crypto", function () {
 
   describe("PDF17Algorithm", function () {
     it("should correctly check a user key", function () {
-      let password, userValidation, userPassword, alg, result;
-      alg = new PDF17();
-      password = new Uint8Array([117, 115, 101, 114]);
-      userValidation = new Uint8Array([117, 169, 4, 32, 159, 101, 22, 220]);
+      const alg = new PDF17();
+      const password = new Uint8Array([117, 115, 101, 114]);
       // prettier-ignore
-      userPassword = new Uint8Array([131, 242, 143, 160, 87, 2, 138, 134, 79,
-                                     253, 189, 173, 224, 73, 144, 241, 190, 81,
-                                     197, 15, 249, 105, 145, 151, 15, 194, 65,
-                                     3, 1, 126, 187, 221]);
-      result = alg.checkUserPassword(password, userValidation, userPassword);
+      const userValidation = new Uint8Array([
+        117, 169, 4, 32, 159, 101, 22, 220
+      ]);
+      // prettier-ignore
+      const userPassword = new Uint8Array([
+        131, 242, 143, 160, 87, 2, 138, 134, 79,
+        253, 189, 173, 224, 73, 144, 241, 190, 81,
+        197, 15, 249, 105, 145, 151, 15, 194, 65,
+        3, 1, 126, 187, 221
+      ]);
+      const result = alg.checkUserPassword(
+        password,
+        userValidation,
+        userPassword
+      );
       expect(result).toEqual(true);
     });
 
     it("should correctly check an owner key", function () {
-      let password, ownerValidation, ownerPassword, alg, result, uBytes;
-      alg = new PDF17();
-      password = new Uint8Array([111, 119, 110, 101, 114]);
-      ownerValidation = new Uint8Array([243, 118, 71, 153, 128, 17, 101, 62]);
+      const alg = new PDF17();
+      const password = new Uint8Array([111, 119, 110, 101, 114]);
       // prettier-ignore
-      ownerPassword = new Uint8Array([60, 98, 137, 35, 51, 101, 200, 152, 210,
-                                      178, 226, 228, 134, 205, 163, 24, 204,
-                                      126, 177, 36, 106, 50, 36, 125, 210, 172,
-                                      171, 120, 222, 108, 139, 115]);
+      const ownerValidation = new Uint8Array([
+        243, 118, 71, 153, 128, 17, 101, 62
+      ]);
       // prettier-ignore
-      uBytes = new Uint8Array([131, 242, 143, 160, 87, 2, 138, 134, 79, 253,
-                               189, 173, 224, 73, 144, 241, 190, 81, 197, 15,
-                               249, 105, 145, 151, 15, 194, 65, 3, 1, 126, 187,
-                               221, 117, 169, 4, 32, 159, 101, 22, 220, 168,
-                               94, 215, 192, 100, 38, 188, 40]);
-      result = alg.checkOwnerPassword(
+      const ownerPassword = new Uint8Array([
+        60, 98, 137, 35, 51, 101, 200, 152, 210,
+        178, 226, 228, 134, 205, 163, 24, 204,
+        126, 177, 36, 106, 50, 36, 125, 210, 172,
+        171, 120, 222, 108, 139, 115
+      ]);
+      // prettier-ignore
+      const uBytes = new Uint8Array([
+        131, 242, 143, 160, 87, 2, 138, 134, 79, 253,
+        189, 173, 224, 73, 144, 241, 190, 81, 197, 15,
+        249, 105, 145, 151, 15, 194, 65, 3, 1, 126, 187,
+        221, 117, 169, 4, 32, 159, 101, 22, 220, 168,
+        94, 215, 192, 100, 38, 188, 40
+      ]);
+      const result = alg.checkOwnerPassword(
         password,
         ownerValidation,
         uBytes,
@@ -419,83 +406,112 @@ describe("crypto", function () {
     });
 
     it("should generate a file encryption key from the user key", function () {
-      let password, userKeySalt, expected, alg, result, userEncryption;
-      alg = new PDF17();
-      password = new Uint8Array([117, 115, 101, 114]);
-      userKeySalt = new Uint8Array([168, 94, 215, 192, 100, 38, 188, 40]);
+      const alg = new PDF17();
+      const password = new Uint8Array([117, 115, 101, 114]);
+      const userKeySalt = new Uint8Array([168, 94, 215, 192, 100, 38, 188, 40]);
       // prettier-ignore
-      userEncryption = new Uint8Array([35, 150, 195, 169, 245, 51, 51, 255,
-                                       158, 158, 33, 242, 231, 75, 125, 190,
-                                       25, 126, 172, 114, 195, 244, 137, 245,
-                                       234, 165, 42, 74, 60, 38, 17, 17]);
-      result = alg.getUserKey(password, userKeySalt, userEncryption);
+      const userEncryption = new Uint8Array([
+        35, 150, 195, 169, 245, 51, 51, 255,
+        158, 158, 33, 242, 231, 75, 125, 190,
+        25, 126, 172, 114, 195, 244, 137, 245,
+        234, 165, 42, 74, 60, 38, 17, 17
+      ]);
+      const result = alg.getUserKey(password, userKeySalt, userEncryption);
       // prettier-ignore
-      expected = new Uint8Array([63, 114, 136, 209, 87, 61, 12, 30, 249, 1,
-                                 186, 144, 254, 248, 163, 153, 151, 51, 133,
-                                 10, 80, 152, 206, 15, 72, 187, 231, 33, 224,
-                                 239, 13, 213]);
+      const expected = new Uint8Array([
+        63, 114, 136, 209, 87, 61, 12, 30, 249, 1,
+        186, 144, 254, 248, 163, 153, 151, 51, 133,
+        10, 80, 152, 206, 15, 72, 187, 231, 33, 224,
+        239, 13, 213
+      ]);
       expect(result).toEqual(expected);
     });
 
     it("should generate a file encryption key from the owner key", function () {
-      let password, ownerKeySalt, expected, alg, result, ownerEncryption;
-      let uBytes;
-      alg = new PDF17();
-      password = new Uint8Array([111, 119, 110, 101, 114]);
-      ownerKeySalt = new Uint8Array([200, 245, 242, 12, 218, 123, 24, 120]);
+      const alg = new PDF17();
+      const password = new Uint8Array([111, 119, 110, 101, 114]);
       // prettier-ignore
-      ownerEncryption = new Uint8Array([213, 202, 14, 189, 110, 76, 70, 191, 6,
-                                        195, 10, 190, 157, 100, 144, 85, 8, 62,
-                                        123, 178, 156, 229, 50, 40, 229, 216,
-                                        54, 222, 34, 38, 106, 223]);
+      const ownerKeySalt = new Uint8Array([
+        200, 245, 242, 12, 218, 123, 24, 120
+      ]);
       // prettier-ignore
-      uBytes = new Uint8Array([131, 242, 143, 160, 87, 2, 138, 134, 79, 253,
-                               189, 173, 224, 73, 144, 241, 190, 81, 197, 15,
-                               249, 105, 145, 151, 15, 194, 65, 3, 1, 126, 187,
-                               221, 117, 169, 4, 32, 159, 101, 22, 220, 168,
-                               94, 215, 192, 100, 38, 188, 40]);
-      result = alg.getOwnerKey(password, ownerKeySalt, uBytes, ownerEncryption);
+      const ownerEncryption = new Uint8Array([
+        213, 202, 14, 189, 110, 76, 70, 191, 6,
+        195, 10, 190, 157, 100, 144, 85, 8, 62,
+        123, 178, 156, 229, 50, 40, 229, 216,
+        54, 222, 34, 38, 106, 223
+      ]);
       // prettier-ignore
-      expected = new Uint8Array([63, 114, 136, 209, 87, 61, 12, 30, 249, 1,
-                                 186, 144, 254, 248, 163, 153, 151, 51, 133,
-                                 10, 80, 152, 206, 15, 72, 187, 231, 33, 224,
-                                 239, 13, 213]);
+      const uBytes = new Uint8Array([
+        131, 242, 143, 160, 87, 2, 138, 134, 79, 253,
+        189, 173, 224, 73, 144, 241, 190, 81, 197, 15,
+        249, 105, 145, 151, 15, 194, 65, 3, 1, 126, 187,
+        221, 117, 169, 4, 32, 159, 101, 22, 220, 168,
+        94, 215, 192, 100, 38, 188, 40
+      ]);
+      const result = alg.getOwnerKey(
+        password,
+        ownerKeySalt,
+        uBytes,
+        ownerEncryption
+      );
+      // prettier-ignore
+      const expected = new Uint8Array([
+        63, 114, 136, 209, 87, 61, 12, 30, 249, 1,
+        186, 144, 254, 248, 163, 153, 151, 51, 133,
+        10, 80, 152, 206, 15, 72, 187, 231, 33, 224,
+        239, 13, 213
+      ]);
       expect(result).toEqual(expected);
     });
   });
 
   describe("PDF20Algorithm", function () {
     it("should correctly check a user key", function () {
-      let password, userValidation, userPassword, alg, result;
-      alg = new PDF20();
-      password = new Uint8Array([117, 115, 101, 114]);
-      userValidation = new Uint8Array([83, 245, 146, 101, 198, 247, 34, 198]);
+      const alg = new PDF20();
+      const password = new Uint8Array([117, 115, 101, 114]);
       // prettier-ignore
-      userPassword = new Uint8Array([94, 230, 205, 75, 166, 99, 250, 76, 219,
-                                     128, 17, 85, 57, 17, 33, 164, 150, 46,
-                                     103, 176, 160, 156, 187, 233, 166, 223,
-                                     163, 253, 147, 235, 95, 184]);
-      result = alg.checkUserPassword(password, userValidation, userPassword);
+      const userValidation = new Uint8Array([
+        83, 245, 146, 101, 198, 247, 34, 198
+      ]);
+      // prettier-ignore
+      const userPassword = new Uint8Array([
+        94, 230, 205, 75, 166, 99, 250, 76, 219,
+        128, 17, 85, 57, 17, 33, 164, 150, 46,
+        103, 176, 160, 156, 187, 233, 166, 223,
+        163, 253, 147, 235, 95, 184
+      ]);
+      const result = alg.checkUserPassword(
+        password,
+        userValidation,
+        userPassword
+      );
       expect(result).toEqual(true);
     });
 
     it("should correctly check an owner key", function () {
-      let password, ownerValidation, ownerPassword, alg, result, uBytes;
-      alg = new PDF20();
-      password = new Uint8Array([111, 119, 110, 101, 114]);
-      ownerValidation = new Uint8Array([142, 232, 169, 208, 202, 214, 5, 185]);
+      const alg = new PDF20();
+      const password = new Uint8Array([111, 119, 110, 101, 114]);
       // prettier-ignore
-      ownerPassword = new Uint8Array([88, 232, 62, 54, 245, 26, 245, 209, 137,
-                                      123, 221, 72, 199, 49, 37, 217, 31, 74,
-                                      115, 167, 127, 158, 176, 77, 45, 163, 87,
-                                      47, 39, 90, 217, 141]);
+      const ownerValidation = new Uint8Array([
+        142, 232, 169, 208, 202, 214, 5, 185
+      ]);
       // prettier-ignore
-      uBytes = new Uint8Array([94, 230, 205, 75, 166, 99, 250, 76, 219, 128,
-                               17, 85, 57, 17, 33, 164, 150, 46, 103, 176, 160,
-                               156, 187, 233, 166, 223, 163, 253, 147, 235, 95,
-                               184, 83, 245, 146, 101, 198, 247, 34, 198, 191,
-                               11, 16, 94, 237, 216, 20, 175]);
-      result = alg.checkOwnerPassword(
+      const ownerPassword = new Uint8Array([
+        88, 232, 62, 54, 245, 26, 245, 209, 137,
+        123, 221, 72, 199, 49, 37, 217, 31, 74,
+        115, 167, 127, 158, 176, 77, 45, 163, 87,
+        47, 39, 90, 217, 141
+      ]);
+      // prettier-ignore
+      const uBytes = new Uint8Array([
+        94, 230, 205, 75, 166, 99, 250, 76, 219, 128,
+        17, 85, 57, 17, 33, 164, 150, 46, 103, 176, 160,
+        156, 187, 233, 166, 223, 163, 253, 147, 235, 95,
+        184, 83, 245, 146, 101, 198, 247, 34, 198, 191,
+        11, 16, 94, 237, 216, 20, 175
+      ]);
+      const result = alg.checkOwnerPassword(
         password,
         ownerValidation,
         uBytes,
@@ -505,47 +521,59 @@ describe("crypto", function () {
     });
 
     it("should generate a file encryption key from the user key", function () {
-      let password, userKeySalt, expected, alg, result, userEncryption;
-      alg = new PDF20();
-      password = new Uint8Array([117, 115, 101, 114]);
-      userKeySalt = new Uint8Array([191, 11, 16, 94, 237, 216, 20, 175]);
+      const alg = new PDF20();
+      const password = new Uint8Array([117, 115, 101, 114]);
+      const userKeySalt = new Uint8Array([191, 11, 16, 94, 237, 216, 20, 175]);
       // prettier-ignore
-      userEncryption = new Uint8Array([121, 208, 2, 181, 230, 89, 156, 60, 253,
-                                       143, 212, 28, 84, 180, 196, 177, 173,
-                                       128, 221, 107, 46, 20, 94, 186, 135, 51,
-                                       95, 24, 20, 223, 254, 36]);
-      result = alg.getUserKey(password, userKeySalt, userEncryption);
+      const userEncryption = new Uint8Array([
+        121, 208, 2, 181, 230, 89, 156, 60, 253,
+        143, 212, 28, 84, 180, 196, 177, 173,
+        128, 221, 107, 46, 20, 94, 186, 135, 51,
+        95, 24, 20, 223, 254, 36
+      ]);
+      const result = alg.getUserKey(password, userKeySalt, userEncryption);
       // prettier-ignore
-      expected = new Uint8Array([42, 218, 213, 39, 73, 91, 72, 79, 67, 38, 248,
-                                 133, 18, 189, 61, 34, 107, 79, 29, 56, 59,
-                                 181, 213, 118, 113, 34, 65, 210, 87, 174, 22,
-                                 239]);
+      const expected = new Uint8Array([
+        42, 218, 213, 39, 73, 91, 72, 79, 67, 38, 248,
+        133, 18, 189, 61, 34, 107, 79, 29, 56, 59,
+        181, 213, 118, 113, 34, 65, 210, 87, 174, 22,
+        239
+      ]);
       expect(result).toEqual(expected);
     });
 
     it("should generate a file encryption key from the owner key", function () {
-      let password, ownerKeySalt, expected, alg, result, ownerEncryption;
-      let uBytes;
-      alg = new PDF20();
-      password = new Uint8Array([111, 119, 110, 101, 114]);
-      ownerKeySalt = new Uint8Array([29, 208, 185, 46, 11, 76, 135, 149]);
+      const alg = new PDF20();
+      const password = new Uint8Array([111, 119, 110, 101, 114]);
+      const ownerKeySalt = new Uint8Array([29, 208, 185, 46, 11, 76, 135, 149]);
       // prettier-ignore
-      ownerEncryption = new Uint8Array([209, 73, 224, 77, 103, 155, 201, 181,
-                                        190, 68, 223, 20, 62, 90, 56, 210, 5,
-                                        240, 178, 128, 238, 124, 68, 254, 253,
-                                        244, 62, 108, 208, 135, 10, 251]);
+      const ownerEncryption = new Uint8Array([
+        209, 73, 224, 77, 103, 155, 201, 181,
+        190, 68, 223, 20, 62, 90, 56, 210, 5,
+        240, 178, 128, 238, 124, 68, 254, 253,
+        244, 62, 108, 208, 135, 10, 251
+      ]);
       // prettier-ignore
-      uBytes = new Uint8Array([94, 230, 205, 75, 166, 99, 250, 76, 219, 128,
-                               17, 85, 57, 17, 33, 164, 150, 46, 103, 176, 160,
-                               156, 187, 233, 166, 223, 163, 253, 147, 235, 95,
-                               184, 83, 245, 146, 101, 198, 247, 34, 198, 191,
-                               11, 16, 94, 237, 216, 20, 175]);
-      result = alg.getOwnerKey(password, ownerKeySalt, uBytes, ownerEncryption);
+      const uBytes = new Uint8Array([
+        94, 230, 205, 75, 166, 99, 250, 76, 219, 128,
+        17, 85, 57, 17, 33, 164, 150, 46, 103, 176, 160,
+        156, 187, 233, 166, 223, 163, 253, 147, 235, 95,
+        184, 83, 245, 146, 101, 198, 247, 34, 198, 191,
+        11, 16, 94, 237, 216, 20, 175
+      ]);
+      const result = alg.getOwnerKey(
+        password,
+        ownerKeySalt,
+        uBytes,
+        ownerEncryption
+      );
       // prettier-ignore
-      expected = new Uint8Array([42, 218, 213, 39, 73, 91, 72, 79, 67, 38, 248,
-                                 133, 18, 189, 61, 34, 107, 79, 29, 56, 59,
-                                 181, 213, 118, 113, 34, 65, 210, 87, 174, 22,
-                                 239]);
+      const expected = new Uint8Array([
+        42, 218, 213, 39, 73, 91, 72, 79, 67, 38, 248,
+        133, 18, 189, 61, 34, 107, 79, 29, 56, 59,
+        181, 213, 118, 113, 34, 65, 210, 87, 174, 22,
+        239
+      ]);
       expect(result).toEqual(expected);
     });
   });

--- a/test/unit/custom_spec.js
+++ b/test/unit/custom_spec.js
@@ -63,8 +63,8 @@ describe("custom canvas rendering", function () {
   });
 
   it("renders to canvas with a default white background", function (done) {
-    var viewport = page.getViewport({ scale: 1 });
-    var canvasAndCtx = CanvasFactory.create(viewport.width, viewport.height);
+    const viewport = page.getViewport({ scale: 1 });
+    const canvasAndCtx = CanvasFactory.create(viewport.width, viewport.height);
 
     const renderTask = page.render({
       canvasContext: canvasAndCtx.context,
@@ -85,8 +85,8 @@ describe("custom canvas rendering", function () {
   });
 
   it("renders to canvas with a custom background", function (done) {
-    var viewport = page.getViewport({ scale: 1 });
-    var canvasAndCtx = CanvasFactory.create(viewport.width, viewport.height);
+    const viewport = page.getViewport({ scale: 1 });
+    const canvasAndCtx = CanvasFactory.create(viewport.width, viewport.height);
 
     const renderTask = page.render({
       canvasContext: canvasAndCtx.context,

--- a/test/unit/display_svg_spec.js
+++ b/test/unit/display_svg_spec.js
@@ -41,8 +41,8 @@ function withZlib(isZlibRequired, callback) {
     return callback();
   }
 
-  var zlib = __non_webpack_require__("zlib");
-  var deflateSync = zlib.deflateSync;
+  const zlib = __non_webpack_require__("zlib");
+  const deflateSync = zlib.deflateSync;
   zlib.deflateSync = disabledDeflateSync;
   function disabledDeflateSync() {
     throw new Error("zlib.deflateSync is explicitly disabled for testing.");
@@ -52,14 +52,14 @@ function withZlib(isZlibRequired, callback) {
       zlib.deflateSync = deflateSync;
     }
   }
-  var promise = callback();
+  const promise = callback();
   promise.then(restoreDeflateSync, restoreDeflateSync);
   return promise;
 }
 
 describe("SVGGraphics", function () {
-  var loadingTask;
-  var page;
+  let loadingTask;
+  let page;
   beforeAll(function (done) {
     loadingTask = getDocument(buildGetDocumentParams("xobject-image.pdf"));
     loadingTask.promise.then(function (doc) {
@@ -75,30 +75,30 @@ describe("SVGGraphics", function () {
 
   describe("paintImageXObject", function () {
     function getSVGImage() {
-      var svgGfx;
+      let svgGfx;
       return page
         .getOperatorList()
         .then(function (opList) {
-          var forceDataSchema = true;
+          const forceDataSchema = true;
           svgGfx = new SVGGraphics(page.commonObjs, page.objs, forceDataSchema);
           return svgGfx.loadDependencies(opList);
         })
         .then(function () {
-          var svgImg;
+          let svgImg;
           // A mock to steal the svg:image element from paintInlineImageXObject.
-          var elementContainer = {
+          const elementContainer = {
             appendChild(element) {
               svgImg = element;
             },
           };
 
           // This points to the XObject image in xobject-image.pdf.
-          var xobjectObjId = "img_p0_1";
+          const xobjectObjId = "img_p0_1";
           if (isNodeJS) {
             setStubs(global);
           }
           try {
-            var imgData = svgGfx.objs.get(xobjectObjId);
+            const imgData = svgGfx.objs.get(xobjectObjId);
             svgGfx.paintInlineImageXObject(imgData, elementContainer);
           } finally {
             if (isNodeJS) {
@@ -133,7 +133,7 @@ describe("SVGGraphics", function () {
           expect(svgImg.nodeName).toBe("svg:image");
           expect(svgImg.getAttributeNS(null, "width")).toBe("200px");
           expect(svgImg.getAttributeNS(null, "height")).toBe("100px");
-          var imgUrl = svgImg.getAttributeNS(XLINK_NS, "href");
+          const imgUrl = svgImg.getAttributeNS(XLINK_NS, "href");
           // forceDataSchema = true, so the generated URL should be a data:-URL.
           expect(imgUrl).toMatch(/^data:image\/png;base64,/);
           // Test whether the generated image has a reasonable file size.
@@ -151,7 +151,7 @@ describe("SVGGraphics", function () {
           expect(svgImg.nodeName).toBe("svg:image");
           expect(svgImg.getAttributeNS(null, "width")).toBe("200px");
           expect(svgImg.getAttributeNS(null, "height")).toBe("100px");
-          var imgUrl = svgImg.getAttributeNS(XLINK_NS, "href");
+          const imgUrl = svgImg.getAttributeNS(XLINK_NS, "href");
           expect(imgUrl).toMatch(/^data:image\/png;base64,/);
           // The size of our naively generated PNG file is excessive :(
           expect(imgUrl.length).toBe(80246);

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -38,8 +38,8 @@ describe("evaluator", function () {
   };
 
   function runOperatorListCheck(evaluator, stream, resources, callback) {
-    var result = new OperatorList();
-    var task = new WorkerTask("OperatorListCheck");
+    const result = new OperatorList();
+    const task = new WorkerTask("OperatorListCheck");
     evaluator
       .getOperatorList({
         stream,
@@ -57,7 +57,7 @@ describe("evaluator", function () {
       );
   }
 
-  var partialEvaluator;
+  let partialEvaluator;
 
   beforeAll(function (done) {
     partialEvaluator = new PartialEvaluator({
@@ -75,7 +75,7 @@ describe("evaluator", function () {
 
   describe("splitCombinedOperations", function () {
     it("should reject unknown operations", function (done) {
-      var stream = new StringStream("fTT");
+      const stream = new StringStream("fTT");
       runOperatorListCheck(
         partialEvaluator,
         stream,
@@ -91,7 +91,7 @@ describe("evaluator", function () {
     });
 
     it("should handle one operation", function (done) {
-      var stream = new StringStream("Q");
+      const stream = new StringStream("Q");
       runOperatorListCheck(
         partialEvaluator,
         stream,
@@ -120,7 +120,7 @@ describe("evaluator", function () {
       const resources = new ResourcesMock();
       resources.XObject = xObject;
 
-      var stream = new StringStream("/Res1 DoQ");
+      const stream = new StringStream("/Res1 DoQ");
       runOperatorListCheck(partialEvaluator, stream, resources, function (
         result
       ) {
@@ -137,7 +137,7 @@ describe("evaluator", function () {
     });
 
     it("should handle three glued operations", function (done) {
-      var stream = new StringStream("fff");
+      const stream = new StringStream("fff");
       runOperatorListCheck(
         partialEvaluator,
         stream,
@@ -154,9 +154,9 @@ describe("evaluator", function () {
     });
 
     it("should handle three glued operations #2", function (done) {
-      var resources = new ResourcesMock();
+      const resources = new ResourcesMock();
       resources.Res1 = {};
-      var stream = new StringStream("B*Bf*");
+      const stream = new StringStream("B*Bf*");
       runOperatorListCheck(partialEvaluator, stream, resources, function (
         result
       ) {
@@ -170,7 +170,7 @@ describe("evaluator", function () {
     });
 
     it("should handle glued operations and operands", function (done) {
-      var stream = new StringStream("f5 Ts");
+      const stream = new StringStream("f5 Ts");
       runOperatorListCheck(
         partialEvaluator,
         stream,
@@ -189,7 +189,7 @@ describe("evaluator", function () {
     });
 
     it("should handle glued operations and literals", function (done) {
-      var stream = new StringStream("trueifalserinulln");
+      const stream = new StringStream("trueifalserinulln");
       runOperatorListCheck(
         partialEvaluator,
         stream,
@@ -214,7 +214,7 @@ describe("evaluator", function () {
 
   describe("validateNumberOfArgs", function () {
     it("should execute if correct number of arguments", function (done) {
-      var stream = new StringStream("5 1 d0");
+      const stream = new StringStream("5 1 d0");
       runOperatorListCheck(
         partialEvaluator,
         stream,
@@ -228,7 +228,7 @@ describe("evaluator", function () {
       );
     });
     it("should execute if too many arguments", function (done) {
-      var stream = new StringStream("5 1 4 d0");
+      const stream = new StringStream("5 1 4 d0");
       runOperatorListCheck(
         partialEvaluator,
         stream,
@@ -252,7 +252,7 @@ describe("evaluator", function () {
       const resources = new ResourcesMock();
       resources.ExtGState = extGState;
 
-      var stream = new StringStream("/F2 /GS2 gs 5.711 Tf");
+      const stream = new StringStream("/F2 /GS2 gs 5.711 Tf");
       runOperatorListCheck(partialEvaluator, stream, resources, function (
         result
       ) {
@@ -273,7 +273,7 @@ describe("evaluator", function () {
       });
     });
     it("should skip if too few arguments", function (done) {
-      var stream = new StringStream("5 d0");
+      const stream = new StringStream("5 d0");
       runOperatorListCheck(
         partialEvaluator,
         stream,
@@ -326,7 +326,7 @@ describe("evaluator", function () {
     );
 
     it("should close opened saves", function (done) {
-      var stream = new StringStream("qq");
+      const stream = new StringStream("qq");
       runOperatorListCheck(
         partialEvaluator,
         stream,
@@ -343,7 +343,7 @@ describe("evaluator", function () {
       );
     });
     it("should error on paintXObject if name is missing", function (done) {
-      var stream = new StringStream("/ Do");
+      const stream = new StringStream("/ Do");
       runOperatorListCheck(
         partialEvaluator,
         stream,
@@ -358,17 +358,17 @@ describe("evaluator", function () {
       );
     });
     it("should skip paintXObject if subtype is PS", function (done) {
-      var xobjStreamDict = new Dict();
+      const xobjStreamDict = new Dict();
       xobjStreamDict.set("Subtype", Name.get("PS"));
-      var xobjStream = new Stream([], 0, 0, xobjStreamDict);
+      const xobjStream = new Stream([], 0, 0, xobjStreamDict);
 
-      var xobjs = new Dict();
+      const xobjs = new Dict();
       xobjs.set("Res1", xobjStream);
 
-      var resources = new Dict();
+      const resources = new Dict();
       resources.set("XObject", xobjs);
 
-      var stream = new StringStream("/Res1 Do");
+      const stream = new StringStream("/Res1 Do");
       runOperatorListCheck(partialEvaluator, stream, resources, function (
         result
       ) {
@@ -381,10 +381,10 @@ describe("evaluator", function () {
 
   describe("thread control", function () {
     it("should abort operator list parsing", function (done) {
-      var stream = new StringStream("qqQQ");
-      var resources = new ResourcesMock();
-      var result = new OperatorList();
-      var task = new WorkerTask("OperatorListAbort");
+      const stream = new StringStream("qqQQ");
+      const resources = new ResourcesMock();
+      const result = new OperatorList();
+      const task = new WorkerTask("OperatorListAbort");
       task.terminate();
       partialEvaluator
         .getOperatorList({
@@ -400,9 +400,9 @@ describe("evaluator", function () {
         });
     });
     it("should abort text parsing parsing", function (done) {
-      var resources = new ResourcesMock();
-      var stream = new StringStream("qqQQ");
-      var task = new WorkerTask("TextContentAbort");
+      const resources = new ResourcesMock();
+      const stream = new StringStream("qqQQ");
+      const task = new WorkerTask("TextContentAbort");
       task.terminate();
       partialEvaluator
         .getTextContent({
@@ -423,7 +423,7 @@ describe("evaluator", function () {
     }
 
     it("should get correct total length after flushing", function () {
-      var operatorList = new OperatorList(null, new StreamSinkMock());
+      const operatorList = new OperatorList(null, new StreamSinkMock());
       operatorList.addOp(OPS.save, null);
       operatorList.addOp(OPS.restore, null);
 

--- a/test/unit/function_spec.js
+++ b/test/unit/function_spec.js
@@ -26,7 +26,7 @@ describe("function", function () {
       toMatchArray(util, customEqualityTesters) {
         return {
           compare(actual, expected) {
-            var result = {};
+            const result = {};
             if (actual.length !== expected.length) {
               result.pass = false;
               result.message =
@@ -37,16 +37,16 @@ describe("function", function () {
               return result;
             }
             result.pass = true;
-            for (var i = 0; i < expected.length; i++) {
-              var a = actual[i],
+            for (let i = 0; i < expected.length; i++) {
+              const a = actual[i],
                 b = expected[i];
               if (Array.isArray(b)) {
                 if (a.length !== b.length) {
                   result.pass = false;
                   break;
                 }
-                for (var j = 0; j < a.length; j++) {
-                  var suba = a[j],
+                for (let j = 0; j < a.length; j++) {
+                  const suba = a[j],
                     subb = b[j];
                   if (suba !== subb) {
                     result.pass = false;
@@ -69,45 +69,45 @@ describe("function", function () {
 
   describe("PostScriptParser", function () {
     function parse(program) {
-      var stream = new StringStream(program);
-      var parser = new PostScriptParser(new PostScriptLexer(stream));
+      const stream = new StringStream(program);
+      const parser = new PostScriptParser(new PostScriptLexer(stream));
       return parser.parse();
     }
     it("parses empty programs", function () {
-      var output = parse("{}");
+      const output = parse("{}");
       expect(output.length).toEqual(0);
     });
     it("parses positive numbers", function () {
-      var number = 999;
-      var program = parse("{ " + number + " }");
-      var expectedProgram = [number];
+      const number = 999;
+      const program = parse("{ " + number + " }");
+      const expectedProgram = [number];
       expect(program).toMatchArray(expectedProgram);
     });
     it("parses negative numbers", function () {
-      var number = -999;
-      var program = parse("{ " + number + " }");
-      var expectedProgram = [number];
+      const number = -999;
+      const program = parse("{ " + number + " }");
+      const expectedProgram = [number];
       expect(program).toMatchArray(expectedProgram);
     });
     it("parses negative floats", function () {
-      var number = 3.3;
-      var program = parse("{ " + number + " }");
-      var expectedProgram = [number];
+      const number = 3.3;
+      const program = parse("{ " + number + " }");
+      const expectedProgram = [number];
       expect(program).toMatchArray(expectedProgram);
     });
     it("parses operators", function () {
-      var program = parse("{ sub }");
-      var expectedProgram = ["sub"];
+      const program = parse("{ sub }");
+      const expectedProgram = ["sub"];
       expect(program).toMatchArray(expectedProgram);
     });
     it("parses if statements", function () {
-      var program = parse("{ { 99 } if }");
-      var expectedProgram = [3, "jz", 99];
+      const program = parse("{ { 99 } if }");
+      const expectedProgram = [3, "jz", 99];
       expect(program).toMatchArray(expectedProgram);
     });
     it("parses ifelse statements", function () {
-      var program = parse("{ { 99 } { 44 } ifelse }");
-      var expectedProgram = [5, "jz", 99, 6, "j", 44];
+      const program = parse("{ { 99 } { 44 } ifelse }");
+      const expectedProgram = [5, "jz", 99, 6, "j", 44];
       expect(program).toMatchArray(expectedProgram);
     });
     it("handles missing brackets", function () {
@@ -116,354 +116,354 @@ describe("function", function () {
       }).toThrow(new Error("Unexpected symbol: found undefined expected 1."));
     });
     it("handles junk after the end", function () {
-      var number = 3.3;
-      var program = parse("{ " + number + " }#");
-      var expectedProgram = [number];
+      const number = 3.3;
+      const program = parse("{ " + number + " }#");
+      const expectedProgram = [number];
       expect(program).toMatchArray(expectedProgram);
     });
   });
 
   describe("PostScriptEvaluator", function () {
     function evaluate(program) {
-      var stream = new StringStream(program);
-      var parser = new PostScriptParser(new PostScriptLexer(stream));
-      var code = parser.parse();
-      var evaluator = new PostScriptEvaluator(code);
-      var output = evaluator.execute();
+      const stream = new StringStream(program);
+      const parser = new PostScriptParser(new PostScriptLexer(stream));
+      const code = parser.parse();
+      const evaluator = new PostScriptEvaluator(code);
+      const output = evaluator.execute();
       return output;
     }
 
     it("pushes stack", function () {
-      var stack = evaluate("{ 99 }");
-      var expectedStack = [99];
+      const stack = evaluate("{ 99 }");
+      const expectedStack = [99];
       expect(stack).toMatchArray(expectedStack);
     });
     it("handles if with true", function () {
-      var stack = evaluate("{ 1 {99} if }");
-      var expectedStack = [99];
+      const stack = evaluate("{ 1 {99} if }");
+      const expectedStack = [99];
       expect(stack).toMatchArray(expectedStack);
     });
     it("handles if with false", function () {
-      var stack = evaluate("{ 0 {99} if }");
-      var expectedStack = [];
+      const stack = evaluate("{ 0 {99} if }");
+      const expectedStack = [];
       expect(stack).toMatchArray(expectedStack);
     });
     it("handles ifelse with true", function () {
-      var stack = evaluate("{ 1 {99} {77} ifelse }");
-      var expectedStack = [99];
+      const stack = evaluate("{ 1 {99} {77} ifelse }");
+      const expectedStack = [99];
       expect(stack).toMatchArray(expectedStack);
     });
     it("handles ifelse with false", function () {
-      var stack = evaluate("{ 0 {99} {77} ifelse }");
-      var expectedStack = [77];
+      const stack = evaluate("{ 0 {99} {77} ifelse }");
+      const expectedStack = [77];
       expect(stack).toMatchArray(expectedStack);
     });
     it("handles nested if", function () {
-      var stack = evaluate("{ 1 {1 {77} if} if }");
-      var expectedStack = [77];
+      const stack = evaluate("{ 1 {1 {77} if} if }");
+      const expectedStack = [77];
       expect(stack).toMatchArray(expectedStack);
     });
 
     it("abs", function () {
-      var stack = evaluate("{ -2 abs }");
-      var expectedStack = [2];
+      const stack = evaluate("{ -2 abs }");
+      const expectedStack = [2];
       expect(stack).toMatchArray(expectedStack);
     });
     it("adds", function () {
-      var stack = evaluate("{ 1 2 add }");
-      var expectedStack = [3];
+      const stack = evaluate("{ 1 2 add }");
+      const expectedStack = [3];
       expect(stack).toMatchArray(expectedStack);
     });
     it("boolean and", function () {
-      var stack = evaluate("{ true false and }");
-      var expectedStack = [false];
+      const stack = evaluate("{ true false and }");
+      const expectedStack = [false];
       expect(stack).toMatchArray(expectedStack);
     });
     it("bitwise and", function () {
-      var stack = evaluate("{ 254 1 and }");
-      var expectedStack = [254 & 1];
+      const stack = evaluate("{ 254 1 and }");
+      const expectedStack = [254 & 1];
       expect(stack).toMatchArray(expectedStack);
     });
     it("calculates the inverse tangent of a number", function () {
-      var stack = evaluate("{ 90 atan }");
-      var expectedStack = [Math.atan(90)];
+      const stack = evaluate("{ 90 atan }");
+      const expectedStack = [Math.atan(90)];
       expect(stack).toMatchArray(expectedStack);
     });
     it("handles bitshifting ", function () {
-      var stack = evaluate("{ 50 2 bitshift }");
-      var expectedStack = [200];
+      const stack = evaluate("{ 50 2 bitshift }");
+      const expectedStack = [200];
       expect(stack).toMatchArray(expectedStack);
     });
     it("calculates the ceiling value", function () {
-      var stack = evaluate("{ 9.9 ceiling }");
-      var expectedStack = [10];
+      const stack = evaluate("{ 9.9 ceiling }");
+      const expectedStack = [10];
       expect(stack).toMatchArray(expectedStack);
     });
     it("copies", function () {
-      var stack = evaluate("{ 99 98 2 copy }");
-      var expectedStack = [99, 98, 99, 98];
+      const stack = evaluate("{ 99 98 2 copy }");
+      const expectedStack = [99, 98, 99, 98];
       expect(stack).toMatchArray(expectedStack);
     });
     it("calculates the cosine of a number", function () {
-      var stack = evaluate("{ 90 cos }");
-      var expectedStack = [Math.cos(90)];
+      const stack = evaluate("{ 90 cos }");
+      const expectedStack = [Math.cos(90)];
       expect(stack).toMatchArray(expectedStack);
     });
     it("converts to int", function () {
-      var stack = evaluate("{ 9.9 cvi }");
-      var expectedStack = [9];
+      const stack = evaluate("{ 9.9 cvi }");
+      const expectedStack = [9];
       expect(stack).toMatchArray(expectedStack);
     });
     it("converts negatives to int", function () {
-      var stack = evaluate("{ -9.9 cvi }");
-      var expectedStack = [-9];
+      const stack = evaluate("{ -9.9 cvi }");
+      const expectedStack = [-9];
       expect(stack).toMatchArray(expectedStack);
     });
     it("converts to real", function () {
-      var stack = evaluate("{ 55.34 cvr }");
-      var expectedStack = [55.34];
+      const stack = evaluate("{ 55.34 cvr }");
+      const expectedStack = [55.34];
       expect(stack).toMatchArray(expectedStack);
     });
     it("divides", function () {
-      var stack = evaluate("{ 6 5 div }");
-      var expectedStack = [1.2];
+      const stack = evaluate("{ 6 5 div }");
+      const expectedStack = [1.2];
       expect(stack).toMatchArray(expectedStack);
     });
     it("maps division by zero to infinity", function () {
-      var stack = evaluate("{ 6 0 div }");
-      var expectedStack = [Infinity];
+      const stack = evaluate("{ 6 0 div }");
+      const expectedStack = [Infinity];
       expect(stack).toMatchArray(expectedStack);
     });
     it("duplicates", function () {
-      var stack = evaluate("{ 99 dup }");
-      var expectedStack = [99, 99];
+      const stack = evaluate("{ 99 dup }");
+      const expectedStack = [99, 99];
       expect(stack).toMatchArray(expectedStack);
     });
     it("accepts an equality", function () {
-      var stack = evaluate("{ 9 9 eq }");
-      var expectedStack = [true];
+      const stack = evaluate("{ 9 9 eq }");
+      const expectedStack = [true];
       expect(stack).toMatchArray(expectedStack);
     });
     it("rejects an inequality", function () {
-      var stack = evaluate("{ 9 8 eq }");
-      var expectedStack = [false];
+      const stack = evaluate("{ 9 8 eq }");
+      const expectedStack = [false];
       expect(stack).toMatchArray(expectedStack);
     });
     it("exchanges", function () {
-      var stack = evaluate("{ 44 99 exch }");
-      var expectedStack = [99, 44];
+      const stack = evaluate("{ 44 99 exch }");
+      const expectedStack = [99, 44];
       expect(stack).toMatchArray(expectedStack);
     });
     it("handles exponentiation", function () {
-      var stack = evaluate("{ 10 2 exp }");
-      var expectedStack = [100];
+      const stack = evaluate("{ 10 2 exp }");
+      const expectedStack = [100];
       expect(stack).toMatchArray(expectedStack);
     });
     it("pushes false onto the stack", function () {
-      var stack = evaluate("{ false }");
-      var expectedStack = [false];
+      const stack = evaluate("{ false }");
+      const expectedStack = [false];
       expect(stack).toMatchArray(expectedStack);
     });
     it("calculates the floor value", function () {
-      var stack = evaluate("{ 9.9 floor }");
-      var expectedStack = [9];
+      const stack = evaluate("{ 9.9 floor }");
+      const expectedStack = [9];
       expect(stack).toMatchArray(expectedStack);
     });
     it("handles greater than or equal to", function () {
-      var stack = evaluate("{ 10 9 ge }");
-      var expectedStack = [true];
+      const stack = evaluate("{ 10 9 ge }");
+      const expectedStack = [true];
       expect(stack).toMatchArray(expectedStack);
     });
     it("rejects less than for greater than or equal to", function () {
-      var stack = evaluate("{ 8 9 ge }");
-      var expectedStack = [false];
+      const stack = evaluate("{ 8 9 ge }");
+      const expectedStack = [false];
       expect(stack).toMatchArray(expectedStack);
     });
     it("handles greater than", function () {
-      var stack = evaluate("{ 10 9 gt }");
-      var expectedStack = [true];
+      const stack = evaluate("{ 10 9 gt }");
+      const expectedStack = [true];
       expect(stack).toMatchArray(expectedStack);
     });
     it("rejects less than or equal for greater than", function () {
-      var stack = evaluate("{ 9 9 gt }");
-      var expectedStack = [false];
+      const stack = evaluate("{ 9 9 gt }");
+      const expectedStack = [false];
       expect(stack).toMatchArray(expectedStack);
     });
     it("divides to integer", function () {
-      var stack = evaluate("{ 2 3 idiv }");
-      var expectedStack = [0];
+      const stack = evaluate("{ 2 3 idiv }");
+      const expectedStack = [0];
       expect(stack).toMatchArray(expectedStack);
     });
     it("divides to negative integer", function () {
-      var stack = evaluate("{ -2 3 idiv }");
-      var expectedStack = [0];
+      const stack = evaluate("{ -2 3 idiv }");
+      const expectedStack = [0];
       expect(stack).toMatchArray(expectedStack);
     });
     it("duplicates index", function () {
-      var stack = evaluate("{ 4 3 2 1 2 index }");
-      var expectedStack = [4, 3, 2, 1, 3];
+      const stack = evaluate("{ 4 3 2 1 2 index }");
+      const expectedStack = [4, 3, 2, 1, 3];
       expect(stack).toMatchArray(expectedStack);
     });
     it("handles less than or equal to", function () {
-      var stack = evaluate("{ 9 10 le }");
-      var expectedStack = [true];
+      const stack = evaluate("{ 9 10 le }");
+      const expectedStack = [true];
       expect(stack).toMatchArray(expectedStack);
     });
     it("rejects greater than for less than or equal to", function () {
-      var stack = evaluate("{ 10 9 le }");
-      var expectedStack = [false];
+      const stack = evaluate("{ 10 9 le }");
+      const expectedStack = [false];
       expect(stack).toMatchArray(expectedStack);
     });
     it("calculates the natural logarithm", function () {
-      var stack = evaluate("{ 10 ln }");
-      var expectedStack = [Math.log(10)];
+      const stack = evaluate("{ 10 ln }");
+      const expectedStack = [Math.log(10)];
       expect(stack).toMatchArray(expectedStack);
     });
     it("calculates the base 10 logarithm", function () {
-      var stack = evaluate("{ 100 log }");
-      var expectedStack = [2];
+      const stack = evaluate("{ 100 log }");
+      const expectedStack = [2];
       expect(stack).toMatchArray(expectedStack);
     });
     it("handles less than", function () {
-      var stack = evaluate("{ 9 10 lt }");
-      var expectedStack = [true];
+      const stack = evaluate("{ 9 10 lt }");
+      const expectedStack = [true];
       expect(stack).toMatchArray(expectedStack);
     });
     it("rejects greater than or equal to for less than", function () {
-      var stack = evaluate("{ 10 9 lt }");
-      var expectedStack = [false];
+      const stack = evaluate("{ 10 9 lt }");
+      const expectedStack = [false];
       expect(stack).toMatchArray(expectedStack);
     });
     it("performs the modulo operation", function () {
-      var stack = evaluate("{ 4 3 mod }");
-      var expectedStack = [1];
+      const stack = evaluate("{ 4 3 mod }");
+      const expectedStack = [1];
       expect(stack).toMatchArray(expectedStack);
     });
     it("multiplies two numbers (positive result)", function () {
-      var stack = evaluate("{ 9 8 mul }");
-      var expectedStack = [72];
+      const stack = evaluate("{ 9 8 mul }");
+      const expectedStack = [72];
       expect(stack).toMatchArray(expectedStack);
     });
     it("multiplies two numbers (negative result)", function () {
-      var stack = evaluate("{ 9 -8 mul }");
-      var expectedStack = [-72];
+      const stack = evaluate("{ 9 -8 mul }");
+      const expectedStack = [-72];
       expect(stack).toMatchArray(expectedStack);
     });
     it("accepts an inequality", function () {
-      var stack = evaluate("{ 9 8 ne }");
-      var expectedStack = [true];
+      const stack = evaluate("{ 9 8 ne }");
+      const expectedStack = [true];
       expect(stack).toMatchArray(expectedStack);
     });
     it("rejects an equality", function () {
-      var stack = evaluate("{ 9 9 ne }");
-      var expectedStack = [false];
+      const stack = evaluate("{ 9 9 ne }");
+      const expectedStack = [false];
       expect(stack).toMatchArray(expectedStack);
     });
     it("negates", function () {
-      var stack = evaluate("{ 4.5 neg }");
-      var expectedStack = [-4.5];
+      const stack = evaluate("{ 4.5 neg }");
+      const expectedStack = [-4.5];
       expect(stack).toMatchArray(expectedStack);
     });
     it("boolean not", function () {
-      var stack = evaluate("{ true not }");
-      var expectedStack = [false];
+      const stack = evaluate("{ true not }");
+      const expectedStack = [false];
       expect(stack).toMatchArray(expectedStack);
     });
     it("bitwise not", function () {
-      var stack = evaluate("{ 12 not }");
-      var expectedStack = [-13];
+      const stack = evaluate("{ 12 not }");
+      const expectedStack = [-13];
       expect(stack).toMatchArray(expectedStack);
     });
     it("boolean or", function () {
-      var stack = evaluate("{ true false or }");
-      var expectedStack = [true];
+      const stack = evaluate("{ true false or }");
+      const expectedStack = [true];
       expect(stack).toMatchArray(expectedStack);
     });
     it("bitwise or", function () {
-      var stack = evaluate("{ 254 1 or }");
-      var expectedStack = [254 | 1];
+      const stack = evaluate("{ 254 1 or }");
+      const expectedStack = [254 | 1];
       expect(stack).toMatchArray(expectedStack);
     });
     it("pops stack", function () {
-      var stack = evaluate("{ 1 2 pop }");
-      var expectedStack = [1];
+      const stack = evaluate("{ 1 2 pop }");
+      const expectedStack = [1];
       expect(stack).toMatchArray(expectedStack);
     });
     it("rolls stack right", function () {
-      var stack = evaluate("{ 1 3 2 2 4 1 roll }");
-      var expectedStack = [2, 1, 3, 2];
+      const stack = evaluate("{ 1 3 2 2 4 1 roll }");
+      const expectedStack = [2, 1, 3, 2];
       expect(stack).toMatchArray(expectedStack);
     });
     it("rolls stack left", function () {
-      var stack = evaluate("{ 1 3 2 2 4 -1 roll }");
-      var expectedStack = [3, 2, 2, 1];
+      const stack = evaluate("{ 1 3 2 2 4 -1 roll }");
+      const expectedStack = [3, 2, 2, 1];
       expect(stack).toMatchArray(expectedStack);
     });
     it("rounds a number", function () {
-      var stack = evaluate("{ 9.52 round }");
-      var expectedStack = [10];
+      const stack = evaluate("{ 9.52 round }");
+      const expectedStack = [10];
       expect(stack).toMatchArray(expectedStack);
     });
     it("calculates the sine of a number", function () {
-      var stack = evaluate("{ 90 sin }");
-      var expectedStack = [Math.sin(90)];
+      const stack = evaluate("{ 90 sin }");
+      const expectedStack = [Math.sin(90)];
       expect(stack).toMatchArray(expectedStack);
     });
     it("calculates a square root (integer)", function () {
-      var stack = evaluate("{ 100 sqrt }");
-      var expectedStack = [10];
+      const stack = evaluate("{ 100 sqrt }");
+      const expectedStack = [10];
       expect(stack).toMatchArray(expectedStack);
     });
     it("calculates a square root (float)", function () {
-      var stack = evaluate("{ 99 sqrt }");
-      var expectedStack = [Math.sqrt(99)];
+      const stack = evaluate("{ 99 sqrt }");
+      const expectedStack = [Math.sqrt(99)];
       expect(stack).toMatchArray(expectedStack);
     });
     it("subtracts (positive result)", function () {
-      var stack = evaluate("{ 6 4 sub }");
-      var expectedStack = [2];
+      const stack = evaluate("{ 6 4 sub }");
+      const expectedStack = [2];
       expect(stack).toMatchArray(expectedStack);
     });
     it("subtracts (negative result)", function () {
-      var stack = evaluate("{ 4 6 sub }");
-      var expectedStack = [-2];
+      const stack = evaluate("{ 4 6 sub }");
+      const expectedStack = [-2];
       expect(stack).toMatchArray(expectedStack);
     });
     it("pushes true onto the stack", function () {
-      var stack = evaluate("{ true }");
-      var expectedStack = [true];
+      const stack = evaluate("{ true }");
+      const expectedStack = [true];
       expect(stack).toMatchArray(expectedStack);
     });
     it("truncates a number", function () {
-      var stack = evaluate("{ 35.004 truncate }");
-      var expectedStack = [35];
+      const stack = evaluate("{ 35.004 truncate }");
+      const expectedStack = [35];
       expect(stack).toMatchArray(expectedStack);
     });
     it("calculates an exclusive or value", function () {
-      var stack = evaluate("{ 3 9 xor }");
-      var expectedStack = [10];
+      const stack = evaluate("{ 3 9 xor }");
+      const expectedStack = [10];
       expect(stack).toMatchArray(expectedStack);
     });
   });
 
   describe("PostScriptCompiler", function () {
     function check(code, domain, range, samples) {
-      var compiler = new PostScriptCompiler();
-      var compiledCode = compiler.compile(code, domain, range);
+      const compiler = new PostScriptCompiler();
+      const compiledCode = compiler.compile(code, domain, range);
       if (samples === null) {
         expect(compiledCode).toBeNull();
       } else {
         expect(compiledCode).not.toBeNull();
         // eslint-disable-next-line no-new-func
-        var fn = new Function(
+        const fn = new Function(
           "src",
           "srcOffset",
           "dest",
           "destOffset",
           compiledCode
         );
-        for (var i = 0; i < samples.length; i++) {
-          var out = new Float32Array(samples[i].output.length);
+        for (let i = 0; i < samples.length; i++) {
+          const out = new Float32Array(samples[i].output.length);
           fn(samples[i].input, 0, out, 0);
           expect(Array.prototype.slice.call(out, 0)).toMatchArray(
             samples[i].output
@@ -620,9 +620,9 @@ describe("function", function () {
       check([], [0, 10000], [100, 1001], [{ input: [1000], output: [1000] }]);
     });
     it("compile optimized", function () {
-      var compiler = new PostScriptCompiler();
-      var code = [0, "add", 1, 1, 3, -1, "roll", "sub", "sub", 1, "mul"];
-      var compiledCode = compiler.compile(code, [0, 1], [0, 1]);
+      const compiler = new PostScriptCompiler();
+      const code = [0, "add", 1, 1, 3, -1, "roll", "sub", "sub", 1, "mul"];
+      const compiledCode = compiler.compile(code, [0, 1], [0, 1]);
       expect(compiledCode).toEqual(
         "dest[destOffset + 0] = Math.max(0, Math.min(1, src[srcOffset + 0]));"
       );

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -124,36 +124,36 @@ function initializePDFJS(callback) {
 
   jasmineRequire.html(jasmine);
 
-  var env = jasmine.getEnv();
+  const env = jasmine.getEnv();
 
-  var jasmineInterface = jasmineRequire.interface(jasmine, env);
+  const jasmineInterface = jasmineRequire.interface(jasmine, env);
   extend(window, jasmineInterface);
 
   // Runner Parameters
-  var queryString = new jasmine.QueryString({
+  const queryString = new jasmine.QueryString({
     getWindowLocation() {
       return window.location;
     },
   });
 
-  var config = {
+  const config = {
     failFast: queryString.getParam("failFast"),
     oneFailurePerSpec: queryString.getParam("oneFailurePerSpec"),
     hideDisabled: queryString.getParam("hideDisabled"),
   };
 
-  var random = queryString.getParam("random");
+  const random = queryString.getParam("random");
   if (random !== undefined && random !== "") {
     config.random = random;
   }
 
-  var seed = queryString.getParam("seed");
+  const seed = queryString.getParam("seed");
   if (seed) {
     config.seed = seed;
   }
 
   // Reporters
-  var htmlReporter = new jasmine.HtmlReporter({
+  const htmlReporter = new jasmine.HtmlReporter({
     env,
     navigateWithNewParam(key, value) {
       return queryString.navigateWithNewParam(key, value);
@@ -176,13 +176,13 @@ function initializePDFJS(callback) {
   env.addReporter(htmlReporter);
 
   if (queryString.getParam("browser")) {
-    var testReporter = new TestReporter(queryString.getParam("browser"));
+    const testReporter = new TestReporter(queryString.getParam("browser"));
     env.addReporter(testReporter);
   }
 
   // Filter which specs will be run by matching the start of the full name
   // against the `spec` query param.
-  var specFilter = new jasmine.HtmlSpecFilter({
+  const specFilter = new jasmine.HtmlSpecFilter({
     filterString() {
       return queryString.getParam("spec");
     },
@@ -200,7 +200,7 @@ function initializePDFJS(callback) {
   // Replace the browser window's `onload`, ensure it's called, and then run
   // all of the loaded specs. This includes initializing the `HtmlReporter`
   // instance and then executing the loaded Jasmine environment.
-  var currentWindowOnload = window.onload;
+  const currentWindowOnload = window.onload;
 
   window.onload = function () {
     if (currentWindowOnload) {
@@ -214,7 +214,7 @@ function initializePDFJS(callback) {
   };
 
   function extend(destination, source) {
-    for (var property in source) {
+    for (const property in source) {
       destination[property] = source[property];
     }
     return destination;

--- a/test/unit/murmurhash3_spec.js
+++ b/test/unit/murmurhash3_spec.js
@@ -17,36 +17,36 @@ import { MurmurHash3_64 } from "../../src/core/murmurhash3.js";
 
 describe("MurmurHash3_64", function () {
   it("instantiates without seed", function () {
-    var hash = new MurmurHash3_64();
+    const hash = new MurmurHash3_64();
     expect(hash).toEqual(jasmine.any(MurmurHash3_64));
   });
   it("instantiates with seed", function () {
-    var hash = new MurmurHash3_64(1);
+    const hash = new MurmurHash3_64(1);
     expect(hash).toEqual(jasmine.any(MurmurHash3_64));
   });
 
-  var hexDigestExpected = "f61cfdbfdae0f65e";
-  var sourceText = "test";
-  var sourceCharCodes = [116, 101, 115, 116]; // 't','e','s','t'
+  const hexDigestExpected = "f61cfdbfdae0f65e";
+  const sourceText = "test";
+  const sourceCharCodes = [116, 101, 115, 116]; // 't','e','s','t'
   it("correctly generates a hash from a string", function () {
-    var hash = new MurmurHash3_64();
+    const hash = new MurmurHash3_64();
     hash.update(sourceText);
     expect(hash.hexdigest()).toEqual(hexDigestExpected);
   });
   it("correctly generates a hash from a Uint8Array", function () {
-    var hash = new MurmurHash3_64();
+    const hash = new MurmurHash3_64();
     hash.update(new Uint8Array(sourceCharCodes));
     expect(hash.hexdigest()).toEqual(hexDigestExpected);
   });
   it("correctly generates a hash from a Uint32Array", function () {
-    var hash = new MurmurHash3_64();
+    const hash = new MurmurHash3_64();
     hash.update(new Uint32Array(new Uint8Array(sourceCharCodes).buffer));
     expect(hash.hexdigest()).toEqual(hexDigestExpected);
   });
 
   it("changes the hash after update without seed", function () {
-    var hash = new MurmurHash3_64();
-    var hexdigest1, hexdigest2;
+    const hash = new MurmurHash3_64();
+    let hexdigest1, hexdigest2;
     hash.update(sourceText);
     hexdigest1 = hash.hexdigest();
     hash.update(sourceText);
@@ -54,8 +54,8 @@ describe("MurmurHash3_64", function () {
     expect(hexdigest1).not.toEqual(hexdigest2);
   });
   it("changes the hash after update with seed", function () {
-    var hash = new MurmurHash3_64(1);
-    var hexdigest1, hexdigest2;
+    const hash = new MurmurHash3_64(1);
+    let hexdigest1, hexdigest2;
     hash.update(sourceText);
     hexdigest1 = hash.hexdigest();
     hash.update(sourceText);

--- a/test/unit/murmurhash3_spec.js
+++ b/test/unit/murmurhash3_spec.js
@@ -46,20 +46,18 @@ describe("MurmurHash3_64", function () {
 
   it("changes the hash after update without seed", function () {
     const hash = new MurmurHash3_64();
-    let hexdigest1, hexdigest2;
     hash.update(sourceText);
-    hexdigest1 = hash.hexdigest();
+    const hexdigest1 = hash.hexdigest();
     hash.update(sourceText);
-    hexdigest2 = hash.hexdigest();
+    const hexdigest2 = hash.hexdigest();
     expect(hexdigest1).not.toEqual(hexdigest2);
   });
   it("changes the hash after update with seed", function () {
     const hash = new MurmurHash3_64(1);
-    let hexdigest1, hexdigest2;
     hash.update(sourceText);
-    hexdigest1 = hash.hexdigest();
+    const hexdigest1 = hash.hexdigest();
     hash.update(sourceText);
-    hexdigest2 = hash.hexdigest();
+    const hexdigest2 = hash.hexdigest();
     expect(hexdigest1).not.toEqual(hexdigest2);
   });
 });

--- a/test/unit/network_spec.js
+++ b/test/unit/network_spec.js
@@ -17,26 +17,26 @@ import { AbortException } from "../../src/shared/util.js";
 import { PDFNetworkStream } from "../../src/display/network.js";
 
 describe("network", function () {
-  var pdf1 = new URL("../pdfs/tracemonkey.pdf", window.location).href;
-  var pdf1Length = 1016315;
+  const pdf1 = new URL("../pdfs/tracemonkey.pdf", window.location).href;
+  const pdf1Length = 1016315;
 
   it("read without stream and range", function (done) {
-    var stream = new PDFNetworkStream({
+    const stream = new PDFNetworkStream({
       url: pdf1,
       rangeChunkSize: 65536,
       disableStream: true,
       disableRange: true,
     });
 
-    var fullReader = stream.getFullReader();
+    const fullReader = stream.getFullReader();
 
-    var isStreamingSupported, isRangeSupported;
-    var promise = fullReader.headersReady.then(function () {
+    let isStreamingSupported, isRangeSupported;
+    const promise = fullReader.headersReady.then(function () {
       isStreamingSupported = fullReader.isStreamingSupported;
       isRangeSupported = fullReader.isRangeSupported;
     });
 
-    var len = 0,
+    let len = 0,
       count = 0;
     var read = function () {
       return fullReader.read().then(function (result) {
@@ -49,7 +49,7 @@ describe("network", function () {
       });
     };
 
-    var readPromise = Promise.all([read(), promise]);
+    const readPromise = Promise.all([read(), promise]);
 
     readPromise
       .then(function (page) {
@@ -67,8 +67,8 @@ describe("network", function () {
   it("read custom ranges", function (done) {
     // We don't test on browsers that don't support range request, so
     // requiring this test to pass.
-    var rangeSize = 32768;
-    var stream = new PDFNetworkStream({
+    const rangeSize = 32768;
+    const stream = new PDFNetworkStream({
       url: pdf1,
       length: pdf1Length,
       rangeChunkSize: rangeSize,
@@ -76,10 +76,10 @@ describe("network", function () {
       disableRange: false,
     });
 
-    var fullReader = stream.getFullReader();
+    const fullReader = stream.getFullReader();
 
-    var isStreamingSupported, isRangeSupported, fullReaderCancelled;
-    var promise = fullReader.headersReady.then(function () {
+    let isStreamingSupported, isRangeSupported, fullReaderCancelled;
+    const promise = fullReader.headersReady.then(function () {
       isStreamingSupported = fullReader.isStreamingSupported;
       isRangeSupported = fullReader.isRangeSupported;
       // we shall be able to close the full reader without issues
@@ -88,15 +88,18 @@ describe("network", function () {
     });
 
     // Skipping fullReader results, requesting something from the PDF end.
-    var tailSize = pdf1Length % rangeSize || rangeSize;
+    const tailSize = pdf1Length % rangeSize || rangeSize;
 
-    var range1Reader = stream.getRangeReader(
+    const range1Reader = stream.getRangeReader(
       pdf1Length - tailSize - rangeSize,
       pdf1Length - tailSize
     );
-    var range2Reader = stream.getRangeReader(pdf1Length - tailSize, pdf1Length);
+    const range2Reader = stream.getRangeReader(
+      pdf1Length - tailSize,
+      pdf1Length
+    );
 
-    var result1 = { value: 0 },
+    const result1 = { value: 0 },
       result2 = { value: 0 };
     var read = function (reader, lenResult) {
       return reader.read().then(function (result) {
@@ -108,7 +111,7 @@ describe("network", function () {
       });
     };
 
-    var readPromises = Promise.all([
+    const readPromises = Promise.all([
       read(range1Reader, result1),
       read(range2Reader, result2),
       promise,

--- a/test/unit/network_spec.js
+++ b/test/unit/network_spec.js
@@ -38,7 +38,7 @@ describe("network", function () {
 
     let len = 0,
       count = 0;
-    var read = function () {
+    const read = function () {
       return fullReader.read().then(function (result) {
         if (result.done) {
           return undefined;
@@ -101,7 +101,7 @@ describe("network", function () {
 
     const result1 = { value: 0 },
       result2 = { value: 0 };
-    var read = function (reader, lenResult) {
+    const read = function (reader, lenResult) {
       return reader.read().then(function (result) {
         if (result.done) {
           return undefined;

--- a/test/unit/stream_spec.js
+++ b/test/unit/stream_spec.js
@@ -22,7 +22,7 @@ describe("stream", function () {
       toMatchTypedArray(util, customEqualityTesters) {
         return {
           compare(actual, expected) {
-            var result = {};
+            const result = {};
             if (actual.length !== expected.length) {
               result.pass = false;
               result.message =
@@ -33,8 +33,8 @@ describe("stream", function () {
               return result;
             }
             result.pass = true;
-            for (var i = 0, ii = expected.length; i < ii; i++) {
-              var a = actual[i],
+            for (let i = 0, ii = expected.length; i < ii; i++) {
+              const a = actual[i],
                 b = expected[i];
               if (a !== b) {
                 result.pass = false;
@@ -49,20 +49,20 @@ describe("stream", function () {
   });
   describe("PredictorStream", function () {
     it("should decode simple predictor data", function () {
-      var dict = new Dict();
+      const dict = new Dict();
       dict.set("Predictor", 12);
       dict.set("Colors", 1);
       dict.set("BitsPerComponent", 8);
       dict.set("Columns", 2);
 
-      var input = new Stream(
+      const input = new Stream(
         new Uint8Array([2, 100, 3, 2, 1, 255, 2, 1, 255]),
         0,
         9,
         dict
       );
-      var predictor = new PredictorStream(input, /* length = */ 9, dict);
-      var result = predictor.getBytes(6);
+      const predictor = new PredictorStream(input, /* length = */ 9, dict);
+      const result = predictor.getBytes(6);
 
       expect(result).toMatchTypedArray(
         new Uint8Array([100, 3, 101, 2, 102, 1])

--- a/test/unit/testreporter.js
+++ b/test/unit/testreporter.js
@@ -1,9 +1,9 @@
 "use strict";
 
 // eslint-disable-next-line no-unused-vars
-var TestReporter = function (browser) {
+const TestReporter = function (browser) {
   function send(action, json, cb) {
-    var r = new XMLHttpRequest();
+    const r = new XMLHttpRequest();
     // (The POST URI is ignored atm.)
     r.open("POST", action, true);
     r.setRequestHeader("Content-Type", "application/json");
@@ -28,7 +28,7 @@ var TestReporter = function (browser) {
   }
 
   function sendResult(status, description, error) {
-    var message = {
+    const message = {
       status,
       description,
     };

--- a/test/unit/type1_parser_spec.js
+++ b/test/unit/type1_parser_spec.js
@@ -19,8 +19,8 @@ import { Type1Parser } from "../../src/core/type1_parser.js";
 
 describe("Type1Parser", function () {
   it("splits tokens", function () {
-    var stream = new StringStream("/BlueValues[-17 0]noaccess def");
-    var parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
+    const stream = new StringStream("/BlueValues[-17 0]noaccess def");
+    const parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
     expect(parser.getToken()).toEqual("/");
     expect(parser.getToken()).toEqual("BlueValues");
     expect(parser.getToken()).toEqual("[");
@@ -33,36 +33,36 @@ describe("Type1Parser", function () {
   });
 
   it("handles glued tokens", function () {
-    var stream = new StringStream("dup/CharStrings");
-    var parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
+    const stream = new StringStream("dup/CharStrings");
+    const parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
     expect(parser.getToken()).toEqual("dup");
     expect(parser.getToken()).toEqual("/");
     expect(parser.getToken()).toEqual("CharStrings");
   });
 
   it("ignores whitespace", function () {
-    var stream = new StringStream("\nab   c\t");
-    var parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
+    const stream = new StringStream("\nab   c\t");
+    const parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
     expect(parser.getToken()).toEqual("ab");
     expect(parser.getToken()).toEqual("c");
   });
 
   it("parses numbers", function () {
-    var stream = new StringStream("123");
-    var parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
+    const stream = new StringStream("123");
+    const parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
     expect(parser.readNumber()).toEqual(123);
   });
 
   it("parses booleans", function () {
-    var stream = new StringStream("true false");
-    var parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
+    const stream = new StringStream("true false");
+    const parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
     expect(parser.readBoolean()).toEqual(1);
     expect(parser.readBoolean()).toEqual(0);
   });
 
   it("parses number arrays", function () {
-    var stream = new StringStream("[1 2]");
-    var parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
+    let stream = new StringStream("[1 2]");
+    let parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
     expect(parser.readNumberArray()).toEqual([1, 2]);
     // Variation on spacing.
     stream = new StringStream("[ 1 2 ]");
@@ -71,18 +71,18 @@ describe("Type1Parser", function () {
   });
 
   it("skips comments", function () {
-    var stream = new StringStream(
+    const stream = new StringStream(
       "%!PS-AdobeFont-1.0: CMSY10 003.002\n" +
         "%%Title: CMSY10\n" +
         "%Version: 003.002\n" +
         "FontDirectory"
     );
-    var parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
+    const parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
     expect(parser.getToken()).toEqual("FontDirectory");
   });
 
   it("parses font program", function () {
-    var stream = new StringStream(
+    const stream = new StringStream(
       "/ExpansionFactor  99\n" +
         "/Subrs 1 array\n" +
         "dup 0 1 RD x noaccess put\n" +
@@ -91,31 +91,31 @@ describe("Type1Parser", function () {
         "/.notdef 1 RD x ND\n" +
         "end"
     );
-    var parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
-    var program = parser.extractFontProgram({});
+    const parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
+    const program = parser.extractFontProgram({});
     expect(program.charstrings.length).toEqual(1);
     expect(program.properties.privateData.ExpansionFactor).toEqual(99);
   });
 
   it("parses font header font matrix", function () {
-    var stream = new StringStream(
+    const stream = new StringStream(
       "/FontMatrix [0.001 0 0 0.001 0 0 ]readonly def\n"
     );
-    var parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
-    var props = {};
+    const parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
+    const props = {};
     parser.extractFontHeader(props);
     expect(props.fontMatrix).toEqual([0.001, 0, 0, 0.001, 0, 0]);
   });
 
   it("parses font header encoding", function () {
-    var stream = new StringStream(
+    const stream = new StringStream(
       "/Encoding 256 array\n" +
         "0 1 255 {1 index exch /.notdef put} for\n" +
         "dup 33 /arrowright put\n" +
         "readonly def\n"
     );
-    var parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
-    var props = { overridableEncoding: true };
+    const parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
+    const props = { overridableEncoding: true };
     parser.extractFontHeader(props);
     expect(props.builtInEncoding[33]).toEqual("arrowright");
   });

--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -301,7 +301,7 @@ describe("ui_utils", function () {
         eventBus.off("test", listener2);
         count++;
       };
-      var listener2 = function () {
+      const listener2 = function () {
         eventBus.off("test", listener1);
         count++;
       };

--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -145,12 +145,12 @@ describe("ui_utils", function () {
     });
 
     it("gets PDF filename from URI-encoded data", function () {
-      var encodedUrl = encodeURIComponent(
+      const encodedUrl = encodeURIComponent(
         "http://www.example.com/pdfs/file1.pdf"
       );
       expect(getPDFFileNameFromURL(encodedUrl)).toEqual("file1.pdf");
 
-      var encodedUrlWithQuery = encodeURIComponent(
+      const encodedUrlWithQuery = encodeURIComponent(
         "http://www.example.com/pdfs/file.txt?file2.pdf"
       );
       expect(getPDFFileNameFromURL(encodedUrlWithQuery)).toEqual("file2.pdf");
@@ -185,8 +185,8 @@ describe("ui_utils", function () {
       if (isNodeJS) {
         pending("Blob in not supported in Node.js.");
       }
-      var typedArray = new Uint8Array([1, 2, 3, 4, 5]);
-      var blobUrl = createObjectURL(typedArray, "application/pdf");
+      const typedArray = new Uint8Array([1, 2, 3, 4, 5]);
+      const blobUrl = createObjectURL(typedArray, "application/pdf");
       // Sanity check to ensure that a "blob:" URL was returned.
       expect(blobUrl.startsWith("blob:")).toEqual(true);
 
@@ -194,8 +194,8 @@ describe("ui_utils", function () {
     });
 
     it('gets fallback filename from query string appended to "data:" URL', function () {
-      var typedArray = new Uint8Array([1, 2, 3, 4, 5]);
-      var dataUrl = createObjectURL(
+      const typedArray = new Uint8Array([1, 2, 3, 4, 5]);
+      const dataUrl = createObjectURL(
         typedArray,
         "application/pdf",
         /* forceDataSchema = */ true
@@ -216,8 +216,8 @@ describe("ui_utils", function () {
 
   describe("EventBus", function () {
     it("dispatch event", function () {
-      var eventBus = new EventBus();
-      var count = 0;
+      const eventBus = new EventBus();
+      let count = 0;
       eventBus.on("test", function (evt) {
         expect(evt).toEqual(undefined);
         count++;
@@ -238,8 +238,8 @@ describe("ui_utils", function () {
       expect(count).toEqual(1);
     });
     it("dispatch different event", function () {
-      var eventBus = new EventBus();
-      var count = 0;
+      const eventBus = new EventBus();
+      let count = 0;
       eventBus.on("test", function () {
         count++;
       });
@@ -247,8 +247,8 @@ describe("ui_utils", function () {
       expect(count).toEqual(0);
     });
     it("dispatch event multiple times", function () {
-      var eventBus = new EventBus();
-      var count = 0;
+      const eventBus = new EventBus();
+      let count = 0;
       eventBus.dispatch("test");
       eventBus.on("test", function () {
         count++;
@@ -258,8 +258,8 @@ describe("ui_utils", function () {
       expect(count).toEqual(2);
     });
     it("dispatch event to multiple handlers", function () {
-      var eventBus = new EventBus();
-      var count = 0;
+      const eventBus = new EventBus();
+      let count = 0;
       eventBus.on("test", function () {
         count++;
       });
@@ -270,9 +270,9 @@ describe("ui_utils", function () {
       expect(count).toEqual(2);
     });
     it("dispatch to detached", function () {
-      var eventBus = new EventBus();
-      var count = 0;
-      var listener = function () {
+      const eventBus = new EventBus();
+      let count = 0;
+      const listener = function () {
         count++;
       };
       eventBus.on("test", listener);
@@ -282,8 +282,8 @@ describe("ui_utils", function () {
       expect(count).toEqual(1);
     });
     it("dispatch to wrong detached", function () {
-      var eventBus = new EventBus();
-      var count = 0;
+      const eventBus = new EventBus();
+      let count = 0;
       eventBus.on("test", function () {
         count++;
       });
@@ -295,9 +295,9 @@ describe("ui_utils", function () {
       expect(count).toEqual(2);
     });
     it("dispatch to detached during handling", function () {
-      var eventBus = new EventBus();
-      var count = 0;
-      var listener1 = function () {
+      const eventBus = new EventBus();
+      let count = 0;
+      const listener1 = function () {
         eventBus.off("test", listener2);
         count++;
       };

--- a/test/unit/unicode_spec.js
+++ b/test/unit/unicode_spec.js
@@ -43,7 +43,7 @@ describe("unicode", function () {
   });
 
   describe("getUnicodeForGlyph", function () {
-    var standardMap, dingbatsMap;
+    let standardMap, dingbatsMap;
 
     beforeAll(function (done) {
       standardMap = getGlyphsUnicode();
@@ -88,7 +88,7 @@ describe("unicode", function () {
   });
 
   describe("getNormalizedUnicodes", function () {
-    var NormalizedUnicodes;
+    let NormalizedUnicodes;
 
     beforeAll(function (done) {
       NormalizedUnicodes = getNormalizedUnicodes();
@@ -112,7 +112,7 @@ describe("unicode", function () {
   });
 
   describe("reverseIfRtl", function () {
-    var NormalizedUnicodes;
+    let NormalizedUnicodes;
 
     function getGlyphUnicode(char) {
       if (NormalizedUnicodes[char] !== undefined) {
@@ -131,19 +131,19 @@ describe("unicode", function () {
     });
 
     it("should not reverse LTR characters", function () {
-      var A = getGlyphUnicode("A");
+      const A = getGlyphUnicode("A");
       expect(reverseIfRtl(A)).toEqual("A");
 
-      var fi = getGlyphUnicode("\uFB01");
+      const fi = getGlyphUnicode("\uFB01");
       expect(reverseIfRtl(fi)).toEqual("fi");
     });
 
     it("should reverse RTL characters", function () {
       // Hebrew (no-op, since it's not a combined character)
-      var heAlef = getGlyphUnicode("\u05D0");
+      const heAlef = getGlyphUnicode("\u05D0");
       expect(reverseIfRtl(heAlef)).toEqual("\u05D0");
       // Arabic
-      var arAlef = getGlyphUnicode("\u0675");
+      const arAlef = getGlyphUnicode("\u0675");
       expect(reverseIfRtl(arAlef)).toEqual("\u0674\u0627");
     });
   });


### PR DESCRIPTION
The commit messages contain more information about the individual commits.

The `test/unit` folder counts for about 50% of the `var` usage in the entire `test` folder and used a mix of `var` and `const`/`let`. This commit series makes the entire `test/unit` folder use `const`/`let` consistently and allows us to enforce that unit tests are written with modern syntax, bringing us one step closer to enabling the ESLint `no-var` rule globally.