### PR TITLE
Implement reference test support for rendering at different zoom levels (issue 14505)

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -430,6 +430,7 @@ class Driver {
       task.pageNum = task.firstPage || 1;
       task.stats = { times: [] };
       task.enableXfa = task.enableXfa === true;
+      task.scale ||= 1;
 
       // Support *linked* test-cases for the other suites, e.g. unit- and
       // integration-tests, without needing to run them as reference-tests.
@@ -601,7 +602,7 @@ class Driver {
         task.pdfDoc.getPage(task.pageNum).then(
           page => {
             const viewport = page.getViewport({
-              scale: PixelsPerInch.PDF_TO_CSS_UNITS,
+              scale: task.scale * PixelsPerInch.PDF_TO_CSS_UNITS,
             });
             this.canvas.width = viewport.width;
             this.canvas.height = viewport.height;

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -5954,6 +5954,14 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue6127_scale4",
+       "file": "pdfs/issue6127.pdf",
+       "md5": "65ef9572bddef5fddfaf7172f10a0df2",
+       "rounds": 1,
+       "lastPage": 1,
+       "scale": 4,
+       "type": "eq"
+    },
     {  "id": "annotation-polyline-polygon",
        "file": "pdfs/annotation-polyline-polygon.pdf",
        "md5": "e68611602f58c8ca70cc40575ba3b04e",


### PR DESCRIPTION
 Add tests to check that the rendering is correct at different zoom levels issue: #14505

This PR adds a scale factor in test_manifest.json. The scale factor is set by default to 1.

Setting to a value >1 results in a larger image for the browsertest. 




