### PR TITLE
[Editor] Simplify the way to create an editor on click

### DIFF
--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -393,8 +393,6 @@ class AnnotationEditorUIManager {
 
   #allLayers = new Map();
 
-  #allowClick = true;
-
   #clipboardManager = new ClipboardManager();
 
   #commandManager = new CommandManager();
@@ -745,29 +743,12 @@ class AnnotationEditorUIManager {
   }
 
   /**
-   * When set to true a click on the current layer will trigger
-   * an editor creation.
-   * @return {boolean}
-   */
-  get allowClick() {
-    return this.#allowClick;
-  }
-
-  /**
-   * @param {boolean} allow
-   */
-  set allowClick(allow) {
-    this.#allowClick = allow;
-  }
-
-  /**
    * Unselect the current editor.
    */
   unselect() {
     if (this.#activeEditor) {
       this.#activeEditor.parent.setActiveEditor(null);
     }
-    this.#allowClick = true;
   }
 
   /**


### PR DESCRIPTION
Previously, we had to set the #allowClick property by hand which was
a bit painful because it's easy to overlook one case or an other.
So with this patch a new editor (for now FreeText one only because the
Ink one is a bit different) is created on the first click if none is selected
on mousedown, else the first click will just commit the data and then the
second will creater a new editor.