### PR TITLE
Add a new `BaseStream.getString(...)` method to replace manual `bytesToString(BaseStream.getBytes(...))` calls

### DIFF
--- a/src/core/base_stream.js
+++ b/src/core/base_stream.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { shadow, unreachable } from "../shared/util.js";
+import { bytesToString, shadow, unreachable } from "../shared/util.js";
 
 class BaseStream {
   constructor() {
@@ -77,6 +77,10 @@ class BaseStream {
 
   getByteRange(begin, end) {
     unreachable("Abstract method `getByteRange` called");
+  }
+
+  getString(length) {
+    return bytesToString(this.getBytes(length, /* forceClamped = */ false));
   }
 
   skip(n) {

--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -14,23 +14,6 @@
  */
 
 import {
-  bytesToString,
-  createPromiseCapability,
-  createValidAbsoluteUrl,
-  DocumentActionEventType,
-  FormatError,
-  info,
-  isBool,
-  isNum,
-  isString,
-  objectSize,
-  PermissionFlag,
-  shadow,
-  stringToPDFString,
-  stringToUTF8String,
-  warn,
-} from "../shared/util.js";
-import {
   clearPrimitiveCaches,
   Dict,
   isDict,
@@ -46,6 +29,22 @@ import {
   MissingDataException,
   toRomanNumerals,
 } from "./core_utils.js";
+import {
+  createPromiseCapability,
+  createValidAbsoluteUrl,
+  DocumentActionEventType,
+  FormatError,
+  info,
+  isBool,
+  isNum,
+  isString,
+  objectSize,
+  PermissionFlag,
+  shadow,
+  stringToPDFString,
+  stringToUTF8String,
+  warn,
+} from "../shared/util.js";
 import { NameTree, NumberTree } from "./name_number_tree.js";
 import { ColorSpace } from "./colorspace.js";
 import { FileSpec } from "./file_spec.js";
@@ -136,7 +135,7 @@ class Catalog {
         // charsets, let's just hope that the author of the PDF was reasonable
         // enough to stick with the XML default charset, which is UTF-8.
         try {
-          const data = stringToUTF8String(bytesToString(stream.getBytes()));
+          const data = stringToUTF8String(stream.getString());
           if (data) {
             metadata = new MetadataParser(data).serializable;
           }
@@ -906,7 +905,7 @@ class Catalog {
 
       let js = jsDict.get("JS");
       if (isStream(js)) {
-        js = bytesToString(js.getBytes());
+        js = js.getString();
       } else if (typeof js !== "string") {
         return;
       }
@@ -1344,7 +1343,7 @@ class Catalog {
           let js;
 
           if (isStream(jsAction)) {
-            js = bytesToString(jsAction.getBytes());
+            js = jsAction.getString();
           } else if (isString(jsAction)) {
             js = jsAction;
           }

--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -16,7 +16,6 @@
 import {
   assert,
   BaseException,
-  bytesToString,
   objectSize,
   stringToPDFString,
   warn,
@@ -269,7 +268,7 @@ function _collectJS(entry, xref, list, parents) {
       const js = entry.get("JS");
       let code;
       if (isStream(js)) {
-        code = bytesToString(js.getBytes());
+        code = js.getString();
       } else {
         code = js;
       }

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -15,7 +15,6 @@
 
 import {
   assert,
-  bytesToString,
   FormatError,
   info,
   InvalidPDFException,
@@ -811,7 +810,7 @@ class PDFDocument {
     };
     if (isStream(xfa) && !xfa.isEmpty) {
       try {
-        entries["xdp:xdp"] = stringToUTF8String(bytesToString(xfa.getBytes()));
+        entries["xdp:xdp"] = stringToUTF8String(xfa.getString());
         return entries;
       } catch (_) {
         warn("XFA - Invalid utf-8 string.");
@@ -841,7 +840,7 @@ class PDFDocument {
         continue;
       }
       try {
-        entries[name] = stringToUTF8String(bytesToString(data.getBytes()));
+        entries[name] = stringToUTF8String(data.getString());
       } catch (_) {
         warn("XFA - Invalid utf-8 string.");
         return null;

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -1486,7 +1486,7 @@ var Font = (function FontClosure() {
       }
 
       function readTableEntry(file) {
-        var tag = bytesToString(file.getBytes(4));
+        var tag = file.getString(4);
 
         var checksum = file.getInt32() >>> 0;
         var offset = file.getInt32() >>> 0;
@@ -1516,7 +1516,7 @@ var Font = (function FontClosure() {
 
       function readOpenTypeHeader(ttf) {
         return {
-          version: bytesToString(ttf.getBytes(4)),
+          version: ttf.getString(4),
           numTables: ttf.getUint16(),
           searchRange: ttf.getUint16(),
           entrySelector: ttf.getUint16(),
@@ -1525,7 +1525,7 @@ var Font = (function FontClosure() {
       }
 
       function readTrueTypeCollectionHeader(ttc) {
-        const ttcTag = bytesToString(ttc.getBytes(4));
+        const ttcTag = ttc.getString(4);
         assert(ttcTag === "ttcf", "Must be a TrueType Collection font.");
 
         const majorVersion = ttc.getUint16();
@@ -2344,7 +2344,7 @@ var Font = (function FontClosure() {
             }
             names[1][nameIndex] = str;
           } else {
-            names[0][nameIndex] = bytesToString(font.getBytes(record.length));
+            names[0][nameIndex] = font.getString(record.length);
           }
         }
         return names;

--- a/src/core/writer.js
+++ b/src/core/writer.js
@@ -31,7 +31,7 @@ function writeDict(dict, buffer, transform) {
 function writeStream(stream, buffer, transform) {
   writeDict(stream.dict, buffer, transform);
   buffer.push(" stream\n");
-  let string = bytesToString(stream.getBytes());
+  let string = stream.getString();
   if (transform !== null) {
     string = transform.encryptString(string);
   }
@@ -129,7 +129,7 @@ function updateXFA(datasetsRef, newRefs, xref) {
     return;
   }
   const datasets = xref.fetchIfRef(datasetsRef);
-  const str = bytesToString(datasets.getBytes());
+  const str = datasets.getString();
   const xml = new SimpleXMLParser({ hasAttributes: true }).parseFromString(str);
 
   for (const { xfa } of newRefs) {

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -397,7 +397,7 @@ class FontFaceObject {
     if (!this.data || this.disableFontFace) {
       return null;
     }
-    const data = bytesToString(new Uint8Array(this.data));
+    const data = bytesToString(this.data);
     // Add the @font-face rule to the document.
     const url = `url(data:${this.mimetype};base64,${btoa(data)});`;
     let rule;


### PR DESCRIPTION
Given that the `bytesToString(BaseStream.getBytes(...))` pattern is somewhat common throughout the `src/core/` code, it cannot hurt to add a new `BaseStream`-method which handles that case internally.

