### PR TITLE
Remove the LGTM configuration and inline disable comments (issue 13829)

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,9 +1,0 @@
-path_classifiers:
-  test:
-    - exclude: test
-    - test/resources
-
-queries:
-  # Already handled by the "no-unused-vars" ESLint rule.
-  - exclude: js/unused-local-variable
-  - exclude: js/useless-assignment-to-local

--- a/src/core/file_spec.js
+++ b/src/core/file_spec.js
@@ -66,7 +66,7 @@ class FileSpec {
   get filename() {
     if (!this._filename && this.root) {
       const filename = pickPlatformItem(this.root) || "unnamed";
-      this._filename = stringToPDFString(filename) // lgtm [js/double-escaping]
+      this._filename = stringToPDFString(filename)
         .replace(/\\\\/g, "\\")
         .replace(/\\\//g, "/")
         .replace(/\\/g, "/");

--- a/test/integration/scripting_spec.js
+++ b/test/integration/scripting_spec.js
@@ -22,7 +22,7 @@ describe("Interaction", () => {
     }
     await action();
     await page.waitForFunction(
-      `document.querySelector("${selector.replace("\\", "\\\\")}").value !== ""` // lgtm [js/incomplete-sanitization]
+      `document.querySelector("${selector.replace("\\", "\\\\")}").value !== ""`
     );
     return page.$eval(selector, el => el.value);
   }

--- a/test/webserver.js
+++ b/test/webserver.js
@@ -153,7 +153,7 @@ WebServer.prototype = {
       fileSize = stats.size;
       var isDir = stats.isDirectory();
       if (isDir && !/\/$/.test(pathPart)) {
-        res.setHeader("Location", pathPart + "/" + urlParts[2]); // lgtm [js/server-side-unvalidated-url-redirection]
+        res.setHeader("Location", pathPart + "/" + urlParts[2]);
         res.writeHead(301);
         res.end("Redirected", "utf8");
         return;


### PR DESCRIPTION
Given that the GitHub Advanced Security workflow now covers everything that LGTM does, but generally faster and with better GitHub-integration, there's no longer much point in also running LGTM separately.
As a follow-up to this patch, we should also disable/remove the LGTM-integration from the PDF.js repository.