### PR TITLE
[api-minor] Add "contentLength" to the information returned by the `getMetadata` method

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2654,9 +2654,8 @@ class WorkerTransport {
         return {
           info: results[0],
           metadata: results[1] ? new Metadata(results[1]) : null,
-          contentDispositionFilename: this._fullReader
-            ? this._fullReader.filename
-            : null,
+          contentDispositionFilename: this._fullReader?.filename ?? null,
+          contentLength: this._fullReader?.contentLength ?? null,
         };
       });
   }

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1132,7 +1132,12 @@ describe("api", function () {
     it("gets metadata", function (done) {
       const promise = pdfDocument.getMetadata();
       promise
-        .then(function ({ info, metadata, contentDispositionFilename }) {
+        .then(function ({
+          info,
+          metadata,
+          contentDispositionFilename,
+          contentLength,
+        }) {
           expect(info.Title).toEqual("Basic API Test");
           // Custom, non-standard, information dictionary entries.
           expect(info.Custom).toEqual(undefined);
@@ -1147,6 +1152,7 @@ describe("api", function () {
           expect(metadata.get("dc:title")).toEqual("Basic API Test");
 
           expect(contentDispositionFilename).toEqual(null);
+          expect(contentLength).toEqual(basicApiFileLength);
           done();
         })
         .catch(done.fail);
@@ -1160,7 +1166,12 @@ describe("api", function () {
         .then(function (pdfDoc) {
           return pdfDoc.getMetadata();
         })
-        .then(function ({ info, metadata, contentDispositionFilename }) {
+        .then(function ({
+          info,
+          metadata,
+          contentDispositionFilename,
+          contentLength,
+        }) {
           expect(info.Creator).toEqual("TeX");
           expect(info.Producer).toEqual("pdfeTeX-1.21a");
           expect(info.CreationDate).toEqual("D:20090401163925-07'00'");
@@ -1181,6 +1192,7 @@ describe("api", function () {
 
           expect(metadata).toEqual(null);
           expect(contentDispositionFilename).toEqual(null);
+          expect(contentLength).toEqual(1016315);
 
           loadingTask.destroy().then(done);
         })
@@ -1193,7 +1205,12 @@ describe("api", function () {
         .then(function (pdfDoc) {
           return pdfDoc.getMetadata();
         })
-        .then(function ({ info, metadata, contentDispositionFilename }) {
+        .then(function ({
+          info,
+          metadata,
+          contentDispositionFilename,
+          contentLength,
+        }) {
           // The following are PDF.js specific, non-standard, properties.
           expect(info.PDFFormatVersion).toEqual(null);
           expect(info.IsLinearized).toEqual(false);
@@ -1203,6 +1220,7 @@ describe("api", function () {
 
           expect(metadata).toEqual(null);
           expect(contentDispositionFilename).toEqual(null);
+          expect(contentLength).toEqual(624);
 
           loadingTask.destroy().then(done);
         })

--- a/web/app.js
+++ b/web/app.js
@@ -863,15 +863,10 @@ const PDFViewerApplication = {
       }
       parameters[key] = value;
     }
-
+    // Finally, update the API parameters with the arguments (if they exist).
     if (args) {
       for (const key in args) {
-        const value = args[key];
-
-        if (key === "length") {
-          this.pdfDocumentProperties.setFileSize(value);
-        }
-        parameters[key] = value;
+        parameters[key] = args[key];
       }
     }
 


### PR DESCRIPTION
Given that we already include the "Content-Disposition"-header filename, when it exists, it shouldn't hurt to also include the information from the "Content-Length"-header.
For PDF documents opened via a URL, which should be a very common way for the PDF.js library to be used, this will[1] thus provide a way of getting the PDF filesize without having to wait for the `getDownloadInfo`-promise to resolve[2].

With these API improvements, we can also simplify the filesize handling in the `PDFDocumentProperties` class.

*Smaller/simpler diff with https://github.com/mozilla/pdf.js/pull/12642/files?w=1*

---
[1] Assuming that the server is correctly configured, of course.

[2] Since that's not *guaranteed* to happen in general, with e.g. `disableAutoFetch = true` set.