### PR TITLE
[api-minor] Stop including the "lib"-build in the `pdfjs-dist` repository

### DIFF
--- a/external/dist/lib/README.md
+++ b/external/dist/lib/README.md
@@ -1,7 +1,0 @@
-It's *very highly* recommended to *not* use these files, but rather use the
-pre-built library as found in e.g. the `/build`, `/web`, and `/image_decoders`
-folders in the root of this repository.
-
-Please note that the "lib" build target exists mostly to enable unit-testing in
-Node.js/GitHub, and that you'll need to handle e.g. any necessary polyfills
-and/or Node.js dependencies yourself if using the files in this folder.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,7 +58,6 @@ const MINIFIED_LEGACY_DIR = BUILD_DIR + "minified-legacy/";
 const JSDOC_BUILD_DIR = BUILD_DIR + "jsdoc/";
 const GH_PAGES_DIR = BUILD_DIR + "gh-pages/";
 const SRC_DIR = "src/";
-const LIB_DIR = BUILD_DIR + "lib/";
 const DIST_DIR = BUILD_DIR + "dist/";
 const TYPES_DIR = BUILD_DIR + "types/";
 const TMP_DIR = BUILD_DIR + "tmp/";
@@ -2233,7 +2232,6 @@ gulp.task(
     "components-legacy",
     "image_decoders",
     "image_decoders-legacy",
-    "lib",
     "minified",
     "minified-legacy",
     "types",
@@ -2323,9 +2321,6 @@ gulp.task(
             base: IMAGE_DECODERS_LEGACY_DIR,
           })
           .pipe(gulp.dest(DIST_DIR + "legacy/image_decoders/")),
-        gulp
-          .src(LIB_DIR + "**/*", { base: LIB_DIR })
-          .pipe(gulp.dest(DIST_DIR + "lib/")),
         gulp
           .src(TYPES_DIR + "**/*", { base: TYPES_DIR })
           .pipe(gulp.dest(DIST_DIR + "types/")),


### PR DESCRIPTION
The `pdfjs-dist/lib/` directory contains a README file that explicitly advises against using those files, however based on a fairly large number of issues filed over the years users seem to be (mostly) overlooking that warning.
In particular it unfortunately seems to be somewhat common for users to attempt to "combine" proper builds from `pdfjs-dist/build/` together with individual components from the `pdfjs-dist/lib/web/` directory, which more often than not leads to subtle bugs and general problems.

When we receive bug reports about this it's often not immediately obvious what the problem is, given that many issues lack enough details (such as runnable test-cases), but after some back-and-forth it usually turns out that usage of `pdfjs-dist/lib/` is the culprit.
Considering that keeping the general PDF.js library working is challenging and time-consuming enough nowadays, this patch thus proposes that we stop including the "lib"-build in the `pdfjs-dist` repository to both reduce user confusion and the support burden.