### PR TITLE
[ESM] Convert the `external/importL10n`-folder to use standard modules

### DIFF
--- a/extensions/firefox/.eslintrc
+++ b/extensions/firefox/.eslintrc
@@ -7,7 +7,7 @@
   ],
 
   "parserOptions": {
-    "sourceType": "script",
+    "sourceType": "module",
   },
 
   "plugins": [

--- a/external/importL10n/locales.mjs
+++ b/external/importL10n/locales.mjs
@@ -13,11 +13,9 @@
  * limitations under the License.
  */
 
-"use strict";
-
-const fs = require("fs");
-const https = require("https");
-const path = require("path");
+import fs from "fs";
+import https from "https";
+import path from "path";
 
 // Fetches all languages that have an *active* translation in mozilla-central.
 // This is used in gulpfile.js for the `importl10n` command.
@@ -112,7 +110,7 @@ function downloadLanguageFiles(root, langCode) {
   });
 }
 
-async function downloadL10n(root, callback) {
+async function downloadL10n(root) {
   const langCodes = await downloadLanguageCodes();
 
   for (const langCode of langCodes) {
@@ -142,10 +140,6 @@ async function downloadL10n(root, callback) {
         "\n"
     );
   }
-
-  if (callback) {
-    callback();
-  }
 }
 
-exports.downloadL10n = downloadL10n;
+export { downloadL10n };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1880,7 +1880,7 @@ gulp.task("lint", function (done) {
   const esLintOptions = [
     "node_modules/eslint/bin/eslint",
     "--ext",
-    ".js,.jsm,.json",
+    ".js,.jsm,.mjs,.json",
     ".",
     "--report-unused-disable-directives",
   ];
@@ -2004,8 +2004,8 @@ gulp.task("clean", function (done) {
   rimraf(BUILD_DIR, done);
 });
 
-gulp.task("importl10n", function (done) {
-  const locales = require("./external/importL10n/locales.js");
+gulp.task("importl10n", async function () {
+  const { downloadL10n } = await import("./external/importL10n/locales.mjs");
 
   console.log();
   console.log("### Importing translations from mozilla-central");
@@ -2013,7 +2013,7 @@ gulp.task("importl10n", function (done) {
   if (!fs.existsSync(L10N_DIR)) {
     fs.mkdirSync(L10N_DIR);
   }
-  locales.downloadL10n(L10N_DIR, done);
+  await downloadL10n(L10N_DIR);
 });
 
 function ghPagesPrepare() {

--- a/l10n/ach/viewer.properties
+++ b/l10n/ach/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Yab Pwail
 open_file_label=Yab
 print.title=Go
 print_label=Go
-download.title=Gam
-download_label=Gam
-bookmark.title=Neno ma kombedi (lok onyo yab i dirica manyen)
-bookmark_label=Neno ma kombedi
 
 # Secondary toolbar and context menu
 tools.title=Gintic
@@ -151,25 +147,6 @@ find_reached_top=Oo iwi gin acoya, omede ki i tere
 find_reached_bottom=Oo i agiki me gin acoya, omede ki iwiye
 find_not_found=Lok pe ononge
 
-# Error panel labels
-error_more_info=Ngec Mukene
-error_less_info=Ngec Manok
-error_close=Lor
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Kwena: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Can kikore {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Pwail: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Rek: {{line}}
-rendering_error=Bal otime i kare me nyuto pot buk.
-
 # Predefined zoom values
 page_scale_width=Lac me iye pot buk
 page_scale_fit=Porre me pot buk
@@ -183,6 +160,8 @@ loading_error=Bal otime kun cano PDF.
 invalid_file_error=Pwail me PDF ma pe atir onyo obale woko.
 missing_file_error=Pwail me PDF tye ka rem.
 unexpected_response_error=Lagam mape kigeno pa lapok tic.
+
+rendering_error=Bal otime i kare me nyuto pot buk.
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/af/viewer.properties
+++ b/l10n/af/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Open lêer
 open_file_label=Open
 print.title=Druk
 print_label=Druk
-download.title=Laai af
-download_label=Laai af
-bookmark.title=Huidige aansig (kopieer of open in nuwe venster)
-bookmark_label=Huidige aansig
 
 # Secondary toolbar and context menu
 tools.title=Nutsgoed
@@ -128,25 +124,6 @@ find_reached_top=Bokant van dokument is bereik; gaan voort van onder af
 find_reached_bottom=Einde van dokument is bereik; gaan voort van bo af
 find_not_found=Frase nie gevind nie
 
-# Error panel labels
-error_more_info=Meer inligting
-error_less_info=Minder inligting
-error_close=Sluit
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (ID: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Boodskap: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stapel: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Lêer: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Lyn: {{line}}
-rendering_error='n Fout het voorgekom toe die bladsy weergegee is.
-
 # Predefined zoom values
 page_scale_width=Bladsywydte
 page_scale_fit=Pas bladsy
@@ -160,6 +137,8 @@ loading_error='n Fout het voorgekom met die laai van die PDF.
 invalid_file_error=Ongeldige of korrupte PDF-lêer.
 missing_file_error=PDF-lêer is weg.
 unexpected_response_error=Onverwagse antwoord van bediener.
+
+rendering_error='n Fout het voorgekom toe die bladsy weergegee is.
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/an/viewer.properties
+++ b/l10n/an/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Ubrir o fichero
 open_file_label=Ubrir
 print.title=Imprentar
 print_label=Imprentar
-download.title=Descargar
-download_label=Descargar
-bookmark.title=Vista actual (copiar u ubrir en una nueva finestra)
-bookmark_label=Vista actual
 
 # Secondary toolbar and context menu
 tools.title=Ferramientas
@@ -190,25 +186,6 @@ find_match_count_limit[many]=Mas que {{limit}} coincidencias
 find_match_count_limit[other]=Mas que {{limit}} coincidencias
 find_not_found=No s'ha trobau a frase
 
-# Error panel labels
-error_more_info=Mas información
-error_less_info=Menos información
-error_close=Zarrar
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Mensache: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Pila: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Fichero: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Linia: {{line}}
-rendering_error=Ha ocurriu una error en renderizar a pachina.
-
 # Predefined zoom values
 page_scale_width=Amplaria d'a pachina
 page_scale_fit=Achuste d'a pachina
@@ -222,6 +199,8 @@ loading_error=S'ha produciu una error en cargar o PDF.
 invalid_file_error=O PDF no ye valido u ye estorbau.
 missing_file_error=No i ha fichero PDF.
 unexpected_response_error=Respuesta a lo servicio inasperada.
+
+rendering_error=Ha ocurriu una error en renderizar a pachina.
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.

--- a/l10n/ar/viewer.properties
+++ b/l10n/ar/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=افتح ملفًا
 open_file_label=افتح
 print.title=اطبع
 print_label=اطبع
-download.title=نزّل
-download_label=نزّل
-bookmark.title=المنظور الحالي (انسخ أو افتح في نافذة جديدة)
-bookmark_label=المنظور الحالي
 
 # Secondary toolbar and context menu
 tools.title=الأدوات
@@ -192,25 +188,6 @@ find_match_count_limit[many]=أكثر من {{limit}} مطابقة
 find_match_count_limit[other]=أكثر من {{limit}} مطابقة
 find_not_found=لا وجود للعبارة
 
-# Error panel labels
-error_more_info=معلومات أكثر
-error_less_info=معلومات أقل
-error_close=أغلق
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=‏PDF.js ن{{version}} ‏(بناء: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=الرسالة: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=الرصّة: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=الملف: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=السطر: {{line}}
-rendering_error=حدث خطأ أثناء عرض الصفحة.
-
 # Predefined zoom values
 page_scale_width=عرض الصفحة
 page_scale_fit=ملائمة الصفحة
@@ -220,12 +197,12 @@ page_scale_actual=الحجم الفعلي
 # numerical scale value.
 page_scale_percent={{scale}}٪
 
-# Loading indicator messages
-loading=يحمّل…
 loading_error=حدث عطل أثناء تحميل ملف PDF.
 invalid_file_error=ملف PDF تالف أو غير صحيح.
 missing_file_error=ملف PDF غير موجود.
 unexpected_response_error=استجابة خادوم غير متوقعة.
+
+rendering_error=حدث خطأ أثناء عرض الصفحة.
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.

--- a/l10n/ast/viewer.properties
+++ b/l10n/ast/viewer.properties
@@ -38,9 +38,6 @@ presentation_mode_label=Mou de presentación
 open_file_label=Abrir
 print.title=Imprentar
 print_label=Imprentar
-download.title=Baxar
-download_label=Baxar
-bookmark_label=Vista actual
 
 # Secondary toolbar and context menu
 tools.title=Ferramientes
@@ -163,23 +160,6 @@ find_match_count_limit[few]=Más de {{limit}} coincidencies
 find_match_count_limit[many]=Más de {{limit}} coincidencies
 find_match_count_limit[other]=Más de {{limit}} coincidencies
 
-# Error panel labels
-error_more_info=Más información
-error_less_info=Menos información
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (compilación: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Mensaxe: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Pila: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Ficheru: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Llinia: {{line}}
-
 # Predefined zoom values
 page_scale_auto=Zoom automáticu
 page_scale_actual=Tamañu real
@@ -187,8 +167,6 @@ page_scale_actual=Tamañu real
 # numerical scale value.
 page_scale_percent={{scale}}%
 
-# Loading indicator messages
-loading=Cargando…
 loading_error=Asocedió un fallu mentanto se cargaba'l PDF.
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be

--- a/l10n/az/viewer.properties
+++ b/l10n/az/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Fayl Aç
 open_file_label=Aç
 print.title=Yazdır
 print_label=Yazdır
-download.title=Endir
-download_label=Endir
-bookmark.title=Hazırkı görünüş (köçür və ya yeni pəncərədə aç)
-bookmark_label=Hazırkı görünüş
 
 # Secondary toolbar and context menu
 tools.title=Alətlər
@@ -190,25 +186,6 @@ find_match_count_limit[many]={{limit}} uyğunluqdan daha çox
 find_match_count_limit[other]={{limit}} uyğunluqdan daha çox
 find_not_found=Uyğunlaşma tapılmadı
 
-# Error panel labels
-error_more_info=Daha çox məlumati
-error_less_info=Daha az məlumat
-error_close=Qapat
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (yığma: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=İsmarıc: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stek: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Fayl: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Sətir: {{line}}
-rendering_error=Səhifə göstərilərkən səhv yarandı.
-
 # Predefined zoom values
 page_scale_width=Səhifə genişliyi
 page_scale_fit=Səhifəni sığdır
@@ -222,6 +199,8 @@ loading_error=PDF yüklenərkən bir səhv yarandı.
 invalid_file_error=Səhv və ya zədələnmiş olmuş PDF fayl.
 missing_file_error=PDF fayl yoxdur.
 unexpected_response_error=Gözlənilməz server cavabı.
+
+rendering_error=Səhifə göstərilərkən səhv yarandı.
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.

--- a/l10n/be/viewer.properties
+++ b/l10n/be/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Адкрыць файл
 open_file_label=Адкрыць
 print.title=Друкаваць
 print_label=Друкаваць
-download.title=Сцягнуць
-download_label=Сцягнуць
-bookmark.title=Цяперашні выгляд (скапіяваць або адкрыць у новым акне)
-bookmark_label=Цяперашняя праява
 
 save.title=Захаваць
 save_label=Захаваць
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Больш за {{limit}} супадзенняў
 find_match_count_limit[other]=Больш за {{limit}} супадзенняў
 find_not_found=Выраз не знойдзены
 
-# Error panel labels
-error_more_info=Падрабязней
-error_less_info=Сцісла
-error_close=Закрыць
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js в{{version}} (зборка: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Паведамленне: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Стос: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Файл: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Радок: {{line}}
-
 # Predefined zoom values
 page_scale_width=Шырыня старонкі
 page_scale_fit=Уцісненне старонкі
@@ -231,9 +209,6 @@ page_scale_actual=Сапраўдны памер
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Чытаецца…
 
 # Loading indicator messages
 loading_error=Здарылася памылка ў часе загрузкі PDF.

--- a/l10n/bg/viewer.properties
+++ b/l10n/bg/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Отваряне на файл
 open_file_label=Отваряне
 print.title=Отпечатване
 print_label=Отпечатване
-download.title=Изтегляне
-download_label=Изтегляне
-bookmark.title=Текущ изглед (копиране или отваряне в нов прозорец)
-bookmark_label=Текущ изглед
 
 # Secondary toolbar and context menu
 tools.title=Инструменти
@@ -186,25 +182,6 @@ find_match_count_limit[many]=Повече от {{limit}} съвпадения
 find_match_count_limit[other]=Повече от {{limit}} съвпадения
 find_not_found=Фразата не е намерена
 
-# Error panel labels
-error_more_info=Повече информация
-error_less_info=По-малко информация
-error_close=Затваряне
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=Издание на PDF.js {{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Съобщение: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Стек: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Файл: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Ред: {{line}}
-rendering_error=Грешка при изчертаване на страницата.
-
 # Predefined zoom values
 page_scale_width=Ширина на страницата
 page_scale_fit=Вместване в страницата
@@ -218,6 +195,8 @@ loading_error=Получи се грешка при зареждане на PDF-
 invalid_file_error=Невалиден или повреден PDF файл.
 missing_file_error=Липсващ PDF файл.
 unexpected_response_error=Неочакван отговор от сървъра.
+
+rendering_error=Грешка при изчертаване на страницата.
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/bn/viewer.properties
+++ b/l10n/bn/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=ফাইল খুলুন
 open_file_label=খুলুন
 print.title=মুদ্রণ
 print_label=মুদ্রণ
-download.title=ডাউনলোড
-download_label=ডাউনলোড
-bookmark.title=বর্তমান অবস্থা (অনুলিপি অথবা নতুন উইন্ডো তে খুলুন)
-bookmark_label=বর্তমান অবস্থা
 
 # Secondary toolbar and context menu
 tools.title=টুল
@@ -185,25 +181,6 @@ find_match_count_limit[many]={{limit}} এর বেশি মিল
 find_match_count_limit[other]={{limit}} এর বেশি মিল
 find_not_found=বাক্যাংশ পাওয়া যায়নি
 
-# Error panel labels
-error_more_info=আরও তথ্য
-error_less_info=কম তথ্য
-error_close=বন্ধ
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=বার্তা: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=নথি: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=লাইন: {{line}}
-rendering_error=পাতা উপস্থাপনার সময় ত্রুটি দেখা দিয়েছে।
-
 # Predefined zoom values
 page_scale_width=পাতার প্রস্থ
 page_scale_fit=পাতা ফিট করুন
@@ -218,6 +195,8 @@ loading_error=পিডিএফ লোড করার সময় ত্রু�
 invalid_file_error=অকার্যকর অথবা ক্ষতিগ্রস্ত পিডিএফ ফাইল।
 missing_file_error=নিখোঁজ PDF ফাইল।
 unexpected_response_error=অপ্রত্যাশীত সার্ভার প্রতিক্রিয়া।
+
+rendering_error=পাতা উপস্থাপনার সময় ত্রুটি দেখা দিয়েছে।
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.

--- a/l10n/bo/viewer.properties
+++ b/l10n/bo/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Open File
 open_file_label=Open
 print.title=Print
 print_label=Print
-download.title=Download
-download_label=Download
-bookmark.title=Current view (copy or open in new window)
-bookmark_label=Current View
 
 # Secondary toolbar and context menu
 tools.title=Tools
@@ -186,25 +182,6 @@ find_match_count_limit[many]=More than {{limit}} matches
 find_match_count_limit[other]=More than {{limit}} matches
 find_not_found=Phrase not found
 
-# Error panel labels
-error_more_info=More Information
-error_less_info=Less Information
-error_close=Close
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Message: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=File: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Line: {{line}}
-rendering_error=An error occurred while rendering the page.
-
 # Predefined zoom values
 page_scale_width=Page Width
 page_scale_fit=Page Fit
@@ -221,6 +198,8 @@ unexpected_response_error=Unexpected server response.
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.
+
+rendering_error=An error occurred while rendering the page.
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/br/viewer.properties
+++ b/l10n/br/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Digeriñ ur restr
 open_file_label=Digeriñ ur restr
 print.title=Moullañ
 print_label=Moullañ
-download.title=Pellgargañ
-download_label=Pellgargañ
-bookmark.title=Gwel bremanel (eilañ pe zigeriñ e-barzh ur prenestr nevez)
-bookmark_label=Gwel bremanel
 
 # Secondary toolbar and context menu
 tools.title=Ostilhoù
@@ -192,25 +188,6 @@ find_match_count_limit[many]=Muioc'h eget {{limit}} a glotadennoù
 find_match_count_limit[other]=Muioc'h eget {{limit}} a glotadennoù
 find_not_found=N'haller ket kavout ar frazenn
 
-# Error panel labels
-error_more_info=Muioc'h a ditouroù
-error_less_info=Nebeutoc'h a ditouroù
-error_close=Serriñ
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js handelv {{version}} (kempunadur: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Kemennadenn: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Torn: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Restr: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Linenn: {{line}}
-rendering_error=Degouezhet ez eus bet ur fazi e-pad skrammañ ar bajennad.
-
 # Predefined zoom values
 page_scale_width=Led ar bajenn
 page_scale_fit=Pajenn a-bezh
@@ -220,12 +197,12 @@ page_scale_actual=Ment wir
 # numerical scale value.
 page_scale_percent={{scale}}%
 
-# Loading indicator messages
-loading=O kargañ…
 loading_error=Degouezhet ez eus bet ur fazi e-pad kargañ ar PDF.
 invalid_file_error=Restr PDF didalvoudek pe kontronet.
 missing_file_error=Restr PDF o vankout.
 unexpected_response_error=Respont dic'hortoz a-berzh an dafariad
+
+rendering_error=Degouezhet ez eus bet ur fazi e-pad skrammañ ar bajennad.
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.

--- a/l10n/brx/viewer.properties
+++ b/l10n/brx/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=फाइलखौ खेव
 open_file_label=खेव
 print.title=साफाय
 print_label=साफाय
-download.title=डाउनल'ड खालाम
-download_label=डाउनल'ड खालाम
-bookmark.title=दानि नुथाय (गोदान उइन्ड'आव कपि खालाम एबा खेव)
-bookmark_label=दानि नुथाय
 
 # Secondary toolbar and context menu
 tools.title=टुल
@@ -152,25 +148,6 @@ find_reached_bottom=बिजौ निफ्राय जागायनान�
 find_match_count_limit={[ plural(limit) ]}
 find_not_found=बाथ्रा खोन्दोब मोनाखै
 
-# Error panel labels
-error_more_info=गोबां फोरमायथिहोग्रा
-error_less_info=खम फोरमायथिहोग्रा
-error_close=बन्द खालाम
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=खौरां: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=स्टेक: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=फाइल: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=सारि: {{line}}
-rendering_error=बिलाइखौ राव सोलायनाय समाव मोनसे गोरोन्थि जादों।
-
 # Predefined zoom values
 page_scale_width=बिलाइनि गुवार
 page_scale_fit=बिलाइ गोरोबनाय
@@ -184,6 +161,8 @@ loading_error=PDF ल'ड खालामनाय समाव मोनसे 
 invalid_file_error=बाहायजायै एबा गाज्रि जानाय PDF फाइल
 missing_file_error=गोमानाय PDF फाइल
 unexpected_response_error=मिजिंथियै सार्भार फिननाय।
+
+rendering_error=बिलाइखौ राव सोलायनाय समाव मोनसे गोरोन्थि जादों।
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.

--- a/l10n/bs/viewer.properties
+++ b/l10n/bs/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Otvori fajl
 open_file_label=Otvori
 print.title=Štampaj
 print_label=Štampaj
-download.title=Preuzmi
-download_label=Preuzmi
-bookmark.title=Trenutni prikaz (kopiraj ili otvori u novom prozoru)
-bookmark_label=Trenutni prikaz
 
 # Secondary toolbar and context menu
 tools.title=Alati
@@ -145,25 +141,6 @@ find_reached_top=Dostigao sam vrh dokumenta, nastavljam sa dna
 find_reached_bottom=Dostigao sam kraj dokumenta, nastavljam sa vrha
 find_not_found=Fraza nije pronađena
 
-# Error panel labels
-error_more_info=Više informacija
-error_less_info=Manje informacija
-error_close=Zatvori
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Poruka: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Fajl: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Linija: {{line}}
-rendering_error=Došlo je do greške prilikom renderiranja strane.
-
 # Predefined zoom values
 page_scale_width=Širina strane
 page_scale_fit=Uklopi stranu
@@ -177,6 +154,8 @@ loading_error=Došlo je do greške prilikom učitavanja PDF-a.
 invalid_file_error=Neispravan ili oštećen PDF fajl.
 missing_file_error=Nedostaje PDF fajl.
 unexpected_response_error=Neočekivani odgovor servera.
+
+rendering_error=Došlo je do greške prilikom renderiranja strane.
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/ca/viewer.properties
+++ b/l10n/ca/viewer.properties
@@ -39,12 +39,8 @@ open_file.title=Obre el fitxer
 open_file_label=Obre
 print.title=Imprimeix
 print_label=Imprimeix
-download.title=Baixa
-download_label=Baixa
 save.title=Desa
 save_label=Desa
-bookmark.title=Vista actual (copia o obre en una finestra nova)
-bookmark_label=Vista actual
 
 bookmark1.title=Pàgina actual (mostra l'URL de la pàgina actual)
 bookmark1_label=Pàgina actual
@@ -202,24 +198,6 @@ find_match_count_limit[many]=Més de {{limit}} coincidències
 find_match_count_limit[other]=Més de {{limit}} coincidències
 find_not_found=No s'ha trobat l'expressió
 
-# Error panel labels
-error_more_info=Més informació
-error_less_info=Menys informació
-error_close=Tanca
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (muntatge: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Missatge: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Pila: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Fitxer: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Línia: {{line}}
-
 # Predefined zoom values
 page_scale_width=Amplada de la pàgina
 page_scale_fit=Ajusta la pàgina
@@ -228,9 +206,6 @@ page_scale_actual=Mida real
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=S'està carregant…
 
 # Loading indicator messages
 loading_error=S'ha produït un error en carregar el PDF.

--- a/l10n/cak/viewer.properties
+++ b/l10n/cak/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Tijaq Yakb'äl
 open_file_label=Tijaq
 print.title=Titz'ajb'äx
 print_label=Titz'ajb'äx
-download.title=Tiqasäx
-download_label=Tiqasäx
-bookmark.title=Rutz'etik wakami (tiwachib'ëx o tijaq pa jun k'ak'a' tzuwäch)
-bookmark_label=Rutzub'al wakami
 
 save.title=Tiyak
 save_label=Tiyak
@@ -201,24 +197,6 @@ find_match_count_limit[many]=K'ïy chi re {{limit}} nikik'äm ki'
 find_match_count_limit[other]=K'ïy chi re {{limit}} nikik'äm ki'
 find_not_found=Man xilitäj ta ri pajtzij
 
-# Error panel labels
-error_more_info=Ch'aqa' chik rutzijol
-error_less_info=Jub'a' ok rutzijol
-error_close=Titz'apïx
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Uqxa'n: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Tzub'aj: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Yakb'äl: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=B'ey: {{line}}
-
 # Predefined zoom values
 page_scale_width=Ruwa ruxaq
 page_scale_fit=Tinuk' ruxaq
@@ -227,9 +205,6 @@ page_scale_actual=Runimilem Wakami
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Nisamäj…
 
 # Loading indicator messages
 loading_error=\u0020Xk'ulwachitäj jun sach'oj toq xnuk'ux ri PDF .

--- a/l10n/ckb/viewer.properties
+++ b/l10n/ckb/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=پەڕگە بکەرەوە
 open_file_label=کردنەوە
 print.title=چاپکردن
 print_label=چاپکردن
-download.title=داگرتن
-download_label=داگرتن
-bookmark.title=پێشبینینی ئێستا(لەبەریبگرەوە یان پەنجەرەیەکی نوێ بکەرەوە)
-bookmark_label=پیشبینینی ئێستا
 
 # Secondary toolbar and context menu
 tools.title=ئامرازەکان
@@ -181,25 +177,6 @@ find_match_count_limit[many]=زیاتر لە {{limit}} لەیەکچوو
 find_match_count_limit[other]=زیاتر لە {{limit}} لەیەکچوو
 find_not_found=نووسین نەدۆزرایەوە
 
-# Error panel labels
-error_more_info=زانیاری زیاتر
-error_less_info=زانیاری کەمتر
-error_close=داخستن
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=پەیام: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=لەسەریەک: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=پەڕگە: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=هێڵ: {{line}}
-rendering_error=هەڵەیەک ڕوویدا لە کاتی پوختەکردنی (ڕێندەر) پەڕە.
-
 # Predefined zoom values
 page_scale_width=پانی پەڕە
 page_scale_fit=پڕبوونی پەڕە
@@ -213,6 +190,8 @@ loading_error=هەڵەیەک ڕوویدا لە کاتی بارکردنی  PDF.
 invalid_file_error=پەڕگەی pdf تێکچووە یان نەگونجاوە.
 missing_file_error=پەڕگەی pdf بوونی نیە.
 unexpected_response_error=وەڵامی ڕاژەخوازی نەخوازراو.
+
+rendering_error=هەڵەیەک ڕوویدا لە کاتی پوختەکردنی (ڕێندەر) پەڕە.
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.

--- a/l10n/cs/viewer.properties
+++ b/l10n/cs/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Otevře soubor
 open_file_label=Otevřít
 print.title=Vytiskne dokument
 print_label=Vytisknout
-download.title=Stáhne dokument
-download_label=Stáhnout
-bookmark.title=Současný pohled (kopírovat nebo otevřít v novém okně)
-bookmark_label=Současný pohled
 
 save.title=Uložit
 save_label=Uložit
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Více než {{limit}} výskytů
 find_match_count_limit[other]=Více než {{limit}} výskytů
 find_not_found=Hledaný text nenalezen
 
-# Error panel labels
-error_more_info=Více informací
-error_less_info=Méně informací
-error_close=Zavřít
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (sestavení: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Zpráva: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Zásobník: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Soubor: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Řádek: {{line}}
-
 # Predefined zoom values
 page_scale_width=Podle šířky
 page_scale_fit=Podle výšky
@@ -231,9 +209,6 @@ page_scale_actual=Skutečná velikost
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}} %
-
-# Loading indicator messages
-loading=Načítání…
 
 # Loading indicator messages
 loading_error=Při nahrávání PDF nastala chyba.

--- a/l10n/cy/viewer.properties
+++ b/l10n/cy/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Agor Ffeil
 open_file_label=Agor
 print.title=Argraffu
 print_label=Argraffu
-download.title=Llwytho i lawr
-download_label=Llwytho i lawr
-bookmark.title=Golwg cyfredol (copïo neu agor ffenestr newydd)
-bookmark_label=Golwg Gyfredol
 
 save.title=Cadw
 save_label=Cadw
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Mwy na {{limit}} cydweddiad
 find_match_count_limit[other]=Mwy na {{limit}} cydweddiad
 find_not_found=Heb ganfod ymadrodd
 
-# Error panel labels
-error_more_info=Rhagor o Wybodaeth
-error_less_info=Llai o wybodaeth
-error_close=Cau
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Neges: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stac: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Ffeil: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Llinell: {{line}}
-
 # Predefined zoom values
 page_scale_width=Lled Tudalen
 page_scale_fit=Ffit Tudalen
@@ -231,9 +209,6 @@ page_scale_actual=Maint Gwirioneddol
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Yn llwytho…
 
 # Loading indicator messages
 loading_error=Digwyddodd gwall wrth lwytho'r PDF.

--- a/l10n/da/viewer.properties
+++ b/l10n/da/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Åbn fil
 open_file_label=Åbn
 print.title=Udskriv
 print_label=Udskriv
-download.title=Hent
-download_label=Hent
-bookmark.title=Aktuel visning (kopier eller åbn i et nyt vindue)
-bookmark_label=Aktuel visning
 
 save.title=Gem
 save_label=Gem
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Mere end {{limit}} forekomster
 find_match_count_limit[other]=Mere end {{limit}} forekomster
 find_not_found=Der blev ikke fundet noget
 
-# Error panel labels
-error_more_info=Mere information
-error_less_info=Mindre information
-error_close=Luk
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Fejlmeddelelse: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Fil: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Linje: {{line}}
-
 # Predefined zoom values
 page_scale_width=Sidebredde
 page_scale_fit=Tilpas til side
@@ -231,9 +209,6 @@ page_scale_actual=Faktisk størrelse
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Indlæser…
 
 # Loading indicator messages
 loading_error=Der opstod en fejl ved indlæsning af PDF-filen.

--- a/l10n/de/viewer.properties
+++ b/l10n/de/viewer.properties
@@ -39,17 +39,14 @@ open_file.title=Datei öffnen
 open_file_label=Öffnen
 print.title=Drucken
 print_label=Drucken
-download.title=Dokument speichern
-download_label=Speichern
-bookmark.title=Aktuelle Ansicht (zum Kopieren oder Öffnen in einem neuen Fenster)
-bookmark_label=Aktuelle Ansicht
 
 save.title=Speichern
 save_label=Speichern
 bookmark1.title=Aktuelle Seite (URL von aktueller Seite anzeigen)
 bookmark1_label=Aktuelle Seite
-
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
 open_in_app.title=Mit App öffnen
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
 open_in_app_label=Mit App öffnen
 
 # Secondary toolbar and context menu
@@ -171,7 +168,7 @@ thumb_page_canvas=Miniaturansicht von Seite {{page}}
 
 # Find panel button title and messages
 find_input.title=Suchen
-find_input.placeholder=Im Dokument suchen…
+find_input.placeholder=Dokument durchsuchen…
 find_previous.title=Vorheriges Vorkommen des Suchbegriffs finden
 find_previous_label=Zurück
 find_next.title=Nächstes Vorkommen des Suchbegriffs finden
@@ -205,24 +202,6 @@ find_match_count_limit[many]=Mehr als {{limit}} Übereinstimmungen
 find_match_count_limit[other]=Mehr als {{limit}} Übereinstimmungen
 find_not_found=Suchbegriff nicht gefunden
 
-# Error panel labels
-error_more_info=Mehr Informationen
-error_less_info=Weniger Informationen
-error_close=Schließen
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js Version {{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Nachricht: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Aufrufliste: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Datei: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Zeile: {{line}}
-
 # Predefined zoom values
 page_scale_width=Seitenbreite
 page_scale_fit=Seitengröße
@@ -231,9 +210,6 @@ page_scale_actual=Originalgröße
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}} %
-
-# Loading indicator messages
-loading=Wird geladen…
 
 # Loading indicator messages
 loading_error=Beim Laden der PDF-Datei trat ein Fehler auf.

--- a/l10n/dsb/viewer.properties
+++ b/l10n/dsb/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Dataju wócyniś
 open_file_label=Wócyniś
 print.title=Śišćaś
 print_label=Śišćaś
-download.title=Ześěgnuś
-download_label=Ześěgnuś
-bookmark.title=Aktualny naglěd (kopěrowaś abo w nowem woknje wócyniś)
-bookmark_label=Aktualny naglěd
 
 save.title=Składowaś
 save_label=Składowaś
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Wěcej ako {{limit}} wótpowědnikow
 find_match_count_limit[other]=Wěcej ako {{limit}} wótpowědnikow
 find_not_found=Pytański wuraz njejo se namakał
 
-# Error panel labels
-error_more_info=Wěcej informacijow
-error_less_info=Mjenjej informacijow
-error_close=Zacyniś
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Powěźenka: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Lisćina zawołanjow: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Dataja: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Smužka: {{line}}
-
 # Predefined zoom values
 page_scale_width=Šyrokosć boka
 page_scale_fit=Wjelikosć boka
@@ -231,9 +209,6 @@ page_scale_actual=Aktualna wjelikosć
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Zacytujo se…
 
 # Loading indicator messages
 loading_error=Pśi zacytowanju PDF jo zmólka nastała.

--- a/l10n/el/viewer.properties
+++ b/l10n/el/viewer.properties
@@ -39,17 +39,14 @@ open_file.title=Άνοιγμα αρχείου
 open_file_label=Άνοιγμα
 print.title=Εκτύπωση
 print_label=Εκτύπωση
-download.title=Λήψη
-download_label=Λήψη
-bookmark.title=Τρέχουσα προβολή (αντιγραφή ή άνοιγμα σε νέο παράθυρο)
-bookmark_label=Τρέχουσα προβολή
 
 save.title=Αποθήκευση
 save_label=Αποθήκευση
 bookmark1.title=Τρέχουσα σελίδα (Προβολή URL από τρέχουσα σελίδα)
 bookmark1_label=Τρέχουσα σελίδα
-
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
 open_in_app.title=Άνοιγμα σε εφαρμογή
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
 open_in_app_label=Άνοιγμα σε εφαρμογή
 
 # Secondary toolbar and context menu
@@ -78,7 +75,7 @@ scroll_horizontal_label=Οριζόντια κύλιση
 scroll_wrapped.title=Χρήση κυκλικής κύλισης
 scroll_wrapped_label=Κυκλική κύλιση
 
-spread_none.title=Να μην γίνει σύνδεση επεκτάσεων σελίδων
+spread_none.title=Να μη γίνει σύνδεση επεκτάσεων σελίδων
 spread_none_label=Χωρίς επεκτάσεις
 spread_odd.title=Σύνδεση επεκτάσεων σελίδων ξεκινώντας από τις μονές σελίδες
 spread_odd_label=Μονές επεκτάσεις
@@ -205,24 +202,6 @@ find_match_count_limit[many]=Περισσότερες από {{limit}} αντι�
 find_match_count_limit[other]=Περισσότερες από {{limit}} αντιστοιχίες
 find_not_found=Η φράση δεν βρέθηκε
 
-# Error panel labels
-error_more_info=Περισσότερες πληροφορίες
-error_less_info=Λιγότερες πληροφορίες
-error_close=Κλείσιμο
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (έκδοση: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Μήνυμα: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Στοίβα: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Αρχείο: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Γραμμή: {{line}}
-
 # Predefined zoom values
 page_scale_width=Πλάτος σελίδας
 page_scale_fit=Μέγεθος σελίδας
@@ -231,9 +210,6 @@ page_scale_actual=Πραγματικό μέγεθος
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Φόρτωση…
 
 # Loading indicator messages
 loading_error=Προέκυψε σφάλμα κατά τη φόρτωση του PDF.

--- a/l10n/en-CA/viewer.properties
+++ b/l10n/en-CA/viewer.properties
@@ -39,12 +39,8 @@ open_file.title=Open File
 open_file_label=Open
 print.title=Print
 print_label=Print
-download.title=Download
-download_label=Download
 save.title=Save
 save_label=Save
-bookmark.title=Current view (copy or open in new window)
-bookmark_label=Current View
 
 bookmark1.title=Current Page (View URL from Current Page)
 bookmark1_label=Current Page
@@ -202,24 +198,6 @@ find_match_count_limit[many]=More than {{limit}} matches
 find_match_count_limit[other]=More than {{limit}} matches
 find_not_found=Phrase not found
 
-# Error panel labels
-error_more_info=More Information
-error_less_info=Less Information
-error_close=Close
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Message: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=File: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Line: {{line}}
-
 # Predefined zoom values
 page_scale_width=Page Width
 page_scale_fit=Page Fit
@@ -228,9 +206,6 @@ page_scale_actual=Actual Size
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Loading…
 
 # Loading indicator messages
 loading_error=An error occurred while loading the PDF.

--- a/l10n/en-GB/viewer.properties
+++ b/l10n/en-GB/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Open File
 open_file_label=Open
 print.title=Print
 print_label=Print
-download.title=Download
-download_label=Download
-bookmark.title=Current view (copy or open in new window)
-bookmark_label=Current View
 
 save.title=Save
 save_label=Save
@@ -205,24 +201,6 @@ find_match_count_limit[many]=More than {{limit}} matches
 find_match_count_limit[other]=More than {{limit}} matches
 find_not_found=Phrase not found
 
-# Error panel labels
-error_more_info=More Information
-error_less_info=Less Information
-error_close=Close
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Message: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=File: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Line: {{line}}
-
 # Predefined zoom values
 page_scale_width=Page Width
 page_scale_fit=Page Fit
@@ -231,9 +209,6 @@ page_scale_actual=Actual Size
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Loading…
 
 # Loading indicator messages
 loading_error=An error occurred while loading the PDF.

--- a/l10n/eo/viewer.properties
+++ b/l10n/eo/viewer.properties
@@ -39,15 +39,15 @@ open_file.title=Malfermi dosieron
 open_file_label=Malfermi
 print.title=Presi
 print_label=Presi
-download.title=Elŝuti
-download_label=Elŝuti
+
 save.title=Konservi
 save_label=Konservi
-bookmark.title=Nuna vido (kopii aŭ malfermi en nova fenestro)
-bookmark_label=Nuna vido
-
 bookmark1.title=Nuna paĝo (Montri adreson de la nuna paĝo)
 bookmark1_label=Nuna paĝo
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=Malfermi en programo
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=Malfermi en programo
 
 # Secondary toolbar and context menu
 tools.title=Iloj
@@ -202,24 +202,6 @@ find_match_count_limit[many]=Pli ol {{limit}} kongruoj
 find_match_count_limit[other]=Pli ol {{limit}} kongruoj
 find_not_found=Frazo ne trovita
 
-# Error panel labels
-error_more_info=Pli da informo
-error_less_info=Malpli da informo
-error_close=Fermi
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Mesaĝo: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stako: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Dosiero: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Linio: {{line}}
-
 # Predefined zoom values
 page_scale_width=Larĝo de paĝo
 page_scale_fit=Adapti paĝon
@@ -228,9 +210,6 @@ page_scale_actual=Reala grando
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Ŝargado…
 
 # Loading indicator messages
 loading_error=Okazis eraro dum la ŝargado de la PDF dosiero.

--- a/l10n/es-AR/viewer.properties
+++ b/l10n/es-AR/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Abrir archivo
 open_file_label=Abrir
 print.title=Imprimir
 print_label=Imprimir
-download.title=Descargar
-download_label=Descargar
-bookmark.title=Vista actual (copiar o abrir en nueva ventana)
-bookmark_label=Vista actual
 
 save.title=Guardar
 save_label=Guardar
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Más de {{limit}} coincidencias
 find_match_count_limit[other]=Más de {{limit}} coincidencias
 find_not_found=Frase no encontrada
 
-# Error panel labels
-error_more_info=Más información
-error_less_info=Menos información
-error_close=Cerrar
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Mensaje: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Pila: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Archivo: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Línea: {{line}}
-
 # Predefined zoom values
 page_scale_width=Ancho de página
 page_scale_fit=Ajustar página
@@ -231,9 +209,6 @@ page_scale_actual=Tamaño real
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Cargando…
 
 # Loading indicator messages
 loading_error=Ocurrió un error al cargar el PDF.

--- a/l10n/es-CL/viewer.properties
+++ b/l10n/es-CL/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Abrir archivo
 open_file_label=Abrir
 print.title=Imprimir
 print_label=Imprimir
-download.title=Descargar
-download_label=Descargar
-bookmark.title=Vista actual (copiar o abrir en nueva ventana)
-bookmark_label=Vista actual
 
 save.title=Guardar
 save_label=Guardar
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Más de {{limit}} coincidencias
 find_match_count_limit[other]=Más de {{limit}} coincidencias
 find_not_found=Frase no encontrada
 
-# Error panel labels
-error_more_info=Más información
-error_less_info=Menos información
-error_close=Cerrar
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (compilación: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Mensaje: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Pila: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Archivo: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Línea: {{line}}
-
 # Predefined zoom values
 page_scale_width=Ancho de página
 page_scale_fit=Ajuste de página
@@ -231,9 +209,6 @@ page_scale_actual=Tamaño actual
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Cargando…
 
 # Loading indicator messages
 loading_error=Ocurrió un error al cargar el PDF.

--- a/l10n/es-ES/viewer.properties
+++ b/l10n/es-ES/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Abrir archivo
 open_file_label=Abrir
 print.title=Imprimir
 print_label=Imprimir
-download.title=Descargar
-download_label=Descargar
-bookmark.title=Vista actual (copiar o abrir en una nueva ventana)
-bookmark_label=Vista actual
 
 save.title=Guardar
 save_label=Guardar
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Más de {{limit}} coincidencias
 find_match_count_limit[other]=Más de {{limit}} coincidencias
 find_not_found=Frase no encontrada
 
-# Error panel labels
-error_more_info=Más información
-error_less_info=Menos información
-error_close=Cerrar
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Mensaje: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Pila: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Archivo: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Línea: {{line}}
-
 # Predefined zoom values
 page_scale_width=Anchura de la página
 page_scale_fit=Ajuste de la página
@@ -231,9 +209,6 @@ page_scale_actual=Tamaño real
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Cargando…
 
 # Loading indicator messages
 loading_error=Ocurrió un error al cargar el PDF.

--- a/l10n/es-MX/viewer.properties
+++ b/l10n/es-MX/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Abrir archivo
 open_file_label=Abrir
 print.title=Imprimir
 print_label=Imprimir
-download.title=Descargar
-download_label=Descargar
-bookmark.title=Vista actual (copiar o abrir en una nueva ventana)
-bookmark_label=Vista actual
 
 save.title=Guardar
 save_label=Guardar
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Más de {{limit}} coincidencias
 find_match_count_limit[other]=Más de {{limit}} coincidencias
 find_not_found=No se encontró la frase
 
-# Error panel labels
-error_more_info=Más información
-error_less_info=Menos información
-error_close=Cerrar
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Mensaje: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Pila: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Archivo: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Línea: {{line}}
-
 # Predefined zoom values
 page_scale_width=Ancho de página
 page_scale_fit=Ajustar página
@@ -231,9 +209,6 @@ page_scale_actual=Tamaño real
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Cargando…
 
 # Loading indicator messages
 loading_error=Un error ocurrió al cargar el PDF.

--- a/l10n/et/viewer.properties
+++ b/l10n/et/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Ava fail
 open_file_label=Ava
 print.title=Prindi
 print_label=Prindi
-download.title=Laadi alla
-download_label=Laadi alla
-bookmark.title=Praegune vaade (kopeeri või ava uues aknas)
-bookmark_label=Praegune vaade
 
 # Secondary toolbar and context menu
 tools.title=Tööriistad
@@ -197,25 +193,6 @@ find_match_count_limit[many]=Rohkem kui {{limit}} vastet
 find_match_count_limit[other]=Rohkem kui {{limit}} vastet
 find_not_found=Fraasi ei leitud
 
-# Error panel labels
-error_more_info=Rohkem teavet
-error_less_info=Vähem teavet
-error_close=Sulge
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Teade: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Fail: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Rida: {{line}}
-rendering_error=Lehe renderdamisel esines viga.
-
 # Predefined zoom values
 page_scale_width=Mahuta laiusele
 page_scale_fit=Mahuta leheküljele
@@ -225,12 +202,12 @@ page_scale_actual=Tegelik suurus
 # numerical scale value.
 page_scale_percent={{scale}}%
 
-# Loading indicator messages
-loading=Laadimine…
 loading_error=PDFi laadimisel esines viga.
 invalid_file_error=Vigane või rikutud PDF-fail.
 missing_file_error=PDF-fail puudub.
 unexpected_response_error=Ootamatu vastus serverilt.
+
+rendering_error=Lehe renderdamisel esines viga.
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.
@@ -249,14 +226,4 @@ password_cancel=Loobu
 printing_not_supported=Hoiatus: printimine pole selle brauseri poolt täielikult toetatud.
 printing_not_ready=Hoiatus: PDF pole printimiseks täielikult laaditud.
 web_fonts_disabled=Veebifondid on keelatud: PDFiga kaasatud fonte pole võimalik kasutada.
-
-# Editor
-editor_none.title=Keela annotatsioonide muutmine
-editor_none_label=Keela muutmine
-editor_free_text.title=Lisa vabateksti annotatsioon
-editor_free_text_label=Vabateksti annotatsioon
-editor_ink.title=Lisa tindiannotatsioon
-editor_ink_label=Tindiannotatsioon
-
-free_text_default_content=Sisesta tekst…
 

--- a/l10n/eu/viewer.properties
+++ b/l10n/eu/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Ireki fitxategia
 open_file_label=Ireki
 print.title=Inprimatu
 print_label=Inprimatu
-download.title=Deskargatu
-download_label=Deskargatu
-bookmark.title=Uneko ikuspegia (kopiatu edo ireki leiho berrian)
-bookmark_label=Uneko ikuspegia
 
 save.title=Gorde
 save_label=Gorde
@@ -206,24 +202,6 @@ find_match_count_limit[many]={{limit}} bat-etortze baino gehiago
 find_match_count_limit[other]={{limit}} bat-etortze baino gehiago
 find_not_found=Esaldia ez da aurkitu
 
-# Error panel labels
-error_more_info=Informazio gehiago
-error_less_info=Informazio gutxiago
-error_close=Itxi
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (eraikuntza: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Mezua: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Pila: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Fitxategia: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Lerroa: {{line}}
-
 # Predefined zoom values
 page_scale_width=Orriaren zabalera
 page_scale_fit=Doitu orrira
@@ -232,9 +210,6 @@ page_scale_actual=Benetako tamaina
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent=%{{scale}}
-
-# Loading indicator messages
-loading=Kargatzen…
 
 # Loading indicator messages
 loading_error=Errorea gertatu da PDFa kargatzean.

--- a/l10n/fa/viewer.properties
+++ b/l10n/fa/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=باز کردن پرونده
 open_file_label=باز کردن
 print.title=چاپ
 print_label=چاپ
-download.title=بارگیری
-download_label=بارگیری
-bookmark.title=نمای فعلی (رونوشت و یا نشان دادن در پنجره جدید)
-bookmark_label=نمای فعلی
 
 save_label=ذخیره
 
@@ -173,24 +169,6 @@ find_match_count[other]={{current}} از {{total}} مطابقت دارد
 # "{{limit}}" will be replaced by a numerical value.
 find_not_found=عبارت پیدا نشد
 
-# Error panel labels
-error_more_info=اطلاعات بیشتر
-error_less_info=اطلاعات کمتر
-error_close=بستن
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=‏PDF.js ورژن{{version}} ‏(ساخت: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=پیام: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=توده: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=پرونده: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=سطر: {{line}}
-
 # Predefined zoom values
 page_scale_width=عرض صفحه
 page_scale_fit=اندازه کردن صفحه
@@ -240,3 +218,4 @@ editor_free_text_size=اندازه
 editor_ink_color=رنگ
 
 # Editor aria
+

--- a/l10n/ff/viewer.properties
+++ b/l10n/ff/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Uddit Fiilde
 open_file_label=Uddit
 print.title=Winndito
 print_label=Winndito
-download.title=Aawto
-download_label=Aawto
-bookmark.title=Jiytol gonangol (natto walla uddit e henorde)
-bookmark_label=Jiytol Gonangol
 
 # Secondary toolbar and context menu
 tools.title=Kuutorɗe
@@ -186,25 +182,6 @@ find_match_count_limit[many]=Ko ɓuri laabi {{limit}}
 find_match_count_limit[other]=Ko ɓuri laabi {{limit}}
 find_not_found=Konngi njiyataa
 
-# Error panel labels
-error_more_info=Ɓeydu Humpito
-error_less_info=Ustu Humpito
-error_close=Uddu
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Ɓatakuure: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Fiilde: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Gorol: {{line}}
-rendering_error=Juumre waɗii tuma nde yoŋkittoo hello.
-
 # Predefined zoom values
 page_scale_width=Njaajeendi Hello
 page_scale_fit=Keƴeendi Hello
@@ -218,6 +195,8 @@ loading_error=Juumre waɗii tuma nde loowata PDF oo.
 invalid_file_error=Fiilde PDF moƴƴaani walla jiibii.
 missing_file_error=Fiilde PDF ena ŋakki.
 unexpected_response_error=Jaabtol sarworde tijjinooka.
+
+rendering_error=Juumre waɗii tuma nde yoŋkittoo hello.
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/fi/viewer.properties
+++ b/l10n/fi/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Avaa tiedosto
 open_file_label=Avaa
 print.title=Tulosta
 print_label=Tulosta
-download.title=Lataa
-download_label=Lataa
-bookmark.title=Avoin ikkuna (kopioi tai avaa uuteen ikkunaan)
-bookmark_label=Avoin ikkuna
 
 save.title=Tallenna
 save_label=Tallenna
@@ -207,24 +203,6 @@ find_match_count_limit[many]=Enemmän kuin {{limit}} osumaa
 find_match_count_limit[other]=Enemmän kuin {{limit}} osumaa
 find_not_found=Hakusanaa ei löytynyt
 
-# Error panel labels
-error_more_info=Lisätietoja
-error_less_info=Lisätietoja
-error_close=Sulje
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (kooste: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Virheilmoitus: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Pino: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Tiedosto: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Rivi: {{line}}
-
 # Predefined zoom values
 page_scale_width=Sivun leveys
 page_scale_fit=Koko sivu
@@ -233,9 +211,6 @@ page_scale_actual=Todellinen koko
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}} %
-
-# Loading indicator messages
-loading=Ladataan…
 
 # Loading indicator messages
 loading_error=Tapahtui virhe ladattaessa PDF-tiedostoa.

--- a/l10n/fr/viewer.properties
+++ b/l10n/fr/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Ouvrir le fichier
 open_file_label=Ouvrir le fichier
 print.title=Imprimer
 print_label=Imprimer
-download.title=Télécharger
-download_label=Télécharger
-bookmark.title=Affichage courant (copier ou ouvrir dans une nouvelle fenêtre)
-bookmark_label=Affichage actuel
 
 save.title=Enregistrer
 save_label=Enregistrer
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Plus de {{limit}} correspondances
 find_match_count_limit[other]=Plus de {{limit}} correspondances
 find_not_found=Expression non trouvée
 
-# Error panel labels
-error_more_info=Plus d’informations
-error_less_info=Moins d’informations
-error_close=Fermer
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (identifiant de compilation : {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Message : {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Pile : {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Fichier : {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Ligne : {{line}}
-
 # Predefined zoom values
 page_scale_width=Pleine largeur
 page_scale_fit=Page entière
@@ -231,9 +209,6 @@ page_scale_actual=Taille réelle
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}} %
-
-# Loading indicator messages
-loading=Chargement…
 
 # Loading indicator messages
 loading_error=Une erreur s’est produite lors du chargement du fichier PDF.

--- a/l10n/fur/viewer.properties
+++ b/l10n/fur/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Vierç un file
 open_file_label=Vierç
 print.title=Stampe
 print_label=Stampe
-download.title=Discjame
-download_label=Discjame
-bookmark.title=Viodude atuâl (copie o vierç intun gnûf barcon)
-bookmark_label=Viodude atuâl
 
 save.title=Salve
 save_label=Salve
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Plui di {{limit}} corispondencis
 find_match_count_limit[other]=Plui di {{limit}} corispondencis
 find_not_found=Test no cjatât
 
-# Error panel labels
-error_more_info=Altris informazions
-error_less_info=Mancul informazions
-error_close=Siere
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (compilazion: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Messaç: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=File: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Rie: {{line}}
-
 # Predefined zoom values
 page_scale_width=Largjece de pagjine
 page_scale_fit=Pagjine interie
@@ -231,9 +209,6 @@ page_scale_actual=Dimension reâl
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Daûr a cjamâ…
 
 # Loading indicator messages
 loading_error=Al è vignût fûr un erôr intant che si cjariave il PDF.

--- a/l10n/fy-NL/viewer.properties
+++ b/l10n/fy-NL/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Bestân iepenje
 open_file_label=Iepenje
 print.title=Ofdrukke
 print_label=Ofdrukke
-download.title=Downloade
-download_label=Downloade
-bookmark.title=Aktuele finster (kopiearje of iepenje yn nij finster)
-bookmark_label=Aktuele finster
 
 save.title=Bewarje
 save_label=Bewarje
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Mear as {{limit}} oerienkomsten
 find_match_count_limit[other]=Mear as {{limit}} oerienkomsten
 find_not_found=Tekst net fûn
 
-# Error panel labels
-error_more_info=Mear ynformaasje
-error_less_info=Minder ynformaasje
-error_close=Slute
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js f{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Berjocht: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Bestân: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Rigel: {{line}}
-
 # Predefined zoom values
 page_scale_width=Sidebreedte
 page_scale_fit=Hiele side
@@ -231,9 +209,6 @@ page_scale_actual=Werklike grutte
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Lade…
 
 # Loading indicator messages
 loading_error=Der is in flater bard by it laden fan de PDF.

--- a/l10n/ga-IE/viewer.properties
+++ b/l10n/ga-IE/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Oscail Comhad
 open_file_label=Oscail
 print.title=Priontáil
 print_label=Priontáil
-download.title=Íoslódáil
-download_label=Íoslódáil
-bookmark.title=An t-amharc reatha (cóipeáil nó oscail i bhfuinneog nua)
-bookmark_label=An tAmharc Reatha
 
 # Secondary toolbar and context menu
 tools.title=Uirlisí
@@ -149,25 +145,6 @@ find_match_count={[ plural(total) ]}
 # "{{limit}}" will be replaced by a numerical value.
 find_not_found=Frása gan aimsiú
 
-# Error panel labels
-error_more_info=Tuilleadh Eolais
-error_less_info=Níos Lú Eolais
-error_close=Dún
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Teachtaireacht: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Cruach: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Comhad: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Líne: {{line}}
-rendering_error=Tharla earráid agus an leathanach á leagan amach.
-
 # Predefined zoom values
 page_scale_width=Leithead Leathanaigh
 page_scale_fit=Laghdaigh go dtí an Leathanach
@@ -185,6 +162,8 @@ unexpected_response_error=Freagra ón bhfreastalaí nach rabhthas ag súil leis.
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.
+
+rendering_error=Tharla earráid agus an leathanach á leagan amach.
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/gd/viewer.properties
+++ b/l10n/gd/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Fosgail faidhle
 open_file_label=Fosgail
 print.title=Clò-bhuail
 print_label=Clò-bhuail
-download.title=Luchdaich a-nuas
-download_label=Luchdaich a-nuas
-bookmark.title=An sealladh làithreach (dèan lethbhreac no fosgail e ann an uinneag ùr)
-bookmark_label=An sealladh làithreach
 
 save.title=Sàbhail
 save_label=Sàbhail
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Barrachd air {{limit}} maids
 find_match_count_limit[other]=Barrachd air {{limit}} maids
 find_not_found=Cha deach an abairt a lorg
 
-# Error panel labels
-error_more_info=Barrachd fiosrachaidh
-error_less_info=Nas lugha de dh'fhiosrachadh
-error_close=Dùin
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Teachdaireachd: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stac: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Faidhle: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Loidhne: {{line}}
-
 # Predefined zoom values
 page_scale_width=Leud na duilleige
 page_scale_fit=Freagair ri meud na duilleige
@@ -231,9 +209,6 @@ page_scale_actual=Am fìor-mheud
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=’Ga luchdadh…
 
 # Loading indicator messages
 loading_error=Thachair mearachd rè luchdadh a' PDF.

--- a/l10n/gl/viewer.properties
+++ b/l10n/gl/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Abrir ficheiro
 open_file_label=Abrir
 print.title=Imprimir
 print_label=Imprimir
-download.title=Descargar
-download_label=Descargar
-bookmark.title=Vista actual (copiar ou abrir nunha nova xanela)
-bookmark_label=Vista actual
 
 save.title=Gardar
 save_label=Gardar
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Máis de {{limit}} coincidencias
 find_match_count_limit[other]=Máis de {{limit}} coincidencias
 find_not_found=Non se atopou a frase
 
-# Error panel labels
-error_more_info=Máis información
-error_less_info=Menos información
-error_close=Pechar
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (Identificador da compilación: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Mensaxe: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Pila: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Ficheiro: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Liña: {{line}}
-
 # Predefined zoom values
 page_scale_width=Largura da páxina
 page_scale_fit=Axuste de páxina
@@ -231,9 +209,6 @@ page_scale_actual=Tamaño actual
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=A cargar…
 
 # Loading indicator messages
 loading_error=Produciuse un erro ao cargar o PDF.

--- a/l10n/gn/viewer.properties
+++ b/l10n/gn/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Marandurendápe jeike
 open_file_label=Jeike
 print.title=Monguatia
 print_label=Monguatia
-download.title=Mboguejy
-download_label=Mboguejy
-bookmark.title=Ag̃agua jehecha (mbohasarã térã eike peteĩ ovetã pyahúpe)
-bookmark_label=Ag̃agua jehecha
 
 save.title=Ñongatu
 save_label=Ñongatu
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Hetave {{limit}} ojojoguáva
 find_match_count_limit[other]=Hetave {{limit}} ojojoguáva
 find_not_found=Ñe’ẽrysýi ojejuhu’ỹva
 
-# Error panel labels
-error_more_info=Maranduve
-error_less_info=Sa’ive marandu
-error_close=Mboty
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Ñe’ẽmondo: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Mbojo’apy: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Marandurenda: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Tairenda: {{line}}
-
 # Predefined zoom values
 page_scale_width=Kuatiarogue pekue
 page_scale_fit=Kuatiarogue ñemoĩporã
@@ -231,9 +209,6 @@ page_scale_actual=Tuichakue ag̃agua
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Henyhẽhína…
 
 # Loading indicator messages
 loading_error=Oiko jejavy PDF oñemyeñyhẽnguévo.

--- a/l10n/gu-IN/viewer.properties
+++ b/l10n/gu-IN/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=ફાઇલ ખોલો
 open_file_label=ખોલો
 print.title=છાપો
 print_label=છારો
-download.title=ડાઉનલોડ
-download_label=ડાઉનલોડ
-bookmark.title=વર્તમાન દૃશ્ય (નવી વિન્ડોમાં નકલ કરો અથવા ખોલો)
-bookmark_label=વર્તમાન દૃશ્ય
 
 # Secondary toolbar and context menu
 tools.title=સાધનો
@@ -186,25 +182,6 @@ find_match_count_limit[many]={{limit}} કરતાં વધુ સરખા �
 find_match_count_limit[other]={{limit}} કરતાં વધુ સરખા મળ્યાં
 find_not_found=શબ્દસમૂહ મળ્યુ નથી
 
-# Error panel labels
-error_more_info=વધારે જાણકારી
-error_less_info=ઓછી જાણકારી
-error_close=બંધ કરો
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=સંદેશો: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=સ્ટેક: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=ફાઇલ: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=વાક્ય: {{line}}
-rendering_error=ભૂલ ઉદ્ભવી જ્યારે પાનાંનુ રેન્ડ કરી રહ્યા હોય.
-
 # Predefined zoom values
 page_scale_width=પાનાની પહોળાઇ
 page_scale_fit=પાનું બંધબેસતુ
@@ -218,6 +195,8 @@ loading_error=ભૂલ ઉદ્ભવી જ્યારે PDF ને લા�
 invalid_file_error=અયોગ્ય અથવા ભાંગેલ PDF ફાઇલ.
 missing_file_error=ગુમ થયેલ PDF ફાઇલ.
 unexpected_response_error=અનપેક્ષિત સર્વર પ્રતિસાદ.
+
+rendering_error=ભૂલ ઉદ્ભવી જ્યારે પાનાંનુ રેન્ડ કરી રહ્યા હોય.
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/he/viewer.properties
+++ b/l10n/he/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=פתיחת קובץ
 open_file_label=פתיחה
 print.title=הדפסה
 print_label=הדפסה
-download.title=הורדה
-download_label=הורדה
-bookmark.title=תצוגה נוכחית (העתקה או פתיחה בחלון חדש)
-bookmark_label=תצוגה נוכחית
 
 save.title=שמירה
 save_label=שמירה
@@ -204,24 +200,6 @@ find_match_count_limit[many]=יותר מ־{{limit}} תוצאות
 find_match_count_limit[other]=יותר מ־{{limit}} תוצאות
 find_not_found=הביטוי לא נמצא
 
-# Error panel labels
-error_more_info=מידע נוסף
-error_less_info=פחות מידע
-error_close=סגירה
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js גרסה {{version}} (בנייה: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=הודעה: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=תוכן מחסנית: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=קובץ: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=שורה: {{line}}
-
 # Predefined zoom values
 page_scale_width=רוחב העמוד
 page_scale_fit=התאמה לעמוד
@@ -230,9 +208,6 @@ page_scale_actual=גודל אמיתי
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=בטעינה…
 
 # Loading indicator messages
 loading_error=אירעה שגיאה בעת טעינת ה־PDF.

--- a/l10n/hi-IN/viewer.properties
+++ b/l10n/hi-IN/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=फ़ाइल खोलें
 open_file_label=\u0020खोलें
 print.title=छापें
 print_label=\u0020छापें
-download.title=डाउनलोड
-download_label=डाउनलोड
-bookmark.title=मौजूदा दृश्य (नए विंडो में नक़ल लें या खोलें)
-bookmark_label=\u0020मौजूदा दृश्य
 
 # Secondary toolbar and context menu
 tools.title=औज़ार
@@ -182,25 +178,6 @@ find_match_count_limit[many]={{limit}} से अधिक मेल
 find_match_count_limit[other]={{limit}} से अधिक मेल
 find_not_found=वाक्यांश नहीं मिला
 
-# Error panel labels
-error_more_info=अधिक सूचना
-error_less_info=कम सूचना
-error_close=बंद करें
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=\u0020संदेश: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=स्टैक: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=फ़ाइल: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=पंक्ति: {{line}}
-rendering_error=पृष्ठ रेंडरिंग के दौरान त्रुटि आई.
-
 # Predefined zoom values
 page_scale_width=\u0020पृष्ठ चौड़ाई
 page_scale_fit=पृष्ठ फिट
@@ -214,6 +191,8 @@ loading_error=PDF लोड करते समय एक त्रुटि ह
 invalid_file_error=अमान्य या भ्रष्ट PDF फ़ाइल.
 missing_file_error=\u0020अनुपस्थित PDF फ़ाइल.
 unexpected_response_error=अप्रत्याशित सर्वर प्रतिक्रिया.
+
+rendering_error=पृष्ठ रेंडरिंग के दौरान त्रुटि आई.
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.

--- a/l10n/hr/viewer.properties
+++ b/l10n/hr/viewer.properties
@@ -39,12 +39,8 @@ open_file.title=Otvori datoteku
 open_file_label=Otvori
 print.title=Ispiši
 print_label=Ispiši
-download.title=Preuzmi
-download_label=Preuzmi
 save.title=Spremi
 save_label=Spremi
-bookmark.title=Trenutačni prikaz (kopiraj ili otvori u novom prozoru)
-bookmark_label=Trenutačni prikaz
 
 # Secondary toolbar and context menu
 tools.title=Alati
@@ -196,24 +192,6 @@ find_match_count_limit[many]=Više od {{limit}} podudaranja
 find_match_count_limit[other]=Više od {{limit}} podudaranja
 find_not_found=Izraz nije pronađen
 
-# Error panel labels
-error_more_info=Više informacija
-error_less_info=Manje informacija
-error_close=Zatvori
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Poruka: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stog: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Datoteka: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Redak: {{line}}
-
 # Predefined zoom values
 page_scale_width=Prilagodi širini prozora
 page_scale_fit=Prilagodi veličini prozora
@@ -223,8 +201,6 @@ page_scale_actual=Stvarna veličina
 # numerical scale value.
 page_scale_percent={{scale}} %
 
-# Loading indicator messages
-loading=Učitavanje…
 loading_error=Došlo je do greške pri učitavanju PDF-a.
 invalid_file_error=Neispravna ili oštećena PDF datoteka.
 missing_file_error=Nedostaje PDF datoteka.

--- a/l10n/hsb/viewer.properties
+++ b/l10n/hsb/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Dataju wočinić
 open_file_label=Wočinić
 print.title=Ćišćeć
 print_label=Ćišćeć
-download.title=Sćahnyć
-download_label=Sćahnyć
-bookmark.title=Aktualny napohlad (kopěrować abo w nowym woknje wočinić)
-bookmark_label=Aktualny napohlad
 
 save.title=Składować
 save_label=Składować
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Wjace hač {{limit}} wotpowědnikow
 find_match_count_limit[other]=Wjace hač {{limit}} wotpowědnikow
 find_not_found=Pytanski wuraz njeje so namakał
 
-# Error panel labels
-error_more_info=Wjace informacijow
-error_less_info=Mjenje informacijow
-error_close=Začinić
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Zdźělenka: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Lisćina zawołanjow: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Dataja: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Linka: {{line}}
-
 # Predefined zoom values
 page_scale_width=Šěrokosć strony
 page_scale_fit=Wulkosć strony
@@ -231,9 +209,6 @@ page_scale_actual=Aktualna wulkosć
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Začituje so…
 
 # Loading indicator messages
 loading_error=Při začitowanju PDF je zmylk wustupił.

--- a/l10n/hu/viewer.properties
+++ b/l10n/hu/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Fájl megnyitása
 open_file_label=Megnyitás
 print.title=Nyomtatás
 print_label=Nyomtatás
-download.title=Letöltés
-download_label=Letöltés
-bookmark.title=Jelenlegi nézet (másolás vagy megnyitás új ablakban)
-bookmark_label=Aktuális nézet
 
 save.title=Mentés
 save_label=Mentés
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Több mint {{limit}} találat
 find_match_count_limit[other]=Több mint {{limit}} találat
 find_not_found=A kifejezés nem található
 
-# Error panel labels
-error_more_info=További tudnivalók
-error_less_info=Kevesebb információ
-error_close=Bezárás
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Üzenet: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Verem: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Fájl: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Sor: {{line}}
-
 # Predefined zoom values
 page_scale_width=Oldalszélesség
 page_scale_fit=Teljes oldal
@@ -231,9 +209,6 @@ page_scale_actual=Valódi méret
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Betöltés…
 
 # Loading indicator messages
 loading_error=Hiba történt a PDF betöltésekor.

--- a/l10n/hy-AM/viewer.properties
+++ b/l10n/hy-AM/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Բացել նիշք
 open_file_label=Բացել
 print.title=Տպել
 print_label=Տպել
-download.title=Բեռնել
-download_label=Բեռնել
-bookmark.title=Ընթացիկ տեսքով (պատճենել կամ բացել նոր պատուհանում)
-bookmark_label=Ընթացիկ տեսքը
 
 # LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
 # LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
@@ -190,24 +186,6 @@ find_match_count_limit[many]=Ավելին քան {{limit}} համընկնում�
 find_match_count_limit[other]=Ավելին քան {{limit}} համընկնումներներ
 find_not_found=Արտահայտությունը չգտնվեց
 
-# Error panel labels
-error_more_info=Ավելի շատ տեղեկություն
-error_less_info=Քիչ տեղեկություն
-error_close=Փակել
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (կառուցումը. {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Գրությունը. {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Շեղջ. {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Ֆայլ. {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Տողը. {{line}}
-
 # Predefined zoom values
 page_scale_width=Էջի լայնքը
 page_scale_fit=Ձգել էջը
@@ -251,3 +229,4 @@ web_fonts_disabled=Վեբ-տառատեսակները անջատված են. հն
 # Editor Parameters
 
 # Editor aria
+

--- a/l10n/hye/viewer.properties
+++ b/l10n/hye/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Բացել նիշքը
 open_file_label=Բացել
 print.title=Տպել
 print_label=Տպել
-download.title=Բեռնել
-download_label=Բեռնել
-bookmark.title=Ընթացիկ տեսքով (պատճէնել կամ բացել նոր պատուհանում)
-bookmark_label=Ընթացիկ տեսք
 
 # Secondary toolbar and context menu
 tools.title=Գործիքներ
@@ -197,25 +193,6 @@ find_match_count_limit[many]=Աւելին քան {{limit}} համընկնում�
 find_match_count_limit[other]=Աւելին քան {{limit}} համընկնումները
 find_not_found=Արտայայտութիւնը չգտնուեց
 
-# Error panel labels
-error_more_info=Աւելի շատ տեղեկութիւն
-error_less_info=Քիչ տեղեկութիւն
-error_close=Փակել
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (կառուցումը. {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Գրութիւնը. {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Շեղջ. {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=նիշք․ {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Տողը. {{line}}
-rendering_error=Սխալ է տեղի ունեցել էջի մեկնաբանման ժամանակ
-
 # Predefined zoom values
 page_scale_width=Էջի լայնութիւն
 page_scale_fit=Հարմարեցնել էջը
@@ -225,12 +202,12 @@ page_scale_actual=Իրական չափը
 # numerical scale value.
 page_scale_percent={{scale}}%
 
-# Loading indicator messages
-loading=Բեռնում…
 loading_error=PDF նիշքը բացելիս սխալ է տեղի ունեցել։
 invalid_file_error=Սխալ կամ վնասուած PDF նիշք։
 missing_file_error=PDF նիշքը բացակաիւմ է։
 unexpected_response_error=Սպասարկիչի անսպասելի պատասխան։
+
+rendering_error=Սխալ է տեղի ունեցել էջի մեկնաբանման ժամանակ
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.

--- a/l10n/ia/viewer.properties
+++ b/l10n/ia/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Aperir le file
 open_file_label=Aperir
 print.title=Imprimer
 print_label=Imprimer
-download.title=Discargar
-download_label=Discargar
-bookmark.title=Vista actual (copiar o aperir in un nove fenestra)
-bookmark_label=Vista actual
 
 save.title=Salvar
 save_label=Salvar
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Plus de {{limit}} correspondentias
 find_match_count_limit[other]=Plus de {{limit}} concordantias
 find_not_found=Phrase non trovate
 
-# Error panel labels
-error_more_info=Plus de informationes
-error_less_info=Minus de informationes
-error_close=Clauder
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Message: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Pila: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=File: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Linea: {{line}}
-
 # Predefined zoom values
 page_scale_width=Plen largor del pagina
 page_scale_fit=Pagina integre
@@ -231,9 +209,6 @@ page_scale_actual=Dimension real
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Cargante…
 
 # Loading indicator messages
 loading_error=Un error occurreva durante que on cargava le file PDF.

--- a/l10n/id/viewer.properties
+++ b/l10n/id/viewer.properties
@@ -39,12 +39,8 @@ open_file.title=Buka Berkas
 open_file_label=Buka
 print.title=Cetak
 print_label=Cetak
-download.title=Unduh
-download_label=Unduh
 save.title=Simpan
 save_label=Simpan
-bookmark.title=Tampilan Sekarang (salin atau buka di jendela baru)
-bookmark_label=Tampilan Sekarang
 
 bookmark1.title=Laman Saat Ini (Lihat URL dari Laman Sekarang)
 bookmark1_label=Laman Saat Ini
@@ -202,24 +198,6 @@ find_match_count_limit[many]=Ditemukan lebih dari {{limit}}
 find_match_count_limit[other]=Ditemukan lebih dari {{limit}}
 find_not_found=Frasa tidak ditemukan
 
-# Error panel labels
-error_more_info=Lebih Banyak Informasi
-error_less_info=Lebih Sedikit Informasi
-error_close=Tutup
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Pesan: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Berkas: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Baris: {{line}}
-
 # Predefined zoom values
 page_scale_width=Lebar Laman
 page_scale_fit=Muat Laman
@@ -229,8 +207,6 @@ page_scale_actual=Ukuran Asli
 # numerical scale value.
 page_scale_percent={{scale}}%
 
-# Loading indicator messages
-loading=Memuat…
 loading_error=Galat terjadi saat memuat PDF.
 invalid_file_error=Berkas PDF tidak valid atau rusak.
 missing_file_error=Berkas PDF tidak ada.

--- a/l10n/is/viewer.properties
+++ b/l10n/is/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Opna skrá
 open_file_label=Opna
 print.title=Prenta
 print_label=Prenta
-download.title=Hala niður
-download_label=Hala niður
-bookmark.title=Núverandi sýn (afritaðu eða opnaðu í nýjum glugga)
-bookmark_label=Núverandi sýn
 
 save.title=Vista
 save_label=Vista
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Fleiri en {{limit}} niðurstöður
 find_match_count_limit[other]=Fleiri en {{limit}} niðurstöður
 find_not_found=Fann ekki orðið
 
-# Error panel labels
-error_more_info=Meiri upplýsingar
-error_less_info=Minni upplýsingar
-error_close=Loka
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Skilaboð: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stafli: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Skrá: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Lína: {{line}}
-
 # Predefined zoom values
 page_scale_width=Síðubreidd
 page_scale_fit=Passa á síðu
@@ -231,9 +209,6 @@ page_scale_actual=Raunstærð
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Hleður…
 
 # Loading indicator messages
 loading_error=Villa kom upp við að hlaða inn PDF.

--- a/l10n/it/viewer.properties
+++ b/l10n/it/viewer.properties
@@ -36,10 +36,6 @@ open_file.title = Apri file
 open_file_label = Apri
 print.title = Stampa
 print_label = Stampa
-download.title = Scarica questo documento
-download_label = Download
-bookmark.title = Visualizzazione corrente (copia o apri in una nuova finestra)
-bookmark_label = Visualizzazione corrente
 
 save.title = Salva
 save_label = Salva
@@ -165,22 +161,11 @@ find_match_count_limit[many] = Più di {{limit}} corrispondenze
 find_match_count_limit[other] = Più di {{limit}} corrispondenze
 find_not_found = Testo non trovato
 
-error_more_info = Ulteriori informazioni
-error_less_info = Nascondi dettagli
-error_close = Chiudi
-error_version_info = PDF.js v{{version}} (build: {{build}})
-error_message = Messaggio: {{message}}
-error_stack = Stack: {{stack}}
-error_file = File: {{file}}
-error_line = Riga: {{line}}
-
 page_scale_width = Larghezza pagina
 page_scale_fit = Adatta a una pagina
 page_scale_auto = Zoom automatico
 page_scale_actual = Dimensioni effettive
 page_scale_percent = {{scale}}%
-
-loading = Caricamento in corso…
 
 loading_error = Si è verificato un errore durante il caricamento del PDF.
 invalid_file_error = File PDF non valido o danneggiato.

--- a/l10n/ka/viewer.properties
+++ b/l10n/ka/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=ფაილის გახსნა
 open_file_label=გახსნა
 print.title=ამობეჭდვა
 print_label=ამობეჭდვა
-download.title=ჩამოტვირთვა
-download_label=ჩამოტვირთვა
-bookmark.title=მიმდინარე ხედი (ასლის აღება ან გახსნა ახალ ფანჯარაში)
-bookmark_label=მიმდინარე ხედი
 
 save.title=შენახვა
 save_label=შენახვა
@@ -205,24 +201,6 @@ find_match_count_limit[many]=არანაკლებ {{limit}} თანხ�
 find_match_count_limit[other]=არანაკლებ {{limit}} თანხვედრა
 find_not_found=ფრაზა ვერ მოიძებნა
 
-# Error panel labels
-error_more_info=ვრცლად
-error_less_info=შემოკლებულად
-error_close=დახურვა
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=შეტყობინება: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=სტეკი: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=ფაილი: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=ხაზი: {{line}}
-
 # Predefined zoom values
 page_scale_width=გვერდის სიგანეზე
 page_scale_fit=მთლიანი გვერდი
@@ -231,9 +209,6 @@ page_scale_actual=საწყისი ზომა
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=ჩატვირთვა…
 
 # Loading indicator messages
 loading_error=შეცდომა, PDF-ფაილის ჩატვირთვისას.

--- a/l10n/kab/viewer.properties
+++ b/l10n/kab/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Ldi Afaylu
 open_file_label=Ldi
 print.title=Siggez
 print_label=Siggez
-download.title=Sader
-download_label=Azdam
-bookmark.title=Timeẓri tamirant (nɣel neɣ ldi ɣef usfaylu amaynut)
-bookmark_label=Askan amiran
 
 save.title=Sekles
 save_label=Sekles
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Ugar n {{limit}} n tmeɣṛuḍin
 find_match_count_limit[other]=Ugar n {{limit}} n tmeɣṛuḍin
 find_not_found=Ulac tawinest
 
-# Error panel labels
-error_more_info=Ugar n telɣut
-error_less_info=Drus n isalen
-error_close=Mdel
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Izen: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Tanebdant: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Afaylu: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Izirig: {{line}}
-
 # Predefined zoom values
 page_scale_width=Tehri n usebter
 page_scale_fit=Asebter imaṛṛa
@@ -231,9 +209,6 @@ page_scale_actual=Teɣzi tilawt
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Asali…
 
 # Loading indicator messages
 loading_error=Teḍra-d tuccḍa deg alluy n PDF:

--- a/l10n/kk/viewer.properties
+++ b/l10n/kk/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Файлды ашу
 open_file_label=Ашу
 print.title=Баспаға шығару
 print_label=Баспаға шығару
-download.title=Жүктеп алу
-download_label=Жүктеп алу
-bookmark.title=Ағымдағы көрініс (көшіру не жаңа терезеде ашу)
-bookmark_label=Ағымдағы көрініс
 
 save.title=Сақтау
 save_label=Сақтау
@@ -205,24 +201,6 @@ find_match_count_limit[many]={{limit}} сәйкестіктен көп
 find_match_count_limit[other]={{limit}} сәйкестіктен көп
 find_not_found=Сөз(дер) табылмады
 
-# Error panel labels
-error_more_info=Көбірек ақпарат
-error_less_info=Азырақ ақпарат
-error_close=Жабу
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (жинақ: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Хабарлама: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Стек: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Файл: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Жол: {{line}}
-
 # Predefined zoom values
 page_scale_width=Парақ ені
 page_scale_fit=Парақты сыйдыру
@@ -231,9 +209,6 @@ page_scale_actual=Нақты өлшемі
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Жүктелуде…
 
 # Loading indicator messages
 loading_error=PDF жүктеу кезінде қате кетті.

--- a/l10n/km/viewer.properties
+++ b/l10n/km/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=បើក​ឯកសារ
 open_file_label=បើក
 print.title=បោះពុម្ព
 print_label=បោះពុម្ព
-download.title=ទាញ​យក
-download_label=ទាញ​យក
-bookmark.title=ទិដ្ឋភាព​បច្ចុប្បន្ន (ចម្លង ឬ​បើក​នៅ​ក្នុង​បង្អួច​ថ្មី)
-bookmark_label=ទិដ្ឋភាព​បច្ចុប្បន្ន
 
 # Secondary toolbar and context menu
 tools.title=ឧបករណ៍
@@ -158,25 +154,6 @@ find_reached_bottom=បាន​បន្ត​ពី​ខាងលើ ទៅ�
 # "{{limit}}" will be replaced by a numerical value.
 find_not_found=រក​មិន​ឃើញ​ពាក្យ ឬ​ឃ្លា
 
-# Error panel labels
-error_more_info=ព័ត៌មាន​បន្ថែម
-error_less_info=ព័ត៌មាន​តិចតួច
-error_close=បិទ
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=សារ ៖ {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=ជង់ ៖ {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=ឯកសារ ៖ {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=ជួរ ៖ {{line}}
-rendering_error=មាន​កំហុស​បាន​កើតឡើង​ពេល​បង្ហាញ​ទំព័រ ។
-
 # Predefined zoom values
 page_scale_width=ទទឹង​ទំព័រ
 page_scale_fit=សម​ទំព័រ
@@ -193,6 +170,8 @@ unexpected_response_error=ការ​ឆ្លើយ​តម​ម៉ាស៊
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.
+
+rendering_error=មាន​កំហុស​បាន​កើតឡើង​ពេល​បង្ហាញ​ទំព័រ ។
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/kn/viewer.properties
+++ b/l10n/kn/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=ಕಡತವನ್ನು ತೆರೆ
 open_file_label=ತೆರೆಯಿರಿ
 print.title=ಮುದ್ರಿಸು
 print_label=ಮುದ್ರಿಸಿ
-download.title=ಇಳಿಸು
-download_label=ಇಳಿಸಿಕೊಳ್ಳಿ
-bookmark.title=ಪ್ರಸಕ್ತ ನೋಟ (ಪ್ರತಿ ಮಾಡು ಅಥವ ಹೊಸ ಕಿಟಕಿಯಲ್ಲಿ ತೆರೆ)
-bookmark_label=ಪ್ರಸಕ್ತ ನೋಟ
 
 # Secondary toolbar and context menu
 tools.title=ಉಪಕರಣಗಳು
@@ -138,25 +134,6 @@ find_reached_top=ದಸ್ತಾವೇಜಿನ ಮೇಲ್ಭಾಗವನ್�
 find_reached_bottom=ದಸ್ತಾವೇಜಿನ ಕೊನೆಯನ್ನು ತಲುಪಿದೆ, ಮೇಲಿನಿಂದ ಆರಂಭಿಸು
 find_not_found=ವಾಕ್ಯವು ಕಂಡು ಬಂದಿಲ್ಲ
 
-# Error panel labels
-error_more_info=ಹೆಚ್ಚಿನ ಮಾಹಿತಿ
-error_less_info=ಕಡಿಮೆ ಮಾಹಿತಿ
-error_close=ಮುಚ್ಚು
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=ಸಂದೇಶ: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=ರಾಶಿ: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=ಕಡತ: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=ಸಾಲು: {{line}}
-rendering_error=ಪುಟವನ್ನು ನಿರೂಪಿಸುವಾಗ ಒಂದು ದೋಷ ಎದುರಾಗಿದೆ.
-
 # Predefined zoom values
 page_scale_width=ಪುಟದ ಅಗಲ
 page_scale_fit=ಪುಟದ ಸರಿಹೊಂದಿಕೆ
@@ -170,6 +147,8 @@ loading_error=PDF ಅನ್ನು ಲೋಡ್ ಮಾಡುವಾಗ ಒಂದ�
 invalid_file_error=ಅಮಾನ್ಯವಾದ ಅಥವ ಹಾಳಾದ PDF ಕಡತ.
 missing_file_error=PDF ಕಡತ ಇಲ್ಲ.
 unexpected_response_error=ಅನಿರೀಕ್ಷಿತವಾದ ಪೂರೈಕೆಗಣಕದ ಪ್ರತಿಕ್ರಿಯೆ.
+
+rendering_error=ಪುಟವನ್ನು ನಿರೂಪಿಸುವಾಗ ಒಂದು ದೋಷ ಎದುರಾಗಿದೆ.
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/ko/viewer.properties
+++ b/l10n/ko/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=파일 열기
 open_file_label=열기
 print.title=인쇄
 print_label=인쇄
-download.title=다운로드
-download_label=다운로드
-bookmark.title=현재 보기 (복사 또는 새 창에서 열기)
-bookmark_label=현재 보기
 
 save.title=저장
 save_label=저장
@@ -205,24 +201,6 @@ find_match_count_limit[many]={{limit}} 이상 일치
 find_match_count_limit[other]={{limit}} 이상 일치
 find_not_found=검색 결과 없음
 
-# Error panel labels
-error_more_info=자세한 정보
-error_less_info=정보 간단히 보기
-error_close=닫기
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (빌드: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=메시지: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=스택: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=파일: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=줄 번호: {{line}}
-
 # Predefined zoom values
 page_scale_width=페이지 너비에 맞추기
 page_scale_fit=페이지에 맞추기
@@ -231,9 +209,6 @@ page_scale_actual=실제 크기
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=로드 중…
 
 # Loading indicator messages
 loading_error=PDF를 로드하는 동안 오류가 발생했습니다.

--- a/l10n/lij/viewer.properties
+++ b/l10n/lij/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Arvi file
 open_file_label=Arvi
 print.title=Stanpa
 print_label=Stanpa
-download.title=Descaregamento
-download_label=Descaregamento
-bookmark.title=Vixon corente (còpia ò arvi inte 'n neuvo barcon)
-bookmark_label=Vixon corente
 
 # Secondary toolbar and context menu
 tools.title=Atressi
@@ -186,25 +182,6 @@ find_match_count_limit[many]=Ciù de {{limit}} corispondense
 find_match_count_limit[other]=Ciù de {{limit}} corispondense
 find_not_found=Testo no trovou
 
-# Error panel labels
-error_more_info=Ciù informaçioin
-error_less_info=Meno informaçioin
-error_close=Særa
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Mesaggio: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Schedaio: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Linia: {{line}}
-rendering_error=Gh'é stæto 'n'erô itno rendering da pagina.
-
 # Predefined zoom values
 page_scale_width=Larghessa pagina
 page_scale_fit=Adatta a una pagina
@@ -218,6 +195,8 @@ loading_error=S'é verificou 'n'erô itno caregamento do PDF.
 invalid_file_error=O schedaio PDF o l'é no valido ò aroinou.
 missing_file_error=O schedaio PDF o no gh'é.
 unexpected_response_error=Risposta inprevista do-u server
+
+rendering_error=Gh'é stæto 'n'erô itno rendering da pagina.
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/lo/viewer.properties
+++ b/l10n/lo/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=ເປີດໄຟລ໌
 open_file_label=ເປີດ
 print.title=ພິມ
 print_label=ພິມ
-download.title=ດາວໂຫລດ
-download_label=ດາວໂຫລດ
-bookmark.title=ມຸມມອງປະຈຸບັນ (ສຳເນົາ ຫລື ເປີດໃນວິນໂດໃຫມ່)
-bookmark_label=ມຸມມອງປະຈຸບັນ
 
 save.title=ບັນທຶກ
 save_label=ບັນທຶກ
@@ -205,24 +201,6 @@ find_match_count_limit[many]=ຫຼາຍກວ່າ {{limit}} ກົງກັ�
 find_match_count_limit[other]=ຫຼາຍກວ່າ {{limit}} ກົງກັນ
 find_not_found=ບໍ່ພົບວະລີທີ່ຕ້ອງການ
 
-# Error panel labels
-error_more_info=ຂໍ້ມູນເພີ່ມເຕີມ
-error_less_info=ຂໍ້ມູນນ້ອຍລົງ
-error_close=ປິດ
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (ສ້າງ: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=ຂໍ້ຄວາມ: {{ message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=ໄຟລ໌: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=ແຖວ: {{line}}
-
 # Predefined zoom values
 page_scale_width=ຄວາມກວ້າງໜ້າ
 page_scale_fit=ໜ້າພໍດີ
@@ -231,9 +209,6 @@ page_scale_actual=ຂະໜາດຕົວຈິງ
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=ກຳລັງໂຫລດ…
 
 # Loading indicator messages
 loading_error=ມີຂໍ້ຜິດພາດເກີດຂື້ນຂະນະທີ່ກຳລັງໂຫລດ PDF.

--- a/l10n/lt/viewer.properties
+++ b/l10n/lt/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Atverti failą
 open_file_label=Atverti
 print.title=Spausdinti
 print_label=Spausdinti
-download.title=Parsiųsti
-download_label=Parsiųsti
-bookmark.title=Esamojo rodinio saitas (kopijavimui ar atvėrimui kitame lange)
-bookmark_label=Esamasis rodinys
 
 # Secondary toolbar and context menu
 tools.title=Priemonės
@@ -197,25 +193,6 @@ find_match_count_limit[many]=Daugiau nei {{limit}} atitikmenų
 find_match_count_limit[other]=Daugiau nei {{limit}} atitikmuo
 find_not_found=Ieškoma frazė nerasta
 
-# Error panel labels
-error_more_info=Išsamiau
-error_less_info=Glausčiau
-error_close=Užverti
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v. {{version}} (darinys: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Pranešimas: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Dėklas: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Failas: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Eilutė: {{line}}
-rendering_error=Atvaizduojant puslapį įvyko klaida.
-
 # Predefined zoom values
 page_scale_width=Priderinti prie lapo pločio
 page_scale_fit=Pritaikyti prie lapo dydžio
@@ -225,12 +202,12 @@ page_scale_actual=Tikras dydis
 # numerical scale value.
 page_scale_percent={{scale}}%
 
-# Loading indicator messages
-loading=Įkeliama…
 loading_error=Įkeliant PDF failą įvyko klaida.
 invalid_file_error=Tai nėra PDF failas arba jis yra sugadintas.
 missing_file_error=PDF failas nerastas.
 unexpected_response_error=Netikėtas serverio atsakas.
+
+rendering_error=Atvaizduojant puslapį įvyko klaida.
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.
@@ -249,12 +226,4 @@ password_cancel=Atsisakyti
 printing_not_supported=Dėmesio! Spausdinimas šioje naršyklėje nėra pilnai realizuotas.
 printing_not_ready=Dėmesio! PDF failas dar nėra pilnai įkeltas spausdinimui.
 web_fonts_disabled=Saityno šriftai išjungti – PDF faile esančių šriftų naudoti negalima.
-
-# Editor
-editor_none.title=Išjungti komentarų redagavimą
-editor_none_label=Išjungti redagavimą
-editor_free_text.title=Pridėti „FreeText“ komentarą
-editor_free_text_label=„FreeText“ komentaras
-editor_ink.title=Pridėti laisvo stiliaus komentarą
-editor_ink_label=Laisvo stiliaus komentaras
 

--- a/l10n/ltg/viewer.properties
+++ b/l10n/ltg/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Attaiseit failu
 open_file_label=Attaiseit
 print.title=Drukuošona
 print_label=Drukōt
-download.title=Lejupīluode
-download_label=Lejupīluodeit
-bookmark.title=Pošreizejais skots (kopēt voi attaiseit jaunā lūgā)
-bookmark_label=Pošreizejais skots
 
 # Secondary toolbar and context menu
 tools.title=Reiki
@@ -164,25 +160,6 @@ find_reached_top=Sasnīgts dokumenta suokums, turpynojom nu beigom
 find_reached_bottom=Sasnīgtys dokumenta beigys, turpynojom nu suokuma
 find_not_found=Frāze nav atrosta
 
-# Error panel labels
-error_more_info=Vairuok informacejis
-error_less_info=mozuok informacejis
-error_close=Close
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Ziņuojums: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Steks: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=File: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Ryndeņa: {{line}}
-rendering_error=Attālojūt lopu rodās klaida
-
 # Predefined zoom values
 page_scale_width=Lopys plotumā
 page_scale_fit=Ītylpynūt lopu
@@ -196,6 +173,8 @@ loading_error=Īluodejūt PDF nūtyka klaida.
 invalid_file_error=Nadereigs voi būjuots PDF fails.
 missing_file_error=PDF fails nav atrosts.
 unexpected_response_error=Unexpected server response.
+
+rendering_error=Attālojūt lopu rodās klaida
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/lv/viewer.properties
+++ b/l10n/lv/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Atvērt failu
 open_file_label=Atvērt
 print.title=Drukāšana
 print_label=Drukāt
-download.title=Lejupielāde
-download_label=Lejupielādēt
-bookmark.title=Pašreizējais skats (kopēt vai atvērt jaunā logā)
-bookmark_label=Pašreizējais skats
 
 # Secondary toolbar and context menu
 tools.title=Rīki
@@ -186,25 +182,6 @@ find_match_count_limit[many]=Vairāk nekā {{limit}} rezultāti
 find_match_count_limit[other]=Vairāk nekā {{limit}} rezultāti
 find_not_found=Frāze nav atrasta
 
-# Error panel labels
-error_more_info=Vairāk informācijas
-error_less_info=MAzāk informācijas
-error_close=Close
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Ziņojums: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Steks: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=File: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Rindiņa: {{line}}
-rendering_error=Attēlojot lapu radās kļūda
-
 # Predefined zoom values
 page_scale_width=Lapas platumā
 page_scale_fit=Ietilpinot lapu
@@ -218,6 +195,8 @@ loading_error=Ielādējot PDF notika kļūda.
 invalid_file_error=Nederīgs vai bojāts PDF fails.
 missing_file_error=PDF fails nav atrasts.
 unexpected_response_error=Negaidīa servera atbilde.
+
+rendering_error=Attēlojot lapu radās kļūda
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/meh/viewer.properties
+++ b/l10n/meh/viewer.properties
@@ -80,11 +80,6 @@ find_match_count={[ plural(total) ]}
 # "{{limit}}" will be replaced by a numerical value.
 find_match_count_limit={[ plural(limit) ]}
 
-# Error panel labels
-error_close=Nakasɨ
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
 # LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
 # english string describing the error.
 # LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack

--- a/l10n/mk/viewer.properties
+++ b/l10n/mk/viewer.properties
@@ -36,10 +36,6 @@ open_file.title=Отворање датотека
 open_file_label=Отвори
 print.title=Печатење
 print_label=Печати
-download.title=Преземање
-download_label=Преземи
-bookmark.title=Овој преглед (копирај или отвори во нов прозорец)
-bookmark_label=Овој преглед
 
 # Secondary toolbar and context menu
 tools.title=Алатки
@@ -96,25 +92,6 @@ find_reached_top=Барањето стигна до почетокот на до
 find_reached_bottom=Барањето стигна до крајот на документот и почнува од почеток
 find_not_found=Фразата не е пронајдена
 
-# Error panel labels
-error_more_info=Повеќе информации
-error_less_info=Помалку информации
-error_close=Затвори
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Порака: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Датотека: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Линија: {{line}}
-rendering_error=Настана грешка при прикажувањето на страницата.
-
 # Predefined zoom values
 page_scale_width=Ширина на страница
 page_scale_fit=Цела страница
@@ -126,6 +103,8 @@ page_scale_actual=Вистинска големина
 loading_error=Настана грешка при вчитувањето на PDF-от.
 invalid_file_error=Невалидна или корумпирана PDF датотека.
 missing_file_error=Недостасува PDF документ.
+
+rendering_error=Настана грешка при прикажувањето на страницата.
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/mr/viewer.properties
+++ b/l10n/mr/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=फाइल उघडा
 open_file_label=उघडा
 print.title=छपाई करा
 print_label=छपाई करा
-download.title=डाउनलोड करा
-download_label=डाउनलोड करा
-bookmark.title=सध्याचे अवलोकन (नवीन पटलात प्रत बनवा किंवा उघडा)
-bookmark_label=सध्याचे अवलोकन
 
 # Secondary toolbar and context menu
 tools.title=साधने
@@ -178,25 +174,6 @@ find_match_count_limit[many]={{limit}} पेक्षा अधिक जुळ
 find_match_count_limit[other]={{limit}} पेक्षा अधिक जुळण्या
 find_not_found=वाकप्रयोग आढळले नाही
 
-# Error panel labels
-error_more_info=आणखी माहिती
-error_less_info=कमी माहिती
-error_close=बंद करा
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=संदेश: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=स्टॅक: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=फाइल: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=रेष: {{line}}
-rendering_error=पृष्ठ दाखवतेवेळी त्रुटी आढळली.
-
 # Predefined zoom values
 page_scale_width=पृष्ठाची रूंदी
 page_scale_fit=पृष्ठ बसवा
@@ -210,6 +187,8 @@ loading_error=PDF लोड करतेवेळी त्रुटी आढ�
 invalid_file_error=अवैध किंवा दोषीत PDF फाइल.
 missing_file_error=न आढळणारी PDF फाइल.
 unexpected_response_error=अनपेक्षित सर्व्हर प्रतिसाद.
+
+rendering_error=पृष्ठ दाखवतेवेळी त्रुटी आढळली.
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.

--- a/l10n/ms/viewer.properties
+++ b/l10n/ms/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Buka Fail
 open_file_label=Buka
 print.title=Cetak
 print_label=Cetak
-download.title=Muat turun
-download_label=Muat turun
-bookmark.title=Paparan semasa (salin atau buka dalam tetingkap baru)
-bookmark_label=Paparan Semasa
 
 # Secondary toolbar and context menu
 tools.title=Alatan
@@ -186,25 +182,6 @@ find_match_count_limit[many]=Lebih daripada {{limit}} padanan
 find_match_count_limit[other]=Lebih daripada {{limit}} padanan
 find_not_found=Frasa tidak ditemui
 
-# Error panel labels
-error_more_info=Maklumat Lanjut
-error_less_info=Kurang Informasi
-error_close=Tutup
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Mesej: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Timbun: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Fail: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Garis: {{line}}
-rendering_error=Ralat berlaku ketika memberikan halaman.
-
 # Predefined zoom values
 page_scale_width=Lebar Halaman
 page_scale_fit=Muat Halaman
@@ -218,6 +195,8 @@ loading_error=Masalah berlaku semasa menuatkan sebuah PDF.
 invalid_file_error=Tidak sah atau fail PDF rosak.
 missing_file_error=Fail PDF Hilang.
 unexpected_response_error=Respon pelayan yang tidak dijangka.
+
+rendering_error=Ralat berlaku ketika memberikan halaman.
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/my/viewer.properties
+++ b/l10n/my/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=ဖိုင်အားဖွင့်ပါ။
 open_file_label=ဖွင့်ပါ
 print.title=ပုံနှိုပ်ပါ
 print_label=ပုံနှိုပ်ပါ
-download.title=ကူးဆွဲ
-download_label=ကူးဆွဲ
-bookmark.title=လက်ရှိ မြင်ကွင်း (ဝင်းဒိုးအသစ်မှာ ကူးပါ သို့မဟုတ် ဖွင့်ပါ)
-bookmark_label=လက်ရှိ မြင်ကွင်း
 
 # Secondary toolbar and context menu
 tools.title=ကိရိယာများ
@@ -142,25 +138,6 @@ find_reached_bottom=စာမျက်နှာအဆုံး ရောက်�
 # "{{limit}}" will be replaced by a numerical value.
 find_not_found=စကားစု မတွေ့ရဘူး
 
-# Error panel labels
-error_more_info=နောက်ထပ်အချက်အလက်များ
-error_less_info=အနည်းငယ်မျှသော သတင်းအချက်အလက်
-error_close=ပိတ်
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=မက်ဆေ့ - {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=အထပ် - {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=ဖိုင် {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=လိုင်း - {{line}}
-rendering_error=စာမျက်နှာကို ပုံဖော်နေချိန်မှာ အမှားတစ်ခုတွေ့ရပါတယ်။
-
 # Predefined zoom values
 page_scale_width=စာမျက်နှာ အကျယ်
 page_scale_fit=စာမျက်နှာ ကွက်တိ
@@ -174,6 +151,8 @@ loading_error=PDF ဖိုင် ကိုဆွဲတင်နေချိန�
 invalid_file_error=မရသော သို့ ပျက်နေသော PDF ဖိုင်
 missing_file_error=PDF ပျောက်ဆုံး
 unexpected_response_error=မမျှော်လင့်ထားသော ဆာဗာမှ ပြန်ကြားချက်
+
+rendering_error=စာမျက်နှာကို ပုံဖော်နေချိန်မှာ အမှားတစ်ခုတွေ့ရပါတယ်။
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/nb-NO/viewer.properties
+++ b/l10n/nb-NO/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Åpne fil
 open_file_label=Åpne
 print.title=Skriv ut
 print_label=Skriv ut
-download.title=Last ned
-download_label=Last ned
-bookmark.title=Nåværende visning (kopier eller åpne i et nytt vindu)
-bookmark_label=Nåværende visning
 
 save.title=Lagre
 save_label=Lagre
@@ -207,24 +203,6 @@ find_match_count_limit[many]=Mer enn {{limit}} treff
 find_match_count_limit[other]=Mer enn {{limit}} treff
 find_not_found=Fant ikke teksten
 
-# Error panel labels
-error_more_info=Mer info
-error_less_info=Mindre info
-error_close=Lukk
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (bygg: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Melding: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stakk: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Fil: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Linje: {{line}}
-
 # Predefined zoom values
 page_scale_width=Sidebredde
 page_scale_fit=Tilpass til siden
@@ -233,9 +211,6 @@ page_scale_actual=Virkelig størrelse
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}} %
-
-# Loading indicator messages
-loading=Laster…
 
 # Loading indicator messages
 loading_error=En feil oppstod ved lasting av PDF.

--- a/l10n/ne-NP/viewer.properties
+++ b/l10n/ne-NP/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=फाइल खोल्नुहोस्
 open_file_label=खोल्नुहोस्
 print.title=मुद्रण गर्नुहोस्
 print_label=मुद्रण गर्नुहोस्
-download.title=डाउनलोडहरू
-download_label=डाउनलोडहरू
-bookmark.title=वर्तमान दृश्य (प्रतिलिपि गर्नुहोस् वा नयाँ सञ्झ्यालमा खुल्नुहोस्)
-bookmark_label=हालको दृश्य
 
 # Secondary toolbar and context menu
 tools.title=औजारहरू
@@ -165,25 +161,6 @@ find_reached_bottom=पृष्ठको अन्त्यमा पुगी�
 # "{{limit}}" will be replaced by a numerical value.
 find_not_found=वाक्यांश फेला परेन
 
-# Error panel labels
-error_more_info=थप जानकारी
-error_less_info=कम जानकारी
-error_close=बन्द गर्नुहोस्
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=सन्देश: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=स्ट्याक: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=फाइल: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=लाइन: {{line}}
-rendering_error=पृष्ठ प्रतिपादन गर्दा एउटा त्रुटि देखापर्‍यो।
-
 # Predefined zoom values
 page_scale_width=पृष्ठ चौडाइ
 page_scale_fit=पृष्ठ ठिक्क मिल्ने
@@ -201,6 +178,8 @@ unexpected_response_error=अप्रत्याशित सर्भर प�
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.
+
+rendering_error=पृष्ठ प्रतिपादन गर्दा एउटा त्रुटि देखापर्‍यो।
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/nl/viewer.properties
+++ b/l10n/nl/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Bestand openen
 open_file_label=Openen
 print.title=Afdrukken
 print_label=Afdrukken
-download.title=Downloaden
-download_label=Downloaden
-bookmark.title=Huidige weergave (kopiëren of openen in nieuw venster)
-bookmark_label=Huidige weergave
 
 save.title=Opslaan
 save_label=Opslaan
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Meer dan {{limit}} overeenkomsten
 find_match_count_limit[other]=Meer dan {{limit}} overeenkomsten
 find_not_found=Tekst niet gevonden
 
-# Error panel labels
-error_more_info=Meer informatie
-error_less_info=Minder informatie
-error_close=Sluiten
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Bericht: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Bestand: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Regel: {{line}}
-
 # Predefined zoom values
 page_scale_width=Paginabreedte
 page_scale_fit=Hele pagina
@@ -231,9 +209,6 @@ page_scale_actual=Werkelijke grootte
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Laden…
 
 # Loading indicator messages
 loading_error=Er is een fout opgetreden bij het laden van de PDF.

--- a/l10n/nn-NO/viewer.properties
+++ b/l10n/nn-NO/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Opne fil
 open_file_label=Opne
 print.title=Skriv ut
 print_label=Skriv ut
-download.title=Last ned
-download_label=Last ned
-bookmark.title=Gjeldande vising (kopier eller opne i nytt vindauge)
-bookmark_label=Gjeldande vising
 
 save.title=Lagre
 save_label=Lagre
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Meir enn {{limit}} treff
 find_match_count_limit[other]=Meir enn {{limit}} treff
 find_not_found=Fann ikkje teksten
 
-# Error panel labels
-error_more_info=Meir info
-error_less_info=Mindre info
-error_close=Lat att
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (bygg: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Melding: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stakk: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Fil: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Linje: {{line}}
-
 # Predefined zoom values
 page_scale_width=Sidebreidde
 page_scale_fit=Tilpass til sida
@@ -231,9 +209,6 @@ page_scale_actual=Verkeleg storleik
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Lastar…
 
 # Loading indicator messages
 loading_error=Ein feil oppstod ved lasting av PDF.

--- a/l10n/oc/viewer.properties
+++ b/l10n/oc/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Dobrir lo fichièr
 open_file_label=Dobrir
 print.title=Imprimir
 print_label=Imprimir
-download.title=Telecargar
-download_label=Telecargar
-bookmark.title=Afichatge corrent (copiar o dobrir dins una fenèstra novèla)
-bookmark_label=Afichatge actual
 
 save.title=Enregistrar
 save_label=Enregistrar
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Mai de {{limit}} ocuréncias
 find_match_count_limit[other]=Mai de {{limit}} ocuréncias
 find_not_found=Frasa pas trobada
 
-# Error panel labels
-error_more_info=Mai de detalhs
-error_less_info=Mens d'informacions
-error_close=Tampar
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (identificant de compilacion : {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Messatge : {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Pila : {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Fichièr : {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Linha : {{line}}
-
 # Predefined zoom values
 page_scale_width=Largor plena
 page_scale_fit=Pagina entièra
@@ -231,9 +209,6 @@ page_scale_actual=Talha vertadièra
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Cargament…
 
 # Loading indicator messages
 loading_error=Una error s'es producha pendent lo cargament del fichièr PDF.

--- a/l10n/pa-IN/viewer.properties
+++ b/l10n/pa-IN/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=ਫਾਈਲ ਨੂੰ ਖੋਲ੍ਹੋ
 open_file_label=ਖੋਲ੍ਹੋ
 print.title=ਪਰਿੰਟ
 print_label=ਪਰਿੰਟ
-download.title=ਡਾਊਨਲੋਡ
-download_label=ਡਾਊਨਲੋਡ
-bookmark.title=ਮੌਜੂਦਾ ਝਲਕ (ਨਵੀਂ ਵਿੰਡੋ ਵਿੱਚ ਕਾਪੀ ਕਰੋ ਜਾਂ ਖੋਲ੍ਹੋ)
-bookmark_label=ਮੌਜੂਦਾ ਝਲਕ
 
 save.title=ਸੰਭਾਲੋ
 save_label=ਸੰਭਾਲੋ
@@ -205,24 +201,6 @@ find_match_count_limit[many]={{limit}} ਮੇਲਾਂ ਤੋਂ ਵੱਧ
 find_match_count_limit[other]={{limit}} ਮੇਲਾਂ ਤੋਂ ਵੱਧ
 find_not_found=ਵਾਕ ਨਹੀਂ ਲੱਭਿਆ
 
-# Error panel labels
-error_more_info=ਹੋਰ ਜਾਣਕਾਰੀ
-error_less_info=ਘੱਟ ਜਾਣਕਾਰੀ
-error_close=ਬੰਦ ਕਰੋ
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (ਬਿਲਡ: {{build}}
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=ਸੁਨੇਹਾ: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=ਸਟੈਕ: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=ਫਾਈਲ: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=ਲਾਈਨ: {{line}}
-
 # Predefined zoom values
 page_scale_width=ਸਫ਼ੇ ਦੀ ਚੌੜਾਈ
 page_scale_fit=ਸਫ਼ਾ ਫਿੱਟ
@@ -231,9 +209,6 @@ page_scale_actual=ਆਟੋਮੈਟਿਕ ਆਕਾਰ
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=…ਲੋਡ ਹੋ ਰਿਹਾ ਹੈ
 
 # Loading indicator messages
 loading_error=PDF ਲੋਡ ਕਰਨ ਦੇ ਦੌਰਾਨ ਗਲਤੀ ਆਈ ਹੈ।

--- a/l10n/pl/viewer.properties
+++ b/l10n/pl/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Otwórz plik
 open_file_label=Otwórz
 print.title=Drukuj
 print_label=Drukuj
-download.title=Pobierz
-download_label=Pobierz
-bookmark.title=Bieżąca pozycja (skopiuj lub otwórz jako odnośnik w nowym oknie)
-bookmark_label=Bieżąca pozycja
 
 save.title=Zapisz
 save_label=Zapisz
@@ -207,24 +203,6 @@ find_match_count_limit[many]=Więcej niż {{limit}} trafień.
 find_match_count_limit[other]=Więcej niż {{limit}} trafień.
 find_not_found=Nie znaleziono tekstu
 
-# Error panel labels
-error_more_info=Więcej informacji
-error_less_info=Mniej informacji
-error_close=Zamknij
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (kompilacja: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Komunikat: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stos: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Plik: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Wiersz: {{line}}
-
 # Predefined zoom values
 page_scale_width=Szerokość strony
 page_scale_fit=Dopasowanie strony
@@ -233,9 +211,6 @@ page_scale_actual=Rozmiar oryginalny
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Wczytywanie…
 
 # Loading indicator messages
 loading_error=Podczas wczytywania dokumentu PDF wystąpił błąd.

--- a/l10n/pt-BR/viewer.properties
+++ b/l10n/pt-BR/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Abrir arquivo
 open_file_label=Abrir
 print.title=Imprimir
 print_label=Imprimir
-download.title=Baixar
-download_label=Baixar
-bookmark.title=Visão atual (copiar ou abrir em nova janela)
-bookmark_label=Exibição atual
 
 save.title=Salvar
 save_label=Salvar
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Mais de {{limit}} ocorrências
 find_match_count_limit[other]=Mais de {{limit}} ocorrências
 find_not_found=Frase não encontrada
 
-# Error panel labels
-error_more_info=Mais informações
-error_less_info=Menos informações
-error_close=Fechar
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (compilação: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Mensagem: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Pilha: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Arquivo: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Linha: {{line}}
-
 # Predefined zoom values
 page_scale_width=Largura da página
 page_scale_fit=Ajustar à janela
@@ -231,9 +209,6 @@ page_scale_actual=Tamanho real
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Carregando…
 
 # Loading indicator messages
 loading_error=Ocorreu um erro ao carregar o PDF.

--- a/l10n/pt-PT/viewer.properties
+++ b/l10n/pt-PT/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Abrir ficheiro
 open_file_label=Abrir
 print.title=Imprimir
 print_label=Imprimir
-download.title=Transferir
-download_label=Transferir
-bookmark.title=Vista atual (copiar ou abrir numa nova janela)
-bookmark_label=Visão atual
 
 save.title=Guardar
 save_label=Guardar
@@ -207,24 +203,6 @@ find_match_count_limit[many]=Mais de {{limit}} correspondências
 find_match_count_limit[other]=Mais de {{limit}} correspondências
 find_not_found=Frase não encontrada
 
-# Error panel labels
-error_more_info=Mais informação
-error_less_info=Menos informação
-error_close=Fechar
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (compilação: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Mensagem: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Ficheiro: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Linha: {{line}}
-
 # Predefined zoom values
 page_scale_width=Ajustar à largura
 page_scale_fit=Ajustar à página
@@ -233,9 +211,6 @@ page_scale_actual=Tamanho real
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=A carregar…
 
 # Loading indicator messages
 loading_error=Ocorreu um erro ao carregar o PDF.

--- a/l10n/rm/viewer.properties
+++ b/l10n/rm/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Avrir datoteca
 open_file_label=Avrir
 print.title=Stampar
 print_label=Stampar
-download.title=Telechargiar
-download_label=Telechargiar
-bookmark.title=Vista actuala (copiar u avrir en ina nova fanestra)
-bookmark_label=Vista actuala
 
 save.title=Memorisar
 save_label=Memorisar
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Dapli che {{limit}} correspundenzas
 find_match_count_limit[other]=Dapli che {{limit}} correspundenzas
 find_not_found=Impussibel da chattar l'expressiun
 
-# Error panel labels
-error_more_info=Dapli infurmaziuns
-error_less_info=Damain infurmaziuns
-error_close=Serrar
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Messadi: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Datoteca: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Lingia: {{line}}
-
 # Predefined zoom values
 page_scale_width=Ladezza da la pagina
 page_scale_fit=Entira pagina
@@ -231,9 +209,6 @@ page_scale_actual=Grondezza actuala
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Chargiar…
 
 # Loading indicator messages
 loading_error=Ina errur è cumparida cun chargiar il PDF.

--- a/l10n/ro/viewer.properties
+++ b/l10n/ro/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Deschide un fișier
 open_file_label=Deschide
 print.title=Tipărește
 print_label=Tipărește
-download.title=Descarcă
-download_label=Descarcă
-bookmark.title=Vizualizare actuală (copiază sau deschide într-o fereastră nouă)
-bookmark_label=Vizualizare actuală
 
 # Secondary toolbar and context menu
 tools.title=Instrumente
@@ -187,25 +183,6 @@ find_match_count_limit[many]=Peste {{limit}} de rezultate
 find_match_count_limit[other]=Peste {{limit}} de rezultate
 find_not_found=Nu s-a găsit textul
 
-# Error panel labels
-error_more_info=Mai multe informații
-error_less_info=Mai puține informații
-error_close=Închide
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (versiunea compilată: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Mesaj: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stivă: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Fișier: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Rând: {{line}}
-rendering_error=A intervenit o eroare la randarea paginii.
-
 # Predefined zoom values
 page_scale_width=Lățime pagină
 page_scale_fit=Potrivire la pagină
@@ -220,6 +197,8 @@ loading_error=A intervenit o eroare la încărcarea PDF-ului.
 invalid_file_error=Fișier PDF nevalid sau corupt.
 missing_file_error=Fișier PDF lipsă.
 unexpected_response_error=Răspuns neașteptat de la server.
+
+rendering_error=A intervenit o eroare la randarea paginii.
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.

--- a/l10n/ru/viewer.properties
+++ b/l10n/ru/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Открыть файл
 open_file_label=Открыть
 print.title=Печать
 print_label=Печать
-download.title=Загрузить
-download_label=Загрузить
-bookmark.title=Ссылка на текущий вид (скопировать или открыть в новом окне)
-bookmark_label=Текущий вид
 
 save.title=Сохранить
 save_label=Сохранить
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Более {{limit}} совпадений
 find_match_count_limit[other]=Более {{limit}} совпадений
 find_not_found=Фраза не найдена
 
-# Error panel labels
-error_more_info=Детали
-error_less_info=Скрыть детали
-error_close=Закрыть
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (сборка: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Сообщение: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Стeк: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Файл: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Строка: {{line}}
-
 # Predefined zoom values
 page_scale_width=По ширине страницы
 page_scale_fit=По размеру страницы
@@ -231,9 +209,6 @@ page_scale_actual=Реальный размер
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Загрузка…
 
 # Loading indicator messages
 loading_error=При загрузке PDF произошла ошибка.

--- a/l10n/sat/viewer.properties
+++ b/l10n/sat/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=ᱨᱮᱫ ᱡᱷᱤᱡᱽ ᱢᱮ
 open_file_label=ᱡᱷᱤᱡᱽ ᱢᱮ
 print.title=ᱪᱷᱟᱯᱟ
 print_label=ᱪᱷᱟᱯᱟ
-download.title=ᱰᱟᱩᱱᱞᱚᱰ
-download_label=ᱰᱟᱩᱱᱞᱚᱰ
-bookmark.title=ᱱᱤᱛᱚᱜᱟᱜ ᱧᱮᱞ (ᱱᱚᱶᱟ ᱡᱷᱚᱨᱠᱟ ᱨᱮ ᱱᱚᱠᱚᱞ ᱟᱨ ᱵᱟᱝ ᱡᱷᱤᱡᱽ ᱢᱮ )
-bookmark_label=ᱱᱤᱛᱚᱜᱟᱜ ᱧᱮᱞ
 
 save.title=ᱥᱟᱺᱪᱟᱣ ᱢᱮ
 save_label=ᱥᱟᱺᱪᱟᱣ ᱢᱮ
@@ -206,24 +202,6 @@ find_match_count_limit[many]={{limit}} ᱡᱚᱲ ᱠᱚ ᱠᱷᱚᱱ ᱰᱷᱮ�
 find_match_count_limit[other]={{limit}} ᱡᱚᱲ ᱠᱚ ᱠᱷᱚᱱ ᱰᱷᱮᱨ
 find_not_found=ᱛᱚᱯᱚᱞ ᱫᱚᱱᱚᱲ ᱵᱟᱝ ᱧᱟᱢ ᱞᱮᱱᱟ
 
-# Error panel labels
-error_more_info=ᱵᱟᱹᱲᱛᱤ ᱞᱟᱹᱭ ᱥᱚᱫᱚᱨ
-error_less_info=ᱠᱚᱢ ᱞᱟᱹᱭ ᱥᱚᱫᱚᱨ
-error_close=ᱵᱚᱸᱫᱚᱭ ᱢᱮ
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=ᱠᱷᱚᱵᱚᱨ : {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=ᱵᱟᱝ : {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=ᱨᱮᱫᱽ : {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=ᱜᱟᱨ : {{line}}
-
 # Predefined zoom values
 page_scale_width=ᱥᱟᱦᱴᱟ ᱚᱥᱟᱨ
 page_scale_fit=ᱥᱟᱦᱴᱟ ᱠᱷᱟᱯ
@@ -232,9 +210,6 @@ page_scale_actual=ᱴᱷᱤᱠ ᱢᱟᱨᱟᱝ ᱛᱮᱫ
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=ᱞᱟᱫᱮᱜ ᱠᱟᱱᱟ …
 
 # Loading indicator messages
 loading_error=PDF ᱞᱟᱫᱮ ᱡᱚᱦᱚᱜ ᱢᱤᱫ ᱵᱷᱩᱞ ᱦᱩᱭ ᱮᱱᱟ ᱾

--- a/l10n/sc/viewer.properties
+++ b/l10n/sc/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Aberi s'archìviu
 open_file_label=Abertu
 print.title=Imprenta
 print_label=Imprenta
-download.title=Iscàrriga
-download_label=Iscàrriga
-bookmark.title=Visualizatzione atuale (còpia o aberi in una ventana noa)
-bookmark_label=Visualizatzione atuale
 
 save.title=Sarva
 save_label=Sarva
@@ -194,32 +190,12 @@ find_match_count_limit[many]=Prus de {{limit}} currispondèntzias
 find_match_count_limit[other]=Prus de {{limit}} currispondèntzias
 find_not_found=Testu no agatadu
 
-# Error panel labels
-error_more_info=Àteras informatziones
-error_less_info=Prus pagu informatziones
-error_close=Serra
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Messàgiu: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Archìviu: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Lìnia: {{line}}
-
 # Predefined zoom values
 page_scale_auto=Ingrandimentu automàticu
 page_scale_actual=Mannària reale
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Carrighende…
 
 # Loading indicator messages
 loading_error=Faddina in sa càrriga de su PDF.

--- a/l10n/sco/viewer.properties
+++ b/l10n/sco/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Open File
 open_file_label=Open
 print.title=Prent
 print_label=Prent
-download.title=Doonload
-download_label=Doonload
-bookmark.title=View the noo (copy or open in new windae)
-bookmark_label=View The Noo
 
 # Secondary toolbar and context menu
 tools.title=Tools
@@ -194,25 +190,6 @@ find_match_count_limit[many]=Mair nor {{limit}} matches
 find_match_count_limit[other]=Mair nor {{limit}} matches
 find_not_found=Phrase no fund
 
-# Error panel labels
-error_more_info=Mair Information
-error_less_info=Less Information
-error_close=Sneck
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Message: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=File: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Line: {{line}}
-rendering_error=A mishanter tuik place while renderin the page.
-
 # Predefined zoom values
 page_scale_width=Page Width
 page_scale_fit=Page Fit
@@ -222,12 +199,12 @@ page_scale_actual=Actual Size
 # numerical scale value.
 page_scale_percent={{scale}}%
 
-# Loading indicator messages
-loading=Loadin…
 loading_error=An mishanter tuik place while loadin the PDF.
 invalid_file_error=No suithfest or camshauchlet PDF file.
 missing_file_error=PDF file tint.
 unexpected_response_error=Unexpectit server repone.
+
+rendering_error=A mishanter tuik place while renderin the page.
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.

--- a/l10n/si/viewer.properties
+++ b/l10n/si/viewer.properties
@@ -37,10 +37,14 @@ open_file.title=ගොනුව අරින්න
 open_file_label=අරින්න
 print.title=මුද්‍රණය
 print_label=මුද්‍රණය
-download.title=බාගන්න
-download_label=බාගන්න
-bookmark.title=වත්මන් දැක්ම (පිටපත් කරන්න හෝ නව කවුළුවක අරින්න)
-bookmark_label=වත්මන් දැක්ම
+
+save.title=සුරකින්න
+save_label=සුරකින්න
+bookmark1_label=පවතින පිටුව
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=යෙදුමෙහි අරින්න
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=යෙදුමෙහි අරින්න
 
 # Secondary toolbar and context menu
 tools.title=මෙවලම්
@@ -165,23 +169,6 @@ find_match_count_limit[many]=ගැළපුම් {{limit}} කට වඩා
 find_match_count_limit[other]=ගැළපුම් {{limit}} කට වඩා
 find_not_found=වැකිකඩ හමු නොවිණි
 
-# Error panel labels
-error_more_info=තව තොරතුරු
-error_less_info=අවම තොරතුරු
-error_close=වසන්න
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=පීඩීඑෆ්.js v{{version}} (තැනීම: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=පණිවිඩය: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=ගොනුව: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=පේළිය: {{line}}
-
 # Predefined zoom values
 page_scale_width=පිටුවේ පළල
 page_scale_auto=ස්වයංක්‍රීය විශාලනය
@@ -191,11 +178,11 @@ page_scale_actual=සැබෑ ප්‍රමාණය
 page_scale_percent={{scale}}%
 
 # Loading indicator messages
-loading=පූරණය වෙමින්…
 loading_error=පීඩීඑෆ් පූරණය කිරීමේදී දෝෂයක් සිදු විය.
 invalid_file_error=වලංගු නොවන හෝ හානිවූ පීඩීඑෆ් ගොනුවකි.
 missing_file_error=මඟහැරුණු පීඩීඑෆ් ගොනුවකි.
 unexpected_response_error=අනපේක්‍ෂිත සේවාදායක ප්‍රතිචාරයකි.
+
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.
@@ -215,11 +202,6 @@ printing_not_ready=අවවාදයයි: මුද්‍රණයට පී�
 web_fonts_disabled=වියමන අකුරු අබලයි: පීඩීඑෆ් වෙත කාවැද්දූ අකුරු භාවිතා කළ නොහැකිය.
 
 # Editor
-editor_none_label=සංස්කරණය අබල කරන්න
-
-free_text_default_content=පෙළ යොදන්න…
-
-# Editor
 editor_free_text2.title=පෙළ
 editor_free_text2_label=පෙළ
 
@@ -229,9 +211,6 @@ editor_free_text_color=වර්ණය
 editor_free_text_size=තරම
 editor_ink_color=වර්ණය
 editor_ink_thickness=ඝණකම
-
-# Editor aria
-editor_free_text_aria_label=FreeText සංස්කරකය
 
 # Editor aria
 editor_free_text2_aria_label=වදන් සකසනය

--- a/l10n/sk/viewer.properties
+++ b/l10n/sk/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Otvoriť súbor
 open_file_label=Otvoriť
 print.title=Tlačiť
 print_label=Tlačiť
-download.title=Stiahnuť
-download_label=Stiahnuť
-bookmark.title=Aktuálne zobrazenie (kopírovať alebo otvoriť v novom okne)
-bookmark_label=Aktuálne zobrazenie
 
 save.title=Uložiť
 save_label=Uložiť
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Viac než {{limit}} výsledkov
 find_match_count_limit[other]=Viac než {{limit}} výsledkov
 find_not_found=Výraz nebol nájdený
 
-# Error panel labels
-error_more_info=Ďalšie informácie
-error_less_info=Menej informácií
-error_close=Zavrieť
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (zostavenie: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Správa: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Zásobník: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Súbor: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Riadok: {{line}}
-
 # Predefined zoom values
 page_scale_width=Na šírku strany
 page_scale_fit=Na veľkosť strany
@@ -231,9 +209,6 @@ page_scale_actual=Skutočná veľkosť
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}} %
-
-# Loading indicator messages
-loading=Načítava sa…
 
 # Loading indicator messages
 loading_error=Počas načítavania dokumentu PDF sa vyskytla chyba.

--- a/l10n/skr/viewer.properties
+++ b/l10n/skr/viewer.properties
@@ -38,12 +38,7 @@ presentation_mode_label=پریزنٹیشن موڈ
 open_file.title=فائل کھولو
 open_file_label=کھولو
 print.title=چھاپو
-print_label=چھاپو
-download.title=ڈاؤن لوڈ 
-download_label=ڈاؤن لوڈ
-bookmark.title=حالیہ نظارہ (نویں ونڈو وِچ نقل کرو یا کھولو)
-bookmark_label=حالیہ نظارہ
-
+print_label=چھاپو 
 save.title=ہتھیکڑا کرو
 save_label=ہتھیکڑا کرو
 bookmark1.title=موجودہ ورقہ (موجودہ ورقے کنوں یوآرایل ݙیکھو)
@@ -205,24 +200,6 @@ find_match_count_limit[many]={{limit}}  مماثلاں کنوں ودھ
 find_match_count_limit[other]={{limit}}  مماثلاں کنوں ودھ
 find_not_found=فقرہ نئیں ملیا
 
-# Error panel labels
-error_more_info=ودھیک معلومات
-error_less_info=گھٹ معلومات
-error_close=بند کرو
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (بݨاؤ: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=سنیہا: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=سٹیک: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=فائل: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=لائن: {{line}}
-
 # Predefined zoom values
 page_scale_width=ورقے دی چوڑائی
 page_scale_fit=ورقہ فٹنگ
@@ -231,9 +208,6 @@ page_scale_actual=اصل میچا
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=لوڈ تھیندا پئے۔۔۔
 
 # Loading indicator messages
 loading_error=PDF لوڈ کریندے ویلھے نقص آ ڳیا۔

--- a/l10n/sl/viewer.properties
+++ b/l10n/sl/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Odpri datoteko
 open_file_label=Odpri
 print.title=Natisni
 print_label=Natisni
-download.title=Prenesi
-download_label=Prenesi
-bookmark.title=Trenutni pogled (kopiraj ali odpri v novem oknu)
-bookmark_label=Trenutni pogled
 
 save.title=Shrani
 save_label=Shrani
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Več kot {{limit}} zadetkov
 find_match_count_limit[other]=Več kot {{limit}} zadetkov
 find_not_found=Iskanega ni mogoče najti
 
-# Error panel labels
-error_more_info=Več informacij
-error_less_info=Manj informacij
-error_close=Zapri
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js r{{version}} (graditev: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Sporočilo: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Sklad: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Datoteka: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Vrstica: {{line}}
-
 # Predefined zoom values
 page_scale_width=Širina strani
 page_scale_fit=Prilagodi stran
@@ -231,9 +209,6 @@ page_scale_actual=Dejanska velikost
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}} %
-
-# Loading indicator messages
-loading=Nalaganje …
 
 # Loading indicator messages
 loading_error=Med nalaganjem datoteke PDF je prišlo do napake.

--- a/l10n/son/viewer.properties
+++ b/l10n/son/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Tuku feeri
 open_file_label=Feeri
 print.title=Kar
 print_label=Kar
-download.title=Zumandi
-download_label=Zumandi
-bookmark.title=Sohõ gunarro (bere wala feeri zanfun taaga ra)
-bookmark_label=Sohõ gunaroo
 
 # Secondary toolbar and context menu
 tools.title=Goyjinawey
@@ -124,25 +120,6 @@ find_reached_top=A too moŋoo boŋoo, koy jine ka šinitin nda cewoo
 find_reached_bottom=A too moɲoo cewoo, koy jine šintioo ga
 find_not_found=Kalimaɲaa mana duwandi
 
-# Error panel labels
-error_more_info=Alhabar tontoni
-error_less_info=Alhabar tontoni
-error_close=Daabu
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Alhabar: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Dekeri: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Tuku: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Žeeri: {{line}}
-rendering_error=Firka bangay kaŋ moɲoo goo ma willandi.
-
 # Predefined zoom values
 page_scale_width=Mooo hayyan
 page_scale_fit=Moo sawayan
@@ -156,6 +133,8 @@ loading_error=Firka bangay kaŋ PDF goo ma zumandi.
 invalid_file_error=PDF tuku laala wala laybante.
 missing_file_error=PDF tuku kumante.
 unexpected_response_error=Manti feršikaw tuuruyan maatante.
+
+rendering_error=Firka bangay kaŋ moɲoo goo ma willandi.
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/sq/viewer.properties
+++ b/l10n/sq/viewer.properties
@@ -39,12 +39,8 @@ open_file.title=Hapni Kartelë
 open_file_label=Hape
 print.title=Shtypje
 print_label=Shtype
-download.title=Shkarkim
-download_label=Shkarkoje
 save.title=Ruaje
 save_label=Ruaje
-bookmark.title=Pamja e tanishme (kopjojeni ose hapeni në dritare të re)
-bookmark_label=Pamja e Tanishme
 
 bookmark1.title=Faqja e Tanishme (Shihni URL nga Faqja e Tanishme)
 bookmark1_label=Faqja e Tanishme
@@ -196,24 +192,6 @@ find_match_count_limit[many]=Më shumë se {{limit}} përputhje
 find_match_count_limit[other]=Më shumë se {{limit}} përputhje
 find_not_found=Togfjalësh që s’gjendet
 
-# Error panel labels
-error_more_info=Më Tepër Hollësi
-error_less_info=Më Pak të Dhëna
-error_close=Mbylleni
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Mesazh: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Kartelë: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Rresht: {{line}}
-
 # Predefined zoom values
 page_scale_width=Gjerësi Faqeje
 page_scale_fit=Sa Nxë Faqja
@@ -223,8 +201,6 @@ page_scale_actual=Madhësia Faktike
 # numerical scale value.
 page_scale_percent={{scale}}%
 
-# Loading indicator messages
-loading=Po ngarkohet…
 loading_error=Ndodhi një gabim gjatë ngarkimit të PDF-së.
 invalid_file_error=Kartelë PDF e pavlefshme ose e dëmtuar.
 missing_file_error=Kartelë PDF që mungon.

--- a/l10n/sr/viewer.properties
+++ b/l10n/sr/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Отвори датотеку
 open_file_label=Отвори
 print.title=Штампај
 print_label=Штампај
-download.title=Преузми
-download_label=Преузми
-bookmark.title=Тренутни приказ (копирај или отвори у новом прозору)
-bookmark_label=Тренутни приказ
 
 save.title=Сачувај
 save_label=Сачувај
@@ -207,24 +203,6 @@ find_match_count_limit[many]=Више од {{limit}} одговара
 find_match_count_limit[other]=Више од {{limit}} одговара
 find_not_found=Фраза није пронађена
 
-# Error panel labels
-error_more_info=Више информација
-error_less_info=Мање информација
-error_close=Затвори
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Порука: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Стек: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Датотека: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Линија: {{line}}
-
 # Predefined zoom values
 page_scale_width=Ширина странице
 page_scale_fit=Прилагоди страницу
@@ -233,9 +211,6 @@ page_scale_actual=Стварна величина
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Учитавање…
 
 # Loading indicator messages
 loading_error=Дошло је до грешке приликом учитавања PDF-а.

--- a/l10n/sv-SE/viewer.properties
+++ b/l10n/sv-SE/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Öppna fil
 open_file_label=Öppna
 print.title=Skriv ut
 print_label=Skriv ut
-download.title=Hämta
-download_label=Hämta
-bookmark.title=Aktuell vy (kopiera eller öppna i nytt fönster)
-bookmark_label=Aktuell vy
 
 save.title=Spara
 save_label=Spara
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Mer än {{limit}} träffar
 find_match_count_limit[other]=Mer än {{limit}} träffar
 find_not_found=Frasen hittades inte
 
-# Error panel labels
-error_more_info=Mer information
-error_less_info=Mindre information
-error_close=Stäng
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Meddelande: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Fil: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Rad: {{line}}
-
 # Predefined zoom values
 page_scale_width=Sidbredd
 page_scale_fit=Anpassa sida
@@ -231,9 +209,6 @@ page_scale_actual=Verklig storlek
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Laddar…
 
 # Loading indicator messages
 loading_error=Ett fel uppstod vid laddning av PDF-filen.

--- a/l10n/szl/viewer.properties
+++ b/l10n/szl/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Ôdewrzij zbiōr
 open_file_label=Ôdewrzij
 print.title=Durkuj
 print_label=Durkuj
-download.title=Pobier
-download_label=Pobier
-bookmark.title=Aktualny widok (kopiuj abo ôdewrzij w nowym ôknie)
-bookmark_label=Aktualny widok
 
 # Secondary toolbar and context menu
 tools.title=Noczynia
@@ -191,25 +187,6 @@ find_match_count_limit[many]=Wiyncyj jak {{limit}}, co pasujōm
 find_match_count_limit[other]=Wiyncyj jak {{limit}}, co pasujōm
 find_not_found=Fraza niy znaleziōno
 
-# Error panel labels
-error_more_info=Wiyncyj informacyji
-error_less_info=Mynij informacyji
-error_close=Zawrzij
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Wiadōmość: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Sztapel: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Zbiōr: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Linijo: {{line}}
-rendering_error=Przi renderowaniu strōny pokozoł sie feler.
-
 # Predefined zoom values
 page_scale_width=Szyrzka strōny
 page_scale_fit=Napasowanie strōny
@@ -224,6 +201,8 @@ loading_error=Przi ladowaniu PDFa pokozoł sie feler.
 invalid_file_error=Zły abo felerny zbiōr PDF.
 missing_file_error=Chybio zbioru PDF.
 unexpected_response_error=Niyôczekowano ôdpowiydź serwera.
+
+rendering_error=Przi renderowaniu strōny pokozoł sie feler.
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.

--- a/l10n/ta/viewer.properties
+++ b/l10n/ta/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=கோப்பினை திற
 open_file_label=திற
 print.title=அச்சிடு
 print_label=அச்சிடு
-download.title=பதிவிறக்கு
-download_label=பதிவிறக்கு
-bookmark.title=தற்போதைய காட்சி (புதிய சாளரத்திற்கு நகலெடு அல்லது புதிய சாளரத்தில் திற)
-bookmark_label=தற்போதைய காட்சி
 
 # Secondary toolbar and context menu
 tools.title=கருவிகள்
@@ -145,25 +141,6 @@ find_reached_top=ஆவணத்தின் மேல் பகுதியை 
 find_reached_bottom=ஆவணத்தின் முடிவை அடைந்தது, மேலிருந்து தொடர்ந்தது
 find_not_found=சொற்றொடர் காணவில்லை
 
-# Error panel labels
-error_more_info=கூடுதல் தகவல்
-error_less_info=குறைந்த தகவல்
-error_close=மூடுக
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=செய்தி: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=ஸ்டேக்: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=கோப்பு: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=வரி: {{line}}
-rendering_error=இந்தப் பக்கத்தை காட்சிப்படுத்தும் போது ஒரு பிழை ஏற்பட்டது.
-
 # Predefined zoom values
 page_scale_width=பக்க அகலம்
 page_scale_fit=பக்கப் பொருத்தம்
@@ -177,6 +154,8 @@ loading_error=PDF ஐ ஏற்றும் போது ஒரு பிழை 
 invalid_file_error=செல்லுபடியாகாத அல்லது சிதைந்த PDF கோப்பு.
 missing_file_error=PDF கோப்பு காணவில்லை.
 unexpected_response_error=சேவகன் பதில் எதிர்பாரதது.
+
+rendering_error=இந்தப் பக்கத்தை காட்சிப்படுத்தும் போது ஒரு பிழை ஏற்பட்டது.
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/te/viewer.properties
+++ b/l10n/te/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=ఫైల్ తెరువు
 open_file_label=తెరువు
 print.title=ముద్రించు
 print_label=ముద్రించు
-download.title=దింపుకోళ్ళు
-download_label=దింపుకోళ్ళు
-bookmark.title=ప్రస్తుత దర్శనం (కాపీ చేయి లేదా కొత్త విండోలో తెరువు)
-bookmark_label=ప్రస్తుత దర్శనం
 
 # Secondary toolbar and context menu
 tools.title=పనిముట్లు
@@ -166,25 +162,6 @@ find_match_count={[ plural(total) ]}
 find_match_count_limit={[ plural(limit) ]}
 find_not_found=పదబంధం కనబడలేదు
 
-# Error panel labels
-error_more_info=మరింత సమాచారం
-error_less_info=తక్కువ సమాచారం
-error_close=మూసివేయి
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=సందేశం: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=స్టాక్: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=ఫైలు: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=వరుస: {{line}}
-rendering_error=పేజీను రెండర్ చేయుటలో ఒక దోషం ఎదురైంది.
-
 # Predefined zoom values
 page_scale_width=పేజీ వెడల్పు
 page_scale_fit=పేజీ అమర్పు
@@ -199,6 +176,8 @@ loading_error=PDF లోడవుచున్నప్పుడు ఒక దో
 invalid_file_error=చెల్లని లేదా పాడైన PDF ఫైలు.
 missing_file_error=దొరకని PDF ఫైలు.
 unexpected_response_error=అనుకోని సర్వర్ స్పందన.
+
+rendering_error=పేజీను రెండర్ చేయుటలో ఒక దోషం ఎదురైంది.
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.

--- a/l10n/tg/viewer.properties
+++ b/l10n/tg/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Кушодани файл
 open_file_label=Кушодан
 print.title=Чоп кардан
 print_label=Чоп кардан
-download.title=Боргирӣ кардан
-download_label=Боргирӣ кардан
-bookmark.title=Намуди ҷорӣ (нусха бардоштан ё кушодан дар равзанаи нав)
-bookmark_label=Намуди ҷорӣ
 
 save.title=Нигоҳ доштан
 save_label=Нигоҳ доштан
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Зиёда аз {{limit}} мувофиқат
 find_match_count_limit[other]=Зиёда аз {{limit}} мувофиқат
 find_not_found=Ибора ёфт нашуд
 
-# Error panel labels
-error_more_info=Маълумоти бештар
-error_less_info=Маълумоти камтар
-error_close=Пӯшидан
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (сохт: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Паём: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Даста: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Файл: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Сатр: {{line}}
-
 # Predefined zoom values
 page_scale_width=Аз рӯи паҳнои саҳифа
 page_scale_fit=Аз рӯи андозаи саҳифа
@@ -231,9 +209,6 @@ page_scale_actual=Андозаи воқеӣ
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Бор шуда истодааст…
 
 # Loading indicator messages
 loading_error=Ҳангоми боркунии «PDF» хато ба миён омад.

--- a/l10n/th/viewer.properties
+++ b/l10n/th/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=เปิดไฟล์
 open_file_label=เปิด
 print.title=พิมพ์
 print_label=พิมพ์
-download.title=ดาวน์โหลด
-download_label=ดาวน์โหลด
-bookmark.title=มุมมองปัจจุบัน (คัดลอกหรือเปิดในหน้าต่างใหม่)
-bookmark_label=มุมมองปัจจุบัน
 
 save.title=บันทึก
 save_label=บันทึก
@@ -207,24 +203,6 @@ find_match_count_limit[many]=มากกว่า {{limit}} ที่ตรง�
 find_match_count_limit[other]=มากกว่า {{limit}} ที่ตรงกัน
 find_not_found=ไม่พบวลี
 
-# Error panel labels
-error_more_info=ข้อมูลเพิ่มเติม
-error_less_info=ข้อมูลน้อยลง
-error_close=ปิด
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=ข้อความ: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=สแตก: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=ไฟล์: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=บรรทัด: {{line}}
-
 # Predefined zoom values
 page_scale_width=ความกว้างหน้า
 page_scale_fit=พอดีหน้า
@@ -233,9 +211,6 @@ page_scale_actual=ขนาดจริง
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=กำลังโหลด…
 
 # Loading indicator messages
 loading_error=เกิดข้อผิดพลาดขณะโหลด PDF

--- a/l10n/tl/viewer.properties
+++ b/l10n/tl/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Magbukas ng file
 open_file_label=Buksan
 print.title=i-Print
 print_label=i-Print
-download.title=i-Download
-download_label=i-Download
-bookmark.title=Kasalukuyang tingin (kopyahin o buksan sa bagong window)
-bookmark_label=Kasalukuyang tingin
 
 # Secondary toolbar and context menu
 tools.title=Mga Kagamitan
@@ -190,25 +186,6 @@ find_match_count_limit[many]=Higit sa {{limit}} tugma
 find_match_count_limit[other]=Higit sa {{limit}} tugma
 find_not_found=Hindi natagpuan ang parirala
 
-# Error panel labels
-error_more_info=Karagdagang Impormasyon
-error_less_info=Mas Kaunting Impormasyon
-error_close=Isara
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Mensahe: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=File: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Linya: {{line}}
-rendering_error=Nagkaproblema habang nirerender ang pahina.
-
 # Predefined zoom values
 page_scale_width=Lapad ng Pahina
 page_scale_fit=Pagkasyahin ang Pahina
@@ -222,6 +199,8 @@ loading_error=Nagkaproblema habang niloload ang PDF.
 invalid_file_error=Di-wasto o sira ang PDF file.
 missing_file_error=Nawawalang PDF file.
 unexpected_response_error=Hindi inaasahang tugon ng server.
+
+rendering_error=Nagkaproblema habang nirerender ang pahina.
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.

--- a/l10n/tr/viewer.properties
+++ b/l10n/tr/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Dosya aç
 open_file_label=Aç
 print.title=Yazdır
 print_label=Yazdır
-download.title=İndir
-download_label=İndir
-bookmark.title=Geçerli görünüm (kopyala veya yeni pencerede aç)
-bookmark_label=Geçerli görünüm
 
 save.title=Kaydet
 save_label=Kaydet
@@ -205,24 +201,6 @@ find_match_count_limit[many]={{limit}} eşleşmeden fazla
 find_match_count_limit[other]={{limit}} eşleşmeden fazla
 find_not_found=Eşleşme bulunamadı
 
-# Error panel labels
-error_more_info=Daha fazla bilgi al
-error_less_info=Daha az bilgi
-error_close=Kapat
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js sürüm {{version}} (yapı: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=İleti: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Yığın: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Dosya: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Satır: {{line}}
-
 # Predefined zoom values
 page_scale_width=Sayfa genişliği
 page_scale_fit=Sayfayı sığdır
@@ -231,9 +209,6 @@ page_scale_actual=Gerçek boyut
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent=%{{scale}}
-
-# Loading indicator messages
-loading=Yükleniyor…
 
 # Loading indicator messages
 loading_error=PDF yüklenirken bir hata oluştu.

--- a/l10n/trs/viewer.properties
+++ b/l10n/trs/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Na'nïn' chrû ñanj
 open_file_label=Na'nïn
 print.title=Nari' ña du'ua
 print_label=Nari' ñadu'ua
-download.title=Nadunïnj
-download_label=Nadunïnj
-bookmark.title=Daj hua ma (Guxun' nej na'nïn' riña ventana nakàa)
-bookmark_label=Daj hua ma
 
 # Secondary toolbar and context menu
 tools.title=Rasun
@@ -169,24 +165,6 @@ find_match_count_limit[few]=Doj ngà da' {{limit}} nej sa nari' dugui'i
 find_match_count_limit[many]=Doj ngà da' {{limit}} nej sa nari' dugui'i
 find_match_count_limit[other]=Doj ngà da' {{limit}} nej sa nari' dugui'i
 find_not_found=Nu narì'ij nugua'anj
-
-# Error panel labels
-error_more_info=Doj nuguan' a'min rayi'î nan
-error_less_info=Dòj nuguan' a'min rayi'î nan
-error_close=Narán
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Message: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Naru'ui': {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Archîbo: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Lînia: {{line}}
 
 # Predefined zoom values
 page_scale_actual=Dàj yàchi akuan' nín

--- a/l10n/uk/viewer.properties
+++ b/l10n/uk/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Відкрити файл
 open_file_label=Відкрити
 print.title=Друк
 print_label=Друк
-download.title=Завантажити
-download_label=Завантажити
-bookmark.title=Поточний вигляд (копіювати чи відкрити в новому вікні)
-bookmark_label=Поточний вигляд
 
 save.title=Зберегти
 save_label=Зберегти
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Понад {{limit}} збігів
 find_match_count_limit[other]=Понад {{limit}} збігів
 find_not_found=Фразу не знайдено
 
-# Error panel labels
-error_more_info=Більше інформації
-error_less_info=Менше інформації
-error_close=Закрити
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Повідомлення: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Стек: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Файл: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Рядок: {{line}}
-
 # Predefined zoom values
 page_scale_width=За шириною
 page_scale_fit=Вмістити
@@ -231,9 +209,6 @@ page_scale_actual=Дійсний розмір
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Завантаження…
 
 # Loading indicator messages
 loading_error=Під час завантаження PDF сталася помилка.

--- a/l10n/ur/viewer.properties
+++ b/l10n/ur/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=مسل کھولیں
 open_file_label=کھولیں
 print.title=چھاپیں
 print_label=چھاپیں
-download.title=ڈاؤن لوڈ
-download_label=ڈاؤن لوڈ
-bookmark.title=حالیہ نظارہ (نۓ دریچہ میں نقل کریں یا کھولیں)
-bookmark_label=حالیہ نظارہ
 
 # Secondary toolbar and context menu
 tools.title=آلات
@@ -183,25 +179,6 @@ find_match_count_limit[many]={{limit}} سے زیادہ میچ
 find_match_count_limit[other]={{limit}} سے زیادہ میچ
 find_not_found=فقرا نہیں ملا
 
-# Error panel labels
-error_more_info=مزید معلومات
-error_less_info=کم معلومات
-error_close=بند کریں
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=پیغام: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=سٹیک: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=مسل: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=لائن: {{line}}
-rendering_error=صفحہ بناتے ہوئے نقص آ گیا۔
-
 # Predefined zoom values
 page_scale_width=صفحہ چوڑائی
 page_scale_fit=صفحہ فٹنگ
@@ -216,6 +193,8 @@ loading_error=PDF لوڈ کرتے وقت نقص آ گیا۔
 invalid_file_error=ناجائز یا خراب PDF مسل
 missing_file_error=PDF مسل غائب ہے۔
 unexpected_response_error=غیرمتوقع پیش کار جواب
+
+rendering_error=صفحہ بناتے ہوئے نقص آ گیا۔
 
 # LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
 # replaced by the modification date, and time, of the annotation.

--- a/l10n/uz/viewer.properties
+++ b/l10n/uz/viewer.properties
@@ -37,10 +37,6 @@ open_file.title=Faylni ochish
 open_file_label=Ochish
 print.title=Chop qilish
 print_label=Chop qilish
-download.title=Yuklab olish
-download_label=Yuklab olish
-bookmark.title=Joriy koʻrinish (nusxa oling yoki yangi oynada oching)
-bookmark_label=Joriy koʻrinish
 
 # Secondary toolbar and context menu
 tools.title=Vositalar
@@ -115,25 +111,6 @@ find_reached_top=Hujjatning boshigacha yetib keldik, pastdan davom ettiriladi
 find_reached_bottom=Hujjatning oxiriga yetib kelindi, yuqoridan davom ettirladi
 find_not_found=Soʻzlar topilmadi
 
-# Error panel labels
-error_more_info=Koʻproq ma`lumot
-error_less_info=Kamroq ma`lumot
-error_close=Yopish
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Xabar: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Toʻplam: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Fayl: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Satr: {{line}}
-rendering_error=Sahifa renderlanayotganda xato yuz berdi.
-
 # Predefined zoom values
 page_scale_width=Sahifa eni
 page_scale_fit=Sahifani moslashtirish
@@ -147,6 +124,8 @@ loading_error=PDF yuklanayotganda xato yuz berdi.
 invalid_file_error=Xato yoki buzuq PDF fayli.
 missing_file_error=PDF fayl kerak.
 unexpected_response_error=Kutilmagan server javobi.
+
+rendering_error=Sahifa renderlanayotganda xato yuz berdi.
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/vi/viewer.properties
+++ b/l10n/vi/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Mở tập tin
 open_file_label=Mở tập tin
 print.title=In
 print_label=In
-download.title=Tải xuống
-download_label=Tải xuống
-bookmark.title=Chế độ xem hiện tại (sao chép hoặc mở trong cửa sổ mới)
-bookmark_label=Chế độ xem hiện tại
 
 save.title=Lưu
 save_label=Lưu
@@ -205,24 +201,6 @@ find_match_count_limit[many]=Nhiều hơn {{limit}} đã trùng
 find_match_count_limit[other]=Nhiều hơn {{limit}} đã trùng
 find_not_found=Không tìm thấy cụm từ này
 
-# Error panel labels
-error_more_info=Thông tin thêm
-error_less_info=Hiển thị ít thông tin hơn
-error_close=Đóng
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Thông điệp: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Stack: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Tập tin: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Dòng: {{line}}
-
 # Predefined zoom values
 page_scale_width=Vừa chiều rộng
 page_scale_fit=Vừa chiều cao
@@ -231,9 +209,6 @@ page_scale_actual=Kích thước thực
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=Đang tải…
 
 # Loading indicator messages
 loading_error=Lỗi khi tải tài liệu PDF.

--- a/l10n/wo/viewer.properties
+++ b/l10n/wo/viewer.properties
@@ -36,10 +36,6 @@ open_file.title=Ubbi benn dencukaay
 open_file_label=Ubbi
 print.title=Móol
 print_label=Móol
-download.title=Yeb yi
-download_label=Yeb yi
-bookmark.title=Wone bi taxaw (duppi walla ubbi palanteer bu bees)
-bookmark_label=Wone bi feeñ
 
 # Secondary toolbar and context menu
 
@@ -83,23 +79,6 @@ find_reached_top=Jot nañu ndorteel xët wi, kontine dale ko ci suuf
 find_reached_bottom=Jot nañu jeexitalu xët wi, kontine ci ndorte
 find_not_found=Gisiñu kaddu gi
 
-# Error panel labels
-error_more_info=Xibaar yu gën bari
-error_less_info=Xibaar yu gën bari
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Bataaxal: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Juug: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Dencukaay: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Rëdd : {{line}}
-rendering_error=Am njumte bu am bi xët bi di wonewu.
-
 # Predefined zoom values
 page_scale_width=Yaatuwaay bu mët
 page_scale_fit=Xët lëmm
@@ -110,6 +89,8 @@ page_scale_actual=Dayo bi am
 
 loading_error=Am na njumte ci yebum dencukaay PDF bi.
 invalid_file_error=Dencukaay PDF bi baaxul walla mu sankar.
+
+rendering_error=Am njumte bu am bi xët bi di wonewu.
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/xh/viewer.properties
+++ b/l10n/xh/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=Vula Ifayile
 open_file_label=Vula
 print.title=Printa
 print_label=Printa
-download.title=Khuphela
-download_label=Khuphela
-bookmark.title=Imbonakalo ekhoyo (kopa okanye vula kwifestile entsha)
-bookmark_label=Imbonakalo ekhoyo
 
 # Secondary toolbar and context menu
 tools.title=Izixhobo zemiyalelo
@@ -128,25 +124,6 @@ find_reached_top=Ufike ngaphezulu ephepheni, kusukwa ngezantsi
 find_reached_bottom=Ufike ekupheleni kwephepha, kusukwa ngaphezulu
 find_not_found=Ibinzana alifunyenwanga
 
-# Error panel labels
-error_more_info=Inkcazelo Engakumbi
-error_less_info=Inkcazelo Encinane
-error_close=Vala
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=I-PDF.js v{{version}} (yakha: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=Umyalezo: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=Imfumba: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=Ifayile: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=Umgca: {{line}}
-rendering_error=Imposiso yenzekile xa bekunikezelwa iphepha.
-
 # Predefined zoom values
 page_scale_width=Ububanzi bephepha
 page_scale_fit=Ukulinganiswa kwephepha
@@ -160,6 +137,8 @@ loading_error=Imposiso yenzekile xa kulayishwa i-PDF.
 invalid_file_error=Ifayile ye-PDF engeyiyo okanye eyonakalisiweyo.
 missing_file_error=Ifayile ye-PDF edukileyo.
 unexpected_response_error=Impendulo yeseva engalindelekanga.
+
+rendering_error=Imposiso yenzekile xa bekunikezelwa iphepha.
 
 # LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
 # "{{type}}" will be replaced with an annotation type from a list defined in

--- a/l10n/zh-CN/viewer.properties
+++ b/l10n/zh-CN/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=打开文件
 open_file_label=打开
 print.title=打印
 print_label=打印
-download.title=下载
-download_label=下载
-bookmark.title=当前在看的内容（复制或在新窗口中打开）
-bookmark_label=当前在看
 
 save.title=保存
 save_label=保存
@@ -205,24 +201,6 @@ find_match_count_limit[many]=超过 {{limit}} 项匹配
 find_match_count_limit[other]=超过 {{limit}} 项匹配
 find_not_found=找不到指定词语
 
-# Error panel labels
-error_more_info=更多信息
-error_less_info=更少信息
-error_close=关闭
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=信息：{{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=堆栈：{{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=文件：{{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=行号：{{line}}
-
 # Predefined zoom values
 page_scale_width=适合页宽
 page_scale_fit=适合页面
@@ -231,9 +209,6 @@ page_scale_actual=实际大小
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=正在加载…
 
 # Loading indicator messages
 loading_error=加载 PDF 时发生错误。

--- a/l10n/zh-TW/viewer.properties
+++ b/l10n/zh-TW/viewer.properties
@@ -39,10 +39,6 @@ open_file.title=開啟檔案
 open_file_label=開啟
 print.title=列印
 print_label=列印
-download.title=下載
-download_label=下載
-bookmark.title=目前畫面（複製或開啟於新視窗）
-bookmark_label=目前畫面
 
 save.title=儲存
 save_label=儲存
@@ -205,24 +201,6 @@ find_match_count_limit[many]=找到超過 {{limit}} 筆
 find_match_count_limit[other]=找到超過 {{limit}} 筆
 find_not_found=找不到指定文字
 
-# Error panel labels
-error_more_info=更多資訊
-error_less_info=更少資訊
-error_close=關閉
-# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
-# replaced by the PDF.JS version and build ID.
-error_version_info=PDF.js v{{version}} (build: {{build}})
-# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
-# english string describing the error.
-error_message=訊息: {{message}}
-# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
-# trace.
-error_stack=堆疊: {{stack}}
-# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
-error_file=檔案: {{file}}
-# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
-error_line=行: {{line}}
-
 # Predefined zoom values
 page_scale_width=頁面寬度
 page_scale_fit=縮放至頁面大小
@@ -231,9 +209,6 @@ page_scale_actual=實際大小
 # LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
 # numerical scale value.
 page_scale_percent={{scale}}%
-
-# Loading indicator messages
-loading=載入中…
 
 # Loading indicator messages
 loading_error=載入 PDF 時發生錯誤。


### PR DESCRIPTION
*Please note:* While I don't expect that all parts of our build-scripts and tooling will be this easy to convert, it hopefully shows a possible way to handle this process *piecewise* rather than all at once.