### PR TITLE
[GeckoView] Don't initalize the cursor-tools, since they're unused

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -576,11 +576,15 @@ const PDFViewerApplication = {
       );
     }
 
-    this.pdfCursorTools = new PDFCursorTools({
-      container,
-      eventBus,
-      cursorToolOnLoad: AppOptions.get("cursorToolOnLoad"),
-    });
+    // NOTE: The cursor-tools are unlikely to be helpful/useful in GeckoView,
+    // in particular the `HandTool` which basically simulates touch scrolling.
+    if (appConfig.secondaryToolbar?.cursorHandToolButton) {
+      this.pdfCursorTools = new PDFCursorTools({
+        container,
+        eventBus,
+        cursorToolOnLoad: AppOptions.get("cursorToolOnLoad"),
+      });
+    }
 
     if (appConfig.toolbar) {
       this.toolbar = new Toolbar(appConfig.toolbar, eventBus, this.l10n);

--- a/web/viewer-geckoview.css
+++ b/web/viewer-geckoview.css
@@ -221,27 +221,6 @@ dialog :link {
   width: 200px;
 }
 
-.grab-to-pan-grab {
-  cursor: grab !important;
-}
-.grab-to-pan-grab
-  *:not(input):not(textarea):not(button):not(select):not(:link) {
-  cursor: inherit !important;
-}
-.grab-to-pan-grab:active,
-.grab-to-pan-grabbing {
-  cursor: grabbing !important;
-  position: fixed;
-  background: rgba(0, 0, 0, 0);
-  display: block;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  overflow: hidden;
-  z-index: 50000; /* should be higher than anything else in PDF.js! */
-}
-
 @page {
   margin: 0;
 }


### PR DESCRIPTION
The reasons for making this change are:
 - There's no UI available to toggle the cursor-tools in the GeckoView-specific viewer.
 - The `HandTool`-implementation basically *simulates* touch scrolling, and is thus unlikely to be helpful/useful anyway.
 - PR #15831 already changed the relevant call-sites to handle `PDFViewerApplication.pdfCursorTools` being undefined.