### PR TITLE
Add an outline around popup trigger areas in ref-tests

### DIFF
--- a/test/annotation_layer_builder_overrides.css
+++ b/test/annotation_layer_builder_overrides.css
@@ -17,7 +17,6 @@
 
 .annotationLayer {
   position: absolute;
-  font-size: calc(100px * var(--scale-factor));
 }
 
 .annotationLayer .buttonWidgetAnnotation.pushButton > img {
@@ -32,7 +31,8 @@
 }
 
 .annotationLayer .linkAnnotation > a,
-.annotationLayer .buttonWidgetAnnotation.pushButton > a {
+.annotationLayer .buttonWidgetAnnotation.pushButton > a,
+.annotationLayer .popupTriggerArea {
   opacity: 0.2;
   background: rgba(255, 255, 0, 1);
   box-shadow: 0 2px 10px rgba(255, 255, 0, 1);


### PR DESCRIPTION
- The goal is to avoid any future regressions.