### PR TITLE
print: RFC: Center when printing a PDF with smaller size than the output page.

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1763,6 +1763,15 @@ html[dir="rtl"] #documentPropertiesOverlay .row > * {
     max-height: 100%;
     page-break-after: always;
     page-break-inside: avoid;
+
+    /* If we're smaller than the page, center the canvas horizontally and
+     * vertically */
+    min-height: 100%;
+    min-width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
   }
   #printContainer canvas,
   #printContainer img {


### PR DESCRIPTION
This builds on top of #13100, but this changes printing behavior intentionally
so I thought it was worth discussing separately, to improve the rendering on
test-cases like the one in https://bugzil.la/1697778.

This matches what e.g.  Evince does when you print the PDF in there on an A4
printer.

We use margins to center horizontally, and flex to center vertically. The
reasoning for this is that it should have better browser support (though maybe
pdf.js no longer supports browsers without flex support?) and it's just as
simple.