### PR TITLE
Remove unused `.noResults` CSS-rule

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1492,13 +1492,6 @@ html[dir="rtl"] .treeItemToggler::before {
   color: var(--treeitem-active-color);
 }
 
-.noResults {
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.8);
-  font-style: italic;
-  cursor: default;
-}
-
 /* TODO: file FF bug to support ::-moz-selection:window-inactive
    so we can override the opaque grey background when the window is inactive;
    see https://bugzilla.mozilla.org/show_bug.cgi?id=706209 */


### PR DESCRIPTION
This CSS-rule was added all the way back in PR #1808, however it's been completely unused for years (I didn't bother finding out *exactly* when that happened). Looking at its only usage, see https://github.com/mozilla/pdf.js/pull/1808/files#diff-987d91686287a25ac2405baaf17b699a5fc1a176a53f8ea347a72ef486001f7bR795, it's already clear from the surrounding code that it's indeed unnecessary now.