### PR TITLE
Improve the cleanup functionality for thumbnails

### DIFF
--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -502,10 +502,6 @@ class PDFThumbnailView {
       }
     });
   }
-
-  static cleanup() {
-    TempImageFactory.destroyCanvas();
-  }
 }
 
-export { PDFThumbnailView };
+export { PDFThumbnailView, TempImageFactory };

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -20,7 +20,8 @@ import {
   scrollIntoView,
   watchScroll,
 } from "./ui_utils.js";
-import { PDFThumbnailView } from "./pdf_thumbnail_view.js";
+import { PDFThumbnailView, TempImageFactory } from "./pdf_thumbnail_view.js";
+import { RenderingStates } from "./pdf_rendering_queue.js";
 
 const THUMBNAIL_SCROLL_MARGIN = -19;
 const THUMBNAIL_SELECTED_CLASS = "selected";
@@ -156,7 +157,15 @@ class PDFThumbnailViewer {
   }
 
   cleanup() {
-    PDFThumbnailView.cleanup();
+    for (let i = 0, ii = this._thumbnails.length; i < ii; i++) {
+      if (
+        this._thumbnails[i] &&
+        this._thumbnails[i].renderingState !== RenderingStates.FINISHED
+      ) {
+        this._thumbnails[i].reset();
+      }
+    }
+    TempImageFactory.destroyCanvas();
   }
 
   /**


### PR DESCRIPTION
*This is a pre-existing issue that I noticed while working on PR #12613, and fixing this also brings the thumbnail code inline with the page code.*

Given the intermittent nature of all of this, it's somewhat difficult to reproduce it consistently; however the following steps should at least provide an outline:
 1. Open the sidebar, and the thumbnailView, and start scrolling around.
 2. *Quickly* close the sidebar, so that all thumbnails won't have time to finish rendering.
 3. Either wait for the cleanup-timeout to occur, or simply run `PDFViewerApplication.cleanup()` in the console.

What *intermittently* happens here is that `WorkerTransport.startCleanup` rejects, and consequently that cleanup doesn't complete as intended, since some of the thumbnails are left in a *pending* renderingState[1].
Fixing this is simple though, and only requires updating `PDFThumbnailViewer.cleanup` along the lines of `BaseViewer.cleanup`.

---
[1] Keep in mind that thumbnails will *only* render when the thumbnailView is visible, to reduce resource usage.