### PR TITLE
Don't trigger worker-thread cleanup when destruction has already started

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2997,11 +2997,11 @@ class WorkerTransport {
   }
 
   async startCleanup(keepLoadedFonts = false) {
-    await this.messageHandler.sendWithPromise("Cleanup", null);
-
     if (this.destroyed) {
       return; // No need to manually clean-up when destruction has started.
     }
+    await this.messageHandler.sendWithPromise("Cleanup", null);
+
     for (const page of this.#pageCache.values()) {
       const cleanupSuccessful = page.cleanup();
 


### PR DESCRIPTION
Note how we're currently skipping all main-thread cleanup when document destruction has started, but for some reason we're still dispatching the "Cleanup" message. This seems like a simple oversight, since destruction will already invoke the `BasePdfManager.cleanup` method (on the worker-thread) to fully clear-out all caches.