### PR TITLE
Limit some `PDFRenderingQueue`-related code to the GENERIC viewer

### DIFF
--- a/web/pdf_rendering_queue.js
+++ b/web/pdf_rendering_queue.js
@@ -36,6 +36,12 @@ class PDFRenderingQueue {
     this.idleTimeout = null;
     this.printing = false;
     this.isThumbnailViewEnabled = false;
+
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+      Object.defineProperty(this, "hasViewer", {
+        value: () => !!this.pdfViewer,
+      });
+    }
   }
 
   /**
@@ -58,13 +64,6 @@ class PDFRenderingQueue {
    */
   isHighestPriority(view) {
     return this.highestPriorityPage === view.renderingId;
-  }
-
-  /**
-   * @returns {boolean}
-   */
-  hasViewer() {
-    return !!this.pdfViewer;
   }
 
   /**

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -301,7 +301,10 @@ class PDFViewer {
     }
 
     this.defaultRenderingQueue = !options.renderingQueue;
-    if (this.defaultRenderingQueue) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&
+      this.defaultRenderingQueue
+    ) {
       // Custom rendering queue is not specified, using default one
       this.renderingQueue = new PDFRenderingQueue();
       this.renderingQueue.setViewer(this);


### PR DESCRIPTION
Given that this functionality is only relevant in third-party use-cases, for example the viewer-components, we can avoid needlessly including it in e.g. the MOZCENTRAL build.