### PR TITLE
Miscellaneous small viewer clean-up

### DIFF
--- a/web/app_options.js
+++ b/web/app_options.js
@@ -15,12 +15,16 @@
 
 const compatibilityParams = Object.create(null);
 if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-  const userAgent =
-    (typeof navigator !== "undefined" && navigator.userAgent) || "";
-  const platform =
-    (typeof navigator !== "undefined" && navigator.platform) || "";
-  const maxTouchPoints =
-    (typeof navigator !== "undefined" && navigator.maxTouchPoints) || 1;
+  if (
+    typeof PDFJSDev !== "undefined" &&
+    PDFJSDev.test("LIB") &&
+    typeof navigator === "undefined"
+  ) {
+    globalThis.navigator = Object.create(null);
+  }
+  const userAgent = navigator.userAgent || "";
+  const platform = navigator.platform || "";
+  const maxTouchPoints = navigator.maxTouchPoints || 1;
 
   const isAndroid = /Android/.test(userAgent);
   const isIOS =
@@ -278,7 +282,7 @@ if (
   };
   defaultOptions.locale = {
     /** @type {string} */
-    value: typeof navigator !== "undefined" ? navigator.language : "en-US",
+    value: navigator.language || "en-US",
     kind: OptionKind.VIEWER,
   };
   defaultOptions.sandboxBundleSrc = {

--- a/web/password_prompt.js
+++ b/web/password_prompt.js
@@ -81,10 +81,9 @@ class PasswordPrompt {
     );
   }
 
-  close() {
-    this.overlayManager.close(this.overlayName).then(() => {
-      this.input.value = "";
-    });
+  async close() {
+    await this.overlayManager.close(this.overlayName);
+    this.input.value = "";
   }
 
   #verify() {


### PR DESCRIPTION
 - Remove the `typeof navigator`-checks in the `web/app_options.js` file

   Given that the `Navigator` interface has been available since "forever", please see https://developer.mozilla.org/en-US/docs/Web/API/Navigator#browser_compatibility, it's somewhat difficult to see why these checks are actually necessary since the viewer is only intended for usage in browsers.

   Looking at the history of the code, this functionality was originally placed in the general `src/shared/compatibility.js` file which could thus run in e.g. worker-threads and Node.js environments (where the `Navigator` interface isn't available).

 - Change `PasswordPrompt.close` to an `async` method

   This is consistent with the `open` method, and it actually *ever so slightly* reduces the size of the file.