### PR TITLE
Don't try to update the cursorTool when switching to PresentationMode failed

### DIFF
--- a/web/pdf_cursor_tools.js
+++ b/web/pdf_cursor_tools.js
@@ -133,8 +133,10 @@ class PDFCursorTools {
         case PresentationModeState.NORMAL: {
           const previouslyActive = this.activeBeforePresentationMode;
 
-          this.activeBeforePresentationMode = null;
-          this.switchTool(previouslyActive);
+          if (previouslyActive !== null) {
+            this.activeBeforePresentationMode = null;
+            this.switchTool(previouslyActive);
+          }
           break;
         }
       }


### PR DESCRIPTION
Currently this may print an Error message in the console, and while nothing breaks (since no actual Error is thrown) we should probably avoid this.