### PR TITLE
Remove the "Open file"-button from the main toolbar

### DIFF
--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -39,7 +39,6 @@ const PAGE_NUMBER_LOADING_INDICATOR = "visiblePageIsLoading";
  * @property {HTMLButtonElement} zoomIn - Button to zoom in the pages.
  * @property {HTMLButtonElement} zoomOut - Button to zoom out the pages.
  * @property {HTMLButtonElement} viewFind - Button to open find bar.
- * @property {HTMLButtonElement} openFile - Button to open a new document.
  * @property {HTMLButtonElement} editorFreeTextButton - Button to switch to
  *   FreeText editing.
  * @property {HTMLButtonElement} download - Button to download the document.
@@ -97,9 +96,6 @@ class Toolbar {
         },
       },
     ];
-    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-      this.buttons.push({ element: options.openFile, eventName: "openfile" });
-    }
     this.items = {
       numPages: options.numPages,
       pageNumber: options.pageNumber,

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -919,13 +919,12 @@ body {
   mask-image: var(--toolbarButton-editorStamp-icon);
 }
 
-#print::before,
-#secondaryPrint::before {
+:is(#print, #secondaryPrint)::before {
   mask-image: var(--toolbarButton-print-icon);
 }
 
 /*#if GENERIC*/
-:is(#openFile, #secondaryOpenFile)::before {
+#secondaryOpenFile::before {
   mask-image: var(--toolbarButton-openFile-icon);
 }
 /*#endif*/
@@ -1435,7 +1434,6 @@ dialog :link {
   }
 }
 
-.visibleLargeView,
 .visibleMediumView {
   display: none;
 }
@@ -1456,15 +1454,6 @@ dialog :link {
   }
   #outerContainer.sidebarOpen #viewerContainer {
     inset-inline-start: 0 !important;
-  }
-}
-
-@media all and (max-width: 820px) {
-  #outerContainer .hiddenLargeView {
-    display: none;
-  }
-  #outerContainer .visibleLargeView {
-    display: inherit;
   }
 }
 

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -210,7 +210,7 @@ See https://github.com/adobe-type-tools/cmap-resources
         <div id="secondaryToolbar" class="secondaryToolbar hidden doorHangerRight">
           <div id="secondaryToolbarButtonContainer">
 <!--#if GENERIC-->
-            <button id="secondaryOpenFile" class="secondaryToolbarButton visibleLargeView" title="Open File" tabindex="51" data-l10n-id="pdfjs-open-file-button">
+            <button id="secondaryOpenFile" class="secondaryToolbarButton" title="Open File" tabindex="51" data-l10n-id="pdfjs-open-file-button">
               <span data-l10n-id="pdfjs-open-file-button-label">Open</span>
             </button>
 <!--#endif-->
@@ -224,7 +224,7 @@ See https://github.com/adobe-type-tools/cmap-resources
             </button>
 
 <!--#if GENERIC-->
-            <div class="horizontalToolbarSeparator visibleLargeView"></div>
+            <div class="horizontalToolbarSeparator"></div>
 <!--#else-->
 <!--        <div class="horizontalToolbarSeparator visibleMediumView"></div>-->
 <!--#endif-->
@@ -329,12 +329,6 @@ See https://github.com/adobe-type-tools/cmap-resources
                 <span id="numPages" class="toolbarLabel"></span>
               </div>
               <div id="toolbarViewerRight">
-<!--#if GENERIC-->
-                <button id="openFile" class="toolbarButton hiddenLargeView" title="Open File" tabindex="31" data-l10n-id="pdfjs-open-file-button">
-                  <span data-l10n-id="pdfjs-open-file-button-label">Open</span>
-                </button>
-<!--#endif-->
-
                 <button id="print" class="toolbarButton hiddenMediumView" title="Print" tabindex="32" data-l10n-id="pdfjs-print-button">
                   <span data-l10n-id="pdfjs-print-button-label">Print</span>
                 </button>

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -52,10 +52,6 @@ function getViewerConfiguration() {
       zoomIn: document.getElementById("zoomIn"),
       zoomOut: document.getElementById("zoomOut"),
       viewFind: document.getElementById("viewFind"),
-      openFile:
-        typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")
-          ? document.getElementById("openFile")
-          : null,
       print: document.getElementById("print"),
       editorFreeTextButton: document.getElementById("editorFreeText"),
       editorFreeTextParamsToolbar: document.getElementById(


### PR DESCRIPTION
This button is *only* used in the GENERIC viewer, and will currently be visible either in the main or secondary toolbars (depending on the viewer width).
To simplify upcoming changes, and to avoid then having to complicate the relevant CSS rules unnecessarily, let's place the "Open file"-button permanently in the secondary toolbar instead.

(Note that the GENERIC viewer also, since five years, supports drag-and-drop in order to open local files.)