### PR TITLE
Fix the protocol timeout configuration for Puppeteer

### DIFF
--- a/test/test.mjs
+++ b/test/test.mjs
@@ -907,6 +907,11 @@ async function startBrowser(browserName, startUrl = "") {
     headless: false,
     defaultViewport: null,
     ignoreDefaultArgs: ["--disable-extensions"],
+    // The timeout for individual protocol (CDP) calls should always be lower
+    // than the Jasmine timeout. This way protocol errors are always raised in
+    // the context of the tests that actually triggered them and don't leak
+    // through to other tests (causing unrelated failures or tracebacks).
+    protocolTimeout: /* jasmine.DEFAULT_TIMEOUT_INTERVAL = */ 30000 - 1000,
   };
 
   if (!tempDir) {


### PR DESCRIPTION
The default protocol timeout is 180 seconds according to the documentation at https://pptr.dev/api/puppeteer.browserconnectoptions, but the Jasmine timeout we configure in the individual boot files is 30 seconds. The consequence of this is that if a protocol (CDP) error occurs after 30 seconds Jasmine will fail the test, but the actual protocol error from Puppeteer is raised much later in the context of another test, which causes unrelated failures or tracebacks.

This commit fixes the problem by configuring Puppeteer to always use a lower protocol timeout than the Jasmine timeout so that protocol errors are always raised in the context of the test that actually triggered it.

Fixes the side-effects part of #17087.