### PR TITLE
Ensure that the initial document position is always correct with non-default Scroll/Spread modes (issue 15695)

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -1023,10 +1023,12 @@ class PDFViewer {
   #scrollIntoView(pageView, pageSpot = null) {
     const { div, id } = pageView;
 
-    if (this._scrollMode === ScrollMode.PAGE) {
-      // Ensure that `this._currentPageNumber` is correct.
+    // Ensure that `this._currentPageNumber` is correct, when `#scrollIntoView`
+    // is called directly (and not from `#resetCurrentPageView`).
+    if (this._currentPageNumber !== id) {
       this._setCurrentPageNumber(id);
-
+    }
+    if (this._scrollMode === ScrollMode.PAGE) {
       this.#ensurePageViewVisible();
       // Ensure that rendering always occurs, to avoid showing a blank page,
       // even if the current position doesn't change when the page is scrolled.
@@ -1046,6 +1048,15 @@ class PDFViewer {
       }
     }
     scrollIntoView(div, pageSpot);
+
+    // Ensure that the correct *initial* document position is set, when any
+    // OpenParameters are used, for documents with non-default Scroll/Spread
+    // modes (fixes issue 15695). This is necessary since the scroll-handler
+    // invokes the `update`-method asynchronously, and `this._location` could
+    // thus be wrong when the initial zooming occurs in the default viewer.
+    if (!this._currentScaleValue && this._location) {
+      this._location = null;
+    }
   }
 
   /**


### PR DESCRIPTION
Please refer to the inline comment for additional details. The patch also improves internal consistency when `#scrollIntoView` is called directly.