### PR TITLE
[GeckoView] Skip fetching/parsing of pageLabels

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -466,7 +466,9 @@ const PDFViewerApplication = {
       linkService: pdfLinkService,
       eventBus,
       updateMatchesCountOnProgress:
-        typeof PDFJSDev === "undefined" || !PDFJSDev.test("GECKOVIEW"),
+        typeof PDFJSDev === "undefined"
+          ? !window.isGECKOVIEW
+          : !PDFJSDev.test("GECKOVIEW"),
     });
     this.findController = findController;
 
@@ -1247,23 +1249,28 @@ const PDFViewerApplication = {
               spreadMode = stored.spreadMode | 0;
             }
           }
-          // Always let the user preference/view history take precedence.
-          if (pageMode && sidebarView === SidebarView.UNKNOWN) {
-            sidebarView = apiPageModeToSidebarView(pageMode);
-          }
-          // NOTE: Always ignore the pageLayout in GeckoView since there's
-          // no UI available to change Scroll/Spread modes for the user.
+          // NOTE: Ignore the pageMode/pageLayout in GeckoView since there's no
+          // sidebar available, nor any UI for changing the Scroll/Spread modes.
           if (
-            (typeof PDFJSDev === "undefined" || !PDFJSDev.test("GECKOVIEW")) &&
-            pageLayout &&
-            scrollMode === ScrollMode.UNKNOWN &&
-            spreadMode === SpreadMode.UNKNOWN
+            typeof PDFJSDev === "undefined"
+              ? !window.isGECKOVIEW
+              : !PDFJSDev.test("GECKOVIEW")
           ) {
-            const modes = apiPageLayoutToViewerModes(pageLayout);
-            // TODO: Try to improve page-switching when using the mouse-wheel
-            // and/or arrow-keys before allowing the document to control this.
-            // scrollMode = modes.scrollMode;
-            spreadMode = modes.spreadMode;
+            // Always let the user preference/view history take precedence.
+            if (pageMode && sidebarView === SidebarView.UNKNOWN) {
+              sidebarView = apiPageModeToSidebarView(pageMode);
+            }
+            if (
+              pageLayout &&
+              scrollMode === ScrollMode.UNKNOWN &&
+              spreadMode === SpreadMode.UNKNOWN
+            ) {
+              const modes = apiPageLayoutToViewerModes(pageLayout);
+              // TODO: Try to improve page-switching when using the mouse-wheel
+              // and/or arrow-keys before allowing the document to control this.
+              // scrollMode = modes.scrollMode;
+              spreadMode = modes.spreadMode;
+            }
           }
 
           this.setInitialView(hash, {

--- a/web/app.js
+++ b/web/app.js
@@ -1531,6 +1531,13 @@ const PDFViewerApplication = {
    * @private
    */
   async _initializePageLabels(pdfDocument) {
+    if (
+      typeof PDFJSDev === "undefined"
+        ? window.isGECKOVIEW
+        : PDFJSDev.test("GECKOVIEW")
+    ) {
+      return;
+    }
     const labels = await pdfDocument.getPageLabels();
 
     if (pdfDocument !== this.pdfDocument) {

--- a/web/pdf_scripting_manager.js
+++ b/web/pdf_scripting_manager.js
@@ -269,7 +269,9 @@ class PDFScriptingManager {
           // NOTE: Always ignore the pageLayout in GeckoView since there's
           // no UI available to change Scroll/Spread modes for the user.
           if (
-            (typeof PDFJSDev !== "undefined" && PDFJSDev.test("GECKOVIEW")) ||
+            (typeof PDFJSDev === "undefined"
+              ? window.isGECKOVIEW
+              : PDFJSDev.test("GECKOVIEW")) ||
             isInPresentationMode
           ) {
             return;

--- a/web/viewer-geckoview.js
+++ b/web/viewer-geckoview.js
@@ -68,6 +68,7 @@ function webViewerLoad() {
 
       document.head.append(link);
     }
+    window.isGECKOVIEW = true;
 
     import("pdfjs-web/genericcom.js").then(function (genericCom) {
       PDFViewerApplication.run(config);


### PR DESCRIPTION
 - [GeckoView] Introduce a development mode constant to tell the viewers apart

   Currently we have a couple of pre-processor checks, specifically for the GV-viewer, spread throughout the code. This works fine when *building* the viewer, however they're obviously ignored in development mode (i.e. `gulp server`).
   This leads to a situation where the GV development viewer, i.e. http://localhost:8888/web/viewer-geckoview.html, behaves subtly different from its built version. This could easily lead to bugs, hence this patch introduces a development mode constant to hopefully improve things here.

   Finally, in a follow-up to PR #15842, also ignores the `pageMode`-state since there's no sidebar available.

 - [GeckoView] Skip fetching/parsing of pageLabels

   Currently there's no toolbar in the GV-viewer, hence invoking the pageLabels functionality isn't meaningful and just leads to unnecessary parsing on both the main- and worker-threads. (And if a toolbar is added at some point, it's not clear to me if we'd want to support pageLabels in the GV-viewer anyway.)