### PR TITLE
[GeckoView] Remove the `enableFloatingToolbar` preference

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -597,15 +597,13 @@ const PDFViewerApplication = {
           ? window.isGECKOVIEW
           : PDFJSDev.test("GECKOVIEW")
       ) {
-        if (AppOptions.get("enableFloatingToolbar")) {
-          this.toolbar = new Toolbar(
-            appConfig.toolbar,
-            eventBus,
-            l10n,
-            await this._nimbusDataPromise,
-            externalServices
-          );
-        }
+        this.toolbar = new Toolbar(
+          appConfig.toolbar,
+          eventBus,
+          l10n,
+          await this._nimbusDataPromise,
+          externalServices
+        );
       } else {
         this.toolbar = new Toolbar(appConfig.toolbar, eventBus, l10n);
       }

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -88,11 +88,6 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
-  enableFloatingToolbar: {
-    /** @type {boolean} */
-    value: typeof PDFJSDev === "undefined",
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
   enablePermissions: {
     /** @type {boolean} */
     value: false,


### PR DESCRIPTION
Note that we'll now display the toolbar unconditionally in GeckoView.