### PR TITLE
[CRX] Set minimum_chrome_version to 88

### DIFF
--- a/extensions/chromium/manifest.json
+++ b/extensions/chromium/manifest.json
@@ -1,4 +1,5 @@
 {
+  "minimum_chrome_version": "88",
   "manifest_version": 2,
   "name": "PDF Viewer",
   "version": "PDFJSSCRIPT_VERSION",


### PR DESCRIPTION
Set minimum_chrome_version to 88 to not distribute an incompatible version of the extension to older Chrome versions.

Note: I'm aware that the current master branch specifies the minimum supported Chrome version in the code to 92+ (by #16499). However, I am not convinced yet of dropping Chrome 91 support given the surprisingly large number of reported Chrome 91 users, as seen in https://github.com/mozilla/pdf.js/issues/13669#issuecomment-1606044691. Because of this information, I'm submitting the commit that I already included in the latest published version of the Chrome extension (https://github.com/Rob--W/pdf.js/releases/tag/chrome-3.7.108).