### PR TITLE
Update the ESLint `env` to use "es2021"

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,7 @@
 
   "env": {
     "browser": true,
-    "es2020": true,
+    "es2021": true,
     "worker": true,
     "amd": true,
   },

--- a/src/scripting_api/app.js
+++ b/src/scripting_api/app.js
@@ -51,15 +51,12 @@ class App extends PDFObject {
     );
 
     this._timeoutIds = new WeakMap();
-    // eslint-disable-next-line no-undef
     if (typeof FinalizationRegistry !== "undefined") {
       // About setTimeOut/setInterval return values (specs):
       //   The return value of this method must be held in a
       //   JavaScript variable.
       //   Otherwise, the timeout object is subject to garbage-collection,
       //   which would cause the clock to stop.
-
-      // eslint-disable-next-line no-undef
       this._timeoutIdsRegistry = new FinalizationRegistry(
         this._cleanTimeout.bind(this)
       );


### PR DESCRIPTION
Currently this is inconsistent, since we're using ECMAScript 2021 in the parser options.