### PR TITLE
Implement a unit test for `getCharUnicodeCategory` in `src/core/unicode.js` (PR 14428 follow-up)

### DIFF
--- a/test/unit/unicode_spec.js
+++ b/test/unit/unicode_spec.js
@@ -14,16 +14,17 @@
  */
 
 import {
-  getDingbatsGlyphsUnicode,
-  getGlyphsUnicode,
-} from "../../src/core/glyphlist.js";
-import {
+  getCharUnicodeCategory,
   getNormalizedUnicodes,
   getUnicodeForGlyph,
   getUnicodeRangeFor,
   mapSpecialUnicodeValues,
   reverseIfRtl,
 } from "../../src/core/unicode.js";
+import {
+  getDingbatsGlyphsUnicode,
+  getGlyphsUnicode,
+} from "../../src/core/glyphlist.js";
 
 describe("unicode", function () {
   describe("mapSpecialUnicodeValues", function () {
@@ -39,6 +40,30 @@ describe("unicode", function () {
       expect(mapSpecialUnicodeValues(0xf8e9)).toEqual(0x00a9);
       // Private Use Area characters
       expect(mapSpecialUnicodeValues(0xffff)).toEqual(0);
+    });
+  });
+
+  describe("getCharUnicodeCategory", function () {
+    it("should correctly determine the character category", function () {
+      const tests = {
+        // Whitespace
+        " ": { isDiacritic: false, isWhitespace: true },
+        "\t": { isDiacritic: false, isWhitespace: true },
+        "\u2001": { isDiacritic: false, isWhitespace: true },
+        "\uFEFF": { isDiacritic: false, isWhitespace: true },
+
+        // Diacritic
+        "\u0302": { isDiacritic: true, isWhitespace: false },
+        "\u0344": { isDiacritic: true, isWhitespace: false },
+        "\u0361": { isDiacritic: true, isWhitespace: false },
+
+        // No whitespace or diacritic
+        a: { isDiacritic: false, isWhitespace: false },
+        1: { isDiacritic: false, isWhitespace: false },
+      };
+      for (const [character, expectation] of Object.entries(tests)) {
+        expect(getCharUnicodeCategory(character)).toEqual(expectation);
+      }
     });
   });
 


### PR DESCRIPTION
Given that the other functions in this file are already covered by unit tests, we should also cover this newly added function.