### PR TITLE
[GENERIC viewer] Skip the `iframe`-case when checking if the `container` div, on `BaseViewer`-instances, is absolutely positioned (PR 12354 follow-up)

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -172,7 +172,10 @@ class BaseViewer {
         throw new Error("Invalid `container` and/or `viewer` option.");
       }
 
-      if (getComputedStyle(this.container).position !== "absolute") {
+      if (
+        this.container.offsetParent &&
+        getComputedStyle(this.container).position !== "absolute"
+      ) {
         throw new Error("The `container` must be absolutely positioned.");
       }
     }


### PR DESCRIPTION
Given that `getComputedStyle` only works on visible elements, the result of PR #12354 is that if the viewer is placed in a *hidden* `iframe` the viewer will now be broken. This obviously wasn't the intention of that PR, hence I believe that we should limit the `position: absolute;` check slightly to avoid this.