### PR TITLE
Restore the old fonts in the debugger (PR 15438 follow-up)

### DIFF
--- a/web/debugger.css
+++ b/web/debugger.css
@@ -13,6 +13,12 @@
  * limitations under the License.
  */
 
+#PDFBug,
+#PDFBug input,
+#PDFBug button,
+#PDFBug select {
+  font: message-box;
+}
 #PDFBug {
   background-color: rgba(255, 255, 255, 1);
   border: 1px solid rgba(102, 102, 102, 1);


### PR DESCRIPTION
The changes in PR #15438 affected the debugger as well, which means that some of the panels/buttons look (in my opinion) a bit less nice than before.