### PR TITLE
Support the `once` option, when registering `EventBus` listeners

### DIFF
--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -312,6 +312,30 @@ describe("ui_utils", function () {
       expect(count).toEqual(2);
     });
 
+    it("dispatch event to handlers with/without 'once' option", function () {
+      const eventBus = new EventBus();
+      let multipleCount = 0,
+        onceCount = 0;
+
+      eventBus.on("test", function () {
+        multipleCount++;
+      });
+      eventBus.on(
+        "test",
+        function () {
+          onceCount++;
+        },
+        { once: true }
+      );
+
+      eventBus.dispatch("test");
+      eventBus.dispatch("test");
+      eventBus.dispatch("test");
+
+      expect(multipleCount).toEqual(3);
+      expect(onceCount).toEqual(1);
+    });
+
     it("should not re-dispatch to DOM", function (done) {
       if (isNodeJS) {
         pending("Document in not supported in Node.js.");

--- a/web/app.js
+++ b/web/app.js
@@ -1497,11 +1497,13 @@ const PDFViewerApplication = {
       // It should be *extremely* rare for metadata to not have been resolved
       // when this code runs, but ensure that we handle that case here.
       await new Promise(resolve => {
-        const metadataLoaded = () => {
-          this.eventBus._off("metadataloaded", metadataLoaded);
-          resolve();
-        };
-        this.eventBus._on("metadataloaded", metadataLoaded);
+        this.eventBus._on(
+          "metadataloaded",
+          evt => {
+            resolve();
+          },
+          { once: true }
+        );
       });
       if (pdfDocument !== this.pdfDocument) {
         return; // The document was closed while the metadata resolved.

--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -76,11 +76,13 @@ class PDFHistory {
     this.eventBus._on("pagesinit", () => {
       this._isPagesLoaded = false;
 
-      const onPagesLoaded = evt => {
-        this.eventBus._off("pagesloaded", onPagesLoaded);
-        this._isPagesLoaded = !!evt.pagesCount;
-      };
-      this.eventBus._on("pagesloaded", onPagesLoaded);
+      this.eventBus._on(
+        "pagesloaded",
+        evt => {
+          this._isPagesLoaded = !!evt.pagesCount;
+        },
+        { once: true }
+      );
     });
   }
 


### PR DESCRIPTION
This follows the same principle as the `once` option that exists in the native `addEventListener` method, and will thus automatically remove an `EventBus` listener when it's invoked; see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Parameters

Finally, this patch also tweaks some the existing `EventBus`-code to use modern features such as optional chaining and logical assignment operators.