### PR TITLE
Prevent run-time errors in `BaseViewer` when it's falling back to `SimpleLinkService` (issue 14442, PR 14295 follow-up)

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -1541,7 +1541,7 @@ class BaseViewer {
       if (!pageView.pdfPage) {
         pageView.setPdfPage(pdfPage);
       }
-      if (!this.linkService._cachedPageNumber(pdfPage.ref)) {
+      if (!this.linkService._cachedPageNumber?.(pdfPage.ref)) {
         this.linkService.cachePageRef(pageView.id, pdfPage.ref);
       }
       return pdfPage;


### PR DESCRIPTION
Fixes #14442