### PR TITLE
Treat all content as visible when no optional content groups are defined (issue 13971)

### DIFF
--- a/src/display/optional_content_config.js
+++ b/src/display/optional_content_config.js
@@ -95,6 +95,9 @@ class OptionalContentConfig {
   }
 
   isVisible(group) {
+    if (this._groups.size === 0) {
+      return true;
+    }
     if (!group) {
       warn("Optional content group not defined.");
       return true;

--- a/test/pdfs/issue13971.pdf.link
+++ b/test/pdfs/issue13971.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/7109095/PDFBOX-5275-p5.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -3728,6 +3728,13 @@
        "link": true,
        "type": "eq"
     },
+    {  "id": "issue13971",
+       "file": "pdfs/issue13971.pdf",
+       "md5": "50fbf6b9f26ea0e4427f33bae62a4d77",
+       "rounds": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "issue1655",
        "file": "pdfs/issue1655r.pdf",
        "md5": "569f48449ba57c15c4f9ade151a651c5",


### PR DESCRIPTION
In the referenced PDF document the /Contents stream contains MarkedContent-operators, however no optional content dictionary exists; according to [the specification](https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/PDF32000_2008.pdf#G7.3883825):

> Null values or references to deleted objects shall be ignored. If this entry is
  not present, is an empty array, or contains references only to null or deleted
  objects,  the  membership  dictionary  shall  have  no  effect  on  the  visibility  of
  any content.

Fixes #13971