### PR TITLE
[Editor] Improve a11y for newly added element (#15109)

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -265,3 +265,8 @@ editor_free_text_font_color=Font Color
 editor_free_text_font_size=Font Size
 editor_ink_line_color=Line Color
 editor_ink_line_thickness=Line Thickness
+
+# Editor aria
+editor_free_text_aria_label=FreeText Editor
+editor_ink_aria_label=Ink Editor
+editor_ink_canvas_aria_label=User-created image

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -601,7 +601,40 @@ function getColorValues(colors) {
   span.remove();
 }
 
+/**
+ * Use binary search to find the index of the first item in a given array which
+ * passes a given condition. The items are expected to be sorted in the sense
+ * that if the condition is true for one item in the array, then it is also true
+ * for all following items.
+ *
+ * @returns {number} Index of the first array element to pass the test,
+ *                   or |items.length| if no such element exists.
+ */
+function binarySearchFirstItem(items, condition, start = 0) {
+  let minIndex = start;
+  let maxIndex = items.length - 1;
+
+  if (maxIndex < 0 || !condition(items[maxIndex])) {
+    return items.length;
+  }
+  if (condition(items[minIndex])) {
+    return minIndex;
+  }
+
+  while (minIndex < maxIndex) {
+    const currentIndex = (minIndex + maxIndex) >> 1;
+    const currentItem = items[currentIndex];
+    if (condition(currentItem)) {
+      maxIndex = currentIndex;
+    } else {
+      minIndex = currentIndex + 1;
+    }
+  }
+  return minIndex; /* === maxIndex */
+}
+
 export {
+  binarySearchFirstItem,
   deprecated,
   DOMCanvasFactory,
   DOMCMapReaderFactory,

--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -220,7 +220,7 @@ class AnnotationEditor {
     this.div.setAttribute("data-editor-rotation", (360 - this.rotation) % 360);
     this.div.className = this.name;
     this.div.setAttribute("id", this.id);
-    this.div.tabIndex = 100;
+    this.div.tabIndex = 0;
 
     const [tx, ty] = this.getInitialTranslation();
     this.translate(tx, ty);
@@ -455,11 +455,38 @@ class AnnotationEditor {
   updateParams(type, value) {}
 
   /**
+   * When the user disables the editing mode some editors can change some of
+   * their properties.
+   */
+  disableEditing() {}
+
+  /**
+   * When the user enables the editing mode some editors can change some of
+   * their properties.
+   */
+  enableEditing() {}
+
+  /**
+   * Get the id to use in aria-owns when a link is done in the text layer.
+   * @returns {string}
+   */
+  getIdForTextLayer() {
+    return this.id;
+  }
+
+  /**
    * Get some properties to update in the UI.
    * @returns {Object}
    */
   get propertiesToUpdate() {
     return {};
+  }
+
+  /**
+   * Get the div which really contains the displayed content.
+   */
+  get contentDiv() {
+    return this.div;
   }
 }
 

--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -426,6 +426,8 @@ class AnnotationEditorUIManager {
 
   #boundOnPageChanging = this.onPageChanging.bind(this);
 
+  #boundOnTextLayerRendered = this.onTextLayerRendered.bind(this);
+
   #previousStates = {
     isEditing: false,
     isEmpty: true,
@@ -439,11 +441,13 @@ class AnnotationEditorUIManager {
     this.#eventBus = eventBus;
     this.#eventBus._on("editingaction", this.#boundOnEditingAction);
     this.#eventBus._on("pagechanging", this.#boundOnPageChanging);
+    this.#eventBus._on("textlayerrendered", this.#boundOnTextLayerRendered);
   }
 
   destroy() {
     this.#eventBus._off("editingaction", this.#boundOnEditingAction);
     this.#eventBus._off("pagechanging", this.#boundOnPageChanging);
+    this.#eventBus._off("textlayerrendered", this.#boundOnTextLayerRendered);
     for (const layer of this.#allLayers.values()) {
       layer.destroy();
     }
@@ -456,6 +460,12 @@ class AnnotationEditorUIManager {
 
   onPageChanging({ pageNumber }) {
     this.#currentPageIndex = pageNumber - 1;
+  }
+
+  onTextLayerRendered({ pageNumber }) {
+    const pageIndex = pageNumber - 1;
+    const layer = this.#allLayers.get(pageIndex);
+    layer?.onTextLayerRendered();
   }
 
   /**

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -41,15 +41,7 @@ import {
   VerbosityLevel,
 } from "./shared/util.js";
 import {
-  build,
-  getDocument,
-  LoopbackPort,
-  PDFDataRangeTransport,
-  PDFWorker,
-  setPDFNetworkStreamFactory,
-  version,
-} from "./display/api.js";
-import {
+  binarySearchFirstItem,
   getFilenameFromUrl,
   getPdfFilenameFromUrl,
   getXfaPageViewport,
@@ -60,6 +52,15 @@ import {
   PixelsPerInch,
   RenderingCancelledException,
 } from "./display/display_utils.js";
+import {
+  build,
+  getDocument,
+  LoopbackPort,
+  PDFDataRangeTransport,
+  PDFWorker,
+  setPDFNetworkStreamFactory,
+  version,
+} from "./display/api.js";
 import { AnnotationEditorLayer } from "./display/editor/annotation_editor_layer.js";
 import { AnnotationEditorUIManager } from "./display/editor/tools.js";
 import { AnnotationLayer } from "./display/annotation_layer.js";
@@ -116,6 +117,7 @@ export {
   AnnotationEditorUIManager,
   AnnotationLayer,
   AnnotationMode,
+  binarySearchFirstItem,
   build,
   CMapCompressionType,
   createPromiseCapability,

--- a/test/unit/display_utils_spec.js
+++ b/test/unit/display_utils_spec.js
@@ -14,6 +14,7 @@
  */
 
 import {
+  binarySearchFirstItem,
   DOMCanvasFactory,
   DOMSVGFactory,
   getFilenameFromUrl,
@@ -25,6 +26,39 @@ import { bytesToString } from "../../src/shared/util.js";
 import { isNodeJS } from "../../src/shared/is_node.js";
 
 describe("display_utils", function () {
+  describe("binary search", function () {
+    function isTrue(boolean) {
+      return boolean;
+    }
+    function isGreater3(number) {
+      return number > 3;
+    }
+
+    it("empty array", function () {
+      expect(binarySearchFirstItem([], isTrue)).toEqual(0);
+    });
+    it("single boolean entry", function () {
+      expect(binarySearchFirstItem([false], isTrue)).toEqual(1);
+      expect(binarySearchFirstItem([true], isTrue)).toEqual(0);
+    });
+    it("three boolean entries", function () {
+      expect(binarySearchFirstItem([true, true, true], isTrue)).toEqual(0);
+      expect(binarySearchFirstItem([false, true, true], isTrue)).toEqual(1);
+      expect(binarySearchFirstItem([false, false, true], isTrue)).toEqual(2);
+      expect(binarySearchFirstItem([false, false, false], isTrue)).toEqual(3);
+    });
+    it("three numeric entries", function () {
+      expect(binarySearchFirstItem([0, 1, 2], isGreater3)).toEqual(3);
+      expect(binarySearchFirstItem([2, 3, 4], isGreater3)).toEqual(2);
+      expect(binarySearchFirstItem([4, 5, 6], isGreater3)).toEqual(0);
+    });
+    it("three numeric entries and a start index", function () {
+      expect(binarySearchFirstItem([0, 1, 2, 3, 4], isGreater3, 2)).toEqual(4);
+      expect(binarySearchFirstItem([2, 3, 4], isGreater3, 2)).toEqual(2);
+      expect(binarySearchFirstItem([4, 5, 6], isGreater3, 1)).toEqual(1);
+    });
+  });
+
   describe("DOMCanvasFactory", function () {
     let canvasFactory;
 

--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -15,7 +15,6 @@
 
 import {
   backtrackBeforeAllVisibleElements,
-  binarySearchFirstItem,
   getPageSizeInches,
   getVisibleElements,
   isPortraitOrientation,
@@ -25,39 +24,6 @@ import {
 } from "../../web/ui_utils.js";
 
 describe("ui_utils", function () {
-  describe("binary search", function () {
-    function isTrue(boolean) {
-      return boolean;
-    }
-    function isGreater3(number) {
-      return number > 3;
-    }
-
-    it("empty array", function () {
-      expect(binarySearchFirstItem([], isTrue)).toEqual(0);
-    });
-    it("single boolean entry", function () {
-      expect(binarySearchFirstItem([false], isTrue)).toEqual(1);
-      expect(binarySearchFirstItem([true], isTrue)).toEqual(0);
-    });
-    it("three boolean entries", function () {
-      expect(binarySearchFirstItem([true, true, true], isTrue)).toEqual(0);
-      expect(binarySearchFirstItem([false, true, true], isTrue)).toEqual(1);
-      expect(binarySearchFirstItem([false, false, true], isTrue)).toEqual(2);
-      expect(binarySearchFirstItem([false, false, false], isTrue)).toEqual(3);
-    });
-    it("three numeric entries", function () {
-      expect(binarySearchFirstItem([0, 1, 2], isGreater3)).toEqual(3);
-      expect(binarySearchFirstItem([2, 3, 4], isGreater3)).toEqual(2);
-      expect(binarySearchFirstItem([4, 5, 6], isGreater3)).toEqual(0);
-    });
-    it("three numeric entries and a start index", function () {
-      expect(binarySearchFirstItem([0, 1, 2, 3, 4], isGreater3, 2)).toEqual(4);
-      expect(binarySearchFirstItem([2, 3, 4], isGreater3, 2)).toEqual(2);
-      expect(binarySearchFirstItem([4, 5, 6], isGreater3, 1)).toEqual(1);
-    });
-  });
-
   describe("isValidRotation", function () {
     it("should reject non-integer angles", function () {
       expect(isValidRotation()).toEqual(false);

--- a/web/annotation_editor_layer_builder.js
+++ b/web/annotation_editor_layer_builder.js
@@ -77,6 +77,7 @@ class AnnotationEditorLayerBuilder {
     this.div = document.createElement("div");
     this.div.className = "annotationEditorLayer";
     this.div.tabIndex = 0;
+    this.pageDiv.append(this.div);
 
     this.annotationEditorLayer = new AnnotationEditorLayer({
       uiManager: this.#uiManager,
@@ -84,6 +85,7 @@ class AnnotationEditorLayerBuilder {
       annotationStorage: this.annotationStorage,
       pageIndex: this.pdfPage._pageIndex,
       l10n: this.l10n,
+      viewport: clonedViewport,
     });
 
     const parameters = {
@@ -94,12 +96,11 @@ class AnnotationEditorLayerBuilder {
     };
 
     this.annotationEditorLayer.render(parameters);
-
-    this.pageDiv.append(this.div);
   }
 
   cancel() {
     this._cancelled = true;
+    this.destroy();
   }
 
   hide() {
@@ -121,8 +122,8 @@ class AnnotationEditorLayerBuilder {
       return;
     }
     this.pageDiv = null;
-    this.div.remove();
     this.annotationEditorLayer.destroy();
+    this.div.remove();
   }
 }
 

--- a/web/l10n_utils.js
+++ b/web/l10n_utils.js
@@ -83,6 +83,9 @@ const DEFAULT_L10N_STRINGS = {
     "Web fonts are disabled: unable to use embedded PDF fonts.",
 
   free_text_default_content: "Enter text…",
+  editor_free_text_aria_label: "FreeText Editor",
+  editor_ink_aria_label: "Ink Editor",
+  editor_ink_canvas_aria_label: "User-created image",
 };
 
 function getL10nFallback(key, args) {

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -17,9 +17,9 @@
 /** @typedef {import("./event_utils").EventBus} EventBus */
 /** @typedef {import("./interfaces").IPDFLinkService} IPDFLinkService */
 
-import { binarySearchFirstItem, scrollIntoView } from "./ui_utils.js";
-import { createPromiseCapability } from "pdfjs-lib";
+import { binarySearchFirstItem, createPromiseCapability } from "pdfjs-lib";
 import { getCharacterType } from "./pdf_find_utils.js";
+import { scrollIntoView } from "./ui_utils.js";
 
 const FindState = {
   FOUND: 0,

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+import { binarySearchFirstItem } from "pdfjs-lib";
+
 const DEFAULT_SCALE_VALUE = "auto";
 const DEFAULT_SCALE = 1.0;
 const DEFAULT_SCALE_DELTA = 1.1;
@@ -219,38 +221,6 @@ function removeNullCharacters(str, replaceInvisible = false) {
     str = str.replace(InvisibleCharactersRegExp, " ");
   }
   return str.replace(NullCharactersRegExp, "");
-}
-
-/**
- * Use binary search to find the index of the first item in a given array which
- * passes a given condition. The items are expected to be sorted in the sense
- * that if the condition is true for one item in the array, then it is also true
- * for all following items.
- *
- * @returns {number} Index of the first array element to pass the test,
- *                   or |items.length| if no such element exists.
- */
-function binarySearchFirstItem(items, condition, start = 0) {
-  let minIndex = start;
-  let maxIndex = items.length - 1;
-
-  if (maxIndex < 0 || !condition(items[maxIndex])) {
-    return items.length;
-  }
-  if (condition(items[minIndex])) {
-    return minIndex;
-  }
-
-  while (minIndex < maxIndex) {
-    const currentIndex = (minIndex + maxIndex) >> 1;
-    const currentItem = items[currentIndex];
-    if (condition(currentItem)) {
-      maxIndex = currentIndex;
-    } else {
-      minIndex = currentIndex + 1;
-    }
-  }
-  return minIndex; /* === maxIndex */
 }
 
 /**
@@ -840,7 +810,6 @@ export {
   approximateFraction,
   AutoPrintRegExp,
   backtrackBeforeAllVisibleElements, // only exported for testing
-  binarySearchFirstItem,
   DEFAULT_SCALE,
   DEFAULT_SCALE_DELTA,
   DEFAULT_SCALE_VALUE,


### PR DESCRIPTION
- In the annotationEditorLayer, reorder the editors in the DOM according
  the position of the elements on the screen;
- add an aria-owns attribute on the "nearest" element in the text layer
  which points to the added editor.