### PR TITLE
[Editor] Disable context menu on alt-text button and in the associated dialog

### DIFF
--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -834,6 +834,8 @@ class AnnotationEditor {
     altText.textContent = msg;
     altText.setAttribute("aria-label", msg);
     altText.tabIndex = "0";
+    altText.addEventListener("contextmenu", AnnotationEditor.#noContextMenu);
+    altText.addEventListener("pointerdown", event => event.stopPropagation());
     altText.addEventListener(
       "click",
       event => {

--- a/web/alt_text_manager.js
+++ b/web/alt_text_manager.js
@@ -78,6 +78,11 @@ class AltTextManager {
     this.#container = container;
 
     dialog.addEventListener("close", this.#close.bind(this));
+    dialog.addEventListener("contextmenu", event => {
+      if (event.target !== this.#textarea) {
+        event.preventDefault();
+      }
+    });
     cancelButton.addEventListener("click", this.#finish.bind(this));
     saveButton.addEventListener("click", this.#save.bind(this));
     optionDescription.addEventListener("change", this.#boundUpdateUIState);


### PR DESCRIPTION
but keep it for the text area.
Disable pointerdown on the alt-text button to disable dragging the editor when the button is clicked (especially when slightly moving the mouse between the down and the up).