### PR TITLE
Remove the `PRODUCTION` build-target

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -96,7 +96,6 @@ const AUTOPREFIXER_CONFIG = {
 const BABEL_TARGETS = ENV_TARGETS.join(", ");
 
 const DEFINES = Object.freeze({
-  PRODUCTION: true,
   SKIP_BABEL: true,
   TESTING: undefined,
   // The main build targets:

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -797,10 +797,7 @@ class Annotation {
    * @param {Dict} borderStyle - The border style dictionary
    */
   setBorderStyle(borderStyle) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(this.rectangle, "setRectangle must have been called previously.");
     }
 
@@ -1062,8 +1059,7 @@ class Annotation {
    */
   reset() {
     if (
-      (typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("!PRODUCTION || TESTING")) &&
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
       this.appearance &&
       !this._streams.includes(this.appearance)
     ) {
@@ -1161,10 +1157,7 @@ class AnnotationBorderStyle {
    * @param {Array} rect - The annotation `Rect` entry.
    */
   setWidth(width, rect = [0, 0, 0, 0]) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         Array.isArray(rect) && rect.length === 4,
         "A valid `rect` parameter must be provided."
@@ -2381,10 +2374,7 @@ class WidgetAnnotation extends Annotation {
    * @private
    */
   _getSaveFieldResources(xref) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         this.data.defaultAppearanceData,
         "Expected `_defaultAppearanceData` to have been set."

--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -295,10 +295,7 @@ class ChunkedStreamManager {
             resolve(chunkData);
             return;
           }
-          if (
-            typeof PDFJSDev === "undefined" ||
-            PDFJSDev.test("!PRODUCTION || TESTING")
-          ) {
+          if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
             assert(
               value instanceof ArrayBuffer,
               "readChunk (sendRequest) - expected an ArrayBuffer."

--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -140,10 +140,7 @@ class ColorSpace {
     comps,
     alpha01
   ) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         dest instanceof Uint8ClampedArray,
         'ColorSpace.fillRgb: Unsupported "dest" type.'
@@ -326,10 +323,7 @@ class ColorSpace {
     pdfFunctionFactory,
     localColorSpaceCache,
   }) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         !this.getCached(cs, xref, localColorSpaceCache),
         "Expected `ColorSpace.getCached` to have been manually checked " +
@@ -551,10 +545,7 @@ class AlternateCS extends ColorSpace {
   }
 
   getRgbItem(src, srcOffset, dest, destOffset) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         dest instanceof Uint8ClampedArray,
         'AlternateCS.getRgbItem: Unsupported "dest" type.'
@@ -566,10 +557,7 @@ class AlternateCS extends ColorSpace {
   }
 
   getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         dest instanceof Uint8ClampedArray,
         'AlternateCS.getRgbBuffer: Unsupported "dest" type.'
@@ -656,10 +644,7 @@ class IndexedCS extends ColorSpace {
   }
 
   getRgbItem(src, srcOffset, dest, destOffset) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         dest instanceof Uint8ClampedArray,
         'IndexedCS.getRgbItem: Unsupported "dest" type.'
@@ -671,10 +656,7 @@ class IndexedCS extends ColorSpace {
   }
 
   getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         dest instanceof Uint8ClampedArray,
         'IndexedCS.getRgbBuffer: Unsupported "dest" type.'
@@ -721,10 +703,7 @@ class DeviceGrayCS extends ColorSpace {
   }
 
   getRgbItem(src, srcOffset, dest, destOffset) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         dest instanceof Uint8ClampedArray,
         'DeviceGrayCS.getRgbItem: Unsupported "dest" type.'
@@ -735,10 +714,7 @@ class DeviceGrayCS extends ColorSpace {
   }
 
   getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         dest instanceof Uint8ClampedArray,
         'DeviceGrayCS.getRgbBuffer: Unsupported "dest" type.'
@@ -770,10 +746,7 @@ class DeviceRgbCS extends ColorSpace {
   }
 
   getRgbItem(src, srcOffset, dest, destOffset) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         dest instanceof Uint8ClampedArray,
         'DeviceRgbCS.getRgbItem: Unsupported "dest" type.'
@@ -785,10 +758,7 @@ class DeviceRgbCS extends ColorSpace {
   }
 
   getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         dest instanceof Uint8ClampedArray,
         'DeviceRgbCS.getRgbBuffer: Unsupported "dest" type.'
@@ -894,10 +864,7 @@ const DeviceCmykCS = (function DeviceCmykCSClosure() {
     }
 
     getRgbItem(src, srcOffset, dest, destOffset) {
-      if (
-        typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("!PRODUCTION || TESTING")
-      ) {
+      if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
         assert(
           dest instanceof Uint8ClampedArray,
           'DeviceCmykCS.getRgbItem: Unsupported "dest" type.'
@@ -907,10 +874,7 @@ const DeviceCmykCS = (function DeviceCmykCSClosure() {
     }
 
     getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
-      if (
-        typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("!PRODUCTION || TESTING")
-      ) {
+      if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
         assert(
           dest instanceof Uint8ClampedArray,
           'DeviceCmykCS.getRgbBuffer: Unsupported "dest" type.'
@@ -1008,10 +972,7 @@ const CalGrayCS = (function CalGrayCSClosure() {
     }
 
     getRgbItem(src, srcOffset, dest, destOffset) {
-      if (
-        typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("!PRODUCTION || TESTING")
-      ) {
+      if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
         assert(
           dest instanceof Uint8ClampedArray,
           'CalGrayCS.getRgbItem: Unsupported "dest" type.'
@@ -1021,10 +982,7 @@ const CalGrayCS = (function CalGrayCSClosure() {
     }
 
     getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
-      if (
-        typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("!PRODUCTION || TESTING")
-      ) {
+      if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
         assert(
           dest instanceof Uint8ClampedArray,
           'CalGrayCS.getRgbBuffer: Unsupported "dest" type.'
@@ -1317,10 +1275,7 @@ const CalRGBCS = (function CalRGBCSClosure() {
     }
 
     getRgbItem(src, srcOffset, dest, destOffset) {
-      if (
-        typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("!PRODUCTION || TESTING")
-      ) {
+      if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
         assert(
           dest instanceof Uint8ClampedArray,
           'CalRGBCS.getRgbItem: Unsupported "dest" type.'
@@ -1330,10 +1285,7 @@ const CalRGBCS = (function CalRGBCSClosure() {
     }
 
     getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
-      if (
-        typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("!PRODUCTION || TESTING")
-      ) {
+      if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
         assert(
           dest instanceof Uint8ClampedArray,
           'CalRGBCS.getRgbBuffer: Unsupported "dest" type.'
@@ -1484,10 +1436,7 @@ const LabCS = (function LabCSClosure() {
     }
 
     getRgbItem(src, srcOffset, dest, destOffset) {
-      if (
-        typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("!PRODUCTION || TESTING")
-      ) {
+      if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
         assert(
           dest instanceof Uint8ClampedArray,
           'LabCS.getRgbItem: Unsupported "dest" type.'
@@ -1497,10 +1446,7 @@ const LabCS = (function LabCSClosure() {
     }
 
     getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
-      if (
-        typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("!PRODUCTION || TESTING")
-      ) {
+      if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
         assert(
           dest instanceof Uint8ClampedArray,
           'LabCS.getRgbBuffer: Unsupported "dest" type.'

--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -86,10 +86,7 @@ class XRefParseException extends BaseException {
  * @returns {Uint8Array}
  */
 function arrayBuffersToBytes(arr) {
-  if (
-    typeof PDFJSDev === "undefined" ||
-    PDFJSDev.test("!PRODUCTION || TESTING")
-  ) {
+  if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
     for (const item of arr) {
       assert(
         item instanceof ArrayBuffer,

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -698,10 +698,7 @@ const EMPTY_FINGERPRINT =
   "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
 
 function find(stream, signature, limit = 1024, backwards = false) {
-  if (
-    typeof PDFJSDev === "undefined" ||
-    PDFJSDev.test("!PRODUCTION || TESTING")
-  ) {
+  if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
     assert(limit > 0, 'The "limit" must be a positive integer.');
   }
   const signatureLength = signature.length;
@@ -755,10 +752,7 @@ function find(stream, signature, limit = 1024, backwards = false) {
  */
 class PDFDocument {
   constructor(pdfManager, stream) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         stream instanceof BaseStream,
         'PDFDocument: Invalid "stream" argument.'
@@ -1419,10 +1413,7 @@ class PDFDocument {
 
   async _getLinearizationPage(pageIndex) {
     const { catalog, linearization, xref } = this;
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         linearization && linearization.pageFirst === pageIndex,
         "_getLinearizationPage - invalid pageIndex argument."

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -4508,10 +4508,7 @@ class TranslatedFont {
    * @private
    */
   _removeType3ColorOperators(operatorList, fontBBoxSize = NaN) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         operatorList.fnArray[0] === OPS.setCharWidthAndBounds,
         "Type3 glyph shall start with the d1 operator."

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -316,10 +316,7 @@ function int32(b0, b1, b2, b3) {
 }
 
 function string16(value) {
-  if (
-    typeof PDFJSDev === "undefined" ||
-    PDFJSDev.test("!PRODUCTION || TESTING")
-  ) {
+  if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
     assert(
       typeof value === "number" && Math.abs(value) < 2 ** 16,
       `string16: Unexpected input "${value}".`
@@ -329,10 +326,7 @@ function string16(value) {
 }
 
 function safeString16(value) {
-  if (
-    typeof PDFJSDev === "undefined" ||
-    PDFJSDev.test("!PRODUCTION || TESTING")
-  ) {
+  if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
     assert(
       typeof value === "number" && !Number.isNaN(value),
       `safeString16: Unexpected input "${value}".`

--- a/src/core/image.js
+++ b/src/core/image.js
@@ -564,10 +564,7 @@ class PDFImage {
   }
 
   fillOpacity(rgbaBuf, width, height, actualHeight, image) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         rgbaBuf instanceof Uint8ClampedArray,
         'PDFImage.fillOpacity: Unsupported "rgbaBuf" type.'
@@ -637,10 +634,7 @@ class PDFImage {
   }
 
   undoPreblend(buffer, width, height) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         buffer instanceof Uint8ClampedArray,
         'PDFImage.undoPreblend: Unsupported "buffer" type.'
@@ -893,10 +887,7 @@ class PDFImage {
   }
 
   fillGrayBuffer(buffer) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         buffer instanceof Uint8ClampedArray,
         'PDFImage.fillGrayBuffer: Unsupported "buffer" type.'

--- a/src/core/image_utils.js
+++ b/src/core/image_utils.js
@@ -186,10 +186,7 @@ class GlobalImageCache {
   }
 
   constructor() {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         GlobalImageCache.NUM_PAGES_THRESHOLD > 1,
         "GlobalImageCache - invalid NUM_PAGES_THRESHOLD constant."

--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -1528,10 +1528,7 @@ class JpegImage {
     forceRGB = false,
     isSourcePDF = false,
   }) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         isSourcePDF === true,
         'JpegImage.getData: Unexpected "isSourcePDF" value for PDF files.'

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -202,10 +202,7 @@ class Parser {
       } else if (state === 1) {
         state = ch === I ? 2 : 0;
       } else {
-        if (
-          typeof PDFJSDev === "undefined" ||
-          PDFJSDev.test("!PRODUCTION || TESTING")
-        ) {
+        if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
           assert(state === 2, "findDefaultInlineStreamEnd - invalid state.");
         }
         if (ch === SPACE || ch === LF || ch === CR) {

--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -25,8 +25,7 @@ const Name = (function NameClosure() {
   class Name {
     constructor(name) {
       if (
-        (typeof PDFJSDev === "undefined" ||
-          PDFJSDev.test("!PRODUCTION || TESTING")) &&
+        (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
         typeof name !== "string"
       ) {
         unreachable('Name: The "name" must be a string.');
@@ -54,8 +53,7 @@ const Cmd = (function CmdClosure() {
   class Cmd {
     constructor(cmd) {
       if (
-        (typeof PDFJSDev === "undefined" ||
-          PDFJSDev.test("!PRODUCTION || TESTING")) &&
+        (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
         typeof cmd !== "string"
       ) {
         unreachable('Cmd: The "cmd" must be a string.');
@@ -103,8 +101,7 @@ class Dict {
     let value = this._map[key1];
     if (value === undefined && key2 !== undefined) {
       if (
-        (typeof PDFJSDev === "undefined" ||
-          PDFJSDev.test("!PRODUCTION || TESTING")) &&
+        (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
         key2.length < key1.length
       ) {
         unreachable("Dict.get: Expected keys to be ordered by length.");
@@ -112,8 +109,7 @@ class Dict {
       value = this._map[key2];
       if (value === undefined && key3 !== undefined) {
         if (
-          (typeof PDFJSDev === "undefined" ||
-            PDFJSDev.test("!PRODUCTION || TESTING")) &&
+          (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
           key3.length < key2.length
         ) {
           unreachable("Dict.get: Expected keys to be ordered by length.");
@@ -132,8 +128,7 @@ class Dict {
     let value = this._map[key1];
     if (value === undefined && key2 !== undefined) {
       if (
-        (typeof PDFJSDev === "undefined" ||
-          PDFJSDev.test("!PRODUCTION || TESTING")) &&
+        (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
         key2.length < key1.length
       ) {
         unreachable("Dict.getAsync: Expected keys to be ordered by length.");
@@ -141,8 +136,7 @@ class Dict {
       value = this._map[key2];
       if (value === undefined && key3 !== undefined) {
         if (
-          (typeof PDFJSDev === "undefined" ||
-            PDFJSDev.test("!PRODUCTION || TESTING")) &&
+          (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
           key3.length < key2.length
         ) {
           unreachable("Dict.getAsync: Expected keys to be ordered by length.");
@@ -161,8 +155,7 @@ class Dict {
     let value = this._map[key1];
     if (value === undefined && key2 !== undefined) {
       if (
-        (typeof PDFJSDev === "undefined" ||
-          PDFJSDev.test("!PRODUCTION || TESTING")) &&
+        (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
         key2.length < key1.length
       ) {
         unreachable("Dict.getArray: Expected keys to be ordered by length.");
@@ -170,8 +163,7 @@ class Dict {
       value = this._map[key2];
       if (value === undefined && key3 !== undefined) {
         if (
-          (typeof PDFJSDev === "undefined" ||
-            PDFJSDev.test("!PRODUCTION || TESTING")) &&
+          (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
           key3.length < key2.length
         ) {
           unreachable("Dict.getArray: Expected keys to be ordered by length.");
@@ -209,10 +201,7 @@ class Dict {
   }
 
   set(key, value) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       if (typeof key !== "string") {
         unreachable('Dict.set: The "key" must be a string.');
       } else if (value === undefined) {
@@ -325,8 +314,7 @@ const Ref = (function RefClosure() {
 class RefSet {
   constructor(parent = null) {
     if (
-      (typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("!PRODUCTION || TESTING")) &&
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
       parent &&
       !(parent instanceof RefSet)
     ) {
@@ -405,10 +393,7 @@ function isDict(v, type) {
 }
 
 function isRefsEqual(v1, v2) {
-  if (
-    typeof PDFJSDev === "undefined" ||
-    PDFJSDev.test("!PRODUCTION || TESTING")
-  ) {
+  if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
     assert(
       v1 instanceof Ref && v2 instanceof Ref,
       "isRefsEqual: Both parameters should be `Ref`s."

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -309,10 +309,7 @@ class WorkerMessageHandler {
               cancelXHRs = null;
               return;
             }
-            if (
-              typeof PDFJSDev === "undefined" ||
-              PDFJSDev.test("!PRODUCTION || TESTING")
-            ) {
+            if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
               assert(
                 value instanceof ArrayBuffer,
                 "readChunk (getPdfManager) - expected an ArrayBuffer."

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -873,10 +873,7 @@ class XRef {
       xrefEntry = parser.getObj();
     }
     if (!(xrefEntry instanceof BaseStream)) {
-      if (
-        typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("!PRODUCTION || TESTING")
-      ) {
+      if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
         assert(
           xrefEntry !== undefined,
           'fetchUncompressed: The "xrefEntry" cannot be undefined.'
@@ -947,10 +944,7 @@ class XRef {
       const num = nums[i],
         entry = this.entries[num];
       if (entry && entry.offset === tableOffset && entry.gen === i) {
-        if (
-          typeof PDFJSDev === "undefined" ||
-          PDFJSDev.test("!PRODUCTION || TESTING")
-        ) {
+        if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
           assert(
             obj !== undefined,
             'fetchCompressed: The "obj" cannot be undefined.'

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -489,10 +489,7 @@ class AnnotationElement {
    * @returns {Array<HTMLElement>} An array of section elements.
    */
   _renderQuadrilaterals(className) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(this.quadrilaterals, "Missing quadrilaterals during rendering");
     }
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -89,7 +89,7 @@ if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("GENERIC") && isNodeJS) {
 }
 
 let createPDFNetworkStream;
-if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
+if (typeof PDFJSDev === "undefined") {
   const streamsPromise = Promise.all([
     import("./network.js"),
     import("./fetch_stream.js"),
@@ -1793,10 +1793,7 @@ class PDFPageProxy {
    * @private
    */
   _pumpOperatorList({ renderingIntent, cacheKey, annotationStorageMap }) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         Number.isInteger(renderingIntent) && renderingIntent > 0,
         '_pumpOperatorList: Expected valid "renderingIntent" argument.'
@@ -1863,10 +1860,7 @@ class PDFPageProxy {
    * @private
    */
   _abortOperatorList({ intentState, reason, force = false }) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         reason instanceof Error,
         '_abortOperatorList: Expected valid "reason" argument.'
@@ -2133,7 +2127,7 @@ class PDFWorker {
         // Some versions of FF can't create a worker on localhost, see:
         // https://bugzilla.mozilla.org/show_bug.cgi?id=683280
         const worker =
-          (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) &&
+          typeof PDFJSDev === "undefined" &&
           !workerSrc.endsWith("/build/pdf.worker.js") &&
           !workerSrc.endsWith("/src/worker_loader.js")
             ? new Worker(workerSrc, { type: "module" })
@@ -2324,7 +2318,7 @@ class PDFWorker {
         // The worker was already loaded using e.g. a `<script>` tag.
         return mainWorkerMessageHandler;
       }
-      if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
+      if (typeof PDFJSDev === "undefined") {
         const worker = await import("pdfjs/pdf.worker.js");
         return worker.WorkerMessageHandler;
       }

--- a/src/display/editor/freetext.js
+++ b/src/display/editor/freetext.js
@@ -85,10 +85,7 @@ class FreeTextEditor extends AnnotationEditor {
 
     const style = getComputedStyle(document.documentElement);
 
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       const lineHeight = parseFloat(
         style.getPropertyValue("--freetext-line-height")
       );

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -32,7 +32,7 @@ class FontLoader {
 
     this.nativeFontFaces = [];
     this.styleElement =
-      typeof PDFJSDev === "undefined" || PDFJSDev.test("!PRODUCTION || TESTING")
+      typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")
         ? styleElement
         : null;
 
@@ -116,10 +116,7 @@ class FontLoader {
 
   get isFontLoadingAPISupported() {
     const hasFonts = !!this._document?.fonts;
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       return shadow(
         this,
         "isFontLoadingAPISupported",

--- a/src/display/network_utils.js
+++ b/src/display/network_utils.js
@@ -27,10 +27,7 @@ function validateRangeRequestCapabilities({
   rangeChunkSize,
   disableRange,
 }) {
-  if (
-    typeof PDFJSDev === "undefined" ||
-    PDFJSDev.test("!PRODUCTION || TESTING")
-  ) {
+  if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
     assert(
       Number.isInteger(rangeChunkSize) && rangeChunkSize > 0,
       "rangeChunkSize must be an integer larger than zero."

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -34,10 +34,7 @@ let SVGGraphics = class {
   }
 };
 
-if (
-  typeof PDFJSDev === "undefined" ||
-  PDFJSDev.test("!PRODUCTION || GENERIC")
-) {
+if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
   const SVG_DEFAULTS = {
     fontStyle: "normal",
     fontWeight: "normal",

--- a/src/pdf.sandbox.js
+++ b/src/pdf.sandbox.js
@@ -55,12 +55,12 @@ class Sandbox {
   }
 
   create(data) {
-    if (PDFJSDev.test("!PRODUCTION || TESTING")) {
+    if (PDFJSDev.test("TESTING")) {
       this._module.ccall("nukeSandbox", null, []);
     }
     const code = [PDFJSDev.eval("PDF_SCRIPTING_JS_SOURCE")];
 
-    if (PDFJSDev.test("!PRODUCTION || TESTING")) {
+    if (PDFJSDev.test("TESTING")) {
       code.push(
         `globalThis.sendResultForTesting = callExternalFunction.bind(null, "send");`
       );
@@ -122,7 +122,7 @@ class Sandbox {
   }
 
   evalForTesting(code, key) {
-    if (PDFJSDev.test("!PRODUCTION || TESTING")) {
+    if (PDFJSDev.test("TESTING")) {
       this._module.ccall(
         "evalInSandbox",
         null,

--- a/src/shared/message_handler.js
+++ b/src/shared/message_handler.js
@@ -149,10 +149,7 @@ class MessageHandler {
   }
 
   on(actionName, handler) {
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || TESTING")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         typeof handler === "function",
         'MessageHandler.on: Expected "handler" to be a function.'

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -452,10 +452,7 @@ function createValidAbsoluteUrl(url, baseUrl = null, options = null) {
 }
 
 function shadow(obj, prop, value, nonSerializable = false) {
-  if (
-    typeof PDFJSDev === "undefined" ||
-    PDFJSDev.test("!PRODUCTION || TESTING")
-  ) {
+  if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
     assert(
       prop in obj,
       `shadow: Property "${prop && prop.toString()}" not found in object.`
@@ -574,10 +571,7 @@ function stringToBytes(str) {
 }
 
 function string32(value) {
-  if (
-    typeof PDFJSDev === "undefined" ||
-    PDFJSDev.test("!PRODUCTION || TESTING")
-  ) {
+  if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
     assert(
       typeof value === "number" && Math.abs(value) < 2 ** 32,
       `string32: Unexpected input "${value}".`

--- a/web/app.js
+++ b/web/app.js
@@ -310,7 +310,7 @@ const PDFViewerApplication = {
       params = parseQueryString(hash);
 
     if (
-      (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) &&
+      typeof PDFJSDev === "undefined" &&
       params.get("workermodules") === "true"
     ) {
       AppOptions.set("workerSrc", "../src/pdf.worker.js");
@@ -377,8 +377,7 @@ const PDFViewerApplication = {
     }
     // It is not possible to change locale for the (various) extension builds.
     if (
-      (typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("!PRODUCTION || GENERIC")) &&
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&
       params.has("locale")
     ) {
       AppOptions.set("locale", params.get("locale"));
@@ -390,7 +389,7 @@ const PDFViewerApplication = {
    */
   async _initializeL10n() {
     this.l10n = this.externalServices.createL10n(
-      typeof PDFJSDev === "undefined" || PDFJSDev.test("!PRODUCTION || GENERIC")
+      typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")
         ? { locale: AppOptions.get("locale") }
         : null
     );
@@ -480,8 +479,7 @@ const PDFViewerApplication = {
     const pdfScriptingManager = new PDFScriptingManager({
       eventBus,
       sandboxBundleSrc:
-        typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("!PRODUCTION || GENERIC || CHROME")
+        typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC || CHROME")
           ? AppOptions.get("sandboxBundleSrc")
           : null,
       scriptingFactory: externalServices,
@@ -959,7 +957,7 @@ const PDFViewerApplication = {
       ...args,
     };
 
-    if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
+    if (typeof PDFJSDev === "undefined") {
       params.docBaseUrl ||= document.URL.split("#")[0];
     } else if (PDFJSDev.test("MOZCENTRAL || CHROME")) {
       params.docBaseUrl ||= this.baseUrl;
@@ -2159,7 +2157,7 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
 async function loadFakeWorker() {
   GlobalWorkerOptions.workerSrc ||= AppOptions.get("workerSrc");
 
-  if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
+  if (typeof PDFJSDev === "undefined") {
     window.pdfjsWorker = await import("pdfjs/pdf.worker.js");
     return;
   }
@@ -2169,7 +2167,7 @@ async function loadFakeWorker() {
 async function loadPDFBug(self) {
   const { debuggerScriptPath } = self.appConfig;
   const { PDFBug } =
-    typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")
+    typeof PDFJSDev === "undefined"
       ? await import(debuggerScriptPath) // eslint-disable-line no-unsanitized/method
       : await __non_webpack_import__(debuggerScriptPath); // eslint-disable-line no-undef
 

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -158,7 +158,7 @@ const defaultOptions = {
   },
   pdfBugEnabled: {
     /** @type {boolean} */
-    value: typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION"),
+    value: typeof PDFJSDev === "undefined",
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
   printResolution: {
@@ -210,9 +210,7 @@ const defaultOptions = {
   cMapUrl: {
     /** @type {string} */
     value:
-      typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")
-        ? "../external/bcmaps/"
-        : "../web/cmaps/",
+      typeof PDFJSDev === "undefined" ? "../external/bcmaps/" : "../web/cmaps/",
     kind: OptionKind.API,
   },
   disableAutoFetch: {
@@ -273,7 +271,7 @@ const defaultOptions = {
   standardFontDataUrl: {
     /** @type {string} */
     value:
-      typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")
+      typeof PDFJSDev === "undefined"
         ? "../external/standard_fonts/"
         : "../web/standard_fonts/",
     kind: OptionKind.API,
@@ -293,7 +291,7 @@ const defaultOptions = {
     /** @type {string} */
     value:
       // eslint-disable-next-line no-nested-ternary
-      typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")
+      typeof PDFJSDev === "undefined"
         ? "../src/worker_loader.js"
         : PDFJSDev.test("MOZCENTRAL")
         ? "resource://pdf.js/build/pdf.worker.js"
@@ -301,10 +299,7 @@ const defaultOptions = {
     kind: OptionKind.WORKER,
   },
 };
-if (
-  typeof PDFJSDev === "undefined" ||
-  PDFJSDev.test("!PRODUCTION || GENERIC")
-) {
+if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
   defaultOptions.defaultUrl = {
     /** @type {string} */
     value: "compressed.tracemonkey-pldi-09.pdf",
@@ -323,7 +318,7 @@ if (
   defaultOptions.sandboxBundleSrc = {
     /** @type {string} */
     value:
-      typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")
+      typeof PDFJSDev === "undefined"
         ? "../build/dev-sandbox/pdf.sandbox.js"
         : "../build/pdf.sandbox.js",
     kind: OptionKind.VIEWER,

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -165,10 +165,7 @@ class PDFPageView {
 
     this.renderTask = null;
     this.resume = null;
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || GENERIC")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       this._isStandalone = !this.renderingQueue?.hasViewer();
     }
 
@@ -194,8 +191,7 @@ class PDFPageView {
     container?.append(div);
 
     if (
-      (typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("!PRODUCTION || GENERIC")) &&
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&
       this._isStandalone
     ) {
       // Ensure that the various layers always get the correct initial size,
@@ -548,8 +544,7 @@ class PDFPageView {
     this.#setDimensions();
 
     if (
-      (typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("!PRODUCTION || GENERIC")) &&
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&
       this._isStandalone
     ) {
       this.div.parentNode?.style.setProperty(
@@ -686,8 +681,7 @@ class PDFPageView {
   }) {
     // Scale target (canvas), its wrapper and page container.
     if (
-      (typeof PDFJSDev === "undefined" ||
-        PDFJSDev.test("!PRODUCTION || TESTING")) &&
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
       !(target instanceof HTMLCanvasElement)
     ) {
       throw new Error("Expected `target` to be a canvas.");

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -240,10 +240,7 @@ class PDFViewer {
     this.container = options.container;
     this.viewer = options.viewer || options.container.firstElementChild;
 
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || GENERIC")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       if (this.container?.tagName !== "DIV" || this.viewer?.tagName !== "DIV") {
         throw new Error("Invalid `container` and/or `viewer` option.");
       }
@@ -274,10 +271,7 @@ class PDFViewer {
       options.annotationEditorMode ?? AnnotationEditorType.NONE;
     this.imageResourcesPath = options.imageResourcesPath || "";
     this.enablePrintAutoRotate = options.enablePrintAutoRotate || false;
-    if (
-      typeof PDFJSDev === "undefined" ||
-      PDFJSDev.test("!PRODUCTION || GENERIC")
-    ) {
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       this.removePageBorders = options.removePageBorders || false;
     }
     this.useOnlyCssZoom = options.useOnlyCssZoom || false;

--- a/web/preferences.js
+++ b/web/preferences.js
@@ -22,7 +22,7 @@ import { AppOptions, OptionKind } from "./app_options.js";
  */
 class BasePreferences {
   #defaults = Object.freeze(
-    typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")
+    typeof PDFJSDev === "undefined"
       ? AppOptions.getAll(OptionKind.PREFERENCE)
       : PDFJSDev.eval("DEFAULT_PREFERENCES")
   );

--- a/web/viewer-geckoview.js
+++ b/web/viewer-geckoview.js
@@ -64,7 +64,7 @@ function getViewerConfiguration() {
 function webViewerLoad() {
   const config = getViewerConfiguration();
 
-  if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("PRODUCTION")) {
+  if (typeof PDFJSDev === "undefined") {
     window.isGECKOVIEW = true;
   }
   PDFViewerApplication.run(config);

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -49,7 +49,7 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!--<script src="resource://pdf.js/web/viewer.js"></script>-->
 <!--#elif !MINIFIED-->
 <!--<script src="viewer.js"></script>-->
-<!--#elif !PRODUCTION-->
+<!--#elif /* Development mode. */-->
     <link rel="resource" type="application/l10n" href="locale/locale.properties">
 
     <script defer src="../node_modules/es-module-shims/dist/es-module-shims.js"></script>


### PR DESCRIPTION
 - **Stop using the `PRODUCTION` build-target in the JavaScript code**

   This *special* build-target is very old, and was introduced with the first pre-processor that only uses comments to enable/disable code.
   When the new pre-processor was added `PRODUCTION` effectively became redundant, at least in JavaScript code, since `typeof PDFJSDev === "undefined"` checks now do the same thing.

   This patch proposes that we remove `PRODUCTION` from the JavaScript code, since that simplifies the conditions and thus improves readability in many cases.
   *Please note:* There's not, nor has there ever been, any gulp-task that set `PRODUCTION = false` during building.

 - **Remove the remaining `PRODUCTION` build-target usage**

   After the previous patch we now have only *a single* `PRODUCTION` occurrence in the entire code-base, more specifically in the `web/viewer.html` file.
   This special build-target can be replaced with any condition that always evaluate to `false`, such as e.g. a comment.

   *Please note:* This patch might be considered too hacky, hence I completely understand if it's rejected.