### PR TITLE
Try to fix TypeScript definitions for the es5-build in pdfjs-dist (issue 12872)

### DIFF
--- a/external/dist/es5/build/pdf.d.ts
+++ b/external/dist/es5/build/pdf.d.ts
@@ -1,0 +1,1 @@
+export * from "pdfjs-dist";


### PR DESCRIPTION
Given that we're already using the `external/dist/` folder for things we simply want to copy to pdfjs-dist during building, this patch *should* hopefully work since it's based on the suggestion in https://github.com/mozilla/pdf.js/issues/12827#issuecomment-756471707.

As long as this only requires a *single/small* file, to fix the TypeScript definitions in es5-builds, this solution seem acceptable as far as I'm concerned. (Although, please note that I don't know enough about TypeScript to actually test the patch.)

Fixes #12827