### PR TITLE
Enable the `declaration-block-no-redundant-longhand-properties` Stylelint rule

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -7,6 +7,7 @@
     "prettier/prettier": true,
 
     "block-no-empty": true,
+    "declaration-block-no-redundant-longhand-properties": true,
     "length-zero-no-unit": [true, {
       ignore: ["custom-properties"]
     }],

--- a/examples/mobile-viewer/viewer.css
+++ b/examples/mobile-viewer/viewer.css
@@ -153,10 +153,7 @@ footer {
   position: absolute;
   overflow: auto;
   width: 100%;
-  top: 5rem;
-  bottom: 4rem;
-  left: 0;
-  right: 0;
+  inset: 5rem 0 4rem;
 }
 
 canvas {

--- a/test/resources/reftest-analyzer.css
+++ b/test/resources/reftest-analyzer.css
@@ -77,18 +77,12 @@ a {
 
 #imagepane {
   position: fixed;
-  left: 340px;
-  right: 0;
-  top: 10px;
-  bottom: 0;
+  inset: 10px 0 0 340px;
 }
 
 #images {
   position: absolute;
-  left: 0;
-  right: 0;
-  top: 22px;
-  bottom: 0;
+  inset: 22px 0 0;
   overflow: auto;
 }
 

--- a/web/debugger.css
+++ b/web/debugger.css
@@ -36,12 +36,9 @@
   padding: 3px;
 }
 #PDFBug .panels {
-  bottom: 0;
-  left: 0;
+  inset: 27px 0 0;
   overflow: auto;
   position: absolute;
-  right: 0;
-  top: 27px;
 }
 #PDFBug .panels > div {
   padding: 5px;


### PR DESCRIPTION
Note that these changes were done automatically, using `gulp lint --fix`.
This rule will help avoid unnecessary repetition in the CSS; please see https://stylelint.io/user-guide/rules/declaration-block-no-redundant-longhand-properties/