### PR TITLE
Improve pre-rendering at the start/end of the document

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -1361,10 +1361,12 @@ class BaseViewer {
     return promise;
   }
 
-  /**
-   * @private
-   */
-  get _scrollAhead() {
+  #getScrollAhead(views) {
+    if (views.first.id === 1) {
+      return true;
+    } else if (views.last.id === this.pagesCount) {
+      return false;
+    }
     switch (this._scrollMode) {
       case ScrollMode.PAGE:
         return this._scrollModePageState.scrollDown;
@@ -1376,7 +1378,7 @@ class BaseViewer {
 
   forceRendering(currentlyVisiblePages) {
     const visiblePages = currentlyVisiblePages || this._getVisiblePages();
-    const scrollAhead = this._scrollAhead;
+    const scrollAhead = this.#getScrollAhead(visiblePages);
     const preRenderExtra =
       this._spreadMode !== SpreadMode.NONE &&
       this._scrollMode !== ScrollMode.HORIZONTAL;

--- a/web/pdf_rendering_queue.js
+++ b/web/pdf_rendering_queue.js
@@ -82,10 +82,11 @@ class PDFRenderingQueue {
       return;
     }
     // No pages needed rendering, so check thumbnails.
-    if (this.pdfThumbnailViewer && this.isThumbnailViewEnabled) {
-      if (this.pdfThumbnailViewer.forceRendering()) {
-        return;
-      }
+    if (
+      this.isThumbnailViewEnabled &&
+      this.pdfThumbnailViewer?.forceRendering()
+    ) {
+      return;
     }
 
     if (this.printing) {

--- a/web/pdf_rendering_queue.js
+++ b/web/pdf_rendering_queue.js
@@ -132,7 +132,7 @@ class PDFRenderingQueue {
     // All the visible views have rendered; try to handle any "holes" in the
     // page layout (can happen e.g. with spreadModes at higher zoom levels).
     if (lastId - firstId > 1) {
-      for (let i = 0, ii = lastId - firstId; i <= ii; i++) {
+      for (let i = 1, ii = lastId - firstId; i < ii; i++) {
         const holeId = scrolledDown ? firstId + i : lastId - i,
           holeView = views[holeId - 1];
         if (!this.isViewFinished(holeView)) {

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -295,12 +295,22 @@ class PDFThumbnailViewer {
     return promise;
   }
 
+  #getScrollAhead(views) {
+    if (views.first.id === 1) {
+      return true;
+    } else if (views.last.id === this._thumbnails.length) {
+      return false;
+    }
+    return this.scroll.down;
+  }
+
   forceRendering() {
     const visibleThumbs = this._getVisibleThumbs();
+    const scrollAhead = this.#getScrollAhead(visibleThumbs);
     const thumbView = this.renderingQueue.getHighestPriority(
       visibleThumbs,
       this._thumbnails,
-      this.scroll.down
+      scrollAhead
     );
     if (thumbView) {
       this._ensurePdfPageLoaded(thumbView).then(() => {


### PR DESCRIPTION
This is a very old "issue", which has existed since essentially forever, and it affects all of the available scrollModes. However, in the recently added Page-mode it's particularily noticeable since we use a *simulated* scroll direction there.

When deciding what page(s) to pre-render, we only consider the current scroll direction. This works well in most cases, but can break down at the start/end of the document by trying to pre-render a page *outside* of the existing ones. To improve this, we'll thus *force* the scroll direction at the start/end of the document.

*Steps to reproduce:*

 0. Open the viewer, e.g. https://mozilla.github.io/pdf.js/web/viewer.html
 1. Enable vertical scrolling.
 2. Press the <kbd>End</kbd> key.
 3. Open the devtools and, using the DOM Inspector, notice how page 13 is *not* being pre-rendered.