### PR TITLE
[Editor] Make editors movable in using the keyboard (bug 1845088)

### DIFF
--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -18,8 +18,13 @@
 // eslint-disable-next-line max-len
 /** @typedef {import("./tools.js").AnnotationEditorUIManager} AnnotationEditorUIManager */
 
+import {
+  AnnotationEditorParamsType,
+  FeatureTest,
+  shadow,
+  unreachable,
+} from "../../shared/util.js";
 import { bindEvents, ColorManager } from "./tools.js";
-import { FeatureTest, shadow, unreachable } from "../../shared/util.js";
 
 /**
  * @typedef {Object} AnnotationEditorParameters
@@ -261,19 +266,33 @@ class AnnotationEditor {
     this.fixAndSetPosition();
   }
 
-  /**
-   * Translate the editor position within its parent.
-   * @param {number} x - x-translation in screen coordinates.
-   * @param {number} y - y-translation in screen coordinates.
-   */
-  translate(x, y) {
-    const [width, height] = this.parentDimensions;
+  #translate([width, height], x, y) {
     [x, y] = this.screenToPageTranslation(x, y);
 
     this.x += x / width;
     this.y += y / height;
 
     this.fixAndSetPosition();
+  }
+
+  /**
+   * Translate the editor position within its parent.
+   * @param {number} x - x-translation in screen coordinates.
+   * @param {number} y - y-translation in screen coordinates.
+   */
+  translate(x, y) {
+    this.#translate(this.parentDimensions, x, y);
+  }
+
+  /**
+   * Translate the editor position within its page and adjust the scroll
+   * in order to have the editor in the view.
+   * @param {number} x - x-translation in page coordinates.
+   * @param {number} y - y-translation in page coordinates.
+   */
+  translateInPage(x, y) {
+    this.#translate(this.pageDimensions, x, y);
+    this.div.scrollIntoView({ block: "nearest" });
   }
 
   fixAndSetPosition() {
@@ -663,7 +682,7 @@ class AnnotationEditor {
       cmd,
       undo,
       mustExec: true,
-      type: this.resizeType,
+      type: AnnotationEditorParamsType.RESIZE,
       overwriteIfSameType: true,
       keepUndo: true,
     });
@@ -920,13 +939,6 @@ class AnnotationEditor {
     } else {
       this._uiManager.removeEditor(this);
     }
-  }
-
-  /**
-   * @returns {number} the type to use in the undo/redo stack when resizing.
-   */
-  get resizeType() {
-    return -1;
   }
 
   /**

--- a/src/display/editor/freetext.js
+++ b/src/display/editor/freetext.js
@@ -71,7 +71,7 @@ class FreeTextEditor extends AnnotationEditor {
           // See bug 1831574.
           ["ctrl+s", "mac+meta+s", "ctrl+p", "mac+meta+p"],
           FreeTextEditor.prototype.commitOrRemove,
-          /* bubbles = */ true,
+          { bubbles: true },
         ],
         [
           ["ctrl+Enter", "mac+meta+Enter", "Escape", "mac+Escape"],

--- a/src/display/editor/ink.js
+++ b/src/display/editor/ink.js
@@ -157,11 +157,6 @@ class InkEditor extends AnnotationEditor {
     ];
   }
 
-  /** @inheritdoc */
-  get resizeType() {
-    return AnnotationEditorParamsType.INK_DIMS;
-  }
-
   /**
    * Update the thickness and make this action undoable.
    * @param {number} thickness

--- a/src/display/editor/stamp.js
+++ b/src/display/editor/stamp.js
@@ -13,11 +13,8 @@
  * limitations under the License.
  */
 
-import {
-  AnnotationEditorParamsType,
-  AnnotationEditorType,
-} from "../../shared/util.js";
 import { AnnotationEditor } from "./editor.js";
+import { AnnotationEditorType } from "../../shared/util.js";
 import { PixelsPerInch } from "../display_utils.js";
 import { StampAnnotationElement } from "../annotation_layer.js";
 
@@ -124,11 +121,6 @@ class StampEditor extends AnnotationEditor {
     if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("TESTING")) {
       input.click();
     }
-  }
-
-  /** @inheritdoc */
-  get resizeType() {
-    return AnnotationEditorParamsType.STAMP_DIMS;
   }
 
   /** @inheritdoc */

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -77,14 +77,13 @@ const AnnotationEditorType = {
 };
 
 const AnnotationEditorParamsType = {
-  FREETEXT_SIZE: 1,
-  FREETEXT_COLOR: 2,
-  FREETEXT_OPACITY: 3,
-  INK_COLOR: 11,
-  INK_THICKNESS: 12,
-  INK_OPACITY: 13,
-  INK_DIMS: 14,
-  STAMP_DIMS: 21,
+  RESIZE: 1,
+  FREETEXT_SIZE: 11,
+  FREETEXT_COLOR: 12,
+  FREETEXT_OPACITY: 13,
+  INK_COLOR: 21,
+  INK_THICKNESS: 22,
+  INK_OPACITY: 23,
 };
 
 // Permission flags from Table 22, Section 7.6.3.2 of the PDF specification.

--- a/test/integration/test_utils.js
+++ b/test/integration/test_utils.js
@@ -137,13 +137,19 @@ const mockClipboard = async pages => {
 };
 exports.mockClipboard = mockClipboard;
 
-const getSerialized = page =>
-  page.evaluate(() => {
+async function getSerialized(page, filter = undefined) {
+  const values = await page.evaluate(() => {
     const { map } =
       window.PDFViewerApplication.pdfDocument.annotationStorage.serializable;
     return map ? [...map.values()] : [];
   });
+  return filter ? values.map(filter) : values;
+}
 exports.getSerialized = getSerialized;
+
+const getFirstSerialized = async (page, filter = undefined) =>
+  (await getSerialized(page, filter))[0];
+exports.getFirstSerialized = getFirstSerialized;
 
 function getEditors(page, kind) {
   return page.evaluate(aKind => {


### PR DESCRIPTION
Selected editors can be moved in using the arrows:
 - up/down/left/right will move the editors of 1 in page unit;
 - ctrl (or meta)+up/down/left/right will move them of 10 in page unit.