### PR TITLE
Check `OffscreenCanvas` support once on the worker-thread

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -23,7 +23,6 @@ import {
   AnnotationType,
   assert,
   BASELINE_FACTOR,
-  FeatureTest,
   getModificationDate,
   IDENTITY_MATRIX,
   LINE_DESCENT_FACTOR,
@@ -147,7 +146,6 @@ class AnnotationFactory {
         !collectFields && acroFormDict.get("NeedAppearances") === true,
       pageIndex,
       isOffscreenCanvasSupported:
-        FeatureTest.isOffscreenCanvasSupported &&
         pdfManager.evaluatorOptions.isOffscreenCanvasSupported,
     };
 
@@ -306,10 +304,8 @@ class AnnotationFactory {
     }
 
     const xref = evaluator.xref;
+    const { isOffscreenCanvasSupported } = evaluator.options;
     const promises = [];
-    const isOffscreenCanvasSupported =
-      FeatureTest.isOffscreenCanvasSupported &&
-      evaluator.options.isOffscreenCanvasSupported;
     for (const annotation of annotations) {
       switch (annotation.annotationType) {
         case AnnotationEditorType.FREETEXT:

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -80,7 +80,7 @@ const DefaultPartialEvaluatorOptions = Object.freeze({
   disableFontFace: false,
   ignoreErrors: false,
   isEvalSupported: true,
-  isOffscreenCanvasSupported: true,
+  isOffscreenCanvasSupported: false,
   fontExtraProperties: false,
   useSystemFonts: true,
   cMapUrl: null,

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -13,14 +13,7 @@
  * limitations under the License.
  */
 
-import {
-  assert,
-  FeatureTest,
-  FormatError,
-  ImageKind,
-  info,
-  warn,
-} from "../shared/util.js";
+import { assert, FormatError, ImageKind, info, warn } from "../shared/util.js";
 import { applyMaskImageData } from "../shared/image_utils.js";
 import { BaseStream } from "./base_stream.js";
 import { ColorSpace } from "./colorspace.js";
@@ -356,7 +349,7 @@ class PDFImage {
     imageIsFromDecodeStream,
     inverseDecode,
     interpolate,
-    isOffscreenCanvasSupported = true,
+    isOffscreenCanvasSupported = false,
   }) {
     const isSingleOpaquePixel =
       width === 1 &&
@@ -367,7 +360,7 @@ class PDFImage {
       return { isSingleOpaquePixel };
     }
 
-    if (isOffscreenCanvasSupported && FeatureTest.isOffscreenCanvasSupported) {
+    if (isOffscreenCanvasSupported) {
       const canvas = new OffscreenCanvas(width, height);
       const ctx = canvas.getContext("2d");
       const imgData = ctx.createImageData(width, height);

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -15,6 +15,7 @@
 
 import {
   createValidAbsoluteUrl,
+  FeatureTest,
   shadow,
   unreachable,
   warn,
@@ -44,6 +45,12 @@ class BasePdfManager {
     this._docId = args.docId;
     this._password = args.password;
     this.enableXfa = args.enableXfa;
+
+    // Check `OffscreenCanvas` support once, rather than repeatedly throughout
+    // the worker-thread code.
+    args.evaluatorOptions.isOffscreenCanvasSupported =
+      args.evaluatorOptions.isOffscreenCanvasSupported &&
+      FeatureTest.isOffscreenCanvasSupported;
     this.evaluatorOptions = args.evaluatorOptions;
   }
 


### PR DESCRIPTION
Currently we repeat the `FeatureTest.isOffscreenCanvasSupported` checks all over the worker-thread code, and with upcoming changes this will become even "worse".

Hence this patch, which changes the *worker-thread* default value for the `isOffscreenCanvasSupported`-parameter to `false` and moves the feature-testing into the `BasePdfManager`-constructor.

*Please note:* This patch is written using the GitHub UI, since I'm currently without a dev machine, so hopefully it works correctly.