### PR TITLE
Remove some `dropdownToolbarButton`-related CSS rules

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -787,14 +787,6 @@ select {
   color: var(--main-color);
 }
 
-#customScaleOption {
-  display: none;
-}
-
-#pageWidthOption {
-  border-bottom: 1px rgba(255, 255, 255, 0.5) solid;
-}
-
 .toolbarButtonSpacer {
   width: 30px;
   display: inline-block;


### PR DESCRIPTION
According to the CSS, there should be a visible "divider" after the "Page Width" zoom-option. However, this is being ignored in both Mozilla Firefox[1] and Google Chrome hence the rule is effectively useless now.
Furthermore, the "custom" zoom-option is already being `hidden` using the attribute (in the HTML code) and there should thus be no reason to duplicate this in the CSS as well.

---
[1] Support for *detailed* styling of `<select>`-elements was removed as part of the E10s project.