### PR TITLE
Take the /CIDToGIDMap data into account when computing the hash, in `PartialEvaluator.preEvaluateFont`, for composite fonts (bug 1734802)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -81,6 +81,7 @@ import {
   LocalTilingPatternCache,
 } from "./image_utils.js";
 import { NullStream, Stream } from "./stream.js";
+import { BaseStream } from "./base_stream.js";
 import { bidi } from "./bidi.js";
 import { ColorSpace } from "./colorspace.js";
 import { DecodeStream } from "./decode_stream.js";
@@ -3139,7 +3140,7 @@ class PartialEvaluator {
       }
 
       const cidToGidMap = dict.get("CIDToGIDMap");
-      if (isStream(cidToGidMap)) {
+      if (cidToGidMap instanceof BaseStream) {
         cidToGidBytes = cidToGidMap.getBytes();
       }
     }
@@ -3789,6 +3790,16 @@ class PartialEvaluator {
             }
           }
           hash.update(widthsBuf.join());
+        }
+
+        const cidToGidMap =
+          dict.getRaw("CIDToGIDMap") || baseDict.getRaw("CIDToGIDMap");
+        if (cidToGidMap instanceof Name) {
+          hash.update(cidToGidMap.name);
+        } else if (cidToGidMap instanceof Ref) {
+          hash.update(cidToGidMap.toString());
+        } else if (cidToGidMap instanceof BaseStream) {
+          hash.update(cidToGidMap.peekBytes());
         }
       }
     }

--- a/test/pdfs/bug1734802.pdf.link
+++ b/test/pdfs/bug1734802.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=9244936

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -166,6 +166,14 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "bug1734802",
+       "file": "pdfs/bug1734802.pdf",
+       "md5": "a23ad8af95ffca3876e110a5f4dec9bc",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 3,
+       "type": "eq"
+    },
     {  "id": "bug921760",
        "file": "pdfs/bug921760.pdf",
        "md5": "1aa136d786a65b0d7cce7bdb3c58c6c3",


### PR DESCRIPTION
This is unfortunately *yet another* bug in the `preEvaluateFont`-implementation, and I've lost count of the number of times I've had to tweak this code over the years :-(
I really cannot help thinking that PR #4423 was way too simplistic, since it missed a bunch of cases that leads to broken font rendering in many PDF documents.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1734802