### PR TITLE
[api-major] Update the minimum supported browsers/environments

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -80,9 +80,10 @@ const config = JSON.parse(fs.readFileSync(CONFIG_FILE).toString());
 
 const ENV_TARGETS = [
   "last 2 versions",
-  "Chrome >= 76",
+  "Chrome >= 85",
   "Firefox ESR",
-  "Safari >= 13.1",
+  "Safari >= 14",
+  "Node >= 14",
   "> 1%",
   "not IE > 0",
   "not dead",
@@ -1400,7 +1401,7 @@ gulp.task(
             postcss([
               postcssLogical({ preserve: true }),
               postcssDirPseudoClass(),
-              autoprefixer({ overrideBrowserslist: ["Chrome >= 76"] }),
+              autoprefixer({ overrideBrowserslist: ["Chrome >= 85"] }),
             ])
           )
           .pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + "web")),
@@ -1973,7 +1974,7 @@ gulp.task("dev-css", function createDevCSS() {
         postcss([
           postcssLogical({ preserve: true }),
           postcssDirPseudoClass(),
-          autoprefixer({ overrideBrowserslist: ["last 2 versions"] }),
+          autoprefixer({ overrideBrowserslist: ["last 1 versions"] }),
         ])
       )
       .pipe(gulp.dest(cssDir)),


### PR DESCRIPTION
In the `legacy`-builds we (obviously) support the currently maintained Firefox ESR version, and looking at the [release history](https://wiki.mozilla.org/Release_Management/Calendar) those are officially supported (by Mozilla) for about 1-1.5 years. However, for non-Firefox browsers the `legacy`-builds currently attempt to "support" browsers that are approximately *three* years old.[1] Historically, in the PDF.js project, trying to support old browsers have caused some maintenance problems and even delayed adoption of new web-platform features/functionality.

To lessen the support burden, given that the primary purpose of the PDF.js library is still to develop the *built-in* Firefox PDF Viewer, this patch proposes that the upcoming *major* release changes the minimum supported browsers/environments as follows:
 - Chrome 85, which was released on 2020-08-25; see https://en.wikipedia.org/wiki/Google_Chrome_version_history
 - Firefox ESR (as before); see https://wiki.mozilla.org/Release_Management/Calendar
 - Safari 14, which was released on 2020-09-16; see https://en.wikipedia.org/wiki/Safari_version_history#Safari_14
 - Node.js 14 (as before), which is now explicitly listed to prevent it from accidentally breaking; see https://en.wikipedia.org/wiki/Node.js#Releases

---
[1] In older browsers some functionality may not be available and generally we'll ask users to update to a modern browser when bugs, specific to old browsers, are being reported.