### PR TITLE
Remove the `extensions/firefox/README.mozilla` file (bug 1778567 follow-up)

### DIFF
--- a/extensions/firefox/README.mozilla
+++ b/extensions/firefox/README.mozilla
@@ -1,5 +1,0 @@
-This is the PDF.js project output, https://github.com/mozilla/pdf.js
-
-Current extension version is: PDFJSSCRIPT_VERSION
-
-Taken from upstream commit: PDFJSSCRIPT_COMMIT

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1266,7 +1266,6 @@ gulp.task(
       const MOZCENTRAL_DIR = BUILD_DIR + "mozcentral/",
         MOZCENTRAL_EXTENSION_DIR = MOZCENTRAL_DIR + "browser/extensions/pdfjs/",
         MOZCENTRAL_CONTENT_DIR = MOZCENTRAL_EXTENSION_DIR + "content/",
-        FIREFOX_EXTENSION_DIR = "extensions/firefox/",
         MOZCENTRAL_L10N_DIR =
           MOZCENTRAL_DIR + "browser/locales/en-US/pdfviewer/",
         FIREFOX_CONTENT_DIR = EXTENSION_SRC_DIR + "/firefox/content/";
@@ -1278,10 +1277,6 @@ gulp.task(
 
       // Clear out everything in the firefox extension build directory
       rimraf.sync(MOZCENTRAL_DIR);
-
-      const versionJSON = getVersionJSON();
-      const version = versionJSON.version,
-        commit = versionJSON.commit;
 
       return merge([
         createMainBundle(defines).pipe(
@@ -1325,11 +1320,6 @@ gulp.task(
         gulp
           .src("l10n/en-US/*.properties")
           .pipe(gulp.dest(MOZCENTRAL_L10N_DIR)),
-        gulp
-          .src(FIREFOX_EXTENSION_DIR + "README.mozilla")
-          .pipe(replace(/\bPDFJSSCRIPT_VERSION\b/g, version))
-          .pipe(replace(/\bPDFJSSCRIPT_COMMIT\b/g, commit))
-          .pipe(gulp.dest(MOZCENTRAL_EXTENSION_DIR)),
         gulp.src("LICENSE").pipe(gulp.dest(MOZCENTRAL_EXTENSION_DIR)),
         gulp
           .src(FIREFOX_CONTENT_DIR + "PdfJsDefaultPreferences.jsm")


### PR DESCRIPTION
With the changes made in [bug 1778567](https://bugzilla.mozilla.org/show_bug.cgi?id=1778567), it no longer seems correct to overwrite the mozilla-central file.