### PR TITLE
Stop showing the fallback bar for "errorFontLoadNative" errors (PR 10539 follow-up)

### DIFF
--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -350,7 +350,7 @@ class FontFaceObject {
       isEvalSupported = true,
       disableFontFace = false,
       ignoreErrors = false,
-      onUnsupportedFeature = null,
+      onUnsupportedFeature,
       fontRegistry = null,
     }
   ) {
@@ -405,11 +405,9 @@ class FontFaceObject {
       if (!this.ignoreErrors) {
         throw ex;
       }
-      if (this._onUnsupportedFeature) {
-        this._onUnsupportedFeature({
-          featureId: UNSUPPORTED_FEATURES.errorFontGetPath,
-        });
-      }
+      this._onUnsupportedFeature({
+        featureId: UNSUPPORTED_FEATURES.errorFontGetPath,
+      });
       warn(`getPathGenerator - ignoring character: "${ex}".`);
 
       return (this.compiledGlyphs[character] = function (c, size) {

--- a/web/app.js
+++ b/web/app.js
@@ -1089,6 +1089,12 @@ const PDFViewerApplication = {
       featureId,
     });
 
+    // Don't show the fallback bar for things that are *very* unlikely to cause
+    // user-visible errors, to avoid bothering the user unnecessarily.
+    switch (featureId) {
+      case UNSUPPORTED_FEATURES.errorFontLoadNative:
+        return;
+    }
     // Only trigger the fallback once so we don't spam the user with messages
     // for one PDF.
     if (this.fellback) {


### PR DESCRIPTION
With PR #10539, we'll now always attempt to fallback to the PDF.js built-in font renderer for fonts that fail to load (i.e. are rejected by the sanitizer). Generally speaking, these errors are the result of insufficient validation in the PDF.js font code, however in almost all cases we've seen thus far our built-in font renderer manages just fine.
However, we still trigger the `onUnsupportedFeature` reporting, which in Firefox causes the fallback bar to be displayed. Given that, in a majority of cases[1], things look fine it seems unfortunate to bother the user with the fallback bar here.

Note that even though we no longer show the fallback bar in this case, we still report telemetry as before.

---
[1] The only *known* case where things aren't fine with the built-in font renderer is issue #10232, however that document is sufficiently broken that there's a couple of other things that will trigger the fallback bar.

