### PR TITLE
Improve Puppeteer's `trimCache` API usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "postcss": "^8.4.23",
         "postcss-dir-pseudo-class": "^7.0.2",
         "prettier": "^2.8.8",
-        "puppeteer": "^20.4.0",
+        "puppeteer": "^20.5.0",
         "rimraf": "^3.0.2",
         "streamqueue": "^1.1.2",
         "stylelint": "^15.6.2",
@@ -2962,15 +2962,15 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.4.0.tgz",
-      "integrity": "sha512-HiRpoc15NhFwoR1IjN3MkMsqeAfRQKNzbhWVV+0BfvybEhjWSyRNQMC0ohMhkFhzoGnFoS59WlrJCGLPky/89g==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.4.1.tgz",
+      "integrity": "sha512-H43VosMzywHCcYcgv0GXXopvwnV21Ud9g2aXbPlQUJj1Xcz9V0wBwHeFz6saFhx/3VKisZfI1GEKEOhQCau7Vw==",
       "dev": true,
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
         "progress": "2.0.3",
-        "proxy-agent": "6.2.0",
+        "proxy-agent": "6.2.1",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
         "yargs": "17.7.1"
@@ -2979,7 +2979,7 @@
         "browsers": "lib/cjs/main-cli.js"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=16.3.0"
       },
       "peerDependencies": {
         "typescript": ">= 4.7.4"
@@ -4733,9 +4733,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.10.tgz",
-      "integrity": "sha512-ngdRIq/f5G3nIOz1M0MtCABCTezr79MBCrJ09K2xRk+hTZQGTH8JIeFbgQmVvNPBMQblh7ROfJnSzsE07YpFfg==",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.11.tgz",
+      "integrity": "sha512-p03ajLhlQ5gebw3cmbDBFmBc2wnJM5dnXS8Phu6mblGn/KQd76yOVL5VwE0VAisa7oazNfKGTaXlIZ8Q5Bb9OA==",
       "dev": true,
       "dependencies": {
         "mitt": "3.0.0"
@@ -8577,9 +8577,9 @@
       }
     },
     "node_modules/http-proxy-agent": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-6.1.1.tgz",
-      "integrity": "sha512-JRCz+4Whs6yrrIoIlrH+ZTmhrRwtMnmOHsHn8GFEn9O2sVfSE+DAZ3oyyGIKF8tjJEeSJmP89j7aTjVsSqsU0g==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
       "dev": true,
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -15825,19 +15825,6 @@
         }
       }
     },
-    "node_modules/pac-proxy-agent/node_modules/http-proxy-agent": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
-      "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.0.tgz",
@@ -16392,17 +16379,17 @@
       }
     },
     "node_modules/proxy-agent": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.2.0.tgz",
-      "integrity": "sha512-g3rBHXPhEa0Z1nxZkirj0+US1SCcA67SnjpxbdZf7BloLdULEUCzbQozsq+wFwhmMeZegeZISDZjPFN/Ct9DaQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.2.1.tgz",
+      "integrity": "sha512-OIbBKlRAT+ycCm6wAYIzMwPejzRtjy8F3QiDX0eKOA3e4pe3U9F/IvzcHP42bmgQxVv97juG+J8/gx+JIeCX/Q==",
       "dev": true,
       "dependencies": {
-        "agent-base": "^7.0.1",
+        "agent-base": "^7.0.2",
         "debug": "^4.3.4",
-        "http-proxy-agent": "^6.0.1",
-        "https-proxy-agent": "^6.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
         "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^6.0.2",
+        "pac-proxy-agent": "^6.0.3",
         "proxy-from-env": "^1.1.0",
         "socks-proxy-agent": "^8.0.1"
       },
@@ -16440,9 +16427,9 @@
       }
     },
     "node_modules/proxy-agent/node_modules/https-proxy-agent": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-6.2.1.tgz",
-      "integrity": "sha512-ONsE3+yfZF2caH5+bJlcddtWqNI3Gvs5A38+ngvljxaBiRXRswym2c7yf8UAeFpRFKjFNHIFEHqR/OLAWJzyiA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-0euwPCRyAPSgGdzD1IVN9nJYHtBhJwb6XPfbpQcYbPCwrBidX6GzxmchnaF4sfF/jPb74Ojx5g4yTg3sixlyPw==",
       "dev": true,
       "dependencies": {
         "agent-base": "^7.0.2",
@@ -16636,32 +16623,32 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.4.0.tgz",
-      "integrity": "sha512-0/lgDbbC2LX/vMQ6+cv/doQuguFAf4Ra52fyW5oBOpQd85SzPBtXg4yPk+VhUpgr+oaOVAIUkgvBs98E+8xhCw==",
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.5.0.tgz",
+      "integrity": "sha512-3j0JShJGDT5z8rfDKf+wZQq3IHxw7JaDAdP7py5H5zOIgmqNG0e8R19y4tFzJ8i2WC4H/0bC51rIrTXyDop1FA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "1.4.0",
+        "@puppeteer/browsers": "1.4.1",
         "cosmiconfig": "8.1.3",
-        "puppeteer-core": "20.4.0"
+        "puppeteer-core": "20.5.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.4.0.tgz",
-      "integrity": "sha512-fcL2fYQLFZEuIIDbMhvf6WF5rAcKXetsrjOxu6Br6FEAet7kEtJlCcrKmnz3pfqkwAIlihjuzwT5ys7jMWEx8A==",
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.5.0.tgz",
+      "integrity": "sha512-9ddHXUQ7jpliGei87zYTuEZYQvFj6Lzk5R8w4vT4gMmNArkEqC5CX72TnVIJiTUbiTpOXJkvMQaXIHYopjdUtQ==",
       "dev": true,
       "dependencies": {
-        "@puppeteer/browsers": "1.4.0",
-        "chromium-bidi": "0.4.10",
+        "@puppeteer/browsers": "1.4.1",
+        "chromium-bidi": "0.4.11",
         "cross-fetch": "3.1.6",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1120988",
         "ws": "8.13.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=16.3.0"
       },
       "peerDependencies": {
         "typescript": ">= 4.7.4"
@@ -19073,9 +19060,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
-      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
       "dev": true
     },
     "node_modules/ttest": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "postcss": "^8.4.23",
     "postcss-dir-pseudo-class": "^7.0.2",
     "prettier": "^2.8.8",
-    "puppeteer": "^20.4.0",
+    "puppeteer": "^20.5.0",
     "rimraf": "^3.0.2",
     "streamqueue": "^1.1.2",
     "stylelint": "^15.6.2",

--- a/test/test.js
+++ b/test/test.js
@@ -953,7 +953,7 @@ async function startBrowsers(initSessionCallback, makeStartUrl = null) {
   // Remove old browser revisions from Puppeteer's cache. Updating Puppeteer can
   // cause new browser revisions to be downloaded, so trimming the cache will
   // prevent the disk from filling up over time.
-  await puppeteer.default.trimCache();
+  await puppeteer.trimCache();
 
   const browserNames = options.noChrome ? ["firefox"] : ["firefox", "chrome"];
 


### PR DESCRIPTION
The original `trimCache` functionality was intended to be exposed on the top-level `puppeteer` module, but due to a bug in Puppeteer this didn't work correctly and we had to call `trimCache` on the default Puppeteer node instance instead, which was fortunately exposed. However, since this didn't feel like intended API usage, this bug was reported and is now fixed in Puppeteer 20.5.0, so this commits updates Puppeteer to that version so we can use the intended API.

The full history of this issue can be found at https://github.com/puppeteer/puppeteer/issues/10174.