### PR TITLE
Pin the `es-module-shims` dependency to version 1.4.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "cross-env": "^7.0.3",
         "dialog-polyfill": "^0.5.6",
         "dommatrix": "^1.0.1",
-        "es-module-shims": "^1.5.4",
+        "es-module-shims": "1.4.7",
         "eslint": "^8.14.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-fetch-options": "^0.0.5",
@@ -4670,9 +4670,9 @@
       "dev": true
     },
     "node_modules/es-module-shims": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-1.5.4.tgz",
-      "integrity": "sha512-OoVOu69uuLCnlMIcZJnYjZmp/0qhnisTUinU2WtIHztM65S1+SozyiDrmJgowScuMdYO41g8FmII+YXrkZwypA==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-1.4.7.tgz",
+      "integrity": "sha512-qYSDOnqPKoBoMGlpY8kQj1v3mVPpTfcob9a2xIIFoNgRlaVuI59yFODKkYrJ3nkz3z7d4dGpiUMRxes8jgiNRQ==",
       "dev": true
     },
     "node_modules/es-to-primitive": {
@@ -22185,9 +22185,9 @@
       "dev": true
     },
     "es-module-shims": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-1.5.4.tgz",
-      "integrity": "sha512-OoVOu69uuLCnlMIcZJnYjZmp/0qhnisTUinU2WtIHztM65S1+SozyiDrmJgowScuMdYO41g8FmII+YXrkZwypA==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-1.4.7.tgz",
+      "integrity": "sha512-qYSDOnqPKoBoMGlpY8kQj1v3mVPpTfcob9a2xIIFoNgRlaVuI59yFODKkYrJ3nkz3z7d4dGpiUMRxes8jgiNRQ==",
       "dev": true
     },
     "es-to-primitive": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "cross-env": "^7.0.3",
     "dialog-polyfill": "^0.5.6",
     "dommatrix": "^1.0.1",
-    "es-module-shims": "^1.5.4",
+    "es-module-shims": "1.4.7",
     "eslint": "^8.14.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-fetch-options": "^0.0.5",


### PR DESCRIPTION
Unfortunately newer versions either caused breakage when running the unit tests manually in a browser or when serving the development viewer. Given that we hope to use native import maps soon and this dependency will then be removed anyway, let's pin it for the time being.

Fixes https://github.com/mozilla/pdf.js/pull/14860#issuecomment-1114214642.