### PR TITLE
[api-minor] Add support, in `PDFFindController`, for mixing phrase/word searches (issue 7442)

### DIFF
--- a/test/unit/pdf_find_controller_spec.js
+++ b/test/unit/pdf_find_controller_spec.js
@@ -95,7 +95,6 @@ function testSearch({
         query: null,
         caseSensitive: false,
         entireWord: false,
-        phraseSearch: true,
         findPrevious: false,
         matchDiacritics: false,
       },
@@ -182,7 +181,6 @@ function testEmptySearch({ eventBus, pdfFindController, state }) {
         query: null,
         caseSensitive: false,
         entireWord: false,
-        phraseSearch: true,
         findPrevious: false,
         matchDiacritics: false,
       },
@@ -321,10 +319,28 @@ describe("pdf_find_controller", function () {
       eventBus,
       pdfFindController,
       state: {
-        query: "alternate solution",
-        phraseSearch: false,
+        query: ["alternate", "solution"],
       },
       matchesPerPage: [0, 0, 0, 0, 0, 1, 0, 0, 4, 0, 0, 0, 0, 0],
+      selectedMatch: {
+        pageIndex: 5,
+        matchIndex: 0,
+      },
+    });
+  });
+
+  it("performs a multiple term (phrase) search", async function () {
+    // Page 9 contains 'alternate solution' and pages 6 and 9 contain
+    // 'solution'. Both should be found for multiple term (phrase) search.
+    const { eventBus, pdfFindController } = await initPdfFindController();
+
+    await testSearch({
+      eventBus,
+      pdfFindController,
+      state: {
+        query: ["alternate solution", "solution"],
+      },
+      matchesPerPage: [0, 0, 0, 0, 0, 1, 0, 0, 3, 0, 0, 0, 0, 0],
       selectedMatch: {
         pageIndex: 5,
         matchIndex: 0,

--- a/web/app.js
+++ b/web/app.js
@@ -2575,7 +2575,6 @@ function webViewerFindFromUrlHash(evt) {
     source: evt.source,
     type: "",
     query: evt.query,
-    phraseSearch: evt.phraseSearch,
     caseSensitive: false,
     entireWord: false,
     highlightAll: true,

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -222,7 +222,6 @@ class MozL10n {
       source: window,
       type: type.substring(findLen),
       query: detail.query,
-      phraseSearch: true,
       caseSensitive: !!detail.caseSensitive,
       entireWord: !!detail.entireWord,
       highlightAll: !!detail.highlightAll,

--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -99,7 +99,6 @@ class PDFFindBar {
       source: this,
       type,
       query: this.findField.value,
-      phraseSearch: true,
       caseSensitive: this.caseSensitive.checked,
       entireWord: this.entireWord.checked,
       highlightAll: this.highlightAll.checked,

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -350,10 +350,12 @@ class PDFLinkService {
     if (hash.includes("=")) {
       const params = parseQueryString(hash);
       if (params.has("search")) {
+        const query = params.get("search").replaceAll('"', ""),
+          phrase = params.get("phrase") === "true";
+
         this.eventBus.dispatch("findfromurlhash", {
           source: this,
-          query: params.get("search").replaceAll('"', ""),
-          phraseSearch: params.get("phrase") === "true",
+          query: phrase ? query : query.match(/\S+/g),
         });
       }
       // borrowing syntax from "Parameters for Opening PDF Files"


### PR DESCRIPTION
*Please note:* This patch only extends the `PDFFindController` implementation itself to support this functionality, however it's *purposely* not exposed in the default viewer.

This replaces the previous `phraseSearch`-parameter, and a `query`-string will now always be interpreted as a phrase-search.
To enable searching for individual words, the `query`-parameter must instead consist of an Array of strings. This way it's now also possible to combine phrase/word searches, with a `query`-parameter looking something like `["Lorem ipsum", "foo", "bar"]` which will search for the phrase "Lorem ipsum" *and* the words "foo" respectively "bar".