### PR TITLE
Enable the ESLint `no-useless-escape` rule (PR 12551 follow-up)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -111,6 +111,7 @@
     "no-useless-call": "error",
     "no-useless-catch": "error",
     "no-useless-concat": "error",
+    "no-useless-escape": "error",
     "no-useless-return": "error",
     "prefer-promise-reject-errors": "error",
     "wrap-iife": ["error", "any"],

--- a/external/builder/builder.js
+++ b/external/builder/builder.js
@@ -202,7 +202,7 @@ function preprocessCSS(mode, source, destination) {
   }
 
   function expandImports(content, baseUrl) {
-    return content.replace(/^\s*@import\s+url\(([^\)]+)\);\s*$/gm, function (
+    return content.replace(/^\s*@import\s+url\(([^)]+)\);\s*$/gm, function (
       all,
       url
     ) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -124,7 +124,7 @@ function safeSpawnSync(command, parameters, options) {
   options.shell = true;
   // `options.shell = true` requires parameters to be quoted.
   parameters = parameters.map(param => {
-    if (!/[\s`~!#$*(){\[|\\;'"<>?]/.test(param)) {
+    if (!/[\s`~!#$*(){[|\\;'"<>?]/.test(param)) {
       return param;
     }
     return '"' + param.replace(/([$\\"`])/g, "\\$1") + '"';

--- a/src/scripting_api/util.js
+++ b/src/scripting_api/util.js
@@ -61,7 +61,7 @@ class Util extends PDFObject {
       throw new TypeError("First argument of printf must be a string");
     }
 
-    const pattern = /%(,[0-4])?([\+ 0#]+)?([0-9]+)?(\.[0-9]+)?(.)/g;
+    const pattern = /%(,[0-4])?([+ 0#]+)?([0-9]+)?(\.[0-9]+)?(.)/g;
     const PLUS = 1;
     const SPACE = 2;
     const ZERO = 4;

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -824,7 +824,7 @@ function escapeString(str) {
   // replace "(", ")", "\n", "\r" and "\"
   // by "\(", "\)", "\\n", "\\r" and "\\"
   // in order to write it in a PDF file.
-  return str.replace(/([\(\)\\\n\r])/g, match => {
+  return str.replace(/([()\\\n\r])/g, match => {
     if (match === "\n") {
       return "\\n";
     } else if (match === "\r") {

--- a/test/webserver.js
+++ b/test/webserver.js
@@ -165,7 +165,7 @@ WebServer.prototype = {
 
       var range = req.headers.range;
       if (range && !disableRangeRequests) {
-        var rangesMatches = /^bytes=(\d+)\-(\d+)?/.exec(range);
+        var rangesMatches = /^bytes=(\d+)-(\d+)?/.exec(range);
         if (!rangesMatches) {
           res.writeHead(501);
           res.end("Bad range", "utf8");

--- a/web/app.js
+++ b/web/app.js
@@ -1552,7 +1552,7 @@ const PDFViewerApplication = {
         if (!producer.includes(generator)) {
           return false;
         }
-        generatorId = generator.replace(/[ .\-]/g, "_");
+        generatorId = generator.replace(/[ .-]/g, "_");
         return true;
       });
     }

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -115,7 +115,7 @@ var FontInspector = (function FontInspectorClosure() {
       name.textContent = fontName;
       var download = document.createElement("a");
       if (url) {
-        url = /url\(['"]?([^\)"']+)/.exec(url);
+        url = /url\(['"]?([^)"']+)/.exec(url);
         download.href = url[1];
       } else if (fontObj.data) {
         download.href = URL.createObjectURL(

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -617,10 +617,10 @@ function getPDFFileNameFromURL(url, defaultFilename = "document.pdf") {
     );
     return defaultFilename;
   }
-  const reURI = /^(?:(?:[^:]+:)?\/\/[^\/]+)?([^?#]*)(\?[^#]*)?(#.*)?$/;
-  //              SCHEME        HOST         1.PATH  2.QUERY   3.REF
+  const reURI = /^(?:(?:[^:]+:)?\/\/[^/]+)?([^?#]*)(\?[^#]*)?(#.*)?$/;
+  //              SCHEME        HOST        1.PATH  2.QUERY   3.REF
   // Pattern to get last matching NAME.pdf
-  const reFilename = /[^\/?#=]+\.pdf\b(?!.*\.pdf\b)/i;
+  const reFilename = /[^/?#=]+\.pdf\b(?!.*\.pdf\b)/i;
   const splitURI = reURI.exec(url);
   let suggestedFilename =
     reFilename.exec(splitURI[1]) ||


### PR DESCRIPTION
Note that a number of these cases are covered by existing unit-tests, and a few others only matter for the development/build scripts.
Furthermore, I've also tried to the best of my ability to test each case *manually* to hopefully further reduce the likelihood of this patch introducing any bugs.

Please find additional details about the ESLint rule at https://eslint.org/docs/rules/no-useless-escape