### PR TITLE
Annotation -- Don't compute appearance when nothing has changed

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -603,7 +603,7 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
       // NOTE: We cannot set the values using `element.value` below, since it
       //       prevents the AnnotationLayer rasterizer in `test/driver.js`
       //       from parsing the elements correctly for the reference tests.
-      const textContent = storage.getOrCreateValue(id, {
+      const textContent = storage.getValue(id, {
         value: this.data.fieldValue,
       }).value;
       const elementData = {
@@ -873,7 +873,7 @@ class CheckboxWidgetAnnotationElement extends WidgetAnnotationElement {
     const storage = this.annotationStorage;
     const data = this.data;
     const id = data.id;
-    const value = storage.getOrCreateValue(id, {
+    const value = storage.getValue(id, {
       value:
         data.fieldValue &&
         ((data.exportValue && data.exportValue === data.fieldValue) ||
@@ -962,7 +962,7 @@ class RadioButtonWidgetAnnotationElement extends WidgetAnnotationElement {
     const storage = this.annotationStorage;
     const data = this.data;
     const id = data.id;
-    const value = storage.getOrCreateValue(id, {
+    const value = storage.getValue(id, {
       value: data.fieldValue === data.buttonValue,
     }).value;
 
@@ -1072,9 +1072,9 @@ class ChoiceWidgetAnnotationElement extends WidgetAnnotationElement {
     // are not properly printed/saved yet, so we only store the first item in
     // the field value array instead of the entire array. Once support for those
     // two field types is implemented, we should use the same pattern as the
-    // other interactive widgets where the return value of `getOrCreateValue` is
-    // used and the full array of field values is stored.
-    storage.getOrCreateValue(id, {
+    // other interactive widgets where the return value of `getValue`
+    // is used and the full array of field values is stored.
+    storage.getValue(id, {
       value:
         this.data.fieldValue.length > 0 ? this.data.fieldValue[0] : undefined,
     });

--- a/src/display/annotation_storage.js
+++ b/src/display/annotation_storage.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import { deprecated } from "./display_utils.js";
 import { objectFromEntries } from "../shared/util.js";
 
 /**
@@ -33,7 +34,7 @@ class AnnotationStorage {
 
   /**
    * Get the value for a given key if it exists
-   * or store and return the default value
+   * or return the default value
    *
    * @public
    * @memberof AnnotationStorage
@@ -41,7 +42,19 @@ class AnnotationStorage {
    * @param {Object} defaultValue
    * @returns {Object}
    */
+  getValue(key, defaultValue) {
+    if (this._storage.has(key)) {
+      return this._storage.get(key);
+    }
+
+    return defaultValue;
+  }
+
+  /**
+   * @deprecated
+   */
   getOrCreateValue(key, defaultValue) {
+    deprecated("Use getValue instead.");
     if (this._storage.has(key)) {
       return this._storage.get(key);
     }

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -1808,7 +1808,7 @@ describe("annotation", function () {
         }, done.fail)
         .then(appearance => {
           expect(appearance).toEqual(
-            "/Tx BMC q BT /Helv 11 Tf 0 g 1 0 0 1 0 0 Tm" +
+            "/Tx BMC q BT /Helv 8 Tf 0 g 1 0 0 1 0 0 Tm" +
               " 2.00 2.00 Td (test \\(print\\)) Tj ET Q EMC"
           );
           done();
@@ -1848,7 +1848,7 @@ describe("annotation", function () {
             "\x30\x53\x30\x93\x30\x6b\x30\x61" +
             "\x30\x6f\x4e\x16\x75\x4c\x30\x6e";
           expect(appearance).toEqual(
-            "/Tx BMC q BT /Goth 9 Tf 0 g 1 0 0 1 0 0 Tm" +
+            "/Tx BMC q BT /Goth 8 Tf 0 g 1 0 0 1 0 0 Tm" +
               ` 2.00 2.00 Td (${utf16String}) Tj ET Q EMC`
           );
           done();

--- a/test/unit/annotation_storage_spec.js
+++ b/test/unit/annotation_storage_spec.js
@@ -16,17 +16,21 @@
 import { AnnotationStorage } from "../../src/display/annotation_storage.js";
 
 describe("AnnotationStorage", function () {
-  describe("GetOrCreateValue", function () {
+  describe("GetOrDefaultValue", function () {
     it("should get and set a new value in the annotation storage", function (done) {
       const annotationStorage = new AnnotationStorage();
-      let value = annotationStorage.getOrCreateValue("123A", {
+      let value = annotationStorage.getValue("123A", {
         value: "hello world",
       }).value;
       expect(value).toEqual("hello world");
 
+      annotationStorage.setValue("123A", {
+        value: "hello world",
+      });
+
       // the second argument is the default value to use
       // if the key isn't in the storage
-      value = annotationStorage.getOrCreateValue("123A", {
+      value = annotationStorage.getValue("123A", {
         value: "an other string",
       }).value;
       expect(value).toEqual("hello world");
@@ -50,16 +54,18 @@ describe("AnnotationStorage", function () {
         called = true;
       };
       annotationStorage.onSetModified = callback;
-      annotationStorage.getOrCreateValue("asdf", { value: "original" });
-      expect(called).toBe(false);
 
-      // not changing value
       annotationStorage.setValue("asdf", { value: "original" });
-      expect(called).toBe(false);
+      expect(called).toBe(true);
 
       // changing value
       annotationStorage.setValue("asdf", { value: "modified" });
       expect(called).toBe(true);
+
+      // not changing value
+      called = false;
+      annotationStorage.setValue("asdf", { value: "modified" });
+      expect(called).toBe(false);
       done();
     });
   });
@@ -72,7 +78,10 @@ describe("AnnotationStorage", function () {
         called = true;
       };
       annotationStorage.onResetModified = callback;
-      annotationStorage.getOrCreateValue("asdf", { value: "original" });
+      annotationStorage.setValue("asdf", { value: "original" });
+      annotationStorage.resetModified();
+      expect(called).toBe(true);
+      called = false;
 
       // not changing value
       annotationStorage.setValue("asdf", { value: "original" });


### PR DESCRIPTION
 * don't set a value in annotationStorage by default:
   - having an undefined when the annotation is rendered for saving/printing means nothing has changed so use normal appearance
   - aims to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1681687
 * change the way to compute font size when this one is null in DA:
   - make fontSize proportional to line height
   - in multiline case, take into account the number of lines for text entered to adapt the font size