### PR TITLE
Avoid doing unnecessary checks, when pre-rendering page layouts with "holes" (PR 14131 follow-up)

### DIFF
--- a/web/pdf_rendering_queue.js
+++ b/web/pdf_rendering_queue.js
@@ -115,13 +115,13 @@ class PDFRenderingQueue {
      * 2. if last scrolled down, the page after the visible pages, or
      *    if last scrolled up, the page before the visible pages
      */
-    const visibleViews = visible.views;
+    const visibleViews = visible.views,
+      numVisible = visibleViews.length;
 
-    const numVisible = visibleViews.length;
     if (numVisible === 0) {
       return null;
     }
-    for (let i = 0; i < numVisible; ++i) {
+    for (let i = 0; i < numVisible; i++) {
       const view = visibleViews[i].view;
       if (!this.isViewFinished(view)) {
         return view;
@@ -132,7 +132,7 @@ class PDFRenderingQueue {
 
     // All the visible views have rendered; try to handle any "holes" in the
     // page layout (can happen e.g. with spreadModes at higher zoom levels).
-    if (lastId - firstId > 1) {
+    if (lastId - firstId + 1 > numVisible) {
       for (let i = 1, ii = lastId - firstId; i < ii; i++) {
         const holeId = scrolledDown ? firstId + i : lastId - i,
           holeView = views[holeId - 1];


### PR DESCRIPTION
*Sometimes I'll hopefully learn to optimize my code directly when writing it, rather than having to do multiple clean-up passes; sorry about the churn here!*

For most page layouts there won't be any "holes" in the visible pages (or thumbnails), and in those cases it'd obviously be preferable not having to repeat any checks of already rendered pages.
Rather than only checking the "distance" between the first/last pages, we can instead compare the theoretical number of pages (between first/last) with the actually visible number of pages instead. This way, we're able to better detect the "holes"-case and can skip unnecessary parsing in the common case.