### PR TITLE
Improve SMask/Mask lookup when parsing inline images

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -724,12 +724,14 @@ class PartialEvaluator {
       return;
     }
 
-    const softMask = dict.get("SM", "SMask") || false;
-    const mask = dict.get("Mask") || false;
-
     const SMALL_IMAGE_DIMENSIONS = 200;
     // Inlining small images into the queue as RGB data
-    if (isInline && !softMask && !mask && w + h < SMALL_IMAGE_DIMENSIONS) {
+    if (
+      isInline &&
+      !dict.has("SMask") &&
+      !dict.has("Mask") &&
+      w + h < SMALL_IMAGE_DIMENSIONS
+    ) {
       const imageObj = new PDFImage({
         xref: this.xref,
         res: resources,


### PR DESCRIPTION
 - Don't attempt to lookup an "SM" entry, since we're only using "SMask" in the `PDFImage` code and I also cannot find any mention in the PDF specification about that being a valid abbreviation for a Soft Mask entry. (There's only a `SM = Smoothness Tolerance` Graphics State parameter, which is obviously something completely different.)

 - Don't lookup the /SMask and /Mask entries unless it's actually an inline image, since it's pointless otherwise.

 - Last, but most importantly, only check for the *existence* of /SMask and /Mask entries but don't actually fetch the data. Note that if either one exists it'll contain a Stream, and those cannot be cached on the `XRef`-instance, which leads to unnecessary parsing/allocations and in this case we're not using the actual data for anything.