### PR TITLE
Fix the `transfer` parameter, for `structuredClone`, in the `LoopbackPort`

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1943,9 +1943,9 @@ class LoopbackPort {
 
   #deferred = Promise.resolve();
 
-  postMessage(obj, transfers) {
+  postMessage(obj, transfer) {
     const event = {
-      data: structuredClone(obj, transfers),
+      data: structuredClone(obj, transfer ? { transfer } : null),
     };
 
     this.#deferred.then(() => {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -208,10 +208,8 @@ describe("api", function () {
       expect(data[0] instanceof PDFDocumentProxy).toEqual(true);
       expect(data[1].loaded / data[1].total).toEqual(1);
 
-      if (!isNodeJS) {
-        // Check that the TypedArray was transferred.
-        expect(typedArrayPdf.length).toEqual(0);
-      }
+      // Check that the TypedArray was transferred.
+      expect(typedArrayPdf.length).toEqual(0);
 
       await loadingTask.destroy();
     });
@@ -240,10 +238,8 @@ describe("api", function () {
       expect(data[0] instanceof PDFDocumentProxy).toEqual(true);
       expect(data[1].loaded / data[1].total).toEqual(1);
 
-      if (!isNodeJS) {
-        // Check that the ArrayBuffer was transferred.
-        expect(arrayBufferPdf.byteLength).toEqual(0);
-      }
+      // Check that the ArrayBuffer was transferred.
+      expect(arrayBufferPdf.byteLength).toEqual(0);
 
       await loadingTask.destroy();
     });
@@ -3368,11 +3364,9 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
       expect(pdfPage.rotate).toEqual(0);
       expect(fetches).toBeGreaterThan(2);
 
-      if (!isNodeJS) {
-        // Check that the TypedArrays were transferred.
-        for (const array of subArrays) {
-          expect(array.length).toEqual(0);
-        }
+      // Check that the TypedArrays were transferred.
+      for (const array of subArrays) {
+        expect(array.length).toEqual(0);
       }
 
       await loadingTask.destroy();
@@ -3417,11 +3411,9 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
         waitSome(resolve);
       });
 
-      if (!isNodeJS) {
-        // Check that the TypedArrays were transferred.
-        for (const array of subArrays) {
-          expect(array.length).toEqual(0);
-        }
+      // Check that the TypedArrays were transferred.
+      for (const array of subArrays) {
+        expect(array.length).toEqual(0);
       }
 
       await loadingTask.destroy();
@@ -3458,11 +3450,9 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
         expect(pdfPage.rotate).toEqual(0);
         expect(fetches).toEqual(0);
 
-        if (!isNodeJS) {
-          // Check that the TypedArrays were transferred.
-          for (const array of subArrays) {
-            expect(array.length).toEqual(0);
-          }
+        // Check that the TypedArrays were transferred.
+        for (const array of subArrays) {
+          expect(array.length).toEqual(0);
         }
 
         await loadingTask.destroy();


### PR DESCRIPTION
The way that we handle the `transfer` parameter is unfortunately wrong, ever since PR #14392 which introduced the code, given that the MDN article originally contained incorrect information; please see https://github.com/mdn/content/pull/23164

By updating the `structuredClone` call such that it works correctly, we can enable more unit-tests in Node.js environments; please refer to https://developer.mozilla.org/en-US/docs/Web/API/structuredClone#parameters