### PR TITLE
Remove unused parameters from the `onOpenWithTransport` method in `PDFViewerApplication.initPassiveLoading`

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -283,28 +283,32 @@ function getDocument(src) {
 
     switch (key) {
       case "url":
-        if (val instanceof URL) {
-          params[key] = val.href;
-          continue;
-        }
-        try {
-          // The full path is required in the 'url' field.
-          params[key] = new URL(val, window.location).href;
-          continue;
-        } catch (ex) {
-          if (
-            typeof PDFJSDev !== "undefined" &&
-            PDFJSDev.test("GENERIC") &&
-            isNodeJS &&
-            typeof val === "string"
-          ) {
-            break; // Use the url as-is in Node.js environments.
+        if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
+          continue; // The 'url' is unused with `PDFDataRangeTransport`.
+        } else {
+          if (val instanceof URL) {
+            params[key] = val.href;
+            continue;
           }
+          try {
+            // The full path is required in the 'url' field.
+            params[key] = new URL(val, window.location).href;
+            continue;
+          } catch (ex) {
+            if (
+              typeof PDFJSDev !== "undefined" &&
+              PDFJSDev.test("GENERIC") &&
+              isNodeJS &&
+              typeof val === "string"
+            ) {
+              break; // Use the url as-is in Node.js environments.
+            }
+          }
+          throw new Error(
+            "Invalid PDF url data: " +
+              "either string or URL-object is expected in the url property."
+          );
         }
-        throw new Error(
-          "Invalid PDF url data: " +
-            "either string or URL-object is expected in the url property."
-        );
       case "range":
         rangeTransport = val;
         continue;

--- a/web/app.js
+++ b/web/app.js
@@ -745,8 +745,8 @@ const PDFViewerApplication = {
       throw new Error("Not implemented: initPassiveLoading");
     }
     this.externalServices.initPassiveLoading({
-      onOpenWithTransport: (url, length, transport) => {
-        this.open({ url, length, range: transport });
+      onOpenWithTransport: range => {
+        this.open({ range });
       },
       onOpenWithData: (data, contentDispositionFilename) => {
         if (isPdfFile(contentDispositionFilename)) {

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -347,11 +347,7 @@ class FirefoxExternalServices extends DefaultExternalServices {
             args.filename
           );
 
-          callbacks.onOpenWithTransport(
-            args.pdfUrl,
-            args.length,
-            pdfDataRangeTransport
-          );
+          callbacks.onOpenWithTransport(pdfDataRangeTransport);
           break;
         case "range":
           pdfDataRangeTransport.onDataRange(args.begin, args.chunk);


### PR DESCRIPTION
The only parameter that we actually need here is the `PDFDataRangeTransport`-instance, since the others are not necessary.
 - The `url` parameter, as passed to the `getDocument` function in the API, is simply being ignored; see https://github.com/mozilla/pdf.js/blob/2d87a2eb1ccce55b8099bf2b8fcc7ed51bd6fbc9/src/display/api.js#L447-L458
 - The `length` parameter, as passed to the `getDocument` function in the API, is always being overwritten; see https://github.com/mozilla/pdf.js/blob/2d87a2eb1ccce55b8099bf2b8fcc7ed51bd6fbc9/src/display/api.js#L519-L525