### PR TITLE
Export typescript types for non-legacy build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *~
 local.mk
-build/
+/build/
 tags
 .DS_Store
 Makefile

--- a/external/dist/build/pdf.d.ts
+++ b/external/dist/build/pdf.d.ts
@@ -1,0 +1,1 @@
+export * from "pdfjs-dist";


### PR DESCRIPTION
Fix `Could not find a declaration file for module 'pdfjs-dist/build/pdf'` when using `import * as pdfjs from 'pdfjs-dist/build/pdf'`. Note that currently, type resolutions works fine with the legacy build, e.g. `import * as pdfjs from 'pdfjs-dist/legacy/build/pdf'`.

The difference is apparent when examining the build output,
<img width="228" alt="Screen Shot 2022-04-22 at 9 53 15 AM" src="https://user-images.githubusercontent.com/11615829/164740541-47266aa8-7b3f-4bf5-990c-436fae9ee15d.png">
