### PR TITLE
Attempt to fallback to a default font, for non-available ones, in more cases (issue 16432)

### DIFF
--- a/test/pdfs/issue16432.pdf.link
+++ b/test/pdfs/issue16432.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/11493613/inputFields-Flattened-Output.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -50,6 +50,14 @@
        "lastPage": 3,
        "type": "eq"
     },
+    {  "id": "issue16432",
+       "file": "pdfs/issue16432.pdf",
+       "md5": "b67b0324c307d8af43d11b0edec88e3e",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "tracemonkey-fbf",
        "file": "pdfs/tracemonkey.pdf",
        "md5": "9a192d8b1a7dc652a19835f6f08098bd",


### PR DESCRIPTION
This essentially extends PR #11218 to also apply when looking up the final font-reference, via the XRef-table, fails because the font isn't available.

This patch also changes `PartialEvaluator.fallbackFontDict` to simply use "Helvetica" as the default font-name, since that seems generally reasonable given the now existing font-substitution code.