### PR TITLE
Tweak the `--toolbar-border-color` CSS variable (PR 15850 follow-up)

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -40,7 +40,7 @@
   --sidebar-narrow-bg-color: rgba(212, 212, 215, 0.9);
   --sidebar-toolbar-bg-color: rgba(245, 246, 247, 1);
   --toolbar-bg-color: rgba(249, 249, 250, 1);
-  --toolbar-border-color: rgba(204, 204, 204, 1);
+  --toolbar-border-color: rgba(184, 184, 184, 1);
   --toolbar-box-shadow: 0 1px 0 var(--toolbar-border-color);
   --toolbar-border-bottom: none;
   --toolbarSidebar-box-shadow: inset calc(-1px * var(--dir-factor)) 0 0


### PR DESCRIPTION
After the changes in PR #15850, the toolbar-border is now quite difficult to spot in the light-theme. Hence, let's tweak it slightly to improve things.