### PR TITLE
[Regression] Prevent the *built* `pdf.scripting.js`/`pdf.sandbox.js` files from accidentally including most of the main-thread code (PR 12631 follow-up)

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -15,7 +15,6 @@
 
 import {
   addLinkAttributes,
-  ColorConverters,
   DOMSVGFactory,
   getFilenameFromUrl,
   LinkTarget,
@@ -30,6 +29,7 @@ import {
   warn,
 } from "../shared/util.js";
 import { AnnotationStorage } from "./annotation_storage.js";
+import { ColorConverters } from "../shared/scripting_utils.js";
 
 /**
  * @typedef {Object} AnnotationElementParameters

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -635,59 +635,6 @@ class PDFDateString {
   }
 }
 
-function makeColorComp(n) {
-  return Math.floor(Math.max(0, Math.min(1, n)) * 255)
-    .toString(16)
-    .padStart(2, "0");
-}
-
-const ColorConverters = {
-  // PDF specifications section 10.3
-  CMYK_G([c, y, m, k]) {
-    return ["G", 1 - Math.min(1, 0.3 * c + 0.59 * m + 0.11 * y + k)];
-  },
-  G_CMYK([g]) {
-    return ["CMYK", 0, 0, 0, 1 - g];
-  },
-  G_RGB([g]) {
-    return ["RGB", g, g, g];
-  },
-  G_HTML([g]) {
-    const G = makeColorComp(g);
-    return `#${G}${G}${G}`;
-  },
-  RGB_G([r, g, b]) {
-    return ["G", 0.3 * r + 0.59 * g + 0.11 * b];
-  },
-  RGB_HTML([r, g, b]) {
-    const R = makeColorComp(r);
-    const G = makeColorComp(g);
-    const B = makeColorComp(b);
-    return `#${R}${G}${B}`;
-  },
-  T_HTML() {
-    return "#00000000";
-  },
-  CMYK_RGB([c, y, m, k]) {
-    return [
-      "RGB",
-      1 - Math.min(1, c + k),
-      1 - Math.min(1, m + k),
-      1 - Math.min(1, y + k),
-    ];
-  },
-  CMYK_HTML(components) {
-    return ColorConverters.RGB_HTML(ColorConverters.CMYK_RGB(components));
-  },
-  RGB_CMYK([r, g, b]) {
-    const c = 1 - r;
-    const m = 1 - g;
-    const y = 1 - b;
-    const k = Math.min(c, m, y);
-    return ["CMYK", c, m, y, k];
-  },
-};
-
 export {
   PageViewport,
   RenderingCancelledException,
@@ -698,7 +645,6 @@ export {
   BaseCanvasFactory,
   DOMCanvasFactory,
   BaseCMapReaderFactory,
-  ColorConverters,
   DOMCMapReaderFactory,
   DOMSVGFactory,
   StatTimer,

--- a/src/scripting_api/color.js
+++ b/src/scripting_api/color.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { ColorConverters } from "../display/display_utils.js";
+import { ColorConverters } from "../shared/scripting_utils.js";
 import { PDFObject } from "./pdf_object.js";
 
 class Color extends PDFObject {

--- a/src/shared/scripting_utils.js
+++ b/src/shared/scripting_utils.js
@@ -1,0 +1,85 @@
+/* Copyright 2020 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * PLEASE NOTE: This file is currently imported in both the `../display/` and
+ *              `../scripting_api/` folders, hence be EXTREMELY careful about
+ *              introducing any dependencies here since that can lead to an
+ *              unexpected/unnecessary size increase of the *built* files.
+ */
+
+function makeColorComp(n) {
+  return Math.floor(Math.max(0, Math.min(1, n)) * 255)
+    .toString(16)
+    .padStart(2, "0");
+}
+
+// PDF specifications section 10.3
+class ColorConverters {
+  static CMYK_G([c, y, m, k]) {
+    return ["G", 1 - Math.min(1, 0.3 * c + 0.59 * m + 0.11 * y + k)];
+  }
+
+  static G_CMYK([g]) {
+    return ["CMYK", 0, 0, 0, 1 - g];
+  }
+
+  static G_RGB([g]) {
+    return ["RGB", g, g, g];
+  }
+
+  static G_HTML([g]) {
+    const G = makeColorComp(g);
+    return `#${G}${G}${G}`;
+  }
+
+  static RGB_G([r, g, b]) {
+    return ["G", 0.3 * r + 0.59 * g + 0.11 * b];
+  }
+
+  static RGB_HTML([r, g, b]) {
+    const R = makeColorComp(r);
+    const G = makeColorComp(g);
+    const B = makeColorComp(b);
+    return `#${R}${G}${B}`;
+  }
+
+  static T_HTML() {
+    return "#00000000";
+  }
+
+  static CMYK_RGB([c, y, m, k]) {
+    return [
+      "RGB",
+      1 - Math.min(1, c + k),
+      1 - Math.min(1, m + k),
+      1 - Math.min(1, y + k),
+    ];
+  }
+
+  static CMYK_HTML(components) {
+    return this.RGB_HTML(this.CMYK_RGB(components));
+  }
+
+  static RGB_CMYK([r, g, b]) {
+    const c = 1 - r;
+    const m = 1 - g;
+    const y = 1 - b;
+    const k = Math.min(c, m, y);
+    return ["CMYK", c, m, y, k];
+  }
+}
+
+export { ColorConverters };


### PR DESCRIPTION
*This is a recent regression, which I stumbled upon while working on cleaning-up the gulpfile related to `pdf.sandbox.js` building.*

By placing the `ColorConverters` functionality in the `src/display/display_utils.js` file, you end up including a *significant* chunk of the `pdf.js` file in the built `pdf.scripting.js`/`pdf.sandbox.js` files.
Given that I cannot imagine that this was actually intended, since it inflates the built files with unnecessary/unused code, this moves `ColorConverters` to a new file instead (thus breaking the dependencies).

To hopefully reduce the risk future bugs, along these lines, a big comment is also placed at the top of the new file.
Finally, the `ColorConverters` is converted to a class with static methods, since this felt slightly cleaner overall.