### PR TITLE
Ignore globally cached images in `PartialEvaluator.getTextContent` (PR 11930 follow-up)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -2515,6 +2515,15 @@ class PartialEvaluator {
                     return;
                   }
 
+                  const globalImage = self.globalImageCache.getData(
+                    xobj,
+                    self.pageIndex
+                  );
+                  if (globalImage) {
+                    resolveXObject();
+                    return;
+                  }
+
                   xobj = xref.fetch(xobj);
                 }
 

--- a/src/core/image_utils.js
+++ b/src/core/image_utils.js
@@ -247,13 +247,14 @@ class GlobalImageCache {
     if (pageIndexSet.size < GlobalImageCache.NUM_PAGES_THRESHOLD) {
       return null;
     }
-    if (!this._imageCache.has(ref)) {
+    const imageData = this._imageCache.get(ref);
+    if (!imageData) {
       return null;
     }
     // Ensure that we keep track of all pages containing the image reference.
     pageIndexSet.add(pageIndex);
 
-    return this._imageCache.get(ref);
+    return imageData;
   }
 
   setData(ref, data) {


### PR DESCRIPTION
Given that we'll only cache `/XObject`s of the `Image`-type globally, we can utilize that in `PartialEvaluator.getTextContent` as well. This way, in cases such as e.g. issue #12098, we can avoid having to fetch/parse `/XObject`s that we already know to be `Image`s. This is helpful, since `Stream`s are not cached on the `XRef` instance (given their potential size) and the lookup can thus be somewhat expensive in general.

Also, skip a redundant `RefSetCache.has` check in the `GlobalImageCache.getData` method.