### PR TITLE
Ensure that all "alt_text_*" save-telemetry values are boolean (PR 16987 follow-up)

### DIFF
--- a/web/alt_text_manager.js
+++ b/web/alt_text_manager.js
@@ -230,7 +230,7 @@ class AltTextManager {
           action: "alt_text_save",
           alt_text_description: !!altText,
           alt_text_edit:
-            this.#previousAltText && this.#previousAltText !== altText,
+            !!this.#previousAltText && this.#previousAltText !== altText,
           alt_text_decorative: decorative,
           alt_text_keyboard: !this.#hasUsedPointer,
         },


### PR DESCRIPTION
Looking at the save-telemetry values they're all boolean *except* for "alt_text_edit" in one instance, since `this.#previousAltText` may be an empty string (looking at the `editAltText` method) and this value may thus become an empty string as well.

@calixteman This is something that I missed during review, and hopefully I've not misunderstood your intended use-case for this value (in which case you can just close the PR).