### PR TITLE
Compatible with ResizeObserver borderBoxSize in legacy safari

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -2169,7 +2169,14 @@ class PDFViewer {
     for (const entry of entries) {
       if (entry.target === this.container) {
         this.#updateContainerHeightCss(
-          Math.floor(entry.borderBoxSize[0].blockSize)
+          // Safari doesn't support `borderBoxSize` until version 15.4.
+          Math.floor(
+            typeof PDFJSDev !== "undefined" &&
+              !PDFJSDev.test("SKIP_BABEL") &&
+              !entry.borderBoxSize?.length
+              ? entry.contentRect.height
+              : entry.borderBoxSize[0].blockSize
+          )
         );
         this.#containerTopLeft = null;
         break;


### PR DESCRIPTION
docs: 
https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry/borderBoxSize#browser_compatibility

error: 
![image](https://user-images.githubusercontent.com/47104575/232688765-3066d44f-9b9f-4dfa-be6a-8ab3379c11c5.png)
