### PR TITLE
Enable more `import` ESLint plugin rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,8 +32,14 @@
 
   "rules": {
     // Plugins
+    "import/export": "error",
+    "import/exports-last": "error",
     "import/extensions": ["error", "always", { "ignorePackages": true, }],
+    "import/first": "error",
     "import/named": "error",
+    "import/no-empty-named-blocks": "error",
+    "import/no-mutable-exports": "error",
+    "import/no-self-import": "error",
     "import/no-unresolved": ["error", {
       "ignore": ["pdfjs", "pdfjs-lib", "pdfjs-web", "web"]
     }],

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -69,24 +69,22 @@ const DEFAULT_RANGE_CHUNK_SIZE = 65536; // 2^16 = 65536
 const RENDERING_CANCELLED_TIMEOUT = 100; // ms
 const DELAYED_CLEANUP_TIMEOUT = 5000; // ms
 
-let DefaultCanvasFactory = DOMCanvasFactory;
-let DefaultCMapReaderFactory = DOMCMapReaderFactory;
-let DefaultFilterFactory = DOMFilterFactory;
-let DefaultStandardFontDataFactory = DOMStandardFontDataFactory;
-
-if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("GENERIC") && isNodeJS) {
-  const {
-    NodeCanvasFactory,
-    NodeCMapReaderFactory,
-    NodeFilterFactory,
-    NodeStandardFontDataFactory,
-  } = require("./node_utils.js");
-
-  DefaultCanvasFactory = NodeCanvasFactory;
-  DefaultCMapReaderFactory = NodeCMapReaderFactory;
-  DefaultFilterFactory = NodeFilterFactory;
-  DefaultStandardFontDataFactory = NodeStandardFontDataFactory;
-}
+const DefaultCanvasFactory =
+  typeof PDFJSDev !== "undefined" && PDFJSDev.test("GENERIC") && isNodeJS
+    ? require("./node_utils.js").NodeCanvasFactory
+    : DOMCanvasFactory;
+const DefaultCMapReaderFactory =
+  typeof PDFJSDev !== "undefined" && PDFJSDev.test("GENERIC") && isNodeJS
+    ? require("./node_utils.js").NodeCMapReaderFactory
+    : DOMCMapReaderFactory;
+const DefaultFilterFactory =
+  typeof PDFJSDev !== "undefined" && PDFJSDev.test("GENERIC") && isNodeJS
+    ? require("./node_utils.js").NodeFilterFactory
+    : DOMFilterFactory;
+const DefaultStandardFontDataFactory =
+  typeof PDFJSDev !== "undefined" && PDFJSDev.test("GENERIC") && isNodeJS
+    ? require("./node_utils.js").NodeStandardFontDataFactory
+    : DOMStandardFontDataFactory;
 
 let createPDFNetworkStream;
 if (typeof PDFJSDev === "undefined") {

--- a/src/display/svg.js
+++ b/src/display/svg.js
@@ -28,6 +28,7 @@ import {
 import { isNodeJS } from "../shared/is_node.js";
 
 /** @type {any} */
+// eslint-disable-next-line import/no-mutable-exports
 let SVGGraphics = class {
   constructor() {
     unreachable("Not implemented: SVGGraphics");


### PR DESCRIPTION
This patch enables more `import` rules to help prevent bugs/inconsistencies, and most of these rules didn't require code changes; please find additional details here:
 - https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/export.md
 - https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/exports-last.md
 - https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/first.md
 - https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-empty-named-blocks.md
 - https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-mutable-exports.md
 - https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-self-import.md