### PR TITLE
Fix dialogs with forced colors (bug 1722984)

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -150,7 +150,6 @@
 
 @media screen and (forced-colors: active) {
   :root {
-    --main-color: ButtonText;
     --button-hover-color: Highlight;
     --doorhanger-hover-bg-color: Highlight;
     --toolbar-icon-opacity: 1;


### PR DESCRIPTION
Fix for #13872.
When forced colors are set, [this](https://github.com/mozilla/pdf.js/commit/a3cc2e63ebdec46deb6a980b45c95d9c61322497#diff-d1047e1376717fbe7c554bb385cd48b2dcbbb135e02884be3db97ad072ba741eL153) variable is set to use the system buttontext color, preventing the use of the color set in the color settings.
This assignment can be removed since the colors of the html elements that use this variable are overwritten by the browser when the forced colors are set. 