### PR TITLE
Remove the `-webkit-outer-spin-button` CSS rule

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1291,10 +1291,8 @@ html[dir="rtl"] .toolbarField[type="checkbox"] {
   background-position: 3px;
 }
 
-.toolbarField.pageNumber::-webkit-inner-spin-button,
-.toolbarField.pageNumber::-webkit-outer-spin-button {
+.toolbarField.pageNumber::-webkit-inner-spin-button {
   -webkit-appearance: none;
-  margin: 0;
 }
 
 .toolbarField:focus {


### PR DESCRIPTION
Unfortunately simply using `appearance: textfield;`, or even `-webkit-appearance: textfield;`, doesn't actually hide the "spinner" in number-input elements in e.g. Google Chrome.
Hence we need to use a work-around with the `-webkit-inner-spin-button` rule, however in our CSS code we also have `-webkit-outer-spin-button` currently. According to both [the MDN compatibility data](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-outer-spin-button#browser_compatibility) and also manual testing in Google Chrome Beta 99, the `-webkit-outer-spin-button` rule is no longer necessary and we can thus clean-up the CSS a tiny bit.