### PR TITLE
Some *small* viewer clean-up for non-GENERIC builds

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2178,14 +2178,14 @@ const PDFViewerApplication = {
   },
 };
 
-let validateFileURL;
 if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
   const HOSTED_VIEWER_ORIGINS = [
     "null",
     "http://mozilla.github.io",
     "https://mozilla.github.io",
   ];
-  validateFileURL = function (file) {
+  // eslint-disable-next-line no-var
+  var validateFileURL = function (file) {
     if (!file) {
       return;
     }

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -69,18 +69,6 @@ if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("CHROME || GENERIC")) {
 }
 
 function getViewerConfiguration() {
-  let errorWrapper = null;
-  if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
-    errorWrapper = {
-      container: document.getElementById("errorWrapper"),
-      errorMessage: document.getElementById("errorMessage"),
-      closeButton: document.getElementById("errorClose"),
-      errorMoreInfo: document.getElementById("errorMoreInfo"),
-      moreInfoButton: document.getElementById("errorShowMore"),
-      lessInfoButton: document.getElementById("errorShowLess"),
-    };
-  }
-
   return {
     appContainer: document.body,
     mainContainer: document.getElementById("viewerContainer"),
@@ -207,7 +195,17 @@ function getViewerConfiguration() {
       editorInkThickness: document.getElementById("editorInkThickness"),
       editorInkOpacity: document.getElementById("editorInkOpacity"),
     },
-    errorWrapper,
+    errorWrapper:
+      typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")
+        ? {
+            container: document.getElementById("errorWrapper"),
+            errorMessage: document.getElementById("errorMessage"),
+            closeButton: document.getElementById("errorClose"),
+            errorMoreInfo: document.getElementById("errorMoreInfo"),
+            moreInfoButton: document.getElementById("errorShowMore"),
+            lessInfoButton: document.getElementById("errorShowLess"),
+          }
+        : null,
     printContainer: document.getElementById("printContainer"),
     openFileInput:
       typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")


### PR DESCRIPTION
 - Only define the `validateFileURL` variable in GENERIC builds

   There's no point in having this variable defined (implicitly) as `undefined` in e.g. the Firefox PDF Viewer.
   By defining it with `var` and using an ESLint ignore, rather than `let`, we can move it into the relevant pre-processor block instead. Note that since the entire viewer-code is placed, by Webpack, in a top-level closure this variable will thus not become globally accessible.

 - Move the `errorWrapper` definition in the `getViewerConfiguration` function

   Similar to how we handle e.g. the "Open File"-buttons in non-GENERIC builds, we can handle the `errorWrapper` definition in the same way.