### PR TITLE
Enable XFA by default in the development viewer

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1547,7 +1547,7 @@ const PDFViewerApplication = {
       // Note: `isPureXfa === true` implies that `enableXfa = true` was set.
       !pdfDocument.isPureXfa
     ) {
-      console.warn("Warning: XFA is not enabled");
+      console.warn("Warning: XFA support is not enabled");
       this.fallback(UNSUPPORTED_FEATURES.forms);
     } else if (
       (info.IsAcroFormPresent || info.IsXFAPresent) &&

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -194,7 +194,7 @@ const defaultOptions = {
   },
   enableXfa: {
     /** @type {boolean} */
-    value: false,
+    value: typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION"),
     kind: OptionKind.API + OptionKind.PREFERENCE,
   },
   fontExtraProperties: {


### PR DESCRIPTION
Given that https://bugzilla.mozilla.org/show_bug.cgi?id=1720402 has just landed, enabling XFA in the development viewer probably cannot hurt now.