### PR TITLE
Check that TrueType (3, 0) cmap tables, for symbolic fonts, are sorted correctly (issue 13626)

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -1540,7 +1540,14 @@ class Font {
       };
     }
 
-    function sanitizeMetrics(file, header, metrics, numGlyphs, dupFirstEntry) {
+    function sanitizeMetrics(
+      file,
+      header,
+      metrics,
+      headTable,
+      numGlyphs,
+      dupFirstEntry
+    ) {
       if (!header) {
         if (metrics) {
           metrics.data = null;
@@ -1559,19 +1566,24 @@ class Font {
       file.pos += 2; // max_extent
       file.pos += 2; // caret_slope_rise
       file.pos += 2; // caret_slope_run
-      file.pos += 2; // caret_offset
+      const caretOffset = file.getUint16();
       file.pos += 8; // reserved
       file.pos += 2; // format
       let numOfMetrics = file.getUint16();
 
+      if (caretOffset !== 0) {
+        const macStyle = int16(headTable.data[44], headTable.data[45]);
+        if (!(macStyle & 2)) {
+          // Suppress OTS warnings about the `caretOffset` in the hhea-table.
+          header.data[22] = 0;
+          header.data[23] = 0;
+        }
+      }
+
       if (numOfMetrics > numGlyphs) {
         info(
-          "The numOfMetrics (" +
-            numOfMetrics +
-            ") should not be " +
-            "greater than the numGlyphs (" +
-            numGlyphs +
-            ")"
+          `The numOfMetrics (${numOfMetrics}) should not be ` +
+            `greater than the numGlyphs (${numGlyphs}).`
         );
         // Reduce numOfMetrics if it is greater than numGlyphs
         numOfMetrics = numGlyphs;
@@ -2457,6 +2469,7 @@ class Font {
       font,
       tables.hhea,
       tables.hmtx,
+      tables.head,
       numGlyphsOut,
       dupFirstEntry
     );

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -1372,7 +1372,18 @@ class Font {
           }
         } else if (isSymbolicFont && platformId === 3 && encodingId === 0) {
           useTable = true;
-          canBreak = true;
+
+          let correctlySorted = true;
+          if (i < numTables - 1) {
+            const nextBytes = file.peekBytes(2),
+              nextPlatformId = int16(nextBytes[0], nextBytes[1]);
+            if (nextPlatformId < platformId) {
+              correctlySorted = false;
+            }
+          }
+          if (correctlySorted) {
+            canBreak = true;
+          }
         }
 
         if (useTable) {

--- a/test/pdfs/issue13626.pdf.link
+++ b/test/pdfs/issue13626.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/6715502/test.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1635,6 +1635,13 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "issue13626",
+       "file": "pdfs/issue13626.pdf",
+       "md5": "68bc1c2459d56e8c33f5a12a88c9df7d",
+       "link": true,
+       "rounds": 1,
+       "type": "eq"
+    },
     {  "id": "simpletype3font-text",
        "file": "pdfs/simpletype3font.pdf",
        "md5": "b374c7543920840c61999e9e86939f99",


### PR DESCRIPTION
 - According to a comment in `readCmapTable`, we're assuming that the cmap tables (when more than one exist) are sorted in ascending order. If that's not the case, keep checking the following cmap tables in order to fix the referenced issue.

   Fixes #13626

 - Suppress OTS warnings about the caretOffset in the hhea-table

    - https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6hhea.html
    - https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6head.html