### PR TITLE
Don't reset temporary XRef-entries during saving (PR 16392 follow-up)

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -661,23 +661,21 @@ class WorkerMessageHandler {
             };
           }
 
-          try {
-            return incrementalUpdate({
-              originalData: stream.bytes,
-              xrefInfo: newXrefInfo,
-              newRefs,
-              xref,
-              hasXfa: !!xfa,
-              xfaDatasetsRef,
-              hasXfaDatasetsEntry,
-              needAppearances,
-              acroFormRef,
-              acroForm,
-              xfaData,
-            });
-          } finally {
+          return incrementalUpdate({
+            originalData: stream.bytes,
+            xrefInfo: newXrefInfo,
+            newRefs,
+            xref,
+            hasXfa: !!xfa,
+            xfaDatasetsRef,
+            hasXfaDatasetsEntry,
+            needAppearances,
+            acroFormRef,
+            acroForm,
+            xfaData,
+          }).finally(() => {
             xref.resetNewTemporaryRef();
-          }
+          });
         });
       }
     );


### PR DESCRIPTION
*Please note:* I'm not aware of any bugs caused by this, however that might be more luck than anything else.

In PR #16392 the `incrementalUpdate` function, and all of its various helpers, were made asynchronous. However the call-site in `src/core/worker.js` wasn't updated, which means that we currently reset temporary XRef-entries while saving is ongoing.