### PR TITLE
Correct return value of getNumber()

### DIFF
--- a/src/core/xfa/formcalc_lexer.js
+++ b/src/core/xfa/formcalc_lexer.js
@@ -240,7 +240,7 @@ class Lexer {
   getNumber(first) {
     const match = this.data.substring(this.pos).match(numberPattern);
     if (!match) {
-      return first - 0x30 /* = 0 */;
+      return new Token(first - 0x30 /* = 0 */);
     }
     const number = parseFloat(
       this.data.substring(this.pos - 1, this.pos + match[0].length)


### PR DESCRIPTION
All other `get*()` in Lexer return `Token`,  except `getNumber()` and `getSlash()`.  `getSlash()` called in `Lexer.next()` is not returned by it directly, but `getNumber()` is.