### PR TITLE
[Generic viewer] Re-factor how the `notFound` appearance is set on the "findInput" in the `PDFFindBar`

### DIFF
--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -104,7 +104,6 @@ class PDFFindBar {
   }
 
   updateUIState(state, previous, matchesCount) {
-    let notFound = false;
     let findMsg = "";
     let status = "";
 
@@ -118,7 +117,7 @@ class PDFFindBar {
 
       case FindState.NOT_FOUND:
         findMsg = this.l10n.get("find_not_found", null, "Phrase not found");
-        notFound = true;
+        status = "notFound";
         break;
 
       case FindState.WRAPPED:
@@ -137,8 +136,6 @@ class PDFFindBar {
         }
         break;
     }
-
-    this.findField.classList.toggle("notFound", notFound);
     this.findField.setAttribute("data-status", status);
 
     Promise.resolve(findMsg).then(msg => {

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -582,6 +582,9 @@ html[dir="rtl"] #findInput {
 html[dir="rtl"] #findInput[data-status="pending"] {
   background-position: 3px;
 }
+#findInput[data-status="notFound"] {
+  background-color: rgba(255, 102, 102, 1);
+}
 
 .secondaryToolbar {
   padding: 6px 0 10px 0;
@@ -680,10 +683,6 @@ html[dir="ltr"] .doorHangerRight:before {
 }
 #findMsg:empty {
   display: none;
-}
-
-#findInput.notFound {
-  background-color: rgba(255, 102, 102, 1);
 }
 
 #toolbarViewerMiddle {


### PR DESCRIPTION
Rather than having two slightly different ways of setting the pending/notFound appearance on the "findInput", we can simply use "data-status" in both cases since they're obviously mutually exclusive.