### PR TITLE
Add optional noScroll parameter to currentScaleValue() of PDFViewer 

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -447,14 +447,14 @@ class PDFViewer {
   /**
    * @param {number} val - Scale of the pages in percents.
    */
-  set currentScale(val) {
-    if (isNaN(val)) {
+  set currentScale({ value, noScroll = true }) {
+    if (isNaN(value)) {
       throw new Error("Invalid numeric scale.");
     }
     if (!this.pdfDocument) {
       return;
     }
-    this.#setScale(val, { noScroll: false });
+    this.#setScale(value, { noScroll });
   }
 
   /**
@@ -467,11 +467,11 @@ class PDFViewer {
   /**
    * @param val - The scale of the pages (in percent or predefined value).
    */
-  set currentScaleValue(val) {
+  set currentScaleValue({ value, noScroll = true }) {
     if (!this.pdfDocument) {
       return;
     }
-    this.#setScale(val, { noScroll: false });
+    this.#setScale(value, { noScroll });
   }
 
   /**


### PR DESCRIPTION
Add optional `noScroll` parameter to `currentScale()` and `currentScaleValue()` of `PDFViewer`; default to `true`
