### PR TITLE
Ignore, rather than throwing on, unsupported Coding style default (COD) options in JPEG 2000 images (issue 11004)

### DIFF
--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -351,8 +351,8 @@ var JpxImage = (function JpxImageClosure() {
               }
               if (unsupported.length > 0) {
                 doNotRecover = true;
-                throw new Error(
-                  "Unsupported COD options (" + unsupported.join(", ") + ")"
+                warn(
+                  `JPX: Unsupported COD options (${unsupported.join(", ")}).`
                 );
               }
               if (context.mainHeader) {
@@ -411,7 +411,7 @@ var JpxImage = (function JpxImageClosure() {
         if (doNotRecover || this.failOnCorruptedImage) {
           throw new JpxError(e.message);
         } else {
-          warn("JPX: Trying to recover from: " + e.message);
+          warn(`JPX: Trying to recover from: "${e.message}".`);
         }
       }
       this.tiles = transformComponents(context);

--- a/test/pdfs/issue11004.pdf.link
+++ b/test/pdfs/issue11004.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/3422968/problem.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2051,6 +2051,14 @@
        "link": true,
        "type": "eq"
     },
+    {  "id": "issue11004",
+       "file": "pdfs/issue11004.pdf",
+       "md5": "25d79508f2c9ef0e2327564966138fc1",
+       "rounds": 1,
+       "lastPage": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "issue12752",
        "file": "pdfs/issue12752.pdf",
        "md5": "9f8ada17a613d18919714baf684e165f",


### PR DESCRIPTION
Similar to other markers that we currently skip, by ignoring unsupported Coding style default (COD) options we'll at least render *something* here (although some JPEG 2000 images may look slightly wrong).
Note that if the unsupported COD options lead to additional errors, during parsing, we'll still abort parsing of the JPEG 2000 image.

Fixes #11004