### PR TITLE
Fix error that's breaking the `ConstL10n` class (PR 17161 follow-up)

### DIFF
--- a/web/l10n_utils.js
+++ b/web/l10n_utils.js
@@ -26,7 +26,7 @@ import { shadow } from "pdfjs-lib";
 class ConstL10n extends L10n {
   constructor(lang) {
     super({ lang });
-    this.setL10n(
+    this._setL10n(
       new DOMLocalization([], ConstL10n.#generateBundles.bind(ConstL10n, lang))
     );
   }


### PR DESCRIPTION
I forgot to include `web/l10n_utils.js` in PR #17161, which currently breaks `ConstL10n` since there's no longer a method called `setL10n`; sorry about that!