### PR TITLE
Use more optional chaining in the web/-folder (PR 12961 follow-up)

### DIFF
--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -262,7 +262,7 @@ class PDFDocumentProperties {
     }
     return this.l10n.get(`document_properties_${mb >= 1 ? "mb" : "kb"}`, {
       size_mb: mb >= 1 && (+mb.toPrecision(3)).toLocaleString(),
-      size_kb: (+kb.toPrecision(3)).toLocaleString(),
+      size_kb: mb < 1 && (+kb.toPrecision(3)).toLocaleString(),
       size_b: fileSize.toLocaleString(),
     });
   }

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -771,7 +771,7 @@ class PDFFindController {
       total = this._matchesCountTotal;
     if (matchIdx !== -1) {
       for (let i = 0; i < pageIdx; i++) {
-        current += (this._pageMatches[i] && this._pageMatches[i].length) || 0;
+        current += this._pageMatches[i]?.length || 0;
       }
       current += matchIdx + 1;
     }
@@ -797,7 +797,7 @@ class PDFFindController {
       state,
       previous,
       matchesCount: this._requestMatchesCount(),
-      rawQuery: this._state ? this._state.query : null,
+      rawQuery: this._state?.query ?? null,
     });
   }
 }

--- a/web/pdf_sidebar_resizer.js
+++ b/web/pdf_sidebar_resizer.js
@@ -53,10 +53,7 @@ class PDFSidebarResizer {
    * @type {number}
    */
   get outerContainerWidth() {
-    if (!this._outerContainerWidth) {
-      this._outerContainerWidth = this.outerContainer.clientWidth;
-    }
-    return this._outerContainerWidth;
+    return (this._outerContainerWidth ||= this.outerContainer.clientWidth);
   }
 
   /**
@@ -135,7 +132,7 @@ class PDFSidebarResizer {
     this.eventBus._on("resize", evt => {
       // When the *entire* viewer is resized, such that it becomes narrower,
       // ensure that the sidebar doesn't end up being too wide.
-      if (!evt || evt.source !== window) {
+      if (evt?.source !== window) {
         return;
       }
       // Always reset the cached width when the viewer is resized.


### PR DESCRIPTION
 - Avoid unnecessary `size_kb` calculation, for large files, in `PDFDocumentProperties._parseFileSize` (PR 13050 follow-up)

 - Use more optional chaining in the `web/`-folder (PR 12961 follow-up)

   I overlooked these cases previously, but there's no reason why optional chaining (and nullish coalescing) cannot be used here as well.

