### PR TITLE
Modernize the `FirefoxCom.request` method

### DIFF
--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -64,12 +64,11 @@ const FirefoxCom = (function FirefoxComClosure() {
     request(action, data, callback) {
       const request = document.createTextNode("");
       if (callback) {
-        document.addEventListener(
+        request.addEventListener(
           "pdf.js.response",
           event => {
-            const node = event.target;
             const response = event.detail.response;
-            node.remove();
+            event.target.remove();
 
             callback(response);
           },

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -48,7 +48,8 @@ const FirefoxCom = (function FirefoxComClosure() {
       });
       request.dispatchEvent(sender);
       const response = sender.detail.response;
-      document.documentElement.removeChild(request);
+      request.remove();
+
       return response;
     },
 
@@ -68,10 +69,9 @@ const FirefoxCom = (function FirefoxComClosure() {
           event => {
             const node = event.target;
             const response = event.detail.response;
+            node.remove();
 
-            document.documentElement.removeChild(node);
-
-            return callback(response);
+            callback(response);
           },
           { once: true }
         );

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -63,15 +63,18 @@ const FirefoxCom = (function FirefoxComClosure() {
     request(action, data, callback) {
       const request = document.createTextNode("");
       if (callback) {
-        document.addEventListener("pdf.js.response", function listener(event) {
-          const node = event.target;
-          const response = event.detail.response;
+        document.addEventListener(
+          "pdf.js.response",
+          event => {
+            const node = event.target;
+            const response = event.detail.response;
 
-          document.documentElement.removeChild(node);
+            document.documentElement.removeChild(node);
 
-          document.removeEventListener("pdf.js.response", listener);
-          return callback(response);
-        });
+            return callback(response);
+          },
+          { once: true }
+        );
       }
       document.documentElement.appendChild(request);
 


### PR DESCRIPTION
*Please note:* I've tested this patch in a *local* Firefox build, to ensure that I didn't break anything here :-)

 - Use the `once: true` option, rather than manually removing the "pdf.js.response" event listener in `FirefoxCom.request`

   When this code was originally added, the `once` option didn't exist yet.

- Use `remove`, rather than `removeChild`, when removing the temporary `Text` nodes used in `FirefoxCom`

   This is the "modern" way of removing a node from the DOM, which has the benefit of being a lot shorter and more concise.

   Also, this patch removes the `return` statement from the "pdf.js.response" event listener, since it's always `undefined`, given that none of the `callback`-functions used here ever return anything (and don't need to either). Generally speaking, returning a value from an event listener isn't normally necessary either.

 - Ensure that the "pdf.js.response" event listener, in `FirefoxCom.request`, actually applies to the current `Text` node

   Given that the event listener is registered on the document, there could in *theory* be more than one of these listeners present at any one time.
   In practice this doesn't currently happen, since all of the `actions` invoked in [`PdfStreamConverter.jsm`](https://searchfox.org/mozilla-central/rev/bfbacfb6a4efd98247e83d3305e912ca4f7e106a/toolkit/components/pdfjs/content/PdfStreamConverter.jsm#933-952) are *synchronous* methods. However, there's no guarantee that this will always be the case, and it's easy enough to prevent any future issues here by simply registering the "pdf.js.response" event listener on the `Text` node instead. This works since, as can be seen in [`PdfStreamConverter.jsm`](https://searchfox.org/mozilla-central/rev/bfbacfb6a4efd98247e83d3305e912ca4f7e106a/toolkit/components/pdfjs/content/PdfStreamConverter.jsm#919,943), the event is dispatched on the element itself rather than the document.