### PR TITLE
Correct annotation borders width

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -1804,8 +1804,8 @@ class LineAnnotationElement extends AnnotationElement {
     line.setAttribute("y2", data.rect[3] - data.lineCoordinates[3]);
     // Ensure that the 'stroke-width' is always non-zero, since otherwise it
     // won't be possible to open/close the popup (note e.g. issue 11122).
-    line.setAttribute("stroke-width", data.borderStyle.width || 1);
-    line.setAttribute("stroke", "transparent");
+    line.setAttribute("stroke-width", (data.borderStyle.width += 3 || 1));
+    line.setAttribute("stroke", `rgb(${data.color})`);
     line.setAttribute("fill", "transparent");
 
     svg.appendChild(line);

--- a/test/pdfs/issue14203.pdf.link
+++ b/test/pdfs/issue14203.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/7428963/pdfcomment.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -6034,6 +6034,16 @@
          }
        }
     },
+    { "id": "issue14203",
+      "file": "pdfs/issue14203.pdf",
+      "md5": "26c1c1e7341bc23fb28d805fa516dbbe",
+      "link": true,
+      "rounds": 1,
+      "firstPage": 11,
+      "lastPage": 11,
+      "type": "eq",
+      "annotations": true
+    },
     {  "id": "issue13003",
        "file": "pdfs/issue13003.pdf",
        "md5": "a4c00bd6456d3c16b9bd44957caa4ab6",


### PR DESCRIPTION
Incrementing value "data.borderStyle.width" in stroke-width property to achieve a wider border and modifying the stroke value to make sure it use data.color as a value instead of "transparent" so the changes to stroke-width are visible.

closes #14203