### PR TITLE
Update the `es-module-shims` package to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5751,9 +5751,9 @@
       "dev": true
     },
     "es-module-shims": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-0.6.0.tgz",
-      "integrity": "sha512-KbhvFoMD5r51T/aAwQODUHns0gerLYoWlWRWVxkMCg1tT2NV7ut70xuWKtG4ztZEXGuEjPrOzmOFQX0gpHbHUQ==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-0.10.4.tgz",
+      "integrity": "sha512-tkmdigmgPVUWp1+psYM5gwBVhsgynU7v8CHpg74BmXSz+sXwAE42AdJahcoIkQPIUXhErX+BISAsW3chrFSCnQ==",
       "dev": true
     },
     "es-to-primitive": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "canvas": "^2.7.0",
     "core-js": "^3.10.0",
     "cross-env": "^7.0.3",
-    "es-module-shims": "^0.6.0",
+    "es-module-shims": "^0.10.4",
     "escodegen": "^2.0.0",
     "eslint": "^7.23.0",
     "eslint-config-prettier": "^6.15.0",


### PR DESCRIPTION
Beside the unit/font-test suites, this is primarily used in the development viewer (i.e. `gulp server`).

https://www.npmjs.com/package/es-module-shims