### PR TITLE
[Editor] Avoid to add unexpected commands in the undo/redo queue when undoing/redoing (bug 1781790)

### DIFF
--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -66,6 +66,8 @@ class IdManager {
 class CommandManager {
   #commands = [];
 
+  #locked = false;
+
   #maxSize;
 
   #position = -1;
@@ -98,6 +100,10 @@ class CommandManager {
   }) {
     if (mustExec) {
       cmd();
+    }
+
+    if (this.#locked) {
+      return;
     }
 
     const save = { cmd, undo, type };
@@ -139,7 +145,12 @@ class CommandManager {
       // Nothing to undo.
       return;
     }
+
+    // Avoid to insert something during the undo execution.
+    this.#locked = true;
     this.#commands[this.#position].undo();
+    this.#locked = false;
+
     this.#position -= 1;
   }
 
@@ -149,7 +160,11 @@ class CommandManager {
   redo() {
     if (this.#position < this.#commands.length - 1) {
       this.#position += 1;
+
+      // Avoid to insert something during the redo execution.
+      this.#locked = true;
       this.#commands[this.#position].cmd();
+      this.#locked = false;
     }
   }
 

--- a/test/integration/freetext_editor_spec.js
+++ b/test/integration/freetext_editor_spec.js
@@ -197,6 +197,28 @@ describe("Editor", () => {
           }, `${editorPrefix}4`);
 
           expect(hasEditor).withContext(`In ${browserName}`).toEqual(false);
+
+          for (let i = 0; i < 2; i++) {
+            await page.keyboard.down("Control");
+            await page.keyboard.press("v");
+            await page.keyboard.up("Control");
+          }
+
+          let length = await page.evaluate(sel => {
+            return document.querySelectorAll(sel).length;
+          }, `${editorPrefix}5, ${editorPrefix}6`);
+          expect(length).withContext(`In ${browserName}`).toEqual(2);
+
+          for (let i = 0; i < 2; i++) {
+            await page.keyboard.down("Control");
+            await page.keyboard.press("z");
+            await page.keyboard.up("Control");
+          }
+
+          length = await page.evaluate(sel => {
+            return document.querySelectorAll(sel).length;
+          }, `${editorPrefix}5, ${editorPrefix}6`);
+          expect(length).withContext(`In ${browserName}`).toEqual(0);
         })
       );
     });
@@ -230,7 +252,7 @@ describe("Editor", () => {
             stacksRect.x + stacksRect.width + 1,
             stacksRect.y + stacksRect.height / 2
           );
-          await page.type(`${editorPrefix}5 .internal`, data);
+          await page.type(`${editorPrefix}7 .internal`, data);
 
           // Commit.
           await page.keyboard.press("Escape");
@@ -242,7 +264,7 @@ describe("Editor", () => {
 
           expect(ariaOwns)
             .withContext(`In ${browserName}`)
-            .toEqual(`${editorPrefix}5-editor`.slice(1));
+            .toEqual(`${editorPrefix}7-editor`.slice(1));
         })
       );
     });
@@ -265,9 +287,9 @@ describe("Editor", () => {
 
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.type(`${editorPrefix}6 .internal`, data);
+          await page.type(`${editorPrefix}8 .internal`, data);
 
-          const editorRect = await page.$eval(`${editorPrefix}6`, el => {
+          const editorRect = await page.$eval(`${editorPrefix}8`, el => {
             const { x, y, width, height } = el.getBoundingClientRect();
             return { x, y, width, height };
           });
@@ -277,7 +299,7 @@ describe("Editor", () => {
 
           expect(await getSelectedEditors(page))
             .withContext(`In ${browserName}`)
-            .toEqual([6]);
+            .toEqual([8]);
 
           await page.keyboard.press("Escape");
           expect(await getSelectedEditors(page))
@@ -291,7 +313,7 @@ describe("Editor", () => {
 
           expect(await getSelectedEditors(page))
             .withContext(`In ${browserName}`)
-            .toEqual([6]);
+            .toEqual([8]);
 
           // Escape.
           await page.keyboard.press("Escape");


### PR DESCRIPTION
We can undo/redo a command which will at some point add a command in the queue: typically
it can happening when redoing an addition.
So the idea is to lock the queue when undoing/redoing.