### PR TITLE
Use the `DOMSVGFactory`, rather than manually creating the SVG-element, in `createMatrix` (PR 13361 follow-up)

### DIFF
--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -20,6 +20,7 @@ import {
   unreachable,
   Util,
 } from "../shared/util.js";
+import { DOMSVGFactory } from "./display_utils.js";
 
 let svgElement;
 
@@ -29,7 +30,8 @@ function createMatrix(matrix) {
     return new DOMMatrix(matrix);
   }
   if (!svgElement) {
-    svgElement = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const svgFactory = new DOMSVGFactory();
+    svgElement = svgFactory.createElement("svg");
   }
   return svgElement.createSVGMatrix(matrix);
 }


### PR DESCRIPTION
Generally, in the `src/display/` folder, we utilize `DOMSVGFactory` rather than manually creating an SVG-element; hence let's do the same thing in `src/display/pattern_helper.js` as well.