### PR TITLE
Introduce `inset` usage in the CSS files

### DIFF
--- a/test/text_layer_test.css
+++ b/test/text_layer_test.css
@@ -17,10 +17,7 @@
 
 .textLayer {
   position: absolute;
-  left: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
   line-height: 1;
   opacity: 1;
 }

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -28,10 +28,7 @@
 .textLayer {
   position: absolute;
   text-align: initial;
-  left: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
   overflow: hidden;
   opacity: 0.25;
   line-height: 1;
@@ -99,10 +96,7 @@
 .textLayer .endOfContent {
   display: block;
   position: absolute;
-  left: 0;
-  top: 100%;
-  right: 0;
-  bottom: 0;
+  inset: 100% 0 0;
   z-index: -1;
   cursor: default;
   user-select: none;

--- a/web/viewer-geckoview.css
+++ b/web/viewer-geckoview.css
@@ -84,20 +84,14 @@ body {
 
 #mainContainer {
   position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  inset: 0;
   min-width: 350px;
 }
 
 #viewerContainer {
   overflow: auto;
   position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  inset: 0;
   outline: none;
 }
 #viewerContainer {

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -282,10 +282,7 @@ body {
 
 #mainContainer {
   position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  inset: 0;
   min-width: 350px;
 }
 
@@ -302,10 +299,7 @@ body {
 #viewerContainer {
   overflow: auto;
   position: absolute;
-  top: 32px;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  inset: 32px 0 0;
   outline: none;
 }
 #viewerContainer:not(.pdfPresentationMode) {
@@ -320,8 +314,7 @@ body {
 
 .toolbar {
   position: relative;
-  left: 0;
-  right: 0;
+  inset-inline: 0;
   z-index: 9999;
   cursor: default;
   font: message-box;
@@ -1404,10 +1397,7 @@ dialog :link {
   position: fixed;
   background: rgba(0, 0, 0, 0);
   display: block;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
   overflow: hidden;
   z-index: 50000; /* should be higher than anything else in PDF.js! */
 }


### PR DESCRIPTION
The `inset` property is a nice shorthand that can be used to avoid having to specify the positions individually; please see
 - https://developer.mozilla.org/en-US/docs/Web/CSS/inset
 - https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline