### PR TITLE
Fix inefficient regular expressions in `external/cmapscompress/parse.js`

### DIFF
--- a/external/cmapscompress/parse.js
+++ b/external/cmapscompress/parse.js
@@ -28,9 +28,9 @@ exports.parseAdobeCMap = function (content) {
     usecmap: null,
     body: [],
   };
-  m = /\/CMapType\s+(\d+)+\s+def\b/.exec(body);
+  m = /\/CMapType\s+(\d+)\s+def\b/.exec(body);
   result.type = +m[1];
-  m = /\/WMode\s+(\d+)+\s+def\b/.exec(body);
+  m = /\/WMode\s+(\d+)\s+def\b/.exec(body);
   result.wmode = +m[1];
   m = /\/([\w-]+)\s+usecmap\b/.exec(body);
   if (m) {


### PR DESCRIPTION
The only purpose, according to the README and existing files, is to parse an integer from those lines, so (\d+) is sufficient for that. This avoids potential exponential backtracking as flagged by CodeQL. I have compared the output of the script with and without these changes and the resulting files are the same.