### PR TITLE
Remove the `isFetchSupported` function since the Fetch API is available in all supported browsers

### DIFF
--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -49,7 +49,7 @@ class DOMCanvasFactory extends BaseCanvasFactory {
 async function fetchData(url, asTypedArray = false) {
   if (
     (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) ||
-    (isFetchSupported() && isValidFetchUrl(url, document.baseURI))
+    isValidFetchUrl(url, document.baseURI)
   ) {
     const response = await fetch(url);
     if (!response.ok) {
@@ -483,15 +483,6 @@ class StatTimer {
   }
 }
 
-function isFetchSupported() {
-  return (
-    typeof fetch !== "undefined" &&
-    typeof Response !== "undefined" &&
-    "body" in Response.prototype &&
-    typeof ReadableStream !== "undefined"
-  );
-}
-
 function isValidFetchUrl(url, baseUrl) {
   try {
     const { protocol } = baseUrl ? new URL(url, baseUrl) : new URL(url);
@@ -626,7 +617,6 @@ export {
   getFilenameFromUrl,
   getPdfFilenameFromUrl,
   isDataScheme,
-  isFetchSupported,
   isPdfFile,
   isValidFetchUrl,
   LinkTarget,


### PR DESCRIPTION
The currently supported browsers, note the minimum versions [listed here](https://github.com/mozilla/pdf.js/blob/5a4e06af2d1f5bf1a4281b4ec3ec18bccd2adebb/gulpfile.js#L78-L88), should now have native support for all of the features checked in the `isFetchSupported` function:

 - https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API#browser_compatibility
 - https://developer.mozilla.org/en-US/docs/Web/API/Response#browser_compatibility
 - https://developer.mozilla.org/en-US/docs/Web/API/Body/body#browser_compatibility
 - https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream#browser_compatibility

Hence this function can now be removed, and the code can thus be simplified a little bit.