### PR TITLE
Remove element `id`s from the layersView in the sidebar

### DIFF
--- a/web/pdf_layer_viewer.js
+++ b/web/pdf_layer_viewer.js
@@ -153,14 +153,13 @@ class PDFLayerViewer extends BaseTreeViewer {
           const input = document.createElement("input");
           this._bindLink(element, { groupId, input });
           input.type = "checkbox";
-          input.id = groupId;
           input.checked = group.visible;
 
           const label = document.createElement("label");
-          label.setAttribute("for", groupId);
           label.textContent = this._normalizeTextContent(group.name);
 
-          element.append(input, label);
+          label.append(input);
+          element.append(label);
           layersCount++;
         }
 

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1156,11 +1156,15 @@ a:focus > .thumbnail > .thumbnailSelectionRing,
   cursor: pointer;
 }
 
-#layersView .treeItem > a > * {
+#layersView .treeItem > a * {
   cursor: pointer;
 }
 #layersView .treeItem > a > label {
   padding-inline-start: 4px;
+}
+#layersView .treeItem > a > label > input {
+  float: inline-start;
+  margin-top: 1px;
 }
 
 .treeItemToggler {


### PR DESCRIPTION
Similar to other recent patches, see e.g. PR #15057, we don't want to add these kind of `id`s to DOM-elements since they shouldn't become "linkable" through the URL hash.

*Please note:* This patch can be tested, in the viewer, with e.g. `bug1737260.pdf` from the test-suite.