### PR TITLE
fix setting textMatrix in moveText optimisation in getTextContent

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -2317,6 +2317,7 @@ class PartialEvaluator {
               advance <= textContentItem.fakeMultiSpaceMax
             ) {
               textState.translateTextLineMatrix(args[0], args[1]);
+              textState.textMatrix = textState.textLineMatrix.slice();
               textContentItem.width +=
                 args[0] - textContentItem.lastAdvanceWidth;
               textContentItem.height +=


### PR DESCRIPTION
bug introduced by 376f8bde1 and results in textlayerdiv misalignment on text that's preceded by a Td, then Tz, where the advance is on the same line and less than `textContentItem.fakeMultiSpaceMax`

Note: In my screenshots, textlayerdivs are coloured red.

I've made a minimal reproduction of the issue I was fixing:
[002 - Test - 10Td.pdf](https://github.com/mozilla/pdf.js/files/6102773/002.-.Test.-.10Td.pdf)

Before:
<img width="425" alt="Screenshot 2021-03-08 at 09 50 08" src="https://user-images.githubusercontent.com/7226807/110350286-7502d100-802b-11eb-8111-638a24913339.png">
After:
<img width="416" alt="Screenshot 2021-03-08 at 09 50 38" src="https://user-images.githubusercontent.com/7226807/110350472-a8ddf680-802b-11eb-891a-1c55f647073f.png">

[002 - Test - 30Td.pdf](https://github.com/mozilla/pdf.js/files/6102775/002.-.Test.-.30Td.pdf)
Before:
<img width="417" alt="Screenshot 2021-03-08 at 09 50 17" src="https://user-images.githubusercontent.com/7226807/110350296-7a601b80-802b-11eb-8acb-d552d0c2cff7.png">
After: 
<img width="417" alt="Screenshot 2021-03-08 at 09 50 55" src="https://user-images.githubusercontent.com/7226807/110350500-b1363180-802b-11eb-96bd-a5cef1ba1c91.png">

It also fixes the document in issue #12110
Before:
<img width="621" alt="Screenshot 2021-03-08 at 09 41 38" src="https://user-images.githubusercontent.com/7226807/110350841-07a37000-802c-11eb-828c-ce898a80ac72.png">
After:
<img width="618" alt="Screenshot 2021-03-08 at 09 34 42" src="https://user-images.githubusercontent.com/7226807/110350853-0e31e780-802c-11eb-8657-a5e1a47991d8.png">

And improves "issue3925.pdf" in the pdf.js test set: (Notice the space between the numbers and text in the first column, and the gap between the columns, where before a word from the right column had drifted into the gap)
Actual:
<img width="689" alt="Screenshot 2021-03-08 at 16 11 06" src="https://user-images.githubusercontent.com/7226807/110351587-e727e580-802c-11eb-9d1d-0c135f3f323b.png">
Before:
<img width="704" alt="Screenshot 2021-03-08 at 16 10 48" src="https://user-images.githubusercontent.com/7226807/110351604-ebec9980-802c-11eb-9e17-aca88b102ff0.png">
After:
<img width="707" alt="Screenshot 2021-03-08 at 16 10 54" src="https://user-images.githubusercontent.com/7226807/110351616-eee78a00-802c-11eb-80e7-0bfad5967c2f.png">

