### PR TITLE
Remove the loading icon div and replace it by a pure css solution using :after.

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -207,7 +207,6 @@ page_scale_actual=Actual Size
 page_scale_percent={{scale}}%
 
 # Loading indicator messages
-loading=Loading…
 loading_error=An error occurred while loading the PDF.
 invalid_file_error=Invalid or corrupted PDF file.
 missing_file_error=Missing PDF file.

--- a/web/l10n_utils.js
+++ b/web/l10n_utils.js
@@ -57,7 +57,6 @@ const DEFAULT_L10N_STRINGS = {
   page_scale_actual: "Actual Size",
   page_scale_percent: "{{scale}}%",
 
-  loading: "Loading…",
   loading_error: "An error occurred while loading the PDF.",
   invalid_file_error: "Invalid or corrupted PDF file.",
   missing_file_error: "Missing PDF file.",

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -150,22 +150,28 @@
   height: 100%;
 }
 
-.pdfViewer .page .loadingIcon {
+.pdfViewer .page.loadingIcon:after {
   position: absolute;
-  display: block;
-  left: 0;
   top: 0;
-  right: 0;
-  bottom: 0;
+  left: 0;
+  content: "";
+  width: 100%;
+  height: 100%;
   background: url("images/loading-icon.gif") center no-repeat;
-  visibility: visible;
+  visibility: hidden;
   /* Using a delay with background-image doesn't work,
      consequently we use the visibility. */
   transition-property: visibility;
   transition-delay: var(--loading-icon-delay);
   z-index: 5;
+  contain: strict;
 }
-.pdfViewer .page .loadingIcon.notVisible {
+
+.pdfViewer .page.loading:after {
+  visibility: visible;
+}
+
+.pdfViewer .page:not(.loading):after {
   transition-property: none;
   visibility: hidden;
 }


### PR DESCRIPTION
This way we don't have a lot of useless divs and we let the css engine handle the creation/destruction of the :after pseudo-element. It'll help to slightly improve performance when zooming.