### PR TITLE
Make `verifyManifestFiles` fail for non-linked test-cases with a `"link": true`-entry

### DIFF
--- a/test/downloadutils.js
+++ b/test/downloadutils.js
@@ -142,6 +142,15 @@ function verifyManifestFiles(manifest, callback) {
       verifyNext();
       return;
     }
+    if (item.link && !fs.existsSync(item.file + ".link")) {
+      console.error(
+        `WARNING: Unneeded \`"link": true\`-entry for the "${item.id}" test.`
+      );
+      error = true;
+      i++;
+      verifyNext();
+      return;
+    }
     calculateMD5(item.file, function (err, md5) {
       if (err) {
         console.log('WARNING: Unable to open file for reading "' + err + '".');

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -3481,7 +3481,6 @@
       "md5": "8039aba56790d3597d2bc8c794a51301",
       "rounds": 1,
       "lastPage": 5,
-      "link": true,
       "type": "eq"
     },
     { "id": "text_clip_cff_cid",
@@ -3555,7 +3554,6 @@
       "file": "pdfs/issue925.pdf",
       "md5": "f58fe943090aff89dcc8e771bc0db4c2",
       "rounds": 1,
-      "link": true,
       "type": "eq"
     },
     {  "id": "issue9291",


### PR DESCRIPTION
Currently it's possible to accidentally, e.g. by simply copy-and-pasting from an existing test-case, add an unnecessary `"link": true`-entry for locally available PDF files.
This leads to inconsistencies in the manifest file, and doesn't feel like a great developer experience. However we can easily fix it by having `verifyManifestFiles` fail in this situation, and doing so actually turned up a couple of existing cases.