### PR TITLE
Use the new "reporttelemetry" event in more viewer components

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -615,8 +615,7 @@ const PDFViewerApplication = {
           appConfig.toolbar,
           eventBus,
           l10n,
-          await this._nimbusDataPromise,
-          externalServices
+          await this._nimbusDataPromise
         );
       } else {
         this.toolbar = new Toolbar(appConfig.toolbar, eventBus, l10n);
@@ -626,8 +625,7 @@ const PDFViewerApplication = {
     if (appConfig.secondaryToolbar) {
       this.secondaryToolbar = new SecondaryToolbar(
         appConfig.secondaryToolbar,
-        eventBus,
-        externalServices
+        eventBus
       );
     }
 
@@ -2141,7 +2139,6 @@ const PDFViewerApplication = {
       eventBus._off("fileinputchange", webViewerFileInputChange);
       eventBus._off("openfile", webViewerOpenFile);
     }
-
     if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
       eventBus._off("reporttelemetry", webViewerReportTelemetry);
     }

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -56,7 +56,7 @@ class SecondaryToolbar {
    * @param {SecondaryToolbarOptions} options
    * @param {EventBus} eventBus
    */
-  constructor(options, eventBus, externalServices) {
+  constructor(options, eventBus) {
     this.toolbar = options.toolbar;
     this.toggleButton = options.toggleButton;
     this.buttons = [
@@ -155,7 +155,6 @@ class SecondaryToolbar {
     };
 
     this.eventBus = eventBus;
-    this.externalServices = externalServices;
     this.opened = false;
 
     // Bind the event listeners for click, cursor tool, and scroll/spread mode
@@ -214,9 +213,12 @@ class SecondaryToolbar {
         if (close) {
           this.close();
         }
-        this.externalServices.reportTelemetry({
-          type: "buttons",
-          data: { id: element.id },
+        this.eventBus.dispatch("reporttelemetry", {
+          source: this,
+          details: {
+            type: "buttons",
+            data: { id: element.id },
+          },
         });
       });
     }

--- a/web/toolbar-geckoview.js
+++ b/web/toolbar-geckoview.js
@@ -25,18 +25,14 @@ class Toolbar {
 
   #eventBus;
 
-  #externalServices;
-
   /**
    * @param {ToolbarOptions} options
    * @param {EventBus} eventBus
    * @param {IL10n} _l10n - Localization service.
    * @param {Object} nimbusData - Nimbus configuration.
-   * @param {Object} externalServices - Interface for external services.
    */
-  constructor(options, eventBus, _l10n, nimbusData, externalServices) {
+  constructor(options, eventBus, _l10n, nimbusData) {
     this.#eventBus = eventBus;
-    this.#externalServices = externalServices;
     const buttons = [
       {
         element: options.download,
@@ -88,9 +84,12 @@ class Toolbar {
       element.addEventListener("click", evt => {
         if (eventName !== null) {
           this.#eventBus.dispatch(eventName, { source: this, ...eventDetails });
-          this.#externalServices.reportTelemetry({
-            type: "gv-buttons",
-            data: { id: `${element.id}_tapped` },
+          this.#eventBus.dispatch("reporttelemetry", {
+            source: this,
+            details: {
+              type: "gv-buttons",
+              data: { id: `${element.id}_tapped` },
+            },
           });
         }
       });


### PR DESCRIPTION
By utilizing the recently added "reporttelemetry" event, we can avoid having to manually pass in `externalServices` to a number of viewer components.