### PR TITLE
[GENERIC viewer] Ensure that the we register the `editorTypes` for each `AnnotationEditorUIManager`-instance (issue 15564)

### DIFF
--- a/src/display/editor/annotation_editor_layer.js
+++ b/src/display/editor/annotation_editor_layer.js
@@ -69,9 +69,9 @@ class AnnotationEditorLayer {
       AnnotationEditorLayer._initialized = true;
       FreeTextEditor.initialize(options.l10n);
       InkEditor.initialize(options.l10n);
-
-      options.uiManager.registerEditorTypes([FreeTextEditor, InkEditor]);
     }
+    options.uiManager.registerEditorTypes([FreeTextEditor, InkEditor]);
+
     this.#uiManager = options.uiManager;
     this.annotationStorage = options.annotationStorage;
     this.pageIndex = options.pageIndex;

--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -637,6 +637,9 @@ class AnnotationEditorUIManager {
   }
 
   registerEditorTypes(types) {
+    if (this.#editorTypes) {
+      return;
+    }
     this.#editorTypes = types;
     for (const editorType of this.#editorTypes) {
       this.#dispatchUpdateUI(editorType.defaultPropertiesToUpdate);


### PR DESCRIPTION
When a new PDF document is opened in the GENERIC viewer we (obviously) create a new `AnnotationEditorUIManager`-instance, since those are document-specific, and thus we need to ensure that we actually register the `editorTypes` for each one.