### PR TITLE
[Editor] Dispatch an event when some global states are changing (bug 1777695)

### DIFF
--- a/src/display/editor/annotation_editor_layer.js
+++ b/src/display/editor/annotation_editor_layer.js
@@ -67,7 +67,7 @@ class AnnotationEditorLayer {
         "mac+ctrl+Backspace",
         "mac+alt+Backspace",
       ],
-      AnnotationEditorLayer.prototype.suppress,
+      AnnotationEditorLayer.prototype.delete,
     ],
   ]);
 
@@ -129,6 +129,14 @@ class AnnotationEditorLayer {
   }
 
   /**
+   * Set the editing state.
+   * @param {boolean} isEditing
+   */
+  setEditingState(isEditing) {
+    this.#uiManager.setEditingState(isEditing);
+  }
+
+  /**
    * Mouseover callback.
    * @param {MouseEvent} event
    */
@@ -173,8 +181,8 @@ class AnnotationEditorLayer {
    * Suppress the selected editor or all editors.
    * @returns {undefined}
    */
-  suppress() {
-    this.#uiManager.suppress();
+  delete() {
+    this.#uiManager.delete();
   }
 
   /**
@@ -188,7 +196,7 @@ class AnnotationEditorLayer {
    * Cut the selected editor.
    */
   cut() {
-    this.#uiManager.cut(this);
+    this.#uiManager.cut();
   }
 
   /**
@@ -196,7 +204,7 @@ class AnnotationEditorLayer {
    * @returns {undefined}
    */
   paste() {
-    this.#uiManager.paste(this);
+    this.#uiManager.paste();
   }
 
   /**

--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -218,9 +218,25 @@ class AnnotationEditor {
     const [tx, ty] = this.getInitialTranslation();
     this.translate(tx, ty);
 
-    bindEvents(this, this.div, ["dragstart", "focusin", "focusout"]);
+    bindEvents(this, this.div, [
+      "dragstart",
+      "focusin",
+      "focusout",
+      "mousedown",
+    ]);
 
     return this.div;
+  }
+
+  /**
+   * Onmousedown callback.
+   * @param {MouseEvent} event
+   */
+  mousedown(event) {
+    if (event.button !== 0) {
+      // Avoid to focus this editor because of a non-left click.
+      event.preventDefault();
+    }
   }
 
   getRect(tx, ty) {
@@ -362,6 +378,11 @@ class AnnotationEditor {
    * @returns {undefined}
    */
   remove() {
+    if (!this.isEmpty()) {
+      // The editor is removed but it can be back at some point thanks to
+      // undo/redo so we must commit it before.
+      this.commit();
+    }
     this.parent.remove(this);
   }
 

--- a/src/display/editor/freetext.js
+++ b/src/display/editor/freetext.js
@@ -214,6 +214,7 @@ class FreeTextEditor extends AnnotationEditor {
 
   /** @inheritdoc */
   enableEditMode() {
+    this.parent.setEditingState(false);
     this.parent.updateToolbar(AnnotationEditorType.FREETEXT);
     super.enableEditMode();
     this.overlayDiv.classList.remove("enabled");
@@ -223,6 +224,7 @@ class FreeTextEditor extends AnnotationEditor {
 
   /** @inheritdoc */
   disableEditMode() {
+    this.parent.setEditingState(true);
     super.disableEditMode();
     this.overlayDiv.classList.add("enabled");
     this.editorDiv.contentEditable = false;
@@ -243,6 +245,12 @@ class FreeTextEditor extends AnnotationEditor {
   /** @inheritdoc */
   isEmpty() {
     return this.editorDiv.innerText.trim() === "";
+  }
+
+  /** @inheritdoc */
+  remove() {
+    this.parent.setEditingState(true);
+    super.remove();
   }
 
   /**
@@ -282,7 +290,7 @@ class FreeTextEditor extends AnnotationEditor {
   commit() {
     if (!this.#hasAlreadyBeenCommitted) {
       // This editor has something and it's the first time
-      // it's commited so we can it in the undo/redo stack.
+      // it's commited so we can add it in the undo/redo stack.
       this.#hasAlreadyBeenCommitted = true;
       this.parent.addUndoableEditor(this);
     }

--- a/src/display/editor/ink.js
+++ b/src/display/editor/ink.js
@@ -211,8 +211,12 @@ class InkEditor extends AnnotationEditor {
       return;
     }
 
+    if (!this.isEmpty()) {
+      this.commit();
+    }
+
     // Destroy the canvas.
-    this.canvas.width = this.canvas.heigth = 0;
+    this.canvas.width = this.canvas.height = 0;
     this.canvas.remove();
     this.canvas = null;
 
@@ -258,7 +262,10 @@ class InkEditor extends AnnotationEditor {
 
   /** @inheritdoc */
   isEmpty() {
-    return this.paths.length === 0;
+    return (
+      this.paths.length === 0 ||
+      (this.paths.length === 1 && this.paths[0].length === 0)
+    );
   }
 
   #getInitialBBox() {
@@ -415,7 +422,7 @@ class InkEditor extends AnnotationEditor {
    * @returns {undefined}
    */
   canvasMousedown(event) {
-    if (!this.isInEditMode() || this.#disableEditing) {
+    if (event.button !== 0 || !this.isInEditMode() || this.#disableEditing) {
       return;
     }
 
@@ -447,6 +454,9 @@ class InkEditor extends AnnotationEditor {
    * @returns {undefined}
    */
   canvasMouseup(event) {
+    if (event.button !== 0) {
+      return;
+    }
     if (this.isInEditMode() && this.currentPath.length !== 0) {
       event.stopPropagation();
       this.#endDrawing(event);

--- a/web/app.js
+++ b/web/app.js
@@ -186,6 +186,10 @@ class DefaultExternalServices {
   static get isInAutomation() {
     return shadow(this, "isInAutomation", false);
   }
+
+  static updateEditorStates(data) {
+    throw new Error("Not implemented: updateEditorStates");
+  }
 }
 
 const PDFViewerApplication = {
@@ -1954,6 +1958,12 @@ const PDFViewerApplication = {
       eventBus._on("fileinputchange", webViewerFileInputChange);
       eventBus._on("openfile", webViewerOpenFile);
     }
+    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
+      eventBus._on(
+        "annotationeditorstateschanged",
+        webViewerAnnotationEditorStatesChanged
+      );
+    }
   },
 
   bindWindowEvents() {
@@ -3074,6 +3084,10 @@ function beforeUnload(evt) {
   evt.preventDefault();
   evt.returnValue = "";
   return false;
+}
+
+function webViewerAnnotationEditorStatesChanged(data) {
+  PDFViewerApplication.externalServices.updateEditorStates(data);
 }
 
 /* Abstract factory for the print service. */

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -640,6 +640,10 @@ class BaseViewer {
       if (this._scriptingManager) {
         this._scriptingManager.setDocument(null);
       }
+      if (this.#annotationEditorUIManager) {
+        this.#annotationEditorUIManager.destroy();
+        this.#annotationEditorUIManager = null;
+      }
     }
 
     this.pdfDocument = pdfDocument;
@@ -899,7 +903,6 @@ class BaseViewer {
   }
 
   _resetView() {
-    this.#annotationEditorUIManager = null;
     this._pages = [];
     this._currentPageNumber = 1;
     this._currentScale = UNKNOWN_SCALE;

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -271,6 +271,20 @@ class MozL10n {
   window.addEventListener("save", handleEvent);
 })();
 
+(function listenEditingEvent() {
+  const handleEvent = function ({ detail }) {
+    if (!PDFViewerApplication.initialized) {
+      return;
+    }
+    PDFViewerApplication.eventBus.dispatch("editingaction", {
+      source: window,
+      name: detail.name,
+    });
+  };
+
+  window.addEventListener("editingaction", handleEvent);
+})();
+
 class FirefoxComDataRangeTransport extends PDFDataRangeTransport {
   requestDataRange(begin, end) {
     FirefoxCom.request("requestDataRange", { begin, end });
@@ -382,6 +396,10 @@ class FirefoxExternalServices extends DefaultExternalServices {
 
   static createPreferences() {
     return new FirefoxPreferences();
+  }
+
+  static updateEditorStates(data) {
+    FirefoxCom.request("updateEditorStates", data);
   }
 
   static createL10n(options) {


### PR DESCRIPTION
- this way the context menu in Firefox can take into account what we
  have in the clipboard, if an editor is selected, ...
- when the user will click on a context menu item, an action will be
  triggered, hence this patch adds what is required to handle it;
- some tests will be added in the Firefox' patch.