### PR TITLE
Remove Escape key press from the `autoprint` integration test, and tweak the protocol timeout configuration for Puppeteer

### DIFF
--- a/test/integration/scripting_spec.mjs
+++ b/test/integration/scripting_spec.mjs
@@ -1793,7 +1793,6 @@ describe("Interaction", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           await page.waitForSelector(".printedPage");
-          await page.keyboard.press("Escape");
         })
       );
     });

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -910,8 +910,11 @@ async function startBrowser(browserName, startUrl = "") {
     // The timeout for individual protocol (CDP) calls should always be lower
     // than the Jasmine timeout. This way protocol errors are always raised in
     // the context of the tests that actually triggered them and don't leak
-    // through to other tests (causing unrelated failures or tracebacks).
-    protocolTimeout: /* jasmine.DEFAULT_TIMEOUT_INTERVAL = */ 30000 - 1000,
+    // through to other tests (causing unrelated failures or tracebacks). The
+    // timeout is set to 75% of the Jasmine timeout to catch operation errors
+    // later in the test run and because if a single operation takes that long
+    // it can't possibly succeed anymore.
+    protocolTimeout: 0.75 * /* jasmine.DEFAULT_TIMEOUT_INTERVAL = */ 30000,
   };
 
   if (!tempDir) {


### PR DESCRIPTION
The commit messages contain more details about the individual changes.

Fixes #16965.