### PR TITLE
[GENERIC viewer] Warn about AppOptions being overridden by Preferences during loading

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -301,13 +301,20 @@ const PDFViewerApplication = {
    */
   async _readPreferences() {
     if (
-      (typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("!PRODUCTION || GENERIC")) &&
-      AppOptions.get("disablePreferences")
+      typeof PDFJSDev === "undefined" ||
+      PDFJSDev.test("!PRODUCTION || GENERIC")
     ) {
-      // Give custom implementations of the default viewer a simpler way to
-      // opt-out of having the `Preferences` override existing `AppOptions`.
-      return;
+      if (AppOptions.get("disablePreferences")) {
+        // Give custom implementations of the default viewer a simpler way to
+        // opt-out of having the `Preferences` override existing `AppOptions`.
+        return;
+      }
+      if (AppOptions._hasUserOptions()) {
+        console.warn(
+          "_readPreferences: The Preferences may override manually set AppOptions; " +
+            'please use the "disablePreferences"-option in order to prevent that.'
+        );
+      }
     }
     try {
       AppOptions.setAll(await this.preferences.getAll());

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -379,6 +379,13 @@ class AppOptions {
   static remove(name) {
     delete userOptions[name];
   }
+
+  /**
+   * @ignore
+   */
+  static _hasUserOptions() {
+    return Object.keys(userOptions).length > 0;
+  }
 }
 
 export { AppOptions, compatibilityParams, OptionKind };


### PR DESCRIPTION
Currently any AppOptions set using e.g. the "webviewerloaded" event listener can/will by default be overridden when the Preferences are read.
To avoid that happening the "disablePreferences"-option can be used, however unless it's been explicitly set all non-default AppOptions will be silently ignored. This patch thus attempts to improve the current situation somewhat, for third-party implementations, by logging a warning in the console when this happens.