### PR TITLE
[Editor] Add padding to the altText-button to account for different locales

### DIFF
--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -462,6 +462,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding-inline: 4px;
   width: auto;
   height: 24px;
   min-width: 88px;


### PR DESCRIPTION
*For many non-English locales the translated strings will be longer, which is easy to forget about during development/review.*

Note how for some locales (e.g. Swedish) the altText-button end up looking horizontally "cramped", hence it seems reasonable to add a bit of inline padding to improve this.

 - With `master`
 
   ![master](https://github.com/mozilla/pdf.js/assets/2692120/cb0470d0-8cc9-4d7c-b73a-12cc1442c007)

 - With this patch
 
   ![patch](https://github.com/mozilla/pdf.js/assets/2692120/6dfaf273-04fa-4159-a010-544be28fa0b8)
