### PR TITLE
Fix integration test "Interaction in autoprint.pdf must check if printing is triggered when the document is open"

### DIFF
--- a/test/integration/scripting_spec.js
+++ b/test/integration/scripting_spec.js
@@ -1793,13 +1793,7 @@ describe("Interaction", () => {
     it("must check if printing is triggered when the document is open", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
-          await page.waitForFunction(
-            "window.PDFViewerApplication.scriptingReady === true"
-          );
-
-          await page.waitForFunction(
-            `document.querySelector(".printedPage") !== null`
-          );
+          await page.waitForSelector(".printedPage");
           await page.keyboard.press("Escape");
         })
       );


### PR DESCRIPTION
_This is part 5 of the work to create tickets for and on a case-by-case basis fix intermittently failing integration tests._

The commit messages contain more information about the individual changes.

Fixes #16965.