### PR TITLE
Remove unneeded `instanceof MissingDataException` checks

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -64,7 +64,6 @@ import {
   WinAnsiEncoding,
   ZapfDingbatsEncoding,
 } from "./encodings.js";
-import { getLookupTableFactory, MissingDataException } from "./core_utils.js";
 import {
   getNormalizedUnicodes,
   getUnicodeForGlyph,
@@ -87,6 +86,7 @@ import {
 import { bidi } from "./bidi.js";
 import { ColorSpace } from "./colorspace.js";
 import { getGlyphsUnicode } from "./glyphlist.js";
+import { getLookupTableFactory } from "./core_utils.js";
 import { getMetrics } from "./metrics.js";
 import { MurmurHash3_64 } from "./murmurhash3.js";
 import { OperatorList } from "./operator_list.js";
@@ -267,9 +267,6 @@ class PartialEvaluator {
             try {
               graphicState = xref.fetch(graphicState);
             } catch (ex) {
-              if (ex instanceof MissingDataException) {
-                throw ex;
-              }
               // Avoid parsing a corrupt ExtGState more than once.
               processed.put(graphicState);
 
@@ -316,9 +313,6 @@ class PartialEvaluator {
           try {
             xObject = xref.fetch(xObject);
           } catch (ex) {
-            if (ex instanceof MissingDataException) {
-              throw ex;
-            }
             // Avoid parsing a corrupt XObject more than once.
             processed.put(xObject);
 
@@ -1270,9 +1264,6 @@ class PartialEvaluator {
           operatorList.addOp(fn, tilingPatternIR);
           return undefined;
         } catch (ex) {
-          if (ex instanceof MissingDataException) {
-            throw ex;
-          }
           // Handle any errors during normal TilingPattern parsing.
         }
       }

--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -1910,9 +1910,6 @@ var XRef = (function XRefClosure() {
           }
           // The top-level /Pages dictionary isn't obviously corrupt.
         } catch (ex) {
-          if (ex instanceof MissingDataException) {
-            throw ex;
-          }
           continue;
         }
         // taking the first one with 'ID'


### PR DESCRIPTION
The following checks are all unneeded, and could easily cause confusion when reading the code. (All of them are my fault as well, since I've sometimes added those checks without really thinking about the surrounding code.)

 - In `PartialEvaluator.hasBlendModes` there cannot be any `MissingDataException`s thrown, given that the `Page.getOperatorList` method waits for all the necessary /Resources to load first. Furthermore, note also that if an error is thrown from `PartialEvaluator.hasBlendModes` then it'd completely break rendering of that page, since any errors thrown from `Page.getOperatorList` are simply sent to the main-thread.

 - In `PartialEvaluator.handleColorN` there cannot be any `MissingDataException`s thrown, given that again the `Page.getOperatorList` method waits for all the necessary /Resources to load before operatorList parsing starts.

 - In `XRef.readXRef` there cannot be any `MissingDataException`s thrown, given that we're *explicitly* requesting (and waiting for) the entire document in `pdfManagerReady` (in `src/core/worker.js`) before re-parsing of a corrupt document starts.