### PR TITLE
Remove a couple of small closures in `src/core/` code

### DIFF
--- a/src/core/ps_parser.js
+++ b/src/core/ps_parser.js
@@ -109,61 +109,59 @@ const PostScriptTokenTypes = {
   IFELSE: 5,
 };
 
-const PostScriptToken = (function PostScriptTokenClosure() {
-  const opCache = Object.create(null);
-
-  // eslint-disable-next-line no-shadow
-  class PostScriptToken {
-    constructor(type, value) {
-      this.type = type;
-      this.value = value;
-    }
-
-    static getOperator(op) {
-      const opValue = opCache[op];
-      if (opValue) {
-        return opValue;
-      }
-      return (opCache[op] = new PostScriptToken(
-        PostScriptTokenTypes.OPERATOR,
-        op
-      ));
-    }
-
-    static get LBRACE() {
-      return shadow(
-        this,
-        "LBRACE",
-        new PostScriptToken(PostScriptTokenTypes.LBRACE, "{")
-      );
-    }
-
-    static get RBRACE() {
-      return shadow(
-        this,
-        "RBRACE",
-        new PostScriptToken(PostScriptTokenTypes.RBRACE, "}")
-      );
-    }
-
-    static get IF() {
-      return shadow(
-        this,
-        "IF",
-        new PostScriptToken(PostScriptTokenTypes.IF, "IF")
-      );
-    }
-
-    static get IFELSE() {
-      return shadow(
-        this,
-        "IFELSE",
-        new PostScriptToken(PostScriptTokenTypes.IFELSE, "IFELSE")
-      );
-    }
+class PostScriptToken {
+  static get opCache() {
+    return shadow(this, "opCache", Object.create(null));
   }
-  return PostScriptToken;
-})();
+
+  constructor(type, value) {
+    this.type = type;
+    this.value = value;
+  }
+
+  static getOperator(op) {
+    const opValue = PostScriptToken.opCache[op];
+    if (opValue) {
+      return opValue;
+    }
+    return (PostScriptToken.opCache[op] = new PostScriptToken(
+      PostScriptTokenTypes.OPERATOR,
+      op
+    ));
+  }
+
+  static get LBRACE() {
+    return shadow(
+      this,
+      "LBRACE",
+      new PostScriptToken(PostScriptTokenTypes.LBRACE, "{")
+    );
+  }
+
+  static get RBRACE() {
+    return shadow(
+      this,
+      "RBRACE",
+      new PostScriptToken(PostScriptTokenTypes.RBRACE, "}")
+    );
+  }
+
+  static get IF() {
+    return shadow(
+      this,
+      "IF",
+      new PostScriptToken(PostScriptTokenTypes.IF, "IF")
+    );
+  }
+
+  static get IFELSE() {
+    return shadow(
+      this,
+      "IFELSE",
+      new PostScriptToken(PostScriptTokenTypes.IFELSE, "IFELSE")
+    );
+  }
+}
 
 class PostScriptLexer {
   constructor(stream) {


### PR DESCRIPTION
This patch-series decreases the size of the *built* `pdf.worker.js` file slightly, and we've been making similar changes elsewhere in the code-base.