### PR TITLE
Ensure that the `loadingIconDiv` is always visible (PR 15829 follow-up)

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -490,6 +490,7 @@ class PDFPageView {
       div.append(this.loadingIconDiv);
     } else {
       this.toggleLoadingIconSpinner();
+      div.append(this.loadingIconDiv);
     }
 
     if (


### PR DESCRIPTION
After the changes in PR #15829 the `loadingIconDiv` is no longer always visible when it should be, specifically in the case where we cancel and re-render a partially parsed/rendered page.
To reproduce this, try opening https://github.com/mozilla/pdf.js/files/1522715/wuppertal_2012.pdf in the viewer and change the zoom level while rendering is ongoing. In this case the `loadingIconDiv` doesn't actually become visible, despite being present in the DOM, since it's no longer at the end of the page-div.

I don't know to what extent this renders PR #15829 "pointless", however we're not repeatedly re-creating and re-inserting the `loadingIconDiv` but rather just *move* the existing element in the DOM.