### PR TITLE
Add the "aria-controls" attribute to the StampEditor toolbar-button

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -351,7 +351,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                   <button id="editorInk" class="toolbarButton" disabled="disabled" title="Draw" role="radio" aria-checked="false" aria-controls="editorInkParamsToolbar" tabindex="35" data-l10n-id="editor_ink2">
                     <span data-l10n-id="editor_ink2_label">Draw</span>
                   </button>
-                  <button id="editorStamp" class="toolbarButton hidden" disabled="disabled" title="Add or edit images" role="radio" aria-checked="false" tabindex="36" data-l10n-id="editor_stamp1">
+                  <button id="editorStamp" class="toolbarButton hidden" disabled="disabled" title="Add or edit images" role="radio" aria-checked="false" aria-controls="editorStampParamsToolbar" tabindex="36" data-l10n-id="editor_stamp1">
                     <span data-l10n-id="editor_stamp1_label">Add or edit images</span>
                   </button>
                 </div>


### PR DESCRIPTION
Given that the other Editor toolbar-buttons use this attribute, it seems that the StampEditor should as well.