### PR TITLE
Use minimized file in pdf.worker.entry.js

### DIFF
--- a/src/pdf.worker.entry.js
+++ b/src/pdf.worker.entry.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-(typeof window !== "undefined"
-  ? window
-  : {}
-).pdfjsWorker = require("./pdf.worker.js");
+(typeof window !== "undefined" ? window : {}).pdfjsWorker =
+  typeof PDFJSDev === "undefined" || PDFJSDev.test("!PRODUCTION || TESTING")
+    ? require("./pdf.worker.js")
+    : require("./pdf.worker.min.js");


### PR DESCRIPTION
The minimized pdf.worker.js is not used in the production build of pdf.worker.entry.js
It has been fixed to use the minimized file at build time.

This fix will reduce the size of the bundle.