### PR TITLE
Extract common functionality into a new `BaseTreeViewer._finishRendering` method

### DIFF
--- a/web/base_tree_viewer.js
+++ b/web/base_tree_viewer.js
@@ -103,6 +103,20 @@ class BaseTreeViewer {
     this._toggleTreeItem(this.container, !this._lastToggleIsShow);
   }
 
+  /**
+   * @private
+   */
+  _finishRendering(fragment, count, hasAnyNesting = false) {
+    if (hasAnyNesting) {
+      this.container.classList.add("treeWithDeepNesting");
+
+      this._lastToggleIsShow = !fragment.querySelector(".treeItemsHidden");
+    }
+    this.container.appendChild(fragment);
+
+    this._dispatchEvent(count);
+  }
+
   render(params) {
     throw new Error("Not implemented: render");
   }

--- a/web/pdf_attachment_viewer.js
+++ b/web/pdf_attachment_viewer.js
@@ -187,9 +187,7 @@ class PDFAttachmentViewer extends BaseTreeViewer {
       attachmentsCount++;
     }
 
-    this.container.appendChild(fragment);
-
-    this._dispatchEvent(attachmentsCount);
+    this._finishRendering(fragment, attachmentsCount);
   }
 
   /**

--- a/web/pdf_layer_viewer.js
+++ b/web/pdf_layer_viewer.js
@@ -174,16 +174,8 @@ class PDFLayerViewer extends BaseTreeViewer {
         levelData.parent.appendChild(div);
       }
     }
-    if (hasAnyNesting) {
-      this.container.classList.add("treeWithDeepNesting");
 
-      this._lastToggleIsShow =
-        fragment.querySelectorAll(".treeItemsHidden").length === 0;
-    }
-
-    this.container.appendChild(fragment);
-
-    this._dispatchEvent(layersCount);
+    this._finishRendering(fragment, layersCount, hasAnyNesting);
   }
 
   /**

--- a/web/pdf_outline_viewer.js
+++ b/web/pdf_outline_viewer.js
@@ -171,16 +171,8 @@ class PDFOutlineViewer extends BaseTreeViewer {
         outlineCount++;
       }
     }
-    if (hasAnyNesting) {
-      this.container.classList.add("treeWithDeepNesting");
 
-      this._lastToggleIsShow =
-        fragment.querySelectorAll(".treeItemsHidden").length === 0;
-    }
-
-    this.container.appendChild(fragment);
-
-    this._dispatchEvent(outlineCount);
+    this._finishRendering(fragment, outlineCount, hasAnyNesting);
   }
 }
 


### PR DESCRIPTION
Note how the end of the `{PDFOutlineViewer, PDFAttachmentViewer, PDFLayerViewer}.render` methods share *almost* identical code, hence we can reduce some duplication by introducing the new `BaseTreeViewer` helper method here.

Furthermore, setting `this._lastToggleIsShow` can be made ever so slightly more efficient, since we don't care about the number of ".treeItemsHidden"-classes but only want to know if at least one exists.