### PR TITLE
Don't get the text content for an annotation when /NeedAppearances is true (bug 1844583)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -2572,7 +2572,7 @@ class TextWidgetAnnotation extends WidgetAnnotation {
   }
 
   get hasTextContent() {
-    return !!this.appearance;
+    return !!this.appearance && !this._needAppearances;
   }
 
   _getCombAppearance(

--- a/test/integration/annotation_spec.js
+++ b/test/integration/annotation_spec.js
@@ -508,4 +508,32 @@ describe("ResetForm action", () => {
       });
     });
   });
+
+  describe("Don't use AP when /NeedAppearances is true", () => {
+    describe("bug1844583.pdf", () => {
+      let pages;
+
+      beforeAll(async () => {
+        pages = await loadAndWait(
+          "bug1844583.pdf",
+          "[data-annotation-id='8R']"
+        );
+      });
+
+      afterAll(async () => {
+        await closePages(pages);
+      });
+
+      it("must check the content of the text field", async () => {
+        await Promise.all(
+          pages.map(async ([browserName, page]) => {
+            const text = await page.$eval(getSelector("8R"), el => el.value);
+            expect(text)
+              .withContext(`In ${browserName}`)
+              .toEqual("Hello World");
+          })
+        );
+      });
+    });
+  });
 });

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -605,3 +605,4 @@
 !rotated_freetexts.pdf
 !issue16633.pdf
 !bug1844576.pdf
+!bug1844583.pdf

