### PR TITLE
[editor] Introduce a proper `annotationEditorMode` option/preference (PR 15075 follow-up)

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -160,9 +160,9 @@
       ],
       "default": 2
     },
-    "annotationEditorEnabled": {
-      "type": "boolean",
-      "default": false
+    "annotationEditorMode": {
+      "type": "integer",
+      "default": -1
     },
     "enablePermissions": {
       "type": "boolean",

--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -258,7 +258,7 @@ editor_free_text_label=FreeText Annotation
 editor_ink.title=Add Ink Annotation
 editor_ink_label=Ink Annotation
 
-freetext_default_content=Enter some text…
+freetext_default_content=Enter text…
 
 # Editor Parameters
 editor_free_text_font_color=Font Color

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -55,6 +55,7 @@ const AnnotationMode = {
 const AnnotationEditorPrefix = "pdfjs_internal_editor_";
 
 const AnnotationEditorType = {
+  DISABLE: -1,
   NONE: 0,
   FREETEXT: 3,
   INK: 15,

--- a/web/app.js
+++ b/web/app.js
@@ -34,9 +34,8 @@ import {
   SpreadMode,
   TextLayerMode,
 } from "./ui_utils.js";
-import { AppOptions, OptionKind } from "./app_options.js";
-import { AutomationEventBus, EventBus } from "./event_utils.js";
 import {
+  AnnotationEditorType,
   build,
   createPromiseCapability,
   getDocument,
@@ -54,6 +53,8 @@ import {
   UNSUPPORTED_FEATURES,
   version,
 } from "pdfjs-lib";
+import { AppOptions, OptionKind } from "./app_options.js";
+import { AutomationEventBus, EventBus } from "./event_utils.js";
 import { CursorTool, PDFCursorTools } from "./pdf_cursor_tools.js";
 import { LinkTarget, PDFLinkService } from "./pdf_link_service.js";
 import { AnnotationEditorParams } from "./annotation_editor_params.js";
@@ -510,7 +511,7 @@ const PDFViewerApplication = {
 
     const container = appConfig.mainContainer,
       viewer = appConfig.viewerContainer;
-    const annotationEditorEnabled = AppOptions.get("annotationEditorEnabled");
+    const annotationEditorMode = AppOptions.get("annotationEditorMode");
     const pageColors = {
       background: AppOptions.get("pageColorsBackground"),
       foreground: AppOptions.get("pageColorsForeground"),
@@ -534,7 +535,7 @@ const PDFViewerApplication = {
       l10n: this.l10n,
       textLayerMode: AppOptions.get("textLayerMode"),
       annotationMode: AppOptions.get("annotationMode"),
-      annotationEditorEnabled,
+      annotationEditorMode,
       imageResourcesPath: AppOptions.get("imageResourcesPath"),
       enablePrintAutoRotate: AppOptions.get("enablePrintAutoRotate"),
       useOnlyCssZoom: AppOptions.get("useOnlyCssZoom"),
@@ -570,7 +571,7 @@ const PDFViewerApplication = {
       this.findBar = new PDFFindBar(appConfig.findBar, eventBus, this.l10n);
     }
 
-    if (annotationEditorEnabled) {
+    if (annotationEditorMode !== AnnotationEditorType.DISABLE) {
       this.annotationEditorParams = new AnnotationEditorParams(
         appConfig.annotationEditorParams,
         eventBus

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -59,11 +59,12 @@ const OptionKind = {
  *       primitive types and cannot rely on any imported types.
  */
 const defaultOptions = {
-  annotationEditorEnabled: {
+  annotationEditorMode: {
     /** @type {boolean} */
     value:
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING"),
+      typeof PDFJSDev === "undefined" || PDFJSDev.test("!PRODUCTION || TESTING")
+        ? 0
+        : -1,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
   annotationMode: {

--- a/web/l10n_utils.js
+++ b/web/l10n_utils.js
@@ -82,7 +82,7 @@ const DEFAULT_L10N_STRINGS = {
   web_fonts_disabled:
     "Web fonts are disabled: unable to use embedded PDF fonts.",
 
-  freetext_default_content: "Enter some text…",
+  freetext_default_content: "Enter text…",
 };
 
 function getL10nFallback(key, args) {

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -151,11 +151,11 @@ See https://github.com/adobe-type-tools/cmap-resources
           <div class="editorParamsToolbarContainer">
             <div class="editorParamsSetter">
               <label for="editorFreeTextColor" class="editorParamsLabel" data-l10n-id="editor_free_text_font_color">Font Color</label>
-              <input type="color" id="editorFreeTextColor" name="fontColor" class="editorParamsColor" tabindex="100">
+              <input type="color" id="editorFreeTextColor" class="editorParamsColor" tabindex="100">
             </div>
             <div class="editorParamsSetter">
               <label for="editorFreeTextFontSize" class="editorParamsLabel" data-l10n-id="editor_free_text_font_size">Font Size</label>
-              <input type="range" id="editorFreeTextFontSize" class="editorParamsSlider" name="fontSize" value="10" min="5" max="100" step="1" tabindex="101">
+              <input type="range" id="editorFreeTextFontSize" class="editorParamsSlider" value="10" min="5" max="100" step="1" tabindex="101">
             </div>
           </div>
         </div>
@@ -164,11 +164,11 @@ See https://github.com/adobe-type-tools/cmap-resources
           <div class="editorParamsToolbarContainer">
             <div class="editorParamsSetter">
               <label for="editorInkColor" class="editorParamsLabel" data-l10n-id="editor_ink_line_color">Line Color</label>
-              <input type="color" id="editorInkColor" name="inkColor" class="editorParamsColor" tabindex="102">
+              <input type="color" id="editorInkColor" class="editorParamsColor" tabindex="102">
             </div>
             <div class="editorParamsSetter">
               <label for="editorInkThickness" class="editorParamsLabel" data-l10n-id="editor_ink_line_thickness">Line Thickness</label>
-              <input type="range" id="editorInkThickness" class="editorParamsSlider" name="lineThickness" value="1" min="1" max="20" step="1" tabindex="103">
+              <input type="range" id="editorInkThickness" class="editorParamsSlider" value="1" min="1" max="20" step="1" tabindex="103">
             </div>
           </div>
         </div>


### PR DESCRIPTION
- [editor] Introduce a proper `annotationEditorMode` option/preference  (PR 15075 follow-up)

   This replaces the boolean `annotationEditorEnabled` option/preference with a "proper" `annotationEditorMode` one. This way it's not only possible for the user to control if Editing is enabled/disabled, but also which *specific* Editing-mode should become enabled upon PDF document load.

   Given that Editing is not enabled/released yet, I cannot imagine that changing the name and type of the option/preference should be an issue.

 - [editor] Remove the unused `name`-property from the editorParamsToolbars DOM elements

   As far as I can tell, this is completely unused and can thus be removed.

 - [editor] Slightly shorten the en-US `freetext_default_content` placeholder text

   Now that it's possible to change the font-size, this placeholder string feels a little bit long (especially for larger font-sizes).

   Given that Editing is not enabled/released yet, I hope that it should be fine to update this without changing the l10n-id.