### PR TITLE
Try adding a very basic `lgtm.yml` file, to prevent LGTM complaining about unused variables (issue 11965)

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,3 @@
+queries:
+  # Already handled by the "no-unused-vars" ESLint rule.
+  - exclude: js/unused-local-variable


### PR DESCRIPTION
*Please note:* I cannot be sure if this actually helps, since we've not enabled LGTM for the PDF.js repository[1], however I hope that it should stop LGTM reporting things that we're already using ESLint to enforce.

(Even though we're currently not intending to integrate LGTM here, since #11965 was closed, this patch shouldn't hurt.)

---
[1] In case the patch does nothing, we can simply revert it and move on :-)