### PR TITLE
Attempt to handle collapsed outline items, in the default viewer, according to the specification (issue 12704, PR 10890 follow-up)

### DIFF
--- a/web/pdf_outline_viewer.js
+++ b/web/pdf_outline_viewer.js
@@ -95,7 +95,23 @@ class PDFOutlineViewer extends BaseTreeViewer {
    * @private
    */
   _addToggleButton(div, { count, items }) {
-    const hidden = count < 0 && Math.abs(count) === items.length;
+    let hidden = false;
+    if (count < 0) {
+      let totalCount = items.length;
+      if (totalCount > 0) {
+        const queue = [...items];
+        while (queue.length > 0) {
+          const { count: nestedCount, items: nestedItems } = queue.shift();
+          if (nestedCount > 0 && nestedItems.length > 0) {
+            totalCount += nestedItems.length;
+            queue.push(...nestedItems);
+          }
+        }
+      }
+      if (Math.abs(count) === totalCount) {
+        hidden = true;
+      }
+    }
     super._addToggleButton(div, hidden);
   }
 


### PR DESCRIPTION
This patch *attempts* to actually implement what's described for the `Count`-entry in the PDF specification, see https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/PDF32000_2008.pdf#G11.2095911, which I mostly ignored back in PR #10890 since it seemed unnecessarily complicated[1].

Besides issue #12704, I've also tested a couple of other documents (e.g. the PDF specification) and these changes don't *seem* to break anything else; additional testing would be helpful though!

Fixes #12704

---
[1] At the time, all PDF documents that I tested worked even with a very simple approach and I thus hoped that it'd would suffice.