### PR TITLE
[JS] Embedded JS scripts can have some null chars

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -982,7 +982,8 @@ class Catalog {
       if (javaScript === null) {
         javaScript = new Map();
       }
-      javaScript.set(name, stringToPDFString(js));
+      js = stringToPDFString(js).replace(/\u0000/g, "");
+      javaScript.set(name, js);
     }
 
     if (obj instanceof Dict && obj.has("JavaScript")) {

--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -339,7 +339,7 @@ function _collectJS(entry, xref, list, parents) {
       } else if (typeof js === "string") {
         code = js;
       }
-      code = code && stringToPDFString(code);
+      code = code && stringToPDFString(code).replace(/\u0000/g, "");
       if (code) {
         list.push(code);
       }


### PR DESCRIPTION
The pdf in https://bugzilla.mozilla.org/show_bug.cgi?id=1779742 contains some scripts with some null chars.
This patch aims to just remove them.