### PR TITLE
[api-minor] Change the `dc:subject` Metadata field to an Array

### DIFF
--- a/test/unit/metadata_spec.js
+++ b/test/unit/metadata_spec.js
@@ -171,7 +171,7 @@ describe("metadata", function () {
       "dc:creator": [""],
       "dc:description": "",
       "dc:format": "application/pdf",
-      "dc:subject": "",
+      "dc:subject": [],
       "dc:title": "",
       "pdf:keywords": "",
       "pdf:pdfversion": "1.7",


### PR DESCRIPTION
This patch simply extends the existing handling of the `dc:creator` field, which should hopefully suffice here; please refer to https://wwwimages2.adobe.com/content/dam/acom/en/devnet/xmp/pdfs/XMP%20SDK%20Release%20cc-2016-08/XMPSpecificationPart1.pdf#page=34

Fixes https://github.com/mozilla/pdf.js/issues/12990#issuecomment-778787111