### PR TITLE
Introduce a GitHub Actions workflow for publishing the website

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -1,0 +1,63 @@
+name: Publish website
+on: [push]
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Use Node.js 18 LTS
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install Gulp
+        run: npm install -g gulp-cli
+
+      - name: Install other dependencies
+        run: npm install
+
+      - name: Build the website
+        run: gulp web
+
+      - name: Archive the website
+        shell: sh
+        run: |
+          chmod -c -R +rX "$INPUT_PATH" | while read line; do
+            echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
+          tar \
+            --dereference --hard-dereference \
+            --directory "$INPUT_PATH" \
+            -cvf "$RUNNER_TEMP/website.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            .
+        env:
+          INPUT_PATH: build/gh-pages
+
+      - name: Upload the website
+        uses: actions/upload-artifact@v3
+        with:
+          name: github-pages
+          path: ${{ runner.temp }}/website.tar
+          retention-days: 1
+          if-no-files-found: error
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      pages: write  # Required to deploy to GitHub Pages.
+      id-token: write  # Required to verify that the deployment originates from this workflow.
+
+    steps:
+      - name: Deploy the website
+        uses: actions/deploy-pages@v2

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,7 +68,6 @@ const COMMON_WEB_FILES = [
 ];
 const MOZCENTRAL_DIFF_FILE = "mozcentral.diff";
 
-const REPO = "git@github.com:mozilla/pdf.js.git";
 const DIST_REPO_URL = "https://github.com/mozilla/pdfjs-dist";
 
 const builder = require("./external/builder/builder.js");
@@ -2133,33 +2132,6 @@ gulp.task("wintersmith", function (done) {
   });
 });
 
-function ghPagesGit(done) {
-  const VERSION = getVersionJSON().version;
-  const reason = process.env.PDFJS_UPDATE_REASON;
-
-  safeSpawnSync("git", ["init"], { cwd: GH_PAGES_DIR });
-  safeSpawnSync("git", ["remote", "add", "origin", REPO], {
-    cwd: GH_PAGES_DIR,
-  });
-  safeSpawnSync("git", ["add", "-A"], { cwd: GH_PAGES_DIR });
-  safeSpawnSync(
-    "git",
-    [
-      "commit",
-      "-am",
-      "gh-pages site created via gulpfile.js script",
-      "-m",
-      "PDF.js version " + VERSION + (reason ? " - " + reason : ""),
-    ],
-    { cwd: GH_PAGES_DIR }
-  );
-  safeSpawnSync("git", ["branch", "-m", "gh-pages"], { cwd: GH_PAGES_DIR });
-
-  console.log();
-  console.log("Website built in " + GH_PAGES_DIR);
-  done();
-}
-
 gulp.task(
   "web",
   gulp.series(
@@ -2167,8 +2139,7 @@ gulp.task(
     "generic-legacy",
     "jsdoc",
     ghPagesPrepare,
-    "wintersmith",
-    ghPagesGit
+    "wintersmith"
   )
 );
 


### PR DESCRIPTION
This commit migrates this functionality away from the bots. Nowadays it's possible to build and deploy the website to GitHub Pages directly through the GitHub Actions, which provides a nice simplication of the process. Not only does this remove the requirement to have a `gh-pages` branch in the repository, it also avoids the complexity of having to configure the workflow to commit to Git branches and allows us to remove the Git committing code from the Gulpfile.

Note that deploying directly though GitHub Actions workflows needs to be enabled in the repository settings, but this is easy and well documented on the link below.

The following resources are relevant for this patch:

- Enabling deployment to GitHub Pages directly through GitHub Actions: https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow
- Uploading GitHub Pages artifacts example: https://github.com/actions/upload-pages-artifact#usage
- Deploying GitHub Pages artifacts example: https://github.com/actions/deploy-pages#usage

You can view this workflow in action on my fork at https://github.com/timvandermeij/pdf.js/actions/runs/4822609834 where I've done nothing other than enabling GitHub Pages deployment from GitHub Actions workflows in the settings of the fork. The published website can be viewed at https://timvandermeij.github.io/pdf.js.

Implements the first step of #11851 to move the non-testing responsibilities away from the bots.
Relates to https://github.com/mozilla/botio-files-pdfjs/pull/39.

Required actions once this PR is approved:

- [x] Merge https://github.com/mozilla/botio-files-pdfjs/pull/39 and deploy it to the bots.
- [x] Enable GitHub Pages deployment in the repository settings (see the link above; this will switch away from the current setting of deploying GitHub Pages from the `gh-pages` branch automatically).
- [x] Merge this PR and check that the workflow succeeded.
- [x] Remove the `gh-pages` branch.
- [x] (For myself) Remove manual changes on my fork.