### PR TITLE
Renderer - Draw text if a font can't be loaded

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1592,10 +1592,10 @@ const CanvasGraphics = (function CanvasGraphicsClosure() {
 
       let addToPath;
       if (font.disableFontFace || isAddToPathSet || patternFill) {
-        addToPath = font.getPathGenerator(this.commonObjs, character);
+        addToPath = font.tryGetPathGenerator(this.commonObjs, character);
       }
 
-      if (font.disableFontFace || patternFill) {
+      if (addToPath && (font.disableFontFace || patternFill)) {
         ctx.save();
         ctx.translate(x, y);
         ctx.beginPath();

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -354,7 +354,7 @@ class FontFaceObject {
       fontRegistry = null,
     }
   ) {
-    this.compiledGlyphs = {};
+    this.compiledGlyphs = Object.create(null);
     // importing translated data
     for (const i in translatedData) {
       this[i] = translatedData[i];
@@ -394,7 +394,7 @@ class FontFaceObject {
   }
 
   tryGetPathGenerator(objs, character) {
-    if (this.compiledGlyphs.hasOwnProperty(character)) {
+    if (this.compiledGlyphs[character] !== undefined) {
       return this.compiledGlyphs[character];
     }
 
@@ -412,7 +412,7 @@ class FontFaceObject {
       }
       warn(`tryGetPathGenerator - ignoring character: "${ex}".`);
 
-      return (this.compiledGlyphs[character] = undefined);
+      return (this.compiledGlyphs[character] = null);
     }
 
     // If we can, compile cmds into JS for MAXIMUM SPEED...

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -354,7 +354,7 @@ class FontFaceObject {
       fontRegistry = null,
     }
   ) {
-    this.compiledGlyphs = Object.create(null);
+    this.compiledGlyphs = {};
     // importing translated data
     for (const i in translatedData) {
       this[i] = translatedData[i];
@@ -393,8 +393,8 @@ class FontFaceObject {
     return rule;
   }
 
-  getPathGenerator(objs, character) {
-    if (this.compiledGlyphs[character] !== undefined) {
+  tryGetPathGenerator(objs, character) {
+    if (this.compiledGlyphs.hasOwnProperty(character)) {
       return this.compiledGlyphs[character];
     }
 
@@ -410,11 +410,9 @@ class FontFaceObject {
           featureId: UNSUPPORTED_FEATURES.errorFontGetPath,
         });
       }
-      warn(`getPathGenerator - ignoring character: "${ex}".`);
+      warn(`tryGetPathGenerator - ignoring character: "${ex}".`);
 
-      return (this.compiledGlyphs[character] = function (c, size) {
-        // No-op function, to allow rendering to continue.
-      });
+      return (this.compiledGlyphs[character] = undefined);
     }
 
     // If we can, compile cmds into JS for MAXIMUM SPEED...


### PR DESCRIPTION
Wanted to at least get the conversation started about #4244. I don't really understand the code in this area, but here's a patch that at least draws text if a font can't be loaded which was important for my purposes.