### PR TITLE
[Google Chrome] Ensure that `markedContent` spans are placed in the top-left corner (issue 14205)

### DIFF
--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -35,6 +35,13 @@
   transform-origin: 0% 0%;
 }
 
+/* Only necessary in Google Chrome, see issue 14205, and most unfortunately
+ * the problem doesn't show up in "text" reference tests. */
+.textLayer span.markedContent {
+  top: 0;
+  height: 0;
+}
+
 .textLayer .highlight {
   margin: -1px;
   padding: 1px;


### PR DESCRIPTION
*This is a tentative patch, since we unfortunately cannot easily test it (as far as I can tell).*

In Firefox this (obviously) works as-is, but in Google Chrome the `markedContent` spans are inserted within the regular text-content (in the DOM) and with non-zero heights.

Fixes #14205