### PR TITLE
[api-minor] Change `PDFFindController` to use the "find"-event directly (issue 12731)

### DIFF
--- a/examples/components/simpleviewer.js
+++ b/examples/components/simpleviewer.js
@@ -77,7 +77,11 @@ eventBus.on("pagesinit", function () {
 
   // We can try searching for things.
   if (SEARCH_FOR) {
-    pdfFindController.executeCommand("find", { query: SEARCH_FOR });
+    if (!pdfFindController._onFind) {
+      pdfFindController.executeCommand("find", { query: SEARCH_FOR });
+    } else {
+      eventBus.dispatch("find", { type: "", query: SEARCH_FOR });
+    }
   }
 });
 

--- a/examples/components/singlepageviewer.js
+++ b/examples/components/singlepageviewer.js
@@ -77,7 +77,11 @@ eventBus.on("pagesinit", function () {
 
   // We can try searching for things.
   if (SEARCH_FOR) {
-    pdfFindController.executeCommand("find", { query: SEARCH_FOR });
+    if (!pdfFindController._onFind) {
+      pdfFindController.executeCommand("find", { query: SEARCH_FOR });
+    } else {
+      eventBus.dispatch("find", { type: "", query: SEARCH_FOR });
+    }
   }
 });
 

--- a/test/unit/pdf_find_controller_spec.js
+++ b/test/unit/pdf_find_controller_spec.js
@@ -69,14 +69,27 @@ async function initPdfFindController(filename) {
 function testSearch({
   eventBus,
   pdfFindController,
-  parameters,
+  state,
   matchesPerPage,
   selectedMatch,
   pageMatches = null,
   pageMatchesLength = null,
 }) {
   return new Promise(function (resolve) {
-    pdfFindController.executeCommand("find", parameters);
+    const eventState = Object.assign(
+      Object.create(null),
+      {
+        source: this,
+        type: "",
+        query: null,
+        caseSensitive: false,
+        entireWord: false,
+        phraseSearch: true,
+        findPrevious: false,
+      },
+      state
+    );
+    eventBus.dispatch("find", eventState);
 
     // The `updatefindmatchescount` event is only emitted if the page contains
     // at least one match for the query, so the last non-zero item in the
@@ -142,12 +155,8 @@ describe("pdf_find_controller", function () {
     await testSearch({
       eventBus,
       pdfFindController,
-      parameters: {
+      state: {
         query: "Dynamic",
-        caseSensitive: false,
-        entireWord: false,
-        phraseSearch: true,
-        findPrevious: false,
       },
       matchesPerPage: [11, 5, 0, 3, 0, 0, 0, 1, 1, 1, 0, 3, 4, 4],
       selectedMatch: {
@@ -166,11 +175,8 @@ describe("pdf_find_controller", function () {
     await testSearch({
       eventBus,
       pdfFindController,
-      parameters: {
+      state: {
         query: "conference",
-        caseSensitive: false,
-        entireWord: false,
-        phraseSearch: true,
         findPrevious: true,
       },
       matchesPerPage: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5],
@@ -187,12 +193,9 @@ describe("pdf_find_controller", function () {
     await testSearch({
       eventBus,
       pdfFindController,
-      parameters: {
+      state: {
         query: "Dynamic",
         caseSensitive: true,
-        entireWord: false,
-        phraseSearch: true,
-        findPrevious: false,
       },
       matchesPerPage: [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3],
       selectedMatch: {
@@ -210,12 +213,9 @@ describe("pdf_find_controller", function () {
     await testSearch({
       eventBus,
       pdfFindController,
-      parameters: {
+      state: {
         query: "Government",
-        caseSensitive: false,
         entireWord: true,
-        phraseSearch: true,
-        findPrevious: false,
       },
       matchesPerPage: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0],
       selectedMatch: {
@@ -233,12 +233,9 @@ describe("pdf_find_controller", function () {
     await testSearch({
       eventBus,
       pdfFindController,
-      parameters: {
+      state: {
         query: "alternate solution",
-        caseSensitive: false,
-        entireWord: false,
         phraseSearch: false,
-        findPrevious: false,
       },
       matchesPerPage: [0, 0, 0, 0, 0, 1, 0, 0, 4, 0, 0, 0, 0, 0],
       selectedMatch: {
@@ -256,12 +253,8 @@ describe("pdf_find_controller", function () {
     await testSearch({
       eventBus,
       pdfFindController,
-      parameters: {
+      state: {
         query: "fraction",
-        caseSensitive: false,
-        entireWord: false,
-        phraseSearch: true,
-        findPrevious: false,
       },
       matchesPerPage: [3],
       selectedMatch: {

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -219,6 +219,8 @@ class MozL10n {
     "findentirewordchange",
     "findbarclose",
   ];
+  const findLen = "find".length;
+
   const handleEvent = function ({ type, detail }) {
     if (!PDFViewerApplication.initialized) {
       return;
@@ -229,7 +231,7 @@ class MozL10n {
     }
     PDFViewerApplication.eventBus.dispatch("find", {
       source: window,
-      type: type.substring("find".length),
+      type: type.substring(findLen),
       query: detail.query,
       phraseSearch: true,
       caseSensitive: !!detail.caseSensitive,

--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -89,7 +89,7 @@ class PDFFindBar {
     this.updateUIState();
   }
 
-  dispatchEvent(type, findPrev) {
+  dispatchEvent(type, findPrev = false) {
     this.eventBus.dispatch("find", {
       source: this,
       type,

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -831,7 +831,7 @@ class PDFPageView {
     renderTask.promise.then(
       function () {
         showCanvas();
-        renderCapability.resolve(undefined);
+        renderCapability.resolve();
       },
       function (error) {
         showCanvas();

--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -278,7 +278,7 @@ class PDFThumbnailView {
   draw() {
     if (this.renderingState !== RenderingStates.INITIAL) {
       console.error("Must be in new state before drawing");
-      return Promise.resolve(undefined);
+      return Promise.resolve();
     }
     const { pdfPage } = this;
 


### PR DESCRIPTION
Looking at the code, I do have to agree with the point made in issue #12731 about it being unexpected/unhelpful that the `PDFFindController.executeCommand`-method isn't directly usable with the "find"-event.
The reason for it being this way is, as so often, for historical reasons: The `executeCommand`-method was added (just) prior to the introduction of the `EventBus` in the viewer.

Obviously we cannot simply change the existing `PDFFindController.executeCommand`-method, since that'd be a breaking change in code which has existed for over five years.
Initially I figured that we could simply add a new method in `PDFFindController` that'd accept the state from the "find"-event, however after thinking about this and looking through the use-cases in the default viewer I settled on a slightly different approach: Let the `PDFFindController` just listen for the "find"-event (on the `EventBus`-instance) directly instead, which also removes one level of (unneeded) indirection during searching in the default viewer.

For GENERIC builds of the PDF.js library, the old `PDFFindController.executeCommand`-method is still available with a deprecation warning.

Fixes #12731 