### PR TITLE
Update TypeScript to version `4.6.2` and work-around stricter type checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "terser": "^5.12.0",
         "through2": "^4.0.2",
         "ttest": "^3.0.0",
-        "typescript": "^4.5.5",
+        "typescript": "^4.6.2",
         "typogr": "^0.6.8",
         "vinyl": "^2.2.1",
         "vinyl-fs": "^3.0.3",
@@ -17571,9 +17571,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -32286,9 +32286,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true
     },
     "typogr": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "terser": "^5.12.0",
     "through2": "^4.0.2",
     "ttest": "^3.0.0",
-    "typescript": "^4.5.5",
+    "typescript": "^4.6.2",
     "typogr": "^0.6.8",
     "vinyl": "^2.2.1",
     "vinyl-fs": "^3.0.3",

--- a/src/display/base_factory.js
+++ b/src/display/base_factory.js
@@ -57,7 +57,7 @@ class BaseCanvasFactory {
   }
 
   /**
-   * @private
+   * @ignore
    */
   _createCanvas(width, height) {
     unreachable("Abstract method `_createCanvas` called.");
@@ -96,7 +96,7 @@ class BaseCMapReaderFactory {
   }
 
   /**
-   * @private
+   * @ignore
    */
   _fetchData(url, compressionType) {
     unreachable("Abstract method `_fetchData` called.");
@@ -129,7 +129,7 @@ class BaseStandardFontDataFactory {
   }
 
   /**
-   * @private
+   * @ignore
    */
   _fetchData(url) {
     unreachable("Abstract method `_fetchData` called.");
@@ -165,7 +165,7 @@ class BaseSVGFactory {
   }
 
   /**
-   * @private
+   * @ignore
    */
   _createSVG(type) {
     unreachable("Abstract method `_createSVG` called.");

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -37,6 +37,9 @@ class DOMCanvasFactory extends BaseCanvasFactory {
     this._document = ownerDocument;
   }
 
+  /**
+   * @ignore
+   */
   _createCanvas(width, height) {
     const canvas = this._document.createElement("canvas");
     canvas.width = width;
@@ -91,6 +94,9 @@ async function fetchData(url, asTypedArray = false) {
 }
 
 class DOMCMapReaderFactory extends BaseCMapReaderFactory {
+  /**
+   * @ignore
+   */
   _fetchData(url, compressionType) {
     return fetchData(url, /* asTypedArray = */ this.isCompressed).then(data => {
       return { cMapData: data, compressionType };
@@ -99,12 +105,18 @@ class DOMCMapReaderFactory extends BaseCMapReaderFactory {
 }
 
 class DOMStandardFontDataFactory extends BaseStandardFontDataFactory {
+  /**
+   * @ignore
+   */
   _fetchData(url) {
     return fetchData(url, /* asTypedArray = */ true);
   }
 }
 
 class DOMSVGFactory extends BaseSVGFactory {
+  /**
+   * @ignore
+   */
   _createSVG(type) {
     return document.createElementNS(SVG_NS, type);
   }

--- a/src/display/node_utils.js
+++ b/src/display/node_utils.js
@@ -55,6 +55,9 @@ if ((typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) && isNodeJS) {
   };
 
   NodeCanvasFactory = class extends BaseCanvasFactory {
+    /**
+     * @ignore
+     */
     _createCanvas(width, height) {
       const Canvas = __non_webpack_require__("canvas");
       return Canvas.createCanvas(width, height);
@@ -62,6 +65,9 @@ if ((typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) && isNodeJS) {
   };
 
   NodeCMapReaderFactory = class extends BaseCMapReaderFactory {
+    /**
+     * @ignore
+     */
     _fetchData(url, compressionType) {
       return fetchData(url).then(data => {
         return { cMapData: data, compressionType };
@@ -70,6 +76,9 @@ if ((typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) && isNodeJS) {
   };
 
   NodeStandardFontDataFactory = class extends BaseStandardFontDataFactory {
+    /**
+     * @ignore
+     */
     _fetchData(url) {
       return fetchData(url);
     }


### PR DESCRIPTION
I'm guessing that we're now running into the class-related improvements mentioned in https://devblogs.microsoft.com/typescript/announcing-typescript-4-6/#target-es2022
To unblock this update, and any future ones, this patch simply tweaks the JSDocs to get `gulp typestest` to run without errors.