### PR TITLE
Ignore non-existing default icons for FileAttachment annotations (issue 16800)

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -2798,8 +2798,12 @@ class FileAttachmentAnnotationElement extends AnnotationElement {
   render() {
     this.container.classList.add("fileAttachmentAnnotation");
 
+    const { data } = this;
+    const m = /paperclip|pushpin/.exec(data.name.toLowerCase());
+    const imgName = m?.[0];
+
     let trigger;
-    if (this.data.hasAppearance) {
+    if (data.hasAppearance || !imgName) {
       trigger = document.createElement("div");
     } else {
       // Unfortunately it seems that it's not clearly specified exactly what
@@ -2808,19 +2812,15 @@ class FileAttachmentAnnotationElement extends AnnotationElement {
       //   least the following standard names: GraphPushPin, PaperclipTag.
       //   Additional names may be supported as well. Default value: PushPin.
       trigger = document.createElement("img");
-      trigger.src = `${this.imageResourcesPath}annotation-${
-        /paperclip/i.test(this.data.name) ? "paperclip" : "pushpin"
-      }.svg`;
+      trigger.src = `${this.imageResourcesPath}annotation-${imgName}.svg`;
     }
     trigger.classList.add("popupTriggerArea");
     trigger.addEventListener("dblclick", this._download.bind(this));
     this.#trigger = trigger;
 
     if (
-      !this.data.popupRef &&
-      (this.data.titleObj?.str ||
-        this.data.contentsObj?.str ||
-        this.data.richText)
+      !data.popupRef &&
+      (data.titleObj?.str || data.contentsObj?.str || data.richText)
     ) {
       this._createPopup();
     }

--- a/test/pdfs/issue16800.pdf.link
+++ b/test/pdfs/issue16800.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/12287878/TS354.Week.2.slides.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -6270,6 +6270,16 @@
        "type": "eq",
        "annotations": true
     },
+    {  "id": "issue16800",
+       "file": "pdfs/issue16800.pdf",
+       "md5": "771bc170a55f923d7903af28ccca196c",
+       "link": true,
+       "rounds": 1,
+       "firstPage": 2,
+       "lastPage": 2,
+       "type": "eq",
+       "annotations": true
+    },
     {  "id": "issue14117",
        "file": "pdfs/issue14117.pdf",
        "md5": "9b1c33ad2f59f4e723c258e863149abf",


### PR DESCRIPTION
The FileAttachment annotations in the referenced PDF document have /Graph Name-entries, which is a type that we don't provide a default icon for; see PR #15747.
In that case, since a non-existent icon is explicitly specified, it seems reasonable to fallback to no icon rather than "PushPin" as we currently do.