### PR TITLE
Don't try to close the `altText` dialog if it's not open (PR 16977 follow-up)

### DIFF
--- a/web/alt_text_manager.js
+++ b/web/alt_text_manager.js
@@ -152,7 +152,7 @@ class AltTextManager {
   }
 
   #finish() {
-    if (this.#dialog) {
+    if (this.#overlayManager.active === this.#dialog) {
       this.#overlayManager.close(this.#dialog);
     }
   }


### PR DESCRIPTION
When closing a document in the viewer, e.g. by running `PDFViewerApplication.close()` in the console, the `AltTextManager.#finish` method currently throws *unless* the `altText` dialog is actually open.
Similar to e.g. the PasswordPrompt, we should thus only attempt to close the `altText` dialog when it's open.