### PR TITLE
Update `external/dist/webpack.js` to account for outputting of JavaScript modules (PR 17055 follow-up)

### DIFF
--- a/external/dist/webpack.mjs
+++ b/external/dist/webpack.mjs
@@ -12,17 +12,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable import/no-commonjs */
+/* eslint-disable import/no-unresolved */
 
-"use strict";
-
-const pdfjs = require("./build/pdf.mjs");
+import { GlobalWorkerOptions } from "./build/pdf.mjs";
 
 if (typeof window !== "undefined" && "Worker" in window) {
-  pdfjs.GlobalWorkerOptions.workerPort = new Worker(
+  GlobalWorkerOptions.workerPort = new Worker(
     new URL("./build/pdf.worker.mjs", import.meta.url),
     { type: "module" }
   );
 }
 
-module.exports = pdfjs;
+export * from "./build/pdf.mjs";


### PR DESCRIPTION
Hopefully this makes sense, since I don't know enough about Webpack to tell exactly how this file is being used in practice.