### PR TITLE
[GeckoView] Remove unused `transition` CSS-rules

### DIFF
--- a/web/viewer-geckoview.css
+++ b/web/viewer-geckoview.css
@@ -94,10 +94,6 @@ body {
   inset: 0;
   outline: none;
 }
-#viewerContainer {
-  transition-duration: var(--sidebar-transition-duration);
-  transition-timing-function: var(--sidebar-transition-timing-function);
-}
 
 .dialogButton {
   border: none;


### PR DESCRIPTION
Given that the GeckoView-viewer doesn't have a sidebar, there's no reason to have CSS-rules for it (and the variables are also undefined).