### PR TITLE
Fail early, in modern `GENERIC` builds, if `globalThis` isn't available (PR 11799 follow-up, issue 12596)

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -143,13 +143,14 @@ class WorkerMessageHandler {
       // `ReadableStream` and `Promise.allSettled`).
       if (
         (typeof PDFJSDev === "undefined" || PDFJSDev.test("SKIP_BABEL")) &&
-        (typeof ReadableStream === "undefined" ||
+        (typeof globalThis === "undefined" ||
+          typeof ReadableStream === "undefined" ||
           typeof Promise.allSettled === "undefined")
       ) {
         throw new Error(
           "The browser/environment lacks native support for critical " +
-            "functionality used by the PDF.js library (e.g. " +
-            "`ReadableStream` and/or `Promise.allSettled`); " +
+            "functionality used by the PDF.js library (e.g. `globalThis`, " +
+            "`ReadableStream`, and/or `Promise.allSettled`); " +
             "please use an ES5-compatible build instead."
         );
       }


### PR DESCRIPTION
It probably doesn't hurt to explicitly check for `globalThis` as well, in addition to the existing checks.