### PR TITLE
Enable unit test "creates pdf doc from non-existent URL"

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -268,10 +268,6 @@ describe("api", function () {
     });
 
     it("creates pdf doc from non-existent URL", async function () {
-      if (!isNodeJS) {
-        // Re-enable in https://github.com/mozilla/pdf.js/issues/13061.
-        pending("Fails intermittently on Linux in browsers.");
-      }
       const loadingTask = getDocument(
         buildGetDocumentParams("non-existent.pdf")
       );


### PR DESCRIPTION
The unit test is re-enabled because it no longer seems to fail after 10 runs on Linux where this used to fail often. Code inspection also shows that the code is correct and should raise the previous exception (anymore). Finally, a lot has changed since this test was disabled such as new Jasmine versions, new Linux bot OS version and new browser versions.