### PR TITLE
Always abort a pending `streamReader` cancel timeout in `PDFPageProxy._abortOperatorList` (PR 15825 follow-up)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1825,6 +1825,12 @@ class PDFPageProxy {
     if (!intentState.streamReader) {
       return;
     }
+    // Ensure that a pending `streamReader` cancel timeout is always aborted.
+    if (intentState.streamReaderCancelTimeout) {
+      clearTimeout(intentState.streamReaderCancelTimeout);
+      intentState.streamReaderCancelTimeout = null;
+    }
+
     if (!force) {
       // Ensure that an Error occurring in *only* one `InternalRenderTask`, e.g.
       // multiple render() calls on the same canvas, won't break all rendering.
@@ -1841,12 +1847,9 @@ class PDFPageProxy {
           delay += reason.extraDelay;
         }
 
-        if (intentState.streamReaderCancelTimeout) {
-          clearTimeout(intentState.streamReaderCancelTimeout);
-        }
         intentState.streamReaderCancelTimeout = setTimeout(() => {
-          this._abortOperatorList({ intentState, reason, force: true });
           intentState.streamReaderCancelTimeout = null;
+          this._abortOperatorList({ intentState, reason, force: true });
         }, delay);
         return;
       }


### PR DESCRIPTION
When we're destroying a `PDFPageProxy`-instance, during full document destruction, we'll force-abort any worker-thread parsing of operatorLists. Hence we should make sure that any pending cancel timeout is always aborted, since a later `PDFPageProxy._abortOperatorList` call should always "replace" a previous one.

*Please note:* Technically this was always wrong, but with the changes in PR #15825 it became *ever so slightly* easier to trigger this thanks to the potentially longer timeout.