### PR TITLE
Remove the `useOnlyCssZoom` preference

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -122,10 +122,6 @@
       ],
       "default": 1
     },
-    "useOnlyCssZoom": {
-      "type": "boolean",
-      "default": false
-    },
     "externalLinkTarget": {
       "title": "External links target window",
       "description": "Controls how external links will be opened.\n 0 = default.\n 1 = replaces current window.\n 2 = new window/tab.\n 3 = parent.\n 4 = in top window.",

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -192,7 +192,7 @@ const defaultOptions = {
   useOnlyCssZoom: {
     /** @type {boolean} */
     value: false,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    kind: OptionKind.VIEWER,
   },
   viewerCssTheme: {
     /** @type {number} */


### PR DESCRIPTION
*Please note:* This only removes the preference itself, however both the viewer-option and the actual implementation is still available.

The `useOnlyCssZoom` functionality was only ever used, by default, in the PDF Viewer for the B2G/FirefoxOS project (which was abandoned years ago). Given that CSS-only zooming can easily make the document look blurry even at low zoom levels, this functionality was only intended for low-powered mobile devices.
Hence it seems reasonable to remove the `useOnlyCssZoom` preference now, since neither the default viewer nor the GeckoView-specific viewer uses this functionality.