### PR TITLE
fix initial state of checkboxes in display layer

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -876,7 +876,10 @@ class CheckboxWidgetAnnotationElement extends WidgetAnnotationElement {
     const data = this.data;
     const id = data.id;
     const value = storage.getOrCreateValue(id, {
-      value: data.fieldValue && data.fieldValue !== "Off",
+      value:
+        data.fieldValue &&
+        ((data.exportValue && data.exportValue === data.fieldValue) ||
+          (!data.exportValue && data.fieldValue !== "Off")),
     }).value;
 
     this.container.className = "buttonWidgetAnnotation checkBox";

--- a/test/pdfs/issue12716.pdf.link
+++ b/test/pdfs/issue12716.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/5670936/form-cms1500.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -5013,5 +5013,15 @@
       "rounds": 1,
       "type": "eq",
       "forms": true
+    },
+    {
+      "id": "issue12716",
+      "file": "pdfs/issue12716.pdf",
+      "md5": "9bdc9c552bcfccd629f5f97385e79ca5",
+      "rounds": 1,
+      "link": true,
+      "type": "eq",
+      "forms": true,
+      "lastPage": 1
     }
 ]


### PR DESCRIPTION
When having multiple checkboxes with the same name, they behave like radiobuttons and the value "V" is equal to the export value of the checked checkbox.

Fixes #12716.