### PR TITLE
Initialize values in the path bounding box before flushing the operator list (bug 1791583)

### DIFF
--- a/test/pdfs/bug1791583.pdf.link
+++ b/test/pdfs/bug1791583.pdf.link
@@ -1,0 +1,2 @@
+https://web.archive.org/web/20220830051811/https://www.tisseo.fr/sites/default/files/plan_general_reseau.pdf
+

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -6896,5 +6896,12 @@
       "firstPage": 1,
       "lastPage": 1,
       "type": "eq"
+   },
+   {  "id": "bug1791583",
+      "file": "pdfs/bug1791583.pdf",
+      "md5": "1ff6badc865c9a5e9a0dc0b7131ffe28",
+      "link": true,
+      "rounds": 1,
+      "type": "eq"
    }
 ]


### PR DESCRIPTION
OperatorList.addOp can trigger a flush if it's required, hence the values passed to it must be correctly initialized in order to avoid some wrong values in the renderer. Because of that a clip path was considered as empty, nothing was clipped, hence the wrong rendering in bug 1791583.