### PR TITLE
Use correct case for JavaScript

### DIFF
--- a/src/core/xfa/som.js
+++ b/src/core/xfa/som.js
@@ -136,7 +136,7 @@ function parseExpression(expr, dotDotAllowed, noExpr = true) {
           return null;
         }
         // TODO:
-        // Javascript expression: should be a boolean operation with a path
+        // JavaScript expression: should be a boolean operation with a path
         // so maybe we can have our own parser for that stuff or
         // maybe use the formcalc one.
         operator = operators.dotParen;

--- a/src/license_header_libre.js
+++ b/src/license_header_libre.js
@@ -1,6 +1,6 @@
 /**
  * @licstart The following is the entire license notice for the
- * Javascript code in this page
+ * JavaScript code in this page
  *
  * Copyright 2022 Mozilla Foundation
  *
@@ -17,5 +17,5 @@
  * limitations under the License.
  *
  * @licend The above is the entire license notice for the
- * Javascript code in this page
+ * JavaScript code in this page
  */


### PR DESCRIPTION
It should be `JavaScript` instead of `Javascript`.