### PR TITLE
[Regression] Prevent errors, during loading, in the viewer for XFA-documents (PR 14295 follow-up)

### DIFF
--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -120,7 +120,7 @@ class PDFLinkService {
     if (typeof destRef === "object" && destRef !== null) {
       pageNumber = this._cachedPageNumber(destRef);
 
-      if (pageNumber === null) {
+      if (!pageNumber) {
         // Fetch the page reference if it's not yet available. This could
         // only occur during loading, before all pages have been resolved.
         this.pdfDocument
@@ -446,6 +446,9 @@ class PDFLinkService {
    * @private
    */
   _cachedPageNumber(pageRef) {
+    if (!pageRef) {
+      return null;
+    }
     const refStr =
       pageRef.gen === 0 ? `${pageRef.num}R` : `${pageRef.num}R${pageRef.gen}`;
     return this._pagesRefCache?.[refStr] || null;


### PR DESCRIPTION
In the second commit in PR #14295, I forgot that the pages in XFA-documents don't have references (like in regular PDF documents); sorry about that!