### PR TITLE
Include the `font`/`integration`/`unit`-test folders in the LGTM report

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,3 +1,9 @@
+path_classifiers:
+  test:
+    - exclude: test/font
+    - exclude: test/integration
+    - exclude: test/unit
+
 queries:
   # Already handled by the "no-unused-vars" ESLint rule.
   - exclude: js/unused-local-variable


### PR DESCRIPTION
By default all files/folders classified as test-code are excluded in the LGTM report, however I do believe that it makes sense to include at least the `font`/`integration`/`unit`-test folders.
It seems pretty obvious that you want to avoid *accidentally* introducing any simple logical errors in the tests (and not only in the main code), to ensure that e.g. the unit-tests actually test the desired thing.

Hopefully I've interpreted the information at https://lgtm.com/help/lgtm/customizing-file-classification correctly, however note that we may need to land this patch to actually see any difference in the results.