### PR TITLE
[api-minor] Remove the "baseviewerinit" event since it's unused (PR 14324 follow-up)

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -323,11 +323,6 @@ class BaseViewer {
       this.viewer.classList.add("removePageBorders");
     }
     this.updateContainerHeightCss();
-    // Defer the dispatching of this event, to give other viewer components
-    // time to initialize *and* register 'baseviewerinit' event listeners.
-    Promise.resolve().then(() => {
-      this.eventBus.dispatch("baseviewerinit", { source: this });
-    });
   }
 
   get pagesCount() {


### PR DESCRIPTION
Given that neither the viewer or the examples listen for this event, it seems unnecessary to keep dispatching it.