### PR TITLE
[Editor] Remove some a11y properties only useful when a FreeText editor is edited

### DIFF
--- a/src/display/editor/freetext.js
+++ b/src/display/editor/freetext.js
@@ -226,6 +226,7 @@ class FreeTextEditor extends AnnotationEditor {
     this.parent.setEditingState(false);
     this.parent.updateToolbar(AnnotationEditorType.FREETEXT);
     super.enableEditMode();
+    this.enableEditing();
     this.overlayDiv.classList.remove("enabled");
     this.editorDiv.contentEditable = true;
     this.div.draggable = false;
@@ -242,6 +243,7 @@ class FreeTextEditor extends AnnotationEditor {
 
     this.parent.setEditingState(true);
     super.disableEditMode();
+    this.disableEditing();
     this.overlayDiv.classList.add("enabled");
     this.editorDiv.contentEditable = false;
     this.div.draggable = true;


### PR DESCRIPTION
It aims to fix:
https://github.com/mozilla/pdf.js/pull/15237#issuecomment-1200656860