### PR TITLE
[api-minor] Update the minimum supported Safari version to 15.4

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -192,8 +192,6 @@ function createWebpackConfig(
     DEFAULT_PREFERENCES: defaultPreferencesDir
       ? getDefaultPreferences(defaultPreferencesDir)
       : {},
-    DIALOG_POLYFILL_CSS:
-      defines.GENERIC && !defines.SKIP_BABEL ? getDialogPolyfillCSS() : "",
   });
   const licenseHeaderLibre = fs
     .readFileSync("./src/license_header_libre.js")
@@ -819,12 +817,6 @@ function getDefaultPreferences(dir) {
     "web/app_options.js");
 
   return AppOptions.getAll(OptionKind.PREFERENCE);
-}
-
-function getDialogPolyfillCSS() {
-  return fs
-    .readFileSync("node_modules/dialog-polyfill/dist/dialog-polyfill.css")
-    .toString();
 }
 
 gulp.task("locale", function () {
@@ -1585,8 +1577,6 @@ function buildLib(defines, dir) {
     DEFAULT_PREFERENCES: getDefaultPreferences(
       defines.SKIP_BABEL ? "lib/" : "lib-legacy/"
     ),
-    DIALOG_POLYFILL_CSS:
-      defines.GENERIC && !defines.SKIP_BABEL ? getDialogPolyfillCSS() : "",
   });
 
   const inputStream = merge([

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -79,7 +79,7 @@ const ENV_TARGETS = [
   "last 2 versions",
   "Chrome >= 88",
   "Firefox ESR",
-  "Safari >= 14.1",
+  "Safari >= 15.4",
   "Node >= 18",
   "> 1%",
   "not IE > 0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "canvas": "^2.11.2",
         "core-js": "^3.30.1",
         "cross-env": "^7.0.3",
-        "dialog-polyfill": "^0.5.6",
         "es-module-shims": "1.4.7",
         "eslint": "^8.39.0",
         "eslint-config-prettier": "^8.8.0",
@@ -5029,12 +5028,6 @@
         "enabled": "1.0.x",
         "kuler": "1.0.x"
       }
-    },
-    "node_modules/dialog-polyfill": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.5.6.tgz",
-      "integrity": "sha512-ZbVDJI9uvxPAKze6z146rmfUZjBqNEwcnFTVamQzXH+svluiV7swmVIGr7miwADgfgt1G2JQIytypM9fbyhX4w==",
-      "dev": true
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -12506,7 +12499,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -12522,19 +12515,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -12549,7 +12542,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -12567,7 +12560,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -23031,12 +23024,6 @@
         "kuler": "1.0.x"
       }
     },
