### PR TITLE
Tweak the internal handling of the `url`-parameter in `getDocument` (PR 13166 follow-up)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -289,17 +289,23 @@ function getDocument(src) {
 
     switch (key) {
       case "url":
-        if (typeof window !== "undefined") {
-          try {
-            // The full path is required in the 'url' field.
-            params[key] = new URL(val, window.location).href;
-            continue;
-          } catch (ex) {
-            warn(`Cannot create valid URL: "${ex}".`);
-          }
-        } else if (typeof val === "string" || val instanceof URL) {
-          params[key] = val.toString(); // Support Node.js environments.
+        if (val instanceof URL) {
+          params[key] = val.href;
           continue;
+        }
+        try {
+          // The full path is required in the 'url' field.
+          params[key] = new URL(val, window.location).href;
+          continue;
+        } catch (ex) {
+          if (
+            typeof PDFJSDev !== "undefined" &&
+            PDFJSDev.test("GENERIC") &&
+            isNodeJS &&
+            typeof val === "string"
+          ) {
+            break; // Use the url as-is in Node.js environments.
+          }
         }
         throw new Error(
           "Invalid PDF url data: " +


### PR DESCRIPTION
 - Use a `URL`-instance directly, since it's by definition an absolute URL.
 - Actually limit the "raw" url-string handling to Node.js environments, as intended.
 - Skip the warning, since we're already throwing an Error if the `url`-parameter is invalid.