### PR TITLE
Lookup image-data correctly in `paintImageMaskXObjectGroup` (issue 14990)

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -3132,10 +3132,9 @@ class CanvasGraphics {
 
     const fillColor = this.current.fillColor;
     const isPatternFill = this.current.patternFill;
-    for (let i = 0, ii = images.length; i < ii; i++) {
-      const image = images[i];
-      const width = image.width,
-        height = image.height;
+
+    for (const image of images) {
+      const { data, width, height, transform } = image;
 
       const maskCanvas = this.cachedCanvases.getCanvas(
         "maskCanvas",
@@ -3146,7 +3145,8 @@ class CanvasGraphics {
       const maskCtx = maskCanvas.context;
       maskCtx.save();
 
-      putBinaryImageMask(maskCtx, image);
+      const img = this.getObject(data, image);
+      putBinaryImageMask(maskCtx, img);
 
       maskCtx.globalCompositeOperation = "source-in";
 
@@ -3163,7 +3163,7 @@ class CanvasGraphics {
       maskCtx.restore();
 
       ctx.save();
-      ctx.transform.apply(ctx, image.transform);
+      ctx.transform.apply(ctx, transform);
       ctx.scale(1, -1);
       drawImageAtIntegerCoords(
         ctx,

--- a/test/pdfs/issue14990.pdf.link
+++ b/test/pdfs/issue14990.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/8839509/ap2114.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2064,6 +2064,15 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "issue14990",
+       "file": "pdfs/issue14990.pdf",
+       "md5": "0fb397e1506acc4ab8e68c18212a1362",
+       "link": true,
+       "rounds": 1,
+       "firstPage": 25,
+       "lastPage": 25,
+       "type": "eq"
+    },
     {  "id": "extgstate-text",
        "file": "pdfs/extgstate.pdf",
        "md5": "001bb4ec04463a01d93aad748361f049",


### PR DESCRIPTION
*This fixes a regression from PR #14754.*

We didn't lookup the image-data correctly, with the result that we tried to render some ImageMasks using a string rather than the intended TypedArray. To make matters worse, this code-path was apparently not *properly* covered by existing test-cases.