### PR TITLE
[api-minor] Modernize and simplify the `ProgressBar` class

### DIFF
--- a/examples/mobile-viewer/viewer.css
+++ b/examples/mobile-viewer/viewer.css
@@ -13,6 +13,10 @@
  * limitations under the License.
  */
 
+:root {
+  --progressBar-percent: 0%;
+}
+
 * {
   padding: 0;
   margin: 0;
@@ -191,13 +195,12 @@ canvas {
   height: 0.6rem;
   background-color: rgba(51, 51, 51, 1);
   border-bottom: 1px solid rgba(51, 51, 51, 1);
-  margin-top: 5rem;
 }
 
 #loadingBar .progress {
   position: absolute;
   left: 0;
-  width: 0;
+  width: var(--progressBar-percent);
   height: 100%;
   background-color: rgba(221, 221, 221, 1);
   overflow: hidden;
@@ -217,6 +220,7 @@ canvas {
 }
 
 #loadingBar .progress.indeterminate {
+  width: 100%;
   background-color: rgba(153, 153, 153, 1);
   transition: none;
 }

--- a/examples/mobile-viewer/viewer.js
+++ b/examples/mobile-viewer/viewer.js
@@ -82,7 +82,9 @@ const PDFViewerApplication = {
         self.pdfDocument = pdfDocument;
         self.pdfViewer.setDocument(pdfDocument);
         self.pdfLinkService.setDocument(pdfDocument);
-        self.pdfHistory.initialize({ fingerprint: pdfDocument.fingerprint });
+        self.pdfHistory.initialize({
+          fingerprint: pdfDocument.fingerprints[0],
+        });
 
         self.loadingBar.hide();
         self.setTitleUsingMetadata(pdfDocument);
@@ -159,7 +161,7 @@ const PDFViewerApplication = {
   },
 
   get loadingBar() {
-    const bar = new pdfjsViewer.ProgressBar("#loadingBar", {});
+    const bar = new pdfjsViewer.ProgressBar("#loadingBar");
 
     return pdfjsLib.shadow(this, "loadingBar", bar);
   },
@@ -187,7 +189,7 @@ const PDFViewerApplication = {
       // Provides some basic debug information
       console.log(
         "PDF " +
-          pdfDocument.fingerprint +
+          pdfDocument.fingerprints[0] +
           " [" +
           info.PDFFormatVersion +
           " " +

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -22,7 +22,6 @@
   --sidebar-transition-timing-function: ease;
   --scale-select-container-width: 140px;
   --scale-select-overflow: 22px;
-  --loadingBar-end-offset: 0;
 
   --toolbar-icon-opacity: 0.7;
   --doorhanger-icon-opacity: 0.9;
@@ -32,6 +31,8 @@
   /*#if !MOZCENTRAL*/
   --errorWrapper-bg-color: rgba(255, 110, 110, 1);
   /*#endif*/
+  --progressBar-percent: 0%;
+  --progressBar-end-offset: 0;
   --progressBar-color: rgba(10, 132, 255, 1);
   --progressBar-indeterminate-bg-color: rgba(221, 221, 222, 1);
   --progressBar-indeterminate-blend-color: rgba(116, 177, 239, 1);
@@ -344,7 +345,7 @@ select {
 
 #loadingBar {
   position: absolute;
-  inset-inline: 0 var(--loadingBar-end-offset);
+  inset-inline: 0 var(--progressBar-end-offset);
   height: 4px;
   background-color: var(--body-bg-color);
   border-bottom: 1px solid var(--toolbar-border-color);
@@ -361,7 +362,7 @@ select {
   position: absolute;
   top: 0;
   left: 0;
-  width: 0%;
+  width: var(--progressBar-percent);
   height: 100%;
   background-color: var(--progressBar-color);
   overflow: hidden;
@@ -378,6 +379,7 @@ select {
 }
 
 #loadingBar .progress.indeterminate {
+  width: 100%;
   background-color: var(--progressBar-indeterminate-bg-color);
   transition: none;
 }


### PR DESCRIPTION
The original `ProgressBar`-functionality is very old, and could thus do with some general clean-up.
In particular, while it currently accepts various options those have never really been used in either the default viewer or in any examples. The sort of "styling" that these options provided are *much better*, not to mention simpler, done directly with CSS rules.

As part of these changes, the "progress" is now updated using CSS variables rather than by directly modifying the `style` of DOM elements. This should hopefully simplify future changes to this code, see e.g. PR #14898.

Finally, this also fixes a couple of other small things in the "mobile viewer" example.