### PR TITLE
Remove the unused "GetIsPureXfa" message handler; and avoid unnecessary parsing when no structTree is available (PR 13069 follow-up, PR 13221 follow-up)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -454,7 +454,13 @@ class Page {
     const structTreeRoot = await this.pdfManager.ensureCatalog(
       "structTreeRoot"
     );
-    return this.pdfManager.ensure(this, "_parseStructTree", [structTreeRoot]);
+    if (!structTreeRoot) {
+      return null;
+    }
+    const structTree = await this.pdfManager.ensure(this, "_parseStructTree", [
+      structTreeRoot,
+    ]);
+    return structTree.serializable;
   }
 
   /**

--- a/src/core/struct_tree.js
+++ b/src/core/struct_tree.js
@@ -328,10 +328,6 @@ class StructTreePage {
       }
       nodeToSerializable(child, root);
     }
-
-    if (root.children.length === 0) {
-      return null;
-    }
     return root;
   }
 }

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -497,10 +497,6 @@ class WorkerMessageHandler {
       });
     });
 
-    handler.on("GetIsPureXfa", function wphSetupGetIsPureXfa(data) {
-      return pdfManager.ensureDoc("isPureXfa");
-    });
-
     handler.on("GetOutline", function wphSetupGetOutline(data) {
       return pdfManager.ensureCatalog("documentOutline");
     });

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -743,15 +743,9 @@ class WorkerMessageHandler {
     });
 
     handler.on("GetStructTree", function wphGetStructTree(data) {
-      const pageIndex = data.pageIndex;
-      return pdfManager
-        .getPage(pageIndex)
-        .then(function (page) {
-          return pdfManager.ensure(page, "getStructTree");
-        })
-        .then(function (structTree) {
-          return structTree.serializable;
-        });
+      return pdfManager.getPage(data.pageIndex).then(function (page) {
+        return pdfManager.ensure(page, "getStructTree");
+      });
     });
 
     handler.on("FontFallback", function (data) {

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -487,7 +487,7 @@ class WorkerMessageHandler {
 
     handler.on("GetPageJSActions", function ({ pageIndex }) {
       return pdfManager.getPage(pageIndex).then(function (page) {
-        return page.jsActions;
+        return pdfManager.ensure(page, "jsActions");
       });
     });
 


### PR DESCRIPTION
 - Remove the unused "GetIsPureXfa" message handler in the worker (PR 13069 follow-up)

   Looking at the API, there's no code which actually sends this message. Most likely it's a left-over from a previous version of PR 13069, since the `isPureXfa` parameter is being included in the "GetDoc" message.

 - Avoid unnecessary parsing, in `Page.GetStructTree`, when no structTree is available (PR 13221 follow-up)

   It's obviously (a bit) more efficient to return early in `Page.getStructTree`, rather than trying to first "parse" an *empty* structTree-root.

   *Somehow I didn't think of this yesterday, but this feels like a much better solution overall; sorry about the churn here!*

