### PR TITLE
Avoid to run localization when inserting the text layer

### DIFF
--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -205,6 +205,16 @@ class IL10n {
    * @returns {Promise<void>}
    */
   async translate(element) {}
+
+  /**
+   * Pause the localization.
+   */
+  pause() {}
+
+  /**
+   * Resume the localization.
+   */
+  resume() {}
 }
 
 export { IDownloadManager, IL10n, IPDFLinkService, IRenderableView };

--- a/web/l10n.js
+++ b/web/l10n.js
@@ -75,6 +75,16 @@ class L10n {
     }
   }
 
+  /** @inheritdoc */
+  pause() {
+    this.#l10n.pauseObserving();
+  }
+
+  /** @inheritdoc */
+  resume() {
+    this.#l10n.resumeObserving();
+  }
+
   static #fixupLangCode(langCode) {
     // Try to support "incompletely" specified language codes (see issue 13689).
     const PARTIAL_LANG_CODES = {

--- a/web/l10n_utils.js
+++ b/web/l10n_utils.js
@@ -75,6 +75,14 @@ const NullL10n = {
   async translate(element) {
     return ConstL10n.instance.translate(element);
   },
+
+  pause() {
+    return ConstL10n.instance.pause();
+  },
+
+  resume() {
+    return ConstL10n.instance.resume();
+  },
 };
 
 export { NullL10n };

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -398,6 +398,12 @@ class PDFPageView {
       error = ex;
     }
 
+    // The text layer doesn't need to be localized, hence we disable
+    // the l10n when inserting it in the DOM.
+    this.l10n.pause();
+    this.div.append(this.textLayer.div);
+    this.l10n.resume();
+
     this.eventBus.dispatch("textlayerrendered", {
       source: this,
       pageNumber: this.id,
@@ -425,8 +431,12 @@ class PDFPageView {
       ? this.pdfPage.getStructTree()
       : null);
     const treeDom = this.structTreeLayer?.render(tree);
-    if (treeDom) {
-      this.canvas?.append(treeDom);
+    if (treeDom && this.canvas) {
+      // The struct tree layer doesn't need to be localized, hence we disable
+      // the l10n when inserting it in the DOM.
+      this.l10n.pause();
+      this.canvas.append(treeDom);
+      this.l10n.resume();
     }
     this.structTreeLayer?.show();
   }
@@ -853,7 +863,6 @@ class PDFPageView {
         enablePermissions:
           this.#textLayerMode === TextLayerMode.ENABLE_PERMISSIONS,
       });
-      div.append(this.textLayer.div);
     }
 
     if (


### PR DESCRIPTION
The text layer contains either some spans with the page text or some accessibility structural info.