### PR TITLE
Simplify the `PDFFunctionFactory._localFunctionCache` initialization (PR 12034 follow-up); Fix the `gStateObj` lookup in `TranslatedFont._removeType3ColorOperators` (PR 12718 follow-up)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -3683,7 +3683,7 @@ class TranslatedFont {
           continue;
 
         case OPS.setGState:
-          const gStateObj = operatorList.argsArray[i];
+          const [gStateObj] = operatorList.argsArray[i];
           let j = 0,
             jj = gStateObj.length;
           while (j < jj) {

--- a/src/core/function.js
+++ b/src/core/function.js
@@ -20,6 +20,7 @@ import {
   info,
   isBool,
   IsEvalSupportedCached,
+  shadow,
   unreachable,
 } from "../shared/util.js";
 import { PostScriptLexer, PostScriptParser } from "./ps_parser.js";
@@ -29,7 +30,6 @@ class PDFFunctionFactory {
   constructor({ xref, isEvalSupported = true }) {
     this.xref = xref;
     this.isEvalSupported = isEvalSupported !== false;
-    this._localFunctionCache = null; // Initialized lazily.
   }
 
   create(fn) {
@@ -76,9 +76,6 @@ class PDFFunctionFactory {
       fnRef = cacheKey.dict && cacheKey.dict.objId;
     }
     if (fnRef) {
-      if (!this._localFunctionCache) {
-        this._localFunctionCache = new LocalFunctionCache();
-      }
       const localFunction = this._localFunctionCache.getByRef(fnRef);
       if (localFunction) {
         return localFunction;
@@ -105,11 +102,15 @@ class PDFFunctionFactory {
       fnRef = cacheKey.dict && cacheKey.dict.objId;
     }
     if (fnRef) {
-      if (!this._localFunctionCache) {
-        this._localFunctionCache = new LocalFunctionCache();
-      }
       this._localFunctionCache.set(/* name = */ null, fnRef, parsedFunction);
     }
+  }
+
+  /**
+   * @private
+   */
+  get _localFunctionCache() {
+    return shadow(this, "_localFunctionCache", new LocalFunctionCache());
   }
 }
 


### PR DESCRIPTION
These two commits are not directly related, but given their small size I figured that one PR won't hurt since that reduces bot usage slightly.

 - Simplify the `PDFFunctionFactory._localFunctionCache` initialization (PR 12034 follow-up)

   By changing this a `shadow`ed getter, we can simply access it directly and not worry about it being initialized. I have no idea why I didn't just implement it this way in the first place.

 - Fix the `gStateObj` lookup in `TranslatedFont._removeType3ColorOperators` (PR 12718 follow-up)

   As can be seen in https://github.com/mozilla/pdf.js/blob/2cba29036180b420778bd2c91d21d71bd207c146/src/core/evaluator.js#L986 the `gStateObj` (which is actually an Array despite its name), is wrapped in Array when it's inserted into the OperatorList. Hence we obviously need to take this into account when accessing it in `TranslatedFont._removeType3ColorOperators`; this mistake happened because we don't have any test-cases for this particular code-path as far as I know.

