### PR TITLE
XFA - Add support for prototypes

### DIFF
--- a/src/core/xfa/parser.js
+++ b/src/core/xfa/parser.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { $clean, $finalize, $onChild, $onText } from "./xfa_object.js";
+import { $clean, $finalize, $onChild, $onText, $setId } from "./xfa_object.js";
 import { XMLParserBase, XMLParserErrorCode } from "../xml_parser.js";
 import { Builder } from "./builder.js";
 import { warn } from "../../shared/util.js";
@@ -23,7 +23,8 @@ class XFAParser extends XMLParserBase {
     super();
     this._builder = new Builder();
     this._stack = [];
-    this._current = this._builder.buildRoot();
+    this._ids = new Map();
+    this._current = this._builder.buildRoot(this._ids);
     this._errorCode = XMLParserErrorCode.NoError;
     this._whiteRegex = /^\s+$/;
   }
@@ -34,6 +35,8 @@ class XFAParser extends XMLParserBase {
     if (this._errorCode !== XMLParserErrorCode.NoError) {
       return undefined;
     }
+
+    this._current[$finalize]();
 
     return this._current.element;
   }
@@ -101,7 +104,9 @@ class XFAParser extends XMLParserBase {
     if (isEmpty) {
       // No children: just push the node into its parent.
       node[$finalize]();
-      this._current[$onChild](node);
+      if (this._current[$onChild](node)) {
+        node[$setId](this._ids);
+      }
       node[$clean](this._builder);
       return;
     }
@@ -114,7 +119,9 @@ class XFAParser extends XMLParserBase {
     const node = this._current;
     node[$finalize]();
     this._current = this._stack.pop();
-    this._current[$onChild](node);
+    if (this._current[$onChild](node)) {
+      node[$setId](this._ids);
+    }
     node[$clean](this._builder);
   }
 

--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -21,6 +21,7 @@ import {
   $namespaceId,
   $nodeName,
   $onChild,
+  $setSetAttributes,
   ContentObject,
   Option01,
   OptionObject,
@@ -1071,9 +1072,15 @@ class ExData extends ContentObject {
       child[$namespaceId] === NamespaceIds.xhtml.id
     ) {
       this[$content] = child;
-    } else if (this.contentType === "text/xml") {
-      this[$content] = child;
+      return true;
     }
+
+    if (this.contentType === "text/xml") {
+      this[$content] = child;
+      return true;
+    }
+
+    return false;
   }
 }
 
@@ -2531,9 +2538,10 @@ class Text extends ContentObject {
   [$onChild](child) {
     if (child[$namespaceId] === NamespaceIds.xhtml.id) {
       this[$content] = child;
-    } else {
-      warn(`XFA - Invalid content in Text: ${child[$nodeName]}.`);
+      return true;
     }
+    warn(`XFA - Invalid content in Text: ${child[$nodeName]}.`);
+    return false;
   }
 }
 
@@ -2757,7 +2765,9 @@ class Variables extends XFAObject {
 class TemplateNamespace {
   static [$buildXFAObject](name, attributes) {
     if (TemplateNamespace.hasOwnProperty(name)) {
-      return TemplateNamespace[name](attributes);
+      const node = TemplateNamespace[name](attributes);
+      node[$setSetAttributes](attributes);
+      return node;
     }
     return undefined;
   }
@@ -3215,4 +3225,4 @@ class TemplateNamespace {
   }
 }
 
-export { TemplateNamespace };
+export { Template, TemplateNamespace };


### PR DESCRIPTION
 - specifications: http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.364.2157&rep=rep1&type=pdf#page=225&zoom=auto,-207,784
 - add a clone method on nodes in order to be able to clone a proto;
 - support ids in template namespace;
 - prevent from cycle when applying protos.