### PR TITLE
Add a new "botbrowsertest" gulp-task, to allow running only the browser tests on the bots

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1608,6 +1608,21 @@ gulp.task(
 );
 
 gulp.task(
+  "botbrowsertest",
+  gulp.series(
+    setTestEnv,
+    "generic",
+    "components",
+    function runBotBrowserTest() {
+      return streamqueue(
+        { objectMode: true },
+        createTestSource("browser (no reftest)", true)
+      );
+    }
+  )
+);
+
+gulp.task(
   "unittest",
   gulp.series(setTestEnv, "generic", function runUnitTest() {
     return createTestSource("unit");


### PR DESCRIPTION
Currently it's possible to run e.g. `gulp unittest`, `gulp fonttest`, and `gulp integrationtest` *separately* on the bots; see https://github.com/mozilla/botio-files-pdfjs
However, it's not possible to run *only* the `gulp browsertest` command on the bots without also running the full test-suite. In some cases, e.g. if the "browsertest" times out, having a way to only re-run those would thus save some time and resources.

If/when this patch lands, I'll follow-up with a patch adding a new `on_cmd_browsertest.js` file to the https://github.com/mozilla/botio-files-pdfjs repository.