### PR TITLE
[Regression] Move the `super`-call in the `PredictorStream`-constructor to prevent errors (PR 13303)

### DIFF
--- a/src/core/predictor_stream.js
+++ b/src/core/predictor_stream.js
@@ -19,10 +19,12 @@ import { isDict } from "./primitives.js";
 
 class PredictorStream extends DecodeStream {
   constructor(str, maybeLength, params) {
+    super(maybeLength);
+
     if (!isDict(params)) {
       return str; // no prediction
     }
-    const predictor = params.get("Predictor") || 1;
+    const predictor = (this.predictor = params.get("Predictor") || 1);
 
     if (predictor <= 1) {
       return str; // no prediction
@@ -30,8 +32,6 @@ class PredictorStream extends DecodeStream {
     if (predictor !== 2 && (predictor < 10 || predictor > 15)) {
       throw new FormatError(`Unsupported predictor: ${predictor}`);
     }
-    super(maybeLength);
-    this.predictor = predictor;
 
     if (predictor === 2) {
       this.readBlock = this.readBlockTiff;


### PR DESCRIPTION
*My apologies for breaking this; thankfully PR #13303 hasn't reach mozilla-central yet.*

It's (obviously) necessary to initialize a `PredictorStream`-instance fully, since otherwise breakage may occur if there's errors during the actual stream parsing.
To reproduce this issue, try opening the PDF document from issue #13051 locally and observe the following message in the console:
```
Warning: Invalid stream: "ReferenceError: this hasn't been initialised - super() hasn't been called"
```