### PR TITLE
Tweak the `--scale-factor` CSS-variable warning threshold (issue 16254)

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -475,7 +475,7 @@ function renderTextLayer(params) {
 
     if (
       visibility === "visible" &&
-      (!scaleFactor || Math.abs(scaleFactor - viewport.scale) > 1e-15)
+      (!scaleFactor || Math.abs(scaleFactor - viewport.scale) > 1e-5)
     ) {
       console.error(
         "The `--scale-factor` CSS-variable must be set, " +


### PR DESCRIPTION
This is apparently needed to account for the rounding used in Chromium-browsers, such that the warning message isn't displayed unnecessarily.