### PR TITLE
Change the `assert` in `Parser.findDefaultInlineStreamEnd` to a non-PRODUCTION one

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -203,7 +203,12 @@ class Parser {
       } else if (state === 1) {
         state = ch === I ? 2 : 0;
       } else {
-        assert(state === 2, "findDefaultInlineStreamEnd - invalid state.");
+        if (
+          typeof PDFJSDev === "undefined" ||
+          PDFJSDev.test("!PRODUCTION || TESTING")
+        ) {
+          assert(state === 2, "findDefaultInlineStreamEnd - invalid state.");
+        }
         if (ch === SPACE || ch === LF || ch === CR) {
           maybeEIPos = stream.pos;
           // Let's check that the next `n` bytes are ASCII... just to be sure.

--- a/test/pdfs/issue2618.pdf.link
+++ b/test/pdfs/issue2618.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/9983741/issue2618.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -3047,6 +3047,14 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "issue2618",
+       "file": "pdfs/issue2618.pdf",
+       "md5": "2c554a99a52288ca1a44a422eeafb8fb",
+       "rounds": 1,
+       "lastPage": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "issue2642",
       "file": "pdfs/issue2642.pdf",
       "md5": "b6679861fdce3bbab0c1fa51bb7f5077",


### PR DESCRIPTION
Given that this `assert` is only intended to catch any implementation bugs in our code, and not actually to validate the PDF data directly[1], we can avoid making this function call unconditionally.

---
[1] In those cases, for example a `FormatError` should have been thrown instead.
