### PR TITLE
[api-minor] Update the minimum supported browsers/environments

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,9 +82,9 @@ const config = JSON.parse(fs.readFileSync(CONFIG_FILE).toString());
 const AUTOPREFIXER_CONFIG = {
   overrideBrowserslist: [
     "last 2 versions",
-    "Chrome >= 73",
+    "Chrome >= 76",
     "Firefox ESR",
-    "Safari >= 12.1",
+    "Safari >= 13",
     "> 1%",
     "not IE > 0",
     "not dead",
@@ -1390,7 +1390,7 @@ gulp.task(
             postcss([
               postcssLogical({ preserve: true }),
               postcssDirPseudoClass(),
-              autoprefixer({ overrideBrowserslist: ["Chrome >= 73"] }),
+              autoprefixer({ overrideBrowserslist: ["Chrome >= 76"] }),
             ])
           )
           .pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + "web")),

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -55,21 +55,6 @@ if (
     );
   })();
 
-  // Provides support for *recent* additions to the Promise specification,
-  // however basic Promise support is assumed to be available natively.
-  // Support: Firefox<71, Chrome<76, Safari<13, Node.js<12.9.0
-  (function checkPromise() {
-    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("IMAGE_DECODERS")) {
-      // The current image decoders are synchronous, hence `Promise` shouldn't
-      // need to be polyfilled for the IMAGE_DECODERS build target.
-      return;
-    }
-    if (globalThis.Promise.allSettled) {
-      return;
-    }
-    globalThis.Promise = require("core-js/es/promise/index.js");
-  })();
-
   // Support: Node.js
   (function checkReadableStream() {
     if (globalThis.ReadableStream || !isNodeJS) {


### PR DESCRIPTION
*Please note:* The dates below are still a little ways off, however that obviously won't affect the existing PDF.js releases. Hence I think that we can make these changes now, since by the time of the *next* official PDF.js release they'll likely match up pretty well.[1]

While we "support" some (by now) fairly old browsers, that essentially means that the library (and viewer) will load and that the basic functionality will work as intended.[2]
However, in older browsers, some functionality may not be available and generally we'll ask users to update to a modern browser when bugs (specific to old browsers) are reported.[3]

Since we've previously settled on only supporting browsers/environments that are approximately *three years old*, this patch updates the minimum supported browsers/environments as follows:
 - Chrome 76, which was released on 2019-07-30; see https://en.wikipedia.org/wiki/Google_Chrome_version_history
 - Firefox ESR (as before); see https://wiki.mozilla.org/Release_Management/Calendar
 - Safari 13, which was released on 2019-09-19; see https://en.wikipedia.org/wiki/Safari_version_history#Safari_13
 - Node.js 14, which was release on 2020-04-21 (all older versions have reached EOL); see https://en.wikipedia.org/wiki/Node.js#Releases

---
[1] Given that the releases usually happen every two to three months.

[2] Assuming that a `legacy/`-build is being used, of course.

[3] In general it's never a good idea to use old/outdated browsers, since those may contain *known* security vulnerabilities.