### PR TITLE
Ensure that the annotationLayer has the correct dimensions (PR 15036 follow-up)

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -2505,18 +2505,19 @@ class AnnotationLayer {
     div.hidden = false;
   }
 
-  static setDimensions(div, viewport) {
-    const { width, height, rotation } = viewport;
+  /**
+   * @param {HTMLDivElement} div
+   * @param {PageViewport} viewport
+   */
+  static setDimensions(div, { width, height, rotation }) {
     const { style } = div;
 
-    if (rotation === 0 || rotation === 180) {
-      style.width = `${width}px`;
-      style.height = `${height}px`;
-    } else {
-      style.width = `${height}px`;
-      style.height = `${width}px`;
-    }
+    const flipOrientation = rotation % 180 !== 0,
+      widthStr = Math.floor(width) + "px",
+      heightStr = Math.floor(height) + "px";
 
+    style.width = flipOrientation ? heightStr : widthStr;
+    style.height = flipOrientation ? widthStr : heightStr;
     div.setAttribute("data-annotation-rotation", rotation);
   }
 


### PR DESCRIPTION
Note how the "page"-div, "canvasWrapper"-div, and `textLayer`-div all have *integer* dimensions (rounded down) rather than using the "raw" viewport-dimensions.
Hence it seems reasonable that the same should apply to the "annotationLayer"-div, now that it's explicit dimensions set.