### PR TITLE
Annotation - For checkboxes, get field value from AS (if any) instead of V (bug 1722036)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -2083,6 +2083,13 @@ class ButtonWidgetAnnotation extends WidgetAnnotation {
       return;
     }
 
+    // See https://bugzilla.mozilla.org/show_bug.cgi?id=1722036.
+    // If we've an AS and a V then take AS.
+    const asValue = this._decodeFormValue(params.dict.get("AS"));
+    if (typeof asValue === "string") {
+      this.data.fieldValue = asValue;
+    }
+
     const exportValues = normalAppearance.getKeys();
     if (!exportValues.includes("Off")) {
       // The /Off appearance is optional.

--- a/test/pdfs/bug1722036.pdf.link
+++ b/test/pdfs/bug1722036.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=9232845

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -5899,5 +5899,13 @@
        "rounds": 1,
        "lastPage": 1,
        "type": "eq"
+    },
+    {  "id": "bug1722036",
+       "file": "pdfs/bug1722036.pdf",
+       "md5": "bbc7f62ca85609c97069bd3ce2658288",
+       "rounds": 1,
+       "link": true,
+       "forms": true,
+       "type": "eq"
     }
 ]


### PR DESCRIPTION
  - it aims to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1722036.
  - AS and V should share the same value for checkbox: it's at least what the specs say;
  - the pdf in the above bug opens correctly in Acrobat so it likely means that AS is chosen over V.