### PR TITLE
Run the PDF.js-viewer API unit-test in Node.js environments (PR 16592 follow-up)

### DIFF
--- a/external/webL10n/l10n.js
+++ b/external/webL10n/l10n.js
@@ -30,12 +30,14 @@
     - Replaces one `Node.insertBefore()` with `Element.prepend()`.
     - Removes `fireL10nReadyEvent` since the "localized" event it dispatches
       is unused and may clash with an identically named event in the viewer.
+    - Use preprocessor statements for browser globals (removed during building),
+      to enable more unit-testing in Node.js environments.
 */
 
 /*jshint browser: true, devel: true, es5: true, globalstrict: true */
 'use strict';
 
-document.webL10n = (function(window, document, undefined) {
+(typeof PDFJSDev !== "undefined" && PDFJSDev.test("LIB") ? {} : document).webL10n = (function(window, document) {
   var gL10nData = {};
   var gTextData = '';
   var gTextProp = 'textContent';
@@ -1026,4 +1028,7 @@ document.webL10n = (function(window, document, undefined) {
       }
     }
   };
-}) (window, document);
+}) (
+  typeof PDFJSDev !== "undefined" && PDFJSDev.test("LIB") ? {} : window,
+  typeof PDFJSDev !== "undefined" && PDFJSDev.test("LIB") ? {} : document
+);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1566,7 +1566,12 @@ function buildLib(defines, dir) {
       { base: "src/" }
     ),
     gulp.src(
-      ["examples/node/domstubs.js", "web/*.js", "!web/{pdfjs,viewer}.js"],
+      [
+        "examples/node/domstubs.js",
+        "external/webL10n/l10n.js",
+        "web/*.js",
+        "!web/{pdfjs,viewer}.js",
+      ],
       { base: "." }
     ),
     gulp.src("test/unit/*.js", { base: "." }),

--- a/test/unit/clitests.json
+++ b/test/unit/clitests.json
@@ -36,6 +36,7 @@
     "pdf_find_utils_spec.js",
     "pdf_history_spec.js",
     "pdf_spec.js",
+    "pdf_viewer.component_spec.js",
     "pdf_viewer_spec.js",
     "primitives_spec.js",
     "stream_spec.js",

--- a/web/genericl10n.js
+++ b/web/genericl10n.js
@@ -18,8 +18,6 @@
 import "../external/webL10n/l10n.js";
 import { getL10nFallback } from "./l10n_utils.js";
 
-const { webL10n } = document;
-
 const PARTIAL_LANG_CODES = {
   en: "en-US",
   es: "es-ES",
@@ -47,6 +45,7 @@ function fixupLangCode(langCode) {
  */
 class GenericL10n {
   constructor(lang) {
+    const { webL10n } = document;
     this._lang = lang;
     this._ready = new Promise((resolve, reject) => {
       webL10n.setLanguage(fixupLangCode(lang), () => {


### PR DESCRIPTION
It occurred to me that we can actually run this unit-test in Node.js environments by making use of the preprocessor to stub out the browser globals there.