### PR TITLE
[api-minor] Improve the `useWorkerFetch` default value checks

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -47,6 +47,7 @@ import {
   DOMCMapReaderFactory,
   DOMStandardFontDataFactory,
   isDataScheme,
+  isValidFetchUrl,
   loadScript,
   PageViewport,
   RenderingCancelledException,
@@ -363,8 +364,11 @@ function getDocument(src) {
   }
   if (typeof params.useWorkerFetch !== "boolean") {
     params.useWorkerFetch =
-      params.CMapReaderFactory === DOMCMapReaderFactory &&
-      params.StandardFontDataFactory === DOMStandardFontDataFactory;
+      (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) ||
+      (params.CMapReaderFactory === DOMCMapReaderFactory &&
+        params.StandardFontDataFactory === DOMStandardFontDataFactory &&
+        isValidFetchUrl(params.cMapUrl, document.baseURI) &&
+        isValidFetchUrl(params.standardFontDataUrl, document.baseURI));
   }
   if (typeof params.isEvalSupported !== "boolean") {
     params.isEvalSupported = true;


### PR DESCRIPTION
Given that the Fetch API only supports the http/https protocols, worker-thread fetching of CMaps and Standard-fonts may thus fail in certain cases. To improve the default behaviour we'll now also check that the `cMapUrl` and `standardFontDataUrl` options are appropriate, except in Firefox where this should always work.