### PR TITLE
Include the /Lang-property, when it exists, in the StructTree-data (issue 14261)

### DIFF
--- a/src/core/struct_tree.js
+++ b/src/core/struct_tree.js
@@ -295,6 +295,10 @@ class StructTreePage {
       if (isString(alt)) {
         obj.alt = stringToPDFString(alt);
       }
+      const lang = node.dict.get("Lang");
+      if (isString(lang)) {
+        obj.lang = stringToPDFString(lang);
+      }
 
       for (const kid of node.kids) {
         const kidElement =

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1836,6 +1836,7 @@ sozialökonomische Gerechtigkeit.`)
         children: [
           {
             role: "Document",
+            lang: "en-US",
             children: [
               {
                 role: "H1",

--- a/test/unit/struct_tree_spec.js
+++ b/test/unit/struct_tree_spec.js
@@ -19,6 +19,7 @@ import { getDocument } from "../../src/display/api.js";
 function equalTrees(rootA, rootB) {
   function walk(a, b) {
     expect(a.role).toEqual(b.role);
+    expect(a.lang).toEqual(b.lang);
     expect(a.type).toEqual(b.type);
     expect("children" in a).toEqual("children" in b);
     if (!a.children) {
@@ -47,6 +48,7 @@ describe("struct tree", function () {
           children: [
             {
               role: "Document",
+              lang: "en-US",
               children: [
                 {
                   role: "H1",

--- a/web/struct_tree_layer_builder.js
+++ b/web/struct_tree_layer_builder.js
@@ -98,6 +98,9 @@ class StructTreeLayerBuilder {
     if (structElement.id !== undefined) {
       htmlElement.setAttribute("aria-owns", structElement.id);
     }
+    if (structElement.lang !== undefined) {
+      htmlElement.setAttribute("lang", structElement.lang);
+    }
   }
 
   _walk(node) {


### PR DESCRIPTION
*Please note:* This is a tentative patch, since I don't have the necessary a11y-software to actually test it.