### PR TITLE
Remove the `isNum` helper function

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -26,7 +26,6 @@ import {
   FormatError,
   info,
   isBool,
-  isNum,
   isString,
   objectSize,
   PermissionFlag,
@@ -381,7 +380,7 @@ class Catalog {
     }
 
     let flags = encrypt.get("P");
-    if (!isNum(flags)) {
+    if (typeof flags !== "number") {
       return null;
     }
 
@@ -1475,7 +1474,7 @@ class Catalog {
       switch (actionName) {
         case "ResetForm":
           const flags = action.get("Flags");
-          const include = ((isNum(flags) ? flags : 0) & 1) === 0;
+          const include = ((typeof flags === "number" ? flags : 0) & 1) === 0;
           const fields = [];
           const refs = [];
           for (const obj of action.get("Fields") || []) {

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -20,8 +20,6 @@ import {
   InvalidPDFException,
   isArrayBuffer,
   isArrayEqual,
-  isBool,
-  isNum,
   isString,
   OPS,
   PageActionEventType,
@@ -177,7 +175,7 @@ class Page {
 
   get userUnit() {
     let obj = this.pageDict.get("UserUnit");
-    if (!isNum(obj) || obj <= 0) {
+    if (typeof obj !== "number" || obj <= 0) {
       obj = DEFAULT_USER_UNIT;
     }
     return shadow(this, "userUnit", obj);
@@ -1193,10 +1191,15 @@ class PDFDocument {
           // For custom values, only accept white-listed types to prevent
           // errors that would occur when trying to send non-serializable
           // objects to the main-thread (for example `Dict` or `Stream`).
+          const customType = typeof value;
           let customValue;
-          if (isString(value)) {
+          if (customType === "string") {
             customValue = stringToPDFString(value);
-          } else if (value instanceof Name || isNum(value) || isBool(value)) {
+          } else if (
+            value instanceof Name ||
+            customType === "number" ||
+            customType === "boolean"
+          ) {
             customValue = value;
           } else {
             info(`Unsupported value in document info for (custom) "${key}".`);

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -24,7 +24,6 @@ import {
   IDENTITY_MATRIX,
   info,
   isArrayEqual,
-  isNum,
   isString,
   OPS,
   shadow,
@@ -572,7 +571,7 @@ class PartialEvaluator {
     const w = dict.get("W", "Width");
     const h = dict.get("H", "Height");
 
-    if (!(w && isNum(w)) || !(h && isNum(h))) {
+    if (!(w && typeof w === "number") || !(h && typeof h === "number")) {
       warn("Image dimensions are missing, or not numbers.");
       return;
     }
@@ -1790,7 +1789,7 @@ class PartialEvaluator {
                   combinedGlyphs,
                   self.handleText(arrItem, state)
                 );
-              } else if (isNum(arrItem)) {
+              } else if (typeof arrItem === "number") {
                 combinedGlyphs.push(arrItem);
               }
             }
@@ -3224,7 +3223,7 @@ class PartialEvaluator {
           let index = 0;
           for (let j = 0, jj = diffEncoding.length; j < jj; j++) {
             const data = xref.fetchIfRef(diffEncoding[j]);
-            if (isNum(data)) {
+            if (typeof data === "number") {
               index = data;
             } else if (data instanceof Name) {
               differences[index++] = data.name;
@@ -3703,7 +3702,7 @@ class PartialEvaluator {
     }
     const glyphWidths = Metrics[lookupName];
 
-    if (isNum(glyphWidths)) {
+    if (typeof glyphWidths === "number") {
       defaultWidth = glyphWidths;
       monospace = true;
     } else {
@@ -3790,7 +3789,10 @@ class PartialEvaluator {
               const diffEntry = entry[j];
               if (diffEntry instanceof Name) {
                 diffBuf[j] = diffEntry.name;
-              } else if (isNum(diffEntry) || diffEntry instanceof Ref) {
+              } else if (
+                typeof diffEntry === "number" ||
+                diffEntry instanceof Ref
+              ) {
                 diffBuf[j] = diffEntry.toString();
               }
             }
@@ -3820,7 +3822,7 @@ class PartialEvaluator {
       if (Array.isArray(widths)) {
         const widthsBuf = [];
         for (const entry of widths) {
-          if (isNum(entry) || entry instanceof Ref) {
+          if (typeof entry === "number" || entry instanceof Ref) {
             widthsBuf.push(entry.toString());
           }
         }
@@ -3834,12 +3836,12 @@ class PartialEvaluator {
         if (Array.isArray(compositeWidths)) {
           const widthsBuf = [];
           for (const entry of compositeWidths) {
-            if (isNum(entry) || entry instanceof Ref) {
+            if (typeof entry === "number" || entry instanceof Ref) {
               widthsBuf.push(entry.toString());
             } else if (Array.isArray(entry)) {
               const subWidthsBuf = [];
               for (const element of entry) {
-                if (isNum(element) || element instanceof Ref) {
+                if (typeof element === "number" || element instanceof Ref) {
                   subWidthsBuf.push(element.toString());
                 }
               }

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -20,7 +20,6 @@ import {
   FontType,
   FormatError,
   info,
-  isNum,
   shadow,
   string32,
   warn,
@@ -3184,7 +3183,9 @@ class Font {
       }
     }
     width = this.widths[widthCode];
-    width = isNum(width) ? width : this.defaultWidth;
+    if (typeof width !== "number") {
+      width = this.defaultWidth;
+    }
     const vmetric = this.vmetrics && this.vmetrics[widthCode];
 
     let unicode = this.toUnicode.get(charcode) || charcode;

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -18,7 +18,6 @@ import {
   bytesToString,
   FormatError,
   info,
-  isNum,
   StreamType,
   warn,
 } from "../shared/util.js";
@@ -1393,7 +1392,7 @@ class Linearization {
         Number.isInteger(obj2) &&
         isCmd(obj3, "obj") &&
         linDict instanceof Dict &&
-        isNum((obj = linDict.get("Linearized"))) &&
+        typeof (obj = linDict.get("Linearized")) === "number" &&
         obj > 0
       )
     ) {

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -19,7 +19,6 @@ import {
   ImageKind,
   info,
   IsLittleEndianCached,
-  isNum,
   OPS,
   shadow,
   TextRenderingMode,
@@ -2210,7 +2209,7 @@ class CanvasGraphics {
       i;
     for (i = 0; i < glyphsLength; ++i) {
       const glyph = glyphs[i];
-      if (isNum(glyph)) {
+      if (typeof glyph === "number") {
         x += (spacingDir * glyph * fontSize) / 1000;
         continue;
       }
@@ -2336,7 +2335,7 @@ class CanvasGraphics {
 
     for (i = 0; i < glyphsLength; ++i) {
       glyph = glyphs[i];
-      if (isNum(glyph)) {
+      if (typeof glyph === "number") {
         spacingLength = (spacingDir * glyph * fontSize) / 1000;
         this.ctx.translate(spacingLength, 0);
         current.x += spacingLength * textHScale;

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -18,7 +18,6 @@ import {
   FONT_IDENTITY_MATRIX,
   IDENTITY_MATRIX,
   ImageKind,
-  isNum,
   OPS,
   TextRenderingMode,
   unreachable,
@@ -837,7 +836,7 @@ if (
           // Word break
           x += fontDirection * wordSpacing;
           continue;
-        } else if (isNum(glyph)) {
+        } else if (typeof glyph === "number") {
           x += (spacingDir * glyph * fontSize) / 1000;
           continue;
         }

--- a/src/shared/fonts_utils.js
+++ b/src/shared/fonts_utils.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 /* globals CFFDictDataMap, CFFDictPrivateDataMap, CFFEncodingMap, CFFStrings,
-           Components, Dict, dump, FormatError, isNum, netscape, Stream */
+           Components, Dict, dump, FormatError, netscape, Stream */
 
 'use strict';
 
@@ -273,7 +273,7 @@ var Type2Parser = function type2Parser(aFilePath) {
     var count = decoded.length;
     for (var i = 0; i < count; i++) {
       var token = decoded[i];
-      if (isNum(token)) {
+      if (typeof token === "number") {
         stack.push(token);
       } else {
         switch (token.operand) {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1034,10 +1034,6 @@ function isBool(v) {
   return typeof v === "boolean";
 }
 
-function isNum(v) {
-  return typeof v === "number";
-}
-
 function isString(v) {
   return typeof v === "string";
 }
@@ -1146,7 +1142,6 @@ export {
   isBool,
   IsEvalSupportedCached,
   IsLittleEndianCached,
-  isNum,
   isSameOrigin,
   isString,
   MissingPDFException,

--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -22,7 +22,6 @@ import {
   isArrayBuffer,
   isAscii,
   isBool,
-  isNum,
   isSameOrigin,
   isString,
   string32,
@@ -88,23 +87,6 @@ describe("util", function () {
       expect(isBool(0)).toEqual(false);
       expect(isBool(null)).toEqual(false);
       expect(isBool(undefined)).toEqual(false);
-    });
-  });
-
-  describe("isNum", function () {
-    it("handles numeric values", function () {
-      expect(isNum(1)).toEqual(true);
-      expect(isNum(0)).toEqual(true);
-      expect(isNum(-1)).toEqual(true);
-      expect(isNum(1000000000000000000)).toEqual(true);
-      expect(isNum(12.34)).toEqual(true);
-    });
-
-    it("handles non-numeric values", function () {
-      expect(isNum("true")).toEqual(false);
-      expect(isNum(true)).toEqual(false);
-      expect(isNum(null)).toEqual(false);
-      expect(isNum(undefined)).toEqual(false);
     });
   });
 


### PR DESCRIPTION
The call-sites are replaced by direct `typeof`-checks instead, which removes unnecessary function calls. Note that in the `src/`-folder we already had more `typeof`-cases than `isNum`-calls.

These changes were *mostly* done using regular expression search-and-replace, with two exceptions:
 - In `Font._charToGlyph` we no longer unconditionally update the `width`, since that seems completely unnecessary.
 - In `PDFDocument.documentInfo`, when parsing custom entries, we now do the `typeof`-check once.