### PR TITLE
Fix integration test "FreeText Editor FreeText (edit existing in double clicking on it) must move an annotation"

### DIFF
--- a/test/integration/freetext_editor_spec.js
+++ b/test/integration/freetext_editor_spec.js
@@ -1176,7 +1176,7 @@ describe("FreeText Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           await page.click("[data-annotation-id='26R']", { clickCount: 2 });
-          await page.waitForTimeout(10);
+          await page.waitForSelector(`${getEditorSelector(0)}-editor`);
 
           const [focusedId, editable] = await page.evaluate(() => {
             const el = document.activeElement;


### PR DESCRIPTION
_This is part 3 of the work to create tickets for and on a case-by-case basis fix intermittently failing integration tests._

The commit messages contain more information about the individual changes.

Fixes #16966.