### PR TITLE
Convert examples/components/pageviewer.js to await/async

### DIFF
--- a/examples/components/pageviewer.js
+++ b/examples/components/pageviewer.js
@@ -47,28 +47,29 @@ const loadingTask = pdfjsLib.getDocument({
   cMapPacked: CMAP_PACKED,
   enableXfa: ENABLE_XFA,
 });
-loadingTask.promise.then(function (pdfDocument) {
+
+(async function () {
+  const pdfDocument = await loadingTask;
   // Document loaded, retrieving the page.
-  return pdfDocument.getPage(PAGE_TO_VIEW).then(function (pdfPage) {
-    // Creating the page view with default parameters.
-    const pdfPageView = new pdfjsViewer.PDFPageView({
-      container,
-      id: PAGE_TO_VIEW,
-      scale: SCALE,
-      defaultViewport: pdfPage.getViewport({ scale: SCALE }),
-      eventBus,
-      // We can enable text/annotation/xfa/struct-layers, as needed.
-      textLayerFactory: !pdfDocument.isPureXfa
-        ? new pdfjsViewer.DefaultTextLayerFactory()
-        : null,
-      annotationLayerFactory: new pdfjsViewer.DefaultAnnotationLayerFactory(),
-      xfaLayerFactory: pdfDocument.isPureXfa
-        ? new pdfjsViewer.DefaultXfaLayerFactory()
-        : null,
-      structTreeLayerFactory: new pdfjsViewer.DefaultStructTreeLayerFactory(),
-    });
-    // Associate the actual page with the view, and draw it.
-    pdfPageView.setPdfPage(pdfPage);
-    return pdfPageView.draw();
+  const pdfPage = await pdfDocument.getPage(PAGE_TO_VIEW);
+  // Creating the page view with default parameters.
+  const pdfPageView = new pdfjsViewer.PDFPageView({
+    container,
+    id: PAGE_TO_VIEW,
+    scale: SCALE,
+    defaultViewport: pdfPage.getViewport({ scale: SCALE }),
+    eventBus,
+    // We can enable text/annotation/xfa/struct-layers, as needed.
+    textLayerFactory: !pdfDocument.isPureXfa
+      ? new pdfjsViewer.DefaultTextLayerFactory()
+      : null,
+    annotationLayerFactory: new pdfjsViewer.DefaultAnnotationLayerFactory(),
+    xfaLayerFactory: pdfDocument.isPureXfa
+      ? new pdfjsViewer.DefaultXfaLayerFactory()
+      : null,
+    structTreeLayerFactory: new pdfjsViewer.DefaultStructTreeLayerFactory(),
   });
-});
+  // Associate the actual page with the view, and draw it.
+  pdfPageView.setPdfPage(pdfPage);
+  return pdfPageView.draw();
+})();


### PR DESCRIPTION
### Because

Pageviewer.js uses chain of promises

### This pull request

Convert examples/components/pageviewer.js to async/await

Issue that this pull request solves

Closes: #14127

Checklist

Put an x in the boxes that apply

  

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).