### PR TITLE
Only warn about missing `--scale-factor` CSS-variable for visible textLayers (PR 16162 follow-up)

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -470,9 +470,13 @@ function renderTextLayer(params) {
   if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("GENERIC && !TESTING")) {
     const { container, viewport } = params;
     const style = getComputedStyle(container);
+    const visibility = style.getPropertyValue("visibility");
     const scaleFactor = parseFloat(style.getPropertyValue("--scale-factor"));
 
-    if (!scaleFactor || Math.abs(scaleFactor - viewport.scale) > 1e-15) {
+    if (
+      visibility === "visible" &&
+      (!scaleFactor || Math.abs(scaleFactor - viewport.scale) > 1e-15)
+    ) {
       console.error(
         "The `--scale-factor` CSS-variable must be set, " +
           "to the same value as `viewport.scale`, " +


### PR DESCRIPTION
This is something that I completely overlooked in PR #16162, which in some cases cause the default viewer to incorrectly print warnings.
This can be reproduced with the PAGE scrolling-mode, and/or the PresentationMode, and this patch simply work-around it by checking the visibility as well (since the warning is a best-effort solution anyway).