### PR TITLE
[GENERIC viewer] Display a warning message, using the `errorWrapper`, for documents with signatures (PR 13214 follow-up, issue 13215)

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -246,3 +246,6 @@ password_cancel=Cancel
 printing_not_supported=Warning: Printing is not fully supported by this browser.
 printing_not_ready=Warning: The PDF is not fully loaded for printing.
 web_fonts_disabled=Web fonts are disabled: unable to use embedded PDF fonts.
+# LOCALIZATION NOTE (unsupported_feature_signatures): Should contain the same
+# exact string as in the `chrome.properties` file.
+unsupported_feature_signatures=This PDF document contains digital signatures. Validation of signatures is not supported.

--- a/web/app.js
+++ b/web/app.js
@@ -198,7 +198,7 @@ class DefaultExternalServices {
 const PDFViewerApplication = {
   initialBookmark: document.location.hash.substring(1),
   _initializedCapability: createPromiseCapability(),
-  fellback: false,
+  _fellback: false,
   appConfig: null,
   pdfDocument: null,
   pdfLoadingTask: null,
@@ -830,6 +830,7 @@ const PDFViewerApplication = {
       this.pdfDocumentProperties.setDocument(null);
     }
     webViewerResetPermissions();
+    this._fellback = false;
     this.store = null;
     this.isInitialViewSet = false;
     this.downloadComplete = false;
@@ -1056,10 +1057,21 @@ const PDFViewerApplication = {
     }
     // Only trigger the fallback once so we don't spam the user with messages
     // for one PDF.
-    if (this.fellback) {
+    if (this._fellback) {
       return;
     }
-    this.fellback = true;
+    this._fellback = true;
+
+    // Ensure that, for signatures, a warning is shown in non-Firefox builds.
+    if (
+      (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) &&
+      featureId === UNSUPPORTED_FEATURES.signatures
+    ) {
+      this.l10n.get("unsupported_feature_signatures").then(msg => {
+        this._otherError(msg);
+      });
+    }
+
     this.externalServices
       .fallback({
         featureId,

--- a/web/l10n_utils.js
+++ b/web/l10n_utils.js
@@ -81,6 +81,8 @@ const DEFAULT_L10N_STRINGS = {
   printing_not_ready: "Warning: The PDF is not fully loaded for printing.",
   web_fonts_disabled:
     "Web fonts are disabled: unable to use embedded PDF fonts.",
+  unsupported_feature_signatures:
+    "This PDF document contains digital signatures. Validation of signatures is not supported.",
 };
 
 function getL10nFallback(key, args) {

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -26,7 +26,7 @@
 
   --main-color: rgba(12, 12, 13, 1);
   --body-bg-color: rgba(237, 237, 240, 1);
-  --errorWrapper-bg-color: rgba(255, 74, 74, 1);
+  --errorWrapper-bg-color: rgba(255, 110, 110, 1);
   --progressBar-color: rgba(10, 132, 255, 1);
   --progressBar-indeterminate-bg-color: rgba(221, 221, 222, 1);
   --progressBar-indeterminate-blend-color: rgba(116, 177, 239, 1);
@@ -101,7 +101,7 @@
   :root {
     --main-color: rgba(249, 249, 250, 1);
     --body-bg-color: rgba(42, 42, 46, 1);
-    --errorWrapper-bg-color: rgba(199, 17, 17, 1);
+    --errorWrapper-bg-color: rgba(169, 14, 14, 1);
     --progressBar-color: rgba(0, 96, 223, 1);
     --progressBar-indeterminate-bg-color: rgba(40, 40, 43, 1);
     --progressBar-indeterminate-blend-color: rgba(20, 68, 133, 1);


### PR DESCRIPTION
To simplify the overall implementation, given that it only applies to the GENERIC-viewer, this patch purposely re-uses the existing `errorWrapper`-functionality to display the message.
While that one is mostly intended for actual *errors*, by re-using it here we considerably reduce the amount of code/complexity necessary for supporting this new warning. It's obviously possible to re-factor/improve this later on, but the patch should do just fine here since it'll indeed inform users (of the GENERIC-viewer) about unverified signatures.

Finally this patch also tweaks the background-color of the `errorWrapper`, making it 20 percent lighter respectively darker (depending on the theme) to make it "stand out" a little bit *less*.[1] While it may perhaps be useful to re-style/re-factor the `errorWrapper`, this patch probably isn't the right place for doing that.

Fixes #13215

---
[1] Note how in the MOZCENTRAL-viewer, which instead uses the browser notification-bar, we're purposely using a neutral colour to not draw too much attention to the notification-bar.