### PR TITLE
Slightly reduce asynchronicity when parsing Annotations

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -67,6 +67,35 @@ import { OperatorList } from "./operator_list.js";
 import { XFAFactory } from "./xfa/factory.js";
 
 class AnnotationFactory {
+  static createGlobals(pdfManager) {
+    return Promise.all([
+      pdfManager.ensureCatalog("acroForm"),
+      pdfManager.ensureDoc("xfaDatasets"),
+      pdfManager.ensureCatalog("structTreeRoot"),
+      // Only necessary to prevent the `Catalog.baseUrl`-getter, used
+      // with some Annotations, from throwing and thus breaking parsing:
+      pdfManager.ensureCatalog("baseUrl"),
+      // Only necessary to prevent the `Catalog.attachments`-getter, used
+      // with "GoToE" actions, from throwing and thus breaking parsing:
+      pdfManager.ensureCatalog("attachments"),
+    ]).then(
+      ([acroForm, xfaDatasets, structTreeRoot, baseUrl, attachments]) => {
+        return {
+          pdfManager,
+          acroForm: acroForm instanceof Dict ? acroForm : Dict.empty,
+          xfaDatasets,
+          structTreeRoot,
+          baseUrl,
+          attachments,
+        };
+      },
+      reason => {
+        warn(`createGlobals: "${reason}".`);
+        return null;
+      }
+    );
+  }
+
   /**
    * Create an `Annotation` object of the correct type for the given reference
    * to an annotation dictionary. This yields a promise that is resolved when
@@ -74,48 +103,33 @@ class AnnotationFactory {
    *
    * @param {XRef} xref
    * @param {Object} ref
-   * @param {PDFManager} pdfManager
+   * @params {Object} annotationGlobals
    * @param {Object} idFactory
-   * @param {boolean} collectFields
+   * @param {boolean} [collectFields]
    * @param {Object} [pageRef]
    * @returns {Promise} A promise that is resolved with an {Annotation}
    *   instance.
    */
-  static create(xref, ref, pdfManager, idFactory, collectFields, pageRef) {
-    return Promise.all([
-      pdfManager.ensureCatalog("acroForm"),
-      // Only necessary to prevent the `pdfManager.docBaseUrl`-getter, used
-      // with certain Annotations, from throwing and thus breaking parsing:
-      pdfManager.ensureCatalog("baseUrl"),
-      // Only necessary in the `Catalog.parseDestDictionary`-method,
-      // when parsing "GoToE" actions:
-      pdfManager.ensureCatalog("attachments"),
-      pdfManager.ensureDoc("xfaDatasets"),
-      collectFields ? this._getPageIndex(xref, ref, pdfManager) : -1,
-      pageRef ? pdfManager.ensureCatalog("structTreeRoot") : null,
-    ]).then(
-      ([
-        acroForm,
-        baseUrl,
-        attachments,
-        xfaDatasets,
-        pageIndex,
-        structTreeRoot,
-      ]) =>
-        pdfManager.ensure(this, "_create", [
-          xref,
-          ref,
-          pdfManager,
-          idFactory,
-          acroForm,
-          attachments,
-          xfaDatasets,
-          collectFields,
-          pageIndex,
-          structTreeRoot,
-          pageRef,
-        ])
-    );
+  static async create(
+    xref,
+    ref,
+    annotationGlobals,
+    idFactory,
+    collectFields,
+    pageRef
+  ) {
+    const pageIndex = collectFields
+      ? await this._getPageIndex(xref, ref, annotationGlobals.pdfManager)
+      : null;
+
+    return annotationGlobals.pdfManager.ensure(this, "_create", [
+      xref,
+      ref,
+      annotationGlobals,
+      idFactory,
+      pageIndex,
+      pageRef,
+    ]);
   }
 
   /**
@@ -124,14 +138,9 @@ class AnnotationFactory {
   static _create(
     xref,
     ref,
-    pdfManager,
+    annotationGlobals,
     idFactory,
-    acroForm,
-    attachments = null,
-    xfaDatasets,
-    collectFields,
-    pageIndex = -1,
-    structTreeRoot = null,
+    pageIndex = null,
     pageRef = null
   ) {
     const dict = xref.fetchIfRef(ref);
@@ -139,14 +148,13 @@ class AnnotationFactory {
       return undefined;
     }
 
+    const { acroForm, pdfManager } = annotationGlobals;
     const id =
       ref instanceof Ref ? ref.toString() : `annot_${idFactory.createObjId()}`;
 
     // Determine the annotation's subtype.
     let subtype = dict.get("Subtype");
     subtype = subtype instanceof Name ? subtype.name : null;
-
-    const acroFormDict = acroForm instanceof Dict ? acroForm : Dict.empty;
 
     // Return the right annotation object based on the subtype and field type.
     const parameters = {
@@ -155,16 +163,11 @@ class AnnotationFactory {
       dict,
       subtype,
       id,
-      pdfManager,
-      acroForm: acroFormDict,
-      attachments,
-      xfaDatasets,
-      collectFields,
+      annotationGlobals,
       needAppearances:
-        !collectFields && acroFormDict.get("NeedAppearances") === true,
+        pageIndex === null && acroForm.get("NeedAppearances") === true,
       pageIndex,
       evaluatorOptions: pdfManager.evaluatorOptions,
-      structTreeRoot,
       pageRef,
     };
 
@@ -241,7 +244,7 @@ class AnnotationFactory {
         return new FileAttachmentAnnotation(parameters);
 
       default:
-        if (!collectFields) {
+        if (pageIndex === null) {
           if (!subtype) {
             warn("Annotation is missing the required /Subtype.");
           } else {
@@ -404,6 +407,7 @@ class AnnotationFactory {
   }
 
   static async printNewAnnotations(
+    annotationGlobals,
     evaluator,
     task,
     annotations,
@@ -422,18 +426,28 @@ class AnnotationFactory {
       switch (annotation.annotationType) {
         case AnnotationEditorType.FREETEXT:
           promises.push(
-            FreeTextAnnotation.createNewPrintAnnotation(xref, annotation, {
-              evaluator,
-              task,
-              evaluatorOptions: options,
-            })
+            FreeTextAnnotation.createNewPrintAnnotation(
+              annotationGlobals,
+              xref,
+              annotation,
+              {
+                evaluator,
+                task,
+                evaluatorOptions: options,
+              }
+            )
           );
           break;
         case AnnotationEditorType.INK:
           promises.push(
-            InkAnnotation.createNewPrintAnnotation(xref, annotation, {
-              evaluatorOptions: options,
-            })
+            InkAnnotation.createNewPrintAnnotation(
+              annotationGlobals,
+              xref,
+              annotation,
+              {
+                evaluatorOptions: options,
+              }
+            )
           );
           break;
         case AnnotationEditorType.STAMP:
@@ -450,10 +464,15 @@ class AnnotationFactory {
             image.imageStream = image.smaskStream = null;
           }
           promises.push(
-            StampAnnotation.createNewPrintAnnotation(xref, annotation, {
-              image,
-              evaluatorOptions: options,
-            })
+            StampAnnotation.createNewPrintAnnotation(
+              annotationGlobals,
+              xref,
+              annotation,
+              {
+                image,
+                evaluatorOptions: options,
+              }
+            )
           );
           break;
       }
@@ -582,7 +601,7 @@ function getTransformMatrix(rect, bbox, matrix) {
 
 class Annotation {
   constructor(params) {
-    const { dict, xref } = params;
+    const { dict, xref, annotationGlobals } = params;
 
     this.setTitle(dict.get("T"));
     this.setContents(dict.get("Contents"));
@@ -610,11 +629,15 @@ class Annotation {
     const isLocked = !!(this.flags & AnnotationFlag.LOCKED);
     const isContentLocked = !!(this.flags & AnnotationFlag.LOCKEDCONTENTS);
 
-    if (params.structTreeRoot) {
+    if (annotationGlobals.structTreeRoot) {
       let structParent = dict.get("StructParent");
       structParent =
         Number.isInteger(structParent) && structParent >= 0 ? structParent : -1;
-      params.structTreeRoot.addAnnotationIdToPage(params.pageRef, structParent);
+
+      annotationGlobals.structTreeRoot.addAnnotationIdToPage(
+        params.pageRef,
+        structParent
+      );
     }
 
     // Expose public properties using a data object.
@@ -636,7 +659,7 @@ class Annotation {
       noHTML: isLocked && isContentLocked,
     };
 
-    if (params.collectFields) {
+    if (params.pageIndex !== null) {
       // Fields can act as container for other fields and have
       // some actions even if no Annotation inherit from them.
       // Those fields can be referenced by CO (calculation order).
@@ -767,9 +790,11 @@ class Annotation {
   }
 
   setDefaultAppearance(params) {
+    const { dict, annotationGlobals } = params;
+
     const defaultAppearance =
-      getInheritableProperty({ dict: params.dict, key: "DA" }) ||
-      params.acroForm.get("DA");
+      getInheritableProperty({ dict, key: "DA" }) ||
+      annotationGlobals.acroForm.get("DA");
     this._defaultAppearance =
       typeof defaultAppearance === "string" ? defaultAppearance : "";
     this.data.defaultAppearanceData = parseDefaultAppearance(
@@ -1652,13 +1677,19 @@ class MarkupAnnotation extends Annotation {
     return { ref: annotationRef, data: buffer.join("") };
   }
 
-  static async createNewPrintAnnotation(xref, annotation, params) {
+  static async createNewPrintAnnotation(
+    annotationGlobals,
+    xref,
+    annotation,
+    params
+  ) {
     const ap = await this.createNewAppearanceStream(annotation, xref, params);
     const annotationDict = this.createNewDict(annotation, xref, { ap });
 
     const newAnnotation = new this.prototype.constructor({
       dict: annotationDict,
       xref,
+      annotationGlobals,
       evaluatorOptions: params.evaluatorOptions,
     });
 
@@ -1674,7 +1705,7 @@ class WidgetAnnotation extends Annotation {
   constructor(params) {
     super(params);
 
-    const { dict, xref } = params;
+    const { dict, xref, annotationGlobals } = params;
     const data = this.data;
     this._needAppearances = params.needAppearances;
 
@@ -1701,12 +1732,13 @@ class WidgetAnnotation extends Annotation {
     });
     data.defaultFieldValue = this._decodeFormValue(defaultFieldValue);
 
-    if (fieldValue === undefined && params.xfaDatasets) {
+    if (fieldValue === undefined && annotationGlobals.xfaDatasets) {
       // Try to figure out if we have something in the xfa dataset.
       const path = this._title.str;
       if (path) {
         this._hasValueFromXFA = true;
-        data.fieldValue = fieldValue = params.xfaDatasets.getValue(path);
+        data.fieldValue = fieldValue =
+          annotationGlobals.xfaDatasets.getValue(path);
       }
     }
 
@@ -1729,7 +1761,7 @@ class WidgetAnnotation extends Annotation {
     data.fieldType = fieldType instanceof Name ? fieldType.name : null;
 
     const localResources = getInheritableProperty({ dict, key: "DR" });
-    const acroFormResources = params.acroForm.get("DR");
+    const acroFormResources = annotationGlobals.acroForm.get("DR");
     const appearanceResources = this.appearance?.dict.get("Resources");
 
     this._fieldResources = {
@@ -3268,22 +3300,20 @@ class ButtonWidgetAnnotation extends WidgetAnnotation {
   }
 
   _processPushButton(params) {
-    if (
-      !params.dict.has("A") &&
-      !params.dict.has("AA") &&
-      !this.data.alternativeText
-    ) {
+    const { dict, annotationGlobals } = params;
+
+    if (!dict.has("A") && !dict.has("AA") && !this.data.alternativeText) {
       warn("Push buttons without action dictionaries are not supported");
       return;
     }
 
-    this.data.isTooltipOnly = !params.dict.has("A") && !params.dict.has("AA");
+    this.data.isTooltipOnly = !dict.has("A") && !dict.has("AA");
 
     Catalog.parseDestDictionary({
-      destDict: params.dict,
+      destDict: dict,
       resultObj: this.data,
-      docBaseUrl: params.pdfManager.docBaseUrl,
-      docAttachments: params.attachments,
+      docBaseUrl: annotationGlobals.baseUrl,
+      docAttachments: annotationGlobals.attachments,
     });
   }
 
@@ -3641,9 +3671,10 @@ class LinkAnnotation extends Annotation {
   constructor(params) {
     super(params);
 
+    const { dict, annotationGlobals } = params;
     this.data.annotationType = AnnotationType.LINK;
 
-    const quadPoints = getQuadPoints(params.dict, this.rectangle);
+    const quadPoints = getQuadPoints(dict, this.rectangle);
     if (quadPoints) {
       this.data.quadPoints = quadPoints;
     }
@@ -3652,10 +3683,10 @@ class LinkAnnotation extends Annotation {
     this.data.borderColor ||= this.data.color;
 
     Catalog.parseDestDictionary({
-      destDict: params.dict,
+      destDict: dict,
       resultObj: this.data,
-      docBaseUrl: params.pdfManager.docBaseUrl,
-      docAttachments: params.attachments,
+      docBaseUrl: annotationGlobals.baseUrl,
+      docAttachments: annotationGlobals.attachments,
     });
   }
 }

--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -1423,19 +1423,16 @@ class Catalog {
    * Helper function used to parse the contents of destination dictionaries.
    * @param {ParseDestDictionaryParameters} params
    */
-  static parseDestDictionary(params) {
-    const destDict = params.destDict;
+  static parseDestDictionary({
+    destDict,
+    resultObj,
+    docBaseUrl = null,
+    docAttachments = null,
+  }) {
     if (!(destDict instanceof Dict)) {
       warn("parseDestDictionary: `destDict` must be a dictionary.");
       return;
     }
-    const resultObj = params.resultObj;
-    if (typeof resultObj !== "object") {
-      warn("parseDestDictionary: `resultObj` must be an object.");
-      return;
-    }
-    const docBaseUrl = params.docBaseUrl || null;
-    const docAttachments = params.docAttachments || null;
 
     let action = destDict.get("A"),
       url,

--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -310,7 +310,7 @@ class Catalog {
       Catalog.parseDestDictionary({
         destDict: outlineDict,
         resultObj: data,
-        docBaseUrl: this.pdfManager.docBaseUrl,
+        docBaseUrl: this.baseUrl,
         docAttachments: this.attachments,
       });
       const title = outlineDict.get("Title");
@@ -1405,7 +1405,7 @@ class Catalog {
         }
       }
     }
-    return shadow(this, "baseUrl", null);
+    return shadow(this, "baseUrl", this.pdfManager.docBaseUrl);
   }
 
   /**

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -435,9 +435,12 @@ class Page {
 
     let newAnnotationsPromise = Promise.resolve(null);
     if (newAnnotationsByPage) {
-      let imagePromises;
       const newAnnotations = newAnnotationsByPage.get(this.pageIndex);
       if (newAnnotations) {
+        const annotationGlobalsPromise =
+          this.pdfManager.ensureDoc("annotationGlobals");
+        let imagePromises;
+
         // An annotation can contain a reference to a bitmap, but this bitmap
         // is defined in another annotation. So we need to find this annotation
         // and generate the bitmap.
@@ -476,11 +479,21 @@ class Page {
 
         deletedAnnotations = new RefSet();
         this.#replaceIdByRef(newAnnotations, deletedAnnotations, null);
-        newAnnotationsPromise = AnnotationFactory.printNewAnnotations(
-          partialEvaluator,
-          task,
-          newAnnotations,
-          imagePromises
+
+        newAnnotationsPromise = annotationGlobalsPromise.then(
+          annotationGlobals => {
+            if (!annotationGlobals) {
+              return null;
+            }
+
+            return AnnotationFactory.printNewAnnotations(
+              annotationGlobals,
+              partialEvaluator,
+              task,
+              newAnnotations,
+              imagePromises
+            );
+          }
         );
       }
     }
@@ -672,7 +685,7 @@ class Page {
   async getAnnotationsData(handler, task, intent) {
     const annotations = await this._parsedAnnotations;
     if (annotations.length === 0) {
-      return [];
+      return annotations;
     }
 
     const annotationsData = [],
@@ -732,16 +745,25 @@ class Page {
   }
 
   get _parsedAnnotations() {
-    const parsedAnnotations = this.pdfManager
+    const promise = this.pdfManager
       .ensure(this, "annotations")
-      .then(() => {
+      .then(async annots => {
+        if (annots.length === 0) {
+          return annots;
+        }
+        const annotationGlobals =
+          await this.pdfManager.ensureDoc("annotationGlobals");
+        if (!annotationGlobals) {
+          return [];
+        }
+
         const annotationPromises = [];
-        for (const annotationRef of this.annotations) {
+        for (const annotationRef of annots) {
           annotationPromises.push(
             AnnotationFactory.create(
               this.xref,
               annotationRef,
-              this.pdfManager,
+              annotationGlobals,
               this._localIdFactory,
               /* collectFields */ false,
               this.ref
@@ -752,34 +774,28 @@ class Page {
           );
         }
 
-        return Promise.all(annotationPromises).then(function (annotations) {
-          if (annotations.length === 0) {
-            return annotations;
+        const sortedAnnotations = [];
+        let popupAnnotations;
+        // Ensure that PopupAnnotations are handled last, since they depend on
+        // their parent Annotation in the display layer; fixes issue 11362.
+        for (const annotation of await Promise.all(annotationPromises)) {
+          if (!annotation) {
+            continue;
           }
+          if (annotation instanceof PopupAnnotation) {
+            (popupAnnotations ||= []).push(annotation);
+            continue;
+          }
+          sortedAnnotations.push(annotation);
+        }
+        if (popupAnnotations) {
+          sortedAnnotations.push(...popupAnnotations);
+        }
 
-          const sortedAnnotations = [];
-          let popupAnnotations;
-          // Ensure that PopupAnnotations are handled last, since they depend on
-          // their parent Annotation in the display layer; fixes issue 11362.
-          for (const annotation of annotations) {
-            if (!annotation) {
-              continue;
-            }
-            if (annotation instanceof PopupAnnotation) {
-              (popupAnnotations ||= []).push(annotation);
-              continue;
-            }
-            sortedAnnotations.push(annotation);
-          }
-          if (popupAnnotations) {
-            sortedAnnotations.push(...popupAnnotations);
-          }
-
-          return sortedAnnotations;
-        });
+        return sortedAnnotations;
       });
 
