### PR TITLE
Enable the ESLint `operator-assignment` rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -188,6 +188,7 @@
       },
     ],
     "no-unneeded-ternary": "error",
+    "operator-assignment": "error",
     "prefer-exponentiation-operator": "error",
     "spaced-comment": ["error", "always", {
       "block": {

--- a/external/cmapscompress/compress.js
+++ b/external/cmapscompress/compress.js
@@ -204,7 +204,7 @@ function parseCMap(binaryData) {
         bufferSize = 0;
       while (s.length < lengthInChars) {
         while (bufferSize < 4 && stack.length > 0) {
-          buffer = (stack.pop() << bufferSize) | buffer;
+          buffer |= stack.pop() << bufferSize;
           bufferSize += 7;
         }
         s = toHexDigit(buffer & 15) + s;
@@ -375,7 +375,7 @@ function writeNumber(n) {
     let i = n.length;
     while (i > 0) {
       --i;
-      buffer = (fromHexDigit(n[i]) << bufferSize) | buffer;
+      buffer |= fromHexDigit(n[i]) << bufferSize;
       bufferSize += 4;
       if (bufferSize >= 7) {
         s = writeByte((buffer & 0x7f) | (s.length > 0 ? 0x80 : 0)) + s;

--- a/external/cmapscompress/compress.js
+++ b/external/cmapscompress/compress.js
@@ -409,7 +409,7 @@ function writeSigned(n) {
       const d = fromHexDigit(n[i]);
       c = (c << 4) | (neg ? d ^ 15 : d);
       t += toHexDigit(c >> 3);
-      c = c & 7;
+      c &= 7;
     }
     t += toHexDigit((c << 1) | (neg ? 1 : 0));
     return writeNumber(t);

--- a/src/core/ascii_85_stream.js
+++ b/src/core/ascii_85_stream.js
@@ -21,7 +21,7 @@ class Ascii85Stream extends DecodeStream {
     // Most streams increase in size when decoded, but Ascii85 streams
     // typically shrink by ~20%.
     if (maybeLength) {
-      maybeLength = 0.8 * maybeLength;
+      maybeLength *= 0.8;
     }
     super(maybeLength);
 

--- a/src/core/ascii_hex_stream.js
+++ b/src/core/ascii_hex_stream.js
@@ -20,7 +20,7 @@ class AsciiHexStream extends DecodeStream {
     // Most streams increase in size when decoded, but AsciiHex streams shrink
     // by 50%.
     if (maybeLength) {
-      maybeLength = 0.5 * maybeLength;
+      maybeLength *= 0.5;
     }
     super(maybeLength);
 

--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -936,7 +936,7 @@ const CFFParser = (function CFFParserClosure() {
         }
         raw = bytes.subarray(dataStart, dataEnd);
       }
-      format = format & 0x7f;
+      format &= 0x7f;
       return new CFFEncoding(predefined, format, encoding, raw);
     }
 
@@ -1552,7 +1552,7 @@ class CFFCompiler {
     if (value >= -107 && value <= 107) {
       code = [value + 139];
     } else if (value >= 108 && value <= 1131) {
-      value = value - 108;
+      value -= 108;
       code = [(value >> 8) + 247, value & 0xff];
     } else if (value >= -1131 && value <= -108) {
       value = -value - 108;

--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -534,7 +534,7 @@ const BinaryCMapReader = (function BinaryCMapReaderClosure() {
         bufferSize = 0;
       while (i >= 0) {
         while (bufferSize < 8 && stack.length > 0) {
-          buffer = (stack[--sp] << bufferSize) | buffer;
+          buffer |= stack[--sp] << bufferSize;
           bufferSize += 7;
         }
         num[i] = buffer & 255;

--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -213,7 +213,7 @@ class Word64 {
       this.low = 0;
     } else {
       this.high = (this.high << places) | (this.low >>> (32 - places));
-      this.low = this.low << places;
+      this.low <<= places;
     }
   }
 
@@ -1165,7 +1165,7 @@ class AES128Cipher extends AESBaseCipher {
       t3 = s[t3];
       t4 = s[t4];
       // Rcon
-      t1 = t1 ^ rcon[i];
+      t1 ^= rcon[i];
       for (let n = 0; n < 4; ++n) {
         result[j] = t1 ^= result[j - 16];
         j++;
@@ -1218,7 +1218,7 @@ class AES256Cipher extends AESBaseCipher {
         t3 = s[t3];
         t4 = s[t4];
         // Rcon
-        t1 = t1 ^ r;
+        t1 ^= r;
         if ((r <<= 1) >= 256) {
           r = (r ^ 0x1b) & 0xff;
         }

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -216,7 +216,7 @@ class Page {
     if (rotate % 90 !== 0) {
       rotate = 0;
     } else if (rotate >= 360) {
-      rotate = rotate % 360;
+      rotate %= 360;
     } else if (rotate < 0) {
       // The spec doesn't cover negatives. Assume it's counterclockwise
       // rotation. The following is the other implementation of modulo.

--- a/src/core/glyf.js
+++ b/src/core/glyf.js
@@ -286,7 +286,7 @@ class SimpleGlyph {
       flags.push(flag);
       if (flag & REPEAT_FLAG) {
         const count = glyf.getUint8(++pos);
-        flag = flag ^ REPEAT_FLAG;
+        flag ^= REPEAT_FLAG;
         for (let m = 0; m < count; m++) {
           flags.push(flag);
         }
@@ -412,16 +412,15 @@ class SimpleGlyph {
         const x = contour.xCoordinates[i];
         let delta = x - lastX;
         if (delta === 0) {
-          flag = flag | X_IS_SAME_OR_POSITIVE_X_SHORT_VECTOR;
+          flag |= X_IS_SAME_OR_POSITIVE_X_SHORT_VECTOR;
           xCoordinates.push(0);
         } else {
           const abs = Math.abs(delta);
           if (abs <= 255) {
-            flag =
-              flag |
-              (delta >= 0
+            flag |=
+              delta >= 0
                 ? X_SHORT_VECTOR | X_IS_SAME_OR_POSITIVE_X_SHORT_VECTOR
-                : X_SHORT_VECTOR);
+                : X_SHORT_VECTOR;
             xCoordinates.push(abs);
           } else {
             xCoordinates.push(delta);
@@ -432,16 +431,15 @@ class SimpleGlyph {
         const y = contour.yCoordinates[i];
         delta = y - lastY;
         if (delta === 0) {
-          flag = flag | Y_IS_SAME_OR_POSITIVE_Y_SHORT_VECTOR;
+          flag |= Y_IS_SAME_OR_POSITIVE_Y_SHORT_VECTOR;
           yCoordinates.push(0);
         } else {
           const abs = Math.abs(delta);
           if (abs <= 255) {
-            flag =
-              flag |
-              (delta >= 0
+            flag |=
+              delta >= 0
                 ? Y_SHORT_VECTOR | Y_IS_SAME_OR_POSITIVE_Y_SHORT_VECTOR
-                : Y_SHORT_VECTOR);
+                : Y_SHORT_VECTOR;
             yCoordinates.push(abs);
           } else {
             yCoordinates.push(delta);
@@ -550,7 +548,7 @@ class CompositeGlyph {
         argument2 = glyf.getUint16(pos + 2);
       }
       pos += 4;
-      flags = flags ^ ARG_1_AND_2_ARE_WORDS;
+      flags ^= ARG_1_AND_2_ARE_WORDS;
     } else {
       argument1 = glyf.getUint8(pos);
       argument2 = glyf.getUint8(pos + 1);
@@ -652,7 +650,7 @@ class CompositeGlyph {
           this.argument2 <= 127
         )
       ) {
-        this.flags = this.flags | ARG_1_AND_2_ARE_WORDS;
+        this.flags |= ARG_1_AND_2_ARE_WORDS;
       }
     } else {
       if (
@@ -663,7 +661,7 @@ class CompositeGlyph {
           this.argument2 <= 255
         )
       ) {
-        this.flags = this.flags | ARG_1_AND_2_ARE_WORDS;
+        this.flags |= ARG_1_AND_2_ARE_WORDS;
       }
     }
 

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -471,7 +471,7 @@ class PDFImage {
           value = max;
         }
         output[i] = value;
-        buf = buf & ((1 << remainingBits) - 1);
+        buf &= (1 << remainingBits) - 1;
         bits = remainingBits;
       }
     }

--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -1088,7 +1088,7 @@ function decodeHalftoneRegion(
       bit = 0;
       patternIndex = 0;
       for (j = bitsPerValue - 1; j >= 0; j--) {
-        bit = grayScaleBitPlanes[j][mg][ng] ^ bit; // Gray decoding
+        bit ^= grayScaleBitPlanes[j][mg][ng]; // Gray decoding
         patternIndex |= bit << j;
       }
       patternBitmap = patterns[patternIndex];

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -2241,7 +2241,7 @@ class Transform {
 class IrreversibleTransform extends Transform {
   filter(x, offset, length) {
     const len = length >> 1;
-    offset = offset | 0;
+    offset |= 0;
     let j, n, current, next;
 
     const alpha = -1.586134342059924;
@@ -2327,7 +2327,7 @@ class IrreversibleTransform extends Transform {
 class ReversibleTransform extends Transform {
   filter(x, offset, length) {
     const len = length >> 1;
-    offset = offset | 0;
+    offset |= 0;
     let j, n;
 
     for (j = offset, n = len + 1; n--; j += 2) {

--- a/src/core/type1_parser.js
+++ b/src/core/type1_parser.js
@@ -312,7 +312,7 @@ const Type1CharString = (function Type1CharStringClosure() {
           }
           continue;
         } else if (value <= 246) {
-          value = value - 139;
+          value -= 139;
         } else if (value <= 250) {
           value = (value - 247) * 256 + encoded[++i] + 108;
         } else if (value <= 254) {

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -202,8 +202,8 @@ class AnnotationElement {
         // Underline styles only have a bottom border, so we do not need
         // to adjust for all borders. This yields a similar result as
         // Adobe Acrobat/Reader.
-        width = width - 2 * data.borderStyle.width;
-        height = height - 2 * data.borderStyle.width;
+        width -= 2 * data.borderStyle.width;
+        height -= 2 * data.borderStyle.width;
       }
 
       const horizontalRadius = data.borderStyle.horizontalCornerRadius;

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -145,10 +145,10 @@ function addContextCurrentTransform(ctx) {
 
   ctx.scale = function ctxScale(x, y) {
     const m = this._transformMatrix;
-    m[0] = m[0] * x;
-    m[1] = m[1] * x;
-    m[2] = m[2] * y;
-    m[3] = m[3] * y;
+    m[0] *= x;
+    m[1] *= x;
+    m[2] *= y;
+    m[3] *= y;
 
     this._originalScale(x, y);
   };

--- a/test/integration/find_spec.js
+++ b/test/integration/find_spec.js
@@ -54,10 +54,10 @@ describe("find bar", () => {
           const firstA = await highlights[0].boundingBox();
           const secondA = await highlights[1].boundingBox();
           // Subtract the page offset from the text bounding boxes;
-          firstA.x = firstA.x - pageBox.x;
-          firstA.y = firstA.y - pageBox.y;
-          secondA.x = secondA.x - pageBox.x;
-          secondA.y = secondA.y - pageBox.y;
+          firstA.x -= pageBox.x;
+          firstA.y -= pageBox.y;
+          secondA.x -= pageBox.x;
+          secondA.y -= pageBox.y;
           // They should be on the same line.
           expect(firstA.y).withContext(`In ${browserName}`).toEqual(secondA.y);
           const fontSize = 26.66; // From the PDF.

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -220,7 +220,7 @@ var StepperManager = (function StepperManagerClosure() {
     },
     selectStepper: function selectStepper(pageIndex, selectPanel) {
       let i;
-      pageIndex = pageIndex | 0;
+      pageIndex |= 0;
       if (selectPanel) {
         this.manager.selectPanel(this);
       }


### PR DESCRIPTION
 - Enable the ESLint `operator-assignment` rule

   This patch was generated automatically, using the `gulp lint --fix` command.

   Please find additional details about the ESLint rule at https://eslint.org/docs/rules/operator-assignment

 - Fix the remaining ESLint `operator-assignment` errors