### PR TITLE
Updated tooltip for Current Page button

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -218,7 +218,7 @@ See https://github.com/adobe-type-tools/cmap-resources
               <span data-l10n-id="presentation_mode_label">Presentation Mode</span>
             </button>
 
-            <a href="#" id="viewBookmark" class="secondaryToolbarButton" title="Current Page (View URL from Current Page)" tabindex="55" data-l10n-id="bookmark1">
+            <a href="#" id="viewBookmark" class="secondaryToolbarButton" title="Current Page (Gets the URL for the current page and displays it in the address bar)" tabindex="55" data-l10n-id="bookmark1">
               <span data-l10n-id="bookmark1_label">Current Page</span>
             </a>
 


### PR DESCRIPTION
This resolves #15967

Added a more descriptive tooltip for the "View URL from Current Page" button.