### PR TITLE
Make it possible to clear the cache, used by the `getB` function in `src/core/pattern.js`

### DIFF
--- a/src/core/cleanup_helper.js
+++ b/src/core/cleanup_helper.js
@@ -13,10 +13,12 @@
  * limitations under the License.
  */
 
+import { clearPatternCaches } from "./pattern.js";
 import { clearPrimitiveCaches } from "./primitives.js";
 import { clearUnicodeCaches } from "./unicode.js";
 
 function clearGlobalCaches() {
+  clearPatternCaches();
   clearPrimitiveCaches();
   clearUnicodeCaches();
 }

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -418,12 +418,7 @@ const getB = (function getBClosure() {
       const t = i / count,
         t_ = 1 - t;
       lut.push(
-        new Float32Array([
-          t_ * t_ * t_,
-          3 * t * t_ * t_,
-          3 * t * t * t_,
-          t * t * t,
-        ])
+        new Float32Array([t_ ** 3, 3 * t * t_ ** 2, 3 * t ** 2 * t_, t ** 3])
       );
     }
     return lut;

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -411,24 +411,26 @@ class MeshStreamReader {
   }
 }
 
-const getB = (function getBClosure() {
-  function buildB(count) {
-    const lut = [];
-    for (let i = 0; i <= count; i++) {
-      const t = i / count,
-        t_ = 1 - t;
-      lut.push(
-        new Float32Array([t_ ** 3, 3 * t * t_ ** 2, 3 * t ** 2 * t_, t ** 3])
-      );
-    }
-    return lut;
-  }
-  const cache = Object.create(null);
+let bCache = Object.create(null);
 
-  return function (count) {
-    return (cache[count] ||= buildB(count));
-  };
-})();
+function buildB(count) {
+  const lut = [];
+  for (let i = 0; i <= count; i++) {
+    const t = i / count,
+      t_ = 1 - t;
+    lut.push(
+      new Float32Array([t_ ** 3, 3 * t * t_ ** 2, 3 * t ** 2 * t_, t ** 3])
+    );
+  }
+  return lut;
+}
+function getB(count) {
+  return (bCache[count] ||= buildB(count));
+}
+
+function clearPatternCaches() {
+  bCache = Object.create(null);
+}
 
 class MeshShading extends BaseShading {
   static MIN_SPLIT_PATCH_CHUNKS_AMOUNT = 3;
@@ -1000,4 +1002,4 @@ function getTilingPatternIR(operatorList, dict, color) {
   ];
 }
 
-export { getTilingPatternIR, Pattern };
+export { clearPatternCaches, getTilingPatternIR, Pattern };


### PR DESCRIPTION
While this cache will not contain a huge amount of data in practice, it's nonetheless a *global* cache that currently will never be cleared.

This patch also removes the existing closure, since it shouldn't really be necessary nowadays given that the code is a JavaScript module which means that only explicitly listed properties will be exported.