### PR TITLE
Convert done callbacks to async/await in the smaller unit test files

### DIFF
--- a/test/unit/custom_spec.js
+++ b/test/unit/custom_spec.js
@@ -35,28 +35,22 @@ describe("custom canvas rendering", function () {
   let loadingTask;
   let page;
 
-  beforeAll(function (done) {
+  beforeAll(async function () {
     CanvasFactory = new DefaultCanvasFactory();
 
     loadingTask = getDocument(transparentGetDocumentParams);
-    loadingTask.promise
-      .then(function (doc) {
-        return doc.getPage(1);
-      })
-      .then(function (data) {
-        page = data;
-        done();
-      })
-      .catch(done.fail);
+    const doc = await loadingTask.promise;
+    const data = await doc.getPage(1);
+    page = data;
   });
 
-  afterAll(function (done) {
+  afterAll(async function () {
     CanvasFactory = null;
     page = null;
-    loadingTask.destroy().then(done);
+    await loadingTask.destroy();
   });
 
-  it("renders to canvas with a default white background", function (done) {
+  it("renders to canvas with a default white background", async function () {
     const viewport = page.getViewport({ scale: 1 });
     const canvasAndCtx = CanvasFactory.create(viewport.width, viewport.height);
 
@@ -64,21 +58,18 @@ describe("custom canvas rendering", function () {
       canvasContext: canvasAndCtx.context,
       viewport,
     });
-    renderTask.promise
-      .then(function () {
-        expect(getTopLeftPixel(canvasAndCtx.context)).toEqual({
-          r: 255,
-          g: 255,
-          b: 255,
-          a: 255,
-        });
-        CanvasFactory.destroy(canvasAndCtx);
-        done();
-      })
-      .catch(done.fail);
+    await renderTask.promise;
+
+    expect(getTopLeftPixel(canvasAndCtx.context)).toEqual({
+      r: 255,
+      g: 255,
+      b: 255,
+      a: 255,
+    });
+    CanvasFactory.destroy(canvasAndCtx);
   });
 
-  it("renders to canvas with a custom background", function (done) {
+  it("renders to canvas with a custom background", async function () {
     const viewport = page.getViewport({ scale: 1 });
     const canvasAndCtx = CanvasFactory.create(viewport.width, viewport.height);
 
@@ -87,18 +78,15 @@ describe("custom canvas rendering", function () {
       viewport,
       background: "rgba(255,0,0,1.0)",
     });
-    renderTask.promise
-      .then(function () {
-        expect(getTopLeftPixel(canvasAndCtx.context)).toEqual({
-          r: 255,
-          g: 0,
-          b: 0,
-          a: 255,
-        });
-        CanvasFactory.destroy(canvasAndCtx);
-        done();
-      })
-      .catch(done.fail);
+    await renderTask.promise;
+
+    expect(getTopLeftPixel(canvasAndCtx.context)).toEqual({
+      r: 255,
+      g: 0,
+      b: 0,
+      a: 255,
+    });
+    CanvasFactory.destroy(canvasAndCtx);
   });
 });
 

--- a/test/unit/fetch_stream_spec.js
+++ b/test/unit/fetch_stream_spec.js
@@ -20,7 +20,7 @@ describe("fetch_stream", function () {
   const pdfUrl = new URL("../pdfs/tracemonkey.pdf", window.location).href;
   const pdfLength = 1016315;
 
-  it("read with streaming", function (done) {
+  it("read with streaming", async function () {
     const stream = new PDFFetchStream({
       url: pdfUrl,
       disableStream: false,
@@ -47,18 +47,14 @@ describe("fetch_stream", function () {
       });
     };
 
-    const readPromise = Promise.all([read(), promise]);
-    readPromise
-      .then(function () {
-        expect(len).toEqual(pdfLength);
-        expect(isStreamingSupported).toEqual(true);
-        expect(isRangeSupported).toEqual(false);
-        done();
-      })
-      .catch(done.fail);
+    await Promise.all([read(), promise]);
+
+    expect(len).toEqual(pdfLength);
+    expect(isStreamingSupported).toEqual(true);
+    expect(isRangeSupported).toEqual(false);
   });
 
-  it("read ranges with streaming", function (done) {
+  it("read ranges with streaming", async function () {
     const rangeSize = 32768;
     const stream = new PDFFetchStream({
       url: pdfUrl,
@@ -98,20 +94,16 @@ describe("fetch_stream", function () {
       });
     };
 
-    const readPromise = Promise.all([
+    await Promise.all([
       read(rangeReader1, result1),
       read(rangeReader2, result2),
       promise,
     ]);
-    readPromise
-      .then(function () {
-        expect(isStreamingSupported).toEqual(true);
-        expect(isRangeSupported).toEqual(true);
-        expect(fullReaderCancelled).toEqual(true);
-        expect(result1.value).toEqual(rangeSize);
-        expect(result2.value).toEqual(tailSize);
-        done();
-      })
-      .catch(done.fail);
+
+    expect(isStreamingSupported).toEqual(true);
+    expect(isRangeSupported).toEqual(true);
+    expect(fullReaderCancelled).toEqual(true);
+    expect(result1.value).toEqual(rangeSize);
+    expect(result2.value).toEqual(tailSize);
   });
 });

--- a/test/unit/network_spec.js
+++ b/test/unit/network_spec.js
@@ -20,7 +20,7 @@ describe("network", function () {
   const pdf1 = new URL("../pdfs/tracemonkey.pdf", window.location).href;
   const pdf1Length = 1016315;
 
-  it("read without stream and range", function (done) {
+  it("read without stream and range", async function () {
     const stream = new PDFNetworkStream({
       url: pdf1,
       rangeChunkSize: 65536,
@@ -49,22 +49,15 @@ describe("network", function () {
       });
     };
 
-    const readPromise = Promise.all([read(), promise]);
+    await Promise.all([read(), promise]);
 
-    readPromise
-      .then(function (page) {
-        expect(len).toEqual(pdf1Length);
-        expect(count).toEqual(1);
-        expect(isStreamingSupported).toEqual(false);
-        expect(isRangeSupported).toEqual(false);
-        done();
-      })
-      .catch(function (reason) {
-        done.fail(reason);
-      });
+    expect(len).toEqual(pdf1Length);
+    expect(count).toEqual(1);
+    expect(isStreamingSupported).toEqual(false);
+    expect(isRangeSupported).toEqual(false);
   });
 
-  it("read custom ranges", function (done) {
+  it("read custom ranges", async function () {
     // We don't test on browsers that don't support range request, so
     // requiring this test to pass.
     const rangeSize = 32768;
@@ -111,23 +104,16 @@ describe("network", function () {
       });
     };
 
-    const readPromises = Promise.all([
+    await Promise.all([
       read(range1Reader, result1),
       read(range2Reader, result2),
       promise,
     ]);
 
-    readPromises
-      .then(function () {
-        expect(result1.value).toEqual(rangeSize);
-        expect(result2.value).toEqual(tailSize);
-        expect(isStreamingSupported).toEqual(false);
-        expect(isRangeSupported).toEqual(true);
-        expect(fullReaderCancelled).toEqual(true);
-        done();
-      })
-      .catch(function (reason) {
-        done.fail(reason);
-      });
+    expect(result1.value).toEqual(rangeSize);
+    expect(result2.value).toEqual(tailSize);
+    expect(isStreamingSupported).toEqual(false);
+    expect(isRangeSupported).toEqual(true);
+    expect(fullReaderCancelled).toEqual(true);
   });
 });

--- a/test/unit/node_stream_spec.js
+++ b/test/unit/node_stream_spec.js
@@ -18,7 +18,7 @@ import { AbortException } from "../../src/shared/util.js";
 import { isNodeJS } from "../../src/shared/is_node.js";
 import { PDFNodeStream } from "../../src/display/node_stream.js";
 
-// Ensure that these test only runs in Node.js environments.
+// Ensure that these tests only run in Node.js environments.
 if (!isNodeJS) {
   throw new Error(
     'The "node_stream" unit-tests can only be run in Node.js environments.'
@@ -84,7 +84,7 @@ describe("node_stream", function () {
     server.close();
   });
 
-  it("read both http(s) and filesystem pdf files", function (done) {
+  it("read both http(s) and filesystem pdf files", async function () {
     const stream1 = new PDFNodeStream({
       url: `http://127.0.0.1:${port}/tracemonkey.pdf`,
       rangeChunkSize: 65536,
@@ -135,23 +135,17 @@ describe("node_stream", function () {
       });
     };
 
-    const readPromise = Promise.all([read1(), read2(), promise1, promise2]);
-    readPromise
-      .then(result => {
-        expect(isStreamingSupported1).toEqual(false);
-        expect(isRangeSupported1).toEqual(false);
-        expect(isStreamingSupported2).toEqual(false);
-        expect(isRangeSupported2).toEqual(false);
-        expect(len1).toEqual(pdfLength);
-        expect(len1).toEqual(len2);
-        done();
-      })
-      .catch(reason => {
-        done.fail(reason);
-      });
+    await Promise.all([read1(), read2(), promise1, promise2]);
+
+    expect(isStreamingSupported1).toEqual(false);
+    expect(isRangeSupported1).toEqual(false);
+    expect(isStreamingSupported2).toEqual(false);
+    expect(isRangeSupported2).toEqual(false);
+    expect(len1).toEqual(pdfLength);
+    expect(len1).toEqual(len2);
   });
 
-  it("read custom ranges for both http(s) and filesystem urls", function (done) {
+  it("read custom ranges for both http(s) and filesystem urls", async function () {
     const rangeSize = 32768;
     const stream1 = new PDFNodeStream({
       url: `http://127.0.0.1:${port}/tracemonkey.pdf`,
@@ -225,7 +219,7 @@ describe("node_stream", function () {
       });
     };
 
-    const readPromises = Promise.all([
+    await Promise.all([
       read(range11Reader, result11),
       read(range12Reader, result12),
       read(range21Reader, result21),
@@ -234,22 +228,15 @@ describe("node_stream", function () {
       promise2,
     ]);
 
-    readPromises
-      .then(function () {
-        expect(result11.value).toEqual(rangeSize);
-        expect(result12.value).toEqual(tailSize);
-        expect(result21.value).toEqual(rangeSize);
-        expect(result22.value).toEqual(tailSize);
-        expect(isStreamingSupported1).toEqual(false);
-        expect(isRangeSupported1).toEqual(true);
-        expect(fullReaderCancelled1).toEqual(true);
-        expect(isStreamingSupported2).toEqual(false);
-        expect(isRangeSupported2).toEqual(true);
-        expect(fullReaderCancelled2).toEqual(true);
-        done();
-      })
-      .catch(function (reason) {
-        done.fail(reason);
-      });
+    expect(result11.value).toEqual(rangeSize);
+    expect(result12.value).toEqual(tailSize);
+    expect(result21.value).toEqual(rangeSize);
+    expect(result22.value).toEqual(tailSize);
+    expect(isStreamingSupported1).toEqual(false);
+    expect(isRangeSupported1).toEqual(true);
+    expect(fullReaderCancelled1).toEqual(true);
+    expect(isStreamingSupported2).toEqual(false);
+    expect(isRangeSupported2).toEqual(true);
+    expect(fullReaderCancelled2).toEqual(true);
   });
 });

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -169,40 +169,28 @@ describe("primitives", function () {
       ).toEqual(testFontFile);
     });
 
-    it("should asynchronously fetch unknown keys", function (done) {
+    it("should asynchronously fetch unknown keys", async function () {
       const keyPromises = [
         dictWithManyKeys.getAsync("Size"),
         dictWithSizeKey.getAsync("FontFile", "FontFile2", "FontFile3"),
       ];
 
-      Promise.all(keyPromises)
-        .then(function (values) {
-          expect(values[0]).toBeUndefined();
-          expect(values[1]).toBeUndefined();
-          done();
-        })
-        .catch(function (reason) {
-          done.fail(reason);
-        });
+      const values = await Promise.all(keyPromises);
+      expect(values[0]).toBeUndefined();
+      expect(values[1]).toBeUndefined();
     });
 
-    it("should asynchronously fetch correct values for multiple stored keys", function (done) {
+    it("should asynchronously fetch correct values for multiple stored keys", async function () {
       const keyPromises = [
         dictWithManyKeys.getAsync("FontFile3"),
         dictWithManyKeys.getAsync("FontFile2", "FontFile3"),
         dictWithManyKeys.getAsync("FontFile", "FontFile2", "FontFile3"),
       ];
 
-      Promise.all(keyPromises)
-        .then(function (values) {
-          expect(values[0]).toEqual(testFontFile3);
-          expect(values[1]).toEqual(testFontFile2);
-          expect(values[2]).toEqual(testFontFile);
-          done();
-        })
-        .catch(function (reason) {
-          done.fail(reason);
-        });
+      const values = await Promise.all(keyPromises);
+      expect(values[0]).toEqual(testFontFile3);
+      expect(values[1]).toEqual(testFontFile2);
+      expect(values[2]).toEqual(testFontFile);
     });
 
     it("should callback for each stored key", function () {
@@ -218,7 +206,7 @@ describe("primitives", function () {
       expect(callbackSpyCalls.count()).toEqual(3);
     });
 
-    it("should handle keys pointing to indirect objects, both sync and async", function (done) {
+    it("should handle keys pointing to indirect objects, both sync and async", async function () {
       const fontRef = Ref.get(1, 0);
       const xref = new XRefMock([{ ref: fontRef, data: testFontFile }]);
       const fontDict = new Dict(xref);
@@ -229,15 +217,12 @@ describe("primitives", function () {
         testFontFile
       );
 
-      fontDict
-        .getAsync("FontFile", "FontFile2", "FontFile3")
-        .then(function (value) {
-          expect(value).toEqual(testFontFile);
-          done();
-        })
-        .catch(function (reason) {
-          done.fail(reason);
-        });
+      const value = await fontDict.getAsync(
+        "FontFile",
+        "FontFile2",
+        "FontFile3"
+      );
+      expect(value).toEqual(testFontFile);
     });
 
     it("should handle arrays containing indirect objects", function () {

--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -178,9 +178,9 @@ describe("ui_utils", function () {
       expect(onceCount).toEqual(1);
     });
 
-    it("should not re-dispatch to DOM", function (done) {
+    it("should not re-dispatch to DOM", async function () {
       if (isNodeJS) {
-        pending("Document in not supported in Node.js.");
+        pending("Document is not supported in Node.js.");
       }
       const eventBus = new EventBus();
       let count = 0;
@@ -189,18 +189,17 @@ describe("ui_utils", function () {
         count++;
       });
       function domEventListener() {
-        done.fail("shall not dispatch DOM event.");
+        // Shouldn't get here.
+        expect(false).toEqual(true);
       }
       document.addEventListener("test", domEventListener);
 
       eventBus.dispatch("test");
 
-      Promise.resolve().then(() => {
-        expect(count).toEqual(1);
+      await Promise.resolve();
+      expect(count).toEqual(1);
 
-        document.removeEventListener("test", domEventListener);
-        done();
-      });
+      document.removeEventListener("test", domEventListener);
     });
   });
 
@@ -265,13 +264,14 @@ describe("ui_utils", function () {
       eventBus = null;
     });
 
-    it("should reject invalid parameters", function (done) {
+    it("should reject invalid parameters", async function () {
       const invalidTarget = waitOnEventOrTimeout({
         target: "window",
         name: "DOMContentLoaded",
       }).then(
         function () {
-          throw new Error("Should reject invalid parameters.");
+          // Shouldn't get here.
+          expect(false).toEqual(true);
         },
         function (reason) {
           expect(reason instanceof Error).toEqual(true);
@@ -283,7 +283,8 @@ describe("ui_utils", function () {
         name: "",
       }).then(
         function () {
-          throw new Error("Should reject invalid parameters.");
+          // Shouldn't get here.
+          expect(false).toEqual(true);
         },
         function (reason) {
           expect(reason instanceof Error).toEqual(true);
@@ -296,22 +297,20 @@ describe("ui_utils", function () {
         delay: -1000,
       }).then(
         function () {
-          throw new Error("Should reject invalid parameters.");
+          // Shouldn't get here.
+          expect(false).toEqual(true);
         },
         function (reason) {
           expect(reason instanceof Error).toEqual(true);
         }
       );
 
-      Promise.all([invalidTarget, invalidName, invalidDelay]).then(
-        done,
-        done.fail
-      );
+      await Promise.all([invalidTarget, invalidName, invalidDelay]);
     });
 
-    it("should resolve on event, using the DOM", function (done) {
+    it("should resolve on event, using the DOM", async function () {
       if (isNodeJS) {
-        pending("Document in not supported in Node.js.");
+        pending("Document is not supported in Node.js.");
       }
       const button = document.createElement("button");
 
@@ -323,15 +322,13 @@ describe("ui_utils", function () {
       // Immediately dispatch the expected event.
       button.click();
 
-      buttonClicked.then(function (type) {
-        expect(type).toEqual(WaitOnType.EVENT);
-        done();
-      }, done.fail);
+      const type = await buttonClicked;
+      expect(type).toEqual(WaitOnType.EVENT);
     });
 
-    it("should resolve on timeout, using the DOM", function (done) {
+    it("should resolve on timeout, using the DOM", async function () {
       if (isNodeJS) {
-        pending("Document in not supported in Node.js.");
+        pending("Document is not supported in Node.js.");
       }
       const button = document.createElement("button");
 
@@ -342,13 +339,11 @@ describe("ui_utils", function () {
       });
       // Do *not* dispatch the event, and wait for the timeout.
 
-      buttonClicked.then(function (type) {
-        expect(type).toEqual(WaitOnType.TIMEOUT);
-        done();
-      }, done.fail);
+      const type = await buttonClicked;
+      expect(type).toEqual(WaitOnType.TIMEOUT);
     });
 
-    it("should resolve on event, using the EventBus", function (done) {
+    it("should resolve on event, using the EventBus", async function () {
       const pageRendered = waitOnEventOrTimeout({
         target: eventBus,
         name: "pagerendered",
@@ -357,13 +352,11 @@ describe("ui_utils", function () {
       // Immediately dispatch the expected event.
       eventBus.dispatch("pagerendered");
 
-      pageRendered.then(function (type) {
-        expect(type).toEqual(WaitOnType.EVENT);
-        done();
-      }, done.fail);
+      const type = await pageRendered;
+      expect(type).toEqual(WaitOnType.EVENT);
     });
 
-    it("should resolve on timeout, using the EventBus", function (done) {
+    it("should resolve on timeout, using the EventBus", async function () {
       const pageRendered = waitOnEventOrTimeout({
         target: eventBus,
         name: "pagerendered",
@@ -371,10 +364,8 @@ describe("ui_utils", function () {
       });
       // Do *not* dispatch the event, and wait for the timeout.
 
-      pageRendered.then(function (type) {
-        expect(type).toEqual(WaitOnType.TIMEOUT);
-        done();
-      }, done.fail);
+      const type = await pageRendered;
+      expect(type).toEqual(WaitOnType.TIMEOUT);
     });
   });
 

--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -289,33 +289,33 @@ describe("util", function () {
   });
 
   describe("createPromiseCapability", function () {
-    it("should resolve with correct data", function (done) {
+    it("should resolve with correct data", async function () {
       const promiseCapability = createPromiseCapability();
       expect(promiseCapability.settled).toEqual(false);
 
       promiseCapability.resolve({ test: "abc" });
 
-      promiseCapability.promise.then(function (data) {
-        expect(promiseCapability.settled).toEqual(true);
-
-        expect(data).toEqual({ test: "abc" });
-        done();
-      }, done.fail);
+      const data = await promiseCapability.promise;
+      expect(promiseCapability.settled).toEqual(true);
+      expect(data).toEqual({ test: "abc" });
     });
 
-    it("should reject with correct reason", function (done) {
+    it("should reject with correct reason", async function () {
       const promiseCapability = createPromiseCapability();
       expect(promiseCapability.settled).toEqual(false);
 
       promiseCapability.reject(new Error("reason"));
 
-      promiseCapability.promise.then(done.fail, function (reason) {
-        expect(promiseCapability.settled).toEqual(true);
+      try {
+        await promiseCapability.promise;
 
+        // Shouldn't get here.
+        expect(false).toEqual(true);
+      } catch (reason) {
+        expect(promiseCapability.settled).toEqual(true);
         expect(reason instanceof Error).toEqual(true);
         expect(reason.message).toEqual("reason");
-        done();
-      });
+      }
     });
   });
 


### PR DESCRIPTION
This commit series is the next step (after PR #13216) in getting rid of the outdated done callbacks by converting to async/await instead. Not using callbacks and having less indentation/code makes the overall code a bit easier to read. I have purposely done the smaller files first to make it easier to review.