### PR TITLE
Warn about missing/incorrect `--scale-factor` CSS-variable in `renderTextLayer` (issue 16139)

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -467,6 +467,19 @@ function renderTextLayer(params) {
     );
     params.textContentSource = params.textContent || params.textContentStream;
   }
+  if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("GENERIC && !TESTING")) {
+    const { container, viewport } = params;
+    const style = getComputedStyle(container);
+    const scaleFactor = parseFloat(style.getPropertyValue("--scale-factor"));
+
+    if (!scaleFactor || Math.abs(scaleFactor - viewport.scale) > 1e-15) {
+      console.error(
+        "The `--scale-factor` CSS-variable must be set, " +
+          "to the same value as `viewport.scale`, " +
+          "either on the `container`-element itself or higher up in the DOM."
+      );
+    }
+  }
   const task = new TextLayerRenderTask(params);
   task._render();
   return task;

--- a/test/unit/text_layer_spec.js
+++ b/test/unit/text_layer_spec.js
@@ -35,7 +35,7 @@ describe("textLayer", function () {
     const textLayerRenderTask = renderTextLayer({
       textContentSource: page.streamTextContent(),
       container: document.createElement("div"),
-      viewport: page.getViewport(),
+      viewport: page.getViewport({ scale: 1 }),
       textContentItemsStr,
     });
     expect(textLayerRenderTask instanceof TextLayerRenderTask).toEqual(true);


### PR DESCRIPTION
Unfortunately I don't believe that we can simply add a default `--scale-factor` CSS-variable to the `container`-element, since that might not be entirely appropriate/correct in all cases.[1]
However, we can at least print a console-error to hopefully make this situation more apparent to users. (This is purposely not using the `warn` helper-function, since those messages can be disabled.)

---
[1] One example is in our reference-tests, where we don't need to add it to the `container`-element itself.