### PR TITLE
Don't consider space as real space when there is an extra spacing (bug 931481)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -2573,7 +2573,8 @@ class PartialEvaluator {
           (i === 0 ||
             i + 1 === ii ||
             glyphs[i - 1].unicode === " " ||
-            glyphs[i + 1].unicode === " ")
+            glyphs[i + 1].unicode === " " ||
+            extraSpacing)
         ) {
           // Don't push a " " in the textContentItem
           // (except when it's between two non-spaces chars),

--- a/test/pdfs/bug931481.pdf.link
+++ b/test/pdfs/bug931481.pdf.link
@@ -1,0 +1,1 @@
+https://web.archive.org/web/20141210054406/http://www.stronachinstitut.at/wp-content/uploads/2012/02/Nachbaur_CV5.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -171,6 +171,13 @@
        "type": "eq",
        "about": "Fonts referenced only by name and not by an object identifier."
     },
+    {  "id": "bug931481",
+       "file": "pdfs/bug931481.pdf",
+       "md5": "547de872cbb2ecc653ae83d5be7e5be9",
+       "rounds": 1,
+       "link": true,
+       "type": "text"
+    },
     {  "id": "bug911034",
        "file": "pdfs/bug911034.pdf",
        "md5": "54ee432a4e16b26b242fbf549cdad177",

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1760,6 +1760,34 @@ sources, for full support with Dvips.`)
       await loadingTask.destroy();
     });
 
+    it("gets text content, with negative spaces (bug 931481)", async function () {
+      if (isNodeJS) {
+        pending("Linked test-cases are not supported in Node.js.");
+      }
+
+      const loadingTask = getDocument(buildGetDocumentParams("bug931481.pdf"));
+      const pdfDoc = await loadingTask.promise;
+      const pdfPage = await pdfDoc.getPage(1);
+      const { items } = await pdfPage.getTextContent();
+      const text = mergeText(items);
+
+      expect(
+        text.includes(`Kathrin Nachbaur
+Die promovierte Juristin ist 1979 in Graz geboren und aufgewachsen. Nach
+erfolgreichem Studienabschluss mit Fokus auf Europarecht absolvierte sie ein
+Praktikum bei Magna International in Kanada in der Human Resources Abteilung.
+Anschliessend wurde sie geschult in Human Resources, Arbeitsrecht und
+Kommunikation, währenddessen sie auch an ihrem Doktorat im Wirtschaftsrecht
+arbeitete. Seither arbeitete sie bei Magna International als Projekt Manager in der
+Innovationsabteilung. Seit 2009 ist sie Frank Stronachs Büroleiterin in Österreich und
+Kanada. Zusätzlich ist sie seit 2012 Vice President, Business Development der
+Stronach Group und Vizepräsidentin und Institutsleiterin des Stronach Institut für
+sozialökonomische Gerechtigkeit.`)
+      ).toEqual(true);
+
+      await loadingTask.destroy();
+    });
+
     it("gets text content, with beginbfrange operator handled correctly (bug 1627427)", async function () {
       const loadingTask = getDocument(
         buildGetDocumentParams("bug1627427_reduced.pdf")


### PR DESCRIPTION
 - it aims to fix https://bugzilla.mozilla.org/show_bug.cgi?id=931481;
 - real space chars are pushed in the chunk but when there is an extra spacing, the next char position must be compared with the previous one;
 - for example, an extra spacing can cancel a space so visually there are no space.