### PR TITLE
Move some validation, in `Dict.merge`, used during merging of sub-dictionaries (PR 13775 follow-up)

### DIFF
--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -197,8 +197,11 @@ class Dict {
         if (property === undefined) {
           property = [];
           properties.set(key, property);
-        } else if (!mergeSubDicts) {
-          continue; // Ignore additional entries for a "shallow" merge.
+        } else if (!mergeSubDicts || !(value instanceof Dict)) {
+          // Ignore additional entries, if either:
+          //  - This is a "shallow" merge, where only the first element matters.
+          //  - The value is *not* a `Dict`, since other types cannot be merged.
+          continue;
         }
         property.push(value);
       }
@@ -211,9 +214,6 @@ class Dict {
       const subDict = new Dict(xref);
 
       for (const dict of values) {
-        if (!(dict instanceof Dict)) {
-          continue;
-        }
         for (const [key, value] of Object.entries(dict._map)) {
           if (subDict._map[key] === undefined) {
             subDict._map[key] = value;


### PR DESCRIPTION
By not adding any additional non-`Dict` entries to the list of candidates for merging of sub-dictionaries, we can very slightly reduce the amount of parsing required by not having to *again* iterate through unmergeable data.