### PR TITLE
Fix zoom parameter can not jump to correct position

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -1515,6 +1515,13 @@ class PDFViewer {
       left = Math.max(left, 0);
       top = Math.max(top, 0);
     }
+
+    // The converted top is just a y-axis value in the device space coordinate system,
+    // it should be transformed to make web browser scroll by setting scrollTop.
+    const viewHeight =
+      (changeOrientation ? pageView.width : pageView.height);
+    top = viewHeight - top;
+
     this.#scrollIntoView(pageView, /* pageSpot = */ { left, top });
   }
 
@@ -1531,10 +1538,15 @@ class PDFViewer {
     const container = this.container;
     const topLeft = currentPageView.getPagePoint(
       container.scrollLeft - firstPage.x,
-      container.scrollTop - firstPage.y
+      0
     );
+
+    // The top value may only related to offset?
+    const offsetTop = (container.scrollTop - firstPage.y) /
+      firstPage.view.scale /
+      PixelsPerInch.PDF_TO_CSS_UNITS;
     const intLeft = Math.round(topLeft[0]);
-    const intTop = Math.round(topLeft[1]);
+    const intTop = Math.round(offsetTop);
 
     let pdfOpenParams = `#page=${pageNumber}`;
     if (!this.isInPresentationMode) {

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -1516,10 +1516,10 @@ class PDFViewer {
       top = Math.max(top, 0);
     }
 
-    // The converted top is just a y-axis value in the device space coordinate system,
-    // it should be transformed to make web browser scroll by setting scrollTop.
-    const viewHeight =
-      (changeOrientation ? pageView.width : pageView.height);
+    // The converted top is just a y-axis value in the device space coordinate
+    // system, it should be transformed to make web browser scroll by setting
+    // scrollTop.
+    const viewHeight = changeOrientation ? pageView.width : pageView.height;
     top = viewHeight - top;
 
     this.#scrollIntoView(pageView, /* pageSpot = */ { left, top });
@@ -1542,7 +1542,8 @@ class PDFViewer {
     );
 
     // The top value may only related to offset?
-    const offsetTop = (container.scrollTop - firstPage.y) /
+    const offsetTop =
+      (container.scrollTop - firstPage.y) /
       firstPage.view.scale /
       PixelsPerInch.PDF_TO_CSS_UNITS;
     const intLeft = Math.round(topLeft[0]);


### PR DESCRIPTION
I'm trying to fix #2843, zoom specified in the hash should be more stable, but the saved location sometimes can not go correct position when the PDF page is rotated.

Could someone review the code and help with related issues?