### PR TITLE
Tweak the background-color of the `editorParamsToolbar`s

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -579,17 +579,14 @@ body {
 
 #editorStampParamsToolbar {
   inset-inline-end: 40px;
-  background-color: var(--toolbar-bg-color);
 }
 
 #editorInkParamsToolbar {
   inset-inline-end: 68px;
-  background-color: var(--toolbar-bg-color);
 }
 
 #editorFreeTextParamsToolbar {
   inset-inline-end: 96px;
-  background-color: var(--toolbar-bg-color);
 }
 
 #editorStampAddImage::before {


### PR DESCRIPTION
Currently the background-color of the `editorParamsToolbar`s don't match that of the arrow, which is especially noticable in dark mode (see zoomed-in screen-shots below).
The simplest solution seem to be to just style the `editorParamsToolbar`s like the `secondaryToolbar`, to limit the amount of CSS changes required.

![light](https://github.com/mozilla/pdf.js/assets/2692120/8f8b22ea-4234-4799-b429-a9fab53c5fd1)

![dark](https://github.com/mozilla/pdf.js/assets/2692120/8fcebb73-8b3c-45f9-8d47-47ac81e251f0)
