### PR TITLE
XFA - Embedded image is missing

### DIFF
--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -138,6 +138,7 @@ const MIMES = new Set([
   "image/x-ms-bmp",
   "image/tiff",
   "image/tif",
+  "application/octet-stream",
 ]);
 
 const IMAGES_HEADERS = [

--- a/test/pdfs/xfa_issue14144.pdf.link
+++ b/test/pdfs/xfa_issue14144.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/7352426/FormDB2_fr.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -6002,5 +6002,14 @@
        "rounds": 1,
        "type": "eq",
        "annotations": true
+    },
+    { "id": "xfa_issue14144",
+      "file": "pdfs/xfa_issue14144.pdf",
+      "md5": "6a0e99edcf31e815dd0e1395e8dc15f2",
+      "link": true,
+      "rounds": 1,
+      "enableXfa": true,
+      "type": "eq",
+      "lastPage": 1
     }
 ]


### PR DESCRIPTION
### Because

XFA - Embedded image is missing.
(the image on the top of each pages is missing)

### This pull request

Added MIME file format to be able to see/read proper that img

### Issue that this pull request solves

Closes: #14144

### References images
<img width="1288" alt="test_vs_makeref" src="https://user-images.githubusercontent.com/76935202/137475378-397362ae-4b23-4ada-8443-33af5bc89bcd.png">


### Checklist

- [x] My commit is GPG signed.
- [x] Makeref vs unit test screens attached