### PR TITLE
Ensure that `Dict.set` only accepts string `key`s

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -1187,7 +1187,7 @@ class PDFDocument {
           } else {
             info(`Bad value in document info for "${key}".`);
           }
-        } else if (typeof key === "string") {
+        } else {
           // For custom values, only accept white-listed types to prevent
           // errors that would occur when trying to send non-serializable
           // objects to the main-thread (for example `Dict` or `Stream`).

--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -198,11 +198,14 @@ class Dict {
 
   set(key, value) {
     if (
-      (typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("!PRODUCTION || TESTING")) &&
-      value === undefined
+      typeof PDFJSDev === "undefined" ||
+      PDFJSDev.test("!PRODUCTION || TESTING")
     ) {
-      unreachable('Dict.set: The "value" cannot be undefined.');
+      if (typeof key !== "string") {
+        unreachable('Dict.set: The "key" must be a string.');
+      } else if (value === undefined) {
+        unreachable('Dict.set: The "value" cannot be undefined.');
+      }
     }
     this._map[key] = value;
   }

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -21,7 +21,6 @@ import {
   getVerbosityLevel,
   info,
   InvalidPDFException,
-  isString,
   MissingPDFException,
   PasswordException,
   setVerbosityLevel,
@@ -639,7 +638,7 @@ class WorkerMessageHandler {
             const xrefInfo = xref.trailer.get("Info") || null;
             if (xrefInfo instanceof Dict) {
               xrefInfo.forEach((key, value) => {
-                if (isString(key) && isString(value)) {
+                if (typeof value === "string") {
                   infoObj[key] = stringToPDFString(value);
                 }
               });

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -149,6 +149,17 @@ describe("primitives", function () {
       checkInvalidKeyValues(dictWithSizeKey);
     });
 
+    it("should not accept to set a non-string key", function () {
+      const dict = new Dict();
+      expect(function () {
+        dict.set(123, "val");
+      }).toThrow(new Error('Dict.set: The "key" must be a string.'));
+
+      expect(dict.has(123)).toBeFalsy();
+
+      checkInvalidKeyValues(dict);
+    });
+
     it("should not accept to set a key with an undefined value", function () {
       const dict = new Dict();
       expect(function () {


### PR DESCRIPTION
Trying to use a non-string `key` in a `Dict` is not intended, and would basically be an implementation error. Hence we can add a non-PRODUCTION check to enforce this, complementing the existing `value` check added in PR #11672.