### PR TITLE
Avoid to have a null fallback if none has been provided

### DIFF
--- a/src/core/font_substitutions.js
+++ b/src/core/font_substitutions.js
@@ -465,10 +465,12 @@ function getFontSubstitution(
     src.push(`local(${baseFontName})`);
   }
   const { style, ultimate } = generateFont(substitution, src, localFontPath);
+  const guessFallback = ultimate === null;
+  const fallback = guessFallback ? "" : `,${ultimate}`;
 
   substitutionInfo = {
-    css: `${loadedName},${ultimate}`,
-    guessFallback: false,
+    css: `${loadedName}${fallback}`,
+    guessFallback,
     loadedName,
     baseFontName,
     src: src.join(","),


### PR DESCRIPTION
I noticed this bug in looking at PR #16451 where no "ultimate" was provided for Wingdings substitution.