### PR TITLE
Improve `PDFDocument.checkLastPage`/`Catalog.getAllPageDicts` for documents with corrupt XRef tables (PR 14311, 14335 follow-up)

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -1224,7 +1224,7 @@ class Catalog {
    * Eagerly fetches the entire /Pages-tree; should ONLY be used as a fallback.
    * @returns {Map}
    */
-  getAllPageDicts() {
+  getAllPageDicts(recoveryMode = false) {
     const queue = [{ currentNode: this.toplevelPagesDict, posInKids: 0 }];
     const visitedNodes = new RefSet();
     const map = new Map();
@@ -1233,8 +1233,8 @@ class Catalog {
     function addPageDict(pageDict, pageRef) {
       map.set(pageIndex++, [pageDict, pageRef]);
     }
-    function addPageError(msg) {
-      map.set(pageIndex++, [new FormatError(msg), null]);
+    function addPageError(error) {
+      map.set(pageIndex++, [error, null]);
     }
 
     while (queue.length > 0) {
@@ -1248,12 +1248,16 @@ class Catalog {
         if (ex instanceof MissingDataException) {
           throw ex;
         }
-        if (ex instanceof XRefEntryException) {
+        if (ex instanceof XRefEntryException && !recoveryMode) {
           throw ex;
         }
+        addPageError(ex);
+        break;
       }
       if (!Array.isArray(kids)) {
-        addPageError("Page dictionary kids object is not an array.");
+        addPageError(
+          new FormatError("Page dictionary kids object is not an array.")
+        );
         break;
       }
 
@@ -1271,13 +1275,17 @@ class Catalog {
           if (ex instanceof MissingDataException) {
             throw ex;
           }
-          if (ex instanceof XRefEntryException) {
+          if (ex instanceof XRefEntryException && !recoveryMode) {
             throw ex;
           }
+          addPageError(ex);
+          break;
         }
         // Prevent circular references in the /Pages tree.
         if (visitedNodes.has(kidObj)) {
-          addPageError("Pages tree contains circular reference.");
+          addPageError(
+            new FormatError("Pages tree contains circular reference.")
+          );
           break;
         }
         visitedNodes.put(kidObj);
@@ -1289,7 +1297,9 @@ class Catalog {
       }
       if (!(obj instanceof Dict)) {
         addPageError(
-          "Page dictionary kid reference points to wrong type of object."
+          new FormatError(
+            "Page dictionary kid reference points to wrong type of object."
+          )
         );
         break;
       }

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -1393,7 +1393,9 @@ class PDFDocument {
 
       let pagesTree;
       try {
-        pagesTree = await pdfManager.ensureCatalog("getAllPageDicts");
+        pagesTree = await pdfManager.ensureCatalog("getAllPageDicts", [
+          recoveryMode,
+        ]);
       } catch (reasonAll) {
         if (reasonAll instanceof XRefEntryException && !recoveryMode) {
           throw new XRefParseException();


### PR DESCRIPTION
 - Improve `PDFDocument.checkLastPage` for documents with corrupt XRef tables (PR 14311, 14335 follow-up)

   Rather than trying, and failing, to fetch the entire /Pages-tree for documents with corrupt XRef tables, let's fallback to indexing all objects *before* trying to invoke the `Catalog.getAllPageDicts` method.

 - Update `Catalog.getAllPageDicts` to always propagate the actual Errors (PR 14335 follow-up)

   Rather than "swallowing" the actual Errors, when data fetching fails, ensure that they're always being propagated as intended to the call-site instead.
   Note that we purposely handle `XRefEntryException` specially, to make it possible to fallback to indexing all XRef objects.
