### PR TITLE
Enabling display of signature annotation empty using configuration key.

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -1760,7 +1760,7 @@ class WidgetAnnotation extends Annotation {
       this._hasFlag(data.annotationFlags, AnnotationFlag.NOVIEW);
 
     if(data.fieldType === 'Sig') {
-      data.isSigned = this._hasSingContent(fieldValue);
+      data.isSigned = this._hasSignatureContent(fieldValue);
     }
 
   }
@@ -2609,9 +2609,12 @@ class WidgetAnnotation extends Annotation {
 
   /**
    * @private
-   * ByteRange and Contents are Required in the signature value. See Table 252 – Entries in a signature dictionary of ISO 32000 is the family of ISO standards defining the core PDF specification.
+   * @memberof WidgetAnnotation
+   * @param {any} fieldValue
+   * @returns {boolean}
+   * The method checks if there is any signature content on the annotation fieldValue. ByteRange and Contents are required in the signature value. See Table 252 – Entries in a signature dictionary of ISO 32000 is the family of ISO standards defining the core PDF specification.
    */
-  _hasSingContent(fieldValue) {
+  _hasSignatureContent(fieldValue) {
     return fieldValue instanceof Dict ?
         fieldValue.get('ByteRange')
         && fieldValue.get('Contents') : false;

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -1758,6 +1758,11 @@ class WidgetAnnotation extends Annotation {
     data.hidden =
       this._hasFlag(data.annotationFlags, AnnotationFlag.HIDDEN) ||
       this._hasFlag(data.annotationFlags, AnnotationFlag.NOVIEW);
+
+    if(data.fieldType === 'Sig') {
+      data.isSigned = this._hasSingContent(fieldValue);
+    }
+
   }
 
   /**
@@ -2600,6 +2605,16 @@ class WidgetAnnotation extends Annotation {
 
   getFieldObject() {
     return null;
+  }
+
+  /**
+   * @private
+   * ByteRange and Contents are Required in the signature value. See Table 252 – Entries in a signature dictionary of ISO 32000 is the family of ISO standards defining the core PDF specification.
+   */
+  _hasSingContent(fieldValue) {
+    return fieldValue instanceof Dict ?
+        fieldValue.get('ByteRange')
+        && fieldValue.get('Contents') : false;
   }
 }
 

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -1510,8 +1510,8 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
 
 class SignatureWidgetAnnotationElement extends WidgetAnnotationElement {
   constructor(parameters) {
-    if(window?.PDFViewerApplicationOptions
-      && window.PDFViewerApplicationOptions.get('showSignatureWidgetAnnotation')) {
+    if(window?.PDFViewerApplicationOptions?.get('showSignatureWidgetAnnotationEmpty')
+      && !parameters.data.isSigned) {
       parameters.data.hasOwnCanvas = true;
     }
     super(parameters, { isRenderable: !!parameters.data.hasOwnCanvas });

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -1510,7 +1510,29 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
 
 class SignatureWidgetAnnotationElement extends WidgetAnnotationElement {
   constructor(parameters) {
+    if(window?.PDFViewerApplicationOptions
+      && window.PDFViewerApplicationOptions.get('showSignatureWidgetAnnotation')) {
+      parameters.data.hasOwnCanvas = true;
+    }
     super(parameters, { isRenderable: !!parameters.data.hasOwnCanvas });
+  }
+
+  render() {
+    const element = document.createElement("button");
+    element.setAttribute("data-sign-annotation-id", this.data.id);
+    element.setAttribute("class", 'sign-box');
+    element.addEventListener("click",() =>
+      element.dispatchEvent(new CustomEvent("signClick", { detail: this.data.id })));
+    element.addEventListener(
+      "signClick",
+      (e) => {
+        this.linkService.eventBus?.dispatch("signClick", {
+          source: this,
+          detail: this.data.id
+        });
+      },false);
+    this.container.append(element);
+    return this.container;
   }
 }
 


### PR DESCRIPTION
We have implemented out of necessity the possibility of making an empty signature form visible on the PDF. We also added a custom event to notify the user when the annotation is clicked. To maintain backwards compatibility, we've also added a new configuration variable (showSignatureWidgetAnnotationEmpty) off by default that allows you to force the visibility of the empty signature annotation.
We then added a boolean "isSigned" attribute to the WidgetAnnotation class that allows you to quickly check whether the annotation is already signed or not.