### PR TITLE
[Editor] Add a very basic and incomplete workaround for issue #15780

### DIFF
--- a/src/display/editor/annotation_editor_layer.js
+++ b/src/display/editor/annotation_editor_layer.js
@@ -246,7 +246,7 @@ class AnnotationEditorLayer {
     this.attach(editor);
     editor.pageIndex = this.pageIndex;
     editor.parent?.detach(editor);
-    editor.parent = this;
+    editor.setParent(this);
     if (editor.div && editor.isAttachedToDOM) {
       editor.div.remove();
       this.div.append(editor.div);
@@ -521,8 +521,8 @@ class AnnotationEditorLayer {
     for (const editor of this.#editors.values()) {
       this.#accessibilityManager?.removePointerInTextLayer(editor.contentDiv);
       editor.isAttachedToDOM = false;
+      editor.setParent(null);
       editor.div.remove();
-      editor.parent = null;
     }
     this.div = null;
     this.#editors.clear();

--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -68,6 +68,8 @@ class AnnotationEditor {
     this.rotation = this.parent.viewport.rotation;
 
     this.isAttachedToDOM = false;
+
+    this._serialized = undefined;
   }
 
   static get _defaultLineColor() {
@@ -76,6 +78,11 @@ class AnnotationEditor {
       "_defaultLineColor",
       this._colorManager.getHexCode("CanvasText")
     );
+  }
+
+  setParent(parent) {
+    this._serialized = !parent ? this.serialize() : undefined;
+    this.parent = parent;
   }
 
   /**

--- a/src/display/editor/freetext.js
+++ b/src/display/editor/freetext.js
@@ -478,6 +478,10 @@ class FreeTextEditor extends AnnotationEditor {
 
   /** @inheritdoc */
   serialize() {
+    if (this._serialized !== undefined) {
+      return this._serialized;
+    }
+
     if (this.isEmpty()) {
       return null;
     }

--- a/src/display/editor/ink.js
+++ b/src/display/editor/ink.js
@@ -1058,6 +1058,10 @@ class InkEditor extends AnnotationEditor {
 
   /** @inheritdoc */
   serialize() {
+    if (this._serialized !== undefined) {
+      return this._serialized;
+    }
+
     if (this.isEmpty()) {
       return null;
     }

--- a/test/integration/test_utils.js
+++ b/test/integration/test_utils.js
@@ -100,3 +100,21 @@ async function waitForEvent(page, eventName, timeout = 30000) {
   ]);
 }
 exports.waitForEvent = waitForEvent;
+
+const waitForStorageEntries = async (page, nEntries) => {
+  await page.waitForFunction(
+    n => window.PDFViewerApplication.pdfDocument.annotationStorage.size === n,
+    {},
+    nEntries
+  );
+};
+exports.waitForStorageEntries = waitForStorageEntries;
+
+const waitForSelectedEditor = async (page, selector) => {
+  await page.waitForFunction(
+    sel => document.querySelector(sel).classList.contains("selectedEditor"),
+    {},
+    selector
+  );
+};
+exports.waitForSelectedEditor = waitForSelectedEditor;


### PR DESCRIPTION
The main issue is due to the fact that an editor's parent can be null when we want to serialize it and that lead to an exception which break all the saving/printing process.
So this incomplete patch fixes only the saving/printing issue but not the underlying problem (i.e. having a null parent) and doesn't bring that much complexity, so it should help to uplift it the next Firefox release.