### PR TITLE
Use `OffscreenCanvas` as intended for all code-paths in `src/display/text_layer.js` (PR 15722 follow-up)

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -311,6 +311,7 @@ class TextLayerRenderTask {
     this._container = this._rootContainer = container;
     this._textDivs = textDivs || [];
     this._textContentItemsStr = textContentItemsStr || [];
+    this._isOffscreenCanvasSupported = isOffscreenCanvasSupported;
     this._fontInspectorEnabled = !!globalThis.FontInspector?.enabled;
 
     this._reader = null;


### PR DESCRIPTION
Currently some `getCtx` calls will have `isOffscreenCanvasSupported === undefined` set, meaning that `OffscreenCanvas` isn't being used as intended, since no `TextLayerRenderTask._isOffscreenCanvasSupported` property exists.

*Please note:* This patch is written using the GitHub UI, since I'm currently without a dev machine, so hopefully it works correctly.

---

Just to clarify, the following call-site is "broken" without this patch:
https://github.com/mozilla/pdf.js/blob/9c58d4f7f204357899db2dd549e3022bf31db771/src/display/text_layer.js#L176-L177