### PR TITLE
[CRX] enableScripting=false by default in Chrome extension

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -69,6 +69,12 @@
       "type": "boolean",
       "default": false
     },
+    "enableScripting": {
+      "title": "Enable active content (JavaScript) in PDFs",
+      "type": "boolean",
+      "description": "Whether to allow execution of active content (JavaScript) by PDF files.",
+      "default": false
+    },
     "disableRange": {
       "title": "Disable range requests",
       "description": "Whether to disable range requests (not recommended).",
@@ -153,10 +159,6 @@
         3
       ],
       "default": 2
-    },
-    "enableScripting": {
-      "type": "boolean",
-      "default": true
     },
     "enablePermissions": {
       "type": "boolean",

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -101,7 +101,7 @@ const defaultOptions = {
   },
   enableScripting: {
     /** @type {boolean} */
-    value: true,
+    value: typeof PDFJSDev === "undefined" || !PDFJSDev.test("CHROME"),
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
   externalLinkRel: {


### PR DESCRIPTION
The scripting engine is bundled for users who'd like to use the feature, but it is disabled by default.

I just audited the scripting implementation and found that it is generally not unsafe, hence I decided to include it rather than disabling it in gulpfile.