### PR TITLE
Simplify some regular expressions

### DIFF
--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -208,7 +208,7 @@ function isWhiteSpace(ch) {
  * each part of the path.
  */
 function parseXFAPath(path) {
-  const positionPattern = /(.+)\[([0-9]+)\]$/;
+  const positionPattern = /(.+)\[(\d+)\]$/;
   return path.split(".").map(component => {
     const m = component.match(positionPattern);
     if (m) {
@@ -428,10 +428,7 @@ function validateCSSFont(cssFontInfo) {
   } else {
     // See https://developer.mozilla.org/en-US/docs/Web/CSS/custom-ident.
     for (const ident of fontFamily.split(/[ \t]+/)) {
-      if (
-        /^([0-9]|(-([0-9]|-)))/.test(ident) ||
-        !/^[a-zA-Z0-9\-_\\]+$/.test(ident)
-      ) {
+      if (/^(\d|(-(\d|-)))/.test(ident) || !/^[\w-\\]+$/.test(ident)) {
         warn(
           `XFA - FontFamily contains some invalid <custom-ident>: ${fontFamily}.`
         );

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -576,7 +576,7 @@ const FINGERPRINT_FIRST_BYTES = 1024;
 const EMPTY_FINGERPRINT =
   "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
 
-const PDF_HEADER_VERSION_REGEXP = /^[1-9]\.[0-9]$/;
+const PDF_HEADER_VERSION_REGEXP = /^[1-9]\.\d$/;
 
 function find(stream, signature, limit = 1024, backwards = false) {
   if (
@@ -988,7 +988,7 @@ class PDFDocument {
       }
       let fontFamily = descriptor.get("FontFamily");
       // For example, "Wingdings 3" is not a valid font name in the css specs.
-      fontFamily = fontFamily.replace(/[ ]+([0-9])/g, "$1");
+      fontFamily = fontFamily.replace(/[ ]+(\d)/g, "$1");
       const fontWeight = descriptor.get("FontWeight");
 
       // Angle is expressed in degrees counterclockwise in PDF

--- a/src/core/xfa/formcalc_lexer.js
+++ b/src/core/xfa/formcalc_lexer.js
@@ -117,8 +117,8 @@ const TOKEN = {
 };
 
 const hexPattern = /^[uU]([0-9a-fA-F]{4,8})/;
-const numberPattern = /^[0-9]*(?:\.[0-9]*)?(?:[Ee][+-]?[0-9]+)?/;
-const dotNumberPattern = /^[0-9]*(?:[Ee][+-]?[0-9]+)?/;
+const numberPattern = /^\d*(?:\.\d*)?(?:[Ee][+-]?\d+)?/;
+const dotNumberPattern = /^\d*(?:[Ee][+-]?\d+)?/;
 const eolPattern = /[\r\n]+/;
 const identifierPattern = new RegExp("^[\\p{L}_$!][\\p{L}\\p{N}_$]*", "u");
 

--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -657,7 +657,7 @@ class Barcode extends XFAObject {
           "shift-jis",
           "ucs-2",
           "utf-16",
-        ].includes(k) || k.match(/iso-8859-[0-9]{2}/),
+        ].includes(k) || k.match(/iso-8859-\d{2}/),
     });
     this.checksum = getStringOption(attributes.checksum, [
       "none",
@@ -5274,7 +5274,7 @@ class Submit extends XFAObject {
           "shift-jis",
           "ucs-2",
           "utf-16",
-        ].includes(k) || k.match(/iso-8859-[0-9]{2}/),
+        ].includes(k) || k.match(/iso-8859-\d{2}/),
     });
     this.use = attributes.use || "";
     this.usehref = attributes.usehref || "";

--- a/src/core/xfa/utils.js
+++ b/src/core/xfa/utils.js
@@ -22,7 +22,7 @@ const dimConverters = {
   in: x => x * 72,
   px: x => x,
 };
-const measurementPattern = /([+-]?[0-9]+\.?[0-9]*)(.*)/;
+const measurementPattern = /([+-]?\d+\.?\d*)(.*)/;
 
 function stripQuotes(str) {
   if (str.startsWith("'") || str.startsWith('"')) {

--- a/src/scripting_api/aform.js
+++ b/src/scripting_api/aform.js
@@ -90,7 +90,7 @@ class AForm {
       str = `0${str}`;
     }
 
-    const numbers = str.match(/([0-9]+)/g);
+    const numbers = str.match(/(\d+)/g);
     if (numbers.length === 0) {
       return null;
     }
@@ -202,13 +202,13 @@ class AForm {
     if (sepStyle > 1) {
       // comma sep
       pattern = event.willCommit
-        ? /^[+-]?([0-9]+(,[0-9]*)?|,[0-9]+)$/
-        : /^[+-]?[0-9]*,?[0-9]*$/;
+        ? /^[+-]?(\d+(,\d*)?|,\d+)$/
+        : /^[+-]?\d*,?\d*$/;
     } else {
       // dot sep
       pattern = event.willCommit
-        ? /^[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)$/
-        : /^[+-]?[0-9]*\.?[0-9]*$/;
+        ? /^[+-]?(\d+(\.\d*)?|\.\d+)$/
+        : /^[+-]?\d*\.?\d*$/;
     }
 
     if (!pattern.test(value)) {

--- a/src/scripting_api/util.js
+++ b/src/scripting_api/util.js
@@ -59,7 +59,7 @@ class Util extends PDFObject {
       throw new TypeError("First argument of printf must be a string");
     }
 
-    const pattern = /%(,[0-4])?([+ 0#]+)?([0-9]+)?(\.[0-9]+)?(.)/g;
+    const pattern = /%(,[0-4])?([+ 0#]+)?(\d+)?(\.\d+)?(.)/g;
     const PLUS = 1;
     const SPACE = 2;
     const ZERO = 4;
@@ -406,13 +406,13 @@ class Util extends PDFObject {
           },
         },
         mm: {
-          pattern: `([0-9]{2})`,
+          pattern: `(\\d{2})`,
           action: (value, data) => {
             data.month = parseInt(value) - 1;
           },
         },
         m: {
-          pattern: `([0-9]{1,2})`,
+          pattern: `(\\d{1,2})`,
           action: (value, data) => {
             data.month = parseInt(value) - 1;
           },
@@ -430,73 +430,73 @@ class Util extends PDFObject {
           },
         },
         dd: {
-          pattern: "([0-9]{2})",
+          pattern: "(\\d{2})",
           action: (value, data) => {
             data.day = parseInt(value);
           },
         },
         d: {
-          pattern: "([0-9]{1,2})",
+          pattern: "(\\d{1,2})",
           action: (value, data) => {
             data.day = parseInt(value);
           },
         },
         yyyy: {
-          pattern: "([0-9]{4})",
+          pattern: "(\\d{4})",
           action: (value, data) => {
             data.year = parseInt(value);
           },
         },
         yy: {
-          pattern: "([0-9]{2})",
+          pattern: "(\\d{2})",
           action: (value, data) => {
             data.year = 2000 + parseInt(value);
           },
         },
         HH: {
-          pattern: "([0-9]{2})",
+          pattern: "(\\d{2})",
           action: (value, data) => {
             data.hours = parseInt(value);
           },
         },
         H: {
-          pattern: "([0-9]{1,2})",
+          pattern: "(\\d{1,2})",
           action: (value, data) => {
             data.hours = parseInt(value);
           },
         },
         hh: {
-          pattern: "([0-9]{2})",
+          pattern: "(\\d{2})",
           action: (value, data) => {
             data.hours = parseInt(value);
           },
         },
         h: {
-          pattern: "([0-9]{1,2})",
+          pattern: "(\\d{1,2})",
           action: (value, data) => {
             data.hours = parseInt(value);
           },
         },
         MM: {
-          pattern: "([0-9]{2})",
+          pattern: "(\\d{2})",
           action: (value, data) => {
             data.minutes = parseInt(value);
           },
         },
         M: {
-          pattern: "([0-9]{1,2})",
+          pattern: "(\\d{1,2})",
           action: (value, data) => {
             data.minutes = parseInt(value);
           },
         },
         ss: {
-          pattern: "([0-9]{2})",
+          pattern: "(\\d{2})",
           action: (value, data) => {
             data.seconds = parseInt(value);
           },
         },
         s: {
-          pattern: "([0-9]{1,2})",
+          pattern: "(\\d{1,2})",
           action: (value, data) => {
             data.seconds = parseInt(value);
           },

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -2036,7 +2036,7 @@ describe("annotation", function () {
       expect(oldData.ref).toEqual(Ref.get(123, 0));
       expect(newData.ref).toEqual(Ref.get(2, 0));
 
-      oldData.data = oldData.data.replace(/\(D:[0-9]+\)/, "(date)");
+      oldData.data = oldData.data.replace(/\(D:\d+\)/, "(date)");
       expect(oldData.data).toEqual(
         "123 0 obj\n" +
           "<< /Type /Annot /Subtype /Widget /FT /Tx /DA (/Helv 5 Tf) /DR " +
@@ -2167,7 +2167,7 @@ describe("annotation", function () {
       expect(oldData.ref).toEqual(Ref.get(123, 0));
       expect(newData.ref).toEqual(Ref.get(2, 0));
 
-      oldData.data = oldData.data.replace(/\(D:[0-9]+\)/, "(date)");
+      oldData.data = oldData.data.replace(/\(D:\d+\)/, "(date)");
       expect(oldData.data).toEqual(
         "123 0 obj\n" +
           "<< /Type /Annot /Subtype /Widget /FT /Tx /DA (/Goth 5 Tf) /DR " +
@@ -2576,7 +2576,7 @@ describe("annotation", function () {
         task,
         annotationStorage
       );
-      oldData.data = oldData.data.replace(/\(D:[0-9]+\)/, "(date)");
+      oldData.data = oldData.data.replace(/\(D:\d+\)/, "(date)");
       expect(oldData.ref).toEqual(Ref.get(123, 0));
       expect(oldData.data).toEqual(
         "123 0 obj\n" +
@@ -2876,7 +2876,7 @@ describe("annotation", function () {
       );
       expect(data.length).toEqual(2);
       const [radioData, parentData] = data;
-      radioData.data = radioData.data.replace(/\(D:[0-9]+\)/, "(date)");
+      radioData.data = radioData.data.replace(/\(D:\d+\)/, "(date)");
       expect(radioData.ref).toEqual(Ref.get(123, 0));
       expect(radioData.data).toEqual(
         "123 0 obj\n" +
@@ -2939,7 +2939,7 @@ describe("annotation", function () {
       );
       expect(data.length).toEqual(2);
       const [radioData, parentData] = data;
-      radioData.data = radioData.data.replace(/\(D:[0-9]+\)/, "(date)");
+      radioData.data = radioData.data.replace(/\(D:\d+\)/, "(date)");
       expect(radioData.ref).toEqual(Ref.get(123, 0));
       expect(radioData.data).toEqual(
         "123 0 obj\n" +
@@ -3389,7 +3389,7 @@ describe("annotation", function () {
       expect(oldData.ref).toEqual(Ref.get(123, 0));
       expect(newData.ref).toEqual(Ref.get(1, 0));
 
-      oldData.data = oldData.data.replace(/\(D:[0-9]+\)/, "(date)");
+      oldData.data = oldData.data.replace(/\(D:\d+\)/, "(date)");
       expect(oldData.data).toEqual(
         "123 0 obj\n" +
           "<< /Type /Annot /Subtype /Widget /FT /Ch /DA (/Helv 5 Tf) /DR " +


### PR DESCRIPTION
There's a fair number of regular expressions througout the code-base which are slightly more verbose than strictly necessary, in particular:
 - We have a lot of regular expressions that use `[0-9]` explicitly, and those can be simplified to use `\d` instead.
 - We have one instance of a regular expression containing a `A-Za-z0-9_` sequence, which can be simplified to use `\w` instead.