### PR TITLE
Remove `CFFCompiler.compileGlobalSubrIndex`, and simplify `CFFCompiler.compileTypedArray`

### DIFF
--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -1845,11 +1845,7 @@ class CFFCompiler {
   }
 
   compileTypedArray(data) {
-    const out = [];
-    for (let i = 0, ii = data.length; i < ii; ++i) {
-      out[i] = data[i];
-    }
-    return out;
+    return Array.from(data);
   }
 
   compileIndex(index, trackers = []) {

--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -1742,11 +1742,6 @@ class CFFCompiler {
     return this.compileIndex(stringIndex);
   }
 
-  compileGlobalSubrIndex() {
-    const globalSubrIndex = this.cff.globalSubrIndex;
-    this.out.writeByteArray(this.compileIndex(globalSubrIndex));
-  }
-
   compileCharStrings(charStrings) {
     const charStringsIndex = new CFFIndex();
     for (let i = 0; i < charStrings.count; i++) {


### PR DESCRIPTION
 - **Remove `CFFCompiler.compileGlobalSubrIndex` since it's completely unused**

   This method was originally added in PR #1320, eleven years ago, however it doesn't appear to ever have been used (not even from the start).
   Furthermore, this method also tries to access a property that doesn't exist (`this.out`) and then call a method that also doesn't exist (`writeByteArray`).

 - **Simplify the `CFFCompiler.compileTypedArray` method**

   Rather than manually creating the Array, we can use the now existing `Array.from` method instead.