### PR TITLE
Avoid the `findResultsCount` span taking up (vertical) space when hidden (PR 13261 follow-up)

### DIFF
--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -163,7 +163,6 @@ class PDFFindBar {
     }
     matchCountMsg.then(msg => {
       this.findResultsCount.textContent = msg;
-      this.findResultsCount.classList.toggle("hidden", !total);
       // Since `updateResultsCount` may be called from `PDFFindController`,
       // ensure that the width of the findbar is always updated correctly.
       this._adjustWidth();

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -691,6 +691,8 @@ html[dir="ltr"] .doorHangerRight:before {
 #findMsg {
   color: rgba(251, 0, 0, 1);
 }
+
+#findResultsCount:empty,
 #findMsg:empty {
   display: none;
 }

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -502,7 +502,7 @@ html[dir="rtl"] #outerContainer.sidebarOpen #loadingBar {
 .findbar.wrapContainers > div {
   clear: both;
 }
-.findbar.wrapContainers > div#findbarMessageContainer {
+.findbar.wrapContainers > div.findbarMessageContainer {
   height: auto;
 }
 html[dir="ltr"] .findbar {

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -142,7 +142,7 @@ See https://github.com/adobe-type-tools/cmap-resources
           </div>
 
           <div class="findbarMessageContainer">
-            <span id="findResultsCount" class="toolbarLabel hidden"></span>
+            <span id="findResultsCount" class="toolbarLabel"></span>
           </div>
           <div class="findbarMessageContainer">
             <span id="findMsg" class="toolbarLabel"></span>

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -141,11 +141,10 @@ See https://github.com/adobe-type-tools/cmap-resources
             <label for="findEntireWord" class="toolbarLabel" data-l10n-id="find_entire_word_label">Whole words</label>
           </div>
 
-          <div id="findbarOptionsThreeContainer">
+          <div class="findbarMessageContainer">
             <span id="findResultsCount" class="toolbarLabel hidden"></span>
           </div>
-
-          <div id="findbarMessageContainer">
+          <div class="findbarMessageContainer">
             <span id="findMsg" class="toolbarLabel"></span>
           </div>
         </div>  <!-- findbar -->


### PR DESCRIPTION
When the viewer becomes narrow, the `PDFFindBar` will (forcibly) wrap its elements to prevent it from extending to the full window width.
Currently, after PR #13261, this now leads to the `findResultsCount` span taking up vertical space *unconditionally* when the findbar is wrapped. To avoid a blank space being shown in this case, before searching has begun, place the `findResultsCount` span in a "message" rather than an "options" container.