### PR TITLE
Attempt to improve non-embedded Wingdings font support (bug 1652224)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -3517,8 +3517,10 @@ class PartialEvaluator {
         if (nonEmbeddedFont) {
           if (/Symbol/i.test(properties.name)) {
             encoding = SymbolSetEncoding;
-          } else if (/Dingbats|Wingdings/i.test(properties.name)) {
+          } else if (/Dingbats/i.test(properties.name)) {
             encoding = ZapfDingbatsEncoding;
+          } else if (/Wingdings/i.test(properties.name)) {
+            encoding = WinAnsiEncoding;
           }
         }
       }

--- a/src/core/font_substitutions.js
+++ b/src/core/font_substitutions.js
@@ -281,6 +281,25 @@ const substitutionMap = new Map([
       fallback: "Helvetica-BoldOblique",
     },
   ],
+  [
+    "Wingdings",
+    {
+      local: ["Wingdings", "URW Dingbats"],
+      style: NORMAL,
+    },
+  ],
+  [
+    "Wingdings-Regular",
+    {
+      alias: "Wingdings",
+    },
+  ],
+  [
+    "Wingdings-Bold",
+    {
+      alias: "Wingdings",
+    },
+  ],
 ]);
 
 const fontAliases = new Map([["Arial-Black", "ArialBlack"]]);

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -1238,9 +1238,6 @@ class Font {
         this.differences
       );
     } else if (/Dingbats/i.test(fontName)) {
-      if (/Wingdings/i.test(name)) {
-        warn("Non-embedded Wingdings font, falling back to ZapfDingbats.");
-      }
       this.toFontChar = buildToFontChar(
         ZapfDingbatsEncoding,
         getDingbatsGlyphsUnicode(),

--- a/src/core/standard_fonts.js
+++ b/src/core/standard_fonts.js
@@ -166,8 +166,6 @@ const getNonStdFontMap = getLookupTableFactory(function (t) {
   t["MS-PMincho-Italic"] = "MS PMincho-Italic";
   t.NuptialScript = "Times-Italic";
   t.SegoeUISymbol = "Helvetica";
-  t.Wingdings = "ZapfDingbats";
-  t["Wingdings-Regular"] = "ZapfDingbats";
 });
 
 const getSerifFonts = getLookupTableFactory(function (t) {

--- a/test/pdfs/bug1652224.pdf.link
+++ b/test/pdfs/bug1652224.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=9167775

--- a/test/pdfs/issue11451.pdf.link
+++ b/test/pdfs/issue11451.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/4003700/error2.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -3442,6 +3442,23 @@
        "rounds": 1,
        "type": "text"
     },
+    {  "id": "issue11451",
+       "file": "pdfs/issue11451.pdf",
+       "md5": "a2fd3c4596ad75562df83a2494263802",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
+    {  "id": "bug1652224",
+       "file": "pdfs/bug1652224.pdf",
+       "md5": "0e1bb427f32e83dc8f091842f7a11ac4",
+       "rounds": 1,
+       "link": true,
+       "firstPage": 5,
+       "lastPage": 5,
+       "type": "eq"
+    },
     {  "id": "issue8586",
        "file": "pdfs/issue8586.pdf",
        "md5": "16b5230364017d3b0d2d65978eb35816",


### PR DESCRIPTION
Now that font-substitution has been implemented, we should be able to do much a better job at supporting non-embedded Wingdings fonts.
Given that this is a Windows-specific font, see https://en.wikipedia.org/wiki/Wingdings, this is however not guaranteed to work (well) on other platforms.