### PR TITLE
Remove some deprecated code from the viewer

### DIFF
--- a/examples/components/simpleviewer.js
+++ b/examples/components/simpleviewer.js
@@ -77,11 +77,7 @@ eventBus.on("pagesinit", function () {
 
   // We can try searching for things.
   if (SEARCH_FOR) {
-    if (!pdfFindController._onFind) {
-      pdfFindController.executeCommand("find", { query: SEARCH_FOR });
-    } else {
-      eventBus.dispatch("find", { type: "", query: SEARCH_FOR });
-    }
+    eventBus.dispatch("find", { type: "", query: SEARCH_FOR });
   }
 });
 

--- a/examples/components/singlepageviewer.js
+++ b/examples/components/singlepageviewer.js
@@ -77,11 +77,7 @@ eventBus.on("pagesinit", function () {
 
   // We can try searching for things.
   if (SEARCH_FOR) {
-    if (!pdfFindController._onFind) {
-      pdfFindController.executeCommand("find", { query: SEARCH_FOR });
-    } else {
-      eventBus.dispatch("find", { type: "", query: SEARCH_FOR });
-    }
+    eventBus.dispatch("find", { type: "", query: SEARCH_FOR });
   }
 });
 

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -261,22 +261,8 @@ class PDFFindController {
     this._eventBus = eventBus;
 
     this._reset();
-    eventBus._on("find", this._onFind.bind(this));
-    eventBus._on("findbarclose", this._onFindBarClose.bind(this));
-
-    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-      this.executeCommand = (cmd, state) => {
-        console.error(
-          "Deprecated method `PDFFindController.executeCommand` called, " +
-            'please dispatch a "find"-event using the EventBus instead.'
-        );
-
-        const eventState = Object.assign(Object.create(null), state, {
-          type: cmd.substring("find".length),
-        });
-        this._onFind(eventState);
-      };
-    }
+    eventBus._on("find", this.#onFind.bind(this));
+    eventBus._on("findbarclose", this.#onFindBarClose.bind(this));
   }
 
   get highlightMatches() {
@@ -316,10 +302,7 @@ class PDFFindController {
     this._firstPageCapability.resolve();
   }
 
-  /**
-   * @private
-   */
-  _onFind(state) {
+  #onFind(state) {
     if (!state) {
       return;
     }
@@ -895,7 +878,7 @@ class PDFFindController {
     }
   }
 
-  _onFindBarClose(evt) {
+  #onFindBarClose(evt) {
     const pdfDocument = this._pdfDocument;
     // Since searching is asynchronous, ensure that the removal of highlighted
     // matches (from the UI) is async too such that the 'updatetextlayermatches'

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -320,23 +320,6 @@ class PDFPageView {
   }
 
   update({ scale = 0, rotation = null, optionalContentConfigPromise = null }) {
-    if (
-      typeof PDFJSDev !== "undefined" &&
-      PDFJSDev.test("GENERIC") &&
-      typeof arguments[0] !== "object"
-    ) {
-      console.error(
-        "PDFPageView.update called with separate parameters, please use an object instead."
-      );
-
-      this.update({
-        scale: arguments[0],
-        rotation: arguments[1],
-        optionalContentConfigPromise: arguments[2],
-      });
-      return;
-    }
-
     this.scale = scale || this.scale;
     if (typeof rotation === "number") {
       this.rotation = rotation; // The rotation may be zero.


### PR DESCRIPTION
 - Revert "[GENERIC viewer] Add fallback logic for the old `PDFPageView.update` method signature"

   This reverts commit 846620438417c395f14f3cb60a02806c1b3bebc8, since it's now been included in three official releases.

 - Remove the deprecated `PDFFindController.executeCommand` method

   This *partially* reverts commit fa8c0ef6164c7abfd5236e97823102a89517f8a4, since it's now been included in two official releases.