### PR TITLE
JS - QuickJS sandbox initialization must be the last evaluated string

### DIFF
--- a/src/pdf.sandbox.js
+++ b/src/pdf.sandbox.js
@@ -61,21 +61,22 @@ class Sandbox {
     if (TESTING) {
       this._module.ccall("nukeSandbox", null, []);
     }
-    const sandboxData = JSON.stringify(data);
-    const code = [
-      PDFJSDev.eval("PDF_SCRIPTING_JS_SOURCE"),
-      `pdfjsScripting.initSandbox({ data: ${sandboxData} })`,
-    ];
+    const code = [PDFJSDev.eval("PDF_SCRIPTING_JS_SOURCE")];
     if (!TESTING) {
       code.push("delete dump;");
     } else {
-      code.unshift(
+      code.push(
         `globalThis.sendResultForTesting = callExternalFunction.bind(null, "send");`
       );
     }
 
     let success = false;
     try {
+      const sandboxData = JSON.stringify(data);
+      // "pdfjsScripting.initSandbox..." MUST be the last line to be evaluated
+      // since the returned value is used for the communication.
+      code.push(`pdfjsScripting.initSandbox({ data: ${sandboxData} })`);
+
       success = !!this._module.ccall(
         "init",
         "number",


### PR DESCRIPTION
 - aims to fix issue #12912