### PR TITLE
Don't use the deprecated `CustomEvent.initCustomEvent` method anymore

### DIFF
--- a/web/event_utils.js
+++ b/web/event_utils.js
@@ -172,7 +172,7 @@ class AutomationEventBus extends EventBus {
     }
     super.dispatch(eventName, data);
 
-    const details = Object.create(null);
+    const detail = Object.create(null);
     if (data) {
       for (const key in data) {
         const value = data[key];
@@ -182,11 +182,14 @@ class AutomationEventBus extends EventBus {
           }
           continue; // Ignore the `source` property.
         }
-        details[key] = value;
+        detail[key] = value;
       }
     }
-    const event = document.createEvent("CustomEvent");
-    event.initCustomEvent(eventName, true, true, details);
+    const event = new CustomEvent(eventName, {
+      bubbles: true,
+      cancelable: true,
+      detail,
+    });
     document.dispatchEvent(event);
   }
 }

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -40,11 +40,14 @@ class FirefoxCom {
     const request = document.createTextNode("");
     document.documentElement.append(request);
 
-    const sender = document.createEvent("CustomEvent");
-    sender.initCustomEvent("pdf.js.message", true, false, {
-      action,
-      data,
-      sync: true,
+    const sender = new CustomEvent("pdf.js.message", {
+      bubbles: true,
+      cancelable: false,
+      detail: {
+        action,
+        data,
+        sync: true,
+      },
     });
     request.dispatchEvent(sender);
     const response = sender.detail.response;
@@ -88,12 +91,15 @@ class FirefoxCom {
     }
     document.documentElement.append(request);
 
-    const sender = document.createEvent("CustomEvent");
-    sender.initCustomEvent("pdf.js.message", true, false, {
-      action,
-      data,
-      sync: false,
-      responseExpected: !!callback,
+    const sender = new CustomEvent("pdf.js.message", {
+      bubbles: true,
+      cancelable: false,
+      detail: {
+        action,
+        data,
+        sync: false,
+        responseExpected: !!callback,
+      },
     });
     request.dispatchEvent(sender);
   }

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -273,8 +273,11 @@ window.print = function () {
 };
 
 function dispatchEvent(eventType) {
-  const event = document.createEvent("CustomEvent");
-  event.initCustomEvent(eventType, false, false, "custom");
+  const event = new CustomEvent(eventType, {
+    bubbles: false,
+    cancelable: false,
+    detail: "custom",
+  });
   window.dispatchEvent(event);
 }
 


### PR DESCRIPTION
In PR #16295 one occurrence of this was changed, but a few more remained in the codebase. This commit fixes the other occurrences so that we don't use the deprecated way of creating custom events anywhere anymore.

According to MDN, see https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/initCustomEvent, using the `CustomEvent.initCustomEvent` method is deprecated and the `CustomEvent` constructor should be used instead.

Extends d9bf571f5c49e1cac9054cf6b7acfc0b5b719876.