### PR TITLE
Add @typedef JSDoc annotaion to fix typestest

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -2455,6 +2455,7 @@ gulp.task(
   "ci-test",
   gulp.series(
     gulp.parallel("lint", "externaltest", "unittestcli"),
-    "lint-chromium"
+    "lint-chromium",
+    "typestest"
   )
 );

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -98,6 +98,10 @@ const DefaultStandardFontDataFactory =
     : DOMStandardFontDataFactory;
 
 /**
+ * @typedef { import("./svg.js").SVGGraphics } SVGGraphics
+ */
+
+/**
  * @typedef { Int8Array | Uint8Array | Uint8ClampedArray |
  *            Int16Array | Uint16Array |
  *            Int32Array | Uint32Array | Float32Array |


### PR DESCRIPTION
Add `@typedef` JSDoc annotaion to fix typestest. Close #16705