### PR TITLE
Change annotation border with correct width

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -884,7 +884,7 @@ class Annotation {
  */
 class AnnotationBorderStyle {
   constructor() {
-    this.width = 1;
+    this.width = 3;
     this.style = AnnotationBorderStyleType.SOLID;
     this.dashArray = [3];
     this.horizontalCornerRadius = 0;

--- a/test/pdfs/issue14203.pdf.link
+++ b/test/pdfs/issue14203.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/7428963/pdfcomment.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -6012,4 +6012,13 @@
       "type": "eq",
       "lastPage": 1
     }
+    { "id": "issue14203",
+      "file": "pdfs/issue14203.pdf",
+      "md5": "26c1c1e7341bc23fb28d805fa516dbbe",
+      "link": true,
+      "rounds": 1,
+      "enableXfa": true,
+      "type": "eq",
+      "annotations": true    
+   }
 ]


### PR DESCRIPTION
CLoses #14203 

Annotation borders don't have the correct width in firefox compared to as rendered in Acrobat. Changes made in annotation border width property.  