### PR TITLE
Re-factor the LocalTilingPatternCache to cache by Ref rather than Name (PR 12458 follow-up, issue 13780)

### DIFF
--- a/src/core/image_utils.js
+++ b/src/core/image_utils.js
@@ -21,7 +21,9 @@ class BaseLocalCache {
     if (this.constructor === BaseLocalCache) {
       unreachable("Cannot initialize BaseLocalCache.");
     }
-    if (!options || !options.onlyRefs) {
+    this._onlyRefs = (options && options.onlyRefs) === true;
+
+    if (!this._onlyRefs) {
       this._nameRefMap = new Map();
       this._imageMap = new Map();
     }
@@ -29,6 +31,9 @@ class BaseLocalCache {
   }
 
   getByName(name) {
+    if (this._onlyRefs) {
+      unreachable("Should not call `getByName` method.");
+    }
     const ref = this._nameRefMap.get(name);
     if (ref) {
       return this.getByRef(ref);
@@ -95,10 +100,6 @@ class LocalColorSpaceCache extends BaseLocalCache {
 class LocalFunctionCache extends BaseLocalCache {
   constructor(options) {
     super({ onlyRefs: true });
-  }
-
-  getByName(name) {
-    unreachable("Should not call `getByName` method.");
   }
 
   set(name = null, ref, data) {

--- a/src/core/image_utils.js
+++ b/src/core/image_utils.js
@@ -135,25 +135,18 @@ class LocalGStateCache extends BaseLocalCache {
 }
 
 class LocalTilingPatternCache extends BaseLocalCache {
-  set(name, ref = null, data) {
-    if (typeof name !== "string") {
-      throw new Error(
-        'LocalTilingPatternCache.set - expected "name" argument.'
-      );
+  constructor(options) {
+    super({ onlyRefs: true });
+  }
+
+  set(name = null, ref, data) {
+    if (!ref) {
+      throw new Error('LocalTilingPatternCache.set - expected "ref" argument.');
     }
-    if (ref) {
-      if (this._imageCache.has(ref)) {
-        return;
-      }
-      this._nameRefMap.set(name, ref);
-      this._imageCache.put(ref, data);
+    if (this._imageCache.has(ref)) {
       return;
     }
-    // name
-    if (this._imageMap.has(name)) {
-      return;
-    }
-    this._imageMap.set(name, data);
+    this._imageCache.put(ref, data);
   }
 }
 


### PR DESCRIPTION
This way there cannot be any *incorrect* cache hits, since Refs are guaranteed to be unique.
Please note that the reason for caching by Ref rather than doing something along the lines of the `localShadingPatternCache` (which uses a `Map` directly), is that TilingPatterns are streams and those cannot be cached on the `XRef`-instance (this way we avoid unnecessary parsing).

Fixes #13780
