### PR TITLE
Correctly order added annotations when saving or printing

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -314,7 +314,6 @@ class Page {
       ...newData.annotations
     );
 
-    this.xref.resetNewRef();
     return objects;
   }
 

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -6638,8 +6638,7 @@
           "fontSize": 10,
           "value": "Hello World",
           "pageIndex": 0,
-          "rect": [67.5, 543, 119, 556.5],
-          "orderIndex": 0
+          "rect": [67.5, 543, 119, 556.5]
         },
         "pdfjs_internal_editor_1": {
           "annotationType": 15,
@@ -6662,8 +6661,7 @@
               ]
           }],
           "pageIndex": 0,
-          "rect": [71.5, 534.5, 115, 562],
-          "orderIndex": 1
+          "rect": [71.5, 534.5, 115, 562]
         }
       }
    }


### PR DESCRIPTION
- the annotations must be rendered in the same order as the chronological one.
- fix a bug in document.js which avoids to read a saved pdf correctly in Acrobat:
  there is no need to reset the xref state: it's done in worker.js once everything
  has been saved.