### PR TITLE
Use a faster method to determine whether the number is even or odd

### DIFF
--- a/src/core/bidi.js
+++ b/src/core/bidi.js
@@ -74,11 +74,11 @@ const arabicTypes = [
 ];
 
 function isOdd(i) {
-  return (i & 1) !== 0;
+  return i % 2 !== 0;
 }
 
 function isEven(i) {
-  return (i & 1) === 0;
+  return i % 2 === 0;
 }
 
 function findUnequal(arr, start, value) {


### PR DESCRIPTION
Bit masking was slower than directly checking whether the number is odd or even. You can check the speed/time complexity of the algorithm by profiling and timestamping both chunks of code.