### PR TITLE
Remove the unused `Util.apply3dTransform` method

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -857,20 +857,6 @@ class Util {
     ];
   }
 
-  // Apply a generic 3d matrix M on a 3-vector v:
-  //   | a b c |   | X |
-  //   | d e f | x | Y |
-  //   | g h i |   | Z |
-  // M is assumed to be serialized as [a,b,c,d,e,f,g,h,i],
-  // with v as [X,Y,Z]
-  static apply3dTransform(m, v) {
-    return [
-      m[0] * v[0] + m[1] * v[1] + m[2] * v[2],
-      m[3] * v[0] + m[4] * v[1] + m[5] * v[2],
-      m[6] * v[0] + m[7] * v[1] + m[8] * v[2],
-    ];
-  }
-
   // This calculation uses Singular Value Decomposition.
   // The SVD can be represented with formula A = USV. We are interested in the
   // matrix S here because it represents the scale values.


### PR DESCRIPTION
This method was originally added in PR #1157 (back in 2012), however its only call-site was then removed in PR #2423 (also in 2012). Hence this method has been completely unused for nearly a decade, and it should thus be safe to remove it.