### PR TITLE
Call `AnnotationLayer.setDimensions` as part of the `render`/`update`-methods (PR 15036 follow-up)

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -2457,12 +2457,16 @@ class AnnotationLayer {
    * @memberof AnnotationLayer
    */
   static render(parameters) {
+    const { annotations, div, viewport } = parameters;
+
+    this.#setDimensions(div, viewport);
+
     const sortedAnnotations = [],
       popupAnnotations = [];
     // Ensure that Popup annotations are handled last, since they're dependant
     // upon the parent annotation having already been rendered (please refer to
     // the `PopupAnnotationElement.render` method); fixes issue 11362.
-    for (const data of parameters.annotations) {
+    for (const data of annotations) {
       if (!data) {
         continue;
       }
@@ -2480,14 +2484,12 @@ class AnnotationLayer {
       sortedAnnotations.push(...popupAnnotations);
     }
 
-    const div = parameters.div;
-
     for (const data of sortedAnnotations) {
       const element = AnnotationElementFactory.create({
         data,
         layer: div,
         page: parameters.page,
-        viewport: parameters.viewport,
+        viewport,
         linkService: parameters.linkService,
         downloadManager: parameters.downloadManager,
         imageResourcesPath: parameters.imageResourcesPath || "",
@@ -2532,8 +2534,9 @@ class AnnotationLayer {
    * @memberof AnnotationLayer
    */
   static update(parameters) {
-    const { annotationCanvasMap, div } = parameters;
+    const { annotationCanvasMap, div, viewport } = parameters;
 
+    this.#setDimensions(div, viewport);
     this.#setAnnotationCanvasMap(div, annotationCanvasMap);
     div.hidden = false;
   }
@@ -2542,7 +2545,7 @@ class AnnotationLayer {
    * @param {HTMLDivElement} div
    * @param {PageViewport} viewport
    */
-  static setDimensions(div, { width, height, rotation }) {
+  static #setDimensions(div, { width, height, rotation }) {
     const { style } = div;
 
     const flipOrientation = rotation % 180 !== 0,

--- a/test/driver.js
+++ b/test/driver.js
@@ -231,7 +231,6 @@ class Rasterize {
         renderForms,
         annotationCanvasMap: annotationImageMap,
       };
-      AnnotationLayer.setDimensions(div, annotationViewport);
       AnnotationLayer.render(parameters);
 
       // Inline SVG images from text annotations.

--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -117,14 +117,11 @@ class AnnotationLayerBuilder {
     if (this.div) {
       // If an annotationLayer already exists, refresh its children's
       // transformation matrices.
-      AnnotationLayer.setDimensions(this.div, viewport);
       AnnotationLayer.update(parameters);
     } else {
       // Create an annotation layer div and render the annotations
       // if there is at least one annotation.
       this.div = document.createElement("div");
-      AnnotationLayer.setDimensions(this.div, viewport);
-
       this.div.className = "annotationLayer";
       this.pageDiv.append(this.div);
       parameters.div = this.div;


### PR DESCRIPTION
Rather than forcing the user to *manually* call `setDimensions`, which is also breaking any existing third-party code, it seems that we can simply let the `AnnotationLayer.{render, update}`-methods handle that internally.

As far as I can tell, based on testing manually in the viewer *and* running the browser-tests, everything still appears to work correctly with this patch.