### PR TITLE
Fix JPX tag tree decode (issue 11957)

### DIFF
--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -1203,6 +1203,11 @@ function parseTilePackets(context, data, offset, dataLength) {
           zeroBitPlanesTree = new TagTree(width, height);
           precinct.inclusionTree = inclusionTree;
           precinct.zeroBitPlanesTree = zeroBitPlanesTree;
+          for (let l = 0; l < layerNumber; l++) {
+            if (readBits(1) !== 0) {
+              throw new JpxError("Invalid tag tree");
+            }
+          }
         }
 
         if (inclusionTree.reset(codeblockColumn, codeblockRow, layerNumber)) {

--- a/test/pdfs/issue12579.pdf.link
+++ b/test/pdfs/issue12579.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/5492304/3.2020.1.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -3987,6 +3987,15 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue12579",
+       "file": "pdfs/issue12579.pdf",
+       "md5": "a56f6c7b6ebe0008bd6215b9a4dc3cca",
+       "link": true,
+       "firstPage": 3,
+       "lastPage": 3,
+       "rounds": 1,
+       "type": "eq"
+    },
     {  "id": "issue11330",
        "file": "pdfs/issue11330.pdf",
        "md5": "03a8a53d4b0dc825e08554f5c0178308",


### PR DESCRIPTION
fix jpx tag tree decode
error message like:
`Warning: JPX: Trying to recover from: JPX error: Out of packets`

the relevant section of the JPEG 2000 specification:
[J2K_Guide.pdf](https://gwg.nga.mil/ntb/baseline/docs/bwcj2k/J2K_Guide_WD1.pdf)  Page 79  (B.10.8)

Since code-block 0,0 is included in this layer for the first time, we need to code the number of zero bit-planes that were skipped.  For this, we use the zero bit-planes tag tree, which is a separate tag tree from the inclusion information tag tree, with its own state.  In this tag tree, we have not coded any partial information yet, so we start at the root and code all nodes on the branch to the leaf for code-block 0,0.  The root q0(0,0) is 3, but its initial state was 0, so we need to increment by 3; i.e. we code three 0s followed by a 1 to lock in the value.  The intermediate node q1(0,0) is also 3, so there is no increment to its parent’s value, and we code the 1 to lock in its value.  The leaf node q2(0,0) is also 3, so again we simply code a 1.  Thus, the code word is 000111.


Fixes 
https://github.com/mozilla/pdf.js/issues/11957
https://github.com/mozilla/pdf.js/issues/12579
https://github.com/mozilla/pdf.js/issues/13487