### PR TITLE
[Editor] Make sure to have the annotation editor layer on top of the annotation one (bug 1791515)

### DIFF
--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -53,6 +53,7 @@
   font-size: calc(100px * var(--scale-factor));
   transform-origin: 0 0;
   cursor: auto;
+  z-index: 20000;
 }
 
 .annotationEditorLayer.freeTextEditing {

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -449,7 +449,7 @@ body {
 .editorParamsToolbar {
   top: 32px;
   position: absolute;
-  z-index: 10000;
+  z-index: 30000;
   height: auto;
   padding: 0 4px;
   margin: 4px 2px;
@@ -523,7 +523,6 @@ body {
   padding: 6px 0 10px;
   inset-inline-end: 4px;
   height: auto;
-  z-index: 30000;
   background-color: var(--doorhanger-bg-color);
 }
 


### PR DESCRIPTION
Some z-index have been added in the annotation layer because the elements inside are re-ordered in order to improve accessibility.
Hence we must add a "high" z-index on the annotation editor layer in order to avoid any bad interaction between the different layers.