### PR TITLE
Remove the remaining IE 11 polyfills

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -84,7 +84,6 @@ var AUTOPREFIXER_CONFIG = {
     "Chrome >= 49", // Last supported on Windows XP
     "Firefox >= 52", // Last supported on Windows XP
     "Firefox ESR",
-    "IE >= 11",
     "Safari >= 9",
     "> 0.5%",
     "not dead",

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -21,7 +21,7 @@ if (
   (typeof globalThis === "undefined" || !globalThis._pdfjsCompatibilityChecked)
 ) {
   // Provides support for globalThis in legacy browsers.
-  // Support: IE11/Edge, Opera
+  // Support: Firefox<65, Chrome<71, Safari<12.1
   if (typeof globalThis === "undefined" || globalThis.Math !== Math) {
     // eslint-disable-next-line no-global-assign
     globalThis = require("core-js/es/global-this");
@@ -50,62 +50,8 @@ if (
     };
   })();
 
-  // Provides support for String.prototype.startsWith in legacy browsers.
-  // Support: IE, Chrome<41
-  (function checkStringStartsWith() {
-    if (String.prototype.startsWith) {
-      return;
-    }
-    require("core-js/es/string/starts-with.js");
-  })();
-
-  // Provides support for String.prototype.endsWith in legacy browsers.
-  // Support: IE, Chrome<41
-  (function checkStringEndsWith() {
-    if (String.prototype.endsWith) {
-      return;
-    }
-    require("core-js/es/string/ends-with.js");
-  })();
-
-  // Provides support for String.prototype.includes in legacy browsers.
-  // Support: IE, Chrome<41
-  (function checkStringIncludes() {
-    if (String.prototype.includes) {
-      return;
-    }
-    require("core-js/es/string/includes.js");
-  })();
-
-  // Provides support for Array.prototype.includes in legacy browsers.
-  // Support: IE, Chrome<47
-  (function checkArrayIncludes() {
-    if (Array.prototype.includes) {
-      return;
-    }
-    require("core-js/es/array/includes.js");
-  })();
-
-  // Provides support for Array.from in legacy browsers.
-  // Support: IE
-  (function checkArrayFrom() {
-    if (Array.from) {
-      return;
-    }
-    require("core-js/es/array/from.js");
-  })();
-
-  // Provides support for Object.assign in legacy browsers.
-  // Support: IE
-  (function checkObjectAssign() {
-    if (Object.assign) {
-      return;
-    }
-    require("core-js/es/object/assign.js");
-  })();
-
   // Provides support for Object.fromEntries in legacy browsers.
-  // Support: IE, Chrome<73
+  // Support: Firefox<63, Chrome<73, Safari<12.1
   (function checkObjectFromEntries() {
     if (Object.fromEntries) {
       return;
@@ -113,35 +59,8 @@ if (
     require("core-js/es/object/from-entries.js");
   })();
 
-  // Provides support for Math.log2 in legacy browsers.
-  // Support: IE, Chrome<38
-  (function checkMathLog2() {
-    if (Math.log2) {
-      return;
-    }
-    Math.log2 = require("core-js/es/math/log2.js");
-  })();
-
-  // Provides support for Number.isNaN in legacy browsers.
-  // Support: IE.
-  (function checkNumberIsNaN() {
-    if (Number.isNaN) {
-      return;
-    }
-    Number.isNaN = require("core-js/es/number/is-nan.js");
-  })();
-
-  // Provides support for Number.isInteger in legacy browsers.
-  // Support: IE, Chrome<34
-  (function checkNumberIsInteger() {
-    if (Number.isInteger) {
-      return;
-    }
-    Number.isInteger = require("core-js/es/number/is-integer.js");
-  })();
-
   // Provides support for TypedArray.prototype.slice in legacy browsers.
-  // Support: IE
+  // Support: Safari<10
   (function checkTypedArraySlice() {
     if (Uint8Array.prototype.slice) {
       return;
@@ -151,7 +70,7 @@ if (
 
   // Provides support for *recent* additions to the Promise specification,
   // however basic Promise support is assumed to be available natively.
-  // Support: Firefox<71, Safari<13, Chrome<76
+  // Support: Firefox<71, Chrome<76, Safari<13
   (function checkPromise() {
     if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("IMAGE_DECODERS")) {
       // The current image decoders are synchronous, hence `Promise` shouldn't
@@ -164,7 +83,7 @@ if (
     globalThis.Promise = require("core-js/es/promise/index.js");
   })();
 
-  // Support: IE
+  // Support: Safari
   (function checkURL() {
     if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
       // Prevent "require is not a function" errors in development mode,
@@ -182,7 +101,7 @@ if (
     globalThis.URL = require("core-js/web/url.js");
   })();
 
-  // Support: IE, Node.js
+  // Support: Safari<10.1, Node.js
   (function checkReadableStream() {
     if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("IMAGE_DECODERS")) {
       // The current image decoders are synchronous, hence `ReadableStream`
@@ -211,44 +130,8 @@ if (
     globalThis.ReadableStream = require("web-streams-polyfill/dist/ponyfill.js").ReadableStream;
   })();
 
-  // We want to support Map iteration, but it doesn't seem possible to easily
-  // test for that specifically; hence using a similarly unsupported property.
-  // Support: IE11
-  (function checkMapEntries() {
-    if (globalThis.Map && globalThis.Map.prototype.entries) {
-      return;
-    }
-    globalThis.Map = require("core-js/es/map/index.js");
-  })();
-
-  // We want to support Set iteration, but it doesn't seem possible to easily
-  // test for that specifically; hence using a similarly unsupported property.
-  // Support: IE11
-  (function checkSetEntries() {
-    if (globalThis.Set && globalThis.Set.prototype.entries) {
-      return;
-    }
-    globalThis.Set = require("core-js/es/set/index.js");
-  })();
-
-  // Support: IE<11, Safari<8, Chrome<36
-  (function checkWeakMap() {
-    if (globalThis.WeakMap) {
-      return;
-    }
-    globalThis.WeakMap = require("core-js/es/weak-map/index.js");
-  })();
-
-  // Support: IE11
-  (function checkWeakSet() {
-    if (globalThis.WeakSet) {
-      return;
-    }
-    globalThis.WeakSet = require("core-js/es/weak-set/index.js");
-  })();
-
   // Provides support for String.codePointAt in legacy browsers.
-  // Support: IE11.
+  // Support: Safari<10
   (function checkStringCodePointAt() {
     if (String.prototype.codePointAt) {
       return;
@@ -257,7 +140,7 @@ if (
   })();
 
   // Provides support for String.fromCodePoint in legacy browsers.
-  // Support: IE11.
+  // Support: Safari<10
   (function checkStringFromCodePoint() {
     if (String.fromCodePoint) {
       return;
@@ -265,16 +148,8 @@ if (
     String.fromCodePoint = require("core-js/es/string/from-code-point.js");
   })();
 
-  // Support: IE
-  (function checkSymbol() {
-    if (globalThis.Symbol) {
-      return;
-    }
-    require("core-js/es/symbol/index.js");
-  })();
-
   // Provides support for String.prototype.padStart in legacy browsers.
-  // Support: IE, Chrome<57
+  // Support: Chrome<57, Safari<10
   (function checkStringPadStart() {
     if (String.prototype.padStart) {
       return;
@@ -283,7 +158,7 @@ if (
   })();
 
   // Provides support for String.prototype.padEnd in legacy browsers.
-  // Support: IE, Chrome<57
+  // Support: Chrome<57, Safari<10
   (function checkStringPadEnd() {
     if (String.prototype.padEnd) {
       return;
@@ -292,7 +167,7 @@ if (
   })();
 
   // Provides support for Object.values in legacy browsers.
-  // Support: IE, Chrome<54
+  // Support: Chrome<54, Safari<10.1
   (function checkObjectValues() {
     if (Object.values) {
       return;
@@ -301,7 +176,7 @@ if (
   })();
 
   // Provides support for Object.entries in legacy browsers.
-  // Support: IE, Chrome<54
+  // Support: Chrome<54, Safari<10.1
   (function checkObjectEntries() {
     if (Object.entries) {
       return;


### PR DESCRIPTION
We really ought to settle on the *lowest* supported versions of various browsers[1], since that should allow even more clean-up, but given that https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#faq-support *explicitly* lists IE 11 as unsupported after PDF.js version `2.6.347` there's a number of polyfills that are no longer needed.

Based on the MDN compatibility data, this patch thus removes the following polyfills:
 - `String.prototype.startsWith()`, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith#Browser_compatibility

 - `String.prototype.endsWith()`, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith#Browser_compatibility

  - `String.prototype.includes()`, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#Browser_compatibility

 - `Array.prototype.includes()`, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes#Browser_compatibility

  - `Array.from()`, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from#Browser_compatibility

  - `Object.assign()`, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Browser_compatibility

  - `Math.log2()`, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log2#Browser_compatibility

  - `Number.isNaN()`, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN#Browser_compatibility

  - `Number.isInteger()`, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger#Browser_compatibility

  - `Map.prototype.entries()`, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/entries#Browser_compatibility

  - `Set.prototype.entries()`, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/entries#Browser_compatibility

  - `WeakMap`, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap#Browser_compatibility

  - `WeakSet`, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet#Browser_compatibility

  - `Symbol`, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#Browser_compatibility

Finally, this patch also attempts to update the compatibility information for the remaining polyfills.

---
[1] For example: It's questionable if Safari 9 should be listed as supported, given that the last release from that branch was in 2016.