### PR TITLE
Change how `src/shared/compatibility.js` is imported

### DIFF
--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -16,79 +16,71 @@
 
 import { isNodeJS } from "./is_node.js";
 
-// Skip compatibility checks for modern builds and if we already ran the module.
-if (
-  (typeof PDFJSDev === "undefined" || !PDFJSDev.test("SKIP_BABEL")) &&
-  !globalThis._pdfjsCompatibilityChecked
-) {
-  globalThis._pdfjsCompatibilityChecked = true;
+// Support: Node.js<16.0.0
+(function checkNodeBtoa() {
+  if (globalThis.btoa || !isNodeJS) {
+    return;
+  }
+  globalThis.btoa = function (chars) {
+    // eslint-disable-next-line no-undef
+    return Buffer.from(chars, "binary").toString("base64");
+  };
+})();
 
-  // Support: Node.js<16.0.0
-  (function checkNodeBtoa() {
-    if (globalThis.btoa || !isNodeJS) {
-      return;
-    }
-    globalThis.btoa = function (chars) {
-      // eslint-disable-next-line no-undef
-      return Buffer.from(chars, "binary").toString("base64");
-    };
-  })();
+// Support: Node.js<16.0.0
+(function checkNodeAtob() {
+  if (globalThis.atob || !isNodeJS) {
+    return;
+  }
+  globalThis.atob = function (input) {
+    // eslint-disable-next-line no-undef
+    return Buffer.from(input, "base64").toString("binary");
+  };
+})();
 
-  // Support: Node.js<16.0.0
-  (function checkNodeAtob() {
-    if (globalThis.atob || !isNodeJS) {
-      return;
-    }
-    globalThis.atob = function (input) {
-      // eslint-disable-next-line no-undef
-      return Buffer.from(input, "base64").toString("binary");
-    };
-  })();
+// Support: Node.js
+(function checkDOMMatrix() {
+  if (globalThis.DOMMatrix || !isNodeJS) {
+    return;
+  }
+  globalThis.DOMMatrix = __non_webpack_require__("canvas").DOMMatrix;
+})();
 
-  // Support: Node.js
-  (function checkDOMMatrix() {
-    if (globalThis.DOMMatrix || !isNodeJS) {
-      return;
-    }
-    globalThis.DOMMatrix = __non_webpack_require__("canvas").DOMMatrix;
-  })();
+// Support: Node.js
+(function checkReadableStream() {
+  if (globalThis.ReadableStream || !isNodeJS) {
+    return;
+  }
+  globalThis.ReadableStream = __non_webpack_require__(
+    "web-streams-polyfill/dist/ponyfill.js"
+  ).ReadableStream;
+})();
 
-  // Support: Node.js
-  (function checkReadableStream() {
-    if (globalThis.ReadableStream || !isNodeJS) {
-      return;
-    }
-    globalThis.ReadableStream = __non_webpack_require__(
-      "web-streams-polyfill/dist/ponyfill.js"
-    ).ReadableStream;
-  })();
+// Support: Firefox<90, Chrome<92, Safari<15.4, Node.js<16.6.0
+(function checkArrayAt() {
+  if (Array.prototype.at) {
+    return;
+  }
+  require("core-js/es/array/at.js");
+})();
 
-  // Support: Firefox<90, Chrome<92, Safari<15.4, Node.js<16.6.0
-  (function checkArrayAt() {
-    if (Array.prototype.at) {
-      return;
-    }
-    require("core-js/es/array/at.js");
-  })();
+// Support: Firefox<90, Chrome<92, Safari<15.4, Node.js<16.6.0
+(function checkTypedArrayAt() {
+  if (Uint8Array.prototype.at) {
+    return;
+  }
+  require("core-js/es/typed-array/at.js");
+})();
 
-  // Support: Firefox<90, Chrome<92, Safari<15.4, Node.js<16.6.0
-  (function checkTypedArrayAt() {
-    if (Uint8Array.prototype.at) {
-      return;
-    }
-    require("core-js/es/typed-array/at.js");
-  })();
-
-  // Support: Firefox<94, Chrome<98, Safari<15.4, Node.js<17.0.0
-  (function checkStructuredClone() {
-    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("IMAGE_DECODERS")) {
-      // The current image decoders are synchronous, hence `structuredClone`
-      // shouldn't need to be polyfilled for the IMAGE_DECODERS build target.
-      return;
-    }
-    if (globalThis.structuredClone) {
-      return;
-    }
-    require("core-js/web/structured-clone.js");
-  })();
-}
+// Support: Firefox<94, Chrome<98, Safari<15.4, Node.js<17.0.0
+(function checkStructuredClone() {
+  if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("IMAGE_DECODERS")) {
+    // The current image decoders are synchronous, hence `structuredClone`
+    // shouldn't need to be polyfilled for the IMAGE_DECODERS build target.
+    return;
+  }
+  if (globalThis.structuredClone) {
+    return;
+  }
+  require("core-js/web/structured-clone.js");
+})();

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -13,7 +13,15 @@
  * limitations under the License.
  */
 
-import "./compatibility.js";
+// Skip compatibility checks for modern builds and if we already ran the module.
+if (
+  typeof PDFJSDev !== "undefined" &&
+  !PDFJSDev.test("SKIP_BABEL") &&
+  !globalThis._pdfjsCompatibilityChecked
+) {
+  globalThis._pdfjsCompatibilityChecked = true;
+  require("./compatibility.js");
+}
 
 const IDENTITY_MATRIX = [1, 0, 0, 1, 0, 0];
 const FONT_IDENTITY_MATRIX = [0.001, 0, 0, 0.001, 0, 0];


### PR DESCRIPTION
Currently the compatibility-file is loaded using a standard `import`-statement and while its code is enclosed in a pre-processor block, and thus is excluded in e.g. the MOZCENTRAL build-target, it still results in the *built* `pdf.js`/`pdf.worker.js` files having an effectively empty closure as a result. By moving the checks from `src/shared/compatibility.js` and into `src/shared/util.js` instead, we can load the file using a build-time `require`-statement and thus avoid that closure.

Note that with these changes the compatibility-file will no longer be loaded in development mode, i.e. when `gulp server` is used. However, this shouldn't be a big issue given that none of its included polyfills could be loaded then anyway (since `require`-statements are being used) and that it's really only intended for the `legacy`-builds of the library.