### PR TITLE
Only define the `renderer`-option in the GENERIC viewer

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -521,7 +521,11 @@ const PDFViewerApplication = {
       findController,
       scriptingManager:
         AppOptions.get("enableScripting") && pdfScriptingManager,
-      renderer: AppOptions.get("renderer"),
+      renderer:
+        typeof PDFJSDev === "undefined" ||
+        PDFJSDev.test("!PRODUCTION || GENERIC")
+          ? AppOptions.get("renderer")
+          : null,
       l10n: this.l10n,
       textLayerMode: AppOptions.get("textLayerMode"),
       annotationMode: AppOptions.get("annotationMode"),

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -160,11 +160,6 @@ const defaultOptions = {
     value: 150,
     kind: OptionKind.VIEWER,
   },
-  renderer: {
-    /** @type {string} */
-    value: "canvas",
-    kind: OptionKind.VIEWER,
-  },
   sidebarViewOnLoad: {
     /** @type {number} */
     value: -1,
@@ -306,6 +301,11 @@ if (
     value: navigator.language || "en-US",
     kind: OptionKind.VIEWER,
   };
+  defaultOptions.renderer = {
+    /** @type {string} */
+    value: "canvas",
+    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+  };
   defaultOptions.sandboxBundleSrc = {
     /** @type {string} */
     value:
@@ -317,8 +317,6 @@ if (
 
   defaultOptions.annotationEditorEnabled.compatibility =
     compatibilityParams.annotationEditorEnabled;
-
-  defaultOptions.renderer.kind += OptionKind.PREFERENCE;
 } else if (PDFJSDev.test("CHROME")) {
   defaultOptions.disableTelemetry = {
     /** @type {boolean} */

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -137,7 +137,6 @@ const defaultOptions = {
   maxCanvasPixels: {
     /** @type {number} */
     value: 16777216,
-    compatibility: compatibilityParams.maxCanvasPixels,
     kind: OptionKind.VIEWER,
   },
   pageColorsBackground: {
@@ -314,9 +313,6 @@ if (
         : "../build/pdf.sandbox.js",
     kind: OptionKind.VIEWER,
   };
-
-  defaultOptions.annotationEditorEnabled.compatibility =
-    compatibilityParams.annotationEditorEnabled;
 } else if (PDFJSDev.test("CHROME")) {
   defaultOptions.disableTelemetry = {
     /** @type {boolean} */
@@ -344,7 +340,7 @@ class AppOptions {
     }
     const defaultOption = defaultOptions[name];
     if (defaultOption !== undefined) {
-      return defaultOption.compatibility ?? defaultOption.value;
+      return compatibilityParams[name] ?? defaultOption.value;
     }
     return undefined;
   }
@@ -376,7 +372,7 @@ class AppOptions {
       options[name] =
         userOption !== undefined
           ? userOption
-          : defaultOption.compatibility ?? defaultOption.value;
+          : compatibilityParams[name] ?? defaultOption.value;
     }
     return options;
   }

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -926,18 +926,13 @@ class PDFPageView {
 
   paintOnSvg(wrapper) {
     if (
-      typeof PDFJSDev !== "undefined" &&
-      PDFJSDev.test("MOZCENTRAL || CHROME")
+      !(
+        typeof PDFJSDev === "undefined" ||
+        PDFJSDev.test("!PRODUCTION || GENERIC")
+      )
     ) {
-      // Return a mock object, to prevent errors such as e.g.
-      // "TypeError: paintTask.promise is undefined".
-      return {
-        promise: Promise.reject(new Error("SVG rendering is not supported.")),
-        onRenderContinue(cont) {},
-        cancel() {},
-      };
+      throw new Error("Not implemented: paintOnSvg");
     }
-
     let cancelled = false;
     const ensureNotCancelled = () => {
       if (cancelled) {


### PR DESCRIPTION
Given that the SVG back-end is not defined anywhere except in GENERIC builds, we can remove a little bit of unnecessary code in e.g. the Firefox PDF Viewer.