### PR TITLE
Re-factor the `PDFScriptingManager`-class for the viewer-components

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -17,7 +17,7 @@
 import * as builder from "./external/builder/builder.mjs";
 import { exec, spawn, spawnSync } from "child_process";
 import autoprefixer from "autoprefixer";
-import { createRequire } from "module";
+import babel from "@babel/core";
 import crypto from "crypto";
 import { fileURLToPath } from "url";
 import fs from "fs";
@@ -41,7 +41,6 @@ import webpackStream from "webpack-stream";
 import zip from "gulp-zip";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const require = createRequire(import.meta.url);
 
 const BUILD_DIR = "build/";
 const L10N_DIR = "l10n/";
@@ -1528,14 +1527,14 @@ function buildLibHelper(bundleDefines, inputStream, outputDir) {
   // __non_webpack_require__ has to be used.
   // In this target, we don't create a bundle, so we have to replace the
   // occurrences of __non_webpack_require__ ourselves.
-  function babelPluginReplaceNonWebpackImports(babel) {
+  function babelPluginReplaceNonWebpackImports(b) {
     return {
       visitor: {
         Identifier(curPath, state) {
           if (curPath.node.name === "__non_webpack_require__") {
-            curPath.replaceWith(babel.types.identifier("require"));
+            curPath.replaceWith(b.types.identifier("require"));
           } else if (curPath.node.name === "__non_webpack_import__") {
-            curPath.replaceWith(babel.types.identifier("import"));
+            curPath.replaceWith(b.types.identifier("import"));
           }
         },
       },
@@ -1562,7 +1561,6 @@ function buildLibHelper(bundleDefines, inputStream, outputDir) {
     );
     return licenseHeaderLibre + content;
   }
-  const babel = require("@babel/core");
   const ctx = {
     rootPath: __dirname,
     saveComments: false,

--- a/test/unit/pdf_viewer.component_spec.js
+++ b/test/unit/pdf_viewer.component_spec.js
@@ -33,7 +33,7 @@ import { GenericL10n } from "../../web/genericl10n.js";
 import { NullL10n } from "../../web/l10n_utils.js";
 import { PDFHistory } from "../../web/pdf_history.js";
 import { PDFPageView } from "../../web/pdf_page_view.js";
-import { PDFScriptingManager } from "../../web/pdf_scripting_manager.js";
+import { PDFScriptingManager } from "../../web/pdf_scripting_manager.component.js";
 import { PDFSinglePageViewer } from "../../web/pdf_single_page_viewer.js";
 import { PDFViewer } from "../../web/pdf_viewer.js";
 import { StructTreeLayerBuilder } from "../../web/struct_tree_layer_builder.js";

--- a/web/pdf_scripting_manager.component.js
+++ b/web/pdf_scripting_manager.component.js
@@ -1,0 +1,44 @@
+/* Copyright 2021 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { docProperties, GenericScripting } from "./generic_scripting.js";
+import { PDFScriptingManager } from "./pdf_scripting_manager.js";
+
+class PDFScriptingManagerComponents extends PDFScriptingManager {
+  constructor(options) {
+    // The default viewer already handles adding/removing of DOM events,
+    // hence limit this to only the viewer components.
+    if (!options.externalServices) {
+      window.addEventListener("updatefromsandbox", event => {
+        options.eventBus.dispatch("updatefromsandbox", {
+          source: window,
+          detail: event.detail,
+        });
+      });
+    }
+
+    options.externalServices ||= {
+      createScripting: ({ sandboxBundleSrc }) => {
+        return new GenericScripting(sandboxBundleSrc);
+      },
+    };
+    options.docProperties ||= pdfDocument => {
+      return docProperties(pdfDocument);
+    };
+    super(options);
+  }
+}
+
+export { PDFScriptingManagerComponents as PDFScriptingManager };

--- a/web/pdf_scripting_manager.js
+++ b/web/pdf_scripting_manager.js
@@ -66,30 +66,6 @@ class PDFScriptingManager {
     }
     this.#externalServices = externalServices;
     this.#docProperties = docProperties;
-
-    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("COMPONENTS")) {
-      const gs = require("./generic_scripting.js");
-
-      this.#externalServices ||= {
-        createScripting: options => {
-          return new gs.GenericScripting(options.sandboxBundleSrc);
-        },
-      };
-      this.#docProperties ||= pdfDocument => {
-        return gs.docProperties(pdfDocument);
-      };
-
-      // The default viewer already handles adding/removing of DOM events,
-      // hence limit this to only the viewer components.
-      if (!externalServices) {
-        window.addEventListener("updatefromsandbox", event => {
-          this.#eventBus.dispatch("updatefromsandbox", {
-            source: window,
-            detail: event.detail,
-          });
-        });
-      }
-    }
   }
 
   setViewer(pdfViewer) {

--- a/web/pdf_viewer.component.js
+++ b/web/pdf_viewer.component.js
@@ -33,7 +33,7 @@ import { GenericL10n } from "./genericl10n.js";
 import { NullL10n } from "./l10n_utils.js";
 import { PDFHistory } from "./pdf_history.js";
 import { PDFPageView } from "./pdf_page_view.js";
-import { PDFScriptingManager } from "./pdf_scripting_manager.js";
+import { PDFScriptingManager } from "./pdf_scripting_manager.component.js";
 import { PDFSinglePageViewer } from "./pdf_single_page_viewer.js";
 import { PDFViewer } from "./pdf_viewer.js";
 import { StructTreeLayerBuilder } from "./struct_tree_layer_builder.js";

--- a/web/pdfjs.js
+++ b/web/pdfjs.js
@@ -12,14 +12,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals module, __non_webpack_require__ */
+/* globals module */
 
 "use strict";
 
-let pdfjsLib;
-if (typeof window !== "undefined" && window["pdfjs-dist/build/pdf"]) {
-  pdfjsLib = window["pdfjs-dist/build/pdf"];
-} else {
-  pdfjsLib = __non_webpack_require__("../build/pdf.js");
-}
-module.exports = pdfjsLib;
+module.exports = globalThis.pdfjsLib;


### PR DESCRIPTION
Currently this class contains a few "special" code-paths for the COMPONENTS build-target, which normally wouldn't be a problem. However, in this particular case that means accessing code that we don't want to include unconditionally in all builds.
This is currently implemented using build-time `require`-calls which we nowadays want to avoid, and we should strive to remove all such cases from the code-base. (Generally speaking `import` is the future, and build-tools may not always play well with a mix of both formats.)

We can easily improve things here by using sub-classing for the COMPONENTS build-target, and then use the ability to re-name when exporting (to avoid breaking existing code).