### PR TITLE
Ensure that the /Resources-entry is actually a dictionary (issue 15150)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -132,10 +132,12 @@ class Page {
     // For robustness: The spec states that a \Resources entry has to be
     // present, but can be empty. Some documents still omit it; in this case
     // we return an empty dictionary.
+    const resources = this._getInheritableProperty("Resources");
+
     return shadow(
       this,
       "resources",
-      this._getInheritableProperty("Resources") || Dict.empty
+      resources instanceof Dict ? resources : Dict.empty
     );
   }
 

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -509,6 +509,7 @@
 !poppler-67295-0.pdf
 !poppler-85140-0.pdf
 !issue15012.pdf
+!issue15150.pdf
 !poppler-395-0-fuzzed.pdf
 !GHOSTSCRIPT-698804-1-fuzzed.pdf
 !issue14814.pdf

--- a/test/pdfs/issue15150.pdf
+++ b/test/pdfs/issue15150.pdf
@@ -1,0 +1,24 @@
+%PDF-1.4
+1 0 obj <</Type /Catalog /Pages 2 0 R>>
+endobj
+2 0 obj <</Type /Pages /Kids [3 0 R] /Count 1>>
+endobj
+3 0 obj<</Type /Page /Parent 2 0 R /Resources 4 0 R /MediaBox [0 0 10 10] /Contents 4 0 R>>
+endobj
+4 0 obj
+<</Length 12>>
+stream
+0.5 w 1 0 0 RG 0 9.75 m 0.5 9.75 l s
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f
+0000000009 00000 n
+0000000056 00000 n
+0000000111 00000 n
+0000000210 00000 n
+trailer <</Size 5/Root 1 0 R>>
+startxref
+294
+%%EOF


### PR DESCRIPTION
Prevent issues in *corrupt* PDF documents, if the /Resources-entry is not of the correct and expected type.