### PR TITLE
[Editor] A pasted FreeText editor was missing when printing/saving

### DIFF
--- a/src/display/editor/annotation_editor_layer.js
+++ b/src/display/editor/annotation_editor_layer.js
@@ -426,7 +426,6 @@ class AnnotationEditorLayer {
    */
   add(editor) {
     this.#changeParent(editor);
-    this.addToAnnotationStorage(editor);
     this.#uiManager.addEditor(editor);
     this.attach(editor);
 
@@ -438,6 +437,7 @@ class AnnotationEditorLayer {
 
     this.moveDivInDOM(editor);
     editor.onceAdded();
+    this.addToAnnotationStorage(editor);
   }
 
   /**

--- a/test/integration/freetext_editor_spec.js
+++ b/test/integration/freetext_editor_spec.js
@@ -32,6 +32,11 @@ describe("Editor", () => {
       await closePages(pages);
     });
 
+    const countStorageEntries = async page =>
+      page.evaluate(
+        () => window.PDFViewerApplication.pdfDocument.annotationStorage.size
+      );
+
     it("must write a string in a FreeText editor", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
@@ -64,6 +69,10 @@ describe("Editor", () => {
             editorRect.y + 2 * editorRect.height
           );
 
+          expect(await countStorageEntries(page))
+            .withContext(`In ${browserName}`)
+            .toEqual(1);
+
           const content = await page.$eval(`${editorPrefix}0`, el =>
             el.innerText.trimEnd()
           );
@@ -94,6 +103,10 @@ describe("Editor", () => {
           await page.keyboard.press("v");
           await page.keyboard.up("Control");
 
+          expect(await countStorageEntries(page))
+            .withContext(`In ${browserName}`)
+            .toEqual(2);
+
           const content = await page.$eval(`${editorPrefix}0`, el =>
             el.innerText.trimEnd()
           );
@@ -113,6 +126,10 @@ describe("Editor", () => {
           await page.keyboard.down("Control");
           await page.keyboard.press("v");
           await page.keyboard.up("Control");
+
+          expect(await countStorageEntries(page))
+            .withContext(`In ${browserName}`)
+            .toEqual(3);
 
           pastedContent = await page.$eval(`${editorPrefix}2`, el =>
             el.innerText.trimEnd()
@@ -142,6 +159,10 @@ describe("Editor", () => {
 
             expect(hasEditor).withContext(`In ${browserName}`).toEqual(false);
           }
+
+          expect(await countStorageEntries(page))
+            .withContext(`In ${browserName}`)
+            .toEqual(0);
         })
       );
     });


### PR DESCRIPTION
When a FreeText editor is pasted then it hasn't an editorDiv yet when added
to the layer, hence it's empty.
So this patch just move the call to addToAnnotationStorage to ensure we've
what we need.