### PR TITLE
Remove a couple of unused constants from `src/shared/util.js`

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -142,24 +142,6 @@ const AnnotationType = {
   REDACT: 26,
 };
 
-const AnnotationStateModelType = {
-  MARKED: "Marked",
-  REVIEW: "Review",
-};
-
-const AnnotationMarkedState = {
-  MARKED: "Marked",
-  UNMARKED: "Unmarked",
-};
-
-const AnnotationReviewState = {
-  ACCEPTED: "Accepted",
-  REJECTED: "Rejected",
-  CANCELLED: "Cancelled",
-  COMPLETED: "Completed",
-  NONE: "None",
-};
-
 const AnnotationReplyType = {
   GROUP: "Group",
   REPLY: "R",
@@ -1040,11 +1022,8 @@ export {
   AnnotationEditorType,
   AnnotationFieldFlag,
   AnnotationFlag,
-  AnnotationMarkedState,
   AnnotationMode,
   AnnotationReplyType,
-  AnnotationReviewState,
-  AnnotationStateModelType,
   AnnotationType,
   assert,
   BaseException,


### PR DESCRIPTION
These constants were added "speculatively" in PR #10820, almost four years ago, but have never actually been used. We already have issue #10982 that tracks *potentially* extending support for the affected annotation-format, however until that happens I really don't think that we should keep shipping completely unused code in the PDF.js library.

For the MOZCENTRAL build-target, i.e. the Firefox PDF Viewer, this reduces the total bundle size by 1.1 kilo-byte.