### PR TITLE
Always re-measure non-embedded ArialNarrow fonts (bug 1671312, PR 12725 follow-up)

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -1335,8 +1335,13 @@ var Font = (function FontClosure() {
       // name ArialBlack for example will be replaced by Helvetica.
       this.black = name.search(/Black/g) !== -1;
 
+      // Use 'name' instead of 'fontName' here because the original
+      // name ArialNarrow for example will be replaced by Helvetica.
+      const isNarrow = name.search(/Narrow/g) !== -1;
+
       // if at least one width is present, remeasure all chars when exists
-      this.remeasure = !isStandardFont && Object.keys(this.widths).length > 0;
+      this.remeasure =
+        (!isStandardFont || isNarrow) && Object.keys(this.widths).length > 0;
       if (
         (isStandardFont || isMappedToStandardFont) &&
         type === "CIDFontType2" &&

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -366,6 +366,7 @@
 !issue6889.pdf
 !bug1001080.pdf
 !bug1671312_reduced.pdf
+!bug1671312_ArialNarrow.pdf
 !issue6108.pdf
 !issue6113.pdf
 !openoffice.pdf

--- a/test/pdfs/bug1671312_ArialNarrow.pdf
+++ b/test/pdfs/bug1671312_ArialNarrow.pdf
@@ -1,0 +1,93 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj 
+<<
+/FontName /ArialNarrow
+/StemV 66
+/Leading 132
+/Ascent 922
+/Flags 32
+/XHeight 461
+/AvgWidth 362
+/Descent -210
+/ItalicAngle 0
+/StemH 66
+/MaxWidth 833
+/MissingWidth 238
+/FontBBox [-250 -210 1000 1054]
+/Type /FontDescriptor
+/CapHeight 922
+>>
+endobj 
+2 0 obj 
+<<
+/Pages 3 0 R
+/Type /Catalog
+>>
+endobj 
+3 0 obj 
+<<
+/MediaBox [0 0 200 50]
+/Kids [4 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+4 0 obj 
+<<
+/Parent 3 0 R
+/MediaBox [0 0 200 50]
+/Resources 
+<<
+/Font 
+<<
+/F1 5 0 R
+>>
+>>
+/Contents 6 0 R
+/Type /Page
+>>
+endobj 
+5 0 obj 
+<<
+/FirstChar 32
+/FontDescriptor 1 0 R
+/Name /F4
+/Encoding /WinAnsiEncoding
+/BaseFont /ArialNarrow
+/Subtype /TrueType
+/LastChar 255
+/Widths [238 238 285 500 452 738 547 166 261 261 309 476 238 261 238 238 452 452 452 452 452 452 452 452 452 452 238 238 476 476 476 452 833 547 547 595 595 547 500 642 595 238 404 547 452 690 595 642 547 642 595 547 500 595 547 785 547 547 500 238 238 238 380 452 261 452 452 404 452 452 238 452 452 190 190 404 190 690 452 452 452 452 261 404 238 452 404 595 404 404 404 285 214 285 476 238 476 238 476 476 476 476 476 476 476 476 476 476 476 238 476 238 238 476 476 476 476 476 476 476 476 476 476 476 476 238 476 476 238 261 452 452 476 452 214 452 261 595 309 452 476 261 595 500 404 547 261 261 261 571 476 238 261 261 309 452 690 690 690 500 547 547 547 547 547 547 809 595 547 547 547 547 238 238 238 238 595 595 642 642 642 642 642 476 642 595 595 595 595 547 547 500 452 452 452 452 452 452 738 404 452 452 452 452 238 238 238 238 452 452 452 452 452 452 452 547 500 452 452 452 452 404 452 404]
+/Type /Font
+>>
+endobj 
+6 0 obj 
+<<
+/Length 51
+>>
+stream
+BT
+10 20 TD
+/F1 20 Tf
+(Accessory facilities) Tj
+ET
+
+endstream 
+endobj xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000273 00000 n 
+0000000324 00000 n 
+0000000406 00000 n 
+0000000535 00000 n 
+0000001605 00000 n 
+trailer
+
+<<
+/Root 2 0 R
+/Size 7
+>>
+startxref
+1708
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2301,6 +2301,12 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "bug1671312_ArialNarrow",
+       "file": "pdfs/bug1671312_ArialNarrow.pdf",
+       "md5": "f4f0a0d1dc9276bd6e3402165ecdc3d7",
+       "rounds": 1,
+       "type": "eq"
+    },
     {  "id": "issue7020",
        "file": "pdfs/issue7020.pdf",
        "md5": "93b464e21c649e64ae92eeafe99fc31b",


### PR DESCRIPTION
While PR #12725 fixed [bug 1671312](https://bugzilla.mozilla.org/show_bug.cgi?id=1671312) as reported, i.e. the "In the upper right corner "Purposes' has bad kerning."-part, it however broke other parts of the text rendering.
Note in particular the tables, e.g. on page 2 and beyond, where the glyphs are now rendered too close together. The reason for this is that the fonts in question are non-embedded ArialNarrow, which we just replace with Helvetica which obviously is not narrow. Given that the font replacement isn't a perfect fit for non-embedded ArialNarrow, we still need to re-measure the glyph widths in this case.