### PR TITLE
Reduce duplication when dispatching the "switchannotationeditorparams" event

### DIFF
--- a/web/annotation_editor_params.js
+++ b/web/annotation_editor_params.js
@@ -32,40 +32,27 @@ class AnnotationEditorParams {
     editorInkThickness,
     editorInkOpacity,
   }) {
-    editorFreeTextFontSize.addEventListener("input", evt => {
+    const dispatchEvent = (typeStr, value) => {
       this.eventBus.dispatch("switchannotationeditorparams", {
         source: this,
-        type: AnnotationEditorParamsType.FREETEXT_SIZE,
-        value: editorFreeTextFontSize.valueAsNumber,
+        type: AnnotationEditorParamsType[typeStr],
+        value,
       });
+    };
+    editorFreeTextFontSize.addEventListener("input", function () {
+      dispatchEvent("FREETEXT_SIZE", this.valueAsNumber);
     });
-    editorFreeTextColor.addEventListener("input", evt => {
-      this.eventBus.dispatch("switchannotationeditorparams", {
-        source: this,
-        type: AnnotationEditorParamsType.FREETEXT_COLOR,
-        value: editorFreeTextColor.value,
-      });
+    editorFreeTextColor.addEventListener("input", function () {
+      dispatchEvent("FREETEXT_COLOR", this.value);
     });
-    editorInkColor.addEventListener("input", evt => {
-      this.eventBus.dispatch("switchannotationeditorparams", {
-        source: this,
-        type: AnnotationEditorParamsType.INK_COLOR,
-        value: editorInkColor.value,
-      });
+    editorInkColor.addEventListener("input", function () {
+      dispatchEvent("INK_COLOR", this.value);
     });
-    editorInkThickness.addEventListener("input", evt => {
-      this.eventBus.dispatch("switchannotationeditorparams", {
-        source: this,
-        type: AnnotationEditorParamsType.INK_THICKNESS,
-        value: editorInkThickness.valueAsNumber,
-      });
+    editorInkThickness.addEventListener("input", function () {
+      dispatchEvent("INK_THICKNESS", this.valueAsNumber);
     });
-    editorInkOpacity.addEventListener("input", evt => {
-      this.eventBus.dispatch("switchannotationeditorparams", {
-        source: this,
-        type: AnnotationEditorParamsType.INK_OPACITY,
-        value: editorInkOpacity.valueAsNumber,
-      });
+    editorInkOpacity.addEventListener("input", function () {
+      dispatchEvent("INK_OPACITY", this.valueAsNumber);
     });
 
     this.eventBus._on("annotationeditorparamschanged", evt => {


### PR DESCRIPTION
Currently we repeat virtually the same code multiple times, which can be avoided by the introduction of a simple helper function.