### PR TITLE
Replace some `Array.prototype`-usage with spread syntax

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1403,7 +1403,7 @@ class PartialEvaluator {
     } else {
       const opArgs = operatorList.argsArray[lastIndex];
       opArgs[0].push(fn);
-      Array.prototype.push.apply(opArgs[1], args);
+      opArgs[1].push(...args);
       const minMax = opArgs[2];
 
       // Compute min/max in the worker instead of the main thread.
@@ -1910,17 +1910,11 @@ class PartialEvaluator {
               self.ensureStateFont(stateManager.state);
               continue;
             }
-            var arr = args[0];
             var combinedGlyphs = [];
-            var arrLength = arr.length;
             var state = stateManager.state;
-            for (i = 0; i < arrLength; ++i) {
-              const arrItem = arr[i];
+            for (const arrItem of args[0]) {
               if (typeof arrItem === "string") {
-                Array.prototype.push.apply(
-                  combinedGlyphs,
-                  self.handleText(arrItem, state)
-                );
+                combinedGlyphs.push(...self.handleText(arrItem, state));
               } else if (typeof arrItem === "number") {
                 combinedGlyphs.push(arrItem);
               }

--- a/src/core/function.js
+++ b/src/core/function.js
@@ -523,9 +523,7 @@ class PostScriptStack {
   }
 
   constructor(initialStack) {
-    this.stack = !initialStack
-      ? []
-      : Array.prototype.slice.call(initialStack, 0);
+    this.stack = initialStack ? Array.from(initialStack) : [];
   }
 
   push(value) {
@@ -1201,10 +1199,7 @@ class PostScriptCompiler {
           if (j === 0) {
             break; // just skipping -- there are nothing to rotate
           }
-          Array.prototype.push.apply(
-            stack,
-            stack.splice(stack.length - n, n - j)
-          );
+          stack.push(...stack.splice(stack.length - n, n - j));
           break;
         default:
           return null; // unsupported operator

--- a/test/unit/function_spec.js
+++ b/test/unit/function_spec.js
@@ -419,7 +419,7 @@ describe("function", function () {
         for (const { input, output } of samples) {
           const out = new Float32Array(output.length);
           fn(input, 0, out, 0);
-          expect(Array.prototype.slice.call(out, 0)).toEqual(output);
+          expect(Array.from(out)).toEqual(output);
         }
       }
     }


### PR DESCRIPTION
We have a few, quite old, call-sites that use the `Array.prototype`-format and which can now be replaced with spread syntax instead.