### PR TITLE
[Firefox] Fetch browser preferences/options together with the viewer preferences (bug 1862192)

### DIFF
--- a/web/app_options.js
+++ b/web/app_options.js
@@ -41,6 +41,7 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
 }
 
 const OptionKind = {
+  BROWSER: 0x01,
   VIEWER: 0x02,
   API: 0x04,
   WORKER: 0x08,
@@ -53,6 +54,42 @@ const OptionKind = {
  *       primitive types and cannot rely on any imported types.
  */
 const defaultOptions = {
+  canvasMaxAreaInBytes: {
+    /** @type {number} */
+    value: -1,
+    kind: OptionKind.BROWSER,
+  },
+  isInAutomation: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.BROWSER,
+  },
+  supportsDocumentFonts: {
+    /** @type {boolean} */
+    value: true,
+    kind: OptionKind.BROWSER,
+  },
+  supportsIntegratedFind: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.BROWSER,
+  },
+  supportsMouseWheelZoomCtrlKey: {
+    /** @type {boolean} */
+    value: true,
+    kind: OptionKind.BROWSER,
+  },
+  supportsMouseWheelZoomMetaKey: {
+    /** @type {boolean} */
+    value: true,
+    kind: OptionKind.BROWSER,
+  },
+  supportsPinchToZoom: {
+    /** @type {boolean} */
+    value: true,
+    kind: OptionKind.BROWSER,
+  },
+
   annotationEditorMode: {
     /** @type {number} */
     value: 0,
@@ -367,6 +404,9 @@ class AppOptions {
           continue;
         }
         if (kind === OptionKind.PREFERENCE) {
+          if (defaultOption.kind & OptionKind.BROWSER) {
+            throw new Error(`Invalid kind for preference: ${name}`);
+          }
           const value = defaultOption.value,
             valueType = typeof value;
 

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -400,10 +400,13 @@ class AppOptions {
     for (const name in defaultOptions) {
       const defaultOption = defaultOptions[name];
       if (kind) {
-        if ((kind & defaultOption.kind) === 0) {
+        if (!(kind & defaultOption.kind)) {
           continue;
         }
-        if (kind === OptionKind.PREFERENCE) {
+        if (
+          (typeof PDFJSDev === "undefined" || PDFJSDev.test("LIB")) &&
+          kind === OptionKind.PREFERENCE
+        ) {
           if (defaultOption.kind & OptionKind.BROWSER) {
             throw new Error(`Invalid kind for preference: ${name}`);
           }

--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -352,7 +352,7 @@ class ChromePreferences extends BasePreferences {
           defaultPrefs = this.defaults;
         }
         storageArea.get(defaultPrefs, function (readPrefs) {
-          resolve(readPrefs);
+          resolve({ prefs: readPrefs });
         });
       };
 

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -14,7 +14,7 @@
  */
 
 import { DefaultExternalServices, PDFViewerApplication } from "./app.js";
-import { isPdfFile, PDFDataRangeTransport, shadow } from "pdfjs-lib";
+import { isPdfFile, PDFDataRangeTransport } from "pdfjs-lib";
 import { BasePreferences } from "./preferences.js";
 import { DEFAULT_SCALE_VALUE } from "./ui_utils.js";
 import { L10n } from "./l10n.js";
@@ -432,40 +432,6 @@ class FirefoxExternalServices extends DefaultExternalServices {
 
   static createScripting(options) {
     return FirefoxScripting;
-  }
-
-  static get supportsPinchToZoom() {
-    const support = FirefoxCom.requestSync("supportsPinchToZoom");
-    return shadow(this, "supportsPinchToZoom", support);
-  }
-
-  static get supportsIntegratedFind() {
-    const support = FirefoxCom.requestSync("supportsIntegratedFind");
-    return shadow(this, "supportsIntegratedFind", support);
-  }
-
-  static get supportsDocumentFonts() {
-    const support = FirefoxCom.requestSync("supportsDocumentFonts");
-    return shadow(this, "supportsDocumentFonts", support);
-  }
-
-  static get supportedMouseWheelZoomModifierKeys() {
-    const support = FirefoxCom.requestSync(
-      "supportedMouseWheelZoomModifierKeys"
-    );
-    return shadow(this, "supportedMouseWheelZoomModifierKeys", support);
-  }
-
-  static get isInAutomation() {
-    // Returns the value of `Cu.isInAutomation`, which is only `true` when e.g.
-    // various test-suites are running in mozilla-central.
-    const isInAutomation = FirefoxCom.requestSync("isInAutomation");
-    return shadow(this, "isInAutomation", isInAutomation);
-  }
-
-  static get canvasMaxAreaInBytes() {
-    const maxArea = FirefoxCom.requestSync("getCanvasMaxArea");
-    return shadow(this, "canvasMaxAreaInBytes", maxArea);
   }
 
   static async getNimbusExperimentData() {

--- a/web/genericcom.js
+++ b/web/genericcom.js
@@ -34,7 +34,7 @@ class GenericPreferences extends BasePreferences {
   }
 
   async _readFromStorage(prefObj) {
-    return JSON.parse(localStorage.getItem("pdfjs.preferences"));
+    return { prefs: JSON.parse(localStorage.getItem("pdfjs.preferences")) };
   }
 }
 

--- a/web/preferences.js
+++ b/web/preferences.js
@@ -45,14 +45,25 @@ class BasePreferences {
     }
 
     this.#initializedPromise = this._readFromStorage(this.#defaults).then(
-      prefs => {
+      ({ browserPrefs, prefs }) => {
+        const BROWSER_PREFS =
+          typeof PDFJSDev === "undefined"
+            ? AppOptions.getAll(OptionKind.BROWSER)
+            : PDFJSDev.eval("BROWSER_PREFERENCES");
+        const options = Object.create(null);
+
+        for (const [name, defaultVal] of Object.entries(BROWSER_PREFS)) {
+          const prefVal = browserPrefs?.[name];
+          options[name] =
+            typeof prefVal === typeof defaultVal ? prefVal : defaultVal;
+        }
         for (const [name, defaultVal] of Object.entries(this.#defaults)) {
           const prefVal = prefs?.[name];
           // Ignore preferences whose types don't match the default values.
-          this.#prefs[name] =
+          options[name] = this.#prefs[name] =
             typeof prefVal === typeof defaultVal ? prefVal : defaultVal;
         }
-        AppOptions.setAll(this.#prefs, /* init = */ true);
+        AppOptions.setAll(options, /* init = */ true);
       }
     );
   }


### PR DESCRIPTION
Currently we *synchronously* fetch a number of browser preferences/options, from the platform code, during the viewer respectively PDF document initialization paths.
This seems unnecessary, and we can re-factor the code to instead include the relevant data when fetching the regular viewer preferences.