### PR TITLE
Limit the `publish_website.yml` work-flow to only the `master` branch (issue 16369)

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -1,5 +1,8 @@
 name: Publish website
-on: [push]
+on:
+  push:
+    branches:
+      - master
 permissions:
   contents: read
 


### PR DESCRIPTION
This is a tentative patch, based on https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#using-filters