### PR TITLE
[gulpfile.js] Move the time-zone hack to the `testing-pre` task, such that *all* tests work regardless of the current time-zone

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1521,6 +1521,10 @@ gulp.task(
 
 gulp.task("testing-pre", function (done) {
   process.env.TESTING = "true";
+  // TODO: Re-write the relevant unit-tests, which are using `new Date(...)`,
+  //       to not required the following time-zone hack since it doesn't work
+  //       when the unit-tests are run directly in the browser.
+  process.env.TZ = "UTC";
   done();
 });
 
@@ -1576,7 +1580,6 @@ gulp.task(
 gulp.task(
   "unittest",
   gulp.series("testing-pre", "generic", "components", function () {
-    process.env.TZ = "UTC";
     return createTestSource("unit");
   })
 );


### PR DESCRIPTION
Currently only the `gulp unittest` task actually set the time-zone, which means that locally I'm now getting failures with e.g. `gulp test`.

*Please note:* I firmly believe that the unit-tests in question should be re-written, since even with this patch applied there's failures when running http://localhost:8888/test/unit/unit_test.html directly in a browser.