### PR TITLE
XFA - Replace deprecated break element (bug 1718053)

### DIFF
--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -4222,6 +4222,46 @@ class Subform extends XFAObject {
   }
 
   [$toHTML](availableSpace) {
+    if (this.break) {
+      // break element is deprecated so plug it on one of its replacement
+      // breakBefore or breakAfter.
+      if (this.break.after !== "auto" || this.break.afterTarget !== "") {
+        const node = new BreakAfter({
+          targetType: this.break.after,
+          target: this.break.afterTarget,
+          startNew: this.break.startNew.toString(),
+        });
+        node[$globalData] = this[$globalData];
+        this[$appendChild](node);
+        this.breakAfter.push(node);
+      }
+
+      if (this.break.before !== "auto" || this.break.beforeTarget !== "") {
+        const node = new BreakBefore({
+          targetType: this.break.before,
+          target: this.break.beforeTarget,
+          startNew: this.break.startNew.toString(),
+        });
+        node[$globalData] = this[$globalData];
+        this[$appendChild](node);
+        this.breakBefore.push(node);
+      }
+
+      if (this.break.overflowTarget !== "") {
+        const node = new Overflow({
+          target: this.break.overflowTarget,
+          leader: this.break.overflowLeader,
+          trailer: this.break.overflowTrailer,
+        });
+        node[$globalData] = this[$globalData];
+        this[$appendChild](node);
+        this.overflow.push(node);
+      }
+
+      this[$removeChild](this.break);
+      this.break = null;
+    }
+
     if (this.presence === "hidden" || this.presence === "inactive") {
       return HTMLResult.EMPTY;
     }

--- a/test/pdfs/xfa_bug1718053.pdf.link
+++ b/test/pdfs/xfa_bug1718053.pdf.link
@@ -1,0 +1,1 @@
+https://bug1718053.bmoattachments.org/attachment.cgi?id=9228759

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -938,6 +938,14 @@
        "lastPage": 2,
        "type": "eq"
     },
+    {  "id": "xfa_bug1718053",
+       "file": "pdfs/xfa_bug1718053.pdf",
+       "md5": "252d728d2c456dcb81699342a71c42ea",
+       "link": true,
+       "rounds": 1,
+       "enableXfa": true,
+       "type": "eq"
+    },
     {  "id": "xfa_bug1717681",
        "file": "pdfs/xfa_bug1717681.pdf",
        "md5": "435b1eae7e017b1a932fe204d1ba8be5",


### PR DESCRIPTION
  - the break element has been deprecated in XFA 2.4 but some old documents can use it, so replace it with one (or more) of its possible substitutions:
    - breakBefore;
    - breakAfter;
    - overflow.