### PR TITLE
[Editor] Avoid to add a cancelled added image in the undo/redo stack

### DIFF
--- a/src/display/editor/stamp.js
+++ b/src/display/editor/stamp.js
@@ -38,6 +38,8 @@ class StampEditor extends AnnotationEditor {
 
   #isSvg = false;
 
+  #hasBeenAddedInUndoStack = false;
+
   static _type = "stamp";
 
   constructor(params) {
@@ -178,7 +180,6 @@ class StampEditor extends AnnotationEditor {
   /** @inheritdoc */
   onceAdded() {
     this._isDraggable = true;
-    this.parent.addUndoableEditor(this);
     this.div.focus();
   }
 
@@ -263,6 +264,10 @@ class StampEditor extends AnnotationEditor {
     this.#drawBitmap(width, height);
     this.#createObserver();
     div.classList.remove("loading");
+    if (!this.#hasBeenAddedInUndoStack) {
+      this.parent.addUndoableEditor(this);
+      this.#hasBeenAddedInUndoStack = true;
+    }
   }
 
   /**


### PR DESCRIPTION
We're adding the action in the undo/redo stack whatever the status of the operation was. This patch aims to add the action only when the image has been successfully added.