### PR TITLE
Ensure that the /Annots-entry, on /Page-instances, is actually an Array (issue 12714)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -437,11 +437,8 @@ class Page {
   }
 
   get annotations() {
-    return shadow(
-      this,
-      "annotations",
-      this._getInheritableProperty("Annots") || []
-    );
+    const annots = this._getInheritableProperty("Annots");
+    return shadow(this, "annotations", Array.isArray(annots) ? annots : []);
   }
 
   get _parsedAnnotations() {

--- a/test/pdfs/issue12714.pdf.link
+++ b/test/pdfs/issue12714.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/5669997/b49fe733-63e0-4972-8b47-3a05c2c8e881.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2028,6 +2028,15 @@
       "link": true,
       "type": "eq"
     },
+    {  "id": "issue12714",
+       "file": "pdfs/issue12714.pdf",
+       "md5": "f9ee31c74f9e342e95122b0b3bc84fa0",
+       "rounds": 1,
+       "firstPage": 2,
+       "lastPage": 2,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "issue7872",
        "file": "pdfs/issue7872.pdf",
        "md5": "81781dfecfcb7e9cd9cc7e60f8b747b7",


### PR DESCRIPTION
In the referenced PDF document, the second and third page has *corrupt* /Annots-entries which contain /Dict-data rather than the intended Arrays.

Fixes #12714