### PR TITLE
XFA -- Add attributes and children in XFAObject

### DIFF
--- a/src/core/xfa/config.js
+++ b/src/core/xfa/config.js
@@ -19,6 +19,7 @@ import {
   OptionObject,
   StringObject,
   XFAObject,
+  XFAObjectArray,
 } from "./xfa_object.js";
 
 const CONFIG_NS_ID = NamespaceIds.config.id;
@@ -31,7 +32,7 @@ class Acrobat extends XFAObject {
     this.common = null;
     this.validate = null;
     this.validateApprovalSignatures = null;
-    this.submitUrl = [];
+    this.submitUrl = new XFAObjectArray();
   }
 }
 
@@ -60,7 +61,7 @@ class Config extends XFAObject {
     this.acrobat = null;
     this.present = null;
     this.trace = null;
-    this.agent = [];
+    this.agent = new XFAObjectArray();
   }
 }
 
@@ -87,14 +88,14 @@ class Present extends XFAObject {
     this.script = null;
     this.validate = null;
     this.xdp = null;
-    this.driver = [];
-    this.labelPrinter = [];
-    this.pcl = [];
-    this.pdf = [];
-    this.ps = [];
-    this.submitUrl = [];
-    this.webClient = [];
-    this.zpl = [];
+    this.driver = new XFAObjectArray();
+    this.labelPrinter = new XFAObjectArray();
+    this.pcl = new XFAObjectArray();
+    this.pdf = new XFAObjectArray();
+    this.ps = new XFAObjectArray();
+    this.submitUrl = new XFAObjectArray();
+    this.webClient = new XFAObjectArray();
+    this.zpl = new XFAObjectArray();
   }
 }
 

--- a/src/core/xfa/xdp.js
+++ b/src/core/xfa/xdp.js
@@ -19,6 +19,7 @@ import {
   $nodeName,
   $onChildCheck,
   XFAObject,
+  XFAObjectArray,
 } from "./xfa_object.js";
 
 const XDP_NS_ID = NamespaceIds.xdp.id;
@@ -32,7 +33,7 @@ class Xdp extends XFAObject {
     this.connectionSet = null;
     this.datasets = null;
     this.localeSet = null;
-    this.stylesheet = [];
+    this.stylesheet = new XFAObjectArray();
     this.template = null;
   }
 


### PR DESCRIPTION
 - in order to evaluate SOM expressions nodes and their attributes must be checked in the same order as in the xml;
 - add an object XFAObjectArray with a parameter max to handle multiple children with the same name.