### PR TITLE
Fixes recent Safari TextWidgetAnnotation regression causing #13191 and #12592, ...

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -668,7 +668,6 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
         if (elementData.formattedValue) {
           event.target.value = elementData.formattedValue;
         }
-        event.target.setSelectionRange(0, 0);
         elementData.beforeInputSelectionRange = null;
       };
 


### PR DESCRIPTION
https://github.com/mozilla/pdf.js/commit/44b24fcc2936e1d75c249aa161970ab8fa83e4d2 causes issues on Safari (see #12592 and #13191). Just removing the `event.target.setSelection(0, 0);`  line fixes the issues and no difference / regression in behavior was observed without the `event.target.setSelection(0, 0);` bit in other browsers (including Firefox). The blur (switching focus out of the control) does effectively achieve the same thing in all browsers I have tested on.

Tested specifically in Firefox with

1. inspect a `TextWidgetAnnotation` `input` element
2. `$0.setSelectionRange = (a, b) => console.warn(a, b);`
3. type `wow` and select `wow` in the input element
4. click/tab/tap outside the input element
5. <kbd>CTRL</kbd> + <kbd>C</kbd> ➡ no `wow` ✔ copied
6. <kbd>CTRL</kbd> + <kbd>V</kbd> ➡ confirmed