### PR TITLE
XFA - Flush contents when breakBefore target is 'auto'

### DIFF
--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -4535,8 +4535,10 @@ class Template extends XFAObject {
           this[$extra].breakingNode = null;
 
           if (node.targetType === "auto") {
-            // Just ignore the break and do layout again.
-            i--;
+            html = root[$flushHTML]();
+            if (html) {
+              htmlContentAreas[i].children.push(html);
+            }
             continue;
           }
 

--- a/test/pdfs/xfa_hsbc_closure.pdf.link
+++ b/test/pdfs/xfa_hsbc_closure.pdf.link
@@ -1,0 +1,1 @@
+https://web.archive.org/web/20210610145227/https://www.hsbc.fr/content/dam/hsbc/fr/docs/pib/Cloture-Compte.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2741,6 +2741,14 @@
        "enableXfa": true,
        "type": "eq"
     },
+    {  "id": "hsbc_closure",
+       "file": "pdfs/xfa_hsbc_closure.pdf",
+       "md5": "7d101861d6232fe5f658e8aeca5c9891",
+       "rounds": 1,
+       "link": true,
+       "enableXfa": true,
+       "type": "eq"
+    },
     {  "id": "xfa_imm1344e",
        "file": "pdfs/xfa_imm1344e.pdf",
        "md5": "f9b8b6e7d385691efdea2544576f5eb2",


### PR DESCRIPTION
  - some page can be missed in the final document because of that (see pdf in the test case which has 4 pages (when only 3 are rendered right now)