### PR TITLE
Inline the `setPDFNetworkStreamFactory` functionality in `src/display/api.js`

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -47,6 +47,7 @@ import {
   DOMCMapReaderFactory,
   DOMStandardFontDataFactory,
   isDataScheme,
+  isValidFetchUrl,
   loadScript,
   PageViewport,
   RenderingCancelledException,
@@ -81,32 +82,37 @@ if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("GENERIC") && isNodeJS) {
   DefaultStandardFontDataFactory = NodeStandardFontDataFactory;
 }
 
-/**
- * @typedef {function} IPDFStreamFactory
- * @param {DocumentInitParameters} params - The document initialization
- *   parameters. The "url" key is always present.
- * @returns {Promise} A promise, which is resolved with an instance of
- *   {IPDFStream}.
- * @ignore
- */
-
-/**
- * @type {IPDFStreamFactory}
- * @private
- */
 let createPDFNetworkStream;
+if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
+  const streamsPromise = Promise.all([
+    import("./network.js"),
+    import("./fetch_stream.js"),
+  ]);
 
-/**
- * Sets the function that instantiates an {IPDFStream} as an alternative PDF
- * data transport.
- *
- * @param {IPDFStreamFactory} pdfNetworkStreamFactory - The factory function
- *   that takes document initialization parameters (including a "url") and
- *   returns a promise which is resolved with an instance of {IPDFStream}.
- * @ignore
- */
-function setPDFNetworkStreamFactory(pdfNetworkStreamFactory) {
-  createPDFNetworkStream = pdfNetworkStreamFactory;
+  createPDFNetworkStream = async params => {
+    const [{ PDFNetworkStream }, { PDFFetchStream }] = await streamsPromise;
+
+    return isValidFetchUrl(params.url)
+      ? new PDFFetchStream(params)
+      : new PDFNetworkStream(params);
+  };
+} else if (PDFJSDev.test("GENERIC || CHROME")) {
+  if (PDFJSDev.test("GENERIC") && isNodeJS) {
+    const { PDFNodeStream } = require("./node_stream.js");
+
+    createPDFNetworkStream = params => {
+      return new PDFNodeStream(params);
+    };
+  } else {
+    const { PDFNetworkStream } = require("./network.js");
+    const { PDFFetchStream } = require("./fetch_stream.js");
+
+    createPDFNetworkStream = params => {
+      return isValidFetchUrl(params.url)
+        ? new PDFFetchStream(params)
+        : new PDFNetworkStream(params);
+    };
+  }
 }
 
 /**
@@ -438,6 +444,9 @@ function getDocument(src) {
             rangeTransport
           );
         } else if (!params.data) {
+          if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
+            throw new Error("Not implemented: createPDFNetworkStream");
+          }
           networkStream = createPDFNetworkStream({
             url: params.url,
             length: params.length,
@@ -3349,6 +3358,5 @@ export {
   PDFWorker,
   PDFWorkerUtil,
   RenderTask,
-  setPDFNetworkStreamFactory,
   version,
 };

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -48,7 +48,6 @@ import {
   getDocument,
   PDFDataRangeTransport,
   PDFWorker,
-  setPDFNetworkStreamFactory,
   version,
 } from "./display/api.js";
 import {
@@ -57,7 +56,6 @@ import {
   getXfaPageViewport,
   isDataScheme,
   isPdfFile,
-  isValidFetchUrl,
   loadScript,
   PDFDateString,
   PixelsPerInch,
@@ -69,7 +67,6 @@ import { AnnotationEditorLayer } from "./display/editor/annotation_editor_layer.
 import { AnnotationEditorUIManager } from "./display/editor/tools.js";
 import { AnnotationLayer } from "./display/annotation_layer.js";
 import { GlobalWorkerOptions } from "./display/worker_options.js";
-import { isNodeJS } from "./shared/is_node.js";
 import { SVGGraphics } from "./display/svg.js";
 import { XfaLayer } from "./display/xfa_layer.js";
 
@@ -79,39 +76,6 @@ const pdfjsVersion =
 /* eslint-disable-next-line no-unused-vars */
 const pdfjsBuild =
   typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_BUILD") : void 0;
