### PR TITLE
Avoid eagerly matching "trailer"-strings when searching for incomplete objects in `XRef.indexObjects` (issue 16759, PR 15854 follow-up, bug 1845762)

### DIFF
--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -431,7 +431,7 @@ class XRef {
       }
       return skipped;
     }
-    const gEndobjRegExp = /\b(endobj|\d+\s+\d+\s+obj|xref|trailer)\b/g;
+    const gEndobjRegExp = /\b(endobj|\d+\s+\d+\s+obj|xref|trailer\s*<<)\b/g;
     const gStartxrefRegExp = /\b(startxref|\d+\s+\d+\s+obj)\b/g;
     const objRegExp = /^(\d+)\s+(\d+)\s+obj\b/;
 

--- a/test/pdfs/issue16759.pdf.link
+++ b/test/pdfs/issue16759.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/12185373/issue16759.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1844,6 +1844,14 @@
        "type": "eq",
        "annotations": true
     },
+    {  "id": "issue16759",
+       "file": "pdfs/issue16759.pdf",
+       "md5": "07d97ae84f3d757e7ed20c628b94ecd5",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue9105_other",
        "file": "pdfs/issue9105_other.pdf",
        "md5": "4c8b9c2cceb9c5d621e1d50b3dc38efc",


### PR DESCRIPTION
When searching for "endobj"-operators, make sure that we don't accidentally match a "trailer"-string in /Content-streams without /Filter-entries (i.e. streams that contain "raw" and thus human-readable data).