### PR TITLE
Allow using the standard font data for non-Type1 fonts (issue 13585, PR 12726 follow-up)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -3143,7 +3143,7 @@ class PartialEvaluator {
       // Heuristic: we have to check if the font is a standard one also
       if (isSymbolicFont) {
         encoding = MacRomanEncoding;
-        if (!properties.file) {
+        if (!properties.file || properties.isInternalFont) {
           if (/Symbol/i.test(properties.name)) {
             encoding = SymbolSetEncoding;
           } else if (/Dingbats|Wingdings/i.test(properties.name)) {
@@ -3791,6 +3791,7 @@ class PartialEvaluator {
           isType3Font,
         };
         const widths = dict.get("Widths");
+
         const standardFontName = getStandardFontName(baseFontName);
         let file = null;
         if (standardFontName) {
@@ -3889,7 +3890,7 @@ class PartialEvaluator {
         isInternalFont = !!fontFile;
         type = "TrueType";
       }
-    } else if (type === "Type1") {
+    } else if (!isType3Font) {
       const standardFontName = getStandardFontName(fontName.name);
       if (standardFontName) {
         isStandardFont = true;


### PR DESCRIPTION
Given that we're not imposing any font-type restrictions[1] in the non-/FontDescriptor case, it's not really clear to me why we'd actually need to do that in the general case.
Please note that there's some *expected* movement, all of which should be improvements, in the `fips197.pdf` file with this patch.

---
[1] With the exception of Type3-fonts, of course.