### PR TITLE
Don't reset `this.#currentEditor` when destroying the dialog

### DIFF
--- a/web/alt_text_manager.js
+++ b/web/alt_text_manager.js
@@ -307,8 +307,7 @@ class AltTextManager {
   }
 
   destroy() {
-    this.#currentEditor = null;
-    this.#uiManager = null;
+    this.#uiManager = null; // Avoid re-adding the edit listeners.
     this.#finish();
     this.#svgElement?.remove();
     this.#svgElement = this.#rectElement = null;


### PR DESCRIPTION
This patch addresses an edge-case that'll probably never happen, but it nonetheless seems like something that we want to fix.

Note how we're using the `#currentEditor`-field to prevent opening the dialog when it's already active, and it being reset once the dialog has been closed.
By also resetting the `#currentEditor`-field during destruction, instead of waiting until the dialog has actually closed (assuming it's currently open), there's a *tiny* window of time[1] during which we could theoretically allow to (incorrectly) re-open the dialog and thus getting out-of-sync state in the viewer-component.

---
[1] Since the "close" event, on a dialog-element, is dispatched asynchronously by the browser.