### PR TITLE
Update `core-js` to allow removing a `structuredClone` work-around

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "babel-loader": "^8.2.4",
         "caniuse-lite": "^1.0.30001324",
         "canvas": "^2.9.1",
-        "core-js": "^3.21.1",
+        "core-js": "^3.22.0",
         "cross-env": "^7.0.3",
         "dialog-polyfill": "^0.5.6",
         "dommatrix": "^0.0.24",
@@ -3957,9 +3957,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
-      "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.0.tgz",
+      "integrity": "sha512-8h9jBweRjMiY+ORO7bdWSeWfHhLPO7whobj7Z2Bl0IDo00C228EdGgH7FE4jGumbEjzcFfkfW8bXgdkEDhnwHQ==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -21645,9 +21645,9 @@
       }
     },
     "core-js": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
-      "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.0.tgz",
+      "integrity": "sha512-8h9jBweRjMiY+ORO7bdWSeWfHhLPO7whobj7Z2Bl0IDo00C228EdGgH7FE4jGumbEjzcFfkfW8bXgdkEDhnwHQ==",
       "dev": true
     },
     "core-js-compat": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "babel-loader": "^8.2.4",
     "caniuse-lite": "^1.0.30001324",
     "canvas": "^2.9.1",
-    "core-js": "^3.21.1",
+    "core-js": "^3.22.0",
     "cross-env": "^7.0.3",
     "dialog-polyfill": "^0.5.6",
     "dommatrix": "^0.0.24",

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1935,12 +1935,7 @@ class LoopbackPort {
 
   postMessage(obj, transfers) {
     const event = {
-      data:
-        typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("SKIP_BABEL") ||
-        transfers
-          ? structuredClone(obj, transfers)
-          : structuredClone(obj),
+      data: structuredClone(obj, transfers),
     };
 
     this._deferred.then(() => {


### PR DESCRIPTION
Because of a bug in previous `core-js` versions, which caused an Error to be thrown if its `structuredClone` polyfill was called with an *explicit* `null`/`undefined` transfer-parameter, the `LoopbackPort`-class contained a work-around.
In the latest `core-js` version this has been fixed, and we can thus simplify our code ever so slightly; please see https://github.com/zloirock/core-js/releases/tag/v3.22.0