### PR TITLE
[GENERIC viewer] Don't display the `errorWrapper`, for documents with signatures (PR 13217 follow-up)

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -246,6 +246,3 @@ password_cancel=Cancel
 printing_not_supported=Warning: Printing is not fully supported by this browser.
 printing_not_ready=Warning: The PDF is not fully loaded for printing.
 web_fonts_disabled=Web fonts are disabled: unable to use embedded PDF fonts.
-# LOCALIZATION NOTE (unsupported_feature_signatures): Should contain the same
-# exact string as in the `chrome.properties` file.
-unsupported_feature_signatures=This PDF document contains digital signatures. Validation of signatures is not supported.

--- a/web/app.js
+++ b/web/app.js
@@ -1062,16 +1062,6 @@ const PDFViewerApplication = {
     }
     this._fellback = true;
 
-    // Ensure that, for signatures, a warning is shown in non-Firefox builds.
-    if (
-      (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) &&
-      featureId === UNSUPPORTED_FEATURES.signatures
-    ) {
-      this.l10n.get("unsupported_feature_signatures").then(msg => {
-        this._otherError(msg);
-      });
-    }
-
     this.externalServices
       .fallback({
         featureId,

--- a/web/app.js
+++ b/web/app.js
@@ -1048,13 +1048,6 @@ const PDFViewerApplication = {
       featureId,
     });
 
-    // Don't show the fallback bar for things that are *very* unlikely to cause
-    // user-visible errors, to avoid bothering the user unnecessarily.
-    switch (featureId) {
-      case UNSUPPORTED_FEATURES.errorFontLoadNative:
-      case UNSUPPORTED_FEATURES.errorFontMissing:
-        return;
-    }
     // Only trigger the fallback once so we don't spam the user with messages
     // for one PDF.
     if (this._fellback) {

--- a/web/l10n_utils.js
+++ b/web/l10n_utils.js
@@ -81,8 +81,6 @@ const DEFAULT_L10N_STRINGS = {
   printing_not_ready: "Warning: The PDF is not fully loaded for printing.",
   web_fonts_disabled:
     "Web fonts are disabled: unable to use embedded PDF fonts.",
-  unsupported_feature_signatures:
-    "This PDF document contains digital signatures. Validation of signatures is not supported.",
 };
 
 function getL10nFallback(key, args) {


### PR DESCRIPTION
According to a decision by UX and PM, please see https://bugzilla.mozilla.org/show_bug.cgi?id=1705060#c2, in Firefox we should first of all *not* display the notification-bar for signatures. Secondly, as can also be seen there, we shouldn't display the notification-bar *at all* and it's thus disabled in https://bugzilla.mozilla.org/show_bug.cgi?id=1705327.

If we purposely don't display a notification, for documents with signatures, in the *built in* Firefox PDF Viewer then it cannot be necessary in the GENERIC viewer either.

