### PR TITLE
Remove mention of `gulp singlefile`-command from `examples/node/getinfo.js`

### DIFF
--- a/examples/node/getinfo.js
+++ b/examples/node/getinfo.js
@@ -3,8 +3,6 @@
 
 //
 // Basic node example that prints document metadata and text content.
-// Requires single file built version of PDF.js -- please run
-// `gulp singlefile` before running the example.
 //
 
 // Run `gulp dist-install` to generate 'pdfjs-dist' npm package files.


### PR DESCRIPTION
This comment should've been removed in PR #9385, but better late than never I suppose.