### PR TITLE
[api-minor] Allow "file:"-URLs only for *local* PDF documents (issue 12415)

### DIFF
--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -42,7 +42,10 @@ class BasePdfManager {
   get docBaseUrl() {
     let docBaseUrl = null;
     if (this._docBaseUrl) {
-      const absoluteUrl = createValidAbsoluteUrl(this._docBaseUrl);
+      const absoluteUrl = createValidAbsoluteUrl(
+        this._docBaseUrl,
+        this._docBaseUrl
+      );
       if (absoluteUrl) {
         docBaseUrl = absoluteUrl.href;
       } else {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1551,12 +1551,31 @@ describe("api", function () {
         }
       );
 
-      Promise.all([defaultPromise, docBaseUrlPromise, invalidDocBaseUrlPromise])
-        .then(function (data) {
-          const defaultAnnotations = data[0];
-          const docBaseUrlAnnotations = data[1];
-          const invalidDocBaseUrlAnnotations = data[2];
+      const fileDocBaseUrlLoadingTask = getDocument(
+        buildGetDocumentParams(filename, {
+          docBaseUrl: "file:///C:/Users/name/test/pdfs/qwerty.pdf",
+        })
+      );
+      const fileDocBaseUrlPromise = fileDocBaseUrlLoadingTask.promise.then(
+        function (pdfDoc) {
+          return pdfDoc.getPage(1).then(function (pdfPage) {
+            return pdfPage.getAnnotations();
+          });
+        }
+      );
 
+      Promise.all([
+        defaultPromise,
+        docBaseUrlPromise,
+        invalidDocBaseUrlPromise,
+        fileDocBaseUrlPromise,
+      ])
+        .then(function ([
+          defaultAnnotations,
+          docBaseUrlAnnotations,
+          invalidDocBaseUrlAnnotations,
+          fileDocBaseUrlAnnotations,
+        ]) {
           expect(defaultAnnotations[0].url).toBeUndefined();
           expect(defaultAnnotations[0].unsafeUrl).toEqual(
             "../../0021/002156/215675E.pdf#15"
@@ -1574,10 +1593,18 @@ describe("api", function () {
             "../../0021/002156/215675E.pdf#15"
           );
 
+          expect(fileDocBaseUrlAnnotations[0].url).toEqual(
+            "file:///C:/Users/name/0021/002156/215675E.pdf#15"
+          );
+          expect(fileDocBaseUrlAnnotations[0].unsafeUrl).toEqual(
+            "../../0021/002156/215675E.pdf#15"
+          );
+
           Promise.all([
             defaultLoadingTask.destroy(),
             docBaseUrlLoadingTask.destroy(),
             invalidDocBaseUrlLoadingTask.destroy(),
+            fileDocBaseUrlLoadingTask.destroy(),
           ]).then(done);
         })
         .catch(done.fail);


### PR DESCRIPTION
*Please note:* This requires [bug 1678914](https://bugzilla.mozilla.org/show_bug.cgi?id=1678914) to be fixed *first*, since we don't want to display non-working links.