### PR TITLE
Re-factor `loadAndEnablePDFBug` and `PDFBug.init`

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -377,7 +377,7 @@ const PDFViewerApplication = {
       AppOptions.set("fontExtraProperties", true);
 
       const enabled = params.get("pdfbug").split(",");
-      waitOn.push(loadAndEnablePDFBug(enabled));
+      waitOn.push(initPDFBug(enabled));
     }
     // It is not possible to change locale for the (various) extension builds.
     if (
@@ -2139,17 +2139,15 @@ async function loadFakeWorker() {
   }
   if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
     window.pdfjsWorker = await import("pdfjs/core/worker.js");
-    return undefined;
+    return;
   }
-  return loadScript(PDFWorker.workerSrc);
+  await loadScript(PDFWorker.workerSrc);
 }
 
-function loadAndEnablePDFBug(enabledTabs) {
-  const appConfig = PDFViewerApplication.appConfig;
-  return loadScript(appConfig.debuggerScriptPath).then(function () {
-    PDFBug.enable(enabledTabs);
-    PDFBug.init({ OPS }, appConfig.mainContainer);
-  });
+async function initPDFBug(enabledTabs) {
+  const { debuggerScriptPath, mainContainer } = PDFViewerApplication.appConfig;
+  await loadScript(debuggerScriptPath);
+  PDFBug.init({ OPS }, mainContainer, enabledTabs);
 }
 
 function reportPageStatsPDFBug({ pageNumber }) {

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -540,7 +540,8 @@ window.PDFBug = (function PDFBugClosure() {
         });
       }
     },
-    init(pdfjsLib, container) {
+    init(pdfjsLib, container, ids) {
+      this.enable(ids);
       /*
        * Basic Layout:
        * PDFBug
@@ -589,12 +590,8 @@ window.PDFBug = (function PDFBugClosure() {
           tool.init(pdfjsLib);
         } else {
           panel.textContent =
-            tool.name +
-            " is disabled. To enable add " +
-            ' "' +
-            tool.id +
-            '" to the pdfBug parameter ' +
-            "and refresh (separate multiple by commas).";
+            `${tool.name} is disabled. To enable add "${tool.id}" to ` +
+            "the pdfBug parameter and refresh (separate multiple by commas).";
         }
         buttons.push(panelButton);
       }


### PR DESCRIPTION
The `loadAndEnablePDFBug` helper function, in `web/app.js`, can be simplified a little bit by making it `async`. Furthermore, given how `PDFBug` is being used, we can also (slightly) re-factor `PDFBug.init` such that the `PDFBug.enable`-call is done internally rather than having to handle that manually at the call-site.

(Finally, utilize `await` more in the `loadFakeWorker` helper function.)