### PR TITLE
DnD a text from a text field doesn't remove text in the source

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -632,13 +632,26 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
         storage.setValue(id, { value: event.target.value });
       });
 
+      let hasDragStarted = false;
       let blurListener = event => {
         if (elementData.formattedValue) {
           event.target.value = elementData.formattedValue;
         }
-        event.target.setSelectionRange(0, 0);
+        if (!hasDragStarted) {
+          // Put the caret at the beginning of the line when leaving
+          // The 'hasDragStarted' is required in Firefox to avoid bug 1679872
+          // TODO: remove hasDragStarted stuff when the above bug is fixed
+          event.target.setSelectionRange(0, 0);
+        }
         elementData.beforeInputSelectionRange = null;
       };
+
+      element.addEventListener("dragstart", () => {
+        hasDragStarted = true;
+      });
+      element.addEventListener("dragend", e => {
+        hasDragStarted = false;
+      });
 
       if (this.enableScripting && this.hasJSActions) {
         element.addEventListener("focus", event => {

--- a/web/app.js
+++ b/web/app.js
@@ -2401,17 +2401,21 @@ function webViewerInitialized() {
 
     // Enable dragging-and-dropping a new PDF file onto the viewerContainer.
     appConfig.mainContainer.addEventListener("dragover", function (evt) {
-      evt.preventDefault();
-
-      evt.dataTransfer.dropEffect = "move";
-    });
-    appConfig.mainContainer.addEventListener("drop", function (evt) {
-      evt.preventDefault();
-
       const files = evt.dataTransfer.files;
       if (!files || files.length === 0) {
         return;
       }
+
+      evt.preventDefault();
+      evt.dataTransfer.dropEffect = "move";
+    });
+    appConfig.mainContainer.addEventListener("drop", function (evt) {
+      const files = evt.dataTransfer.files;
+      if (!files || files.length === 0) {
+        return;
+      }
+
+      evt.preventDefault();
       PDFViewerApplication.eventBus.dispatch("fileinputchange", {
         source: this,
         fileInput: evt.dataTransfer,


### PR DESCRIPTION
 * aims to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1679872
 * Fix a bug in generic build: it wasn't possible to drop a text in a form