### PR TITLE
Set the default value of `useSystemFonts` correctly, depending on `disableFontFace`, in the API (PR 13516 follow-up)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -397,16 +397,14 @@ class PartialEvaluator {
       return new Stream(cachedData);
     }
 
-    if (!this.options.disableFontFace) {
-      // The symbol fonts are not consistent across platforms, always load the
-      // standard font data for them.
-      if (
-        this.options.useSystemFonts &&
-        name !== "Symbol" &&
-        name !== "ZapfDingbats"
-      ) {
-        return null;
-      }
+    // The symbol fonts are not consistent across platforms, always load the
+    // standard font data for them.
+    if (
+      this.options.useSystemFonts &&
+      name !== "Symbol" &&
+      name !== "ZapfDingbats"
+    ) {
+      return null;
     }
 
     const standardFontNameToFileName = getFontNameToFileMap(),

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -153,7 +153,9 @@ function setPDFNetworkStreamFactory(pdfNetworkStreamFactory) {
  *   Node.js. The default value is {DOMCMapReaderFactory}.
  * @property {boolean} [useSystemFonts] - When `true`, fonts that aren't
  *   embedded in the PDF document will fallback to a system font.
- *   The default value is `true` in web environments and `false` in Node.js.
+ *   The default value is `true` in web environments and `false` in Node.js;
+ *   unless `disableFontFace === true` in which case this defaults to `false`
+ *   regardless of the environment (to prevent completely broken fonts).
  * @property {string} [standardFontDataUrl] - The URL where the standard font
  *   files are located. Include the trailing slash.
  * @property {Object} [StandardFontDataFactory] - The factory that will be used
@@ -328,12 +330,6 @@ function getDocument(src) {
   if (!Number.isInteger(params.maxImageSize)) {
     params.maxImageSize = -1;
   }
-  if (typeof params.useSystemFonts !== "boolean") {
-    params.useSystemFonts = !(
-      (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&
-      isNodeJS
-    );
-  }
   if (typeof params.useWorkerFetch !== "boolean") {
     params.useWorkerFetch =
       params.CMapReaderFactory === DOMCMapReaderFactory &&
@@ -345,6 +341,13 @@ function getDocument(src) {
   if (typeof params.disableFontFace !== "boolean") {
     params.disableFontFace =
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) && isNodeJS;
+  }
+  if (typeof params.useSystemFonts !== "boolean") {
+    params.useSystemFonts =
+      !(
+        (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&
+        isNodeJS
+      ) && !params.disableFontFace;
   }
   if (typeof params.ownerDocument === "undefined") {
     params.ownerDocument = globalThis.document;


### PR DESCRIPTION
*Sorry about the churn here, since the change that I made in PR #13516 was not very smart.*

With the current code, it's now *impossible* for a user to actually control the `useSystemFonts` option manually. To prevent outright breakage we obviously still need to default to setting `useSystemFonts = false` when `disableFontFace === true`, however that should be possible for an API consumer to override.