### PR TITLE
[GrabToPan] Remove more IE-specific code, and remove *unconditional* browser sniffing

### DIFF
--- a/web/grab_to_pan.js
+++ b/web/grab_to_pan.js
@@ -194,7 +194,6 @@ let matchesSelector;
 
 // Browser sniffing because it's impossible to feature-detect
 // whether event.which for onmousemove is reliable
-const isNotIEorIsIE10plus = !document.documentMode || document.documentMode > 9;
 const chrome = window.chrome;
 const isChrome15OrOpera15plus = chrome && (chrome.webstore || chrome.app);
 //                                         ^ Chrome 15+       ^ Opera 15+
@@ -209,10 +208,9 @@ const isSafari6plus =
  *                    False if unsure or if the left mouse button is pressed.
  */
 function isLeftMouseReleased(event) {
-  if ("buttons" in event && isNotIEorIsIE10plus) {
+  if ("buttons" in event) {
     // http://www.w3.org/TR/DOM-Level-3-Events/#events-MouseEvent-buttons
     // Firefox 15+
-    // Internet Explorer 10+
     return !(event.buttons & 1);
   }
   if (isChrome15OrOpera15plus || isSafari6plus) {

--- a/web/grab_to_pan.js
+++ b/web/grab_to_pan.js
@@ -192,15 +192,6 @@ let matchesSelector;
   return matchesSelector; // If found, then truthy, and [].some() ends.
 });
 
-// Browser sniffing because it's impossible to feature-detect
-// whether event.which for onmousemove is reliable
-const chrome = window.chrome;
-const isChrome15OrOpera15plus = chrome && (chrome.webstore || chrome.app);
-//                                         ^ Chrome 15+       ^ Opera 15+
-const isSafari6plus =
-  /Apple/.test(navigator.vendor) &&
-  /Version\/([6-9]\d*|[1-5]\d+)/.test(navigator.userAgent);
-
 /**
  * Whether the left mouse is not pressed.
  * @param event {MouseEvent}
@@ -211,13 +202,26 @@ function isLeftMouseReleased(event) {
   if ("buttons" in event) {
     // http://www.w3.org/TR/DOM-Level-3-Events/#events-MouseEvent-buttons
     // Firefox 15+
+    // Chrome 43+
+    // Safari 11.1+
     return !(event.buttons & 1);
   }
-  if (isChrome15OrOpera15plus || isSafari6plus) {
-    // Chrome 14+
-    // Opera 15+
-    // Safari 6.0+
-    return event.which === 0;
+  if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
+    // Browser sniffing because it's impossible to feature-detect
+    // whether event.which for onmousemove is reliable.
+    const chrome = window.chrome;
+    const isChrome15OrOpera15plus = chrome && (chrome.webstore || chrome.app);
+    //                                         ^ Chrome 15+       ^ Opera 15+
+    const isSafari6plus =
+      /Apple/.test(navigator.vendor) &&
+      /Version\/([6-9]\d*|[1-5]\d+)/.test(navigator.userAgent);
+
+    if (isChrome15OrOpera15plus || isSafari6plus) {
+      // Chrome 14+
+      // Opera 15+
+      // Safari 6.0+
+      return event.which === 0;
+    }
   }
   return false;
 }


### PR DESCRIPTION
 - Remove the remaining IE-specific checks from `web/grab_to_pan.js` (PR 12328 follow-up)

   Given that all versions of Internet Explorer are now *explicitly* unsupported, we can remove some more dead code in this file.

 - Remove *unconditional* browser sniffing in `web/grab_to_pan.js`

   According to https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons#browser_compatibility, and manual testing in an up-to-date version of Google Chrome, the *unconditional* browser sniffing in `web/grab_to_pan.js` is no longer necessary.
   In particular, this code is definitely not necessary in MOZCENTRAL-builds.

