### PR TITLE
Use a more compact format for the fallback EventBus-listeners in `PDFViewerApplication_initializeJavaScript`

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1479,13 +1479,7 @@ const PDFViewerApplication = {
       // It should be *extremely* rare for metadata to not have been resolved
       // when this code runs, but ensure that we handle that case here.
       await new Promise(resolve => {
-        this.eventBus._on(
-          "metadataloaded",
-          evt => {
-            resolve();
-          },
-          { once: true }
-        );
+        this.eventBus._on("metadataloaded", resolve, { once: true });
       });
       if (pdfDocument !== this.pdfDocument) {
         return; // The document was closed while the metadata resolved.
@@ -1498,13 +1492,7 @@ const PDFViewerApplication = {
       // Hence we'll simply have to trust that the `contentLength` (as provided
       // by the server), when it exists, is accurate enough here.
       await new Promise(resolve => {
-        this.eventBus._on(
-          "documentloaded",
-          evt => {
-            resolve();
-          },
-          { once: true }
-        );
+        this.eventBus._on("documentloaded", resolve, { once: true });
       });
       if (pdfDocument !== this.pdfDocument) {
         return; // The document was closed while the downloadInfo resolved.

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -740,8 +740,8 @@ class BaseViewer {
    */
   get _pageWidthScaleFactor() {
     if (
-      this.spreadMode !== SpreadMode.NONE &&
-      this.scrollMode !== ScrollMode.HORIZONTAL &&
+      this._spreadMode !== SpreadMode.NONE &&
+      this._scrollMode !== ScrollMode.HORIZONTAL &&
       !this.isInPresentationMode
     ) {
       return 2;
@@ -1642,7 +1642,7 @@ class BaseViewer {
     return true;
   }
 
-  initializeScriptingEvents() {
+  async initializeScriptingEvents() {
     if (!this.enableScripting || this._pageOpenPendingSet) {
       return;
     }


### PR DESCRIPTION
*Please refer to the individual commit messages for additional details.*