### PR TITLE
[Editor] Tweak the save flow in the alt-text dialog

### DIFF
--- a/web/alt_text_manager.js
+++ b/web/alt_text_manager.js
@@ -52,6 +52,8 @@ class AltTextManager {
 
   #container;
 
+  #previousDecorative = null;
+
   constructor(
     {
       dialog,
@@ -149,6 +151,7 @@ class AltTextManager {
       this.#optionDescription.checked = true;
     }
     this.#previousAltText = this.#textarea.value = altText?.trim() || "";
+    this.#previousDecorative = decorative;
     this.#updateUIState();
 
     this.#currentEditor = editor;
@@ -265,11 +268,14 @@ class AltTextManager {
   }
 
   #updateUIState() {
-    const hasAltText = !!this.#textarea.value.trim();
+    const altText = this.#textarea.value.trim();
     const decorative = this.#optionDecorative.checked;
 
     this.#textarea.disabled = decorative;
-    this.#saveButton.disabled = !decorative && !hasAltText;
+    this.#saveButton.disabled = !(
+      this.#previousDecorative !== decorative ||
+      this.#previousAltText !== altText
+    );
   }
 
   #save() {


### PR DESCRIPTION
When the user edit an existing alt-text and remove it, we want to be able to save this state and consequently remove the done state from the alt-text button.
Remove the button from its parent when the editor is removed: it should help to save few Kb of memory.