### PR TITLE
Improve the consistency between the `LocalPdfManager`/`NetworkPdfManager` constructor

### DIFF
--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -36,10 +36,15 @@ function parseDocBaseUrl(url) {
 }
 
 class BasePdfManager {
-  constructor() {
+  constructor(args) {
     if (this.constructor === BasePdfManager) {
       unreachable("Cannot initialize BasePdfManager.");
     }
+    this._docBaseUrl = parseDocBaseUrl(args.docBaseUrl);
+    this._docId = args.docId;
+    this._password = args.password;
+    this.enableXfa = args.enableXfa;
+    this.evaluatorOptions = args.evaluatorOptions;
   }
 
   get docId() {
@@ -117,25 +122,10 @@ class BasePdfManager {
 }
 
 class LocalPdfManager extends BasePdfManager {
-  constructor(
-    docId,
-    data,
-    password,
-    msgHandler,
-    evaluatorOptions,
-    enableXfa,
-    docBaseUrl
-  ) {
-    super();
+  constructor(args) {
+    super(args);
 
-    this._docId = docId;
-    this._password = password;
-    this._docBaseUrl = parseDocBaseUrl(docBaseUrl);
-    this.msgHandler = msgHandler;
-    this.evaluatorOptions = evaluatorOptions;
-    this.enableXfa = enableXfa;
-
-    const stream = new Stream(data);
+    const stream = new Stream(args.source);
     this.pdfDocument = new PDFDocument(this, stream);
     this._loadedStreamPromise = Promise.resolve(stream);
   }
@@ -160,25 +150,11 @@ class LocalPdfManager extends BasePdfManager {
 }
 
 class NetworkPdfManager extends BasePdfManager {
-  constructor(
-    docId,
-    pdfNetworkStream,
-    args,
-    evaluatorOptions,
-    enableXfa,
-    docBaseUrl
-  ) {
-    super();
+  constructor(args) {
+    super(args);
 
-    this._docId = docId;
-    this._password = args.password;
-    this._docBaseUrl = parseDocBaseUrl(docBaseUrl);
-    this.msgHandler = args.msgHandler;
-    this.evaluatorOptions = evaluatorOptions;
-    this.enableXfa = enableXfa;
-
-    this.streamManager = new ChunkedStreamManager(pdfNetworkStream, {
-      msgHandler: args.msgHandler,
+    this.streamManager = new ChunkedStreamManager(args.source, {
+      msgHandler: args.handler,
       length: args.length,
       disableAutoFetch: args.disableAutoFetch,
       rangeChunkSize: args.rangeChunkSize,

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -210,20 +210,26 @@ class WorkerMessageHandler {
       enableXfa,
       evaluatorOptions,
     }) {
+      const pdfManagerArgs = {
+        source: null,
+        disableAutoFetch,
+        docBaseUrl,
+        docId,
+        enableXfa,
+        evaluatorOptions,
+        handler,
+        length,
+        password,
+        rangeChunkSize,
+      };
       const pdfManagerCapability = createPromiseCapability();
       let newPdfManager;
 
       if (data) {
         try {
-          newPdfManager = new LocalPdfManager(
-            docId,
-            data,
-            password,
-            handler,
-            evaluatorOptions,
-            enableXfa,
-            docBaseUrl
-          );
+          pdfManagerArgs.source = data;
+
+          newPdfManager = new LocalPdfManager(pdfManagerArgs);
           pdfManagerCapability.resolve(newPdfManager);
         } catch (ex) {
           pdfManagerCapability.reject(ex);
@@ -246,24 +252,13 @@ class WorkerMessageHandler {
           if (!fullRequest.isRangeSupported) {
             return;
           }
+          pdfManagerArgs.source = pdfStream;
+          pdfManagerArgs.length = fullRequest.contentLength;
           // We don't need auto-fetch when streaming is enabled.
-          disableAutoFetch =
-            disableAutoFetch || fullRequest.isStreamingSupported;
+          pdfManagerArgs.disableAutoFetch =
+            pdfManagerArgs.disableAutoFetch || fullRequest.isStreamingSupported;
 
-          newPdfManager = new NetworkPdfManager(
-            docId,
-            pdfStream,
-            {
-              msgHandler: handler,
-              password,
-              length: fullRequest.contentLength,
-              disableAutoFetch,
-              rangeChunkSize,
-            },
-            evaluatorOptions,
-            enableXfa,
-            docBaseUrl
-          );
+          newPdfManager = new NetworkPdfManager(pdfManagerArgs);
           // There may be a chance that `newPdfManager` is not initialized for
           // the first few runs of `readchunk` block of code. Be sure to send
           // all cached chunks, if any, to chunked_stream via pdf_manager.
@@ -288,15 +283,9 @@ class WorkerMessageHandler {
         }
         // the data is array, instantiating directly from it
         try {
-          newPdfManager = new LocalPdfManager(
-            docId,
-            pdfFile,
-            password,
-            handler,
-            evaluatorOptions,
-            enableXfa,
-            docBaseUrl
-          );
+          pdfManagerArgs.source = pdfFile;
+
+          newPdfManager = new LocalPdfManager(pdfManagerArgs);
           pdfManagerCapability.resolve(newPdfManager);
         } catch (ex) {
           pdfManagerCapability.reject(ex);


### PR DESCRIPTION
Currently these classes take a bunch of parameters (somewhat randomly ordered), probably because this is very old code that's been extended over the years.
Hence this patch changes the constructors to use parameter-objects instead, which improves consistency and (slightly) reduces the amount of code as well.

*Please note:* Also removes the `msgHandler`-property on these classes, since I cannot find a single call-site that accesses it.