### PR TITLE
Drop redundant styles from .grab-to-pan-grab:active

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1368,6 +1368,8 @@ dialog :link {
 .grab-to-pan-grab:active,
 .grab-to-pan-grabbing {
   cursor: grabbing !important;
+}
+.grab-to-pan-grabbing {
   position: fixed;
   background: rgba(0, 0, 0, 0);
   display: block;


### PR DESCRIPTION
`.grab-to-pan-grab:active` is `#viewerContainer` when the mouse is pressed down.  It is supposed to have a `cursor: grabbing` appearance immediately on mousedown,

`.grab-to-pan-grabbing` is the overlay that is supposed to cover everything, and also has the `cursor: grabbing` appearance. The "cover everything" result is achieved through `position:fixed`, `inset:0`, etc.

The block with these CSS properties for "cover everything" is currently shared by `.grab-to-pan-grab:active` and `.grab-to-pan-grabbing`, but only "cursor" need to be shared. The original JS and CSS code at https://github.com/Rob--W/grab-to-pan.js shows that these were supposed to be associated with the overlay only.

The PR that added this to PDF.js also shows that the "cover everything" CSS properties were supposed to be limited to the overlay only: https://github.com/mozilla/pdf.js/pull/4209#discussion-diff-9285917

But the final version of the PR mistakenly merged them together. This patch rectifies that mistake.