### PR TITLE
Enable the `no-var` linting rule in more core files

### DIFF
--- a/src/core/ccitt_stream.js
+++ b/src/core/ccitt_stream.js
@@ -12,13 +12,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable no-var */
 
 import { Dict, isDict } from "./primitives.js";
 import { CCITTFaxDecoder } from "./ccitt.js";
 import { DecodeStream } from "./stream.js";
 
-var CCITTFaxStream = (function CCITTFaxStreamClosure() {
+const CCITTFaxStream = (function CCITTFaxStreamClosure() {
   // eslint-disable-next-line no-shadow
   function CCITTFaxStream(str, maybeLength, params) {
     this.str = str;

--- a/src/core/glyphlist.js
+++ b/src/core/glyphlist.js
@@ -13,11 +13,10 @@
  * limitations under the License.
  */
 /* no-babel-preset */
-/* eslint-disable no-var */
 
 import { getArrayLookupTableFactory } from "./core_utils.js";
 
-var getGlyphsUnicode = getArrayLookupTableFactory(function () {
+const getGlyphsUnicode = getArrayLookupTableFactory(function () {
   // prettier-ignore
   return [
     "A", 0x0041,
@@ -4347,7 +4346,7 @@ var getGlyphsUnicode = getArrayLookupTableFactory(function () {
   ];
 });
 
-var getDingbatsGlyphsUnicode = getArrayLookupTableFactory(function () {
+const getDingbatsGlyphsUnicode = getArrayLookupTableFactory(function () {
   // prettier-ignore
   return [
     "space", 0x0020,

--- a/src/core/metrics.js
+++ b/src/core/metrics.js
@@ -12,14 +12,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable no-var */
 
 import { getLookupTableFactory } from "./core_utils.js";
 
 // The Metrics object contains glyph widths (in glyph space units).
 // As per PDF spec, for most fonts (Type 3 being an exception) a glyph
 // space unit corresponds to 1/1000th of text space unit.
-var getMetrics = getLookupTableFactory(function (t) {
+const getMetrics = getLookupTableFactory(function (t) {
   t.Courier = 600;
   t["Courier-Bold"] = 600;
   t["Courier-BoldOblique"] = 600;

--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -12,13 +12,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable no-var */
 
 import { assert, unreachable } from "../shared/util.js";
 
-var EOF = {};
+const EOF = {};
 
-var Name = (function NameClosure() {
+const Name = (function NameClosure() {
   let nameCache = Object.create(null);
 
   // eslint-disable-next-line no-shadow
@@ -29,7 +28,7 @@ var Name = (function NameClosure() {
   Name.prototype = {};
 
   Name.get = function Name_get(name) {
-    var nameValue = nameCache[name];
+    const nameValue = nameCache[name];
     // eslint-disable-next-line no-restricted-syntax
     return nameValue ? nameValue : (nameCache[name] = new Name(name));
   };
@@ -41,7 +40,7 @@ var Name = (function NameClosure() {
   return Name;
 })();
 
-var Cmd = (function CmdClosure() {
+const Cmd = (function CmdClosure() {
   let cmdCache = Object.create(null);
 
   // eslint-disable-next-line no-shadow
@@ -52,7 +51,7 @@ var Cmd = (function CmdClosure() {
   Cmd.prototype = {};
 
   Cmd.get = function Cmd_get(cmd) {
-    var cmdValue = cmdCache[cmd];
+    const cmdValue = cmdCache[cmd];
     // eslint-disable-next-line no-restricted-syntax
     return cmdValue ? cmdValue : (cmdCache[cmd] = new Cmd(cmd));
   };
@@ -64,8 +63,8 @@ var Cmd = (function CmdClosure() {
   return Cmd;
 })();
 
-var Dict = (function DictClosure() {
-  var nonSerializable = function nonSerializableClosure() {
+const Dict = (function DictClosure() {
+  const nonSerializable = function nonSerializableClosure() {
     return nonSerializable; // creating closure on some variable
   };
 
@@ -165,7 +164,7 @@ var Dict = (function DictClosure() {
     },
 
     forEach: function Dict_forEach(callback) {
-      for (var key in this._map) {
+      for (const key in this._map) {
         callback(key, this.get(key));
       }
     },
@@ -240,7 +239,7 @@ var Dict = (function DictClosure() {
   return Dict;
 })();
 
-var Ref = (function RefClosure() {
+const Ref = (function RefClosure() {
   let refCache = Object.create(null);
 
   // eslint-disable-next-line no-shadow

--- a/src/core/unicode.js
+++ b/src/core/unicode.js
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 /* no-babel-preset */
-/* eslint-disable no-var */
 
 import {
   getArrayLookupTableFactory,
@@ -23,7 +22,7 @@ import {
 // Some characters, e.g. copyrightserif, are mapped to the private use area
 // and might not be displayed using standard fonts. Mapping/hacking well-known
 // chars to the similar equivalents in the normal characters range.
-var getSpecialPUASymbols = getLookupTableFactory(function (t) {
+const getSpecialPUASymbols = getLookupTableFactory(function (t) {
   t[63721] = 0x00a9; // copyrightsans (0xF8E9) => copyright
   t[63193] = 0x00a9; // copyrightserif (0xF6D9) => copyright
   t[63720] = 0x00ae; // registersans (0xF8E8) => registered
@@ -63,7 +62,7 @@ function mapSpecialUnicodeValues(code) {
 }
 
 function getUnicodeForGlyph(name, glyphsUnicodeMap) {
-  var unicode = glyphsUnicodeMap[name];
+  let unicode = glyphsUnicodeMap[name];
   if (unicode !== undefined) {
     return unicode;
   }
@@ -72,8 +71,8 @@ function getUnicodeForGlyph(name, glyphsUnicodeMap) {
   }
   // Try to recover valid Unicode values from 'uniXXXX'/'uXXXX{XX}' glyphs.
   if (name[0] === "u") {
-    var nameLen = name.length,
-      hexStr;
+    const nameLen = name.length;
+    let hexStr;
 
     if (nameLen === 7 && name[1] === "n" && name[2] === "i") {
       // 'uniXXXX'
@@ -95,7 +94,7 @@ function getUnicodeForGlyph(name, glyphsUnicodeMap) {
   return -1;
 }
 
-var UnicodeRanges = [
+const UnicodeRanges = [
   { begin: 0x0000, end: 0x007f }, // Basic Latin
   { begin: 0x0080, end: 0x00ff }, // Latin-1 Supplement
   { begin: 0x0100, end: 0x017f }, // Latin Extended-A
@@ -222,8 +221,8 @@ var UnicodeRanges = [
 ];
 
 function getUnicodeRangeFor(value) {
-  for (var i = 0, ii = UnicodeRanges.length; i < ii; i++) {
-    var range = UnicodeRanges[i];
+  for (let i = 0, ii = UnicodeRanges.length; i < ii; i++) {
+    const range = UnicodeRanges[i];
     if (value >= range.begin && value < range.end) {
       return i;
     }
@@ -232,7 +231,7 @@ function getUnicodeRangeFor(value) {
 }
 
 function isRTLRangeFor(value) {
-  var range = UnicodeRanges[13];
+  let range = UnicodeRanges[13];
   if (value >= range.begin && value < range.end) {
     return true;
   }
@@ -245,7 +244,7 @@ function isRTLRangeFor(value) {
 
 // The normalization table is obtained by filtering the Unicode characters
 // database with <compat> entries.
-var getNormalizedUnicodes = getArrayLookupTableFactory(function () {
+const getNormalizedUnicodes = getArrayLookupTableFactory(function () {
   // prettier-ignore
   return [
     "\u00A8", "\u0020\u0308",
@@ -1629,13 +1628,13 @@ var getNormalizedUnicodes = getArrayLookupTableFactory(function () {
 });
 
 function reverseIfRtl(chars) {
-  var charsLength = chars.length;
+  const charsLength = chars.length;
   // Reverse an arabic ligature.
   if (charsLength <= 1 || !isRTLRangeFor(chars.charCodeAt(0))) {
     return chars;
   }
-  var s = "";
-  for (var ii = charsLength - 1; ii >= 0; ii--) {
+  let s = "";
+  for (let ii = charsLength - 1; ii >= 0; ii--) {
     s += chars[ii];
   }
   return s;

--- a/src/core/unicode.js
+++ b/src/core/unicode.js
@@ -1633,11 +1633,11 @@ function reverseIfRtl(chars) {
   if (charsLength <= 1 || !isRTLRangeFor(chars.charCodeAt(0))) {
     return chars;
   }
-  let s = "";
+  const buf = [];
   for (let ii = charsLength - 1; ii >= 0; ii--) {
-    s += chars[ii];
+    buf.push(chars[ii]);
   }
-  return s;
+  return buf.join("");
 }
 
 export {


### PR DESCRIPTION
This is mostly done using the `gulp lint --fix` command, and manual changes in a small number of cases where ESLint couldn't determine what to use, in an effort to reduce the number of disabled ESLint rules in the core folder and to use modern syntax.