### PR TITLE
Always use standard font data, with `disableFontFace` set in the API (PR 12726 follow-up)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -397,14 +397,16 @@ class PartialEvaluator {
       return new Stream(cachedData);
     }
 
-    // The symbol fonts are not consistent across platforms, always load the
-    // standard font data for them.
-    if (
-      this.options.useSystemFonts &&
-      name !== "Symbol" &&
-      name !== "ZapfDingbats"
-    ) {
-      return null;
+    if (!this.options.disableFontFace) {
+      // The symbol fonts are not consistent across platforms, always load the
+      // standard font data for them.
+      if (
+        this.options.useSystemFonts &&
+        name !== "Symbol" &&
+        name !== "ZapfDingbats"
+      ) {
+        return null;
+      }
     }
 
     const standardFontNameToFileName = getFontNameToFileMap(),


### PR DESCRIPTION
We must force-fetch standard font data, when `disableFontFace = true` is set in the API, since otherwise rendering in e.g. the viewer is still broken (same as before PR #12726 landed).

*Please note:* We still need to also load standard font data for patterns and/or some text-rendering modes, however that will require larger changes so I figured that it cannot hurt to submit *this* patch right now.

---

Currently I'm also looking into the follow-up of how to try and support the patterns and/or text-rendering modes use-cases, which is quite important to fix a number of bugs, but it unfortunately looks quite messy :-(

It seems that we'd need to somehow invalidate and then re-parse fonts in these cases, however my initial experiments have lead to *very* ugly code that isn't really maintainable. 

Basically, all of this would be *a lot* easier if we could just always load the standard font files instead. Obviously the Foxit fonts are a bit limited, but if we *replaced* them with Liberation fonts instead that might work (despite those files being a bit larger)?

There's also the question of Linux in particular, since there's a number of bugs/issues about the system fonts leading to poor rendering there. Hence it seems to me that we'd maybe even want to *unconditionally* load the standard font files there?
