### PR TITLE
Move the `reset`-calls to occur last in the toolbar-constructors

### DIFF
--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -152,14 +152,14 @@ class SecondaryToolbar {
     this.eventBus = eventBus;
     this.opened = false;
 
-    this.reset();
-
     // Bind the event listeners for click, cursor tool, and scroll/spread mode
     // actions.
     this.#bindClickListeners();
     this.#bindCursorToolsListener(options);
     this.#bindScrollModeListener(options);
     this.#bindSpreadModeListener(options);
+
+    this.reset();
   }
 
   /**

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -53,6 +53,8 @@ const PAGE_NUMBER_LOADING_INDICATOR = "visiblePageIsLoading";
  */
 
 class Toolbar {
+  #wasLocalized = false;
+
   /**
    * @param {ToolbarOptions} options
    * @param {EventBus} eventBus
@@ -109,29 +111,28 @@ class Toolbar {
       editorInkParamsToolbar: options.editorInkParamsToolbar,
     };
 
-    this._wasLocalized = false;
     this.reset();
 
     // Bind the event listeners for click and various other actions.
-    this._bindListeners(options);
+    this.#bindListeners(options);
   }
 
   setPageNumber(pageNumber, pageLabel) {
     this.pageNumber = pageNumber;
     this.pageLabel = pageLabel;
-    this._updateUIState(false);
+    this.#updateUIState(false);
   }
 
   setPagesCount(pagesCount, hasPageLabels) {
     this.pagesCount = pagesCount;
     this.hasPageLabels = hasPageLabels;
-    this._updateUIState(true);
+    this.#updateUIState(true);
   }
 
   setPageScale(pageScaleValue, pageScale) {
     this.pageScaleValue = (pageScaleValue || pageScale).toString();
     this.pageScale = pageScale;
-    this._updateUIState(false);
+    this.#updateUIState(false);
   }
 
   reset() {
@@ -141,14 +142,14 @@ class Toolbar {
     this.pagesCount = 0;
     this.pageScaleValue = DEFAULT_SCALE_VALUE;
     this.pageScale = DEFAULT_SCALE;
-    this._updateUIState(true);
+    this.#updateUIState(true);
     this.updateLoadingIndicatorState();
 
     // Reset the Editor buttons too, since they're document specific.
     this.eventBus.dispatch("toolbarreset", { source: this });
   }
 
-  _bindListeners(options) {
+  #bindListeners(options) {
     const { pageNumber, scaleSelect } = this.items;
     const self = this;
 
@@ -203,9 +204,9 @@ class Toolbar {
     scaleSelect.oncontextmenu = noContextMenuHandler;
 
     this.eventBus._on("localized", () => {
-      this._wasLocalized = true;
+      this.#wasLocalized = true;
       this.#adjustScaleWidth();
-      this._updateUIState(true);
+      this.#updateUIState(true);
     });
 
     this.#bindEditorToolsListener(options);
@@ -244,6 +245,7 @@ class Toolbar {
       }
     };
     this.eventBus._on("annotationeditormodechanged", editorModeChanged);
+
     this.eventBus._on("toolbarreset", evt => {
       if (evt.source === this) {
         editorModeChanged(
@@ -254,8 +256,8 @@ class Toolbar {
     });
   }
 
-  _updateUIState(resetNumPages = false) {
-    if (!this._wasLocalized) {
+  #updateUIState(resetNumPages = false) {
+    if (!this.#wasLocalized) {
       // Don't update the UI state until we localize the toolbar.
       return;
     }

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -111,10 +111,10 @@ class Toolbar {
       editorInkParamsToolbar: options.editorInkParamsToolbar,
     };
 
-    this.reset();
-
     // Bind the event listeners for click and various other actions.
     this.#bindListeners(options);
+
+    this.reset();
   }
 
   setPageNumber(pageNumber, pageLabel) {


### PR DESCRIPTION
By invoking the `reset` methods *last* in the `Toolbar`/`SecondaryToolbar`-constructors, we ensure that the "toolbarreset"/"secondarytoolbarreset"-events are actually handle when the viewer loads. Note that previously those events were dispatched *before* the relevant event-listeners had been attached.
With this small change we can avoid inconsistent initial toolbar-state, specifically in the case when the viewer is *reloaded* (since Firefox keeps the HTML-state on "soft" reloads).