### PR TITLE
[api-minor] Extend general transfer function support to browsers without `OffscreenCanvas`

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -417,8 +417,6 @@ class Page {
           this.resources,
           this.nonBlendModesSet
         ),
-        isOffscreenCanvasSupported:
-          this.evaluatorOptions.isOffscreenCanvasSupported,
         pageIndex: this.pageIndex,
         cacheKey,
       });

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -46,8 +46,8 @@ import {
   deprecated,
   DOMCanvasFactory,
   DOMCMapReaderFactory,
+  DOMFilterFactory,
   DOMStandardFontDataFactory,
-  FilterFactory,
   isDataScheme,
   isValidFetchUrl,
   loadScript,
@@ -71,17 +71,20 @@ const DELAYED_CLEANUP_TIMEOUT = 5000; // ms
 
 let DefaultCanvasFactory = DOMCanvasFactory;
 let DefaultCMapReaderFactory = DOMCMapReaderFactory;
+let DefaultFilterFactory = DOMFilterFactory;
 let DefaultStandardFontDataFactory = DOMStandardFontDataFactory;
 
 if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("GENERIC") && isNodeJS) {
   const {
     NodeCanvasFactory,
     NodeCMapReaderFactory,
+    NodeFilterFactory,
     NodeStandardFontDataFactory,
   } = require("./node_utils.js");
 
   DefaultCanvasFactory = NodeCanvasFactory;
   DefaultCMapReaderFactory = NodeCMapReaderFactory;
+  DefaultFilterFactory = NodeFilterFactory;
   DefaultStandardFontDataFactory = NodeStandardFontDataFactory;
 }
 
