### PR TITLE
Actually reset the `PDFPageProxy._xfaPromise` property as intended (PR 13069 follow-up)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1468,6 +1468,7 @@ class PDFPageProxy {
     this.objs.clear();
     this.annotationsPromise = null;
     this._jsActionsPromise = null;
+    this._xfaPromise = null;
     this.pendingCleanup = false;
     return Promise.all(waitOn);
   }
@@ -1502,6 +1503,7 @@ class PDFPageProxy {
     this.objs.clear();
     this.annotationsPromise = null;
     this._jsActionsPromise = null;
+    this._xfaPromise = null;
     if (resetStats && this._stats) {
       this._stats = new StatTimer();
     }


### PR DESCRIPTION
Similar to the existing `annotationsPromise` and `_jsActionsPromise` properties, the new `_xfaPromise` should obviously also be reset, since otherwise you might end up holding onto a lot of data for pages that are no longer active.

(That caching wasn't present in the original version of PR #13069, which is why I didn't spot it until now.)