### PR TITLE
Convert done callbacks to async/await in more unit test files

### DIFF
--- a/test/unit/annotation_storage_spec.js
+++ b/test/unit/annotation_storage_spec.js
@@ -17,7 +17,7 @@ import { AnnotationStorage } from "../../src/display/annotation_storage.js";
 
 describe("AnnotationStorage", function () {
   describe("GetOrDefaultValue", function () {
-    it("should get and set a new value in the annotation storage", function (done) {
+    it("should get and set a new value in the annotation storage", function () {
       const annotationStorage = new AnnotationStorage();
       let value = annotationStorage.getValue("123A", {
         value: "hello world",
@@ -34,20 +34,18 @@ describe("AnnotationStorage", function () {
         value: "an other string",
       }).value;
       expect(value).toEqual("hello world");
-      done();
     });
   });
 
   describe("SetValue", function () {
-    it("should set a new value in the annotation storage", function (done) {
+    it("should set a new value in the annotation storage", function () {
       const annotationStorage = new AnnotationStorage();
       annotationStorage.setValue("123A", { value: "an other string" });
       const value = annotationStorage.getAll()["123A"].value;
       expect(value).toEqual("an other string");
-      done();
     });
 
-    it("should call onSetModified() if value is changed", function (done) {
+    it("should call onSetModified() if value is changed", function () {
       const annotationStorage = new AnnotationStorage();
       let called = false;
       const callback = function () {
@@ -66,12 +64,11 @@ describe("AnnotationStorage", function () {
       called = false;
       annotationStorage.setValue("asdf", { value: "modified" });
       expect(called).toBe(false);
-      done();
     });
   });
 
   describe("ResetModified", function () {
-    it("should call onResetModified() if set", function (done) {
+    it("should call onResetModified() if set", function () {
       const annotationStorage = new AnnotationStorage();
       let called = false;
       const callback = function () {
@@ -92,7 +89,6 @@ describe("AnnotationStorage", function () {
       annotationStorage.setValue("asdf", { value: "modified" });
       annotationStorage.resetModified();
       expect(called).toBe(true);
-      done();
     });
   });
 });

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -40,305 +40,218 @@ describe("cmap", function () {
     fetchBuiltInCMap = null;
   });
 
-  it("parses beginbfchar", function (done) {
+  it("parses beginbfchar", async function () {
     // prettier-ignore
     const str = "2 beginbfchar\n" +
               "<03> <00>\n" +
               "<04> <01>\n" +
               "endbfchar\n";
     const stream = new StringStream(str);
-    const cmapPromise = CMapFactory.create({ encoding: stream });
-    cmapPromise
-      .then(function (cmap) {
-        expect(cmap.lookup(0x03)).toEqual(String.fromCharCode(0x00));
-        expect(cmap.lookup(0x04)).toEqual(String.fromCharCode(0x01));
-        expect(cmap.lookup(0x05)).toBeUndefined();
-        done();
-      })
-      .catch(function (reason) {
-        done.fail(reason);
-      });
+    const cmap = await CMapFactory.create({ encoding: stream });
+    expect(cmap.lookup(0x03)).toEqual(String.fromCharCode(0x00));
+    expect(cmap.lookup(0x04)).toEqual(String.fromCharCode(0x01));
+    expect(cmap.lookup(0x05)).toBeUndefined();
   });
-  it("parses beginbfrange with range", function (done) {
+
+  it("parses beginbfrange with range", async function () {
     // prettier-ignore
     const str = "1 beginbfrange\n" +
               "<06> <0B> 0\n" +
               "endbfrange\n";
     const stream = new StringStream(str);
-    const cmapPromise = CMapFactory.create({ encoding: stream });
-    cmapPromise
-      .then(function (cmap) {
-        expect(cmap.lookup(0x05)).toBeUndefined();
-        expect(cmap.lookup(0x06)).toEqual(String.fromCharCode(0x00));
-        expect(cmap.lookup(0x0b)).toEqual(String.fromCharCode(0x05));
-        expect(cmap.lookup(0x0c)).toBeUndefined();
-        done();
-      })
-      .catch(function (reason) {
-        done.fail(reason);
-      });
+    const cmap = await CMapFactory.create({ encoding: stream });
+    expect(cmap.lookup(0x05)).toBeUndefined();
+    expect(cmap.lookup(0x06)).toEqual(String.fromCharCode(0x00));
+    expect(cmap.lookup(0x0b)).toEqual(String.fromCharCode(0x05));
+    expect(cmap.lookup(0x0c)).toBeUndefined();
   });
-  it("parses beginbfrange with array", function (done) {
+
+  it("parses beginbfrange with array", async function () {
     // prettier-ignore
     const str = "1 beginbfrange\n" +
               "<0D> <12> [ 0 1 2 3 4 5 ]\n" +
               "endbfrange\n";
     const stream = new StringStream(str);
-    const cmapPromise = CMapFactory.create({ encoding: stream });
-    cmapPromise
-      .then(function (cmap) {
-        expect(cmap.lookup(0x0c)).toBeUndefined();
-        expect(cmap.lookup(0x0d)).toEqual(0x00);
-        expect(cmap.lookup(0x12)).toEqual(0x05);
-        expect(cmap.lookup(0x13)).toBeUndefined();
-        done();
-      })
-      .catch(function (reason) {
-        done.fail(reason);
-      });
+    const cmap = await CMapFactory.create({ encoding: stream });
+    expect(cmap.lookup(0x0c)).toBeUndefined();
+    expect(cmap.lookup(0x0d)).toEqual(0x00);
+    expect(cmap.lookup(0x12)).toEqual(0x05);
+    expect(cmap.lookup(0x13)).toBeUndefined();
   });
-  it("parses begincidchar", function (done) {
+
+  it("parses begincidchar", async function () {
     // prettier-ignore
     const str = "1 begincidchar\n" +
               "<14> 0\n" +
               "endcidchar\n";
     const stream = new StringStream(str);
-    const cmapPromise = CMapFactory.create({ encoding: stream });
-    cmapPromise
-      .then(function (cmap) {
-        expect(cmap.lookup(0x14)).toEqual(0x00);
-        expect(cmap.lookup(0x15)).toBeUndefined();
-        done();
-      })
-      .catch(function (reason) {
-        done.fail(reason);
-      });
+    const cmap = await CMapFactory.create({ encoding: stream });
+    expect(cmap.lookup(0x14)).toEqual(0x00);
+    expect(cmap.lookup(0x15)).toBeUndefined();
   });
-  it("parses begincidrange", function (done) {
+
+  it("parses begincidrange", async function () {
     // prettier-ignore
     const str = "1 begincidrange\n" +
               "<0016> <001B>   0\n" +
               "endcidrange\n";
     const stream = new StringStream(str);
-    const cmapPromise = CMapFactory.create({ encoding: stream });
-    cmapPromise
-      .then(function (cmap) {
-        expect(cmap.lookup(0x15)).toBeUndefined();
-        expect(cmap.lookup(0x16)).toEqual(0x00);
-        expect(cmap.lookup(0x1b)).toEqual(0x05);
-        expect(cmap.lookup(0x1c)).toBeUndefined();
-        done();
-      })
-      .catch(function (reason) {
-        done.fail(reason);
-      });
+    const cmap = await CMapFactory.create({ encoding: stream });
+    expect(cmap.lookup(0x15)).toBeUndefined();
+    expect(cmap.lookup(0x16)).toEqual(0x00);
+    expect(cmap.lookup(0x1b)).toEqual(0x05);
+    expect(cmap.lookup(0x1c)).toBeUndefined();
   });
-  it("decodes codespace ranges", function (done) {
+
+  it("decodes codespace ranges", async function () {
     // prettier-ignore
     const str = "1 begincodespacerange\n" +
               "<01> <02>\n" +
               "<00000003> <00000004>\n" +
               "endcodespacerange\n";
     const stream = new StringStream(str);
-    const cmapPromise = CMapFactory.create({ encoding: stream });
-    cmapPromise
-      .then(function (cmap) {
-        const c = {};
-        cmap.readCharCode(String.fromCharCode(1), 0, c);
-        expect(c.charcode).toEqual(1);
-        expect(c.length).toEqual(1);
-        cmap.readCharCode(String.fromCharCode(0, 0, 0, 3), 0, c);
-        expect(c.charcode).toEqual(3);
-        expect(c.length).toEqual(4);
-        done();
-      })
-      .catch(function (reason) {
-        done.fail(reason);
-      });
+    const cmap = await CMapFactory.create({ encoding: stream });
+    const c = {};
+    cmap.readCharCode(String.fromCharCode(1), 0, c);
+    expect(c.charcode).toEqual(1);
+    expect(c.length).toEqual(1);
+    cmap.readCharCode(String.fromCharCode(0, 0, 0, 3), 0, c);
+    expect(c.charcode).toEqual(3);
+    expect(c.length).toEqual(4);
   });
-  it("decodes 4 byte codespace ranges", function (done) {
+
+  it("decodes 4 byte codespace ranges", async function () {
     // prettier-ignore
     const str = "1 begincodespacerange\n" +
               "<8EA1A1A1> <8EA1FEFE>\n" +
               "endcodespacerange\n";
     const stream = new StringStream(str);
-    const cmapPromise = CMapFactory.create({ encoding: stream });
-    cmapPromise
-      .then(function (cmap) {
-        const c = {};
-        cmap.readCharCode(String.fromCharCode(0x8e, 0xa1, 0xa1, 0xa1), 0, c);
-        expect(c.charcode).toEqual(0x8ea1a1a1);
-        expect(c.length).toEqual(4);
-        done();
-      })
-      .catch(function (reason) {
-        done.fail(reason);
-      });
+    const cmap = await CMapFactory.create({ encoding: stream });
+    const c = {};
+    cmap.readCharCode(String.fromCharCode(0x8e, 0xa1, 0xa1, 0xa1), 0, c);
+    expect(c.charcode).toEqual(0x8ea1a1a1);
+    expect(c.length).toEqual(4);
   });
-  it("read usecmap", function (done) {
+
+  it("read usecmap", async function () {
     const str = "/Adobe-Japan1-1 usecmap\n";
     const stream = new StringStream(str);
-    const cmapPromise = CMapFactory.create({
+    const cmap = await CMapFactory.create({
       encoding: stream,
       fetchBuiltInCMap,
       useCMap: null,
     });
-    cmapPromise
-      .then(function (cmap) {
-        expect(cmap instanceof CMap).toEqual(true);
-        expect(cmap.useCMap).not.toBeNull();
-        expect(cmap.builtInCMap).toBeFalsy();
-        expect(cmap.length).toEqual(0x20a7);
-        expect(cmap.isIdentityCMap).toEqual(false);
-        done();
-      })
-      .catch(function (reason) {
-        done.fail(reason);
-      });
+    expect(cmap instanceof CMap).toEqual(true);
+    expect(cmap.useCMap).not.toBeNull();
+    expect(cmap.builtInCMap).toBeFalsy();
+    expect(cmap.length).toEqual(0x20a7);
+    expect(cmap.isIdentityCMap).toEqual(false);
   });
-  it("parses cmapname", function (done) {
+
+  it("parses cmapname", async function () {
     const str = "/CMapName /Identity-H def\n";
     const stream = new StringStream(str);
-    const cmapPromise = CMapFactory.create({ encoding: stream });
-    cmapPromise
-      .then(function (cmap) {
-        expect(cmap.name).toEqual("Identity-H");
-        done();
-      })
-      .catch(function (reason) {
-        done.fail(reason);
-      });
+    const cmap = await CMapFactory.create({ encoding: stream });
+    expect(cmap.name).toEqual("Identity-H");
   });
-  it("parses wmode", function (done) {
+
+  it("parses wmode", async function () {
     const str = "/WMode 1 def\n";
     const stream = new StringStream(str);
-    const cmapPromise = CMapFactory.create({ encoding: stream });
-    cmapPromise
-      .then(function (cmap) {
-        expect(cmap.vertical).toEqual(true);
-        done();
-      })
-      .catch(function (reason) {
-        done.fail(reason);
-      });
+    const cmap = await CMapFactory.create({ encoding: stream });
+    expect(cmap.vertical).toEqual(true);
   });
-  it("loads built in cmap", function (done) {
-    const cmapPromise = CMapFactory.create({
+
+  it("loads built in cmap", async function () {
+    const cmap = await CMapFactory.create({
       encoding: Name.get("Adobe-Japan1-1"),
       fetchBuiltInCMap,
       useCMap: null,
     });
-    cmapPromise
-      .then(function (cmap) {
-        expect(cmap instanceof CMap).toEqual(true);
-        expect(cmap.useCMap).toBeNull();
-        expect(cmap.builtInCMap).toBeTruthy();
-        expect(cmap.length).toEqual(0x20a7);
-        expect(cmap.isIdentityCMap).toEqual(false);
-        done();
-      })
-      .catch(function (reason) {
-        done.fail(reason);
-      });
+    expect(cmap instanceof CMap).toEqual(true);
+    expect(cmap.useCMap).toBeNull();
+    expect(cmap.builtInCMap).toBeTruthy();
+    expect(cmap.length).toEqual(0x20a7);
+    expect(cmap.isIdentityCMap).toEqual(false);
   });
-  it("loads built in identity cmap", function (done) {
-    const cmapPromise = CMapFactory.create({
+
+  it("loads built in identity cmap", async function () {
+    const cmap = await CMapFactory.create({
       encoding: Name.get("Identity-H"),
       fetchBuiltInCMap,
       useCMap: null,
     });
-    cmapPromise
-      .then(function (cmap) {
-        expect(cmap instanceof IdentityCMap).toEqual(true);
-        expect(cmap.vertical).toEqual(false);
-        expect(cmap.length).toEqual(0x10000);
-        expect(function () {
-          return cmap.isIdentityCMap;
-        }).toThrow(new Error("should not access .isIdentityCMap"));
-        done();
-      })
-      .catch(function (reason) {
-        done.fail(reason);
+    expect(cmap instanceof IdentityCMap).toEqual(true);
+    expect(cmap.vertical).toEqual(false);
+    expect(cmap.length).toEqual(0x10000);
+    expect(function () {
+      return cmap.isIdentityCMap;
+    }).toThrow(new Error("should not access .isIdentityCMap"));
+  });
+
+  it("attempts to load a non-existent built-in CMap", async function () {
+    try {
+      await CMapFactory.create({
+        encoding: Name.get("null"),
+        fetchBuiltInCMap,
+        useCMap: null,
       });
+
+      // Shouldn't get here.
+      expect(false).toEqual(true);
+    } catch (reason) {
+      expect(reason instanceof Error).toEqual(true);
+      expect(reason.message).toEqual("Unknown CMap name: null");
+    }
   });
 
-  it("attempts to load a non-existent built-in CMap", function (done) {
-    const cmapPromise = CMapFactory.create({
-      encoding: Name.get("null"),
-      fetchBuiltInCMap,
-      useCMap: null,
-    });
-    cmapPromise.then(
-      function () {
-        done.fail("No CMap should be loaded");
-      },
-      function (reason) {
-        expect(reason instanceof Error).toEqual(true);
-        expect(reason.message).toEqual("Unknown CMap name: null");
-        done();
-      }
-    );
-  });
-
-  it("attempts to load a built-in CMap without the necessary API parameters", function (done) {
+  it("attempts to load a built-in CMap without the necessary API parameters", async function () {
     function tmpFetchBuiltInCMap(name) {
       const CMapReaderFactory = new DefaultCMapReaderFactory({});
-
-      return CMapReaderFactory.fetch({
-        name,
-      });
+      return CMapReaderFactory.fetch({ name });
     }
 
-    const cmapPromise = CMapFactory.create({
-      encoding: Name.get("Adobe-Japan1-1"),
-      fetchBuiltInCMap: tmpFetchBuiltInCMap,
-      useCMap: null,
-    });
-    cmapPromise.then(
-      function () {
-        done.fail("No CMap should be loaded");
-      },
-      function (reason) {
-        expect(reason instanceof Error).toEqual(true);
-        expect(reason.message).toEqual(
-          'The CMap "baseUrl" parameter must be specified, ensure that ' +
-            'the "cMapUrl" and "cMapPacked" API parameters are provided.'
-        );
-        done();
-      }
-    );
+    try {
+      await CMapFactory.create({
+        encoding: Name.get("Adobe-Japan1-1"),
+        fetchBuiltInCMap: tmpFetchBuiltInCMap,
+        useCMap: null,
+      });
+
+      // Shouldn't get here.
+      expect(false).toEqual(true);
+    } catch (reason) {
+      expect(reason instanceof Error).toEqual(true);
+      expect(reason.message).toEqual(
+        'The CMap "baseUrl" parameter must be specified, ensure that ' +
+          'the "cMapUrl" and "cMapPacked" API parameters are provided.'
+      );
+    }
   });
 
-  it("attempts to load a built-in CMap with inconsistent API parameters", function (done) {
+  it("attempts to load a built-in CMap with inconsistent API parameters", async function () {
     function tmpFetchBuiltInCMap(name) {
       const CMapReaderFactory = new DefaultCMapReaderFactory({
         baseUrl: CMAP_PARAMS.cMapUrl,
         isCompressed: false,
       });
-
-      return CMapReaderFactory.fetch({
-        name,
-      });
+      return CMapReaderFactory.fetch({ name });
     }
 
-    const cmapPromise = CMapFactory.create({
-      encoding: Name.get("Adobe-Japan1-1"),
-      fetchBuiltInCMap: tmpFetchBuiltInCMap,
-      useCMap: null,
-    });
-    cmapPromise.then(
-      function () {
-        done.fail("No CMap should be loaded");
-      },
-      function (reason) {
-        expect(reason instanceof Error).toEqual(true);
-        const message = reason.message;
-        expect(message.startsWith("Unable to load CMap at: ")).toEqual(true);
-        expect(message.endsWith("/external/bcmaps/Adobe-Japan1-1")).toEqual(
-          true
-        );
-        done();
-      }
-    );
+    try {
+      await CMapFactory.create({
+        encoding: Name.get("Adobe-Japan1-1"),
+        fetchBuiltInCMap: tmpFetchBuiltInCMap,
+        useCMap: null,
+      });
+
+      // Shouldn't get here.
+      expect(false).toEqual(true);
+    } catch (reason) {
+      expect(reason instanceof Error).toEqual(true);
+      const message = reason.message;
+      expect(message.startsWith("Unable to load CMap at: ")).toEqual(true);
+      expect(message.endsWith("/external/bcmaps/Adobe-Japan1-1")).toEqual(true);
+    }
   });
 });

--- a/test/unit/crypto_spec.js
+++ b/test/unit/crypto_spec.js
@@ -588,43 +588,40 @@ describe("CipherTransformFactory", function () {
     return dict;
   }
 
-  function ensurePasswordCorrect(done, dict, fileId, password) {
+  function ensurePasswordCorrect(dict, fileId, password) {
     try {
       const factory = new CipherTransformFactory(dict, fileId, password);
       expect("createCipherTransform" in factory).toEqual(true);
     } catch (ex) {
-      done.fail("Password should be accepted: " + ex);
-      return;
+      // Shouldn't get here.
+      expect(false).toEqual(true);
     }
-    done();
   }
 
-  function ensurePasswordNeeded(done, dict, fileId, password) {
+  function ensurePasswordNeeded(dict, fileId, password) {
     try {
       // eslint-disable-next-line no-new
       new CipherTransformFactory(dict, fileId, password);
+
+      // Shouldn't get here.
+      expect(false).toEqual(true);
     } catch (ex) {
       expect(ex instanceof PasswordException).toEqual(true);
       expect(ex.code).toEqual(PasswordResponses.NEED_PASSWORD);
-
-      done();
-      return;
     }
-    done.fail("Password should be rejected.");
   }
 
-  function ensurePasswordIncorrect(done, dict, fileId, password) {
+  function ensurePasswordIncorrect(dict, fileId, password) {
     try {
       // eslint-disable-next-line no-new
       new CipherTransformFactory(dict, fileId, password);
+
+      // Shouldn't get here.
+      expect(false).toEqual(true);
     } catch (ex) {
       expect(ex instanceof PasswordException).toEqual(true);
       expect(ex.code).toEqual(PasswordResponses.INCORRECT_PASSWORD);
-
-      done();
-      return;
     }
-    done.fail("Password should be rejected.");
   }
 
   function ensureEncryptDecryptIsIdentity(dict, fileId, password, string) {
@@ -784,55 +781,55 @@ describe("CipherTransformFactory", function () {
 
   describe("#ctor", function () {
     describe("AES256 Revision 5", function () {
-      it("should accept user password", function (done) {
-        ensurePasswordCorrect(done, aes256Dict, fileId1, "user");
+      it("should accept user password", function () {
+        ensurePasswordCorrect(aes256Dict, fileId1, "user");
       });
-      it("should accept owner password", function (done) {
-        ensurePasswordCorrect(done, aes256Dict, fileId1, "owner");
+      it("should accept owner password", function () {
+        ensurePasswordCorrect(aes256Dict, fileId1, "owner");
       });
-      it("should not accept blank password", function (done) {
-        ensurePasswordNeeded(done, aes256Dict, fileId1);
+      it("should not accept blank password", function () {
+        ensurePasswordNeeded(aes256Dict, fileId1);
       });
-      it("should not accept wrong password", function (done) {
-        ensurePasswordIncorrect(done, aes256Dict, fileId1, "wrong");
+      it("should not accept wrong password", function () {
+        ensurePasswordIncorrect(aes256Dict, fileId1, "wrong");
       });
-      it("should accept blank password", function (done) {
-        ensurePasswordCorrect(done, aes256BlankDict, fileId1);
+      it("should accept blank password", function () {
+        ensurePasswordCorrect(aes256BlankDict, fileId1);
       });
     });
 
     describe("AES256 Revision 6", function () {
-      it("should accept user password", function (done) {
-        ensurePasswordCorrect(done, aes256IsoDict, fileId1, "user");
+      it("should accept user password", function () {
+        ensurePasswordCorrect(aes256IsoDict, fileId1, "user");
       });
-      it("should accept owner password", function (done) {
-        ensurePasswordCorrect(done, aes256IsoDict, fileId1, "owner");
+      it("should accept owner password", function () {
+        ensurePasswordCorrect(aes256IsoDict, fileId1, "owner");
       });
-      it("should not accept blank password", function (done) {
-        ensurePasswordNeeded(done, aes256IsoDict, fileId1);
+      it("should not accept blank password", function () {
+        ensurePasswordNeeded(aes256IsoDict, fileId1);
       });
-      it("should not accept wrong password", function (done) {
-        ensurePasswordIncorrect(done, aes256IsoDict, fileId1, "wrong");
+      it("should not accept wrong password", function () {
+        ensurePasswordIncorrect(aes256IsoDict, fileId1, "wrong");
       });
-      it("should accept blank password", function (done) {
-        ensurePasswordCorrect(done, aes256IsoBlankDict, fileId1);
+      it("should accept blank password", function () {
+        ensurePasswordCorrect(aes256IsoBlankDict, fileId1);
       });
     });
 
-    it("should accept user password", function (done) {
-      ensurePasswordCorrect(done, dict1, fileId1, "123456");
+    it("should accept user password", function () {
+      ensurePasswordCorrect(dict1, fileId1, "123456");
     });
-    it("should accept owner password", function (done) {
-      ensurePasswordCorrect(done, dict1, fileId1, "654321");
+    it("should accept owner password", function () {
+      ensurePasswordCorrect(dict1, fileId1, "654321");
     });
-    it("should not accept blank password", function (done) {
-      ensurePasswordNeeded(done, dict1, fileId1);
+    it("should not accept blank password", function () {
+      ensurePasswordNeeded(dict1, fileId1);
     });
-    it("should not accept wrong password", function (done) {
-      ensurePasswordIncorrect(done, dict1, fileId1, "wrong");
+    it("should not accept wrong password", function () {
+      ensurePasswordIncorrect(dict1, fileId1, "wrong");
     });
-    it("should accept blank password", function (done) {
-      ensurePasswordCorrect(done, dict2, fileId2);
+    it("should accept blank password", function () {
+      ensurePasswordCorrect(dict2, fileId2);
     });
   });
 


### PR DESCRIPTION
This is the follow-up PR after #13222 that finalizes the conversion for the smaller and medium sized unit test files. Only three unit test files remain with done callbacks after this PR, but since they are bigger they will be done in a follow-up PR.

_Using the `?w=1` parameter will help during review for most commits._