### PR TITLE
JS - Avoid a popup to ask for updating Acrobat.

### DIFF
--- a/src/scripting_api/initialization.js
+++ b/src/scripting_api/initialization.js
@@ -115,6 +115,12 @@ function initSandbox(params) {
   globalThis.trans = Trans;
   globalThis.zoomtype = ZoomType;
 
+  // Avoid to have a popup asking to update Acrobat.
+  globalThis.ADBE = {
+    Reader_Value_Asked: true,
+    Viewer_Value_Asked: true,
+  };
+
   // AF... functions
   const aform = new AForm(doc, app, util, color);
   for (const name of Object.getOwnPropertyNames(AForm.prototype)) {


### PR DESCRIPTION
  - this popup appears because js is enabled;
  - and because the pdf contains some unsupported features (e.g. XFA);
  - can be tested with: https://www.cbsa-asfc.gc.ca/publications/forms-formulaires/a10.pdf.