### PR TITLE
[Firefox] Set the `imageResourcesPath` correctly (PR 16153 follow-up)

### DIFF
--- a/web/app_options.js
+++ b/web/app_options.js
@@ -125,7 +125,10 @@ const defaultOptions = {
   },
   imageResourcesPath: {
     /** @type {string} */
-    value: "./images/",
+    value:
+      typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")
+        ? "resource://pdf.js/web/images/"
+        : "./images/",
     kind: OptionKind.VIEWER,
   },
   maxCanvasPixels: {


### PR DESCRIPTION
We missed updating this path in PR #16153, which breaks loading of annotation-icons in the Firefox PDF Viewer.