### PR TITLE
Support (rare) Type3 fonts with Pattern resources (issue 16127)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1482,8 +1482,16 @@ class PartialEvaluator {
       );
       const patternIR = shadingFill.getIR();
       id = `pattern_${this.idFactory.createObjId()}`;
+      if (this.parsingType3Font) {
+        id = `${this.idFactory.getDocId()}_type3_${id}`;
+      }
       localShadingPatternCache.set(shading, id);
-      this.handler.send("obj", [id, this.pageIndex, "Pattern", patternIR]);
+
+      if (this.parsingType3Font) {
+        this.handler.send("commonobj", [id, "Pattern", patternIR]);
+      } else {
+        this.handler.send("obj", [id, this.pageIndex, "Pattern", patternIR]);
+      }
     }
     return id;
   }

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2777,6 +2777,7 @@ class WorkerTransport {
           break;
         case "FontPath":
         case "Image":
+        case "Pattern":
           this.commonObjs.resolve(id, exportedData);
           break;
         default:

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -2517,7 +2517,7 @@ class CanvasGraphics {
     if (this.cachedPatterns.has(objId)) {
       pattern = this.cachedPatterns.get(objId);
     } else {
-      pattern = getShadingPattern(this.objs.get(objId));
+      pattern = getShadingPattern(this.getObject(objId));
       this.cachedPatterns.set(objId, pattern);
     }
     if (matrix) {

--- a/test/pdfs/issue16127.pdf.link
+++ b/test/pdfs/issue16127.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/10913919/Noto.Color.Emoji.-.Google.Fonts.-.Chrome.112.-.Full.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2378,6 +2378,16 @@
        "type": "eq",
        "about": "Type3 fonts with image resources; both pages need to be tested, otherwise the bug won't manifest."
     },
+    {  "id": "issue16127",
+       "file": "pdfs/issue16127.pdf",
+       "md5": "42714567a818876f51ef960df21600f5",
+       "link": true,
+       "rounds": 1,
+       "firstPage": 1,
+       "lastPage": 2,
+       "type": "eq",
+       "about": "Type3 fonts with pattern resources; both pages need to be tested, otherwise the bug won't manifest."
+    },
     {  "id": "doc_actions",
        "file": "pdfs/doc_actions.pdf",
        "md5": "ceae4eb405a0b40394f4d63d7525a870",


### PR DESCRIPTION
This simply extends the approach in PR #10727 to also cover Patterns, which shouldn't be a common occurrence in Type3 fonts (since this is the first issue we've seen).