### PR TITLE
Don't include `images/toolbarButton-editorInk.svg` in the `gulp components` build (issue 15260)

### DIFF
--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -18,7 +18,11 @@
   --hover-outline: dashed 2px blue;
   --freetext-line-height: 1.35;
   --freetext-padding: 2px;
+  /*#if COMPONENTS*/
+  --editorInk-editing-cursor: pointer;
+  /*#else*/
   --editorInk-editing-cursor: url(images/toolbarButton-editorInk.svg) 0 16;
+  /*#endif*/
 }
 
 @media (forced-colors: active) {


### PR DESCRIPTION
Given that this image is intended specifically for the default viewer, we simply use the CSS preprocessor to remove the image reference in the `gulp components` build.
Considering that the issue only affects a CSS file, I don't believe that replacing the *just released* PDF.js version is actually necessary here.