### PR TITLE
[Editor] Make a deleted (when it was invisible) editor undoable

### DIFF
--- a/src/display/editor/annotation_editor_layer.js
+++ b/src/display/editor/annotation_editor_layer.js
@@ -432,6 +432,7 @@ class AnnotationEditorLayer {
    */
   addOrRebuild(editor) {
     if (editor.needsToBeRebuilt()) {
+      editor.parent ||= this;
       editor.rebuild();
     } else {
       this.add(editor);


### PR DESCRIPTION
When the editor is invisible (because on a non-rendered page) its parent is null. But when we undo its deletion, we need to have a parent to attach it.