### PR TITLE
[Firefox] Add CSS at-page size when printing from FirefoxPrintService (bug 1820651)

### DIFF
--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -111,9 +111,9 @@ PDFPrintService.prototype = {
     // TODO(robwu): Use named pages when size calculation bugs get resolved
     // (e.g. https://crbug.com/355116) AND when support for named pages is
     // added (http://www.w3.org/TR/css3-page/#using-named-pages).
-    // In browsers where @page + size is not supported (such as Firefox,
-    // https://bugzil.la/851441), the next stylesheet will be ignored and the
-    // user has to select the correct paper size in the UI if wanted.
+    // In browsers where @page + size is not supported, the next stylesheet
+    // will be ignored and the user has to select the correct paper size in
+    // the UI if wanted.
     this.pageStyleSheet = document.createElement("style");
     const pageSize = this.pagesOverview[0];
     this.pageStyleSheet.textContent =

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -1673,21 +1673,27 @@ class PDFViewer {
    * @returns {Array} Array of objects with width/height/rotation fields.
    */
   getPagesOverview() {
+    let initialOrientation;
     return this._pages.map(pageView => {
       const viewport = pageView.pdfPage.getViewport({ scale: 1 });
-
-      if (!this.enablePrintAutoRotate || isPortraitOrientation(viewport)) {
+      const orientation = isPortraitOrientation(viewport);
+      if (initialOrientation === undefined) {
+        initialOrientation = orientation;
+      } else if (
+        this.enablePrintAutoRotate &&
+        orientation !== initialOrientation
+      ) {
+        // Rotate to fit the initial orientation.
         return {
-          width: viewport.width,
-          height: viewport.height,
-          rotation: viewport.rotation,
+          width: viewport.height,
+          height: viewport.width,
+          rotation: (viewport.rotation - 90) % 360,
         };
       }
-      // Landscape orientation.
       return {
-        width: viewport.height,
-        height: viewport.width,
-        rotation: (viewport.rotation - 90) % 360,
+        width: viewport.width,
+        height: viewport.height,
+        rotation: viewport.rotation,
       };
     });
   }


### PR DESCRIPTION
Now that `@page { size: X X }` is [supported in Firefox](https://bugzil.la/851441) and that [size is reflected in the printed PDF output](https://bugzil.la/1793220) size, the `FirefoxPrintService` can add the PDF page size in the at-page rule.

This copies over the existing code to do that from the `PDFPrintService`.

Updates `getPagesOverview` to rotate pages to fit the initial orientation rather than always rotating landscape pages.