### PR TITLE
[Editor] Add l10n-strings for the Stamp-editor (PR 16585 follow-up)

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -240,6 +240,8 @@ editor_free_text2.title=Text
 editor_free_text2_label=Text
 editor_ink2.title=Draw
 editor_ink2_label=Draw
+editor_stamp.title=Add an image
+editor_stamp_label=Add an image
 
 free_text2_default_content=Start typing…
 


### PR DESCRIPTION
This ought to have been included in PR #16585, since we obviously need default (en-US) l10n-strings for this feature.