### PR TITLE
Ignore, rather than throwing on, Coding style component (COC) markers in JPEG 2000 images (issue 12752)

### DIFF
--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -392,6 +392,9 @@ var JpxImage = (function JpxImageClosure() {
               length = tile.dataEnd - position;
               parseTilePackets(context, data, position, length);
               break;
+            case 0xff53: // Coding style component (COC)
+              warn("JPX: Codestream code 0xFF53 (COC) is not implemented.");
+            /* falls through */
             case 0xff55: // Tile-part lengths, main header (TLM)
             case 0xff57: // Packet length, main header (PLM)
             case 0xff58: // Packet length, tile-part header (PLT)
@@ -399,10 +402,6 @@ var JpxImage = (function JpxImageClosure() {
               length = readUint16(data, position);
               // skipping content
               break;
-            case 0xff53: // Coding style component (COC)
-              throw new Error(
-                "Codestream code 0xFF53 (COC) is not implemented"
-              );
             default:
               throw new Error("Unknown codestream code: " + code.toString(16));
           }

--- a/test/pdfs/issue12752.pdf.link
+++ b/test/pdfs/issue12752.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/5715933/WE2330Ausweis_2.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2045,6 +2045,14 @@
        "link": true,
        "type": "eq"
     },
+    {  "id": "issue12752",
+       "file": "pdfs/issue12752.pdf",
+       "md5": "9f8ada17a613d18919714baf684e165f",
+       "rounds": 1,
+       "lastPage": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "issue7872",
        "file": "pdfs/issue7872.pdf",
        "md5": "81781dfecfcb7e9cd9cc7e60f8b747b7",


### PR DESCRIPTION
Similar to other markers that we currently skip, by ignoring the Coding style component (COC) marker we'll at least prevent outright errors (although some JPEG 2000 images may look slightly wrong).

Fixes #12752