### PR TITLE
Use the correct border-style for Annotations, when a dash array is specified (bug 1219400)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -660,7 +660,7 @@ class Annotation {
 
         if (array.length === 4) {
           // Dash array available
-          this.borderStyle.setDashArray(array[3]);
+          this.borderStyle.setDashArray(array[3], /* forceStyle = */ true);
         }
       }
     } else {
@@ -981,8 +981,9 @@ class AnnotationBorderStyle {
    * @public
    * @memberof AnnotationBorderStyle
    * @param {Array} dashArray - The dash array with at least one element
+   * @param {boolean} [forceStyle]
    */
-  setDashArray(dashArray) {
+  setDashArray(dashArray, forceStyle = false) {
     // We validate the dash array, but we do not use it because CSS does not
     // allow us to change spacing of dashes. For more information, visit
     // http://www.w3.org/TR/css3-background/#the-border-style.
@@ -1002,6 +1003,12 @@ class AnnotationBorderStyle {
       }
       if (isValid && !allZeros) {
         this.dashArray = dashArray;
+
+        if (forceStyle) {
+          // Even though we cannot use the dash array in the display layer,
+          // at least ensure that we use the correct border-style.
+          this.setStyle(Name.get("D"));
+        }
       } else {
         this.width = 0; // Adobe behavior when the array is invalid.
       }

--- a/test/pdfs/bug1219400.pdf.link
+++ b/test/pdfs/bug1219400.pdf.link
@@ -1,0 +1,1 @@
+https://web.archive.org/web/20160212224934/http://www.ghostscript.com/doc/examples/annots.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1822,6 +1822,15 @@
        "link": false,
        "type": "eq"
     },
+    {  "id": "bug1219400",
+       "file": "pdfs/bug1219400.pdf",
+       "md5": "a1554914cc9653d5ee0b9220657b334f",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq",
+       "annotations": true
+    },
     {  "id": "bug1245391",
        "file": "pdfs/bug1245391_reduced.pdf",
        "md5": "6c946045ee0f2f663f269717c0f1614a",


### PR DESCRIPTION
Even though we cannot use the dash array in the display layer, at least ensure that we use the correct border-style.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1219400