### PR TITLE
[GENERIC viewer] Export some viewer constants in the default viewer (issue 15294)

### DIFF
--- a/web/pdf_viewer.component.js
+++ b/web/pdf_viewer.component.js
@@ -24,7 +24,13 @@ import {
   PDFLinkService,
   SimpleLinkService,
 } from "./pdf_link_service.js";
-import { parseQueryString, ProgressBar } from "./ui_utils.js";
+import {
+  parseQueryString,
+  ProgressBar,
+  RenderingStates,
+  ScrollMode,
+  SpreadMode,
+} from "./ui_utils.js";
 import { PDFSinglePageViewer, PDFViewer } from "./pdf_viewer.js";
 import { AnnotationLayerBuilder } from "./annotation_layer_builder.js";
 import { DownloadManager } from "./download_manager.js";
@@ -64,7 +70,10 @@ export {
   PDFSinglePageViewer,
   PDFViewer,
   ProgressBar,
+  RenderingStates,
+  ScrollMode,
   SimpleLinkService,
+  SpreadMode,
   StructTreeLayerBuilder,
   TextLayerBuilder,
   XfaLayerBuilder,

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -13,7 +13,9 @@
  * limitations under the License.
  */
 
+import { RenderingStates, ScrollMode, SpreadMode } from "./ui_utils.js";
 import { AppOptions } from "./app_options.js";
+import { LinkTarget } from "./pdf_link_service.js";
 import { PDFViewerApplication } from "./app.js";
 
 /* eslint-disable-next-line no-unused-vars */
@@ -23,7 +25,13 @@ const pdfjsVersion =
 const pdfjsBuild =
   typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_BUILD") : void 0;
 
+const AppConstants =
+  typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")
+    ? { LinkTarget, RenderingStates, ScrollMode, SpreadMode }
+    : null;
+
 window.PDFViewerApplication = PDFViewerApplication;
+window.PDFViewerApplicationConstants = AppConstants;
 window.PDFViewerApplicationOptions = AppOptions;
 
 if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("CHROME")) {
@@ -270,4 +278,8 @@ if (
   document.addEventListener("DOMContentLoaded", webViewerLoad, true);
 }
 
-export { PDFViewerApplication, AppOptions as PDFViewerApplicationOptions };
+export {
+  PDFViewerApplication,
+  AppConstants as PDFViewerApplicationConstants,
+  AppOptions as PDFViewerApplicationOptions,
+};


### PR DESCRIPTION
This exports the same constants as the viewer components, but in the default viewer. To avoid bloating the global-scope the constants are added to a new `PDFViewerApplicationConstants` object[1], which also allows us to skip this in builds where it's not actually needed (e.g. the Firefox *built-in* PDF Viewer).

*Please note:* I'm not completely sold on this idea, and thus wouldn't mind the patch being rejected, since we probably don't want to export every single viewer constant this way. (And it may seem a bit arbitrary, to users, why some constants are exported and others are not.)

---
[1] Somewhat similar to the existing `PDFViewerApplicationOptions` structure.