### PR TITLE
Add a note about minification to the webpack-example README (issue 13290)

### DIFF
--- a/examples/webpack/README.md
+++ b/examples/webpack/README.md
@@ -18,6 +18,12 @@ Refer to the `main.js` and `webpack.config.js` files for the source code.
 Note that PDF.js packaging requires packaging of the main application and
 the worker code, and the `workerSrc` path shall be set to the latter file.
 
+### Minification
+
+If you are configuring Webpack to output a minified build, please note that you
+*must* configure the minifier to keep original class/function names intact;
+otherwise the build is not guaranteed to work correctly.
+
 ## Worker loading
 
 If you are getting the `Setting up fake worker` warning, make sure you are


### PR DESCRIPTION
Since we really don't want to let a particular Webpack-mode dictate how we can/can't write code, let's add a note in the webpack-example README about minification instead.

Fixes #13290

---

I'd also suggest that we amend the FAQ-entry, i.e. https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#minified, with something like:
```
If you are not using `gulp minified`, please note that you *must* configure the minifier to keep original class/function names intact; otherwise the build is not guaranteed to work correctly.
```