### PR TITLE
[api-minor] Enable transferring of TypedArray PDF data by default (PR 15908 follow-up)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -281,20 +281,20 @@ function getDocument(src) {
     worker = null;
 
   for (const key in source) {
-    const value = source[key];
+    const val = source[key];
 
     switch (key) {
       case "url":
         if (typeof window !== "undefined") {
           try {
             // The full path is required in the 'url' field.
-            params[key] = new URL(value, window.location).href;
+            params[key] = new URL(val, window.location).href;
             continue;
           } catch (ex) {
             warn(`Cannot create valid URL: "${ex}".`);
           }
-        } else if (typeof value === "string" || value instanceof URL) {
-          params[key] = value.toString(); // Support Node.js environments.
+        } else if (typeof val === "string" || val instanceof URL) {
+          params[key] = val.toString(); // Support Node.js environments.
           continue;
         }
         throw new Error(
@@ -302,10 +302,10 @@ function getDocument(src) {
             "either string or URL-object is expected in the url property."
         );
       case "range":
-        rangeTransport = value;
+        rangeTransport = val;
         continue;
       case "worker":
-        worker = value;
+        worker = val;
         continue;
       case "data":
         // Converting string or array-like data to Uint8Array.
@@ -314,21 +314,18 @@ function getDocument(src) {
           PDFJSDev.test("GENERIC") &&
           isNodeJS &&
           typeof Buffer !== "undefined" && // eslint-disable-line no-undef
-          value instanceof Buffer // eslint-disable-line no-undef
+          val instanceof Buffer // eslint-disable-line no-undef
         ) {
-          params[key] = new Uint8Array(value);
-        } else if (value instanceof Uint8Array) {
+          params[key] = new Uint8Array(val);
+        } else if (val instanceof Uint8Array) {
           break; // Use the data as-is when it's already a Uint8Array.
-        } else if (typeof value === "string") {
-          params[key] = stringToBytes(value);
+        } else if (typeof val === "string") {
+          params[key] = stringToBytes(val);
         } else if (
-          typeof value === "object" &&
-          value !== null &&
-          !isNaN(value.length)
+          (typeof val === "object" && val !== null && !isNaN(val.length)) ||
+          isArrayBuffer(val)
         ) {
-          params[key] = new Uint8Array(value);
-        } else if (isArrayBuffer(value)) {
-          params[key] = new Uint8Array(value);
+          params[key] = new Uint8Array(val);
         } else {
           throw new Error(
             "Invalid PDF binary data: either TypedArray, " +
@@ -337,7 +334,7 @@ function getDocument(src) {
         }
         continue;
     }
-    params[key] = value;
+    params[key] = val;
   }
 
   params.CMapReaderFactory =

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -270,11 +270,6 @@ const defaultOptions = {
         : "../web/standard_fonts/",
     kind: OptionKind.API,
   },
-  transferPdfData: {
-    /** @type {boolean} */
-    value: typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL"),
-    kind: OptionKind.API,
-  },
   verbosity: {
     /** @type {number} */
     value: 1,


### PR DESCRIPTION
This patch removes the recently introduced `transferPdfData` API-option, and simply enables transferring of TypedArray data *by default* instead of copying it. This will help reduce main-thread memory usage, however it will take ownership of the TypedArrays. Currently this only applies to the following cases:
 - TypedArrays passed to the `getDocument`-function in the API, in order to open PDF documents from binary data.
 - TypedArrays passed to a `PDFDataRangeTransport`-instance, used to support custom PDF document fetching/loading (see e.g. the Firefox PDF Viewer).

*PLEASE NOTE:* To avoid being affected by this, please simply *copy* any TypedArray data before passing it to either of the functions/methods mentioned above.

Now that we transfer TypedArray data that we previously only copied, we need to be more careful with input validation. Given how the `{IPDFStreamReader, IPDFStreamRangeReader}.read` methods will always return ArrayBuffer data, which is then transferred to the worker-thread[1], the actual TypedArray data passed to the API thus need to have the same exact size as its underlying ArrayBuffer to prevent issues.
Hence we'll check for this and only allow transferring of *safe* TypedArray data, and fallback to simply copying the data just as before. This obviously shouldn't be an issue in the Firefox PDF Viewer, but for the general PDF.js library we need to be more careful here.

---
[1] See https://github.com/mozilla/pdf.js/blob/e09ad99973b1dcb82a06c001da96d52fc5bcab9d/src/display/api.js#L2492-L2506 respectively https://github.com/mozilla/pdf.js/blob/e09ad99973b1dcb82a06c001da96d52fc5bcab9d/src/display/api.js#L2578-L2590