### PR TITLE
[api-minor] Remove the separate `enableScripting` option in `BaseViewer`

### DIFF
--- a/examples/components/simpleviewer.js
+++ b/examples/components/simpleviewer.js
@@ -35,8 +35,6 @@ const DEFAULT_URL = "../../web/compressed.tracemonkey-pldi-09.pdf";
 // var DEFAULT_URL = "../../test/pdfs/160F-2019.pdf";
 
 const SEARCH_FOR = ""; // try 'Mozilla';
-
-// For scripting support, note also `enableScripting` below.
 const SANDBOX_BUNDLE_SRC = "../../node_modules/pdfjs-dist/build/pdf.sandbox.js";
 
 const container = document.getElementById("viewerContainer");
@@ -66,7 +64,7 @@ const pdfViewer = new pdfjsViewer.PDFViewer({
   linkService: pdfLinkService,
   findController: pdfFindController,
   scriptingManager: pdfScriptingManager,
-  enableScripting: true,
+  enableScripting: true, // Only necessary in PDF.js version 2.10.377 and below.
 });
 pdfLinkService.setViewer(pdfViewer);
 pdfScriptingManager.setViewer(pdfViewer);

--- a/examples/components/singlepageviewer.js
+++ b/examples/components/singlepageviewer.js
@@ -35,8 +35,6 @@ const DEFAULT_URL = "../../web/compressed.tracemonkey-pldi-09.pdf";
 // var DEFAULT_URL = "../../test/pdfs/160F-2019.pdf";
 
 const SEARCH_FOR = ""; // try 'Mozilla';
-
-// For scripting support, note also `enableScripting` below.
 const SANDBOX_BUNDLE_SRC = "../../node_modules/pdfjs-dist/build/pdf.sandbox.js";
 
 const container = document.getElementById("viewerContainer");
@@ -66,7 +64,7 @@ const pdfSinglePageViewer = new pdfjsViewer.PDFSinglePageViewer({
   linkService: pdfLinkService,
   findController: pdfFindController,
   scriptingManager: pdfScriptingManager,
-  enableScripting: true,
+  enableScripting: true, // Only necessary in PDF.js version 2.10.377 and below.
 });
 pdfLinkService.setViewer(pdfSinglePageViewer);
 pdfScriptingManager.setViewer(pdfSinglePageViewer);

--- a/web/app.js
+++ b/web/app.js
@@ -505,7 +505,8 @@ const PDFViewerApplication = {
       linkService: pdfLinkService,
       downloadManager,
       findController,
-      scriptingManager: pdfScriptingManager,
+      scriptingManager:
+        AppOptions.get("enableScripting") && pdfScriptingManager,
       renderer: AppOptions.get("renderer"),
       l10n: this.l10n,
       textLayerMode: AppOptions.get("textLayerMode"),
@@ -514,7 +515,6 @@ const PDFViewerApplication = {
       enablePrintAutoRotate: AppOptions.get("enablePrintAutoRotate"),
       useOnlyCssZoom: AppOptions.get("useOnlyCssZoom"),
       maxCanvasPixels: AppOptions.get("maxCanvasPixels"),
-      enableScripting: AppOptions.get("enableScripting"),
     });
     pdfRenderingQueue.setViewer(this.pdfViewer);
     pdfLinkService.setViewer(this.pdfViewer);

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -79,8 +79,6 @@ const DEFAULT_CACHE_SIZE = 10;
  *   total pixels, i.e. width * height. Use -1 for no limit. The default value
  *   is 4096 * 4096 (16 mega-pixels).
  * @property {IL10n} l10n - Localization service.
- * @property {boolean} [enableScripting] - Enable embedded script execution
- *   (also requires {scriptingManager} being set). The default value is `false`.
  */
 
 function PDFPageViewBuffer(size) {
@@ -195,8 +193,6 @@ class BaseViewer {
     this.useOnlyCssZoom = options.useOnlyCssZoom || false;
     this.maxCanvasPixels = options.maxCanvasPixels;
     this.l10n = options.l10n || NullL10n;
-    this.enableScripting =
-      options.enableScripting === true && !!this._scriptingManager;
 
     this.defaultRenderingQueue = !options.renderingQueue;
     if (this.defaultRenderingQueue) {
@@ -242,6 +238,13 @@ class BaseViewer {
     return this._pages.every(function (pageView) {
       return pageView?.pdfPage;
     });
+  }
+
+  /**
+   * @type {boolean}
+   */
+  get enableScripting() {
+    return !!this._scriptingManager;
   }
 
   /**
@@ -572,8 +575,8 @@ class BaseViewer {
           if (this.findController) {
             this.findController.setDocument(pdfDocument); // Enable searching.
           }
-          if (this.enableScripting) {
-            this._scriptingManager.setDocument(pdfDocument);
+          if (this._scriptingManager) {
+            this._scriptingManager.setDocument(pdfDocument); // Enable scripting.
           }
 
           // In addition to 'disableAutoFetch' being set, also attempt to reduce


### PR DESCRIPTION
Prior to PR #13042, when scripting wasn't really possible to use outside of the full viewer, the `enableScripting` option made sense.
However, at this point in time having to both pass in a `PDFScriptingManager`-instance *and* set the `enableScripting`-boolean when creating a `BaseViewer`-instance feels redundant and (mostly) annoying. Hence this patch, which removes the *separate* boolean and always enables scripting when `scriptingManager` is provided.

The relevant "viewer component" examples are also updated (with a comment), but in such a way that scripting support won't just break when used with the current PDF.js releases.