### PR TITLE
Try to remove the `mozOpaque` canvas-property (PR 6551 follow-up)

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -730,12 +730,6 @@ class TextLayerRenderTask {
     const canvas = this._document.createElement("canvas");
     canvas.height = canvas.width = DEFAULT_FONT_SIZE;
 
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("MOZCENTRAL || GENERIC")
-    ) {
-      canvas.mozOpaque = true;
-    }
     this._layoutTextCtx = canvas.getContext("2d", { alpha: false });
 
     if (this._textContent) {

--- a/test/driver.js
+++ b/test/driver.js
@@ -607,7 +607,6 @@ class Driver {
         this._log(
           " Loading page " + task.pageNum + "/" + task.pdfDoc.numPages + "... "
         );
-        this.canvas.mozOpaque = true;
         ctx = this.canvas.getContext("2d", { alpha: false });
         task.pdfDoc.getPage(task.pageNum).then(
           page => {

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -783,13 +783,6 @@ class PDFPageView {
     canvasWrapper.appendChild(canvas);
     this.canvas = canvas;
 
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("MOZCENTRAL || GENERIC")
-    ) {
-      canvas.mozOpaque = true;
-    }
-
     const ctx = canvas.getContext("2d", { alpha: false });
     const outputScale = (this.outputScale = new OutputScale());
 

--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -51,13 +51,6 @@ class TempImageFactory {
 
     // Since this is a temporary canvas, we need to fill it with a white
     // background ourselves. `_getPageDrawContext` uses CSS rules for this.
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("MOZCENTRAL || GENERIC")
-    ) {
-      tempCanvas.mozOpaque = true;
-    }
-
     const ctx = tempCanvas.getContext("2d", { alpha: false });
     ctx.save();
     ctx.fillStyle = "rgb(255, 255, 255)";
@@ -225,13 +218,6 @@ class PDFThumbnailView {
     // Keep the no-thumbnail outline visible, i.e. `data-loaded === false`,
     // until rendering/image conversion is complete, to avoid display issues.
     const canvas = document.createElement("canvas");
-
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("MOZCENTRAL || GENERIC")
-    ) {
-      canvas.mozOpaque = true;
-    }
     const ctx = canvas.getContext("2d", { alpha: false });
     const outputScale = new OutputScale();
 

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -261,12 +261,6 @@ class Toolbar {
 
     // The temporary canvas is used to measure text length in the DOM.
     let canvas = document.createElement("canvas");
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("MOZCENTRAL || GENERIC")
-    ) {
-      canvas.mozOpaque = true;
-    }
     let ctx = canvas.getContext("2d", { alpha: false });
 
     await animationStarted;


### PR DESCRIPTION
According to MDN, see https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/mozOpaque, the `mozOpaque` canvas-property is not only non-standard (obviously) but it's also been deprecated.
Instead it's recommended to use `alpha = false` when getting the canvas-context, see https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext#contextattributes, which all of our affected code is already doing.