### PR TITLE
Set a type for the `Blob` used in `createCDNWrapper` (issue 17259)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2008,7 +2008,9 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
     // We want this function to fail in case if createObjectURL or Blob do not
     // exist or fail for some reason -- our Worker creation will fail anyway.
     const wrapper = `await import("${url}");`;
-    return URL.createObjectURL(new Blob([wrapper]));
+    return URL.createObjectURL(
+      new Blob([wrapper], { type: "text/javascript" })
+    );
   };
 }
 


### PR DESCRIPTION
Hopefully this is enough to address the problem of initializing the Worker in Chromium-based browsers.
Locally I've tried to *force* use of `createCDNWrapper` in development mode, by commenting out the `isSameOrigin` checks, and worker-loading fails against `master` and works with this patch.