### PR TITLE
Improve caching of shading patterns. (bug 1721949)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1315,20 +1315,17 @@ class PartialEvaluator {
   }
 
   parseShading({
-    keyObj,
     shading,
     resources,
     localColorSpaceCache,
     localShadingPatternCache,
-    matrix = null,
   }) {
     // Shadings and patterns may be referenced by the same name but the resource
     // dictionary could be different so we can't use the name for the cache key.
-    let id = localShadingPatternCache.get(keyObj);
+    let id = localShadingPatternCache.get(shading);
     if (!id) {
       var shadingFill = Pattern.parseShading(
         shading,
-        matrix,
         this.xref,
         resources,
         this.handler,
@@ -1337,7 +1334,7 @@ class PartialEvaluator {
       );
       const patternIR = shadingFill.getIR();
       id = `pattern_${this.idFactory.createObjId()}`;
-      localShadingPatternCache.set(keyObj, id);
+      localShadingPatternCache.set(shading, id);
       this.handler.send("obj", [id, this.pageIndex, "Pattern", patternIR]);
     }
     return id;
@@ -1402,14 +1399,12 @@ class PartialEvaluator {
           const shading = dict.get("Shading");
           const matrix = dict.getArray("Matrix");
           const objId = this.parseShading({
-            keyObj: pattern,
             shading,
-            matrix,
             resources,
             localColorSpaceCache,
             localShadingPatternCache,
           });
-          operatorList.addOp(fn, ["Shading", objId]);
+          operatorList.addOp(fn, ["Shading", objId, matrix]);
           return undefined;
         }
         throw new FormatError(`Unknown PatternType: ${typeNum}`);
@@ -1942,7 +1937,6 @@ class PartialEvaluator {
               throw new FormatError("No shading object found");
             }
             const patternId = self.parseShading({
-              keyObj: shading,
               shading,
               resources,
               localColorSpaceCache,

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -44,7 +44,6 @@ class Pattern {
 
   static parseShading(
     shading,
-    matrix,
     xref,
     res,
     handler,
@@ -60,7 +59,6 @@ class Pattern {
         case ShadingType.RADIAL:
           return new RadialAxialShading(
             dict,
-            matrix,
             xref,
             res,
             pdfFunctionFactory,
@@ -72,7 +70,6 @@ class Pattern {
         case ShadingType.TENSOR_PATCH_MESH:
           return new MeshShading(
             shading,
-            matrix,
             xref,
             res,
             pdfFunctionFactory,
@@ -115,16 +112,8 @@ class BaseShading {
 // Radial and axial shading have very similar implementations
 // If needed, the implementations can be broken into two classes.
 class RadialAxialShading extends BaseShading {
-  constructor(
-    dict,
-    matrix,
-    xref,
-    resources,
-    pdfFunctionFactory,
-    localColorSpaceCache
-  ) {
+  constructor(dict, xref, resources, pdfFunctionFactory, localColorSpaceCache) {
     super();
-    this.matrix = matrix;
     this.coordsArr = dict.getArray("Coords");
     this.shadingType = dict.get("ShadingType");
     const cs = ColorSpace.parse({
@@ -244,17 +233,7 @@ class RadialAxialShading extends BaseShading {
       unreachable(`getPattern type unknown: ${shadingType}`);
     }
 
-    return [
-      "RadialAxial",
-      type,
-      this.bbox,
-      this.colorStops,
-      p0,
-      p1,
-      r0,
-      r1,
-      this.matrix,
-    ];
+    return ["RadialAxial", type, this.bbox, this.colorStops, p0, p1, r0, r1];
   }
 }
 
@@ -418,7 +397,6 @@ class MeshShading extends BaseShading {
 
   constructor(
     stream,
-    matrix,
     xref,
     resources,
     pdfFunctionFactory,
@@ -429,7 +407,6 @@ class MeshShading extends BaseShading {
       throw new FormatError("Mesh data is not a stream");
     }
     const dict = stream.dict;
-    this.matrix = matrix;
     this.shadingType = dict.get("ShadingType");
     const bbox = dict.getArray("BBox");
     if (Array.isArray(bbox) && bbox.length === 4) {
@@ -942,7 +919,6 @@ class MeshShading extends BaseShading {
       this.colors,
       this.figures,
       this.bounds,
-      this.matrix,
       this.bbox,
       this.background,
     ];


### PR DESCRIPTION
The PDF in bug 1721949 uses many unique pattern objects
that references the same shading many times. This caused
a new canvas pattern to be created and cached many times
driving up memory use.

To fix, I've changed the cache in the worker to key off the
shading object and instead send the shading and matrix
separately. While that worked well to fix the above bug,
there could be PDFs that use many shading that could
cause memory issues, so I've also added a LRU cache
on the main thread for canvas patterns. This should prevent
memory use from getting too high.