### PR TITLE
[Editor] Remove the stamp editor displayed when the image was loading (bug 1848313)

### DIFF
--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -547,6 +547,8 @@ class AnnotationEditorUIManager {
 
   #isEnabled = false;
 
+  #isWaiting = false;
+
   #lastActiveElement = null;
 
   #mode = AnnotationEditorType.NONE;
@@ -1156,6 +1158,21 @@ class AnnotationEditorUIManager {
 
     for (const editorType of this.#editorTypes) {
       editorType.updateDefaultParams(type, value);
+    }
+  }
+
+  enableWaiting(mustWait = false) {
+    if (this.#isWaiting === mustWait) {
+      return;
+    }
+    this.#isWaiting = mustWait;
+    for (const layer of this.#allLayers.values()) {
+      if (mustWait) {
+        layer.disableClick();
+      } else {
+        layer.enableClick();
+      }
+      layer.div.classList.toggle("waiting", mustWait);
     }
   }
 

--- a/test/integration/stamp_editor_spec.js
+++ b/test/integration/stamp_editor_spec.js
@@ -15,9 +15,7 @@
 
 const {
   closePages,
-  dragAndDropAnnotation,
   getEditorDimensions,
-  getEditorSelector,
   loadAndWait,
   serializeBitmapDimensions,
   waitForAnnotationEditorLayer,
@@ -109,68 +107,6 @@ describe("Stamp Editor", () => {
           await page.waitForTimeout(10);
 
           await page.keyboard.press("Backspace");
-        })
-      );
-    });
-  });
-
-  describe("Page overflow", () => {
-    let pages;
-
-    beforeAll(async () => {
-      pages = await loadAndWait("empty.pdf", ".annotationEditorLayer", 50);
-    });
-
-    afterAll(async () => {
-      await closePages(pages);
-    });
-
-    it("must check that an added image stay within the page", async () => {
-      await Promise.all(
-        pages.map(async ([browserName, page]) => {
-          if (browserName === "firefox") {
-            // Disabled in Firefox, because of https://bugzilla.mozilla.org/1553847.
-            return;
-          }
-
-          await page.click("#editorStamp");
-          await page.click("#editorStampAddImage");
-
-          const rect = await page.$eval(".annotationEditorLayer", el => {
-            // With Chrome something is wrong when serializing a DomRect,
-            // hence we extract the values and just return them.
-            const { right, bottom } = el.getBoundingClientRect();
-            return { x: right, y: bottom };
-          });
-
-          const editorRect = await page.$eval(getEditorSelector(0), el => {
-            // With Chrome something is wrong when serializing a DomRect,
-            // hence we extract the values and just return them.
-            const { x, y } = el.getBoundingClientRect();
-            return { x, y };
-          });
-
-          const input = await page.$("#stampEditorFileInput");
-          await input.uploadFile(
-            `${path.join(__dirname, "../images/firefox_logo.png")}`
-          );
-
-          await page.waitForTimeout(300);
-
-          await dragAndDropAnnotation(
-            page,
-            editorRect.x + 10,
-            editorRect.y + 10,
-            rect.x - 10,
-            rect.y - 10
-          );
-          await page.waitForTimeout(10);
-
-          const { left } = await getEditorDimensions(page, 0);
-
-          // The image is bigger than the page, so it has been scaled down to
-          // 75% of the page width.
-          expect(left).toEqual("25%");
         })
       );
     });

--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -72,6 +72,15 @@
   z-index: 4;
 }
 
+.annotationEditorLayer.waiting {
+  content: "";
+  cursor: wait;
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
 .annotationEditorLayer.freeTextEditing {
   cursor: var(--editorFreeText-editing-cursor);
 }
@@ -166,19 +175,6 @@
 .annotationEditorLayer .stampEditor {
   width: auto;
   height: auto;
-}
-
-.annotationEditorLayer .stampEditor.loading {
-  aspect-ratio: 1;
-  width: 10%;
-  height: auto;
-  background-color: rgba(128, 128, 128, 0.5);
-  background-image: var(--loading-icon);
-  background-repeat: no-repeat;
-  background-position: 50%;
-  background-size: 16px 16px;
-  transition-property: background-size;
-  transition-delay: var(--loading-icon-delay);
 }
 
 .annotationEditorLayer .stampEditor canvas {


### PR DESCRIPTION
Make the annotation editor layer unclickable while the image is loading and change the cursor to 'wait'.