### PR TITLE
Allow, optionally, using worker-modules during local development

### DIFF
--- a/docs/contents/getting_started/index.md
+++ b/docs/contents/getting_started/index.md
@@ -108,8 +108,7 @@ Note that we only mention the most relevant files and folders.
 │   ├── display/                           - display layer
 │   ├── shared/                            - shared code between the core and display layers
 │   ├── interfaces.js                      - interface definitions for the core/display layers
-│   ├── pdf.*.js                           - wrapper files for bundling
-│   └── worker_loader.js                   - used for developer builds to load worker files
+│   └── pdf.*.js                           - wrapper files for bundling
 ├── test/                                  - unit, font, reference, and integration tests
 ├── web/                                   - viewer layer
 ├── LICENSE

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2101,7 +2101,12 @@ class PDFWorker {
 
         // Some versions of FF can't create a worker on localhost, see:
         // https://bugzilla.mozilla.org/show_bug.cgi?id=683280
-        const worker = new Worker(workerSrc);
+        const worker =
+          (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) &&
+          !workerSrc.endsWith("/build/pdf.worker.js") &&
+          !workerSrc.endsWith("/src/worker_loader.js")
+            ? new Worker(workerSrc, { type: "module" })
+            : new Worker(workerSrc);
         const messageHandler = new MessageHandler("main", "worker", worker);
         const terminateEarly = () => {
           worker.removeEventListener("error", onWorkerError);
@@ -2289,7 +2294,7 @@ class PDFWorker {
         return mainWorkerMessageHandler;
       }
       if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
-        const worker = await import("pdfjs/core/worker.js");
+        const worker = await import("pdfjs/pdf.worker.js");
         return worker.WorkerMessageHandler;
       }
       if (

--- a/src/pdf.worker.js
+++ b/src/pdf.worker.js
@@ -16,8 +16,10 @@
 import { WorkerMessageHandler } from "./core/worker.js";
 
 /* eslint-disable-next-line no-unused-vars */
-const pdfjsVersion = PDFJSDev.eval("BUNDLE_VERSION");
+const pdfjsVersion =
+  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_VERSION") : void 0;
 /* eslint-disable-next-line no-unused-vars */
-const pdfjsBuild = PDFJSDev.eval("BUNDLE_BUILD");
+const pdfjsBuild =
+  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_BUILD") : void 0;
 
 export { WorkerMessageHandler };

--- a/web/app.js
+++ b/web/app.js
@@ -304,7 +304,12 @@ const PDFViewerApplication = {
     const { mainContainer, viewerContainer } = this.appConfig,
       params = parseQueryString(hash);
 
-    if (params.get("disableworker") === "true") {
+    if (
+      (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) &&
+      params.get("workermodules") === "true"
+    ) {
+      AppOptions.set("workerSrc", "../src/pdf.worker.js");
+    } else if (params.get("disableworker") === "true") {
       try {
         await loadFakeWorker();
       } catch (ex) {
@@ -2143,7 +2148,7 @@ async function loadFakeWorker() {
   GlobalWorkerOptions.workerSrc ||= AppOptions.get("workerSrc");
 
   if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
-    window.pdfjsWorker = await import("pdfjs/core/worker.js");
+    window.pdfjsWorker = await import("pdfjs/pdf.worker.js");
     return;
   }
   await loadScript(PDFWorker.workerSrc);


### PR DESCRIPTION
Until PR #12563 is deemed safe to land, I'd still like to be able to use worker-modules in the viewer during local development.
Hence this patch which *temporarily* adds a new `workerModules` hash-parameter, only available in non-PRODUCTION mode, that allows using worker-modules in the development viewer.

To enable this functionality, simply use http://localhost:8888/web/viewer.html#workerModules=true