### PR TITLE
Update the "Interactive examples" links (PR 17055 follow-up)

### DIFF
--- a/docs/contents/examples/index.md
+++ b/docs/contents/examples/index.md
@@ -83,17 +83,17 @@ var scaledViewport = page.getViewport({ scale: scale, });
 The example demonstrates how promises can be used to handle errors during loading.
 It also demonstrates how to wait until a page is loaded and rendered.
 
-<script async src="//jsfiddle.net/pdfjs/9engc9mw/embed/js,html,css,result/"></script>
+<script async src="//jsfiddle.net/pdfjs/9engc9mw/embed/html,css,result/"></script>
 
 ### Hello World using base64 encoded PDF
 
 The PDF.js can accept any decoded base64 data as an array.
 
-<script async src="//jsfiddle.net/pdfjs/cq0asLqz/embed/js,html,css,result/"></script>
+<script async src="//jsfiddle.net/pdfjs/cq0asLqz/embed/html,css,result/"></script>
 
 ### Previous/Next example
 
 The same canvas cannot be used to perform to draw two pages at the same time --
 the example demonstrates how to wait on previous operation to be complete.
 
-<script async src="//jsfiddle.net/pdfjs/wagvs9Lf/embed/js,html,css,result/"></script>
+<script async src="//jsfiddle.net/pdfjs/wagvs9Lf/embed/html,css,result/"></script>


### PR DESCRIPTION
The examples themselves were updated to account for JavaScript modules, which didn't require changing the actual URLs.
However, since it seems that JSFiddle doesn't support JavaScript modules in its separate "JavaScript" editing-area we need to change how we embed the examples to avoid showing a blank "JavaScript"-tab.