### PR TITLE
Move canvas to optionalDependencies

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2168,8 +2168,10 @@ function packageJson() {
     homepage: DIST_HOMEPAGE,
     bugs: DIST_BUGS_URL,
     license: DIST_LICENSE,
-    dependencies: {
+    optionalDependencies: {
       canvas: "^2.10.1",
+    },
+    dependencies: {
       "web-streams-polyfill": "^3.2.1",
     },
     browser: {


### PR DESCRIPTION
Move `canvas` to `optionalDependencies`, which enables npm to continue installing `pdfjs-dist` even if the installation of `canvas` fails. Close #15652.