### PR TITLE
Stop encoding the value in the `DOMElement.setAttribute` method (issue 8558)

### DIFF
--- a/examples/node/domstubs.js
+++ b/examples/node/domstubs.js
@@ -93,9 +93,7 @@ DOMElement.prototype = {
   },
 
   setAttribute: function DOMElement_setAttribute(name, value) {
-    value = value || "";
-    value = xmlEncode(value);
-    this.attributes[name] = value;
+    this.attributes[name] = value || "";
   },
 
   setAttributeNS: function DOMElement_setAttributeNS(NS, name, value) {


### PR DESCRIPTION
This patch is an attempt at closing an old, and seemingly trivial, issue and the SVG-files created by the `pdf2svg.js` examples still appear to work just fine when opened in browsers (tested with Firefox Nightly and Google Chrome Beta).

Fixes #8558