### PR TITLE
Ignore *negative* /FitH parameters in the viewer (issue 14385)

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -1173,7 +1173,7 @@ class BaseViewer {
         if (y === null && this._location) {
           x = this._location.left;
           y = this._location.top;
-        } else if (typeof y !== "number") {
+        } else if (typeof y !== "number" || y < 0) {
           // The "top" value isn't optional, according to the spec, however some
           // bad PDF generators will pretend that it is (fixes bug 1663390).
           y = pageHeight;


### PR DESCRIPTION
This provides a work-around for badly generated PDF documents that contain *negative* /FitH parameters (in the referenced issue the value `-32768` is used).

Fixes #14385