### PR TITLE
Improve glyph mapping for non-embedded composite standard fonts (issue 11088)

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -1084,8 +1084,7 @@ class Font {
         }
       }
 
-      const isIdentityUnicode = this.toUnicode instanceof IdentityToUnicodeMap;
-      if (!isIdentityUnicode) {
+      if (!(this.toUnicode instanceof IdentityToUnicodeMap)) {
         this.toUnicode.forEach(function (charCode, unicodeCharCode) {
           map[+charCode] = unicodeCharCode;
         });
@@ -1108,11 +1107,22 @@ class Font {
         this.differences
       );
     } else if (isStandardFont) {
-      this.toFontChar = buildToFontChar(
+      const map = buildToFontChar(
         this.defaultEncoding,
         getGlyphsUnicode(),
         this.differences
       );
+
+      if (
+        type === "CIDFontType2" &&
+        !this.cidEncoding.startsWith("Identity-") &&
+        !(this.toUnicode instanceof IdentityToUnicodeMap)
+      ) {
+        this.toUnicode.forEach(function (charCode, unicodeCharCode) {
+          map[+charCode] = unicodeCharCode;
+        });
+      }
+      this.toFontChar = map;
     } else {
       const glyphsUnicodeMap = getGlyphsUnicode();
       const map = [];

--- a/test/pdfs/issue11088.pdf.link
+++ b/test/pdfs/issue11088.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/3533108/default.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -4003,6 +4003,14 @@
        "link": false,
        "type": "eq"
     },
+    {  "id": "issue11088",
+       "file": "pdfs/issue11088.pdf",
+       "md5": "c46e7d81197fae61a52e00efb30dd7ce",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue11287",
        "file": "pdfs/issue11287.pdf",
        "md5": "d7d6a7c124fad7b00f79112b71ee09d6",


### PR DESCRIPTION
For non-embedded CIDFontType2 fonts with a non-/Identity encoding, use the /ToUnicode data to improve the glyph mapping.

Fixes #11088