### PR TITLE
Fix property chain orders of Operators in isDotExpression

### DIFF
--- a/src/core/xfa/formcalc_parser.js
+++ b/src/core/xfa/formcalc_parser.js
@@ -661,14 +661,14 @@ class AstBinaryOperator extends Leaf {
   }
 
   isDotExpression() {
-    return Operators.id.dot <= this.id && this.id <= Operators.id.dotHash;
+    return Operators.dot.id <= this.id && this.id <= Operators.dotHash.id;
   }
 
   isSomPredicate() {
     return (
       this.isDotExpression() ||
-      (Operators.id.lt <= this.id &&
-        this.id <= Operators.id.or &&
+      (Operators.lt.id <= this.id &&
+        this.id <= Operators.or.id &&
         ((this.left.isDotExpression() && this.right.isConstant()) ||
           (this.left.isConstant() && this.right.isDotExpression()) ||
           (this.left.isDotExpression() && this.right.isDotExpression())))

--- a/test/unit/xfa_formcalc_spec.js
+++ b/test/unit/xfa_formcalc_spec.js
@@ -266,7 +266,9 @@ describe("FormCalc expression parser", function () {
 
     it("should parse basic expression with dots", function () {
       const parser = new Parser("a.b.c.#d..e.f..g.*");
-      expect(parser.parse().dump()[0]).toEqual({
+      const exprlist = parser.parse();
+      expect(exprlist.expressions[0].isDotExpression()).toEqual(true);
+      expect(exprlist.dump()[0]).toEqual({
         operator: ".",
         left: { id: "a" },
         right: {
@@ -726,6 +728,13 @@ endfunc
         "if (foo == 1) then a = 1 elseif (foo == 2) then a = 2 end"
       );
       expect(() => parser.parse()).toThrow(new Error(Errors.if));
+    });
+
+    it("should parse som predicate", () => {
+      const parser = new Parser("a.b <= 3");
+      const expr = parser.parse().expressions[0];
+      expect(expr.isSomPredicate()).toEqual(true);
+      expect(expr.left.isSomPredicate()).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
There is no property `id` for `Operators`, and number `id` has no operator properties `dot`, `dotHash`, `lt`, `or`. (see `Operators.lt.id` in `getOperatorOrValue()` below)