### PR TITLE
Remove the internal `PDFScriptingManager._pageEventsReady` boolean (PR 13074 follow-up)

### DIFF
--- a/web/pdf_scripting_manager.js
+++ b/web/pdf_scripting_manager.js
@@ -96,7 +96,14 @@ class PDFScriptingManager {
     if (pdfDocument !== this._pdfDocument) {
       return; // The document was closed while the data resolved.
     }
-    this._scripting = this._createScripting();
+    try {
+      this._scripting = this._createScripting();
+    } catch (error) {
+      console.error(`PDFScriptingManager.setDocument: "${error?.message}".`);
+
+      await this._destroyScripting();
+      return;
+    }
 
     this._internalEvents.set("updatefromsandbox", event => {
       if (event?.source !== window) {

--- a/web/pdf_scripting_manager.js
+++ b/web/pdf_scripting_manager.js
@@ -46,7 +46,6 @@ class PDFScriptingManager {
 
     this._scripting = null;
     this._mouseState = Object.create(null);
-    this._pageEventsReady = false;
     this._ready = false;
 
     this._eventBus = eventBus;
@@ -308,7 +307,6 @@ class PDFScriptingManager {
         return;
       }
     }
-
     delete detail.id;
     delete detail.siblings;
 
@@ -333,10 +331,8 @@ class PDFScriptingManager {
 
     if (initialize) {
       this._closeCapability = createPromiseCapability();
-
-      this._pageEventsReady = true;
     }
-    if (!this._pageEventsReady) {
+    if (!this._closeCapability) {
       return; // Scripting isn't fully initialized yet.
     }
     const pageView = this._pdfViewer.getPageView(/* index = */ pageNumber - 1);
@@ -373,7 +369,7 @@ class PDFScriptingManager {
     const pdfDocument = this._pdfDocument,
       visitedPages = this._visitedPages;
 
-    if (!this._pageEventsReady) {
+    if (!this._closeCapability) {
       return; // Scripting isn't fully initialized yet.
     }
     if (this._pageOpenPending.has(pageNumber)) {
@@ -481,7 +477,6 @@ class PDFScriptingManager {
 
     this._scripting = null;
     delete this._mouseState.isDown;
-    this._pageEventsReady = false;
     this._ready = false;
 
     this._destroyCapability?.resolve();


### PR DESCRIPTION
With the introduction of `PDFScriptingManager._closeCapability` in PR #13074, the pre-existing `PDFScriptingManager._pageEventsReady` boolean essentially became redundant.
Given that you always want to avoid tracking closely related state *separately*, since it's easy to introduce subtle bugs that way, we should just remove `PDFScriptingManager._pageEventsReady` now.

Obviously I *should* have done this already back in PR #13074, sorry about the churn here!