### PR TITLE
Upgrade Node.js to version 16 in the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Use Node.js 14 LTS
-        uses: actions/setup-node@v1
+      - name: Use Node.js 16 LTS
+        uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: '16'
 
       - name: Install Gulp
         run: npm install -g gulp-cli


### PR DESCRIPTION
Version 14 that we used before is now in maintenance mode, so we should upgrade to the most recent LTS version.

Moreover, use the most recent `setup-node` workflow version and syntax; see https://github.com/actions/setup-node#usage.