### PR TITLE
Upgrade `setup-node` to version 4 in the GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
 
       - name: Use Node.js 18 LTS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
 

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Use Node.js 18 LTS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
 


### PR DESCRIPTION
This major version mainly involves not using Node.js 16 internally anymore, which will be end of life on September 11th. This prevents the workflows from using an unsupported version of Node.js as well as deprecation warnings getting printed in the workflow logs.

For more information please refer to https://github.com/actions/setup-node/releases/tag/v4.0.0 and https://github.com/actions/setup-node/issues/850.