### PR TITLE
Simplify setting the `GlobalWorkerOptions` default values (PR 9480 follow-up)

### DIFF
--- a/src/display/worker_options.js
+++ b/src/display/worker_options.js
@@ -27,14 +27,7 @@
 /** @type {GlobalWorkerOptionsType} */
 const GlobalWorkerOptions = Object.create(null);
 
-GlobalWorkerOptions.workerPort =
-  GlobalWorkerOptions.workerPort === undefined
-    ? null
-    : GlobalWorkerOptions.workerPort;
-
-GlobalWorkerOptions.workerSrc =
-  GlobalWorkerOptions.workerSrc === undefined
-    ? ""
-    : GlobalWorkerOptions.workerSrc;
+GlobalWorkerOptions.workerPort = null;
+GlobalWorkerOptions.workerSrc = "";
 
 export { GlobalWorkerOptions };


### PR DESCRIPTION
There's really no need for these "complicated" default value assignments, since `GlobalWorkerOptions` is a local variable at this point, and this is rather a case of too much copy-and-paste.
Note that years ago, when all options were set using a global `PDFJS` object, it's possible that options had been set (from the outside) *before* the object had been properly initialized; see e.g. https://github.com/mozilla/pdf.js/blob/a89071bdefb90733fc2e671fcca61f6d03964e04/src/display/global.js