### PR TITLE
[XFA] Add some padding inline in selects

### DIFF
--- a/web/xfa_layer_builder.css
+++ b/web/xfa_layer_builder.css
@@ -219,6 +219,10 @@
   background-image: var(--xfa-unfocused-field-background);
 }
 
+.xfaSelect {
+  padding-inline: 2px;
+}
+
 .xfaTop > .xfaTextfield,
 .xfaTop > .xfaSelect,
 .xfaBottom > .xfaTextfield,


### PR DESCRIPTION
Because of https://bugzilla.mozilla.org/show_bug.cgi?id=1582545, the padding-inline is by default 0. 0 is not really enough because of the outline, so just set it to 2px (it was 4px before the patch) in order to have something visually correct.