### PR TITLE
Ignore named encoding for non-embedded symbol fonts (issue 16464)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -3487,6 +3487,17 @@ class PartialEvaluator {
       }
     }
 
+    const nonEmbeddedFont = !properties.file || properties.isInternalFont;
+    // Ignore an incorrectly specified named encoding for non-embedded
+    // symbol fonts (fixes issue16464.pdf).
+    if (
+      baseEncodingName &&
+      nonEmbeddedFont &&
+      getSymbolsFonts()[properties.name]
+    ) {
+      baseEncodingName = null;
+    }
+
     if (baseEncodingName) {
       properties.defaultEncoding = getEncoding(baseEncodingName);
     } else {
@@ -3503,7 +3514,7 @@ class PartialEvaluator {
       // Heuristic: we have to check if the font is a standard one also
       if (isSymbolicFont) {
         encoding = MacRomanEncoding;
-        if (!properties.file || properties.isInternalFont) {
+        if (nonEmbeddedFont) {
           if (/Symbol/i.test(properties.name)) {
             encoding = SymbolSetEncoding;
           } else if (/Dingbats|Wingdings/i.test(properties.name)) {

--- a/test/pdfs/issue16464.pdf.link
+++ b/test/pdfs/issue16464.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/11548733/DocumentWithCheckbox.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -58,6 +58,14 @@
        "lastPage": 1,
        "type": "eq"
     },
+    {  "id": "issue16464",
+       "file": "pdfs/issue16464.pdf",
+       "md5": "2bd97ff909e2185605788daa70de38ee",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "tracemonkey-fbf",
        "file": "pdfs/tracemonkey.pdf",
        "md5": "9a192d8b1a7dc652a19835f6f08098bd",


### PR DESCRIPTION
The affected font is non-embedded ZapfDingbats, however the PDF document for some inexplicable reason specifies the encoding as "WinAnsiEncoding" (which is obviously wrong).
To work-around this bug in the PDF generator, we'll simply ignore any explicitly specified named encoding for non-embedded symbol fonts.