### PR TITLE
For Annotations that define a closed area, make all of it toggle the PopupAnnotation (issue 14107)

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -1798,6 +1798,7 @@ class LineAnnotationElement extends AnnotationElement {
     // won't be possible to open/close the popup (note e.g. issue 11122).
     line.setAttribute("stroke-width", data.borderStyle.width || 1);
     line.setAttribute("stroke", "transparent");
+    line.setAttribute("fill", "transparent");
 
     svg.appendChild(line);
     this.container.append(svg);
@@ -1844,7 +1845,7 @@ class SquareAnnotationElement extends AnnotationElement {
     // won't be possible to open/close the popup (note e.g. issue 11122).
     square.setAttribute("stroke-width", borderWidth || 1);
     square.setAttribute("stroke", "transparent");
-    square.setAttribute("fill", "none");
+    square.setAttribute("fill", "transparent");
 
     svg.appendChild(square);
     this.container.append(svg);
@@ -1891,7 +1892,7 @@ class CircleAnnotationElement extends AnnotationElement {
     // won't be possible to open/close the popup (note e.g. issue 11122).
     circle.setAttribute("stroke-width", borderWidth || 1);
     circle.setAttribute("stroke", "transparent");
-    circle.setAttribute("fill", "none");
+    circle.setAttribute("fill", "transparent");
 
     svg.appendChild(circle);
     this.container.append(svg);
@@ -1946,7 +1947,7 @@ class PolylineAnnotationElement extends AnnotationElement {
     // won't be possible to open/close the popup (note e.g. issue 11122).
     polyline.setAttribute("stroke-width", data.borderStyle.width || 1);
     polyline.setAttribute("stroke", "transparent");
-    polyline.setAttribute("fill", "none");
+    polyline.setAttribute("fill", "transparent");
 
     svg.appendChild(polyline);
     this.container.append(svg);
@@ -2034,7 +2035,7 @@ class InkAnnotationElement extends AnnotationElement {
       // won't be possible to open/close the popup (note e.g. issue 11122).
       polyline.setAttribute("stroke-width", data.borderStyle.width || 1);
       polyline.setAttribute("stroke", "transparent");
-      polyline.setAttribute("fill", "none");
+      polyline.setAttribute("fill", "transparent");
 
       // Create the popup ourselves so that we can bind it to the polyline
       // instead of to the entire container (which is the default).


### PR DESCRIPTION
For Circle, Square, and Polygon Annotations it's currently only possible to toggle the associated PopupAnnotation by clicking on its border. Depending on the border width, and also the current zoom-level in the viewer, that can make interacting with certain Annotations *practically* impossible (which is the case in issue 14107).
Hence, in order to improve this, change the "fill"-property of the SVG element in the annotationLayer to make the *entire* element part of the click/mouse-over target.

*Please note:* Given that this is a viewer-related issue, there's no simple way to test this as far as I can tell.

Fixes #14107