### PR TITLE
Ensure that pre-rendering works correctly with spreadModes at higher zoom levels

### DIFF
--- a/web/pdf_rendering_queue.js
+++ b/web/pdf_rendering_queue.js
@@ -126,10 +126,24 @@ class PDFRenderingQueue {
         return view;
       }
     }
+    const firstId = visible.first.id,
+      lastId = visible.last.id;
+
+    // All the visible views have rendered; try to handle any "holes" in the
+    // page layout (can happen e.g. with spreadModes at higher zoom levels).
+    if (lastId - firstId > 1) {
+      for (let i = 0, ii = lastId - firstId; i <= ii; i++) {
+        const holeId = scrolledDown ? firstId + i : lastId - i,
+          holeView = views[holeId - 1];
+        if (!this.isViewFinished(holeView)) {
+          return holeView;
+        }
+      }
+    }
 
     // All the visible views have rendered; try to render next/previous page.
     // (IDs start at 1, so no need to add 1 when `scrolledDown === true`.)
-    let preRenderIndex = scrolledDown ? visible.last.id : visible.first.id - 2;
+    let preRenderIndex = scrolledDown ? lastId : firstId - 2;
     let preRenderView = views[preRenderIndex];
 
     if (preRenderView && !this.isViewFinished(preRenderView)) {


### PR DESCRIPTION
Having recently worked with this code, in PR #14096 (and indirectly in PR #14112), I happened to notice a pre-existing issue with spreadModes at higher zoom levels.
The `PDFRenderingQueue` code was written back when the viewer only supported "normal" vertical scrolling, and some edge-cases related to spreadModes are thus not perfectly supported. Depending on the zoom level, it's possible that there are "holes" in the currently visible page layout, and those pages will not be pre-rendered as you'd expect.

*Steps to reproduce:*

 0. Open the viewer, e.g. https://mozilla.github.io/pdf.js/web/viewer.html
 1. Enable vertical scrolling.
 2. Enable the ODD spreadMode.
 3. Scroll down, such that both pages 1 and 3 are visible.
 4. Zoom-in until *only* page 1 and 3 are visible.
 5. Open the devtools and, using the DOM Inspector, notice how page 2 is *not* being pre-rendered despite all surrounding pages being rendered.

---

![data-loaded](https://user-images.githubusercontent.com/2692120/137203127-cb36b0cf-c79a-460a-a3ec-8cfbd5822b8a.png)

