### PR TITLE
Remove most build-time `require` statements from the viewer (PR 16009 follow-up)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2004,27 +2004,6 @@ gulp.task(
   )
 );
 
-gulp.task("dev-css", function createDevCSS() {
-  console.log();
-  console.log("### Building development CSS");
-
-  const defines = builder.merge(DEFINES, { GENERIC: true, TESTING: true });
-  const cssDir = BUILD_DIR + "dev-css/";
-
-  return merge([
-    gulp.src("web/images/*", { base: "web/" }).pipe(gulp.dest(cssDir)),
-
-    preprocessCSS("web/viewer.css", defines)
-      .pipe(
-        postcss([
-          postcssDirPseudoClass(),
-          autoprefixer({ overrideBrowserslist: ["last 1 versions"] }),
-        ])
-      )
-      .pipe(gulp.dest(cssDir)),
-  ]);
-});
-
 gulp.task(
   "dev-sandbox",
   gulp.series(
@@ -2053,13 +2032,6 @@ gulp.task(
 gulp.task(
   "server",
   gulp.parallel(
-    function watchDevCSS() {
-      gulp.watch(
-        ["web/*.css", "web/images/*"],
-        { ignoreInitial: false },
-        gulp.series("dev-css")
-      );
-    },
     function watchDevFitCurve() {
       gulp.watch(
         ["src/display/editor/*"],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -241,6 +241,7 @@ function createWebpackConfig(
   };
   const viewerAlias = {
     "web-annotation_editor_params": "web/annotation_editor_params.js",
+    "web-com": "",
     "web-pdf_attachment_viewer": "web/pdf_attachment_viewer.js",
     "web-pdf_cursor_tools": "web/pdf_cursor_tools.js",
     "web-pdf_document_properties": "web/pdf_document_properties.js",
@@ -251,13 +252,25 @@ function createWebpackConfig(
     "web-pdf_sidebar": "web/pdf_sidebar.js",
     "web-pdf_sidebar_resizer": "web/pdf_sidebar_resizer.js",
     "web-pdf_thumbnail_viewer": "web/pdf_thumbnail_viewer.js",
+    "web-print_service": "",
     "web-secondary_toolbar": "web/secondary_toolbar.js",
     "web-toolbar": "web/toolbar.js",
   };
-  if (bundleDefines.GECKOVIEW) {
-    for (const key in viewerAlias) {
-      viewerAlias[key] = "web/stubs-geckoview.js";
+  if (bundleDefines.CHROME) {
+    viewerAlias["web-com"] = "web/chromecom.js";
+    viewerAlias["web-print_service"] = "web/pdf_print_service.js";
+  } else if (bundleDefines.GENERIC) {
+    viewerAlias["web-com"] = "web/genericcom.js";
+    viewerAlias["web-print_service"] = "web/pdf_print_service.js";
+  } else if (bundleDefines.MOZCENTRAL) {
+    if (bundleDefines.GECKOVIEW) {
+      for (const key in viewerAlias) {
+        viewerAlias[key] = "web/stubs-geckoview.js";
+      }
+    } else {
+      viewerAlias["web-print_service"] = "web/firefox_print_service.js";
     }
+    viewerAlias["web-com"] = "web/firefoxcom.js";
   }
   const alias = { ...basicAlias, ...viewerAlias };
   for (const key in alias) {

--- a/test/unit/unit_test.html
+++ b/test/unit/unit_test.html
@@ -19,6 +19,7 @@
         "pdfjs-test/": "../",
 
         "web-annotation_editor_params": "../../web/annotation_editor_params.js",
+        "web-com": "../../web/genericcom.js",
         "web-pdf_attachment_viewer": "../../web/pdf_attachment_viewer.js",
         "web-pdf_cursor_tools": "../../web/pdf_cursor_tools.js",
         "web-pdf_document_properties": "../../web/pdf_document_properties.js",
@@ -29,6 +30,7 @@
         "web-pdf_sidebar": "../../web/pdf_sidebar.js",
         "web-pdf_sidebar_resizer": "../../web/pdf_sidebar_resizer.js",
         "web-pdf_thumbnail_viewer": "../../web/pdf_thumbnail_viewer.js",
+        "web-print_service": "../../web/pdf_print_service.js",
         "web-secondary_toolbar": "../../web/secondary_toolbar.js",
         "web-toolbar": "../../web/toolbar.js"
       }

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -46,6 +46,7 @@ import { AnnotationEditorLayerBuilder } from "./annotation_editor_layer_builder.
 import { AnnotationLayerBuilder } from "./annotation_layer_builder.js";
 import { compatibilityParams } from "./app_options.js";
 import { NullL10n } from "./l10n_utils.js";
+import { SimpleLinkService } from "./pdf_link_service.js";
 import { StructTreeLayerBuilder } from "./struct_tree_layer_builder.js";
 import { TextAccessibilityManager } from "./text_accessibility.js";
 import { TextHighlighter } from "./text_highlighter.js";
@@ -103,7 +104,6 @@ const DEFAULT_LAYER_PROPERTIES = () => {
     findController: null,
     hasJSActionsPromise: null,
     get linkService() {
-      const { SimpleLinkService } = require("./pdf_link_service.js");
       return new SimpleLinkService();
     },
   };

--- a/web/viewer-geckoview.html
+++ b/web/viewer-geckoview.html
@@ -51,6 +51,7 @@ See https://github.com/adobe-type-tools/cmap-resources
           "pdfjs-fitCurve": "../build/dev-fitCurve/fit_curve.js",
 
           "web-annotation_editor_params": "./stubs-geckoview.js",
+          "web-com": "./genericcom.js",
           "web-pdf_attachment_viewer": "./stubs-geckoview.js",
           "web-pdf_cursor_tools": "./stubs-geckoview.js",
           "web-pdf_document_properties": "./stubs-geckoview.js",
@@ -61,6 +62,7 @@ See https://github.com/adobe-type-tools/cmap-resources
           "web-pdf_sidebar": "./stubs-geckoview.js",
           "web-pdf_sidebar_resizer": "./stubs-geckoview.js",
           "web-pdf_thumbnail_viewer": "./stubs-geckoview.js",
+          "web-print_service": "./stubs-geckoview.js",
           "web-secondary_toolbar": "./stubs-geckoview.js",
           "web-toolbar": "./stubs-geckoview.js"
         }

--- a/web/viewer-geckoview.js
+++ b/web/viewer-geckoview.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import "web-com";
 import { RenderingStates, ScrollMode, SpreadMode } from "./ui_utils.js";
 import { AppOptions } from "./app_options.js";
 import { LinkTarget } from "./pdf_link_service.js";
@@ -33,10 +34,6 @@ const AppConstants =
 window.PDFViewerApplication = PDFViewerApplication;
 window.PDFViewerApplicationConstants = AppConstants;
 window.PDFViewerApplicationOptions = AppOptions;
-
-if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
-  require("./firefoxcom.js");
-}
 
 function getViewerConfiguration() {
   return {
@@ -60,15 +57,11 @@ function getViewerConfiguration() {
 
 function webViewerLoad() {
   const config = getViewerConfiguration();
+
   if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
     window.isGECKOVIEW = true;
-
-    import("pdfjs-web/genericcom.js").then(function (genericCom) {
-      PDFViewerApplication.run(config);
-    });
-  } else {
-    PDFViewerApplication.run(config);
   }
+  PDFViewerApplication.run(config);
 }
 
 // Block the "load" event until all pages are loaded, to ensure that printing

--- a/web/viewer-geckoview.js
+++ b/web/viewer-geckoview.js
@@ -61,13 +61,6 @@ function getViewerConfiguration() {
 function webViewerLoad() {
   const config = getViewerConfiguration();
   if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
-    if (window.chrome) {
-      const link = document.createElement("link");
-      link.rel = "stylesheet";
-      link.href = "../build/dev-css/viewer.css";
-
-      document.head.append(link);
-    }
     window.isGECKOVIEW = true;
 
     import("pdfjs-web/genericcom.js").then(function (genericCom) {

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -52,6 +52,7 @@ See https://github.com/adobe-type-tools/cmap-resources
           "pdfjs-fitCurve": "../build/dev-fitCurve/fit_curve.js",
 
           "web-annotation_editor_params": "./annotation_editor_params.js",
+          "web-com": "./genericcom.js",
           "web-pdf_attachment_viewer": "./pdf_attachment_viewer.js",
           "web-pdf_cursor_tools": "./pdf_cursor_tools.js",
           "web-pdf_document_properties": "./pdf_document_properties.js",
@@ -62,6 +63,7 @@ See https://github.com/adobe-type-tools/cmap-resources
           "web-pdf_sidebar": "./pdf_sidebar.js",
           "web-pdf_sidebar_resizer": "./pdf_sidebar_resizer.js",
           "web-pdf_thumbnail_viewer": "./pdf_thumbnail_viewer.js",
+          "web-print_service": "./pdf_print_service.js",
           "web-secondary_toolbar": "./secondary_toolbar.js",
           "web-toolbar": "./toolbar.js"
         }

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -207,14 +207,6 @@ function getViewerConfiguration() {
 function webViewerLoad() {
   const config = getViewerConfiguration();
   if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
-    if (window.chrome) {
-      const link = document.createElement("link");
-      link.rel = "stylesheet";
-      link.href = "../build/dev-css/viewer.css";
-
-      document.head.append(link);
-    }
-
     Promise.all([
       import("pdfjs-web/genericcom.js"),
       import("pdfjs-web/pdf_print_service.js"),

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+import "web-com";
+import "web-print_service";
 import { RenderingStates, ScrollMode, SpreadMode } from "./ui_utils.js";
 import { AppOptions } from "./app_options.js";
 import { LinkTarget } from "./pdf_link_service.js";
@@ -52,20 +54,6 @@ if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("CHROME")) {
 
     AppOptions.set("defaultUrl", defaultUrl);
   })();
-}
-
-if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
-  require("./firefoxcom.js");
-  require("./firefox_print_service.js");
-}
-if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("GENERIC")) {
-  require("./genericcom.js");
-}
-if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("CHROME")) {
-  require("./chromecom.js");
-}
-if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("CHROME || GENERIC")) {
-  require("./pdf_print_service.js");
 }
 
 function getViewerConfiguration() {
@@ -206,37 +194,28 @@ function getViewerConfiguration() {
 
 function webViewerLoad() {
   const config = getViewerConfiguration();
-  if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
-    Promise.all([
-      import("pdfjs-web/genericcom.js"),
-      import("pdfjs-web/pdf_print_service.js"),
-    ]).then(function ([genericCom, pdfPrintService]) {
-      PDFViewerApplication.run(config);
-    });
-  } else {
-    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("GENERIC")) {
-      // Give custom implementations of the default viewer a simpler way to
-      // set various `AppOptions`, by dispatching an event once all viewer
-      // files are loaded but *before* the viewer initialization has run.
-      const event = document.createEvent("CustomEvent");
-      event.initCustomEvent("webviewerloaded", true, true, {
-        source: window,
-      });
-      try {
-        // Attempt to dispatch the event at the embedding `document`,
-        // in order to support cases where the viewer is embedded in
-        // a *dynamically* created <iframe> element.
-        parent.document.dispatchEvent(event);
-      } catch (ex) {
-        // The viewer could be in e.g. a cross-origin <iframe> element,
-        // fallback to dispatching the event at the current `document`.
-        console.error(`webviewerloaded: ${ex}`);
-        document.dispatchEvent(event);
-      }
-    }
 
-    PDFViewerApplication.run(config);
+  if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("GENERIC")) {
+    // Give custom implementations of the default viewer a simpler way to
+    // set various `AppOptions`, by dispatching an event once all viewer
+    // files are loaded but *before* the viewer initialization has run.
+    const event = document.createEvent("CustomEvent");
+    event.initCustomEvent("webviewerloaded", true, true, {
+      source: window,
+    });
+    try {
+      // Attempt to dispatch the event at the embedding `document`,
+      // in order to support cases where the viewer is embedded in
+      // a *dynamically* created <iframe> element.
+      parent.document.dispatchEvent(event);
+    } catch (ex) {
+      // The viewer could be in e.g. a cross-origin <iframe> element,
+      // fallback to dispatching the event at the current `document`.
+      console.error(`webviewerloaded: ${ex}`);
+      document.dispatchEvent(event);
+    }
   }
+  PDFViewerApplication.run(config);
 }
 
 // Block the "load" event until all pages are loaded, to ensure that printing


### PR DESCRIPTION
 - Remove the "div-css" gulp task (PR 15968 follow-up)

   After the compatibility updates in PR #15968 it's no longer strictly necessary to build the `viewer.css` file in order for the *development viewer* to work in Chromium-based browsers.

   *Please note:* Given that Chromium-based browsers still don't support the *unprefixed* `mask-image` property the icons won't look right, however the development viewer itself works.
   Given that Firefox is the *primary* development target, and that running `gulp generic` locally will generate polyfilled CSS, it seems reasonable to make this simplification here.

 - Remove most build-time `require` statements from the viewer (PR 16009 follow-up)

   This further extends the web-specific import maps introduced in PR #16009, to allow removing *most* of the build-time `require` statements from the viewer. The few remaining ones are fallbacks used for the COMPONENTS respectively the `legacy` GENERIC builds.