### PR TITLE
Pre-render *one* additional page when spreadModes are enabled

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -1250,10 +1250,16 @@ class BaseViewer {
     const scrollAhead = this._isScrollModeHorizontal
       ? this.scroll.right
       : this.scroll.down;
+    const preRenderExtra =
+      this._scrollMode === ScrollMode.VERTICAL &&
+      this._spreadMode !== SpreadMode.NONE &&
+      !this.isInPresentationMode;
+
     const pageView = this.renderingQueue.getHighestPriority(
       visiblePages,
       this._pages,
-      scrollAhead
+      scrollAhead,
+      preRenderExtra
     );
     if (pageView) {
       this._ensurePdfPageLoaded(pageView).then(() => {

--- a/web/pdf_rendering_queue.js
+++ b/web/pdf_rendering_queue.js
@@ -126,21 +126,15 @@ class PDFRenderingQueue {
       }
     }
 
-    // All the visible views have rendered; try to render next/previous pages.
-    if (scrolledDown) {
-      const nextPageIndex = visible.last.id;
-      // IDs start at 1, so no need to add 1.
-      if (views[nextPageIndex] && !this.isViewFinished(views[nextPageIndex])) {
-        return views[nextPageIndex];
-      }
-    } else {
-      const previousPageIndex = visible.first.id - 2;
-      if (
-        views[previousPageIndex] &&
-        !this.isViewFinished(views[previousPageIndex])
-      ) {
-        return views[previousPageIndex];
-      }
+    // All the visible views have rendered; try to render next/previous page.
+    // (IDs start at 1, so no need to add 1 when `scrolledDown === true`.)
+    const preRenderIndex = scrolledDown
+      ? visible.last.id
+      : visible.first.id - 2;
+    const preRenderView = views[preRenderIndex];
+
+    if (preRenderView && !this.isViewFinished(preRenderView)) {
+      return preRenderView;
     }
     // Everything that needs to be rendered has been.
     return null;

--- a/web/pdf_rendering_queue.js
+++ b/web/pdf_rendering_queue.js
@@ -102,8 +102,9 @@ class PDFRenderingQueue {
    * @param {Object} visible
    * @param {Array} views
    * @param {boolean} scrolledDown
+   * @param {boolean} [preRenderExtra]
    */
-  getHighestPriority(visible, views, scrolledDown) {
+  getHighestPriority(visible, views, scrolledDown, preRenderExtra = false) {
     /**
      * The state has changed. Figure out which page has the highest priority to
      * render next (if any).
@@ -128,13 +129,19 @@ class PDFRenderingQueue {
 
     // All the visible views have rendered; try to render next/previous page.
     // (IDs start at 1, so no need to add 1 when `scrolledDown === true`.)
-    const preRenderIndex = scrolledDown
-      ? visible.last.id
-      : visible.first.id - 2;
-    const preRenderView = views[preRenderIndex];
+    let preRenderIndex = scrolledDown ? visible.last.id : visible.first.id - 2;
+    let preRenderView = views[preRenderIndex];
 
     if (preRenderView && !this.isViewFinished(preRenderView)) {
       return preRenderView;
+    }
+    if (preRenderExtra) {
+      preRenderIndex += scrolledDown ? 1 : -1;
+      preRenderView = views[preRenderIndex];
+
+      if (preRenderView && !this.isViewFinished(preRenderView)) {
+        return preRenderView;
+      }
     }
     // Everything that needs to be rendered has been.
     return null;


### PR DESCRIPTION
*I've had this patch lying around locally for (at least) a year, and going through some old half-finished stuff figured that actually submitting it for review may be useful.*

Please note that we (obviously) don't want to unconditionally pre-render more than one page all the time, since that could very easily lead to overall worse performance in some documents.[1]
However, when spreadModes are enabled it does make sense to attempt to pre-render both of the pages of the next/previous spread.

---
[1] Since it may cause pre-rendering to unnecessarily compete for parsing resources, on the worker-thread, with "regular" rendering.



