### PR TITLE
XFA - Get line height from the font

### DIFF
--- a/src/core/xfa/fonts.js
+++ b/src/core/xfa/fonts.js
@@ -154,4 +154,17 @@ class FontFinder {
   }
 }
 
-export { FontFinder };
+function selectFont(xfaFont, typeface) {
+  if (xfaFont.posture === "italic") {
+    if (xfaFont.weight === "bold") {
+      return typeface.bolditalic;
+    }
+    return typeface.italic;
+  } else if (xfaFont.weight === "bold") {
+    return typeface.bold;
+  }
+
+  return typeface.regular;
+}
+
+export { FontFinder, selectFont };

--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -70,12 +70,12 @@ import {
   createWrapper,
   fixDimensions,
   fixTextIndent,
-  getFonts,
   isPrintOnly,
   layoutClass,
   layoutText,
   measureToString,
   setAccess,
+  setFontFamily,
   setMinMaxDimensions,
   toStyle,
 } from "./html_utils.js";
@@ -2695,7 +2695,7 @@ class Font extends XFAObject {
       style.fontSize = fontSize;
     }
 
-    style.fontFamily = getFonts(this.typeface, this[$globalData].fontFinder);
+    setFontFamily(this, this[$globalData].fontFinder, style);
 
     if (this.underline !== 0) {
       style.textDecoration = "underline";

--- a/src/core/xfa/text.js
+++ b/src/core/xfa/text.js
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+import { selectFont } from "./fonts.js";
+
 const WIDTH_FACTOR = 1.2;
 const HEIGHT_FACTOR = 1.2;
 
@@ -30,18 +32,7 @@ class FontInfo {
       return;
     }
 
-    this.pdfFont = null;
-    if (xfaFont.posture === "italic") {
-      if (xfaFont.weight === "bold") {
-        this.pdfFont = typeface.bolditalic;
-      } else {
-        this.pdfFont = typeface.italic;
-      }
-    } else if (xfaFont.weigth === "bold") {
-      this.pdfFont = typeface.bold;
-    } else {
-      this.pdfFont = typeface.regular;
-    }
+    this.pdfFont = selectFont(xfaFont, typeface);
 
     if (!this.pdfFont) {
       [this.pdfFont, this.xfaFont] = this.defaultFont(fontFinder);

--- a/src/core/xfa/utils.js
+++ b/src/core/xfa/utils.js
@@ -24,6 +24,13 @@ const dimConverters = {
 };
 const measurementPattern = /([+-]?[0-9]+\.?[0-9]*)(.*)/;
 
+function stripQuotes(str) {
+  if (str.startsWith("'") || str.startsWith('"')) {
+    return str.slice(1, str.length - 1);
+  }
+  return str;
+}
+
 function getInteger({ data, defaultValue, validate }) {
   if (!data) {
     return defaultValue;
@@ -206,4 +213,5 @@ export {
   getRelevant,
   getStringOption,
   HTMLResult,
+  stripQuotes,
 };

--- a/src/core/xfa/xhtml.js
+++ b/src/core/xfa/xhtml.js
@@ -28,7 +28,7 @@ import {
   XmlObject,
 } from "./xfa_object.js";
 import { $buildXFAObject, NamespaceIds } from "./namespaces.js";
-import { fixTextIndent, getFonts, measureToString } from "./html_utils.js";
+import { fixTextIndent, measureToString, setFontFamily } from "./html_utils.js";
 import { getMeasurement, HTMLResult } from "./utils.js";
 
 const XHTML_NS_ID = NamespaceIds.xhtml.id;
@@ -92,7 +92,7 @@ const StyleMapping = new Map([
   ["margin-right", value => measureToString(getMeasurement(value))],
   ["margin-top", value => measureToString(getMeasurement(value))],
   ["text-indent", value => measureToString(getMeasurement(value))],
-  ["font-family", (value, fontFinder) => getFonts(value, fontFinder)],
+  ["font-family", value => value],
 ]);
 
 const spacesRegExp = /\s+/g;
@@ -126,6 +126,18 @@ function mapStyle(styleStr, fontFinder) {
       style[key.replaceAll(/-([a-zA-Z])/g, (_, x) => x.toUpperCase())] =
         newValue;
     }
+  }
+
+  if (style.fontFamily) {
+    setFontFamily(
+      {
+        typeface: style.fontFamily,
+        weight: style.fontWeight || "normal",
+        posture: style.fontStyle || "normal",
+      },
+      fontFinder,
+      style
+    );
   }
 
   fixTextIndent(style);

--- a/test/pdfs/xfa_bug1717681.pdf.link
+++ b/test/pdfs/xfa_bug1717681.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=9228400

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -930,6 +930,14 @@
        "link": true,
        "type": "load"
     },
+    {  "id": "xfa_bug1717681",
+       "file": "pdfs/xfa_bug1717681.pdf",
+       "md5": "435b1eae7e017b1a932fe204d1ba8be5",
+       "link": true,
+       "rounds": 1,
+       "enableXfa": true,
+       "type": "eq"
+    },
     {  "id": "xfa_bug1716380",
        "file": "pdfs/xfa_bug1716380.pdf",
        "md5": "1351f816f0509fe750ca61ef2bd40872",

--- a/web/xfa_layer_builder.css
+++ b/web/xfa_layer_builder.css
@@ -24,6 +24,7 @@
   left: 0;
   z-index: 200;
   transform-origin: 0 0;
+  line-height: 1.2;
 }
 
 .xfaLayer * {
@@ -53,10 +54,6 @@
 
 .xfaRich li {
   margin-left: 3em;
-}
-
-.xfaLayer p {
-  margin-bottom: -1px;
 }
 
 .xfaFont {


### PR DESCRIPTION
  - when the CSS line-height property is set to 'normal' then the value depends of the user agent. So use a line height based on the font itself and if for any reasons this value is not available use 1.2 as default.
  - it's a partial fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1717681.