--- a/test/pdfs/bug1844583.pdf
+++ b/test/pdfs/bug1844583.pdf
@@ -1,0 +1,148 @@
+%PDF-1.6
+%¿÷¢þ
+1 0 obj
+<< /AcroForm 5 0 R /Metadata 11 0 R /Names 6 0 R /Outlines 13 0 R /Pages 17 0 R /Type /Catalog >>
+endobj
+2 0 obj
+<< /Type /ObjStm /Length 188 /N 1 /First 4 >>
+stream
+3 0
+<< /CreationDate (D:20230721095805+02'00') /Creator (Adobe Acrobat Pro \(64-bit\) 23.3.20244) /ModDate (D:20230721100148+02'00') /Producer (Adobe Acrobat Pro \(64-bit\) 23.3.20244) >>
+endstream
+endobj
+4 0 obj
+<< /Type /ObjStm /Length 1801 /N 6 /First 35 >>
+stream
+5 0 6 132 7 149 8 159 9 371 10 455
+<<  /DR << /Encoding << /PDFDocEncoding 10 0 R >> /Font << /Helv 9 0 R /ZaDb 20 0 R >> >> /Fields [ 8 0 R ]/NeedAppearances true >>
+<< /AP 18 0 R >>
+[ 8 0 R ]
+<< /AP << /N 21 0 R >> /DA (/Helv 12 Tf 0 g) /DV (Hello World) /F 4 /FT /Tx /MK << /BC [ 0.0 0.0 0.0 ] >> /P 22 0 R /Rect [ 131.6 601.2 281.6 623.2 ] /Subtype /Widget /T (Texte2) /Type /Annot /V (Hello World) >>
+<< /BaseFont /Helvetica /Encoding 10 0 R /Name /Helv /Subtype /Type1 /Type /Font >>
+<< /Differences [ 24 /breve /caron /circumflex /dotaccent /hungarumlaut /ogonek /ring /tilde 39 /quotesingle 96 /grave 128 /bullet /dagger /daggerdbl /ellipsis /emdash /endash /florin /fraction /guilsinglleft /guilsinglright /minus /perthousand /quotedblbase /quotedblleft /quotedblright /quoteleft /quoteright /quotesinglbase /trademark /fi /fl /Lslash /OE /Scaron /Ydieresis /Zcaron /dotlessi /lslash /oe /scaron /zcaron 160 /Euro 164 /currency 166 /brokenbar 168 /dieresis /copyright /ordfeminine 172 /logicalnot /.notdef /registered /macron /degree /plusminus /twosuperior /threesuperior /acute /mu 183 /periodcentered /cedilla /onesuperior /ordmasculine 188 /onequarter /onehalf /threequarters 192 /Agrave /Aacute /Acircumflex /Atilde /Adieresis /Aring /AE /Ccedilla /Egrave /Eacute /Ecircumflex /Edieresis /Igrave /Iacute /Icircumflex /Idieresis /Eth /Ntilde /Ograve /Oacute /Ocircumflex /Otilde /Odieresis /multiply /Oslash /Ugrave /Uacute /Ucircumflex /Udieresis /Yacute /Thorn /germandbls /agrave /aacute /acircumflex /atilde /adieresis /aring /ae /ccedilla /egrave /eacute /ecircumflex /edieresis /igrave /iacute /icircumflex /idieresis /eth /ntilde /ograve /oacute /ocircumflex /otilde /odieresis /divide /oslash /ugrave /uacute /ucircumflex /udieresis /yacute /thorn /ydieresis ] /Type /Encoding >>
+endstream
+endobj
+11 0 obj
+<< /Subtype /XML /Type /Metadata /Length 3364 >>
+stream
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 9.1-c001 79.2a0d8d9, 2023/03/14-11:19:46        ">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description rdf:about=""
+            xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"
+            xmlns:pdf="http://ns.adobe.com/pdf/1.3/"
+            xmlns:adhocwf="http://ns.adobe.com/AcrobatAdhocWorkflow/1.0/">
+         <xmp:ModifyDate>2023-07-21T10:01:48+02:00</xmp:ModifyDate>
+         <xmp:CreateDate>2023-07-21T09:58:05+02:00</xmp:CreateDate>
+         <xmp:MetadataDate>2023-07-21T10:01:48+02:00</xmp:MetadataDate>
+         <xmp:CreatorTool>Adobe Acrobat Pro (64-bit) 23.3.20244</xmp:CreatorTool>
+         <dc:format>application/pdf</dc:format>
+         <xmpMM:DocumentID>uuid:01408f4e-b0df-4768-b616-81fb5426259c</xmpMM:DocumentID>
+         <xmpMM:InstanceID>uuid:a83efd67-436f-4844-9d28-46e27f819da6</xmpMM:InstanceID>
+         <pdf:Producer>Adobe Acrobat Pro (64-bit) 23.3.20244</pdf:Producer>
+         <adhocwf:state>1</adhocwf:state>
+         <adhocwf:version>1.1</adhocwf:version>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                           
+<?xpacket end="w"?>endstream
+endobj
+12 0 obj
+<< /Type /ObjStm /Length 173 /N 3 /First 18 >>
+stream
+13 0 14 58 15 110
+<< /Count 1 /First 14 0 R /Last 14 0 R /Type /Outlines >>
+<< /A 15 0 R /Parent 13 0 R /Title (Page vierge) >>
+<< /D [ 22 0 R /XYZ 0 792 null ] /S /GoTo >>
+endstream
+endobj
+16 0 obj
+<< /Type /ObjStm /Length 365 /N 2 /First 11 >>
+stream
+17 0 18 45
+<< /Count 1 /Kids [ 22 0 R ] /Type /Pages >>
+<< /Names [ <feff007e00690063006f006e002b0043006f006d006d0065006e0074002b003200350035003a003200300039003a0030002d004600520041002d0030> 23 0 R <feff007e00690063006f006e002b0043006f006d006d0065006e007400530065006c00650063007400650064002b003200350035003a003200300039003a0030002d004600520041002d0030> 24 0 R ] >>
+endstream
+endobj
+19 0 obj
+<< /Type /ObjStm /Length 75 /N 1 /First 5 >>
+stream
+20 0
+<< /BaseFont /ZapfDingbats /Name /ZaDb /Subtype /Type1 /Type /Font >>
+endstream
+endobj
+21 0 obj
+<< /BBox [ 0.0 0.0 150.0 22.0 ] /FormType 1 /Matrix [ 1.0 0.0 0.0 1.0 0.0 0.0 ] /Resources << /Font << /Helv 9 0 R >> /ProcSet [ /PDF /Text ] >> /Subtype /Form /Type /XObject /Length 130 >>
+stream
+q
+0 G
+0.5 0.5 149 21 re
+s
+Q
+/Tx BMC 
+q
+1 1 148 20 re
+W
+n
+BT
+/Helv 12 Tf
+0 g
+2 6.548 Td
+(Dlrow ) Tj
+30.66 0 Td
+(Olleh) Tj
+ET
+Q
+EMC
+endstream
+endobj
+22 0 obj
+<< /Annots 7 0 R /Contents 25 0 R /CropBox [ 115.6 587.6 293.2 641.6 ] /MediaBox [ 0.0 0.0 612.0 792.0 ] /Parent 17 0 R /Resources << >> /Rotate 0 /TrimBox [ 115.6 587.6 293.2 641.6 ] /Type /Page >>
+endobj
+23 0 obj
+<< /BBox [ 0.0 0.0 24.0 24.0 ] /Resources << /ExtGState << /GS0 << /AIS false /BM /Normal /CA 0.6 /Type /ExtGState /ca 0.6 >> >> >> /Subtype /Form /Type /XObject /Length 846 >>
+stream
+q 1 1 1 rg 0 i 1 w 4 M 1 j 0 J []0 d /GS0 gs 1 0 0 1 9 5.0908 cm 7.74 12.616 m -7.74 12.616 l -8.274 12.616 -8.707 12.184 -8.707 11.649 c -8.707 -3.831 l -8.707 -4.365 -8.274 -4.798 -7.74 -4.798 c 7.74 -4.798 l 8.274 -4.798 8.707 -4.365 8.707 -3.831 c 8.707 11.649 l 8.707 12.184 8.274 12.616 7.74 12.616 c h f Q 0 G 1 0.819611 0 rg 0 i 0.60 w 4 M 1 j 0 J [0 100]1 d  1 0 0 1 9 5.0908 cm 1 0 m -2.325 -2.81 l  -2.325 0 l  -5.72 0 l  -5.72 8.94 l  5.51 8.94 l  5.51 0 l  1 0 l -3.50 5.01 m -3.50 5.59 l 3.29 5.59 l 3.29 5.01 l -3.50 5.01 l -3.50 3.34 m -3.50 3.92 l 2.27 3.92 l 2.27 3.34 l -3.50 3.34 l 7.74 12.616 m -7.74 12.616 l -8.274 12.616 -8.707 12.184 -8.707 11.649 c -8.707 -3.831 l -8.707 -4.365 -8.274 -4.798 -7.74 -4.798 c 7.74 -4.798 l 8.274 -4.798 8.707 -4.365 8.707 -3.831 c 8.707 11.649 l 8.707 12.184 8.274 12.616 7.74 12.616 c b endstream
+endobj
+24 0 obj
+<< /BBox [ 0.0 0.0 24.0 24.0 ] /Resources << /ExtGState << /GS0 << /AIS false /BM /Normal /CA 0.6 /Type /ExtGState /ca 0.6 >> >> >> /Subtype /Form /Type /XObject /Length 385 >>
+stream
+0 G 1 0.819611 0 rg 0 i 0.60 w 4 M 1 j 0 J [0 100]1 d  1 0 0 1 9 5.0908 cm 4.1 1.71 m -0.54 -2.29 l  -0.54 1.71 l  -5.5 1.71 l  -5.5 14.42 l  10.5 14.42 l  10.5 1.71 l  4.1 1.71 l -2.33 9.66 m 7.34 9.66 l 7.34 8.83 l -2.33 8.83 l -2.33 9.66 l -2.33 7.28 m 5.88 7.28 l 5.88 6.46 l -2.33 6.46 l -2.33 7.28 l 14.9 23.1235 m -14.9 23.1235 l -14.9 -20.345 l 14.9 -20.345 l 14.9 23.1235 l b endstream
+endobj
+25 0 obj
+<< /Length 0 >>
+stream
+endstream
+endobj
+26 0 obj
+<< /Type /XRef /Length 108 /W [ 1 2 1 ] /Info 3 0 R /Root 1 0 R /Size 27 /ID [<8d8ee619e3ffbd4890861ff2e03d4ca5><482932e9b1e074ad6477186dfde6b11d>] >>
+stream
+       €   Š        ã Y     V       ¬  ä   "W "ˆ 
+endstream
+endobj
+startxref
+8840
+%%EOF


### PR DESCRIPTION
When the flag is set, the appearance has to be generated from the value so it's useless/meaningless to extract the content from the existing appearance.