### PR TITLE
Don't add `aria-owns` attributes for non-existent elements (PR 15237 follow-up)

### DIFF
--- a/web/text_accessibility.js
+++ b/web/text_accessibility.js
@@ -97,6 +97,13 @@ class TextAccessibilityManager {
       // we restore them.
       const textChildren = this.#textChildren;
       for (const [id, nodeIndex] of this.#textNodes) {
+        const element = document.getElementById(id);
+        if (!element) {
+          // If the page was *fully* reset the element no longer exists, and it
+          // will be re-inserted later (i.e. when the annotationLayer renders).
+          this.#textNodes.delete(id);
+          continue;
+        }
         this.#addIdToAriaOwns(id, textChildren[nodeIndex]);
       }
     }


### PR DESCRIPTION
Currently when the `TextAccessibilityManager.enabled` method is called, we'll update `aria-owns` for any pre-existing elements. This obviously makes sense when e.g. zooming/rotating in the viewer, since the annotationLayer/annotationEditorLayer is kept in those cases.
However when the page is *fully* reset, e.g. as result of going out-of-view and thus being evicted from the cache, we still keep the `#textNodes`-Map around. This causes us to set the `aria-owns` attribute (in the textLayer) for an element that doesn't actually exist any more, which as far as I'm concerned seems incorrect. In this case the element will simply, as already implemented, be re-inserted when the annotationLayer/annotationEditorLayer renders again.