### PR TITLE
[api-minor] Update the minimum supported Node.js version to 16

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,7 +82,7 @@ const ENV_TARGETS = [
   "Chrome >= 87",
   "Firefox ESR",
   "Safari >= 14.1",
-  "Node >= 14",
+  "Node >= 16",
   "> 1%",
   "not IE > 0",
   "not dead",
@@ -2219,6 +2219,9 @@ function packageJson() {
     repository: {
       type: "git",
       url: DIST_REPO_URL,
+    },
+    engines: {
+      node: ">=16",
     },
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,9 @@
         "webpack-stream": "^7.0.0",
         "wintersmith": "^2.5.0",
         "yargs": "^17.6.2"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -70,5 +70,8 @@
     "type": "git",
     "url": "git://github.com/mozilla/pdf.js.git"
   },
+  "engines": {
+    "node": ">=16"
+  },
   "license": "Apache-2.0"
 }

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -16,28 +16,6 @@
 
 import { isNodeJS } from "./is_node.js";
 
-// Support: Node.js<16.0.0
-(function checkNodeBtoa() {
-  if (globalThis.btoa || !isNodeJS) {
-    return;
-  }
-  globalThis.btoa = function (chars) {
-    // eslint-disable-next-line no-undef
-    return Buffer.from(chars, "binary").toString("base64");
-  };
-})();
-
-// Support: Node.js<16.0.0
-(function checkNodeAtob() {
-  if (globalThis.atob || !isNodeJS) {
-    return;
-  }
-  globalThis.atob = function (input) {
-    // eslint-disable-next-line no-undef
-    return Buffer.from(input, "base64").toString("binary");
-  };
-})();
-
 // Support: Node.js
 (function checkDOMMatrix() {
   if (globalThis.DOMMatrix || !isNodeJS) {


### PR DESCRIPTION
This patch updates the minimum supported environments as follows:
 - Node.js 16, which was released on 2021-04-20; see https://en.wikipedia.org/wiki/Node.js#Releases

Note also that Node.js 14 will very soon reach EOL, and thus no longer receive any security updates.