### PR TITLE
Simplify the `dialog::backdrop` CSS rules (PR 14710 follow-up)

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1254,7 +1254,7 @@ a:focus > .thumbnail > .thumbnailSelectionRing,
 }
 
 #errorWrapper {
-  background: none repeat scroll 0 0 var(--errorWrapper-bg-color);
+  background-color: var(--errorWrapper-bg-color);
   color: var(--main-color);
   left: 0;
   position: absolute;
@@ -1364,7 +1364,7 @@ dialog :link {
 }
 
 #PDFBug {
-  background: none repeat scroll 0 0 rgba(255, 255, 255, 1);
+  background-color: rgba(255, 255, 255, 1);
   border: 1px solid rgba(102, 102, 102, 1);
   position: fixed;
   top: 32px;
@@ -1393,12 +1393,9 @@ dialog :link {
 #PDFBug button.active {
   font-weight: bold;
 }
-.debuggerShowText {
-  background: none repeat scroll 0 0 rgba(255, 255, 0, 1);
-  color: rgba(0, 0, 255, 1);
-}
+.debuggerShowText,
 .debuggerHideText:hover {
-  background: none repeat scroll 0 0 rgba(255, 255, 0, 1);
+  background-color: rgba(255, 255, 0, 1);
 }
 #PDFBug .stats {
   font-family: courier;

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1302,7 +1302,6 @@ dialog {
 }
 dialog::backdrop {
   background-color: rgba(0, 0, 0, 0.2);
-  user-select: none;
 }
 
 dialog > .row {


### PR DESCRIPTION
After the changes in https://bugzilla.mozilla.org/show_bug.cgi?id=1761839, we no longer need this CSS work-around to prevent the entire `<dialog>` contents from becoming selected when the backdrop is clicked.