### PR TITLE
Reset all the canvas states after rendering each annotations (#14105)

### DIFF
--- a/test/pdfs/issue14105.pdf.link
+++ b/test/pdfs/issue14105.pdf.link
@@ -1,0 +1,2 @@
+https://github.com/mozilla/pdf.js/files/7291567/Stamp_Problem.pdf
+

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -6545,5 +6545,13 @@
       "link": true,
       "type": "eq",
       "annotations": true
+   },
+   {  "id": "issue14105",
+      "file": "pdfs/issue14105.pdf",
+      "md5": "554174cd461180cbe46c137e846dd527",
+      "rounds": 1,
+      "link": true,
+      "type": "eq",
+      "annotations": true
    }
 ]


### PR DESCRIPTION
- each annotation must be rendered independently of the others. So
  after having rendered each annotation, the canvas states are reset
  in order to have something clean to render the next one.