### PR TITLE
Re-factor the default preferences generation to support build targets (PR 10548)

### DIFF
--- a/extensions/firefox/content/PdfJsDefaultPreferences.jsm
+++ b/extensions/firefox/content/PdfJsDefaultPreferences.jsm
@@ -18,5 +18,5 @@
 var EXPORTED_SYMBOLS = ["PdfJsDefaultPreferences"];
 
 var PdfJsDefaultPreferences = Object.freeze(
-  PDFJSDev.json("$ROOT/build/default_preferences.json")
+  PDFJSDev.eval("DEFAULT_PREFERENCES")
 );

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -289,8 +289,7 @@ function getVersionJSON() {
 
 function checkChromePreferencesFile(chromePrefsPath, webPrefs) {
   const chromePrefs = JSON.parse(fs.readFileSync(chromePrefsPath).toString());
-  let chromePrefsKeys = Object.keys(chromePrefs.properties);
-  chromePrefsKeys = chromePrefsKeys.filter(function (key) {
+  const chromePrefsKeys = Object.keys(chromePrefs.properties).filter(key => {
     const description = chromePrefs.properties[key].description;
     // Deprecated keys are allowed in the managed preferences file.
     // The code maintained is responsible for adding migration logic to
@@ -301,15 +300,9 @@ function checkChromePreferencesFile(chromePrefsPath, webPrefs) {
 
   const webPrefsKeys = Object.keys(webPrefs);
   webPrefsKeys.sort();
-  const telemetryIndex = chromePrefsKeys.indexOf("disableTelemetry");
-  if (telemetryIndex >= 0) {
-    chromePrefsKeys.splice(telemetryIndex, 1);
-  } else {
-    console.log("Warning: disableTelemetry key not found in chrome prefs!");
-    return false;
-  }
+
   if (webPrefsKeys.length !== chromePrefsKeys.length) {
-    console.log("Warning: Prefs objects haven't the same length");
+    console.log("Warning: Pref objects doesn't have the same length.");
     return false;
   }
 
@@ -324,7 +317,8 @@ function checkChromePreferencesFile(chromePrefsPath, webPrefs) {
     } else if (chromePrefs.properties[value].default !== webPrefs[value]) {
       ret = false;
       console.log(
-        `Warning: not the same values: ${chromePrefs.properties[value].default} !== ${webPrefs[value]}`
+        `Warning: not the same values (for "${value}"): ` +
+          `${chromePrefs.properties[value].default} !== ${webPrefs[value]}`
       );
     }
   }

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -271,6 +271,11 @@ if (
     kind: OptionKind.VIEWER,
   };
 } else if (PDFJSDev.test("CHROME")) {
+  defaultOptions.disableTelemetry = {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+  };
   defaultOptions.sandboxBundleSrc = {
     /** @type {string} */
     value: "../build/pdf.sandbox.js",

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -297,7 +297,7 @@ class AppOptions {
     }
     const defaultOption = defaultOptions[name];
     if (defaultOption !== undefined) {
-      return defaultOption.compatibility || defaultOption.value;
+      return defaultOption.compatibility ?? defaultOption.value;
     }
     return undefined;
   }
@@ -329,7 +329,7 @@ class AppOptions {
       options[name] =
         userOption !== undefined
           ? userOption
-          : defaultOption.compatibility || defaultOption.value;
+          : defaultOption.compatibility ?? defaultOption.value;
     }
     return options;
   }

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -250,7 +250,7 @@ const defaultOptions = {
 };
 if (
   typeof PDFJSDev === "undefined" ||
-  PDFJSDev.test("!PRODUCTION || (GENERIC && !LIB)")
+  PDFJSDev.test("!PRODUCTION || GENERIC")
 ) {
   defaultOptions.disablePreferences = {
     /** @type {boolean} */

--- a/web/preferences.js
+++ b/web/preferences.js
@@ -29,7 +29,7 @@ class BasePreferences {
       value: Object.freeze(
         typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")
           ? AppOptions.getAll(OptionKind.PREFERENCE)
-          : PDFJSDev.json("$ROOT/build/default_preferences.json")
+          : PDFJSDev.eval("DEFAULT_PREFERENCES")
       ),
       writable: false,
       enumerable: true,


### PR DESCRIPTION
Originally the default preferences where simply placed in a JSON-file, checked into the repository, which over time became impractical, annoying, and error-prone to maintain; please see PR #10548.
While that improved the overall situation a fair bit, it however inherited one quite unfortunate property of the old JSON-based solution[1]: It's still not possible for *different* build targets to specify their *own* default preference values.

With some preferences, such as e.g. `enableScripting`, it's not inconceivable that you'd want to (at least) support build-specific default preference values. Currently that's not really possible, which is why this PR re-factors the default preferences generation to support this.

*Much smaller/simpler diff with https://github.com/mozilla/pdf.js/pull/13117/files?w=1*

---
[1] This fact isn't really clear from the `AppOptions` implementation, unless you're familiar with the `gulpfile.js` code, which could lead to some confusion for those new to this part of the code-base.

