### PR TITLE
Remove the "tagged" telemetry-reporting

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -260,7 +260,6 @@ const PDFViewerApplication = {
   _saveInProgress: false,
   _docStats: null,
   _wheelUnusedTicks: 0,
-  _idleCallbacks: new Set(),
   _PDFBug: null,
   _hasAnnotationEditors: false,
   _title: document.title,
@@ -817,19 +816,6 @@ const PDFViewerApplication = {
   },
 
   /**
-   * @private
-   */
-  _cancelIdleCallbacks() {
-    if (!this._idleCallbacks.size) {
-      return;
-    }
-    for (const callback of this._idleCallbacks) {
-      window.cancelIdleCallback(callback);
-    }
-    this._idleCallbacks.clear();
-  },
-
-  /**
    * Closes opened PDF document.
    * @returns {Promise} - Returns the promise, which is resolved when all
    *                      destruction is completed.
@@ -886,7 +872,6 @@ const PDFViewerApplication = {
     this._docStats = null;
     this._hasAnnotationEditors = false;
 
-    this._cancelIdleCallbacks();
     promises.push(this.pdfScriptingManager.destroyPromise);
 
     this.setTitle();
@@ -1427,19 +1412,6 @@ const PDFViewerApplication = {
         }
         this.pdfLayerViewer.render({ optionalContentConfig, pdfDocument });
       });
-      if (
-        (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) ||
-        "requestIdleCallback" in window
-      ) {
-        const callback = window.requestIdleCallback(
-          () => {
-            this._collectTelemetry(pdfDocument);
-            this._idleCallbacks.delete(callback);
-          },
-          { timeout: 1000 }
-        );
-        this._idleCallbacks.add(callback);
-      }
     });
 
     this._initializePageLabels(pdfDocument);
@@ -1484,23 +1456,6 @@ const PDFViewerApplication = {
       numPages: this.pagesCount,
       URL: this.url,
     };
-  },
-
-  /**
-   * A place to fetch data for telemetry after one page is rendered and the
-   * viewer is idle.
-   * @private
-   */
-  async _collectTelemetry(pdfDocument) {
-    const markInfo = await this.pdfDocument.getMarkInfo();
-    if (pdfDocument !== this.pdfDocument) {
-      return; // Document was closed while waiting for mark info.
-    }
-    const tagged = markInfo?.Marked || false;
-    this.externalServices.reportTelemetry({
-      type: "tagged",
-      tagged,
-    });
   },
 
   /**


### PR DESCRIPTION
Given that this is no longer being recorded in Firefox, it shouldn't be necessary to keep the associated code in the default viewer.