### PR TITLE
[api-minor] Update the minimum supported Google Chrome version to 92

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -77,7 +77,7 @@ const config = JSON.parse(fs.readFileSync(CONFIG_FILE).toString());
 
 const ENV_TARGETS = [
   "last 2 versions",
-  "Chrome >= 88",
+  "Chrome >= 92",
   "Firefox ESR",
   "Safari >= 15.4",
   "Node >= 18",

--- a/src/shared/compatibility.js
+++ b/src/shared/compatibility.js
@@ -36,22 +36,6 @@ import { isNodeJS } from "./is_node.js";
   polyfillPath2D(globalThis);
 })();
 
-// Support: Chrome<92
-(function checkArrayAt() {
-  if (Array.prototype.at) {
-    return;
-  }
-  require("core-js/es/array/at.js");
-})();
-
-// Support: Chrome<92
-(function checkTypedArrayAt() {
-  if (Uint8Array.prototype.at) {
-    return;
-  }
-  require("core-js/es/typed-array/at.js");
-})();
-
 // Support: Chrome<98
 (function checkStructuredClone() {
   if (globalThis.structuredClone) {


### PR DESCRIPTION
This patch updates the minimum supported browsers as follows:
 - Google Chrome 92, which was released on 2021-07-20; see https://support.google.com/chrome/a/answer/10314655

Note that nowadays we usually try, where feasible and possible, to support browsers that are about two years old. By limiting support to only "recent" browsers we reduce the risk of holding back improvements of the *built-in* Firefox PDF Viewer, and also (significantly) reduce the maintenance/support burden for the PDF.js contributors.

*Please note:* As always, the minimum supported browser version assumes that a `legacy`-build of the PDF.js library is being used; see https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#faq-support