### PR TITLE
Improve handling of JPEG images without an EOI marker (issue 12841)

### DIFF
--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -1063,7 +1063,7 @@ var JpegImage = (function JpegImageClosure() {
               offset = nextFileMarker.offset;
               break;
             }
-            if (offset >= data.length - 1) {
+            if (!nextFileMarker || offset >= data.length - 1) {
               warn(
                 "JpegImage.parse - reached the end of the image data " +
                   "without finding an EOI marker (0xFFD9)."

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -241,6 +241,7 @@
 !personwithdog.pdf
 !helloworld-bad.pdf
 !zerowidthline.pdf
+!issue12841_reduced.pdf
 !bug868745.pdf
 !mmtype1.pdf
 !issue4436r.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -3236,6 +3236,12 @@
        "link": true,
        "type": "eq"
     },
+    {  "id": "issue12841",
+       "file": "pdfs/issue12841_reduced.pdf",
+       "md5": "5c645897c652853ad86b59df5fc6cce0",
+       "rounds": 1,
+       "type": "eq"
+    },
     {  "id": "issue1597",
       "file": "pdfs/issue1597.pdf",
       "md5": "a5ebef467fd6e2fc0aeb56c9eb725ae3",


### PR DESCRIPTION
Given that the PDF document in the issue contains the same very large JPEG image *three* times, this patch includes a test-case where only the first page has been extracted from it.

Fixes #12841