### PR TITLE
Ensure that the viewer waits for the library to complete loading (issue 17228)

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -422,7 +422,7 @@ function tweakWebpackOutput(jsName) {
       case " __webpack_exports__ = {};":
         return ` __webpack_exports__ = globalThis.${jsName} = {};`;
       case " __webpack_exports__ = await __webpack_exports__;":
-        return ` __webpack_exports__ = globalThis.${jsName} = await __webpack_exports__;`;
+        return ` __webpack_exports__ = globalThis.${jsName} = await (globalThis.${jsName}Promise = __webpack_exports__);`;
     }
     return match;
   });

--- a/web/pdfjs.js
+++ b/web/pdfjs.js
@@ -13,6 +13,15 @@
  * limitations under the License.
  */
 
+// Ensure that the viewer waits for the library to complete loading,
+// to avoid breaking e.g. the standalone viewer components (see issue 17228).
+if (
+  (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&
+  !globalThis.pdfjsLib
+) {
+  await globalThis.pdfjsLibPromise;
+}
+
 const {
   AbortException,
   AnnotationEditorLayer,


### PR DESCRIPTION
This should *hopefully* fix #17228, by tweaking the build scripts to give the GENERIC viewer something to await to avoid breaking third-party users of the standalone viewer components.