### PR TITLE
XFA - Remove namespace from nodes under xfa:data node

### DIFF
--- a/src/core/xfa/datasets.js
+++ b/src/core/xfa/datasets.js
@@ -15,6 +15,7 @@
 
 import {
   $appendChild,
+  $isNsAgnostic,
   $namespaceId,
   $nodeName,
   $onChild,
@@ -28,6 +29,10 @@ const DATASETS_NS_ID = NamespaceIds.datasets.id;
 class Data extends XmlObject {
   constructor(attributes) {
     super(DATASETS_NS_ID, "data", attributes);
+  }
+
+  [$isNsAgnostic]() {
+    return true;
   }
 }
 

--- a/src/core/xfa/parser.js
+++ b/src/core/xfa/parser.js
@@ -118,12 +118,12 @@ class XFAParser extends XMLParserBase {
     return [namespace, prefixes, attributeObj];
   }
 
-  _getNameAndPrefix(name) {
+  _getNameAndPrefix(name, nsAgnostic) {
     const i = name.indexOf(":");
     if (i === -1) {
       return [name, null];
     }
-    return [name.substring(i + 1), name.substring(0, i)];
+    return [name.substring(i + 1), nsAgnostic ? "" : name.substring(0, i)];
   }
 
   onBeginElement(tagName, attributes, isEmpty) {
@@ -131,7 +131,10 @@ class XFAParser extends XMLParserBase {
       attributes,
       tagName
     );
-    const [name, nsPrefix] = this._getNameAndPrefix(tagName);
+    const [name, nsPrefix] = this._getNameAndPrefix(
+      tagName,
+      this._builder.isNsAgnostic()
+    );
     const node = this._builder.build({
       nsPrefix,
       name,

--- a/src/core/xfa/xfa_object.js
+++ b/src/core/xfa/xfa_object.js
@@ -60,6 +60,7 @@ const $isCDATAXml = Symbol();
 const $isBindable = Symbol();
 const $isDataValue = Symbol();
 const $isDescendent = Symbol();
+const $isNsAgnostic = Symbol();
 const $isSplittable = Symbol();
 const $isThereMoreWidth = Symbol();
 const $isTransparent = Symbol();
@@ -158,6 +159,10 @@ class XFAObject {
       this.hasOwnProperty(child[$nodeName]) &&
       child[$namespaceId] === this[$namespaceId]
     );
+  }
+
+  [$isNsAgnostic]() {
+    return false;
   }
 
   [$acceptWhitespace]() {
@@ -1087,6 +1092,7 @@ export {
   $isCDATAXml,
   $isDataValue,
   $isDescendent,
+  $isNsAgnostic,
   $isSplittable,
   $isThereMoreWidth,
   $isTransparent,

--- a/test/pdfs/xfa_bug1721600.pdf.link
+++ b/test/pdfs/xfa_bug1721600.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=9232367

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -952,6 +952,15 @@
        "enableXfa": true,
        "type": "eq"
     },
+    {  "id": "xfa_bug1721600",
+       "file": "pdfs/xfa_bug1721600.pdf",
+       "md5": "5f514f476169eeb7254da380a8db495a",
+       "link": true,
+       "rounds": 1,
+       "lastPage": 1,
+       "enableXfa": true,
+       "type": "eq"
+    },
     {  "id": "xfa_bug1720182",
        "file": "pdfs/xfa_bug1720182.pdf",
        "md5": "1351f816f0509fe750ca61ef2bd40872",


### PR DESCRIPTION
  - in real life some xfa contains xml like \<xfa:data>\<xfa:Foo>\<xfa:Bar>...</xfa:data>
    since there are no Foo or Bar in the xfa namespace the JS representation are empty
    and that leads to errors.
  - so the idea is to make all nodes under xfa:data namespace agnostic which means
    that ns are removed from nodes in the parser but only for xfa:data descendants.