### PR TITLE
Enable fork-sync

### DIFF
--- a/.github/workflows/fork-sync.yaml
+++ b/.github/workflows/fork-sync.yaml
@@ -1,0 +1,17 @@
+name: Sync Fork
+
+on:
+  schedule:
+    - cron: "*/30 * * * *" # every 30 minutes
+  workflow_dispatch: # on button click
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tgymnich/fork-sync@v1.4
+        with:
+          owner: StileEducation
+          base: master
+          head: master
+          pr_title: "Upstream Change via Fork Sync"


### PR DESCRIPTION
Enables the [`fork-sync`](https://github.com/marketplace/actions/fork-sync) action to keep this repository up-to-date with the original pdf.js one.