### PR TITLE
XFA - Checkboxes must be printed (bug 1720182)

### DIFF
--- a/src/display/xfa_layer.js
+++ b/src/display/xfa_layer.js
@@ -33,7 +33,7 @@ class XfaLayer {
           element.attributes.type === "radio" ||
           element.attributes.type === "checkbox"
         ) {
-          if (storedData.value === element.attributes.exportedValue) {
+          if (storedData.value === element.attributes.xfaOn) {
             html.setAttribute("checked", true);
           }
           if (intent === "print") {
@@ -82,6 +82,9 @@ class XfaLayer {
       attributes.name = `${attributes.name}-${intent}`;
     }
     for (const [key, value] of Object.entries(attributes)) {
+      // We don't need to add dataId in the html object but it can
+      // be useful to know its value when writing printing tests:
+      // in this case, don't skip dataId to have its value.
       if (value === null || value === undefined || key === "dataId") {
         continue;
       }

--- a/test/pdfs/xfa_bug1720182.pdf.link
+++ b/test/pdfs/xfa_bug1720182.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=9230780

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -952,6 +952,26 @@
        "enableXfa": true,
        "type": "eq"
     },
+    {  "id": "xfa_bug1720182",
+       "file": "pdfs/xfa_bug1720182.pdf",
+       "md5": "1351f816f0509fe750ca61ef2bd40872",
+       "link": true,
+       "rounds": 1,
+       "enableXfa": true,
+       "type": "eq",
+       "print": true,
+       "annotationStorage": {
+         "RadioButtonList2707": {
+           "value": "1"
+         },
+         "ComplainantFirstname2710": {
+           "value": "Foo"
+         },
+         "ComplainantLastname2711": {
+           "value": "Bar"
+         }
+       }
+    },
     {  "id": "xfa_bug1718740",
        "file": "pdfs/xfa_bug1718740.pdf",
        "md5": "fab4277f2c70fd1edb35f597f5fe6819",


### PR DESCRIPTION
  - to avoid future regressions, annotationStorage is passed to the xfa render in reftests.