### PR TITLE
Update the `StampEditor.isEmpty` method to handle File (PR 16828 follow-up)

### DIFF
--- a/src/display/editor/stamp.js
+++ b/src/display/editor/stamp.js
@@ -249,10 +249,11 @@ class StampEditor extends AnnotationEditor {
 
   /** @inheritdoc */
   isEmpty() {
-    return (
-      this.#bitmapPromise === null &&
-      this.#bitmap === null &&
-      this.#bitmapUrl === null
+    return !(
+      this.#bitmapPromise ||
+      this.#bitmap ||
+      this.#bitmapUrl ||
+      this.#bitmapFile
     );
   }
 


### PR DESCRIPTION
After the changes in PR #16828 the `StampEditor` can now be initialized with a File, in addition to a URL, hence it seems that the `isEmpty` method ought to take that property into account as well.

Looking at this I also noticed that the assignment in the constructor may cause the `this.#bitmapUrl`/`this.#bitmapFile` fields be `undefined` which "breaks" the comparisons in the `isEmpty` method.
We could obviously fix those specific cases, but it seemed overall safer (with future changes) to just update the `isEmpty` method to be less sensitive to exactly how these fields are initialized and reset.