### PR TITLE
[api-minor] Include the /Lang-property in the `documentInfo`, and use it in the viewer (issue 14110)

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -89,6 +89,15 @@ class Catalog {
     );
   }
 
+  get lang() {
+    const lang = this._catDict.get("Lang");
+    return shadow(
+      this,
+      "lang",
+      typeof lang === "string" ? stringToPDFString(lang) : null
+    );
+  }
+
   /**
    * @type {boolean} `true` for pure XFA documents,
    *   `false` for XFA Foreground documents.

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -1160,6 +1160,7 @@ class PDFDocument {
 
     const docInfo = {
       PDFFormatVersion: version,
+      Language: this.catalog.lang,
       IsLinearized: !!this.linearization,
       IsAcroFormPresent: this.formInfo.hasAcroForm,
       IsXFAPresent: this.formInfo.hasXfa,

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1161,6 +1161,7 @@ describe("api", function () {
       expect(info.Custom).toEqual(undefined);
       // The following are PDF.js specific, non-standard, properties.
       expect(info.PDFFormatVersion).toEqual("1.7");
+      expect(info.Language).toEqual("en");
       expect(info.IsLinearized).toEqual(false);
       expect(info.IsAcroFormPresent).toEqual(false);
       expect(info.IsXFAPresent).toEqual(false);
@@ -1195,6 +1196,7 @@ describe("api", function () {
       );
       // The following are PDF.js specific, non-standard, properties.
       expect(info.PDFFormatVersion).toEqual("1.4");
+      expect(info.Language).toEqual(null);
       expect(info.IsLinearized).toEqual(false);
       expect(info.IsAcroFormPresent).toEqual(false);
       expect(info.IsXFAPresent).toEqual(false);
@@ -1216,6 +1218,7 @@ describe("api", function () {
 
       // The following are PDF.js specific, non-standard, properties.
       expect(info.PDFFormatVersion).toEqual(null);
+      expect(info.Language).toEqual(null);
       expect(info.IsLinearized).toEqual(false);
       expect(info.IsAcroFormPresent).toEqual(false);
       expect(info.IsXFAPresent).toEqual(false);

--- a/web/app.js
+++ b/web/app.js
@@ -812,6 +812,7 @@ const PDFViewerApplication = {
       const { container } = this.appConfig.errorWrapper;
       container.hidden = true;
     }
+    this.appConfig.viewerContainer.removeAttribute("lang");
 
     if (!this.pdfLoadingTask) {
       return;
@@ -1536,6 +1537,9 @@ const PDFViewerApplication = {
         `(PDF.js: ${version || "-"})`
     );
 
+    if (info.Language) {
+      this.appConfig.viewerContainer.lang = info.Language;
+    }
     let pdfTitle = info?.Title;
 
     const metadataTitle = metadata?.get("dc:title");


### PR DESCRIPTION
*Please note:* This is a tentative patch, since I don't have the necessary a11y-software to actually test it.

To avoid having to add a new API-method just for a single string, I figured that adding the new property to the existing `documentInfo`-data (accessed via `PDFDocumentProxy.getMetadata` in the API) will hopefully be deemed acceptable.

Fixes #14110