### PR TITLE
Remove the `isEOF` helper function and slightly re-factor `EOF`

### DIFF
--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -20,7 +20,7 @@ import {
   unreachable,
   warn,
 } from "../shared/util.js";
-import { isCmd, isEOF, isName, isStream } from "./primitives.js";
+import { EOF, isCmd, isName, isStream } from "./primitives.js";
 import { Lexer } from "./parser.js";
 import { MissingDataException } from "./core_utils.js";
 import { Stream } from "./stream.js";
@@ -773,7 +773,7 @@ const CMapFactory = (function CMapFactoryClosure() {
   function parseBfChar(cMap, lexer) {
     while (true) {
       let obj = lexer.getObj();
-      if (isEOF(obj)) {
+      if (obj === EOF) {
         break;
       }
       if (isCmd(obj, "endbfchar")) {
@@ -792,7 +792,7 @@ const CMapFactory = (function CMapFactoryClosure() {
   function parseBfRange(cMap, lexer) {
     while (true) {
       let obj = lexer.getObj();
-      if (isEOF(obj)) {
+      if (obj === EOF) {
         break;
       }
       if (isCmd(obj, "endbfrange")) {
@@ -810,7 +810,7 @@ const CMapFactory = (function CMapFactoryClosure() {
       } else if (isCmd(obj, "[")) {
         obj = lexer.getObj();
         const array = [];
-        while (!isCmd(obj, "]") && !isEOF(obj)) {
+        while (!isCmd(obj, "]") && obj !== EOF) {
           array.push(obj);
           obj = lexer.getObj();
         }
@@ -825,7 +825,7 @@ const CMapFactory = (function CMapFactoryClosure() {
   function parseCidChar(cMap, lexer) {
     while (true) {
       let obj = lexer.getObj();
-      if (isEOF(obj)) {
+      if (obj === EOF) {
         break;
       }
       if (isCmd(obj, "endcidchar")) {
@@ -843,7 +843,7 @@ const CMapFactory = (function CMapFactoryClosure() {
   function parseCidRange(cMap, lexer) {
     while (true) {
       let obj = lexer.getObj();
-      if (isEOF(obj)) {
+      if (obj === EOF) {
         break;
       }
       if (isCmd(obj, "endcidrange")) {
@@ -864,7 +864,7 @@ const CMapFactory = (function CMapFactoryClosure() {
   function parseCodespaceRange(cMap, lexer) {
     while (true) {
       let obj = lexer.getObj();
-      if (isEOF(obj)) {
+      if (obj === EOF) {
         break;
       }
       if (isCmd(obj, "endcodespacerange")) {
@@ -903,7 +903,7 @@ const CMapFactory = (function CMapFactoryClosure() {
     objLoop: while (true) {
       try {
         const obj = lexer.getObj();
-        if (isEOF(obj)) {
+        if (obj === EOF) {
           break;
         } else if (isName(obj)) {
           if (obj.name === "WMode") {

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -28,7 +28,6 @@ import {
   EOF,
   isCmd,
   isDict,
-  isEOF,
   isName,
   Name,
   Ref,
@@ -124,10 +123,10 @@ class Parser {
           return this.makeInlineImage(cipherTransform);
         case "[": // array
           const array = [];
-          while (!isCmd(this.buf1, "]") && !isEOF(this.buf1)) {
+          while (!isCmd(this.buf1, "]") && this.buf1 !== EOF) {
             array.push(this.getObj(cipherTransform));
           }
-          if (isEOF(this.buf1)) {
+          if (this.buf1 === EOF) {
             if (this.recoveryMode) {
               return array;
             }
@@ -137,7 +136,7 @@ class Parser {
           return array;
         case "<<": // dictionary or stream
           const dict = new Dict(this.xref);
-          while (!isCmd(this.buf1, ">>") && !isEOF(this.buf1)) {
+          while (!isCmd(this.buf1, ">>") && this.buf1 !== EOF) {
             if (!isName(this.buf1)) {
               info("Malformed dictionary: key must be a name object");
               this.shift();
@@ -146,12 +145,12 @@ class Parser {
 
             const key = this.buf1.name;
             this.shift();
-            if (isEOF(this.buf1)) {
+            if (this.buf1 === EOF) {
               break;
             }
             dict.set(key, this.getObj(cipherTransform));
           }
-          if (isEOF(this.buf1)) {
+          if (this.buf1 === EOF) {
             if (this.recoveryMode) {
               return dict;
             }
@@ -498,13 +497,13 @@ class Parser {
     // Parse dictionary.
     const dict = new Dict(this.xref);
     let dictLength;
-    while (!isCmd(this.buf1, "ID") && !isEOF(this.buf1)) {
+    while (!isCmd(this.buf1, "ID") && this.buf1 !== EOF) {
       if (!isName(this.buf1)) {
         throw new FormatError("Dictionary key must be a name object");
       }
       const key = this.buf1.name;
       this.shift();
-      if (isEOF(this.buf1)) {
+      if (this.buf1 === EOF) {
         break;
       }
       dict.set(key, this.getObj(cipherTransform));

--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -16,7 +16,7 @@
 import { assert, shadow, unreachable } from "../shared/util.js";
 import { BaseStream } from "./base_stream.js";
 
-const EOF = {};
+const EOF = Symbol("EOF");
 
 const Name = (function NameClosure() {
   let nameCache = Object.create(null);
@@ -338,10 +338,6 @@ class RefSetCache {
   }
 }
 
-function isEOF(v) {
-  return v === EOF;
-}
-
 function isName(v, name) {
   return v instanceof Name && (name === undefined || v.name === name);
 }
@@ -390,7 +386,6 @@ export {
   EOF,
   isCmd,
   isDict,
-  isEOF,
   isName,
   isRef,
   isRefsEqual,

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -16,10 +16,8 @@
 import {
   Cmd,
   Dict,
-  EOF,
   isCmd,
   isDict,
-  isEOF,
   isName,
   isRef,
   isRefsEqual,
@@ -470,17 +468,6 @@ describe("primitives", function () {
         values.push(value);
       });
       expect(values).toEqual([obj1, obj2]);
-    });
-  });
-
-  describe("isEOF", function () {
-    it("handles non-EOF", function () {
-      const nonEOF = "foo";
-      expect(isEOF(nonEOF)).toEqual(false);
-    });
-
-    it("handles EOF", function () {
-      expect(isEOF(EOF)).toEqual(true);
     });
   });
 


### PR DESCRIPTION
Given how trivial the `isEOF` function is, we can simply inline the check at the various call-sites and remove the function (which ought to be ever so slightly more efficient as well).
Furthermore, this patch also changes the `EOF` primitive itself to a `Symbol` instead of an Object since that has the nice benefit of making it unclonable (thus preventing *accidentally* trying to send `EOF` from the worker-thread).