### PR TITLE
Handle appending consistently in the xfaLayer regardless of rendering intent (PR 17177 follow-up)

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -1026,7 +1026,6 @@ class PDFPageView {
         const { annotationStorage, linkService } = this.#layerProperties;
 
         this.xfaLayer = new XfaLayerBuilder({
-          pageDiv: div,
           pdfPage,
           annotationStorage,
           linkService,

--- a/web/print_utils.js
+++ b/web/print_utils.js
@@ -28,7 +28,6 @@ function getXfaHtmlForPrinting(printContainer, pdfDocument) {
     printContainer.append(page);
 
     const builder = new XfaLayerBuilder({
-      pageDiv: page,
       pdfPage: null,
       annotationStorage: pdfDocument.annotationStorage,
       linkService,
@@ -37,6 +36,7 @@ function getXfaHtmlForPrinting(printContainer, pdfDocument) {
     const viewport = getXfaPageViewport(xfaPage, { scale });
 
     builder.render(viewport, "print");
+    page.append(builder.div);
   }
 }
 

--- a/web/xfa_layer_builder.js
+++ b/web/xfa_layer_builder.js
@@ -24,7 +24,6 @@ import { XfaLayer } from "pdfjs-lib";
 
 /**
  * @typedef {Object} XfaLayerBuilderOptions
- * @property {HTMLDivElement} pageDiv
  * @property {PDFPageProxy} pdfPage
  * @property {AnnotationStorage} [annotationStorage]
  * @property {IPDFLinkService} linkService
@@ -36,13 +35,11 @@ class XfaLayerBuilder {
    * @param {XfaLayerBuilderOptions} options
    */
   constructor({
-    pageDiv,
     pdfPage,
     annotationStorage = null,
     linkService,
     xfaHtml = null,
   }) {
-    this.pageDiv = pageDiv;
     this.pdfPage = pdfPage;
     this.annotationStorage = annotationStorage;
     this.linkService = linkService;
@@ -71,9 +68,8 @@ class XfaLayerBuilder {
       };
 
       // Create an xfa layer div and render the form
-      const div = document.createElement("div");
-      this.pageDiv.append(div);
-      parameters.div = div;
+      this.div = document.createElement("div");
+      parameters.div = this.div;
 
       return XfaLayer.render(parameters);
     }


### PR DESCRIPTION
After PR #17177 the interface of `XfaLayerBuilder` is now inconsistent, since whether or not we directly append the xfaLayer to the DOM now depends on the rendering intent.