### PR TITLE
Stop polyfilling CSS variables in GENERIC builds

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,6 @@
 
 var autoprefixer = require("autoprefixer");
 var calc = require("postcss-calc");
-var cssvariables = require("postcss-css-variables");
 var fs = require("fs");
 var gulp = require("gulp");
 var postcss = require("gulp-postcss");
@@ -88,9 +87,6 @@ var AUTOPREFIXER_CONFIG = {
     "not IE > 0",
     "not dead",
   ],
-};
-var CSS_VARIABLES_CONFIG = {
-  preserve: true,
 };
 
 const DEFINES = Object.freeze({
@@ -846,13 +842,7 @@ function buildGeneric(defines, dir) {
       .pipe(gulp.dest(dir + "web/cmaps")),
     preprocessHTML("web/viewer.html", defines).pipe(gulp.dest(dir + "web")),
     preprocessCSS("web/viewer.css", "generic", defines, true)
-      .pipe(
-        postcss([
-          cssvariables(CSS_VARIABLES_CONFIG),
-          calc(),
-          autoprefixer(AUTOPREFIXER_CONFIG),
-        ])
-      )
+      .pipe(postcss([calc(), autoprefixer(AUTOPREFIXER_CONFIG)]))
       .pipe(gulp.dest(dir + "web")),
 
     gulp
@@ -924,13 +914,7 @@ function buildComponents(defines, dir) {
     createComponentsBundle(defines).pipe(gulp.dest(dir)),
     gulp.src(COMPONENTS_IMAGES).pipe(gulp.dest(dir + "images")),
     preprocessCSS("web/pdf_viewer.css", "components", defines, true)
-      .pipe(
-        postcss([
-          cssvariables(CSS_VARIABLES_CONFIG),
-          calc(),
-          autoprefixer(AUTOPREFIXER_CONFIG),
-        ])
-      )
+      .pipe(postcss([calc(), autoprefixer(AUTOPREFIXER_CONFIG)]))
       .pipe(gulp.dest(dir)),
   ]);
 }
@@ -1019,13 +1003,7 @@ function buildMinified(defines, dir) {
 
     preprocessHTML("web/viewer.html", defines).pipe(gulp.dest(dir + "web")),
     preprocessCSS("web/viewer.css", "minified", defines, true)
-      .pipe(
-        postcss([
-          cssvariables(CSS_VARIABLES_CONFIG),
-          calc(),
-          autoprefixer(AUTOPREFIXER_CONFIG),
-        ])
-      )
+      .pipe(postcss([calc(), autoprefixer(AUTOPREFIXER_CONFIG)]))
       .pipe(gulp.dest(dir + "web")),
 
     gulp

--- a/package-lock.json
+++ b/package-lock.json
@@ -13623,31 +13623,6 @@
         }
       }
     },
-    "postcss-css-variables": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/postcss-css-variables/-/postcss-css-variables-0.17.0.tgz",
-      "integrity": "sha512-/ZpFnJgksNOrQA72b3DKhExYh+0e2P5nEc3aPZ62G7JLmdDjWRFv3k/q4LxV7uzXFnmvkhXRbdVIiH5tKgfFNA==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "escape-string-regexp": "^1.0.3",
-        "extend": "^3.0.1",
-        "postcss": "^6.0.8"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
-          }
-        }
-      }
-    },
     "postcss-html": {
       "version": "0.36.0",
       "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.36.0.tgz",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "needle": "^2.6.0",
     "postcss": "^8.2.4",
     "postcss-calc": "^7.0.5",
-    "postcss-css-variables": "^0.17.0",
     "prettier": "^2.2.1",
     "puppeteer": "^5.5.0",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
At this point in time, all browsers that we support have native support for CSS variables; please see https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties#browser_compatibility and https://github.com/mozilla/pdf.js/blob/9af8501e6c44eb32bea905c3b56b4c1e6c5f5ba5/gulpfile.js#L79-L91

This reduces the size of the *built* `viewer.css` file, in GENERIC builds, from `93 814` to `55 285` bytes (~41 percent).