### PR TITLE
Remove the "no-babel-preset" comment used with the LIB build-target (PR 16829 follow-up)

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -1586,8 +1586,7 @@ function buildLibHelper(bundleDefines, inputStream, outputDir) {
     };
   }
   function preprocess(content) {
-    const skipBabel =
-      bundleDefines.SKIP_BABEL || /\/\*\s*no-babel-preset\s*\*\//.test(content);
+    const skipBabel = bundleDefines.SKIP_BABEL;
     content = preprocessPDFJSCode(ctx, content);
     content = babel.transform(content, {
       sourceType: "module",

--- a/src/core/glyphlist.js
+++ b/src/core/glyphlist.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* no-babel-preset */
 
 import { getLookupTableFactory } from "./core_utils.js";
 


### PR DESCRIPTION
Similar to the changes in PR #16829, this no longer seems necessary now.