### PR TITLE
Improve "EI" detection in inline images (PR 12028 follow-up, issue 16454)

### DIFF
--- a/test/pdfs/issue16454.pdf.link
+++ b/test/pdfs/issue16454.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/11537582/Pages.62.73.from.0560-22_WSP.Plan_July.2022_Version.1.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -5963,6 +5963,14 @@
        "link": true,
        "type": "eq"
     },
+    {  "id": "issue16454",
+       "file": "pdfs/issue16454.pdf",
+       "md5": "82fe0c54a96667472ce999be7a789199",
+       "rounds": 1,
+       "lastPage": 1,
+       "link": true,
+       "type": "eq"
+    },
     {  "id": "decodeACSuccessive",
        "file": "pdfs/decodeACSuccessive.pdf",
        "md5": "7749c032624fe27ab8e8d7d5e9a4a93f",


### PR DESCRIPTION
Given that inline images may contain "EI"-sequences in the image-data itself, actually finding the end-of-image operator isn't always straightforward.
Here we extend the implementation from PR #12028 to potentially check all of the following bytes, rather than stopping immediately. While we have fairly decent test-coverage for this code, whenever you're changing it there's unfortunately a slightly higher than normal risk of regressions. (You'd really wish that PDF generators just stop using inline images.)