### PR TITLE
Request all data, rather than throwing, when encountering general errors in `ObjectLoader._walk` (issue 9462, PR 3289 follow-up)

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -2556,7 +2556,11 @@ const ObjectLoader = (function () {
             currentNode = this.xref.fetch(currentNode);
           } catch (ex) {
             if (!(ex instanceof MissingDataException)) {
-              throw ex;
+              warn(`ObjectLoader._walk - requesting all data: "${ex}".`);
+              this.refSet = null;
+
+              const { manager } = this.xref.stream;
+              return manager.requestAllChunks();
             }
             nodesToRevisit.push(currentNode);
             pendingRequests.push({ begin: ex.begin, end: ex.end });

--- a/test/pdfs/issue9462.pdf.link
+++ b/test/pdfs/issue9462.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/1706865/cb7e7bd2362328f37fe97dc8dff151a3.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1127,6 +1127,15 @@
        "rounds": 1,
        "type": "load"
     },
+    {  "id": "issue9462",
+       "file": "pdfs/issue9462.pdf",
+       "md5": "0a2895b0aa8a8ef730a20b4116cd996c",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 3,
+       "lastPage": 3,
+       "type": "eq"
+    },
     {  "id": "f1040",
        "file": "pdfs/f1040.pdf",
        "md5": "7323b50c6d28d959b8b4b92c469b2469",


### PR DESCRIPTION
*As far as I can tell, this has been broken ever since PR #3289 (back in 2013) without anyone noticing.*

For any non-`MissingDataException` errors encountered in `ObjectLoader._walk`, we're simply throwing immediately which thus has the potential to *completely* break rendering of an entire page.
In practice this is obviously only an issue for PDF documents which are in one way or another corrupt, since that's the only way that `XRef.fetch` will throw non-`MissingDataException` errors. To make matters worse these errors are *intermittent*, since they can only occur if the document is still loading when the `ObjectLoader`-code runs (note the early return in `ObjectLoader.load`).

Please note that we cannot simply catch the error and let "normal" parsing continue in `ObjectLoader._walk`, since that could lead to errors elsewhere given that resources "below" the current one (in the graph) might not be checked as intended then.
All-in-all, the only way to make absolutely sure that we won't cause *unexpected* `MissingDataException`s somewhere else in the code-base is to fallback to fetching the *entire* document in this edge-case.

---

While debugging and fixing this, I went through every stage of http://plasmasturm.org/log/6debug/

