### PR TITLE
A couple of small `TextHighlighter`/`TextLayerBuilder` tweaks (PR 13908 follow-up)

### DIFF
--- a/web/text_highlighter.js
+++ b/web/text_highlighter.js
@@ -167,7 +167,7 @@ class TextHighlighter {
 
     function appendTextToDiv(divIdx, fromOffset, toOffset, className) {
       let div = textDivs[divIdx];
-      if (div.nodeType === 3) {
+      if (div.nodeType === Node.TEXT_NODE) {
         const span = document.createElement("span");
         div.parentNode.insertBefore(span, div);
         span.appendChild(div);

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -49,9 +49,7 @@ class TextLayerBuilder {
     this.textContentItemsStr = [];
     this.textContentStream = null;
     this.renderingDone = false;
-    this.pageIdx = pageIndex;
-    this.pageNumber = this.pageIdx + 1;
-    this.matches = [];
+    this.pageNumber = pageIndex + 1;
     this.viewport = viewport;
     this.textDivs = [];
     this.textLayerRenderTask = null;


### PR DESCRIPTION
 - Use `Node.TEXT_NODE` rather than a magical constant, in `TextHighlighter._convertMatches`, to improve readability. According to MDN, this has been supported since "forever": https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType#browser_compatibility

 - Remove the `pageIdx`-property, on `TextLayerBuilder`-instances, since the re-factoring in PR #13908 meant that it's now unused.

 - Remove the `matches`-property, on `TextLayerBuilder`-instances, since the re-factoring in PR #13908 meant that it's now unused.