### PR TITLE
[api-minor] Stop exposing the `LoopbackPort` class in the API

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1853,34 +1853,33 @@ class PDFPageProxy {
 }
 
 class LoopbackPort {
-  constructor() {
-    this._listeners = [];
-    this._deferred = Promise.resolve();
-  }
+  #listeners = [];
+
+  #deferred = Promise.resolve();
 
   postMessage(obj, transfers) {
     const event = {
       data: structuredClone(obj, transfers),
     };
 
-    this._deferred.then(() => {
-      for (const listener of this._listeners) {
+    this.#deferred.then(() => {
+      for (const listener of this.#listeners) {
         listener.call(this, event);
       }
     });
   }
 
   addEventListener(name, listener) {
-    this._listeners.push(listener);
+    this.#listeners.push(listener);
   }
 
   removeEventListener(name, listener) {
-    const i = this._listeners.indexOf(listener);
-    this._listeners.splice(i, 1);
+    const i = this.#listeners.indexOf(listener);
+    this.#listeners.splice(i, 1);
   }
 
   terminate() {
-    this._listeners.length = 0;
+    this.#listeners.length = 0;
   }
 }
 

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -43,7 +43,6 @@ import {
 import {
   build,
   getDocument,
-  LoopbackPort,
   PDFDataRangeTransport,
   PDFWorker,
   setPDFNetworkStreamFactory,
@@ -128,7 +127,6 @@ export {
   InvalidPDFException,
   isPdfFile,
   loadScript,
-  LoopbackPort,
   MissingPDFException,
   OPS,
   PasswordResponses,


### PR DESCRIPTION
This was done all the way back in PR #8361, for a mozilla-central test that's since been removed. As can be seen in the following search results, there's no `LoopbackPort` invocation outside of the PDF.js code itself: https://searchfox.org/mozilla-central/search?q=LoopbackPort&path=

Given that the `LoopbackPort` is only used in connection with "fake workers", which is something that we don't officially recommend/support, this doesn't seem like functionality that we want to keep exposing in the public API.
