### PR TITLE
[api-minor] Replace the hash-computation with a `uuid`-property in `AnnotationStorage`

### DIFF
--- a/src/display/annotation_storage.js
+++ b/src/display/annotation_storage.js
@@ -13,9 +13,8 @@
  * limitations under the License.
  */
 
-import { objectFromMap, unreachable } from "../shared/util.js";
+import { getUuid, objectFromMap, shadow, unreachable } from "../shared/util.js";
 import { AnnotationEditor } from "./editor/editor.js";
-import { MurmurHash3_64 } from "../shared/murmurhash3.js";
 
 /**
  * Key/value storage for annotation data in forms.
@@ -189,16 +188,8 @@ class AnnotationStorage {
    * PLEASE NOTE: Only intended for usage within the API itself.
    * @ignore
    */
-  static getHash(map) {
-    if (!map) {
-      return "";
-    }
-    const hash = new MurmurHash3_64();
-
-    for (const [key, val] of map) {
-      hash.update(`${key}:${JSON.stringify(val)}`);
-    }
-    return hash.hexdigest();
+  get uuid() {
+    return this.#storage.size > 0 ? getUuid() : "";
   }
 }
 
@@ -230,6 +221,14 @@ class PrintAnnotationStorage extends AnnotationStorage {
    */
   get serializable() {
     return this.#serializable;
+  }
+
+  /**
+   * PLEASE NOTE: Only intended for usage within the API itself.
+   * @ignore
+   */
+  get uuid() {
+    return shadow(this, "uuid", this.#serializable?.size > 0 ? getUuid() : "");
   }
 }
 

--- a/src/display/annotation_storage.js
+++ b/src/display/annotation_storage.js
@@ -158,10 +158,10 @@ class AnnotationStorage {
   }
 
   /**
-   * @returns {PrintAnnotationStorage}
+   * @returns {FrozenAnnotationStorage}
    */
-  get print() {
-    return new PrintAnnotationStorage(this);
+  get frozen() {
+    return new FrozenAnnotationStorage(this);
   }
 
   /**
@@ -194,11 +194,12 @@ class AnnotationStorage {
 }
 
 /**
- * A special `AnnotationStorage` for use during printing, where the serializable
- * data is *frozen* upon initialization, to prevent scripting from modifying its
- * contents. (Necessary since printing is triggered synchronously in browsers.)
+ * A special version of the `AnnotationStorage` for use e.g. during printing,
+ * where the serializable data is *frozen* upon initialization, to prevent e.g.
+ * scripting from modifying its contents. (Necessary since printing is triggered
+ * synchronously in browsers.)
  */
-class PrintAnnotationStorage extends AnnotationStorage {
+class FrozenAnnotationStorage extends AnnotationStorage {
   #serializable = null;
 
   constructor(parent) {
@@ -208,11 +209,11 @@ class PrintAnnotationStorage extends AnnotationStorage {
   }
 
   /**
-   * @returns {PrintAnnotationStorage}
+   * @returns {FrozenAnnotationStorage}
    */
   // eslint-disable-next-line getter-return
-  get print() {
-    unreachable("Should not call PrintAnnotationStorage.print");
+  get frozen() {
+    unreachable("Should not call FrozenAnnotationStorage.frozen");
   }
 
   /**
@@ -232,4 +233,4 @@ class PrintAnnotationStorage extends AnnotationStorage {
   }
 }
 
-export { AnnotationStorage, PrintAnnotationStorage };
+export { AnnotationStorage, FrozenAnnotationStorage };

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2442,7 +2442,8 @@ class WorkerTransport {
     isOpList = false
   ) {
     let renderingIntent = RenderingIntentFlag.DISPLAY; // Default value.
-    let annotationMap = null;
+    let annotationMap = null,
+      annotationUuid = "";
 
     switch (intent) {
       case "any":
@@ -2476,6 +2477,7 @@ class WorkerTransport {
             : this.annotationStorage;
 
         annotationMap = annotationStorage.serializable;
+        annotationUuid = annotationStorage.uuid;
         break;
       default:
         warn(`getRenderingIntent - invalid annotationMode: ${annotationMode}`);
@@ -2487,9 +2489,7 @@ class WorkerTransport {
 
     return {
       renderingIntent,
-      cacheKey: `${renderingIntent}_${AnnotationStorage.getHash(
-        annotationMap
-      )}`,
+      cacheKey: `${renderingIntent}_${annotationUuid}`,
       annotationStorageMap: annotationMap,
     };
   }

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -40,7 +40,7 @@ import {
 } from "../shared/util.js";
 import {
   AnnotationStorage,
-  PrintAnnotationStorage,
+  FrozenAnnotationStorage,
 } from "./annotation_storage.js";
 import {
   deprecated,
@@ -1226,7 +1226,7 @@ class PDFDocumentProxy {
  *   states set.
  * @property {Map<string, HTMLCanvasElement>} [annotationCanvasMap] - Map some
  *   annotation ids with canvases used to render them.
- * @property {PrintAnnotationStorage} [printAnnotationStorage]
+ * @property {FrozenAnnotationStorage} [frozenAnnotationStorage]
  */
 
 /**
@@ -1247,7 +1247,7 @@ class PDFDocumentProxy {
  *      (as above) but where interactive form elements are updated with data
  *      from the {@link AnnotationStorage}-instance; useful e.g. for printing.
  *   The default value is `AnnotationMode.ENABLE`.
- * @property {PrintAnnotationStorage} [printAnnotationStorage]
+ * @property {FrozenAnnotationStorage} [frozenAnnotationStorage]
  */
 
 /**
@@ -1415,7 +1415,7 @@ class PDFPageProxy {
     optionalContentConfigPromise = null,
     annotationCanvasMap = null,
     pageColors = null,
-    printAnnotationStorage = null,
+    frozenAnnotationStorage = null,
   }) {
     if (
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&
@@ -1432,7 +1432,7 @@ class PDFPageProxy {
     const intentArgs = this._transport.getRenderingIntent(
       intent,
       annotationMode,
-      printAnnotationStorage
+      frozenAnnotationStorage
     );
     // If there was a pending destroy, cancel it so no cleanup happens during
     // this call to render...
@@ -1555,7 +1555,7 @@ class PDFPageProxy {
   getOperatorList({
     intent = "display",
     annotationMode = AnnotationMode.ENABLE,
-    printAnnotationStorage = null,
+    frozenAnnotationStorage = null,
   } = {}) {
     if (typeof PDFJSDev !== "undefined" && !PDFJSDev.test("GENERIC")) {
       throw new Error("Not implemented: getOperatorList");
@@ -1571,7 +1571,7 @@ class PDFPageProxy {
     const intentArgs = this._transport.getRenderingIntent(
       intent,
       annotationMode,
-      printAnnotationStorage,
+      frozenAnnotationStorage,
       /* isOpList = */ true
     );
     let intentState = this._intentStates.get(intentArgs.cacheKey);
@@ -2438,7 +2438,7 @@ class WorkerTransport {
   getRenderingIntent(
     intent,
     annotationMode = AnnotationMode.ENABLE,
-    printAnnotationStorage = null,
+    frozenAnnotationStorage = null,
     isOpList = false
   ) {
     let renderingIntent = RenderingIntentFlag.DISPLAY; // Default value.
@@ -2471,9 +2471,8 @@ class WorkerTransport {
         renderingIntent += RenderingIntentFlag.ANNOTATIONS_STORAGE;
 
         const annotationStorage =
-          renderingIntent & RenderingIntentFlag.PRINT &&
-          printAnnotationStorage instanceof PrintAnnotationStorage
-            ? printAnnotationStorage
+          frozenAnnotationStorage instanceof FrozenAnnotationStorage
+            ? frozenAnnotationStorage
             : this.annotationStorage;
 
         annotationMap = annotationStorage.serializable;

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1013,6 +1013,27 @@ function normalizeUnicode(str) {
   });
 }
 
+function getUuid() {
+  if (
+    (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) ||
+    (typeof crypto !== "undefined" && typeof crypto?.randomUUID === "function")
+  ) {
+    return crypto.randomUUID();
+  }
+  const buf = new Uint8Array(32);
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto?.getRandomValues === "function"
+  ) {
+    crypto.getRandomValues(buf);
+  } else {
+    for (let i = 0; i < 32; i++) {
+      buf[i] = Math.floor(Math.random() * 255);
+    }
+  }
+  return bytesToString(buf);
+}
+
 export {
   AbortException,
   AnnotationActionEventType,
@@ -1036,6 +1057,7 @@ export {
   FONT_IDENTITY_MATRIX,
   FormatError,
   getModificationDate,
+  getUuid,
   getVerbosityLevel,
   IDENTITY_MATRIX,
   ImageKind,

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -3430,8 +3430,8 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
       firstImgData = null;
     });
 
-    it("render for printing, with `printAnnotationStorage` set", async function () {
-      async function getPrintData(printAnnotationStorage = null) {
+    it("render for printing, with `frozenAnnotationStorage` set", async function () {
+      async function getPrintData(frozenAnnotationStorage = null) {
         const canvasAndCtx = CanvasFactory.create(
           viewport.width,
           viewport.height
@@ -3441,7 +3441,7 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
           viewport,
           intent: "print",
           annotationMode: AnnotationMode.ENABLE_STORAGE,
-          printAnnotationStorage,
+          frozenAnnotationStorage,
         });
 
         await renderTask.promise;
@@ -3468,13 +3468,13 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
       const printOriginalData = await getPrintData();
 
       // Get the *frozen* print-storage for use during printing.
-      const printAnnotationStorage = annotationStorage.print;
+      const frozenAnnotationStorage = annotationStorage.frozen;
       // Update the contents of the form-field again.
       annotationStorage.setValue("22R", { value: "Printing again..." });
 
       // Sanity check to ensure that the print-storage didn't change,
       // after the form-field was updated.
-      expect(printAnnotationStorage.serializable).not.toEqual(
+      expect(frozenAnnotationStorage.serializable).not.toEqual(
         annotationStorage.serializable
       );
 
@@ -3483,13 +3483,13 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
       const printAgainData = await getPrintData();
 
       // Render for printing again, after updating the form-field,
-      // with `printAnnotationStorage` set.
-      const printStorageData = await getPrintData(printAnnotationStorage);
+      // with `frozenAnnotationStorage` set.
+      const printStorageData = await getPrintData(frozenAnnotationStorage);
 
       // Ensure that printing again, with default parameters,
       // actually uses the "new" form-field data.
       expect(printAgainData).not.toEqual(printOriginalData);
-      // Finally ensure that printing, with `printAnnotationStorage` set,
+      // Finally ensure that printing, with `frozenAnnotationStorage` set,
       // still uses the "previous" form-field data.
       expect(printStorageData).toEqual(printOriginalData);
 

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -50,7 +50,6 @@ import {
   RenderingCancelledException,
   StatTimer,
 } from "../../src/display/display_utils.js";
-import { AnnotationStorage } from "../../src/display/annotation_storage.js";
 import { AutoPrintRegExp } from "../../web/ui_utils.js";
 import { GlobalImageCache } from "../../src/core/image_utils.js";
 import { GlobalWorkerOptions } from "../../src/display/worker_options.js";
@@ -3473,15 +3472,11 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
       // Update the contents of the form-field again.
       annotationStorage.setValue("22R", { value: "Printing again..." });
 
-      const annotationHash = AnnotationStorage.getHash(
-        annotationStorage.serializable
-      );
-      const printAnnotationHash = AnnotationStorage.getHash(
-        printAnnotationStorage.serializable
-      );
       // Sanity check to ensure that the print-storage didn't change,
       // after the form-field was updated.
-      expect(printAnnotationHash).not.toEqual(annotationHash);
+      expect(printAnnotationStorage.serializable).not.toEqual(
+        annotationStorage.serializable
+      );
 
       // Render for printing again, after updating the form-field,
       // with default parameters.

--- a/web/app.js
+++ b/web/app.js
@@ -228,7 +228,7 @@ const PDFViewerApplication = {
   _PDFBug: null,
   _hasAnnotationEditors: false,
   _title: document.title,
-  _printAnnotationStoragePromise: null,
+  _frozenAnnotationStoragePromise: null,
   _touchInfo: null,
   _isCtrlKeyDown: false,
   _nimbusDataPromise: null,
@@ -1738,13 +1738,13 @@ const PDFViewerApplication = {
   },
 
   beforePrint() {
-    this._printAnnotationStoragePromise = this.pdfScriptingManager
+    this._frozenAnnotationStoragePromise = this.pdfScriptingManager
       .dispatchWillPrint()
       .catch(() => {
         /* Avoid breaking printing; ignoring errors. */
       })
       .then(() => {
-        return this.pdfDocument?.annotationStorage.print;
+        return this.pdfDocument?.annotationStorage.frozen;
       });
 
     if (this.printService) {
@@ -1783,7 +1783,7 @@ const PDFViewerApplication = {
       printContainer,
       printResolution,
       optionalContentConfigPromise,
-      this._printAnnotationStoragePromise,
+      this._frozenAnnotationStoragePromise,
       this.l10n
     );
     this.printService = printService;
@@ -1802,11 +1802,11 @@ const PDFViewerApplication = {
   },
 
   afterPrint() {
-    if (this._printAnnotationStoragePromise) {
-      this._printAnnotationStoragePromise.then(() => {
+    if (this._frozenAnnotationStoragePromise) {
+      this._frozenAnnotationStoragePromise.then(() => {
         this.pdfScriptingManager.dispatchDidPrint();
       });
-      this._printAnnotationStoragePromise = null;
+      this._frozenAnnotationStoragePromise = null;
     }
 
     if (this.printService) {

--- a/web/firefox_print_service.js
+++ b/web/firefox_print_service.js
@@ -30,7 +30,7 @@ function composePage(
   printContainer,
   printResolution,
   optionalContentConfigPromise,
-  printAnnotationStoragePromise
+  frozenAnnotationStoragePromise
 ) {
   const canvas = document.createElement("canvas");
 
@@ -65,9 +65,9 @@ function composePage(
 
     Promise.all([
       pdfDocument.getPage(pageNumber),
-      printAnnotationStoragePromise,
+      frozenAnnotationStoragePromise,
     ])
-      .then(function ([pdfPage, printAnnotationStorage]) {
+      .then(function ([pdfPage, frozenAnnotationStorage]) {
         if (currentRenderTask) {
           currentRenderTask.cancel();
           currentRenderTask = null;
@@ -79,7 +79,7 @@ function composePage(
           intent: "print",
           annotationMode: AnnotationMode.ENABLE_STORAGE,
           optionalContentConfigPromise,
-          printAnnotationStorage,
+          frozenAnnotationStorage,
         };
         currentRenderTask = thisRenderTask = pdfPage.render(renderContext);
         return thisRenderTask.promise;
@@ -121,7 +121,7 @@ class FirefoxPrintService {
     printContainer,
     printResolution,
     optionalContentConfigPromise = null,
-    printAnnotationStoragePromise = null
+    frozenAnnotationStoragePromise = null
   ) {
     this.pdfDocument = pdfDocument;
     this.pagesOverview = pagesOverview;
@@ -129,8 +129,8 @@ class FirefoxPrintService {
     this._printResolution = printResolution || 150;
     this._optionalContentConfigPromise =
       optionalContentConfigPromise || pdfDocument.getOptionalContentConfig();
-    this._printAnnotationStoragePromise =
-      printAnnotationStoragePromise || Promise.resolve();
+    this._frozenAnnotationStoragePromise =
+      frozenAnnotationStoragePromise || Promise.resolve();
   }
 
   layout() {
@@ -140,7 +140,7 @@ class FirefoxPrintService {
       printContainer,
       _printResolution,
       _optionalContentConfigPromise,
-      _printAnnotationStoragePromise,
+      _frozenAnnotationStoragePromise,
     } = this;
 
     const body = document.querySelector("body");
@@ -176,7 +176,7 @@ class FirefoxPrintService {
         printContainer,
         _printResolution,
         _optionalContentConfigPromise,
-        _printAnnotationStoragePromise
+        _frozenAnnotationStoragePromise
       );
     }
   }
@@ -208,7 +208,7 @@ PDFPrintServiceFactory.instance = {
     printContainer,
     printResolution,
     optionalContentConfigPromise,
-    printAnnotationStoragePromise
+    frozenAnnotationStoragePromise
   ) {
     return new FirefoxPrintService(
       pdfDocument,
@@ -216,7 +216,7 @@ PDFPrintServiceFactory.instance = {
       printContainer,
       printResolution,
       optionalContentConfigPromise,
-      printAnnotationStoragePromise
+      frozenAnnotationStoragePromise
     );
   },
 };


### PR DESCRIPTION
With upcoming changes to the Editor, that will allow adding images (i.e. Stamp-annotations), the "hash" computed in the `AnnotationStorage` will no longer work as intended. Note how it was implemented under the assumption that data stored in the `AnnotationStorage` would be "simple" and not contain `ImageBitmap`s or similar, hence it seems complicated (and possibly complex/slow) to attempt to improve hash-computation for such data.

Please note that the whole purpose of this hash is to help prevent issues with OperatorList caching in the API, since rendering a page with `annotationMode = AnnotationMode.ENABLE_STORAGE` set will include the `AnnotationStorage`-data in the canvas itself. If the `AnnotationStorage` has been updated between render-invocations, we obviously cannot re-use a cached OperatorList since that would cause bugs.
In the PDF.js default viewer we're only ever using that `annotationMode` during printing, and we already clean-up immediately after rendering in that case (to reduce memory usage given that the *entire* document must be rendered at once).

This patch thus suggests that we replace the hash-computation with a simple `uuid`-property instead, to avoid breaking OperatorList caching in the API.
Obviously this might result is slightly more re-parsing of PDF data, e.g. in some third-party use-case, however it's guaranteed to not cause rendering issues. Furthermore, as mentioned above it won't really affect the PDF.js default viewer (since we use a special *frozen* `AnnotationStorage` during printing).

The uuid calculation is purposely implemented using multiple fallback code-paths, since:
 - The `crypto.randomUUID()` function is not available everywhere just yet *and* it's also limited to only secure contexts; please see https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID
 - The `crypto.getRandomValues()` function should be genererally available, however in Node.js environments `crypto` itself may not be; please see https://nodejs.org/dist/latest-v20.x/docs/api/crypto.html#determining-if-crypto-support-is-unavailable