### PR TITLE
Fix AForm Validation for fields with non-digit characters

### DIFF
--- a/src/scripting_api/aform.js
+++ b/src/scripting_api/aform.js
@@ -564,7 +564,7 @@ class AForm {
           event.change.length +
           event.selStart -
           event.selEnd;
-        if (finalLen >= 8) {
+        if (finalLen > 8 || event.value[0] === "(") {
           formatStr = "(999) 999-9999";
         } else {
           formatStr = "999-9999";

--- a/src/scripting_api/aform.js
+++ b/src/scripting_api/aform.js
@@ -486,15 +486,15 @@ class AForm {
     ]);
 
     function _checkValidity(_value, _cMask) {
-      for (let i = 0, ii = value.length; i < ii; i++) {
-        const mask = _cMask.charAt(i);
-        const char = _value.charAt(i);
-        const checker = checkers.get(mask);
+      for (let i = 0, ii = _value.length; i < ii; i++) {
+        const maskChar = _cMask.charAt(i);
+        const valueChar = _value.charAt(i);
+        const checker = checkers.get(maskChar);
         if (checker) {
-          if (!checker(char)) {
+          if (!checker(valueChar)) {
             return false;
           }
-        } else if (mask !== char) {
+        } else if (maskChar !== valueChar) {
           return false;
         }
       }

--- a/src/scripting_api/event.js
+++ b/src/scripting_api/event.js
@@ -52,19 +52,23 @@ class EventDispatcher {
    * the change is applied, so we can validate against it and cancel the event
    * if need be
    *
-   * TODO: Given the event info we currently have, single-character insertions
-   * and deletes are indistinguishable from appends. For now we just assume
-   * it's an append, the most common case, but this leaves some edge cases. See
-   * issue #14307 for details.
-   *
+   * TODO: Given the event info we currently have, we can't determine where in
+   * the value a single-character insertion/deletion happened.  For now we just
+   * assume they happen at the end of the string, which is by far the most
+   * common case, but this leaves some edge cases, see issue #14307.
    */
   mergeChange(event) {
     let value = event.value;
     if (typeof value !== "string") {
       value = value.toString();
     }
-    // If there was no selection, assume this is an append
+    // If there was no selection, it's a single-character change
     if (event.selStart === -1 && event.selEnd === -1) {
+      if (event.change === "") {
+        // Empty change indicates a deletion
+        return value.slice(0, -1);
+      }
+      // Otherwise, assume it's an append
       return value + event.change;
     }
 

--- a/src/scripting_api/event.js
+++ b/src/scripting_api/event.js
@@ -47,11 +47,28 @@ class EventDispatcher {
     this._document.obj._eventDispatcher = this;
   }
 
+  /*
+   * Take an event object and reconstruct what we think the result will be once
+   * the change is applied, so we can validate against it and cancel the event
+   * if need be
+   *
+   * TODO: Given the event info we currently have, single-character insertions
+   * and deletes are indistinguishable from appends. For now we just assume
+   * it's an append, the most common case, but this leaves some edge cases. See
+   * issue #14307 for details.
+   *
+   */
   mergeChange(event) {
     let value = event.value;
     if (typeof value !== "string") {
       value = value.toString();
     }
+    // If there was no selection, assume this is an append
+    if (event.selStart === -1 && event.selEnd === -1) {
+      return value + event.change;
+    }
+
+    // Otherwise, splice in the change to replace the selection
     const prefix =
       event.selStart >= 0 ? value.substring(0, event.selStart) : "";
     const postfix =

--- a/test/unit/scripting_spec.js
+++ b/test/unit/scripting_spec.js
@@ -361,8 +361,8 @@ describe("Scripting", function () {
         name: "Keystroke",
         willCommit: false,
         change: "o",
-        selStart: 4,
-        selEnd: 4,
+        selStart: -1,
+        selEnd: -1,
       });
 
       expect(send_queue.has(refId)).toEqual(true);
@@ -398,8 +398,8 @@ describe("Scripting", function () {
         name: "Keystroke",
         willCommit: false,
         change: "o",
-        selStart: 4,
-        selEnd: 4,
+        selStart: -1,
+        selEnd: -1,
       });
 
       expect(send_queue.has(refId)).toEqual(true);
@@ -1119,8 +1119,8 @@ describe("Scripting", function () {
           change: "3",
           name: "Keystroke",
           willCommit: false,
-          selStart: 0,
-          selEnd: 0,
+          selStart: -1,
+          selEnd: -1,
         });
         expect(send_queue.has(refId)).toEqual(false);
 
@@ -1130,8 +1130,8 @@ describe("Scripting", function () {
           change: "F",
           name: "Keystroke",
           willCommit: false,
-          selStart: 1,
-          selEnd: 1,
+          selStart: -1,
+          selEnd: -1,
         });
         expect(send_queue.has(refId)).toEqual(false);
 
@@ -1141,8 +1141,8 @@ describe("Scripting", function () {
           change: "?",
           name: "Keystroke",
           willCommit: false,
-          selStart: 2,
-          selEnd: 2,
+          selStart: -1,
+          selEnd: -1,
         });
         expect(send_queue.has(refId)).toEqual(false);
 
@@ -1152,8 +1152,8 @@ describe("Scripting", function () {
           change: "@",
           name: "Keystroke",
           willCommit: false,
-          selStart: 3,
-          selEnd: 3,
+          selStart: -1,
+          selEnd: -1,
         });
         expect(send_queue.has(refId)).toEqual(true);
         expect(send_queue.get(refId)).toEqual({
@@ -1169,7 +1169,7 @@ describe("Scripting", function () {
           change: "0",
           name: "Keystroke",
           willCommit: true,
-          selStart: 3,
+          selStart: -1,
           selEnd: 3,
         });
         expect(send_queue.has(refId)).toEqual(false);

--- a/test/unit/scripting_spec.js
+++ b/test/unit/scripting_spec.js
@@ -369,7 +369,7 @@ describe("Scripting", function () {
       expect(send_queue.get(refId)).toEqual({
         id: refId,
         value: "hell",
-        selRange: [4, 4],
+        selRange: [-1, -1],
       });
     });
 
@@ -1159,7 +1159,7 @@ describe("Scripting", function () {
         expect(send_queue.get(refId)).toEqual({
           id: refId,
           value: "3F?",
-          selRange: [3, 3],
+          selRange: [-1, -1],
         });
 
         send_queue.delete(refId);


### PR DESCRIPTION
This is a proposed fix for #14306 - I believe the core issue is that `mergeChanges()` tries to use the keyboard event to predict what the value of the field will be after the change is applied, and gets it wrong for changes that don't involve an explicit selection, at least in my environment.

The cause here is that `mergeChanges()` seems to assume that character insertions/appends will come with `selStart` and `selEnd` set, and thus it can just treat them like any other selection replacement. That isn't the case on in my environment, where appends (as well as single-character insertions and deletions) have `selStart` and `selEnd` set to `-1`. This results in the predicted value of the field being a single character: the character being appended.

This ends up not totally breaking things - for validations that will pass if each individual character typed is a valid first character in the field (since that's what it gets interpreted as), things are mostly fine - a ZIP code can be entered just fine, although length is not constrained until the field is exited.

But for fields with hyphens in them, for instance, pdf.js won't allow you to type the hyphen (because "-" by itself is not the beginning of a valid SSN), and then when the field is blurred, the final validation runs, and complains about the missing hyphens.

This PR updates `mergeChanges()` so that if `selStart` and `selEnd` are `-1` it assumes the event is either an append and predicts the result as value + change, or a delete and predicts the result as value.slice(0, -1). This fixes the most common cases, but still leaves room for some very strange behavior if the user inserts or deletes characters in the middle.

Because we don't have `selStart` and `selEnd`, I don't see any way of distinguishing between and append an an insertion, or a deletion at the end of the value vs an internal deletion. In this PR I just assume that changes are happening at the end of the string, but that means we'll be quite wrong about internal deletions/insertions, and if someone goes back and inserts a character we'll predict that it was added at the end of the string.

Fortunately that prediction isn't persisted, and internal insertions/deletions should be rare, so I think it's worth this most-of-the-way fix that should cover the majority of cases. If there is some way to determine _where_ single-character changes are being made, from the event or some other source, that would of course be optimal, but I didn't see one, and I don't know enough about how these events are generated to know if it's something we could add ourselves, or if it's something in some PDF standard somewhere.