### PR TITLE
[api-minor] Allow specifying an extra-delay, in `RenderTask.cancel`, for worker-thread aborting of operatorList parsing

### DIFF
--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -332,9 +332,10 @@ class PageViewport {
 }
 
 class RenderingCancelledException extends BaseException {
-  constructor(msg, type) {
+  constructor(msg, type, extraDelay = 0) {
     super(msg, "RenderingCancelledException");
     this.type = type;
+    this.extraDelay = extraDelay;
   }
 }
 

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -2870,6 +2870,7 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
         expect(reason instanceof RenderingCancelledException).toEqual(true);
         expect(reason.message).toEqual("Rendering cancelled, page 1");
         expect(reason.type).toEqual("canvas");
+        expect(reason.extraDelay).toEqual(0);
       }
 
       CanvasFactory.destroy(canvasAndCtx);


### PR DESCRIPTION
This is done to support upcoming viewer-changes, and in order to prevent third-party users from outright breaking things we'll simply ignore too large values.