### PR TITLE
Fix npm arguments in `dist-install` task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2320,7 +2320,7 @@ gulp.task(
       opts.cwd = installPath;
       distPath = path.relative(installPath, distPath);
     }
-    safeSpawnSync("npm", ["install", distPath], opts);
+    safeSpawnSync("npm", ["--prefix", distPath, "install", distPath], opts);
     done();
   })
 );


### PR DESCRIPTION
Fixes https://github.com/mozilla/pdf.js/issues/15382 (for real). Cloning the repository and running `gulp dist-install` failed with the error

```text
Error: command "npm" with parameters "install,build/dist/" exited with code 1
```

on Node 16.15.0, npm 8.19.1, and Ubuntu 22.04.

Credit to @cuiyc2000 for [finding](https://github.com/mozilla/pdf.js/issues/15382#issuecomment-1236036582) this fix.