### PR TITLE
Change `NameOrNumberTree.getAll` to return a `Map` rather than an Object

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -894,18 +894,20 @@ class Catalog {
 
   _collectJavaScript() {
     const obj = this._catDict.get("Names");
-
     let javaScript = null;
+
     function appendIfJavaScriptDict(name, jsDict) {
-      const type = jsDict.get("S");
-      if (!isName(type, "JavaScript")) {
+      if (!(jsDict instanceof Dict)) {
+        return;
+      }
+      if (!isName(jsDict.get("S"), "JavaScript")) {
         return;
       }
 
       let js = jsDict.get("JS");
       if (isStream(js)) {
         js = bytesToString(js.getBytes());
-      } else if (!isString(js)) {
+      } else if (typeof js !== "string") {
         return;
       }
 
@@ -918,17 +920,12 @@ class Catalog {
     if (obj instanceof Dict && obj.has("JavaScript")) {
       const nameTree = new NameTree(obj.getRaw("JavaScript"), this.xref);
       for (const [key, value] of nameTree.getAll()) {
-        // We don't use most JavaScript in PDF documents. This code is
-        // defensive so we don't cause errors on document load.
-        if (value instanceof Dict) {
-          appendIfJavaScriptDict(key, value);
-        }
+        appendIfJavaScriptDict(key, value);
       }
     }
-
-    // Append OpenAction "JavaScript" actions to the JavaScript array.
+    // Append OpenAction "JavaScript" actions, if any, to the JavaScript map.
     const openAction = this._catDict.get("OpenAction");
-    if (isDict(openAction) && isName(openAction.get("S"), "JavaScript")) {
+    if (openAction) {
       appendIfJavaScriptDict("OpenAction", openAction);
     }
 

--- a/src/core/name_number_tree.js
+++ b/src/core/name_number_tree.js
@@ -32,9 +32,9 @@ class NameOrNumberTree {
   }
 
   getAll() {
-    const dict = Object.create(null);
+    const map = new Map();
     if (!this.root) {
-      return dict;
+      return map;
     }
     const xref = this.xref;
     // Reading Name/Number tree.
@@ -59,13 +59,14 @@ class NameOrNumberTree {
         continue;
       }
       const entries = obj.get(this._type);
-      if (Array.isArray(entries)) {
-        for (let i = 0, ii = entries.length; i < ii; i += 2) {
-          dict[xref.fetchIfRef(entries[i])] = xref.fetchIfRef(entries[i + 1]);
-        }
+      if (!Array.isArray(entries)) {
+        continue;
+      }
+      for (let i = 0, ii = entries.length; i < ii; i += 2) {
+        map.set(xref.fetchIfRef(entries[i]), xref.fetchIfRef(entries[i + 1]));
       }
     }
-    return dict;
+    return map;
   }
 
   get(key) {


### PR DESCRIPTION
Given that we're (almost) always iterating through the result of the `getAll`-calls, using a `Map` seems nicer overall since it's more suited to iteration compared to a regular Object.

Also, add a couple of `Dict`-checks in existing code touched by this patch, since it really cannot hurt to prevent *potential* errors in a corrupt PDF document.