### PR TITLE
Add unit-tests to check that more PDF.js APIs expose the expected functionality

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1559,7 +1559,7 @@ function buildLib(defines, dir) {
       [
         "src/{core,display,shared}/**/*.js",
         "!src/shared/{cffStandardStrings,fonts_utils}.js",
-        "src/{pdf,pdf.worker}.js",
+        "src/{pdf,pdf.image_decoders,pdf.worker}.js",
       ],
       { base: "src/" }
     ),

--- a/src/pdf.image_decoders.js
+++ b/src/pdf.image_decoders.js
@@ -18,10 +18,12 @@ import { Jbig2Image } from "./core/jbig2.js";
 import { JpegImage } from "./core/jpg.js";
 import { JpxImage } from "./core/jpx.js";
 
-// eslint-disable-next-line no-unused-vars
-const pdfjsVersion = PDFJSDev.eval("BUNDLE_VERSION");
-// eslint-disable-next-line no-unused-vars
-const pdfjsBuild = PDFJSDev.eval("BUNDLE_BUILD");
+/* eslint-disable-next-line no-unused-vars */
+const pdfjsVersion =
+  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_VERSION") : void 0;
+/* eslint-disable-next-line no-unused-vars */
+const pdfjsBuild =
+  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_BUILD") : void 0;
 
 export {
   getVerbosityLevel,

--- a/test/unit/clitests.json
+++ b/test/unit/clitests.json
@@ -32,6 +32,8 @@
     "network_utils_spec.js",
     "node_stream_spec.js",
     "parser_spec.js",
+    "pdf.image_decoders_spec.js",
+    "pdf.worker_spec.js",
     "pdf_find_controller_spec.js",
     "pdf_find_utils_spec.js",
     "pdf_history_spec.js",

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -74,6 +74,8 @@ async function initializePDFJS(callback) {
       "pdfjs-test/unit/network_spec.js",
       "pdfjs-test/unit/network_utils_spec.js",
       "pdfjs-test/unit/parser_spec.js",
+      "pdfjs-test/unit/pdf.image_decoders_spec.js",
+      "pdfjs-test/unit/pdf.worker_spec.js",
       "pdfjs-test/unit/pdf_find_controller_spec.js",
       "pdfjs-test/unit/pdf_find_utils_spec.js",
       "pdfjs-test/unit/pdf_history_spec.js",

--- a/test/unit/pdf.image_decoders_spec.js
+++ b/test/unit/pdf.image_decoders_spec.js
@@ -1,0 +1,40 @@
+/* Copyright 2023 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getVerbosityLevel, setVerbosityLevel } from "../../src/shared/util.js";
+import { Jbig2Image } from "../../src/core/jbig2.js";
+import { JpegImage } from "../../src/core/jpg.js";
+import { JpxImage } from "../../src/core/jpx.js";
+
+describe("pdfimage_api", function () {
+  it("checks that the *official* PDF.js-image decoders API exposes the expected functionality", async function () {
+    // eslint-disable-next-line no-unsanitized/method
+    const pdfimageAPI = await import(
+      typeof PDFJSDev !== "undefined" && PDFJSDev.test("LIB")
+        ? "../../pdf.image_decoders.js"
+        : "../../src/pdf.image_decoders.js"
+    );
+
+    // The imported Object contains an (automatically) inserted Symbol,
+    // hence we copy the data to allow using a simple comparison below.
+    expect({ ...pdfimageAPI }).toEqual({
+      getVerbosityLevel,
+      Jbig2Image,
+      JpegImage,
+      JpxImage,
+      setVerbosityLevel,
+    });
+  });
+});

--- a/test/unit/pdf.worker_spec.js
+++ b/test/unit/pdf.worker_spec.js
@@ -1,0 +1,33 @@
+/* Copyright 2023 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { WorkerMessageHandler } from "../../src/core/worker.js";
+
+describe("pdfworker_api", function () {
+  it("checks that the *official* PDF.js-worker API exposes the expected functionality", async function () {
+    // eslint-disable-next-line no-unsanitized/method
+    const pdfworkerAPI = await import(
+      typeof PDFJSDev !== "undefined" && PDFJSDev.test("LIB")
+        ? "../../pdf.worker.js"
+        : "../../src/pdf.worker.js"
+    );
+
+    // The imported Object contains an (automatically) inserted Symbol,
+    // hence we copy the data to allow using a simple comparison below.
+    expect({ ...pdfworkerAPI }).toEqual({
+      WorkerMessageHandler,
+    });
+  });
+});


### PR DESCRIPTION
Similar to e.g. PR #16587, let's ensure that the `pdf.worker.js` and `pdf.image_decoders.js` files expose the expected functionality.