### PR TITLE
[Annotation] A combo can have a value other than one in the options

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -1981,15 +1981,14 @@ class WidgetAnnotation extends Annotation {
     }
 
     assert(typeof value === "string", "Expected `value` to be a string.");
+    value = value.trim();
 
-    if (!this.data.combo) {
-      value = value.trim();
-    } else {
-      // The value is supposed to be one of the exportValue.
-      const option =
-        this.data.options.find(({ exportValue }) => value === exportValue) ||
-        this.data.options[0];
-      value = (option && option.displayValue) || "";
+    if (this.data.combo) {
+      // The value can be one of the exportValue or any other values.
+      const option = this.data.options.find(
+        ({ exportValue }) => value === exportValue
+      );
+      value = (option && option.displayValue) || value;
     }
 
     if (value === "") {


### PR DESCRIPTION
When printing the pdf in #12233 in Acrobat, we can see that the combo for country
is empty: it's because the V entry doesn't have to be one of the options.