### PR TITLE
fixed memory leak when layer offset lower than mask offset

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1127,12 +1127,9 @@ function genericComposeSMask(
   const chunkSize = Math.min(height, Math.ceil(PIXELS_TO_PROCESS / width));
   for (let row = 0; row < height; row += chunkSize) {
     const chunkHeight = Math.min(chunkSize, height - row);
-    const maskData = maskCtx.getImageData(
-      layerOffsetX - maskOffsetX,
-      row + (layerOffsetY - maskOffsetY),
-      width,
-      chunkHeight
-    );
+    const maskX = Math.max(0, layerOffsetX - maskOffsetX);
+    const maskY = Math.max(0, row + (layerOffsetY - maskOffsetY));
+    const maskData = maskCtx.getImageData(maskX, maskY, width, chunkHeight);
     const layerData = layerCtx.getImageData(
       layerOffsetX,
       row + layerOffsetY,


### PR DESCRIPTION
In some pdf files, the mask offset is larger than the layer offset. In this case first two parameters of the function `getImageData` become negative numbers and produce such a memory leak:

```
<--- Last few GCs --->

[3181:0x7f7aa3b00000]     7098 ms: Mark-sweep (reduce) 86.9 (130.2) -> 86.8 (90.7) MB, 109.2 / 0.0 ms  (average mu = 0.384, current mu = 0.000) external memory pressure GC in old space requested
[3181:0x7f7aa3b00000]     7170 ms: Mark-sweep (reduce) 86.8 (90.7) -> 86.7 (90.4) MB, 72.4 / 0.0 ms  (average mu = 0.261, current mu = 0.000) external memory pressure GC in old space requested


<--- JS stacktrace --->

FATAL ERROR: v8::ArrayBuffer::New Allocation failed - process out of memory
 1: 0x10a56f735 node::Abort() (.cold.1) [/usr/local/bin/node]
 2: 0x109151619 node::Abort() [/usr/local/bin/node]
 3: 0x10915178f node::OnFatalError(char const*, char const*) [/usr/local/bin/node]
 4: 0x1092d38c7 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [/usr/local/bin/node]
 5: 0x1092d3863 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [/usr/local/bin/node]
 6: 0x1092d35eb v8::internal::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*) [/usr/local/bin/node]
 7: 0x1092fb705 v8::ArrayBuffer::New(v8::Isolate*, unsigned long) [/usr/local/bin/node]
 8: 0x10e20b212 Context2d::GetImageData(Nan::FunctionCallbackInfo<v8::Value> const&) [node_modules/canvas/build/Release/canvas.node]
 9: 0x10e1f7d27 Nan::imp::FunctionCallbackWrapper(v8::FunctionCallbackInfo<v8::Value> const&) [node_modules/canvas/build/Release/canvas.node]
10: 0x10933c789 v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo) [/usr/local/bin/node]
11: 0x10933c256 v8::internal::MaybeHandle<v8::internal::Object> v8::internal::(anonymous namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::FunctionTemplateInfo>, v8::internal::Handle<v8::internal::Object>, v8::internal::BuiltinArguments) [/usr/local/bin/node]
12: 0x10933b9cf v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) [/usr/local/bin/node]
13: 0x109bf23b9 Builtins_CEntry_Return1_DontSaveFPRegs_ArgvOnStack_BuiltinExit [/usr/local/bin/node]
14: 0x10eed67a1
15: 0x109b8140e Builtins_InterpreterEntryTrampoline [/usr/local/bin/node]
```