### PR TITLE
Fix handling of fetch errors

### DIFF
--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -290,7 +290,7 @@ class ChunkedStreamManager {
 
     let chunks = [],
       loaded = 0;
-    const promise = new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       const readChunk = chunk => {
         try {
           if (!chunk.done) {
@@ -311,14 +311,12 @@ class ChunkedStreamManager {
         }
       };
       rangeReader.read().then(readChunk, reject);
-    });
-    promise.then(data => {
+    }).then(data => {
       if (this.aborted) {
         return; // Ignoring any data after abort.
       }
       this.onReceiveData({ chunk: data, begin });
     });
-    // TODO check errors
   }
 
   /**
@@ -369,7 +367,7 @@ class ChunkedStreamManager {
           groupedChunk.endChunk * this.chunkSize,
           this.length
         );
-        this.sendRequest(begin, end);
+        this.sendRequest(begin, end).catch(capability.reject);
       }
     }
 

--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -247,12 +247,7 @@ class PDFFetchStreamRangeReader {
         this._readCapability.resolve();
         this._reader = response.body.getReader();
       })
-      .catch(reason => {
-        if (reason?.name === "AbortError") {
-          return;
-        }
-        throw reason;
-      });
+      .catch(this._readCapability.reject);
 
     this.onProgress = null;
   }


### PR DESCRIPTION
Hi!

We at @overleaf noticed that the error handling of network downloads is incomplete in a few scenarios.

We are hosting a lot of user content on a large cluster of VMs that scales with load. As VMs go, users will see 404s for downloads that reference PDFs on an old VM. Our user base is very diverse and so are the networks they access this content from, leading to occasional increases of network errors that are out of our control.

When downloads fail, our frontend got stuck in waiting for PDF.js to render or cleanup an instance -- despite already seeing network errors from the OS/browser in the Developer Tools.
These errors would turn up in the console as unhandled promise rejections and never reached our frontend code.

This PR is making sure that network errors make it to the call-sites.

Testing:
- delete the pdf file while the initial request is inflight
- delete the pdf file after the initial request has finished

Repeat for a small file and large file, exercising both one-off and chunked transports.

We are seeing good results with the patch (rebased on top of v2.2.288) in production over the course of the past 2 months.

I ran the test suite as per the docs and it passed -- apart from a few pixel imperfections that seem to be unrelated to the patch, see example below.

<details>

![image](https://user-images.githubusercontent.com/17931887/130961885-c6b48899-26e7-484d-aa0a-c56bef2ea317.png)
</details>