### PR TITLE
Update the Node.js compatibility-check in the worker-thread

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -133,10 +133,14 @@ class WorkerMessageHandler {
       // Ensure that (primarily) Node.js users won't accidentally attempt to use
       // a non-translated/non-polyfilled build of the library, since that would
       // quickly fail anyway because of missing functionality.
-      if (typeof ReadableStream === "undefined") {
+      if (
+        typeof Path2D === "undefined" ||
+        typeof ReadableStream === "undefined"
+      ) {
         const partialMsg =
           "The browser/environment lacks native support for critical " +
-          "functionality used by the PDF.js library (e.g. `ReadableStream`); ";
+          "functionality used by the PDF.js library " +
+          "(e.g. `Path2D` and/or `ReadableStream`); ";
 
         if (isNodeJS) {
           throw new Error(partialMsg + "please use a `legacy`-build instead.");

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -36,7 +36,7 @@ import { isNodeJS } from "./is_node.js";
   polyfillPath2D(globalThis);
 })();
 
-// Support: Node.js
+// Support: Node.js<18.0.0
 (function checkReadableStream() {
   if (globalThis.ReadableStream || !isNodeJS) {
     return;


### PR DESCRIPTION
*Please note:* In Node.js environments a `legacy`-build must be used since only those versions include any polyfills.

Previously we'd only check if `ReadableStream` is natively supported, however since Node.js version 18 that's now been implemented; please see https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream#browser_compatibility
Hence we'll also check for the availability of `Path2D`, since that's browser-specific functionality not expected to be available in Node.js environments; please see https://developer.mozilla.org/en-US/docs/Web/API/Path2D#browser_compatibility