### PR TITLE
[api-minor] Update the minimum supported Safari version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -84,7 +84,7 @@ const AUTOPREFIXER_CONFIG = {
     "last 2 versions",
     "Chrome >= 76",
     "Firefox ESR",
-    "Safari >= 13",
+    "Safari >= 13.1",
     "> 1%",
     "not IE > 0",
     "not dead",

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -38,13 +38,6 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       compatibilityParams.maxCanvasPixels = 5242880;
     }
   })();
-
-  // Support: Safari<13.1
-  (function checkResizeObserver() {
-    if (typeof ResizeObserver === "undefined") {
-      compatibilityParams.annotationEditorMode = -1;
-    }
-  })();
 }
 
 const OptionKind = {

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -67,7 +67,6 @@ import {
 } from "./ui_utils.js";
 import { AnnotationEditorLayerBuilder } from "./annotation_editor_layer_builder.js";
 import { AnnotationLayerBuilder } from "./annotation_layer_builder.js";
-import { compatibilityParams } from "./app_options.js";
 import { NullL10n } from "./l10n_utils.js";
 import { PDFPageView } from "./pdf_page_view.js";
 import { PDFRenderingQueue } from "./pdf_rendering_queue.js";
@@ -85,9 +84,6 @@ const PagesCountLimit = {
   FORCE_LAZY_PAGE_INIT: 7500,
   PAUSE_EAGER_PAGE_INIT: 250,
 };
-
-const ANNOTATION_EDITOR_MODE =
-  compatibilityParams.annotationEditorMode ?? AnnotationEditorType.DISABLE;
 
 function isValidAnnotationEditorMode(mode) {
   return (
@@ -281,7 +277,7 @@ class BaseViewer {
     this.#annotationMode =
       options.annotationMode ?? AnnotationMode.ENABLE_FORMS;
     this.#annotationEditorMode =
-      options.annotationEditorMode ?? ANNOTATION_EDITOR_MODE;
+      options.annotationEditorMode ?? AnnotationEditorType.DISABLE;
     this.imageResourcesPath = options.imageResourcesPath || "";
     this.enablePrintAutoRotate = options.enablePrintAutoRotate || false;
     if (


### PR DESCRIPTION
The Ink-editor uses `ResizeObserver`, which is supported in all reasonably modern browsers; see https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver#browser_compatibility

With the exception of Safari, `ResizeObserver` is thus available in all of the browsers that the PDF.js library currently support. Rather than trying to e.g. add a polyfill, let's just bump the compatibility (slightly) to Safari 13.1 instead; see https://en.wikipedia.org/wiki/Safari_version_history#Safari_13