### PR TITLE
[api-minor] Remove the TextLayer `timeout` parameter (PR 15742 follow-up)

### DIFF
--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -79,11 +79,8 @@ class TextLayerBuilder {
 
   /**
    * Renders the text layer.
-   *
-   * @param {number} [timeout] - Wait for a specified amount of milliseconds
-   *                             before rendering.
    */
-  render(timeout = 0) {
+  render() {
     if (!(this.textContent || this.textContentStream) || this.renderingDone) {
       return;
     }
@@ -101,7 +98,6 @@ class TextLayerBuilder {
       viewport: this.viewport,
       textDivs: this.textDivs,
       textContentItemsStr: this.textContentItemsStr,
-      timeout,
     });
     this.textLayerRenderTask.promise.then(
       () => {


### PR DESCRIPTION
The deprecation is included in the current release, i.e. version `3.1.81`, and given the edge-case nature of this option I really don't think that we need to keep it deprecated for multiple releases.