### PR TITLE
Fix intermittent reference failures.

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -673,9 +673,10 @@ var Driver = (function DriverClosure() {
     },
 
     _clearCanvas: function Driver_clearCanvas() {
-      var ctx = this.canvas.getContext("2d", { alpha: false });
-      ctx.beginPath();
-      ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+      // Ideally we would just clear the canvas and beginPath, but this doesn't
+      // seem to totally reset the canvas state and causes intermittent
+      // failures.
+      this.canvas = document.createElement("canvas");
     },
 
     _snapshot: function Driver_snapshot(task, failure) {

--- a/test/test.js
+++ b/test/test.js
@@ -467,25 +467,6 @@ function checkFBF(task, results, browser, masterMode) {
       continue;
     }
     if (r0Page.snapshot !== r1Page.snapshot) {
-      // The FBF tests fail intermittently in Firefox and Google Chrome when run
-      // on the bots, ignoring `makeref` failures for now; see
-      //  - https://github.com/mozilla/pdf.js/pull/12368
-      //  - https://github.com/mozilla/pdf.js/pull/11491
-      //
-      // TODO: Figure out why this happens, so that we can remove the hack; see
-      //       https://github.com/mozilla/pdf.js/issues/12371
-      if (masterMode) {
-        console.log(
-          "TEST-SKIPPED | forward-back-forward test " +
-            task.id +
-            " | in " +
-            browser +
-            " | page" +
-            (page + 1)
-        );
-        continue;
-      }
-
       console.log(
         "TEST-UNEXPECTED-FAIL | forward-back-forward test " +
           task.id +


### PR DESCRIPTION
It's not ideal to use a new canvas for every PDF, but this makes the tests
reliable which I think is more important.