### PR TITLE
Ensure that `PasswordException` is handled correctly in the `wrapReason` function

### DIFF
--- a/src/shared/message_handler.js
+++ b/src/shared/message_handler.js
@@ -18,6 +18,7 @@ import {
   assert,
   createPromiseCapability,
   MissingPDFException,
+  PasswordException,
   UnexpectedResponseException,
   UnknownErrorException,
   warn,
@@ -64,6 +65,8 @@ function wrapReason(reason) {
       return new AbortException(reason.message);
     case "MissingPDFException":
       return new MissingPDFException(reason.message);
+    case "PasswordException":
+      return new PasswordException(reason.message, reason.code);
     case "UnexpectedResponseException":
       return new UnexpectedResponseException(reason.message, reason.status);
     case "UnknownErrorException":


### PR DESCRIPTION
While running the unit-tests with some logging statements added to this code, I noticed that `PasswordException` was missing from the list of potential Errors that could be passed to the `wrapReason` function.