### PR TITLE
Simplify the `PDFViewerApplication.supportsFullscreen` getter

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -679,21 +679,13 @@ const PDFViewerApplication = {
     if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
       return shadow(this, "supportsFullscreen", document.fullscreenEnabled);
     }
-    const doc = document.documentElement;
-    let support = !!(
-      doc.requestFullscreen ||
-      doc.mozRequestFullScreen ||
-      doc.webkitRequestFullScreen
+    return shadow(
+      this,
+      "supportsFullscreen",
+      document.fullscreenEnabled ||
+        document.mozFullScreenEnabled ||
+        document.webkitFullscreenEnabled
     );
-
-    if (
-      document.fullscreenEnabled === false ||
-      document.mozFullScreenEnabled === false ||
-      document.webkitFullscreenEnabled === false
-    ) {
-      support = false;
-    }
-    return shadow(this, "supportsFullscreen", support);
   },
 
   get supportsIntegratedFind() {

--- a/web/app.js
+++ b/web/app.js
@@ -853,12 +853,8 @@ const PDFViewerApplication = {
     this.pdfAttachmentViewer.reset();
     this.pdfLayerViewer.reset();
 
-    if (this.pdfHistory) {
-      this.pdfHistory.reset();
-    }
-    if (this.findBar) {
-      this.findBar.reset();
-    }
+    this.pdfHistory?.reset();
+    this.findBar?.reset();
     this.toolbar.reset();
     this.secondaryToolbar.reset();
 
@@ -1850,9 +1846,7 @@ const PDFViewerApplication = {
       this.printService.destroy();
       this.printService = null;
 
-      if (this.pdfDocument) {
-        this.pdfDocument.annotationStorage.resetModified();
-      }
+      this.pdfDocument?.annotationStorage.resetModified();
     }
     this.forceRendering();
   },
@@ -1864,10 +1858,7 @@ const PDFViewerApplication = {
   },
 
   requestPresentationMode() {
-    if (!this.pdfPresentationMode) {
-      return;
-    }
-    this.pdfPresentationMode.request();
+    this.pdfPresentationMode?.request();
   },
 
   triggerPrinting() {


### PR DESCRIPTION
 - Use optional chaining even more in the `web/app.js` file

 - Simplify the `PDFViewerApplication.supportsFullscreen` getter
   
   A lot of the code in this getter has existed ever since the initial PresentationMode-implementation was first added all the way back in PR #1938 (which is *nine* years ago now).
   At this point in time however, there's now a simpler way detect if a browser supports the FullScreen API and we should thus be able to simplify this getter; please refer to https://developer.mozilla.org/en-US/docs/Web/API/Document/fullscreenEnabled#browser_compatibility