### PR TITLE
Send the `verbosity` when using a workerPort (issue 15419)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2010,6 +2010,10 @@ class PDFWorker {
       // and ready to accept messages.
     });
     this._readyCapability.resolve();
+    // Send global setting, e.g. verbosity level.
+    this._messageHandler.send("configure", {
+      verbosity: this.verbosity,
+    });
   }
 
   _initialize() {


### PR DESCRIPTION
This *should* fix issue #15419, but given the lack of a runnable example it's difficult to know for sure.