### PR TITLE
Fallback and try a *previous* generation if all else fails in `XRef.indexObjects` (issue 15577)

### DIFF
--- a/test/pdfs/issue15577.pdf.link
+++ b/test/pdfs/issue15577.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/9813960/hang-080214-152005-90.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -661,6 +661,14 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue15577",
+       "file": "pdfs/issue15577.pdf",
+       "md5": "6939244cf44b7b31ff960b58ed7e4004",
+       "link": true,
+       "rounds": 1,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "hmm-pdf",
        "file": "pdfs/hmm.pdf",
        "md5": "e08467e60101ee5f4a59716e86db6dc9",


### PR DESCRIPTION
When we fail to find a usable PDF document `trailer` *and* there were errors during parsing, try and fallback to a *previous* generation as a last resort during fetching of uncompressed references.
*Please note:* This will not affect "normal" PDF documents, with valid /XRef data, and even most *corrupt* documents should be completely unaffected by these changes.