### PR TITLE
Replace `dir`-dependent `float` with logical properties

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,6 @@
 "use strict";
 
 const autoprefixer = require("autoprefixer");
-const postcssCalc = require("postcss-calc");
 const postcssDirPseudoClass = require("postcss-dir-pseudo-class");
 const postcssLogical = require("postcss-logical");
 const fs = require("fs");
@@ -853,7 +852,6 @@ function buildGeneric(defines, dir) {
     preprocessCSS("web/viewer.css", defines)
       .pipe(
         postcss([
-          postcssCalc(),
           postcssLogical({ preserve: true }),
           postcssDirPseudoClass(),
           autoprefixer(AUTOPREFIXER_CONFIG),
@@ -936,7 +934,6 @@ function buildComponents(defines, dir) {
     preprocessCSS("web/pdf_viewer.css", defines)
       .pipe(
         postcss([
-          postcssCalc(),
           postcssLogical({ preserve: true }),
           postcssDirPseudoClass(),
           autoprefixer(AUTOPREFIXER_CONFIG),
@@ -1033,7 +1030,6 @@ function buildMinified(defines, dir) {
     preprocessCSS("web/viewer.css", defines)
       .pipe(
         postcss([
-          postcssCalc(),
           postcssLogical({ preserve: true }),
           postcssDirPseudoClass(),
           autoprefixer(AUTOPREFIXER_CONFIG),

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "mkdirp": "^1.0.4",
         "needle": "^3.0.0",
         "postcss": "^8.4.7",
-        "postcss-calc": "^8.2.4",
         "postcss-dir-pseudo-class": "^6.0.4",
         "postcss-logical": "^5.0.4",
         "prettier": "^2.5.1",
@@ -14967,19 +14966,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/postcss-calc": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.4.tgz",
-      "integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
-      "dev": true,
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.9",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.2"
       }
     },
     "node_modules/postcss-dir-pseudo-class": {
@@ -30239,16 +30225,6 @@
         "nanoid": "^3.3.1",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
-      }
-    },
-    "postcss-calc": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.4.tgz",
-      "integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
-      "dev": true,
-      "requires": {
-        "postcss-selector-parser": "^6.0.9",
-        "postcss-value-parser": "^4.2.0"
       }
     },
     "postcss-dir-pseudo-class": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "mkdirp": "^1.0.4",
     "needle": "^3.0.0",
     "postcss": "^8.4.7",
-    "postcss-calc": "^8.2.4",
     "postcss-dir-pseudo-class": "^6.0.4",
     "postcss-logical": "^5.0.4",
     "prettier": "^2.5.1",

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -244,12 +244,12 @@ select {
 }
 html[dir="ltr"] #sidebarContainer {
   transition-property: left;
-  left: calc(0px - var(--sidebar-width));
+  left: calc(-1 * var(--sidebar-width));
   border-right: var(--doorhanger-border-color-whcm);
 }
 html[dir="rtl"] #sidebarContainer {
   transition-property: right;
-  right: calc(0px - var(--sidebar-width));
+  right: calc(-1 * var(--sidebar-width));
   border-left: var(--doorhanger-border-color-whcm);
 }
 

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -668,46 +668,31 @@ html[dir="rtl"] .secondaryToolbar {
   transform: translateX(-50%);
 }
 
-html[dir="ltr"] #toolbarViewerLeft,
-html[dir="rtl"] #toolbarViewerRight,
-html[dir="ltr"] #toolbarSidebarLeft,
-html[dir="rtl"] #toolbarSidebarRight {
-  float: left;
+#toolbarViewerLeft,
+#toolbarSidebarLeft {
+  float: inline-start;
 }
-html[dir="ltr"] #toolbarViewerRight,
-html[dir="rtl"] #toolbarViewerLeft,
-html[dir="ltr"] #toolbarSidebarRight,
-html[dir="rtl"] #toolbarSidebarLeft {
-  float: right;
+#toolbarViewerRight,
+#toolbarSidebarRight {
+  float: inline-end;
 }
-html[dir="ltr"] #toolbarViewerLeft > *,
-html[dir="ltr"] #toolbarViewerMiddle > *,
-html[dir="ltr"] #toolbarViewerRight > *,
-html[dir="ltr"] #toolbarSidebarLeft *,
-html[dir="ltr"] #toolbarSidebarRight *,
-html[dir="ltr"] .findbar * {
+
+#toolbarViewerLeft > *,
+#toolbarViewerMiddle > *,
+#toolbarViewerRight > *,
+#toolbarSidebarLeft *,
+#toolbarSidebarRight *,
+.findbar * {
   position: relative;
-  float: left;
-}
-html[dir="rtl"] #toolbarViewerLeft > *,
-html[dir="rtl"] #toolbarViewerMiddle > *,
-html[dir="rtl"] #toolbarViewerRight > *,
-html[dir="rtl"] #toolbarSidebarLeft *,
-html[dir="rtl"] #toolbarSidebarRight *,
-html[dir="rtl"] .findbar * {
-  position: relative;
-  float: right;
+  float: inline-start;
 }
 
 .splitToolbarButton {
   margin: 2px 2px 0;
   display: inline-block;
 }
-html[dir="ltr"] .splitToolbarButton > .toolbarButton {
-  float: left;
-}
-html[dir="rtl"] .splitToolbarButton > .toolbarButton {
-  float: right;
+.splitToolbarButton > .toolbarButton {
+  float: inline-start;
 }
 
 .toolbarButton,
@@ -764,6 +749,7 @@ html[dir="rtl"] .splitToolbarButton > .toolbarButton:first-child {
   margin: 0;
 }
 .splitToolbarButtonSeparator {
+  float: inline-start;
   padding: 10px 0;
   width: 1px;
   background-color: var(--separator-color);
@@ -776,13 +762,6 @@ html[dir="rtl"] .splitToolbarButton > .toolbarButton:first-child {
   background-color: var(--field-border-color);
   margin: 0;
   padding: 13px 0;
-}
-
-html[dir="ltr"] .splitToolbarButtonSeparator {
-  float: left;
-}
-html[dir="rtl"] .splitToolbarButtonSeparator {
-  float: right;
 }
 
 .toolbarButton,
@@ -1230,13 +1209,8 @@ html[dir="rtl"] .toolbarButton.pdfSidebarNotification::after {
 }
 
 .thumbnail {
+  float: inline-start;
   margin: 0 10px 5px;
-}
-html[dir="ltr"] .thumbnail {
-  float: left;
-}
-html[dir="rtl"] .thumbnail {
-  float: right;
 }
 
 #thumbnailView > a:last-of-type > .thumbnail {
@@ -1332,11 +1306,13 @@ a:focus > .thumbnail > .thumbnailSelectionRing,
 
 .treeItemToggler {
   position: relative;
+  float: inline-start;
   height: 0;
   width: 0;
   color: rgba(255, 255, 255, 0.5);
 }
 .treeItemToggler::before {
+  inset-inline-end: 4px;
   mask-image: var(--treeitem-expanded-icon);
 }
 .treeItemToggler.treeItemsHidden::before {
@@ -1347,18 +1323,6 @@ html[dir="rtl"] .treeItemToggler.treeItemsHidden::before {
 }
 .treeItemToggler.treeItemsHidden ~ .treeItems {
   display: none;
-}
-html[dir="ltr"] .treeItemToggler {
-  float: left;
-}
-html[dir="rtl"] .treeItemToggler {
-  float: right;
-}
-html[dir="ltr"] .treeItemToggler::before {
-  right: 4px;
-}
-html[dir="rtl"] .treeItemToggler::before {
-  left: 4px;
 }
 
 .treeItem.selected > a {
@@ -1396,7 +1360,6 @@ html[dir="rtl"] .treeItemToggler::before {
 #errorMessageLeft {
   float: left;
 }
-
 #errorMessageRight {
   float: right;
 }


### PR DESCRIPTION
 - Stop polyfilling the CSS `calc` functionality

   At this point in time, all browsers that we support have native support for CSS variables; please see https://developer.mozilla.org/en-US/docs/Web/CSS/calc()#browser_compatibility and https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#faq-support

   We can also remove the hack introduced back in PR https://github.com/mozilla/pdf.js/pull/11567#issuecomment-582166160, which was only necessary to work-around an IE 11 specific bug.

 - Replace `dir`-dependent `float` with logical properties

   *Please note:* This is another step in what will, time permitting, become a series of patches to simplify/modernize the viewer CSS.

   Rather than having to manually specify ltr/rtl-specific float-values in the CSS, we can use logical `inline-start`/`inline-end` instead (and similar for some related left/right occurrences).
   These logical properties depend on, among other things, the direction of the HTML document which we *always* specify in the viewer.

   Given that most of these logical CSS properties are fairly new, and that cross-browser support is thus somewhat limited (see below), we rely on PostCSS plugins in order to support this in the GENERIC viewer.

    - https://developer.mozilla.org/en-US/docs/Web/CSS/float#browser_compatibility
    - https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline-end#browser_compatibility
