### PR TITLE
Conditionally bundle `gulp image_decoders`-specific code in `src/core/jbig2.js` (PR 9729 follow-up)

### DIFF
--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -1473,8 +1473,7 @@ function processSegment(segment, visitor) {
       break;
     default:
       throw new Jbig2Error(
-        `segment type ${header.typeName}(${header.type})` +
-          " is not implemented"
+        `segment type ${header.typeName}(${header.type}) is not implemented`
       );
   }
   const callbackName = "on" + header.typeName;
@@ -1500,6 +1499,9 @@ function parseJbig2Chunks(chunks) {
 }
 
 function parseJbig2(data) {
+  if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("IMAGE_DECODERS")) {
+    throw new Error("Not implemented: parseJbig2");
+  }
   const end = data.length;
   let position = 0;
 
@@ -2560,6 +2562,9 @@ class Jbig2Image {
   }
 
   parse(data) {
+    if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("IMAGE_DECODERS")) {
+      throw new Error("Not implemented: Jbig2Image.parse");
+    }
     const { imgData, width, height } = parseJbig2(data);
     this.width = width;
     this.height = height;


### PR DESCRIPTION
This method/function was added only for the `gulp image_decoders`-builds, and is completely unused elsewhere (e.g. in the Firefox PDF Viewer).
While this only reduces the size of the *built* `pdf.worker.js` file by a little over 1 kB, it can't hurt to remove completely unused code from the "normal" builds.