### PR TITLE
Introduce some `:is` usage in the debugger CSS

### DIFF
--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -137,8 +137,8 @@
   resize: horizontal;
 }
 
-.annotationEditorLayer .freeTextEditor:hover:not(.selectedEditor),
-.annotationEditorLayer .inkEditor:hover:not(.selectedEditor) {
+.annotationEditorLayer
+  :is(.freeTextEditor, .inkEditor):hover:not(.selectedEditor) {
   outline: var(--hover-outline);
 }
 

--- a/web/debugger.css
+++ b/web/debugger.css
@@ -14,9 +14,7 @@
  */
 
 #PDFBug,
-#PDFBug input,
-#PDFBug button,
-#PDFBug select {
+#PDFBug :is(input, button, select) {
   font: message-box;
 }
 #PDFBug {
@@ -67,8 +65,7 @@
   text-align: center;
 }
 #PDFBug table.showText,
-#PDFBug table.showText tr,
-#PDFBug table.showText td {
+#PDFBug table.showText :is(tr, td) {
   border: 1px solid black;
   padding: 1px;
 }


### PR DESCRIPTION
Also adds one more instance of `:is` in the `web/annotation_editor_layer_builder.css` file.