### PR TITLE
Don't focus the `PasswordPrompt` input-field on load, when the viewer is embedded in e.g. an `iframe` (issue 12951)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -558,7 +558,8 @@ const PDFViewerApplication = {
     this.passwordPrompt = new PasswordPrompt(
       appConfig.passwordOverlay,
       this.overlayManager,
-      this.l10n
+      this.l10n,
+      this.isViewerEmbedded
     );
 
     this.pdfOutlineViewer = new PDFOutlineViewer({

--- a/web/password_prompt.js
+++ b/web/password_prompt.js
@@ -34,8 +34,15 @@ class PasswordPrompt {
    * @param {PasswordPromptOptions} options
    * @param {OverlayManager} overlayManager - Manager for the viewer overlays.
    * @param {IL10n} l10n - Localization service.
+   * @param {boolean} [isViewerEmbedded] - If the viewer is embedded, in e.g.
+   *   an <iframe> or an <object>. The default value is `false`.
    */
-  constructor(options, overlayManager, l10n = NullL10n) {
+  constructor(
+    options,
+    overlayManager,
+    l10n = NullL10n,
+    isViewerEmbedded = false
+  ) {
     this.overlayName = options.overlayName;
     this.container = options.container;
     this.label = options.label;
@@ -44,6 +51,7 @@ class PasswordPrompt {
     this.cancelButton = options.cancelButton;
     this.overlayManager = overlayManager;
     this.l10n = l10n;
+    this._isViewerEmbedded = isViewerEmbedded;
 
     this.updateCallback = null;
     this.reason = null;
@@ -67,7 +75,12 @@ class PasswordPrompt {
 
   open() {
     this.overlayManager.open(this.overlayName).then(() => {
-      this.input.focus();
+      if (
+        !this._isViewerEmbedded ||
+        this.reason === PasswordResponses.INCORRECT_PASSWORD
+      ) {
+        this.input.focus();
+      }
 
       let promptString;
       if (this.reason === PasswordResponses.INCORRECT_PASSWORD) {


### PR DESCRIPTION
Given that we don't focus the viewer *itself* (among other things) when the viewer is embedded, I suppose that it makes some sense to not focus the `PasswordPrompt` input-field either on load.
In order to improve the overall UX here, if an *incorrect* password was provided we'll still focus the input-field.

Fixes #12951 (assuming we care to do so, of course).