### PR TITLE
Take the mask-offset into account when rendering repeated image masks (bug 1799927)

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -2902,7 +2902,14 @@ class CanvasGraphics {
     ctx.transform(scaleX, skewX, skewY, scaleY, 0, 0);
     const mask = this._createMaskCanvas(img);
 
-    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.setTransform(
+      1,
+      0,
+      0,
+      1,
+      mask.offsetX - currentTransform[4],
+      mask.offsetY - currentTransform[5]
+    );
     for (let i = 0, ii = positions.length; i < ii; i += 2) {
       const trans = Util.transform(currentTransform, [
         scaleX,


### PR DESCRIPTION
*Please note:* As usual when I'm working with the `src/display/canvas.js` code I don't really know what I'm doing, but it at least *appears* to work.