### PR TITLE
Enable the `unicorn/no-useless-promise-resolve-reject` ESLint plugin rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -48,6 +48,10 @@
     "unicorn/no-instanceof-array": "error",
     "unicorn/no-invalid-remove-event-listener": "error",
     "unicorn/no-new-buffer": "error",
+    "unicorn/no-typeof-undefined": ["error", {
+      "checkGlobalVariables": false,
+    }],
+    "unicorn/no-useless-promise-resolve-reject": "error",
     "unicorn/no-useless-spread": "error",
     "unicorn/prefer-array-find": "error",
     "unicorn/prefer-array-flat": "error",
@@ -63,7 +67,6 @@
     "unicorn/prefer-regexp-test": "error",
     "unicorn/prefer-string-replace-all": "error",
     "unicorn/prefer-string-starts-ends-with": "error",
-    "unicorn/no-typeof-undefined": ["error", { "checkGlobalVariables": false, }],
 
     // Possible errors
     "for-direction": "error",

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -344,7 +344,7 @@ describe("api", function () {
         function () {
           // Shouldn't get here.
           expect(false).toEqual(true);
-          return Promise.reject(new Error("loadingTask should be rejected"));
+          throw new Error("loadingTask should be rejected");
         },
         function (data) {
           expect(data instanceof PasswordException).toEqual(true);
@@ -366,7 +366,7 @@ describe("api", function () {
         function () {
           // Shouldn't get here.
           expect(false).toEqual(true);
-          return Promise.reject(new Error("loadingTask should be rejected"));
+          throw new Error("loadingTask should be rejected");
         },
         function (data) {
           expect(data instanceof PasswordException).toEqual(true);
@@ -427,7 +427,7 @@ describe("api", function () {
           function () {
             // Shouldn't get here.
             expect(false).toEqual(true);
-            return Promise.reject(new Error("loadingTask should be rejected"));
+            throw new Error("loadingTask should be rejected");
           },
           function (reason) {
             expect(reason instanceof PasswordException).toEqual(true);
@@ -447,7 +447,7 @@ describe("api", function () {
           function () {
             // Shouldn't get here.
             expect(false).toEqual(true);
-            return Promise.reject(new Error("loadingTask should be rejected"));
+            throw new Error("loadingTask should be rejected");
           },
           function (reason) {
             expect(reason instanceof PasswordException).toEqual(true);


### PR DESCRIPTION
Please see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-promise-resolve-reject.md

Note that this patch also re-sorts the existing `unicorn`-rules in proper alphabetical order.