### PR TITLE
Move `gulp typestest` to a separate GitHub Actions workflow

### DIFF
--- a/.github/workflows/types_tests.yml
+++ b/.github/workflows/types_tests.yml
@@ -1,0 +1,34 @@
+name: Types tests
+on: [push, pull_request]
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [lts/*]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Gulp
+        run: npm install -g gulp-cli
+
+      - name: Install other dependencies
+        run: npm install
+
+      - name: Run types tests
+        run: gulp typestest

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -2437,7 +2437,4 @@ gulp.task("externaltest", function (done) {
   done();
 });
 
-gulp.task(
-  "ci-test",
-  gulp.series(gulp.parallel("externaltest", "unittestcli"), "typestest")
-);
+gulp.task("ci-test", gulp.parallel("externaltest", "unittestcli"));


### PR DESCRIPTION
This way we introduce more parallelism in the GitHub Actions tests, which should reduce overall runtime and thus cannot hurt.