### PR TITLE
Fix (obvious) typo in typedef-import of `IPDFXfaLayerFactory` (PR 14373 follow-up)

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -27,7 +27,7 @@
 /** @typedef {import("./interfaces").IPDFStructTreeLayerFactory} IPDFStructTreeLayerFactory */
 // eslint-disable-next-line max-len
 /** @typedef {import("./interfaces").IPDFTextLayerFactory} IPDFTextLayerFactory */
-/** @typedef {import("./interfaces").IL10n} IPDFXfaLayerFactory */
+/** @typedef {import("./interfaces").IPDFXfaLayerFactory} IPDFXfaLayerFactory */
 /** @typedef {import("./interfaces").IRenderableView} IRenderableView */
 // eslint-disable-next-line max-len
 /** @typedef {import("./pdf_rendering_queue").PDFRenderingQueue} PDFRenderingQueue */


### PR DESCRIPTION
This only affects the viewer-components TypeScript definitions, and not any actual code.