### PR TITLE
Prevent the `AnnotationStorage`-data from being "silently" modified when using the the `getRawValue`-method (PR 14869 follow-up)

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -383,9 +383,10 @@ class AnnotationElement {
     if (!this.enableScripting) {
       return;
     }
+    const { id } = this.data;
 
     // Some properties may have been updated thanks to JS.
-    const storedData = this.annotationStorage.getRawValue(this.data.id);
+    const storedData = this.annotationStorage.getRawValue(id);
     if (!storedData) {
       return;
     }
@@ -397,6 +398,11 @@ class AnnotationElement {
         action({ detail, target: element });
         // The action has been consumed: no need to keep it.
         delete storedData[actionName];
+        this.annotationStorage.setValue(
+          id,
+          storedData,
+          /* forceReplace = */ true
+        );
       }
     }
   }

--- a/src/display/annotation_storage.js
+++ b/src/display/annotation_storage.js
@@ -46,7 +46,6 @@ class AnnotationStorage {
     if (value === undefined) {
       return defaultValue;
     }
-
     return Object.assign(defaultValue, value);
   }
 
@@ -59,7 +58,13 @@ class AnnotationStorage {
    * @returns {Object}
    */
   getRawValue(key) {
-    return this._storage.get(key);
+    const value = this._storage.get(key);
+    if (value === undefined) {
+      return value;
+    }
+    // Ensure that the stored value can't be accidentally changed, since that'd
+    // break the "modified"-handling and thus OperatorList-caching in the API.
+    return Object.assign(Object.create(null), value);
   }
 
   /**
@@ -69,11 +74,12 @@ class AnnotationStorage {
    * @memberof AnnotationStorage
    * @param {string} key
    * @param {Object} value
+   * @param {boolean} [forceReplace]
    */
-  setValue(key, value) {
+  setValue(key, value, forceReplace = false) {
     const obj = this._storage.get(key);
     let modified = false;
-    if (obj !== undefined) {
+    if (obj !== undefined && !forceReplace) {
       for (const [entry, val] of Object.entries(value)) {
         if (obj[entry] !== val) {
           modified = true;

--- a/src/display/annotation_storage.js
+++ b/src/display/annotation_storage.js
@@ -97,7 +97,9 @@ class AnnotationStorage {
   }
 
   getAll() {
-    return this._storage.size > 0 ? objectFromMap(this._storage) : null;
+    return this._storage.size > 0
+      ? objectFromMap(this._storage, /* copySubObjects = */ true)
+      : null;
   }
 
   get size() {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -667,10 +667,14 @@ function objectSize(obj) {
 
 // Ensure that the returned Object has a `null` prototype; hence why
 // `Object.fromEntries(...)` is not used.
-function objectFromMap(map) {
+function objectFromMap(map, copySubObjects = false) {
   const obj = Object.create(null);
   for (const [key, value] of map) {
-    obj[key] = value;
+    if (copySubObjects && typeof value === "object" && value !== null) {
+      obj[key] = Object.assign(Object.create(null), value);
+    } else {
+      obj[key] = value;
+    }
   }
   return obj;
 }


### PR DESCRIPTION
*I missed this during review of PR #14869, sorry about that!*

The way that the `AnnotationStorage.getRawValue`-method is implemented, and then used in the annotation-layer, unfortunately means that it's possible to *modify* the stored value without that correctly triggering the existing "modified"-handling.

This matters since the `lastModified`-getter is being used to compute the cache-key that we use for OperatorList-caching in the API, and without these changes it's thus *possible* that we fail to invalidate the cache as intended.
Given how the `AnnotationStorage.getRawValue`-method is currently being used that's not likely to cause problems, but with any future changes the old code *could* have caused weird/intermittent rendering bugs.