### PR TITLE
Move the opening of PDF file attachments into the `DownloadManager`-implementations

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -1982,11 +1982,11 @@ class FileAttachmentAnnotationElement extends AnnotationElement {
    * @memberof FileAttachmentAnnotationElement
    */
   _download() {
-    if (!this.downloadManager) {
-      warn("Download cannot be started due to unavailable download manager");
-      return;
-    }
-    this.downloadManager.downloadData(this.content, this.filename, "");
+    this.downloadManager?.openOrDownloadData(
+      this.container,
+      this.content,
+      this.filename
+    );
   }
 }
 

--- a/web/pdf_attachment_viewer.js
+++ b/web/pdf_attachment_viewer.js
@@ -15,9 +15,6 @@
 
 import { createPromiseCapability, getFilenameFromUrl } from "pdfjs-lib";
 import { BaseTreeViewer } from "./base_tree_viewer.js";
-import { viewerCompatibilityParams } from "./viewer_compatibility.js";
-
-const PdfFileRegExp = /\.pdf$/i;
 
 /**
  * @typedef {Object} PDFAttachmentViewerOptions
@@ -92,54 +89,11 @@ class PDFAttachmentViewer extends BaseTreeViewer {
   }
 
   /**
-   * NOTE: Should only be used when `URL.createObjectURL` is natively supported.
-   * @private
-   */
-  _bindPdfLink(element, { content, filename }) {
-    let blobUrl;
-    element.onclick = () => {
-      if (!blobUrl) {
-        blobUrl = URL.createObjectURL(
-          new Blob([content], { type: "application/pdf" })
-        );
-      }
-      let viewerUrl;
-      if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-        // The current URL is the viewer, let's use it and append the file.
-        viewerUrl = "?file=" + encodeURIComponent(blobUrl + "#" + filename);
-      } else if (PDFJSDev.test("MOZCENTRAL")) {
-        // Let Firefox's content handler catch the URL and display the PDF.
-        viewerUrl = blobUrl + "#filename=" + encodeURIComponent(filename);
-      } else if (PDFJSDev.test("CHROME")) {
-        // In the Chrome extension, the URL is rewritten using the history API
-        // in viewer.js, so an absolute URL must be generated.
-        viewerUrl =
-          // eslint-disable-next-line no-undef
-          chrome.runtime.getURL("/content/web/viewer.html") +
-          "?file=" +
-          encodeURIComponent(blobUrl + "#" + filename);
-      }
-      try {
-        window.open(viewerUrl);
-      } catch (ex) {
-        console.error(`_bindPdfLink: ${ex}`);
-        // Release the `blobUrl`, since opening it failed...
-        URL.revokeObjectURL(blobUrl);
-        blobUrl = null;
-        // ... and fallback to downloading the PDF file.
-        this.downloadManager.downloadData(content, filename, "application/pdf");
-      }
-      return false;
-    };
-  }
-
-  /**
    * @private
    */
   _bindLink(element, { content, filename }) {
     element.onclick = () => {
-      const contentType = PdfFileRegExp.test(filename) ? "application/pdf" : "";
-      this.downloadManager.downloadData(content, filename, contentType);
+      this.downloadManager.openOrDownloadData(element, content, filename);
       return false;
     };
   }
@@ -165,20 +119,14 @@ class PDFAttachmentViewer extends BaseTreeViewer {
     let attachmentsCount = 0;
     for (const name of names) {
       const item = attachments[name];
+      const content = item.content;
       const filename = getFilenameFromUrl(item.filename);
 
       const div = document.createElement("div");
       div.className = "treeItem";
 
       const element = document.createElement("a");
-      if (
-        PdfFileRegExp.test(filename) &&
-        !viewerCompatibilityParams.disableCreateObjectURL
-      ) {
-        this._bindPdfLink(element, { content: item.content, filename });
-      } else {
-        this._bindLink(element, { content: item.content, filename });
-      }
+      this._bindLink(element, { content, filename });
       element.textContent = this._normalizeTextContent(filename);
 
       div.appendChild(element);

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -69,6 +69,9 @@ const SpreadMode = {
 // Used by `PDFViewerApplication`, and by the API unit-tests.
 const AutoPrintRegExp = /\bprint\s*\(/;
 
+// Used by the (various) `DownloadManager`-implementations.
+const PdfFileRegExp = /\.pdf$/i;
+
 // Replaces {{arguments}} with their values.
 function formatL10nValue(text, args) {
   if (!args) {
@@ -1059,6 +1062,7 @@ export {
   normalizeWheelEventDirection,
   NullL10n,
   parseQueryString,
+  PdfFileRegExp,
   PresentationModeState,
   ProgressBar,
   RendererType,


### PR DESCRIPTION
Note how the `PDFAttachmentViewer` handles PDF file attachments specially, by opening them in a new window/tab, rather than forcing them to be downloaded. This is done to improve the overall UX, since browsers in general are able to handle PDF files internally.
However, for file *annotations* we're currently not attempting to do the same thing and are instead just downloading them directly. In order to unify the behaviour, without having to duplicate a lot of code, the opening of PDF file attachments is thus moved into a new `DownloadManager.openOrDownloadData` method.