### PR TITLE
Remove inline opening of PDF attachments in the COMPONENTS build

### DIFF
--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -71,7 +71,10 @@ class DownloadManager {
     const isPdfData = isPdfFile(filename);
     const contentType = isPdfData ? "application/pdf" : "";
 
-    if (isPdfData) {
+    if (
+      (typeof PDFJSDev === "undefined" || !PDFJSDev.test("COMPONENTS")) &&
+      isPdfData
+    ) {
       let blobUrl = this.#openBlobUrls.get(element);
       if (!blobUrl) {
         blobUrl = URL.createObjectURL(new Blob([data], { type: contentType }));


### PR DESCRIPTION
The `DownloadManager.openOrDownloadData` method is written for the default-viewer specifically, assuming a viewer able to handle e.g. URL search/hash parameters. In the viewer components there's obviously no such functionality, and we should thus trigger downloading of PDF attachments directly instead.