### PR TITLE
[api-minor] Add a new `transferPdfData` option to allow transferring more data to the worker-thread (bug 1809164)

### DIFF
--- a/web/app_options.js
+++ b/web/app_options.js
@@ -270,6 +270,11 @@ const defaultOptions = {
         : "../web/standard_fonts/",
     kind: OptionKind.API,
   },
+  transferPdfData: {
+    /** @type {boolean} */
+    value: typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL"),
+    kind: OptionKind.API,
+  },
   verbosity: {
     /** @type {number} */
     value: 1,


### PR DESCRIPTION
Also, removes the `initialData`-parameter JSDocs for the `getDocument`-function given that this parameter has been completely unused since PR #8982 (over five years ago). Note that the `initialData`-parameter is, and always was, intended to be provided when initializing a `PDFDataRangeTransport`-instance.