### PR TITLE
Add BrightSign support

### DIFF
--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -16,6 +16,9 @@
 
 import { isNodeJS } from "./is_node.js";
 
+// GlobalThis object is available since chrome 71.
+require("core-js/stable/global-this.js");
+
 // Skip compatibility checks for modern builds and if we already ran the module.
 if (
   (typeof PDFJSDev === "undefined" || !PDFJSDev.test("SKIP_BABEL")) &&

--- a/src/shared/is_node.js
+++ b/src/shared/is_node.js
@@ -23,6 +23,7 @@ const isNodeJS =
   typeof process === "object" &&
   process + "" === "[object process]" &&
   !process.versions.nw &&
-  !(process.versions.electron && process.type && process.type !== "browser");
+  !(process.versions.electron && process.type && process.type !== "browser") &&
+  process.argv0 !== "brightsign";
 
 export { isNodeJS };

--- a/src/shared/is_node.js
+++ b/src/shared/is_node.js
@@ -26,6 +26,6 @@ const isNodeJS =
   process + "" === "[object process]" &&
   !process.versions.nw &&
   !(process.versions.electron && process.type && process.type !== "browser") &&
-  !(window && window.BSDeviceInfo);
+  !(typeof window !== "undefined" && window && window.BSDeviceInfo);
 
 export { isNodeJS };

--- a/src/shared/is_node.js
+++ b/src/shared/is_node.js
@@ -14,16 +14,18 @@
  */
 /* globals process */
 
-// NW.js / Electron is a browser context, but copies some Node.js objects; see
+// NW.js / Electron / BrightSign is a browser context,
+// but copies some Node.js objects; see
 // http://docs.nwjs.io/en/latest/For%20Users/Advanced/JavaScript%20Contexts%20in%20NW.js/#access-nodejs-and-nwjs-api-in-browser-context
 // https://www.electronjs.org/docs/api/process#processversionselectron-readonly
 // https://www.electronjs.org/docs/api/process#processtype-readonly
+// https://brightsign.atlassian.net/wiki/spaces/DOC/pages/370672370/BSDeviceInfo
 const isNodeJS =
   (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&
   typeof process === "object" &&
   process + "" === "[object process]" &&
   !process.versions.nw &&
   !(process.versions.electron && process.type && process.type !== "browser") &&
-  process.argv0 !== "brightsign";
+  !(window && window.BSDeviceInfo);
 
 export { isNodeJS };


### PR DESCRIPTION
Like NW and Electron, treat BrightSign as a browser, but not Node.js.

BrightSign is a media player in digital signage: [BrightSign](https://www.brightsign.biz/), [Documentation](https://brightsign.atlassian.net/wiki/spaces/DOC/overview?mode=global).