### PR TITLE
Use the (viewer) `parseQueryString` helper function in the reference tests

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -26,7 +26,7 @@ const {
   shadow,
   XfaLayer,
 } = pdfjsLib;
-const { SimpleLinkService } = pdfjsViewer;
+const { parseQueryString, SimpleLinkService } = pdfjsViewer;
 
 const WAITING_TIME = 100; // ms
 const CMAP_URL = "/build/generic/web/cmaps/";
@@ -332,23 +332,16 @@ class Driver {
     this.end = options.end;
 
     // Set parameters from the query string
-    const parameters = this._getQueryStringParameters();
-    this.browser = parameters.browser;
-    this.manifestFile = parameters.manifestFile;
-    this.delay = parameters.delay | 0 || 0;
+    const params = parseQueryString(window.location.search.substring(1));
+    this.browser = params.get("browser");
+    this.manifestFile = params.get("manifestfile");
+    this.delay = params.get("delay") | 0;
     this.inFlightRequests = 0;
-    this.testFilter = parameters.testFilter
-      ? JSON.parse(parameters.testFilter)
-      : [];
-    this.xfaOnly = parameters.xfaOnly === "true";
+    this.testFilter = JSON.parse(params.get("testfilter") || "[]");
+    this.xfaOnly = params.get("xfaonly") === "true";
 
     // Create a working canvas
     this.canvas = document.createElement("canvas");
-  }
-
-  _getQueryStringParameters() {
-    const queryString = window.location.search.substring(1);
-    return Object.fromEntries(new URLSearchParams(queryString).entries());
   }
 
   run() {

--- a/web/pdf_viewer.component.js
+++ b/web/pdf_viewer.component.js
@@ -24,6 +24,7 @@ import {
   PDFLinkService,
   SimpleLinkService,
 } from "./pdf_link_service.js";
+import { parseQueryString, ProgressBar } from "./ui_utils.js";
 import { PDFSinglePageViewer, PDFViewer } from "./pdf_viewer.js";
 import { AnnotationLayerBuilder } from "./annotation_layer_builder.js";
 import { DownloadManager } from "./download_manager.js";
@@ -34,7 +35,6 @@ import { PDFFindController } from "./pdf_find_controller.js";
 import { PDFHistory } from "./pdf_history.js";
 import { PDFPageView } from "./pdf_page_view.js";
 import { PDFScriptingManager } from "./pdf_scripting_manager.js";
-import { ProgressBar } from "./ui_utils.js";
 import { StructTreeLayerBuilder } from "./struct_tree_layer_builder.js";
 import { TextLayerBuilder } from "./text_layer_builder.js";
 import { XfaLayerBuilder } from "./xfa_layer_builder.js";
@@ -55,6 +55,7 @@ export {
   GenericL10n,
   LinkTarget,
   NullL10n,
+  parseQueryString,
   PDFFindController,
   PDFHistory,
   PDFLinkService,


### PR DESCRIPTION
Rather than re-implementing this functionality in the `Driver` class, we can simply re-use the existing `parseQueryString` helper function instead.