### PR TITLE
Enable, a basic version of, the ESLint `no-use-before-define` rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -139,6 +139,11 @@
       "vars": "local",
       "args": "none",
     }],
+    "no-use-before-define": ["error", {
+      "functions": false,
+      "classes": false,
+      "variables": false,
+    }],
 
     // Node.js and CommonJS
     "no-buffer-constructor": "error",


### PR DESCRIPTION
Given how our existing code-base is written, we simply can't (and probably don't want to) enable *all* of this ESLint rule. The reason is that we have a lot of code, especially related to functions, which is fine at runtime but might to a static analyzer *look* like a problem.
However, even in its most *basic* version this ESLint rule can help catch some outright bugs; see PR #12891.

Please find additional details about the ESLint rule at https://eslint.org/docs/rules/no-use-before-define