### PR TITLE
Hide a couple of LGTM warnings that we don't care about

### DIFF
--- a/src/core/file_spec.js
+++ b/src/core/file_spec.js
@@ -67,7 +67,7 @@ class FileSpec {
     if (!this._filename && this.root) {
       const filename = pickPlatformItem(this.root) || "unnamed";
       this._filename = stringToPDFString(filename)
-        .replace(/\\\\/g, "\\")
+        .replace(/\\\\/g, "\\") // lgtm [js/double-escaping]
         .replace(/\\\//g, "/")
         .replace(/\\/g, "/");
     }

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -192,7 +192,7 @@ function drawTriangle(data, context, p1, p2, p3, c1, c2, c3) {
       let k;
       if (y < y1) {
         k = 0;
-      } else if (y1 === y2) {
+      } else if (y1 === y2 /* lgtm [js/useless-comparison-test] */) {
         k = 1;
       } else {
         k = (y1 - y) / (y1 - y2);

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -779,7 +779,7 @@ class EventBus {
         this._off(eventName, listener);
       }
       if (external) {
-        (externalListeners ||= []).push(listener);
+        (externalListeners ||= new Set()).add(listener);
         continue;
       }
       listener.apply(null, args);


### PR DESCRIPTION
 - The `web/ui_utils.js` one is *definitely* a false positive, since we've got e.g. unit-tests that trigger this code-path (and so does the "viewer component" examples).

 - The `src/core/file_spec.js` one seem to be another false positive (at least to me, and we have similar regular expressions elsewhere in the code-base).

 - The `src/display/pattern_helper.js` one is technically correct, but given that we have very similiar code elsewhere in this file I figured that it cannot hurt to leave it as-is.

Note that since Prettier doesn't allow trailing comments on lines ending with a curly bracket, I unfortunately had to use a slightly ugly formatting for some of these LGTM comments.