### PR TITLE
Fix various zooming regressions (PR 15812 follow-up)

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -759,10 +759,7 @@ class PDFPageView {
         scaleX = height / width;
         scaleY = width / height;
       }
-
-      if (absRotation !== 0) {
-        target.style.transform = `rotate(${relativeRotation}deg) scale(${scaleX}, ${scaleY})`;
-      }
+      target.style.transform = `rotate(${relativeRotation}deg) scale(${scaleX}, ${scaleY})`;
     }
 
     if (redrawAnnotationLayer && this.annotationLayer) {

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -607,14 +607,13 @@ class PDFPageView {
         isScalingRestricted = true;
       }
     }
-    const postponeDrawing = drawingDelay >= 0 && drawingDelay < 1000;
+    const onlyCssZoom =
+      this.useOnlyCssZoom || (this.hasRestrictedScaling && isScalingRestricted);
+    const postponeDrawing =
+      !onlyCssZoom && drawingDelay >= 0 && drawingDelay < 1000;
 
     if (this.canvas) {
-      if (
-        postponeDrawing ||
-        this.useOnlyCssZoom ||
-        (this.hasRestrictedScaling && isScalingRestricted)
-      ) {
+      if (postponeDrawing || onlyCssZoom) {
         if (
           postponeDrawing &&
           this.renderingState !== RenderingStates.FINISHED


### PR DESCRIPTION
 - Fix rotation of the `zoomLayer` (PR 15812 follow-up)

   Currently the `zoomLayer` isn't rotated correctly in all cases. To reproduce:
    - Load https://github.com/mozilla/pdf.js/files/1522715/wuppertal_2012.pdf
    - Let the document render.
    - Rotate the document *four* times, such that the original rotation is restored.

   The easiest solution, as far as I can tell, is that we always set the `transform` just as we did (for years) prior to the changes in PR #15812.

 - Fix CSS-only zooming in the viewer (PR 15812 follow-up)

   Currently if you e.g. enable the `useOnlyCssZoom` option rendering may no longer finish as intended. To reproduce:
    - Enable the `useOnlyCssZoom` option.
    - Load https://github.com/mozilla/pdf.js/files/1522715/wuppertal_2012.pdf (in the development viewer).
    - When rendering starts, *immediately* change the zoom-level.

   In this case the document will never finish rendering, since the `postponeDrawing`-functionality will (here incorrectly) abort rendering and with CSS-only zooming rendering is only expected to happen once per page.
   To fix this we'll simply ignore any `drawingDelay` when CSS-only zooming is used (regardless if it's triggered via the option or the zoom-level being very large).