### PR TITLE
Limit the `Path2D`-checks in the worker-thread to Node.js (PR 16238 follow-up, issue 16289)

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -134,7 +134,7 @@ class WorkerMessageHandler {
       // a non-translated/non-polyfilled build of the library, since that would
       // quickly fail anyway because of missing functionality.
       if (
-        typeof Path2D === "undefined" ||
+        (isNodeJS && typeof Path2D === "undefined") ||
         typeof ReadableStream === "undefined"
       ) {
         const partialMsg =


### PR DESCRIPTION
The changes in PR #16238 were intended specifically for Node.js environments, however they accidentally applied to older browsers as well.

*Please note:* In up-to-date browsers `Path2D` is available in Workers, which should be connected to the introduction of `OffscreenCanvas`.