### PR TITLE
[api-minor] Fetch binary CMap data in the worker-thread, when `useWorkerFetch` is set

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -412,6 +412,7 @@ class WorkerMessageHandler {
         isEvalSupported: data.isEvalSupported,
         fontExtraProperties: data.fontExtraProperties,
         useSystemFonts: data.useSystemFonts,
+        cMapUrl: data.cMapUrl,
         standardFontDataUrl: data.standardFontDataUrl,
       };
 

--- a/src/display/base_factory.js
+++ b/src/display/base_factory.js
@@ -1,0 +1,129 @@
+/* Copyright 2015 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CMapCompressionType, unreachable } from "../shared/util.js";
+
+class BaseCanvasFactory {
+  constructor() {
+    if (this.constructor === BaseCanvasFactory) {
+      unreachable("Cannot initialize BaseCanvasFactory.");
+    }
+  }
+
+  create(width, height) {
+    unreachable("Abstract method `create` called.");
+  }
+
+  reset(canvasAndContext, width, height) {
+    if (!canvasAndContext.canvas) {
+      throw new Error("Canvas is not specified");
+    }
+    if (width <= 0 || height <= 0) {
+      throw new Error("Invalid canvas size");
+    }
+    canvasAndContext.canvas.width = width;
+    canvasAndContext.canvas.height = height;
+  }
+
+  destroy(canvasAndContext) {
+    if (!canvasAndContext.canvas) {
+      throw new Error("Canvas is not specified");
+    }
+    // Zeroing the width and height cause Firefox to release graphics
+    // resources immediately, which can greatly reduce memory consumption.
+    canvasAndContext.canvas.width = 0;
+    canvasAndContext.canvas.height = 0;
+    canvasAndContext.canvas = null;
+    canvasAndContext.context = null;
+  }
+}
+
+class BaseCMapReaderFactory {
+  constructor({ baseUrl = null, isCompressed = false }) {
+    if (this.constructor === BaseCMapReaderFactory) {
+      unreachable("Cannot initialize BaseCMapReaderFactory.");
+    }
+    this.baseUrl = baseUrl;
+    this.isCompressed = isCompressed;
+  }
+
+  async fetch({ name }) {
+    if (!this.baseUrl) {
+      throw new Error(
+        'The CMap "baseUrl" parameter must be specified, ensure that ' +
+          'the "cMapUrl" and "cMapPacked" API parameters are provided.'
+      );
+    }
+    if (!name) {
+      throw new Error("CMap name must be specified.");
+    }
+    const url = this.baseUrl + name + (this.isCompressed ? ".bcmap" : "");
+    const compressionType = this.isCompressed
+      ? CMapCompressionType.BINARY
+      : CMapCompressionType.NONE;
+
+    return this._fetchData(url, compressionType).catch(reason => {
+      throw new Error(
+        `Unable to load ${this.isCompressed ? "binary " : ""}CMap at: ${url}`
+      );
+    });
+  }
+
+  /**
+   * @private
+   */
+  _fetchData(url, compressionType) {
+    unreachable("Abstract method `_fetchData` called.");
+  }
+}
+
+class BaseStandardFontDataFactory {
+  constructor({ baseUrl = null }) {
+    if (this.constructor === BaseStandardFontDataFactory) {
+      unreachable("Cannot initialize BaseStandardFontDataFactory.");
+    }
+    this.baseUrl = baseUrl;
+  }
+
+  async fetch({ filename }) {
+    if (!this.baseUrl) {
+      throw new Error(
+        'The standard font "baseUrl" parameter must be specified, ensure that ' +
+          'the "standardFontDataUrl" API parameter is provided.'
+      );
+    }
+    if (!filename) {
+      throw new Error("Font filename must be specified.");
+    }
+    const url = this.baseUrl + filename + ".pfb";
+
+    return this._fetchData(url).catch(reason => {
+      throw new Error(`Unable to load font data at: ${url}`);
+    });
+  }
+
+  /**
+   * @private
+   */
+  _fetchData(url) {
+    unreachable("Abstract method `_fetchData` called.");
+  }
+}
+
+export {
+  BaseCanvasFactory,
+  BaseCMapReaderFactory,
+  BaseStandardFontDataFactory,
+};

--- a/src/display/node_utils.js
+++ b/src/display/node_utils.js
@@ -18,22 +18,9 @@ import {
   BaseCanvasFactory,
   BaseCMapReaderFactory,
   BaseStandardFontDataFactory,
-} from "./display_utils.js";
+} from "./base_factory.js";
 import { isNodeJS } from "../shared/is_node.js";
 import { unreachable } from "../shared/util.js";
-
-function fetchData(url) {
-  return new Promise((resolve, reject) => {
-    const fs = __non_webpack_require__("fs");
-    fs.readFile(url, (error, data) => {
-      if (error || !data) {
-        reject(new Error(error));
-        return;
-      }
-      resolve(new Uint8Array(data));
-    });
-  });
-}
 
 let NodeCanvasFactory = class {
   constructor() {
@@ -54,6 +41,19 @@ let NodeStandardFontDataFactory = class {
 };
 
 if ((typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) && isNodeJS) {
+  const fetchData = function (url) {
+    return new Promise((resolve, reject) => {
+      const fs = __non_webpack_require__("fs");
+      fs.readFile(url, (error, data) => {
+        if (error || !data) {
+          reject(new Error(error));
+          return;
+        }
+        resolve(new Uint8Array(data));
+      });
+    });
+  };
+
   NodeCanvasFactory = class extends BaseCanvasFactory {
     create(width, height) {
       if (width <= 0 || height <= 0) {

--- a/test/driver.js
+++ b/test/driver.js
@@ -19,7 +19,7 @@
 
 const WAITING_TIME = 100; // ms
 const PDF_TO_CSS_UNITS = 96.0 / 72.0;
-const CMAP_URL = "../external/bcmaps/";
+const CMAP_URL = "/build/generic/web/cmaps/";
 const CMAP_PACKED = true;
 const STANDARD_FONT_DATA_URL = "/build/generic/web/standard_fonts/";
 const IMAGE_RESOURCES_PATH = "/web/images/";

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -4046,6 +4046,15 @@
       "lastPage": 1,
       "type": "eq"
     },
+    {  "id": "mao-main_thread_fetch",
+       "file": "pdfs/mao.pdf",
+       "md5": "797093d67c4d4d4231ac6e1fb66bf6c3",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq",
+       "useWorkerFetch": false
+    },
     {  "id": "mao-text",
        "file": "pdfs/mao.pdf",
        "md5": "797093d67c4d4d4231ac6e1fb66bf6c3",


### PR DESCRIPTION
This patch uses the new option added in PR #12726 to *also* allow fetching binary CMap data directly in the worker-thread in browsers.
Given that these changes remove the need to transfer data between threads for the default (browser) use-case, we can also revert the changes in PR #11118 since that simplifies the overall implementation.