### PR TITLE
[GeckoView] Ignore the pageLayout, from the PDF document, to prevent issues

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1236,7 +1236,10 @@ const PDFViewerApplication = {
           if (pageMode && sidebarView === SidebarView.UNKNOWN) {
             sidebarView = apiPageModeToSidebarView(pageMode);
           }
+          // NOTE: Always ignore the pageLayout in GeckoView since there's
+          // no UI available to change Scroll/Spread modes for the user.
           if (
+            (typeof PDFJSDev === "undefined" || !PDFJSDev.test("GECKOVIEW")) &&
             pageLayout &&
             scrollMode === ScrollMode.UNKNOWN &&
             spreadMode === SpreadMode.UNKNOWN

--- a/web/pdf_scripting_manager.js
+++ b/web/pdf_scripting_manager.js
@@ -265,13 +265,19 @@ class PDFScriptingManager {
         case "error":
           console.error(value);
           break;
-        case "layout":
-          if (isInPresentationMode) {
+        case "layout": {
+          // NOTE: Always ignore the pageLayout in GeckoView since there's
+          // no UI available to change Scroll/Spread modes for the user.
+          if (
+            (typeof PDFJSDev !== "undefined" && PDFJSDev.test("GECKOVIEW")) ||
+            isInPresentationMode
+          ) {
             return;
           }
           const modes = apiPageLayoutToViewerModes(value);
           this._pdfViewer.spreadMode = modes.spreadMode;
           break;
+        }
         case "page-num":
           this._pdfViewer.currentPageNumber = value + 1;
           break;

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -769,9 +769,6 @@ function getActiveOrFocusedElement() {
 
 /**
  * Converts API PageLayout values to the format used by `BaseViewer`.
- * NOTE: This is supported to the extent that the viewer implements the
- *       necessary Scroll/Spread modes (since SinglePage, TwoPageLeft,
- *       and TwoPageRight all suggests using non-continuous scrolling).
  * @param {string} mode - The API PageLayout value.
  * @returns {Object}
  */


### PR DESCRIPTION
First of all, given the screen-sizes of most mobile phones using Spread modes is unlikely to be useful.
Secondly, and more importantly, since there's (currently) no UI available for the user to override a PDF document-specified Spread mode this would result in a bad UX otherwise.

Also, removes an outdated comment from the `apiPageLayoutToViewerModes` helper function.