### PR TITLE
Update the styling of the findbar `findMsg`-element (issue 16355)

### DIFF
--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -129,6 +129,7 @@ class PDFFindBar {
     this.findField.setAttribute("aria-invalid", state === FindState.NOT_FOUND);
 
     findMsg.then(msg => {
+      this.findMsg.setAttribute("data-status", status);
       this.findMsg.textContent = msg;
       this.#adjustWidth();
     });

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -627,8 +627,8 @@ body {
   margin: 5px;
 }
 
-#findMsg {
-  color: rgba(251, 0, 0, 1);
+#findMsg[data-status="notFound"] {
+  font-weight: bold;
 }
 
 :is(#findResultsCount, #findMsg):empty {


### PR DESCRIPTION
This patch tries to mimic the look of the message-element in the Firefox browser-findbar, and thus makes the following changes:
 - Remove the red colour, since it didn't take the light/dark themes into account.
 - Display the "notFound" message in bold.