### PR TITLE
XFA - Prevent breaking errors in `Binder`, when `searchNode` doesn't return data (issue 13756)

### DIFF
--- a/src/core/xfa/bind.js
+++ b/src/core/xfa/bind.js
@@ -198,34 +198,36 @@ class Binder {
         continue;
       }
 
-      const [node] = searchNode(
+      const nodes = searchNode(
         this.root,
         dataNode,
         ref,
         false /* = dotDotAllowed */,
         false /* = useCache */
       );
-      if (!node) {
+      if (!nodes) {
         warn(`XFA - Invalid reference: ${ref}.`);
         continue;
       }
+      const [node] = nodes;
 
       if (!node[$isDescendent](this.data)) {
         warn(`XFA - Invalid node: must be a data node.`);
         continue;
       }
 
-      const [targetNode] = searchNode(
+      const targetNodes = searchNode(
         this.root,
         formNode,
         target,
         false /* = dotDotAllowed */,
         false /* = useCache */
       );
-      if (!targetNode) {
+      if (!targetNodes) {
         warn(`XFA - Invalid target: ${target}.`);
         continue;
       }
+      const [targetNode] = targetNodes;
 
       if (!targetNode[$isDescendent](formNode)) {
         warn(`XFA - Invalid target: must be a property or subproperty.`);
@@ -337,34 +339,36 @@ class Binder {
           continue;
         }
 
-        const [labelNode] = searchNode(
+        const labelNodes = searchNode(
           this.root,
           node,
           labelRef,
           true /* = dotDotAllowed */,
           false /* = useCache */
         );
-        if (!labelNode) {
+        if (!labelNodes) {
           warn(`XFA - Invalid label: ${labelRef}.`);
           continue;
         }
+        const [labelNode] = labelNodes;
 
         if (!labelNode[$isDescendent](this.datasets)) {
           warn(`XFA - Invalid label: must be a datasets child.`);
           continue;
         }
 
-        const [valueNode] = searchNode(
+        const valueNodes = searchNode(
           this.root,
           node,
           valueRef,
           true /* = dotDotAllowed */,
           false /* = useCache */
         );
-        if (!valueNode) {
+        if (!valueNodes) {
           warn(`XFA - Invalid value: ${valueRef}.`);
           continue;
         }
+        const [valueNode] = valueNodes;
 
         if (!valueNode[$isDescendent](this.datasets)) {
           warn(`XFA - Invalid value: must be a datasets child.`);

--- a/test/pdfs/issue13756.pdf.link
+++ b/test/pdfs/issue13756.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/6842290/Attestation_d.occupation.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1347,6 +1347,14 @@
        "link": false,
        "type": "eq"
     },
+    {  "id": "issue13756",
+       "file": "pdfs/issue13756.pdf",
+       "md5": "67040c6df3b5039fcbc81bf63b7c7f98",
+       "link": true,
+       "rounds": 1,
+       "enableXfa": true,
+       "type": "eq"
+    },
     {  "id": "issue9262",
        "file": "pdfs/issue9262_reduced.pdf",
        "md5": "5347ce2d7b3866625c22e115fd90e0de",


### PR DESCRIPTION
As can be seen in the code (see below), the `searchNode` helper function will return `null` in some cases and all of its call-sites should protect against that before attempting to access the returned data.
While only one of these changes were necessary to fix the breaking errors in issue #13756, in order to prevent future bugs I've added similar defensive code throughout this file.

 - https://github.com/mozilla/pdf.js/blob/07955fa1d31df62fd668a15f58cd40b29a82bd63/src/core/xfa/som.js#L169
 - https://github.com/mozilla/pdf.js/blob/07955fa1d31df62fd668a15f58cd40b29a82bd63/src/core/xfa/som.js#L239
 - https://github.com/mozilla/pdf.js/blob/07955fa1d31df62fd668a15f58cd40b29a82bd63/src/core/xfa/som.js#L254