### PR TITLE
[api-minor] Stop translating logical assignment in non-`legacy` builds (PR 12887 follow-up)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -208,9 +208,6 @@ function createWebpackConfig(
   }
   const babelExcludeRegExp = new RegExp(`(${babelExcludes.join("|")})`);
 
-  // Since logical assignment operators is a fairly new ECMAScript feature,
-  // for now we translate these regardless of the `SKIP_BABEL` value (with the
-  // exception of `MOZCENTRAL`/`TESTING`-builds where this isn't an issue).
   const babelPlugins = [
     "@babel/plugin-transform-modules-commonjs",
     [
@@ -221,9 +218,6 @@ function createWebpackConfig(
       },
     ],
   ];
-  if (!bundleDefines.MOZCENTRAL && !bundleDefines.TESTING) {
-    babelPlugins.push("@babel/plugin-proposal-logical-assignment-operators");
-  }
 
   const plugins = [];
   if (!disableLicenseHeader) {
@@ -1416,7 +1410,6 @@ function buildLibHelper(bundleDefines, inputStream, outputDir) {
       sourceType: "module",
       presets: skipBabel ? undefined : ["@babel/preset-env"],
       plugins: [
-        "@babel/plugin-proposal-logical-assignment-operators",
         "@babel/plugin-transform-modules-commonjs",
         [
           "@babel/plugin-transform-runtime",


### PR DESCRIPTION
When we started using logical assignment operators in the PDF.js project, the feature was new enough that browser support was somewhat limited. That should no longer be the case, since logical assignment has now been available for approximately one year.
Hence this patch, which (basically) reverts PR #12887, since using the Babel plugin unconditionally was never intended to be a permanent thing. For browsers/environments without native logical assignment support, users will now have to use a `legacy` build instead.

Please refer to the browser compatibility information on MDN:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND_assignment#browser_compatibility
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment#browser_compatibility
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_nullish_assignment#browser_compatibility

Note also the release information for the major browsers:
 - https://wiki.mozilla.org/Release_Management/Calendar
 - https://en.wikipedia.org/wiki/Google_Chrome_version_history
 - https://en.wikipedia.org/wiki/Safari_version_history#Safari_14