### PR TITLE
Fix text layer regression tests in using the correct line-height property

### DIFF
--- a/test/text_layer_test.css
+++ b/test/text_layer_test.css
@@ -21,6 +21,7 @@
   top: 0;
   right: 0;
   bottom: 0;
+  line-height: 1;
 }
 .textLayer > span {
   position: absolute;


### PR DESCRIPTION
The `line-height` property for text layer has been set:
https://github.com/mozilla/pdf.js/commit/a2cac8fa71945babc7e570b39bb3aa439b8bad0d
but the current css used for test hasn't the same.
It should fix the visual differences we've between reference images and what we can see locally. 