### PR TITLE
Remove the unused `CMapCompressionType.STREAM` value

### DIFF
--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -1012,9 +1012,7 @@ const CMapFactory = (function CMapFactoryClosure() {
       const lexer = new Lexer(new Stream(cMapData));
       return parseCMap(cMap, lexer, fetchBuiltInCMap, null);
     }
-    throw new Error(
-      "TODO: Only BINARY/NONE CMap compression is currently supported."
-    );
+    throw new Error(`Invalid CMap "compressionType" value: ${compressionType}`);
   }
 
   return {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -271,7 +271,6 @@ const VerbosityLevel = {
 const CMapCompressionType = {
   NONE: 0,
   BINARY: 1,
-  STREAM: 2,
 };
 
 // All the possible operations for an operator list.


### PR DESCRIPTION
This was added in [PR 8064](https://github.com/mozilla/pdf.js/pull/8064#issuecomment-279730182), over five years ago, for a possible future CMap file-format that was never implemented.