### PR TITLE
Avoid to have a factor too close to 2 when downscaling image

### DIFF
--- a/src/core/image_resizer.js
+++ b/src/core/image_resizer.js
@@ -184,8 +184,13 @@ class ImageResizer {
     for (const step of steps) {
       const prevWidth = newWidth;
       const prevHeight = newHeight;
-      newWidth = Math.floor(newWidth / step);
-      newHeight = Math.floor(newHeight / step);
+
+      // See bug 1820511 (Windows specific bug).
+      // TODO: once the above bug is fixed we could revert to:
+      // newWidth = Math.floor(newWidth / 2);
+      newWidth = Math.floor(newWidth / step) - 1;
+      newHeight = Math.floor(newHeight / step) - 1;
+
       const canvas = new OffscreenCanvas(newWidth, newHeight);
       const ctx = canvas.getContext("2d");
       ctx.drawImage(

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1313,11 +1313,21 @@ class CanvasGraphics {
       let newWidth = paintWidth,
         newHeight = paintHeight;
       if (widthScale > 2 && paintWidth > 1) {
-        newWidth = Math.ceil(paintWidth / 2);
+        // See bug 1820511 (Windows specific bug).
+        // TODO: once the above bug is fixed we could revert to:
+        // newWidth = Math.ceil(paintWidth / 2);
+        newWidth =
+          paintWidth >= 16384
+            ? Math.floor(paintWidth / 2) - 1 || 1
+            : Math.ceil(paintWidth / 2);
         widthScale /= paintWidth / newWidth;
       }
       if (heightScale > 2 && paintHeight > 1) {
-        newHeight = Math.ceil(paintHeight / 2);
+        // TODO: see the comment above.
+        newHeight =
+          paintHeight >= 16384
+            ? Math.floor(paintHeight / 2) - 1 || 1
+            : Math.ceil(paintHeight) / 2;
         heightScale /= paintHeight / newHeight;
       }
       tmpCanvas = this.cachedCanvases.getCanvas(


### PR DESCRIPTION
It's a workaround for bug 1820511: it only affects Firefox on Windows using the D2D backend.