### PR TITLE
Fix `WidgetAnnotationElement._getKeyModifier` to account for Linux

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -1018,8 +1018,7 @@ class WidgetAnnotationElement extends AnnotationElement {
   }
 
   _getKeyModifier(event) {
-    const { isWin, isMac } = FeatureTest.platform;
-    return (isWin && event.ctrlKey) || (isMac && event.metaKey);
+    return FeatureTest.platform.isMac ? event.metaKey : event.ctrlKey;
   }
 
   _setEventListener(element, elementData, baseName, eventName, valueGetter) {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -619,10 +619,9 @@ class FeatureTest {
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&
       typeof navigator === "undefined"
     ) {
-      return shadow(this, "platform", { isWin: false, isMac: false });
+      return shadow(this, "platform", { isMac: false });
     }
     return shadow(this, "platform", {
-      isWin: navigator.platform.includes("Win"),
       isMac: navigator.platform.includes("Mac"),
     });
   }


### PR DESCRIPTION
Currently the `WidgetAnnotationElement._getKeyModifier` method will always be falsy on Linux, which seems like a simple oversight. Looking at all the other `FeatureTest.platform` accesses we only handle the `isMac`-case specially, and it seems reasonable to do the same thing here.
The reason that this hasn't led to any bug reports is most likely that the `modifier`-property seems completely unused in the scripting-implementation.

Finally, with these changes we can (slightly) simplify the `FeatureTest.platform` implementation.