### PR TITLE
Improve performance of shared/utils.js::intersect (bug 1135277)

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -827,46 +827,33 @@ class Util {
   }
 
   // Returns a rectangle [x1, y1, x2, y2] corresponding to the
-  // intersection of rect1 and rect2. If no intersection, returns 'false'
+  // intersection of rect1 and rect2. If no intersection, returns 'null'
   // The rectangle coordinates of rect1, rect2 should be [x1, y1, x2, y2]
   static intersect(rect1, rect2) {
-    function compare(a, b) {
-      return a - b;
+    const xLow = Math.max(
+      Math.min(rect1[0], rect1[2]),
+      Math.min(rect2[0], rect2[2])
+    );
+    const xHigh = Math.min(
+      Math.max(rect1[0], rect1[2]),
+      Math.max(rect2[0], rect2[2])
+    );
+    if (xLow > xHigh) {
+      return null;
     }
-
-    // Order points along the axes
-    const orderedX = [rect1[0], rect1[2], rect2[0], rect2[2]].sort(compare);
-    const orderedY = [rect1[1], rect1[3], rect2[1], rect2[3]].sort(compare);
-    const result = [];
-
-    rect1 = Util.normalizeRect(rect1);
-    rect2 = Util.normalizeRect(rect2);
-
-    // X: first and second points belong to different rectangles?
-    if (
-      (orderedX[0] === rect1[0] && orderedX[1] === rect2[0]) ||
-      (orderedX[0] === rect2[0] && orderedX[1] === rect1[0])
-    ) {
-      // Intersection must be between second and third points
-      result[0] = orderedX[1];
-      result[2] = orderedX[2];
-    } else {
+    const yLow = Math.max(
+      Math.min(rect1[1], rect1[3]),
+      Math.min(rect2[1], rect2[3])
+    );
+    const yHigh = Math.min(
+      Math.max(rect1[1], rect1[3]),
+      Math.max(rect2[1], rect2[3])
+    );
+    if (yLow > yHigh) {
       return null;
     }
 
-    // Y: first and second points belong to different rectangles?
-    if (
-      (orderedY[0] === rect1[1] && orderedY[1] === rect2[1]) ||
-      (orderedY[0] === rect2[1] && orderedY[1] === rect1[1])
-    ) {
-      // Intersection must be between second and third points
-      result[1] = orderedY[1];
-      result[3] = orderedY[2];
-    } else {
-      return null;
-    }
-
-    return result;
+    return [xLow, yLow, xHigh, yHigh];
   }
 
   // From https://github.com/adobe-webplatform/Snap.svg/blob/b365287722a72526000ac4bfcf0ce4cac2faa015/src/path.js#L852


### PR DESCRIPTION
- avoid to call normalizeRect which clones the rectangles: it's useless
  and time consuming;
- in profiling the pdf in bug 1135277, the time spent in intersect drops
  from ~1s to ~30ms.