### PR TITLE
Fix find highlighting regression from #13306.

### DIFF
--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -34,11 +34,14 @@
 }
 
 .textLayer .highlight {
-  position: relative;
   margin: -1px;
   padding: 1px;
   background-color: rgba(180, 0, 170, 1);
   border-radius: 4px;
+}
+
+.textLayer .highlight.appended {
+  position: initial;
 }
 
 .textLayer .highlight.begin {

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -239,7 +239,7 @@ class TextLayerBuilder {
       const node = document.createTextNode(content);
       if (className) {
         const span = document.createElement("span");
-        span.className = className;
+        span.className = `${className} appended`;
         span.appendChild(node);
         div.appendChild(span);
         return;


### PR DESCRIPTION
When we insert extra spans for highlighting we want
them to be positioned normally instead of absolute or
relative.

Fixes #13345.