### PR TITLE
Take the /CIDToGIDMap into account when getting the glyph mapping for CFF fonts (issue 15559)

### DIFF
--- a/test/pdfs/issue15559.pdf.link
+++ b/test/pdfs/issue15559.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/9745330/FutureABC.L3.-1.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -653,6 +653,14 @@
        "type": "eq",
        "annotations": true
     },
+    {  "id": "issue15559",
+       "file": "pdfs/issue15559.pdf",
+       "md5": "b937f2e32925aef8c1740f357f2a6282",
+       "link": true,
+       "rounds": 1,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "hmm-pdf",
        "file": "pdfs/hmm.pdf",
        "md5": "e08467e60101ee5f4a59716e86db6dc9",


### PR DESCRIPTION
*Please note:* I don't really know what I'm doing here, however the patch appears to fix the referenced issue when comparing the rendering with Adobe Reader (with the caveat that I don't speak the language in question).