### PR TITLE
Simplify the vague logic about typeof document

### DIFF
--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -680,8 +680,6 @@ const animationStarted = new Promise(function (resolve) {
 });
 
 const docStyle =
-  typeof PDFJSDev !== "undefined" &&
-  PDFJSDev.test("LIB") &&
   typeof document === "undefined"
     ? null
     : document.documentElement.style;


### PR DESCRIPTION
Consider the negative case
```js
typeof PDFJSDev === "undefined" || !PDFJSDev.test("LIB") || typeof document !== "undefined"
```
then `document.documentElement.style` seems logically vague.