### PR TITLE
Handle possibly undefined parameters *once* per `AnnotationLayer.render` invocation

### DIFF
--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -42,7 +42,7 @@ import { PresentationModeState } from "./ui_utils.js";
  * @property {Promise<Object<string, Array<Object>> | null>}
  *   [fieldObjectsPromise]
  * @property {Map<string, HTMLCanvasElement>} [annotationCanvasMap]
- * @property {TextAccessibilityManager} accessibilityManager
+ * @property {TextAccessibilityManager} [accessibilityManager]
  */
 
 class AnnotationLayerBuilder {


### PR DESCRIPTION
There's no reason to repeat this for every single annotation. Also, adds a couple of missing JSDoc-parameters.