### PR TITLE
Simplify setting the `defaultUrl`-option in the CHROME viewer (PR 12470 follow-up)

### DIFF
--- a/web/app_options.js
+++ b/web/app_options.js
@@ -74,11 +74,6 @@ const defaultOptions = {
     value: 0,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
-  defaultUrl: {
-    /** @type {string} */
-    value: "compressed.tracemonkey-pldi-09.pdf",
-    kind: OptionKind.VIEWER,
-  },
   defaultZoomValue: {
     /** @type {string} */
     value: "",
@@ -296,6 +291,11 @@ if (
   typeof PDFJSDev === "undefined" ||
   PDFJSDev.test("!PRODUCTION || GENERIC")
 ) {
+  defaultOptions.defaultUrl = {
+    /** @type {string} */
+    value: "compressed.tracemonkey-pldi-09.pdf",
+    kind: OptionKind.VIEWER,
+  };
   defaultOptions.disablePreferences = {
     /** @type {boolean} */
     value: typeof PDFJSDev !== "undefined" && PDFJSDev.test("TESTING"),
@@ -320,6 +320,11 @@ if (
 
   defaultOptions.renderer.kind += OptionKind.PREFERENCE;
 } else if (PDFJSDev.test("CHROME")) {
+  defaultOptions.defaultUrl = {
+    /** @type {string} */
+    value: "",
+    kind: OptionKind.VIEWER,
+  };
   defaultOptions.disableTelemetry = {
     /** @type {boolean} */
     value: false,

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -27,14 +27,12 @@ window.PDFViewerApplication = PDFViewerApplication;
 window.PDFViewerApplicationOptions = AppOptions;
 
 if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("CHROME")) {
-  var defaultUrl; // eslint-disable-line no-var
-
   (function rewriteUrlClosure() {
     // Run this code outside DOMContentLoaded to make sure that the URL
     // is rewritten as soon as possible.
     const queryString = document.location.search.slice(1);
     const m = /(^|&)file=([^&]*)/.exec(queryString);
-    defaultUrl = m ? decodeURIComponent(m[2]) : "";
+    const defaultUrl = m ? decodeURIComponent(m[2]) : "";
 
     // Example: chrome-extension://.../http://example.com/file.pdf
     const humanReadableUrl = "/" + defaultUrl + location.hash;
@@ -43,6 +41,8 @@ if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("CHROME")) {
       // eslint-disable-next-line no-undef
       chrome.runtime.sendMessage("showPageAction");
     }
+
+    AppOptions.set("defaultUrl", defaultUrl);
   })();
 }
 
@@ -222,10 +222,6 @@ function webViewerLoad() {
       PDFViewerApplication.run(config);
     });
   } else {
-    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("CHROME")) {
-      AppOptions.set("defaultUrl", defaultUrl);
-    }
-
     if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("GENERIC")) {
       // Give custom implementations of the default viewer a simpler way to
       // set various `AppOptions`, by dispatching an event once all viewer


### PR DESCRIPTION
This should really have been done as part of PR #12470, since it's now possible to directly set the `defaultUrl`-option without having to fallback to `var`-usage.