### PR TITLE
[Regression] Avoid showing a black canvas during zooming with a `drawingDelay` set (PR 15812 follow-up)

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -1071,7 +1071,12 @@ class PDFPageView {
         renderCapability.resolve();
       },
       function (error) {
-        showCanvas();
+        // When zooming with a `drawingDelay` set, avoid temporarily showing
+        // a black canvas if rendering was cancelled before the `onContinue`-
+        // callback had been invoked at least once.
+        if (!(error instanceof RenderingCancelledException)) {
+          showCanvas();
+        }
         renderCapability.reject(error);
       }
     );


### PR DESCRIPTION
After the changes in PR #15812 we'll now *intermittently* display completely black canvases during zooming. To reproduce this, try switching to wrapped-scrolling and zoom in/out very quickly using either the mouse-wheel or pinching.