### PR TITLE
Move the `_isOffscreenCanvasSupported` property to the base `Annotation` class

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -524,6 +524,7 @@ class Annotation {
       this.data.pageIndex = params.pageIndex;
     }
 
+    this._isOffscreenCanvasSupported = params.isOffscreenCanvasSupported;
     this._fallbackFontDict = null;
     this._needAppearances = false;
   }
@@ -1519,7 +1520,6 @@ class WidgetAnnotation extends Annotation {
     const data = this.data;
     this.ref = params.ref;
     this._needAppearances = params.needAppearances;
-    this._isOffscreenCanvasSupported = params.isOffscreenCanvasSupported;
 
     data.annotationType = AnnotationType.WIDGET;
     if (data.fieldName === undefined) {


### PR DESCRIPTION
Having just played around with adding FreeText-annotations and then trying to print, there were `FreeTextAnnotation: OffscreenCanvas is not supported, annotation may not render correctly.` messages printed in the console.
The reason for this is that `FreeTextAnnotation` inherits from `MarkupAnnotation`, however only `WidgetAnnotation` actually defines the `_isOffscreenCanvasSupported` property.