### PR TITLE
Prevent the annotationLayer from overflowing (PR 15036 follow-up)

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -2506,18 +2506,19 @@ class AnnotationLayer {
     div.hidden = false;
   }
 
-  static setDimensions(div, viewport) {
-    const { width, height, rotation } = viewport;
+  /**
+   * @param {HTMLDivElement} div
+   * @param {PageViewport} viewport
+   */
+  static setDimensions(div, { width, height, rotation }) {
     const { style } = div;
 
-    if (rotation === 0 || rotation === 180) {
-      style.width = `${width}px`;
-      style.height = `${height}px`;
-    } else {
-      style.width = `${height}px`;
-      style.height = `${width}px`;
-    }
+    const flipOrientation = rotation % 180 !== 0,
+      intWidth = Math.floor(width) + "px",
+      intHeight = Math.floor(height) + "px";
 
+    style.width = flipOrientation ? intHeight : intWidth;
+    style.height = flipOrientation ? intWidth : intHeight;
     div.setAttribute("data-annotation-rotation", rotation);
   }
 

--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -41,6 +41,7 @@
   position: absolute;
   top: 0;
   left: 0;
+  overflow: hidden;
   font-size: calc(100px * var(--scale-factor));
   pointer-events: none;
   transform-origin: 0 0;


### PR DESCRIPTION
After the changes in PR #15036, in some cases the annotationLayer may cause an empty area to appear after the last page; one example is `f1040.pdf` in the test-suite.
This patch simply does the same thing as we already do in the textLayer, that is simply hide any overflow.

---

![overflow](https://user-images.githubusercontent.com/2692120/174488590-fc095124-73f9-4c75-b02a-39abcfe4f53b.png)

