### PR TITLE
Drop the beta logic from the Gulpfile/website/`pdfjs.config` file

### DIFF
--- a/docs/contents/getting_started/index.md
+++ b/docs/contents/getting_started/index.md
@@ -43,20 +43,14 @@ Before downloading PDF.js please take a moment to understand the different layer
     <p>
       Includes the generic build of PDF.js and the viewer.
     </p>
-    <span class="GROUP_CLASS">
-      <a type="button" class="btn btn-primary" href="https://github.com/mozilla/pdf.js/releases/download/vSTABLE_VERSION/pdfjs-STABLE_VERSION-dist.zip">Stable (vSTABLE_VERSION)</a>
-      <a type="button" class="btn btn-warning HIDDEN_CLASS" href="https://github.com/mozilla/pdf.js/releases/download/vBETA_VERSION/pdfjs-BETA_VERSION-dist.zip">Beta (vBETA_VERSION)</a>
-    </span>
+    <a type="button" class="btn btn-primary" href="https://github.com/mozilla/pdf.js/releases/download/vSTABLE_VERSION/pdfjs-STABLE_VERSION-dist.zip">Stable (vSTABLE_VERSION)</a>
   </div>
   <div class="col-md-4">
     <h3>Prebuilt (for older browsers)</h3>
     <p>
       Includes the generic build of PDF.js and the viewer.
     </p>
-    <span class="GROUP_CLASS">
-      <a type="button" class="btn btn-primary" href="https://github.com/mozilla/pdf.js/releases/download/vSTABLE_VERSION/pdfjs-STABLE_VERSION-legacy-dist.zip">Stable (vSTABLE_VERSION)</a>
-      <a type="button" class="btn btn-warning HIDDEN_CLASS" href="https://github.com/mozilla/pdf.js/releases/download/vBETA_VERSION/pdfjs-BETA_VERSION-legacy-dist.zip">Beta (vBETA_VERSION)</a>
-    </span>
+    <a type="button" class="btn btn-primary" href="https://github.com/mozilla/pdf.js/releases/download/vSTABLE_VERSION/pdfjs-STABLE_VERSION-legacy-dist.zip">Stable (vSTABLE_VERSION)</a>
   </div>
   <div class="col-md-4">
     <h3>Source</h3>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1555,8 +1555,7 @@ gulp.task(
       fs.readFileSync(BUILD_DIR + "version.json").toString()
     ).version;
 
-    config.stableVersion = config.betaVersion;
-    config.betaVersion = version;
+    config.stableVersion = version;
 
     return merge([
       createStringSource(CONFIG_FILE, JSON.stringify(config, null, 2)).pipe(
@@ -1957,31 +1956,11 @@ gulp.task("wintersmith", function (done) {
       done(error);
       return;
     }
-    const { stableVersion, betaVersion } = config;
 
     replaceInFile(
       GH_PAGES_DIR + "/getting_started/index.html",
       /STABLE_VERSION/g,
-      stableVersion
-    );
-    replaceInFile(
-      GH_PAGES_DIR + "/getting_started/index.html",
-      /BETA_VERSION/g,
-      betaVersion
-    );
-
-    // Hide the beta version button if there is only a stable version.
-    const groupClass = betaVersion ? "btn-group-vertical centered" : "";
-    const hiddenClass = betaVersion ? "" : "hidden";
-    replaceInFile(
-      GH_PAGES_DIR + "/getting_started/index.html",
-      /GROUP_CLASS/g,
-      groupClass
-    );
-    replaceInFile(
-      GH_PAGES_DIR + "/getting_started/index.html",
-      /HIDDEN_CLASS/g,
-      hiddenClass
+      config.stableVersion
     );
 
     console.log("Done building with wintersmith.");

--- a/pdfjs.config
+++ b/pdfjs.config
@@ -1,5 +1,4 @@
 {
-  "betaVersion": "2.12.313",
   "stableVersion": "2.12.313",
   "baseVersion": "a2ae56f394acb485ce7067a75342ac60da17f171",
   "versionPrefix": "2.13."


### PR DESCRIPTION
From now on we only make stable releases, so the beta logic should be removed to simplify the code. To test this, you can locally run `gulp wintersmith` to build the website and `gulp publish` to check that the `pdfjs.config` file is adjusted correctly. The website can also be viewed in the browser at http://54.241.84.105:8877/752a0925ca20096/getting_started.