### PR TITLE
[editor] Update the `AnnotationStorage.hash`-getter to support editing

### DIFF
--- a/src/display/annotation_storage.js
+++ b/src/display/annotation_storage.js
@@ -142,11 +142,8 @@ class AnnotationStorage {
 
     const clone = new Map();
     for (const [key, value] of this._storage) {
-      if (value instanceof AnnotationEditor) {
-        clone.set(key, value.serialize());
-      } else {
-        clone.set(key, value);
-      }
+      const val = value instanceof AnnotationEditor ? value.serialize() : value;
+      clone.set(key, val);
     }
     return clone;
   }
@@ -159,7 +156,8 @@ class AnnotationStorage {
     const hash = new MurmurHash3_64();
 
     for (const [key, value] of this._storage) {
-      hash.update(`${key}:${JSON.stringify(value)}`);
+      const val = value instanceof AnnotationEditor ? value.serialize() : value;
+      hash.update(`${key}:${JSON.stringify(val)}`);
     }
     return hash.hexdigest();
   }

--- a/src/display/editor/freetext.js
+++ b/src/display/editor/freetext.js
@@ -203,12 +203,12 @@ class FreeTextEditor extends AnnotationEditor {
     const rect = this.div.getBoundingClientRect();
     const [x1, y1] = Util.applyTransform(
       [this.x, this.y + rect.height],
-      this.parent.viewport.inverseTransform
+      this.parent.inverseViewportTransform
     );
 
     const [x2, y2] = Util.applyTransform(
       [this.x + rect.width, this.y],
-      this.parent.viewport.inverseTransform
+      this.parent.inverseViewportTransform
     );
 
     return {


### PR DESCRIPTION
While calling `JSON.stringify(...)` on a class-instance obviously "works" (as in it doesn't throw), since it's really just an Object, it doesn't really make much sense in the context of the `AnnotationStorage.hash`-getter.

Also, access the *inverse* Viewport-transform correctly in `FreeTextEditor.serialize` to prevent errors being thrown when that method is invoked.

Finally, slightly updates the `AnnotationStorage.serializable`-getter to improve consistency within the class.