### PR TITLE
Add general iteration support in the `RefSet` and `RefSetCache` classes

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -1040,42 +1040,32 @@ class Catalog {
     return shadow(this, "jsActions", actions);
   }
 
-  fontFallback(id, handler) {
-    const promises = [];
-    this.fontCache.forEach(function (promise) {
-      promises.push(promise);
-    });
+  async fontFallback(id, handler) {
+    const translatedFonts = await Promise.all(this.fontCache);
 
-    return Promise.all(promises).then(translatedFonts => {
-      for (const translatedFont of translatedFonts) {
-        if (translatedFont.loadedName === id) {
-          translatedFont.fallback(handler);
-          return;
-        }
+    for (const translatedFont of translatedFonts) {
+      if (translatedFont.loadedName === id) {
+        translatedFont.fallback(handler);
+        return;
       }
-    });
+    }
   }
 
-  cleanup(manuallyTriggered = false) {
+  async cleanup(manuallyTriggered = false) {
     clearGlobalCaches();
     this.globalImageCache.clear(/* onlyData = */ manuallyTriggered);
     this.pageKidsCountCache.clear();
     this.pageIndexCache.clear();
     this.nonBlendModesSet.clear();
 
-    const promises = [];
-    this.fontCache.forEach(function (promise) {
-      promises.push(promise);
-    });
+    const translatedFonts = await Promise.all(this.fontCache);
 
-    return Promise.all(promises).then(translatedFonts => {
-      for (const { dict } of translatedFonts) {
-        delete dict.cacheKey;
-      }
-      this.fontCache.clear();
-      this.builtInCMapCache.clear();
-      this.standardFontDataCache.clear();
-    });
+    for (const { dict } of translatedFonts) {
+      delete dict.cacheKey;
+    }
+    this.fontCache.clear();
+    this.builtInCMapCache.clear();
+    this.standardFontDataCache.clear();
   }
 
   async getPageDict(pageIndex) {

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -352,9 +352,9 @@ class PartialEvaluator {
     // When no blend modes exist, there's no need re-fetch/re-parse any of the
     // processed `Ref`s again for subsequent pages. This helps reduce redundant
     // `XRef.fetch` calls for some documents (e.g. issue6961.pdf).
-    processed.forEach(ref => {
+    for (const ref of processed) {
       nonBlendModesSet.put(ref);
-    });
+    }
     return false;
   }
 

--- a/src/core/image_utils.js
+++ b/src/core/image_utils.js
@@ -179,9 +179,9 @@ class GlobalImageCache {
 
   get _byteSize() {
     let byteSize = 0;
-    this._imageCache.forEach(imageData => {
+    for (const imageData of this._imageCache) {
       byteSize += imageData.byteSize;
-    });
+    }
     return byteSize;
   }
 

--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -350,10 +350,8 @@ class RefSet {
     this._set.delete(ref.toString());
   }
 
-  forEach(callback) {
-    for (const ref of this._set.values()) {
-      callback(ref);
-    }
+  [Symbol.iterator]() {
+    return this._set.values();
   }
 
   clear() {
@@ -386,10 +384,8 @@ class RefSetCache {
     this._map.set(ref.toString(), this.get(aliasRef));
   }
 
-  forEach(callback) {
-    for (const value of this._map.values()) {
-      callback(value);
-    }
+  [Symbol.iterator]() {
+    return this._map.values();
   }
 
   clear() {

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -418,28 +418,41 @@ describe("primitives", function () {
   });
 
   describe("RefSet", function () {
-    it("should have a stored value", function () {
-      const ref = Ref.get(4, 2);
-      const refset = new RefSet();
-      refset.put(ref);
-      expect(refset.has(ref)).toBeTruthy();
-    });
-    it("should not have an unknown value", function () {
-      const ref = Ref.get(4, 2);
-      const refset = new RefSet();
-      expect(refset.has(ref)).toBeFalsy();
+    const ref1 = Ref.get(4, 2),
+      ref2 = Ref.get(5, 2);
+    let refSet;
 
-      refset.put(ref);
-      const anotherRef = Ref.get(2, 4);
-      expect(refset.has(anotherRef)).toBeFalsy();
+    beforeEach(function () {
+      refSet = new RefSet();
+    });
+
+    afterEach(function () {
+      refSet = null;
+    });
+
+    it("should have a stored value", function () {
+      refSet.put(ref1);
+      expect(refSet.has(ref1)).toBeTruthy();
+    });
+
+    it("should not have an unknown value", function () {
+      expect(refSet.has(ref1)).toBeFalsy();
+      refSet.put(ref1);
+      expect(refSet.has(ref2)).toBeFalsy();
+    });
+
+    it("should support iteration", function () {
+      refSet.put(ref1);
+      refSet.put(ref2);
+      expect([...refSet]).toEqual([ref1.toString(), ref2.toString()]);
     });
   });
 
   describe("RefSetCache", function () {
-    const ref1 = Ref.get(4, 2);
-    const ref2 = Ref.get(5, 2);
-    const obj1 = Name.get("foo");
-    const obj2 = Name.get("bar");
+    const ref1 = Ref.get(4, 2),
+      ref2 = Ref.get(5, 2),
+      obj1 = Name.get("foo"),
+      obj2 = Name.get("bar");
     let cache;
 
     beforeEach(function () {
@@ -483,12 +496,7 @@ describe("primitives", function () {
     it("should support iteration", function () {
       cache.put(ref1, obj1);
       cache.put(ref2, obj2);
-
-      const values = [];
-      cache.forEach(function (value) {
-        values.push(value);
-      });
-      expect(values).toEqual([obj1, obj2]);
+      expect([...cache]).toEqual([obj1, obj2]);
     });
   });
 


### PR DESCRIPTION
This patch removes the existing `forEach` methods, in favor of making the classes properly iterable instead. Given that the classes are using a `Set` respectively a `Map` internally, implementing this is very easy/efficient and allows us to simplify some existing code.