### PR TITLE
Enable the ESLint `no-var rule` in the `extensions/firefox/` folder

### DIFF
--- a/extensions/firefox/.eslintrc
+++ b/extensions/firefox/.eslintrc
@@ -15,9 +15,6 @@
   ],
 
   "rules": {
-    // Items different from the mozilla/recommended configuration.
-    "no-var": "off",
-
     // Other rules mozilla/recommended hasn't enabled yet.
     "no-shadow": "error",
     "arrow-body-style": ["error", "as-needed"],

--- a/extensions/firefox/tools/l10n.js
+++ b/extensions/firefox/tools/l10n.js
@@ -40,7 +40,7 @@
       property = "textContent";
     }
     const data = getL10nData(name);
-    const value = (data && data[property]) || fallback;
+    const value = data?.[property] || fallback;
     if (!value) {
       return "{{" + key + "}}";
     }
@@ -49,7 +49,7 @@
 
   // translate an HTML element
   function translateElement(element) {
-    if (!element || !element.dataset) {
+    if (!element?.dataset) {
       return;
     }
 
@@ -80,7 +80,7 @@
 
   // translate an HTML subtree
   function translateFragment(element) {
-    element = element || document.querySelector("html");
+    element ||= document.querySelector("html");
 
     // check all translatable children (= w/ a `data-l10n-id' attribute)
     const children = element.querySelectorAll("*[data-l10n-id]");

--- a/extensions/firefox/tools/l10n.js
+++ b/extensions/firefox/tools/l10n.js
@@ -30,8 +30,8 @@
 
   // translate a string
   function translateString(key, args, fallback) {
-    var i = key.lastIndexOf(".");
-    var name, property;
+    const i = key.lastIndexOf(".");
+    let name, property;
     if (i >= 0) {
       name = key.substring(0, i);
       property = key.substring(i + 1);
@@ -39,8 +39,8 @@
       name = key;
       property = "textContent";
     }
-    var data = getL10nData(name);
-    var value = (data && data[property]) || fallback;
+    const data = getL10nData(name);
+    const value = (data && data[property]) || fallback;
     if (!value) {
       return "{{" + key + "}}";
     }
@@ -54,15 +54,15 @@
     }
 
     // get the related l10n object
-    var key = element.dataset.l10nId;
-    var data = getL10nData(key);
+    const key = element.dataset.l10nId;
+    const data = getL10nData(key);
     if (!data) {
       return;
     }
 
     // get arguments (if any)
     // TODO: more flexible parser?
-    var args;
+    let args;
     if (element.dataset.l10nArgs) {
       try {
         args = JSON.parse(element.dataset.l10nArgs);
@@ -73,7 +73,7 @@
 
     // translate element
     // TODO: security check?
-    for (var k in data) {
+    for (const k in data) {
       element[k] = substArguments(data[k], args);
     }
   }
@@ -83,9 +83,9 @@
     element = element || document.querySelector("html");
 
     // check all translatable children (= w/ a `data-l10n-id' attribute)
-    var children = element.querySelectorAll("*[data-l10n-id]");
-    var elementCount = children.length;
-    for (var i = 0; i < elementCount; i++) {
+    const children = element.querySelectorAll("*[data-l10n-id]");
+    const elementCount = children.length;
+    for (let i = 0; i < elementCount; i++) {
       translateElement(children[i]);
     }
 
@@ -109,10 +109,10 @@
     getDirection() {
       // http://www.w3.org/International/questions/qa-scripts
       // Arabic, Hebrew, Farsi, Pashto, Urdu
-      var rtlList = ["ar", "he", "fa", "ps", "ur"];
+      const rtlList = ["ar", "he", "fa", "ps", "ur"];
 
       // use the short language code for "full" codes like 'ar-sa' (issue 5440)
-      var shortCode = gLanguage.split("-")[0];
+      const shortCode = gLanguage.split("-")[0];
 
       return rtlList.includes(shortCode) ? "rtl" : "ltr";
     },


### PR DESCRIPTION
This was done automatically, using the `gulp lint --fix` command.