### PR TITLE
Slightly delay cleanup, after rendering, in documents with large images

### DIFF
--- a/src/core/image_utils.js
+++ b/src/core/image_utils.js
@@ -13,7 +13,13 @@
  * limitations under the License.
  */
 
-import { assert, shadow, unreachable, warn } from "../shared/util.js";
+import {
+  assert,
+  MAX_IMAGE_SIZE_TO_CACHE,
+  shadow,
+  unreachable,
+  warn,
+} from "../shared/util.js";
 import { RefSetCache } from "./primitives.js";
 
 class BaseLocalCache {
@@ -160,7 +166,7 @@ class GlobalImageCache {
   }
 
   static get MAX_BYTE_SIZE() {
-    return shadow(this, "MAX_BYTE_SIZE", /* Forty megabytes = */ 40e6);
+    return shadow(this, "MAX_BYTE_SIZE", 5 * MAX_IMAGE_SIZE_TO_CACHE);
   }
 
   constructor() {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -66,6 +66,7 @@ import { XfaText } from "./xfa_text.js";
 
 const DEFAULT_RANGE_CHUNK_SIZE = 65536; // 2^16 = 65536
 const RENDERING_CANCELLED_TIMEOUT = 100; // ms
+const DELAYED_CLEANUP_TIMEOUT = 5000; // ms
 
 let DefaultCanvasFactory = DOMCanvasFactory;
 let DefaultCMapReaderFactory = DOMCMapReaderFactory;
@@ -1262,6 +1263,8 @@ class PDFDocumentProxy {
  * Proxy to a `PDFPage` in the worker thread.
  */
 class PDFPageProxy {
+  #delayedCleanupTimeout = null;
+
   #pendingCleanup = false;
 
   constructor(pageIndex, pageInfo, transport, pdfBug = false) {
@@ -1274,7 +1277,7 @@ class PDFPageProxy {
     this.commonObjs = transport.commonObjs;
     this.objs = new PDFObjects();
 
-    this.cleanupAfterRender = false;
+    this._maybeCleanupAfterRender = false;
     this._intentStates = new Map();
     this.destroyed = false;
   }
@@ -1414,8 +1417,10 @@ class PDFPageProxy {
       printAnnotationStorage
     );
     // If there was a pending destroy, cancel it so no cleanup happens during
-    // this call to render.
+    // this call to render...
     this.#pendingCleanup = false;
+    // ... and ensure that a delayed cleanup is always aborted.
+    this.#abortDelayedCleanup();
 
     if (!optionalContentConfigPromise) {
       optionalContentConfigPromise = this._transport.getOptionalContentConfig();
@@ -1456,11 +1461,11 @@ class PDFPageProxy {
       intentState.renderTasks.delete(internalRenderTask);
 
       // Attempt to reduce memory usage during *printing*, by always running
-      // cleanup once rendering has finished (regardless of cleanupAfterRender).
-      if (this.cleanupAfterRender || intentPrint) {
+      // cleanup immediately once rendering has finished.
+      if (this._maybeCleanupAfterRender || intentPrint) {
         this.#pendingCleanup = true;
       }
-      this.#tryCleanup();
+      this.#tryCleanup(/* delayed = */ !intentPrint);
 
       if (error) {
         internalRenderTask.capability.reject(error);
@@ -1683,6 +1688,8 @@ class PDFPageProxy {
     }
     this.objs.clear();
     this.#pendingCleanup = false;
+    this.#abortDelayedCleanup();
+
     return Promise.all(waitOn);
   }
 
@@ -1695,14 +1702,33 @@ class PDFPageProxy {
    */
   cleanup(resetStats = false) {
     this.#pendingCleanup = true;
-    return this.#tryCleanup(resetStats);
+    const success = this.#tryCleanup(/* delayed = */ false);
+
+    if (resetStats && success) {
+      this._stats &&= new StatTimer();
+    }
+    return success;
   }
 
   /**
    * Attempts to clean up if rendering is in a state where that's possible.
+   * @param {boolean} [delayed] - Delay the cleanup, to e.g. improve zooming
+   *   performance in documents with large images.
+   *   The default value is `false`.
+   * @returns {boolean} Indicates if clean-up was successfully run.
    */
-  #tryCleanup(resetStats = false) {
+  #tryCleanup(delayed = false) {
+    this.#abortDelayedCleanup();
+
     if (!this.#pendingCleanup) {
+      return false;
+    }
+    if (delayed) {
+      this.#delayedCleanupTimeout = setTimeout(() => {
+        this.#delayedCleanupTimeout = null;
+        this.#tryCleanup(/* delayed = */ false);
+      }, DELAYED_CLEANUP_TIMEOUT);
+
       return false;
     }
     for (const { renderTasks, operatorList } of this._intentStates.values()) {
@@ -1710,14 +1736,17 @@ class PDFPageProxy {
         return false;
       }
     }
-
     this._intentStates.clear();
     this.objs.clear();
-    if (resetStats && this._stats) {
-      this._stats = new StatTimer();
-    }
     this.#pendingCleanup = false;
     return true;
+  }
+
+  #abortDelayedCleanup() {
+    if (this.#delayedCleanupTimeout) {
+      clearTimeout(this.#delayedCleanupTimeout);
+      this.#delayedCleanupTimeout = null;
+    }
   }
 
   /**
@@ -1756,7 +1785,7 @@ class PDFPageProxy {
     }
 
     if (operatorListChunk.lastChunk) {
-      this.#tryCleanup();
+      this.#tryCleanup(/* delayed = */ true);
     }
   }
 
@@ -1814,7 +1843,7 @@ class PDFPageProxy {
             for (const internalRenderTask of intentState.renderTasks) {
               internalRenderTask.operatorListChanged();
             }
-            this.#tryCleanup();
+            this.#tryCleanup(/* delayed = */ true);
           }
 
           if (intentState.displayReadyCapability) {
@@ -2793,7 +2822,7 @@ class WorkerTransport {
             }
 
             if (length > MAX_IMAGE_SIZE_TO_STORE) {
-              pageProxy.cleanupAfterRender = true;
+              pageProxy._maybeCleanupAfterRender = true;
             }
           }
           break;

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -26,6 +26,7 @@ import {
   info,
   InvalidPDFException,
   isArrayBuffer,
+  MAX_IMAGE_SIZE_TO_CACHE,
   MissingPDFException,
   PasswordException,
   RenderingIntentFlag,
@@ -2811,7 +2812,6 @@ class WorkerTransport {
           pageProxy.objs.resolve(id, imageData);
 
           // Heuristic that will allow us not to store large data.
-          const MAX_IMAGE_SIZE_TO_STORE = 8000000;
           if (imageData) {
             let length;
             if (imageData.bitmap) {
@@ -2821,7 +2821,7 @@ class WorkerTransport {
               length = imageData.data?.length || 0;
             }
 
-            if (length > MAX_IMAGE_SIZE_TO_STORE) {
+            if (length > MAX_IMAGE_SIZE_TO_CACHE) {
               pageProxy._maybeCleanupAfterRender = true;
             }
           }

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -26,6 +26,8 @@ if (
 const IDENTITY_MATRIX = [1, 0, 0, 1, 0, 0];
 const FONT_IDENTITY_MATRIX = [0.001, 0, 0, 0.001, 0, 0];
 
+const MAX_IMAGE_SIZE_TO_CACHE = 10e6; // Ten megabytes.
+
 // Represent the percentage of the height of a single-line field over
 // the font size. Acrobat seems to use this value.
 const LINE_FACTOR = 1.35;
@@ -1060,6 +1062,7 @@ export {
   isArrayEqual,
   LINE_DESCENT_FACTOR,
   LINE_FACTOR,
+  MAX_IMAGE_SIZE_TO_CACHE,
   MissingPDFException,
   objectFromMap,
   objectSize,


### PR DESCRIPTION
 - Convert a couple of fields/methods into properly private ones in `PDFPageProxy`

   These were always intended to be *private*, so let's use modern JS features to actually enforce that.

 - Slightly delay cleanup, after rendering, in documents with large images

   Currently in PDF documents with large images we immediately cleanup once rendering has finished, in order to reduce memory-usage.
   Normally that shouldn't be a big problem, however when e.g. repeated zooming happens in the viewer that could easily lead to a lot of wasted resources (and waiting).

   Hence this patch, which introduces a new `PDFPageProxy` method that will slightly delay cleanup after rendering.

 - Slightly increase the maximum image sizes that we'll cache

   The current value originated in PR #2317, and in the decade that have passed the amount of RAM available in (most) devices should have increased a fair bit.
   Nowadays we also do a much better job of detecting repeated images at both the page- and document-level, which helps reduce overall memory-usage in many documents.

   Finally the constant is also moved into the `src/shared/util.js` file, since it was implicitly used on both the main- and worker-thread previously.