### PR TITLE
Don't attempt to re-create the `annotationLayer`, for pages without any annotations, on zooming and rotation

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1258,7 +1258,6 @@ class PDFPageProxy {
     this.cleanupAfterRender = false;
     this.pendingCleanup = false;
     this._intentStates = new Map();
-    this._annotationPromises = new Map();
     this.destroyed = false;
   }
 
@@ -1328,15 +1327,10 @@ class PDFPageProxy {
   getAnnotations({ intent = "display" } = {}) {
     const intentArgs = this._transport.getRenderingIntent(intent);
 
-    let promise = this._annotationPromises.get(intentArgs.cacheKey);
-    if (!promise) {
-      promise = this._transport.getAnnotations(
-        this._pageIndex,
-        intentArgs.renderingIntent
-      );
-      this._annotationPromises.set(intentArgs.cacheKey, promise);
-    }
-    return promise;
+    return this._transport.getAnnotations(
+      this._pageIndex,
+      intentArgs.renderingIntent
+    );
   }
 
   /**
@@ -1655,7 +1649,6 @@ class PDFPageProxy {
       bitmap.close();
     }
     this._bitmaps.clear();
-    this._annotationPromises.clear();
     this._jsActionsPromise = null;
     this.pendingCleanup = false;
     return Promise.all(waitOn);
@@ -1689,7 +1682,6 @@ class PDFPageProxy {
 
     this._intentStates.clear();
     this.objs.clear();
-    this._annotationPromises.clear();
     this._jsActionsPromise = null;
     if (resetStats && this._stats) {
       this._stats = new StatTimer();


### PR DESCRIPTION
 - Don't attempt to re-create the `annotationLayer`, for pages without any annotations, on zooming and rotation

   For pages without any annotations, applies e.g. to the `tracemonkey.pdf` document, we'll repeatedly try to re-create the `annotationLayer` on every zoom and rotation operation.
   The reason that this happens is because we want to avoid inserting an empty `div`-element into the DOM, which thus means that we miss the existing `annotationLayer`-caching present in the `PDFPageView` implementation.

   This is a very old issue, and the easiest solution (as far as I'm concerned) is to simply use a dummy-div such that the existing code/caching starts working for the "no annotations" case as well.

 - Remove the API-caching of annotation-data

   This was essentially done only to compensate for the viewer calling `PDFPageProxy.getAnnotations` unconditionally on every annotationLayer-rendering invocation. With the previous patch that's no longer happening, and this API-caching should thus no longer be necessary.