### PR TITLE
Update webpack example

### DIFF
--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -5,8 +5,8 @@
     "build": "webpack"
   },
   "devDependencies": {
-    "webpack": "4.21.0",
-    "webpack-cli": "^3.1.2",
+    "webpack": "^5.11.1",
+    "webpack-cli": "^4.3.1",
     "pdfjs-dist": "../../node_modules/pdfjs-dist"
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1969,6 +1969,9 @@ function packageBowerJson() {
     homepage: DIST_HOMEPAGE,
     bugs: DIST_BUGS_URL,
     license: DIST_LICENSE,
+    peerDependencies: {
+      "worker-loader": "^3.0.7", // Used in `external/dist/webpack.js`.
+    },
     browser: {
       canvas: false,
       fs: false,


### PR DESCRIPTION
 - Update the webpack-versions used in `examples/webpack`

   Once the next PDF.js release is made, the `webpack` example will no longer work since the non-translated builds now use ECMAScript features not supported by older `webpack`-versions.

 - Try to re-add the `worker-loader` package, in pdfjs-dist, using `peerDependencies` (PR 11474 follow-up)

   There's been a number of (somewhat) recent issues where people are having trouble using pdfjs-dist together with `webpack`, since that library purposely doesn't declare any dependencies; refer to PR #11474 for additional context.

   In an *attempt*, although I don't know how much this will actually help in practice (given my limited `webpack` experience), let's try to list `worker-loader` as a *peer*-dependency to see if that helps. This should, unless I'm completely misunderstanding https://docs.npmjs.com/cli/v6/configuring-npm/package-json#peerdependencies, prevent `worker-loader` from being installed by default for *all* pdfjs-dist users while still indicating the dependency for those who need it.

