### PR TITLE
Stop Dependabot from creating its own, otherwise unused, labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Currently all Dependabot update PRs get tagged with a "javascript" label, which is annoying since we don't actually use that one. To try and avoid this we specify the labels explicitly, please see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#labels