### PR TITLE
Remove the unused `skipCount` parameter from `Catalog.getPageDict` (PR 14311 follow-up)

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -1085,7 +1085,7 @@ class Catalog {
     });
   }
 
-  getPageDict(pageIndex, skipCount = false) {
+  getPageDict(pageIndex) {
     const capability = createPromiseCapability();
     const nodesToVisit = [this._catDict.getRaw("Pages")];
     const visitedNodes = new RefSet();
@@ -1153,7 +1153,7 @@ class Catalog {
             throw ex;
           }
         }
-        if (Number.isInteger(count) && count >= 0 && !skipCount) {
+        if (Number.isInteger(count) && count >= 0) {
           // Cache the Kids count, since it can reduce redundant lookups in
           // documents where all nodes are found at *one* level of the tree.
           const objId = currentNode.objId;

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -1388,7 +1388,7 @@ class PDFDocument {
       let pageIndex = 1; // The first page was already loaded.
       while (true) {
         try {
-          await this.getPage(pageIndex, /* skipCount = */ true);
+          await this.getPage(pageIndex);
         } catch (reasonLoop) {
           if (reasonLoop instanceof PageDictMissingException) {
             break;

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -457,6 +457,14 @@ describe("api", function () {
       const pdfDocument = await loadingTask.promise;
       expect(pdfDocument.numPages).toEqual(1);
 
+      const page = await pdfDocument.getPage(1);
+      expect(page instanceof PDFPageProxy).toEqual(true);
+
+      const opList = await page.getOperatorList();
+      expect(opList.fnArray.length).toEqual(0);
+      expect(opList.argsArray.length).toEqual(0);
+      expect(opList.lastChunk).toEqual(true);
+
       await loadingTask.destroy();
     });
 


### PR DESCRIPTION
 - Remove the unused `skipCount` parameter from `Catalog.getPageDict` (PR 14311 follow-up)

   This was added in PR #14311, but given that I completely missed to update the `PDFDocument.getPage` signature accordingly it's completely unused.
   Given that things work just as fine as-is, let's simply remove that optional parameter for now; sorry about the churn here!

 - Slightly extend the "creates pdf doc from PDF file with bad XRef table" unit-test (PR 14304 follow-up)

   Given that we're able to "render" this document, let's extend the unit-test to actually check that we're able to obtain the operatorList; although given the overall issues in the document it'll be empty.