### PR TITLE
Don't update the Scroll/Spread-mode in the ViewHistory while PresentationMode is active (issue 15453)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2469,7 +2469,10 @@ function webViewerUpdateViewarea({ location }) {
 }
 
 function webViewerScrollModeChanged(evt) {
-  if (PDFViewerApplication.isInitialViewSet) {
+  if (
+    PDFViewerApplication.isInitialViewSet &&
+    !PDFViewerApplication.pdfViewer.isInPresentationMode
+  ) {
     // Only update the storage when the document has been loaded *and* rendered.
     PDFViewerApplication.store?.set("scrollMode", evt.mode).catch(() => {
       // Unable to write to storage.
@@ -2478,7 +2481,10 @@ function webViewerScrollModeChanged(evt) {
 }
 
 function webViewerSpreadModeChanged(evt) {
-  if (PDFViewerApplication.isInitialViewSet) {
+  if (
+    PDFViewerApplication.isInitialViewSet &&
+    !PDFViewerApplication.pdfViewer.isInPresentationMode
+  ) {
     // Only update the storage when the document has been loaded *and* rendered.
     PDFViewerApplication.store?.set("spreadMode", evt.mode).catch(() => {
       // Unable to write to storage.


### PR DESCRIPTION
By force-quitting the browser while the FullScreen API is active, we don't get a chance to exit PresentationMode *cleanly* and some of its state thus remains (via the `ViewHistory`). To try and improve things here we can skip updating the Scroll/Spread-mode while PresentationMode is active, since they will be changed when entering PresentationMode, which seems to help and is really the best that we can do here (and what the issue describes is very much an edge-case anyway).