### PR TITLE
Don't listen for window resolution changes in old browsers (PR 15319 follow-up)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1971,6 +1971,13 @@ const PDFViewerApplication = {
       const mediaQueryList = window.matchMedia(
         `(resolution: ${window.devicePixelRatio || 1}dppx)`
       );
+      if (
+        typeof PDFJSDev !== "undefined" &&
+        PDFJSDev.test("GENERIC && !SKIP_BABEL") &&
+        typeof mediaQueryList.addEventListener !== "function"
+      ) {
+        return; // Not supported in Safari<14.
+      }
       mediaQueryList.addEventListener("change", addWindowResolutionChange, {
         once: true,
       });


### PR DESCRIPTION
This is a slightly speculative change, based on something that I happened to notice while browsing MDN, to hopefully prevent PDF.js from outright breaking in older browsers. According to the following information on MDN, Safari didn't implement support for the necessary features until version 14:
 - https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#browser_compatibility
 - https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/change_event#browser_compatibility

Given the browsers that we currently support only older versions of Safari should be affected, hence it seems reasonable to simply disable the functionality rather than trying to polyfill it. (It's interesting how it's very often Safari which is *much* slower than the other browsers at implementing new features.)