### PR TITLE
Correctly align annotation content in horizontal/spead scrolling modes

### DIFF
--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -15,6 +15,7 @@
 
 .annotationLayer section {
   position: absolute;
+  text-align: initial;
 }
 
 .annotationLayer .linkAnnotation > a,
@@ -165,6 +166,7 @@
   cursor: pointer;
   font: message-box;
   font-size: 9px;
+  white-space: normal;
   word-wrap: break-word;
 }
 


### PR DESCRIPTION
Not only was long text in popups no longer wrapped correctly, the alignment was also center instead of left (or right, depending on the locale used) for both text in popups and the other parts within the annotation's section, such as the icon.

In order to test this, I made [annotation-popup-long.pdf](https://github.com/mozilla/pdf.js/files/5792830/annotation-popup-long.pdf) that, when opened with the current viewer, will show the issue when the horizontal/spread scrolling modes are used and when opened with the new viewer will no longer have this issue. I have checked the other files in the test suite as well to make sure that this works for all of them.

Fixes #12847.