### PR TITLE
[api-minor] Remove the `PDFDocumentProxy.stats` getter (PR 15758 follow-up)

### DIFF
--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -17,9 +17,7 @@ import {
   AnnotationEditorPrefix,
   assert,
   BaseException,
-  FontType,
   objectSize,
-  StreamType,
   stringToPDFString,
   warn,
 } from "../shared/util.js";
@@ -79,55 +77,6 @@ class XRefEntryException extends BaseException {
 class XRefParseException extends BaseException {
   constructor(msg) {
     super(msg, "XRefParseException");
-  }
-}
-
-class DocStats {
-  constructor(handler) {
-    this._handler = handler;
-
-    this._streamTypes = new Set();
-    this._fontTypes = new Set();
-  }
-
-  _send() {
-    const streamTypes = Object.create(null),
-      fontTypes = Object.create(null);
-    for (const type of this._streamTypes) {
-      streamTypes[type] = true;
-    }
-    for (const type of this._fontTypes) {
-      fontTypes[type] = true;
-    }
-    this._handler.send("DocStats", { streamTypes, fontTypes });
-  }
-
-  addStreamType(type) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
-      assert(StreamType[type] === type, 'addStreamType: Invalid "type" value.');
-    }
-    if (this._streamTypes.has(type)) {
-      return;
-    }
-    this._streamTypes.add(type);
-    this._send();
-  }
-
-  addFontType(type) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
-      assert(FontType[type] === type, 'addFontType: Invalid "type" value.');
-    }
-    if (this._fontTypes.has(type)) {
-      return;
-    }
-    this._fontTypes.add(type);
-    this._send();
   }
 }
 
