### PR TITLE
Fix highlighting of search results when the `textLayer` contains `br`-elements (PR 13257 follow-up, issue 13323)

### DIFF
--- a/test/text_layer_test.css
+++ b/test/text_layer_test.css
@@ -23,7 +23,8 @@
   bottom: 0;
   line-height: 1;
 }
-.textLayer span {
+.textLayer span,
+.textLayer br {
   position: absolute;
   white-space: pre;
   -webkit-transform-origin: 0% 0%;

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -24,7 +24,8 @@
   line-height: 1;
 }
 
-.textLayer span {
+.textLayer span,
+.textLayer br {
   color: transparent;
   position: absolute;
   white-space: pre;


### PR DESCRIPTION
Apparently we need to layout `br`-elements in the same *exact* way as the regular `span`-elements which contain the text-content.

Fixes #13323