### PR TITLE
Re-factor the `isPageVisible`-handling in the find-controller (PR 10217 follow-up)

### DIFF
--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -116,11 +116,6 @@ class IPDFLinkService {
   /**
    * @param {number} pageNumber
    */
-  isPageVisible(pageNumber) {}
-
-  /**
-   * @param {number} pageNumber
-   */
   isPageCached(pageNumber) {}
 }
 

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -396,6 +396,12 @@ class PDFFindController {
     this._eventBus = eventBus;
     this.#updateMatchesCountOnProgress = updateMatchesCountOnProgress;
 
+    /**
+     * Callback used to check if a `pageNumber` is currently visible.
+     * @type {function}
+     */
+    this.onIsPageVisible = null;
+
     this.#reset();
     eventBus._on("find", this.#onFind.bind(this));
     eventBus._on("findbarclose", this.#onFindBarClose.bind(this));
@@ -636,15 +642,12 @@ class PDFFindController {
         // there's a risk that consecutive 'findagain' operations could "skip"
         // over matches at the top/bottom of pages thus making them completely
         // inaccessible when there's multiple pages visible in the viewer.
-        if (
+        return (
           pageNumber >= 1 &&
           pageNumber <= linkService.pagesCount &&
           pageNumber !== linkService.page &&
-          !linkService.isPageVisible(pageNumber)
-        ) {
-          return true;
-        }
-        return false;
+          !(this.onIsPageVisible?.(pageNumber) ?? true)
+        );
       case "highlightallchange":
         return false;
     }

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -572,13 +572,6 @@ class PDFLinkService {
   /**
    * @param {number} pageNumber
    */
-  isPageVisible(pageNumber) {
-    return this.pdfViewer.isPageVisible(pageNumber);
-  }
-
-  /**
-   * @param {number} pageNumber
-   */
   isPageCached(pageNumber) {
     return this.pdfViewer.isPageCached(pageNumber);
   }
@@ -744,13 +737,6 @@ class SimpleLinkService {
    * @param {Object} pageRef - reference to the page.
    */
   cachePageRef(pageNum, pageRef) {}
-
-  /**
-   * @param {number} pageNumber
-   */
-  isPageVisible(pageNumber) {
-    return true;
-  }
 
   /**
    * @param {number} pageNumber

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -259,6 +259,11 @@ class PDFViewer {
     this.linkService = options.linkService || new SimpleLinkService();
     this.downloadManager = options.downloadManager || null;
     this.findController = options.findController || null;
+
+    if (this.findController) {
+      this.findController.onIsPageVisible = pageNumber =>
+        this._getVisiblePages().ids.has(pageNumber);
+    }
     this._scriptingManager = options.scriptingManager || null;
     this.#textLayerMode = options.textLayerMode ?? TextLayerMode.ENABLE;
     this.#annotationMode =
@@ -1638,26 +1643,6 @@ class PDFViewer {
       horizontal,
       rtl,
     });
-  }
-
-  /**
-   * @param {number} pageNumber
-   */
-  isPageVisible(pageNumber) {
-    if (!this.pdfDocument) {
-      return false;
-    }
-    if (
-      !(
-        Number.isInteger(pageNumber) &&
-        pageNumber > 0 &&
-        pageNumber <= this.pagesCount
-      )
-    ) {
-      console.error(`isPageVisible: "${pageNumber}" is not a valid page.`);
-      return false;
-    }
-    return this._getVisiblePages().ids.has(pageNumber);
   }
 
   /**


### PR DESCRIPTION
The way that this was implemented in PR #10217 has always bothered me slightly, since the `isPageVisible`-method that I introduced there always felt quite out-of-place in the `IPDFLinkService`-implementations.
Hence this is instead replaced by a callback-function in `PDFFindController`, to handle the page-visibility checks. Note that since the `PDFViewer`-constructor always sets this callback-function, e.g. the viewer-component examples still work as-is.