### PR TITLE
[Editor] Make the border of the resizers slightly rounded

### DIFF
--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -254,7 +254,9 @@
         width: var(--resizer-size);
         height: var(--resizer-size);
         background: var(--resizer-bg-color);
+        background-clip: content-box;
         border: var(--focus-outline-around);
+        border-radius: 2px;
         position: absolute;
 
         &.topLeft {


### PR DESCRIPTION
It's a part of the UX specifications. There's a drawing issue in Firefox (see bug https://bugzilla.mozilla.org/1853288) but setting the background-clip property to content-box seems to be a good workaround.