### PR TITLE
Switch Puppeteer tests from CDP to WebDriver BiDi

### DIFF
--- a/test/test.mjs
+++ b/test/test.mjs
@@ -937,6 +937,10 @@ async function startBrowser({ browserName, headless, startUrl }) {
   }
 
   if (browserName === "firefox") {
+    // Run tests with the WebDriver BiDi protocol enabled only for Firefox for
+    // now given that for Chrome further fixes are needed first.
+    options.protocol = "webDriverBiDi";
+
     options.extraPrefsFirefox = {
       // avoid to have a prompt when leaving a page with a form
       "dom.disable_beforeunload": true,

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -1056,9 +1056,6 @@ async function closeSession(browser) {
       continue;
     }
     if (session.browser !== undefined) {
-      for (const page of await session.browser.pages()) {
-        await page.close();
-      }
       await session.browser.close();
     }
     session.closed = true;


### PR DESCRIPTION
Over the last months we have made great progress in implementing WebDriver BiDi in both Firefox and Chrome. Also Puppeteer uses already a lot of the new APIs when the `webDriverBiDi` protocol is enabled.

It would be good to see if pdf.js Puppeteer tests would already be in a position so that the underlying protocol can be changed to an officially spec'ed one. CC @marco-c.

All the testing commands by the bot can be found at https://github.com/mozilla/pdf.js/issues/11851#issuecomment-1528747331.

I'm going to use this PR to check which APIs might still be missing or failing.

Internally we are going to use this meta bug to track the remaining work on the WebDriver BiDi side:
https://bugzilla.mozilla.org/show_bug.cgi?id=1860992