### PR TITLE
Change 'Current View' to 'Current Page' in the secondary toolbar

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -41,8 +41,8 @@ print.title=Print
 print_label=Print
 save.title=Save
 save_label=Save
-bookmark.title=Current view (copy or open in new window)
-bookmark_label=Current View
+bookmark1.title=Current Page (View URL from Current Page)
+bookmark1_label=Current Page
 
 # Secondary toolbar and context menu
 tools.title=Tools

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -204,8 +204,8 @@ See https://github.com/adobe-type-tools/cmap-resources
               <span data-l10n-id="presentation_mode_label">Presentation Mode</span>
             </button>
 
-            <a href="#" id="viewBookmark" class="secondaryToolbarButton" title="Current view (copy or open in new window)" tabindex="55" data-l10n-id="bookmark">
-              <span data-l10n-id="bookmark_label">Current View</span>
+            <a href="#" id="viewBookmark" class="secondaryToolbarButton" title="Current Page (View URL from Current Page)" tabindex="55" data-l10n-id="bookmark1">
+              <span data-l10n-id="bookmark1_label">Current Page</span>
             </a>
 
             <div id="viewBookmarkSeparator" class="horizontalToolbarSeparator"></div>


### PR DESCRIPTION
Content Design team (UX) proposed this change.