### PR TITLE
XFA - Paragraphes must take their style values from the containing container (bug 1722003)

### DIFF
--- a/src/core/xfa/html_utils.js
+++ b/src/core/xfa/html_utils.js
@@ -565,6 +565,27 @@ function getCurrentPara(node) {
   return stack.length ? stack[stack.length - 1] : null;
 }
 
+function setParaStyle(node, nodeStyle) {
+  const para = getCurrentPara(node);
+  if (!para) {
+    return;
+  }
+
+  const paraStyle = para[$toStyle]();
+  for (const key of [
+    "paddingLeft",
+    "paddingRight",
+    "paddingTop",
+    "paddingBottom",
+    "textIndent",
+    "tabSize",
+  ]) {
+    if (!(key in nodeStyle) && key in paraStyle) {
+      nodeStyle[key] = paraStyle[key];
+    }
+  }
+}
+
 function setPara(node, nodeStyle, value) {
   if (value.attributes.class && value.attributes.class.includes("xfaRich")) {
     if (nodeStyle) {
@@ -596,9 +617,9 @@ function setPara(node, nodeStyle, value) {
       }
 
       const paraStyle = para[$toStyle]();
-      for (const [key, val] of Object.entries(paraStyle)) {
-        if (!(key in valueStyle)) {
-          valueStyle[key] = val;
+      for (const key of ["lineHeight", "textAlign"]) {
+        if (!(key in valueStyle) && key in paraStyle) {
+          valueStyle[key] = paraStyle[key];
         }
       }
     }
@@ -661,5 +682,6 @@ export {
   setFontFamily,
   setMinMaxDimensions,
   setPara,
+  setParaStyle,
   toStyle,
 };

--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -4289,7 +4289,7 @@ class Para extends XFAObject {
       style.paddingLeft = measureToString(this.marginLeft);
     }
     if (this.marginRight !== "") {
-      style.paddingight = measureToString(this.marginRight);
+      style.paddingRight = measureToString(this.marginRight);
     }
     if (this.spaceAbove !== "") {
       style.paddingTop = measureToString(this.spaceAbove);

--- a/src/core/xfa/xhtml.js
+++ b/src/core/xfa/xhtml.js
@@ -35,6 +35,7 @@ import {
   fixURL,
   measureToString,
   setFontFamily,
+  setParaStyle,
 } from "./html_utils.js";
 import { getMeasurement, HTMLResult, stripQuotes } from "./utils.js";
 
@@ -480,6 +481,19 @@ class P extends XhtmlObject {
       return super[$text]();
     }
     return super[$text]() + "\n";
+  }
+
+  [$toHTML](availableSpace) {
+    const res = super[$toHTML](availableSpace);
+    const { html } = res;
+    if (!html) {
+      return HTMLResult.EMPTY;
+    }
+    if (!html.attributes.style) {
+      html.attributes.style = Object.create(null);
+    }
+    setParaStyle(this, html.attributes.style);
+    return res;
   }
 }
 

--- a/test/pdfs/xfa_bug1722003.pdf.link
+++ b/test/pdfs/xfa_bug1722003.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=9232818

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1009,6 +1009,15 @@
        "enableXfa": true,
        "type": "eq"
     },
+    {  "id": "xfa_bug1722003",
+      "file": "pdfs/xfa_bug1722003.pdf",
+      "md5": "47453e6ea9426d22108c6307805464a2",
+      "link": true,
+      "lastPage": 1,
+      "rounds": 1,
+      "enableXfa": true,
+      "type": "eq"
+   },
     {  "id": "issue14164",
        "file": "pdfs/issue14164.pdf",
        "md5": "feb444c716b0337efff8094b156def32",


### PR DESCRIPTION
  - it aims to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1722003
  - some containers have a para element which contains the default values to apply to paragraph they contain, these values are correctly set in the container but they aren't applied to children.