### PR TITLE
Fix tiling pattern with smask.

### DIFF
--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -538,6 +538,8 @@ const TilingPattern = (function TilingPatternClosure() {
 
       graphics.executeOperatorList(operatorList);
 
+      graphics.endDrawing();
+
       return {
         canvas: tmpCanvas.canvas,
         scaleX: dimx.scale,

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -157,6 +157,7 @@
 !issue3879r.pdf
 !issue5686.pdf
 !issue3928.pdf
+!issue8565.pdf
 !clippath.pdf
 !issue8795_reduced.pdf
 !close-path-bug.pdf

--- a/test/pdfs/issue8565.pdf
+++ b/test/pdfs/issue8565.pdf
@@ -1,0 +1,193 @@
+%PDF-1.3
+%ÿÿÿÿ
+6 0 obj
+<<
+/FunctionType 2
+/Domain [0 1]
+/C0 [1 0.647059 0]
+/C1 [1 0.647059 0]
+/N 1
+>>
+endobj
+7 0 obj
+<<
+/ShadingType 3
+/ColorSpace /DeviceRGB
+/Coords [200 200 0 200 200 200]
+/Function 6 0 R
+/Extend [true true]
+>>
+endobj
+8 0 obj
+<<
+/Type /Pattern
+/PatternType 2
+/Shading 7 0 R
+/Matrix [1 0 0 -1 0 400]
+>>
+endobj
+9 0 obj
+<<
+/FunctionType 2
+/Domain [0 1]
+/C0 [0]
+/C1 [1]
+/N 1
+>>
+endobj
+10 0 obj
+<<
+/ShadingType 3
+/ColorSpace /DeviceGray
+/Coords [200 200 0 200 200 200]
+/Function 9 0 R
+/Extend [true true]
+>>
+endobj
+11 0 obj
+<<
+/Type /Pattern
+/PatternType 2
+/Shading 10 0 R
+/Matrix [1 0 0 -1 0 400]
+>>
+endobj
+12 0 obj
+<<
+/Type /XObject
+/Subtype /Form
+/FormType 1
+/BBox [0 0 400 400]
+/Group <<
+/Type /Group
+/S /Transparency
+/CS /DeviceGray
+>>
+/Resources <<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Pattern <<
+/Sh1 11 0 R
+>>
+>>
+/Length 38
+>>
+stream
+/Pattern cs /Sh1 scn
+0 0 400 400 re f
+
+endstream
+endobj
+13 0 obj
+<<
+/Type /ExtGState
+/SMask <<
+/Type /Mask
+/S /Luminosity
+/G 12 0 R
+>>
+>>
+endobj
+14 0 obj
+<<
+/Type /Pattern
+/PatternType 1
+/PaintType 1
+/TilingType 2
+/BBox [0 0 400 400]
+/XStep 400
+/YStep 400
+/Resources <<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Pattern <<
+/Sh1 8 0 R
+>>
+/ExtGState <<
+/Gs1 13 0 R
+>>
+>>
+/Length 46
+>>
+stream
+/Gs1 gs /Pattern cs /Sh1 scn
+0 0 400 400 re f
+
+endstream
+endobj
+5 0 obj
+<<
+/Type /Page
+/Parent 1 0 R
+/MediaBox [0 0 400 400]
+/Contents 3 0 R
+/Resources 4 0 R
+>>
+endobj
+4 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Pattern <<
+/Sh2 11 0 R
+/Sh1 14 0 R
+>>
+>>
+endobj
+3 0 obj
+<<
+/Length 56
+>>
+stream
+1 0 0 -1 0 400 cm
+0 0 400 400 re
+/Pattern cs
+/Sh1 scn
+f
+
+endstream
+endobj
+15 0 obj
+<<
+/Producer (PDFKit)
+/Creator (PDFKit)
+/CreationDate (D:20170623040811Z)
+>>
+endobj
+2 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+>>
+endobj
+1 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [5 0 R]
+>>
+endobj
+xref
+0 16
+0000000000 65535 f 
+0000001782 00000 n 
+0000001733 00000 n 
+0000001534 00000 n 
+0000001428 00000 n 
+0000001324 00000 n 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000236 00000 n 
+0000000327 00000 n 
+0000000399 00000 n 
+0000000528 00000 n 
+0000000621 00000 n 
+0000000921 00000 n 
+0000001010 00000 n 
+0000001640 00000 n 
+trailer
+<<
+/Size 16
+/Root 2 0 R
+/Info 15 0 R
+>>
+startxref
+1839
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -383,6 +383,12 @@
        "rounds": 1,
        "type": "load"
     },
+    {  "id": "issue8565",
+       "file": "pdfs/issue8565.pdf",
+       "md5": "84e0e2fc2775bc489beac475503dd67b",
+       "rounds": 1,
+       "type": "eq"
+    },
     {  "id": "arabiccidtruetype-text",
        "file": "pdfs/ArabicCIDTrueType.pdf",
        "md5": "d66dbd18bdb572d3ac8b88b32de2ece6",


### PR DESCRIPTION
After drawing a tiling pattern we were not calling
endDrawing, which handles compositing any
active smasks.

Fixes #8565.