### PR TITLE
XFA - Handle correctly subformSet

### DIFF
--- a/src/core/xfa/html_utils.js
+++ b/src/core/xfa/html_utils.js
@@ -16,6 +16,7 @@
 import {
   $extra,
   $getParent,
+  $getSubformParent,
   $nodeName,
   $toStyle,
   XFAObject,
@@ -296,7 +297,7 @@ function computeBbox(node, html, availableSpace) {
 }
 
 function fixDimensions(node) {
-  const parent = node[$getParent]();
+  const parent = node[$getSubformParent]();
   if (parent.layout && parent.layout.includes("row")) {
     const extra = parent[$extra];
     const colSpan = node.colSpan;

--- a/src/core/xfa/xfa_object.js
+++ b/src/core/xfa/xfa_object.js
@@ -43,7 +43,9 @@ const $getChildrenByNameIt = Symbol();
 const $getDataValue = Symbol();
 const $getRealChildrenByNameIt = Symbol();
 const $getChildren = Symbol();
+const $getContainedChildren = Symbol();
 const $getNextPage = Symbol();
+const $getSubformParent = Symbol();
 const $getParent = Symbol();
 const $global = Symbol();
 const $hasItem = Symbol();
@@ -255,6 +257,10 @@ class XFAObject {
     return this[_parent];
   }
 
+  [$getSubformParent]() {
+    return this[$getParent]();
+  }
+
   [$getChildren](name = null) {
     if (!name) {
       return this[_children];
@@ -296,8 +302,15 @@ class XFAObject {
     return HTMLResult.EMPTY;
   }
 
-  *[_filteredChildrenGenerator](filter, include) {
+  *[$getContainedChildren]() {
+    // This function is overriden in Subform and SubformSet.
     for (const node of this[$getChildren]()) {
+      yield node;
+    }
+  }
+
+  *[_filteredChildrenGenerator](filter, include) {
+    for (const node of this[$getContainedChildren]()) {
       if (!filter || include === filter.has(node[$nodeName])) {
         const availableSpace = this[$getAvailableSpace]();
         const res = node[$toHTML](availableSpace);
@@ -965,10 +978,12 @@ export {
   $getChildrenByClass,
   $getChildrenByName,
   $getChildrenByNameIt,
+  $getContainedChildren,
   $getDataValue,
   $getNextPage,
   $getParent,
   $getRealChildrenByNameIt,
+  $getSubformParent,
   $global,
   $hasItem,
   $hasSettableValue,

--- a/test/pdfs/xfa_issue13213.pdf.link
+++ b/test/pdfs/xfa_issue13213.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/6290046/cerfa_12156-05.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -938,6 +938,14 @@
        "enableXfa": true,
        "type": "eq"
     },
+    {  "id": "xfa_issue13213",
+       "file": "pdfs/xfa_issue13213.pdf",
+       "md5": "8a0e3179bffbac721589d1b1df863b49",
+       "link": true,
+       "rounds": 1,
+       "enableXfa": true,
+       "type": "eq"
+    },
     {  "id": "issue10272",
        "file": "pdfs/issue10272.pdf",
        "md5": "bf3b2f74c6878d38a70dc0825f1b9a02",


### PR DESCRIPTION
  - it aims to avoid to loop forever when opening pdf in #13213;
  - the idea is to consider subformSet as inexistent when running in the tree. So if we've subformA > subformSet > subformB then subformB will be visited as a direct child of subformA.