### PR TITLE
Revert "Don't listen for window resolution changes in old browsers (PR 15319 follow-up)"

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1979,13 +1979,6 @@ const PDFViewerApplication = {
       const mediaQueryList = window.matchMedia(
         `(resolution: ${window.devicePixelRatio || 1}dppx)`
       );
-      if (
-        typeof PDFJSDev !== "undefined" &&
-        PDFJSDev.test("GENERIC && !SKIP_BABEL") &&
-        typeof mediaQueryList.addEventListener !== "function"
-      ) {
-        return; // Not supported in Safari<14.
-      }
       mediaQueryList.addEventListener("change", addWindowResolutionChange, {
         once: true,
       });


### PR DESCRIPTION
Reverts mozilla/pdf.js#15418, given that PR #15451 has since landed which increased the minimum supported browsers for the next *major* PDF.js release.