### PR TITLE
Remove the `isEmptyObj` unit-test helper function

### DIFF
--- a/src/core/metadata_parser.js
+++ b/src/core/metadata_parser.js
@@ -57,7 +57,7 @@ class MetadataParser {
             throw new Error(`_repair: ${name} isn't defined.`);
           });
 
-        const charBuf = [];
+        const charBuf = [">"];
         for (let i = 0, ii = bytes.length; i < ii; i += 2) {
           const code = bytes.charCodeAt(i) * 256 + bytes.charCodeAt(i + 1);
           if (
@@ -74,7 +74,7 @@ class MetadataParser {
             );
           }
         }
-        return ">" + charBuf.join("");
+        return charBuf.join("");
       });
   }
 

--- a/test/unit/metadata_spec.js
+++ b/test/unit/metadata_spec.js
@@ -13,9 +13,10 @@
  * limitations under the License.
  */
 
-import { isEmptyObj } from "./test_utils.js";
 import { Metadata } from "../../src/display/metadata.js";
 import { MetadataParser } from "../../src/core/metadata_parser.js";
+
+const emptyObj = Object.create(null);
 
 function createMetadata(data) {
   const metadataParser = new MetadataParser(data);
@@ -136,7 +137,7 @@ describe("metadata", function () {
       '<?xpacket end="w"?>';
     const metadata = createMetadata(data);
 
-    expect(isEmptyObj(metadata.getAll())).toEqual(true);
+    expect(metadata.getAll()).toEqual(emptyObj);
   });
 
   it('should gracefully handle "junk" before the actual metadata (issue 10395)', function () {
@@ -228,7 +229,7 @@ describe("metadata", function () {
       '</rdf:RDF></x:xmpmeta><?xpacket end="w"?>';
     const metadata = createMetadata(data);
 
-    expect(isEmptyObj(metadata.getAll())).toEqual(true);
+    expect(metadata.getAll()).toEqual(emptyObj);
   });
 
   it("should not be vulnerable to the billion laughs attack", function () {

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -15,7 +15,6 @@
 
 import { NullStream, StringStream } from "../../src/core/stream.js";
 import { Page, PDFDocument } from "../../src/core/document.js";
-import { assert } from "../../src/shared/util.js";
 import { isNodeJS } from "../../src/shared/is_node.js";
 import { Ref } from "../../src/core/primitives.js";
 
@@ -144,20 +143,11 @@ function createIdFactory(pageIndex) {
   return page._localIdFactory;
 }
 
-function isEmptyObj(obj) {
-  assert(
-    typeof obj === "object" && obj !== null,
-    "isEmptyObj - invalid argument."
-  );
-  return Object.keys(obj).length === 0;
-}
-
 export {
   buildGetDocumentParams,
   CMAP_PARAMS,
   createIdFactory,
   DefaultFileReaderFactory,
-  isEmptyObj,
   STANDARD_FONT_DATA_URL,
   TEST_PDFS_PATH,
   XRefMock,


### PR DESCRIPTION
We should be able to let Jasmine simply compare directly against an actually empty Object, rather than using a manually implemented helper function for that.