### PR TITLE
Remove the transition when displaying the sidebar when the user prefers reduced motion (bug 1813138)

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -189,6 +189,12 @@
   }
 }
 
+@media screen and (prefers-reduced-motion: reduce) {
+  :root {
+    --sidebar-transition-duration: 0;
+  }
+}
+
 * {
   padding: 0;
   margin: 0;


### PR DESCRIPTION
In Firefox, it can be easily tested in setting the pref `ui.prefersReducedMotion` to 1.