### PR TITLE
Simplify the `newRefs` computation in the "SaveDocument"-handler in the worker-thread

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -349,7 +349,9 @@ class Page {
         );
       }
 
-      return Promise.all(newRefsPromises);
+      return Promise.all(newRefsPromises).then(function (newRefs) {
+        return newRefs.filter(newRef => !!newRef);
+      });
     });
   }
 

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -629,11 +629,7 @@ class WorkerMessageHandler {
               return stream.bytes;
             }
           } else {
-            for (const ref of refs) {
-              newRefs = ref
-                .filter(x => x !== null)
-                .reduce((a, b) => a.concat(b), newRefs);
-            }
+            newRefs = refs.flat(2);
 
             if (newRefs.length === 0) {
               // No new refs so just return the initial bytes


### PR DESCRIPTION
 - Let the `Page.save`-method filter out "empty" entries, similar to the `Page._parsedAnnotations`-getter, since that on its own already simplifies the "SaveDocument"-handler a tiny bit.

 - The existing `reduce` and `concat` construction isn't exactly a wonder of readability :-)
   Thanks to modern JavaScript features it should be possible to replace all of this with `Array.prototype.flat()` instead, which at least to me feels a lot easier to understand.