### PR TITLE
Remove old prefixed CSS rules used with `text` tests

### DIFF
--- a/test/text_layer_test.css
+++ b/test/text_layer_test.css
@@ -27,15 +27,9 @@
 .textLayer br {
   position: absolute;
   white-space: pre;
-  -webkit-transform-origin: 0% 0%;
-  -moz-transform-origin: 0% 0%;
-  -o-transform-origin: 0% 0%;
-  -ms-transform-origin: 0% 0%;
   transform-origin: 0% 0%;
   border: solid 1px rgba(255, 0, 0, 0.5);
   background-color: rgba(255, 255, 32, 0.1);
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
According to MDN, both the `transform-origin` and `box-sizing` CSS rules are supported in their *unprefixed* versions in modern browsers:

 - https://developer.mozilla.org/en-US/docs/Web/CSS/transform-origin#browser_compatibility
 - https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing#browser_compatibility