### PR TITLE
Skip transfers, in `LoopbackPort.postMessage`, for PDF.js `legacy`-builds (issue 16255)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1943,7 +1943,14 @@ class LoopbackPort {
 
   postMessage(obj, transfer) {
     const event = {
-      data: structuredClone(obj, transfer ? { transfer } : null),
+      data: structuredClone(
+        obj,
+        (typeof PDFJSDev === "undefined" ||
+          PDFJSDev.test("SKIP_BABEL || TESTING")) &&
+          transfer
+          ? { transfer }
+          : null
+      ),
     };
 
     this.#deferred.then(() => {


### PR DESCRIPTION
Apparently the `structuredClone` polyfill doesn't handle transfers correctly, and `DOMException`s may thus be thrown. This is particularly problematical in Node.js environments, where that exception (obviously) isn't available.

To work-around these issues we'll simply ignore any transfers in `legacy`-builds, since those *may* use the `structuredClone` polyfill. This will obviously lead to slightly higher memory usage in those builds, however this really only affects Node.js environments. (Browsers are only affected if workers are disabled, however that's never been an officially recommended/supported configuration.)