### PR TITLE
Disable failing print actions integration test in Firefox

### DIFF
--- a/test/integration/scripting_spec.js
+++ b/test/integration/scripting_spec.js
@@ -353,6 +353,9 @@ describe("Interaction", () => {
     it("must execute WillPrint and DidPrint actions", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
+          if (browserName === "firefox") {
+            pending("Disabled in Firefox, because of bug 1741698.");
+          }
           if (process.platform === "win32" && browserName === "firefox") {
             pending("Disabled in Firefox on Windows, because of bug 1662471.");
           }


### PR DESCRIPTION
Once the upstream bug is fixed it can be enabled again because it's causing way too much noise now. This is tracked in issue #14293. Note that I deliberately added a new block so we can easily remove it later on and because the other block is about another bug.