### PR TITLE
Remove the unused `getXhr`-option in the `NetworkManager` constructor

### DIFF
--- a/src/display/network.js
+++ b/src/display/network.js
@@ -47,11 +47,6 @@ class NetworkManager {
     this.isHttp = /^https?:/i.test(url);
     this.httpHeaders = (this.isHttp && args.httpHeaders) || Object.create(null);
     this.withCredentials = args.withCredentials || false;
-    this.getXhr =
-      args.getXhr ||
-      function NetworkManager_getXhr() {
-        return new XMLHttpRequest();
-      };
 
     this.currXhrId = 0;
     this.pendingRequests = Object.create(null);
@@ -73,7 +68,7 @@ class NetworkManager {
   }
 
   request(args) {
-    const xhr = this.getXhr();
+    const xhr = new XMLHttpRequest();
     const xhrId = this.currXhrId++;
     const pendingRequest = (this.pendingRequests[xhrId] = { xhr });
 


### PR DESCRIPTION
Originally this file was shared, using pre-processor statements, between the generic PDF.js library and the *built-in* Firefox PDF Viewer. In the latter case the `getXhr`-option is being used, see https://searchfox.org/mozilla-central/rev/f32d5f3949a3f4f185122142b29f2e3ab776836e/toolkit/components/pdfjs/content/PdfStreamConverter.sys.mjs#612-621