### PR TITLE
[editor] Initialize `KeyboardManager`-instances lazily

### DIFF
--- a/src/display/editor/freetext.js
+++ b/src/display/editor/freetext.js
@@ -21,6 +21,7 @@ import {
   AnnotationEditorType,
   assert,
   LINE_FACTOR,
+  shadow,
   Util,
 } from "../../shared/util.js";
 import { bindEvents, KeyboardManager } from "./tools.js";
@@ -58,12 +59,18 @@ class FreeTextEditor extends AnnotationEditor {
 
   static _defaultFontSize = 10;
 
-  static _keyboardManager = new KeyboardManager([
-    [
-      ["ctrl+Enter", "mac+meta+Enter", "Escape", "mac+Escape"],
-      FreeTextEditor.prototype.commitOrRemove,
-    ],
-  ]);
+  static get _keyboardManager() {
+    return shadow(
+      this,
+      "_keyboardManager",
+      new KeyboardManager([
+        [
+          ["ctrl+Enter", "mac+meta+Enter", "Escape", "mac+Escape"],
+          FreeTextEditor.prototype.commitOrRemove,
+        ],
+      ])
+    );
+  }
 
   static _type = "freetext";
 

--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -396,30 +396,42 @@ class AnnotationEditorUIManager {
 
   #container = null;
 
-  static _keyboardManager = new KeyboardManager([
-    [["ctrl+a", "mac+meta+a"], AnnotationEditorUIManager.prototype.selectAll],
-    [["ctrl+z", "mac+meta+z"], AnnotationEditorUIManager.prototype.undo],
-    [
-      ["ctrl+y", "ctrl+shift+Z", "mac+meta+shift+Z"],
-      AnnotationEditorUIManager.prototype.redo,
-    ],
-    [
-      [
-        "Backspace",
-        "alt+Backspace",
-        "ctrl+Backspace",
-        "shift+Backspace",
-        "mac+Backspace",
-        "mac+alt+Backspace",
-        "mac+ctrl+Backspace",
-        "Delete",
-        "ctrl+Delete",
-        "shift+Delete",
-      ],
-      AnnotationEditorUIManager.prototype.delete,
-    ],
-    [["Escape", "mac+Escape"], AnnotationEditorUIManager.prototype.unselectAll],
-  ]);
+  static get _keyboardManager() {
+    return shadow(
+      this,
+      "_keyboardManager",
+      new KeyboardManager([
+        [
+          ["ctrl+a", "mac+meta+a"],
+          AnnotationEditorUIManager.prototype.selectAll,
+        ],
+        [["ctrl+z", "mac+meta+z"], AnnotationEditorUIManager.prototype.undo],
+        [
+          ["ctrl+y", "ctrl+shift+Z", "mac+meta+shift+Z"],
+          AnnotationEditorUIManager.prototype.redo,
+        ],
+        [
+          [
+            "Backspace",
+            "alt+Backspace",
+            "ctrl+Backspace",
+            "shift+Backspace",
+            "mac+Backspace",
+            "mac+alt+Backspace",
+            "mac+ctrl+Backspace",
+            "Delete",
+            "ctrl+Delete",
+            "shift+Delete",
+          ],
+          AnnotationEditorUIManager.prototype.delete,
+        ],
+        [
+          ["Escape", "mac+Escape"],
+          AnnotationEditorUIManager.prototype.unselectAll,
+        ],
+      ])
+    );
+  }
 
   constructor(container, eventBus, annotationStorage) {
     this.#container = container;


### PR DESCRIPTION
As far as I can tell there's no particular reason for initializing `KeyboardManager`-instances eagerly, since the user may never use editing, and we can easily do this lazily instead by utilizing shadowed getters.