### PR TITLE
Support images with /Filter-entries that contain Arrays (issue 15220)

### DIFF
--- a/src/core/image.js
+++ b/src/core/image.js
@@ -103,25 +103,31 @@ class PDFImage {
     const dict = image.dict;
 
     const filter = dict.get("F", "Filter");
+    let filterName;
     if (filter instanceof Name) {
-      switch (filter.name) {
-        case "JPXDecode":
-          const jpxImage = new JpxImage();
-          jpxImage.parseImageProperties(image.stream);
-          image.stream.reset();
-
-          image.width = jpxImage.width;
-          image.height = jpxImage.height;
-          image.bitsPerComponent = jpxImage.bitsPerComponent;
-          image.numComps = jpxImage.componentsCount;
-          break;
-        case "JBIG2Decode":
-          image.bitsPerComponent = 1;
-          image.numComps = 1;
-          break;
+      filterName = filter.name;
+    } else if (Array.isArray(filter)) {
+      const filterZero = xref.fetchIfRef(filter[0]);
+      if (filterZero instanceof Name) {
+        filterName = filterZero.name;
       }
     }
-    // TODO cache rendered images?
+    switch (filterName) {
+      case "JPXDecode":
+        const jpxImage = new JpxImage();
+        jpxImage.parseImageProperties(image.stream);
+        image.stream.reset();
+
+        image.width = jpxImage.width;
+        image.height = jpxImage.height;
+        image.bitsPerComponent = jpxImage.bitsPerComponent;
+        image.numComps = jpxImage.componentsCount;
+        break;
+      case "JBIG2Decode":
+        image.bitsPerComponent = 1;
+        image.numComps = 1;
+        break;
+    }
 
     let width = dict.get("W", "Width");
     let height = dict.get("H", "Height");

--- a/test/pdfs/issue15220.pdf.link
+++ b/test/pdfs/issue15220.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/9178570/issue15220_page2.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -152,6 +152,14 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue15220",
+       "file": "pdfs/issue15220.pdf",
+       "md5": "0864a9e3860c0cb5e98b5eb23287fba4",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue11549",
        "file": "pdfs/issue11549_reduced.pdf",
        "md5": "a1ea636f413e02e10dbdf379ab4a99ae",


### PR DESCRIPTION
This patch "borrows" the code found in the `Parser.makeInlineImage`-method, to ensure that JBIG2 and JPX images can be rendered correctly.