### PR TITLE
Ignore `pageColors` when the background/foreground is identical (PR 14874 follow-up)

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -209,12 +209,12 @@
       ],
       "default": -1
     },
-    "pageBackgroundColor": {
+    "pageColorsBackground": {
       "description": "The color is a string as defined in CSS. Its goal is to help improve readability in high contrast mode",
       "type": "string",
       "default": "Canvas"
     },
-    "pageForegroundColor": {
+    "pageColorsForeground": {
       "description": "The color is a string as defined in CSS. Its goal is to help improve readability in high contrast mode",
       "type": "string",
       "default": "CanvasText"

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1302,7 +1302,19 @@ class CanvasGraphics {
           typeof defaultBg === "string" && /^#[0-9A-Fa-f]{6}$/.test(defaultBg);
       }
 
-      if ((fg === "#000000" && bg === "#ffffff") || !isValidDefaultBg) {
+      if (
+        (fg === "#000000" && bg === "#ffffff") ||
+        fg === bg ||
+        !isValidDefaultBg
+      ) {
+        // Ignore the `pageColors`-option when:
+        //  - The computed background/foreground colors have their default
+        //    values, i.e. white/black.
+        //  - The computed background/foreground colors are identical,
+        //    since that'd render the `canvas` mostly blank.
+        //  - The `background`-option has a value that's incompatible with
+        //    the `pageColors`-values.
+        //
         this.foregroundColor = this.backgroundColor = null;
       } else {
         // https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_Colors_and_Luminance

--- a/web/app.js
+++ b/web/app.js
@@ -526,8 +526,8 @@ const PDFViewerApplication = {
       maxCanvasPixels: AppOptions.get("maxCanvasPixels"),
       enablePermissions: AppOptions.get("enablePermissions"),
       pageColors: {
-        background: AppOptions.get("pageBackgroundColor"),
-        foreground: AppOptions.get("pageForegroundColor"),
+        background: AppOptions.get("pageColorsBackground"),
+        foreground: AppOptions.get("pageColorsForeground"),
       },
     });
     pdfRenderingQueue.setViewer(this.pdfViewer);

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -129,12 +129,12 @@ const defaultOptions = {
     compatibility: compatibilityParams.maxCanvasPixels,
     kind: OptionKind.VIEWER,
   },
-  pageBackgroundColor: {
+  pageColorsBackground: {
     /** @type {string} */
     value: "Canvas",
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
-  pageForegroundColor: {
+  pageColorsForeground: {
     /** @type {string} */
     value: "CanvasText",
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,


### PR DESCRIPTION
If the computed background/foreground colors are identical, the `canvas` would be rendered mostly blank with only images visible. Hence it seems reasonable to also ignore the `pageColors`-option in this case.

Also, the patch tries to *briefly* outline the various cases in which we ignore the `pageColors`-option in a comment.