### PR TITLE
[Annotation] Use the clip-path property when an annotation has some quad points

### DIFF
--- a/test/annotation_layer_builder_overrides.css
+++ b/test/annotation_layer_builder_overrides.css
@@ -29,12 +29,22 @@
   -webkit-appearance: none;
 }
 
-.annotationLayer :is(.linkAnnotation, .buttonWidgetAnnotation.pushButton) > a,
+.annotationLayer
+  :is(.linkAnnotation, .buttonWidgetAnnotation.pushButton):not(.hasBorder)
+  > a,
 .annotationLayer .popupTriggerArea::after,
 .annotationLayer .fileAttachmentAnnotation .popupTriggerArea {
   opacity: 0.2;
   background: rgba(255, 255, 0, 1);
   box-shadow: 0 2px 10px rgba(255, 255, 0, 1);
+}
+
+.annotationLayer .hasClipPath::after {
+  box-shadow: none;
+}
+
+.annotationLayer .linkAnnotation.hasBorder {
+  background-color: rgba(255, 255, 0, 0.2);
 }
 
 .annotationLayer .popupTriggerArea::after {

--- a/test/driver.js
+++ b/test/driver.js
@@ -84,6 +84,9 @@ async function writeSVG(svgElement, ctx) {
     // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1844414
     // we load the image two times.
     await loadImage(svg_xml, null);
+    await new Promise(resolve => {
+      setTimeout(resolve, 10);
+    });
   }
   return loadImage(svg_xml, ctx);
 }

--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -120,11 +120,19 @@
 }
 
 .annotationLayer
-  :is(.linkAnnotation, .buttonWidgetAnnotation.pushButton)
+  :is(.linkAnnotation, .buttonWidgetAnnotation.pushButton):not(.hasBorder)
   > a:hover {
   opacity: 0.2;
-  background: rgba(255, 255, 0, 1);
+  background-color: rgba(255, 255, 0, 1);
   box-shadow: 0 2px 10px rgba(255, 255, 0, 1);
+}
+
+.annotationLayer .linkAnnotation.hasBorder:hover {
+  background-color: rgba(255, 255, 0, 0.2);
+}
+
+.annotationLayer .hasBorder {
+  background-size: 100% 100%;
 }
 
 .annotationLayer .textAnnotation img {
@@ -367,4 +375,14 @@
 .annotationLayer .annotationTextContent span {
   width: 100%;
   display: inline-block;
+}
+
+.annotationLayer svg.quadrilateralsContainer {
+  contain: strict;
+  width: 0;
+  height: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: -1;
 }


### PR DESCRIPTION
This way it'll avoid to split a div in multiple divs having the same id (which is supposed to be unique).