### PR TITLE
Fix typo in the `baseVersion` commit hash (PR 16769 follow-up)

### DIFF
--- a/pdfjs.config
+++ b/pdfjs.config
@@ -1,5 +1,5 @@
 {
   "stableVersion": "3.9.179",
-  "baseVersion": "1ef6fbc525856318e78a6035b200ba1c6ec02d491",
+  "baseVersion": "1ef6fbc525856318e78a6035b200ba1c6ec02d49",
   "versionPrefix": "3.10."
 }


### PR DESCRIPTION
Looking at the demo-viewer I noticed that the version number seems to be stuck at version `3.10.0` despite a couple of PRs having landed since the version bump in PR #16769.

Searching for the current `baseVersion` doesn't find an actual commit, see https://github.com/search?q=repo%3Amozilla%2Fpdf.js+1ef6fbc525856318e78a6035b200ba1c6ec02d491&type=commits

However, looking at the commit hash it seems to be too long and removing the trailing `1` appears to fix things; see https://github.com/search?q=repo%3Amozilla%2Fpdf.js+1ef6fbc525856318e78a6035b200ba1c6ec02d49&type=commits