### PR TITLE
Fix #9820 Thumbnail scale

### DIFF
--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -128,7 +128,8 @@ class PDFThumbnailView {
 
     this.canvasWidth = THUMBNAIL_WIDTH;
     this.canvasHeight = (this.canvasWidth / this.pageRatio) | 0;
-    this.scale = this.canvasWidth / this.pageWidth;
+    this.scale =
+      (this.canvasWidth / this.pageWidth) * (window.devicePixelRatio || 1);
 
     this.l10n = l10n;
 
@@ -177,7 +178,8 @@ class PDFThumbnailView {
     this.pageRatio = this.pageWidth / this.pageHeight;
 
     this.canvasHeight = (this.canvasWidth / this.pageRatio) | 0;
-    this.scale = this.canvasWidth / this.pageWidth;
+    this.scale =
+      (this.canvasWidth / this.pageWidth) * (window.devicePixelRatio || 1);
 
     this.div.removeAttribute("data-loaded");
     const ring = this.ring;


### PR DESCRIPTION
#9820

To reproduce the bug
- Set monitor DPI/Scale beyond 100%
- Thumbnails of pages out of view (not in the getVisibleElements from ui_utils.js)

![image](https://user-images.githubusercontent.com/5492274/99074881-81ce6580-25f3-11eb-9f42-61c0b3dc0224.png)
![image](https://user-images.githubusercontent.com/5492274/99074963-a4607e80-25f3-11eb-847c-cffd92c30c1e.png)
