### PR TITLE
Allow text-selection, but not copying, when `enablePermissions` is set (PR 16320 follow-up)

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -122,6 +122,8 @@ class PDFPageView {
 
   #renderingState = RenderingStates.INITIAL;
 
+  #textLayerMode = TextLayerMode.ENABLE;
+
   #useThumbnailCanvas = {
     initialOptionalContent: true,
     regularAnnotations: true,
@@ -149,7 +151,7 @@ class PDFPageView {
     this._optionalContentConfigPromise =
       options.optionalContentConfigPromise || null;
     this.hasRestrictedScaling = false;
-    this.textLayerMode = options.textLayerMode ?? TextLayerMode.ENABLE;
+    this.#textLayerMode = options.textLayerMode ?? TextLayerMode.ENABLE;
     this.#annotationMode =
       options.annotationMode ?? AnnotationMode.ENABLE_FORMS;
     this.imageResourcesPath = options.imageResourcesPath || "";
@@ -798,7 +800,7 @@ class PDFPageView {
 
     if (
       !this.textLayer &&
-      this.textLayerMode !== TextLayerMode.DISABLE &&
+      this.#textLayerMode !== TextLayerMode.DISABLE &&
       !pdfPage.isPureXfa
     ) {
       this._accessibilityManager ||= new TextAccessibilityManager();
@@ -807,6 +809,8 @@ class PDFPageView {
         highlighter: this._textHighlighter,
         accessibilityManager: this._accessibilityManager,
         isOffscreenCanvasSupported: this.isOffscreenCanvasSupported,
+        enablePermissions:
+          this.#textLayerMode === TextLayerMode.ENABLE_PERMISSIONS,
       });
       div.append(this.textLayer.div);
     }

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -185,11 +185,6 @@
   display: none;
 }
 
-.pdfViewer.enablePermissions .textLayer span {
-  user-select: none !important;
-  cursor: not-allowed;
-}
-
 .pdfPresentationMode .pdfViewer {
   padding-bottom: 0;
 }

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -38,6 +38,8 @@ import { removeNullCharacters } from "./ui_utils.js";
  * contain text that matches the PDF text they are overlaying.
  */
 class TextLayerBuilder {
+  #enablePermissions = false;
+
   #rotation = 0;
 
   #scale = 0;
@@ -48,6 +50,7 @@ class TextLayerBuilder {
     highlighter = null,
     accessibilityManager = null,
     isOffscreenCanvasSupported = true,
+    enablePermissions = false,
   }) {
     this.textContentItemsStr = [];
     this.renderingDone = false;
@@ -57,6 +60,7 @@ class TextLayerBuilder {
     this.highlighter = highlighter;
     this.accessibilityManager = accessibilityManager;
     this.isOffscreenCanvasSupported = isOffscreenCanvasSupported;
+    this.#enablePermissions = enablePermissions === true;
 
     this.div = document.createElement("div");
     this.div.className = "textLayer";
@@ -215,11 +219,13 @@ class TextLayerBuilder {
     });
 
     div.addEventListener("copy", event => {
-      const selection = document.getSelection();
-      event.clipboardData.setData(
-        "text/plain",
-        removeNullCharacters(normalizeUnicode(selection.toString()))
-      );
+      if (!this.#enablePermissions) {
+        const selection = document.getSelection();
+        event.clipboardData.setData(
+          "text/plain",
+          removeNullCharacters(normalizeUnicode(selection.toString()))
+        );
+      }
       event.preventDefault();
       event.stopPropagation();
     });

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -49,6 +49,7 @@ const SidebarView = {
 const TextLayerMode = {
   DISABLE: 0,
   ENABLE: 1,
+  ENABLE_PERMISSIONS: 2,
 };
 
 const ScrollMode = {


### PR DESCRIPTION
This implements part of https://github.com/mozilla/pdf.js/pull/16320#issuecomment-1514690567, however any UI-integration is ignored for now since as mentioned in https://github.com/mozilla/pdf.js/pull/16320#issuecomment-1514711525 that'd really benefit from UX feedback.