### PR TITLE
Fix pdf_viewer definitions

### DIFF
--- a/external/dist/legacy/web/pdf_viewer.d.ts
+++ b/external/dist/legacy/web/pdf_viewer.d.ts
@@ -1,1 +1,1 @@
-export * from "pdfjs-dist/types/web/pdf_viewer.component.d.ts";
+export * from "pdfjs-dist/types/web/pdf_viewer.component";

--- a/external/dist/web/pdf_viewer.d.ts
+++ b/external/dist/web/pdf_viewer.d.ts
@@ -1,1 +1,1 @@
-export * from "pdfjs-dist/types/web/pdf_viewer.component.d.ts";
+export * from "pdfjs-dist/types/web/pdf_viewer.component";


### PR DESCRIPTION
Follow up to https://github.com/mozilla/pdf.js/pull/13588

Current pdf_viewer definitions result in errors like the following when trying to use them in a ts project:

```
[error] TypeScript error node_modules/.pnpm/pdfjs-dist@2.10.377/node_modules/pdfjs-dist/web/pdf_viewer.d.ts:1:15 - error TS2691: An import path cannot end with a '.d.ts' extension. Consider importing 'pdfjs-dist/types/web/pdf_viewer.component.js' instead.

1 export * from "pdfjs-dist/types/web/pdf_viewer.component.d.ts";
```

Import/export statements in typescript should not include file extensions.