### PR TITLE
Fix reading property of null object in chrome extension's updateEmbedElement function

### DIFF
--- a/extensions/chromium/contentscript.js
+++ b/extensions/chromium/contentscript.js
@@ -132,8 +132,12 @@ function updateEmbedElement(elem) {
   }
   elem.type = "text/html";
   elem.src = getEmbeddedViewerURL(elem.src);
+
   if (parentNode) {
-    nextSibling.before(elem);
+    // Suppress linter warning: insertBefore is preferable to
+    // nextSibling.before(elem) because nextSibling may be null.
+    // eslint-disable-next-line unicorn/prefer-modern-dom-apis
+    parentNode.insertBefore(elem, nextSibling);
   }
 }
 


### PR DESCRIPTION
We have faced the problem that [PDF Viewer extension](https://chrome.google.com/webstore/detail/pdf-viewer/oemmndcbldboiebfnladdacbdfmadadm) does not work correctly in the following cases

```jsx
<div>
  <embed src="..." />
</div>
```

The error output to the console is as follows
```
contentscript.js:136 Uncaught TypeError: Cannot read properties of null (reading 'before')
    at updateEmbedElement (contentscript.js:136:17)
    at updateViewerFrame (contentscript.js:99:11)
    at watchObjectOrEmbed (contentscript.js:108:3)
    at HTMLDocument.onAnimationStart (contentscript.js:33:5)
````


Checking [the previous changes](https://github.com/mozilla/pdf.js/pull/15031), 
it looks like the change is from `parentNode.insertBefore(elem, nextSibling)` to `nextSibling.before(elem)`.
In the case of insertBefore, if nextSibling is null, it is added as the end of the node's child, so it behaves differently.

Therefore, if nextSibling does not exist, adding the node to the end of the child by `parentNode.append`.

Reference: 
[Node.insertBefore()](https://developer.mozilla.org/en-US/docs/Web/API/Node/insertBefore)
[Element.before()](https://developer.mozilla.org/en-US/docs/Web/API/Element/before)
