### PR TITLE
Fix commFunc typo in the SandboxSupportBase.destroy method

### DIFF
--- a/src/pdf.sandbox.external.js
+++ b/src/pdf.sandbox.external.js
@@ -29,7 +29,7 @@ class SandboxSupportBase {
   }
 
   destroy() {
-    this.commFunc = null;
+    this.commFun = null;
     this.timeoutIds.forEach(([_, id]) => this.win.clearTimeout(id));
     this.timeoutIds = null;
   }


### PR DESCRIPTION
As can be seen in the constructor, the correct name is `commFun` which means that the property wasn't being cleaned-up correctly.