### PR TITLE
Add a special `gulp xfatest` command, to limit the ref-tests to only XFA-documents (issue 13744)

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -382,6 +382,7 @@ var Driver = (function DriverClosure() {
     this.testFilter = parameters.testFilter
       ? JSON.parse(parameters.testFilter)
       : [];
+    this.xfaOnly = parameters.xfaOnly === "true";
 
     // Create a working canvas
     this.canvas = document.createElement("canvas");
@@ -425,9 +426,15 @@ var Driver = (function DriverClosure() {
         if (r.readyState === 4) {
           self._log("done\n");
           self.manifest = JSON.parse(r.responseText);
-          if (self.testFilter && self.testFilter.length) {
+          if (self.testFilter?.length || self.xfaOnly) {
             self.manifest = self.manifest.filter(function (item) {
-              return self.testFilter.includes(item.id);
+              if (self.testFilter.includes(item.id)) {
+                return true;
+              }
+              if (self.xfaOnly && item.enableXfa) {
+                return true;
+              }
+              return false;
             });
           }
           self.currentTask = 0;


### PR DESCRIPTION
The new command is a *variation* of the standard `gulp test` command and will run all unit/font/integration-tests just as normal, while *only* running ref-tests for XFA-documents to speed up development.
Given that we currently have (some) unit-tests for XFA-documents, and that we may also (in the future) want to add integration-tests, it thus makes sense to run all test-suites in my opinion.

*Please note:* Once this patch has landed, I'll submit a follow-up patch to https://github.com/mozilla/botio-files-pdfjs such that we can also run the new command on the bots.