### PR TITLE
XFA - Add support for reftests

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2272,6 +2272,7 @@ class WorkerTransport {
       docId: loadingTask.docId,
       onUnsupportedFeature: this._onUnsupportedFeature.bind(this),
       ownerDocument: params.ownerDocument,
+      styleElement: params.styleElement,
     });
     this._params = params;
     this.CMapReaderFactory = new params.CMapReaderFactory({

--- a/test/pdfs/hsbc.pdf.link
+++ b/test/pdfs/hsbc.pdf.link
@@ -1,0 +1,1 @@
+https://web.archive.org/web/20210607145115/https://www.hsbc.fr/content/dam/hsbc/fr/docs/pib/Contestation-Transaction-Carte-Bancaire.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2725,6 +2725,14 @@
        "rounds": 1,
        "type": "eq"
    },
+    {  "id": "hsbc",
+       "file": "pdfs/hsbc.pdf",
+       "md5": "34a63a9ed9cdf3790562a3dfd1703e48",
+       "rounds": 1,
+       "link": true,
+       "enableXfa": true,
+       "type": "eq"
+    },
     {  "id": "issue7580-text",
        "file": "pdfs/issue7580.pdf",
        "md5": "44dd5a9b4373fcab9890cf567722a766",

--- a/web/xfa_layer_builder.css
+++ b/web/xfa_layer_builder.css
@@ -33,6 +33,8 @@
   vertical-align: inherit;
   box-sizing: border-box;
   background: transparent;
+  padding: 0;
+  margin: 0;
 }
 
 .xfaLayer a {


### PR DESCRIPTION
In order to render correctly embedded fonts, we need hack the font loader to get font rules to inject them in the svg.
The idea is to pass a style element through the api to the font loader, load font rules in this element and finally get rules as string in the driver.  
