### PR TITLE
Update Puppeteer to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "postcss-discard-comments": "^6.0.0",
         "postcss-nesting": "^12.0.1",
         "prettier": "^3.0.3",
-        "puppeteer": "^21.2.1",
+        "puppeteer": "^21.3.4",
         "rimraf": "^3.0.2",
         "streamqueue": "^1.1.2",
         "stylelint": "^15.10.3",
@@ -3267,9 +3267,9 @@
       }
     },
     "node_modules/@types/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.1.tgz",
+      "integrity": "sha512-CHzgNU3qYBnp/O4S3yv2tXPlvMTq0YWSTVg2/JYLqWZGHwwgJGAwd00poay/11asPq8wLFwHzubyInqHIFmmiw==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -4830,12 +4830,13 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.26.tgz",
-      "integrity": "sha512-lukBGfogAI4T0y3acc86RaacqgKQve47/8pV2c+Hr1PjcICj2K4OkL3qfX3qrqxxnd4ddurFC0WBA3VCQqYeUQ==",
+      "version": "0.4.28",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.28.tgz",
+      "integrity": "sha512-2HZ74QlAApJrEwcGlU/sUu0s4VS+FI3CJ09Toc9aE9VemMyhHZXeaROQgJKNRaYMUTUx6qIv1cLBs3F+vfgjSw==",
       "dev": true,
       "dependencies": {
-        "mitt": "3.0.1"
+        "mitt": "3.0.1",
+        "urlpattern-polyfill": "9.0.0"
       },
       "peerDependencies": {
         "devtools-protocol": "*"
@@ -5206,9 +5207,9 @@
       "dev": true
     },
     "node_modules/cosmiconfig": {
-      "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.5.tgz",
-      "integrity": "sha512-A5Xry3xfS96wy2qbiLkQLAg4JUrR2wvfybxj6yqLmrUfMAvhS3MZxIP2oQn0grgYIvJqzpeTEWu4vK0t+12NNw==",
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "dev": true,
       "dependencies": {
         "import-fresh": "^3.3.0",
@@ -5660,9 +5661,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1159816",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1159816.tgz",
-      "integrity": "sha512-2cZlHxC5IlgkIWe2pSDmCrDiTzbSJWywjbDDnupOImEBcG31CQgBLV8wWE+5t+C4rimcjHsbzy7CBzf9oFjboA==",
+      "version": "0.0.1179426",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1179426.tgz",
+      "integrity": "sha512-KKC7IGwdOr7u9kTGgjUvGTov/z1s2H7oHi3zKCdR9eSDyCPia5CBi4aRhtp7d8uR7l0GS5UTDw3TjKGu5CqINg==",
       "dev": true
     },
     "node_modules/diagnostics": {
@@ -17200,32 +17201,32 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.2.1.tgz",
-      "integrity": "sha512-bgY/lYBH3rR+m5EP1FxzY2MRMrau7Pyq+N5YlspA63sF+cBkUiTn5WZXwXm7mEHwkkOSVi5LiS74T5QIgrSklg==",
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.3.4.tgz",
+      "integrity": "sha512-kE67k1KR6hQs3g0Yf/i3GYOhTU8zC2dtcpHhtcSC9bGoVxRgqDo/hwVkDqlNKxJsJHuVX+qviWC7F0FdSjcFTA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "1.7.1",
-        "cosmiconfig": "8.3.5",
-        "puppeteer-core": "21.2.1"
+        "cosmiconfig": "8.3.6",
+        "puppeteer-core": "21.3.4"
       },
       "engines": {
         "node": ">=16.3.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.2.1.tgz",
-      "integrity": "sha512-+I8EjpWFeeFKScpQiTEnC4jGve2Wr4eA9qUMoa8S317DJPm9h7wzrT4YednZK2TQZMyPtPQ2Disb/Tg02+4Naw==",
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.3.4.tgz",
+      "integrity": "sha512-iaG7ScTXOm9hlsBTBGGtr5dAAsA8IiWTx8E0Ghr0b5Ntl42bdcPS8EXjcERKocDhua2YqdlnFGs/cBxHY+VNyA==",
       "dev": true,
       "dependencies": {
         "@puppeteer/browsers": "1.7.1",
-        "chromium-bidi": "0.4.26",
+        "chromium-bidi": "0.4.28",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1159816",
-        "ws": "8.14.1"
+        "devtools-protocol": "0.0.1179426",
+        "ws": "8.14.2"
       },
       "engines": {
         "node": ">=16.3.0"
@@ -20486,6 +20487,12 @@
       "deprecated": "Please see https://github.com/lydell/urix#deprecated",
       "dev": true
     },
+    "node_modules/urlpattern-polyfill": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
+      "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+      "dev": true
+    },
     "node_modules/use": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
@@ -21284,9 +21291,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.1.tgz",
-      "integrity": "sha512-4OOseMUq8AzRBI/7SLMUwO+FEDnguetSk7KMb1sHwvF2w2Wv5Hoj0nlifx8vtGsftE/jWHojPy8sMMzYLJ2G/A==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "postcss-discard-comments": "^6.0.0",
     "postcss-nesting": "^12.0.1",
     "prettier": "^3.0.3",
-    "puppeteer": "^21.2.1",
+    "puppeteer": "^21.3.4",
     "rimraf": "^3.0.2",
     "streamqueue": "^1.1.2",
     "stylelint": "^15.10.3",
@@ -62,7 +62,7 @@
     "yargs": "^17.7.2"
   },
   "scripts": {
-    "postinstall": "cross-env PUPPETEER_PRODUCT=firefox node node_modules/puppeteer/install.js"
+    "postinstall": "cross-env PUPPETEER_PRODUCT=firefox node node_modules/puppeteer/install.mjs"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This also required updating the `postinstall`-step to account for recent changes in Puppeteer.