### PR TITLE
XFA - Avoid an exception when looking for a font in a parent node

### DIFF
--- a/src/core/xfa/html_utils.js
+++ b/src/core/xfa/html_utils.js
@@ -238,7 +238,7 @@ function layoutNode(node, availableSpace) {
     if (!font) {
       const root = node[$getTemplateRoot]();
       let parent = node[$getParent]();
-      while (parent !== root) {
+      while (parent && parent !== root) {
         if (parent.font) {
           font = parent.font;
           break;

--- a/test/pdfs/xfa_issue14150.pdf.link
+++ b/test/pdfs/xfa_issue14150.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/7528643/dol4n.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1013,6 +1013,15 @@
        "link": true,
        "type": "load"
     },
+    {  "id": "xfa_issue14150",
+       "file": "pdfs/xfa_issue14150.pdf",
+       "md5": "295b3e513b62945fbba73bce6908344c",
+       "link": true,
+       "rounds": 1,
+       "enableXfa": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "xfa_issue14071",
        "file": "pdfs/xfa_issue14071.pdf",
        "md5": "7ef09705091602668ce22086c83a90f3",


### PR DESCRIPTION
  - it aims to fix issue https://github.com/mozilla/pdf.js/issues/14150;
  - a parent can be null in case the root has been reached, so just add a check.