### PR TITLE
Keep logical assignment operators in `MOZCENTRAL`/`TESTING`-builds

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -210,6 +210,23 @@ function createWebpackConfig(
   }
   const babelExcludeRegExp = new RegExp(`(${babelExcludes.join("|")})`);
 
+  // Since logical assignment operators is a fairly new ECMAScript feature,
+  // for now we translate these regardless of the `SKIP_BABEL` value (with the
+  // exception of `MOZCENTRAL`/`TESTING`-builds where this isn't an issue).
+  const babelPlugins = [
+    "@babel/plugin-transform-modules-commonjs",
+    [
+      "@babel/plugin-transform-runtime",
+      {
+        helpers: false,
+        regenerator: true,
+      },
+    ],
+  ];
+  if (!bundleDefines.MOZCENTRAL && !bundleDefines.TESTING) {
+    babelPlugins.push("@babel/plugin-proposal-logical-assignment-operators");
+  }
+
   const plugins = [];
   if (!disableLicenseHeader) {
     plugins.push(
@@ -242,17 +259,7 @@ function createWebpackConfig(
           exclude: babelExcludeRegExp,
           options: {
             presets: skipBabel ? undefined : ["@babel/preset-env"],
-            plugins: [
-              "@babel/plugin-proposal-logical-assignment-operators",
-              "@babel/plugin-transform-modules-commonjs",
-              [
-                "@babel/plugin-transform-runtime",
-                {
-                  helpers: false,
-                  regenerator: true,
-                },
-              ],
-            ],
+            plugins: babelPlugins,
           },
         },
         {


### PR DESCRIPTION
Given how recently logical assignment operators support were added to browsers, we're intentionally translating them even in `SKIP_BABEL = true` builds for the time being.
However, in either `MOZCENTRAL` or `TESTING` builds it should be OK to simply leave logical assignment operators intact.