### PR TITLE
Don't try to insert a structTree in a removed page (PR 13171 follow-up)

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -618,9 +618,16 @@ class PDFPageView {
         }
         this.eventBus._off("textlayerrendered", this._onTextLayerRendered);
         this._onTextLayerRendered = null;
+
+        if (!this.canvas) {
+          return; // The canvas was removed, prevent errors below.
+        }
         this.pdfPage.getStructTree().then(tree => {
           if (!tree) {
             return;
+          }
+          if (!this.canvas) {
+            return; // The canvas was removed, prevent errors below.
           }
           const treeDom = this.structTreeLayer.render(tree);
           treeDom.classList.add("structTree");


### PR DESCRIPTION
Given that both the textLayer rendering *and* the structTree parsing is asynchronous, it's possible that we'll attempt to insert the structTree in a removed page. While there's thankfully no outright breakage caused by this, it will nonetheless lead to errors being printed in the console and we should obviously avoid this.

To reproduce this bug (without the patch), open http://localhost:8888/web/viewer.html?file=/test/pdfs/pdf.pdf#disableStream=true&disableAutoFetch=true and scroll *very quickly* through the document and notice the following error being (intermittently) printed in the console:
```
Uncaught (in promise) TypeError: can't access property "appendChild", this.canvas is undefined
```

/cc @brendandahl 