### PR TITLE
Fix font data clone error when pdfBug is enabled.

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -3192,7 +3192,7 @@ class PartialEvaluator {
 
   getBaseFontMetrics(name) {
     var defaultWidth = 0;
-    var widths = [];
+    var widths = Object.create(null);
     var monospace = false;
     var stdFontMap = getStdFontMap();
     var lookupName = stdFontMap[name] || name;


### PR DESCRIPTION
The widths property should be an object to match what metrics returns.

In ZapfDingbats.pdf I was getting a data clone error with pdfBug enabled.
In buildCharCodeToWidth() there was an encoding with the name "at" which
is also the name of a method on an array. buildCharCodeToWidth assumes an
object is passed in, so when it checked for the "at" property, it found the
method and copied it over.

This only seemed to affect Firefox.