### PR TITLE
Don't allow `adjustToUnicode` to extend a built-in /ToUnicode map (issue 15352)

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -137,6 +137,9 @@ function adjustToUnicode(properties, builtInEncoding) {
   if (properties.isInternalFont) {
     return;
   }
+  if (properties.hasIncludedToUnicodeMap) {
+    return; // The font dictionary has a `ToUnicode` entry.
+  }
   if (builtInEncoding === properties.defaultEncoding) {
     return; // No point in trying to adjust `toUnicode` if the encodings match.
   }
@@ -146,11 +149,7 @@ function adjustToUnicode(properties, builtInEncoding) {
   const toUnicode = [],
     glyphsUnicodeMap = getGlyphsUnicode();
   for (const charCode in builtInEncoding) {
-    if (properties.hasIncludedToUnicodeMap) {
-      if (properties.toUnicode.has(charCode)) {
-        continue; // The font dictionary has a `ToUnicode` entry.
-      }
-    } else if (properties.hasEncoding) {
+    if (properties.hasEncoding) {
       if (
         properties.differences.length === 0 ||
         properties.differences[charCode] !== undefined

--- a/test/pdfs/issue15352.pdf.link
+++ b/test/pdfs/issue15352.pdf.link
@@ -1,0 +1,1 @@
+https://web.archive.org/web/20220903205442/https://pdf.cdn.readpaper.com/aiKnowledge/pdf/2022-05-06/d55ec560f4c142c3973abc66397d1822-/userUpload/d0edf452a85821acf41cbfa0a6f2f2ac.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2860,6 +2860,14 @@
        "link": false,
        "type": "text"
     },
+    {  "id": "issue15352",
+       "file": "pdfs/issue15352.pdf",
+       "md5": "d0edf452a85821acf41cbfa0a6f2f2ac",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "text"
+    },
     {  "id": "issue6962",
        "file": "pdfs/issue6962.pdf",
        "md5": "d40e871ecca68baf93114bd28c782148",


### PR DESCRIPTION
Given that the change in PR #13393 was slightly speculative, given the lack of test-cases, let's just revert part of that to fix the referenced issue.
Based on a quick look at old issues and existing test-cases, it seems that most (if not all) PDF documents that benefit from using the font-data in this way lack any /ToUnicode maps which should mean that they're unaffected by these changes.