### PR TITLE
Enable scripting by default in the viewer (PR 13053 follow-up)

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -153,7 +153,7 @@
     },
     "enableScripting": {
       "type": "boolean",
-      "default": false
+      "default": true
     },
     "enablePermissions": {
       "type": "boolean",

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -67,9 +67,7 @@ const defaultOptions = {
   },
   enableScripting: {
     /** @type {boolean} */
-    value:
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING"),
+    value: true,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
   enableWebGL: {


### PR DESCRIPTION
Given that https://bugzilla.mozilla.org/show_bug.cgi?id=1699219 has enabled scripting for all Firefox-channels, it seems reasonable to simply set `enableScripting = true` unconditionally in the viewer preferences/options.

For now, this patch leaves the standalone viewer-components alone (such as e.g. `BaseViewer`), and if those are used scripting will thus have to be manually enabled (see e.g. the "simpleviewer"/"singlepageviewer" examples).