### PR TITLE
[Annotation] Add a div containing the text of a FreeText annotation (bug 1780375)

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -536,7 +536,18 @@ class WorkerMessageHandler {
 
     handler.on("GetAnnotations", function ({ pageIndex, intent }) {
       return pdfManager.getPage(pageIndex).then(function (page) {
-        return page.getAnnotationsData(intent);
+        const task = new WorkerTask(`GetAnnotations: page ${pageIndex}`);
+        startWorkerTask(task);
+
+        return page.getAnnotationsData(handler, task, intent).then(
+          data => {
+            finishWorkerTask(task);
+            return data;
+          },
+          reason => {
+            finishWorkerTask(task);
+          }
+        );
       });
     });
 

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -1932,10 +1932,22 @@ class FreeTextAnnotationElement extends AnnotationElement {
       parameters.data.richText?.str
     );
     super(parameters, { isRenderable, ignoreBorder: true });
+    this.textContent = parameters.data.textContent;
   }
 
   render() {
     this.container.className = "freeTextAnnotation";
+
+    if (this.textContent) {
+      const content = document.createElement("div");
+      content.className = "annotationTextContent";
+      for (const line of this.textContent) {
+        const lineSpan = document.createElement("span");
+        lineSpan.textContent = line;
+        content.append(lineSpan);
+      }
+      this.container.append(content);
+    }
 
     if (!this.data.hasPopup) {
       this._createPopup(null, this.data);

--- a/test/annotation_layer_builder_overrides.css
+++ b/test/annotation_layer_builder_overrides.css
@@ -48,3 +48,13 @@
   margin: 0;
   padding: 0;
 }
+
+.annotationLayer .annotationTextContent {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  opacity: 0.4;
+  background-color: transparent;
+  color: red;
+  font-size: 10px;
+}

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -4101,6 +4101,35 @@ describe("annotation", function () {
         OPS.endAnnotation,
       ]);
     });
+
+    it("should extract the text from a FreeText annotation", async function () {
+      partialEvaluator.xref = new XRefMock();
+      const task = new WorkerTask("test FreeText text extraction");
+      const freetextAnnotation = (
+        await AnnotationFactory.printNewAnnotations(partialEvaluator, task, [
+          {
+            annotationType: AnnotationEditorType.FREETEXT,
+            rect: [12, 34, 56, 78],
+            rotation: 0,
+            fontSize: 10,
+            color: [0, 0, 0],
+            value: "Hello PDF.js\nWorld !",
+          },
+        ])
+      )[0];
+
+      await freetextAnnotation.extractTextContent(partialEvaluator, task, [
+        -Infinity,
+        -Infinity,
+        Infinity,
+        Infinity,
+      ]);
+
+      expect(freetextAnnotation.data.textContent).toEqual([
+        "Hello PDF.js",
+        "World !",
+      ]);
+    });
   });
 
   describe("InkAnnotation", function () {

--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -271,3 +271,18 @@
   width: 100%;
   height: 100%;
 }
+
+.annotationLayer .annotationTextContent {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  color: transparent;
+  user-select: none;
+  pointer-events: none;
+}
+
+.annotationLayer .annotationTextContent span {
+  width: 100%;
+  display: inline-block;
+}


### PR DESCRIPTION
An annotation doesn't have to be in the text flow, hence it's likely a bad idea
to insert its text in the text layer. But the text must be visible from a screen
reader point of view so it must somewhere in the DOM.
So with this patch, the text from a FreeText annotation is extracted and added in
a div in its HTML counterpart, and with the patch #15237 the text should be visible
and positioned relatively to the text flow.