### PR TITLE
JS -- in integration test, wait for open actions

### DIFF
--- a/src/scripting_api/doc.js
+++ b/src/scripting_api/doc.js
@@ -109,6 +109,7 @@ class Doc extends PDFObject {
         }
       }
       this._runActions("OpenAction");
+      this._send({ command: "opendocfinished" });
     } else {
       this._runActions(name);
     }

--- a/test/integration/scripting_spec.js
+++ b/test/integration/scripting_spec.js
@@ -30,9 +30,12 @@ describe("Interaction", () => {
     it("must check that first text field has focus", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
+          await page.waitForFunction(
+            "window.PDFViewerApplication.opendocfinished === true"
+          );
+
           // The document has an open action in order to give
           // the focus to 401R.
-          await page.waitForTimeout(1000);
           const id = await page.evaluate(
             () => window.document.activeElement.id
           );

--- a/web/app.js
+++ b/web/app.js
@@ -1525,6 +1525,11 @@ const PDFViewerApplication = {
               this.pdfViewer.currentScale = value;
             }
             break;
+          case "opendocfinished":
+            if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("TESTING")) {
+              this.opendocfinished = true;
+            }
+            break;
         }
         return;
       }


### PR DESCRIPTION
Aims to fix intermittent failures in integration tests