### PR TITLE
Prevent incomplete copy-all behaviour while text-extraction is running (PR 16286 follow-up)

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -691,18 +691,18 @@ class PDFViewer {
       //    including this element so having it in the selection means that all
       //    has been selected.
 
-      if (textLayerMode === TextLayerMode.ENABLE_PERMISSIONS) {
+      if (
+        this.#getAllTextInProgress ||
+        textLayerMode === TextLayerMode.ENABLE_PERMISSIONS
+      ) {
         event.preventDefault();
         event.stopPropagation();
         return;
       }
+      this.#getAllTextInProgress = true;
+
       // TODO: if all the pages are rendered we don't need to wait for
       // getAllText and we could just get text from the Selection object.
-
-      if (this.#getAllTextInProgress) {
-        return;
-      }
-      this.#getAllTextInProgress = true;
 
       // Select all the document.
       const savedCursor = this.container.style.cursor;


### PR DESCRIPTION
Currently we only prevent triggering the actual text-extraction multiple times in "parallel", when using the "copy all text" feature, however the "copy"-event itself is not prevented.
The result is that if the user selects all text in a long PDF document and then uses the copy-shortcut multiple times in quick succession, we'll actually populate the clipboard with "incomplete" contents (via a `TextLayerBuilder` copy-listener) until all text-extraction finishes.