### PR TITLE
[api-minor] Re-factor `NullL10n` and remove the hard-coded l10n strings (PR 17115 follow-up)

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -192,6 +192,7 @@ function createWebpackConfig(
     DEFAULT_PREFERENCES: defaultPreferencesDir
       ? getDefaultPreferences(defaultPreferencesDir)
       : {},
+    DEFAULT_FTL: defines.GENERIC ? getDefaultFtl() : "",
   };
   const licenseHeaderLibre = fs
     .readFileSync("./src/license_header_libre.js")
@@ -246,7 +247,6 @@ function createWebpackConfig(
   };
   const libraryAlias = {
     "display-fetch_stream": "src/display/stubs.js",
-    "display-l10n_utils": "src/display/stubs.js",
     "display-network": "src/display/stubs.js",
     "display-node_stream": "src/display/stubs.js",
     "display-node_utils": "src/display/stubs.js",
@@ -280,7 +280,6 @@ function createWebpackConfig(
     // the tsconfig.json file for the type generation to work.
     // In the tsconfig.json files, the .js extension must be omitted.
     libraryAlias["display-fetch_stream"] = "src/display/fetch_stream.js";
-    libraryAlias["display-l10n_utils"] = "web/l10n_utils.js";
     libraryAlias["display-network"] = "src/display/network.js";
     libraryAlias["display-node_stream"] = "src/display/node_stream.js";
     libraryAlias["display-node_utils"] = "src/display/node_utils.js";
@@ -829,6 +828,21 @@ function getDefaultPreferences(dir) {
     .readFileSync(DEFAULT_PREFERENCES_DIR + dir + "default_preferences.json")
     .toString();
   return JSON.parse(str);
+}
+
+function getDefaultFtl() {
+  const content = fs.readFileSync("l10n/en-US/viewer.ftl").toString(),
+    stringBuf = [];
+
+  // Strip out comments and line-breaks.
+  const regExp = /^\s*#/;
+  for (const line of content.split("\n")) {
+    if (!line || regExp.test(line)) {
+      continue;
+    }
+    stringBuf.push(line);
+  }
+  return stringBuf.join("\n");
 }
 
 gulp.task("locale", function () {
@@ -1544,7 +1558,6 @@ function buildLibHelper(bundleDefines, inputStream, outputDir) {
     map: {
       "pdfjs-lib": "../pdf.js",
       "display-fetch_stream": "./fetch_stream.js",
-      "display-l10n_utils": "../web/l10n_utils.js",
       "display-network": "./network.js",
       "display-node_stream": "./node_stream.js",
       "display-node_utils": "./node_utils.js",
@@ -1572,6 +1585,7 @@ function buildLib(defines, dir) {
     DEFAULT_PREFERENCES: getDefaultPreferences(
       defines.SKIP_BABEL ? "lib/" : "lib-legacy/"
     ),
+    DEFAULT_FTL: getDefaultFtl(),
   };
 
   const inputStream = merge([

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -41,7 +41,6 @@ import {
 } from "./display_utils.js";
 import { AnnotationStorage } from "./annotation_storage.js";
 import { ColorConverters } from "../shared/scripting_utils.js";
-import { NullL10n } from "display-l10n_utils";
 import { XfaLayer } from "./xfa_layer.js";
 
 const DEFAULT_TAB_INDEX = 1000;
@@ -2902,12 +2901,6 @@ class AnnotationLayer {
     this.viewport = viewport;
     this.zIndex = 0;
 
-    if (
-      typeof PDFJSDev !== "undefined" &&
-      PDFJSDev.test("GENERIC && !TESTING")
-    ) {
-      this.l10n ||= NullL10n;
-    }
     if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("TESTING")) {
       // For testing purposes.
       Object.defineProperty(this, "showPopups", {
@@ -3008,14 +3001,6 @@ class AnnotationLayer {
     }
 
     this.#setAnnotationCanvasMap();
-
-    if (
-      typeof PDFJSDev !== "undefined" &&
-      PDFJSDev.test("GENERIC && !TESTING") &&
-      this.l10n instanceof NullL10n
-    ) {
-      await this.l10n.translate(layer);
-    }
   }
 
   /**

--- a/src/display/stubs.js
+++ b/src/display/stubs.js
@@ -17,7 +17,6 @@ const NodeCanvasFactory = null;
 const NodeCMapReaderFactory = null;
 const NodeFilterFactory = null;
 const NodeStandardFontDataFactory = null;
-const NullL10n = null;
 const PDFFetchStream = null;
 const PDFNetworkStream = null;
 const PDFNodeStream = null;
@@ -27,7 +26,6 @@ export {
   NodeCMapReaderFactory,
   NodeFilterFactory,
   NodeStandardFontDataFactory,
-  NullL10n,
   PDFFetchStream,
   PDFNetworkStream,
   PDFNodeStream,

--- a/test/unit/unit_test.html
+++ b/test/unit/unit_test.html
@@ -21,7 +21,6 @@
         "cached-iterable": "../../node_modules/cached-iterable/src/index.mjs",
 
         "display-fetch_stream": "../../src/display/fetch_stream.js",
-        "display-l10n_utils": "../../src/display/stubs.js",
         "display-network": "../../src/display/network.js",
         "display-node_stream": "../../src/display/stubs.js",
         "display-node_utils": "../../src/display/stubs.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "paths": {
       "pdfjs-lib": ["./src/pdf"],
       "display-fetch_stream": ["./src/display/fetch_stream"],
-      "display-l10n_utils": ["./web/l10n_utils"],
       "display-network": ["./src/display/network"],
       "display-node_stream": ["./src/display/node_stream"],
       "display-node_utils": ["./src/display/node_utils"],

--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -192,12 +192,12 @@ class IL10n {
    * Translates text identified by the key and adds/formats data using the args
    * property bag. If the key was not found, translation falls back to the
    * fallback text.
-   * @param {string} key
+   * @param {Array | string} ids
    * @param {Object | null} [args]
    * @param {string} [fallback]
    * @returns {Promise<string>}
    */
-  async get(key, args = null, fallback) {}
+  async get(ids, args = null, fallback) {}
 
   /**
    * Translates HTML element.

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -215,6 +215,11 @@ class PDFPageView {
             optionalContentConfig.hasInitialVisibility;
         });
       }
+
+      // Ensure that Fluent is connected in e.g. the COMPONENTS build.
+      if (this.l10n === NullL10n) {
+        this.l10n.translate(this.div);
+      }
     }
   }
 

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -322,6 +322,14 @@ class PDFViewer {
         pdfPage?.cleanup();
       }
     });
+
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&
+      this.l10n === NullL10n
+    ) {
+      // Ensure that Fluent is connected in e.g. the COMPONENTS build.
+      this.l10n.translate(this.container);
+    }
   }
 
   get pagesCount() {

--- a/web/viewer-geckoview.html
+++ b/web/viewer-geckoview.html
@@ -54,7 +54,6 @@ See https://github.com/adobe-type-tools/cmap-resources
           "cached-iterable": "../node_modules/cached-iterable/src/index.mjs",
 
           "display-fetch_stream": "../src/display/fetch_stream.js",
-          "display-l10n_utils": "../src/display/stubs.js",
           "display-network": "../src/display/network.js",
           "display-node_stream": "../src/display/stubs.js",
           "display-node_utils": "../src/display/stubs.js",

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -63,7 +63,6 @@ See https://github.com/adobe-type-tools/cmap-resources
           "cached-iterable": "../node_modules/cached-iterable/src/index.mjs",
 
           "display-fetch_stream": "../src/display/fetch_stream.js",
-          "display-l10n_utils": "../src/display/stubs.js",
           "display-network": "../src/display/network.js",
           "display-node_stream": "../src/display/stubs.js",
           "display-node_utils": "../src/display/stubs.js",


### PR DESCRIPTION
*Please note:* These changes only affect the GENERIC build, since `NullL10n` is only a stub elsewhere (see PR #17135).

After the changes in PR #17115, which modernized and improved l10n-handling, the `NullL10n`-implementation is no longer a good fallback for the "proper" `L10n`-classes.
To improve this situation, especially for the *standalone* viewer-components, this patch makes the following changes:
 - Let the `NullL10n`-implementation extend an actual `L10n`-class, which is constant and lazily initialized, to ensure that it works *exactly* like the "proper" ones.

 - Automatically bundle the "en-US" l10n-strings in the build, via the pre-processor, such that we don't need to remember to manually update them.

 - Ensure that the *standalone* viewer-components register their DOM-elements for translation, similar to the default viewer, since this will allow future code improvements by using "data-l10n-id"/"data-l10n-args" in most (if not all) parts of the viewer.

 - Remove the `NullL10n` from the `AnnotationLayer`, to avoid affecting bundle size too much.
   For third-party users that access the `AnnotationLayer`, as exposed in the main PDF.js library, they'll now need to *manually* register it for translation. (However, the *standalone* viewer-components still works given the point above.)