### PR TITLE
Prevent errors, in `PDFOutlineViewer._getPageNumberToDestHash`, for invalid `destRef` values (PR 12777 follow-up)

### DIFF
--- a/web/pdf_outline_viewer.js
+++ b/web/pdf_outline_viewer.js
@@ -276,7 +276,7 @@ class PDFOutlineViewer extends BaseTreeViewer {
         if (Array.isArray(explicitDest)) {
           const [destRef] = explicitDest;
 
-          if (typeof destRef === "object") {
+          if (destRef instanceof Object) {
             pageNumber = this.linkService._cachedPageNumber(destRef);
 
             if (!pageNumber) {


### PR DESCRIPTION
Currently `destRef === null`, which will only happen in documents with corrupt destinations, will (unsurprisingly) throw when trying to lookup the pageNumber. To avoid this, we can simply use the same format as in https://github.com/mozilla/pdf.js/blob/1a2cdaffc513385fc2f17d0e53d2643f92d5fa81/web/pdf_link_service.js#L128

(I was browsing through some old issues, and stumbled upon this bug in https://github.com/mozilla/pdf.js/files/5483662/pdf-bugs.pdf, although I'm sure there's loads of other examples as well.)