### PR TITLE
Move the `fixupLangCode` helper function into the `web/genericl10n.js` file

### DIFF
--- a/web/genericl10n.js
+++ b/web/genericl10n.js
@@ -16,9 +16,31 @@
 /** @typedef {import("./interfaces").IL10n} IL10n */
 
 import "../external/webL10n/l10n.js";
-import { fixupLangCode, getL10nFallback } from "./l10n_utils.js";
+import { getL10nFallback } from "./l10n_utils.js";
 
-const webL10n = document.webL10n;
+const { webL10n } = document;
+
+const PARTIAL_LANG_CODES = {
+  en: "en-US",
+  es: "es-ES",
+  fy: "fy-NL",
+  ga: "ga-IE",
+  gu: "gu-IN",
+  hi: "hi-IN",
+  hy: "hy-AM",
+  nb: "nb-NO",
+  ne: "ne-NP",
+  nn: "nn-NO",
+  pa: "pa-IN",
+  pt: "pt-PT",
+  sv: "sv-SE",
+  zh: "zh-CN",
+};
+
+// Try to support "incompletely" specified language codes (see issue 13689).
+function fixupLangCode(langCode) {
+  return PARTIAL_LANG_CODES[langCode?.toLowerCase()] || langCode;
+}
 
 /**
  * @implements {IL10n}

--- a/web/l10n_utils.js
+++ b/web/l10n_utils.js
@@ -99,28 +99,6 @@ function getL10nFallback(key, args) {
   return DEFAULT_L10N_STRINGS[key] || "";
 }
 
-const PARTIAL_LANG_CODES = {
-  en: "en-US",
-  es: "es-ES",
-  fy: "fy-NL",
-  ga: "ga-IE",
-  gu: "gu-IN",
-  hi: "hi-IN",
-  hy: "hy-AM",
-  nb: "nb-NO",
-  ne: "ne-NP",
-  nn: "nn-NO",
-  pa: "pa-IN",
-  pt: "pt-PT",
-  sv: "sv-SE",
-  zh: "zh-CN",
-};
-
-// Try to support "incompletely" specified language codes (see issue 13689).
-function fixupLangCode(langCode) {
-  return PARTIAL_LANG_CODES[langCode?.toLowerCase()] || langCode;
-}
-
 // Replaces {{arguments}} with their values.
 function formatL10nValue(text, args) {
   if (!args) {
@@ -151,4 +129,4 @@ const NullL10n = {
   async translate(element) {},
 };
 
-export { fixupLangCode, getL10nFallback, NullL10n };
+export { getL10nFallback, NullL10n };


### PR DESCRIPTION
This helper function was added almost two years ago, in PR #13696, and it still has only a single call-site. Furthermore, with the changes made in PR #16572 it also cannot hurt to reduce the size of the `web/l10n_utils.js` file slightly.