### PR TITLE
[Scripting] Try to ensure that the `WillPrint`/`DidPrint` respectively `DidSave` events are always dispatched

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1047,16 +1047,16 @@ const PDFViewerApplication = {
       .then(data => {
         const blob = new Blob([data], { type: "application/pdf" });
         downloadManager.download(blob, url, filename, sourceEventType);
-
-        this._scriptingInstance?.scripting.dispatchEventInSandbox({
-          id: "doc",
-          name: "DidSave",
-        });
       })
       .catch(() => {
         this.download({ sourceEventType });
       })
       .finally(() => {
+        this._scriptingInstance?.scripting.dispatchEventInSandbox({
+          id: "doc",
+          name: "DidSave",
+        });
+
         this._saveInProgress = false;
       });
   },
@@ -1967,6 +1967,11 @@ const PDFViewerApplication = {
   },
 
   beforePrint() {
+    this._scriptingInstance?.scripting.dispatchEventInSandbox({
+      id: "doc",
+      name: "WillPrint",
+    });
+
     if (this.printService) {
       // There is no way to suppress beforePrint/afterPrint events,
       // but PDFPrintService may generate double events -- this will ignore
@@ -2028,6 +2033,11 @@ const PDFViewerApplication = {
   },
 
   afterPrint() {
+    this._scriptingInstance?.scripting.dispatchEventInSandbox({
+      id: "doc",
+      name: "DidPrint",
+    });
+
     if (this.printService) {
       this.printService.destroy();
       this.printService = null;
@@ -2060,17 +2070,7 @@ const PDFViewerApplication = {
     if (!this.supportsPrinting) {
       return;
     }
-    this._scriptingInstance?.scripting.dispatchEventInSandbox({
-      id: "doc",
-      name: "WillPrint",
-    });
-
     window.print();
-
-    this._scriptingInstance?.scripting.dispatchEventInSandbox({
-      id: "doc",
-      name: "DidPrint",
-    });
   },
 
   bindEvents() {


### PR DESCRIPTION
 - [Scripting] Try to ensure that the `WillPrint`/`DidPrint` respectively `DidSave` events are always dispatched
 
   Note that currently the `DidSave` event is not *guaranteed* to actually be dispatched if there's any errors during saving, which is easily fixed by simply moving it to occur in the `finally`-handler in `PDFViewerApplication.save` method.

   For the `WillPrint`/`DidPrint` events, things are unfortunately more complicated. Currently these events will *only* be dispatched iff the printing request comes from within the viewer itself (e.g. by the user clicking on the "Print" toolbar button), however printing can be triggered in a few additional ways:
    - In the GENERIC viewer:
      - By the <kbd>Ctrl</kbd>+<kbd>P</kbd> keyboard shortcut.
    - In the MOZCENTRAL viewer, i.e. the Firefox built-in viewer:
      - By the <kbd>Ctrl</kbd>+<kbd>P</kbd> keyboard shortcut.
      - By the "Print" item, as found in either the Firefox "Hamburger menu" or in the browser-window menu.

   In either of the cases described above, no `WillPrint`/`DidPrint` events will be dispatched. In order to *guarantee* that things work in the general case, we thus have to move the `dispatchEventInSandbox` calls to the "beforeprint"/"afterprint" event handlers instead.

- [Scripting] Await manually triggered `dispatchEventInSandbox` calls in the viewer

   Given that the `dispatchEventInSandbox` method (on the scripting-classes) is asynchronous, there's a very real risk that the events won't be dispatched/handled until *after* their associated functionality has actually run (with the "Will..." events being particularily susceptible to this issue).
   To reduce the likelihood of that happening, we can simply `await` the `dispatchEventInSandbox` calls as necessary. A couple of methods are now marked as `async` to support these changes, however that shouldn't be a problem as far as I can tell.

   *Please note:* Given that the browser "beforeprint"/"afterprint" events are *synchronous*, we unfortunately cannot await the `WillPrint`/`DidPrint` event dispatching. To fix this properly the web-platform would need support for asynchronous printing, and we'll thus have to hope that things work correctly anyway.

/cc @calixteman 

