### PR TITLE
Collect the l10n error/warning message lookup, in `web/app.js`, in a new helper method

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -702,13 +702,13 @@ const PDFViewerApplication = {
       throw new Error("Not implemented: initPassiveLoading");
     }
     this.externalServices.initPassiveLoading({
-      onOpenWithTransport(url, length, transport) {
-        PDFViewerApplication.open(url, { length, range: transport });
+      onOpenWithTransport: (url, length, transport) => {
+        this.open(url, { length, range: transport });
       },
-      onOpenWithData(data) {
-        PDFViewerApplication.open(data);
+      onOpenWithData: data => {
+        this.open(data);
       },
-      onOpenWithURL(url, length, originalUrl) {
+      onOpenWithURL: (url, length, originalUrl) => {
         let file = url,
           args = null;
         if (length !== undefined) {
@@ -717,21 +717,21 @@ const PDFViewerApplication = {
         if (originalUrl !== undefined) {
           file = { url, originalUrl };
         }
-        PDFViewerApplication.open(file, args);
+        this.open(file, args);
       },
-      onError(err) {
-        PDFViewerApplication.l10n
+      onError: err => {
+        this.l10n
           .get(
             "loading_error",
             null,
             "An error occurred while loading the PDF."
           )
           .then(msg => {
-            PDFViewerApplication._documentError(msg, err);
+            this._documentError(msg, err);
           });
       },
-      onProgress(loaded, total) {
-        PDFViewerApplication.progress(loaded / total);
+      onProgress: (loaded, total) => {
+        this.progress(loaded / total);
       },
     });
   },

--- a/web/app.js
+++ b/web/app.js
@@ -709,14 +709,9 @@ const PDFViewerApplication = {
         this.open(data);
       },
       onOpenWithURL: (url, length, originalUrl) => {
-        let file = url,
-          args = null;
-        if (length !== undefined) {
-          args = { length };
-        }
-        if (originalUrl !== undefined) {
-          file = { url, originalUrl };
-        }
+        const file = originalUrl !== undefined ? { url, originalUrl } : url;
+        const args = length !== undefined ? { length } : null;
+
         this.open(file, args);
       },
       onError: err => {


### PR DESCRIPTION
Some of the localization strings (e.g. "loading_error") are repeated multiple times throughout the `web/app.js` file, which means that we need to duplicate the fallback strings as well. Furthermore, the signature of the `IL10n.get` method makes the call-sites quite verbose.

By adding a new helper method, in `PDFViewerApplication`, we're able to gather the localization fallback strings in one central spot in `web/app.js` and also make the lookup of the error/warning messages more compact.

