### PR TITLE
Update the "aria-label" of the page when a `pageLabel` exists

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -1042,6 +1042,11 @@ class PDFPageView {
   setPageLabel(label) {
     this.pageLabel = typeof label === "string" ? label : null;
 
+    this.div.setAttribute(
+      "data-l10n-args",
+      JSON.stringify({ page: this.pageLabel ?? this.id })
+    );
+
     if (this.pageLabel !== null) {
       this.div.setAttribute("data-page-label", this.pageLabel);
     } else {


### PR DESCRIPTION
Looking at the [`PDFThumbnailView.setPageLabel` method](https://github.com/mozilla/pdf.js/blob/8376b3fb054937ee615a2685f6e893959b46fd93/web/pdf_thumbnail_view.js#L435) you'll see that we update e.g. the "aria-label" of the thumbnail-image for documents that contain (valid) pageLabels.
This isn't done in `PDFPageView`, which seems inconsistent, hence this patch.