### PR TITLE
Use AccentColor as background for selected text in the text layer (bug 1790309)

### DIFF
--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -21,7 +21,7 @@
   right: 0;
   bottom: 0;
   overflow: hidden;
-  opacity: 0.2;
+  opacity: 0.25;
   line-height: 1;
   text-size-adjust: none;
   forced-color-adjust: none;
@@ -71,7 +71,10 @@
 }
 
 .textLayer ::selection {
-  background: rgba(0, 0, 255, 1);
+  /*#if !MOZCENTRAL*/
+  background: blue;
+  /*#endif*/
+  background: AccentColor;
 }
 
 /* Avoids https://github.com/mozilla/pdf.js/issues/13840 in Chrome */

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1288,13 +1288,6 @@ a:focus > .thumbnail > .thumbnailSelectionRing,
   color: var(--treeitem-hover-color);
 }
 
-/* TODO: file FF bug to support ::-moz-selection:window-inactive
-   so we can override the opaque grey background when the window is inactive;
-   see https://bugzilla.mozilla.org/show_bug.cgi?id=706209 */
-::selection {
-  background: rgba(0, 0, 255, 0.3);
-}
-
 /*#if !MOZCENTRAL*/
 #errorWrapper {
   background-color: var(--errorWrapper-bg-color);

--- a/web/xfa_layer_builder.css
+++ b/web/xfa_layer_builder.css
@@ -58,10 +58,6 @@
   background-color: rgba(203, 223, 203, 1);
 }
 
-.xfaLayer ::selection {
-  background: rgba(0, 0, 255, 1);
-}
-
 .xfaPage {
   overflow: hidden;
   position: relative;


### PR DESCRIPTION
and use the default color for the viewer in general.