### PR TITLE
A couple of smaller JSDocs tweaks in `src/display/api.js`

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -515,6 +515,12 @@ function _fetchDocument(worker, source, pdfDataRangeTransport, docId) {
 }
 
 /**
+ * @typedef {Object} OnProgressParameters
+ * @property {number} loaded - Currently loaded number of bytes.
+ * @property {number} total - Total number of bytes in the PDF file.
+ */
+
+/**
  * The loading task controls the operations required to load a PDF document
  * (such as network requests) and provides a way to listen for completion,
  * after which individual pages can be rendered.
@@ -528,8 +534,7 @@ function _fetchDocument(worker, source, pdfDataRangeTransport, docId) {
  *   {@link PasswordResponses}).
  * @property {function} [onProgress] - Callback to be able to monitor the
  *   loading progress of the PDF file (necessary to implement e.g. a loading
- *   bar). The callback receives an {Object} with the properties `loaded`
- *   ({number}) and `total` ({number}) that indicate how many bytes are loaded.
+ *   bar). The callback receives an {@link OnProgressParameters} argument.
  * @property {function} [onUnsupportedFeature] - Callback for when an
  *   unsupported feature is used in the PDF document. The callback receives an
  *   {@link UNSUPPORTED_FEATURES} argument.
@@ -581,9 +586,8 @@ const PDFDocumentLoadingTask = (function PDFDocumentLoadingTaskClosure() {
 
       /**
        * Callback to be able to monitor the loading progress of the PDF file
-       * (necessary to implement e.g. a loading bar). The callback receives
-       * an {Object} with the properties `loaded` ({number}) and `total`
-       * ({number}) that indicate how many bytes are loaded.
+       * (necessary to implement e.g. a loading bar).
+       * The callback receives an {@link OnProgressParameters} argument.
        * @type {function}
        */
       this.onProgress = null;

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -115,6 +115,12 @@ function setPDFNetworkStreamFactory(pdfNetworkStreamFactory) {
  */
 
 /**
+ * @typedef {Object} RefProxy
+ * @property {number} num
+ * @property {number} gen
+ */
+
+/**
  * Document initialization / loading parameters object.
  *
  * @typedef {Object} DocumentInitParameters
@@ -762,12 +768,6 @@ class PDFDocumentProxy {
   }
 
   /**
-   * @typedef {Object} RefProxy
-   * @property {number} num
-   * @property {number} gen
-   */
-
-  /**
    * @param {RefProxy} ref - The page reference.
    * @returns {Promise<number>} A promise that is resolved with the page index,
    *   starting from zero, that is associated with the reference.
@@ -1231,8 +1231,7 @@ class PDFPageProxy {
   }
 
   /**
-   * @type {Object} The reference that points to this page. It has `num` and
-   *   `gen` properties.
+   * @type {RefProxy | null} The reference that points to this page.
    */
   get ref() {
     return this._pageInfo.ref;


### PR DESCRIPTION
 - Use the `RefProxy` typedef in more JSDoc comments in `src/display/api.js`

 - Add a `OnProgressParameters` typedef to reduce (some) duplication in `src/display/api.js`