### PR TITLE
Slightly modernize print-related code

### DIFF
--- a/web/firefox_print_service.js
+++ b/web/firefox_print_service.js
@@ -146,16 +146,13 @@ FirefoxPrintService.prototype = {
     const body = document.querySelector("body");
     body.setAttribute("data-pdfjsprinting", true);
 
-    const hasEqualPageSizes = this.pagesOverview.every(function (size) {
-      return (
-        size.width === this.pagesOverview[0].width &&
-        size.height === this.pagesOverview[0].height
-      );
-    }, this);
+    const { width, height } = this.pagesOverview[0];
+    const hasEqualPageSizes = this.pagesOverview.every(
+      size => size.width === width && size.height === height
+    );
     if (!hasEqualPageSizes) {
       console.warn(
-        "Not all pages have the same size. The printed " +
-          "result may be incorrect!"
+        "Not all pages have the same size. The printed result may be incorrect!"
       );
     }
 
@@ -163,8 +160,7 @@ FirefoxPrintService.prototype = {
     // set. Note that we assume that all pages have the same size, because
     // variable-size pages are scaled down to the initial page size in Firefox.
     this.pageStyleSheet = document.createElement("style");
-    const pageSize = this.pagesOverview[0];
-    this.pageStyleSheet.textContent = `@page { size: ${pageSize.width}pt ${pageSize.height}pt;}`;
+    this.pageStyleSheet.textContent = `@page { size: ${width}pt ${height}pt;}`;
     body.append(this.pageStyleSheet);
 
     if (pdfDocument.isPureXfa) {

--- a/web/firefox_print_service.js
+++ b/web/firefox_print_service.js
@@ -114,25 +114,25 @@ function composePage(
   };
 }
 
-function FirefoxPrintService(
-  pdfDocument,
-  pagesOverview,
-  printContainer,
-  printResolution,
-  optionalContentConfigPromise = null,
-  printAnnotationStoragePromise = null
-) {
-  this.pdfDocument = pdfDocument;
-  this.pagesOverview = pagesOverview;
-  this.printContainer = printContainer;
-  this._printResolution = printResolution || 150;
-  this._optionalContentConfigPromise =
-    optionalContentConfigPromise || pdfDocument.getOptionalContentConfig();
-  this._printAnnotationStoragePromise =
-    printAnnotationStoragePromise || Promise.resolve();
-}
+class FirefoxPrintService {
+  constructor(
+    pdfDocument,
+    pagesOverview,
+    printContainer,
+    printResolution,
+    optionalContentConfigPromise = null,
+    printAnnotationStoragePromise = null
+  ) {
+    this.pdfDocument = pdfDocument;
+    this.pagesOverview = pagesOverview;
+    this.printContainer = printContainer;
+    this._printResolution = printResolution || 150;
+    this._optionalContentConfigPromise =
+      optionalContentConfigPromise || pdfDocument.getOptionalContentConfig();
+    this._printAnnotationStoragePromise =
+      printAnnotationStoragePromise || Promise.resolve();
+  }
 
-FirefoxPrintService.prototype = {
   layout() {
     const {
       pdfDocument,
@@ -179,7 +179,7 @@ FirefoxPrintService.prototype = {
         _printAnnotationStoragePromise
       );
     }
-  },
+  }
 
   destroy() {
     this.printContainer.textContent = "";
@@ -191,8 +191,8 @@ FirefoxPrintService.prototype = {
       this.pageStyleSheet.remove();
       this.pageStyleSheet = null;
     }
-  },
-};
+  }
+}
 
 PDFPrintServiceFactory.instance = {
   get supportsPrinting() {

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -62,30 +62,30 @@ function renderPage(
   });
 }
 
