### PR TITLE
Adjust the heuristics for handling of incomplete path operators (issue 14917)

### DIFF
--- a/test/pdfs/issue14917.pdf.link
+++ b/test/pdfs/issue14917.pdf.link
@@ -1,0 +1,1 @@
+https://web.archive.org/web/20220515091440/https://pdf.cdn.readpaper.com/spd/2963250244.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -3016,6 +3016,14 @@
        },
        "about": "Need to test *at least* three pages, since the `GlobalImageCache` is involved."
     },
+    {  "id": "issue14917",
+       "file": "pdfs/issue14917.pdf",
+       "md5": "12201b35853f78a501ac46b91608f8b6",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue1127-text",
        "file": "pdfs/issue1127.pdf",
        "md5": "4fb2be5ffefeafda4ba977de2a1bb4d8",


### PR DESCRIPTION
This limits the heuristics for handling of incomplete path operators, see PR #9838, to only apply to *sequences* of such operators. In practice a couple of invalid path operators are (hopefully) unlikely to completely break rendering, whereas a sequence of them will easily lead to fairly chaotic rendering artifacts.