### PR TITLE
Ensure that `Cmd`/`Name` is only initialized with string arguments

### DIFF
--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -901,7 +901,7 @@ const CMapFactory = (function CMapFactoryClosure() {
 
   function parseCMapName(cMap, lexer) {
     const obj = lexer.getObj();
-    if (obj instanceof Name && isString(obj.name)) {
+    if (obj instanceof Name) {
       cMap.name = obj.name;
     }
   }

--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -24,6 +24,13 @@ const Name = (function NameClosure() {
   // eslint-disable-next-line no-shadow
   class Name {
     constructor(name) {
+      if (
+        (typeof PDFJSDev === "undefined" ||
+          PDFJSDev.test("!PRODUCTION || TESTING")) &&
+        typeof name !== "string"
+      ) {
+        unreachable('Name: The "name" must be a string.');
+      }
       this.name = name;
     }
 
@@ -47,6 +54,13 @@ const Cmd = (function CmdClosure() {
   // eslint-disable-next-line no-shadow
   class Cmd {
     constructor(cmd) {
+      if (
+        (typeof PDFJSDev === "undefined" ||
+          PDFJSDev.test("!PRODUCTION || TESTING")) &&
+        typeof cmd !== "string"
+      ) {
+        unreachable('Cmd: The "cmd" must be a string.');
+      }
       this.cmd = cmd;
     }
 

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -55,6 +55,12 @@ describe("primitives", function () {
       expect(firstEmpty).toBe(secondEmpty);
       expect(firstEmpty).not.toBe(normalName);
     });
+
+    it("should not accept to create a non-string name", function () {
+      expect(function () {
+        Name.get(123);
+      }).toThrow(new Error('Name: The "name" must be a string.'));
+    });
   });
 
   describe("Cmd", function () {
@@ -73,6 +79,12 @@ describe("primitives", function () {
       expect(firstBT).toBe(secondBT);
       expect(firstET).toBe(secondET);
       expect(firstBT).not.toBe(firstET);
+    });
+
+    it("should not accept to create a non-string cmd", function () {
+      expect(function () {
+        Cmd.get(123);
+      }).toThrow(new Error('Cmd: The "cmd" must be a string.'));
     });
   });
 


### PR DESCRIPTION
Trying to use a non-string argument in either a `Cmd` or a `Name` is not intended, and would basically be an implementation error. Hence we can add a non-PRODUCTION check to enforce this, similar to the existing one used e.g. in the `Dict.set` method.