### PR TITLE
[api-minor] Move the `canvasFactory` option into `getDocument`

### DIFF
--- a/examples/node/pdf2png/pdf2png.js
+++ b/examples/node/pdf2png/pdf2png.js
@@ -58,6 +58,8 @@ const CMAP_PACKED = true;
 const STANDARD_FONT_DATA_URL =
   "../../../node_modules/pdfjs-dist/standard_fonts/";
 
+const canvasFactory = new NodeCanvasFactory();
+
 // Loading file from file system into typed array.
 const pdfPath =
   process.argv[2] || "../../../web/compressed.tracemonkey-pldi-09.pdf";
@@ -69,6 +71,7 @@ const loadingTask = pdfjsLib.getDocument({
   cMapUrl: CMAP_URL,
   cMapPacked: CMAP_PACKED,
   standardFontDataUrl: STANDARD_FONT_DATA_URL,
+  canvasFactory,
 });
 
 (async function () {
@@ -79,7 +82,6 @@ const loadingTask = pdfjsLib.getDocument({
     const page = await pdfDocument.getPage(1);
     // Render the page on a Node canvas with 100% scale.
     const viewport = page.getViewport({ scale: 1.0 });
-    const canvasFactory = new NodeCanvasFactory();
     const canvasAndContext = canvasFactory.create(
       viewport.width,
       viewport.height
@@ -87,7 +89,6 @@ const loadingTask = pdfjsLib.getDocument({
     const renderContext = {
       canvasContext: canvasAndContext.context,
       viewport,
-      canvasFactory,
     };
 
     const renderTask = page.render(renderContext);

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -2880,7 +2880,6 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
       );
       const renderTask = pdfPage.render({
         canvasContext: canvasAndCtx.context,
-        canvasFactory: CanvasFactory,
         viewport,
       });
       expect(renderTask instanceof RenderTask).toEqual(true);
@@ -2916,7 +2915,6 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
       );
       const renderTask = page.render({
         canvasContext: canvasAndCtx.context,
-        canvasFactory: CanvasFactory,
         viewport,
       });
       expect(renderTask instanceof RenderTask).toEqual(true);
@@ -2948,7 +2946,6 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
       );
       const renderTask = page.render({
         canvasContext: canvasAndCtx.context,
-        canvasFactory: CanvasFactory,
         viewport,
       });
       expect(renderTask instanceof RenderTask).toEqual(true);
@@ -2966,7 +2963,6 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
 
       const reRenderTask = page.render({
         canvasContext: canvasAndCtx.context,
-        canvasFactory: CanvasFactory,
         viewport,
       });
       expect(reRenderTask instanceof RenderTask).toEqual(true);
@@ -2990,7 +2986,6 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
       );
       const renderTask1 = page.render({
         canvasContext: canvasAndCtx.context,
-        canvasFactory: CanvasFactory,
         viewport,
         optionalContentConfigPromise,
       });
@@ -2998,7 +2993,6 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
 
       const renderTask2 = page.render({
         canvasContext: canvasAndCtx.context,
-        canvasFactory: CanvasFactory,
         viewport,
         optionalContentConfigPromise,
       });
@@ -3033,7 +3027,6 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
       );
       const renderTask = pdfPage.render({
         canvasContext: canvasAndCtx.context,
-        canvasFactory: CanvasFactory,
         viewport,
       });
       expect(renderTask instanceof RenderTask).toEqual(true);
@@ -3064,7 +3057,6 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
       );
       const renderTask = pdfPage.render({
         canvasContext: canvasAndCtx.context,
-        canvasFactory: CanvasFactory,
         viewport,
       });
       expect(renderTask instanceof RenderTask).toEqual(true);
@@ -3166,7 +3158,6 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
         );
         const renderTask = pdfPage.render({
           canvasContext: canvasAndCtx.context,
-          canvasFactory: CanvasFactory,
           viewport,
           intent: "print",
           annotationMode: AnnotationMode.ENABLE_STORAGE,
@@ -3256,7 +3247,6 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
       );
       const renderTask = page.render({
         canvasContext: canvasAndCtx.context,
-        canvasFactory: CanvasFactory,
         viewport,
       });
       await renderTask.promise;


### PR DESCRIPTION
Rather than repeatedly initializing a `canvasFactory`-instance for every page, move it to the document-level instead.

*Please note:* This patch is written using the GitHub UI, since I'm currently without a dev machine, so hopefully it works correctly.