### PR TITLE
Improve the code analysis workflow with quality checks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-name: GitHub Advanced Security
+name: CodeQL
 on: [push, pull_request]
 jobs:
   analyze:
@@ -23,7 +23,7 @@ jobs:
         uses: github/codeql-action/init@v1
         with:
           languages: ${{ matrix.language }}
-          queries: security-extended
+          queries: security-and-quality
 
       - name: Autobuild CodeQL
         uses: github/codeql-action/autobuild@v1


### PR DESCRIPTION
This allows us to get the quality checks that LGTM does into GitHub Advanced Security. Since it not only runs security checks anymore, the workflow is also renamed to CodeQL to make this more explicit (and this matches the documentation better).

@Snuffleupagus Now that we run the security and quality checks, in other words all checks that CodeQL provides, we get more results, mostly the same as LGTM but I think even some new ones (for example https://github.com/timvandermeij/pdf.js/security/code-scanning/103?query=ref%3Arefs%2Fheads%2Fcodeql). Please see https://github.com/timvandermeij/pdf.js/security/code-scanning?query=is%3Aopen+branch%3Acodeql+ for the test run. Once this is merged, we can classify the list of security/quality issues and after that disable LGTM.