### PR TITLE
[a11y] Improve the visibility of link annotations in HCM

### DIFF
--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -20,6 +20,7 @@
   --input-unfocused-border-color: transparent;
   --input-disabled-border-color: transparent;
   --input-hover-border-color: black;
+  --link-outline: none;
 }
 
 @media screen and (forced-colors: active) {
@@ -28,6 +29,7 @@
     --input-unfocused-border-color: ActiveText;
     --input-disabled-border-color: GrayText;
     --input-hover-border-color: Highlight;
+    --link-outline: 1.5px solid LinkText;
   }
   .annotationLayer .textWidgetAnnotation input:required,
   .annotationLayer .textWidgetAnnotation textarea:required,
@@ -35,6 +37,10 @@
   .annotationLayer .buttonWidgetAnnotation.checkBox input:required,
   .annotationLayer .buttonWidgetAnnotation.radioButton input:required {
     outline: 1.5px solid selectedItem;
+  }
+
+  .annotationLayer .linkAnnotation:hover {
+    backdrop-filter: invert(100%);
   }
 }
 
@@ -53,6 +59,10 @@
   pointer-events: auto;
   box-sizing: border-box;
   transform-origin: 0 0;
+}
+
+.annotationLayer .linkAnnotation {
+  outline: var(--link-outline);
 }
 
 .annotationLayer .linkAnnotation > a,


### PR DESCRIPTION
In order to help to identify a link, we add a border around it with the LinkText color. And backdrop colors are inverted when the mouse pointer hovers them, this way it should help to identify the link where the pointer is.
![image](https://user-images.githubusercontent.com/5641725/220602718-36d24126-d8aa-4246-b7df-47d2c9af0040.png)
(`Appendix A...` was hovered)