### PR TITLE
Remove the `xfa_bug1716838` browser-test since it's a duplicate

### DIFF
--- a/test/pdfs/xfa_bug1716838.pdf.link
+++ b/test/pdfs/xfa_bug1716838.pdf.link
@@ -1,1 +1,0 @@
-https://bugzilla.mozilla.org/attachment.cgi?id=9227473

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1278,7 +1278,8 @@
        "link": true,
        "rounds": 1,
        "enableXfa": true,
-       "type": "eq"
+       "type": "eq",
+       "about": "Also tests bug 1716838."
     },
     {  "id": "xfa_bug1717668_2",
        "file": "pdfs/xfa_bug1717668_2.pdf",
@@ -1371,14 +1372,6 @@
     {  "id": "xfa_bug1716809",
        "file": "pdfs/xfa_bug1716809.pdf",
        "md5": "7192f9e27e8b84776d107f57cbe353d5",
-       "link": true,
-       "rounds": 1,
-       "enableXfa": true,
-       "type": "eq"
-    },
-    {  "id": "xfa_bug1716838",
-       "file": "pdfs/xfa_bug1716838.pdf",
-       "md5": "564ecff67be690b43c2a144ae5967034",
        "link": true,
        "rounds": 1,
        "enableXfa": true,


### PR DESCRIPTION
The md5 entry perfectly matches the `xfa_bug1717668_1` test-case, which means that we unnecessarily test the same exact document twice.