### PR TITLE
Tweak the vertical position of the sidebar notification icon

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -977,8 +977,8 @@ a.secondaryToolbarButton[href="#"] {
 .pdfSidebarNotification::after {
   position: absolute;
   display: inline-block;
-  top: 1px;
-  inset-inline-start: 17px;
+  top: 2px;
+  inset-inline-end: 2px;
   /* Create a filled circle, with a diameter of 9 pixels, using only CSS: */
   content: "";
   background-color: rgba(112, 219, 85, 1);


### PR DESCRIPTION
Given that the new sidebar icon is slightly shorter than the old one, it cannot hurt to ever so slightly tweak the vertical position of the notification icon.

(While the patch also changes the CSS rule used for the horizontal position, this is a no-op and was done to improve consistency between the two values.)