### PR TITLE
Update TypeScript to version `5`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "terser": "^5.16.8",
         "through2": "^4.0.2",
         "ttest": "^4.0.0",
-        "typescript": "^4.9.5",
+        "typescript": "^5.0.4",
         "typogr": "^0.6.8",
         "vinyl": "^3.0.0",
         "vinyl-fs": "^3.0.3",
@@ -17852,16 +17852,16 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/typogr": {
@@ -32750,9 +32750,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true
     },
     "typogr": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "terser": "^5.16.8",
     "through2": "^4.0.2",
     "ttest": "^4.0.0",
-    "typescript": "^4.9.5",
+    "typescript": "^5.0.4",
     "typogr": "^0.6.8",
     "vinyl": "^3.0.0",
     "vinyl-fs": "^3.0.3",


### PR DESCRIPTION
Note that this is a major version increase, however the `gulp types` and `gulp typestest` tasks seem to work as-is; please see https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/