### PR TITLE
[Annotations] Show buttons even if they've no actions

### DIFF
--- a/test/pdfs/bug1737260.pdf.link
+++ b/test/pdfs/bug1737260.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=9247258

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -6528,5 +6528,13 @@
          "value": "1"
         }
       }
+   },
+   { "id": "bug1737260",
+      "file": "pdfs/bug1737260.pdf",
+      "md5": "8bd4f810d30972764b07ae141a4afbc4",
+      "rounds": 1,
+      "link": true,
+      "type": "eq",
+      "annotations": true
    }
 ]


### PR DESCRIPTION
- it's a regression from PR #14247:
 - before the PR, the button was rendered on the canvas whatever its status was;
 - after the PR, the button image has been moved in an other canvas so when the button is not renderable
   (because it has no actions) then the image is not added the HTML element.
- the buttons in the pdf in bug 1737260 or in the pdf in #14308 were not visible
- make the button always renderable but don't add the link element if it's useless.