### PR TITLE
[api-minor] Move the `addDefaultProtocolToUrl`/`tryConvertUrlEncoding` functionality into the `createValidAbsoluteUrl` function

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -14,14 +14,6 @@
  */
 
 import {
-  addDefaultProtocolToUrl,
-  collectActions,
-  MissingDataException,
-  recoverJsURL,
-  toRomanNumerals,
-  tryConvertUrlEncoding,
-} from "./core_utils.js";
-import {
   clearPrimitiveCaches,
   Dict,
   isDict,
@@ -29,9 +21,16 @@ import {
   isRef,
   isRefsEqual,
   isStream,
+  Name,
   RefSet,
   RefSetCache,
 } from "./primitives.js";
+import {
+  collectActions,
+  MissingDataException,
+  recoverJsURL,
+  toRomanNumerals,
+} from "./core_utils.js";
 import {
   createPromiseCapability,
   createValidAbsoluteUrl,
@@ -1331,11 +1330,9 @@ class Catalog {
       switch (actionName) {
         case "URI":
           url = action.get("URI");
-          if (isName(url)) {
+          if (url instanceof Name) {
             // Some bad PDFs do not put parentheses around relative URLs.
             url = "/" + url.name;
-          } else if (isString(url)) {
-            url = addDefaultProtocolToUrl(url);
           }
           // TODO: pdf spec mentions urls can be relative to a Base
           // entry in the dictionary.
@@ -1426,8 +1423,10 @@ class Catalog {
     }
 
     if (isString(url)) {
-      url = tryConvertUrlEncoding(url);
-      const absoluteUrl = createValidAbsoluteUrl(url, docBaseUrl);
+      const absoluteUrl = createValidAbsoluteUrl(url, docBaseUrl, {
+        addDefaultProtocol: true,
+        tryConvertEncoding: true,
+      });
       if (absoluteUrl) {
         resultObj.url = absoluteUrl.href;
       }

--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -18,7 +18,6 @@ import {
   BaseException,
   objectSize,
   stringToPDFString,
-  stringToUTF8String,
   warn,
 } from "../shared/util.js";
 import { Dict, isName, isRef, isStream, RefSet } from "./primitives.js";
@@ -452,21 +451,6 @@ function validateCSSFont(cssFontInfo) {
   return true;
 }
 
-// Let URLs beginning with 'www.' default to using the 'http://' protocol.
-function addDefaultProtocolToUrl(url) {
-  return url.startsWith("www.") ? `http://${url}` : url;
-}
-
-// According to ISO 32000-1:2008, section 12.6.4.7, URIs should be encoded
-// in 7-bit ASCII. Some bad PDFs use UTF-8 encoding; see Bugzilla 1122280.
-function tryConvertUrlEncoding(url) {
-  try {
-    return stringToUTF8String(url);
-  } catch (e) {
-    return url;
-  }
-}
-
 function recoverJsURL(str) {
   // Attempt to recover valid URLs from `JS` entries with certain
   // white-listed formats:
@@ -496,7 +480,6 @@ function recoverJsURL(str) {
 }
 
 export {
-  addDefaultProtocolToUrl,
   collectActions,
   encodeToXmlString,
   escapePDFName,
@@ -513,7 +496,6 @@ export {
   readUint32,
   recoverJsURL,
   toRomanNumerals,
-  tryConvertUrlEncoding,
   validateCSSFont,
   XRefEntryException,
   XRefParseException,

--- a/src/core/xfa/html_utils.js
+++ b/src/core/xfa/html_utils.js
@@ -26,10 +26,6 @@ import {
   $toStyle,
   XFAObject,
 } from "./xfa_object.js";
-import {
-  addDefaultProtocolToUrl,
-  tryConvertUrlEncoding,
-} from "../core_utils.js";
 import { createValidAbsoluteUrl, warn } from "../../shared/util.js";
 import { getMeasurement, stripQuotes } from "./utils.js";
 import { selectFont } from "./fonts.js";
@@ -638,15 +634,11 @@ function setFontFamily(xfaFont, node, fontFinder, style) {
 }
 
 function fixURL(str) {
-  if (typeof str === "string") {
-    let url = addDefaultProtocolToUrl(str);
-    url = tryConvertUrlEncoding(url);
-    const absoluteUrl = createValidAbsoluteUrl(url);
-    if (absoluteUrl) {
-      return absoluteUrl.href;
-    }
-  }
-  return null;
+  const absoluteUrl = createValidAbsoluteUrl(str, /* baseUrl = */ null, {
+    addDefaultProtocol: true,
+    tryConvertEncoding: true,
+  });
+  return absoluteUrl ? absoluteUrl.href : null;
 }
 
 export {

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -796,7 +796,7 @@ describe("annotation", function () {
         );
         expect(data.annotationType).toEqual(AnnotationType.LINK);
         expect(data.url).toEqual("http://www.hmrc.gov.uk/");
-        expect(data.unsafeUrl).toEqual("http://www.hmrc.gov.uk");
+        expect(data.unsafeUrl).toEqual("www.hmrc.gov.uk");
         expect(data.dest).toBeUndefined();
       }
     );
@@ -843,7 +843,7 @@ describe("annotation", function () {
           ).href
         );
         expect(data.unsafeUrl).toEqual(
-          stringToUTF8String("http://www.example.com/\xC3\xBC\xC3\xB6\xC3\xA4")
+          "http://www.example.com/\xC3\xBC\xC3\xB6\xC3\xA4"
         );
         expect(data.dest).toBeUndefined();
       }


### PR DESCRIPTION
Having recently worked with, and reviewed patches touching, this code it seemed that it's probably not a bad idea to move that functionality into `createValidAbsoluteUrl` as new options instead.

For the `addDefaultProtocolToUrl` functionality in particular, the existing helper function was not only moved but slightly improved as well. Looking at the code, I realized that there's a small risk that it would incorrectly match a *relative* URL-string too.

With these changes, the `createValidAbsoluteUrl` call-sites in the `src/core/`-code can be simplified a little bit.

*Please note:* This patch may, indirectly, change the format of the `unsafeUrl`-property returned with relevant Annotations and OutlineItems; hence the `api-minor` tag.
However, I'd argue that it's actually more correct this way since the whole purpose of `unsafeUrl` is/was to return the URL data as-is without any parsing done.