### PR TITLE
Improve memory usage around the `BasePdfManager.docBaseUrl` parameter (PR 7689 follow-up)

### DIFF
--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -13,16 +13,22 @@
  * limitations under the License.
  */
 
-import {
-  createValidAbsoluteUrl,
-  shadow,
-  unreachable,
-  warn,
-} from "../shared/util.js";
+import { createValidAbsoluteUrl, unreachable, warn } from "../shared/util.js";
 import { ChunkedStreamManager } from "./chunked_stream.js";
 import { MissingDataException } from "./core_utils.js";
 import { PDFDocument } from "./document.js";
 import { Stream } from "./stream.js";
+
+function parseDocBaseUrl(url) {
+  if (url) {
+    const absoluteUrl = createValidAbsoluteUrl(url);
+    if (absoluteUrl) {
+      return absoluteUrl.href;
+    }
+    warn(`Invalid absolute docBaseUrl: "${url}".`);
+  }
+  return null;
+}
 
 class BasePdfManager {
   constructor() {
@@ -40,16 +46,7 @@ class BasePdfManager {
   }
 
   get docBaseUrl() {
-    let docBaseUrl = null;
-    if (this._docBaseUrl) {
-      const absoluteUrl = createValidAbsoluteUrl(this._docBaseUrl);
-      if (absoluteUrl) {
-        docBaseUrl = absoluteUrl.href;
-      } else {
-        warn(`Invalid absolute docBaseUrl: "${this._docBaseUrl}".`);
-      }
-    }
-    return shadow(this, "docBaseUrl", docBaseUrl);
+    return this._docBaseUrl;
   }
 
   onLoadedStream() {
@@ -111,7 +108,7 @@ class LocalPdfManager extends BasePdfManager {
 
     this._docId = docId;
     this._password = password;
-    this._docBaseUrl = docBaseUrl;
+    this._docBaseUrl = parseDocBaseUrl(docBaseUrl);
     this.evaluatorOptions = evaluatorOptions;
 
     const stream = new Stream(data);
@@ -146,7 +143,7 @@ class NetworkPdfManager extends BasePdfManager {
 
     this._docId = docId;
     this._password = args.password;
-    this._docBaseUrl = docBaseUrl;
+    this._docBaseUrl = parseDocBaseUrl(docBaseUrl);
     this.msgHandler = args.msgHandler;
     this.evaluatorOptions = evaluatorOptions;
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -40,6 +40,7 @@ import {
   deprecated,
   DOMCanvasFactory,
   DOMCMapReaderFactory,
+  isDataScheme,
   loadScript,
   PageViewport,
   RenderingCancelledException,
@@ -285,6 +286,15 @@ function getDocument(src) {
   params.fontExtraProperties = params.fontExtraProperties === true;
   params.pdfBug = params.pdfBug === true;
 
+  if (
+    typeof params.docBaseUrl !== "string" ||
+    isDataScheme(params.docBaseUrl)
+  ) {
+    // Ignore "data:"-URLs, since they can't be used to recover valid absolute
+    // URLs anyway. We want to avoid sending them to the worker-thread, since
+    // they contain the *entire* PDF document and can thus be arbitrarily long.
+    params.docBaseUrl = null;
+  }
   if (!Number.isInteger(params.maxImageSize)) {
     params.maxImageSize = -1;
   }

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -708,6 +708,7 @@ export {
   DOMSVGFactory,
   getFilenameFromUrl,
   getPdfFilenameFromUrl,
+  isDataScheme,
   isFetchSupported,
   isPdfFile,
   isValidFetchUrl,

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -451,13 +451,23 @@ function addLinkAttributes(link, { url, target, rel, enabled = true } = {}) {
   link.rel = typeof rel === "string" ? rel : DEFAULT_LINK_REL;
 }
 
+function isDataScheme(url) {
+  const ii = url.length;
+  let i = 0;
+  while (i < ii && url[i].trim() === "") {
+    i++;
+  }
+  return url.substring(i, i + 5).toLowerCase() === "data:";
+}
+
 function isPdfFile(filename) {
   return typeof filename === "string" && /\.pdf$/i.test(filename);
 }
 
 /**
- * Gets the file name from a given URL.
+ * Gets the filename from a given URL.
  * @param {string} url
+ * @returns {string}
  */
 function getFilenameFromUrl(url) {
   const anchor = url.indexOf("#");
@@ -467,6 +477,48 @@ function getFilenameFromUrl(url) {
     query > 0 ? query : url.length
   );
   return url.substring(url.lastIndexOf("/", end) + 1, end);
+}
+
+/**
+ * Returns the filename or guessed filename from the url (see issue 3455).
+ * @param {string} url - The original PDF location.
+ * @param {string} defaultFilename - The value returned if the filename is
+ *   unknown, or the protocol is unsupported.
+ * @returns {string} Guessed PDF filename.
+ */
+function getPdfFilenameFromUrl(url, defaultFilename = "document.pdf") {
+  if (typeof url !== "string") {
+    return defaultFilename;
+  }
+  if (isDataScheme(url)) {
+    warn('getPdfFilenameFromUrl: ignore "data:"-URL for performance reasons.');
+    return defaultFilename;
+  }
+  const reURI = /^(?:(?:[^:]+:)?\/\/[^/]+)?([^?#]*)(\?[^#]*)?(#.*)?$/;
+  //              SCHEME        HOST        1.PATH  2.QUERY   3.REF
+  // Pattern to get last matching NAME.pdf
+  const reFilename = /[^/?#=]+\.pdf\b(?!.*\.pdf\b)/i;
+  const splitURI = reURI.exec(url);
+  let suggestedFilename =
+    reFilename.exec(splitURI[1]) ||
+    reFilename.exec(splitURI[2]) ||
+    reFilename.exec(splitURI[3]);
+  if (suggestedFilename) {
+    suggestedFilename = suggestedFilename[0];
+    if (suggestedFilename.includes("%")) {
+      // URL-encoded %2Fpath%2Fto%2Ffile.pdf should be file.pdf
+      try {
+        suggestedFilename = reFilename.exec(
+          decodeURIComponent(suggestedFilename)
+        )[0];
+      } catch (ex) {
+        // Possible (extremely rare) errors:
+        // URIError "Malformed URI", e.g. for "%AA.pdf"
+        // TypeError "null has no properties", e.g. for "%2F.pdf"
+      }
+    }
+  }
+  return suggestedFilename || defaultFilename;
 }
 
 class StatTimer {
@@ -655,6 +707,7 @@ export {
   DOMCMapReaderFactory,
   DOMSVGFactory,
   getFilenameFromUrl,
+  getPdfFilenameFromUrl,
   isFetchSupported,
   isPdfFile,
   isValidFetchUrl,

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -17,6 +17,7 @@
 import {
   addLinkAttributes,
   getFilenameFromUrl,
+  getPdfFilenameFromUrl,
   isFetchSupported,
   isPdfFile,
   isValidFetchUrl,
@@ -129,6 +130,7 @@ export {
   // From "./display/display_utils.js":
   addLinkAttributes,
   getFilenameFromUrl,
+  getPdfFilenameFromUrl,
   isPdfFile,
   LinkTarget,
   loadScript,

--- a/test/unit/display_utils_spec.js
+++ b/test/unit/display_utils_spec.js
@@ -17,9 +17,11 @@ import {
   DOMCanvasFactory,
   DOMSVGFactory,
   getFilenameFromUrl,
+  getPdfFilenameFromUrl,
   isValidFetchUrl,
   PDFDateString,
 } from "../../src/display/display_utils.js";
+import { createObjectURL } from "../../src/shared/util.js";
 import { isNodeJS } from "../../src/shared/is_node.js";
 
 describe("display_utils", function () {
@@ -189,6 +191,162 @@ describe("display_utils", function () {
     it("should get the filename from a URL with query parameters", function () {
       const url = "https://server.org/filename.pdf?foo=bar";
       expect(getFilenameFromUrl(url)).toEqual("filename.pdf");
+    });
+  });
+
+  describe("getPdfFilenameFromUrl", function () {
+    it("gets PDF filename", function () {
+      // Relative URL
+      expect(getPdfFilenameFromUrl("/pdfs/file1.pdf")).toEqual("file1.pdf");
+      // Absolute URL
+      expect(
+        getPdfFilenameFromUrl("http://www.example.com/pdfs/file2.pdf")
+      ).toEqual("file2.pdf");
+    });
+
+    it("gets fallback filename", function () {
+      // Relative URL
+      expect(getPdfFilenameFromUrl("/pdfs/file1.txt")).toEqual("document.pdf");
+      // Absolute URL
+      expect(
+        getPdfFilenameFromUrl("http://www.example.com/pdfs/file2.txt")
+      ).toEqual("document.pdf");
+    });
+
+    it("gets custom fallback filename", function () {
+      // Relative URL
+      expect(getPdfFilenameFromUrl("/pdfs/file1.txt", "qwerty1.pdf")).toEqual(
+        "qwerty1.pdf"
+      );
+      // Absolute URL
+      expect(
+        getPdfFilenameFromUrl(
+          "http://www.example.com/pdfs/file2.txt",
+          "qwerty2.pdf"
+        )
+      ).toEqual("qwerty2.pdf");
+
+      // An empty string should be a valid custom fallback filename.
+      expect(getPdfFilenameFromUrl("/pdfs/file3.txt", "")).toEqual("");
+    });
+
+    it("gets fallback filename when url is not a string", function () {
+      expect(getPdfFilenameFromUrl(null)).toEqual("document.pdf");
+
+      expect(getPdfFilenameFromUrl(null, "file.pdf")).toEqual("file.pdf");
+    });
+
+    it("gets PDF filename from URL containing leading/trailing whitespace", function () {
+      // Relative URL
+      expect(getPdfFilenameFromUrl("   /pdfs/file1.pdf   ")).toEqual(
+        "file1.pdf"
+      );
+      // Absolute URL
+      expect(
+        getPdfFilenameFromUrl("   http://www.example.com/pdfs/file2.pdf   ")
+      ).toEqual("file2.pdf");
+    });
+
+    it("gets PDF filename from query string", function () {
+      // Relative URL
+      expect(getPdfFilenameFromUrl("/pdfs/pdfs.html?name=file1.pdf")).toEqual(
+        "file1.pdf"
+      );
+      // Absolute URL
+      expect(
+        getPdfFilenameFromUrl("http://www.example.com/pdfs/pdf.html?file2.pdf")
+      ).toEqual("file2.pdf");
+    });
+
+    it("gets PDF filename from hash string", function () {
+      // Relative URL
+      expect(getPdfFilenameFromUrl("/pdfs/pdfs.html#name=file1.pdf")).toEqual(
+        "file1.pdf"
+      );
+      // Absolute URL
+      expect(
+        getPdfFilenameFromUrl("http://www.example.com/pdfs/pdf.html#file2.pdf")
+      ).toEqual("file2.pdf");
+    });
+
+    it("gets correct PDF filename when multiple ones are present", function () {
+      // Relative URL
+      expect(getPdfFilenameFromUrl("/pdfs/file1.pdf?name=file.pdf")).toEqual(
+        "file1.pdf"
+      );
+      // Absolute URL
+      expect(
+        getPdfFilenameFromUrl("http://www.example.com/pdfs/file2.pdf#file.pdf")
+      ).toEqual("file2.pdf");
+    });
+
+    it("gets PDF filename from URI-encoded data", function () {
+      const encodedUrl = encodeURIComponent(
+        "http://www.example.com/pdfs/file1.pdf"
+      );
+      expect(getPdfFilenameFromUrl(encodedUrl)).toEqual("file1.pdf");
+
+      const encodedUrlWithQuery = encodeURIComponent(
+        "http://www.example.com/pdfs/file.txt?file2.pdf"
+      );
+      expect(getPdfFilenameFromUrl(encodedUrlWithQuery)).toEqual("file2.pdf");
+    });
+
+    it("gets PDF filename from data mistaken for URI-encoded", function () {
+      expect(getPdfFilenameFromUrl("/pdfs/%AA.pdf")).toEqual("%AA.pdf");
+
+      expect(getPdfFilenameFromUrl("/pdfs/%2F.pdf")).toEqual("%2F.pdf");
+    });
+
+    it("gets PDF filename from (some) standard protocols", function () {
+      // HTTP
+      expect(getPdfFilenameFromUrl("http://www.example.com/file1.pdf")).toEqual(
+        "file1.pdf"
+      );
+      // HTTPS
+      expect(
+        getPdfFilenameFromUrl("https://www.example.com/file2.pdf")
+      ).toEqual("file2.pdf");
+      // File
+      expect(getPdfFilenameFromUrl("file:///path/to/files/file3.pdf")).toEqual(
+        "file3.pdf"
+      );
+      // FTP
+      expect(getPdfFilenameFromUrl("ftp://www.example.com/file4.pdf")).toEqual(
+        "file4.pdf"
+      );
+    });
+
+    it('gets PDF filename from query string appended to "blob:" URL', function () {
+      if (isNodeJS) {
+        pending("Blob in not supported in Node.js.");
+      }
+      const typedArray = new Uint8Array([1, 2, 3, 4, 5]);
+      const blobUrl = createObjectURL(typedArray, "application/pdf");
+      // Sanity check to ensure that a "blob:" URL was returned.
+      expect(blobUrl.startsWith("blob:")).toEqual(true);
+
+      expect(getPdfFilenameFromUrl(blobUrl + "?file.pdf")).toEqual("file.pdf");
+    });
+
+    it('gets fallback filename from query string appended to "data:" URL', function () {
+      const typedArray = new Uint8Array([1, 2, 3, 4, 5]);
+      const dataUrl = createObjectURL(
+        typedArray,
+        "application/pdf",
+        /* forceDataSchema = */ true
+      );
+      // Sanity check to ensure that a "data:" URL was returned.
+      expect(dataUrl.startsWith("data:")).toEqual(true);
+
+      expect(getPdfFilenameFromUrl(dataUrl + "?file1.pdf")).toEqual(
+        "document.pdf"
+      );
+
+      // Should correctly detect a "data:" URL with leading whitespace.
+      expect(getPdfFilenameFromUrl("     " + dataUrl + "?file2.pdf")).toEqual(
+        "document.pdf"
+      );
     });
   });
 

--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -18,7 +18,6 @@ import {
   binarySearchFirstItem,
   EventBus,
   getPageSizeInches,
-  getPDFFileNameFromURL,
   getVisibleElements,
   isPortraitOrientation,
   isValidRotation,
@@ -26,7 +25,6 @@ import {
   waitOnEventOrTimeout,
   WaitOnType,
 } from "../../web/ui_utils.js";
-import { createObjectURL } from "../../src/shared/util.js";
 import { isNodeJS } from "../../src/shared/is_node.js";
 
 describe("ui_utils", function () {
@@ -55,162 +53,6 @@ describe("ui_utils", function () {
       expect(binarySearchFirstItem([0, 1, 2], isGreater3)).toEqual(3);
       expect(binarySearchFirstItem([2, 3, 4], isGreater3)).toEqual(2);
       expect(binarySearchFirstItem([4, 5, 6], isGreater3)).toEqual(0);
-    });
-  });
-
-  describe("getPDFFileNameFromURL", function () {
-    it("gets PDF filename", function () {
-      // Relative URL
-      expect(getPDFFileNameFromURL("/pdfs/file1.pdf")).toEqual("file1.pdf");
-      // Absolute URL
-      expect(
-        getPDFFileNameFromURL("http://www.example.com/pdfs/file2.pdf")
-      ).toEqual("file2.pdf");
-    });
-
-    it("gets fallback filename", function () {
-      // Relative URL
-      expect(getPDFFileNameFromURL("/pdfs/file1.txt")).toEqual("document.pdf");
-      // Absolute URL
-      expect(
-        getPDFFileNameFromURL("http://www.example.com/pdfs/file2.txt")
-      ).toEqual("document.pdf");
-    });
-
-    it("gets custom fallback filename", function () {
-      // Relative URL
-      expect(getPDFFileNameFromURL("/pdfs/file1.txt", "qwerty1.pdf")).toEqual(
-        "qwerty1.pdf"
-      );
-      // Absolute URL
-      expect(
-        getPDFFileNameFromURL(
-          "http://www.example.com/pdfs/file2.txt",
-          "qwerty2.pdf"
-        )
-      ).toEqual("qwerty2.pdf");
-
-      // An empty string should be a valid custom fallback filename.
-      expect(getPDFFileNameFromURL("/pdfs/file3.txt", "")).toEqual("");
-    });
-
-    it("gets fallback filename when url is not a string", function () {
-      expect(getPDFFileNameFromURL(null)).toEqual("document.pdf");
-
-      expect(getPDFFileNameFromURL(null, "file.pdf")).toEqual("file.pdf");
-    });
-
-    it("gets PDF filename from URL containing leading/trailing whitespace", function () {
-      // Relative URL
-      expect(getPDFFileNameFromURL("   /pdfs/file1.pdf   ")).toEqual(
-        "file1.pdf"
-      );
-      // Absolute URL
-      expect(
-        getPDFFileNameFromURL("   http://www.example.com/pdfs/file2.pdf   ")
-      ).toEqual("file2.pdf");
-    });
-
-    it("gets PDF filename from query string", function () {
-      // Relative URL
-      expect(getPDFFileNameFromURL("/pdfs/pdfs.html?name=file1.pdf")).toEqual(
-        "file1.pdf"
-      );
-      // Absolute URL
-      expect(
-        getPDFFileNameFromURL("http://www.example.com/pdfs/pdf.html?file2.pdf")
-      ).toEqual("file2.pdf");
-    });
-
-    it("gets PDF filename from hash string", function () {
-      // Relative URL
-      expect(getPDFFileNameFromURL("/pdfs/pdfs.html#name=file1.pdf")).toEqual(
-        "file1.pdf"
-      );
-      // Absolute URL
-      expect(
-        getPDFFileNameFromURL("http://www.example.com/pdfs/pdf.html#file2.pdf")
-      ).toEqual("file2.pdf");
-    });
-
-    it("gets correct PDF filename when multiple ones are present", function () {
-      // Relative URL
-      expect(getPDFFileNameFromURL("/pdfs/file1.pdf?name=file.pdf")).toEqual(
-        "file1.pdf"
-      );
-      // Absolute URL
-      expect(
-        getPDFFileNameFromURL("http://www.example.com/pdfs/file2.pdf#file.pdf")
-      ).toEqual("file2.pdf");
-    });
-
-    it("gets PDF filename from URI-encoded data", function () {
-      const encodedUrl = encodeURIComponent(
-        "http://www.example.com/pdfs/file1.pdf"
-      );
-      expect(getPDFFileNameFromURL(encodedUrl)).toEqual("file1.pdf");
-
-      const encodedUrlWithQuery = encodeURIComponent(
-        "http://www.example.com/pdfs/file.txt?file2.pdf"
-      );
-      expect(getPDFFileNameFromURL(encodedUrlWithQuery)).toEqual("file2.pdf");
-    });
-
-    it("gets PDF filename from data mistaken for URI-encoded", function () {
-      expect(getPDFFileNameFromURL("/pdfs/%AA.pdf")).toEqual("%AA.pdf");
-
-      expect(getPDFFileNameFromURL("/pdfs/%2F.pdf")).toEqual("%2F.pdf");
-    });
-
-    it("gets PDF filename from (some) standard protocols", function () {
-      // HTTP
-      expect(getPDFFileNameFromURL("http://www.example.com/file1.pdf")).toEqual(
-        "file1.pdf"
-      );
-      // HTTPS
-      expect(
-        getPDFFileNameFromURL("https://www.example.com/file2.pdf")
-      ).toEqual("file2.pdf");
-      // File
-      expect(getPDFFileNameFromURL("file:///path/to/files/file3.pdf")).toEqual(
-        "file3.pdf"
-      );
-      // FTP
-      expect(getPDFFileNameFromURL("ftp://www.example.com/file4.pdf")).toEqual(
-        "file4.pdf"
-      );
-    });
-
-    it('gets PDF filename from query string appended to "blob:" URL', function () {
-      if (isNodeJS) {
-        pending("Blob in not supported in Node.js.");
-      }
-      const typedArray = new Uint8Array([1, 2, 3, 4, 5]);
-      const blobUrl = createObjectURL(typedArray, "application/pdf");
-      // Sanity check to ensure that a "blob:" URL was returned.
-      expect(blobUrl.startsWith("blob:")).toEqual(true);
-
-      expect(getPDFFileNameFromURL(blobUrl + "?file.pdf")).toEqual("file.pdf");
-    });
-
-    it('gets fallback filename from query string appended to "data:" URL', function () {
-      const typedArray = new Uint8Array([1, 2, 3, 4, 5]);
-      const dataUrl = createObjectURL(
-        typedArray,
-        "application/pdf",
-        /* forceDataSchema = */ true
-      );
-      // Sanity check to ensure that a "data:" URL was returned.
-      expect(dataUrl.startsWith("data:")).toEqual(true);
-
-      expect(getPDFFileNameFromURL(dataUrl + "?file1.pdf")).toEqual(
-        "document.pdf"
-      );
-
-      // Should correctly detect a "data:" URL with leading whitespace.
-      expect(getPDFFileNameFromURL("     " + dataUrl + "?file2.pdf")).toEqual(
-        "document.pdf"
-      );
     });
   });
 

--- a/web/app.js
+++ b/web/app.js
@@ -22,7 +22,6 @@ import {
   DEFAULT_SCALE_VALUE,
   EventBus,
   getActiveOrFocusedElement,
-  getPDFFileNameFromURL,
   isValidRotation,
   isValidScrollMode,
   isValidSpreadMode,
@@ -44,6 +43,7 @@ import {
   createPromiseCapability,
   getDocument,
   getFilenameFromUrl,
+  getPdfFilenameFromUrl,
   GlobalWorkerOptions,
   InvalidPDFException,
   isPdfFile,
@@ -748,7 +748,7 @@ const PDFViewerApplication = {
   setTitleUsingUrl(url = "") {
     this.url = url;
     this.baseUrl = url.split("#")[0];
-    let title = getPDFFileNameFromURL(url, "");
+    let title = getPdfFilenameFromUrl(url, "");
     if (!title) {
       try {
         title = decodeURIComponent(getFilenameFromUrl(url)) || url;
@@ -772,7 +772,7 @@ const PDFViewerApplication = {
   get _docFilename() {
     // Use `this.url` instead of `this.baseUrl` to perform filename detection
     // based on the reference fragment as ultimate fallback if needed.
-    return this._contentDispositionFilename || getPDFFileNameFromURL(this.url);
+    return this._contentDispositionFilename || getPdfFilenameFromUrl(this.url);
   },
 
   /**

--- a/web/generic_scripting.js
+++ b/web/generic_scripting.js
@@ -13,8 +13,7 @@
  * limitations under the License.
  */
 
-import { getPDFFileNameFromURL } from "./ui_utils.js";
-import { loadScript } from "pdfjs-lib";
+import { getPdfFilenameFromUrl, loadScript } from "pdfjs-lib";
 
 async function docPropertiesLookup(pdfDocument) {
   const url = "",
@@ -37,7 +36,7 @@ async function docPropertiesLookup(pdfDocument) {
     ...info,
     baseURL: baseUrl,
     filesize: contentLength,
-    filename: contentDispositionFilename || getPDFFileNameFromURL(url),
+    filename: contentDispositionFilename || getPdfFilenameFromUrl(url),
     metadata: metadata?.getRaw(),
     authors: metadata?.get("dc:creator"),
     numPages: pdfDocument.numPages,

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -13,12 +13,12 @@
  * limitations under the License.
  */
 
-import { createPromiseCapability, PDFDateString } from "pdfjs-lib";
 import {
-  getPageSizeInches,
-  getPDFFileNameFromURL,
-  isPortraitOrientation,
-} from "./ui_utils.js";
+  createPromiseCapability,
+  getPdfFilenameFromUrl,
+  PDFDateString,
+} from "pdfjs-lib";
+import { getPageSizeInches, isPortraitOrientation } from "./ui_utils.js";
 
 const DEFAULT_FIELD_CONTENT = "-";
 
@@ -140,7 +140,7 @@ class PDFDocumentProperties {
       pageSize,
       isLinearized,
     ] = await Promise.all([
-      contentDispositionFilename || getPDFFileNameFromURL(this.url),
+      contentDispositionFilename || getPdfFilenameFromUrl(this.url),
       this._parseFileSize(contentLength),
       this._parseDate(info.CreationDate),
       this._parseDate(info.ModDate),

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -570,60 +570,6 @@ function noContextMenuHandler(evt) {
   evt.preventDefault();
 }
 
-function isDataSchema(url) {
-  let i = 0;
-  const ii = url.length;
-  while (i < ii && url[i].trim() === "") {
-    i++;
-  }
-  return url.substring(i, i + 5).toLowerCase() === "data:";
-}
-
-/**
- * Returns the filename or guessed filename from the url (see issue 3455).
- * @param {string} url - The original PDF location.
- * @param {string} defaultFilename - The value returned if the filename is
- *   unknown, or the protocol is unsupported.
- * @returns {string} Guessed PDF filename.
- */
-function getPDFFileNameFromURL(url, defaultFilename = "document.pdf") {
-  if (typeof url !== "string") {
-    return defaultFilename;
-  }
-  if (isDataSchema(url)) {
-    console.warn(
-      "getPDFFileNameFromURL: " +
-        'ignoring "data:" URL for performance reasons.'
-    );
-    return defaultFilename;
-  }
-  const reURI = /^(?:(?:[^:]+:)?\/\/[^/]+)?([^?#]*)(\?[^#]*)?(#.*)?$/;
-  //              SCHEME        HOST        1.PATH  2.QUERY   3.REF
-  // Pattern to get last matching NAME.pdf
-  const reFilename = /[^/?#=]+\.pdf\b(?!.*\.pdf\b)/i;
-  const splitURI = reURI.exec(url);
-  let suggestedFilename =
-    reFilename.exec(splitURI[1]) ||
-    reFilename.exec(splitURI[2]) ||
-    reFilename.exec(splitURI[3]);
-  if (suggestedFilename) {
-    suggestedFilename = suggestedFilename[0];
-    if (suggestedFilename.includes("%")) {
-      // URL-encoded %2Fpath%2Fto%2Ffile.pdf should be file.pdf
-      try {
-        suggestedFilename = reFilename.exec(
-          decodeURIComponent(suggestedFilename)
-        )[0];
-      } catch (ex) {
-        // Possible (extremely rare) errors:
-        // URIError "Malformed URI", e.g. for "%AA.pdf"
-        // TypeError "null has no properties", e.g. for "%2F.pdf"
-      }
-    }
-  }
-  return suggestedFilename || defaultFilename;
-}
-
 function normalizeWheelEventDirection(evt) {
   let delta = Math.hypot(evt.deltaX, evt.deltaY);
   const angle = Math.atan2(evt.deltaY, evt.deltaX);
@@ -1063,7 +1009,6 @@ export {
   getActiveOrFocusedElement,
   getOutputScale,
   getPageSizeInches,
-  getPDFFileNameFromURL,
   getVisibleElements,
   isPortraitOrientation,
   isValidRotation,


### PR DESCRIPTION
While there is nothing *outright* wrong with the existing implementation, it can however lead to increased memory usage in one particular case (that I completely overlooked when implementing this):
For "data:"-URLs, which by definition contains the entire PDF document and can thus be arbitrarily large, we obviously want to avoid sending, storing, and/or logging the "raw" docBaseUrl in that case.

To address this, this patch makes the following changes:
 - Ignore any non-string in the `docBaseUrl` option passed to `getDocument`, since those are unsupported anyway, already on the main-thread.

 - Ignore "data:"-URLs in the `docBaseUrl` option passed to `getDocument`, to avoid having to send what could potentially be a *very* long string to the worker-thread.

 - Parse the `docBaseUrl` option *directly* in the `BasePdfManager`-constructors, on the worker-thread, to avoid having to store the "raw" docBaseUrl in the first place.