### PR TITLE
Split `PDFViewerApplication.error` into two methods, for PDF document loading/parsing errors vs other errors (PR 11647 follow-up)

### DIFF
--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -86,7 +86,7 @@ const ChromeCom = {
         // Even without this check, the file load in frames is still blocked,
         // but this may change in the future (https://crbug.com/550151).
         if (origin && !/^file:|^chrome-extension:/.test(origin)) {
-          PDFViewerApplication.error(
+          PDFViewerApplication._documentError(
             "Blocked " +
               origin +
               " from loading " +


### PR DESCRIPTION
With these changes, we can easily unblock the "load" event regardless of where an error occurred.

/cc @emilio 