### PR TITLE
Always prefer the post-table for TrueType fonts with (0, x) cmap-tables (issue 13433)

### DIFF
--- a/test/pdfs/issue13433.pdf.link
+++ b/test/pdfs/issue13433.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/6537699/pos36.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1294,6 +1294,14 @@
        "enableXfa": true,
        "type": "eq"
     },
+    {  "id": "issue13433",
+       "file": "pdfs/issue13433.pdf",
+       "md5": "4038cd87ff48fd54b3c4a36593d2ba03",
+       "link": true,
+       "rounds": 1,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "xfa_issue13668",
        "file": "pdfs/xfa_issue13668.pdf",
        "md5": "8a5ed3c8a58b425b1ec53329334a0f5b",


### PR DESCRIPTION
While I don't know if this is necessarily the "correct" solution, it does fix issue 13433 without breaking any of the existing reference-tests.