### PR TITLE
For CFF fonts without proper `ToUnicode`/`Encoding` data, utilize the "charset"/"Encoding"-data from the font file to improve text-selection (issue 13260)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -2853,7 +2853,7 @@ class PartialEvaluator {
     }
 
     if (baseEncodingName) {
-      properties.defaultEncoding = getEncoding(baseEncodingName).slice();
+      properties.defaultEncoding = getEncoding(baseEncodingName);
     } else {
       var isSymbolicFont = !!(properties.flags & FontFlags.Symbolic);
       var isNonsymbolicFont = !!(properties.flags & FontFlags.Nonsymbolic);


### PR DESCRIPTION
This patch extends the approach, implemented in PR #7550, to also apply to CFF fonts.

Fixes #13260