### PR TITLE
Remove some duplication in the `Dict.merge` method

### DIFF
--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -185,22 +185,8 @@ class Dict {
   }
 
   static merge({ xref, dictArray, mergeSubDicts = false }) {
-    const mergedDict = new Dict(xref);
-
-    if (!mergeSubDicts) {
-      for (const dict of dictArray) {
-        if (!(dict instanceof Dict)) {
-          continue;
-        }
-        for (const [key, value] of Object.entries(dict._map)) {
-          if (mergedDict._map[key] === undefined) {
-            mergedDict._map[key] = value;
-          }
-        }
-      }
-      return mergedDict.size > 0 ? mergedDict : Dict.empty;
-    }
-    const properties = new Map();
+    const mergedDict = new Dict(xref),
+      properties = new Map();
 
     for (const dict of dictArray) {
       if (!(dict instanceof Dict)) {
@@ -211,6 +197,8 @@ class Dict {
         if (property === undefined) {
           property = [];
           properties.set(key, property);
+        } else if (!mergeSubDicts) {
+          continue; // Ignore additional entries for a "shallow" merge.
         }
         property.push(value);
       }


### PR DESCRIPTION
Currently the `!mergeSubDicts` code-path is essentially just duplicated code, which we can easily avoid by simply moving that check. (This may lead to ever so slightly more parsing for this case, but the difference ought to be negligible in practice.)