### PR TITLE
Use `AbortController` unconditionally with the Fetch API

### DIFF
--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -35,7 +35,7 @@ function createFetchOptions(headers, withCredentials, abortController) {
   return {
     method: "GET",
     headers,
-    signal: abortController?.signal,
+    signal: abortController.signal,
     mode: "cors",
     credentials: withCredentials ? "include" : "same-origin",
     redirect: "follow",
@@ -114,9 +114,7 @@ class PDFFetchStreamReader {
       this._disableRange = true;
     }
 
-    if (typeof AbortController !== "undefined") {
-      this._abortController = new AbortController();
-    }
+    this._abortController = new AbortController();
     this._isStreamingSupported = !source.disableStream;
     this._isRangeSupported = !source.disableRange;
 
@@ -207,9 +205,7 @@ class PDFFetchStreamReader {
     if (this._reader) {
       this._reader.cancel(reason);
     }
-    if (this._abortController) {
-      this._abortController.abort();
-    }
+    this._abortController.abort();
   }
 }
 
@@ -224,10 +220,7 @@ class PDFFetchStreamRangeReader {
     this._readCapability = createPromiseCapability();
     this._isStreamingSupported = !source.disableStream;
 
-    if (typeof AbortController !== "undefined") {
-      this._abortController = new AbortController();
-    }
-
+    this._abortController = new AbortController();
     this._headers = createHeaders(this._stream.httpHeaders);
     this._headers.append("Range", `bytes=${begin}-${end - 1}`);
 
@@ -274,9 +267,7 @@ class PDFFetchStreamRangeReader {
     if (this._reader) {
       this._reader.cancel(reason);
     }
-    if (this._abortController) {
-      this._abortController.abort();
-    }
+    this._abortController.abort();
   }
 }
 


### PR DESCRIPTION
Given the browsers that we currently support in the PDF.js project and the MDN compatibility data, see links below, it should no longer be necessary to check for the availability of `AbortController` before using it.
 - https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#faq-support
 - https://developer.mozilla.org/en-US/docs/Web/API/AbortController#browser_compatibility