### PR TITLE
 Re-factor the `PDFDocument.documentInfo` method, and remove the `isString` helper function

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -24,7 +24,6 @@ import {
   escapeString,
   getModificationDate,
   isAscii,
-  isString,
   OPS,
   RenderingIntentFlag,
   shadow,
@@ -542,9 +541,8 @@ class Annotation {
    *                                    annotation was last modified
    */
   setModificationDate(modificationDate) {
-    this.modificationDate = isString(modificationDate)
-      ? modificationDate
-      : null;
+    this.modificationDate =
+      typeof modificationDate === "string" ? modificationDate : null;
   }
 
   /**
@@ -1121,7 +1119,7 @@ class MarkupAnnotation extends Annotation {
    *                                annotation was originally created
    */
   setCreationDate(creationDate) {
-    this.creationDate = isString(creationDate) ? creationDate : null;
+    this.creationDate = typeof creationDate === "string" ? creationDate : null;
   }
 
   _setDefaultAppearance({
@@ -1258,9 +1256,8 @@ class WidgetAnnotation extends Annotation {
 
     const defaultAppearance =
       getInheritableProperty({ dict, key: "DA" }) || params.acroForm.get("DA");
-    this._defaultAppearance = isString(defaultAppearance)
-      ? defaultAppearance
-      : "";
+    this._defaultAppearance =
+      typeof defaultAppearance === "string" ? defaultAppearance : "";
     data.defaultAppearanceData = parseDefaultAppearance(
       this._defaultAppearance
     );
@@ -1305,11 +1302,11 @@ class WidgetAnnotation extends Annotation {
   _decodeFormValue(formValue) {
     if (Array.isArray(formValue)) {
       return formValue
-        .filter(item => isString(item))
+        .filter(item => typeof item === "string")
         .map(item => stringToPDFString(item));
     } else if (formValue instanceof Name) {
       return stringToPDFString(formValue.name);
-    } else if (isString(formValue)) {
+    } else if (typeof formValue === "string") {
       return stringToPDFString(formValue);
     }
     return null;
@@ -1788,7 +1785,7 @@ class TextWidgetAnnotation extends WidgetAnnotation {
     const dict = params.dict;
 
     // The field value is always a string.
-    if (!isString(this.data.fieldValue)) {
+    if (typeof this.data.fieldValue !== "string") {
       this.data.fieldValue = "";
     }
 
@@ -2452,7 +2449,7 @@ class ChoiceWidgetAnnotation extends WidgetAnnotation {
     // item is selected or an array of strings if multiple items are selected.
     // For consistency in the API and convenience in the display layer, we
     // always make the field value an array with zero, one or multiple items.
-    if (isString(this.data.fieldValue)) {
+    if (typeof this.data.fieldValue === "string") {
       this.data.fieldValue = [this.data.fieldValue];
     } else if (!this.data.fieldValue) {
       this.data.fieldValue = [];

--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -25,7 +25,6 @@ import {
   DocumentActionEventType,
   FormatError,
   info,
-  isString,
   objectSize,
   PermissionFlag,
   shadow,
@@ -424,12 +423,14 @@ class Catalog {
         const group = this.xref.fetchIfRef(groupRef);
         groups.push({
           id: groupRef.toString(),
-          name: isString(group.get("Name"))
-            ? stringToPDFString(group.get("Name"))
-            : null,
-          intent: isString(group.get("Intent"))
-            ? stringToPDFString(group.get("Intent"))
-            : null,
+          name:
+            typeof group.get("Name") === "string"
+              ? stringToPDFString(group.get("Name"))
+              : null,
+          intent:
+            typeof group.get("Intent") === "string"
+              ? stringToPDFString(group.get("Intent"))
+              : null,
         });
       }
       config = this._readOptionalContentConfig(defaultConfig, groupRefs);
@@ -521,12 +522,14 @@ class Catalog {
       MAX_NESTED_LEVELS = 10;
 
     return {
-      name: isString(config.get("Name"))
-        ? stringToPDFString(config.get("Name"))
-        : null,
-      creator: isString(config.get("Creator"))
-        ? stringToPDFString(config.get("Creator"))
-        : null,
+      name:
+        typeof config.get("Name") === "string"
+          ? stringToPDFString(config.get("Name"))
+          : null,
+      creator:
+        typeof config.get("Creator") === "string"
+          ? stringToPDFString(config.get("Creator"))
+          : null,
       baseState:
         config.get("BaseState") instanceof Name
           ? config.get("BaseState").name
@@ -676,7 +679,7 @@ class Catalog {
 
         if (labelDict.has("P")) {
           const p = labelDict.get("P");
-          if (!isString(p)) {
+          if (typeof p !== "string") {
             throw new FormatError("Invalid prefix in PageLabel dictionary.");
           }
           prefix = stringToPDFString(p);
@@ -1467,7 +1470,7 @@ class Catalog {
           for (const obj of action.get("Fields") || []) {
             if (obj instanceof Ref) {
               refs.push(obj.toString());
-            } else if (isString(obj)) {
+            } else if (typeof obj === "string") {
               fields.push(stringToPDFString(obj));
             }
           }
@@ -1499,7 +1502,7 @@ class Catalog {
             // We assume that we found a FileSpec dictionary
             // and fetch the URL without checking any further.
             url = urlDict.get("F") || null;
-          } else if (isString(urlDict)) {
+          } else if (typeof urlDict === "string") {
             url = urlDict;
           }
 
@@ -1509,9 +1512,9 @@ class Catalog {
             if (remoteDest instanceof Name) {
               remoteDest = remoteDest.name;
             }
-            if (isString(url)) {
+            if (typeof url === "string") {
               const baseUrl = url.split("#")[0];
-              if (isString(remoteDest)) {
+              if (typeof remoteDest === "string") {
                 url = baseUrl + "#" + remoteDest;
               } else if (Array.isArray(remoteDest)) {
                 url = baseUrl + "#" + JSON.stringify(remoteDest);
@@ -1538,7 +1541,7 @@ class Catalog {
 
           if (jsAction instanceof BaseStream) {
             js = jsAction.getString();
-          } else if (isString(jsAction)) {
+          } else if (typeof jsAction === "string") {
             js = jsAction;
           }
 
@@ -1563,7 +1566,7 @@ class Catalog {
       dest = destDict.get("Dest");
     }
 
-    if (isString(url)) {
+    if (typeof url === "string") {
       const absoluteUrl = createValidAbsoluteUrl(url, docBaseUrl, {
         addDefaultProtocol: true,
         tryConvertEncoding: true,
@@ -1577,7 +1580,7 @@ class Catalog {
       if (dest instanceof Name) {
         dest = dest.name;
       }
-      if (isString(dest) || Array.isArray(dest)) {
+      if (typeof dest === "string" || Array.isArray(dest)) {
         resultObj.dest = dest;
       }
     }

--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -16,7 +16,6 @@
 import {
   CMapCompressionType,
   FormatError,
-  isString,
   unreachable,
   warn,
 } from "../shared/util.js";
@@ -767,7 +766,7 @@ const CMapFactory = (function CMapFactoryClosure() {
   }
 
   function expectString(obj) {
-    if (!isString(obj)) {
+    if (typeof obj !== "string") {
       throw new FormatError("Malformed CMap: expected string.");
     }
   }
@@ -812,7 +811,7 @@ const CMapFactory = (function CMapFactoryClosure() {
       expectString(obj);
       const high = strToInt(obj);
       obj = lexer.getObj();
-      if (Number.isInteger(obj) || isString(obj)) {
+      if (Number.isInteger(obj) || typeof obj === "string") {
         const dstLow = Number.isInteger(obj) ? String.fromCharCode(obj) : obj;
         cMap.mapBfRange(low, high, dstLow);
       } else if (isCmd(obj, "[")) {
@@ -878,12 +877,12 @@ const CMapFactory = (function CMapFactoryClosure() {
       if (isCmd(obj, "endcodespacerange")) {
         return;
       }
-      if (!isString(obj)) {
+      if (typeof obj !== "string") {
         break;
       }
       const low = strToInt(obj);
       obj = lexer.getObj();
-      if (!isString(obj)) {
+      if (typeof obj !== "string") {
         break;
       }
       const high = strToInt(obj);

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -24,7 +24,6 @@ import {
   IDENTITY_MATRIX,
   info,
   isArrayEqual,
-  isString,
   OPS,
   shadow,
   stringToPDFString,
@@ -1784,7 +1783,7 @@ class PartialEvaluator {
             var state = stateManager.state;
             for (i = 0; i < arrLength; ++i) {
               const arrItem = arr[i];
-              if (isString(arrItem)) {
+              if (typeof arrItem === "string") {
                 Array.prototype.push.apply(
                   combinedGlyphs,
                   self.handleText(arrItem, state)
@@ -3974,10 +3973,10 @@ class PartialEvaluator {
     let fontName = descriptor.get("FontName");
     let baseFont = dict.get("BaseFont");
     // Some bad PDFs have a string as the font name.
-    if (isString(fontName)) {
+    if (typeof fontName === "string") {
       fontName = Name.get(fontName);
     }
-    if (isString(baseFont)) {
+    if (typeof baseFont === "string") {
       baseFont = Name.get(baseFont);
     }
 

--- a/src/core/murmurhash3.js
+++ b/src/core/murmurhash3.js
@@ -17,7 +17,7 @@
  * Hashes roughly 100 KB per millisecond on i7 3.4 GHz.
  */
 
-import { isArrayBuffer, isString } from "../shared/util.js";
+import { isArrayBuffer } from "../shared/util.js";
 
 const SEED = 0xc3d2e1f0;
 // Workaround for missing math precision in JS.
@@ -32,7 +32,7 @@ class MurmurHash3_64 {
 
   update(input) {
     let data, length;
-    if (isString(input)) {
+    if (typeof input === "string") {
       data = new Uint8Array(input.length * 2);
       length = 0;
       for (let i = 0, ii = input.length; i < ii; i++) {

--- a/src/core/struct_tree.js
+++ b/src/core/struct_tree.js
@@ -14,7 +14,7 @@
  */
 
 import { Dict, isName, Name, Ref } from "./primitives.js";
-import { isString, stringToPDFString, warn } from "../shared/util.js";
+import { stringToPDFString, warn } from "../shared/util.js";
 import { NumberTree } from "./name_number_tree.js";
 
 const MAX_DEPTH = 40;
@@ -295,11 +295,11 @@ class StructTreePage {
       obj.children = [];
       parent.children.push(obj);
       const alt = node.dict.get("Alt");
-      if (isString(alt)) {
+      if (typeof alt === "string") {
         obj.alt = stringToPDFString(alt);
       }
       const lang = node.dict.get("Lang");
-      if (isString(lang)) {
+      if (typeof lang === "string") {
         obj.lang = stringToPDFString(lang);
       }
 

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -19,13 +19,7 @@ import {
   BaseStandardFontDataFactory,
   BaseSVGFactory,
 } from "./base_factory.js";
-import {
-  BaseException,
-  isString,
-  stringToBytes,
-  Util,
-  warn,
-} from "../shared/util.js";
+import { BaseException, stringToBytes, Util, warn } from "../shared/util.js";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 
@@ -482,7 +476,7 @@ class PDFDateString {
    * @returns {Date|null}
    */
   static toDateObject(input) {
-    if (!input || !isString(input)) {
+    if (!input || typeof input !== "string") {
       return null;
     }
 

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1030,10 +1030,6 @@ function utf8StringToString(str) {
   return unescape(encodeURIComponent(str));
 }
 
-function isString(v) {
-  return typeof v === "string";
-}
-
 function isArrayBuffer(v) {
   return typeof v === "object" && v !== null && v.byteLength !== undefined;
 }
@@ -1138,7 +1134,6 @@ export {
   IsEvalSupportedCached,
   IsLittleEndianCached,
   isSameOrigin,
-  isString,
   MissingPDFException,
   objectFromMap,
   objectSize,

--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -22,7 +22,6 @@ import {
   isArrayBuffer,
   isAscii,
   isSameOrigin,
-  isString,
   string32,
   stringToBytes,
   stringToPDFString,
@@ -70,20 +69,6 @@ describe("util", function () {
       expect(isArrayBuffer(1)).toEqual(false);
       expect(isArrayBuffer(null)).toEqual(false);
       expect(isArrayBuffer(undefined)).toEqual(false);
-    });
-  });
-
-  describe("isString", function () {
-    it("handles string values", function () {
-      expect(isString("foo")).toEqual(true);
-      expect(isString("")).toEqual(true);
-    });
-
-    it("handles non-string values", function () {
-      expect(isString(true)).toEqual(false);
-      expect(isString(1)).toEqual(false);
-      expect(isString(null)).toEqual(false);
-      expect(isString(undefined)).toEqual(false);
     });
   });
 


### PR DESCRIPTION
 - Re-factor the `PDFDocument.documentInfo` method

   This removes the `DocumentInfoValidators` structure, and thus (slightly) simplifies the code overall. With these changes we only have to iterate through, and validate, the actually available Dictionary entries.

 - Remove the `isString` helper function

   The call-sites are replaced by direct `typeof`-checks instead, which removes unnecessary function calls. Note that in the `src/`-folder we already had more `typeof`-cases than `isString`-calls.