### PR TITLE
Disable the browser-tests, during `gulp makeref`, in Google Chrome on the Windows bot (PR 14392 follow-up)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -607,11 +607,18 @@ function makeRef(done, bot) {
   console.log();
   console.log("### Creating reference images");
 
+  let forceNoChrome = false;
   const args = ["test.js", "--masterMode"];
   if (bot) {
+    const os = process.env.OS;
+    if (/windows/i.test(os)) {
+      // The browser-tests are too slow in Google Chrome on the Windows
+      // bot, causing a timeout, hence disabling them for now.
+      forceNoChrome = true;
+    }
     args.push("--noPrompts", "--strictVerify");
   }
-  if (process.argv.includes("--noChrome")) {
+  if (process.argv.includes("--noChrome") || forceNoChrome) {
     args.push("--noChrome");
   }
 


### PR DESCRIPTION
Either the latest Chromium update, the latest Puppeteer update, or a combination of them both are now causing the Windows bot to timeout during the browser-tests; please see PR #14392.