### PR TITLE
Simplify the `wrapReason` helper function

### DIFF
--- a/src/shared/message_handler.js
+++ b/src/shared/message_handler.js
@@ -21,7 +21,7 @@ import {
   PasswordException,
   UnexpectedResponseException,
   UnknownErrorException,
-  warn,
+  unreachable,
 } from "./util.js";
 
 const CallbackKind = {
@@ -49,16 +49,9 @@ function wrapReason(reason) {
       (typeof reason === "object" && reason !== null)
     )
   ) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
-      throw new Error(
-        'wrapReason: Expected "reason" to be a (possibly cloned) Error.'
-      );
-    }
-    warn('wrapReason: Expected "reason" to be a (possibly cloned) Error.');
-    return reason;
+    unreachable(
+      'wrapReason: Expected "reason" to be a (possibly cloned) Error.'
+    );
   }
   switch (reason.name) {
     case "AbortException":


### PR DESCRIPTION
All call-sites that use `wrapReason` should be passing a (possibly cloned) `Error` to the helper function, hence we shouldn't need to have a fallback code-path for any other data.
Note that for the `cancel`/`error` methods on Streams, since PR #11115 we've been asserting that the argument is in fact an `Error` as intended.
When calling `wrapReason` from *rejected* Promises, we should also be guaranteed that an `Error` is provided thanks to the ESLint rules `no-throw-literal` and `prefer-promise-reject-errors`.