### PR TITLE
[Regression] Re-factor the *internal* `includeAnnotationStorage` handling, since it's currently subtly wrong

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -49,6 +49,7 @@
     "unicorn/no-new-buffer": "error",
     "unicorn/no-instanceof-array": "error",
     "unicorn/no-useless-spread": "error",
+    "unicorn/prefer-date-now": "error",
     "unicorn/prefer-string-starts-ends-with": "error",
 
     // Possible errors

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -320,7 +320,14 @@ class Page {
     });
   }
 
-  getOperatorList({ handler, sink, task, intent, annotationStorage }) {
+  getOperatorList({
+    handler,
+    sink,
+    task,
+    intent,
+    cacheKey,
+    annotationStorage = null,
+  }) {
     const contentStreamPromise = this.getContentStream(handler);
     const resourcesPromise = this.loadResources([
       "ColorSpace",
@@ -354,7 +361,7 @@ class Page {
           this.nonBlendModesSet
         ),
         pageIndex: this.pageIndex,
-        intent,
+        cacheKey,
       });
 
       return partialEvaluator
@@ -377,7 +384,7 @@ class Page {
           pageOpList.flush(true);
           return { length: pageOpList.totalLength };
         }
-        const renderForms = !!(intent & RenderingIntentFlag.ANNOTATION_FORMS),
+        const renderForms = !!(intent & RenderingIntentFlag.ANNOTATIONS_FORMS),
           intentAny = !!(intent & RenderingIntentFlag.ANY),
           intentDisplay = !!(intent & RenderingIntentFlag.DISPLAY),
           intentPrint = !!(intent & RenderingIntentFlag.PRINT);

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -688,6 +688,7 @@ class WorkerMessageHandler {
             sink,
             task,
             intent: data.intent,
+            cacheKey: data.cacheKey,
             annotationStorage: data.annotationStorage,
           })
           .then(

--- a/src/display/annotation_storage.js
+++ b/src/display/annotation_storage.js
@@ -21,6 +21,7 @@ import { objectFromMap } from "../shared/util.js";
 class AnnotationStorage {
   constructor() {
     this._storage = new Map();
+    this._timeStamp = Date.now();
     this._modified = false;
 
     // Callbacks to signal when the modification state is set or reset.
@@ -41,8 +42,7 @@ class AnnotationStorage {
    * @returns {Object}
    */
   getValue(key, defaultValue) {
-    const obj = this._storage.get(key);
-    return obj !== undefined ? obj : defaultValue;
+    return this._storage.get(key) ?? defaultValue;
   }
 
   /**
@@ -64,10 +64,11 @@ class AnnotationStorage {
         }
       }
     } else {
-      this._storage.set(key, value);
       modified = true;
+      this._storage.set(key, value);
     }
     if (modified) {
+      this._timeStamp = Date.now();
       this._setModified();
     }
   }
@@ -107,6 +108,14 @@ class AnnotationStorage {
    */
   get serializable() {
     return this._storage.size > 0 ? this._storage : null;
+  }
+
+  /**
+   * PLEASE NOTE: Only intended for usage within the API itself.
+   * @ignore
+   */
+  get lastModified() {
+    return this._timeStamp.toString();
   }
 }
 

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -18,11 +18,23 @@ import "./compatibility.js";
 const IDENTITY_MATRIX = [1, 0, 0, 1, 0, 0];
 const FONT_IDENTITY_MATRIX = [0.001, 0, 0, 0.001, 0, 0];
 
+/**
+ * Refer to the `WorkerTransport.getRenderingIntent`-method in the API, to see
+ * how these flags are being used:
+ *  - ANY, DISPLAY, and PRINT are the normal rendering intents, note the
+ *    `PDFPageProxy.{render, getOperatorList, getAnnotations}`-methods.
+ *  - ANNOTATIONS_FORMS, and ANNOTATIONS_STORAGE controls which annotations are
+ *    rendered onto the canvas, note the `renderInteractiveForms`- respectively
+ *    `includeAnnotationStorage`-options in the `PDFPageProxy.render`-method.
+ *  - OPLIST is used with the `PDFPageProxy.getOperatorList`-method, note the
+ *    `OperatorList`-constructor (on the worker-thread).
+ */
 const RenderingIntentFlag = {
   ANY: 0x01,
   DISPLAY: 0x02,
   PRINT: 0x04,
-  ANNOTATION_FORMS: 0x20,
+  ANNOTATIONS_FORMS: 0x10,
+  ANNOTATIONS_STORAGE: 0x20,
   OPLIST: 0x100,
 };
 


### PR DESCRIPTION
*This patch is very similar to the recently fixed `renderInteractiveForms`-options, see PR #13867.*
As far as I can tell, this *subtle* bug has existed ever since `AnnotationStorage`-support was first added in PR #12106 (a little over a year ago).

The value of the `includeAnnotationStorage`-option, as passed to the `PDFPageProxy.render` method, will (potentially) affect the size/content of the operatorList that's returned from the worker (for documents with forms).
Given that operatorLists will generally, unless they contain huge images, be cached in the API, repeated `PDFPageProxy.render` calls where the form-data has been changed by the user in between, can thus *wrongly* return a cached operatorList.

In the viewer we're only using the `includeAnnotationStorage`-option when printing, which is probably why this has gone unnoticed for so long. Note that we, for performance reasons, don't cache printing-operatorLists in the API.
However, there's nothing stopping an API-user from using the `includeAnnotationStorage`-option during "normal" rendering, which could thus result in *subtle* (and difficult to understand) rendering bugs.

In order to handle this, we need to know if the `AnnotationStorage`-instance has been updated since the last `PDFPageProxy.render` call. The most "correct" solution would obviously be to create a hash of the `AnnotationStorage` contents, however that would require adding a bunch of code, complexity, and runtime overhead.
Given that operatorList caching in the API doesn't have to be perfect[1], but only have to avoid *false* cache-hits, we can simplify things significantly be only keeping track of the last time that the `AnnotationStorage`-data was modified.

*Please note:* While working on this patch, I also noticed that the `renderInteractiveForms`- and `includeAnnotationStorage`-options in the `PDFPageProxy.render` method are mutually exclusive.[2]
Given that the various Annotation-related options in `PDFPageProxy.render` have been added at different times, this has unfortunately led to the current "messy" situation.[3]

---
[1] Note how we're already not caching operatorLists for pages with *huge* images, in order to save memory, hence there's no guarantee that operatorLists will always be cached.

[2] Setting both to `true` will result in undefined behaviour, since trying to insert `AnnotationStorage`-values into fields that are being excluded from the operatorList-building will obviously not work, which isn't at all clear from the documentation.

[3] My intention is to try and fix this in a follow-up PR, and I've got a WIP patch locally, however it will result in a number of API-observable changes.