### PR TITLE
Remove the `vinyl-fs` dependency

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -34,7 +34,6 @@ import rimraf from "rimraf";
 import stream from "stream";
 import streamqueue from "streamqueue";
 import through from "through2";
-import vfs from "vinyl-fs";
 import Vinyl from "vinyl";
 import webpack2 from "webpack";
 import webpackStream from "webpack-stream";
@@ -2098,15 +2097,14 @@ function ghPagesPrepare() {
 
   rimraf.sync(GH_PAGES_DIR);
 
-  // 'vfs' because web/viewer.html needs its BOM.
   return merge([
-    vfs
-      .src(GENERIC_DIR + "**/*", { base: GENERIC_DIR, stripBOM: false })
+    gulp
+      .src(GENERIC_DIR + "**/*", { base: GENERIC_DIR, removeBOM: false })
       .pipe(gulp.dest(GH_PAGES_DIR)),
-    vfs
+    gulp
       .src(GENERIC_LEGACY_DIR + "**/*", {
         base: GENERIC_LEGACY_DIR,
-        stripBOM: false,
+        removeBOM: false,
       })
       .pipe(gulp.dest(GH_PAGES_DIR + "legacy/")),
     gulp
@@ -2223,8 +2221,11 @@ gulp.task(
 
       return merge([
         packageJson().pipe(gulp.dest(DIST_DIR)),
-        vfs
-          .src("external/dist/**/*", { base: "external/dist", stripBOM: false })
+        gulp
+          .src("external/dist/**/*", {
+            base: "external/dist",
+            removeBOM: false,
+          })
           .pipe(gulp.dest(DIST_DIR)),
         gulp.src(GENERIC_DIR + "LICENSE").pipe(gulp.dest(DIST_DIR)),
         gulp

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,6 @@
         "typescript": "^5.1.6",
         "typogr": "^0.6.8",
         "vinyl": "^3.0.0",
-        "vinyl-fs": "^3.0.3",
         "webpack": "^5.88.2",
         "webpack-stream": "^7.0.0",
         "wintersmith": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "typescript": "^5.1.6",
     "typogr": "^0.6.8",
     "vinyl": "^3.0.0",
-    "vinyl-fs": "^3.0.3",
     "webpack": "^5.88.2",
     "webpack-stream": "^7.0.0",
     "wintersmith": "^2.5.0",


### PR DESCRIPTION
In Gulp 4, which we use for years now, the `gulp.src()` function supports the `removeBOM` option to disable the default BOM stripping, so this commit uses that to get rid of our `vinyl-fs` dependency.

Note that this actually makes disabling BOM stripping work again. It's currently broken because in `vinyl-fs` 3, that we already use since 2018 in commit 95de23e, the `stripBOM` option was renamed to `removeBOM`, so the current code doesn't actually disable BOM stripping which we now confirmed and sadly broke for years without anyone noticing. Most likely this is because the BOM is not required for UTF-8 documents, but while not necessary it also can't hurt to have it for tools that use it to determine if a document is UTF-8.

Fixes #16694.