### PR TITLE
Add a (basic) TypeScript definitions for the viewer components (issue 13267)

### DIFF
--- a/external/dist/legacy/web/pdf_viewer.d.ts
+++ b/external/dist/legacy/web/pdf_viewer.d.ts
@@ -1,0 +1,1 @@
+export * from "pdfjs-dist/types/web/pdf_viewer.component.d.ts";

--- a/external/dist/lib/README.md
+++ b/external/dist/lib/README.md
@@ -3,5 +3,5 @@ pre-built library as found in e.g. the `/build`, `/web`, and `/image_decoders`
 folders in the root of this repository.
 
 Please note that the "lib" build target exists mostly to enable unit-testing in
-Node.js/Travis, and that you'll need to handle e.g. any necessary polyfills
+Node.js/GitHub, and that you'll need to handle e.g. any necessary polyfills
 and/or Node.js dependencies yourself if using the files in this folder.

--- a/external/dist/web/pdf_viewer.d.ts
+++ b/external/dist/web/pdf_viewer.d.ts
@@ -1,0 +1,1 @@
+export * from "pdfjs-dist/types/web/pdf_viewer.component.d.ts";

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1382,7 +1382,10 @@ gulp.task("types", function (done) {
     "emitDeclarationOnly",
     "moduleResolution node",
   ].join(" --");
-  exec(`"node_modules/.bin/tsc" --${args} src/pdf.js`, done);
+  exec(
+    `"node_modules/.bin/tsc" --${args} src/pdf.js web/pdf_viewer.component.js`,
+    done
+  );
 });
 
 function buildLibHelper(bundleDefines, inputStream, outputDir) {
@@ -1993,7 +1996,7 @@ function packageBowerJson() {
     name: DIST_NAME,
     version: VERSION,
     main: "build/pdf.js",
-    types: "types/pdf.d.ts",
+    types: "types/src/pdf.d.ts",
     description: DIST_DESCRIPTION,
     keywords: DIST_KEYWORDS,
     homepage: DIST_HOMEPAGE,


### PR DESCRIPTION
Please note that while the `gulp types`/`gulp typestest` tasks (obviously) still work with this patch, I've got no idea if the output is first of all even useable and secondly if it's actually useful in practice.
However, in the interest of closing some (seemingly simple) issues, I suppose that this probably shouldn't hurt (and we'd need TypeScript users to help improve things here).

Fixes #13267