### PR TITLE
Fallback to font name matching, when checking for serif fonts (issue 13845)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -3855,6 +3855,7 @@ class PartialEvaluator {
           loadedName: baseDict.loadedName,
           widths: metrics.widths,
           defaultWidth: metrics.defaultWidth,
+          isSimulatedFlags: true,
           flags,
           firstChar,
           lastChar,

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -45,6 +45,7 @@ import {
 import {
   getGlyphMapForStandardFonts,
   getNonStdFontMap,
+  getSerifFonts,
   getStdFontMap,
   getSupplementalGlyphMapForArialBlack,
   getSupplementalGlyphMapForCalibri,
@@ -872,7 +873,21 @@ class Font {
     this._charsCache = Object.create(null);
     this._glyphCache = Object.create(null);
 
-    this.isSerifFont = !!(properties.flags & FontFlags.Serif);
+    let isSerifFont = !!(properties.flags & FontFlags.Serif);
+    // Fallback to checking the font name, in order to improve text-selection,
+    // since the /Flags-entry is often wrong (fixes issue13845.pdf).
+    if (!isSerifFont && !properties.isSimulatedFlags) {
+      const baseName = name.replace(/[,_]/g, "-").split("-")[0],
+        serifFonts = getSerifFonts();
+      for (const namePart of baseName.split("+")) {
+        if (serifFonts[namePart]) {
+          isSerifFont = true;
+          break;
+        }
+      }
+    }
+    this.isSerifFont = isSerifFont;
+
     this.isSymbolicFont = !!(properties.flags & FontFlags.Symbolic);
     this.isMonospace = !!(properties.flags & FontFlags.FixedPitch);
 

--- a/src/core/standard_fonts.js
+++ b/src/core/standard_fonts.js
@@ -243,6 +243,7 @@ const getSerifFonts = getLookupTableFactory(function (t) {
   t.Joanna = true;
   t.Korinna = true;
   t.Lexicon = true;
+  t.LiberationSerif = true;
   t["Liberation Serif"] = true;
   t["Linux Libertine"] = true;
   t.Literaturnaya = true;

--- a/test/pdfs/issue13845.pdf.link
+++ b/test/pdfs/issue13845.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/6916129/example.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1084,6 +1084,14 @@
        "type": "eq",
        "forms": true
     },
+    {  "id": "issue13845",
+       "file": "pdfs/issue13845.pdf",
+       "md5": "7c6b675f61ae68a2e416f4aa26da567c",
+       "link": true,
+       "rounds": 1,
+       "lastPage": 1,
+       "type": "text"
+    },
     {  "id": "xfa_bug1718521_1",
        "file": "pdfs/xfa_bug1718521_1.pdf",
        "md5": "9b89dd9e6a4c6c3258ca24debd806863",


### PR DESCRIPTION
In order to handle fonts that specify completely bogus /Flags-entries, fallback to font name matching to determine if the font is a serif one.

Fixes #13845