### PR TITLE
XFA - Convert some template properties into CSS ones

### DIFF
--- a/src/core/xfa/utils.js
+++ b/src/core/xfa/utils.js
@@ -13,7 +13,13 @@
  * limitations under the License.
  */
 
-const measurementPattern = /([+-]?)([0-9]+\.?[0-9]*)(.*)/;
+const dimConverters = {
+  pt: x => x,
+  cm: x => (x / 2.54) * 72,
+  mm: x => (x / (10 * 2.54)) * 72,
+  in: x => x * 72,
+};
+const measurementPattern = /([+-]?[0-9]+\.?[0-9]*)(.*)/;
 
 function getInteger({ data, defaultValue, validate }) {
   if (!data) {
@@ -67,15 +73,22 @@ function getMeasurement(str, def = "0") {
   if (!match) {
     return getMeasurement(def);
   }
-  const [, sign, valueStr, unit] = match;
+  const [, valueStr, unit] = match;
   const value = parseFloat(valueStr);
   if (isNaN(value)) {
     return getMeasurement(def);
   }
-  return {
-    value: sign === "-" ? -value : value,
-    unit: unit || "pt",
-  };
+
+  if (value === 0) {
+    return 0;
+  }
+
+  const conv = dimConverters[unit];
+  if (conv) {
+    return conv(value);
+  }
+
+  return value;
 }
 
 function getRatio(data) {
@@ -134,7 +147,7 @@ function getColor(data, def = [0, 0, 0]) {
 }
 
 function getBBox(data) {
-  const def = getMeasurement("-1");
+  const def = -1;
   if (!data) {
     return { x: def, y: def, width: def, height: def };
   }
@@ -142,7 +155,7 @@ function getBBox(data) {
     .trim()
     .split(/\s*,\s*/)
     .map(m => getMeasurement(m, "-1"));
-  if (bbox.length < 4 || bbox[2].value < 0 || bbox[3].value < 0) {
+  if (bbox.length < 4 || bbox[2] < 0 || bbox[3] < 0) {
     return { x: def, y: def, width: def, height: def };
   }
 

--- a/src/core/xfa/xfa_object.js
+++ b/src/core/xfa/xfa_object.js
@@ -59,6 +59,7 @@ const $setSetAttributes = Symbol();
 const $setValue = Symbol();
 const $text = Symbol();
 const $toHTML = Symbol();
+const $toStyle = Symbol();
 const $uid = Symbol("uid");
 
 const _applyPrototype = Symbol();
@@ -257,6 +258,10 @@ class XFAObject {
     }
 
     return dumped;
+  }
+
+  [$toStyle]() {
+    return null;
   }
 
   [$toHTML]() {
@@ -839,6 +844,7 @@ export {
   $setValue,
   $text,
   $toHTML,
+  $toStyle,
   $uid,
   ContentObject,
   IntegerObject,

--- a/src/display/xfa_layer.js
+++ b/src/display/xfa_layer.js
@@ -36,9 +36,13 @@ class XfaLayer {
     }
     const stack = [[root, -1, rootHtml]];
 
-    parameters.div.appendChild(rootHtml);
+    const rootDiv = parameters.div;
+    rootDiv.appendChild(rootHtml);
     const coeffs = parameters.viewport.transform.join(",");
-    parameters.div.style.transform = `matrix(${coeffs})`;
+    rootDiv.style.transform = `matrix(${coeffs})`;
+
+    // Set defaults.
+    rootDiv.setAttribute("class", "xfaLayer xfaFont");
 
     while (stack.length > 0) {
       const [parent, i, html] = stack[stack.length - 1];

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -87,6 +87,7 @@ async function initializePDFJS(callback) {
       "pdfjs-test/unit/writer_spec.js",
       "pdfjs-test/unit/xfa_formcalc_spec.js",
       "pdfjs-test/unit/xfa_parser_spec.js",
+      "pdfjs-test/unit/xfa_tohtml_spec.js",
       "pdfjs-test/unit/xml_spec.js",
     ].map(function (moduleName) {
       // eslint-disable-next-line no-unsanitized/method

--- a/test/unit/xfa_parser_spec.js
+++ b/test/unit/xfa_parser_spec.js
@@ -81,9 +81,9 @@ describe("XFAParser", function () {
       };
       const mediumAttributes = {
         id: "",
-        long: { value: 0, unit: "pt" },
+        long: 0,
         orientation: "portrait",
-        short: { value: 0, unit: "pt" },
+        short: 0,
         stock: "",
         trayIn: "auto",
         trayOut: "auto",
@@ -116,17 +116,17 @@ describe("XFAParser", function () {
             allowMacro: 0,
             anchorType: "topLeft",
             colSpan: 1,
-            columnWidths: [{ value: 0, unit: "pt" }],
-            h: { value: 0, unit: "pt" },
+            columnWidths: [0],
+            h: 0,
             hAlign: "left",
             id: "",
             layout: "position",
             locale: "",
-            maxH: { value: 0, unit: "pt" },
-            maxW: { value: 0, unit: "pt" },
+            maxH: 0,
+            maxW: 0,
             mergeMode: "consumeData",
-            minH: { value: 0, unit: "pt" },
-            minW: { value: 0, unit: "pt" },
+            minH: 0,
+            minW: 0,
             name: "",
             presence: "visible",
             relevant: [],
@@ -134,15 +134,15 @@ describe("XFAParser", function () {
             scope: "name",
             use: "",
             usehref: "",
-            w: { value: 0, unit: "pt" },
-            x: { value: 0, unit: "pt" },
-            y: { value: 0, unit: "pt" },
+            w: 0,
+            x: 0,
+            y: 0,
             proto: {
               area: {
                 ...attributes,
                 colSpan: 1,
-                x: { value: 0, unit: "pt" },
-                y: { value: -3.14, unit: "in" },
+                x: 0,
+                y: -226.08,
                 relevant: [
                   { excluded: true, viewname: "foo" },
                   { excluded: false, viewname: "bar" },
@@ -162,19 +162,19 @@ describe("XFAParser", function () {
                 {
                   ...mediumAttributes,
                   imagingBBox: {
-                    x: { value: 1, unit: "pt" },
-                    y: { value: 2, unit: "in" },
-                    width: { value: 3.4, unit: "cm" },
-                    height: { value: 5.67, unit: "px" },
+                    x: 1,
+                    y: 144,
+                    width: 96.3779527559055,
+                    height: 5.67,
                   },
                 },
                 {
                   ...mediumAttributes,
                   imagingBBox: {
-                    x: { value: -1, unit: "pt" },
-                    y: { value: -1, unit: "pt" },
-                    width: { value: -1, unit: "pt" },
-                    height: { value: -1, unit: "pt" },
+                    x: -1,
+                    y: -1,
+                    width: -1,
+                    height: -1,
                   },
                 },
               ],
@@ -288,7 +288,7 @@ describe("XFAParser", function () {
       let font = root.template.subform.field[0].font;
       expect(font.typeface).toEqual("Foo");
       expect(font.overline).toEqual(0);
-      expect(font.size).toEqual({ value: 123, unit: "pt" });
+      expect(font.size).toEqual(123);
       expect(font.weight).toEqual("bold");
       expect(font.posture).toEqual("italic");
       expect(font.fill.color.value).toEqual({ r: 1, g: 2, b: 3 });
@@ -297,7 +297,7 @@ describe("XFAParser", function () {
       font = root.template.subform.field[1].font;
       expect(font.typeface).toEqual("Foo");
       expect(font.overline).toEqual(0);
-      expect(font.size).toEqual({ value: 456, unit: "pt" });
+      expect(font.size).toEqual(456);
       expect(font.weight).toEqual("bold");
       expect(font.posture).toEqual("normal");
       expect(font.fill.color.value).toEqual({ r: 4, g: 5, b: 6 });
@@ -387,7 +387,7 @@ describe("XFAParser", function () {
 
       expect(font.typeface).toEqual("helvetica");
       expect(font.overline).toEqual(0);
-      expect(font.size).toEqual({ value: 31, unit: "pt" });
+      expect(font.size).toEqual(31);
       expect(font.weight).toEqual("normal");
       expect(font.posture).toEqual("italic");
       expect(font.fill.color.value).toEqual({ r: 7, g: 8, b: 9 });
@@ -1005,10 +1005,7 @@ describe("XFAParser", function () {
       ).toBe("myfont");
       expect(
         searchNode(form, form, "Id.LastName.font.size")[0][$text]()
-      ).toEqual({
-        value: 123.4,
-        unit: "pt",
-      });
+      ).toEqual(123.4);
       expect(
         searchNode(form, form, "Id.LastName.assist.toolTip")[0][$dump]()
           .$content

--- a/test/unit/xfa_tohtml_spec.js
+++ b/test/unit/xfa_tohtml_spec.js
@@ -1,0 +1,98 @@
+/* Copyright 2020 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { XFAFactory } from "../../src/core/xfa/factory.js";
+
+describe("XFAFactory", function () {
+  describe("toHTML", function () {
+    it("should convert some basic properties to CSS", function () {
+      const xml = `
+<?xml version="1.0"?>
+<xdp:xdp xmlns:xdp="http://ns.adobe.com/xdp/">
+  <template xmlns="http://www.xfa.org/schema/xfa-template/3.3">
+    <subform name="root" mergeMode="matchTemplate">
+      <pageSet>
+        <pageArea>
+          <contentArea x="123pt" w="456pt" h="789pt"/>
+          <medium stock="default" short="456pt" long="789pt"/>
+          <draw y="1pt" w="11pt" h="22pt" rotate="90" x="2pt">
+            <font size="7pt" typeface="Arial" baselineShift="2pt">
+              <fill>
+                <color value="12,23,34"/>
+                <solid/>
+              </fill>
+            </font>
+            <value/>
+            <margin topInset="1pt" bottomInset="2pt" leftInset="3pt" rightInset="4pt"/>
+            <para spaceAbove="1pt" spaceBelow="2pt" textIndent="3pt" marginLeft="4pt" marginRight="5pt"/>
+          </draw>
+        </pageArea>
+      </pageSet>
+      <subform name="first">
+      </subform>
+      <subform name="second">
+      </subform>
+    </subform>
+  </template>
+  <xfa:datasets xmlns:xfa="http://www.xfa.org/schema/xfa-data/1.0/">
+    <xfa:data>
+    </xfa:data>
+  </xfa:datasets>
+</xdp:xdp>
+      `;
+      const factory = new XFAFactory({ "xdp:xdp": xml });
+
+      expect(factory.numberPages).toEqual(2);
+
+      const page1 = factory.getPage(0);
+      expect(page1.attributes.style).toEqual({
+        height: "789px",
+        width: "456px",
+      });
+
+      expect(page1.children.length).toEqual(2);
+      const container = page1.children[0];
+      expect(container.attributes.class).toEqual("xfaContentarea");
+      expect(container.attributes.style).toEqual({
+        height: "789px",
+        width: "456px",
+        left: "123px",
+        top: "0px",
+        position: "absolute",
+      });
+
+      const draw = page1.children[1];
+      expect(draw.attributes.class).toEqual("xfaDraw xfaFont");
+      expect(draw.attributes.style).toEqual({
+        color: "#0c1722",
+        fontFamily: "Arial",
+        fontSize: "7px",
+        height: "22px",
+        left: "2px",
+        position: "absolute",
+        top: "1px",
+        transform: "rotate(-90deg)",
+        transformOrigin: "top left",
+        verticalAlign: "2px",
+        width: "11px",
+      });
+
+      // draw element must be on each page.
+      expect(draw.attributes.style).toEqual(
+        factory.getPage(1).children[1].attributes.style
+      );
+    });
+  });
+});

--- a/web/xfa_layer_builder.css
+++ b/web/xfa_layer_builder.css
@@ -20,3 +20,43 @@
   z-index: 200;
   transform-origin: 0 0;
 }
+
+.xfaLayer * {
+  color: inherit;
+  font: inherit;
+  font-kerning: inherit;
+  letter-spacing: inherit;
+  text-decoration: inherit;
+  vertical-align: inherit;
+}
+
+.xfaFont {
+  color: black;
+  font-weight: normal;
+  font-kerning: none;
+  font-size: 10px;
+  font-style: normal;
+  letter-spacing: 0;
+  text-decoration: none;
+  vertical-align: 0;
+}
+
+.xfaDraw {
+  z-index: 200;
+  background-color: #ff000080;
+}
+
+.xfaExclgroup {
+  z-index: 300;
+  background-color: #0000ff80;
+}
+
+.xfaField {
+  z-index: 300;
+  background-color: #00ff0080;
+}
+
+.xfaSubform {
+  z-index: 100;
+  background-color: #ffff0080;
+}

--- a/web/xfa_layer_builder.js
+++ b/web/xfa_layer_builder.js
@@ -57,7 +57,6 @@ class XfaLayerBuilder {
       } else {
         // Create an xfa layer div and render the form
         this.div = document.createElement("div");
-        this.div.className = "xfaLayer";
         this.pageDiv.appendChild(this.div);
         parameters.div = this.div;
 


### PR DESCRIPTION
  - implement few positioning properties: position, width, height, anchor;
  - implement font element;   - implement fill element (used by font) and its children (linear, radial, ...);
  - font property is inherited from ancestor container (see https://www.pdfa.org/wp-content/uploads/2020/07/XFA-3_3.pdf#page=43) so let CSS handles that stuff;
  - in order to reduce the number of properties to set, only set non default properties and put the default in CSS;
  - set a background to some containers to be able to see them (will be removed in a future commit).