### PR TITLE
[Editor] Add a tooltip showing the alt text when hovering the alt-text button (bug 1844952)

### DIFF
--- a/l10n/en-US/viewer.properties
+++ b/l10n/en-US/viewer.properties
@@ -265,9 +265,9 @@ editor_ink2_aria_label=Draw Editor
 editor_ink_canvas_aria_label=User-created image
 
 # Alt-text dialog
-# LOCALIZATION NOTE (alt_text_button_label): Alternative text (alt text) helps
+# LOCALIZATION NOTE (editor_alt_text_button_label): Alternative text (alt text) helps
 # when people can't see the image.
-alt_text_button_label=Alt text
+editor_alt_text_button_label=Alt text
 editor_alt_text_dialog_label=Choose an option
 editor_alt_text_dialog_description=Alt text (alternative text) helps when people can’t see the image or when it doesn’t load.
 editor_alt_text_enter_description_label=Enter a description
@@ -276,3 +276,4 @@ editor_alt_text_mark_decorative_label=Mark as decorative
 editor_alt_text_mark_decorative_description=This is best for images that aren’t informative, like borders or stylistic elements.
 editor_alt_text_cancel_button=Cancel
 editor_alt_text_save_button=Save
+editor_alt_text_decorative_tooltip=Marked as decorative

--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -529,13 +529,53 @@
     mask-image: var(--alt-text-done-image);
   }
 
-  & .description {
-    position: absolute;
-    top: 0;
-    left: 0;
+  & .tooltip {
     display: none;
-    width: 0;
-    height: 0;
+
+    &.decorative {
+      font-style: italic;
+    }
+
+    &.show {
+      --alt-text-tooltip-bg: #f0f0f4;
+      --alt-text-tooltip-fg: #15141a;
+      --alt-text-tooltip-border: #8f8f9d;
+      --alt-text-tooltip-shadow: 0px 2px 6px 0px rgba(58, 57, 68, 0.2);
+
+      @media (prefers-color-scheme: dark) {
+        --alt-text-tooltip-bg: #1c1b22;
+        --alt-text-tooltip-fg: #fbfbfe;
+        --alt-text-tooltip-shadow: 0px 2px 6px 0px #15141a;
+      }
+
+      @media screen and (forced-colors: active) {
+        --alt-text-tooltip-bg: Canvas;
+        --alt-text-tooltip-fg: CanvasText;
+        --alt-text-tooltip-border: CanvasText;
+        --alt-text-tooltip-shadow: none;
+      }
+
+      display: inline-flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      position: absolute;
+      top: calc(100% + 2px);
+      inset-inline-start: 0;
+      padding-block: 2px 3px;
+      padding-inline: 3px;
+      max-width: 300px;
+      width: max-content;
+      height: auto;
+      font-size: 12px;
+
+      border: 0.5px solid var(--alt-text-tooltip-border);
+      background: var(--alt-text-tooltip-bg);
+      box-shadow: var(--alt-text-tooltip-shadow);
+      color: var(--alt-text-tooltip-fg);
+
+      pointer-events: none;
+    }
   }
 }
 

--- a/web/l10n_utils.js
+++ b/web/l10n_utils.js
@@ -82,7 +82,8 @@ const DEFAULT_L10N_STRINGS = {
   editor_free_text2_aria_label: "Text Editor",
   editor_ink2_aria_label: "Draw Editor",
   editor_ink_canvas_aria_label: "User-created image",
-  alt_text_button_label: "Alt text",
+  editor_alt_text_button_label: "Alt text",
+  editor_alt_text_decorative_tooltip: "Marked as decorative",
 };
 if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
   DEFAULT_L10N_STRINGS.print_progress_percent = "{{progress}}%";


### PR DESCRIPTION
It has been added by UX to the specifications.
The goal is to help to visualize what the alt text is.