### PR TITLE
Revert "Don't use window.print in the Firefox builtin viewer (bug 1774427)"

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -152,10 +152,6 @@ class DefaultExternalServices {
 
   static reportTelemetry(data) {}
 
-  static print() {
-    window.print();
-  }
-
   static createDownloadManager(options) {
     throw new Error("Not implemented: createDownloadManager");
   }
@@ -1901,7 +1897,7 @@ const PDFViewerApplication = {
     if (!this.supportsPrinting) {
       return;
     }
-    this.externalServices.print();
+    window.print();
   },
 
   bindEvents() {

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -402,10 +402,6 @@ class FirefoxExternalServices extends DefaultExternalServices {
     FirefoxCom.request("updateEditorStates", data);
   }
 
-  static print() {
-    FirefoxCom.request("print", null);
-  }
-
   static createL10n(options) {
     const mozL10n = document.mozL10n;
     // TODO refactor mozL10n.setExternalLocalizerServices


### PR DESCRIPTION
Reverts mozilla/pdf.js#15459
The patch is not ready yet in m-c and I want to make a release today because next week is dedicated to the All Hands.