### PR TITLE
Inline the `addPageIndex` method in `GlobalImageCache.shouldCache`

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -826,10 +826,9 @@ class PartialEvaluator {
       if (imageRef) {
         this._regionalImageCache.set(/* name = */ null, imageRef, cacheData);
 
-        assert(!isInline, "Cannot cache an inline image globally.");
-        this.globalImageCache.addPageIndex(imageRef, this.pageIndex);
-
         if (cacheGlobally) {
+          assert(!isInline, "Cannot cache an inline image globally.");
+
           this.globalImageCache.setData(imageRef, {
             objId,
             fn: OPS.paintImageXObject,

--- a/src/core/image_utils.js
+++ b/src/core/image_utils.js
@@ -215,27 +215,20 @@ class GlobalImageCache {
   }
 
   shouldCache(ref, pageIndex) {
-    const pageIndexSet = this._refCache.get(ref);
-    const numPages = pageIndexSet
-      ? pageIndexSet.size + (pageIndexSet.has(pageIndex) ? 0 : 1)
-      : 1;
-
-    if (numPages < GlobalImageCache.NUM_PAGES_THRESHOLD) {
-      return false;
-    }
-    if (!this._imageCache.has(ref) && this._cacheLimitReached) {
-      return false;
-    }
-    return true;
-  }
-
-  addPageIndex(ref, pageIndex) {
     let pageIndexSet = this._refCache.get(ref);
     if (!pageIndexSet) {
       pageIndexSet = new Set();
       this._refCache.put(ref, pageIndexSet);
     }
     pageIndexSet.add(pageIndex);
+
+    if (pageIndexSet.size < GlobalImageCache.NUM_PAGES_THRESHOLD) {
+      return false;
+    }
+    if (!this._imageCache.has(ref) && this._cacheLimitReached) {
+      return false;
+    }
+    return true;
   }
 
   /**
@@ -273,7 +266,7 @@ class GlobalImageCache {
   setData(ref, data) {
     if (!this._refCache.has(ref)) {
       throw new Error(
-        'GlobalImageCache.setData - expected "addPageIndex" to have been called.'
+        'GlobalImageCache.setData - expected "shouldCache" to have been called.'
       );
     }
     if (this._imageCache.has(ref)) {


### PR DESCRIPTION
When the `GlobalImageCache` implementation originally landed, back in PR #11912, the image handling was slightly more complex (with e.g. browser-decoding of some JPEG images). At this point it no longer seems necessary to manually handle pageIndexes in this way, and we should be able to simply inline that in the `GlobalImageCache.shouldCache` method.