### PR TITLE
[api-minor] Update the minimum supported browser versions

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -78,9 +78,9 @@ const config = JSON.parse(fs.readFileSync(CONFIG_FILE).toString());
 const AUTOPREFIXER_CONFIG = {
   overrideBrowserslist: [
     "last 2 versions",
-    "Chrome >= 68",
+    "Chrome >= 73",
     "Firefox ESR",
-    "Safari >= 11.1",
+    "Safari >= 12.1",
     "> 0.5%",
     "not IE > 0",
     "not dead",
@@ -1346,7 +1346,7 @@ gulp.task(
         ),
         preprocessCSS("web/viewer.css", "chrome", defines, true)
           .pipe(
-            postcss([autoprefixer({ overrideBrowserslist: ["chrome >= 68"] })])
+            postcss([autoprefixer({ overrideBrowserslist: ["Chrome >= 73"] })])
           )
           .pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + "web")),
 

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -18,14 +18,8 @@ import { isNodeJS } from "./is_node.js";
 // Skip compatibility checks for modern builds and if we already ran the module.
 if (
   (typeof PDFJSDev === "undefined" || !PDFJSDev.test("SKIP_BABEL")) &&
-  (typeof globalThis === "undefined" || !globalThis._pdfjsCompatibilityChecked)
+  !globalThis._pdfjsCompatibilityChecked
 ) {
-  // Provides support for `globalThis` in legacy browsers.
-  // Support: Firefox<65, Chrome<71, Safari<12.1, Node.js<12.0.0
-  if (typeof globalThis === "undefined" || globalThis.Math !== Math) {
-    // eslint-disable-next-line no-global-assign
-    globalThis = require("core-js/es/global-this");
-  }
   globalThis._pdfjsCompatibilityChecked = true;
 
   // Support: Node.js
@@ -56,15 +50,6 @@ if (
       return;
     }
     globalThis.DOMMatrix = require("dommatrix/dist/dommatrix.js");
-  })();
-
-  // Provides support for Object.fromEntries in legacy browsers.
-  // Support: Firefox<63, Chrome<73, Safari<12.1, Node.js<12.0.0
-  (function checkObjectFromEntries() {
-    if (Object.fromEntries) {
-      return;
-    }
-    require("core-js/es/object/from-entries.js");
   })();
 
   // Provides support for *recent* additions to the Promise specification,


### PR DESCRIPTION
Please note that while we "support" some (by now) fairly old browsers, that essentially means that the library (and viewer) will load and that the basic functionality will work as intended.[1]
However, in older browsers, some functionality may not be available and generally we'll ask users to update to a modern browser when bugs (specific to old browsers) are reported.[2]

There's always a question of just how old browsers the PDF.js contributors can realistically support, and here I'm suggesting that we place the cut-off point at approximately *three* years.
With that in mind, this patch updates the *minimum* supported browsers (and environments) as follows:
 - Chrome 73, which was released on 2019-03-12; see https://en.wikipedia.org/wiki/Google_Chrome_version_history
 - Firefox ESR (as before); see https://wiki.mozilla.org/Release_Management/Calendar
 - Safari 12.1, which was released on 2019-03-25; see https://en.wikipedia.org/wiki/Safari_version_history#Safari_12
 - Node.js 12, which was release on 2019-04-23 (and will soon reach EOL); see https://en.wikipedia.org/wiki/Node.js#Releases

---
[1] Assuming a `legacy`-build is being used, of course.

[2] In general it's never a good idea to use an old/outdated browser, since those may contain *known* security vulnerabilities.