@@ -631,7 +580,6 @@ function getRotationMatrix(rotation, width, height) {
 
 export {
   collectActions,
-  DocStats,
   encodeToXmlString,
   escapePDFName,
   escapeString,

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -222,11 +222,13 @@ class Page {
    */
   _onSubStreamError(handler, reason, objId) {
     if (this.evaluatorOptions.ignoreErrors) {
-      // Error(s) when reading one of the /Contents sub-streams -- sending
-      // unsupported feature notification and allow parsing to continue.
-      handler.send("UnsupportedFeature", {
-        featureId: UNSUPPORTED_FEATURES.errorContentSubStream,
-      });
+      if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+        // Error(s) when reading one of the /Contents sub-streams -- sending
+        // unsupported feature notification and allow parsing to continue.
+        handler.send("UnsupportedFeature", {
+          featureId: UNSUPPORTED_FEATURES.errorContentSubStream,
+        });
+      }
       warn(`getContentStream - ignoring sub-stream (${objId}): "${reason}".`);
       return;
     }

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -929,11 +929,13 @@ class PartialEvaluator {
           return;
         }
         if (this.options.ignoreErrors) {
-          // Error(s) in the TilingPattern -- sending unsupported feature
-          // notification and allow rendering to continue.
-          this.handler.send("UnsupportedFeature", {
-            featureId: UNSUPPORTED_FEATURES.errorTilingPattern,
-          });
+          if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+            // Error(s) in the TilingPattern -- sending unsupported feature
+            // notification and allow rendering to continue.
+            this.handler.send("UnsupportedFeature", {
+              featureId: UNSUPPORTED_FEATURES.errorTilingPattern,
+            });
+          }
           warn(`handleTilingType - ignoring pattern: "${reason}".`);
           return;
         }
@@ -975,11 +977,13 @@ class PartialEvaluator {
             return translated;
           })
           .catch(reason => {
-            // Error in the font data -- sending unsupported feature
-            // notification.
-            this.handler.send("UnsupportedFeature", {
-              featureId: UNSUPPORTED_FEATURES.errorFontLoadType3,
-            });
+            if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+              // Error in the font data -- sending unsupported feature
+              // notification.
+              this.handler.send("UnsupportedFeature", {
+                featureId: UNSUPPORTED_FEATURES.errorFontLoadType3,
+              });
+            }
             return new TranslatedFont({
               loadedName: "g_font_error",
               font: new ErrorFont(`Type3 font load error: ${reason}`),
@@ -1029,11 +1033,13 @@ class PartialEvaluator {
     );
 
     if (this.options.ignoreErrors) {
-      // Missing setFont operator before text rendering operator -- sending
-      // unsupported feature notification and allow rendering to continue.
-      this.handler.send("UnsupportedFeature", {
-        featureId: UNSUPPORTED_FEATURES.errorFontState,
-      });
+      if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+        // Missing setFont operator before text rendering operator -- sending
+        // unsupported feature notification and allow rendering to continue.
+        this.handler.send("UnsupportedFeature", {
+          featureId: UNSUPPORTED_FEATURES.errorFontState,
+        });
+      }
       warn(`ensureStateFont: "${reason}".`);
       return;
     }
@@ -1191,10 +1197,12 @@ class PartialEvaluator {
         warn(`${partialMsg}.`);
         return errorFont();
       }
-      // Font not found -- sending unsupported feature notification.
-      this.handler.send("UnsupportedFeature", {
-        featureId: UNSUPPORTED_FEATURES.errorFontMissing,
-      });
+      if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+        // Font not found -- sending unsupported feature notification.
+        this.handler.send("UnsupportedFeature", {
+          featureId: UNSUPPORTED_FEATURES.errorFontMissing,
+        });
+      }
       warn(`${partialMsg} -- attempting to fallback to a default font.`);
 
       // Falling back to a default font to avoid completely broken rendering,
@@ -1313,10 +1321,12 @@ class PartialEvaluator {
       })
       .catch(reason => {
         // TODO fontCapability.reject?
-        // Error in the font data -- sending unsupported feature notification.
-        this.handler.send("UnsupportedFeature", {
-          featureId: UNSUPPORTED_FEATURES.errorFontTranslate,
-        });
+        if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+          // Error in the font data -- sending unsupported feature notification.
+          this.handler.send("UnsupportedFeature", {
+            featureId: UNSUPPORTED_FEATURES.errorFontTranslate,
+          });
+        }
         warn(`loadFont - translateFont failed: "${reason}".`);
 
         fontCapability.resolve(
@@ -1422,11 +1432,13 @@ class PartialEvaluator {
         return null;
       }
       if (this.options.ignoreErrors) {
-        // Error(s) in the ColorSpace -- sending unsupported feature
-        // notification and allow rendering to continue.
-        this.handler.send("UnsupportedFeature", {
-          featureId: UNSUPPORTED_FEATURES.errorColorSpace,
-        });
+        if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+          // Error(s) in the ColorSpace -- sending unsupported feature
+          // notification and allow rendering to continue.
+          this.handler.send("UnsupportedFeature", {
+            featureId: UNSUPPORTED_FEATURES.errorColorSpace,
+          });
+        }
         warn(`parseColorSpace - ignoring ColorSpace: "${reason}".`);
         return null;
       }
@@ -1811,11 +1823,16 @@ class PartialEvaluator {
                   return;
                 }
                 if (self.options.ignoreErrors) {
-                  // Error(s) in the XObject -- sending unsupported feature
-                  // notification and allow rendering to continue.
-                  self.handler.send("UnsupportedFeature", {
-                    featureId: UNSUPPORTED_FEATURES.errorXObject,
-                  });
+                  if (
+                    typeof PDFJSDev === "undefined" ||
+                    PDFJSDev.test("GENERIC")
+                  ) {
+                    // Error(s) in the XObject -- sending unsupported feature
+                    // notification and allow rendering to continue.
+                    self.handler.send("UnsupportedFeature", {
+                      featureId: UNSUPPORTED_FEATURES.errorXObject,
+                    });
+                  }
                   warn(`getOperatorList - ignoring XObject: "${reason}".`);
                   return;
                 }
@@ -2130,11 +2147,16 @@ class PartialEvaluator {
                   return;
                 }
                 if (self.options.ignoreErrors) {
-                  // Error(s) in the ExtGState -- sending unsupported feature
-                  // notification and allow parsing/rendering to continue.
-                  self.handler.send("UnsupportedFeature", {
-                    featureId: UNSUPPORTED_FEATURES.errorExtGState,
-                  });
+                  if (
+                    typeof PDFJSDev === "undefined" ||
+                    PDFJSDev.test("GENERIC")
+                  ) {
+                    // Error(s) in the ExtGState -- sending unsupported feature
+                    // notification and allow parsing/rendering to continue.
+                    self.handler.send("UnsupportedFeature", {
+                      featureId: UNSUPPORTED_FEATURES.errorExtGState,
+                    });
+                  }
                   warn(`getOperatorList - ignoring ExtGState: "${reason}".`);
                   return;
                 }
@@ -2182,9 +2204,14 @@ class PartialEvaluator {
                       return;
                     }
                     if (self.options.ignoreErrors) {
-                      self.handler.send("UnsupportedFeature", {
-                        featureId: UNSUPPORTED_FEATURES.errorMarkedContent,
-                      });
+                      if (
+                        typeof PDFJSDev === "undefined" ||
+                        PDFJSDev.test("GENERIC")
+                      ) {
+                        self.handler.send("UnsupportedFeature", {
+                          featureId: UNSUPPORTED_FEATURES.errorMarkedContent,
+                        });
+                      }
                       warn(
                         `getOperatorList - ignoring beginMarkedContentProps: "${reason}".`
                       );
@@ -2235,11 +2262,13 @@ class PartialEvaluator {
         return;
       }
       if (this.options.ignoreErrors) {
-        // Error(s) in the OperatorList -- sending unsupported feature
-        // notification and allow rendering to continue.
-        this.handler.send("UnsupportedFeature", {
-          featureId: UNSUPPORTED_FEATURES.errorOperatorList,
-        });
+        if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+          // Error(s) in the OperatorList -- sending unsupported feature
+          // notification and allow rendering to continue.
+          this.handler.send("UnsupportedFeature", {
+            featureId: UNSUPPORTED_FEATURES.errorOperatorList,
+          });
+        }
         warn(
           `getOperatorList - ignoring errors during "${task.name}" ` +
             `task: "${reason}".`
@@ -3734,11 +3763,13 @@ class PartialEvaluator {
             return null;
           }
           if (this.options.ignoreErrors) {
-            // Error in the ToUnicode data -- sending unsupported feature
-            // notification and allow font parsing to continue.
-            this.handler.send("UnsupportedFeature", {
-              featureId: UNSUPPORTED_FEATURES.errorFontToUnicode,
-            });
+            if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+              // Error in the ToUnicode data -- sending unsupported feature
+              // notification and allow font parsing to continue.
+              this.handler.send("UnsupportedFeature", {
+                featureId: UNSUPPORTED_FEATURES.errorFontToUnicode,
+              });
+            }
             warn(`readToUnicode - ignoring ToUnicode data: "${reason}".`);
             return null;
           }
@@ -4312,11 +4343,13 @@ class PartialEvaluator {
         ]);
       } catch (reason) {
         if (evaluatorOptions.ignoreErrors) {
-          // Error in the font data -- sending unsupported feature notification
-          // and allow glyph path building to continue.
-          handler.send("UnsupportedFeature", {
-            featureId: UNSUPPORTED_FEATURES.errorFontBuildPath,
-          });
+          if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+            // Error in the font data -- sending unsupported feature
+            // notification and allow glyph path building to continue.
+            handler.send("UnsupportedFeature", {
+              featureId: UNSUPPORTED_FEATURES.errorFontBuildPath,
+            });
+          }
           warn(`buildFontPaths - ignoring ${glyphName} glyph: "${reason}".`);
           return;
         }

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -35,7 +35,6 @@ import {
 import { CMapFactory, IdentityCMap } from "./cmap.js";
 import { Cmd, Dict, EOF, isName, Name, Ref, RefSet } from "./primitives.js";
 import { ErrorFont, Font } from "./fonts.js";
-import { FontFlags, getFontType } from "./fonts_utils.js";
 import {
   getEncoding,
   MacRomanEncoding,
@@ -67,6 +66,7 @@ import { BaseStream } from "./base_stream.js";
 import { bidi } from "./bidi.js";
 import { ColorSpace } from "./colorspace.js";
 import { DecodeStream } from "./decode_stream.js";
+import { FontFlags } from "./fonts_utils.js";
 import { getGlyphsUnicode } from "./glyphlist.js";
 import { getLookupTableFactory } from "./core_utils.js";
 import { getMetrics } from "./metrics.js";
@@ -1302,10 +1302,6 @@ class PartialEvaluator {
 
     this.translateFont(preEvaluatedFont)
       .then(translatedFont => {
-        if (translatedFont.fontType !== undefined) {
-          xref.stats.addFontType(translatedFont.fontType);
-        }
-
         fontCapability.resolve(
           new TranslatedFont({
             loadedName: font.loadedName,
@@ -1322,19 +1318,6 @@ class PartialEvaluator {
           featureId: UNSUPPORTED_FEATURES.errorFontTranslate,
         });
         warn(`loadFont - translateFont failed: "${reason}".`);
-
-        try {
-          // error, but it's still nice to have font type reported
-          const fontFile3 = descriptor && descriptor.get("FontFile3");
-          const subtype = fontFile3 && fontFile3.get("Subtype");
-          const fontType = getFontType(
-            preEvaluatedFont.type,
-            subtype && subtype.name
-          );
-          if (fontType !== undefined) {
-            xref.stats.addFontType(fontType);
-          }
-        } catch (ex) {}
 
         fontCapability.resolve(
           new TranslatedFont({

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -17,7 +17,6 @@ import {
   assert,
   bytesToString,
   FONT_IDENTITY_MATRIX,
-  FontType,
   FormatError,
   info,
   shadow,
@@ -27,7 +26,6 @@ import {
 import { CFFCompiler, CFFParser } from "./cff_parser.js";
 import {
   FontFlags,
-  getFontType,
   MacStandardGlyphOrdering,
   normalizeFontName,
   recoverGlyphName,
@@ -92,7 +90,6 @@ const EXPORT_DATA_PROPERTIES = [
   "descent",
   "fallbackName",
   "fontMatrix",
-  "fontType",
   "isInvalidPDFjsFont",
   "isType3Font",
   "italic",
@@ -986,7 +983,6 @@ class Font {
         this.toFontChar[charCode] =
           this.differences[charCode] || properties.defaultEncoding[charCode];
       }
-      this.fontType = FontType.TYPE3;
       return;
     }
 
@@ -1066,7 +1062,6 @@ class Font {
 
     amendFallbackToUnicode(properties);
     this.data = data;
-    this.fontType = getFontType(type, subtype, properties.isStandardFont);
 
     // Transfer some properties again that could change during font conversion
     this.fontMatrix = properties.fontMatrix;
@@ -1102,9 +1097,7 @@ class Font {
     this.missingFile = true;
     // The file data is not specified. Trying to fix the font name
     // to be used with the canvas.font.
-    const name = this.name;
-    const type = this.type;
-    const subtype = this.subtype;
+    const { name, type } = this;
     let fontName = normalizeFontName(name);
     const stdFontMap = getStdFontMap(),
       nonStdFontMap = getNonStdFontMap();
@@ -1252,7 +1245,6 @@ class Font {
 
     amendFallbackToUnicode(properties);
     this.loadedName = fontName.split("-")[0];
-    this.fontType = getFontType(type, subtype, properties.isStandardFont);
   }
 
   checkAndRepair(name, font, properties) {

--- a/src/core/fonts_utils.js
+++ b/src/core/fonts_utils.js
@@ -13,10 +13,10 @@
  * limitations under the License.
  */
 
-import { FontType, info } from "../shared/util.js";
 import { getEncoding, StandardEncoding } from "./encodings.js";
 import { getGlyphsUnicode } from "./glyphlist.js";
 import { getUnicodeForGlyph } from "./unicode.js";
+import { info } from "../shared/util.js";
 
 // Accented characters have issues on Windows and Linux. When this flag is
 // enabled glyphs that use seac and seac style endchar operators are truncated
@@ -77,32 +77,6 @@ const MacStandardGlyphOrdering = [
   "onesuperior", "twosuperior", "threesuperior", "onehalf", "onequarter",
   "threequarters", "franc", "Gbreve", "gbreve", "Idotaccent", "Scedilla",
   "scedilla", "Cacute", "cacute", "Ccaron", "ccaron", "dcroat"];
-
-function getFontType(type, subtype, isStandardFont = false) {
-  switch (type) {
-    case "Type1":
-      if (isStandardFont) {
-        return FontType.TYPE1STANDARD;
-      }
-      return subtype === "Type1C" ? FontType.TYPE1C : FontType.TYPE1;
-    case "CIDFontType0":
-      return subtype === "CIDFontType0C"
-        ? FontType.CIDFONTTYPE0C
-        : FontType.CIDFONTTYPE0;
-    case "OpenType":
-      return FontType.OPENTYPE;
-    case "TrueType":
-      return FontType.TRUETYPE;
-    case "CIDFontType2":
-      return FontType.CIDFONTTYPE2;
-    case "MMType1":
-      return FontType.MMTYPE1;
-    case "Type0":
-      return FontType.TYPE0;
-    default:
-      return FontType.UNKNOWN;
-  }
-}
 
 // Some bad PDF generators, e.g. Scribus PDF, include glyph names
 // in a 'uniXXXX' format -- attempting to recover proper ones.
@@ -212,7 +186,6 @@ function normalizeFontName(name) {
 
 export {
   FontFlags,
-  getFontType,
   MacStandardGlyphOrdering,
   normalizeFontName,
   recoverGlyphName,

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -18,7 +18,6 @@ import {
   bytesToString,
   FormatError,
   info,
-  StreamType,
   warn,
 } from "../shared/util.js";
 import { Cmd, Dict, EOF, isCmd, Name, Ref } from "./primitives.js";
@@ -732,13 +731,11 @@ class Parser {
       warn(`Empty "${name}" stream.`);
       return new NullStream();
     }
-    const xrefStats = this.xref.stats;
 
     try {
       switch (name) {
         case "Fl":
         case "FlateDecode":
-          xrefStats.addStreamType(StreamType.FLATE);
           if (params) {
             return new PredictorStream(
               new FlateStream(stream, maybeLength),
@@ -749,7 +746,6 @@ class Parser {
           return new FlateStream(stream, maybeLength);
         case "LZW":
         case "LZWDecode":
-          xrefStats.addStreamType(StreamType.LZW);
           let earlyChange = 1;
           if (params) {
             if (params.has("EarlyChange")) {
@@ -764,30 +760,23 @@ class Parser {
           return new LZWStream(stream, maybeLength, earlyChange);
         case "DCT":
         case "DCTDecode":
-          xrefStats.addStreamType(StreamType.DCT);
           return new JpegStream(stream, maybeLength, params);
         case "JPX":
         case "JPXDecode":
-          xrefStats.addStreamType(StreamType.JPX);
           return new JpxStream(stream, maybeLength, params);
         case "A85":
         case "ASCII85Decode":
-          xrefStats.addStreamType(StreamType.A85);
           return new Ascii85Stream(stream, maybeLength);
         case "AHx":
         case "ASCIIHexDecode":
-          xrefStats.addStreamType(StreamType.AHX);
           return new AsciiHexStream(stream, maybeLength);
         case "CCF":
         case "CCITTFaxDecode":
-          xrefStats.addStreamType(StreamType.CCF);
           return new CCITTFaxStream(stream, maybeLength, params);
         case "RL":
         case "RunLengthDecode":
-          xrefStats.addStreamType(StreamType.RLX);
           return new RunLengthStream(stream, maybeLength);
         case "JBIG2Decode":
-          xrefStats.addStreamType(StreamType.JBIG);
           return new Jbig2Stream(stream, maybeLength, params);
       }
       warn(`Filter "${name}" is not supported.`);

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -82,9 +82,11 @@ class Pattern {
       if (ex instanceof MissingDataException) {
         throw ex;
       }
-      handler.send("UnsupportedFeature", {
-        featureId: UNSUPPORTED_FEATURES.shadingPattern,
-      });
+      if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+        handler.send("UnsupportedFeature", {
+          featureId: UNSUPPORTED_FEATURES.shadingPattern,
+        });
+      }
       warn(ex);
       return new DummyShading();
     }

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -22,14 +22,13 @@ import {
   warn,
 } from "../shared/util.js";
 import { CIRCULAR_REF, Cmd, Dict, isCmd, Ref, RefSet } from "./primitives.js";
+import { Lexer, Parser } from "./parser.js";
 import {
-  DocStats,
   MissingDataException,
   ParserEOFException,
   XRefEntryException,
   XRefParseException,
 } from "./core_utils.js";
-import { Lexer, Parser } from "./parser.js";
 import { BaseStream } from "./base_stream.js";
 import { CipherTransformFactory } from "./crypto.js";
 
@@ -41,7 +40,6 @@ class XRef {
     this.xrefstms = Object.create(null);
     this._cacheMap = new Map(); // Prepare the XRef cache.
     this._pendingRefs = new RefSet();
-    this.stats = new DocStats(pdfManager.msgHandler);
     this._newPersistentRefNum = null;
     this._newTemporaryRefNum = null;
   }

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -759,27 +759,6 @@ class PDFDocumentProxy {
   }
 
   /**
-   * @typedef {Object} PDFDocumentStats
-   * @property {Object<string, boolean>} streamTypes - Used stream types in the
-   *   document (an item is set to true if specific stream ID was used in the
-   *   document).
-   * @property {Object<string, boolean>} fontTypes - Used font types in the
-   *   document (an item is set to true if specific font ID was used in the
-   *   document).
-   */
-
-  /**
-   * @type {PDFDocumentStats | null} The current statistics about document
-   *   structures, or `null` when no statistics exists.
-   */
-  get stats() {
-    deprecated(
-      "The PDFDocumentProxy stats property will be removed in the future."
-    );
-    return this._transport.stats;
-  }
-
-  /**
    * @type {boolean} True if only XFA form.
    */
   get isPureXfa() {
@@ -2296,8 +2275,6 @@ class PDFWorker {
  * @ignore
  */
 class WorkerTransport {
-  #docStats = null;
-
   #pageCache = new Map();
 
   #pagePromises = new Map();
@@ -2339,10 +2316,6 @@ class WorkerTransport {
 
   get annotationStorage() {
     return shadow(this, "annotationStorage", new AnnotationStorage());
-  }
-
-  get stats() {
-    return this.#docStats;
   }
 
   getRenderingIntent(
@@ -2772,18 +2745,6 @@ class WorkerTransport {
       loadingTask.onProgress?.({
         loaded: data.loaded,
         total: data.total,
-      });
-    });
-
-    messageHandler.on("DocStats", data => {
-      if (this.destroyed) {
-        return; // Ignore any pending requests if the worker was terminated.
-      }
-      // Ensure that a `PDFDocumentProxy.stats` call-site cannot accidentally
-      // modify this internal data.
-      this.#docStats = Object.freeze({
-        streamTypes: Object.freeze(data.streamTypes),
-        fontTypes: Object.freeze(data.fontTypes),
       });
     });
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -609,10 +609,12 @@ class PDFDocumentLoadingTask {
    * @type {function}
    */
   set onUnsupportedFeature(callback) {
-    deprecated(
-      "The PDFDocumentLoadingTask onUnsupportedFeature property will be removed in the future."
-    );
-    this.#onUnsupportedFeature = callback;
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+      deprecated(
+        "The PDFDocumentLoadingTask onUnsupportedFeature property will be removed in the future."
+      );
+      this.#onUnsupportedFeature = callback;
+    }
   }
 
   /**
@@ -2748,10 +2750,12 @@ class WorkerTransport {
       });
     });
 
-    messageHandler.on(
-      "UnsupportedFeature",
-      this._onUnsupportedFeature.bind(this)
-    );
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+      messageHandler.on(
+        "UnsupportedFeature",
+        this._onUnsupportedFeature.bind(this)
+      );
+    }
 
     messageHandler.on("FetchBuiltInCMap", data => {
       if (this.destroyed) {
@@ -2783,10 +2787,12 @@ class WorkerTransport {
   }
 
   _onUnsupportedFeature({ featureId }) {
-    if (this.destroyed) {
-      return; // Ignore any pending requests if the worker was terminated.
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+      if (this.destroyed) {
+        return; // Ignore any pending requests if the worker was terminated.
+      }
+      this.loadingTask.onUnsupportedFeature?.(featureId);
     }
-    this.loadingTask.onUnsupportedFeature?.(featureId);
   }
 
   getData() {

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -30,7 +30,9 @@ class FontLoader {
     ownerDocument = globalThis.document,
     styleElement = null, // For testing only.
   }) {
-    this._onUnsupportedFeature = onUnsupportedFeature;
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+      this._onUnsupportedFeature = onUnsupportedFeature;
+    }
     this._document = ownerDocument;
 
     this.nativeFontFaces = [];
@@ -88,9 +90,11 @@ class FontLoader {
         try {
           await nativeFontFace.loaded;
         } catch (ex) {
-          this._onUnsupportedFeature({
-            featureId: UNSUPPORTED_FEATURES.errorFontLoadNative,
-          });
+          if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+            this._onUnsupportedFeature({
+              featureId: UNSUPPORTED_FEATURES.errorFontLoadNative,
+            });
+          }
           warn(`Failed to load font '${nativeFontFace.family}': '${ex}'.`);
 
           // When font loading failed, fall back to the built-in font renderer.
@@ -340,7 +344,9 @@ class FontFaceObject {
     this.isEvalSupported = isEvalSupported !== false;
     this.disableFontFace = disableFontFace === true;
     this.ignoreErrors = ignoreErrors === true;
-    this._onUnsupportedFeature = onUnsupportedFeature;
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+      this._onUnsupportedFeature = onUnsupportedFeature;
+    }
     this.fontRegistry = fontRegistry;
   }
 
@@ -403,9 +409,11 @@ class FontFaceObject {
       if (!this.ignoreErrors) {
         throw ex;
       }
-      this._onUnsupportedFeature({
-        featureId: UNSUPPORTED_FEATURES.errorFontGetPath,
-      });
+      if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+        this._onUnsupportedFeature({
+          featureId: UNSUPPORTED_FEATURES.errorFontGetPath,
+        });
+      }
       warn(`getPathGenerator - ignoring character: "${ex}".`);
 
       return (this.compiledGlyphs[character] = function (c, size) {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -346,28 +346,31 @@ const OPS = {
   constructPath: 91,
 };
 
-const UNSUPPORTED_FEATURES = {
-  forms: "forms",
-  javaScript: "javaScript",
-  signatures: "signatures",
-  smask: "smask",
-  shadingPattern: "shadingPattern",
-  errorTilingPattern: "errorTilingPattern",
-  errorExtGState: "errorExtGState",
-  errorXObject: "errorXObject",
-  errorFontLoadType3: "errorFontLoadType3",
-  errorFontState: "errorFontState",
-  errorFontMissing: "errorFontMissing",
-  errorFontTranslate: "errorFontTranslate",
-  errorColorSpace: "errorColorSpace",
-  errorOperatorList: "errorOperatorList",
-  errorFontToUnicode: "errorFontToUnicode",
-  errorFontLoadNative: "errorFontLoadNative",
-  errorFontBuildPath: "errorFontBuildPath",
-  errorFontGetPath: "errorFontGetPath",
-  errorMarkedContent: "errorMarkedContent",
-  errorContentSubStream: "errorContentSubStream",
-};
+const UNSUPPORTED_FEATURES =
+  typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")
+    ? {
+        forms: "forms",
+        javaScript: "javaScript",
+        signatures: "signatures",
+        smask: "smask",
+        shadingPattern: "shadingPattern",
+        errorTilingPattern: "errorTilingPattern",
+        errorExtGState: "errorExtGState",
+        errorXObject: "errorXObject",
+        errorFontLoadType3: "errorFontLoadType3",
+        errorFontState: "errorFontState",
+        errorFontMissing: "errorFontMissing",
+        errorFontTranslate: "errorFontTranslate",
+        errorColorSpace: "errorColorSpace",
+        errorOperatorList: "errorOperatorList",
+        errorFontToUnicode: "errorFontToUnicode",
+        errorFontLoadNative: "errorFontLoadNative",
+        errorFontBuildPath: "errorFontBuildPath",
+        errorFontGetPath: "errorFontGetPath",
+        errorMarkedContent: "errorMarkedContent",
+        errorContentSubStream: "errorContentSubStream",
+      }
+    : null;
 
 const PasswordResponses = {
   NEED_PASSWORD: 1,

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -236,34 +236,6 @@ const PageActionEventType = {
   C: "PageClose",
 };
 
-const StreamType = {
-  UNKNOWN: "UNKNOWN",
-  FLATE: "FLATE",
-  LZW: "LZW",
-  DCT: "DCT",
-  JPX: "JPX",
-  JBIG: "JBIG",
-  A85: "A85",
-  AHX: "AHX",
-  CCF: "CCF",
-  RLX: "RLX", // PDF short name is 'RL', but telemetry requires three chars.
-};
-
-const FontType = {
-  UNKNOWN: "UNKNOWN",
-  TYPE1: "TYPE1",
-  TYPE1STANDARD: "TYPE1STANDARD",
-  TYPE1C: "TYPE1C",
-  CIDFONTTYPE0: "CIDFONTTYPE0",
-  CIDFONTTYPE0C: "CIDFONTTYPE0C",
-  TRUETYPE: "TRUETYPE",
-  CIDFONTTYPE2: "CIDFONTTYPE2",
-  TYPE3: "TYPE3",
-  OPENTYPE: "OPENTYPE",
-  TYPE0: "TYPE0",
-  MMTYPE1: "MMTYPE1",
-};
-
 const VerbosityLevel = {
   ERRORS: 0,
   WARNINGS: 1,
@@ -1152,7 +1124,6 @@ export {
   DocumentActionEventType,
   FeatureTest,
   FONT_IDENTITY_MATRIX,
-  FontType,
   FormatError,
   getModificationDate,
   getVerbosityLevel,
@@ -1175,7 +1146,6 @@ export {
   RenderingIntentFlag,
   setVerbosityLevel,
   shadow,
-  StreamType,
   string32,
   stringToBytes,
   stringToPDFString,

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -17,7 +17,6 @@ import {
   AnnotationMode,
   AnnotationType,
   createPromiseCapability,
-  FontType,
   ImageKind,
   InvalidPDFException,
   MissingPDFException,
@@ -25,7 +24,6 @@ import {
   PasswordException,
   PasswordResponses,
   PermissionFlag,
-  StreamType,
   UnknownErrorException,
 } from "../../src/shared/util.js";
 import {
@@ -1846,11 +1844,6 @@ describe("api", function () {
       expect(downloadInfo).toEqual({ length: basicApiFileLength });
     });
 
-    it("gets document stats", async function () {
-      const stats = pdfDocument.stats;
-      expect(stats).toEqual(null);
-    });
-
     it("cleans up document resources", async function () {
       await pdfDocument.cleanup();
 
@@ -2759,24 +2752,6 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
       expect(opList.lastChunk).toEqual(true);
 
       await loadingTask.destroy();
-    });
-
-    it("gets document stats after parsing page", async function () {
-      await page.getOperatorList();
-      const stats = pdfDocument.stats;
-
-      const expectedStreamTypes = {
-        [StreamType.FLATE]: true,
-      };
-      const expectedFontTypes = {
-        [FontType.TYPE1STANDARD]: true,
-        [FontType.CIDFONTTYPE2]: true,
-      };
-
-      expect(stats).toEqual({
-        streamTypes: expectedStreamTypes,
-        fontTypes: expectedFontTypes,
-      });
     });
 
     it("gets page stats after parsing page, without `pdfBug` set", async function () {

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -16,7 +16,6 @@
 import { NullStream, StringStream } from "../../src/core/stream.js";
 import { Page, PDFDocument } from "../../src/core/document.js";
 import { assert } from "../../src/shared/util.js";
-import { DocStats } from "../../src/core/core_utils.js";
 import { isNodeJS } from "../../src/shared/is_node.js";
 import { Ref } from "../../src/core/primitives.js";
 
@@ -77,7 +76,6 @@ function buildGetDocumentParams(filename, options) {
 class XRefMock {
   constructor(array) {
     this._map = Object.create(null);
-    this.stats = new DocStats({ send: () => {} });
     this._newTemporaryRefNum = null;
     this._newPersistentRefNum = null;
     this.stream = new NullStream();


### PR DESCRIPTION
 - [api-minor] Remove the `PDFDocumentProxy.stats` getter (PR 15758 follow-up)

   This was deprecated in PR #15758 and given that it's quite unlikely that any third-party users are relying on this functionality, since it was only ever added to support telemetry reporting in the Firefox PDF Viewer, it should hopefully be fine to remove this fairly quickly.

   These changes reduce the bundle size of the Firefox PDF Viewer by 4.5 kB in total.

 - [api-minor] Limit the `PDFDocumentLoadingTask.onUnsupportedFeature` functionality to GENERIC builds (PR 15758 follow-up)

   This was deprecated in PR #15758 but it's unfortunately quite difficult to tell if third-party users are depending on this, e.g. to implement custom error reporting, and if so to what extent.
   However, thanks to the pre-processor we can limit *most* of this code to GENERIC builds which still seem like a worthwhile change.

   These changes reduce the bundle size of the Firefox PDF Viewer by 3.8 kB in total.