### PR TITLE
Re-factor the `arraysToBytes` helper function (PR 16032 follow-up)

### DIFF
--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -13,12 +13,8 @@
  * limitations under the License.
  */
 
-import {
-  arrayBuffersToBytes,
-  assert,
-  createPromiseCapability,
-} from "../shared/util.js";
-import { MissingDataException } from "./core_utils.js";
+import { arrayBuffersToBytes, MissingDataException } from "./core_utils.js";
+import { assert, createPromiseCapability } from "../shared/util.js";
 import { Stream } from "./stream.js";
 
 class ChunkedStream extends Stream {

--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -14,7 +14,7 @@
  */
 
 import {
-  arraysToBytes,
+  arrayBuffersToBytes,
   assert,
   createPromiseCapability,
 } from "../shared/util.js";
@@ -294,7 +294,7 @@ class ChunkedStreamManager {
       const readChunk = ({ value, done }) => {
         try {
           if (done) {
-            const chunkData = arraysToBytes(chunks);
+            const chunkData = arrayBuffersToBytes(chunks);
             chunks = null;
             resolve(chunkData);
             return;

--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -81,6 +81,44 @@ class XRefParseException extends BaseException {
 }
 
 /**
+ * Combines multiple ArrayBuffers into a single Uint8Array.
+ * @param {Array<ArrayBuffer>} arr - An array of ArrayBuffers.
+ * @returns {Uint8Array}
+ */
+function arrayBuffersToBytes(arr) {
+  if (
+    typeof PDFJSDev === "undefined" ||
+    PDFJSDev.test("!PRODUCTION || TESTING")
+  ) {
+    for (const item of arr) {
+      assert(
+        item instanceof ArrayBuffer,
+        "arrayBuffersToBytes - expected an ArrayBuffer."
+      );
+    }
+  }
+  const length = arr.length;
+  if (length === 0) {
+    return new Uint8Array(0);
+  }
+  if (length === 1) {
+    return new Uint8Array(arr[0]);
+  }
+  let dataLength = 0;
+  for (let i = 0; i < length; i++) {
+    dataLength += arr[i].byteLength;
+  }
+  const data = new Uint8Array(dataLength);
+  let pos = 0;
+  for (let i = 0; i < length; i++) {
+    const item = new Uint8Array(arr[i]);
+    data.set(item, pos);
+    pos += item.byteLength;
+  }
+  return data;
+}
+
+/**
  * Get the value of an inheritable property.
  *
  * If the PDF specification explicitly lists a property in a dictionary as
@@ -579,6 +617,7 @@ function getRotationMatrix(rotation, width, height) {
 }
 
 export {
+  arrayBuffersToBytes,
   collectActions,
   encodeToXmlString,
   escapePDFName,

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -15,7 +15,7 @@
 
 import {
   AbortException,
-  arraysToBytes,
+  arrayBuffersToBytes,
   assert,
   createPromiseCapability,
   getVerbosityLevel,
@@ -281,7 +281,7 @@ class WorkerMessageHandler {
 
       let loaded = 0;
       const flushChunks = function () {
-        const pdfFile = arraysToBytes(cachedChunks);
+        const pdfFile = arrayBuffersToBytes(cachedChunks);
         if (length && pdfFile.length !== length) {
           warn("reported HTTP length is different from actual");
         }

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -93,7 +93,7 @@ class WorkerMessageHandler {
     let pdfManager;
     let terminated = false;
     let cancelXHRs = null;
-    const WorkerTasks = [];
+    const WorkerTasks = new Set();
     const verbosity = getVerbosityLevel();
 
     const { docId, apiVersion } = docParams;
@@ -151,13 +151,12 @@ class WorkerMessageHandler {
     }
 
     function startWorkerTask(task) {
-      WorkerTasks.push(task);
+      WorkerTasks.add(task);
     }
 
     function finishWorkerTask(task) {
       task.finish();
-      const i = WorkerTasks.indexOf(task);
-      WorkerTasks.splice(i, 1);
+      WorkerTasks.delete(task);
     }
 
     async function loadDocument(recoveryMode) {

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -15,7 +15,6 @@
 
 import {
   AbortException,
-  arrayBuffersToBytes,
   assert,
   createPromiseCapability,
   getVerbosityLevel,
@@ -30,8 +29,12 @@ import {
   VerbosityLevel,
   warn,
 } from "../shared/util.js";
+import {
+  arrayBuffersToBytes,
+  getNewAnnotationsMap,
+  XRefParseException,
+} from "./core_utils.js";
 import { Dict, Ref } from "./primitives.js";
-import { getNewAnnotationsMap, XRefParseException } from "./core_utils.js";
 import { LocalPdfManager, NetworkPdfManager } from "./pdf_manager.js";
 import { clearGlobalCaches } from "./cleanup_helper.js";
 import { incrementalUpdate } from "./writer.js";

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -598,51 +598,39 @@ function stringToBytes(str) {
 }
 
 /**
- * Gets length of the array (Array, Uint8Array, or string) in bytes.
- * @param {Array<any>|Uint8Array|string} arr
- * @returns {number}
- */
-// eslint-disable-next-line consistent-return
-function arrayByteLength(arr) {
-  if (arr.length !== undefined) {
-    return arr.length;
-  }
-  if (arr.byteLength !== undefined) {
-    return arr.byteLength;
-  }
-  unreachable("Invalid argument for arrayByteLength");
-}
-
-/**
- * Combines array items (arrays) into single Uint8Array object.
- * @param {Array<Array<any>|Uint8Array|string>} arr - the array of the arrays
- *   (Array, Uint8Array, or string).
+ * Combines multiple ArrayBuffers into a single Uint8Array.
+ * @param {Array<ArrayBuffer>} arr - An array of ArrayBuffers.
  * @returns {Uint8Array}
  */
-function arraysToBytes(arr) {
-  const length = arr.length;
-  // Shortcut: if first and only item is Uint8Array, return it.
-  if (length === 1 && arr[0] instanceof Uint8Array) {
-    return arr[0];
-  }
-  let resultLength = 0;
-  for (let i = 0; i < length; i++) {
-    resultLength += arrayByteLength(arr[i]);
-  }
-  let pos = 0;
-  const data = new Uint8Array(resultLength);
-  for (let i = 0; i < length; i++) {
-    let item = arr[i];
-    if (!(item instanceof Uint8Array)) {
-      if (typeof item === "string") {
-        item = stringToBytes(item);
-      } else {
-        item = new Uint8Array(item);
-      }
+function arrayBuffersToBytes(arr) {
+  if (
+    typeof PDFJSDev === "undefined" ||
+    PDFJSDev.test("!PRODUCTION || TESTING")
+  ) {
+    for (const item of arr) {
+      assert(
+        item instanceof ArrayBuffer,
+        "arrayBuffersToBytes - expected an ArrayBuffer."
+      );
     }
-    const itemLength = item.byteLength;
+  }
+  const length = arr.length;
+  if (length === 0) {
+    return new Uint8Array(0);
+  }
+  if (length === 1) {
+    return new Uint8Array(arr[0]);
+  }
+  let dataLength = 0;
+  for (let i = 0; i < length; i++) {
+    dataLength += arr[i].byteLength;
+  }
+  const data = new Uint8Array(dataLength);
+  let pos = 0;
+  for (let i = 0; i < length; i++) {
+    const item = new Uint8Array(arr[i]);
     data.set(item, pos);
-    pos += itemLength;
+    pos += item.byteLength;
   }
   return data;
 }
@@ -1115,7 +1103,7 @@ export {
   AnnotationReviewState,
   AnnotationStateModelType,
   AnnotationType,
-  arraysToBytes,
+  arrayBuffersToBytes,
   assert,
   BaseException,
   BASELINE_FACTOR,

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -597,44 +597,6 @@ function stringToBytes(str) {
   return bytes;
 }
 
-/**
- * Combines multiple ArrayBuffers into a single Uint8Array.
- * @param {Array<ArrayBuffer>} arr - An array of ArrayBuffers.
- * @returns {Uint8Array}
- */
-function arrayBuffersToBytes(arr) {
-  if (
-    typeof PDFJSDev === "undefined" ||
-    PDFJSDev.test("!PRODUCTION || TESTING")
-  ) {
-    for (const item of arr) {
-      assert(
-        item instanceof ArrayBuffer,
-        "arrayBuffersToBytes - expected an ArrayBuffer."
-      );
-    }
-  }
-  const length = arr.length;
-  if (length === 0) {
-    return new Uint8Array(0);
-  }
-  if (length === 1) {
-    return new Uint8Array(arr[0]);
-  }
-  let dataLength = 0;
-  for (let i = 0; i < length; i++) {
-    dataLength += arr[i].byteLength;
-  }
-  const data = new Uint8Array(dataLength);
-  let pos = 0;
-  for (let i = 0; i < length; i++) {
-    const item = new Uint8Array(arr[i]);
-    data.set(item, pos);
-    pos += item.byteLength;
-  }
-  return data;
-}
-
 function string32(value) {
   if (
     typeof PDFJSDev === "undefined" ||
@@ -1103,7 +1065,6 @@ export {
   AnnotationReviewState,
   AnnotationStateModelType,
   AnnotationType,
-  arrayBuffersToBytes,
   assert,
   BaseException,
   BASELINE_FACTOR,

--- a/test/unit/core_utils_spec.js
+++ b/test/unit/core_utils_spec.js
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import { Dict, Ref } from "../../src/core/primitives.js";
 import {
+  arrayBuffersToBytes,
   encodeToXmlString,
   escapePDFName,
   escapeString,
@@ -30,9 +30,36 @@ import {
   toRomanNumerals,
   validateCSSFont,
 } from "../../src/core/core_utils.js";
+import { Dict, Ref } from "../../src/core/primitives.js";
 import { XRefMock } from "./test_utils.js";
 
 describe("core_utils", function () {
+  describe("arrayBuffersToBytes", function () {
+    it("handles zero ArrayBuffers", function () {
+      const bytes = arrayBuffersToBytes([]);
+
+      expect(bytes).toEqual(new Uint8Array(0));
+    });
+
+    it("handles one ArrayBuffer", function () {
+      const buffer = new Uint8Array([1, 2, 3]).buffer;
+      const bytes = arrayBuffersToBytes([buffer]);
+
+      expect(bytes).toEqual(new Uint8Array([1, 2, 3]));
+      // Ensure that the fast-path works correctly.
+      expect(bytes.buffer).toBe(buffer);
+    });
+
+    it("handles multiple ArrayBuffers", function () {
+      const buffer1 = new Uint8Array([1, 2, 3]).buffer,
+        buffer2 = new Uint8Array(0).buffer,
+        buffer3 = new Uint8Array([4, 5]).buffer;
+      const bytes = arrayBuffersToBytes([buffer1, buffer2, buffer3]);
+
+      expect(bytes).toEqual(new Uint8Array([1, 2, 3, 4, 5]));
+    });
+  });
+
   describe("getInheritableProperty", function () {
     it("handles non-dictionary arguments", function () {
       expect(getInheritableProperty({ dict: null, key: "foo" })).toEqual(


### PR DESCRIPTION
 - Change `WorkerTasks`, in `WorkerMessageHandler.createDocumentHandler`, to a use a Set

   This is a tiny bit more compact, thanks to the `Set.prototype.delete` method.

 - Re-factor the `arraysToBytes` helper function (PR 16032 follow-up)

   Currently this helper function only has two call-sites, and both of them only pass in `ArrayBuffer` data. Given how it's implemented there's a couple of code-paths that are completely unused (e.g. the "string" one), and in particular the intended fast-paths don't actually work.
   This patch re-factors and simplifies the helper function, and it'll no longer accept anything except `ArrayBuffer` data (hence why it's also re-named).

   Note that at the time when `arraysToBytes` was added we still supported browsers without TypedArray functionality, and we'd then simulate them using regular Arrays.

 - Move the `arrayBuffersToBytes` helper function into the worker-thread

   Given that this helper function is only used on the worker-thread, there's no reason to duplicate it in both of the *built* `pdf.js` and `pdf.worker.js` files.