### PR TITLE
Ensure that the viewer handles `BaseViewer` initialization failures

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -530,12 +530,14 @@ class BaseViewer {
       this.eventBus.dispatch("scrollmodechanged", { source: this, mode });
     }
 
-    this._pagesCapability.promise.then(() => {
-      this.eventBus.dispatch("pagesloaded", {
-        source: this,
-        pagesCount,
-      });
-    });
+    this._pagesCapability.promise.then(
+      () => {
+        this.eventBus.dispatch("pagesloaded", { source: this, pagesCount });
+      },
+      () => {
+        /* Prevent "Uncaught (in promise)"-messages in the console. */
+      }
+    );
 
     this._onBeforeDraw = evt => {
       const pageView = this._pages[evt.pageNumber - 1];
@@ -680,6 +682,8 @@ class BaseViewer {
       })
       .catch(reason => {
         console.error("Unable to initialize viewer", reason);
+
+        this._pagesCapability.reject(reason);
       });
   }
 

--- a/web/pdf_outline_viewer.js
+++ b/web/pdf_outline_viewer.js
@@ -72,7 +72,7 @@ class PDFOutlineViewer extends BaseTreeViewer {
 
     this._pageNumberToDestHashCapability = null;
     this._currentPageNumber = 1;
-    this._isPagesLoaded = false;
+    this._isPagesLoaded = null;
 
     if (
       this._currentOutlineItemCapability &&
@@ -93,8 +93,10 @@ class PDFOutlineViewer extends BaseTreeViewer {
       this._pdfDocument?.loadingParams.disableAutoFetch
     ) {
       this._currentOutlineItemCapability.resolve(/* enabled = */ false);
-    } else if (this._isPagesLoaded) {
-      this._currentOutlineItemCapability.resolve(/* enabled = */ true);
+    } else if (this._isPagesLoaded !== null) {
+      this._currentOutlineItemCapability.resolve(
+        /* enabled = */ this._isPagesLoaded
+      );
     }
 
     this.eventBus.dispatch("outlineloaded", {


### PR DESCRIPTION
*This patch can be tested e.g. with the `poppler-85140-0.pdf` document from the test-suite.*

For some sufficiently corrupt documents the `getDocument` call will succeed, but fetching even the very first page fails. Currently we only print error messages (in the console) from the `{BaseViewer, PDFThumbnailViewer}.setDocument` methods, but don't actually provide these errors to allow the viewer to handle them properly.
In practice this means that the GENERIC viewer won't display the `errorWrapper`, and in the MOZCENTRAL viewer the *browser* loading indicator is never hidden (since we never unblock the "load" event).