### PR TITLE
Upgrade Node.js to version 18 in the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Use Node.js 16 LTS
+      - name: Use Node.js 18 LTS
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Install Gulp
         run: npm install -g gulp-cli


### PR DESCRIPTION
Version 16 that we used before is now in maintenance mode, so we should upgrade to the most recent LTS version. For more information on the Node.js release schedule please refer to https://github.com/nodejs/release#release-schedule.