### PR TITLE
XFA - Don't use system font when a font is not embeded but there is a substitution

### DIFF
--- a/src/core/xfa/html_utils.js
+++ b/src/core/xfa/html_utils.js
@@ -481,7 +481,7 @@ function setFontFamily(xfaFont, fontFinder, style) {
   if (typeface) {
     const { fontFamily } = typeface.regular.cssFontInfo;
     if (fontFamily !== name) {
-      style.fontFamily += `,"${fontFamily}"`;
+      style.fontFamily = `"${fontFamily}"`;
     }
     if (style.lineHeight) {
       // Already something so don't overwrite.


### PR DESCRIPTION
  - always use a font coming from pdf.js when there is one: this way we don't use a system font which could looks wrong.