### PR TITLE
Add presentation role to text layer spans.

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -173,6 +173,9 @@ const renderTextLayer = (function renderTextLayerClosure() {
     textDiv.style.fontSize = `${fontHeight}px`;
     textDiv.style.fontFamily = style.fontFamily;
 
+    // Keeps screen readers from pausing on every new text span.
+    textDiv.setAttribute("role", "presentation");
+
     textDiv.textContent = geom.str;
     // geom.dir may be 'ttb' for vertical texts.
     textDiv.dir = geom.dir;


### PR DESCRIPTION
Keeps screen readers from pausing on every span so
paragraphs are read more naturally. Note: this only seems
to affect Firefox, Chrome automatically combines the spans.

One of the review comments from
https://bugzilla.mozilla.org/show_bug.cgi?id=1705139#c1