### PR TITLE
Remove the `IPDFHistory` interface

### DIFF
--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -105,34 +105,6 @@ class IPDFLinkService {
 /**
  * @interface
  */
-class IPDFHistory {
-  /**
-   * @param {Object} params
-   */
-  initialize({ fingerprint, resetHistory = false, updateUrl = false }) {}
-
-  reset() {}
-
-  /**
-   * @param {Object} params
-   */
-  push({ namedDest = null, explicitDest, pageNumber }) {}
-
-  /**
-   * @param {number} pageNumber
-   */
-  pushPage(pageNumber) {}
-
-  pushCurrentPosition() {}
-
-  back() {}
-
-  forward() {}
-}
-
-/**
- * @interface
- */
 class IRenderableView {
   /**
    * @type {string} - Unique ID for rendering queue.
@@ -265,7 +237,6 @@ class IL10n {
 export {
   IL10n,
   IPDFAnnotationLayerFactory,
-  IPDFHistory,
   IPDFLinkService,
   IPDFStructTreeLayerFactory,
   IPDFTextLayerFactory,


### PR DESCRIPTION
Generalizing, and documenting, the `PDFHistory`-implementation as part of the web-interfaces doesn't seem entirely necessary and in hindsight I'm not entirely sure why we need it since:

 - The `PDFHistory` implementation is/was written specifically for the default viewer use-case, which is why e.g. the `simpleviewer` component example isn't using it. (While it *could* be used there, it'd need to be manually created/initialized correctly.)

 - There's only *one* `PDFHistory`-implementation present (and no other viewer-component will fail without it being available), as opposed to the other web-interfaces documented in this file.

 - The `PDFHistory` implementation is not even usable with e.g. the `pageviewer` component example, since it (obviously) requires a complete viewer to work. (This is in contrast to e.g. `IPDFTextLayerFactory` and `IPDFAnnotationLayerFactory`.)