### PR TITLE
Rotate landscape pages, during printing, by default in the viewer (`enablePrintAutoRotate = true`)

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -173,7 +173,7 @@
       "title": "Automatically rotate printed pages",
       "description": "When enabled, landscape pages are rotated when printed.",
       "type": "boolean",
-      "default": false
+      "default": true
     },
     "scrollModeOnLoad": {
       "title": "Scroll mode on load",

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -62,7 +62,7 @@ const defaultOptions = {
   },
   enablePrintAutoRotate: {
     /** @type {boolean} */
-    value: false,
+    value: true,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
   enableScripting: {

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -1347,25 +1347,21 @@ class BaseViewer {
    * @returns {Array} Array of objects with width/height/rotation fields.
    */
   getPagesOverview() {
-    const pagesOverview = this._pages.map(function (pageView) {
+    return this._pages.map(pageView => {
       const viewport = pageView.pdfPage.getViewport({ scale: 1 });
-      return {
-        width: viewport.width,
-        height: viewport.height,
-        rotation: viewport.rotation,
-      };
-    });
-    if (!this.enablePrintAutoRotate) {
-      return pagesOverview;
-    }
-    return pagesOverview.map(function (size) {
-      if (isPortraitOrientation(size)) {
-        return size;
+
+      if (!this.enablePrintAutoRotate || isPortraitOrientation(viewport)) {
+        return {
+          width: viewport.width,
+          height: viewport.height,
+          rotation: viewport.rotation,
+        };
       }
+      // Landscape orientation.
       return {
-        width: size.height,
-        height: size.width,
-        rotation: (size.rotation - 90) % 360,
+        width: viewport.height,
+        height: viewport.width,
+        rotation: (viewport.rotation - 90) % 360,
       };
     });
   }

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -1365,7 +1365,7 @@ class BaseViewer {
       return {
         width: size.height,
         height: size.width,
-        rotation: (size.rotation + 90) % 360,
+        rotation: (size.rotation - 90) % 360,
       };
     });
   }


### PR DESCRIPTION
While this will perhaps not be perfect for *every* PDF document with mixed page orientation, based on the large number of bugs/issues seen over the years I'm however pretty convinced that it'll be an overall improvement in a majority of cases.

In order to improve things further, we'd probably need Firefox to support e.g. `@page` such that the viewer can provide better information to the print engine.

