### PR TITLE
[api-minor] Add a basic `requestIdleCallback` polyfill

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,6 +6,7 @@ external/bcmaps/
 external/webL10n/
 external/builder/fixtures/
 external/builder/fixtures_esprima/
+external/polyfill/
 external/quickjs/
 src/shared/cffStandardStrings.js
 src/shared/fonts_utils.js

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -6,6 +6,7 @@ external/bcmaps/
 external/webL10n/
 external/builder/fixtures/
 external/builder/fixtures_esprima/
+external/polyfill/
 external/quickjs/
 src/shared/cffStandardStrings.js
 src/shared/fonts_utils.js

--- a/external/polyfill/LICENSE
+++ b/external/polyfill/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Behnam Mohammadi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/external/polyfill/window.polyfill.js
+++ b/external/polyfill/window.polyfill.js
@@ -1,0 +1,62 @@
+/**
+ * window.requestIdleCallback()
+ * version 0.0.0
+ * Browser Compatibility:
+ * https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback#browser_compatibility
+ */
+if (!window.requestIdleCallback) {
+  window.requestIdleCallback = function (callback, options) {
+    var options = options || {};
+    var relaxation = 1;
+    var timeout = options.timeout || relaxation;
+    var start = performance.now();
+    return setTimeout(function () {
+      callback({
+        get didTimeout() {
+          return options.timeout ? false : (performance.now() - start) - relaxation > timeout;
+        },
+        timeRemaining: function () {
+          return Math.max(0, relaxation + (performance.now() - start));
+        },
+      });
+    }, relaxation);
+  };
+}
+
+/**
+* window.cancelIdleCallback()
+* version 0.0.0
+* Browser Compatibility:
+* https://developer.mozilla.org/en-US/docs/Web/API/Window/cancelIdleCallback#browser_compatibility
+*/
+if (!window.cancelIdleCallback) {
+  window.cancelIdleCallback = function (id) {
+    clearTimeout(id);
+  };
+}
+
+/**
+* window.requestAnimationFrame()
+* version 0.0.0
+* Browser Compatibility:
+* https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame#browser_compatibility
+*/
+if (!window.requestAnimationFrame) {
+  window.requestAnimationFrame = function (callback) {
+    return window.setTimeout(function () {
+      callback(Date.now());
+    }, 1000 / 60);
+  };
+}
+
+/**
+* window.cancelAnimationFrame()
+* version 0.0.0
+* Browser Compatibility:
+* https://developer.mozilla.org/en-US/docs/Web/API/Window/cancelAnimationFrame#browser_compatibility
+*/
+if (!window.cancelAnimationFrame) {
+  window.cancelAnimationFrame = function (id) {
+    clearTimeout(id);
+  };
+}

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -93,4 +93,15 @@ if (
     }
     require("core-js/web/structured-clone.js");
   })();
+
+  // Support: Safari
+  (function checkRequestIdleCallback() {
+    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("IMAGE_DECODERS")) {
+      return;
+    }
+    if (typeof window === "undefined" || window.requestIdleCallback) {
+      return;
+    }
+    require("../../external/polyfill/window.polyfill.js");
+  })();
 }


### PR DESCRIPTION
According to the MDN compatibility data, all browsers *except* Safari have been supporting `requestIdleCallback` since many years: https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback#browser_compatibility

Furthermore, according to the "Notes"-section at the following link, `requestIdleCallback` is actually implemented but not enabled (by default) in Safari: https://caniuse.com/requestidlecallback

Hence, rather than having Safari-specific checks in the viewer, let's add a basic polyfill instead. Here we utilize the polyfill that's [linked from MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback#see_also), see https://github.com/behnammodi/polyfill/blob/master/window.polyfill.js which unfortunately doesn't exist on NPM. However, all the polyfills that I could find on NPM are much older and thus didn't seem like a good idea to use.

*Please note:* One (obvious) effect of these changes is that all Safari-users, unless they enable `requestIdleCallback`-support manually, will need to use a `legacy`-build of the PDF.js library.