### PR TITLE
Update the ESLint `globals` list (PR 17055 follow-up)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,6 @@
     "browser": true,
     "es2022": true,
     "worker": true,
-    "amd": true,
   },
 
   "globals": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -26,8 +26,8 @@
   },
 
   "globals": {
-    "PDFJSDev": false,
-    "exports": false,
+    "PDFJSDev": "readonly",
+    "__non_webpack_import__": "readonly",
   },
 
   "rules": {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2306,7 +2306,7 @@ class PDFWorker {
       const worker =
         typeof PDFJSDev === "undefined"
           ? await import("pdfjs/pdf.worker.js")
-          : await __non_webpack_import__(this.workerSrc); // eslint-disable-line no-undef
+          : await __non_webpack_import__(this.workerSrc);
       return worker.WorkerMessageHandler;
     };
 

--- a/src/display/node_stream.js
+++ b/src/display/node_stream.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals __non_webpack_import__ */
 
 import {
   AbortException,

--- a/src/display/node_utils.js
+++ b/src/display/node_utils.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals __non_webpack_import__ */
 
 import {
   BaseCanvasFactory,

--- a/src/pdf.worker.entry.js
+++ b/src/pdf.worker.entry.js
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* globals require:readonly */
 /* eslint-disable import/no-commonjs */
 
 (typeof window !== "undefined"

--- a/test/unit/node_stream_spec.js
+++ b/test/unit/node_stream_spec.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals __non_webpack_import__ */
 
 import { AbortException, isNodeJS } from "../../src/shared/util.js";
 import { PDFNodeStream } from "../../src/display/node_stream.js";

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals __non_webpack_import__ */
 
 import { NullStream, StringStream } from "../../src/core/stream.js";
 import { Page, PDFDocument } from "../../src/core/document.js";

--- a/web/app.js
+++ b/web/app.js
@@ -2268,7 +2268,7 @@ async function loadFakeWorker() {
     globalThis.pdfjsWorker = await import("pdfjs/pdf.worker.js");
     return;
   }
-  await __non_webpack_import__(PDFWorker.workerSrc); // eslint-disable-line no-undef
+  await __non_webpack_import__(PDFWorker.workerSrc);
 }
 
 async function loadPDFBug(self) {
@@ -2276,7 +2276,7 @@ async function loadPDFBug(self) {
   const { PDFBug } =
     typeof PDFJSDev === "undefined"
       ? await import(debuggerScriptPath) // eslint-disable-line no-unsanitized/method
-      : await __non_webpack_import__(debuggerScriptPath); // eslint-disable-line no-undef
+      : await __non_webpack_import__(debuggerScriptPath);
 
   self._PDFBug = PDFBug;
 }

--- a/web/generic_scripting.js
+++ b/web/generic_scripting.js
@@ -45,7 +45,7 @@ class GenericScripting {
       const sandbox =
         typeof PDFJSDev === "undefined"
           ? import(sandboxBundleSrc) // eslint-disable-line no-unsanitized/method
-          : __non_webpack_import__(sandboxBundleSrc); // eslint-disable-line no-undef
+          : __non_webpack_import__(sandboxBundleSrc);
       sandbox
         .then(pdfjsSandbox => {
           resolve(pdfjsSandbox.QuickJSSandbox());


### PR DESCRIPTION
Given that we only use standard `import`/`export` statements now, after recent PRs, the "exports" global is unused.
Instead we add "\_\_non_webpack_import__" to the `globals` to avoid having to sprinkle disable statements throughout the code.

Finally, the way that `globals` are defined has changed in ESLint and we should thus explicitly specify them as "readonly"; please find additional details at https://eslint.org/docs/latest/use/configure/language-options#specifying-globals