### PR TITLE
Include most of the `test`-folder in the LGTM report (PR 13772 follow-up)

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,8 +1,7 @@
 path_classifiers:
   test:
-    - exclude: test/font
-    - exclude: test/integration
-    - exclude: test/unit
+    - exclude: test
+    - test/resources
 
 queries:
   # Already handled by the "no-unused-vars" ESLint rule.


### PR DESCRIPTION
Given that PR #13772 seem to have worked as intended, it probably cannot hurt to enable the LGTM report for *most* of the remaining code in the `test`-folder. (The one remaining exception is code which originated *outside* of the PDF.js project.)

*Please note:* We'll need to land this patch to actually see any difference in the LGTM results.