### PR TITLE
Convert examples/node/pdf2png/pdf2png.js to await/async

### DIFF
--- a/examples/node/pdf2png/pdf2png.js
+++ b/examples/node/pdf2png/pdf2png.js
@@ -70,41 +70,40 @@ const loadingTask = pdfjsLib.getDocument({
   cMapPacked: CMAP_PACKED,
   standardFontDataUrl: STANDARD_FONT_DATA_URL,
 });
-loadingTask.promise
-  .then(function (pdfDocument) {
+
+(async function () {
+  try {
+    const pdfDocument = await loadingTask.promise;
     console.log("# PDF document loaded.");
-
     // Get the first page.
-    pdfDocument.getPage(1).then(function (page) {
-      // Render the page on a Node canvas with 100% scale.
-      const viewport = page.getViewport({ scale: 1.0 });
-      const canvasFactory = new NodeCanvasFactory();
-      const canvasAndContext = canvasFactory.create(
-        viewport.width,
-        viewport.height
-      );
-      const renderContext = {
-        canvasContext: canvasAndContext.context,
-        viewport,
-        canvasFactory,
-      };
+    const page = await pdfDocument.getPage(1);
+    // Render the page on a Node canvas with 100% scale.
+    const viewport = page.getViewport({ scale: 1.0 });
+    const canvasFactory = new NodeCanvasFactory();
+    const canvasAndContext = canvasFactory.create(
+      viewport.width,
+      viewport.height
+    );
+    const renderContext = {
+      canvasContext: canvasAndContext.context,
+      viewport,
+      canvasFactory,
+    };
 
-      const renderTask = page.render(renderContext);
-      renderTask.promise.then(function () {
-        // Convert the canvas to an image buffer.
-        const image = canvasAndContext.canvas.toBuffer();
-        fs.writeFile("output.png", image, function (error) {
-          if (error) {
-            console.error("Error: " + error);
-          } else {
-            console.log(
-              "Finished converting first page of PDF file to a PNG image."
-            );
-          }
-        });
-      });
+    const renderTask = page.render(renderContext);
+    await renderTask.promise;
+    // Convert the canvas to an image buffer.
+    const image = canvasAndContext.canvas.toBuffer();
+    fs.writeFile("output.png", image, function (error) {
+      if (error) {
+        console.error("Error: " + error);
+      } else {
+        console.log(
+          "Finished converting first page of PDF file to a PNG image."
+        );
+      }
     });
-  })
-  .catch(function (reason) {
+  } catch (reason) {
     console.log(reason);
-  });
+  }
+})();


### PR DESCRIPTION
### Because

Pdf2png.js uses chain of promises

### This pull request

Convert examples/node/pdf2png/pdf2png.js to await/async

### Issue that this pull request solves

Closes: #14126

### Checklist

Put an x in the boxes that apply

  

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).