### PR TITLE
Enable the Stylelint `length-zero-no-unit` rule

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -10,5 +10,8 @@
 
   "rules": {
     "block-no-empty": true,
+    "length-zero-no-unit": [true, {
+      ignore: ["custom-properties"]
+    }],
   },
 }

--- a/test/annotation_layer_builder_overrides.css
+++ b/test/annotation_layer_builder_overrides.css
@@ -28,7 +28,7 @@
 .annotationLayer .buttonWidgetAnnotation.pushButton > a {
   opacity: 0.2;
   background: rgba(255, 255, 0, 1);
-  box-shadow: 0px 2px 10px rgba(255, 255, 0, 1);
+  box-shadow: 0 2px 10px rgba(255, 255, 0, 1);
 }
 
 .annotationLayer .popupAnnotation,

--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -31,7 +31,7 @@
 .annotationLayer .buttonWidgetAnnotation.pushButton > a:hover {
   opacity: 0.2;
   background: rgba(255, 255, 0, 1);
-  box-shadow: 0px 2px 10px rgba(255, 255, 0, 1);
+  box-shadow: 0 2px 10px rgba(255, 255, 0, 1);
 }
 
 .annotationLayer .textAnnotation img {
@@ -158,7 +158,7 @@
   z-index: 200;
   max-width: 20em;
   background-color: rgba(255, 255, 153, 1);
-  box-shadow: 0px 2px 5px rgba(136, 136, 136, 1);
+  box-shadow: 0 2px 5px rgba(136, 136, 136, 1);
   border-radius: 2px;
   padding: 6px;
   margin-left: 5px;

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -33,7 +33,7 @@
 }
 
 .pdfViewer.removePageBorders .page {
-  margin: 0px auto 10px auto;
+  margin: 0 auto 10px auto;
   border: none;
 }
 

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -40,15 +40,15 @@
 }
 
 .textLayer .highlight.begin {
-  border-radius: 4px 0px 0px 4px;
+  border-radius: 4px 0 0 4px;
 }
 
 .textLayer .highlight.end {
-  border-radius: 0px 4px 4px 0px;
+  border-radius: 0 4px 4px 0;
 }
 
 .textLayer .highlight.middle {
-  border-radius: 0px;
+  border-radius: 0;
 }
 
 .textLayer .highlight.selected {
@@ -62,15 +62,15 @@
 .textLayer .endOfContent {
   display: block;
   position: absolute;
-  left: 0px;
+  left: 0;
   top: 100%;
-  right: 0px;
-  bottom: 0px;
+  right: 0;
+  bottom: 0;
   z-index: -1;
   cursor: default;
   user-select: none;
 }
 
 .textLayer .endOfContent.active {
-  top: 0px;
+  top: 0;
 }

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -179,7 +179,7 @@ select {
 }
 
 #viewerContainer.pdfPresentationMode:fullscreen {
-  top: 0px;
+  top: 0;
   border-top: 2px solid rgba(0, 0, 0, 0);
   background-color: rgba(0, 0, 0, 1);
   width: 100%;
@@ -240,10 +240,10 @@ html[dir="rtl"] #sidebarContainer {
   visibility: visible;
 }
 html[dir="ltr"] #outerContainer.sidebarOpen #sidebarContainer {
-  left: 0px;
+  left: 0;
 }
 html[dir="rtl"] #outerContainer.sidebarOpen #sidebarContainer {
-  right: 0px;
+  right: 0;
 }
 
 #mainContainer {
@@ -456,7 +456,7 @@ html[dir="rtl"] #outerContainer.sidebarOpen #loadingBar {
   z-index: 10000;
   height: auto;
   min-width: 16px;
-  padding: 0px 4px 0px 4px;
+  padding: 0 4px 0 4px;
   margin: 4px 2px 4px 2px;
   color: rgba(217, 217, 217, 1);
   font-size: 12px;
@@ -489,12 +489,12 @@ html[dir="rtl"] .findbar {
   margin-top: 3px;
 }
 html[dir="ltr"] .findbar .splitToolbarButton {
-  margin-left: 0px;
+  margin-left: 0;
   margin-right: 5px;
 }
 html[dir="rtl"] .findbar .splitToolbarButton {
   margin-left: 5px;
-  margin-right: 0px;
+  margin-right: 0;
 }
 
 .findbar .splitToolbarButton > .toolbarButton {
@@ -1794,10 +1794,10 @@ html[dir="rtl"] #documentPropertiesOverlay .row > * {
   }
 
   html[dir="ltr"] #outerContainer.sidebarOpen #viewerContainer {
-    left: 0px !important;
+    left: 0 !important;
   }
   html[dir="rtl"] #outerContainer.sidebarOpen #viewerContainer {
-    right: 0px !important;
+    right: 0 !important;
   }
 
   #outerContainer .hiddenLargeView,


### PR DESCRIPTION
Note that these changes were done automatically, using `gulp lint --fix`.
With this rule, we'll thus enforce a *consistent* formatting of zero-lengths in our CSS files.

Please find additional details about the Stylelint rule at https://stylelint.io/user-guide/rules/length-zero-no-unit