### PR TITLE
Fix incorrect `USERACTIVATION_CALLBACKID` import (15618 follow-up)

### DIFF
--- a/src/scripting_api/event.js
+++ b/src/scripting_api/event.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { USERACTIVATION_CALLBACKID } from "./doc.js";
+import { USERACTIVATION_CALLBACKID } from "./app.js";
 
 const USERACTIVATION_MAXTIME_VALIDITY = 5000;
 


### PR DESCRIPTION
This constant is currently imported from the wrong file, where it doesn't exist; see PR #15618.