### PR TITLE
Don't bother trying to unregister the "reporttelemetry" event listener

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2007,6 +2007,8 @@ const PDFViewerApplication = {
       eventBus._on("openfile", webViewerOpenFile);
     }
     if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
+      // The `unbindEvents` method is unused in MOZCENTRAL builds,
+      // hence we don't need to unregister these event listeners.
       eventBus._on(
         "annotationeditorstateschanged",
         webViewerAnnotationEditorStatesChanged
@@ -2139,9 +2141,6 @@ const PDFViewerApplication = {
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       eventBus._off("fileinputchange", webViewerFileInputChange);
       eventBus._off("openfile", webViewerOpenFile);
-    }
-    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
-      eventBus._off("reporttelemetry", webViewerReportTelemetry);
     }
 
     _boundEvents.beforePrint = null;


### PR DESCRIPTION
Note that both event-unbind methods are unused in MOZCENTRAL builds; see https://searchfox.org/mozilla-central/rev/48b6992e03fa66f77ac9688ba61c95d31a451bc1/toolkit/components/pdfjs/content/web/viewer.js#1864-1869