### PR TITLE
When `stopAtErrors` is set, throw rather than warn when exceeding `maxImageSize` (issue 14626)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -576,8 +576,13 @@ class PartialEvaluator {
     }
     const maxImageSize = this.options.maxImageSize;
     if (maxImageSize !== -1 && w * h > maxImageSize) {
-      warn("Image exceeded maximum allowed size and was removed.");
-      return;
+      const msg = "Image exceeded maximum allowed size and was removed.";
+
+      if (this.options.ignoreErrors) {
+        warn(msg);
+        return;
+      }
+      throw new Error(msg);
     }
 
     let optionalContent;


### PR DESCRIPTION
The situation described in issue #14626 seems like a fairly special case, and it thus seem reasonable that we simply follow the same pattern as elsewhere in the `PartialEvaluator` when the `stopAtErrors` API-option is being used.