### PR TITLE
Await manually triggered `dispatchEventInSandbox` calls in the viewer

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1013,7 +1013,7 @@ const PDFViewerApplication = {
       .catch(downloadByUrl); // Error occurred, try downloading with the URL.
   },
 
-  save({ sourceEventType = "download" } = {}) {
+  async save({ sourceEventType = "download" } = {}) {
     if (this._saveInProgress) {
       return;
     }
@@ -1036,19 +1036,20 @@ const PDFViewerApplication = {
       this.download({ sourceEventType });
       return;
     }
-    this._scriptingInstance?.scripting.dispatchEventInSandbox({
+    this._saveInProgress = true;
+
+    await this._scriptingInstance?.scripting.dispatchEventInSandbox({
       id: "doc",
       name: "WillSave",
     });
 
-    this._saveInProgress = true;
     this.pdfDocument
       .saveDocument(this.pdfDocument.annotationStorage)
-      .then(data => {
+      .then(async data => {
         const blob = new Blob([data], { type: "application/pdf" });
         downloadManager.download(blob, url, filename, sourceEventType);
 
-        this._scriptingInstance?.scripting.dispatchEventInSandbox({
+        await this._scriptingInstance?.scripting.dispatchEventInSandbox({
           id: "doc",
           name: "DidSave",
         });
@@ -1614,7 +1615,7 @@ const PDFViewerApplication = {
       return;
     }
 
-    scripting.dispatchEventInSandbox({
+    await scripting.dispatchEventInSandbox({
       id: "doc",
       name: "Open",
     });
@@ -2058,18 +2059,18 @@ const PDFViewerApplication = {
     this.pdfPresentationMode.request();
   },
 
-  triggerPrinting() {
+  async triggerPrinting() {
     if (!this.supportsPrinting) {
       return;
     }
-    this._scriptingInstance?.scripting.dispatchEventInSandbox({
+    await this._scriptingInstance?.scripting.dispatchEventInSandbox({
       id: "doc",
       name: "WillPrint",
     });
 
     window.print();
 
-    this._scriptingInstance?.scripting.dispatchEventInSandbox({
+    await this._scriptingInstance?.scripting.dispatchEventInSandbox({
       id: "doc",
       name: "DidPrint",
     });

--- a/web/app.js
+++ b/web/app.js
@@ -167,7 +167,7 @@ class DefaultExternalServices {
     throw new Error("Not implemented: createL10n");
   }
 
-  static createScripting() {
+  static createScripting(options) {
     throw new Error("Not implemented: createScripting");
   }
 
@@ -1477,7 +1477,12 @@ const PDFViewerApplication = {
     if (pdfDocument !== this.pdfDocument) {
       return; // The document was closed while the data resolved.
     }
-    const scripting = this.externalServices.createScripting();
+    const scripting = this.externalServices.createScripting(
+      typeof PDFJSDev === "undefined" ||
+        PDFJSDev.test("!PRODUCTION || GENERIC || CHROME")
+        ? { sandboxBundleSrc: AppOptions.get("sandboxBundleSrc") }
+        : null
+    );
     // Store a reference to the current scripting-instance, to allow destruction
     // of the sandbox and removal of the event listeners at document closing.
     const internalEvents = new Map(),

--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -430,8 +430,8 @@ class ChromeExternalServices extends DefaultExternalServices {
     return new GenericL10n(navigator.language);
   }
 
-  static createScripting() {
-    return new GenericScripting();
+  static createScripting({ sandboxBundleSrc }) {
+    return new GenericScripting(sandboxBundleSrc);
   }
 }
 PDFViewerApplication.externalServices = ChromeExternalServices;

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -366,7 +366,7 @@ class FirefoxExternalServices extends DefaultExternalServices {
     return new MozL10n(mozL10n);
   }
 
-  static createScripting() {
+  static createScripting(options) {
     return FirefoxScripting;
   }
 

--- a/web/generic_scripting.js
+++ b/web/generic_scripting.js
@@ -13,13 +13,12 @@
  * limitations under the License.
  */
 
-import { AppOptions } from "./app_options.js";
 import { loadScript } from "pdfjs-lib";
 
 class GenericScripting {
-  constructor() {
+  constructor(sandboxBundleSrc) {
     this._ready = loadScript(
-      AppOptions.get("sandboxBundleSrc"),
+      sandboxBundleSrc,
       /* removeScriptElement = */ true
     ).then(() => {
       return window.pdfjsSandbox.QuickJSSandbox();

--- a/web/genericcom.js
+++ b/web/genericcom.js
@@ -51,8 +51,8 @@ class GenericExternalServices extends DefaultExternalServices {
     return new GenericL10n(locale);
   }
 
-  static createScripting() {
-    return new GenericScripting();
+  static createScripting({ sandboxBundleSrc }) {
+    return new GenericScripting(sandboxBundleSrc);
   }
 }
 PDFViewerApplication.externalServices = GenericExternalServices;


### PR DESCRIPTION
 - Await manually triggered `dispatchEventInSandbox` calls in the viewer

   *As usual, this only occured to me after the recent round of scripting-related patches had landed.*

   Given that the `dispatchEventInSandbox` method (on the scripting-classes) is asynchronous, there's a very real risk that things such as e.g. "WillPrint" and "WillSave" are dispatched/handled *after* the associated functionality has run.
   To reduce the likelihood of that happening, we can simply `await` the `dispatchEventInSandbox` calls as necessary. A couple of methods are now marked as `async` to support these changes, however that shouldn't be a problem as far as I can tell.

 - Pass in the "sandboxBundleSrc" option when calling `DefaultExternalServices.createScripting`

   Similar to e.g. the "locale" option, this in *only* done for those build-targets where the "sandboxBundleSrc" is actually defined.
   With these changes we can remove an `AppOptions` dependency from the `web/generic_scripting.js` file, thus limiting *direct* `AppOptions` usage in the default viewer files.