-    return shadow(this, "_parsedAnnotations", parsedAnnotations);
+    return shadow(this, "_parsedAnnotations", promise);
   }
 
   get jsActions() {
@@ -1704,10 +1720,7 @@ class PDFDocument {
       : clearGlobalCaches();
   }
 
-  /**
-   * @private
-   */
-  _collectFieldObjects(name, fieldRef, promises) {
+  #collectFieldObjects(name, fieldRef, promises, annotationGlobals) {
     const field = this.xref.fetchIfRef(fieldRef);
     if (field.has("T")) {
       const partName = stringToPDFString(field.get("T"));
@@ -1721,22 +1734,21 @@ class PDFDocument {
       AnnotationFactory.create(
         this.xref,
         fieldRef,
-        this.pdfManager,
+        annotationGlobals,
         this._localIdFactory,
         /* collectFields */ true,
         /* pageRef */ null
       )
         .then(annotation => annotation?.getFieldObject())
         .catch(function (reason) {
-          warn(`_collectFieldObjects: "${reason}".`);
+          warn(`#collectFieldObjects: "${reason}".`);
           return null;
         })
     );
 
     if (field.has("Kids")) {
-      const kids = field.get("Kids");
-      for (const kid of kids) {
-        this._collectFieldObjects(name, kid, promises);
+      for (const kid of field.get("Kids")) {
+        this.#collectFieldObjects(name, kid, promises, annotationGlobals);
       }
     }
   }
@@ -1746,29 +1758,41 @@ class PDFDocument {
       return shadow(this, "fieldObjects", Promise.resolve(null));
     }
 
-    const allFields = Object.create(null);
-    const fieldPromises = new Map();
-    for (const fieldRef of this.catalog.acroForm.get("Fields")) {
-      this._collectFieldObjects("", fieldRef, fieldPromises);
-    }
+    const promise = this.pdfManager
+      .ensureDoc("annotationGlobals")
+      .then(async annotationGlobals => {
+        if (!annotationGlobals) {
+          return null;
+        }
 
-    const allPromises = [];
-    for (const [name, promises] of fieldPromises) {
-      allPromises.push(
-        Promise.all(promises).then(fields => {
-          fields = fields.filter(field => !!field);
-          if (fields.length > 0) {
-            allFields[name] = fields;
-          }
-        })
-      );
-    }
+        const allFields = Object.create(null);
+        const fieldPromises = new Map();
+        for (const fieldRef of this.catalog.acroForm.get("Fields")) {
+          this.#collectFieldObjects(
+            "",
+            fieldRef,
+            fieldPromises,
+            annotationGlobals
+          );
+        }
 
-    return shadow(
-      this,
-      "fieldObjects",
-      Promise.all(allPromises).then(() => allFields)
-    );
+        const allPromises = [];
+        for (const [name, promises] of fieldPromises) {
+          allPromises.push(
+            Promise.all(promises).then(fields => {
+              fields = fields.filter(field => !!field);
+              if (fields.length > 0) {
+                allFields[name] = fields;
+              }
+            })
+          );
+        }
+
+        await Promise.all(allPromises);
+        return allFields;
+      });
+
+    return shadow(this, "fieldObjects", promise);
   }
 
   get hasJSActions() {
@@ -1817,6 +1841,14 @@ class PDFDocument {
       return shadow(this, "calculationOrderIds", null);
     }
     return shadow(this, "calculationOrderIds", ids);
+  }
+
+  get annotationGlobals() {
+    return shadow(
+      this,
+      "annotationGlobals",
+      AnnotationFactory.createGlobals(this.pdfManager)
+    );
   }
 }
 

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -16,7 +16,6 @@
 import {
   createValidAbsoluteUrl,
   FeatureTest,
-  shadow,
   unreachable,
   warn,
 } from "../shared/util.js";
