### PR TITLE
Output `pdf.scripting.js` as a JavaScript module (PR 17055 follow-up)

### DIFF
--- a/src/pdf.scripting.js
+++ b/src/pdf.scripting.js
@@ -22,4 +22,6 @@ const pdfjsVersion =
 const pdfjsBuild =
   typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_BUILD") : void 0;
 
-export { initSandbox };
+// To avoid problems with `export` statements in the QuickJS Javascript Engine,
+// we manually expose `pdfjsScripting` globally instead.
+globalThis.pdfjsScripting = { initSandbox };


### PR DESCRIPTION
To avoid problems with `export` statements in the QuickJS Javascript Engine, we can work-around that by *explicitly* exposing `pdfjsScripting` globally instead.