### PR TITLE
Limit the `removePageBorders` option, in `PDFViewer`, to only GENERIC builds

### DIFF
--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -78,10 +78,12 @@
   height: var(--viewer-container-height);
 }
 
+/*#if GENERIC*/
 .pdfViewer.removePageBorders .page {
   margin: 0 auto 10px;
   border: none;
 }
+/*#endif*/
 
 /*#if COMPONENTS*/
 .pdfViewer.singlePageView {
@@ -107,7 +109,9 @@
   white-space: nowrap;
 }
 
+/*#if GENERIC*/
 .pdfViewer.removePageBorders,
+/*#endif*/
 .pdfViewer.scrollHorizontal .spread,
 .pdfViewer.scrollWrapped .spread {
   margin-left: 0;
@@ -131,12 +135,14 @@
   margin-right: var(--spreadHorizontalWrapped-margin-LR);
 }
 
+/*#if GENERIC*/
 .pdfViewer.removePageBorders .spread .page,
 .pdfViewer.removePageBorders.scrollHorizontal .page,
 .pdfViewer.removePageBorders.scrollWrapped .page {
   margin-left: 5px;
   margin-right: 5px;
 }
+/*#endif*/
 
 .pdfViewer .page canvas {
   margin: 0;

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -254,7 +254,6 @@ class PDFViewer {
     this.downloadManager = options.downloadManager || null;
     this.findController = options.findController || null;
     this._scriptingManager = options.scriptingManager || null;
-    this.removePageBorders = options.removePageBorders || false;
     this.textLayerMode = options.textLayerMode ?? TextLayerMode.ENABLE;
     this.#annotationMode =
       options.annotationMode ?? AnnotationMode.ENABLE_FORMS;
@@ -266,6 +265,7 @@ class PDFViewer {
       typeof PDFJSDev === "undefined" ||
       PDFJSDev.test("!PRODUCTION || GENERIC")
     ) {
+      this.removePageBorders = options.removePageBorders || false;
       this.renderer = options.renderer || RendererType.CANVAS;
     }
     this.useOnlyCssZoom = options.useOnlyCssZoom || false;
@@ -307,7 +307,10 @@ class PDFViewer {
     this._onBeforeDraw = this._onAfterDraw = null;
     this._resetView();
 
-    if (this.removePageBorders) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&
+      this.removePageBorders
+    ) {
       this.viewer.classList.add("removePageBorders");
     }
 
@@ -1183,7 +1186,10 @@ class PDFViewer {
           // "doubling" the total border width.
           hPadding *= 2;
         }
-      } else if (this.removePageBorders) {
+      } else if (
+        (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&
+        this.removePageBorders
+      ) {
         hPadding = vPadding = 0;
       } else if (this._scrollMode === ScrollMode.HORIZONTAL) {
         [hPadding, vPadding] = [vPadding, hPadding]; // Swap the padding values.
@@ -1350,9 +1356,15 @@ class PDFViewer {
         y = destArray[3];
         width = destArray[4] - x;
         height = destArray[5] - y;
-        const hPadding = this.removePageBorders ? 0 : SCROLLBAR_PADDING;
-        const vPadding = this.removePageBorders ? 0 : VERTICAL_PADDING;
+        let hPadding = SCROLLBAR_PADDING,
+          vPadding = VERTICAL_PADDING;
 
+        if (
+          (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&
+          this.removePageBorders
+        ) {
+          hPadding = vPadding = 0;
+        }
         widthScale =
           (this.container.clientWidth - hPadding) /
           width /


### PR DESCRIPTION
This option was added specifically for third-party users, but has never been used in the PDF.js project itself.
Furthermore there's no preference that can be used to enable it, and you need to provide the `removePageBorders` option when initializing a `PDFViewer`-instance.

This patch thus get rid of a little bit more unused code in the Firefox PDF Viewer.