### PR TITLE
[JS] Some functions (print, alert,...) must be called only after a user activation

### DIFF
--- a/src/pdf.sandbox.external.js
+++ b/src/pdf.sandbox.external.js
@@ -81,6 +81,13 @@ class SandboxSupportBase {
         ) {
           return;
         }
+
+        if (callbackId === 0) {
+          // This callbackId corresponds to the one used for userActivation.
+          // So here, we cancel the last userActivation.
+          this.win.clearTimeout(this.timeoutIds.get(callbackId));
+        }
+
         const id = this.win.setTimeout(() => {
           this.timeoutIds.delete(callbackId);
           this.callSandboxFunction("timeoutCb", {

--- a/src/scripting_api/app.js
+++ b/src/scripting_api/app.js
@@ -23,6 +23,7 @@ const VIEWER_TYPE = "PDF.js";
 const VIEWER_VARIATION = "Full";
 const VIEWER_VERSION = 21.00720099;
 const FORMS_VERSION = 21.00720099;
+const USERACTIVATION_CALLBACKID = 0;
 
 class App extends PDFObject {
   constructor(data) {
@@ -45,7 +46,8 @@ class App extends PDFObject {
     this._eventDispatcher = new EventDispatcher(
       this._document,
       data.calculationOrder,
-      this._objects
+      this._objects,
+      data.externalCall
     );
 
     this._timeoutIds = new WeakMap();
@@ -63,7 +65,7 @@ class App extends PDFObject {
     }
 
     this._timeoutCallbackIds = new Map();
-    this._timeoutCallbackId = 0;
+    this._timeoutCallbackId = USERACTIVATION_CALLBACKID + 1;
     this._globalEval = data.globalEval;
     this._externalCall = data.externalCall;
   }
@@ -85,6 +87,11 @@ class App extends PDFObject {
   }
 
   _evalCallback({ callbackId, interval }) {
+    if (callbackId === USERACTIVATION_CALLBACKID) {
+      // Special callback id for userActivation stuff.
+      this._document.obj._userActivation = false;
+      return;
+    }
     const expr = this._timeoutCallbackIds.get(callbackId);
     if (!interval) {
       this._unregisterTimeoutCallback(callbackId);
@@ -429,6 +436,11 @@ class App extends PDFObject {
     oDoc = null,
     oCheckbox = null
   ) {
+    if (!this._document.obj._userActivation) {
+      return 0;
+    }
+    this._document.obj._userActivation = false;
+
     if (cMsg && typeof cMsg === "object") {
       nType = cMsg.nType;
       cMsg = cMsg.cMsg;
@@ -475,8 +487,18 @@ class App extends PDFObject {
   }
 
   execMenuItem(item) {
+    if (!this._document.obj._userActivation) {
+      return;
+    }
+    this._document.obj._userActivation = false;
+
     switch (item) {
       case "SaveAs":
+        if (this._document.obj._disableSaving) {
+          return;
+        }
+        this._send({ command: item });
+        break;
       case "FirstPage":
       case "LastPage":
       case "NextPage":
@@ -489,6 +511,9 @@ class App extends PDFObject {
         this._send({ command: "zoom", value: "page-fit" });
         break;
       case "Print":
+        if (this._document.obj._disablePrinting) {
+          return;
+        }
         this._send({ command: "print" });
         break;
     }
@@ -629,4 +654,4 @@ class App extends PDFObject {
   }
 }
 
-export { App };
+export { App, USERACTIVATION_CALLBACKID };


### PR DESCRIPTION
- Some events, which require a user interaction, will allow those functions to be called. But after few seconds, if there are no more user interaction, it won't be possible anymore.
The idea is to give an opportunity to the user to leave the pdf.
- Disable print function when we're printing, the same with saving and disallow to save on open events.

Close #15614.