### PR TITLE
Only call `PDFDocumentProxy.getPermissions`, in the viewer, when `pdfjs.enablePermissions` is set (PR 14362 follow-up)

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -490,7 +490,7 @@ class BaseViewer {
     if (pdfDocument !== this.pdfDocument) {
       return; // The document was closed while the permissions resolved.
     }
-    if (!permissions || !this.#enablePermissions) {
+    if (!permissions) {
       return;
     }
 
@@ -554,7 +554,9 @@ class BaseViewer {
     const firstPagePromise = pdfDocument.getPage(1);
     // Rendering (potentially) depends on this, hence fetching it immediately.
     const optionalContentConfigPromise = pdfDocument.getOptionalContentConfig();
-    const permissionsPromise = pdfDocument.getPermissions();
+    const permissionsPromise = this.#enablePermissions
+      ? pdfDocument.getPermissions()
+      : Promise.resolve();
 
     // Given that browsers don't handle huge amounts of DOM-elements very well,
     // enforce usage of PAGE-scrolling when loading *very* long/large documents.


### PR DESCRIPTION
By making this API-call *unconditionally*, we introduce a (slight) delay in the initialization of *all* documents.
That seems quite unfortunate, since `pdfjs.enablePermissions` is off by default, and it thus seem better only do the API-call when actually needed; sorry about this!