### PR TITLE
print: Remove invalid @supports condition.

### DIFF
--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -120,15 +120,7 @@ PDFPrintService.prototype = {
     this.pageStyleSheet = document.createElement("style");
     const pageSize = this.pagesOverview[0];
     this.pageStyleSheet.textContent =
-      // "size:<width> <height>" is what we need. But also add "A4" because
-      // Firefox incorrectly reports support for the other value.
-      "@supports ((size:A4) and (size:1pt 1pt)) {" +
-      "@page { size: " +
-      pageSize.width +
-      "pt " +
-      pageSize.height +
-      "pt;}" +
-      "}";
+      "@page { size: " + pageSize.width + "pt " + pageSize.height + "pt;}";
     body.appendChild(this.pageStyleSheet);
   },
 


### PR DESCRIPTION
@supports() is not supposed to report support for page descriptors, this is
depending on a Chromium bug, which doesn't treat as invalid:

```
<div style="size: 1pt 1pt">
```

Even though it should. That is
https://bugs.chromium.org/p/chromium/issues/detail?id=1079214

There's no need to use @supports for this. If the descriptor is not accepted it
will just be ignored.

That way, when Firefox implements @page { size }, which is in progress, it will
get the right behavior.