### PR TITLE
Fix pattern handling regression in `SVGGraphics` (PR 13770 follow-up)

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -1160,6 +1160,9 @@ if (
      * @private
      */
     _makeShadingPattern(args) {
+      if (typeof args === "string") {
+        args = this.objs.get(args);
+      }
       switch (args[0]) {
         case "RadialAxial":
           const shadingId = `shading${shadingCount++}`;


### PR DESCRIPTION
While the FAQ clearly lists the SVG back-end as unsupported, see https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#backends, I suppose that small/simple regressions still makes sense to fix.