### PR TITLE
Annotation - Some checkboxes have an empty N dictionary

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -1013,10 +1013,7 @@ class CheckboxWidgetAnnotationElement extends WidgetAnnotationElement {
     const data = this.data;
     const id = data.id;
     let value = storage.getValue(id, {
-      value:
-        data.fieldValue &&
-        ((data.exportValue && data.exportValue === data.fieldValue) ||
-          (!data.exportValue && data.fieldValue !== "Off")),
+      value: data.exportValue === data.fieldValue,
     }).value;
     if (typeof value === "string") {
       // The value has been changed through js and set in annotationStorage.

--- a/test/pdfs/issue14021.pdf.link
+++ b/test/pdfs/issue14021.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/7159923/docOficialPDF.php.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -5944,5 +5944,36 @@
        "rounds": 1,
        "type": "eq",
        "annotations": true
+    },
+    {  "id": "issue14021",
+       "file": "pdfs/issue14021.pdf",
+       "md5": "d18aa84135ce985c70a8f56306ecb95f",
+       "link": true,
+       "rounds": 1,
+       "firstPage": 2,
+       "lastPage": 2,
+       "type": "eq",
+       "forms": true
+    },
+    {  "id": "issue14021-storage",
+       "file": "pdfs/issue14021.pdf",
+       "md5": "d18aa84135ce985c70a8f56306ecb95f",
+       "link": true,
+       "rounds": 1,
+       "firstPage": 2,
+       "lastPage": 3,
+       "type": "eq",
+       "print": true,
+       "annotationStorage": {
+         "148R": {
+           "value": true
+         },
+         "138R": {
+           "value": true
+         },
+         "139R": {
+           "value": true
+         }
+       }
     }
 ]


### PR DESCRIPTION
  - it aims to fix #14021;
  - the N dict is empty here so just create a default one;
  - it implies that the checked checkbox has no appearance so create a default one too in order to print it.
  - in the pdf in the issue, a checked box is not printed because it has no default appearance so we need to guess its appearance from its state.