### PR TITLE
Update the support information for `structuredClone` (PR 14392 follow-up)

### DIFF
--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -78,7 +78,7 @@ if (
     ).ReadableStream;
   })();
 
-  // Support: Firefox<94, Chrome<98, Safari, Node.js<17.0.0
+  // Support: Firefox<94, Chrome<98, Safari<15.4, Node.js<17.0.0
   (function checkStructuredClone() {
     if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("IMAGE_DECODERS")) {
       // The current image decoders are synchronous, hence `structuredClone`


### PR DESCRIPTION
When the `structuredClone` polyfill was added, the support information in Safari was unclear. Given that an actual version *number* is now available, see below, it seems like a good idea to update the comment accordingly.

https://developer.mozilla.org/en-US/docs/Web/API/structuredClone#browser_compatibility