### PR TITLE
An option is missing for last versions of worker-loader to use pdf.js with webpack

### DIFF
--- a/examples/webpack/README.md
+++ b/examples/webpack/README.md
@@ -23,7 +23,7 @@ the worker code, and the `workerSrc` path shall be set to the latter file.
 If you are getting the `Setting up fake worker` warning, make sure you are
 importing `pdfjs-dist/webpack` which is the zero-configuration method for
 Webpack users. You will need to install
-[worker-loader](https://github.com/webpack-contrib/worker-loader) as a
+[worker-loader](https://github.com/webpack-contrib/worker-loader) (version 3.0.0 or higher is required), as a
 dependency in your project in order to use `pdfjs-dist/webpack` (configuring
 `worker-loader` is not necessary; just installing it is sufficient).
 

--- a/external/dist/webpack.js
+++ b/external/dist/webpack.js
@@ -16,7 +16,7 @@
 "use strict";
 
 var pdfjs = require("./build/pdf.js");
-var PdfjsWorker = require("worker-loader?esModule=false!./build/pdf.worker.js");
+var PdfjsWorker = require("worker-loader?esModule=false&filename=[name].js!./build/pdf.worker.js");
 
 if (typeof window !== "undefined" && "Worker" in window) {
   pdfjs.GlobalWorkerOptions.workerPort = new PdfjsWorker();


### PR DESCRIPTION
Fix #12813 