### PR TITLE
Add a (linked) test-case for issue 8022

### DIFF
--- a/test/pdfs/issue8022.pdf.link
+++ b/test/pdfs/issue8022.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/750774/February.Collision.Generic.PC.R2-1.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -875,6 +875,14 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "issue8022",
+       "file": "pdfs/issue8022.pdf",
+       "md5": "a1a028a5d44433a965dd1e778f321c14",
+       "link": true,
+       "rounds": 1,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue8078",
        "file": "pdfs/issue8078.pdf",
        "md5": "8b7d74bc24b4157393e4e88a511c05f1",


### PR DESCRIPTION
Given that [bug 1336591](https://bugzilla.mozilla.org/show_bug.cgi?id=1336591) was just closed as fixed, thus fixing issue #8022 in Firefox, let's add a test-case to enable us to catch any future regressions either in PDF.js or in browsers themselves.