### PR TITLE
Allow consumers of the text layer builder and render task to specify element type of the text div.

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -40,6 +40,8 @@ import {
  *   text runs occurs.
  * @property {boolean} [enhanceTextSelection] - Whether to turn on the text
  *   selection enhancement.
+ * @property {"span" | "div" } [textDivElementType] - Allows to specify type
+ * of text elements for backwards compatibility. Defaults to span.
  */
 
 const MAX_TEXT_DIVS_TO_RENDER = 100000;
@@ -117,7 +119,7 @@ function getAscent(fontFamily, ctx) {
 
 function appendText(task, geom, styles, ctx) {
   // Initialize all used properties to keep the caches monomorphic.
-  const textDiv = document.createElement("span");
+  const textDiv = document.createElement(task._textDivElementType);
   const textDivProperties = {
     angle: 0,
     canvasWidth: 0,
@@ -563,6 +565,7 @@ class TextLayerRenderTask {
     textDivs,
     textContentItemsStr,
     enhanceTextSelection,
+    textDivElementType = "span",
   }) {
     this._textContent = textContent;
     this._textContentStream = textContentStream;
@@ -572,6 +575,7 @@ class TextLayerRenderTask {
     this._textDivs = textDivs || [];
     this._textContentItemsStr = textContentItemsStr || [];
     this._enhanceTextSelection = !!enhanceTextSelection;
+    this._textDivElementType = textDivElementType;
     this._fontInspectorEnabled = !!globalThis.FontInspector?.enabled;
 
     this._reader = null;
@@ -839,6 +843,7 @@ function renderTextLayer(renderParameters) {
     textDivs: renderParameters.textDivs,
     textContentItemsStr: renderParameters.textContentItemsStr,
     enhanceTextSelection: renderParameters.enhanceTextSelection,
+    textDivElementType: renderParameters.textDivElementType,
   });
   task._render(renderParameters.timeout);
   return task;

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -26,6 +26,8 @@ const EXPAND_DIVS_TIMEOUT = 300; // ms
  * @property {PDFFindController} findController
  * @property {boolean} enhanceTextSelection - Option to turn on improved
  *   text selection.
+ * @property {"span" | "div" } [textDivElementType] - Allows to specify type
+ * of text elements for backwards compatibility. Defaults to span.
  */
 
 /**
@@ -42,6 +44,7 @@ class TextLayerBuilder {
     viewport,
     findController = null,
     enhanceTextSelection = false,
+    textDivElementType = "span",
   }) {
     this.textLayerDiv = textLayerDiv;
     this.eventBus = eventBus;
@@ -57,6 +60,7 @@ class TextLayerBuilder {
     this.findController = findController;
     this.textLayerRenderTask = null;
     this.enhanceTextSelection = enhanceTextSelection;
+    this.textDivElementType = textDivElementType;
 
     this._onUpdateTextLayerMatches = null;
     this._bindMouse();
@@ -104,6 +108,7 @@ class TextLayerBuilder {
       textContentItemsStr: this.textContentItemsStr,
       timeout,
       enhanceTextSelection: this.enhanceTextSelection,
+      textDivElementType: this.textDivElementType,
     });
     this.textLayerRenderTask.promise.then(
       () => {


### PR DESCRIPTION
**Background** 
Once upon a time text layer used to generate `div` text elements (the variable name is still `textDiv`). It was later changed to `span`. For our use case, it is a breaking change and we have been maintaining our own fork that still generates div(s).

**Summary** 
This pull request adds the ability to override element type for text builder and rendering task constructors. The current behavior of using span is preserved as the default value. 
