### PR TITLE
Fix #selectEditors typo in the AnnotationEditorUIManager.unselectAll method

### DIFF
--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -998,7 +998,7 @@ class AnnotationEditorUIManager {
       return;
     }
 
-    if (this.#selectEditors.size === 0) {
+    if (this.#selectedEditors.size === 0) {
       return;
     }
     for (const editor of this.#selectedEditors) {


### PR DESCRIPTION
…method