### PR TITLE
Add the `.mjs` file-extension to the EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[*.{js,jsm,json,html,css,pdf.link}]
+[*.{js,jsm,mjs,json,html,css,pdf.link}]
 charset = utf-8
 end_of_line = lf
 indent_size = 2


### PR DESCRIPTION
Given that this file-extension is used for JavaScript modules, those files should obviously be formatted just like any "normal" JS file.