### PR TITLE
[Editor] Remove the class fooEditing from the layer when destroying it

### DIFF
--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -941,7 +941,7 @@ class AnnotationEditor {
 
   /**
    * Render this editor in a div.
-   * @returns {HTMLDivElement}
+   * @returns {HTMLDivElement | null}
    */
   render() {
     this.div = document.createElement("div");
@@ -1192,8 +1192,9 @@ class AnnotationEditor {
    * new annotation to add to the pdf document.
    *
    * To implement in subclasses.
-   * @param {boolean} isForCopying
-   * @param {Object} [context]
+   * @param {boolean} [isForCopying]
+   * @param {Object | null} [context]
+   * @returns {Object | null}
    */
   serialize(isForCopying = false, context = null) {
     unreachable("An editor must be serializable");
@@ -1206,7 +1207,7 @@ class AnnotationEditor {
    * @param {Object} data
    * @param {AnnotationEditorLayer} parent
    * @param {AnnotationEditorUIManager} uiManager
-   * @returns {AnnotationEditor}
+   * @returns {AnnotationEditor | null}
    */
   static deserialize(data, parent, uiManager) {
     const editor = new this.prototype.constructor({
@@ -1327,6 +1328,7 @@ class AnnotationEditor {
 
   /**
    * Get the div which really contains the displayed content.
+   * @returns {HTMLDivElement | undefined}
    */
   get contentDiv() {
     return this.div;

--- a/src/display/editor/freetext.js
+++ b/src/display/editor/freetext.js
@@ -132,6 +132,8 @@ class FreeTextEditor extends AnnotationEditor {
 
   static _type = "freetext";
 
+  static _editorType = AnnotationEditorType.FREETEXT;
+
   constructor(params) {
     super({ ...params, name: "freeTextEditor" });
     this.#color =
@@ -335,7 +337,7 @@ class FreeTextEditor extends AnnotationEditor {
 
     // In case the blur callback hasn't been called.
     this.isEditing = false;
-    this.parent.div.classList.add("freeTextEditing");
+    this.parent.div.classList.add("freetextEditing");
   }
 
   /** @inheritdoc */
@@ -374,7 +376,7 @@ class FreeTextEditor extends AnnotationEditor {
     this.isEditing = false;
     if (this.parent) {
       this.parent.setEditingState(true);
-      this.parent.div.classList.add("freeTextEditing");
+      this.parent.div.classList.add("freetextEditing");
     }
     super.remove();
   }
@@ -508,7 +510,7 @@ class FreeTextEditor extends AnnotationEditor {
   }
 
   editorDivInput(event) {
-    this.parent.div.classList.toggle("freeTextEditing", this.isEmpty());
+    this.parent.div.classList.toggle("freetextEditing", this.isEmpty());
   }
 
   /** @inheritdoc */
@@ -649,6 +651,7 @@ class FreeTextEditor extends AnnotationEditor {
     }
   }
 
+  /** @inheritdoc */
   get contentDiv() {
     return this.editorDiv;
   }

--- a/src/display/editor/ink.js
+++ b/src/display/editor/ink.js
@@ -63,6 +63,8 @@ class InkEditor extends AnnotationEditor {
 
   static _type = "ink";
 
+  static _editorType = AnnotationEditorType.INK;
+
   constructor(params) {
     super({ ...params, name: "inkEditor" });
     this.color = params.color || null;

--- a/src/display/editor/stamp.js
+++ b/src/display/editor/stamp.js
@@ -44,6 +44,8 @@ class StampEditor extends AnnotationEditor {
 
   static _type = "stamp";
 
+  static _editorType = AnnotationEditorType.STAMP;
+
   constructor(params) {
     super({ ...params, name: "stampEditor" });
     this.#bitmapUrl = params.bitmapUrl;

--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -121,7 +121,7 @@
   height: 100%;
 }
 
-.annotationEditorLayer.freeTextEditing {
+.annotationEditorLayer.freetextEditing {
   cursor: var(--editorFreeText-editing-cursor);
 }
 


### PR DESCRIPTION
and simplify the way to handle the different types of editors.