### PR TITLE
[JS] Remove duplicate `this._document` assignment in the `App`-class

### DIFF
--- a/src/scripting_api/app.js
+++ b/src/scripting_api/app.js
@@ -66,7 +66,6 @@ class App extends PDFObject {
     this._timeoutCallbackId = 0;
     this._globalEval = data.globalEval;
     this._externalCall = data.externalCall;
-    this._document = data._document;
   }
 
   // This function is called thanks to the proxy


### PR DESCRIPTION
This property is already being assigned earlier in the constructor, see https://github.com/mozilla/pdf.js/blob/ea1d35976718a87d35846748016d843ea996d2e2/src/scripting_api/app.js#L42