### PR TITLE
Fix integration test "FreeText Editor Move several FreeTexts must move several annotations"

### DIFF
--- a/test/integration/freetext_editor_spec.js
+++ b/test/integration/freetext_editor_spec.js
@@ -2254,12 +2254,12 @@ describe("FreeText Editor", () => {
               return { x, y };
             });
             const oldPos = allPositions[i];
-            expect(Math.round(pos.x))
+            expect(Math.round(pos.x - oldPos.x))
               .withContext(`In ${browserName}`)
-              .toEqual(Math.round(oldPos.x + 39));
-            expect(Math.round(pos.y))
+              .toEqual(39);
+            expect(Math.round(pos.y - oldPos.y))
               .withContext(`In ${browserName}`)
-              .toEqual(Math.round(oldPos.y + 74));
+              .toEqual(74);
           }
         })
       );


### PR DESCRIPTION
_This is part 2 of the work to create tickets for and on a case-by-case basis fix intermittently failing integration tests._

The commit messages contain more information about the individual changes.

Fixes #16926.