### PR TITLE
Include the entire `git` history in the work-flows (issue 16366)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js 18 LTS
         uses: actions/setup-node@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js 18 LTS
         uses: actions/setup-node@v3


### PR DESCRIPTION
Without this change we're not able to correctly determine the version number, please refer to https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches