### PR TITLE
Allow to have float numbers when getting image information in reftest-analyzer

### DIFF
--- a/test/resources/reftest-analyzer.js
+++ b/test/resources/reftest-analyzer.js
@@ -225,7 +225,9 @@ window.onload = function () {
         });
         continue;
       }
-      match = line.match(/^ {2}IMAGE[^:]*\((\d+)x(\d+)x(\d+)\): (.*)$/);
+      match = line.match(
+        /^ {2}IMAGE[^:]*\((\d+\.?\d*)x(\d+\.?\d*)x(\d+\.?\d*)\): (.*)$/
+      );
       if (match) {
         const item = gTestItems[gTestItems.length - 1];
         item.images.push({


### PR DESCRIPTION
- outputScale can be e.g. 1.5 in real life.