### PR TITLE
Remove some outdated CSS rules related to printing

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1474,14 +1474,10 @@ dialog :link {
   #sidebarContainer,
   #secondaryToolbar,
   .toolbar,
-  #loadingBox,
   #errorWrapper,
   .textLayer,
   .canvasWrapper {
     display: none;
-  }
-  #viewerContainer {
-    overflow: visible;
   }
 
   #mainContainer,


### PR DESCRIPTION
Given that no HTML element has used the `loadingBox`-id for many years, we obviously don't need to try and hide a non-existent element during printing.
Furthermore, we also shouldn't need to change the `overflow`-value for the `viewerContainer`-element during printing. Originally, many years ago now, we printed "directly" using the viewer and then this apparently made sense.