### PR TITLE
Initialize the `L10n`-instance as soon as possible in Firefox (PR 17115 follow-up)

### DIFF
--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -435,7 +435,7 @@ class ChromeExternalServices extends DefaultExternalServices {
     return new ChromePreferences();
   }
 
-  static async createL10n(options) {
+  static async createL10n() {
     return new GenericL10n(navigator.language);
   }
 

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -422,7 +422,7 @@ class FirefoxExternalServices extends DefaultExternalServices {
     FirefoxCom.request("updateEditorStates", data);
   }
 
-  static async createL10n(_options) {
+  static async createL10n() {
     const [localeProperties] = await Promise.all([
       FirefoxCom.requestAsync("getLocaleProperties", null),
       document.l10n.ready,

--- a/web/genericcom.js
+++ b/web/genericcom.js
@@ -14,6 +14,7 @@
  */
 
 import { DefaultExternalServices, PDFViewerApplication } from "./app.js";
+import { AppOptions } from "./app_options.js";
 import { BasePreferences } from "./preferences.js";
 import { DownloadManager } from "./download_manager.js";
 import { GenericL10n } from "./genericl10n.js";
@@ -46,8 +47,8 @@ class GenericExternalServices extends DefaultExternalServices {
     return new GenericPreferences();
   }
 
-  static async createL10n({ locale = "en-US" }) {
-    return new GenericL10n(locale);
+  static async createL10n() {
+    return new GenericL10n(AppOptions.get("locale") || "en-US");
   }
 
   static createScripting({ sandboxBundleSrc }) {


### PR DESCRIPTION
Given that there's now a bit more asynchronicity in the l10n-initialization in the Firefox PDF Viewer, after PR #17115, try to limit the impact of that by moving it to occur a tiny bit earlier in the default viewer initialization.