### PR TITLE
Update the `type`/`subtype` at the end of font parsing

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -945,8 +945,7 @@ class Font {
     this.isSymbolicFont = !!(properties.flags & FontFlags.Symbolic);
     this.isMonospace = !!(properties.flags & FontFlags.FixedPitch);
 
-    let type = properties.type;
-    let subtype = properties.subtype;
+    let { type, subtype } = properties;
     this.type = type;
     this.subtype = subtype;
 
@@ -1064,6 +1063,8 @@ class Font {
     this.data = data;
 
     // Transfer some properties again that could change during font conversion
+    this.type = type;
+    this.subtype = subtype;
     this.fontMatrix = properties.fontMatrix;
     this.widths = properties.widths;
     this.defaultWidth = properties.defaultWidth;


### PR DESCRIPTION
This fixes a warning reported by CodeQL, and should also make general sense given that we parse the font-data to determine the *actual* `type`/`subtype` rather than trusting the PDF document.