### PR TITLE
Fully remove the `canvasFactory` option from `PDFPageProxy.render` (PR 16242 follow-up)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1424,16 +1424,6 @@ class PDFPageProxy {
     pageColors = null,
     printAnnotationStorage = null,
   }) {
-    if (
-      (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&
-      arguments[0]?.canvasFactory
-    ) {
-      throw new Error(
-        "render no longer accepts the `canvasFactory`-option, " +
-          "please pass it to the `getDocument`-function instead."
-      );
-    }
-
     this._stats?.time("Overall");
 
     const intentArgs = this._transport.getRenderingIntent(


### PR DESCRIPTION
We've now been throwing an Error in *three* releases if the `canvasFactory` option is provided, hence it ought to be fine to stop doing that and simply ignore the option instead.