### PR TITLE
Enable the `unicorn/prefer-optional-catch-binding` ESLint plugin rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -72,6 +72,7 @@
     "unicorn/prefer-logical-operator-over-ternary": "error",
     "unicorn/prefer-modern-dom-apis": "error",
     "unicorn/prefer-negative-index": "error",
+    "unicorn/prefer-optional-catch-binding": "error",
     "unicorn/prefer-regexp-test": "error",
     "unicorn/prefer-string-replace-all": "error",
     "unicorn/prefer-string-starts-ends-with": "error",

--- a/examples/mobile-viewer/viewer.js
+++ b/examples/mobile-viewer/viewer.js
@@ -174,7 +174,7 @@ const PDFViewerApplication = {
     let title = pdfjsLib.getFilenameFromUrl(url) || url;
     try {
       title = decodeURIComponent(title);
-    } catch (e) {
+    } catch {
       // decodeURIComponent may throw URIError,
       // fall back to using the unprocessed url in that case
     }

--- a/extensions/chromium/preserve-referer.js
+++ b/extensions/chromium/preserve-referer.js
@@ -62,7 +62,7 @@ var extraInfoSpecWithHeaders; // = ['requestHeaders', 'extraHeaders']
   }
   try {
     registerListener(["requestHeaders", "extraHeaders"]);
-  } catch (e) {
+  } catch {
     // "extraHeaders" is not supported in Chrome 71 and earlier.
     registerListener(["requestHeaders"]);
   }

--- a/extensions/firefox/tools/l10n.js
+++ b/extensions/firefox/tools/l10n.js
@@ -66,7 +66,7 @@
     if (element.dataset.l10nArgs) {
       try {
         args = JSON.parse(element.dataset.l10nArgs);
-      } catch (e) {
+      } catch {
         console.warn("[l10n] could not parse arguments for #" + key + "");
       }
     }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -594,7 +594,7 @@ function checkFile(filePath) {
   try {
     const stat = fs.lstatSync(filePath);
     return stat.isFile();
-  } catch (e) {
+  } catch {
     return false;
   }
 }
@@ -603,7 +603,7 @@ function checkDir(dirPath) {
   try {
     const stat = fs.lstatSync(dirPath);
     return stat.isDirectory();
-  } catch (e) {
+  } catch {
     return false;
   }
 }

--- a/src/core/cff_font.js
+++ b/src/core/cff_font.js
@@ -28,7 +28,7 @@ class CFFFont {
     this.seacs = this.cff.seacs;
     try {
       this.data = compiler.compile();
-    } catch (e) {
+    } catch {
       warn("Failed to compile font " + properties.loadedName);
       // There may have just been an issue with the compiler, set the data
       // anyway and hope the font loaded.

--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -1734,7 +1734,7 @@ const CipherTransformFactory = (function CipherTransformFactoryClosure() {
         if (revision === 6) {
           try {
             password = utf8StringToString(password);
-          } catch (ex) {
+          } catch {
             warn(
               "CipherTransformFactory: Unable to convert UTF8 encoded password."
             );

--- a/src/core/dataset_reader.js
+++ b/src/core/dataset_reader.js
@@ -53,7 +53,7 @@ class DatasetReader {
       const parser = new DatasetXMLParser({ hasAttributes: true });
       try {
         parser.parseFromString(data["xdp:xdp"]);
-      } catch (_) {}
+      } catch {}
       this.node = parser.node;
     }
   }

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -1057,7 +1057,7 @@ class PDFDocument {
         const str = stringToUTF8String(stream.getString());
         const data = { [key]: str };
         return shadow(this, "xfaDatasets", new DatasetReader(data));
-      } catch (_) {
+      } catch {
         warn("XFA - Invalid utf-8 string.");
         break;
       }
@@ -1077,7 +1077,7 @@ class PDFDocument {
       }
       try {
         data[key] = stringToUTF8String(stream.getString());
-      } catch (_) {
+      } catch {
         warn("XFA - Invalid utf-8 string.");
         return null;
       }

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1498,7 +1498,7 @@ class PartialEvaluator {
           );
           operatorList.addOp(fn, tilingPatternIR);
           return undefined;
-        } catch (ex) {
+        } catch {
           // Handle any errors during normal TilingPattern parsing.
         }
       }

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -3045,7 +3045,7 @@ class Font {
         cff.duplicateFirstGlyph();
         const compiler = new CFFCompiler(cff);
         tables["CFF "].data = compiler.compile();
-      } catch (e) {
+      } catch {
         warn("Failed to compile font " + properties.loadedName);
       }
     }

--- a/src/core/image_resizer.js
+++ b/src/core/image_resizer.js
@@ -129,7 +129,7 @@ class ImageResizer {
       const opacity = ctx.getImageData(0, 0, 1, 1).data[3];
       canvas.width = canvas.height = 1;
       return opacity !== 0;
-    } catch (e) {
+    } catch {
       return false;
     }
   }

