### PR TITLE
Simplify the `fallback`-logic in the default viewer

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -149,8 +149,6 @@ class DefaultExternalServices {
 
   static initPassiveLoading(callbacks) {}
 
-  static async fallback(data) {}
-
   static reportTelemetry(data) {}
 
   static createDownloadManager(options) {
@@ -192,7 +190,6 @@ class DefaultExternalServices {
 const PDFViewerApplication = {
   initialBookmark: document.location.hash.substring(1),
   _initializedCapability: createPromiseCapability(),
-  _fellback: false,
   appConfig: null,
   pdfDocument: null,
   pdfLoadingTask: null,
@@ -825,7 +822,6 @@ const PDFViewerApplication = {
       this.pdfDocumentProperties.setDocument(null);
     }
     this.pdfLinkService.externalLinkEnabled = true;
-    this._fellback = false;
     this.store = null;
     this.isInitialViewSet = false;
     this.downloadComplete = false;
@@ -924,7 +920,7 @@ const PDFViewerApplication = {
       this.progress(loaded / total);
     };
 
-    // Listen for unsupported features to trigger the fallback UI.
+    // Listen for unsupported features to report telemetry.
     loadingTask.onUnsupportedFeature = this.fallback.bind(this);
 
     return loadingTask.promise.then(
@@ -1019,25 +1015,6 @@ const PDFViewerApplication = {
       type: "unsupportedFeature",
       featureId,
     });
-
-    // Only trigger the fallback once so we don't spam the user with messages
-    // for one PDF.
-    if (this._fellback) {
-      return;
-    }
-    this._fellback = true;
-
-    this.externalServices
-      .fallback({
-        featureId,
-        url: this.baseUrl,
-      })
-      .then(download => {
-        if (!download) {
-          return;
-        }
-        this.download({ sourceEventType: "download" });
-      });
   },
 
   /**

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -382,10 +382,6 @@ class FirefoxExternalServices extends DefaultExternalServices {
     FirefoxCom.requestSync("initPassiveLoading", null);
   }
 
-  static async fallback(data) {
-    return FirefoxCom.requestAsync("fallback", data);
-  }
-
   static reportTelemetry(data) {
     FirefoxCom.request("reportTelemetry", JSON.stringify(data));
   }


### PR DESCRIPTION
After [bug 1705327](https://bugzilla.mozilla.org/show_bug.cgi?id=1705327) the `ChromeActions.fallback`-method is now just a stub[1], since the fallback bar was removed.
Hence there's no good reason, as far as I can tell, to keep this code in the viewer itself when it's completely unused.

---
[1] See https://searchfox.org/mozilla-central/rev/292d17c13daa61016fd082e2337297091d53a015/toolkit/components/pdfjs/content/PdfStreamConverter.jsm#575-581