### PR TITLE
Simplify the `applyTransferMapsToCanvas` method (PR 16151 follow-up)

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -2964,19 +2964,11 @@ class CanvasGraphics {
   }
 
   applyTransferMapsToCanvas(ctx) {
-    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
-      if (this.current.transferMaps !== "none") {
-        warn("Ignoring transferMaps - `OffscreenCanvas` support is disabled.");
-      }
-      return ctx.canvas;
+    if (this.current.transferMaps !== "none") {
+      ctx.filter = this.current.transferMaps;
+      ctx.drawImage(ctx.canvas, 0, 0);
+      ctx.filter = "none";
     }
-    if (this.current.transferMaps === "none") {
-      return ctx.canvas;
-    }
-    ctx.filter = this.current.transferMaps;
-    ctx.drawImage(ctx.canvas, 0, 0);
-    ctx.filter = "none";
-
     return ctx.canvas;
   }
 


### PR DESCRIPTION
During review of PR #16151 this method was simplified, however I overlooked the fact that we now can (and really should) improve this by removing duplication.