### PR TITLE
Convert `GrabToPan` to a standard `class`

### DIFF
--- a/web/grab_to_pan.js
+++ b/web/grab_to_pan.js
@@ -142,7 +142,8 @@ GrabToPan.prototype = {
    */
   _onmousemove: function GrabToPan__onmousemove(event) {
     this.element.removeEventListener("scroll", this._endPan, true);
-    if (isLeftMouseReleased(event)) {
+    if (!(event.buttons & 1)) {
+      // The left mouse button is released.
       this._endPan();
       return;
     }
@@ -176,39 +177,5 @@ GrabToPan.prototype = {
     this.overlay.remove();
   },
 };
-
-/**
- * Whether the left mouse is not pressed.
- * @param event {MouseEvent}
- * @returns {boolean} True if the left mouse button is not pressed,
- *                    False if unsure or if the left mouse button is pressed.
- */
-function isLeftMouseReleased(event) {
-  if ("buttons" in event) {
-    // http://www.w3.org/TR/DOM-Level-3-Events/#events-MouseEvent-buttons
-    // Firefox 15+
-    // Chrome 43+
-    // Safari 11.1+
-    return !(event.buttons & 1);
-  }
-  if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
-    // Browser sniffing because it's impossible to feature-detect
-    // whether event.which for onmousemove is reliable.
-    const chrome = window.chrome;
-    const isChrome15OrOpera15plus = chrome && (chrome.webstore || chrome.app);
-    //                                         ^ Chrome 15+       ^ Opera 15+
-    const isSafari6plus =
-      /Apple/.test(navigator.vendor) &&
-      /Version\/([6-9]\d*|[1-5]\d+)/.test(navigator.userAgent);
-
-    if (isChrome15OrOpera15plus || isSafari6plus) {
-      // Chrome 14+
-      // Opera 15+
-      // Safari 6.0+
-      return event.which === 0;
-    }
-  }
-  return false;
-}
 
 export { GrabToPan };


### PR DESCRIPTION
 - **[web/grab_to_pan.js] Inline the `isLeftMouseReleased` helper function**

   Given the support information listed in the function itself, the [MDN compatibility data](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons#browser_compatibility), and the [currently supported browsers](https://github.com/mozilla/pdf.js/blob/4bb9de4b008dca2cdccf770bc359ae21971debb0/gulpfile.js#L79-L87) in the PDF.js project we should be able to simplify the code by inlining the function instead.

 - **Convert `GrabToPan` to a standard `class`**

   This code is the last piece[1] of the viewer that's not using standard `class`es, and by converting this code we get rid of some now unneeded boilerplate code (slightly reducing the size of the *built* `web/viewer.js` file).
   Note that while this code was originally imported from a separate repository, it was last sync-ed with upstream *five years* ago which is why this re-factoring should be OK as far as I'm concerned (and we've done some other clean-up since then as well).

   ---
   [1] Technically the `web/debugger.js` file is left as well, however that code is first of all not bundled in the *built* `web/viewer.js` file and secondly it's not even loaded by default either.