### PR TITLE
[test/driver.js] Ensure that Image `src` is set *after* the callbacks in `resolveImages`

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -97,7 +97,6 @@ async function resolveImages(node, silentErrors = false) {
 
   const loadedPromises = [];
   for (let i = 0, ii = data.length; i < ii; i++) {
-    images[i].src = data[i];
     loadedPromises.push(
       new Promise(function (resolveImage, rejectImage) {
         images[i].onload = resolveImage;
@@ -108,6 +107,7 @@ async function resolveImages(node, silentErrors = false) {
             rejectImage(new Error("Error loading image " + e));
           }
         };
+        images[i].src = data[i];
       })
     );
   }


### PR DESCRIPTION
*While I cannot guarantee that this will fix the recent intermittents, this patch really shouldn't hurt.*

By setting the Image `src` first, there's a small possibility that the Image is loaded *before* we've had a change to attach the `onload`/`onerror` callbacks which may cause the Promise to remain in a pending state.
Note that prior to PR #13641 we didn't correctly await all image resources to actually load, which could explain the very recent intermittent test-failures.