### PR TITLE
Avoid to display download panel during integration tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -921,6 +921,7 @@ async function startBrowser(browserName, startUrl = "") {
       "pdfjs.disabled": true,
       "browser.helperApps.neverAsk.saveToDisk": "application/pdf",
       // Avoid popup when saving is done
+      "browser.download.improvements_to_download_panel": false,
       "browser.download.panel.shown": true,
       // Save file in output
       "browser.download.folderList": 2,


### PR DESCRIPTION
  - it could be the cause of the failures in #14189;
  - and the patch in firefox to enable the pref landed very recently:
  https://hg.mozilla.org/mozilla-central/rev/3de56e38f3c87f33a1e7849701edb3c62bc472a5