### PR TITLE
Remove the `isStream` helper function

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -39,15 +39,8 @@ import {
   createDefaultAppearance,
   parseDefaultAppearance,
 } from "./default_appearance.js";
-import {
-  Dict,
-  isDict,
-  isName,
-  isRef,
-  isStream,
-  Name,
-  RefSet,
-} from "./primitives.js";
+import { Dict, isDict, isName, isRef, Name, RefSet } from "./primitives.js";
+import { BaseStream } from "./base_stream.js";
 import { bidi } from "./bidi.js";
 import { Catalog } from "./catalog.js";
 import { ColorSpace } from "./colorspace.js";
@@ -693,7 +686,7 @@ class Annotation {
 
     // In case the normal appearance is a stream, then it is used directly.
     const normalAppearanceState = appearanceStates.get("N");
-    if (isStream(normalAppearanceState)) {
+    if (normalAppearanceState instanceof BaseStream) {
       this.appearance = normalAppearanceState;
       return;
     }

--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -41,7 +41,6 @@ import {
   isName,
   isRef,
   isRefsEqual,
-  isStream,
   Name,
   Ref,
   RefSet,
@@ -993,7 +992,7 @@ class Catalog {
       }
 
       let js = jsDict.get("JS");
-      if (isStream(js)) {
+      if (js instanceof BaseStream) {
         js = js.getString();
       } else if (typeof js !== "string") {
         return;
@@ -1551,7 +1550,7 @@ class Catalog {
           const jsAction = action.get("JS");
           let js;
 
-          if (isStream(jsAction)) {
+          if (jsAction instanceof BaseStream) {
             js = jsAction.getString();
           } else if (isString(jsAction)) {
             js = jsAction;

--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -20,7 +20,8 @@ import {
   unreachable,
   warn,
 } from "../shared/util.js";
-import { EOF, isCmd, isName, isStream } from "./primitives.js";
+import { EOF, isCmd, isName } from "./primitives.js";
+import { BaseStream } from "./base_stream.js";
 import { Lexer } from "./parser.js";
 import { MissingDataException } from "./core_utils.js";
 import { Stream } from "./stream.js";
@@ -1025,7 +1026,7 @@ const CMapFactory = (function CMapFactoryClosure() {
 
       if (isName(encoding)) {
         return createBuiltInCMap(encoding.name, fetchBuiltInCMap);
-      } else if (isStream(encoding)) {
+      } else if (encoding instanceof BaseStream) {
         const parsedCMap = await parseCMap(
           /* cMap = */ new CMap(),
           /* lexer = */ new Lexer(encoding),

--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -21,7 +21,8 @@ import {
   unreachable,
   warn,
 } from "../shared/util.js";
-import { isDict, isName, isStream, Name, Ref } from "./primitives.js";
+import { isDict, isName, Name, Ref } from "./primitives.js";
+import { BaseStream } from "./base_stream.js";
 import { MissingDataException } from "./core_utils.js";
 
 /**
@@ -642,7 +643,7 @@ class IndexedCS extends ColorSpace {
     const length = base.numComps * highVal;
     this.lookup = new Uint8Array(length);
 
-    if (isStream(lookup)) {
+    if (lookup instanceof BaseStream) {
       const bytes = lookup.getBytes(length);
       this.lookup.set(bytes);
     } else if (typeof lookup === "string") {

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -44,15 +44,7 @@ import {
   XRefEntryException,
   XRefParseException,
 } from "./core_utils.js";
-import {
-  Dict,
-  isDict,
-  isName,
-  isRef,
-  isStream,
-  Name,
-  Ref,
-} from "./primitives.js";
+import { Dict, isDict, isName, isRef, Name, Ref } from "./primitives.js";
 import { getXfaFontDict, getXfaFontName } from "./xfa_fonts.js";
 import { NullStream, Stream } from "./stream.js";
 import { AnnotationFactory } from "./annotation.js";
@@ -638,7 +630,7 @@ function find(stream, signature, limit = 1024, backwards = false) {
 class PDFDocument {
   constructor(pdfManager, arg) {
     let stream;
-    if (isStream(arg)) {
+    if (arg instanceof BaseStream) {
       stream = arg;
     } else if (isArrayBuffer(arg)) {
       stream = new Stream(arg);
@@ -848,7 +840,7 @@ class PDFDocument {
       stylesheet: "",
       "/xdp:xdp": "",
     };
-    if (isStream(xfa) && !xfa.isEmpty) {
+    if (xfa instanceof BaseStream && !xfa.isEmpty) {
       try {
         entries["xdp:xdp"] = stringToUTF8String(xfa.getString());
         return entries;
@@ -876,7 +868,7 @@ class PDFDocument {
         continue;
       }
       const data = this.xref.fetchIfRef(xfa[i + 1]);
-      if (!isStream(data) || data.isEmpty) {
+      if (!(data instanceof BaseStream) || data.isEmpty) {
         continue;
       }
       try {
@@ -923,10 +915,9 @@ class PDFDocument {
     const xfaImages = new Map();
     for (const key of keys) {
       const stream = xfaImagesDict.get(key);
-      if (!isStream(stream)) {
-        continue;
+      if (stream instanceof BaseStream) {
+        xfaImages.set(key, stream.getBytes());
       }
-      xfaImages.set(key, stream.getBytes());
     }
 
     this.xfaFactory.setImages(xfaImages);
@@ -1115,7 +1106,7 @@ class PDFDocument {
       const xfa = acroForm.get("XFA");
       formInfo.hasXfa =
         (Array.isArray(xfa) && xfa.length > 0) ||
-        (isStream(xfa) && !xfa.isEmpty);
+        (xfa instanceof BaseStream && !xfa.isEmpty);
 
       // The document contains AcroForm data if the `Fields` entry is a
       // non-empty array and it doesn't consist of only document signatures.

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -42,7 +42,6 @@ import {
   isDict,
   isName,
   isRef,
-  isStream,
   Name,
   Ref,
   RefSet,
@@ -340,7 +339,7 @@ class PartialEvaluator {
             continue;
           }
         }
-        if (!isStream(xObject)) {
+        if (!(xObject instanceof BaseStream)) {
           continue;
         }
         if (xObject.dict.objId) {
@@ -1420,7 +1419,7 @@ class PartialEvaluator {
 
       const pattern = this.xref.fetchIfRef(rawPattern);
       if (pattern) {
-        const dict = isStream(pattern) ? pattern.dict : pattern;
+        const dict = pattern instanceof BaseStream ? pattern.dict : pattern;
         const typeNum = dict.get("PatternType");
 
         if (typeNum === PatternType.TILING) {
@@ -1664,7 +1663,7 @@ class PartialEvaluator {
                   xobj = xref.fetch(xobj);
                 }
 
-                if (!isStream(xobj)) {
+                if (!(xobj instanceof BaseStream)) {
                   throw new FormatError("XObject should be a stream");
                 }
 
@@ -2986,7 +2985,7 @@ class PartialEvaluator {
                   xobj = xref.fetch(xobj);
                 }
 
-                if (!isStream(xobj)) {
+                if (!(xobj instanceof BaseStream)) {
                   throw new FormatError("XObject should be a stream");
                 }
 
@@ -3509,7 +3508,7 @@ class PartialEvaluator {
         }
         return new ToUnicodeMap(cmap.getMap());
       });
-    } else if (isStream(cmapObj)) {
+    } else if (cmapObj instanceof BaseStream) {
       return CMapFactory.create({
         encoding: cmapObj,
         fetchBuiltInCMap: this._fetchBuiltInCMapBound,
@@ -3813,7 +3812,7 @@ class PartialEvaluator {
       hash.update(`${firstChar}-${lastChar}`); // Fixes issue10665_reduced.pdf
 
       toUnicode = dict.get("ToUnicode") || baseDict.get("ToUnicode");
-      if (isStream(toUnicode)) {
+      if (toUnicode instanceof BaseStream) {
         const stream = toUnicode.str || toUnicode;
         const uint8array = stream.buffer
           ? new Uint8Array(stream.buffer.buffer, 0, stream.bufferLength)

--- a/src/core/file_spec.js
+++ b/src/core/file_spec.js
@@ -13,8 +13,9 @@
  * limitations under the License.
  */
 
-import { isDict, isStream } from "./primitives.js";
 import { stringToPDFString, warn } from "../shared/util.js";
+import { BaseStream } from "./base_stream.js";
+import { isDict } from "./primitives.js";
 
 function pickPlatformItem(dict) {
   // Look for the filename in this order:
@@ -84,7 +85,7 @@ class FileSpec {
     let content = null;
     if (this.contentRef) {
       const fileObj = this.xref.fetchIfRef(this.contentRef);
-      if (fileObj && isStream(fileObj)) {
+      if (fileObj instanceof BaseStream) {
         content = fileObj.getBytes();
       } else {
         warn(

--- a/src/core/function.js
+++ b/src/core/function.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Dict, isDict, isStream, Ref } from "./primitives.js";
+import { Dict, isDict, Ref } from "./primitives.js";
 import {
   FormatError,
   info,
@@ -23,6 +23,7 @@ import {
   unreachable,
 } from "../shared/util.js";
 import { PostScriptLexer, PostScriptParser } from "./ps_parser.js";
+import { BaseStream } from "./base_stream.js";
 import { LocalFunctionCache } from "./image_utils.js";
 
 class PDFFunctionFactory {
@@ -71,7 +72,7 @@ class PDFFunctionFactory {
       fnRef = cacheKey;
     } else if (cacheKey instanceof Dict) {
       fnRef = cacheKey.objId;
-    } else if (isStream(cacheKey)) {
+    } else if (cacheKey instanceof BaseStream) {
       fnRef = cacheKey.dict && cacheKey.dict.objId;
     }
     if (fnRef) {
@@ -97,7 +98,7 @@ class PDFFunctionFactory {
       fnRef = cacheKey;
     } else if (cacheKey instanceof Dict) {
       fnRef = cacheKey.objId;
-    } else if (isStream(cacheKey)) {
+    } else if (cacheKey instanceof BaseStream) {
       fnRef = cacheKey.dict && cacheKey.dict.objId;
     }
     if (fnRef) {
@@ -509,7 +510,7 @@ function isPDFFunction(v) {
     return false;
   } else if (isDict(v)) {
     fnDict = v;
-  } else if (isStream(v)) {
+  } else if (v instanceof BaseStream) {
     fnDict = v.dict;
   } else {
     return false;

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -14,7 +14,8 @@
  */
 
 import { assert, FormatError, ImageKind, info, warn } from "../shared/util.js";
-import { isName, isStream, Name } from "./primitives.js";
+import { isName, Name } from "./primitives.js";
+import { BaseStream } from "./base_stream.js";
 import { ColorSpace } from "./colorspace.js";
 import { DecodeStream } from "./decode_stream.js";
 import { JpegStream } from "./jpeg_stream.js";
@@ -223,7 +224,7 @@ class PDFImage {
         localColorSpaceCache,
       });
     } else if (mask) {
-      if (isStream(mask)) {
+      if (mask instanceof BaseStream) {
         const maskDict = mask.dict,
           imageMask = maskDict.get("IM", "ImageMask");
         if (!imageMask) {
@@ -268,7 +269,7 @@ class PDFImage {
     if (smask) {
       smaskData = smask;
     } else if (mask) {
-      if (isStream(mask) || Array.isArray(mask)) {
+      if (mask instanceof BaseStream || Array.isArray(mask)) {
         maskData = mask;
       } else {
         warn("Unsupported mask format.");

--- a/src/core/jbig2_stream.js
+++ b/src/core/jbig2_stream.js
@@ -13,8 +13,9 @@
  * limitations under the License.
  */
 
-import { isDict, isStream } from "./primitives.js";
+import { BaseStream } from "./base_stream.js";
 import { DecodeStream } from "./decode_stream.js";
+import { isDict } from "./primitives.js";
 import { Jbig2Image } from "./jbig2.js";
 import { shadow } from "../shared/util.js";
 
@@ -51,7 +52,7 @@ class Jbig2Stream extends DecodeStream {
     const chunks = [];
     if (isDict(this.params)) {
       const globalsStream = this.params.get("JBIG2Globals");
-      if (isStream(globalsStream)) {
+      if (globalsStream instanceof BaseStream) {
         const globals = globalsStream.getBytes();
         chunks.push({ data: globals, start: 0, end: globals.length });
       }

--- a/src/core/object_loader.js
+++ b/src/core/object_loader.js
@@ -13,7 +13,8 @@
  * limitations under the License.
  */
 
-import { Dict, isStream, Ref, RefSet } from "./primitives.js";
+import { Dict, Ref, RefSet } from "./primitives.js";
+import { BaseStream } from "./base_stream.js";
 import { MissingDataException } from "./core_utils.js";
 import { warn } from "../shared/util.js";
 
@@ -21,15 +22,15 @@ function mayHaveChildren(value) {
   return (
     value instanceof Ref ||
     value instanceof Dict ||
-    Array.isArray(value) ||
-    isStream(value)
+    value instanceof BaseStream ||
+    Array.isArray(value)
   );
 }
 
 function addChildren(node, nodesToVisit) {
   if (node instanceof Dict) {
     node = node.getRawValues();
-  } else if (isStream(node)) {
+  } else if (node instanceof BaseStream) {
     node = node.dict.getRawValues();
   } else if (!Array.isArray(node)) {
     return;
@@ -108,7 +109,7 @@ class ObjectLoader {
           pendingRequests.push({ begin: ex.begin, end: ex.end });
         }
       }
-      if (isStream(currentNode)) {
+      if (currentNode instanceof BaseStream) {
         const baseStreams = currentNode.getBaseStreams();
         if (baseStreams) {
           let foundMissingData = false;

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -23,8 +23,8 @@ import {
   Util,
   warn,
 } from "../shared/util.js";
+import { BaseStream } from "./base_stream.js";
 import { ColorSpace } from "./colorspace.js";
-import { isStream } from "./primitives.js";
 import { MissingDataException } from "./core_utils.js";
 
 const ShadingType = {
@@ -50,7 +50,7 @@ class Pattern {
     pdfFunctionFactory,
     localColorSpaceCache
   ) {
-    const dict = isStream(shading) ? shading.dict : shading;
+    const dict = shading instanceof BaseStream ? shading.dict : shading;
     const type = dict.get("ShadingType");
 
     try {
@@ -403,7 +403,7 @@ class MeshShading extends BaseShading {
     localColorSpaceCache
   ) {
     super();
-    if (!isStream(stream)) {
+    if (!(stream instanceof BaseStream)) {
       throw new FormatError("Mesh data is not a stream");
     }
     const dict = stream.dict;

--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -14,7 +14,6 @@
  */
 
 import { assert, shadow, unreachable } from "../shared/util.js";
-import { BaseStream } from "./base_stream.js";
 
 const CIRCULAR_REF = Symbol("CIRCULAR_REF");
 const EOF = Symbol("EOF");
@@ -412,10 +411,6 @@ function isRefsEqual(v1, v2) {
   return v1.num === v2.num && v1.gen === v2.gen;
 }
 
-function isStream(v) {
-  return v instanceof BaseStream;
-}
-
 function clearPrimitiveCaches() {
   Cmd._clearCache();
   Name._clearCache();
@@ -433,7 +428,6 @@ export {
   isName,
   isRef,
   isRefsEqual,
-  isStream,
   Name,
   Ref,
   RefSet,

--- a/src/core/writer.js
+++ b/src/core/writer.js
@@ -14,9 +14,10 @@
  */
 
 import { bytesToString, escapeString, warn } from "../shared/util.js";
-import { Dict, isDict, isName, isRef, isStream, Name } from "./primitives.js";
+import { Dict, isDict, isName, isRef, Name } from "./primitives.js";
 import { escapePDFName, parseXFAPath } from "./core_utils.js";
 import { SimpleDOMNode, SimpleXMLParser } from "./xml_parser.js";
+import { BaseStream } from "./base_stream.js";
 import { calculateMD5 } from "./crypto.js";
 
 function writeDict(dict, buffer, transform) {
@@ -87,7 +88,7 @@ function writeValue(value, buffer, transform) {
     buffer.push(value.toString());
   } else if (isDict(value)) {
     writeDict(value, buffer, transform);
-  } else if (isStream(value)) {
+  } else if (value instanceof BaseStream) {
     writeStream(value, buffer, transform);
   } else if (value === null) {
     buffer.push("null");

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -21,7 +21,6 @@ import {
   isName,
   isRef,
   isRefsEqual,
-  isStream,
   Name,
   Ref,
   RefSet,
@@ -558,18 +557,6 @@ describe("primitives", function () {
       const ref1 = Ref.get(1, 0);
       const ref2 = Ref.get(2, 0);
       expect(isRefsEqual(ref1, ref2)).toEqual(false);
-    });
-  });
-
-  describe("isStream", function () {
-    it("handles non-streams", function () {
-      const nonStream = {};
-      expect(isStream(nonStream)).toEqual(false);
-    });
-
-    it("handles streams", function () {
-      const stream = new StringStream("foo");
-      expect(isStream(stream)).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
At this point all the various Stream-classes extends an abstract base-class, hence this helper function is no longer necessary and only adds unnecessary indirection in the code.