### PR TITLE
Update (primarily) the Node.js examples to release page resources

### DIFF
--- a/examples/node/getinfo.js
+++ b/examples/node/getinfo.js
@@ -53,6 +53,8 @@ loadingTask.promise
             });
             console.log("## Text Content");
             console.log(strings.join(" "));
+            // Release page resources.
+            page.cleanup();
           })
           .then(function () {
             console.log();

--- a/examples/node/pdf2png/pdf2png.js
+++ b/examples/node/pdf2png/pdf2png.js
@@ -103,6 +103,8 @@ const loadingTask = pdfjsLib.getDocument({
         );
       }
     });
+    // Release page resources.
+    page.cleanup();
   } catch (reason) {
     console.log(reason);
   }

--- a/examples/node/pdf2svg.js
+++ b/examples/node/pdf2svg.js
@@ -118,6 +118,8 @@ const loadingTask = pdfjsLib.getDocument({
       svgGfx.embedFonts = true;
       const svg = await svgGfx.getSVG(opList, viewport);
       await writeSvgToFile(svg, getFilePathForPage(pageNum));
+      // Release page resources.
+      page.cleanup();
     } catch (err) {
       console.log(`Error: ${err}`);
     }

--- a/examples/text-only/pdf2svg.js
+++ b/examples/text-only/pdf2svg.js
@@ -58,6 +58,8 @@ async function pageLoaded() {
   // building SVG and adding that to the DOM
   const svg = buildSVG(viewport, textContent);
   document.getElementById("pageContainer").appendChild(svg);
+  // Release page resources.
+  page.cleanup();
 }
 
 document.addEventListener("DOMContentLoaded", function () {


### PR DESCRIPTION
Given that Node.js doesn't support Workers, general PDF.js performance will be worse when compared to browsers. In an attempt to improve at least memory usage a little bit, update the Node.js examples to release page resources once parsing is done for that page.