### PR TITLE
Fix a broken regular expression in the `docId` unit-test (issue 13838, PR 13813 follow-up)

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -397,7 +397,7 @@ describe("api", function () {
 
       expect(docId1).not.toEqual(docId2);
 
-      const docIdRegExp = /^d(\d)+$/,
+      const docIdRegExp = /^d(\d+)$/,
         docNum1 = docIdRegExp.exec(docId1)?.[1],
         docNum2 = docIdRegExp.exec(docId2)?.[1];
 


### PR DESCRIPTION
The current regular expression contains a typo, leading to intermittent test-failures for certain `docId`s; sorry about that!

Fixes #13838