### PR TITLE
Use DOM hidden property instead of attribute methods

### DIFF
--- a/examples/mobile-viewer/viewer.js
+++ b/examples/mobile-viewer/viewer.js
@@ -135,7 +135,7 @@ var PDFViewerApplication = {
    */
   close() {
     var errorWrapper = document.getElementById("errorWrapper");
-    errorWrapper.setAttribute("hidden", "true");
+    errorWrapper.hidden = true;
 
     if (!this.pdfLoadingTask) {
       return Promise.resolve();
@@ -270,32 +270,32 @@ var PDFViewerApplication = {
     }
 
     var errorWrapper = document.getElementById("errorWrapper");
-    errorWrapper.removeAttribute("hidden");
+    errorWrapper.hidden = false;
 
     var errorMessage = document.getElementById("errorMessage");
     errorMessage.textContent = message;
 
     var closeButton = document.getElementById("errorClose");
     closeButton.onclick = function () {
-      errorWrapper.setAttribute("hidden", "true");
+      errorWrapper.hidden = true;
     };
 
     var errorMoreInfo = document.getElementById("errorMoreInfo");
     var moreInfoButton = document.getElementById("errorShowMore");
     var lessInfoButton = document.getElementById("errorShowLess");
     moreInfoButton.onclick = function () {
-      errorMoreInfo.removeAttribute("hidden");
-      moreInfoButton.setAttribute("hidden", "true");
-      lessInfoButton.removeAttribute("hidden");
+      errorMoreInfo.hidden = false;
+      moreInfoButton.hidden = true;
+      lessInfoButton.hidden = false;
       errorMoreInfo.style.height = errorMoreInfo.scrollHeight + "px";
     };
     lessInfoButton.onclick = function () {
-      errorMoreInfo.setAttribute("hidden", "true");
-      moreInfoButton.removeAttribute("hidden");
-      lessInfoButton.setAttribute("hidden", "true");
+      errorMoreInfo.hidden = true;
+      moreInfoButton.hidden = false;
+      lessInfoButton.hidden = true;
     };
-    moreInfoButton.removeAttribute("hidden");
-    lessInfoButton.setAttribute("hidden", "true");
+    moreInfoButton.hidden = false;
+    lessInfoButton.hidden = true;
     Promise.all(moreInfoText).then(function (parts) {
       errorMoreInfo.value = parts.join("\n");
     });

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -1353,7 +1353,7 @@ class PopupElement {
     // annotation, we cannot hide the entire container as the image would
     // disappear too. In that special case, hiding the wrapper suffices.
     this.hideElement = this.hideWrapper ? wrapper : this.container;
-    this.hideElement.setAttribute("hidden", true);
+    this.hideElement.hidden = true;
 
     const popup = document.createElement("div");
     popup.className = "popup";
@@ -1451,8 +1451,8 @@ class PopupElement {
     if (pin) {
       this.pinned = true;
     }
-    if (this.hideElement.hasAttribute("hidden")) {
-      this.hideElement.removeAttribute("hidden");
+    if (this.hideElement.hidden) {
+      this.hideElement.hidden = false;
       this.container.style.zIndex += 1;
     }
   }
@@ -1468,8 +1468,8 @@ class PopupElement {
     if (unpin) {
       this.pinned = false;
     }
-    if (!this.hideElement.hasAttribute("hidden") && !this.pinned) {
-      this.hideElement.setAttribute("hidden", true);
+    if (!this.hideElement.hidden && !this.pinned) {
+      this.hideElement.hidden = true;
       this.container.style.zIndex -= 1;
     }
   }
@@ -2061,7 +2061,7 @@ class AnnotationLayer {
         });
       }
     }
-    parameters.div.removeAttribute("hidden");
+    parameters.div.hidden = false;
   }
 }
 

--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -125,7 +125,7 @@ class AnnotationLayerBuilder {
     if (!this.div) {
       return;
     }
-    this.div.setAttribute("hidden", "true");
+    this.div.hidden = true;
   }
 }
 

