### PR TITLE
[Editor] Remove unused CSS rules for the altText "Save"-button (PR 17015 follow-up)

### DIFF
--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -620,9 +620,6 @@
   --button-save-hover-bg-color: var(--button-save-bg-color);
   --button-save-hover-fg-color: var(--button-save-fg-color);
   --button-save-hover-border-color: var(--button-save-hover-bg-color);
-  --button-save-disabled-bg-color: var(--button-save-bg-color);
-  --button-save-disabled-fg-color: var(--button-save-fg-color);
-  --button-save-disabled-opacity: 0.4;
 
   @media (prefers-color-scheme: dark) {
     --dialog-bg-color: #1c1b22;
@@ -672,9 +669,6 @@
     --button-save-fg-color: ButtonFace;
     --button-save-hover-bg-color: AccentColor;
     --button-save-hover-fg-color: AccentColorText;
-    --button-save-disabled-bg-color: GrayText;
-    --button-save-disabled-fg-color: Canvas;
-    --button-save-disabled-opacity: 1;
   }
 
   font: message-box;
@@ -853,13 +847,6 @@
             color: var(--button-save-hover-fg-color);
             background-color: var(--button-save-hover-bg-color);
             border-color: var(--button-save-hover-border-color);
-          }
-
-          &:disabled {
-            color: var(--button-save-disabled-fg-color);
-            background-color: var(--button-save-disabled-bg-color);
-            opacity: var(--button-save-disabled-opacity);
-            pointer-events: none;
           }
         }
       }


### PR DESCRIPTION
When PR #17015 removed the `disabled` handling for the "Save"-button it left a bunch of now unused CSS rules behind, which seems like a simply oversight.
Rather than shipping "dead" CSS rules, let's remove those until such a time that they're actually needed.