### PR TITLE
Remove the `isRef` helper function

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -39,7 +39,7 @@ import {
   createDefaultAppearance,
   parseDefaultAppearance,
 } from "./default_appearance.js";
-import { Dict, isDict, isName, isRef, Name, RefSet } from "./primitives.js";
+import { Dict, isDict, isName, Name, Ref, RefSet } from "./primitives.js";
 import { BaseStream } from "./base_stream.js";
 import { bidi } from "./bidi.js";
 import { Catalog } from "./catalog.js";
@@ -99,7 +99,8 @@ class AnnotationFactory {
       return undefined;
     }
 
-    const id = isRef(ref) ? ref.toString() : `annot_${idFactory.createObjId()}`;
+    const id =
+      ref instanceof Ref ? ref.toString() : `annot_${idFactory.createObjId()}`;
 
     // Determine the annotation's subtype.
     let subtype = dict.get("Subtype");
@@ -212,7 +213,7 @@ class AnnotationFactory {
         return -1;
       }
       const pageRef = annotDict.getRaw("P");
-      if (!isRef(pageRef)) {
+      if (!(pageRef instanceof Ref)) {
         return -1;
       }
       const pageIndex = await pdfManager.ensureCatalog("getPageIndex", [
@@ -391,7 +392,7 @@ class Annotation {
       if (Array.isArray(kids)) {
         const kidIds = [];
         for (const kid of kids) {
-          if (isRef(kid)) {
+          if (kid instanceof Ref) {
             kidIds.push(kid.toString());
           }
         }
@@ -1051,7 +1052,7 @@ class MarkupAnnotation extends Annotation {
 
     if (dict.has("IRT")) {
       const rawIRT = dict.getRaw("IRT");
-      this.data.inReplyTo = isRef(rawIRT) ? rawIRT.toString() : null;
+      this.data.inReplyTo = rawIRT instanceof Ref ? rawIRT.toString() : null;
 
       const rt = dict.get("RT");
       this.data.replyType = isName(rt) ? rt.name : AnnotationReplyType.REPLY;
@@ -2144,7 +2145,7 @@ class ButtonWidgetAnnotation extends WidgetAnnotation {
     const encrypt = evaluator.xref.encrypt;
 
     if (value) {
-      if (isRef(this.parent)) {
+      if (this.parent instanceof Ref) {
         const parent = evaluator.xref.fetch(this.parent);
         let parentTransform = null;
         if (encrypt) {
@@ -2567,7 +2568,7 @@ class PopupAnnotation extends Annotation {
     const parentSubtype = parentItem.get("Subtype");
     this.data.parentType = isName(parentSubtype) ? parentSubtype.name : null;
     const rawParent = parameters.dict.getRaw("Parent");
-    this.data.parentId = isRef(rawParent) ? rawParent.toString() : null;
+    this.data.parentId = rawParent instanceof Ref ? rawParent.toString() : null;
 
     const parentRect = parentItem.getArray("Rect");
     if (Array.isArray(parentRect) && parentRect.length === 4) {

--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -39,7 +39,6 @@ import {
   Dict,
   isDict,
   isName,
-  isRef,
   isRefsEqual,
   Name,
   Ref,
@@ -151,7 +150,7 @@ class Catalog {
 
   get acroFormRef() {
     const value = this._catDict.getRaw("AcroForm");
-    return shadow(this, "acroFormRef", isRef(value) ? value : null);
+    return shadow(this, "acroFormRef", value instanceof Ref ? value : null);
   }
 
   get metadata() {
@@ -288,7 +287,7 @@ class Catalog {
       return null;
     }
     obj = obj.getRaw("First");
-    if (!isRef(obj)) {
+    if (!(obj instanceof Ref)) {
       return null;
     }
 
@@ -346,12 +345,12 @@ class Catalog {
 
       i.parent.items.push(outlineItem);
       obj = outlineDict.getRaw("First");
-      if (isRef(obj) && !processed.has(obj)) {
+      if (obj instanceof Ref && !processed.has(obj)) {
         queue.push({ obj, parent: outlineItem });
         processed.put(obj);
       }
       obj = outlineDict.getRaw("Next");
-      if (isRef(obj) && !processed.has(obj)) {
+      if (obj instanceof Ref && !processed.has(obj)) {
         queue.push({ obj, parent: i.parent });
         processed.put(obj);
       }
@@ -420,7 +419,7 @@ class Catalog {
       const groupRefs = [];
       // Ensure all the optional content groups are valid.
       for (const groupRef of groupsData) {
-        if (!isRef(groupRef)) {
+        if (!(groupRef instanceof Ref)) {
           continue;
         }
         groupRefs.push(groupRef);
@@ -451,7 +450,7 @@ class Catalog {
       const onParsed = [];
       if (Array.isArray(refs)) {
         for (const value of refs) {
-          if (!isRef(value)) {
+          if (!(value instanceof Ref)) {
             continue;
           }
           if (contentGroupRefs.includes(value)) {
@@ -469,7 +468,7 @@ class Catalog {
       const order = [];
 
       for (const value of refs) {
-        if (isRef(value) && contentGroupRefs.includes(value)) {
+        if (value instanceof Ref && contentGroupRefs.includes(value)) {
           parsedOrderRefs.put(value); // Handle "hidden" groups, see below.
 
           order.push(value.toString());
@@ -1371,7 +1370,7 @@ class Catalog {
           let found = false;
           for (let i = 0, ii = kids.length; i < ii; i++) {
             const kid = kids[i];
-            if (!isRef(kid)) {
+            if (!(kid instanceof Ref)) {
               throw new FormatError("Kid must be a reference.");
             }
             if (isRefsEqual(kid, kidRef)) {
@@ -1479,7 +1478,7 @@ class Catalog {
           const fields = [];
           const refs = [];
           for (const obj of action.get("Fields") || []) {
-            if (isRef(obj)) {
+            if (obj instanceof Ref) {
               refs.push(obj.toString());
             } else if (isString(obj)) {
               fields.push(stringToPDFString(obj));

--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -22,7 +22,7 @@ import {
   stringToPDFString,
   warn,
 } from "../shared/util.js";
-import { Dict, isName, isRef, RefSet } from "./primitives.js";
+import { Dict, isName, Ref, RefSet } from "./primitives.js";
 import { BaseStream } from "./base_stream.js";
 
 function getLookupTableFactory(initializer) {
@@ -316,7 +316,7 @@ function _collectJS(entry, xref, list, parents) {
   }
 
   let parent = null;
-  if (isRef(entry)) {
+  if (entry instanceof Ref) {
     if (parents.has(entry)) {
       // If we've already found entry then we've a cycle.
       return;

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -44,7 +44,7 @@ import {
   XRefEntryException,
   XRefParseException,
 } from "./core_utils.js";
-import { Dict, isDict, isName, isRef, Name, Ref } from "./primitives.js";
+import { Dict, isDict, isName, Name, Ref } from "./primitives.js";
 import { getXfaFontDict, getXfaFontName } from "./xfa_fonts.js";
 import { NullStream, Stream } from "./stream.js";
 import { AnnotationFactory } from "./annotation.js";
@@ -1548,7 +1548,12 @@ class PDFDocument {
       return shadow(this, "calculationOrderIds", null);
     }
 
-    const ids = calculationOrder.filter(isRef).map(ref => ref.toString());
+    const ids = [];
+    for (const id of calculationOrder) {
+      if (id instanceof Ref) {
+        ids.push(id.toString());
+      }
+    }
     if (ids.length === 0) {
       return shadow(this, "calculationOrderIds", null);
     }

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -41,7 +41,6 @@ import {
   EOF,
   isDict,
   isName,
-  isRef,
   Name,
   Ref,
   RefSet,
@@ -1119,7 +1118,7 @@ class PartialEvaluator {
     let fontRef;
     if (font) {
       // Loading by ref.
-      if (!isRef(font)) {
+      if (!(font instanceof Ref)) {
         throw new FormatError('The "font" object should be a reference.');
       }
       fontRef = font;
@@ -1185,7 +1184,7 @@ class PartialEvaluator {
     }
     const { descriptor, hash } = preEvaluatedFont;
 
-    const fontRefIsRef = isRef(fontRef);
+    const fontRefIsRef = fontRef instanceof Ref;
     let fontID;
     if (fontRefIsRef) {
       fontID = `f${fontRef.toString()}`;
@@ -1482,7 +1481,7 @@ class PartialEvaluator {
         currentResult.push(nestedResult);
         // Recursively parse a subarray.
         this._parseVisibilityExpression(object, nestingCounter, nestedResult);
-      } else if (isRef(raw)) {
+      } else if (raw instanceof Ref) {
         // Reference to an OCG dictionary.
         currentResult.push(raw.toString());
       }
@@ -1542,7 +1541,7 @@ class PartialEvaluator {
             : null,
           expression: null,
         };
-      } else if (isRef(optionalContentGroups)) {
+      } else if (optionalContentGroups instanceof Ref) {
         return {
           type: optionalContentType,
           id: optionalContentGroups.toString(),
@@ -3783,13 +3782,13 @@ class PartialEvaluator {
       const encoding = baseDict.getRaw("Encoding");
       if (isName(encoding)) {
         hash.update(encoding.name);
-      } else if (isRef(encoding)) {
+      } else if (encoding instanceof Ref) {
         hash.update(encoding.toString());
       } else if (isDict(encoding)) {
         for (const entry of encoding.getRawValues()) {
           if (isName(entry)) {
             hash.update(entry.name);
-          } else if (isRef(entry)) {
+          } else if (entry instanceof Ref) {
             hash.update(entry.toString());
           } else if (Array.isArray(entry)) {
             // 'Differences' array (fixes bug1157493.pdf).
@@ -3800,7 +3799,7 @@ class PartialEvaluator {
               const diffEntry = entry[j];
               if (isName(diffEntry)) {
                 diffBuf[j] = diffEntry.name;
-              } else if (isNum(diffEntry) || isRef(diffEntry)) {
+              } else if (isNum(diffEntry) || diffEntry instanceof Ref) {
                 diffBuf[j] = diffEntry.toString();
               }
             }
@@ -3830,7 +3829,7 @@ class PartialEvaluator {
       if (Array.isArray(widths)) {
         const widthsBuf = [];
         for (const entry of widths) {
-          if (isNum(entry) || isRef(entry)) {
+          if (isNum(entry) || entry instanceof Ref) {
             widthsBuf.push(entry.toString());
           }
         }
@@ -3844,12 +3843,12 @@ class PartialEvaluator {
         if (Array.isArray(compositeWidths)) {
           const widthsBuf = [];
           for (const entry of compositeWidths) {
-            if (isNum(entry) || isRef(entry)) {
+            if (isNum(entry) || entry instanceof Ref) {
               widthsBuf.push(entry.toString());
             } else if (Array.isArray(entry)) {
               const subWidthsBuf = [];
               for (const element of entry) {
-                if (isNum(element) || isRef(element)) {
+                if (isNum(element) || element instanceof Ref) {
                   subWidthsBuf.push(element.toString());
                 }
               }

--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -394,10 +394,6 @@ function isDict(v, type) {
   );
 }
 
-function isRef(v) {
-  return v instanceof Ref;
-}
-
 function isRefsEqual(v1, v2) {
   if (
     typeof PDFJSDev === "undefined" ||
@@ -426,7 +422,6 @@ export {
   isCmd,
   isDict,
   isName,
-  isRef,
   isRefsEqual,
   Name,
   Ref,

--- a/src/core/struct_tree.js
+++ b/src/core/struct_tree.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { isDict, isName, isRef } from "./primitives.js";
+import { isDict, isName, Ref } from "./primitives.js";
 import { isString, stringToPDFString, warn } from "../shared/util.js";
 import { NumberTree } from "./name_number_tree.js";
 
@@ -75,7 +75,7 @@ class StructElementNode {
   parseKids() {
     let pageObjId = null;
     const objRef = this.dict.getRaw("Pg");
-    if (isRef(objRef)) {
+    if (objRef instanceof Ref) {
       pageObjId = objRef.toString();
     }
     const kids = this.dict.get("K");
@@ -110,7 +110,7 @@ class StructElementNode {
 
     // Find the dictionary for the kid.
     let kidDict = null;
-    if (isRef(kid)) {
+    if (kid instanceof Ref) {
       kidDict = this.dict.xref.fetch(kid);
     } else if (isDict(kid)) {
       kidDict = kid;
@@ -119,7 +119,7 @@ class StructElementNode {
       return null;
     }
     const pageRef = kidDict.getRaw("Pg");
-    if (isRef(pageRef)) {
+    if (pageRef instanceof Ref) {
       pageObjId = pageRef.toString();
     }
 
@@ -130,9 +130,10 @@ class StructElementNode {
       }
       return new StructElement({
         type: StructElementType.STREAM_CONTENT,
-        refObjId: isRef(kidDict.getRaw("Stm"))
-          ? kidDict.getRaw("Stm").toString()
-          : null,
+        refObjId:
+          kidDict.getRaw("Stm") instanceof Ref
+            ? kidDict.getRaw("Stm").toString()
+            : null,
         pageObjId,
         mcid: kidDict.get("MCID"),
       });
@@ -144,9 +145,10 @@ class StructElementNode {
       }
       return new StructElement({
         type: StructElementType.OBJECT,
-        refObjId: isRef(kidDict.getRaw("Obj"))
-          ? kidDict.getRaw("Obj").toString()
-          : null,
+        refObjId:
+          kidDict.getRaw("Obj") instanceof Ref
+            ? kidDict.getRaw("Obj").toString()
+            : null,
         pageObjId,
       });
     }
@@ -203,7 +205,7 @@ class StructTreePage {
     }
     const map = new Map();
     for (const ref of parentArray) {
-      if (isRef(ref)) {
+      if (ref instanceof Ref) {
         this.addNode(this.rootDict.xref.fetch(ref), map);
       }
     }

--- a/src/core/writer.js
+++ b/src/core/writer.js
@@ -14,7 +14,7 @@
  */
 
 import { bytesToString, escapeString, warn } from "../shared/util.js";
-import { Dict, isDict, isName, isRef, Name } from "./primitives.js";
+import { Dict, isDict, isName, Name, Ref } from "./primitives.js";
 import { escapePDFName, parseXFAPath } from "./core_utils.js";
 import { SimpleDOMNode, SimpleXMLParser } from "./xml_parser.js";
 import { BaseStream } from "./base_stream.js";
@@ -73,7 +73,7 @@ function numberToString(value) {
 function writeValue(value, buffer, transform) {
   if (isName(value)) {
     buffer.push(`/${escapePDFName(value.name)}`);
-  } else if (isRef(value)) {
+  } else if (value instanceof Ref) {
     buffer.push(`${value.num} ${value.gen} R`);
   } else if (Array.isArray(value)) {
     writeArray(value, buffer, transform);

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -19,7 +19,6 @@ import {
   isCmd,
   isDict,
   isName,
-  isRef,
   isRefsEqual,
   Name,
   Ref,
@@ -531,18 +530,6 @@ describe("primitives", function () {
       dict.set("Type", Name.get("Page"));
       expect(isDict(dict, "Page")).toEqual(true);
       expect(isDict(dict, "Contents")).toEqual(false);
-    });
-  });
-
-  describe("isRef", function () {
-    it("handles non-refs", function () {
-      const nonRef = {};
-      expect(isRef(nonRef)).toEqual(false);
-    });
-
-    it("handles refs", function () {
-      const ref = Ref.get(1, 0);
-      expect(isRef(ref)).toEqual(true);
     });
   });
 

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -13,11 +13,11 @@
  * limitations under the License.
  */
 
-import { isRef, Ref } from "../../src/core/primitives.js";
 import { Page, PDFDocument } from "../../src/core/document.js";
 import { assert } from "../../src/shared/util.js";
 import { DocStats } from "../../src/core/core_utils.js";
 import { isNodeJS } from "../../src/shared/is_node.js";
+import { Ref } from "../../src/core/primitives.js";
 import { StringStream } from "../../src/core/stream.js";
 
 const TEST_PDFS_PATH = isNodeJS ? "./test/pdfs/" : "../pdfs/";
@@ -106,10 +106,10 @@ class XRefMock {
   }
 
   fetchIfRef(obj) {
-    if (!isRef(obj)) {
-      return obj;
+    if (obj instanceof Ref) {
+      return this.fetch(obj);
     }
-    return this.fetch(obj);
+    return obj;
   }
 
   async fetchIfRefAsync(obj) {


### PR DESCRIPTION
This helper function is not really needed, since it's just a wrapper around a simple `instanceof` check, and it only adds unnecessary indirection in the code.