### PR TITLE
Annotation - Checkboxes with the same name and export values must be in unison

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -976,25 +976,29 @@ class CheckboxWidgetAnnotationElement extends WidgetAnnotationElement {
     const element = document.createElement("input");
     element.disabled = data.readOnly;
     element.type = "checkbox";
-    element.name = this.data.fieldName;
+    element.name = data.fieldName;
     if (value) {
       element.setAttribute("checked", true);
     }
     element.setAttribute("id", id);
+    element.setAttribute("exportValue", data.exportValue);
     element.tabIndex = DEFAULT_TAB_INDEX;
 
     element.addEventListener("change", function (event) {
       const name = event.target.name;
+      const checked = event.target.checked;
       for (const checkbox of document.getElementsByName(name)) {
         if (checkbox !== event.target) {
-          checkbox.checked = false;
+          checkbox.checked =
+            checked &&
+            checkbox.getAttribute("exportValue") === data.exportValue;
           storage.setValue(
             checkbox.parentNode.getAttribute("data-annotation-id"),
             { value: false }
           );
         }
       }
-      storage.setValue(id, { value: event.target.checked });
+      storage.setValue(id, { value: checked });
     });
 
     if (this.enableScripting && this.hasJSActions) {


### PR DESCRIPTION
  - it aims to fix #14024.
  - this patch adds an attribute `acroformExportValue` to the HTML input in order to set the checked attribute in taking into account the exportValue for the checkboxes with the same name.