### PR TITLE
Restore a weaker version of the /Pages dictionary /Count check for corrupt documents (PR 15593 follow-up)

### DIFF
--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -582,6 +582,7 @@ class XRef {
         continue;
       }
       // Do some basic validation of the trailer/root dictionary candidate.
+      let validPagesDict = false;
       try {
         const rootDict = dict.get("Root");
         if (!(rootDict instanceof Dict)) {
@@ -591,13 +592,17 @@ class XRef {
         if (!(pagesDict instanceof Dict)) {
           continue;
         }
+        const pagesCount = pagesDict.get("Count");
+        if (Number.isInteger(pagesCount)) {
+          validPagesDict = true;
+        }
         // The top-level /Pages dictionary isn't obviously corrupt.
       } catch (ex) {
         trailerError = ex;
         continue;
       }
       // taking the first one with 'ID'
-      if (dict.has("ID")) {
+      if (validPagesDict && dict.has("ID")) {
         return dict;
       }
       // The current dictionary is a candidate, but continue searching.

--- a/test/driver.js
+++ b/test/driver.js
@@ -553,11 +553,7 @@ class Driver {
     if (!task.pdfDoc) {
       return task.firstPage || 1;
     }
-    let lastPageNumber = task.lastPage || 0;
-    if (!lastPageNumber || lastPageNumber > task.pdfDoc.numPages) {
-      lastPageNumber = task.pdfDoc.numPages;
-    }
-    return lastPageNumber;
+    return task.lastPage || task.pdfDoc.numPages;
   }
 
   _nextPage(task, loadError) {


### PR DESCRIPTION
It appears that PR #15593 broke `issue12402`, and we thus need to partially restore the /Count check.
 I completely missed this when looking at the test-results for PR #15593, both locally and on the bots, since the `Driver._getLastPageNumber` method would "swallow" an unavailable page number.