### PR TITLE
Implement unit tests for the `parseQueryString` utility function

### DIFF
--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -22,6 +22,7 @@ import {
   isPortraitOrientation,
   isValidRotation,
   moveToEndOfArray,
+  parseQueryString,
   waitOnEventOrTimeout,
   WaitOnType,
 } from "../../web/ui_utils.js";
@@ -250,6 +251,43 @@ describe("ui_utils", function () {
           height: 300,
         })
       ).toEqual(false);
+    });
+  });
+
+  describe("parseQueryString", function () {
+    it("should parse one key/value pair", function () {
+      const parameters = parseQueryString("key1=value1");
+      expect(parameters.size).toEqual(1);
+      expect(parameters.get("key1")).toEqual("value1");
+    });
+
+    it("should parse multiple key/value pairs", function () {
+      const parameters = parseQueryString(
+        "key1=value1&key2=value2&key3=value3"
+      );
+      expect(parameters.size).toEqual(3);
+      expect(parameters.get("key1")).toEqual("value1");
+      expect(parameters.get("key2")).toEqual("value2");
+      expect(parameters.get("key3")).toEqual("value3");
+    });
+
+    it("should parse keys without values", function () {
+      const parameters = parseQueryString("key1");
+      expect(parameters.size).toEqual(1);
+      expect(parameters.get("key1")).toEqual("");
+    });
+
+    it("should decode encoded key/value pairs", function () {
+      const parameters = parseQueryString("k%C3%ABy1=valu%C3%AB1");
+      expect(parameters.size).toEqual(1);
+      expect(parameters.get("këy1")).toEqual("valuë1");
+    });
+
+    it("should convert keys to lowercase", function () {
+      const parameters = parseQueryString("Key1=Value1&KEY2=Value2");
+      expect(parameters.size).toEqual(2);
+      expect(parameters.get("key1")).toEqual("Value1");
+      expect(parameters.get("key2")).toEqual("Value2");
     });
   });
 

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -185,10 +185,9 @@ function watchScroll(viewAreaElement, callback) {
  * @returns {Map}
  */
 function parseQueryString(query) {
-  const parts = query.split("&");
   const params = new Map();
-  for (let i = 0, ii = parts.length; i < ii; ++i) {
-    const param = parts[i].split("="),
+  for (const part of query.split("&")) {
+    const param = part.split("="),
       key = param[0].toLowerCase(),
       value = param.length > 1 ? param[1] : "";
     params.set(decodeURIComponent(key), decodeURIComponent(value));


### PR DESCRIPTION
Now that these unit tests are in place, we also take the opportunity to slightly modernize the code itself by using a `for ... of` loop.

(I noticed after the `Map` change that this function did not have unit test coverage yet, so I thought it would be good to add that, especially considering the special `decodeURIComponent(null)` case so that the unit tests assert that we don't accidentally return `"null"` anymore.)