### PR TITLE
[Regression] Prevent breaking errors when opening a new document in the GENERIC viewer (PR 14158 follow-up)

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -1361,10 +1361,10 @@ class BaseViewer {
     return promise;
   }
 
-  #getScrollAhead(views) {
-    if (views.first.id === 1) {
+  #getScrollAhead(visible) {
+    if (visible.first?.id === 1) {
       return true;
-    } else if (views.last.id === this.pagesCount) {
+    } else if (visible.last?.id === this.pagesCount) {
       return false;
     }
     switch (this._scrollMode) {

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -295,10 +295,10 @@ class PDFThumbnailViewer {
     return promise;
   }
 
-  #getScrollAhead(views) {
-    if (views.first.id === 1) {
+  #getScrollAhead(visible) {
+    if (visible.first?.id === 1) {
       return true;
-    } else if (views.last.id === this._thumbnails.length) {
+    } else if (visible.last?.id === this._thumbnails.length) {
       return false;
     }
     return this.scroll.down;


### PR DESCRIPTION
In the GENERIC viewer, e.g. when dragging-and-dropping a new PDF document which automatically opens the outline, there can now be breaking errors in the `{BaseViewer, PDFThumbnailViewer}.#getScrollAhead` methods since there's no visible pages/thumbs during loading; sorry about the breakage!