### PR TITLE
Enable the ESLint `no-var` rule in a few font-parsing files, and convert `src/core/type1_parser.js` to use "standard" classes

### DIFF
--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable no-var */
 
 import {
   bytesToString,
@@ -31,14 +30,14 @@ import {
 import { ExpertEncoding, StandardEncoding } from "./encodings.js";
 
 // Maximum subroutine call depth of type 2 chartrings. Matches OTS.
-var MAX_SUBR_NESTING = 10;
+const MAX_SUBR_NESTING = 10;
 
 /**
  * The CFF class takes a Type1 file and wrap it into a
  * 'Compact Font Format' which itself embed Type2 charstrings.
  */
 // prettier-ignore
-var CFFStandardStrings = [
+const CFFStandardStrings = [
   ".notdef", "space", "exclam", "quotedbl", "numbersign", "dollar", "percent",
   "ampersand", "quoteright", "parenleft", "parenright", "asterisk", "plus",
   "comma", "hyphen", "period", "slash", "zero", "one", "two", "three", "four",
@@ -108,8 +107,8 @@ var CFFStandardStrings = [
 
 const NUM_STANDARD_CFF_STRINGS = 391;
 
-var CFFParser = (function CFFParserClosure() {
-  var CharstringValidationData = [
+const CFFParser = (function CFFParserClosure() {
+  const CharstringValidationData = [
     null,
     { id: "hstem", min: 2, stackClearing: true, stem: true },
     null,
@@ -143,7 +142,7 @@ var CFFParser = (function CFFParserClosure() {
     { id: "vhcurveto", min: 4, resetStack: true },
     { id: "hvcurveto", min: 4, resetStack: true },
   ];
-  var CharstringValidationData12 = [
+  const CharstringValidationData12 = [
     null,
     null,
     null,
@@ -228,20 +227,20 @@ var CFFParser = (function CFFParserClosure() {
     }
 
     parse() {
-      var properties = this.properties;
-      var cff = new CFF();
+      const properties = this.properties;
+      const cff = new CFF();
       this.cff = cff;
 
       // The first five sections must be in order, all the others are reached
       // via offsets contained in one of the below.
-      var header = this.parseHeader();
-      var nameIndex = this.parseIndex(header.endPos);
-      var topDictIndex = this.parseIndex(nameIndex.endPos);
-      var stringIndex = this.parseIndex(topDictIndex.endPos);
-      var globalSubrIndex = this.parseIndex(stringIndex.endPos);
+      const header = this.parseHeader();
+      const nameIndex = this.parseIndex(header.endPos);
+      const topDictIndex = this.parseIndex(nameIndex.endPos);
+      const stringIndex = this.parseIndex(topDictIndex.endPos);
+      const globalSubrIndex = this.parseIndex(stringIndex.endPos);
 
-      var topDictParsed = this.parseDict(topDictIndex.obj.get(0));
-      var topDict = this.createDict(CFFTopDict, topDictParsed, cff.strings);
+      const topDictParsed = this.parseDict(topDictIndex.obj.get(0));
+      const topDict = this.createDict(CFFTopDict, topDictParsed, cff.strings);
 
       cff.header = header.obj;
       cff.names = this.parseNameIndex(nameIndex.obj);
@@ -253,15 +252,15 @@ var CFFParser = (function CFFParserClosure() {
 
       cff.isCIDFont = topDict.hasName("ROS");
 
-      var charStringOffset = topDict.getByName("CharStrings");
-      var charStringIndex = this.parseIndex(charStringOffset).obj;
+      const charStringOffset = topDict.getByName("CharStrings");
+      const charStringIndex = this.parseIndex(charStringOffset).obj;
 
-      var fontMatrix = topDict.getByName("FontMatrix");
+      const fontMatrix = topDict.getByName("FontMatrix");
       if (fontMatrix) {
         properties.fontMatrix = fontMatrix;
       }
 
-      var fontBBox = topDict.getByName("FontBBox");
+      const fontBBox = topDict.getByName("FontBBox");
       if (fontBBox) {
         // adjusting ascent/descent
         properties.ascent = Math.max(fontBBox[3], fontBBox[1]);
@@ -269,12 +268,12 @@ var CFFParser = (function CFFParserClosure() {
         properties.ascentScaled = true;
       }
 
-      var charset, encoding;
+      let charset, encoding;
       if (cff.isCIDFont) {
-        var fdArrayIndex = this.parseIndex(topDict.getByName("FDArray")).obj;
-        for (var i = 0, ii = fdArrayIndex.count; i < ii; ++i) {
-          var dictRaw = fdArrayIndex.get(i);
-          var fontDict = this.createDict(
+        const fdArrayIndex = this.parseIndex(topDict.getByName("FDArray")).obj;
+        for (let i = 0, ii = fdArrayIndex.count; i < ii; ++i) {
+          const dictRaw = fdArrayIndex.get(i);
+          const fontDict = this.createDict(
             CFFTopDict,
             this.parseDict(dictRaw),
             cff.strings
@@ -312,7 +311,7 @@ var CFFParser = (function CFFParserClosure() {
       cff.charset = charset;
       cff.encoding = encoding;
 
-      var charStringsAndSeacs = this.parseCharStrings({
+      const charStringsAndSeacs = this.parseCharStrings({
         charStrings: charStringIndex,
         localSubrIndex: topDict.privateDict.subrsIndex,
         globalSubrIndex: globalSubrIndex.obj,
@@ -328,9 +327,9 @@ var CFFParser = (function CFFParserClosure() {
     }
 
     parseHeader() {
-      var bytes = this.bytes;
-      var bytesLength = bytes.length;
-      var offset = 0;
+      let bytes = this.bytes;
+      const bytesLength = bytes.length;
+      let offset = 0;
 
       // Prevent an infinite loop, by checking that the offset is within the
       // bounds of the bytes array. Necessary in empty, or invalid, font files.
@@ -345,19 +344,19 @@ var CFFParser = (function CFFParserClosure() {
         bytes = bytes.subarray(offset);
         this.bytes = bytes;
       }
-      var major = bytes[0];
-      var minor = bytes[1];
-      var hdrSize = bytes[2];
-      var offSize = bytes[3];
-      var header = new CFFHeader(major, minor, hdrSize, offSize);
+      const major = bytes[0];
+      const minor = bytes[1];
+      const hdrSize = bytes[2];
+      const offSize = bytes[3];
+      const header = new CFFHeader(major, minor, hdrSize, offSize);
       return { obj: header, endPos: hdrSize };
     }
 
     parseDict(dict) {
-      var pos = 0;
+      let pos = 0;
 
       function parseOperand() {
-        var value = dict[pos++];
+        let value = dict[pos++];
         if (value === 30) {
           return parseFloatOperand();
         } else if (value === 28) {
@@ -382,16 +381,16 @@ var CFFParser = (function CFFParserClosure() {
       }
 
       function parseFloatOperand() {
-        var str = "";
-        var eof = 15;
+        let str = "";
+        const eof = 15;
         // prettier-ignore
         const lookup = ["0", "1", "2", "3", "4", "5", "6", "7", "8",
                         "9", ".", "E", "E-", null, "-"];
-        var length = dict.length;
+        const length = dict.length;
         while (pos < length) {
-          var b = dict[pos++];
-          var b1 = b >> 4;
-          var b2 = b & 15;
+          const b = dict[pos++];
+          const b1 = b >> 4;
+          const b2 = b & 15;
 
           if (b1 === eof) {
             break;
@@ -406,13 +405,13 @@ var CFFParser = (function CFFParserClosure() {
         return parseFloat(str);
       }
 
-      var operands = [];
-      var entries = [];
+      let operands = [];
+      const entries = [];
 
       pos = 0;
-      var end = dict.length;
+      const end = dict.length;
       while (pos < end) {
-        var b = dict[pos];
+        let b = dict[pos];
         if (b <= 21) {
           if (b === 12) {
             b = (b << 8) | dict[++pos];
@@ -428,21 +427,21 @@ var CFFParser = (function CFFParserClosure() {
     }
 
     parseIndex(pos) {
-      var cffIndex = new CFFIndex();
-      var bytes = this.bytes;
-      var count = (bytes[pos++] << 8) | bytes[pos++];
-      var offsets = [];
-      var end = pos;
-      var i, ii;
+      const cffIndex = new CFFIndex();
+      const bytes = this.bytes;
+      const count = (bytes[pos++] << 8) | bytes[pos++];
+      const offsets = [];
+      let end = pos;
+      let i, ii;
 
       if (count !== 0) {
-        var offsetSize = bytes[pos++];
+        const offsetSize = bytes[pos++];
         // add 1 for offset to determine size of last object
-        var startPos = pos + (count + 1) * offsetSize - 1;
+        const startPos = pos + (count + 1) * offsetSize - 1;
 
         for (i = 0, ii = count + 1; i < ii; ++i) {
-          var offset = 0;
-          for (var j = 0; j < offsetSize; ++j) {
+          let offset = 0;
+          for (let j = 0; j < offsetSize; ++j) {
             offset <<= 8;
             offset += bytes[pos++];
           }
@@ -451,37 +450,37 @@ var CFFParser = (function CFFParserClosure() {
         end = offsets[count];
       }
       for (i = 0, ii = offsets.length - 1; i < ii; ++i) {
-        var offsetStart = offsets[i];
-        var offsetEnd = offsets[i + 1];
+        const offsetStart = offsets[i];
+        const offsetEnd = offsets[i + 1];
         cffIndex.add(bytes.subarray(offsetStart, offsetEnd));
       }
       return { obj: cffIndex, endPos: end };
     }
 
     parseNameIndex(index) {
-      var names = [];
-      for (var i = 0, ii = index.count; i < ii; ++i) {
-        var name = index.get(i);
+      const names = [];
+      for (let i = 0, ii = index.count; i < ii; ++i) {
+        const name = index.get(i);
         names.push(bytesToString(name));
       }
       return names;
     }
 
     parseStringIndex(index) {
-      var strings = new CFFStrings();
-      for (var i = 0, ii = index.count; i < ii; ++i) {
-        var data = index.get(i);
+      const strings = new CFFStrings();
+      for (let i = 0, ii = index.count; i < ii; ++i) {
+        const data = index.get(i);
         strings.add(bytesToString(data));
       }
       return strings;
     }
 
     createDict(Type, dict, strings) {
-      var cffDict = new Type(strings);
-      for (var i = 0, ii = dict.length; i < ii; ++i) {
-        var pair = dict[i];
-        var key = pair[0];
-        var value = pair[1];
+      const cffDict = new Type(strings);
+      for (let i = 0, ii = dict.length; i < ii; ++i) {
+        const pair = dict[i];
+        const key = pair[0];
+        const value = pair[1];
         cffDict.setByKey(key, value);
       }
       return cffDict;
@@ -491,16 +490,16 @@ var CFFParser = (function CFFParserClosure() {
       if (!data || state.callDepth > MAX_SUBR_NESTING) {
         return false;
       }
-      var stackSize = state.stackSize;
-      var stack = state.stack;
+      let stackSize = state.stackSize;
+      const stack = state.stack;
 
-      var length = data.length;
+      const length = data.length;
 
-      for (var j = 0; j < length; ) {
-        var value = data[j++];
-        var validationCommand = null;
+      for (let j = 0; j < length; ) {
+        const value = data[j++];
+        let validationCommand = null;
         if (value === 12) {
-          var q = data[j++];
+          const q = data[j++];
           if (q === 0) {
             // The CFF specification state that the 'dotsection' command
             // (12, 0) is deprecated and treated as a no-op, but all Type2
@@ -556,7 +555,7 @@ var CFFParser = (function CFFParserClosure() {
           stackSize %= 2;
           validationCommand = CharstringValidationData[value];
         } else if (value === 10 || value === 29) {
-          var subrsIndex;
+          let subrsIndex;
           if (value === 10) {
             subrsIndex = localSubrIndex;
           } else {
@@ -567,13 +566,13 @@ var CFFParser = (function CFFParserClosure() {
             warn("Missing subrsIndex for " + validationCommand.id);
             return false;
           }
-          var bias = 32768;
+          let bias = 32768;
           if (subrsIndex.count < 1240) {
             bias = 107;
           } else if (subrsIndex.count < 33900) {
             bias = 1131;
           }
-          var subrNumber = stack[--stackSize] + bias;
+          const subrNumber = stack[--stackSize] + bias;
           if (
             subrNumber < 0 ||
             subrNumber >= subrsIndex.count ||
@@ -585,7 +584,7 @@ var CFFParser = (function CFFParserClosure() {
           }
           state.stackSize = stackSize;
           state.callDepth++;
-          var valid = this.parseCharString(
+          const valid = this.parseCharString(
             state,
             subrsIndex.get(subrNumber),
             localSubrIndex,
@@ -674,12 +673,12 @@ var CFFParser = (function CFFParserClosure() {
       fdArray,
       privateDict,
     }) {
-      var seacs = [];
-      var widths = [];
-      var count = charStrings.count;
-      for (var i = 0; i < count; i++) {
-        var charstring = charStrings.get(i);
-        var state = {
+      const seacs = [];
+      const widths = [];
+      const count = charStrings.count;
+      for (let i = 0; i < count; i++) {
+        const charstring = charStrings.get(i);
+        const state = {
           callDepth: 0,
           stackSize: 0,
           stack: [],
@@ -690,11 +689,11 @@ var CFFParser = (function CFFParserClosure() {
           width: null,
           hasVStems: false,
         };
-        var valid = true;
-        var localSubrToUse = null;
-        var privateDictToUse = privateDict;
+        let valid = true;
+        let localSubrToUse = null;
+        let privateDictToUse = privateDict;
         if (fdSelect && fdArray.length) {
-          var fdIndex = fdSelect.getFDIndex(i);
+          const fdIndex = fdSelect.getFDIndex(i);
           if (fdIndex === -1) {
             warn("Glyph index is not in fd select.");
             valid = false;
@@ -737,7 +736,11 @@ var CFFParser = (function CFFParserClosure() {
     }
 
     emptyPrivateDictionary(parentDict) {
-      var privateDict = this.createDict(CFFPrivateDict, [], parentDict.strings);
+      const privateDict = this.createDict(
+        CFFPrivateDict,
+        [],
+        parentDict.strings
+      );
       parentDict.setByKey(18, [0, 0]);
       parentDict.privateDict = privateDict;
     }
@@ -748,24 +751,24 @@ var CFFParser = (function CFFParserClosure() {
         this.emptyPrivateDictionary(parentDict);
         return;
       }
-      var privateOffset = parentDict.getByName("Private");
+      const privateOffset = parentDict.getByName("Private");
       // make sure the params are formatted correctly
       if (!Array.isArray(privateOffset) || privateOffset.length !== 2) {
         parentDict.removeByName("Private");
         return;
       }
-      var size = privateOffset[0];
-      var offset = privateOffset[1];
+      const size = privateOffset[0];
+      const offset = privateOffset[1];
       // remove empty dicts or ones that refer to invalid location
       if (size === 0 || offset >= this.bytes.length) {
         this.emptyPrivateDictionary(parentDict);
         return;
       }
 
-      var privateDictEnd = offset + size;
-      var dictData = this.bytes.subarray(offset, privateDictEnd);
-      var dict = this.parseDict(dictData);
-      var privateDict = this.createDict(
+      const privateDictEnd = offset + size;
+      const dictData = this.bytes.subarray(offset, privateDictEnd);
+      const dict = this.parseDict(dictData);
+      const privateDict = this.createDict(
         CFFPrivateDict,
         dict,
         parentDict.strings
@@ -776,14 +779,14 @@ var CFFParser = (function CFFParserClosure() {
       if (!privateDict.getByName("Subrs")) {
         return;
       }
-      var subrsOffset = privateDict.getByName("Subrs");
-      var relativeOffset = offset + subrsOffset;
+      const subrsOffset = privateDict.getByName("Subrs");
+      const relativeOffset = offset + subrsOffset;
       // Validate the offset.
       if (subrsOffset === 0 || relativeOffset >= this.bytes.length) {
         this.emptyPrivateDictionary(parentDict);
         return;
       }
-      var subrsIndex = this.parseIndex(relativeOffset);
+      const subrsIndex = this.parseIndex(relativeOffset);
       privateDict.subrsIndex = subrsIndex.obj;
     }
 
@@ -808,11 +811,11 @@ var CFFParser = (function CFFParserClosure() {
         );
       }
 
-      var bytes = this.bytes;
-      var start = pos;
-      var format = bytes[pos++];
+      const bytes = this.bytes;
+      const start = pos;
+      const format = bytes[pos++];
       const charset = [cid ? 0 : ".notdef"];
-      var id, count, i;
+      let id, count, i;
 
       // subtract 1 for the .notdef glyph
       length -= 1;
@@ -846,24 +849,24 @@ var CFFParser = (function CFFParserClosure() {
           throw new FormatError("Unknown charset format");
       }
       // Raw won't be needed if we actually compile the charset.
-      var end = pos;
-      var raw = bytes.subarray(start, end);
+      const end = pos;
+      const raw = bytes.subarray(start, end);
 
       return new CFFCharset(false, format, charset, raw);
     }
 
     parseEncoding(pos, properties, strings, charset) {
-      var encoding = Object.create(null);
-      var bytes = this.bytes;
-      var predefined = false;
-      var format, i, ii;
-      var raw = null;
+      const encoding = Object.create(null);
+      const bytes = this.bytes;
+      let predefined = false;
+      let format, i, ii;
+      let raw = null;
 
       function readSupplement() {
-        var supplementsCount = bytes[pos++];
+        const supplementsCount = bytes[pos++];
         for (i = 0; i < supplementsCount; i++) {
-          var code = bytes[pos++];
-          var sid = (bytes[pos++] << 8) + (bytes[pos++] & 0xff);
+          const code = bytes[pos++];
+          const sid = (bytes[pos++] << 8) + (bytes[pos++] & 0xff);
           encoding[code] = charset.indexOf(strings.get(sid));
         }
       }
@@ -871,31 +874,31 @@ var CFFParser = (function CFFParserClosure() {
       if (pos === 0 || pos === 1) {
         predefined = true;
         format = pos;
-        var baseEncoding = pos ? ExpertEncoding : StandardEncoding;
+        const baseEncoding = pos ? ExpertEncoding : StandardEncoding;
         for (i = 0, ii = charset.length; i < ii; i++) {
-          var index = baseEncoding.indexOf(charset[i]);
+          const index = baseEncoding.indexOf(charset[i]);
           if (index !== -1) {
             encoding[index] = i;
           }
         }
       } else {
-        var dataStart = pos;
+        const dataStart = pos;
         format = bytes[pos++];
         switch (format & 0x7f) {
           case 0:
-            var glyphsCount = bytes[pos++];
+            const glyphsCount = bytes[pos++];
             for (i = 1; i <= glyphsCount; i++) {
               encoding[bytes[pos++]] = i;
             }
             break;
 
           case 1:
-            var rangesCount = bytes[pos++];
-            var gid = 1;
+            const rangesCount = bytes[pos++];
+            let gid = 1;
             for (i = 0; i < rangesCount; i++) {
-              var start = bytes[pos++];
-              var left = bytes[pos++];
-              for (var j = start; j <= start + left; j++) {
+              const start = bytes[pos++];
+              const left = bytes[pos++];
+              for (let j = start; j <= start + left; j++) {
                 encoding[j] = gid++;
               }
             }
@@ -904,7 +907,7 @@ var CFFParser = (function CFFParserClosure() {
           default:
             throw new FormatError(`Unknown encoding format: ${format} in CFF`);
         }
-        var dataEnd = pos;
+        const dataEnd = pos;
         if (format & 0x80) {
           // hasSupplement
           // The font sanitizer does not support CFF encoding with a
@@ -922,22 +925,22 @@ var CFFParser = (function CFFParserClosure() {
     }
 
     parseFDSelect(pos, length) {
-      var bytes = this.bytes;
-      var format = bytes[pos++];
-      var fdSelect = [];
-      var i;
+      const bytes = this.bytes;
+      const format = bytes[pos++];
+      const fdSelect = [];
+      let i;
 
       switch (format) {
         case 0:
           for (i = 0; i < length; ++i) {
-            var id = bytes[pos++];
+            const id = bytes[pos++];
             fdSelect.push(id);
           }
           break;
         case 3:
-          var rangesCount = (bytes[pos++] << 8) | bytes[pos++];
+          const rangesCount = (bytes[pos++] << 8) | bytes[pos++];
           for (i = 0; i < rangesCount; ++i) {
-            var first = (bytes[pos++] << 8) | bytes[pos++];
+            let first = (bytes[pos++] << 8) | bytes[pos++];
             if (i === 0 && first !== 0) {
               warn(
                 "parseFDSelect: The first range must have a first GID of 0" +
@@ -945,9 +948,9 @@ var CFFParser = (function CFFParserClosure() {
               );
               first = 0;
             }
-            var fdIndex = bytes[pos++];
-            var next = (bytes[pos] << 8) | bytes[pos + 1];
-            for (var j = first; j < next; ++j) {
+            const fdIndex = bytes[pos++];
+            const next = (bytes[pos] << 8) | bytes[pos + 1];
+            for (let j = first; j < next; ++j) {
               fdSelect.push(fdIndex);
             }
           }
@@ -995,7 +998,7 @@ class CFF {
       warn("Not enough space in charstrings to duplicate first glyph.");
       return;
     }
-    var glyphZero = this.charStrings.get(0);
+    const glyphZero = this.charStrings.get(0);
     this.charStrings.add(glyphZero);
     if (this.isCIDFont) {
       this.fdSelect.fdSelect.push(this.fdSelect.fdSelect[0]);
@@ -1006,7 +1009,7 @@ class CFF {
     if (id < 0 || id >= this.charStrings.count) {
       return false;
     }
-    var glyph = this.charStrings.get(id);
+    const glyph = this.charStrings.get(id);
     return glyph.length > 0;
   }
 }
@@ -1098,19 +1101,19 @@ class CFFDict {
     if (!(key in this.keyToNameMap)) {
       return false;
     }
-    var valueLength = value.length;
+    const valueLength = value.length;
     // ignore empty values
     if (valueLength === 0) {
       return true;
     }
     // Ignore invalid values (fixes bug1068432.pdf and bug1308536.pdf).
-    for (var i = 0; i < valueLength; i++) {
+    for (let i = 0; i < valueLength; i++) {
       if (isNaN(value[i])) {
         warn('Invalid CFFDict value: "' + value + '" for key "' + key + '".');
         return true;
       }
     }
-    var type = this.types[key];
+    const type = this.types[key];
     // remove the array wrapping these types of values
     if (type === "num" || type === "sid" || type === "offset") {
       value = value[0];
@@ -1134,7 +1137,7 @@ class CFFDict {
     if (!(name in this.nameToKeyMap)) {
       throw new FormatError(`Invalid dictionary name ${name}"`);
     }
-    var key = this.nameToKeyMap[name];
+    const key = this.nameToKeyMap[name];
     if (!(key in this.values)) {
       return this.defaults[key];
     }
@@ -1146,7 +1149,7 @@ class CFFDict {
   }
 
   static createTables(layout) {
-    var tables = {
+    const tables = {
       keyToNameMap: {},
       nameToKeyMap: {},
       defaults: {},
@@ -1154,9 +1157,9 @@ class CFFDict {
       opcodes: {},
       order: [],
     };
-    for (var i = 0, ii = layout.length; i < ii; ++i) {
-      var entry = layout[i];
-      var key = Array.isArray(entry[0])
+    for (let i = 0, ii = layout.length; i < ii; ++i) {
+      const entry = layout[i];
+      const key = Array.isArray(entry[0])
         ? (entry[0][0] << 8) + entry[0][1]
         : entry[0];
       tables.keyToNameMap[key] = entry[1];
@@ -1170,8 +1173,8 @@ class CFFDict {
   }
 }
 
-var CFFTopDict = (function CFFTopDictClosure() {
-  var layout = [
+const CFFTopDict = (function CFFTopDictClosure() {
+  const layout = [
     [[12, 30], "ROS", ["sid", "sid", "num"], null],
     [[12, 20], "SyntheticBase", "num", null],
     [0, "version", "sid", null],
@@ -1211,7 +1214,7 @@ var CFFTopDict = (function CFFTopDictClosure() {
     [[12, 36], "FDArray", "offset", null],
     [[12, 38], "FontName", "sid", null],
   ];
-  var tables = null;
+  let tables = null;
 
   // eslint-disable-next-line no-shadow
   class CFFTopDict extends CFFDict {
@@ -1226,8 +1229,8 @@ var CFFTopDict = (function CFFTopDictClosure() {
   return CFFTopDict;
 })();
 
-var CFFPrivateDict = (function CFFPrivateDictClosure() {
-  var layout = [
+const CFFPrivateDict = (function CFFPrivateDictClosure() {
+  const layout = [
     [6, "BlueValues", "delta", null],
     [7, "OtherBlues", "delta", null],
     [8, "FamilyBlues", "delta", null],
@@ -1247,7 +1250,7 @@ var CFFPrivateDict = (function CFFPrivateDictClosure() {
     [21, "nominalWidthX", "num", 0],
     [19, "Subrs", "offset", null],
   ];
-  var tables = null;
+  let tables = null;
 
   // eslint-disable-next-line no-shadow
   class CFFPrivateDict extends CFFDict {
@@ -1262,11 +1265,12 @@ var CFFPrivateDict = (function CFFPrivateDictClosure() {
   return CFFPrivateDict;
 })();
 
-var CFFCharsetPredefinedTypes = {
+const CFFCharsetPredefinedTypes = {
   ISO_ADOBE: 0,
   EXPERT: 1,
   EXPERT_SUBSET: 2,
 };
+
 class CFFCharset {
   constructor(predefined, format, charset, raw) {
     this.predefined = predefined;
@@ -1318,7 +1322,7 @@ class CFFOffsetTracker {
   }
 
   offset(value) {
-    for (var key in this.offsets) {
+    for (const key in this.offsets) {
       this.offsets[key] += value;
     }
   }
@@ -1327,15 +1331,15 @@ class CFFOffsetTracker {
     if (!(key in this.offsets)) {
       throw new FormatError(`Not tracking location of ${key}`);
     }
-    var data = output.data;
-    var dataOffset = this.offsets[key];
-    var size = 5;
-    for (var i = 0, ii = values.length; i < ii; ++i) {
-      var offset0 = i * size + dataOffset;
-      var offset1 = offset0 + 1;
-      var offset2 = offset0 + 2;
-      var offset3 = offset0 + 3;
-      var offset4 = offset0 + 4;
+    const data = output.data;
+    const dataOffset = this.offsets[key];
+    const size = 5;
+    for (let i = 0, ii = values.length; i < ii; ++i) {
+      const offset0 = i * size + dataOffset;
+      const offset1 = offset0 + 1;
+      const offset2 = offset0 + 2;
+      const offset3 = offset0 + 3;
+      const offset4 = offset0 + 4;
       // It's easy to screw up offsets so perform this sanity check.
       if (
         data[offset0] !== 0x1d ||
@@ -1346,7 +1350,7 @@ class CFFOffsetTracker {
       ) {
         throw new FormatError("writing to an offset that is not empty");
       }
-      var value = values[i];
+      const value = values[i];
       data[offset0] = 0x1d;
       data[offset1] = (value >> 24) & 0xff;
       data[offset2] = (value >> 16) & 0xff;
@@ -1363,8 +1367,8 @@ class CFFCompiler {
   }
 
   compile() {
-    var cff = this.cff;
-    var output = {
+    const cff = this.cff;
+    const output = {
       data: [],
       length: 0,
       add: function CFFCompiler_add(data) {
@@ -1374,10 +1378,10 @@ class CFFCompiler {
     };
 
     // Compile the five entries that must be in order.
-    var header = this.compileHeader(cff.header);
+    const header = this.compileHeader(cff.header);
     output.add(header);
 
-    var nameIndex = this.compileNameIndex(cff.names);
+    const nameIndex = this.compileNameIndex(cff.names);
     output.add(nameIndex);
 
     if (cff.isCIDFont) {
@@ -1394,11 +1398,11 @@ class CFFCompiler {
       // To make this work on all platforms we move the top matrix into each
       // sub top dict and concat if necessary.
       if (cff.topDict.hasName("FontMatrix")) {
-        var base = cff.topDict.getByName("FontMatrix");
+        const base = cff.topDict.getByName("FontMatrix");
         cff.topDict.removeByName("FontMatrix");
-        for (var i = 0, ii = cff.fdArray.length; i < ii; i++) {
-          var subDict = cff.fdArray[i];
-          var matrix = base.slice(0);
+        for (let i = 0, ii = cff.fdArray.length; i < ii; i++) {
+          const subDict = cff.fdArray[i];
+          let matrix = base.slice(0);
           if (subDict.hasName("FontMatrix")) {
             matrix = Util.transform(matrix, subDict.getByName("FontMatrix"));
           }
@@ -1414,18 +1418,18 @@ class CFFCompiler {
     }
 
     cff.topDict.setByName("charset", 0);
-    var compiled = this.compileTopDicts(
+    let compiled = this.compileTopDicts(
       [cff.topDict],
       output.length,
       cff.isCIDFont
     );
     output.add(compiled.output);
-    var topDictTracker = compiled.trackers[0];
+    const topDictTracker = compiled.trackers[0];
 
-    var stringIndex = this.compileStringIndex(cff.strings.strings);
+    const stringIndex = this.compileStringIndex(cff.strings.strings);
     output.add(stringIndex);
 
-    var globalSubrIndex = this.compileIndex(cff.globalSubrIndex);
+    const globalSubrIndex = this.compileIndex(cff.globalSubrIndex);
     output.add(globalSubrIndex);
 
     // Now start on the other entries that have no specific order.
@@ -1437,12 +1441,12 @@ class CFFCompiler {
           output
         );
       } else {
-        var encoding = this.compileEncoding(cff.encoding);
+        const encoding = this.compileEncoding(cff.encoding);
         topDictTracker.setEntryLocation("Encoding", [output.length], output);
         output.add(encoding);
       }
     }
-    var charset = this.compileCharset(
+    const charset = this.compileCharset(
       cff.charset,
       cff.charStrings.count,
       cff.strings,
@@ -1451,7 +1455,7 @@ class CFFCompiler {
     topDictTracker.setEntryLocation("charset", [output.length], output);
     output.add(charset);
 
-    var charStrings = this.compileCharStrings(cff.charStrings);
+    const charStrings = this.compileCharStrings(cff.charStrings);
     topDictTracker.setEntryLocation("CharStrings", [output.length], output);
     output.add(charStrings);
 
@@ -1459,14 +1463,14 @@ class CFFCompiler {
       // For some reason FDSelect must be in front of FDArray on windows. OSX
       // and linux don't seem to care.
       topDictTracker.setEntryLocation("FDSelect", [output.length], output);
-      var fdSelect = this.compileFDSelect(cff.fdSelect);
+      const fdSelect = this.compileFDSelect(cff.fdSelect);
       output.add(fdSelect);
       // It is unclear if the sub font dictionary can have CID related
       // dictionary keys, but the sanitizer doesn't like them so remove them.
       compiled = this.compileTopDicts(cff.fdArray, output.length, true);
       topDictTracker.setEntryLocation("FDArray", [output.length], output);
       output.add(compiled.output);
-      var fontDictTrackers = compiled.trackers;
+      const fontDictTrackers = compiled.trackers;
 
       this.compilePrivateDicts(cff.fdArray, fontDictTrackers, output);
     }
@@ -1496,19 +1500,19 @@ class CFFCompiler {
   }
 
   encodeFloat(num) {
-    var value = num.toString();
+    let value = num.toString();
 
     // Rounding inaccurate doubles.
-    var m = CFFCompiler.EncodeFloatRegExp.exec(value);
+    const m = CFFCompiler.EncodeFloatRegExp.exec(value);
     if (m) {
-      var epsilon = parseFloat("1e" + ((m[2] ? +m[2] : 0) + m[1].length));
+      const epsilon = parseFloat("1e" + ((m[2] ? +m[2] : 0) + m[1].length));
       value = (Math.round(num * epsilon) / epsilon).toString();
     }
 
-    var nibbles = "";
-    var i, ii;
+    let nibbles = "";
+    let i, ii;
     for (i = 0, ii = value.length; i < ii; ++i) {
-      var a = value[i];
+      const a = value[i];
       if (a === "e") {
         nibbles += value[++i] === "-" ? "c" : "b";
       } else if (a === ".") {
@@ -1520,7 +1524,7 @@ class CFFCompiler {
       }
     }
     nibbles += nibbles.length & 1 ? "f" : "ff";
-    var out = [30];
+    const out = [30];
     for (i = 0, ii = nibbles.length; i < ii; i += 2) {
       out.push(parseInt(nibbles.substring(i, i + 2), 16));
     }
@@ -1528,7 +1532,7 @@ class CFFCompiler {
   }
 
   encodeInteger(value) {
-    var code;
+    let code;
     if (value >= -107 && value <= 107) {
       code = [value + 139];
     } else if (value >= 108 && value <= 1131) {
@@ -1556,16 +1560,16 @@ class CFFCompiler {
   }
 
   compileNameIndex(names) {
-    var nameIndex = new CFFIndex();
-    for (var i = 0, ii = names.length; i < ii; ++i) {
-      var name = names[i];
+    const nameIndex = new CFFIndex();
+    for (let i = 0, ii = names.length; i < ii; ++i) {
+      const name = names[i];
       // OTS doesn't allow names to be over 127 characters.
-      var length = Math.min(name.length, 127);
-      var sanitizedName = new Array(length);
-      for (var j = 0; j < length; j++) {
+      const length = Math.min(name.length, 127);
+      let sanitizedName = new Array(length);
+      for (let j = 0; j < length; j++) {
         // OTS requires chars to be between a range and not certain other
         // chars.
-        var char = name[j];
+        let char = name[j];
         if (
           char < "!" ||
           char > "~" ||
@@ -1595,10 +1599,10 @@ class CFFCompiler {
   }
 
   compileTopDicts(dicts, length, removeCidKeys) {
-    var fontDictTrackers = [];
-    var fdArrayIndex = new CFFIndex();
-    for (var i = 0, ii = dicts.length; i < ii; ++i) {
-      var fontDict = dicts[i];
+    const fontDictTrackers = [];
+    let fdArrayIndex = new CFFIndex();
+    for (let i = 0, ii = dicts.length; i < ii; ++i) {
+      const fontDict = dicts[i];
       if (removeCidKeys) {
         fontDict.removeByName("CIDFontVersion");
         fontDict.removeByName("CIDFontRevision");
@@ -1606,8 +1610,8 @@ class CFFCompiler {
         fontDict.removeByName("CIDCount");
         fontDict.removeByName("UIDBase");
       }
-      var fontDictTracker = new CFFOffsetTracker();
-      var fontDictData = this.compileDict(fontDict, fontDictTracker);
+      const fontDictTracker = new CFFOffsetTracker();
+      const fontDictData = this.compileDict(fontDict, fontDictTracker);
       fontDictTrackers.push(fontDictTracker);
       fdArrayIndex.add(fontDictData);
       fontDictTracker.offset(length);
@@ -1620,16 +1624,16 @@ class CFFCompiler {
   }
 
   compilePrivateDicts(dicts, trackers, output) {
-    for (var i = 0, ii = dicts.length; i < ii; ++i) {
-      var fontDict = dicts[i];
-      var privateDict = fontDict.privateDict;
+    for (let i = 0, ii = dicts.length; i < ii; ++i) {
+      const fontDict = dicts[i];
+      const privateDict = fontDict.privateDict;
       if (!privateDict || !fontDict.hasName("Private")) {
         throw new FormatError("There must be a private dictionary.");
       }
-      var privateDictTracker = new CFFOffsetTracker();
-      var privateDictData = this.compileDict(privateDict, privateDictTracker);
+      const privateDictTracker = new CFFOffsetTracker();
+      const privateDictData = this.compileDict(privateDict, privateDictTracker);
 
-      var outputLength = output.length;
+      let outputLength = output.length;
       privateDictTracker.offset(outputLength);
       if (!privateDictData.length) {
         // The private dictionary was empty, set the output length to zero to
@@ -1646,7 +1650,7 @@ class CFFCompiler {
       output.add(privateDictData);
 
       if (privateDict.subrsIndex && privateDict.hasName("Subrs")) {
-        var subrs = this.compileIndex(privateDict.subrsIndex);
+        const subrs = this.compileIndex(privateDict.subrsIndex);
         privateDictTracker.setEntryLocation(
           "Subrs",
           [privateDictData.length],
@@ -1658,16 +1662,16 @@ class CFFCompiler {
   }
 
   compileDict(dict, offsetTracker) {
-    var out = [];
+    let out = [];
     // The dictionary keys must be in a certain order.
-    var order = dict.order;
-    for (var i = 0; i < order.length; ++i) {
-      var key = order[i];
+    const order = dict.order;
+    for (let i = 0; i < order.length; ++i) {
+      const key = order[i];
       if (!(key in dict.values)) {
         continue;
       }
-      var values = dict.values[key];
-      var types = dict.types[key];
+      let values = dict.values[key];
+      let types = dict.types[key];
       if (!Array.isArray(types)) {
         types = [types];
       }
@@ -1680,9 +1684,9 @@ class CFFCompiler {
         continue;
       }
 
-      for (var j = 0, jj = types.length; j < jj; ++j) {
-        var type = types[j];
-        var value = values[j];
+      for (let j = 0, jj = types.length; j < jj; ++j) {
+        const type = types[j];
+        const value = values[j];
         switch (type) {
           case "num":
           case "sid":
@@ -1692,7 +1696,7 @@ class CFFCompiler {
             // For offsets we just insert a 32bit integer so we don't have to
             // deal with figuring out the length of the offset when it gets
             // replaced later on by the compiler.
-            var name = dict.keyToNameMap[key];
+            const name = dict.keyToNameMap[key];
             // Some offsets have the offset and the length, so just record the
             // position of the first one.
             if (!offsetTracker.isTracking(name)) {
@@ -1703,7 +1707,7 @@ class CFFCompiler {
           case "array":
           case "delta":
             out = out.concat(this.encodeNumber(value));
-            for (var k = 1, kk = values.length; k < kk; ++k) {
+            for (let k = 1, kk = values.length; k < kk; ++k) {
               out = out.concat(this.encodeNumber(values[k]));
             }
             break;
@@ -1717,22 +1721,22 @@ class CFFCompiler {
   }
 
   compileStringIndex(strings) {
-    var stringIndex = new CFFIndex();
-    for (var i = 0, ii = strings.length; i < ii; ++i) {
+    const stringIndex = new CFFIndex();
+    for (let i = 0, ii = strings.length; i < ii; ++i) {
       stringIndex.add(stringToBytes(strings[i]));
     }
     return this.compileIndex(stringIndex);
   }
 
   compileGlobalSubrIndex() {
-    var globalSubrIndex = this.cff.globalSubrIndex;
+    const globalSubrIndex = this.cff.globalSubrIndex;
     this.out.writeByteArray(this.compileIndex(globalSubrIndex));
   }
 
   compileCharStrings(charStrings) {
-    var charStringsIndex = new CFFIndex();
-    for (var i = 0; i < charStrings.count; i++) {
-      var glyph = charStrings.get(i);
+    const charStringsIndex = new CFFIndex();
+    for (let i = 0; i < charStrings.count; i++) {
+      const glyph = charStrings.get(i);
       // If the CharString outline is empty, replace it with .notdef to
       // prevent OTS from rejecting the font (fixes bug1252420.pdf).
       if (glyph.length === 0) {
@@ -1832,17 +1836,17 @@ class CFFCompiler {
   }
 
   compileTypedArray(data) {
-    var out = [];
-    for (var i = 0, ii = data.length; i < ii; ++i) {
+    const out = [];
+    for (let i = 0, ii = data.length; i < ii; ++i) {
       out[i] = data[i];
     }
     return out;
   }
 
   compileIndex(index, trackers = []) {
-    var objects = index.objects;
+    const objects = index.objects;
     // First 2 bytes contains the number of objects contained into this index
-    var count = objects.length;
+    const count = objects.length;
 
     // If there is no object, just create an index. This technically
     // should just be [0, 0] but OTS has an issue with that.
@@ -1850,15 +1854,15 @@ class CFFCompiler {
       return [0, 0, 0];
     }
 
-    var data = [(count >> 8) & 0xff, count & 0xff];
+    const data = [(count >> 8) & 0xff, count & 0xff];
 
-    var lastOffset = 1,
+    let lastOffset = 1,
       i;
     for (i = 0; i < count; ++i) {
       lastOffset += objects[i].length;
     }
 
-    var offsetSize;
+    let offsetSize;
     if (lastOffset < 0x100) {
       offsetSize = 1;
     } else if (lastOffset < 0x10000) {
@@ -1873,7 +1877,7 @@ class CFFCompiler {
     data.push(offsetSize);
 
     // Add another offset after this one because we need a new offset
-    var relativeOffset = 1;
+    let relativeOffset = 1;
     for (i = 0; i < count + 1; i++) {
       if (offsetSize === 1) {
         data.push(relativeOffset & 0xff);
@@ -1904,7 +1908,7 @@ class CFFCompiler {
       if (trackers[i]) {
         trackers[i].offset(data.length);
       }
-      for (var j = 0, jj = objects[i].length; j < jj; j++) {
+      for (let j = 0, jj = objects[i].length; j < jj; j++) {
         data.push(objects[i][j]);
       }
     }

--- a/src/core/font_renderer.js
+++ b/src/core/font_renderer.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable no-var */
 
 import {
   bytesToString,
@@ -26,7 +25,7 @@ import { getGlyphsUnicode } from "./glyphlist.js";
 import { StandardEncoding } from "./encodings.js";
 import { Stream } from "./stream.js";
 
-var FontRendererFactory = (function FontRendererFactoryClosure() {
+const FontRendererFactory = (function FontRendererFactoryClosure() {
   function getLong(data, offset) {
     return (
       (data[offset] << 24) |
@@ -52,15 +51,15 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
   }
 
   function parseCmap(data, start, end) {
-    var offset =
+    const offset =
       getUshort(data, start + 2) === 1
         ? getLong(data, start + 8)
         : getLong(data, start + 16);
-    var format = getUshort(data, start + offset);
-    var ranges, p, i;
+    const format = getUshort(data, start + offset);
+    let ranges, p, i;
     if (format === 4) {
       getUshort(data, start + offset + 2); // length
-      var segCount = getUshort(data, start + offset + 6) >> 1;
+      const segCount = getUshort(data, start + offset + 6) >> 1;
       p = start + offset + 14;
       ranges = [];
       for (i = 0; i < segCount; i++, p += 2) {
@@ -74,12 +73,12 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
         ranges[i].idDelta = getUshort(data, p);
       }
       for (i = 0; i < segCount; i++, p += 2) {
-        var idOffset = getUshort(data, p);
+        let idOffset = getUshort(data, p);
         if (idOffset === 0) {
           continue;
         }
         ranges[i].ids = [];
-        for (var j = 0, jj = ranges[i].end - ranges[i].start + 1; j < jj; j++) {
+        for (let j = 0, jj = ranges[i].end - ranges[i].start + 1; j < jj; j++) {
           ranges[i].ids[j] = getUshort(data, p + idOffset);
           idOffset += 2;
         }
@@ -87,7 +86,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
       return ranges;
     } else if (format === 12) {
       getLong(data, start + offset + 4); // length
-      var groups = getLong(data, start + offset + 12);
+      const groups = getLong(data, start + offset + 12);
       p = start + offset + 16;
       ranges = [];
       for (i = 0; i < groups; i++) {
@@ -104,13 +103,13 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
   }
 
   function parseCff(data, start, end, seacAnalysisEnabled) {
-    var properties = {};
-    var parser = new CFFParser(
+    const properties = {};
+    const parser = new CFFParser(
       new Stream(data, start, end - start),
       properties,
       seacAnalysisEnabled
     );
-    var cff = parser.parse();
+    const cff = parser.parse();
     return {
       glyphs: cff.charStrings.objects,
       subrs:
@@ -125,7 +124,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
   }
 
   function parseGlyfTable(glyf, loca, isGlyphLocationsLong) {
-    var itemSize, itemDecode;
+    let itemSize, itemDecode;
     if (isGlyphLocationsLong) {
       itemSize = 4;
       itemDecode = function fontItemDecodeLong(data, offset) {
@@ -142,10 +141,10 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
         return (data[offset] << 9) | (data[offset + 1] << 1);
       };
     }
-    var glyphs = [];
-    var startOffset = itemDecode(loca, 0);
-    for (var j = itemSize; j < loca.length; j += itemSize) {
-      var endOffset = itemDecode(loca, j);
+    const glyphs = [];
+    let startOffset = itemDecode(loca, 0);
+    for (let j = itemSize; j < loca.length; j += itemSize) {
+      const endOffset = itemDecode(loca, j);
       glyphs.push(glyf.subarray(startOffset, endOffset));
       startOffset = endOffset;
     }
@@ -153,12 +152,12 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
   }
 
   function lookupCmap(ranges, unicode) {
-    var code = unicode.codePointAt(0),
-      gid = 0;
-    var l = 0,
+    const code = unicode.codePointAt(0);
+    let gid = 0,
+      l = 0,
       r = ranges.length - 1;
     while (l < r) {
-      var c = (l + r + 1) >> 1;
+      const c = (l + r + 1) >> 1;
       if (code < ranges[c].start) {
         r = c - 1;
       } else {
@@ -188,19 +187,19 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
       cmds.push({ cmd: "quadraticCurveTo", args: [xa, ya, x, y] });
     }
 
-    var i = 0;
-    var numberOfContours = ((code[i] << 24) | (code[i + 1] << 16)) >> 16;
-    var flags;
-    var x = 0,
+    let i = 0;
+    const numberOfContours = ((code[i] << 24) | (code[i + 1] << 16)) >> 16;
+    let flags;
+    let x = 0,
       y = 0;
     i += 10;
     if (numberOfContours < 0) {
       // composite glyph
       do {
         flags = (code[i] << 8) | code[i + 1];
-        var glyphIndex = (code[i + 2] << 8) | code[i + 3];
+        const glyphIndex = (code[i + 2] << 8) | code[i + 3];
         i += 4;
-        var arg1, arg2;
+        let arg1, arg2;
         if (flags & 0x01) {
           arg1 = ((code[i] << 24) | (code[i + 1] << 16)) >> 16;
           arg2 = ((code[i + 2] << 24) | (code[i + 3] << 16)) >> 16;
@@ -216,7 +215,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
           x = 0;
           y = 0; // TODO "they are points" ?
         }
-        var scaleX = 1,
+        let scaleX = 1,
           scaleY = 1,
           scale01 = 0,
           scale10 = 0;
@@ -235,7 +234,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
           scaleY = ((code[i + 6] << 24) | (code[i + 7] << 16)) / 1073741824;
           i += 8;
         }
-        var subglyph = font.glyphs[glyphIndex];
+        const subglyph = font.glyphs[glyphIndex];
         if (subglyph) {
           cmds.push({ cmd: "save" });
           cmds.push({
@@ -248,19 +247,19 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
       } while (flags & 0x20);
     } else {
       // simple glyph
-      var endPtsOfContours = [];
-      var j, jj;
+      const endPtsOfContours = [];
+      let j, jj;
       for (j = 0; j < numberOfContours; j++) {
         endPtsOfContours.push((code[i] << 8) | code[i + 1]);
         i += 2;
       }
-      var instructionLength = (code[i] << 8) | code[i + 1];
+      const instructionLength = (code[i] << 8) | code[i + 1];
       i += 2 + instructionLength; // skipping the instructions
-      var numberOfPoints = endPtsOfContours[endPtsOfContours.length - 1] + 1;
-      var points = [];
+      const numberOfPoints = endPtsOfContours[endPtsOfContours.length - 1] + 1;
+      const points = [];
       while (points.length < numberOfPoints) {
         flags = code[i++];
-        var repeat = 1;
+        let repeat = 1;
         if (flags & 0x08) {
           repeat += code[i++];
         }
@@ -299,12 +298,12 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
         points[j].y = y;
       }
 
-      var startPoint = 0;
+      let startPoint = 0;
       for (i = 0; i < numberOfContours; i++) {
-        var endPoint = endPtsOfContours[i];
+        const endPoint = endPtsOfContours[i];
         // contours might have implicit points, which is located in the middle
         // between two neighboring off-curve points
-        var contour = points.slice(startPoint, endPoint + 1);
+        const contour = points.slice(startPoint, endPoint + 1);
         if (contour[0].flags & 1) {
           contour.push(contour[0]); // using start point at the contour end
         } else if (contour[contour.length - 1].flags & 1) {
@@ -312,7 +311,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
           contour.unshift(contour[contour.length - 1]);
         } else {
           // start and end are off-curve points, creating implicit one
-          var p = {
+          const p = {
             flags: 1,
             x: (contour[0].x + contour[contour.length - 1].x) / 2,
             y: (contour[0].y + contour[contour.length - 1].y) / 2,
@@ -357,17 +356,17 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
       cmds.push({ cmd: "bezierCurveTo", args: [x1, y1, x2, y2, x, y] });
     }
 
-    var stack = [];
-    var x = 0,
+    const stack = [];
+    let x = 0,
       y = 0;
-    var stems = 0;
+    let stems = 0;
 
     function parse(code) {
-      var i = 0;
+      let i = 0;
       while (i < code.length) {
-        var stackClean = false;
-        var v = code[i++];
-        var xa, xb, ya, yb, y1, y2, y3, n, subrCode;
+        let stackClean = false;
+        let v = code[i++];
+        let xa, xb, ya, yb, y1, y2, y3, n, subrCode;
         switch (v) {
           case 1: // hstem
             stems += stack.length >> 1;
@@ -495,7 +494,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
                 bezierCurveTo(xa, y2, xb, y3, x, y);
                 break;
               case 37: // flex1
-                var x0 = x,
+                const x0 = x,
                   y0 = y;
                 xa = x + stack.shift();
                 ya = y + stack.shift();
@@ -523,13 +522,13 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
             break;
           case 14: // endchar
             if (stack.length >= 4) {
-              var achar = stack.pop();
-              var bchar = stack.pop();
+              const achar = stack.pop();
+              const bchar = stack.pop();
               y = stack.pop();
               x = stack.pop();
               cmds.push({ cmd: "save" });
               cmds.push({ cmd: "translate", args: [x, y] });
-              var cmap = lookupCmap(
+              let cmap = lookupCmap(
                 font.cmap,
                 String.fromCharCode(font.glyphNameMap[StandardEncoding[achar]])
               );
@@ -830,13 +829,13 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
 
   return {
     create: function FontRendererFactory_create(font, seacAnalysisEnabled) {
-      var data = new Uint8Array(font.data);
-      var cmap, glyf, loca, cff, indexToLocFormat, unitsPerEm;
-      var numTables = getUshort(data, 4);
-      for (var i = 0, p = 12; i < numTables; i++, p += 16) {
-        var tag = bytesToString(data.subarray(p, p + 4));
-        var offset = getLong(data, p + 8);
-        var length = getLong(data, p + 12);
+      const data = new Uint8Array(font.data);
+      let cmap, glyf, loca, cff, indexToLocFormat, unitsPerEm;
+      const numTables = getUshort(data, 4);
+      for (let i = 0, p = 12; i < numTables; i++, p += 16) {
+        const tag = bytesToString(data.subarray(p, p + 4));
+        const offset = getLong(data, p + 8);
+        const length = getLong(data, p + 12);
         switch (tag) {
           case "cmap":
             cmap = parseCmap(data, offset, offset + length);
@@ -858,7 +857,7 @@ var FontRendererFactory = (function FontRendererFactoryClosure() {
       }
 
       if (glyf) {
-        var fontMatrix = !unitsPerEm
+        const fontMatrix = !unitsPerEm
           ? font.fontMatrix
           : [1 / unitsPerEm, 0, 0, 1 / unitsPerEm, 0, 0];
         return new TrueTypeCompiled(

--- a/src/core/type1_parser.js
+++ b/src/core/type1_parser.js
@@ -80,20 +80,16 @@ const Type1CharString = (function Type1CharStringClosure() {
   };
 
   // eslint-disable-next-line no-shadow
-  function Type1CharString() {
-    this.width = 0;
-    this.lsb = 0;
-    this.flexing = false;
-    this.output = [];
-    this.stack = [];
-  }
+  class Type1CharString {
+    constructor() {
+      this.width = 0;
+      this.lsb = 0;
+      this.flexing = false;
+      this.output = [];
+      this.stack = [];
+    }
 
-  Type1CharString.prototype = {
-    convert: function Type1CharString_convert(
-      encoded,
-      subrs,
-      seacAnalysisEnabled
-    ) {
+    convert(encoded, subrs, seacAnalysisEnabled) {
       const count = encoded.length;
       let error = false;
       let wx, sbx, subrNumber;
@@ -331,7 +327,7 @@ const Type1CharString = (function Type1CharStringClosure() {
         this.stack.push(value);
       }
       return error;
-    },
+    }
 
     executeCommand(howManyArgs, command, keepStack) {
       const stackLength = this.stack.length;
@@ -362,8 +358,8 @@ const Type1CharString = (function Type1CharStringClosure() {
         this.stack.length = 0;
       }
       return false;
-    },
-  };
+    }
+  }
 
   return Type1CharString;
 })();
@@ -455,33 +451,33 @@ const Type1Parser = (function Type1ParserClosure() {
   }
 
   // eslint-disable-next-line no-shadow
-  function Type1Parser(stream, encrypted, seacAnalysisEnabled) {
-    if (encrypted) {
-      const data = stream.getBytes();
-      const isBinary = !(
-        (isHexDigit(data[0]) || isWhiteSpace(data[0])) &&
-        isHexDigit(data[1]) &&
-        isHexDigit(data[2]) &&
-        isHexDigit(data[3]) &&
-        isHexDigit(data[4]) &&
-        isHexDigit(data[5]) &&
-        isHexDigit(data[6]) &&
-        isHexDigit(data[7])
-      );
-      stream = new Stream(
-        isBinary
-          ? decrypt(data, EEXEC_ENCRYPT_KEY, 4)
-          : decryptAscii(data, EEXEC_ENCRYPT_KEY, 4)
-      );
+  class Type1Parser {
+    constructor(stream, encrypted, seacAnalysisEnabled) {
+      if (encrypted) {
+        const data = stream.getBytes();
+        const isBinary = !(
+          (isHexDigit(data[0]) || isWhiteSpace(data[0])) &&
+          isHexDigit(data[1]) &&
+          isHexDigit(data[2]) &&
+          isHexDigit(data[3]) &&
+          isHexDigit(data[4]) &&
+          isHexDigit(data[5]) &&
+          isHexDigit(data[6]) &&
+          isHexDigit(data[7])
+        );
+        stream = new Stream(
+          isBinary
+            ? decrypt(data, EEXEC_ENCRYPT_KEY, 4)
+            : decryptAscii(data, EEXEC_ENCRYPT_KEY, 4)
+        );
+      }
+      this.seacAnalysisEnabled = !!seacAnalysisEnabled;
+
+      this.stream = stream;
+      this.nextChar();
     }
-    this.seacAnalysisEnabled = !!seacAnalysisEnabled;
 
-    this.stream = stream;
-    this.nextChar();
-  }
-
-  Type1Parser.prototype = {
-    readNumberArray: function Type1Parser_readNumberArray() {
+    readNumberArray() {
       this.getToken(); // read '[' or '{' (arrays can start with either)
       const array = [];
       while (true) {
@@ -492,32 +488,31 @@ const Type1Parser = (function Type1ParserClosure() {
         array.push(parseFloat(token || 0));
       }
       return array;
-    },
+    }
 
-    readNumber: function Type1Parser_readNumber() {
+    readNumber() {
       const token = this.getToken();
       return parseFloat(token || 0);
-    },
+    }
 
-    readInt: function Type1Parser_readInt() {
+    readInt() {
       // Use '| 0' to prevent setting a double into length such as the double
       // does not flow into the loop variable.
       const token = this.getToken();
       return parseInt(token || 0, 10) | 0;
-    },
+    }
 
-    readBoolean: function Type1Parser_readBoolean() {
+    readBoolean() {
       const token = this.getToken();
-
       // Use 1 and 0 since that's what type2 charstrings use.
       return token === "true" ? 1 : 0;
-    },
+    }
 
-    nextChar: function Type1_nextChar() {
+    nextChar() {
       return (this.currentChar = this.stream.getByte());
-    },
+    }
 
-    getToken: function Type1Parser_getToken() {
+    getToken() {
       // Eat whitespace and comments.
       let comment = false;
       let ch = this.currentChar;
@@ -547,22 +542,22 @@ const Type1Parser = (function Type1ParserClosure() {
         ch = this.nextChar();
       } while (ch >= 0 && !isWhiteSpace(ch) && !isSpecial(ch));
       return token;
-    },
+    }
 
-    readCharStrings: function Type1Parser_readCharStrings(bytes, lenIV) {
+    readCharStrings(bytes, lenIV) {
       if (lenIV === -1) {
         // This isn't in the spec, but Adobe's tx program handles -1
         // as plain text.
         return bytes;
       }
       return decrypt(bytes, CHAR_STRS_ENCRYPT_KEY, lenIV);
-    },
+    }
 
     /*
      * Returns an object containing a Subrs array and a CharStrings
      * array extracted from and eexec encrypted block of data
      */
-    extractFontProgram: function Type1Parser_extractFontProgram(properties) {
+    extractFontProgram(properties) {
       const stream = this.stream;
 
       const subrs = [],
@@ -717,9 +712,9 @@ const Type1Parser = (function Type1ParserClosure() {
       }
 
       return program;
-    },
+    }
 
-    extractFontHeader: function Type1Parser_extractFontHeader(properties) {
+    extractFontHeader(properties) {
       let token;
       while ((token = this.getToken()) !== null) {
         if (token !== "/") {
@@ -772,8 +767,8 @@ const Type1Parser = (function Type1ParserClosure() {
             break;
         }
       }
-    },
-  };
+    }
+  }
 
   return Type1Parser;
 })();

--- a/src/core/type1_parser.js
+++ b/src/core/type1_parser.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable no-var */
 
 import { getEncoding } from "./encodings.js";
 import { isWhiteSpace } from "./core_utils.js";
@@ -21,7 +20,7 @@ import { warn } from "../shared/util.js";
 
 // Hinting is currently disabled due to unknown problems on windows
 // in tracemonkey and various other pdfs with type1 fonts.
-var HINTING_ENABLED = false;
+const HINTING_ENABLED = false;
 
 /*
  * CharStrings are encoded following the the CharString Encoding sequence
@@ -61,8 +60,8 @@ var HINTING_ENABLED = false;
  * to be encoded and this encoding technique helps to minimize the length of
  * the charStrings.
  */
-var Type1CharString = (function Type1CharStringClosure() {
-  var COMMAND_MAP = {
+const Type1CharString = (function Type1CharStringClosure() {
+  const COMMAND_MAP = {
     hstem: [1],
     vstem: [3],
     vmoveto: [4],
@@ -95,11 +94,11 @@ var Type1CharString = (function Type1CharStringClosure() {
       subrs,
       seacAnalysisEnabled
     ) {
-      var count = encoded.length;
-      var error = false;
-      var wx, sbx, subrNumber;
-      for (var i = 0; i < count; i++) {
-        var value = encoded[i];
+      const count = encoded.length;
+      let error = false;
+      let wx, sbx, subrNumber;
+      for (let i = 0; i < count; i++) {
+        let value = encoded[i];
         if (value < 32) {
           if (value === 12) {
             value = (value << 8) + encoded[++i];
@@ -127,7 +126,7 @@ var Type1CharString = (function Type1CharStringClosure() {
                 }
                 // Add the dx for flex and but also swap the values so they are
                 // the right order.
-                var dy = this.stack.pop();
+                const dy = this.stack.pop();
                 this.stack.push(0, dy);
                 break;
               }
@@ -252,7 +251,7 @@ var Type1CharString = (function Type1CharStringClosure() {
               // vhea tables reconstruction -- ignoring it.
               this.stack.pop(); // wy
               wx = this.stack.pop();
-              var sby = this.stack.pop();
+              const sby = this.stack.pop();
               sbx = this.stack.pop();
               this.lsb = sbx;
               this.width = wx;
@@ -264,8 +263,8 @@ var Type1CharString = (function Type1CharStringClosure() {
                 error = true;
                 break;
               }
-              var num2 = this.stack.pop();
-              var num1 = this.stack.pop();
+              const num2 = this.stack.pop();
+              const num1 = this.stack.pop();
               this.stack.push(num1 / num2);
               break;
             case (12 << 8) + 16: // callothersubr
@@ -274,9 +273,9 @@ var Type1CharString = (function Type1CharStringClosure() {
                 break;
               }
               subrNumber = this.stack.pop();
-              var numArgs = this.stack.pop();
+              const numArgs = this.stack.pop();
               if (subrNumber === 0 && numArgs === 3) {
-                var flexArgs = this.stack.splice(this.stack.length - 17, 17);
+                const flexArgs = this.stack.splice(this.stack.length - 17, 17);
                 this.stack.push(
                   flexArgs[2] + flexArgs[0], // bcp1x + rpx
                   flexArgs[3] + flexArgs[1], // bcp1y + rpy
@@ -335,13 +334,13 @@ var Type1CharString = (function Type1CharStringClosure() {
     },
 
     executeCommand(howManyArgs, command, keepStack) {
-      var stackLength = this.stack.length;
+      const stackLength = this.stack.length;
       if (howManyArgs > stackLength) {
         return true;
       }
-      var start = stackLength - howManyArgs;
-      for (var i = start; i < stackLength; i++) {
-        var value = this.stack[i];
+      const start = stackLength - howManyArgs;
+      for (let i = start; i < stackLength; i++) {
+        let value = this.stack[i];
         if (Number.isInteger(value)) {
           this.output.push(28, (value >> 8) & 0xff, value & 0xff);
         } else {
@@ -377,14 +376,14 @@ var Type1CharString = (function Type1CharStringClosure() {
  * of PostScript, but it is possible in most cases to extract what we need
  * without a full parse.
  */
-var Type1Parser = (function Type1ParserClosure() {
+const Type1Parser = (function Type1ParserClosure() {
   /*
    * Decrypt a Sequence of Ciphertext Bytes to Produce the Original Sequence
    * of Plaintext Bytes. The function took a key as a parameter which can be
    * for decrypting the eexec block of for decoding charStrings.
    */
-  var EEXEC_ENCRYPT_KEY = 55665;
-  var CHAR_STRS_ENCRYPT_KEY = 4330;
+  const EEXEC_ENCRYPT_KEY = 55665;
+  const CHAR_STRS_ENCRYPT_KEY = 4330;
 
   function isHexDigit(code) {
     return (
@@ -398,18 +397,18 @@ var Type1Parser = (function Type1ParserClosure() {
     if (discardNumber >= data.length) {
       return new Uint8Array(0);
     }
-    var r = key | 0,
-      c1 = 52845,
-      c2 = 22719,
+    const c1 = 52845,
+      c2 = 22719;
+    let r = key | 0,
       i,
       j;
     for (i = 0; i < discardNumber; i++) {
       r = ((data[i] + r) * c1 + c2) & ((1 << 16) - 1);
     }
-    var count = data.length - discardNumber;
-    var decrypted = new Uint8Array(count);
+    const count = data.length - discardNumber;
+    const decrypted = new Uint8Array(count);
     for (i = discardNumber, j = 0; j < count; i++, j++) {
-      var value = data[i];
+      const value = data[i];
       decrypted[j] = value ^ (r >> 8);
       r = ((value + r) * c1 + c2) & ((1 << 16) - 1);
     }
@@ -417,25 +416,25 @@ var Type1Parser = (function Type1ParserClosure() {
   }
 
   function decryptAscii(data, key, discardNumber) {
-    var r = key | 0,
-      c1 = 52845,
+    const c1 = 52845,
       c2 = 22719;
-    var count = data.length,
+    let r = key | 0;
+    const count = data.length,
       maybeLength = count >>> 1;
-    var decrypted = new Uint8Array(maybeLength);
-    var i, j;
+    const decrypted = new Uint8Array(maybeLength);
+    let i, j;
     for (i = 0, j = 0; i < count; i++) {
-      var digit1 = data[i];
+      const digit1 = data[i];
       if (!isHexDigit(digit1)) {
         continue;
       }
       i++;
-      var digit2;
+      let digit2;
       while (i < count && !isHexDigit((digit2 = data[i]))) {
         i++;
       }
       if (i < count) {
-        var value = parseInt(String.fromCharCode(digit1, digit2), 16);
+        const value = parseInt(String.fromCharCode(digit1, digit2), 16);
         decrypted[j++] = value ^ (r >> 8);
         r = ((value + r) * c1 + c2) & ((1 << 16) - 1);
       }
@@ -458,8 +457,8 @@ var Type1Parser = (function Type1ParserClosure() {
   // eslint-disable-next-line no-shadow
   function Type1Parser(stream, encrypted, seacAnalysisEnabled) {
     if (encrypted) {
-      var data = stream.getBytes();
-      var isBinary = !(
+      const data = stream.getBytes();
+      const isBinary = !(
         (isHexDigit(data[0]) || isWhiteSpace(data[0])) &&
         isHexDigit(data[1]) &&
         isHexDigit(data[2]) &&
@@ -484,9 +483,9 @@ var Type1Parser = (function Type1ParserClosure() {
   Type1Parser.prototype = {
     readNumberArray: function Type1Parser_readNumberArray() {
       this.getToken(); // read '[' or '{' (arrays can start with either)
-      var array = [];
+      const array = [];
       while (true) {
-        var token = this.getToken();
+        const token = this.getToken();
         if (token === null || token === "]" || token === "}") {
           break;
         }
@@ -496,19 +495,19 @@ var Type1Parser = (function Type1ParserClosure() {
     },
 
     readNumber: function Type1Parser_readNumber() {
-      var token = this.getToken();
+      const token = this.getToken();
       return parseFloat(token || 0);
     },
 
     readInt: function Type1Parser_readInt() {
       // Use '| 0' to prevent setting a double into length such as the double
       // does not flow into the loop variable.
-      var token = this.getToken();
+      const token = this.getToken();
       return parseInt(token || 0, 10) | 0;
     },
 
     readBoolean: function Type1Parser_readBoolean() {
-      var token = this.getToken();
+      const token = this.getToken();
 
       // Use 1 and 0 since that's what type2 charstrings use.
       return token === "true" ? 1 : 0;
@@ -520,8 +519,8 @@ var Type1Parser = (function Type1ParserClosure() {
 
     getToken: function Type1Parser_getToken() {
       // Eat whitespace and comments.
-      var comment = false;
-      var ch = this.currentChar;
+      let comment = false;
+      let ch = this.currentChar;
       while (true) {
         if (ch === -1) {
           return null;
@@ -542,7 +541,7 @@ var Type1Parser = (function Type1ParserClosure() {
         this.nextChar();
         return String.fromCharCode(ch);
       }
-      var token = "";
+      let token = "";
       do {
         token += String.fromCharCode(ch);
         ch = this.nextChar();
@@ -564,20 +563,20 @@ var Type1Parser = (function Type1ParserClosure() {
      * array extracted from and eexec encrypted block of data
      */
     extractFontProgram: function Type1Parser_extractFontProgram(properties) {
-      var stream = this.stream;
+      const stream = this.stream;
 
-      var subrs = [],
+      const subrs = [],
         charstrings = [];
-      var privateData = Object.create(null);
+      const privateData = Object.create(null);
       privateData.lenIV = 4;
-      var program = {
+      const program = {
         subrs: [],
         charstrings: [],
         properties: {
           privateData,
         },
       };
-      var token, length, data, lenIV, encoded;
+      let token, length, data, lenIV, encoded;
       while ((token = this.getToken()) !== null) {
         if (token !== "/") {
           continue;
@@ -600,7 +599,7 @@ var Type1Parser = (function Type1ParserClosure() {
               if (token !== "/") {
                 continue;
               }
-              var glyph = this.getToken();
+              const glyph = this.getToken();
               length = this.readInt();
               this.getToken(); // read in 'RD' or '-|'
               data = length > 0 ? stream.getBytes(length) : new Uint8Array(0);
@@ -639,7 +638,7 @@ var Type1Parser = (function Type1ParserClosure() {
           case "OtherBlues":
           case "FamilyBlues":
           case "FamilyOtherBlues":
-            var blueArray = this.readNumberArray();
+            const blueArray = this.readNumberArray();
             // *Blue* values may contain invalid data: disables reading of
             // those values when hinting is disabled.
             if (
@@ -672,16 +671,16 @@ var Type1Parser = (function Type1ParserClosure() {
         }
       }
 
-      for (var i = 0; i < charstrings.length; i++) {
-        glyph = charstrings[i].glyph;
+      for (let i = 0; i < charstrings.length; i++) {
+        const glyph = charstrings[i].glyph;
         encoded = charstrings[i].encoded;
-        var charString = new Type1CharString();
-        var error = charString.convert(
+        const charString = new Type1CharString();
+        const error = charString.convert(
           encoded,
           subrs,
           this.seacAnalysisEnabled
         );
-        var output = charString.output;
+        let output = charString.output;
         if (error) {
           // It seems when FreeType encounters an error while evaluating a glyph
           // that it completely ignores the glyph so we'll mimic that behaviour
@@ -721,7 +720,7 @@ var Type1Parser = (function Type1ParserClosure() {
     },
 
     extractFontHeader: function Type1Parser_extractFontHeader(properties) {
-      var token;
+      let token;
       while ((token = this.getToken()) !== null) {
         if (token !== "/") {
           continue;
@@ -729,21 +728,21 @@ var Type1Parser = (function Type1ParserClosure() {
         token = this.getToken();
         switch (token) {
           case "FontMatrix":
-            var matrix = this.readNumberArray();
+            const matrix = this.readNumberArray();
             properties.fontMatrix = matrix;
             break;
           case "Encoding":
-            var encodingArg = this.getToken();
-            var encoding;
+            const encodingArg = this.getToken();
+            let encoding;
             if (!/^\d+$/.test(encodingArg)) {
               // encoding name is specified
               encoding = getEncoding(encodingArg);
             } else {
               encoding = [];
-              var size = parseInt(encodingArg, 10) | 0;
+              const size = parseInt(encodingArg, 10) | 0;
               this.getToken(); // read in 'array'
 
-              for (var j = 0; j < size; j++) {
+              for (let j = 0; j < size; j++) {
                 token = this.getToken();
                 // skipping till first dup or def (e.g. ignoring for statement)
                 while (token !== "dup" && token !== "def") {
@@ -755,9 +754,9 @@ var Type1Parser = (function Type1ParserClosure() {
                 if (token === "def") {
                   break; // read all array data
                 }
-                var index = this.readInt();
+                const index = this.readInt();
                 this.getToken(); // read in '/'
-                var glyph = this.getToken();
+                const glyph = this.getToken();
                 encoding[index] = glyph;
                 this.getToken(); // read the in 'put'
               }
@@ -765,7 +764,7 @@ var Type1Parser = (function Type1ParserClosure() {
             properties.builtInEncoding = encoding;
             break;
           case "FontBBox":
-            var fontBBox = this.readNumberArray();
+            const fontBBox = this.readNumberArray();
             // adjusting ascent/descent
             properties.ascent = Math.max(fontBBox[3], fontBBox[1]);
             properties.descent = Math.min(fontBBox[1], fontBBox[3]);


### PR DESCRIPTION
*Please refer to the individual commit messages for additional details.*