### PR TITLE
Change the minimum "supported" version of the Safari-browser to Safari 10

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -84,7 +84,7 @@ var AUTOPREFIXER_CONFIG = {
     "Chrome >= 49", // Last supported on Windows XP
     "Firefox >= 52", // Last supported on Windows XP
     "Firefox ESR",
-    "Safari >= 9",
+    "Safari >= 10",
     "> 0.5%",
     "not dead",
   ],

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -59,15 +59,6 @@ if (
     require("core-js/es/object/from-entries.js");
   })();
 
-  // Provides support for TypedArray.prototype.slice in legacy browsers.
-  // Support: Safari<10
-  (function checkTypedArraySlice() {
-    if (Uint8Array.prototype.slice) {
-      return;
-    }
-    require("core-js/es/typed-array/slice");
-  })();
-
   // Provides support for *recent* additions to the Promise specification,
   // however basic Promise support is assumed to be available natively.
   // Support: Firefox<71, Chrome<76, Safari<13
@@ -128,24 +119,6 @@ if (
       return;
     }
     globalThis.ReadableStream = require("web-streams-polyfill/dist/ponyfill.js").ReadableStream;
-  })();
-
-  // Provides support for String.codePointAt in legacy browsers.
-  // Support: Safari<10
-  (function checkStringCodePointAt() {
-    if (String.prototype.codePointAt) {
-      return;
-    }
-    require("core-js/es/string/code-point-at.js");
-  })();
-
-  // Provides support for String.fromCodePoint in legacy browsers.
-  // Support: Safari<10
-  (function checkStringFromCodePoint() {
-    if (String.fromCodePoint) {
-      return;
-    }
-    String.fromCodePoint = require("core-js/es/string/from-code-point.js");
   })();
 
   // Provides support for String.prototype.padStart in legacy browsers.


### PR DESCRIPTION
According to https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#faq-support, Safari 9 is still listed as "mostly supported".

Given that the *last* release from the Safari 9 branch was on [September 1, 2016](https://en.wikipedia.org/wiki/Safari_version_history#Safari_9), it's questionable at least to me if it actually makes sense for us to even pretend to "support" such an old browser.
Especially when the *first* release from the Safari 10 branch was on [September 20, 2016](https://en.wikipedia.org/wiki/Safari_version_history#Safari_10), which is now over four years ago.

Based on the MDN compatibility data, this patch thus removes the following polyfills:
 - `TypedArray.prototype.slice()`, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/slice#Browser_compatibility
 - `String.prototype.codePointAt()`, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/codePointAt#Browser_compatibility
 - `String.fromCodePoint()`, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint#Browser_compatibility

