### PR TITLE
Tweak the pre-processor condition, for Node.js environments, in the `animationStarted` helper (issue 13057)

### DIFF
--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -684,11 +684,11 @@ function waitOnEventOrTimeout({ target, name, delay = 0 }) {
 const animationStarted = new Promise(function (resolve) {
   if (
     typeof PDFJSDev !== "undefined" &&
-    PDFJSDev.test("LIB && TESTING") &&
+    PDFJSDev.test("LIB") &&
     typeof window === "undefined"
   ) {
     // Prevent "ReferenceError: window is not defined" errors when running the
-    // unit-tests in Node.js/Travis.
+    // unit-tests in Node.js environments.
     setTimeout(resolve, 20);
     return;
   }


### PR DESCRIPTION
While it's still not entirely clear if this would've prevented the issue as reported, given that the particular use-case reported apparently no longer applies, this small change really cannot hurt in general *and* it won't effect "regular" viewer builds in any way.

Fixes #13057, to the extent that doing so is even necessary now given https://github.com/mozilla/pdf.js/issues/13057#issuecomment-803104197.