### PR TITLE
Converted simple viewer.js to await/async #14128 

### DIFF
--- a/examples/components/simpleviewer.js
+++ b/examples/components/simpleviewer.js
@@ -92,10 +92,9 @@ const loadingTask = pdfjsLib.getDocument({
   cMapPacked: CMAP_PACKED,
   enableXfa: ENABLE_XFA,
 });
-loadingTask.promise.then(function (pdfDocument) {
-  // Document loaded, specifying document for the viewer and
-  // the (optional) linkService.
+(async () => {
+  const pdfDocument = await loadingTask.promise;
   pdfViewer.setDocument(pdfDocument);
 
   pdfLinkService.setDocument(pdfDocument, null);
-});
+})();


### PR DESCRIPTION
 #14128 

- converted examples/components/simple viewer.js to await/async since it was using outdated style of 
   promise.then and callbacks. 
