### PR TITLE
Ensure that worker-thread image caching doesn't break optional content (issue 14824)

### DIFF
--- a/src/core/operator_list.js
+++ b/src/core/operator_list.js
@@ -622,6 +622,18 @@ class OperatorList {
     }
   }
 
+  addImageOps(fn, args, optionalContent) {
+    if (optionalContent !== undefined) {
+      this.addOp(OPS.beginMarkedContentProps, ["OC", optionalContent]);
+    }
+
+    this.addOp(fn, args);
+
+    if (optionalContent !== undefined) {
+      this.addOp(OPS.endMarkedContent, []);
+    }
+  }
+
   addDependency(dependency) {
     if (this.dependencies.has(dependency)) {
       return;

--- a/test/pdfs/issue14824.pdf.link
+++ b/test/pdfs/issue14824.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/8540275/PDF.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2965,6 +2965,18 @@
        "annotations": true,
        "about": "LinkAnnotation with a relative link, and a /Catalog Base-URI."
     },
+    {  "id": "issue14824",
+       "file": "pdfs/issue14824.pdf",
+       "md5": "7b8d061ab0a342e3606a3b3ba1925d5b",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 4,
+       "type": "eq",
+       "optionalContent": {
+         "7R": false
+       },
+       "about": "Need to test *at least* three pages, since the `GlobalImageCache` is involved."
+    },
     {  "id": "issue1127-text",
        "file": "pdfs/issue1127.pdf",
        "md5": "4fb2be5ffefeafda4ba977de2a1bb4d8",


### PR DESCRIPTION
Currently we only insert optionalContent-data into the operatorList the first time that an image is parsed, which will (in hindsight) obviously cause problems for cached images.
Hence we also need to insert the optionalContent-data in the various worker-thread image caches, such that it can be accessed in the fast-paths that are used to skip re-parsing of images.

In order to reduce the amount of repeated code, this patch also adds a new `OperatorList`-method that takes care of inserting the necessary data in the operatorList.