### PR TITLE
Let `Lexer.getNumber` treat a single minus sign as zero (bug 1753983)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -4561,7 +4561,7 @@ class EvaluatorPreprocessor {
   }
 
   static get MAX_INVALID_PATH_OPS() {
-    return shadow(this, "MAX_INVALID_PATH_OPS", 20);
+    return shadow(this, "MAX_INVALID_PATH_OPS", 10);
   }
 
   constructor(stream, xref, stateManager = new StateManager()) {

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -908,14 +908,17 @@ class Lexer {
       ch = this.nextChar();
     }
     if (ch < /* '0' = */ 0x30 || ch > /* '9' = */ 0x39) {
-      if (
-        divideBy === 10 &&
-        sign === 0 &&
-        (isWhiteSpace(ch) || ch === /* EOF = */ -1)
-      ) {
+      if (isWhiteSpace(ch) || ch === /* EOF = */ -1) {
         // This is consistent with Adobe Reader (fixes issue9252.pdf).
-        warn("Lexer.getNumber - treating a single decimal point as zero.");
-        return 0;
+        if (divideBy === 10 && sign === 0) {
+          warn("Lexer.getNumber - treating a single decimal point as zero.");
+          return 0;
+        }
+        // This is consistent with Adobe Reader (fixes bug1753983.pdf).
+        if (divideBy === 0 && sign === -1) {
+          warn("Lexer.getNumber - treating a single minus sign as zero.");
+          return 0;
+        }
       }
       throw new FormatError(
         `Invalid number: ${String.fromCharCode(ch)} (charCode ${ch})`

--- a/test/pdfs/bug1753983.pdf.link
+++ b/test/pdfs/bug1753983.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=9262646

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -219,6 +219,13 @@
        "lastPage": 3,
        "type": "eq"
     },
+    {  "id": "bug1753983",
+       "file": "pdfs/bug1753983.pdf",
+       "md5": "432be86262e5071176c49713ce458031",
+       "rounds": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "bug921760",
        "file": "pdfs/bug921760.pdf",
        "md5": "1aa136d786a65b0d7cce7bdb3c58c6c3",

--- a/test/unit/parser_spec.js
+++ b/test/unit/parser_spec.js
@@ -151,10 +151,14 @@ describe("parser", function () {
         expect(plusLexer.getNumber()).toEqual(205.88);
       });
 
-      it("should treat a single decimal point as zero", function () {
-        const input = new StringStream(".");
-        const lexer = new Lexer(input);
-        expect(lexer.getNumber()).toEqual(0);
+      it("should treat a single decimal point, or minus sign, as zero", function () {
+        const dotInput = new StringStream(".");
+        const dotLexer = new Lexer(dotInput);
+        expect(dotLexer.getNumber()).toEqual(0);
+
+        const minusInput = new StringStream("-");
+        const minusLexer = new Lexer(minusInput);
+        expect(minusLexer.getNumber()).toEqual(0);
 
         const numbers = ["..", "-.", "+.", "-\r\n.", "+\r\n."];
         for (const number of numbers) {


### PR DESCRIPTION
This appears to be consistent with the behaviour in both Adobe Reader and PDFium (in Google Chrome); this is essentially the same approach as used for a single decimal point in PR #9827.