### PR TITLE
[api-minor] Update minimum supported browser versions (PR 13361 follow-up)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -79,10 +79,9 @@ const config = JSON.parse(fs.readFileSync(CONFIG_FILE).toString());
 const AUTOPREFIXER_CONFIG = {
   overrideBrowserslist: [
     "last 2 versions",
-    "Chrome >= 49", // Last supported on Windows XP
-    "Firefox >= 52", // Last supported on Windows XP
+    "Chrome >= 68",
     "Firefox ESR",
-    "Safari >= 10",
+    "Safari >= 11.1",
     "> 0.5%",
     "not IE > 0",
     "not dead",
@@ -1321,7 +1320,7 @@ gulp.task(
         ),
         preprocessCSS("web/viewer.css", "chrome", defines, true)
           .pipe(
-            postcss([autoprefixer({ overrideBrowserslist: ["chrome >= 49"] })])
+            postcss([autoprefixer({ overrideBrowserslist: ["chrome >= 68"] })])
           )
           .pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + "web")),
 

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -51,7 +51,7 @@ if (
   })();
 
   // Provides support for Object.fromEntries in legacy browsers.
-  // Support: Firefox<63, Chrome<73, Safari<12.1
+  // Support: Firefox<63, Chrome<73, Safari<12.1, Node.js<12.0.0
   (function checkObjectFromEntries() {
     if (Object.fromEntries) {
       return;
@@ -61,7 +61,7 @@ if (
 
   // Provides support for *recent* additions to the Promise specification,
   // however basic Promise support is assumed to be available natively.
-  // Support: Firefox<71, Chrome<76, Safari<13
+  // Support: Firefox<71, Chrome<76, Safari<13, Node.js<12.9.0
   (function checkPromise() {
     if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("IMAGE_DECODERS")) {
       // The current image decoders are synchronous, hence `Promise` shouldn't
@@ -74,7 +74,7 @@ if (
     globalThis.Promise = require("core-js/es/promise/index.js");
   })();
 
-  // Support: Safari<10.1, Node.js
+  // Support: Node.js
   (function checkReadableStream() {
     if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("IMAGE_DECODERS")) {
       // The current image decoders are synchronous, hence `ReadableStream`
@@ -101,41 +101,5 @@ if (
       return;
     }
     globalThis.ReadableStream = require("web-streams-polyfill/dist/ponyfill.js").ReadableStream;
-  })();
-
-  // Provides support for String.prototype.padStart in legacy browsers.
-  // Support: Chrome<57, Safari<10
-  (function checkStringPadStart() {
-    if (String.prototype.padStart) {
-      return;
-    }
-    require("core-js/es/string/pad-start.js");
-  })();
-
-  // Provides support for String.prototype.padEnd in legacy browsers.
-  // Support: Chrome<57, Safari<10
-  (function checkStringPadEnd() {
-    if (String.prototype.padEnd) {
-      return;
-    }
-    require("core-js/es/string/pad-end.js");
-  })();
-
-  // Provides support for Object.values in legacy browsers.
-  // Support: Chrome<54, Safari<10.1
-  (function checkObjectValues() {
-    if (Object.values) {
-      return;
-    }
-    Object.values = require("core-js/es/object/values.js");
-  })();
-
-  // Provides support for Object.entries in legacy browsers.
-  // Support: Chrome<54, Safari<10.1
-  (function checkObjectEntries() {
-    if (Object.entries) {
-      return;
-    }
-    Object.entries = require("core-js/es/object/entries.js");
   })();
 }


### PR DESCRIPTION
With the changes in PR #13361, we're now using the `CanvasPattern.setTransform()` method when rendering certain Shadings/Patterns.
Note that while `CanvasPattern` itself has been supported since basically "forever", its `setTransform` method is a slightly newer addition to the specification; please refer to https://developer.mozilla.org/en-US/docs/Web/API/CanvasPattern#browser_compatibility

Rather than trying to re-write PR #13361 to not use, or possibly spending time/effort (if possible) polyfilling, `CanvasPattern.setTransform()` this patch thus suggests that we simply update the *minimum* supported browser versions instead.

According to the compatibility data linked above, the *minimum* supported browser versions in the PDF.js library are now as follows:
 - Chrome >= 68, which was released on 2018-07-24.[1]
 - Firefox ESR, see https://wiki.mozilla.org/Release_Management/Calendar.
 - Safari >= 11.1, which was release on 2018-03-29.[2]

(Given that the PDF.js contributors cannot realistically test a bunch of old browsers, it's not unimaginable that some older browser versions are already not working with the PDF.js library.)

Based on these changes, which we should ensure are reflected in the Wiki as well, we can also remove a number of now redundant polyfills. Furthermore we'll no longer "claim" to support Windows XP, note the `gulpfile.js` changes, which should definitely *not* be an issue given that it's no longer officially supported.[3]

---
[1] According to https://en.wikipedia.org/wiki/Google_Chrome_version_history

[2] According to https://en.wikipedia.org/wiki/Safari_version_history#Safari_11

[3] According to https://en.wikipedia.org/wiki/Windows_XP#End_of_support