### PR TITLE
Convert the `PDFDocumentProperties.open` method to be async

### DIFF
--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -97,7 +97,7 @@ class PDFDocumentProperties {
   /**
    * Open the document properties overlay.
    */
-  open() {
+  async open() {
     const freezeFieldData = data => {
       Object.defineProperty(this, "fieldData", {
         value: Object.freeze(data),
@@ -107,95 +107,81 @@ class PDFDocumentProperties {
       });
     };
 
-    Promise.all([
+    await Promise.all([
       this.overlayManager.open(this.overlayName),
       this._dataAvailableCapability.promise,
-    ]).then(() => {
-      const currentPageNumber = this._currentPageNumber;
-      const pagesRotation = this._pagesRotation;
+    ]);
+    const currentPageNumber = this._currentPageNumber;
+    const pagesRotation = this._pagesRotation;
 
-      // If the document properties were previously fetched (for this PDF file),
-      // just update the dialog immediately to avoid redundant lookups.
-      if (
-        this.fieldData &&
-        currentPageNumber === this.fieldData._currentPageNumber &&
-        pagesRotation === this.fieldData._pagesRotation
-      ) {
-        this._updateUI();
-        return;
-      }
+    // If the document properties were previously fetched (for this PDF file),
+    // just update the dialog immediately to avoid redundant lookups.
+    if (
+      this.fieldData &&
+      currentPageNumber === this.fieldData._currentPageNumber &&
+      pagesRotation === this.fieldData._pagesRotation
+    ) {
+      this._updateUI();
+      return;
+    }
 
-      // Get the document properties.
-      this.pdfDocument
-        .getMetadata()
-        .then(
-          ({ info, metadata, contentDispositionFilename, contentLength }) => {
-            return Promise.all([
-              info,
-              metadata,
-              contentDispositionFilename || getPDFFileNameFromURL(this.url),
-              this._parseFileSize(contentLength),
-              this._parseDate(info.CreationDate),
-              this._parseDate(info.ModDate),
-              this.pdfDocument.getPage(currentPageNumber).then(pdfPage => {
-                return this._parsePageSize(
-                  getPageSizeInches(pdfPage),
-                  pagesRotation
-                );
-              }),
-              this._parseLinearization(info.IsLinearized),
-            ]);
-          }
-        )
-        .then(
-          ([
-            info,
-            metadata,
-            fileName,
-            fileSize,
-            creationDate,
-            modDate,
-            pageSize,
-            isLinearized,
-          ]) => {
-            freezeFieldData({
-              fileName,
-              fileSize,
-              title: info.Title,
-              author: info.Author,
-              subject: info.Subject,
-              keywords: info.Keywords,
-              creationDate,
-              modificationDate: modDate,
-              creator: info.Creator,
-              producer: info.Producer,
-              version: info.PDFFormatVersion,
-              pageCount: this.pdfDocument.numPages,
-              pageSize,
-              linearized: isLinearized,
-              _currentPageNumber: currentPageNumber,
-              _pagesRotation: pagesRotation,
-            });
-            this._updateUI();
+    // Get the document properties.
+    const {
+      info,
+      /* metadata, */
+      contentDispositionFilename,
+      contentLength,
+    } = await this.pdfDocument.getMetadata();
 
-            // Get the correct fileSize, since it may not have been available
-            // or could potentially be wrong.
-            return this.pdfDocument.getDownloadInfo().then(downloadInfo => {
-              return this._parseFileSize(downloadInfo.length);
-            });
-          }
-        )
-        .then(fileSize => {
-          if (fileSize === this.fieldData.fileSize) {
-            return; // The fileSize has already been correctly set.
-          }
-          const data = Object.assign(Object.create(null), this.fieldData);
-          data.fileSize = fileSize;
+    const [
+      fileName,
+      fileSize,
+      creationDate,
+      modificationDate,
+      pageSize,
+      isLinearized,
+    ] = await Promise.all([
+      contentDispositionFilename || getPDFFileNameFromURL(this.url),
+      this._parseFileSize(contentLength),
+      this._parseDate(info.CreationDate),
+      this._parseDate(info.ModDate),
+      this.pdfDocument.getPage(currentPageNumber).then(pdfPage => {
+        return this._parsePageSize(getPageSizeInches(pdfPage), pagesRotation);
+      }),
+      this._parseLinearization(info.IsLinearized),
+    ]);
 
-          freezeFieldData(data);
-          this._updateUI();
-        });
+    freezeFieldData({
+      fileName,
+      fileSize,
+      title: info.Title,
+      author: info.Author,
+      subject: info.Subject,
+      keywords: info.Keywords,
+      creationDate,
+      modificationDate,
+      creator: info.Creator,
+      producer: info.Producer,
+      version: info.PDFFormatVersion,
+      pageCount: this.pdfDocument.numPages,
+      pageSize,
+      linearized: isLinearized,
+      _currentPageNumber: currentPageNumber,
+      _pagesRotation: pagesRotation,
     });
+    this._updateUI();
+
+    // Get the correct fileSize, since it may not have been available
+    // or could potentially be wrong.
+    const { length } = await this.pdfDocument.getDownloadInfo();
+    if (contentLength === length) {
+      return; // The fileSize has already been correctly set.
+    }
+    const data = Object.assign(Object.create(null), this.fieldData);
+    data.fileSize = await this._parseFileSize(length);
+
+    freezeFieldData(data);
+    this._updateUI();
   }
 
   /**


### PR DESCRIPTION
By using `await`, rather than chaining promises, this method becomes more compact and slightly easier to reason about (at least in my opinion).

*Smaller/simpler diff with https://github.com/mozilla/pdf.js/pull/12645/files?w=1*