### PR TITLE
Re-factor the `toggleButton` l10n in the `PDFSidebar` class

### DIFF
--- a/web/l10n_utils.js
+++ b/web/l10n_utils.js
@@ -40,10 +40,6 @@ const DEFAULT_L10N_STRINGS = {
 
   print_progress_percent: "{{progress}}%",
 
-  "toggle_sidebar.title": "Toggle Sidebar",
-  "toggle_sidebar_notification2.title":
-    "Toggle Sidebar (document contains outline/attachments/layers)",
-
   additional_layers: "Additional Layers",
   page_landmark: "Page {{page}}",
   thumb_page_title: "Page {{page}}",

--- a/web/pdf_sidebar.js
+++ b/web/pdf_sidebar.js
@@ -307,9 +307,11 @@ class PDFSidebar {
   }
 
   #showUINotification() {
-    this.l10n.get("toggle_sidebar_notification2.title").then(msg => {
-      this.toggleButton.title = msg;
-    });
+    this.toggleButton.setAttribute(
+      "data-l10n-id",
+      "toggle_sidebar_notification2"
+    );
+    this.l10n.translate(this.toggleButton);
 
     if (!this.isOpen) {
       // Only show the notification on the `toggleButton` if the sidebar is
@@ -326,9 +328,8 @@ class PDFSidebar {
     }
 
     if (reset) {
-      this.l10n.get("toggle_sidebar.title").then(msg => {
-        this.toggleButton.title = msg;
-      });
+      this.toggleButton.setAttribute("data-l10n-id", "toggle_sidebar");
+      this.l10n.translate(this.toggleButton);
     }
   }
 


### PR DESCRIPTION
Rather than "manually" looking up the l10n-string and then updating the button, we can (and probably even should) just update the l10n-id and then trigger proper translation for the button DOM-element.