### PR TITLE
[api-minor] Remove the `forceClamped`-functionality in the Streams (issue 14849)

### DIFF
--- a/src/core/base_stream.js
+++ b/src/core/base_stream.js
@@ -40,7 +40,7 @@ class BaseStream {
     unreachable("Abstract method `getByte` called");
   }
 
-  getBytes(length, forceClamped = false) {
+  getBytes(length) {
     unreachable("Abstract method `getBytes` called");
   }
 
@@ -52,8 +52,8 @@ class BaseStream {
     return peekedByte;
   }
 
-  peekBytes(length, forceClamped = false) {
-    const bytes = this.getBytes(length, forceClamped);
+  peekBytes(length) {
+    const bytes = this.getBytes(length);
     this.pos -= bytes.length;
     return bytes;
   }
@@ -80,7 +80,7 @@ class BaseStream {
   }
 
   getString(length) {
-    return bytesToString(this.getBytes(length, /* forceClamped = */ false));
+    return bytesToString(this.getBytes(length));
   }
 
   skip(n) {

--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -169,7 +169,7 @@ class ChunkedStream extends Stream {
     return this.bytes[this.pos++];
   }
 
-  getBytes(length, forceClamped = false) {
+  getBytes(length) {
     const bytes = this.bytes;
     const pos = this.pos;
     const strEnd = this.end;
@@ -178,9 +178,7 @@ class ChunkedStream extends Stream {
       if (strEnd > this.progressiveDataLength) {
         this.ensureRange(pos, strEnd);
       }
-      const subarray = bytes.subarray(pos, strEnd);
-      // `this.bytes` is always a `Uint8Array` here.
-      return forceClamped ? new Uint8ClampedArray(subarray) : subarray;
+      return bytes.subarray(pos, strEnd);
     }
 
     let end = pos + length;
@@ -192,9 +190,7 @@ class ChunkedStream extends Stream {
     }
 
     this.pos = end;
-    const subarray = bytes.subarray(pos, end);
-    // `this.bytes` is always a `Uint8Array` here.
-    return forceClamped ? new Uint8ClampedArray(subarray) : subarray;
+    return bytes.subarray(pos, end);
   }
 
   getByteRange(begin, end) {

--- a/src/core/decode_stream.js
+++ b/src/core/decode_stream.js
@@ -73,7 +73,7 @@ class DecodeStream extends BaseStream {
     return this.buffer[this.pos++];
   }
 
-  getBytes(length, forceClamped = false) {
+  getBytes(length) {
     const pos = this.pos;
     let end;
 
@@ -96,11 +96,7 @@ class DecodeStream extends BaseStream {
     }
 
     this.pos = end;
-    const subarray = this.buffer.subarray(pos, end);
-    // `this.buffer` is either a `Uint8Array` or `Uint8ClampedArray` here.
-    return forceClamped && !(subarray instanceof Uint8ClampedArray)
-      ? new Uint8ClampedArray(subarray)
-      : subarray;
+    return this.buffer.subarray(pos, end);
   }
 
   reset() {

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -613,10 +613,7 @@ class PartialEvaluator {
       // for later.
       const interpolate = dict.get("I", "Interpolate");
       const bitStrideLength = (w + 7) >> 3;
-      const imgArray = image.getBytes(
-        bitStrideLength * h,
-        /* forceClamped = */ true
-      );
+      const imgArray = image.getBytes(bitStrideLength * h);
       const decode = dict.getArray("D", "Decode");
 
       if (this.parsingType3Font) {

--- a/src/core/operator_list.js
+++ b/src/core/operator_list.js
@@ -14,7 +14,6 @@
  */
 
 import {
-  assert,
   ImageKind,
   OPS,
   RenderingIntentFlag,
@@ -109,7 +108,7 @@ addState(
     }
     const imgWidth = Math.max(maxX, currentX) + IMAGE_PADDING;
     const imgHeight = currentY + maxLineHeight + IMAGE_PADDING;
-    const imgData = new Uint8ClampedArray(imgWidth * imgHeight * 4);
+    const imgData = new Uint8Array(imgWidth * imgHeight * 4);
     const imgRowSize = imgWidth << 2;
     for (let q = 0; q < count; q++) {
       const data = argsArray[iFirstPIIXO + (q << 2)][0].data;
@@ -678,17 +677,6 @@ class OperatorList {
         case OPS.paintInlineImageXObjectGroup:
         case OPS.paintImageMaskXObject:
           const arg = argsArray[i][0]; // First parameter in imgData.
-
-          if (
-            typeof PDFJSDev === "undefined" ||
-            PDFJSDev.test("!PRODUCTION || TESTING")
-          ) {
-            assert(
-              arg.data instanceof Uint8ClampedArray ||
-                typeof arg.data === "string",
-              'OperatorList._transfers: Unsupported "arg.data" type.'
-            );
-          }
           if (
             !arg.cached &&
             arg.data &&

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -45,24 +45,20 @@ class Stream extends BaseStream {
     return this.bytes[this.pos++];
   }
 
-  getBytes(length, forceClamped = false) {
+  getBytes(length) {
     const bytes = this.bytes;
     const pos = this.pos;
     const strEnd = this.end;
 
     if (!length) {
-      const subarray = bytes.subarray(pos, strEnd);
-      // `this.bytes` is always a `Uint8Array` here.
-      return forceClamped ? new Uint8ClampedArray(subarray) : subarray;
+      return bytes.subarray(pos, strEnd);
     }
     let end = pos + length;
     if (end > strEnd) {
       end = strEnd;
     }
     this.pos = end;
-    const subarray = bytes.subarray(pos, end);
-    // `this.bytes` is always a `Uint8Array` here.
-    return forceClamped ? new Uint8ClampedArray(subarray) : subarray;
+    return bytes.subarray(pos, end);
   }
 
   getByteRange(begin, end) {

--- a/test/unit/stream_spec.js
+++ b/test/unit/stream_spec.js
@@ -36,12 +36,6 @@ describe("stream", function () {
       const result = predictor.getBytes(6);
 
       expect(result).toEqual(new Uint8Array([100, 3, 101, 2, 102, 1]));
-
-      predictor.reset();
-      const clampedResult = predictor.getBytes(6, /* forceClamped = */ true);
-      expect(clampedResult).toEqual(
-        new Uint8ClampedArray([100, 3, 101, 2, 102, 1])
-      );
     });
   });
 });


### PR DESCRIPTION
As it turns out, most of the code-paths in the `PDFImage`-class won't actually pass the TypedArray (containing the image-data) to the `ColorSpace`-code. Hence we *generally* don't need to force the image-data to be a `Uint8ClampedArray`, and can just as well directly use a `Uint8Array` instead.

In the following cases we're returning the data without any `ColorSpace`-parsing, and the exact TypedArray used shouldn't matter:
 - https://github.com/mozilla/pdf.js/blob/b72a4483276d65bef32cff269eb40923c1363f2d/src/core/image.js#L714
 - https://github.com/mozilla/pdf.js/blob/b72a4483276d65bef32cff269eb40923c1363f2d/src/core/image.js#L751

In the following cases the image-data is only used *internally*, and again the exact TypedArray used shouldn't matter:
 - https://github.com/mozilla/pdf.js/blob/b72a4483276d65bef32cff269eb40923c1363f2d/src/core/image.js#L762 with the actual image-data being defined (as `Uint8ClampedArray`) further below
 - https://github.com/mozilla/pdf.js/blob/b72a4483276d65bef32cff269eb40923c1363f2d/src/core/image.js#L837

*Please note:* This is tagged `api-minor` because it's API-observable, given that *some* image/mask-data will now be returned as `Uint8Array` rather than using `Uint8ClampedArray` unconditionally. However, that seems like a small price to pay to (slightly) reduce memory usage during image-conversion.