### PR TITLE
[Firefox] Unblock load event on error.

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -721,6 +721,7 @@ const PDFViewerApplication = {
         PDFViewerApplication.open(file, args);
       },
       onError(err) {
+        PDFViewerApplication._unblockDocumentLoadEvent();
         PDFViewerApplication.l10n
           .get(
             "loading_error",


### PR DESCRIPTION
We can get this when loading a PDF with no data, etc.