### PR TITLE
Initialize `HTMLResult.{FAILURE, EMPTY}` lazily

### DIFF
--- a/src/core/xfa/utils.js
+++ b/src/core/xfa/utils.js
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+import { shadow } from "../../shared/util.js";
+
 const dimConverters = {
   pt: x => x,
   cm: x => (x / 2.54) * 72,
@@ -165,6 +167,14 @@ function getBBox(data) {
 }
 
 class HTMLResult {
+  static get FAILURE() {
+    return shadow(this, "FAILURE", new HTMLResult(false, null, null));
+  }
+
+  static get EMPTY() {
+    return shadow(this, "EMPTY", new HTMLResult(true, null, null));
+  }
+
   constructor(success, html, bbox) {
     this.success = success;
     this.html = html;
@@ -175,9 +185,6 @@ class HTMLResult {
     return new HTMLResult(true, html, bbox);
   }
 }
-
-HTMLResult.FAILURE = new HTMLResult(false, null, null);
-HTMLResult.EMPTY = new HTMLResult(true, null, null);
 
 export {
   getBBox,


### PR DESCRIPTION
While these objects aren't exactly that big and/or complex, they are nonetheless *only* necessary for XFA documents.
However, currently these objects are initialized *eagerly* for all PDF documents. By using the same pattern as elsewhere in the code-base, it's very easy to make these lazily initialized; so let's just do that instead :-)