### PR TITLE
Add fit-curve as a dependency of pdfjs-dist

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2172,6 +2172,7 @@ function packageJson() {
       canvas: "^2.10.2",
     },
     dependencies: {
+      "fit-curve": "^0.2.0",
       "web-streams-polyfill": "^3.2.1",
     },
     browser: {


### PR DESCRIPTION
https://github.com/mozilla/pdf.js/blob/67e1c37e0fea06951ece8c457c2b39d2ee2a683f/src/display/editor/fit_curve.js#L16-L18

`fit-curve` is not included in the `pdfjs-dist` dependencies, but it is used above code.
So I got the following error when I have built a code with `pdfjs-dist`.

```
Can't resolve 'fit-curve' in '***/node_modules/pdfjs-dist/lib/display/editor'
```

So, I include `fit-curve` as a dependency of `pdfjs-dist`.