### PR TITLE
Dispatch a "Doc/WillClose" event, when scripting is enabled, when closing the document

### DIFF
--- a/web/pdf_scripting_manager.js
+++ b/web/pdf_scripting_manager.js
@@ -128,6 +128,11 @@ class PDFScriptingManager {
     this._internalEvents.set("pagesdestroy", async event => {
       await this._dispatchPageClose(this._pdfViewer.currentPageNumber);
 
+      await this._scripting?.dispatchEventInSandbox({
+        id: "doc",
+        name: "WillClose",
+      });
+
       this._closeCapability?.resolve();
     });
 


### PR DESCRIPTION
This event is mentioned in the specification, see https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/AcrobatDC_js_api_reference.pdf#G5.1963176, and it's also listed as a valid type in https://github.com/mozilla/pdf.js/blob/fb87704b386bdc940ceef4eff31b1374432a6122/src/shared/util.js#L164-L170

Since we're already dispatching a "PageClose" event in this case, it seems reasonable to *also* dispatch a "Doc/WillClose" event as well.

