### PR TITLE
Slightly improve validation of (some) parameters in `getDocument`

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -316,7 +316,6 @@ function getDocument(src) {
     params[key] = value;
   }
 
-  params.rangeChunkSize = params.rangeChunkSize || DEFAULT_RANGE_CHUNK_SIZE;
   params.CMapReaderFactory =
     params.CMapReaderFactory || DefaultCMapReaderFactory;
   params.StandardFontDataFactory =
@@ -326,6 +325,9 @@ function getDocument(src) {
   params.pdfBug = params.pdfBug === true;
   params.enableXfa = params.enableXfa === true;
 
+  if (!Number.isInteger(params.rangeChunkSize) || params.rangeChunkSize < 1) {
+    params.rangeChunkSize = DEFAULT_RANGE_CHUNK_SIZE;
+  }
   if (
     typeof params.docBaseUrl !== "string" ||
     isDataScheme(params.docBaseUrl)
@@ -335,7 +337,7 @@ function getDocument(src) {
     // they contain the *entire* PDF document and can thus be arbitrarily long.
     params.docBaseUrl = null;
   }
-  if (!Number.isInteger(params.maxImageSize)) {
+  if (!Number.isInteger(params.maxImageSize) || params.maxImageSize < -1) {
     params.maxImageSize = -1;
   }
   if (typeof params.cMapUrl !== "string") {
@@ -363,7 +365,10 @@ function getDocument(src) {
         isNodeJS
       ) && !params.disableFontFace;
   }
-  if (typeof params.ownerDocument === "undefined") {
+  if (
+    typeof params.ownerDocument !== "object" ||
+    params.ownerDocument === null
+  ) {
     params.ownerDocument = globalThis.document;
   }
 

--- a/src/display/network_utils.js
+++ b/src/display/network_utils.js
@@ -27,7 +27,15 @@ function validateRangeRequestCapabilities({
   rangeChunkSize,
   disableRange,
 }) {
-  assert(rangeChunkSize > 0, "Range chunk size must be larger than zero");
+  if (
+    typeof PDFJSDev === "undefined" ||
+    PDFJSDev.test("!PRODUCTION || TESTING")
+  ) {
+    assert(
+      Number.isInteger(rangeChunkSize) && rangeChunkSize > 0,
+      "rangeChunkSize must be an integer larger than zero."
+    );
+  }
   const returnValues = {
     allowRangeRequests: false,
     suggestedLength: undefined,

--- a/test/unit/network_utils_spec.js
+++ b/test/unit/network_utils_spec.js
@@ -26,10 +26,18 @@ import {
 
 describe("network_utils", function () {
   describe("validateRangeRequestCapabilities", function () {
-    it("rejects range chunk sizes that are not larger than zero", function () {
+    it("rejects invalid rangeChunkSize", function () {
+      expect(function () {
+        validateRangeRequestCapabilities({ rangeChunkSize: "abc" });
+      }).toThrow(
+        new Error("rangeChunkSize must be an integer larger than zero.")
+      );
+
       expect(function () {
         validateRangeRequestCapabilities({ rangeChunkSize: 0 });
-      }).toThrow(new Error("Range chunk size must be larger than zero"));
+      }).toThrow(
+        new Error("rangeChunkSize must be an integer larger than zero.")
+      );
     });
 
     it("rejects disabled or non-HTTP range requests", function () {


### PR DESCRIPTION
There's a couple of `getDocument` parameters that should be numbers, but which are currently not *fully* validated to prevent issues elsewhere in the code-base.
Also, improves validation of the `ownerDocument` parameter since we currently accept more-or-less anything here.