### PR TITLE
XFA - Bind items when there's a bindItems entry

### DIFF
--- a/src/core/xfa/bind.js
+++ b/src/core/xfa/bind.js
@@ -478,6 +478,12 @@ class Binder {
     return [occur.min, max];
   }
 
+  _setAndBind(formNode, dataNode) {
+    this._setProperties(formNode, dataNode);
+    this._bindItems(formNode, dataNode);
+    this._bindElement(formNode, dataNode);
+  }
+
   _bindElement(formNode, dataNode) {
     // Some nodes can be useless because min=0 so remove them
     // after the loop to avoid bad things.
@@ -530,7 +536,7 @@ class Binder {
       if (child.bind) {
         switch (child.bind.match) {
           case "none":
-            this._bindElement(child, dataNode);
+            this._setAndBind(child, dataNode);
             continue;
           case "global":
             global = true;
@@ -538,7 +544,7 @@ class Binder {
           case "dataRef":
             if (!child.bind.ref) {
               warn(`XFA - ref is empty in node ${child[$nodeName]}.`);
-              this._bindElement(child, dataNode);
+              this._setAndBind(child, dataNode);
               continue;
             }
             ref = child.bind.ref;
@@ -578,7 +584,7 @@ class Binder {
           }
 
           // Don't bind the value in newly created node because it's empty.
-          this._bindElement(child, match);
+          this._setAndBind(child, match);
           continue;
         } else {
           if (this._isConsumeData()) {
@@ -598,7 +604,7 @@ class Binder {
         }
       } else {
         if (!child.name) {
-          this._bindElement(child, dataNode);
+          this._setAndBind(child, dataNode);
           continue;
         }
         if (this._isConsumeData()) {
@@ -642,9 +648,7 @@ class Binder {
             dataNode[$appendChild](match);
 
             // Don't bind the value in newly created node because it's empty.
-            this._setProperties(child, match);
-            this._bindItems(child, match);
-            this._bindElement(child, match);
+            this._setAndBind(child, match);
             continue;
           }
           if (this.emptyMerge) {
@@ -657,9 +661,7 @@ class Binder {
       if (match) {
         this._bindOccurrences(child, match, picture);
       } else if (min > 0) {
-        this._setProperties(child, dataNode);
-        this._bindItems(child, dataNode);
-        this._bindElement(child, dataNode);
+        this._setAndBind(child, dataNode);
       } else {
         uselessNodes.push(child);
       }

--- a/test/unit/xfa_parser_spec.js
+++ b/test/unit/xfa_parser_spec.js
@@ -1259,6 +1259,57 @@ describe("XFAParser", function () {
       ]);
     });
 
+    it("should make binding and bind items with a ref", function () {
+      const xml = `
+<?xml version="1.0"?>
+<xdp:xdp xmlns:xdp="http://ns.adobe.com/xdp/">
+  <template xmlns="http://www.xfa.org/schema/xfa-template/3.3">
+    <subform name="main">
+      <field name="CardName">
+        <bind match="dataRef" ref="$data.main.value"/>
+        <bindItems ref="$data.main.ccs.cc[*]" labelRef="uiname" valueRef="token"/>
+        <ui>
+          <choiceList/>
+        </ui>
+      </field>
+    </subform>
+  </template>
+  <xfa:datasets xmlns:xfa="http://www.xfa.org/schema/xfa-data/1.0/">
+    <xfa:data>
+      <main>
+        <value>VISA</value>
+        <ccs>
+          <cc uiname="Visa" token="VISA"/>
+          <cc uiname="Mastercard" token="MC"/>
+          <cc uiname="American Express" token="AMEX"/>
+        </ccs>
+        <CardName>MC</CardName>
+      </main>
+    </xfa:data>
+  </xfa:datasets>
+</xdp:xdp>
+      `;
+      const root = new XFAParser().parse(xml);
+      const form = new Binder(root).bind();
+      expect(
+        searchNode(form, form, "subform.CardName.value.text").map(x =>
+          x[$text]()
+        )
+      ).toEqual(["VISA"]);
+      expect(
+        searchNode(form, form, "subform.CardName.items[*].text[*]").map(x =>
+          x[$text]()
+        )
+      ).toEqual([
+        "Visa",
+        "Mastercard",
+        "American Express",
+        "VISA",
+        "MC",
+        "AMEX",
+      ]);
+    });
+
     it("should make binding with occurrences in consumeData mode", function () {
       const xml = `
 <?xml version="1.0"?>


### PR DESCRIPTION
  - In the pdf in issue #14071, some select fields don't contain any values;
  - the corresponding node has a bindItems and a bind elements and _bindItems function was just not called.