### PR TITLE
Add an easy way to log to the terminal during browser tests.

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -466,6 +466,24 @@ var Driver = (function DriverClosure() {
       }, this.delay);
     },
 
+    /**
+     * A debugging tool to log to the terminal while tests are running.
+     * XXX: This isn't currently referenced, but it's useful for debugging so
+     * do not remove it.
+     *
+     * @param {string} msg - The message to log, it will be prepended with the
+     *    current PDF ID if there is one.
+     */
+    log(msg) {
+      let id = this.browser;
+      const task = this.manifest[this.currentTask];
+      if (task) {
+        id += `-${task.id}`;
+      }
+
+      this._info(`${id}: ${msg}`);
+    },
+
     _nextTask() {
       let failure = "";
 


### PR DESCRIPTION
On the main thread call `driver.log` and the message will output in the
terminal with the pdf id and the message.

I've been using this a lot when trying to find certain PDFs or logging
stats.