### PR TITLE
Ignore optional content with missing /Type-entries

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1581,7 +1581,7 @@ class PartialEvaluator {
       throw new FormatError("Optional content properties malformed.");
     }
 
-    const optionalContentType = optionalContent.get("Type").name;
+    const optionalContentType = optionalContent.get("Type")?.name;
     if (optionalContentType === "OCG") {
       return {
         type: optionalContentType,

--- a/test/pdfs/mupdf-707147.pdf.link
+++ b/test/pdfs/mupdf-707147.pdf.link
@@ -1,0 +1,1 @@
+https://web.archive.org/web/20230919100948/https://bugs.ghostscript.com/attachment.cgi?id=24825

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -5590,6 +5590,14 @@
        "lastPage": 1,
        "type": "text"
     },
+    {  "id": "mupdf-707147",
+       "file": "pdfs/mupdf-707147.pdf",
+       "md5": "3b6f4e142baed0585bb52c1eb79f918a",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq"
+    },
     {  "id": "issue5421",
        "file": "pdfs/issue5421.pdf",
        "md5": "273f6813758a2349090003c7c8a0d85e",


### PR DESCRIPTION
In the rare situation that an optional content dictionary lacks a /Type-entry we currently throw, which may prevent e.g. Form XObjects from rendering completely.

Fixes https://bugs.ghostscript.com/show_bug.cgi?id=707147