### PR TITLE
XFA - Handle `startIndex` correctly in the `Template.$toHTML` method (issue 13751)

### DIFF
--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -5288,13 +5288,14 @@ class Template extends XFAObject {
           } else if (target instanceof ContentArea) {
             const index = contentAreas.findIndex(e => e === target);
             if (index !== -1) {
+              // In the next loop iteration `i` will be incremented, note the
+              // `continue` just below, hence we need to subtract one here.
               i = index - 1;
             } else {
               targetPageArea = target[$getParent]();
-              startIndex =
-                targetPageArea.contentArea.children.findIndex(
-                  e => e === target
-                ) - 1;
+              startIndex = targetPageArea.contentArea.children.findIndex(
+                e => e === target
+              );
             }
           }
           continue;

--- a/test/pdfs/issue13751.pdf.link
+++ b/test/pdfs/issue13751.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/6834770/Oswiadczenie_o_statusie_FATCA_i_CRS-1.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1356,6 +1356,15 @@
        "enableXfa": true,
        "type": "eq"
     },
+    {  "id": "issue13751",
+       "file": "pdfs/issue13751.pdf",
+       "md5": "b9960bfa99be3573d9c32a9d55e5b7da",
+       "link": true,
+       "rounds": 1,
+       "lastPage": 1,
+       "enableXfa": true,
+       "type": "eq"
+    },
     {  "id": "issue13756",
        "file": "pdfs/issue13756.pdf",
        "md5": "67040c6df3b5039fcbc81bf63b7c7f98",


### PR DESCRIPTION
*Please note:* The PDF document in issue #13751 is *dynamically* created (in e.g. Adobe Reader), with pages added when certain buttons are clicked, hence this patch simply fixes the breaking error and nothing more.

It looks like the current code contains a little bit too much copy-and-paste from the *similar* `index` branch above, since we cannot set the `startIndex` to a negative value. Note how it's being used to initialize the loop-variable, which is then used to lookup values in an Array and accessing the `-1`th element of an Array obviously makes no sense.