### PR TITLE
Change the name of the generated pdf.sandbox.external for mozilla-central

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -393,12 +393,15 @@ function createSandboxExternal(defines) {
     saveComments: false,
     defines,
   };
-  return gulp.src("./src/pdf.sandbox.external.js").pipe(
-    transform("utf8", content => {
-      content = preprocessor2.preprocessPDFJSCode(ctx, content);
-      return `${licenseHeader}\n${content}`;
-    })
-  );
+  return gulp
+    .src("./src/pdf.sandbox.external.js")
+    .pipe(
+      transform("utf8", content => {
+        content = preprocessor2.preprocessPDFJSCode(ctx, content);
+        return `${licenseHeader}\n${content}`;
+      })
+    )
+    .pipe(rename("pdf.sandbox.external.jsm"));
 }
 
 function createTemporaryScriptingBundle(defines, extraOptions = undefined) {


### PR DESCRIPTION
This patch is blocking https://phabricator.services.mozilla.com/D148600.