### PR TITLE
Re-factor the `OverlayManager` class and remove the callback functions

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -464,7 +464,7 @@ const PDFViewerApplication = {
       : new EventBus();
     this.eventBus = eventBus;
 
-    this.overlayManager = new OverlayManager();
+    this.overlayManager = new OverlayManager(eventBus);
 
     const pdfRenderingQueue = new PDFRenderingQueue();
     pdfRenderingQueue.onIdle = this._cleanup.bind(this);
@@ -580,6 +580,7 @@ const PDFViewerApplication = {
     this.passwordPrompt = new PasswordPrompt(
       appConfig.passwordOverlay,
       this.overlayManager,
+      eventBus,
       this.l10n,
       this.isViewerEmbedded
     );

--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -160,16 +160,24 @@ function requestAccessToLocalFile(fileUrl, overlayManager, callback) {
     onCloseOverlay = function () {
       window.removeEventListener("focus", reloadIfRuntimeIsUnavailable);
       reloadIfRuntimeIsUnavailable();
-      overlayManager.close("chromeFileAccessOverlay");
     };
   }
   if (!chromeFileAccessOverlayPromise) {
     chromeFileAccessOverlayPromise = overlayManager.register(
       "chromeFileAccessOverlay",
       document.getElementById("chromeFileAccessOverlay"),
-      onCloseOverlay,
-      true
+      /* canForceClose = */ true
     );
+
+    PDFViewerApplication.eventBus._on("overlayclosed", ({ source, name }) => {
+      if (
+        source === overlayManager &&
+        name === "chromeFileAccessOverlay" &&
+        onCloseOverlay
+      ) {
+        onCloseOverlay();
+      }
+    });
   }
   chromeFileAccessOverlayPromise.then(function () {
     const iconPath = chrome.runtime.getManifest().icons[48];

--- a/web/overlay_manager.js
+++ b/web/overlay_manager.js
@@ -14,14 +14,14 @@
  */
 
 class OverlayManager {
-  constructor() {
-    this._overlays = {};
-    this._active = null;
-    this._keyDownBound = this._keyDown.bind(this);
-  }
+  #overlays = Object.create(null);
+
+  #active = null;
+
+  #keyDownBound = null;
 
   get active() {
-    return this._active;
+    return this.#active;
   }
 
   /**
@@ -46,10 +46,10 @@ class OverlayManager {
     let container;
     if (!name || !element || !(container = element.parentNode)) {
       throw new Error("Not enough parameters.");
-    } else if (this._overlays[name]) {
+    } else if (this.#overlays[name]) {
       throw new Error("The overlay is already registered.");
     }
-    this._overlays[name] = {
+    this.#overlays[name] = {
       element,
       container,
       callerCloseMethod,
@@ -63,12 +63,12 @@ class OverlayManager {
    *                    unregistered.
    */
   async unregister(name) {
-    if (!this._overlays[name]) {
+    if (!this.#overlays[name]) {
       throw new Error("The overlay does not exist.");
-    } else if (this._active === name) {
+    } else if (this.#active === name) {
       throw new Error("The overlay cannot be removed while it is active.");
     }
-    delete this._overlays[name];
+    delete this.#overlays[name];
   }
 
   /**
@@ -77,22 +77,23 @@ class OverlayManager {
    *                    opened.
    */
   async open(name) {
-    if (!this._overlays[name]) {
+    if (!this.#overlays[name]) {
       throw new Error("The overlay does not exist.");
-    } else if (this._active) {
-      if (this._overlays[name].canForceClose) {
-        this._closeThroughCaller();
-      } else if (this._active === name) {
+    } else if (this.#active) {
+      if (this.#overlays[name].canForceClose) {
+        this.#closeThroughCaller();
+      } else if (this.#active === name) {
         throw new Error("The overlay is already active.");
       } else {
         throw new Error("Another overlay is currently active.");
       }
     }
-    this._active = name;
-    this._overlays[this._active].element.classList.remove("hidden");
-    this._overlays[this._active].container.classList.remove("hidden");
+    this.#active = name;
+    this.#overlays[this.#active].element.classList.remove("hidden");
+    this.#overlays[this.#active].container.classList.remove("hidden");
 
-    window.addEventListener("keydown", this._keyDownBound);
+    this.#keyDownBound = this.#keyDown.bind(this);
+    window.addEventListener("keydown", this.#keyDownBound);
   }
 
   /**
@@ -101,39 +102,34 @@ class OverlayManager {
    *                    closed.
    */
   async close(name) {
-    if (!this._overlays[name]) {
+    if (!this.#overlays[name]) {
       throw new Error("The overlay does not exist.");
-    } else if (!this._active) {
+    } else if (!this.#active) {
       throw new Error("The overlay is currently not active.");
-    } else if (this._active !== name) {
+    } else if (this.#active !== name) {
       throw new Error("Another overlay is currently active.");
     }
-    this._overlays[this._active].container.classList.add("hidden");
-    this._overlays[this._active].element.classList.add("hidden");
-    this._active = null;
+    this.#overlays[this.#active].container.classList.add("hidden");
+    this.#overlays[this.#active].element.classList.add("hidden");
+    this.#active = null;
 
-    window.removeEventListener("keydown", this._keyDownBound);
+    window.removeEventListener("keydown", this.#keyDownBound);
+    this.#keyDownBound = null;
   }
 
-  /**
-   * @private
-   */
-  _keyDown(evt) {
-    if (this._active && evt.keyCode === /* Esc = */ 27) {
-      this._closeThroughCaller();
+  #keyDown(evt) {
+    if (this.#active && evt.keyCode === /* Esc = */ 27) {
+      this.#closeThroughCaller();
       evt.preventDefault();
     }
   }
 
-  /**
-   * @private
-   */
-  _closeThroughCaller() {
-    if (this._overlays[this._active].callerCloseMethod) {
-      this._overlays[this._active].callerCloseMethod();
+  #closeThroughCaller() {
+    if (this.#overlays[this.#active].callerCloseMethod) {
+      this.#overlays[this.#active].callerCloseMethod();
     }
-    if (this._active) {
-      this.close(this._active);
+    if (this.#active) {
+      this.close(this.#active);
     }
   }
 }

--- a/web/overlay_manager.js
+++ b/web/overlay_manager.js
@@ -14,11 +14,17 @@
  */
 
 class OverlayManager {
+  #eventBus = null;
+
   #overlays = Object.create(null);
 
   #active = null;
 
   #keyDownBound = null;
+
+  constructor(eventBus) {
+    this.#eventBus = eventBus;
+  }
 
   get active() {
     return this.#active;
@@ -27,22 +33,12 @@ class OverlayManager {
   /**
    * @param {string} name - The name of the overlay that is registered.
    * @param {HTMLDivElement} element - The overlay's DOM element.
-   * @param {function} [callerCloseMethod] - The method that, if present, calls
-   *                   `OverlayManager.close` from the object registering the
-   *                   overlay. Access to this method is necessary in order to
-   *                   run cleanup code when e.g. the overlay is force closed.
-   *                   The default is `null`.
    * @param {boolean} [canForceClose] - Indicates if opening the overlay closes
    *                  an active overlay. The default is `false`.
    * @returns {Promise} A promise that is resolved when the overlay has been
    *                    registered.
    */
-  async register(
-    name,
-    element,
-    callerCloseMethod = null,
-    canForceClose = false
-  ) {
+  async register(name, element, canForceClose = false) {
     let container;
     if (!name || !element || !(container = element.parentNode)) {
       throw new Error("Not enough parameters.");
@@ -52,7 +48,6 @@ class OverlayManager {
     this.#overlays[name] = {
       element,
       container,
-      callerCloseMethod,
       canForceClose,
     };
   }
@@ -81,7 +76,7 @@ class OverlayManager {
       throw new Error("The overlay does not exist.");
     } else if (this.#active) {
       if (this.#overlays[name].canForceClose) {
-        this.#closeThroughCaller();
+        await this.close();
       } else if (this.#active === name) {
         throw new Error("The overlay is already active.");
       } else {
@@ -101,7 +96,7 @@ class OverlayManager {
    * @returns {Promise} A promise that is resolved when the overlay has been
    *                    closed.
    */
-  async close(name) {
+  async close(name = this.#active) {
     if (!this.#overlays[name]) {
       throw new Error("The overlay does not exist.");
     } else if (!this.#active) {
@@ -115,21 +110,16 @@ class OverlayManager {
 
     window.removeEventListener("keydown", this.#keyDownBound);
     this.#keyDownBound = null;
+
+    // Ensure that any overlay-specific cleanup code can always be run,
+    // even if the overlay is force closed.
+    this.#eventBus.dispatch("overlayclosed", { source: this, name });
   }
 
   #keyDown(evt) {
     if (this.#active && evt.keyCode === /* Esc = */ 27) {
-      this.#closeThroughCaller();
+      this.close();
       evt.preventDefault();
-    }
-  }
-
-  #closeThroughCaller() {
-    if (this.#overlays[this.#active].callerCloseMethod) {
-      this.#overlays[this.#active].callerCloseMethod();
-    }
-    if (this.#active) {
-      this.close(this.#active);
     }
   }
 }

--- a/web/password_prompt.js
+++ b/web/password_prompt.js
@@ -32,11 +32,18 @@ class PasswordPrompt {
   /**
    * @param {PasswordPromptOptions} options
    * @param {OverlayManager} overlayManager - Manager for the viewer overlays.
+   * @param {EventBus} eventBus - The application event bus.
    * @param {IL10n} l10n - Localization service.
    * @param {boolean} [isViewerEmbedded] - If the viewer is embedded, in e.g.
    *   an <iframe> or an <object>. The default value is `false`.
    */
-  constructor(options, overlayManager, l10n, isViewerEmbedded = false) {
+  constructor(
+    options,
+    overlayManager,
+    eventBus,
+    l10n,
+    isViewerEmbedded = false
+  ) {
     this.overlayName = options.overlayName;
     this.container = options.container;
     this.label = options.label;
@@ -62,9 +69,14 @@ class PasswordPrompt {
     this.overlayManager.register(
       this.overlayName,
       this.container,
-      this.#cancel.bind(this),
-      true
+      /* canForceClose = */ true
     );
+
+    eventBus._on("overlayclosed", ({ source, name }) => {
+      if (source === this.overlayManager && name === this.overlayName) {
+        this.input.value = "";
+      }
+    });
   }
 
   async open() {
@@ -82,8 +94,7 @@ class PasswordPrompt {
   }
 
   async close() {
-    await this.overlayManager.close(this.overlayName);
-    this.input.value = "";
+    this.overlayManager.close(this.overlayName);
   }
 
   #verify() {

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -76,11 +76,7 @@ class PDFDocumentProperties {
     // Bind the event listener for the Close button.
     closeButton.addEventListener("click", this.close.bind(this));
 
-    this.overlayManager.register(
-      this.overlayName,
-      this.container,
-      this.close.bind(this)
-    );
+    this.overlayManager.register(this.overlayName, this.container);
 
     eventBus._on("pagechanging", evt => {
       this._currentPageNumber = evt.pageNumber;
@@ -179,7 +175,7 @@ class PDFDocumentProperties {
   /**
    * Close the document properties overlay.
    */
-  close() {
+  async close() {
     this.overlayManager.close(this.overlayName);
   }
 

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -342,10 +342,17 @@ function ensureOverlay() {
     overlayPromise = overlayManager.register(
       "printServiceOverlay",
       document.getElementById("printServiceOverlay"),
-      abort,
-      true
+      /* canForceClose = */ true
     );
-    document.getElementById("printCancel").onclick = abort;
+    document.getElementById("printCancel").onclick = () => {
+      overlayManager.close("printServiceOverlay");
+    };
+
+    PDFViewerApplication.eventBus._on("overlayclosed", ({ source, name }) => {
+      if (source === overlayManager && name === "printServiceOverlay") {
+        abort();
+      }
+    });
   }
   return overlayPromise;
 }


### PR DESCRIPTION
Having the individual overlays provide callback functions to handle them being force closed has always felt somewhat clunky and like a bad abstraction.
Hence this patch, which replaces the callback functions with a new "overlayclosed" event (on the `EventBus`) that the overlays that need to can listen for.[1]

---
[1] Note that the `OverlayManager` functionality is old enough that it pre-dates the introduction of the `EventBus`.