### PR TITLE
[Editor] Move an editor in the DOM just after having moved it on the screen

### DIFF
--- a/src/display/editor/annotation_editor_layer.js
+++ b/src/display/editor/annotation_editor_layer.js
@@ -377,10 +377,8 @@ class AnnotationEditorLayer {
       editor.isAttachedToDOM = true;
     }
 
-    // The editor must have the right position before being moved in the DOM.
+    // The editor will be correctly moved into the DOM (see fixAndSetPosition).
     editor.fixAndSetPosition();
-    this.moveEditorInDOM(editor);
-
     editor.onceAdded();
     this.#uiManager.addToAnnotationStorage(editor);
   }

--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -340,7 +340,6 @@ class AnnotationEditor {
    */
   translateInPage(x, y) {
     this.#translate(this.pageDimensions, x, y);
-    this.moveInDOM();
     this.div.scrollIntoView({ block: "nearest" });
   }
 
@@ -398,11 +397,14 @@ class AnnotationEditor {
         break;
     }
 
-    this.x = x / pageWidth;
-    this.y = y / pageHeight;
+    this.x = x /= pageWidth;
+    this.y = y /= pageHeight;
 
-    this.div.style.left = `${(100 * this.x).toFixed(2)}%`;
-    this.div.style.top = `${(100 * this.y).toFixed(2)}%`;
+    const { style } = this.div;
+    style.left = `${(100 * x).toFixed(2)}%`;
+    style.top = `${(100 * y).toFixed(2)}%`;
+
+    this.moveInDOM();
   }
 
   static #rotatePoint(x, y, angle) {
@@ -600,7 +602,6 @@ class AnnotationEditor {
           const [parentWidth, parentHeight] = this.parentDimensions;
           this.setDims(parentWidth * newWidth, parentHeight * newHeight);
           this.fixAndSetPosition();
-          this.moveInDOM();
         },
         undo: () => {
           this.width = savedWidth;
@@ -610,7 +611,6 @@ class AnnotationEditor {
           const [parentWidth, parentHeight] = this.parentDimensions;
           this.setDims(parentWidth * savedWidth, parentHeight * savedHeight);
           this.fixAndSetPosition();
-          this.moveInDOM();
         },
         mustExec: true,
       });
@@ -856,7 +856,7 @@ class AnnotationEditor {
   }
 
   moveInDOM() {
-    this.parent.moveEditorInDOM(this);
+    this.parent?.moveEditorInDOM(this);
   }
 
   _setParentAndPosition(parent, x, y) {
@@ -864,7 +864,6 @@ class AnnotationEditor {
     this.x = x;
     this.y = y;
     this.fixAndSetPosition();
-    this.moveInDOM();
   }
 
   /**


### PR DESCRIPTION
It avoids to have to remember to call moveInDOM after fixAndSetPosition is called.