### PR TITLE
Avoid when it's possible to use Array.concat when compiling a CFF font

### DIFF
--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -1383,7 +1383,13 @@ class CFFCompiler {
       data: [],
       length: 0,
       add(data) {
-        this.data = this.data.concat(data);
+        if (data.length <= 65536) {
+          // The number of arguments is limited, hence we just take 65536 as
+          // limit because it isn't too high or too low.
+          this.data.push(...data);
+        } else {
+          this.data = this.data.concat(data);
+        }
         this.length = this.data.length;
       },
     };


### PR DESCRIPTION
In looking at https://bugs.ghostscript.com/show_bug.cgi?id=706451 I noticed that bug2.pdf was pretty slow to load for such a basic file.
In profiling I noticed that a lot of time is spent in Array.concat, hence this patch use Array.push when it's possible (it's now ~3 times faster).