### PR TITLE
Add normalization for Hyphen -> Hyphen-minus

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -29,6 +29,7 @@ const MATCH_SCROLL_OFFSET_TOP = -50; // px
 const MATCH_SCROLL_OFFSET_LEFT = -400; // px
 
 const CHARACTERS_TO_NORMALIZE = {
+  "\u2010": "-", // Hyphen
   "\u2018": "'", // Left single quotation mark
   "\u2019": "'", // Right single quotation mark
   "\u201A": "'", // Single low-9 quotation mark


### PR DESCRIPTION
Previously these two characters were not searchable interchangably, even when Hyphen-Minus is being changed to Hyphen in some text to PDF pipelines.

example of what it fixes: The CA/B Forum Baseline Requirements documents (v1.7.5, https://cabforum.org/wp-content/uploads/CA-Browser-Forum-BR-1.7.5.pdf)  currently contain "SHA-1" on page 15 (search 'Subordinate CA certificates using the SHA"), but you won't find matches for "SHA-1" due to it using Hyphen (\u2010) instead of Hyphen-Minus (\u002D). 