### PR TITLE
Re-factor how the `debugger` accesses API-functionality

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -46,7 +46,6 @@ import {
   isPdfFile,
   loadScript,
   MissingPDFException,
-  OPS,
   PDFWorker,
   PromiseCapability,
   shadow,
@@ -375,7 +374,7 @@ const PDFViewerApplication = {
       const enabled = params.get("pdfbug").split(",");
       try {
         await loadPDFBug(this);
-        this._PDFBug.init({ OPS }, mainContainer, enabled);
+        this._PDFBug.init(mainContainer, enabled);
       } catch (ex) {
         console.error(`_parseHashParams: "${ex.message}".`);
       }

--- a/web/debugger.js
+++ b/web/debugger.js
@@ -13,7 +13,12 @@
  * limitations under the License.
  */
 
-let opMap;
+const { OPS } = globalThis.pdfjsLib || (await import("pdfjs-lib"));
+
+const opMap = Object.create(null);
+for (const key in OPS) {
+  opMap[OPS[key]] = key;
+}
 
 const FontInspector = (function FontInspectorClosure() {
   let fonts;
@@ -63,7 +68,7 @@ const FontInspector = (function FontInspectorClosure() {
     name: "Font Inspector",
     panel: null,
     manager: null,
-    init(pdfjsLib) {
+    init() {
       const panel = this.panel;
       const tmp = document.createElement("button");
       tmp.addEventListener("click", resetSelection);
@@ -160,7 +165,7 @@ const StepperManager = (function StepperManagerClosure() {
     name: "Stepper",
     panel: null,
     manager: null,
-    init(pdfjsLib) {
+    init() {
       const self = this;
       stepperControls = document.createElement("div");
       stepperChooser = document.createElement("select");
@@ -172,11 +177,6 @@ const StepperManager = (function StepperManagerClosure() {
       this.panel.append(stepperControls, stepperDiv);
       if (sessionStorage.getItem("pdfjsBreakPoints")) {
         breakPoints = JSON.parse(sessionStorage.getItem("pdfjsBreakPoints"));
-      }
-
-      opMap = Object.create(null);
-      for (const key in pdfjsLib.OPS) {
-        opMap[pdfjsLib.OPS[key]] = key;
       }
     },
     cleanup() {
@@ -457,7 +457,7 @@ const Stats = (function Stats() {
     name: "Stats",
     panel: null,
     manager: null,
-    init(pdfjsLib) {},
+    init() {},
     enabled: false,
     active: false,
     // Stats specific functions.
@@ -521,7 +521,7 @@ const PDFBug = (function PDFBugClosure() {
         });
       }
     },
-    init(pdfjsLib, container, ids) {
+    init(container, ids) {
       this.loadCSS();
       this.enable(ids);
       /*
@@ -561,7 +561,7 @@ const PDFBug = (function PDFBugClosure() {
         tool.panel = panel;
         tool.manager = this;
         if (tool.enabled) {
-          tool.init(pdfjsLib);
+          tool.init();
         } else {
           panel.textContent =
             `${tool.name} is disabled. To enable add "${tool.id}" to ` +


### PR DESCRIPTION
Given that the `debugger` is loaded as a module we can use "top level await" in development mode to access the necessary API-functionality, which removes the need to manually pass in the required properties.