-
-if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
-  const streamsPromise = Promise.all([
-    import("pdfjs/display/network.js"),
-    import("pdfjs/display/fetch_stream.js"),
-  ]);
-
-  setPDFNetworkStreamFactory(async params => {
-    const [{ PDFNetworkStream }, { PDFFetchStream }] = await streamsPromise;
-    if (isValidFetchUrl(params.url)) {
-      return new PDFFetchStream(params);
-    }
-    return new PDFNetworkStream(params);
-  });
-} else if (PDFJSDev.test("GENERIC || CHROME")) {
-  if (PDFJSDev.test("GENERIC") && isNodeJS) {
-    const { PDFNodeStream } = require("./display/node_stream.js");
-
-    setPDFNetworkStreamFactory(params => {
-      return new PDFNodeStream(params);
-    });
-  } else {
-    const { PDFNetworkStream } = require("./display/network.js");
-    const { PDFFetchStream } = require("./display/fetch_stream.js");
-
-    setPDFNetworkStreamFactory(params => {
-      if (isValidFetchUrl(params.url)) {
-        return new PDFFetchStream(params);
-      }
-      return new PDFNetworkStream(params);
-    });
-  }
-}
 
 export {
   AbortException,

--- a/test/unit/clitests_helper.js
+++ b/test/unit/clitests_helper.js
@@ -15,8 +15,6 @@
 
 import { setVerbosityLevel, VerbosityLevel } from "../../src/shared/util.js";
 import { isNodeJS } from "../../src/shared/is_node.js";
-import { PDFNodeStream } from "../../src/display/node_stream.js";
-import { setPDFNetworkStreamFactory } from "../../src/display/api.js";
 
 // Sets longer timeout, similar to `jasmine-boot.js`.
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
@@ -31,8 +29,3 @@ if (!isNodeJS) {
 // Reduce the amount of console "spam", by ignoring `info`/`warn` calls,
 // when running the unit-tests in Node.js/Travis.
 setVerbosityLevel(VerbosityLevel.ERRORS);
-
-// Set the network stream factory for the unit-tests.
-setPDFNetworkStreamFactory(function (params) {
-  return new PDFNodeStream(params);
-});

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -42,10 +42,6 @@
 
 import { GlobalWorkerOptions } from "pdfjs/display/worker_options.js";
 import { isNodeJS } from "pdfjs/shared/is_node.js";
-import { isValidFetchUrl } from "pdfjs/display/display_utils.js";
-import { PDFFetchStream } from "pdfjs/display/fetch_stream.js";
-import { PDFNetworkStream } from "pdfjs/display/network.js";
-import { setPDFNetworkStreamFactory } from "pdfjs/display/api.js";
 import { TestReporter } from "./testreporter.js";
 
 async function initializePDFJS(callback) {
@@ -107,14 +103,6 @@ async function initializePDFJS(callback) {
       "The `gulp unittest` command cannot be used in Node.js environments."
     );
   }
-  // Set the network stream factory for the unit-tests.
-  setPDFNetworkStreamFactory(params => {
-    if (isValidFetchUrl(params.url)) {
-      return new PDFFetchStream(params);
-    }
-    return new PDFNetworkStream(params);
-  });
-
   // Configure the worker.
   GlobalWorkerOptions.workerSrc = "../../build/generic/build/pdf.worker.js";
 


### PR DESCRIPTION
Given that this is internal functionality, not exposed in the official API, it's not entirely clear (at least to me) why we can't just initialize this directly in `src/display/api.js` instead.
When testing both the development viewer and all the ways in which we run tests, everthing still appears to work just fine with this patch.