### PR TITLE
Fix XFA links (bug 1735738)

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -291,6 +291,10 @@ var rasterizeXfaLayer = (function rasterizeXfaLayerClosure() {
       file: "../web/xfa_layer_builder.css",
       promise: null,
     },
+    overrides: {
+      file: "./xfa_layer_builder_overrides.css",
+      promise: null,
+    },
   };
 
   function getXfaLayerStyle() {
@@ -326,8 +330,8 @@ var rasterizeXfaLayer = (function rasterizeXfaLayerClosure() {
       foreignObject.appendChild(div);
 
       stylePromise
-        .then(async ([cssRules]) => {
-          style.textContent = fontRules + "\n" + cssRules;
+        .then(async ([common, overrides]) => {
+          style.textContent = fontRules + "\n" + common + "\n" + overrides;
 
           XfaLayer.render({
             xfa,

--- a/test/pdfs/xfa_bug1735738.pdf.link
+++ b/test/pdfs/xfa_bug1735738.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=9227382

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -6011,5 +6011,13 @@
       "enableXfa": true,
       "type": "eq",
       "lastPage": 1
+    },
+    { "id": "xfa_bug1735738",
+      "file": "pdfs/xfa_bug1735738.pdf",
+      "md5": "7aa91f6681798c48e0c9d9836ed30742",
+      "enableXfa": true,
+      "link": true,
+      "rounds": 1,
+      "type": "eq"
     }
 ]

--- a/test/xfa_layer_builder_overrides.css
+++ b/test/xfa_layer_builder_overrides.css
@@ -1,0 +1,20 @@
+/* Copyright 2021 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.xfaLink {
+  opacity: 0.2;
+  background: rgba(255, 255, 0, 1);
+  box-shadow: 0 2px 10px rgba(255, 255, 0, 1);
+}

--- a/web/xfa_layer_builder.css
+++ b/web/xfa_layer_builder.css
@@ -223,6 +223,9 @@
 .xfaLink {
   width: 100%;
   height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
 }
 
 .xfaCheckbox,


### PR DESCRIPTION
At the end the anchor tag inside the button wasn't the problem here, after comparing the reference file and this one 

> https://bug1716758.bmoattachments.org/attachment.cgi?id=9240360

I realized that in the reference file the anchor tag has an inline display and couldn't receive any height. After changing the display to inline-block it started working but since it receives a 100% height the text wasn't showing properly so I added an absolute position and now the reference file it's working in both Firefox nightly and Chrome.

It also solves a bug in this file 

> https://bug1716758.bmoattachments.org/attachment.cgi?id=9240360

Where the second link in schedule II wasn't working at all, now all links in both files are working just fine.

Thank you @calixteman for explaining me with so much patience!

closes #14139