### PR TITLE
Improve handling of /Filter-entries in `writeStream`

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1979,7 +1979,7 @@ describe("api", function () {
       await loadingTask.destroy();
     });
 
-    it("write a a new annotation, save the pdf and check that the prev entry in xref stream is correct", async function () {
+    it("write a new annotation, save the pdf and check that the prev entry in xref stream is correct", async function () {
       if (isNodeJS) {
         pending("Linked test-cases are not supported in Node.js.");
       }


### PR DESCRIPTION
Fix handling of /Filter-entries, since the current implementation could potentially corrupt the data if there's multiple filters present. Please note that filters are applied *sequentially* during decoding, starting from the first one in the Array, hence the first Array-entry needs to be /FlateDecode in order for things to actually work correctly.

To prevent a future bug, if we want to save more "complex" data such as images, also ensure that we include any existing /DecodeParms-entries when updating the /Filter-entry.