### PR TITLE
Enable the ESLint `object-shorthand` rule in the `extensions/chromium/`-folder

### DIFF
--- a/extensions/chromium/.eslintrc
+++ b/extensions/chromium/.eslintrc
@@ -18,6 +18,5 @@
   "rules": {
     "mozilla/import-globals": "error",
     "no-var": "off",
-    "object-shorthand": "off",
   },
 }

--- a/extensions/chromium/options/migration.js
+++ b/extensions/chromium/options/migration.js
@@ -119,7 +119,7 @@ limitations under the License.
             // Overwrite if computed textLayerMode is not the default value (1).
             storageSync.set(
               {
-                textLayerMode: textLayerMode,
+                textLayerMode,
               },
               function () {
                 if (!chrome.runtime.lastError) {

--- a/extensions/chromium/pageAction/background.js
+++ b/extensions/chromium/pageAction/background.js
@@ -28,7 +28,7 @@ limitations under the License.
     if (url) {
       url = url[1];
       chrome.pageAction.setPopup({
-        tabId: tabId,
+        tabId,
         popup: "/pageAction/popup.html?file=" + encodeURIComponent(url),
       });
       chrome.pageAction.show(tabId);

--- a/extensions/chromium/pdfHandler-vcros.js
+++ b/extensions/chromium/pdfHandler-vcros.js
@@ -78,9 +78,9 @@ limitations under the License.
     if (windowId) {
       chrome.tabs.create(
         {
-          windowId: windowId,
+          windowId,
           active: true,
-          url: url,
+          url,
         },
         function () {
           openViewer(windowId, fileEntries);
@@ -91,7 +91,7 @@ limitations under the License.
         {
           type: "normal",
           focused: true,
-          url: url,
+          url,
         },
         function (chromeWindow) {
           openViewer(chromeWindow.id, fileEntries);

--- a/extensions/chromium/pdfHandler.js
+++ b/extensions/chromium/pdfHandler.js
@@ -242,12 +242,12 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
       chrome.tabs.create({
         windowId: sender.tab.windowId,
         index: sender.tab.index + 1,
-        url: url,
+        url,
         openerTabId: sender.tab.id,
       });
     } else {
       chrome.tabs.update(sender.tab.id, {
-        url: url,
+        url,
       });
     }
   }

--- a/extensions/chromium/preserve-referer.js
+++ b/extensions/chromium/preserve-referer.js
@@ -123,7 +123,7 @@ chrome.runtime.onConnect.addListener(function onReceivePort(port) {
         {
           urls: [data.requestUrl],
           types: ["xmlhttprequest"],
-          tabId: tabId,
+          tabId,
         },
         ["blocking", ...extraInfoSpecWithHeaders]
       );
@@ -148,7 +148,7 @@ chrome.runtime.onConnect.addListener(function onReceivePort(port) {
     {
       urls: ["https://*/*"],
       types: ["xmlhttprequest"],
-      tabId: tabId,
+      tabId,
     },
     ["blocking", "responseHeaders"]
   );


### PR DESCRIPTION
Based on the following compatibility information, there can't be any compelling reason to not enable this ESLint rule now: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#browser_compatibility

See also https://eslint.org/docs/rules/object-shorthand