### PR TITLE
Remove the `Glyph.matchesForCache` method (PR 13494 follow-up)

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -3225,6 +3225,12 @@ class Font {
    * @private
    */
   _charToGlyph(charcode, isSpace = false) {
+    let glyph = this._glyphCache[charcode];
+    // All `Glyph`-properties, except `isSpace` in multi-byte strings,
+    // depend indirectly on the `charcode`.
+    if (glyph && glyph.isSpace === isSpace) {
+      return glyph;
+    }
     let fontCharCode, width, operatorListId;
 
     let widthCode = charcode;
@@ -3289,24 +3295,18 @@ class Font {
       }
     }
 
-    let glyph = this._glyphCache[charcode];
-    // All `Glyph`-properties, except `isSpace` in multi-byte strings,
-    // depend indirectly on the `charcode`.
-    if (!glyph || glyph.isSpace !== isSpace) {
-      glyph = new Glyph(
-        charcode,
-        fontChar,
-        unicode,
-        accent,
-        width,
-        vmetric,
-        operatorListId,
-        isSpace,
-        isInFont
-      );
-      this._glyphCache[charcode] = glyph;
-    }
-    return glyph;
+    glyph = new Glyph(
+      charcode,
+      fontChar,
+      unicode,
+      accent,
+      width,
+      vmetric,
+      operatorListId,
+      isSpace,
+      isInFont
+    );
+    return (this._glyphCache[charcode] = glyph);
   }
 
   charsToGlyphs(chars) {

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -218,30 +218,6 @@ class Glyph {
     this.isZeroWidthDiacritic = category.isZeroWidthDiacritic;
     this.isInvisibleFormatMark = category.isInvisibleFormatMark;
   }
-
-  matchesForCache(
-    originalCharCode,
-    fontChar,
-    unicode,
-    accent,
-    width,
-    vmetric,
-    operatorListId,
-    isSpace,
-    isInFont
-  ) {
-    return (
-      this.originalCharCode === originalCharCode &&
-      this.fontChar === fontChar &&
-      this.unicode === unicode &&
-      this.accent === accent &&
-      this.width === width &&
-      this.vmetric === vmetric &&
-      this.operatorListId === operatorListId &&
-      this.isSpace === isSpace &&
-      this.isInFont === isInFont
-    );
-  }
 }
 
 function int16(b0, b1) {
@@ -3314,20 +3290,9 @@ class Font {
     }
 
     let glyph = this._glyphCache[charcode];
-    if (
-      !glyph ||
-      !glyph.matchesForCache(
-        charcode,
-        fontChar,
-        unicode,
-        accent,
-        width,
-        vmetric,
-        operatorListId,
-        isSpace,
-        isInFont
-      )
-    ) {
+    // All `Glyph`-properties, except `isSpace` in multi-byte strings,
+    // depend indirectly on the `charcode`.
+    if (!glyph || glyph.isSpace !== isSpace) {
       glyph = new Glyph(
         charcode,
         fontChar,


### PR DESCRIPTION
This method, and its class, was originally added in PR #4453 to reduce memory usage when parsing text. Then PR #13494 extended the `Glyph`-representation slightly to also include the `charCode`, which made the `matchesForCache` method *effectively* redundant since most properties on a `Glyph`-instance indirectly depends on that one. The only exception is potentially `isSpace` in multi-byte strings.

Also, something that I noticed when testing this code: The `matchesForCache` method never worked correctly for `Glyph`s containing `accent`-data, since Objects are passed by reference in JavaScript. For affected fonts, of which there's only a handful of examples in our test-suite, we'd fail to find an already existing `Glyph` because of this.