### PR TITLE
Correctly align the `textLayer` content with horizontal/spread scrolling modes (issue 13605)

### DIFF
--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -15,6 +15,7 @@
 
 .textLayer {
   position: absolute;
+  text-align: initial;
   left: 0;
   top: 0;
   right: 0;


### PR DESCRIPTION
This is *very* similar to PR 12848, however for this `textLayer`-case it appears to only be an issue in documents with marked content.