### PR TITLE
Only show the `loadingIcon`-spinner on visible pages (issue 14242)

### DIFF
--- a/test/unit/base_viewer_spec.js
+++ b/test/unit/base_viewer_spec.js
@@ -40,7 +40,7 @@ describe("BaseViewer", function () {
         buffer.push(view);
       }
       // Ensure that the correct views are inserted.
-      expect(buffer._buffer).toEqual([
+      expect([...buffer]).toEqual([
         viewsMap.get(1),
         viewsMap.get(2),
         viewsMap.get(3),
@@ -51,7 +51,7 @@ describe("BaseViewer", function () {
         buffer.push(view);
       }
       // Ensure that the correct views are evicted.
-      expect(buffer._buffer).toEqual([
+      expect([...buffer]).toEqual([
         viewsMap.get(3),
         viewsMap.get(4),
         viewsMap.get(5),
@@ -71,7 +71,7 @@ describe("BaseViewer", function () {
       // Ensure that keeping the size constant won't evict any views.
       buffer.resize(5);
 
-      expect(buffer._buffer).toEqual([
+      expect([...buffer]).toEqual([
         viewsMap.get(1),
         viewsMap.get(2),
         viewsMap.get(3),
@@ -82,7 +82,7 @@ describe("BaseViewer", function () {
       // Ensure that increasing the size won't evict any views.
       buffer.resize(10);
 
-      expect(buffer._buffer).toEqual([
+      expect([...buffer]).toEqual([
         viewsMap.get(1),
         viewsMap.get(2),
         viewsMap.get(3),
@@ -93,7 +93,7 @@ describe("BaseViewer", function () {
       // Ensure that decreasing the size will evict the correct views.
       buffer.resize(3);
 
-      expect(buffer._buffer).toEqual([
+      expect([...buffer]).toEqual([
         viewsMap.get(3),
         viewsMap.get(4),
         viewsMap.get(5),
@@ -114,7 +114,7 @@ describe("BaseViewer", function () {
       // while re-ordering them correctly.
       buffer.resize(5, new Set([1, 2]));
 
-      expect(buffer._buffer).toEqual([
+      expect([...buffer]).toEqual([
         viewsMap.get(3),
         viewsMap.get(4),
         viewsMap.get(5),
@@ -126,7 +126,7 @@ describe("BaseViewer", function () {
       // while re-ordering them correctly.
       buffer.resize(10, new Set([3, 4, 5]));
 
-      expect(buffer._buffer).toEqual([
+      expect([...buffer]).toEqual([
         viewsMap.get(1),
         viewsMap.get(2),
         viewsMap.get(3),
@@ -138,7 +138,7 @@ describe("BaseViewer", function () {
       // while re-ordering the remaining ones correctly.
       buffer.resize(3, new Set([1, 2, 5]));
 
-      expect(buffer._buffer).toEqual([
+      expect([...buffer]).toEqual([
         viewsMap.get(1),
         viewsMap.get(2),
         viewsMap.get(5),

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -99,17 +99,6 @@ class PDFPageViewBuffer {
 
   constructor(size) {
     this.#size = size;
-
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
-      Object.defineProperty(this, "_buffer", {
-        get() {
-          return [...this.#buf];
-        },
-      });
-    }
   }
 
   push(view) {

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -289,7 +289,10 @@ class PDFPageView {
     }
 
     this.loadingIconDiv = document.createElement("div");
-    this.loadingIconDiv.className = "loadingIcon";
+    this.loadingIconDiv.className = "loadingIcon notVisible";
+    if (this._isStandalone) {
+      this.toggleLoadingIconSpinner(/* viewVisible = */ true);
+    }
     this.loadingIconDiv.setAttribute("role", "img");
     this.l10n.get("loading").then(msg => {
       this.loadingIconDiv?.setAttribute("aria-label", msg);
@@ -521,6 +524,13 @@ class PDFPageView {
 
   getPagePoint(x, y) {
     return this.viewport.convertToPdfPoint(x, y);
+  }
+
+  /**
+   * @ignore
+   */
+  toggleLoadingIconSpinner(viewVisible = false) {
+    this.loadingIconDiv?.classList.toggle("notVisible", !viewVisible);
   }
 
   draw() {

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -129,6 +129,9 @@
   bottom: 0;
   background: url("images/loading-icon.gif") center no-repeat;
 }
+.pdfViewer .page .loadingIcon.notVisible {
+  background: none;
+}
 
 .pdfPresentationMode .pdfViewer {
   margin-left: 0;


### PR DESCRIPTION
This patch preserves the old behaviour of appending a `loadingIcon`-div to all pages that are not yet loaded/rendered. However, the actual `loadingIcon`-spinner (i.e. the `loading-icon.gif` image) will only be displayed on *visible* pages to improve performance.

To avoid having to iterate through all pages in the document, which doesn't seem like a good idea for a PDF document with thousands of pages, we use a combination of the currently visible *and* cached pages to toggle the `loadingIcon`-spinner.

Fixes #14242