### PR TITLE
Enable the `unicorn/prefer-array-flat` and `unicorn/prefer-array-flat-map` ESLint plugin rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -49,6 +49,8 @@
     "unicorn/no-new-buffer": "error",
     "unicorn/no-instanceof-array": "error",
     "unicorn/no-useless-spread": "error",
+    "unicorn/prefer-array-flat": "error",
+    "unicorn/prefer-array-flat-map": "error",
     "unicorn/prefer-at": "error",
     "unicorn/prefer-date-now": "error",
     "unicorn/prefer-dom-node-remove": "error",

--- a/src/core/xfa/som.js
+++ b/src/core/xfa/som.js
@@ -254,7 +254,7 @@ function searchNode(
     if (isFinite(index)) {
       root = nodes.filter(node => index < node.length).map(node => node[index]);
     } else {
-      root = nodes.reduce((acc, node) => acc.concat(node), []);
+      root = nodes.flat();
     }
   }
 


### PR DESCRIPTION
These rules will help enforce shorter and more readable code, and according to MDN these Array-methods are available in all browsers/environments that we currently support:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat#browser_compatibility
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap#browser_compatibility

Please find additional information about these ESLint rules here:
 - https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-flat.md
 - https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-flat-map.md