### PR TITLE
[GeckoView] Fix l10n of the download toolbar-button (PR 16340 follow-up)

### DIFF
--- a/web/viewer-geckoview.html
+++ b/web/viewer-geckoview.html
@@ -80,8 +80,8 @@ See https://github.com/adobe-type-tools/cmap-resources
       <div id="mainContainer">
 
         <div id="floatingToolbar">
-          <button id="download" class="toolbarButton" title="Save" tabindex="31" data-l10n-id="download">
-            <span data-l10n-id="download_label">Download</span>
+          <button id="download" class="toolbarButton" title="Save" tabindex="31" data-l10n-id="save">
+            <span data-l10n-id="save_label">Save</span>
           </button>
           <button id="openInApp" class="toolbarButton" title="Open in app" tabindex="32" data-l10n-id="open_in_app">
             <span data-l10n-id="open_in_app_label">Open in app</span>


### PR DESCRIPTION
Localization of this button broke in PR #16340, which I assume was completely accidental, since the download-button now tries to access a l10n-id that was removed some time ago (see PR #15617).
Note how loading even the development viewer, i.e. http://localhost:8888/web/viewer-geckoview.html#locale=en-US, currently logs l10n-warnings on the `master` branch.