### PR TITLE
Update the Node.js `atob`/`btoa` compatibility info

### DIFF
--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -23,7 +23,7 @@ if (
 ) {
   globalThis._pdfjsCompatibilityChecked = true;
 
-  // Support: Node.js
+  // Support: Node.js<16.0.0
   (function checkNodeBtoa() {
     if (globalThis.btoa || !isNodeJS) {
       return;
@@ -34,7 +34,7 @@ if (
     };
   })();
 
-  // Support: Node.js
+  // Support: Node.js<16.0.0
   (function checkNodeAtob() {
     if (globalThis.atob || !isNodeJS) {
       return;


### PR DESCRIPTION
Given that Node.js has finally implemented native support for `atob`/`btoa`, it can't hurt to update the comments in `src/shared/compatibility.js` so that we don't forget to remove the polyfills once Node.js version `16` becomes the lowest supported LTS release; see
 - https://developer.mozilla.org/en-US/docs/Web/API/atob#browser_compatibility
 - https://developer.mozilla.org/en-US/docs/Web/API/btoa#browser_compatibility