### PR TITLE
Reduce unnecessary usage of `Array.prototype.concat()`

### DIFF
--- a/external/builder/preprocessor2.js
+++ b/external/builder/preprocessor2.js
@@ -220,10 +220,11 @@ function postprocessNode(ctx, node) {
           case "BlockStatement":
             // Block statements inside a block are moved to the parent one.
             const subChildren = node.body[subExpressionIndex].body;
-            Array.prototype.splice.apply(
-              node.body,
-              [subExpressionIndex, 1].concat(subChildren)
-            );
+            Array.prototype.splice.apply(node.body, [
+              subExpressionIndex,
+              1,
+              ...subChildren,
+            ]);
             subExpressionIndex += Math.max(subChildren.length - 1, 0);
             continue;
           case "ReturnStatement":

--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -1387,7 +1387,7 @@ class CFFCompiler {
     const output = {
       data: [],
       length: 0,
-      add: function CFFCompiler_add(data) {
+      add(data) {
         this.data = this.data.concat(data);
         this.length = this.data.length;
       },
@@ -1680,7 +1680,7 @@ class CFFCompiler {
   }
 
   compileDict(dict, offsetTracker) {
-    let out = [];
+    const out = [];
     // The dictionary keys must be in a certain order.
     const order = dict.order;
     for (let i = 0; i < order.length; ++i) {
@@ -1708,7 +1708,7 @@ class CFFCompiler {
         switch (type) {
           case "num":
           case "sid":
-            out = out.concat(this.encodeNumber(value));
+            out.push(...this.encodeNumber(value));
             break;
           case "offset":
             // For offsets we just insert a 32bit integer so we don't have to
@@ -1720,20 +1720,20 @@ class CFFCompiler {
             if (!offsetTracker.isTracking(name)) {
               offsetTracker.track(name, out.length);
             }
-            out = out.concat([0x1d, 0, 0, 0, 0]);
+            out.push(0x1d, 0, 0, 0, 0);
             break;
           case "array":
           case "delta":
-            out = out.concat(this.encodeNumber(value));
+            out.push(...this.encodeNumber(value));
             for (let k = 1, kk = values.length; k < kk; ++k) {
-              out = out.concat(this.encodeNumber(values[k]));
+              out.push(...this.encodeNumber(values[k]));
             }
             break;
           default:
             throw new FormatError(`Unknown data type of ${type}`);
         }
       }
-      out = out.concat(dict.opcodes[key]);
+      out.push(...dict.opcodes[key]);
     }
     return out;
   }

--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -1663,13 +1663,13 @@ class SimpleSegmentVisitor {
       this.symbols = symbols = {};
     }
 
-    let inputSymbols = [];
-    for (let i = 0, ii = referredSegments.length; i < ii; i++) {
-      const referredSymbols = symbols[referredSegments[i]];
+    const inputSymbols = [];
+    for (const referredSegment of referredSegments) {
+      const referredSymbols = symbols[referredSegment];
       // referredSymbols is undefined when we have a reference to a Tables
       // segment instead of a SymbolDictionary.
       if (referredSymbols) {
-        inputSymbols = inputSymbols.concat(referredSymbols);
+        inputSymbols.push(...referredSymbols);
       }
     }
 
@@ -1696,13 +1696,13 @@ class SimpleSegmentVisitor {
 
     // Combines exported symbols from all referred segments
     const symbols = this.symbols;
-    let inputSymbols = [];
-    for (let i = 0, ii = referredSegments.length; i < ii; i++) {
-      const referredSymbols = symbols[referredSegments[i]];
+    const inputSymbols = [];
+    for (const referredSegment of referredSegments) {
+      const referredSymbols = symbols[referredSegment];
       // referredSymbols is undefined when we have a reference to a Tables
       // segment instead of a SymbolDictionary.
       if (referredSymbols) {
-        inputSymbols = inputSymbols.concat(referredSymbols);
+        inputSymbols.push(...referredSymbols);
       }
     }
     const symbolCodeLength = log2(inputSymbols.length);

--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -547,10 +547,7 @@ function expandBoundsLTR(width, bounds) {
       }
     }
 
-    Array.prototype.splice.apply(
-      horizon,
-      [i, j - i + 1].concat(changedHorizon)
-    );
+    Array.prototype.splice.apply(horizon, [i, j - i + 1, ...changedHorizon]);
   }
 
   // Set new x2 for all unset boundaries.


### PR DESCRIPTION
There are obviously cases where using `concat` makes perfect sense, since that method doesn't change any of the existing Arrays; see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/concat

However, in a few cases throughout the code-base that's not an issue and using `concat` only leads to unnecessary intermediate allocations. With modern JavaScript we can thus replace those with a combination of `push` and spread-syntax, which wasn't originally possible when the code was written.