### PR TITLE
Improve the "write a new annotation, save the pdf and check that the text content is correct" unit-test (PR 16559 follow-up)

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -2203,8 +2203,14 @@ describe("api", function () {
       We have learned that we should more explicitly set out our aspirations for the human experience of the internet.
       We do so now.
       `.repeat(100);
+      expect(manifesto.length).toEqual(80500);
+
       let loadingTask = getDocument(buildGetDocumentParams("empty.pdf"));
       let pdfDoc = await loadingTask.promise;
+      // The initial document size (indirectly) affects the length check below.
+      let typedArray = await pdfDoc.getData();
+      expect(typedArray.length).toBeLessThan(5000);
+
       pdfDoc.annotationStorage.setValue("pdfjs_internal_editor_0", {
         annotationType: AnnotationEditorType.FREETEXT,
         rect: [10, 10, 500, 500],
@@ -2214,12 +2220,15 @@ describe("api", function () {
         value: manifesto,
         pageIndex: 0,
       });
-
       const data = await pdfDoc.saveDocument();
       await loadingTask.destroy();
 
       loadingTask = getDocument(data);
       pdfDoc = await loadingTask.promise;
+      // Ensure that the Annotation text-content was actually compressed.
+      typedArray = await pdfDoc.getData();
+      expect(typedArray.length).toBeLessThan(90000);
+
       const page = await pdfDoc.getPage(1);
       const annotations = await page.getAnnotations();
 


### PR DESCRIPTION
Currently this unit-test will pass just fine if compression is disabled, e.g. by commenting out the relevant code in the `src/core/writer.js` file.
While we don't have a simple way of *directly* checking that the Annotation text-content is compressed, we can however use the resulting file-size as a fairly good proxy. (Note that if compression is disabled the file-size is more than doubled.)