### PR TITLE
Fix typos when handling CMYK colors in `src/core/default_appearance.js`

### DIFF
--- a/src/core/default_appearance.js
+++ b/src/core/default_appearance.js
@@ -69,7 +69,7 @@ class DefaultAppearanceEvaluator extends EvaluatorPreprocessor {
           case OPS.setFillGray:
             ColorSpace.singletons.gray.getRgbItem(args, 0, result.fontColor, 0);
             break;
-          case OPS.setFillColorSpace:
+          case OPS.setFillCMYKColor:
             ColorSpace.singletons.cmyk.getRgbItem(args, 0, result.fontColor, 0);
             break;
         }
@@ -146,7 +146,7 @@ class AppearanceStreamEvaluator extends EvaluatorPreprocessor {
           case OPS.setFillGray:
             ColorSpace.singletons.gray.getRgbItem(args, 0, result.fontColor, 0);
             break;
-          case OPS.setFillColorSpace:
+          case OPS.setFillCMYKColor:
             ColorSpace.singletons.cmyk.getRgbItem(args, 0, result.fontColor, 0);
             break;
           case OPS.showText:


### PR DESCRIPTION
Note how we're accidentally using the wrong operator when trying to parse CMYK colors. I'm not aware of any bugs caused by this, since it seems uncommon in practice for annotations to specify text-colors in CMYK format.