### PR TITLE
Prevent double-rendering borders for PushButton-annotations (PR 14083 follow-up)

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -421,7 +421,7 @@ class AnnotationElement {
 }
 
 class LinkAnnotationElement extends AnnotationElement {
-  constructor(parameters) {
+  constructor(parameters, options = null) {
     const isRenderable = !!(
       parameters.data.url ||
       parameters.data.dest ||
@@ -433,7 +433,11 @@ class LinkAnnotationElement extends AnnotationElement {
           parameters.data.actions["Mouse Up"] ||
           parameters.data.actions["Mouse Down"]))
     );
-    super(parameters, { isRenderable, createQuadrilaterals: true });
+    super(parameters, {
+      isRenderable,
+      ignoreBorder: !!options?.ignoreBorder,
+      createQuadrilaterals: true,
+    });
   }
 
   render() {
@@ -1298,6 +1302,10 @@ class RadioButtonWidgetAnnotationElement extends WidgetAnnotationElement {
 }
 
 class PushButtonWidgetAnnotationElement extends LinkAnnotationElement {
+  constructor(parameters) {
+    super(parameters, { ignoreBorder: parameters.data.hasAppearance });
+  }
+
   render() {
     // The rendering and functionality of a push button widget annotation is
     // equal to that of a link annotation, but may have more functionality, such


### PR DESCRIPTION
With ResetForm-action support added in PR #14083, there's a regression in the `issue12716` test-case. More specifically the border around the "Clear Form"-link is now rendered *twice*, once in the canvas via the appearance-stream and once in the annotationLayer via the border-data.
This looks slightly weird, and was most likely not intended, which is why this patch suggests that we ignore the border in the annotationLayer when an appearance-stream exists.