### PR TITLE
Replace loop with `TypedArray.prototype.set` in the `DecryptStream.readBlock` method

### DIFF
--- a/src/core/decrypt_stream.js
+++ b/src/core/decrypt_stream.js
@@ -46,13 +46,11 @@ class DecryptStream extends DecodeStream {
     const decrypt = this.decrypt;
     chunk = decrypt(chunk, !hasMoreData);
 
-    let bufferLength = this.bufferLength;
-    const n = chunk.length,
-      buffer = this.ensureBuffer(bufferLength + n);
-    for (let i = 0; i < n; i++) {
-      buffer[bufferLength++] = chunk[i];
-    }
-    this.bufferLength = bufferLength;
+    const bufferLength = this.bufferLength,
+      newLength = bufferLength + chunk.length,
+      buffer = this.ensureBuffer(newLength);
+    buffer.set(chunk, bufferLength);
+    this.bufferLength = newLength;
   }
 }
 


### PR DESCRIPTION
There's no reason to use a manual loop, when a native method exists.