### PR TITLE
[api-minor] Improve performances with image masks (bug 857031)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -675,6 +675,7 @@ class PartialEvaluator {
           width: imgData.width,
           height: imgData.height,
           interpolate: imgData.interpolate,
+          count: 1,
         },
       ];
 
@@ -1676,6 +1677,13 @@ class PartialEvaluator {
               const localImage = localImageCache.getByName(name);
               if (localImage) {
                 operatorList.addOp(localImage.fn, localImage.args);
+                if (
+                  localImage.fn === OPS.paintImageMaskXObject &&
+                  localImage.args[0] &&
+                  localImage.args[0].count > 0
+                ) {
+                  localImage.args[0].count++;
+                }
                 args = null;
                 continue;
               }
@@ -1692,7 +1700,13 @@ class PartialEvaluator {
                   const localImage = localImageCache.getByRef(xobj);
                   if (localImage) {
                     operatorList.addOp(localImage.fn, localImage.args);
-
+                    if (
+                      localImage.fn === OPS.paintImageMaskXObject &&
+                      localImage.args[0] &&
+                      localImage.args[0].count > 0
+                    ) {
+                      localImage.args[0].count++;
+                    }
                     resolveXObject();
                     return;
                   }
@@ -1809,6 +1823,13 @@ class PartialEvaluator {
               const localImage = localImageCache.getByName(cacheKey);
               if (localImage) {
                 operatorList.addOp(localImage.fn, localImage.args);
+                if (
+                  localImage.fn === OPS.paintImageMaskXObject &&
+                  localImage.args[0] &&
+                  localImage.args[0].count > 0
+                ) {
+                  localImage.args[0].count++;
+                }
                 args = null;
                 continue;
               }

--- a/src/core/operator_list.js
+++ b/src/core/operator_list.js
@@ -256,6 +256,8 @@ addState(
           data: maskParams.data,
           width: maskParams.width,
           height: maskParams.height,
+          interpolate: maskParams.interpolate,
+          count: maskParams.count,
           transform: transformArgs,
         });
       }

--- a/test/pdfs/bug857031.pdf.link
+++ b/test/pdfs/bug857031.pdf.link
@@ -1,0 +1,2 @@
+https://bug857031.bmoattachments.org/attachment.cgi?id=732270
+

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -6354,5 +6354,13 @@
          "value": "Hello PDF.js World"
         }
       }
+   },
+   {  "id": "bug857031",
+      "file": "pdfs/bug857031.pdf",
+      "md5": "f11ecd7f75675e0cafbc9880c1a586c7",
+      "rounds": 1,
+      "link": true,
+      "lastPage": 1,
+      "type": "eq"
    }
 ]


### PR DESCRIPTION
- it's the second part of the fix for https://bugzilla.mozilla.org/show_bug.cgi?id=857031;
- some image masks can be used several times but at different positions;
- an image need to be pre-process before to be rendered:
  * rescale it;
  * use the fill color/pattern.
- the two operations above are time consuming so we can cache the generated canvas;
- the cache key is based on the current transform matrix (without the translation part)
  and the current fill color when it isn't a pattern.
- the rendering of the pdf in the above bug is really faster than without this patch.