### PR TITLE
Restore the old fonts in the `errorWrapper` (PR 15438 follow-up)

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -320,6 +320,10 @@ body {
   font: message-box;
 }
 
+/*#if !MOZCENTRAL*/
+#errorWrapper,
+#errorWrapper button,
+/*#endif*/
 .toolbar input,
 .toolbar button,
 .toolbar select,


### PR DESCRIPTION
This only applies to the GENERIC viewer, hence we use the pre-processor to exclude it from the Firefox PDF Viewer.