### PR TITLE
Improve handling of the "Cancel"-button in the password dialog

### DIFF
--- a/web/password_prompt.js
+++ b/web/password_prompt.js
@@ -53,7 +53,7 @@ class PasswordPrompt {
 
     // Attach the event listeners.
     this.submitButton.addEventListener("click", this.#verify.bind(this));
-    this.cancelButton.addEventListener("click", this.#cancel.bind(this));
+    this.cancelButton.addEventListener("click", this.close.bind(this));
     this.input.addEventListener("keydown", e => {
       if (e.keyCode === /* Enter = */ 13) {
         this.#verify();


### PR DESCRIPTION
The password dialog can be cancelled in three different ways:
 - By clicking on its "Cancel"-button.
 - By pressing the Escape-key.
 - By force-opening another dialog, although this shouldn't happen in practice.

Here the "Cancel"-button case is slightly special since it'll trigger `PasswordPrompt.#cancel` *twice*, first directly via the click and secondly via the "close" event on the `dialog`-element.
While this shouldn't, as far as I know, cause any bugs it's nonetheless inconsistent with the other cases outlined above. To improve this we can simply attempt to *close* the password dialog instead, and then rely on the "close" event to run the `PasswordPrompt.#cancel` method.