### PR TITLE
Prevent run-time errors in Node.js versions with `URL.createObjectURL` support (issue 14170)

### DIFF
--- a/examples/node/pdf2svg.js
+++ b/examples/node/pdf2svg.js
@@ -110,7 +110,11 @@ const loadingTask = pdfjsLib.getDocument({
       console.log();
 
       const opList = await page.getOperatorList();
-      const svgGfx = new pdfjsLib.SVGGraphics(page.commonObjs, page.objs);
+      const svgGfx = new pdfjsLib.SVGGraphics(
+        page.commonObjs,
+        page.objs,
+        /* forceDataSchema = */ true
+      );
       svgGfx.embedFonts = true;
       const svg = await svgGfx.getSVG(opList, viewport);
       await writeSvgToFile(svg, getFilePathForPage(pageNum));

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1030,7 +1030,7 @@ function createPromiseCapability() {
 }
 
 function createObjectURL(data, contentType = "", forceDataSchema = false) {
-  if (URL.createObjectURL && !forceDataSchema) {
+  if (URL.createObjectURL && typeof Blob !== "undefined" && !forceDataSchema) {
     return URL.createObjectURL(new Blob([data], { type: contentType }));
   }
   // Blob/createObjectURL is not available, falling back to data schema.


### PR DESCRIPTION
Apparently Node.js has added *global* `URL.createObjectURL` support, but not done the same thing for `Blob`. Hence we also need to check for the availability of `Blob` in the `createObjectURL` helper function, and it's probably a good idea to also update `examples/node/pdf2svg.js` to work-around this until these changes reach an official PDF.js release.

Fixes #14170