### PR TITLE
Add an `eq` test for bug 858128

### DIFF
--- a/test/pdfs/bug858128.pdf.link
+++ b/test/pdfs/bug858128.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=733434

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -496,6 +496,14 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "bug858128",
+       "file": "pdfs/bug858128.pdf",
+       "md5": "46c7e78250b623782832801d4e6de2dc",
+       "link": true,
+       "lastPage": 1,
+       "rounds": 1,
+       "type": "eq"
+    },
     {  "id": "bug859204",
        "file": "pdfs/bug859204.pdf",
        "md5": "ac1ea1dbfa6ac9d5b13167483049af0b",


### PR DESCRIPTION
The ten year old bug 858128 was recently fixed upstream, see https://bugzilla.mozilla.org/show_bug.cgi?id=858128#c25, and it seems like a good idea for us to add a test-case to help catch any future regressions here.