### PR TITLE
Fix new intermittent failures with ink and stamp tests

### DIFF
--- a/test/integration/ink_editor_spec.js
+++ b/test/integration/ink_editor_spec.js
@@ -20,11 +20,11 @@ const {
   waitForStorageEntries,
 } = require("./test_utils.js");
 
-const waitForClick = async page =>
+const waitForPointerUp = page =>
   page.evaluate(
     () =>
       new Promise(resolve => {
-        window.addEventListener("click", resolve, { once: true });
+        window.addEventListener("pointerup", resolve, { once: true });
       })
   );
 
@@ -77,7 +77,7 @@ describe("Ink Editor", () => {
           for (let i = 0; i < 3; i++) {
             const x = rect.x + 100 + i * 100;
             const y = rect.y + 100 + i * 100;
-            const promise = waitForClick(page);
+            const promise = waitForPointerUp(page);
             await page.mouse.move(x, y);
             await page.mouse.down();
             await page.mouse.move(x + 50, y + 50);
@@ -115,7 +115,7 @@ describe("Ink Editor", () => {
 
           const xStart = rect.x + 300;
           const yStart = rect.y + 300;
-          const clickPromise = waitForClick(page);
+          const clickPromise = waitForPointerUp(page);
           await page.mouse.move(xStart, yStart);
           await page.mouse.down();
           await page.mouse.move(xStart + 50, yStart + 50);
@@ -185,7 +185,7 @@ describe("Ink Editor", () => {
 
           const x = rect.x + 20;
           const y = rect.y + 20;
-          const clickPromise = waitForClick(page);
+          const clickPromise = waitForPointerUp(page);
           await page.mouse.move(x, y);
           await page.mouse.down();
           await page.mouse.move(x + 50, y + 50);

--- a/test/integration/stamp_editor_spec.js
+++ b/test/integration/stamp_editor_spec.js
@@ -43,6 +43,22 @@ const clearAll = async page => {
   await waitForStorageEntries(page, 0);
 };
 
+const waitForImage = async (page, selector) => {
+  await page.waitForSelector(`${selector} canvas`);
+  await page.waitForFunction(
+    sel => {
+      const canvas = document.querySelector(sel);
+      const data = canvas
+        .getContext("2d")
+        .getImageData(0, 0, canvas.width, canvas.height);
+      return data.data.some(x => x !== 0);
+    },
+    {},
+    `${selector} canvas`
+  );
+  await page.waitForSelector(`${selector} .altText`);
+};
+
 describe("Stamp Editor", () => {
   describe("Basic operations", () => {
     let pages;
@@ -70,7 +86,7 @@ describe("Stamp Editor", () => {
           await input.uploadFile(
             `${path.join(__dirname, "../images/firefox_logo.png")}`
           );
-          await page.waitForSelector(`${getEditorSelector(0)} .altText`);
+          await waitForImage(page, getEditorSelector(0));
 
           const { width } = await getEditorDimensions(page, 0);
 
@@ -100,7 +116,7 @@ describe("Stamp Editor", () => {
           await input.uploadFile(
             `${path.join(__dirname, "../images/firefox_logo.svg")}`
           );
-          await page.waitForSelector(`${getEditorSelector(1)} .altText`);
+          await waitForImage(page, getEditorSelector(1));
 
           const { width } = await getEditorDimensions(page, 1);
 
@@ -153,6 +169,7 @@ describe("Stamp Editor", () => {
             await input.uploadFile(
               `${path.join(__dirname, "../images/firefox_logo.png")}`
             );
+            await waitForImage(page, getEditorSelector(i));
             await page.waitForSelector(`${getEditorSelector(i)} .altText`);
 
             for (let j = 0; j < 4; j++) {
@@ -236,8 +253,10 @@ describe("Stamp Editor", () => {
           await page.keyboard.press("v");
           await page.keyboard.up("Control");
 
+          await waitForImage(page, getEditorSelector(0));
+
           // Wait for the alt-text button to be visible.
-          const buttonSelector = "#pdfjs_internal_editor_0 button.altText";
+          const buttonSelector = `${getEditorSelector(0)} button.altText`;
           await page.waitForSelector(buttonSelector);
 
           // Click on the alt-text button.

--- a/test/integration/test_utils.js
+++ b/test/integration/test_utils.js
@@ -207,7 +207,18 @@ function getEditorDimensions(page, id) {
 }
 exports.getEditorDimensions = getEditorDimensions;
 
-function serializeBitmapDimensions(page) {
+async function serializeBitmapDimensions(page) {
+  await page.waitForFunction(() => {
+    try {
+      const map =
+        window.PDFViewerApplication.pdfDocument.annotationStorage.serializable
+          .map;
+      return !!map;
+    } catch {
+      return false;
+    }
+  });
+
   return page.evaluate(() => {
     const { map } =
       window.PDFViewerApplication.pdfDocument.annotationStorage.serializable;


### PR DESCRIPTION
It happens only on windows with chrome.
For any reason, click event isn't correctly triggered and it seems work correctly with pointerup.
And it seems that when drawing a svg on an OffscreenCanvas we need to wait a little in order to be able to transfer it: it's why this patch adds a check on the canvas content.