### PR TITLE
Limit the `singlePageView` CSS rules to only the COMPONENTS build

### DIFF
--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -83,6 +83,7 @@
   border: none;
 }
 
+/*#if COMPONENTS*/
 .pdfViewer.singlePageView {
   display: inline-block;
 }
@@ -91,6 +92,7 @@
   margin: 0;
   border: none;
 }
+/*#endif*/
 
 .pdfViewer.scrollHorizontal,
 .pdfViewer.scrollWrapped,


### PR DESCRIPTION
These CSS rules exist solely for the `pageviewer` viewer-component example, see https://github.com/mozilla/pdf.js/tree/master/examples/components, and consequently it doesn't make sense in other builds.