### PR TITLE
Ensure that the `TESTING` define can always be overridden in `gulpfile.js`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -90,7 +90,7 @@ const AUTOPREFIXER_CONFIG = {
 const DEFINES = Object.freeze({
   PRODUCTION: true,
   SKIP_BABEL: true,
-  TESTING: false,
+  TESTING: undefined,
   // The main build targets:
   GENERIC: false,
   MOZCENTRAL: false,
@@ -179,7 +179,10 @@ function createWebpackConfig(
   const bundleDefines = builder.merge(defines, {
     BUNDLE_VERSION: versionInfo.version,
     BUNDLE_BUILD: versionInfo.commit,
-    TESTING: defines.TESTING || process.env.TESTING === "true",
+    TESTING:
+      defines.TESTING !== undefined
+        ? defines.TESTING
+        : process.env.TESTING === "true",
     DEFAULT_PREFERENCES: defaultPreferencesDir
       ? getDefaultPreferences(defaultPreferencesDir)
       : {},
@@ -677,7 +680,10 @@ function buildDefaultPreferences(defines, dir) {
     SKIP_BABEL: false,
     BUNDLE_VERSION: 0, // Dummy version
     BUNDLE_BUILD: 0, // Dummy build
-    TESTING: defines.TESTING || process.env.TESTING === "true",
+    TESTING:
+      defines.TESTING !== undefined
+        ? defines.TESTING
+        : process.env.TESTING === "true",
   });
 
   const inputStream = merge([
@@ -1452,7 +1458,10 @@ function buildLib(defines, dir) {
   const bundleDefines = builder.merge(defines, {
     BUNDLE_VERSION: versionInfo.version,
     BUNDLE_BUILD: versionInfo.commit,
-    TESTING: defines.TESTING || process.env.TESTING === "true",
+    TESTING:
+      defines.TESTING !== undefined
+        ? defines.TESTING
+        : process.env.TESTING === "true",
     DEFAULT_PREFERENCES: getDefaultPreferences(
       defines.SKIP_BABEL ? "lib/" : "lib-legacy/"
     ),
@@ -1824,6 +1833,7 @@ gulp.task(
       const defines = builder.merge(DEFINES, {
         CHROME: true,
         SKIP_BABEL: false,
+        TESTING: false,
       });
       return buildDefaultPreferences(defines, "lint-chromium/");
     },

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -226,7 +226,9 @@ const defaultOptions = {
   },
   enableXfa: {
     /** @type {boolean} */
-    value: typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION"),
+    value:
+      typeof PDFJSDev === "undefined" ||
+      PDFJSDev.test("!PRODUCTION || TESTING"),
     kind: OptionKind.API + OptionKind.PREFERENCE,
   },
   fontExtraProperties: {


### PR DESCRIPTION
Currently a `TESTING = true` environment variable will *always* take precedence in the various build-tasks, and there's no way to explicitly disable it for a particular build. That's clearly an oversight on my part, however it's easy enough to fix this; sorry about breaking this!