### PR TITLE
Extend TextLayerRenderParameters.container type to include HTMLElement.

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -27,8 +27,8 @@ import {
  *   render (the object is returned by the page's `getTextContent` method).
  * @property {ReadableStream} [textContentStream] - Text content stream to
  *   render (the stream is returned by the page's `streamTextContent` method).
- * @property {DocumentFragment} container - The DOM node that will contain the
- *   text runs.
+ * @property {DocumentFragment | HTMLElement} container - The DOM node that
+ *   will contain the text runs.
  * @property {import("./display_utils").PageViewport} viewport - The target
  *   viewport to properly layout the text runs.
  * @property {Array<HTMLElement>} [textDivs] - HTML elements that correspond to


### PR DESCRIPTION
In PR #14717, `TextLayerRenderParameters.container` was changed from a `HTMLElement` to a `DocumentFragment` since the prebuilt web viewer uses a fragment.

This type breaks projects that use a `HTMLElement` for a container.

<img width="993" alt="Screen Shot 2022-06-09 at 9 58 52 AM" src="https://user-images.githubusercontent.com/18181641/172950601-cec38e10-6ca8-45e2-8143-aa16f58a2d29.png">

To remedy this, we extend the type of container to also include `HTMLElement`.