### PR TITLE
Temporarily stop listing the official Chrome extension in the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ PDF.js is built into version 19+ of Firefox.
 
 #### Chrome
 
-+ The official extension for Chrome can be installed from the [Chrome Web Store](https://chrome.google.com/webstore/detail/pdf-viewer/oemmndcbldboiebfnladdacbdfmadadm).
-*This extension is maintained by [@Rob--W](https://github.com/Rob--W).*
 + Build Your Own - Get the code as explained below and issue `gulp chromium`. Then open
 Chrome, go to `Tools > Extension` and load the (unpackaged) extension from the
 directory `build/chromium`.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2452,9 +2452,5 @@ gulp.task("externaltest", function (done) {
 
 gulp.task(
   "ci-test",
-  gulp.series(
-    gulp.parallel("lint", "externaltest", "unittestcli"),
-    "lint-chromium",
-    "typestest"
-  )
+  gulp.series(gulp.parallel("lint", "externaltest", "unittestcli"), "typestest")
 );


### PR DESCRIPTION
The [official Chrome extension](https://chrome.google.com/webstore/detail/pdf-viewer/oemmndcbldboiebfnladdacbdfmadadm) has unfortunately not been updated for *three years*, which means that it's currently missing out on years worth of bug fixes, performance improvements, and new features. In particular, the Chrome extension suffers from a known bug with non-embedded standard fonts; see [issue 13669](https://github.com/mozilla/pdf.js/issues/13669#issuecomment-889062050) for details.

For the time being, this patch proposes that we *temporary* make the following changes:
 - Remove the mention of the official Chrome extension from the main README, since it seems unfortunate to somewhat prominently recommend users an old and partially non-working extension.
 - Don't run the `gulp lint-chromium` task as part of the CI, since in addition to the official extension not having been updated its code is also not being actively maintained.[1]

Once the official Chrome extension has been updated, and it's being actively maintained again, this patch should be simple enough to revert.

---
[1] The last commits, which aren't e.g. linting or general code-maintenance related, happened a year ago now.