### PR TITLE
XFA - remove unnecessary check in the `handleBreak` function (PR 13687 follow-up)

### DIFF
--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -176,7 +176,7 @@ function handleBreak(node) {
     if (!target) {
       return false;
     }
-    target = target ? target[0] : target;
+    target = target[0];
   }
 
   const { currentPageArea, currentContentArea } = root[$extra];


### PR DESCRIPTION
With the changes in PR #13687 we're now checking if `target` is defined *twice* in a row, which shouldn't be necessary :-)

(I noticed this when glancing at the unofficial LGTM results; maybe we should re-evalute the decision to not integrate that into the CI.)