### PR TITLE
Improve unit test coverage of `src/core/core_utils.js`

### DIFF
--- a/test/unit/core_utils_spec.js
+++ b/test/unit/core_utils_spec.js
@@ -23,6 +23,7 @@ import {
   isWhiteSpace,
   log2,
   parseXFAPath,
+  recoverJsURL,
   stringToUTF16HexString,
   stringToUTF16String,
   toRomanNumerals,
@@ -207,6 +208,39 @@ describe("core_utils", function () {
         { name: "FOO", pos: 123 },
         { name: "BAR", pos: 456 },
       ]);
+    });
+  });
+
+  describe("recoverJsURL", function () {
+    it("should get valid URLs without `newWindow` property", function () {
+      const inputs = [
+        "window.open('https://test.local')",
+        "window.open('https://test.local', true)",
+        "app.launchURL('https://test.local')",
+        "app.launchURL('https://test.local', false)",
+        "xfa.host.gotoURL('https://test.local')",
+        "xfa.host.gotoURL('https://test.local', true)",
+      ];
+
+      for (const input of inputs) {
+        expect(recoverJsURL(input)).toEqual({
+          url: "https://test.local",
+          newWindow: false,
+        });
+      }
+    });
+
+    it("should get valid URLs with `newWindow` property", function () {
+      const input = "app.launchURL('https://test.local', true)";
+      expect(recoverJsURL(input)).toEqual({
+        url: "https://test.local",
+        newWindow: true,
+      });
+    });
+
+    it("should not get invalid URLs", function () {
+      const input = "navigateToUrl('https://test.local')";
+      expect(recoverJsURL(input)).toBeNull();
     });
   });
 

--- a/test/unit/core_utils_spec.js
+++ b/test/unit/core_utils_spec.js
@@ -22,6 +22,7 @@ import {
   isAscii,
   isWhiteSpace,
   log2,
+  numberToString,
   parseXFAPath,
   recoverJsURL,
   stringToUTF16HexString,
@@ -179,6 +180,21 @@ describe("core_utils", function () {
       expect(log2(2)).toEqual(1);
       expect(log2(3)).toEqual(2);
       expect(log2(3.14)).toEqual(2);
+    });
+  });
+
+  describe("numberToString", function () {
+    it("should stringify integers", function () {
+      expect(numberToString(1)).toEqual("1");
+      expect(numberToString(0)).toEqual("0");
+      expect(numberToString(-1)).toEqual("-1");
+    });
+
+    it("should stringify floats", function () {
+      expect(numberToString(1.0)).toEqual("1");
+      expect(numberToString(1.2)).toEqual("1.2");
+      expect(numberToString(1.23)).toEqual("1.23");
+      expect(numberToString(1.234)).toEqual("1.23");
     });
   });
 


### PR DESCRIPTION
This patch introduces unit tests for the `recoverJsURL` and `numberToString` core utility functions that were missing before, increasing the overall unit test coverage of this file.