### PR TITLE
[Editor] - Add the ability to directly draw after selecting ink tool

### DIFF
--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -54,6 +54,20 @@ class AnnotationEditor {
   }
 
   /**
+   * This editor will be behind the others.
+   */
+  setInBackground() {
+    this.div.classList.add("background");
+  }
+
+  /**
+   * This editor will be in the foreground.
+   */
+  setInForeground() {
+    this.div.classList.remove("background");
+  }
+
+  /**
    * onfocus callback.
    */
   focusin(/* event */) {
@@ -81,12 +95,16 @@ class AnnotationEditor {
 
     event.preventDefault();
 
+    this.commitOrRemove();
+    this.parent.setActiveEditor(null);
+  }
+
+  commitOrRemove() {
     if (this.isEmpty()) {
       this.remove();
     } else {
       this.commit();
     }
-    this.parent.setActiveEditor(null);
   }
 
   /**
@@ -156,7 +174,6 @@ class AnnotationEditor {
     this.div = document.createElement("div");
     this.div.className = this.name;
     this.div.setAttribute("id", this.id);
-    this.div.draggable = true;
     this.div.tabIndex = 100;
 
     const [tx, ty] = this.getInitialTranslation();

--- a/src/display/editor/freetext.js
+++ b/src/display/editor/freetext.js
@@ -33,6 +33,8 @@ class FreeTextEditor extends AnnotationEditor {
 
   #contentHTML = "";
 
+  #hasAlreadyBeenCommitted = false;
+
   #fontSize;
 
   static _freeTextDefaultContent = "";
@@ -168,6 +170,13 @@ class FreeTextEditor extends AnnotationEditor {
    * @returns {undefined}
    */
   commit() {
+    if (!this.#hasAlreadyBeenCommitted) {
+      // This editor has something and it's the first time
+      // it's commited so we can it in the undo/redo stack.
+      this.#hasAlreadyBeenCommitted = true;
+      this.parent.addUndoableEditor(this);
+    }
+
     this.disableEditMode();
     this.#contentHTML = this.editorDiv.innerHTML;
     this.#content = this.#extractText().trimEnd();

--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -63,8 +63,9 @@ class CommandManager {
    * Add a new couple of commands to be used in case of redo/undo.
    * @param {function} cmd
    * @param {function} undo
+   * @param {boolean} mustExec
    */
-  add(cmd, undo) {
+  add(cmd, undo, mustExec) {
     const save = [cmd, undo];
     const next = (this.#position + 1) % this.#maxSize;
     if (next !== this.#start) {
@@ -79,7 +80,10 @@ class CommandManager {
       this.#position = this.#commands.length - 1;
     }
     this.#setCommands(save);
-    cmd();
+
+    if (mustExec) {
+      cmd();
+    }
   }
 
   /**
@@ -316,6 +320,9 @@ class AnnotationEditorUIManager {
       this.#disableAll();
     } else {
       this.#enableAll();
+      for (const layer of this.#allLayers) {
+        layer.updateMode(mode);
+      }
     }
   }
 
@@ -409,9 +416,10 @@ class AnnotationEditorUIManager {
    * Add a command to execute (cmd) and another one to undo it.
    * @param {function} cmd
    * @param {function} undo
+   * @param {boolean} mustExec
    */
-  addCommands(cmd, undo) {
-    this.#commandManager.add(cmd, undo);
+  addCommands(cmd, undo, mustExec) {
+    this.#commandManager.add(cmd, undo, mustExec);
   }
 
   /**
@@ -460,7 +468,7 @@ class AnnotationEditorUIManager {
         }
       };
 
-      this.addCommands(cmd, undo);
+      this.addCommands(cmd, undo, true);
     } else {
       if (!this.#activeEditor) {
         return;
@@ -474,7 +482,7 @@ class AnnotationEditorUIManager {
       };
     }
 
-    this.addCommands(cmd, undo);
+    this.addCommands(cmd, undo, true);
   }
 
   /**
@@ -501,7 +509,7 @@ class AnnotationEditorUIManager {
         layer.addOrRebuild(editor);
       };
 
-      this.addCommands(cmd, undo);
+      this.addCommands(cmd, undo, true);
     }
   }
 
@@ -522,7 +530,7 @@ class AnnotationEditorUIManager {
       editor.remove();
     };
 
-    this.addCommands(cmd, undo);
+    this.addCommands(cmd, undo, true);
   }
 
   /**

--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -98,6 +98,11 @@
   overflow: auto;
   width: 100%;
   height: 100%;
+  z-index: 1;
+}
+
+.annotationEditorLayer .background {
+  z-index: 0;
 }
 
 .annotationEditorLayer .inkEditor:focus {


### PR DESCRIPTION
- Right now, we must select the tool, then click to select a page and
  click to start drawing and it's a bit painful;
- so just create a new ink editor when we're hovering a page without one.