### PR TITLE
Ensure that the field value, for checkboxes, refers to an existing appearance state (bug 1720411)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -2075,6 +2075,11 @@ class ButtonWidgetAnnotation extends WidgetAnnotation {
       // The /Off appearance is optional.
       exportValues.push("Off");
     }
+    // Don't use a "V" entry pointing to a non-existent appearance state,
+    // see e.g. bug1720411.pdf where it's an *empty* Name-instance.
+    if (!exportValues.includes(this.data.fieldValue)) {
+      this.data.fieldValue = null;
+    }
     if (exportValues.length !== 2) {
       return;
     }

--- a/test/pdfs/bug1720411.pdf.link
+++ b/test/pdfs/bug1720411.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=9231160

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -972,6 +972,14 @@
          }
        }
     },
+    {  "id": "bug1720411",
+       "file": "pdfs/bug1720411.pdf",
+       "md5": "a3a3616d89d475b000373025fbd24735",
+       "rounds": 1,
+       "link": true,
+       "type": "eq",
+       "forms": true
+    },
     {  "id": "xfa_bug1718740",
        "file": "pdfs/xfa_bug1718740.pdf",
        "md5": "fab4277f2c70fd1edb35f597f5fe6819",

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -2192,8 +2192,8 @@ describe("annotation", function () {
     });
 
     it("should handle checkboxes with export value", async function () {
-      buttonWidgetDict.set("V", Name.get("1"));
-      buttonWidgetDict.set("DV", Name.get("2"));
+      buttonWidgetDict.set("V", Name.get("Checked"));
+      buttonWidgetDict.set("DV", Name.get("Off"));
 
       const appearanceStatesDict = new Dict();
       const normalAppearanceDict = new Dict();
@@ -2216,15 +2216,15 @@ describe("annotation", function () {
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
       expect(data.checkBox).toEqual(true);
-      expect(data.fieldValue).toEqual("1");
-      expect(data.defaultFieldValue).toEqual("2");
+      expect(data.fieldValue).toEqual("Checked");
+      expect(data.defaultFieldValue).toEqual("Off");
       expect(data.radioButton).toEqual(false);
       expect(data.exportValue).toEqual("Checked");
     });
 
     it("should handle checkboxes without export value", async function () {
-      buttonWidgetDict.set("V", Name.get("1"));
-      buttonWidgetDict.set("DV", Name.get("2"));
+      buttonWidgetDict.set("V", Name.get("Checked"));
+      buttonWidgetDict.set("DV", Name.get("Off"));
 
       const buttonWidgetRef = Ref.get(124, 0);
       const xref = new XRefMock([
@@ -2239,14 +2239,14 @@ describe("annotation", function () {
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
       expect(data.checkBox).toEqual(true);
-      expect(data.fieldValue).toEqual("1");
-      expect(data.defaultFieldValue).toEqual("2");
+      expect(data.fieldValue).toEqual("Checked");
+      expect(data.defaultFieldValue).toEqual("Off");
       expect(data.radioButton).toEqual(false);
     });
 
     it("should handle checkboxes without /Off appearance", async function () {
-      buttonWidgetDict.set("V", Name.get("1"));
-      buttonWidgetDict.set("DV", Name.get("2"));
+      buttonWidgetDict.set("V", Name.get("Checked"));
+      buttonWidgetDict.set("DV", Name.get("Off"));
 
       const appearanceStatesDict = new Dict();
       const normalAppearanceDict = new Dict();
@@ -2268,8 +2268,8 @@ describe("annotation", function () {
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
       expect(data.checkBox).toEqual(true);
-      expect(data.fieldValue).toEqual("1");
-      expect(data.defaultFieldValue).toEqual("2");
+      expect(data.fieldValue).toEqual("Checked");
+      expect(data.defaultFieldValue).toEqual("Off");
       expect(data.radioButton).toEqual(false);
       expect(data.exportValue).toEqual("Checked");
     });


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1720411