### PR TITLE
Add even more non-standard ligatures (PR 15517 follow-up)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -3550,6 +3550,16 @@ class PartialEvaluator {
             code = unicode;
           }
           break;
+        default:
+          // Support (some) non-standard ligatures.
+          switch (glyphName) {
+            case "f_h":
+            case "f_t":
+            case "T_h":
+              toUnicode[charcode] = glyphName.replaceAll("_", "");
+              continue;
+          }
+          break;
       }
       if (code > 0 && code <= 0x10ffff && Number.isInteger(code)) {
         // If `baseEncodingName` is one the predefined encodings, and `code`

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -230,7 +230,14 @@
       "link": true,
       "type": "eq",
       "annotations": true
-   },
+    },
+    {  "id": "issue15516",
+       "file": "pdfs/issue15516_reduced.pdf",
+       "md5": "a30be78c73d13aa6ff890834ce69adc1",
+       "rounds": 1,
+       "link": false,
+       "type": "text"
+    },
     {  "id": "bug946506",
        "file": "pdfs/bug946506.pdf",
        "md5": "c28911b5c31bdc337c2ce404c5971cfc",

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -2607,23 +2607,6 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
       await loadingTask.destroy();
     });
 
-    // TODO: Change this to a `text` reference test instead.
-    //       Currently that doesn't work, since the `XMLSerializer` fails on
-    //       the ASCII "control characters" found in the text-content.
-    it("gets text content with non-standard ligatures (issue issue15516)", async function () {
-      const loadingTask = getDocument(
-        buildGetDocumentParams("issue15516_reduced.pdf")
-      );
-      const pdfDoc = await loadingTask.promise;
-      const pdfPage = await pdfDoc.getPage(1);
-      const { items } = await pdfPage.getTextContent();
-      const text = mergeText(items);
-
-      expect(text).toEqual("ffi fi ffl ff fl \x07 \x08 Ý");
-
-      await loadingTask.destroy();
-    });
-
     it("gets text content with multi-byte entries, using predefined CMaps (issue 16176)", async function () {
       const loadingTask = getDocument(
         buildGetDocumentParams("issue16176.pdf", {


### PR DESCRIPTION
Given that we already create multi-byte ToUnicode entries in other cases, see e.g. the `getNormalizedUnicodes` table, this is hopefully fine.