### PR TITLE
Remove obsolete entries in the lint-ignore files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,12 +3,9 @@ l10n/
 docs/
 node_modules/
 external/bcmaps/
-external/webL10n/
 external/builder/fixtures/
 external/builder/fixtures_esprima/
 external/quickjs/
-src/shared/cffStandardStrings.js
-src/shared/fonts_utils.js
 test/tmp/
 test/pdfs/
 *~/

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -3,12 +3,9 @@ l10n/
 docs/
 node_modules/
 external/bcmaps/
-external/webL10n/
 external/builder/fixtures/
 external/builder/fixtures_esprima/
 external/quickjs/
-src/shared/cffStandardStrings.js
-src/shared/fonts_utils.js
 test/tmp/
 test/pdfs/
 *~/


### PR DESCRIPTION
 - The `external/webL10n/` directory was removed in PR #17115.

 - The `src/shared/{cffStandardStrings, fonts_utils}.js` files were removed in PR #17120.