### PR TITLE
[api-minor] Remove the `type` from `RenderingCancelledException` (PR 16226 follow-up)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -3347,7 +3347,6 @@ class InternalRenderTask {
       error ||
         new RenderingCancelledException(
           `Rendering cancelled, page ${this._pageIndex + 1}`,
-          "canvas",
           extraDelay
         )
     );

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -583,9 +583,8 @@ class PageViewport {
 }
 
 class RenderingCancelledException extends BaseException {
-  constructor(msg, type, extraDelay = 0) {
+  constructor(msg, extraDelay = 0) {
     super(msg, "RenderingCancelledException");
-    this.type = type;
     this.extraDelay = extraDelay;
   }
 }

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -3075,7 +3075,6 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
       } catch (reason) {
         expect(reason instanceof RenderingCancelledException).toEqual(true);
         expect(reason.message).toEqual("Rendering cancelled, page 1");
-        expect(reason.type).toEqual("canvas");
         expect(reason.extraDelay).toEqual(0);
       }
 


### PR DESCRIPTION
After PR #16226 we're only using `RenderingCancelledException` together with canvas-rendering, hence the `type`-property is no longer necessary.