### PR TITLE
Replace a few `new Date().getTime()` instances with `Date.now()`

### DIFF
--- a/test/unit/testreporter.js
+++ b/test/unit/testreporter.js
@@ -40,7 +40,7 @@ const TestReporter = function (browser) {
   }
 
   this.now = function () {
-    return new Date().getTime();
+    return Date.now();
   };
 
   this.jasmineStarted = function (suiteInfo) {

--- a/web/pdf_presentation_mode.js
+++ b/web/pdf_presentation_mode.js
@@ -102,7 +102,7 @@ class PDFPresentationMode {
     evt.preventDefault();
 
     const delta = normalizeWheelEventDelta(evt);
-    const currentTime = new Date().getTime();
+    const currentTime = Date.now();
     const storedTime = this.mouseScrollTimeStamp;
 
     // If we've already switched page, avoid accidentally switching again.


### PR DESCRIPTION
The former format is not only more verbose, but it's also *slightly* less efficient since it creates a new `Date` object.