### PR TITLE
Add a new `FirefoxCom.requestAsync` method, to simplify the code in `web/firefoxcom.js`

### DIFF
--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -29,8 +29,8 @@ class FirefoxCom {
   /**
    * Creates an event that the extension is listening for and will
    * synchronously respond to.
-   * NOTE: It is recommended to use request() instead since one day we may not
-   * be able to synchronously reply.
+   * NOTE: It is recommended to use requestAsync() instead since one day we may
+   *       not be able to synchronously reply.
    * @param {string} action - The action to trigger.
    * @param {Object|string} [data] - The data to send.
    * @returns {*} The response.
@@ -50,6 +50,19 @@ class FirefoxCom {
     request.remove();
 
     return response;
+  }
+
+  /**
+   * Creates an event that the extension is listening for and will
+   * asynchronously respond to.
+   * @param {string} action - The action to trigger.
+   * @param {Object|string} [data] - The data to send.
+   * @returns {Promise<any>} A promise that is resolved with the response data.
+   */
+  static requestAsync(action, data) {
+    return new Promise(resolve => {
+      this.request(action, data, resolve);
+    });
   }
 
   /**
@@ -97,58 +110,42 @@ class DownloadManager {
     const blobUrl = URL.createObjectURL(
       new Blob([data], { type: contentType })
     );
-    const onResponse = err => {
-      URL.revokeObjectURL(blobUrl);
-    };
 
-    FirefoxCom.request(
-      "download",
-      {
-        blobUrl,
-        originalUrl: blobUrl,
-        filename,
-        isAttachment: true,
-      },
-      onResponse
-    );
+    FirefoxCom.requestAsync("download", {
+      blobUrl,
+      originalUrl: blobUrl,
+      filename,
+      isAttachment: true,
+    }).then(error => {
+      URL.revokeObjectURL(blobUrl);
+    });
   }
 
   download(blob, url, filename, sourceEventType = "download") {
     const blobUrl = URL.createObjectURL(blob);
-    const onResponse = err => {
-      if (err && this.onerror) {
-        this.onerror(err);
+
+    FirefoxCom.requestAsync("download", {
+      blobUrl,
+      originalUrl: url,
+      filename,
+      sourceEventType,
+    }).then(error => {
+      if (error && this.onerror) {
+        this.onerror(error);
       }
       URL.revokeObjectURL(blobUrl);
-    };
-
-    FirefoxCom.request(
-      "download",
-      {
-        blobUrl,
-        originalUrl: url,
-        filename,
-        sourceEventType,
-      },
-      onResponse
-    );
+    });
   }
 }
 
 class FirefoxPreferences extends BasePreferences {
   async _writeToStorage(prefObj) {
-    return new Promise(function (resolve) {
-      FirefoxCom.request("setPreferences", prefObj, resolve);
-    });
+    return FirefoxCom.requestAsync("setPreferences", prefObj);
   }
 
   async _readFromStorage(prefObj) {
-    return new Promise(function (resolve) {
-      FirefoxCom.request("getPreferences", prefObj, function (prefStr) {
-        const readPrefs = JSON.parse(prefStr);
-        resolve(readPrefs);
-      });
-    });
+    const prefStr = await FirefoxCom.requestAsync("getPreferences", prefObj);
+    return JSON.parse(prefStr);
   }
 }
 
@@ -254,13 +251,10 @@ class FirefoxComDataRangeTransport extends PDFDataRangeTransport {
 
 class FirefoxScripting {
   static async createSandbox(data) {
-    return new Promise(resolve => {
-      FirefoxCom.request("createSandbox", data, resolve);
-    }).then(success => {
-      if (!success) {
-        throw new Error("Cannot create sandbox.");
-      }
-    });
+    const success = await FirefoxCom.requestAsync("createSandbox", data);
+    if (!success) {
+      throw new Error("Cannot create sandbox.");
+    }
   }
 
   static async dispatchEventInSandbox(event) {
@@ -343,9 +337,7 @@ class FirefoxExternalServices extends DefaultExternalServices {
   }
 
   static async fallback(data) {
-    return new Promise(resolve => {
-      FirefoxCom.request("fallback", data, resolve);
-    });
+    return FirefoxCom.requestAsync("fallback", data);
   }
 
   static reportTelemetry(data) {

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -25,69 +25,65 @@ if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
   );
 }
 
-const FirefoxCom = (function FirefoxComClosure() {
-  return {
-    /**
-     * Creates an event that the extension is listening for and will
-     * synchronously respond to.
-     * NOTE: It is reccomended to use request() instead since one day we may not
-     * be able to synchronously reply.
-     * @param {string} action - The action to trigger.
-     * @param {string} [data] - The data to send.
-     * @returns {*} The response.
-     */
-    requestSync(action, data) {
-      const request = document.createTextNode("");
-      document.documentElement.appendChild(request);
+class FirefoxCom {
+  /**
+   * Creates an event that the extension is listening for and will
+   * synchronously respond to.
+   * NOTE: It is recommended to use request() instead since one day we may not
+   * be able to synchronously reply.
+   * @param {string} action - The action to trigger.
+   * @param {Object|string} [data] - The data to send.
+   * @returns {*} The response.
+   */
+  static requestSync(action, data) {
+    const request = document.createTextNode("");
+    document.documentElement.appendChild(request);
 
-      const sender = document.createEvent("CustomEvent");
-      sender.initCustomEvent("pdf.js.message", true, false, {
-        action,
-        data,
-        sync: true,
-      });
-      request.dispatchEvent(sender);
-      const response = sender.detail.response;
-      request.remove();
+    const sender = document.createEvent("CustomEvent");
+    sender.initCustomEvent("pdf.js.message", true, false, {
+      action,
+      data,
+      sync: true,
+    });
+    request.dispatchEvent(sender);
+    const response = sender.detail.response;
+    request.remove();
 
-      return response;
-    },
+    return response;
+  }
 
-    /**
-     * Creates an event that the extension is listening for and will
-     * asynchronously respond by calling the callback.
-     * @param {string} action - The action to trigger.
-     * @param {string} [data] - The data to send.
-     * @param {Function} [callback] - Response callback that will be called
-     *   with one data argument.
-     */
-    request(action, data, callback) {
-      const request = document.createTextNode("");
-      if (callback) {
-        request.addEventListener(
-          "pdf.js.response",
-          event => {
-            const response = event.detail.response;
-            event.target.remove();
+  /**
+   * Creates an event that the extension is listening for and will, optionally,
+   * asynchronously respond to.
+   * @param {string} action - The action to trigger.
+   * @param {Object|string} [data] - The data to send.
+   */
+  static request(action, data, callback = null) {
+    const request = document.createTextNode("");
+    if (callback) {
+      request.addEventListener(
+        "pdf.js.response",
+        event => {
+          const response = event.detail.response;
+          event.target.remove();
 
-            callback(response);
-          },
-          { once: true }
-        );
-      }
-      document.documentElement.appendChild(request);
+          callback(response);
+        },
+        { once: true }
+      );
+    }
+    document.documentElement.appendChild(request);
 
-      const sender = document.createEvent("CustomEvent");
-      sender.initCustomEvent("pdf.js.message", true, false, {
-        action,
-        data,
-        sync: false,
-        responseExpected: !!callback,
-      });
-      return request.dispatchEvent(sender);
-    },
-  };
-})();
+    const sender = document.createEvent("CustomEvent");
+    sender.initCustomEvent("pdf.js.message", true, false, {
+      action,
+      data,
+      sync: false,
+      responseExpected: !!callback,
+    });
+    request.dispatchEvent(sender);
+  }
+}
 
 class DownloadManager {
   downloadUrl(url, filename) {


### PR DESCRIPTION
*Please note:* I've tested this patch in a *local* Firefox build, to ensure that I didn't break anything here :-)

 - Convert `FirefoxCom` to a class, with `static` methods

   *Please note:* It's highly recommended to ignore whitespace-only changes when looking at this patch.

   Besides modernizing this code, by converting it to a standard class, the existing JSDoc comments are updated to actually agree better with the way that this functionality is used now. (The next patch will reduce usage of `FirefoxCom.request` significantly, hence the JSDocs for the optional `callback` is removed to not unnecessarily advertise that functionality.)

   Finally, the unnecessary/unused `return` statement at the end of `FirefoxCom.request` is also removed.

 - Add a new `FirefoxCom.requestAsync` method, to simplify the code in `web/firefoxcom.js`

   There's a fair number of cases where `FirefoxCom.request`-calls are manually wrapped in a Promise to make it asynchronous. We can reduce the amount of boilerplate code in these cases by introducing a new `FirefoxCom.requestAsync` method instead.

   Furthermore, a couple of `FirefoxCom.request`-calls in the `DownloadManager` are also changed to be asynchronous rather than using callback-functions.
   With this patch, we're thus able to replace a lot of *direct* usages of `FirefoxCom.request` with the new `FirefoxCom.requestAsync` method instead.
