### PR TITLE
[CRX] Drop code supporting ancient Chrome versions

### DIFF
--- a/extensions/chromium/contentscript.js
+++ b/extensions/chromium/contentscript.js
@@ -22,11 +22,7 @@ function getViewerURL(pdf_url) {
   return VIEWER_URL + "?file=" + encodeURIComponent(pdf_url);
 }
 
-if (CSS.supports("animation", "0s")) {
-  document.addEventListener("animationstart", onAnimationStart, true);
-} else {
-  document.addEventListener("webkitAnimationStart", onAnimationStart, true);
-}
+document.addEventListener("animationstart", onAnimationStart, true);
 
 function onAnimationStart(event) {
   if (event.animationName === "pdfjs-detected-object-or-embed") {

--- a/extensions/chromium/contentstyle.css
+++ b/extensions/chromium/contentstyle.css
@@ -1,11 +1,6 @@
 /**
  * Detect creation of <embed> and <object> tags.
  */
-@-webkit-keyframes pdfjs-detected-object-or-embed {
-  from {
-    /* empty */
-  }
-}
 @keyframes pdfjs-detected-object-or-embed {
   from {
     /* empty */
@@ -13,9 +8,6 @@
 }
 object,
 embed {
-  -webkit-animation-delay: 0s !important;
-  -webkit-animation-name: pdfjs-detected-object-or-embed !important;
-  -webkit-animation-play-state: running !important;
   animation-delay: 0s !important;
   animation-name: pdfjs-detected-object-or-embed !important;
   animation-play-state: running !important;

--- a/extensions/chromium/pdfHandler.js
+++ b/extensions/chromium/pdfHandler.js
@@ -154,19 +154,7 @@ chrome.webRequest.onBeforeRequest.addListener(
     return { redirectUrl: viewerUrl };
   },
   {
-    urls: [
-      "file://*/*.pdf",
-      "file://*/*.PDF",
-      ...// Duck-typing: MediaError.prototype.message was added in Chrome 59.
-      (MediaError.prototype.hasOwnProperty("message")
-        ? []
-        : [
-            // Note: Chrome 59 has disabled ftp resource loading by default:
-            // https://www.chromestatus.com/feature/5709390967472128
-            "ftp://*/*.pdf",
-            "ftp://*/*.PDF",
-          ]),
-    ],
+    urls: ["file://*/*.pdf", "file://*/*.PDF"],
     types: ["main_frame", "sub_frame"],
   },
   ["blocking"]
@@ -252,10 +240,3 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
   }
   return undefined;
 });
-
-// Remove keys from storage that were once part of the deleted feature-detect.js
-chrome.storage.local.remove([
-  "featureDetectLastUA",
-  "webRequestRedirectUrl",
-  "extensionSupportsFTP",
-]);

--- a/extensions/chromium/telemetry.js
+++ b/extensions/chromium/telemetry.js
@@ -70,29 +70,20 @@ limitations under the License.
 
       var deduplication_id = getDeduplicationId(wasUpdated);
       var extension_version = chrome.runtime.getManifest().version;
-      if (window.Request && "mode" in Request.prototype) {
-        // fetch is supported in extensions since Chrome 42 (though the above
-        // feature-detection method detects Chrome 43+).
-        // Unlike XMLHttpRequest, fetch omits credentials such as cookies in the
-        // requests, which guarantees that the server cannot track the client
-        // via HTTP cookies.
-        fetch(LOG_URL, {
-          method: "POST",
-          headers: new Headers({
-            "Deduplication-Id": deduplication_id,
-            "Extension-Version": extension_version,
-          }),
-          // Set mode=cors so that the above custom headers are included in the
-          // request.
-          mode: "cors",
-        });
-        return;
-      }
-      var x = new XMLHttpRequest();
-      x.open("POST", LOG_URL);
-      x.setRequestHeader("Deduplication-Id", deduplication_id);
-      x.setRequestHeader("Extension-Version", extension_version);
-      x.send();
+      fetch(LOG_URL, {
+        method: "POST",
+        headers: new Headers({
+          "Deduplication-Id": deduplication_id,
+          "Extension-Version": extension_version,
+        }),
+        // Set mode=cors so that the above custom headers are included in the
+        // request.
+        mode: "cors",
+        // Omits credentials such as cookies in the requests, which guarantees
+        // that the server cannot track the client via HTTP cookies.
+        credentials: "omit",
+        cache: "no-store",
+      });
     });
   }
 


### PR DESCRIPTION
I bumped the minimum support level to Chrome 88 in #16600. This means that there is no way for the extension to be loaded in older versions any more, so we can safely delete all (feature detection) code that supported old Chrome versions.