### PR TITLE
Simplify the `isPDFFunction` helper function

### DIFF
--- a/src/core/function.js
+++ b/src/core/function.js
@@ -502,9 +502,7 @@ class PDFFunction {
 
 function isPDFFunction(v) {
   let fnDict;
-  if (typeof v !== "object") {
-    return false;
-  } else if (v instanceof Dict) {
+  if (v instanceof Dict) {
     fnDict = v;
   } else if (v instanceof BaseStream) {
     fnDict = v.dict;


### PR DESCRIPTION
Originally we used helper functions for checking if something was a Dictionary or Stream, and then having an initial `typeof` check probably made sense. However, given that we're using `instanceof` nowadays the additional check longer seems necessary.