### PR TITLE
Prevent breaking errors when an optional content group is undefined (issue 13851)

### DIFF
--- a/src/display/optional_content_config.js
+++ b/src/display/optional_content_config.js
@@ -95,6 +95,10 @@ class OptionalContentConfig {
   }
 
   isVisible(group) {
+    if (!group) {
+      warn("Optional content group not defined.");
+      return true;
+    }
     if (group.type === "OCG") {
       if (!this._groups.has(group.id)) {
         warn(`Optional content group not found: ${group.id}`);

--- a/test/pdfs/issue13851.pdf.link
+++ b/test/pdfs/issue13851.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/6896539/doc_image.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -3688,6 +3688,13 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "issue13851",
+       "file": "pdfs/issue13851.pdf",
+       "md5": "d933d397c4efc80faba856bf8deafc1a",
+       "rounds": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "issue1655",
        "file": "pdfs/issue1655r.pdf",
        "md5": "569f48449ba57c15c4f9ade151a651c5",


### PR DESCRIPTION
In the referenced PDF document *most* of the form `/Form` XObjects don't have an `/OC` entry, which thus causes the runtime failure during rendering.

Fixes #13851