### PR TITLE
Remove unnecessary `font-size` CSS rule from the `html` element (issue 14555, PR 3794 follow-up)

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -178,8 +178,6 @@
 html {
   height: 100%;
   width: 100%;
-  /* Font size is needed to make the activity bar the correct size. */
-  font-size: 10px;
 }
 
 body {


### PR DESCRIPTION
According to https://github.com/mozilla/pdf.js/pull/3794#discussion_r6983639 this was intended to be *temporary*, and the B2G project itself was discontinued years ago.