### PR TITLE
Don't close window from test driver.

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -850,11 +850,6 @@ class Driver {
     // Send the quit request
     const r = new XMLHttpRequest();
     r.open("POST", `/tellMeToQuit?browser=${escape(this.browser)}`, false);
-    r.onreadystatechange = function (e) {
-      if (r.readyState === 4) {
-        window.close();
-      }
-    };
     r.send(null);
   }
 


### PR DESCRIPTION
Sometimes I get a "Unable to find target with id XXX closeTarget..." error
when running tests which happens when test.js tries to close all the
open pages. I haven't been able to fully verify since this is intermittent,
but I think this is coming from us closing the window in driver.js and also
trying to close it in test.js.