### PR TITLE
[api-minor] Get rid of CSS transform on each annotation in the annotation layer

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -432,6 +432,7 @@ class Annotation {
     this.setAppearance(dict);
     this.setBorderAndBackgroundColors(dict.get("MK"));
 
+    this._hasOwnCanvas = false;
     this._streams = [];
     if (this.appearance) {
       this._streams.push(this.appearance);
@@ -450,7 +451,6 @@ class Annotation {
       modificationDate: this.modificationDate,
       rect: this.rectangle,
       subtype: params.subtype,
-      hasOwnCanvas: false,
     };
 
     if (params.collectFields) {
@@ -849,7 +849,7 @@ class Annotation {
     const data = this.data;
     let appearance = this.appearance;
     const isUsingOwnCanvas =
-      data.hasOwnCanvas && intent & RenderingIntentFlag.DISPLAY;
+      this._hasOwnCanvas && intent & RenderingIntentFlag.DISPLAY;
     if (!appearance) {
       if (!isUsingOwnCanvas) {
         return Promise.resolve(new OperatorList());
@@ -2163,7 +2163,7 @@ class ButtonWidgetAnnotation extends WidgetAnnotation {
     } else if (this.data.radioButton) {
       this._processRadioButton(params);
     } else if (this.data.pushButton) {
-      this.data.hasOwnCanvas = true;
+      this._hasOwnCanvas = true;
       this._processPushButton(params);
     } else {
       warn("Invalid field flags for button widget annotation");

--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -1425,7 +1425,7 @@ class ChoiceList extends XFAObject {
     const field = ui[$getParent]();
     const fontSize = (field.font && field.font.size) || 10;
     const optionStyle = {
-      fontSize: `calc(${fontSize}px * var(--zoom-factor))`,
+      fontSize: `calc(${fontSize}px * var(--scale-factor))`,
     };
     const children = [];
 

--- a/src/core/xfa/xhtml.js
+++ b/src/core/xfa/xhtml.js
@@ -182,6 +182,10 @@ function mapStyle(styleStr, node, richText) {
     );
   }
 
+  if (richText && style.fontSize) {
+    style.fontSize = `calc(${style.fontSize} * var(--scale-factor))`;
+  }
+
   fixTextIndent(style);
   return style;
 }

--- a/src/display/base_factory.js
+++ b/src/display/base_factory.js
@@ -143,14 +143,18 @@ class BaseSVGFactory {
     }
   }
 
-  create(width, height) {
+  create(width, height, skipDimensions = false) {
     if (width <= 0 || height <= 0) {
       throw new Error("Invalid SVG dimensions");
     }
     const svg = this._createSVG("svg:svg");
     svg.setAttribute("version", "1.1");
-    svg.setAttribute("width", `${width}px`);
-    svg.setAttribute("height", `${height}px`);
+
+    if (!skipDimensions) {
+      svg.setAttribute("width", `${width}px`);
+      svg.setAttribute("height", `${height}px`);
+    }
+
     svg.setAttribute("preserveAspectRatio", "none");
     svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
 

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -3021,9 +3021,6 @@ class CanvasGraphics {
           canvasHeight
         );
         const { canvas, context } = this.annotationCanvas;
-        const viewportScaleFactorStr = `var(--zoom-factor) * ${PixelsPerInch.PDF_TO_CSS_UNITS}`;
-        canvas.style.width = `calc(${width}px * ${viewportScaleFactorStr})`;
-        canvas.style.height = `calc(${height}px * ${viewportScaleFactorStr})`;
         this.annotationCanvasMap.set(id, canvas);
         this.annotationCanvas.savedCtx = this.ctx;
         this.ctx = context;

--- a/src/display/editor/annotation_editor_layer.js
+++ b/src/display/editor/annotation_editor_layer.js
@@ -24,7 +24,6 @@ import { AnnotationEditorType, Util } from "../../shared/util.js";
 import { bindEvents, KeyboardManager } from "./tools.js";
 import { FreeTextEditor } from "./freetext.js";
 import { InkEditor } from "./ink.js";
-import { PixelsPerInch } from "../display_utils.js";
 
 /**
  * @typedef {Object} AnnotationEditorLayerOptions
@@ -491,14 +490,6 @@ class AnnotationEditorLayer {
    */
   get scaleFactor() {
     return this.viewport.scale;
-  }
-
-  /**
-   * Get the zoom factor.
-   * @returns {number}
-   */
-  get zoomFactor() {
-    return this.viewport.scale / PixelsPerInch.PDF_TO_CSS_UNITS;
   }
 }
 

--- a/src/display/editor/freetext.js
+++ b/src/display/editor/freetext.js
@@ -21,7 +21,6 @@ import {
 } from "../../shared/util.js";
 import { AnnotationEditor } from "./editor.js";
 import { bindEvents } from "./tools.js";
-import { PixelsPerInch } from "../display_utils.js";
 
 /**
  * Basic text editor in order to create a FreeTex annotation.
@@ -94,9 +93,9 @@ class FreeTextEditor extends AnnotationEditor {
   getInitialTranslation() {
     // The start of the base line is where the user clicked.
     return [
-      -FreeTextEditor._internalPadding * this.parent.zoomFactor,
+      -FreeTextEditor._internalPadding * this.parent.scaleFactor,
       -(FreeTextEditor._internalPadding + this.#fontSize) *
-        this.parent.zoomFactor,
+        this.parent.scaleFactor,
     ];
   }
 
@@ -217,7 +216,7 @@ class FreeTextEditor extends AnnotationEditor {
     this.editorDiv.contentEditable = true;
 
     const { style } = this.editorDiv;
-    style.fontSize = `calc(${this.#fontSize}px * var(--zoom-factor))`;
+    style.fontSize = `${this.#fontSize}%`;
     style.color = this.#color;
 
     this.div.append(this.editorDiv);
@@ -244,7 +243,7 @@ class FreeTextEditor extends AnnotationEditor {
   /** @inheritdoc */
   serialize() {
     const rect = this.editorDiv.getBoundingClientRect();
-    const padding = FreeTextEditor._internalPadding * this.parent.zoomFactor;
+    const padding = FreeTextEditor._internalPadding * this.parent.scaleFactor;
     const [x1, y1] = Util.applyTransform(
       [this.x + padding, this.y + padding + rect.height],
       this.parent.inverseViewportTransform
@@ -257,7 +256,7 @@ class FreeTextEditor extends AnnotationEditor {
     return {
       annotationType: AnnotationEditorType.FREETEXT,
       color: [0, 0, 0],
-      fontSize: this.#fontSize / PixelsPerInch.PDF_TO_CSS_UNITS,
+      fontSize: this.#fontSize,
       value: this.#content,
       pageIndex: this.parent.pageIndex,
       rect: [x1, y1, x2, y2],

--- a/test/annotation_layer_builder_overrides.css
+++ b/test/annotation_layer_builder_overrides.css
@@ -17,6 +17,13 @@
 
 .annotationLayer {
   position: absolute;
+  font-size: calc(100px * var(--scale-factor));
+}
+
+.annotationLayer .buttonWidgetAnnotation.pushButton > img {
+  width: 100%;
+  height: 100%;
+  position: absolute;
 }
 
 .annotationLayer .buttonWidgetAnnotation.checkBox input,

--- a/test/driver.js
+++ b/test/driver.js
@@ -215,7 +215,7 @@ class Rasterize {
       div.className = "annotationLayer";
 
       const [common, overrides] = await this.annotationStylePromise;
-      style.textContent = `${common}\n${overrides}`;
+      style.textContent = `:root { --scale-factor: ${viewport.scale} } ${common}\n${overrides}`;
 
       const annotationViewport = viewport.clone({ dontFlip: true });
       const annotationImageMap = await convertCanvasesToImages(
@@ -234,6 +234,7 @@ class Rasterize {
         renderForms,
         annotationCanvasMap: annotationImageMap,
       };
+      AnnotationLayer.setDimensions(div, annotationViewport);
       AnnotationLayer.render(parameters);
 
       // Inline SVG images from text annotations.

--- a/test/integration/freetext_editor_spec.js
+++ b/test/integration/freetext_editor_spec.js
@@ -42,7 +42,7 @@ describe("Editor", () => {
           });
 
           const data = "Hello PDF.js World !!";
-          await page.mouse.click(rect.x + 10, rect.y + 10);
+          await page.mouse.click(rect.x + 100, rect.y + 100);
           await page.type(`${editorPrefix}0 .internal`, data);
 
           const editorRect = await page.$eval(`${editorPrefix}0`, el => {
@@ -151,7 +151,7 @@ describe("Editor", () => {
           });
 
           const data = "Hello PDF.js World !!";
-          await page.mouse.click(rect.x + 10, rect.y + 10);
+          await page.mouse.click(rect.x + 100, rect.y + 100);
           await page.type(`${editorPrefix}5 .internal`, data);
 
           const editorRect = await page.$eval(`${editorPrefix}5`, el => {

--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -27,13 +27,14 @@
   position: absolute;
   top: 0;
   left: 0;
+  font-size: calc(100px * var(--scale-factor));
 }
 
 .annotationEditorLayer .freeTextEditor {
   position: absolute;
   background: transparent;
   border-radius: 3px;
-  padding: calc(var(--freetext-padding) * var(--zoom-factor));
+  padding: calc(var(--freetext-padding) * var(--scale-factor));
   resize: none;
   width: auto;
   height: auto;

--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -27,9 +27,30 @@
   }
 }
 
+[data-annotation-rotation="90"] {
+  transform: rotate(90deg) translateY(-100%);
+}
+[data-annotation-rotation="180"] {
+  transform: rotate(180deg) translate(-100%, -100%);
+}
+[data-annotation-rotation="270"] {
+  transform: rotate(270deg) translateX(-100%);
+}
+
+.annotationLayer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  font-size: calc(100px * var(--scale-factor));
+  pointer-events: none;
+  transform-origin: 0 0;
+}
+
 .annotationLayer section {
   position: absolute;
   text-align: initial;
+  pointer-events: auto;
+  box-sizing: border-box;
 }
 
 .annotationLayer .linkAnnotation > a,
@@ -43,10 +64,8 @@
 }
 
 .annotationLayer .buttonWidgetAnnotation.pushButton > canvas {
-  position: relative;
-  top: 0;
-  left: 0;
-  z-index: -1;
+  width: 100%;
+  height: 100%;
 }
 
 .annotationLayer .linkAnnotation > a:hover,
@@ -59,6 +78,8 @@
 .annotationLayer .textAnnotation img {
   position: absolute;
   cursor: pointer;
+  width: 100%;
+  height: 100%;
 }
 
 .annotationLayer .textWidgetAnnotation input,
@@ -69,7 +90,7 @@
   background-image: var(--annotation-unfocused-field-background);
   border: 1px solid transparent;
   box-sizing: border-box;
-  font: 9px sans-serif;
+  font: 9% sans-serif;
   height: 100%;
   margin: 0;
   vertical-align: top;
@@ -186,27 +207,31 @@
 
 .annotationLayer .popupWrapper {
   position: absolute;
-  width: 20em;
+  font-size: calc(9px * var(--scale-factor));
+  width: 100%;
+  min-width: calc(180px * var(--scale-factor));
+  pointer-events: none;
 }
 
 .annotationLayer .popup {
   position: absolute;
   z-index: 200;
-  max-width: 20em;
+  max-width: calc(180px * var(--scale-factor));
   background-color: rgba(255, 255, 153, 1);
-  box-shadow: 0 2px 5px rgba(136, 136, 136, 1);
-  border-radius: 2px;
-  padding: 6px;
-  margin-left: 5px;
+  box-shadow: 0 calc(2px * var(--scale-factor)) calc(5px * var(--scale-factor))
+    rgba(136, 136, 136, 1);
+  border-radius: calc(2px * var(--scale-factor));
+  padding: calc(6px * var(--scale-factor));
+  margin-left: calc(5px * var(--scale-factor));
   cursor: pointer;
   font: message-box;
-  font-size: 9px;
   white-space: normal;
   word-wrap: break-word;
+  pointer-events: auto;
 }
 
 .annotationLayer .popup > * {
-  font-size: 9px;
+  font-size: calc(9px * var(--scale-factor));
 }
 
 .annotationLayer .popup h1 {
@@ -215,17 +240,18 @@
 
 .annotationLayer .popupDate {
   display: inline-block;
-  margin-left: 5px;
+  margin-left: calc(5px * var(--scale-factor));
 }
 
 .annotationLayer .popupContent {
   border-top: 1px solid rgba(51, 51, 51, 1);
-  margin-top: 2px;
-  padding-top: 2px;
+  margin-top: calc(2px * var(--scale-factor));
+  padding-top: calc(2px * var(--scale-factor));
 }
 
 .annotationLayer .richText > * {
   white-space: pre-wrap;
+  font-size: calc(9px * var(--scale-factor));
 }
 
 .annotationLayer .highlightAnnotation,
@@ -243,4 +269,10 @@
 .annotationLayer .stampAnnotation,
 .annotationLayer .fileAttachmentAnnotation {
   cursor: pointer;
+}
+
+.annotationLayer section svg {
+  position: absolute;
+  width: 100%;
+  height: 100%;
 }

--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -117,11 +117,14 @@ class AnnotationLayerBuilder {
     if (this.div) {
       // If an annotationLayer already exists, refresh its children's
       // transformation matrices.
+      AnnotationLayer.setDimensions(this.div, viewport);
       AnnotationLayer.update(parameters);
     } else {
       // Create an annotation layer div and render the annotations
       // if there is at least one annotation.
       this.div = document.createElement("div");
+      AnnotationLayer.setDimensions(this.div, viewport);
+
       this.div.className = "annotationLayer";
       this.pageDiv.append(this.div);
       parameters.div = this.div;

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -1048,7 +1048,10 @@ class BaseViewer {
       return;
     }
 
-    docStyle.setProperty("--zoom-factor", newScale);
+    docStyle.setProperty(
+      "--scale-factor",
+      newScale * PixelsPerInch.PDF_TO_CSS_UNITS
+    );
 
     const updateArgs = { scale: newScale };
     for (const pageView of this._pages) {

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -377,7 +377,7 @@ class PDFPageView {
     });
 
     if (this._isStandalone) {
-      docStyle.setProperty("--zoom-factor", this.scale);
+      docStyle.setProperty("--scale-factor", this.viewport.scale);
     }
 
     if (this.svg) {

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -23,7 +23,7 @@
   --page-margin: 1px auto -8px;
   --page-border: 9px solid transparent;
   --spreadHorizontalWrapped-margin-LR: -3.5px;
-  --zoom-factor: 1;
+  --scale-factor: 1;
 }
 
 @media screen and (forced-colors: active) {


### PR DESCRIPTION
- each annotation has its coordinates/dimensions expressed in percentage,
  hence it's correctly positioned whatever the scale factor is;
- the font sizes are expressed in percentage too and the main font size
  is scaled thanks a css var (--scale-factor);
- the rotation is now applied on the div annotationLayer;
- this patch improve the rendering of some strings where the glyph spacing
  was not correct (it's a Firefox bug);
- it helps to simplify the code and it should slightly improve the update of
  page (on zoom or rotation).