### PR TITLE
XFA - Elements created outside of XML must have all their properties (bug 1722029)

### DIFF
--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -3603,24 +3603,59 @@ class Occur extends XFAObject {
   constructor(attributes) {
     super(TEMPLATE_NS_ID, "occur", /* hasChildren = */ true);
     this.id = attributes.id || "";
-    this.initial = getInteger({
-      data: attributes.initial,
-      defaultValue: 1,
-      validate: x => true,
-    });
-    this.max = getInteger({
-      data: attributes.max,
-      defaultValue: 1,
-      validate: x => true,
-    });
-    this.min = getInteger({
-      data: attributes.min,
-      defaultValue: 1,
-      validate: x => true,
-    });
+    this.initial =
+      attributes.initial !== ""
+        ? getInteger({
+            data: attributes.initial,
+            defaultValue: "",
+            validate: x => true,
+          })
+        : "";
+    this.max =
+      attributes.max !== ""
+        ? getInteger({
+            data: attributes.max,
+            defaultValue: 1,
+            validate: x => true,
+          })
+        : "";
+    this.min =
+      attributes.min !== ""
+        ? getInteger({
+            data: attributes.min,
+            defaultValue: 1,
+            validate: x => true,
+          })
+        : "";
     this.use = attributes.use || "";
     this.usehref = attributes.usehref || "";
     this.extras = null;
+  }
+
+  [$clean]() {
+    const parent = this[$getParent]();
+    const originalMin = this.min;
+
+    if (this.min === "") {
+      this.min =
+        parent instanceof PageArea || parent instanceof PageSet ? 0 : 1;
+    }
+    if (this.max === "") {
+      if (originalMin === "") {
+        this.max =
+          parent instanceof PageArea || parent instanceof PageSet ? -1 : 1;
+      } else {
+        this.max = this.min;
+      }
+    }
+
+    if (this.max !== -1 && this.max < this.min) {
+      this.max = this.min;
+    }
+
+    if (this.initial === "") {
+      this.initial = parent instanceof Template ? 1 : this.min;
+    }
   }
 }
 
@@ -5705,6 +5740,7 @@ class Value extends XFAObject {
       if (parent.ui && parent.ui.imageEdit) {
         if (!this.image) {
           this.image = new Image({});
+          this[$appendChild](this.image);
         }
         this.image[$content] = value[$content];
         return;

--- a/src/core/xfa/xfa_object.js
+++ b/src/core/xfa/xfa_object.js
@@ -204,6 +204,9 @@ class XFAObject {
   [$appendChild](child) {
     child[_parent] = this;
     this[_children].push(child);
+    if (!child[$globalData] && this[$globalData]) {
+      child[$globalData] = this[$globalData];
+    }
   }
 
   [$removeChild](child) {
@@ -236,6 +239,9 @@ class XFAObject {
   [$insertAt](i, child) {
     child[_parent] = this;
     this[_children].splice(i, 0, child);
+    if (!child[$globalData] && this[$globalData]) {
+      child[$globalData] = this[$globalData];
+    }
   }
 
   /**

--- a/test/pdfs/xfa_bug1722029.pdf.link
+++ b/test/pdfs/xfa_bug1722029.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=9233058

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -952,6 +952,14 @@
        "enableXfa": true,
        "type": "eq"
     },
+    {  "id": "xfa_bug1722029",
+       "file": "pdfs/xfa_bug1722029.pdf",
+       "md5": "d8dd6bb20599fc777b4c7ff7b74dd5e3",
+       "link": true,
+       "rounds": 1,
+       "enableXfa": true,
+       "type": "eq"
+    },
     {  "id": "xfa_bug1721600",
        "file": "pdfs/xfa_bug1721600.pdf",
        "md5": "5f514f476169eeb7254da380a8db495a",


### PR DESCRIPTION
  - an Image element was created, attached to its parent but the $globalData property was not set and that led to an error.
  - the pdf in bug 1722029 has 27 rendered rows (checked in Acrobat) when only one was displayed: this patch fixes some binding issues around the occur element.