### PR TITLE
Add a unit-test to ensure that `NullL10n` won't diverge from the `L10n`-class

### DIFF
--- a/test/unit/pdf_viewer.component_spec.js
+++ b/test/unit/pdf_viewer.component_spec.js
@@ -30,6 +30,7 @@ import { AnnotationLayerBuilder } from "../../web/annotation_layer_builder.js";
 import { DownloadManager } from "../../web/download_manager.js";
 import { EventBus } from "../../web/event_utils.js";
 import { GenericL10n } from "../../web/genericl10n.js";
+import { L10n } from "../../web/l10n.js";
 import { NullL10n } from "../../web/l10n_utils.js";
 import { PDFHistory } from "../../web/pdf_history.js";
 import { PDFPageView } from "../../web/pdf_page_view.js";
@@ -71,5 +72,15 @@ describe("pdfviewer_api", function () {
       TextLayerBuilder,
       XfaLayerBuilder,
     });
+  });
+
+  it("checks that `NullL10n` implements all methods", function () {
+    const methods = Object.getOwnPropertyNames(NullL10n).sort();
+
+    const baseMethods = Object.getOwnPropertyNames(L10n.prototype)
+      .filter(m => m !== "constructor" && !m.startsWith("_"))
+      .sort();
+
+    expect(methods).toEqual(baseMethods);
   });
 });

--- a/web/genericl10n.js
+++ b/web/genericl10n.js
@@ -25,7 +25,7 @@ import { L10n } from "./l10n.js";
 class GenericL10n extends L10n {
   constructor(lang) {
     super({ lang });
-    this.setL10n(
+    this._setL10n(
       new DOMLocalization(
         [],
         GenericL10n.#generateBundles.bind(

--- a/web/l10n.js
+++ b/web/l10n.js
@@ -31,7 +31,7 @@ class L10n {
     this.#dir = isRTL ?? L10n.#isRTL(this.#lang) ? "rtl" : "ltr";
   }
 
-  setL10n(l10n) {
+  _setL10n(l10n) {
     this.#l10n = l10n;
     if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("TESTING")) {
       document.l10n = l10n;

--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -144,16 +144,15 @@ class PDFFindBar {
     const { findResultsCount } = this;
 
     if (total > 0) {
-      const limit = MATCHES_COUNT_LIMIT,
-        isLimited = total > limit;
+      const limit = MATCHES_COUNT_LIMIT;
 
       findResultsCount.setAttribute(
         "data-l10n-id",
-        `pdfjs-find-match-count${isLimited ? "-limit" : ""}`
+        `pdfjs-find-match-count${total > limit ? "-limit" : ""}`
       );
       findResultsCount.setAttribute(
         "data-l10n-args",
-        JSON.stringify(isLimited ? { limit } : { current, total })
+        JSON.stringify({ limit, current, total })
       );
     } else {
       findResultsCount.removeAttribute("data-l10n-id");


### PR DESCRIPTION
 - **Add a unit-test to ensure that `NullL10n` won't diverge from the `L10n`-class**
 
   To prevent the *standalone* viewer-components from breaking, we need to ensure that the `NullL10n`-interface won't accidentally diverge from the actual `L10n`-implementations.

 - **Tweak the `matchCount` l10n-args handling slightly (PR 17146 follow-up)**

   Given that providing unused parameters in the l10n-args shouldn't be a problem, let's simplify the relevant JavaScript code a tiny bit.