### PR TITLE
Enable XFA by default in the viewer, and `components/` examples (issue 13968)

### DIFF
--- a/examples/components/pageviewer.js
+++ b/examples/components/pageviewer.js
@@ -34,6 +34,8 @@ const DEFAULT_URL = "../../web/compressed.tracemonkey-pldi-09.pdf";
 const PAGE_TO_VIEW = 1;
 const SCALE = 1.0;
 
+const ENABLE_XFA = true;
+
 const container = document.getElementById("pageContainer");
 
 const eventBus = new pdfjsViewer.EventBus();
@@ -43,6 +45,7 @@ const loadingTask = pdfjsLib.getDocument({
   url: DEFAULT_URL,
   cMapUrl: CMAP_URL,
   cMapPacked: CMAP_PACKED,
+  enableXfa: ENABLE_XFA,
 });
 loadingTask.promise.then(function (pdfDocument) {
   // Document loaded, retrieving the page.
@@ -55,9 +58,13 @@ loadingTask.promise.then(function (pdfDocument) {
       defaultViewport: pdfPage.getViewport({ scale: SCALE }),
       eventBus,
       // We can enable text/annotation/xfa/struct-layers, as needed.
-      textLayerFactory: new pdfjsViewer.DefaultTextLayerFactory(),
+      textLayerFactory: !pdfDocument.isPureXfa
+        ? new pdfjsViewer.DefaultTextLayerFactory()
+        : null,
       annotationLayerFactory: new pdfjsViewer.DefaultAnnotationLayerFactory(),
-      xfaLayerFactory: new pdfjsViewer.DefaultXfaLayerFactory(),
+      xfaLayerFactory: pdfDocument.isPureXfa
+        ? new pdfjsViewer.DefaultXfaLayerFactory()
+        : null,
       structTreeLayerFactory: new pdfjsViewer.DefaultStructTreeLayerFactory(),
     });
     // Associate the actual page with the view, and draw it.

--- a/examples/components/simpleviewer.js
+++ b/examples/components/simpleviewer.js
@@ -32,9 +32,11 @@ const CMAP_PACKED = true;
 
 const DEFAULT_URL = "../../web/compressed.tracemonkey-pldi-09.pdf";
 // To test the AcroForm and/or scripting functionality, try e.g. this file:
-// var DEFAULT_URL = "../../test/pdfs/160F-2019.pdf";
+// "../../test/pdfs/160F-2019.pdf"
 
-const SEARCH_FOR = ""; // try 'Mozilla';
+const ENABLE_XFA = true;
+const SEARCH_FOR = ""; // try "Mozilla";
+
 const SANDBOX_BUNDLE_SRC = "../../node_modules/pdfjs-dist/build/pdf.sandbox.js";
 
 const container = document.getElementById("viewerContainer");
@@ -84,6 +86,7 @@ const loadingTask = pdfjsLib.getDocument({
   url: DEFAULT_URL,
   cMapUrl: CMAP_URL,
   cMapPacked: CMAP_PACKED,
+  enableXfa: ENABLE_XFA,
 });
 loadingTask.promise.then(function (pdfDocument) {
   // Document loaded, specifying document for the viewer and

--- a/examples/components/singlepageviewer.js
+++ b/examples/components/singlepageviewer.js
@@ -32,9 +32,11 @@ const CMAP_PACKED = true;
 
 const DEFAULT_URL = "../../web/compressed.tracemonkey-pldi-09.pdf";
 // To test the AcroForm and/or scripting functionality, try e.g. this file:
-// var DEFAULT_URL = "../../test/pdfs/160F-2019.pdf";
+// "../../test/pdfs/160F-2019.pdf"
 
-const SEARCH_FOR = ""; // try 'Mozilla';
+const ENABLE_XFA = true;
+const SEARCH_FOR = ""; // try "Mozilla";
+
 const SANDBOX_BUNDLE_SRC = "../../node_modules/pdfjs-dist/build/pdf.sandbox.js";
 
 const container = document.getElementById("viewerContainer");
@@ -84,6 +86,7 @@ const loadingTask = pdfjsLib.getDocument({
   url: DEFAULT_URL,
   cMapUrl: CMAP_URL,
   cMapPacked: CMAP_PACKED,
+  enableXfa: ENABLE_XFA,
 });
 loadingTask.promise.then(function (pdfDocument) {
   // Document loaded, specifying document for the viewer and

--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -166,7 +166,7 @@
     },
     "enableXfa": {
       "type": "boolean",
-      "default": false
+      "default": true
     },
     "historyUpdateUrl": {
       "type": "boolean",

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -55,8 +55,9 @@ const OptionKind = {
 };
 
 /**
- * PLEASE NOTE: To avoid introducing unnecessary dependencies, we specify the
- *              values below *explicitly* rather than relying on imported types.
+ * NOTE: These options are used to generate the `default_preferences.json` file,
+ *       see `OptionKind.PREFERENCE`, hence the values below must use only
+ *       primitive types and cannot rely on any imported types.
  */
 const defaultOptions = {
   annotationMode: {
@@ -226,9 +227,7 @@ const defaultOptions = {
   },
   enableXfa: {
     /** @type {boolean} */
-    value:
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING"),
+    value: true,
     kind: OptionKind.API + OptionKind.PREFERENCE,
   },
   fontExtraProperties: {

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -244,6 +244,7 @@ class DefaultTextLayerFactory {
       viewport,
       enhanceTextSelection,
       eventBus,
+      highlighter,
     });
   }
 }


### PR DESCRIPTION
Given that https://bugzilla.mozilla.org/show_bug.cgi?id=1727396 has now landed, it should now be OK to make this change.

Fixes #13968