### PR TITLE
Change `PixelsPerInch` to a class with `static` properties (issue 14579)

### DIFF
--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -22,7 +22,6 @@ import {
 import {
   BaseException,
   isString,
-  shadow,
   stringToBytes,
   Util,
   warn,
@@ -30,15 +29,13 @@ import {
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 
-const PixelsPerInch = {
-  CSS: 96.0,
-  PDF: 72.0,
+class PixelsPerInch {
+  static CSS = 96.0;
 
-  /** @type {number} */
-  get PDF_TO_CSS_UNITS() {
-    return shadow(this, "PDF_TO_CSS_UNITS", this.CSS / this.PDF);
-  },
-};
+  static PDF = 72.0;
+
+  static PDF_TO_CSS_UNITS = this.CSS / this.PDF;
+}
 
 class DOMCanvasFactory extends BaseCanvasFactory {
   constructor({ ownerDocument = globalThis.document } = {}) {


### PR DESCRIPTION
*Please note:* I'm completely fine with this patch being rejected, and the issue instead closed as WONTFIX, since this is unfortunately a case where the TypeScript definitions dictate how we can/cannot write JavaScript code.

Apparently the TypeScript definitions generation converts the existing `PixelsPerInch` code into a `namespace` and simply ignores the getter; please see https://github.com/mozilla/pdfjs-dist/blob/a7fc0d33a11d032741f44d0b623780253747da10/types/src/display/display_utils.d.ts#L223-L226

Initially I tried tagging `PixelsPerInch` as en `@enum`, see https://jsdoc.app/tags-enum.html, however that unfortunately didn't help.
Hence the only good/simple solution, as far as I'm concerned, is to convert `PixelsPerInch` into a class with `static` properties. This patch results in the following diff, for the `gulp types` build target:
```diff
@@ -195,9 +195,10 @@
      */
     static toDateObject(input: string): Date | null;
 }
-export namespace PixelsPerInch {
-    const CSS: number;
-    const PDF: number;
+export class PixelsPerInch {
+    static CSS: number;
+    static PDF: number;
+    static PDF_TO_CSS_UNITS: number;
 }
 declare const RenderingCancelledException_base: any;
 export class RenderingCancelledException extends RenderingCancelledException_base {
```