### PR TITLE
Use optional chaining, where possible, in the `web/`-folder

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1326,7 +1326,7 @@ const PDFViewerApplication = {
           this._initializePdfHistory({
             fingerprint: pdfDocument.fingerprint,
             viewOnLoad,
-            initialDest: openAction && openAction.dest,
+            initialDest: openAction?.dest,
           });
           const initialBookmark = this.initialBookmark;
 
@@ -1776,11 +1776,11 @@ const PDFViewerApplication = {
     );
 
     let pdfTitle;
-    const infoTitle = info && info.Title;
+    const infoTitle = info?.Title;
     if (infoTitle) {
       pdfTitle = infoTitle;
     }
-    const metadataTitle = metadata && metadata.get("dc:title");
+    const metadataTitle = metadata?.get("dc:title");
     if (metadataTitle) {
       // Ghostscript can produce invalid 'dc:title' Metadata entries:
       //  - The title may be "Untitled" (fixes bug 1031612).
@@ -2372,11 +2372,12 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
         throw new Error("file origin does not match viewer's");
       }
     } catch (ex) {
-      const message = ex && ex.message;
       PDFViewerApplication.l10n
         .get("loading_error", null, "An error occurred while loading the PDF.")
         .then(loadingErrorMessage => {
-          PDFViewerApplication.error(loadingErrorMessage, { message });
+          PDFViewerApplication.error(loadingErrorMessage, {
+            message: ex?.message,
+          });
         });
       throw ex;
     }
