### PR TITLE
Ignore too small page-canvases in `PDFThumbnailView.setImage`

### DIFF
--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -352,12 +352,16 @@ class PDFThumbnailView {
     if (this.renderingState !== RenderingStates.INITIAL) {
       return;
     }
-    const { thumbnailCanvas: canvas, pdfPage } = pageView;
+    const { thumbnailCanvas: canvas, pdfPage, scale } = pageView;
     if (!canvas) {
       return;
     }
     if (!this.pdfPage) {
       this.setPdfPage(pdfPage);
+    }
+    if (scale < this.scale) {
+      // Avoid upscaling the image, since that makes the thumbnail look blurry.
+      return;
     }
     this.renderingState = RenderingStates.FINISHED;
     this._convertCanvasToImage(canvas);


### PR DESCRIPTION
It doesn't make sense to use a page-canvas that's *smaller* than the resulting thumbnail, since that causes the image to be upscaled which results in a blurry thumbnail. Note that this doesn't normally happen, unless a very small zoom-level is used in the viewer.