### PR TITLE
Reduce usage of the `arrayByteLength` helper function

### DIFF
--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -14,8 +14,8 @@
  */
 
 import {
-  arrayByteLength,
   arraysToBytes,
+  assert,
   createPromiseCapability,
 } from "../shared/util.js";
 import { MissingDataException } from "./core_utils.js";
@@ -299,12 +299,22 @@ class ChunkedStreamManager {
             resolve(chunkData);
             return;
           }
+          if (
+            typeof PDFJSDev === "undefined" ||
+            PDFJSDev.test("!PRODUCTION || TESTING")
+          ) {
+            assert(
+              value instanceof ArrayBuffer,
+              "readChunk (sendRequest) - expected an ArrayBuffer."
+            );
+          }
+          loaded += value.byteLength;
 
-          chunks.push(value);
-          loaded += arrayByteLength(value);
           if (rangeReader.isStreamingSupported) {
             this.onProgress({ loaded });
           }
+
+          chunks.push(value);
           rangeReader.read().then(readChunk, reject);
         } catch (e) {
           reject(e);

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -15,8 +15,8 @@
 
 import {
   AbortException,
-  arrayByteLength,
   arraysToBytes,
+  assert,
   createPromiseCapability,
   getVerbosityLevel,
   info,
@@ -314,8 +314,17 @@ class WorkerMessageHandler {
               cancelXHRs = null;
               return;
             }
+            if (
+              typeof PDFJSDev === "undefined" ||
+              PDFJSDev.test("!PRODUCTION || TESTING")
+            ) {
+              assert(
+                value instanceof ArrayBuffer,
+                "readChunk (getPdfManager) - expected an ArrayBuffer."
+              );
+            }
+            loaded += value.byteLength;
 
-            loaded += arrayByteLength(value);
             if (!fullRequest.isStreamingSupported) {
               handler.send("DocProgress", {
                 loaded,
@@ -328,7 +337,6 @@ class WorkerMessageHandler {
             } else {
               cachedChunks.push(value);
             }
-
             fullRequest.read().then(readChunk, reject);
           } catch (e) {
             reject(e);

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1115,7 +1115,6 @@ export {
   AnnotationReviewState,
   AnnotationStateModelType,
   AnnotationType,
-  arrayByteLength,
   arraysToBytes,
   assert,
   BaseException,


### PR DESCRIPTION
We're using this helper function when reading data from the [`PDFWorkerStreamReader.read`](https://github.com/mozilla/pdf.js/blob/a49d1d1615c87130e12f3542deac6c2de314813d/src/core/worker_stream.js#L90-L98) and [`PDFWorkerStreamRangeReader.read`](https://github.com/mozilla/pdf.js/blob/a49d1d1615c87130e12f3542deac6c2de314813d/src/core/worker_stream.js#L122-L128) methods, and as can be seen they always return `ArrayBuffer` data. Hence we can simply get the `byteLength` directly, and don't need to use the helper function.

Note that at the time when `arrayByteLength` was added we still supported browsers without TypedArray functionality, and we'd then simulate them using regular Arrays.