### PR TITLE
Remove the `MBTA-pretax-form-July2012` browser-test since it's a duplicate

### DIFF
--- a/test/pdfs/MBTA-pretax-form-July2012.pdf.link
+++ b/test/pdfs/MBTA-pretax-form-July2012.pdf.link
@@ -1,2 +1,0 @@
-https://web.archive.org/web/20121105185256/http://www.northeastern.edu/hrm/pdfs/resources/benefits/MBTA-pretax-form-July2012.pdf
-

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1328,14 +1328,6 @@
       "enableXfa": true,
       "type": "eq"
     },
-    {  "id": "MBTA-pretax-form-July2012",
-      "file": "pdfs/MBTA-pretax-form-July2012.pdf",
-      "md5": "c23beb39e1c91a780da9d4b60cbd157f",
-      "rounds": 1,
-      "link": true,
-      "enableXfa": true,
-      "type": "eq"
-    },
     {  "id": "xfa_bug1716380",
        "file": "pdfs/xfa_bug1716380.pdf",
        "md5": "1351f816f0509fe750ca61ef2bd40872",


### PR DESCRIPTION
The md5 entry perfectly matches the `xfa_bug1718521_2` test-case, which means that we unnecessarily test the same exact document twice.