### PR TITLE
[GeckoView] Bundle the Firefox printing code in the viewer (bug 1810111)

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -286,10 +286,9 @@ function createWebpackConfig(
       for (const key in viewerAlias) {
         viewerAlias[key] = gvAlias[key] || "web/stubs-geckoview.js";
       }
-    } else {
-      viewerAlias["web-print_service"] = "web/firefox_print_service.js";
     }
     viewerAlias["web-com"] = "web/firefoxcom.js";
+    viewerAlias["web-print_service"] = "web/firefox_print_service.js";
   }
   const alias = { ...basicAlias, ...libraryAlias, ...viewerAlias };
   for (const key in alias) {

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -289,6 +289,9 @@ function abort() {
 }
 
 function renderProgress(index, total, l10n) {
+  if (typeof PDFJSDev === "undefined" && window.isGECKOVIEW) {
+    return;
+  }
   dialog ||= document.getElementById("printServiceDialog");
   const progress = Math.round((100 * index) / total);
   const progressBar = dialog.querySelector("progress");
@@ -333,6 +336,11 @@ if ("onbeforeprint" in window) {
 
 let overlayPromise;
 function ensureOverlay() {
+  if (typeof PDFJSDev === "undefined" && window.isGECKOVIEW) {
+    return Promise.reject(
+      new Error("ensureOverlay not implemented in GECKOVIEW development mode.")
+    );
+  }
   if (!overlayPromise) {
     overlayManager = PDFViewerApplication.overlayManager;
     if (!overlayManager) {

--- a/web/viewer-geckoview.css
+++ b/web/viewer-geckoview.css
@@ -292,3 +292,57 @@ dialog :link {
 @page {
   margin: 0;
 }
+
+#printContainer {
+  display: none;
+}
+
+@media print {
+  body {
+    background: rgba(0, 0, 0, 0) none;
+  }
+  body[data-pdfjsprinting] #outerContainer {
+    display: none;
+  }
+  body[data-pdfjsprinting] #printContainer {
+    display: block;
+  }
+  #printContainer {
+    height: 100%;
+  }
+  /* wrapper around (scaled) print canvas elements */
+  #printContainer > .printedPage {
+    page-break-after: always;
+    page-break-inside: avoid;
+
+    /* The wrapper always cover the whole page. */
+    height: 100%;
+    width: 100%;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+
+  #printContainer > .xfaPrintedPage .xfaPage {
+    position: absolute;
+  }
+
+  #printContainer > .xfaPrintedPage {
+    page-break-after: always;
+    page-break-inside: avoid;
+    width: 100%;
+    height: 100%;
+    position: relative;
+  }
+
+  #printContainer > .printedPage :is(canvas, img) {
+    /* The intrinsic canvas / image size will make sure that we fit the page. */
+    max-width: 100%;
+    max-height: 100%;
+
+    direction: ltr;
+    display: block;
+  }
+}

--- a/web/viewer-geckoview.html
+++ b/web/viewer-geckoview.html
@@ -67,7 +67,7 @@ See https://github.com/adobe-type-tools/cmap-resources
           "web-pdf_presentation_mode": "./stubs-geckoview.js",
           "web-pdf_sidebar": "./stubs-geckoview.js",
           "web-pdf_thumbnail_viewer": "./stubs-geckoview.js",
-          "web-print_service": "./stubs-geckoview.js",
+          "web-print_service": "./pdf_print_service.js",
           "web-secondary_toolbar": "./stubs-geckoview.js",
           "web-toolbar": "./toolbar-geckoview.js"
         }
@@ -116,6 +116,7 @@ See https://github.com/adobe-type-tools/cmap-resources
       </div>  <!-- dialogContainer -->
 
     </div> <!-- outerContainer -->
+    <div id="printContainer"></div>
 
 <!--#if !MOZCENTRAL-->
     <input type="file" id="fileInput" class="hidden">

--- a/web/viewer-geckoview.js
+++ b/web/viewer-geckoview.js
@@ -14,6 +14,7 @@
  */
 
 import "web-com";
+import "web-print_service";
 import { RenderingStates, ScrollMode, SpreadMode } from "./ui_utils.js";
 import { AppOptions } from "./app_options.js";
 import { LinkTarget } from "./pdf_link_service.js";
@@ -55,6 +56,7 @@ function getViewerConfiguration() {
       submitButton: document.getElementById("passwordSubmit"),
       cancelButton: document.getElementById("passwordCancel"),
     },
+    printContainer: document.getElementById("printContainer"),
     openFileInput:
       typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")
         ? document.getElementById("fileInput")


### PR DESCRIPTION
This may not be enough, on its own, to completely fix [bug 1810111](https://bugzilla.mozilla.org/show_bug.cgi?id=1810111) however it's impossible for printing to work in GeckoView without this patch.