### PR TITLE
Remove `PDFPageProxy.getJSActions` caching, since it's unused, in the API

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1338,9 +1338,7 @@ class PDFPageProxy {
    *   {Object} with JS actions.
    */
   getJSActions() {
-    return (this._jsActionsPromise ||= this._transport.getPageJSActions(
-      this._pageIndex
-    ));
+    return this._transport.getPageJSActions(this._pageIndex);
   }
 
   /**
@@ -1656,7 +1654,6 @@ class PDFPageProxy {
       bitmap.close();
     }
     this._bitmaps.clear();
-    this._jsActionsPromise = null;
     this.pendingCleanup = false;
     return Promise.all(waitOn);
   }
@@ -1689,7 +1686,6 @@ class PDFPageProxy {
 
     this._intentStates.clear();
     this.objs.clear();
-    this._jsActionsPromise = null;
     if (resetStats && this._stats) {
       this._stats = new StatTimer();
     }


### PR DESCRIPTION
Note how, in the scripting initialization in the viewer, we only ever invoke `PDFPageProxy.getJSActions` *once* per page in order to improve overall performance; see https://github.com/mozilla/pdf.js/blob/a575aa13b9e4ce7e671be7794e7a7296406a3087/web/pdf_scripting_manager.js#L372-L375

Hence it really shouldn't be necessary to cache its result in the API, especially when that is done *manually* rather than using something like `shadow`.