### PR TITLE
Remove comments from the *built* CSS files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "pngjs": "^7.0.0",
         "postcss": "^8.4.30",
         "postcss-dir-pseudo-class": "^8.0.0",
+        "postcss-discard-comments": "^6.0.0",
         "postcss-nesting": "^12.0.1",
         "prettier": "^3.0.3",
         "puppeteer": "^21.2.1",
@@ -16766,6 +16767,18 @@
       },
       "peerDependencies": {
         "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-discard-comments": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.0.tgz",
+      "integrity": "sha512-p2skSGqzPMZkEQvJsgnkBhCn8gI7NzRH2683EEjrIkoMiwRELx68yoUJ3q3DGSGuQ8Ug9Gsn+OuDr46yfO+eFw==",
+      "dev": true,
+      "engines": {
+        "node": "^14 || ^16 || >=18.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-load-config": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "pngjs": "^7.0.0",
     "postcss": "^8.4.30",
     "postcss-dir-pseudo-class": "^8.0.0",
+    "postcss-discard-comments": "^6.0.0",
     "postcss-nesting": "^12.0.1",
     "prettier": "^3.0.3",
     "puppeteer": "^21.2.1",


### PR DESCRIPTION
The old pre-processor used for CSS, and HTML, files leaves comments intact which unnecessarily contributes to the overall size of the *built* CSS files (note that the built JavaScript files don't include comments).
Rather than trying to "hack" comment removal into the pre-processor it seems easier to use a PostCSS plugin instead. The one potential issue is that it also affects *some* whitespaces, and it's not clear to me if this'll work with the various CSS-related tests that run in mozilla-central.

Please refer to https://www.npmjs.com/package/postcss-discard-comments for additional information.