### PR TITLE
[GENERIC viewer] Fix printing regression from PR 13411

### DIFF
--- a/web/firefox_print_service.js
+++ b/web/firefox_print_service.js
@@ -34,7 +34,7 @@ function composePage(
   canvas.height = Math.floor(size.height * PRINT_UNITS);
 
   const canvasWrapper = document.createElement("div");
-  canvasWrapper.setAttribute("class", "printedPage");
+  canvasWrapper.className = "printedPage";
   canvasWrapper.appendChild(canvas);
   printContainer.appendChild(canvasWrapper);
 

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -163,10 +163,8 @@ PDFPrintService.prototype = {
         this._printResolution,
         this._optionalContentConfigPromise
       )
-        .then(() => {
-          this.useRenderedPage.bind(this);
-        })
-        .then(() => {
+        .then(this.useRenderedPage.bind(this))
+        .then(function () {
           renderNextPage(resolve, reject);
         }, reject);
     };
@@ -189,7 +187,7 @@ PDFPrintService.prototype = {
     }
 
     const wrapper = document.createElement("div");
-    wrapper.setAttribute("class", "printedPage");
+    wrapper.className = "printedPage";
     wrapper.appendChild(img);
     this.printContainer.appendChild(wrapper);
 

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -1002,7 +1002,7 @@ function getXfaHtmlForPrinting(printContainer, pdfDocument) {
   const scale = Math.round(CSS_UNITS * 100) / 100;
   for (const xfaPage of xfaHtml.children) {
     const page = document.createElement("div");
-    page.setAttribute("class", "xfaPrintedPage");
+    page.className = "xfaPrintedPage";
     printContainer.appendChild(page);
 
     const { width, height } = xfaPage.attributes.style;

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1839,8 +1839,8 @@ html[dir="rtl"] #documentPropertiesOverlay .row > * {
     position: relative;
   }
 
-  .printedPage canvas,
-  .printedPage img {
+  #printContainer > .printedPage canvas,
+  #printContainer > .printedPage img {
     /* The intrinsic canvas / image size will make sure that we fit the page. */
     max-width: 100%;
     max-height: 100%;


### PR DESCRIPTION
I missed this during review, since some of the changes in `web/pdf_print_service.js` broke printing.

Also, as part of these changes the patch replaces what looks like unnecessary `setAttribute` usage with "regular" `className` assignment and finally updates a couple of the CSS-rules to be more consistent.