### PR TITLE
Remove the `OverlayManager.unregister` method since it's completely unused

### DIFF
--- a/web/overlay_manager.js
+++ b/web/overlay_manager.js
@@ -45,20 +45,6 @@ class OverlayManager {
   /**
    * @param {HTMLDialogElement} dialog - The overlay's DOM element.
    * @returns {Promise} A promise that is resolved when the overlay has been
-   *                    unregistered.
-   */
-  async unregister(dialog) {
-    if (!this.#overlays.has(dialog)) {
-      throw new Error("The overlay does not exist.");
-    } else if (this.#active === dialog) {
-      throw new Error("The overlay cannot be removed while it is active.");
-    }
-    this.#overlays.delete(dialog);
-  }
-
-  /**
-   * @param {HTMLDialogElement} dialog - The overlay's DOM element.
-   * @returns {Promise} A promise that is resolved when the overlay has been
    *                    opened.
    */
   async open(dialog) {


### PR DESCRIPTION
This method was added only for consistency with the `register`-method, however it's never actually been used. To avoid including dead code in the builds, let's just remove the `unregister`-method for now.

*Please note:* If this method ever becomes useful, it'll be trivial to revert this commit.