### PR TITLE
Convert `DefaultExternalServices.fallback` to an asynchronous method

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -150,7 +150,7 @@ class DefaultExternalServices {
 
   static initPassiveLoading(callbacks) {}
 
-  static fallback(data, callback) {}
+  static async fallback(data) {}
 
   static reportTelemetry(data) {}
 
@@ -1102,18 +1102,17 @@ const PDFViewerApplication = {
       return;
     }
     this.fellback = true;
-    this.externalServices.fallback(
-      {
+    this.externalServices
+      .fallback({
         featureId,
         url: this.baseUrl,
-      },
-      function response(download) {
+      })
+      .then(download => {
         if (!download) {
           return;
         }
-        PDFViewerApplication.download({ sourceEventType: "download" });
-      }
-    );
+        this.download({ sourceEventType: "download" });
+      });
   },
 
   /**

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -344,8 +344,10 @@ class FirefoxExternalServices extends DefaultExternalServices {
     FirefoxCom.requestSync("initPassiveLoading", null);
   }
 
-  static fallback(data, callback) {
-    FirefoxCom.request("fallback", data, callback);
+  static async fallback(data) {
+    return new Promise(resolve => {
+      FirefoxCom.request("fallback", data, resolve);
+    });
   }
 
   static reportTelemetry(data) {


### PR DESCRIPTION
This method currently accepts a callback-function, which does feel a bit old fashioned now. At the time that this code was introduced, native Promises didn't exist yet and there's a custom Promise-implementation used instead.

However, today with Promises and async/await being used *a lot* it seems reasonable to change `DefaultExternalServices.fallback` to an `async` method instead such that the callback-function can be removed.