### PR TITLE
Fix page-switching for landscape documents with SpreadModes and PresentationMode (PR 14877 follow-up)

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -1163,7 +1163,14 @@ class PDFViewer {
         vPadding = VERTICAL_PADDING;
 
       if (this.isInPresentationMode) {
-        hPadding = vPadding = 4;
+        // Pages have a 2px (transparent) border in PresentationMode, see
+        // the `web/pdf_viewer.css` file.
+        hPadding = vPadding = 4; // 2 * 2px
+        if (this._spreadMode !== SpreadMode.NONE) {
+          // Account for two pages being visible in PresentationMode, thus
+          // "doubling" the total border width.
+          hPadding *= 2;
+        }
       } else if (this.removePageBorders) {
         hPadding = vPadding = 0;
       } else if (this._scrollMode === ScrollMode.HORIZONTAL) {


### PR DESCRIPTION
In PR #14877 I forgot to update the horizontal padding, used when computing the scale of the pages, for the case where SpreadModes and PresentationMode are being used together.

Steps to reproduce:
 1. Open the viewer with the default `tracemonkey.pdf` document.
 1. Enable any SpreadMode.
 2. Rotate the document *once*, either clockwise or counterclockwise.
 3. Enter PresentationMode.
 4. Try swithching page, e.g. by clicking on the document.

Expected result:
 The visible pages change as you click.

Actual result:
 The visible pages are "stuck" in the current view.