### PR TITLE
Remove the `-webkit-overflow-scrolling: touch;` CSS rules (PR 4516 follow-up)

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -284,7 +284,6 @@ html[dir="rtl"] #outerContainer.sidebarOpen #sidebarContainer {
   top: 32px;
   bottom: 0;
   overflow: auto;
-  -webkit-overflow-scrolling: touch;
   position: absolute;
   width: 100%;
   background-color: rgba(0, 0, 0, 0.1);
@@ -300,7 +299,6 @@ html[dir="rtl"] #sidebarContent {
 
 #viewerContainer {
   overflow: auto;
-  -webkit-overflow-scrolling: touch;
   position: absolute;
   top: 32px;
   right: 0;
@@ -614,7 +612,6 @@ html[dir="rtl"] .secondaryToolbar {
   max-width: 220px;
   max-height: 400px;
   overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
   margin-bottom: -4px;
 }
 
@@ -1328,7 +1325,6 @@ html[dir="rtl"] #numPages.toolbarLabel {
   bottom: 0;
   padding: 10px 30px 0;
   overflow: auto;
-  -webkit-overflow-scrolling: touch;
 }
 
 #thumbnailView > a:active,
@@ -1404,7 +1400,6 @@ a:focus > .thumbnail > .thumbnailSelectionRing,
   bottom: 0;
   padding: 4px 4px 0;
   overflow: auto;
-  -webkit-overflow-scrolling: touch;
   user-select: none;
 }
 
@@ -1550,10 +1545,6 @@ html[dir="rtl"] .treeItemToggler::before {
   background-color: rgba(0, 0, 0, 0.2);
   z-index: 40000;
 }
-#overlayContainer > * {
-  overflow: auto;
-  -webkit-overflow-scrolling: touch;
-}
 
 #overlayContainer > .container {
   display: table-cell;
@@ -1668,7 +1659,6 @@ html[dir="rtl"] #documentPropertiesOverlay .row > * {
   bottom: 0;
   left: 0;
   overflow: auto;
-  -webkit-overflow-scrolling: touch;
   position: absolute;
   right: 0;
   top: 27px;


### PR DESCRIPTION
This was added in PR #4516 specifically for Safari on iOS devices, but according to MDN it should no longer be necessary now; see https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-overflow-scrolling#browser_compatibility

According to the MDN compatibility data, this CSS feature:
 - Was never implemented anywhere *except* for Safari on iOS.
 - Was never standardized and thus never existed in an *unprefixed* version.
 - Has now been removed, starting with Safari version 13.

Given that [the FAQ](https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#faq-support) already lists Safari as "Mostly" supported, and that the default viewer is written primarily for Mozilla Firefox, it ought to be fine to remove these CSS rules now.