### PR TITLE
Make a warning instead of an error when the required dereference cannot be obtained.

### DIFF
--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -766,7 +766,7 @@ class XRef {
       this._pendingRefs.remove(ref);
     } catch (ex) {
       this._pendingRefs.remove(ref);
-      throw ex;
+      //throw ex;
     }
     if (xrefEntry instanceof Dict) {
       xrefEntry.objId = ref.toString();

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -766,7 +766,7 @@ class XRef {
       this._pendingRefs.remove(ref);
     } catch (ex) {
       this._pendingRefs.remove(ref);
-      //throw ex;
+      warn(ex);
     }
     if (xrefEntry instanceof Dict) {
       xrefEntry.objId = ref.toString();


### PR DESCRIPTION
https://opensource.adobe.com/dc-acrobat-sdk-docs/standards/pdfstandards/pdf/PDF32000_2008.pdf

In PDF Reference, if there is no reference destination of indirect reference, it is treated as a null object without error.