### PR TITLE
Convert examples/components/simpleviewer.js to await/async

### DIFF
--- a/examples/components/simpleviewer.js
+++ b/examples/components/simpleviewer.js
@@ -88,10 +88,12 @@ const loadingTask = pdfjsLib.getDocument({
   cMapPacked: CMAP_PACKED,
   enableXfa: ENABLE_XFA,
 });
-loadingTask.promise.then(function (pdfDocument) {
+
+(async function () {
   // Document loaded, specifying document for the viewer and
   // the (optional) linkService.
+  const pdfDocument = await loadingTask;
   pdfViewer.setDocument(pdfDocument);
 
   pdfLinkService.setDocument(pdfDocument, null);
-});
+})();


### PR DESCRIPTION
### Because

Simpleviewer.js uses chain of promises

### This pull request

Convert examples/components/simpleviewer.js to await/async

### Issue that this pull request solves

Closes: #14128

Checklist

Put an x in the boxes that apply

  

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).