### PR TITLE
Fix `examples/webpack`

### DIFF
--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -7,6 +7,6 @@
   "devDependencies": {
     "webpack": "^5.11.1",
     "webpack-cli": "^4.3.1",
-    "pdfjs-dist": "../../node_modules/pdfjs-dist"
+    "pdfjs-dist": "../../build/dist"
   }
 }


### PR DESCRIPTION
Nothing existed at the path `../../node_modules/pdfjs-dist`. I changed it to `../../build/dist` and it worked.