### PR TITLE
Handle CSS-comments better in the preprocess-function (PR 14963 follow-up)

### DIFF
--- a/external/builder/builder.js
+++ b/external/builder/builder.js
@@ -209,7 +209,10 @@ function preprocess(inFilename, outFilename, defines) {
         !stack.includes(STATE_ELSE_FALSE)
       ) {
         writeLine(
-          line.replace(/^\/\/|^\/\*|^<!--/g, "  ").replace(/\*\/$|-->$/g, "")
+          line
+            .replace(/^\/\/|^<!--/g, "  ")
+            .replace(/(^\s*)\/\*/g, "$1  ")
+            .replace(/\*\/$|-->$/g, "")
         );
       }
     }

--- a/external/builder/fixtures/css-comment-expected.css
+++ b/external/builder/fixtures/css-comment-expected.css
@@ -1,4 +1,5 @@
 /* Comment here... */
   div {
     margin: 0;
+    padding: 0;
   }

--- a/external/builder/fixtures/css-comment.css
+++ b/external/builder/fixtures/css-comment.css
@@ -2,5 +2,6 @@
 /*#if TRUE*/
 /*div {*/
 /*  margin: 0;*/
+  /*padding: 0;*/
 /*}*/
 /*#endif*/


### PR DESCRIPTION
This fixes another oversight, please see the updated tests.