### PR TITLE
Re-factor the PDF version parsing in the worker-thread

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -16,6 +16,7 @@
 import {
   collectActions,
   MissingDataException,
+  PDF_VERSION_REGEXP,
   recoverJsURL,
   toRomanNumerals,
   XRefEntryException,
@@ -84,11 +85,13 @@ class Catalog {
 
   get version() {
     const version = this._catDict.get("Version");
-    return shadow(
-      this,
-      "version",
-      version instanceof Name ? version.name : null
-    );
+    if (version instanceof Name) {
+      if (PDF_VERSION_REGEXP.test(version.name)) {
+        return shadow(this, "version", version.name);
+      }
+      warn(`Invalid PDF catalog version: ${version.name}`);
+    }
+    return shadow(this, "version", null);
   }
 
   get lang() {

--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -26,6 +26,8 @@ import {
 import { Dict, isName, Ref, RefSet } from "./primitives.js";
 import { BaseStream } from "./base_stream.js";
 
+const PDF_VERSION_REGEXP = /^[1-9]\.\d$/;
+
 function getLookupTableFactory(initializer) {
   let lookup;
   return function () {
@@ -585,6 +587,7 @@ export {
   numberToString,
   ParserEOFException,
   parseXFAPath,
+  PDF_VERSION_REGEXP,
   readInt8,
   readUint16,
   readUint32,


### PR DESCRIPTION
Part of this is very old code, and back when support for parsing the catalog-version was added things became less clear (in my opinion). Hence this patch tries to improve things, by e.g. validating the header- and catalog-version separately.