### PR TITLE
Use integer coordinates when drawing images (bug 1264608, issue #3351)

### DIFF
--- a/test/pdfs/issue3351.1.pdf.link
+++ b/test/pdfs/issue3351.1.pdf.link
@@ -1,0 +1,2 @@
+https://github.com/mozilla/pdf.js/files/8582209/Doc2.pdf
+

--- a/test/pdfs/issue3351.2.pdf.link
+++ b/test/pdfs/issue3351.2.pdf.link
@@ -1,0 +1,2 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=8741330
+

--- a/test/pdfs/issue3351.3.pdf.link
+++ b/test/pdfs/issue3351.3.pdf.link
@@ -1,0 +1,2 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=8741334
+

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -6403,5 +6403,29 @@
       "link": true,
       "lastPage": 1,
       "type": "eq"
+   },
+   {  "id": "issue3351.1",
+      "file": "pdfs/issue3351.1.pdf",
+      "md5": "4216245a5f18bb3eac80575ccf0b272d",
+      "rounds": 1,
+      "link": true,
+      "lastPage": 1,
+      "type": "eq"
+   },
+   {  "id": "issue3351.2",
+      "file": "pdfs/issue3351.2.pdf",
+      "md5": "fa3fd1659c409c7824ef8838c3071efc",
+      "rounds": 1,
+      "link": true,
+      "lastPage": 1,
+      "type": "eq"
+   },
+   {  "id": "issue3351.3",
+      "file": "pdfs/issue3351.3.pdf",
+      "md5": "60e2f2c480b6bc0e7f726743c6896520",
+      "rounds": 1,
+      "link": true,
+      "lastPage": 1,
+      "type": "eq"
    }
 ]


### PR DESCRIPTION
 - it aims to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1264608; 
 - it's only a partial fix for #3351;
 - some tiled images have some spurious white lines between the tiles.
   When the current transform is applied the corners of an image can have
   some non-integer coordinates leading to some extra transparency added
   to handle that. So with this patch the current transform is applied on the
   point and on the dimensions in order to have at the end only integer values.