### PR TITLE
Improve zooming with the mouse wheel

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -2582,7 +2582,6 @@ class AnnotationLayer {
   static render(parameters) {
     const { annotations, div, viewport, accessibilityManager } = parameters;
 
-    this.#setDimensions(div, viewport);
     let zIndex = 0;
 
     for (const data of annotations) {
@@ -2659,27 +2658,10 @@ class AnnotationLayer {
    * @memberof AnnotationLayer
    */
   static update(parameters) {
-    const { annotationCanvasMap, div, viewport } = parameters;
+    const { annotationCanvasMap, div } = parameters;
 
-    this.#setDimensions(div, viewport);
     this.#setAnnotationCanvasMap(div, annotationCanvasMap);
     div.hidden = false;
-  }
-
-  /**
-   * @param {HTMLDivElement} div
-   * @param {PageViewport} viewport
-   */
-  static #setDimensions(div, { width, height, rotation }) {
-    const { style } = div;
-
-    const flipOrientation = rotation % 180 !== 0,
-      widthStr = Math.floor(width) + "px",
-      heightStr = Math.floor(height) + "px";
-
-    style.width = flipOrientation ? heightStr : widthStr;
-    style.height = flipOrientation ? widthStr : heightStr;
-    div.setAttribute("data-main-rotation", rotation);
   }
 
   static #setAnnotationCanvasMap(div, annotationCanvasMap) {

--- a/src/display/editor/annotation_editor_layer.js
+++ b/src/display/editor/annotation_editor_layer.js
@@ -549,7 +549,6 @@ class AnnotationEditorLayer {
   render(parameters) {
     this.viewport = parameters.viewport;
     bindEvents(this, this.div, ["dragover", "drop"]);
-    this.setDimensions();
     for (const editor of this.#uiManager.getEditors(this.pageIndex)) {
       this.add(editor);
     }
@@ -567,7 +566,6 @@ class AnnotationEditorLayer {
     this.#uiManager.commitOrRemove();
 
     this.viewport = parameters.viewport;
-    this.setDimensions();
     this.updateMode();
   }
 
@@ -594,21 +592,6 @@ class AnnotationEditorLayer {
   get viewportBaseDimensions() {
     const { width, height, rotation } = this.viewport;
     return rotation % 180 === 0 ? [width, height] : [height, width];
-  }
-
-  /**
-   * Set the dimensions of the main div.
-   */
-  setDimensions() {
-    const { width, height, rotation } = this.viewport;
-
-    const flipOrientation = rotation % 180 !== 0,
-      widthStr = Math.floor(width) + "px",
-      heightStr = Math.floor(height) + "px";
-
-    this.div.style.width = flipOrientation ? heightStr : widthStr;
-    this.div.style.height = flipOrientation ? widthStr : heightStr;
-    this.div.setAttribute("data-main-rotation", rotation);
   }
 }
 

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -59,12 +59,12 @@ import {
   PixelsPerInch,
   RenderingCancelledException,
 } from "./display/display_utils.js";
+import { renderTextLayer, updateTextLayer } from "./display/text_layer.js";
 import { AnnotationEditorLayer } from "./display/editor/annotation_editor_layer.js";
 import { AnnotationEditorUIManager } from "./display/editor/tools.js";
 import { AnnotationLayer } from "./display/annotation_layer.js";
 import { GlobalWorkerOptions } from "./display/worker_options.js";
 import { isNodeJS } from "./shared/is_node.js";
-import { renderTextLayer } from "./display/text_layer.js";
 import { SVGGraphics } from "./display/svg.js";
 import { XfaLayer } from "./display/xfa_layer.js";
 
@@ -141,6 +141,7 @@ export {
   SVGGraphics,
   UnexpectedResponseException,
   UNSUPPORTED_FEATURES,
+  updateTextLayer,
   Util,
   VerbosityLevel,
   version,

--- a/web/annotation_editor_layer_builder.js
+++ b/web/annotation_editor_layer_builder.js
@@ -73,19 +73,22 @@ class AnnotationEditorLayerBuilder {
     const clonedViewport = viewport.clone({ dontFlip: true });
     if (this.div) {
       this.annotationEditorLayer.update({ viewport: clonedViewport });
+      this.#updateRotation(viewport);
       this.show();
       return;
     }
 
     // Create an AnnotationEditor layer div
-    this.div = document.createElement("div");
-    this.div.className = "annotationEditorLayer";
-    this.div.tabIndex = 0;
-    this.pageDiv.append(this.div);
+    const div = (this.div = document.createElement("div"));
+    div.className = "annotationEditorLayer";
+    div.tabIndex = 0;
+    this.#setDimensions(viewport);
+    this.#updateRotation(viewport);
+    this.pageDiv.append(div);
 
     this.annotationEditorLayer = new AnnotationEditorLayer({
       uiManager: this.#uiManager,
-      div: this.div,
+      div,
       annotationStorage: this.annotationStorage,
       accessibilityManager: this.accessibilityManager,
       pageIndex: this.pdfPage._pageIndex,
@@ -95,12 +98,27 @@ class AnnotationEditorLayerBuilder {
 
     const parameters = {
       viewport: clonedViewport,
-      div: this.div,
+      div,
       annotations: null,
       intent,
     };
 
     this.annotationEditorLayer.render(parameters);
+  }
+
+  #setDimensions(viewport) {
+    const { div } = this;
+    const [pageLLx, pageLLy, pageURx, pageURy] = viewport.viewBox;
+    const pageWidth = pageURx - pageLLx;
+    const pageHeight = pageURy - pageLLy;
+    const { style } = div;
+
+    style.width = `calc(var(--scale-factor) * ${pageWidth}px)`;
+    style.height = `calc(var(--scale-factor) * ${pageHeight}px)`;
+  }
+
+  #updateRotation(viewport) {
+    this.div.setAttribute("data-main-rotation", viewport.rotation);
   }
 
   cancel() {

--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -128,11 +128,14 @@ class AnnotationLayerBuilder {
       // If an annotationLayer already exists, refresh its children's
       // transformation matrices.
       AnnotationLayer.update(parameters);
+      this.#updateRotation(viewport);
     } else {
       // Create an annotation layer div and render the annotations
       // if there is at least one annotation.
       this.div = document.createElement("div");
       this.div.className = "annotationLayer";
+      this.#setDimensions(viewport);
+      this.#updateRotation(viewport);
       this.pageDiv.append(this.div);
       parameters.div = this.div;
 
@@ -154,6 +157,21 @@ class AnnotationLayerBuilder {
         );
       }
     }
+  }
+
+  #setDimensions(viewport) {
+    const { div } = this;
+    const [pageLLx, pageLLy, pageURx, pageURy] = viewport.viewBox;
+    const pageWidth = pageURx - pageLLx;
+    const pageHeight = pageURy - pageLLy;
+    const { style } = div;
+
+    style.width = `calc(var(--scale-factor) * ${pageWidth}px)`;
+    style.height = `calc(var(--scale-factor) * ${pageHeight}px)`;
+  }
+
+  #updateRotation(viewport) {
+    this.div.setAttribute("data-main-rotation", viewport.rotation);
   }
 
   cancel() {

--- a/web/app.js
+++ b/web/app.js
@@ -547,6 +547,7 @@ const PDFViewerApplication = {
       imageResourcesPath: AppOptions.get("imageResourcesPath"),
       enablePrintAutoRotate: AppOptions.get("enablePrintAutoRotate"),
       useOnlyCssZoom: AppOptions.get("useOnlyCssZoom"),
+      isOffscreenCanvasSupported: AppOptions.get("isOffscreenCanvasSupported"),
       maxCanvasPixels: AppOptions.get("maxCanvasPixels"),
       enablePermissions: AppOptions.get("enablePermissions"),
       pageColors,
@@ -2072,9 +2073,7 @@ const PDFViewerApplication = {
       this._wheelUnusedTicks = 0;
     }
     this._wheelUnusedTicks += ticks;
-    const wholeTicks =
-      Math.sign(this._wheelUnusedTicks) *
-      Math.floor(Math.abs(this._wheelUnusedTicks));
+    const wholeTicks = Math.trunc(this._wheelUnusedTicks);
     this._wheelUnusedTicks -= wholeTicks;
     return wholeTicks;
   },

--- a/web/app.js
+++ b/web/app.js
@@ -680,18 +680,18 @@ const PDFViewerApplication = {
     return this._initializedCapability.promise;
   },
 
-  zoomIn(steps) {
+  zoomIn(steps, options) {
     if (this.pdfViewer.isInPresentationMode) {
       return;
     }
-    this.pdfViewer.increaseScale(steps);
+    this.pdfViewer.increaseScale(steps, options);
   },
 
-  zoomOut(steps) {
+  zoomOut(steps, options) {
     if (this.pdfViewer.isInPresentationMode) {
       return;
     }
-    this.pdfViewer.decreaseScale(steps);
+    this.pdfViewer.decreaseScale(steps, options);
   },
 
   zoomReset() {
@@ -2701,10 +2701,12 @@ function webViewerWheel(evt) {
       );
     }
 
+    const DRAW_AFTER_SCALE_DELAY = 500;
+    const zoomOptions = { delay: DRAW_AFTER_SCALE_DELAY };
     if (ticks < 0) {
-      PDFViewerApplication.zoomOut(-ticks);
+      PDFViewerApplication.zoomOut(-ticks, zoomOptions);
     } else if (ticks > 0) {
-      PDFViewerApplication.zoomIn(ticks);
+      PDFViewerApplication.zoomIn(ticks, zoomOptions);
     }
 
     const currentScale = pdfViewer.currentScale;

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -387,6 +387,7 @@ class PDFPageView {
         case annotationEditorLayerNode:
         case xfaLayerNode:
         case textLayerNode:
+        case this.loadingIconDiv:
           continue;
       }
       node.remove();
@@ -430,8 +431,17 @@ class PDFPageView {
       delete this.svg;
     }
 
-    this.loadingIconDiv = document.createElement("div");
-    this.loadingIconDiv.className = "loadingIcon notVisible";
+    if (!this.loadingIconDiv) {
+      this.loadingIconDiv = document.createElement("div");
+      this.loadingIconDiv.className = "loadingIcon notVisible";
+      this.loadingIconDiv.setAttribute("role", "img");
+      this.l10n.get("loading").then(msg => {
+        this.loadingIconDiv?.setAttribute("aria-label", msg);
+      });
+      div.append(this.loadingIconDiv);
+    } else {
+      this.toggleLoadingIconSpinner();
+    }
 
     if (
       (typeof PDFJSDev === "undefined" ||
@@ -440,11 +450,6 @@ class PDFPageView {
     ) {
       this.toggleLoadingIconSpinner(/* viewVisible = */ true);
     }
-    this.loadingIconDiv.setAttribute("role", "img");
-    this.l10n.get("loading").then(msg => {
-      this.loadingIconDiv?.setAttribute("aria-label", msg);
-    });
-    div.append(this.loadingIconDiv);
   }
 
   update({
@@ -710,6 +715,8 @@ class PDFPageView {
       }
       return Promise.reject(new Error("pdfPage is not loaded"));
     }
+
+    this.toggleLoadingIconSpinner(/* viewVisible = */ true);
 
     this.renderingState = RenderingStates.RUNNING;
 

--- a/web/pdf_scripting_manager.js
+++ b/web/pdf_scripting_manager.js
@@ -329,13 +329,13 @@ class PDFScriptingManager {
           if (isInPresentationMode) {
             return;
           }
-          this._pdfViewer.increaseScale();
+          this._pdfViewer.increaseScale(/* steps = */ 1);
           break;
         case "ZoomViewOut":
           if (isInPresentationMode) {
             return;
           }
-          this._pdfViewer.decreaseScale();
+          this._pdfViewer.decreaseScale(/* steps = */ 1);
           break;
       }
       return;

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -53,6 +53,8 @@
 
 .pdfViewer .canvasWrapper {
   overflow: hidden;
+  width: 100%;
+  height: 100%;
 }
 
 .pdfViewer .page {

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -143,6 +143,11 @@
   display: none;
 }
 
+.pdfViewer .page canvas[zooming] {
+  width: 100%;
+  height: 100%;
+}
+
 .pdfViewer .page .textLayer[hidden] {
   display: none;
 }

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -141,6 +141,10 @@
   display: none;
 }
 
+.pdfViewer .page .textLayer[hidden] {
+  display: none;
+}
+
 .pdfViewer .page .loadingIcon {
   position: absolute;
   display: block;

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -128,6 +128,8 @@ function isValidAnnotationEditorMode(mode) {
  *   landscape pages upon printing. The default is `false`.
  * @property {boolean} [useOnlyCssZoom] - Enables CSS only zooming. The default
  *   value is `false`.
+ * @property {boolean} [isOffscreenCanvasSupported] - Allows to use an
+ *   OffscreenCanvas if needed.
  * @property {number} [maxCanvasPixels] - The maximum supported canvas size in
  *   total pixels, i.e. width * height. Use -1 for no limit. The default value
  *   is 4096 * 4096 (16 mega-pixels).
@@ -287,6 +289,8 @@ class PDFViewer {
       this.renderer = options.renderer || RendererType.CANVAS;
     }
     this.useOnlyCssZoom = options.useOnlyCssZoom || false;
+    this.isOffscreenCanvasSupported =
+      options.isOffscreenCanvasSupported ?? true;
     this.maxCanvasPixels = options.maxCanvasPixels;
     this.l10n = options.l10n || NullL10n;
     this.#enablePermissions = options.enablePermissions || false;
@@ -775,6 +779,7 @@ class PDFViewer {
                 ? this.renderer
                 : null,
             useOnlyCssZoom: this.useOnlyCssZoom,
+            isOffscreenCanvasSupported: this.isOffscreenCanvasSupported,
             maxCanvasPixels: this.maxCanvasPixels,
             pageColors: this.pageColors,
             l10n: this.l10n,
@@ -1078,10 +1083,13 @@ class PDFViewer {
       newScale * PixelsPerInch.PDF_TO_CSS_UNITS
     );
 
-    const updateArgs = { scale: newScale };
+    const updateArgs = {
+      scale: newScale,
+    };
     for (const pageView of this._pages) {
       pageView.update(updateArgs);
     }
+
     this._currentScale = newScale;
 
     if (!noScroll) {

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -25,6 +25,7 @@
   line-height: 1;
   text-size-adjust: none;
   forced-color-adjust: none;
+  transform-origin: 0 0;
 }
 
 .textLayer span,


### PR DESCRIPTION
- Refactor the text layer code in order to avoid compute it on each draw: the idea is just to resuse what we got on the first draw. Now, we only update the scaleX of the different spans and the other values are dependant of --scale-factor.
- Move some properties in the CSS in order to avoid any updates in JS.
- When zooming in using mouse wheel, delay the page drawing and rescale in using css in order to minimize the drawing operations.
- with tracemonkey.pdf, we can see a real difference when profiling zooming operations (in using ctrl+wheel): there is nothing in the worker and this patch helps to remove all the jank markers.