### PR TITLE
Don't force-install packages in the CI job anymore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: npm install -g gulp-cli
 
       - name: Install other dependencies
-        run: npm install -f
+        run: npm install
 
       - name: Run tests
         run: gulp ci-test


### PR DESCRIPTION
In PR #16327 the `eslint-plugin-mozilla` package was updated so we no longer have to force-install packages, and the force install flags for `npm install` were removed. However, the CI job was missing from this commit, which we fix here. In general force-installing packages shouldn't be necessary unless there are problems with dependencies, which we would like to know about, so especially in the CI job it seems like a good idea to not force-install packages to catch upcoming defects early on.

Extends 19526d2322fabd4425688bb7c5504fa9ea015c5c.