### PR TITLE
Set a `border-radius` when hovering annotationLayer-inputs (PR 15438 follow-up)

### DIFF
--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -135,6 +135,12 @@
 .annotationLayer .buttonWidgetAnnotation.radioButton input:hover {
   border: 2px solid var(--input-hover-border-color);
 }
+.annotationLayer .textWidgetAnnotation input:hover,
+.annotationLayer .textWidgetAnnotation textarea:hover,
+.annotationLayer .choiceWidgetAnnotation select:hover,
+.annotationLayer .buttonWidgetAnnotation.checkBox input:hover {
+  border-radius: 2px;
+}
 
 .annotationLayer .textWidgetAnnotation input:focus,
 .annotationLayer .textWidgetAnnotation textarea:focus,


### PR DESCRIPTION
The changes in PR #15438 added a `border-radius` when input-elements are focused, however there's no radius when the same elements are hovered. Having the radius change, and not just the `border-color`, when input goes from hovered to focused feels a bit inconsistent (at least to me).