### PR TITLE
Remove the `PdfManager.onLoadedStream` method (PR 15616 follow-up)

### DIFF
--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -282,10 +282,6 @@ class ChunkedStreamManager {
     this._loadedStreamCapability = createPromiseCapability();
   }
 
-  onLoadedStream() {
-    return this._loadedStreamCapability.promise;
-  }
-
   sendRequest(begin, end) {
     const rangeReader = this.pdfNetworkStream.getRangeReader(begin, end);
     if (!rangeReader.isStreamingSupported) {
@@ -327,9 +323,11 @@ class ChunkedStreamManager {
    * Get all the chunks that are not yet loaded and group them into
    * contiguous ranges to load in as few requests as possible.
    */
-  requestAllChunks() {
-    const missingChunks = this.stream.getMissingChunks();
-    this._requestChunks(missingChunks);
+  requestAllChunks(noFetch = false) {
+    if (!noFetch) {
+      const missingChunks = this.stream.getMissingChunks();
+      this._requestChunks(missingChunks);
+    }
     return this._loadedStreamCapability.promise;
   }
 

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -55,10 +55,6 @@ class BasePdfManager {
     return shadow(this, "docBaseUrl", catalog.baseUrl || this._docBaseUrl);
   }
 
-  onLoadedStream() {
-    unreachable("Abstract method `onLoadedStream` called");
-  }
-
   ensureDoc(prop, args) {
     return this.ensure(this.pdfDocument, prop, args);
   }
@@ -103,7 +99,7 @@ class BasePdfManager {
     unreachable("Abstract method `requestRange` called");
   }
 
-  requestLoadedStream() {
+  requestLoadedStream(noFetch = false) {
     unreachable("Abstract method `requestLoadedStream` called");
   }
 
@@ -156,11 +152,7 @@ class LocalPdfManager extends BasePdfManager {
     return Promise.resolve();
   }
 
-  requestLoadedStream() {
-    return this._loadedStreamPromise;
-  }
-
-  onLoadedStream() {
+  requestLoadedStream(noFetch = false) {
     return this._loadedStreamPromise;
   }
 
@@ -214,16 +206,12 @@ class NetworkPdfManager extends BasePdfManager {
     return this.streamManager.requestRange(begin, end);
   }
 
-  requestLoadedStream() {
-    return this.streamManager.requestAllChunks();
+  requestLoadedStream(noFetch = false) {
+    return this.streamManager.requestAllChunks(noFetch);
   }
 
   sendProgressiveData(chunk) {
     this.streamManager.onReceiveData({ chunk });
-  }
-
-  onLoadedStream() {
-    return this.streamManager.onLoadedStream();
   }
 
   terminate(reason) {

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -420,7 +420,7 @@ class WorkerMessageHandler {
           }
           pdfManager = newPdfManager;
 
-          pdfManager.onLoadedStream().then(function (stream) {
+          pdfManager.requestLoadedStream(/* noFetch = */ true).then(stream => {
             handler.send("DataLoaded", { length: stream.bytes.byteLength });
           });
         })


### PR DESCRIPTION
After the clean-up in PR #15616, the `PdfManager.onLoadedStream` method now only has a single call-site.
Hence why this patch suggests that we remove this method and replace it with an *optional* parameter in `PdfManager.requestLoadedStream` instead. By making the new behaviour opt-in, we'll thus not change any existing call-site.