### PR TITLE
web: Read WheelEvent.deltaMode before deltas.

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2691,13 +2691,17 @@ function webViewerWheel(evt) {
       return;
     }
 
+    // It is important that we query deltaMode before delta{X,Y}, so that
+    // Firefox doesn't switch to DOM_DELTA_PIXEL mode for compat with other
+    // browsers, see https://bugzilla.mozilla.org/show_bug.cgi?id=1392460.
+    const deltaMode = evt.deltaMode;
+    const delta = normalizeWheelEventDirection(evt);
     const previousScale = pdfViewer.currentScale;
 
-    const delta = normalizeWheelEventDirection(evt);
     let ticks = 0;
     if (
-      evt.deltaMode === WheelEvent.DOM_DELTA_LINE ||
-      evt.deltaMode === WheelEvent.DOM_DELTA_PAGE
+      deltaMode === WheelEvent.DOM_DELTA_LINE ||
+      deltaMode === WheelEvent.DOM_DELTA_PAGE
     ) {
       // For line-based devices, use one tick per event, because different
       // OSs have different defaults for the number lines. But we generally


### PR DESCRIPTION
So that Firefox doesn't switch to pixel mode for compat with other
browsers.

This should fix https://github.com/mozilla/pdf.js/issues/14476, in terms
of restoring the previous behavior.

We probably want to change the pixel-based scrolling code to not scroll
so much (the deltaMode stuff normalizes to +/-1 tick for each wheel
event, perhaps the pixel-based value should do the same).