### PR TITLE
Stop including `-ms` prefixed CSS rules in GENERIC builds

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -85,6 +85,7 @@ var AUTOPREFIXER_CONFIG = {
     "Firefox ESR",
     "Safari >= 10",
     "> 0.5%",
+    "not IE > 0",
     "not dead",
   ],
 };


### PR DESCRIPTION
Given that IE 11/Edge is now unsupported in PDF.js, and that Microsoft Edge is now a Chromium-browser, we can avoid (some) unnecessary bloat in the built CSS files.