### PR TITLE
Ignoring "resize" events during printing (issue 15324)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2514,7 +2514,12 @@ function webViewerSpreadModeChanged(evt) {
 }
 
 function webViewerResize() {
-  const { pdfDocument, pdfViewer } = PDFViewerApplication;
+  const { pdfDocument, pdfViewer, pdfRenderingQueue } = PDFViewerApplication;
+
+  if (pdfRenderingQueue.printing && window.matchMedia("print").matches) {
+    // Work-around issue 15324 by ignoring "resize" events during printing.
+    return;
+  }
   pdfViewer.updateContainerHeightCss();
 
   if (!pdfDocument) {


### PR DESCRIPTION
This is a quick work-around, to prevent the viewer from breaking as a result of https://bugzilla.mozilla.org/show_bug.cgi?id=774398