### PR TITLE
Mark the `paintJpegXObject` operator as deprecated (PR 11601 follow-up)

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -328,6 +328,7 @@ const OPS = {
   endAnnotations: 79,
   beginAnnotation: 80,
   endAnnotation: 81,
+  /** @deprecated unused */
   paintJpegXObject: 82,
   paintImageMaskXObject: 83,
   paintImageMaskXObjectGroup: 84,


### PR DESCRIPTION
After PR #11601, the `paintJpegXObject` operator is no longer used for anything. While I don't think we can just remove it, and essentially leave a "hole" in the `OPS` structure, we should at least mark it as explicitly unused to aid readability/maintainability of the code.