### PR TITLE
Fix (most) LGTM warnings

### DIFF
--- a/src/core/file_spec.js
+++ b/src/core/file_spec.js
@@ -67,7 +67,7 @@ class FileSpec {
     if (!this._filename && this.root) {
       const filename = pickPlatformItem(this.root) || "unnamed";
       this._filename = stringToPDFString(filename)
-        .replace(/\\\\/g, "\\")
+        .replace(/\\\\/g, "\\") // lgtm [js/double-escaping]
         .replace(/\\\//g, "/")
         .replace(/\\/g, "/");
     }

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -192,8 +192,6 @@ function drawTriangle(data, context, p1, p2, p3, c1, c2, c3) {
       let k;
       if (y < y1) {
         k = 0;
-      } else if (y1 === y2) {
-        k = 1;
       } else {
         k = (y1 - y) / (y1 - y2);
       }

--- a/test/integration/scripting_spec.js
+++ b/test/integration/scripting_spec.js
@@ -22,7 +22,7 @@ describe("Interaction", () => {
     }
     await action();
     await page.waitForFunction(
-      `document.querySelector("${selector.replace("\\", "\\\\")}").value !== ""`
+      `document.querySelector("${selector.replace("\\", "\\\\")}").value !== ""` // lgtm [js/incomplete-sanitization]
     );
     return page.$eval(selector, el => el.value);
   }

--- a/test/test.js
+++ b/test/test.js
@@ -262,11 +262,9 @@ function startRefTest(masterMode, showRefImages) {
     } else if (showRefImages && numEqFailures > 0) {
       console.log();
       console.log(
-        "Starting reftest harness to examine " +
-          numEqFailures +
-          " eq test failures."
+        `Starting reftest harness to examine ${numEqFailures} eq test failures.`
       );
-      examineRefImages(numEqFailures);
+      examineRefImages();
     }
   }
 

--- a/test/webserver.js
+++ b/test/webserver.js
@@ -153,7 +153,7 @@ WebServer.prototype = {
       fileSize = stats.size;
       var isDir = stats.isDirectory();
       if (isDir && !/\/$/.test(pathPart)) {
-        res.setHeader("Location", pathPart + "/" + urlParts[2]);
+        res.setHeader("Location", pathPart + "/" + urlParts[2]); // lgtm [js/server-side-unvalidated-url-redirection]
         res.writeHead(301);
         res.end("Redirected", "utf8");
         return;


### PR DESCRIPTION
Most of the warnings we don't really care about, and those are simply white-listed using inline comments; however two cases prompted actual code changes:

 - In `src/display/pattern_helper.js` the branch in question is indeed unreachable, and should thus be safe to remove. (This code originated in PR #4192, which is now over seven years ago.)

 - In `test/test.js`, the function in question indeed doesn't accept any arguments. (The patch also re-formats a string just above, which didn't seem worthy of a separated patch.)

This now leaves only *one* warning in the LGTM report, however that one is a false positive that we'll need to report upstream.