### PR TITLE
Refresh the viewer if the window resolution changes (bug 1784850)

### DIFF
--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -2247,6 +2247,17 @@ class BaseViewer {
     }
     this.#annotationEditorUIManager.updateParams(type, value);
   }
+
+  refresh() {
+    if (!this.pdfDocument) {
+      return;
+    }
+    const updateArgs = {};
+    for (const pageView of this._pages) {
+      pageView.update(updateArgs);
+    }
+    this.update();
+  }
 }
 
 export { BaseViewer, PagesCountLimit, PDFPageViewBuffer };


### PR DESCRIPTION
*Please note:* This probably fixes bug 1784850, however I don't have the necessary hardware to reproduce the situation described in https://bugzilla.mozilla.org/show_bug.cgi?id=1784850#c0

Unfortunately it doesn't, as far as I can tell, appear possible to detect *all* resolution changes with a single media query. Instead we have to update it, and its listener, on every resolution change as outlined in [this MDN example](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio#monitoring_screen_resolution_or_zoom_level_changes).