### PR TITLE
Make downloadManager optional in JSDoc types

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -60,7 +60,7 @@ function getRectDims(rect) {
  * @property {Object} data
  * @property {HTMLDivElement} layer
  * @property {IPDFLinkService} linkService
- * @property {IDownloadManager} downloadManager
+ * @property {IDownloadManager} [downloadManager]
  * @property {AnnotationStorage} [annotationStorage]
  * @property {string} [imageResourcesPath] - Path for image resources, mainly
  *   for annotation icons. Include trailing slash.

--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -37,7 +37,7 @@ import { PresentationModeState } from "./ui_utils.js";
  *   for annotation icons. Include trailing slash.
  * @property {boolean} renderForms
  * @property {IPDFLinkService} linkService
- * @property {IDownloadManager} downloadManager
+ * @property {IDownloadManager} [downloadManager]
  * @property {IL10n} l10n - Localization service.
  * @property {boolean} [enableScripting]
  * @property {Promise<boolean>} [hasJSActionsPromise]


### PR DESCRIPTION
This pull request addresses an issue where the downloadManager parameter was incorrectly marked as required in the JSDoc types for AnnotationLayerParameters and AnnotationLayerBuilderOptions. The change aligns the parameter with similar optional parameters in the codebase for better consistency.

Details:

In pdf.js/src/display/annotation_layer.js, I updated the JSDoc comments for AnnotationLayerParameters to make downloadManager optional using square brackets.
In pdf.js/web/annotation_layer_builder.js, I did the same for the JSDoc comments for AnnotationLayerBuilderOptions.
Additionally, in pdf.js/web/text_layer_builder.js, I marked the downloadManager parameter as optional in the JSDoc comment to maintain consistency with other optional parameters.
Expected Behavior:

The downloadManager parameter should be considered optional in the JSDoc types.
What Went Wrong:

Previously, downloadManager was incorrectly marked as a required parameter.
Configuration:

PDF.js version: 2.11.174
Browser extension: No
This change resolves the issue where downloadManager was mistakenly marked as required, making it optional in the JSDoc types, improving codebase consistency.

Closes: #17029