### PR TITLE
[api-minor] Make the popup independent of their associated annotations

### DIFF
--- a/src/display/editor/freetext.js
+++ b/src/display/editor/freetext.js
@@ -537,7 +537,9 @@ class FreeTextEditor extends AnnotationEditor {
           id,
         },
         textContent,
-        page: { pageNumber },
+        parent: {
+          page: { pageNumber },
+        },
       } = data;
       if (!textContent || textContent.length === 0) {
         // Empty annotation.

--- a/test/annotation_layer_builder_overrides.css
+++ b/test/annotation_layer_builder_overrides.css
@@ -30,14 +30,18 @@
 }
 
 .annotationLayer :is(.linkAnnotation, .buttonWidgetAnnotation.pushButton) > a,
-.annotationLayer .popupTriggerArea {
+.annotationLayer .popupTriggerArea::after,
+.annotationLayer .fileAttachmentAnnotation .popupTriggerArea {
   opacity: 0.2;
   background: rgba(255, 255, 0, 1);
   box-shadow: 0 2px 10px rgba(255, 255, 0, 1);
 }
 
-.annotationLayer :is(.popupAnnotation, .popupWrapper) {
+.annotationLayer .popupTriggerArea::after {
   display: block;
+  width: 100%;
+  height: 100%;
+  content: "";
 }
 
 .annotationLayer .popup :is(h1, p) {

--- a/test/driver.js
+++ b/test/driver.js
@@ -223,9 +223,7 @@ class Rasterize {
 
       // Rendering annotation layer as HTML.
       const parameters = {
-        viewport: annotationViewport,
         annotations,
-        page,
         linkService: new SimpleLinkService(),
         imageResourcesPath,
         renderForms,
@@ -233,8 +231,12 @@ class Rasterize {
       const annotationLayer = new AnnotationLayer({
         div,
         annotationCanvasMap: annotationImageMap,
+        page,
+        l10n,
+        viewport: annotationViewport,
       });
       annotationLayer.render(parameters);
+      await annotationLayer.showPopups();
       await l10n.translate(div);
 
       // Inline SVG images from text annotations.

--- a/test/integration/annotation_spec.js
+++ b/test/integration/annotation_spec.js
@@ -21,7 +21,7 @@ const {
 } = require("./test_utils.js");
 
 describe("Annotation highlight", () => {
-  describe("annotation-highlight.pdf", () => {
+  fdescribe("annotation-highlight.pdf", () => {
     let pages;
 
     beforeAll(async () => {

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -623,7 +623,7 @@ describe("annotation", function () {
       expect(data.creationDate).toEqual("D:20180423");
       expect(data.modificationDate).toEqual("D:20190423");
       expect(data.color).toEqual(new Uint8ClampedArray([0, 0, 255]));
-      expect(data.hasPopup).toEqual(true);
+      expect(data.popupRef).toEqual("820R");
     });
 
     it("should parse IRT/RT for a reply type", async function () {
@@ -678,7 +678,7 @@ describe("annotation", function () {
       expect(data.creationDate).toEqual("D:20180523");
       expect(data.modificationDate).toEqual("D:20190523");
       expect(data.color).toEqual(new Uint8ClampedArray([102, 102, 102]));
-      expect(data.hasPopup).toEqual(false);
+      expect(data.popupRef).toEqual(null);
     });
   });
 

--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -42,6 +42,10 @@
   .annotationLayer .linkAnnotation:hover {
     backdrop-filter: invert(100%);
   }
+
+  .annotationLayer .popupAnnotation.focused .popup {
+    outline: calc(3px * var(--scale-factor)) solid Highlight !important;
+  }
 }
 
 .annotationLayer {
@@ -240,32 +244,27 @@
   appearance: none;
 }
 
-.annotationLayer .popupTriggerArea {
+.annotationLayer .fileAttachmentAnnotation .popupTriggerArea {
   height: 100%;
   width: 100%;
 }
 
-.annotationLayer .fileAttachmentAnnotation .popupTriggerArea {
-  position: absolute;
-}
-
-.annotationLayer .popupWrapper {
+.annotationLayer .popupAnnotation {
   position: absolute;
   font-size: calc(9px * var(--scale-factor));
-  width: 100%;
-  min-width: calc(180px * var(--scale-factor));
   pointer-events: none;
+  width: max-content;
+  max-width: 45%;
+  height: auto;
 }
 
 .annotationLayer .popup {
-  position: absolute;
-  max-width: calc(180px * var(--scale-factor));
   background-color: rgba(255, 255, 153, 1);
   box-shadow: 0 calc(2px * var(--scale-factor)) calc(5px * var(--scale-factor))
     rgba(136, 136, 136, 1);
   border-radius: calc(2px * var(--scale-factor));
+  outline: 1.5px solid rgb(255, 255, 74);
   padding: calc(6px * var(--scale-factor));
-  margin-left: calc(5px * var(--scale-factor));
   cursor: pointer;
   font: message-box;
   white-space: normal;
@@ -273,17 +272,26 @@
   pointer-events: auto;
 }
 
-.annotationLayer .popup > * {
+.annotationLayer .popupAnnotation.focused .popup {
+  outline-width: 3px;
+}
+
+.annotationLayer .popup * {
   font-size: calc(9px * var(--scale-factor));
 }
 
-.annotationLayer .popup h1 {
+.annotationLayer .popup > .header {
   display: inline-block;
 }
 
-.annotationLayer .popupDate {
+.annotationLayer .popup > .header h1 {
+  display: inline;
+}
+
+.annotationLayer .popup > .header .popupDate {
   display: inline-block;
   margin-left: calc(5px * var(--scale-factor));
+  width: fit-content;
 }
 
 .annotationLayer .popupContent {

--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -129,12 +129,13 @@ class AnnotationLayerBuilder {
       div,
       accessibilityManager: this._accessibilityManager,
       annotationCanvasMap: this._annotationCanvasMap,
+      l10n: this.l10n,
+      page: this.pdfPage,
+      viewport: viewport.clone({ dontFlip: true }),
     });
 
     this.annotationLayer.render({
-      viewport: viewport.clone({ dontFlip: true }),
       annotations,
-      page: this.pdfPage,
       imageResourcesPath: this.imageResourcesPath,
       renderForms: this.renderForms,
       linkService: this.linkService,


### PR DESCRIPTION
- it'll help to be able to move popups on screen to let the user read the text
- popups won't inherit some properties from their parent:
  - the popup can be misrendered if for example the parent has a clip-path property.
- add an outline to the popup when the parent is focused.
- hide a popup when it's clicked.