### PR TITLE
Fix the `Jbig2Image` export for the `gulp image_decoders` build (PR 9729 follow-up, issue 13367)

### DIFF
--- a/src/pdf.image_decoders.js
+++ b/src/pdf.image_decoders.js
@@ -14,7 +14,7 @@
  */
 
 import { getVerbosityLevel, setVerbosityLevel } from "./shared/util.js";
-import { Jbig2mage } from "./core/jbig2.js";
+import { Jbig2Image } from "./core/jbig2.js";
 import { JpegImage } from "./core/jpg.js";
 import { JpxImage } from "./core/jpx.js";
 
@@ -37,4 +37,10 @@ const pdfjsVersion = PDFJSDev.eval("BUNDLE_VERSION");
 // eslint-disable-next-line no-unused-vars
 const pdfjsBuild = PDFJSDev.eval("BUNDLE_BUILD");
 
-export { getVerbosityLevel, Jbig2mage, JpegImage, JpxImage, setVerbosityLevel };
+export {
+  getVerbosityLevel,
+  Jbig2Image,
+  JpegImage,
+  JpxImage,
+  setVerbosityLevel,
+};


### PR DESCRIPTION
Fixes #13367