### PR TITLE
Move `binarySearchFirstItem` back to the `web/`-folder (PR 15237 follow-up)

### DIFF
--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -611,38 +611,6 @@ function getColorValues(colors) {
   span.remove();
 }
 
-/**
- * Use binary search to find the index of the first item in a given array which
- * passes a given condition. The items are expected to be sorted in the sense
- * that if the condition is true for one item in the array, then it is also true
- * for all following items.
- *
- * @returns {number} Index of the first array element to pass the test,
- *                   or |items.length| if no such element exists.
- */
-function binarySearchFirstItem(items, condition, start = 0) {
-  let minIndex = start;
-  let maxIndex = items.length - 1;
-
-  if (maxIndex < 0 || !condition(items[maxIndex])) {
-    return items.length;
-  }
-  if (condition(items[minIndex])) {
-    return minIndex;
-  }
-
-  while (minIndex < maxIndex) {
-    const currentIndex = (minIndex + maxIndex) >> 1;
-    const currentItem = items[currentIndex];
-    if (condition(currentItem)) {
-      maxIndex = currentIndex;
-    } else {
-      minIndex = currentIndex + 1;
-    }
-  }
-  return minIndex; /* === maxIndex */
-}
-
 function getCurrentTransform(ctx) {
   const { a, b, c, d, e, f } = ctx.getTransform();
   return [a, b, c, d, e, f];
@@ -655,7 +623,6 @@ function getCurrentTransformInverse(ctx) {
 
 export {
   AnnotationPrefix,
-  binarySearchFirstItem,
   deprecated,
   DOMCanvasFactory,
   DOMCMapReaderFactory,

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -41,7 +41,15 @@ import {
   VerbosityLevel,
 } from "./shared/util.js";
 import {
-  binarySearchFirstItem,
+  build,
+  getDocument,
+  LoopbackPort,
+  PDFDataRangeTransport,
+  PDFWorker,
+  setPDFNetworkStreamFactory,
+  version,
+} from "./display/api.js";
+import {
   getFilenameFromUrl,
   getPdfFilenameFromUrl,
   getXfaPageViewport,
@@ -52,15 +60,6 @@ import {
   PixelsPerInch,
   RenderingCancelledException,
 } from "./display/display_utils.js";
-import {
-  build,
-  getDocument,
-  LoopbackPort,
-  PDFDataRangeTransport,
-  PDFWorker,
-  setPDFNetworkStreamFactory,
-  version,
-} from "./display/api.js";
 import { AnnotationEditorLayer } from "./display/editor/annotation_editor_layer.js";
 import { AnnotationEditorUIManager } from "./display/editor/tools.js";
 import { AnnotationLayer } from "./display/annotation_layer.js";
@@ -117,7 +116,6 @@ export {
   AnnotationEditorUIManager,
   AnnotationLayer,
   AnnotationMode,
-  binarySearchFirstItem,
   build,
   CMapCompressionType,
   createPromiseCapability,

--- a/test/unit/display_utils_spec.js
+++ b/test/unit/display_utils_spec.js
@@ -14,7 +14,6 @@
  */
 
 import {
-  binarySearchFirstItem,
   DOMCanvasFactory,
   DOMSVGFactory,
   getFilenameFromUrl,
@@ -26,39 +25,6 @@ import { bytesToString } from "../../src/shared/util.js";
 import { isNodeJS } from "../../src/shared/is_node.js";
 
 describe("display_utils", function () {
-  describe("binary search", function () {
-    function isTrue(boolean) {
-      return boolean;
-    }
-    function isGreater3(number) {
-      return number > 3;
-    }
-
-    it("empty array", function () {
-      expect(binarySearchFirstItem([], isTrue)).toEqual(0);
-    });
-    it("single boolean entry", function () {
-      expect(binarySearchFirstItem([false], isTrue)).toEqual(1);
-      expect(binarySearchFirstItem([true], isTrue)).toEqual(0);
-    });
-    it("three boolean entries", function () {
-      expect(binarySearchFirstItem([true, true, true], isTrue)).toEqual(0);
-      expect(binarySearchFirstItem([false, true, true], isTrue)).toEqual(1);
-      expect(binarySearchFirstItem([false, false, true], isTrue)).toEqual(2);
-      expect(binarySearchFirstItem([false, false, false], isTrue)).toEqual(3);
-    });
-    it("three numeric entries", function () {
-      expect(binarySearchFirstItem([0, 1, 2], isGreater3)).toEqual(3);
-      expect(binarySearchFirstItem([2, 3, 4], isGreater3)).toEqual(2);
-      expect(binarySearchFirstItem([4, 5, 6], isGreater3)).toEqual(0);
-    });
-    it("three numeric entries and a start index", function () {
-      expect(binarySearchFirstItem([0, 1, 2, 3, 4], isGreater3, 2)).toEqual(4);
-      expect(binarySearchFirstItem([2, 3, 4], isGreater3, 2)).toEqual(2);
-      expect(binarySearchFirstItem([4, 5, 6], isGreater3, 1)).toEqual(1);
-    });
-  });
-
   describe("DOMCanvasFactory", function () {
     let canvasFactory;
 

--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -15,6 +15,7 @@
 
 import {
   backtrackBeforeAllVisibleElements,
+  binarySearchFirstItem,
   getPageSizeInches,
   getVisibleElements,
   isPortraitOrientation,
@@ -24,6 +25,39 @@ import {
 } from "../../web/ui_utils.js";
 
 describe("ui_utils", function () {
+  describe("binary search", function () {
+    function isTrue(boolean) {
+      return boolean;
+    }
+    function isGreater3(number) {
+      return number > 3;
+    }
+
+    it("empty array", function () {
+      expect(binarySearchFirstItem([], isTrue)).toEqual(0);
+    });
+    it("single boolean entry", function () {
+      expect(binarySearchFirstItem([false], isTrue)).toEqual(1);
+      expect(binarySearchFirstItem([true], isTrue)).toEqual(0);
+    });
+    it("three boolean entries", function () {
+      expect(binarySearchFirstItem([true, true, true], isTrue)).toEqual(0);
+      expect(binarySearchFirstItem([false, true, true], isTrue)).toEqual(1);
+      expect(binarySearchFirstItem([false, false, true], isTrue)).toEqual(2);
+      expect(binarySearchFirstItem([false, false, false], isTrue)).toEqual(3);
+    });
+    it("three numeric entries", function () {
+      expect(binarySearchFirstItem([0, 1, 2], isGreater3)).toEqual(3);
+      expect(binarySearchFirstItem([2, 3, 4], isGreater3)).toEqual(2);
+      expect(binarySearchFirstItem([4, 5, 6], isGreater3)).toEqual(0);
+    });
+    it("three numeric entries and a start index", function () {
+      expect(binarySearchFirstItem([0, 1, 2, 3, 4], isGreater3, 2)).toEqual(4);
+      expect(binarySearchFirstItem([2, 3, 4], isGreater3, 2)).toEqual(2);
+      expect(binarySearchFirstItem([4, 5, 6], isGreater3, 1)).toEqual(1);
+    });
+  });
+
   describe("isValidRotation", function () {
     it("should reject non-integer angles", function () {
       expect(isValidRotation()).toEqual(false);

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -17,9 +17,9 @@
 /** @typedef {import("./event_utils").EventBus} EventBus */
 /** @typedef {import("./interfaces").IPDFLinkService} IPDFLinkService */
 
-import { binarySearchFirstItem, createPromiseCapability } from "pdfjs-lib";
+import { binarySearchFirstItem, scrollIntoView } from "./ui_utils.js";
+import { createPromiseCapability } from "pdfjs-lib";
 import { getCharacterType } from "./pdf_find_utils.js";
-import { scrollIntoView } from "./ui_utils.js";
 
 const FindState = {
   FOUND: 0,

--- a/web/text_accessibility.js
+++ b/web/text_accessibility.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { binarySearchFirstItem } from "pdfjs-lib";
+import { binarySearchFirstItem } from "./ui_utils.js";
 
 /**
  * This class aims to provide some methods:

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { binarySearchFirstItem } from "pdfjs-lib";
-
 const DEFAULT_SCALE_VALUE = "auto";
 const DEFAULT_SCALE = 1.0;
 const DEFAULT_SCALE_DELTA = 1.1;
@@ -224,6 +222,38 @@ function removeNullCharacters(str, replaceInvisible = false) {
     str = str.replace(InvisibleCharactersRegExp, " ");
   }
   return str.replace(NullCharactersRegExp, "");
+}
+
+/**
+ * Use binary search to find the index of the first item in a given array which
+ * passes a given condition. The items are expected to be sorted in the sense
+ * that if the condition is true for one item in the array, then it is also true
+ * for all following items.
+ *
+ * @returns {number} Index of the first array element to pass the test,
+ *                   or |items.length| if no such element exists.
+ */
+function binarySearchFirstItem(items, condition, start = 0) {
+  let minIndex = start;
+  let maxIndex = items.length - 1;
+
+  if (maxIndex < 0 || !condition(items[maxIndex])) {
+    return items.length;
+  }
+  if (condition(items[minIndex])) {
+    return minIndex;
+  }
+
+  while (minIndex < maxIndex) {
+    const currentIndex = (minIndex + maxIndex) >> 1;
+    const currentItem = items[currentIndex];
+    if (condition(currentItem)) {
+      maxIndex = currentIndex;
+    } else {
+      minIndex = currentIndex + 1;
+    }
+  }
+  return minIndex; /* === maxIndex */
 }
 
 /**
@@ -813,6 +843,7 @@ export {
   approximateFraction,
   AutoPrintRegExp,
   backtrackBeforeAllVisibleElements, // only exported for testing
+  binarySearchFirstItem,
   DEFAULT_SCALE,
   DEFAULT_SCALE_DELTA,
   DEFAULT_SCALE_VALUE,


### PR DESCRIPTION
This was moved into the `src/display/`-folder in PR #15110, for the initial editor-a11y patch. However, with the changes in PR #15237 we're again only using `binarySearchFirstItem` in the `web/`-folder and it thus seem reasonable to move it back there.
The primary reason for moving it back is that `binarySearchFirstItem` is currently exposed in the public API, and we always want to avoid that unless it's either PDF-related functionality or code that simply must be shared between the `src/`- and `web/`-folders. In this case, `binarySearchFirstItem` is a general helper function that doesn't really satisfy either of those alternatives.