### PR TITLE
Dispatch a "documenterror" event in `PDFViewerApplication._documentError` (issue 14451)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1057,6 +1057,12 @@ const PDFViewerApplication = {
     this._unblockDocumentLoadEvent();
 
     this._otherError(message, moreInfo);
+
+    this.eventBus.dispatch("documenterror", {
+      source: this,
+      message,
+      reason: moreInfo?.message ?? null,
+    });
   },
 
   /**


### PR DESCRIPTION
*Please note:* This is a tentative patch, since I don't know if this is deemed important enough to fix.

The new event could be seen as a *supplement* to the existing "documentinit" and "documentloaded" events, but for the case when a PDF document fails to load.
To make the "documenterror" event generally useful, it'll include both the localized error message as well as the original reason for the error (when that exists).

This (probably) fixes #14451