### PR TITLE
Always focus the `viewerContainer` when entering PresentationMode (bug 1787456)

### DIFF
--- a/web/pdf_presentation_mode.js
+++ b/web/pdf_presentation_mode.js
@@ -99,6 +99,7 @@ class PDFPresentationMode {
 
     try {
       await promise;
+      pdfViewer.focus(); // Fixes bug 1787456.
       return true;
     } catch (reason) {
       this.#removeFullscreenChangeListeners();


### PR DESCRIPTION
This fixes the regression in [bug 1787456](https://bugzilla.mozilla.org/show_bug.cgi?id=1787456), assuming that it should be handled on the PDF.js side.