### PR TITLE
Fix some static analyzer warnings (issue 11965)

### DIFF
--- a/src/shared/fonts_utils.js
+++ b/src/shared/fonts_utils.js
@@ -120,7 +120,7 @@ function readFontDictData(aString, aMap) {
   var fontDictDataTokens = [];
 
   var count = aString.length;
-  for (var i = 0; i < count; i) {
+  for (var i = 0; i < count; ) {
     var value = aString[i++] | 0;
     var token = null;
 

--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -418,7 +418,7 @@ class ChromeExternalServices extends DefaultExternalServices {
   }
 
   static createDownloadManager(options) {
-    return new DownloadManager(options);
+    return new DownloadManager();
   }
 
   static createPreferences() {

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -381,7 +381,6 @@ var Stepper = (function StepperClosure() {
         line.appendChild(c("td", JSON.stringify(simplifyArgs(decArgs))));
       }
       if (operatorsToDisplay < operatorList.fnArray.length) {
-        line = c("tr");
         var lastCell = c("td", "...");
         lastCell.colspan = 4;
         chunk.appendChild(lastCell);

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -347,7 +347,7 @@ class FirefoxExternalServices extends DefaultExternalServices {
   }
 
   static createDownloadManager(options) {
-    return new DownloadManager(options);
+    return new DownloadManager();
   }
 
   static createPreferences() {

--- a/web/genericcom.js
+++ b/web/genericcom.js
@@ -39,7 +39,7 @@ class GenericPreferences extends BasePreferences {
 
 class GenericExternalServices extends DefaultExternalServices {
   static createDownloadManager(options) {
-    return new DownloadManager(options);
+    return new DownloadManager();
   }
 
   static createPreferences() {


### PR DESCRIPTION
This fixes only those warnings, as reported by https://lgtm.com/projects/g/mozilla/pdf.js?mode=list, that make sense (as far as I'm concerned).

Hence this patch leaves the following things unaddressed:
 - The "recommendation"-category, since it only complains about unused variables. However, note that all of those cases are purposely included and that there's thus ESLint-disable comments added to explictly allow them.
 - The "warning"-category, which still contains two complaints. However, as far as I can tell, they are both false positives.

Given first of all the false positives of the LGTM static analyzer, and secondly that we'd need to add (essentially duplicated) disable-comments for the unused variable cases, it's not entirely clear to me if we actually want to work towards including LGTM in the PDF.js project (e.g. running alongside Travis) or if we should just close issue #11965.