### PR TITLE
BUG | fixing cache "not modified" response

### DIFF
--- a/src/display/network_utils.js
+++ b/src/display/network_utils.js
@@ -94,7 +94,7 @@ function createResponseStatusError(status, url) {
 }
 
 function validateResponseStatus(status) {
-  return status === 200 || status === 206;
+  return [200,206,304].includes(status);
 }
 
 export {


### PR DESCRIPTION
When resource or document is cached and called again the 304 Not Modified is returned.
This should be accepted in validateResponseStatus