### PR TITLE
Get any width (if one is present) in CFF parser

### DIFF
--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -640,7 +640,9 @@ const CFFParser = (function CFFParserClosure() {
             } else if (stackSize > 1) {
               warn("Found too many parameters for stack-clearing command");
             }
-            if (stackSize > 0 && stack[stackSize - 1] >= 0) {
+            if (stackSize > 0) {
+              // Width can be any number since its the difference
+              // from nominalWidthX.
               state.width = stack[stackSize - 1];
             }
           }


### PR DESCRIPTION
  - in charstring specs at page 21 (section 4.2): "Also, it may appear in the charstring as the difference from nominalWidthX" so the number we've on the stack doesn't have to be positive.
  - currently this bug has probably no visible effect
  - but when the font is loaded to be used with XFA, then the rendering is incorrect.