### PR TITLE
Don't dispatch "pageclose" events if a "pageopen" wasn't dispatched for the page (PR 12747 follow-up)

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -1517,6 +1517,9 @@ class BaseViewer {
     const { eventBus } = this;
 
     const dispatchPageClose = pageNumber => {
+      if (this._pageOpenPendingSet?.has(pageNumber)) {
+        return; // No "pageopen" event was dispatched for the previous page.
+      }
       eventBus.dispatch("pageclose", { source: this, pageNumber });
     };
     const dispatchPageOpen = (pageNumber, force = false) => {
@@ -1542,10 +1545,7 @@ class BaseViewer {
     });
 
     eventBus._on("pagerendered", ({ pageNumber }) => {
-      if (!this._pageOpenPendingSet) {
-        return; // No pending "pageopen" events.
-      }
-      if (!this._pageOpenPendingSet.has(pageNumber)) {
+      if (!this._pageOpenPendingSet?.has(pageNumber)) {
         return; // No pending "pageopen" event for the newly rendered page.
       }
       if (pageNumber !== this._currentPageNumber) {


### PR DESCRIPTION
Given that "pageopen" events are not guaranteed to occur, if the page becomes inactive *before* it finishes rendering, we should probably also avoid dispatching a "pageclose" event in that case to avoid confusing/inconsistent state in any event handlers.