### PR TITLE
Move the `disableAutoFetch` functionality into the `ProgressBar`-class

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -77,7 +77,6 @@ import { SecondaryToolbar } from "./secondary_toolbar.js";
 import { Toolbar } from "./toolbar.js";
 import { ViewHistory } from "./view_history.js";
 
-const DISABLE_AUTO_FETCH_LOADING_BAR_TIMEOUT = 5000; // ms
 const FORCE_PAGES_LOADED_TIMEOUT = 10000; // ms
 const WHEEL_ZOOM_DISABLED_TIMEOUT = 1000; // ms
 
@@ -1121,23 +1120,12 @@ const PDFViewerApplication = {
     // the loading bar will not be completely filled, nor will it be hidden.
     // To prevent displaying a partially filled loading bar permanently, we
     // hide it when no data has been loaded during a certain amount of time.
-    const disableAutoFetch =
+    if (
       this.pdfDocument?.loadingParams.disableAutoFetch ??
-      AppOptions.get("disableAutoFetch");
-
-    if (!disableAutoFetch || isNaN(percent)) {
-      return;
+      AppOptions.get("disableAutoFetch")
+    ) {
+      this.loadingBar.setDisableAutoFetch();
     }
-    if (this.disableAutoFetchLoadingBarTimeout) {
-      clearTimeout(this.disableAutoFetchLoadingBarTimeout);
-      this.disableAutoFetchLoadingBarTimeout = null;
-    }
-    this.loadingBar.show();
-
-    this.disableAutoFetchLoadingBarTimeout = setTimeout(() => {
-      this.loadingBar.hide();
-      this.disableAutoFetchLoadingBarTimeout = null;
-    }, DISABLE_AUTO_FETCH_LOADING_BAR_TIMEOUT);
   },
 
   load(pdfDocument) {

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -693,6 +693,8 @@ function clamp(v, min, max) {
 class ProgressBar {
   #classList = null;
 
+  #disableAutoFetchTimeout = null;
+
   #percent = 0;
 
   #visible = true;
@@ -726,6 +728,21 @@ class ProgressBar {
     if (scrollbarWidth > 0) {
       docStyle.setProperty("--progressBar-end-offset", `${scrollbarWidth}px`);
     }
+  }
+
+  setDisableAutoFetch(delay = /* ms = */ 5000) {
+    if (isNaN(this.#percent)) {
+      return;
+    }
+    if (this.#disableAutoFetchTimeout) {
+      clearTimeout(this.#disableAutoFetchTimeout);
+    }
+    this.show();
+
+    this.#disableAutoFetchTimeout = setTimeout(() => {
+      this.#disableAutoFetchTimeout = null;
+      this.hide();
+    }, delay);
   }
 
   hide() {


### PR DESCRIPTION
It seems nicer overall, since we're exporting the `ProgressBar` in the viewer-components, to move this functionality into the `ProgressBar`-class itself rather than handling it "manually" in the default-viewer.