### PR TITLE
[L10n] Don't try to connect the root element when it has already been done

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -272,14 +272,6 @@ const PDFViewerApplication = {
     this.bindEvents();
     this.bindWindowEvents();
 
-    // We can start UI localization now.
-    const appContainer = appConfig.appContainer || document.documentElement;
-    this.l10n.translate(appContainer).then(() => {
-      // Dispatch the 'localized' event on the `eventBus` once the viewer
-      // has been fully initialized and translated.
-      this.eventBus.dispatch("localized", { source: this });
-    });
-
     this._initializedCapability.resolve();
   },
 
@@ -375,6 +367,12 @@ const PDFViewerApplication = {
         : null
     );
     document.getElementsByTagName("html")[0].dir = this.l10n.getDirection();
+    if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
+      const appContainer =
+        this.appConfig.appContainer || document.documentElement;
+      // Connect Fluent and translate what we already have.
+      this.l10n.translate(appContainer);
+    }
   },
 
   /**

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -46,8 +46,6 @@ const PAGE_NUMBER_LOADING_INDICATOR = "visiblePageIsLoading";
  */
 
 class Toolbar {
-  #wasLocalized = false;
-
   /**
    * @param {ToolbarOptions} options
    * @param {EventBus} eventBus
@@ -206,11 +204,6 @@ class Toolbar {
     // Suppress context menus for some controls.
     scaleSelect.oncontextmenu = noContextMenu;
 
-    this.eventBus._on("localized", () => {
-      this.#wasLocalized = true;
-      this.#updateUIState(true);
-    });
-
     this.#bindEditorToolsListener(options);
   }
 
@@ -254,10 +247,6 @@ class Toolbar {
   }
 
   #updateUIState(resetNumPages = false) {
-    if (!this.#wasLocalized) {
-      // Don't update the UI state until we localize the toolbar.
-      return;
-    }
     const { pageNumber, pagesCount, pageScaleValue, pageScale, items } = this;
 
     if (resetNumPages) {


### PR DESCRIPTION
In Firefox debug builds, there is an assertion to check that we don't connect a subelement of an already connected root. Thanks to this assertion, we can see that the root has already been added to Fluent, hence we don't need to do it a second time.
We don't need to await anymore on the translation in order to update the toolbar: it'll be done by Fluent, so we can safely remove the "localized" event and avoid to wait for it.