### PR TITLE
[api-minor] Remove the, in `legacy` builds, bundled `DOMMatrix` polyfill

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2043,6 +2043,7 @@ function packageBowerJson() {
     bugs: DIST_BUGS_URL,
     license: DIST_LICENSE,
     dependencies: {
+      dommatrix: "^0.0.24",
       "web-streams-polyfill": "^3.2.0",
     },
     peerDependencies: {

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -50,7 +50,9 @@ if (
     if (globalThis.DOMMatrix || !isNodeJS) {
       return;
     }
-    globalThis.DOMMatrix = require("dommatrix/dist/dommatrix.js");
+    globalThis.DOMMatrix = __non_webpack_require__(
+      "dommatrix/dist/dommatrix.js"
+    );
   })();
 
   // Provides support for *recent* additions to the Promise specification,


### PR DESCRIPTION
According to the MDN compatibility data, see https://developer.mozilla.org/en-US/docs/Web/API/DOMMatrix/DOMMatrix#browser_compatibility, all browsers that we support have native `DOMMatrix` implementations (since quite some time too).

Hence Node.js is the only environment that lack `DOMMatrix` support, which probably isn't that surprising given that it's browser functionality.
While the `DOMMatrix` polyfill isn't that large, it nonetheless seems completely unnecessary to bundle it in the `legacy` builds when it's not needed in browsers. However, we can avoid that by simply listing `dommatrix` as a dependency for the `pdfjs-dist` library.