### PR TITLE
Show the first page of the PDF files explicitly in the integration tests

### DIFF
--- a/test/integration/find_spec.mjs
+++ b/test/integration/find_spec.mjs
@@ -29,7 +29,7 @@ describe("find bar", () => {
     let pages;
 
     beforeAll(async () => {
-      pages = await loadAndWait("find_all.pdf#zoom=100", ".textLayer");
+      pages = await loadAndWait("find_all.pdf", ".textLayer", 100);
     });
 
     afterAll(async () => {
@@ -76,7 +76,7 @@ describe("find bar", () => {
     let pages;
 
     beforeAll(async () => {
-      pages = await loadAndWait("xfa_imm5257e.pdf#zoom=100", ".xfaLayer");
+      pages = await loadAndWait("xfa_imm5257e.pdf", ".xfaLayer", 100);
     });
 
     afterAll(async () => {

--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -33,9 +33,9 @@ function loadAndWait(filename, selector, zoom, pageSetup) {
         });
       });
 
-      let url = `${global.integrationBaseUrl}?file=/test/pdfs/${filename}`;
+      let url = `${global.integrationBaseUrl}?file=/test/pdfs/${filename}#page=1`;
       if (zoom) {
-        url += `#zoom=${zoom}`;
+        url += `&zoom=${zoom}`;
       }
       await page.goto(url);
       if (pageSetup) {


### PR DESCRIPTION
Most integration tests currently implicitly rely on the fact that if we load a PDF file into the viewer that the first page is shown. However, this is not enforced explicitly, so if there is e.g. viewer history or scroll events happen the first page might not be visible (entirely) before the test runs.

I noticed this in debugging #17087 and #17096 where those tests fail in the same way as on the bots if I manually enforced a different page during load or if I scrolled before the page was fully loaded. For both tests it makes sense that they fail then: the find test doesn't have the first result in view, so if we search we'll always find a later result, and the freetext test doesn't await the first selector because it assumes it's in view (note how it does check the last selector because we perform an action to navigate there).

This commit should fix the problems by explicitly enforcing loading of the first page, and thereby also ensuring we start at the top of the page which is important for e.g. the find test. Note that this also requires the find tests to use the existing `zoom` argument instead of manually providing hash parameters.