### PR TITLE
Enable the `unicorn/no-array-push-push` ESLint plugin rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,6 +43,7 @@
       "ignoreCase": true,
     }],
     "unicorn/no-abusive-eslint-disable": "error",
+    "unicorn/no-array-push-push": "error",
     "unicorn/no-instanceof-array": "error",
     "unicorn/prefer-string-starts-ends-with": "error",
 

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -1390,9 +1390,7 @@ class WidgetAnnotation extends Annotation {
 
     const bufferNew = [`${newRef.num} ${newRef.gen} obj\n`];
     writeDict(appearanceDict, bufferNew, newTransform);
-    bufferNew.push(" stream\n");
-    bufferNew.push(appearance);
-    bufferNew.push("\nendstream\nendobj\n");
+    bufferNew.push(" stream\n", appearance, "\nendstream\nendobj\n");
 
     return [
       // data for the original object
@@ -2421,9 +2419,11 @@ class LineAnnotation extends MarkupAnnotation {
         extra: `${borderWidth} w`,
         strokeColor,
         pointsCallback: (buffer, points) => {
-          buffer.push(`${lineCoordinates[0]} ${lineCoordinates[1]} m`);
-          buffer.push(`${lineCoordinates[2]} ${lineCoordinates[3]} l`);
-          buffer.push("S");
+          buffer.push(
+            `${lineCoordinates[0]} ${lineCoordinates[1]} m`,
+            `${lineCoordinates[2]} ${lineCoordinates[3]} l`,
+            "S"
+          );
           return [
             points[0].x - borderWidth,
             points[1].x + borderWidth,
@@ -2523,21 +2523,14 @@ class CircleAnnotation extends MarkupAnnotation {
           const xOffset = ((x1 - x0) / 2) * controlPointsDistance;
           const yOffset = ((y1 - y0) / 2) * controlPointsDistance;
 
-          buffer.push(`${xMid} ${y1} m`);
           buffer.push(
-            `${xMid + xOffset} ${y1} ${x1} ${yMid + yOffset} ${x1} ${yMid} c`
+            `${xMid} ${y1} m`,
+            `${xMid + xOffset} ${y1} ${x1} ${yMid + yOffset} ${x1} ${yMid} c`,
+            `${x1} ${yMid - yOffset} ${xMid + xOffset} ${y0} ${xMid} ${y0} c`,
+            `${xMid - xOffset} ${y0} ${x0} ${yMid - yOffset} ${x0} ${yMid} c`,
+            `${x0} ${yMid + yOffset} ${xMid - xOffset} ${y1} ${xMid} ${y1} c`,
+            "h"
           );
-          buffer.push(
-            `${x1} ${yMid - yOffset} ${xMid + xOffset} ${y0} ${xMid} ${y0} c`
-          );
-          buffer.push(
-            `${xMid - xOffset} ${y0} ${x0} ${yMid - yOffset} ${x0} ${yMid} c`
-          );
-          buffer.push(
-            `${x0} ${yMid + yOffset} ${xMid - xOffset} ${y1} ${xMid} ${y1} c`
-          );
-
-          buffer.push("h");
           if (fillColor) {
             buffer.push("B");
           } else {
@@ -2693,11 +2686,13 @@ class HighlightAnnotation extends MarkupAnnotation {
           fillColor,
           blendMode: "Multiply",
           pointsCallback: (buffer, points) => {
-            buffer.push(`${points[0].x} ${points[0].y} m`);
-            buffer.push(`${points[1].x} ${points[1].y} l`);
-            buffer.push(`${points[3].x} ${points[3].y} l`);
-            buffer.push(`${points[2].x} ${points[2].y} l`);
-            buffer.push("f");
+            buffer.push(
+              `${points[0].x} ${points[0].y} m`,
+              `${points[1].x} ${points[1].y} l`,
+              `${points[3].x} ${points[3].y} l`,
+              `${points[2].x} ${points[2].y} l`,
+              "f"
+            );
             return [points[0].x, points[1].x, points[3].y, points[1].y];
           },
         });
@@ -2728,9 +2723,11 @@ class UnderlineAnnotation extends MarkupAnnotation {
           extra: "[] 0 d 1 w",
           strokeColor,
           pointsCallback: (buffer, points) => {
-            buffer.push(`${points[2].x} ${points[2].y} m`);
-            buffer.push(`${points[3].x} ${points[3].y} l`);
-            buffer.push("S");
+            buffer.push(
+              `${points[2].x} ${points[2].y} m`,
+              `${points[3].x} ${points[3].y} l`,
+              "S"
+            );
             return [points[0].x, points[1].x, points[3].y, points[1].y];
           },
         });
@@ -2806,14 +2803,12 @@ class StrikeOutAnnotation extends MarkupAnnotation {
           strokeColor,
           pointsCallback: (buffer, points) => {
             buffer.push(
-              `${(points[0].x + points[2].x) / 2}` +
-                ` ${(points[0].y + points[2].y) / 2} m`
+              `${(points[0].x + points[2].x) / 2} ` +
+                `${(points[0].y + points[2].y) / 2} m`,
+              `${(points[1].x + points[3].x) / 2} ` +
+                `${(points[1].y + points[3].y) / 2} l`,
+              "S"
             );
-            buffer.push(
-              `${(points[1].x + points[3].x) / 2}` +
-                ` ${(points[1].y + points[3].y) / 2} l`
-            );
-            buffer.push("S");
             return [points[0].x, points[1].x, points[3].y, points[1].y];
           },
         });

--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -145,7 +145,7 @@ function toRomanNumerals(number, lowerCase = false) {
   number %= 10;
   romanBuf.push(ROMAN_NUMBER_MAP[10 + pos]);
   // Ones
-  romanBuf.push(ROMAN_NUMBER_MAP[20 + number]);
+  romanBuf.push(ROMAN_NUMBER_MAP[20 + number]); // eslint-disable-line unicorn/no-array-push-push
 
   const romanStr = romanBuf.join("");
   return lowerCase ? romanStr.toLowerCase() : romanStr;

--- a/src/core/font_renderer.js
+++ b/src/core/font_renderer.js
@@ -234,11 +234,13 @@ function compileGlyf(code, cmds, font) {
       }
       const subglyph = font.glyphs[glyphIndex];
       if (subglyph) {
-        cmds.push({ cmd: "save" });
-        cmds.push({
-          cmd: "transform",
-          args: [scaleX, scale01, scale10, scaleY, x, y],
-        });
+        cmds.push(
+          { cmd: "save" },
+          {
+            cmd: "transform",
+            args: [scaleX, scale01, scale10, scaleY, x, y],
+          }
+        );
         compileGlyf(subglyph, cmds, font);
         cmds.push({ cmd: "restore" });
       }
@@ -524,8 +526,7 @@ function compileCharString(charStringCode, cmds, font, glyphId) {
             const bchar = stack.pop();
             y = stack.pop();
             x = stack.pop();
-            cmds.push({ cmd: "save" });
-            cmds.push({ cmd: "translate", args: [x, y] });
+            cmds.push({ cmd: "save" }, { cmd: "translate", args: [x, y] });
             let cmap = lookupCmap(
               font.cmap,
               String.fromCharCode(font.glyphNameMap[StandardEncoding[achar]])
@@ -774,11 +775,11 @@ class CompiledFont {
       }
     }
 
-    const cmds = [];
-    cmds.push({ cmd: "save" });
-    cmds.push({ cmd: "transform", args: fontMatrix.slice() });
-    cmds.push({ cmd: "scale", args: ["size", "-size"] });
-
+    const cmds = [
+      { cmd: "save" },
+      { cmd: "transform", args: fontMatrix.slice() },
+      { cmd: "scale", args: ["size", "-size"] },
+    ];
     this.compileGlyphImpl(code, cmds, glyphId);
 
     cmds.push({ cmd: "restore" });

--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -943,18 +943,20 @@ function decodePatternDictionary(
       y: 0,
     });
     if (template === 0) {
-      at.push({
-        x: -3,
-        y: -1,
-      });
-      at.push({
-        x: 2,
-        y: -2,
-      });
-      at.push({
-        x: -2,
-        y: -2,
-      });
+      at.push(
+        {
+          x: -3,
+          y: -1,
+        },
+        {
+          x: 2,
+          y: -2,
+        },
+        {
+          x: -2,
+          y: -2,
+        }
+      );
     }
   }
   const collectiveWidth = (maxPatternIndex + 1) * patternWidth;
@@ -1034,18 +1036,20 @@ function decodeHalftoneRegion(
       y: -1,
     });
     if (template === 0) {
-      at.push({
-        x: -3,
-        y: -1,
-      });
-      at.push({
-        x: 2,
-        y: -2,
-      });
-      at.push({
-        x: -2,
-        y: -2,
-      });
+      at.push(
+        {
+          x: -3,
+          y: -1,
+        },
+        {
+          x: 2,
+          y: -2,
+        },
+        {
+          x: -2,
+          y: -2,
+        }
+      );
     }
   }
   // Annex C. Gray-scale Image Decoding Procedure.

--- a/src/core/writer.js
+++ b/src/core/writer.js
@@ -35,8 +35,7 @@ function writeStream(stream, buffer, transform) {
   if (transform !== null) {
     string = transform.encryptString(string);
   }
-  buffer.push(string);
-  buffer.push("\nendstream\n");
+  buffer.push(string, "\nendstream\n");
 }
 
 function writeArray(array, buffer, transform) {
@@ -219,8 +218,7 @@ function incrementalUpdate({
     maxOffset = Math.max(maxOffset, baseOffset);
     xrefTableData.push([1, baseOffset, Math.min(ref.gen, 0xffff)]);
     baseOffset += data.length;
-    indexes.push(ref.num);
-    indexes.push(1);
+    indexes.push(ref.num, 1);
     buffer.push(data);
   }
 

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -366,8 +366,7 @@ function compileType3Glyph(imgData) {
         points[p] &= (type >> 2) | (type << 2);
       }
 
-      coords.push(p % width1);
-      coords.push((p / width1) | 0);
+      coords.push(p % width1, (p / width1) | 0);
 
       if (!points[p]) {
         --count;

--- a/src/scripting_api/aform.js
+++ b/src/scripting_api/aform.js
@@ -161,11 +161,7 @@ class AForm {
     // sepStyle is an integer in [0;4]
     sepStyle = Math.min(Math.max(0, Math.floor(sepStyle)), 4);
 
-    buf.push("%,");
-    buf.push(sepStyle);
-    buf.push(".");
-    buf.push(nDec.toString());
-    buf.push("f");
+    buf.push("%,", sepStyle, ".", nDec.toString(), "f");
 
     if (!bCurrencyPrepend) {
       buf.push(strCurrency);

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -856,8 +856,10 @@ function stringToUTF16BEString(str) {
   const buf = ["\xFE\xFF"];
   for (let i = 0, ii = str.length; i < ii; i++) {
     const char = str.charCodeAt(i);
-    buf.push(String.fromCharCode((char >> 8) & 0xff));
-    buf.push(String.fromCharCode(char & 0xff));
+    buf.push(
+      String.fromCharCode((char >> 8) & 0xff),
+      String.fromCharCode(char & 0xff)
+    );
   }
   return buf.join("");
 }


### PR DESCRIPTION
There's generally speaking no need to use multiple consecutive `Array.prototype.push()` calls, since that method accepts multiple arguments, and this ESLint rule helps enforce that pattern.

Please see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-array-push-push.md for additional information.