### PR TITLE
Support cmaps with only CID characters, when building the ToUnicode-map (issue 9367)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -3455,6 +3455,11 @@ class PartialEvaluator {
           // NOTE: cmap can be a sparse array, so use forEach instead of
           // `for(;;)` to iterate over all keys.
           cmap.forEach(function (charCode, token) {
+            // Some cmaps contain *only* CID characters (fixes issue9367.pdf).
+            if (typeof token === "number") {
+              map[charCode] = String.fromCodePoint(token);
+              return;
+            }
             const str = [];
             for (let k = 0; k < token.length; k += 2) {
               const w1 = (token.charCodeAt(k) << 8) | token.charCodeAt(k + 1);

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -376,6 +376,12 @@ function getFontFileType(file, { type, subtype, composite }) {
   return [fileType, fileSubtype];
 }
 
+function applyStandardFontGlyphMap(map, glyphMap) {
+  for (const charCode in glyphMap) {
+    map[+charCode] = glyphMap[charCode];
+  }
+}
+
 function buildToFontChar(encoding, glyphsUnicodeMap, differences) {
   const toFontChar = [];
   let unicode;
@@ -1052,26 +1058,16 @@ class Font {
       type === "CIDFontType2" &&
       this.cidEncoding.startsWith("Identity-")
     ) {
-      const GlyphMapForStandardFonts = getGlyphMapForStandardFonts(),
-        cidToGidMap = properties.cidToGidMap;
+      const cidToGidMap = properties.cidToGidMap;
       // Standard fonts might be embedded as CID font without glyph mapping.
       // Building one based on GlyphMapForStandardFonts.
       const map = [];
-      for (const charCode in GlyphMapForStandardFonts) {
-        map[+charCode] = GlyphMapForStandardFonts[charCode];
-      }
+      applyStandardFontGlyphMap(map, getGlyphMapForStandardFonts());
+
       if (/Arial-?Black/i.test(name)) {
-        const SupplementalGlyphMapForArialBlack =
-          getSupplementalGlyphMapForArialBlack();
-        for (const charCode in SupplementalGlyphMapForArialBlack) {
-          map[+charCode] = SupplementalGlyphMapForArialBlack[charCode];
-        }
+        applyStandardFontGlyphMap(map, getSupplementalGlyphMapForArialBlack());
       } else if (/Calibri/i.test(name)) {
-        const SupplementalGlyphMapForCalibri =
-          getSupplementalGlyphMapForCalibri();
-        for (const charCode in SupplementalGlyphMapForCalibri) {
-          map[+charCode] = SupplementalGlyphMapForCalibri[charCode];
-        }
+        applyStandardFontGlyphMap(map, getSupplementalGlyphMapForCalibri());
       }
 
       // Always update the glyph mapping with the `cidToGidMap` when it exists
@@ -1158,10 +1154,7 @@ class Font {
       if (this.composite && this.toUnicode instanceof IdentityToUnicodeMap) {
         if (/Verdana/i.test(name)) {
           // Fixes issue11242_reduced.pdf
-          const GlyphMapForStandardFonts = getGlyphMapForStandardFonts();
-          for (const charCode in GlyphMapForStandardFonts) {
-            map[+charCode] = GlyphMapForStandardFonts[charCode];
-          }
+          applyStandardFontGlyphMap(map, getGlyphMapForStandardFonts());
         }
       }
       this.toFontChar = map;

--- a/test/pdfs/issue9367.pdf.link
+++ b/test/pdfs/issue9367.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/1634833/E-WG18_105147.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2358,6 +2358,14 @@
        "lastPage": 2,
        "type": "eq"
     },
+    {  "id": "issue9367",
+       "file": "pdfs/issue9367.pdf",
+       "md5": "81a2c6f1fe5d1bb00ff0479aa6547155",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue10529",
        "file": "pdfs/issue10529.pdf",
        "md5": "1a4d404a137c610ff0c747cbea3b8666",


### PR DESCRIPTION
In this particular case the `CMap`-data that we create contains only numbers, but no strings, which causes `PartialEvaluator.readToUnicode` to create a ToUnicode-map with only empty strings.

*Please note:* This is yet another case where I don't know if it's necessarily the best and most correct solution, but it does fix the referenced issue.

Fixes #9367