### PR TITLE
XFA - Implement usehref support

### DIFF
--- a/src/core/xfa/builder.js
+++ b/src/core/xfa/builder.js
@@ -21,6 +21,7 @@ import {
   $nsAttributes,
   $onChild,
   $resolvePrototypes,
+  $root,
   XFAObject,
 } from "./xfa_object.js";
 import { NamespaceSetUp } from "./setup.js";
@@ -43,6 +44,10 @@ class Root extends XFAObject {
   [$finalize]() {
     super[$finalize]();
     if (this.element.template instanceof Template) {
+      // Set the root element in $ids using a symbol in order
+      // to avoid conflict with real IDs.
+      this[$ids].set($root, this.element);
+
       this.element.template[$resolvePrototypes](this[$ids]);
       this.element.template[$ids] = this[$ids];
     }

--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -3866,9 +3866,6 @@ class Subform extends XFAObject {
   }
 
   [$toHTML](availableSpace) {
-    if (this.name === "helpText") {
-      return HTMLResult.EMPTY;
-    }
     if (this[$extra] && this[$extra].afterBreakAfter) {
       const ret = this[$extra].afterBreakAfter;
       delete this[$extra];
@@ -3889,8 +3886,6 @@ class Subform extends XFAObject {
         "XFA - Several breakBefore or breakAfter in subforms: please file a bug."
       );
     }
-
-    // TODO: implement usehref (probably in bind.js).
 
     // TODO: incomplete.
     fixDimensions(this);

--- a/test/unit/xfa_parser_spec.js
+++ b/test/unit/xfa_parser_spec.js
@@ -304,6 +304,56 @@ describe("XFAParser", function () {
       expect(font.extras.id).toEqual("id2");
     });
 
+    it("should parse a xfa document and apply some prototypes through usehref", function () {
+      const xml = `
+<?xml version="1.0"?>
+<xdp:xdp xmlns:xdp="http://ns.adobe.com/xdp/">
+  <template xmlns="http://www.xfa.org/schema/xfa-template/3.3">
+    <subform>
+      <proto>
+        <draw name="foo">
+          <font typeface="Foo" size="123pt" weight="bold" posture="italic">
+            <fill>
+              <color value="1,2,3"/>
+            </fill>
+          </font>
+        </draw>
+      </proto>
+      <field>
+        <font usehref=".#som($template.#subform.foo.#font)"/>
+      </field>
+      <field>
+        <font usehref=".#som($template.#subform.foo.#font)" size="456pt" weight="bold" posture="normal">
+          <fill>
+            <color value="4,5,6"/>
+          </fill>
+          <extras id="id2"/>
+        </font>
+      </field>
+    </subform>
+  </template>
+</xdp:xdp>
+      `;
+      const root = new XFAParser().parse(xml)[$dump]();
+      let font = root.template.subform.field[0].font;
+      expect(font.typeface).toEqual("Foo");
+      expect(font.overline).toEqual(0);
+      expect(font.size).toEqual(123);
+      expect(font.weight).toEqual("bold");
+      expect(font.posture).toEqual("italic");
+      expect(font.fill.color.value).toEqual({ r: 1, g: 2, b: 3 });
+      expect(font.extras).toEqual(undefined);
+
+      font = root.template.subform.field[1].font;
+      expect(font.typeface).toEqual("Foo");
+      expect(font.overline).toEqual(0);
+      expect(font.size).toEqual(456);
+      expect(font.weight).toEqual("bold");
+      expect(font.posture).toEqual("normal");
+      expect(font.fill.color.value).toEqual({ r: 4, g: 5, b: 6 });
+      expect(font.extras.id).toEqual("id2");
+    });
+
     it("should parse a xfa document with xhtml", function () {
       const xml = `
 <?xml version="1.0"?>


### PR DESCRIPTION
  - attribute 'use' was already implemented but not usehref
  - in general, usehref should make reference to current document
  - add support for SOM expressions in use and usehref to search a node.
  - get prototype for all nodes if any.