### PR TITLE
Revert "Temporarily stop listing the official Chrome extension in the main README"

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ PDF.js is built into version 19+ of Firefox.
 
 #### Chrome
 
++ The official extension for Chrome can be installed from the [Chrome Web Store](https://chrome.google.com/webstore/detail/pdf-viewer/oemmndcbldboiebfnladdacbdfmadadm).
+*This extension is maintained by [@Rob--W](https://github.com/Rob--W).*
 + Build Your Own - Get the code as explained below and issue `gulp chromium`. Then open
 Chrome, go to `Tools > Extension` and load the (unpackaged) extension from the
 directory `build/chromium`.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2367,5 +2367,9 @@ gulp.task("externaltest", function (done) {
 
 gulp.task(
   "ci-test",
-  gulp.series(gulp.parallel("lint", "externaltest", "unittestcli"), "typestest")
+  gulp.series(
+    gulp.parallel("lint", "externaltest", "unittestcli"),
+    "lint-chromium",
+    "typestest"
+  )
 );


### PR DESCRIPTION
This restores the mention of the extension listing by reverting #15452.

The Chrome Web Store has an updated version (https://github.com/mozilla/pdf.js/issues/13669#issuecomment-1606044691) and will continue to receive updates as needed.