### PR TITLE
Use a local font when the font isn't embedded (bug 1766039)

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -1212,7 +1212,9 @@ class Font {
     }
 
     amendFallbackToUnicode(properties);
-    this.loadedName = fontName.split("-")[0];
+    if (!properties.isExistingLocally) {
+      this.loadedName = fontName.split("-")[0];
+    }
     this.fontType = getFontType(type, subtype, properties.isStandardFont);
   }
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2860,6 +2860,13 @@ class WorkerTransport {
       }
       return this.StandardFontDataFactory.fetch(data);
     });
+
+    messageHandler.on("LoadNonEmbeddedFont", ({ loadedName, localName }) => {
+      if (this.destroyed) {
+        return Promise.reject(new Error("Worker was destroyed."));
+      }
+      return this.fontLoader.loadNonEmbeddedFont(loadedName, localName);
+    });
   }
 
   _onUnsupportedFeature({ featureId }) {

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -77,6 +77,25 @@ class BaseFontLoader {
     }
   }
 
+  async loadNonEmbeddedFont(loadedName, localNames) {
+    if (!this.isFontLoadingAPISupported) {
+      return false;
+    }
+
+    if (!Array.isArray(localNames)) {
+      localNames = [localNames];
+    }
+    localNames = localNames.map(name => `local('${name}')`).join(" ");
+    const fontFace = new FontFace(loadedName, localNames);
+    try {
+      await fontFace.load();
+      this.addNativeFontFace(fontFace);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   async bind(font) {
     // Add the font to the DOM only once; skip if the font is already loaded.
     if (font.attached || font.missingFile) {


### PR DESCRIPTION
- it aims to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1766039;
- if the font is not present locally and it has a standard font replacement
  then use the standard font.