### PR TITLE
Re-factor how HCM highlight-filters are handled in the viewer components (PR 16593 follow-up)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1382,6 +1382,13 @@ class PDFPageProxy {
   }
 
   /**
+   * @type {Object} The filter factory instance.
+   */
+  get filterFactory() {
+    return this._transport.filterFactory;
+  }
+
+  /**
    * @type {boolean} True if only XFA form.
    */
   get isPureXfa() {

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -916,7 +916,6 @@ class PDFViewer {
             pageColors: this.pageColors,
             l10n: this.l10n,
             layerProperties,
-            filterFactory: pdfDocument.filterFactory,
           });
           this._pages.push(pageView);
         }


### PR DESCRIPTION
This is something that I completely overlooked during review of PR #16593, since the idea is (obviously) that the viewer-components should be usable as-is without the user needing to manually pass in any *additional* parameters.

To support this we can very easily expose the current `FilterFactory`-instance on the `PDFPageProxy`-class, and if needed initialize the highlight-filters when initializing the page (again limited to the viewer-components).