### PR TITLE
JS - Avoid a popup to ask for specific version of Acrobat

### DIFF
--- a/src/scripting_api/app.js
+++ b/src/scripting_api/app.js
@@ -21,8 +21,8 @@ import { Thermometer } from "./thermometer.js";
 
 const VIEWER_TYPE = "PDF.js";
 const VIEWER_VARIATION = "Full";
-const VIEWER_VERSION = "10.0";
-const FORMS_VERSION = undefined;
+const VIEWER_VERSION = 21.00720099;
+const FORMS_VERSION = 21.00720099;
 
 class App extends PDFObject {
   constructor(data) {


### PR DESCRIPTION
### Because

Popup keep asking regarding specific version of Acrobat (Spanish and version 5.0 or greater).
That happens because:
- JS in pdf is enabled;
- And the pdf contains some unsupported features (e.g. XFA);

By searching through pdf source code I have found that there is an embedded JS in pdf throws error & alert, if
```
If ( app.formVersion = undefined || app.formVersion < 5.0 ) {
Alert(“These documents are only functional in Spanish versions of Acrobat equal to or greater than 5.0”);
}
```

Regarding documents in https://helpx.adobe.com/livecycle/help/mobile-forms/scripting-support.html for Scripting Support,


### <img width="783" alt="Screen Shot 2021-10-29 at 10 17 05 am" src="https://user-images.githubusercontent.com/76935202/139354979-9cda2c2d-9c03-4611-9948-eaa3734e508e.png">

### Issue that this pull request solves

Closes: #14206

<img width="1279" alt="good" src="https://user-images.githubusercontent.com/76935202/139354995-b04a527d-0860-45fd-9466-6c43ef34fd32.png">
