### PR TITLE
Tighten the `vars`-argument for the ESLint `no-unused-vars` rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -159,7 +159,7 @@
     "no-undef-init": "error",
     "no-undef": ["error", { "typeof": true, }],
     "no-unused-vars": ["error", {
-      "vars": "local",
+      "vars": "all",
       "args": "none",
     }],
     "no-use-before-define": ["error", {

--- a/extensions/chromium/preserve-referer.js
+++ b/extensions/chromium/preserve-referer.js
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 /* import-globals-from pdfHandler.js */
+/* exported saveReferer */
 
 "use strict";
 /**

--- a/test/driver.js
+++ b/test/driver.js
@@ -14,8 +14,6 @@
  */
 /* globals pdfjsLib, pdfjsViewer */
 
-"use strict";
-
 const {
   AnnotationLayer,
   AnnotationMode,
@@ -322,7 +320,6 @@ class Rasterize {
  * @property {HTMLDivElement} end - Container for a completion message.
  */
 
-// eslint-disable-next-line no-unused-vars
 class Driver {
   /**
    * @param {DriverOptions} options
@@ -962,3 +959,5 @@ class Driver {
     return capability.promise;
   }
 }
+
+export { Driver };

--- a/test/test_slave.html
+++ b/test/test_slave.html
@@ -20,7 +20,6 @@ limitations under the License.
     <meta charset="utf-8">
     <script src="../build/generic/build/pdf.js"></script>
     <script src="../build/components/pdf_viewer.js"></script>
-    <script src="driver.js"></script>
 
     <link rel="resource" type="application/l10n" href="../build/generic/web/locale/locale.properties">
   </head>
@@ -33,8 +32,10 @@ limitations under the License.
     <pre id="output" style="max-height: 800px; overflow-y: scroll;"></pre>
     <div id="end"></div>
   </body>
-  <script>
-    var driver = new Driver({
+  <script type="module">
+    import { Driver } from "./driver.js";
+
+    const driver = new Driver({
       disableScrolling: document.getElementById('disableScrolling'),
       inflight: document.getElementById('inflight'),
       output: document.getElementById('output'),


### PR DESCRIPTION
Please see https://eslint.org/docs/latest/rules/no-unused-vars#vars