### PR TITLE
draft: Add tooltips for shortcuts

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -333,11 +333,11 @@ See https://github.com/adobe-type-tools/cmap-resources
               </div>
               <div id="toolbarViewerMiddle">
                 <div class="splitToolbarButton">
-                  <button id="zoomOut" class="toolbarButton" title="Zoom Out" tabindex="21" data-l10n-id="zoom_out">
+                  <button id="zoomOut" class="toolbarButton" title="Zoom Out (Ctrl+-)" tabindex="21" data-l10n-id="zoom_out">
                     <span data-l10n-id="zoom_out_label">Zoom Out</span>
                   </button>
                   <div class="splitToolbarButtonSeparator"></div>
-                  <button id="zoomIn" class="toolbarButton" title="Zoom In" tabindex="22" data-l10n-id="zoom_in">
+                  <button id="zoomIn" class="toolbarButton" title="Zoom In (Ctrl++)" tabindex="22" data-l10n-id="zoom_in">
                     <span data-l10n-id="zoom_in_label">Zoom In</span>
                    </button>
                 </div>


### PR DESCRIPTION
This currently only adds tooltips for zooming, because I wasn't sure what's the best way to do this, given the different localizations. I don't think the shortcut names need to be localized, it should be added somewhere separate. Not sure if the current solution works for different languages.

Fixes: #4279