### PR TITLE
When parsing corrupt documents, avoid inserting obviously broken data in the XRef-table (issue 13783)

### DIFF
--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -58,6 +58,8 @@ class MissingDataException extends BaseException {
   }
 }
 
+class ParserEOFException extends BaseException {}
+
 class XRefEntryException extends BaseException {}
 
 class XRefParseException extends BaseException {}
@@ -450,6 +452,7 @@ export {
   isWhiteSpace,
   log2,
   MissingDataException,
+  ParserEOFException,
   parseXFAPath,
   readInt8,
   readUint16,

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -33,7 +33,11 @@ import {
   Name,
   Ref,
 } from "./primitives.js";
-import { isWhiteSpace, MissingDataException } from "./core_utils.js";
+import {
+  isWhiteSpace,
+  MissingDataException,
+  ParserEOFException,
+} from "./core_utils.js";
 import { Ascii85Stream } from "./ascii_85_stream.js";
 import { AsciiHexStream } from "./ascii_hex_stream.js";
 import { CCITTFaxStream } from "./ccitt_stream.js";
@@ -124,10 +128,10 @@ class Parser {
             array.push(this.getObj(cipherTransform));
           }
           if (isEOF(this.buf1)) {
-            if (!this.recoveryMode) {
-              throw new FormatError("End of file inside array");
+            if (this.recoveryMode) {
+              return array;
             }
-            return array;
+            throw new ParserEOFException("End of file inside array.");
           }
           this.shift();
           return array;
@@ -148,10 +152,10 @@ class Parser {
             dict.set(key, this.getObj(cipherTransform));
           }
           if (isEOF(this.buf1)) {
-            if (!this.recoveryMode) {
-              throw new FormatError("End of file inside dictionary");
+            if (this.recoveryMode) {
+              return dict;
             }
-            return dict;
+            throw new ParserEOFException("End of file inside dictionary.");
           }
 
           // Stream objects are not allowed inside content streams or

--- a/test/pdfs/issue13783.pdf.link
+++ b/test/pdfs/issue13783.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/6869824/TimeTravel.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1382,6 +1382,15 @@
        "enableXfa": true,
        "type": "eq"
     },
+    {  "id": "issue13783",
+       "file": "pdfs/issue13783.pdf",
+       "md5": "6958d827afa566efbd82f53271ea5cd6",
+       "link": true,
+       "rounds": 1,
+       "firstPage": 7,
+       "lastPage": 7,
+       "type": "eq"
+    },
     {  "id": "issue9262",
        "file": "pdfs/issue9262_reduced.pdf",
        "md5": "5347ce2d7b3866625c22e115fd90e0de",


### PR DESCRIPTION
In cases where even the very *first* attempt at reading from an object will throw, simply ignoring such objects will help improve rendering of *some* corrupt documents.
Note that this will lead to more parsing in some cases, but considering that this only applies to *corrupt* documents that shouldn't be a big deal.