### PR TITLE
Move the svg definitions in its own div

### DIFF
--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -67,14 +67,22 @@ class FilterFactory {
 
   get #defs() {
     if (!this.#_defs) {
+      const div = this.#document.createElement("div");
+      const { style } = div;
+      style.visibility = "hidden";
+      style.contain = "strict";
+      style.width = style.height = 0;
+      style.position = "absolute";
+      style.top = style.left = 0;
+      style.zIndex = -1;
+
       const svg = this.#document.createElementNS(SVG_NS, "svg");
       svg.setAttribute("width", 0);
       svg.setAttribute("height", 0);
-      svg.style.visibility = "hidden";
-      svg.style.contain = "strict";
       this.#_defs = this.#document.createElementNS(SVG_NS, "defs");
+      div.append(svg);
       svg.append(this.#_defs);
-      this.#document.body.append(svg);
+      this.#document.body.append(div);
     }
     return this.#_defs;
   }
@@ -161,7 +169,7 @@ class FilterFactory {
 
   destroy() {
     if (this.#_defs) {
-      this.#_defs.parentNode.remove();
+      this.#_defs.parentNode.parentNode.remove();
       this.#_defs = null;
     }
     if (this.#_cache) {


### PR DESCRIPTION
This way the svg element doesn't take up space in the viewer. Fixes issue #16135.