### PR TITLE
Update webpack import instructions

### DIFF
--- a/examples/webpack/README.md
+++ b/examples/webpack/README.md
@@ -33,6 +33,6 @@ Webpack users. You will need to install
 dependency in your project in order to use `pdfjs-dist/webpack` (configuring
 `worker-loader` is not necessary; just installing it is sufficient).
 
-    import pdfjsLib from 'pdfjs-dist/webpack';
+    import * as pdfjsLib from 'pdfjs-dist/webpack';
 
 For a full working example refer to [this repository](https://github.com/yurydelendik/pdfjs-react).


### PR DESCRIPTION
This resolves an issue I had when loading pdf.js with webpack. `pdfjsLib` was always `undefined` after the import, and I dug deep into pdf.js's `webpack.js` file to sort out this issue, making all sorts of changes.

I figured out that there was just something wrong with the export/import procedure. After making this change, I now have the full pdfjs object in my webpack application.