### PR TITLE
Remove extra new line from HTML source.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -817,7 +817,7 @@ function preprocessHTML(source, defines) {
   fs.unlinkSync(outName);
 
   var i = source.lastIndexOf("/");
-  return createStringSource(source.substr(i + 1), out);
+  return createStringSource(source.substr(i + 1), `${out.trimEnd()}\n`);
 }
 
 function buildGeneric(defines, dir) {


### PR DESCRIPTION
This avoids issues in mozcentral with linting.