### PR TITLE
Remove the `contentmenu` usage, from PresentationMode, since it's no longer working

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -48,16 +48,12 @@ bookmark_label=Current View
 tools.title=Tools
 tools_label=Tools
 first_page.title=Go to First Page
-first_page.label=Go to First Page
 first_page_label=Go to First Page
 last_page.title=Go to Last Page
-last_page.label=Go to Last Page
 last_page_label=Go to Last Page
 page_rotate_cw.title=Rotate Clockwise
-page_rotate_cw.label=Rotate Clockwise
 page_rotate_cw_label=Rotate Clockwise
 page_rotate_ccw.title=Rotate Counterclockwise
-page_rotate_ccw.label=Rotate Counterclockwise
 page_rotate_ccw_label=Rotate Counterclockwise
 
 cursor_text_select_tool.title=Enable Text Selection Tool

--- a/web/app.js
+++ b/web/app.js
@@ -551,7 +551,6 @@ const PDFViewerApplication = {
         container,
         pdfViewer: this.pdfViewer,
         eventBus,
-        contextMenuItems: appConfig.fullscreen,
       });
     }
 

--- a/web/pdf_presentation_mode.js
+++ b/web/pdf_presentation_mode.js
@@ -34,15 +34,13 @@ const SWIPE_ANGLE_THRESHOLD = Math.PI / 6;
  * @property {HTMLDivElement} container - The container for the viewer element.
  * @property {PDFViewer} pdfViewer - The document viewer.
  * @property {EventBus} eventBus - The application event bus.
- * @property {Array} [contextMenuItems] - The menu items that are added to the
- *   context menu in Presentation Mode.
  */
 
 class PDFPresentationMode {
   /**
    * @param {PDFPresentationModeOptions} options
    */
-  constructor({ container, pdfViewer, eventBus, contextMenuItems = null }) {
+  constructor({ container, pdfViewer, eventBus }) {
     this.container = container;
     this.pdfViewer = pdfViewer;
     this.eventBus = eventBus;
@@ -53,25 +51,6 @@ class PDFPresentationMode {
     this.mouseScrollTimeStamp = 0;
     this.mouseScrollDelta = 0;
     this.touchSwipeState = null;
-
-    if (contextMenuItems) {
-      contextMenuItems.contextFirstPage.addEventListener("click", () => {
-        this.contextMenuOpen = false;
-        this.eventBus.dispatch("firstpage", { source: this });
-      });
-      contextMenuItems.contextLastPage.addEventListener("click", () => {
-        this.contextMenuOpen = false;
-        this.eventBus.dispatch("lastpage", { source: this });
-      });
-      contextMenuItems.contextPageRotateCw.addEventListener("click", () => {
-        this.contextMenuOpen = false;
-        this.eventBus.dispatch("rotatecw", { source: this });
-      });
-      contextMenuItems.contextPageRotateCcw.addEventListener("click", () => {
-        this.contextMenuOpen = false;
-        this.eventBus.dispatch("rotateccw", { source: this });
-      });
-    }
   }
 
   /**
@@ -249,7 +228,6 @@ class PDFPresentationMode {
     this._addWindowListeners();
     this._showControls();
     this.contextMenuOpen = false;
-    this.container.setAttribute("contextmenu", "viewerContextMenu");
 
     // Text selection is disabled in Presentation Mode, thus it's not possible
     // for the user to deselect text that is selected (e.g. with "Select all")
@@ -279,7 +257,6 @@ class PDFPresentationMode {
     this._removeWindowListeners();
     this._hideControls();
     this._resetMouseScrollState();
-    this.container.removeAttribute("contextmenu");
     this.contextMenuOpen = false;
   }
 

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -316,17 +316,6 @@ See https://github.com/adobe-type-tools/cmap-resources
           </div>
         </div>
 
-        <menu type="context" id="viewerContextMenu">
-          <menuitem id="contextFirstPage" label="First Page"
-                    data-l10n-id="first_page"></menuitem>
-          <menuitem id="contextLastPage" label="Last Page"
-                    data-l10n-id="last_page"></menuitem>
-          <menuitem id="contextPageRotateCw" label="Rotate Clockwise"
-                    data-l10n-id="page_rotate_cw"></menuitem>
-          <menuitem id="contextPageRotateCcw" label="Rotate Counter-Clockwise"
-                    data-l10n-id="page_rotate_ccw"></menuitem>
-        </menu>
-
         <div id="viewerContainer" tabindex="0">
           <div id="viewer" class="pdfViewer"></div>
         </div>

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -111,12 +111,6 @@ function getViewerConfiguration() {
       spreadEvenButton: document.getElementById("spreadEven"),
       documentPropertiesButton: document.getElementById("documentProperties"),
     },
-    fullscreen: {
-      contextFirstPage: document.getElementById("contextFirstPage"),
-      contextLastPage: document.getElementById("contextLastPage"),
-      contextPageRotateCw: document.getElementById("contextPageRotateCw"),
-      contextPageRotateCcw: document.getElementById("contextPageRotateCcw"),
-    },
     sidebar: {
       // Divs (and sidebar button)
       outerContainer: document.getElementById("outerContainer"),


### PR DESCRIPTION
This feature was Firefox-specific, and it's now been removed from the HTML specification and it's disabled by default starting with Firefox 85. Hence it seems completely unnecessary to keep this code in the default viewer.

Please refer to https://groups.google.com/g/mozilla.dev.platform/c/tc11BCenm2c and the resources that it links to.