### PR TITLE
[Editor] Reduce a bit of duplication on `_keyboardManager` initialization

### DIFF
--- a/src/display/editor/freetext.js
+++ b/src/display/editor/freetext.js
@@ -65,9 +65,13 @@ class FreeTextEditor extends AnnotationEditor {
   static _defaultFontSize = 10;
 
   static get _keyboardManager() {
+    const proto = FreeTextEditor.prototype;
+
     const arrowChecker = self => self.isEmpty();
+
     const small = AnnotationEditorUIManager.TRANSLATE_SMALL;
     const big = AnnotationEditorUIManager.TRANSLATE_BIG;
+
     return shadow(
       this,
       "_keyboardManager",
@@ -77,51 +81,51 @@ class FreeTextEditor extends AnnotationEditor {
           // The event must bubble in order to be caught by the viewer.
           // See bug 1831574.
           ["ctrl+s", "mac+meta+s", "ctrl+p", "mac+meta+p"],
-          FreeTextEditor.prototype.commitOrRemove,
+          proto.commitOrRemove,
           { bubbles: true },
         ],
         [
           ["ctrl+Enter", "mac+meta+Enter", "Escape", "mac+Escape"],
-          FreeTextEditor.prototype.commitOrRemove,
+          proto.commitOrRemove,
         ],
         [
           ["ArrowLeft", "mac+ArrowLeft"],
-          FreeTextEditor.prototype._translateEmpty,
+          proto._translateEmpty,
           { args: [-small, 0], checker: arrowChecker },
         ],
         [
           ["ctrl+ArrowLeft", "mac+shift+ArrowLeft"],
-          FreeTextEditor.prototype._translateEmpty,
+          proto._translateEmpty,
           { args: [-big, 0], checker: arrowChecker },
         ],
         [
           ["ArrowRight", "mac+ArrowRight"],
-          FreeTextEditor.prototype._translateEmpty,
+          proto._translateEmpty,
           { args: [small, 0], checker: arrowChecker },
         ],
         [
           ["ctrl+ArrowRight", "mac+shift+ArrowRight"],
-          FreeTextEditor.prototype._translateEmpty,
+          proto._translateEmpty,
           { args: [big, 0], checker: arrowChecker },
         ],
         [
           ["ArrowUp", "mac+ArrowUp"],
-          FreeTextEditor.prototype._translateEmpty,
+          proto._translateEmpty,
           { args: [0, -small], checker: arrowChecker },
         ],
         [
           ["ctrl+ArrowUp", "mac+shift+ArrowUp"],
-          FreeTextEditor.prototype._translateEmpty,
+          proto._translateEmpty,
           { args: [0, -big], checker: arrowChecker },
         ],
         [
           ["ArrowDown", "mac+ArrowDown"],
-          FreeTextEditor.prototype._translateEmpty,
+          proto._translateEmpty,
           { args: [0, small], checker: arrowChecker },
         ],
         [
           ["ctrl+ArrowDown", "mac+shift+ArrowDown"],
-          FreeTextEditor.prototype._translateEmpty,
+          proto._translateEmpty,
           { args: [0, big], checker: arrowChecker },
         ],
       ])

--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -566,6 +566,8 @@ class AnnotationEditorUIManager {
   static TRANSLATE_BIG = 10; // page units.
 
   static get _keyboardManager() {
+    const proto = AnnotationEditorUIManager.prototype;
+
     const arrowChecker = self => {
       // If the focused element is an input, we don't want to handle the arrow.
       // For example, sliders can be controlled with the arrow keys.
@@ -576,17 +578,16 @@ class AnnotationEditorUIManager {
         self.hasSomethingToControl()
       );
     };
+
     const small = this.TRANSLATE_SMALL;
     const big = this.TRANSLATE_BIG;
+
     return shadow(
       this,
       "_keyboardManager",
       new KeyboardManager([
-        [
-          ["ctrl+a", "mac+meta+a"],
-          AnnotationEditorUIManager.prototype.selectAll,
-        ],
-        [["ctrl+z", "mac+meta+z"], AnnotationEditorUIManager.prototype.undo],
+        [["ctrl+a", "mac+meta+a"], proto.selectAll],
+        [["ctrl+z", "mac+meta+z"], proto.undo],
         [
           // On mac, depending of the OS version, the event.key is either "z" or
           // "Z" when the user presses "meta+shift+z".
@@ -597,7 +598,7 @@ class AnnotationEditorUIManager {
             "ctrl+shift+Z",
             "mac+meta+shift+Z",
           ],
-          AnnotationEditorUIManager.prototype.redo,
+          proto.redo,
         ],
         [
           [
@@ -613,50 +614,47 @@ class AnnotationEditorUIManager {
             "shift+Delete",
             "mac+Delete",
           ],
-          AnnotationEditorUIManager.prototype.delete,
+          proto.delete,
         ],
-        [
-          ["Escape", "mac+Escape"],
-          AnnotationEditorUIManager.prototype.unselectAll,
-        ],
+        [["Escape", "mac+Escape"], proto.unselectAll],
         [
           ["ArrowLeft", "mac+ArrowLeft"],
-          AnnotationEditorUIManager.prototype.translateSelectedEditors,
+          proto.translateSelectedEditors,
           { args: [-small, 0], checker: arrowChecker },
         ],
         [
           ["ctrl+ArrowLeft", "mac+shift+ArrowLeft"],
-          AnnotationEditorUIManager.prototype.translateSelectedEditors,
+          proto.translateSelectedEditors,
           { args: [-big, 0], checker: arrowChecker },
         ],
         [
           ["ArrowRight", "mac+ArrowRight"],
-          AnnotationEditorUIManager.prototype.translateSelectedEditors,
+          proto.translateSelectedEditors,
           { args: [small, 0], checker: arrowChecker },
         ],
         [
           ["ctrl+ArrowRight", "mac+shift+ArrowRight"],
-          AnnotationEditorUIManager.prototype.translateSelectedEditors,
+          proto.translateSelectedEditors,
           { args: [big, 0], checker: arrowChecker },
         ],
         [
           ["ArrowUp", "mac+ArrowUp"],
-          AnnotationEditorUIManager.prototype.translateSelectedEditors,
+          proto.translateSelectedEditors,
           { args: [0, -small], checker: arrowChecker },
         ],
         [
           ["ctrl+ArrowUp", "mac+shift+ArrowUp"],
-          AnnotationEditorUIManager.prototype.translateSelectedEditors,
+          proto.translateSelectedEditors,
           { args: [0, -big], checker: arrowChecker },
         ],
         [
           ["ArrowDown", "mac+ArrowDown"],
-          AnnotationEditorUIManager.prototype.translateSelectedEditors,
+          proto.translateSelectedEditors,
           { args: [0, small], checker: arrowChecker },
         ],
         [
           ["ctrl+ArrowDown", "mac+shift+ArrowDown"],
-          AnnotationEditorUIManager.prototype.translateSelectedEditors,
+          proto.translateSelectedEditors,
           { args: [0, big], checker: arrowChecker },
         ],
       ])


### PR DESCRIPTION
The way that the callback-methods are specified feels unnecessarily verbose, however we can introduce a short-hand to improve this.

Also, adds a couple of new-lines to improve overall readability.