### PR TITLE
Fix *some* errors reported by the ESLint `no-useless-escape` rule

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -1333,7 +1333,7 @@ class WidgetAnnotation extends Annotation {
       // 1.5 * capHeight * fontSize seems to be a good value for lineHeight
       fontSize = Math.max(1, Math.floor(height / (1.5 * capHeight)));
 
-      let fontRegex = new RegExp(`/${fontName}\\s+[0-9\.]+\\s+Tf`);
+      let fontRegex = new RegExp(`/${fontName}\\s+[0-9.]+\\s+Tf`);
       if (this.data.defaultAppearance.search(fontRegex) === -1) {
         // The font size is missing
         fontRegex = new RegExp(`/${fontName}\\s+Tf`);

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -3415,8 +3415,8 @@ class PartialEvaluator {
       var baseFontStr = baseFont && baseFont.name;
       if (fontNameStr !== baseFontStr) {
         info(
-          `The FontDescriptor\'s FontName is "${fontNameStr}" but ` +
-            `should be the same as the Font\'s BaseFont "${baseFontStr}".`
+          `The FontDescriptor's FontName is "${fontNameStr}" but ` +
+            `should be the same as the Font's BaseFont "${baseFontStr}".`
         );
         // Workaround for cases where e.g. fontNameStr = 'Arial' and
         // baseFontStr = 'Arial,Bold' (needed when no font file is embedded).

--- a/src/scripting_api/field.js
+++ b/src/scripting_api/field.js
@@ -110,8 +110,8 @@ class Field extends PDFObject {
     } catch (error) {
       event.rc = false;
       const value =
-        `\"${error.toString()}\" for event ` +
-        `\"${eventName}\" in object ${this._id}.` +
+        `"${error.toString()}" for event ` +
+        `"${eventName}" in object ${this._id}.` +
         `\n${error.stack}`;
       this._send({ command: "error", value });
     }

--- a/src/shared/xml_parser.js
+++ b/src/shared/xml_parser.js
@@ -408,7 +408,7 @@ class SimpleDOMNode {
     if (this.attributes) {
       for (const attribute of this.attributes) {
         buffer.push(
-          ` ${attribute.name}=\"${encodeToXmlString(attribute.value)}\"`
+          ` ${attribute.name}="${encodeToXmlString(attribute.value)}"`
         );
       }
     }


### PR DESCRIPTION
This patch removes unnecessary escape-sequence in (mostly) strings, as a first step, since the ones in regular expressions probably requires more careful testing (just in case).
The only exception is a regular expression in `src/core/annotation.js`, since we should have both unit- and reference-tests for this code *and* given [this information on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes#Types):
 > Inside a character set, the dot loses its special meaning and matches a literal dot.

Please find additional details about the ESLint rule at https://eslint.org/docs/rules/no-useless-escape