### PR TITLE
Update highlight background when forced colors are active (bug 1759886)

### DIFF
--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -72,6 +72,15 @@
   background-color: rgba(0, 100, 0, 1);
 }
 
+@media (forced-colors: active) {
+  .textLayer .highlight {
+    background-color: Highlight;
+  }
+  .textLayer .highlight.selected {
+    background-color: ButtonText;
+  }
+}
+
 .textLayer ::selection {
   /*#if !MOZCENTRAL*/
   background: blue;


### PR DESCRIPTION
When forced color are active this updates the background of highlights to use CSS system colors, so Windows HCM mode will pick a highlight color that strongly contrasts the text.

<img width="863" alt="Screen Shot 2023-01-13 at 2 30 01 PM" src="https://user-images.githubusercontent.com/213312/212431306-776bc9a6-a294-4f48-bf86-618fa14d943a.png">

Ideally we could add outlines for highlights and remove the background to provide better contrast, but I don't think this is possible without `forced-color-adjust: none` or `color: transparent` support. 