### PR TITLE
Re-enable editing, if necessary, when exiting PresentationMode (PR 16659 follow-up)

### DIFF
--- a/web/pdf_presentation_mode.js
+++ b/web/pdf_presentation_mode.js
@@ -209,7 +209,9 @@ class PDFPresentationMode {
       this.pdfViewer.currentPageNumber = pageNumber;
 
       if (this.#args.annotationEditorMode !== null) {
-        this.pdfViewer.annotationEditorMode = this.#args.annotationEditorMode;
+        this.pdfViewer.annotationEditorMode = {
+          mode: this.#args.annotationEditorMode,
+        };
       }
       this.#args = null;
     }, 0);


### PR DESCRIPTION
This regressed in PR #16659, when the signature of the `PDFViewer.annotationEditorMode`-setter was changed, and it currently leads to an Error being thrown when exiting PresentationMode.