### PR TITLE
Handle CSS-comments correctly in the `preprocess`-function (PR 14886 follow-up)

### DIFF
--- a/external/builder/builder.js
+++ b/external/builder/builder.js
@@ -208,7 +208,9 @@ function preprocess(inFilename, outFilename, defines) {
         !stack.includes(STATE_IF_FALSE) &&
         !stack.includes(STATE_ELSE_FALSE)
       ) {
-        writeLine(line.replace(/^\/\/|^<!--/g, "  ").replace(/-->$/g, ""));
+        writeLine(
+          line.replace(/^\/\/|^\/\*|^<!--/g, "  ").replace(/\*\/$|-->$/g, "")
+        );
       }
     }
   }

--- a/external/builder/fixtures/css-comment-expected.css
+++ b/external/builder/fixtures/css-comment-expected.css
@@ -1,0 +1,4 @@
+/* Comment here... */
+  div {
+    margin: 0;
+  }

--- a/external/builder/fixtures/css-comment.css
+++ b/external/builder/fixtures/css-comment.css
@@ -1,0 +1,6 @@
+/* Comment here... */
+/*#if TRUE*/
+/*div {*/
+/*  margin: 0;*/
+/*}*/
+/*#endif*/


### PR DESCRIPTION
I overlooked this in PR #14886, sorry about that!