### PR TITLE
Fallback to a standard font when a Type1 font program is empty (issue 15292)

### DIFF
--- a/src/core/type1_font.js
+++ b/src/core/type1_font.js
@@ -24,11 +24,11 @@ import {
   CFFStrings,
   CFFTopDict,
 } from "./cff_parser.js";
+import { FormatError, warn } from "../shared/util.js";
 import { SEAC_ANALYSIS_ENABLED, type1FontGlyphMapping } from "./fonts_utils.js";
 import { isWhiteSpace } from "./core_utils.js";
 import { Stream } from "./stream.js";
 import { Type1Parser } from "./type1_parser.js";
-import { warn } from "../shared/util.js";
 
 function findBlock(streamBytes, signature, startIndex) {
   const streamBytesLength = streamBytes.length;
@@ -140,6 +140,9 @@ function getEexecBlock(stream, suggestedLength) {
   // in the returned eexec block. In practice this does *not* seem to matter,
   // since `Type1Parser_extractFontProgram` will skip over any non-commands.
   const eexecBytes = stream.getBytes();
+  if (eexecBytes.length === 0) {
+    throw new FormatError("getEexecBlock - no font program found.");
+  }
   return {
     stream: new Stream(eexecBytes),
     length: eexecBytes.length,

--- a/test/pdfs/issue15292.pdf.link
+++ b/test/pdfs/issue15292.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/9288663/issue15292.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -153,6 +153,14 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue15292",
+       "file": "pdfs/issue15292.pdf",
+       "md5": "24297e183bf16cdd684dac8902e9fbe6",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue11549",
        "file": "pdfs/issue11549_reduced.pdf",
        "md5": "a1ea636f413e02e10dbdf379ab4a99ae",


### PR DESCRIPTION
*Please note:* This is only a, hopefully generally helpful, work-around rather than a proper solution to issue #15292.

There's something that's "special" about the Type1 fonts in the referenced PDF document, since we don't manage to find any actual font programs and thus cannot render anything.
Given that it shouldn't make sense for a Type1 font program to ever be empty, since that means that there's no glyph-data to render, we simply fallback to a standard font to at least try and render *something* in these rare cases.