### PR TITLE
[api-minor] Add validation for the  `PDFDocumentProxy.getPageIndex` method

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -454,8 +454,8 @@ class WorkerMessageHandler {
       });
     });
 
-    handler.on("GetPageIndex", function wphSetupGetPageIndex({ ref }) {
-      const pageRef = Ref.get(ref.num, ref.gen);
+    handler.on("GetPageIndex", function wphSetupGetPageIndex(data) {
+      const pageRef = Ref.get(data.num, data.gen);
       return pdfManager.ensureCatalog("getPageIndex", [pageRef]);
     });
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2848,7 +2848,7 @@ class WorkerTransport {
       pageNumber <= 0 ||
       pageNumber > this._numPages
     ) {
-      return Promise.reject(new Error("Invalid page request"));
+      return Promise.reject(new Error("Invalid page request."));
     }
 
     const pageIndex = pageNumber - 1,

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2879,8 +2879,19 @@ class WorkerTransport {
   }
 
   getPageIndex(ref) {
+    if (
+      typeof ref !== "object" ||
+      ref === null ||
+      !Number.isInteger(ref.num) ||
+      ref.num < 0 ||
+      !Number.isInteger(ref.gen) ||
+      ref.gen < 0
+    ) {
+      return Promise.reject(new Error("Invalid pageIndex request."));
+    }
     return this.messageHandler.sendWithPromise("GetPageIndex", {
-      ref,
+      num: ref.num,
+      gen: ref.gen,
     });
   }
 

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -890,18 +890,35 @@ describe("api", function () {
     });
 
     it("gets invalid page index", async function () {
-      const ref = { num: 3, gen: 0 }; // Reference to a font dictionary.
+      const pageRefs = [
+        /* fontRef = */ { num: 3, gen: 0 },
+        /* invalidRef = */ { num: -1, gen: 0 },
+        /* nonRef = */ "qwerty",
+        /* nullRef = */ null,
+      ];
 
-      try {
-        await pdfDocument.getPageIndex(ref);
+      const expectedErrors = [
+        {
+          exception: UnknownErrorException,
+          message: "The reference does not point to a /Page dictionary.",
+        },
+        { exception: Error, message: "Invalid pageIndex request." },
+        { exception: Error, message: "Invalid pageIndex request." },
+        { exception: Error, message: "Invalid pageIndex request." },
+      ];
 
-        // Shouldn't get here.
-        expect(false).toEqual(true);
-      } catch (reason) {
-        expect(reason instanceof UnknownErrorException).toEqual(true);
-        expect(reason.message).toEqual(
-          "The reference does not point to a /Page dictionary."
-        );
+      for (let i = 0, ii = pageRefs.length; i < ii; i++) {
+        try {
+          await pdfDocument.getPageIndex(pageRefs[i]);
+
+          // Shouldn't get here.
+          expect(false).toEqual(true);
+        } catch (reason) {
+          const { exception, message } = expectedErrors[i];
+
+          expect(reason instanceof exception).toEqual(true);
+          expect(reason.message).toEqual(message);
+        }
       }
     });
 

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -815,40 +815,23 @@ describe("api", function () {
     });
 
     it("gets non-existent page", async function () {
-      let outOfRangePromise = pdfDocument.getPage(100);
-      let nonIntegerPromise = pdfDocument.getPage(2.5);
-      let nonNumberPromise = pdfDocument.getPage("1");
+      const pageNumbers = [
+        /* outOfRange = */ 100,
+        /* nonInteger = */ 2.5,
+        /* nonNumber = */ "1",
+      ];
 
-      outOfRangePromise = outOfRangePromise.then(
-        function () {
-          throw new Error("shall fail for out-of-range pageNumber parameter");
-        },
-        function (reason) {
-          expect(reason instanceof Error).toEqual(true);
-        }
-      );
-      nonIntegerPromise = nonIntegerPromise.then(
-        function () {
-          throw new Error("shall fail for non-integer pageNumber parameter");
-        },
-        function (reason) {
-          expect(reason instanceof Error).toEqual(true);
-        }
-      );
-      nonNumberPromise = nonNumberPromise.then(
-        function () {
-          throw new Error("shall fail for non-number pageNumber parameter");
-        },
-        function (reason) {
-          expect(reason instanceof Error).toEqual(true);
-        }
-      );
+      for (const pageNumber of pageNumbers) {
+        try {
+          await pdfDocument.getPage(pageNumber);
 
-      await Promise.all([
-        outOfRangePromise,
-        nonIntegerPromise,
-        nonNumberPromise,
-      ]);
+          // Shouldn't get here.
+          expect(false).toEqual(true);
+        } catch (reason) {
+          expect(reason instanceof Error).toEqual(true);
+          expect(reason.message).toEqual("Invalid page request.");
+        }
+      }
     });
 
     it("gets page, from /Pages tree with circular reference", async function () {


### PR DESCRIPTION
Currently we'll happily attempt to send any argument passed to this method over to the worker-thread, without doing any sort of validation.
That could obviously be quite bad, since there's first of all no protection against sending unclonable data. Secondly, it's also possible to pass data that will cause the `Ref.get` call in the worker-thread to fail immediately.

In order to address all of these issues, we'll now properly validate the argument passed to `PDFDocumentProxy.getPageIndex` and when necessary reject already on the main-thread instead.