### PR TITLE
Revert "Fix the remaining `no-var` failures, which couldn't be handled automatically, in the `src/core/evaluator.js` file" (PR 13344 follow-up)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint-disable no-var */
 
 import {
   AbortException,
@@ -393,8 +394,7 @@ class PartialEvaluator {
     } else {
       bbox = null;
     }
-    let optionalContent = null,
-      groupOptions = null;
+    let optionalContent = null;
     if (dict.has("OC")) {
       optionalContent = await this.parseMarkedContentProps(
         dict.get("OC"),
@@ -404,7 +404,7 @@ class PartialEvaluator {
     }
     const group = dict.get("Group");
     if (group) {
-      groupOptions = {
+      var groupOptions = {
         matrix,
         bbox,
         smask,
@@ -1467,7 +1467,7 @@ class PartialEvaluator {
       timeSlotManager.reset();
 
       const operation = {};
-      let stop, i, ii, cs;
+      let stop, i, ii, cs, name;
       while (!(stop = timeSlotManager.check())) {
         // The arguments parsed by read() are used beyond this loop, so we
         // cannot reuse the same array on each iteration. Therefore we pass
@@ -1481,9 +1481,9 @@ class PartialEvaluator {
         let fn = operation.fn;
 
         switch (fn | 0) {
-          case OPS.paintXObject: {
+          case OPS.paintXObject:
             // eagerly compile XForm objects
-            const name = args[0].name;
+            name = args[0].name;
             if (name) {
               const localImage = localImageCache.getByName(name);
               if (localImage) {
@@ -1589,9 +1589,8 @@ class PartialEvaluator {
               })
             );
             return;
-          }
-          case OPS.setFont: {
-            const fontSize = args[1];
+          case OPS.setFont:
+            var fontSize = args[1];
             // eagerly collect all fonts
             next(
               self
@@ -1610,15 +1609,14 @@ class PartialEvaluator {
                 })
             );
             return;
-          }
           case OPS.beginText:
             parsingText = true;
             break;
           case OPS.endText:
             parsingText = false;
             break;
-          case OPS.endInlineImage: {
-            const cacheKey = args[0].cacheKey;
+          case OPS.endInlineImage:
+            var cacheKey = args[0].cacheKey;
             if (cacheKey) {
               const localImage = localImageCache.getByName(cacheKey);
               if (localImage) {
@@ -1639,7 +1637,6 @@ class PartialEvaluator {
               })
             );
             return;
-          }
           case OPS.showText:
             if (!stateManager.state.font) {
               self.ensureStateFont(stateManager.state);
@@ -1652,10 +1649,10 @@ class PartialEvaluator {
               self.ensureStateFont(stateManager.state);
               continue;
             }
-            const arr = args[0],
-              arrLength = arr.length,
-              combinedGlyphs = [],
-              state = stateManager.state;
+            var arr = args[0];
+            var combinedGlyphs = [];
+            var arrLength = arr.length;
+            var state = stateManager.state;
             for (i = 0; i < arrLength; ++i) {
               const arrItem = arr[i];
               if (isString(arrItem)) {
@@ -1827,18 +1824,18 @@ class PartialEvaluator {
             fn = OPS.setStrokeRGBColor;
             break;
 
-          case OPS.shadingFill: {
-            const shadingRes = resources.get("Shading");
+          case OPS.shadingFill:
+            var shadingRes = resources.get("Shading");
             if (!shadingRes) {
               throw new FormatError("No shading resource found");
             }
 
-            const shading = shadingRes.get(args[0].name);
+            var shading = shadingRes.get(args[0].name);
             if (!shading) {
               throw new FormatError("No shading object found");
             }
 
-            const shadingFill = Pattern.parseShading(
+            var shadingFill = Pattern.parseShading(
               shading,
               null,
               xref,
@@ -1847,13 +1844,12 @@ class PartialEvaluator {
               self._pdfFunctionFactory,
               localColorSpaceCache
             );
-            const patternIR = shadingFill.getIR();
+            var patternIR = shadingFill.getIR();
             args = [patternIR];
             fn = OPS.shadingFill;
             break;
-          }
-          case OPS.setGState: {
-            const name = args[0].name;
+          case OPS.setGState:
+            name = args[0].name;
             if (name) {
               const localGStateObj = localGStateCache.getByName(name);
               if (localGStateObj) {
@@ -1913,7 +1909,6 @@ class PartialEvaluator {
               })
             );
             return;
-          }
           case OPS.moveTo:
           case OPS.lineTo:
           case OPS.curveTo:
@@ -2569,9 +2564,9 @@ class PartialEvaluator {
         args = operation.args;
 
         switch (fn | 0) {
-          case OPS.setFont: {
+          case OPS.setFont:
             // Optimization to ignore multiple identical Tf commands.
-            const fontNameArg = args[0].name,
+            var fontNameArg = args[0].name,
               fontSizeArg = args[1];
             if (
               textState.font &&
@@ -2586,7 +2581,6 @@ class PartialEvaluator {
             textState.fontSize = fontSizeArg;
             next(handleSetFont(fontNameArg, null));
             return;
-          }
           case OPS.setTextRise:
             flushTextContentItem();
             textState.textRise = args[0];
@@ -2736,13 +2730,13 @@ class PartialEvaluator {
               isFirstChunk: true,
             });
             break;
-          case OPS.paintXObject: {
+          case OPS.paintXObject:
             flushTextContentItem();
             if (!xobjs) {
               xobjs = resources.get("XObject") || Dict.empty;
             }
 
-            const name = args[0].name;
+            var name = args[0].name;
             if (name && emptyXObjectCache.getByName(name)) {
               break;
             }
@@ -2853,9 +2847,8 @@ class PartialEvaluator {
               })
             );
             return;
-          }
-          case OPS.setGState: {
-            const name = args[0].name;
+          case OPS.setGState:
+            name = args[0].name;
             if (name && emptyGStateCache.getByName(name)) {
               break;
             }
@@ -2908,7 +2901,6 @@ class PartialEvaluator {
               })
             );
             return;
-          }
           case OPS.beginMarkedContent:
             if (includeMarkedContent) {
               textContent.items.push({
@@ -3775,7 +3767,7 @@ class PartialEvaluator {
       throw new FormatError("invalid font name");
     }
 
-    let fontFile, subtype, length1, length2, length3;
+    let fontFile;
     try {
       fontFile = descriptor.get("FontFile", "FontFile2", "FontFile3");
     } catch (ex) {
@@ -3787,13 +3779,13 @@ class PartialEvaluator {
     }
     if (fontFile) {
       if (fontFile.dict) {
-        const subtypeEntry = fontFile.dict.get("Subtype");
-        if (subtypeEntry instanceof Name) {
-          subtype = subtypeEntry.name;
+        var subtype = fontFile.dict.get("Subtype");
+        if (subtype) {
+          subtype = subtype.name;
         }
-        length1 = fontFile.dict.get("Length1");
-        length2 = fontFile.dict.get("Length2");
-        length3 = fontFile.dict.get("Length3");
+        var length1 = fontFile.dict.get("Length1");
+        var length2 = fontFile.dict.get("Length2");
+        var length3 = fontFile.dict.get("Length3");
       }
     }
 


### PR DESCRIPTION
This reverts commit 0ef9b5aafc88094f19fec793c174c622e7e15542, since it cases a lot of warnings (see below) *locally* with e.g. the document from issue #9627.
Strangely enough, this only occurs with `gulp server`-mode and the actual builds are apparently fine. It seems that this *may* be some unfortunate interaction with the old Babel-plugin that's used together with SystemJS.

```
Warning: getTextContent - ignoring ExtGState: "FormatError: ExtGState should be a dictionary.".
```

Rather than taking the risk that this could actually cover a more serious bug, and since I cannot immediately figure out what's wrong, it thus seem safest to revert this for now and we can (carefully) revisit this once SystemJS has been removed (see PR #12563).

*Reverts part of PR #13344.*