### PR TITLE
Enable the `unicorn/no-invalid-remove-event-listener` ESLint plugin rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -46,6 +46,7 @@
     "unicorn/no-abusive-eslint-disable": "error",
     "unicorn/no-array-push-push": "error",
     "unicorn/no-instanceof-array": "error",
+    "unicorn/no-invalid-remove-event-listener": "error",
     "unicorn/no-new-buffer": "error",
     "unicorn/no-useless-spread": "error",
     "unicorn/prefer-array-find": "error",


### PR DESCRIPTION
This rule won't only be helpful when writing code, but will also help during reviews to make sure that we don't accidentally leave any event-listeners attached; please see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-invalid-remove-event-listener.md