### PR TITLE
fix(acroforms): pdf path in acroforms example

### DIFF
--- a/examples/acroforms/acroforms.js
+++ b/examples/acroforms/acroforms.js
@@ -18,7 +18,7 @@
 pdfjsLib.GlobalWorkerOptions.workerSrc =
   "../../node_modules/pdfjs-dist/build/pdf.worker.js";
 
-var DEFAULT_URL = "../../test/pdfs/f1040.pdf";
+var DEFAULT_URL = "../../test/pdfs/prefilled_f1040.pdf";
 var DEFAULT_SCALE = 1.0;
 
 var container = document.getElementById("pageContainer");


### PR DESCRIPTION
## Summary
f1040.pdf not found

## Steps to reproduce
[build acroforms example](https://github.com/mozilla/pdf.js/tree/master/examples/acroforms)

## Relevant logs
```
11:16:39,647 Uncaught (in promise) 
Object { message: "Missing PDF \"http://localhost:8888/test/pdfs/f1040.pdf\".", name: "MissingPDFException", stack: "BaseExceptionClosure@http://localhost:8888/node_modules/pdfjs-dist/build/pdf.js:1296:29\n__webpack_modules__<@http://localhost:8888/node_modules/pdfjs-dist/build/pdf.js:1299:2\n__w_pdfjs_require__@http://localhost:8888/node_modules/pdfjs-dist/build/pdf.js:15195:41\n__webpack_modules__<@http://localhost:8888/node_modules/pdfjs-dist/build/pdf.js:302:32\n__w_pdfjs_require__@http://localhost:8888/node_modules/pdfjs-dist/build/pdf.js:15195:41\n__webpack_modules__<@http://localhost:8888/node_modules/pdfjs-dist/build/pdf.js:237:41\n__w_pdfjs_require__@http://localhost:8888/node_modules/pdfjs-dist/build/pdf.js:15195:41\n@http://localhost:8888/node_modules/pdfjs-dist/build/pdf.js:15205:18\n@http://localhost:8888/node_modules/pdfjs-dist/build/pdf.js:15206:12\nwebpackUniversalModuleDefinition@http://localhost:8888/node_modules/pdfjs-dist/build/pdf.js:31:50\n@http://localhost:8888/node_modules/pdfjs-dist/build/pdf.js:32:3\n" }
```
