### PR TITLE
[Regression] Ensure that documents with varying page sizes are initialized correctly (PR 15812 follow-up)

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -196,7 +196,6 @@ class PDFPageView {
     this.div = div;
 
     this.#setDimensions();
-
     container?.append(div);
 
     if (
@@ -230,10 +229,12 @@ class PDFPageView {
 
   #setDimensions() {
     const { viewport } = this;
-    if (this.#previousRotation === viewport.rotation) {
-      return;
+    if (this.pdfPage) {
+      if (this.#previousRotation === viewport.rotation) {
+        return;
+      }
+      this.#previousRotation = viewport.rotation;
     }
-    this.#previousRotation = viewport.rotation;
 
     setLayerDimensions(
       this.div,


### PR DESCRIPTION
The rotation-caching added in PR #15812 completely breaks initialization of PDF documents with varying page sizes, causing all pages to wrongly get the same size; see e.g. `sizes.pdf` from the test-suite.
To fix that without having to e.g. add a new parameter, which feels error prone, this patch changes the `PDFPageView.#setDimensions` method to completely ignore the rotation-caching until the `setPdfPage`-method has been called.