### PR TITLE
XFA - Overwrite AcroForm dictionary when saving if no datasets in XFA (bug 1720179)

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -130,6 +130,11 @@ class Catalog {
     return shadow(this, "acroForm", acroForm);
   }
 
+  get acroFormRef() {
+    const value = this._catDict.getRaw("AcroForm");
+    return shadow(this, "acroFormRef", isRef(value) ? value : null);
+  }
+
   get metadata() {
     const streamRef = this._catDict.getRaw("Metadata");
     if (!isRef(streamRef)) {

--- a/test/unit/writer_spec.js
+++ b/test/unit/writer_spec.js
@@ -142,4 +142,67 @@ describe("Writer", function () {
       expect(buffer.join("")).toEqual(expected);
     });
   });
+
+  describe("XFA", function () {
+    it("should update AcroForm when no datasets in XFA array", function () {
+      const originalData = new Uint8Array();
+      const newRefs = [];
+
+      const acroForm = new Dict(null);
+      acroForm.set("XFA", [
+        "preamble",
+        Ref.get(123, 0),
+        "postamble",
+        Ref.get(456, 0),
+      ]);
+      const acroFormRef = Ref.get(789, 0);
+      const datasetsRef = Ref.get(101112, 0);
+      const xfaData = "<hello>world</hello>";
+
+      const xrefInfo = {
+        newRef: Ref.get(131415, 0),
+        startXRef: 314,
+        fileIds: null,
+        rootRef: null,
+        infoRef: null,
+        encryptRef: null,
+        filename: "foo.pdf",
+        info: {},
+      };
+
+      let data = incrementalUpdate({
+        originalData,
+        xrefInfo,
+        newRefs,
+        datasetsRef,
+        hasDatasets: false,
+        acroFormRef,
+        acroForm,
+        xfaData,
+        xref: {},
+      });
+      data = bytesToString(data);
+
+      const expected =
+        "\n" +
+        "789 0 obj\n" +
+        "<< /XFA [(preamble) 123 0 R (datasets) 101112 0 R (postamble) 456 0 R]>>\n" +
+        "101112 0 obj\n" +
+        "<< /Type /EmbeddedFile /Length 20>>\n" +
+        "stream\n" +
+        "<hello>world</hello>\n" +
+        "endstream\n" +
+        "endobj\n" +
+        "131415 0 obj\n" +
+        "<< /Size 131416 /Prev 314 /Type /XRef /Index [0 1 789 1 101112 1 131415 1] /W [1 1 2] /Length 16>> stream\n" +
+        "\u0000\u0001ÿÿ\u0001\u0001\u0000\u0000\u0001T\u0000\u0000\u0001²\u0000\u0000\n" +
+        "endstream\n" +
+        "endobj\n" +
+        "startxref\n" +
+        "178\n" +
+        "%%EOF\n";
+
+      expect(data).toEqual(expected);
+    });
+  });
 });


### PR DESCRIPTION
  - aims to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1720179
  - in some pdfs the XFA array in AcroForm dictionary doesn't contain an entry for 'datasets' (which contains saved data), so basically this patch allows to overwrite the AcroForm dictionary with an updated XFA array when doing an incremental update.

In fixing this bug I found another one: https://github.com/mozilla/pdf.js/pull/13966 and with both fix we can save the form in the above bug and opening it in Acrobat.