### PR TITLE
Remove `<meta>` tag only necessary for IE-compatibility

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -27,9 +27,6 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!--#if GENERIC || CHROME-->
     <meta name="google" content="notranslate">
 <!--#endif-->
-<!--#if GENERIC-->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-<!--#endif-->
     <title>PDF.js viewer</title>
 
 <!--#if MOZCENTRAL-->


### PR DESCRIPTION
Given that Internet Explorer is, since some time now, no longer supported in the PDF.js library this `<meta>` tag can also be removed (added in PR #6374).