### PR TITLE
[XFA] Fix an hidden issue in the FormCalc lexer

### DIFF
--- a/src/core/xfa/formcalc_lexer.js
+++ b/src/core/xfa/formcalc_lexer.js
@@ -239,8 +239,8 @@ class Lexer {
 
   getNumber(first) {
     const match = this.data.substring(this.pos).match(numberPattern);
-    if (!match) {
-      return first - 0x30 /* = 0 */;
+    if (!match[0]) {
+      return new Token(TOKEN.number, first - 0x30 /* = 0 */);
     }
     const number = parseFloat(
       this.data.substring(this.pos - 1, this.pos + match[0].length)

--- a/test/unit/xfa_formcalc_spec.js
+++ b/test/unit/xfa_formcalc_spec.js
@@ -22,8 +22,10 @@ describe("FormCalc expression parser", function () {
   describe("FormCalc lexer", function () {
     it("should lex numbers", function () {
       const lexer = new Lexer(
-        "12 1.2345 .7 .12345 1e-2 1.2E+3 1e2 1.2E3 nan 12. 2.e3 infinity 99999999999999999 123456789.012345678 9e99999"
+        "1 7 12 1.2345 .7 .12345 1e-2 1.2E+3 1e2 1.2E3 nan 12. 2.e3 infinity 99999999999999999 123456789.012345678 9e99999"
       );
+      expect(lexer.next()).toEqual(new Token(TOKEN.number, 1));
+      expect(lexer.next()).toEqual(new Token(TOKEN.number, 7));
       expect(lexer.next()).toEqual(new Token(TOKEN.number, 12));
       expect(lexer.next()).toEqual(new Token(TOKEN.number, 1.2345));
       expect(lexer.next()).toEqual(new Token(TOKEN.number, 0.7));


### PR DESCRIPTION
Since there are no script engine with XFA, the FormCalc parser is not used irl.
The bug @nmtigor noticed was hidden by another one (the wrong check on `match`).