### PR TITLE
Make worker-loader optional as peerDependencies. Close #13825.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2018,7 +2018,12 @@ function packageBowerJson() {
     bugs: DIST_BUGS_URL,
     license: DIST_LICENSE,
     peerDependencies: {
-      "worker-loader": "^3.0.7", // Used in `external/dist/webpack.js`.
+      "worker-loader": "^3.0.8", // Used in `external/dist/webpack.js`.
+    },
+    peerDependenciesMeta: {
+      "worker-loader": {
+        optional: true,
+      },
     },
     browser: {
       canvas: false,


### PR DESCRIPTION
Make `worker-loader` optional as peerDependencies. Close #13825.

- https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependencies
- https://github.blog/2020-10-13-presenting-v7-0-0-of-the-npm-cli/
- https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependenciesmeta

Update `worker-loader` to v3.0.8.