### PR TITLE
Remove the `src/core/` Babel excludes, since they no longer seem necessary

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -202,13 +202,9 @@ function createWebpackConfig(
     !disableSourceMaps;
   const skipBabel = bundleDefines.SKIP_BABEL;
 
-  // `core-js` (see https://github.com/zloirock/core-js/issues/514), and
-  // `src/core/{glyphlist,unicode}.js` (Babel is too slow for those when
-  // source-maps are enabled) should be excluded from processing.
+  // `core-js`, see https://github.com/zloirock/core-js/issues/514,
+  // should be excluded from processing.
   const babelExcludes = ["node_modules[\\\\\\/]core-js"];
-  if (enableSourceMaps) {
-    babelExcludes.push("src[\\\\\\/]core[\\\\\\/](glyphlist|unicode)");
-  }
   const babelExcludeRegExp = new RegExp(`(${babelExcludes.join("|")})`);
 
   const babelPresets = skipBabel


### PR DESCRIPTION
 - The `src/core/unicode.js` exclude ought to have become unnecessary already with PR #16200, which significantly shortened and simplified that file.
 - The `src/core/glyphlist.js` exclude no longer seems necessary in practice either, possibly because of improvements in Babel.