### PR TITLE
Remove the `loadingIcon` in all cases when resetting the page (PR 15992 follow-up)

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -245,7 +245,6 @@ class PDFPageView {
     }
 
     switch (state) {
-      case RenderingStates.INITIAL:
       case RenderingStates.PAUSED:
         this.div.classList.remove("loading");
         break;
@@ -260,6 +259,7 @@ class PDFPageView {
           this.#loadingId = null;
         }, 0);
         break;
+      case RenderingStates.INITIAL:
       case RenderingStates.FINISHED:
         this.div.classList.remove("loadingIcon", "loading");
         break;


### PR DESCRIPTION
*Unfortunately I missed this during testing/reviewing of PR #15992.*

With the changes in PR #15992 we're now only adding the `loadingIcon`-class when rendering is actually `RUNNING`, in order to improve overall performance.
However when resetting the page, i.e. the `INITIAL` state, we also need to remove the `loadingIcon` completely. Without this patch if you scroll through a document where the pages don't load instantaneously, see e.g. issue #2504, we'll leave the `loadingIcon`-class attached to pages that have had their rendering cancelled *and* also been evicted from the `PDFPageViewBuffer`-instance.