### PR TITLE
[Editor] Avoid spurious text selection when double clicking to add a FreeText

### DIFF
--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -114,6 +114,7 @@
   resize: none;
   font: 10px sans-serif;
   line-height: var(--freetext-line-height);
+  user-select: none;
 }
 
 .annotationEditorLayer .freeTextEditor .overlay {
@@ -137,6 +138,7 @@
 
 .annotationEditorLayer .freeTextEditor .internal:focus {
   outline: none;
+  user-select: auto;
 }
 
 .annotationEditorLayer .inkEditor.disabled {


### PR DESCRIPTION
In order to reproduce the original issue:
 - switch to freetext mode
 - add a text somewhere
 - double click outside and add some text
 - repeat the previous step several times

no text is selected during the edition.