### PR TITLE
Don't reset all fields when the resetForm argument is an array

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -3190,6 +3190,9 @@ class ButtonWidgetAnnotation extends WidgetAnnotation {
       this._streams.push(this.uncheckedAppearance);
     }
     this._fallbackFontDict = this.fallbackFontDict;
+    if (this.data.defaultFieldValue === null) {
+      this.data.defaultFieldValue = "Off";
+    }
   }
 
   _processRadioButton(params) {
@@ -3238,6 +3241,9 @@ class ButtonWidgetAnnotation extends WidgetAnnotation {
       this._streams.push(this.uncheckedAppearance);
     }
     this._fallbackFontDict = this.fallbackFontDict;
+    if (this.data.defaultFieldValue === null) {
+      this.data.defaultFieldValue = "Off";
+    }
   }
 
   _processPushButton(params) {

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -373,11 +373,7 @@ class AnnotationElement {
         event.target.title = event.detail.userName;
       },
       readonly: event => {
-        if (event.detail.readonly) {
-          event.target.setAttribute("readonly", "");
-        } else {
-          event.target.removeAttribute("readonly");
-        }
+        event.target.disabled = event.detail.readonly;
       },
       required: event => {
         this._setRequired(event.target, event.detail.required);

--- a/src/scripting_api/doc.js
+++ b/src/scripting_api/doc.js
@@ -1185,7 +1185,7 @@ class Doc extends PDFObject {
 
   resetForm(aFields = null) {
     // Handle the case resetForm({ aFields: ... })
-    if (aFields && typeof aFields === "object") {
+    if (aFields && typeof aFields === "object" && !Array.isArray(aFields)) {
       aFields = aFields.aFields;
     }
 

--- a/test/integration/scripting_spec.js
+++ b/test/integration/scripting_spec.js
@@ -2098,4 +2098,60 @@ describe("Interaction", () => {
       );
     });
   });
+
+  describe("in issue16863.pdf", () => {
+    let pages;
+
+    beforeAll(async () => {
+      pages = await loadAndWait("issue16863.pdf", getSelector("334R"));
+    });
+
+    afterAll(async () => {
+      await closePages(pages);
+    });
+
+    it("must check that checkboxes are correctly resetted", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          await page.waitForFunction(
+            "window.PDFViewerApplication.scriptingReady === true"
+          );
+
+          let readonly = await page.$eval(
+            getSelector("353R"),
+            el => el.disabled
+          );
+          expect(readonly).withContext(`In ${browserName}`).toEqual(true);
+          await page.click(getSelector("334R"));
+          await page.waitForTimeout(10);
+
+          readonly = await page.$eval(getSelector("353R"), el => el.disabled);
+          expect(readonly).withContext(`In ${browserName}`).toEqual(true);
+          await page.click(getSelector("351R"));
+          await page.waitForTimeout(10);
+
+          readonly = await page.$eval(getSelector("353R"), el => el.disabled);
+          expect(readonly).withContext(`In ${browserName}`).toEqual(true);
+          await page.click(getSelector("352R"));
+          await page.waitForTimeout(10);
+
+          readonly = await page.$eval(getSelector("353R"), el => el.disabled);
+          expect(readonly).withContext(`In ${browserName}`).toEqual(false);
+
+          await page.click(getSelector("353R"));
+          await page.waitForTimeout(10);
+
+          let checked = await page.$eval(getSelector("353R"), el => el.checked);
+          expect(checked).withContext(`In ${browserName}`).toEqual(true);
+          await page.click(getSelector("334R"));
+          await page.waitForTimeout(10);
+
+          readonly = await page.$eval(getSelector("353R"), el => el.disabled);
+          expect(readonly).withContext(`In ${browserName}`).toEqual(true);
+          checked = await page.$eval(getSelector("353R"), el => el.checked);
+          expect(checked).withContext(`In ${browserName}`).toEqual(false);
+        })
+      );
+    });
+  });
 });

--- a/test/pdfs/issue16863.pdf.link
+++ b/test/pdfs/issue16863.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/12422360/4422-84.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -8119,5 +8119,12 @@
           "rotation": 0
        }
      }
+   },
+   {
+      "id": "issue16863",
+      "file": "pdfs/issue16863.pdf",
+      "md5": "af8abe281721f92a0d46646969f061de",
+      "link": true,
+      "type": "other"
    }
 ]


### PR DESCRIPTION
correctly set the readonly property in the annotation layer and set the default checkbox value to Off when none is provided.