### PR TITLE
Update the Annotation `--zoom-factor` CSS variable when `PDFPageView` is used standalone (PR 13868 follow-up)

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -202,7 +202,6 @@ class BaseViewer {
     } else {
       this.renderingQueue = options.renderingQueue;
     }
-
     this._doc = document.documentElement;
 
     this.scroll = watchScroll(this.container, this._scrollUpdate.bind(this));
@@ -708,7 +707,6 @@ class BaseViewer {
       }
       return;
     }
-
     this._doc.style.setProperty("--zoom-factor", newScale);
 
     for (let i = 0, ii = this._pages.length; i < ii; i++) {

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -110,6 +110,7 @@ class PDFPageView {
     this.renderingState = RenderingStates.INITIAL;
     this.resume = null;
     this._renderError = null;
+    this._isStandalone = !this.renderingQueue?.hasViewer();
 
     this.annotationLayer = null;
     this.textLayer = null;
@@ -280,6 +281,10 @@ class PDFPageView {
     }
     if (optionalContentConfigPromise instanceof Promise) {
       this._optionalContentConfigPromise = optionalContentConfigPromise;
+    }
+    if (this._isStandalone) {
+      const doc = document.documentElement;
+      doc.style.setProperty("--zoom-factor", this.scale);
     }
 
     const totalRotation = (this.rotation + this.pdfPageRotate) % 360;

--- a/web/pdf_rendering_queue.js
+++ b/web/pdf_rendering_queue.js
@@ -61,6 +61,13 @@ class PDFRenderingQueue {
   }
 
   /**
+   * @returns {boolean}
+   */
+  hasViewer() {
+    return !!this.pdfViewer;
+  }
+
+  /**
    * @param {Object} currentlyVisiblePages
    */
   renderHighestPriority(currentlyVisiblePages) {


### PR DESCRIPTION
Without this patch, when using `PDFPageView` directly[1] this CSS variable won't be updated and consequently things won't work as intended.
This is purposely implemented such that when a `PDFPageView`-instance is part of a viewer, we don't repeatedly set the CSS variable for every single page.

---
[1] See e.g. the "pageviewer" example in the `examples/components/` folder.