### PR TITLE
Use `replaceAll` in the `recoverJsURL` helper function

### DIFF
--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -515,7 +515,7 @@ function recoverJsURL(str) {
   const URL_OPEN_METHODS = ["app.launchURL", "window.open", "xfa.host.gotoURL"];
   const regex = new RegExp(
     "^\\s*(" +
-      URL_OPEN_METHODS.join("|").split(".").join("\\.") +
+      URL_OPEN_METHODS.join("|").replaceAll(".", "\\.") +
       ")\\((?:'|\")([^'\"]*)(?:'|\")(?:,\\s*(\\w+)\\)|\\))",
     "i"
   );


### PR DESCRIPTION
We can just do direct replacement when building the regular expression, rather than splitting the string into an Array and then re-joining it.