### PR TITLE
Force-install when using `gulp dist-install` (issue 15435)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2345,7 +2345,7 @@ gulp.task(
       opts.cwd = installPath;
       distPath = path.relative(installPath, distPath);
     }
-    safeSpawnSync("npm", ["install", distPath], opts);
+    safeSpawnSync("npm", ["install", "--force", distPath], opts);
     done();
   })
 );


### PR DESCRIPTION
When installing the PDF.js project itself it's currently necessary to use `--force` in order for all packages to install correctly, see issue #15429, hence the same is also necessary when using the `gulp dist-install` command for local development/testing.