### PR TITLE
Don't steal the copy event (bug 1857823)

### DIFF
--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -218,17 +218,26 @@ class TextLayerBuilder {
       end.classList.remove("active");
     });
 
-    div.addEventListener("copy", event => {
-      if (!this.#enablePermissions) {
-        const selection = document.getSelection();
-        event.clipboardData.setData(
-          "text/plain",
-          removeNullCharacters(normalizeUnicode(selection.toString()))
-        );
-      }
-      event.preventDefault();
-      event.stopPropagation();
-    });
+    div.addEventListener(
+      "copy",
+      event => {
+        if (!this.#enablePermissions) {
+          const selection = document.getSelection();
+          event.clipboardData.setData(
+            "text/plain",
+            removeNullCharacters(normalizeUnicode(selection.toString()))
+          );
+        } else {
+          event.stopPropagation();
+        }
+        // It's required after the clipboard data have been changed else the
+        // clipboard will contain the selection!
+        event.preventDefault();
+      },
+      // Capture the event in order to be sure that the copy event has the
+      // correct value.
+      { capture: true }
+    );
   }
 }
 


### PR DESCRIPTION
There were no specific reasons to stop the propagation of the event and it can be useful for some third parties to catch the event to let them do their own stuff.