### PR TITLE
Add a (linked) test-case for issue 8019

### DIFF
--- a/test/pdfs/issue8019.pdf.link
+++ b/test/pdfs/issue8019.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/748704/R9450_5_2_jersey.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -868,6 +868,13 @@
        "type": "eq",
        "about": "Type1 font with |Ref|s in the Differences array of the Encoding dictionary."
     },
+    {  "id": "issue8019",
+       "file": "pdfs/issue8019.pdf",
+       "md5": "5263ea3e295ee004c9fe770146bc34ef",
+       "link": true,
+       "rounds": 1,
+       "type": "eq"
+    },
     {  "id": "issue8078",
        "file": "pdfs/issue8078.pdf",
        "md5": "8b7d74bc24b4157393e4e88a511c05f1",


### PR DESCRIPTION
Given that [bug 1336572](https://bugzilla.mozilla.org/show_bug.cgi?id=1336572) was just closed as fixed, thus fixing issue #8019 in Firefox[1], let's add a test-case to enable us to catch any future regressions either in PDF.js or in browsers themselves.

---
[1] It also seems to be working in Google Chrome, although I'm having a slightly difficult time deciphering *exactly* what configurations were affected when looking through issue #8019.