### PR TITLE
Use `String.prototype.repeat()` in a couple of spots

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -717,11 +717,7 @@ class Catalog {
           const character = String.fromCharCode(
             baseCharCode + (letterIndex % LIMIT)
           );
-          const charBuf = [];
-          for (let j = 0, jj = (letterIndex / LIMIT) | 0; j <= jj; j++) {
-            charBuf.push(character);
-          }
-          currentLabel = charBuf.join("");
+          currentLabel = character.repeat(Math.floor(letterIndex / LIMIT) + 1);
           break;
         default:
           if (style) {

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -261,10 +261,9 @@ describe("evaluator", function () {
         "(bug 1443140)",
       async function () {
         const NUM_INVALID_OPS = 25;
-        const tempArr = new Array(NUM_INVALID_OPS + 1);
 
         // Non-path operators, should be ignored.
-        const invalidMoveText = tempArr.join("10 Td\n");
+        const invalidMoveText = "10 Td\n".repeat(NUM_INVALID_OPS);
         const moveTextStream = new StringStream(invalidMoveText);
         const result = await runOperatorListCheck(
           partialEvaluator,
@@ -275,7 +274,7 @@ describe("evaluator", function () {
         expect(result.fnArray).toEqual([]);
 
         // Path operators, should throw error.
-        const invalidLineTo = tempArr.join("20 l\n");
+        const invalidLineTo = "20 l\n".repeat(NUM_INVALID_OPS);
         const lineToStream = new StringStream(invalidLineTo);
 
         try {

--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -49,9 +49,8 @@ describe("util", function () {
         bytes[i] = "a".charCodeAt(0);
       }
 
-      // Create a string with `length` 'a' characters. We need an array of size
-      // `length + 1` since `join` puts the argument between the array elements.
-      const string = Array(length + 1).join("a");
+      // Create a string with `length` 'a' characters.
+      const string = "a".repeat(length);
 
       expect(bytesToString(bytes)).toEqual(string);
     });


### PR DESCRIPTION
Rather than using a temporary Array to manually create repeated strings, we can use `String.prototype.repeat()` instead.
The reason that we didn't use this from the start is most likely because some browsers, notably IE, didn't support this; note https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/repeat#browser_compatibility