### PR TITLE
Don't uselessly change the filter when drawing (bug 1508765)

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -790,7 +790,10 @@ function resetCtxToDefault(ctx) {
     (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) ||
     !isNodeJS
   ) {
-    ctx.filter = "none";
+    const { filter } = ctx;
+    if (filter !== "none" && filter !== "") {
+      ctx.filter = "none";
+    }
   }
 }
 
@@ -2961,7 +2964,10 @@ class CanvasGraphics {
       // It must be applied to the image before rescaling else some artifacts
       // could appear.
       // The final restore will reset it to its value.
-      ctx.filter = "none";
+      const { filter } = ctx;
+      if (filter !== "none" && filter !== "") {
+        ctx.filter = "none";
+      }
     }
 
     // scale the image to the unit square


### PR DESCRIPTION
When profiling the pdf in https://bugzilla.mozilla.org/show_bug.cgi?id=1508765, I noticed that half a second was spent to set the filter to "none".