### PR TITLE
Add the `caniuse-lite` package

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -81,7 +81,7 @@ const AUTOPREFIXER_CONFIG = {
     "Chrome >= 73",
     "Firefox ESR",
     "Safari >= 12.1",
-    "> 0.5%",
+    "> 1%",
     "not IE > 0",
     "not dead",
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "acorn": "^8.7.0",
         "autoprefixer": "^10.4.2",
         "babel-loader": "^8.2.3",
+        "caniuse-lite": "^1.0.30001312",
         "canvas": "^2.9.0",
         "core-js": "^3.21.1",
         "cross-env": "^7.0.3",
@@ -3461,9 +3462,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001298",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz",
-      "integrity": "sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ==",
+      "version": "1.0.30001312",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
+      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -12154,7 +12155,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -12170,19 +12171,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -12197,7 +12198,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -12215,7 +12216,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -21273,9 +21274,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001298",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz",
-      "integrity": "sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ==",
+      "version": "1.0.30001312",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
+      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
       "dev": true
     },
     "canvas": {
@@ -28052,7 +28053,7 @@
         "lodash._baseindexof": {
           "version": "3.1.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -28066,17 +28067,17 @@
         "lodash._bindcallback": {
           "version": "3.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
@@ -28089,7 +28090,7 @@
         "lodash._getnative": {
           "version": "3.9.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         },
         "lodash._root": {
           "version": "3.0.1",
@@ -28104,7 +28105,7 @@
         "lodash.restparam": {
           "version": "3.6.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         },
         "lodash.union": {
           "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "acorn": "^8.7.0",
     "autoprefixer": "^10.4.2",
     "babel-loader": "^8.2.3",
+    "caniuse-lite": "^1.0.30001312",
     "canvas": "^2.9.0",
     "core-js": "^3.21.1",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
Since the Autoprefixer plugin indirectly depends on this, it seems like a good idea to add this as a direct dependency in the PDF.js project to hopefully avoid having to manually update `caniuse-lite` in the future; see https://github.com/browserslist/browserslist#browsers-data-updating

Also, slightly tweaks the Autoprefixer config for GENERIC-builds of the PDF.js library; note that this change doesn't affect the contents of the *built* `web/viewer.js` file.