### PR TITLE
XFA - Fix a breakBefore issue when target is a contentArea and startNew is 1 (bug 1739502)

### DIFF
--- a/src/core/xfa/layout.js
+++ b/src/core/xfa/layout.js
@@ -147,7 +147,10 @@ function addHTML(node, html, bbox) {
       break;
     }
     case "tb": {
-      extra.width = availableSpace.width;
+      // Even if the subform can possibly take all the available width,
+      // we must compute the final width as it is in order to be able
+      // for example to center the subform within its parent.
+      extra.width = Math.min(availableSpace.width, Math.max(extra.width, w));
       extra.height += h;
       extra.children.push(html);
       break;

--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -369,23 +369,32 @@ function handleBreak(node) {
   const pageArea = target && target[$getParent]();
 
   let index;
+  let nextPageArea = pageArea;
   if (node.startNew) {
+    // startNew === 1 so we must create a new container (pageArea or
+    // contentArea).
     if (target) {
       const contentAreas = pageArea.contentArea.children;
-      index = contentAreas.findIndex(e => e === target) - 1;
+      const indexForCurrent = contentAreas.indexOf(currentContentArea);
+      const indexForTarget = contentAreas.indexOf(target);
+      if (indexForCurrent !== -1 && indexForCurrent < indexForTarget) {
+        // The next container is after the current container so
+        // we can stay on the same page.
+        nextPageArea = null;
+      }
+      index = indexForTarget - 1;
     } else {
-      index = currentPageArea.contentArea.children.findIndex(
-        e => e === currentContentArea
-      );
+      index = currentPageArea.contentArea.children.indexOf(currentContentArea);
     }
   } else if (target && target !== currentContentArea) {
     const contentAreas = pageArea.contentArea.children;
-    index = contentAreas.findIndex(e => e === target) - 1;
+    index = contentAreas.indexOf(target) - 1;
+    nextPageArea = pageArea === currentPageArea ? null : pageArea;
   } else {
     return false;
   }
 
-  node[$extra].target = pageArea === currentPageArea ? null : pageArea;
+  node[$extra].target = nextPageArea;
   node[$extra].index = index;
   return true;
 }
@@ -5208,6 +5217,13 @@ class Subform extends XFAObject {
       style.height = measureToString(height);
     }
 
+    if (
+      (style.width === "0px" || style.height === "0px") &&
+      children.length === 0
+    ) {
+      return HTMLResult.EMPTY;
+    }
+
     const html = {
       name: "div",
       attributes,
@@ -5551,7 +5567,7 @@ class Template extends XFAObject {
               hasSomething ||
               (html.html.children && html.html.children.length !== 0);
             htmlContentAreas[i].children.push(html.html);
-          } else if (!hasSomething) {
+          } else if (!hasSomething && mainHtml.children.length > 1) {
             mainHtml.children.pop();
           }
           return mainHtml;

--- a/test/pdfs/xfa_bug1739502.pdf.link
+++ b/test/pdfs/xfa_bug1739502.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=9249303

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1033,6 +1033,14 @@
        "enableXfa": true,
        "type": "eq"
     },
+    {  "id": "xfa_bug1739502",
+       "file": "pdfs/xfa_bug1739502.pdf",
+       "md5": "a760a950cb225c3cbf25a55b5d95e264",
+       "link": true,
+       "rounds": 1,
+       "enableXfa": true,
+       "type": "eq"
+    },
     {  "id": "xfa_bug1729877",
        "file": "pdfs/xfa_bug1729877.pdf",
        "md5": "1bf5429ea13a090f52edcd49cb0c4a47",


### PR DESCRIPTION
 - it aims to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1739502;
 - when the target area was the current content area, everything was pushed in it instead of creating a new one (and consequently a new pageArea is created).
 - the pdf shows an alignment issue on page 4:
   - the hAlign is "center" but the subform was the width of its parent, so compute the real width of the subform with tb layout;
 - there is an extra empty page at the end of the pdf:
   - there is a subform with some hidden elements which are not rendered for now (since there is no plugged JS engine it isn't possible to draw them in changing their visibility).
   - so in case a subform is empty and has no real dimensions (at least one is 0), we just consider it as empty.