### PR TITLE
Print a special warning message, in the viewer, for XFA Foreground documents

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -3060,6 +3060,7 @@ class WorkerTransport {
     const params = this._params;
     return shadow(this, "loadingParams", {
       disableAutoFetch: params.disableAutoFetch,
+      enableXfa: params.enableXfa,
     });
   }
 }

--- a/web/app.js
+++ b/web/app.js
@@ -1555,10 +1555,13 @@ const PDFViewerApplication = {
     if (
       info.IsXFAPresent &&
       !info.IsAcroFormPresent &&
-      // Note: `isPureXfa === true` implies that `enableXfa = true` was set.
       !pdfDocument.isPureXfa
     ) {
-      console.warn("Warning: XFA support is not enabled");
+      if (pdfDocument.loadingParams.enableXfa) {
+        console.warn("Warning: XFA Foreground documents are not supported");
+      } else {
+        console.warn("Warning: XFA support is not enabled");
+      }
       this.fallback(UNSUPPORTED_FEATURES.forms);
     } else if (
       (info.IsAcroFormPresent || info.IsXFAPresent) &&


### PR DESCRIPTION
Currently XFAF documents use the same warning message as in the XFA *disabled* case, which is neither helpful nor correct.