@@ -342,7 +345,7 @@ function getDocument(src) {
   const canvasFactory =
     src.canvasFactory || new DefaultCanvasFactory({ ownerDocument });
   const filterFactory =
-    src.filterFactory || new FilterFactory({ docId, ownerDocument });
+    src.filterFactory || new DefaultFilterFactory({ docId, ownerDocument });
 
   // Parameters only intended for development/testing purposes.
   const styleElement =
@@ -782,6 +785,13 @@ class PDFDocumentProxy {
    */
   get annotationStorage() {
     return this._transport.annotationStorage;
+  }
+
+  /**
+   * @type {Object} The filter factory instance.
+   */
+  get filterFactory() {
+    return this._transport.filterFactory;
   }
 
   /**
@@ -3324,7 +3334,7 @@ class InternalRenderTask {
       this.commonObjs,
       this.objs,
       this.canvasFactory,
-      isOffscreenCanvasSupported ? this.filterFactory : null,
+      this.filterFactory,
       { optionalContentConfig },
       this.annotationCanvasMap,
       this.pageColors
@@ -3429,6 +3439,7 @@ export {
   build,
   DefaultCanvasFactory,
   DefaultCMapReaderFactory,
+  DefaultFilterFactory,
   DefaultStandardFontDataFactory,
   getDocument,
   LoopbackPort,

--- a/src/display/base_factory.js
+++ b/src/display/base_factory.js
@@ -15,6 +15,20 @@
 
 import { CMapCompressionType, unreachable } from "../shared/util.js";
 
+class BaseFilterFactory {
+  constructor() {
+    if (this.constructor === BaseFilterFactory) {
+      unreachable("Cannot initialize BaseFilterFactory.");
+    }
+  }
+
+  addFilter(maps) {
+    return "none";
+  }
+
+  destroy() {}
+}
+
 class BaseCanvasFactory {
   constructor() {
     if (this.constructor === BaseCanvasFactory) {
@@ -179,6 +193,7 @@ class BaseSVGFactory {
 export {
   BaseCanvasFactory,
   BaseCMapReaderFactory,
+  BaseFilterFactory,
   BaseStandardFontDataFactory,
   BaseSVGFactory,
 };

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -16,6 +16,7 @@
 import {
   BaseCanvasFactory,
   BaseCMapReaderFactory,
+  BaseFilterFactory,
   BaseStandardFontDataFactory,
   BaseSVGFactory,
 } from "./base_factory.js";
@@ -48,7 +49,7 @@ class PixelsPerInch {
  * an image without the need to apply them on the pixel arrays: the renderer
  * does the magic for us.
  */
-class FilterFactory {
+class DOMFilterFactory extends BaseFilterFactory {
   #_cache;
 
   #_defs;
@@ -60,6 +61,7 @@ class FilterFactory {
   #id = 0;
 
   constructor({ docId, ownerDocument = globalThis.document } = {}) {
+    super();
     this.#docId = docId;
     this.#document = ownerDocument;
   }
@@ -823,9 +825,9 @@ export {
   deprecated,
   DOMCanvasFactory,
   DOMCMapReaderFactory,
+  DOMFilterFactory,
   DOMStandardFontDataFactory,
   DOMSVGFactory,
-  FilterFactory,
   getColorValues,
   getCurrentTransform,
   getCurrentTransformInverse,

--- a/src/display/node_utils.js
+++ b/src/display/node_utils.js
@@ -17,6 +17,7 @@
 import {
   BaseCanvasFactory,
   BaseCMapReaderFactory,
+  BaseFilterFactory,
   BaseStandardFontDataFactory,
 } from "./base_factory.js";
 
@@ -38,6 +39,8 @@ const fetchData = function (url) {
     });
   });
 };
+
+class NodeFilterFactory extends BaseFilterFactory {}
 
 class NodeCanvasFactory extends BaseCanvasFactory {
   /**
@@ -72,5 +75,6 @@ class NodeStandardFontDataFactory extends BaseStandardFontDataFactory {
 export {
   NodeCanvasFactory,
   NodeCMapReaderFactory,
+  NodeFilterFactory,
   NodeStandardFontDataFactory,
 };

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -51,7 +51,6 @@ import {
   version,
 } from "./display/api.js";
 import {
-  FilterFactory,
   getFilenameFromUrl,
   getPdfFilenameFromUrl,
   getXfaPageViewport,
@@ -91,7 +90,6 @@ export {
   createPromiseCapability,
   createValidAbsoluteUrl,
   FeatureTest,
-  FilterFactory,
   getDocument,
   getFilenameFromUrl,
   getPdfFilenameFromUrl,

--- a/test/driver.js
+++ b/test/driver.js
@@ -469,6 +469,8 @@ class Driver {
             .getElementsByTagName("head")[0]
             .append(xfaStyleElement);
         }
+        const isOffscreenCanvasSupported =
+          task.isOffscreenCanvasSupported === false ? false : undefined;
 
         const loadingTask = getDocument({
           url: new URL(task.file, window.location),
@@ -480,6 +482,7 @@ class Driver {
           useSystemFonts: task.useSystemFonts,
           useWorkerFetch: task.useWorkerFetch,
           enableXfa: task.enableXfa,
+          isOffscreenCanvasSupported,
           styleElement: xfaStyleElement,
         });
         let promise = loadingTask.promise;

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -6281,6 +6281,13 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "issue6931-disable-isOffscreenCanvasSupported",
+       "file": "pdfs/issue6931_reduced.pdf",
+       "md5": "e61388913821a5e044bf85a5846d6d9a",
+       "rounds": 1,
+       "type": "eq",
+       "isOffscreenCanvasSupported": false
+    },
     {  "id": "annotation-button-widget-annotations",
        "file": "pdfs/annotation-button-widget.pdf",
        "md5": "5cf23adfff84256d9cfe261bea96dade",
@@ -7473,6 +7480,15 @@
       "rounds": 1,
       "link": true,
       "type": "eq"
+   },
+   {
+      "id": "issue16114-disable-isOffscreenCanvasSupported",
+      "file": "pdfs/issue16114.pdf",
+      "md5": "c04827ea33692e0f94a5e51716d9aa2e",
+      "rounds": 1,
+      "link": true,
+      "type": "eq",
+      "isOffscreenCanvasSupported": false
    },
    {
       "id": "bug1820909",


### PR DESCRIPTION
This patch extends PR #16115 to work in all browsers, regardless of their `OffscreenCanvas` support, such that transfer functions will be applied to general rendering (and not just image data).
In order to do this we introduce the `BaseFilterFactory` that is then extended in browsers/Node.js environments, similar to all the other factories used in the API, such that we always have the necessary factory available in `src/display/canvas.js`.

These changes help simplify the existing `putBinaryImageData` function, and the new method can easily be stubbed-out in the Firefox PDF Viewer.
~~Possibly the new code is slightly less efficient than the old one, given the use of another temporary canvas, however note that this only applies to browsers *without* `OffscreenCanvas` support.~~

*Please note:* This patch removes the old *partial* transfer function support, which only applied to image data, from Node.js environments since the `node-canvas` package currently doesn't support filters. However, this should hopefully be fine given that:
 - Transfer functions are not very commonly used in PDF documents.
 - Browsers in general, and Firefox in particular, are the *primary* development target for the PDF.js library.
 - The FAQ only lists Node.js as *mostly* supported, see https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#faq-support