### PR TITLE
Bundle the `<dialog>` polyfill-CSS in the GENERIC `legacy/`-viewer (PR 14710 follow-up)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -190,6 +190,8 @@ function createWebpackConfig(
     DEFAULT_PREFERENCES: defaultPreferencesDir
       ? getDefaultPreferences(defaultPreferencesDir)
       : {},
+    DIALOG_POLYFILL_CSS:
+      defines.GENERIC && !defines.SKIP_BABEL ? getDialogPolyfillCSS() : "",
   });
   const licenseHeaderLibre = fs
     .readFileSync("./src/license_header_libre.js")
@@ -734,6 +736,12 @@ function getDefaultPreferences(dir) {
     "web/app_options.js");
 
   return AppOptions.getAll(OptionKind.PREFERENCE);
+}
+
+function getDialogPolyfillCSS() {
+  return fs
+    .readFileSync("node_modules/dialog-polyfill/dist/dialog-polyfill.css")
+    .toString();
 }
 
 gulp.task("locale", function () {
@@ -1519,6 +1527,8 @@ function buildLib(defines, dir) {
     DEFAULT_PREFERENCES: getDefaultPreferences(
       defines.SKIP_BABEL ? "lib/" : "lib-legacy/"
     ),
+    DIALOG_POLYFILL_CSS:
+      defines.GENERIC && !defines.SKIP_BABEL ? getDialogPolyfillCSS() : "",
   });
 
   const inputStream = merge([

--- a/web/overlay_manager.js
+++ b/web/overlay_manager.js
@@ -44,6 +44,15 @@ class OverlayManager {
     ) {
       const dialogPolyfill = require("dialog-polyfill/dist/dialog-polyfill.js");
       dialogPolyfill.registerDialog(dialog);
+
+      if (!this._dialogPolyfillCSS) {
+        this._dialogPolyfillCSS = true;
+
+        const style = document.createElement("style");
+        style.textContent = PDFJSDev.eval("DIALOG_POLYFILL_CSS");
+
+        document.head.insertBefore(style, document.head.firstElementChild);
+      }
     }
 
     dialog.addEventListener("cancel", evt => {


### PR DESCRIPTION
In PR #14710 we only included the JavaScript-part of the polyfill, however we probably need to include the CSS as well to reduce the risk of problems in older browsers.

With the recent CSS-related improvements in the `preprocess`-function we could probably have included this conditionally in the `viewer.css` file. However, considering that the `<dialog>` polyfill-code is only invoked when actually needed it seemed most appropriate/correct to lazy-load the polyfill-CSS as well.