-function PDFPrintService(
-  pdfDocument,
-  pagesOverview,
-  printContainer,
-  printResolution,
-  optionalContentConfigPromise = null,
-  printAnnotationStoragePromise = null,
-  l10n
-) {
-  this.pdfDocument = pdfDocument;
-  this.pagesOverview = pagesOverview;
-  this.printContainer = printContainer;
-  this._printResolution = printResolution || 150;
-  this._optionalContentConfigPromise =
-    optionalContentConfigPromise || pdfDocument.getOptionalContentConfig();
-  this._printAnnotationStoragePromise =
-    printAnnotationStoragePromise || Promise.resolve();
-  this.l10n = l10n;
-  this.currentPage = -1;
-  // The temporary canvas where renderPage paints one page at a time.
-  this.scratchCanvas = document.createElement("canvas");
-}
+class PDFPrintService {
+  constructor(
+    pdfDocument,
+    pagesOverview,
+    printContainer,
+    printResolution,
+    optionalContentConfigPromise = null,
+    printAnnotationStoragePromise = null,
+    l10n
+  ) {
+    this.pdfDocument = pdfDocument;
+    this.pagesOverview = pagesOverview;
+    this.printContainer = printContainer;
+    this._printResolution = printResolution || 150;
+    this._optionalContentConfigPromise =
+      optionalContentConfigPromise || pdfDocument.getOptionalContentConfig();
+    this._printAnnotationStoragePromise =
+      printAnnotationStoragePromise || Promise.resolve();
+    this.l10n = l10n;
+    this.currentPage = -1;
+    // The temporary canvas where renderPage paints one page at a time.
+    this.scratchCanvas = document.createElement("canvas");
+  }
 
-PDFPrintService.prototype = {
   layout() {
     this.throwIfInactive();
 
@@ -114,7 +114,7 @@ PDFPrintService.prototype = {
     this.pageStyleSheet = document.createElement("style");
     this.pageStyleSheet.textContent = `@page { size: ${width}pt ${height}pt;}`;
     body.append(this.pageStyleSheet);
-  },
+  }
 
   destroy() {
     if (activeService !== this) {
@@ -139,7 +139,7 @@ PDFPrintService.prototype = {
         overlayManager.close(dialog);
       }
     });
-  },
+  }
 
   renderPages() {
     if (this.pdfDocument.isPureXfa) {
@@ -172,7 +172,7 @@ PDFPrintService.prototype = {
         }, reject);
     };
     return new Promise(renderNextPage);
-  },
+  }
 
   useRenderedPage() {
     this.throwIfInactive();
@@ -195,7 +195,7 @@ PDFPrintService.prototype = {
       img.onload = resolve;
       img.onerror = reject;
     });
-  },
+  }
 
   performPrint() {
     this.throwIfInactive();
@@ -213,18 +213,18 @@ PDFPrintService.prototype = {
         setTimeout(resolve, 20); // Tidy-up.
       }, 0);
     });
-  },
+  }
 
   get active() {
     return this === activeService;
-  },
+  }
 
   throwIfInactive() {
     if (!this.active) {
       throw new Error("This print request was cancelled or completed.");
     }
-  },
-};
+  }
+}
 
 const print = window.print;
 window.print = function () {

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -92,16 +92,13 @@ PDFPrintService.prototype = {
     const body = document.querySelector("body");
     body.setAttribute("data-pdfjsprinting", true);
 
-    const hasEqualPageSizes = this.pagesOverview.every(function (size) {
-      return (
-        size.width === this.pagesOverview[0].width &&
-        size.height === this.pagesOverview[0].height
-      );
-    }, this);
+    const { width, height } = this.pagesOverview[0];
+    const hasEqualPageSizes = this.pagesOverview.every(
+      size => size.width === width && size.height === height
+    );
     if (!hasEqualPageSizes) {
       console.warn(
-        "Not all pages have the same size. The printed " +
-          "result may be incorrect!"
+        "Not all pages have the same size. The printed result may be incorrect!"
       );
     }
 
@@ -115,9 +112,7 @@ PDFPrintService.prototype = {
     // will be ignored and the user has to select the correct paper size in
     // the UI if wanted.
     this.pageStyleSheet = document.createElement("style");
-    const pageSize = this.pagesOverview[0];
-    this.pageStyleSheet.textContent =
-      "@page { size: " + pageSize.width + "pt " + pageSize.height + "pt;}";
+    this.pageStyleSheet.textContent = `@page { size: ${width}pt ${height}pt;}`;
     body.append(this.pageStyleSheet);
   },
 


### PR DESCRIPTION
 - Slightly modernize the print `layout`-methods

   By getting the width/height of the first page initially, we can slightly reduce the amount of code needed both in the `hasEqualPageSizes`-check and when building the print-styles.

 - Convert `FirefoxPrintService` and `PDFPrintService` into standard classes

   Note that both of the affected files are old enough to predate the general availability of `class`.