### PR TITLE
[api-minor][editor] Indicate, in the title, if the document has been edited (bug 1785854)

### DIFF
--- a/src/display/annotation_storage.js
+++ b/src/display/annotation_storage.js
@@ -68,11 +68,20 @@ class AnnotationStorage {
    * Remove a value from the storage.
    * @param {string} key
    */
-  removeKey(key) {
+  remove(key) {
     this._storage.delete(key);
 
     if (this._storage.size === 0) {
       this.resetModified();
+    }
+
+    if (typeof this.onAnnotationEditor === "function") {
+      for (const value of this._storage.values()) {
+        if (value instanceof AnnotationEditor) {
+          return;
+        }
+      }
+      this.onAnnotationEditor(null);
     }
   }
 
@@ -170,15 +179,6 @@ class AnnotationStorage {
       }
     }
     return clone;
-  }
-
-  get hasAnnotationEditors() {
-    for (const value of this._storage.values()) {
-      if (value instanceof AnnotationEditor) {
-        return true;
-      }
-    }
-    return false;
   }
 
   /**

--- a/src/display/editor/annotation_editor_layer.js
+++ b/src/display/editor/annotation_editor_layer.js
@@ -207,7 +207,7 @@ class AnnotationEditorLayer {
 
     this.#uiManager.removeEditor(editor);
     this.detach(editor);
-    this.annotationStorage.removeKey(editor.id);
+    this.annotationStorage.remove(editor.id);
     editor.div.style.display = "none";
     setTimeout(() => {
       // When the div is removed from DOM the focus can move on the


### PR DESCRIPTION
Note that this patch prepends the document title with "* ", rather than only "*" as suggested in the bug, since there's nothing that says that a PDF document cannot specify a title[1] beginning with an asterisk. To reduce possible confusion, having a space between the "editing marker" and the actual document title thus cannot hurt as far as I'm concerned.

In order to notify the viewer when all `AnnotationEditor`s have been removed, we utilize the existing `onAnnotationEditor`-callback to allow the document title to be updated as necessary.

Finally, this patch makes the following (slightly unrelated) changes:
 - Rename the `AnnotationStorage.removeKey` method to just `AnnotationStorage.remove` instead. This is consistent with e.g. the `has`-method and should suffice to explain what it does.
 - Remove the `AnnotationStorage.hasAnnotationEditors` getter, since the viewer now tracks the necessary state internally. This avoids unnecessarily having to iterate through the `AnnotationStorage`-instance when saving/printing the document.

---
[1] Using either an /Info dictionary or a /Metadata stream.