### PR TITLE
Ensure that printing, triggered from scripting, won't accidentally throw in `PDFScriptingManager._updateFromSandbox`

### DIFF
--- a/web/pdf_scripting_manager.js
+++ b/web/pdf_scripting_manager.js
@@ -260,7 +260,7 @@ class PDFScriptingManager {
   /**
    * @private
    */
-  _updateFromSandbox(detail) {
+  async _updateFromSandbox(detail) {
     const { id, command, value } = detail;
     if (!id) {
       switch (command) {
@@ -277,9 +277,8 @@ class PDFScriptingManager {
           this._pdfViewer.currentPageNumber = value + 1;
           break;
         case "print":
-          this._pdfViewer.pagesPromise.then(() => {
-            this._eventBus.dispatch("print", { source: this });
-          });
+          await this._pdfViewer.pagesPromise;
+          this._eventBus.dispatch("print", { source: this });
           break;
         case "println":
           console.log(value);


### PR DESCRIPTION
The issue that this patch fixes is extremely unlikely, but still theoretically possible, and I really should've caught this earlier.
Note how `BaseViewer.pagesPromise` will only be defined when a document is active, see below, and that if a printing event (triggered from scripting) arrives while the document is been closed there's a small chance that the promise isn't defined.

https://github.com/mozilla/pdf.js/blob/eb92ed12f202de4cc8b0060aac1f1a06b26f83a4/web/base_viewer.js#L426-L428