### PR TITLE
Add overloads to getTextContent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "terser": "^5.16.6",
         "through2": "^4.0.2",
         "ttest": "^4.0.0",
-        "typescript": "^4.9.5",
+        "typescript": "^5.0.1-rc",
         "typogr": "^0.6.8",
         "vinyl": "^3.0.0",
         "vinyl-fs": "^3.0.3",
@@ -12353,6 +12353,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -12368,16 +12369,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -12392,6 +12396,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -12409,6 +12414,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -17849,9 +17855,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.0.1-rc",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.1-rc.tgz",
+      "integrity": "sha512-zh75jY8gPo/y7fpmlTVN2bb2MigoLx4hGk+Cla9pY6lgSTvzJrmQQrRt5S80VTsEt6biWPZJgLK2nm6f0Ya+mA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -28453,7 +28459,8 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -28466,15 +28473,18 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
@@ -28486,7 +28496,8 @@
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._root": {
           "version": "3.0.1",
@@ -28500,7 +28511,8 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash.union": {
           "version": "4.6.0",
@@ -32747,9 +32759,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.0.1-rc",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.1-rc.tgz",
+      "integrity": "sha512-zh75jY8gPo/y7fpmlTVN2bb2MigoLx4hGk+Cla9pY6lgSTvzJrmQQrRt5S80VTsEt6biWPZJgLK2nm6f0Ya+mA==",
       "dev": true
     },
     "typogr": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "terser": "^5.16.6",
     "through2": "^4.0.2",
     "ttest": "^4.0.0",
-    "typescript": "^4.9.5",
+    "typescript": "^5.0.1-rc",
     "typogr": "^0.6.8",
     "vinyl": "^3.0.0",
     "vinyl-fs": "^3.0.3",

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1105,7 +1105,7 @@ class PDFDocumentProxy {
  * Page getTextContent parameters.
  *
  * @typedef {Object} getTextContentParameters
- * @property {boolean} disableCombineTextItems - Do not attempt to combine
+ * @property {boolean} [disableCombineTextItems] - Do not attempt to combine
  *   same line {@link TextItem}'s. The default value is `false`.
  * @property {boolean} [includeMarkedContent] - When true include marked
  *   content items in the items array of TextContent. The default is `false`.
@@ -1114,8 +1114,9 @@ class PDFDocumentProxy {
 /**
  * Page text content.
  *
+ * @template {TextItem | TextMarkedContent} [T=TextItem | TextMarkedContent]
  * @typedef {Object} TextContent
- * @property {Array<TextItem | TextMarkedContent>} items - Array of
+ * @property {Array<T>} items - Array of
  *   {@link TextItem} and {@link TextMarkedContent} objects. TextMarkedContent
  *   items are included when includeMarkedContent is true.
  * @property {Object<string, TextStyle>} styles - {@link TextStyle} objects,
@@ -1586,11 +1587,34 @@ class PDFPageProxy {
   }
 
   /**
+   * @overload
+   * @param {getTextContentParameters & {includeMarkedContent:true}} params -
+   *   getTextContent parameters.
+   * @returns {ReadableStream<TextContent<TextMarkedContent>>} Stream for
+   *   reading text content chunks. TextMarkedContent items are included when
+   *   includeMarkedContent is true.
+   */
+  /**
+   * @overload
+   * @param {getTextContentParameters & {includeMarkedContent?:false}} [params]
+   *   - getTextContent parameters.
+   * @returns {ReadableStream<TextContent<TextItem>>} Stream for reading text
+   *   content chunks. TextItem items are included when includeMarkedContent is
+   *   false.
+   */
+  /**
+   * @overload
+   * @param {getTextContentParameters} params - getTextContent parameters.
+   * @returns {ReadableStream<TextContent>} Stream for reading text content
+   *   chunks.
+   */
+  /**
    * NOTE: All occurrences of whitespace will be replaced by
    * standard spaces (0x20).
    *
    * @param {getTextContentParameters} params - getTextContent parameters.
-   * @returns {ReadableStream} Stream for reading text content chunks.
+   * @returns {ReadableStream<TextContent>} Stream for reading text content
+   *   chunks.
    */
   streamTextContent({
     disableCombineTextItems = false,
@@ -1614,6 +1638,30 @@ class PDFPageProxy {
     );
   }
 
+  /**
+   * @overload
+   * @param {getTextContentParameters & {includeMarkedContent:true}} params -
+   *   getTextContent parameters.
+   * @returns {Promise<TextContent<TextMarkedContent>>} A promise that is
+   *   resolved with a {@link TextContent} object that represents the page's
+   *   text content. TextMarkedContent items are included when
+   *   includeMarkedContent is true.
+   */
+  /**
+   * @overload
+   * @param {getTextContentParameters & {includeMarkedContent?:false}} [params]
+   *   - getTextContent parameters.
+   * @returns {Promise<TextContent<TextItem>>} A promise that is
+   *   resolved with a {@link TextContent} object that represents the page's
+   *   text content. TextItem items are included when includeMarkedContent is
+   *   false.
+   */
+  /**
+   * @overload
+   * @param {getTextContentParameters} params - getTextContent parameters.
+   * @returns {Promise<TextContent>} A promise that is resolved with a
+   *   {@link TextContent} object that represents the page's text content.
+   */
   /**
    * NOTE: All occurrences of whitespace will be replaced by
    * standard spaces (0x20).


### PR DESCRIPTION
This updates the TypeScript types for `getTextContent` so that the `items` array properly reflects the type of text content. It uses JSDoc overloads, which are introduced in TypeScript 5.0 (although the generated types work for lower TypeScript versions).

```ts
// Before:
const { items } = await page.getTextContent();
// items is (TextItem | TextMarkedContent)[]

// After:
const { items } = await page.getTextContent();
// items is TextItem[]
```