### PR TITLE
[api-minor] Remove the deprecated `onUnsupportedFeature` functionality (PR 15758 follow-up)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -27,7 +27,6 @@ import {
   stringToPDFString,
   stringToUTF8String,
   unreachable,
-  UNSUPPORTED_FEATURES,
   Util,
   warn,
 } from "../shared/util.js";
@@ -220,15 +219,8 @@ class Page {
   /**
    * @private
    */
-  _onSubStreamError(handler, reason, objId) {
+  _onSubStreamError(reason, objId) {
     if (this.evaluatorOptions.ignoreErrors) {
-      if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-        // Error(s) when reading one of the /Contents sub-streams -- sending
-        // unsupported feature notification and allow parsing to continue.
-        handler.send("UnsupportedFeature", {
-          featureId: UNSUPPORTED_FEATURES.errorContentSubStream,
-        });
-      }
       warn(`getContentStream - ignoring sub-stream (${objId}): "${reason}".`);
       return;
     }
@@ -238,7 +230,7 @@ class Page {
   /**
    * @returns {Promise<BaseStream>}
    */
-  getContentStream(handler) {
+  getContentStream() {
     return this.pdfManager.ensure(this, "content").then(content => {
       if (content instanceof BaseStream) {
         return content;
@@ -246,7 +238,7 @@ class Page {
       if (Array.isArray(content)) {
         return new StreamsSequenceStream(
           content,
-          this._onSubStreamError.bind(this, handler)
+          this._onSubStreamError.bind(this)
         );
       }
       // Replace non-existent page content with empty content.
@@ -378,7 +370,7 @@ class Page {
     cacheKey,
     annotationStorage = null,
   }) {
-    const contentStreamPromise = this.getContentStream(handler);
+    const contentStreamPromise = this.getContentStream();
     const resourcesPromise = this.loadResources([
       "ColorSpace",
       "ExtGState",
@@ -528,7 +520,7 @@ class Page {
     sink,
     combineTextItems,
   }) {
-    const contentStreamPromise = this.getContentStream(handler);
+    const contentStreamPromise = this.getContentStream();
     const resourcesPromise = this.loadResources([
       "ExtGState",
       "Font",

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -28,7 +28,6 @@ import {
   shadow,
   stringToPDFString,
   TextRenderingMode,
-  UNSUPPORTED_FEATURES,
   Util,
   warn,
 } from "../shared/util.js";
@@ -945,13 +944,6 @@ class PartialEvaluator {
           return;
         }
         if (this.options.ignoreErrors) {
-          if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-            // Error(s) in the TilingPattern -- sending unsupported feature
-            // notification and allow rendering to continue.
-            this.handler.send("UnsupportedFeature", {
-              featureId: UNSUPPORTED_FEATURES.errorTilingPattern,
-            });
-          }
           warn(`handleTilingType - ignoring pattern: "${reason}".`);
           return;
         }
@@ -993,13 +985,6 @@ class PartialEvaluator {
             return translated;
           })
           .catch(reason => {
-            if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-              // Error in the font data -- sending unsupported feature
-              // notification.
-              this.handler.send("UnsupportedFeature", {
-                featureId: UNSUPPORTED_FEATURES.errorFontLoadType3,
-              });
-            }
             return new TranslatedFont({
               loadedName: "g_font_error",
               font: new ErrorFont(`Type3 font load error: ${reason}`),
@@ -1049,13 +1034,6 @@ class PartialEvaluator {
     );
 
     if (this.options.ignoreErrors) {
-      if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-        // Missing setFont operator before text rendering operator -- sending
-        // unsupported feature notification and allow rendering to continue.
-        this.handler.send("UnsupportedFeature", {
-          featureId: UNSUPPORTED_FEATURES.errorFontState,
-        });
-      }
       warn(`ensureStateFont: "${reason}".`);
       return;
     }
@@ -1213,12 +1191,6 @@ class PartialEvaluator {
         warn(`${partialMsg}.`);
         return errorFont();
       }
-      if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-        // Font not found -- sending unsupported feature notification.
-        this.handler.send("UnsupportedFeature", {
-          featureId: UNSUPPORTED_FEATURES.errorFontMissing,
-        });
-      }
       warn(`${partialMsg} -- attempting to fallback to a default font.`);
 
       // Falling back to a default font to avoid completely broken rendering,
@@ -1337,12 +1309,6 @@ class PartialEvaluator {
       })
       .catch(reason => {
         // TODO fontCapability.reject?
-        if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-          // Error in the font data -- sending unsupported feature notification.
-          this.handler.send("UnsupportedFeature", {
-            featureId: UNSUPPORTED_FEATURES.errorFontTranslate,
-          });
-        }
         warn(`loadFont - translateFont failed: "${reason}".`);
 
         fontCapability.resolve(
@@ -1448,13 +1414,6 @@ class PartialEvaluator {
         return null;
       }
       if (this.options.ignoreErrors) {
-        if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-          // Error(s) in the ColorSpace -- sending unsupported feature
-          // notification and allow rendering to continue.
-          this.handler.send("UnsupportedFeature", {
-            featureId: UNSUPPORTED_FEATURES.errorColorSpace,
-          });
-        }
         warn(`parseColorSpace - ignoring ColorSpace: "${reason}".`);
         return null;
       }
@@ -1476,7 +1435,6 @@ class PartialEvaluator {
         shading,
         this.xref,
         resources,
-        this.handler,
         this._pdfFunctionFactory,
         localColorSpaceCache
       );
@@ -1839,16 +1797,6 @@ class PartialEvaluator {
                   return;
                 }
                 if (self.options.ignoreErrors) {
-                  if (
-                    typeof PDFJSDev === "undefined" ||
-                    PDFJSDev.test("GENERIC")
-                  ) {
-                    // Error(s) in the XObject -- sending unsupported feature
-                    // notification and allow rendering to continue.
-                    self.handler.send("UnsupportedFeature", {
-                      featureId: UNSUPPORTED_FEATURES.errorXObject,
-                    });
-                  }
                   warn(`getOperatorList - ignoring XObject: "${reason}".`);
                   return;
                 }
@@ -2163,16 +2111,6 @@ class PartialEvaluator {
                   return;
                 }
                 if (self.options.ignoreErrors) {
-                  if (
-                    typeof PDFJSDev === "undefined" ||
-                    PDFJSDev.test("GENERIC")
-                  ) {
-                    // Error(s) in the ExtGState -- sending unsupported feature
-                    // notification and allow parsing/rendering to continue.
-                    self.handler.send("UnsupportedFeature", {
-                      featureId: UNSUPPORTED_FEATURES.errorExtGState,
-                    });
-                  }
                   warn(`getOperatorList - ignoring ExtGState: "${reason}".`);
                   return;
                 }
@@ -2220,14 +2158,6 @@ class PartialEvaluator {
                       return;
                     }
                     if (self.options.ignoreErrors) {
-                      if (
-                        typeof PDFJSDev === "undefined" ||
-                        PDFJSDev.test("GENERIC")
-                      ) {
-                        self.handler.send("UnsupportedFeature", {
-                          featureId: UNSUPPORTED_FEATURES.errorMarkedContent,
-                        });
-                      }
                       warn(
                         `getOperatorList - ignoring beginMarkedContentProps: "${reason}".`
                       );
@@ -2278,13 +2208,6 @@ class PartialEvaluator {
         return;
       }
       if (this.options.ignoreErrors) {
-        if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-          // Error(s) in the OperatorList -- sending unsupported feature
-          // notification and allow rendering to continue.
-          this.handler.send("UnsupportedFeature", {
-            featureId: UNSUPPORTED_FEATURES.errorOperatorList,
-          });
-        }
         warn(
           `getOperatorList - ignoring errors during "${task.name}" ` +
             `task: "${reason}".`
@@ -3779,13 +3702,6 @@ class PartialEvaluator {
             return null;
           }
           if (this.options.ignoreErrors) {
-            if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-              // Error in the ToUnicode data -- sending unsupported feature
-              // notification and allow font parsing to continue.
-              this.handler.send("UnsupportedFeature", {
-                featureId: UNSUPPORTED_FEATURES.errorFontToUnicode,
-              });
-            }
             warn(`readToUnicode - ignoring ToUnicode data: "${reason}".`);
             return null;
           }
@@ -4359,13 +4275,6 @@ class PartialEvaluator {
         ]);
       } catch (reason) {
         if (evaluatorOptions.ignoreErrors) {
-          if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-            // Error in the font data -- sending unsupported feature
-            // notification and allow glyph path building to continue.
-            handler.send("UnsupportedFeature", {
-              featureId: UNSUPPORTED_FEATURES.errorFontBuildPath,
-            });
-          }
           warn(`buildFontPaths - ignoring ${glyphName} glyph: "${reason}".`);
           return;
         }

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -19,7 +19,6 @@ import {
   info,
   shadow,
   unreachable,
-  UNSUPPORTED_FEATURES,
   Util,
   warn,
 } from "../shared/util.js";
@@ -46,7 +45,6 @@ class Pattern {
     shading,
     xref,
     res,
-    handler,
     pdfFunctionFactory,
     localColorSpaceCache
   ) {
@@ -81,11 +79,6 @@ class Pattern {
     } catch (ex) {
       if (ex instanceof MissingDataException) {
         throw ex;
-      }
-      if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-        handler.send("UnsupportedFeature", {
-          featureId: UNSUPPORTED_FEATURES.shadingPattern,
-        });
       }
       warn(ex);
       return new DummyShading();

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -575,8 +575,6 @@ function getDataProp(val) {
 class PDFDocumentLoadingTask {
   static #docId = 0;
 
-  #onUnsupportedFeature = null;
-
   constructor() {
     this._capability = createPromiseCapability();
     this._transport = null;
@@ -609,28 +607,6 @@ class PDFDocumentLoadingTask {
      * @type {function}
      */
     this.onProgress = null;
-  }
-
-  /**
-   * @type {function | null} The current callback used with unsupported
-   * features.
-   */
-  get onUnsupportedFeature() {
-    return this.#onUnsupportedFeature;
-  }
-
-  /**
-   * Callback for when an unsupported feature is used in the PDF document.
-   * The callback receives an {@link UNSUPPORTED_FEATURES} argument.
-   * @type {function}
-   */
-  set onUnsupportedFeature(callback) {
-    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-      deprecated(
-        "The PDFDocumentLoadingTask onUnsupportedFeature property will be removed in the future."
-      );
-      this.#onUnsupportedFeature = callback;
-    }
   }
 
   /**
@@ -2354,7 +2330,6 @@ class WorkerTransport {
     this.loadingTask = loadingTask;
     this.commonObjs = new PDFObjects();
     this.fontLoader = new FontLoader({
-      onUnsupportedFeature: this._onUnsupportedFeature.bind(this),
       ownerDocument: params.ownerDocument,
       styleElement: params.styleElement,
     });
@@ -2754,7 +2729,6 @@ class WorkerTransport {
             isEvalSupported: params.isEvalSupported,
             disableFontFace: params.disableFontFace,
             ignoreErrors: params.ignoreErrors,
-            onUnsupportedFeature: this._onUnsupportedFeature.bind(this),
             fontRegistry,
           });
 
@@ -2833,13 +2807,6 @@ class WorkerTransport {
       });
     });
 
-    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-      messageHandler.on(
-        "UnsupportedFeature",
-        this._onUnsupportedFeature.bind(this)
-      );
-    }
-
     messageHandler.on("FetchBuiltInCMap", data => {
       if (this.destroyed) {
         return Promise.reject(new Error("Worker was destroyed."));
@@ -2867,15 +2834,6 @@ class WorkerTransport {
       }
       return this.standardFontDataFactory.fetch(data);
     });
-  }
-
-  _onUnsupportedFeature({ featureId }) {
-    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-      if (this.destroyed) {
-        return; // Ignore any pending requests if the worker was terminated.
-      }
-      this.loadingTask.onUnsupportedFeature?.(featureId);
-    }
   }
 
   getData() {

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -19,20 +19,15 @@ import {
   FeatureTest,
   shadow,
   string32,
-  UNSUPPORTED_FEATURES,
   warn,
 } from "../shared/util.js";
 import { isNodeJS } from "../shared/is_node.js";
 
 class FontLoader {
   constructor({
-    onUnsupportedFeature,
     ownerDocument = globalThis.document,
     styleElement = null, // For testing only.
   }) {
-    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-      this._onUnsupportedFeature = onUnsupportedFeature;
-    }
     this._document = ownerDocument;
 
     this.nativeFontFaces = [];
@@ -90,11 +85,6 @@ class FontLoader {
         try {
           await nativeFontFace.loaded;
         } catch (ex) {
-          if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-            this._onUnsupportedFeature({
-              featureId: UNSUPPORTED_FEATURES.errorFontLoadNative,
-            });
-          }
           warn(`Failed to load font '${nativeFontFace.family}': '${ex}'.`);
 
           // When font loading failed, fall back to the built-in font renderer.
@@ -332,7 +322,6 @@ class FontFaceObject {
       isEvalSupported = true,
       disableFontFace = false,
       ignoreErrors = false,
-      onUnsupportedFeature,
       fontRegistry = null,
     }
   ) {
@@ -344,9 +333,6 @@ class FontFaceObject {
     this.isEvalSupported = isEvalSupported !== false;
     this.disableFontFace = disableFontFace === true;
     this.ignoreErrors = ignoreErrors === true;
-    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-      this._onUnsupportedFeature = onUnsupportedFeature;
-    }
     this.fontRegistry = fontRegistry;
   }
 
@@ -408,11 +394,6 @@ class FontFaceObject {
     } catch (ex) {
       if (!this.ignoreErrors) {
         throw ex;
-      }
-      if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-        this._onUnsupportedFeature({
-          featureId: UNSUPPORTED_FEATURES.errorFontGetPath,
-        });
       }
       warn(`getPathGenerator - ignoring character: "${ex}".`);
 

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -40,7 +40,6 @@ import {
   PermissionFlag,
   shadow,
   UnexpectedResponseException,
-  UNSUPPORTED_FEATURES,
   Util,
   VerbosityLevel,
 } from "./shared/util.js";
@@ -116,7 +115,6 @@ export {
   shadow,
   SVGGraphics,
   UnexpectedResponseException,
-  UNSUPPORTED_FEATURES,
   updateTextLayer,
   Util,
   VerbosityLevel,

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -346,32 +346,6 @@ const OPS = {
   constructPath: 91,
 };
 
-const UNSUPPORTED_FEATURES =
-  typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")
-    ? {
-        forms: "forms",
-        javaScript: "javaScript",
-        signatures: "signatures",
-        smask: "smask",
-        shadingPattern: "shadingPattern",
-        errorTilingPattern: "errorTilingPattern",
-        errorExtGState: "errorExtGState",
-        errorXObject: "errorXObject",
-        errorFontLoadType3: "errorFontLoadType3",
-        errorFontState: "errorFontState",
-        errorFontMissing: "errorFontMissing",
-        errorFontTranslate: "errorFontTranslate",
-        errorColorSpace: "errorColorSpace",
-        errorOperatorList: "errorOperatorList",
-        errorFontToUnicode: "errorFontToUnicode",
-        errorFontLoadNative: "errorFontLoadNative",
-        errorFontBuildPath: "errorFontBuildPath",
-        errorFontGetPath: "errorFontGetPath",
-        errorMarkedContent: "errorMarkedContent",
-        errorContentSubStream: "errorContentSubStream",
-      }
-    : null;
-
 const PasswordResponses = {
   NEED_PASSWORD: 1,
   INCORRECT_PASSWORD: 2,
@@ -1105,7 +1079,6 @@ export {
   UnexpectedResponseException,
   UnknownErrorException,
   unreachable,
-  UNSUPPORTED_FEATURES,
   utf8StringToString,
   Util,
   VerbosityLevel,


### PR DESCRIPTION
This was deprecated in PR #15758, which has now been included in three official PDF.js releases.
While PR #15880 did limit the bundle-size impact of this functionality on e.g. the Firefox PDF Viewer, it still leads to some unnecessary "bloat" that these changes remove.
Furthermore, with this being deprecated there'd also be no effort put into e.g. extending the `UNSUPPORTED_FEATURES` list when handling future error cases.