### PR TITLE
Remove superfluous trailing arguments from `parseFloat`-calls (PR 14978 follow-up)

### DIFF
--- a/src/display/editor/freetext.js
+++ b/src/display/editor/freetext.js
@@ -56,8 +56,7 @@ class FreeTextEditor extends AnnotationEditor {
       PDFJSDev.test("!PRODUCTION || TESTING")
     ) {
       const lineHeight = parseFloat(
-        style.getPropertyValue("--freetext-line-height"),
-        10
+        style.getPropertyValue("--freetext-line-height")
       );
       assert(
         lineHeight === LINE_FACTOR,
@@ -66,8 +65,7 @@ class FreeTextEditor extends AnnotationEditor {
     }
 
     this._internalPadding = parseFloat(
-      style.getPropertyValue("--freetext-padding"),
-      10
+      style.getPropertyValue("--freetext-padding")
     );
   }
 


### PR DESCRIPTION
Fixes two recent "Code scanning alerts" on GitHub, which likely happened because these calls originally used `parseInt` instead (during initial development).