### PR TITLE
Avoid the `textLayer` becoming visible in high contrast mode (issue 13230)

### DIFF
--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -24,6 +24,7 @@
   opacity: 0.2;
   line-height: 1;
   text-size-adjust: none;
+  forced-color-adjust: none;
 }
 
 .textLayer span,


### PR DESCRIPTION
Unfortunately this CSS property is not yet available in Firefox, see https://developer.mozilla.org/en-US/docs/Web/CSS/forced-color-adjust#browser_compatibility which is tracked in https://bugzilla.mozilla.org/show_bug.cgi?id=1591210, however this patch seems to work when testing in Google Chrome.

Given that we really cannot do any more on the PDF.js-side of things, until this CSS feature is actually implemented in Firefox, I figured that submitting this patch cannot hurt in order to get rid of an open issue.