### PR TITLE
Enable the `import/named` ESLint plugin rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,7 @@
   "rules": {
     // Plugins
     "import/extensions": ["error", "always", { "ignorePackages": true, }],
+    "import/named": "error",
     "import/no-unresolved": ["error", {
       "ignore": ["pdfjs", "pdfjs-lib", "pdfjs-web", "web"]
     }],


### PR DESCRIPTION
This would've prevented issue #16512, please see https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/named.md