### PR TITLE
fix(featch_stream.js): response.body is undefined in Dingtalk app's b…

### DIFF
--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -128,11 +128,19 @@ class PDFFetchStreamReader {
         this._abortController
       )
     )
-      .then(response => {
+      .then(async response => {
         if (!validateResponseStatus(response.status)) {
           throw createResponseStatusError(response.status, url);
         }
-        this._reader = response.body.getReader();
+        
+        if (!response.body) {
+          const myBlob = await response.blob();
+          const stream = myBlob.stream();
+          _this._reader = stream.getReader();
+        } else {
+          _this._reader = response.body.getReader();
+        }
+
         this._headersCapability.resolve();
 
         const getResponseHeader = name => {


### PR DESCRIPTION
Hi, I was used pdfjs-dist@2.12.313 in my application, and it's doing well in web and most mobile browsers. But in the DingTalk app in China, fetch then returning _bodyBlob _bodyInit and no body property, it's cause an exception that response.body is undefined. 