### PR TITLE
Prevent LGTM from complaining about useless assignments (PR 12562 follow-up)

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,3 +1,4 @@
 queries:
   # Already handled by the "no-unused-vars" ESLint rule.
   - exclude: js/unused-local-variable
+  - exclude: js/useless-assignment-to-local


### PR DESCRIPTION
Given that we're using ESLint, which is fine with the code as-is, let's just silence the warnings; this is similar to PR #12562.