### PR TITLE
Activate the selector check for the `autoprint` integration test as soon as possible

### DIFF
--- a/test/integration/scripting_spec.js
+++ b/test/integration/scripting_spec.js
@@ -1773,7 +1773,16 @@ describe("Interaction", () => {
     let pages;
 
     beforeAll(async () => {
-      pages = await loadAndWait("autoprint.pdf", ".endOfContent");
+      // Autoprinting is triggered by the `Open` event, which is one of the
+      // first events to be dispatched to the sandbox, even before scripting
+      // is reported to be ready. It's therefore important that `loadAndWait`
+      // returns control as soon as possible after opening the PDF document,
+      // and the first element we can check for is the `<html>` tag of the
+      // viewer. Note that the `autoprint.pdf` file is very small, so printing
+      // it is usually very fast and therefore activating the selector check
+      // too late will cause it to never resolve because printing is already
+      // done (and the printed page div removed) before we even get to it.
+      pages = await loadAndWait("autoprint.pdf", "html");
     });
 
     afterAll(async () => {


### PR DESCRIPTION
The Windows bot is usually slower than the Linux bot, and therefore text layer rendering is as well. However, the `autoprint` test awaited text layer rendering to complete before activating the selector check, which makes it timing-sensitive and causes it to never resolve because the page is already printed (and the printed page div removed) by then.

This commit should fix the issue by activating the selector check as soon as possible, namely as soon as the viewer appears, which should ensure we're always registering the selector check in time because we're doing it even before rendering is starting.

Fixes #16965.