### PR TITLE
[api-minor] Stop "supporting" binary data provided as `Buffer` in Node.js environments (PR 16055 follow-up)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -549,10 +549,9 @@ function getDataProp(val) {
     typeof Buffer !== "undefined" && // eslint-disable-line no-undef
     val instanceof Buffer // eslint-disable-line no-undef
   ) {
-    deprecated(
+    throw new Error(
       "Please provide binary data as `Uint8Array`, rather than `Buffer`."
     );
-    return new Uint8Array(val);
   }
   if (val instanceof Uint8Array && val.byteLength === val.buffer.byteLength) {
     // Use the data as-is when it's already a Uint8Array that completely


### PR DESCRIPTION
Given that the PDF.js library has never officially supported/documented that binary data can be provided as a `Buffer`, and that it's been explicitly deprecated in *four* releases, it seems reasonable that we outright reject such data instead (to reduce the amount of Node.js specific code-paths).