### PR TITLE
Stop running `gulp components` as part of the unit-tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1583,7 +1583,7 @@ gulp.task(
 
 gulp.task(
   "unittest",
-  gulp.series("testing-pre", "generic", "components", function () {
+  gulp.series("testing-pre", "generic", function () {
     return createTestSource("unit");
   })
 );


### PR DESCRIPTION
The `gulp components` task is only necessary when running the reference-tests, since they use the `SimpleLinkService` during the `annotationLayer` sub-tests.
However, unit-tests don't actually use any part of the `gulp components` build, and we can thus reduce the overall runtime of the standalone unit-tests by not building unnecessary files.