### PR TITLE
Let the `PdfManager.requestLoadedStream` method return the stream

### DIFF
--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -156,7 +156,9 @@ class LocalPdfManager extends BasePdfManager {
     return Promise.resolve();
   }
 
-  requestLoadedStream() {}
+  requestLoadedStream() {
+    return this._loadedStreamPromise;
+  }
 
   onLoadedStream() {
     return this._loadedStreamPromise;
@@ -213,7 +215,7 @@ class NetworkPdfManager extends BasePdfManager {
   }
 
   requestLoadedStream() {
-    this.streamManager.requestAllChunks();
+    return this.streamManager.requestAllChunks();
   }
 
   sendProgressiveData(chunk) {

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -398,8 +398,7 @@ class WorkerMessageHandler {
             onFailure(reason);
             return;
           }
-          pdfManager.requestLoadedStream();
-          pdfManager.onLoadedStream().then(function () {
+          pdfManager.requestLoadedStream().then(function () {
             ensureNotTerminated();
 
             loadDocument(true).then(onSuccess, onFailure);
@@ -521,8 +520,7 @@ class WorkerMessageHandler {
     });
 
     handler.on("GetData", function wphSetupGetData(data) {
-      pdfManager.requestLoadedStream();
-      return pdfManager.onLoadedStream().then(function (stream) {
+      return pdfManager.requestLoadedStream().then(function (stream) {
         return stream.bytes;
       });
     });
@@ -559,19 +557,17 @@ class WorkerMessageHandler {
     handler.on(
       "SaveDocument",
       function ({ isPureXfa, numPages, annotationStorage, filename }) {
-        pdfManager.requestLoadedStream();
-
-        const newAnnotationsByPage = !isPureXfa
-          ? getNewAnnotationsMap(annotationStorage)
-          : null;
-
         const promises = [
-          pdfManager.onLoadedStream(),
+          pdfManager.requestLoadedStream(),
           pdfManager.ensureCatalog("acroForm"),
           pdfManager.ensureCatalog("acroFormRef"),
           pdfManager.ensureDoc("xref"),
           pdfManager.ensureDoc("startXRef"),
         ];
+
+        const newAnnotationsByPage = !isPureXfa
+          ? getNewAnnotationsMap(annotationStorage)
+          : null;
 
         if (newAnnotationsByPage) {
           for (const [pageIndex, annotations] of newAnnotationsByPage) {


### PR DESCRIPTION
*This is very old code, and it could thus do with some simplification.*

Note how in the `src/core/worker.js` file we're combining both the `PdfManager.requestLoadedStream` and `PdfManager.onLoadedStream` methods in order to access the stream-data. This seems unnecessary, and it's simple enough to always let the `PdfManager.requestLoadedStream` method return the stream-data as well.