### PR TITLE
Clean-up the CI workflow a bit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Install other dependencies
         run: npm install
 
-      - name: Run tests
-        run: gulp ci-test
+      - name: Run external tests
+        run: gulp externaltest
+
+      - name: Run CLI unit tests
+        run: gulp unittestcli

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -2436,5 +2436,3 @@ gulp.task("externaltest", function (done) {
   });
   done();
 });
-
-gulp.task("ci-test", gulp.parallel("externaltest", "unittestcli"));


### PR DESCRIPTION
After recent PRs the size and scope of the CI workflow is now reduced, and this patch tries to simplify things further. More specifically we can directly specify the gulp-tasks in the workflow, and thus clean-up the `gulpfile` a tiny bit.

Note that this will technically be slower, since the tests are now run in series (rather than in parallel), however `gulp externaltest` runs so quickly that it really won't matter in practice.