### PR TITLE
Slightly re-factor the version fetching in `PDFDocument.checkHeader`

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -900,19 +900,19 @@ class PDFDocument {
     }
     stream.moveStart();
 
+    // Skip over the "%PDF-" prefix, since it was found above.
+    stream.skip(PDF_HEADER_SIGNATURE.length);
     // Read the PDF format version.
-    const MAX_PDF_VERSION_LENGTH = 12;
     let version = "",
       ch;
-    while ((ch = stream.getByte()) > /* Space = */ 0x20) {
-      if (version.length >= MAX_PDF_VERSION_LENGTH) {
-        break;
-      }
+    while (
+      (ch = stream.getByte()) > /* Space = */ 0x20 &&
+      version.length < /* MAX_PDF_VERSION_LENGTH = */ 7
+    ) {
       version += String.fromCharCode(ch);
     }
     if (!this._version) {
-      // Remove the "%PDF-" prefix.
-      this._version = version.substring(5);
+      this._version = version;
     }
   }
 


### PR DESCRIPTION
Note how after having found the "%PDF-" prefix we then read both the prefix and the version in the loop, only to then remove the prefix at the end. It seems better to instead advance the stream position past the "%PDF-" prefix, and then read only the version data.

Finally the loop-condition can also be simplified slightly, to further clean-up some very old code.