### PR TITLE
Misc. small CSS cleanup

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -424,7 +424,6 @@ select {
   height: auto;
   padding: 0 4px;
   margin: 4px 2px;
-  color: rgba(217, 217, 217, 1);
   font-size: 12px;
   line-height: 14px;
   text-align: left;

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -531,13 +531,18 @@ select {
 .editorParamsToolbarContainer .editorParamsSlider::-moz-range-progress {
   background-color: black;
 }
-.editorParamsToolbarContainer .editorParamsSlider::-moz-range-track,
-.editorParamsToolbarContainer
-  .editorParamsSlider::-webkit-slider-runnable-track {
+
+/*#if !MOZCENTRAL*/
+.editorParamsToolbarContainer .editorParamsSlider::-webkit-slider-runnable-track,
+/*#endif*/
+.editorParamsToolbarContainer .editorParamsSlider::-moz-range-track {
   background-color: black;
 }
-.editorParamsToolbarContainer .editorParamsSlider::-moz-range-thumb,
-.editorParamsToolbarContainer .editorParamsSlider::-webkit-slider-thumb {
+
+/*#if !MOZCENTRAL*/
+.editorParamsToolbarContainer .editorParamsSlider::-webkit-slider-thumb,
+/*#endif*/
+.editorParamsToolbarContainer .editorParamsSlider::-moz-range-thumb {
   background-color: white;
 }
 


### PR DESCRIPTION
 - Remove unnecessary `color` CSS property

   This property is first of all unused, and secondly it contained a static value which means that it'd not have worked correctly in light/dark themes.

 - [Firefox] Remove a couple of `webkit` CSS rules related to editing

   Thanks to the CSS preprocessor, we can get rid of a couple of unnecessary CSS rules in the Firefox PDF Viewer.