### PR TITLE
Fix a couple of small typos in JSDoc `typedef` comments

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -1406,7 +1406,7 @@ class Catalog {
   }
 
   /**
-   * @typedef ParseDestDictionaryParameters
+   * @typedef {Object} ParseDestDictionaryParameters
    * @property {Dict} destDict - The dictionary containing the destination.
    * @property {Object} resultObj - The object where the parsed destination
    *   properties will be placed.

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -1160,7 +1160,7 @@ class BaseViewer {
   }
 
   /**
-   * @typedef ScrollPageIntoViewParameters
+   * @typedef {Object} ScrollPageIntoViewParameters
    * @property {number} pageNumber - The page number.
    * @property {Array} [destArray] - The original PDF destination array, in the
    *   format: <page-ref> </XYZ|/FitXXX> <args..>

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -29,7 +29,6 @@ const LinkTarget = {
 };
 
 /**
- * @typedef ExternalLinkParameters
  * @typedef {Object} ExternalLinkParameters
  * @property {string} url - An absolute URL.
  * @property {LinkTarget} [target] - The link target. The default value is


### PR DESCRIPTION
While this doesn't affect the official API documentation, these cases should nonetheless be fixed.