### PR TITLE
Some more, small, CSS clean-up

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -691,11 +691,8 @@ select {
   color: var(--toggled-btn-color);
 }
 
+.toolbarButton.toggled::before,
 .secondaryToolbarButton.toggled::before {
-  background-color: var(--toggled-btn-color);
-}
-
-.toolbarButton.toggled::before {
   background-color: var(--toggled-btn-color);
 }
 
@@ -710,7 +707,6 @@ select {
   padding: 0;
   overflow: hidden;
   background-color: var(--dropdown-btn-bg-color);
-  margin-top: 2px !important;
 }
 .dropdownToolbarButton::after {
   top: 6px;


### PR DESCRIPTION
 - Remove a redundant `margin-top` rule for the `.dropdownToolbarButton`. After the (somewhat) recent UI-refresh all buttons now use `margin: 2px 1px;`, which renders the override unnecessary (and getting rid of an `!important`-rule can't hurt).

 - Combine two `.toggled::before` rules, since they're identical.