### PR TITLE
Remove a couple of closures in the `src/display/api.js` file

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1905,8 +1905,8 @@ class LoopbackPort {
  * @typedef {Object} PDFWorkerParameters
  * @property {string} [name] - The name of the worker.
  * @property {Object} [port] - The `workerPort` object.
- * @property {number} [verbosity] - Controls the logging level; the
- *   constants from {@link VerbosityLevel} should be used.
+ * @property {number} [verbosity] - Controls the logging level;
+ *   the constants from {@link VerbosityLevel} should be used.
  */
 
 /** @type {any} */
@@ -1923,13 +1923,11 @@ const PDFWorker = (function PDFWorkerClosure() {
       // Workers aren't supported in Node.js, force-disabling them there.
       isWorkerDisabled = true;
 
-      if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("LIB")) {
-        fallbackWorkerSrc = "../pdf.worker.js";
-      } else {
-        fallbackWorkerSrc = "./pdf.worker.js";
-      }
-    } else if (typeof document === "object" && "currentScript" in document) {
-      const pdfjsFilePath = document.currentScript?.src;
+      fallbackWorkerSrc = PDFJSDev.test("LIB")
+        ? "../pdf.worker.js"
+        : "./pdf.worker.js";
+    } else if (typeof document === "object") {
+      const pdfjsFilePath = document?.currentScript?.src;
       if (pdfjsFilePath) {
         fallbackWorkerSrc = pdfjsFilePath.replace(
           /(\.(?:min\.)?js)(\?.*)?$/i,
@@ -1953,16 +1951,14 @@ const PDFWorker = (function PDFWorkerClosure() {
   }
 
   function getMainThreadWorkerMessageHandler() {
-    let mainWorkerMessageHandler;
     try {
-      mainWorkerMessageHandler = globalThis.pdfjsWorker?.WorkerMessageHandler;
+      return globalThis.pdfjsWorker?.WorkerMessageHandler || null;
     } catch (ex) {
-      /* Ignore errors. */
+      return null;
     }
-    return mainWorkerMessageHandler || null;
   }
 
-  // Loads worker code into main thread.
+  // Loads worker code into main-thread.
   function setupFakeWorkerGlobal() {
     if (fakeWorkerCapability) {
       return fakeWorkerCapability.promise;

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -385,6 +385,26 @@ describe("api", function () {
 
       await loadingTask.destroy();
     });
+
+    it("checks that `docId`s are unique and increasing", async function () {
+      const loadingTask1 = getDocument(basicApiGetDocumentParams);
+      await loadingTask1.promise;
+      const docId1 = loadingTask1.docId;
+
+      const loadingTask2 = getDocument(basicApiGetDocumentParams);
+      await loadingTask2.promise;
+      const docId2 = loadingTask2.docId;
+
+      expect(docId1).not.toEqual(docId2);
+
+      const docIdRegExp = /^d(\d)+$/,
+        docNum1 = docIdRegExp.exec(docId1)?.[1],
+        docNum2 = docIdRegExp.exec(docId2)?.[1];
+
+      expect(+docNum1).toBeLessThan(+docNum2);
+
+      await Promise.all([loadingTask1.destroy(), loadingTask2.destroy()]);
+    });
   });
 
   describe("PDFWorker", function () {


### PR DESCRIPTION
*Please refer to the individual commit messages for additional details.*

Also, note that this patch-series still leaves the `PDFWorkerClosure` intact. The reason is partly that the code is less straightforward to re-factor in this way, and more importantly that `PDFWorker` is exposed in the *public API* and I really didn't want to accidentally make any internal state visible to the outside. This could possibly be improved upon if/when we've started using static class fields (currently blocked on ESLint support).