### PR TITLE
[XFA] Send URLs as strings, rather than objects (issue 1773)

### DIFF
--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -2257,7 +2257,7 @@ class Image extends StringObject {
     };
 
     if (this.href) {
-      html.attributes.src = new URL(this.href);
+      html.attributes.src = new URL(this.href).href;
       return html;
     }
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1800,7 +1800,10 @@ class LoopbackPort {
         }
         return result;
       }
-      result = Array.isArray(value) ? [] : {};
+      if (value instanceof URL) {
+        throw new Error(`LoopbackPort.postMessage - cannot clone: ${value}`);
+      }
+      result = Array.isArray(value) ? [] : Object.create(null);
       cloned.set(value, result); // Adding to cache now for cyclic references.
       // Cloning all value and object properties, however ignoring properties
       // defined via getter.


### PR DESCRIPTION
Given that `URL`s aren't supported by the structured clone algorithm, see https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm, the document in issue #1773 will cause the browser to throw `DataCloneError: The object could not be cloned.`-errors and nothing will render.
To fix this, we'll instead simply send the stringified version of the `URL` to prevent these errors from occuring.

