### PR TITLE
[api-minor] Include line endings in Line/Polyline Annotation-data (issue 14896)

### DIFF
--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -3618,6 +3618,7 @@ describe("annotation", function () {
       lineDict.set("Type", Name.get("Annot"));
       lineDict.set("Subtype", Name.get("Line"));
       lineDict.set("L", [1, 2, 3, 4]);
+      lineDict.set("LE", ["Square", "Circle"]);
 
       const lineRef = Ref.get(122, 0);
       const xref = new XRefMock([{ ref: lineRef, data: lineDict }]);
@@ -3630,6 +3631,28 @@ describe("annotation", function () {
       );
       expect(data.annotationType).toEqual(AnnotationType.LINE);
       expect(data.lineCoordinates).toEqual([1, 2, 3, 4]);
+      expect(data.lineEndings).toEqual(["None", "None"]);
+    });
+
+    it("should set the line endings", async function () {
+      const lineDict = new Dict();
+      lineDict.set("Type", Name.get("Annot"));
+      lineDict.set("Subtype", Name.get("Line"));
+      lineDict.set("L", [1, 2, 3, 4]);
+      lineDict.set("LE", [Name.get("Square"), Name.get("Circle")]);
+
+      const lineRef = Ref.get(122, 0);
+      const xref = new XRefMock([{ ref: lineRef, data: lineDict }]);
+
+      const { data } = await AnnotationFactory.create(
+        xref,
+        lineRef,
+        pdfManagerMock,
+        idFactoryMock
+      );
+      expect(data.annotationType).toEqual(AnnotationType.LINE);
+      expect(data.lineCoordinates).toEqual([1, 2, 3, 4]);
+      expect(data.lineEndings).toEqual(["Square", "Circle"]);
     });
   });
 


### PR DESCRIPTION
Please refer to:
 - https://web.archive.org/web/20220309040754if_/https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/PDF32000_2008.pdf#G11.2109792
 - https://web.archive.org/web/20220309040754if_/https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/PDF32000_2008.pdf#G11.2096489
 - https://web.archive.org/web/20220309040754if_/https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/PDF32000_2008.pdf#G11.2096447

Note that we still won't attempt to use the /LE-data when creating fallback appearance streams, as mentioned in PR #13448, since custom line endings aren't common enough to warrant the added complexity.
Finally, note that according to the PDF specification we should *potentially* also take the line endings into account for FreeText Annotations. However, in that case their use is conditional on other parameters that we currently don't support.