### PR TITLE
Add app options to limit print range

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1819,6 +1819,14 @@ const PDFViewerApplication = {
       optionalContentConfigPromise,
       this.l10n
     );
+    const printRangeStart = AppOptions.get("printRangeStart");
+    const printRangeEnd = AppOptions.get("printRangeEnd");
+    if (printRangeStart > 0 && printRangeEnd > 0)
+    {
+      printService.currentPage = printRangeStart - 2;
+      printService.pagesOverview = printService.pagesOverview.slice(0, printRangeEnd);
+    }
+
     this.printService = printService;
     this.forceRendering();
 

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -140,6 +140,16 @@ const defaultOptions = {
     value: typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION"),
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
+  printRangeStart: {
+    /** @type {number} */
+    value: 0,
+    kind: OptionKind.VIEWER,
+  },
+  printRangeEnd: {
+    /** @type {number} */
+    value: 0,
+    kind: OptionKind.VIEWER,
+  },
   printResolution: {
     /** @type {number} */
     value: 150,


### PR DESCRIPTION
This adds application options which allow to limit which pages are
rendered when printing. This is not usefull for the default viewer
but allows applications to programatically print specifc pages
independent of user selection.