### PR TITLE
A little clean-up of the `getDocument` call in `test/driver.js`

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -457,7 +457,6 @@ class Driver {
 
       this._log('Loading file "' + task.file + '"\n');
 
-      const absoluteUrl = new URL(task.file, window.location).href;
       try {
         let xfaStyleElement = null;
         if (task.enableXfa) {
@@ -471,11 +470,10 @@ class Driver {
         }
 
         const loadingTask = getDocument({
-          url: absoluteUrl,
+          url: new URL(task.file, window.location),
           password: task.password,
           cMapUrl: CMAP_URL,
           standardFontDataUrl: STANDARD_FONT_DATA_URL,
-          disableRange: task.disableRange,
           disableAutoFetch: !task.enableAutoFetch,
           pdfBug: true,
           useSystemFonts: task.useSystemFonts,


### PR DESCRIPTION
 - Pass the `URL`-object directly to `getDocument`, since that's been supported since PR #13166.
 - Remove support for the `disableRange`-option in the test-manifest, since it's completely unused. Please note that it's originally added in PR #2719, however there's never actually been any reference tests using it (not even from the start). Given that the option is `false` by default everywhere (e.g. in the Firefox PDF Viewer) and that we have unit-tests for `disableRange = true`, it doesn't seem necessary to add new reference tests for it now.