### PR TITLE
Construct the correct field name and strip out classes when searching

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -1284,12 +1284,7 @@ class Annotation {
       }
 
       if (loopDict.has("T")) {
-        const t = stringToPDFString(loopDict.get("T"));
-        if (!t.startsWith("#")) {
-          // If it starts with a # then it's a class which is not a concept for
-          // datasets elements (https://www.pdfa.org/norm-refs/XFA-3_3.pdf#page=96).
-          fieldName.unshift(t);
-        }
+        fieldName.unshift(stringToPDFString(loopDict.get("T")));
       }
     }
     return fieldName.join(".");

--- a/src/core/xml_parser.js
+++ b/src/core/xml_parser.js
@@ -354,6 +354,11 @@ class SimpleDOMNode {
     }
 
     const component = paths[pos];
+    if (component.name.startsWith("#") && pos < paths.length - 1) {
+      // If it starts with a # then it's a class which is not a concept for
+      // datasets elements (https://www.pdfa.org/norm-refs/XFA-3_3.pdf#page=96).
+      return this.searchNode(paths, pos + 1);
+    }
     const stack = [];
     let node = this;
 

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -2037,6 +2037,7 @@ describe("api", function () {
       const value = "Hello World";
 
       pdfDoc.annotationStorage.setValue("2055R", { value });
+      pdfDoc.annotationStorage.setValue("2090R", { value });
 
       const data = await pdfDoc.saveDocument();
       await loadingTask.destroy();
@@ -2050,6 +2051,17 @@ describe("api", function () {
         "xfa:data.PPTC_153.Page1.PersonalInformation.TitleAndNameInformation.PersonalInfo.Surname.#text"
       );
       expect(surName.nodeValue).toEqual(value);
+
+      // The path for the date is:
+      // PPTC_153[0].Page1[0].DeclerationAndSignatures[0]
+      //            .#subform[2].currentDate[0]
+      // and it contains a class (i.e. #subform[2]) which is irrelevant in the
+      // context of datasets (it's more a template concept).
+      const date = getNamedNodeInXML(
+        datasets.node,
+        "xfa:data.PPTC_153.Page1.DeclerationAndSignatures.currentDate.#text"
+      );
+      expect(date.nodeValue).toEqual(value);
 
       await loadingTask.destroy();
     });


### PR DESCRIPTION
The classes were stripped out when creating the field name but it led to a wrong name.
Since class components in a path are irrelevant, they're just ignored when searching for a node in the datasets.