### PR TITLE
Fix intermittent problems on Windows in the XFA search integration test

### DIFF
--- a/test/integration/find_spec.mjs
+++ b/test/integration/find_spec.mjs
@@ -88,19 +88,19 @@ describe("find bar", () => {
         pages.map(async ([browserName, page]) => {
           await page.click("#viewFind");
           await page.waitForSelector("#viewFind", { hidden: false });
-          await page.type("#findInput", "city");
+          await page.type("#findInput", "preferences");
           await page.waitForSelector("#findInput[data-status='']");
           await page.waitForSelector(".xfaLayer .highlight");
           const resultElement = await page.waitForSelector("#findResultsCount");
           const resultText = await resultElement.evaluate(el => el.textContent);
-          expect(resultText).toEqual("1 of 7 matches");
+          expect(resultText).toEqual("1 of 1 match");
           const selectedElement = await page.waitForSelector(
             ".highlight.selected"
           );
           const selectedText = await selectedElement.evaluate(
             el => el.textContent
           );
-          expect(selectedText).toEqual("City");
+          expect(selectedText).toEqual("Preferences");
         })
       );
     });


### PR DESCRIPTION
The current test fails intermittently only on Windows for unknown reasons: the code is correct and on Linux it always passes. However, we have already spent quite a lot of time on this test, so rather than spending even more time on it I figured we should look at what behavior the test is trying to check and find an alternative way to do it that can't trigger this intermittent issue anymore.

This commit changes the test to use a term that only exists once in the entire document so we cannot accidentally highlight another match anymore. This doesn't change anything about the behavior that this test aims to check: we still test searching in the XFA layer, we still test that the original term is matched case-insensitively and we still test that that match is actually highlighted. Note that the only objective of the test is confirming that the search functionality covers the XFA layer, so the exact phrase/match is not the interesting bit.

Fixes #17096.