### PR TITLE
Enable ESLint rules that no longer need to be disabled on a directory/file-basis

### DIFF
--- a/examples/.eslintrc
+++ b/examples/.eslintrc
@@ -3,23 +3,9 @@
     "../.eslintrc"
   ],
 
-  "parserOptions": {
-    "ecmaVersion": 6,
-  },
-
-  "env": {
-    "es6": false,
-  },
-
   "globals": {
     "pdfjsImageDecoders": false,
     "pdfjsLib": false,
     "pdfjsViewer": false,
-    "Uint8Array": false,
   },
-
-  "rules": {
-    "no-alert": "off",
-    "object-shorthand": ["error", "never"]
-  }
 }

--- a/examples/acroforms/acroforms.js
+++ b/examples/acroforms/acroforms.js
@@ -37,11 +37,11 @@ loadingTask.promise.then(function (doc) {
         return doc.getPage(pageNum).then(function (pdfPage) {
           // Create the page view.
           var pdfPageView = new pdfjsViewer.PDFPageView({
-            container: container,
+            container,
             id: pageNum,
             scale: DEFAULT_SCALE,
             defaultViewport: pdfPage.getViewport({ scale: DEFAULT_SCALE }),
-            eventBus: eventBus,
+            eventBus,
             annotationLayerFactory: new pdfjsViewer.DefaultAnnotationLayerFactory(),
             renderInteractiveForms: true,
           });

--- a/examples/browserify/main.js
+++ b/examples/browserify/main.js
@@ -25,7 +25,7 @@ loadingTask.promise
       var ctx = canvas.getContext("2d");
       var renderTask = pdfPage.render({
         canvasContext: ctx,
-        viewport: viewport,
+        viewport,
       });
       return renderTask.promise;
     });

--- a/examples/components/pageviewer.js
+++ b/examples/components/pageviewer.js
@@ -16,6 +16,7 @@
 "use strict";
 
 if (!pdfjsLib.getDocument || !pdfjsViewer.PDFPageView) {
+  // eslint-disable-next-line no-alert
   alert("Please build the pdfjs-dist library using\n  `gulp dist-install`");
 }
 
@@ -48,11 +49,11 @@ loadingTask.promise.then(function (pdfDocument) {
   return pdfDocument.getPage(PAGE_TO_VIEW).then(function (pdfPage) {
     // Creating the page view with default parameters.
     var pdfPageView = new pdfjsViewer.PDFPageView({
-      container: container,
+      container,
       id: PAGE_TO_VIEW,
       scale: SCALE,
       defaultViewport: pdfPage.getViewport({ scale: SCALE }),
-      eventBus: eventBus,
+      eventBus,
       // We can enable text/annotations layers, if needed
       textLayerFactory: new pdfjsViewer.DefaultTextLayerFactory(),
       annotationLayerFactory: new pdfjsViewer.DefaultAnnotationLayerFactory(),

--- a/examples/components/simpleviewer.js
+++ b/examples/components/simpleviewer.js
@@ -16,6 +16,7 @@
 "use strict";
 
 if (!pdfjsLib.getDocument || !pdfjsViewer.PDFViewer) {
+  // eslint-disable-next-line no-alert
   alert("Please build the pdfjs-dist library using\n  `gulp dist-install`");
 }
 
@@ -38,18 +39,18 @@ var eventBus = new pdfjsViewer.EventBus();
 
 // (Optionally) enable hyperlinks within PDF files.
 var pdfLinkService = new pdfjsViewer.PDFLinkService({
-  eventBus: eventBus,
+  eventBus,
 });
 
 // (Optionally) enable find controller.
 var pdfFindController = new pdfjsViewer.PDFFindController({
-  eventBus: eventBus,
+  eventBus,
   linkService: pdfLinkService,
 });
 
 var pdfViewer = new pdfjsViewer.PDFViewer({
-  container: container,
-  eventBus: eventBus,
+  container,
+  eventBus,
   linkService: pdfLinkService,
   findController: pdfFindController,
 });

--- a/examples/components/singlepageviewer.js
+++ b/examples/components/singlepageviewer.js
@@ -16,6 +16,7 @@
 "use strict";
 
 if (!pdfjsLib.getDocument || !pdfjsViewer.PDFSinglePageViewer) {
+  // eslint-disable-next-line no-alert
   alert("Please build the pdfjs-dist library using\n  `gulp dist-install`");
 }
 
@@ -38,18 +39,18 @@ var eventBus = new pdfjsViewer.EventBus();
 
 // (Optionally) enable hyperlinks within PDF files.
 var pdfLinkService = new pdfjsViewer.PDFLinkService({
-  eventBus: eventBus,
+  eventBus,
 });
 
 // (Optionally) enable find controller.
 var pdfFindController = new pdfjsViewer.PDFFindController({
-  eventBus: eventBus,
+  eventBus,
   linkService: pdfLinkService,
 });
 
 var pdfSinglePageViewer = new pdfjsViewer.PDFSinglePageViewer({
-  container: container,
-  eventBus: eventBus,
+  container,
+  eventBus,
   linkService: pdfLinkService,
   findController: pdfFindController,
 });

--- a/examples/image_decoders/jpeg_viewer.js
+++ b/examples/image_decoders/jpeg_viewer.js
@@ -16,6 +16,7 @@
 "use strict";
 
 if (!pdfjsImageDecoders.JpegImage) {
+  // eslint-disable-next-line no-alert
   alert("Please build the pdfjs-dist library using `gulp dist-install`");
 }
 
@@ -61,8 +62,8 @@ jpegImage.parse(typedArrayImage);
 var width = jpegImage.width,
   height = jpegImage.height;
 var jpegData = jpegImage.getData({
-  width: width,
-  height: height,
+  width,
+  height,
   forceRGB: true,
 });
 

--- a/examples/mobile-viewer/viewer.js
+++ b/examples/mobile-viewer/viewer.js
@@ -16,6 +16,7 @@
 "use strict";
 
 if (!pdfjsLib.getDocument || !pdfjsViewer.PDFViewer) {
+  // eslint-disable-next-line no-alert
   alert("Please build the pdfjs-dist library using\n `gulp dist-install`");
 }
 
@@ -47,7 +48,7 @@ var PDFViewerApplication = {
    * @returns {Promise} - Returns the promise, which is resolved when document
    *                      is opened.
    */
-  open: function (params) {
+  open(params) {
     if (this.pdfLoadingTask) {
       // We need to destroy already opened document
       return this.close().then(
@@ -64,7 +65,7 @@ var PDFViewerApplication = {
 
     // Loading document.
     var loadingTask = pdfjsLib.getDocument({
-      url: url,
+      url,
       maxImageSize: MAX_IMAGE_SIZE,
       cMapUrl: CMAP_URL,
       cMapPacked: CMAP_PACKED,
@@ -120,7 +121,7 @@ var PDFViewerApplication = {
         }
 
         loadingErrorMessage.then(function (msg) {
-          self.error(msg, { message: message });
+          self.error(msg, { message });
         });
         self.loadingBar.hide();
       }
@@ -132,7 +133,7 @@ var PDFViewerApplication = {
    * @returns {Promise} - Returns the promise, which is resolved when all
    *                      destruction is completed.
    */
-  close: function () {
+  close() {
     var errorWrapper = document.getElementById("errorWrapper");
     errorWrapper.setAttribute("hidden", "true");
 
@@ -175,7 +176,7 @@ var PDFViewerApplication = {
     this.setTitle(title);
   },
 
-  setTitleUsingMetadata: function (pdfDocument) {
+  setTitleUsingMetadata(pdfDocument) {
     var self = this;
     pdfDocument.getMetadata().then(function (data) {
       var info = data.info,
@@ -345,7 +346,7 @@ var PDFViewerApplication = {
     this.eventBus = eventBus;
 
     var linkService = new pdfjsViewer.PDFLinkService({
-      eventBus: eventBus,
+      eventBus,
     });
     this.pdfLinkService = linkService;
 
@@ -353,9 +354,9 @@ var PDFViewerApplication = {
 
     var container = document.getElementById("viewerContainer");
     var pdfViewer = new pdfjsViewer.PDFViewer({
-      container: container,
-      eventBus: eventBus,
-      linkService: linkService,
+      container,
+      eventBus,
+      linkService,
       l10n: this.l10n,
       useOnlyCssZoom: USE_ONLY_CSS_ZOOM,
       textLayerMode: TEXT_LAYER_MODE,
@@ -364,8 +365,8 @@ var PDFViewerApplication = {
     linkService.setViewer(pdfViewer);
 
     this.pdfHistory = new pdfjsViewer.PDFHistory({
-      eventBus: eventBus,
-      linkService: linkService,
+      eventBus,
+      linkService,
     });
     linkService.setHistory(this.pdfHistory);
 

--- a/examples/node/domstubs.js
+++ b/examples/node/domstubs.js
@@ -58,7 +58,7 @@ function DOMElement(name) {
   if (name === "style") {
     this.sheet = {
       cssRules: [],
-      insertRule: function (rule) {
+      insertRule(rule) {
         this.cssRules.push(rule);
       },
     };
@@ -226,16 +226,16 @@ const document = {
     return this;
   },
 
-  createElementNS: function (NS, element) {
+  createElementNS(NS, element) {
     var elObject = new DOMElement(element);
     return elObject;
   },
 
-  createElement: function (element) {
+  createElement(element) {
     return this.createElementNS("", element);
   },
 
-  getElementsByTagName: function (element) {
+  getElementsByTagName(element) {
     if (element === "head") {
       return [this.head || (this.head = new DOMElement("head"))];
     }

--- a/examples/node/pdf2png/pdf2png.js
+++ b/examples/node/pdf2png/pdf2png.js
@@ -24,8 +24,8 @@ NodeCanvasFactory.prototype = {
     var canvas = Canvas.createCanvas(width, height);
     var context = canvas.getContext("2d");
     return {
-      canvas: canvas,
-      context: context,
+      canvas,
+      context,
     };
   },
 
@@ -61,7 +61,7 @@ var data = new Uint8Array(fs.readFileSync(pdfPath));
 
 // Load the PDF file.
 var loadingTask = pdfjsLib.getDocument({
-  data: data,
+  data,
   cMapUrl: CMAP_URL,
   cMapPacked: CMAP_PACKED,
 });
@@ -80,8 +80,8 @@ loadingTask.promise
       );
       var renderContext = {
         canvasContext: canvasAndContext.context,
-        viewport: viewport,
-        canvasFactory: canvasFactory,
+        viewport,
+        canvasFactory,
       };
 
       var renderTask = page.render(renderContext);

--- a/examples/node/pdf2svg.js
+++ b/examples/node/pdf2svg.js
@@ -71,7 +71,7 @@ ReadableSVGStream.prototype._read = function () {
 // Streams the SVG element to the given file path.
 function writeSvgToFile(svgElement, filePath) {
   var readableSvgStream = new ReadableSVGStream({
-    svgElement: svgElement,
+    svgElement,
   });
   var writableStream = fs.createWriteStream(filePath);
   return new Promise(function (resolve, reject) {
@@ -89,7 +89,7 @@ function writeSvgToFile(svgElement, filePath) {
 // Will be using promises to load document, pages and misc data instead of
 // callback.
 var loadingTask = pdfjsLib.getDocument({
-  data: data,
+  data,
   cMapUrl: CMAP_URL,
   cMapPacked: CMAP_PACKED,
   fontExtraProperties: true,

--- a/examples/svgviewer/viewer.js
+++ b/examples/svgviewer/viewer.js
@@ -16,6 +16,7 @@
 "use strict";
 
 if (!pdfjsLib.getDocument || !pdfjsViewer.PDFViewer) {
+  // eslint-disable-next-line no-alert
   alert("Please build the pdfjs-dist library using\n  `gulp dist-install`");
 }
 
@@ -37,12 +38,12 @@ var eventBus = new pdfjsViewer.EventBus();
 
 // (Optionally) enable hyperlinks within PDF files.
 var pdfLinkService = new pdfjsViewer.PDFLinkService({
-  eventBus: eventBus,
+  eventBus,
 });
 
 var pdfViewer = new pdfjsViewer.PDFViewer({
-  container: container,
-  eventBus: eventBus,
+  container,
+  eventBus,
   linkService: pdfLinkService,
   renderer: "svg",
   textLayerMode: 0,

--- a/examples/text-only/pdf2svg.js
+++ b/examples/text-only/pdf2svg.js
@@ -65,10 +65,8 @@ function pageLoaded() {
 
 document.addEventListener("DOMContentLoaded", function () {
   if (typeof pdfjsLib === "undefined") {
-    alert(
-      "Built version of PDF.js was not found.\n" +
-        "Please run `gulp dist-install`."
-    );
+    // eslint-disable-next-line no-alert
+    alert("Please build the pdfjs-dist library using\n  `gulp dist-install`");
     return;
   }
   pageLoaded();

--- a/examples/webpack/main.js
+++ b/examples/webpack/main.js
@@ -25,7 +25,7 @@ loadingTask.promise
       var ctx = canvas.getContext("2d");
       var renderTask = pdfPage.render({
         canvasContext: ctx,
-        viewport: viewport,
+        viewport,
       });
       return renderTask.promise;
     });

--- a/extensions/.eslintrc
+++ b/extensions/.eslintrc
@@ -1,9 +1,0 @@
-{
-  "extends": [
-    ../.eslintrc
-  ],
-
-  "rules": {
-    "no-restricted-globals": "off",
-  },
-}

--- a/external/.eslintrc
+++ b/external/.eslintrc
@@ -6,10 +6,4 @@
   "env": {
     "node": true,
   },
-
-  "rules": {
-    "mozilla/use-includes-instead-of-indexOf": "off",
-    "object-shorthand": "off",
-    "no-restricted-globals": "off",
-  },
 }

--- a/external/builder/preprocessor2.js
+++ b/external/builder/preprocessor2.js
@@ -35,7 +35,7 @@ function handlePreprocessorAction(ctx, actionName, args, loc) {
           throw new Error("No code for testing is given");
         }
         var isTrue = !!evalWithDefines(arg.value, ctx.defines);
-        return { type: "Literal", value: isTrue, loc: loc };
+        return { type: "Literal", value: isTrue, loc };
       case "eval":
         arg = args[0];
         if (!arg || arg.type !== "Literal" || typeof arg.value !== "string") {
@@ -47,7 +47,7 @@ function handlePreprocessorAction(ctx, actionName, args, loc) {
           typeof result === "string" ||
           typeof result === "number"
         ) {
-          return { type: "Literal", value: result, loc: loc };
+          return { type: "Literal", value: result, loc };
         }
         if (typeof result === "object") {
           const parsedObj = acorn.parse("(" + JSON.stringify(result) + ")", {
@@ -333,8 +333,8 @@ function preprocessPDFJSCode(ctx, code) {
     sourceType: "module",
   };
   var codegenOptions = {
-    format: format,
-    parse: function (input) {
+    format,
+    parse(input) {
       return acorn.parse(input, { ecmaVersion: ACORN_ECMA_VERSION });
     },
     sourceMap: ctx.sourceMap,

--- a/external/builder/test-fixtures_esprima.js
+++ b/external/builder/test-fixtures_esprima.js
@@ -34,8 +34,8 @@ files.forEach(function (expectationFilename) {
     "import-alias": "import-name",
   };
   var ctx = {
-    defines: defines,
-    map: map,
+    defines,
+    map,
     rootPath: __dirname + "/../..",
   };
   var out;

--- a/external/systemjs/plugin-babel-cached.js
+++ b/external/systemjs/plugin-babel-cached.js
@@ -46,11 +46,11 @@ function storeCache(address, hashCode, translated, format) {
     var tx = db.transaction(dbCacheTable, "readwrite");
     var store = tx.objectStore(dbCacheTable);
     store.put({
-      address: address,
-      hashCode: hashCode,
-      translated: translated,
+      address,
+      hashCode,
+      translated,
       expires: Date.now() + cacheExpiration,
-      format: format,
+      format,
     });
     return new Promise(function (resolve, reject) {
       tx.oncomplete = function () {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 /* eslint-env node */
-/* eslint-disable object-shorthand */
 /* globals target */
 
 "use strict";
@@ -222,7 +221,7 @@ function createWebpackConfig(
 
   return {
     mode: "none",
-    output: output,
+    output,
     performance: {
       hints: false, // Disable messages about larger file sizes.
     },
@@ -629,7 +628,7 @@ gulp.task("buildnumber", function (done) {
           "version.json",
           JSON.stringify(
             {
-              version: version,
+              version,
               build: buildNumber,
               commit: buildCommit,
             },

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -7,8 +7,4 @@
     "node": true,
     "jasmine": true,
   },
-
-  "rules": {
-    "no-restricted-globals": "off",
-  },
 }

--- a/test/chromium/test-telemetry.js
+++ b/test/chromium/test-telemetry.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable object-shorthand */
 
 "use strict";
 
@@ -110,17 +109,17 @@ function createExtensionGlobal() {
     };
     var headers = {};
     return {
-      open: function (method, url) {
+      open(method, url) {
         assert.equal(invoked.open, false);
         invoked.open = true;
         assert.equal(method, "POST");
         assert.equal(url, LOG_URL);
       },
-      setRequestHeader: function (k, v) {
+      setRequestHeader(k, v) {
         assert.equal(invoked.open, true);
         headers[k] = String(v);
       },
-      send: function (body) {
+      send(body) {
         assert.equal(invoked.open, true);
         assert.equal(invoked.send, false);
         invoked.send = true;
@@ -138,7 +137,7 @@ function createExtensionGlobal() {
   };
   window.Date = {
     test_now_value: Date.now(),
-    now: function () {
+    now() {
       return window.Date.test_now_value;
     },
   };

--- a/test/downloadutils.js
+++ b/test/downloadutils.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable object-shorthand */
 
 "use strict";
 
@@ -133,7 +132,7 @@ function downloadManifestFiles(manifest, callback) {
       var linkfile = file + ".link";
       var url = fs.readFileSync(linkfile).toString();
       url = url.replace(/\s+$/, "");
-      return { file: file, url: url };
+      return { file, url };
     });
 
   var i = 0;

--- a/test/test.js
+++ b/test/test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable object-shorthand */
 
 "use strict";
 
@@ -646,15 +645,15 @@ function refTestPostHandler(req, res) {
     }
 
     taskResults[round][page] = {
-      failure: failure,
-      snapshot: snapshot,
+      failure,
+      snapshot,
     };
     if (stats) {
       stats.push({
-        browser: browser,
+        browser,
         pdf: id,
-        page: page,
-        round: round,
+        page,
+        round,
         stats: data.stats,
       });
     }

--- a/test/webserver.js
+++ b/test/webserver.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable object-shorthand */
 
 "use strict";
 
@@ -53,7 +52,7 @@ function WebServer() {
   };
 }
 WebServer.prototype = {
-  start: function (callback) {
+  start(callback) {
     this._ensureNonZeroPort();
     this.server = http.createServer(this._handler.bind(this));
     this.server.listen(this.port, this.host, callback);
@@ -61,11 +60,11 @@ WebServer.prototype = {
       "Server running at http://" + this.host + ":" + this.port + "/"
     );
   },
-  stop: function (callback) {
+  stop(callback) {
     this.server.close(callback);
     this.server = null;
   },
-  _ensureNonZeroPort: function () {
+  _ensureNonZeroPort() {
     if (!this.port) {
       // If port is 0, a random port will be chosen instead. Do not set a host
       // name to make sure that the port is synchronously set by .listen().
@@ -78,7 +77,7 @@ WebServer.prototype = {
       server.close();
     }
   },
-  _handler: function (req, res) {
+  _handler(req, res) {
     var url = req.url.replace(/\/\//g, "/");
     var urlParts = /([^?]*)((?:\?(.*))?)/.exec(url);
     try {
@@ -312,7 +311,7 @@ WebServer.prototype = {
     function serveRequestedFileRange(reqFilePath, start, end) {
       var stream = fs.createReadStream(reqFilePath, {
         flags: "rs",
-        start: start,
+        start,
         end: end - 1,
       });
 


### PR DESCRIPTION
Given that browsers/environments without native support for both arrow functions and object shorthand properties are no longer supported in PDF.js, please refer to the compatibility information below, we can now enable a fair number of ESLint rules and also simplify/remove some `.eslintrc` files.

With the exception of the `no-alert` cases, all code changes were made automatically by using `gulp lint --fix`.

 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#browser_compatibility
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#browser_compatibility