### PR TITLE
Tweak the `pdf.scripting.js` bundling, to improve overall consistency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -317,20 +317,20 @@ function createMainBundle(defines) {
 }
 
 function createScriptingBundle(defines) {
-  var mainAMDName = "pdfjs-dist/build/pdf.scripting";
-  var mainOutputName = "pdf.scripting.js";
+  var scriptingAMDName = "pdfjs-dist/build/pdf.scripting";
+  var scriptingOutputName = "pdf.scripting.js";
 
-  var mainFileConfig = createWebpackConfig(defines, {
-    filename: mainOutputName,
-    library: mainAMDName,
+  var scriptingFileConfig = createWebpackConfig(defines, {
+    filename: scriptingOutputName,
+    library: scriptingAMDName,
     libraryTarget: "umd",
     umdNamedDefine: true,
   });
   return gulp
-    .src("./src/scripting_api/initialization.js")
-    .pipe(webpack2Stream(mainFileConfig))
+    .src("./src/pdf.scripting.js")
+    .pipe(webpack2Stream(scriptingFileConfig))
     .pipe(replaceWebpackRequire())
-    .pipe(replaceJSRootName(mainAMDName, "pdfjsScripting"));
+    .pipe(replaceJSRootName(scriptingAMDName, "pdfjsScripting"));
 }
 
 function createWorkerBundle(defines) {

--- a/src/pdf.scripting.js
+++ b/src/pdf.scripting.js
@@ -1,0 +1,25 @@
+/* Copyright 2020 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { initSandbox } from "./scripting_api/initialization.js";
+
+/* eslint-disable-next-line no-unused-vars */
+const pdfjsVersion =
+  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_VERSION") : void 0;
+/* eslint-disable-next-line no-unused-vars */
+const pdfjsBuild =
+  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_BUILD") : void 0;
+
+export { initSandbox };


### PR DESCRIPTION
This brings the new `pdf.scripting.js` bundling more in-line with the pre-existing handling for the  `pdf.js`/`pdf.worker.js` files:
 - Add a new `src/pdf.scripting.js` file as the entry-point for the build scripts.

 - Add the version/build numbers at the top of the *built* `pdf.scripting.js` files, since all other built files include that information given that it's often helpful to be able to easily determine the *exact* version.

 - Tweak the `createScriptingBundle` in the gulp-file, since it looks like a little bit too much copy-and-paste in the variable names.