### PR TITLE
Improve the Pattern-detection in `CanvasGraphics.stroke`

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1350,11 +1350,7 @@ const CanvasGraphics = (function CanvasGraphicsClosure() {
       // stroking alpha.
       ctx.globalAlpha = this.current.strokeAlpha;
       if (this.contentVisible) {
-        if (
-          strokeColor &&
-          strokeColor.hasOwnProperty("type") &&
-          strokeColor.type === "Pattern"
-        ) {
+        if (typeof strokeColor === "object" && strokeColor?.getPattern) {
           // for patterns, we transform to pattern space, calculate
           // the pattern, call stroke, and restore to user space
           ctx.save();

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -38,7 +38,6 @@ ShadingIRs.RadialAxial = {
     const r0 = raw[6];
     const r1 = raw[7];
     return {
-      type: "Pattern",
       getPattern: function RadialAxial_getPattern(ctx) {
         applyBoundingBox(ctx, bbox);
         let grad;
@@ -340,7 +339,6 @@ ShadingIRs.Mesh = {
     const bbox = raw[7];
     const background = raw[8];
     return {
-      type: "Pattern",
       getPattern: function Mesh_getPattern(ctx, owner, shadingFill) {
         applyBoundingBox(ctx, bbox);
         let scale;
@@ -390,7 +388,6 @@ ShadingIRs.Mesh = {
 ShadingIRs.Dummy = {
   fromIR: function Dummy_fromIR() {
     return {
-      type: "Pattern",
       getPattern: function Dummy_fromIR_getPattern() {
         return "hotpink";
       },
@@ -429,7 +426,6 @@ const TilingPattern = (function TilingPatternClosure() {
     this.color = color;
     this.canvasGraphicsFactory = canvasGraphicsFactory;
     this.baseTransform = baseTransform;
-    this.type = "Pattern";
     this.ctx = ctx;
   }
 


### PR DESCRIPTION
The vast majority of the time, unless a Pattern is active, the `strokeColor`-property contains a "simple" colour value represented by a String. Hence it seems somewhat ridiculous to do a `hasOwnProperty` check on a String, and it's should thus be possible to improve things a tiny bit here.

Unfortunately using a simple `instanceof` check would only work for `TilingPattern`s, but not for the `ShadingIRs` given how they are implemented; see `src/display/pattern_helper.js`. (While that file could probably do with some clean-up, given the age of some of its code, that probably shouldn't happen here.)

Finally, the `this.type = "Pattern"`-property of the various Shadings/TilingPatterns were removed, since I cannot see why it's necessary when we can simply check for a `getPattern` method instead. Note that part of this code even pre-dates the main/worker-thread split, which probably in part explains why it looks the way it does.