### PR TITLE
Use indirect eval for require in display/api.js

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2273,7 +2273,7 @@ class PDFWorker {
         // the Webpack warnings instead (telling users to ignore them).
         //
         // eslint-disable-next-line no-eval
-        const worker = eval("require")(this.workerSrc);
+        const worker = (0, eval)("require")(this.workerSrc);
         return worker.WorkerMessageHandler;
       }
       await loadScript(this.workerSrc);


### PR DESCRIPTION
When using pdfjs-dist with Rollup, it creates a warning because of the use of eval.

This is because using eval like `eval("require")` means the string can potentially reference any variable in scope currently which causes issues with minification. See https://esbuild.github.io/content-types/#direct-eval for a better explanation.

Using it as `(0, eval)("require")` causes the evaluation to occur in the global scope, which is fine because require is a global in node. The behaviour should be identical for the current use and this gets rid of the warning.