### PR TITLE
Ensure that "GetAnnotations" errors are propagated to the main-thread (PR 15267 follow-up)

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -544,6 +544,7 @@ class WorkerMessageHandler {
           },
           reason => {
             finishWorkerTask(task);
+            throw reason;
           }
         );
       });


### PR DESCRIPTION
With the changes in PR #15267 we're now accidentally swallowing "GetAnnotations" errors, rather than propagating them to the main-thread as intended.