### PR TITLE
Support disabling of form editing when `pdfjs.enablePermissions` is set (issue 14356)

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -76,6 +76,8 @@ const MAX_CANVAS_PIXELS = compatibilityParams.maxCanvasPixels || 16777216;
  * @implements {IRenderableView}
  */
 class PDFPageView {
+  #annotationMode = AnnotationMode.ENABLE_FORMS;
+
   /**
    * @param {PDFPageViewOptions} options
    */
@@ -96,7 +98,7 @@ class PDFPageView {
       options.optionalContentConfigPromise || null;
     this.hasRestrictedScaling = false;
     this.textLayerMode = options.textLayerMode ?? TextLayerMode.ENABLE;
-    this._annotationMode =
+    this.#annotationMode =
       options.annotationMode ?? AnnotationMode.ENABLE_FORMS;
     this.imageResourcesPath = options.imageResourcesPath || "";
     this.useOnlyCssZoom = options.useOnlyCssZoom || false;
@@ -597,7 +599,7 @@ class PDFPageView {
     this.textLayer = textLayer;
 
     if (
-      this._annotationMode !== AnnotationMode.DISABLE &&
+      this.#annotationMode !== AnnotationMode.DISABLE &&
       this.annotationLayerFactory
     ) {
       this._annotationCanvasMap ||= new Map();
@@ -607,7 +609,7 @@ class PDFPageView {
           pdfPage,
           /* annotationStorage = */ null,
           this.imageResourcesPath,
-          this._annotationMode === AnnotationMode.ENABLE_FORMS,
+          this.#annotationMode === AnnotationMode.ENABLE_FORMS,
           this.l10n,
           /* enableScripting = */ null,
           /* hasJSActionsPromise = */ null,
@@ -835,7 +837,7 @@ class PDFPageView {
       canvasContext: ctx,
       transform,
       viewport: this.viewport,
-      annotationMode: this._annotationMode,
+      annotationMode: this.#annotationMode,
       optionalContentConfigPromise: this._optionalContentConfigPromise,
       annotationCanvasMap: this._annotationCanvasMap,
     };
@@ -892,7 +894,7 @@ class PDFPageView {
     });
     const promise = pdfPage
       .getOperatorList({
-        annotationMode: this._annotationMode,
+        annotationMode: this.#annotationMode,
       })
       .then(opList => {
         ensureNotCancelled();

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -141,6 +141,11 @@
   background: none;
 }
 
+.pdfViewer.enablePermissions .textLayer span {
+  user-select: none !important;
+  cursor: not-allowed;
+}
+
 .pdfPresentationMode .pdfViewer {
   padding-bottom: 0;
 }

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -204,11 +204,6 @@ select {
   display: none !important;
 }
 
-.pdfViewer.enablePermissions .textLayer span {
-  user-select: none !important;
-  cursor: not-allowed;
-}
-
 #viewerContainer.pdfPresentationMode:fullscreen {
   top: 0;
   background-color: rgba(0, 0, 0, 1);


### PR DESCRIPTION
For encrypted PDF documents without the required permissions set, this patch adds support for disabling of form editing. However, please note that it also requires that the `pdfjs.enablePermissions` preference is set to `true`[1] (since PDF document permissions could be seen as user hostile).

Based on https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/PDF32000_2008.pdf#G6.1942134, this condition hopefully makes sense.

Fixes #14356

---
[1] Either manually with `about:config`, or using e.g. a [Group Policy](https://github.com/mozilla/policy-templates).
