### PR TITLE
[api-minor] Stop using the `beginAnnotations`/`endAnnotations` operators (PR 14998 follow-up)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -19,7 +19,6 @@ import {
   info,
   InvalidPDFException,
   isArrayEqual,
-  OPS,
   PageActionEventType,
   RenderingIntentFlag,
   shadow,
@@ -467,11 +466,9 @@ class Page {
         }
 
         return Promise.all(opListPromises).then(function (opLists) {
-          pageOpList.addOp(OPS.beginAnnotations, []);
           for (const opList of opLists) {
             pageOpList.addOpList(opList);
           }
-          pageOpList.addOp(OPS.endAnnotations, []);
           pageOpList.flush(true);
           return { length: pageOpList.totalLength };
         });

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -2976,10 +2976,6 @@ class CanvasGraphics {
     }
   }
 
-  beginAnnotations() {}
-
-  endAnnotations() {}
-
   beginAnnotation(id, rect, transform, matrix, hasOwnCanvas) {
     // The annotations are drawn just after the page content.
     // The page content drawing can potentially have set a transform,

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -337,7 +337,9 @@ const OPS = {
   paintFormXObjectEnd: 75,
   beginGroup: 76,
   endGroup: 77,
+  /** @deprecated unused */
   beginAnnotations: 78,
+  /** @deprecated unused */
   endAnnotations: 79,
   beginAnnotation: 80,
   endAnnotation: 81,

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -2443,15 +2443,15 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
       const opListAnnotEnable = await pdfPage.getOperatorList({
         annotationMode: AnnotationMode.ENABLE,
       });
-      expect(opListAnnotEnable.fnArray.length).toBeGreaterThan(150);
-      expect(opListAnnotEnable.argsArray.length).toBeGreaterThan(150);
+      expect(opListAnnotEnable.fnArray.length).toBeGreaterThan(140);
+      expect(opListAnnotEnable.argsArray.length).toBeGreaterThan(140);
       expect(opListAnnotEnable.lastChunk).toEqual(true);
 
       const opListAnnotEnableForms = await pdfPage.getOperatorList({
         annotationMode: AnnotationMode.ENABLE_FORMS,
       });
-      expect(opListAnnotEnableForms.fnArray.length).toBeGreaterThan(40);
-      expect(opListAnnotEnableForms.argsArray.length).toBeGreaterThan(40);
+      expect(opListAnnotEnableForms.fnArray.length).toBeGreaterThan(30);
+      expect(opListAnnotEnableForms.argsArray.length).toBeGreaterThan(30);
       expect(opListAnnotEnableForms.lastChunk).toEqual(true);
 
       const opListAnnotEnableStorage = await pdfPage.getOperatorList({


### PR DESCRIPTION
After the changes in PR #14998, these operators are now no-ops in the `src/display/canvas.js` code and should no longer be necessary.
Given that `beginAnnotations`/`endAnnotations` are not in the PDF specification, but are rather *custom* PDF.js operators, it seems reasonable to stop using them now that they've become no-ops.