### PR TITLE
Support `LineAnnotation`s with empty /Rect-entries (issue 6564)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -23,6 +23,7 @@ import {
   assert,
   escapeString,
   getModificationDate,
+  isArrayEqual,
   isAscii,
   isString,
   OPS,
@@ -2290,6 +2291,17 @@ class LineAnnotation extends MarkupAnnotation {
         : [0, 0, 0];
 
       const borderWidth = this.borderStyle.width;
+
+      // If the /Rect-entry is empty, create a fallback rectangle such that we
+      // get similar rendering/highlighting behaviour as in Adobe Reader.
+      if (isArrayEqual(this.rectangle, [0, 0, 0, 0])) {
+        this.rectangle = [
+          this.data.lineCoordinates[0] - 2 * borderWidth,
+          this.data.lineCoordinates[1] - 2 * borderWidth,
+          this.data.lineCoordinates[2] + 2 * borderWidth,
+          this.data.lineCoordinates[3] + 2 * borderWidth,
+        ];
+      }
 
       this._setDefaultAppearance({
         xref: parameters.xref,

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -246,6 +246,7 @@
 !helloworld-bad.pdf
 !zerowidthline.pdf
 !js-colors.pdf
+!annotation-line-without-appearance-empty-Rect.pdf
 !issue12841_reduced.pdf
 !bug868745.pdf
 !mmtype1.pdf

--- a/test/pdfs/annotation-line-without-appearance-empty-Rect.pdf
+++ b/test/pdfs/annotation-line-without-appearance-empty-Rect.pdf
@@ -1,0 +1,92 @@
+%PDF-1.5
+%‚„œ”
+1 0 obj 
+<<
+/W 2
+>>
+endobj 
+2 0 obj 
+<<
+/Rotate 0
+/L [24 572 594 572]
+/Contents (Contents)
+/F 4
+/BS 1 0 R
+/NM (e6bb78a9c-0418-56ae-c91e-bb07d06b496)
+/C [1 0 0]
+/Subtype /Line
+/LE [/None /None]
+/Page 0
+/Type /Annot
+/T (Title)
+/Rect [0 0 0 0]
+>>
+endobj 
+3 0 obj 
+<<
+/Pages 4 0 R
+/Type /Catalog
+>>
+endobj 
+4 0 obj 
+<<
+/Kids [5 0 R]
+/Count 1
+/Type /Pages
+>>
+endobj 
+5 0 obj 
+<<
+/Parent 4 0 R
+/Annots [2 0 R]
+/MediaBox [0 0 650 792]
+/Resources 
+<<
+/Font 
+<<
+/F1 6 0 R
+>>
+>>
+/Contents 7 0 R
+/Type /Page
+>>
+endobj 
+6 0 obj 
+<<
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/Type /Font
+>>
+endobj 
+7 0 obj 
+<<
+/Length 69
+>>
+stream
+BT
+50 700 TD
+/F1 20 Tf
+(LineAnnotation with empty /Rect-entry) Tj
+ET
+
+endstream 
+endobj xref
+0 8
+0000000000 65535 f 
+0000000015 00000 n 
+0000000043 00000 n 
+0000000267 00000 n 
+0000000318 00000 n 
+0000000377 00000 n 
+0000000523 00000 n 
+0000000624 00000 n 
+trailer
+
+<<
+/Root 3 0 R
+/Size 8
+>>
+startxref
+745
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -4655,6 +4655,13 @@
        "annotations": true,
        "type": "eq"
     },
+    {  "id": "annotation-line-without-appearance-empty-Rect",
+       "file": "pdfs/annotation-line-without-appearance-empty-Rect.pdf",
+       "md5": "65f2d3ef80acfea637718c3fc66043b7",
+       "rounds": 1,
+       "annotations": true,
+       "type": "eq"
+    },
     {  "id": "issue12705",
        "file": "pdfs/issue12705.pdf",
        "md5": "d8725b9dcfef72fd4fa4a39cab711624",


### PR DESCRIPTION
This extends PR #13033 slightly, with a heuristic to support corrupt PDF documents where the `LineAnnotation`s have an empty /Rect-entry. Please note that while I have no idea if this is "correct", this patch at least makes us output the same /BBox as re-saving in Adobe Reader does.