--- a/web/app.js
+++ b/web/app.js
@@ -813,7 +813,7 @@ const PDFViewerApplication = {
    */
   async close() {
     const errorWrapper = this.appConfig.errorWrapper.container;
-    errorWrapper.setAttribute("hidden", "true");
+    errorWrapper.hidden = true;
 
     if (!this.pdfLoadingTask) {
       return undefined;
@@ -1169,35 +1169,35 @@ const PDFViewerApplication = {
     if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
       const errorWrapperConfig = this.appConfig.errorWrapper;
       const errorWrapper = errorWrapperConfig.container;
-      errorWrapper.removeAttribute("hidden");
+      errorWrapper.hidden = false;
 
       const errorMessage = errorWrapperConfig.errorMessage;
       errorMessage.textContent = message;
 
       const closeButton = errorWrapperConfig.closeButton;
       closeButton.onclick = function () {
-        errorWrapper.setAttribute("hidden", "true");
+        errorWrapper.hidden = true;
       };
 
       const errorMoreInfo = errorWrapperConfig.errorMoreInfo;
       const moreInfoButton = errorWrapperConfig.moreInfoButton;
       const lessInfoButton = errorWrapperConfig.lessInfoButton;
       moreInfoButton.onclick = function () {
-        errorMoreInfo.removeAttribute("hidden");
-        moreInfoButton.setAttribute("hidden", "true");
-        lessInfoButton.removeAttribute("hidden");
+        errorMoreInfo.hidden = false;
+        moreInfoButton.hidden = true;
+        lessInfoButton.hidden = false;
         errorMoreInfo.style.height = errorMoreInfo.scrollHeight + "px";
       };
       lessInfoButton.onclick = function () {
-        errorMoreInfo.setAttribute("hidden", "true");
-        moreInfoButton.removeAttribute("hidden");
-        lessInfoButton.setAttribute("hidden", "true");
+        errorMoreInfo.hidden = true;
+        moreInfoButton.hidden = false;
+        lessInfoButton.hidden = true;
       };
       moreInfoButton.oncontextmenu = noContextMenuHandler;
       lessInfoButton.oncontextmenu = noContextMenuHandler;
       closeButton.oncontextmenu = noContextMenuHandler;
-      moreInfoButton.removeAttribute("hidden");
-      lessInfoButton.setAttribute("hidden", "true");
+      moreInfoButton.hidden = false;
+      lessInfoButton.hidden = true;
       Promise.all(moreInfoText).then(parts => {
         errorMoreInfo.value = parts.join("\n");
       });
@@ -2462,8 +2462,8 @@ function webViewerInitialized() {
       !window.FileList ||
       !window.Blob
     ) {
-      appConfig.toolbar.openFile.setAttribute("hidden", "true");
-      appConfig.secondaryToolbar.openFileButton.setAttribute("hidden", "true");
+      appConfig.toolbar.openFile.hidden = true;
+      appConfig.secondaryToolbar.openFileButton.hidden = true;
     } else {
       fileInput.value = null;
     }
@@ -2498,8 +2498,8 @@ function webViewerInitialized() {
       });
     });
   } else {
-    appConfig.toolbar.openFile.setAttribute("hidden", "true");
-    appConfig.secondaryToolbar.openFileButton.setAttribute("hidden", "true");
+    appConfig.toolbar.openFile.hidden = true;
+    appConfig.secondaryToolbar.openFileButton.hidden = true;
   }
 
   if (!PDFViewerApplication.supportsDocumentFonts) {
@@ -2808,13 +2808,10 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
 
     // URL does not reflect proper document location - hiding some icons.
     const appConfig = PDFViewerApplication.appConfig;
-    appConfig.toolbar.viewBookmark.setAttribute("hidden", "true");
-    appConfig.secondaryToolbar.viewBookmarkButton.setAttribute(
-      "hidden",
-      "true"
-    );
-    appConfig.toolbar.download.setAttribute("hidden", "true");
-    appConfig.secondaryToolbar.downloadButton.setAttribute("hidden", "true");
+    appConfig.toolbar.viewBookmark.hidden = true;
+    appConfig.secondaryToolbar.viewBookmarkButton.hidden = true;
+    appConfig.toolbar.download.hidden = true;
+    appConfig.secondaryToolbar.downloadButton.hidden = true;
   };
 
   webViewerOpenFile = function (evt) {

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -201,7 +201,7 @@ var StepperManager = (function StepperManagerClosure() {
     create: function create(pageIndex) {
       var debug = document.createElement("div");
       debug.id = "stepper" + pageIndex;
-      debug.setAttribute("hidden", true);
+      debug.hidden = true;
       debug.className = "stepper";
       stepperDiv.appendChild(debug);
       var b = document.createElement("option");
@@ -224,11 +224,7 @@ var StepperManager = (function StepperManagerClosure() {
       }
       for (i = 0; i < steppers.length; ++i) {
         var stepper = steppers[i];
-        if (stepper.pageIndex === pageIndex) {
-          stepper.panel.removeAttribute("hidden");
-        } else {
-          stepper.panel.setAttribute("hidden", true);
-        }
+        stepper.panel.hidden = stepper.pageIndex !== pageIndex;
       }
       var options = stepperChooser.options;
       for (i = 0; i < options.length; ++i) {
@@ -608,15 +604,10 @@ window.PDFBug = (function PDFBugClosure() {
       activePanel = index;
       var tools = this.tools;
       for (var j = 0; j < tools.length; ++j) {
-        if (j === index) {
-          buttons[j].setAttribute("class", "active");
-          tools[j].active = true;
-          tools[j].panel.removeAttribute("hidden");
-        } else {
-          buttons[j].setAttribute("class", "");
-          tools[j].active = false;
-          tools[j].panel.setAttribute("hidden", "true");
-        }
+        var isActive = j === index;
+        buttons[j].classList.toggle("active", isActive);
+        tools[j].active = isActive;
+        tools[j].panel.hidden = !isActive;
       }
     },
   };

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -296,7 +296,7 @@ class PDFPageView {
         });
         return;
       }
-      if (!this.zoomLayer && !this.canvas.hasAttribute("hidden")) {
+      if (!this.zoomLayer && !this.canvas.hidden) {
         this.zoomLayer = this.canvas.parentNode;
         this.zoomLayer.style.position = "absolute";
       }
@@ -587,11 +587,11 @@ class PDFPageView {
 
     // Keep the canvas hidden until the first draw callback, or until drawing
     // is complete when `!this.renderingQueue`, to prevent black flickering.
-    canvas.setAttribute("hidden", "hidden");
+    canvas.hidden = true;
     let isCanvasHidden = true;
     const showCanvas = function () {
       if (isCanvasHidden) {
-        canvas.removeAttribute("hidden");
+        canvas.hidden = false;
         isCanvasHidden = false;
       }
     };


### PR DESCRIPTION
`.setAttribute("hidden", "true")` or `.setAttribute("hidden", true)` are misleading, because `.setAttribute("hidden", "false")` also hides the element. This is because the HTML UA sheet matches `[hidden]`.

`.setAttribute("hidden", "hidden");` or `.hidden = true` would be correct ways to do it. The latter is more future-proof though.

The reason I'm doing this is because this showed up in the XUL boolean attribute matches in mozilla-central (XUL considers `hidden=true` as correct unlike HTML, and I'm looking into fixing that).