### PR TITLE
Use CSS variables for the textLayer `highlight` colors (PR 15921 follow-up)

### DIFF
--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -35,7 +35,7 @@
   }
 }
 
-@media (forced-colors: active) {
+@media screen and (forced-colors: active) {
   :root {
     --focus-outline: solid 3px ButtonText;
     --hover-outline: dashed 3px ButtonText;

--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -22,7 +22,7 @@
   --input-hover-border-color: black;
 }
 
-@media (forced-colors: active) {
+@media screen and (forced-colors: active) {
   :root {
     --input-focus-border-color: CanvasText;
     --input-unfocused-border-color: ActiveText;

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -18,7 +18,7 @@
   --highlight-selected-bg-color: rgba(0, 100, 0, 1);
 }
 
-@media (forced-colors: active) {
+@media screen and (forced-colors: active) {
   :root {
     --highlight-bg-color: Highlight;
     --highlight-selected-bg-color: ButtonText;

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -13,6 +13,18 @@
  * limitations under the License.
  */
 
+:root {
+  --highlight-bg-color: rgba(180, 0, 170, 1);
+  --highlight-selected-bg-color: rgba(0, 100, 0, 1);
+}
+
+@media (forced-colors: active) {
+  :root {
+    --highlight-bg-color: Highlight;
+    --highlight-selected-bg-color: ButtonText;
+  }
+}
+
 .textLayer {
   position: absolute;
   text-align: initial;
@@ -48,7 +60,7 @@
 .textLayer .highlight {
   margin: -1px;
   padding: 1px;
-  background-color: rgba(180, 0, 170, 1);
+  background-color: var(--highlight-bg-color);
   border-radius: 4px;
 }
 
@@ -69,16 +81,7 @@
 }
 
 .textLayer .highlight.selected {
-  background-color: rgba(0, 100, 0, 1);
-}
-
-@media (forced-colors: active) {
-  .textLayer .highlight {
-    background-color: Highlight;
-  }
-  .textLayer .highlight.selected {
-    background-color: ButtonText;
-  }
+  background-color: var(--highlight-selected-bg-color);
 }
 
 .textLayer ::selection {

--- a/web/xfa_layer_builder.css
+++ b/web/xfa_layer_builder.css
@@ -18,7 +18,7 @@
   --xfa-focus-outline: auto;
 }
 
-@media (forced-colors: active) {
+@media screen and (forced-colors: active) {
   :root {
     --xfa-focus-outline: 2px solid CanvasText;
   }


### PR DESCRIPTION
 - Use CSS variables for the textLayer `highlight` colors (PR 15921 follow-up)

   Rather than adding `@media (forced-colors: active) { ... }`-blocks throughout the CSS code, we should utilize CSS variables instead as in our other CSS files.

 - Use consistent `forced-colors` media-queries throughout the CSS files

   Note how e.g. the `viewer.css` and `pdf_viewer.css` files already used this format.