### PR TITLE
Simplify the non-OffscreenCanvas path in `putBinaryImageMask` function

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -716,35 +716,19 @@ function putBinaryImageMask(ctx, imgData) {
   }
 
   // Slow path: OffscreenCanvas isn't available in the worker.
-  const height = imgData.height,
-    width = imgData.width;
-  const partialChunkHeight = height % FULL_CHUNK_HEIGHT;
-  const fullChunks = (height - partialChunkHeight) / FULL_CHUNK_HEIGHT;
-  const totalChunks = partialChunkHeight === 0 ? fullChunks : fullChunks + 1;
+  const { width, height, data: src } = imgData;
 
-  const chunkImgData = ctx.createImageData(width, FULL_CHUNK_HEIGHT);
-  let srcPos = 0;
-  const src = imgData.data;
-  const dest = chunkImgData.data;
+  const fullImageData = ctx.createImageData(width, height);
+  const dest = fullImageData.data;
 
-  for (let i = 0; i < totalChunks; i++) {
-    const thisChunkHeight =
-      i < fullChunks ? FULL_CHUNK_HEIGHT : partialChunkHeight;
-
-    // Expand the mask so it can be used by the canvas.  Any required
-    // inversion has already been handled.
-
-    ({ srcPos } = convertBlackAndWhiteToRGBA({
-      src,
-      srcPos,
-      dest,
-      width,
-      height: thisChunkHeight,
-      nonBlackColor: 0,
-    }));
-
-    ctx.putImageData(chunkImgData, 0, i * FULL_CHUNK_HEIGHT);
-  }
+  convertBlackAndWhiteToRGBA({
+    src,
+    dest,
+    width,
+    height,
+    nonBlackColor: 0,
+  });
+  ctx.putImageData(fullImageData, 0, 0);
 }
 
 function copyCtxState(sourceCtx, destCtx) {


### PR DESCRIPTION
In modern browsers we now use `OffscreenCanvas` by default when rendering e.g. /ImageMask-objects, and we should thus be able to simplify the `putBinaryImageMask` function in `src/display/canvas.js`.
Similar to the helper function used when rendering "normal" image-objects the "chunking" was implemented to reduce memory usage, however that seems less necessary nowadays that `OffscreenCanvas` is being used. Hence this patch will only affect older browsers and Node.js environments; refer to https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas#browser_compatibility

*Please note:* The patch was tested locally [with this line](https://github.com/mozilla/pdf.js/blob/92f7653cfbc2b8e824991f496564cf17fc3ee09b/src/core/evaluator.js#L661) changed to `isOffscreenCanvasSupported: false,` to ensure that the relevant `src/display/canvas.js` code-path is taken, and there were (obviously) no regressions.