### PR TITLE
[Editor] Make the annotation editor layer invisible when disabled and empty

### DIFF
--- a/src/display/editor/annotation_editor_layer.js
+++ b/src/display/editor/annotation_editor_layer.js
@@ -84,6 +84,10 @@ class AnnotationEditorLayer {
     this.#uiManager.addLayer(this);
   }
 
+  get isEmpty() {
+    return this.#editors.size === 0;
+  }
+
   /**
    * Update the toolbar if it's required to reflect the tool currently used.
    * @param {number} mode
@@ -107,11 +111,17 @@ class AnnotationEditorLayer {
     }
     this.#uiManager.unselectAll();
 
-    this.div.classList.toggle(
-      "freeTextEditing",
-      mode === AnnotationEditorType.FREETEXT
-    );
-    this.div.classList.toggle("inkEditing", mode === AnnotationEditorType.INK);
+    if (mode !== AnnotationEditorType.NONE) {
+      this.div.classList.toggle(
+        "freeTextEditing",
+        mode === AnnotationEditorType.FREETEXT
+      );
+      this.div.classList.toggle(
+        "inkEditing",
+        mode === AnnotationEditorType.INK
+      );
+      this.div.hidden = false;
+    }
   }
 
   addInkEditorIfNeeded(isCommitting) {
@@ -171,6 +181,10 @@ class AnnotationEditorLayer {
     this.div.style.pointerEvents = "none";
     for (const editor of this.#editors.values()) {
       editor.disableEditing();
+    }
+    this.#cleanup();
+    if (this.isEmpty) {
+      this.div.hidden = true;
     }
   }
 

--- a/web/annotation_editor_layer_builder.js
+++ b/web/annotation_editor_layer_builder.js
@@ -75,6 +75,7 @@ class AnnotationEditorLayerBuilder {
     const div = (this.div = document.createElement("div"));
     div.className = "annotationEditorLayer";
     div.tabIndex = 0;
+    div.hidden = true;
     this.pageDiv.append(div);
 
     this.annotationEditorLayer = new AnnotationEditorLayer({
@@ -94,6 +95,7 @@ class AnnotationEditorLayerBuilder {
     };
 
     this.annotationEditorLayer.render(parameters);
+    this.show();
   }
 
   cancel() {
@@ -115,7 +117,7 @@ class AnnotationEditorLayerBuilder {
   }
 
   show() {
-    if (!this.div) {
+    if (!this.div || this.annotationEditorLayer.isEmpty) {
       return;
     }
     this.div.hidden = false;


### PR DESCRIPTION
It'll help to avoid to consider them when the browser is restyling.