### PR TITLE
Replace the `DOMMatrix` polyfill, used with Node.js, with the one from `node-canvas`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2169,7 +2169,7 @@ function packageJson() {
     bugs: DIST_BUGS_URL,
     license: DIST_LICENSE,
     dependencies: {
-      dommatrix: "^1.0.3",
+      canvas: "^2.10.1",
       "web-streams-polyfill": "^3.2.1",
     },
     browser: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "core-js": "^3.25.1",
         "cross-env": "^7.0.3",
         "dialog-polyfill": "^0.5.6",
-        "dommatrix": "^1.0.3",
         "es-module-shims": "1.4.7",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
@@ -4940,12 +4939,6 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
-    },
-    "node_modules/dommatrix": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dommatrix/-/dommatrix-1.0.3.tgz",
-      "integrity": "sha512-l32Xp/TLgWb8ReqbVJAFIvXmY7go4nTxxlWiAFyhoQw9RKEOHBZNnyGvJWqDVSPmq3Y9HlM4npqF/T6VMOXhww==",
-      "dev": true
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -12837,6 +12830,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -12852,16 +12846,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -12876,6 +12873,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -12893,6 +12891,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -23119,12 +23118,6 @@
         "domelementtype": "^2.2.0"
       }
     },
-    "dommatrix": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dommatrix/-/dommatrix-1.0.3.tgz",
-      "integrity": "sha512-l32Xp/TLgWb8ReqbVJAFIvXmY7go4nTxxlWiAFyhoQw9RKEOHBZNnyGvJWqDVSPmq3Y9HlM4npqF/T6VMOXhww==",
-      "dev": true
-    },
     "domutils": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
@@ -29244,7 +29237,8 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -29257,15 +29251,18 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
+          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
@@ -29277,7 +29274,8 @@
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash._root": {
           "version": "3.0.1",
@@ -29291,7 +29289,8 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash.union": {
           "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "core-js": "^3.25.1",
     "cross-env": "^7.0.3",
     "dialog-polyfill": "^0.5.6",
-    "dommatrix": "^1.0.3",
     "es-module-shims": "1.4.7",
     "eslint": "^8.23.1",
     "eslint-config-prettier": "^8.5.0",

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -50,9 +50,7 @@ if (
     if (globalThis.DOMMatrix || !isNodeJS) {
       return;
     }
-    globalThis.DOMMatrix = __non_webpack_require__(
-      "dommatrix/dist/dommatrix.js"
-    );
+    globalThis.DOMMatrix = __non_webpack_require__("canvas").DOMMatrix;
   })();
 
   // Support: Node.js


### PR DESCRIPTION
Fewer dependencies shouldn't be a bad idea in general, and given that the `node-canvas` package already include a `DOMMatrix` polyfill we can simply use that one instead.