### PR TITLE
Improve handling of JPEG images with non-standard /Decode-entries (issue 16395)

### DIFF
--- a/src/core/image.js
+++ b/src/core/image.js
@@ -746,7 +746,12 @@ class PDFImage {
         }
         return imgData;
       }
-      if (this.image instanceof JpegStream && !this.smask && !this.mask) {
+      if (
+        this.image instanceof JpegStream &&
+        !this.smask &&
+        !this.mask &&
+        !this.needsDecode
+      ) {
         let imageLength = originalHeight * rowBytes;
         if (isOffscreenCanvasSupported && !mustBeResized) {
           let isHandled = false;

--- a/test/pdfs/issue16395.pdf.link
+++ b/test/pdfs/issue16395.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/11412207/issue16395.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -41,6 +41,15 @@
        "lastPage": 2,
        "type": "eq"
     },
+    {  "id": "issue16395",
+       "file": "pdfs/issue16395.pdf",
+       "md5": "a5de985711ec27cd2a2ed97d5f1c536c",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 3,
+       "lastPage": 3,
+       "type": "eq"
+    },
     {  "id": "tracemonkey-fbf",
        "file": "pdfs/tracemonkey.pdf",
        "md5": "9a192d8b1a7dc652a19835f6f08098bd",


### PR DESCRIPTION
The /Decode-implementation in the our JPEG decoder, i.e. `src/core/jpg.js`, seems to only handle *inverting* of images properly. To support arbitrary /Decode-entries correctly we'll always use the `PDFImage.decodeBuffer` method, even for "simple" JPEG images, which should be fine since non-default /Decode-entries aren't a very common occurrence.

*Please note:* This patch will lead to a little bit of movement in some existing test-cases, however it should be virtually imperceivable to the naked eye.