### PR TITLE
Enable the `unicorn/prefer-logical-operator-over-ternary` ESLint plugin rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -46,8 +46,8 @@
     }],
     "unicorn/no-abusive-eslint-disable": "error",
     "unicorn/no-array-push-push": "error",
-    "unicorn/no-new-buffer": "error",
     "unicorn/no-instanceof-array": "error",
+    "unicorn/no-new-buffer": "error",
     "unicorn/no-useless-spread": "error",
     "unicorn/prefer-array-flat": "error",
     "unicorn/prefer-array-flat-map": "error",
@@ -56,6 +56,7 @@
     "unicorn/prefer-date-now": "error",
     "unicorn/prefer-dom-node-append": "error",
     "unicorn/prefer-dom-node-remove": "error",
+    "unicorn/prefer-logical-operator-over-ternary": "error",
     "unicorn/prefer-modern-dom-apis": "error",
     "unicorn/prefer-string-starts-ends-with": "error",
 

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -1267,7 +1267,7 @@ class Font {
 
       // Read the table associated data
       const previousPosition = file.pos;
-      file.pos = file.start ? file.start : 0;
+      file.pos = file.start || 0;
       file.skip(offset);
       const data = file.getBytes(length);
       file.pos = previousPosition;
@@ -1405,7 +1405,7 @@ class Font {
         };
       }
       let segment;
-      let start = (file.start ? file.start : 0) + cmap.offset;
+      let start = (file.start || 0) + cmap.offset;
       file.pos = start;
 
       file.skip(2); // version
@@ -1717,7 +1717,7 @@ class Font {
         return;
       }
 
-      file.pos = (file.start ? file.start : 0) + header.offset;
+      file.pos = (file.start || 0) + header.offset;
       file.pos += 4; // version
       file.pos += 2; // ascent
       file.pos += 2; // descent
@@ -2081,7 +2081,7 @@ class Font {
     }
 
     function readPostScriptTable(post, propertiesObj, maxpNumGlyphs) {
-      const start = (font.start ? font.start : 0) + post.offset;
+      const start = (font.start || 0) + post.offset;
       font.pos = start;
 
       const length = post.length,
@@ -2151,7 +2151,7 @@ class Font {
     }
 
     function readNameTable(nameTable) {
-      const start = (font.start ? font.start : 0) + nameTable.offset;
+      const start = (font.start || 0) + nameTable.offset;
       font.pos = start;
 
       const names = [[], []];

--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -35,9 +35,8 @@ const Name = (function NameClosure() {
     }
 
     static get(name) {
-      const nameValue = nameCache[name];
       // eslint-disable-next-line no-restricted-syntax
-      return nameValue ? nameValue : (nameCache[name] = new Name(name));
+      return nameCache[name] || (nameCache[name] = new Name(name));
     }
 
     static _clearCache() {
@@ -65,9 +64,8 @@ const Cmd = (function CmdClosure() {
     }
 
     static get(cmd) {
-      const cmdValue = cmdCache[cmd];
       // eslint-disable-next-line no-restricted-syntax
-      return cmdValue ? cmdValue : (cmdCache[cmd] = new Cmd(cmd));
+      return cmdCache[cmd] || (cmdCache[cmd] = new Cmd(cmd));
     }
 
     static _clearCache() {
@@ -310,9 +308,8 @@ const Ref = (function RefClosure() {
 
     static get(num, gen) {
       const key = gen === 0 ? `${num}R` : `${num}R${gen}`;
-      const refValue = refCache[key];
       // eslint-disable-next-line no-restricted-syntax
-      return refValue ? refValue : (refCache[key] = new Ref(num, gen));
+      return refCache[key] || (refCache[key] = new Ref(num, gen));
     }
 
     static _clearCache() {

--- a/src/core/xfa/html_utils.js
+++ b/src/core/xfa/html_utils.js
@@ -247,7 +247,7 @@ function layoutNode(node, availableSpace) {
       }
     }
 
-    const maxWidth = (!node.w ? availableSpace.width : node.w) - marginH;
+    const maxWidth = (node.w || availableSpace.width) - marginH;
     const fontFinder = node[$globalData].fontFinder;
     if (
       node.value.exData &&

--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -457,7 +457,7 @@ class Arc extends XFAObject {
   }
 
   [$toHTML]() {
-    const edge = this.edge ? this.edge : new Edge({});
+    const edge = this.edge || new Edge({});
     const edgeStyle = edge[$toStyle]();
     const style = Object.create(null);
     if (this.fill && this.fill.presence === "visible") {
@@ -3650,7 +3650,7 @@ class Line extends XFAObject {
 
   [$toHTML]() {
     const parent = this[$getParent]()[$getParent]();
-    const edge = this.edge ? this.edge : new Edge({});
+    const edge = this.edge || new Edge({});
     const edgeStyle = edge[$toStyle]();
     const style = Object.create(null);
     const thickness = edge.presence === "visible" ? edge.thickness : 0;


### PR DESCRIPTION
This leads to ever so slightly more compact code, and can in some cases remove the need for a temporary variable.

Please find additional information here:
https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-logical-operator-over-ternary.md