### PR TITLE
Don't change options of the globally used `PartialEvaluator` in the "should render checkbox with fallback font for printing" unit-test

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -229,9 +229,13 @@ class PartialEvaluator {
     return shadow(this, "_pdfFunctionFactory", pdfFunctionFactory);
   }
 
-  clone(newOptions = DefaultPartialEvaluatorOptions) {
+  clone(newOptions = null) {
     const newEvaluator = Object.create(this);
-    newEvaluator.options = newOptions;
+    newEvaluator.options = Object.assign(
+      Object.create(null),
+      this.options,
+      newOptions
+    );
     return newEvaluator;
   }
 
@@ -3948,9 +3952,7 @@ class TranslatedFont {
     // When parsing Type3 glyphs, always ignore them if there are errors.
     // Compared to the parsing of e.g. an entire page, it doesn't really
     // make sense to only be able to render a Type3 glyph partially.
-    const type3Options = Object.create(evaluator.options);
-    type3Options.ignoreErrors = false;
-    const type3Evaluator = evaluator.clone(type3Options);
+    const type3Evaluator = evaluator.clone({ ignoreErrors: false });
     type3Evaluator.parsingType3Font = true;
 
     const translatedFont = this.font,

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -2281,7 +2281,7 @@ describe("annotation", function () {
         { ref: buttonWidgetRef, data: buttonWidgetDict },
       ]);
       const task = new WorkerTask("test print");
-      partialEvaluator.options = { ignoreErrors: true };
+      const checkboxEvaluator = partialEvaluator.clone({ ignoreErrors: true });
 
       const annotation = await AnnotationFactory.create(
         xref,
@@ -2293,7 +2293,7 @@ describe("annotation", function () {
       annotationStorage.set(annotation.data.id, { value: true });
 
       const operatorList = await annotation.getOperatorList(
-        partialEvaluator,
+        checkboxEvaluator,
         task,
         false,
         annotationStorage


### PR DESCRIPTION
Given that the same `PartialEvaluator`-instance is used for a lot of these unit-tests, manually changing the options in any one test-case could lead to intermittently failing unit-tests since they're run in a random order.
To fix this, we simply have to use the existing method to clone the `PartialEvaluator`-instance but with the custom options.