### PR TITLE
Support encoded dest-strings in /GoTo destination dictionaries (issue 14864)

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -1576,7 +1576,9 @@ class Catalog {
       if (dest instanceof Name) {
         dest = dest.name;
       }
-      if (typeof dest === "string" || Array.isArray(dest)) {
+      if (typeof dest === "string") {
+        resultObj.dest = stringToPDFString(dest);
+      } else if (Array.isArray(dest)) {
         resultObj.dest = dest;
       }
     }

--- a/test/pdfs/issue14864.pdf.link
+++ b/test/pdfs/issue14864.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/8599802/songbook.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -6,6 +6,13 @@
       "link": true,
       "type": "other"
     },
+    {  "id": "issue14864",
+       "file": "pdfs/issue14864.pdf",
+       "md5": "cfe5e68267d1e84ec909a915911974cf",
+       "rounds": 1,
+       "link": true,
+       "type": "other"
+    },
     {  "id": "filled-background-range",
       "file": "pdfs/filled-background.pdf",
       "md5": "2e3120255d9c3e79b96d2543b12d2589",

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1454,6 +1454,33 @@ describe("api", function () {
       await loadingTask.destroy();
     });
 
+    it("gets outline, with dest-strings using PDFDocEncoding (issue 14864)", async function () {
+      if (isNodeJS) {
+        pending("Linked test-cases are not supported in Node.js.");
+      }
+      const loadingTask = getDocument(buildGetDocumentParams("issue14864.pdf"));
+      const pdfDoc = await loadingTask.promise;
+      const outline = await pdfDoc.getOutline();
+
+      expect(Array.isArray(outline)).toEqual(true);
+      expect(outline.length).toEqual(6);
+
+      expect(outline[4]).toEqual({
+        dest: "Händel -- Halle🎆lujah",
+        url: null,
+        unsafeUrl: undefined,
+        newWindow: undefined,
+        title: "Händel -- Halle🎆lujah",
+        color: new Uint8ClampedArray([0, 0, 0]),
+        count: undefined,
+        bold: false,
+        italic: false,
+        items: [],
+      });
+
+      await loadingTask.destroy();
+    });
+
     it("gets outline with non-displayable chars", async function () {
       const loadingTask = getDocument(buildGetDocumentParams("issue14267.pdf"));
       const pdfDoc = await loadingTask.promise;


### PR DESCRIPTION
Interestingly enough this appears to be the very first case of *encoded* dest-strings, in /GoTo destination dictionaries, that we've actually come across. What's really fascinating is that it's less than a week after issue #14847, given that these issues are *somewhat* similar.