### PR TITLE
Change the type of the `container` property, in the `TextLayerRenderParameters` typedef (issue 14716)

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -27,15 +27,16 @@ import {
  *   render (the object is returned by the page's `getTextContent` method).
  * @property {ReadableStream} [textContentStream] - Text content stream to
  *   render (the stream is returned by the page's `streamTextContent` method).
- * @property {HTMLElement} container - HTML element that will contain text runs.
+ * @property {DocumentFragment} container - The DOM node that will contain the
+ *   text runs.
  * @property {import("./display_utils").PageViewport} viewport - The target
  *   viewport to properly layout the text runs.
- * @property {Array<HTMLElement>} [textDivs] - HTML elements that are correspond
- *   to the text items of the textContent input. This is output and shall be
- *   initially be set to empty array.
+ * @property {Array<HTMLElement>} [textDivs] - HTML elements that correspond to
+ *   the text items of the textContent input.
+ *   This is output and shall initially be set to an empty array.
  * @property {Array<string>} [textContentItemsStr] - Strings that correspond to
- *    the `str` property of the text items of textContent input. This is output
- *   and shall be initially be set to empty array.
+ *   the `str` property of the text items of the textContent input.
+ *   This is output and shall initially be set to an empty array.
  * @property {number} [timeout] - Delay in milliseconds before rendering of the
  *   text runs occurs.
  * @property {boolean} [enhanceTextSelection] - Whether to turn on the text


### PR DESCRIPTION
Given that the textLayer-code has been using a `DocumentFragment` ever since PR #3356 (back in 2013), simply updating the type of the `container` property should be fine.
This patch also tries to, ever so slightly, improve the grammar of a couple of other properties in the typedef.