### PR TITLE
[GENERIC viewer] Remove the `moz`-prefixed FullScreen API usage from the viewer

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -677,9 +677,7 @@ const PDFViewerApplication = {
     return shadow(
       this,
       "supportsFullscreen",
-      document.fullscreenEnabled ||
-        document.mozFullScreenEnabled ||
-        document.webkitFullscreenEnabled
+      document.fullscreenEnabled || document.webkitFullscreenEnabled
     );
   },
 

--- a/web/pdf_presentation_mode.js
+++ b/web/pdf_presentation_mode.js
@@ -79,8 +79,6 @@ class PDFPresentationMode {
     } else {
       if (this.container.requestFullscreen) {
         this.container.requestFullscreen();
-      } else if (this.container.mozRequestFullScreen) {
-        this.container.mozRequestFullScreen();
       } else if (this.container.webkitRequestFullscreen) {
         this.container.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
       } else {
@@ -145,11 +143,7 @@ class PDFPresentationMode {
     if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
       return !!document.fullscreenElement;
     }
-    return !!(
-      document.fullscreenElement ||
-      document.mozFullScreen ||
-      document.webkitIsFullScreen
-    );
+    return !!(document.fullscreenElement || document.webkitIsFullScreen);
   }
 
   /**
@@ -450,7 +444,6 @@ class PDFPresentationMode {
 
     window.addEventListener("fullscreenchange", this.fullscreenChangeBind);
     if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
-      window.addEventListener("mozfullscreenchange", this.fullscreenChangeBind);
       window.addEventListener(
         "webkitfullscreenchange",
         this.fullscreenChangeBind
@@ -464,10 +457,6 @@ class PDFPresentationMode {
   _removeFullscreenChangeListeners() {
     window.removeEventListener("fullscreenchange", this.fullscreenChangeBind);
     if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
-      window.removeEventListener(
-        "mozfullscreenchange",
-        this.fullscreenChangeBind
-      );
       window.removeEventListener(
         "webkitfullscreenchange",
         this.fullscreenChangeBind


### PR DESCRIPTION
The unprefixed FullScreen API has been available since Firefox 64, which was [released on 2018-12-11](https://wiki.mozilla.org/Release_Management/Calendar#Past_branch_dates), and has now been included in no less than *three* ESR releases.
Please also see the following MDN compatibility data:
 - https://developer.mozilla.org/en-US/docs/Web/API/Document/fullscreenEnabled#browser_compatibility
 - https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullScreen#browser_compatibility
 - https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API#browser_compatibility
 - https://developer.mozilla.org/en-US/docs/Web/API/Document/fullscreenchange_event#browser_compatibility