### PR TITLE
[api-minor] Propagate the translated font name to TextContentItem for system fonts

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -2430,8 +2430,7 @@ class PartialEvaluator {
       if (textContentItem.initialized) {
         return textContentItem;
       }
-      const font = textState.font,
-        loadedName = font.loadedName;
+      const { font, loadedName } = textState;
       if (!seenStyles.has(loadedName)) {
         seenStyles.add(loadedName);
 
@@ -2544,6 +2543,7 @@ class PartialEvaluator {
             });
         })
         .then(function (translated) {
+          textState.loadedName = translated.loadedName;
           textState.font = translated.font;
           textState.fontMatrix =
             translated.font.fontMatrix || FONT_IDENTITY_MATRIX;
@@ -2877,7 +2877,7 @@ class PartialEvaluator {
           width: 0,
           height: 0,
           transform: getCurrentTextTransform(),
-          fontName: textState.font.loadedName,
+          fontName: textState.loadedName,
           hasEOL: true,
         });
       }
@@ -4607,6 +4607,7 @@ class TextState {
     this.ctm = new Float32Array(IDENTITY_MATRIX);
     this.fontName = null;
     this.fontSize = 0;
+    this.loadedName = null;
     this.font = null;
     this.fontMatrix = FONT_IDENTITY_MATRIX;
     this.textMatrix = IDENTITY_MATRIX.slice();

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -2244,7 +2244,7 @@ page 1 / 3`);
       const pdfPage = await pdfDoc.getPage(1);
       const { items, styles } = await pdfPage.getTextContent();
       expect(items.length).toEqual(1);
-      // Font name will a random object id.
+      // Font name will be a random object id.
       const fontName = items[0].fontName;
       expect(Object.keys(styles)).toEqual([fontName]);
 
@@ -2265,6 +2265,11 @@ page 1 / 3`);
         descent: isNodeJS ? NaN : -0.217,
         vertical: false,
       });
+
+      // Wait for font data to be loaded so we can check that the font names
+      // match.
+      await pdfPage.getOperatorList();
+      expect(pdfPage.commonObjs.has(fontName)).toEqual(true);
 
       await loadingTask.destroy();
     });


### PR DESCRIPTION
This allows font data for system fonts to be looked up in PDFObjects. Without this, only text with non-system fonts get a font name that matches the name in PDFObjects (e.g., "g_d0_f1") while text with system fonts get an untranslated name (e.g., "Times").