### PR TITLE
fix mouse wheel scroll delay problem

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -84,7 +84,7 @@ import { ViewHistory } from "./view_history.js";
 const DEFAULT_SCALE_DELTA = 1.1;
 const DISABLE_AUTO_FETCH_LOADING_BAR_TIMEOUT = 5000; // ms
 const FORCE_PAGES_LOADED_TIMEOUT = 10000; // ms
-const WHEEL_ZOOM_DISABLED_TIMEOUT = 1000; // ms
+const WHEEL_ZOOM_DISABLED_TIMEOUT = 0; // ms
 const ENABLE_PERMISSIONS_CLASS = "enablePermissions";
 
 const ViewOnLoad = {


### PR DESCRIPTION
Removed the annoying delay when attempting to mouse wheel zoom while viewing a PDF, does not cause other issues. Tested with PDF Viewer extension for chrome https://chrome.google.com/webstore/detail/pdf-viewer/oemmndcbldboiebfnladdacbdfmadadm?hl=en