### PR TITLE
Fix the `treeitem-expanded`/`treeitem-collapsed` images in dark-mode (PR 12666 follow-up)

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -955,7 +955,8 @@ html[dir="rtl"] #findNext {
 
 .toolbarButton::before,
 .secondaryToolbarButton::before,
-.dropdownToolbarButton::after {
+.dropdownToolbarButton::after,
+.treeItemToggler::before {
   /* All matching images have a size of 16x16
    * All relevant containers have a size of 28x28 */
   position: absolute;
@@ -1450,14 +1451,12 @@ html[dir="rtl"] #layersView .treesItem > a > label {
   color: rgba(255, 255, 255, 0.5);
 }
 .treeItemToggler::before {
-  content: var(--treeitem-expanded-icon);
-  display: inline-block;
-  position: absolute;
-  max-width: 16px;
+  -webkit-mask-image: var(--treeitem-expanded-icon);
+  mask-image: var(--treeitem-expanded-icon);
 }
 .treeItemToggler.treeItemsHidden::before {
-  content: var(--treeitem-collapsed-icon);
-  max-width: 16px;
+  -webkit-mask-image: var(--treeitem-collapsed-icon);
+  mask-image: var(--treeitem-collapsed-icon);
 }
 html[dir="rtl"] .treeItemToggler.treeItemsHidden::before {
   transform: scaleX(-1);


### PR DESCRIPTION
I completely missed updating these in PR #12666; sorry about that!

/cc @timvandermeij 