### PR TITLE
[api-minor] Re-factor the `PDFScriptingManager` class to use private fields/methods

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1281,28 +1281,20 @@ const PDFViewerApplication = {
               spreadMode = stored.spreadMode | 0;
             }
           }
-          // NOTE: Ignore the pageMode/pageLayout in GeckoView since there's no
-          // sidebar available, nor any UI for changing the Scroll/Spread modes.
+          // Always let the user preference/view history take precedence.
+          if (pageMode && sidebarView === SidebarView.UNKNOWN) {
+            sidebarView = apiPageModeToSidebarView(pageMode);
+          }
           if (
-            typeof PDFJSDev === "undefined"
-              ? !window.isGECKOVIEW
-              : !PDFJSDev.test("GECKOVIEW")
+            pageLayout &&
+            scrollMode === ScrollMode.UNKNOWN &&
+            spreadMode === SpreadMode.UNKNOWN
           ) {
-            // Always let the user preference/view history take precedence.
-            if (pageMode && sidebarView === SidebarView.UNKNOWN) {
-              sidebarView = apiPageModeToSidebarView(pageMode);
-            }
-            if (
-              pageLayout &&
-              scrollMode === ScrollMode.UNKNOWN &&
-              spreadMode === SpreadMode.UNKNOWN
-            ) {
-              const modes = apiPageLayoutToViewerModes(pageLayout);
-              // TODO: Try to improve page-switching when using the mouse-wheel
-              // and/or arrow-keys before allowing the document to control this.
-              // scrollMode = modes.scrollMode;
-              spreadMode = modes.spreadMode;
-            }
+            const modes = apiPageLayoutToViewerModes(pageLayout);
+            // TODO: Try to improve page-switching when using the mouse-wheel
+            // and/or arrow-keys before allowing the document to control this.
+            // scrollMode = modes.scrollMode;
+            spreadMode = modes.spreadMode;
           }
 
           this.setInitialView(hash, {

--- a/web/app.js
+++ b/web/app.js
@@ -487,8 +487,8 @@ const PDFViewerApplication = {
         typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC || CHROME")
           ? AppOptions.get("sandboxBundleSrc")
           : null,
-      scriptingFactory: externalServices,
-      docPropertiesLookup: this._scriptingDocProperties.bind(this),
+      externalServices,
+      docProperties: this._scriptingDocProperties.bind(this),
     });
     this.pdfScriptingManager = pdfScriptingManager;
 

--- a/web/generic_scripting.js
+++ b/web/generic_scripting.js
@@ -15,7 +15,7 @@
 
 import { getPdfFilenameFromUrl, loadScript } from "pdfjs-lib";
 
-async function docPropertiesLookup(pdfDocument) {
+async function docProperties(pdfDocument) {
   const url = "",
     baseUrl = url.split("#")[0];
   // eslint-disable-next-line prefer-const
@@ -65,4 +65,4 @@ class GenericScripting {
   }
 }
 
-export { docPropertiesLookup, GenericScripting };
+export { docProperties, GenericScripting };

--- a/web/pdf_scripting_manager.js
+++ b/web/pdf_scripting_manager.js
@@ -265,21 +265,13 @@ class PDFScriptingManager {
         case "error":
           console.error(value);
           break;
-        case "layout": {
-          // NOTE: Always ignore the pageLayout in GeckoView since there's
-          // no UI available to change Scroll/Spread modes for the user.
-          if (
-            (typeof PDFJSDev === "undefined"
-              ? window.isGECKOVIEW
-              : PDFJSDev.test("GECKOVIEW")) ||
-            isInPresentationMode
-          ) {
+        case "layout":
+          if (isInPresentationMode) {
             return;
           }
           const modes = apiPageLayoutToViewerModes(value);
           this._pdfViewer.spreadMode = modes.spreadMode;
           break;
-        }
         case "page-num":
           this._pdfViewer.currentPageNumber = value + 1;
           break;

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -1842,6 +1842,15 @@ class PDFViewer {
    *   The constants from {ScrollMode} should be used.
    */
   set scrollMode(mode) {
+    if (
+      typeof PDFJSDev === "undefined"
+        ? window.isGECKOVIEW
+        : PDFJSDev.test("GECKOVIEW")
+    ) {
+      // NOTE: Always ignore the pageLayout in GeckoView since there's
+      // no UI available to change Scroll/Spread modes for the user.
+      return;
+    }
     if (this._scrollMode === mode) {
       return; // The Scroll mode didn't change.
     }
@@ -1903,6 +1912,15 @@ class PDFViewer {
    *   The constants from {SpreadMode} should be used.
    */
   set spreadMode(mode) {
+    if (
+      typeof PDFJSDev === "undefined"
+        ? window.isGECKOVIEW
+        : PDFJSDev.test("GECKOVIEW")
+    ) {
+      // NOTE: Always ignore the pageLayout in GeckoView since there's
+      // no UI available to change Scroll/Spread modes for the user.
+      return;
+    }
     if (this._spreadMode === mode) {
       return; // The Spread mode didn't change.
     }


### PR DESCRIPTION
 - Change (most) fields/methods into private ones, since that's now supported.
 - Tweak the constructor-parameters, and simplify the sandbox initialization w.r.t. the viewer components.
 - Remove some unused function/method parameters.
 - Slightly simplify the "updatefromsandbox"-handler by using local variables and inverting some conditions.