### PR TITLE
Use more optional chaining in the code-base

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -380,9 +380,7 @@ class AnnotationElement {
     const commonActions = this._commonActions;
     for (const name of Object.keys(jsEvent.detail)) {
       const action = actions[name] || commonActions[name];
-      if (action) {
-        action(jsEvent);
-      }
+      action?.(jsEvent);
     }
   }
 
@@ -752,9 +750,7 @@ class LinkAnnotationElement extends AnnotationElement {
     }
 
     link.onclick = () => {
-      if (otherClickAction) {
-        otherClickAction();
-      }
+      otherClickAction?.();
 
       const {
         fields: resetFormFields,

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1354,9 +1354,7 @@ class PDFPageProxy {
     pageColors = null,
     printAnnotationStorage = null,
   }) {
-    if (this._stats) {
-      this._stats.time("Overall");
-    }
+    this._stats?.time("Overall");
 
     const intentArgs = this._transport.getRenderingIntent(
       intent,
@@ -1401,9 +1399,7 @@ class PDFPageProxy {
         separateAnnots: null,
       };
 
-      if (this._stats) {
-        this._stats.time("Page Request");
-      }
+      this._stats?.time("Page Request");
       this._pumpOperatorList(intentArgs);
     }
 
@@ -1427,10 +1423,9 @@ class PDFPageProxy {
       } else {
         internalRenderTask.capability.resolve();
       }
-      if (this._stats) {
-        this._stats.timeEnd("Rendering");
-        this._stats.timeEnd("Overall");
-      }
+
+      this._stats?.timeEnd("Rendering");
+      this._stats?.timeEnd("Overall");
     };
 
     const internalRenderTask = new InternalRenderTask({
@@ -1465,9 +1460,8 @@ class PDFPageProxy {
           complete();
           return;
         }
-        if (this._stats) {
-          this._stats.time("Rendering");
-        }
+        this._stats?.time("Rendering");
+
         internalRenderTask.initializeGraphics({
           transparency,
           optionalContentConfig,
@@ -1523,9 +1517,7 @@ class PDFPageProxy {
         separateAnnots: null,
       };
 
-      if (this._stats) {
-        this._stats.time("Page Request");
-      }
+      this._stats?.time("Page Request");
       this._pumpOperatorList(intentArgs);
     }
     return intentState.opListReadCapability.promise;
@@ -1697,14 +1689,11 @@ class PDFPageProxy {
     if (!intentState) {
       return; // Rendering was cancelled.
     }
-    if (this._stats) {
-      this._stats.timeEnd("Page Request");
-    }
+    this._stats?.timeEnd("Page Request");
+
     // TODO Refactor RenderPageRequest to separate rendering
     // and operator list logic
-    if (intentState.displayReadyCapability) {
-      intentState.displayReadyCapability.resolve(transparency);
-    }
+    intentState.displayReadyCapability?.resolve(transparency);
   }
 
   /**
@@ -3259,17 +3248,14 @@ class InternalRenderTask {
     });
     this.operatorListIdx = 0;
     this.graphicsReady = true;
-    if (this.graphicsReadyCallback) {
-      this.graphicsReadyCallback();
-    }
+    this.graphicsReadyCallback?.();
   }
 
   cancel(error = null) {
     this.running = false;
     this.cancelled = true;
-    if (this.gfx) {
-      this.gfx.endDrawing();
-    }
+    this.gfx?.endDrawing();
+
     if (this._canvas) {
       InternalRenderTask.#canvasInUse.delete(this._canvas);
     }
@@ -3289,10 +3275,7 @@ class InternalRenderTask {
       }
       return;
     }
-
-    if (this.stepper) {
-      this.stepper.updateOperatorList(this.operatorList);
-    }
+    this.stepper?.updateOperatorList(this.operatorList);
 
     if (this.running) {
       return;

--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -88,9 +88,8 @@ class PDFFetchStream {
   }
 
   cancelAllRequests(reason) {
-    if (this._fullRequestReader) {
-      this._fullRequestReader.cancel(reason);
-    }
+    this._fullRequestReader?.cancel(reason);
+
     for (const reader of this._rangeRequestReaders.slice(0)) {
       reader.cancel(reason);
     }
@@ -202,9 +201,7 @@ class PDFFetchStreamReader {
   }
 
   cancel(reason) {
-    if (this._reader) {
-      this._reader.cancel(reason);
-    }
+    this._reader?.cancel(reason);
     this._abortController.abort();
   }
 }
@@ -256,17 +253,14 @@ class PDFFetchStreamRangeReader {
       return { value, done };
     }
     this._loaded += value.byteLength;
-    if (this.onProgress) {
-      this.onProgress({ loaded: this._loaded });
-    }
+    this.onProgress?.({ loaded: this._loaded });
+
     const buffer = new Uint8Array(value).buffer;
     return { value: buffer, done: false };
   }
 
   cancel(reason) {
-    if (this._reader) {
-      this._reader.cancel(reason);
-    }
+    this._reader?.cancel(reason);
     this._abortController.abort();
   }
 }

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -402,9 +402,7 @@ class FontFaceObject {
       );
     }
 
-    if (this.fontRegistry) {
-      this.fontRegistry.registerFont(this);
-    }
+    this.fontRegistry?.registerFont(this);
     return nativeFontFace;
   }
 
@@ -426,9 +424,7 @@ class FontFaceObject {
       rule = `@font-face {font-family:"${this.cssFontInfo.fontFamily}";${css}src:${url}}`;
     }
 
-    if (this.fontRegistry) {
-      this.fontRegistry.registerFont(this, url);
-    }
+    this.fontRegistry?.registerFont(this, url);
     return rule;
   }
 

--- a/src/display/node_stream.js
+++ b/src/display/node_stream.js
@@ -95,9 +95,8 @@ class PDFNodeStream {
   }
 
   cancelAllRequests(reason) {
-    if (this._fullRequestReader) {
-      this._fullRequestReader.cancel(reason);
-    }
+    this._fullRequestReader?.cancel(reason);
+
     for (const reader of this._rangeRequestReaders.slice(0)) {
       reader.cancel(reason);
     }
@@ -252,9 +251,8 @@ class BaseRangeReader {
       return this.read();
     }
     this._loaded += chunk.length;
-    if (this.onProgress) {
-      this.onProgress({ loaded: this._loaded });
-    }
+    this.onProgress?.({ loaded: this._loaded });
+
     // Ensure that `read()` method returns ArrayBuffer.
     const buffer = new Uint8Array(chunk).buffer;
     return { value: buffer, done: false };

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -1543,9 +1543,7 @@ if (
     }
 
     eoFill() {
-      if (this.current.element) {
-        this.current.element.setAttributeNS(null, "fill-rule", "evenodd");
-      }
+      this.current.element?.setAttributeNS(null, "fill-rule", "evenodd");
       this.fill();
     }
 
@@ -1557,9 +1555,7 @@ if (
     }
 
     eoFillStroke() {
-      if (this.current.element) {
-        this.current.element.setAttributeNS(null, "fill-rule", "evenodd");
-      }
+      this.current.element?.setAttributeNS(null, "fill-rule", "evenodd");
       this.fillStroke();
     }
 

--- a/src/display/transport_stream.js
+++ b/src/display/transport_stream.js
@@ -105,9 +105,7 @@ class PDFDataTransportStream {
   }
 
   _onProgressiveDone() {
-    if (this._fullRequestReader) {
-      this._fullRequestReader.progressiveDone();
-    }
+    this._fullRequestReader?.progressiveDone();
     this._progressiveDone = true;
   }
 
@@ -144,9 +142,8 @@ class PDFDataTransportStream {
   }
 
   cancelAllRequests(reason) {
-    if (this._fullRequestReader) {
-      this._fullRequestReader.cancel(reason);
-    }
+    this._fullRequestReader?.cancel(reason);
+
     for (const reader of this._rangeReaders.slice(0)) {
       reader.cancel(reason);
     }

--- a/src/scripting_api/app.js
+++ b/src/scripting_api/app.js
@@ -100,16 +100,12 @@ class App extends PDFObject {
     const timeout = Object.create(null);
     const id = { callbackId, interval };
     this._timeoutIds.set(timeout, id);
-    if (this._timeoutIdsRegistry) {
-      this._timeoutIdsRegistry.register(timeout, id);
-    }
+    this._timeoutIdsRegistry?.register(timeout, id);
     return timeout;
   }
 
   _unregisterTimeout(timeout) {
-    if (this._timeoutIdsRegistry) {
-      this._timeoutIdsRegistry.unregister(timeout);
-    }
+    this._timeoutIdsRegistry?.unregister(timeout);
 
     const data = this._timeoutIds.get(timeout);
     if (!data) {

--- a/src/scripting_api/doc.js
+++ b/src/scripting_api/doc.js
@@ -950,10 +950,9 @@ class Doc extends PDFObject {
   }
 
   getPrintParams() {
-    if (!this._printParams) {
-      this._printParams = new PrintParams({ lastPage: this._numPages - 1 });
-    }
-    return this._printParams;
+    return (this._printParams ||= new PrintParams({
+      lastPage: this._numPages - 1,
+    }));
   }
 
   getSound() {

--- a/src/scripting_api/event.js
+++ b/src/scripting_api/event.js
@@ -91,9 +91,7 @@ class EventDispatcher {
       } else if (id === "app" && baseEvent.name === "ResetForm") {
         for (const fieldId of baseEvent.ids) {
           const obj = this._objects[fieldId];
-          if (obj) {
-            obj.obj._reset();
-          }
+          obj?.obj._reset();
         }
       }
       return;

--- a/test/test.js
+++ b/test/test.js
@@ -854,9 +854,7 @@ function unitTestPostHandler(req, res) {
       var onCancel = null,
         ttxTimeout = 10000;
       var timeoutId = setTimeout(function () {
-        if (onCancel) {
-          onCancel("TTX timeout");
-        }
+        onCancel?.("TTX timeout");
       }, ttxTimeout);
       translateFont(
         body,
@@ -1002,9 +1000,7 @@ function startBrowsers(initSessionCallback, makeStartUrl = null) {
     session.browserPromise = startBrowser(browserName, startUrl)
       .then(function (browser) {
         session.browser = browser;
-        if (initSessionCallback) {
-          initSessionCallback(session);
-        }
+        initSessionCallback?.(session);
       })
       .catch(function (ex) {
         console.log(`Error while starting ${browserName}: ${ex.message}`);
@@ -1050,10 +1046,7 @@ async function closeSession(browser) {
         const rimraf = require("rimraf");
         rimraf.sync(tempDir);
       }
-
-      if (onAllSessionsClosed) {
-        onAllSessionsClosed();
-      }
+      onAllSessionsClosed?.();
     }
   }
 }

--- a/web/base_viewer.js
+++ b/web/base_viewer.js
@@ -637,12 +637,9 @@ class BaseViewer {
       this._cancelRendering();
       this._resetView();
 
-      if (this.findController) {
-        this.findController.setDocument(null);
-      }
-      if (this._scriptingManager) {
-        this._scriptingManager.setDocument(null);
-      }
+      this.findController?.setDocument(null);
+      this._scriptingManager?.setDocument(null);
+
       if (this.#annotationEditorUIManager) {
         this.#annotationEditorUIManager.destroy();
         this.#annotationEditorUIManager = null;
@@ -807,12 +804,8 @@ class BaseViewer {
         // starts to create the correct size canvas. Wait until one page is
         // rendered so we don't tie up too many resources early on.
         this.#onePageRenderedOrForceFetch().then(async () => {
-          if (this.findController) {
-            this.findController.setDocument(pdfDocument); // Enable searching.
-          }
-          if (this._scriptingManager) {
-            this._scriptingManager.setDocument(pdfDocument); // Enable scripting.
-          }
+          this.findController?.setDocument(pdfDocument); // Enable searching.
+          this._scriptingManager?.setDocument(pdfDocument); // Enable scripting.
 
           if (this.#annotationEditorUIManager) {
             // Ensure that the Editor buttons, in the toolbar, are updated.

--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -45,9 +45,7 @@ const ChromeCom = {
     };
     if (!chrome.runtime) {
       console.error("chrome.runtime is undefined.");
-      if (callback) {
-        callback();
-      }
+      callback?.();
     } else if (callback) {
       chrome.runtime.sendMessage(message, callback);
     } else {

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -221,9 +221,7 @@ class PDFPageView {
 
   destroy() {
     this.reset();
-    if (this.pdfPage) {
-      this.pdfPage.cleanup();
-    }
+    this.pdfPage?.cleanup();
   }
 
   /**

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -231,10 +231,7 @@ class PDFThumbnailViewer {
         // Set the first `pdfPage` immediately, since it's already loaded,
         // rather than having to repeat the `PDFDocumentProxy.getPage` call in
         // the `this.#ensurePdfPageLoaded` method before rendering can start.
-        const firstThumbnailView = this._thumbnails[0];
-        if (firstThumbnailView) {
-          firstThumbnailView.setPdfPage(firstPdfPage);
-        }
+        this._thumbnails[0]?.setPdfPage(firstPdfPage);
 
         // Ensure that the current thumbnail is always highlighted on load.
         const thumbnailView = this._thumbnails[this._currentPageNumber - 1];


### PR DESCRIPTION
This patch updates a bunch of older code, that makes conditional function calls, to use optional chaining rather than `if`-blocks.

These mostly mechanical changes reduce the size of the `gulp mozcentral` build by a little over 1 kB.