@@ -2409,7 +2410,7 @@ function reportPageStatsPDFBug({ pageNumber }) {
   const pageView = PDFViewerApplication.pdfViewer.getPageView(
     /* index = */ pageNumber - 1
   );
-  const pageStats = pageView && pageView.pdfPage && pageView.pdfPage.stats;
+  const pageStats = pageView?.pdfPage?.stats;
   if (!pageStats) {
     return;
   }
@@ -2714,8 +2715,7 @@ function webViewerUpdateViewarea(evt) {
   const currentPage = PDFViewerApplication.pdfViewer.getPageView(
     /* index = */ PDFViewerApplication.page - 1
   );
-  const loading =
-    (currentPage && currentPage.renderingState) !== RenderingStates.FINISHED;
+  const loading = currentPage?.renderingState !== RenderingStates.FINISHED;
   PDFViewerApplication.toolbar.updateLoadingIndicatorState(loading);
 }
 
@@ -2767,10 +2767,7 @@ function webViewerHashchange(evt) {
 let webViewerFileInputChange, webViewerOpenFile;
 if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
   webViewerFileInputChange = function (evt) {
-    if (
-      PDFViewerApplication.pdfViewer &&
-      PDFViewerApplication.pdfViewer.isInPresentationMode
-    ) {
+    if (PDFViewerApplication.pdfViewer?.isInPresentationMode) {
       return; // Opening a new PDF file isn't supported in Presentation Mode.
     }
     const file = evt.fileInput.files[0];
@@ -3108,8 +3105,7 @@ function webViewerKeyDown(evt) {
     (evt.metaKey ? 8 : 0);
 
   const pdfViewer = PDFViewerApplication.pdfViewer;
-  const isViewerInPresentationMode =
-    pdfViewer && pdfViewer.isInPresentationMode;
+  const isViewerInPresentationMode = pdfViewer?.isInPresentationMode;
 
   // First, handle the key bindings that are independent whether an input
   // control is selected or not.
@@ -3234,12 +3230,12 @@ function webViewerKeyDown(evt) {
   // Some shortcuts should not get handled if a control/input element
   // is selected.
   const curElement = getActiveOrFocusedElement();
-  const curElementTagName = curElement && curElement.tagName.toUpperCase();
+  const curElementTagName = curElement?.tagName.toUpperCase();
   if (
     curElementTagName === "INPUT" ||
     curElementTagName === "TEXTAREA" ||
     curElementTagName === "SELECT" ||
-    (curElement && curElement.isContentEditable)
+    curElement?.isContentEditable
   ) {
     // Make sure that the secondary toolbar is closed when Escape is pressed.
     if (evt.keyCode !== /* Esc = */ 27) {

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -240,7 +240,7 @@ class BaseViewer {
     // Prevent printing errors when 'disableAutoFetch' is set, by ensuring
     // that *all* pages have in fact been completely loaded.
     return this._pages.every(function (pageView) {
-      return pageView && pageView.pdfPage;
+      return pageView?.pdfPage;
     });
   }
 

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -290,7 +290,7 @@ class BaseViewer {
     this.eventBus.dispatch("pagechanging", {
       source: this,
       pageNumber: val,
-      pageLabel: this._pageLabels && this._pageLabels[val - 1],
+      pageLabel: this._pageLabels?.[val - 1] ?? null,
       previous,
     });
 
@@ -305,7 +305,7 @@ class BaseViewer {
    *   labels exist.
    */
   get currentPageLabel() {
-    return this._pageLabels && this._pageLabels[this._currentPageNumber - 1];
+    return this._pageLabels?.[this._currentPageNumber - 1] ?? null;
   }
 
   /**
@@ -631,9 +631,7 @@ class BaseViewer {
     }
     // Update all the `PDFPageView` instances.
     for (let i = 0, ii = this._pages.length; i < ii; i++) {
-      const pageView = this._pages[i];
-      const label = this._pageLabels && this._pageLabels[i];
-      pageView.setPageLabel(label);
+      this._pages[i].setPageLabel(this._pageLabels?.[i] ?? null);
     }
   }
 

--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -132,7 +132,7 @@ function isRuntimeAvailable() {
   try {
     // When the extension is reloaded, the extension runtime is destroyed and
     // the extension APIs become unavailable.
-    if (chrome.runtime && chrome.runtime.getManifest()) {
+    if (chrome.runtime?.getManifest()) {
       return true;
     }
   } catch (e) {}
@@ -181,7 +181,7 @@ function requestAccessToLocalFile(fileUrl, overlayManager, callback) {
     // These strings are from chrome/app/resources/generated_resources_*.xtb.
     const i18nFileAccessLabel = PDFJSDev.json(
       "$ROOT/web/chrome-i18n-allow-access-to-file-urls.json"
-    )[chrome.i18n.getUILanguage && chrome.i18n.getUILanguage()];
+    )[chrome.i18n.getUILanguage?.()];
 
     if (i18nFileAccessLabel) {
       document.getElementById(
@@ -279,7 +279,7 @@ function setReferer(url, callback) {
   port.onMessage.addListener(onMessage);
   // Initiate the information exchange.
   port.postMessage({
-    referer: window.history.state && window.history.state.chromecomState,
+    referer: window.history.state?.chromecomState,
     requestUrl: url,
   });
 

--- a/web/password_prompt.js
+++ b/web/password_prompt.js
@@ -111,7 +111,7 @@ class PasswordPrompt {
 
   verify() {
     const password = this.input.value;
-    if (password && password.length > 0) {
+    if (password?.length > 0) {
       this.close();
       this.updateCallback(password);
     }

--- a/web/pdf_layer_viewer.js
+++ b/web/pdf_layer_viewer.js
@@ -122,7 +122,7 @@ class PDFLayerViewer extends BaseTreeViewer {
     this._optionalContentConfig = optionalContentConfig || null;
     this._pdfDocument = pdfDocument || null;
 
-    const groups = optionalContentConfig && optionalContentConfig.getOrder();
+    const groups = optionalContentConfig?.getOrder();
     if (!groups) {
       this._dispatchEvent(/* layersCount = */ 0);
       return;

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -445,7 +445,7 @@ class PDFLinkService {
   _cachedPageNumber(pageRef) {
     const refStr =
       pageRef.gen === 0 ? `${pageRef.num}R` : `${pageRef.num}R${pageRef.gen}`;
-    return (this._pagesRefCache && this._pagesRefCache[refStr]) || null;
+    return this._pagesRefCache?.[refStr] || null;
   }
 
   /**

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -199,8 +199,7 @@ class PDFPageView {
     const childNodes = div.childNodes;
     const currentZoomLayerNode = (keepZoomLayer && this.zoomLayer) || null;
     const currentAnnotationNode =
-      (keepAnnotations && this.annotationLayer && this.annotationLayer.div) ||
-      null;
+      (keepAnnotations && this.annotationLayer?.div) || null;
     for (let i = childNodes.length - 1; i >= 0; i--) {
       const node = childNodes[i];
       if (currentZoomLayerNode === node || currentAnnotationNode === node) {
@@ -437,7 +436,7 @@ class PDFPageView {
     canvasWrapper.style.height = div.style.height;
     canvasWrapper.classList.add("canvasWrapper");
 
-    if (this.annotationLayer && this.annotationLayer.div) {
+    if (this.annotationLayer?.div) {
       // The annotation layer needs to stay on top.
       div.insertBefore(canvasWrapper, this.annotationLayer.div);
     } else {
@@ -450,7 +449,7 @@ class PDFPageView {
       textLayerDiv.className = "textLayer";
       textLayerDiv.style.width = canvasWrapper.style.width;
       textLayerDiv.style.height = canvasWrapper.style.height;
-      if (this.annotationLayer && this.annotationLayer.div) {
+      if (this.annotationLayer?.div) {
         // The annotation layer needs to stay on top.
         div.insertBefore(textLayerDiv, this.annotationLayer.div);
       } else {

--- a/web/pdf_sidebar.js
+++ b/web/pdf_sidebar.js
@@ -331,7 +331,7 @@ class PDFSidebar {
     const pagesCount = pdfViewer.pagesCount;
     for (let pageIndex = 0; pageIndex < pagesCount; pageIndex++) {
       const pageView = pdfViewer.getPageView(pageIndex);
-      if (pageView && pageView.renderingState === RenderingStates.FINISHED) {
+      if (pageView?.renderingState === RenderingStates.FINISHED) {
         const thumbnailView = pdfThumbnailViewer.getThumbnail(pageIndex);
         thumbnailView.setImage(pageView);
       }

--- a/web/pdf_sidebar_resizer.js
+++ b/web/pdf_sidebar_resizer.js
@@ -131,7 +131,7 @@ class PDFSidebarResizer {
     });
 
     this.eventBus._on("sidebarviewchanged", evt => {
-      this.sidebarOpen = !!(evt && evt.view);
+      this.sidebarOpen = !!evt?.view;
     });
 
     this.eventBus._on("resize", evt => {

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -268,8 +268,7 @@ class PDFThumbnailViewer {
     }
     // Update all the `PDFThumbnailView` instances.
     for (let i = 0, ii = this._thumbnails.length; i < ii; i++) {
-      const label = this._pageLabels && this._pageLabels[i];
-      this._thumbnails[i].setPageLabel(label);
+      this._thumbnails[i].setPageLabel(this._pageLabels?.[i] ?? null);
     }
   }
 

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -338,7 +338,7 @@ class TextLayerBuilder {
       clearedUntilDivIdx = match.end.divIdx + 1;
     }
 
-    if (!findController || !findController.highlightMatches) {
+    if (!findController?.highlightMatches) {
       return;
     }
     // Convert the matches on the `findController` into the match format

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -787,7 +787,7 @@ function dispatchDOMEvent(eventName, args = null) {
     throw new Error("Not implemented: dispatchDOMEvent");
   }
   const details = Object.create(null);
-  if (args && args.length > 0) {
+  if (args?.length > 0) {
     const obj = args[0];
     for (const key in obj) {
       const value = obj[key];
@@ -1022,7 +1022,7 @@ function getActiveOrFocusedElement() {
   let curActiveOrFocused =
     curRoot.activeElement || curRoot.querySelector(":focus");
 
-  while (curActiveOrFocused && curActiveOrFocused.shadowRoot) {
+  while (curActiveOrFocused?.shadowRoot) {
     curRoot = curActiveOrFocused.shadowRoot;
     curActiveOrFocused =
       curRoot.activeElement || curRoot.querySelector(":focus");


### PR DESCRIPTION
 - Slightly re-factor how the `BaseViewer`/`PDFThumbnailViewer` handle page labels internally, to make the `null` default value clearer

   Currently it's not *immediately* clear from the code itself, unless you look at the definition of `this._pageLabels`, that the default value is `null`.[1]
   We can improve this, and also reduce the amount of code, by using modern ECMAScript features such as optional chaining and nullish coalescing.

   ---
   [1] Keep in mind that an *empty* string is actually a valid page label, according to the PDF specification.

 - Use optional chaining, where possible, in the `web/`-folder

   By using optional chaining, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining, it's possible to reduce unnecessary code-repetition in many cases.

