### PR TITLE
Update the events, used with scripting, to use lower-case names and avoid using DOM events internally in the viewer + misc scripting-related tweaks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -97,7 +97,6 @@ const DEFINES = Object.freeze({
   PRODUCTION: true,
   SKIP_BABEL: true,
   TESTING: false,
-  ENABLE_SCRIPTING: false,
   // The main build targets:
   GENERIC: false,
   MOZCENTRAL: false,
@@ -682,7 +681,6 @@ gulp.task("default_preferences-pre", function () {
       LIB: true,
       BUNDLE_VERSION: 0, // Dummy version
       BUNDLE_BUILD: 0, // Dummy build
-      ENABLE_SCRIPTING: process.env.ENABLE_SCRIPTING === "true",
     }),
     map: {
       "pdfjs-lib": "../pdf",
@@ -1551,46 +1549,29 @@ gulp.task("testing-pre", function (done) {
   done();
 });
 
-gulp.task("enable-scripting", function (done) {
-  process.env.ENABLE_SCRIPTING = "true";
-  done();
-});
-
 gulp.task(
   "test",
-  gulp.series(
-    "enable-scripting",
-    "testing-pre",
-    "generic",
-    "components",
-    function () {
-      return streamqueue(
-        { objectMode: true },
-        createTestSource("unit"),
-        createTestSource("browser"),
-        createTestSource("integration")
-      );
-    }
-  )
+  gulp.series("testing-pre", "generic", "components", function () {
+    return streamqueue(
+      { objectMode: true },
+      createTestSource("unit"),
+      createTestSource("browser"),
+      createTestSource("integration")
+    );
+  })
 );
 
 gulp.task(
   "bottest",
-  gulp.series(
-    "enable-scripting",
-    "testing-pre",
-    "generic",
-    "components",
-    function () {
-      return streamqueue(
-        { objectMode: true },
-        createTestSource("unit", true),
-        createTestSource("font", true),
-        createTestSource("browser (no reftest)", true),
-        createTestSource("integration")
-      );
-    }
-  )
+  gulp.series("testing-pre", "generic", "components", function () {
+    return streamqueue(
+      { objectMode: true },
+      createTestSource("unit", true),
+      createTestSource("font", true),
+      createTestSource("browser (no reftest)", true),
+      createTestSource("integration")
+    );
+  })
 );
 
 gulp.task(
@@ -1609,7 +1590,7 @@ gulp.task(
 
 gulp.task(
   "integrationtest",
-  gulp.series("enable-scripting", "testing-pre", "generic", function () {
+  gulp.series("testing-pre", "generic", function () {
     return createTestSource("integration");
   })
 );

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -478,14 +478,13 @@ class LinkAnnotationElement extends AnnotationElement {
         continue;
       }
       link[jsName] = () => {
-        window.dispatchEvent(
-          new CustomEvent("dispatchEventInSandbox", {
-            detail: {
-              id: data.id,
-              name,
-            },
-          })
-        );
+        this.linkService.eventBus?.dispatch("dispatcheventinsandbox", {
+          source: this,
+          detail: {
+            id: data.id,
+            name,
+          },
+        });
         return false;
       };
     }
@@ -551,30 +550,28 @@ class WidgetAnnotationElement extends AnnotationElement {
     if (baseName.includes("mouse")) {
       // Mouse events
       element.addEventListener(baseName, event => {
-        window.dispatchEvent(
-          new CustomEvent("dispatchEventInSandbox", {
-            detail: {
-              id: this.data.id,
-              name: eventName,
-              value: valueGetter(event),
-              shift: event.shiftKey,
-              modifier: this._getKeyModifier(event),
-            },
-          })
-        );
+        this.linkService.eventBus?.dispatch("dispatcheventinsandbox", {
+          source: this,
+          detail: {
+            id: this.data.id,
+            name: eventName,
+            value: valueGetter(event),
+            shift: event.shiftKey,
+            modifier: this._getKeyModifier(event),
+          },
+        });
       });
     } else {
       // Non mouse event
       element.addEventListener(baseName, event => {
-        window.dispatchEvent(
-          new CustomEvent("dispatchEventInSandbox", {
-            detail: {
-              id: this.data.id,
-              name: eventName,
-              value: event.target.checked,
-            },
-          })
-        );
+        this.linkService.eventBus?.dispatch("dispatcheventinsandbox", {
+          source: this,
+          detail: {
+            id: this.data.id,
+            name: eventName,
+            value: event.target.checked,
+          },
+        });
       });
     }
   }
@@ -650,7 +647,7 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
           }
         });
 
-        element.addEventListener("updateFromSandbox", function (event) {
+        element.addEventListener("updatefromsandbox", function (event) {
           const { detail } = event;
           const actions = {
             value() {
@@ -721,19 +718,18 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
             }
             // Save the entered value
             elementData.userValue = event.target.value;
-            window.dispatchEvent(
-              new CustomEvent("dispatchEventInSandbox", {
-                detail: {
-                  id,
-                  name: "Keystroke",
-                  value: event.target.value,
-                  willCommit: true,
-                  commitKey,
-                  selStart: event.target.selectionStart,
-                  selEnd: event.target.selectionEnd,
-                },
-              })
-            );
+            this.linkService.eventBus?.dispatch("dispatcheventinsandbox", {
+              source: this,
+              detail: {
+                id,
+                name: "Keystroke",
+                value: event.target.value,
+                willCommit: true,
+                commitKey,
+                selStart: event.target.selectionStart,
+                selEnd: event.target.selectionEnd,
+              },
+            });
           });
           const _blurListener = blurListener;
           blurListener = null;
@@ -741,19 +737,18 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
             if (this._mouseState.isDown) {
               // Focus out using the mouse: data are committed
               elementData.userValue = event.target.value;
-              window.dispatchEvent(
-                new CustomEvent("dispatchEventInSandbox", {
-                  detail: {
-                    id,
-                    name: "Keystroke",
-                    value: event.target.value,
-                    willCommit: true,
-                    commitKey: 1,
-                    selStart: event.target.selectionStart,
-                    selEnd: event.target.selectionEnd,
-                  },
-                })
-              );
+              this.linkService.eventBus?.dispatch("dispatcheventinsandbox", {
+                source: this,
+                detail: {
+                  id,
+                  name: "Keystroke",
+                  value: event.target.value,
+                  willCommit: true,
+                  commitKey: 1,
+                  selStart: event.target.selectionStart,
+                  selEnd: event.target.selectionEnd,
+                },
+              });
             }
             _blurListener(event);
           });
@@ -783,19 +778,18 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
               if (elementData.beforeInputSelectionRange) {
                 [selStart, selEnd] = elementData.beforeInputSelectionRange;
               }
-              window.dispatchEvent(
-                new CustomEvent("dispatchEventInSandbox", {
-                  detail: {
-                    id,
-                    name: "Keystroke",
-                    value: elementData.beforeInputValue,
-                    change: event.data,
-                    willCommit: false,
-                    selStart,
-                    selEnd,
-                  },
-                })
-              );
+              this.linkService.eventBus?.dispatch("dispatcheventinsandbox", {
+                source: this,
+                detail: {
+                  id,
+                  name: "Keystroke",
+                  value: elementData.beforeInputValue,
+                  change: event.data,
+                  willCommit: false,
+                  selStart,
+                  selEnd,
+                },
+              });
             });
           }
 
@@ -929,7 +923,7 @@ class CheckboxWidgetAnnotationElement extends WidgetAnnotationElement {
     });
 
     if (this.enableScripting && this.hasJSActions) {
-      element.addEventListener("updateFromSandbox", event => {
+      element.addEventListener("updatefromsandbox", event => {
         const { detail } = event;
         const actions = {
           value() {
@@ -1010,7 +1004,7 @@ class RadioButtonWidgetAnnotationElement extends WidgetAnnotationElement {
     });
 
     if (this.enableScripting && this.hasJSActions) {
-      element.addEventListener("updateFromSandbox", event => {
+      element.addEventListener("updatefromsandbox", event => {
         const { detail } = event;
         const actions = {
           value() {
@@ -1132,7 +1126,7 @@ class ChoiceWidgetAnnotationElement extends WidgetAnnotationElement {
     }
 
     if (this.enableScripting && this.hasJSActions) {
-      selectElement.addEventListener("updateFromSandbox", event => {
+      selectElement.addEventListener("updatefromsandbox", event => {
         const { detail } = event;
         const actions = {
           value() {
@@ -1162,22 +1156,21 @@ class ChoiceWidgetAnnotationElement extends WidgetAnnotationElement {
           .forEach(name => actions[name]());
       });
 
-      selectElement.addEventListener("input", function (event) {
+      selectElement.addEventListener("input", event => {
         const value = getValue(event);
         storage.setValue(id, { value });
 
-        window.dispatchEvent(
-          new CustomEvent("dispatchEventInSandbox", {
-            detail: {
-              id,
-              name: "Keystroke",
-              changeEx: value,
-              willCommit: true,
-              commitKey: 1,
-              keyDown: false,
-            },
-          })
-        );
+        this.linkService.eventBus?.dispatch("dispatcheventinsandbox", {
+          source: this,
+          detail: {
+            id,
+            name: "Keystroke",
+            changeEx: value,
+            willCommit: true,
+            commitKey: 1,
+            keyDown: false,
+          },
+        });
       });
 
       this._setEventListeners(
@@ -1852,14 +1845,12 @@ class FileAttachmentAnnotationElement extends AnnotationElement {
     this.filename = getFilenameFromUrl(filename);
     this.content = content;
 
-    if (this.linkService.eventBus) {
-      this.linkService.eventBus.dispatch("fileattachmentannotation", {
-        source: this,
-        id: stringToPDFString(filename),
-        filename,
-        content,
-      });
-    }
+    this.linkService.eventBus?.dispatch("fileattachmentannotation", {
+      source: this,
+      id: stringToPDFString(filename),
+      filename,
+      content,
+    });
   }
 
   render() {

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -47,6 +47,7 @@ import { ColorConverters } from "../shared/scripting_utils.js";
  * @property {Object} svgFactory
  * @property {boolean} [enableScripting]
  * @property {boolean} [hasJSActions]
+ * @property {Object} [mouseState]
  */
 
 class AnnotationElementFactory {
@@ -155,6 +156,7 @@ class AnnotationElement {
     this.annotationStorage = parameters.annotationStorage;
     this.enableScripting = parameters.enableScripting;
     this.hasJSActions = parameters.hasJSActions;
+    this._mouseState = parameters.mouseState;
 
     if (isRenderable) {
       this.container = this._createContainer(ignoreBorder);
@@ -590,7 +592,6 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
       parameters.renderInteractiveForms ||
       (!parameters.data.hasAppearance && !!parameters.data.fieldValue);
     super(parameters, { isRenderable });
-    this.mouseState = parameters.mouseState;
   }
 
   render() {
@@ -734,7 +735,7 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
           const _blurListener = blurListener;
           blurListener = null;
           element.addEventListener("blur", event => {
-            if (this.mouseState.isDown) {
+            if (this._mouseState.isDown) {
               // Focus out using the mouse: data are committed
               elementData.userValue = event.target.value;
               window.dispatchEvent(
@@ -1951,7 +1952,7 @@ class AnnotationLayer {
           parameters.annotationStorage || new AnnotationStorage(),
         enableScripting: parameters.enableScripting,
         hasJSActions: parameters.hasJSActions,
-        mouseState: parameters.mouseState,
+        mouseState: parameters.mouseState || { isDown: false },
       });
       if (element.isRenderable) {
         const rendered = element.render();

--- a/src/pdf.sandbox.external.js
+++ b/src/pdf.sandbox.external.js
@@ -148,7 +148,7 @@ class SandboxSupportBase {
         if (!data) {
           return;
         }
-        const event = new this.win.CustomEvent("updateFromSandbox", {
+        const event = new this.win.CustomEvent("updatefromsandbox", {
           detail: this.importValueFromSandbox(data),
         });
         this.win.dispatchEvent(event);

--- a/src/pdf.sandbox.js
+++ b/src/pdf.sandbox.js
@@ -63,8 +63,6 @@ class Sandbox {
     }
     const sandboxData = JSON.stringify(data);
     const code = [
-      // Next line is replaced by code from initialization.js
-      // when we create the bundle for the sandbox.
       PDFJSDev.eval("PDF_SCRIPTING_JS_SOURCE"),
       `pdfjsScripting.initSandbox({ data: ${sandboxData} })`,
     ];

--- a/test/integration/scripting_spec.js
+++ b/test/integration/scripting_spec.js
@@ -30,9 +30,12 @@ describe("Interaction", () => {
     it("must check that first text field has focus", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
+          await page.waitForFunction(
+            "window.PDFViewerApplication.scriptingReady === true"
+          );
+
           // The document has an open action in order to give
           // the focus to 401R.
-          await page.waitForTimeout(1000);
           const id = await page.evaluate(
             () => window.document.activeElement.id
           );

--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -30,6 +30,7 @@ import { SimpleLinkService } from "./pdf_link_service.js";
  * @property {IL10n} l10n - Localization service.
  * @property {boolean} [enableScripting]
  * @property {Promise<boolean>} [hasJSActionsPromise]
+ * @property {Object} [mouseState]
  */
 
 class AnnotationLayerBuilder {

--- a/web/app.js
+++ b/web/app.js
@@ -794,6 +794,7 @@ const PDFViewerApplication = {
     }
     events.clear();
 
+    delete this._mouseState.isDown;
     this._scriptingInstance = null;
   },
 

--- a/web/app.js
+++ b/web/app.js
@@ -1036,13 +1036,10 @@ const PDFViewerApplication = {
       this.download({ sourceEventType });
       return;
     }
-
-    if (this._scriptingInstance) {
-      this._scriptingInstance.scripting.dispatchEventInSandbox({
-        id: "doc",
-        name: "WillSave",
-      });
-    }
+    this._scriptingInstance?.scripting.dispatchEventInSandbox({
+      id: "doc",
+      name: "WillSave",
+    });
 
     this._saveInProgress = true;
     this.pdfDocument
@@ -1051,12 +1048,10 @@ const PDFViewerApplication = {
         const blob = new Blob([data], { type: "application/pdf" });
         downloadManager.download(blob, url, filename, sourceEventType);
 
-        if (this._scriptingInstance) {
-          this._scriptingInstance.scripting.dispatchEventInSandbox({
-            id: "doc",
-            name: "DidSave",
-          });
-        }
+        this._scriptingInstance?.scripting.dispatchEventInSandbox({
+          id: "doc",
+          name: "DidSave",
+        });
       })
       .catch(() => {
         this.download({ sourceEventType });
@@ -1514,15 +1509,15 @@ const PDFViewerApplication = {
             break;
           case "layout":
             this.pdfViewer.spreadMode = apiPageLayoutToSpreadMode(value);
-            return;
+            break;
           case "page-num":
             this.pdfViewer.currentPageNumber = value + 1;
-            return;
+            break;
           case "print":
             this.pdfViewer.pagesPromise.then(() => {
               this.triggerPrinting();
             });
-            return;
+            break;
           case "println":
             console.log(value);
             break;
@@ -1608,7 +1603,9 @@ const PDFViewerApplication = {
       }
     } catch (error) {
       console.error(`_initializeJavaScript: "${error?.message}".`);
+
       this._destroyScriptingInstance();
+      return;
     }
 
     scripting.dispatchEventInSandbox({
@@ -2033,21 +2030,17 @@ const PDFViewerApplication = {
     if (!this.supportsPrinting) {
       return;
     }
-    if (this._scriptingInstance) {
-      this._scriptingInstance.scripting.dispatchEventInSandbox({
-        id: "doc",
-        name: "WillPrint",
-      });
-    }
+    this._scriptingInstance?.scripting.dispatchEventInSandbox({
+      id: "doc",
+      name: "WillPrint",
+    });
 
     window.print();
 
-    if (this._scriptingInstance) {
-      this._scriptingInstance.scripting.dispatchEventInSandbox({
-        id: "doc",
-        name: "DidPrint",
-      });
-    }
+    this._scriptingInstance?.scripting.dispatchEventInSandbox({
+      id: "doc",
+      name: "DidPrint",
+    });
   },
 
   bindEvents() {

--- a/web/app.js
+++ b/web/app.js
@@ -1480,7 +1480,12 @@ const PDFViewerApplication = {
     // of the sandbox and removal of the event listeners at document closing.
     const internalEvents = new Map(),
       domEvents = new Map();
-    this._scriptingInstance = { scripting, internalEvents, domEvents };
+    this._scriptingInstance = {
+      scripting,
+      ready: false,
+      internalEvents,
+      domEvents,
+    };
 
     if (!this.documentInfo) {
       // It should be *extremely* rare for metadata to not have been resolved
@@ -1611,6 +1616,15 @@ const PDFViewerApplication = {
     scripting.dispatchEventInSandbox({
       id: "doc",
       name: "Open",
+    });
+
+    // Used together with the integration-tests, see the `scriptingReady`
+    // getter, to enable awaiting full initialization of the scripting/sandbox.
+    // (Defer this slightly, to make absolutely sure that everything is done.)
+    Promise.resolve().then(() => {
+      if (this._scriptingInstance) {
+        this._scriptingInstance.ready = true;
+      }
     });
   },
 
@@ -2241,6 +2255,14 @@ const PDFViewerApplication = {
       Math.floor(Math.abs(this._wheelUnusedTicks));
     this._wheelUnusedTicks -= wholeTicks;
     return wholeTicks;
+  },
+
+  /**
+   * Used together with the integration-tests, to enable awaiting full
+   * initialization of the scripting/sandbox.
+   */
+  get scriptingReady() {
+    return this._scriptingInstance?.ready || false;
   },
 };
 

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -67,7 +67,7 @@ const defaultOptions = {
   },
   enableScripting: {
     /** @type {boolean} */
-    value: typeof PDFJSDev !== "undefined" && PDFJSDev.test("ENABLE_SCRIPTING"),
+    value: typeof PDFJSDev !== "undefined" && PDFJSDev.test("TESTING"),
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
   enableWebGL: {
@@ -249,7 +249,7 @@ if (
 ) {
   defaultOptions.disablePreferences = {
     /** @type {boolean} */
-    value: false,
+    value: typeof PDFJSDev !== "undefined" && PDFJSDev.test("TESTING"),
     kind: OptionKind.VIEWER,
   };
   defaultOptions.locale = {
@@ -260,8 +260,7 @@ if (
   defaultOptions.sandboxBundleSrc = {
     /** @type {string} */
     value:
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION && !ENABLE_SCRIPTING")
+      typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")
         ? "../build/dev-sandbox/pdf.sandbox.js"
         : "../build/pdf.sandbox.js",
     kind: OptionKind.VIEWER,

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -79,7 +79,8 @@ const DEFAULT_CACHE_SIZE = 10;
  * @property {IL10n} l10n - Localization service.
  * @property {boolean} [enableScripting] - Enable embedded script execution.
  *   The default value is `false`.
- * @property {Object} [mouseState] - The mouse button state.
+ * @property {Object} [mouseState] - The mouse button state. The default value
+ *   is `null`.
  */
 
 function PDFPageViewBuffer(size) {
@@ -195,7 +196,7 @@ class BaseViewer {
     this.maxCanvasPixels = options.maxCanvasPixels;
     this.l10n = options.l10n || NullL10n;
     this.enableScripting = options.enableScripting || false;
-    this.mouseState = options.mouseState || null;
+    this._mouseState = options.mouseState || null;
 
     this.defaultRenderingQueue = !options.renderingQueue;
     if (this.defaultRenderingQueue) {
@@ -540,7 +541,6 @@ class BaseViewer {
             maxCanvasPixels: this.maxCanvasPixels,
             l10n: this.l10n,
             enableScripting: this.enableScripting,
-            mouseState: this.mouseState,
           });
           this._pages.push(pageView);
         }
@@ -1301,7 +1301,7 @@ class BaseViewer {
       enableScripting,
       hasJSActionsPromise:
         hasJSActionsPromise || this.pdfDocument?.hasJSActions(),
-      mouseState,
+      mouseState: mouseState || this._mouseState,
     });
   }
 

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -255,12 +255,12 @@ class FirefoxComDataRangeTransport extends PDFDataRangeTransport {
 }
 
 class FirefoxScripting {
-  static createSandbox(data) {
+  static async createSandbox(data) {
     return new Promise(resolve => {
       FirefoxCom.request("createSandbox", data, resolve);
     }).then(success => {
       if (!success) {
-        throw new Error("Cannot start sandbox");
+        throw new Error("Cannot create sandbox.");
       }
     });
   }

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -63,7 +63,6 @@ import { viewerCompatibilityParams } from "./viewer_compatibility.js";
  * @property {IL10n} l10n - Localization service.
  * @property {boolean} [enableScripting] - Enable embedded script execution.
  *   The default value is `false`.
- * @property {Object} [mouseState] - The mouse button state.
  */
 
 const MAX_CANVAS_PIXELS = viewerCompatibilityParams.maxCanvasPixels || 16777216;
@@ -110,7 +109,6 @@ class PDFPageView {
     this.enableWebGL = options.enableWebGL || false;
     this.l10n = options.l10n || NullL10n;
     this.enableScripting = options.enableScripting || false;
-    this.mouseState = options.mouseState || null;
 
     this.paintTask = null;
     this.paintedViewportMap = new WeakMap();
@@ -554,7 +552,7 @@ class PDFPageView {
           this.l10n,
           this.enableScripting,
           /* hasJSActionsPromise = */ null,
-          this.mouseState
+          /* mouseState = */ null
         );
       }
       this._renderAnnotationLayer();


### PR DESCRIPTION
*Please refer to the individual commit messages for additional information.*

Also, ignoring white-space changes when viewing the larger patches should be helpful.