### PR TITLE
Fix Postscript name in font to avoid bug when saving in pdf

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -722,6 +722,11 @@ function createPostTable(properties) {
   ); // maxMemType1
 }
 
+function createPostscriptName(name) {
+  // See https://docs.microsoft.com/en-us/typography/opentype/spec/recom#name.
+  return name.replace(/[^\x21-\x7E]|[[\](){}<>/%]/g, "").slice(0, 63);
+}
+
 function createNameTable(name, proto) {
   if (!proto) {
     proto = [[], []]; // no strings and unicode strings
@@ -734,7 +739,7 @@ function createNameTable(name, proto) {
     proto[0][3] || "uniqueID", // 3.Unique ID
     proto[0][4] || name, // 4.Full font name
     proto[0][5] || "Version 0.11", // 5.Version
-    proto[0][6] || "", // 6.Postscript name
+    proto[0][6] || createPostscriptName(name), // 6.Postscript name
     proto[0][7] || "Unknown", // 7.Trademark
     proto[0][8] || "Unknown", // 8.Manufacturer
     proto[0][9] || "Unknown", // 9.Designer


### PR DESCRIPTION
  - for xfa rendering, fonts are loaded and used in html;
  - when printed and saved in pdf, on linux, Firefox uses cairo backend
  - when subsetting a font, cairo uses the font postscript name and when this one is empty that leads to a bug
    (the append at https://github.com/freedesktop/cairo/blob/63f0d6268469dcd12316ea405a026f4be900dd79/src/cairo-cff-subset.c#L2049 is failing because of null length)
  - so this patch adds a postscript name to the font to make cairo happy.