### PR TITLE
Simplify the `decodeFontData`/`encodeFontData` font-test helper functions

### DIFF
--- a/test/font/fontutils.js
+++ b/test/font/fontutils.js
@@ -14,55 +14,16 @@
  * limitations under the License.
  */
 
-const base64alphabet =
-  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+import { bytesToString, stringToBytes } from "../../src/shared/util.js";
 
 function decodeFontData(base64) {
-  const result = [];
-
-  let bits = 0,
-    bitsLength = 0;
-  for (let i = 0, ii = base64.length; i < ii; i++) {
-    const ch = base64[i];
-    if (ch <= " ") {
-      continue;
-    }
-    const index = base64alphabet.indexOf(ch);
-    if (index < 0) {
-      throw new Error("Invalid character");
-    }
-    if (index >= 64) {
-      break;
-    }
-    bits = (bits << 6) | index;
-    bitsLength += 6;
-    if (bitsLength >= 8) {
-      bitsLength -= 8;
-      const code = (bits >> bitsLength) & 0xff;
-      result.push(code);
-    }
-  }
-  return new Uint8Array(result);
+  const str = atob(base64);
+  return stringToBytes(str);
 }
 
 function encodeFontData(data) {
-  let buffer = "";
-  let i, n;
-  for (i = 0, n = data.length; i < n; i += 3) {
-    const b1 = data[i] & 0xff;
-    const b2 = data[i + 1] & 0xff;
-    const b3 = data[i + 2] & 0xff;
-    const d1 = b1 >> 2,
-      d2 = ((b1 & 3) << 4) | (b2 >> 4);
-    const d3 = i + 1 < n ? ((b2 & 0xf) << 2) | (b3 >> 6) : 64;
-    const d4 = i + 2 < n ? b3 & 0x3f : 64;
-    buffer +=
-      base64alphabet.charAt(d1) +
-      base64alphabet.charAt(d2) +
-      base64alphabet.charAt(d3) +
-      base64alphabet.charAt(d4);
-  }
-  return buffer;
+  const str = bytesToString(data);
+  return btoa(str);
 }
 
 async function ttx(data) {


### PR DESCRIPTION
We can (and in my opinion should) use the standard `atob`/`btoa` functions, rather than manually re-implementing this functionality for the font-tests.