### PR TITLE
Fix the Popup-trigger for `FileAttachmentAnnotationElement` (PR 15036 follow-up)

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -2400,8 +2400,7 @@ class FileAttachmentAnnotationElement extends AnnotationElement {
     this.container.className = "fileAttachmentAnnotation";
 
     const trigger = document.createElement("div");
-    trigger.style.height = this.container.style.height;
-    trigger.style.width = this.container.style.width;
+    trigger.className = "popupTriggerArea";
     trigger.addEventListener("dblclick", this._download.bind(this));
 
     if (


### PR DESCRIPTION
After the changes in PR #15036, the trigger-element created in `FileAttachmentAnnotationElement.render` is now too small. This can be fixed by using the same approach as in PR #15065, and the patch can be tested using the `annotation-fileattachment.pdf` document in the test-suite.