### PR TITLE
[editor] A couple of small FreeText-related fixes (PR 14976 follow-up)

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -253,6 +253,7 @@ web_fonts_disabled=Web fonts are disabled: unable to use embedded PDF fonts.
 # Editor
 editor_none.title=Disable Annotation Editing
 editor_none_label=Disable Editing
-freetext_default_content=Enter some text…
 editor_free_text.title=Add FreeText Annotation
 editor_free_text_label=FreeText Annotation
+
+freetext_default_content=Enter some text…

--- a/src/display/annotation_storage.js
+++ b/src/display/annotation_storage.js
@@ -69,6 +69,10 @@ class AnnotationStorage {
    */
   removeKey(key) {
     this._storage.delete(key);
+
+    if (this._storage.size === 0) {
+      this.resetModified();
+    }
   }
 
   /**

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -55,7 +55,7 @@ const AnnotationEditorPrefix = "pdfjs_internal_editor_";
 
 const AnnotationEditorType = {
   NONE: 0,
-  FREETEXT: 1,
+  FREETEXT: 3,
 };
 
 // Permission flags from Table 22, Section 7.6.3.2 of the PDF specification.

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -85,6 +85,10 @@ const PagesCountLimit = {
   PAUSE_EAGER_PAGE_INIT: 250,
 };
 
+function isValidAnnotationEditorMode(mode) {
+  return Object.values(AnnotationEditorType).includes(mode);
+}
+
 /**
  * @typedef {Object} PDFViewerOptions
  * @property {HTMLDivElement} container - The container for the viewer element.
@@ -2122,28 +2126,24 @@ class BaseViewer {
   }
 
   /**
-   * @param {number} mode - Annotation Editor mode (None, FreeText, Ink, ...)
+   * @param {number} mode - AnnotationEditor mode (None, FreeText, Ink, ...)
    */
   set annotationEditorMode(mode) {
     if (!this.#annotationEditorUIManager) {
       throw new Error(`The AnnotationEditor is not enabled.`);
     }
-
     if (this.#annotationEditorMode === mode) {
-      return;
+      return; // The AnnotationEditor mode didn't change.
     }
-
-    if (!Object.values(AnnotationEditorType).includes(mode)) {
+    if (!isValidAnnotationEditorMode(mode)) {
       throw new Error(`Invalid AnnotationEditor mode: ${mode}`);
     }
-
-    // If the mode is the same as before, it means that this mode is disabled
-    // and consequently the mode is NONE.
     this.#annotationEditorMode = mode;
     this.eventBus.dispatch("annotationeditormodechanged", {
       source: this,
       mode,
     });
+
     this.#annotationEditorUIManager.updateMode(mode);
   }
 }

--- a/web/l10n_utils.js
+++ b/web/l10n_utils.js
@@ -81,6 +81,7 @@ const DEFAULT_L10N_STRINGS = {
   printing_not_ready: "Warning: The PDF is not fully loaded for printing.",
   web_fonts_disabled:
     "Web fonts are disabled: unable to use embedded PDF fonts.",
+
   freetext_default_content: "Enter some text…",
 };
 

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -45,8 +45,8 @@ const PAGE_NUMBER_LOADING_INDICATOR = "visiblePageIsLoading";
  * @property {HTMLButtonElement} presentationModeButton - Button to switch to
  *   presentation mode.
  * @property {HTMLButtonElement} editorNoneButton - Button to disable editing.
- * @property {HTMLButtonElement} editorFreeTextButton - Button to switch to Free
- *   Text edition.
+ * @property {HTMLButtonElement} editorFreeTextButton - Button to switch to
+ *   FreeText editing.
  * @property {HTMLButtonElement} download - Button to download the document.
  * @property {HTMLAnchorElement} viewBookmark - Button to obtain a bookmark link
  *   to the current location in the document.

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -263,8 +263,8 @@ See https://github.com/adobe-type-tools/cmap-resources
                 <span id="numPages" class="toolbarLabel"></span>
               </div>
               <div id="toolbarViewerRight">
-                <div id="editorModeButtons" class="splitToolbarButton hidden" role="radiogroup">
-                  <button id="editorNone" class="toolbarButton" title="Disable Annotation Editing" role="radio" aria-checked="false" tabindex="31" data-l10n-id="editor_none">
+                <div id="editorModeButtons" class="splitToolbarButton toggled hidden" role="radiogroup">
+                  <button id="editorNone" class="toolbarButton toggled" title="Disable Annotation Editing" role="radio" aria-checked="true" tabindex="31" data-l10n-id="editor_none">
                     <span data-l10n-id="editor_none_label">Disable Editing</span>
                   </button>
                   <button id="editorFreeText" class="toolbarButton" title="Add FreeText Annotation" role="radio" aria-checked="false" tabindex="32" data-l10n-id="editor_free_text">

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -93,8 +93,8 @@ function getViewerConfiguration() {
           ? document.getElementById("openFile")
           : null,
       print: document.getElementById("print"),
-      editorFreeTextButton: document.getElementById("editorFreeText"),
       editorNoneButton: document.getElementById("editorNone"),
+      editorFreeTextButton: document.getElementById("editorFreeText"),
       presentationModeButton: document.getElementById("presentationMode"),
       download: document.getElementById("download"),
       viewBookmark: document.getElementById("viewBookmark"),


### PR DESCRIPTION
 - Ensure that the modified-warning won't be displayed, when navigating away from the viewer, if the user has added custom Annotations and then *removed all* of them.
 - Ensure that the *initial* editor-buttons state, i.e. the `toggled`-class, is correctly displayed in the toolbar when then viewer loads.
 - Tweak the CSS-classes for the editor-buttons, such that they use the correct focus/hover-rules (similar to the sidebar-buttons).
 - Remove a no longer accurate comment from the `BaseViewer.annotationEditorMode`-setter.
 - Address a couple of *smaller* outstanding review comments, including some re-formatting changes, from PR #14976.