### PR TITLE
Update `ttx` from version 2.5 to version 3.19.0

### DIFF
--- a/test/font/font_fpgm_spec.js
+++ b/test/font/font_fpgm_spec.js
@@ -31,7 +31,9 @@ describe("font_fpgm", function () {
 
       verifyTtxOutput(output);
       expect(
-        /(ENDF\[ \]|SVTCA\[0\])\s*<\/assembly>\s*<\/fpgm>/.test(output)
+        /(ENDF\[ \]|SVTCA\[0\])\s*\/\*.*\*\/\s*<\/assembly>\s*<\/fpgm>/.test(
+          output
+        )
       ).toEqual(true);
     });
   });

--- a/test/font/font_os2_spec.js
+++ b/test/font/font_os2_spec.js
@@ -30,7 +30,9 @@ describe("font_post", function () {
       const output = await ttx(font.data);
 
       verifyTtxOutput(output);
-      expect(/<OS_2>\s*<version value="3"\/>/.test(output)).toEqual(true);
+      expect(
+        /<OS_2>\s*<!--.*\r?\n.*-->\s*<version value="3"\/>/.test(output)
+      ).toEqual(true);
     });
 
     it("has invalid selection attributes presence", async function () {
@@ -51,7 +53,9 @@ describe("font_post", function () {
       const output = await ttx(font.data);
 
       verifyTtxOutput(output);
-      expect(/<OS_2>\s*<version value="3"\/>/.test(output)).toEqual(true);
+      expect(
+        /<OS_2>\s*<!--.*\r?\n.*-->\s*<version value="3"\/>/.test(output)
+      ).toEqual(true);
     });
   });
 });

--- a/test/font/ttxdriver.js
+++ b/test/font/ttxdriver.js
@@ -28,7 +28,7 @@ function runTtx(ttxResourcesHomePath, fontPath, registerOnCancel, callback) {
   fs.realpath(ttxResourcesHomePath, function (error, realTtxResourcesHomePath) {
     const fontToolsHome = path.join(realTtxResourcesHomePath, "fonttools-code");
     fs.realpath(fontPath, function (errorFontPath, realFontPath) {
-      const ttxPath = path.join("Tools", "ttx");
+      const ttxPath = path.join("Lib", "fontTools", "ttx.py");
       if (!fs.existsSync(path.join(fontToolsHome, ttxPath))) {
         callback("TTX was not found, please checkout PDF.js submodules");
         return;
@@ -38,7 +38,8 @@ function runTtx(ttxResourcesHomePath, fontPath, registerOnCancel, callback) {
         PYTHONDONTWRITEBYTECODE: true,
       };
       const ttxStdioMode = "ignore";
-      const ttx = spawn("python", [ttxPath, realFontPath], {
+      const python = process.platform !== "win32" ? "python2" : "python";
+      const ttx = spawn(python, [ttxPath, realFontPath], {
         cwd: fontToolsHome,
         stdio: ttxStdioMode,
         env: ttxEnv,

--- a/test/ttx/README.md
+++ b/test/ttx/README.md
@@ -1,3 +1,1 @@
 If `git clone --recursive` was not used, please run `git submodule init; git submodule update` to pull fonttools code.
-
-Note: python 2.6 for 32-bit is required to run ttx.


### PR DESCRIPTION
The current version 2.5 is from September 2014, which is almost 8 years old now. The new version 3.19.0 is from November 2017, which is still almost 5 years old, but is a step forward towards eventually using the most recent version. Note that we currently can't update any further; see #11802 for the details.

Fortunately using this newer version only required a few changes:

- The `ttx` output regexes needed updating to ignore comments that `ttx` now puts after some XML nodes (`<!-- ... -->` and `/* ... */`).
- The `ttx` invocation now explicitly uses `python2` since otherwise the font tests can't be run on modern systems anymore given that `python` is nowadays an alias for `python3`, and it now points at the new location of the `ttx.py` file since the `Tools` folder got removed.
- The note about needing a 32-bit Python 2.6 version is dropped since it's obsolete: this version (and also the existing one already) work just fine on a 64-bit Python 2.7 as well.

Fixes a part of #11802.