### PR TITLE
Improve lint-chromium to output actionable information

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -326,33 +326,40 @@ function checkChromePreferencesFile(chromePrefsPath, webPrefs) {
   const chromePrefsKeys = Object.keys(chromePrefs.properties).filter(key => {
     const description = chromePrefs.properties[key].description;
     // Deprecated keys are allowed in the managed preferences file.
-    // The code maintained is responsible for adding migration logic to
+    // The code maintainer is responsible for adding migration logic to
     // extensions/chromium/options/migration.js and web/chromecom.js .
     return !description || !description.startsWith("DEPRECATED.");
   });
-  chromePrefsKeys.sort();
-
-  const webPrefsKeys = Object.keys(webPrefs);
-  webPrefsKeys.sort();
-
-  if (webPrefsKeys.length !== chromePrefsKeys.length) {
-    console.log("Warning: Pref objects doesn't have the same length.");
-    return false;
-  }
 
   let ret = true;
-  for (let i = 0, ii = webPrefsKeys.length; i < ii; i++) {
-    const value = webPrefsKeys[i];
-    if (chromePrefsKeys[i] !== value) {
+  // Verify that every entry in webPrefs is also in preferences_schema.json.
+  for (const [key, value] of Object.entries(webPrefs)) {
+    if (!chromePrefsKeys.includes(key)) {
+      // Note: this would also reject keys that are present but marked as
+      // DEPRECATED. A key should not be marked as DEPRECATED if it is still
+      // listed in webPrefs.
       ret = false;
       console.log(
-        `Warning: not the same keys: ${chromePrefsKeys[i]} !== ${value}`
+        `Warning: ${chromePrefsPath} does not contain an entry for pref: ${key}`
       );
-    } else if (chromePrefs.properties[value].default !== webPrefs[value]) {
+    } else if (chromePrefs.properties[key].default !== value) {
       ret = false;
       console.log(
-        `Warning: not the same values (for "${value}"): ` +
-          `${chromePrefs.properties[value].default} !== ${webPrefs[value]}`
+        `Warning: not the same values (for "${key}"): ` +
+          `${chromePrefs.properties[key].default} !== ${value}`
+      );
+    }
+  }
+
+  // Verify that preferences_schema.json does not contain entries that are not
+  // in webPrefs (app_options.js).
+  for (const key of chromePrefsKeys) {
+    if (!(key in webPrefs)) {
+      ret = false;
+      console.log(
+        `Warning: ${chromePrefsPath} contains an unrecognized pref: ${key}. ` +
+          `Remove it, or prepend "DEPRECATED. " and add migration logic to ` +
+          `extensions/chromium/options/migration.js and web/chromecom.js.`
       );
     }
   }


### PR DESCRIPTION
Before this commit, lint-chromium complained without an obvious course of action:

> Warning: Pref objects doesn't have the same length.
> Error: chromium/preferences_schema is not in sync

With this commit, the error message is more actionable:

> Warning: extensions/chromium/preferences_schema.json does not contain entry for pref: enableFloatingToolbar
> Error: chromium/preferences_schema is not in sync