### PR TITLE
Remove the `disableCanvasToImageConversion` functionality from `PDFThumbnailView` (PR 7029 follow-up)

### DIFF
--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -33,9 +33,6 @@ const THUMBNAIL_WIDTH = 98; // px
  * @property {IPDFLinkService} linkService - The navigation/linking service.
  * @property {PDFRenderingQueue} renderingQueue - The rendering queue object.
  * @property {function} checkSetImageDisabled
- * @property {boolean} [disableCanvasToImageConversion] - Don't convert the
- *   canvas thumbnails to images. This prevents `toDataURL` calls, but
- *   increases the overall memory usage. The default value is `false`.
  * @property {IL10n} l10n - Localization service.
  */
 
@@ -97,7 +94,6 @@ class PDFThumbnailView {
     linkService,
     renderingQueue,
     checkSetImageDisabled,
-    disableCanvasToImageConversion = false,
     l10n,
   }) {
     this.id = id;
@@ -121,7 +117,6 @@ class PDFThumbnailView {
       function () {
         return false;
       };
-    this.disableCanvasToImageConversion = disableCanvasToImageConversion;
 
     const pageWidth = this.viewport.width,
       pageHeight = this.viewport.height,
@@ -260,20 +255,6 @@ class PDFThumbnailView {
     }
     const reducedCanvas = this._reduceImage(canvas);
 
-    if (this.disableCanvasToImageConversion) {
-      reducedCanvas.className = "thumbnailImage";
-      this._thumbPageCanvas.then(msg => {
-        reducedCanvas.setAttribute("aria-label", msg);
-      });
-      reducedCanvas.style.width = this.canvasWidth + "px";
-      reducedCanvas.style.height = this.canvasHeight + "px";
-
-      this.canvas = reducedCanvas;
-
-      this.div.setAttribute("data-loaded", true);
-      this.ring.appendChild(reducedCanvas);
-      return;
-    }
     const image = document.createElement("img");
     image.className = "thumbnailImage";
     this._thumbPageCanvas.then(msg => {
@@ -501,11 +482,7 @@ class PDFThumbnailView {
     }
 
     this._thumbPageCanvas.then(msg => {
-      if (this.image) {
-        this.image.setAttribute("aria-label", msg);
-      } else if (this.canvas) {
-        this.canvas.setAttribute("aria-label", msg);
-      }
+      this.image?.setAttribute("aria-label", msg);
     });
   }
 }

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -209,7 +209,6 @@ class PDFThumbnailViewer {
             linkService: this.linkService,
             renderingQueue: this.renderingQueue,
             checkSetImageDisabled,
-            disableCanvasToImageConversion: false,
             l10n: this.l10n,
           });
           this._thumbnails.push(thumbnail);


### PR DESCRIPTION
This functionality was originally implemented in PR #7029; however it's not, nor has it ever been, used as far as I can tell.[1]
Note in particular that the default viewer does not expose either a preference or even an option with which `disableCanvasToImageConversion` can be toggled, and source-code modification is thus required.

Furthermore, note also that we have multiple other instances of `canvas`-data accesses in both the `src/display/canvas.js` and `src/display/text_layer.js` files. If any of those are blocked, by e.g. browser settings, there will be outright rendering bugs and non-working thumbnails thus seem like a very small issue in the grand scheme of things; hence why I'm suggesting that we remove the unused `disableCanvasToImageConversion` functionality.

---
[1] For the Tor use-case mentioned in issue #7026, I *believe* that the solution was to white-list `canvas`-data accesses for its built-in PDF Viewer.