### PR TITLE
Don't warn about actions that require scripting support in `Catalog.parseDestDictionary`

### DIFF
--- a/src/core/obj.js
+++ b/src/core/obj.js
@@ -1366,7 +1366,16 @@ class Catalog {
           }
         /* falls through */
         default:
-          warn(`parseDestDictionary: unsupported action type "${actionName}".`);
+          if (
+            actionName === "JavaScript" ||
+            actionName === "ResetForm" ||
+            actionName === "SubmitForm"
+          ) {
+            // Don't bother the user with a warning for actions that require
+            // scripting support, since those will be handled separately.
+            break;
+          }
+          warn(`parseDestDictionary - unsupported action: "${actionName}".`);
           break;
       }
     } else if (destDict.has("Dest")) {


### PR DESCRIPTION
Now that we have scripting support, warning about e.g. JavaScript actions doesn't seem necessary anymore. Especially considering that scripting-related actions are/will not be parsed by the `Catalog.parseDestDictionary` method anyway, since it's intended for handling "simple" actions.