### PR TITLE
[JS] Take into account all the required fields for some computations

### DIFF
--- a/src/scripting_api/aform.js
+++ b/src/scripting_api/aform.js
@@ -500,14 +500,18 @@ class AForm {
 
     const event = globalThis.event;
     const values = [];
+
+    cFields = this.AFMakeArrayFromList(cFields);
     for (const cField of cFields) {
       const field = this._document.getField(cField);
       if (!field) {
         continue;
       }
-      const number = this.AFMakeNumber(field.value);
-      if (number !== null) {
-        values.push(number);
+      for (const child of field.getArray()) {
+        const number = this.AFMakeNumber(child.value);
+        if (number !== null) {
+          values.push(number);
+        }
       }
     }
 

--- a/src/scripting_api/doc.js
+++ b/src/scripting_api/doc.js
@@ -889,6 +889,24 @@ class Doc extends PDFObject {
     return children;
   }
 
+  _getTerminalChildren(fieldName) {
+    // Get all the descendants which have a value.
+    const children = [];
+    const len = fieldName.length;
+    for (const [name, field] of this._fields.entries()) {
+      if (name.startsWith(fieldName)) {
+        const finalPart = name.slice(len);
+        if (
+          field.obj._hasValue &&
+          (finalPart === "" || finalPart.startsWith("."))
+        ) {
+          children.push(field.wrapped);
+        }
+      }
+    }
+    return children;
+  }
+
   getIcon() {
     /* Not implemented */
   }


### PR DESCRIPTION
- Fix Field::getArray in order to collect only the fields which have a value;
- Fix AFSimple_Calculate:
  * allow to have a string with a list of field names as argument;
  * since a field can be non-terminal, use Field::getArray to collect the field under it and then apply the calculation on all the descendants.