### PR TITLE
[editor] Disable the editor-buttons in XFA documents

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -561,10 +561,6 @@ const PDFViewerApplication = {
       this.findBar = new PDFFindBar(appConfig.findBar, eventBus, this.l10n);
     }
 
-    if (AppOptions.get("annotationEditorEnabled")) {
-      document.getElementById("editorModeButtons").classList.remove("hidden");
-    }
-
     this.pdfDocumentProperties = new PDFDocumentProperties(
       appConfig.documentProperties,
       this.overlayManager,
@@ -1195,6 +1191,11 @@ const PDFViewerApplication = {
 
     this.toolbar.setPagesCount(pdfDocument.numPages, false);
     this.secondaryToolbar.setPagesCount(pdfDocument.numPages);
+
+    if (pdfDocument.isPureXfa) {
+      console.warn("Warning: XFA-editing is not implemented.");
+      this.toolbar.updateEditorModeButtonsState(/* disabled = */ true);
+    }
 
     let baseDocumentUrl;
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
@@ -2235,6 +2236,10 @@ function webViewerInitialized() {
 
   if (PDFViewerApplication.supportsIntegratedFind) {
     appConfig.toolbar.viewFind.classList.add("hidden");
+  }
+
+  if (PDFViewerApplication.pdfViewer.enableAnnotationEditor) {
+    appConfig.toolbar.editorModeButtons.classList.remove("hidden");
   }
 
   appConfig.mainContainer.addEventListener(

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -53,14 +53,14 @@ const OptionKind = {
  *       primitive types and cannot rely on any imported types.
  */
 const defaultOptions = {
-  annotationMode: {
-    /** @type {number} */
-    value: 2,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
   annotationEditorEnabled: {
     /** @type {boolean} */
     value: typeof PDFJSDev !== "undefined" && PDFJSDev.test("TESTING"),
+    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+  },
+  annotationMode: {
+    /** @type {number} */
+    value: 2,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
   cursorToolOnLoad: {

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -362,6 +362,13 @@ class BaseViewer {
   /**
    * @type {boolean}
    */
+  get enableAnnotationEditor() {
+    return !!this.#annotationEditorUIManager;
+  }
+
+  /**
+   * @type {boolean}
+   */
   get enableScripting() {
     return !!this._scriptingManager;
   }
@@ -719,9 +726,8 @@ class BaseViewer {
         const annotationLayerFactory =
           this.#annotationMode !== AnnotationMode.DISABLE ? this : null;
         const xfaLayerFactory = isPureXfa ? this : null;
-        const annotationEditorLayerFactory = this.#annotationEditorUIManager
-          ? this
-          : null;
+        const annotationEditorLayerFactory =
+          this.#annotationEditorUIManager && !isPureXfa ? this : null;
 
         for (let pageNum = 1; pageNum <= pagesCount; ++pageNum) {
           const pageView = new PDFPageView({

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -97,6 +97,8 @@ class Toolbar {
       next: options.next,
       zoomIn: options.zoomIn,
       zoomOut: options.zoomOut,
+      editorNoneButton: options.editorNoneButton,
+      editorFreeTextButton: options.editorFreeTextButton,
     };
 
     this._wasLocalized = false;
@@ -133,6 +135,7 @@ class Toolbar {
     this.pageScale = DEFAULT_SCALE;
     this._updateUIState(true);
     this.updateLoadingIndicatorState();
+    this.updateEditorModeButtonsState();
   }
 
   _bindListeners(options) {
@@ -267,9 +270,16 @@ class Toolbar {
   }
 
   updateLoadingIndicatorState(loading = false) {
-    const pageNumberInput = this.items.pageNumber;
+    const { pageNumber } = this.items;
 
-    pageNumberInput.classList.toggle(PAGE_NUMBER_LOADING_INDICATOR, loading);
+    pageNumber.classList.toggle(PAGE_NUMBER_LOADING_INDICATOR, loading);
+  }
+
+  updateEditorModeButtonsState(disabled = false) {
+    const { editorNoneButton, editorFreeTextButton } = this.items;
+
+    editorNoneButton.disabled = disabled;
+    editorFreeTextButton.disabled = disabled;
   }
 
   /**

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -71,8 +71,8 @@
   --loading-icon: url(images/loading.svg);
   --treeitem-expanded-icon: url(images/treeitem-expanded.svg);
   --treeitem-collapsed-icon: url(images/treeitem-collapsed.svg);
-  --toolbarButton-editorFreeText-icon: url(images/toolbarButton-editorFreeText.svg);
   --toolbarButton-editorNone-icon: url(images/toolbarButton-editorNone.svg);
+  --toolbarButton-editorFreeText-icon: url(images/toolbarButton-editorFreeText.svg);
   --toolbarButton-menuArrow-icon: url(images/toolbarButton-menuArrow.svg);
   --toolbarButton-sidebarToggle-icon: url(images/toolbarButton-sidebarToggle.svg);
   --toolbarButton-secondaryToolbarToggle-icon: url(images/toolbarButton-secondaryToolbarToggle.svg);

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -93,6 +93,7 @@ function getViewerConfiguration() {
           ? document.getElementById("openFile")
           : null,
       print: document.getElementById("print"),
+      editorModeButtons: document.getElementById("editorModeButtons"),
       editorNoneButton: document.getElementById("editorNone"),
       editorFreeTextButton: document.getElementById("editorFreeText"),
       presentationModeButton: document.getElementById("presentationMode"),


### PR DESCRIPTION
Given the differences between XFA documents and "normal" PDF documents, we don't support editing of the former ones. Hence, when a XFA-document is opened, we temporarily disable the editor-buttons.