### PR TITLE
XFA - SVG elements mustn't get any pointer events (bug 1721589)

### DIFF
--- a/web/xfa_layer_builder.css
+++ b/web/xfa_layer_builder.css
@@ -55,6 +55,14 @@
   pointer-events: none;
 }
 
+.xfaLayer svg {
+  pointer-events: none;
+}
+
+.xfaLayer svg * {
+  pointer-events: none;
+}
+
 .xfaLayer a {
   color: blue;
 }


### PR DESCRIPTION
  - a rectangle can be defined after a field and so from a z-index pov, it's on top of the field, which means that the rectangle avoid to have some mouse events in the fields;
  - so this patch just disable pointer events for all elements under svg (included).