### PR TITLE
Update the file used with the `xfa_bug1720182` test-case

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -37,6 +37,8 @@ const WORKER_SRC = "../build/generic/build/pdf.worker.js";
 const RENDER_TASK_ON_CONTINUE_DELAY = 5; // ms
 const SVG_NS = "http://www.w3.org/2000/svg";
 
+const md5FileMap = new Map();
+
 function loadStyles(styles) {
   const promises = [];
 
@@ -430,6 +432,19 @@ class Driver {
       task.pageNum = task.firstPage || 1;
       task.stats = { times: [] };
       task.enableXfa = task.enableXfa === true;
+
+      const prevFile = md5FileMap.get(task.md5);
+      if (prevFile) {
+        if (task.file !== prevFile) {
+          this._nextPage(
+            task,
+            `The "${task.file}" file is identical to the previously used "${prevFile}" file.`
+          );
+          return;
+        }
+      } else {
+        md5FileMap.set(task.md5, task.file);
+      }
 
       // Support *linked* test-cases for the other suites, e.g. unit- and
       // integration-tests, without needing to run them as reference-tests.

--- a/test/pdfs/xfa_bug1720182.pdf.link
+++ b/test/pdfs/xfa_bug1720182.pdf.link
@@ -1,1 +1,0 @@
-https://bugzilla.mozilla.org/attachment.cgi?id=9230780

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1157,7 +1157,7 @@
        "type": "eq"
     },
     {  "id": "xfa_bug1720182",
-       "file": "pdfs/xfa_bug1720182.pdf",
+       "file": "pdfs/xfa_bug1716380.pdf",
        "md5": "1351f816f0509fe750ca61ef2bd40872",
        "link": true,
        "rounds": 1,
@@ -1174,7 +1174,8 @@
          "ComplainantLastname2711": {
            "value": "Bar"
          }
-       }
+       },
+       "about": "This *intentionally* uses the same file as test-case xfa_bug1716380."
     },
     {  "id": "bug1720411",
        "file": "pdfs/bug1720411.pdf",


### PR DESCRIPTION
The file used in this test-case is *identical* to, i.e. the md5 entry perfectly matches, the file used with the `xfa_bug1716380` test-case.
While it's obviously fine to use the same PDF document in different reference-tests, note how we e.g. have both `eq` and `text` tests for one document, we should always avoid adding *duplicate* files in the `test/pdfs/` folder.