### PR TITLE
Use the `stringToBytes` helper function in more places

### DIFF
--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -57,7 +57,7 @@ import {
   getRelevant,
   getStringOption,
 } from "./utils.js";
-import { Util, warn } from "../../shared/util.js";
+import { stringToBytes, Util, warn } from "../../shared/util.js";
 
 const TEMPLATE_NS_ID = NamespaceIds.template.id;
 
@@ -2262,9 +2262,7 @@ class Image extends StringObject {
     }
 
     if (this.transferEncoding === "base64") {
-      const buffer = Uint8Array.from(atob(this[$content]), c =>
-        c.charCodeAt(0)
-      );
+      const buffer = stringToBytes(atob(this[$content]));
       const blob = new Blob([buffer], { type: this.contentType });
       html.attributes.src = URL.createObjectURL(blob);
       return html;

--- a/src/display/content_disposition.js
+++ b/src/display/content_disposition.js
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+import { stringToBytes } from "../shared/util.js";
+
 // This getFilenameFromContentDispositionHeader function is adapted from
 // https://github.com/Rob--W/open-in-browser/blob/7e2e35a38b8b4e981b11da7b2f01df0149049e92/extension/content-disposition.js
 // with the following changes:
@@ -85,10 +87,8 @@ function getFilenameFromContentDispositionHeader(contentDisposition) {
       }
       try {
         const decoder = new TextDecoder(encoding, { fatal: true });
-        const bytes = Array.from(value, function (ch) {
-          return ch.charCodeAt(0) & 0xff;
-        });
-        value = decoder.decode(new Uint8Array(bytes));
+        const buffer = stringToBytes(value);
+        value = decoder.decode(buffer);
         needsEncodingFixup = false;
       } catch (e) {
         // TextDecoder constructor threw - unrecognized encoding.


### PR DESCRIPTION
Rather than manually reimplementing, more-or-less, this functionality in a few spots we can simply use the existing helper function instead.