-    "dialog-polyfill": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.5.6.tgz",
-      "integrity": "sha512-ZbVDJI9uvxPAKze6z146rmfUZjBqNEwcnFTVamQzXH+svluiV7swmVIGr7miwADgfgt1G2JQIytypM9fbyhX4w==",
-      "dev": true
-    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -28769,7 +28756,7 @@
         "lodash._baseindexof": {
           "version": "3.1.0",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -28783,17 +28770,17 @@
         "lodash._bindcallback": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "dev": true,
+          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
@@ -28806,7 +28793,7 @@
         "lodash._getnative": {
           "version": "3.9.1",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash._root": {
           "version": "3.0.1",
@@ -28821,7 +28808,7 @@
         "lodash.restparam": {
           "version": "3.6.1",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash.union": {
           "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "canvas": "^2.11.2",
     "core-js": "^3.30.1",
     "cross-env": "^7.0.3",
-    "dialog-polyfill": "^0.5.6",
     "es-module-shims": "1.4.7",
     "eslint": "^8.39.0",
     "eslint-config-prettier": "^8.8.0",

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -36,7 +36,7 @@ import { isNodeJS } from "./is_node.js";
   polyfillPath2D(globalThis);
 })();
 
-// Support: Chrome<92, Safari<15.4
+// Support: Chrome<92
 (function checkArrayAt() {
   if (Array.prototype.at) {
     return;
@@ -44,7 +44,7 @@ import { isNodeJS } from "./is_node.js";
   require("core-js/es/array/at.js");
 })();
 
-// Support: Chrome<92, Safari<15.4
+// Support: Chrome<92
 (function checkTypedArrayAt() {
   if (Uint8Array.prototype.at) {
     return;
@@ -52,7 +52,7 @@ import { isNodeJS } from "./is_node.js";
   require("core-js/es/typed-array/at.js");
 })();
 
-// Support: Chrome<98, Safari<15.4
+// Support: Chrome<98
 (function checkStructuredClone() {
   if (globalThis.structuredClone) {
     return;

--- a/web/overlay_manager.js
+++ b/web/overlay_manager.js
@@ -44,15 +44,6 @@ class OverlayManager {
     ) {
       const dialogPolyfill = require("dialog-polyfill/dist/dialog-polyfill.js");
       dialogPolyfill.registerDialog(dialog);
-
-      if (!this._dialogPolyfillCSS) {
-        this._dialogPolyfillCSS = true;
-
-        const style = document.createElement("style");
-        style.textContent = PDFJSDev.eval("DIALOG_POLYFILL_CSS");
-
-        document.head.prepend(style);
-      }
     }
 
     dialog.addEventListener("cancel", evt => {

--- a/web/overlay_manager.js
+++ b/web/overlay_manager.js
@@ -37,15 +37,6 @@ class OverlayManager {
     }
     this.#overlays.set(dialog, { canForceClose });
 
-    if (
-      typeof PDFJSDev !== "undefined" &&
-      PDFJSDev.test("GENERIC && !SKIP_BABEL") &&
-      !dialog.showModal
-    ) {
-      const dialogPolyfill = require("dialog-polyfill/dist/dialog-polyfill.js");
-      dialogPolyfill.registerDialog(dialog);
-    }
-
     dialog.addEventListener("cancel", evt => {
       this.#active = null;
     });

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -2180,14 +2180,7 @@ class PDFViewer {
     for (const entry of entries) {
       if (entry.target === this.container) {
         this.#updateContainerHeightCss(
-          // Safari doesn't support `borderBoxSize` until version 15.4.
-          Math.floor(
-            typeof PDFJSDev !== "undefined" &&
-              !PDFJSDev.test("SKIP_BABEL") &&
-              !entry.borderBoxSize?.length
-              ? entry.contentRect.height
-              : entry.borderBoxSize[0].blockSize
-          )
+          Math.floor(entry.borderBoxSize[0].blockSize)
         );
         this.#containerTopLeft = null;
         break;


### PR DESCRIPTION
This patch updates the minimum supported browsers as follows:
 - Safari 15.4, which was released on 2022-03-15; see https://en.wikipedia.org/wiki/Safari_version_history#Safari_15

Nowadays we usually we try, where feasible and possible, to support browsers that are about two years old. The reasons for limiting support to a *somewhat* more recent Safari version include:
 - Throughout the history of the PDF.js project, Safari has always been the worst browser to attempt to support. Compared to other browsers there's a disproportionate number of bugs affecting Safari, especially on iOS, and in most cases those are browser-specific issues that we simply cannot address.[1]
 - Safari has often been a lot slower, compared to other browsers, at implementing new web-platform features. Historically this has sometimes blocked usage of new features, for the benefit of the Firefox PDF Viewer, and it's very often meant having to include and maintain polyfills *only* for Safari.
 - The current (minimum) supported Safari version lack enough functionality that polyfills placed in the `src/shared/compatibility.js` file are unfortunately not sufficient, but it also requires a bunch of special-cases in both the `gulpfile` and in the `web/`-code.
 - Given that the *built-in* Firefox PDF Viewer is the primary development target for the PDF.js library, and the general development pace these days, we need to limit the maintenance "overhead" caused by other browsers.

 ---
 [1] In a few cases a work-around might be possible, however it'd negatively affect e.g. performance, readability, and/or maintainability of the code.