### PR TITLE
Remove the overflowing text special-case from `scrollIntoView` (issue 15714)

### DIFF
--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -109,8 +109,8 @@ class OutputScale {
  * @param {Object} spot - An object with optional top and left properties,
  *   specifying the offset from the top left edge.
  * @param {boolean} [scrollMatches] - When scrolling search results into view,
- *   ignore elements that either: Contains marked content identifiers,
- *   or have the CSS-rule `overflow: hidden;` set. The default value is `false`.
+ *   ignore elements that contain marked content identifiers.
+ *   The default value is `false`.
  */
 function scrollIntoView(element, spot, scrollMatches = false) {
   // Assuming offsetParent is available (it's not available when viewer is in
@@ -126,9 +126,7 @@ function scrollIntoView(element, spot, scrollMatches = false) {
   while (
     (parent.clientHeight === parent.scrollHeight &&
       parent.clientWidth === parent.scrollWidth) ||
-    (scrollMatches &&
-      (parent.classList.contains("markedContent") ||
-        getComputedStyle(parent).overflow === "hidden"))
+    (scrollMatches && parent.classList.contains("markedContent"))
   ) {
     offsetY += parent.offsetTop;
     offsetX += parent.offsetLeft;


### PR DESCRIPTION
With the changes made in PR #14564 this *should* no longer be necessary now, however we still need to keep the `scrollMatches` parameter to handle textLayers with markedContent correctly when searching.