### PR TITLE
[api-minor] Remove the default-factories from the viewer components (PR 15811 follow-up)

### DIFF
--- a/examples/components/pageviewer.js
+++ b/examples/components/pageviewer.js
@@ -52,20 +52,6 @@ const loadingTask = pdfjsLib.getDocument({
   // Document loaded, retrieving the page.
   const pdfPage = await pdfDocument.getPage(PAGE_TO_VIEW);
 
-  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(pdfjsLib.version);
-  if (match && (match[1] | 0) >= 3 && (match[2] | 0) >= 2) {
-    // Creating the page view with default parameters.
-    const pdfPageView = new pdfjsViewer.PDFPageView({
-      container,
-      id: PAGE_TO_VIEW,
-      scale: SCALE,
-      defaultViewport: pdfPage.getViewport({ scale: SCALE }),
-      eventBus,
-    });
-    // Associate the actual page with the view, and draw it.
-    pdfPageView.setPdfPage(pdfPage);
-    return pdfPageView.draw();
-  }
   // Creating the page view with default parameters.
   const pdfPageView = new pdfjsViewer.PDFPageView({
     container,
@@ -73,15 +59,6 @@ const loadingTask = pdfjsLib.getDocument({
     scale: SCALE,
     defaultViewport: pdfPage.getViewport({ scale: SCALE }),
     eventBus,
-    // We can enable text/annotation/xfa/struct-layers, as needed.
-    textLayerFactory: !pdfDocument.isPureXfa
-      ? new pdfjsViewer.DefaultTextLayerFactory()
-      : null,
-    annotationLayerFactory: new pdfjsViewer.DefaultAnnotationLayerFactory(),
-    xfaLayerFactory: pdfDocument.isPureXfa
-      ? new pdfjsViewer.DefaultXfaLayerFactory()
-      : null,
-    structTreeLayerFactory: new pdfjsViewer.DefaultStructTreeLayerFactory(),
   });
   // Associate the actual page with the view, and draw it.
   pdfPageView.setPdfPage(pdfPage);

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -78,6 +78,7 @@ async function initializePDFJS(callback) {
       "pdfjs-test/unit/pdf_find_utils_spec.js",
       "pdfjs-test/unit/pdf_history_spec.js",
       "pdfjs-test/unit/pdf_spec.js",
+      "pdfjs-test/unit/pdf_viewer.component_spec.js",
       "pdfjs-test/unit/pdf_viewer_spec.js",
       "pdfjs-test/unit/primitives_spec.js",
       "pdfjs-test/unit/scripting_spec.js",

--- a/test/unit/pdf_viewer.component_spec.js
+++ b/test/unit/pdf_viewer.component_spec.js
@@ -1,0 +1,74 @@
+/* Copyright 2023 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  LinkTarget,
+  PDFLinkService,
+  SimpleLinkService,
+} from "../../web/pdf_link_service.js";
+import {
+  parseQueryString,
+  ProgressBar,
+  RenderingStates,
+  ScrollMode,
+  SpreadMode,
+} from "../../web/ui_utils.js";
+import { AnnotationLayerBuilder } from "../../web/annotation_layer_builder.js";
+import { DownloadManager } from "../../web/download_manager.js";
+import { EventBus } from "../../web/event_utils.js";
+import { GenericL10n } from "../../web/genericl10n.js";
+import { NullL10n } from "../../web/l10n_utils.js";
+import { PDFFindController } from "../../web/pdf_find_controller.js";
+import { PDFHistory } from "../../web/pdf_history.js";
+import { PDFPageView } from "../../web/pdf_page_view.js";
+import { PDFScriptingManager } from "../../web/pdf_scripting_manager.js";
+import { PDFSinglePageViewer } from "../../web/pdf_single_page_viewer.js";
+import { PDFViewer } from "../../web/pdf_viewer.js";
+import { StructTreeLayerBuilder } from "../../web/struct_tree_layer_builder.js";
+import { TextLayerBuilder } from "../../web/text_layer_builder.js";
+import { XfaLayerBuilder } from "../../web/xfa_layer_builder.js";
+
+describe("pdfviewer_api", function () {
+  it("checks that the *official* PDF.js-viewer API exposes the expected functionality", async function () {
+    const pdfviewerAPI = await import("../../web/pdf_viewer.component.js");
+
+    // The imported Object contains an (automatically) inserted Symbol,
+    // hence we copy the data to allow using a simple comparison below.
+    expect({ ...pdfviewerAPI }).toEqual({
+      AnnotationLayerBuilder,
+      DownloadManager,
+      EventBus,
+      GenericL10n,
+      LinkTarget,
+      NullL10n,
+      parseQueryString,
+      PDFFindController,
+      PDFHistory,
+      PDFLinkService,
+      PDFPageView,
+      PDFScriptingManager,
+      PDFSinglePageViewer,
+      PDFViewer,
+      ProgressBar,
+      RenderingStates,
+      ScrollMode,
+      SimpleLinkService,
+      SpreadMode,
+      StructTreeLayerBuilder,
+      TextLayerBuilder,
+      XfaLayerBuilder,
+    });
+  });
+});

--- a/test/unit/pdf_viewer.component_spec.js
+++ b/test/unit/pdf_viewer.component_spec.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import { FindState, PDFFindController } from "../../web/pdf_find_controller.js";
 import {
   LinkTarget,
   PDFLinkService,
@@ -30,7 +31,6 @@ import { DownloadManager } from "../../web/download_manager.js";
 import { EventBus } from "../../web/event_utils.js";
 import { GenericL10n } from "../../web/genericl10n.js";
 import { NullL10n } from "../../web/l10n_utils.js";
-import { PDFFindController } from "../../web/pdf_find_controller.js";
 import { PDFHistory } from "../../web/pdf_history.js";
 import { PDFPageView } from "../../web/pdf_page_view.js";
 import { PDFScriptingManager } from "../../web/pdf_scripting_manager.js";
@@ -50,6 +50,7 @@ describe("pdfviewer_api", function () {
       AnnotationLayerBuilder,
       DownloadManager,
       EventBus,
+      FindState,
       GenericL10n,
       LinkTarget,
       NullL10n,

--- a/web/pdf_viewer.component.js
+++ b/web/pdf_viewer.component.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import { FindState, PDFFindController } from "./pdf_find_controller.js";
 import {
   LinkTarget,
   PDFLinkService,
@@ -30,7 +31,6 @@ import { DownloadManager } from "./download_manager.js";
 import { EventBus } from "./event_utils.js";
 import { GenericL10n } from "./genericl10n.js";
 import { NullL10n } from "./l10n_utils.js";
-import { PDFFindController } from "./pdf_find_controller.js";
 import { PDFHistory } from "./pdf_history.js";
 import { PDFPageView } from "./pdf_page_view.js";
 import { PDFScriptingManager } from "./pdf_scripting_manager.js";
@@ -51,6 +51,7 @@ export {
   AnnotationLayerBuilder,
   DownloadManager,
   EventBus,
+  FindState,
   GenericL10n,
   LinkTarget,
   NullL10n,

--- a/web/pdf_viewer.component.js
+++ b/web/pdf_viewer.component.js
@@ -40,10 +40,12 @@ import { StructTreeLayerBuilder } from "./struct_tree_layer_builder.js";
 import { TextLayerBuilder } from "./text_layer_builder.js";
 import { XfaLayerBuilder } from "./xfa_layer_builder.js";
 
-// eslint-disable-next-line no-unused-vars
-const pdfjsVersion = PDFJSDev.eval("BUNDLE_VERSION");
-// eslint-disable-next-line no-unused-vars
-const pdfjsBuild = PDFJSDev.eval("BUNDLE_BUILD");
+/* eslint-disable-next-line no-unused-vars */
+const pdfjsVersion =
+  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_VERSION") : void 0;
+/* eslint-disable-next-line no-unused-vars */
+const pdfjsBuild =
+  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_BUILD") : void 0;
 
 export {
   AnnotationLayerBuilder,

--- a/web/pdf_viewer.component.js
+++ b/web/pdf_viewer.component.js
@@ -45,51 +45,8 @@ const pdfjsVersion = PDFJSDev.eval("BUNDLE_VERSION");
 // eslint-disable-next-line no-unused-vars
 const pdfjsBuild = PDFJSDev.eval("BUNDLE_BUILD");
 
-class DefaultAnnotationLayerFactory {
-  constructor() {
-    throw new Error(
-      "The `DefaultAnnotationLayerFactory` has been removed, " +
-        "please use the `annotationMode` option when initializing " +
-        "the `PDFPageView`-instance to control AnnotationLayer rendering."
-    );
-  }
-}
-
-class DefaultStructTreeLayerFactory {
-  constructor() {
-    throw new Error(
-      "The `DefaultStructTreeLayerFactory` has been removed, " +
-        "this functionality is automatically enabled when the TextLayer is used."
-    );
-  }
-}
-
-class DefaultTextLayerFactory {
-  constructor() {
-    throw new Error(
-      "The `DefaultTextLayerFactory` has been removed, " +
-        "please use the `textLayerMode` option when initializing " +
-        "the `PDFPageView`-instance to control TextLayer rendering."
-    );
-  }
-}
-
-class DefaultXfaLayerFactory {
-  constructor() {
-    throw new Error(
-      "The `DefaultXfaLayerFactory` has been removed, " +
-        "please use the `enableXfa` option when calling " +
-        "the `getDocument`-function to control XfaLayer rendering."
-    );
-  }
-}
-
 export {
   AnnotationLayerBuilder,
-  DefaultAnnotationLayerFactory,
-  DefaultStructTreeLayerFactory,
-  DefaultTextLayerFactory,
-  DefaultXfaLayerFactory,
   DownloadManager,
   EventBus,
   GenericL10n,


### PR DESCRIPTION
The changes in PR #15811 have now been included in no less than six official releases, hence it should hopefully be OK to remove this now.