### PR TITLE
Add (basic) support for Optional Content in Annotations

### DIFF
--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -6561,6 +6561,16 @@
         }
       }
    },
+   {  "id": "bug1737260-oc",
+      "file": "pdfs/bug1737260.pdf",
+      "md5": "8bd4f810d30972764b07ae141a4afbc4",
+      "rounds": 1,
+      "link": true,
+      "type": "eq",
+      "optionalContent": {
+        "191R": false
+      }
+   },
    { "id": "bug1737260",
       "file": "pdfs/bug1737260.pdf",
       "md5": "8bd4f810d30972764b07ae141a4afbc4",


### PR DESCRIPTION
Given that Annotations can also have an `OC`-entry, we need to take that into account when generating their operatorLists.

Note that in order to simplify the patch the `getOperatorList`-methods, for the Annotation-classes, were converted to be `async`.