### PR TITLE
Add an `AppOptions.setAll` method, and use it in `PDFViewerApplication._readPreferences`

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -385,6 +385,9 @@ const PDFViewerApplication = {
       AppOptions.set("locale", hashParams.locale);
     }
 
+    if (waitOn.length === 0) {
+      return undefined;
+    }
     return Promise.all(waitOn).catch(reason => {
       console.error(`_parseHashParameters: "${reason.message}".`);
     });

--- a/web/app.js
+++ b/web/app.js
@@ -305,12 +305,9 @@ const PDFViewerApplication = {
       return;
     }
     try {
-      const prefs = await this.preferences.getAll();
-      for (const name in prefs) {
-        AppOptions.set(name, prefs[name]);
-      }
+      AppOptions.setAll(await this.preferences.getAll());
     } catch (reason) {
-      console.error(`_readPreferences: "${reason.message}".`);
+      console.error(`_readPreferences: "${reason?.message}".`);
     }
   },
 

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -314,6 +314,12 @@ class AppOptions {
     userOptions[name] = value;
   }
 
+  static setAll(options) {
+    for (const name in options) {
+      userOptions[name] = options[name];
+    }
+  }
+
   static remove(name) {
     delete userOptions[name];
   }


### PR DESCRIPTION
Given that it's generally faster to call *one* function and have it loop through an object, rather than looping through an object and calling a function for every iteration, this patch will reduce the total time spent in `PDFViewerApplication._readPreferences` ever so slightly.
Also, over time we've been adding more and more preferences, rather than removing them, so using the new `AppOptions.setAll` method should be generally beneficial as well.

While the effect of these changes is quite small, it does reduces the time it takes for the preferences to be fully initialized. Given the amount of asynchronous code during viewer initialization, every bit of time that we can save should thus help.
Especially considering the recently added `viewerCssTheme` preference, which needs to be read very early to reduce the risk of the viewer UI "flashing" visibly as the theme changes, I figured that a couple of small patches reducing the time spend reading preferences cannot hurt.

