### PR TITLE
Validate the `cMapUrl`/`standardFontDataUrl` parameters in `getDocument`

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -339,6 +339,12 @@ function getDocument(src) {
   if (!Number.isInteger(params.maxImageSize)) {
     params.maxImageSize = -1;
   }
+  if (typeof params.cMapUrl !== "string") {
+    params.cMapUrl = null;
+  }
+  if (typeof params.standardFontDataUrl !== "string") {
+    params.standardFontDataUrl = null;
+  }
   if (typeof params.useWorkerFetch !== "boolean") {
     params.useWorkerFetch =
       params.CMapReaderFactory === DOMCMapReaderFactory &&


### PR DESCRIPTION
These changes make sense for two reasons:
 - Given that the parameters are potentially passed to the worker-thread, depending on the `useWorkerFetch` parameter, we need to prevent errors if the user provides values that aren't clonable.
 - By ensuring that the default values are indeed `null`, we'll trigger main-thread fetching (of CMaps and Standard fonts) as intended in the `PartialEvaluator` and thus potentially provide better Error messages.