### PR TITLE
[api-minor] Deprecate providing binary data as `Buffer` in Node.js environments

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -507,7 +507,8 @@ async function _fetchDocument(worker, source) {
 function getUrlProp(val) {
   if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
     return null; // The 'url' is unused with `PDFDataRangeTransport`.
-  } else if (val instanceof URL) {
+  }
+  if (val instanceof URL) {
     return val.href;
   }
   try {
@@ -539,20 +540,17 @@ function getDataProp(val) {
     val instanceof Buffer // eslint-disable-line no-undef
   ) {
     return new Uint8Array(val);
-  } else if (
-    val instanceof Uint8Array &&
-    val.byteLength === val.buffer.byteLength
-  ) {
+  }
+  if (val instanceof Uint8Array && val.byteLength === val.buffer.byteLength) {
     // Use the data as-is when it's already a Uint8Array that completely
     // "utilizes" its underlying ArrayBuffer, to prevent any possible
     // issues when transferring it to the worker-thread.
     return val;
-  } else if (typeof val === "string") {
+  }
+  if (typeof val === "string") {
     return stringToBytes(val);
-  } else if (
-    (typeof val === "object" && !isNaN(val?.length)) ||
-    isArrayBuffer(val)
-  ) {
+  }
+  if ((typeof val === "object" && !isNaN(val?.length)) || isArrayBuffer(val)) {
     return new Uint8Array(val);
   }
   throw new Error(

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -539,6 +539,9 @@ function getDataProp(val) {
     typeof Buffer !== "undefined" && // eslint-disable-line no-undef
     val instanceof Buffer // eslint-disable-line no-undef
   ) {
+    deprecated(
+      "Please provide binary data as `Uint8Array`, rather than `Buffer`."
+    );
     return new Uint8Array(val);
   }
   if (val instanceof Uint8Array && val.byteLength === val.buffer.byteLength) {


### PR DESCRIPTION
The `Buffer`-object is Node.js specific functionality[1], thus (obviously) not found in browsers. Please note that the PDF.js library has never officially supported/documented that binary data can be passed as a `Buffer`, and that *internally* in the `src/core`-code we only work with standard `Uint8Array`s.
This means that if, in Node.js environments, a `Buffer` is passed to the API we need to wrap it into a `Uint8Array`, which essentially means creating a copy of the data and thus increasing memory usage.

---
[1] Refer to https://nodejs.org/api/buffer.html#buffer