### PR TITLE
Ensure that failing to open the password dialog once won't permanently disable it (PR 15335 follow-up)

### DIFF
--- a/web/password_prompt.js
+++ b/web/password_prompt.js
@@ -74,7 +74,7 @@ class PasswordPrompt {
     try {
       await this.overlayManager.open(this.dialog);
     } catch (ex) {
-      this.#activeCapability = null;
+      this.#activeCapability.resolve();
       throw ex;
     }
 


### PR DESCRIPTION
*Please note:* This situation should never happen in practice, but it nonetheless cannot hurt to fix this.

If the `PasswordPrompt.open` method would ever be called synchronously back-to-back *and* if opening of the dialog fails the first time, then the second invocation would remain pending indefinitely since we just clear out the capability.