### PR TITLE
Enable the "gets fieldObjects" unit-test in Node.js (PR 14409 follow-up)

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1296,12 +1296,6 @@ describe("api", function () {
     });
 
     it("gets fieldObjects", async function () {
-      if (isNodeJS) {
-        pending(
-          "Node.js appears to ignore Object properties that are explicitly " +
-            "set to `undefined`, thus breaking the expectations used below."
-        );
-      }
       const loadingTask = getDocument(buildGetDocumentParams("js-authors.pdf"));
       const pdfDoc = await loadingTask.promise;
       const fieldObjects = await pdfDoc.getFieldObjects();


### PR DESCRIPTION
Apparently this unit-test works in Node.js now, hence it's *possible* that the reason it didn't work previously is that there were bugs in our old `structuredClone` polyfill.