### PR TITLE
Remove focus from the zoom dropdown, when a mouse is used (bug 1300525, issue 4923)

### DIFF
--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -155,6 +155,19 @@ class Toolbar {
         value: this.value,
       });
     });
+    // Here we depend on browsers dispatching the "click" event *after* the
+    // "change" event, when the <select>-element changes.
+    scaleSelect.addEventListener("click", function (evt) {
+      const target = evt.target;
+      // Remove focus when an <option>-element was *clicked*, to improve the UX
+      // for mouse users (fixes bug 1300525 and issue 4923).
+      if (
+        this.value === self.pageScaleValue &&
+        target.tagName.toUpperCase() === "OPTION"
+      ) {
+        this.blur();
+      }
+    });
     // Suppress context menus for some controls.
     scaleSelect.oncontextmenu = noContextMenuHandler;
 


### PR DESCRIPTION
This patch fixes the referenced bugs/issues, in a way that won't interfere with keyboard users, assuming that we actually want to fix these old bugs/issues. (If not, we should close them as WONTFIX.)

Fixes [bug 1300525](https://bugzilla.mozilla.org/show_bug.cgi?id=1300525)
Fixes #4923