### PR TITLE
Revert "Avoid all rendering breaking completely when CanvasPattern.setTransform() is unsupported" (PR 13725 follow-up)

### DIFF
--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -19,7 +19,6 @@ import {
   shadow,
   unreachable,
   Util,
-  warn,
 } from "../shared/util.js";
 import { getCurrentTransform } from "./display_utils.js";
 import { isNodeJS } from "../shared/is_node.js";
@@ -140,13 +139,7 @@ class RadialAxialShadingPattern extends BaseShadingPattern {
 
       pattern = ctx.createPattern(tmpCanvas.canvas, "no-repeat");
       const domMatrix = new DOMMatrix(inverse);
-      try {
-        pattern.setTransform(domMatrix);
-      } catch (ex) {
-        // Avoid rendering breaking completely in Firefox 78 ESR,
-        // and in Node.js (see issue 13724).
-        warn(`RadialAxialShadingPattern.getPattern: "${ex?.message}".`);
-      }
+      pattern.setTransform(domMatrix);
     } else {
       // Shading fills are applied relative to the current matrix which is also
       // how canvas gradients work, so there's no need to do anything special
@@ -680,13 +673,8 @@ class TilingPattern {
     );
 
     const pattern = ctx.createPattern(temporaryPatternCanvas.canvas, "repeat");
-    try {
-      pattern.setTransform(domMatrix);
-    } catch (ex) {
-      // Avoid rendering breaking completely in Firefox 78 ESR,
-      // and in Node.js (see issue 13724).
-      warn(`TilingPattern.getPattern: "${ex?.message}".`);
-    }
+    pattern.setTransform(domMatrix);
+
     return pattern;
   }
 }


### PR DESCRIPTION
PR #13725 was only intended as a temporary work-around, and it seems that we can now revert that.
 - Firefox 102 is the currently maintained ESR-branch, and the PDF.js project only supports the active one.
 - Node.js now works, thanks to the `node-canvas` package, and I've confirmed locally that following the STR in [issue 13724](https://github.com/mozilla/pdf.js/issues/13724#issue-942388333) generates a correct image.