### PR TITLE
[Type-definitions] Hack around the broken `SVGGraphics` import map (issue 16705)

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -2475,6 +2475,7 @@ gulp.task(
   "ci-test",
   gulp.series(
     gulp.parallel("lint", "externaltest", "unittestcli"),
-    "lint-chromium"
+    "lint-chromium",
+    "typestest"
   )
 );

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -14,6 +14,10 @@
  */
 
 /**
+ * @ignore @typedef { import("./svg.js").SVGGraphics } SVGGraphics
+ */
+
+/**
  * @module pdfjsLib
  */
 


### PR DESCRIPTION
Previous attempts at "importing" the `@typedef` caused the JSDoc-generation to fail, however it seems that prepending it with `@ignore` causes JSDoc to completely skip the rest of the line while TypeScript will (seemingly) parse the `@typedef` as usual.
While both `gulp jsdoc` and `gulp typestest` pass with this patch, it's unfortunately nothing more than a crude work-around for the actual issue.

This way of "fixing" issue #16705 does feel very undesirable, for a number of reasons:
 - It does nothing to address the underlying issue, i.e. that the Type-generation doesn't understand the import maps, which means that the same problem could resurface somewhere else in the code-base next week/month.
 - It feels very arbitrary/brittle, since a future update of JSDoc and/or TypeScript could very easily break this hack.
 - It further increases the maintenance burden for the Type-generation, when the opposite would be desirable here. (Since it's already very difficult to get TypeScript users to *actively* help with maintaining this code.)