### PR TITLE
[src/core/writer.js] Support `null` values in the `writeValue` function

### DIFF
--- a/src/core/writer.js
+++ b/src/core/writer.js
@@ -89,6 +89,8 @@ function writeValue(value, buffer, transform) {
     writeDict(value, buffer, transform);
   } else if (isStream(value)) {
     writeStream(value, buffer, transform);
+  } else if (value === null) {
+    buffer.push("null");
   } else {
     warn(`Unhandled value in writer: ${typeof value}, please file a bug.`);
   }

--- a/test/unit/writer_spec.js
+++ b/test/unit/writer_spec.js
@@ -117,6 +117,9 @@ describe("Writer", function () {
       dict.set("J", true);
       dict.set("K", false);
 
+      dict.set("NullArr", [null, 10]);
+      dict.set("NullVal", null);
+
       const buffer = [];
       writeDict(dict, buffer, null);
 
@@ -125,7 +128,8 @@ describe("Writer", function () {
         "/E (\\(hello\\\\world\\)) /F [1.23 4.5 6] " +
         "/G << /H 123 /I << /Length 8>> stream\n" +
         "a stream\n" +
-        "endstream\n>> /J true /K false>>";
+        "endstream\n>> /J true /K false " +
+        "/NullArr [null 10] /NullVal null>>";
 
       expect(buffer.join("")).toEqual(expected);
     });


### PR DESCRIPTION
*This fixes something that I noticed, having recently looked at both the `Lexer.getObj` and `writeValue` code.*

Please note that I unfortunately don't have an example of a form where saving fails without this patch. However, given its overall simplicity and that unit-tests are added, it's hopefully deemed useful to fix this potential issue pro-actively rather than waiting for a bug report.

At this point one might, and rightly so, wonder if there's actually any real-world PDF documents where a `null` value is being used?
Unfortunately the answer is *yes*, and we have a couple of examples in the test-suite (although none of those are related to forms); please see: `issue1015`, `issue2642`, `issue10402`, `issue12823`, `issue13823`, and `pr12564`.