### PR TITLE
[GeckoView] Exclude `annotation_editor_layer_builder.css` in the build (issue 16994)

### DIFF
--- a/external/builder/builder.mjs
+++ b/external/builder/builder.mjs
@@ -42,6 +42,12 @@ function preprocess(inFilename, outFilename, defines) {
     return content.replaceAll(
       /^\s*@import\s+url\(([^)]+)\);\s*$/gm,
       function (all, url) {
+        if (defines.GECKOVIEW) {
+          switch (url) {
+            case "annotation_editor_layer_builder.css":
+              return "";
+          }
+        }
         const file = path.join(path.dirname(baseUrl), url);
         const imported = fs.readFileSync(file, "utf8").toString();
         return expandCssImports(imported, file);

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -1354,6 +1354,7 @@ gulp.task(
       console.log();
       console.log("### Building mozilla-central extension");
       const defines = builder.merge(DEFINES, { MOZCENTRAL: true });
+      const gvDefines = builder.merge(defines, { GECKOVIEW: true });
 
       const MOZCENTRAL_DIR = BUILD_DIR + "mozcentral/",
         MOZCENTRAL_EXTENSION_DIR = MOZCENTRAL_DIR + "browser/extensions/pdfjs/",
@@ -1405,7 +1406,7 @@ gulp.task(
         preprocessHTML("web/viewer.html", defines).pipe(
           gulp.dest(MOZCENTRAL_CONTENT_DIR + "web")
         ),
-        preprocessHTML("web/viewer-geckoview.html", defines).pipe(
+        preprocessHTML("web/viewer-geckoview.html", gvDefines).pipe(
           gulp.dest(MOZCENTRAL_CONTENT_DIR + "web")
         ),
 
@@ -1414,7 +1415,7 @@ gulp.task(
           .pipe(replaceMozcentralCSS())
           .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + "web")),
 
-        preprocessCSS("web/viewer-geckoview.css", defines)
+        preprocessCSS("web/viewer-geckoview.css", gvDefines)
           .pipe(postcss([autoprefixer(MOZCENTRAL_AUTOPREFIXER_CONFIG)]))
           .pipe(replaceMozcentralCSS())
           .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + "web")),

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -15,6 +15,7 @@
 @import url(text_layer_builder.css);
 @import url(annotation_layer_builder.css);
 @import url(xfa_layer_builder.css);
+/* Ignored in GECKOVIEW builds: */
 @import url(annotation_editor_layer_builder.css);
 
 :root {


### PR DESCRIPTION
Given the limitations of the old pre-processor that's used for CSS/HTML files, this unfortunately isn't as "easy" to implement as it is for JavaScript code.
Since this is the first case where we've wanted to do conditional CSS imports, rather than trying to completely re-write the pre-processor, this patch settles for handling it explicitly in the `expandCssImports` function.