### PR TITLE
Add `PDF_TO_CSS_UNITS` to the `PixelsPerInch`-structure

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -879,7 +879,7 @@ function getImageSmoothingEnabled(transform, interpolate) {
   scale[0] = Math.fround(scale[0]);
   scale[1] = Math.fround(scale[1]);
   const actualScale = Math.fround(
-    ((globalThis.devicePixelRatio || 1) * PixelsPerInch.CSS) / PixelsPerInch.PDF
+    (globalThis.devicePixelRatio || 1) * PixelsPerInch.PDF_TO_CSS_UNITS
   );
   if (interpolate !== undefined) {
     // If the value is explicitly set use it.

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -18,6 +18,7 @@ import {
   BaseException,
   isString,
   removeNullCharacters,
+  shadow,
   stringToBytes,
   Util,
   warn,
@@ -35,6 +36,11 @@ const SVG_NS = "http://www.w3.org/2000/svg";
 const PixelsPerInch = {
   CSS: 96.0,
   PDF: 72.0,
+
+  /** @type {number} */
+  get PDF_TO_CSS_UNITS() {
+    return shadow(this, "PDF_TO_CSS_UNITS", this.CSS / this.PDF);
+  },
 };
 
 class DOMCanvasFactory extends BaseCanvasFactory {

--- a/test/driver.js
+++ b/test/driver.js
@@ -29,7 +29,6 @@ const {
 const { SimpleLinkService } = pdfjsViewer;
 
 const WAITING_TIME = 100; // ms
-const PDF_TO_CSS_UNITS = PixelsPerInch.CSS / PixelsPerInch.PDF;
 const CMAP_URL = "/build/generic/web/cmaps/";
 const CMAP_PACKED = true;
 const STANDARD_FONT_DATA_URL = "/build/generic/web/standard_fonts/";
@@ -656,7 +655,9 @@ var Driver = (function DriverClosure() {
           ctx = this.canvas.getContext("2d", { alpha: false });
           task.pdfDoc.getPage(task.pageNum).then(
             function (page) {
-              var viewport = page.getViewport({ scale: PDF_TO_CSS_UNITS });
+              var viewport = page.getViewport({
+                scale: PixelsPerInch.PDF_TO_CSS_UNITS,
+              });
               self.canvas.width = viewport.width;
               self.canvas.height = viewport.height;
               self._clearCanvas();

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -13,9 +13,13 @@
  * limitations under the License.
  */
 
-import { AnnotationMode, createPromiseCapability, version } from "pdfjs-lib";
 import {
-  CSS_UNITS,
+  AnnotationMode,
+  createPromiseCapability,
+  PixelsPerInch,
+  version,
+} from "pdfjs-lib";
+import {
   DEFAULT_SCALE,
   DEFAULT_SCALE_DELTA,
   DEFAULT_SCALE_VALUE,
@@ -535,7 +539,9 @@ class BaseViewer {
         this._optionalContentConfigPromise = optionalContentConfigPromise;
 
         const scale = this.currentScale;
-        const viewport = firstPdfPage.getViewport({ scale: scale * CSS_UNITS });
+        const viewport = firstPdfPage.getViewport({
+          scale: scale * PixelsPerInch.PDF_TO_CSS_UNITS,
+        });
         const textLayerFactory =
           this.textLayerMode !== TextLayerMode.DISABLE && !isPureXfa
             ? this
@@ -904,11 +910,11 @@ class BaseViewer {
     const pageWidth =
       (changeOrientation ? pageView.height : pageView.width) /
       pageView.scale /
-      CSS_UNITS;
+      PixelsPerInch.PDF_TO_CSS_UNITS;
     const pageHeight =
       (changeOrientation ? pageView.width : pageView.height) /
       pageView.scale /
-      CSS_UNITS;
+      PixelsPerInch.PDF_TO_CSS_UNITS;
     let scale = 0;
     switch (destArray[1].name) {
       case "XYZ":
@@ -957,9 +963,13 @@ class BaseViewer {
         const vPadding = this.removePageBorders ? 0 : VERTICAL_PADDING;
 
         widthScale =
-          (this.container.clientWidth - hPadding) / width / CSS_UNITS;
+          (this.container.clientWidth - hPadding) /
+          width /
+          PixelsPerInch.PDF_TO_CSS_UNITS;
         heightScale =
-          (this.container.clientHeight - vPadding) / height / CSS_UNITS;
+          (this.container.clientHeight - vPadding) /
+          height /
+          PixelsPerInch.PDF_TO_CSS_UNITS;
         scale = Math.min(Math.abs(widthScale), Math.abs(heightScale));
         break;
       default:

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -18,12 +18,12 @@
 import {
   AnnotationMode,
   createPromiseCapability,
+  PixelsPerInch,
   RenderingCancelledException,
   SVGGraphics,
 } from "pdfjs-lib";
 import {
   approximateFraction,
-  CSS_UNITS,
   DEFAULT_SCALE,
   getOutputScale,
   RendererType,
@@ -149,7 +149,7 @@ class PDFPageView {
 
     const totalRotation = (this.rotation + this.pdfPageRotate) % 360;
     this.viewport = pdfPage.getViewport({
-      scale: this.scale * CSS_UNITS,
+      scale: this.scale * PixelsPerInch.PDF_TO_CSS_UNITS,
       rotation: totalRotation,
     });
     this.reset();
@@ -329,7 +329,7 @@ class PDFPageView {
 
     const totalRotation = (this.rotation + this.pdfPageRotate) % 360;
     this.viewport = this.viewport.clone({
-      scale: this.scale * CSS_UNITS,
+      scale: this.scale * PixelsPerInch.PDF_TO_CSS_UNITS,
       rotation: totalRotation,
     });
 
@@ -774,7 +774,9 @@ class PDFPageView {
     this.outputScale = outputScale;
 
     if (this.useOnlyCssZoom) {
-      const actualSizeViewport = viewport.clone({ scale: CSS_UNITS });
+      const actualSizeViewport = viewport.clone({
+        scale: PixelsPerInch.PDF_TO_CSS_UNITS,
+      });
       // Use a scale that makes the canvas have the originally intended size
       // of the page.
       outputScale.sx *= actualSizeViewport.width / viewport.width;
@@ -863,7 +865,9 @@ class PDFPageView {
     };
 
     const pdfPage = this.pdfPage;
-    const actualSizeViewport = this.viewport.clone({ scale: CSS_UNITS });
+    const actualSizeViewport = this.viewport.clone({
+      scale: PixelsPerInch.PDF_TO_CSS_UNITS,
+    });
     const promise = pdfPage
       .getOperatorList({
         annotationMode: this._annotatationMode,

--- a/web/print_utils.js
+++ b/web/print_utils.js
@@ -13,14 +13,13 @@
  * limitations under the License.
  */
 
-import { CSS_UNITS } from "./ui_utils.js";
+import { getXfaPageViewport, PixelsPerInch } from "pdfjs-lib";
 import { DefaultXfaLayerFactory } from "./xfa_layer_builder.js";
-import { getXfaPageViewport } from "pdfjs-lib";
 
 function getXfaHtmlForPrinting(printContainer, pdfDocument) {
   const xfaHtml = pdfDocument.allXfaHtml;
   const factory = new DefaultXfaLayerFactory();
-  const scale = Math.round(CSS_UNITS * 100) / 100;
+  const scale = Math.round(PixelsPerInch.PDF_TO_CSS_UNITS * 100) / 100;
 
   for (const xfaPage of xfaHtml.children) {
     const page = document.createElement("div");

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -13,9 +13,6 @@
  * limitations under the License.
  */
 
-import { PixelsPerInch } from "pdfjs-lib";
-
-const CSS_UNITS = PixelsPerInch.CSS / PixelsPerInch.PDF;
 const DEFAULT_SCALE_VALUE = "auto";
 const DEFAULT_SCALE = 1.0;
 const DEFAULT_SCALE_DELTA = 1.1;
@@ -1004,7 +1001,6 @@ export {
   AutoPrintRegExp,
   backtrackBeforeAllVisibleElements, // only exported for testing
   binarySearchFirstItem,
-  CSS_UNITS,
   DEFAULT_SCALE,
   DEFAULT_SCALE_DELTA,
   DEFAULT_SCALE_VALUE,


### PR DESCRIPTION
Rather than re-computing this value in a number of different places throughout the code-base[1], we can expose this in the API via the existing `PixelsPerInch`-structure instead.
There's also been feature requests asking for the old `CSS_UNITS` viewer constant to be made accessible, such that it could be used in third-party implementations.

I suppose that it could be argued that it's somewhat confusing to place a unitless property in `PixelsPerInch`, however given that the `PDF_TO_CSS_UNITS`-property is defined strictly in terms of the existing properties this is hopefully deemed reasonable.

---
[1] These include:
 - The viewer, with the `CSS_UNITS` name.
 - The reference-tests.
 - The display-layer, when rendering images; see PR 13991.