### PR TITLE
Ignore pageLabels, in the viewer, when they're all empty

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1632,12 +1632,6 @@ const PDFViewerApplication = {
       return;
     }
     const numLabels = labels.length;
-    if (numLabels !== this.pagesCount) {
-      console.error(
-        "The number of Page Labels does not match the number of pages in the document."
-      );
-      return;
-    }
     let i = 0;
     // Ignore page labels that correspond to standard page numbering.
     while (i < numLabels && labels[i] === (i + 1).toString()) {

--- a/web/app.js
+++ b/web/app.js
@@ -1632,12 +1632,21 @@ const PDFViewerApplication = {
       return;
     }
     const numLabels = labels.length;
-    let i = 0;
-    // Ignore page labels that correspond to standard page numbering.
-    while (i < numLabels && labels[i] === (i + 1).toString()) {
-      i++;
+    // Ignore page labels that correspond to standard page numbering,
+    // or page labels that are all empty.
+    let standardLabels = 0,
+      emptyLabels = 0;
+    for (let i = 0; i < numLabels; i++) {
+      const label = labels[i];
+      if (label === (i + 1).toString()) {
+        standardLabels++;
+      } else if (label === "") {
+        emptyLabels++;
+      } else {
+        break;
+      }
     }
-    if (i === numLabels) {
+    if (standardLabels >= numLabels || emptyLabels >= numLabels) {
       return;
     }
     const { pdfViewer, pdfThumbnailViewer, toolbar } = this;


### PR DESCRIPTION
 - Remove unnecessary pageLabel length-check in the viewer

   Given how the pageLabel array is defined, see https://github.com/mozilla/pdf.js/blob/1ab9a6e36e84389775e5f3d6faebdb6b327b8d62/src/core/catalog.js#L627, it shouldn't be necessary to check the length in the viewer.

 - Ignore pageLabels, in the viewer, when they're all empty

   Unfortunately there exist PDF documents where all pageLabels are empty strings, see e.g. http://www.cs.cornell.edu/~ragarwal/pubs/blk-switch.pdf (taken from an old issue), which result in the pageNumber-input being completely blank. That doesn't seem very helpful, and this patch simply extends the approach used to ignore pageLabels that are identical to standard page numbering.

