### PR TITLE
Fix Viewer API definitions and include in CI

### DIFF
--- a/external/dist/legacy/web/pdf_viewer.d.ts
+++ b/external/dist/legacy/web/pdf_viewer.d.ts
@@ -1,1 +1,1 @@
-export * from "pdfjs-dist/types/web/pdf_viewer.component";
+export * from "../../types/web/pdf_viewer.component";

--- a/external/dist/web/pdf_viewer.d.ts
+++ b/external/dist/web/pdf_viewer.d.ts
@@ -1,1 +1,1 @@
-export * from "pdfjs-dist/types/web/pdf_viewer.component";
+export * from "../types/web/pdf_viewer.component";

--- a/test/types/main.ts
+++ b/test/types/main.ts
@@ -1,9 +1,12 @@
 import { getDocument } from "pdfjs-dist";
+import { EventBus } from "pdfjs-dist/web/pdf_viewer.component";
 
 class MainTest {
+  eventBus: EventBus;
   task: ReturnType<typeof getDocument> | undefined;
 
   constructor(public file: string) {
+    this.eventBus = new EventBus({});
   }
 
   loadPdf() {

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -17,7 +17,7 @@
     ],
     "paths": {
       "pdfjs-dist": ["../../build/typestest"],
-      "pdfjs-dist/*": ["../../build/typestest/build/*"]
+      "pdfjs-dist/*": ["../../build/typestest/types/*"]
     }
   },
   "files": [

--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -13,6 +13,9 @@
  * limitations under the License.
  */
 
+// eslint-disable-next-line max-len
+/** @typedef {import("./interfaces").IPDFAnnotationLayerFactory} IPDFAnnotationLayerFactory */
+
 import { AnnotationLayer } from "pdfjs-lib";
 import { NullL10n } from "./l10n_utils.js";
 import { SimpleLinkService } from "./pdf_link_service.js";

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -139,7 +139,6 @@ function isSameScale(oldScale, newScale) {
 
 /**
  * Simple viewer control to display PDF content/pages.
- * @implements {IRenderableView}
  */
 class BaseViewer {
   /**

--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -106,6 +106,11 @@ class IPDFLinkService {
  * @interface
  */
 class IRenderableView {
+  constructor() {
+    /** @type {function | null} */
+    this.resume = null;
+  }
+
   /**
    * @type {string} - Unique ID for rendering queue.
    */
@@ -120,8 +125,6 @@ class IRenderableView {
    * @returns {Promise} Resolved on draw completion.
    */
   draw() {}
-
-  resume() {}
 }
 
 /**

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+/** @typedef {import("./interfaces").IPDFLinkService} IPDFLinkService */
+
 import { parseQueryString } from "./ui_utils.js";
 
 /**

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+/** @typedef {import("./interfaces").IRenderableView} IRenderableView */
+
 import {
   AnnotationMode,
   createPromiseCapability,

--- a/web/pdf_rendering_queue.js
+++ b/web/pdf_rendering_queue.js
@@ -33,6 +33,7 @@ class PDFRenderingQueue {
     this.pdfThumbnailViewer = null;
     this.onIdle = null;
     this.highestPriorityPage = null;
+    /** @type {number} */
     this.idleTimeout = null;
     this.printing = false;
     this.isThumbnailViewEnabled = false;

--- a/web/struct_tree_layer_builder.js
+++ b/web/struct_tree_layer_builder.js
@@ -13,6 +13,9 @@
  * limitations under the License.
  */
 
+// eslint-disable-next-line max-len
+/** @typedef {import("./interfaces").IPDFStructTreeLayerFactory} IPDFStructTreeLayerFactory */
+
 const PDF_ROLE_TO_HTML_ROLE = {
   // Document level structure types
   Document: null, // There's a "document" role, but it doesn't make sense here.

--- a/web/text_highlighter.js
+++ b/web/text_highlighter.js
@@ -14,7 +14,7 @@
  */
 
 /**
- * @typedef {Object} TextHighlighter
+ * @typedef {Object} TextHighlighterOptions
  * @property {PDFFindController} findController
  * @property {EventBus} eventBus - The application event bus.
  * @property {number} pageIndex - The page index.
@@ -25,6 +25,9 @@
  * either the text layer or XFA layer depending on the type of document.
  */
 class TextHighlighter {
+  /**
+   * @param {TextHighlighterOptions} options
+   */
   constructor({ findController, eventBus, pageIndex }) {
     this.findController = findController;
     this.matches = [];

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -13,6 +13,9 @@
  * limitations under the License.
  */
 
+// eslint-disable-next-line max-len
+/** @typedef {import("./interfaces").IPDFTextLayerFactory} IPDFTextLayerFactory */
+
 import { renderTextLayer } from "pdfjs-lib";
 
 const EXPAND_DIVS_TIMEOUT = 300; // ms

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -285,11 +285,22 @@ function roundToDivide(x, div) {
 }
 
 /**
+ * @typedef {Object} GetPageSizeInchesParameters
+ * @property {number[]} view
+ * @property {number} userUnit
+ * @property {number} rotate
+ */
+
+/**
+ * @typedef {Object} PageSize
+ * @property {number} width - In inches.
+ * @property {number} height - In inches.
+ */
+
+/**
  * Gets the size of the specified page, converted from PDF units to inches.
- * @param {Object} An Object containing the properties: {Array} `view`,
- *   {number} `userUnit`, and {number} `rotate`.
- * @returns {Object} An Object containing the properties: {number} `width`
- *   and {number} `height`, given in inches.
+ * @param {GetPageSizeInchesParameters} params
+ * @returns {PageSize}
  */
 function getPageSizeInches({ view, userUnit, rotate }) {
   const [x1, y1, x2, y2] = view;

--- a/web/xfa_layer_builder.js
+++ b/web/xfa_layer_builder.js
@@ -13,12 +13,15 @@
  * limitations under the License.
  */
 
+/** @typedef {import("./interfaces").IPDFXfaLayerFactory} IPDFXfaLayerFactory */
+
 import { XfaLayer } from "pdfjs-lib";
 
 /**
  * @typedef {Object} XfaLayerBuilderOptions
  * @property {HTMLDivElement} pageDiv
  * @property {PDFPage} pdfPage
+ * @property {Object} [xfaHtml]
  * @property {AnnotationStorage} [annotationStorage]
  */
 


### PR DESCRIPTION
The Viewer API definitions do not compile because of missing imports and
anonymous objects are typed as `Object`. These issues were not caught
during CI because the test project was not compiling anything from the
Viewer API.

As an example of the first problem:

```
/**
 * @implements MyInterface
 */
export class MyClass {
    ...
}
```

will generate a broken definition that doesn’t import MyInterface:

```
/**
 * @implements MyInterface
 */
export class MyClass implements MyInterface {
    ...
}
```

This can be fixed by adding a typedef jsdoc to specify the import:

```
/** @typedef {import("./otherFile").MyInterface} MyInterface */
```

See https://github.com/jsdoc/jsdoc/issues/1537 and
https://github.com/microsoft/TypeScript/issues/22160 for more details.

As an example of the second problem:

```
/**
 * Gets the size of the specified page, converted from PDF units to inches.
 * @param {Object} An Object containing the properties: {Array} `view`,
 *   {number} `userUnit`, and {number} `rotate`.
 */
function getPageSizeInches({ view, userUnit, rotate }) {
    ...
}
```

generates the broken definition:

```
function getPageSizeInches({ view, userUnit, rotate }: Object) {
    ...
}
```

The jsdoc should specify the type of each nested property:

```
/**
 * Gets the size of the specified page, converted from PDF units to inches.
 * @param {Object} options An object containing the properties: {Array} `view`,
 *   {number} `userUnit`, and {number} `rotate`.
 * @param {number[]} options.view
 * @param {number} options.userUnit
 * @param {number} options.rotate
 */
```