### PR TITLE
Enable the `unicorn/prefer-modern-dom-apis` ESLint plugin rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -53,6 +53,7 @@
     "unicorn/prefer-date-now": "error",
     "unicorn/prefer-dom-node-append": "error",
     "unicorn/prefer-dom-node-remove": "error",
+    "unicorn/prefer-modern-dom-apis": "error",
     "unicorn/prefer-string-starts-ends-with": "error",
 
     // Possible errors

--- a/extensions/chromium/contentscript.js
+++ b/extensions/chromium/contentscript.js
@@ -133,7 +133,7 @@ function updateEmbedElement(elem) {
   elem.type = "text/html";
   elem.src = getEmbeddedViewerURL(elem.src);
   if (parentNode) {
-    parentNode.insertBefore(elem, nextSibling);
+    nextSibling.before(elem);
   }
 }
 

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -2559,9 +2559,9 @@ class AnnotationLayer {
       if (!firstChild) {
         element.append(canvas);
       } else if (firstChild.nodeName === "CANVAS") {
-        element.replaceChild(canvas, firstChild);
+        firstChild.replaceWith(canvas);
       } else {
-        element.insertBefore(canvas, firstChild);
+        firstChild.before(canvas);
       }
     }
     annotationCanvasMap.clear();

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -627,7 +627,7 @@ class PDFPageView {
 
     if (lastDivBeforeTextDiv) {
       // The annotation layer needs to stay on top.
-      div.insertBefore(canvasWrapper, lastDivBeforeTextDiv);
+      lastDivBeforeTextDiv.before(canvasWrapper);
     } else {
       div.append(canvasWrapper);
     }
@@ -640,7 +640,7 @@ class PDFPageView {
       textLayerDiv.style.height = canvasWrapper.style.height;
       if (lastDivBeforeTextDiv) {
         // The annotation layer needs to stay on top.
-        div.insertBefore(textLayerDiv, lastDivBeforeTextDiv);
+        lastDivBeforeTextDiv.before(textLayerDiv);
       } else {
         div.append(textLayerDiv);
       }


### PR DESCRIPTION
This rule will help enforce slightly shorter code, and according to MDN both `Element.replaceWith()` and `Element.before()` are available in all browsers that we currently support.

Please find additional information here:
 - https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-modern-dom-apis.md
 - https://developer.mozilla.org/en-US/docs/Web/API/Element/replaceWith
 - https://developer.mozilla.org/en-US/docs/Web/API/Element/before