### PR TITLE
[JS] Override the `Doc.external`-getter to avoid `alert`-modals on load (issue 15509)

### DIFF
--- a/src/scripting_api/doc.js
+++ b/src/scripting_api/doc.js
@@ -18,6 +18,8 @@ import { PDFObject } from "./pdf_object.js";
 import { PrintParams } from "./print_params.js";
 import { ZoomType } from "./constants.js";
 
+const DOC_EXTERNAL = false;
+
 class InfoProxyHandler {
   static get(obj, prop) {
     return obj[prop.toLowerCase()];
@@ -272,7 +274,10 @@ class Doc extends PDFObject {
   }
 
   get external() {
-    return true;
+    // According to the specification this should be `true` in non-Acrobat
+    // applications, however we ignore that to avoid bothering users with
+    // an `alert`-dialog on document load (see issue 15509).
+    return DOC_EXTERNAL;
   }
 
   set external(_) {


### PR DESCRIPTION
This property is documented in https://web.archive.org/web/20201112021418if_/https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/AcrobatDC_js_api_reference.pdf#G5.1977075

Given that PR #14207, which is *somewhat* similar, landed without tests that's hopefully fine here as well.