### PR TITLE
Remove the `file://`-URL special-case from `webViewerOpenFileViaURL`

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2274,10 +2274,9 @@ function webViewerInitialized() {
   }
 }
 
-let webViewerOpenFileViaURL;
-if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-  webViewerOpenFileViaURL = function (file) {
-    if (file && file.lastIndexOf("file:", 0) === 0) {
+function webViewerOpenFileViaURL(file) {
+  if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+    if (file?.lastIndexOf("file:", 0) === 0) {
       // file:-scheme. Load the contents in the main thread because QtWebKit
       // cannot load file:-URLs in a Web Worker. file:-URLs are usually loaded
       // very quickly, so there is no need to set up progress event listeners.
@@ -2295,18 +2294,14 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
     if (file) {
       PDFViewerApplication.open(file);
     }
-  };
-} else if (PDFJSDev.test("MOZCENTRAL || CHROME")) {
-  webViewerOpenFileViaURL = function (file) {
+  } else if (PDFJSDev.test("MOZCENTRAL || CHROME")) {
     PDFViewerApplication.setTitleUsingUrl(file);
     PDFViewerApplication.initPassiveLoading();
-  };
-} else {
-  webViewerOpenFileViaURL = function (file) {
+  } else {
     if (file) {
       throw new Error("Not implemented: webViewerOpenFileViaURL");
     }
-  };
+  }
 }
 
 function webViewerResetPermissions() {

--- a/web/app.js
+++ b/web/app.js
@@ -2276,21 +2276,6 @@ function webViewerInitialized() {
 
 function webViewerOpenFileViaURL(file) {
   if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-    if (file?.lastIndexOf("file:", 0) === 0) {
-      // file:-scheme. Load the contents in the main thread because QtWebKit
-      // cannot load file:-URLs in a Web Worker. file:-URLs are usually loaded
-      // very quickly, so there is no need to set up progress event listeners.
-      PDFViewerApplication.setTitleUsingUrl(file);
-      const xhr = new XMLHttpRequest();
-      xhr.onload = function () {
-        PDFViewerApplication.open(new Uint8Array(xhr.response));
-      };
-      xhr.open("GET", file);
-      xhr.responseType = "arraybuffer";
-      xhr.send();
-      return;
-    }
-
     if (file) {
       PDFViewerApplication.open(file);
     }


### PR DESCRIPTION
Given that *all* data has been loaded on the main-thread, and then transferred to the worker-thread, ever since PR #8617 (almost four years ago) it should no longer be necessary to keep this special-case around.

