### PR TITLE
Move the `isSameOrigin` helper function

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -411,22 +411,6 @@ function assert(cond, msg) {
   }
 }
 
-// Checks if URLs have the same origin. For non-HTTP based URLs, returns false.
-function isSameOrigin(baseUrl, otherUrl) {
-  let base;
-  try {
-    base = new URL(baseUrl);
-    if (!base.origin || base.origin === "null") {
-      return false; // non-HTTP url
-    }
-  } catch (e) {
-    return false;
-  }
-
-  const other = new URL(otherUrl, base);
-  return base.origin === other.origin;
-}
-
 // Checks if URLs use one of the allowed protocols, e.g. to avoid XSS.
 function _isValidProtocol(url) {
   if (!url) {
@@ -1133,7 +1117,6 @@ export {
   isAscii,
   IsEvalSupportedCached,
   IsLittleEndianCached,
-  isSameOrigin,
   MissingPDFException,
   objectFromMap,
   objectSize,

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -40,6 +40,7 @@ import {
   PDFDocumentProxy,
   PDFPageProxy,
   PDFWorker,
+  PDFWorkerUtil,
   RenderTask,
 } from "../../src/display/api.js";
 import {
@@ -2966,5 +2967,34 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
         await loadingTask.destroy();
       }
     );
+  });
+
+  describe("PDFWorkerUtil", function () {
+    describe("isSameOrigin", function () {
+      const { isSameOrigin } = PDFWorkerUtil;
+
+      it("handles invalid base URLs", function () {
+        // The base URL is not valid.
+        expect(isSameOrigin("/foo", "/bar")).toEqual(false);
+
+        // The base URL has no origin.
+        expect(isSameOrigin("blob:foo", "/bar")).toEqual(false);
+      });
+
+      it("correctly checks if the origin of both URLs matches", function () {
+        expect(
+          isSameOrigin(
+            "https://www.mozilla.org/foo",
+            "https://www.mozilla.org/bar"
+          )
+        ).toEqual(true);
+        expect(
+          isSameOrigin(
+            "https://www.mozilla.org/foo",
+            "https://www.example.com/bar"
+          )
+        ).toEqual(false);
+      });
+    });
   });
 });

--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -21,7 +21,6 @@ import {
   getModificationDate,
   isArrayBuffer,
   isAscii,
-  isSameOrigin,
   string32,
   stringToBytes,
   stringToPDFString,
@@ -162,31 +161,6 @@ describe("util", function () {
     it("should have property `href`", function () {
       const url = new URL("https://example.com");
       expect(typeof url.href).toEqual("string");
-    });
-  });
-
-  describe("isSameOrigin", function () {
-    it("handles invalid base URLs", function () {
-      // The base URL is not valid.
-      expect(isSameOrigin("/foo", "/bar")).toEqual(false);
-
-      // The base URL has no origin.
-      expect(isSameOrigin("blob:foo", "/bar")).toEqual(false);
-    });
-
-    it("correctly checks if the origin of both URLs matches", function () {
-      expect(
-        isSameOrigin(
-          "https://www.mozilla.org/foo",
-          "https://www.mozilla.org/bar"
-        )
-      ).toEqual(true);
-      expect(
-        isSameOrigin(
-          "https://www.mozilla.org/foo",
-          "https://www.example.com/bar"
-        )
-      ).toEqual(false);
     });
   });
 


### PR DESCRIPTION
This function is currently placed in the `src/shared/util.js` file, which means that the code is duplicated in both of the *built* `pdf.js` and `pdf.worker.js` files. Furthermore, it only has a single call-site which is also specific to the `GENERIC`-build of the PDF.js library.

Hence this helper function is instead moved into the `src/display/api.js` file, in such a way that it's conditionally defined but still can be unit-tested.