### PR TITLE
Guard `navigator`-object accesses in `src/`-files (issue 15728)

### DIFF
--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -184,6 +184,7 @@ class FontLoader {
         supported = true;
       } else if (
         typeof navigator !== "undefined" &&
+        typeof navigator?.userAgent === "string" &&
         // User agent string sniffing is bad, but there is no reliable way to
         // tell if the font is fully loaded and ready to be used with canvas.
         /Mozilla\/5.0.*?rv:\d+.*? Gecko/.test(navigator.userAgent)

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -616,14 +616,15 @@ class FeatureTest {
 
   static get platform() {
     if (
-      (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&
-      typeof navigator === "undefined"
+      (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) ||
+      (typeof navigator !== "undefined" &&
+        typeof navigator?.platform === "string")
     ) {
-      return shadow(this, "platform", { isMac: false });
+      return shadow(this, "platform", {
+        isMac: navigator.platform.includes("Mac"),
+      });
     }
-    return shadow(this, "platform", {
-      isMac: navigator.platform.includes("Mac"),
-    });
+    return shadow(this, "platform", { isMac: false });
   }
 
   static get isCSSRoundSupported() {


### PR DESCRIPTION
There are environments that include *incomplete* polyfills for the `navigator`-object, which may thus cause the PDF.js library to break.
Despite that clearly not being our fault, it may still result in bug reports filed against the PDF.js project; see e.g. #15728.

Currently this even seem to affect *the latest* version of Node.js; see e.g. [here](https://github.com/nodejs/node/issues/39540#issuecomment-1771203699).

*Please note:* Thanks to the pre-processor none of these changes affect the Firefox PDF Viewer, however it does add "overhead" when working with and reviewing the affected code (which is why I'm not crazy about this).