### PR TITLE
PDFScriptingManager: Bind mousedown listener with capture=true

### DIFF
--- a/web/pdf_scripting_manager.js
+++ b/web/pdf_scripting_manager.js
@@ -154,7 +154,7 @@ class PDFScriptingManager {
       this._eventBus._on(name, listener);
     }
     for (const [name, listener] of this._domEvents) {
-      window.addEventListener(name, listener);
+      window.addEventListener(name, listener, true);
     }
 
     try {
@@ -507,7 +507,7 @@ class PDFScriptingManager {
     this._internalEvents.clear();
 
     for (const [name, listener] of this._domEvents) {
-      window.removeEventListener(name, listener);
+      window.removeEventListener(name, listener, true);
     }
     this._domEvents.clear();
 


### PR DESCRIPTION
PDFScriptingManager uses the `mousedown` and `mouseup` listeners to keep track of whether the mouse pointer is pressed in the `isDown` flag. These listeners were registered to run during the bubbling phase of the event dispatch, which can be interrupted if any of the previous event listeners stopped the event propagation. An example of that is by `GrabToPan` in web/grab_to_pan.js.

Since the mousedown (and mouseup) listeners of PDFScriptingManager are free of side effects, and the intention is to always run them, it makes most sense to register them with the capture flag.

More details at https://github.com/mozilla/pdf.js/issues/14721#issuecomment-1080065362
Fixes #14721