### PR TITLE
[GENERIC viewer] Remove the `errorWrapper` UI

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -197,10 +197,6 @@ find_match_count_limit[many]=More than {{limit}} matches
 find_match_count_limit[other]=More than {{limit}} matches
 find_not_found=Phrase not found
 
-# Error panel labels
-error_more_info=More Information
-error_less_info=Less Information
-error_close=Close
 # LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
 # replaced by the PDF.JS version and build ID.
 error_version_info=PDF.js v{{version}} (build: {{build}})

--- a/web/app.js
+++ b/web/app.js
@@ -23,7 +23,6 @@ import {
   isValidRotation,
   isValidScrollMode,
   isValidSpreadMode,
-  noContextMenuHandler,
   normalizeWheelEventDirection,
   parseQueryString,
   ProgressBar,
@@ -826,11 +825,6 @@ const PDFViewerApplication = {
     this._unblockDocumentLoadEvent();
     this._hideViewBookmark();
 
-    if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
-      const { container } = this.appConfig.errorWrapper;
-      container.hidden = true;
-    }
-
     if (!this.pdfLoadingTask) {
       return;
     }
@@ -1114,47 +1108,10 @@ const PDFViewerApplication = {
       }
     }
 
-    if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
-      const errorWrapperConfig = this.appConfig.errorWrapper;
-      const errorWrapper = errorWrapperConfig.container;
-      errorWrapper.hidden = false;
-
-      const errorMessage = errorWrapperConfig.errorMessage;
-      errorMessage.textContent = message;
-
-      const closeButton = errorWrapperConfig.closeButton;
-      closeButton.onclick = function () {
-        errorWrapper.hidden = true;
-      };
-
-      const errorMoreInfo = errorWrapperConfig.errorMoreInfo;
-      const moreInfoButton = errorWrapperConfig.moreInfoButton;
-      const lessInfoButton = errorWrapperConfig.lessInfoButton;
-      moreInfoButton.onclick = function () {
-        errorMoreInfo.hidden = false;
-        moreInfoButton.hidden = true;
-        lessInfoButton.hidden = false;
-        errorMoreInfo.style.height = errorMoreInfo.scrollHeight + "px";
-      };
-      lessInfoButton.onclick = function () {
-        errorMoreInfo.hidden = true;
-        moreInfoButton.hidden = false;
-        lessInfoButton.hidden = true;
-      };
-      moreInfoButton.oncontextmenu = noContextMenuHandler;
-      lessInfoButton.oncontextmenu = noContextMenuHandler;
-      closeButton.oncontextmenu = noContextMenuHandler;
-      moreInfoButton.hidden = false;
-      lessInfoButton.hidden = true;
-      Promise.all(moreInfoText).then(parts => {
-        errorMoreInfo.value = parts.join("\n");
-      });
-    } else {
-      Promise.all(moreInfoText).then(parts => {
-        console.error(message + "\n" + parts.join("\n"));
-      });
-      this.fallback();
-    }
+    Promise.all(moreInfoText).then(parts => {
+      console.error(`${message}\n${parts.join("\n")}`);
+    });
+    this.fallback();
   },
 
   progress(level) {

--- a/web/l10n_utils.js
+++ b/web/l10n_utils.js
@@ -38,8 +38,6 @@ const DEFAULT_L10N_STRINGS = {
   document_properties_linearized_yes: "Yes",
   document_properties_linearized_no: "No",
 
-  print_progress_percent: "{{progress}}%",
-
   additional_layers: "Additional Layers",
   page_landmark: "Page {{page}}",
   thumb_page_title: "Page {{page}}",
@@ -83,6 +81,9 @@ const DEFAULT_L10N_STRINGS = {
   editor_ink2_aria_label: "Draw Editor",
   editor_ink_canvas_aria_label: "User-created image",
 };
+if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
+  DEFAULT_L10N_STRINGS.print_progress_percent = "{{progress}}%";
+}
 
 function getL10nFallback(key, args) {
   switch (key) {

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -28,9 +28,6 @@
 
   --main-color: rgba(12, 12, 13, 1);
   --body-bg-color: rgba(237, 237, 240, 1);
-  /*#if !MOZCENTRAL*/
-  --errorWrapper-bg-color: rgba(255, 110, 110, 1);
-  /*#endif*/
   --progressBar-percent: 0%;
   --progressBar-end-offset: 0;
   --progressBar-color: rgba(10, 132, 255, 1);
@@ -126,9 +123,6 @@
   :root {
     --main-color: rgba(249, 249, 250, 1);
     --body-bg-color: rgba(42, 42, 46, 1);
-    /*#if !MOZCENTRAL*/
-    --errorWrapper-bg-color: rgba(169, 14, 14, 1);
-    /*#endif*/
     --progressBar-color: rgba(0, 96, 223, 1);
     --progressBar-indeterminate-bg-color: rgba(40, 40, 43, 1);
     --progressBar-indeterminate-blend-color: rgba(20, 68, 133, 1);
@@ -320,10 +314,6 @@ body {
   font: message-box;
 }
 
-/*#if !MOZCENTRAL*/
-#errorWrapper,
-#errorWrapper button,
-/*#endif*/
 .toolbar input,
 .toolbar button,
 .toolbar select,
@@ -1291,37 +1281,6 @@ a:focus > .thumbnail > .thumbnailSelectionRing,
   border-radius: 2px;
   color: var(--treeitem-hover-color);
 }
-
-/*#if !MOZCENTRAL*/
-#errorWrapper {
-  background-color: var(--errorWrapper-bg-color);
-  color: var(--main-color);
-  left: 0;
-  position: absolute;
-  right: 0;
-  z-index: 1000;
-  padding: 3px 6px;
-}
-
-#errorMessageLeft {
-  float: left;
-}
-#errorMessageRight {
-  float: right;
-}
-
-#errorSpacer {
-  clear: both;
-}
-#errorMoreInfo {
-  background-color: var(--field-bg-color);
-  color: var(--field-color);
-  border: 1px solid var(--field-border-color);
-  padding: 3px;
-  margin: 3px;
-  width: 98%;
-}
-/*#endif*/
 
 .dialogButton {
   width: auto;

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -372,27 +372,6 @@ See https://github.com/adobe-type-tools/cmap-resources
         <div id="viewerContainer" tabindex="0">
           <div id="viewer" class="pdfViewer"></div>
         </div>
-
-<!--#if !MOZCENTRAL-->
-        <div id="errorWrapper" hidden='true'>
-          <div id="errorMessageLeft">
-            <span id="errorMessage"></span>
-            <button id="errorShowMore" data-l10n-id="error_more_info">
-              More Information
-            </button>
-            <button id="errorShowLess" data-l10n-id="error_less_info" hidden='true'>
-              Less Information
-            </button>
-          </div>
-          <div id="errorMessageRight">
-            <button id="errorClose" data-l10n-id="error_close">
-              Close
-            </button>
-          </div>
-          <div id="errorSpacer"></div>
-          <textarea id="errorMoreInfo" hidden='true' readonly="readonly"></textarea>
-        </div>
-<!--#endif-->
       </div> <!-- mainContainer -->
 
       <div id="dialogContainer">

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -195,17 +195,6 @@ function getViewerConfiguration() {
       editorInkThickness: document.getElementById("editorInkThickness"),
       editorInkOpacity: document.getElementById("editorInkOpacity"),
     },
-    errorWrapper:
-      typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")
-        ? {
-            container: document.getElementById("errorWrapper"),
-            errorMessage: document.getElementById("errorMessage"),
-            closeButton: document.getElementById("errorClose"),
-            errorMoreInfo: document.getElementById("errorMoreInfo"),
-            moreInfoButton: document.getElementById("errorShowMore"),
-            lessInfoButton: document.getElementById("errorShowLess"),
-          }
-        : null,
     printContainer: document.getElementById("printContainer"),
     openFileInput:
       typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")


### PR DESCRIPTION
In the Firefox PDF Viewer this has never been used, with the error message simply printed in the web-console, and (somewhat) recently we've also updated the viewer code to avoid bundling the relevant code there. Furthermore, in the Firefox PDF Viewer we're not even display the *browser* fallback bar any more; see https://bugzilla.mozilla.org/show_bug.cgi?id=1705327.

Hence it seems slightly strange to keep this UI around in the GENERIC viewer, and this patch proposes that we simply remove it to simplify/unify the relevant code in the viewer. In particular this also allows us to remove a couple of l10n-strings, which have always been unused in the Firefox PDF Viewer.