### PR TITLE
Reference supported browsers Wiki-page in more README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Feel free to stop by our [Matrix room](https://chat.mozilla.org/#/room/#pdfjs:mo
 
 Please note that the "Modern browsers" version assumes native support for
 features such as optional chaining, nullish coalescing,
-and private `class` fields/methods.
+and private `class` fields/methods; please also see [this wiki page](https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#faq-support).
 
 + Modern browsers: https://mozilla.github.io/pdf.js/web/viewer.html
 

--- a/docs/contents/getting_started/index.md
+++ b/docs/contents/getting_started/index.md
@@ -37,16 +37,18 @@ Before downloading PDF.js please take a moment to understand the different layer
 
 ## Download
 
+Please refer to [this wiki page](https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#faq-support) for information about supported browsers.
+
 <div class="row">
   <div class="col-md-4">
-    <h3>Prebuilt</h3>
+    <h3>Prebuilt (modern browsers)</h3>
     <p>
       Includes the generic build of PDF.js and the viewer.
     </p>
     <a type="button" class="btn btn-primary" href="https://github.com/mozilla/pdf.js/releases/download/vSTABLE_VERSION/pdfjs-STABLE_VERSION-dist.zip">Stable (vSTABLE_VERSION)</a>
   </div>
   <div class="col-md-4">
-    <h3>Prebuilt (for older browsers)</h3>
+    <h3>Prebuilt (older browsers)</h3>
     <p>
       Includes the generic build of PDF.js and the viewer.
     </p>


### PR DESCRIPTION
I've just updated https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#faq-support to hopefully provide better support data, and it cannot hurt to explicitly link that from a couple of places.