@@ -62,8 +61,7 @@ class BasePdfManager {
   }
 
   get docBaseUrl() {
-    const catalog = this.pdfDocument.catalog;
-    return shadow(this, "docBaseUrl", catalog.baseUrl || this._docBaseUrl);
+    return this._docBaseUrl;
   }
 
   ensureDoc(prop, args) {

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -50,10 +50,9 @@ import { WorkerTask } from "../../src/core/worker.js";
 describe("annotation", function () {
   class PDFManagerMock {
     constructor(params) {
-      this.docBaseUrl = params.docBaseUrl || null;
       this.pdfDocument = {
         catalog: {
-          acroForm: new Dict(),
+          baseUrl: params.docBaseUrl || null,
         },
       };
       this.evaluatorOptions = {
@@ -86,27 +85,32 @@ describe("annotation", function () {
     baseUrl: STANDARD_FONT_DATA_URL,
   });
 
-  function HandlerMock() {
-    this.inputs = [];
-  }
-  HandlerMock.prototype = {
+  class HandlerMock {
+    constructor() {
+      this.inputs = [];
+    }
+
     send(name, data) {
       this.inputs.push({ name, data });
-    },
+    }
+
     sendWithPromise(name, data) {
       if (name !== "FetchStandardFontData") {
         return Promise.reject(new Error(`Unsupported mock ${name}.`));
       }
       return fontDataReader.fetch(data);
-    },
-  };
+    }
+  }
 
-  let pdfManagerMock, idFactoryMock, partialEvaluator;
+  let annotationGlobalsMock, pdfManagerMock, idFactoryMock, partialEvaluator;
 
   beforeAll(async function () {
     pdfManagerMock = new PDFManagerMock({
       docBaseUrl: null,
     });
+
+    annotationGlobalsMock =
+      await AnnotationFactory.createGlobals(pdfManagerMock);
 
     const CMapReaderFactory = new DefaultCMapReaderFactory({
       baseUrl: CMAP_URL,
@@ -136,6 +140,7 @@ describe("annotation", function () {
   });
 
   afterAll(function () {
+    annotationGlobalsMock = null;
     pdfManagerMock = null;
     idFactoryMock = null;
     partialEvaluator = null;
@@ -153,7 +158,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.LINK);
@@ -174,7 +179,7 @@ describe("annotation", function () {
         const annotation1 = AnnotationFactory.create(
           xref,
           annotationDict,
-          pdfManagerMock,
+          annotationGlobalsMock,
           idFactory
         ).then(({ data }) => {
           expect(data.annotationType).toEqual(AnnotationType.LINK);
@@ -184,7 +189,7 @@ describe("annotation", function () {
         const annotation2 = AnnotationFactory.create(
           xref,
           annotationDict,
-          pdfManagerMock,
+          annotationGlobalsMock,
           idFactory
         ).then(({ data }) => {
           expect(data.annotationType).toEqual(AnnotationType.LINK);
@@ -205,7 +210,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toBeUndefined();
@@ -318,6 +323,7 @@ describe("annotation", function () {
       const annotation = new Annotation({
         dict,
         ref,
+        annotationGlobals: annotationGlobalsMock,
         evaluatorOptions: pdfManagerMock.evaluatorOptions,
       });
       annotation.setContents("Foo bar baz");
@@ -329,6 +335,7 @@ describe("annotation", function () {
       const annotation = new Annotation({
         dict,
         ref,
+        annotationGlobals: annotationGlobalsMock,
         evaluatorOptions: pdfManagerMock.evaluatorOptions,
       });
       annotation.setContents(undefined);
@@ -340,6 +347,7 @@ describe("annotation", function () {
       const annotation = new Annotation({
         dict,
         ref,
+        annotationGlobals: annotationGlobalsMock,
         evaluatorOptions: pdfManagerMock.evaluatorOptions,
       });
       annotation.setModificationDate("D:20190422");
@@ -351,6 +359,7 @@ describe("annotation", function () {
       const annotation = new Annotation({
         dict,
         ref,
+        annotationGlobals: annotationGlobalsMock,
         evaluatorOptions: pdfManagerMock.evaluatorOptions,
       });
       annotation.setModificationDate(undefined);
@@ -362,6 +371,7 @@ describe("annotation", function () {
       const annotation = new Annotation({
         dict,
         ref,
+        annotationGlobals: annotationGlobalsMock,
         evaluatorOptions: pdfManagerMock.evaluatorOptions,
       });
       annotation.setFlags(13);
@@ -377,6 +387,7 @@ describe("annotation", function () {
       const annotation = new Annotation({
         dict,
         ref,
+        annotationGlobals: annotationGlobalsMock,
         evaluatorOptions: pdfManagerMock.evaluatorOptions,
       });
 
@@ -388,6 +399,7 @@ describe("annotation", function () {
       const annotation = new Annotation({
         dict,
         ref,
+        annotationGlobals: annotationGlobalsMock,
         evaluatorOptions: pdfManagerMock.evaluatorOptions,
       });
       annotation.setRectangle([117, 694, 164.298, 720]);
@@ -399,6 +411,7 @@ describe("annotation", function () {
       const annotation = new Annotation({
         dict,
         ref,
+        annotationGlobals: annotationGlobalsMock,
         evaluatorOptions: pdfManagerMock.evaluatorOptions,
       });
       annotation.setRectangle([117, 694, 164.298]);
@@ -410,6 +423,7 @@ describe("annotation", function () {
       const annotation = new Annotation({
         dict,
         ref,
+        annotationGlobals: annotationGlobalsMock,
         evaluatorOptions: pdfManagerMock.evaluatorOptions,
       });
       annotation.setColor("red");
@@ -421,6 +435,7 @@ describe("annotation", function () {
       const annotation = new Annotation({
         dict,
         ref,
+        annotationGlobals: annotationGlobalsMock,
         evaluatorOptions: pdfManagerMock.evaluatorOptions,
       });
       annotation.setColor([]);
@@ -432,6 +447,7 @@ describe("annotation", function () {
       const annotation = new Annotation({
         dict,
         ref,
+        annotationGlobals: annotationGlobalsMock,
         evaluatorOptions: pdfManagerMock.evaluatorOptions,
       });
       annotation.setColor([0.4]);
@@ -443,6 +459,7 @@ describe("annotation", function () {
       const annotation = new Annotation({
         dict,
         ref,
+        annotationGlobals: annotationGlobalsMock,
         evaluatorOptions: pdfManagerMock.evaluatorOptions,
       });
       annotation.setColor([0, 0, 1]);
@@ -454,6 +471,7 @@ describe("annotation", function () {
       const annotation = new Annotation({
         dict,
         ref,
+        annotationGlobals: annotationGlobalsMock,
         evaluatorOptions: pdfManagerMock.evaluatorOptions,
       });
       annotation.setColor([0.1, 0.92, 0.84, 0.02]);
@@ -465,6 +483,7 @@ describe("annotation", function () {
       const annotation = new Annotation({
         dict,
         ref,
+        annotationGlobals: annotationGlobalsMock,
         evaluatorOptions: pdfManagerMock.evaluatorOptions,
       });
       annotation.setColor([0.4, 0.6]);
@@ -574,6 +593,7 @@ describe("annotation", function () {
       const markupAnnotation = new MarkupAnnotation({
         dict,
         ref,
+        annotationGlobals: annotationGlobalsMock,
         evaluatorOptions: pdfManagerMock.evaluatorOptions,
       });
       markupAnnotation.setCreationDate("D:20190422");
@@ -585,6 +605,7 @@ describe("annotation", function () {
       const markupAnnotation = new MarkupAnnotation({
         dict,
         ref,
+        annotationGlobals: annotationGlobalsMock,
         evaluatorOptions: pdfManagerMock.evaluatorOptions,
       });
       markupAnnotation.setCreationDate(undefined);
@@ -600,7 +621,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         ref,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.inReplyTo).toBeUndefined();
@@ -629,7 +650,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         replyRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.inReplyTo).toEqual(annotationRef.toString());
@@ -678,7 +699,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         replyRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.inReplyTo).toEqual(annotationRef.toString());
@@ -733,7 +754,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         replyRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.inReplyTo).toEqual(annotationRef.toString());
@@ -773,7 +794,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         replyRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.stateModel).toBeNull();
@@ -805,7 +826,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         replyRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.stateModel).toEqual("Review");
@@ -831,7 +852,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.LINK);
@@ -864,7 +885,7 @@ describe("annotation", function () {
         const { data } = await AnnotationFactory.create(
           xref,
           annotationRef,
-          pdfManagerMock,
+          annotationGlobalsMock,
           idFactoryMock
         );
         expect(data.annotationType).toEqual(AnnotationType.LINK);
@@ -904,7 +925,7 @@ describe("annotation", function () {
         const { data } = await AnnotationFactory.create(
           xref,
           annotationRef,
-          pdfManagerMock,
+          annotationGlobalsMock,
           idFactoryMock
         );
         expect(data.annotationType).toEqual(AnnotationType.LINK);
@@ -939,7 +960,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.LINK);
@@ -972,7 +993,7 @@ describe("annotation", function () {
         const { data } = await AnnotationFactory.create(
           xref,
           annotationRef,
-          pdfManagerMock,
+          annotationGlobalsMock,
           idFactoryMock
         );
         expect(data.annotationType).toEqual(AnnotationType.LINK);
@@ -1005,11 +1026,13 @@ describe("annotation", function () {
         const pdfManager = new PDFManagerMock({
           docBaseUrl: "http://www.example.com/test/pdfs/qwerty.pdf",
         });
+        const annotationGlobals =
+          await AnnotationFactory.createGlobals(pdfManager);
 
         const { data } = await AnnotationFactory.create(
           xref,
           annotationRef,
-          pdfManager,
+          annotationGlobals,
           idFactoryMock
         );
         expect(data.annotationType).toEqual(AnnotationType.LINK);
@@ -1039,7 +1062,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.LINK);
@@ -1067,7 +1090,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.LINK);
@@ -1112,11 +1135,13 @@ describe("annotation", function () {
         const pdfManager = new PDFManagerMock({
           docBaseUrl: "http://www.example.com/test/pdfs/qwerty.pdf",
         });
+        const annotationGlobals =
+          await AnnotationFactory.createGlobals(pdfManager);
 
         const { data } = await AnnotationFactory.create(
           xref,
           annotationRef,
-          pdfManager,
+          annotationGlobals,
           idFactoryMock
         );
         expect(data.annotationType).toEqual(AnnotationType.LINK);
@@ -1157,7 +1182,7 @@ describe("annotation", function () {
           return AnnotationFactory.create(
             xref,
             annotationRef,
-            pdfManagerMock,
+            annotationGlobalsMock,
             idFactoryMock
           ).then(({ data }) => {
             expect(data.annotationType).toEqual(AnnotationType.LINK);
@@ -1215,7 +1240,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.LINK);
@@ -1236,7 +1261,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.LINK);
@@ -1263,7 +1288,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.LINK);
@@ -1302,7 +1327,7 @@ describe("annotation", function () {
         const { data } = await AnnotationFactory.create(
           xref,
           annotationRef,
-          pdfManagerMock,
+          annotationGlobalsMock,
           idFactoryMock
         );
         expect(data.annotationType).toEqual(AnnotationType.LINK);
@@ -1323,7 +1348,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.LINK);
@@ -1343,7 +1368,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         annotationRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.LINK);
@@ -1378,7 +1403,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         widgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -1394,7 +1419,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         widgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -1418,7 +1443,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         widgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -1442,7 +1467,7 @@ describe("annotation", function () {
         const { data } = await AnnotationFactory.create(
           xref,
           widgetRef,
-          pdfManagerMock,
+          annotationGlobalsMock,
           idFactoryMock
         );
         expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -1517,7 +1542,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -1541,7 +1566,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -1567,7 +1592,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -1587,7 +1612,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -1604,7 +1629,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -1640,7 +1665,7 @@ describe("annotation", function () {
           return AnnotationFactory.create(
             xref,
             textWidgetRef,
-            pdfManagerMock,
+            annotationGlobalsMock,
             idFactoryMock
           ).then(({ data }) => {
             expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -1670,7 +1695,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -1703,7 +1728,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -1747,7 +1772,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -1789,7 +1814,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -1822,7 +1847,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -1858,7 +1883,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -1887,7 +1912,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -1931,7 +1956,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -1989,7 +2014,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -2030,7 +2055,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -2069,7 +2094,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -2104,7 +2129,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -2147,7 +2172,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -2193,7 +2218,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -2298,7 +2323,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const fieldObject = await annotation.getFieldObject();
@@ -2329,7 +2354,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         textWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -2399,7 +2424,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -2422,7 +2447,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -2451,7 +2476,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -2492,7 +2517,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -2553,7 +2578,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -2637,7 +2662,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -2702,7 +2727,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -2751,7 +2776,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -2802,7 +2827,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -2854,7 +2879,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -2886,7 +2911,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -2914,7 +2939,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -2955,7 +2980,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -3040,7 +3065,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -3100,7 +3125,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -3163,7 +3188,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -3200,7 +3225,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -3229,7 +3254,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -3249,7 +3274,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -3276,7 +3301,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.url).toEqual("https://developer.mozilla.org/en-US/");
@@ -3304,7 +3329,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         buttonWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.url).toEqual("https://developer.mozilla.org/en-US/");
@@ -3350,7 +3375,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -3381,7 +3406,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -3409,7 +3434,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -3439,7 +3464,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -3462,7 +3487,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -3490,7 +3515,7 @@ describe("annotation", function () {
           return AnnotationFactory.create(
             xref,
             choiceWidgetRef,
-            pdfManagerMock,
+            annotationGlobalsMock,
             idFactoryMock
           ).then(({ data }) => {
             expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -3510,7 +3535,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -3531,7 +3556,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -3557,7 +3582,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
@@ -3579,7 +3604,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -3624,7 +3649,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -3673,7 +3698,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -3717,7 +3742,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -3778,7 +3803,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -3843,7 +3868,7 @@ describe("annotation", function () {
       const annotation = await AnnotationFactory.create(
         xref,
         choiceWidgetRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       const annotationStorage = new Map();
@@ -3905,7 +3930,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         lineRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.LINE);
@@ -3926,7 +3951,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         lineRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.LINE);
@@ -3985,7 +4010,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         fileAttachmentRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.FILEATTACHMENT);
@@ -4013,7 +4038,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         popupRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.POPUP);
@@ -4037,7 +4062,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         popupRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.POPUP);
@@ -4066,7 +4091,7 @@ describe("annotation", function () {
         const { data, viewable } = await AnnotationFactory.create(
           xref,
           popupRef,
-          pdfManagerMock,
+          annotationGlobalsMock,
           idFactoryMock
         );
         expect(data.annotationType).toEqual(AnnotationType.POPUP);
@@ -4125,7 +4150,7 @@ describe("annotation", function () {
         const { data } = await AnnotationFactory.create(
           xref,
           popupRef,
-          pdfManagerMock,
+          annotationGlobalsMock,
           idFactoryMock
         );
         expect(data.titleObj).toEqual({ str: "Correct Title", dir: "ltr" });
@@ -4196,16 +4221,21 @@ describe("annotation", function () {
       partialEvaluator.xref = new XRefMock();
       const task = new WorkerTask("test FreeText printing");
       const freetextAnnotation = (
-        await AnnotationFactory.printNewAnnotations(partialEvaluator, task, [
-          {
-            annotationType: AnnotationEditorType.FREETEXT,
-            rect: [12, 34, 56, 78],
-            rotation: 0,
-            fontSize: 10,
-            color: [0, 0, 0],
-            value: "A",
-          },
-        ])
+        await AnnotationFactory.printNewAnnotations(
+          annotationGlobalsMock,
+          partialEvaluator,
+          task,
+          [
+            {
+              annotationType: AnnotationEditorType.FREETEXT,
+              rect: [12, 34, 56, 78],
+              rotation: 0,
+              fontSize: 10,
+              color: [0, 0, 0],
+              value: "A",
+            },
+          ]
+        )
       )[0];
 
       const { opList } = await freetextAnnotation.getOperatorList(
@@ -4241,16 +4271,21 @@ describe("annotation", function () {
       partialEvaluator.xref = new XRefMock();
       const task = new WorkerTask("test FreeText text extraction");
       const freetextAnnotation = (
-        await AnnotationFactory.printNewAnnotations(partialEvaluator, task, [
-          {
-            annotationType: AnnotationEditorType.FREETEXT,
-            rect: [12, 34, 56, 78],
-            rotation: 0,
-            fontSize: 10,
-            color: [0, 0, 0],
-            value: "Hello PDF.js\nWorld !",
-          },
-        ])
+        await AnnotationFactory.printNewAnnotations(
+          annotationGlobalsMock,
+          partialEvaluator,
+          task,
+          [
+            {
+              annotationType: AnnotationEditorType.FREETEXT,
+              rect: [12, 34, 56, 78],
+              rotation: 0,
+              fontSize: 10,
+              color: [0, 0, 0],
+              value: "Hello PDF.js\nWorld !",
+            },
+          ]
+        )
       )[0];
 
       await freetextAnnotation.extractTextContent(partialEvaluator, task, [
@@ -4280,7 +4315,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         inkRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.INK);
@@ -4308,7 +4343,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         inkRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.INK);
@@ -4451,23 +4486,28 @@ describe("annotation", function () {
       partialEvaluator.xref = new XRefMock();
       const task = new WorkerTask("test Ink printing");
       const inkAnnotation = (
-        await AnnotationFactory.printNewAnnotations(partialEvaluator, task, [
-          {
-            annotationType: AnnotationEditorType.INK,
-            rect: [12, 34, 56, 78],
-            rotation: 0,
-            thickness: 3,
-            opacity: 1,
-            color: [0, 255, 0],
-            paths: [
-              {
-                bezier: [1, 2, 3, 4, 5, 6, 7, 8],
-                // Useless in the printing case.
-                points: [1, 2, 3, 4, 5, 6, 7, 8],
-              },
-            ],
-          },
-        ])
+        await AnnotationFactory.printNewAnnotations(
+          annotationGlobalsMock,
+          partialEvaluator,
+          task,
+          [
+            {
+              annotationType: AnnotationEditorType.INK,
+              rect: [12, 34, 56, 78],
+              rotation: 0,
+              thickness: 3,
+              opacity: 1,
+              color: [0, 255, 0],
+              paths: [
+                {
+                  bezier: [1, 2, 3, 4, 5, 6, 7, 8],
+                  // Useless in the printing case.
+                  points: [1, 2, 3, 4, 5, 6, 7, 8],
+                },
+              ],
+            },
+          ]
+        )
       )[0];
 
       const { opList } = await inkAnnotation.getOperatorList(
@@ -4518,7 +4558,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         highlightRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.HIGHLIGHT);
@@ -4538,7 +4578,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         highlightRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.HIGHLIGHT);
@@ -4565,7 +4605,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         highlightRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.HIGHLIGHT);
@@ -4585,7 +4625,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         underlineRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.UNDERLINE);
@@ -4605,7 +4645,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         underlineRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.UNDERLINE);
@@ -4632,7 +4672,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         squigglyRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.SQUIGGLY);
@@ -4652,7 +4692,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         squigglyRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.SQUIGGLY);
@@ -4679,7 +4719,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         strikeOutRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.STRIKEOUT);
@@ -4699,7 +4739,7 @@ describe("annotation", function () {
       const { data } = await AnnotationFactory.create(
         xref,
         strikeOutRef,
-        pdfManagerMock,
+        annotationGlobalsMock,
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.STRIKEOUT);


### PR DESCRIPTION
Over time the amount of "document level" data potentially needed during parsing of Annotations have increased a fair bit, which means that we currently need to ensure that a bunch of data is available for each individual Annotation.
Given that this data is "constant" for a PDF document we can instead create (and cache) it lazily, only when needed, *before* starting to parse the Annotations on a page. This way the parsing of individual Annotations should become slightly less asynchronous, which really cannot hurt.

An additional benefit of these changes is that we can reduce the number of parameters that need to be explicitly passed around in the annotation-code, which helps overall readability in my opinion.

One potential drawback of these changes is that the `AnnotationFactory.create` method no longer handles "everything" on its own, however given how few call-sites there are I don't think that's too much of a problem.