--- a/src/core/type1_font.js
+++ b/src/core/type1_font.js
@@ -67,7 +67,7 @@ function getHeaderBlock(stream, suggestedLength) {
   try {
     headerBytes = stream.getBytes(suggestedLength);
     headerBytesLength = headerBytes.length;
-  } catch (ex) {
+  } catch {
     // Ignore errors if the `suggestedLength` is huge enough that a Uint8Array
     // cannot hold the result of `getBytes`, and fallback to simply checking
     // the entire stream (fixes issue3928.pdf).

--- a/src/core/xfa/xfa_object.js
+++ b/src/core/xfa/xfa_object.js
@@ -644,7 +644,7 @@ class XFAObject {
     for (const $symbol of Object.getOwnPropertySymbols(this)) {
       try {
         clone[$symbol] = this[$symbol];
-      } catch (_) {
+      } catch {
         shadow(clone, $symbol, this[$symbol]);
       }
     }

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -523,7 +523,7 @@ function getUrlProp(val) {
   try {
     // The full path is required in the 'url' field.
     return new URL(val, window.location).href;
-  } catch (ex) {
+  } catch {
     if (
       typeof PDFJSDev !== "undefined" &&
       PDFJSDev.test("GENERIC") &&
@@ -2011,7 +2011,7 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       if (!base.origin || base.origin === "null") {
         return false; // non-HTTP url
       }
-    } catch (e) {
+    } catch {
       return false;
     }
 
@@ -2187,7 +2187,7 @@ class PDFWorker {
           }
           try {
             sendTest();
-          } catch (e) {
+          } catch {
             // We need fallback to a faked worker.
             this._setupFakeWorker();
           }
@@ -2204,7 +2204,7 @@ class PDFWorker {
         // The worker shall process only the first received "test" message.
         sendTest();
         return;
-      } catch (e) {
+      } catch {
         info("The worker has been disabled.");
       }
     }
@@ -2305,7 +2305,7 @@ class PDFWorker {
   static get _mainThreadWorkerMessageHandler() {
     try {
       return globalThis.pdfjsWorker?.WorkerMessageHandler || null;
-    } catch (ex) {
+    } catch {
       return null;
     }
   }

--- a/src/display/content_disposition.js
+++ b/src/display/content_disposition.js
@@ -89,7 +89,7 @@ function getFilenameFromContentDispositionHeader(contentDisposition) {
         const buffer = stringToBytes(value);
         value = decoder.decode(buffer);
         needsEncodingFixup = false;
-      } catch (e) {
+      } catch {
         // TextDecoder constructor threw - unrecognized encoding.
       }
     }
@@ -207,7 +207,7 @@ function getFilenameFromContentDispositionHeader(contentDisposition) {
         } // else encoding is b or B - base64 (RFC 2047 section 4.1)
         try {
           text = atob(text);
-        } catch (e) {}
+        } catch {}
         return textdecode(charset, text);
       }
     );

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -648,7 +648,7 @@ function getPdfFilenameFromUrl(url, defaultFilename = "document.pdf") {
         suggestedFilename = reFilename.exec(
           decodeURIComponent(suggestedFilename)
         )[0];
-      } catch (ex) {
+      } catch {
         // Possible (extremely rare) errors:
         // URIError "Malformed URI", e.g. for "%AA.pdf"
         // TypeError "null has no properties", e.g. for "%2F.pdf"
@@ -702,7 +702,7 @@ function isValidFetchUrl(url, baseUrl) {
     const { protocol } = baseUrl ? new URL(url, baseUrl) : new URL(url);
     // The Fetch API only supports the http/https protocols, and not file/ftp.
     return protocol === "http:" || protocol === "https:";
-  } catch (ex) {
+  } catch {
     return false; // `new URL()` will throw on incorrect data.
   }
 }

--- a/src/display/network_utils.js
+++ b/src/display/network_utils.js
@@ -74,7 +74,7 @@ function extractFilenameFromHeader(getResponseHeader) {
     if (filename.includes("%")) {
       try {
         filename = decodeURIComponent(filename);
-      } catch (ex) {}
+      } catch {}
     }
     if (isPdfFile(filename)) {
       return filename;

--- a/src/scripting_api/aform.js
+++ b/src/scripting_api/aform.js
@@ -144,7 +144,7 @@ class AForm {
     let date = null;
     try {
       date = this._util.scand(cFormat, cDate);
-    } catch (error) {}
+    } catch {}
     if (!date) {
       date = Date.parse(cDate);
       if (isNaN(date)) {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -434,7 +434,7 @@ function createValidAbsoluteUrl(url, baseUrl = null, options = null) {
       if (options.tryConvertEncoding) {
         try {
           url = stringToUTF8String(url);
-        } catch (ex) {}
+        } catch {}
       }
     }
 
@@ -442,7 +442,7 @@ function createValidAbsoluteUrl(url, baseUrl = null, options = null) {
     if (_isValidProtocol(absoluteUrl)) {
       return absoluteUrl;
     }
-  } catch (ex) {
+  } catch {
     /* `new URL()` will throw on incorrect data. */
   }
   return null;
@@ -605,7 +605,7 @@ function isEvalSupported() {
   try {
     new Function(""); // eslint-disable-line no-new, no-new-func
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 }

--- a/test/integration/scripting_spec.js
+++ b/test/integration/scripting_spec.js
@@ -471,7 +471,7 @@ describe("Interaction", () => {
             await page._client.send("Page.setDownloadBehavior", {
               behavior: "deny",
             });
-          } catch (_) {}
+          } catch {}
           await clearInput(page, getSelector("47R"));
           await page.evaluate(_ => {
             window.document.activeElement.blur();

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -168,7 +168,7 @@ describe("api", function () {
 
         // Shouldn't get here.
         expect(false).toEqual(true);
-      } catch (reason) {
+      } catch {
         expect(true).toEqual(true);
         await destroyed;
       }

--- a/test/unit/crypto_spec.js
+++ b/test/unit/crypto_spec.js
@@ -549,7 +549,7 @@ describe("CipherTransformFactory", function () {
     try {
       const factory = new CipherTransformFactory(dict, fileId, password);
       expect("createCipherTransform" in factory).toEqual(true);
-    } catch (ex) {
+    } catch {
       // Shouldn't get here.
       expect(false).toEqual(true);
     }

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -368,7 +368,7 @@ describe("evaluator", function () {
 
         // Shouldn't get here.
         expect(false).toEqual(true);
-      } catch (_) {
+      } catch {
         expect(!!result.fnArray && !!result.argsArray).toEqual(true);
         expect(result.fnArray.length).toEqual(0);
       }
@@ -389,7 +389,7 @@ describe("evaluator", function () {
 
         // Shouldn't get here.
         expect(false).toEqual(true);
-      } catch (_) {
+      } catch {
         expect(true).toEqual(true);
       }
     });

--- a/test/webserver.js
+++ b/test/webserver.js
@@ -90,7 +90,7 @@ WebServer.prototype = {
       // Windows paths cause issues in statFile and serverDirectoryIndex.
       // Converting to unix path would avoid platform checks in said functions.
       pathPart = pathPart.replaceAll("\\", "/");
-    } catch (ex) {
+    } catch {
       // If the URI cannot be decoded, a `URIError` is thrown. This happens for
       // malformed URIs such as `http://localhost:8888/%s%s` and should be
       // handled as a bad request.

--- a/web/app.js
+++ b/web/app.js
@@ -815,7 +815,7 @@ const PDFViewerApplication = {
     if (!title) {
       try {
         title = decodeURIComponent(getFilenameFromUrl(url)) || url;
-      } catch (ex) {
+      } catch {
         // decodeURIComponent may throw URIError,
         // fall back to using the unprocessed url in that case
         title = url;
@@ -876,7 +876,7 @@ const PDFViewerApplication = {
       try {
         // Trigger saving, to prevent data loss in forms; see issue 12257.
         await this.save();
-      } catch (reason) {
+      } catch {
         // Ignoring errors, to ensure that document closing won't break.
       }
     }
@@ -1044,7 +1044,7 @@ const PDFViewerApplication = {
       const blob = new Blob([data], { type: "application/pdf" });
 
       await this.downloadManager.download(blob, url, filename, options);
-    } catch (reason) {
+    } catch {
       // When the PDF document isn't ready, or the PDF file is still
       // downloading, simply download using the URL.
       await this.downloadManager.downloadUrl(url, filename, options);

--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -150,7 +150,7 @@ function isRuntimeAvailable() {
     if (chrome.runtime?.getManifest()) {
       return true;
     }
-  } catch (e) {}
+  } catch {}
   return false;
 }
 

--- a/web/grab_to_pan.js
+++ b/web/grab_to_pan.js
@@ -106,7 +106,7 @@ class GrabToPan {
       try {
         // eslint-disable-next-line no-unused-expressions
         event.originalTarget.tagName;
-      } catch (e) {
+      } catch {
         // Mozilla-specific: element is a scrollbar (XUL element)
         return;
       }

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -445,7 +445,7 @@ class PDFLinkService {
           // e.g. "4.3" or "true", because `JSON.parse` converted its type.
           dest = dest.toString();
         }
-      } catch (ex) {}
+      } catch {}
 
       if (
         typeof dest === "string" ||

--- a/web/pdf_outline_viewer.js
+++ b/web/pdf_outline_viewer.js
@@ -341,7 +341,7 @@ class PDFOutlineViewer extends BaseTreeViewer {
                   return null; // The document was closed while the data resolved.
                 }
                 this.linkService.cachePageRef(pageNumber, destRef);
-              } catch (ex) {
+              } catch {
                 // Invalid page reference, ignore it and continue parsing.
               }
             }

--- a/web/pdf_presentation_mode.js
+++ b/web/pdf_presentation_mode.js
@@ -101,7 +101,7 @@ class PDFPresentationMode {
       await promise;
       pdfViewer.focus(); // Fixes bug 1787456.
       return true;
-    } catch (reason) {
+    } catch {
       this.#removeFullscreenChangeListeners();
       this.#notifyStateChange(PresentationModeState.NORMAL);
     }

--- a/web/pdf_scripting_manager.js
+++ b/web/pdf_scripting_manager.js
@@ -487,7 +487,7 @@ class PDFScriptingManager {
 
     try {
       await this._scripting.destroySandbox();
-    } catch (ex) {}
+    } catch {}
 
     for (const [name, listener] of this._internalEvents) {
       this._eventBus._off(name, listener);


### PR DESCRIPTION
According to MDN this format is available in all browsers/environments that we currently support, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch#browser_compatibility

Please also see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-optional-catch-binding.md