### PR TITLE
Export RenderTask type

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -3364,6 +3364,7 @@ export {
   PDFDocumentProxy,
   PDFPageProxy,
   PDFWorker,
+  RenderTask,
   setPDFNetworkStreamFactory,
   version,
 };


### PR DESCRIPTION
While using TypeScript, I noticed that the `RenderTask` type is being returned out of `pageProxy.render(renderContext)`, but the package `"pdfjs-dist/types/display/api"` isn't exporting this type.

This PR adds `RenderTask` to the export group.


```ts
/**
 * Sample pseudo-code; I'm not bothering with proper async management in this snippet.
 * Proper async management is left as an exercise to the reader.
 */
import {
  PDFDocumentProxy,
  PDFPageProxy,
  RenderParameters,
  // RenderTask <-- Missing ~ being added in this PR
} from "pdfjs-dist/types/display/api";
import { PageViewport } from "pdfjs-dist/types/display/display_utils";

const pdfProxy: PDFDocumentProxy = getProxySomehow();
const pageProxy: PDFPageProxy = pdfProxy.getPage(1)
const viewport: PageViewport = pageProxy.getViewport({ scale: 1 });

const renderContext: RenderParameters = {
    canvasContext: getContextSomehow(),
    viewport: viewport
  };

// Type RenderTask is missing
const task: RenderTask = pageProxy.render(renderContext);
```

Thank you.