### PR TITLE
[api-minor] Combine the `textContent`/`textContentStream` parameters

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -284,7 +284,6 @@ function render(task) {
   // No point in rendering many divs as it would make the browser
   // unusable even after the divs are rendered.
   if (textDivsLength > MAX_TEXT_DIVS_TO_RENDER) {
-    task._renderingDone = true;
     capability.resolve();
     return;
   }
@@ -294,8 +293,6 @@ function render(task) {
       task._layoutText(textDiv);
     }
   }
-
-  task._renderingDone = true;
   capability.resolve();
 }
 
@@ -318,7 +315,6 @@ class TextLayerRenderTask {
 
     this._reader = null;
     this._textDivProperties = textDivProperties || new WeakMap();
-    this._renderingDone = false;
     this._canceled = false;
     this._capability = createPromiseCapability();
     this._layoutTextParams = {

--- a/test/driver.js
+++ b/test/driver.js
@@ -263,7 +263,7 @@ class Rasterize {
 
       // Rendering text layer as HTML.
       const task = renderTextLayer({
-        textContent,
+        textContentSource: textContent,
         container: div,
         viewport,
       });

--- a/test/unit/text_layer_spec.js
+++ b/test/unit/text_layer_spec.js
@@ -33,7 +33,7 @@ describe("textLayer", function () {
     const textContentItemsStr = [];
 
     const textLayerRenderTask = renderTextLayer({
-      textContentStream: page.streamTextContent(),
+      textContentSource: page.streamTextContent(),
       container: document.createElement("div"),
       viewport: page.getViewport(),
       textContentItemsStr,

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -301,7 +301,7 @@ class PDFPageView {
         const readableStream = pdfPage.streamTextContent({
           includeMarkedContent: true,
         });
-        textLayer.setTextContentStream(readableStream);
+        textLayer.setTextContentSource(readableStream);
       }
       await textLayer.render(viewport);
     } catch (ex) {


### PR DESCRIPTION
Rather than handling these parameters separately, which is a left-over from back when streaming of textContent was originally added, we can simply pass either data directly to the `TextLayer` and let it handle things accordingly.

Also, improves a few JSDoc comments and `typedef`-imports.