### PR TITLE
Declare the `linkService` and `l10n` properties as optional in the `PDFViewerOptions` documentation

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -83,7 +83,7 @@ function isValidAnnotationEditorMode(mode) {
  * @property {HTMLDivElement} container - The container for the viewer element.
  * @property {HTMLDivElement} [viewer] - The viewer element.
  * @property {EventBus} eventBus - The application event bus.
- * @property {IPDFLinkService} linkService - The navigation/linking service.
+ * @property {IPDFLinkService} [linkService] - The navigation/linking service.
  * @property {IDownloadManager} [downloadManager] - The download manager
  *   component.
  * @property {PDFFindController} [findController] - The find controller
@@ -115,7 +115,7 @@ function isValidAnnotationEditorMode(mode) {
  * @property {number} [maxCanvasPixels] - The maximum supported canvas size in
  *   total pixels, i.e. width * height. Use -1 for no limit. The default value
  *   is 4096 * 4096 (16 mega-pixels).
- * @property {IL10n} l10n - Localization service.
+ * @property {IL10n} [l10n] - Localization service.
  * @property {boolean} [enablePermissions] - Enables PDF document permissions,
  *   when they exist. The default value is `false`.
  * @property {Object} [pageColors] - Overwrites background and foreground colors


### PR DESCRIPTION
Both properties have a fallback to `SimpleLinkService` respectively `NullL10n` if no other value is provided explicitly.

I have also checked the other properties of the `PDFViewerOptions` documentation to make sure those are also correct now and found no further problems.

Fixes #16360.