### PR TITLE
Enable the `import/no-commonjs` ESLint plugin rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,6 +39,7 @@
     "import/named": "error",
     "import/no-cycle": "error",
     "import/no-empty-named-blocks": "error",
+    "import/no-commonjs": "error",
     "import/no-mutable-exports": "error",
     "import/no-self-import": "error",
     "import/no-unresolved": ["error", {

--- a/examples/node/getinfo.js
+++ b/examples/node/getinfo.js
@@ -1,6 +1,8 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
+/* eslint-disable import/no-commonjs */
+
 //
 // Basic node example that prints document metadata and text content.
 //

--- a/examples/node/pdf2png/pdf2png.js
+++ b/examples/node/pdf2png/pdf2png.js
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint-disable import/no-commonjs */
 
 const Canvas = require("canvas");
 const assert = require("assert").strict;

--- a/examples/webpack/main.js
+++ b/examples/webpack/main.js
@@ -1,6 +1,8 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/licenses/publicdomain/
 
+/* eslint-disable import/no-commonjs */
+
 // Hello world example for webpack.
 
 const pdfjsLib = require("pdfjs-dist");

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -1,3 +1,5 @@
+/* eslint-disable import/no-commonjs */
+
 const webpack = require("webpack"); // eslint-disable-line no-unused-vars
 const path = require("path");
 

--- a/external/dist/webpack.js
+++ b/external/dist/webpack.js
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint-disable import/no-commonjs */
 
 "use strict";
 

--- a/src/pdf.worker.entry.js
+++ b/src/pdf.worker.entry.js
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint-disable import/no-commonjs */
 
 (typeof window !== "undefined"
   ? window

--- a/test/chromium/test-telemetry.js
+++ b/test/chromium/test-telemetry.js
@@ -15,11 +15,9 @@
  */
 /* eslint-disable no-var */
 
-"use strict";
-
-var assert = require("assert");
-var fs = require("fs");
-var vm = require("vm");
+import assert from "assert";
+import fs from "fs";
+import vm from "vm";
 
 var SRC_DIR = __dirname + "/../../";
 var telemetryJsPath = "extensions/chromium/telemetry.js";

--- a/test/stats/statcmp.js
+++ b/test/stats/statcmp.js
@@ -1,3 +1,5 @@
+/* eslint-disable import/no-commonjs */
+
 import { createRequire } from "module";
 import fs from "fs";
 


### PR DESCRIPTION
Given the amount of work put into removing `require`-calls from the code-base, let's ensure that new ones aren't accidentally added in the future.

Note that we still have a couple of files where `require` is being used, in particular:
 - The Node.js examples, however those will be updated to use `import` in PR #17081.
 - The Webpack examples, and related support files, however I unfortunately don't know enough about Webpack to be able to update those. (Hopefully users of that code will help out here, once version `4` is released.)
 - The `statcmp`-tool, since *some* of those `require`-calls cannot be converted to `import` without other code changes (and that file is only used during benchmarking).

Please find additional details at https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-commonjs.md