### PR TITLE
Add a test-case for bug 1292316

### DIFF
--- a/test/pdfs/bug1292316.pdf.link
+++ b/test/pdfs/bug1292316.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=8777935

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -851,6 +851,14 @@
        "lastPage": 8,
        "type": "eq"
     },
+    {  "id": "bug1292316",
+       "file": "pdfs/bug1292316.pdf",
+       "md5": "f0a815ada0276059242f264653cfd2bc",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue10004",
        "file": "pdfs/issue10004.pdf",
        "md5": "64d1853060cefe3be50e5c4617dd0505",


### PR DESCRIPTION
It appears that the PDF document in [bug 1292316](https://bugzilla.mozilla.org/show_bug.cgi?id=1292316) now renders "correctly"[1] when compared to e.g. Adobe Reader and PDFium. Most likely this bug was fixed by a *somewhat* recent patch, or patches, to the `XRef.indexObjects` method.

Before just closing [bug 1292316](https://bugzilla.mozilla.org/show_bug.cgi?id=1292316) as WFM, I figured that it probably can't hurt to add it as a new test-case to avoid accidentally regressing this document in the future.

---
[1] Given that the XRef table is corrupt, and that we're forced to recover, there's generally speaking probably some question as to what actually constitutes "correct" in this case.