### PR TITLE
Stop showing the fallback bar for "errorFontMissing" errors (PR 11218 follow-up)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1082,6 +1082,7 @@ const PDFViewerApplication = {
     // user-visible errors, to avoid bothering the user unnecessarily.
     switch (featureId) {
       case UNSUPPORTED_FEATURES.errorFontLoadNative:
+      case UNSUPPORTED_FEATURES.errorFontMissing:
         return;
     }
     // Only trigger the fallback once so we don't spam the user with messages


### PR DESCRIPTION
*This is somewhat similar to PR #12931.*

For PDF documents where fonts are completely missing in the /Resources dictionaries, there's basically no "correct" way of rendering the document.
Hence it's very unlikely that another PDF viewer will do a better job than PDF.js in these cases, and consequently it seems highly questionable if the fallback bar really helps here.