### PR TITLE
Add a missing string-check in the `_collectJS` helper function

### DIFF
--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -22,7 +22,8 @@ import {
   stringToPDFString,
   warn,
 } from "../shared/util.js";
-import { Dict, isName, isRef, isStream, RefSet } from "./primitives.js";
+import { Dict, isName, isRef, RefSet } from "./primitives.js";
+import { BaseStream } from "./base_stream.js";
 
 function getLookupTableFactory(initializer) {
   let lookup;
@@ -329,15 +330,15 @@ function _collectJS(entry, xref, list, parents) {
       _collectJS(element, xref, list, parents);
     }
   } else if (entry instanceof Dict) {
-    if (isName(entry.get("S"), "JavaScript") && entry.has("JS")) {
+    if (isName(entry.get("S"), "JavaScript")) {
       const js = entry.get("JS");
       let code;
-      if (isStream(js)) {
+      if (js instanceof BaseStream) {
         code = js.getString();
-      } else {
+      } else if (typeof js === "string") {
         code = js;
       }
-      code = stringToPDFString(code);
+      code = code && stringToPDFString(code);
       if (code) {
         list.push(code);
       }


### PR DESCRIPTION
Unfortunately I don't have a test-case that breaks without this change, however the `stringToPDFString` helper function will fail if anything other than a string is passed to it.
The changes in this patch thus make this code more-or-less identical to that found in the `Catalog.{_collectJavaScript, parseDestDictionary}` methods.