### PR TITLE
Improve handling of *linked* test-cases for the unit/integration suites

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -392,6 +392,20 @@ var Driver = (function DriverClosure() {
         task.pageNum = task.firstPage || 1;
         task.stats = { times: [] };
 
+        // Support *linked* test-cases for the other suites, e.g. unit- and
+        // integration-tests, without needing to run them as reference-tests.
+        if (task.type === "other") {
+          this._log(`Skipping file "${task.file}"\n`);
+
+          if (!task.link) {
+            this._nextPage(task, 'Expected "other" test-case to be linked.');
+            return;
+          }
+          this.currentTask++;
+          this._nextTask();
+          return;
+        }
+
         this._log('Loading file "' + task.file + '"\n');
 
         const absoluteUrl = new URL(task.file, window.location).href;

--- a/test/test.js
+++ b/test/test.js
@@ -1000,7 +1000,10 @@ function main() {
   } else if (options.fontTest) {
     startUnitTest("/test/font/font_test.html", "font");
   } else if (options.integration) {
-    startIntegrationTest();
+    // Allows linked PDF files in integration-tests as well.
+    ensurePDFsDownloaded(function () {
+      startIntegrationTest();
+    });
   } else {
     startRefTest(options.masterMode, options.reftest);
   }


### PR DESCRIPTION
 - Actually support *linked* test-cases in the integration-tests (in the same way as the unit-tests).

 - Add a new `"type": "other"`-kind to the test-manifest, to support *linked* test-cases in the unit/integration-tests without requiring the PDF document in question to also be a reference-test.

*Please note:* I'm purposely not adding a new case below, since the whole purpose of `other`-tests is that they shouldn't run at all during reference tests, and if we'd ever get that far it's an error.
https://github.com/mozilla/pdf.js/blob/1a2cdaffc513385fc2f17d0e53d2643f92d5fa81/test/test.js#L562-L575