### PR TITLE
Pass in the "sandboxBundleSrc" option when calling `DefaultExternalServices.createScripting`

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -167,7 +167,7 @@ class DefaultExternalServices {
     throw new Error("Not implemented: createL10n");
   }
 
-  static createScripting() {
+  static createScripting(options) {
     throw new Error("Not implemented: createScripting");
   }
 
@@ -1476,7 +1476,12 @@ const PDFViewerApplication = {
     if (pdfDocument !== this.pdfDocument) {
       return; // The document was closed while the data resolved.
     }
-    const scripting = this.externalServices.createScripting();
+    const scripting = this.externalServices.createScripting(
+      typeof PDFJSDev === "undefined" ||
+        PDFJSDev.test("!PRODUCTION || GENERIC || CHROME")
+        ? { sandboxBundleSrc: AppOptions.get("sandboxBundleSrc") }
+        : null
+    );
     // Store a reference to the current scripting-instance, to allow destruction
     // of the sandbox and removal of the event listeners at document closing.
     const internalEvents = new Map(),

--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -430,8 +430,8 @@ class ChromeExternalServices extends DefaultExternalServices {
     return new GenericL10n(navigator.language);
   }
 
-  static createScripting() {
-    return new GenericScripting();
+  static createScripting({ sandboxBundleSrc }) {
+    return new GenericScripting(sandboxBundleSrc);
   }
 }
 PDFViewerApplication.externalServices = ChromeExternalServices;

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -366,7 +366,7 @@ class FirefoxExternalServices extends DefaultExternalServices {
     return new MozL10n(mozL10n);
   }
 
-  static createScripting() {
+  static createScripting(options) {
     return FirefoxScripting;
   }
 

--- a/web/generic_scripting.js
+++ b/web/generic_scripting.js
@@ -13,13 +13,12 @@
  * limitations under the License.
  */
 
-import { AppOptions } from "./app_options.js";
 import { loadScript } from "pdfjs-lib";
 
 class GenericScripting {
-  constructor() {
+  constructor(sandboxBundleSrc) {
     this._ready = loadScript(
-      AppOptions.get("sandboxBundleSrc"),
+      sandboxBundleSrc,
       /* removeScriptElement = */ true
     ).then(() => {
       return window.pdfjsSandbox.QuickJSSandbox();

--- a/web/genericcom.js
+++ b/web/genericcom.js
@@ -51,8 +51,8 @@ class GenericExternalServices extends DefaultExternalServices {
     return new GenericL10n(locale);
   }
 
-  static createScripting() {
-    return new GenericScripting();
+  static createScripting({ sandboxBundleSrc }) {
+    return new GenericScripting(sandboxBundleSrc);
   }
 }
 PDFViewerApplication.externalServices = GenericExternalServices;


### PR DESCRIPTION
Similar to e.g. the "locale" option, this in *only* done for those build-targets where the "sandboxBundleSrc" is actually defined.
With these changes we can remove an `AppOptions` dependency from the `web/generic_scripting.js` file, thus limiting *direct* `AppOptions` usage in the default viewer files.