### PR TITLE
[api-minor] Remove the closure from the `PDFWorker` class, in the `src/display/api.js` file

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -501,7 +501,7 @@ describe("api", function () {
         pending("Worker is not supported in Node.js.");
       }
 
-      const workerSrc = PDFWorker.getWorkerSrc();
+      const workerSrc = PDFWorker.workerSrc;
       expect(typeof workerSrc).toEqual("string");
       expect(workerSrc).toEqual(GlobalWorkerOptions.workerSrc);
     });

--- a/web/app.js
+++ b/web/app.js
@@ -2139,7 +2139,7 @@ async function loadFakeWorker() {
     window.pdfjsWorker = await import("pdfjs/core/worker.js");
     return undefined;
   }
-  return loadScript(PDFWorker.getWorkerSrc());
+  return loadScript(PDFWorker.workerSrc);
 }
 
 function loadAndEnablePDFBug(enabledTabs) {


### PR DESCRIPTION
This patch removes the only remaining closure in the `src/display/api.js` file, utilizing a similar approach as used in lots of other parts of the code-base, which results in a small decrease in the size of the *build* `pdf.js` file.

Given that `PDFWorker` is exposed through the *public* API, this complicates things somewhat since there's a couple of worker-related properties that really should stay *private*. Initially, while working on PR #13813, I believed that we'd need support for private (static) class fields in order to get rid of this closure, however I've managed to come up with what's hopefully deemed an acceptable work-around here.
Furthermore, some helper functions were simply moved into the `PDFWorker` class as static methods, thus simplifying the overall implementation (e.g. we don't need to manually cache the Promise in the `PDFWorker._setupFakeWorkerGlobal`-method).

Finally, as part of this re-factoring a number of missing JSDoc-comments were added which *together* with the removal of the closure significantly improves the `gulp jsdoc` output for the `PDFWorker` class.

*Please note:* This patch is tagged with `api-minor` since it deprecates `PDFWorker.getWorkerSrc()` in favor of the shorter `PDFWorker.workerSrc`, with the fallback limited to `GENERIC` builds.