### PR TITLE
Add a `MurmurHash3_64.update` unit-test for TypedArrays which share the same underlying ArrayBuffer (PR 12534 follow-up)

### DIFF
--- a/test/unit/murmurhash3_spec.js
+++ b/test/unit/murmurhash3_spec.js
@@ -60,4 +60,34 @@ describe("MurmurHash3_64", function () {
     const hexdigest2 = hash.hexdigest();
     expect(hexdigest1).not.toEqual(hexdigest2);
   });
+
+  it(
+    "generates correct hashes for TypedArrays which share the same " +
+      "underlying ArrayBuffer (issue 12533)",
+    function () {
+      // prettier-ignore
+      const typedArray = new Uint8Array([
+        0, 0, 0, 0, 0, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+      ]);
+      const startArray = new Uint8Array(typedArray.buffer, 0, 10);
+      const endArray = new Uint8Array(typedArray.buffer, 10, 10);
+
+      expect(startArray).not.toEqual(endArray);
+
+      const startHash = new MurmurHash3_64();
+      startHash.update(startArray);
+      const startHexdigest = startHash.hexdigest();
+
+      const endHash = new MurmurHash3_64();
+      endHash.update(endArray);
+      const endHexdigest = endHash.hexdigest();
+
+      // The two hashes *must* be different.
+      expect(startHexdigest).not.toEqual(endHexdigest);
+
+      expect(startHexdigest).toEqual("a49de339cc5b0819");
+      expect(endHexdigest).toEqual("f81a92d9e214ab35");
+    }
+  );
 });


### PR DESCRIPTION
This probably ought to have been included in PR #12534, but better late than never I suppose, since it helps to more clearly demonstrate the bug in a way that a reference-test alone just cannot do.

When writing this unit-test I also noticed that it required a certain amount of "luck" to actually trigger the bug, prior to the patch, since it seems that the bug only reproduced for certain *unfortunate* sequences of TypedArray data. (The added unit-test contains one such, purposely simple, example.)