### PR TITLE
Don't use window.print in the Firefox builtin viewer (bug 1774427)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -152,6 +152,10 @@ class DefaultExternalServices {
 
   static reportTelemetry(data) {}
 
+  static print() {
+    window.print();
+  }
+
   static createDownloadManager(options) {
     throw new Error("Not implemented: createDownloadManager");
   }
@@ -1897,7 +1901,7 @@ const PDFViewerApplication = {
     if (!this.supportsPrinting) {
       return;
     }
-    window.print();
+    this.externalServices.print();
   },
 
   bindEvents() {

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -402,6 +402,10 @@ class FirefoxExternalServices extends DefaultExternalServices {
     FirefoxCom.request("updateEditorStates", data);
   }
 
+  static print() {
+    FirefoxCom.request("print", null);
+  }
+
   static createL10n(options) {
     const mozL10n = document.mozL10n;
     // TODO refactor mozL10n.setExternalLocalizerServices


### PR DESCRIPTION
Currently, it's impossible to print a pdf in a sandboxed iframe in using window.print.