### PR TITLE
Use native `import maps` in development mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "canvas": "^2.11.2",
         "core-js": "^3.32.2",
         "cross-env": "^7.0.3",
-        "es-module-shims": "1.4.7",
         "eslint": "^8.50.0",
         "eslint-config-prettier": "^8.10.0",
         "eslint-plugin-fetch-options": "^0.0.5",
@@ -5972,12 +5971,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.2.1.tgz",
       "integrity": "sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==",
-      "dev": true
-    },
-    "node_modules/es-module-shims": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-1.4.7.tgz",
-      "integrity": "sha512-qYSDOnqPKoBoMGlpY8kQj1v3mVPpTfcob9a2xIIFoNgRlaVuI59yFODKkYrJ3nkz3z7d4dGpiUMRxes8jgiNRQ==",
       "dev": true
     },
     "node_modules/es-set-tostringtag": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "canvas": "^2.11.2",
     "core-js": "^3.32.2",
     "cross-env": "^7.0.3",
-    "es-module-shims": "1.4.7",
     "eslint": "^8.50.0",
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-fetch-options": "^0.0.5",

--- a/test/font/font_test.html
+++ b/test/font/font_test.html
@@ -8,8 +8,7 @@
   <script src="../../node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>
   <script src="../../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
 
-  <script defer src="../../node_modules/es-module-shims/dist/es-module-shims.js"></script>
-  <script type="importmap-shim">
+  <script type="importmap">
     {
       "imports": {
         "pdfjs/": "../../src/",
@@ -19,7 +18,7 @@
       }
     }
   </script>
-  <script src="jasmine-boot.js" type="module-shim"></script>
+  <script src="jasmine-boot.js" type="module"></script>
 </head>
 <body>
 </body>

--- a/test/unit/unit_test.html
+++ b/test/unit/unit_test.html
@@ -8,8 +8,7 @@
   <script src="../../node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>
   <script src="../../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
 
-  <script defer src="../../node_modules/es-module-shims/dist/es-module-shims.js"></script>
-  <script type="importmap-shim">
+  <script type="importmap">
     {
       "imports": {
         "pdfjs/": "../../src/",
@@ -41,7 +40,7 @@
       }
     }
   </script>
-  <script src="jasmine-boot.js" type="module-shim"></script>
+  <script src="jasmine-boot.js" type="module"></script>
 </head>
 <body>
 </body>

--- a/web/viewer-geckoview.html
+++ b/web/viewer-geckoview.html
@@ -41,8 +41,7 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!--#endif-->
 
 <!--#if !MOZCENTRAL-->
-    <script defer src="../node_modules/es-module-shims/dist/es-module-shims.js"></script>
-    <script type="importmap-shim">
+    <script type="importmap">
       {
         "imports": {
           "pdfjs/": "../src/",
@@ -73,8 +72,7 @@ See https://github.com/adobe-type-tools/cmap-resources
         }
       }
     </script>
-
-    <script src="viewer-geckoview.js" type="module-shim"></script>
+    <script src="viewer-geckoview.js" type="module"></script>
 <!--#else-->
 <!--<script src="resource://pdf.js/web/viewer.mjs" type="module"></script>-->
 <!--#endif-->

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -50,8 +50,7 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!--#elif /* Development mode. */-->
     <link rel="resource" type="application/l10n" href="locale/locale.properties">
 
-    <script defer src="../node_modules/es-module-shims/dist/es-module-shims.js"></script>
-    <script type="importmap-shim">
+    <script type="importmap">
       {
         "imports": {
           "pdfjs/": "../src/",
@@ -82,8 +81,7 @@ See https://github.com/adobe-type-tools/cmap-resources
         }
       }
     </script>
-
-    <script src="viewer.js" type="module-shim"></script>
+    <script src="viewer.js" type="module"></script>
 <!--#endif-->
   </head>
 


### PR DESCRIPTION
This patch seem to work fine locally now, and `mozregression` points to it being fixed in bug https://bugzilla.mozilla.org/show_bug.cgi?id=1803984 which landed in Firefox 116.

By using the native `import maps` functionality, we can remove a development dependency. Please find the specification at https://wicg.github.io/import-maps/