### PR TITLE
Disable intermittent unit test "creates pdf doc from non-existent URL"

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -169,6 +169,10 @@ describe("api", function () {
         });
     });
     it("creates pdf doc from non-existent URL", function (done) {
+      if (!isNodeJS) {
+        // re-enable https://github.com/mozilla/pdf.js/issues/13061
+        pending("Fails intermittently on linux in browsers.");
+      }
       const loadingTask = getDocument(
         buildGetDocumentParams("non-existent.pdf")
       );


### PR DESCRIPTION
Disable this test so we don't have to manually review unit test
failure log all the time.