### PR TITLE
Avoid a useless animation when the spinner is invisible

### DIFF
--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -166,22 +166,22 @@
   width: 100%;
   height: 100%;
   background: url("images/loading-icon.gif") center no-repeat;
-  visibility: hidden;
+  display: none;
   /* Using a delay with background-image doesn't work,
-     consequently we use the visibility. */
-  transition-property: visibility;
+     consequently we use the display. */
+  transition-property: display;
   transition-delay: var(--loading-icon-delay);
   z-index: 5;
   contain: strict;
 }
 
 .pdfViewer .page.loading:after {
-  visibility: visible;
+  display: block;
 }
 
 .pdfViewer .page:not(.loading):after {
   transition-property: none;
-  visibility: hidden;
+  display: none;
 }
 
 .pdfViewer.enablePermissions .textLayer span {


### PR DESCRIPTION
In looking at a profile, I noticed in Marker chart that there's an animation for loading-icon.gif even if this icon isn't visible. This patch doesn't completely remove it but just slightly postpones it.