### PR TITLE
Convert done callbacks to async/await in the last two unit test files

### DIFF
--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -117,7 +117,7 @@ describe("annotation", function () {
   });
 
   describe("AnnotationFactory", function () {
-    it("should get id for annotation", function (done) {
+    it("should get id for annotation", async function () {
       const annotationDict = new Dict();
       annotationDict.set("Type", Name.get("Annot"));
       annotationDict.set("Subtype", Name.get("Link"));
@@ -125,22 +125,20 @@ describe("annotation", function () {
       const annotationRef = Ref.get(10, 0);
       const xref = new XRefMock([{ ref: annotationRef, data: annotationDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.LINK);
-        expect(data.id).toEqual("10R");
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.LINK);
+      expect(data.id).toEqual("10R");
     });
 
     it(
       "should handle, and get fallback IDs for, annotations that are not " +
         "indirect objects (issue 7569)",
-      function (done) {
+      async function () {
         const annotationDict = new Dict();
         annotationDict.set("Type", Name.get("Annot"));
         annotationDict.set("Subtype", Name.get("Link"));
@@ -168,26 +166,24 @@ describe("annotation", function () {
           expect(data.id).toEqual("annot_p0_2");
         });
 
-        Promise.all([annotation1, annotation2]).then(done, done.fail);
+        await Promise.all([annotation1, annotation2]);
       }
     );
 
-    it("should handle missing /Subtype", function (done) {
+    it("should handle missing /Subtype", async function () {
       const annotationDict = new Dict();
       annotationDict.set("Type", Name.get("Annot"));
 
       const annotationRef = Ref.get(1, 0);
       const xref = new XRefMock([{ ref: annotationRef, data: annotationDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toBeUndefined();
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toBeUndefined();
     });
   });
 
@@ -518,23 +514,22 @@ describe("annotation", function () {
       expect(markupAnnotation.creationDate).toEqual(null);
     });
 
-    it("should not parse IRT/RT when not defined", function (done) {
+    it("should not parse IRT/RT when not defined", async function () {
       dict.set("Type", Name.get("Annot"));
       dict.set("Subtype", Name.get("Text"));
 
       const xref = new XRefMock([{ ref, data: dict }]);
-
-      AnnotationFactory.create(xref, ref, pdfManagerMock, idFactoryMock).then(
-        ({ data }) => {
-          expect(data.inReplyTo).toBeUndefined();
-          expect(data.replyType).toBeUndefined();
-          done();
-        },
-        done.fail
+      const { data } = await AnnotationFactory.create(
+        xref,
+        ref,
+        pdfManagerMock,
+        idFactoryMock
       );
+      expect(data.inReplyTo).toBeUndefined();
+      expect(data.replyType).toBeUndefined();
     });
 
-    it("should parse IRT and set default RT when not defined.", function (done) {
+    it("should parse IRT and set default RT when not defined", async function () {
       const annotationRef = Ref.get(819, 0);
       const annotationDict = new Dict();
       annotationDict.set("Type", Name.get("Annot"));
@@ -553,19 +548,17 @@ describe("annotation", function () {
       annotationDict.assignXref(xref);
       replyDict.assignXref(xref);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         replyRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.inReplyTo).toEqual(annotationRef.toString());
-        expect(data.replyType).toEqual("R");
-        done();
-      }, done.fail);
+      );
+      expect(data.inReplyTo).toEqual(annotationRef.toString());
+      expect(data.replyType).toEqual("R");
     });
 
-    it("should parse IRT/RT for a group type", function (done) {
+    it("should parse IRT/RT for a group type", async function () {
       const annotationRef = Ref.get(819, 0);
       const annotationDict = new Dict();
       annotationDict.set("Type", Name.get("Annot"));
@@ -604,25 +597,23 @@ describe("annotation", function () {
       popupDict.assignXref(xref);
       replyDict.assignXref(xref);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         replyRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.inReplyTo).toEqual(annotationRef.toString());
-        expect(data.replyType).toEqual("Group");
-        expect(data.title).toEqual("ParentTitle");
-        expect(data.contents).toEqual("ParentText");
-        expect(data.creationDate).toEqual("D:20180423");
-        expect(data.modificationDate).toEqual("D:20190423");
-        expect(data.color).toEqual(new Uint8ClampedArray([0, 0, 255]));
-        expect(data.hasPopup).toEqual(true);
-        done();
-      }, done.fail);
+      );
+      expect(data.inReplyTo).toEqual(annotationRef.toString());
+      expect(data.replyType).toEqual("Group");
+      expect(data.title).toEqual("ParentTitle");
+      expect(data.contents).toEqual("ParentText");
+      expect(data.creationDate).toEqual("D:20180423");
+      expect(data.modificationDate).toEqual("D:20190423");
+      expect(data.color).toEqual(new Uint8ClampedArray([0, 0, 255]));
+      expect(data.hasPopup).toEqual(true);
     });
 
-    it("should parse IRT/RT for a reply type", function (done) {
+    it("should parse IRT/RT for a reply type", async function () {
       const annotationRef = Ref.get(819, 0);
       const annotationDict = new Dict();
       annotationDict.set("Type", Name.get("Annot"));
@@ -661,27 +652,25 @@ describe("annotation", function () {
       popupDict.assignXref(xref);
       replyDict.assignXref(xref);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         replyRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.inReplyTo).toEqual(annotationRef.toString());
-        expect(data.replyType).toEqual("R");
-        expect(data.title).toEqual("ReplyTitle");
-        expect(data.contents).toEqual("ReplyText");
-        expect(data.creationDate).toEqual("D:20180523");
-        expect(data.modificationDate).toEqual("D:20190523");
-        expect(data.color).toEqual(new Uint8ClampedArray([102, 102, 102]));
-        expect(data.hasPopup).toEqual(false);
-        done();
-      }, done.fail);
+      );
+      expect(data.inReplyTo).toEqual(annotationRef.toString());
+      expect(data.replyType).toEqual("R");
+      expect(data.title).toEqual("ReplyTitle");
+      expect(data.contents).toEqual("ReplyText");
+      expect(data.creationDate).toEqual("D:20180523");
+      expect(data.modificationDate).toEqual("D:20190523");
+      expect(data.color).toEqual(new Uint8ClampedArray([102, 102, 102]));
+      expect(data.hasPopup).toEqual(false);
     });
   });
 
   describe("TextAnnotation", function () {
-    it("should not parse state model and state when not defined", function (done) {
+    it("should not parse state model and state when not defined", async function () {
       const annotationRef = Ref.get(819, 0);
       const annotationDict = new Dict();
       annotationDict.set("Type", Name.get("Annot"));
@@ -703,19 +692,17 @@ describe("annotation", function () {
       annotationDict.assignXref(xref);
       replyDict.assignXref(xref);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         replyRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.stateModel).toBeNull();
-        expect(data.state).toBeNull();
-        done();
-      }, done.fail);
+      );
+      expect(data.stateModel).toBeNull();
+      expect(data.state).toBeNull();
     });
 
-    it("should correctly parse state model and state when defined", function (done) {
+    it("should correctly parse state model and state when defined", async function () {
       const annotationRef = Ref.get(819, 0);
       const annotationDict = new Dict();
       annotationDict.set("Type", Name.get("Annot"));
@@ -737,21 +724,19 @@ describe("annotation", function () {
       annotationDict.assignXref(xref);
       replyDict.assignXref(xref);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         replyRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.stateModel).toEqual("Review");
-        expect(data.state).toEqual("Rejected");
-        done();
-      }, done.fail);
+      );
+      expect(data.stateModel).toEqual("Review");
+      expect(data.state).toEqual("Rejected");
     });
   });
 
   describe("LinkAnnotation", function () {
-    it("should correctly parse a URI action", function (done) {
+    it("should correctly parse a URI action", async function () {
       const actionDict = new Dict();
       actionDict.set("Type", Name.get("Action"));
       actionDict.set("S", Name.get("URI"));
@@ -765,26 +750,24 @@ describe("annotation", function () {
       const annotationRef = Ref.get(820, 0);
       const xref = new XRefMock([{ ref: annotationRef, data: annotationDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.LINK);
-        expect(data.url).toEqual("http://www.ctan.org/tex-archive/info/lshort");
-        expect(data.unsafeUrl).toEqual(
-          "http://www.ctan.org/tex-archive/info/lshort"
-        );
-        expect(data.dest).toBeUndefined();
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.LINK);
+      expect(data.url).toEqual("http://www.ctan.org/tex-archive/info/lshort");
+      expect(data.unsafeUrl).toEqual(
+        "http://www.ctan.org/tex-archive/info/lshort"
+      );
+      expect(data.dest).toBeUndefined();
     });
 
     it(
       "should correctly parse a URI action, where the URI entry " +
         "is missing a protocol",
-      function (done) {
+      async function () {
         const actionDict = new Dict();
         actionDict.set("Type", Name.get("Action"));
         actionDict.set("S", Name.get("URI"));
@@ -800,25 +783,23 @@ describe("annotation", function () {
           { ref: annotationRef, data: annotationDict },
         ]);
 
-        AnnotationFactory.create(
+        const { data } = await AnnotationFactory.create(
           xref,
           annotationRef,
           pdfManagerMock,
           idFactoryMock
-        ).then(({ data }) => {
-          expect(data.annotationType).toEqual(AnnotationType.LINK);
-          expect(data.url).toEqual("http://www.hmrc.gov.uk/");
-          expect(data.unsafeUrl).toEqual("http://www.hmrc.gov.uk");
-          expect(data.dest).toBeUndefined();
-          done();
-        }, done.fail);
+        );
+        expect(data.annotationType).toEqual(AnnotationType.LINK);
+        expect(data.url).toEqual("http://www.hmrc.gov.uk/");
+        expect(data.unsafeUrl).toEqual("http://www.hmrc.gov.uk");
+        expect(data.dest).toBeUndefined();
       }
     );
 
     it(
       "should correctly parse a URI action, where the URI entry " +
         "has an incorrect encoding (bug 1122280)",
-      function (done) {
+      async function () {
         const actionStream = new StringStream(
           "<<\n" +
             "/Type /Action\n" +
@@ -842,32 +823,28 @@ describe("annotation", function () {
           { ref: annotationRef, data: annotationDict },
         ]);
 
-        AnnotationFactory.create(
+        const { data } = await AnnotationFactory.create(
           xref,
           annotationRef,
           pdfManagerMock,
           idFactoryMock
-        ).then(({ data }) => {
-          expect(data.annotationType).toEqual(AnnotationType.LINK);
-          expect(data.url).toEqual(
-            new URL(
-              stringToUTF8String(
-                "http://www.example.com/\xC3\xBC\xC3\xB6\xC3\xA4"
-              )
-            ).href
-          );
-          expect(data.unsafeUrl).toEqual(
+        );
+        expect(data.annotationType).toEqual(AnnotationType.LINK);
+        expect(data.url).toEqual(
+          new URL(
             stringToUTF8String(
               "http://www.example.com/\xC3\xBC\xC3\xB6\xC3\xA4"
             )
-          );
-          expect(data.dest).toBeUndefined();
-          done();
-        }, done.fail);
+          ).href
+        );
+        expect(data.unsafeUrl).toEqual(
+          stringToUTF8String("http://www.example.com/\xC3\xBC\xC3\xB6\xC3\xA4")
+        );
+        expect(data.dest).toBeUndefined();
       }
     );
 
-    it("should correctly parse a GoTo action", function (done) {
+    it("should correctly parse a GoTo action", async function () {
       const actionDict = new Dict();
       actionDict.set("Type", Name.get("Action"));
       actionDict.set("S", Name.get("GoTo"));
@@ -881,24 +858,22 @@ describe("annotation", function () {
       const annotationRef = Ref.get(798, 0);
       const xref = new XRefMock([{ ref: annotationRef, data: annotationDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.LINK);
-        expect(data.url).toBeUndefined();
-        expect(data.unsafeUrl).toBeUndefined();
-        expect(data.dest).toEqual("page.157");
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.LINK);
+      expect(data.url).toBeUndefined();
+      expect(data.unsafeUrl).toBeUndefined();
+      expect(data.dest).toEqual("page.157");
     });
 
     it(
       "should correctly parse a GoToR action, where the FileSpec entry " +
         "is a string containing a relative URL",
-      function (done) {
+      async function () {
         const actionDict = new Dict();
         actionDict.set("Type", Name.get("Action"));
         actionDict.set("S", Name.get("GoToR"));
@@ -916,26 +891,24 @@ describe("annotation", function () {
           { ref: annotationRef, data: annotationDict },
         ]);
 
-        AnnotationFactory.create(
+        const { data } = await AnnotationFactory.create(
           xref,
           annotationRef,
           pdfManagerMock,
           idFactoryMock
-        ).then(({ data }) => {
-          expect(data.annotationType).toEqual(AnnotationType.LINK);
-          expect(data.url).toBeUndefined();
-          expect(data.unsafeUrl).toEqual("../../0013/001346/134685E.pdf#4.3");
-          expect(data.dest).toBeUndefined();
-          expect(data.newWindow).toEqual(true);
-          done();
-        }, done.fail);
+        );
+        expect(data.annotationType).toEqual(AnnotationType.LINK);
+        expect(data.url).toBeUndefined();
+        expect(data.unsafeUrl).toEqual("../../0013/001346/134685E.pdf#4.3");
+        expect(data.dest).toBeUndefined();
+        expect(data.newWindow).toEqual(true);
       }
     );
 
     it(
       "should correctly parse a GoToR action, containing a relative URL, " +
         'with the "docBaseUrl" parameter specified',
-      function (done) {
+      async function () {
         const actionDict = new Dict();
         actionDict.set("Type", Name.get("Action"));
         actionDict.set("S", Name.get("GoToR"));
@@ -955,24 +928,22 @@ describe("annotation", function () {
           docBaseUrl: "http://www.example.com/test/pdfs/qwerty.pdf",
         });
 
-        AnnotationFactory.create(
+        const { data } = await AnnotationFactory.create(
           xref,
           annotationRef,
           pdfManager,
           idFactoryMock
-        ).then(({ data }) => {
-          expect(data.annotationType).toEqual(AnnotationType.LINK);
-          expect(data.url).toEqual(
-            "http://www.example.com/0013/001346/134685E.pdf#4.3"
-          );
-          expect(data.unsafeUrl).toEqual("../../0013/001346/134685E.pdf#4.3");
-          expect(data.dest).toBeUndefined();
-          done();
-        }, done.fail);
+        );
+        expect(data.annotationType).toEqual(AnnotationType.LINK);
+        expect(data.url).toEqual(
+          "http://www.example.com/0013/001346/134685E.pdf#4.3"
+        );
+        expect(data.unsafeUrl).toEqual("../../0013/001346/134685E.pdf#4.3");
+        expect(data.dest).toBeUndefined();
       }
     );
 
-    it("should correctly parse a GoToR action, with named destination", function (done) {
+    it("should correctly parse a GoToR action, with named destination", async function () {
       const actionDict = new Dict();
       actionDict.set("Type", Name.get("Action"));
       actionDict.set("S", Name.get("GoToR"));
@@ -987,22 +958,20 @@ describe("annotation", function () {
       const annotationRef = Ref.get(495, 0);
       const xref = new XRefMock([{ ref: annotationRef, data: annotationDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.LINK);
-        expect(data.url).toEqual("http://www.example.com/test.pdf#15");
-        expect(data.unsafeUrl).toEqual("http://www.example.com/test.pdf#15");
-        expect(data.dest).toBeUndefined();
-        expect(data.newWindow).toBeFalsy();
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.LINK);
+      expect(data.url).toEqual("http://www.example.com/test.pdf#15");
+      expect(data.unsafeUrl).toEqual("http://www.example.com/test.pdf#15");
+      expect(data.dest).toBeUndefined();
+      expect(data.newWindow).toBeFalsy();
     });
 
-    it("should correctly parse a GoToR action, with explicit destination array", function (done) {
+    it("should correctly parse a GoToR action, with explicit destination array", async function () {
       const actionDict = new Dict();
       actionDict.set("Type", Name.get("Action"));
       actionDict.set("S", Name.get("GoToR"));
@@ -1017,33 +986,31 @@ describe("annotation", function () {
       const annotationRef = Ref.get(489, 0);
       const xref = new XRefMock([{ ref: annotationRef, data: annotationDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.LINK);
-        expect(data.url).toEqual(
-          new URL(
-            "http://www.example.com/test.pdf#" +
-              '[14,{"name":"XYZ"},null,298.043,null]'
-          ).href
-        );
-        expect(data.unsafeUrl).toEqual(
+      );
+      expect(data.annotationType).toEqual(AnnotationType.LINK);
+      expect(data.url).toEqual(
+        new URL(
           "http://www.example.com/test.pdf#" +
             '[14,{"name":"XYZ"},null,298.043,null]'
-        );
-        expect(data.dest).toBeUndefined();
-        expect(data.newWindow).toBeFalsy();
-        done();
-      }, done.fail);
+        ).href
+      );
+      expect(data.unsafeUrl).toEqual(
+        "http://www.example.com/test.pdf#" +
+          '[14,{"name":"XYZ"},null,298.043,null]'
+      );
+      expect(data.dest).toBeUndefined();
+      expect(data.newWindow).toBeFalsy();
     });
 
     it(
       "should correctly parse a Launch action, where the FileSpec dict " +
         'contains a relative URL, with the "docBaseUrl" parameter specified',
-      function (done) {
+      async function () {
         const fileSpecDict = new Dict();
         fileSpecDict.set("Type", Name.get("FileSpec"));
         fileSpecDict.set("F", "Part II/Part II.pdf");
@@ -1068,28 +1035,26 @@ describe("annotation", function () {
           docBaseUrl: "http://www.example.com/test/pdfs/qwerty.pdf",
         });
 
-        AnnotationFactory.create(
+        const { data } = await AnnotationFactory.create(
           xref,
           annotationRef,
           pdfManager,
           idFactoryMock
-        ).then(({ data }) => {
-          expect(data.annotationType).toEqual(AnnotationType.LINK);
-          expect(data.url).toEqual(
-            new URL("http://www.example.com/test/pdfs/Part II/Part II.pdf").href
-          );
-          expect(data.unsafeUrl).toEqual("Part II/Part II.pdf");
-          expect(data.dest).toBeUndefined();
-          expect(data.newWindow).toEqual(true);
-          done();
-        }, done.fail);
+        );
+        expect(data.annotationType).toEqual(AnnotationType.LINK);
+        expect(data.url).toEqual(
+          new URL("http://www.example.com/test/pdfs/Part II/Part II.pdf").href
+        );
+        expect(data.unsafeUrl).toEqual("Part II/Part II.pdf");
+        expect(data.dest).toBeUndefined();
+        expect(data.newWindow).toEqual(true);
       }
     );
 
     it(
       "should recover valid URLs from JavaScript actions having certain " +
         "white-listed formats",
-      function (done) {
+      async function () {
         function checkJsAction(params) {
           const jsEntry = params.jsEntry;
           const expectedUrl = params.expectedUrl;
@@ -1151,14 +1116,11 @@ describe("annotation", function () {
           expectedNewWindow: true,
         });
 
-        Promise.all([annotation1, annotation2, annotation3]).then(
-          done,
-          done.fail
-        );
+        await Promise.all([annotation1, annotation2, annotation3]);
       }
     );
 
-    it("should correctly parse a Named action", function (done) {
+    it("should correctly parse a Named action", async function () {
       const actionDict = new Dict();
       actionDict.set("Type", Name.get("Action"));
       actionDict.set("S", Name.get("Named"));
@@ -1172,21 +1134,19 @@ describe("annotation", function () {
       const annotationRef = Ref.get(12, 0);
       const xref = new XRefMock([{ ref: annotationRef, data: annotationDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.LINK);
-        expect(data.url).toBeUndefined();
-        expect(data.unsafeUrl).toBeUndefined();
-        expect(data.action).toEqual("GoToPage");
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.LINK);
+      expect(data.url).toBeUndefined();
+      expect(data.unsafeUrl).toBeUndefined();
+      expect(data.action).toEqual("GoToPage");
     });
 
-    it("should correctly parse a simple Dest", function (done) {
+    it("should correctly parse a simple Dest", async function () {
       const annotationDict = new Dict();
       annotationDict.set("Type", Name.get("Annot"));
       annotationDict.set("Subtype", Name.get("Link"));
@@ -1195,21 +1155,19 @@ describe("annotation", function () {
       const annotationRef = Ref.get(583, 0);
       const xref = new XRefMock([{ ref: annotationRef, data: annotationDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.LINK);
-        expect(data.url).toBeUndefined();
-        expect(data.unsafeUrl).toBeUndefined();
-        expect(data.dest).toEqual("LI0");
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.LINK);
+      expect(data.url).toBeUndefined();
+      expect(data.unsafeUrl).toBeUndefined();
+      expect(data.dest).toEqual("LI0");
     });
 
-    it("should correctly parse a simple Dest, with explicit destination array", function (done) {
+    it("should correctly parse a simple Dest, with explicit destination array", async function () {
       const annotationDict = new Dict();
       annotationDict.set("Type", Name.get("Annot"));
       annotationDict.set("Subtype", Name.get("Link"));
@@ -1224,30 +1182,28 @@ describe("annotation", function () {
       const annotationRef = Ref.get(10, 0);
       const xref = new XRefMock([{ ref: annotationRef, data: annotationDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.LINK);
-        expect(data.url).toBeUndefined();
-        expect(data.unsafeUrl).toBeUndefined();
-        expect(data.dest).toEqual([
-          { num: 17, gen: 0 },
-          { name: "XYZ" },
-          0,
-          841.89,
-          null,
-        ]);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.LINK);
+      expect(data.url).toBeUndefined();
+      expect(data.unsafeUrl).toBeUndefined();
+      expect(data.dest).toEqual([
+        { num: 17, gen: 0 },
+        { name: "XYZ" },
+        0,
+        841.89,
+        null,
+      ]);
     });
 
     it(
       "should correctly parse a Dest, which violates the specification " +
         "by containing a dictionary",
-      function (done) {
+      async function () {
         const destDict = new Dict();
         destDict.set("Type", Name.get("Action"));
         destDict.set("S", Name.get("GoTo"));
@@ -1265,22 +1221,20 @@ describe("annotation", function () {
           { ref: annotationRef, data: annotationDict },
         ]);
 
-        AnnotationFactory.create(
+        const { data } = await AnnotationFactory.create(
           xref,
           annotationRef,
           pdfManagerMock,
           idFactoryMock
-        ).then(({ data }) => {
-          expect(data.annotationType).toEqual(AnnotationType.LINK);
-          expect(data.url).toBeUndefined();
-          expect(data.unsafeUrl).toBeUndefined();
-          expect(data.dest).toEqual("page.157");
-          done();
-        }, done.fail);
+        );
+        expect(data.annotationType).toEqual(AnnotationType.LINK);
+        expect(data.url).toBeUndefined();
+        expect(data.unsafeUrl).toBeUndefined();
+        expect(data.dest).toEqual("page.157");
       }
     );
 
-    it("should not set quadpoints if not defined", function (done) {
+    it("should not set quadpoints if not defined", async function () {
       const annotationDict = new Dict();
       annotationDict.set("Type", Name.get("Annot"));
       annotationDict.set("Subtype", Name.get("Link"));
@@ -1288,19 +1242,17 @@ describe("annotation", function () {
       const annotationRef = Ref.get(121, 0);
       const xref = new XRefMock([{ ref: annotationRef, data: annotationDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.LINK);
-        expect(data.quadPoints).toBeUndefined();
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.LINK);
+      expect(data.quadPoints).toBeUndefined();
     });
 
-    it("should set quadpoints if defined", function (done) {
+    it("should set quadpoints if defined", async function () {
       const annotationDict = new Dict();
       annotationDict.set("Type", Name.get("Annot"));
       annotationDict.set("Subtype", Name.get("Link"));
@@ -1310,23 +1262,21 @@ describe("annotation", function () {
       const annotationRef = Ref.get(121, 0);
       const xref = new XRefMock([{ ref: annotationRef, data: annotationDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.LINK);
-        expect(data.quadPoints).toEqual([
-          [
-            { x: 10, y: 20 },
-            { x: 20, y: 20 },
-            { x: 10, y: 10 },
-            { x: 20, y: 10 },
-          ],
-        ]);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.LINK);
+      expect(data.quadPoints).toEqual([
+        [
+          { x: 10, y: 20 },
+          { x: 20, y: 20 },
+          { x: 10, y: 10 },
+          { x: 20, y: 10 },
+        ],
+      ]);
     });
   });
 
@@ -1343,41 +1293,37 @@ describe("annotation", function () {
       widgetDict = null;
     });
 
-    it("should handle unknown field names", function (done) {
+    it("should handle unknown field names", async function () {
       const widgetRef = Ref.get(20, 0);
       const xref = new XRefMock([{ ref: widgetRef, data: widgetDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         widgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.fieldName).toEqual("");
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.fieldName).toEqual("");
     });
 
-    it("should construct the field name when there are no ancestors", function (done) {
+    it("should construct the field name when there are no ancestors", async function () {
       widgetDict.set("T", "foo");
 
       const widgetRef = Ref.get(21, 0);
       const xref = new XRefMock([{ ref: widgetRef, data: widgetDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         widgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.fieldName).toEqual("foo");
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.fieldName).toEqual("foo");
     });
 
-    it("should construct the field name when there are ancestors", function (done) {
+    it("should construct the field name when there are ancestors", async function () {
       const firstParent = new Dict();
       firstParent.set("T", "foo");
 
@@ -1391,22 +1337,20 @@ describe("annotation", function () {
       const widgetRef = Ref.get(22, 0);
       const xref = new XRefMock([{ ref: widgetRef, data: widgetDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         widgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.fieldName).toEqual("foo.bar.baz");
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.fieldName).toEqual("foo.bar.baz");
     });
 
     it(
       "should construct the field name if a parent is not a dictionary " +
         "(issue 8143)",
-      function (done) {
+      async function () {
         const parentDict = new Dict();
         parentDict.set("Parent", null);
         parentDict.set("T", "foo");
@@ -1417,16 +1361,14 @@ describe("annotation", function () {
         const widgetRef = Ref.get(22, 0);
         const xref = new XRefMock([{ ref: widgetRef, data: widgetDict }]);
 
-        AnnotationFactory.create(
+        const { data } = await AnnotationFactory.create(
           xref,
           widgetRef,
           pdfManagerMock,
           idFactoryMock
-        ).then(({ data }) => {
-          expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-          expect(data.fieldName).toEqual("foo.bar");
-          done();
-        }, done.fail);
+        );
+        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+        expect(data.fieldName).toEqual("foo.bar");
       }
     );
   });
@@ -1488,31 +1430,29 @@ describe("annotation", function () {
       textWidgetDict = helvRefObj = gothRefObj = null;
     });
 
-    it("should handle unknown text alignment, maximum length and flags", function (done) {
+    it("should handle unknown text alignment, maximum length and flags", async function () {
       textWidgetDict.set("DV", "foo");
 
       const textWidgetRef = Ref.get(124, 0);
       const xref = new XRefMock([{ ref: textWidgetRef, data: textWidgetDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         textWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.textAlignment).toEqual(null);
-        expect(data.maxLen).toEqual(null);
-        expect(data.readOnly).toEqual(false);
-        expect(data.hidden).toEqual(false);
-        expect(data.multiLine).toEqual(false);
-        expect(data.comb).toEqual(false);
-        expect(data.defaultFieldValue).toEqual("foo");
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.textAlignment).toEqual(null);
+      expect(data.maxLen).toEqual(null);
+      expect(data.readOnly).toEqual(false);
+      expect(data.hidden).toEqual(false);
+      expect(data.multiLine).toEqual(false);
+      expect(data.comb).toEqual(false);
+      expect(data.defaultFieldValue).toEqual("foo");
     });
 
-    it("should not set invalid text alignment, maximum length and flags", function (done) {
+    it("should not set invalid text alignment, maximum length and flags", async function () {
       textWidgetDict.set("Q", "center");
       textWidgetDict.set("MaxLen", "five");
       textWidgetDict.set("Ff", "readonly");
@@ -1520,24 +1460,22 @@ describe("annotation", function () {
       const textWidgetRef = Ref.get(43, 0);
       const xref = new XRefMock([{ ref: textWidgetRef, data: textWidgetDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         textWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.textAlignment).toEqual(null);
-        expect(data.maxLen).toEqual(null);
-        expect(data.readOnly).toEqual(false);
-        expect(data.hidden).toEqual(false);
-        expect(data.multiLine).toEqual(false);
-        expect(data.comb).toEqual(false);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.textAlignment).toEqual(null);
+      expect(data.maxLen).toEqual(null);
+      expect(data.readOnly).toEqual(false);
+      expect(data.hidden).toEqual(false);
+      expect(data.multiLine).toEqual(false);
+      expect(data.comb).toEqual(false);
     });
 
-    it("should set valid text alignment, maximum length and flags", function (done) {
+    it("should set valid text alignment, maximum length and flags", async function () {
       textWidgetDict.set("Q", 1);
       textWidgetDict.set("MaxLen", 20);
       textWidgetDict.set(
@@ -1548,60 +1486,54 @@ describe("annotation", function () {
       const textWidgetRef = Ref.get(84, 0);
       const xref = new XRefMock([{ ref: textWidgetRef, data: textWidgetDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         textWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.textAlignment).toEqual(1);
-        expect(data.maxLen).toEqual(20);
-        expect(data.readOnly).toEqual(true);
-        expect(data.hidden).toEqual(false);
-        expect(data.multiLine).toEqual(true);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.textAlignment).toEqual(1);
+      expect(data.maxLen).toEqual(20);
+      expect(data.readOnly).toEqual(true);
+      expect(data.hidden).toEqual(false);
+      expect(data.multiLine).toEqual(true);
     });
 
-    it("should reject comb fields without a maximum length", function (done) {
+    it("should reject comb fields without a maximum length", async function () {
       textWidgetDict.set("Ff", AnnotationFieldFlag.COMB);
 
       const textWidgetRef = Ref.get(46, 0);
       const xref = new XRefMock([{ ref: textWidgetRef, data: textWidgetDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         textWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.comb).toEqual(false);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.comb).toEqual(false);
     });
 
-    it("should accept comb fields with a maximum length", function (done) {
+    it("should accept comb fields with a maximum length", async function () {
       textWidgetDict.set("MaxLen", 20);
       textWidgetDict.set("Ff", AnnotationFieldFlag.COMB);
 
       const textWidgetRef = Ref.get(46, 0);
       const xref = new XRefMock([{ ref: textWidgetRef, data: textWidgetDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         textWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.comb).toEqual(true);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.comb).toEqual(true);
     });
 
-    it("should only accept comb fields when the flags are valid", function (done) {
+    it("should only accept comb fields when the flags are valid", async function () {
       const invalidFieldFlags = [
         AnnotationFieldFlag.MULTILINE,
         AnnotationFieldFlag.PASSWORD,
@@ -1645,10 +1577,10 @@ describe("annotation", function () {
           });
         });
       }
-      promise.then(done, done.fail);
+      await promise;
     });
 
-    it("should render regular text for printing", function (done) {
+    it("should render regular text for printing", async function () {
       const textWidgetRef = Ref.get(271, 0);
       const xref = new XRefMock([
         { ref: textWidgetRef, data: textWidgetDict },
@@ -1657,32 +1589,27 @@ describe("annotation", function () {
       const task = new WorkerTask("test print");
       partialEvaluator.xref = xref;
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, { value: "test\\print" });
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, { value: "test\\print" });
 
-          return annotation._getAppearance(
-            partialEvaluator,
-            task,
-            annotationStorage
-          );
-        }, done.fail)
-        .then(appearance => {
-          expect(appearance).toEqual(
-            "/Tx BMC q BT /Helv 5 Tf 1 0 0 1 0 0 Tm" +
-              " 2.00 2.00 Td (test\\\\print) Tj ET Q EMC"
-          );
-          done();
-        }, done.fail);
+      const appearance = await annotation._getAppearance(
+        partialEvaluator,
+        task,
+        annotationStorage
+      );
+      expect(appearance).toEqual(
+        "/Tx BMC q BT /Helv 5 Tf 1 0 0 1 0 0 Tm" +
+          " 2.00 2.00 Td (test\\\\print) Tj ET Q EMC"
+      );
     });
 
-    it("should render regular text in Japanese for printing", function (done) {
+    it("should render regular text in Japanese for printing", async function () {
       textWidgetDict.get("DR").get("Font").set("Goth", gothRefObj.ref);
       textWidgetDict.set("DA", "/Goth 5 Tf");
 
@@ -1694,37 +1621,31 @@ describe("annotation", function () {
       const task = new WorkerTask("test print");
       partialEvaluator.xref = xref;
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, {
-            value: "こんにちは世界の",
-          });
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, {
+        value: "こんにちは世界の",
+      });
 
-          return annotation._getAppearance(
-            partialEvaluator,
-            task,
-            annotationStorage
-          );
-        }, done.fail)
-        .then(appearance => {
-          const utf16String =
-            "\x30\x53\x30\x93\x30\x6b\x30\x61" +
-            "\x30\x6f\x4e\x16\x75\x4c\x30\x6e";
-          expect(appearance).toEqual(
-            "/Tx BMC q BT /Goth 5 Tf 1 0 0 1 0 0 Tm" +
-              ` 2.00 2.00 Td (${utf16String}) Tj ET Q EMC`
-          );
-          done();
-        }, done.fail);
+      const appearance = await annotation._getAppearance(
+        partialEvaluator,
+        task,
+        annotationStorage
+      );
+      const utf16String =
+        "\x30\x53\x30\x93\x30\x6b\x30\x61\x30\x6f\x4e\x16\x75\x4c\x30\x6e";
+      expect(appearance).toEqual(
+        "/Tx BMC q BT /Goth 5 Tf 1 0 0 1 0 0 Tm" +
+          ` 2.00 2.00 Td (${utf16String}) Tj ET Q EMC`
+      );
     });
 
-    it("should render regular text for printing using normal appearance", function (done) {
+    it("should render regular text for printing using normal appearance", async function () {
       const textWidgetRef = Ref.get(271, 0);
 
       const appearanceStatesDict = new Dict();
@@ -1743,38 +1664,32 @@ describe("annotation", function () {
       const task = new WorkerTask("test print");
       partialEvaluator.xref = xref;
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
+      );
+      const annotationStorage = new Map();
 
-          return annotation.getOperatorList(
-            partialEvaluator,
-            task,
-            false,
-            annotationStorage
-          );
-        })
-        .then(opList => {
-          expect(opList.argsArray.length).toEqual(3);
-          expect(opList.fnArray).toEqual([
-            OPS.beginAnnotation,
-            OPS.setFillRGBColor,
-            OPS.endAnnotation,
-          ]);
-          expect(opList.argsArray[1]).toEqual(
-            new Uint8ClampedArray([26, 51, 76])
-          );
-          done();
-        })
-        .catch(done.fail);
+      const operatorList = await annotation.getOperatorList(
+        partialEvaluator,
+        task,
+        false,
+        annotationStorage
+      );
+      expect(operatorList.argsArray.length).toEqual(3);
+      expect(operatorList.fnArray).toEqual([
+        OPS.beginAnnotation,
+        OPS.setFillRGBColor,
+        OPS.endAnnotation,
+      ]);
+      expect(operatorList.argsArray[1]).toEqual(
+        new Uint8ClampedArray([26, 51, 76])
+      );
     });
 
-    it("should render auto-sized text for printing", function (done) {
+    it("should render auto-sized text for printing", async function () {
       textWidgetDict.set("DA", "/Helv 0 Tf");
 
       const textWidgetRef = Ref.get(271, 0);
@@ -1785,32 +1700,27 @@ describe("annotation", function () {
       const task = new WorkerTask("test print");
       partialEvaluator.xref = xref;
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, { value: "test (print)" });
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, { value: "test (print)" });
 
-          return annotation._getAppearance(
-            partialEvaluator,
-            task,
-            annotationStorage
-          );
-        }, done.fail)
-        .then(appearance => {
-          expect(appearance).toEqual(
-            "/Tx BMC q BT /Helv 8 Tf 0 g 1 0 0 1 0 0 Tm" +
-              " 2.00 2.00 Td (test \\(print\\)) Tj ET Q EMC"
-          );
-          done();
-        }, done.fail);
+      const appearance = await annotation._getAppearance(
+        partialEvaluator,
+        task,
+        annotationStorage
+      );
+      expect(appearance).toEqual(
+        "/Tx BMC q BT /Helv 8 Tf 0 g 1 0 0 1 0 0 Tm" +
+          " 2.00 2.00 Td (test \\(print\\)) Tj ET Q EMC"
+      );
     });
 
-    it("should render auto-sized text in Japanese for printing", function (done) {
+    it("should render auto-sized text in Japanese for printing", async function () {
       textWidgetDict.get("DR").get("Font").set("Goth", gothRefObj.ref);
       textWidgetDict.set("DA", "/Goth 0 Tf");
 
@@ -1822,37 +1732,31 @@ describe("annotation", function () {
       const task = new WorkerTask("test print");
       partialEvaluator.xref = xref;
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, {
-            value: "こんにちは世界の",
-          });
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, {
+        value: "こんにちは世界の",
+      });
 
-          return annotation._getAppearance(
-            partialEvaluator,
-            task,
-            annotationStorage
-          );
-        }, done.fail)
-        .then(appearance => {
-          const utf16String =
-            "\x30\x53\x30\x93\x30\x6b\x30\x61" +
-            "\x30\x6f\x4e\x16\x75\x4c\x30\x6e";
-          expect(appearance).toEqual(
-            "/Tx BMC q BT /Goth 8 Tf 0 g 1 0 0 1 0 0 Tm" +
-              ` 2.00 2.00 Td (${utf16String}) Tj ET Q EMC`
-          );
-          done();
-        }, done.fail);
+      const appearance = await annotation._getAppearance(
+        partialEvaluator,
+        task,
+        annotationStorage
+      );
+      const utf16String =
+        "\x30\x53\x30\x93\x30\x6b\x30\x61\x30\x6f\x4e\x16\x75\x4c\x30\x6e";
+      expect(appearance).toEqual(
+        "/Tx BMC q BT /Goth 8 Tf 0 g 1 0 0 1 0 0 Tm" +
+          ` 2.00 2.00 Td (${utf16String}) Tj ET Q EMC`
+      );
     });
 
-    it("should not render a password for printing", function (done) {
+    it("should not render a password for printing", async function () {
       textWidgetDict.set("Ff", AnnotationFieldFlag.PASSWORD);
 
       const textWidgetRef = Ref.get(271, 0);
@@ -1863,29 +1767,24 @@ describe("annotation", function () {
       const task = new WorkerTask("test print");
       partialEvaluator.xref = xref;
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, { value: "mypassword" });
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, { value: "mypassword" });
 
-          return annotation._getAppearance(
-            partialEvaluator,
-            task,
-            annotationStorage
-          );
-        }, done.fail)
-        .then(appearance => {
-          expect(appearance).toEqual(null);
-          done();
-        }, done.fail);
+      const appearance = await annotation._getAppearance(
+        partialEvaluator,
+        task,
+        annotationStorage
+      );
+      expect(appearance).toEqual(null);
     });
 
-    it("should render multiline text for printing", function (done) {
+    it("should render multiline text for printing", async function () {
       textWidgetDict.set("Ff", AnnotationFieldFlag.MULTILINE);
 
       const textWidgetRef = Ref.get(271, 0);
@@ -1896,42 +1795,37 @@ describe("annotation", function () {
       const task = new WorkerTask("test print");
       partialEvaluator.xref = xref;
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, {
-            value:
-              "a aa aaa aaaa aaaaa aaaaaa " +
-              "pneumonoultramicroscopicsilicovolcanoconiosis",
-          });
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, {
+        value:
+          "a aa aaa aaaa aaaaa aaaaaa " +
+          "pneumonoultramicroscopicsilicovolcanoconiosis",
+      });
 
-          return annotation._getAppearance(
-            partialEvaluator,
-            task,
-            annotationStorage
-          );
-        }, done.fail)
-        .then(appearance => {
-          expect(appearance).toEqual(
-            "/Tx BMC q BT /Helv 5 Tf 1 0 0 1 0 10 Tm " +
-              "2.00 -5.00 Td (a aa aaa ) Tj\n" +
-              "0.00 -5.00 Td (aaaa aaaaa ) Tj\n" +
-              "0.00 -5.00 Td (aaaaaa ) Tj\n" +
-              "0.00 -5.00 Td (pneumonoultr) Tj\n" +
-              "0.00 -5.00 Td (amicroscopi) Tj\n" +
-              "0.00 -5.00 Td (csilicovolca) Tj\n" +
-              "0.00 -5.00 Td (noconiosis) Tj ET Q EMC"
-          );
-          done();
-        }, done.fail);
+      const appearance = await annotation._getAppearance(
+        partialEvaluator,
+        task,
+        annotationStorage
+      );
+      expect(appearance).toEqual(
+        "/Tx BMC q BT /Helv 5 Tf 1 0 0 1 0 10 Tm " +
+          "2.00 -5.00 Td (a aa aaa ) Tj\n" +
+          "0.00 -5.00 Td (aaaa aaaaa ) Tj\n" +
+          "0.00 -5.00 Td (aaaaaa ) Tj\n" +
+          "0.00 -5.00 Td (pneumonoultr) Tj\n" +
+          "0.00 -5.00 Td (amicroscopi) Tj\n" +
+          "0.00 -5.00 Td (csilicovolca) Tj\n" +
+          "0.00 -5.00 Td (noconiosis) Tj ET Q EMC"
+      );
     });
 
-    it("should render multiline text in Japanese for printing", function (done) {
+    it("should render multiline text in Japanese for printing", async function () {
       textWidgetDict.set("Ff", AnnotationFieldFlag.MULTILINE);
       textWidgetDict.get("DR").get("Font").set("Goth", gothRefObj.ref);
       textWidgetDict.set("DA", "/Goth 5 Tf");
@@ -1944,35 +1838,30 @@ describe("annotation", function () {
       const task = new WorkerTask("test print");
       partialEvaluator.xref = xref;
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, {
-            value: "こんにちは世界の",
-          });
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, {
+        value: "こんにちは世界の",
+      });
 
-          return annotation._getAppearance(
-            partialEvaluator,
-            task,
-            annotationStorage
-          );
-        }, done.fail)
-        .then(appearance => {
-          expect(appearance).toEqual(
-            "/Tx BMC q BT /Goth 5 Tf 1 0 0 1 0 10 Tm " +
-              "2.00 -5.00 Td (\x30\x53\x30\x93\x30\x6b\x30\x61\x30\x6f) Tj\n" +
-              "0.00 -5.00 Td (\x4e\x16\x75\x4c\x30\x6e) Tj ET Q EMC"
-          );
-          done();
-        }, done.fail);
+      const appearance = await annotation._getAppearance(
+        partialEvaluator,
+        task,
+        annotationStorage
+      );
+      expect(appearance).toEqual(
+        "/Tx BMC q BT /Goth 5 Tf 1 0 0 1 0 10 Tm " +
+          "2.00 -5.00 Td (\x30\x53\x30\x93\x30\x6b\x30\x61\x30\x6f) Tj\n" +
+          "0.00 -5.00 Td (\x4e\x16\x75\x4c\x30\x6e) Tj ET Q EMC"
+      );
     });
 
-    it("should render multiline text with various EOL for printing", function (done) {
+    it("should render multiline text with various EOL for printing", async function () {
       textWidgetDict.set("Ff", AnnotationFieldFlag.MULTILINE);
       textWidgetDict.set("Rect", [0, 0, 128, 10]);
 
@@ -2006,39 +1895,34 @@ describe("annotation", function () {
         "0.00 -5.00 Td " +
         "(Etiam facilisis tempus interdum.) Tj ET Q EMC";
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, {
-            value:
-              "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\r" +
-              "Aliquam vitae felis ac lectus bibendum ultricies quis non diam.\n" +
-              "Morbi id porttitor quam, a iaculis dui.\r\n" +
-              "Pellentesque habitant morbi tristique senectus et " +
-              "netus et malesuada fames ac turpis egestas.\n\r\n\r" +
-              "Nulla consectetur, ligula in tincidunt placerat, " +
-              "velit augue consectetur orci, sed mattis libero nunc ut massa.\r" +
-              "Etiam facilisis tempus interdum.",
-          });
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, {
+        value:
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\r" +
+          "Aliquam vitae felis ac lectus bibendum ultricies quis non diam.\n" +
+          "Morbi id porttitor quam, a iaculis dui.\r\n" +
+          "Pellentesque habitant morbi tristique senectus et " +
+          "netus et malesuada fames ac turpis egestas.\n\r\n\r" +
+          "Nulla consectetur, ligula in tincidunt placerat, " +
+          "velit augue consectetur orci, sed mattis libero nunc ut massa.\r" +
+          "Etiam facilisis tempus interdum.",
+      });
 
-          return annotation._getAppearance(
-            partialEvaluator,
-            task,
-            annotationStorage
-          );
-        }, done.fail)
-        .then(appearance => {
-          expect(appearance).toEqual(expectedAppearance);
-          done();
-        }, done.fail);
+      const appearance = await annotation._getAppearance(
+        partialEvaluator,
+        task,
+        annotationStorage
+      );
+      expect(appearance).toEqual(expectedAppearance);
     });
 
-    it("should render comb for printing", function (done) {
+    it("should render comb for printing", async function () {
       textWidgetDict.set("Ff", AnnotationFieldFlag.COMB);
       textWidgetDict.set("MaxLen", 4);
 
@@ -2050,35 +1934,30 @@ describe("annotation", function () {
       const task = new WorkerTask("test print");
       partialEvaluator.xref = xref;
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, { value: "aa(aa)a\\" });
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, { value: "aa(aa)a\\" });
 
-          return annotation._getAppearance(
-            partialEvaluator,
-            task,
-            annotationStorage
-          );
-        }, done.fail)
-        .then(appearance => {
-          expect(appearance).toEqual(
-            "/Tx BMC q BT /Helv 5 Tf 1 0 0 1 2 2 Tm" +
-              " (a) Tj 8.00 0 Td (a) Tj 8.00 0 Td (\\() Tj" +
-              " 8.00 0 Td (a) Tj 8.00 0 Td (a) Tj" +
-              " 8.00 0 Td (\\)) Tj 8.00 0 Td (a) Tj" +
-              " 8.00 0 Td (\\\\) Tj ET Q EMC"
-          );
-          done();
-        }, done.fail);
+      const appearance = await annotation._getAppearance(
+        partialEvaluator,
+        task,
+        annotationStorage
+      );
+      expect(appearance).toEqual(
+        "/Tx BMC q BT /Helv 5 Tf 1 0 0 1 2 2 Tm" +
+          " (a) Tj 8.00 0 Td (a) Tj 8.00 0 Td (\\() Tj" +
+          " 8.00 0 Td (a) Tj 8.00 0 Td (a) Tj" +
+          " 8.00 0 Td (\\)) Tj 8.00 0 Td (a) Tj" +
+          " 8.00 0 Td (\\\\) Tj ET Q EMC"
+      );
     });
 
-    it("should render comb with Japanese text for printing", function (done) {
+    it("should render comb with Japanese text for printing", async function () {
       textWidgetDict.set("Ff", AnnotationFieldFlag.COMB);
       textWidgetDict.set("MaxLen", 4);
       textWidgetDict.get("DR").get("Font").set("Goth", gothRefObj.ref);
@@ -2093,37 +1972,32 @@ describe("annotation", function () {
       const task = new WorkerTask("test print");
       partialEvaluator.xref = xref;
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, {
-            value: "こんにちは世界の",
-          });
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, {
+        value: "こんにちは世界の",
+      });
 
-          return annotation._getAppearance(
-            partialEvaluator,
-            task,
-            annotationStorage
-          );
-        }, done.fail)
-        .then(appearance => {
-          expect(appearance).toEqual(
-            "/Tx BMC q BT /Goth 5 Tf 1 0 0 1 2 2 Tm" +
-              " (\x30\x53) Tj 8.00 0 Td (\x30\x93) Tj 8.00 0 Td (\x30\x6b) Tj" +
-              " 8.00 0 Td (\x30\x61) Tj 8.00 0 Td (\x30\x6f) Tj" +
-              " 8.00 0 Td (\x4e\x16) Tj 8.00 0 Td (\x75\x4c) Tj" +
-              " 8.00 0 Td (\x30\x6e) Tj ET Q EMC"
-          );
-          done();
-        }, done.fail);
+      const appearance = await annotation._getAppearance(
+        partialEvaluator,
+        task,
+        annotationStorage
+      );
+      expect(appearance).toEqual(
+        "/Tx BMC q BT /Goth 5 Tf 1 0 0 1 2 2 Tm" +
+          " (\x30\x53) Tj 8.00 0 Td (\x30\x93) Tj 8.00 0 Td (\x30\x6b) Tj" +
+          " 8.00 0 Td (\x30\x61) Tj 8.00 0 Td (\x30\x6f) Tj" +
+          " 8.00 0 Td (\x4e\x16) Tj 8.00 0 Td (\x75\x4c) Tj" +
+          " 8.00 0 Td (\x30\x6e) Tj ET Q EMC"
+      );
     });
 
-    it("should save text", function (done) {
+    it("should save text", async function () {
       const textWidgetRef = Ref.get(123, 0);
       const xref = new XRefMock([
         { ref: textWidgetRef, data: textWidgetDict },
@@ -2132,42 +2006,41 @@ describe("annotation", function () {
       partialEvaluator.xref = xref;
       const task = new WorkerTask("test save");
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, { value: "hello world" });
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, { value: "hello world" });
 
-          return annotation.save(partialEvaluator, task, annotationStorage);
-        }, done.fail)
-        .then(data => {
-          expect(data.length).toEqual(2);
-          const [oldData, newData] = data;
-          expect(oldData.ref).toEqual(Ref.get(123, 0));
-          expect(newData.ref).toEqual(Ref.get(2, 0));
+      const data = await annotation.save(
+        partialEvaluator,
+        task,
+        annotationStorage
+      );
+      expect(data.length).toEqual(2);
+      const [oldData, newData] = data;
+      expect(oldData.ref).toEqual(Ref.get(123, 0));
+      expect(newData.ref).toEqual(Ref.get(2, 0));
 
-          oldData.data = oldData.data.replace(/\(D:[0-9]+\)/, "(date)");
-          expect(oldData.data).toEqual(
-            "123 0 obj\n" +
-              "<< /Type /Annot /Subtype /Widget /FT /Tx /DA (/Helv 5 Tf) /DR " +
-              "<< /Font << /Helv 314 0 R>>>> /Rect [0 0 32 10] " +
-              "/V (hello world) /AP << /N 2 0 R>> /M (date)>>\nendobj\n"
-          );
-          expect(newData.data).toEqual(
-            "2 0 obj\n<< /Length 77 /Subtype /Form /Resources " +
-              "<< /Font << /Helv 314 0 R>>>> /BBox [0 0 32 10]>> stream\n" +
-              "/Tx BMC q BT /Helv 5 Tf 1 0 0 1 0 0 Tm 2.00 2.00 Td (hello world) Tj " +
-              "ET Q EMC\nendstream\nendobj\n"
-          );
-          done();
-        }, done.fail);
+      oldData.data = oldData.data.replace(/\(D:[0-9]+\)/, "(date)");
+      expect(oldData.data).toEqual(
+        "123 0 obj\n" +
+          "<< /Type /Annot /Subtype /Widget /FT /Tx /DA (/Helv 5 Tf) /DR " +
+          "<< /Font << /Helv 314 0 R>>>> /Rect [0 0 32 10] " +
+          "/V (hello world) /AP << /N 2 0 R>> /M (date)>>\nendobj\n"
+      );
+      expect(newData.data).toEqual(
+        "2 0 obj\n<< /Length 77 /Subtype /Form /Resources " +
+          "<< /Font << /Helv 314 0 R>>>> /BBox [0 0 32 10]>> stream\n" +
+          "/Tx BMC q BT /Helv 5 Tf 1 0 0 1 0 0 Tm 2.00 2.00 Td (hello world) Tj " +
+          "ET Q EMC\nendstream\nendobj\n"
+      );
     });
 
-    it("should get field object for usage in JS sandbox", function (done) {
+    it("should get field object for usage in JS sandbox", async function () {
       const textWidgetRef = Ref.get(123, 0);
       const xDictRef = Ref.get(141, 0);
       const dDictRef = Ref.get(262, 0);
@@ -2199,7 +2072,7 @@ describe("annotation", function () {
       eDict.set("S", JS);
       additionalActionsDict.set("E", eDict);
 
-      // Test the cycle detection here
+      // Test the cycle detection here.
       xDict.set("JS", "world()");
       xDict.set("S", JS);
       xDict.set("Next", [next0Ref, next1Ref, next2Ref, xDictRef]);
@@ -2229,31 +2102,26 @@ describe("annotation", function () {
 
       partialEvaluator.xref = xref;
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          return annotation.getFieldObject();
-        })
-        .then(object => {
-          const actions = object.actions;
-          expect(actions["Mouse Enter"]).toEqual(["hello()"]);
-          expect(actions["Mouse Exit"]).toEqual([
-            "world()",
-            "olleh()",
-            "foo()",
-            "dlrow()",
-            "oof()",
-          ]);
-          expect(actions["Mouse Down"]).toEqual(["bar()"]);
-          done();
-        }, done.fail);
+      );
+      const fieldObject = await annotation.getFieldObject();
+      const actions = fieldObject.actions;
+      expect(actions["Mouse Enter"]).toEqual(["hello()"]);
+      expect(actions["Mouse Exit"]).toEqual([
+        "world()",
+        "olleh()",
+        "foo()",
+        "dlrow()",
+        "oof()",
+      ]);
+      expect(actions["Mouse Down"]).toEqual(["bar()"]);
     });
 
-    it("should save Japanese text", function (done) {
+    it("should save Japanese text", async function () {
       textWidgetDict.get("DR").get("Font").set("Goth", gothRefObj.ref);
       textWidgetDict.set("DA", "/Goth 5 Tf");
 
@@ -2265,44 +2133,42 @@ describe("annotation", function () {
       partialEvaluator.xref = xref;
       const task = new WorkerTask("test save");
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, {
-            value: "こんにちは世界の",
-          });
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, {
+        value: "こんにちは世界の",
+      });
 
-          return annotation.save(partialEvaluator, task, annotationStorage);
-        }, done.fail)
-        .then(data => {
-          const utf16String =
-            "\x30\x53\x30\x93\x30\x6b\x30\x61" +
-            "\x30\x6f\x4e\x16\x75\x4c\x30\x6e";
-          expect(data.length).toEqual(2);
-          const [oldData, newData] = data;
-          expect(oldData.ref).toEqual(Ref.get(123, 0));
-          expect(newData.ref).toEqual(Ref.get(2, 0));
+      const data = await annotation.save(
+        partialEvaluator,
+        task,
+        annotationStorage
+      );
+      const utf16String =
+        "\x30\x53\x30\x93\x30\x6b\x30\x61\x30\x6f\x4e\x16\x75\x4c\x30\x6e";
+      expect(data.length).toEqual(2);
+      const [oldData, newData] = data;
+      expect(oldData.ref).toEqual(Ref.get(123, 0));
+      expect(newData.ref).toEqual(Ref.get(2, 0));
 
-          oldData.data = oldData.data.replace(/\(D:[0-9]+\)/, "(date)");
-          expect(oldData.data).toEqual(
-            "123 0 obj\n" +
-              "<< /Type /Annot /Subtype /Widget /FT /Tx /DA (/Goth 5 Tf) /DR " +
-              "<< /Font << /Helv 314 0 R /Goth 159 0 R>>>> /Rect [0 0 32 10] " +
-              `/V (\xfe\xff${utf16String}) /AP << /N 2 0 R>> /M (date)>>\nendobj\n`
-          );
-          expect(newData.data).toEqual(
-            "2 0 obj\n<< /Length 82 /Subtype /Form /Resources " +
-              "<< /Font << /Helv 314 0 R /Goth 159 0 R>>>> /BBox [0 0 32 10]>> stream\n" +
-              `/Tx BMC q BT /Goth 5 Tf 1 0 0 1 0 0 Tm 2.00 2.00 Td (${utf16String}) Tj ` +
-              "ET Q EMC\nendstream\nendobj\n"
-          );
-          done();
-        }, done.fail);
+      oldData.data = oldData.data.replace(/\(D:[0-9]+\)/, "(date)");
+      expect(oldData.data).toEqual(
+        "123 0 obj\n" +
+          "<< /Type /Annot /Subtype /Widget /FT /Tx /DA (/Goth 5 Tf) /DR " +
+          "<< /Font << /Helv 314 0 R /Goth 159 0 R>>>> /Rect [0 0 32 10] " +
+          `/V (\xfe\xff${utf16String}) /AP << /N 2 0 R>> /M (date)>>\nendobj\n`
+      );
+      expect(newData.data).toEqual(
+        "2 0 obj\n<< /Length 82 /Subtype /Form /Resources " +
+          "<< /Font << /Helv 314 0 R /Goth 159 0 R>>>> /BBox [0 0 32 10]>> stream\n" +
+          `/Tx BMC q BT /Goth 5 Tf 1 0 0 1 0 0 Tm 2.00 2.00 Td (${utf16String}) Tj ` +
+          "ET Q EMC\nendstream\nendobj\n"
+      );
     });
   });
 
@@ -2320,7 +2186,7 @@ describe("annotation", function () {
       buttonWidgetDict = null;
     });
 
-    it("should handle checkboxes with export value", function (done) {
+    it("should handle checkboxes with export value", async function () {
       buttonWidgetDict.set("V", Name.get("1"));
       buttonWidgetDict.set("DV", Name.get("2"));
 
@@ -2337,23 +2203,21 @@ describe("annotation", function () {
         { ref: buttonWidgetRef, data: buttonWidgetDict },
       ]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.checkBox).toEqual(true);
-        expect(data.fieldValue).toEqual("1");
-        expect(data.defaultFieldValue).toEqual("2");
-        expect(data.radioButton).toEqual(false);
-        expect(data.exportValue).toEqual("Checked");
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.checkBox).toEqual(true);
+      expect(data.fieldValue).toEqual("1");
+      expect(data.defaultFieldValue).toEqual("2");
+      expect(data.radioButton).toEqual(false);
+      expect(data.exportValue).toEqual("Checked");
     });
 
-    it("should handle checkboxes without export value", function (done) {
+    it("should handle checkboxes without export value", async function () {
       buttonWidgetDict.set("V", Name.get("1"));
       buttonWidgetDict.set("DV", Name.get("2"));
 
@@ -2362,22 +2226,20 @@ describe("annotation", function () {
         { ref: buttonWidgetRef, data: buttonWidgetDict },
       ]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.checkBox).toEqual(true);
-        expect(data.fieldValue).toEqual("1");
-        expect(data.defaultFieldValue).toEqual("2");
-        expect(data.radioButton).toEqual(false);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.checkBox).toEqual(true);
+      expect(data.fieldValue).toEqual("1");
+      expect(data.defaultFieldValue).toEqual("2");
+      expect(data.radioButton).toEqual(false);
     });
 
-    it("should handle checkboxes without /Off appearance", function (done) {
+    it("should handle checkboxes without /Off appearance", async function () {
       buttonWidgetDict.set("V", Name.get("1"));
       buttonWidgetDict.set("DV", Name.get("2"));
 
@@ -2393,23 +2255,21 @@ describe("annotation", function () {
         { ref: buttonWidgetRef, data: buttonWidgetDict },
       ]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.checkBox).toEqual(true);
-        expect(data.fieldValue).toEqual("1");
-        expect(data.defaultFieldValue).toEqual("2");
-        expect(data.radioButton).toEqual(false);
-        expect(data.exportValue).toEqual("Checked");
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.checkBox).toEqual(true);
+      expect(data.fieldValue).toEqual("1");
+      expect(data.defaultFieldValue).toEqual("2");
+      expect(data.radioButton).toEqual(false);
+      expect(data.exportValue).toEqual("Checked");
     });
 
-    it("should render checkbox with fallback font for printing", function (done) {
+    it("should render checkbox with fallback font for printing", async function () {
       const appearanceStatesDict = new Dict();
       const normalAppearanceDict = new Dict();
       const checkedAppearanceDict = new Dict();
@@ -2437,39 +2297,33 @@ describe("annotation", function () {
       const task = new WorkerTask("test print");
       partialEvaluator.options = { ignoreErrors: true };
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, { value: true });
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, { value: true });
 
-          return annotation.getOperatorList(
-            partialEvaluator,
-            task,
-            false,
-            annotationStorage
-          );
-        })
-        .then(opList => {
-          expect(opList.argsArray.length).toEqual(5);
-          expect(opList.fnArray).toEqual([
-            OPS.beginAnnotation,
-            OPS.dependency,
-            OPS.setFont,
-            OPS.showText,
-            OPS.endAnnotation,
-          ]);
-          expect(opList.argsArray[3][0][0].fontChar).toEqual("✔");
-          done();
-        })
-        .catch(done.fail);
+      const operatorList = await annotation.getOperatorList(
+        partialEvaluator,
+        task,
+        false,
+        annotationStorage
+      );
+      expect(operatorList.argsArray.length).toEqual(5);
+      expect(operatorList.fnArray).toEqual([
+        OPS.beginAnnotation,
+        OPS.dependency,
+        OPS.setFont,
+        OPS.showText,
+        OPS.endAnnotation,
+      ]);
+      expect(operatorList.argsArray[3][0][0].fontChar).toEqual("✔");
     });
 
-    it("should render checkboxes for printing", function (done) {
+    it("should render checkboxes for printing", async function () {
       const appearanceStatesDict = new Dict();
       const normalAppearanceDict = new Dict();
       const checkedAppearanceDict = new Dict();
@@ -2496,64 +2350,51 @@ describe("annotation", function () {
       ]);
       const task = new WorkerTask("test print");
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, { value: true });
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, { value: true });
 
-          return Promise.all([
-            annotation,
-            annotation.getOperatorList(
-              partialEvaluator,
-              task,
-              false,
-              annotationStorage
-            ),
-          ]);
-        }, done.fail)
-        .then(([annotation, opList]) => {
-          expect(opList.argsArray.length).toEqual(3);
-          expect(opList.fnArray).toEqual([
-            OPS.beginAnnotation,
-            OPS.setFillRGBColor,
-            OPS.endAnnotation,
-          ]);
-          expect(opList.argsArray[1]).toEqual(
-            new Uint8ClampedArray([26, 51, 76])
-          );
-          return annotation;
-        }, done.fail)
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, { value: false });
+      let operatorList = await annotation.getOperatorList(
+        partialEvaluator,
+        task,
+        false,
+        annotationStorage
+      );
+      expect(operatorList.argsArray.length).toEqual(3);
+      expect(operatorList.fnArray).toEqual([
+        OPS.beginAnnotation,
+        OPS.setFillRGBColor,
+        OPS.endAnnotation,
+      ]);
+      expect(operatorList.argsArray[1]).toEqual(
+        new Uint8ClampedArray([26, 51, 76])
+      );
 
-          return annotation.getOperatorList(
-            partialEvaluator,
-            task,
-            false,
-            annotationStorage
-          );
-        }, done.fail)
-        .then(opList => {
-          expect(opList.argsArray.length).toEqual(3);
-          expect(opList.fnArray).toEqual([
-            OPS.beginAnnotation,
-            OPS.setFillRGBColor,
-            OPS.endAnnotation,
-          ]);
-          expect(opList.argsArray[1]).toEqual(
-            new Uint8ClampedArray([76, 51, 26])
-          );
-          done();
-        }, done.fail);
+      annotationStorage.set(annotation.data.id, { value: false });
+
+      operatorList = await annotation.getOperatorList(
+        partialEvaluator,
+        task,
+        false,
+        annotationStorage
+      );
+      expect(operatorList.argsArray.length).toEqual(3);
+      expect(operatorList.fnArray).toEqual([
+        OPS.beginAnnotation,
+        OPS.setFillRGBColor,
+        OPS.endAnnotation,
+      ]);
+      expect(operatorList.argsArray[1]).toEqual(
+        new Uint8ClampedArray([76, 51, 26])
+      );
     });
 
-    it("should render checkboxes for printing two times", function (done) {
+    it("should render checkboxes for printing twice", async function () {
       const appearanceStatesDict = new Dict();
       const normalAppearanceDict = new Dict();
       const checkedAppearanceDict = new Dict();
@@ -2581,65 +2422,36 @@ describe("annotation", function () {
       ]);
       const task = new WorkerTask("test print");
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, { value: true });
+      );
+      const annotationStorage = new Map();
 
-          return Promise.all([
-            annotation,
-            annotation.getOperatorList(
-              partialEvaluator,
-              task,
-              false,
-              annotationStorage
-            ),
-          ]);
-        })
-        .then(([annotation, opList]) => {
-          expect(opList.argsArray.length).toEqual(3);
-          expect(opList.fnArray).toEqual([
-            OPS.beginAnnotation,
-            OPS.setFillRGBColor,
-            OPS.endAnnotation,
-          ]);
-          expect(opList.argsArray[1]).toEqual(
-            new Uint8ClampedArray([26, 51, 76])
-          );
-          return annotation;
-        })
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, { value: true });
+      for (let i = 0; i < 2; i++) {
+        annotationStorage.set(annotation.data.id, { value: true });
 
-          return annotation.getOperatorList(
-            partialEvaluator,
-            task,
-            false,
-            annotationStorage
-          );
-        })
-        .then(opList => {
-          expect(opList.argsArray.length).toEqual(3);
-          expect(opList.fnArray).toEqual([
-            OPS.beginAnnotation,
-            OPS.setFillRGBColor,
-            OPS.endAnnotation,
-          ]);
-          expect(opList.argsArray[1]).toEqual(
-            new Uint8ClampedArray([26, 51, 76])
-          );
-          done();
-        })
-        .catch(done.fail);
+        const operatorList = await annotation.getOperatorList(
+          partialEvaluator,
+          task,
+          false,
+          annotationStorage
+        );
+        expect(operatorList.argsArray.length).toEqual(3);
+        expect(operatorList.fnArray).toEqual([
+          OPS.beginAnnotation,
+          OPS.setFillRGBColor,
+          OPS.endAnnotation,
+        ]);
+        expect(operatorList.argsArray[1]).toEqual(
+          new Uint8ClampedArray([26, 51, 76])
+        );
+      }
     });
 
-    it("should render checkboxes for printing using normal appearance", function (done) {
+    it("should render checkboxes for printing using normal appearance", async function () {
       const appearanceStatesDict = new Dict();
       const normalAppearanceDict = new Dict();
       const checkedAppearanceDict = new Dict();
@@ -2667,38 +2479,32 @@ describe("annotation", function () {
       ]);
       const task = new WorkerTask("test print");
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
+      );
+      const annotationStorage = new Map();
 
-          return annotation.getOperatorList(
-            partialEvaluator,
-            task,
-            false,
-            annotationStorage
-          );
-        })
-        .then(opList => {
-          expect(opList.argsArray.length).toEqual(3);
-          expect(opList.fnArray).toEqual([
-            OPS.beginAnnotation,
-            OPS.setFillRGBColor,
-            OPS.endAnnotation,
-          ]);
-          expect(opList.argsArray[1]).toEqual(
-            new Uint8ClampedArray([26, 51, 76])
-          );
-          done();
-        })
-        .catch(done.fail);
+      const operatorList = await annotation.getOperatorList(
+        partialEvaluator,
+        task,
+        false,
+        annotationStorage
+      );
+      expect(operatorList.argsArray.length).toEqual(3);
+      expect(operatorList.fnArray).toEqual([
+        OPS.beginAnnotation,
+        OPS.setFillRGBColor,
+        OPS.endAnnotation,
+      ]);
+      expect(operatorList.argsArray[1]).toEqual(
+        new Uint8ClampedArray([26, 51, 76])
+      );
     });
 
-    it("should save checkboxes", function (done) {
+    it("should save checkboxes", async function () {
       const appearanceStatesDict = new Dict();
       const normalAppearanceDict = new Dict();
 
@@ -2716,45 +2522,40 @@ describe("annotation", function () {
       partialEvaluator.xref = xref;
       const task = new WorkerTask("test save");
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, { value: true });
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, { value: true });
 
-          return Promise.all([
-            annotation,
-            annotation.save(partialEvaluator, task, annotationStorage),
-          ]);
-        }, done.fail)
-        .then(([annotation, [oldData]]) => {
-          oldData.data = oldData.data.replace(/\(D:[0-9]+\)/, "(date)");
-          expect(oldData.ref).toEqual(Ref.get(123, 0));
-          expect(oldData.data).toEqual(
-            "123 0 obj\n" +
-              "<< /Type /Annot /Subtype /Widget /FT /Btn " +
-              "/AP << /N << /Checked 314 0 R /Off 271 0 R>>>> " +
-              "/V /Checked /AS /Checked /M (date)>>\nendobj\n"
-          );
-          return annotation;
-        }, done.fail)
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, { value: false });
+      const [oldData] = await annotation.save(
+        partialEvaluator,
+        task,
+        annotationStorage
+      );
+      oldData.data = oldData.data.replace(/\(D:[0-9]+\)/, "(date)");
+      expect(oldData.ref).toEqual(Ref.get(123, 0));
+      expect(oldData.data).toEqual(
+        "123 0 obj\n" +
+          "<< /Type /Annot /Subtype /Widget /FT /Btn " +
+          "/AP << /N << /Checked 314 0 R /Off 271 0 R>>>> " +
+          "/V /Checked /AS /Checked /M (date)>>\nendobj\n"
+      );
 
-          return annotation.save(partialEvaluator, task, annotationStorage);
-        }, done.fail)
-        .then(data => {
-          expect(data).toEqual(null);
-          done();
-        }, done.fail);
+      annotationStorage.set(annotation.data.id, { value: false });
+
+      const data = await annotation.save(
+        partialEvaluator,
+        task,
+        annotationStorage
+      );
+      expect(data).toEqual(null);
     });
 
-    it("should handle radio buttons with a field value", function (done) {
+    it("should handle radio buttons with a field value", async function () {
       const parentDict = new Dict();
       parentDict.set("V", Name.get("1"));
 
@@ -2773,22 +2574,20 @@ describe("annotation", function () {
         { ref: buttonWidgetRef, data: buttonWidgetDict },
       ]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.checkBox).toEqual(false);
-        expect(data.radioButton).toEqual(true);
-        expect(data.fieldValue).toEqual("1");
-        expect(data.buttonValue).toEqual("2");
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.checkBox).toEqual(false);
+      expect(data.radioButton).toEqual(true);
+      expect(data.fieldValue).toEqual("1");
+      expect(data.buttonValue).toEqual("2");
     });
 
-    it("should handle radio buttons with a field value not an ascii string", function (done) {
+    it("should handle radio buttons with a field value that's not an ASCII string", async function () {
       const parentDict = new Dict();
       parentDict.set("V", Name.get("\x91I=\x91\xf0\x93\xe0\x97e3"));
 
@@ -2807,22 +2606,20 @@ describe("annotation", function () {
         { ref: buttonWidgetRef, data: buttonWidgetDict },
       ]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.checkBox).toEqual(false);
-        expect(data.radioButton).toEqual(true);
-        expect(data.fieldValue).toEqual("‚I=‚ðﬁàŠe3");
-        expect(data.buttonValue).toEqual("‚I=‚ðﬁàŠe3");
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.checkBox).toEqual(false);
+      expect(data.radioButton).toEqual(true);
+      expect(data.fieldValue).toEqual("‚I=‚ðﬁàŠe3");
+      expect(data.buttonValue).toEqual("‚I=‚ðﬁàŠe3");
     });
 
-    it("should handle radio buttons without a field value", function (done) {
+    it("should handle radio buttons without a field value", async function () {
       const normalAppearanceStateDict = new Dict();
       normalAppearanceStateDict.set("2", null);
 
@@ -2837,22 +2634,20 @@ describe("annotation", function () {
         { ref: buttonWidgetRef, data: buttonWidgetDict },
       ]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.checkBox).toEqual(false);
-        expect(data.radioButton).toEqual(true);
-        expect(data.fieldValue).toEqual(null);
-        expect(data.buttonValue).toEqual("2");
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.checkBox).toEqual(false);
+      expect(data.radioButton).toEqual(true);
+      expect(data.fieldValue).toEqual(null);
+      expect(data.buttonValue).toEqual("2");
     });
 
-    it("should render radio buttons for printing", function (done) {
+    it("should render radio buttons for printing", async function () {
       const appearanceStatesDict = new Dict();
       const normalAppearanceDict = new Dict();
       const checkedAppearanceDict = new Dict();
@@ -2880,64 +2675,51 @@ describe("annotation", function () {
       ]);
       const task = new WorkerTask("test print");
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, { value: true });
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, { value: true });
 
-          return Promise.all([
-            annotation,
-            annotation.getOperatorList(
-              partialEvaluator,
-              task,
-              false,
-              annotationStorage
-            ),
-          ]);
-        }, done.fail)
-        .then(([annotation, opList]) => {
-          expect(opList.argsArray.length).toEqual(3);
-          expect(opList.fnArray).toEqual([
-            OPS.beginAnnotation,
-            OPS.setFillRGBColor,
-            OPS.endAnnotation,
-          ]);
-          expect(opList.argsArray[1]).toEqual(
-            new Uint8ClampedArray([26, 51, 76])
-          );
-          return annotation;
-        }, done.fail)
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, { value: false });
+      let operatorList = await annotation.getOperatorList(
+        partialEvaluator,
+        task,
+        false,
+        annotationStorage
+      );
+      expect(operatorList.argsArray.length).toEqual(3);
+      expect(operatorList.fnArray).toEqual([
+        OPS.beginAnnotation,
+        OPS.setFillRGBColor,
+        OPS.endAnnotation,
+      ]);
+      expect(operatorList.argsArray[1]).toEqual(
+        new Uint8ClampedArray([26, 51, 76])
+      );
 
-          return annotation.getOperatorList(
-            partialEvaluator,
-            task,
-            false,
-            annotationStorage
-          );
-        }, done.fail)
-        .then(opList => {
-          expect(opList.argsArray.length).toEqual(3);
-          expect(opList.fnArray).toEqual([
-            OPS.beginAnnotation,
-            OPS.setFillRGBColor,
-            OPS.endAnnotation,
-          ]);
-          expect(opList.argsArray[1]).toEqual(
-            new Uint8ClampedArray([76, 51, 26])
-          );
-          done();
-        }, done.fail);
+      annotationStorage.set(annotation.data.id, { value: false });
+
+      operatorList = await annotation.getOperatorList(
+        partialEvaluator,
+        task,
+        false,
+        annotationStorage
+      );
+      expect(operatorList.argsArray.length).toEqual(3);
+      expect(operatorList.fnArray).toEqual([
+        OPS.beginAnnotation,
+        OPS.setFillRGBColor,
+        OPS.endAnnotation,
+      ]);
+      expect(operatorList.argsArray[1]).toEqual(
+        new Uint8ClampedArray([76, 51, 26])
+      );
     });
 
-    it("should render radio buttons for printing using normal appearance", function (done) {
+    it("should render radio buttons for printing using normal appearance", async function () {
       const appearanceStatesDict = new Dict();
       const normalAppearanceDict = new Dict();
       const checkedAppearanceDict = new Dict();
@@ -2966,38 +2748,32 @@ describe("annotation", function () {
       ]);
       const task = new WorkerTask("test print");
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
+      );
+      const annotationStorage = new Map();
 
-          return annotation.getOperatorList(
-            partialEvaluator,
-            task,
-            false,
-            annotationStorage
-          );
-        })
-        .then(opList => {
-          expect(opList.argsArray.length).toEqual(3);
-          expect(opList.fnArray).toEqual([
-            OPS.beginAnnotation,
-            OPS.setFillRGBColor,
-            OPS.endAnnotation,
-          ]);
-          expect(opList.argsArray[1]).toEqual(
-            new Uint8ClampedArray([76, 51, 26])
-          );
-          done();
-        })
-        .catch(done.fail);
+      const operatorList = await annotation.getOperatorList(
+        partialEvaluator,
+        task,
+        false,
+        annotationStorage
+      );
+      expect(operatorList.argsArray.length).toEqual(3);
+      expect(operatorList.fnArray).toEqual([
+        OPS.beginAnnotation,
+        OPS.setFillRGBColor,
+        OPS.endAnnotation,
+      ]);
+      expect(operatorList.argsArray[1]).toEqual(
+        new Uint8ClampedArray([76, 51, 26])
+      );
     });
 
-    it("should save radio buttons", function (done) {
+    it("should save radio buttons", async function () {
       const appearanceStatesDict = new Dict();
       const normalAppearanceDict = new Dict();
 
@@ -3026,52 +2802,42 @@ describe("annotation", function () {
       partialEvaluator.xref = xref;
       const task = new WorkerTask("test save");
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, { value: true });
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, { value: true });
 
-          return Promise.all([
-            annotation,
-            annotation.save(partialEvaluator, task, annotationStorage),
-          ]);
-        }, done.fail)
-        .then(([annotation, data]) => {
-          expect(data.length).toEqual(2);
-          const [radioData, parentData] = data;
-          radioData.data = radioData.data.replace(/\(D:[0-9]+\)/, "(date)");
-          expect(radioData.ref).toEqual(Ref.get(123, 0));
-          expect(radioData.data).toEqual(
-            "123 0 obj\n" +
-              "<< /Type /Annot /Subtype /Widget /FT /Btn /Ff 32768 " +
-              "/AP << /N << /Checked 314 0 R /Off 271 0 R>>>> " +
-              "/Parent 456 0 R /AS /Checked /M (date)>>\nendobj\n"
-          );
-          expect(parentData.ref).toEqual(Ref.get(456, 0));
-          expect(parentData.data).toEqual(
-            "456 0 obj\n<< /V /Checked /Kids [123 0 R]>>\nendobj\n"
-          );
+      let data = await annotation.save(
+        partialEvaluator,
+        task,
+        annotationStorage
+      );
+      expect(data.length).toEqual(2);
+      const [radioData, parentData] = data;
+      radioData.data = radioData.data.replace(/\(D:[0-9]+\)/, "(date)");
+      expect(radioData.ref).toEqual(Ref.get(123, 0));
+      expect(radioData.data).toEqual(
+        "123 0 obj\n" +
+          "<< /Type /Annot /Subtype /Widget /FT /Btn /Ff 32768 " +
+          "/AP << /N << /Checked 314 0 R /Off 271 0 R>>>> " +
+          "/Parent 456 0 R /AS /Checked /M (date)>>\nendobj\n"
+      );
+      expect(parentData.ref).toEqual(Ref.get(456, 0));
+      expect(parentData.data).toEqual(
+        "456 0 obj\n<< /V /Checked /Kids [123 0 R]>>\nendobj\n"
+      );
 
-          return annotation;
-        }, done.fail)
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, { value: false });
+      annotationStorage.set(annotation.data.id, { value: false });
 
-          return annotation.save(partialEvaluator, task, annotationStorage);
-        }, done.fail)
-        .then(data => {
-          expect(data).toEqual(null);
-          done();
-        }, done.fail);
+      data = await annotation.save(partialEvaluator, task, annotationStorage);
+      expect(data).toEqual(null);
     });
 
-    it("should save radio buttons without a field value", function (done) {
+    it("should save radio buttons without a field value", async function () {
       const appearanceStatesDict = new Dict();
       const normalAppearanceDict = new Dict();
 
@@ -3099,67 +2865,60 @@ describe("annotation", function () {
       partialEvaluator.xref = xref;
       const task = new WorkerTask("test save");
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, { value: true });
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, { value: true });
 
-          return Promise.all([
-            annotation,
-            annotation.save(partialEvaluator, task, annotationStorage),
-          ]);
-        })
-        .then(([annotation, data]) => {
-          expect(data.length).toEqual(2);
-          const [radioData, parentData] = data;
-          radioData.data = radioData.data.replace(/\(D:[0-9]+\)/, "(date)");
-          expect(radioData.ref).toEqual(Ref.get(123, 0));
-          expect(radioData.data).toEqual(
-            "123 0 obj\n" +
-              "<< /Type /Annot /Subtype /Widget /FT /Btn /Ff 32768 " +
-              "/AP << /N << /Checked 314 0 R /Off 271 0 R>>>> " +
-              "/Parent 456 0 R /AS /Checked /M (date)>>\nendobj\n"
-          );
-          expect(parentData.ref).toEqual(Ref.get(456, 0));
-          expect(parentData.data).toEqual(
-            "456 0 obj\n<< /Kids [123 0 R] /V /Checked>>\nendobj\n"
-          );
-          done();
-        })
-        .catch(done.fail);
+      const data = await annotation.save(
+        partialEvaluator,
+        task,
+        annotationStorage
+      );
+      expect(data.length).toEqual(2);
+      const [radioData, parentData] = data;
+      radioData.data = radioData.data.replace(/\(D:[0-9]+\)/, "(date)");
+      expect(radioData.ref).toEqual(Ref.get(123, 0));
+      expect(radioData.data).toEqual(
+        "123 0 obj\n" +
+          "<< /Type /Annot /Subtype /Widget /FT /Btn /Ff 32768 " +
+          "/AP << /N << /Checked 314 0 R /Off 271 0 R>>>> " +
+          "/Parent 456 0 R /AS /Checked /M (date)>>\nendobj\n"
+      );
+      expect(parentData.ref).toEqual(Ref.get(456, 0));
+      expect(parentData.data).toEqual(
+        "456 0 obj\n<< /Kids [123 0 R] /V /Checked>>\nendobj\n"
+      );
     });
 
-    it("should save nothing", function (done) {
+    it("should save nothing", async function () {
       const buttonWidgetRef = Ref.get(124, 0);
       const xref = new XRefMock([
         { ref: buttonWidgetRef, data: buttonWidgetDict },
       ]);
       const task = new WorkerTask("test save");
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
+      );
+      const annotationStorage = new Map();
 
-          return annotation.save(partialEvaluator, task, annotationStorage);
-        })
-        .then(data => {
-          expect(data).toEqual(null);
-          done();
-        })
-        .catch(done.fail);
+      const data = await annotation.save(
+        partialEvaluator,
+        task,
+        annotationStorage
+      );
+      expect(data).toEqual(null);
     });
 
-    it("should handle push buttons", function (done) {
+    it("should handle push buttons", async function () {
       const buttonWidgetRef = Ref.get(124, 0);
       buttonWidgetDict.set("Ff", AnnotationFieldFlag.PUSHBUTTON);
 
@@ -3172,20 +2931,18 @@ describe("annotation", function () {
         { ref: buttonWidgetRef, data: buttonWidgetDict },
       ]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.pushButton).toEqual(true);
-        expect(data.actions.Action).toEqual(["do_something();"]);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.pushButton).toEqual(true);
+      expect(data.actions.Action).toEqual(["do_something();"]);
     });
 
-    it("should handle push buttons that act as a tooltip only", function (done) {
+    it("should handle push buttons that act as a tooltip only", async function () {
       const buttonWidgetRef = Ref.get(124, 0);
       buttonWidgetDict.set("Ff", AnnotationFieldFlag.PUSHBUTTON);
       buttonWidgetDict.set("TU", "An alternative text");
@@ -3194,20 +2951,18 @@ describe("annotation", function () {
         { ref: buttonWidgetRef, data: buttonWidgetDict },
       ]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.pushButton).toEqual(true);
-        expect(data.alternativeText).toEqual("An alternative text");
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.pushButton).toEqual(true);
+      expect(data.alternativeText).toEqual("An alternative text");
     });
 
-    it("should handle URL in A dict in push buttons", function (done) {
+    it("should handle URL in A dict in push buttons", async function () {
       const buttonWidgetRef = Ref.get(124, 0);
       buttonWidgetDict.set("Ff", AnnotationFieldFlag.PUSHBUTTON);
 
@@ -3223,22 +2978,20 @@ describe("annotation", function () {
         { ref: buttonWidgetRef, data: buttonWidgetDict },
       ]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.url).toEqual("https://developer.mozilla.org/en-US/");
-        done();
-      }, done.fail);
+      );
+      expect(data.url).toEqual("https://developer.mozilla.org/en-US/");
     });
 
-    it("should handle URL in AA dict in push buttons", function (done) {
+    it("should handle URL in AA dict in push buttons", async function () {
       const buttonWidgetRef = Ref.get(124, 0);
       buttonWidgetDict.set("Ff", AnnotationFieldFlag.PUSHBUTTON);
 
-      // D stands for MouseDown
+      // D stands for MouseDown.
       const dDict = new Dict();
       dDict.set("S", Name.get("JavaScript"));
       dDict.set(
@@ -3253,15 +3006,13 @@ describe("annotation", function () {
         { ref: buttonWidgetRef, data: buttonWidgetDict },
       ]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.url).toEqual("https://developer.mozilla.org/en-US/");
-        done();
-      }, done.fail);
+      );
+      expect(data.url).toEqual("https://developer.mozilla.org/en-US/");
     });
   });
 
@@ -3295,25 +3046,23 @@ describe("annotation", function () {
       choiceWidgetDict = fontRefObj = null;
     });
 
-    it("should handle missing option arrays", function (done) {
+    it("should handle missing option arrays", async function () {
       const choiceWidgetRef = Ref.get(122, 0);
       const xref = new XRefMock([
         { ref: choiceWidgetRef, data: choiceWidgetDict },
       ]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.options).toEqual([]);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.options).toEqual([]);
     });
 
-    it("should handle option arrays with array elements", function (done) {
+    it("should handle option arrays with array elements", async function () {
       const optionBarRef = Ref.get(20, 0);
       const optionBarStr = "Bar";
       const optionOneRef = Ref.get(10, 0);
@@ -3334,19 +3083,17 @@ describe("annotation", function () {
         { ref: optionOneRef, data: optionOneArr },
       ]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.options).toEqual(expected);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.options).toEqual(expected);
     });
 
-    it("should handle option arrays with string elements", function (done) {
+    it("should handle option arrays with string elements", async function () {
       const optionBarRef = Ref.get(10, 0);
       const optionBarStr = "Bar";
 
@@ -3364,19 +3111,17 @@ describe("annotation", function () {
         { ref: optionBarRef, data: optionBarStr },
       ]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.options).toEqual(expected);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.options).toEqual(expected);
     });
 
-    it("should handle inherited option arrays (issue 8094)", function (done) {
+    it("should handle inherited option arrays (issue 8094)", async function () {
       const options = [
         ["Value1", "Description1"],
         ["Value2", "Description2"],
@@ -3396,19 +3141,17 @@ describe("annotation", function () {
         { ref: choiceWidgetRef, data: choiceWidgetDict },
       ]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.options).toEqual(expected);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.options).toEqual(expected);
     });
 
-    it("should decode form values", function (done) {
+    it("should decode form values", async function () {
       const encodedString = "\xFE\xFF\x00F\x00o\x00o";
       const decodedString = "Foo";
 
@@ -3421,23 +3164,21 @@ describe("annotation", function () {
         { ref: choiceWidgetRef, data: choiceWidgetDict },
       ]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.fieldValue).toEqual([decodedString]);
-        expect(data.defaultFieldValue).toEqual("foo");
-        expect(data.options).toEqual([
-          { exportValue: decodedString, displayValue: decodedString },
-        ]);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.fieldValue).toEqual([decodedString]);
+      expect(data.defaultFieldValue).toEqual("foo");
+      expect(data.options).toEqual([
+        { exportValue: decodedString, displayValue: decodedString },
+      ]);
     });
 
-    it("should convert the field value to an array", function (done) {
+    it("should convert the field value to an array", async function () {
       const inputs = [null, "Foo", ["Foo", "Bar"]];
       const outputs = [[], ["Foo"], ["Foo", "Bar"]];
 
@@ -3462,31 +3203,29 @@ describe("annotation", function () {
           });
         });
       }
-      promise.then(done, done.fail);
+      await promise;
     });
 
-    it("should handle unknown flags", function (done) {
+    it("should handle unknown flags", async function () {
       const choiceWidgetRef = Ref.get(166, 0);
       const xref = new XRefMock([
         { ref: choiceWidgetRef, data: choiceWidgetDict },
       ]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.readOnly).toEqual(false);
-        expect(data.hidden).toEqual(false);
-        expect(data.combo).toEqual(false);
-        expect(data.multiSelect).toEqual(false);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.readOnly).toEqual(false);
+      expect(data.hidden).toEqual(false);
+      expect(data.combo).toEqual(false);
+      expect(data.multiSelect).toEqual(false);
     });
 
-    it("should not set invalid flags", function (done) {
+    it("should not set invalid flags", async function () {
       choiceWidgetDict.set("Ff", "readonly");
 
       const choiceWidgetRef = Ref.get(165, 0);
@@ -3494,22 +3233,20 @@ describe("annotation", function () {
         { ref: choiceWidgetRef, data: choiceWidgetDict },
       ]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.readOnly).toEqual(false);
-        expect(data.hidden).toEqual(false);
-        expect(data.combo).toEqual(false);
-        expect(data.multiSelect).toEqual(false);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.readOnly).toEqual(false);
+      expect(data.hidden).toEqual(false);
+      expect(data.combo).toEqual(false);
+      expect(data.multiSelect).toEqual(false);
     });
 
-    it("should set valid flags", function (done) {
+    it("should set valid flags", async function () {
       choiceWidgetDict.set(
         "Ff",
         AnnotationFieldFlag.READONLY +
@@ -3522,22 +3259,20 @@ describe("annotation", function () {
         { ref: choiceWidgetRef, data: choiceWidgetDict },
       ]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-        expect(data.readOnly).toEqual(true);
-        expect(data.hidden).toEqual(false);
-        expect(data.combo).toEqual(true);
-        expect(data.multiSelect).toEqual(true);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.readOnly).toEqual(true);
+      expect(data.hidden).toEqual(false);
+      expect(data.combo).toEqual(true);
+      expect(data.multiSelect).toEqual(true);
     });
 
-    it("should render choice for printing", function (done) {
+    it("should render choice for printing", async function () {
       const choiceWidgetRef = Ref.get(271, 0);
       const xref = new XRefMock([
         { ref: choiceWidgetRef, data: choiceWidgetDict },
@@ -3546,32 +3281,27 @@ describe("annotation", function () {
       const task = new WorkerTask("test print");
       partialEvaluator.xref = xref;
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, { value: "a value" });
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, { value: "a value" });
 
-          return annotation._getAppearance(
-            partialEvaluator,
-            task,
-            annotationStorage
-          );
-        }, done.fail)
-        .then(appearance => {
-          expect(appearance).toEqual(
-            "/Tx BMC q BT /Helv 5 Tf 1 0 0 1 0 0 Tm" +
-              " 2.00 2.00 Td (a value) Tj ET Q EMC"
-          );
-          done();
-        }, done.fail);
+      const appearance = await annotation._getAppearance(
+        partialEvaluator,
+        task,
+        annotationStorage
+      );
+      expect(appearance).toEqual(
+        "/Tx BMC q BT /Helv 5 Tf 1 0 0 1 0 0 Tm" +
+          " 2.00 2.00 Td (a value) Tj ET Q EMC"
+      );
     });
 
-    it("should save choice", function (done) {
+    it("should save choice", async function () {
       choiceWidgetDict.set("Opt", ["A", "B", "C"]);
       choiceWidgetDict.set("V", "A");
 
@@ -3582,46 +3312,45 @@ describe("annotation", function () {
       partialEvaluator.xref = xref;
       const task = new WorkerTask("test save");
 
-      AnnotationFactory.create(
+      const annotation = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
         pdfManagerMock,
         idFactoryMock
-      )
-        .then(annotation => {
-          const annotationStorage = new Map();
-          annotationStorage.set(annotation.data.id, { value: "C" });
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, { value: "C" });
 
-          return annotation.save(partialEvaluator, task, annotationStorage);
-        }, done.fail)
-        .then(data => {
-          expect(data.length).toEqual(2);
-          const [oldData, newData] = data;
-          expect(oldData.ref).toEqual(Ref.get(123, 0));
-          expect(newData.ref).toEqual(Ref.get(1, 0));
+      const data = await annotation.save(
+        partialEvaluator,
+        task,
+        annotationStorage
+      );
+      expect(data.length).toEqual(2);
+      const [oldData, newData] = data;
+      expect(oldData.ref).toEqual(Ref.get(123, 0));
+      expect(newData.ref).toEqual(Ref.get(1, 0));
 
-          oldData.data = oldData.data.replace(/\(D:[0-9]+\)/, "(date)");
-          expect(oldData.data).toEqual(
-            "123 0 obj\n" +
-              "<< /Type /Annot /Subtype /Widget /FT /Ch /DA (/Helv 5 Tf) /DR " +
-              "<< /Font << /Helv 314 0 R>>>> " +
-              "/Rect [0 0 32 10] /Opt [(A) (B) (C)] /V (C) " +
-              "/AP << /N 1 0 R>> /M (date)>>\nendobj\n"
-          );
-          expect(newData.data).toEqual(
-            "1 0 obj\n" +
-              "<< /Length 67 /Subtype /Form /Resources << /Font << /Helv 314 0 R>>>> " +
-              "/BBox [0 0 32 10]>> stream\n" +
-              "/Tx BMC q BT /Helv 5 Tf 1 0 0 1 0 0 Tm 2.00 2.00 Td (C) Tj ET Q EMC\n" +
-              "endstream\nendobj\n"
-          );
-          done();
-        }, done.fail);
+      oldData.data = oldData.data.replace(/\(D:[0-9]+\)/, "(date)");
+      expect(oldData.data).toEqual(
+        "123 0 obj\n" +
+          "<< /Type /Annot /Subtype /Widget /FT /Ch /DA (/Helv 5 Tf) /DR " +
+          "<< /Font << /Helv 314 0 R>>>> " +
+          "/Rect [0 0 32 10] /Opt [(A) (B) (C)] /V (C) " +
+          "/AP << /N 1 0 R>> /M (date)>>\nendobj\n"
+      );
+      expect(newData.data).toEqual(
+        "1 0 obj\n" +
+          "<< /Length 67 /Subtype /Form /Resources << /Font << /Helv 314 0 R>>>> " +
+          "/BBox [0 0 32 10]>> stream\n" +
+          "/Tx BMC q BT /Helv 5 Tf 1 0 0 1 0 0 Tm 2.00 2.00 Td (C) Tj ET Q EMC\n" +
+          "endstream\nendobj\n"
+      );
     });
   });
 
   describe("LineAnnotation", function () {
-    it("should set the line coordinates", function (done) {
+    it("should set the line coordinates", async function () {
       const lineDict = new Dict();
       lineDict.set("Type", Name.get("Annot"));
       lineDict.set("Subtype", Name.get("Line"));
@@ -3630,21 +3359,19 @@ describe("annotation", function () {
       const lineRef = Ref.get(122, 0);
       const xref = new XRefMock([{ ref: lineRef, data: lineDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         lineRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.LINE);
-        expect(data.lineCoordinates).toEqual([1, 2, 3, 4]);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.LINE);
+      expect(data.lineCoordinates).toEqual([1, 2, 3, 4]);
     });
   });
 
   describe("FileAttachmentAnnotation", function () {
-    it("should correctly parse a file attachment", function (done) {
+    it("should correctly parse a file attachment", async function () {
       const fileStream = new StringStream(
         "<<\n" +
           "/Type /EmbeddedFile\n" +
@@ -3690,22 +3417,20 @@ describe("annotation", function () {
       fileSpecDict.assignXref(xref);
       fileAttachmentDict.assignXref(xref);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         fileAttachmentRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.FILEATTACHMENT);
-        expect(data.file.filename).toEqual("Test.txt");
-        expect(data.file.content).toEqual(stringToBytes("Test attachment"));
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.FILEATTACHMENT);
+      expect(data.file.filename).toEqual("Test.txt");
+      expect(data.file.content).toEqual(stringToBytes("Test attachment"));
     });
   });
 
   describe("PopupAnnotation", function () {
-    it("should inherit properties from its parent", function (done) {
+    it("should inherit properties from its parent", async function () {
       const parentDict = new Dict();
       parentDict.set("Type", Name.get("Annot"));
       parentDict.set("Subtype", Name.get("Text"));
@@ -3720,20 +3445,18 @@ describe("annotation", function () {
       const popupRef = Ref.get(13, 0);
       const xref = new XRefMock([{ ref: popupRef, data: popupDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         popupRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data, viewable }) => {
-        expect(data.annotationType).toEqual(AnnotationType.POPUP);
-        expect(data.modificationDate).toEqual("D:20190423");
-        expect(data.color).toEqual(new Uint8ClampedArray([0, 0, 255]));
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.POPUP);
+      expect(data.modificationDate).toEqual("D:20190423");
+      expect(data.color).toEqual(new Uint8ClampedArray([0, 0, 255]));
     });
 
-    it("should handle missing parent properties", function (done) {
+    it("should handle missing parent properties", async function () {
       const parentDict = new Dict();
       parentDict.set("Type", Name.get("Annot"));
       parentDict.set("Subtype", Name.get("Text"));
@@ -3746,23 +3469,21 @@ describe("annotation", function () {
       const popupRef = Ref.get(13, 0);
       const xref = new XRefMock([{ ref: popupRef, data: popupDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         popupRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data, viewable }) => {
-        expect(data.annotationType).toEqual(AnnotationType.POPUP);
-        expect(data.modificationDate).toEqual(null);
-        expect(data.color).toEqual(null);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.POPUP);
+      expect(data.modificationDate).toEqual(null);
+      expect(data.color).toEqual(null);
     });
 
     it(
       "should inherit the parent flags when the Popup is not viewable, " +
         "but the parent is (PR 7352)",
-      function (done) {
+      async function () {
         const parentDict = new Dict();
         parentDict.set("Type", Name.get("Annot"));
         parentDict.set("Subtype", Name.get("Text"));
@@ -3777,27 +3498,25 @@ describe("annotation", function () {
         const popupRef = Ref.get(13, 0);
         const xref = new XRefMock([{ ref: popupRef, data: popupDict }]);
 
-        AnnotationFactory.create(
+        const { data, viewable } = await AnnotationFactory.create(
           xref,
           popupRef,
           pdfManagerMock,
           idFactoryMock
-        ).then(({ data, viewable }) => {
-          expect(data.annotationType).toEqual(AnnotationType.POPUP);
-          // We should not modify the `annotationFlags` returned through
-          // e.g., the API.
-          expect(data.annotationFlags).toEqual(25);
-          // The popup should inherit the `viewable` property of the parent.
-          expect(viewable).toEqual(true);
-          done();
-        }, done.fail);
+        );
+        expect(data.annotationType).toEqual(AnnotationType.POPUP);
+        // We should not modify the `annotationFlags` returned through
+        // e.g., the API.
+        expect(data.annotationFlags).toEqual(25);
+        // The popup should inherit the `viewable` property of the parent.
+        expect(viewable).toEqual(true);
       }
     );
 
     it(
       "should correctly inherit Contents from group-master annotation " +
         "if parent has ReplyType == Group",
-      function (done) {
+      async function () {
         const annotationRef = Ref.get(819, 0);
         const annotationDict = new Dict();
         annotationDict.set("Type", Name.get("Annot"));
@@ -3838,24 +3557,22 @@ describe("annotation", function () {
         popupDict.assignXref(xref);
         replyDict.assignXref(xref);
 
-        AnnotationFactory.create(
+        const { data } = await AnnotationFactory.create(
           xref,
           popupRef,
           pdfManagerMock,
           idFactoryMock
-        ).then(({ data }) => {
-          expect(data.title).toEqual("Correct Title");
-          expect(data.contents).toEqual("Correct Text");
-          expect(data.modificationDate).toEqual("D:20190423");
-          expect(data.color).toEqual(new Uint8ClampedArray([0, 0, 255]));
-          done();
-        }, done.fail);
+        );
+        expect(data.title).toEqual("Correct Title");
+        expect(data.contents).toEqual("Correct Text");
+        expect(data.modificationDate).toEqual("D:20190423");
+        expect(data.color).toEqual(new Uint8ClampedArray([0, 0, 255]));
       }
     );
   });
 
   describe("InkAnnotation", function () {
-    it("should handle a single ink list", function (done) {
+    it("should handle a single ink list", async function () {
       const inkDict = new Dict();
       inkDict.set("Type", Name.get("Annot"));
       inkDict.set("Subtype", Name.get("Ink"));
@@ -3864,25 +3581,23 @@ describe("annotation", function () {
       const inkRef = Ref.get(142, 0);
       const xref = new XRefMock([{ ref: inkRef, data: inkDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         inkRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.INK);
-        expect(data.inkLists.length).toEqual(1);
-        expect(data.inkLists[0]).toEqual([
-          { x: 1, y: 1 },
-          { x: 1, y: 2 },
-          { x: 2, y: 2 },
-          { x: 3, y: 3 },
-        ]);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.INK);
+      expect(data.inkLists.length).toEqual(1);
+      expect(data.inkLists[0]).toEqual([
+        { x: 1, y: 1 },
+        { x: 1, y: 2 },
+        { x: 2, y: 2 },
+        { x: 3, y: 3 },
+      ]);
     });
 
-    it("should handle multiple ink lists", function (done) {
+    it("should handle multiple ink lists", async function () {
       const inkDict = new Dict();
       inkDict.set("Type", Name.get("Annot"));
       inkDict.set("Subtype", Name.get("Ink"));
@@ -3894,29 +3609,27 @@ describe("annotation", function () {
       const inkRef = Ref.get(143, 0);
       const xref = new XRefMock([{ ref: inkRef, data: inkDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         inkRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.INK);
-        expect(data.inkLists.length).toEqual(2);
-        expect(data.inkLists[0]).toEqual([
-          { x: 1, y: 1 },
-          { x: 1, y: 2 },
-        ]);
-        expect(data.inkLists[1]).toEqual([
-          { x: 3, y: 3 },
-          { x: 4, y: 5 },
-        ]);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.INK);
+      expect(data.inkLists.length).toEqual(2);
+      expect(data.inkLists[0]).toEqual([
+        { x: 1, y: 1 },
+        { x: 1, y: 2 },
+      ]);
+      expect(data.inkLists[1]).toEqual([
+        { x: 3, y: 3 },
+        { x: 4, y: 5 },
+      ]);
     });
   });
 
   describe("HightlightAnnotation", function () {
-    it("should set quadpoints to null if not defined", function (done) {
+    it("should set quadpoints to null if not defined", async function () {
       const highlightDict = new Dict();
       highlightDict.set("Type", Name.get("Annot"));
       highlightDict.set("Subtype", Name.get("Highlight"));
@@ -3924,19 +3637,17 @@ describe("annotation", function () {
       const highlightRef = Ref.get(121, 0);
       const xref = new XRefMock([{ ref: highlightRef, data: highlightDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         highlightRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.HIGHLIGHT);
-        expect(data.quadPoints).toEqual(null);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.HIGHLIGHT);
+      expect(data.quadPoints).toEqual(null);
     });
 
-    it("should set quadpoints if defined", function (done) {
+    it("should set quadpoints if defined", async function () {
       const highlightDict = new Dict();
       highlightDict.set("Type", Name.get("Annot"));
       highlightDict.set("Subtype", Name.get("Highlight"));
@@ -3946,26 +3657,24 @@ describe("annotation", function () {
       const highlightRef = Ref.get(121, 0);
       const xref = new XRefMock([{ ref: highlightRef, data: highlightDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         highlightRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.HIGHLIGHT);
-        expect(data.quadPoints).toEqual([
-          [
-            { x: 10, y: 20 },
-            { x: 20, y: 20 },
-            { x: 10, y: 10 },
-            { x: 20, y: 10 },
-          ],
-        ]);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.HIGHLIGHT);
+      expect(data.quadPoints).toEqual([
+        [
+          { x: 10, y: 20 },
+          { x: 20, y: 20 },
+          { x: 10, y: 10 },
+          { x: 20, y: 10 },
+        ],
+      ]);
     });
 
-    it("should set quadpoints to null when empty", function (done) {
+    it("should set quadpoints to null when empty", async function () {
       const highlightDict = new Dict();
       highlightDict.set("Type", Name.get("Annot"));
       highlightDict.set("Subtype", Name.get("Highlight"));
@@ -3975,21 +3684,19 @@ describe("annotation", function () {
       const highlightRef = Ref.get(121, 0);
       const xref = new XRefMock([{ ref: highlightRef, data: highlightDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         highlightRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.HIGHLIGHT);
-        expect(data.quadPoints).toEqual(null);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.HIGHLIGHT);
+      expect(data.quadPoints).toEqual(null);
     });
   });
 
   describe("UnderlineAnnotation", function () {
-    it("should set quadpoints to null if not defined", function (done) {
+    it("should set quadpoints to null if not defined", async function () {
       const underlineDict = new Dict();
       underlineDict.set("Type", Name.get("Annot"));
       underlineDict.set("Subtype", Name.get("Underline"));
@@ -3997,19 +3704,17 @@ describe("annotation", function () {
       const underlineRef = Ref.get(121, 0);
       const xref = new XRefMock([{ ref: underlineRef, data: underlineDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         underlineRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.UNDERLINE);
-        expect(data.quadPoints).toEqual(null);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.UNDERLINE);
+      expect(data.quadPoints).toEqual(null);
     });
 
-    it("should set quadpoints if defined", function (done) {
+    it("should set quadpoints if defined", async function () {
       const underlineDict = new Dict();
       underlineDict.set("Type", Name.get("Annot"));
       underlineDict.set("Subtype", Name.get("Underline"));
@@ -4019,28 +3724,26 @@ describe("annotation", function () {
       const underlineRef = Ref.get(121, 0);
       const xref = new XRefMock([{ ref: underlineRef, data: underlineDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         underlineRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.UNDERLINE);
-        expect(data.quadPoints).toEqual([
-          [
-            { x: 10, y: 20 },
-            { x: 20, y: 20 },
-            { x: 10, y: 10 },
-            { x: 20, y: 10 },
-          ],
-        ]);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.UNDERLINE);
+      expect(data.quadPoints).toEqual([
+        [
+          { x: 10, y: 20 },
+          { x: 20, y: 20 },
+          { x: 10, y: 10 },
+          { x: 20, y: 10 },
+        ],
+      ]);
     });
   });
 
   describe("SquigglyAnnotation", function () {
-    it("should set quadpoints to null if not defined", function (done) {
+    it("should set quadpoints to null if not defined", async function () {
       const squigglyDict = new Dict();
       squigglyDict.set("Type", Name.get("Annot"));
       squigglyDict.set("Subtype", Name.get("Squiggly"));
@@ -4048,19 +3751,17 @@ describe("annotation", function () {
       const squigglyRef = Ref.get(121, 0);
       const xref = new XRefMock([{ ref: squigglyRef, data: squigglyDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         squigglyRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.SQUIGGLY);
-        expect(data.quadPoints).toEqual(null);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.SQUIGGLY);
+      expect(data.quadPoints).toEqual(null);
     });
 
-    it("should set quadpoints if defined", function (done) {
+    it("should set quadpoints if defined", async function () {
       const squigglyDict = new Dict();
       squigglyDict.set("Type", Name.get("Annot"));
       squigglyDict.set("Subtype", Name.get("Squiggly"));
@@ -4070,28 +3771,26 @@ describe("annotation", function () {
       const squigglyRef = Ref.get(121, 0);
       const xref = new XRefMock([{ ref: squigglyRef, data: squigglyDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         squigglyRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.SQUIGGLY);
-        expect(data.quadPoints).toEqual([
-          [
-            { x: 10, y: 20 },
-            { x: 20, y: 20 },
-            { x: 10, y: 10 },
-            { x: 20, y: 10 },
-          ],
-        ]);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.SQUIGGLY);
+      expect(data.quadPoints).toEqual([
+        [
+          { x: 10, y: 20 },
+          { x: 20, y: 20 },
+          { x: 10, y: 10 },
+          { x: 20, y: 10 },
+        ],
+      ]);
     });
   });
 
   describe("StrikeOutAnnotation", function () {
-    it("should set quadpoints to null if not defined", function (done) {
+    it("should set quadpoints to null if not defined", async function () {
       const strikeOutDict = new Dict();
       strikeOutDict.set("Type", Name.get("Annot"));
       strikeOutDict.set("Subtype", Name.get("StrikeOut"));
@@ -4099,19 +3798,17 @@ describe("annotation", function () {
       const strikeOutRef = Ref.get(121, 0);
       const xref = new XRefMock([{ ref: strikeOutRef, data: strikeOutDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         strikeOutRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.STRIKEOUT);
-        expect(data.quadPoints).toEqual(null);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.STRIKEOUT);
+      expect(data.quadPoints).toEqual(null);
     });
 
-    it("should set quadpoints if defined", function (done) {
+    it("should set quadpoints if defined", async function () {
       const strikeOutDict = new Dict();
       strikeOutDict.set("Type", Name.get("Annot"));
       strikeOutDict.set("Subtype", Name.get("StrikeOut"));
@@ -4121,23 +3818,21 @@ describe("annotation", function () {
       const strikeOutRef = Ref.get(121, 0);
       const xref = new XRefMock([{ ref: strikeOutRef, data: strikeOutDict }]);
 
-      AnnotationFactory.create(
+      const { data } = await AnnotationFactory.create(
         xref,
         strikeOutRef,
         pdfManagerMock,
         idFactoryMock
-      ).then(({ data }) => {
-        expect(data.annotationType).toEqual(AnnotationType.STRIKEOUT);
-        expect(data.quadPoints).toEqual([
-          [
-            { x: 10, y: 20 },
-            { x: 20, y: 20 },
-            { x: 10, y: 10 },
-            { x: 20, y: 10 },
-          ],
-        ]);
-        done();
-      }, done.fail);
+      );
+      expect(data.annotationType).toEqual(AnnotationType.STRIKEOUT);
+      expect(data.quadPoints).toEqual([
+        [
+          { x: 10, y: 20 },
+          { x: 20, y: 20 },
+          { x: 10, y: 10 },
+          { x: 20, y: 10 },
+        ],
+      ]);
     });
   });
 });

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -37,24 +37,16 @@ describe("evaluator", function () {
     },
   };
 
-  function runOperatorListCheck(evaluator, stream, resources, callback) {
-    const result = new OperatorList();
+  async function runOperatorListCheck(evaluator, stream, resources) {
+    const operatorList = new OperatorList();
     const task = new WorkerTask("OperatorListCheck");
-    evaluator
-      .getOperatorList({
-        stream,
-        task,
-        resources,
-        operatorList: result,
-      })
-      .then(
-        function () {
-          callback(result);
-        },
-        function (reason) {
-          callback(reason);
-        }
-      );
+    await evaluator.getOperatorList({
+      stream,
+      task,
+      resources,
+      operatorList,
+    });
+    return operatorList;
   }
 
   let partialEvaluator;
@@ -73,38 +65,32 @@ describe("evaluator", function () {
   });
 
   describe("splitCombinedOperations", function () {
-    it("should reject unknown operations", function (done) {
+    it("should reject unknown operations", async function () {
       const stream = new StringStream("fTT");
-      runOperatorListCheck(
+      const result = await runOperatorListCheck(
         partialEvaluator,
         stream,
-        new ResourcesMock(),
-        function (result) {
-          expect(!!result.fnArray && !!result.argsArray).toEqual(true);
-          expect(result.fnArray.length).toEqual(1);
-          expect(result.fnArray[0]).toEqual(OPS.fill);
-          expect(result.argsArray[0]).toEqual(null);
-          done();
-        }
+        new ResourcesMock()
       );
+      expect(!!result.fnArray && !!result.argsArray).toEqual(true);
+      expect(result.fnArray.length).toEqual(1);
+      expect(result.fnArray[0]).toEqual(OPS.fill);
+      expect(result.argsArray[0]).toEqual(null);
     });
 
-    it("should handle one operation", function (done) {
+    it("should handle one operation", async function () {
       const stream = new StringStream("Q");
-      runOperatorListCheck(
+      const result = await runOperatorListCheck(
         partialEvaluator,
         stream,
-        new ResourcesMock(),
-        function (result) {
-          expect(!!result.fnArray && !!result.argsArray).toEqual(true);
-          expect(result.fnArray.length).toEqual(1);
-          expect(result.fnArray[0]).toEqual(OPS.restore);
-          done();
-        }
+        new ResourcesMock()
       );
+      expect(!!result.fnArray && !!result.argsArray).toEqual(true);
+      expect(result.fnArray.length).toEqual(1);
+      expect(result.fnArray[0]).toEqual(OPS.restore);
     });
 
-    it("should handle two glued operations", function (done) {
+    it("should handle two glued operations", async function () {
       const imgDict = new Dict();
       imgDict.set("Subtype", Name.get("Image"));
       imgDict.set("Width", 1);
@@ -120,133 +106,114 @@ describe("evaluator", function () {
       resources.XObject = xObject;
 
       const stream = new StringStream("/Res1 DoQ");
-      runOperatorListCheck(
+      const result = await runOperatorListCheck(
         partialEvaluator,
         stream,
-        resources,
-        function (result) {
-          expect(result.fnArray.length).toEqual(3);
-          expect(result.fnArray[0]).toEqual(OPS.dependency);
-          expect(result.fnArray[1]).toEqual(OPS.paintImageXObject);
-          expect(result.fnArray[2]).toEqual(OPS.restore);
-          expect(result.argsArray.length).toEqual(3);
-          expect(result.argsArray[0]).toEqual(["img_p0_1"]);
-          expect(result.argsArray[1]).toEqual(["img_p0_1", 1, 1]);
-          expect(result.argsArray[2]).toEqual(null);
-          done();
-        }
+        resources
       );
+      expect(result.fnArray.length).toEqual(3);
+      expect(result.fnArray[0]).toEqual(OPS.dependency);
+      expect(result.fnArray[1]).toEqual(OPS.paintImageXObject);
+      expect(result.fnArray[2]).toEqual(OPS.restore);
+      expect(result.argsArray.length).toEqual(3);
+      expect(result.argsArray[0]).toEqual(["img_p0_1"]);
+      expect(result.argsArray[1]).toEqual(["img_p0_1", 1, 1]);
+      expect(result.argsArray[2]).toEqual(null);
     });
 
-    it("should handle three glued operations", function (done) {
+    it("should handle three glued operations", async function () {
       const stream = new StringStream("fff");
-      runOperatorListCheck(
+      const result = await runOperatorListCheck(
         partialEvaluator,
         stream,
-        new ResourcesMock(),
-        function (result) {
-          expect(!!result.fnArray && !!result.argsArray).toEqual(true);
-          expect(result.fnArray.length).toEqual(3);
-          expect(result.fnArray[0]).toEqual(OPS.fill);
-          expect(result.fnArray[1]).toEqual(OPS.fill);
-          expect(result.fnArray[2]).toEqual(OPS.fill);
-          done();
-        }
+        new ResourcesMock()
       );
+      expect(!!result.fnArray && !!result.argsArray).toEqual(true);
+      expect(result.fnArray.length).toEqual(3);
+      expect(result.fnArray[0]).toEqual(OPS.fill);
+      expect(result.fnArray[1]).toEqual(OPS.fill);
+      expect(result.fnArray[2]).toEqual(OPS.fill);
     });
 
-    it("should handle three glued operations #2", function (done) {
+    it("should handle three glued operations #2", async function () {
       const resources = new ResourcesMock();
       resources.Res1 = {};
       const stream = new StringStream("B*Bf*");
-      runOperatorListCheck(
+      const result = await runOperatorListCheck(
         partialEvaluator,
         stream,
-        resources,
-        function (result) {
-          expect(!!result.fnArray && !!result.argsArray).toEqual(true);
-          expect(result.fnArray.length).toEqual(3);
-          expect(result.fnArray[0]).toEqual(OPS.eoFillStroke);
-          expect(result.fnArray[1]).toEqual(OPS.fillStroke);
-          expect(result.fnArray[2]).toEqual(OPS.eoFill);
-          done();
-        }
+        resources
       );
+      expect(!!result.fnArray && !!result.argsArray).toEqual(true);
+      expect(result.fnArray.length).toEqual(3);
+      expect(result.fnArray[0]).toEqual(OPS.eoFillStroke);
+      expect(result.fnArray[1]).toEqual(OPS.fillStroke);
+      expect(result.fnArray[2]).toEqual(OPS.eoFill);
     });
 
-    it("should handle glued operations and operands", function (done) {
+    it("should handle glued operations and operands", async function () {
       const stream = new StringStream("f5 Ts");
-      runOperatorListCheck(
+      const result = await runOperatorListCheck(
         partialEvaluator,
         stream,
-        new ResourcesMock(),
-        function (result) {
-          expect(!!result.fnArray && !!result.argsArray).toEqual(true);
-          expect(result.fnArray.length).toEqual(2);
-          expect(result.fnArray[0]).toEqual(OPS.fill);
-          expect(result.fnArray[1]).toEqual(OPS.setTextRise);
-          expect(result.argsArray.length).toEqual(2);
-          expect(result.argsArray[1].length).toEqual(1);
-          expect(result.argsArray[1][0]).toEqual(5);
-          done();
-        }
+        new ResourcesMock()
       );
+      expect(!!result.fnArray && !!result.argsArray).toEqual(true);
+      expect(result.fnArray.length).toEqual(2);
+      expect(result.fnArray[0]).toEqual(OPS.fill);
+      expect(result.fnArray[1]).toEqual(OPS.setTextRise);
+      expect(result.argsArray.length).toEqual(2);
+      expect(result.argsArray[1].length).toEqual(1);
+      expect(result.argsArray[1][0]).toEqual(5);
     });
 
-    it("should handle glued operations and literals", function (done) {
+    it("should handle glued operations and literals", async function () {
       const stream = new StringStream("trueifalserinulln");
-      runOperatorListCheck(
+      const result = await runOperatorListCheck(
         partialEvaluator,
         stream,
-        new ResourcesMock(),
-        function (result) {
-          expect(!!result.fnArray && !!result.argsArray).toEqual(true);
-          expect(result.fnArray.length).toEqual(3);
-          expect(result.fnArray[0]).toEqual(OPS.setFlatness);
-          expect(result.fnArray[1]).toEqual(OPS.setRenderingIntent);
-          expect(result.fnArray[2]).toEqual(OPS.endPath);
-          expect(result.argsArray.length).toEqual(3);
-          expect(result.argsArray[0].length).toEqual(1);
-          expect(result.argsArray[0][0]).toEqual(true);
-          expect(result.argsArray[1].length).toEqual(1);
-          expect(result.argsArray[1][0]).toEqual(false);
-          expect(result.argsArray[2]).toEqual(null);
-          done();
-        }
+        new ResourcesMock()
       );
+      expect(!!result.fnArray && !!result.argsArray).toEqual(true);
+      expect(result.fnArray.length).toEqual(3);
+      expect(result.fnArray[0]).toEqual(OPS.setFlatness);
+      expect(result.fnArray[1]).toEqual(OPS.setRenderingIntent);
+      expect(result.fnArray[2]).toEqual(OPS.endPath);
+      expect(result.argsArray.length).toEqual(3);
+      expect(result.argsArray[0].length).toEqual(1);
+      expect(result.argsArray[0][0]).toEqual(true);
+      expect(result.argsArray[1].length).toEqual(1);
+      expect(result.argsArray[1][0]).toEqual(false);
+      expect(result.argsArray[2]).toEqual(null);
     });
   });
 
   describe("validateNumberOfArgs", function () {
-    it("should execute if correct number of arguments", function (done) {
+    it("should execute if correct number of arguments", async function () {
       const stream = new StringStream("5 1 d0");
-      runOperatorListCheck(
+      const result = await runOperatorListCheck(
         partialEvaluator,
         stream,
-        new ResourcesMock(),
-        function (result) {
-          expect(result.argsArray[0][0]).toEqual(5);
-          expect(result.argsArray[0][1]).toEqual(1);
-          expect(result.fnArray[0]).toEqual(OPS.setCharWidth);
-          done();
-        }
+        new ResourcesMock()
       );
+      expect(result.argsArray[0][0]).toEqual(5);
+      expect(result.argsArray[0][1]).toEqual(1);
+      expect(result.fnArray[0]).toEqual(OPS.setCharWidth);
     });
-    it("should execute if too many arguments", function (done) {
+
+    it("should execute if too many arguments", async function () {
       const stream = new StringStream("5 1 4 d0");
-      runOperatorListCheck(
+      const result = await runOperatorListCheck(
         partialEvaluator,
         stream,
-        new ResourcesMock(),
-        function (result) {
-          expect(result.argsArray[0][0]).toEqual(1);
-          expect(result.argsArray[0][1]).toEqual(4);
-          expect(result.fnArray[0]).toEqual(OPS.setCharWidth);
-          done();
-        }
+        new ResourcesMock()
       );
+      expect(result.argsArray[0][0]).toEqual(1);
+      expect(result.argsArray[0][1]).toEqual(4);
+      expect(result.fnArray[0]).toEqual(OPS.setCharWidth);
     });
-    it("should execute if nested commands", function (done) {
+
+    it("should execute if nested commands", async function () {
       const gState = new Dict();
       gState.set("LW", 2);
       gState.set("CA", 0.5);
@@ -258,114 +225,111 @@ describe("evaluator", function () {
       resources.ExtGState = extGState;
 
       const stream = new StringStream("/F2 /GS2 gs 5.711 Tf");
-      runOperatorListCheck(
+      const result = await runOperatorListCheck(
         partialEvaluator,
         stream,
-        resources,
-        function (result) {
-          expect(result.fnArray.length).toEqual(3);
-          expect(result.fnArray[0]).toEqual(OPS.setGState);
-          expect(result.fnArray[1]).toEqual(OPS.dependency);
-          expect(result.fnArray[2]).toEqual(OPS.setFont);
-          expect(result.argsArray.length).toEqual(3);
-          expect(result.argsArray[0]).toEqual([
-            [
-              ["LW", 2],
-              ["CA", 0.5],
-            ],
-          ]);
-          expect(result.argsArray[1]).toEqual(["g_font_error"]);
-          expect(result.argsArray[2]).toEqual(["g_font_error", 5.711]);
-          done();
-        }
+        resources
       );
+      expect(result.fnArray.length).toEqual(3);
+      expect(result.fnArray[0]).toEqual(OPS.setGState);
+      expect(result.fnArray[1]).toEqual(OPS.dependency);
+      expect(result.fnArray[2]).toEqual(OPS.setFont);
+      expect(result.argsArray.length).toEqual(3);
+      expect(result.argsArray[0]).toEqual([
+        [
+          ["LW", 2],
+          ["CA", 0.5],
+        ],
+      ]);
+      expect(result.argsArray[1]).toEqual(["g_font_error"]);
+      expect(result.argsArray[2]).toEqual(["g_font_error", 5.711]);
     });
-    it("should skip if too few arguments", function (done) {
+
+    it("should skip if too few arguments", async function () {
       const stream = new StringStream("5 d0");
-      runOperatorListCheck(
+      const result = await runOperatorListCheck(
         partialEvaluator,
         stream,
-        new ResourcesMock(),
-        function (result) {
-          expect(result.argsArray).toEqual([]);
-          expect(result.fnArray).toEqual([]);
-          done();
-        }
+        new ResourcesMock()
       );
+      expect(result.argsArray).toEqual([]);
+      expect(result.fnArray).toEqual([]);
     });
 
     it(
       "should error if (many) path operators have too few arguments " +
         "(bug 1443140)",
-      function (done) {
+      async function () {
         const NUM_INVALID_OPS = 25;
         const tempArr = new Array(NUM_INVALID_OPS + 1);
 
         // Non-path operators, should be ignored.
         const invalidMoveText = tempArr.join("10 Td\n");
         const moveTextStream = new StringStream(invalidMoveText);
-        runOperatorListCheck(
+        const result = await runOperatorListCheck(
           partialEvaluator,
           moveTextStream,
-          new ResourcesMock(),
-          function (result) {
-            expect(result.argsArray).toEqual([]);
-            expect(result.fnArray).toEqual([]);
-            done();
-          }
+          new ResourcesMock()
         );
+        expect(result.argsArray).toEqual([]);
+        expect(result.fnArray).toEqual([]);
 
         // Path operators, should throw error.
         const invalidLineTo = tempArr.join("20 l\n");
         const lineToStream = new StringStream(invalidLineTo);
-        runOperatorListCheck(
-          partialEvaluator,
-          lineToStream,
-          new ResourcesMock(),
-          function (error) {
-            expect(error instanceof FormatError).toEqual(true);
-            expect(error.message).toEqual(
-              "Invalid command l: expected 2 args, but received 1 args."
-            );
-            done();
-          }
-        );
+
+        try {
+          await runOperatorListCheck(
+            partialEvaluator,
+            lineToStream,
+            new ResourcesMock()
+          );
+
+          // Shouldn't get here.
+          expect(false).toEqual(true);
+        } catch (reason) {
+          expect(reason instanceof FormatError).toEqual(true);
+          expect(reason.message).toEqual(
+            "Invalid command l: expected 2 args, but received 1 args."
+          );
+        }
       }
     );
 
-    it("should close opened saves", function (done) {
+    it("should close opened saves", async function () {
       const stream = new StringStream("qq");
-      runOperatorListCheck(
+      const result = await runOperatorListCheck(
         partialEvaluator,
         stream,
-        new ResourcesMock(),
-        function (result) {
-          expect(!!result.fnArray && !!result.argsArray).toEqual(true);
-          expect(result.fnArray.length).toEqual(4);
-          expect(result.fnArray[0]).toEqual(OPS.save);
-          expect(result.fnArray[1]).toEqual(OPS.save);
-          expect(result.fnArray[2]).toEqual(OPS.restore);
-          expect(result.fnArray[3]).toEqual(OPS.restore);
-          done();
-        }
+        new ResourcesMock()
       );
+      expect(!!result.fnArray && !!result.argsArray).toEqual(true);
+      expect(result.fnArray.length).toEqual(4);
+      expect(result.fnArray[0]).toEqual(OPS.save);
+      expect(result.fnArray[1]).toEqual(OPS.save);
+      expect(result.fnArray[2]).toEqual(OPS.restore);
+      expect(result.fnArray[3]).toEqual(OPS.restore);
     });
-    it("should error on paintXObject if name is missing", function (done) {
+
+    it("should error on paintXObject if name is missing", async function () {
       const stream = new StringStream("/ Do");
-      runOperatorListCheck(
-        partialEvaluator,
-        stream,
-        new ResourcesMock(),
-        function (result) {
-          expect(result instanceof FormatError).toEqual(true);
-          expect(result.message).toEqual(
-            "XObject must be referred to by name."
-          );
-          done();
-        }
-      );
+
+      try {
+        await runOperatorListCheck(
+          partialEvaluator,
+          stream,
+          new ResourcesMock()
+        );
+
+        // Shouldn't get here.
+        expect(false).toEqual(true);
+      } catch (reason) {
+        expect(reason instanceof FormatError).toEqual(true);
+        expect(reason.message).toEqual("XObject must be referred to by name.");
+      }
     });
-    it("should skip paintXObject if subtype is PS", function (done) {
+
+    it("should skip paintXObject if subtype is PS", async function () {
       const xobjStreamDict = new Dict();
       xobjStreamDict.set("Subtype", Name.get("PS"));
       const xobjStream = new Stream([], 0, 0, xobjStreamDict);
@@ -377,54 +341,58 @@ describe("evaluator", function () {
       resources.set("XObject", xobjs);
 
       const stream = new StringStream("/Res1 Do");
-      runOperatorListCheck(
+      const result = await runOperatorListCheck(
         partialEvaluator,
         stream,
-        resources,
-        function (result) {
-          expect(result.argsArray).toEqual([]);
-          expect(result.fnArray).toEqual([]);
-          done();
-        }
+        resources
       );
+      expect(result.argsArray).toEqual([]);
+      expect(result.fnArray).toEqual([]);
     });
   });
 
   describe("thread control", function () {
-    it("should abort operator list parsing", function (done) {
+    it("should abort operator list parsing", async function () {
       const stream = new StringStream("qqQQ");
       const resources = new ResourcesMock();
       const result = new OperatorList();
       const task = new WorkerTask("OperatorListAbort");
       task.terminate();
-      partialEvaluator
-        .getOperatorList({
+
+      try {
+        await partialEvaluator.getOperatorList({
           stream,
           task,
           resources,
           operatorList: result,
-        })
-        .catch(function () {
-          expect(!!result.fnArray && !!result.argsArray).toEqual(true);
-          expect(result.fnArray.length).toEqual(0);
-          done();
         });
+
+        // Shouldn't get here.
+        expect(false).toEqual(true);
+      } catch (_) {
+        expect(!!result.fnArray && !!result.argsArray).toEqual(true);
+        expect(result.fnArray.length).toEqual(0);
+      }
     });
-    it("should abort text parsing parsing", function (done) {
+
+    it("should abort text content parsing", async function () {
       const resources = new ResourcesMock();
       const stream = new StringStream("qqQQ");
       const task = new WorkerTask("TextContentAbort");
       task.terminate();
-      partialEvaluator
-        .getTextContent({
+
+      try {
+        await partialEvaluator.getTextContent({
           stream,
           task,
           resources,
-        })
-        .catch(function () {
-          expect(true).toEqual(true);
-          done();
         });
+
+        // Shouldn't get here.
+        expect(false).toEqual(true);
+      } catch (_) {
+        expect(true).toEqual(true);
+      }
     });
   });
 


### PR DESCRIPTION
It's highly recommended to use the `?w=1` flag during review because of many indentation changes.