### PR TITLE
[Editor] Avoid to update default params too early

### DIFF
--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -658,6 +658,10 @@ class AnnotationEditorUIManager {
    * @param {*} value
    */
   updateParams(type, value) {
+    if (!this.#editorTypes) {
+      return;
+    }
+
     for (const editor of this.#selectedEditors) {
       editor.updateParams(type, value);
     }


### PR DESCRIPTION
I got this exception in nightly:
```
Uncaught TypeError: can't access property Symbol.iterator, this[#editorTypes] is null
    updateParams resource://pdf.js/build/pdf.js:4393
    set annotationEditorParams resource://pdf.js/web/viewer.js:11521
    webViewerSwitchAnnotationEditorParams resource://pdf.js/web/viewer.js:3477
    dispatch resource://pdf.js/web/viewer.js:4133
    bindListeners resource://pdf.js/web/viewer.js:4496
```

I don't know how to reproduce the issue.