### PR TITLE
Annotations - Avoid empty value in text field when storage contains something for it (bug 1719148)

### DIFF
--- a/src/display/annotation_storage.js
+++ b/src/display/annotation_storage.js
@@ -42,7 +42,12 @@ class AnnotationStorage {
    * @returns {Object}
    */
   getValue(key, defaultValue) {
-    return this._storage.get(key) ?? defaultValue;
+    const value = this._storage.get(key);
+    if (value === undefined) {
+      return defaultValue;
+    }
+
+    return Object.assign(defaultValue, value);
   }
 
   /**

--- a/test/unit/annotation_storage_spec.js
+++ b/test/unit/annotation_storage_spec.js
@@ -35,6 +35,24 @@ describe("AnnotationStorage", function () {
       }).value;
       expect(value).toEqual("hello world");
     });
+
+    it("should get set values and default ones in the annotation storage", function () {
+      const annotationStorage = new AnnotationStorage();
+      annotationStorage.setValue("123A", {
+        value: "hello world",
+        hello: "world",
+      });
+
+      const result = annotationStorage.getValue("123A", {
+        value: "an other string",
+        world: "hello",
+      });
+      expect(result).toEqual({
+        value: "hello world",
+        hello: "world",
+        world: "hello",
+      });
+    });
   });
 
   describe("SetValue", function () {


### PR DESCRIPTION
  - it aims to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1719148;
  - JS can set a property for a non-rendered annotation using the annotationStorage but the other unset default properties must be used when the annotation is finally rendered;
  - so this patch just adds the properties already set in the annotationStorage to the default value.

@gijsk shared his pdf with me, I was able to reproduce his issue with a local firefox build and I verified that this patch fixes the issue.