### PR TITLE
Slightly re-factor preferences/options initialization in the viewer

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -268,10 +268,7 @@ const PDFViewerApplication = {
    * @private
    */
   async _readPreferences() {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || GENERIC")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       if (AppOptions.get("disablePreferences")) {
         // Give custom implementations of the default viewer a simpler way to
         // opt-out of having the `Preferences` override existing `AppOptions`.

--- a/web/app.js
+++ b/web/app.js
@@ -233,8 +233,7 @@ const PDFViewerApplication = {
     this.preferences = this.externalServices.createPreferences();
     this.appConfig = appConfig;
 
-    await this._readPreferences();
-    await this._parseHashParameters();
+    await this._initializeOptions();
     this._forceCssTheme();
     await this._initializeL10n();
 
@@ -267,16 +266,19 @@ const PDFViewerApplication = {
   /**
    * @private
    */
-  async _readPreferences() {
+  async _initializeOptions() {
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       if (AppOptions.get("disablePreferences")) {
+        if (AppOptions.get("pdfBugEnabled")) {
+          await this._parseHashParams();
+        }
         // Give custom implementations of the default viewer a simpler way to
         // opt-out of having the `Preferences` override existing `AppOptions`.
         return;
       }
       if (AppOptions._hasUserOptions()) {
         console.warn(
-          "_readPreferences: The Preferences may override manually set AppOptions; " +
+          "_initializeOptions: The Preferences may override manually set AppOptions; " +
             'please use the "disablePreferences"-option in order to prevent that.'
         );
       }
@@ -284,7 +286,11 @@ const PDFViewerApplication = {
     try {
       AppOptions.setAll(await this.preferences.getAll());
     } catch (reason) {
-      console.error(`_readPreferences: "${reason?.message}".`);
+      console.error(`_initializeOptions: "${reason.message}".`);
+    }
+
+    if (AppOptions.get("pdfBugEnabled")) {
+      await this._parseHashParams();
     }
   },
 
@@ -292,10 +298,7 @@ const PDFViewerApplication = {
    * Potentially parse special debugging flags in the hash section of the URL.
    * @private
    */
-  async _parseHashParameters() {
-    if (!AppOptions.get("pdfBugEnabled")) {
-      return;
-    }
+  async _parseHashParams() {
     const hash = document.location.hash.substring(1);
     if (!hash) {
       return;
@@ -312,7 +315,7 @@ const PDFViewerApplication = {
       try {
         await loadFakeWorker();
       } catch (ex) {
-        console.error(`_parseHashParameters: "${ex.message}".`);
+        console.error(`_parseHashParams: "${ex.message}".`);
       }
     }
     if (params.has("disablerange")) {
@@ -352,7 +355,7 @@ const PDFViewerApplication = {
             await loadPDFBug(this);
             this._PDFBug.loadCSS();
           } catch (ex) {
-            console.error(`_parseHashParameters: "${ex.message}".`);
+            console.error(`_parseHashParams: "${ex.message}".`);
           }
           break;
       }
@@ -366,7 +369,7 @@ const PDFViewerApplication = {
         await loadPDFBug(this);
         this._PDFBug.init({ OPS }, mainContainer, enabled);
       } catch (ex) {
-        console.error(`_parseHashParameters: "${ex.message}".`);
+        console.error(`_parseHashParams: "${ex.message}".`);
       }
     }
     // It is not possible to change locale for the (various) extension builds.

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -404,13 +404,12 @@ class AppOptions {
   static remove(name) {
     delete userOptions[name];
   }
+}
 
-  /**
-   * @ignore
-   */
-  static _hasUserOptions() {
+if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+  AppOptions._hasUserOptions = function () {
     return Object.keys(userOptions).length > 0;
-  }
+  };
 }
 
 export { AppOptions, compatibilityParams, OptionKind };


### PR DESCRIPTION
Given that the debugging hash-parameters will only be used when the `pdfBugEnabled` option is manually set[1], we can skip a *tiny* bit of asynchronicity for "regular" users.

---
[1] Note that it's enabled by default in the development viewer, i.e. in `gulp server` mode.