### PR TITLE
Hide specific annotations during render

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1384,6 +1384,7 @@ class PDFPageProxy {
     background = null,
     optionalContentConfigPromise = null,
     annotationCanvasMap = null,
+    annotationIdsNotRendered = [],
   }) {
     if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("GENERIC")) {
       if (arguments[0]?.renderInteractiveForms !== undefined) {


### PR DESCRIPTION
### Background
There has been much deliberating over adding functionality to programmatically hide annotations during canvas render. 

### TODO 
- [ ] Hide annotations from render context based on ids 