### PR TITLE
XFA - Set storage values to select and option elements

### DIFF
--- a/src/display/xfa_layer.js
+++ b/src/display/xfa_layer.js
@@ -79,9 +79,12 @@ class XfaLayer {
         break;
       case "select":
         if (storedData.value !== null) {
+          html.setAttribute("value", storedData.value);
           for (const option of element.children) {
             if (option.attributes.value === storedData.value) {
               option.attributes.selected = true;
+            } else if (option.attributes.hasOwnProperty("selected")) {
+              delete option.attributes.selected;
             }
           }
         }


### PR DESCRIPTION
With XFA Forms, select fields always render with default attributes values and doesn't change if storage has different values, this PR intent to fix that by updating element attributes with storage values if exists and removing the 'selected' attribute (if exists) if the option actually isn't selected.
