### PR TITLE
Prevent "Uncaught promise" messages in the console when cancelling (some) `ReadableStream`s

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1802,7 +1802,11 @@ class PDFPageProxy {
         return;
       }
     }
-    intentState.streamReader.cancel(new AbortException(reason?.message));
+    intentState.streamReader
+      .cancel(new AbortException(reason?.message))
+      .catch(() => {
+        // Avoid "Uncaught promise" messages in the console.
+      });
     intentState.streamReader = null;
 
     if (this._transport.destroyed) {

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -597,7 +597,7 @@ class TextLayerRenderTask {
         }
       })
       .catch(() => {
-        /* Avoid "Uncaught promise" messages in the console. */
+        // Avoid "Uncaught promise" messages in the console.
       });
   }
 
@@ -615,7 +615,11 @@ class TextLayerRenderTask {
   cancel() {
     this._canceled = true;
     if (this._reader) {
-      this._reader.cancel(new AbortException("TextLayer task cancelled."));
+      this._reader
+        .cancel(new AbortException("TextLayer task cancelled."))
+        .catch(() => {
+          // Avoid "Uncaught promise" messages in the console.
+        });
       this._reader = null;
     }
     if (this._renderTimer !== null) {
@@ -741,8 +745,7 @@ class TextLayerRenderTask {
       pump();
     } else {
       throw new Error(
-        'Neither "textContent" nor "textContentStream"' +
-          " parameters specified."
+        'Neither "textContent" nor "textContentStream" parameters specified.'
       );
     }
 


### PR DESCRIPTION
While fixing issue #13794, I noticed that cancelling the `ReadableStream` returned by the `PDFPageProxy.streamTextContent`-method could lead to "Uncaught promise" messages in the console.[1]
Generally speaking, we don't really care about errors when *cancelling* a `ReadableStream` and it thus seems reasonable to simply suppress any output in those cases.

---
[1] Although, after that issue was fixed you'd now need to set the API-option `stopAtErrors = true` to actually trigger this.