### PR TITLE
Update Puppeteer to version 8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4932,9 +4932,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.847576",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.847576.tgz",
-      "integrity": "sha512-0M8kobnSQE0Jmly7Mhbeq0W/PpZfnuK+WjN2ZRVPbGqYwCHCioAVp84H0TcLimgECcN5H976y5QiXMGBC9JKmg==",
+      "version": "0.0.854822",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.854822.tgz",
+      "integrity": "sha512-xd4D8kHQtB0KtWW0c9xBZD5LVtm9chkMOfs/3Yn01RhT/sFIsVtzTtypfKoFfWBaL+7xCYLxjOLkhwPXaX/Kcg==",
       "dev": true
     },
     "diagnostics": {
@@ -14967,13 +14967,13 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-7.1.0.tgz",
-      "integrity": "sha512-lqOLzqCKdh7yUAHvK6LxgOpQrL8Bv1/jvS8MLDXxcNms2rlM3E8p/Wlwc7efbRZ0twxTzUeqjN5EqrTwxOwc9g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-8.0.0.tgz",
+      "integrity": "sha512-D0RzSWlepeWkxPPdK3xhTcefj8rjah1791GE82Pdjsri49sy11ci/JQsAO8K2NRukqvwEtcI+ImP5F4ZiMvtIQ==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
-        "devtools-protocol": "0.0.847576",
+        "devtools-protocol": "0.0.854822",
         "extract-zip": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
         "node-fetch": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "postcss": "^8.2.6",
     "postcss-calc": "^7.0.5",
     "prettier": "^2.2.1",
-    "puppeteer": "^7.1.0",
+    "puppeteer": "^8.0.0",
     "rimraf": "^3.0.2",
     "streamqueue": "^1.1.2",
     "stylelint": "^13.11.0",


### PR DESCRIPTION
Hopefully the updated Chromium-version might help reduce the number of intermittent test failures.

Please find additional information at https://github.com/puppeteer/puppeteer/releases/tag/v8.0.0