### PR TITLE
Polyfill `Array.prototype.at` with core-js (PR 14976 follow-up)

### DIFF
--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -80,6 +80,14 @@ if (
     ).ReadableStream;
   })();
 
+  // Support: Firefox<90, Chrome<92, Safari<15.4, Node.js<16.6.0
+  (function checkArrayAt() {
+    if (Array.prototype.at) {
+      return;
+    }
+    require("core-js/es/array/at.js");
+  })();
+
   // Support: Firefox<94, Chrome<98, Safari<15.4, Node.js<17.0.0
   (function checkStructuredClone() {
     if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("IMAGE_DECODERS")) {


### PR DESCRIPTION
This Array-method is a fairly new addition to the ECMAScript specification, hence we need a polyfill to avoid the library/viewer breaking in older browsers.

Please find additional information at:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at#browser_compatibility