### PR TITLE
Simplify writeObject function

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -321,16 +321,7 @@ class Page {
     const savedDict = pageDict.get("Annots");
     pageDict.set("Annots", annotationsArray);
     const buffer = [];
-
-    let transform = null;
-    if (this.xref.encrypt) {
-      transform = this.xref.encrypt.createCipherTransform(
-        this.ref.num,
-        this.ref.gen
-      );
-    }
-
-    await writeObject(this.ref, pageDict, buffer, transform);
+    await writeObject(this.ref, pageDict, buffer, this.xref);
     if (savedDict) {
       pageDict.set("Annots", savedDict);
     }


### PR DESCRIPTION
It'll avoid to have the duplication of the code to get the encrypt transform, and last but not least, it'll avoid to forget about encryption.