### PR TITLE
[api-minor] Deprecate the `PDFDocumentProxy.getJavaScript` method

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -987,7 +987,10 @@ class Catalog {
         return;
       }
       js = stringToPDFString(js).replaceAll("\x00", "");
-      (javaScript ||= new Map()).set(name, js);
+      // Skip empty entries, similar to the `_collectJS` function.
+      if (js) {
+        (javaScript ||= new Map()).set(name, js);
+      }
     }
 
     if (obj instanceof Dict && obj.has("JavaScript")) {
@@ -1005,15 +1008,6 @@ class Catalog {
     return javaScript;
   }
 
-  get javaScript() {
-    const javaScript = this._collectJavaScript();
-    return shadow(
-      this,
-      "javaScript",
-      javaScript ? [...javaScript.values()] : null
-    );
-  }
-
   get jsActions() {
     const javaScript = this._collectJavaScript();
     let actions = collectActions(
@@ -1023,9 +1017,8 @@ class Catalog {
     );
 
     if (javaScript) {
-      if (!actions) {
-        actions = Object.create(null);
-      }
+      actions ||= Object.create(null);
+
       for (const [key, val] of javaScript) {
         if (key in actions) {
           actions[key].push(val);

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -463,10 +463,6 @@ class WorkerMessageHandler {
       return pdfManager.ensureCatalog("attachments");
     });
 
-    handler.on("GetJavaScript", function (data) {
-      return pdfManager.ensureCatalog("javaScript");
-    });
-
     handler.on("GetDocJSActions", function (data) {
       return pdfManager.ensureCatalog("jsActions");
     });

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -760,6 +760,26 @@ class PDFDocumentProxy {
     this._pdfInfo = pdfInfo;
     this._transport = transport;
 
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+      Object.defineProperty(this, "getJavaScript", {
+        value: () => {
+          deprecated(
+            "`PDFDocumentProxy.getJavaScript`, " +
+              "please use `PDFDocumentProxy.getJSActions` instead."
+          );
+          return this.getJSActions().then(js => {
+            if (!js) {
+              return js;
+            }
+            const jsArr = [];
+            for (const name in js) {
+              jsArr.push(...js[name]);
+            }
+            return jsArr;
+          });
+        },
+      });
+    }
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       // For testing purposes.
       Object.defineProperty(this, "getXFADatasets", {
@@ -918,18 +938,9 @@ class PDFDocumentProxy {
   }
 
   /**
-   * @returns {Promise<Array<string> | null>} A promise that is resolved with
-   *   an {Array} of all the JavaScript strings in the name tree, or `null`
-   *   if no JavaScript exists.
-   */
-  getJavaScript() {
-    return this._transport.getJavaScript();
-  }
-
-  /**
    * @returns {Promise<Object | null>} A promise that is resolved with
    *   an {Object} with the JavaScript actions:
-   *     - from the name tree (like getJavaScript);
+   *     - from the name tree.
    *     - from A or AA entries in the catalog dictionary.
    *   , or `null` if no JavaScript exists.
    */
@@ -3014,10 +3025,6 @@ class WorkerTransport {
 
   getAttachments() {
     return this.messageHandler.sendWithPromise("GetAttachments", null);
-  }
-
-  getJavaScript() {
-    return this.messageHandler.sendWithPromise("GetJavaScript", null);
   }
 
   getDocJSActions() {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1358,21 +1358,16 @@ describe("api", function () {
       await loadingTask.destroy();
     });
 
-    it("gets javascript", async function () {
-      const javascript = await pdfDocument.getJavaScript();
-      expect(javascript).toEqual(null);
-    });
-
     it("gets javascript with printing instructions (JS action)", async function () {
       // PDF document with "JavaScript" action in the OpenAction dictionary.
       const loadingTask = getDocument(buildGetDocumentParams("issue6106.pdf"));
       const pdfDoc = await loadingTask.promise;
-      const javascript = await pdfDoc.getJavaScript();
+      const { OpenAction } = await pdfDoc.getJSActions();
 
-      expect(javascript).toEqual([
+      expect(OpenAction).toEqual([
         "this.print({bUI:true,bSilent:false,bShrinkToFit:true});",
       ]);
-      expect(javascript[0]).toMatch(AutoPrintRegExp);
+      expect(OpenAction[0]).toMatch(AutoPrintRegExp);
 
       await loadingTask.destroy();
     });


### PR DESCRIPTION
This method is very old, however with the exception of the auto-print hack (when scripting is disabled) in the viewer it's never actually been used.

Most likely the idea with `PDFDocumentProxy.getJavaScript` was that it'd be useful if scripting support was added, however it turned out that it was a bit too simplistic and instead a number of new methods were added for the scripting use-cases.