### PR TITLE
Update `eslint-plugin-mozilla` to avoid having to force-install packages (issue 15429)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2345,7 +2345,7 @@ gulp.task(
       opts.cwd = installPath;
       distPath = path.relative(installPath, distPath);
     }
-    safeSpawnSync("npm", ["install", "--force", distPath], opts);
+    safeSpawnSync("npm", ["install", distPath], opts);
     done();
   })
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "eslint-plugin-html": "^7.1.0",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-json": "^3.1.0",
-        "eslint-plugin-mozilla": "^3.0.1",
+        "eslint-plugin-mozilla": "^3.1.0",
         "eslint-plugin-no-unsanitized": "^4.0.2",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-sort-exports": "^0.8.0",
@@ -5705,18 +5705,18 @@
       }
     },
     "node_modules/eslint-plugin-mozilla": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mozilla/-/eslint-plugin-mozilla-3.0.1.tgz",
-      "integrity": "sha512-BmUszqAp/ssnoL9WXYQK+nQuuvmc3Sm7CoPmAoy6CYzb6wBFnq8PcTHT8MNKbp79YpLyLGqHIH5n1Ylrurcdgg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mozilla/-/eslint-plugin-mozilla-3.1.0.tgz",
+      "integrity": "sha512-ncYd3Z4UoPuoFqlC9UwyZHoMK5ADXqe25TeJpRh+ohuIefNFFL6qogom4jLMFwgQzUDru8jydpSZ2kHJdnBTIw==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.19.1",
+        "@babel/core": "^7.20.12",
         "@babel/eslint-parser": "^7.19.1",
         "eslint-scope": "^7.1.1",
         "eslint-visitor-keys": "^3.3.0",
         "estraverse": "^5.3.0",
         "htmlparser2": "^8.0.1",
-        "multi-ini": "^2.2.0"
+        "multi-ini": "^2.3.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -5727,9 +5727,7 @@
         "eslint-config-prettier": "^8.0.0",
         "eslint-plugin-fetch-options": "^0.0.5",
         "eslint-plugin-html": "^7.0.0",
-        "eslint-plugin-no-unsanitized": "^4.0.0",
-        "eslint-plugin-prettier": "^3.0.0",
-        "prettier": "^1.19.1"
+        "eslint-plugin-no-unsanitized": "^4.0.0"
       }
     },
     "node_modules/eslint-plugin-mozilla/node_modules/eslint-scope": {
@@ -9738,11 +9736,12 @@
       "dev": true
     },
     "node_modules/multi-ini": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/multi-ini/-/multi-ini-2.2.0.tgz",
-      "integrity": "sha512-RKNuYAX0LC+UfjRQSRC3QoV37vVxNhx32mGysN+aiiNfJzu4xIzGCtpAKwgFXqdmUdCFmX/VSfpHCS0ALNjasQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/multi-ini/-/multi-ini-2.3.2.tgz",
+      "integrity": "sha512-zuznIotGjtc8AXfWwX5/pfQI6JadxR/kN7zA1W8qqomk/7zKHMW54ik052dqV3bPzWLucysvPgJXEySsctUUWQ==",
       "dev": true,
       "dependencies": {
+        "@babel/runtime": "^7.0.0",
         "lodash": "^4.0.0"
       }
     },
@@ -23614,18 +23613,18 @@
       }
     },
     "eslint-plugin-mozilla": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mozilla/-/eslint-plugin-mozilla-3.0.1.tgz",
-      "integrity": "sha512-BmUszqAp/ssnoL9WXYQK+nQuuvmc3Sm7CoPmAoy6CYzb6wBFnq8PcTHT8MNKbp79YpLyLGqHIH5n1Ylrurcdgg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mozilla/-/eslint-plugin-mozilla-3.1.0.tgz",
+      "integrity": "sha512-ncYd3Z4UoPuoFqlC9UwyZHoMK5ADXqe25TeJpRh+ohuIefNFFL6qogom4jLMFwgQzUDru8jydpSZ2kHJdnBTIw==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.19.1",
+        "@babel/core": "^7.20.12",
         "@babel/eslint-parser": "^7.19.1",
         "eslint-scope": "^7.1.1",
         "eslint-visitor-keys": "^3.3.0",
         "estraverse": "^5.3.0",
         "htmlparser2": "^8.0.1",
-        "multi-ini": "^2.2.0"
+        "multi-ini": "^2.3.2"
       },
       "dependencies": {
         "eslint-scope": {
@@ -26470,11 +26469,12 @@
       "dev": true
     },
     "multi-ini": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/multi-ini/-/multi-ini-2.2.0.tgz",
-      "integrity": "sha512-RKNuYAX0LC+UfjRQSRC3QoV37vVxNhx32mGysN+aiiNfJzu4xIzGCtpAKwgFXqdmUdCFmX/VSfpHCS0ALNjasQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/multi-ini/-/multi-ini-2.3.2.tgz",
+      "integrity": "sha512-zuznIotGjtc8AXfWwX5/pfQI6JadxR/kN7zA1W8qqomk/7zKHMW54ik052dqV3bPzWLucysvPgJXEySsctUUWQ==",
       "dev": true,
       "requires": {
+        "@babel/runtime": "^7.0.0",
         "lodash": "^4.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "eslint-plugin-html": "^7.1.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-json": "^3.1.0",
-    "eslint-plugin-mozilla": "^3.0.1",
+    "eslint-plugin-mozilla": "^3.1.0",
     "eslint-plugin-no-unsanitized": "^4.0.2",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-sort-exports": "^0.8.0",


### PR DESCRIPTION
The latest version of `eslint-plugin-mozilla` removed the Prettier dependency, see https://bugzilla.mozilla.org/show_bug.cgi?id=1677562, which means that we no longer need to use `npm install --force` in the PDF.js library.