### PR TITLE
Improve name consistency in the viewer (PR 15812 follow-up)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -656,7 +656,7 @@ const PDFViewerApplication = {
       return;
     }
     this.pdfViewer.increaseScale(steps, {
-      delay: AppOptions.get("defaultZoomDelay"),
+      drawingDelay: AppOptions.get("defaultZoomDelay"),
     });
   },
 
@@ -665,7 +665,7 @@ const PDFViewerApplication = {
       return;
     }
     this.pdfViewer.decreaseScale(steps, {
-      delay: AppOptions.get("defaultZoomDelay"),
+      drawingDelay: AppOptions.get("defaultZoomDelay"),
     });
   },
 

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -599,7 +599,6 @@ class PDFPageView {
         isScalingRestricted = true;
       }
     }
-
     const postponeDrawing = drawingDelay >= 0 && drawingDelay < 1000;
 
     if (this.canvas) {

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -1083,7 +1083,7 @@ class PDFViewer {
   _setScaleUpdatePages(
     newScale,
     newValue,
-    { noScroll = false, preset = false, delay: drawingDelay = -1 }
+    { noScroll = false, preset = false, drawingDelay = -1 }
   ) {
     this._currentScaleValue = newValue.toString();
 
@@ -1103,16 +1103,13 @@ class PDFViewer {
       newScale * PixelsPerInch.PDF_TO_CSS_UNITS
     );
 
-    const mustPostponeDrawing = drawingDelay >= 0 && drawingDelay < 1000;
-    const updateArgs = {
+    const postponeDrawing = drawingDelay >= 0 && drawingDelay < 1000;
+    this.refresh(true, {
       scale: newScale,
-    };
-    if (mustPostponeDrawing) {
-      updateArgs.drawingDelay = drawingDelay;
-    }
-    this.refresh(true, updateArgs);
+      drawingDelay: postponeDrawing ? drawingDelay : -1,
+    });
 
-    if (mustPostponeDrawing) {
+    if (postponeDrawing) {
       this.#scaleTimeoutId = setTimeout(() => {
         this.#scaleTimeoutId = null;
         this.refresh();


### PR DESCRIPTION
This tweaks a few name that originated in PR #15812, to improve overall consistency:
 - Use the `drawingDelay` parameter-name in all methods that accept a delay.
 - Use the `postponeDrawing` variable-name in all relevant methods.