### PR TITLE
JS - Handle correctly hierarchy of fields

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -471,7 +471,8 @@ class Page {
               this.xref,
               annotationRef,
               this.pdfManager,
-              this._localIdFactory
+              this._localIdFactory,
+              /* collectFields */ false
             ).catch(function (reason) {
               warn(`_parsedAnnotations: "${reason}".`);
               return null;
@@ -1098,7 +1099,8 @@ class PDFDocument {
         this.xref,
         fieldRef,
         this.pdfManager,
-        this._localIdFactory
+        this._localIdFactory,
+        /* collectFields */ true
       )
         .then(annotation => annotation && annotation.getFieldObject())
         .catch(function (reason) {

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -636,9 +636,11 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
       // NOTE: We cannot set the values using `element.value` below, since it
       //       prevents the AnnotationLayer rasterizer in `test/driver.js`
       //       from parsing the elements correctly for the reference tests.
-      const textContent = storage.getValue(id, {
+      const storedData = storage.getValue(id, {
         value: this.data.fieldValue,
-      }).value;
+        valueAsString: this.data.fieldValue,
+      });
+      const textContent = storedData.valueAsString || storedData.value || "";
       const elementData = {
         userValue: null,
         formattedValue: null,

--- a/src/scripting_api/common.js
+++ b/src/scripting_api/common.js
@@ -13,6 +13,14 @@
  * limitations under the License.
  */
 
+const FieldType = {
+  none: 0,
+  number: 1,
+  percent: 2,
+  date: 3,
+  time: 4,
+};
+
 function createActionsMap(actions) {
   const actionsMap = new Map();
   if (actions) {
@@ -23,4 +31,28 @@ function createActionsMap(actions) {
   return actionsMap;
 }
 
-export { createActionsMap };
+function getFieldType(actions) {
+  let format = actions.get("Format");
+  if (!format) {
+    return FieldType.none;
+  }
+
+  format = format[0];
+
+  format = format.trim();
+  if (format.startsWith("AFNumber_")) {
+    return FieldType.number;
+  }
+  if (format.startsWith("AFPercent_")) {
+    return FieldType.percent;
+  }
+  if (format.startsWith("AFDate_")) {
+    return FieldType.date;
+  }
+  if (format.startsWith("AFTime__")) {
+    return FieldType.time;
+  }
+  return FieldType.none;
+}
+
+export { createActionsMap, FieldType, getFieldType };

--- a/src/scripting_api/event.js
+++ b/src/scripting_api/event.js
@@ -187,16 +187,27 @@ class EventDispatcher {
         continue;
       }
 
+      event.value = null;
       const target = this._objects[targetId];
       this.runActions(source, target, event, "Calculate");
+      if (!event.rc) {
+        continue;
+      }
+      if (event.value !== null) {
+        target.wrapped.value = event.value;
+      }
+
+      event.value = target.obj.value;
       this.runActions(target, target, event, "Validate");
       if (!event.rc) {
         continue;
       }
 
-      target.wrapped.value = event.value;
+      event.value = target.obj.value;
       this.runActions(target, target, event, "Format");
-      target.wrapped.valueAsString = event.value;
+      if (event.value !== null) {
+        target.wrapped.valueAsString = event.value;
+      }
     }
   }
 }

--- a/src/scripting_api/initialization.js
+++ b/src/scripting_api/initialization.js
@@ -67,20 +67,39 @@ function initSandbox(params) {
   });
 
   const util = new Util({ externalCall });
+  const appObjects = app._objects;
 
   if (data.objects) {
+    const annotations = [];
+
     for (const [name, objs] of Object.entries(data.objects)) {
-      const obj = objs[0];
-      obj.send = send;
+      annotations.length = 0;
+      let container = null;
+
+      for (const obj of objs) {
+        if (obj.type !== "") {
+          annotations.push(obj);
+        } else {
+          container = obj;
+        }
+      }
+
+      let obj = container;
+      if (annotations.length > 0) {
+        obj = annotations[0];
+        obj.send = send;
+      }
+
       obj.globalEval = globalEval;
       obj.doc = _document;
       obj.fieldPath = name;
+      obj.appObjects = appObjects;
       let field;
       if (obj.type === "radiobutton") {
-        const otherButtons = objs.slice(1);
+        const otherButtons = annotations.slice(1);
         field = new RadioButtonField(otherButtons, obj);
       } else if (obj.type === "checkbox") {
-        const otherButtons = objs.slice(1);
+        const otherButtons = annotations.slice(1);
         field = new CheckboxField(otherButtons, obj);
       } else {
         field = new Field(obj);
@@ -90,7 +109,10 @@ function initSandbox(params) {
       doc._addField(name, wrapped);
       const _object = { obj: field, wrapped };
       for (const object of objs) {
-        app._objects[object.id] = _object;
+        appObjects[object.id] = _object;
+      }
+      if (container) {
+        appObjects[container.id] = _object;
       }
     }
   }

--- a/src/scripting_api/util.js
+++ b/src/scripting_api/util.js
@@ -372,6 +372,10 @@ class Util extends PDFObject {
   }
 
   scand(cFormat, cDate) {
+    if (cDate === "") {
+      return new Date();
+    }
+
     switch (cFormat) {
       case 0:
         return this.scand("D:yyyymmddHHMMss", cDate);
@@ -525,14 +529,14 @@ class Util extends PDFObject {
         }
       );
 
-      this._scandCache.set(cFormat, [new RegExp(re, "g"), actions]);
+      this._scandCache.set(cFormat, [re, actions]);
     }
 
-    const [regexForFormat, actions] = this._scandCache.get(cFormat);
+    const [re, actions] = this._scandCache.get(cFormat);
 
-    const matches = regexForFormat.exec(cDate);
-    if (matches.length !== actions.length + 1) {
-      throw new Error("Invalid date in util.scand");
+    const matches = new RegExp(re, "g").exec(cDate);
+    if (!matches || matches.length !== actions.length + 1) {
+      return null;
     }
 
     const data = {

--- a/test/pdfs/issue13132.pdf.link
+++ b/test/pdfs/issue13132.pdf.link
@@ -1,0 +1,1 @@
+https://web.archive.org/web/20210324123420/https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/866023/IHT205_2004-2006.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2549,10 +2549,8 @@
     {  "id": "issue13132",
        "file": "pdfs/issue13132.pdf",
        "md5": "1b28964b9188047bc6c786302c95029f",
-       "rounds": 1,
-       "lastPage": 1,
        "link": true,
-       "type": "load"
+       "type": "other"
     },
     {  "id": "issue4722",
        "file": "pdfs/issue4722.pdf",

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2546,6 +2546,14 @@
        "link": true,
        "type": "load"
     },
+    {  "id": "issue13132",
+       "file": "pdfs/issue13132.pdf",
+       "md5": "1b28964b9188047bc6c786302c95029f",
+       "rounds": 1,
+       "lastPage": 1,
+       "link": true,
+       "type": "load"
+    },
     {  "id": "issue4722",
        "file": "pdfs/issue4722.pdf",
        "md5": "a42ca858af7d179358f92f47e57c0fed",

--- a/web/pdf_scripting_manager.js
+++ b/web/pdf_scripting_manager.js
@@ -308,10 +308,9 @@ class PDFScriptingManager {
     if (element) {
       element.dispatchEvent(new CustomEvent("updatefromsandbox", { detail }));
     } else {
-      if (value !== undefined && value !== null) {
-        // The element hasn't been rendered yet, use the AnnotationStorage.
-        this._pdfDocument?.annotationStorage.setValue(id, value);
-      }
+      delete detail.id;
+      // The element hasn't been rendered yet, use the AnnotationStorage.
+      this._pdfDocument?.annotationStorage.setValue(id, detail);
     }
   }
 


### PR DESCRIPTION
  - it aims to fix #13132;
  - annotations can inherit their actions from the parent field;
  - there are some fields which act as a container for other fields:
    - they can be access through js so need to add them with an empty type (nothing in the spec about that but checked in Acrobat);
    - calculation order list (CO) can reference them so need make them through this.getField;
    - getArray method must return kids.
  - field values are number, string, ... depending of their type but nothing in the spec on how to know what's the type:
    - according to the comment for Canonical Format: https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/PDF32000_2008.pdf#page=461
    - it seems that this "type" can be guessed from js action Format (when setting a type in Acrobat DC, the only affected thing is this action).
  - util.scand with an empty string returns the current date.