### PR TITLE
Remove redundant compatibility checks, for modern `generic` builds, in `src/core/worker.js`

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -139,19 +139,15 @@ class WorkerMessageHandler {
 
       // Ensure that (primarily) Node.js users won't accidentally attempt to use
       // a non-translated/non-polyfilled build of the library, since that would
-      // quickly fail anyway because of missing functionality (such as e.g.
-      // `ReadableStream` and `Promise.allSettled`).
+      // quickly fail anyway because of missing functionality.
       if (
         (typeof PDFJSDev === "undefined" || PDFJSDev.test("SKIP_BABEL")) &&
-        (typeof globalThis === "undefined" ||
-          typeof ReadableStream === "undefined" ||
-          typeof Promise.allSettled === "undefined")
+        typeof ReadableStream === "undefined"
       ) {
         throw new Error(
           "The browser/environment lacks native support for critical " +
-            "functionality used by the PDF.js library (e.g. `globalThis`, " +
-            "`ReadableStream`, and/or `Promise.allSettled`); " +
-            "please use an ES5-compatible build instead."
+            "functionality used by the PDF.js library (e.g. `ReadableStream`); " +
+            "please use an `es5`-build instead."
         );
       }
     }


### PR DESCRIPTION
With the recent additions of optional chaining and nullish coalescing to the PDF.js code-base, a couple of the checks in `src/core/worker.js` are now redundant; please see this compatibility information:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining#browser_compatibility
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator#browser_compatibility

In practice, for the non-translated/non-polyfilled PDF.js builds, browsers without support for optional chaining and nullish coalescing will simply throw immediately upon loading of the code.
Hence both the `globalThis` and `Promise.allSettled` checks are now unnecessary, given this compatibility information:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis#browser_compatibility
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled#browser_compatibility

*Please note:* The `ReadableStream` check is however still necessary, since Node.js doesn't support that.