### PR TITLE
Re-factor the `CSS_PIXELS_PER_INCH`/`PDF_PIXELS_PER_INCH` exports (PR 13991 follow-up)

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -2458,11 +2458,8 @@ class CanvasGraphics {
     this.ctx = this.groupStack.pop();
     // Turn off image smoothing to avoid sub pixel interpolation which can
     // look kind of blurry for some pdfs.
-    if (this.ctx.imageSmoothingEnabled !== undefined) {
-      this.ctx.imageSmoothingEnabled = false;
-    } else {
-      this.ctx.mozImageSmoothingEnabled = false;
-    }
+    this.ctx.imageSmoothingEnabled = false;
+
     if (group.smask) {
       this.tempSMask = this.smaskStack.pop();
     } else {

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { CSS_PIXELS_PER_INCH, PDF_PIXELS_PER_INCH } from "./display_utils.js";
+
 import {
   FONT_IDENTITY_MATRIX,
   IDENTITY_MATRIX,
@@ -28,6 +28,7 @@ import {
   warn,
 } from "../shared/util.js";
 import { getShadingPattern, TilingPattern } from "./pattern_helper.js";
+import { PixelsPerInch } from "./display_utils.js";
 
 // <canvas> contexts store most of the state we need natively.
 // However, PDF needs a bit more state, which we store here.
@@ -878,8 +879,7 @@ function getImageSmoothingEnabled(transform, interpolate) {
   scale[0] = Math.fround(scale[0]);
   scale[1] = Math.fround(scale[1]);
   const actualScale = Math.fround(
-    ((globalThis.devicePixelRatio || 1) * CSS_PIXELS_PER_INCH) /
-      PDF_PIXELS_PER_INCH
+    ((globalThis.devicePixelRatio || 1) * PixelsPerInch.CSS) / PixelsPerInch.PDF
   );
   if (interpolate !== undefined) {
     // If the value is explicitly set use it.

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -32,8 +32,10 @@ import {
 const DEFAULT_LINK_REL = "noopener noreferrer nofollow";
 const SVG_NS = "http://www.w3.org/2000/svg";
 
-const CSS_PIXELS_PER_INCH = 96.0;
-const PDF_PIXELS_PER_INCH = 72.0;
+const PixelsPerInch = {
+  CSS: 96.0,
+  PDF: 72.0,
+};
 
 class DOMCanvasFactory extends BaseCanvasFactory {
   constructor({ ownerDocument = globalThis.document } = {}) {
@@ -625,7 +627,6 @@ function getXfaPageViewport(xfaPage, { scale = 1, rotation = 0 }) {
 
 export {
   addLinkAttributes,
-  CSS_PIXELS_PER_INCH,
   DEFAULT_LINK_REL,
   deprecated,
   DOMCanvasFactory,
@@ -641,8 +642,8 @@ export {
   LinkTarget,
   loadScript,
   PageViewport,
-  PDF_PIXELS_PER_INCH,
   PDFDateString,
+  PixelsPerInch,
   RenderingCancelledException,
   StatTimer,
 };

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -16,7 +16,6 @@
 
 import {
   addLinkAttributes,
-  CSS_PIXELS_PER_INCH,
   getFilenameFromUrl,
   getPdfFilenameFromUrl,
   getXfaPageViewport,
@@ -24,8 +23,8 @@ import {
   isValidFetchUrl,
   LinkTarget,
   loadScript,
-  PDF_PIXELS_PER_INCH,
   PDFDateString,
+  PixelsPerInch,
   RenderingCancelledException,
 } from "./display/display_utils.js";
 import {
@@ -105,14 +104,13 @@ if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
 export {
   // From "./display/display_utils.js":
   addLinkAttributes,
-  CSS_PIXELS_PER_INCH,
   getFilenameFromUrl,
   getPdfFilenameFromUrl,
   isPdfFile,
   LinkTarget,
   loadScript,
-  PDF_PIXELS_PER_INCH,
   PDFDateString,
+  PixelsPerInch,
   RenderingCancelledException,
   getXfaPageViewport,
   // From "./shared/util.js":

--- a/test/driver.js
+++ b/test/driver.js
@@ -20,17 +20,16 @@
 const {
   AnnotationLayer,
   AnnotationMode,
-  CSS_PIXELS_PER_INCH,
   getDocument,
   GlobalWorkerOptions,
-  PDF_PIXELS_PER_INCH,
+  PixelsPerInch,
   renderTextLayer,
   XfaLayer,
 } = pdfjsLib;
 const { SimpleLinkService } = pdfjsViewer;
 
 const WAITING_TIME = 100; // ms
-const PDF_TO_CSS_UNITS = CSS_PIXELS_PER_INCH / PDF_PIXELS_PER_INCH;
+const PDF_TO_CSS_UNITS = PixelsPerInch.CSS / PixelsPerInch.PDF;
 const CMAP_URL = "/build/generic/web/cmaps/";
 const CMAP_PACKED = true;
 const STANDARD_FONT_DATA_URL = "/build/generic/web/standard_fonts/";

--- a/web/firefox_print_service.js
+++ b/web/firefox_print_service.js
@@ -15,7 +15,7 @@
 
 import {
   AnnotationMode,
-  PDF_PIXELS_PER_INCH,
+  PixelsPerInch,
   RenderingCancelledException,
   shadow,
 } from "pdfjs-lib";
@@ -34,7 +34,7 @@ function composePage(
   const canvas = document.createElement("canvas");
 
   // The size of the canvas in pixels for printing.
-  const PRINT_UNITS = printResolution / PDF_PIXELS_PER_INCH;
+  const PRINT_UNITS = printResolution / PixelsPerInch.PDF;
   canvas.width = Math.floor(size.width * PRINT_UNITS);
   canvas.height = Math.floor(size.height * PRINT_UNITS);
 

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { AnnotationMode, PDF_PIXELS_PER_INCH } from "pdfjs-lib";
+import { AnnotationMode, PixelsPerInch } from "pdfjs-lib";
 import { PDFPrintServiceFactory, PDFViewerApplication } from "./app.js";
 import { compatibilityParams } from "./app_options.js";
 import { getXfaHtmlForPrinting } from "./print_utils.js";
@@ -34,7 +34,7 @@ function renderPage(
   const scratchCanvas = activeService.scratchCanvas;
 
   // The size of the canvas in pixels for printing.
-  const PRINT_UNITS = printResolution / PDF_PIXELS_PER_INCH;
+  const PRINT_UNITS = printResolution / PixelsPerInch.PDF;
   scratchCanvas.width = Math.floor(size.width * PRINT_UNITS);
   scratchCanvas.height = Math.floor(size.height * PRINT_UNITS);
 

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import { CSS_PIXELS_PER_INCH, PDF_PIXELS_PER_INCH } from "pdfjs-lib";
+import { PixelsPerInch } from "pdfjs-lib";
 
-const CSS_UNITS = CSS_PIXELS_PER_INCH / PDF_PIXELS_PER_INCH;
+const CSS_UNITS = PixelsPerInch.CSS / PixelsPerInch.PDF;
 const DEFAULT_SCALE_VALUE = "auto";
 const DEFAULT_SCALE = 1.0;
 const MIN_SCALE = 0.1;


### PR DESCRIPTION
 - Remove `mozImageSmoothingEnabled` fallback in `CanvasGraphics.endGroup`

   This was added all the way back in PR 2936, however it's been unnecessary ever since Firefox 51 (released on 2017-01-24); please see the MDN compatibility data:
   https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/imageSmoothingEnabled#browser_compatibility

 - Re-factor the `CSS_PIXELS_PER_INCH`/`PDF_PIXELS_PER_INCH` exports (PR 13991 follow-up)

   For improved maintainability, since these constants are being exposed in the official API, this patch moves them into an Object instead.