### PR TITLE
Added option to disable group size scaling. Closes 14982.

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -948,7 +948,8 @@ class CanvasGraphics {
     filterFactory,
     { optionalContentConfig, markedContentStack = null },
     annotationCanvasMap,
-    pageColors
+    pageColors,
+    disableGroupSizeScaling
   ) {
     this.ctx = canvasCtx;
     this.current = new CanvasExtraState(
@@ -985,6 +986,7 @@ class CanvasGraphics {
     this.outputScaleX = 1;
     this.outputScaleY = 1;
     this.pageColors = pageColors;
+    this.disableGroupSizeScaling = disableGroupSizeScaling;
 
     this._cachedScaleForStroking = null;
     this._cachedGetSinglePixelWidth = null;
@@ -2575,13 +2577,18 @@ class CanvasGraphics {
     let drawnHeight = Math.max(Math.ceil(bounds[3]) - offsetY, 1);
     let scaleX = 1,
       scaleY = 1;
-    if (drawnWidth > MAX_GROUP_SIZE) {
-      scaleX = drawnWidth / MAX_GROUP_SIZE;
-      drawnWidth = MAX_GROUP_SIZE;
-    }
-    if (drawnHeight > MAX_GROUP_SIZE) {
-      scaleY = drawnHeight / MAX_GROUP_SIZE;
-      drawnHeight = MAX_GROUP_SIZE;
+
+    // if disableGroupSizeScaling is true, don't scale using group size
+    if (!this.disableGroupSizeScaling) {
+      if (drawnWidth > MAX_GROUP_SIZE) {
+        scaleX = drawnWidth / MAX_GROUP_SIZE;
+        drawnWidth = MAX_GROUP_SIZE;
+      }
+
+      if (drawnHeight > MAX_GROUP_SIZE) {
+        scaleY = drawnHeight / MAX_GROUP_SIZE;
+        drawnHeight = MAX_GROUP_SIZE;
+      }
     }
 
     this.current.startNewPathAndClipBox([0, 0, drawnWidth, drawnHeight]);

--- a/web/app.js
+++ b/web/app.js
@@ -515,6 +515,7 @@ const PDFViewerApplication = {
       maxCanvasPixels: AppOptions.get("maxCanvasPixels"),
       enablePermissions: AppOptions.get("enablePermissions"),
       pageColors,
+      disableGroupSizeScaling: AppOptions.get("disableGroupSizeScaling"),
     });
     pdfRenderingQueue.setViewer(this.pdfViewer);
     pdfLinkService.setViewer(this.pdfViewer);

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -263,6 +263,11 @@ const defaultOptions = {
     value: true,
     kind: OptionKind.API,
   },
+  disableGroupSizeScaling: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.API + OptionKind.PREFERENCE,
+  },
   maxImageSize: {
     /** @type {number} */
     value: -1,

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -121,6 +121,8 @@ function isValidAnnotationEditorMode(mode) {
  * @property {Object} [pageColors] - Overwrites background and foreground colors
  *   with user defined ones in order to improve readability in high contrast
  *   mode.
+ * @property {boolean} [disableGroupSizeScaling] - Disables scaling based on
+ *  group size
  */
 
 class PDFPageViewBuffer {
@@ -277,6 +279,7 @@ class PDFViewer {
     this.l10n = options.l10n || NullL10n;
     this.#enablePermissions = options.enablePermissions || false;
     this.pageColors = options.pageColors || null;
+    this.disableGroupSizeScaling = options.disableGroupSizeScaling;
 
     if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
       if (
@@ -881,6 +884,7 @@ class PDFViewer {
             pageColors: this.pageColors,
             l10n: this.l10n,
             layerProperties,
+            disableGroupSizeScaling: this.disableGroupSizeScaling,
           });
           this._pages.push(pageView);
         }


### PR DESCRIPTION
PDF link: https://github.com/mozilla/pdf.js/files/8829368/Tillamook-Market-Menu-04.04.22.pdf

Addresses this issue: https://github.com/mozilla/pdf.js/issues/14982

Solution context: https://github.com/mozilla/pdf.js/issues/14982#issuecomment-1472232511
