### PR TITLE
Correct element access of Map

### DIFF
--- a/src/scripting_api/field.js
+++ b/src/scripting_api/field.js
@@ -457,9 +457,9 @@ class Field extends PDFObject {
       return;
     }
     if (!(cTrigger in this._actions)) {
-      this._actions[cTrigger] = [];
+      this._actions.set(cTrigger, []);
     }
-    this._actions[cTrigger].push(cScript);
+    this._actions.get(cTrigger).push(cScript);
   }
 
   setFocus() {


### PR DESCRIPTION
`this._actions` is assigned by `createActionsMap()` which returns Map.