### PR TITLE
Replace the remaining `Node.removeChild()` instances with `Element.remove()`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -50,6 +50,7 @@
     "unicorn/no-instanceof-array": "error",
     "unicorn/no-useless-spread": "error",
     "unicorn/prefer-date-now": "error",
+    "unicorn/prefer-dom-node-remove": "error",
     "unicorn/prefer-string-starts-ends-with": "error",
 
     // Possible errors

--- a/extensions/chromium/contentscript.js
+++ b/extensions/chromium/contentscript.js
@@ -128,7 +128,7 @@ function updateEmbedElement(elem) {
   var parentNode = elem.parentNode;
   var nextSibling = elem.nextSibling;
   if (parentNode) {
-    parentNode.removeChild(elem);
+    elem.remove();
   }
   elem.type = "text/html";
   elem.src = getEmbeddedViewerURL(elem.src);

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -350,7 +350,7 @@ if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
       this._document.body.appendChild(div);
 
       isFontReady(loadTestFontId, () => {
-        this._document.body.removeChild(div);
+        div.remove();
         request.complete();
       });
       /** Hack end */

--- a/test/driver.js
+++ b/test/driver.js
@@ -565,7 +565,7 @@ var Driver = (function DriverClosure() {
       }
       const body = document.body;
       while (body.lastChild !== this.end) {
-        body.removeChild(body.lastChild);
+        body.lastChild.remove();
       }
 
       const destroyedPromises = [];

--- a/test/resources/reftest-analyzer.js
+++ b/test/resources/reftest-analyzer.js
@@ -245,9 +245,7 @@ window.onload = function () {
 
     // const cell = ID("itemlist");
     const table = document.getElementById("itemtable");
-    while (table.childNodes.length > 0) {
-      table.removeChild(table.childNodes[table.childNodes.length - 1]);
-    }
+    table.textContent = ""; // Remove any table contents from the DOM.
     const tbody = document.createElement("tbody");
     table.appendChild(tbody);
 

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -462,9 +462,7 @@ const Stepper = (function StepperClosure() {
 var Stats = (function Stats() {
   let stats = [];
   function clear(node) {
-    while (node.hasChildNodes()) {
-      node.removeChild(node.lastChild);
-    }
+    node.textContent = ""; // Remove any `node` contents from the DOM.
   }
   function getStatIndex(pageNumber) {
     for (let i = 0, ii = stats.length; i < ii; ++i) {
@@ -490,8 +488,7 @@ var Stats = (function Stats() {
       }
       const statsIndex = getStatIndex(pageNumber);
       if (statsIndex !== false) {
-        const b = stats[statsIndex];
-        this.panel.removeChild(b.div);
+        stats[statsIndex].div.remove();
         stats.splice(statsIndex, 1);
       }
       const wrapper = document.createElement("div");

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -257,7 +257,7 @@ class PDFPageView {
         case xfaLayerNode:
           continue;
       }
-      div.removeChild(node);
+      node.remove();
     }
     div.removeAttribute("data-loaded");
 
@@ -534,7 +534,7 @@ class PDFPageView {
       this.renderingState = RenderingStates.FINISHED;
 
       if (this.loadingIconDiv) {
-        div.removeChild(this.loadingIconDiv);
+        this.loadingIconDiv.remove();
         delete this.loadingIconDiv;
       }
       return Promise.reject(new Error("pdfPage is not loaded"));
@@ -617,7 +617,7 @@ class PDFPageView {
       this.renderingState = RenderingStates.FINISHED;
 
       if (this.loadingIconDiv) {
-        div.removeChild(this.loadingIconDiv);
+        this.loadingIconDiv.remove();
         delete this.loadingIconDiv;
       }
       this._resetZoomLayer(/* removeFromDOM = */ true);


### PR DESCRIPTION
Using `Element.remove()` is a slightly more compact way of removing an element, since you no longer need to explicitly find/use its parent element.
Furthermore, the patch also replaces a couple of loops that're used to delete all elements under a node with simply overwriting the contents directly (a pattern already used throughout the viewer).

See also:
 - https://developer.mozilla.org/en-US/docs/Web/API/Node/removeChild
 - https://developer.mozilla.org/en-US/docs/Web/API/Element/remove