### PR TITLE
Support corrupt documents with *empty* `Name`-entries (issue 13610)

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -1113,6 +1113,9 @@ class Lexer {
     }
     if (strBuf.length > 127) {
       warn(`Name token is longer than allowed by the spec: ${strBuf.length}`);
+    } else if (strBuf.length === 0) {
+      warn("Name token is empty.");
+      return Name.empty;
     }
     return Name.get(strBuf.join(""));
   }

--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -33,6 +33,12 @@ const Name = (function NameClosure() {
       return nameValue ? nameValue : (nameCache[name] = new Name(name));
     }
 
+    static get empty() {
+      // eslint-disable-next-line no-restricted-syntax
+      const emptyName = new Name({ empty: true });
+      return shadow(this, "empty", emptyName);
+    }
+
     static _clearCache() {
       nameCache = Object.create(null);
     }

--- a/test/pdfs/issue13610.pdf.link
+++ b/test/pdfs/issue13610.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/6694277/Unitfactuur_18707277_KORTELAND_PRINTEN.INSCANNEN.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1612,6 +1612,13 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "issue13610",
+       "file": "pdfs/issue13610.pdf",
+       "md5": "5b894c0b1b2279a245c23abd76648ca9",
+       "link": true,
+       "rounds": 1,
+       "type": "eq"
+    },
     {  "id": "simpletype3font-text",
        "file": "pdfs/simpletype3font.pdf",
        "md5": "b374c7543920840c61999e9e86939f99",

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -325,7 +325,7 @@ describe("evaluator", function () {
         expect(false).toEqual(true);
       } catch (reason) {
         expect(reason instanceof FormatError).toEqual(true);
-        expect(reason.message).toEqual("XObject must be referred to by name.");
+        expect(reason.message).toEqual("XObject should be a stream");
       }
     });
 


### PR DESCRIPTION
Apparently some really bad PDF software can create documents with *empty* `Name`-entries, which we thus need to somehow deal with.
While I don't know if this patch is necessarily the best solution, it should at least ensure that the *empty* `Name`-instance cannot accidentally match a proper `Name`-instance (and it doesn't require changes to a lot of existing code).[1]

---
[1] I briefly considered using a `Symbol` rather than an Object, but quickly decided against that since the former one [is not clonable](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types) and `Name`-instances may be sent to the API.