### PR TITLE
[api-minor] Let the `cMapPacked` parameter, in `getDocument`, default to `true`

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -166,7 +166,7 @@ if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
  * @property {string} [cMapUrl] - The URL where the predefined Adobe CMaps are
  *   located. Include the trailing slash.
  * @property {boolean} [cMapPacked] - Specifies if the Adobe CMaps are binary
- *   packed or not.
+ *   packed or not. The default value is `true`.
  * @property {Object} [CMapReaderFactory] - The factory that will be used when
  *   reading built-in CMap files. Providing a custom factory is useful for
  *   environments without Fetch API or `XMLHttpRequest` support, such as
@@ -347,6 +347,7 @@ function getDocument(src) {
     params[key] = val;
   }
 
+  params.cMapPacked = params.cMapPacked !== false;
   params.CMapReaderFactory =
     params.CMapReaderFactory || DefaultCMapReaderFactory;
   params.StandardFontDataFactory =

--- a/src/display/base_factory.js
+++ b/src/display/base_factory.js
@@ -65,7 +65,7 @@ class BaseCanvasFactory {
 }
 
 class BaseCMapReaderFactory {
-  constructor({ baseUrl = null, isCompressed = false }) {
+  constructor({ baseUrl = null, isCompressed = true }) {
     if (this.constructor === BaseCMapReaderFactory) {
       unreachable("Cannot initialize BaseCMapReaderFactory.");
     }

--- a/test/driver.js
+++ b/test/driver.js
@@ -30,7 +30,6 @@ const { GenericL10n, NullL10n, parseQueryString, SimpleLinkService } =
 
 const WAITING_TIME = 100; // ms
 const CMAP_URL = "/build/generic/web/cmaps/";
-const CMAP_PACKED = true;
 const STANDARD_FONT_DATA_URL = "/build/generic/web/standard_fonts/";
 const IMAGE_RESOURCES_PATH = "/web/images/";
 const VIEWER_CSS = "../build/components/pdf_viewer.css";
@@ -475,7 +474,6 @@ class Driver {
           url: absoluteUrl,
           password: task.password,
           cMapUrl: CMAP_URL,
-          cMapPacked: CMAP_PACKED,
           standardFontDataUrl: STANDARD_FONT_DATA_URL,
           disableRange: task.disableRange,
           disableAutoFetch: !task.enableAutoFetch,

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -32,7 +32,7 @@ import {
   stringToUTF8String,
 } from "../../src/shared/util.js";
 import {
-  CMAP_PARAMS,
+  CMAP_URL,
   createIdFactory,
   STANDARD_FONT_DATA_URL,
   XRefMock,
@@ -108,8 +108,7 @@ describe("annotation", function () {
     });
 
     const CMapReaderFactory = new DefaultCMapReaderFactory({
-      baseUrl: CMAP_PARAMS.cMapUrl,
-      isCompressed: CMAP_PARAMS.cMapPacked,
+      baseUrl: CMAP_URL,
     });
 
     const builtInCMapCache = new Map();

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -14,7 +14,7 @@
  */
 
 import { CMap, CMapFactory, IdentityCMap } from "../../src/core/cmap.js";
-import { CMAP_PARAMS } from "./test_utils.js";
+import { CMAP_URL } from "./test_utils.js";
 import { DefaultCMapReaderFactory } from "../../src/display/api.js";
 import { Name } from "../../src/core/primitives.js";
 import { StringStream } from "../../src/core/stream.js";
@@ -25,8 +25,7 @@ describe("cmap", function () {
   beforeAll(function () {
     // Allow CMap testing in Node.js, e.g. for Travis.
     const CMapReaderFactory = new DefaultCMapReaderFactory({
-      baseUrl: CMAP_PARAMS.cMapUrl,
-      isCompressed: CMAP_PARAMS.cMapPacked,
+      baseUrl: CMAP_URL,
     });
 
     fetchBuiltInCMap = function (name) {
@@ -232,7 +231,7 @@ describe("cmap", function () {
   it("attempts to load a built-in CMap with inconsistent API parameters", async function () {
     function tmpFetchBuiltInCMap(name) {
       const CMapReaderFactory = new DefaultCMapReaderFactory({
-        baseUrl: CMAP_PARAMS.cMapUrl,
+        baseUrl: CMAP_URL,
         isCompressed: false,
       });
       return CMapReaderFactory.fetch({ name });

--- a/test/unit/pdf_find_controller_spec.js
+++ b/test/unit/pdf_find_controller_spec.js
@@ -21,10 +21,8 @@ import { isNodeJS } from "../../src/shared/is_node.js";
 import { SimpleLinkService } from "../../web/pdf_link_service.js";
 
 const tracemonkeyFileName = "tracemonkey.pdf";
-const CMAP_PARAMS = {
-  cMapUrl: isNodeJS ? "./external/bcmaps/" : "../../../external/bcmaps/",
-  cMapPacked: true,
-};
+
+const CMAP_URL = isNodeJS ? "./external/bcmaps/" : "../../../external/bcmaps/";
 
 class MockLinkService extends SimpleLinkService {
   constructor() {
@@ -57,7 +55,7 @@ async function initPdfFindController(
 ) {
   const loadingTask = getDocument(
     buildGetDocumentParams(filename || tracemonkeyFileName, {
-      ...CMAP_PARAMS,
+      cMapUrl: CMAP_URL,
     })
   );
   const pdfDocument = await loadingTask.promise;

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -21,10 +21,7 @@ import { Ref } from "../../src/core/primitives.js";
 
 const TEST_PDFS_PATH = isNodeJS ? "./test/pdfs/" : "../pdfs/";
 
-const CMAP_PARAMS = {
-  cMapUrl: isNodeJS ? "./external/bcmaps/" : "../../external/bcmaps/",
-  cMapPacked: true,
-};
+const CMAP_URL = isNodeJS ? "./external/bcmaps/" : "../../external/bcmaps/";
 
 const STANDARD_FONT_DATA_URL = isNodeJS
   ? "./external/standard_fonts/"
@@ -154,7 +151,7 @@ function isEmptyObj(obj) {
 
 export {
   buildGetDocumentParams,
-  CMAP_PARAMS,
+  CMAP_URL,
   createIdFactory,
   DefaultFileReaderFactory,
   isEmptyObj,


### PR DESCRIPTION
The initial CMap support was added in PR #4259 using the "raw" Adobe files, however they were quickly deemed to be unnecessarily large. As a result PR #4470 introduced the more compact "binary" CMap format, with both of those PRs being included in the very same release (version `0.8.1334`) .

Please note that we've thus never shipped anything *except* the "binary" CMap files with the PDF library, and furthermore note that we've not even once updated the CMap files since they were originally added almost nine years ago.

Requiring users to remember that `cMapPacked = true` is necessary, in addition to setting the `cMapUrl` parameter, in order for CMap loading to work feels like a less than ideal API.
Hence this patch, which suggests that we simply let `cMapPacked` default to `true` now.