### PR TITLE
Remove the `NullL10n` default value from viewer components not included in the `COMPONENTS`-bundle

### DIFF
--- a/web/password_prompt.js
+++ b/web/password_prompt.js
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-import { NullL10n } from "./ui_utils.js";
 import { PasswordResponses } from "pdfjs-lib";
 
 /**
@@ -37,12 +36,7 @@ class PasswordPrompt {
    * @param {boolean} [isViewerEmbedded] - If the viewer is embedded, in e.g.
    *   an <iframe> or an <object>. The default value is `false`.
    */
-  constructor(
-    options,
-    overlayManager,
-    l10n = NullL10n,
-    isViewerEmbedded = false
-  ) {
+  constructor(options, overlayManager, l10n, isViewerEmbedded = false) {
     this.overlayName = options.overlayName;
     this.container = options.container;
     this.label = options.label;

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -18,7 +18,6 @@ import {
   getPageSizeInches,
   getPDFFileNameFromURL,
   isPortraitOrientation,
-  NullL10n,
 } from "./ui_utils.js";
 
 const DEFAULT_FIELD_CONTENT = "-";
@@ -63,7 +62,7 @@ class PDFDocumentProperties {
     { overlayName, fields, container, closeButton },
     overlayManager,
     eventBus,
-    l10n = NullL10n
+    l10n
   ) {
     this.overlayName = overlayName;
     this.fields = fields;

--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -14,7 +14,6 @@
  */
 
 import { FindState } from "./pdf_find_controller.js";
-import { NullL10n } from "./ui_utils.js";
 
 const MATCHES_COUNT_LIMIT = 1000;
 
@@ -25,7 +24,7 @@ const MATCHES_COUNT_LIMIT = 1000;
  * is done by PDFFindController.
  */
 class PDFFindBar {
-  constructor(options, eventBus, l10n = NullL10n) {
+  constructor(options, eventBus, l10n) {
     this.opened = false;
 
     this.bar = options.bar || null;

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import { CSS_UNITS, NullL10n } from "./ui_utils.js";
 import { PDFPrintServiceFactory, PDFViewerApplication } from "./app.js";
+import { CSS_UNITS } from "./ui_utils.js";
 import { viewerCompatibilityParams } from "./viewer_compatibility.js";
 
 let activeService = null;
@@ -82,7 +82,7 @@ function PDFPrintService(
   this._printResolution = printResolution || 150;
   this._optionalContentConfigPromise =
     optionalContentConfigPromise || pdfDocument.getOptionalContentConfig();
-  this.l10n = l10n || NullL10n;
+  this.l10n = l10n;
   this.currentPage = -1;
   // The temporary canvas where renderPage paints one page at a time.
   this.scratchCanvas = document.createElement("canvas");

--- a/web/pdf_sidebar.js
+++ b/web/pdf_sidebar.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { NullL10n, PresentationModeState, SidebarView } from "./ui_utils.js";
+import { PresentationModeState, SidebarView } from "./ui_utils.js";
 import { RenderingStates } from "./pdf_rendering_queue.js";
 
 const UI_NOTIFICATION_CLASS = "pdfSidebarNotification";
@@ -61,13 +61,7 @@ class PDFSidebar {
   /**
    * @param {PDFSidebarOptions} options
    */
-  constructor({
-    elements,
-    pdfViewer,
-    pdfThumbnailViewer,
-    eventBus,
-    l10n = NullL10n,
-  }) {
+  constructor({ elements, pdfViewer, pdfThumbnailViewer, eventBus, l10n }) {
     this.isOpen = false;
     this.active = SidebarView.THUMBS;
     this.isInitialViewSet = false;

--- a/web/pdf_sidebar_resizer.js
+++ b/web/pdf_sidebar_resizer.js
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { NullL10n } from "./ui_utils.js";
-
 const SIDEBAR_WIDTH_VAR = "--sidebar-width";
 const SIDEBAR_MIN_WIDTH = 200; // pixels
 const SIDEBAR_RESIZING_CLASS = "sidebarResizing";
@@ -33,7 +31,7 @@ class PDFSidebarResizer {
    * @param {EventBus} eventBus - The application event bus.
    * @param {IL10n} l10n - Localization service.
    */
-  constructor(options, eventBus, l10n = NullL10n) {
+  constructor(options, eventBus, l10n) {
     this.isRTL = false;
     this.sidebarOpen = false;
     this.doc = document.documentElement;

--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { getOutputScale, NullL10n } from "./ui_utils.js";
+import { getOutputScale } from "./ui_utils.js";
 import { RenderingCancelledException } from "pdfjs-lib";
 import { RenderingStates } from "./pdf_rendering_queue.js";
 
@@ -97,7 +97,7 @@ class PDFThumbnailView {
     renderingQueue,
     checkSetImageDisabled,
     disableCanvasToImageConversion = false,
-    l10n = NullL10n,
+    l10n,
   }) {
     this.id = id;
     this.renderingId = "thumbnail" + id;

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -16,7 +16,6 @@
 import {
   getVisibleElements,
   isValidRotation,
-  NullL10n,
   scrollIntoView,
   watchScroll,
 } from "./ui_utils.js";
@@ -45,13 +44,7 @@ class PDFThumbnailViewer {
   /**
    * @param {PDFThumbnailViewerOptions} options
    */
-  constructor({
-    container,
-    eventBus,
-    linkService,
-    renderingQueue,
-    l10n = NullL10n,
-  }) {
+  constructor({ container, eventBus, linkService, renderingQueue, l10n }) {
     this.container = container;
     this.linkService = linkService;
     this.renderingQueue = renderingQueue;

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -20,7 +20,6 @@ import {
   MAX_SCALE,
   MIN_SCALE,
   noContextMenuHandler,
-  NullL10n,
 } from "./ui_utils.js";
 
 const PAGE_NUMBER_LOADING_INDICATOR = "visiblePageIsLoading";
@@ -58,7 +57,7 @@ class Toolbar {
    * @param {EventBus} eventBus
    * @param {IL10n} l10n - Localization service.
    */
-  constructor(options, eventBus, l10n = NullL10n) {
+  constructor(options, eventBus, l10n) {
     this.toolbar = options.container;
     this.eventBus = eventBus;
     this.l10n = l10n;


### PR DESCRIPTION
For any viewer component not listed in `web/pdf_viewer.component.js`, it shouldn't be necessary to provide a default value for the `l10n`-parameters.
Note also that these *specific* components are heavily tailored towards the default viewer use-case, rather than for general usage.