### PR TITLE
Remove <base> tag from the Firefox built-in viewer (bug 1821408)

### DIFF
--- a/web/app_options.js
+++ b/web/app_options.js
@@ -284,8 +284,11 @@ const defaultOptions = {
   workerSrc: {
     /** @type {string} */
     value:
+      // eslint-disable-next-line no-nested-ternary
       typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")
         ? "../src/worker_loader.js"
+        : PDFJSDev.test("MOZCENTRAL")
+        ? "resource://pdf.js/build/pdf.worker.js"
         : "../build/pdf.worker.js",
     kind: OptionKind.WORKER,
   },

--- a/web/viewer-geckoview.html
+++ b/web/viewer-geckoview.html
@@ -31,7 +31,7 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!--#endif-->
 
 <!--#if MOZCENTRAL-->
-<!--<link rel="stylesheet" href="viewer.css">-->
+<!--<link rel="stylesheet" href="resource://pdf.js/web/viewer.css">-->
 <!--#else-->
 <link rel="stylesheet" href="viewer-geckoview.css">
 <!--#endif-->
@@ -71,7 +71,7 @@ See https://github.com/adobe-type-tools/cmap-resources
 
     <script src="viewer-geckoview.js" type="module-shim"></script>
 <!--#else-->
-<!--<script src="viewer.js"></script>-->
+<!--<script src="resource://pdf.js/web/viewer.js"></script>-->
 <!--#endif-->
 
   </head>

--- a/web/viewer-snippet-firefox-extension.html
+++ b/web/viewer-snippet-firefox-extension.html
@@ -1,3 +1,2 @@
 <!-- This snippet is used in the Firefox extension (included from viewer.html) -->
-<base href="resource://pdf.js/web/">
-<script src="../build/pdf.js"></script>
+<script src="resource://pdf.js/build/pdf.js"></script>

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -36,7 +36,12 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!--#include viewer-snippet-chrome-extension.html-->
 <!--#endif-->
 
+<!--#if MOZCENTRAL-->
+<!--<link rel="stylesheet" href="resource://pdf.js/web/viewer.css">-->
+<!--#else-->
     <link rel="stylesheet" href="viewer.css">
+<!--#endif-->
+
 <!--#if !PRODUCTION-->
     <link rel="resource" type="application/l10n" href="locale/locale.properties">
 <!--#endif-->
@@ -77,10 +82,12 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!--#include viewer-snippet.html-->
 <!--#endif-->
 
-<!--#if !MINIFIED -->
-<!--<script src="viewer.js"></script>-->
-<!--#else-->
+<!--#if MINIFIED-->
 <!--#include viewer-snippet-minified.html-->
+<!--#elif MOZCENTRAL-->
+<!--<script src="resource://pdf.js/web/viewer.js"></script>-->
+<!--#else-->
+<!--<script src="viewer.js"></script>-->
 <!--#endif-->
 
   </head>


### PR DESCRIPTION
The tag <base> is used to resolve relative URIs within the document. Newly added SVG filters use a relative URI which then use the URI in base but this one mismatches with the document URI and consequently filters are not found in the Firefox viewer.
So this patch just removes <base> and replace few relative URLs by absolute ones.