### PR TITLE
Fix scrolling of search results in documents with marked content (bug 1714183)

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -223,7 +223,7 @@ class PDFFindController {
       top: MATCH_SCROLL_OFFSET_TOP,
       left: MATCH_SCROLL_OFFSET_LEFT,
     };
-    scrollIntoView(element, spot, /* skipOverflowHiddenElements = */ true);
+    scrollIntoView(element, spot, /* scrollMatches = */ true);
   }
 
   _reset() {

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -97,10 +97,11 @@ function getOutputScale(ctx) {
  * @param {Object} element - The element to be visible.
  * @param {Object} spot - An object with optional top and left properties,
  *   specifying the offset from the top left edge.
- * @param {boolean} skipOverflowHiddenElements - Ignore elements that have
- *   the CSS rule `overflow: hidden;` set. The default is false.
+ * @param {boolean} [scrollMatches] - When scrolling search results into view,
+ *   ignore elements that either: Contains marked content identifiers,
+ *   or have the CSS-rule `overflow: hidden;` set. The default value is `false`.
  */
-function scrollIntoView(element, spot, skipOverflowHiddenElements = false) {
+function scrollIntoView(element, spot, scrollMatches = false) {
   // Assuming offsetParent is available (it's not available when viewer is in
   // hidden iframe or object). We have to scroll: if the offsetParent is not set
   // producing the error. See also animationStarted.
@@ -114,8 +115,9 @@ function scrollIntoView(element, spot, skipOverflowHiddenElements = false) {
   while (
     (parent.clientHeight === parent.scrollHeight &&
       parent.clientWidth === parent.scrollWidth) ||
-    (skipOverflowHiddenElements &&
-      getComputedStyle(parent).overflow === "hidden")
+    (scrollMatches &&
+      (parent.classList.contains("markedContent") ||
+        getComputedStyle(parent).overflow === "hidden"))
   ) {
     offsetY += parent.offsetTop;
     offsetX += parent.offsetLeft;

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -117,12 +117,9 @@ function scrollIntoView(element, spot, skipOverflowHiddenElements = false) {
     (skipOverflowHiddenElements &&
       getComputedStyle(parent).overflow === "hidden")
   ) {
-    if (parent.dataset._scaleY) {
-      offsetY /= parent.dataset._scaleY;
-      offsetX /= parent.dataset._scaleX;
-    }
     offsetY += parent.offsetTop;
     offsetX += parent.offsetLeft;
+
     parent = parent.offsetParent;
     if (!parent) {
       return; // no need to scroll


### PR DESCRIPTION
This regressed in PR #13171, since the `span`s with the marked content identifiers interfere with scrolling of search results.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1714183

