### PR TITLE
Remove the `sourceEventType` from the viewer (bug 1757771 follow-up)

### DIFF
--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -109,13 +109,7 @@ class DownloadManager {
     return false;
   }
 
-  /**
-   * @param sourceEventType {string} Used to signal what triggered the download.
-   *   The version of PDF.js integrated with Firefox uses this to to determine
-   *   which dialog to show. "save" triggers "save as" and "download" triggers
-   *   the "open with" dialog.
-   */
-  download(blob, url, filename, sourceEventType = "download") {
+  download(blob, url, filename) {
     const blobUrl = URL.createObjectURL(blob);
     download(blobUrl, filename);
   }

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -116,13 +116,11 @@ class DownloadManager {
       new Blob([data], { type: contentType })
     );
 
-    FirefoxCom.requestAsync("download", {
+    FirefoxCom.request("download", {
       blobUrl,
       originalUrl: blobUrl,
       filename,
       isAttachment: true,
-    }).then(error => {
-      URL.revokeObjectURL(blobUrl);
     });
   }
 
@@ -161,17 +159,10 @@ class DownloadManager {
   download(blob, url, filename) {
     const blobUrl = URL.createObjectURL(blob);
 
-    FirefoxCom.requestAsync("download", {
+    FirefoxCom.request("download", {
       blobUrl,
       originalUrl: url,
       filename,
-    }).then(error => {
-      if (error) {
-        // If downloading failed in `PdfStreamConverter.jsm` it's very unlikely
-        // that attempting to fallback and re-download would be helpful here.
-        console.error("`ChromeActions.download` failed.");
-      }
-      URL.revokeObjectURL(blobUrl);
     });
   }
 }

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -158,14 +158,13 @@ class DownloadManager {
     return false;
   }
 
-  download(blob, url, filename, sourceEventType = "download") {
+  download(blob, url, filename) {
     const blobUrl = URL.createObjectURL(blob);
 
     FirefoxCom.requestAsync("download", {
       blobUrl,
       originalUrl: url,
       filename,
-      sourceEventType,
     }).then(error => {
       if (error) {
         // If downloading failed in `PdfStreamConverter.jsm` it's very unlikely
@@ -275,7 +274,7 @@ class MozL10n {
     if (!PDFViewerApplication.initialized) {
       return;
     }
-    PDFViewerApplication.eventBus.dispatch(type, { source: window });
+    PDFViewerApplication.eventBus.dispatch("download", { source: window });
   };
 
   window.addEventListener("save", handleEvent);

--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -267,9 +267,8 @@ class IDownloadManager {
    * @param {Blob} blob
    * @param {string} url
    * @param {string} filename
-   * @param {string} [sourceEventType]
    */
-  download(blob, url, filename, sourceEventType = "download") {}
+  download(blob, url, filename) {}
 }
 
 /**

--- a/web/pdf_scripting_manager.js
+++ b/web/pdf_scripting_manager.js
@@ -311,7 +311,7 @@ class PDFScriptingManager {
           this._pdfViewer.currentScaleValue = value;
           break;
         case "SaveAs":
-          this._eventBus.dispatch("save", { source: this });
+          this._eventBus.dispatch("download", { source: this });
           break;
         case "FirstPage":
           this._pdfViewer.currentPageNumber = 1;


### PR DESCRIPTION
 - Remove the `sourceEventType` from the viewer (bug 1757771 follow-up)

   After the changes in https://bugzilla.mozilla.org/show_bug.cgi?id=1757771, that simplified the MOZCENTRAL downloading code, the `sourceEventType` is now completely unused and should thus be removed (in my opinion).

   Furthermore, with these changes, we also no longer need a *separate* internal "save"-event and can instead just use the older "download"-event everywhere.

 - [Firefox viewer] Stop using `FirefoxCom.requestAsync` in the `DownloadManager`

   After the changes in https://bugzilla.mozilla.org/show_bug.cgi?id=1757771, that simplified the MOZCENTRAL downloading code, the `ChromeActions.download`-method will no longer invoke the `sendResponse`-callback.
   Hence it should no longer be necessary for the `DownloadManager`, in the MOZCENTRAL viewer, to use `FirefoxCom.requestAsync` since no response is ever provided.[1] For the allocated BlobURLs, they should (hopefully) be released when navigating away from the viewer.

   ---
   [1] Note that that was *already* the case, for one of the previous code-paths in the `ChromeActions.download`-method.
