### PR TITLE
Remove the `background-color` of the sidebarContent (PR 15850 follow-up)

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -281,7 +281,6 @@ body {
   overflow: auto;
   position: absolute;
   width: 100%;
-  background-color: rgba(0, 0, 0, 0.05);
   box-shadow: inset calc(-1px * var(--dir-factor)) 0 0 rgba(0, 0, 0, 0.25);
 }
 


### PR DESCRIPTION
After the changes in PR #15850, the `background-color` of the sidebar is now unnecessarily dark in the light-theme. Hence, we can simply remove this CSS rule to improve things overall (and these changes don't affect the dark-theme much at all).
This is even an overall consistency improvement, given the existing `--sidebar-narrow-bg-color` values.