### PR TITLE
Move the `transfers` computation into the `AnnotationStorage` class

### DIFF
--- a/test/integration/freetext_editor_spec.js
+++ b/test/integration/freetext_editor_spec.js
@@ -688,13 +688,12 @@ describe("FreeText Editor", () => {
           }
 
           const serialize = proprName =>
-            page.evaluate(
-              name =>
-                [
-                  ...window.PDFViewerApplication.pdfDocument.annotationStorage.serializable.values(),
-                ].map(x => x[name]),
-              proprName
-            );
+            page.evaluate(name => {
+              const { map } =
+                window.PDFViewerApplication.pdfDocument.annotationStorage
+                  .serializable;
+              return map ? Array.from(map.values(), x => x[name]) : [];
+            }, proprName);
 
           expect(await serialize("value"))
             .withContext(`In ${browserName}`)
@@ -805,13 +804,12 @@ describe("FreeText Editor", () => {
           }
 
           const serialize = proprName =>
-            page.evaluate(
-              name =>
-                [
-                  ...window.PDFViewerApplication.pdfDocument.annotationStorage.serializable.values(),
-                ].map(x => x[name]),
-              proprName
-            );
+            page.evaluate(name => {
+              const { map } =
+                window.PDFViewerApplication.pdfDocument.annotationStorage
+                  .serializable;
+              return map ? Array.from(map.values(), x => x[name]) : [];
+            }, proprName);
 
           const rects = (await serialize("rect")).map(rect =>
             rect.slice(0, 2).map(x => Math.floor(x))

--- a/test/integration/test_utils.js
+++ b/test/integration/test_utils.js
@@ -136,9 +136,11 @@ const mockClipboard = async pages => {
 exports.mockClipboard = mockClipboard;
 
 const getSerialized = page =>
-  page.evaluate(() => [
-    ...window.PDFViewerApplication.pdfDocument.annotationStorage.serializable.values(),
-  ]);
+  page.evaluate(() => {
+    const { map } =
+      window.PDFViewerApplication.pdfDocument.annotationStorage.serializable;
+    return map ? [...map.values()] : [];
+  });
 exports.getSerialized = getSerialized;
 
 function getEditors(page, kind) {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -50,7 +50,6 @@ import {
   RenderingCancelledException,
   StatTimer,
 } from "../../src/display/display_utils.js";
-import { AnnotationStorage } from "../../src/display/annotation_storage.js";
 import { AutoPrintRegExp } from "../../web/ui_utils.js";
 import { GlobalImageCache } from "../../src/core/image_utils.js";
 import { GlobalWorkerOptions } from "../../src/display/worker_options.js";
@@ -3525,12 +3524,8 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
       // Update the contents of the form-field again.
       annotationStorage.setValue("22R", { value: "Printing again..." });
 
-      const annotationHash = AnnotationStorage.getHash(
-        annotationStorage.serializable
-      );
-      const printAnnotationHash = AnnotationStorage.getHash(
-        printAnnotationStorage.serializable
-      );
+      const { hash: annotationHash } = annotationStorage.serializable;
+      const { hash: printAnnotationHash } = printAnnotationStorage.serializable;
       // Sanity check to ensure that the print-storage didn't change,
       // after the form-field was updated.
       expect(printAnnotationHash).not.toEqual(annotationHash);


### PR DESCRIPTION
Rather than having to *manually* determine the potential `transfers` at various spots in the API, we can let the `AnnotationStorage.serializable` getter include this.
To further simplify things, we can also let the `serializable` getter compute and include the `hash`-string as well.