### PR TITLE
Convert files in the `src/display/`-folder to use optional chaining where possible

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1566,9 +1566,7 @@ class PDFPageProxy {
         return;
       }
     }
-    intentState.streamReader.cancel(
-      new AbortException(reason && reason.message)
-    );
+    intentState.streamReader.cancel(new AbortException(reason?.message));
     intentState.streamReader = null;
 
     if (this._transport.destroyed) {
@@ -1615,8 +1613,7 @@ class LoopbackPort {
       let buffer, result;
       if ((buffer = value.buffer) && isArrayBuffer(buffer)) {
         // We found object with ArrayBuffer (typed array).
-        const transferable = transfers && transfers.includes(buffer);
-        if (transferable) {
+        if (transfers?.includes(buffer)) {
           result = new value.constructor(
             buffer,
             value.byteOffset,
@@ -1712,8 +1709,7 @@ const PDFWorker = (function PDFWorkerClosure() {
         fallbackWorkerSrc = "./pdf.worker.js";
       }
     } else if (typeof document === "object" && "currentScript" in document) {
-      const pdfjsFilePath =
-        document.currentScript && document.currentScript.src;
+      const pdfjsFilePath = document.currentScript?.src;
       if (pdfjsFilePath) {
         fallbackWorkerSrc = pdfjsFilePath.replace(
           /(\.(?:min\.)?js)(\?.*)?$/i,
@@ -1739,8 +1735,7 @@ const PDFWorker = (function PDFWorkerClosure() {
   function getMainThreadWorkerMessageHandler() {
     let mainWorkerMessageHandler;
     try {
-      mainWorkerMessageHandler =
-        globalThis.pdfjsWorker && globalThis.pdfjsWorker.WorkerMessageHandler;
+      mainWorkerMessageHandler = globalThis.pdfjsWorker?.WorkerMessageHandler;
     } catch (ex) {
       /* Ignore errors. */
     }
@@ -2378,11 +2373,7 @@ class WorkerTransport {
           }
 
           let fontRegistry = null;
-          if (
-            params.pdfBug &&
-            globalThis.FontInspector &&
-            globalThis.FontInspector.enabled
-          ) {
+          if (params.pdfBug && globalThis.FontInspector?.enabled) {
             fontRegistry = {
               registerFont(font, url) {
                 globalThis.FontInspector.fontAdded(font, url);
@@ -2441,11 +2432,7 @@ class WorkerTransport {
 
           // Heuristic that will allow us not to store large data.
           const MAX_IMAGE_SIZE_TO_STORE = 8000000;
-          if (
-            imageData &&
-            "data" in imageData &&
-            imageData.data.length > MAX_IMAGE_SIZE_TO_STORE
-          ) {
+          if (imageData?.data?.length > MAX_IMAGE_SIZE_TO_STORE) {
             pageProxy.cleanupAfterRender = true;
           }
           break;
@@ -2868,11 +2855,7 @@ const InternalRenderTask = (function InternalRenderTaskClosure() {
         canvasInRendering.add(this._canvas);
       }
 
-      if (
-        this._pdfBug &&
-        globalThis.StepperManager &&
-        globalThis.StepperManager.enabled
-      ) {
+      if (this._pdfBug && globalThis.StepperManager?.enabled) {
         this.stepper = globalThis.StepperManager.create(this._pageIndex);
         this.stepper.init(this.operatorList);
         this.stepper.nextBreakPoint = this.stepper.getNextBreakPoint();

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -2242,7 +2242,7 @@ const CanvasGraphics = (function CanvasGraphicsClosure() {
         }
       }
 
-      if (glyph && glyph.compiled) {
+      if (glyph?.compiled) {
         glyph.compiled(ctx);
         return;
       }

--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -35,7 +35,7 @@ function createFetchOptions(headers, withCredentials, abortController) {
   return {
     method: "GET",
     headers,
-    signal: abortController && abortController.signal,
+    signal: abortController?.signal,
     mode: "cors",
     credentials: withCredentials ? "include" : "same-origin",
     redirect: "follow",
@@ -251,7 +251,7 @@ class PDFFetchStreamRangeReader {
         this._reader = response.body.getReader();
       })
       .catch(reason => {
-        if (reason && reason.name === "AbortError") {
+        if (reason?.name === "AbortError") {
           return;
         }
         throw reason;

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -121,9 +121,7 @@ class BaseFontLoader {
   }
 
   get isFontLoadingAPISupported() {
-    const supported =
-      typeof this._document !== "undefined" && !!this._document.fonts;
-    return shadow(this, "isFontLoadingAPISupported", supported);
+    return shadow(this, "isFontLoadingAPISupported", !!this._document?.fonts);
   }
 
   // eslint-disable-next-line getter-return
@@ -173,7 +171,7 @@ if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
           const m = /Mozilla\/5.0.*?rv:(\d+).*? Gecko/.exec(
             navigator.userAgent
           );
-          if (m && m[1] >= 14) {
+          if (m?.[1] >= 14) {
             supported = true;
           }
           // TODO - other browsers...

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -1015,8 +1015,7 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       const current = this.current;
       if (
         current.textRenderingMode & TextRenderingMode.ADD_TO_PATH_FLAG &&
-        current.txtElement &&
-        current.txtElement.hasChildNodes()
+        current.txtElement?.hasChildNodes()
       ) {
         // If no glyphs are shown (i.e. no child nodes), no clipping occurs.
         current.element = current.txtElement;

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -526,9 +526,7 @@ const renderTextLayer = (function renderTextLayerClosure() {
     this._textDivs = textDivs || [];
     this._textContentItemsStr = textContentItemsStr || [];
     this._enhanceTextSelection = !!enhanceTextSelection;
-    this._fontInspectorEnabled = !!(
-      globalThis.FontInspector && globalThis.FontInspector.enabled
-    );
+    this._fontInspectorEnabled = !!globalThis.FontInspector?.enabled;
 
     this._reader = null;
     this._layoutTextLastFontSize = null;

--- a/src/display/transport_stream.js
+++ b/src/display/transport_stream.js
@@ -27,7 +27,7 @@ class PDFDataTransportStream {
     this._progressiveDone = params.progressiveDone || false;
 
     const initialData = params.initialData;
-    if (initialData && initialData.length > 0) {
+    if (initialData?.length > 0) {
       const buffer = new Uint8Array(initialData).buffer;
       this._queuedChunks.push(buffer);
     }
@@ -90,12 +90,12 @@ class PDFDataTransportStream {
     if (evt.total === undefined) {
       // Reporting to first range reader, if it exists.
       const firstReader = this._rangeReaders[0];
-      if (firstReader && firstReader.onProgress) {
+      if (firstReader?.onProgress) {
         firstReader.onProgress({ loaded: evt.loaded });
       }
     } else {
       const fullReader = this._fullRequestReader;
-      if (fullReader && fullReader.onProgress) {
+      if (fullReader?.onProgress) {
         fullReader.onProgress({ loaded: evt.loaded, total: evt.total });
       }
     }

--- a/src/display/webgl.js
+++ b/src/display/webgl.js
@@ -478,11 +478,11 @@ const WebGLUtils = (function WebGLUtilsClosure() {
     drawFigures,
 
     cleanup() {
-      if (smaskCache && smaskCache.canvas) {
+      if (smaskCache?.canvas) {
         smaskCache.canvas.width = 0;
         smaskCache.canvas.height = 0;
       }
-      if (figuresCache && figuresCache.canvas) {
+      if (figuresCache?.canvas) {
         figuresCache.canvas.width = 0;
         figuresCache.canvas.height = 0;
       }


### PR DESCRIPTION
By using optional chaining, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining, it's possible to reduce unnecessary code-repetition in many cases.
Note that these changes also reduce the size of the *built* `pdf.js` file, when `SKIP_BABEL == true` is set, and for the `MOZCENTRAL` build-target that result in a `0.1%` filesize reduction from a simple and mostly mechanical code change.