### PR TITLE
Correctly align the `xfaLayer` content with horizontal scrolling/spread modes

### DIFF
--- a/web/xfa_layer_builder.css
+++ b/web/xfa_layer_builder.css
@@ -19,6 +19,7 @@
 
 .xfaLayer {
   position: absolute;
+  text-align: initial;
   top: 0;
   left: 0;
   z-index: 200;


### PR DESCRIPTION
This extends the approach in PRs #12848 and #13606 to also apply to the `xfaLayer`, since otherwise XFA forms will be similarly broken in most non-default scroll/spread modes.