### PR TITLE
Replace the `objectFromEntries` helper function with an `objectFromMap` one instead, and simplify the data lookup in the AnnotationStorage.getValue method

### DIFF
--- a/src/display/annotation_storage.js
+++ b/src/display/annotation_storage.js
@@ -14,7 +14,7 @@
  */
 
 import { deprecated } from "./display_utils.js";
-import { objectFromEntries } from "../shared/util.js";
+import { objectFromMap } from "../shared/util.js";
 
 /**
  * Key/value storage for annotation data in forms.
@@ -91,7 +91,7 @@ class AnnotationStorage {
   }
 
   getAll() {
-    return this._storage.size > 0 ? objectFromEntries(this._storage) : null;
+    return this._storage.size > 0 ? objectFromMap(this._storage) : null;
   }
 
   get size() {

--- a/src/display/annotation_storage.js
+++ b/src/display/annotation_storage.js
@@ -33,8 +33,7 @@ class AnnotationStorage {
   }
 
   /**
-   * Get the value for a given key if it exists
-   * or return the default value
+   * Get the value for a given key if it exists, or return the default value.
    *
    * @public
    * @memberof AnnotationStorage
@@ -43,11 +42,8 @@ class AnnotationStorage {
    * @returns {Object}
    */
   getValue(key, defaultValue) {
-    if (this._storage.has(key)) {
-      return this._storage.get(key);
-    }
-
-    return defaultValue;
+    const obj = this._storage.get(key);
+    return obj !== undefined ? obj : defaultValue;
   }
 
   /**

--- a/src/display/metadata.js
+++ b/src/display/metadata.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { objectFromEntries } from "../shared/util.js";
+import { objectFromMap } from "../shared/util.js";
 
 class Metadata {
   constructor({ parsedData, rawData }) {
@@ -30,7 +30,7 @@ class Metadata {
   }
 
   getAll() {
-    return objectFromEntries(this._metadataMap);
+    return objectFromMap(this._metadataMap);
   }
 
   has(name) {

--- a/src/display/optional_content_config.js
+++ b/src/display/optional_content_config.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { objectFromEntries, warn } from "../shared/util.js";
+import { objectFromMap, warn } from "../shared/util.js";
 
 class OptionalContentGroup {
   constructor(name, intent) {
@@ -142,10 +142,7 @@ class OptionalContentConfig {
   }
 
   getGroups() {
-    if (!this._groups.size) {
-      return null;
-    }
-    return objectFromEntries(this._groups);
+    return this._groups.size > 0 ? objectFromMap(this._groups) : null;
   }
 
   getGroup(id) {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -597,9 +597,14 @@ function objectSize(obj) {
   return Object.keys(obj).length;
 }
 
-// Ensures that the returned Object has a `null` prototype.
-function objectFromEntries(iterable) {
-  return Object.assign(Object.create(null), Object.fromEntries(iterable));
+// Ensure that the returned Object has a `null` prototype; hence why
+// `Object.fromEntries(...)` is not used.
+function objectFromMap(map) {
+  const obj = Object.create(null);
+  for (const [key, value] of map) {
+    obj[key] = value;
+  }
+  return obj;
 }
 
 // Checks the endianness of the platform.
@@ -1006,7 +1011,7 @@ export {
   isSameOrigin,
   isString,
   MissingPDFException,
-  objectFromEntries,
+  objectFromMap,
   objectSize,
   OPS,
   PageActionEventType,


### PR DESCRIPTION
 - Replace the `objectFromEntries` helper function with an `objectFromMap` one instead

   Given that it's only used with `Map`s, and that it's currently implemented in such a way that we (indirectly) must iterate through the data *twice*, some simplification cannot hurt here.
   Note that the only reason that we're not using `Object.fromEntries(...)` directly, at each call-site, is that that one won't guarantee that a `null` prototype is being used.

 - Simplify the data lookup in the `AnnotationStorage.getValue` method

   Rather than first checking if data exists before fetching it from storage, we can simply do the lookup directly and then check its value.
   Note that this follows the same pattern as utilized in the `AnnotationStorage.setValue` method.

