### PR TITLE
Replace some ternary operators with optional chaining, and nullish coalescing, in the `src/display/`-folder

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2605,7 +2605,7 @@ class WorkerTransport {
       .sendWithPromise("SaveDocument", {
         numPages: this._numPages,
         annotationStorage: annotationStorage?.getAll() || null,
-        filename: this._fullReader ? this._fullReader.filename : null,
+        filename: this._fullReader?.filename ?? null,
       })
       .finally(() => {
         if (annotationStorage) {
@@ -2800,7 +2800,7 @@ class PDFObjects {
 
   has(objId) {
     const obj = this._objs[objId];
-    return obj ? obj.resolved : false;
+    return obj?.resolved || false;
   }
 
   /**

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1506,10 +1506,7 @@ const CanvasGraphics = (function CanvasGraphicsClosure() {
       if (!fontObj) {
         throw new Error(`Can't find font for ${fontRefName}`);
       }
-
-      current.fontMatrix = fontObj.fontMatrix
-        ? fontObj.fontMatrix
-        : FONT_IDENTITY_MATRIX;
+      current.fontMatrix = fontObj.fontMatrix || FONT_IDENTITY_MATRIX;
 
       // A valid matrix needs all main diagonal elements to be non-zero
       // This also ensures we bypass FF bugzilla bug #719844.

--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -66,7 +66,7 @@ class PDFFetchStream {
   }
 
   get _progressiveDataLength() {
-    return this._fullRequestReader ? this._fullRequestReader._loaded : 0;
+    return this._fullRequestReader?._loaded ?? 0;
   }
 
   getFullReader() {

--- a/src/display/metadata.js
+++ b/src/display/metadata.js
@@ -146,7 +146,7 @@ class Metadata {
   }
 
   get(name) {
-    return this._metadataMap.has(name) ? this._metadataMap.get(name) : null;
+    return this._metadataMap.get(name) ?? null;
   }
 
   getAll() {

--- a/src/display/node_stream.js
+++ b/src/display/node_stream.js
@@ -69,7 +69,7 @@ class PDFNodeStream {
   }
 
   get _progressiveDataLength() {
-    return this._fullRequestReader ? this._fullRequestReader._loaded : 0;
+    return this._fullRequestReader?._loaded ?? 0;
   }
 
   getFullReader() {

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -981,10 +981,7 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
         this.addFontStyle(fontObj);
         this.embeddedFonts[fontObj.loadedName] = fontObj;
       }
-
-      current.fontMatrix = fontObj.fontMatrix
-        ? fontObj.fontMatrix
-        : FONT_IDENTITY_MATRIX;
+      current.fontMatrix = fontObj.fontMatrix || FONT_IDENTITY_MATRIX;
 
       let bold = "normal";
       if (fontObj.black) {

--- a/src/display/transport_stream.js
+++ b/src/display/transport_stream.js
@@ -83,7 +83,7 @@ class PDFDataTransportStream {
   }
 
   get _progressiveDataLength() {
-    return this._fullRequestReader ? this._fullRequestReader._loaded : 0;
+    return this._fullRequestReader?._loaded ?? 0;
   }
 
   _onProgress(evt) {


### PR DESCRIPTION
This way, we can further reduce unnecessary code-repetition in some cases.