### PR TITLE
[api-minor] Stop exposing the `createObjectURL` helper function in the API

### DIFF
--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -15,7 +15,6 @@
 /* globals __non_webpack_require__ */
 
 import {
-  createObjectURL,
   FONT_IDENTITY_MATRIX,
   IDENTITY_MATRIX,
   ImageKind,
@@ -49,6 +48,36 @@ if (
   const XLINK_NS = "http://www.w3.org/1999/xlink";
   const LINE_CAP_STYLES = ["butt", "round", "square"];
   const LINE_JOIN_STYLES = ["miter", "round", "bevel"];
+
+  const createObjectURL = function (
+    data,
+    contentType = "",
+    forceDataSchema = false
+  ) {
+    if (
+      URL.createObjectURL &&
+      typeof Blob !== "undefined" &&
+      !forceDataSchema
+    ) {
+      return URL.createObjectURL(new Blob([data], { type: contentType }));
+    }
+    // Blob/createObjectURL is not available, falling back to data schema.
+    const digits =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+
+    let buffer = `data:${contentType};base64,`;
+    for (let i = 0, ii = data.length; i < ii; i += 3) {
+      const b1 = data[i] & 0xff;
+      const b2 = data[i + 1] & 0xff;
+      const b3 = data[i + 2] & 0xff;
+      const d1 = b1 >> 2,
+        d2 = ((b1 & 3) << 4) | (b2 >> 4);
+      const d3 = i + 1 < ii ? ((b2 & 0xf) << 2) | (b3 >> 6) : 64;
+      const d4 = i + 2 < ii ? b3 & 0x3f : 64;
+      buffer += digits[d1] + digits[d2] + digits[d3] + digits[d4];
+    }
+    return buffer;
+  };
 
   const convertImgDataToPng = (function () {
     const PNG_HEADER = new Uint8Array([

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -23,7 +23,6 @@
 import {
   AnnotationMode,
   CMapCompressionType,
-  createObjectURL,
   createPromiseCapability,
   createValidAbsoluteUrl,
   InvalidPDFException,
@@ -109,7 +108,6 @@ export {
   AnnotationMode,
   build,
   CMapCompressionType,
-  createObjectURL,
   createPromiseCapability,
   createValidAbsoluteUrl,
   getDocument,

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1109,28 +1109,6 @@ function createPromiseCapability() {
   return capability;
 }
 
-function createObjectURL(data, contentType = "", forceDataSchema = false) {
-  if (URL.createObjectURL && typeof Blob !== "undefined" && !forceDataSchema) {
-    return URL.createObjectURL(new Blob([data], { type: contentType }));
-  }
-  // Blob/createObjectURL is not available, falling back to data schema.
-  const digits =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-
-  let buffer = `data:${contentType};base64,`;
-  for (let i = 0, ii = data.length; i < ii; i += 3) {
-    const b1 = data[i] & 0xff;
-    const b2 = data[i + 1] & 0xff;
-    const b3 = data[i + 2] & 0xff;
-    const d1 = b1 >> 2,
-      d2 = ((b1 & 3) << 4) | (b2 >> 4);
-    const d3 = i + 1 < ii ? ((b2 & 0xf) << 2) | (b3 >> 6) : 64;
-    const d4 = i + 2 < ii ? b3 & 0x3f : 64;
-    buffer += digits[d1] + digits[d2] + digits[d3] + digits[d4];
-  }
-  return buffer;
-}
-
 export {
   AbortException,
   AnnotationActionEventType,
@@ -1149,7 +1127,6 @@ export {
   BaseException,
   bytesToString,
   CMapCompressionType,
-  createObjectURL,
   createPromiseCapability,
   createValidAbsoluteUrl,
   DocumentActionEventType,

--- a/test/unit/display_utils_spec.js
+++ b/test/unit/display_utils_spec.js
@@ -21,7 +21,7 @@ import {
   isValidFetchUrl,
   PDFDateString,
 } from "../../src/display/display_utils.js";
-import { createObjectURL } from "../../src/shared/util.js";
+import { bytesToString } from "../../src/shared/util.js";
 import { isNodeJS } from "../../src/shared/is_node.js";
 
 describe("display_utils", function () {
@@ -320,7 +320,9 @@ describe("display_utils", function () {
         pending("Blob in not supported in Node.js.");
       }
       const typedArray = new Uint8Array([1, 2, 3, 4, 5]);
-      const blobUrl = createObjectURL(typedArray, "application/pdf");
+      const blobUrl = URL.createObjectURL(
+        new Blob([typedArray], { type: "application/pdf" })
+      );
       // Sanity check to ensure that a "blob:" URL was returned.
       expect(blobUrl.startsWith("blob:")).toEqual(true);
 
@@ -328,12 +330,9 @@ describe("display_utils", function () {
     });
 
     it('gets fallback filename from query string appended to "data:" URL', function () {
-      const typedArray = new Uint8Array([1, 2, 3, 4, 5]);
-      const dataUrl = createObjectURL(
-        typedArray,
-        "application/pdf",
-        /* forceDataSchema = */ true
-      );
+      const typedArray = new Uint8Array([1, 2, 3, 4, 5]),
+        str = bytesToString(typedArray);
+      const dataUrl = `data:application/pdf;base64,${btoa(str)}`;
       // Sanity check to ensure that a "data:" URL was returned.
       expect(dataUrl.startsWith("data:")).toEqual(true);
 


### PR DESCRIPTION
 - Update two `display_utils` unit-tests to use native functionality rather than the `createObjectURL` helper function

   Given that most of the code-base is already using native functionality, we can update these unit-tests similarily as well.
    - For the `blob:`-URL test, we simply use `URL.createObjectURL(...)` and `Blob` directly instead.
    - For the `data:`-URL test, we simply use `btoa` to do the Base64 encoding and then build the final URL-string.

- [api-minor] Stop exposing the `createObjectURL` helper function in the API

   With recent changes, specifically PR #14515 *and* the previous patch, the `createObjectURL` helper function is now only used with the SVG back-end.
   All other call-sites, throughout the code-base, are now using `URL.createObjectURL(...)` directly and it no longer seems necessary to keep exposing the helper function in the API.
   Finally, the `createObjectURL` helper function is moved into the `src/display/svg.js` file to avoid unnecessarily duplicating this code on both the main- and worker-threads.