### PR TITLE
 Removed .grab-to-pan-grab:active to resolve toolbars going behind canvas issue (issue 5452)

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1365,7 +1365,7 @@ dialog :link {
   *:not(input):not(textarea):not(button):not(select):not(:link) {
   cursor: inherit !important;
 }
-.grab-to-pan-grab:active,
+
 .grab-to-pan-grabbing {
   cursor: grabbing !important;
   position: fixed;


### PR DESCRIPTION
 Removed .grab-to-pan-grab:active to resolve toolbars going behind canvas issue (issue 5452).

While my fix was targeted toward the secondaryToolbar, I noticed that the issue regarding the toolbars going behind the canvas on using the hand tool persisted for the findToolbar as well. This was because the viewerContainer div had alot of unnecessary styling applied to it via .grab-to-pan-grab:active. On applying those rules to .grab-to-pan-grabbing alone the issue was resolved.
I tested the fix extensively in Chrome, Firefox and Brave with no issues seen.

This is a fix for #5452