### PR TITLE
Only bundle the `src/display/node_utils.js` file in GENERIC-builds

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -353,15 +353,10 @@ function getDocument(src) {
     params.isEvalSupported = true;
   }
   if (typeof params.disableFontFace !== "boolean") {
-    params.disableFontFace =
-      (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) && isNodeJS;
+    params.disableFontFace = isNodeJS;
   }
   if (typeof params.useSystemFonts !== "boolean") {
-    params.useSystemFonts =
-      !(
-        (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&
-        isNodeJS
-      ) && !params.disableFontFace;
+    params.useSystemFonts = !isNodeJS && !params.disableFontFace;
   }
   if (
     typeof params.ownerDocument !== "object" ||

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -49,11 +49,6 @@ import {
   StatTimer,
 } from "./display_utils.js";
 import { FontFaceObject, FontLoader } from "./font_loader.js";
-import {
-  NodeCanvasFactory,
-  NodeCMapReaderFactory,
-  NodeStandardFontDataFactory,
-} from "./node_utils.js";
 import { AnnotationStorage } from "./annotation_storage.js";
 import { CanvasGraphics } from "./canvas.js";
 import { GlobalWorkerOptions } from "./worker_options.js";
@@ -67,18 +62,21 @@ import { XfaText } from "./xfa_text.js";
 const DEFAULT_RANGE_CHUNK_SIZE = 65536; // 2^16 = 65536
 const RENDERING_CANCELLED_TIMEOUT = 100; // ms
 
-const DefaultCanvasFactory =
-  (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) && isNodeJS
-    ? NodeCanvasFactory
-    : DOMCanvasFactory;
-const DefaultCMapReaderFactory =
-  (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) && isNodeJS
-    ? NodeCMapReaderFactory
-    : DOMCMapReaderFactory;
-const DefaultStandardFontDataFactory =
-  (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) && isNodeJS
-    ? NodeStandardFontDataFactory
-    : DOMStandardFontDataFactory;
+let DefaultCanvasFactory = DOMCanvasFactory;
+let DefaultCMapReaderFactory = DOMCMapReaderFactory;
+let DefaultStandardFontDataFactory = DOMStandardFontDataFactory;
+
+if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("GENERIC") && isNodeJS) {
+  const {
+    NodeCanvasFactory,
+    NodeCMapReaderFactory,
+    NodeStandardFontDataFactory,
+  } = require("./node_utils.js");
+
+  DefaultCanvasFactory = NodeCanvasFactory;
+  DefaultCMapReaderFactory = NodeCMapReaderFactory;
+  DefaultStandardFontDataFactory = NodeStandardFontDataFactory;
+}
 
 /**
  * @typedef {function} IPDFStreamFactory

--- a/src/display/node_utils.js
+++ b/src/display/node_utils.js
@@ -19,70 +19,54 @@ import {
   BaseCMapReaderFactory,
   BaseStandardFontDataFactory,
 } from "./base_factory.js";
-import { isNodeJS } from "../shared/is_node.js";
-import { unreachable } from "../shared/util.js";
 
-let NodeCanvasFactory = class {
-  constructor() {
-    unreachable("Not implemented: NodeCanvasFactory");
-  }
-};
+if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
+  throw new Error(
+    'Module "./node_utils.js" shall not be used with MOZCENTRAL builds.'
+  );
+}
 
-let NodeCMapReaderFactory = class {
-  constructor() {
-    unreachable("Not implemented: NodeCMapReaderFactory");
-  }
-};
-
-let NodeStandardFontDataFactory = class {
-  constructor() {
-    unreachable("Not implemented: NodeStandardFontDataFactory");
-  }
-};
-
-if ((typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) && isNodeJS) {
-  const fetchData = function (url) {
-    return new Promise((resolve, reject) => {
-      const fs = __non_webpack_require__("fs");
-      fs.readFile(url, (error, data) => {
-        if (error || !data) {
-          reject(new Error(error));
-          return;
-        }
-        resolve(new Uint8Array(data));
-      });
+const fetchData = function (url) {
+  return new Promise((resolve, reject) => {
+    const fs = __non_webpack_require__("fs");
+    fs.readFile(url, (error, data) => {
+      if (error || !data) {
+        reject(new Error(error));
+        return;
+      }
+      resolve(new Uint8Array(data));
     });
-  };
+  });
+};
 
-  NodeCanvasFactory = class extends BaseCanvasFactory {
-    /**
-     * @ignore
-     */
-    _createCanvas(width, height) {
-      const Canvas = __non_webpack_require__("canvas");
-      return Canvas.createCanvas(width, height);
-    }
-  };
+class NodeCanvasFactory extends BaseCanvasFactory {
+  /**
+   * @ignore
+   */
+  _createCanvas(width, height) {
+    const Canvas = __non_webpack_require__("canvas");
+    return Canvas.createCanvas(width, height);
+  }
+}
 
-  NodeCMapReaderFactory = class extends BaseCMapReaderFactory {
-    /**
-     * @ignore
-     */
-    _fetchData(url, compressionType) {
-      return fetchData(url).then(data => {
-        return { cMapData: data, compressionType };
-      });
-    }
-  };
+class NodeCMapReaderFactory extends BaseCMapReaderFactory {
+  /**
+   * @ignore
+   */
+  _fetchData(url, compressionType) {
+    return fetchData(url).then(data => {
+      return { cMapData: data, compressionType };
+    });
+  }
+}
 
-  NodeStandardFontDataFactory = class extends BaseStandardFontDataFactory {
-    /**
-     * @ignore
-     */
-    _fetchData(url) {
-      return fetchData(url);
-    }
-  };
+class NodeStandardFontDataFactory extends BaseStandardFontDataFactory {
+  /**
+   * @ignore
+   */
+  _fetchData(url) {
+    return fetchData(url);
+  }
 }
 
 export {


### PR DESCRIPTION
 - Only bundle the `src/display/node_utils.js` file in GENERIC-builds

   This first of all simplifies the file, since we no longer need dummy-classes and can instead *directly* define the actual classes.
   Furthermore, and more importantly, this means that we no longer need to bundle this code in e.g. MOZCENTRAL-builds which reduces the size of *built* `pdf.js` file slightly.

 - Simplify a couple of `isNodeJS`-dependent `getDocument` default values

   Given that the `isNodeJS`-constant will, after PR 14858, *always* be `false` in non-GENERIC builds we can simplify a couple of `getDocument`-parameter default values slightly.
   The old format, with inline `PDFJSDev`-checks, wasn't exactly a wonder of readability; which was my fault.
