### PR TITLE
Tweak the `normalizeWheelEventDelta` helper function

### DIFF
--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -622,17 +622,16 @@ function normalizeWheelEventDirection(evt) {
 }
 
 function normalizeWheelEventDelta(evt) {
+  const deltaMode = evt.deltaMode; // Avoid being affected by bug 1392460.
   let delta = normalizeWheelEventDirection(evt);
 
-  const MOUSE_DOM_DELTA_PIXEL_MODE = 0;
-  const MOUSE_DOM_DELTA_LINE_MODE = 1;
   const MOUSE_PIXELS_PER_LINE = 30;
   const MOUSE_LINES_PER_PAGE = 30;
 
   // Converts delta to per-page units
-  if (evt.deltaMode === MOUSE_DOM_DELTA_PIXEL_MODE) {
+  if (deltaMode === WheelEvent.DOM_DELTA_PIXEL) {
     delta /= MOUSE_PIXELS_PER_LINE * MOUSE_LINES_PER_PAGE;
-  } else if (evt.deltaMode === MOUSE_DOM_DELTA_LINE_MODE) {
+  } else if (deltaMode === WheelEvent.DOM_DELTA_LINE) {
     delta /= MOUSE_LINES_PER_PAGE;
   }
   return delta;


### PR DESCRIPTION
This function is only used in PresentationMode these days, but we can still improve it a little bit:
 - Use the existing web-platform `deltaMode` constants, rather than defining our own constants for those values.
 - Access the `deltaMode` first, before the `delta{X, Y}` properties, to avoid being affected by [bug 1392460 ](https://bugzilla.mozilla.org/show_bug.cgi?id=1392460) (similar to the default viewer).