### PR TITLE
Stop localizing error *details* in the viewer (PR 15533 follow-up)

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -197,21 +197,6 @@ find_match_count_limit[many]=More than {{limit}} matches
 find_match_count_limit[other]=More than {{limit}} matches
 find_not_found=Phrase not found
 
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Message: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=File: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Line: {{line}}
-rendering_error=An error occurred while rendering the page.
-
 # Predefined zoom values
 page_scale_width=Page Width
 page_scale_fit=Page Fit
@@ -227,6 +212,7 @@ loading_error=An error occurred while loading the PDF.
 invalid_file_error=Invalid or corrupted PDF file.
 missing_file_error=Missing PDF file.
 unexpected_response_error=Unexpected server response.
+rendering_error=An error occurred while rendering the page.
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.

--- a/web/app.js
+++ b/web/app.js
@@ -1057,7 +1057,7 @@ const PDFViewerApplication = {
   },
 
   /**
-   * Show the error box; used for errors affecting loading and/or parsing of
+   * Report the error; used for errors affecting loading and/or parsing of
    * the entire PDF document.
    */
   _documentError(message, moreInfo = null) {
@@ -1073,45 +1073,30 @@ const PDFViewerApplication = {
   },
 
   /**
-   * Show the error box; used for errors affecting e.g. only a single page.
-   *
+   * Report the error; used for errors affecting e.g. only a single page.
    * @param {string} message - A message that is human readable.
    * @param {Object} [moreInfo] - Further information about the error that is
-   *                              more technical.  Should have a 'message' and
+   *                              more technical. Should have a 'message' and
    *                              optionally a 'stack' property.
    */
   _otherError(message, moreInfo = null) {
-    const moreInfoText = [
-      this.l10n.get("error_version_info", {
-        version: version || "?",
-        build: build || "?",
-      }),
-    ];
+    const moreInfoText = [`PDF.js v${version || "?"} (build: ${build || "?"})`];
     if (moreInfo) {
-      moreInfoText.push(
-        this.l10n.get("error_message", { message: moreInfo.message })
-      );
+      moreInfoText.push(`Message: ${moreInfo.message}`);
+
       if (moreInfo.stack) {
-        moreInfoText.push(
-          this.l10n.get("error_stack", { stack: moreInfo.stack })
-        );
+        moreInfoText.push(`Stack: ${moreInfo.stack}`);
       } else {
         if (moreInfo.filename) {
-          moreInfoText.push(
-            this.l10n.get("error_file", { file: moreInfo.filename })
-          );
+          moreInfoText.push(`File: ${moreInfo.filename}`);
         }
         if (moreInfo.lineNumber) {
-          moreInfoText.push(
-            this.l10n.get("error_line", { line: moreInfo.lineNumber })
-          );
+          moreInfoText.push(`Line: ${moreInfo.lineNumber}`);
         }
       }
     }
 
-    Promise.all(moreInfoText).then(parts => {
-      console.error(`${message}\n${parts.join("\n")}`);
-    });
+    console.error(`${message}\n\n${moreInfoText.join("\n")}`);
     this.fallback();
   },
 

--- a/web/app.js
+++ b/web/app.js
@@ -1481,7 +1481,7 @@ const PDFViewerApplication = {
     console.log(
       `PDF ${pdfDocument.fingerprints[0]} [${info.PDFFormatVersion} ` +
         `${(info.Producer || "-").trim()} / ${(info.Creator || "-").trim()}] ` +
-        `(PDF.js: ${version || "-"})`
+        `(PDF.js: ${version || "?"} [${build || "?"}])`
     );
     let pdfTitle = info.Title;
 

--- a/web/l10n_utils.js
+++ b/web/l10n_utils.js
@@ -51,13 +51,6 @@ const DEFAULT_L10N_STRINGS = {
   "find_match_count_limit[other]": "More than {{limit}} matches",
   find_not_found: "Phrase not found",
 
-  error_version_info: "PDF.js v{{version}} (build: {{build}})",
-  error_message: "Message: {{message}}",
-  error_stack: "Stack: {{stack}}",
-  error_file: "File: {{file}}",
-  error_line: "Line: {{line}}",
-  rendering_error: "An error occurred while rendering the page.",
-
   page_scale_width: "Page Width",
   page_scale_fit: "Page Fit",
   page_scale_auto: "Automatic Zoom",
@@ -69,6 +62,7 @@ const DEFAULT_L10N_STRINGS = {
   invalid_file_error: "Invalid or corrupted PDF file.",
   missing_file_error: "Missing PDF file.",
   unexpected_response_error: "Unexpected server response.",
+  rendering_error: "An error occurred while rendering the page.",
 
   printing_not_supported:
     "Warning: Printing is not fully supported by this browser.",


### PR DESCRIPTION
While it can't hurt to localize the main error-messages, also localizing the error *details* has always seemed somewhat unnecessary since those are only intended for debugging/development purposes. However, I can understand why that's done since the GENERIC viewer used to expose this information in the UI; via the `errorWrapper` UI that's removed in PR #15533.

At this point, when any errors are simply logged in the console, it no longer seems necessary to keep localizing the error *details* in the default viewer.