### PR TITLE
Fix annotation input focus trap regression in Safari

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -668,6 +668,7 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
         if (elementData.formattedValue) {
           event.target.value = elementData.formattedValue;
         }
+        // Reset the cursor position to the start of the field (issue 12359).
         event.target.scrollLeft = 0;
         elementData.beforeInputSelectionRange = null;
       };

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -667,6 +667,7 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
       let blurListener = event => {
         if (elementData.formattedValue) {
           event.target.value = elementData.formattedValue;
+          event.target.scrollLeft = 0;
         }
         elementData.beforeInputSelectionRange = null;
       };

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -668,7 +668,6 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
         if (elementData.formattedValue) {
           event.target.value = elementData.formattedValue;
         }
-        event.target.setSelectionRange(0, 0);
         elementData.beforeInputSelectionRange = null;
       };
 

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -667,8 +667,8 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
       let blurListener = event => {
         if (elementData.formattedValue) {
           event.target.value = elementData.formattedValue;
-          event.target.scrollLeft = 0;
         }
+        event.target.scrollLeft = 0;
         elementData.beforeInputSelectionRange = null;
       };
 


### PR DESCRIPTION
`setSelectionRange(0, 0)` added in https://github.com/mozilla/pdf.js/commit/44b24fcc2936e1d75c249aa161970ab8fa83e4d2 for #12359, required only by Firefox ([bug](https://bugzilla.mozilla.org/show_bug.cgi?id=860329)), causes issues mozilla#13191, mozilla#12592 in Safari.
`scrollLeft = 0` is a fix that breaks the focus trap in Safari while **keeping Firefox behavior same for #12359**.

@calixteman 