### PR TITLE
Fix saving of XFA checkboxes. (bug 1726381)

### DIFF
--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -1265,8 +1265,8 @@ class CheckButton extends XFAObject {
         field.items.children[0][$toHTML]().html) ||
       [];
     const exportedValue = {
-      on: (items[0] || "on").toString(),
-      off: (items[1] || "off").toString(),
+      on: (items[0] !== undefined ? items[0] : "on").toString(),
+      off: (items[1] !== undefined ? items[1] : "off").toString(),
     };
 
     const value = (field.value && field.value[$text]()) || "off";
@@ -1296,6 +1296,7 @@ class CheckButton extends XFAObject {
         type,
         checked,
         xfaOn: exportedValue.on,
+        xfaOff: exportedValue.off,
         "aria-label": ariaLabel(field),
       },
     };

--- a/src/display/xfa_layer.js
+++ b/src/display/xfa_layer.js
@@ -42,7 +42,11 @@ class XfaLayer {
             break;
           }
           html.addEventListener("change", event => {
-            storage.setValue(id, { value: event.target.getAttribute("xfaOn") });
+            storage.setValue(id, {
+              value: event.target.checked
+                ? event.target.getAttribute("xfaOn")
+                : event.target.getAttribute("xfaOff"),
+            });
           });
         } else {
           if (storedData.value !== null) {


### PR DESCRIPTION
Previously were were always setting the storage value to the on value.

I'd like to add a test for this, but it's proving difficult to intercept the save file. My plan is to add a mozilla central test since we already have some tests for saving acroforms there.