### PR TITLE
Expose `TextLayerRenderTask` in the TypeScript definitions (issue 15016, PR 14013 follow-up)

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -857,4 +857,4 @@ function renderTextLayer(renderParameters) {
   return task;
 }
 
-export { renderTextLayer };
+export { renderTextLayer, TextLayerRenderTask };

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -19,6 +19,8 @@
 /** @typedef {import("./display/api").PDFPageProxy} PDFPageProxy */
 /** @typedef {import("./display/api").RenderTask} RenderTask */
 /** @typedef {import("./display/display_utils").PageViewport} PageViewport */
+// eslint-disable-next-line max-len
+/** @typedef {import("./display/text_layer").TextLayerRenderTask} TextLayerRenderTask */
 
 import {
   AnnotationEditorType,

--- a/test/unit/clitests.json
+++ b/test/unit/clitests.json
@@ -37,6 +37,7 @@
     "primitives_spec.js",
     "stream_spec.js",
     "struct_tree_spec.js",
+    "text_layer_spec.js",
     "type1_parser_spec.js",
     "ui_utils_spec.js",
     "unicode_spec.js",

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -84,6 +84,7 @@ async function initializePDFJS(callback) {
       "pdfjs-test/unit/scripting_spec.js",
       "pdfjs-test/unit/stream_spec.js",
       "pdfjs-test/unit/struct_tree_spec.js",
+      "pdfjs-test/unit/text_layer_spec.js",
       "pdfjs-test/unit/type1_parser_spec.js",
       "pdfjs-test/unit/ui_utils_spec.js",
       "pdfjs-test/unit/unicode_spec.js",

--- a/test/unit/text_layer_spec.js
+++ b/test/unit/text_layer_spec.js
@@ -1,0 +1,62 @@
+/* Copyright 2022 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  renderTextLayer,
+  TextLayerRenderTask,
+} from "../../src/display/text_layer.js";
+import { buildGetDocumentParams } from "./test_utils.js";
+import { getDocument } from "../../src/display/api.js";
+import { isNodeJS } from "../../src/shared/is_node.js";
+
+describe("textLayer", function () {
+  it("creates textLayer from ReadableStream", async function () {
+    if (isNodeJS) {
+      pending("document.createDocumentFragment is not supported in Node.js.");
+    }
+    const loadingTask = getDocument(buildGetDocumentParams("basicapi.pdf"));
+    const pdfDocument = await loadingTask.promise;
+    const page = await pdfDocument.getPage(1);
+
+    const textContentItemsStr = [];
+
+    const textLayerRenderTask = renderTextLayer({
+      textContentStream: page.streamTextContent(),
+      container: document.createDocumentFragment(),
+      viewport: page.getViewport(),
+      textContentItemsStr,
+    });
+    expect(textLayerRenderTask instanceof TextLayerRenderTask).toEqual(true);
+
+    await textLayerRenderTask.promise;
+    expect(textContentItemsStr).toEqual([
+      "Table Of Content",
+      "",
+      "Chapter 1",
+      " ",
+      "..........................................................",
+      " ",
+      "2",
+      "",
+      "Paragraph 1.1",
+      " ",
+      "......................................................",
+      " ",
+      "3",
+      "",
+      "page 1 / 3",
+    ]);
+  });
+});


### PR DESCRIPTION
While `TextLayerRenderTask` apparently makes sense in TypeScript environments, given that it's being returned by the `renderTextLayer`-function in the API, we really don't want to extend the *public* API by simply exporting the class directly in `src/pdf.js` since it should never be called/initialized manually.
Hence we follow the same pattern as in PR #14013, and add some very basic unit-tests to ensure that `renderTextLayer` always returns a `TextLayerRenderTask`-instance as expected.