### PR TITLE
Ensure that `saveDocument` works if there's no /ID-entry in the PDF document (issue 13279)

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -633,11 +633,11 @@ class WorkerMessageHandler {
 
             newXrefInfo = {
               rootRef: xref.trailer.getRaw("Root") || null,
-              encrypt: xref.trailer.getRaw("Encrypt") || null,
+              encryptRef: xref.trailer.getRaw("Encrypt") || null,
               newRef: xref.getNewRef(),
               infoRef: xref.trailer.getRaw("Info") || null,
               info: infoObj,
-              fileIds: xref.trailer.getRaw("ID") || null,
+              fileIds: xref.trailer.get("ID") || null,
               startXRef,
               filename,
             };

--- a/src/core/writer.js
+++ b/src/core/writer.js
@@ -201,8 +201,8 @@ function incrementalUpdate({
   if (xrefInfo.infoRef !== null) {
     newXref.set("Info", xrefInfo.infoRef);
   }
-  if (xrefInfo.encrypt !== null) {
-    newXref.set("Encrypt", xrefInfo.encrypt);
+  if (xrefInfo.encryptRef !== null) {
+    newXref.set("Encrypt", xrefInfo.encryptRef);
   }
 
   // Add a ref for the new xref and sort them
@@ -226,7 +226,7 @@ function incrementalUpdate({
 
   newXref.set("Index", indexes);
 
-  if (xrefInfo.fileIds.length !== 0) {
+  if (Array.isArray(xrefInfo.fileIds) && xrefInfo.fileIds.length > 0) {
     const md5 = computeMD5(baseOffset, xrefInfo);
     newXref.set("ID", [xrefInfo.fileIds[0], md5]);
   }

--- a/test/unit/writer_spec.js
+++ b/test/unit/writer_spec.js
@@ -32,7 +32,7 @@ describe("Writer", function () {
         fileIds: ["id", ""],
         rootRef: null,
         infoRef: null,
-        encrypt: null,
+        encryptRef: null,
         filename: "foo.pdf",
         info: {},
       };
@@ -55,6 +55,40 @@ describe("Writer", function () {
         "endobj\n" +
         "startxref\n" +
         "10\n" +
+        "%%EOF\n";
+
+      expect(data).toEqual(expected);
+    });
+
+    it("should update a file, missing the /ID-entry, with new objects", function () {
+      const originalData = new Uint8Array();
+      const newRefs = [{ ref: Ref.get(123, 0x2d), data: "abc\n" }];
+      const xrefInfo = {
+        newRef: Ref.get(789, 0),
+        startXRef: 314,
+        fileIds: null,
+        rootRef: null,
+        infoRef: null,
+        encryptRef: null,
+        filename: "foo.pdf",
+        info: {},
+      };
+
+      let data = incrementalUpdate({ originalData, xrefInfo, newRefs });
+      data = bytesToString(data);
+
+      const expected =
+        "\nabc\n" +
+        "789 0 obj\n" +
+        "<< /Size 790 /Prev 314 /Type /XRef /Index [0 1 123 1 789 1] " +
+        "/W [1 1 2] /Length 12>> stream\n" +
+        "\x00\x01\xff\xff" +
+        "\x01\x01\x00\x2d" +
+        "\x01\x05\x00\x00\n" +
+        "endstream\n" +
+        "endobj\n" +
+        "startxref\n" +
+        "5\n" +
         "%%EOF\n";
 
       expect(data).toEqual(expected);


### PR DESCRIPTION
First of all, while it should be very unlikely that the /ID-entry is an *indirect* object, note how we're using `Dict.get` when parsing it e.g. in `PDFDocument.fingerprint`. Hence we definitely should be consistent here, since if the /ID-entry is an *indirect* object the existing code in `src/core/writer.js` would already fail.
Secondly, to fix the referenced issue, we also need to check that the /ID-entry actually is an Array before attempting to access its contents in `src/core/writer.js`.

*Drive-by change:* In the `xrefInfo` object passed to the `incrementalUpdate` function, re-name the `encrypt` property to `encryptRef` since its data is fetched using `Dict.getRaw` (given the names of the other properties fetched similarly).

Fixes #13279