### PR TITLE
Allow `StreamsSequenceStream.readBlock` to skip sub-streams with errors (issue 13794)

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -335,6 +335,7 @@ const UNSUPPORTED_FEATURES = {
   errorFontBuildPath: "errorFontBuildPath",
   errorFontGetPath: "errorFontGetPath",
   errorMarkedContent: "errorMarkedContent",
+  errorContentSubStream: "errorContentSubStream",
 };
 
 const PasswordResponses = {

--- a/test/pdfs/issue13794.pdf.link
+++ b/test/pdfs/issue13794.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/6876708/Scan-to-Mail-PDF1_.1.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1391,6 +1391,14 @@
        "lastPage": 7,
        "type": "eq"
     },
+    {  "id": "issue13794",
+       "file": "pdfs/issue13794.pdf",
+       "md5": "6b4c099e04c9df145198740f2bf75c48",
+       "link": true,
+       "rounds": 1,
+       "firstPage": 3,
+       "type": "eq"
+    },
     {  "id": "issue9262",
        "file": "pdfs/issue9262_reduced.pdf",
        "md5": "5347ce2d7b3866625c22e115fd90e0de",


### PR DESCRIPTION
This patch makes use of the existing `ignoreErrors` option, thus allowing a page to continue parsing/rendering even if (some of) its sub-streams are corrupt. Obviously this may cause *part* of a page to be broken/missing, however it should be better than (potentially) rendering nothing.
Also, to the best of my knowledge, this is the first bug of its kind that we've encountered.

To avoid having to pass in a bunch of, for a `BaseStream`-instance, mostly unrelated parameters when initializing a `StreamsSequenceStream`-instance, I settled on utilizing a callback function instead to allow conditional Error-suppression.
Note that the `StreamsSequenceStream`-class is a *special* stream-implementation that we only use when the `/Contents`-entry, in the `/Page`-dictionary, consists of an Array with streams.