### PR TITLE
Ignore Square/Circle-annnotations with a zero borderWidth when creating a fallback appearance stream (issue 14164)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -2648,6 +2648,11 @@ class SquareAnnotation extends MarkupAnnotation {
       }
       const fillAlpha = fillColor ? strokeAlpha : null;
 
+      if (this.borderStyle.width === 0 && !fillColor) {
+        // Prevent rendering a "hairline" border (fixes issue14164.pdf).
+        return;
+      }
+
       this._setDefaultAppearance({
         xref: parameters.xref,
         extra: `${this.borderStyle.width} w`,
@@ -2696,6 +2701,11 @@ class CircleAnnotation extends MarkupAnnotation {
           : null;
       }
       const fillAlpha = fillColor ? strokeAlpha : null;
+
+      if (this.borderStyle.width === 0 && !fillColor) {
+        // Prevent rendering a "hairline" border (fixes issue14164.pdf).
+        return;
+      }
 
       // Circles are approximated by Bézier curves with four segments since
       // there is no circle primitive in the PDF specification. For the control

--- a/test/pdfs/issue14164.pdf.link
+++ b/test/pdfs/issue14164.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/7372181/Test.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -973,6 +973,14 @@
        "enableXfa": true,
        "type": "eq"
     },
+    {  "id": "issue14164",
+       "file": "pdfs/issue14164.pdf",
+       "md5": "feb444c716b0337efff8094b156def32",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "xfa_filled_imm1344e",
        "file": "pdfs/xfa_filled_imm1344e.pdf",
        "md5": "0576d16692fcd8ef2366cb48bf296e81",


### PR DESCRIPTION
Trying to render these Annotation-types, when the borderWidth is `0`, causes a "hairline" border to appear. If these Annotations included an appearance stream, as they are supposed to, this wouldn't have happened and the simplest solution here seem to be to just ignore these particular Annotations.

Fixes #14164