### PR TITLE
Use globalThis for webpack's output.globalObject instead of this

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -230,7 +230,7 @@ function createWebpackConfig(
   }
 
   // Required to expose e.g., the `window` object.
-  output.globalObject = "this";
+  output.globalObject = "globalThis";
 
   return {
     mode: "none",


### PR DESCRIPTION
Use `globalThis` for webpack's `output.globalObject` instead of `this`. Close #14915.

That allows us to import `pdfjs-dist/build/pdf.js` dynamically from modules.

- https://webpack.js.org/configuration/output/#outputglobalobject
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis