### PR TITLE
Consistently use string arguments for page.waitForFunction calls and upgrade to Puppeteer 13.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "postcss": "^8.4.4",
         "postcss-calc": "^8.0.0",
         "prettier": "^2.5.1",
-        "puppeteer": "^12.0.1",
+        "puppeteer": "^13.0.0",
         "rimraf": "^3.0.2",
         "streamqueue": "^1.1.2",
         "stylelint": "^14.1.0",
@@ -12389,7 +12389,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -12405,19 +12405,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -12432,7 +12432,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -12450,7 +12450,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -15524,9 +15524,9 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-12.0.1.tgz",
-      "integrity": "sha512-YQ3GRiyZW0ddxTW+iiQcv2/8TT5c3+FcRUCg7F8q2gHqxd5akZN400VRXr9cHQKLWGukmJLDiE72MrcLK9tFHQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.0.0.tgz",
+      "integrity": "sha512-kZfGAieIVSo4bFqYuvY2KvhgP9txzmPbbnpZIzLlfdt8nEu9evXEwsbBt1BHocVQM4fJmCiS+FRyw7c8aWadNg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -28466,7 +28466,7 @@
         "lodash._baseindexof": {
           "version": "3.1.0",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -28480,17 +28480,17 @@
         "lodash._bindcallback": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "dev": true,
+          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
@@ -28503,7 +28503,7 @@
         "lodash._getnative": {
           "version": "3.9.1",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash._root": {
           "version": "3.0.1",
@@ -28518,7 +28518,7 @@
         "lodash.restparam": {
           "version": "3.6.1",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash.union": {
           "version": "4.6.0",
@@ -30906,9 +30906,9 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-12.0.1.tgz",
-      "integrity": "sha512-YQ3GRiyZW0ddxTW+iiQcv2/8TT5c3+FcRUCg7F8q2gHqxd5akZN400VRXr9cHQKLWGukmJLDiE72MrcLK9tFHQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.0.0.tgz",
+      "integrity": "sha512-kZfGAieIVSo4bFqYuvY2KvhgP9txzmPbbnpZIzLlfdt8nEu9evXEwsbBt1BHocVQM4fJmCiS+FRyw7c8aWadNg==",
       "dev": true,
       "requires": {
         "debug": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "postcss": "^8.4.4",
     "postcss-calc": "^8.0.0",
     "prettier": "^2.5.1",
-    "puppeteer": "^12.0.1",
+    "puppeteer": "^13.0.0",
     "rimraf": "^3.0.2",
     "streamqueue": "^1.1.2",
     "stylelint": "^14.1.0",

--- a/test/integration/scripting_spec.js
+++ b/test/integration/scripting_spec.js
@@ -696,14 +696,9 @@ describe("Interaction", () => {
               );
 
               await page.click(`[data-annotation-id='${id}R']`);
+              const selector = ref.replace("\\", "\\\\");
               await page.waitForFunction(
-                (_ref, _current, _propName) =>
-                  getComputedStyle(document.querySelector(_ref))[_propName] !==
-                  _current,
-                {},
-                ref,
-                current,
-                propName
+                `getComputedStyle(document.querySelector("${selector}"))["${propName}"] !== "${current}"`
               );
 
               const color = await page.$eval(
@@ -755,11 +750,7 @@ describe("Interaction", () => {
             await page.keyboard.press("Tab");
 
             await page.waitForFunction(
-              _prev =>
-                getComputedStyle(document.querySelector("#\\31 71R")).value !==
-                _prev,
-              {},
-              prev
+              `getComputedStyle(document.querySelector("#\\\\31 71R")).value !== "${prev}"`
             );
 
             sum += val;


### PR DESCRIPTION
The commit messages contain more information about the individual changes.

This commit makes sure that our code is consistent and avoids the issue now reported upstream in https://github.com/puppeteer/puppeteer/issues/7836 so that it's no longer a blocker for us.

Fixes #14363.