### PR TITLE
Handle non-integer Annotation border widths correctly (issue 14203) 

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -922,7 +922,7 @@ class AnnotationBorderStyle {
       this.width = 0; // This is consistent with the behaviour in Adobe Reader.
       return;
     }
-    if (Number.isInteger(width)) {
+    if (typeof width === "number") {
       if (width > 0) {
         const maxWidth = (rect[2] - rect[0]) / 2;
         const maxHeight = (rect[3] - rect[1]) / 2;

--- a/test/pdfs/issue14203.pdf.link
+++ b/test/pdfs/issue14203.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/7428963/pdfcomment.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -4212,6 +4212,15 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "issue14203",
+       "file": "pdfs/issue14203.pdf",
+       "md5": "26c1c1e7341bc23fb28d805fa516dbbe",
+       "link": true,
+       "rounds": 1,
+       "firstPage": 11,
+       "lastPage": 11,
+       "type": "eq"
+   },
     {  "id": "issue11045",
        "file": "pdfs/issue11045.pdf",
        "md5": "101d4cb649cc006e0f2b14923e8d97d6",

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -414,10 +414,13 @@ describe("annotation", function () {
 
   describe("AnnotationBorderStyle", function () {
     it("should set and get a valid width", function () {
-      const borderStyle = new AnnotationBorderStyle();
-      borderStyle.setWidth(3);
+      const borderStyleInt = new AnnotationBorderStyle();
+      borderStyleInt.setWidth(3);
+      const borderStyleNum = new AnnotationBorderStyle();
+      borderStyleNum.setWidth(2.5);
 
-      expect(borderStyle.width).toEqual(3);
+      expect(borderStyleInt.width).toEqual(3);
+      expect(borderStyleNum.width).toEqual(2.5);
     });
 
     it("should not set and get an invalid width", function () {


### PR DESCRIPTION
The border width is expected to be 3 but tracing Class Annotation, I found the width actually comes as float 2.99998 so when the width passed to Number.Isinteger in Class AnnotationBorderStyle:setWidth() the width gets lost.

Number.Isinteger makes sure that the value should be integer.Taking it into account,adding Math.round can solve this issue I think.