### PR TITLE
Remove the `URL` polyfill

### DIFF
--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -74,24 +74,6 @@ if (
     globalThis.Promise = require("core-js/es/promise/index.js");
   })();
 
-  // Support: Safari
-  (function checkURL() {
-    if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
-      // Prevent "require is not a function" errors in development mode,
-      // since the `URL` constructor should be available in modern browers.
-      return;
-    } else if (!PDFJSDev.test("GENERIC")) {
-      // The `URL` constructor is assumed to be available in the extension
-      // builds.
-      return;
-    } else if (PDFJSDev.test("IMAGE_DECODERS")) {
-      // The current image decoders don't use the `URL` constructor, so it
-      // doesn't need to be polyfilled for the IMAGE_DECODERS build target.
-      return;
-    }
-    globalThis.URL = require("core-js/web/url.js");
-  })();
-
   // Support: Safari<10.1, Node.js
   (function checkReadableStream() {
     if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("IMAGE_DECODERS")) {


### PR DESCRIPTION
Based on this compatibility information, given that IE 11 is now *explicitly* unsupported, we should no longer need to bundle a `URL` polyfill in any builds: https://developer.mozilla.org/en-US/docs/Web/API/URL/URL#browser_compatibility

Note that the caveat listed for older Safari-versions doesn't apply to any code in the PDF.js library, since we never call `new URL(url, undefined)` in the code-base.

Note also that Node.js has a web-compatible `URL` implementation, which according to the "History" section at https://nodejs.org/api/url.html#url_the_whatwg_url_api has been available since Node.js `10.0.0` (according to https://nodejs.org/en/about/releases/ that branch is one month away from being EOL-ed).