### PR TITLE
XFA - Add a missing method to `XFAAttribute`, to prevent breaking errors (issue 13748)

### DIFF
--- a/src/core/xfa/xfa_object.js
+++ b/src/core/xfa/xfa_object.js
@@ -745,6 +745,10 @@ class XFAAttribute {
     return true;
   }
 
+  [$getDataValue]() {
+    return this[$content].trim();
+  }
+
   [$setValue](value) {
     value = value.value || "";
     this[$content] = value.toString();

--- a/test/pdfs/issue13748.pdf.link
+++ b/test/pdfs/issue13748.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/6849364/IFT-3R.7._v1-1E.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1347,6 +1347,15 @@
        "link": false,
        "type": "eq"
     },
+    {  "id": "issue13748",
+       "file": "pdfs/issue13748.pdf",
+       "md5": "de0e4dde2890b9ff145a3184831bae02",
+       "link": true,
+       "rounds": 1,
+       "lastPage": 1,
+       "enableXfa": true,
+       "type": "eq"
+    },
     {  "id": "issue13756",
        "file": "pdfs/issue13756.pdf",
        "md5": "67040c6df3b5039fcbc81bf63b7c7f98",


### PR DESCRIPTION
*This is yet another case where I've got no idea if the patch is correct, but it does at least fix a breaking error :-)*

Note how in the [`Binder._bindValue` method](https://github.com/mozilla/pdf.js/blob/683ce66a48cd54fa48e96e1925277c134859e76c/src/core/xfa/bind.js#L92-L93), we're assuming that if a `data`-value exists then it'll also be possible to actually access it. For the `XFAAttribute`-implementation however, the second method is missing and that's what causes the breaking errors in issue #13748.

Please note that another possible way of "fixing" the error wouldn't been to simply change the exists-check to return `false`, and I could see that being a preferred solution.
However, the reason for submitting the current patch is that we get *fewer* warnings about Nodes with mis-matched types this way.