### PR TITLE
Don't try to place the `xfaLayer` "on top" in regular PDF documents

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -863,11 +863,6 @@ class PDFPageView {
       });
     }
 
-    if (this.xfaLayer?.div) {
-      // The xfa layer needs to stay on top.
-      div.append(this.xfaLayer.div);
-    }
-
     let renderContinueCallback = null;
     if (this.renderingQueue) {
       renderContinueCallback = cont => {
@@ -967,6 +962,9 @@ class PDFPageView {
           annotationStorage,
           linkService,
         });
+      } else if (this.xfaLayer.div) {
+        // The xfa layer needs to stay on top.
+        div.append(this.xfaLayer.div);
       }
       this.#renderXfaLayer();
     }


### PR DESCRIPTION
Given that we only create an `xfaLayer` in "pure" XFA-documents, this code can be moved into the appropriate branch instead.