### PR TITLE
Empty name is allowed in ISO 32000

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -1116,8 +1116,6 @@ class Lexer {
     }
     if (strBuf.length > 127) {
       warn(`Name token is longer than allowed by the spec: ${strBuf.length}`);
-    } else if (strBuf.length === 0) {
-      warn("Name token is empty.");
     }
     return Name.get(strBuf.join(""));
   }


### PR DESCRIPTION
  - the exact sentence from the spec:
    "The token SOLIDUS (a slash followed by no regular characters) introduces a unique valid name defined by the empty sequence of characters."
  - so just remove the warning.