### PR TITLE
[Regression] Fix comb fields scrolling when the last character is entered (PR 14049 follow-up)

### DIFF
--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -147,6 +147,16 @@
   padding-right: 0;
 }
 
+.annotationLayer .textWidgetAnnotation input.comb:focus {
+  /*
+   * Letter spacing is placed on the right side of each character. Hence, the
+   * letter spacing of the last character may be placed outside the visible
+   * area, causing horizontal scrolling. We avoid this by extending the width
+   * when the element has focus and revert this when it loses focus.
+   */
+  width: 103%;
+}
+
 .annotationLayer .buttonWidgetAnnotation.checkBox input,
 .annotationLayer .buttonWidgetAnnotation.radioButton input {
   appearance: none;


### PR DESCRIPTION
Note that PR #14049 removed this, since https://github.com/mozilla/pdf.js/pull/14049#discussion_r716245518 claimed that it's not necessary anymore. Unfortunately that, in my testing on Windows, actually re-introduced exactly the issue described in the comment; more specifically once the *last* character has been entered in the comb-field it's now again incorrectly scrolled (with the first character being invisible) until focus is lost.

This can be tested with e.g. `f1040.pdf`, see page 2, from the test-suite.