### PR TITLE
Relax the /Pages dictionary /Count check for corrupt documents (issue 9105)

### DIFF
--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -591,10 +591,6 @@ class XRef {
         if (!(pagesDict instanceof Dict)) {
           continue;
         }
-        const pagesCount = pagesDict.get("Count");
-        if (!Number.isInteger(pagesCount)) {
-          continue;
-        }
         // The top-level /Pages dictionary isn't obviously corrupt.
       } catch (ex) {
         trailerError = ex;

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -94,6 +94,7 @@
 !issue9084.pdf
 !issue12963.pdf
 !issue9105_reduced.pdf
+!issue9105_other.pdf
 !issue9252.pdf
 !issue9262_reduced.pdf
 !issue9291.pdf

--- a/test/pdfs/issue9105_other.pdf
+++ b/test/pdfs/issue9105_other.pdf
@@ -1,0 +1,14 @@
+%PDF-1.
+1 0 obj
+<</Kids[<</Parent 1 0 R/Contents[2 0 R]>>]/Resources<<>>>>
+2 0 obj
+<<>>
+stream
+BT
+/F1 105 Tf
+0 400 Td
+(Adobe tweet) Tj
+ET
+endstream
+endobj
+trailer<</Root<</Pages 1 0 R>>>>

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1748,6 +1748,13 @@
        "link": false,
        "type": "eq"
     },
+    {  "id": "issue9105_other",
+       "file": "pdfs/issue9105_other.pdf",
+       "md5": "4c8b9c2cceb9c5d621e1d50b3dc38efc",
+       "rounds": 1,
+       "link": false,
+       "type": "eq"
+    },
     {  "id": "issue269_1",
        "file": "pdfs/issue269_1.pdf",
        "md5": "ab932f697b4d2e2bf700de15a8efea9c",


### PR DESCRIPTION
After PR #14311, and follow-up patches, we no longer require that the /Count entry (in the /Pages dictionary) is either present or even valid in order to parse/render a PDF document.
Hence it seems strange to keep this requirement for *corrupt* PDF documents, when trying to find a usable `trailer` in the `XRef.indexObjects` method.

Fixes https://github.com/mozilla/pdf.js/issues/9105#issuecomment-342817956