### PR TITLE
Try to make the `Preferences`/`AppOptions` initialization slightly more efficient

### DIFF
--- a/web/app_options.js
+++ b/web/app_options.js
@@ -402,7 +402,21 @@ class AppOptions {
     userOptions[name] = value;
   }
 
-  static setAll(options) {
+  static setAll(options, init = false) {
+    if ((typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) && init) {
+      if (this.get("disablePreferences")) {
+        // Give custom implementations of the default viewer a simpler way to
+        // opt-out of having the `Preferences` override existing `AppOptions`.
+        return;
+      }
+      if (Object.keys(userOptions).length) {
+        console.warn(
+          "setAll: The Preferences may override manually set AppOptions; " +
+            'please use the "disablePreferences"-option in order to prevent that.'
+        );
+      }
+    }
+
     for (const name in options) {
       userOptions[name] = options[name];
     }
@@ -411,12 +425,6 @@ class AppOptions {
   static remove(name) {
     delete userOptions[name];
   }
-}
-
-if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-  AppOptions._hasUserOptions = function () {
-    return Object.keys(userOptions).length > 0;
-  };
 }
 
 export { AppOptions, compatibilityParams, OptionKind };

--- a/web/preferences.js
+++ b/web/preferences.js
@@ -46,13 +46,13 @@ class BasePreferences {
 
     this.#initializedPromise = this._readFromStorage(this.#defaults).then(
       prefs => {
-        for (const name in this.#defaults) {
-          const prefValue = prefs?.[name];
+        for (const [name, defaultVal] of Object.entries(this.#defaults)) {
+          const prefVal = prefs?.[name];
           // Ignore preferences whose types don't match the default values.
-          if (typeof prefValue === typeof this.#defaults[name]) {
-            this.#prefs[name] = prefValue;
-          }
+          this.#prefs[name] =
+            typeof prefVal === typeof defaultVal ? prefVal : defaultVal;
         }
+        AppOptions.setAll(this.#prefs, /* init = */ true);
       }
     );
   }
@@ -156,19 +156,8 @@ class BasePreferences {
     return this.#prefs[name] ?? defaultValue;
   }
 
-  /**
-   * Get the values of all preferences.
-   * @returns {Promise} A promise that is resolved with an {Object} containing
-   *                    the values of all preferences.
-   */
-  async getAll() {
-    await this.#initializedPromise;
-    const obj = Object.create(null);
-
-    for (const name in this.#defaults) {
-      obj[name] = this.#prefs[name] ?? this.#defaults[name];
-    }
-    return obj;
+  get initializedPromise() {
+    return this.#initializedPromise;
   }
 }
 


### PR DESCRIPTION
*Please note:* This patch contains a couple of micro-optimizations, hence I understand if it's deemed unnecessary.

Move the `AppOptions` initialization into the `Preferences` constructor, since that allows us to remove a couple of function calls, a bit of asynchronicity and one loop that's currently happening in the early stages of the default viewer initialization.

Finally, move the `Preferences` initialization to occur a *tiny* bit earlier since that cannot hurt given that the entire viewer initialization depends on it being available.