### PR TITLE
[api-minor] Use `new Worker()` syntax in webpack entrypoint

### DIFF
--- a/examples/webpack/README.md
+++ b/examples/webpack/README.md
@@ -28,10 +28,7 @@ otherwise the build is not guaranteed to work correctly.
 
 If you are getting the `Setting up fake worker` warning, make sure you are
 importing `pdfjs-dist/webpack` which is the zero-configuration method for
-Webpack users. You will need to install
-[worker-loader](https://github.com/webpack-contrib/worker-loader) (version 3.0.0 or higher is required), as a
-dependency in your project in order to use `pdfjs-dist/webpack` (configuring
-`worker-loader` is not necessary; just installing it is sufficient).
+Webpack users. Installing `worker-loader` is no longer necessary.
 
     import * as pdfjsLib from 'pdfjs-dist/webpack';
 

--- a/external/dist/webpack.js
+++ b/external/dist/webpack.js
@@ -16,10 +16,11 @@
 "use strict";
 
 const pdfjs = require("./build/pdf.js");
-const PdfjsWorker = require("worker-loader?esModule=false&filename=[name].[contenthash].js!./build/pdf.worker.js");
 
 if (typeof window !== "undefined" && "Worker" in window) {
-  pdfjs.GlobalWorkerOptions.workerPort = new PdfjsWorker();
+  pdfjs.GlobalWorkerOptions.workerPort = new Worker(
+    new URL("./build/pdf.worker.js", import.meta.url)
+  );
 }
 
 module.exports = pdfjs;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2171,14 +2171,6 @@ function packageJson() {
       dommatrix: "^1.0.3",
       "web-streams-polyfill": "^3.2.1",
     },
-    peerDependencies: {
-      "worker-loader": "^3.0.8", // Used in `external/dist/webpack.js`.
-    },
-    peerDependenciesMeta: {
-      "worker-loader": {
-        optional: true,
-      },
-    },
     browser: {
       canvas: false,
       fs: false,


### PR DESCRIPTION
Closes #15426.

**This requires Webpack 5 and will break for anyone using Webpack 4.** `worker-loader` no longer needs to be installed.

I tested this change in my project and it worked.