### PR TITLE
Prevent mobile devices from interfering with the textLayer-elements (issue 14243)

### DIFF
--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -23,6 +23,7 @@
   overflow: hidden;
   opacity: 0.2;
   line-height: 1;
+  text-size-adjust: none;
 }
 
 .textLayer span,


### PR DESCRIPTION
*This is a tentative patch, since I don't have the necessary hardware to test it.*

See https://developer.mozilla.org/en-US/docs/Web/CSS/text-size-adjust, which is currently ignored in Firefox.
It seems overall safer, and more future-proof, to simply add this to the *entire* `textLayer` rather than its individual elements.

Fixes #14243