### PR TITLE
Use `_defaultAppearanceData` directly in `WidgetAnnotation._getSaveFieldResources` (PR 12831 follow-up)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -1266,8 +1266,6 @@ class WidgetAnnotation extends Annotation {
   }
 
   async _getAppearance(evaluator, task, annotationStorage) {
-    this._fontName = null;
-
     const isPassword = this.hasFieldFlag(AnnotationFieldFlag.PASSWORD);
     if (!annotationStorage || isPassword) {
       return null;
@@ -1303,7 +1301,6 @@ class WidgetAnnotation extends Annotation {
 
     const font = await this._getFontData(evaluator, task);
     const fontSize = this._computeFontSize(font, totalHeight);
-    this._fontName = this._defaultAppearanceData.fontName.name;
 
     let descent = font.descent;
     if (isNaN(descent)) {
@@ -1459,34 +1456,35 @@ class WidgetAnnotation extends Annotation {
       PDFJSDev.test("!PRODUCTION || TESTING")
     ) {
       assert(
-        this._fontName !== undefined,
-        "Expected `_getAppearance()` to have been called."
+        this._defaultAppearanceData,
+        "Expected `_defaultAppearanceData` to have been set."
       );
     }
     const {
       localResources,
-      acroFormResources,
       appearanceResources,
+      acroFormResources,
     } = this._fieldResources;
 
-    if (!this._fontName) {
+    const fontNameStr =
+      this._defaultAppearanceData && this._defaultAppearanceData.fontName.name;
+    if (!fontNameStr) {
       return localResources || Dict.empty;
     }
 
     for (const resources of [localResources, appearanceResources]) {
       if (resources instanceof Dict) {
         const localFont = resources.get("Font");
-        if (localFont instanceof Dict && localFont.has(this._fontName)) {
+        if (localFont instanceof Dict && localFont.has(fontNameStr)) {
           return resources;
         }
       }
     }
-
     if (acroFormResources instanceof Dict) {
       const acroFormFont = acroFormResources.get("Font");
-      if (acroFormFont instanceof Dict && acroFormFont.has(this._fontName)) {
+      if (acroFormFont instanceof Dict && acroFormFont.has(fontNameStr)) {
         const subFontDict = new Dict(xref);
-        subFontDict.set(this._fontName, acroFormFont.getRaw(this._fontName));
+        subFontDict.set(fontNameStr, acroFormFont.getRaw(fontNameStr));
 
         const subResourcesDict = new Dict(xref);
         subResourcesDict.set("Font", subFontDict);


### PR DESCRIPTION
With the changes in PR #12831, it's no longer necessary to keep track of the `fontName`-string separately since it's available through the `_defaultAppearanceData`-property as well.