### PR TITLE
Prevent circular references in XRef tables from hanging the worker-thread (issue 14303)

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -632,7 +632,7 @@ class Parser {
     // Get the length.
     let length = dict.get("Length");
     if (!Number.isInteger(length)) {
-      info(`Bad length "${length}" in stream`);
+      info(`Bad length "${length && length.toString()}" in stream.`);
       length = 0;
     }
 

--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -16,6 +16,7 @@
 import { assert, shadow, unreachable } from "../shared/util.js";
 import { BaseStream } from "./base_stream.js";
 
+const CIRCULAR_REF = Symbol("CIRCULAR_REF");
 const EOF = Symbol("EOF");
 
 const Name = (function NameClosure() {
@@ -422,6 +423,7 @@ function clearPrimitiveCaches() {
 }
 
 export {
+  CIRCULAR_REF,
   clearPrimitiveCaches,
   Cmd,
   Dict,

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -289,19 +289,15 @@ class XRef {
   }
 
   readXRefStream(stream) {
-    let i, j;
     const streamState = this.streamState;
     stream.pos = streamState.streamPos;
 
-    const byteWidths = streamState.byteWidths;
-    const typeFieldWidth = byteWidths[0];
-    const offsetFieldWidth = byteWidths[1];
-    const generationFieldWidth = byteWidths[2];
+    const [typeFieldWidth, offsetFieldWidth, generationFieldWidth] =
+      streamState.byteWidths;
 
     const entryRanges = streamState.entryRanges;
     while (entryRanges.length > 0) {
-      const first = entryRanges[0];
-      const n = entryRanges[1];
+      const [first, n] = entryRanges;
 
       if (!Number.isInteger(first) || !Number.isInteger(n)) {
         throw new FormatError(`Invalid XRef range fields: ${first}, ${n}`);
@@ -315,14 +311,14 @@ class XRef {
           `Invalid XRef entry fields length: ${first}, ${n}`
         );
       }
-      for (i = streamState.entryNum; i < n; ++i) {
+      for (let i = streamState.entryNum; i < n; ++i) {
         streamState.entryNum = i;
         streamState.streamPos = stream.pos;
 
         let type = 0,
           offset = 0,
           generation = 0;
-        for (j = 0; j < typeFieldWidth; ++j) {
+        for (let j = 0; j < typeFieldWidth; ++j) {
           const typeByte = stream.getByte();
           if (typeByte === -1) {
             throw new FormatError("Invalid XRef byteWidths 'type'.");
@@ -333,14 +329,14 @@ class XRef {
         if (typeFieldWidth === 0) {
           type = 1;
         }
-        for (j = 0; j < offsetFieldWidth; ++j) {
+        for (let j = 0; j < offsetFieldWidth; ++j) {
           const offsetByte = stream.getByte();
           if (offsetByte === -1) {
             throw new FormatError("Invalid XRef byteWidths 'offset'.");
           }
           offset = (offset << 8) | offsetByte;
         }
-        for (j = 0; j < generationFieldWidth; ++j) {
+        for (let j = 0; j < generationFieldWidth; ++j) {
           const generationByte = stream.getByte();
           if (generationByte === -1) {
             throw new FormatError("Invalid XRef byteWidths 'generation'.");

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -492,3 +492,5 @@
 !xfa_issue14315.pdf
 !poppler-67295-0.pdf
 !poppler-85140-0.pdf
+!poppler-91414-0-53.pdf
+!poppler-91414-0-54.pdf

--- a/test/pdfs/poppler-91414-0-53.pdf
+++ b/test/pdfs/poppler-91414-0-53.pdf
@@ -1,0 +1,70 @@
+%PDF-1.5
+%€€€€
+1 0 obj
+<<
+	/Type /Catalog
+	/Pages 2 0 R
+>>
+endobj
+2 0 obj
+<<
+	/Count 6 0 R
+	/Kids [3 0 R]
+	/Type /Pages
+>>
+endobj
+3 0 obj
+<<
+	/Resources <<
+		/Font <<
+			/F1 5 0 R
+		>>
+	>>
+	/MediaBox [0 0 795 842]
+	/Parent 2 0 R
+	/Contents 4 0 R
+	/Type /Page
+>>
+endobj
+4 0 obj
+<< /Length 43 >>
+stream
+BT 1 Tr /F1 30 Tf 350 750 Td (foobar) Tj ET
+endstream
+endobj
+5 0 obj
+<<
+	/Name /F1
+	/BaseFont /Helvetica
+	/Type /Font
+	/Subtype /Type1
+>>
+endobj
+6 0 obj
+<< /Length 6 0 R >>
+stream
+2
+endstream
+endobj
+7 0 obj
+<<>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000015 00000 n 
+0000000066 00000 n 
+0000000130 00000 n 
+0000000269 00000 n 
+0000000362 00000 n 
+0000000446 00000 n 
+0000000500 00000 n 
+trailer
+<<
+	/Size 8
+	/Root 1 0 R
+	/Info 7 0 R
+>>
+startxref
+520
+%%EOF

--- a/test/pdfs/poppler-91414-0-54.pdf
+++ b/test/pdfs/poppler-91414-0-54.pdf
@@ -1,0 +1,77 @@
+%PDF-1.5
+%€€€€
+1 0 obj
+<<
+	/Type /Catalog
+	/Pages 2 0 R
+>>
+endobj
+2 0 obj
+<<
+	/Count 6 0 R
+	/Kids [3 0 R]
+	/Type /Pages
+>>
+endobj
+3 0 obj
+<<
+	/Resources <<
+		/Font <<
+			/F1 5 0 R
+		>>
+	>>
+	/MediaBox [0 0 795 842]
+	/Parent 2 0 R
+	/Contents 4 0 R
+	/Type /Page
+>>
+endobj
+4 0 obj
+<< /Length 43 >>
+stream
+BT 1 Tr /F1 30 Tf 350 750 Td (foobar) Tj ET
+endstream
+endobj
+5 0 obj
+<<
+	/Name /F1
+	/BaseFont /Helvetica
+	/Type /Font
+	/Subtype /Type1
+>>
+endobj
+6 0 obj
+<< /Length 7 0 R >>
+stream
+	foobar
+endstream
+endobj
+7 0 obj
+<< /Length 6 0 R >>
+stream
+	foobar
+endstream
+endobj
+8 0 obj
+<<>>
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000015 00000 n 
+0000000066 00000 n 
+0000000130 00000 n 
+0000000269 00000 n 
+0000000362 00000 n 
+0000000446 00000 n 
+0000000506 00000 n 
+0000000566 00000 n 
+trailer
+<<
+	/Size 9
+	/Root 1 0 R
+	/Info 8 0 R
+>>
+startxref
+586
+%%EOF


### PR DESCRIPTION
*Please note:* While this patch on its own is sufficient to prevent the worker-thread from hanging, however in combination with PR #14311 these PDF documents will both load *and* render correctly.

Rather than focusing on the particular structure of these PDF documents, it seemed (at least to me) to make sense to try and prevent all circular references when fetching/looking-up data using the XRef table.
To avoid a solution that required tracking the references manually everywhere, the implementation settled on here instead handles that internally in the `XRef.fetch`-method. This should work, since that method *and* the `Parser`/`Lexer`-implementations are completely synchronous.

Note also that the existing `XRef`-caching, used for all data-types *except* Streams, should hopefully help to lessen the performance impact of these changes.
One *potential* problem with these changes could be certain *browser* exceptions, since those are generally not catchable in JavaScript code, however those would most likely "stop" worker-thread parsing anyway (at least I hope so).

Finally, note that I settled on returning dummy-data rather than throwing an exception. This was done to allow parsing, for the rest of the document, to continue such that *one* bad reference doesn't prevent an entire document from loading.

Fixes two of the issues listed in issue #14303, namely the `poppler-91414-0.zip-2.gz-53.pdf` and `poppler-91414-0.zip-2.gz-54.pdf` documents.