### PR TITLE
Cache babel source map.

### DIFF
--- a/external/systemjs/plugin-babel-cached.js
+++ b/external/systemjs/plugin-babel-cached.js
@@ -43,7 +43,7 @@ function getDb() {
   return dbPromise;
 }
 
-function storeCache(address, hashCode, translated, format) {
+function storeCache(address, hashCode, translated, format, sourceMap) {
   return getDb().then(function (db) {
     var tx = db.transaction(dbCacheTable, "readwrite");
     var store = tx.objectStore(dbCacheTable);
@@ -53,6 +53,7 @@ function storeCache(address, hashCode, translated, format) {
       translated,
       expires: Date.now() + cacheExpiration,
       format,
+      sourceMap,
     });
     return new Promise(function (resolve, reject) {
       tx.oncomplete = function () {
@@ -80,6 +81,7 @@ function loadCache(address, hashCode) {
             ? {
                 translated: found.translated,
                 format: found.format,
+                sourceMap: found.sourceMap,
               }
             : null
         );
@@ -127,7 +129,8 @@ exports.translate = function (load, opt) {
               load.address,
               savedHashCode,
               translated,
-              load.metadata.format
+              load.metadata.format,
+              load.metadata.sourceMap
             ).then(function () {
               return translated;
             });


### PR DESCRIPTION
When source is already cached and you reload,
the source map is lost which makes debugging
async functions difficult.