### PR TITLE
Remove the `npm test`-command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
         run: npm install
 
       - name: Run tests
-        run: npm test
+        run: gulp ci-test

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2348,7 +2348,7 @@ gulp.task("externaltest", function (done) {
 });
 
 gulp.task(
-  "npm-test",
+  "ci-test",
   gulp.series(
     gulp.parallel("lint", "externaltest", "unittestcli"),
     "lint-chromium",

--- a/package.json
+++ b/package.json
@@ -64,8 +64,7 @@
     "yargs": "^17.1.1"
   },
   "scripts": {
-    "postinstall": "cross-env PUPPETEER_PRODUCT=firefox node node_modules/puppeteer/install.js",
-    "test": "gulp npm-test"
+    "postinstall": "cross-env PUPPETEER_PRODUCT=firefox node node_modules/puppeteer/install.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This command was added all the way back when basic CI-support was first introduced (using Travis at the time), however it's never really intended to be used e.g. for local development.
By having a `npm test`-command listed in the `package.json` file, there's a very real risk that someone unfamiliar with the code-base would only run that one and thus miss all the other (more important) test-suites[1].

Hence this patch which removes the `npm test`-command, and instead simply calls the relevant gulp-task[2] directly in the GitHub Actions configuration.

---
[1] Which consist of the unit-tests (run in browsers), the font-tests (potentially), the reference-tests, and the integration-tests.

[2] Which is also renamed slightly, to better fit its current usage.