### PR TITLE
Revert "For mozcentral use Firefox color theme instead of system theme." since `-moz-toolbar-prefers-color-scheme` was removed

### DIFF
--- a/external/builder/builder.js
+++ b/external/builder/builder.js
@@ -270,12 +270,6 @@ function preprocessCSS(mode, source, destination) {
   content = expandImports(content, source);
   if (mode === "mozcentral") {
     content = removePrefixed(content, hasPrefixedMozcentral);
-    // In the mozcentral version the color theme should be based on the Firefox
-    // theme instead of the system theme.
-    content = content.replace(
-      "prefers-color-scheme",
-      "-moz-toolbar-prefers-color-scheme"
-    );
   }
   fs.writeFileSync(destination, content);
 }

--- a/web/app.js
+++ b/web/app.js
@@ -431,23 +431,21 @@ const PDFViewerApplication = {
     try {
       const styleSheet = document.styleSheets[0];
       const cssRules = styleSheet?.cssRules || [];
-      const mediaMatcher =
-        typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")
-          ? "-moz-toolbar-prefers-color-scheme"
-          : "prefers-color-scheme";
-      const mediaRule = `(${mediaMatcher}: dark)`;
-      const mediaRegex = new RegExp(
-        `^@media \\(${mediaMatcher}: dark\\) {\\n\\s*([\\w\\s-.,:;/\\\\{}()]+)\\n}$`
-      );
       for (let i = 0, ii = cssRules.length; i < ii; i++) {
         const rule = cssRules[i];
-        if (rule instanceof CSSMediaRule && rule.media?.[0] === mediaRule) {
+        if (
+          rule instanceof CSSMediaRule &&
+          rule.media?.[0] === "(prefers-color-scheme: dark)"
+        ) {
           if (cssTheme === ViewerCssTheme.LIGHT) {
             styleSheet.deleteRule(i);
             return;
           }
           // cssTheme === ViewerCssTheme.DARK
-          const darkRules = mediaRegex.exec(rule.cssText);
+          const darkRules =
+            /^@media \(prefers-color-scheme: dark\) {\n\s*([\w\s-.,:;/\\{}()]+)\n}$/.exec(
+              rule.cssText
+            );
           if (darkRules?.[1]) {
             styleSheet.deleteRule(i);
             styleSheet.insertRule(darkRules[1], i);


### PR DESCRIPTION
Reverts mozilla/pdf.js#13314, see https://groups.google.com/g/firefox-dev/c/vajhbYKDpPM

Given that `-moz-toolbar-prefers-color-scheme` was removed in https://bugzilla.mozilla.org/show_bug.cgi?id=1736038, unless we fix this before the next PDF.js update in mozilla-central we'll thus break dark mode in the Firefox built-in PDF Viewer.