### PR TITLE
Let `getVisibleElements` return a Set containing the visible element `id`s

### DIFF
--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -497,7 +497,8 @@ describe("ui_utils", function () {
     // This is a reimplementation of getVisibleElements without the
     // optimizations.
     function slowGetVisibleElements(scroll, pages) {
-      const views = [];
+      const views = [],
+        ids = new Set();
       const { scrollLeft, scrollTop } = scroll;
       const scrollRight = scrollLeft + scroll.clientWidth;
       const scrollBottom = scrollTop + scroll.clientHeight;
@@ -535,9 +536,10 @@ describe("ui_utils", function () {
             percent,
             widthPercent: (fractionWidth * 100) | 0,
           });
+          ids.add(view.id);
         }
       }
-      return { first: views[0], last: views[views.length - 1], views };
+      return { first: views[0], last: views[views.length - 1], views, ids };
     }
 
     // This function takes a fixed layout of pages and compares the system under
@@ -699,6 +701,7 @@ describe("ui_utils", function () {
         first: undefined,
         last: undefined,
         views: [],
+        ids: new Set(),
       });
     });
 
@@ -715,6 +718,7 @@ describe("ui_utils", function () {
         first: undefined,
         last: undefined,
         views: [],
+        ids: new Set(),
       });
     });
 

--- a/web/pdf_rendering_queue.js
+++ b/web/pdf_rendering_queue.js
@@ -133,9 +133,13 @@ class PDFRenderingQueue {
     // All the visible views have rendered; try to handle any "holes" in the
     // page layout (can happen e.g. with spreadModes at higher zoom levels).
     if (lastId - firstId + 1 > numVisible) {
+      const visibleIds = visible.ids;
       for (let i = 1, ii = lastId - firstId; i < ii; i++) {
-        const holeId = scrolledDown ? firstId + i : lastId - i,
-          holeView = views[holeId - 1];
+        const holeId = scrolledDown ? firstId + i : lastId - i;
+        if (visibleIds.has(holeId)) {
+          continue;
+        }
+        const holeView = views[holeId - 1];
         if (!this.isViewFinished(holeView)) {
           return holeView;
         }

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -99,26 +99,21 @@ class PDFThumbnailViewer {
       // ... and add the highlight to the new thumbnail.
       thumbnailView.div.classList.add(THUMBNAIL_SELECTED_CLASS);
     }
-    const visibleThumbs = this._getVisibleThumbs();
-    const numVisibleThumbs = visibleThumbs.views.length;
+    const { first, last, views } = this._getVisibleThumbs();
 
     // If the thumbnail isn't currently visible, scroll it into view.
-    if (numVisibleThumbs > 0) {
-      const first = visibleThumbs.first.id;
-      // Account for only one thumbnail being visible.
-      const last = numVisibleThumbs > 1 ? visibleThumbs.last.id : first;
-
+    if (views.length > 0) {
       let shouldScroll = false;
-      if (pageNumber <= first || pageNumber >= last) {
+      if (pageNumber <= first.id || pageNumber >= last.id) {
         shouldScroll = true;
       } else {
-        visibleThumbs.views.some(function (view) {
-          if (view.id !== pageNumber) {
-            return false;
+        for (const { id, percent } of views) {
+          if (id !== pageNumber) {
+            continue;
           }
-          shouldScroll = view.percent < 100;
-          return true;
-        });
+          shouldScroll = percent < 100;
+          break;
+        }
       }
       if (shouldScroll) {
         scrollIntoView(thumbnailView.div, { top: THUMBNAIL_SCROLL_MARGIN });

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -473,6 +473,7 @@ function getVisibleElements({
   }
 
   const visible = [],
+    ids = new Set(),
     numViews = views.length;
   let firstVisibleElementInd = binarySearchFirstItem(
     views,
@@ -558,6 +559,7 @@ function getVisibleElements({
       percent,
       widthPercent: (fractionWidth * 100) | 0,
     });
+    ids.add(view.id);
   }
 
   const first = visible[0],
@@ -572,7 +574,7 @@ function getVisibleElements({
       return a.id - b.id; // ensure stability
     });
   }
-  return { first, last, views: visible };
+  return { first, last, views: visible, ids };
 }
 
 /**


### PR DESCRIPTION
Note how in `PDFPageViewBuffer.resize` we're manually iterating through the visible pages in order to build a Set of the visible page `id`s. By instead moving the building of this Set into the `getVisibleElements` helper function, as part of the existing parsing, this code becomes *ever so slightly* more efficient.

Furthermore, more direct access to the visible page `id`s also come in handy in other parts of the viewer as well.
In the `BaseViewer.isPageVisible` method we no longer need to loop through the visible pages, but can instead directly check if the pageNumber is visible.
In the `PDFRenderingQueue.getHighestPriority` method, when checking for "holes" in the page layout, we can also avoid some unnecessary look-ups this way.

