### PR TITLE
Reduce the amount scaled when using mouse-wheel zooming in Chromium-browsers (issue 16325)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2760,6 +2760,9 @@ function webViewerWheel(evt) {
 
       let ticks = 0;
       if (
+        (typeof PDFJSDev !== "undefined" &&
+          PDFJSDev.test("GENERIC || CHROME") &&
+          window.chrome) ||
         deltaMode === WheelEvent.DOM_DELTA_LINE ||
         deltaMode === WheelEvent.DOM_DELTA_PAGE
       ) {


### PR DESCRIPTION
The deltaMode value apparently defaults to a different value depending on the browser OS combo (as per https://github.com/w3c/pointerevents/issues/592#issuecomment-392648065 ) . In our case I've noticed that for Chromium browsers the delta value always comes out to a value greater than the PIXELS_PER_LINE_SCALE variable. This is what causes the error. So to fix, I just put a check there and set the correct tick value accordingly. Ive tested in both Edge and Brave browsers and it seems to be working fine both in desktop view and mobile view. 

This is a fix for #16325 