### PR TITLE
Stop bundling the openFile-buttons in the MOZCENTRAL build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1239,6 +1239,11 @@ gulp.task(
           MOZCENTRAL_DIR + "browser/locales/en-US/pdfviewer/",
         FIREFOX_CONTENT_DIR = EXTENSION_SRC_DIR + "/firefox/content/";
 
+      const MOZCENTRAL_WEB_FILES = [
+        ...COMMON_WEB_FILES,
+        "!web/images/toolbarButton-openFile.svg",
+      ];
+
       // Clear out everything in the firefox extension build directory
       rimraf.sync(MOZCENTRAL_DIR);
 
@@ -1263,7 +1268,7 @@ gulp.task(
           gulp.dest(MOZCENTRAL_CONTENT_DIR + "web")
         ),
         gulp
-          .src(COMMON_WEB_FILES, { base: "web/" })
+          .src(MOZCENTRAL_WEB_FILES, { base: "web/" })
           .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + "web")),
         createCMapBundle().pipe(
           gulp.dest(MOZCENTRAL_CONTENT_DIR + "web/cmaps")

--- a/web/app.js
+++ b/web/app.js
@@ -2192,7 +2192,7 @@ function webViewerInitialized() {
         fileInput: evt.dataTransfer,
       });
     });
-  } else {
+  } else if (!PDFJSDev.test("MOZCENTRAL")) {
     appConfig.toolbar.openFile.hidden = true;
     appConfig.secondaryToolbar.openFileButton.hidden = true;
   }

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -65,7 +65,6 @@ class SecondaryToolbar {
         eventName: "presentationmode",
         close: true,
       },
-      { element: options.openFileButton, eventName: "openfile", close: true },
       { element: options.printButton, eventName: "print", close: true },
       { element: options.downloadButton, eventName: "download", close: true },
       { element: options.viewBookmarkButton, eventName: null, close: true },
@@ -141,6 +140,13 @@ class SecondaryToolbar {
         close: true,
       },
     ];
+    if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
+      this.buttons.push({
+        element: options.openFileButton,
+        eventName: "openfile",
+        close: true,
+      });
+    }
     this.items = {
       firstPage: options.firstPageButton,
       lastPage: options.lastPageButton,

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -62,7 +62,6 @@ class Toolbar {
       { element: options.next, eventName: "nextpage" },
       { element: options.zoomIn, eventName: "zoomin" },
       { element: options.zoomOut, eventName: "zoomout" },
-      { element: options.openFile, eventName: "openfile" },
       { element: options.print, eventName: "print" },
       {
         element: options.presentationModeButton,
@@ -71,6 +70,9 @@ class Toolbar {
       { element: options.download, eventName: "download" },
       { element: options.viewBookmark, eventName: null },
     ];
+    if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
+      this.buttons.push({ element: options.openFile, eventName: "openfile" });
+    }
     this.items = {
       numPages: options.numPages,
       pageNumber: options.pageNumber,

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -77,7 +77,7 @@
   --toolbarButton-zoomIn-icon: url(images/toolbarButton-zoomIn.svg);
   --toolbarButton-presentationMode-icon: url(images/toolbarButton-presentationMode.svg);
   --toolbarButton-print-icon: url(images/toolbarButton-print.svg);
-  --toolbarButton-openFile-icon: url(images/toolbarButton-openFile.svg);
+  --toolbarButton-openFile-icon: url(images/toolbarButton-openFile.svg); /* -webkit-non-mozcentral */
   --toolbarButton-download-icon: url(images/toolbarButton-download.svg);
   --toolbarButton-bookmark-icon: url(images/toolbarButton-bookmark.svg);
   --toolbarButton-viewThumbnail-icon: url(images/toolbarButton-viewThumbnail.svg);
@@ -821,8 +821,8 @@ select {
   mask-image: var(--toolbarButton-print-icon);
 }
 
-.toolbarButton.openFile::before,
-.secondaryToolbarButton.openFile::before {
+.toolbarButton.openFile::before, /* -webkit-non-mozcentral */
+.secondaryToolbarButton.openFile::before /* -webkit-non-mozcentral */ {
   mask-image: var(--toolbarButton-openFile-icon);
 }
 

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -153,9 +153,11 @@ See https://github.com/adobe-type-tools/cmap-resources
               <span data-l10n-id="presentation_mode_label">Presentation Mode</span>
             </button>
 
+<!--#if !MOZCENTRAL-->
             <button id="secondaryOpenFile" class="secondaryToolbarButton openFile visibleLargeView" title="Open File" tabindex="52" data-l10n-id="open_file">
               <span data-l10n-id="open_file_label">Open</span>
             </button>
+<!--#endif-->
 
             <button id="secondaryPrint" class="secondaryToolbarButton print visibleMediumView" title="Print" tabindex="53" data-l10n-id="print">
               <span data-l10n-id="print_label">Print</span>
@@ -265,9 +267,11 @@ See https://github.com/adobe-type-tools/cmap-resources
                   <span data-l10n-id="presentation_mode_label">Presentation Mode</span>
                 </button>
 
+<!--#if !MOZCENTRAL-->
                 <button id="openFile" class="toolbarButton openFile hiddenLargeView" title="Open File" tabindex="32" data-l10n-id="open_file">
                   <span data-l10n-id="open_file_label">Open</span>
                 </button>
+<!--#endif-->
 
                 <button id="print" class="toolbarButton print hiddenMediumView" title="Print" tabindex="33" data-l10n-id="print">
                   <span data-l10n-id="print_label">Print</span>

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -88,7 +88,10 @@ function getViewerConfiguration() {
       zoomIn: document.getElementById("zoomIn"),
       zoomOut: document.getElementById("zoomOut"),
       viewFind: document.getElementById("viewFind"),
-      openFile: document.getElementById("openFile"),
+      openFile:
+        typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")
+          ? document.getElementById("openFile")
+          : null,
       print: document.getElementById("print"),
       presentationModeButton: document.getElementById("presentationMode"),
       download: document.getElementById("download"),
@@ -103,7 +106,10 @@ function getViewerConfiguration() {
       presentationModeButton: document.getElementById(
         "secondaryPresentationMode"
       ),
-      openFileButton: document.getElementById("secondaryOpenFile"),
+      openFileButton:
+        typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")
+          ? document.getElementById("secondaryOpenFile")
+          : null,
       printButton: document.getElementById("secondaryPrint"),
       downloadButton: document.getElementById("secondaryDownload"),
       viewBookmarkButton: document.getElementById("secondaryViewBookmark"),


### PR DESCRIPTION
Note how both of the openFile-buttons are always hidden during viewer initialization in the MOZCENTRAL build, i.e. the *built-in* Firefox PDF Viewer. Despite that we still include HTML, CSS, and JavaScript code for these buttons in the build.

This patch *reduces* the size of the `gulp mozcentral` output by `1679` bytes, which isn't a lot but still cannot hurt.