### PR TITLE
Update xfa_layer_builder.css issue(14130)

### DIFF
--- a/web/xfa_layer_builder.css
+++ b/web/xfa_layer_builder.css
@@ -240,6 +240,7 @@
   white-space: pre-wrap;
   width: 100%;
   height: 100%;
+  display:none;
 }
 
 .xfaImage {


### PR DESCRIPTION
solves issue #14130 where "no-min you should not see this displays" instead of a blank page;
An  xfa subform will have a class "xfaRich",in case of a blank xfa subform,it lacks inline 'display' property while a non-empty one has an inline css 'display' property.it's external diplay being set to "none" solves the issue since a non empty one will have an inline property which will have precedence over the external hence displays.