### PR TITLE
Re-factor the `PDFScriptingManager._destroyScripting` method (PR 13042 follow-up)

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -470,10 +470,7 @@ class BaseViewer {
         this.findController.setDocument(null);
       }
       if (this._scriptingManager) {
-        // Defer this slightly, to allow the "PageClose" event to be handled.
-        Promise.resolve().then(() => {
-          this._scriptingManager.setDocument(null);
-        });
+        this._scriptingManager.setDocument(null);
       }
     }
 


### PR DESCRIPTION
*Please note:* Given the pre-existing issues raised in PR #13056, which seem to block immediate progress there, this patch extracts some *overall* improvements of the scripting/sandbox destruction in `PDFScriptingManager`.

As can be seen in `BaseViewer.setDocument`, it's currently necessary to *manually* delay the `PDFScriptingManager`-destruction in order for things to work correctly. This is, in hindsight, obviously an *extremely poor* design choice on my part; sorry about the churn here!

In order to improve things overall, the `PDFScriptingManager._destroyScripting`-method is re-factored to wait for the relevant events to be dispatched *before* sandbox-destruction occurs.
To avoid the scripting/sandbox-destruction hanging indefinitely, we utilize a timeout to force-destroy the sandbox after a short time (currently set to 1 second).