### PR TITLE
Update some deprecated ESLint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -46,6 +46,7 @@
     }],
     "unicorn/no-abusive-eslint-disable": "error",
     "unicorn/no-array-push-push": "error",
+    "unicorn/no-new-buffer": "error",
     "unicorn/no-instanceof-array": "error",
     "unicorn/no-useless-spread": "error",
     "unicorn/prefer-string-starts-ends-with": "error",
@@ -136,7 +137,6 @@
     "strict": ["off", "global"],
 
     // Variables
-    "no-catch-shadow": "error",
     "no-delete-var": "error",
     "no-label-var": "error",
     "no-shadow": "error",
@@ -152,9 +152,6 @@
       "classes": false,
       "variables": false,
     }],
-
-    // Node.js and CommonJS
-    "no-buffer-constructor": "error",
 
     // Stylistic Issues
     "lines-between-class-members": ["error", "always"],


### PR DESCRIPTION
Please see https://eslint.org/docs/rules/#deprecated where the following rules apply to the PDF.js project:
 - [`no-buffer-constructor`](https://eslint.org/docs/rules/no-buffer-constructor), which we can replace with the `unicorn/no-new-buffer` rule; see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-new-buffer.md
 - [`no-catch-shadow`](https://eslint.org/docs/rules/no-catch-shadow), which was replaced by the `no-shadow` rule (that we're already using).