### PR TITLE
Rename `web/debugger.js` since it's actually a JavaScript module (PR 17055 follow-up)

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -68,7 +68,7 @@ const TMP_DIR = BUILD_DIR + "tmp/";
 const TYPESTEST_DIR = BUILD_DIR + "typestest/";
 const COMMON_WEB_FILES = [
   "web/images/*.{png,svg,gif}",
-  "web/debugger.{css,js}",
+  "web/debugger.{css,mjs}",
 ];
 const MOZCENTRAL_DIFF_FILE = "mozcentral.diff";
 

--- a/web/debugger.mjs
+++ b/web/debugger.mjs
@@ -574,7 +574,7 @@ class PDFBug {
 
     const link = document.createElement("link");
     link.rel = "stylesheet";
-    link.href = url.replace(/.js$/, ".css");
+    link.href = url.replace(/\.mjs$/, ".css");
 
     document.head.append(link);
   }

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -178,7 +178,7 @@ function getViewerConfiguration() {
       typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")
         ? document.getElementById("fileInput")
         : null,
-    debuggerScriptPath: "./debugger.js",
+    debuggerScriptPath: "./debugger.mjs",
   };
 }
 


### PR DESCRIPTION
It's been loaded as a JavaScript module for a long time, and given that the file is bundled as-is (without building) it seems reasonable to just change the file extension now.