### PR TITLE
[api-minor] Deprecate the TextLayer `timeout` parameter

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -18,6 +18,7 @@ import {
   createPromiseCapability,
   Util,
 } from "../shared/util.js";
+import { deprecated } from "./display_utils.js";
 
 /**
  * Text layer render parameters.
@@ -250,7 +251,6 @@ class TextLayerRenderTask {
     this._canceled = false;
     this._capability = createPromiseCapability();
     this._renderTimer = null;
-    this._bounds = [];
     this._devicePixelRatio = globalThis.devicePixelRatio || 1;
 
     // Always clean-up the temporary canvas once rendering is no longer pending.
@@ -421,6 +421,13 @@ class TextLayerRenderTask {
         // Render right away
         render(this);
       } else {
+        if (typeof PDFJSDev !== "undefined" && !PDFJSDev.test("GENERIC")) {
+          throw new Error("The `timeout` parameter was removed.");
+        }
+        deprecated(
+          "The TextLayerRender `timeout` parameter will be removed in the " +
+            "future, since streaming of textContent has made it obsolete."
+        );
         // Schedule
         this._renderTimer = setTimeout(() => {
           render(this);


### PR DESCRIPTION
This has never really been used anywhere within the PDF.js library[1], and when streaming of textContent was introduced this parameter was effectively made redundant.
Note that when streaming of textContent is used, all text-layout has already happened by the time that this `timeout`-functionality is actually invoked (thus making it pointless).
While the `timeout`-functionality may still "work" when the textContent is provided upfront, although it's never been used/tested, streaming will generally perform better (in e.g. a viewer setting).

*Please note:* While unrelated here, also removes a now unused property that I forgot in PR #15259.

---
[1] At least not since the code was moved into its current file, which happened in PR #6619 and landed seven years ago.