### PR TITLE
Ignore null-chars when using structTree-data in the viewer

### DIFF
--- a/test/integration/accessibility_spec.js
+++ b/test/integration/accessibility_spec.js
@@ -169,6 +169,22 @@ describe("accessibility", () => {
       );
     });
 
+    it("must check the aria-label linked to the stamp annotation", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          await page.waitForSelector(".structTree");
+
+          const ariaLabel = await page.$eval(
+            ".structTree [role='figure']",
+            el => el.getAttribute("aria-label")
+          );
+          expect(ariaLabel)
+            .withContext(`In ${browserName}`)
+            .toEqual("Secondary text for stamp");
+        })
+      );
+    });
+
     it("must check that the stamp annotation is linked to the struct tree", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {

--- a/web/struct_tree_layer_builder.js
+++ b/web/struct_tree_layer_builder.js
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+import { removeNullCharacters } from "./ui_utils.js";
+
 const PDF_ROLE_TO_HTML_ROLE = {
   // Document level structure types
   Document: null, // There's a "document" role, but it doesn't make sense here.
@@ -102,13 +104,16 @@ class StructTreeLayerBuilder {
   #setAttributes(structElement, htmlElement) {
     const { alt, id, lang } = structElement;
     if (alt !== undefined) {
-      htmlElement.setAttribute("aria-label", alt);
+      htmlElement.setAttribute("aria-label", removeNullCharacters(alt));
     }
     if (id !== undefined) {
       htmlElement.setAttribute("aria-owns", id);
     }
     if (lang !== undefined) {
-      htmlElement.setAttribute("lang", lang);
+      htmlElement.setAttribute(
+        "lang",
+        removeNullCharacters(lang, /* replaceInvisible = */ true)
+      );
     }
   }
 


### PR DESCRIPTION
Testing the `tagged_stamp.pdf` document locally in the viewer, I noticed that e.g. the /Alt entry for the StampAnnotation contains "Secondary text for stamp\u0000".
Elsewhere in the viewer we're skipping null-chars and it's easy enough to do that in the `StructTreeLayerBuilder` class as well. (Note that we generally let the API itself return the data as-is.)