### PR TITLE
[Firefox] Simplify `FirefoxPreferences._readFromStorage` (PR 16583 follow-up)

### DIFF
--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -175,8 +175,7 @@ class DownloadManager {
 
 class FirefoxPreferences extends BasePreferences {
   async _readFromStorage(prefObj) {
-    const prefs = await FirefoxCom.requestAsync("getPreferences", prefObj);
-    return typeof prefs === "string" ? JSON.parse(prefs) : prefs;
+    return FirefoxCom.requestAsync("getPreferences", prefObj);
   }
 }
 


### PR DESCRIPTION
Now that https://bugzilla.mozilla.org/show_bug.cgi?id=1840064 has landed in mozilla-central we can implement the final piece of clean-up for the `FirefoxPreferences._readFromStorage` method.