### PR TITLE
Fix the visibility of a separator in the secondaryToolbar (PR 15391 follow-up)

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -194,7 +194,11 @@ See https://github.com/adobe-type-tools/cmap-resources
               <span data-l10n-id="download_label">Download</span>
             </button>
 
+<!--#if GENERIC-->
             <div class="horizontalToolbarSeparator visibleLargeView"></div>
+<!--#else-->
+<!--        <div class="horizontalToolbarSeparator visibleMediumView"></div>-->
+<!--#endif-->
 
             <button id="presentationMode" class="secondaryToolbarButton" title="Switch to Presentation Mode" tabindex="54" data-l10n-id="presentation_mode">
               <span data-l10n-id="presentation_mode_label">Presentation Mode</span>


### PR DESCRIPTION
After the changes in PR #15391 one separator may now become visible too soon when the viewer is narrow, applies e.g. to the MOZCENTRAL viewer, since the wrong CSS class is being used. The reason that this happens is that only the GENERIC viewer includes the "openFile"-buttons, and we thus need the separator to also be conditionally defined.