### PR TITLE
Handle PI with no value in xml parser

### DIFF
--- a/src/core/xml_parser.js
+++ b/src/core/xml_parser.js
@@ -145,6 +145,7 @@ class XMLParserBase {
       pos < s.length &&
       !isWhitespace(s, pos) &&
       s[pos] !== ">" &&
+      s[pos] !== "?" &&
       s[pos] !== "/"
     ) {
       ++pos;

--- a/test/unit/xml_spec.js
+++ b/test/unit/xml_spec.js
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
+import { SimpleXMLParser, XMLParserBase } from "../../src/core/xml_parser.js";
 import { parseXFAPath } from "../../src/core/core_utils.js";
-import { SimpleXMLParser } from "../../src/core/xml_parser.js";
 
 describe("XML", function () {
   describe("searchNode", function () {
@@ -107,5 +107,29 @@ describe("XML", function () {
         xml.replace(/\s+/g, "")
       );
     });
+  });
+
+  it("should parse processing instructions", function () {
+    const xml = `
+      <a>
+          <?foo bar?>
+          <?foo bar oof?>
+          <?foo?>
+      </a>`;
+    const pi = [];
+
+    class MyParser extends XMLParserBase {
+      onPi(name, value) {
+        pi.push([name, value]);
+      }
+    }
+
+    new MyParser().parseXml(xml);
+
+    expect(pi).toEqual([
+      ["foo", "bar"],
+      ["foo", "bar oof"],
+      ["foo", ""],
+    ]);
   });
 });


### PR DESCRIPTION
  - an XML PI contains a target and optionally some content (see https://en.wikipedia.org/wiki/Processing_Instruction)
  - the parser expected to always have some content and so it could lead to wrong parsing.