### PR TITLE
[Editor] Move an the editor div in the DOM once a translation with the keyboard is done

### DIFF
--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -50,6 +50,8 @@ class AnnotationEditor {
 
   _uiManager = null;
 
+  _focusEventsAllowed = true;
+
   #isDraggable = false;
 
   #zIndex = AnnotationEditor._zIndex++;
@@ -190,6 +192,9 @@ class AnnotationEditor {
    * onfocus callback.
    */
   focusin(event) {
+    if (!this._focusEventsAllowed) {
+      return;
+    }
     if (!this.#hasBeenSelected) {
       this.parent.setSelected(this);
     } else {
@@ -202,6 +207,10 @@ class AnnotationEditor {
    * @param {FocusEvent} event
    */
   focusout(event) {
+    if (!this._focusEventsAllowed) {
+      return;
+    }
+
     if (!this.isAttachedToDOM) {
       return;
     }
@@ -284,6 +293,7 @@ class AnnotationEditor {
    */
   translateInPage(x, y) {
     this.#translate(this.pageDimensions, x, y);
+    this.parent.moveEditorInDOM(this);
     this.div.scrollIntoView({ block: "nearest" });
   }
 
@@ -790,7 +800,6 @@ class AnnotationEditor {
 
       this.fixAndSetPosition();
       this.parent.moveEditorInDOM(this);
-      this.div.focus();
     };
     window.addEventListener("pointerup", pointerUpCallback);
     // If the user is using alt+tab during the dragging session, the pointerup

--- a/src/display/editor/freetext.js
+++ b/src/display/editor/freetext.js
@@ -342,6 +342,9 @@ class FreeTextEditor extends AnnotationEditor {
 
   /** @inheritdoc */
   focusin(event) {
+    if (!this._focusEventsAllowed) {
+      return;
+    }
     super.focusin(event);
     if (event.target !== this.editorDiv) {
       this.editorDiv.focus();

--- a/src/display/editor/ink.js
+++ b/src/display/editor/ink.js
@@ -634,6 +634,9 @@ class InkEditor extends AnnotationEditor {
 
   /** @inheritdoc */
   focusin(event) {
+    if (!this._focusEventsAllowed) {
+      return;
+    }
     super.focusin(event);
     this.enableEditMode();
   }

--- a/test/integration/ink_editor_spec.js
+++ b/test/integration/ink_editor_spec.js
@@ -50,23 +50,28 @@ describe("Ink Editor", () => {
             await page.mouse.down();
             await page.mouse.move(x + 50, y + 50);
             await page.mouse.up();
+            await page.waitForTimeout(10);
 
             await page.keyboard.press("Escape");
+            await page.waitForTimeout(10);
           }
 
           await page.keyboard.down("Control");
           await page.keyboard.press("a");
           await page.keyboard.up("Control");
+          await page.waitForTimeout(10);
 
           expect(await getSelectedEditors(page))
             .withContext(`In ${browserName}`)
             .toEqual([0, 1, 2]);
 
           await page.keyboard.press("Backspace");
+          await page.waitForTimeout(10);
 
           await page.keyboard.down("Control");
           await page.keyboard.press("z");
           await page.keyboard.up("Control");
+          await page.waitForTimeout(10);
 
           expect(await getSelectedEditors(page))
             .withContext(`In ${browserName}`)
@@ -81,8 +86,10 @@ describe("Ink Editor", () => {
           await page.keyboard.down("Control");
           await page.keyboard.press("a");
           await page.keyboard.up("Control");
+          await page.waitForTimeout(10);
 
           await page.keyboard.press("Backspace");
+          await page.waitForTimeout(10);
 
           const rect = await page.$eval(".annotationEditorLayer", el => {
             // With Chrome something is wrong when serializing a DomRect,
@@ -97,8 +104,10 @@ describe("Ink Editor", () => {
           await page.mouse.down();
           await page.mouse.move(xStart + 50, yStart + 50);
           await page.mouse.up();
+          await page.waitForTimeout(10);
 
           await page.keyboard.press("Escape");
+          await page.waitForTimeout(10);
 
           const rectBefore = await page.$eval(".inkEditor canvas", el => {
             const { x, y } = el.getBoundingClientRect();


### PR DESCRIPTION
When moving an element in the DOM, the focus is potentially lost, so we need to make sure that the focused element before the translation will get back its focus after it. But we must take care to not execute any focus/blur callbacks because the user didn't do anything which should trigger such events: it's a detail of implementation. For example, when several editors are selected and moved, then at the end the same must be selected, so no element receive a focus event which will set it as selected.