### PR TITLE
Include the document-id in the SVG-filter names (PR 16062 follow-up)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -269,6 +269,7 @@ function getDocument(src) {
     );
   }
   const task = new PDFDocumentLoadingTask();
+  const { docId } = task;
 
   const url = src.url ? getUrlProp(src.url) : null;
   const data = src.data ? getDataProp(src.data) : null;
@@ -339,7 +340,7 @@ function getDocument(src) {
   const canvasFactory =
     src.canvasFactory || new DefaultCanvasFactory({ ownerDocument });
   const filterFactory =
-    src.filterFactory || new FilterFactory({ ownerDocument });
+    src.filterFactory || new FilterFactory({ docId, ownerDocument });
 
   // Parameters only intended for development/testing purposes.
   const styleElement =
@@ -378,7 +379,6 @@ function getDocument(src) {
       : new PDFWorker(workerParams);
     task._worker = worker;
   }
-  const docId = task.docId;
 
   const fetchDocParams = {
     docId,

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -53,11 +53,14 @@ class FilterFactory {
 
   #_defs;
 
+  #docId;
+
   #document;
 
   #id = 0;
 
-  constructor({ ownerDocument = globalThis.document } = {}) {
+  constructor({ docId, ownerDocument = globalThis.document } = {}) {
+    this.#docId = docId;
     this.#document = ownerDocument;
   }
 
@@ -124,7 +127,7 @@ class FilterFactory {
     // We create a SVG filter: feComponentTransferElement
     //  https://www.w3.org/TR/SVG11/filters.html#feComponentTransferElement
 
-    const id = `transfer_map_${this.#id++}`;
+    const id = `g_${this.#docId}_transfer_map_${this.#id++}`;
     const url = `url(#${id})`;
     this.#cache.set(maps, url);
     this.#cache.set(key, url);


### PR DESCRIPTION
In the general PDF.js library multiple PDF documents may be opened on the same web-page, which is why we many years ago started using document-specific identifiers to prevent issues with global data such e.g. with fonts.
Hence we need to treat the identifiers generated by the `FilterFactory` in the same way, since the SVG-filters for two separate PDF documents may otherwise get identical ids.