### PR TITLE
[GeckoView] Reduce the size of the *built* viewer

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,7 +35,7 @@
     // Plugins
     "import/extensions": ["error", "always", { "ignorePackages": true, }],
     "import/no-unresolved": ["error", {
-      "ignore": ["pdfjs", "pdfjs-lib", "pdfjs-web", "pdfjs-fitCurve"]
+      "ignore": ["pdfjs", "pdfjs-lib", "pdfjs-web", "pdfjs-fitCurve", "web"]
     }],
     "mozilla/avoid-removeChild": "error",
     "mozilla/use-includes-instead-of-indexOf": "error",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -233,6 +233,37 @@ function createWebpackConfig(
   // Required to expose e.g., the `window` object.
   output.globalObject = "globalThis";
 
+  const basicAlias = {
+    pdfjs: "src",
+    "pdfjs-web": "web",
+    "pdfjs-lib": "web/pdfjs",
+    "pdfjs-fitCurve": "src/display/editor/fit_curve",
+  };
+  const viewerAlias = {
+    "web-annotation_editor_params": "web/annotation_editor_params.js",
+    "web-pdf_attachment_viewer": "web/pdf_attachment_viewer.js",
+    "web-pdf_cursor_tools": "web/pdf_cursor_tools.js",
+    "web-pdf_document_properties": "web/pdf_document_properties.js",
+    "web-pdf_find_bar": "web/pdf_find_bar.js",
+    "web-pdf_layer_viewer": "web/pdf_layer_viewer.js",
+    "web-pdf_outline_viewer": "web/pdf_outline_viewer.js",
+    "web-pdf_presentation_mode": "web/pdf_presentation_mode.js",
+    "web-pdf_sidebar": "web/pdf_sidebar.js",
+    "web-pdf_sidebar_resizer": "web/pdf_sidebar_resizer.js",
+    "web-pdf_thumbnail_viewer": "web/pdf_thumbnail_viewer.js",
+    "web-secondary_toolbar": "web/secondary_toolbar.js",
+    "web-toolbar": "web/toolbar.js",
+  };
+  if (bundleDefines.GECKOVIEW) {
+    for (const key in viewerAlias) {
+      viewerAlias[key] = "web/stubs-geckoview.js";
+    }
+  }
+  const alias = { ...basicAlias, ...viewerAlias };
+  for (const key in alias) {
+    alias[key] = path.join(__dirname, alias[key]);
+  }
+
   return {
     mode: "none",
     experiments,
@@ -242,12 +273,7 @@ function createWebpackConfig(
     },
     plugins,
     resolve: {
-      alias: {
-        pdfjs: path.join(__dirname, "src"),
-        "pdfjs-web": path.join(__dirname, "web"),
-        "pdfjs-lib": path.join(__dirname, "web/pdfjs"),
-        "pdfjs-fitCurve": path.join(__dirname, "src/display/editor/fit_curve"),
-      },
+      alias,
     },
     devtool: enableSourceMaps ? "source-map" : undefined,
     module: {

--- a/test/unit/unit_test.html
+++ b/test/unit/unit_test.html
@@ -16,7 +16,21 @@
         "pdfjs-lib": "../../src/pdf.js",
         "pdfjs-web/": "../../web/",
         "pdfjs-fitCurve": "../../build/dev-fitCurve/fit_curve.js",
-        "pdfjs-test/": "../"
+        "pdfjs-test/": "../",
+
+        "web-annotation_editor_params": "../../web/annotation_editor_params.js",
+        "web-pdf_attachment_viewer": "../../web/pdf_attachment_viewer.js",
+        "web-pdf_cursor_tools": "../../web/pdf_cursor_tools.js",
+        "web-pdf_document_properties": "../../web/pdf_document_properties.js",
+        "web-pdf_find_bar": "../../web/pdf_find_bar.js",
+        "web-pdf_layer_viewer": "../../web/pdf_layer_viewer.js",
+        "web-pdf_outline_viewer": "../../web/pdf_outline_viewer.js",
+        "web-pdf_presentation_mode": "../../web/pdf_presentation_mode.js",
+        "web-pdf_sidebar": "../../web/pdf_sidebar.js",
+        "web-pdf_sidebar_resizer": "../../web/pdf_sidebar_resizer.js",
+        "web-pdf_thumbnail_viewer": "../../web/pdf_thumbnail_viewer.js",
+        "web-secondary_toolbar": "../../web/secondary_toolbar.js",
+        "web-toolbar": "../../web/toolbar.js"
       }
     }
   </script>

--- a/web/app.js
+++ b/web/app.js
@@ -18,6 +18,7 @@ import {
   apiPageLayoutToViewerModes,
   apiPageModeToSidebarView,
   AutoPrintRegExp,
+  CursorTool,
   DEFAULT_SCALE_VALUE,
   getActiveOrFocusedElement,
   isValidRotation,
@@ -54,27 +55,27 @@ import {
 } from "pdfjs-lib";
 import { AppOptions, OptionKind } from "./app_options.js";
 import { AutomationEventBus, EventBus } from "./event_utils.js";
-import { CursorTool, PDFCursorTools } from "./pdf_cursor_tools.js";
 import { LinkTarget, PDFLinkService } from "./pdf_link_service.js";
-import { AnnotationEditorParams } from "./annotation_editor_params.js";
+import { AnnotationEditorParams } from "web-annotation_editor_params";
 import { OverlayManager } from "./overlay_manager.js";
 import { PasswordPrompt } from "./password_prompt.js";
-import { PDFAttachmentViewer } from "./pdf_attachment_viewer.js";
-import { PDFDocumentProperties } from "./pdf_document_properties.js";
-import { PDFFindBar } from "./pdf_find_bar.js";
+import { PDFAttachmentViewer } from "web-pdf_attachment_viewer";
+import { PDFCursorTools } from "web-pdf_cursor_tools";
+import { PDFDocumentProperties } from "web-pdf_document_properties";
+import { PDFFindBar } from "web-pdf_find_bar";
 import { PDFFindController } from "./pdf_find_controller.js";
 import { PDFHistory } from "./pdf_history.js";
-import { PDFLayerViewer } from "./pdf_layer_viewer.js";
-import { PDFOutlineViewer } from "./pdf_outline_viewer.js";
-import { PDFPresentationMode } from "./pdf_presentation_mode.js";
+import { PDFLayerViewer } from "web-pdf_layer_viewer";
+import { PDFOutlineViewer } from "web-pdf_outline_viewer";
+import { PDFPresentationMode } from "web-pdf_presentation_mode";
 import { PDFRenderingQueue } from "./pdf_rendering_queue.js";
 import { PDFScriptingManager } from "./pdf_scripting_manager.js";
-import { PDFSidebar } from "./pdf_sidebar.js";
-import { PDFSidebarResizer } from "./pdf_sidebar_resizer.js";
-import { PDFThumbnailViewer } from "./pdf_thumbnail_viewer.js";
+import { PDFSidebar } from "web-pdf_sidebar";
+import { PDFSidebarResizer } from "web-pdf_sidebar_resizer";
+import { PDFThumbnailViewer } from "web-pdf_thumbnail_viewer";
 import { PDFViewer } from "./pdf_viewer.js";
-import { SecondaryToolbar } from "./secondary_toolbar.js";
-import { Toolbar } from "./toolbar.js";
+import { SecondaryToolbar } from "web-secondary_toolbar";
+import { Toolbar } from "web-toolbar";
 import { ViewHistory } from "./view_history.js";
 
 const FORCE_PAGES_LOADED_TIMEOUT = 10000; // ms
@@ -598,7 +599,10 @@ const PDFViewerApplication = {
       );
     }
 
-    if (this.supportsFullscreen) {
+    if (
+      this.supportsFullscreen &&
+      appConfig.secondaryToolbar?.presentationModeButton
+    ) {
       this.pdfPresentationMode = new PDFPresentationMode({
         container,
         pdfViewer: this.pdfViewer,

--- a/web/pdf_cursor_tools.js
+++ b/web/pdf_cursor_tools.js
@@ -13,15 +13,9 @@
  * limitations under the License.
  */
 
+import { CursorTool, PresentationModeState } from "./ui_utils.js";
 import { AnnotationEditorType } from "pdfjs-lib";
 import { GrabToPan } from "./grab_to_pan.js";
-import { PresentationModeState } from "./ui_utils.js";
-
-const CursorTool = {
-  SELECT: 0, // The default value.
-  HAND: 1,
-  ZOOM: 2,
-};
 
 /**
  * @typedef {Object} PDFCursorToolsOptions
@@ -175,4 +169,4 @@ class PDFCursorTools {
   }
 }
 
-export { CursorTool, PDFCursorTools };
+export { PDFCursorTools };

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -13,8 +13,7 @@
  * limitations under the License.
  */
 
-import { ScrollMode, SpreadMode } from "./ui_utils.js";
-import { CursorTool } from "./pdf_cursor_tools.js";
+import { CursorTool, ScrollMode, SpreadMode } from "./ui_utils.js";
 import { PagesCountLimit } from "./pdf_viewer.js";
 
 /**

--- a/web/stubs-geckoview.js
+++ b/web/stubs-geckoview.js
@@ -1,0 +1,44 @@
+/* Copyright 2023 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const AnnotationEditorParams = null;
+const PDFAttachmentViewer = null;
+const PDFCursorTools = null;
+const PDFDocumentProperties = null;
+const PDFFindBar = null;
+const PDFLayerViewer = null;
+const PDFOutlineViewer = null;
+const PDFPresentationMode = null;
+const PDFSidebar = null;
+const PDFSidebarResizer = null;
+const PDFThumbnailViewer = null;
+const SecondaryToolbar = null;
+const Toolbar = null;
+
+export {
+  AnnotationEditorParams,
+  PDFAttachmentViewer,
+  PDFCursorTools,
+  PDFDocumentProperties,
+  PDFFindBar,
+  PDFLayerViewer,
+  PDFOutlineViewer,
+  PDFPresentationMode,
+  PDFSidebar,
+  PDFSidebarResizer,
+  PDFThumbnailViewer,
+  SecondaryToolbar,
+  Toolbar,
+};

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -74,6 +74,12 @@ const SpreadMode = {
   EVEN: 2,
 };
 
+const CursorTool = {
+  SELECT: 0, // The default value.
+  HAND: 1,
+  ZOOM: 2,
+};
+
 // Used by `PDFViewerApplication`, and by the API unit-tests.
 const AutoPrintRegExp = /\bprint\s*\(/;
 
@@ -852,6 +858,7 @@ export {
   AutoPrintRegExp,
   backtrackBeforeAllVisibleElements, // only exported for testing
   binarySearchFirstItem,
+  CursorTool,
   DEFAULT_SCALE,
   DEFAULT_SCALE_DELTA,
   DEFAULT_SCALE_VALUE,

--- a/web/viewer-geckoview.html
+++ b/web/viewer-geckoview.html
@@ -48,7 +48,21 @@ See https://github.com/adobe-type-tools/cmap-resources
           "pdfjs/": "../src/",
           "pdfjs-lib": "../src/pdf.js",
           "pdfjs-web/": "./",
-          "pdfjs-fitCurve": "../build/dev-fitCurve/fit_curve.js"
+          "pdfjs-fitCurve": "../build/dev-fitCurve/fit_curve.js",
+
+          "web-annotation_editor_params": "./stubs-geckoview.js",
+          "web-pdf_attachment_viewer": "./stubs-geckoview.js",
+          "web-pdf_cursor_tools": "./stubs-geckoview.js",
+          "web-pdf_document_properties": "./stubs-geckoview.js",
+          "web-pdf_find_bar": "./stubs-geckoview.js",
+          "web-pdf_layer_viewer": "./stubs-geckoview.js",
+          "web-pdf_outline_viewer": "./stubs-geckoview.js",
+          "web-pdf_presentation_mode": "./stubs-geckoview.js",
+          "web-pdf_sidebar": "./stubs-geckoview.js",
+          "web-pdf_sidebar_resizer": "./stubs-geckoview.js",
+          "web-pdf_thumbnail_viewer": "./stubs-geckoview.js",
+          "web-secondary_toolbar": "./stubs-geckoview.js",
+          "web-toolbar": "./stubs-geckoview.js"
         }
       }
     </script>

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -49,7 +49,21 @@ See https://github.com/adobe-type-tools/cmap-resources
           "pdfjs/": "../src/",
           "pdfjs-lib": "../src/pdf.js",
           "pdfjs-web/": "./",
-          "pdfjs-fitCurve": "../build/dev-fitCurve/fit_curve.js"
+          "pdfjs-fitCurve": "../build/dev-fitCurve/fit_curve.js",
+
+          "web-annotation_editor_params": "./annotation_editor_params.js",
+          "web-pdf_attachment_viewer": "./pdf_attachment_viewer.js",
+          "web-pdf_cursor_tools": "./pdf_cursor_tools.js",
+          "web-pdf_document_properties": "./pdf_document_properties.js",
+          "web-pdf_find_bar": "./pdf_find_bar.js",
+          "web-pdf_layer_viewer": "./pdf_layer_viewer.js",
+          "web-pdf_outline_viewer": "./pdf_outline_viewer.js",
+          "web-pdf_presentation_mode": "./pdf_presentation_mode.js",
+          "web-pdf_sidebar": "./pdf_sidebar.js",
+          "web-pdf_sidebar_resizer": "./pdf_sidebar_resizer.js",
+          "web-pdf_thumbnail_viewer": "./pdf_thumbnail_viewer.js",
+          "web-secondary_toolbar": "./secondary_toolbar.js",
+          "web-toolbar": "./toolbar.js"
         }
       }
     </script>


### PR DESCRIPTION
Given that the GV-viewer isn't using most of the UI-related components of the default-viewer, we can avoid including them in the *built* viewer to save space.[1] The least "invasive" way of implementing this, at least that I could come up with, is to leverage import maps with suitable stubs for the GV-viewer.

The one slightly annoying thing is that we now have larger import maps across multiple html-files, and you'll need to remember to update all of them when making future changes.

---
[1] With this patch, the built `viewer.js` size is 391 kB and `viewer-geckoview.js` is 285 kB.