### PR TITLE
Remove the `enableScripting`-parameter from the component examples (PR 13816 follow-up)

### DIFF
--- a/examples/components/simpleviewer.js
+++ b/examples/components/simpleviewer.js
@@ -66,7 +66,6 @@ const pdfViewer = new pdfjsViewer.PDFViewer({
   linkService: pdfLinkService,
   findController: pdfFindController,
   scriptingManager: pdfScriptingManager,
-  enableScripting: true, // Only necessary in PDF.js version 2.10.377 and below.
 });
 pdfLinkService.setViewer(pdfViewer);
 pdfScriptingManager.setViewer(pdfViewer);

--- a/examples/components/singlepageviewer.js
+++ b/examples/components/singlepageviewer.js
@@ -66,7 +66,6 @@ const pdfSinglePageViewer = new pdfjsViewer.PDFSinglePageViewer({
   linkService: pdfLinkService,
   findController: pdfFindController,
   scriptingManager: pdfScriptingManager,
-  enableScripting: true, // Only necessary in PDF.js version 2.10.377 and below.
 });
 pdfLinkService.setViewer(pdfSinglePageViewer);
 pdfScriptingManager.setViewer(pdfSinglePageViewer);


### PR DESCRIPTION
This became unnecessary with PDF.js version `2.11.338`, which was relasesed almost a year ago and is no longer supported.