### PR TITLE
A couple of small scripting/XFA-related tweaks in the worker-code

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -2966,7 +2966,7 @@ var Font = (function FontClosure() {
       }
 
       // When `cssFontInfo` is set, the font is used to render text in the HTML
-      // view (e.g. with Xfa) so nothing must be moved in the private area use.
+      // view (e.g. with Xfa) so nothing must be moved in the private use area.
       if (!properties.cssFontInfo) {
         // Converting glyphs and ids into font's cmap table
         var newMapping = adjustMapping(

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -195,7 +195,7 @@ class WorkerMessageHandler {
       ]);
 
       if (isPureXfa) {
-        const task = new WorkerTask("Load fonts for Xfa");
+        const task = new WorkerTask("loadXfaFonts");
         startWorkerTask(task);
         await pdfManager
           .loadXfaFonts(handler, task)

--- a/test/unit/document_spec.js
+++ b/test/unit/document_spec.js
@@ -53,18 +53,18 @@ describe("document", function () {
         get docId() {
           return "d0";
         },
+        ensureDoc(prop, args) {
+          return pdfManager.ensure(pdfDocument, prop, args);
+        },
         ensureCatalog(prop, args) {
           return pdfManager.ensure(catalog, prop, args);
         },
-        ensure(obj, prop, args) {
-          return new Promise(function (resolve) {
-            const value = obj[prop];
-            if (typeof value === "function") {
-              resolve(value.apply(obj, args));
-            } else {
-              resolve(value);
-            }
-          });
+        async ensure(obj, prop, args) {
+          const value = obj[prop];
+          if (typeof value === "function") {
+            return value.apply(obj, args);
+          }
+          return value;
         },
       };
       const pdfDocument = new PDFDocument(pdfManager, stream);


### PR DESCRIPTION
 - Use `PDFManager.ensureDoc`, rather than `PDFManager.ensure`, in a couple of spots in the code. If there exists a short-hand format, we should obviously use it wherever possible.

 - Fix a unit-test helper, to account for the previous changes. (Also, converts a function to be `async` instead.)

 - Add one more exists-check in `PDFDocument.loadXfaFonts`, which I missed to suggest in PR 13146, to prevent any future errors if the method is ever called in a situation where it shouldn't be.
  Also, print a warning if the actual font-loading fails since that could help future debugging. (Finally, reduce overall indentation in the loop.)

 - Slightly unrelated, but make a small tweak of a comment in `src/core/fonts.js` to reduce possible confusion.

*Slightly smaller/simpler diff with https://github.com/mozilla/pdf.js/pull/13254/files?w=1*