### PR TITLE
Reset path bounding box tracking when starting a new path.

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -3071,6 +3071,7 @@ class CanvasGraphics {
       }
       this.pendingClip = null;
     }
+    this.current.startNewPathAndClipBox(this.current.clipBox);
     ctx.beginPath();
   }
 


### PR DESCRIPTION
Starting a new path will wipe out any of the current subpaths in the
current graphics state, so we should reset the min/maxes.

This makes a number of the bounding boxes smaller and reduces the number
of composed pixels. For the smask tests in the corpus, the number of
composed pixesl goes from 19,872,109 to 19,676,905. The difference is much
larger on other PDFs though.