### PR TITLE
Fix broken "issue12394" test-case

### DIFF
--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -4419,7 +4419,9 @@
        "type": "eq",
        "print": "true",
        "annotationStorage": {
-         "35R": "收文"
+         "35R": {
+           "value": "收文"
+         }
        }
     },
     {  "id": "issue4883",


### PR DESCRIPTION
This test-case is currently broken, with the reference image being completely empty, since it uses the old "annotationStorage" format in the manifest.